### PR TITLE
perf(app): optimize streaming state updates and auto-scroll

### DIFF
--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -183,6 +183,9 @@ function SessionProviderInternal({
   const setAgentStreamHead = useSessionStore(
     (state) => state.setAgentStreamHead
   );
+  const setAgentStreamState = useSessionStore(
+    (state) => state.setAgentStreamState
+  );
   const clearAgentStreamHead = useSessionStore(
     (state) => state.clearAgentStreamHead
   );
@@ -784,23 +787,10 @@ function SessionProviderInternal({
         timestamp: parsedTimestamp,
       });
 
-      if (changedTail) {
-        setAgentStreamTail(serverId, (prev) => {
-          const next = new Map(prev);
-          next.set(agentId, tail);
-          return next;
-        });
-      }
-
-      if (changedHead) {
-        setAgentStreamHead(serverId, (prev) => {
-          const next = new Map(prev);
-          if (head.length > 0) {
-            next.set(agentId, head);
-          } else {
-            next.delete(agentId);
-          }
-          return next;
+      if (changedTail || changedHead) {
+        setAgentStreamState(serverId, agentId, {
+          ...(changedTail ? { tail } : {}),
+          ...(changedHead ? { head } : {}),
         });
       }
 
@@ -1261,6 +1251,7 @@ function SessionProviderInternal({
     setCurrentAssistantMessage,
     setAgentStreamTail,
     setAgentStreamHead,
+    setAgentStreamState,
     clearAgentStreamHead,
     setAgentTimelineCursor,
     setInitializingAgents,

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -243,6 +243,11 @@ interface SessionStoreActions {
   // Stream state (head/tail model)
   setAgentStreamTail: (serverId: string, state: Map<string, StreamItem[]> | ((prev: Map<string, StreamItem[]>) => Map<string, StreamItem[]>)) => void;
   setAgentStreamHead: (serverId: string, state: Map<string, StreamItem[]> | ((prev: Map<string, StreamItem[]>) => Map<string, StreamItem[]>)) => void;
+  setAgentStreamState: (
+    serverId: string,
+    agentId: string,
+    state: { tail?: StreamItem[]; head?: StreamItem[] }
+  ) => void;
   clearAgentStreamHead: (serverId: string, agentId: string) => void;
   setAgentTimelineCursor: (
     serverId: string,
@@ -618,6 +623,67 @@ export const useSessionStore = create<SessionStore>()(
           sessions: {
             ...prev.sessions,
             [serverId]: { ...session, agentStreamHead: nextState },
+          },
+        };
+      });
+    },
+
+    setAgentStreamState: (serverId, agentId, state) => {
+      set((prev) => {
+        const session = prev.sessions[serverId];
+        if (!session) {
+          return prev;
+        }
+
+        let nextTail = session.agentStreamTail;
+        let nextHead = session.agentStreamHead;
+        let changedTail = false;
+        let changedHead = false;
+
+        if (state.tail !== undefined) {
+          const existingTail = session.agentStreamTail.get(agentId);
+          if (existingTail !== state.tail) {
+            nextTail = new Map(session.agentStreamTail);
+            nextTail.set(agentId, state.tail);
+            changedTail = true;
+          }
+        }
+
+        if (state.head !== undefined) {
+          const existingHead = session.agentStreamHead.get(agentId);
+          const shouldDeleteHead = state.head.length === 0;
+          if (shouldDeleteHead) {
+            if (session.agentStreamHead.has(agentId)) {
+              nextHead = new Map(session.agentStreamHead);
+              nextHead.delete(agentId);
+              changedHead = true;
+            }
+          } else if (existingHead !== state.head) {
+            nextHead = new Map(session.agentStreamHead);
+            nextHead.set(agentId, state.head);
+            changedHead = true;
+          }
+        }
+
+        if (!changedTail && !changedHead) {
+          return prev;
+        }
+
+        logSessionStoreUpdate("setAgentStreamState", serverId, {
+          agentId,
+          changedTail,
+          changedHead,
+        });
+
+        return {
+          ...prev,
+          sessions: {
+            ...prev.sessions,
+            [serverId]: {
+              ...session,
+              agentStreamTail: nextTail,
+              agentStreamHead: nextHead,
+            },
           },
         };
       });


### PR DESCRIPTION
## Summary
- batch stream `head` + `tail` updates into one Zustand store write per stream event
- throttle streaming auto-scroll to once per animation frame in `AgentStreamView`
- keep existing stream semantics and UI behavior unchanged

## Why this helps
- The stream pipeline previously performed up to two separate store writes for every stream event (`setAgentStreamTail` + `setAgentStreamHead`), increasing subscriber notifications and render pressure.
- During active streaming, every new chunk could trigger an immediate `scrollToOffset` call while pinned to bottom. Coalescing to one RAF-backed scroll per frame cuts redundant work and reduces scroll jank.

## Changes
1. `session-store`
- added `setAgentStreamState(serverId, agentId, { tail?, head? })` to update both maps in a single `set()` call
- avoids unnecessary map copies if the specific agent stream arrays are unchanged

2. `session-context`
- replaced separate `setAgentStreamTail`/`setAgentStreamHead` calls in `agent_stream` handler with one `setAgentStreamState` call

3. `agent-stream-view`
- introduced `scheduleAutoScroll` that coalesces bottom-scroll updates via `requestAnimationFrame`
- added cleanup for pending animation frame on unmount

## Verification
- `npm run typecheck --workspace=@getpaseo/app`
- `npm run test --workspace=@getpaseo/app -- src/types/stream.test.ts`
