### PR TITLE
Fix auto-generated agent title/branch updates not surfacing

### DIFF
--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -859,7 +859,12 @@ export class AgentManager {
 
   async setTitle(agentId: string, title: string): Promise<void> {
     const agent = this.requireAgent(agentId);
-    await this.registry?.setTitle(agentId, title);
+    const normalizedTitle = title.trim();
+    if (!normalizedTitle) {
+      return;
+    }
+    this.touchUpdatedAt(agent);
+    await this.persistSnapshot(agent, { title: normalizedTitle });
     this.emitState(agent);
   }
 
@@ -878,6 +883,7 @@ export class AgentManager {
     if (!agent || agent.internal) {
       return;
     }
+    this.touchUpdatedAt(agent);
     this.emitState(agent);
   }
 

--- a/packages/server/src/server/agent/agent-metadata-generator.ts
+++ b/packages/server/src/server/agent/agent-metadata-generator.ts
@@ -237,6 +237,7 @@ export async function generateAndApplyAgentMetadata(
 
     try {
       await renameCurrentBranchImpl(options.cwd, normalizedBranch);
+      options.agentManager.notifyAgentState(options.agentId);
     } catch (error) {
       options.logger.warn(
         { err: error, agentId: options.agentId, branch: normalizedBranch },

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -228,6 +228,7 @@ export class AgentStorage {
     options?: { title?: string | null; internal?: boolean }
   ): Promise<void> {
     await this.load();
+    await this.waitForPendingWrite(agent.id);
     const existing = (await this.get(agent.id)) ?? null;
     const hasTitleOverride =
       options !== undefined && Object.prototype.hasOwnProperty.call(options, "title");
@@ -252,6 +253,7 @@ export class AgentStorage {
 
   async setTitle(agentId: string, title: string): Promise<void> {
     await this.load();
+    await this.waitForPendingWrite(agentId);
     const record = await this.get(agentId);
     if (!record) {
       throw new Error(`Agent ${agentId} not found`);
@@ -376,6 +378,12 @@ export class AgentStorage {
     }
 
     return null;
+  }
+
+  private async waitForPendingWrite(agentId: string): Promise<void> {
+    await (this.pendingWrites.get(agentId) ?? Promise.resolve()).catch(
+      () => undefined
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- fix a race where title writes could be overwritten by concurrent snapshot writes
- make title updates advance `updatedAt` and persist through one coherent snapshot path
- emit a post-rename state update (with fresh `updatedAt`) after metadata-driven branch rename
- add regressions for storage write ordering, setTitle timestamp behavior, and rename notification

## Root cause
Metadata generation was succeeding, but downstream state propagation could be dropped/staled:
1. `applySnapshot()` could read stale title while a previous write was still pending.
2. title/state notifications did not always produce a strictly newer `updatedAt`, so bootstrap freshness guards could ignore updates.
3. successful branch rename did not force a state refresh for subscribers.

## Validation
- `npm run test --workspace=@getpaseo/server -- src/server/agent/agent-storage.test.ts src/server/agent/agent-manager.test.ts src/server/agent/agent-metadata-generator.unit.test.ts`
- `npm run typecheck --workspace=@getpaseo/server`
