### PR TITLE
fix: terminal shrinks after switching agents

### DIFF
--- a/packages/app/src/components/terminal-emulator.tsx
+++ b/packages/app/src/components/terminal-emulator.tsx
@@ -29,6 +29,7 @@ interface TerminalEmulatorProps {
   onOutputChunkConsumed?: (sequence: number) => Promise<void> | void;
   pendingModifiers?: PendingTerminalModifiers;
   focusRequestToken?: number;
+  resizeRequestToken?: number;
 }
 
 declare global {
@@ -51,6 +52,7 @@ export default function TerminalEmulator({
   onOutputChunkConsumed,
   pendingModifiers = { ctrl: false, shift: false, alt: false },
   focusRequestToken = 0,
+  resizeRequestToken = 0,
 }: TerminalEmulatorProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const hostRef = useRef<HTMLDivElement | null>(null);
@@ -141,6 +143,13 @@ export default function TerminalEmulator({
     }
     runtimeRef.current?.focus();
   }, [focusRequestToken]);
+
+  useEffect(() => {
+    if (resizeRequestToken <= 0) {
+      return;
+    }
+    runtimeRef.current?.resize({ force: true });
+  }, [resizeRequestToken]);
 
   return (
     <div

--- a/packages/app/src/terminal/runtime/terminal-emulator-runtime.test.ts
+++ b/packages/app/src/terminal/runtime/terminal-emulator-runtime.test.ts
@@ -157,4 +157,18 @@ describe("terminal-emulator-runtime", () => {
     expect(onCommittedA).toHaveBeenCalledTimes(1);
     expect(onCommittedB).toHaveBeenCalledTimes(1);
   });
+
+  it("forces a refit when resize is requested", () => {
+    const runtime = new TerminalEmulatorRuntime();
+    const fitAndEmitResize = vi.fn();
+
+    (runtime as unknown as { fitAndEmitResize: (force: boolean) => void }).fitAndEmitResize =
+      fitAndEmitResize;
+
+    runtime.resize();
+    runtime.resize({ force: true });
+
+    expect(fitAndEmitResize).toHaveBeenNthCalledWith(1, false);
+    expect(fitAndEmitResize).toHaveBeenNthCalledWith(2, true);
+  });
 });

--- a/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
+++ b/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
@@ -76,6 +76,7 @@ export class TerminalEmulatorRuntime {
   };
   private terminal: Terminal | null = null;
   private fitAddon: FitAddon | null = null;
+  private fitAndEmitResize: ((force: boolean) => void) | null = null;
   private lastSize: { rows: number; cols: number } | null = null;
   private cleanup: (() => void) | null = null;
   private outputOperations: TerminalOutputOperation[] = [];
@@ -168,6 +169,7 @@ export class TerminalEmulatorRuntime {
         cols: nextCols,
       });
     };
+    this.fitAndEmitResize = fitAndEmitResize;
 
     fitAndEmitResize(true);
 
@@ -383,6 +385,10 @@ export class TerminalEmulatorRuntime {
     this.processOutputQueue();
   }
 
+  resize(input?: { force?: boolean }): void {
+    this.fitAndEmitResize?.(input?.force ?? false);
+  }
+
   focus(): void {
     this.terminal?.focus();
   }
@@ -413,6 +419,7 @@ export class TerminalEmulatorRuntime {
     }
     this.terminal = null;
     this.fitAddon = null;
+    this.fitAndEmitResize = null;
     this.lastSize = null;
   }
 


### PR DESCRIPTION
## Summary
- add a focus-triggered terminal refit pulse when returning to an agent screen
- expose a runtime `resize({ force })` entrypoint so the emulator can force xterm fit on demand
- cover the new runtime resize path with a unit test

## Testing
- npm run test --workspace=@getpaseo/app -- src/terminal/runtime/terminal-emulator-runtime.test.ts
- npm run typecheck --workspace=@getpaseo/app
- npm run typecheck

Closes #39
