### PR TITLE
fix(test): add missing getRuntimeMetrics mock to MockSession

### DIFF
--- a/packages/server/src/server/websocket-server.relay-reconnect.test.ts
+++ b/packages/server/src/server/websocket-server.relay-reconnect.test.ts
@@ -37,6 +37,15 @@ const sessionMock = vi.hoisted(() => {
     handleMessage = vi.fn(async () => {});
     handleBinaryFrame = vi.fn((_frame: unknown) => {});
     getClientActivity = vi.fn(() => null);
+    getRuntimeMetrics = vi.fn(() => ({
+      checkoutDiffTargetCount: 0,
+      checkoutDiffSubscriptionCount: 0,
+      checkoutDiffWatcherCount: 0,
+      checkoutDiffFallbackRefreshTargetCount: 0,
+      terminalDirectorySubscriptionCount: 0,
+      terminalSubscriptionCount: 0,
+      terminalStreamCount: 0,
+    }));
     readonly args: Record<string, unknown>;
 
     constructor(args: Record<string, unknown>) {


### PR DESCRIPTION
The production code calls `connection.session.getRuntimeMetrics()` when closing the WebSocket server, but `MockSession` in the relay-reconnect tests didn't implement this method, causing all `close()` calls in those tests to throw:

```
TypeError: connection.session.getRuntimeMetrics is not a function
```

This adds the missing mock returning zero values for all metrics fields.

The other two CI failures (`claude-agent.interrupt-restart-regression` and `claude-agent.redesign`) are integration tests that require the Claude CLI to be installed in the CI environment — separate issue.