### PR TITLE
feat: branch switching with stash-and-switch

### DIFF
--- a/packages/app/src/components/branch-switcher.tsx
+++ b/packages/app/src/components/branch-switcher.tsx
@@ -1,0 +1,125 @@
+import { useRef } from "react";
+import { Pressable, Text, View } from "react-native";
+import { ChevronDown, GitBranch } from "lucide-react-native";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/combobox";
+
+interface BranchSwitcherProps {
+  currentBranchName: string | null;
+  title: string;
+  branchOptions: ComboboxOption[];
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onBranchSelect: (branchId: string) => void;
+}
+
+export function BranchSwitcher({
+  currentBranchName,
+  title,
+  branchOptions,
+  isOpen,
+  onOpenChange,
+  onBranchSelect,
+}: BranchSwitcherProps) {
+  const { theme } = useUnistyles();
+  const anchorRef = useRef<View>(null);
+
+  if (!currentBranchName) {
+    return (
+      <Text
+        testID="workspace-header-title"
+        style={styles.headerTitle}
+        numberOfLines={1}
+      >
+        {title}
+      </Text>
+    );
+  }
+
+  return (
+    <View ref={anchorRef} collapsable={false}>
+      <Pressable
+        testID="workspace-header-branch-switcher"
+        onPress={() => onOpenChange(true)}
+        style={({ hovered, pressed }) => [
+          styles.branchSwitcherTrigger,
+          (hovered || pressed) && styles.branchSwitcherTriggerHovered,
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={`Current branch: ${currentBranchName}. Press to switch branch.`}
+      >
+        <GitBranch
+          size={14}
+          color={theme.colors.foregroundMuted}
+        />
+        <Text
+          testID="workspace-header-title"
+          style={styles.headerTitle}
+          numberOfLines={1}
+        >
+          {title}
+        </Text>
+        <ChevronDown
+          size={12}
+          color={theme.colors.foregroundMuted}
+        />
+      </Pressable>
+      <Combobox
+        options={branchOptions}
+        value={currentBranchName}
+        onSelect={onBranchSelect}
+        searchable
+        placeholder="Switch branch..."
+        searchPlaceholder="Filter branches..."
+        emptyText="No branches found."
+        title="Switch branch"
+        open={isOpen}
+        onOpenChange={onOpenChange}
+        anchorRef={anchorRef}
+        desktopPlacement="bottom-start"
+        desktopPreventInitialFlash
+        desktopMinWidth={280}
+        renderOption={({ option, selected, active, onPress }) => (
+          <ComboboxItem
+            key={option.id}
+            label={option.label}
+            selected={selected}
+            active={active}
+            onPress={onPress}
+            leadingSlot={
+              <GitBranch
+                size={14}
+                color={theme.colors.foregroundMuted}
+              />
+            }
+          />
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  headerTitle: {
+    fontSize: theme.fontSize.base,
+    fontWeight: {
+      xs: "400",
+      md: "300",
+    },
+    color: theme.colors.foreground,
+    flexShrink: 1,
+  },
+  branchSwitcherTrigger: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    paddingVertical: theme.spacing[1],
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.md,
+    flexShrink: 1,
+    minWidth: 0,
+  },
+  branchSwitcherTriggerHovered: {
+    backgroundColor: theme.colors.surface1,
+  },
+}));

--- a/packages/app/src/components/toast-host.tsx
+++ b/packages/app/src/components/toast-host.tsx
@@ -109,6 +109,7 @@ export function ToastViewport({
 }) {
   const { theme } = useUnistyles();
   const insets = useSafeAreaInsets();
+  const isMobile = useIsCompactFormFactor();
   const opacity = useRef(new Animated.Value(0)).current;
   const translateY = useRef(new Animated.Value(-8)).current;
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -182,7 +183,6 @@ export function ToastViewport({
     return null;
   }
 
-  const isMobile = useIsCompactFormFactor();
   const headerHeight = isMobile ? HEADER_INNER_HEIGHT_MOBILE : HEADER_INNER_HEIGHT;
   const headerTopPadding = isMobile ? HEADER_TOP_PADDING_MOBILE : 0;
   const topOffset =

--- a/packages/app/src/components/ui/combobox-options.test.ts
+++ b/packages/app/src/components/ui/combobox-options.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildVisibleComboboxOptions,
+  filterAndRankComboboxOptions,
   getComboboxFallbackIndex,
   orderVisibleComboboxOptions,
 } from "./combobox-options";
@@ -44,6 +45,48 @@ describe("buildVisibleComboboxOptions", () => {
     expect(visible).toEqual([
       { id: "/Users/me/project-a", label: "/Users/me/project-a", kind: "directory" },
     ]);
+  });
+});
+
+describe("filterAndRankComboboxOptions", () => {
+  const options = [
+    { id: "feat/login", label: "feat/login" },
+    { id: "main", label: "main" },
+    { id: "feat/main-nav", label: "feat/main-nav" },
+    { id: "fix/logout", label: "fix/logout", description: "fixes main logout bug" },
+  ];
+
+  it("returns all options when search is empty", () => {
+    expect(filterAndRankComboboxOptions(options, "")).toEqual(options);
+  });
+
+  it("filters by label substring", () => {
+    const result = filterAndRankComboboxOptions(options, "login");
+    expect(result.map((o) => o.id)).toEqual(["feat/login"]);
+  });
+
+  it("filters by id substring", () => {
+    const result = filterAndRankComboboxOptions(options, "fix/");
+    expect(result.map((o) => o.id)).toEqual(["fix/logout"]);
+  });
+
+  it("filters by description substring", () => {
+    const result = filterAndRankComboboxOptions(options, "logout bug");
+    expect(result.map((o) => o.id)).toEqual(["fix/logout"]);
+  });
+
+  it("ranks prefix matches above substring matches", () => {
+    const result = filterAndRankComboboxOptions(options, "main");
+    expect(result.map((o) => o.id)).toEqual(["main", "feat/main-nav", "fix/logout"]);
+  });
+
+  it("is case-insensitive", () => {
+    const items = [{ id: "Alpha", label: "Alpha" }];
+    expect(filterAndRankComboboxOptions(items, "alpha")).toHaveLength(1);
+  });
+
+  it("returns empty when nothing matches", () => {
+    expect(filterAndRankComboboxOptions(options, "zzz")).toEqual([]);
   });
 });
 

--- a/packages/app/src/components/ui/combobox-options.ts
+++ b/packages/app/src/components/ui/combobox-options.ts
@@ -35,29 +35,33 @@ export function shouldShowCustomComboboxOption(input: {
   );
 }
 
+export function filterAndRankComboboxOptions(
+  options: ComboboxOptionModel[],
+  search: string,
+): ComboboxOptionModel[] {
+  if (!search) return options;
+  return options
+    .filter(
+      (opt) =>
+        opt.label.toLowerCase().includes(search) ||
+        opt.id.toLowerCase().includes(search) ||
+        opt.description?.toLowerCase().includes(search),
+    )
+    .sort((a, b) => {
+      const aPrefix =
+        a.label.toLowerCase().startsWith(search) || a.id.toLowerCase().startsWith(search);
+      const bPrefix =
+        b.label.toLowerCase().startsWith(search) || b.id.toLowerCase().startsWith(search);
+      if (aPrefix !== bPrefix) return aPrefix ? -1 : 1;
+      return 0;
+    });
+}
+
 export function buildVisibleComboboxOptions(
   input: BuildVisibleComboboxOptionsInput,
 ): ComboboxOptionModel[] {
   const normalizedSearch = input.searchable ? input.searchQuery.trim().toLowerCase() : "";
-  const filteredOptions = normalizedSearch
-    ? input.options
-        .filter(
-          (opt) =>
-            opt.label.toLowerCase().includes(normalizedSearch) ||
-            opt.id.toLowerCase().includes(normalizedSearch) ||
-            opt.description?.toLowerCase().includes(normalizedSearch),
-        )
-        .sort((a, b) => {
-          const aPrefix =
-            a.label.toLowerCase().startsWith(normalizedSearch) ||
-            a.id.toLowerCase().startsWith(normalizedSearch);
-          const bPrefix =
-            b.label.toLowerCase().startsWith(normalizedSearch) ||
-            b.id.toLowerCase().startsWith(normalizedSearch);
-          if (aPrefix !== bPrefix) return aPrefix ? -1 : 1;
-          return 0;
-        })
-    : input.options;
+  const filteredOptions = filterAndRankComboboxOptions(input.options, normalizedSearch);
 
   const sanitizedSearchValue = input.searchQuery.trim();
   const showCustomOption = shouldShowCustomComboboxOption({

--- a/packages/app/src/components/ui/combobox-options.ts
+++ b/packages/app/src/components/ui/combobox-options.ts
@@ -40,12 +40,23 @@ export function buildVisibleComboboxOptions(
 ): ComboboxOptionModel[] {
   const normalizedSearch = input.searchable ? input.searchQuery.trim().toLowerCase() : "";
   const filteredOptions = normalizedSearch
-    ? input.options.filter(
-        (opt) =>
-          opt.label.toLowerCase().includes(normalizedSearch) ||
-          opt.id.toLowerCase().includes(normalizedSearch) ||
-          opt.description?.toLowerCase().includes(normalizedSearch),
-      )
+    ? input.options
+        .filter(
+          (opt) =>
+            opt.label.toLowerCase().includes(normalizedSearch) ||
+            opt.id.toLowerCase().includes(normalizedSearch) ||
+            opt.description?.toLowerCase().includes(normalizedSearch),
+        )
+        .sort((a, b) => {
+          const aPrefix =
+            a.label.toLowerCase().startsWith(normalizedSearch) ||
+            a.id.toLowerCase().startsWith(normalizedSearch);
+          const bPrefix =
+            b.label.toLowerCase().startsWith(normalizedSearch) ||
+            b.id.toLowerCase().startsWith(normalizedSearch);
+          if (aPrefix !== bPrefix) return aPrefix ? -1 : 1;
+          return 0;
+        })
     : input.options;
 
   const sanitizedSearchValue = input.searchQuery.trim();

--- a/packages/app/src/components/ui/combobox.tsx
+++ b/packages/app/src/components/ui/combobox.tsx
@@ -660,13 +660,7 @@ export function Combobox({
     </>
   );
 
-  const defaultContent = (
-    <>
-      {effectiveOptionsPosition === "above-search" ? optionsList : null}
-      {searchable ? searchInput : null}
-      {effectiveOptionsPosition === "below-search" ? optionsList : null}
-    </>
-  );
+  const defaultContent = optionsList;
 
   const content = children ?? defaultContent;
 
@@ -691,6 +685,7 @@ export function Combobox({
           <Text style={styles.comboboxTitle}>{title}</Text>
         </View>
         {stickyHeader}
+        {!children && searchable ? searchInput : null}
         <BottomSheetScrollView
           contentContainerStyle={styles.comboboxScrollContent}
           keyboardShouldPersistTaps="handled"
@@ -746,6 +741,7 @@ export function Combobox({
             </>
           ) : (
             <>
+              {searchable ? searchInput : null}
               {effectiveOptionsPosition === "above-search" ? (
                 <ScrollView
                   ref={desktopOptionsScrollRef}
@@ -760,9 +756,7 @@ export function Combobox({
                 >
                   {optionsList}
                 </ScrollView>
-              ) : null}
-              {searchable ? searchInput : null}
-              {effectiveOptionsPosition === "below-search" ? (
+              ) : (
                 <ScrollView
                   contentContainerStyle={styles.desktopScrollContent}
                   keyboardShouldPersistTaps="handled"
@@ -771,7 +765,7 @@ export function Combobox({
                 >
                   {optionsList}
                 </ScrollView>
-              ) : null}
+              )}
             </>
           )}
         </Animated.View>
@@ -784,15 +778,12 @@ const styles = StyleSheet.create((theme) => ({
   searchInputContainer: {
     flexDirection: "row",
     alignItems: "center",
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    backgroundColor: theme.colors.surface1,
-    borderRadius: theme.borderRadius.lg,
     paddingHorizontal: theme.spacing[3],
-    marginHorizontal: theme.spacing[2],
-    marginBottom: theme.spacing[2],
-    marginTop: theme.spacing[1],
     gap: theme.spacing[2],
+    backgroundColor: theme.colors.surface1,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+    ...(IS_WEB ? {} : { marginHorizontal: theme.spacing[1] }),
   },
   searchInput: {
     flex: 1,

--- a/packages/app/src/hooks/use-branch-switcher.ts
+++ b/packages/app/src/hooks/use-branch-switcher.ts
@@ -1,0 +1,164 @@
+import { useState, useCallback, useMemo } from "react";
+import { useQuery, type QueryClient } from "@tanstack/react-query";
+import type { DaemonClient } from "@server/client/daemon-client";
+import type { ComboboxOption } from "@/components/ui/combobox";
+import type { ToastApi } from "@/components/toast-host";
+import { checkoutStatusQueryKey } from "@/hooks/use-checkout-status-query";
+import { confirmDialog } from "@/utils/confirm-dialog";
+
+interface UseBranchSwitcherInput {
+  client: DaemonClient | null;
+  normalizedServerId: string;
+  normalizedWorkspaceId: string;
+  currentBranchName: string | null;
+  isGitCheckout: boolean;
+  isConnected: boolean;
+  toast: ToastApi;
+  queryClient: QueryClient;
+}
+
+interface UseBranchSwitcherResult {
+  branchOptions: ComboboxOption[];
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  handleBranchSelect: (branchId: string) => void;
+  invalidateStashAndCheckout: () => Promise<void>;
+}
+
+export function useBranchSwitcher({
+  client,
+  normalizedServerId,
+  normalizedWorkspaceId,
+  currentBranchName,
+  isGitCheckout,
+  isConnected,
+  toast,
+  queryClient,
+}: UseBranchSwitcherInput): UseBranchSwitcherResult {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const branchSuggestionsQuery = useQuery({
+    queryKey: ["branchSuggestions", normalizedServerId, normalizedWorkspaceId],
+    queryFn: async () => {
+      if (!client) {
+        throw new Error("Daemon client unavailable");
+      }
+      const payload = await client.getBranchSuggestions({
+        cwd: normalizedWorkspaceId,
+        limit: 200,
+      });
+      if (payload.error) {
+        throw new Error(payload.error);
+      }
+      return payload.branches ?? [];
+    },
+    enabled: isOpen && isGitCheckout && Boolean(client) && isConnected,
+    retry: false,
+    staleTime: 15_000,
+  });
+
+  const branchOptions = useMemo<ComboboxOption[]>(() => {
+    const branches = branchSuggestionsQuery.data ?? [];
+    return branches.map((name) => ({ id: name, label: name }));
+  }, [branchSuggestionsQuery.data]);
+
+  const stashListQueryKey = useMemo(
+    () => ["stashList", normalizedServerId, normalizedWorkspaceId] as const,
+    [normalizedServerId, normalizedWorkspaceId],
+  );
+
+  const invalidateStashAndCheckout = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: stashListQueryKey }),
+      queryClient.invalidateQueries({
+        queryKey: checkoutStatusQueryKey(normalizedServerId, normalizedWorkspaceId),
+      }),
+    ]);
+  }, [queryClient, stashListQueryKey, normalizedServerId, normalizedWorkspaceId]);
+
+  const stashAndSwitch = useCallback(
+    async (branchId: string) => {
+      if (!client) return;
+      const shouldStash = await confirmDialog({
+        title: "Uncommitted changes",
+        message:
+          "You have uncommitted changes. Stash them before switching branches?",
+        confirmLabel: "Stash & Switch",
+        cancelLabel: "Cancel",
+      });
+      if (!shouldStash) return;
+
+      try {
+        const stashPayload = await client.stashSave(normalizedWorkspaceId, {
+          branch: currentBranchName ?? undefined,
+        });
+        if (stashPayload.error) {
+          toast.error(stashPayload.error.message);
+          return;
+        }
+        await invalidateStashAndCheckout();
+        const switchPayload = await client.checkoutSwitchBranch(normalizedWorkspaceId, branchId);
+        if (switchPayload.error) {
+          toast.error(switchPayload.error.message);
+          return;
+        }
+        await invalidateStashAndCheckout();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to stash changes");
+      }
+    },
+    [client, currentBranchName, invalidateStashAndCheckout, normalizedWorkspaceId, toast],
+  );
+
+  const handleBranchSelect = useCallback(
+    (branchId: string) => {
+      if (branchId === currentBranchName) return;
+
+      void (async () => {
+        if (!client) return;
+        try {
+          const payload = await client.checkoutSwitchBranch(normalizedWorkspaceId, branchId);
+          if (payload.error) {
+            // If the error is about uncommitted changes, offer the stash dialog
+            if (payload.error.message.toLowerCase().includes("uncommitted")) {
+              await stashAndSwitch(branchId);
+              return;
+            }
+            toast.error(payload.error.message);
+            return;
+          }
+          // Success — refresh and check for stashes on the target branch
+          await invalidateStashAndCheckout();
+          try {
+            const stashPayload = await client.stashList(normalizedWorkspaceId, { paseoOnly: true });
+            const targetStash = stashPayload.entries.find((e) => e.branch === branchId);
+            if (targetStash) {
+              const shouldRestore = await confirmDialog({
+                title: "Restore stashed changes?",
+                message: "This branch has stashed changes from a previous session. Would you like to restore them?",
+                confirmLabel: "Restore",
+                cancelLabel: "Later",
+              });
+              if (shouldRestore) {
+                const popPayload = await client.stashPop(normalizedWorkspaceId, targetStash.index);
+                if (popPayload.error) {
+                  toast.error(popPayload.error.message);
+                } else {
+                  toast.show("Stashed changes restored");
+                }
+                await invalidateStashAndCheckout();
+              }
+            }
+          } catch {
+            // Non-critical — user can still restore on next branch switch
+          }
+        } catch (err) {
+          toast.error(err instanceof Error ? err.message : "Failed to switch branch");
+        }
+      })();
+    },
+    [client, currentBranchName, invalidateStashAndCheckout, normalizedWorkspaceId, stashAndSwitch, toast],
+  );
+
+  return { branchOptions, isOpen, setIsOpen, handleBranchSelect, invalidateStashAndCheckout };
+}

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -5,8 +5,10 @@ import {
   ActivityIndicator,
   BackHandler,
   Keyboard,
+  Modal,
   Platform,
   Pressable,
+  ScrollView,
   Text,
   View,
 } from "react-native";
@@ -20,8 +22,10 @@ import {
   Copy,
   Ellipsis,
   EllipsisVertical,
+  Eye,
   GitBranch,
   Package,
+  Trash2,
   PanelRight,
   RotateCw,
   SquarePen,
@@ -827,10 +831,33 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
     staleTime: 30_000,
   });
 
+  const allStashes = stashListQuery.data ?? [];
+  const hasStashes = allStashes.length > 0;
+
   const currentBranchStash = useMemo<StashEntry | null>(() => {
     if (!currentBranchName || !stashListQuery.data) return null;
     return stashListQuery.data.find((e) => e.branch === currentBranchName) ?? null;
   }, [currentBranchName, stashListQuery.data]);
+
+  // Stash diff preview state
+  const [previewStashIndex, setPreviewStashIndex] = useState<number | null>(null);
+  const isStashPreviewOpen = previewStashIndex !== null;
+
+  const stashShowQuery = useQuery({
+    queryKey: ["stashShow", normalizedServerId, normalizedWorkspaceId, previewStashIndex],
+    queryFn: async () => {
+      if (!client || previewStashIndex === null) {
+        throw new Error("Daemon client unavailable");
+      }
+      const payload = await client.stashShow(normalizedWorkspaceId, previewStashIndex);
+      if (payload.error) {
+        throw new Error(payload.error.message);
+      }
+      return payload.files;
+    },
+    enabled: isStashPreviewOpen && Boolean(client) && isConnected,
+    staleTime: 60_000,
+  });
 
   const invalidateStashAndCheckout = useCallback(async () => {
     await Promise.all([
@@ -872,24 +899,6 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
       toast.error(error instanceof Error ? error.message : "Failed to discard stash");
     },
   });
-
-  const handleRestoreStash = useCallback(() => {
-    if (!currentBranchStash) return;
-    stashPopMutation.mutate(currentBranchStash.index);
-  }, [currentBranchStash, stashPopMutation]);
-
-  const handleDropStash = useCallback(async () => {
-    if (!currentBranchStash) return;
-    const confirmed = await confirmDialog({
-      title: "Discard stash?",
-      message: "The stashed changes will be permanently deleted.",
-      confirmLabel: "Discard",
-      destructive: true,
-    });
-    if (confirmed) {
-      stashDropMutation.mutate(currentBranchStash.index);
-    }
-  }, [currentBranchStash, stashDropMutation]);
 
   // ---- Branch switch with stash-awareness ----
 
@@ -2221,7 +2230,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                           {workspaceHeader.title}
                         </Text>
                       )}
-                      {currentBranchStash ? (
+                      {hasStashes ? (
                         <DropdownMenu>
                           <DropdownMenuTrigger
                             testID="workspace-header-stash-trigger"
@@ -2230,7 +2239,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                               (hovered || pressed) && styles.stashIndicatorHovered,
                             ]}
                             accessibilityRole="button"
-                            accessibilityLabel="Stashed changes available"
+                            accessibilityLabel={`${allStashes.length} stashed change${allStashes.length === 1 ? "" : "s"}`}
                           >
                             {({ hovered }) => (
                               <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
@@ -2246,31 +2255,66 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                                     />
                                   </View>
                                 </TooltipTrigger>
-                                <TooltipContent>Stashed changes</TooltipContent>
+                                <TooltipContent>
+                                  {allStashes.length} stash{allStashes.length === 1 ? "" : "es"}
+                                </TooltipContent>
                               </Tooltip>
                             )}
                           </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start" width={200}>
-                            <DropdownMenuItem
-                              testID="workspace-header-stash-restore"
-                              leading={
-                                <Package size={14} color={theme.colors.foregroundMuted} />
-                              }
-                              onSelect={handleRestoreStash}
-                              disabled={stashPopMutation.isPending}
-                            >
-                              Restore stash
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                              testID="workspace-header-stash-drop"
-                              leading={
-                                <X size={14} color={theme.colors.foregroundMuted} />
-                              }
-                              onSelect={handleDropStash}
-                              disabled={stashDropMutation.isPending}
-                            >
-                              Discard stash
-                            </DropdownMenuItem>
+                          <DropdownMenuContent align="start" width={300}>
+                            {allStashes.map((stash) => (
+                              <View key={stash.index}>
+                                <View style={styles.stashEntryHeader}>
+                                  <Text
+                                    style={styles.stashEntryBranch}
+                                    numberOfLines={1}
+                                  >
+                                    {stash.branch ?? "unnamed"}
+                                  </Text>
+                                </View>
+                                <DropdownMenuItem
+                                  leading={
+                                    <Eye size={14} color={theme.colors.foregroundMuted} />
+                                  }
+                                  onSelect={() => setPreviewStashIndex(stash.index)}
+                                >
+                                  Preview
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  leading={
+                                    <Package size={14} color={theme.colors.foregroundMuted} />
+                                  }
+                                  onSelect={() => stashPopMutation.mutate(stash.index)}
+                                  disabled={stashPopMutation.isPending}
+                                >
+                                  Restore
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  leading={
+                                    <Trash2 size={14} color={theme.colors.foregroundMuted} />
+                                  }
+                                  onSelect={() => {
+                                    void (async () => {
+                                      const confirmed = await confirmDialog({
+                                        title: "Discard stash?",
+                                        message: `The stashed changes for "${stash.branch ?? "unnamed"}" will be permanently deleted.`,
+                                        confirmLabel: "Discard",
+                                        destructive: true,
+                                      });
+                                      if (confirmed) {
+                                        stashDropMutation.mutate(stash.index);
+                                      }
+                                    })();
+                                  }}
+                                  disabled={stashDropMutation.isPending}
+                                >
+                                  Discard
+                                </DropdownMenuItem>
+                                {stash.index < allStashes[allStashes.length - 1]!.index ? (
+                                  <DropdownMenuSeparator />
+                                ) : null}
+                              </View>
+                            ))}
                           </DropdownMenuContent>
                         </DropdownMenu>
                       ) : null}
@@ -2574,6 +2618,141 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
           />
         )}
       </View>
+      {isStashPreviewOpen ? (
+        <Modal
+          transparent
+          animationType="none"
+          visible
+          onRequestClose={() => setPreviewStashIndex(null)}
+        >
+          <Pressable
+            style={styles.stashPreviewBackdrop}
+            onPress={() => setPreviewStashIndex(null)}
+          />
+          <View style={styles.stashPreviewCard}>
+            <View style={styles.stashPreviewHeader}>
+              <Text style={styles.stashPreviewTitle} numberOfLines={1}>
+                Stash preview — {allStashes.find((s) => s.index === previewStashIndex)?.branch ?? "unnamed"}
+              </Text>
+              <Pressable
+                accessibilityLabel="Close"
+                style={styles.stashPreviewCloseButton}
+                onPress={() => setPreviewStashIndex(null)}
+              >
+                <X size={16} color={theme.colors.foregroundMuted} />
+              </Pressable>
+            </View>
+            <ScrollView
+              style={styles.stashPreviewScroll}
+              contentContainerStyle={styles.stashPreviewScrollContent}
+            >
+              {stashShowQuery.isLoading ? (
+                <View style={styles.stashPreviewLoading}>
+                  <ActivityIndicator size="small" color={theme.colors.foregroundMuted} />
+                  <Text style={styles.stashPreviewLoadingText}>Loading diff...</Text>
+                </View>
+              ) : stashShowQuery.isError ? (
+                <Text style={styles.stashPreviewErrorText}>
+                  Failed to load stash diff.
+                </Text>
+              ) : stashShowQuery.data && stashShowQuery.data.length > 0 ? (
+                stashShowQuery.data.map((file) => (
+                  <View key={file.path} style={styles.stashPreviewFile}>
+                    <View style={styles.stashPreviewFileHeader}>
+                      <Text style={styles.stashPreviewFilePath} numberOfLines={1}>
+                        {file.path}
+                      </Text>
+                      <Text style={styles.stashPreviewFileStats}>
+                        {file.additions > 0 ? (
+                          <Text style={{ color: theme.colors.palette.green[500] }}>
+                            +{file.additions}
+                          </Text>
+                        ) : null}
+                        {file.additions > 0 && file.deletions > 0 ? " " : null}
+                        {file.deletions > 0 ? (
+                          <Text style={{ color: theme.colors.palette.red[500] }}>
+                            -{file.deletions}
+                          </Text>
+                        ) : null}
+                      </Text>
+                    </View>
+                    {file.status === "binary" ? (
+                      <Text style={styles.stashPreviewBinaryLabel}>Binary file</Text>
+                    ) : file.status === "too_large" ? (
+                      <Text style={styles.stashPreviewBinaryLabel}>File too large to preview</Text>
+                    ) : (
+                      file.hunks.map((hunk, hunkIdx) => (
+                        <View key={hunkIdx} style={styles.stashPreviewHunk}>
+                          {hunk.lines.map((line, lineIdx) => (
+                            <Text
+                              key={lineIdx}
+                              style={[
+                                styles.stashPreviewLine,
+                                line.type === "add" && styles.stashPreviewLineAdd,
+                                line.type === "remove" && styles.stashPreviewLineRemove,
+                                line.type === "header" && styles.stashPreviewLineHeader,
+                              ]}
+                              numberOfLines={1}
+                            >
+                              {line.type === "add"
+                                ? "+"
+                                : line.type === "remove"
+                                  ? "-"
+                                  : " "}
+                              {line.content}
+                            </Text>
+                          ))}
+                        </View>
+                      ))
+                    )}
+                  </View>
+                ))
+              ) : (
+                <Text style={styles.stashPreviewErrorText}>No changes in this stash.</Text>
+              )}
+            </ScrollView>
+            <View style={styles.stashPreviewActions}>
+              <Pressable
+                style={({ hovered }) => [
+                  styles.stashPreviewActionButton,
+                  hovered && styles.stashPreviewActionButtonHovered,
+                ]}
+                onPress={() => {
+                  stashPopMutation.mutate(previewStashIndex);
+                  setPreviewStashIndex(null);
+                }}
+              >
+                <Text style={styles.stashPreviewActionText}>Restore</Text>
+              </Pressable>
+              <Pressable
+                style={({ hovered }) => [
+                  styles.stashPreviewActionButton,
+                  styles.stashPreviewActionButtonDestructive,
+                  hovered && styles.stashPreviewActionButtonDestructiveHovered,
+                ]}
+                onPress={() => {
+                  void (async () => {
+                    const confirmed = await confirmDialog({
+                      title: "Discard stash?",
+                      message: "The stashed changes will be permanently deleted.",
+                      confirmLabel: "Discard",
+                      destructive: true,
+                    });
+                    if (confirmed) {
+                      stashDropMutation.mutate(previewStashIndex);
+                      setPreviewStashIndex(null);
+                    }
+                  })();
+                }}
+              >
+                <Text style={[styles.stashPreviewActionText, styles.stashPreviewActionTextDestructive]}>
+                  Discard
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </Modal>
+      ) : null}
     </View>
   );
 }
@@ -2667,6 +2846,171 @@ const styles = StyleSheet.create((theme) => ({
   stashIndicatorInner: {
     alignItems: "center",
     justifyContent: "center",
+  },
+  stashEntryHeader: {
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[1],
+    paddingTop: theme.spacing[2],
+  },
+  stashEntryBranch: {
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.medium,
+    color: theme.colors.foregroundMuted,
+  },
+  stashPreviewBackdrop: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    backgroundColor: "rgba(0,0,0,0.55)",
+  },
+  stashPreviewCard: {
+    position: "absolute",
+    top: "5%",
+    left: "10%",
+    right: "10%",
+    bottom: "5%",
+    backgroundColor: theme.colors.surface0,
+    borderRadius: theme.borderRadius.xl,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    overflow: "hidden",
+    ...theme.shadow.lg,
+  },
+  stashPreviewHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  stashPreviewTitle: {
+    fontSize: theme.fontSize.base,
+    fontWeight: theme.fontWeight.medium,
+    color: theme.colors.foreground,
+    flex: 1,
+  },
+  stashPreviewCloseButton: {
+    padding: theme.spacing[2],
+    borderRadius: theme.borderRadius.md,
+  },
+  stashPreviewScroll: {
+    flex: 1,
+    minHeight: 0,
+  },
+  stashPreviewScrollContent: {
+    padding: theme.spacing[3],
+    gap: theme.spacing[3],
+  },
+  stashPreviewLoading: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: theme.spacing[2],
+    padding: theme.spacing[6],
+  },
+  stashPreviewLoadingText: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foregroundMuted,
+  },
+  stashPreviewErrorText: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foregroundMuted,
+    padding: theme.spacing[4],
+    textAlign: "center",
+  },
+  stashPreviewFile: {
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.md,
+    overflow: "hidden",
+  },
+  stashPreviewFileHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[2],
+    backgroundColor: theme.colors.surface1,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  stashPreviewFilePath: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+    color: theme.colors.foreground,
+    fontFamily: theme.fontFamily.mono,
+    flex: 1,
+  },
+  stashPreviewFileStats: {
+    fontSize: theme.fontSize.xs,
+    fontFamily: theme.fontFamily.mono,
+    marginLeft: theme.spacing[2],
+  },
+  stashPreviewBinaryLabel: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+    padding: theme.spacing[3],
+    fontStyle: "italic",
+  },
+  stashPreviewHunk: {
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+  },
+  stashPreviewLine: {
+    fontSize: theme.fontSize.xs,
+    fontFamily: theme.fontFamily.mono,
+    color: theme.colors.foreground,
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: 1,
+  },
+  stashPreviewLineAdd: {
+    backgroundColor: "rgba(34,197,94,0.12)",
+    color: theme.colors.palette.green[400],
+  },
+  stashPreviewLineRemove: {
+    backgroundColor: "rgba(239,68,68,0.12)",
+    color: theme.colors.palette.red[400],
+  },
+  stashPreviewLineHeader: {
+    color: theme.colors.foregroundMuted,
+    backgroundColor: theme.colors.surface1,
+    fontStyle: "italic",
+  },
+  stashPreviewActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: theme.spacing[2],
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[3],
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+  },
+  stashPreviewActionButton: {
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[2],
+    borderRadius: theme.borderRadius.md,
+    backgroundColor: theme.colors.surface1,
+  },
+  stashPreviewActionButtonHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+  stashPreviewActionButtonDestructive: {
+    backgroundColor: "transparent",
+  },
+  stashPreviewActionButtonDestructiveHovered: {
+    backgroundColor: "rgba(239,68,68,0.1)",
+  },
+  stashPreviewActionText: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+    color: theme.colors.foreground,
+  },
+  stashPreviewActionTextDestructive: {
+    color: theme.colors.palette.red[500],
   },
   sourceControlButton: {
     flexDirection: "row",

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -767,8 +767,6 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
   const [branchSearchQuery, setBranchSearchQuery] = useState("");
   const [debouncedBranchSearchQuery, setDebouncedBranchSearchQuery] = useState("");
   const branchSwitcherAnchorRef = useRef<View>(null);
-  const hasUncommittedChanges = checkoutQuery.data?.isGit ? checkoutQuery.data.isDirty : false;
-
   useEffect(() => {
     const trimmed = branchSearchQuery.trim();
     const timer = setTimeout(() => setDebouncedBranchSearchQuery(trimmed), 180);
@@ -895,91 +893,88 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
 
   // ---- Branch switch with stash-awareness ----
 
-  const switchBranchMutation = useMutation({
-    mutationFn: async (branch: string) => {
-      if (!client) throw new Error("Daemon client unavailable");
-      const payload = await client.checkoutSwitchBranch(normalizedWorkspaceId, branch);
-      if (payload.error) throw new Error(payload.error.message);
-      return payload;
-    },
-    onSuccess: (_data, branch) => {
-      // After switching, refresh queries then check if the target branch has a Paseo stash
-      void (async () => {
-        await invalidateStashAndCheckout();
-        try {
-          if (!client) return;
-          const stashPayload = await client.stashList(normalizedWorkspaceId, { paseoOnly: true });
-          const targetStash = stashPayload.entries.find((e) => e.branch === branch);
-          if (targetStash) {
-            const shouldRestore = await confirmDialog({
-              title: "Restore stashed changes?",
-              message: `This branch has stashed changes from a previous session. Would you like to restore them?`,
-              confirmLabel: "Restore",
-              cancelLabel: "Later",
-            });
-            if (shouldRestore) {
-              const popPayload = await client.stashPop(normalizedWorkspaceId, targetStash.index);
-              if (popPayload.error) {
-                toast.error(popPayload.error.message);
-              } else {
-                toast.success("Stashed changes restored");
-              }
-              await invalidateStashAndCheckout();
-            }
-          }
-        } catch {
-          // Non-critical — the user can still restore manually
+  const stashAndSwitch = useCallback(
+    async (branchId: string) => {
+      if (!client) return;
+      const shouldStash = await confirmDialog({
+        title: "Uncommitted changes",
+        message:
+          "You have uncommitted changes. Stash them before switching branches?",
+        confirmLabel: "Stash & Switch",
+        cancelLabel: "Cancel",
+      });
+      if (!shouldStash) return;
+
+      try {
+        const stashPayload = await client.stashSave(normalizedWorkspaceId, {
+          branch: currentBranchName ?? undefined,
+        });
+        if (stashPayload.error) {
+          toast.error(stashPayload.error.message);
+          return;
         }
-      })();
+        await invalidateStashAndCheckout();
+        const switchPayload = await client.checkoutSwitchBranch(normalizedWorkspaceId, branchId);
+        if (switchPayload.error) {
+          toast.error(switchPayload.error.message);
+          return;
+        }
+        await invalidateStashAndCheckout();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to stash changes");
+      }
     },
-    onError: (error) => {
-      toast.error(error instanceof Error ? error.message : "Failed to switch branch");
-    },
-  });
+    [client, currentBranchName, invalidateStashAndCheckout, normalizedWorkspaceId, toast],
+  );
 
   const handleBranchSelect = useCallback(
     (branchId: string) => {
       if (branchId === currentBranchName) return;
 
-      if (hasUncommittedChanges) {
-        void (async () => {
-          const shouldStash = await confirmDialog({
-            title: "Uncommitted changes",
-            message:
-              "You have uncommitted changes. Stash them before switching branches?",
-            confirmLabel: "Stash & Switch",
-            cancelLabel: "Cancel",
-          });
-          if (!shouldStash || !client) return;
-
-          try {
-            const stashPayload = await client.stashSave(normalizedWorkspaceId, {
-              branch: currentBranchName ?? undefined,
-            });
-            if (stashPayload.error) {
-              toast.error(stashPayload.error.message);
+      void (async () => {
+        if (!client) return;
+        try {
+          const payload = await client.checkoutSwitchBranch(normalizedWorkspaceId, branchId);
+          if (payload.error) {
+            // If the error is about uncommitted changes, offer the stash dialog
+            if (payload.error.message.toLowerCase().includes("uncommitted")) {
+              await stashAndSwitch(branchId);
               return;
             }
-            // Invalidate so the checkout query sees clean state before switching
-            await invalidateStashAndCheckout();
-            switchBranchMutation.mutate(branchId);
-          } catch (err) {
-            toast.error(err instanceof Error ? err.message : "Failed to stash changes");
+            toast.error(payload.error.message);
+            return;
           }
-        })();
-        return;
-      }
-
-      switchBranchMutation.mutate(branchId);
+          // Success — refresh and check for stashes on the target branch
+          await invalidateStashAndCheckout();
+          try {
+            const stashPayload = await client.stashList(normalizedWorkspaceId, { paseoOnly: true });
+            const targetStash = stashPayload.entries.find((e) => e.branch === branchId);
+            if (targetStash) {
+              const shouldRestore = await confirmDialog({
+                title: "Restore stashed changes?",
+                message: "This branch has stashed changes from a previous session. Would you like to restore them?",
+                confirmLabel: "Restore",
+                cancelLabel: "Later",
+              });
+              if (shouldRestore) {
+                const popPayload = await client.stashPop(normalizedWorkspaceId, targetStash.index);
+                if (popPayload.error) {
+                  toast.error(popPayload.error.message);
+                } else {
+                  toast.success("Stashed changes restored");
+                }
+                await invalidateStashAndCheckout();
+              }
+            }
+          } catch {
+            // Non-critical — user can still restore manually via stash indicator
+          }
+        } catch (err) {
+          toast.error(err instanceof Error ? err.message : "Failed to switch branch");
+        }
+      })();
     },
-    [
-      client,
-      currentBranchName,
-      hasUncommittedChanges,
-      normalizedWorkspaceId,
-      switchBranchMutation,
-      toast,
-    ],
+    [client, currentBranchName, invalidateStashAndCheckout, normalizedWorkspaceId, stashAndSwitch, toast],
   );
 
   const mobileView = usePanelStore((state) => state.mobileView);

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -834,11 +834,13 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
     return stashListQuery.data.find((e) => e.branch === currentBranchName) ?? null;
   }, [currentBranchName, stashListQuery.data]);
 
-  const invalidateStashAndCheckout = useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey: stashListQueryKey });
-    void queryClient.invalidateQueries({
-      queryKey: checkoutStatusQueryKey(normalizedServerId, normalizedWorkspaceId),
-    });
+  const invalidateStashAndCheckout = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: stashListQueryKey }),
+      queryClient.invalidateQueries({
+        queryKey: checkoutStatusQueryKey(normalizedServerId, normalizedWorkspaceId),
+      }),
+    ]);
   }, [queryClient, stashListQueryKey, normalizedServerId, normalizedWorkspaceId]);
 
   const stashPopMutation = useMutation({
@@ -901,9 +903,9 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
       return payload;
     },
     onSuccess: (_data, branch) => {
-      invalidateStashAndCheckout();
-      // After switching, check if the target branch has a Paseo stash
+      // After switching, refresh queries then check if the target branch has a Paseo stash
       void (async () => {
+        await invalidateStashAndCheckout();
         try {
           if (!client) return;
           const stashPayload = await client.stashList(normalizedWorkspaceId, { paseoOnly: true });
@@ -922,7 +924,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
               } else {
                 toast.success("Stashed changes restored");
               }
-              invalidateStashAndCheckout();
+              await invalidateStashAndCheckout();
             }
           }
         } catch {
@@ -958,7 +960,8 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
               toast.error(stashPayload.error.message);
               return;
             }
-            // Stash succeeded — now switch
+            // Invalidate so the checkout query sees clean state before switching
+            await invalidateStashAndCheckout();
             switchBranchMutation.mutate(branchId);
           } catch (err) {
             toast.error(err instanceof Error ? err.message : "Failed to stash changes");

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -20,6 +20,8 @@ import {
   Copy,
   Ellipsis,
   EllipsisVertical,
+  GitBranch,
+  Package,
   PanelRight,
   RotateCw,
   SquarePen,
@@ -76,7 +78,7 @@ import {
   checkoutStatusQueryKey,
   type CheckoutStatusPayload,
 } from "@/hooks/use-checkout-status-query";
-import type { ListTerminalsResponse } from "@server/shared/messages";
+import type { ListTerminalsResponse, StashEntry } from "@server/shared/messages";
 import { upsertTerminalListEntry } from "@/utils/terminal-list";
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { useArchiveAgent } from "@/hooks/use-archive-agent";
@@ -759,6 +761,224 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
     checkoutQuery.data?.isGit && checkoutQuery.data.currentBranch !== "HEAD"
       ? trimNonEmpty(checkoutQuery.data.currentBranch)
       : null;
+
+  // Branch switcher state
+  const [isBranchSwitcherOpen, setIsBranchSwitcherOpen] = useState(false);
+  const [branchSearchQuery, setBranchSearchQuery] = useState("");
+  const [debouncedBranchSearchQuery, setDebouncedBranchSearchQuery] = useState("");
+  const branchSwitcherAnchorRef = useRef<View>(null);
+  const hasUncommittedChanges = checkoutQuery.data?.isGit ? checkoutQuery.data.isDirty : false;
+
+  useEffect(() => {
+    const trimmed = branchSearchQuery.trim();
+    const timer = setTimeout(() => setDebouncedBranchSearchQuery(trimmed), 180);
+    return () => clearTimeout(timer);
+  }, [branchSearchQuery]);
+
+  const branchSuggestionsQuery = useQuery({
+    queryKey: [
+      "branchSuggestions",
+      normalizedServerId,
+      normalizedWorkspaceId,
+      debouncedBranchSearchQuery,
+    ],
+    queryFn: async () => {
+      if (!client) {
+        throw new Error("Daemon client unavailable");
+      }
+      const payload = await client.getBranchSuggestions({
+        cwd: normalizedWorkspaceId,
+        query: debouncedBranchSearchQuery || undefined,
+        limit: 50,
+      });
+      if (payload.error) {
+        throw new Error(payload.error);
+      }
+      return payload.branches ?? [];
+    },
+    enabled: isBranchSwitcherOpen && isGitCheckout && Boolean(client) && isConnected,
+    retry: false,
+    staleTime: 15_000,
+  });
+
+  const branchOptions = useMemo<ComboboxOption[]>(() => {
+    const branches = branchSuggestionsQuery.data ?? [];
+    return branches.map((name) => ({ id: name, label: name }));
+  }, [branchSuggestionsQuery.data]);
+
+  // ---- Stash queries & mutations ----
+
+  const stashListQueryKey = useMemo(
+    () => ["stashList", normalizedServerId, normalizedWorkspaceId] as const,
+    [normalizedServerId, normalizedWorkspaceId],
+  );
+
+  const stashListQuery = useQuery({
+    queryKey: stashListQueryKey,
+    queryFn: async () => {
+      if (!client) {
+        throw new Error("Daemon client unavailable");
+      }
+      const payload = await client.stashList(normalizedWorkspaceId, { paseoOnly: true });
+      if (payload.error) {
+        throw new Error(payload.error.message);
+      }
+      return payload.entries;
+    },
+    enabled: isGitCheckout && Boolean(client) && isConnected,
+    staleTime: 30_000,
+  });
+
+  const currentBranchStash = useMemo<StashEntry | null>(() => {
+    if (!currentBranchName || !stashListQuery.data) return null;
+    return stashListQuery.data.find((e) => e.branch === currentBranchName) ?? null;
+  }, [currentBranchName, stashListQuery.data]);
+
+  const invalidateStashAndCheckout = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: stashListQueryKey });
+    void queryClient.invalidateQueries({
+      queryKey: checkoutStatusQueryKey(normalizedServerId, normalizedWorkspaceId),
+    });
+  }, [queryClient, stashListQueryKey, normalizedServerId, normalizedWorkspaceId]);
+
+  const stashPopMutation = useMutation({
+    mutationFn: async (stashIndex: number) => {
+      if (!client) throw new Error("Daemon client unavailable");
+      const payload = await client.stashPop(normalizedWorkspaceId, stashIndex);
+      if (payload.error) throw new Error(payload.error.message);
+      return payload;
+    },
+    onSuccess: () => {
+      invalidateStashAndCheckout();
+      toast.success("Stashed changes restored");
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to restore stash");
+    },
+  });
+
+  const stashDropMutation = useMutation({
+    mutationFn: async (stashIndex: number) => {
+      if (!client) throw new Error("Daemon client unavailable");
+      const payload = await client.stashDrop(normalizedWorkspaceId, stashIndex);
+      if (payload.error) throw new Error(payload.error.message);
+      return payload;
+    },
+    onSuccess: () => {
+      invalidateStashAndCheckout();
+      toast.success("Stash discarded");
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to discard stash");
+    },
+  });
+
+  const handleRestoreStash = useCallback(() => {
+    if (!currentBranchStash) return;
+    stashPopMutation.mutate(currentBranchStash.index);
+  }, [currentBranchStash, stashPopMutation]);
+
+  const handleDropStash = useCallback(async () => {
+    if (!currentBranchStash) return;
+    const confirmed = await confirmDialog({
+      title: "Discard stash?",
+      message: "The stashed changes will be permanently deleted.",
+      confirmLabel: "Discard",
+      destructive: true,
+    });
+    if (confirmed) {
+      stashDropMutation.mutate(currentBranchStash.index);
+    }
+  }, [currentBranchStash, stashDropMutation]);
+
+  // ---- Branch switch with stash-awareness ----
+
+  const switchBranchMutation = useMutation({
+    mutationFn: async (branch: string) => {
+      if (!client) throw new Error("Daemon client unavailable");
+      const payload = await client.checkoutSwitchBranch(normalizedWorkspaceId, branch);
+      if (payload.error) throw new Error(payload.error.message);
+      return payload;
+    },
+    onSuccess: (_data, branch) => {
+      invalidateStashAndCheckout();
+      // After switching, check if the target branch has a Paseo stash
+      void (async () => {
+        try {
+          if (!client) return;
+          const stashPayload = await client.stashList(normalizedWorkspaceId, { paseoOnly: true });
+          const targetStash = stashPayload.entries.find((e) => e.branch === branch);
+          if (targetStash) {
+            const shouldRestore = await confirmDialog({
+              title: "Restore stashed changes?",
+              message: `This branch has stashed changes from a previous session. Would you like to restore them?`,
+              confirmLabel: "Restore",
+              cancelLabel: "Later",
+            });
+            if (shouldRestore) {
+              const popPayload = await client.stashPop(normalizedWorkspaceId, targetStash.index);
+              if (popPayload.error) {
+                toast.error(popPayload.error.message);
+              } else {
+                toast.success("Stashed changes restored");
+              }
+              invalidateStashAndCheckout();
+            }
+          }
+        } catch {
+          // Non-critical — the user can still restore manually
+        }
+      })();
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to switch branch");
+    },
+  });
+
+  const handleBranchSelect = useCallback(
+    (branchId: string) => {
+      if (branchId === currentBranchName) return;
+
+      if (hasUncommittedChanges) {
+        void (async () => {
+          const shouldStash = await confirmDialog({
+            title: "Uncommitted changes",
+            message:
+              "You have uncommitted changes. Stash them before switching branches?",
+            confirmLabel: "Stash & Switch",
+            cancelLabel: "Cancel",
+          });
+          if (!shouldStash || !client) return;
+
+          try {
+            const stashPayload = await client.stashSave(normalizedWorkspaceId, {
+              branch: currentBranchName ?? undefined,
+            });
+            if (stashPayload.error) {
+              toast.error(stashPayload.error.message);
+              return;
+            }
+            // Stash succeeded — now switch
+            switchBranchMutation.mutate(branchId);
+          } catch (err) {
+            toast.error(err instanceof Error ? err.message : "Failed to stash changes");
+          }
+        })();
+        return;
+      }
+
+      switchBranchMutation.mutate(branchId);
+    },
+    [
+      client,
+      currentBranchName,
+      hasUncommittedChanges,
+      normalizedWorkspaceId,
+      switchBranchMutation,
+      toast,
+    ],
+  );
+
   const mobileView = usePanelStore((state) => state.mobileView);
   const desktopFileExplorerOpen = usePanelStore((state) => state.desktop.fileExplorerOpen);
   const toggleFileExplorer = usePanelStore((state) => state.toggleFileExplorer);
