### PR TITLE
fix(server): decouple explicit and auto agent title limits

### DIFF
--- a/packages/server/src/server/agent/agent-metadata-generator.unit.test.ts
+++ b/packages/server/src/server/agent/agent-metadata-generator.unit.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import { MAX_AUTO_AGENT_TITLE_CHARS } from "./agent-title-limits.js";
+import {
+  generateAndApplyAgentMetadata,
+  type AgentMetadataGeneratorDeps,
+} from "./agent-metadata-generator.js";
+import type { AgentManager } from "./agent-manager.js";
+
+const logger = createTestLogger();
+
+const NON_GIT_CHECKOUT_STATUS = {
+  isGit: false,
+  isPaseoOwnedWorktree: false,
+  currentBranch: null,
+  repoRoot: "/tmp/repo",
+} as Awaited<
+  ReturnType<NonNullable<AgentMetadataGeneratorDeps["getCheckoutStatus"]>>
+>;
+
+function createDeps(
+  generateStructuredAgentResponseWithFallback: NonNullable<
+    AgentMetadataGeneratorDeps["generateStructuredAgentResponseWithFallback"]
+  >
+): AgentMetadataGeneratorDeps {
+  return {
+    generateStructuredAgentResponseWithFallback,
+    getCheckoutStatus: vi
+      .fn()
+      .mockResolvedValue(NON_GIT_CHECKOUT_STATUS) as NonNullable<
+      AgentMetadataGeneratorDeps["getCheckoutStatus"]
+    >,
+  };
+}
+
+describe("agent metadata generator auto-title", () => {
+  it("caps generated auto titles at 40 characters before persisting", async () => {
+    const setTitle = vi.fn().mockResolvedValue(undefined);
+    const manager = { setTitle } as unknown as AgentManager;
+    const generatedTitle = "x".repeat(MAX_AUTO_AGENT_TITLE_CHARS + 25);
+    const generateStructured = vi.fn().mockResolvedValue({ title: generatedTitle }) as NonNullable<
+      AgentMetadataGeneratorDeps["generateStructuredAgentResponseWithFallback"]
+    >;
+
+    await generateAndApplyAgentMetadata({
+      agentManager: manager,
+      agentId: "agent-1",
+      cwd: "/tmp/repo",
+      initialPrompt: "Implement this feature",
+      explicitTitle: null,
+      logger,
+      deps: createDeps(generateStructured),
+    });
+
+    expect(setTitle).toHaveBeenCalledTimes(1);
+    expect(setTitle).toHaveBeenCalledWith(
+      "agent-1",
+      "x".repeat(MAX_AUTO_AGENT_TITLE_CHARS)
+    );
+  });
+
+  it("does not generate an auto title when an explicit title is provided", async () => {
+    const setTitle = vi.fn().mockResolvedValue(undefined);
+    const manager = { setTitle } as unknown as AgentManager;
+    const generateStructured = vi.fn().mockResolvedValue({ title: "Generated" }) as NonNullable<
+      AgentMetadataGeneratorDeps["generateStructuredAgentResponseWithFallback"]
+    >;
+
+    await generateAndApplyAgentMetadata({
+      agentManager: manager,
+      agentId: "agent-2",
+      cwd: "/tmp/repo",
+      initialPrompt: "Implement this feature",
+      explicitTitle: "Keep this title",
+      logger,
+      deps: createDeps(generateStructured),
+    });
+
+    expect(generateStructured).not.toHaveBeenCalled();
+    expect(setTitle).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/server/agent/agent-title-limits.ts
+++ b/packages/server/src/server/agent/agent-title-limits.ts
@@ -1,0 +1,2 @@
+export const MAX_EXPLICIT_AGENT_TITLE_CHARS = 200;
+export const MAX_AUTO_AGENT_TITLE_CHARS = 40;

--- a/packages/server/src/shared/messages.create-agent-client-message-id.test.ts
+++ b/packages/server/src/shared/messages.create-agent-client-message-id.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { SessionInboundMessageSchema } from "./messages";
+import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "../server/agent/agent-title-limits.js";
 
 describe("create_agent_request clientMessageId", () => {
   it("accepts clientMessageId for stable initial prompt transfer", () => {
@@ -19,5 +20,37 @@ describe("create_agent_request clientMessageId", () => {
       throw new Error("Expected create_agent_request");
     }
     expect(parsed.clientMessageId).toBe("client-msg-1");
+  });
+
+  it("accepts explicit titles up to the create-agent limit", () => {
+    const parsed = SessionInboundMessageSchema.parse({
+      type: "create_agent_request",
+      requestId: "req-title-ok",
+      config: {
+        provider: "claude",
+        cwd: "/tmp/project",
+        title: "x".repeat(MAX_EXPLICIT_AGENT_TITLE_CHARS),
+      },
+    });
+
+    expect(parsed.type).toBe("create_agent_request");
+    if (parsed.type !== "create_agent_request") {
+      throw new Error("Expected create_agent_request");
+    }
+    expect(parsed.config.title).toHaveLength(MAX_EXPLICIT_AGENT_TITLE_CHARS);
+  });
+
+  it("rejects explicit titles longer than the create-agent limit", () => {
+    const parsed = SessionInboundMessageSchema.safeParse({
+      type: "create_agent_request",
+      requestId: "req-title-too-long",
+      config: {
+        provider: "claude",
+        cwd: "/tmp/project",
+        title: "x".repeat(MAX_EXPLICIT_AGENT_TITLE_CHARS + 1),
+      },
+    });
+
+    expect(parsed.success).toBe(false);
   });
 });

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { AGENT_LIFECYCLE_STATUSES } from './agent-lifecycle.js'
+import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from '../server/agent/agent-title-limits.js'
 import { AgentProviderSchema } from '../server/agent/provider-manifest.js'
 import type {
   AgentCapabilityFlags,
@@ -89,7 +90,7 @@ const AgentSessionConfigSchema = z.object({
   modeId: z.string().optional(),
   model: z.string().optional(),
   thinkingOptionId: z.string().optional(),
-  title: z.string().trim().min(1).max(40).optional().nullable(),
+  title: z.string().trim().min(1).max(MAX_EXPLICIT_AGENT_TITLE_CHARS).optional().nullable(),
   approvalPolicy: z.string().optional(),
   sandboxMode: z.string().optional(),
   networkAccess: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- raise explicit create-agent title limit to 200 characters in shared create/config validation
- keep auto-generated metadata titles capped at 40 characters
- colocate both title limits in packages/server/src/server/agent/agent-title-limits.ts
- add tests for explicit title limit validation and auto-title truncation behavior

## Validation
- npm run test --workspace=@getpaseo/server -- src/shared/messages.create-agent-client-message-id.test.ts src/server/agent/agent-metadata-generator.unit.test.ts
- npm run typecheck