### PR TITLE
fix: hash worktree root by cwd to prevent path clashes

### DIFF
--- a/packages/server/src/server/daemon-e2e/git-operations.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/git-operations.e2e.test.ts
@@ -7,7 +7,7 @@ import {
   type DaemonTestContext,
 } from "../test-utils/index.js";
 import { createMessageCollector, type MessageCollector } from "../test-utils/message-collector.js";
-import { slugify } from "../../utils/worktree.js";
+import { deriveWorktreeProjectHash } from "../../utils/worktree.js";
 import type { AgentTimelineItem } from "../agent/agent-sdk-types.js";
 import type { AgentSnapshotPayload, SessionOutboundMessage } from "../messages.js";
 
@@ -685,9 +685,10 @@ describe("daemon E2E", () => {
 
   describe("createAgent with worktree", () => {
     test(
-      "creates agent in ~/.paseo/worktrees/{project} when worktree is requested",
+      "creates agent in ~/.paseo/worktrees/{hash} when worktree is requested",
       async () => {
         const cwd = tmpCwd();
+        const projectHash = await deriveWorktreeProjectHash(cwd);
 
         const { execSync } = await import("child_process");
         execSync("git init -b main", { cwd, stdio: "pipe" });
@@ -724,7 +725,7 @@ describe("daemon E2E", () => {
             path.join(
               ctx.daemon.paseoHome,
               "worktrees",
-              slugify(path.basename(cwd)),
+              projectHash,
               "worktree-test"
             )
           )

--- a/packages/website/src/routes/docs/worktrees.tsx
+++ b/packages/website/src/routes/docs/worktrees.tsx
@@ -52,20 +52,20 @@ function Worktrees() {
         <h2 className="text-xl font-medium">Directory structure</h2>
         <p className="text-white/60 leading-relaxed">
           Paseo creates worktrees under <code className="font-mono">$PASEO_HOME/worktrees/</code>,
-          organized by project:
+          organized by a short hash of the source checkout path:
         </p>
         <Code>
           <pre className="text-white/80">{`~/.paseo/worktrees/
-├── my-project/
+├── 1vnnm9k3/
 │   ├── tidy-fox/            # random slug
 │   └── bold-owl/            # random slug
-└── another-repo/
+└── 4k8q2d1p/
     └── swift-hare/          # random slug`}</pre>
         </Code>
         <p className="text-white/60 leading-relaxed">
-          The project name is derived from your git remote URL or repository directory name.
-          Directory names are random slugs — the branch name is separate and chosen when
-          you first launch an agent in the worktree.
+          The hash avoids collisions between repositories that share the same directory or
+          remote name. Worktree directory names are random slugs — the branch name is
+          separate and chosen when you first launch an agent in the worktree.
         </p>
       </section>
 


### PR DESCRIPTION
## Summary
- replace project-name inference for `~/.paseo/worktrees/*` with a deterministic short alphanumeric hash derived from canonical repo root path
- add a TDD regression test proving two repositories with the same directory name no longer collide in worktree root selection
- update existing server tests and docs to reflect `~/.paseo/worktrees/{hash}`

## Coding standards review
- verified deterministic test coverage for the behavior change (new failing test added before implementation and now passing)
- kept API behavior explicit: no fallback to guessed project names once hash derivation is available
- kept changes scoped to worktree root derivation, expectations, and docs only

## Testing
- `npm run -w packages/server test -- src/utils/worktree.test.ts`
- `npm run -w packages/server typecheck`
- `npm run -w packages/website typecheck`
- `npm run -w packages/server test -- src/server/daemon-e2e/git-operations.e2e.test.ts -t "creates agent in ~/.paseo/worktrees/{hash} when worktree is requested"` (fails locally due existing module-resolution issue for `@getpaseo/relay/e2ee`)

Closes #41