@@ -1948,13 +2168,114 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                     </>
                   ) : (
                     <>
-                      <Text
-                        testID="workspace-header-title"
-                        style={styles.headerTitle}
-                        numberOfLines={1}
-                      >
-                        {workspaceHeader.title}
-                      </Text>
+                      {currentBranchName ? (
+                        <View ref={branchSwitcherAnchorRef} collapsable={false}>
+                          <Pressable
+                            testID="workspace-header-branch-switcher"
+                            onPress={() => setIsBranchSwitcherOpen(true)}
+                            style={({ hovered, pressed }) => [
+                              styles.branchSwitcherTrigger,
+                              (hovered || pressed) && styles.branchSwitcherTriggerHovered,
+                            ]}
+                            accessibilityRole="button"
+                            accessibilityLabel={`Current branch: ${currentBranchName}. Press to switch branch.`}
+                          >
+                            <GitBranch
+                              size={14}
+                              color={theme.colors.foregroundMuted}
+                            />
+                            <Text
+                              testID="workspace-header-title"
+                              style={styles.headerTitle}
+                              numberOfLines={1}
+                            >
+                              {workspaceHeader.title}
+                            </Text>
+                            <ChevronDown
+                              size={12}
+                              color={theme.colors.foregroundMuted}
+                            />
+                          </Pressable>
+                          <Combobox
+                            options={branchOptions}
+                            value={currentBranchName ?? ""}
+                            onSelect={handleBranchSelect}
+                            onSearchQueryChange={setBranchSearchQuery}
+                            searchable
+                            placeholder="Switch branch..."
+                            searchPlaceholder="Filter branches..."
+                            emptyText="No branches found."
+                            title="Switch branch"
+                            open={isBranchSwitcherOpen}
+                            onOpenChange={setIsBranchSwitcherOpen}
+                            anchorRef={branchSwitcherAnchorRef}
+                            desktopPlacement="bottom-start"
+                            desktopPreventInitialFlash
+                            desktopMinWidth={280}
+                          />
+                        </View>
+                      ) : (
+                        <Text
+                          testID="workspace-header-title"
+                          style={styles.headerTitle}
+                          numberOfLines={1}
+                        >
+                          {workspaceHeader.title}
+                        </Text>
+                      )}
+                      {currentBranchStash ? (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            testID="workspace-header-stash-trigger"
+                            style={({ hovered, pressed }) => [
+                              styles.stashIndicator,
+                              (hovered || pressed) && styles.stashIndicatorHovered,
+                            ]}
+                            accessibilityRole="button"
+                            accessibilityLabel="Stashed changes available"
+                          >
+                            {({ hovered }) => (
+                              <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
+                                <TooltipTrigger asChild>
+                                  <View style={styles.stashIndicatorInner}>
+                                    <Package
+                                      size={14}
+                                      color={
+                                        hovered
+                                          ? theme.colors.foreground
+                                          : theme.colors.palette.amber[500]
+                                      }
+                                    />
+                                  </View>
+                                </TooltipTrigger>
+                                <TooltipContent>Stashed changes</TooltipContent>
+                              </Tooltip>
+                            )}
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="start" width={200}>
+                            <DropdownMenuItem
+                              testID="workspace-header-stash-restore"
+                              leading={
+                                <Package size={14} color={theme.colors.foregroundMuted} />
+                              }
+                              onSelect={handleRestoreStash}
+                              disabled={stashPopMutation.isPending}
+                            >
+                              Restore stash
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              testID="workspace-header-stash-drop"
+                              leading={
+                                <X size={14} color={theme.colors.foregroundMuted} />
+                              }
+                              onSelect={handleDropStash}
+                              disabled={stashDropMutation.isPending}
+                            >
+                              Discard stash
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      ) : null}
                       <Text
                         testID="workspace-header-subtitle"
                         style={styles.headerProjectTitle}
@@ -2323,6 +2644,31 @@ const styles = StyleSheet.create((theme) => ({
     paddingVertical: theme.spacing[2],
     paddingHorizontal: theme.spacing[2],
     borderRadius: theme.borderRadius.lg,
+  },
+  branchSwitcherTrigger: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    paddingVertical: theme.spacing[1],
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.md,
+    flexShrink: 1,
+    minWidth: 0,
+  },
+  branchSwitcherTriggerHovered: {
+    backgroundColor: theme.colors.surface1,
+  },
+  stashIndicator: {
+    paddingVertical: theme.spacing[1],
+    paddingHorizontal: theme.spacing[1],
+    borderRadius: theme.borderRadius.md,
+  },
+  stashIndicatorHovered: {
+    backgroundColor: theme.colors.surface1,
+  },
+  stashIndicatorInner: {
+    alignItems: "center",
+    justifyContent: "center",
   },
   sourceControlButton: {
     flexDirection: "row",

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -848,9 +848,9 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
       if (payload.error) throw new Error(payload.error.message);
       return payload;
     },
-    onSuccess: () => {
-      invalidateStashAndCheckout();
-      toast.success("Stashed changes restored");
+    onSuccess: async () => {
+      await invalidateStashAndCheckout();
+      toast.show("Stashed changes restored");
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : "Failed to restore stash");
@@ -864,9 +864,9 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
       if (payload.error) throw new Error(payload.error.message);
       return payload;
     },
-    onSuccess: () => {
-      invalidateStashAndCheckout();
-      toast.success("Stash discarded");
+    onSuccess: async () => {
+      await invalidateStashAndCheckout();
+      toast.show("Stash discarded");
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : "Failed to discard stash");
@@ -961,7 +961,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                 if (popPayload.error) {
                   toast.error(popPayload.error.message);
                 } else {
-                  toast.success("Stashed changes restored");
+                  toast.show("Stashed changes restored");
                 }
                 await invalidateStashAndCheckout();
               }

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -833,12 +833,19 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
   });
 
   const allStashes = stashListQuery.data ?? [];
