### PR TITLE
fix: pin @opencode-ai/sdk to 1.2.6 to fix startup crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4884,7 +4884,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.1.12",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.2.6.tgz",
+      "integrity": "sha512-dWMF8Aku4h7fh8sw5tQ2FtbqRLbIFT8FcsukpxTird49ax7oUXP+gzqxM/VdxHjfksQvzLBjLZyMdDStc5g7xA==",
       "license": "MIT"
     },
     "node_modules/@opentelemetry/api": {
@@ -21732,7 +21734,7 @@
         "@lezer/markdown": "^1.6.2",
         "@lezer/python": "^1.1.18",
         "@modelcontextprotocol/sdk": "^1.20.1",
-        "@opencode-ai/sdk": "^1.1.12",
+        "@opencode-ai/sdk": "1.2.6",
         "@sctg/sentencepiece-js": "^1.1.0",
         "@xterm/headless": "^6.0.0",
         "ai": "5.0.78",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -66,7 +66,7 @@
     "@lezer/markdown": "^1.6.2",
     "@lezer/python": "^1.1.18",
     "@modelcontextprotocol/sdk": "^1.20.1",
-    "@opencode-ai/sdk": "^1.1.12",
+    "@opencode-ai/sdk": "1.2.6",
     "@sctg/sentencepiece-js": "^1.1.0",
     "@xterm/headless": "^6.0.0",
     "ai": "5.0.78",


### PR DESCRIPTION
## Summary

- Pins `@opencode-ai/sdk` to `1.2.6` in `packages/server/package.json`
- Versions 1.2.7–1.2.9 have a broken npm publish: compiled files land in `dist/src/` but the package `exports` map references `dist/v2/`, causing an `ERR_MODULE_NOT_FOUND` crash on startup
- `1.2.6` has the correct dist layout and works fine

Closes #64

## Test plan

- [ ] `npm install -g @getpaseo/cli` and run `paseo` — should start without the `ERR_MODULE_NOT_FOUND` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)