### PR TITLE
fix(server): ensure final assistant answer renders immediately in existing threads

### DIFF
--- a/packages/app/src/types/stream-event.test.ts
+++ b/packages/app/src/types/stream-event.test.ts
@@ -131,6 +131,37 @@ describe("applyStreamEvent", () => {
     expect(result.tail[0].kind).toBe("assistant_message");
   });
 
+  it("replaces stale tail content with finalized head content on turn completion", () => {
+    const result = applyStreamEvent({
+      tail: [
+        {
+          kind: "assistant_message",
+          id: "assistant-shared",
+          text: "Hello",
+          timestamp: new Date(0),
+        },
+      ],
+      head: [
+        {
+          kind: "assistant_message",
+          id: "assistant-shared",
+          text: "Hello world",
+          timestamp: new Date(1),
+        },
+      ],
+      event: completionEvent(),
+      timestamp: baseTimestamp,
+    });
+
+    expect(result.head).toHaveLength(0);
+    expect(result.tail).toHaveLength(1);
+    expect(result.tail[0]).toMatchObject({
+      kind: "assistant_message",
+      id: "assistant-shared",
+      text: "Hello world",
+    });
+  });
+
   it("flushes reasoning when assistant message starts", () => {
     let result = applyStreamEvent({
       tail: [],

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -735,14 +735,30 @@ function flushHeadToTail(tail: StreamItem[], head: StreamItem[]): StreamItem[] {
   }
 
   const finalized = finalizeHeadItems(head);
-  const tailIds = new Set(tail.map((item) => item.id));
-  const newItems = finalized.filter((item) => !tailIds.has(item.id));
+  const tailIndexById = new Map(tail.map((item, index) => [item.id, index]));
+  let nextTail = tail;
 
-  if (newItems.length === 0) {
-    return tail;
+  for (const item of finalized) {
+    const existingIndex = tailIndexById.get(item.id);
+    if (existingIndex === undefined) {
+      if (nextTail === tail) {
+        nextTail = [...tail];
+      }
+      nextTail.push(item);
+      tailIndexById.set(item.id, nextTail.length - 1);
+      continue;
+    }
+
+    const existing = nextTail[existingIndex];
+    if (existing !== item) {
+      if (nextTail === tail) {
+        nextTail = [...tail];
+      }
+      nextTail[existingIndex] = item;
+    }
   }
 
-  return [...tail, ...newItems];
+  return nextTail;
 }
 
 /**

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -346,14 +346,19 @@ describe("Codex app-server provider", () => {
     });
   });
 
-  test("emits buffered assistant text before task_complete closes the turn", () => {
+  test("emits all buffered assistant text before task_complete closes the turn", () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];
     session.subscribe((event) => events.push(event));
 
     ;(session as any).handleNotification("item/agentMessage/delta", {
-      itemId: "msg-late-final",
-      delta: "COMPLEX_REPRO_OK",
+      itemId: "msg-late-final-1",
+      delta: "FIRST_BUFFERED_MESSAGE",
+    });
+
+    ;(session as any).handleNotification("item/agentMessage/delta", {
+      itemId: "msg-late-final-2",
+      delta: "SECOND_BUFFERED_MESSAGE",
     });
 
     ;(session as any).handleNotification("codex/event/task_complete", {
@@ -367,7 +372,16 @@ describe("Codex app-server provider", () => {
         turnId: "test-turn",
         item: {
           type: "assistant_message",
-          text: "COMPLEX_REPRO_OK",
+          text: "FIRST_BUFFERED_MESSAGE",
+        },
+      },
+      {
+        type: "timeline",
+        provider: "codex",
+        turnId: "test-turn",
+        item: {
+          type: "assistant_message",
+          text: "SECOND_BUFFERED_MESSAGE",
         },
       },
       {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -345,4 +345,37 @@ describe("Codex app-server provider", () => {
       },
     });
   });
+
+  test("emits buffered assistant text before task_complete closes the turn", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    ;(session as any).handleNotification("item/agentMessage/delta", {
+      itemId: "msg-late-final",
+      delta: "COMPLEX_REPRO_OK",
+    });
+
+    ;(session as any).handleNotification("codex/event/task_complete", {
+      msg: { type: "task_complete" },
+    });
+
+    expect(events).toEqual([
+      {
+        type: "timeline",
+        provider: "codex",
+        turnId: "test-turn",
+        item: {
+          type: "assistant_message",
+          text: "COMPLEX_REPRO_OK",
+        },
+      },
+      {
+        type: "turn_completed",
+        provider: "codex",
+        turnId: "test-turn",
+        usage: undefined,
+      },
+    ]);
+  });
 });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3175,7 +3175,10 @@ class CodexAppServerAgentSession implements AgentSession {
   }
 
   private emitBufferedAssistantMessages(): void {
-    for (const [itemId, text] of this.pendingAgentMessages.entries()) {
+    const bufferedMessages = [...this.pendingAgentMessages.entries()];
+    this.pendingAgentMessages.clear();
+
+    for (const [itemId, text] of bufferedMessages) {
       if (!text) {
         continue;
       }
@@ -3186,7 +3189,6 @@ class CodexAppServerAgentSession implements AgentSession {
       });
       this.emittedItemCompletedIds.add(itemId);
     }
-    this.pendingAgentMessages.clear();
   }
 
   private createTurnId(): string {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3174,6 +3174,21 @@ class CodexAppServerAgentSession implements AgentSession {
     }
   }
 
+  private emitBufferedAssistantMessages(): void {
+    for (const [itemId, text] of this.pendingAgentMessages.entries()) {
+      if (!text) {
+        continue;
+      }
+      this.emitEvent({
+        type: "timeline",
+        provider: CODEX_PROVIDER,
+        item: { type: "assistant_message", text },
+      });
+      this.emittedItemCompletedIds.add(itemId);
+    }
+    this.pendingAgentMessages.clear();
+  }
+
   private createTurnId(): string {
     return `codex-turn-${this.nextTurnOrdinal++}`;
   }
@@ -3205,6 +3220,9 @@ class CodexAppServerAgentSession implements AgentSession {
     }
 
     if (parsed.kind === "turn_completed") {
+      if (parsed.status === "completed" && this.pendingAgentMessages.size > 0) {
+        this.emitBufferedAssistantMessages();
+      }
       if (parsed.status === "failed") {
         this.emitEvent({
           type: "turn_failed",


### PR DESCRIPTION
## Problem

When opening an existing thread and immediately asking a follow-up, the final assistant answer sometimes never appears — the turn completes but the last message is missing or shows partial/stale content.

Two coordinated bugs cause this:

**Bug 1 — Server drops buffered messages on turn completion**

In `codex-app-server-agent.ts`, `item/agentMessage/delta` events are collected into `pendingAgentMessages` and emitted lazily. But the `turn_completed` handler emits the `turn_completed` event without first flushing pending messages when status is `"completed"`. The client sees the turn close and never receives the final assistant text.

**Bug 2 — Client replaces streamed content with a stale tail**

In `stream.ts`, `flushHeadToTail()` builds an append-only set of tail IDs. When the finalized head arrives, items with matching IDs are not replaced — they're just skipped. The UI ends up showing the partially-streamed tail content even after the head delivers the full final text.

## Fix

**Server** (`codex-app-server-agent.ts`):
- Added `emitBufferedAssistantMessages()` private method that flushes `pendingAgentMessages` as `timeline/assistant_message` events
- Called before `turn_completed` emission whenever `status === "completed"` and the map is non-empty

**Client** (`stream.ts`):
- Replaced `flushHeadToTail()` internals with a `Map<id, index>` lookup
- When a finalized head item ID matches an existing tail entry, the tail entry is replaced in-place rather than appended

## Tests

Two regression tests added — one per bug:
- `codex-app-server-agent.test.ts`: "emits buffered assistant text before task_complete closes the turn"
- `stream-event.test.ts`: "replaces stale tail content with finalized head content on turn completion"

All existing tests continue to pass (9/9 server, 7/7 stream).