### PR TITLE
Fix web stream scroll contention with strategy-driven renderer

### DIFF
--- a/packages/app/src/components/agent-stream-render-strategy.test.ts
+++ b/packages/app/src/components/agent-stream-render-strategy.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from "vitest";
+import type { StreamItem } from "@/types/stream";
+import {
+  collectAssistantTurnContentForStreamRenderStrategy,
+  getBottomOffsetForStreamRenderStrategy,
+  getStreamEdgeSlotProps,
+  getStreamNeighborIndex,
+  getStreamNeighborItem,
+  isNearBottomForStreamRenderStrategy,
+  orderHeadForStreamRenderStrategy,
+  orderTailForStreamRenderStrategy,
+  resolveStreamRenderStrategy,
+} from "./agent-stream-render-strategy";
+
+function createTimestamp(seed: number): Date {
+  return new Date(`2026-01-01T00:00:0${seed}.000Z`);
+}
+
+function userMessage(id: string, text: string, seed: number): StreamItem {
+  return {
+    kind: "user_message",
+    id,
+    text,
+    timestamp: createTimestamp(seed),
+  };
+}
+
+function assistantMessage(id: string, text: string, seed: number): StreamItem {
+  return {
+    kind: "assistant_message",
+    id,
+    text,
+    timestamp: createTimestamp(seed),
+  };
+}
+
+describe("resolveStreamRenderStrategy", () => {
+  it("uses forward_stream on web", () => {
+    const strategy = resolveStreamRenderStrategy({
+      platform: "web",
+      isMobileBreakpoint: false,
+    });
+
+    expect(strategy.kind).toBe("forward_stream");
+    expect(strategy.flatListInverted).toBe(false);
+    expect(strategy.overlayScrollbarInverted).toBe(false);
+  });
+
+  it("uses inverted_stream on native", () => {
+    const strategy = resolveStreamRenderStrategy({
+      platform: "ios",
+      isMobileBreakpoint: false,
+    });
+
+    expect(strategy.kind).toBe("inverted_stream");
+    expect(strategy.flatListInverted).toBe(true);
+    expect(strategy.overlayScrollbarInverted).toBe(true);
+  });
+});
+
+describe("stream ordering", () => {
+  const streamItems: StreamItem[] = [
+    userMessage("u1", "user-1", 1),
+    assistantMessage("a1", "assistant-1", 2),
+    assistantMessage("a2", "assistant-2", 3),
+  ];
+
+  it("keeps forward_stream order unchanged for tail and head", () => {
+    const strategy = resolveStreamRenderStrategy({
+      platform: "web",
+      isMobileBreakpoint: false,
+    });
+
+    const tail = orderTailForStreamRenderStrategy({ strategy, streamItems });
+    const head = orderHeadForStreamRenderStrategy({ strategy, streamHead: streamItems });
+
+    expect(tail.map((item) => item.id)).toEqual(["u1", "a1", "a2"]);
+    expect(head.map((item) => item.id)).toEqual(["u1", "a1", "a2"]);
+  });
+
+  it("reverses inverted_stream order for tail and head", () => {
+    const strategy = resolveStreamRenderStrategy({
+      platform: "android",
+      isMobileBreakpoint: false,
+    });
+
+    const tail = orderTailForStreamRenderStrategy({ strategy, streamItems });
+    const head = orderHeadForStreamRenderStrategy({ strategy, streamHead: streamItems });
+
+    expect(tail.map((item) => item.id)).toEqual(["a2", "a1", "u1"]);
+    expect(head.map((item) => item.id)).toEqual(["a2", "a1", "u1"]);
+  });
+});
+
+describe("neighbor and traversal semantics", () => {
+  it("maps above/below indices for forward and inverted streams", () => {
+    const forward = resolveStreamRenderStrategy({
+      platform: "web",
+      isMobileBreakpoint: false,
+    });
+    const inverted = resolveStreamRenderStrategy({
+      platform: "ios",
+      isMobileBreakpoint: false,
+    });
+
+    expect(getStreamNeighborIndex({ strategy: forward, index: 3, relation: "above" })).toBe(2);
+    expect(getStreamNeighborIndex({ strategy: forward, index: 3, relation: "below" })).toBe(4);
+    expect(getStreamNeighborIndex({ strategy: inverted, index: 3, relation: "above" })).toBe(4);
+    expect(getStreamNeighborIndex({ strategy: inverted, index: 3, relation: "below" })).toBe(2);
+  });
+
+  it("collects assistant turn content with strategy traversal direction", () => {
+    const chronological: StreamItem[] = [
+      userMessage("u1", "user-1", 1),
+      assistantMessage("a1", "assistant-1", 2),
+      assistantMessage("a2", "assistant-2", 3),
+      userMessage("u2", "user-2", 4),
+    ];
+
+    const forward = resolveStreamRenderStrategy({
+      platform: "web",
+      isMobileBreakpoint: false,
+    });
+    const forwardStartIndex = chronological.findIndex((item) => item.id === "a2");
+    expect(
+      collectAssistantTurnContentForStreamRenderStrategy({
+        strategy: forward,
+        items: chronological,
+        startIndex: forwardStartIndex,
+      })
+    ).toBe("assistant-1\n\nassistant-2");
+
+    const inverted = resolveStreamRenderStrategy({
+      platform: "android",
+      isMobileBreakpoint: false,
+    });
+    const invertedItems = orderTailForStreamRenderStrategy({
+      strategy: inverted,
+      streamItems: chronological,
+    });
+    const invertedStartIndex = invertedItems.findIndex((item) => item.id === "a2");
+    expect(
+      collectAssistantTurnContentForStreamRenderStrategy({
+        strategy: inverted,
+        items: invertedItems,
+        startIndex: invertedStartIndex,
+      })
+    ).toBe("assistant-1\n\nassistant-2");
+  });
+
+  it("returns undefined neighbor when index would be out of bounds", () => {
+    const forward = resolveStreamRenderStrategy({
+      platform: "web",
+      isMobileBreakpoint: false,
+    });
+    const items: StreamItem[] = [userMessage("u1", "user-1", 1)];
+
+    expect(
+      getStreamNeighborItem({
+        strategy: forward,
+        items,
+        index: 0,
+        relation: "above",
+      })
+    ).toBeUndefined();
+    expect(
+      getStreamNeighborItem({
+        strategy: forward,
+        items,
+        index: 0,
+        relation: "below",
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe("scroll/bottom calculations", () => {
+  it("computes near-bottom using forward_stream distance-from-bottom math", () => {
+    const strategy = resolveStreamRenderStrategy({
+      platform: "web",
+      isMobileBreakpoint: false,
+    });
+
+    expect(
+      isNearBottomForStreamRenderStrategy({
+        strategy,
+        offsetY: 680,
+        viewportHeight: 300,
+        contentHeight: 1000,
+        threshold: 24,
+      })
+    ).toBe(true);
+    expect(
+      isNearBottomForStreamRenderStrategy({
+        strategy,
+        offsetY: 600,
+        viewportHeight: 300,
+        contentHeight: 1000,
+        threshold: 24,
+      })
+    ).toBe(false);
+  });
+
+  it("computes near-bottom and scroll-to-bottom offset for inverted_stream", () => {
+    const strategy = resolveStreamRenderStrategy({
+      platform: "ios",
+      isMobileBreakpoint: false,
+    });
+
+    expect(
+      isNearBottomForStreamRenderStrategy({
+        strategy,
+        offsetY: 12,
+        viewportHeight: 300,
+        contentHeight: 1000,
+        threshold: 24,
+      })
+    ).toBe(true);
+    expect(
+      isNearBottomForStreamRenderStrategy({
+        strategy,
+        offsetY: 40,
+        viewportHeight: 300,
+        contentHeight: 1000,
+        threshold: 24,
+      })
+    ).toBe(false);
+    expect(
+      getBottomOffsetForStreamRenderStrategy({
+        strategy,
+        viewportHeight: 300,
+        contentHeight: 1000,
+      })
+    ).toBe(0);
+  });
+
+  it("maps scroll-to-bottom to max offset for forward_stream", () => {
+    const strategy = resolveStreamRenderStrategy({
+      platform: "web",
+      isMobileBreakpoint: false,
+    });
+
+    expect(
+      getBottomOffsetForStreamRenderStrategy({
+        strategy,
+        viewportHeight: 320,
+        contentHeight: 1000,
+      })
+    ).toBe(680);
+  });
+});
+
+describe("edge slot semantics", () => {
+  it("uses footer slot for forward_stream and header slot for inverted_stream", () => {
+    const EdgeSlot = () => null;
+    const forward = resolveStreamRenderStrategy({
+      platform: "web",
+      isMobileBreakpoint: false,
+    });
+    const inverted = resolveStreamRenderStrategy({
+      platform: "android",
+      isMobileBreakpoint: false,
+    });
+
+    const forwardProps = getStreamEdgeSlotProps({
+      strategy: forward,
+      component: EdgeSlot,
+      gapSize: 4,
+    });
+    const invertedProps = getStreamEdgeSlotProps({
+      strategy: inverted,
+      component: EdgeSlot,
+      gapSize: 4,
+    });
+
+    expect(forwardProps).toEqual({
+      ListFooterComponent: EdgeSlot,
+      ListFooterComponentStyle: { marginTop: 4 },
+    });
+    expect(invertedProps).toEqual({
+      ListHeaderComponent: EdgeSlot,
+      ListHeaderComponentStyle: { marginBottom: 4 },
+    });
+  });
+});

--- a/packages/app/src/components/agent-stream-render-strategy.ts
+++ b/packages/app/src/components/agent-stream-render-strategy.ts
@@ -1,0 +1,221 @@
+import type { ComponentType, ReactElement } from "react";
+import type { StyleProp, ViewStyle } from "react-native";
+import type { StreamItem } from "@/types/stream";
+
+type EdgeSlot = "header" | "footer";
+type NeighborRelation = "above" | "below";
+type AssistantTurnTraversalStep = -1 | 1;
+
+export type MaintainVisibleContentPositionConfig = Readonly<{
+  minIndexForVisible: number;
+  autoscrollToTopThreshold: number;
+}>;
+
+type StreamRenderStrategyBase = {
+  kind: "inverted_stream" | "forward_stream";
+  flatListInverted: boolean;
+  edgeSlot: EdgeSlot;
+  overlayScrollbarInverted: boolean;
+  maintainVisibleContentPosition?: MaintainVisibleContentPositionConfig;
+  assistantTurnTraversalStep: AssistantTurnTraversalStep;
+  disableParentScrollOnInlineDetailsExpansion: boolean;
+};
+
+export type InvertedStreamRenderStrategy = StreamRenderStrategyBase & {
+  kind: "inverted_stream";
+  flatListInverted: true;
+  edgeSlot: "header";
+  overlayScrollbarInverted: true;
+  maintainVisibleContentPosition: MaintainVisibleContentPositionConfig;
+  assistantTurnTraversalStep: 1;
+  disableParentScrollOnInlineDetailsExpansion: false;
+};
+
+export type ForwardStreamRenderStrategy = StreamRenderStrategyBase & {
+  kind: "forward_stream";
+  flatListInverted: false;
+  edgeSlot: "footer";
+  overlayScrollbarInverted: false;
+  maintainVisibleContentPosition?: undefined;
+  assistantTurnTraversalStep: -1;
+};
+
+export type StreamRenderStrategy =
+  | InvertedStreamRenderStrategy
+  | ForwardStreamRenderStrategy;
+
+export type ResolveStreamRenderStrategyInput = {
+  platform: string;
+  isMobileBreakpoint: boolean;
+};
+
+export type StreamViewportMetrics = {
+  contentHeight: number;
+  viewportHeight: number;
+};
+
+export type StreamNearBottomInput = StreamViewportMetrics & {
+  offsetY: number;
+  threshold: number;
+};
+
+export type StreamEdgeSlotProps = {
+  ListHeaderComponent?: ReactElement | ComponentType<any> | null;
+  ListHeaderComponentStyle?: StyleProp<ViewStyle>;
+  ListFooterComponent?: ReactElement | ComponentType<any> | null;
+  ListFooterComponentStyle?: StyleProp<ViewStyle>;
+};
+
+const DEFAULT_MAINTAIN_VISIBLE_CONTENT_POSITION: MaintainVisibleContentPositionConfig =
+  Object.freeze({
+    minIndexForVisible: 0,
+    autoscrollToTopThreshold: 0,
+  });
+
+const INVERTED_STREAM_STRATEGY: InvertedStreamRenderStrategy = {
+  kind: "inverted_stream",
+  flatListInverted: true,
+  edgeSlot: "header",
+  overlayScrollbarInverted: true,
+  maintainVisibleContentPosition: DEFAULT_MAINTAIN_VISIBLE_CONTENT_POSITION,
+  assistantTurnTraversalStep: 1,
+  disableParentScrollOnInlineDetailsExpansion: false,
+};
+
+const FORWARD_STREAM_STRATEGY_DESKTOP: ForwardStreamRenderStrategy = {
+  kind: "forward_stream",
+  flatListInverted: false,
+  edgeSlot: "footer",
+  overlayScrollbarInverted: false,
+  assistantTurnTraversalStep: -1,
+  disableParentScrollOnInlineDetailsExpansion: true,
+};
+
+const FORWARD_STREAM_STRATEGY_MOBILE: ForwardStreamRenderStrategy = {
+  ...FORWARD_STREAM_STRATEGY_DESKTOP,
+  disableParentScrollOnInlineDetailsExpansion: false,
+};
+
+export function resolveStreamRenderStrategy(
+  input: ResolveStreamRenderStrategyInput
+): StreamRenderStrategy {
+  if (input.platform === "web") {
+    return input.isMobileBreakpoint
+      ? FORWARD_STREAM_STRATEGY_MOBILE
+      : FORWARD_STREAM_STRATEGY_DESKTOP;
+  }
+  return INVERTED_STREAM_STRATEGY;
+}
+
+export function orderTailForStreamRenderStrategy(params: {
+  strategy: StreamRenderStrategy;
+  streamItems: StreamItem[];
+}): StreamItem[] {
+  const { strategy, streamItems } = params;
+  return strategy.kind === "inverted_stream"
+    ? [...streamItems].reverse()
+    : streamItems;
+}
+
+export function orderHeadForStreamRenderStrategy(params: {
+  strategy: StreamRenderStrategy;
+  streamHead: StreamItem[];
+}): StreamItem[] {
+  const { strategy, streamHead } = params;
+  return strategy.kind === "inverted_stream"
+    ? [...streamHead].reverse()
+    : streamHead;
+}
+
+export function getStreamNeighborIndex(params: {
+  strategy: StreamRenderStrategy;
+  index: number;
+  relation: NeighborRelation;
+}): number {
+  const { strategy, index, relation } = params;
+  if (strategy.kind === "inverted_stream") {
+    return relation === "above" ? index + 1 : index - 1;
+  }
+  return relation === "above" ? index - 1 : index + 1;
+}
+
+export function getStreamNeighborItem(params: {
+  strategy: StreamRenderStrategy;
+  items: StreamItem[];
+  index: number;
+  relation: NeighborRelation;
+}): StreamItem | undefined {
+  const nextIndex = getStreamNeighborIndex(params);
+  if (nextIndex < 0 || nextIndex >= params.items.length) {
+    return undefined;
+  }
+  return params.items[nextIndex];
+}
+
+export function collectAssistantTurnContentForStreamRenderStrategy(params: {
+  strategy: StreamRenderStrategy;
+  items: StreamItem[];
+  startIndex: number;
+}): string {
+  const { strategy, items, startIndex } = params;
+  const messages: string[] = [];
+
+  for (
+    let index = startIndex;
+    index >= 0 && index < items.length;
+    index += strategy.assistantTurnTraversalStep
+  ) {
+    const currentItem = items[index];
+    if (currentItem.kind === "user_message") {
+      break;
+    }
+    if (currentItem.kind === "assistant_message") {
+      messages.push(currentItem.text);
+    }
+  }
+
+  return messages.reverse().join("\n\n");
+}
+
+export function isNearBottomForStreamRenderStrategy(
+  params: StreamNearBottomInput & { strategy: StreamRenderStrategy }
+): boolean {
+  const { strategy, threshold, offsetY } = params;
+  if (strategy.kind === "inverted_stream") {
+    return offsetY <= threshold;
+  }
+
+  const distanceFromBottom = Math.max(
+    0,
+    params.contentHeight - (offsetY + params.viewportHeight)
+  );
+  return distanceFromBottom <= threshold;
+}
+
+export function getBottomOffsetForStreamRenderStrategy(params: StreamViewportMetrics & {
+  strategy: StreamRenderStrategy;
+}): number {
+  const { strategy } = params;
+  if (strategy.kind === "inverted_stream") {
+    return 0;
+  }
+  return Math.max(0, params.contentHeight - params.viewportHeight);
+}
+
+export function getStreamEdgeSlotProps(params: {
+  strategy: StreamRenderStrategy;
+  component: ReactElement | ComponentType<any> | null;
+  gapSize: number;
+}): StreamEdgeSlotProps {
+  const { strategy, component, gapSize } = params;
+  if (strategy.edgeSlot === "header") {
+    return {
+      ListHeaderComponent: component,
+      ListHeaderComponentStyle: { marginBottom: gapSize },
+    };
+  }
+  return {
+    ListFooterComponent: component,
+    ListFooterComponentStyle: { marginTop: gapSize },
+  };
+}


### PR DESCRIPTION
## Summary
This refactor replaces web usage of inverted `FlatList` behavior in `AgentStreamView` with a centralized stream render strategy, while keeping native behavior equivalent.

## Root Cause
- `AgentStreamView` used an inverted list path on web.
- RN Web's inverted `VirtualizedList` wheel handling path contributed to reverse-feeling boundary wheel behavior and aligned with progressive scroll/JS contention symptoms seen after repeated agent/thread switching.
- Orientation assumptions (ordering, neighbor indices, bottom math, edge-slot placement) were embedded directly in the component, making platform-specific behavior hard to isolate.

## Design
- Added `packages/app/src/components/agent-stream-render-strategy.ts`.
- Introduced a discriminated union strategy:
  - `inverted_stream` (native parity)
  - `forward_stream` (web, non-inverted)
- Added single resolver: `resolveStreamRenderStrategy({ platform, isMobileBreakpoint })`.
- Moved stream orientation decisions into strategy helpers:
  - tail/head ordering
  - neighbor semantics (`above` / `below`)
  - assistant-turn traversal for copy button
  - near-bottom detection and scroll-to-bottom offset
  - edge slot semantics (header vs footer)
  - overlay scrollbar inversion
  - `maintainVisibleContentPosition`
  - inline-detail parent-scroll disabling behavior
- Refactored `packages/app/src/components/agent-stream-view.tsx` to consume strategy helpers end-to-end, removing scattered orientation branching.

## Tests
Added deterministic tests in:
- `packages/app/src/components/agent-stream-render-strategy.test.ts`

Covered:
- resolver outputs (`forward_stream` on web, `inverted_stream` on native)
- ordering transforms for tail/head
- neighbor/index semantics and assistant-turn traversal
- near-bottom + bottom offset calculations
- edge-slot mapping semantics

## Verification
- `npm run typecheck --workspace=@getpaseo/app`
- `npm run test --workspace=@getpaseo/app -- src/components/agent-stream-render-strategy.test.ts`
- `npm run test --workspace=@getpaseo/app -- src/components/web-desktop-scrollbar.test.ts src/components/agent-stream-render-strategy.test.ts`

## Manual Test Notes (Web)
Started Expo web in tmux session `fix-stream-render-strategy`, window `2:expo-web`.

Command run:
- `cd packages/app && npm run web`

Runtime URL:
- `http://localhost:8085`

Backend target for validation:
- `localhost:6767`
