### PR TITLE
Improve post-ship worktree flow and merged PR handling

### DIFF
--- a/packages/app/e2e/checkout-ship.spec.ts
+++ b/packages/app/e2e/checkout-ship.spec.ts
@@ -394,7 +394,7 @@ test('checkout-first Changes panel ship loop', async ({ page }) => {
     await expect(page.getByTestId('changes-menu-archive-worktree')).toBeVisible();
     await page.getByTestId('changes-menu-archive-worktree').click();
     // Archiving a worktree deletes agents and redirects to home
-    await expect(page).toHaveURL(/\/agent\/?$/, { timeout: 30000 });
+    await expect(page).toHaveURL(/\/agent\/?(?:\?.*)?$/, { timeout: 30000 });
     await setWorkingDirectory(page, repo.path);
     await ensureHostSelected(page);
     // Repo inspection is async; wait until git options are interactive again.

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1690,6 +1690,7 @@ const CheckoutPrStatusSchema = z.object({
   state: z.string(),
   baseRefName: z.string(),
   headRefName: z.string(),
+  isMerged: z.boolean(),
 });
 
 export const CheckoutPrStatusResponseSchema = z.object({


### PR DESCRIPTION
## Summary
This PR tightens the solo worktree shipping flow and removes ambiguity after PR merges by detecting merged PR state and promoting archive/sync actions in the Git panel.

## What changed
- server: detect merged PRs when no open PR exists by checking closed PRs with `merged_at`.
- server: include `isMerged` in checkout PR status payload.
- app: promote `Archive worktree` after ship conditions (local merge completion or merged PR status).
- app: route archive success to draft/new-agent screen using base checkout working directory.
- app: expose base sync action when on base branch and adjust primary action prioritization for base/worktree contexts.
- e2e: allow draft/new-agent URL assertion with optional query params (for `workingDir`).
- tests: add coverage for merged-PR detection and ensure closed-unmerged PRs are not treated as shipped.

## Verification
- `npm run test --workspace=@getpaseo/server -- src/utils/checkout-git.test.ts`
- `npm run test --workspace=@getpaseo/app -- src/utils/new-agent-routing.test.ts`
- `npm run typecheck`

## Issue linkage
- None provided.