-  const hasStashes = allStashes.length > 0;
 
-  const currentBranchStash = useMemo<StashEntry | null>(() => {
-    if (!currentBranchName || !stashListQuery.data) return null;
-    return stashListQuery.data.find((e) => e.branch === currentBranchName) ?? null;
-  }, [currentBranchName, stashListQuery.data]);
+  // Only show stashes for the current branch in the dropdown
+  const currentBranchStashes = useMemo(
+    () =>
+      currentBranchName
+        ? allStashes.filter((e) => e.branch === currentBranchName)
+        : [],
+    [allStashes, currentBranchName],
+  );
+  const hasCurrentBranchStashes = currentBranchStashes.length > 0;
+
+  // Used by the post-switch restore prompt
+  const currentBranchStash = currentBranchStashes[0] ?? null;
 
   // Stash diff preview state
   const [previewStashIndex, setPreviewStashIndex] = useState<number | null>(null);
@@ -869,20 +876,55 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
     ]);
   }, [queryClient, stashListQueryKey, normalizedServerId, normalizedWorkspaceId]);
 
-  const stashPopMutation = useMutation({
-    mutationFn: async (stashIndex: number) => {
-      if (!client) throw new Error("Daemon client unavailable");
+  const restoreStash = useCallback(
+    async (stashIndex: number) => {
+      if (!client) return;
       const payload = await client.stashPop(normalizedWorkspaceId, stashIndex);
-      if (payload.error) throw new Error(payload.error.message);
-      return payload;
-    },
-    onSuccess: async () => {
+      if (!payload.error) {
+        await invalidateStashAndCheckout();
+        toast.show("Stashed changes restored");
+        return;
+      }
+
+      const isOverwrite = payload.error.message.toLowerCase().includes("overwritten");
+      if (!isOverwrite) {
+        toast.error(payload.error.message);
+        return;
+      }
+
+      // Conflict: current changes would be overwritten
+      const confirmed = await confirmDialog({
+        title: "Uncommitted changes conflict",
+        message:
+          "Your current changes would be overwritten by restoring this stash. Stash current changes first, then restore?",
+        confirmLabel: "Stash current & restore",
+        cancelLabel: "Cancel",
+      });
+      if (!confirmed) return;
+
+      // Stash current changes, then pop the target stash
+      const savePayload = await client.stashSave(normalizedWorkspaceId, {
+        branch: currentBranchName ?? undefined,
+      });
+      if (savePayload.error) {
+        toast.error(savePayload.error.message);
+        return;
+      }
+      // The stash we want shifted up by 1 since we just pushed a new stash
+      const adjustedIndex = stashIndex + 1;
+      const retryPayload = await client.stashPop(normalizedWorkspaceId, adjustedIndex);
+      if (retryPayload.error) {
+        toast.error(retryPayload.error.message);
+      } else {
+        toast.show("Stashed changes restored");
+      }
       await invalidateStashAndCheckout();
-      toast.show("Stashed changes restored");
     },
-    onError: (error) => {
-      toast.error(error instanceof Error ? error.message : "Failed to restore stash");
-    },
+    [client, currentBranchName, invalidateStashAndCheckout, normalizedWorkspaceId, toast],
+  );
+
+  const stashPopMutation = useMutation({
+    mutationFn: restoreStash,
   });
 
   const stashDropMutation = useMutation({
@@ -2231,7 +2273,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                           {workspaceHeader.title}
                         </Text>
                       )}
-                      {hasStashes ? (
+                      {hasCurrentBranchStashes ? (
                         <DropdownMenu>
                           <DropdownMenuTrigger
                             testID="workspace-header-stash-trigger"
@@ -2240,7 +2282,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                               (hovered || pressed) && styles.stashIndicatorHovered,
                             ]}
                             accessibilityRole="button"
-                            accessibilityLabel={`${allStashes.length} stashed change${allStashes.length === 1 ? "" : "s"}`}
+                            accessibilityLabel={`${currentBranchStashes.length} stashed change${currentBranchStashes.length === 1 ? "" : "s"}`}
                           >
                             {({ hovered }) => (
                               <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
@@ -2257,22 +2299,24 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                                   </View>
                                 </TooltipTrigger>
                                 <TooltipContent>
-                                  {allStashes.length} stash{allStashes.length === 1 ? "" : "es"}
+                                  {currentBranchStashes.length} stash{currentBranchStashes.length === 1 ? "" : "es"}
                                 </TooltipContent>
                               </Tooltip>
                             )}
                           </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start" width={300}>
-                            {allStashes.map((stash) => (
+                          <DropdownMenuContent align="start" width={240}>
+                            {currentBranchStashes.map((stash, idx) => (
                               <View key={stash.index}>
-                                <View style={styles.stashEntryHeader}>
-                                  <Text
-                                    style={styles.stashEntryBranch}
-                                    numberOfLines={1}
-                                  >
-                                    {stash.branch ?? "unnamed"}
-                                  </Text>
-                                </View>
+                                {currentBranchStashes.length > 1 ? (
+                                  <View style={styles.stashEntryHeader}>
+                                    <Text
+                                      style={styles.stashEntryBranch}
+                                      numberOfLines={1}
+                                    >
+                                      Stash {idx + 1}
+                                    </Text>
+                                  </View>
+                                ) : null}
                                 <DropdownMenuItem
                                   leading={
                                     <Eye size={14} color={theme.colors.foregroundMuted} />
@@ -2298,7 +2342,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                                     void (async () => {
                                       const confirmed = await confirmDialog({
                                         title: "Discard stash?",
-                                        message: `The stashed changes for "${stash.branch ?? "unnamed"}" will be permanently deleted.`,
+                                        message: "The stashed changes will be permanently deleted.",
                                         confirmLabel: "Discard",
                                         destructive: true,
                                       });
@@ -2311,7 +2355,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                                 >
                                   Discard
                                 </DropdownMenuItem>
-                                {stash.index < allStashes[allStashes.length - 1]!.index ? (
+                                {idx < currentBranchStashes.length - 1 ? (
                                   <DropdownMenuSeparator />
                                 ) : null}
                               </View>
@@ -2974,7 +3018,7 @@ const styles = StyleSheet.create((theme) => ({
   },
   stashPreviewLineRemove: {
     backgroundColor: "rgba(239,68,68,0.12)",
-    color: theme.colors.palette.red[400],
+    color: theme.colors.palette.red[500],
   },
   stashPreviewLineHeader: {
     color: theme.colors.foregroundMuted,

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -20,7 +20,6 @@ import {
   Copy,
   Ellipsis,
   EllipsisVertical,
-  GitBranch,
   PanelRight,
   RotateCw,
   SquarePen,
@@ -35,7 +34,8 @@ import invariant from "tiny-invariant";
 import { SidebarMenuToggle } from "@/components/headers/menu-header";
 import { HeaderToggleButton } from "@/components/headers/header-toggle-button";
 import { ScreenHeader } from "@/components/headers/screen-header";
-import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/combobox";
+import { BranchSwitcher } from "@/components/branch-switcher";
+import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
 import { Shortcut } from "@/components/ui/shortcut";
 import {
   DropdownMenu,
@@ -81,6 +81,7 @@ import type { ListTerminalsResponse } from "@server/shared/messages";
 import { upsertTerminalListEntry } from "@/utils/terminal-list";
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { useArchiveAgent } from "@/hooks/use-archive-agent";
+import { useBranchSwitcher } from "@/hooks/use-branch-switcher";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import { buildProviderCommand } from "@/utils/provider-command-templates";
 import { generateDraftId } from "@/stores/draft-keys";
@@ -761,134 +762,22 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
       ? trimNonEmpty(checkoutQuery.data.currentBranch)
       : null;
 
-  // Branch switcher state
-  const [isBranchSwitcherOpen, setIsBranchSwitcherOpen] = useState(false);
-  const branchSwitcherAnchorRef = useRef<View>(null);
-
-  const branchSuggestionsQuery = useQuery({
-    queryKey: ["branchSuggestions", normalizedServerId, normalizedWorkspaceId],
-    queryFn: async () => {
-      if (!client) {
-        throw new Error("Daemon client unavailable");
-      }
-      const payload = await client.getBranchSuggestions({
-        cwd: normalizedWorkspaceId,
-        limit: 200,
-      });
-      if (payload.error) {
-        throw new Error(payload.error);
-      }
-      return payload.branches ?? [];
-    },
-    enabled: isBranchSwitcherOpen && isGitCheckout && Boolean(client) && isConnected,
-    retry: false,
-    staleTime: 15_000,
+  const {
+    branchOptions,
+    isOpen: isBranchSwitcherOpen,
+    setIsOpen: setIsBranchSwitcherOpen,
+    handleBranchSelect,
+    invalidateStashAndCheckout,
+  } = useBranchSwitcher({
+    client,
+    normalizedServerId,
+    normalizedWorkspaceId,
+    currentBranchName,
+    isGitCheckout,
+    isConnected,
+    toast,
+    queryClient,
   });
-
-  const branchOptions = useMemo<ComboboxOption[]>(() => {
-    const branches = branchSuggestionsQuery.data ?? [];
-    return branches.map((name) => ({ id: name, label: name }));
-  }, [branchSuggestionsQuery.data]);
-
-  const stashListQueryKey = useMemo(
-    () => ["stashList", normalizedServerId, normalizedWorkspaceId] as const,
-    [normalizedServerId, normalizedWorkspaceId],
-  );
-
-  const invalidateStashAndCheckout = useCallback(async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: stashListQueryKey }),
-      queryClient.invalidateQueries({
-        queryKey: checkoutStatusQueryKey(normalizedServerId, normalizedWorkspaceId),
-      }),
-    ]);
-  }, [queryClient, stashListQueryKey, normalizedServerId, normalizedWorkspaceId]);
-
-  // ---- Branch switch with stash-awareness ----
-
-  const stashAndSwitch = useCallback(
-    async (branchId: string) => {
-      if (!client) return;
-      const shouldStash = await confirmDialog({
-        title: "Uncommitted changes",
-        message:
-          "You have uncommitted changes. Stash them before switching branches?",
-        confirmLabel: "Stash & Switch",
-        cancelLabel: "Cancel",
-      });
-      if (!shouldStash) return;
-
-      try {
-        const stashPayload = await client.stashSave(normalizedWorkspaceId, {
-          branch: currentBranchName ?? undefined,
-        });
-        if (stashPayload.error) {
-          toast.error(stashPayload.error.message);
-          return;
-        }
-        await invalidateStashAndCheckout();
-        const switchPayload = await client.checkoutSwitchBranch(normalizedWorkspaceId, branchId);
-        if (switchPayload.error) {
-          toast.error(switchPayload.error.message);
-          return;
-        }
-        await invalidateStashAndCheckout();
-      } catch (err) {
-        toast.error(err instanceof Error ? err.message : "Failed to stash changes");
-      }
-    },
-    [client, currentBranchName, invalidateStashAndCheckout, normalizedWorkspaceId, toast],
-  );
-
-  const handleBranchSelect = useCallback(
-    (branchId: string) => {
-      if (branchId === currentBranchName) return;
-
-      void (async () => {
-        if (!client) return;
-        try {
-          const payload = await client.checkoutSwitchBranch(normalizedWorkspaceId, branchId);
-          if (payload.error) {
-            // If the error is about uncommitted changes, offer the stash dialog
-            if (payload.error.message.toLowerCase().includes("uncommitted")) {
-              await stashAndSwitch(branchId);
-              return;
-            }
-            toast.error(payload.error.message);
-            return;
-          }
-          // Success — refresh and check for stashes on the target branch
-          await invalidateStashAndCheckout();
-          try {
-            const stashPayload = await client.stashList(normalizedWorkspaceId, { paseoOnly: true });
-            const targetStash = stashPayload.entries.find((e) => e.branch === branchId);
-            if (targetStash) {
-              const shouldRestore = await confirmDialog({
-                title: "Restore stashed changes?",
-                message: "This branch has stashed changes from a previous session. Would you like to restore them?",
-                confirmLabel: "Restore",
-                cancelLabel: "Later",
-              });
-              if (shouldRestore) {
-                const popPayload = await client.stashPop(normalizedWorkspaceId, targetStash.index);
-                if (popPayload.error) {
-                  toast.error(popPayload.error.message);
-                } else {
-                  toast.show("Stashed changes restored");
-                }
-                await invalidateStashAndCheckout();
-              }
-            }
-          } catch {
-            // Non-critical — user can still restore on next branch switch
-          }
-        } catch (err) {
-          toast.error(err instanceof Error ? err.message : "Failed to switch branch");
-        }
-      })();
-    },
-    [client, currentBranchName, invalidateStashAndCheckout, normalizedWorkspaceId, stashAndSwitch, toast],
-  );
 
   const mobileView = usePanelStore((state) => state.mobileView);
   const desktopFileExplorerOpen = usePanelStore((state) => state.desktop.fileExplorerOpen);
@@ -2079,75 +1968,14 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                     </>
                   ) : (
                     <>
-                      {currentBranchName ? (
-                        <View ref={branchSwitcherAnchorRef} collapsable={false}>
-                          <Pressable
-                            testID="workspace-header-branch-switcher"
-                            onPress={() => setIsBranchSwitcherOpen(true)}
-                            style={({ hovered, pressed }) => [
-                              styles.branchSwitcherTrigger,
-                              (hovered || pressed) && styles.branchSwitcherTriggerHovered,
-                            ]}
-                            accessibilityRole="button"
-                            accessibilityLabel={`Current branch: ${currentBranchName}. Press to switch branch.`}
-                          >
-                            <GitBranch
-                              size={14}
-                              color={theme.colors.foregroundMuted}
-                            />
-                            <Text
-                              testID="workspace-header-title"
-                              style={styles.headerTitle}
-                              numberOfLines={1}
-                            >
-                              {workspaceHeader.title}
-                            </Text>
-                            <ChevronDown
-                              size={12}
-                              color={theme.colors.foregroundMuted}
-                            />
-                          </Pressable>
-                          <Combobox
-                            options={branchOptions}
-                            value={currentBranchName ?? ""}
-                            onSelect={handleBranchSelect}
-                            searchable
-                            placeholder="Switch branch..."
-                            searchPlaceholder="Filter branches..."
-                            emptyText="No branches found."
-                            title="Switch branch"
-                            open={isBranchSwitcherOpen}
-                            onOpenChange={setIsBranchSwitcherOpen}
-                            anchorRef={branchSwitcherAnchorRef}
-                            desktopPlacement="bottom-start"
-                            desktopPreventInitialFlash
-                            desktopMinWidth={280}
-                            renderOption={({ option, selected, active, onPress }) => (
-                              <ComboboxItem
-                                key={option.id}
-                                label={option.label}
-                                selected={selected}
-                                active={active}
-                                onPress={onPress}
-                                leadingSlot={
-                                  <GitBranch
-                                    size={14}
-                                    color={theme.colors.foregroundMuted}
-                                  />
-                                }
-                              />
-                            )}
-                          />
-                        </View>
-                      ) : (
-                        <Text
-                          testID="workspace-header-title"
-                          style={styles.headerTitle}
-                          numberOfLines={1}
-                        >
-                          {workspaceHeader.title}
-                        </Text>
-                      )}
+                      <BranchSwitcher
+                        currentBranchName={currentBranchName}
+                        title={workspaceHeader.title}
+                        branchOptions={branchOptions}
+                        isOpen={isBranchSwitcherOpen}
+                        onOpenChange={setIsBranchSwitcherOpen}
+                        onBranchSelect={handleBranchSelect}
+                      />
                       <Text
                         testID="workspace-header-subtitle"
                         style={styles.headerProjectTitle}
@@ -2516,19 +2344,6 @@ const styles = StyleSheet.create((theme) => ({
     paddingVertical: theme.spacing[2],
     paddingHorizontal: theme.spacing[2],
     borderRadius: theme.borderRadius.lg,
-  },
-  branchSwitcherTrigger: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[1],
-    paddingVertical: theme.spacing[1],
-    paddingHorizontal: theme.spacing[2],
-    borderRadius: theme.borderRadius.md,
-    flexShrink: 1,
-    minWidth: 0,
-  },
-  branchSwitcherTriggerHovered: {
-    backgroundColor: theme.colors.surface1,
   },
   sourceControlButton: {
     flexDirection: "row",

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -123,6 +123,7 @@ import {
 } from "@/screens/workspace/workspace-bulk-close";
 import { findAdjacentPane } from "@/utils/split-navigation";
 import { useIsCompactFormFactor, supportsDesktopPaneSplits } from "@/constants/layout";
+import { Fonts } from "@/constants/theme";
 
 const TERMINALS_QUERY_STALE_TIME = 5_000;
 const NEW_TAB_AGENT_OPTION_ID = "__new_tab_agent__";
@@ -2942,12 +2943,12 @@ const styles = StyleSheet.create((theme) => ({
     fontSize: theme.fontSize.sm,
     fontWeight: theme.fontWeight.medium,
     color: theme.colors.foreground,
-    fontFamily: theme.fontFamily.mono,
+    fontFamily: Fonts.mono,
     flex: 1,
   },
   stashPreviewFileStats: {
     fontSize: theme.fontSize.xs,
-    fontFamily: theme.fontFamily.mono,
+    fontFamily: Fonts.mono,
     marginLeft: theme.spacing[2],
   },
   stashPreviewBinaryLabel: {
@@ -2962,7 +2963,7 @@ const styles = StyleSheet.create((theme) => ({
   },
   stashPreviewLine: {
     fontSize: theme.fontSize.xs,
-    fontFamily: theme.fontFamily.mono,
+    fontFamily: Fonts.mono,
     color: theme.colors.foreground,
     paddingHorizontal: theme.spacing[2],
     paddingVertical: 1,

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -40,7 +40,7 @@ import invariant from "tiny-invariant";
 import { SidebarMenuToggle } from "@/components/headers/menu-header";
 import { HeaderToggleButton } from "@/components/headers/header-toggle-button";
 import { ScreenHeader } from "@/components/headers/screen-header";
-import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
+import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/combobox";
 import { Shortcut } from "@/components/ui/shortcut";
 import {
   DropdownMenu,
@@ -769,30 +769,17 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
 
   // Branch switcher state
   const [isBranchSwitcherOpen, setIsBranchSwitcherOpen] = useState(false);
-  const [branchSearchQuery, setBranchSearchQuery] = useState("");
-  const [debouncedBranchSearchQuery, setDebouncedBranchSearchQuery] = useState("");
   const branchSwitcherAnchorRef = useRef<View>(null);
-  useEffect(() => {
-    const trimmed = branchSearchQuery.trim();
-    const timer = setTimeout(() => setDebouncedBranchSearchQuery(trimmed), 180);
-    return () => clearTimeout(timer);
-  }, [branchSearchQuery]);
 
   const branchSuggestionsQuery = useQuery({
-    queryKey: [
-      "branchSuggestions",
-      normalizedServerId,
-      normalizedWorkspaceId,
-      debouncedBranchSearchQuery,
-    ],
+    queryKey: ["branchSuggestions", normalizedServerId, normalizedWorkspaceId],
     queryFn: async () => {
       if (!client) {
         throw new Error("Daemon client unavailable");
       }
       const payload = await client.getBranchSuggestions({
         cwd: normalizedWorkspaceId,
-        query: debouncedBranchSearchQuery || undefined,
-        limit: 50,
+        limit: 200,
       });
       if (payload.error) {
         throw new Error(payload.error);
@@ -2250,7 +2237,6 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                             options={branchOptions}
                             value={currentBranchName ?? ""}
                             onSelect={handleBranchSelect}
-                            onSearchQueryChange={setBranchSearchQuery}
                             searchable
                             placeholder="Switch branch..."
                             searchPlaceholder="Filter branches..."
@@ -2262,6 +2248,21 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                             desktopPlacement="bottom-start"
                             desktopPreventInitialFlash
                             desktopMinWidth={280}
+                            renderOption={({ option, selected, active, onPress }) => (
+                              <ComboboxItem
+                                key={option.id}
+                                label={option.label}
+                                selected={selected}
+                                active={active}
+                                onPress={onPress}
+                                leadingSlot={
+                                  <GitBranch
+                                    size={14}
+                                    color={theme.colors.foregroundMuted}
+                                  />
+                                }
+                              />
+                            )}
                           />
                         </View>
                       ) : (

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -5,10 +5,8 @@ import {
   ActivityIndicator,
   BackHandler,
   Keyboard,
-  Modal,
   Platform,
   Pressable,
-  ScrollView,
   Text,
   View,
 } from "react-native";
@@ -22,10 +20,7 @@ import {
   Copy,
   Ellipsis,
   EllipsisVertical,
-  Eye,
   GitBranch,
-  Package,
-  Trash2,
   PanelRight,
   RotateCw,
   SquarePen,
@@ -82,7 +77,7 @@ import {
   checkoutStatusQueryKey,
   type CheckoutStatusPayload,
 } from "@/hooks/use-checkout-status-query";
-import type { ListTerminalsResponse, StashEntry } from "@server/shared/messages";
+import type { ListTerminalsResponse } from "@server/shared/messages";
 import { upsertTerminalListEntry } from "@/utils/terminal-list";
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { useArchiveAgent } from "@/hooks/use-archive-agent";
@@ -123,7 +118,6 @@ import {
 } from "@/screens/workspace/workspace-bulk-close";
 import { findAdjacentPane } from "@/utils/split-navigation";
 import { useIsCompactFormFactor, supportsDesktopPaneSplits } from "@/constants/layout";
-import { Fonts } from "@/constants/theme";
 
 const TERMINALS_QUERY_STALE_TIME = 5_000;
 const NEW_TAB_AGENT_OPTION_ID = "__new_tab_agent__";
@@ -796,63 +790,10 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
     return branches.map((name) => ({ id: name, label: name }));
   }, [branchSuggestionsQuery.data]);
 
-  // ---- Stash queries & mutations ----
-
   const stashListQueryKey = useMemo(
     () => ["stashList", normalizedServerId, normalizedWorkspaceId] as const,
     [normalizedServerId, normalizedWorkspaceId],
   );
-
-  const stashListQuery = useQuery({
-    queryKey: stashListQueryKey,
-    queryFn: async () => {
-      if (!client) {
-        throw new Error("Daemon client unavailable");
-      }
-      const payload = await client.stashList(normalizedWorkspaceId, { paseoOnly: true });
-      if (payload.error) {
-        throw new Error(payload.error.message);
-      }
-      return payload.entries;
-    },
-    enabled: isGitCheckout && Boolean(client) && isConnected,
-    staleTime: 30_000,
-  });
-
-  const allStashes = stashListQuery.data ?? [];
-
-  // Only show stashes for the current branch in the dropdown
-  const currentBranchStashes = useMemo(
-    () =>
-      currentBranchName
-        ? allStashes.filter((e) => e.branch === currentBranchName)
-        : [],
-    [allStashes, currentBranchName],
-  );
-  const hasCurrentBranchStashes = currentBranchStashes.length > 0;
-
-  // Used by the post-switch restore prompt
-  const currentBranchStash = currentBranchStashes[0] ?? null;
-
-  // Stash diff preview state
-  const [previewStashIndex, setPreviewStashIndex] = useState<number | null>(null);
-  const isStashPreviewOpen = previewStashIndex !== null;
-
-  const stashShowQuery = useQuery({
-    queryKey: ["stashShow", normalizedServerId, normalizedWorkspaceId, previewStashIndex],
-    queryFn: async () => {
-      if (!client || previewStashIndex === null) {
-        throw new Error("Daemon client unavailable");
-      }
-      const payload = await client.stashShow(normalizedWorkspaceId, previewStashIndex);
-      if (payload.error) {
-        throw new Error(payload.error.message);
-      }
-      return payload.files;
-    },
-    enabled: isStashPreviewOpen && Boolean(client) && isConnected,
-    staleTime: 60_000,
-  });
 
   const invalidateStashAndCheckout = useCallback(async () => {
     await Promise.all([
@@ -862,73 +803,6 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
       }),
     ]);
   }, [queryClient, stashListQueryKey, normalizedServerId, normalizedWorkspaceId]);
-
-  const restoreStash = useCallback(
-    async (stashIndex: number) => {
-      if (!client) return;
-      const payload = await client.stashPop(normalizedWorkspaceId, stashIndex);
-      if (!payload.error) {
-        await invalidateStashAndCheckout();
-        toast.show("Stashed changes restored");
-        return;
-      }
-
-      const isOverwrite = payload.error.message.toLowerCase().includes("overwritten");
-      if (!isOverwrite) {
-        toast.error(payload.error.message);
-        return;
-      }
-
-      // Conflict: current changes would be overwritten
-      const confirmed = await confirmDialog({
-        title: "Uncommitted changes conflict",
-        message:
-          "Your current changes would be overwritten by restoring this stash. Stash current changes first, then restore?",
-        confirmLabel: "Stash current & restore",
-        cancelLabel: "Cancel",
-      });
-      if (!confirmed) return;
-
-      // Stash current changes, then pop the target stash
-      const savePayload = await client.stashSave(normalizedWorkspaceId, {
-        branch: currentBranchName ?? undefined,
-      });
-      if (savePayload.error) {
-        toast.error(savePayload.error.message);
-        return;
-      }
-      // The stash we want shifted up by 1 since we just pushed a new stash
-      const adjustedIndex = stashIndex + 1;
-      const retryPayload = await client.stashPop(normalizedWorkspaceId, adjustedIndex);
-      if (retryPayload.error) {
-        toast.error(retryPayload.error.message);
-      } else {
-        toast.show("Stashed changes restored");
-      }
-      await invalidateStashAndCheckout();
-    },
-    [client, currentBranchName, invalidateStashAndCheckout, normalizedWorkspaceId, toast],
-  );
-
-  const stashPopMutation = useMutation({
-    mutationFn: restoreStash,
-  });
-
-  const stashDropMutation = useMutation({
-    mutationFn: async (stashIndex: number) => {
-      if (!client) throw new Error("Daemon client unavailable");
-      const payload = await client.stashDrop(normalizedWorkspaceId, stashIndex);
-      if (payload.error) throw new Error(payload.error.message);
-      return payload;
-    },
-    onSuccess: async () => {
-      await invalidateStashAndCheckout();
-      toast.show("Stash discarded");
-    },
-    onError: (error) => {
-      toast.error(error instanceof Error ? error.message : "Failed to discard stash");
-    },
-  });
 
   // ---- Branch switch with stash-awareness ----
 
@@ -1006,7 +880,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
               }
             }
           } catch {
-            // Non-critical — user can still restore manually via stash indicator
+            // Non-critical — user can still restore on next branch switch
           }
         } catch (err) {
           toast.error(err instanceof Error ? err.message : "Failed to switch branch");
@@ -2274,96 +2148,6 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                           {workspaceHeader.title}
                         </Text>
                       )}
-                      {hasCurrentBranchStashes ? (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger
-                            testID="workspace-header-stash-trigger"
-                            style={({ hovered, pressed }) => [
-                              styles.stashIndicator,
-                              (hovered || pressed) && styles.stashIndicatorHovered,
-                            ]}
-                            accessibilityRole="button"
-                            accessibilityLabel={`${currentBranchStashes.length} stashed change${currentBranchStashes.length === 1 ? "" : "s"}`}
-                          >
-                            {({ hovered }) => (
-                              <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
-                                <TooltipTrigger asChild>
-                                  <View style={styles.stashIndicatorInner}>
-                                    <Package
-                                      size={14}
-                                      color={
-                                        hovered
-                                          ? theme.colors.foreground
-                                          : theme.colors.palette.amber[500]
-                                      }
-                                    />
-                                  </View>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  {currentBranchStashes.length} stash{currentBranchStashes.length === 1 ? "" : "es"}
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start" width={240}>
-                            {currentBranchStashes.map((stash, idx) => (
-                              <View key={stash.index}>
-                                {currentBranchStashes.length > 1 ? (
-                                  <View style={styles.stashEntryHeader}>
-                                    <Text
-                                      style={styles.stashEntryBranch}
-                                      numberOfLines={1}
-                                    >
-                                      Stash {idx + 1}
-                                    </Text>
-                                  </View>
-                                ) : null}
-                                <DropdownMenuItem
-                                  leading={
-                                    <Eye size={14} color={theme.colors.foregroundMuted} />
-                                  }
-                                  onSelect={() => setPreviewStashIndex(stash.index)}
-                                >
-                                  Preview
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                  leading={
-                                    <Package size={14} color={theme.colors.foregroundMuted} />
-                                  }
-                                  onSelect={() => stashPopMutation.mutate(stash.index)}
-                                  disabled={stashPopMutation.isPending}
-                                >
-                                  Restore
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                  leading={
-                                    <Trash2 size={14} color={theme.colors.foregroundMuted} />
-                                  }
-                                  onSelect={() => {
-                                    void (async () => {
-                                      const confirmed = await confirmDialog({
-                                        title: "Discard stash?",
-                                        message: "The stashed changes will be permanently deleted.",
-                                        confirmLabel: "Discard",
-                                        destructive: true,
-                                      });
-                                      if (confirmed) {
-                                        stashDropMutation.mutate(stash.index);
-                                      }
-                                    })();
-                                  }}
-                                  disabled={stashDropMutation.isPending}
-                                >
-                                  Discard
-                                </DropdownMenuItem>
-                                {idx < currentBranchStashes.length - 1 ? (
-                                  <DropdownMenuSeparator />
-                                ) : null}
-                              </View>
-                            ))}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      ) : null}
                       <Text
                         testID="workspace-header-subtitle"
                         style={styles.headerProjectTitle}
@@ -2664,141 +2448,6 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
           />
         )}
       </View>
-      {isStashPreviewOpen ? (
-        <Modal
-          transparent
-          animationType="none"
-          visible
-          onRequestClose={() => setPreviewStashIndex(null)}
-        >
-          <Pressable
-            style={styles.stashPreviewBackdrop}
-            onPress={() => setPreviewStashIndex(null)}
-          />
-          <View style={styles.stashPreviewCard}>
-            <View style={styles.stashPreviewHeader}>
-              <Text style={styles.stashPreviewTitle} numberOfLines={1}>
-                Stash preview — {allStashes.find((s) => s.index === previewStashIndex)?.branch ?? "unnamed"}
-              </Text>
-              <Pressable
-                accessibilityLabel="Close"
-                style={styles.stashPreviewCloseButton}
-                onPress={() => setPreviewStashIndex(null)}
-              >
-                <X size={16} color={theme.colors.foregroundMuted} />
-              </Pressable>
-            </View>
-            <ScrollView
-              style={styles.stashPreviewScroll}
-              contentContainerStyle={styles.stashPreviewScrollContent}
-            >
-              {stashShowQuery.isLoading ? (
-                <View style={styles.stashPreviewLoading}>
-                  <ActivityIndicator size="small" color={theme.colors.foregroundMuted} />
-                  <Text style={styles.stashPreviewLoadingText}>Loading diff...</Text>
-                </View>
-              ) : stashShowQuery.isError ? (
-                <Text style={styles.stashPreviewErrorText}>
-                  Failed to load stash diff.
-                </Text>
-              ) : stashShowQuery.data && stashShowQuery.data.length > 0 ? (
-                stashShowQuery.data.map((file) => (
-                  <View key={file.path} style={styles.stashPreviewFile}>
-                    <View style={styles.stashPreviewFileHeader}>
-                      <Text style={styles.stashPreviewFilePath} numberOfLines={1}>
-                        {file.path}
-                      </Text>
-                      <Text style={styles.stashPreviewFileStats}>
-                        {file.additions > 0 ? (
-                          <Text style={{ color: theme.colors.palette.green[500] }}>
-                            +{file.additions}
-                          </Text>
-                        ) : null}
-                        {file.additions > 0 && file.deletions > 0 ? " " : null}
-                        {file.deletions > 0 ? (
-                          <Text style={{ color: theme.colors.palette.red[500] }}>
-                            -{file.deletions}
-                          </Text>
-                        ) : null}
-                      </Text>
-                    </View>
-                    {file.status === "binary" ? (
-                      <Text style={styles.stashPreviewBinaryLabel}>Binary file</Text>
-                    ) : file.status === "too_large" ? (
-                      <Text style={styles.stashPreviewBinaryLabel}>File too large to preview</Text>
-                    ) : (
-                      file.hunks.map((hunk, hunkIdx) => (
-                        <View key={hunkIdx} style={styles.stashPreviewHunk}>
-                          {hunk.lines.map((line, lineIdx) => (
-                            <Text
-                              key={lineIdx}
-                              style={[
-                                styles.stashPreviewLine,
-                                line.type === "add" && styles.stashPreviewLineAdd,
-                                line.type === "remove" && styles.stashPreviewLineRemove,
-                                line.type === "header" && styles.stashPreviewLineHeader,
-                              ]}
-                              numberOfLines={1}
-                            >
-                              {line.type === "add"
-                                ? "+"
-                                : line.type === "remove"
-                                  ? "-"
-                                  : " "}
-                              {line.content}
-                            </Text>
-                          ))}
-                        </View>
-                      ))
-                    )}
-                  </View>
-                ))
-              ) : (
-                <Text style={styles.stashPreviewErrorText}>No changes in this stash.</Text>
-              )}
-            </ScrollView>
-            <View style={styles.stashPreviewActions}>
-              <Pressable
-                style={({ hovered }) => [
-                  styles.stashPreviewActionButton,
-                  hovered && styles.stashPreviewActionButtonHovered,
-                ]}
-                onPress={() => {
-                  stashPopMutation.mutate(previewStashIndex);
-                  setPreviewStashIndex(null);
-                }}
-              >
-                <Text style={styles.stashPreviewActionText}>Restore</Text>
-              </Pressable>
-              <Pressable
-                style={({ hovered }) => [
-                  styles.stashPreviewActionButton,
-                  styles.stashPreviewActionButtonDestructive,
-                  hovered && styles.stashPreviewActionButtonDestructiveHovered,
-                ]}
-                onPress={() => {
-                  void (async () => {
-                    const confirmed = await confirmDialog({
-                      title: "Discard stash?",
-                      message: "The stashed changes will be permanently deleted.",
-                      confirmLabel: "Discard",
-                      destructive: true,
-                    });
-                    if (confirmed) {
-                      stashDropMutation.mutate(previewStashIndex);
-                      setPreviewStashIndex(null);
-                    }
-                  })();
-                }}
-              >
-                <Text style={[styles.stashPreviewActionText, styles.stashPreviewActionTextDestructive]}>
-                  Discard
-                </Text>
-              </Pressable>
-            </View>
-          </View>
-        </Modal>
-      ) : null}
     </View>
   );
 }
@@ -2880,183 +2529,6 @@ const styles = StyleSheet.create((theme) => ({
   },
   branchSwitcherTriggerHovered: {
     backgroundColor: theme.colors.surface1,
-  },
-  stashIndicator: {
-    paddingVertical: theme.spacing[1],
-    paddingHorizontal: theme.spacing[1],
-    borderRadius: theme.borderRadius.md,
-  },
-  stashIndicatorHovered: {
-    backgroundColor: theme.colors.surface1,
-  },
-  stashIndicatorInner: {
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  stashEntryHeader: {
-    paddingHorizontal: theme.spacing[3],
-    paddingVertical: theme.spacing[1],
-    paddingTop: theme.spacing[2],
-  },
-  stashEntryBranch: {
-    fontSize: theme.fontSize.xs,
-    fontWeight: theme.fontWeight.medium,
-    color: theme.colors.foregroundMuted,
-  },
-  stashPreviewBackdrop: {
-    position: "absolute",
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
-    backgroundColor: "rgba(0,0,0,0.55)",
-  },
-  stashPreviewCard: {
-    position: "absolute",
-    top: "5%",
-    left: "10%",
-    right: "10%",
-    bottom: "5%",
-    backgroundColor: theme.colors.surface0,
-    borderRadius: theme.borderRadius.xl,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    overflow: "hidden",
-    ...theme.shadow.lg,
-  },
-  stashPreviewHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingHorizontal: theme.spacing[4],
-    paddingVertical: theme.spacing[3],
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border,
-  },
-  stashPreviewTitle: {
-    fontSize: theme.fontSize.base,
-    fontWeight: theme.fontWeight.medium,
-    color: theme.colors.foreground,
-    flex: 1,
-  },
-  stashPreviewCloseButton: {
-    padding: theme.spacing[2],
-    borderRadius: theme.borderRadius.md,
-  },
-  stashPreviewScroll: {
-    flex: 1,
-    minHeight: 0,
-  },
-  stashPreviewScrollContent: {
-    padding: theme.spacing[3],
-    gap: theme.spacing[3],
-  },
-  stashPreviewLoading: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: theme.spacing[2],
-    padding: theme.spacing[6],
-  },
-  stashPreviewLoadingText: {
-    fontSize: theme.fontSize.sm,
-    color: theme.colors.foregroundMuted,
-  },
-  stashPreviewErrorText: {
-    fontSize: theme.fontSize.sm,
-    color: theme.colors.foregroundMuted,
-    padding: theme.spacing[4],
-    textAlign: "center",
-  },
-  stashPreviewFile: {
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    borderRadius: theme.borderRadius.md,
-    overflow: "hidden",
-  },
-  stashPreviewFileHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingHorizontal: theme.spacing[3],
-    paddingVertical: theme.spacing[2],
-    backgroundColor: theme.colors.surface1,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border,
-  },
-  stashPreviewFilePath: {
-    fontSize: theme.fontSize.sm,
-    fontWeight: theme.fontWeight.medium,
-    color: theme.colors.foreground,
-    fontFamily: Fonts.mono,
-    flex: 1,
-  },
-  stashPreviewFileStats: {
-    fontSize: theme.fontSize.xs,
-    fontFamily: Fonts.mono,
-    marginLeft: theme.spacing[2],
-  },
-  stashPreviewBinaryLabel: {
-    fontSize: theme.fontSize.xs,
-    color: theme.colors.foregroundMuted,
-    padding: theme.spacing[3],
-    fontStyle: "italic",
-  },
-  stashPreviewHunk: {
-    borderTopWidth: 1,
-    borderTopColor: theme.colors.border,
-  },
-  stashPreviewLine: {
-    fontSize: theme.fontSize.xs,
-    fontFamily: Fonts.mono,
-    color: theme.colors.foreground,
-    paddingHorizontal: theme.spacing[2],
-    paddingVertical: 1,
-  },
-  stashPreviewLineAdd: {
-    backgroundColor: "rgba(34,197,94,0.12)",
-    color: theme.colors.palette.green[400],
-  },
-  stashPreviewLineRemove: {
-    backgroundColor: "rgba(239,68,68,0.12)",
-    color: theme.colors.palette.red[500],
-  },
-  stashPreviewLineHeader: {
-    color: theme.colors.foregroundMuted,
-    backgroundColor: theme.colors.surface1,
-    fontStyle: "italic",
-  },
-  stashPreviewActions: {
-    flexDirection: "row",
-    justifyContent: "flex-end",
-    gap: theme.spacing[2],
-    paddingHorizontal: theme.spacing[4],
-    paddingVertical: theme.spacing[3],
-    borderTopWidth: 1,
-    borderTopColor: theme.colors.border,
-  },
-  stashPreviewActionButton: {
-    paddingHorizontal: theme.spacing[4],
-    paddingVertical: theme.spacing[2],
-    borderRadius: theme.borderRadius.md,
-    backgroundColor: theme.colors.surface1,
-  },
-  stashPreviewActionButtonHovered: {
-    backgroundColor: theme.colors.surface2,
-  },
-  stashPreviewActionButtonDestructive: {
-    backgroundColor: "transparent",
-  },
-  stashPreviewActionButtonDestructiveHovered: {
-    backgroundColor: "rgba(239,68,68,0.1)",
-  },
-  stashPreviewActionText: {
-    fontSize: theme.fontSize.sm,
-    fontWeight: theme.fontWeight.medium,
-    color: theme.colors.foreground,
-  },
-  stashPreviewActionTextDestructive: {
-    color: theme.colors.palette.red[500],
   },
   sourceControlButton: {
     flexDirection: "row",

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -28,6 +28,11 @@ import type {
   CheckoutPushResponse,
   CheckoutPrCreateResponse,
   CheckoutPrStatusResponse,
+  CheckoutSwitchBranchResponse,
+  StashSaveResponse,
+  StashPopResponse,
+  StashDropResponse,
+  StashListResponse,
   ValidateBranchResponse,
   BranchSuggestionsResponse,
   DirectorySuggestionsResponse,
@@ -217,6 +222,11 @@ type CheckoutMergeFromBasePayload = CheckoutMergeFromBaseResponse["payload"];
 type CheckoutPushPayload = CheckoutPushResponse["payload"];
 type CheckoutPrCreatePayload = CheckoutPrCreateResponse["payload"];
 type CheckoutPrStatusPayload = CheckoutPrStatusResponse["payload"];
+type CheckoutSwitchBranchPayload = CheckoutSwitchBranchResponse["payload"];
+type StashSavePayload = StashSaveResponse["payload"];
+type StashPopPayload = StashPopResponse["payload"];
+type StashDropPayload = StashDropResponse["payload"];
+type StashListPayload = StashListResponse["payload"];
 type ValidateBranchPayload = ValidateBranchResponse["payload"];
 type BranchSuggestionsPayload = BranchSuggestionsResponse["payload"];
 type DirectorySuggestionsPayload = DirectorySuggestionsResponse["payload"];
@@ -2371,6 +2381,91 @@ export class DaemonClient {
       },
       responseType: "checkout_pr_status_response",
       timeout: 60000,
+    });
+  }
+
+  async checkoutSwitchBranch(
+    cwd: string,
+    branch: string,
+    requestId?: string,
+  ): Promise<CheckoutSwitchBranchPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "checkout_switch_branch_request",
+        cwd,
+        branch,
+      },
+      responseType: "checkout_switch_branch_response",
+      timeout: 30000,
+    });
+  }
+
+  async stashSave(
+    cwd: string,
+    options?: { branch?: string },
+    requestId?: string,
+  ): Promise<StashSavePayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "stash_save_request",
+        cwd,
+        branch: options?.branch,
+      },
+      responseType: "stash_save_response",
+      timeout: 30000,
+    });
+  }
+
+  async stashPop(
+    cwd: string,
+    stashIndex: number,
+    requestId?: string,
+  ): Promise<StashPopPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "stash_pop_request",
+        cwd,
+        stashIndex,
+      },
+      responseType: "stash_pop_response",
+      timeout: 30000,
+    });
+  }
+
+  async stashDrop(
+    cwd: string,
+    stashIndex: number,
+    requestId?: string,
+  ): Promise<StashDropPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "stash_drop_request",
+        cwd,
+        stashIndex,
+      },
+      responseType: "stash_drop_response",
+      timeout: 30000,
+    });
+  }
+
+  async stashList(
+    cwd: string,
+    options?: { paseoOnly?: boolean },
+    requestId?: string,
+  ): Promise<StashListPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "stash_list_request",
+        cwd,
+        paseoOnly: options?.paseoOnly,
+      },
+      responseType: "stash_list_response",
+      timeout: 10000,
     });
   }
 

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -33,6 +33,7 @@ import type {
   StashPopResponse,
   StashDropResponse,
   StashListResponse,
+  StashShowResponse,
   ValidateBranchResponse,
   BranchSuggestionsResponse,
   DirectorySuggestionsResponse,
@@ -227,6 +228,7 @@ type StashSavePayload = StashSaveResponse["payload"];
 type StashPopPayload = StashPopResponse["payload"];
 type StashDropPayload = StashDropResponse["payload"];
 type StashListPayload = StashListResponse["payload"];
+type StashShowPayload = StashShowResponse["payload"];
 type ValidateBranchPayload = ValidateBranchResponse["payload"];
 type BranchSuggestionsPayload = BranchSuggestionsResponse["payload"];
 type DirectorySuggestionsPayload = DirectorySuggestionsResponse["payload"];
@@ -2466,6 +2468,23 @@ export class DaemonClient {
       },
       responseType: "stash_list_response",
       timeout: 10000,
+    });
+  }
+
+  async stashShow(
+    cwd: string,
+    stashIndex: number,
+    requestId?: string,
+  ): Promise<StashShowPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "stash_show_request",
+        cwd,
+        stashIndex,
+      },
+      responseType: "stash_show_response",
+      timeout: 30000,
     });
   }
 

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -31,9 +31,7 @@ import type {
   CheckoutSwitchBranchResponse,
   StashSaveResponse,
   StashPopResponse,
-  StashDropResponse,
   StashListResponse,
-  StashShowResponse,
   ValidateBranchResponse,
   BranchSuggestionsResponse,
   DirectorySuggestionsResponse,
@@ -226,9 +224,7 @@ type CheckoutPrStatusPayload = CheckoutPrStatusResponse["payload"];
 type CheckoutSwitchBranchPayload = CheckoutSwitchBranchResponse["payload"];
 type StashSavePayload = StashSaveResponse["payload"];
 type StashPopPayload = StashPopResponse["payload"];
-type StashDropPayload = StashDropResponse["payload"];
 type StashListPayload = StashListResponse["payload"];
-type StashShowPayload = StashShowResponse["payload"];
 type ValidateBranchPayload = ValidateBranchResponse["payload"];
 type BranchSuggestionsPayload = BranchSuggestionsResponse["payload"];
 type DirectorySuggestionsPayload = DirectorySuggestionsResponse["payload"];
@@ -2437,23 +2433,6 @@ export class DaemonClient {
     });
   }
 
