### PR TITLE
build: universal macOS binary (Apple Silicon + Intel)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Install JS dependencies
         run: npm ci
@@ -110,4 +110,4 @@ jobs:
           releaseBody: See the assets to download and install this version.
           releaseDraft: false
           prerelease: false
-          args: --target aarch64-apple-darwin
+          args: --target universal-apple-darwin


### PR DESCRIPTION
## Summary

- Adds `x86_64-apple-darwin` Rust target alongside the existing `aarch64-apple-darwin`
- Switches Tauri build to `--target universal-apple-darwin`, producing a single DMG that runs natively on both Apple Silicon and Intel Macs

## Why

A universal binary simplifies distribution: one DMG for all Mac users, and makes it straightforward to publish a Homebrew cask without arch-branching logic.

## Test plan

- [ ] Trigger the `Desktop Release` workflow on a tag and verify the release assets include a universal DMG
- [ ] Confirm the DMG runs on both Apple Silicon and Intel Macs