### PR TITLE
feat(app): add colorblind appearance mode

### DIFF
--- a/packages/app/src/hooks/use-settings.ts
+++ b/packages/app/src/hooks/use-settings.ts
@@ -7,7 +7,7 @@ const LEGACY_SETTINGS_KEY = "@paseo:settings";
 const APP_SETTINGS_QUERY_KEY = ["app-settings"];
 
 export interface AppSettings {
-  theme: "dark" | "light" | "auto";
+  theme: "dark" | "light" | "auto" | "colorblind";
 }
 
 const DEFAULT_APP_SETTINGS: AppSettings = {
@@ -95,7 +95,12 @@ async function loadSettingsFromStorage(): Promise<AppSettings> {
 
 function pickAppSettingsFromLegacy(legacy: Record<string, unknown>): Partial<AppSettings> {
   const result: Partial<AppSettings> = {};
-  if (legacy.theme === "dark" || legacy.theme === "light" || legacy.theme === "auto") {
+  if (
+    legacy.theme === "dark" ||
+    legacy.theme === "light" ||
+    legacy.theme === "auto" ||
+    legacy.theme === "colorblind"
+  ) {
     result.theme = legacy.theme;
   }
   return result;

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -13,7 +13,7 @@ import Constants from "expo-constants";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { StyleSheet, UnistylesRuntime, useUnistyles } from "react-native-unistyles";
 import { useQueries } from "@tanstack/react-query";
-import { Sun, Moon, Monitor, Globe, Settings, RotateCw, Trash2, Check } from "lucide-react-native";
+import { Sun, Moon, Monitor, Eye, Globe, Settings, RotateCw, Trash2, Check } from "lucide-react-native";
 import { useAppSettings, type AppSettings } from "@/hooks/use-settings";
 import { useDaemonRegistry, type HostProfile, type HostConnection } from "@/contexts/daemon-registry-context";
 import { useDaemonConnections, type ActiveConnection, type ConnectionStatus } from "@/contexts/daemon-connections-context";
@@ -905,6 +905,11 @@ export default function SettingsScreen() {
                       value: "auto",
                       label: "System",
                       icon: ({ color, size }) => <Monitor size={size} color={color} />,
+                    },
+                    {
+                      value: "colorblind",
+                      label: "Colorblind",
+                      icon: ({ color, size }) => <Eye size={size} color={color} />,
                     },
                   ]}
                 />

--- a/packages/app/src/styles/theme.ts
+++ b/packages/app/src/styles/theme.ts
@@ -188,6 +188,71 @@ const darkSemanticColors = {
   ring: "#d4d4d8",
 } as const;
 
+const colorblindSemanticColors = {
+  // GitHub dark colorblind-inspired surfaces
+  surface0: "#0d1117",       // App background
+  surface1: "#151b23",       // Subtle hover
+  surface2: "#212830",       // Elevated: badges, inputs, sheets
+  surface3: "#2f3742",       // Highest elevation
+
+  // Text
+  foreground: "#f0f6fc",
+  foregroundMuted: "#9198a1",
+
+  // Borders
+  border: "#3d444d",
+  borderAccent: "#656c76",
+
+  // Brand
+  accent: "#1f6feb",
+  accentForeground: "#ffffff",
+
+  // Semantic
+  destructive: "#bd561d",
+  destructiveForeground: "#ffffff",
+  success: "#1f6feb",
+  successForeground: "#ffffff",
+
+  // Legacy aliases (for gradual migration)
+  background: "#0d1117",
+  card: "#212830",
+  cardForeground: "#f0f6fc",
+  popover: "#212830",
+  popoverForeground: "#f0f6fc",
+  primary: "#f0f6fc",
+  primaryForeground: "#0d1117",
+  secondary: "#212830",
+  secondaryForeground: "#f0f6fc",
+  muted: "#212830",
+  mutedForeground: "#9198a1",
+  accentBorder: "#656c76",
+  input: "#212830",
+  ring: "#4493f8",
+} as const;
+
+const colorblindPalette = {
+  ...baseColors,
+  // Replace red/green ramps with blue/orange ramps from GitHub's colorblind theme.
+  green: {
+    100: "#cae8ff",
+    200: "#a5d6ff",
+    400: "#79c0ff",
+    500: "#58a6ff",
+    600: "#1f6feb",
+    800: "#1158c7",
+    900: "#0c2d6b",
+  },
+  red: {
+    100: "#ffdfb6",
+    200: "#ffd8b5",
+    300: "#ffc680",
+    500: "#f0883e",
+    600: "#bd561d",
+    800: "#9b4215",
+    900: "#762c00",
+  },
+} as const;
+
 const commonTheme = {
   spacing: {
     0: 0,
@@ -269,8 +334,16 @@ export const lightTheme = {
   ...commonTheme,
 } as const;
 
+export const colorblindTheme = {
+  colors: {
+    ...colorblindSemanticColors,
+    palette: colorblindPalette,
+  },
+  ...commonTheme,
+} as const;
+
 // Keep compatibility with existing code
 export const theme = darkTheme;
 
 // Export a union type that works for both themes
-export type Theme = typeof darkTheme | typeof lightTheme;
+export type Theme = typeof darkTheme | typeof lightTheme | typeof colorblindTheme;

--- a/packages/app/src/styles/unistyles.ts
+++ b/packages/app/src/styles/unistyles.ts
@@ -1,6 +1,6 @@
 import { StyleSheet } from "react-native-unistyles";
 // import { UnistylesRuntime } from "react-native-unistyles";
-import { lightTheme, darkTheme } from "./theme";
+import { lightTheme, darkTheme, colorblindTheme } from "./theme";
 
 console.log("[Unistyles] Configuring...");
 
@@ -9,6 +9,7 @@ StyleSheet.configure({
   themes: {
     light: lightTheme,
     dark: darkTheme,
+    colorblind: colorblindTheme,
   },
   breakpoints: {
     xs: 0,
@@ -28,6 +29,7 @@ console.log("[Unistyles] Configuration complete!");
 type AppThemes = {
   light: typeof lightTheme;
   dark: typeof darkTheme;
+  colorblind: typeof colorblindTheme;
 };
 
 type AppBreakpoints = {


### PR DESCRIPTION
## Summary
- add a dedicated `colorblind` app theme based on GitHub dark colorblind tokens
- register the new theme in Unistyles and extend theme typings
- add `Colorblind` as a selectable option in Settings > Appearance
- persist `colorblind` in app settings, including legacy settings migration support

## Details
- Introduced `colorblindTheme` with:
  - GitHub colorblind-inspired surfaces, borders, and semantic colors
  - blue/orange replacements for green/red palette ramps to reduce red-green ambiguity
- Kept existing `dark`, `light`, and `auto` behavior unchanged.

Closes #65

## Verification
- `npm run typecheck --workspace=@getpaseo/app`