-  async stashDrop(
-    cwd: string,
-    stashIndex: number,
-    requestId?: string,
-  ): Promise<StashDropPayload> {
-    return this.sendCorrelatedSessionRequest({
-      requestId,
-      message: {
-        type: "stash_drop_request",
-        cwd,
-        stashIndex,
-      },
-      responseType: "stash_drop_response",
-      timeout: 30000,
-    });
-  }
-
   async stashList(
     cwd: string,
     options?: { paseoOnly?: boolean },
@@ -2468,23 +2447,6 @@ export class DaemonClient {
       },
       responseType: "stash_list_response",
       timeout: 10000,
-    });
-  }
-
-  async stashShow(
-    cwd: string,
-    stashIndex: number,
-    requestId?: string,
-  ): Promise<StashShowPayload> {
-    return this.sendCorrelatedSessionRequest({
-      requestId,
-      message: {
-        type: "stash_show_request",
-        cwd,
-        stashIndex,
-      },
-      responseType: "stash_show_response",
-      timeout: 30000,
     });
   }
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -4456,6 +4456,10 @@ export class Session {
       await this.checkoutExistingBranch(cwd, branch);
       this.checkoutDiffManager.scheduleRefreshForCwd(cwd);
 
+      // Push a workspace_update immediately so the sidebar/header reflect
+      // the new branch name without waiting for the background git watcher.
+      await this.emitWorkspaceUpdateForCwd(cwd);
+
       this.emit({
         type: "checkout_switch_branch_response",
         payload: {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -170,6 +170,7 @@ import {
   toCheckoutError,
 } from "./checkout-git-utils.js";
 import { CheckoutDiffManager } from "./checkout-diff-manager.js";
+import { parseDiff } from "./utils/diff-highlighter.js";
 import type { LocalSpeechModelId } from "./speech/providers/local/models.js";
 import { toResolver, type Resolvable } from "./speech/provider-resolver.js";
 import type { SpeechReadinessSnapshot, SpeechReadinessState } from "./speech/speech-runtime.js";
@@ -1764,6 +1765,10 @@ export class Session {
 
         case "stash_list_request":
           await this.handleStashListRequest(msg);
+          break;
+
+        case "stash_show_request":
+          await this.handleStashShowRequest(msg);
           break;
 
         case "checkout_commit_request":
@@ -4594,6 +4599,28 @@ export class Session {
       this.emit({
         type: "stash_list_response",
         payload: { cwd, entries: [], error: toCheckoutError(error), requestId },
+      });
+    }
+  }
+
+  private async handleStashShowRequest(
+    msg: Extract<SessionInboundMessage, { type: "stash_show_request" }>,
+  ): Promise<void> {
+    const { cwd, stashIndex, requestId } = msg;
+    try {
+      const { stdout } = await execAsync(
+        `git stash show -p --no-color "stash@{${stashIndex}}"`,
+        { cwd, env: READ_ONLY_GIT_ENV, maxBuffer: 4 * 1024 * 1024 },
+      );
+      const files = parseDiff(stdout);
+      this.emit({
+        type: "stash_show_response",
+        payload: { cwd, stashIndex, files, error: null, requestId },
+      });
+    } catch (error) {
+      this.emit({
+        type: "stash_show_response",
+        payload: { cwd, stashIndex, files: [], error: toCheckoutError(error), requestId },
       });
     }
   }

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -4576,9 +4576,10 @@ export class Session {
         const indexMatch = refPart.match(/\{(\d+)\}/);
         if (!indexMatch) continue;
         const index = Number(indexMatch[1]);
-        const isPaseo = subject.startsWith(Session.PASEO_STASH_PREFIX);
+        const prefixIdx = subject.indexOf(Session.PASEO_STASH_PREFIX);
+        const isPaseo = prefixIdx >= 0;
         const branch = isPaseo
-          ? subject.slice(Session.PASEO_STASH_PREFIX.length).trim() || null
+          ? subject.slice(prefixIdx + Session.PASEO_STASH_PREFIX.length).trim() || null
           : null;
 
         if (paseoOnly && !isPaseo) continue;

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1746,6 +1746,26 @@ export class Session {
           this.handleUnsubscribeCheckoutDiffRequest(msg);
           break;
 
+        case "checkout_switch_branch_request":
+          await this.handleCheckoutSwitchBranchRequest(msg);
+          break;
+
+        case "stash_save_request":
+          await this.handleStashSaveRequest(msg);
+          break;
+
+        case "stash_pop_request":
+          await this.handleStashPopRequest(msg);
+          break;
+
+        case "stash_drop_request":
+          await this.handleStashDropRequest(msg);
+          break;
+
+        case "stash_list_request":
+          await this.handleStashListRequest(msg);
+          break;
+
         case "checkout_commit_request":
           await this.handleCheckoutCommitRequest(msg);
           break;
@@ -4425,6 +4445,152 @@ export class Session {
   private handleUnsubscribeCheckoutDiffRequest(msg: UnsubscribeCheckoutDiffRequest): void {
     this.checkoutDiffSubscriptions.get(msg.subscriptionId)?.();
     this.checkoutDiffSubscriptions.delete(msg.subscriptionId);
+  }
+
+  private async handleCheckoutSwitchBranchRequest(
+    msg: Extract<SessionInboundMessage, { type: "checkout_switch_branch_request" }>,
+  ): Promise<void> {
+    const { cwd, branch, requestId } = msg;
+
+    try {
+      await this.checkoutExistingBranch(cwd, branch);
+      this.checkoutDiffManager.scheduleRefreshForCwd(cwd);
+
+      this.emit({
+        type: "checkout_switch_branch_response",
+        payload: {
+          cwd,
+          success: true,
+          branch,
+          error: null,
+          requestId,
+        },
+      });
+    } catch (error) {
+      this.emit({
+        type: "checkout_switch_branch_response",
+        payload: {
+          cwd,
+          success: false,
+          branch,
+          error: toCheckoutError(error),
+          requestId,
+        },
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Stash handlers
+  // ---------------------------------------------------------------------------
+
+  private static readonly PASEO_STASH_PREFIX = "paseo-auto-stash:";
+
+  private async handleStashSaveRequest(
+    msg: Extract<SessionInboundMessage, { type: "stash_save_request" }>,
+  ): Promise<void> {
+    const { cwd, requestId } = msg;
+    try {
+      const branchLabel = msg.branch?.trim() ?? "";
+      const message = branchLabel
+        ? `${Session.PASEO_STASH_PREFIX} ${branchLabel}`
+        : `${Session.PASEO_STASH_PREFIX} unnamed`;
+      await execFileAsync("git", ["stash", "push", "-m", message], { cwd });
+      this.checkoutDiffManager.scheduleRefreshForCwd(cwd);
+      this.emit({
+        type: "stash_save_response",
+        payload: { cwd, success: true, error: null, requestId },
+      });
+    } catch (error) {
+      this.emit({
+        type: "stash_save_response",
+        payload: { cwd, success: false, error: toCheckoutError(error), requestId },
+      });
+    }
+  }
+
+  private async handleStashPopRequest(
+    msg: Extract<SessionInboundMessage, { type: "stash_pop_request" }>,
+  ): Promise<void> {
+    const { cwd, stashIndex, requestId } = msg;
+    try {
+      await execFileAsync("git", ["stash", "pop", `stash@{${stashIndex}}`], { cwd });
+      this.checkoutDiffManager.scheduleRefreshForCwd(cwd);
+      this.emit({
+        type: "stash_pop_response",
+        payload: { cwd, success: true, error: null, requestId },
+      });
+    } catch (error) {
+      this.emit({
+        type: "stash_pop_response",
+        payload: { cwd, success: false, error: toCheckoutError(error), requestId },
+      });
+    }
+  }
+
+  private async handleStashDropRequest(
+    msg: Extract<SessionInboundMessage, { type: "stash_drop_request" }>,
+  ): Promise<void> {
+    const { cwd, stashIndex, requestId } = msg;
+    try {
+      await execFileAsync("git", ["stash", "drop", `stash@{${stashIndex}}`], { cwd });
+      this.emit({
+        type: "stash_drop_response",
+        payload: { cwd, success: true, error: null, requestId },
+      });
+    } catch (error) {
+      this.emit({
+        type: "stash_drop_response",
+        payload: { cwd, success: false, error: toCheckoutError(error), requestId },
+      });
+    }
+  }
+
+  private async handleStashListRequest(
+    msg: Extract<SessionInboundMessage, { type: "stash_list_request" }>,
+  ): Promise<void> {
+    const { cwd, requestId } = msg;
+    const paseoOnly = msg.paseoOnly !== false;
+    try {
+      const { stdout } = await execAsync("git stash list --format=%gd%x00%s", {
+        cwd,
+        env: READ_ONLY_GIT_ENV,
+      });
+      const lines = stdout.trim().split("\n").filter(Boolean);
+      const entries: Array<{
+        index: number;
+        message: string;
+        branch: string | null;
+        isPaseo: boolean;
+      }> = [];
+
+      for (const line of lines) {
+        const sepIdx = line.indexOf("\0");
+        if (sepIdx < 0) continue;
+        const refPart = line.slice(0, sepIdx);
+        const subject = line.slice(sepIdx + 1);
+        const indexMatch = refPart.match(/\{(\d+)\}/);
+        if (!indexMatch) continue;
+        const index = Number(indexMatch[1]);
+        const isPaseo = subject.startsWith(Session.PASEO_STASH_PREFIX);
+        const branch = isPaseo
+          ? subject.slice(Session.PASEO_STASH_PREFIX.length).trim() || null
+          : null;
+
+        if (paseoOnly && !isPaseo) continue;
+        entries.push({ index, message: subject, branch, isPaseo });
+      }
+
+      this.emit({
+        type: "stash_list_response",
+        payload: { cwd, entries, error: null, requestId },
+      });
+    } catch (error) {
+      this.emit({
+        type: "stash_list_response",
+        payload: { cwd, entries: [], error: toCheckoutError(error), requestId },
+      });
+    }
   }
 
   private async handleCheckoutCommitRequest(

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -4504,7 +4504,7 @@ export class Session {
       const message = branchLabel
         ? `${Session.PASEO_STASH_PREFIX} ${branchLabel}`
         : `${Session.PASEO_STASH_PREFIX} unnamed`;
-      await execFileAsync("git", ["stash", "push", "-m", message], { cwd });
+      await execFileAsync("git", ["stash", "push", "--include-untracked", "-m", message], { cwd });
       this.checkoutDiffManager.scheduleRefreshForCwd(cwd);
       this.emit({
         type: "stash_save_response",

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -170,7 +170,6 @@ import {
   toCheckoutError,
 } from "./checkout-git-utils.js";
 import { CheckoutDiffManager } from "./checkout-diff-manager.js";
-import { parseDiff } from "./utils/diff-highlighter.js";
 import type { LocalSpeechModelId } from "./speech/providers/local/models.js";
 import { toResolver, type Resolvable } from "./speech/provider-resolver.js";
 import type { SpeechReadinessSnapshot, SpeechReadinessState } from "./speech/speech-runtime.js";
@@ -1759,16 +1758,8 @@ export class Session {
           await this.handleStashPopRequest(msg);
           break;
 
-        case "stash_drop_request":
-          await this.handleStashDropRequest(msg);
-          break;
-
         case "stash_list_request":
           await this.handleStashListRequest(msg);
-          break;
-
-        case "stash_show_request":
-          await this.handleStashShowRequest(msg);
           break;
 
         case "checkout_commit_request":
@@ -4537,24 +4528,6 @@ export class Session {
     }
   }
 
-  private async handleStashDropRequest(
-    msg: Extract<SessionInboundMessage, { type: "stash_drop_request" }>,
-  ): Promise<void> {
-    const { cwd, stashIndex, requestId } = msg;
-    try {
-      await execFileAsync("git", ["stash", "drop", `stash@{${stashIndex}}`], { cwd });
-      this.emit({
-        type: "stash_drop_response",
-        payload: { cwd, success: true, error: null, requestId },
-      });
-    } catch (error) {
-      this.emit({
-        type: "stash_drop_response",
-        payload: { cwd, success: false, error: toCheckoutError(error), requestId },
-      });
-    }
-  }
-
   private async handleStashListRequest(
     msg: Extract<SessionInboundMessage, { type: "stash_list_request" }>,
   ): Promise<void> {
@@ -4599,28 +4572,6 @@ export class Session {
       this.emit({
         type: "stash_list_response",
         payload: { cwd, entries: [], error: toCheckoutError(error), requestId },
-      });
-    }
-  }
-
-  private async handleStashShowRequest(
-    msg: Extract<SessionInboundMessage, { type: "stash_show_request" }>,
-  ): Promise<void> {
-    const { cwd, stashIndex, requestId } = msg;
-    try {
-      const { stdout } = await execAsync(
-        `git stash show -p --no-color "stash@{${stashIndex}}"`,
-        { cwd, env: READ_ONLY_GIT_ENV, maxBuffer: 4 * 1024 * 1024 },
-      );
-      const files = parseDiff(stdout);
-      this.emit({
-        type: "stash_show_response",
-        payload: { cwd, stashIndex, files, error: null, requestId },
-      });
-    } catch (error) {
-      this.emit({
-        type: "stash_show_response",
-        payload: { cwd, stashIndex, files: [], error: toCheckoutError(error), requestId },
       });
     }
   }

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1096,6 +1096,13 @@ export const StashListRequestSchema = z.object({
   requestId: z.string(),
 });
 
+export const StashShowRequestSchema = z.object({
+  type: z.literal("stash_show_request"),
+  cwd: z.string(),
+  stashIndex: z.number().int().min(0),
+  requestId: z.string(),
+});
+
 export const BranchSuggestionsRequestSchema = z.object({
   type: z.literal("branch_suggestions_request"),
   cwd: z.string(),
@@ -1436,6 +1443,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   StashPopRequestSchema,
   StashDropRequestSchema,
   StashListRequestSchema,
+  StashShowRequestSchema,
   ValidateBranchRequestSchema,
   BranchSuggestionsRequestSchema,
   DirectorySuggestionsRequestSchema,
@@ -2294,6 +2302,17 @@ export const StashListResponseSchema = z.object({
   }),
 });
 
+export const StashShowResponseSchema = z.object({
+  type: z.literal("stash_show_response"),
+  payload: z.object({
+    cwd: z.string(),
+    stashIndex: z.number(),
+    files: z.array(ParsedDiffFileSchema),
+    error: CheckoutErrorSchema.nullable(),
+    requestId: z.string(),
+  }),
+});
+
 export const ValidateBranchResponseSchema = z.object({
   type: z.literal("validate_branch_response"),
   payload: z.object({
@@ -2685,6 +2704,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   StashPopResponseSchema,
   StashDropResponseSchema,
   StashListResponseSchema,
+  StashShowResponseSchema,
   ValidateBranchResponseSchema,
   BranchSuggestionsResponseSchema,
   DirectorySuggestionsResponseSchema,
@@ -2910,6 +2930,8 @@ export type StashDropRequest = z.infer<typeof StashDropRequestSchema>;
 export type StashDropResponse = z.infer<typeof StashDropResponseSchema>;
 export type StashListRequest = z.infer<typeof StashListRequestSchema>;
 export type StashListResponse = z.infer<typeof StashListResponseSchema>;
+export type StashShowRequest = z.infer<typeof StashShowRequestSchema>;
+export type StashShowResponse = z.infer<typeof StashShowResponseSchema>;
 export type StashEntry = z.infer<typeof StashEntrySchema>;
 export type ValidateBranchRequest = z.infer<typeof ValidateBranchRequestSchema>;
 export type ValidateBranchResponse = z.infer<typeof ValidateBranchResponseSchema>;

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1057,6 +1057,45 @@ export const ValidateBranchRequestSchema = z.object({
   requestId: z.string(),
 });
 
+export const CheckoutSwitchBranchRequestSchema = z.object({
+  type: z.literal("checkout_switch_branch_request"),
+  cwd: z.string(),
+  branch: z.string(),
+  requestId: z.string(),
+});
+
+export const StashSaveRequestSchema = z.object({
+  type: z.literal("stash_save_request"),
+  cwd: z.string(),
+  /** Branch name to tag the stash with for later identification. */
+  branch: z.string().optional(),
+  requestId: z.string(),
+});
+
+export const StashPopRequestSchema = z.object({
+  type: z.literal("stash_pop_request"),
+  cwd: z.string(),
+  /** Zero-based index from stash_list_response. */
+  stashIndex: z.number().int().min(0),
+  requestId: z.string(),
+});
+
+export const StashDropRequestSchema = z.object({
+  type: z.literal("stash_drop_request"),
+  cwd: z.string(),
+  /** Zero-based index from stash_list_response. */
+  stashIndex: z.number().int().min(0),
+  requestId: z.string(),
+});
+
+export const StashListRequestSchema = z.object({
+  type: z.literal("stash_list_request"),
+  cwd: z.string(),
+  /** If true, only return paseo-created stashes. Default true. */
+  paseoOnly: z.boolean().optional(),
+  requestId: z.string(),
+});
+
 export const BranchSuggestionsRequestSchema = z.object({
   type: z.literal("branch_suggestions_request"),
   cwd: z.string(),
@@ -1392,6 +1431,11 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   CheckoutPushRequestSchema,
   CheckoutPrCreateRequestSchema,
   CheckoutPrStatusRequestSchema,
+  CheckoutSwitchBranchRequestSchema,
+  StashSaveRequestSchema,
+  StashPopRequestSchema,
+  StashDropRequestSchema,
+  StashListRequestSchema,
   ValidateBranchRequestSchema,
   BranchSuggestionsRequestSchema,
   DirectorySuggestionsRequestSchema,
@@ -2192,6 +2236,64 @@ export const CheckoutPrStatusResponseSchema = z.object({
   }),
 });
 
+export const CheckoutSwitchBranchResponseSchema = z.object({
+  type: z.literal("checkout_switch_branch_response"),
+  payload: z.object({
+    cwd: z.string(),
+    success: z.boolean(),
+    branch: z.string(),
+    error: CheckoutErrorSchema.nullable(),
+    requestId: z.string(),
+  }),
+});
+
+const StashEntrySchema = z.object({
+  index: z.number().int().min(0),
+  message: z.string(),
+  branch: z.string().nullable(),
+  isPaseo: z.boolean(),
+});
+
+export const StashSaveResponseSchema = z.object({
+  type: z.literal("stash_save_response"),
+  payload: z.object({
+    cwd: z.string(),
+    success: z.boolean(),
+    error: CheckoutErrorSchema.nullable(),
+    requestId: z.string(),
+  }),
+});
+
+export const StashPopResponseSchema = z.object({
+  type: z.literal("stash_pop_response"),
+  payload: z.object({
+    cwd: z.string(),
+    success: z.boolean(),
+    error: CheckoutErrorSchema.nullable(),
+    requestId: z.string(),
+  }),
+});
+
+export const StashDropResponseSchema = z.object({
+  type: z.literal("stash_drop_response"),
+  payload: z.object({
+    cwd: z.string(),
+    success: z.boolean(),
+    error: CheckoutErrorSchema.nullable(),
+    requestId: z.string(),
+  }),
+});
+
+export const StashListResponseSchema = z.object({
+  type: z.literal("stash_list_response"),
+  payload: z.object({
+    cwd: z.string(),
+    entries: z.array(StashEntrySchema),
+    error: CheckoutErrorSchema.nullable(),
+    requestId: z.string(),
+  }),
+});
+
 export const ValidateBranchResponseSchema = z.object({
   type: z.literal("validate_branch_response"),
   payload: z.object({
@@ -2578,6 +2680,11 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   CheckoutPushResponseSchema,
   CheckoutPrCreateResponseSchema,
   CheckoutPrStatusResponseSchema,
+  CheckoutSwitchBranchResponseSchema,
+  StashSaveResponseSchema,
+  StashPopResponseSchema,
+  StashDropResponseSchema,
+  StashListResponseSchema,
   ValidateBranchResponseSchema,
   BranchSuggestionsResponseSchema,
   DirectorySuggestionsResponseSchema,
@@ -2793,6 +2900,17 @@ export type CheckoutPrCreateRequest = z.infer<typeof CheckoutPrCreateRequestSche
 export type CheckoutPrCreateResponse = z.infer<typeof CheckoutPrCreateResponseSchema>;
 export type CheckoutPrStatusRequest = z.infer<typeof CheckoutPrStatusRequestSchema>;
 export type CheckoutPrStatusResponse = z.infer<typeof CheckoutPrStatusResponseSchema>;
+export type CheckoutSwitchBranchRequest = z.infer<typeof CheckoutSwitchBranchRequestSchema>;
+export type CheckoutSwitchBranchResponse = z.infer<typeof CheckoutSwitchBranchResponseSchema>;
+export type StashSaveRequest = z.infer<typeof StashSaveRequestSchema>;
+export type StashSaveResponse = z.infer<typeof StashSaveResponseSchema>;
+export type StashPopRequest = z.infer<typeof StashPopRequestSchema>;
+export type StashPopResponse = z.infer<typeof StashPopResponseSchema>;
+export type StashDropRequest = z.infer<typeof StashDropRequestSchema>;
+export type StashDropResponse = z.infer<typeof StashDropResponseSchema>;
+export type StashListRequest = z.infer<typeof StashListRequestSchema>;
+export type StashListResponse = z.infer<typeof StashListResponseSchema>;
+export type StashEntry = z.infer<typeof StashEntrySchema>;
 export type ValidateBranchRequest = z.infer<typeof ValidateBranchRequestSchema>;
 export type ValidateBranchResponse = z.infer<typeof ValidateBranchResponseSchema>;
 export type BranchSuggestionsRequest = z.infer<typeof BranchSuggestionsRequestSchema>;

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1080,26 +1080,11 @@ export const StashPopRequestSchema = z.object({
   requestId: z.string(),
 });
 
-export const StashDropRequestSchema = z.object({
-  type: z.literal("stash_drop_request"),
-  cwd: z.string(),
-  /** Zero-based index from stash_list_response. */
-  stashIndex: z.number().int().min(0),
-  requestId: z.string(),
-});
-
 export const StashListRequestSchema = z.object({
   type: z.literal("stash_list_request"),
   cwd: z.string(),
   /** If true, only return paseo-created stashes. Default true. */
   paseoOnly: z.boolean().optional(),
-  requestId: z.string(),
-});
-
-export const StashShowRequestSchema = z.object({
-  type: z.literal("stash_show_request"),
-  cwd: z.string(),
-  stashIndex: z.number().int().min(0),
   requestId: z.string(),
 });
 
@@ -1441,9 +1426,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   CheckoutSwitchBranchRequestSchema,
   StashSaveRequestSchema,
   StashPopRequestSchema,
-  StashDropRequestSchema,
   StashListRequestSchema,
-  StashShowRequestSchema,
   ValidateBranchRequestSchema,
   BranchSuggestionsRequestSchema,
   DirectorySuggestionsRequestSchema,
@@ -2282,32 +2265,11 @@ export const StashPopResponseSchema = z.object({
   }),
 });
 
-export const StashDropResponseSchema = z.object({
-  type: z.literal("stash_drop_response"),
-  payload: z.object({
-    cwd: z.string(),
-    success: z.boolean(),
-    error: CheckoutErrorSchema.nullable(),
-    requestId: z.string(),
-  }),
-});
-
 export const StashListResponseSchema = z.object({
   type: z.literal("stash_list_response"),
   payload: z.object({
     cwd: z.string(),
     entries: z.array(StashEntrySchema),
-    error: CheckoutErrorSchema.nullable(),
-    requestId: z.string(),
-  }),
-});
-
-export const StashShowResponseSchema = z.object({
-  type: z.literal("stash_show_response"),
-  payload: z.object({
-    cwd: z.string(),
-    stashIndex: z.number(),
-    files: z.array(ParsedDiffFileSchema),
     error: CheckoutErrorSchema.nullable(),
     requestId: z.string(),
   }),
@@ -2702,9 +2664,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   CheckoutSwitchBranchResponseSchema,
   StashSaveResponseSchema,
   StashPopResponseSchema,
-  StashDropResponseSchema,
   StashListResponseSchema,
-  StashShowResponseSchema,
   ValidateBranchResponseSchema,
   BranchSuggestionsResponseSchema,
   DirectorySuggestionsResponseSchema,
@@ -2926,12 +2886,8 @@ export type StashSaveRequest = z.infer<typeof StashSaveRequestSchema>;
 export type StashSaveResponse = z.infer<typeof StashSaveResponseSchema>;
 export type StashPopRequest = z.infer<typeof StashPopRequestSchema>;
 export type StashPopResponse = z.infer<typeof StashPopResponseSchema>;
-export type StashDropRequest = z.infer<typeof StashDropRequestSchema>;
-export type StashDropResponse = z.infer<typeof StashDropResponseSchema>;
 export type StashListRequest = z.infer<typeof StashListRequestSchema>;
 export type StashListResponse = z.infer<typeof StashListResponseSchema>;
-export type StashShowRequest = z.infer<typeof StashShowRequestSchema>;
-export type StashShowResponse = z.infer<typeof StashShowResponseSchema>;
 export type StashEntry = z.infer<typeof StashEntrySchema>;
 export type ValidateBranchRequest = z.infer<typeof ValidateBranchRequestSchema>;
 export type ValidateBranchResponse = z.infer<typeof ValidateBranchResponseSchema>;

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -157,7 +157,6 @@ type CheckoutFileChange = {
   isUntracked?: boolean;
 };
 
-type BranchSuggestionRefOrigin = "local" | "remote";
 
 function normalizeBranchSuggestionName(raw: string): string | null {
   const trimmed = raw.trim();
@@ -176,47 +175,57 @@ function normalizeBranchSuggestionName(raw: string): string | null {
     normalized = normalized.slice("origin/".length);
   }
 
-  if (!normalized || normalized === "HEAD") {
+  if (!normalized || normalized === "HEAD" || normalized === "origin") {
     return null;
   }
 
   return normalized;
 }
 
-async function listGitRefs(cwd: string, refPrefix: string): Promise<string[]> {
-  const { stdout } = await execGit(`git for-each-ref --format="%(refname:short)" ${refPrefix}`, {
-    cwd,
-    env: READ_ONLY_GIT_ENV,
-  });
+interface GitRef {
+  name: string;
+  committerDate: number;
+}
+
+async function listGitRefs(cwd: string, refPrefix: string): Promise<GitRef[]> {
+  const { stdout } = await execGit(
+    `git for-each-ref --sort=-committerdate --format="%(refname)%09%(committerdate:unix)" ${refPrefix}`,
+    { cwd, env: READ_ONLY_GIT_ENV },
+  );
   return stdout
     .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+    .map((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return null;
+      const [name, dateStr] = trimmed.split("\t");
+      if (!name) return null;
+      return { name, committerDate: Number(dateStr) || 0 };
+    })
+    .filter((ref): ref is GitRef => ref !== null);
 }
 
 function sortBranchSuggestions(
   branchNames: string[],
-  localBranchNames: Set<string>,
+  branchMeta: Map<string, { isLocal: boolean; committerDate: number }>,
   query: string,
 ): string[] {
   const normalizedQuery = query.trim().toLowerCase();
   const hasQuery = normalizedQuery.length > 0;
   return branchNames.sort((a, b) => {
-    const aLower = a.toLowerCase();
-    const bLower = b.toLowerCase();
-
     if (hasQuery) {
-      const aPrefix = aLower.startsWith(normalizedQuery);
-      const bPrefix = bLower.startsWith(normalizedQuery);
+      const aPrefix = a.toLowerCase().startsWith(normalizedQuery);
+      const bPrefix = b.toLowerCase().startsWith(normalizedQuery);
       if (aPrefix !== bPrefix) {
         return aPrefix ? -1 : 1;
       }
     }
 
-    const aIsLocal = localBranchNames.has(a);
-    const bIsLocal = localBranchNames.has(b);
-    if (aIsLocal !== bIsLocal) {
-      return aIsLocal ? -1 : 1;
+    const aMeta = branchMeta.get(a);
+    const bMeta = branchMeta.get(b);
+    const aDate = aMeta?.committerDate ?? 0;
+    const bDate = bMeta?.committerDate ?? 0;
+    if (aDate !== bDate) {
+      return bDate - aDate;
     }
 
     return a.localeCompare(b);
@@ -238,41 +247,40 @@ export async function listBranchSuggestions(
     listGitRefs(cwd, "refs/remotes/origin"),
   ]);
 
-  const merged = new Map<string, Set<BranchSuggestionRefOrigin>>();
-  for (const localRef of localRefs) {
-    const normalized = normalizeBranchSuggestionName(localRef);
-    if (!normalized) {
-      continue;
-    }
-    const origins = merged.get(normalized) ?? new Set<BranchSuggestionRefOrigin>();
-    origins.add("local");
-    merged.set(normalized, origins);
-  }
-  for (const remoteRef of remoteRefs) {
-    const normalized = normalizeBranchSuggestionName(remoteRef);
-    if (!normalized) {
-      continue;
-    }
-    const origins = merged.get(normalized) ?? new Set<BranchSuggestionRefOrigin>();
-    origins.add("remote");
-    merged.set(normalized, origins);
+  const branchMeta = new Map<string, { isLocal: boolean; committerDate: number }>();
+
+  for (const ref of localRefs) {
+    const normalized = normalizeBranchSuggestionName(ref.name);
+    if (!normalized) continue;
+    const existing = branchMeta.get(normalized);
+    branchMeta.set(normalized, {
+      isLocal: true,
+      committerDate: Math.max(ref.committerDate, existing?.committerDate ?? 0),
+    });
   }
 
-  const filteredNames = Array.from(merged.keys()).filter((name) =>
+  for (const ref of remoteRefs) {
+    const normalized = normalizeBranchSuggestionName(ref.name);
+    if (!normalized) continue;
+    const existing = branchMeta.get(normalized);
+    if (!existing) {
+      branchMeta.set(normalized, { isLocal: false, committerDate: ref.committerDate });
+    } else {
+      branchMeta.set(normalized, {
+        ...existing,
+        committerDate: Math.max(ref.committerDate, existing.committerDate),
+      });
+    }
+  }
+
+  const filteredNames = Array.from(branchMeta.keys()).filter((name) =>
     query ? name.toLowerCase().includes(query) : true,
   );
   if (filteredNames.length === 0) {
     return [];
   }
 
-  const localBranchNames = new Set<string>();
-  for (const [name, origins] of merged) {
-    if (origins.has("local")) {
-      localBranchNames.add(name);
-    }
-  }
-
-  const ordered = sortBranchSuggestions(filteredNames, localBranchNames, query);
+  const ordered = sortBranchSuggestions(filteredNames, branchMeta, query);
   return ordered.slice(0, limit);
 }
 


### PR DESCRIPTION
## Summary

- Branch switcher with recency sort, sticky search, and branch type icons
- Auto-stash uncommitted/untracked changes before switching branches
- Offer to restore stashed changes when switching to a branch that has them
- Fix: include untracked files in stash (`--include-untracked`)

Based on heyimsteve/main with stash management UI stripped (indicator icon, preview modal, drop/show RPCs) to reduce maintenance surface. Kept the stash-and-switch flow which handles the useful case automatically.

## Test plan

- [ ] Switch branches with no uncommitted changes — direct switch
- [ ] Switch branches with tracked changes — stash dialog, stash & switch, then restore prompt on target
- [ ] Switch branches with untracked files only — same flow works
- [ ] Cancel stash dialog — stays on current branch
- [ ] Decline restore prompt — changes remain stashed for later