### PR TITLE
fix(server): bypass Copilot ACP prompts in autopilot

### DIFF
--- a/lessons.md
+++ b/lessons.md
@@ -1,7 +1,0 @@
-# Lessons
-
-## 2026-04-06
-
-- Match the source checkout to the installed desktop release before verifying daemon behavior. The installed app was `0.1.48`, and using a `0.1.43` daemon caused protocol drift during runtime checks.
-- For Copilot ACP autopilot permission issues, the narrow fix point is `ACPAgentSession.requestPermission()`. Bypassing the emitted `permission_requested` event there keeps the change provider-specific and low risk.
-- In this release line, run `npm run build --workspace=@getpaseo/highlight` before repo-wide `npm run typecheck` if the workspace has not been built yet, otherwise downstream packages may fail to resolve `@getpaseo/highlight` types.

--- a/lessons.md
+++ b/lessons.md
@@ -1,0 +1,7 @@
+# Lessons
+
+## 2026-04-06
+
+- Match the source checkout to the installed desktop release before verifying daemon behavior. The installed app was `0.1.48`, and using a `0.1.43` daemon caused protocol drift during runtime checks.
+- For Copilot ACP autopilot permission issues, the narrow fix point is `ACPAgentSession.requestPermission()`. Bypassing the emitted `permission_requested` event there keeps the change provider-specific and low risk.
+- In this release line, run `npm run build --workspace=@getpaseo/highlight` before repo-wide `npm run typecheck` if the workspace has not been built yet, otherwise downstream packages may fail to resolve `@getpaseo/highlight` types.

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -747,4 +747,55 @@ describe("ACPAgentSession", () => {
     });
     expect((session as any).activeForegroundTurnId).toBeNull();
   });
+
+  test("auto-approves Copilot ACP permissions in autopilot mode without emitting prompt events", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "copilot",
+        cwd: "/tmp/paseo-acp-test",
+        modeId: "https://agentclientprotocol.com/protocol/session-modes#autopilot",
+      },
+      {
+        provider: "copilot",
+        logger: createTestLogger(),
+        defaultCommand: ["copilot", "--acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+      },
+    );
+
+    const events: Array<{ type: string }> = [];
+    session.subscribe((event) => {
+      events.push(event as { type: string });
+    });
+
+    const response = await session.requestPermission({
+      toolCall: {
+        toolCallId: "tool-1",
+        title: "Edit file",
+        kind: "edit",
+        status: "pending",
+      } as any,
+      options: [
+        { optionId: "allow-once", name: "Allow Once", kind: "allow_once" },
+        { optionId: "reject-once", name: "Reject Once", kind: "reject_once" },
+      ],
+    } as any);
+
+    expect(response).toEqual({
+      outcome: {
+        outcome: "selected",
+        optionId: "allow-once",
+      },
+    });
+    expect(session.getPendingPermissions()).toEqual([]);
+    expect(events.find((event) => event.type === "permission_requested")).toBeUndefined();
+  });
 });

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -107,6 +107,9 @@ const ACP_CLIENT_CAPABILITIES: ACPClientCapabilities = {
   terminal: true,
 };
 
+const COPILOT_AUTOPILOT_MODE =
+  "https://agentclientprotocol.com/protocol/session-modes#autopilot";
+
 type ACPAgentClientOptions = {
   provider: string;
   logger: Logger;
@@ -1084,6 +1087,18 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   async requestPermission(
     params: RequestPermissionRequest,
   ): Promise<RequestPermissionResponse> {
+    if (shouldAutoApprovePermissionRequest(this.provider, this.currentMode)) {
+      const selectedOption = selectPermissionOption(params.options, { behavior: "allow" });
+      return selectedOption
+        ? {
+            outcome: {
+              outcome: "selected",
+              optionId: selectedOption.optionId,
+            },
+          }
+        : { outcome: { outcome: "cancelled" } };
+    }
+
     const requestId = randomUUID();
     let toolSnapshot =
       this.toolCalls.get(params.toolCall.toolCallId) ??
@@ -1937,6 +1952,10 @@ function mapPermissionRequest(
       options: params.options,
     },
   };
+}
+
+function shouldAutoApprovePermissionRequest(provider: string, currentMode: string | null): boolean {
+  return provider === "copilot" && currentMode === COPILOT_AUTOPILOT_MODE;
 }
 
 function selectPermissionOption(


### PR DESCRIPTION
## Summary
- bypass ACP permission prompts when the provider is Copilot and the active session mode is Autopilot
- keep the change narrowly scoped to `ACPAgentSession.requestPermission()` so other providers and modes retain their existing permission flow
- add a regression test covering Copilot ACP autopilot permission handling and document the release-matching verification lesson

## Rationale
Copilot ACP Autopilot is expected to run without user interaction, but Paseo was still surfacing ACP permission callbacks as UI permission requests. That made Autopilot behave like a prompting mode instead of a fully autonomous one.

This change treats Copilot ACP Autopilot as an allow path at the ACP adapter boundary by selecting an allow option immediately instead of emitting a `permission_requested` event.

## Verification
- added a regression test that asserts Copilot ACP Autopilot auto-approves a permission request and does not emit `permission_requested`
- ran `npm exec vitest run packages/server/src/server/agent/providers/acp-agent.test.ts`
- ran `npm run typecheck`
- built the daemon with `npm run build:daemon`