### PR TITLE
Fix working-directory combobox to continue search after selection

### DIFF
--- a/packages/app/e2e/helpers/app.ts
+++ b/packages/app/e2e/helpers/app.ts
@@ -265,7 +265,13 @@ export const setWorkingDirectory = async (page: Page, directory: string) => {
     await activeInput.press('Enter');
   }
 
-  // Wait for picker to close.
+  // Wait for picker to close. Working-directory combobox selection can keep
+  // the picker open to allow continued search, so close it explicitly here.
+  if (await activeInput.isVisible().catch(() => false)) {
+    await page.keyboard.press('Escape').catch(() => undefined);
+    await closeBottomSheet();
+  }
+
   await expect(activeInput).not.toBeVisible({ timeout: 10000 });
 
   const directoryCandidates = new Set<string>([trimmedDirectory]);

--- a/packages/app/e2e/working-directory-combobox-continue-search.spec.ts
+++ b/packages/app/e2e/working-directory-combobox-continue-search.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "./fixtures";
+import { gotoHome } from "./helpers/app";
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+test("working directory combobox keeps search open after selecting a directory", async ({ page }) => {
+  await gotoHome(page);
+
+  const workingDirectorySelect = page
+    .locator('[data-testid="working-directory-select"]:visible')
+    .first();
+  await expect(workingDirectorySelect).toBeVisible();
+  await workingDirectorySelect.click({ force: true });
+
+  const searchInput = page.getByRole("textbox", { name: /search directories/i }).first();
+  await expect(searchInput).toBeVisible();
+
+  const firstQuery = `/tmp/paseo-continue-search-${Date.now()}-a`;
+  await searchInput.fill(firstQuery);
+
+  const firstOption = page.getByText(new RegExp(`^${escapeRegex(firstQuery)}$`)).first();
+  await expect(firstOption).toBeVisible();
+  await firstOption.click({ force: true });
+
+  await expect(searchInput).toBeVisible();
+  await expect(searchInput).toHaveValue(firstQuery);
+
+  const secondQuery = `${firstQuery}-b`;
+  await searchInput.fill(secondQuery);
+  const secondOption = page.getByText(new RegExp(`^${escapeRegex(secondQuery)}$`)).first();
+  await expect(secondOption).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(searchInput).not.toBeVisible();
+});

--- a/packages/app/src/components/agent-form/agent-form-dropdowns.tsx
+++ b/packages/app/src/components/agent-form/agent-form-dropdowns.tsx
@@ -883,6 +883,7 @@ export function WorkingDirectoryDropdown({
         options={options}
         value={workingDir}
         onSelect={onSelectPath}
+        closeOnSelect={false}
         searchPlaceholder="Search directories..."
         emptyText={emptyText}
         allowCustomValue

--- a/packages/app/src/components/ui/combobox.tsx
+++ b/packages/app/src/components/ui/combobox.tsx
@@ -39,6 +39,7 @@ export interface ComboboxProps {
   options: ComboboxOption[];
   value: string;
   onSelect: (id: string) => void;
+  closeOnSelect?: boolean;
   onSearchQueryChange?: (query: string) => void;
   searchable?: boolean;
   placeholder?: string;
@@ -191,6 +192,7 @@ export function Combobox({
   options,
   value,
   onSelect,
+  closeOnSelect = true,
   onSearchQueryChange,
   searchable = true,
   placeholder = "Search...",
@@ -491,9 +493,11 @@ export function Combobox({
   const handleSelect = useCallback(
     (id: string) => {
       onSelect(id);
-      handleClose();
+      if (closeOnSelect) {
+        handleClose();
+      }
     },
-    [handleClose, onSelect]
+    [closeOnSelect, handleClose, onSelect]
   );
 
   const handleSubmitSearch = useCallback(() => {

--- a/packages/app/src/screens/agent/draft-agent-screen.tsx
+++ b/packages/app/src/screens/agent/draft-agent-screen.tsx
@@ -1188,6 +1188,7 @@ export function DraftAgentScreen({
             options={workingDirComboOptions}
             value={workingDir}
             onSelect={setWorkingDirFromUser}
+            closeOnSelect={false}
             onSearchQueryChange={setWorkingDirSearchQuery}
             searchPlaceholder="Search directories..."
             emptyText={workingDirEmptyText}


### PR DESCRIPTION
## Summary
- keep `Combobox` close behavior configurable via `closeOnSelect` (defaults to existing behavior)
- enable `closeOnSelect={false}` for working-directory pickers so selecting a directory doesn't dismiss search
- add an e2e regression spec for continuing search after selecting a directory
- update the e2e helper to explicitly dismiss the picker when a flow expects closure

## Verification
- `npm run typecheck`
- `npm run test:e2e --workspace=@getpaseo/app -- working-directory-combobox-continue-search.spec.ts`
- `npm run test:e2e --workspace=@getpaseo/app -- working-directory-combobox-positioning.spec.ts`

Closes #34