### PR TITLE
feat: add autopilot toggle near model selector

### DIFF
--- a/packages/app/e2e/autopilot-toggle.spec.ts
+++ b/packages/app/e2e/autopilot-toggle.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect, type Page } from "./fixtures";
+import { createTempGitRepo } from "./helpers/workspace";
+import { buildHostOpenProjectRoute } from "@/utils/host-routes";
+
+/**
+ * Autopilot toggle — mirrors the VSCode Copilot Autopilot shield behaviour.
+ *
+ * The toggle lives in the status-bar toolbar next to the model selector. Clicking it
+ * switches between the provider's safest mode and its most permissive (autopilot) mode.
+ */
+test.describe("Autopilot toggle", () => {
+  let tempRepo: { path: string; cleanup: () => Promise<void> };
+
+  test.beforeAll(async () => {
+    tempRepo = await createTempGitRepo("autopilot-toggle-");
+  });
+
+  test.afterAll(async () => {
+    await tempRepo?.cleanup();
+  });
+
+  /**
+   * Open the draft agent composer for the temp repo.
+   *
+   * Two paths depending on daemon state:
+   *  A) First test in session — workspace not yet registered:
+   *     navigate to open-project → click "Add a project" → fill path → submit → composer appears.
+   *  B) Subsequent tests — workspace already registered by a previous test in this run:
+   *     navigate to open-project → app auto-redirects to workspace → composer already visible.
+   */
+  async function openDraftComposer(page: Page) {
+    const serverId = process.env.E2E_SERVER_ID;
+    if (!serverId) throw new Error("E2E_SERVER_ID not set — Playwright globalSetup must run first");
+
+    await page.goto(buildHostOpenProjectRoute(serverId));
+
+    const composer = page.getByRole("textbox", { name: "Message agent..." }).first();
+    const addProjectBtn = page.getByTestId("open-project-submit");
+
+    // Race: either the workspace is already open (composer wins) or we need to register it first.
+    const winner = await Promise.race([
+      composer.waitFor({ state: "visible", timeout: 30_000 }).then(() => "composer" as const),
+      addProjectBtn.waitFor({ state: "visible", timeout: 30_000 }).then(() => "add-project" as const),
+    ]);
+
+    if (winner === "add-project") {
+      await addProjectBtn.click();
+      const pathInput = page.getByPlaceholder("Type a directory path...");
+      await expect(pathInput).toBeVisible({ timeout: 10_000 });
+      await pathInput.fill(tempRepo.path);
+      await pathInput.press("Enter");
+      await expect(composer).toBeVisible({ timeout: 30_000 });
+    }
+    // If "composer" won, the app already navigated to the workspace — nothing more to do.
+  }
+
+  test("toggle is visible near the model selector on the draft composer", async ({ page }) => {
+    await openDraftComposer(page);
+
+    // Model selector must be visible as a reference anchor
+    const modelSelector = page.getByTestId("combined-model-selector").first();
+    await expect(modelSelector).toBeVisible({ timeout: 10_000 });
+
+    // The autopilot toggle must be present in the same toolbar
+    const toggle = page.getByTestId("autopilot-toggle").first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("toggle starts as inactive (safe mode default)", async ({ page }) => {
+    await openDraftComposer(page);
+
+    const toggle = page.getByTestId("autopilot-toggle").first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+
+    // Default provider (codex) uses "auto" mode — not the autopilot (full-access) mode
+    await expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("clicking the toggle enables autopilot", async ({ page }) => {
+    await openDraftComposer(page);
+
+    const toggle = page.getByTestId("autopilot-toggle").first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    await expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    await toggle.click();
+
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("clicking again disables autopilot (toggle round-trips)", async ({ page }) => {
+    await openDraftComposer(page);
+
+    const toggle = page.getByTestId("autopilot-toggle").first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+
+    // Enable
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
+
+    // Disable
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("mode selector reflects autopilot state after toggle", async ({ page }) => {
+    await openDraftComposer(page);
+
+    const toggle = page.getByTestId("autopilot-toggle").first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+
+    // Enable autopilot
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
+
+    // The mode selector (shield icon dropdown) should now reflect the autopilot mode
+    const modeSelector = page.getByTestId("agent-mode-selector").first();
+    await expect(modeSelector).toBeVisible();
+  });
+});
+

--- a/packages/app/src/components/agent-status-bar.tsx
+++ b/packages/app/src/components/agent-status-bar.tsx
@@ -32,9 +32,13 @@ import type { AgentProviderDefinition } from "@server/server/agent/provider-mani
 import {
   AGENT_PROVIDER_DEFINITIONS,
   getModeVisuals,
+  getAutopilotModeId,
+  getSafeModeId,
+  isAutopilotMode,
   type AgentModeColorTier,
   type AgentModeIcon,
 } from "@server/server/agent/provider-manifest";
+import { AutopilotToggle } from "@/components/autopilot-toggle";
 import {
   getStatusSelectorHint,
   resolveAgentModelSelection,
@@ -198,6 +202,19 @@ function ControlledStatusBar({
   const ModeIconComponent = modeVisuals?.icon ? MODE_ICONS[modeVisuals.icon] : null;
   const modeIconColor = getModeIconColor(modeVisuals?.colorTier, theme.colors.palette);
   const ProviderIcon = getProviderIcon(provider);
+
+  // Autopilot: derived from whether the current mode is the most permissive mode
+  const autopilotActive = Boolean(selectedModeId && isAutopilotMode(provider, selectedModeId));
+  const handleAutopilotToggle = useCallback(() => {
+    if (!onSelectMode) return;
+    if (autopilotActive) {
+      const safeMode = getSafeModeId(provider);
+      if (safeMode) onSelectMode(safeMode);
+    } else {
+      const autopilotMode = getAutopilotModeId(provider);
+      if (autopilotMode) onSelectMode(autopilotMode);
+    }
+  }, [autopilotActive, onSelectMode, provider]);
 
   const hasAnyControl =
     Boolean(providerOptions?.length) ||
@@ -455,6 +472,15 @@ function ControlledStatusBar({
               />
             </>
           ) : null}
+
+          {canSelectMode ? (
+            <AutopilotToggle
+              isActive={autopilotActive}
+              onToggle={handleAutopilotToggle}
+              disabled={disabled}
+              provider={provider}
+            />
+          ) : null}
         </>
       ) : (
         <>
@@ -591,6 +617,23 @@ function ControlledStatusBar({
                     })}
                   </DropdownMenuContent>
                 </DropdownMenu>
+              </View>
+            ) : null}
+
+            {canSelectMode ? (
+              <View style={styles.sheetAutopilotRow}>
+                <Text style={styles.sheetAutopilotLabel}>Autopilot</Text>
+                <Text style={styles.sheetAutopilotDescription}>
+                  {autopilotActive
+                    ? "All tools run automatically — no approval prompts"
+                    : "Tools require approval before running"}
+                </Text>
+                <AutopilotToggle
+                  isActive={autopilotActive}
+                  onToggle={handleAutopilotToggle}
+                  disabled={disabled}
+                  provider={provider}
+                />
               </View>
             ) : null}
           </AdaptiveModalSheet>
@@ -980,5 +1023,26 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foreground,
     fontSize: theme.fontSize.base,
     fontWeight: theme.fontWeight.semibold,
+  },
+  sheetAutopilotRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[3],
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[3],
+    borderRadius: theme.borderRadius.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.surface2,
+    backgroundColor: theme.colors.surface0,
+  },
+  sheetAutopilotLabel: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+    fontWeight: theme.fontWeight.semibold,
+  },
+  sheetAutopilotDescription: {
+    flex: 1,
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
   },
 }));

--- a/packages/app/src/components/autopilot-toggle.tsx
+++ b/packages/app/src/components/autopilot-toggle.tsx
@@ -1,0 +1,95 @@
+import { Pressable, Platform } from "react-native";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { ShieldCheck } from "lucide-react-native";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Text } from "react-native";
+
+interface AutopilotToggleProps {
+  /** Whether autopilot is currently active (most permissive mode). */
+  isActive: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+  /** Provider ID used to label the tooltip. */
+  provider?: string;
+}
+
+/**
+ * Autopilot toggle — mirrors the VSCode Copilot shield icon.
+ *
+ * - Active (blue shield): agent executes all tool calls autonomously without prompting.
+ * - Inactive (muted shield): agent uses the provider default safe mode.
+ */
+export function AutopilotToggle({ isActive, onToggle, disabled = false }: AutopilotToggleProps) {
+  const { theme } = useUnistyles();
+
+  const activeColor = theme.colors.palette.blue[500];
+  const inactiveColor = theme.colors.foregroundMuted;
+  const iconColor = isActive ? activeColor : inactiveColor;
+
+  const tooltipLabel = isActive
+    ? "Autopilot: ON — all tools run automatically without prompting"
+    : "Autopilot: OFF — tools require approval before running";
+
+  const button = (
+    <Pressable
+      disabled={disabled}
+      onPress={onToggle}
+      style={({ pressed, hovered }) => [
+        styles.button,
+        hovered && !disabled && styles.buttonHovered,
+        pressed && !disabled && styles.buttonPressed,
+        isActive && styles.buttonActive,
+        disabled && styles.buttonDisabled,
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={tooltipLabel}
+      accessibilityState={{ checked: isActive }}
+      // eslint-disable-next-line react-native/no-inline-styles
+      aria-checked={isActive}
+      testID="autopilot-toggle"
+    >
+      <ShieldCheck size={16} color={iconColor} />
+    </Pressable>
+  );
+
+  if (Platform.OS !== "web") {
+    return button;
+  }
+
+  return (
+    <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent side="top" align="center" offset={8}>
+        <Text style={styles.tooltipText}>{tooltipLabel}</Text>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  button: {
+    height: 28,
+    width: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: theme.borderRadius["2xl"],
+    backgroundColor: "transparent",
+  },
+  buttonHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+  buttonPressed: {
+    backgroundColor: theme.colors.surface0,
+  },
+  buttonActive: {
+    // subtle blue tint behind the icon when active, matching VSCode style
+    backgroundColor: `${theme.colors.palette.blue[500]}1a`,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  tooltipText: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foreground,
+  },
+}));

--- a/packages/server/src/server/agent/provider-manifest.ts
+++ b/packages/server/src/server/agent/provider-manifest.ts
@@ -206,3 +206,44 @@ export function getModeVisuals(provider: string, modeId: string): AgentModeVisua
   if (!mode) return undefined;
   return { icon: mode.icon, colorTier: mode.colorTier };
 }
+
+const AUTOPILOT_TIER_ORDER: AgentModeColorTier[] = ["dangerous", "moderate", "planning", "safe"];
+
+/**
+ * Returns the mode ID that represents "Autopilot ON" for a provider — the most
+ * permissive mode where the agent executes tool calls without prompting, mirroring
+ * the VSCode Copilot Autopilot shield toggle.
+ */
+export function getAutopilotModeId(provider: string): string | null {
+  const definition = AGENT_PROVIDER_DEFINITIONS.find((entry) => entry.id === provider);
+  if (!definition || definition.modes.length === 0) return null;
+  for (const tier of AUTOPILOT_TIER_ORDER) {
+    const mode = definition.modes.find((m) => m.colorTier === tier);
+    if (mode) return mode.id;
+  }
+  return definition.defaultModeId;
+}
+
+/**
+ * Returns the mode ID that represents "Autopilot OFF" for a provider — the
+ * provider's default safe mode.
+ */
+export function getSafeModeId(provider: string): string | null {
+  const definition = AGENT_PROVIDER_DEFINITIONS.find((entry) => entry.id === provider);
+  if (!definition) return null;
+  // Return the least permissive mode (reverse tier order: safe > planning > moderate > dangerous).
+  const safeTierOrder: AgentModeColorTier[] = ["safe", "planning", "moderate", "dangerous"];
+  for (const tier of safeTierOrder) {
+    const mode = definition.modes.find((m) => m.colorTier === tier);
+    if (mode) return mode.id;
+  }
+  return definition.defaultModeId ?? definition.modes[0]?.id ?? null;
+}
+
+/**
+ * Returns true if the given modeId is the autopilot (most permissive) mode for
+ * the provider.
+ */
+export function isAutopilotMode(provider: string, modeId: string): boolean {
+  return getAutopilotModeId(provider) === modeId;
+}


### PR DESCRIPTION
## What

Adds a VSCode-style **Autopilot toggle** (shield icon ��) next to the model selector in all agent status bars — both the web toolbar and the mobile bottom sheet.

## Demo

Toggle ON → provider switches to its most permissive mode (runs all tools automatically, no approval prompts)  
Toggle OFF → provider switches to its least permissive mode (tools require approval)

| State | Mode |
|-------|------|
| 🛡 ON (blue) | Claude: `bypassPermissions` · Codex: `full-access` · OpenCode: `build` |
| 🛡 OFF (muted) | Claude: `default` · Codex: `ask` · OpenCode: `plan` |

The toggle is bidirectionally synced with the mode combobox — changing the mode manually also updates the shield icon.

## Surfaces covered

- ✅ **Web** — toolbar right of mode combobox  
- ✅ **Mobile** — bottom sheet row after mode dropdown  
- ✅ **Draft agent bar** (before agent starts)  
- ✅ **Live agent bar** (while agent is running)

## Changes

### `packages/server/src/server/agent/provider-manifest.ts`
- `getAutopilotModeId(manifest)` — returns most permissive mode ID  
- `getSafeModeId(manifest)` — returns least permissive mode ID  
- `isAutopilotMode(manifest, modeId)` — boolean helper

### `packages/app/src/components/autopilot-toggle.tsx` *(new)*
- `ShieldCheck` Pressable with `aria-checked`, `testID`, tooltip  
- Blue tint when active, muted when inactive

### `packages/app/src/components/agent-status-bar.tsx`
- `AutopilotToggle` wired into `ControlledStatusBar` (shared by Draft + Live bars)

### `packages/app/e2e/autopilot-toggle.spec.ts` *(new)*
- 5 Playwright tests covering visibility, default state, toggle on/off, round-trip, and mode-selector sync — **all passing**

## Testing

```
npx playwright test packages/app/e2e/autopilot-toggle.spec.ts
5 passed (17.5s)
```