### PR TITLE
fix(server): serve workspace list instantly on fetch, reconcile in background

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -5402,7 +5402,6 @@ export class Session {
   }
 
   private async listWorkspaceDescriptors(): Promise<WorkspaceDescriptorPayload[]> {
-    await this.reconcileActiveWorkspaceRecords();
     return this.listWorkspaceDescriptorsSnapshot();
   }
 
@@ -5732,6 +5731,31 @@ export class Session {
     }
   }
 
+  private async reconcileAndEmitWorkspaceUpdates(): Promise<void> {
+    const subscription = this.workspaceUpdatesSubscription;
+    if (!subscription) {
+      return;
+    }
+    try {
+      const changedWorkspaceIds = await this.reconcileActiveWorkspaceRecords();
+      if (changedWorkspaceIds.size === 0) {
+        return;
+      }
+      const all = await this.listWorkspaceDescriptorsSnapshot();
+      const descriptorsByWorkspaceId = new Map(all.map((entry) => [entry.id, entry] as const));
+      for (const workspaceId of changedWorkspaceIds) {
+        const workspace = descriptorsByWorkspaceId.get(workspaceId) ?? null;
+        if (workspace && this.matchesWorkspaceFilter({ workspace, filter: subscription.filter })) {
+          this.bufferOrEmitWorkspaceUpdate(subscription, { kind: "upsert", workspace });
+        } else {
+          this.bufferOrEmitWorkspaceUpdate(subscription, { kind: "remove", id: workspaceId });
+        }
+      }
+    } catch (error) {
+      this.sessionLogger.error({ err: error }, "Background workspace reconciliation failed");
+    }
+  }
+
   private async emitWorkspaceUpdateForCwd(
     cwd: string,
     options?: { dedupeGitState?: boolean },
@@ -5932,6 +5956,7 @@ export class Session {
 
       if (subscriptionId && this.workspaceUpdatesSubscription?.subscriptionId === subscriptionId) {
         this.flushBootstrappedWorkspaceUpdates({ snapshotLatestActivityByWorkspaceId });
+        void this.reconcileAndEmitWorkspaceUpdates();
       }
     } catch (error) {
       if (subscriptionId && this.workspaceUpdatesSubscription?.subscriptionId === subscriptionId) {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -5297,6 +5297,26 @@ export class Session {
   ): Promise<WorkspaceDescriptorPayload> {
     const resolvedProjectRecord =
       projectRecord ?? (await this.projectRegistry.get(workspace.projectId));
+
+    return {
+      id: workspace.workspaceId,
+      projectId: workspace.projectId,
+      projectDisplayName: resolvedProjectRecord?.displayName ?? workspace.projectId,
+      projectRootPath: resolvedProjectRecord?.rootPath ?? workspace.cwd,
+      projectKind: resolvedProjectRecord?.kind ?? "non_git",
+      workspaceKind: workspace.kind,
+      name: workspace.displayName,
+      status: "done",
+      activityAt: null,
+      diffStat: null,
+    };
+  }
+
+  private async describeWorkspaceRecordWithGitData(
+    workspace: PersistedWorkspaceRecord,
+    projectRecord?: PersistedProjectRecord | null,
+  ): Promise<WorkspaceDescriptorPayload> {
+    const base = await this.describeWorkspaceRecord(workspace, projectRecord);
     let displayName = workspace.displayName;
     try {
       const placement = await this.buildProjectPlacement(workspace.cwd);
@@ -5315,18 +5335,7 @@ export class Session {
       // Non-critical — leave null on failure.
     }
 
-    return {
-      id: workspace.workspaceId,
-      projectId: workspace.projectId,
-      projectDisplayName: resolvedProjectRecord?.displayName ?? workspace.projectId,
-      projectRootPath: resolvedProjectRecord?.rootPath ?? workspace.cwd,
-      projectKind: resolvedProjectRecord?.kind ?? "non_git",
-      workspaceKind: workspace.kind,
-      name: displayName,
-      status: "done",
-      activityAt: null,
-      diffStat,
-    };
+    return { ...base, name: displayName, diffStat };
   }
 
   private async listWorkspaceDescriptorsSnapshot(): Promise<WorkspaceDescriptorPayload[]> {
@@ -5983,7 +5992,7 @@ export class Session {
     try {
       const workspace = await this.ensureWorkspaceRegistered(request.cwd);
       await this.emitWorkspaceUpdateForCwd(workspace.cwd);
-      const descriptor = await this.describeWorkspaceRecord(workspace);
+      const descriptor = await this.describeWorkspaceRecordWithGitData(workspace);
       this.emit({
         type: "open_project_response",
         payload: {
@@ -6012,7 +6021,7 @@ export class Session {
     return handleCreateWorktreeRequest(
       {
         paseoHome: this.paseoHome,
-        describeWorkspaceRecord: (workspace) => this.describeWorkspaceRecord(workspace),
+        describeWorkspaceRecord: (workspace) => this.describeWorkspaceRecordWithGitData(workspace),
         emit: (message) => this.emit(message),
         registerPendingWorktreeWorkspace: (options) =>
           this.registerPendingWorktreeWorkspace(options),


### PR DESCRIPTION
`fetch_workspaces_request` blocked on `reconcileActiveWorkspaceRecords()` before responding. This runs `getCheckoutStatusLite` (git operations) on every active workspace, so with 10+ workspaces the projects list appears empty for several seconds after every daemon restart or reconnect.

To fix this issue, return the registry snapshot immediately, then run reconciliation in the background. When reconciliation finds changed workspaces (stale worktrees being archived, git metadata updates), it pushes `workspace_update` events through the existing subscription so the client updates live.

```
fetch_workspaces_request arrives
  → respond immediately with registry snapshot  ← projects appear instantly
  → background: reconcileActiveWorkspaceRecords()
  → push workspace_update for any changed workspaces
```

Fixes #203