### PR TITLE
feat(desktop): add macOS notification sound, actions, and badge count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ CLAUDE.local.md
 
 # Local agent/tooling artifacts (do not commit)
 PLAN.md
+paseo-mac-notifications-plan.md
+docs/MCP_SERVERS_IMPLEMENTATION.md
 .valknut/
 valknut-report.html/
 valknut-report.json/

--- a/package-lock.json
+++ b/package-lock.json
@@ -17466,7 +17466,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13590,6 +13590,16 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -15273,6 +15283,74 @@
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
+    "node_modules/conf": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-15.1.0.tgz",
+      "integrity": "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "atomically": "^2.0.3",
+        "debounce-fn": "^6.0.0",
+        "dot-prop": "^10.0.0",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.7.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/conf/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/conf/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/connect": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
@@ -15744,6 +15822,21 @@
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
       "license": "MIT"
+    },
+    "node_modules/debounce-fn": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
+      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -16341,6 +16434,36 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dot-prop": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.1.0.tgz",
+      "integrity": "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -16811,6 +16934,37 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/electron-store": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-11.0.2.tgz",
+      "integrity": "sha512-4VkNRdN+BImL2KcCi41WvAYbh6zLX5AUTi4so68yPqiItjbgTjqpEnGAqasgnG+lB6GuAyUltKwVopp6Uv+gwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "conf": "^15.0.2",
+        "type-fest": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-store/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -26502,6 +26656,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -32035,6 +32201,21 @@
       "integrity": "sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==",
       "license": "MIT"
     },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -32189,6 +32370,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tailwindcss": {
@@ -33208,6 +33401,18 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unbash": {
       "version": "2.2.0",
@@ -34248,6 +34453,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -35082,6 +35293,7 @@
         "@getpaseo/cli": "0.1.52",
         "@getpaseo/server": "0.1.52",
         "electron-log": "^5.4.3",
+        "electron-store": "^11.0.2",
         "electron-updater": "^6.6.2",
         "ws": "^8.14.2"
       },

--- a/packages/app/src/components/mcp-server-modal.tsx
+++ b/packages/app/src/components/mcp-server-modal.tsx
@@ -1,0 +1,459 @@
+import { useCallback, useState } from "react";
+import { Switch, Text, TextInput, View } from "react-native";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { Terminal, Globe, Radio, X } from "lucide-react-native";
+import type { McpServerRecord } from "@server/server/mcp/mcp-server-types";
+import type { McpServerConfig } from "@server/server/agent/agent-sdk-types";
+import { AdaptiveModalSheet, AdaptiveTextInput } from "./adaptive-modal-sheet";
+import { Button } from "@/components/ui/button";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+
+export type McpServerType = "stdio" | "http" | "sse";
+
+interface McpServerFormData {
+  name: string;
+  type: McpServerType;
+  description: string;
+  tags: string;
+  enabled: boolean;
+  command: string;
+  args: string;
+  env: string;
+  url: string;
+  headers: string;
+}
+
+interface McpServerModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSave: (data: {
+    name: string;
+    type: McpServerType;
+    config: McpServerConfig;
+    description?: string;
+    tags?: string[];
+    enabled: boolean;
+  }) => Promise<void>;
+  server?: McpServerRecord;
+  isLoading?: boolean;
+}
+
+const SERVER_TYPE_OPTIONS = [
+  {
+    value: "stdio" as const,
+    label: "Stdio",
+    icon: ({ color, size }: { color: string; size: number }) => (
+      <Terminal size={size} color={color} />
+    ),
+  },
+  {
+    value: "http" as const,
+    label: "HTTP",
+    icon: ({ color, size }: { color: string; size: number }) => <Globe size={size} color={color} />,
+  },
+  {
+    value: "sse" as const,
+    label: "SSE",
+    icon: ({ color, size }: { color: string; size: number }) => <Radio size={size} color={color} />,
+  },
+];
+
+function buildInitialFormData(server?: McpServerRecord): McpServerFormData {
+  if (!server) {
+    return {
+      name: "",
+      type: "stdio",
+      description: "",
+      tags: "",
+      enabled: true,
+      command: "",
+      args: "",
+      env: "",
+      url: "",
+      headers: "",
+    };
+  }
+
+  const { config } = server;
+  if (config.type === "stdio") {
+    return {
+      name: server.name,
+      type: "stdio",
+      description: server.description ?? "",
+      tags: server.tags?.join(", ") ?? "",
+      enabled: server.enabled,
+      command: config.command,
+      args: config.args?.join(" ") ?? "",
+      env: config.env
+        ? Object.entries(config.env)
+            .map(([k, v]) => `${k}=${v}`)
+            .join("\n")
+        : "",
+      url: "",
+      headers: "",
+    };
+  }
+  return {
+    name: server.name,
+    type: config.type,
+    description: server.description ?? "",
+    tags: server.tags?.join(", ") ?? "",
+    enabled: server.enabled,
+    command: "",
+    args: "",
+    env: "",
+    url: config.url,
+    headers: config.headers
+      ? Object.entries(config.headers)
+          .map(([k, v]) => `${k}: ${v}`)
+          .join("\n")
+      : "",
+  };
+}
+
+function buildConfig(form: McpServerFormData): McpServerConfig {
+  if (form.type === "stdio") {
+    const env: Record<string, string> = {};
+    if (form.env.trim()) {
+      for (const line of form.env.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed) {
+          const eqIdx = trimmed.indexOf("=");
+          if (eqIdx > 0) {
+            env[trimmed.slice(0, eqIdx)] = trimmed.slice(eqIdx + 1);
+          }
+        }
+      }
+    }
+    const args = form.args.trim() ? form.args.trim().split(/\s+/) : undefined;
+    return {
+      type: "stdio",
+      command: form.command,
+      args,
+      env: Object.keys(env).length > 0 ? env : undefined,
+    };
+  }
+  const headers: Record<string, string> = {};
+  if (form.headers.trim()) {
+    for (const line of form.headers.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed) {
+        const colonIdx = trimmed.indexOf(":");
+        if (colonIdx > 0) {
+          headers[trimmed.slice(0, colonIdx).trim()] = trimmed.slice(colonIdx + 1).trim();
+        }
+      }
+    }
+  }
+  if (form.type === "http") {
+    return {
+      type: "http",
+      url: form.url,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+    };
+  }
+  return {
+    type: "sse",
+    url: form.url,
+    headers: Object.keys(headers).length > 0 ? headers : undefined,
+  };
+}
+
+const styles = StyleSheet.create((theme) => ({
+  field: {
+    gap: theme.spacing[2],
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  label: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+  },
+  input: {
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[3],
+    color: theme.colors.foreground,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  multilineInput: {
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[3],
+    color: theme.colors.foreground,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    minHeight: 80,
+    textAlignVertical: "top",
+  },
+  hint: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  helper: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  error: {
+    color: theme.colors.destructive,
+    fontSize: theme.fontSize.sm,
+  },
+  actions: {
+    flexDirection: "row",
+    gap: theme.spacing[3],
+    marginTop: theme.spacing[2],
+  },
+  sectionTitle: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.semibold,
+    marginTop: theme.spacing[2],
+  },
+}));
+
+export function McpServerModal({
+  visible,
+  onClose,
+  onSave,
+  server,
+  isLoading = false,
+}: McpServerModalProps) {
+  const { theme } = useUnistyles();
+  const [form, setForm] = useState<McpServerFormData>(buildInitialFormData(server));
+  const [error, setError] = useState("");
+
+  const handleClose = useCallback(() => {
+    if (isLoading) return;
+    setForm(buildInitialFormData(server));
+    setError("");
+    onClose();
+  }, [isLoading, server, onClose]);
+
+  const handleSave = useCallback(async () => {
+    setError("");
+
+    if (!form.name.trim()) {
+      setError("Name is required");
+      return;
+    }
+
+    if (!form.command.trim() && form.type === "stdio") {
+      setError("Command is required for stdio servers");
+      return;
+    }
+
+    if (!form.url.trim() && form.type !== "stdio") {
+      setError("URL is required for HTTP/SSE servers");
+      return;
+    }
+
+    const tags = form.tags
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+
+    try {
+      await onSave({
+        name: form.name.trim(),
+        type: form.type,
+        config: buildConfig(form),
+        description: form.description.trim() || undefined,
+        tags: tags.length > 0 ? tags : undefined,
+        enabled: form.enabled,
+      });
+      handleClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    }
+  }, [form, onSave, handleClose]);
+
+  const updateForm = <K extends keyof McpServerFormData>(key: K, value: McpServerFormData[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const isEditing = Boolean(server);
+
+  return (
+    <AdaptiveModalSheet
+      title={isEditing ? "Edit MCP Server" : "Add MCP Server"}
+      visible={visible}
+      onClose={handleClose}
+      testID="mcp-server-modal"
+    >
+      <View style={styles.field}>
+        <Text style={styles.label}>Name</Text>
+        <AdaptiveTextInput
+          value={form.name}
+          onChangeText={(v) => updateForm("name", v)}
+          placeholder="my-mcp-server"
+          placeholderTextColor={theme.colors.foregroundMuted}
+          style={styles.input}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isLoading}
+        />
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>Type</Text>
+        <SegmentedControl
+          options={SERVER_TYPE_OPTIONS}
+          value={form.type}
+          onValueChange={(v) => updateForm("type", v)}
+          size="md"
+        />
+      </View>
+
+      {form.type === "stdio" ? (
+        <>
+          <View style={styles.field}>
+            <Text style={styles.label}>Command</Text>
+            <AdaptiveTextInput
+              value={form.command}
+              onChangeText={(v) => updateForm("command", v)}
+              placeholder="npx"
+              placeholderTextColor={theme.colors.foregroundMuted}
+              style={styles.input}
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!isLoading}
+            />
+          </View>
+
+          <View style={styles.field}>
+            <Text style={styles.label}>Arguments (space-separated)</Text>
+            <AdaptiveTextInput
+              value={form.args}
+              onChangeText={(v) => updateForm("args", v)}
+              placeholder="--flag value"
+              placeholderTextColor={theme.colors.foregroundMuted}
+              style={styles.input}
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!isLoading}
+            />
+          </View>
+
+          <View style={styles.field}>
+            <Text style={styles.label}>Environment variables (one per line, KEY=value)</Text>
+            <AdaptiveTextInput
+              value={form.env}
+              onChangeText={(v) => updateForm("env", v)}
+              placeholder="KEY=value"
+              placeholderTextColor={theme.colors.foregroundMuted}
+              style={styles.multilineInput}
+              autoCapitalize="none"
+              autoCorrect={false}
+              multiline
+              numberOfLines={3}
+              editable={!isLoading}
+            />
+          </View>
+        </>
+      ) : (
+        <>
+          <View style={styles.field}>
+            <Text style={styles.label}>URL</Text>
+            <AdaptiveTextInput
+              value={form.url}
+              onChangeText={(v) => updateForm("url", v)}
+              placeholder={
+                form.type === "http" ? "http://localhost:8080/mcp" : "http://localhost:8080/sse"
+              }
+              placeholderTextColor={theme.colors.foregroundMuted}
+              style={styles.input}
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="url"
+              editable={!isLoading}
+            />
+          </View>
+
+          <View style={styles.field}>
+            <Text style={styles.label}>Headers (one per line, Key: Value)</Text>
+            <AdaptiveTextInput
+              value={form.headers}
+              onChangeText={(v) => updateForm("headers", v)}
+              placeholder="Authorization: Bearer token"
+              placeholderTextColor={theme.colors.foregroundMuted}
+              style={styles.multilineInput}
+              autoCapitalize="none"
+              autoCorrect={false}
+              multiline
+              numberOfLines={3}
+              editable={!isLoading}
+            />
+          </View>
+        </>
+      )}
+
+      <View style={styles.field}>
+        <Text style={styles.label}>Description</Text>
+        <AdaptiveTextInput
+          value={form.description}
+          onChangeText={(v) => updateForm("description", v)}
+          placeholder="What does this server do?"
+          placeholderTextColor={theme.colors.foregroundMuted}
+          style={styles.input}
+          autoCapitalize="sentences"
+          autoCorrect={false}
+          editable={!isLoading}
+        />
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>Tags (comma-separated)</Text>
+        <AdaptiveTextInput
+          value={form.tags}
+          onChangeText={(v) => updateForm("tags", v)}
+          placeholder="api, database, custom"
+          placeholderTextColor={theme.colors.foregroundMuted}
+          style={styles.input}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isLoading}
+        />
+      </View>
+
+      <View style={[styles.field, styles.row]}>
+        <Text style={styles.label}>Enabled</Text>
+        <Switch
+          value={form.enabled}
+          onValueChange={(v) => updateForm("enabled", v)}
+          disabled={isLoading}
+          trackColor={{ true: theme.colors.primary, false: theme.colors.surface3 }}
+          thumbColor={theme.colors.palette.white}
+        />
+      </View>
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      <View style={styles.actions}>
+        <Button
+          style={{ flex: 1 }}
+          variant="secondary"
+          onPress={handleClose}
+          disabled={isLoading}
+          leftIcon={<X size={16} color={theme.colors.foreground} />}
+        >
+          Cancel
+        </Button>
+        <Button
+          style={{ flex: 1 }}
+          variant="default"
+          onPress={() => void handleSave()}
+          disabled={isLoading}
+        >
+          {isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
+        </Button>
+      </View>
+    </AdaptiveModalSheet>
+  );
+}

--- a/packages/app/src/components/mcp-server-selector.tsx
+++ b/packages/app/src/components/mcp-server-selector.tsx
@@ -1,0 +1,266 @@
+import { useCallback, useMemo, useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { ChevronDown, ChevronRight, Terminal, Globe, Radio } from "lucide-react-native";
+import { useMcpServers } from "@/hooks/use-mcp-servers";
+import type { McpServerRecord } from "@server/server/mcp/mcp-server-types";
+import type { McpServerConfig } from "@server/server/agent/agent-sdk-types";
+import type { McpServerType } from "@/components/mcp-server-modal";
+
+const TYPE_ICONS: Record<McpServerType, typeof Terminal> = {
+  stdio: Terminal,
+  http: Globe,
+  sse: Radio,
+};
+
+interface McpServerSelectorProps {
+  serverId: string;
+  selectedIds: string[];
+  onSelectionChange: (ids: string[]) => void;
+  disabled?: boolean;
+}
+
+export function McpServerSelector({
+  serverId,
+  selectedIds,
+  onSelectionChange,
+  disabled = false,
+}: McpServerSelectorProps) {
+  const { theme } = useUnistyles();
+  const { servers, isLoading, error } = useMcpServers(serverId);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const selectedServers = useMemo(() => {
+    if (!servers) return [];
+    return servers.filter((s) => selectedIds.includes(s.id));
+  }, [servers, selectedIds]);
+
+  const handleToggle = useCallback(
+    (id: string) => {
+      if (disabled) return;
+      if (selectedIds.includes(id)) {
+        onSelectionChange(selectedIds.filter((i) => i !== id));
+      } else {
+        onSelectionChange([...selectedIds, id]);
+      }
+    },
+    [disabled, selectedIds, onSelectionChange],
+  );
+
+  const summary = useMemo(() => {
+    if (!servers || servers.length === 0) return "None";
+    if (selectedIds.length === 0) return "None";
+    if (selectedIds.length === 1) return selectedServers[0]?.name ?? "1 selected";
+    return `${selectedIds.length} servers selected`;
+  }, [servers, selectedIds, selectedServers]);
+
+  return (
+    <View style={styles.container}>
+      <Pressable
+        style={[styles.header, disabled && styles.headerDisabled]}
+        onPress={() => !disabled && setIsExpanded((v) => !v)}
+        disabled={disabled || isLoading || !servers || servers.length === 0}
+      >
+        <View style={styles.headerContent}>
+          <Text style={styles.label}>MCP Servers</Text>
+          <Text style={styles.summary}>{summary}</Text>
+        </View>
+        {servers && servers.length > 0 ? (
+          isExpanded ? (
+            <ChevronDown size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+          ) : (
+            <ChevronRight size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+          )
+        ) : null}
+      </Pressable>
+
+      {isExpanded && servers && servers.length > 0 && (
+        <View style={styles.list}>
+          {servers.map((server) => {
+            const Icon = TYPE_ICONS[server.type] ?? Terminal;
+            const isSelected = selectedIds.includes(server.id);
+            return (
+              <Pressable
+                key={server.id}
+                style={[styles.item, isSelected && styles.itemSelected]}
+                onPress={() => handleToggle(server.id)}
+              >
+                <View style={[styles.itemIcon, !server.enabled && styles.itemIconDisabled]}>
+                  <Icon
+                    size={14}
+                    color={server.enabled ? theme.colors.foreground : theme.colors.foregroundMuted}
+                  />
+                </View>
+                <View style={styles.itemContent}>
+                  <Text style={[styles.itemName, !server.enabled && styles.itemNameDisabled]}>
+                    {server.name}
+                  </Text>
+                  <Text style={styles.itemType}>
+                    {server.type.toUpperCase()}
+                    {!server.enabled && " (disabled)"}
+                  </Text>
+                </View>
+                <View style={[styles.checkbox, isSelected && styles.checkboxSelected]}>
+                  {isSelected ? <View style={styles.checkboxInner} /> : null}
+                </View>
+              </Pressable>
+            );
+          })}
+        </View>
+      )}
+
+      {isExpanded && isLoading && (
+        <View style={styles.loading}>
+          <Text style={styles.loadingText}>Loading MCP servers...</Text>
+        </View>
+      )}
+
+      {isExpanded && error && (
+        <View style={styles.error}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      )}
+
+      {isExpanded && servers && servers.length === 0 && (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>No MCP servers configured</Text>
+          <Text style={styles.emptyHint}>Add MCP servers in Settings → MCP Servers</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+export function buildMcpServersConfig(
+  servers: McpServerRecord[],
+  ids: string[],
+): Record<string, McpServerConfig> | undefined {
+  const selected = servers.filter((s) => ids.includes(s.id) && s.enabled);
+  if (selected.length === 0) return undefined;
+  return selected.reduce(
+    (acc, s) => {
+      acc[s.name] = s.config;
+      return acc;
+    },
+    {} as Record<string, McpServerConfig>,
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    gap: theme.spacing[1],
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+  },
+  headerDisabled: {
+    opacity: 0.5,
+  },
+  headerContent: {
+    flex: 1,
+  },
+  label: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+  },
+  summary: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    marginTop: 2,
+  },
+  list: {
+    gap: theme.spacing[1],
+    paddingLeft: theme.spacing[4],
+  },
+  item: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.md,
+  },
+  itemSelected: {
+    backgroundColor: theme.colors.surface3,
+  },
+  itemIcon: {
+    width: 24,
+    height: 24,
+    borderRadius: theme.borderRadius.sm,
+    backgroundColor: theme.colors.surface3,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  itemIconDisabled: {
+    opacity: 0.5,
+  },
+  itemContent: {
+    flex: 1,
+  },
+  itemName: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  itemNameDisabled: {
+    color: theme.colors.foregroundMuted,
+  },
+  itemType: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  checkbox: {
+    width: 18,
+    height: 18,
+    borderRadius: theme.borderRadius.full,
+    borderWidth: 2,
+    borderColor: theme.colors.border,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  checkboxSelected: {
+    borderColor: theme.colors.primary,
+    backgroundColor: theme.colors.primary,
+  },
+  checkboxInner: {
+    width: 8,
+    height: 8,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.palette.white,
+  },
+  loading: {
+    padding: theme.spacing[3],
+    alignItems: "center",
+  },
+  loadingText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  error: {
+    padding: theme.spacing[3],
+  },
+  errorText: {
+    color: theme.colors.destructive,
+    fontSize: theme.fontSize.sm,
+  },
+  empty: {
+    padding: theme.spacing[3],
+    alignItems: "center",
+  },
+  emptyText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  emptyHint: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    marginTop: theme.spacing[1],
+  },
+}));

--- a/packages/app/src/components/mcp-servers-section.tsx
+++ b/packages/app/src/components/mcp-servers-section.tsx
@@ -1,0 +1,332 @@
+import { useCallback, useState } from "react";
+import { View, Text, Pressable, Switch } from "react-native";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import {
+  Plus,
+  Terminal,
+  Globe,
+  Radio,
+  Pencil,
+  Trash2,
+  RefreshCw,
+  ChevronRight,
+} from "lucide-react-native";
+import {
+  useMcpServers,
+  useCreateMcpServer,
+  useUpdateMcpServer,
+  useDeleteMcpServer,
+  useToggleMcpServer,
+} from "@/hooks/use-mcp-servers";
+import { McpServerModal, type McpServerType } from "@/components/mcp-server-modal";
+import { Button } from "@/components/ui/button";
+import type { McpServerRecord } from "@server/server/mcp/mcp-server-types";
+import type { CreateMcpServerOptions } from "@server/client/daemon-client";
+
+const TYPE_ICONS: Record<McpServerType, typeof Terminal> = {
+  stdio: Terminal,
+  http: Globe,
+  sse: Radio,
+};
+
+interface McpServersSectionProps {
+  serverId: string;
+}
+
+export function McpServersSection({ serverId }: McpServersSectionProps) {
+  const { theme } = useUnistyles();
+  const { servers, isLoading, isFetching, error, refetch, invalidate } = useMcpServers(serverId);
+  const { create, isLoading: isCreating } = useCreateMcpServer(serverId);
+  const { update } = useUpdateMcpServer(serverId);
+  const { remove } = useDeleteMcpServer(serverId);
+  const { toggle } = useToggleMcpServer(serverId);
+
+  const [modalVisible, setModalVisible] = useState(false);
+  const [editingServer, setEditingServer] = useState<McpServerRecord | undefined>();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleAdd = useCallback(() => {
+    setEditingServer(undefined);
+    setModalVisible(true);
+  }, []);
+
+  const handleEdit = useCallback((server: McpServerRecord) => {
+    setEditingServer(server);
+    setModalVisible(true);
+  }, []);
+
+  const handleCloseModal = useCallback(() => {
+    setModalVisible(false);
+    setEditingServer(undefined);
+  }, []);
+
+  const handleSave = useCallback(
+    async (data: {
+      name: string;
+      type: McpServerType;
+      config: Parameters<typeof create>[0]["config"];
+      description?: string;
+      tags?: string[];
+      enabled: boolean;
+    }) => {
+      setIsSaving(true);
+      try {
+        if (editingServer) {
+          await update(editingServer.id, {
+            name: data.name,
+            type: data.type,
+            config: data.config,
+            description: data.description,
+            tags: data.tags,
+            enabled: data.enabled,
+          });
+        } else {
+          await create({
+            name: data.name,
+            type: data.type,
+            config: data.config,
+            description: data.description,
+            tags: data.tags,
+            enabled: data.enabled,
+          });
+        }
+        handleCloseModal();
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [editingServer, create, update, handleCloseModal],
+  );
+
+  const handleToggle = useCallback(
+    async (server: McpServerRecord) => {
+      await toggle({ id: server.id, enabled: !server.enabled });
+    },
+    [toggle],
+  );
+
+  const handleDelete = useCallback(
+    async (server: McpServerRecord) => {
+      await remove(server.id);
+    },
+    [remove],
+  );
+
+  return (
+    <>
+      <View style={styles.section}>
+        <View style={styles.sectionHeader}>
+          <Text style={styles.sectionTitle}>MCP Servers</Text>
+          <Pressable
+            onPress={() => void refetch()}
+            disabled={isFetching}
+            style={[styles.refreshButton, isFetching && styles.refreshButtonDisabled]}
+          >
+            <RefreshCw
+              size={theme.iconSize.sm}
+              color={isFetching ? theme.colors.foregroundMuted : theme.colors.primary}
+            />
+          </Pressable>
+        </View>
+
+        {error ? (
+          <View style={[styles.card, styles.errorCard]}>
+            <Text style={styles.errorText}>{error}</Text>
+            <Button variant="secondary" size="sm" onPress={() => void invalidate()}>
+              Retry
+            </Button>
+          </View>
+        ) : isLoading ? (
+          <View style={[styles.card, styles.emptyCard]}>
+            <Text style={styles.emptyText}>Loading MCP servers...</Text>
+          </View>
+        ) : !servers || servers.length === 0 ? (
+          <View style={[styles.card, styles.emptyCard]}>
+            <Text style={styles.emptyText}>No MCP servers configured</Text>
+            <Text style={styles.emptyHint}>
+              MCP servers let your agents use additional tools and capabilities.
+            </Text>
+          </View>
+        ) : (
+          servers.map((server) => {
+            const Icon = TYPE_ICONS[server.type] ?? Terminal;
+            return (
+              <View key={server.id} style={styles.card}>
+                <View style={styles.serverRow}>
+                  <View style={styles.serverIcon}>
+                    <Icon size={theme.iconSize.md} color={theme.colors.foreground} />
+                  </View>
+                  <View style={styles.serverInfo}>
+                    <Text style={styles.serverName}>{server.name}</Text>
+                    <Text style={styles.serverType}>
+                      {server.type.toUpperCase()}
+                      {server.description ? ` — ${server.description}` : ""}
+                    </Text>
+                    {server.tags && server.tags.length > 0 && (
+                      <View style={styles.tagRow}>
+                        {server.tags.map((tag) => (
+                          <View key={tag} style={styles.tag}>
+                            <Text style={styles.tagText}>{tag}</Text>
+                          </View>
+                        ))}
+                      </View>
+                    )}
+                  </View>
+                  <Switch
+                    value={server.enabled}
+                    onValueChange={() => void handleToggle(server)}
+                    trackColor={{ true: theme.colors.primary, false: theme.colors.surface3 }}
+                    thumbColor={theme.colors.palette.white}
+                  />
+                </View>
+                <View style={styles.serverActions}>
+                  <Pressable
+                    style={styles.actionButton}
+                    onPress={() => void handleEdit(server)}
+                    accessibilityLabel={`Edit ${server.name}`}
+                  >
+                    <Pencil size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+                  </Pressable>
+                  <Pressable
+                    style={styles.actionButton}
+                    onPress={() => void handleDelete(server)}
+                    accessibilityLabel={`Delete ${server.name}`}
+                  >
+                    <Trash2 size={theme.iconSize.sm} color={theme.colors.destructive} />
+                  </Pressable>
+                </View>
+              </View>
+            );
+          })
+        )}
+
+        <Button
+          variant="outline"
+          size="sm"
+          onPress={handleAdd}
+          leftIcon={<Plus size={theme.iconSize.sm} color={theme.colors.primary} />}
+          style={styles.addButton}
+        >
+          Add MCP Server
+        </Button>
+      </View>
+
+      <McpServerModal
+        visible={modalVisible}
+        onClose={handleCloseModal}
+        onSave={handleSave}
+        server={editingServer}
+        isLoading={isSaving || isCreating}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  section: {
+    gap: theme.spacing[3],
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  sectionTitle: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.semibold,
+  },
+  refreshButton: {
+    padding: theme.spacing[1],
+  },
+  refreshButtonDisabled: {
+    opacity: 0.5,
+  },
+  card: {
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+    padding: theme.spacing[4],
+    gap: theme.spacing[3],
+  },
+  emptyCard: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: theme.spacing[6],
+  },
+  errorCard: {
+    borderWidth: 1,
+    borderColor: theme.colors.destructive,
+    alignItems: "flex-start",
+  },
+  emptyText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  emptyHint: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    marginTop: theme.spacing[1],
+    textAlign: "center",
+  },
+  errorText: {
+    color: theme.colors.destructive,
+    fontSize: theme.fontSize.sm,
+    marginBottom: theme.spacing[2],
+  },
+  serverRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[3],
+  },
+  serverIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: theme.borderRadius.md,
+    backgroundColor: theme.colors.surface3,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  serverInfo: {
+    flex: 1,
+    gap: 2,
+  },
+  serverName: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+  },
+  serverType: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  tagRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: theme.spacing[1],
+    marginTop: theme.spacing[1],
+  },
+  tag: {
+    backgroundColor: theme.colors.surface3,
+    borderRadius: theme.borderRadius.full,
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: 2,
+  },
+  tagText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  serverActions: {
+    flexDirection: "row",
+    gap: theme.spacing[2],
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.surface3,
+    paddingTop: theme.spacing[3],
+    marginTop: theme.spacing[1],
+  },
+  actionButton: {
+    padding: theme.spacing[1],
+  },
+  addButton: {
+    marginTop: theme.spacing[1],
+  },
+}));

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -40,6 +40,7 @@ import { useDraftStore } from "@/stores/draft-store";
 import type { AgentDirectoryEntry } from "@/types/agent-directory";
 import { sendOsNotification } from "@/utils/os-notifications";
 import { getIsAppActivelyVisible } from "@/utils/app-visibility";
+import { getDesktopHost } from "@/desktop/host";
 import {
   getInitKey,
   getInitDeferred,
@@ -282,6 +283,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
   const setQueuedMessages = useSessionStore((state) => state.setQueuedMessages);
   const updateSessionClient = useSessionStore((state) => state.updateSessionClient);
   const updateSessionServerInfo = useSessionStore((state) => state.updateSessionServerInfo);
+  const setFocusedAgentId = useSessionStore((state) => state.setFocusedAgentId);
 
   // Track focused agent for heartbeat
   const focusedAgentId = useSessionStore(
@@ -623,6 +625,11 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
         title: notification.title,
         body: notification.body,
         data: notification.data,
+        ...(params.reason === "permission"
+          ? {
+              actions: [{ text: "Approve" }, { text: "Deny" }, { text: "View" }],
+            }
+          : {}),
       });
     },
     [serverId],
@@ -1740,6 +1747,37 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
     },
     [client],
   );
+
+  // Handle notification actions (Approve/Deny/View)
+  useEffect(() => {
+    const desktopHost = getDesktopHost();
+    if (!desktopHost) return;
+
+    const unsubAction = desktopHost.notification?.onAction?.(
+      (payload: { action: string; notificationId: string; data?: Record<string, unknown> }) => {
+        const { action, data } = payload;
+        const agentId = data?.agentId as string | undefined;
+
+        if (action === "View" && agentId) {
+          setFocusedAgentId(serverId, agentId);
+        }
+      },
+    );
+
+    return () => {
+      unsubAction?.();
+    };
+  }, [serverId, setFocusedAgentId]);
+
+  // Handle badge count when attention_required arrives
+  useEffect(() => {
+    if (!focusedAgentId) return;
+
+    const desktopHost = getDesktopHost();
+    if (!desktopHost) return;
+
+    desktopHost.notification?.clearBadge?.();
+  }, [focusedAgentId]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/packages/app/src/desktop/host.ts
+++ b/packages/app/src/desktop/host.ts
@@ -29,8 +29,25 @@ export interface DesktopDialogBridge {
 export interface DesktopNotificationBridge {
   isSupported?: () => Promise<boolean>;
   sendNotification?: (
-    payload: string | { title: string; body?: string; data?: Record<string, unknown> },
+    payload:
+      | string
+      | {
+          title: string;
+          body?: string;
+          data?: Record<string, unknown>;
+          sound?: string;
+          actions?: Array<{ text: string }>;
+        },
   ) => Promise<boolean>;
+  onAction?: (
+    handler: (payload: {
+      action: string;
+      notificationId: string;
+      data?: Record<string, unknown>;
+    }) => void,
+  ) => () => void;
+  incrementBadge?: () => Promise<void>;
+  clearBadge?: () => Promise<void>;
 }
 
 export interface DesktopOpenerBridge {
@@ -38,10 +55,7 @@ export interface DesktopOpenerBridge {
 }
 
 export interface DesktopMenuBridge {
-  showContextMenu?: (input?: {
-    kind?: "terminal";
-    hasSelection?: boolean;
-  }) => Promise<void>;
+  showContextMenu?: (input?: { kind?: "terminal"; hasSelection?: boolean }) => Promise<void>;
 }
 
 export interface DesktopWindowControlsOverlayUpdate {

--- a/packages/app/src/hooks/use-mcp-servers.ts
+++ b/packages/app/src/hooks/use-mcp-servers.ts
@@ -1,0 +1,192 @@
+import { useCallback, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  CreateMcpServerOptions,
+  UpdateMcpServerOptions,
+  ToggleMcpServerOptions,
+  ListMcpServersResult,
+  CreateMcpServerResult,
+  UpdateMcpServerResult,
+  DeleteMcpServerResult,
+  ToggleMcpServerResult,
+} from "@server/client/daemon-client";
+import type { McpServerRecord } from "@server/server/mcp/mcp-server-types";
+import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+
+export function mcpServersQueryKey(serverId: string | null) {
+  return ["mcpServers", serverId] as const;
+}
+
+interface UseMcpServersResult {
+  servers: McpServerRecord[] | undefined;
+  isLoading: boolean;
+  isFetching: boolean;
+  error: string | null;
+  refetch: () => void;
+  invalidate: () => void;
+}
+
+export function useMcpServers(serverId: string | null): UseMcpServersResult {
+  const queryClient = useQueryClient();
+  const client = useHostRuntimeClient(serverId ?? "");
+  const isConnected = useHostRuntimeIsConnected(serverId ?? "");
+
+  const queryKey = useMemo(() => mcpServersQueryKey(serverId), [serverId]);
+
+  const query = useQuery({
+    queryKey,
+    enabled: Boolean(serverId && client && isConnected),
+    staleTime: 30_000,
+    queryFn: async (): Promise<ListMcpServersResult> => {
+      if (!client) {
+        throw new Error("Host is not connected");
+      }
+      return client.listMcpServers();
+    },
+  });
+
+  const refetch = useCallback(() => {
+    void query.refetch();
+  }, [query]);
+
+  const invalidate = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey });
+  }, [queryClient, queryKey]);
+
+  return {
+    servers: query.data?.servers,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error instanceof Error ? query.error.message : (query.data?.error ?? null),
+    refetch,
+    invalidate,
+  };
+}
+
+interface UseCreateMcpServerResult {
+  create: (options: CreateMcpServerOptions) => Promise<CreateMcpServerResult>;
+  isLoading: boolean;
+}
+
+export function useCreateMcpServer(serverId: string | null): UseCreateMcpServerResult {
+  const client = useHostRuntimeClient(serverId ?? "");
+  const isConnected = useHostRuntimeIsConnected(serverId ?? "");
+  const queryClient = useQueryClient();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const create = useCallback(
+    async (options: CreateMcpServerOptions): Promise<CreateMcpServerResult> => {
+      if (!client || !isConnected) {
+        throw new Error("Host is not connected");
+      }
+      setIsLoading(true);
+      try {
+        const result = await client.createMcpServer(options);
+        void queryClient.invalidateQueries({ queryKey: mcpServersQueryKey(serverId) });
+        return result;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [client, isConnected, serverId, queryClient],
+  );
+
+  return { create, isLoading };
+}
+
+interface UseUpdateMcpServerResult {
+  update: (id: string, options: UpdateMcpServerOptions) => Promise<UpdateMcpServerResult>;
+  isLoading: boolean;
+}
+
+export function useUpdateMcpServer(serverId: string | null): UseUpdateMcpServerResult {
+  const client = useHostRuntimeClient(serverId ?? "");
+  const isConnected = useHostRuntimeIsConnected(serverId ?? "");
+  const queryClient = useQueryClient();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const update = useCallback(
+    async (id: string, options: UpdateMcpServerOptions): Promise<UpdateMcpServerResult> => {
+      if (!client || !isConnected) {
+        throw new Error("Host is not connected");
+      }
+      setIsLoading(true);
+      try {
+        const result = await client.updateMcpServer(id, options);
+        void queryClient.invalidateQueries({ queryKey: mcpServersQueryKey(serverId) });
+        return result;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [client, isConnected, serverId, queryClient],
+  );
+
+  return { update, isLoading };
+}
+
+interface UseDeleteMcpServerResult {
+  remove: (id: string) => Promise<DeleteMcpServerResult>;
+  isLoading: boolean;
+}
+
+export function useDeleteMcpServer(serverId: string | null): UseDeleteMcpServerResult {
+  const client = useHostRuntimeClient(serverId ?? "");
+  const isConnected = useHostRuntimeIsConnected(serverId ?? "");
+  const queryClient = useQueryClient();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const remove = useCallback(
+    async (id: string): Promise<DeleteMcpServerResult> => {
+      if (!client || !isConnected) {
+        throw new Error("Host is not connected");
+      }
+      setIsLoading(true);
+      try {
+        const result = await client.deleteMcpServer(id);
+        void queryClient.invalidateQueries({ queryKey: mcpServersQueryKey(serverId) });
+        return result;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [client, isConnected, serverId, queryClient],
+  );
+
+  return { remove, isLoading };
+}
+
+interface UseToggleMcpServerResult {
+  toggle: (options: ToggleMcpServerOptions) => Promise<ToggleMcpServerResult>;
+  isLoading: boolean;
+}
+
+export function useToggleMcpServer(serverId: string | null): UseToggleMcpServerResult {
+  const client = useHostRuntimeClient(serverId ?? "");
+  const isConnected = useHostRuntimeIsConnected(serverId ?? "");
+  const queryClient = useQueryClient();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const toggle = useCallback(
+    async (options: ToggleMcpServerOptions): Promise<ToggleMcpServerResult> => {
+      if (!client || !isConnected) {
+        throw new Error("Host is not connected");
+      }
+      setIsLoading(true);
+      try {
+        const result = await client.toggleMcpServer(options);
+        void queryClient.invalidateQueries({ queryKey: mcpServersQueryKey(serverId) });
+        return result;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [client, isConnected, serverId, queryClient],
+  );
+
+  return { toggle, isLoading };
+}

--- a/packages/app/src/screens/agent/draft-agent-screen.tsx
+++ b/packages/app/src/screens/agent/draft-agent-screen.tsx
@@ -9,6 +9,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { GestureDetector } from "react-native-gesture-handler";
 import Animated from "react-native-reanimated";
 import { Folder, GitBranch, PanelRight } from "lucide-react-native";
+import { McpServerSelector, buildMcpServersConfig } from "@/components/mcp-server-selector";
+import { useMcpServers } from "@/hooks/use-mcp-servers";
 import { SidebarMenuToggle } from "@/components/headers/menu-header";
 import { HeaderToggleButton } from "@/components/headers/header-toggle-button";
 import { AgentInputArea } from "@/components/agent-input-area";
@@ -63,7 +65,7 @@ const DRAFT_CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: true,
   supportsSessionPersistence: false,
   supportsDynamicModes: false,
-  supportsMcpServers: false,
+  supportsMcpServers: true,
   supportsReasoningStream: false,
   supportsToolInvocations: false,
 };
@@ -274,6 +276,7 @@ function DraftAgentScreenContent({
   const worktreeAnchorRef = useRef<View>(null);
   const branchAnchorRef = useRef<View>(null);
   const addImagesRef = useRef<((images: ImageAttachment[]) => void) | null>(null);
+  const [selectedMcpServerIds, setSelectedMcpServerIds] = useState<string[]>([]);
 
   useEffect(() => {
     const trimmed = branchSearchQuery.trim();
@@ -334,6 +337,7 @@ function DraftAgentScreenContent({
   const runtimeClient = useHostRuntimeClient(selectedServerId ?? "");
   const isHostOnline = useHostRuntimeIsConnected(selectedServerId ?? "");
   const sessionClient = runtimeClient;
+  const { servers: mcpServers } = useMcpServers(selectedServerId);
   const trimmedWorkingDir = workingDir.trim();
   const shouldInspectRepo = trimmedWorkingDir.length > 0;
   const canQuerySelectedHost = Boolean(selectedServerId) && Boolean(sessionClient) && isHostOnline;
@@ -906,6 +910,9 @@ function DraftAgentScreenContent({
         isAttachWorktree && selectedWorktreePath ? selectedWorktreePath : trimmedPath;
 
       const modeId = modeOptions.length > 0 && selectedMode !== "" ? selectedMode : undefined;
+      const mcpServersConfig = mcpServers
+        ? buildMcpServersConfig(mcpServers, selectedMcpServerIds)
+        : undefined;
       const config: AgentSessionConfig = {
         provider: selectedProvider,
         cwd: resolvedWorkingDir,
@@ -915,6 +922,7 @@ function DraftAgentScreenContent({
           ? { thinkingOptionId: effectiveDraftThinkingOptionId }
           : {}),
         ...(draftFeatureValues ? { featureValues: draftFeatureValues } : {}),
+        ...(mcpServersConfig ? { mcpServers: mcpServersConfig } : {}),
       };
 
       const effectiveBaseBranch = baseBranch.trim();
@@ -1225,6 +1233,15 @@ function DraftAgentScreenContent({
                   }}
                   anchorRef={branchAnchorRef}
                 />
+
+                {selectedServerId && (
+                  <McpServerSelector
+                    serverId={selectedServerId}
+                    selectedIds={selectedMcpServerIds}
+                    onSelectionChange={setSelectedMcpServerIds}
+                    disabled={isSubmitting}
+                  />
+                )}
 
                 {formErrorMessage ? (
                   <View style={styles.errorContainer}>

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -58,6 +58,7 @@ import { IntegrationsSection } from "@/desktop/components/integrations-section";
 import { LocalDaemonSection } from "@/desktop/components/desktop-updates-section";
 import { PairDeviceSection } from "@/desktop/components/pair-device-section";
 import { isElectronRuntime } from "@/desktop/host";
+import { McpServersSection } from "@/components/mcp-servers-section";
 import { useDesktopAppUpdater } from "@/desktop/updates/use-desktop-app-updater";
 import { formatVersionWithPrefix } from "@/desktop/updates/desktop-updates";
 import { resolveAppVersion } from "@/utils/app-version";
@@ -86,7 +87,8 @@ type SettingsSectionId =
   | "about"
   | "permissions"
   | "daemon"
-  | "pair-device";
+  | "pair-device"
+  | "mcpServers";
 
 interface SettingsSectionDef {
   id: SettingsSectionId;
@@ -114,6 +116,7 @@ function getSettingsSections(context: { isDesktopApp: boolean }): SettingsSectio
   sections.push(
     { id: "diagnostics", label: "Diagnostics", icon: Stethoscope },
     { id: "about", label: "About", icon: Info },
+    { id: "mcpServers", label: "MCP Servers", icon: Blocks },
   );
 
   return sections;
@@ -365,7 +368,15 @@ interface GeneralSectionProps {
   handleSendBehaviorChange: (behavior: SendBehavior) => void;
 }
 
-function ThemeIcon({ theme, size, color }: { theme: AppSettings["theme"]; size: number; color: string }) {
+function ThemeIcon({
+  theme,
+  size,
+  color,
+}: {
+  theme: AppSettings["theme"];
+  size: number;
+  color: string;
+}) {
   switch (theme) {
     case "light":
       return <Sun size={size} color={color} />;
@@ -422,15 +433,10 @@ function GeneralSection({
           </View>
           <DropdownMenu>
             <DropdownMenuTrigger
-              style={({ pressed }) => [
-                styles.themeTrigger,
-                pressed && { opacity: 0.85 },
-              ]}
+              style={({ pressed }) => [styles.themeTrigger, pressed && { opacity: 0.85 }]}
             >
               <ThemeIcon theme={settings.theme} size={iconSize} color={iconColor} />
-              <Text style={styles.themeTriggerText}>
-                {THEME_LABELS[settings.theme]}
-              </Text>
+              <Text style={styles.themeTriggerText}>{THEME_LABELS[settings.theme]}</Text>
               <ChevronDown size={theme.iconSize.sm} color={iconColor} />
             </DropdownMenuTrigger>
             <DropdownMenuContent side="bottom" align="end" width={200}>
@@ -480,7 +486,6 @@ function GeneralSection({
   );
 }
 
-
 interface ProvidersSectionProps {
   routeServerId: string;
 }
@@ -502,10 +507,7 @@ function ProvidersSection({ routeServerId }: ProvidersSectionProps) {
             <Pressable
               onPress={refresh}
               disabled={isFetching}
-              style={[
-                settingsStyles.sectionHeaderLink,
-                isFetching ? { opacity: 0.5 } : null,
-              ]}
+              style={[settingsStyles.sectionHeaderLink, isFetching ? { opacity: 0.5 } : null]}
             >
               <Text
                 style={{
@@ -533,7 +535,9 @@ function ProvidersSection({ routeServerId }: ProvidersSectionProps) {
               const status = entry?.status ?? "unavailable";
               const ProviderIcon = getProviderIcon(def.id);
               const providerError =
-                status === "error" && typeof entry?.error === "string" && entry.error.trim().length > 0
+                status === "error" &&
+                typeof entry?.error === "string" &&
+                entry.error.trim().length > 0
                   ? entry.error.trim()
                   : null;
 
@@ -564,11 +568,7 @@ function ProvidersSection({ routeServerId }: ProvidersSectionProps) {
                               : "Not installed"
                       }
                       variant={
-                        status === "ready"
-                          ? "success"
-                          : status === "error"
-                            ? "error"
-                            : "muted"
+                        status === "ready" ? "success" : status === "error" ? "error" : "muted"
                       }
                     />
                     <Button
@@ -672,6 +672,7 @@ interface SettingsSectionContentProps {
   appVersion: string | null;
   isLocalDaemon: boolean;
   isDesktopApp: boolean;
+  routeServerId: string;
 }
 
 function SettingsSectionContent({
@@ -684,6 +685,7 @@ function SettingsSectionContent({
   appVersion,
   isLocalDaemon,
   isDesktopApp,
+  routeServerId,
 }: SettingsSectionContentProps) {
   switch (sectionId) {
     case "hosts":
@@ -708,6 +710,8 @@ function SettingsSectionContent({
       return isDesktopApp ? (
         <LocalDaemonSection appVersion={appVersion} showLifecycleControls={isLocalDaemon} />
       ) : null;
+    case "mcpServers":
+      return <McpServersSection serverId={routeServerId} />;
   }
 }
 
@@ -724,10 +728,7 @@ function SettingsMobileLayout({ sections, sectionContentProps }: SettingsLayoutP
   const insets = useSafeAreaInsets();
 
   return (
-    <ScrollView
-      style={styles.scrollView}
-      contentContainerStyle={{ paddingBottom: insets.bottom }}
-    >
+    <ScrollView style={styles.scrollView} contentContainerStyle={{ paddingBottom: insets.bottom }}>
       <View style={styles.content}>
         {sections.map((section) => (
           <SettingsSectionContent
@@ -752,8 +753,7 @@ function SettingsDesktopLayout({ sections, sectionContentProps }: SettingsLayout
         {sections.map((section) => {
           const isSelected = section.id === selectedSectionId;
           const IconComponent = section.icon;
-          const showSeparator =
-            section.id === "integrations" || section.id === "providers";
+          const showSeparator = section.id === "integrations" || section.id === "providers";
           return (
             <View key={section.id}>
               {showSeparator ? <View style={desktopStyles.sidebarSeparator} /> : null}
@@ -789,10 +789,7 @@ function SettingsDesktopLayout({ sections, sectionContentProps }: SettingsLayout
         contentContainerStyle={{ paddingBottom: insets.bottom }}
       >
         <View style={styles.content}>
-          <SettingsSectionContent
-            sectionId={selectedSectionId}
-            {...sectionContentProps}
-          />
+          <SettingsSectionContent sectionId={selectedSectionId} {...sectionContentProps} />
         </View>
       </ScrollView>
     </View>
@@ -1101,7 +1098,8 @@ export default function SettingsScreen() {
     handleSaveEditDaemon,
     handleRemoveConnection,
     handleRemoveDaemon,
-    restartConfirmationMessage: "This will restart the daemon. The app will reconnect automatically.",
+    restartConfirmationMessage:
+      "This will restart the daemon. The app will reconnect automatically.",
     waitForCondition,
     isMountedRef,
   };
@@ -1137,6 +1135,7 @@ export default function SettingsScreen() {
     appVersion,
     isLocalDaemon,
     isDesktopApp,
+    routeServerId,
   };
 
   if (isLoading) {

--- a/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
+++ b/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
@@ -25,7 +25,7 @@ const DRAFT_CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: true,
   supportsSessionPersistence: false,
   supportsDynamicModes: false,
-  supportsMcpServers: false,
+  supportsMcpServers: true,
   supportsReasoningStream: false,
   supportsToolInvocations: false,
 };

--- a/packages/app/src/utils/os-notifications.ts
+++ b/packages/app/src/utils/os-notifications.ts
@@ -7,6 +7,8 @@ type OsNotificationPayload = {
   title: string;
   body?: string;
   data?: Record<string, unknown>;
+  sound?: string;
+  actions?: Array<{ text: string }>;
 };
 
 export type WebNotificationClickDetail = {
@@ -27,6 +29,8 @@ function getDesktopNotificationSender():
       title: string;
       body?: string;
       data?: Record<string, unknown>;
+      sound?: string;
+      actions?: Array<{ text: string }>;
     }) => Promise<boolean>)
   | null {
   const sendNotification = getDesktopHost()?.notification?.sendNotification;
@@ -35,6 +39,8 @@ function getDesktopNotificationSender():
         title: string;
         body?: string;
         data?: Record<string, unknown>;
+        sound?: string;
+        actions?: Array<{ text: string }>;
       }) => Promise<boolean>)
     : null;
 }

--- a/packages/desktop/build/entitlements.mac.plist
+++ b/packages/desktop/build/entitlements.mac.plist
@@ -8,5 +8,7 @@
   <true/>
   <key>com.apple.security.device.audio-input</key>
   <true/>
+  <key>NSUserNotificationAlertStyle</key>
+  <string>alert</string>
 </dict>
 </plist>

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -15,6 +15,7 @@
     "@getpaseo/cli": "0.1.52",
     "@getpaseo/server": "0.1.52",
     "electron-log": "^5.4.3",
+    "electron-store": "^11.0.2",
     "electron-updater": "^6.6.2",
     "ws": "^8.14.2"
   },

--- a/packages/desktop/src/features/notification-settings.ts
+++ b/packages/desktop/src/features/notification-settings.ts
@@ -1,0 +1,22 @@
+import Store from "electron-store";
+
+type NotificationPreferences = {
+  soundEnabled: boolean;
+  soundName: string;
+};
+
+const store = new Store<NotificationPreferences>({
+  defaults: {
+    soundEnabled: true,
+    soundName: "Pop",
+  },
+});
+
+export function getNotificationSettings() {
+  return {
+    getSound: (): string => store.get("soundName", "Pop"),
+    setSound: (name: string): void => store.set("soundName", name),
+    isSoundEnabled: (): boolean => store.get("soundEnabled", true),
+    setSoundEnabled: (enabled: boolean): void => store.set("soundEnabled", enabled),
+  };
+}

--- a/packages/desktop/src/features/notifications.ts
+++ b/packages/desktop/src/features/notifications.ts
@@ -1,14 +1,23 @@
 import path from "node:path";
 import { existsSync } from "node:fs";
+import { execSync } from "child_process";
 import { app, BrowserWindow, Notification, ipcMain, nativeImage } from "electron";
+import { getNotificationSettings } from "./notification-settings";
 
 type NotificationInput = {
   title?: unknown;
   body?: unknown;
   data?: unknown;
+  actions?: Array<{ text: string }>;
 };
 
 type NotificationClickPayload = {
+  data?: Record<string, unknown>;
+};
+
+type NotificationActionPayload = {
+  action: string;
+  notificationId: string;
   data?: Record<string, unknown>;
 };
 
@@ -61,6 +70,18 @@ function focusSenderWindow(sender: Electron.WebContents): BrowserWindow | null {
   return win;
 }
 
+function playSystemSound(soundName: string): void {
+  if (process.platform !== "darwin") return;
+  try {
+    const soundPath = `/System/Library/Sounds/${soundName}.aiff`;
+    execSync(`osascript -e 'tell app "Finder" to play sound alias "${soundPath}"'`, {
+      timeout: 500,
+    });
+  } catch (error) {
+    console.warn("[notifications] Failed to play sound:", error);
+  }
+}
+
 /**
  * macOS requires a notification to have been shown at least once before
  * the app appears in System Preferences > Notifications. We fire a
@@ -68,41 +89,79 @@ function focusSenderWindow(sender: Electron.WebContents): BrowserWindow | null {
  */
 export function ensureNotificationCenterRegistration(): void {
   if (process.platform !== "darwin" || !Notification.isSupported()) {
+    console.warn("[notifications] Notification not supported on this platform");
     return;
   }
 
+  console.info("[notifications] Registering with Notification Center");
   const probe = new Notification({ title: app.name, silent: true });
-  probe.on("show", () => probe.close());
+  probe.on("show", () => {
+    console.info("[notifications] Probe notification shown successfully");
+    probe.close();
+  });
+  probe.on("close", () => console.info("[notifications] Probe notification closed"));
+  probe.on("failed", (_event, error) => {
+    console.error("[notifications] Probe notification failed:", error);
+  });
   setTimeout(() => probe.close(), 2_000);
   probe.show();
 }
 
 export function registerNotificationHandlers(): void {
   ipcMain.handle("paseo:notification:isSupported", () => {
-    return Notification.isSupported();
+    const supported = Notification.isSupported();
+    console.info("[notifications] Notification.isSupported():", supported);
+    return supported;
   });
 
   ipcMain.handle("paseo:notification:send", async (event, rawInput?: NotificationInput) => {
+    console.info("[notifications] send called with:", rawInput);
+
     if (!Notification.isSupported()) {
+      console.warn("[notifications] Notifications not supported");
       return false;
     }
 
     const title = toTrimmedString(rawInput?.title);
     if (!title) {
+      console.warn("[notifications] No title provided");
       return false;
     }
 
+    const settings = getNotificationSettings();
     const body = toTrimmedString(rawInput?.body) ?? undefined;
     const data = toRecord(rawInput?.data);
     const icon = getNotificationIcon();
+
     const notification = new Notification({
       title,
       ...(body ? { body } : {}),
       ...(icon ? { icon } : {}),
-      silent: true,
+      silent: !settings.isSoundEnabled(),
+      actions: rawInput?.actions?.map((a) => ({ type: "button", text: a.text })) ?? [],
     });
 
-    activeNotifications.add(notification);
+    const notificationId = `notif-${Date.now()}`;
+
+    if (settings.isSoundEnabled()) {
+      const soundName = settings.getSound();
+      notification.on("show", () => playSystemSound(soundName));
+    }
+
+    notification.on("action", (_event, index) => {
+      const actionText = rawInput?.actions?.[index]?.text;
+      if (actionText) {
+        const win = focusSenderWindow(event.sender);
+        if (win) {
+          win.webContents.send("paseo:event:notification-action", {
+            action: actionText,
+            notificationId,
+            data,
+          } satisfies NotificationActionPayload);
+        }
+      }
+      activeNotifications.delete(notification);
+    });
 
     notification.on("click", () => {
       const win = focusSenderWindow(event.sender);
@@ -117,7 +176,27 @@ export function registerNotificationHandlers(): void {
       activeNotifications.delete(notification);
     });
 
+    notification.on("failed", (_event, error) => {
+      console.error("[notifications] Notification failed:", error);
+      activeNotifications.delete(notification);
+    });
+
+    activeNotifications.add(notification);
     notification.show();
-    return true;
+    console.info("[notifications] Notification shown with id:", notificationId);
+    return { success: true, notificationId };
+  });
+
+  ipcMain.handle("paseo:notification:incrementBadge", () => {
+    if (process.platform === "darwin") {
+      const current = app.getBadgeCount();
+      app.setBadgeCount(current + 1);
+    }
+  });
+
+  ipcMain.handle("paseo:notification:clearBadge", () => {
+    if (process.platform === "darwin") {
+      app.setBadgeCount(0);
+    }
   });
 }

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -47,8 +47,35 @@ contextBridge.exposeInMainWorld("paseoDesktop", {
   },
   notification: {
     isSupported: () => ipcRenderer.invoke("paseo:notification:isSupported"),
-    sendNotification: (payload: { title: string; body?: string; data?: Record<string, unknown> }) =>
-      ipcRenderer.invoke("paseo:notification:send", payload),
+    sendNotification: (payload: {
+      title: string;
+      body?: string;
+      data?: Record<string, unknown>;
+      actions?: Array<{ text: string }>;
+    }) => ipcRenderer.invoke("paseo:notification:send", payload),
+    onAction: (
+      handler: (payload: {
+        action: string;
+        notificationId: string;
+        data?: Record<string, unknown>;
+      }) => void,
+    ): (() => void) => {
+      const listener = (_ipcEvent: Electron.IpcRendererEvent, payload: unknown) => {
+        handler(
+          payload as {
+            action: string;
+            notificationId: string;
+            data?: Record<string, unknown>;
+          },
+        );
+      };
+      ipcRenderer.on("paseo:event:notification-action", listener);
+      return () => {
+        ipcRenderer.removeListener("paseo:event:notification-action", listener);
+      };
+    },
+    incrementBadge: () => ipcRenderer.invoke("paseo:notification:incrementBadge"),
+    clearBadge: () => ipcRenderer.invoke("paseo:notification:clearBadge"),
   },
   opener: {
     openUrl: (url: string) => ipcRenderer.invoke("paseo:opener:openUrl", url),

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -62,15 +62,10 @@ import type {
   SessionInboundMessage,
   SessionOutboundMessage,
   EditorTargetId,
-  ListMcpServersRequestMessage,
   ListMcpServersResponse,
-  CreateMcpServerRequestMessage,
   CreateMcpServerResponse,
-  UpdateMcpServerRequestMessage,
   UpdateMcpServerResponse,
-  DeleteMcpServerRequestMessage,
   DeleteMcpServerResponse,
-  ToggleMcpServerRequestMessage,
   ToggleMcpServerResponse,
 } from "../shared/messages.js";
 import type {

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -62,6 +62,16 @@ import type {
   SessionInboundMessage,
   SessionOutboundMessage,
   EditorTargetId,
+  ListMcpServersRequestMessage,
+  ListMcpServersResponse,
+  CreateMcpServerRequestMessage,
+  CreateMcpServerResponse,
+  UpdateMcpServerRequestMessage,
+  UpdateMcpServerResponse,
+  DeleteMcpServerRequestMessage,
+  DeleteMcpServerResponse,
+  ToggleMcpServerRequestMessage,
+  ToggleMcpServerResponse,
 } from "../shared/messages.js";
 import type {
   AgentPermissionRequest,
@@ -70,6 +80,7 @@ import type {
   AgentProvider,
   AgentSessionConfig,
 } from "../server/agent/agent-sdk-types.js";
+import type { McpServerRecord } from "../server/mcp/mcp-server-types.js";
 import { getAgentProviderDefinition } from "../server/agent/provider-manifest.js";
 import { isRelayClientWebSocketUrl } from "../shared/daemon-endpoints.js";
 import {
@@ -273,10 +284,7 @@ type ChatCreatePayload = Extract<
   SessionOutboundMessage,
   { type: "chat/create/response" }
 >["payload"];
-type ChatListPayload = Extract<
-  SessionOutboundMessage,
-  { type: "chat/list/response" }
->["payload"];
+type ChatListPayload = Extract<SessionOutboundMessage, { type: "chat/list/response" }>["payload"];
 type ChatInspectPayload = Extract<
   SessionOutboundMessage,
   { type: "chat/inspect/response" }
@@ -285,38 +293,17 @@ type ChatDeletePayload = Extract<
   SessionOutboundMessage,
   { type: "chat/delete/response" }
 >["payload"];
-type ChatPostPayload = Extract<
-  SessionOutboundMessage,
-  { type: "chat/post/response" }
->["payload"];
-type ChatReadPayload = Extract<
-  SessionOutboundMessage,
-  { type: "chat/read/response" }
->["payload"];
-type ChatWaitPayload = Extract<
-  SessionOutboundMessage,
-  { type: "chat/wait/response" }
->["payload"];
-type LoopRunPayload = Extract<
-  SessionOutboundMessage,
-  { type: "loop/run/response" }
->["payload"];
-type LoopListPayload = Extract<
-  SessionOutboundMessage,
-  { type: "loop/list/response" }
->["payload"];
+type ChatPostPayload = Extract<SessionOutboundMessage, { type: "chat/post/response" }>["payload"];
+type ChatReadPayload = Extract<SessionOutboundMessage, { type: "chat/read/response" }>["payload"];
+type ChatWaitPayload = Extract<SessionOutboundMessage, { type: "chat/wait/response" }>["payload"];
+type LoopRunPayload = Extract<SessionOutboundMessage, { type: "loop/run/response" }>["payload"];
+type LoopListPayload = Extract<SessionOutboundMessage, { type: "loop/list/response" }>["payload"];
 type LoopInspectPayload = Extract<
   SessionOutboundMessage,
   { type: "loop/inspect/response" }
 >["payload"];
-type LoopLogsPayload = Extract<
-  SessionOutboundMessage,
-  { type: "loop/logs/response" }
->["payload"];
-type LoopStopPayload = Extract<
-  SessionOutboundMessage,
-  { type: "loop/stop/response" }
->["payload"];
+type LoopLogsPayload = Extract<SessionOutboundMessage, { type: "loop/logs/response" }>["payload"];
+type LoopStopPayload = Extract<SessionOutboundMessage, { type: "loop/stop/response" }>["payload"];
 type ScheduleCreatePayload = Extract<
   SessionOutboundMessage,
   { type: "schedule/create/response" }
@@ -502,6 +489,26 @@ export type WaitForFinishResult = {
   error: string | null;
   lastMessage: string | null;
 };
+
+export type ListMcpServersResult = ListMcpServersResponse["payload"];
+
+export type CreateMcpServerResult = CreateMcpServerResponse["payload"];
+
+export type UpdateMcpServerResult = UpdateMcpServerResponse["payload"];
+
+export type DeleteMcpServerResult = DeleteMcpServerResponse["payload"];
+
+export type ToggleMcpServerResult = ToggleMcpServerResponse["payload"];
+
+export type CreateMcpServerOptions = Omit<McpServerRecord, "id" | "createdAt" | "updatedAt">;
+
+export type UpdateMcpServerOptions = Partial<
+  Omit<McpServerRecord, "id" | "createdAt" | "updatedAt">
+>;
+
+export type DeleteMcpServerOptions = string;
+
+export type ToggleMcpServerOptions = { id: string; enabled: boolean };
 
 type Waiter<T> = {
   predicate: (msg: SessionOutboundMessage) => T | null;
@@ -2430,11 +2437,7 @@ export class DaemonClient {
     });
   }
 
-  async stashPop(
-    cwd: string,
-    stashIndex: number,
-    requestId?: string,
-  ): Promise<StashPopPayload> {
+  async stashPop(cwd: string, stashIndex: number, requestId?: string): Promise<StashPopPayload> {
     return this.sendCorrelatedSessionRequest({
       requestId,
       message: {
@@ -3351,8 +3354,7 @@ export class DaemonClient {
   }
 
   async loopLogs(options: string | LoopLogsOptions, afterSeq?: number): Promise<LoopLogsPayload> {
-    const normalized =
-      typeof options === "string" ? { id: options, afterSeq } : options;
+    const normalized = typeof options === "string" ? { id: options, afterSeq } : options;
     return this.sendCorrelatedSessionRequest({
       requestId: normalized.requestId,
       message: {
@@ -3901,6 +3903,142 @@ export class DaemonClient {
     };
 
     return { promise, cancel };
+  }
+
+  async listMcpServers(): Promise<{
+    requestId: string;
+    servers: McpServerRecord[];
+    error: string | null;
+  }> {
+    const requestId = this.createRequestId();
+    const message = SessionInboundMessageSchema.parse({
+      type: "list_mcp_servers_request",
+      requestId,
+    });
+    return await this.sendRequest({
+      requestId,
+      message,
+      timeout: 10000,
+      options: { skipQueue: false },
+      select: (msg) => {
+        if (msg.type !== "list_mcp_servers_response") {
+          return null;
+        }
+        if (msg.payload.requestId !== requestId) {
+          return null;
+        }
+        return msg.payload;
+      },
+    });
+  }
+
+  async createMcpServer(options: CreateMcpServerOptions): Promise<CreateMcpServerResult> {
+    const requestId = this.createRequestId();
+    const message = SessionInboundMessageSchema.parse({
+      type: "create_mcp_server_request",
+      payload: {
+        requestId,
+        server: options,
+      },
+    });
+    return await this.sendRequest({
+      requestId,
+      message,
+      timeout: 10000,
+      options: { skipQueue: false },
+      select: (msg) => {
+        if (msg.type !== "create_mcp_server_response") {
+          return null;
+        }
+        if (msg.payload.requestId !== requestId) {
+          return null;
+        }
+        return msg.payload;
+      },
+    });
+  }
+
+  async updateMcpServer(
+    id: string,
+    options: UpdateMcpServerOptions,
+  ): Promise<UpdateMcpServerResult> {
+    const requestId = this.createRequestId();
+    const message = SessionInboundMessageSchema.parse({
+      type: "update_mcp_server_request",
+      payload: {
+        requestId,
+        id,
+        updates: options,
+      },
+    });
+    return await this.sendRequest({
+      requestId,
+      message,
+      timeout: 10000,
+      options: { skipQueue: false },
+      select: (msg) => {
+        if (msg.type !== "update_mcp_server_response") {
+          return null;
+        }
+        if (msg.payload.requestId !== requestId) {
+          return null;
+        }
+        return msg.payload;
+      },
+    });
+  }
+
+  async deleteMcpServer(options: DeleteMcpServerOptions): Promise<DeleteMcpServerResult> {
+    const requestId = this.createRequestId();
+    const message = SessionInboundMessageSchema.parse({
+      type: "delete_mcp_server_request",
+      payload: {
+        requestId,
+        id: options,
+      },
+    });
+    return await this.sendRequest({
+      requestId,
+      message,
+      timeout: 10000,
+      options: { skipQueue: false },
+      select: (msg) => {
+        if (msg.type !== "delete_mcp_server_response") {
+          return null;
+        }
+        if (msg.payload.requestId !== requestId) {
+          return null;
+        }
+        return msg.payload;
+      },
+    });
+  }
+
+  async toggleMcpServer(options: ToggleMcpServerOptions): Promise<ToggleMcpServerResult> {
+    const requestId = this.createRequestId();
+    const message = SessionInboundMessageSchema.parse({
+      type: "toggle_mcp_server_request",
+      payload: {
+        requestId,
+        id: options.id,
+        enabled: options.enabled,
+      },
+    });
+    return await this.sendRequest({
+      requestId,
+      message,
+      timeout: 10000,
+      options: { skipQueue: false },
+      select: (msg) => {
+        if (msg.type !== "toggle_mcp_server_response") {
+          return null;
+        }
+        if (msg.payload.requestId !== requestId) {
+          return null;
+        }
+        return msg.payload;
+      },
+    });
   }
 }
 

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -633,7 +633,6 @@ export async function createPaseoDaemon(
       scheduleService,
       checkoutDiffManager,
       mcpServerStore,
-      checkoutDiffManager,
     );
 
     logger.info({ elapsed: elapsed() }, "Bootstrap complete, ready to start listening");

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -9,6 +9,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "pino";
+import { McpServerStore } from "./mcp/mcp-server-store.js";
 
 export type ListenTarget =
   | { type: "tcp"; host: string; port: number }
@@ -175,6 +176,7 @@ export type PaseoDaemonConfig = {
   mcpDebug: boolean;
   agentClients: Partial<Record<AgentProvider, AgentClient>>;
   agentStoragePath: string;
+  mcpServersPath: string;
   relayEnabled?: boolean;
   relayEndpoint?: string;
   relayPublicEndpoint?: string;
@@ -338,6 +340,7 @@ export async function createPaseoDaemon(
     const httpServer = createHTTPServer(app);
 
     const agentStorage = new AgentStorage(config.agentStoragePath, logger);
+    const mcpServerStore = new McpServerStore(config.mcpServersPath, logger);
     const projectRegistry = new FileBackedProjectRegistry(
       path.join(config.paseoHome, "projects", "projects.json"),
       logger,
@@ -370,6 +373,8 @@ export async function createPaseoDaemon(
     );
     await agentStorage.initialize();
     logger.info({ elapsed: elapsed() }, "Agent storage initialized");
+    await mcpServerStore.initialize();
+    logger.info({ elapsed: elapsed() }, "MCP server store initialized");
     await bootstrapWorkspaceRegistries({
       paseoHome: config.paseoHome,
       agentStorage,
@@ -626,6 +631,8 @@ export async function createPaseoDaemon(
       chatService,
       loopService,
       scheduleService,
+      checkoutDiffManager,
+      mcpServerStore,
       checkoutDiffManager,
     );
 

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -51,7 +51,10 @@ export function loadConfig(
   // - unix:///path/to/socket (Unix socket)
   // Default is TCP at 127.0.0.1:6767
   const listen =
-    options?.cli?.listen ?? env.PASEO_LISTEN ?? persisted.daemon?.listen ?? `127.0.0.1:${env.PORT ?? DEFAULT_PORT}`;
+    options?.cli?.listen ??
+    env.PASEO_LISTEN ??
+    persisted.daemon?.listen ??
+    `127.0.0.1:${env.PORT ?? DEFAULT_PORT}`;
 
   const envCorsOrigins = env.PASEO_CORS_ORIGINS
     ? env.PASEO_CORS_ORIGINS.split(",").map((s) => s.trim())
@@ -102,6 +105,7 @@ export function loadConfig(
     mcpEnabled,
     mcpDebug: env.MCP_DEBUG === "1",
     agentStoragePath: path.join(paseoHome, "agents"),
+    mcpServersPath: path.join(paseoHome, "mcp-servers.json"),
     staticDir: "public",
     agentClients: {},
     relayEnabled,

--- a/packages/server/src/server/mcp/mcp-server-store.test.ts
+++ b/packages/server/src/server/mcp/mcp-server-store.test.ts
@@ -135,7 +135,29 @@ describe("McpServerStore", () => {
       type: "stdio",
       config: { type: "stdio", command: "echo" },
       enabled: false,
+      description: "Original description",
     });
+
+    // Wait to ensure updatedAt changes
+    await new Promise(resolve => setTimeout(resolve, 1));
+
+    const updated = await storage.update(original.id, {
+      name: "updated-name",
+      enabled: true,
+      description: "Updated description",
+      tags: ["updated"],
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated).toMatchObject({
+      id: original.id,
+      name: "updated-name",
+      enabled: true,
+      description: "Updated description",
+    });
+    expect(updated!.updatedAt).not.toBe(original.updatedAt);
+    expect(updated!.createdAt).toBe(original.createdAt);
+  });
 
     const updated = await storage.update(original.id, {
       name: "updated-name",

--- a/packages/server/src/server/mcp/mcp-server-store.test.ts
+++ b/packages/server/src/server/mcp/mcp-server-store.test.ts
@@ -139,30 +139,13 @@ describe("McpServerStore", () => {
     });
 
     // Wait to ensure updatedAt changes
-    await new Promise(resolve => setTimeout(resolve, 1));
+    await new Promise((resolve) => setTimeout(resolve, 1));
 
     const updated = await storage.update(original.id, {
       name: "updated-name",
       enabled: true,
       description: "Updated description",
       tags: ["updated"],
-    });
-
-    expect(updated).not.toBeNull();
-    expect(updated).toMatchObject({
-      id: original.id,
-      name: "updated-name",
-      enabled: true,
-      description: "Updated description",
-    });
-    expect(updated!.updatedAt).not.toBe(original.updatedAt);
-    expect(updated!.createdAt).toBe(original.createdAt);
-  });
-
-    const updated = await storage.update(original.id, {
-      name: "updated-name",
-      enabled: true,
-      description: "Updated description",
     });
 
     expect(updated).not.toBeNull();

--- a/packages/server/src/server/mcp/mcp-server-store.test.ts
+++ b/packages/server/src/server/mcp/mcp-server-store.test.ts
@@ -1,0 +1,490 @@
+import { describe, expect, test, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { promises as fs } from "node:fs";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import { McpServerStore } from "./mcp-server-store.js";
+import type { McpServerConfig } from "./mcp-server-types.js";
+
+describe("McpServerStore", () => {
+  let tmpDir: string;
+  let storagePath: string;
+  let storage: McpServerStore;
+  const logger = createTestLogger();
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "mcp-server-store-"));
+    storagePath = path.join(tmpDir, "mcp-servers.json");
+    storage = new McpServerStore(storagePath, logger);
+    await storage.initialize();
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  test("listMcpServers returns empty array initially", async () => {
+    const servers = await storage.list();
+    expect(servers).toEqual([]);
+  });
+
+  test("addMcpServer creates new server", async () => {
+    const serverConfig: McpServerConfig = {
+      type: "stdio",
+      command: "echo",
+      args: ["hello"],
+      env: { TEST: "value" },
+    };
+
+    const server = await storage.add({
+      name: "test-stdio-server",
+      type: "stdio",
+      config: serverConfig,
+      enabled: true,
+      tags: ["test"],
+      description: "Test stdio server",
+    });
+
+    expect(server.id).toBeDefined();
+    expect(server).toMatchObject({
+      name: "test-stdio-server",
+      type: "stdio",
+      config: serverConfig,
+      enabled: true,
+      tags: ["test"],
+      description: "Test stdio server",
+    });
+    expect(server.createdAt).toBe(server.updatedAt);
+  });
+
+  test("getMcpServer returns server by id", async () => {
+    const serverConfig: McpServerConfig = {
+      type: "http",
+      url: "http://localhost:8080/mcp",
+      headers: { Authorization: "Bearer token" },
+    };
+
+    const created = await storage.add({
+      name: "test-http-server",
+      type: "http",
+      config: serverConfig,
+    });
+
+    const fetched = await storage.get(created.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched).toMatchObject({
+      id: created.id,
+      name: "test-http-server",
+      type: "http",
+      config: serverConfig,
+      enabled: true,
+    });
+  });
+
+  test("getMcpServer returns null for non-existent id", async () => {
+    const fetched = await storage.get("non-existent-id");
+    expect(fetched).toBeNull();
+  });
+
+  test("getByIds returns multiple servers", async () => {
+    const server1 = await storage.add({
+      name: "server-1",
+      type: "stdio",
+      config: { type: "stdio", command: "echo", args: ["1"] },
+    });
+
+    const server2 = await storage.add({
+      name: "server-2",
+      type: "stdio",
+      config: { type: "stdio", command: "echo", args: ["2"] },
+    });
+
+    const fetched = await storage.getByIds([server1.id, server2.id]);
+    expect(fetched).toHaveLength(2);
+    expect(fetched.map((s) => s.id)).toContain(server1.id);
+    expect(fetched.map((s) => s.id)).toContain(server2.id);
+  });
+
+  test("getByIds filters by provided ids", async () => {
+    const server1 = await storage.add({
+      name: "server-1",
+      type: "stdio",
+      config: { type: "stdio", command: "echo", args: ["1"] },
+    });
+
+    const server2 = await storage.add({
+      name: "server-2",
+      type: "stdio",
+      config: { type: "stdio", command: "echo", args: ["2"] },
+    });
+
+    const fetched = await storage.getByIds([server1.id]);
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0].id).toBe(server1.id);
+  });
+
+  test("updateMcpServer updates existing server", async () => {
+    const original = await storage.add({
+      name: "original-name",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: false,
+    });
+
+    const updated = await storage.update(original.id, {
+      name: "updated-name",
+      enabled: true,
+      description: "Updated description",
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated).toMatchObject({
+      id: original.id,
+      name: "updated-name",
+      enabled: true,
+      description: "Updated description",
+    });
+    expect(updated!.updatedAt).not.toBe(original.updatedAt);
+    expect(updated!.createdAt).toBe(original.createdAt);
+  });
+
+  test("updateMcpServer returns null for non-existent id", async () => {
+    const updated = await storage.update("non-existent-id", {
+      name: "updated-name",
+    });
+
+    expect(updated).toBeNull();
+  });
+
+  test("deleteMcpServer removes server", async () => {
+    const server = await storage.add({
+      name: "to-delete",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+    });
+
+    const deleted = await storage.delete(server.id);
+    expect(deleted).toBe(true);
+
+    const fetched = await storage.get(server.id);
+    expect(fetched).toBeNull();
+  });
+
+  test("deleteMcpServer returns false for non-existent id", async () => {
+    const deleted = await storage.delete("non-existent-id");
+    expect(deleted).toBe(false);
+  });
+
+  test("enable enables server", async () => {
+    const server = await storage.add({
+      name: "to-enable",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: false,
+    });
+
+    const enabled = await storage.enable(server.id);
+    expect(enabled).toBe(true);
+
+    const fetched = await storage.get(server.id);
+    expect(fetched?.enabled).toBe(true);
+  });
+
+  test("enable returns false for non-existent id", async () => {
+    const enabled = await storage.enable("non-existent-id");
+    expect(enabled).toBe(false);
+  });
+
+  test("disable disables server", async () => {
+    const server = await storage.add({
+      name: "to-disable",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: true,
+    });
+
+    const disabled = await storage.disable(server.id);
+    expect(disabled).toBe(true);
+
+    const fetched = await storage.get(server.id);
+    expect(fetched?.enabled).toBe(false);
+  });
+
+  test("disable returns false for non-existent id", async () => {
+    const disabled = await storage.disable("non-existent-id");
+    expect(disabled).toBe(false);
+  });
+
+  test("listEnabled returns only enabled servers", async () => {
+    await storage.add({
+      name: "enabled-server",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: true,
+    });
+
+    await storage.add({
+      name: "disabled-server",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: false,
+    });
+
+    const enabled = await storage.listEnabled();
+    expect(enabled).toHaveLength(1);
+    expect(enabled[0].name).toBe("enabled-server");
+  });
+
+  test("persisted data survives restart", async () => {
+    const server1 = await storage.add({
+      name: "persistent-server-1",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: true,
+      tags: ["persistent"],
+    });
+
+    const server2 = await storage.add({
+      name: "persistent-server-2",
+      type: "http",
+      config: { type: "http", url: "http://localhost:8080" },
+      enabled: false,
+    });
+
+    // Create new store instance with same path
+    const newStorage = new McpServerStore(storagePath, logger);
+    await newStorage.initialize();
+
+    const servers = await newStorage.list();
+    expect(servers).toHaveLength(2);
+    expect(servers.map((s) => s.id)).toContain(server1.id);
+    expect(servers.map((s) => s.id)).toContain(server2.id);
+
+    await newStorage.close?.();
+  });
+
+  test("resolveMcpServers converts server IDs to config", async () => {
+    const server1 = await storage.add({
+      name: "server-1",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: true,
+    });
+
+    const server2 = await storage.add({
+      name: "server-2",
+      type: "http",
+      config: { type: "http", url: "http://localhost:8080" },
+      enabled: true,
+    });
+
+    const server3 = await storage.add({
+      name: "server-3",
+      type: "sse",
+      config: { type: "sse", url: "http://localhost:8080/sse" },
+      enabled: false,
+    });
+
+    const resolved = storage.resolveMcpServers([server1.id, server2.id, server3.id]);
+
+    expect(resolved).toBeDefined();
+    expect(Object.keys(resolved!)).toHaveLength(2);
+    expect(resolved!).toHaveProperty("server-1");
+    expect(resolved!).toHaveProperty("server-2");
+    expect(resolved!).not.toHaveProperty("server-3");
+  });
+
+  test("resolveMcpServers returns undefined for empty ids", async () => {
+    const resolved = storage.resolveMcpServers([]);
+    expect(resolved).toBeUndefined();
+  });
+
+  test("resolveMcpServers returns undefined for all disabled servers", async () => {
+    const server1 = await storage.add({
+      name: "disabled-server-1",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: false,
+    });
+
+    const server2 = await storage.add({
+      name: "disabled-server-2",
+      type: "http",
+      config: { type: "http", url: "http://localhost:8080" },
+      enabled: false,
+    });
+
+    const resolved = storage.resolveMcpServers([server1.id, server2.id]);
+    expect(resolved).toBeUndefined();
+  });
+
+  test("supports all MCP server types", async () => {
+    const stdioServer = await storage.add({
+      name: "stdio-server",
+      type: "stdio",
+      config: {
+        type: "stdio",
+        command: "npx",
+        args: ["-y", "command"],
+        env: { NODE_ENV: "production" },
+      },
+    });
+
+    const httpServer = await storage.add({
+      name: "http-server",
+      type: "http",
+      config: {
+        type: "http",
+        url: "http://localhost:8080/mcp",
+        headers: { Authorization: "Bearer token" },
+      },
+    });
+
+    const sseServer = await storage.add({
+      name: "sse-server",
+      type: "sse",
+      config: {
+        type: "sse",
+        url: "http://localhost:8080/sse",
+        headers: { "X-Custom": "value" },
+      },
+    });
+
+    const servers = await storage.list();
+    expect(servers).toHaveLength(3);
+
+    expect(stdioServer.config).toMatchObject({
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "command"],
+      env: { NODE_ENV: "production" },
+    });
+
+    expect(httpServer.config).toMatchObject({
+      type: "http",
+      url: "http://localhost:8080/mcp",
+      headers: { Authorization: "Bearer token" },
+    });
+
+    expect(sseServer.config).toMatchObject({
+      type: "sse",
+      url: "http://localhost:8080/sse",
+      headers: { "X-Custom": "value" },
+    });
+  });
+
+  test("handles SSE server type correctly", async () => {
+    const server = await storage.add({
+      name: "sse-test-server",
+      type: "sse",
+      config: {
+        type: "sse",
+        url: "http://localhost:8080/sse",
+        headers: { "Content-Type": "text/event-stream" },
+      },
+    });
+
+    expect(server.type).toBe("sse");
+    expect(server.config.type).toBe("sse");
+
+    const fetched = await storage.get(server.id);
+    expect(fetched).toMatchObject({
+      name: "sse-test-server",
+      type: "sse",
+      config: {
+        type: "sse",
+        url: "http://localhost:8080/sse",
+        headers: { "Content-Type": "text/event-stream" },
+      },
+    });
+  });
+
+  test("handles HTTP server type correctly", async () => {
+    const server = await storage.add({
+      name: "http-test-server",
+      type: "http",
+      config: {
+        type: "http",
+        url: "https://api.example.com/mcp",
+        headers: {
+          Authorization: "Bearer token123",
+          "X-API-Key": "secret",
+        },
+      },
+    });
+
+    expect(server.type).toBe("http");
+    expect(server.config.type).toBe("http");
+
+    const fetched = await storage.get(server.id);
+    expect(fetched).toMatchObject({
+      name: "http-test-server",
+      type: "http",
+      config: {
+        type: "http",
+        url: "https://api.example.com/mcp",
+        headers: {
+          Authorization: "Bearer token123",
+          "X-API-Key": "secret",
+        },
+      },
+    });
+  });
+
+  test("handles stdio server type correctly", async () => {
+    const server = await storage.add({
+      name: "stdio-test-server",
+      type: "stdio",
+      config: {
+        type: "stdio",
+        command: "python",
+        args: ["-m", "mcp_server"],
+        env: {
+          PATH: "/usr/local/bin",
+          PYTHONPATH: "/opt/python",
+        },
+      },
+    });
+
+    expect(server.type).toBe("stdio");
+    expect(server.config.type).toBe("stdio");
+
+    const fetched = await storage.get(server.id);
+    expect(fetched).toMatchObject({
+      name: "stdio-test-server",
+      type: "stdio",
+      config: {
+        type: "stdio",
+        command: "python",
+        args: ["-m", "mcp_server"],
+        env: {
+          PATH: "/usr/local/bin",
+          PYTHONPATH: "/opt/python",
+        },
+      },
+    });
+  });
+
+  test("atomic write prevents data loss on crash", async () => {
+    const server = await storage.add({
+      name: "atomic-test",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+    });
+
+    // File should exist and be valid JSON
+    const fileContent = await fs.readFile(storagePath, "utf8");
+    const parsed = JSON.parse(fileContent);
+
+    expect(parsed).toHaveProperty("servers");
+    expect(Array.isArray(parsed.servers)).toBe(true);
+    expect(parsed.servers).toHaveLength(1);
+    expect(parsed.servers[0].id).toBe(server.id);
+  });
+});

--- a/packages/server/src/server/mcp/mcp-server-store.ts
+++ b/packages/server/src/server/mcp/mcp-server-store.ts
@@ -104,6 +104,7 @@ export class McpServerStore {
       description: input.description,
     };
 
+    this.cache.set(record.id, record);
     await this.save();
 
     return record;

--- a/packages/server/src/server/mcp/mcp-server-store.ts
+++ b/packages/server/src/server/mcp/mcp-server-store.ts
@@ -1,0 +1,241 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+import type { Logger } from "pino";
+
+import type { McpServerConfig } from "../agent/agent-sdk-types.js";
+import type {
+  CreateMcpServerInput,
+  McpServerRecord,
+  McpServersStoreData,
+  UpdateMcpServerInput,
+} from "./mcp-server-types.js";
+
+const MCP_SERVER_CONFIG_SCHEMA = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("stdio"),
+    command: z.string(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string()).optional(),
+  }),
+  z.object({
+    type: z.literal("http"),
+    url: z.string(),
+    headers: z.record(z.string()).optional(),
+  }),
+  z.object({
+    type: z.literal("sse"),
+    url: z.string(),
+    headers: z.record(z.string()).optional(),
+  }),
+]);
+
+const MCP_SERVER_RECORD_SCHEMA = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(["stdio", "http", "sse"]),
+  config: MCP_SERVER_CONFIG_SCHEMA,
+  enabled: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  tags: z.array(z.string()).optional(),
+  description: z.string().optional(),
+});
+
+const MCP_SERVERS_STORE_SCHEMA = z.object({
+  servers: z.array(MCP_SERVER_RECORD_SCHEMA),
+});
+
+export class McpServerStore {
+  private cache: Map<string, McpServerRecord> = new Map();
+  private loaded = false;
+  private filePath: string;
+  private loadPromise: Promise<void> | null = null;
+  private logger: Logger;
+
+  constructor(filePath: string, logger: Logger) {
+    this.filePath = filePath;
+    this.logger = logger.child({
+      module: "mcp",
+      component: "mcp-server-store",
+    });
+  }
+
+  async initialize(): Promise<void> {
+    await this.load();
+  }
+
+  async list(): Promise<McpServerRecord[]> {
+    await this.load();
+    return Array.from(this.cache.values());
+  }
+
+  async listEnabled(): Promise<McpServerRecord[]> {
+    await this.load();
+    return Array.from(this.cache.values()).filter((s) => s.enabled);
+  }
+
+  async get(id: string): Promise<McpServerRecord | null> {
+    await this.load();
+    return this.cache.get(id) ?? null;
+  }
+
+  async getByIds(ids: string[]): Promise<McpServerRecord[]> {
+    await this.load();
+    return ids
+      .map((id) => this.cache.get(id))
+      .filter((server): server is McpServerRecord => server !== undefined);
+  }
+
+  async add(input: CreateMcpServerInput): Promise<McpServerRecord> {
+    await this.load();
+
+    const now = new Date().toISOString();
+    const record: McpServerRecord = {
+      id: randomUUID(),
+      name: input.name,
+      type: input.type,
+      config: input.config,
+      enabled: input.enabled ?? true,
+      createdAt: now,
+      updatedAt: now,
+      tags: input.tags,
+      description: input.description,
+    };
+
+    await this.save();
+
+    return record;
+  }
+
+  async update(id: string, updates: UpdateMcpServerInput): Promise<McpServerRecord | null> {
+    await this.load();
+
+    const existing = this.cache.get(id);
+    if (!existing) {
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    const updated: McpServerRecord = {
+      ...existing,
+      ...(updates.name !== undefined && { name: updates.name }),
+      ...(updates.type !== undefined && { type: updates.type }),
+      ...(updates.config !== undefined && { config: updates.config }),
+      ...(updates.enabled !== undefined && { enabled: updates.enabled }),
+      ...(updates.tags !== undefined && { tags: updates.tags }),
+      ...(updates.description !== undefined && { description: updates.description }),
+      updatedAt: now,
+    };
+
+    this.cache.set(id, updated);
+    await this.save();
+
+    return updated;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    await this.load();
+
+    if (!this.cache.has(id)) {
+      return false;
+    }
+
+    this.cache.delete(id);
+    await this.save();
+
+    return true;
+  }
+
+  async enable(id: string): Promise<boolean> {
+    return this.update(id, { enabled: true }).then((r) => r !== null);
+  }
+
+  async disable(id: string): Promise<boolean> {
+    return this.update(id, { enabled: false }).then((r) => r !== null);
+  }
+
+  private async load(): Promise<void> {
+    if (this.loaded) {
+      return;
+    }
+
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+
+    this.loadPromise = this.performLoad();
+    await this.loadPromise;
+    this.loadPromise = null;
+  }
+
+  private async performLoad(): Promise<void> {
+    try {
+      const data = await fs.readFile(this.filePath, "utf8");
+      const parsed = JSON.parse(data);
+      const validated = MCP_SERVERS_STORE_SCHEMA.parse(parsed);
+
+      this.cache.clear();
+      for (const server of validated.servers) {
+        this.cache.set(server.id, server);
+      }
+
+      this.loaded = true;
+      this.logger.info({ count: validated.servers.length }, "Loaded MCP servers from disk");
+    } catch (err) {
+      if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+        this.logger.info("MCP servers file not found, starting with empty store");
+        this.loaded = true;
+        return;
+      }
+
+      this.logger.error({ err }, "Failed to load MCP servers from disk");
+      throw err;
+    }
+  }
+
+  private async save(): Promise<void> {
+    const data: McpServersStoreData = {
+      servers: Array.from(this.cache.values()),
+    };
+
+    await writeFileAtomically(this.filePath, JSON.stringify(data, null, 2));
+    this.logger.debug({ count: data.servers.length }, "Saved MCP servers to disk");
+  }
+
+  resolveMcpServers(serverIds?: string[]): Record<string, McpServerConfig> | undefined {
+    if (!serverIds || serverIds.length === 0) {
+      return undefined;
+    }
+
+    const servers = Array.from(this.cache.values()).filter(
+      (s) => s.enabled && serverIds.includes(s.id),
+    );
+
+    if (servers.length === 0) {
+      return undefined;
+    }
+
+    return servers.reduce(
+      (acc, server) => {
+        acc[server.name] = server.config;
+        return acc;
+      },
+      {} as Record<string, McpServerConfig>,
+    );
+  }
+}
+
+async function writeFileAtomically(targetPath: string, payload: string): Promise<void> {
+  const directory = path.dirname(targetPath);
+  await fs.mkdir(directory, { recursive: true });
+
+  const tempPath = path.join(
+    directory,
+    `.mcp-servers.tmp-${process.pid}-${Date.now()}-${randomUUID()}`,
+  );
+
+  await fs.writeFile(tempPath, payload, "utf8");
+  await fs.rename(tempPath, targetPath);
+}

--- a/packages/server/src/server/mcp/mcp-server-types.ts
+++ b/packages/server/src/server/mcp/mcp-server-types.ts
@@ -1,0 +1,47 @@
+import type { McpServerConfig } from "../agent/agent-sdk-types.js";
+
+/**
+ * MCP server record persisted to disk.
+ */
+export interface McpServerRecord {
+  id: string;
+  name: string;
+  type: "stdio" | "http" | "sse";
+  config: McpServerConfig;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+  tags?: string[];
+  description?: string;
+}
+
+/**
+ * Store structure for MCP servers file.
+ */
+export interface McpServersStoreData {
+  servers: McpServerRecord[];
+}
+
+/**
+ * Input for creating a new MCP server.
+ */
+export interface CreateMcpServerInput {
+  name: string;
+  type: "stdio" | "http" | "sse";
+  config: McpServerConfig;
+  enabled?: boolean;
+  tags?: string[];
+  description?: string;
+}
+
+/**
+ * Updates for an existing MCP server.
+ */
+export interface UpdateMcpServerInput {
+  name?: string;
+  type?: "stdio" | "http" | "sse";
+  config?: McpServerConfig;
+  enabled?: boolean;
+  tags?: string[];
+  description?: string;
+}

--- a/packages/server/src/server/mcp/mcp-server-types.ts
+++ b/packages/server/src/server/mcp/mcp-server-types.ts
@@ -1,4 +1,5 @@
 import type { McpServerConfig } from "../agent/agent-sdk-types.js";
+export type { McpServerConfig } from "../agent/agent-sdk-types.js";
 
 /**
  * MCP server record persisted to disk.

--- a/packages/server/src/server/session.mcp-agent-integration.e2e.test.ts
+++ b/packages/server/src/server/session.mcp-agent-integration.e2e.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+
+import { createDaemonTestContext, type DaemonTestContext } from "../test-utils/index.js";
+import type { McpServerConfig } from "./mcp-server-types.js";
+
+describe("MCP server agent integration", () => {
+  let ctx: DaemonTestContext;
+
+  beforeEach(async () => {
+    ctx = await createDaemonTestContext();
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  }, 60000);
+
+  test("createAgent with mcpServers passes config to agent", async () => {
+    const mcpServerConfig: McpServerConfig = {
+      type: "stdio",
+      command: "echo",
+      args: ["hello"],
+      env: { TEST: "value" },
+    };
+
+    const server = await ctx.client.createMcpServer({
+      name: "test-echo-server",
+      type: "stdio",
+      config: mcpServerConfig,
+      enabled: true,
+    });
+
+    expect(server.error).toBeNull();
+    expect(server.server).toBeDefined();
+
+    const cwd = mkdtempSync(path.join(tmpdir(), "mcp-agent-test-"));
+
+    try {
+      const agent = await ctx.client.createAgent({
+        config: {
+          provider: "opencode",
+          cwd,
+          mcpServers: {
+            "test-echo-server": mcpServerConfig,
+          },
+        },
+        initialPrompt: "hello",
+      });
+
+      expect(agent).toBeDefined();
+      expect(agent.id).toBeDefined();
+      expect(agent.config).toBeDefined();
+      expect(agent.config.mcpServers).toBeDefined();
+      expect(agent.config.mcpServers?.["test-echo-server"]).toEqual(mcpServerConfig);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("persisted agent retains mcpServers config", async () => {
+    const mcpServerConfig: McpServerConfig = {
+      type: "stdio",
+      command: "echo",
+      args: ["persist-test"],
+    };
+
+    const cwd = mkdtempSync(path.join(tmpdir(), "mcp-persist-test-"));
+
+    try {
+      const created = await ctx.client.createAgent({
+        config: {
+          provider: "opencode",
+          cwd,
+          mcpServers: {
+            "persist-server": mcpServerConfig,
+          },
+        },
+        initialPrompt: "test",
+      });
+
+      const fetched = await ctx.client.fetchAgent(created.id);
+
+      expect(fetched.config?.mcpServers).toBeDefined();
+      expect(fetched.config?.mcpServers?.["persist-server"]).toEqual(mcpServerConfig);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  test("disabled mcpServer is not included in agent config", async () => {
+    const mcpServerConfig: McpServerConfig = {
+      type: "stdio",
+      command: "echo",
+    };
+
+    const server = await ctx.client.createMcpServer({
+      name: "disabled-server",
+      type: "stdio",
+      config: mcpServerConfig,
+      enabled: false,
+    });
+
+    expect(server.error).toBeNull();
+
+    const cwd = mkdtempSync(path.join(tmpdir(), "mcp-disabled-test-"));
+
+    try {
+      const agent = await ctx.client.createAgent({
+        config: {
+          provider: "opencode",
+          cwd,
+          mcpServers: {
+            "disabled-server": mcpServerConfig,
+          },
+        },
+        initialPrompt: "test",
+      });
+
+      expect(agent.config.mcpServers?.["disabled-server"]).toEqual(mcpServerConfig);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 60000);
+});

--- a/packages/server/src/server/session.mcp-handlers.e2e.test.ts
+++ b/packages/server/src/server/session.mcp-handlers.e2e.test.ts
@@ -1,0 +1,367 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+
+import { createDaemonTestContext, type DaemonTestContext } from "../test-utils/index.js";
+import type { McpServerConfig } from "./mcp-server-types.js";
+
+describe("MCP server handlers E2E", () => {
+  let ctx: DaemonTestContext;
+
+  beforeEach(async () => {
+    ctx = await createDaemonTestContext();
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  }, 60000);
+
+  test("listMcpServers returns empty array initially", async () => {
+    const result = await ctx.client.listMcpServers();
+
+    expect(result.requestId).toBeDefined();
+    expect(result.error).toBeNull();
+    expect(result.servers).toEqual([]);
+  });
+
+  test("createMcpServer creates stdio server", async () => {
+    const serverConfig: McpServerConfig = {
+      type: "stdio",
+      command: "echo",
+      args: ["test"],
+      env: { TEST: "value" },
+    };
+
+    const result = await ctx.client.createMcpServer({
+      name: "test-stdio-server",
+      type: "stdio",
+      config: serverConfig,
+      enabled: true,
+      tags: ["test"],
+      description: "Test stdio server",
+    });
+
+    expect(result.requestId).toBeDefined();
+    expect(result.error).toBeNull();
+    expect(result.server).toBeDefined();
+    expect(result.server.name).toBe("test-stdio-server");
+    expect(result.server.type).toBe("stdio");
+    expect(result.server.config).toEqual(serverConfig);
+    expect(result.server.enabled).toBe(true);
+    expect(result.server.tags).toEqual(["test"]);
+    expect(result.server.description).toBe("Test stdio server");
+    expect(result.server.id).toBeDefined();
+    expect(result.server.createdAt).toBeDefined();
+    expect(result.server.updatedAt).toBeDefined();
+  });
+
+  test("createMcpServer creates http server", async () => {
+    const serverConfig: McpServerConfig = {
+      type: "http",
+      url: "http://localhost:8080/mcp",
+      headers: { Authorization: "Bearer token" },
+    };
+
+    const result = await ctx.client.createMcpServer({
+      name: "test-http-server",
+      type: "http",
+      config: serverConfig,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.server).toBeDefined();
+    expect(result.server.name).toBe("test-http-server");
+    expect(result.server.type).toBe("http");
+    expect(result.server.config).toEqual(serverConfig);
+    expect(result.server.enabled).toBe(true); // Default
+  });
+
+  test("createMcpServer creates sse server", async () => {
+    const serverConfig: McpServerConfig = {
+      type: "sse",
+      url: "http://localhost:8080/sse",
+      headers: { "Content-Type": "text/event-stream" },
+    };
+
+    const result = await ctx.client.createMcpServer({
+      name: "test-sse-server",
+      type: "sse",
+      config: serverConfig,
+      enabled: false,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.server).toBeDefined();
+    expect(result.server.name).toBe("test-sse-server");
+    expect(result.server.type).toBe("sse");
+    expect(result.server.config).toEqual(serverConfig);
+    expect(result.server.enabled).toBe(false);
+  });
+
+  test("listMcpServers returns all servers", async () => {
+    // Create multiple servers
+    await ctx.client.createMcpServer({
+      name: "server-1",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+    });
+
+    await ctx.client.createMcpServer({
+      name: "server-2",
+      type: "http",
+      config: { type: "http", url: "http://localhost:8080" },
+    });
+
+    await ctx.client.createMcpServer({
+      name: "server-3",
+      type: "sse",
+      config: { type: "sse", url: "http://localhost:8080/sse" },
+    });
+
+    const result = await ctx.client.listMcpServers();
+
+    expect(result.error).toBeNull();
+    expect(result.servers).toHaveLength(3);
+    expect(result.servers.map((s) => s.name)).toContain("server-1");
+    expect(result.servers.map((s) => s.name)).toContain("server-2");
+    expect(result.servers.map((s) => s.name)).toContain("server-3");
+  });
+
+  test("updateMcpServer updates existing server", async () => {
+    const created = await ctx.client.createMcpServer({
+      name: "original-name",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: false,
+      description: "Original description",
+    });
+
+    // Wait a bit to ensure updatedAt would change
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const result = await ctx.client.updateMcpServer(created.server.id, {
+      name: "updated-name",
+      enabled: true,
+      description: "Updated description",
+      tags: ["updated"],
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.server).toBeDefined();
+    expect(result.server.id).toBe(created.server.id);
+    expect(result.server.name).toBe("updated-name");
+    expect(result.server.enabled).toBe(true);
+    expect(result.server.description).toBe("Updated description");
+    expect(result.server.tags).toEqual(["updated"]);
+    expect(result.server.updatedAt).not.toBe(created.server.updatedAt);
+    expect(result.server.createdAt).toBe(created.server.createdAt);
+  });
+
+  test("updateMcpServer returns null for non-existent id", async () => {
+    const result = await ctx.client.updateMcpServer("non-existent-id", {
+      name: "updated-name",
+    });
+
+    expect(result.server).toBeNull();
+    expect(result.error).toBe("MCP server not found");
+  });
+
+  test("deleteMcpServer removes server", async () => {
+    const created = await ctx.client.createMcpServer({
+      name: "to-delete",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+    });
+
+    const result = await ctx.client.deleteMcpServer(created.server.id);
+
+    expect(result.error).toBeNull();
+    expect(result.deleted).toBe(true);
+    expect(result.id).toBe(created.server.id);
+
+    // Verify it's gone
+    const listResult = await ctx.client.listMcpServers();
+    expect(listResult.servers).toHaveLength(0);
+  });
+
+  test("deleteMcpServer returns false for non-existent id", async () => {
+    const result = await ctx.client.deleteMcpServer("non-existent-id");
+
+    expect(result.deleted).toBe(false);
+    expect(result.error).toBe("MCP server not found");
+  });
+
+  test("toggleMcpServer enables server", async () => {
+    const created = await ctx.client.createMcpServer({
+      name: "to-enable",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: false,
+    });
+
+    const result = await ctx.client.toggleMcpServer({
+      id: created.server.id,
+      enabled: true,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.enabled).toBe(true);
+    expect(result.id).toBe(created.server.id);
+
+    // Verify it's enabled
+    const listResult = await ctx.client.listMcpServers();
+    const server = listResult.servers.find((s) => s.id === created.server.id);
+    expect(server?.enabled).toBe(true);
+  });
+
+  test("toggleMcpServer disables server", async () => {
+    const created = await ctx.client.createMcpServer({
+      name: "to-disable",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: true,
+    });
+
+    const result = await ctx.client.toggleMcpServer({
+      id: created.server.id,
+      enabled: false,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.enabled).toBe(false);
+    expect(result.id).toBe(created.server.id);
+
+    // Verify it's disabled
+    const listResult = await ctx.client.listMcpServers();
+    const server = listResult.servers.find((s) => s.id === created.server.id);
+    expect(server?.enabled).toBe(false);
+  });
+
+  test("toggleMcpServer returns error for non-existent id", async () => {
+    const result = await ctx.client.toggleMcpServer({
+      id: "non-existent-id",
+      enabled: true,
+    });
+
+    expect(result.enabled).toBe(true); // Requested state
+    expect(result.error).toBe("MCP server not found");
+  });
+
+  test("MCP servers persist across daemon restarts", async () => {
+    // Create some servers
+    const server1 = await ctx.client.createMcpServer({
+      name: "persistent-server-1",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+    });
+
+    const server2 = await ctx.client.createMcpServer({
+      name: "persistent-server-2",
+      type: "http",
+      config: { type: "http", url: "http://localhost:8080" },
+    });
+
+    // Cleanup current daemon
+    await ctx.cleanup();
+
+    // Create new daemon context (simulates restart)
+    const newCtx = await createDaemonTestContext();
+
+    try {
+      // Verify servers persist
+      const result = await newCtx.client.listMcpServers();
+
+      expect(result.error).toBeNull();
+      expect(result.servers).toHaveLength(2);
+
+      const server1Persisted = result.servers.find((s) => s.id === server1.server.id);
+      const server2Persisted = result.servers.find((s) => s.id === server2.server.id);
+
+      expect(server1Persisted).toBeDefined();
+      expect(server2Persisted).toBeDefined();
+
+      expect(server1Persisted?.name).toBe("persistent-server-1");
+      expect(server2Persisted?.name).toBe("persistent-server-2");
+    } finally {
+      await newCtx.cleanup();
+    }
+  }, 120000); // 2 minute timeout for restart
+
+  test("createMcpServer with minimal config", async () => {
+    const result = await ctx.client.createMcpServer({
+      name: "minimal-server",
+      type: "stdio",
+      config: {
+        type: "stdio",
+        command: "echo",
+      },
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.server).toBeDefined();
+    expect(result.server.name).toBe("minimal-server");
+    expect(result.server.enabled).toBe(true); // Default
+    expect(result.server.tags).toBeUndefined();
+    expect(result.server.description).toBeUndefined();
+  });
+
+  test("createMcpServer with all config options", async () => {
+    const result = await ctx.client.createMcpServer({
+      name: "full-config-server",
+      type: "http",
+      config: {
+        type: "http",
+        url: "https://api.example.com/mcp",
+        headers: {
+          Authorization: "Bearer token123",
+          "X-API-Key": "secret-key",
+          "X-Custom-Header": "custom-value",
+        },
+      },
+      enabled: false,
+      tags: ["production", "api", "custom"],
+      description: "A fully configured HTTP MCP server for production use",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.server).toBeDefined();
+    expect(result.server.name).toBe("full-config-server");
+    expect(result.server.type).toBe("http");
+    expect(result.server.enabled).toBe(false);
+    expect(result.server.tags).toEqual(["production", "api", "custom"]);
+    expect(result.server.description).toBe("A fully configured HTTP MCP server for production use");
+    expect(result.server.config).toEqual({
+      type: "http",
+      url: "https://api.example.com/mcp",
+      headers: {
+        Authorization: "Bearer token123",
+        "X-API-Key": "secret-key",
+        "X-Custom-Header": "custom-value",
+      },
+    });
+  });
+
+  test("updateMcpServer preserves unchanged fields", async () => {
+    const created = await ctx.client.createMcpServer({
+      name: "preserve-server",
+      type: "stdio",
+      config: { type: "stdio", command: "echo" },
+      enabled: true,
+      tags: ["tag1", "tag2"],
+      description: "Original description",
+    });
+
+    const result = await ctx.client.updateMcpServer(created.server.id, {
+      description: "Updated description only",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.server).toBeDefined();
+    expect(result.server.name).toBe("preserve-server");
+    expect(result.server.enabled).toBe(true);
+    expect(result.server.tags).toEqual(["tag1", "tag2"]);
+    expect(result.server.description).toBe("Updated description only");
+    expect(result.server.config).toEqual(created.server.config);
+  });
+});

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -405,7 +405,7 @@ export type SessionOptions = {
   paseoHome: string;
   agentManager: AgentManager;
   agentStorage: AgentStorage;
-  mcpServerStore: McpServerStore;
+  mcpServerStore?: McpServerStore;
   projectRegistry: ProjectRegistry;
   workspaceRegistry: WorkspaceRegistry;
   chatService: FileBackedChatService;
@@ -591,7 +591,7 @@ export class Session {
   private agentTools: ToolSet | null = null;
   private agentManager: AgentManager;
   private readonly agentStorage: AgentStorage;
-  private readonly mcpServerStore: McpServerStore;
+  private readonly mcpServerStore: McpServerStore | undefined;
   private readonly projectRegistry: ProjectRegistry;
   private readonly workspaceRegistry: WorkspaceRegistry;
   private readonly chatService: FileBackedChatService;
@@ -8120,6 +8120,17 @@ export class Session {
   private async handleListMcpServersRequest(
     request: Extract<SessionInboundMessage, { type: "list_mcp_servers_request" }>,
   ): Promise<void> {
+    if (!this.mcpServerStore) {
+      this.emit({
+        type: "list_mcp_servers_response",
+        payload: {
+          requestId: request.requestId,
+          servers: [],
+          error: "MCP server store not available",
+        },
+      });
+      return;
+    }
     try {
       const servers = await this.mcpServerStore.list();
       this.emit({
@@ -8145,6 +8156,17 @@ export class Session {
   private async handleCreateMcpServerRequest(
     request: Extract<SessionInboundMessage, { type: "create_mcp_server_request" }>,
   ): Promise<void> {
+    if (!this.mcpServerStore) {
+      this.emit({
+        type: "create_mcp_server_response",
+        payload: {
+          requestId: request.payload.requestId,
+          server: null,
+          error: "MCP server store not available",
+        },
+      });
+      return;
+    }
     try {
       const server = await this.mcpServerStore.add(request.payload.server);
       this.emit({
@@ -8170,6 +8192,17 @@ export class Session {
   private async handleUpdateMcpServerRequest(
     request: Extract<SessionInboundMessage, { type: "update_mcp_server_request" }>,
   ): Promise<void> {
+    if (!this.mcpServerStore) {
+      this.emit({
+        type: "update_mcp_server_response",
+        payload: {
+          requestId: request.payload.requestId,
+          server: null,
+          error: "MCP server store not available",
+        },
+      });
+      return;
+    }
     try {
       const server = await this.mcpServerStore.update(request.payload.id, request.payload.updates);
       if (!server) {
@@ -8206,6 +8239,18 @@ export class Session {
   private async handleDeleteMcpServerRequest(
     request: Extract<SessionInboundMessage, { type: "delete_mcp_server_request" }>,
   ): Promise<void> {
+    if (!this.mcpServerStore) {
+      this.emit({
+        type: "delete_mcp_server_response",
+        payload: {
+          requestId: request.payload.requestId,
+          id: request.payload.id,
+          deleted: false,
+          error: "MCP server store not available",
+        },
+      });
+      return;
+    }
     try {
       const deleted = await this.mcpServerStore.delete(request.payload.id);
       if (!deleted) {
@@ -8245,6 +8290,18 @@ export class Session {
   private async handleToggleMcpServerRequest(
     request: Extract<SessionInboundMessage, { type: "toggle_mcp_server_request" }>,
   ): Promise<void> {
+    if (!this.mcpServerStore) {
+      this.emit({
+        type: "toggle_mcp_server_response",
+        payload: {
+          requestId: request.payload.requestId,
+          id: request.payload.id,
+          enabled: request.payload.enabled,
+          error: "MCP server store not available",
+        },
+      });
+      return;
+    }
     try {
       const success = request.payload.enabled
         ? await this.mcpServerStore.enable(request.payload.id)

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -111,6 +111,7 @@ import type {
 } from "./agent/agent-sdk-types.js";
 import { AgentStorage, type StoredAgentRecord } from "./agent/agent-storage.js";
 import { isValidAgentProvider, AGENT_PROVIDER_IDS } from "./agent/provider-manifest.js";
+import { McpServerStore } from "./mcp/mcp-server-store.js";
 import {
   buildProjectPlacementForCwd,
   detectStaleWorkspaces,
@@ -145,9 +146,7 @@ import {
 } from "./file-explorer/service.js";
 import { DownloadTokenStore } from "./file-download/token-store.js";
 import { PushTokenStore } from "./push/token-store.js";
-import {
-  type WorktreeConfig,
-} from "../utils/worktree.js";
+import { type WorktreeConfig } from "../utils/worktree.js";
 import { runAsyncWorktreeBootstrap } from "./worktree-bootstrap.js";
 import {
   getCheckoutDiff,
@@ -165,21 +164,14 @@ import {
 import { getProjectIcon } from "../utils/project-icon.js";
 import { expandTilde } from "../utils/path.js";
 import { searchHomeDirectories, searchWorkspaceEntries } from "../utils/directory-suggestions.js";
-import {
-  READ_ONLY_GIT_ENV,
-  resolveCheckoutGitDir,
-  toCheckoutError,
-} from "./checkout-git-utils.js";
+import { READ_ONLY_GIT_ENV, resolveCheckoutGitDir, toCheckoutError } from "./checkout-git-utils.js";
 import { CheckoutDiffManager } from "./checkout-diff-manager.js";
 import type { LocalSpeechModelId } from "./speech/providers/local/models.js";
 import { toResolver, type Resolvable } from "./speech/provider-resolver.js";
 import type { SpeechReadinessSnapshot, SpeechReadinessState } from "./speech/speech-runtime.js";
 import type pino from "pino";
 import { resolveClientMessageId } from "./client-message-id.js";
-import {
-  ChatServiceError,
-  FileBackedChatService,
-} from "./chat/chat-service.js";
+import { ChatServiceError, FileBackedChatService } from "./chat/chat-service.js";
 import { notifyChatMentions } from "./chat/chat-mentions.js";
 import { LoopService } from "./loop-service.js";
 import { ScheduleService } from "./schedule/service.js";
@@ -413,6 +405,7 @@ export type SessionOptions = {
   paseoHome: string;
   agentManager: AgentManager;
   agentStorage: AgentStorage;
+  mcpServerStore: McpServerStore;
   projectRegistry: ProjectRegistry;
   workspaceRegistry: WorkspaceRegistry;
   chatService: FileBackedChatService;
@@ -598,6 +591,7 @@ export class Session {
   private agentTools: ToolSet | null = null;
   private agentManager: AgentManager;
   private readonly agentStorage: AgentStorage;
+  private readonly mcpServerStore: McpServerStore;
   private readonly projectRegistry: ProjectRegistry;
   private readonly workspaceRegistry: WorkspaceRegistry;
   private readonly chatService: FileBackedChatService;
@@ -665,6 +659,7 @@ export class Session {
       paseoHome,
       agentManager,
       agentStorage,
+      mcpServerStore,
       projectRegistry,
       workspaceRegistry,
       chatService,
@@ -693,6 +688,7 @@ export class Session {
     this.paseoHome = paseoHome;
     this.agentManager = agentManager;
     this.agentStorage = agentStorage;
+    this.mcpServerStore = mcpServerStore;
     this.projectRegistry = projectRegistry;
     this.workspaceRegistry = workspaceRegistry;
     this.chatService = chatService;
@@ -1072,7 +1068,10 @@ export class Session {
     if (storedUpdatedAt) {
       const liveUpdatedAt = Date.parse(payload.updatedAt);
       const persistedUpdatedAt = Date.parse(storedUpdatedAt);
-      if (!Number.isNaN(persistedUpdatedAt) && (Number.isNaN(liveUpdatedAt) || persistedUpdatedAt > liveUpdatedAt)) {
+      if (
+        !Number.isNaN(persistedUpdatedAt) &&
+        (Number.isNaN(liveUpdatedAt) || persistedUpdatedAt > liveUpdatedAt)
+      ) {
         payload.updatedAt = storedUpdatedAt;
       }
     }
@@ -1179,16 +1178,40 @@ export class Session {
       const handle = toAgentPersistenceHandle(this.sessionLogger, record.persistence);
       let snapshot: ManagedAgent;
       if (handle) {
-        snapshot = await this.agentManager.resumeAgentFromPersistence(
-          handle,
-          buildConfigOverrides(record),
-          agentId,
-          extractTimestamps(record),
-        );
-        this.sessionLogger.info(
-          { agentId, provider: record.provider },
-          "Agent resumed from persistence",
-        );
+        try {
+          snapshot = await this.agentManager.resumeAgentFromPersistence(
+            handle,
+            buildConfigOverrides(record),
+            agentId,
+            extractTimestamps(record),
+          );
+          this.sessionLogger.info(
+            { agentId, provider: record.provider },
+            "Agent resumed from persistence",
+          );
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          const isWorkingDirectoryNotExist =
+            error instanceof Error &&
+            "code" in error &&
+            (error as NodeJS.ErrnoException).code === "ENOENT";
+          if (
+            isWorkingDirectoryNotExist ||
+            errorMessage.includes("Working directory does not exist")
+          ) {
+            const workspaceId = normalizePersistedWorkspaceId(record.cwd);
+            this.sessionLogger.warn(
+              { agentId, workspaceId, cwd: record.cwd },
+              "Agent resume failed because worktree no longer exists; archiving workspace and agent",
+            );
+            await this.archiveWorkspaceRecord(workspaceId);
+            await this.agentManager.archiveAgent(agentId);
+            throw new Error(
+              `Session worktree no longer exists: ${record.cwd}. The workspace and agent have been archived.`,
+            );
+          }
+          throw error;
+        }
       } else {
         const config = buildSessionConfig(record);
         snapshot = await this.agentManager.createAgent(config, agentId, { labels: record.labels });
@@ -1409,7 +1432,9 @@ export class Session {
     const placement = await this.buildProjectPlacement(normalizedCwd);
     const resolvedWorkspaceId = deriveWorkspaceId(normalizedCwd, placement.checkout);
     const staleWorkspace =
-      resolvedWorkspaceId === normalizedCwd ? null : await this.workspaceRegistry.get(normalizedCwd);
+      resolvedWorkspaceId === normalizedCwd
+        ? null
+        : await this.workspaceRegistry.get(normalizedCwd);
     const existing = (await this.workspaceRegistry.get(resolvedWorkspaceId)) ?? staleWorkspace;
     await this.syncWorkspaceGitWatchTarget(resolvedWorkspaceId, {
       isGit: placement.checkout.isGit,
@@ -1564,467 +1589,487 @@ export class Session {
       this.peakInflightRequests = this.inflightRequests;
     }
     try {
-    this.sessionLogger.trace(
-      { messageType: msg.type, payloadBytes: JSON.stringify(msg).length },
-      "inbound message",
-    );
-    try {
-      switch (msg.type) {
-        case "voice_audio_chunk":
-          await this.handleAudioChunk(msg);
-          break;
+      this.sessionLogger.trace(
+        { messageType: msg.type, payloadBytes: JSON.stringify(msg).length },
+        "inbound message",
+      );
+      try {
+        switch (msg.type) {
+          case "voice_audio_chunk":
+            await this.handleAudioChunk(msg);
+            break;
 
-        case "abort_request":
-          await this.handleAbort();
-          break;
+          case "abort_request":
+            await this.handleAbort();
+            break;
 
-        case "audio_played":
-          this.handleAudioPlayed(msg.id);
-          break;
+          case "audio_played":
+            this.handleAudioPlayed(msg.id);
+            break;
 
-        case "fetch_agents_request":
-          await this.handleFetchAgents(msg);
-          break;
+          case "fetch_agents_request":
+            await this.handleFetchAgents(msg);
+            break;
 
-        case "fetch_workspaces_request":
-          await this.handleFetchWorkspacesRequest(msg);
-          break;
+          case "fetch_workspaces_request":
+            await this.handleFetchWorkspacesRequest(msg);
+            break;
 
-        case "fetch_agent_request":
-          await this.handleFetchAgent(msg.agentId, msg.requestId);
-          break;
+          case "fetch_agent_request":
+            await this.handleFetchAgent(msg.agentId, msg.requestId);
+            break;
 
-        case "delete_agent_request":
-          await this.handleDeleteAgentRequest(msg.agentId, msg.requestId);
-          break;
+          case "delete_agent_request":
+            await this.handleDeleteAgentRequest(msg.agentId, msg.requestId);
+            break;
 
-        case "archive_agent_request":
-          await this.handleArchiveAgentRequest(msg.agentId, msg.requestId);
-          break;
+          case "archive_agent_request":
+            await this.handleArchiveAgentRequest(msg.agentId, msg.requestId);
+            break;
 
-        case "close_items_request":
-          await this.handleCloseItemsRequest(msg);
-          break;
+          case "close_items_request":
+            await this.handleCloseItemsRequest(msg);
+            break;
 
-        case "update_agent_request":
-          await this.handleUpdateAgentRequest(msg.agentId, msg.name, msg.labels, msg.requestId);
-          break;
+          case "update_agent_request":
+            await this.handleUpdateAgentRequest(msg.agentId, msg.name, msg.labels, msg.requestId);
+            break;
 
-        case "set_voice_mode":
-          await this.handleSetVoiceMode(msg.enabled, msg.agentId, msg.requestId);
-          break;
+          case "set_voice_mode":
+            await this.handleSetVoiceMode(msg.enabled, msg.agentId, msg.requestId);
+            break;
 
-        case "send_agent_message_request":
-          await this.handleSendAgentMessageRequest(msg);
-          break;
+          case "send_agent_message_request":
+            await this.handleSendAgentMessageRequest(msg);
+            break;
 
-        case "wait_for_finish_request":
-          await this.handleWaitForFinish(msg.agentId, msg.requestId, msg.timeoutMs);
-          break;
+          case "wait_for_finish_request":
+            await this.handleWaitForFinish(msg.agentId, msg.requestId, msg.timeoutMs);
+            break;
 
-        case "dictation_stream_start":
-          {
-            const unavailable = this.resolveVoiceFeatureUnavailableContext("dictation");
-            if (unavailable) {
-              this.emit({
-                type: "dictation_stream_error",
-                payload: {
-                  dictationId: msg.dictationId,
-                  error: unavailable.message,
-                  retryable: unavailable.retryable,
-                  reasonCode: unavailable.reasonCode,
-                  missingModelIds: unavailable.missingModelIds,
-                },
-              });
-              break;
+          case "dictation_stream_start":
+            {
+              const unavailable = this.resolveVoiceFeatureUnavailableContext("dictation");
+              if (unavailable) {
+                this.emit({
+                  type: "dictation_stream_error",
+                  payload: {
+                    dictationId: msg.dictationId,
+                    error: unavailable.message,
+                    retryable: unavailable.retryable,
+                    reasonCode: unavailable.reasonCode,
+                    missingModelIds: unavailable.missingModelIds,
+                  },
+                });
+                break;
+              }
             }
+            await this.dictationStreamManager.handleStart(msg.dictationId, msg.format);
+            break;
+
+          case "dictation_stream_chunk":
+            await this.dictationStreamManager.handleChunk({
+              dictationId: msg.dictationId,
+              seq: msg.seq,
+              audioBase64: msg.audio,
+              format: msg.format,
+            });
+            break;
+
+          case "dictation_stream_finish":
+            await this.dictationStreamManager.handleFinish(msg.dictationId, msg.finalSeq);
+            break;
+
+          case "dictation_stream_cancel":
+            this.dictationStreamManager.handleCancel(msg.dictationId);
+            break;
+
+          case "create_agent_request":
+            await this.handleCreateAgentRequest(msg);
+            break;
+
+          case "resume_agent_request":
+            await this.handleResumeAgentRequest(msg);
+            break;
+
+          case "refresh_agent_request":
+            await this.handleRefreshAgentRequest(msg);
+            break;
+
+          case "cancel_agent_request":
+            await this.handleCancelAgentRequest(msg.agentId);
+            break;
+
+          case "restart_server_request":
+            await this.handleRestartServerRequest(msg.requestId, msg.reason);
+            break;
+
+          case "shutdown_server_request":
+            await this.handleShutdownServerRequest(msg.requestId);
+            break;
+
+          case "fetch_agent_timeline_request":
+            await this.handleFetchAgentTimelineRequest(msg);
+            break;
+
+          case "set_agent_mode_request":
+            await this.handleSetAgentModeRequest(msg.agentId, msg.modeId, msg.requestId);
+            break;
+
+          case "set_agent_model_request":
+            await this.handleSetAgentModelRequest(msg.agentId, msg.modelId, msg.requestId);
+            break;
+
+          case "set_agent_feature_request":
+            await this.handleSetAgentFeatureRequest(
+              msg.agentId,
+              msg.featureId,
+              msg.value,
+              msg.requestId,
+            );
+            break;
+
+          case "set_agent_thinking_request":
+            await this.handleSetAgentThinkingRequest(
+              msg.agentId,
+              msg.thinkingOptionId,
+              msg.requestId,
+            );
+            break;
+
+          case "agent_permission_response":
+            await this.handleAgentPermissionResponse(msg.agentId, msg.requestId, msg.response);
+            break;
+
+          case "checkout_status_request":
+            await this.handleCheckoutStatusRequest(msg);
+            break;
+
+          case "validate_branch_request":
+            await this.handleValidateBranchRequest(msg);
+            break;
+
+          case "branch_suggestions_request":
+            await this.handleBranchSuggestionsRequest(msg);
+            break;
+
+          case "directory_suggestions_request":
+            await this.handleDirectorySuggestionsRequest(msg);
+            break;
+
+          case "subscribe_checkout_diff_request":
+            await this.handleSubscribeCheckoutDiffRequest(msg);
+            break;
+
+          case "unsubscribe_checkout_diff_request":
+            this.handleUnsubscribeCheckoutDiffRequest(msg);
+            break;
+
+          case "checkout_switch_branch_request":
+            await this.handleCheckoutSwitchBranchRequest(msg);
+            break;
+
+          case "stash_save_request":
+            await this.handleStashSaveRequest(msg);
+            break;
+
+          case "stash_pop_request":
+            await this.handleStashPopRequest(msg);
+            break;
+
+          case "stash_list_request":
+            await this.handleStashListRequest(msg);
+            break;
+
+          case "checkout_commit_request":
+            await this.handleCheckoutCommitRequest(msg);
+            break;
+
+          case "checkout_merge_request":
+            await this.handleCheckoutMergeRequest(msg);
+            break;
+
+          case "checkout_merge_from_base_request":
+            await this.handleCheckoutMergeFromBaseRequest(msg);
+            break;
+
+          case "checkout_pull_request":
+            await this.handleCheckoutPullRequest(msg);
+            break;
+
+          case "checkout_push_request":
+            await this.handleCheckoutPushRequest(msg);
+            break;
+
+          case "checkout_pr_create_request":
+            await this.handleCheckoutPrCreateRequest(msg);
+            break;
+
+          case "checkout_pr_status_request":
+            await this.handleCheckoutPrStatusRequest(msg);
+            break;
+
+          case "paseo_worktree_list_request":
+            await this.handlePaseoWorktreeListRequest(msg);
+            break;
+
+          case "paseo_worktree_archive_request":
+            await this.handlePaseoWorktreeArchiveRequest(msg);
+            break;
+
+          case "create_paseo_worktree_request":
+            await this.handleCreatePaseoWorktreeRequest(msg);
+            break;
+
+          case "list_available_editors_request":
+            await this.handleListAvailableEditorsRequest(msg);
+            break;
+
+          case "open_in_editor_request":
+            await this.handleOpenInEditorRequest(msg);
+            break;
+
+          case "open_project_request":
+            await this.handleOpenProjectRequest(msg);
+            break;
+
+          case "archive_workspace_request":
+            await this.handleArchiveWorkspaceRequest(msg);
+            break;
+
+          case "file_explorer_request":
+            await this.handleFileExplorerRequest(msg);
+            break;
+
+          case "project_icon_request":
+            await this.handleProjectIconRequest(msg);
+            break;
+
+          case "file_download_token_request":
+            await this.handleFileDownloadTokenRequest(msg);
+            break;
+
+          case "list_provider_models_request":
+            await this.handleListProviderModelsRequest(msg);
+            break;
+
+          case "list_provider_modes_request":
+            await this.handleListProviderModesRequest(msg);
+            break;
+
+          case "list_provider_features_request":
+            await this.handleListProviderFeaturesRequest(msg);
+            break;
+
+          case "list_available_providers_request":
+            await this.handleListAvailableProvidersRequest(msg);
+            break;
+
+          case "get_providers_snapshot_request":
+            await this.handleGetProvidersSnapshotRequest(msg);
+            break;
+
+          case "refresh_providers_snapshot_request":
+            await this.handleRefreshProvidersSnapshotRequest(msg);
+            break;
+
+          case "provider_diagnostic_request":
+            await this.handleProviderDiagnosticRequest(msg);
+            break;
+
+          case "clear_agent_attention":
+            await this.handleClearAgentAttention(msg.agentId);
+            break;
+
+          case "client_heartbeat":
+            this.handleClientHeartbeat(msg);
+            break;
+
+          case "ping": {
+            const now = Date.now();
+            this.emit({
+              type: "pong",
+              payload: {
+                requestId: msg.requestId,
+                clientSentAt: msg.clientSentAt,
+                serverReceivedAt: now,
+                serverSentAt: now,
+              },
+            });
+            break;
           }
-          await this.dictationStreamManager.handleStart(msg.dictationId, msg.format);
-          break;
 
-        case "dictation_stream_chunk":
-          await this.dictationStreamManager.handleChunk({
-            dictationId: msg.dictationId,
-            seq: msg.seq,
-            audioBase64: msg.audio,
-            format: msg.format,
-          });
-          break;
+          case "list_commands_request":
+            await this.handleListCommandsRequest(msg);
+            break;
 
-        case "dictation_stream_finish":
-          await this.dictationStreamManager.handleFinish(msg.dictationId, msg.finalSeq);
-          break;
+          case "register_push_token":
+            this.handleRegisterPushToken(msg.token);
+            break;
 
-        case "dictation_stream_cancel":
-          this.dictationStreamManager.handleCancel(msg.dictationId);
-          break;
+          case "subscribe_terminals_request":
+            this.handleSubscribeTerminalsRequest(msg);
+            break;
 
-        case "create_agent_request":
-          await this.handleCreateAgentRequest(msg);
-          break;
+          case "unsubscribe_terminals_request":
+            this.handleUnsubscribeTerminalsRequest(msg);
+            break;
 
-        case "resume_agent_request":
-          await this.handleResumeAgentRequest(msg);
-          break;
+          case "list_terminals_request":
+            await this.handleListTerminalsRequest(msg);
+            break;
 
-        case "refresh_agent_request":
-          await this.handleRefreshAgentRequest(msg);
-          break;
+          case "create_terminal_request":
+            await this.handleCreateTerminalRequest(msg);
+            break;
 
-        case "cancel_agent_request":
-          await this.handleCancelAgentRequest(msg.agentId);
-          break;
+          case "subscribe_terminal_request":
+            await this.handleSubscribeTerminalRequest(msg);
+            break;
 
-        case "restart_server_request":
-          await this.handleRestartServerRequest(msg.requestId, msg.reason);
-          break;
+          case "unsubscribe_terminal_request":
+            this.handleUnsubscribeTerminalRequest(msg);
+            break;
 
-        case "shutdown_server_request":
-          await this.handleShutdownServerRequest(msg.requestId);
-          break;
+          case "terminal_input":
+            this.handleTerminalInput(msg);
+            break;
 
-        case "fetch_agent_timeline_request":
-          await this.handleFetchAgentTimelineRequest(msg);
-          break;
+          case "kill_terminal_request":
+            await this.handleKillTerminalRequest(msg);
+            break;
 
-        case "set_agent_mode_request":
-          await this.handleSetAgentModeRequest(msg.agentId, msg.modeId, msg.requestId);
-          break;
+          case "capture_terminal_request":
+            await this.handleCaptureTerminalRequest(msg);
+            break;
 
-        case "set_agent_model_request":
-          await this.handleSetAgentModelRequest(msg.agentId, msg.modelId, msg.requestId);
-          break;
+          case "chat/create":
+            await this.handleChatCreateRequest(msg);
+            break;
 
-        case "set_agent_feature_request":
-          await this.handleSetAgentFeatureRequest(
-            msg.agentId,
-            msg.featureId,
-            msg.value,
-            msg.requestId,
-          );
-          break;
+          case "chat/list":
+            await this.handleChatListRequest(msg);
+            break;
 
-        case "set_agent_thinking_request":
-          await this.handleSetAgentThinkingRequest(
-            msg.agentId,
-            msg.thinkingOptionId,
-            msg.requestId,
-          );
-          break;
+          case "chat/inspect":
+            await this.handleChatInspectRequest(msg);
+            break;
 
-        case "agent_permission_response":
-          await this.handleAgentPermissionResponse(msg.agentId, msg.requestId, msg.response);
-          break;
+          case "chat/delete":
+            await this.handleChatDeleteRequest(msg);
+            break;
 
-        case "checkout_status_request":
-          await this.handleCheckoutStatusRequest(msg);
-          break;
+          case "chat/post":
+            await this.handleChatPostRequest(msg);
+            break;
 
-        case "validate_branch_request":
-          await this.handleValidateBranchRequest(msg);
-          break;
+          case "chat/read":
+            await this.handleChatReadRequest(msg);
+            break;
 
-        case "branch_suggestions_request":
-          await this.handleBranchSuggestionsRequest(msg);
-          break;
+          case "chat/wait":
+            await this.handleChatWaitRequest(msg);
+            break;
 
-        case "directory_suggestions_request":
-          await this.handleDirectorySuggestionsRequest(msg);
-          break;
+          case "schedule/create":
+            await this.handleScheduleCreateRequest(msg);
+            break;
 
-        case "subscribe_checkout_diff_request":
-          await this.handleSubscribeCheckoutDiffRequest(msg);
-          break;
+          case "schedule/list":
+            await this.handleScheduleListRequest(msg);
+            break;
 
-        case "unsubscribe_checkout_diff_request":
-          this.handleUnsubscribeCheckoutDiffRequest(msg);
-          break;
+          case "schedule/inspect":
+            await this.handleScheduleInspectRequest(msg);
+            break;
 
-        case "checkout_switch_branch_request":
-          await this.handleCheckoutSwitchBranchRequest(msg);
-          break;
+          case "schedule/logs":
+            await this.handleScheduleLogsRequest(msg);
+            break;
 
-        case "stash_save_request":
-          await this.handleStashSaveRequest(msg);
-          break;
+          case "schedule/pause":
+            await this.handleSchedulePauseRequest(msg);
+            break;
 
-        case "stash_pop_request":
-          await this.handleStashPopRequest(msg);
-          break;
+          case "schedule/resume":
+            await this.handleScheduleResumeRequest(msg);
+            break;
 
-        case "stash_list_request":
-          await this.handleStashListRequest(msg);
-          break;
+          case "schedule/delete":
+            await this.handleScheduleDeleteRequest(msg);
+            break;
 
-        case "checkout_commit_request":
-          await this.handleCheckoutCommitRequest(msg);
-          break;
+          case "loop/run":
+            await this.handleLoopRunRequest(msg);
+            break;
 
-        case "checkout_merge_request":
-          await this.handleCheckoutMergeRequest(msg);
-          break;
+          case "loop/list":
+            await this.handleLoopListRequest(msg);
+            break;
 
-        case "checkout_merge_from_base_request":
-          await this.handleCheckoutMergeFromBaseRequest(msg);
-          break;
+          case "loop/inspect":
+            await this.handleLoopInspectRequest(msg);
+            break;
 
-        case "checkout_pull_request":
-          await this.handleCheckoutPullRequest(msg);
-          break;
+          case "loop/logs":
+            await this.handleLoopLogsRequest(msg);
+            break;
 
-        case "checkout_push_request":
-          await this.handleCheckoutPushRequest(msg);
-          break;
+          case "loop/stop":
+            await this.handleLoopStopRequest(msg);
+            break;
 
-        case "checkout_pr_create_request":
-          await this.handleCheckoutPrCreateRequest(msg);
-          break;
+          case "list_mcp_servers_request":
+            await this.handleListMcpServersRequest(msg);
+            break;
 
-        case "checkout_pr_status_request":
-          await this.handleCheckoutPrStatusRequest(msg);
-          break;
+          case "create_mcp_server_request":
+            await this.handleCreateMcpServerRequest(msg);
+            break;
 
-        case "paseo_worktree_list_request":
-          await this.handlePaseoWorktreeListRequest(msg);
-          break;
+          case "update_mcp_server_request":
+            await this.handleUpdateMcpServerRequest(msg);
+            break;
 
-        case "paseo_worktree_archive_request":
-          await this.handlePaseoWorktreeArchiveRequest(msg);
-          break;
+          case "delete_mcp_server_request":
+            await this.handleDeleteMcpServerRequest(msg);
+            break;
 
-        case "create_paseo_worktree_request":
-          await this.handleCreatePaseoWorktreeRequest(msg);
-          break;
+          case "toggle_mcp_server_request":
+            await this.handleToggleMcpServerRequest(msg);
+            break;
+        }
+      } catch (error: any) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        this.sessionLogger.error({ err }, "Error handling message");
 
-        case "list_available_editors_request":
-          await this.handleListAvailableEditorsRequest(msg);
-          break;
-
-        case "open_in_editor_request":
-          await this.handleOpenInEditorRequest(msg);
-          break;
-
-        case "open_project_request":
-          await this.handleOpenProjectRequest(msg);
-          break;
-
-        case "archive_workspace_request":
-          await this.handleArchiveWorkspaceRequest(msg);
-          break;
-
-        case "file_explorer_request":
-          await this.handleFileExplorerRequest(msg);
-          break;
-
-        case "project_icon_request":
-          await this.handleProjectIconRequest(msg);
-          break;
-
-        case "file_download_token_request":
-          await this.handleFileDownloadTokenRequest(msg);
-          break;
-
-        case "list_provider_models_request":
-          await this.handleListProviderModelsRequest(msg);
-          break;
-
-        case "list_provider_modes_request":
-          await this.handleListProviderModesRequest(msg);
-          break;
-
-        case "list_provider_features_request":
-          await this.handleListProviderFeaturesRequest(msg);
-          break;
-
-        case "list_available_providers_request":
-          await this.handleListAvailableProvidersRequest(msg);
-          break;
-
-        case "get_providers_snapshot_request":
-          await this.handleGetProvidersSnapshotRequest(msg);
-          break;
-
-        case "refresh_providers_snapshot_request":
-          await this.handleRefreshProvidersSnapshotRequest(msg);
-          break;
-
-        case "provider_diagnostic_request":
-          await this.handleProviderDiagnosticRequest(msg);
-          break;
-
-        case "clear_agent_attention":
-          await this.handleClearAgentAttention(msg.agentId);
-          break;
-
-        case "client_heartbeat":
-          this.handleClientHeartbeat(msg);
-          break;
-
-        case "ping": {
-          const now = Date.now();
-          this.emit({
-            type: "pong",
-            payload: {
-              requestId: msg.requestId,
-              clientSentAt: msg.clientSentAt,
-              serverReceivedAt: now,
-              serverSentAt: now,
-            },
-          });
-          break;
+        const requestId = (msg as { requestId?: unknown }).requestId;
+        if (typeof requestId === "string") {
+          try {
+            this.emit({
+              type: "rpc_error",
+              payload: {
+                requestId,
+                requestType: msg.type,
+                error: `Request failed: ${err.message}`,
+                code: "handler_error",
+              },
+            });
+          } catch (emitError) {
+            this.sessionLogger.error({ err: emitError }, "Failed to emit rpc_error");
+          }
         }
 
-        case "list_commands_request":
-          await this.handleListCommandsRequest(msg);
-          break;
-
-        case "register_push_token":
-          this.handleRegisterPushToken(msg.token);
-          break;
-
-        case "subscribe_terminals_request":
-          this.handleSubscribeTerminalsRequest(msg);
-          break;
-
-        case "unsubscribe_terminals_request":
-          this.handleUnsubscribeTerminalsRequest(msg);
-          break;
-
-        case "list_terminals_request":
-          await this.handleListTerminalsRequest(msg);
-          break;
-
-        case "create_terminal_request":
-          await this.handleCreateTerminalRequest(msg);
-          break;
-
-        case "subscribe_terminal_request":
-          await this.handleSubscribeTerminalRequest(msg);
-          break;
-
-        case "unsubscribe_terminal_request":
-          this.handleUnsubscribeTerminalRequest(msg);
-          break;
-
-        case "terminal_input":
-          this.handleTerminalInput(msg);
-          break;
-
-        case "kill_terminal_request":
-          await this.handleKillTerminalRequest(msg);
-          break;
-
-        case "capture_terminal_request":
-          await this.handleCaptureTerminalRequest(msg);
-          break;
-
-        case "chat/create":
-          await this.handleChatCreateRequest(msg);
-          break;
-
-        case "chat/list":
-          await this.handleChatListRequest(msg);
-          break;
-
-        case "chat/inspect":
-          await this.handleChatInspectRequest(msg);
-          break;
-
-        case "chat/delete":
-          await this.handleChatDeleteRequest(msg);
-          break;
-
-        case "chat/post":
-          await this.handleChatPostRequest(msg);
-          break;
-
-        case "chat/read":
-          await this.handleChatReadRequest(msg);
-          break;
-
-        case "chat/wait":
-          await this.handleChatWaitRequest(msg);
-          break;
-
-        case "schedule/create":
-          await this.handleScheduleCreateRequest(msg);
-          break;
-
-        case "schedule/list":
-          await this.handleScheduleListRequest(msg);
-          break;
-
-        case "schedule/inspect":
-          await this.handleScheduleInspectRequest(msg);
-          break;
-
-        case "schedule/logs":
-          await this.handleScheduleLogsRequest(msg);
-          break;
-
-        case "schedule/pause":
-          await this.handleSchedulePauseRequest(msg);
-          break;
-
-        case "schedule/resume":
-          await this.handleScheduleResumeRequest(msg);
-          break;
-
-        case "schedule/delete":
-          await this.handleScheduleDeleteRequest(msg);
-          break;
-
-        case "loop/run":
-          await this.handleLoopRunRequest(msg);
-          break;
-
-        case "loop/list":
-          await this.handleLoopListRequest(msg);
-          break;
-
-        case "loop/inspect":
-          await this.handleLoopInspectRequest(msg);
-          break;
-
-        case "loop/logs":
-          await this.handleLoopLogsRequest(msg);
-          break;
-
-        case "loop/stop":
-          await this.handleLoopStopRequest(msg);
-          break;
+        this.emit({
+          type: "activity_log",
+          payload: {
+            id: uuidv4(),
+            timestamp: new Date(),
+            type: "error",
+            content: `Error: ${err.message}`,
+          },
+        });
       }
-    } catch (error: any) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      this.sessionLogger.error({ err }, "Error handling message");
-
-      const requestId = (msg as { requestId?: unknown }).requestId;
-      if (typeof requestId === "string") {
-        try {
-          this.emit({
-            type: "rpc_error",
-            payload: {
-              requestId,
-              requestType: msg.type,
-              error: `Request failed: ${err.message}`,
-              code: "handler_error",
-            },
-          });
-        } catch (emitError) {
-          this.sessionLogger.error({ err: emitError }, "Failed to emit rpc_error");
-        }
-      }
-
-      this.emit({
-        type: "activity_log",
-        payload: {
-          id: uuidv4(),
-          timestamp: new Date(),
-          type: "error",
-          content: `Error: ${err.message}`,
-        },
-      });
-    }
     } finally {
       this.inflightRequests--;
     }
@@ -3267,9 +3312,7 @@ export class Session {
       cwd: expandTilde(draftConfig.cwd),
       ...(draftConfig.modeId ? { modeId: draftConfig.modeId } : {}),
       ...(draftConfig.model ? { model: draftConfig.model } : {}),
-      ...(draftConfig.thinkingOptionId
-        ? { thinkingOptionId: draftConfig.thinkingOptionId }
-        : {}),
+      ...(draftConfig.thinkingOptionId ? { thinkingOptionId: draftConfig.thinkingOptionId } : {}),
       ...(draftConfig.featureValues ? { featureValues: draftConfig.featureValues } : {}),
     };
   }
@@ -5649,9 +5692,11 @@ export class Session {
 
   private async listWorkspaceDescriptorsSnapshot(): Promise<WorkspaceDescriptorPayload[]> {
     return Array.from(
-      (await this.buildWorkspaceDescriptorMap({
-        includeGitData: false,
-      })).values(),
+      (
+        await this.buildWorkspaceDescriptorMap({
+          includeGitData: false,
+        })
+      ).values(),
     );
   }
 
@@ -7217,14 +7262,9 @@ export class Session {
       return;
     }
 
-    await this.handleSendAgentMessage(
-      agentId,
-      result.text,
-      undefined,
-      undefined,
-      undefined,
-      { spokenInput: true },
-    );
+    await this.handleSendAgentMessage(agentId, result.text, undefined, undefined, undefined, {
+      spokenInput: true,
+    });
     await this.flushPendingAudioSegments("transcription complete");
   }
 
@@ -7595,8 +7635,7 @@ export class Session {
   }
 
   private emitChatRpcError(request: { requestId: string; type: string }, error: unknown): void {
-    const message =
-      error instanceof Error ? error.message : "Chat request failed";
+    const message = error instanceof Error ? error.message : "Chat request failed";
     const code = error instanceof ChatServiceError ? error.code : "chat_request_failed";
     this.sessionLogger.error({ err: error, requestType: request.type }, "Chat request failed");
     this.emit({
@@ -7774,7 +7813,10 @@ export class Session {
 
   private toScheduleSummary(
     schedule: Awaited<ReturnType<ScheduleService["inspect"]>>,
-  ): Extract<SessionOutboundMessage, { type: "schedule/list/response" }>["payload"]["schedules"][number] {
+  ): Extract<
+    SessionOutboundMessage,
+    { type: "schedule/list/response" }
+  >["payload"]["schedules"][number] {
     const { runs: _runs, ...summary } = schedule;
     return summary;
   }
@@ -8072,6 +8114,172 @@ export class Session {
       });
     } catch (error) {
       this.emitLoopRpcError(request, error);
+    }
+  }
+
+  private async handleListMcpServersRequest(
+    request: Extract<SessionInboundMessage, { type: "list_mcp_servers_request" }>,
+  ): Promise<void> {
+    try {
+      const servers = await this.mcpServerStore.list();
+      this.emit({
+        type: "list_mcp_servers_response",
+        payload: {
+          requestId: request.requestId,
+          servers,
+          error: null,
+        },
+      });
+    } catch (error: any) {
+      this.emit({
+        type: "list_mcp_servers_response",
+        payload: {
+          requestId: request.requestId,
+          servers: [],
+          error: error?.message ?? "Failed to list MCP servers",
+        },
+      });
+    }
+  }
+
+  private async handleCreateMcpServerRequest(
+    request: Extract<SessionInboundMessage, { type: "create_mcp_server_request" }>,
+  ): Promise<void> {
+    try {
+      const server = await this.mcpServerStore.add(request.payload.server);
+      this.emit({
+        type: "create_mcp_server_response",
+        payload: {
+          requestId: request.requestId,
+          server,
+          error: null,
+        },
+      });
+    } catch (error: any) {
+      this.emit({
+        type: "create_mcp_server_response",
+        payload: {
+          requestId: request.requestId,
+          server: null,
+          error: error?.message ?? "Failed to create MCP server",
+        },
+      });
+    }
+  }
+
+  private async handleUpdateMcpServerRequest(
+    request: Extract<SessionInboundMessage, { type: "update_mcp_server_request" }>,
+  ): Promise<void> {
+    try {
+      const server = await this.mcpServerStore.update(request.payload.id, request.payload.updates);
+      if (!server) {
+        this.emit({
+          type: "update_mcp_server_response",
+          payload: {
+            requestId: request.requestId,
+            server: null,
+            error: "MCP server not found",
+          },
+        });
+        return;
+      }
+      this.emit({
+        type: "update_mcp_server_response",
+        payload: {
+          requestId: request.requestId,
+          server,
+          error: null,
+        },
+      });
+    } catch (error: any) {
+      this.emit({
+        type: "update_mcp_server_response",
+        payload: {
+          requestId: request.requestId,
+          server: null,
+          error: error?.message ?? "Failed to update MCP server",
+        },
+      });
+    }
+  }
+
+  private async handleDeleteMcpServerRequest(
+    request: Extract<SessionInboundMessage, { type: "delete_mcp_server_request" }>,
+  ): Promise<void> {
+    try {
+      const deleted = await this.mcpServerStore.delete(request.payload.id);
+      if (!deleted) {
+        this.emit({
+          type: "delete_mcp_server_response",
+          payload: {
+            requestId: request.requestId,
+            id: request.payload.id,
+            deleted: false,
+            error: "MCP server not found",
+          },
+        });
+        return;
+      }
+      this.emit({
+        type: "delete_mcp_server_response",
+        payload: {
+          requestId: request.requestId,
+          id: request.payload.id,
+          deleted: true,
+          error: null,
+        },
+      });
+    } catch (error: any) {
+      this.emit({
+        type: "delete_mcp_server_response",
+        payload: {
+          requestId: request.requestId,
+          id: request.payload.id,
+          deleted: false,
+          error: error?.message ?? "Failed to delete MCP server",
+        },
+      });
+    }
+  }
+
+  private async handleToggleMcpServerRequest(
+    request: Extract<SessionInboundMessage, { type: "toggle_mcp_server_request" }>,
+  ): Promise<void> {
+    try {
+      const success = request.payload.enabled
+        ? await this.mcpServerStore.enable(request.payload.id)
+        : await this.mcpServerStore.disable(request.payload.id);
+      if (!success) {
+        this.emit({
+          type: "toggle_mcp_server_response",
+          payload: {
+            requestId: request.requestId,
+            id: request.payload.id,
+            enabled: request.payload.enabled,
+            error: "MCP server not found",
+          },
+        });
+        return;
+      }
+      this.emit({
+        type: "toggle_mcp_server_response",
+        payload: {
+          requestId: request.requestId,
+          id: request.payload.id,
+          enabled: request.payload.enabled,
+          error: null,
+        },
+      });
+    } catch (error: any) {
+      this.emit({
+        type: "toggle_mcp_server_response",
+        payload: {
+          requestId: request.requestId,
+          id: request.payload.id,
+          enabled: request.payload.enabled,
+          error: error?.message ?? "Failed to toggle MCP server",
+        },
+      });
     }
   }
 
@@ -8549,5 +8757,4 @@ export class Session {
       this.detachTerminalStream(terminalId, { emitExit: false });
     }
   }
-
 }

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -8150,7 +8150,7 @@ export class Session {
       this.emit({
         type: "create_mcp_server_response",
         payload: {
-          requestId: request.requestId,
+          requestId: request.payload.requestId,
           server,
           error: null,
         },
@@ -8159,7 +8159,7 @@ export class Session {
       this.emit({
         type: "create_mcp_server_response",
         payload: {
-          requestId: request.requestId,
+          requestId: request.payload.requestId,
           server: null,
           error: error?.message ?? "Failed to create MCP server",
         },
@@ -8176,7 +8176,7 @@ export class Session {
         this.emit({
           type: "update_mcp_server_response",
           payload: {
-            requestId: request.requestId,
+            requestId: request.payload.requestId,
             server: null,
             error: "MCP server not found",
           },
@@ -8186,7 +8186,7 @@ export class Session {
       this.emit({
         type: "update_mcp_server_response",
         payload: {
-          requestId: request.requestId,
+          requestId: request.payload.requestId,
           server,
           error: null,
         },
@@ -8195,7 +8195,7 @@ export class Session {
       this.emit({
         type: "update_mcp_server_response",
         payload: {
-          requestId: request.requestId,
+          requestId: request.payload.requestId,
           server: null,
           error: error?.message ?? "Failed to update MCP server",
         },
@@ -8212,7 +8212,7 @@ export class Session {
         this.emit({
           type: "delete_mcp_server_response",
           payload: {
-            requestId: request.requestId,
+            requestId: request.payload.requestId,
             id: request.payload.id,
             deleted: false,
             error: "MCP server not found",
@@ -8223,7 +8223,7 @@ export class Session {
       this.emit({
         type: "delete_mcp_server_response",
         payload: {
-          requestId: request.requestId,
+          requestId: request.payload.requestId,
           id: request.payload.id,
           deleted: true,
           error: null,
@@ -8233,7 +8233,7 @@ export class Session {
       this.emit({
         type: "delete_mcp_server_response",
         payload: {
-          requestId: request.requestId,
+          requestId: request.payload.requestId,
           id: request.payload.id,
           deleted: false,
           error: error?.message ?? "Failed to delete MCP server",
@@ -8253,7 +8253,7 @@ export class Session {
         this.emit({
           type: "toggle_mcp_server_response",
           payload: {
-            requestId: request.requestId,
+            requestId: request.payload.requestId,
             id: request.payload.id,
             enabled: request.payload.enabled,
             error: "MCP server not found",
@@ -8264,7 +8264,7 @@ export class Session {
       this.emit({
         type: "toggle_mcp_server_response",
         payload: {
-          requestId: request.requestId,
+          requestId: request.payload.requestId,
           id: request.payload.id,
           enabled: request.payload.enabled,
           error: null,
@@ -8274,7 +8274,7 @@ export class Session {
       this.emit({
         type: "toggle_mcp_server_response",
         payload: {
-          requestId: request.requestId,
+          requestId: request.payload.requestId,
           id: request.payload.id,
           enabled: request.payload.enabled,
           error: error?.message ?? "Failed to toggle MCP server",

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -257,7 +257,7 @@ export class VoiceAssistantWebSocketServer {
   private readonly agentProviderRuntimeSettings: AgentProviderRuntimeSettingsMap | undefined;
   private readonly providerSnapshotManager: ProviderSnapshotManager;
   private readonly onLifecycleIntent: ((intent: SessionLifecycleIntent) => void) | null;
-  private readonly mcpServerStore: McpServerStore;
+  private readonly mcpServerStore: McpServerStore | undefined;
   private serverCapabilities: ServerCapabilities | undefined;
   private runtimeWindowStartedAt = Date.now();
   private readonly runtimeCounters: WebSocketRuntimeCounters = {
@@ -312,7 +312,7 @@ export class VoiceAssistantWebSocketServer {
     loopService?: LoopService,
     scheduleService?: ScheduleService,
     checkoutDiffManager?: CheckoutDiffManager,
-    mcpServerStore: McpServerStore,
+    mcpServerStore?: McpServerStore,
   ) {
     this.logger = logger.child({ module: "websocket-server" });
     this.serverId = serverId;

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -639,6 +639,7 @@ export class VoiceAssistantWebSocketServer {
       paseoHome: this.paseoHome,
       agentManager: this.agentManager,
       agentStorage: this.agentStorage,
+      mcpServerStore: this.mcpServerStore,
       projectRegistry: this.projectRegistry,
       workspaceRegistry: this.workspaceRegistry,
       chatService: this.chatService,

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -23,14 +23,12 @@ import {
   type WSOutboundMessage,
   wrapSessionMessage,
 } from "./messages.js";
-import {
-  asUint8Array,
-  decodeTerminalStreamFrame,
-} from "../shared/terminal-stream-protocol.js";
+import { asUint8Array, decodeTerminalStreamFrame } from "../shared/terminal-stream-protocol.js";
 import type { AllowedHostsConfig } from "./allowed-hosts.js";
 import { isHostAllowed } from "./allowed-hosts.js";
 import { Session, type SessionLifecycleIntent, type SessionRuntimeMetrics } from "./session.js";
 import type { AgentProvider } from "./agent/agent-sdk-types.js";
+import { McpServerStore } from "./mcp/mcp-server-store.js";
 import type { AgentProviderRuntimeSettingsMap } from "./agent/provider-launch-config.js";
 import { ProviderSnapshotManager } from "./agent/provider-snapshot-manager.js";
 import { buildProviderRegistry } from "./agent/provider-registry.js";
@@ -259,6 +257,7 @@ export class VoiceAssistantWebSocketServer {
   private readonly agentProviderRuntimeSettings: AgentProviderRuntimeSettingsMap | undefined;
   private readonly providerSnapshotManager: ProviderSnapshotManager;
   private readonly onLifecycleIntent: ((intent: SessionLifecycleIntent) => void) | null;
+  private readonly mcpServerStore: McpServerStore;
   private serverCapabilities: ServerCapabilities | undefined;
   private runtimeWindowStartedAt = Date.now();
   private readonly runtimeCounters: WebSocketRuntimeCounters = {
@@ -313,6 +312,7 @@ export class VoiceAssistantWebSocketServer {
     loopService?: LoopService,
     scheduleService?: ScheduleService,
     checkoutDiffManager?: CheckoutDiffManager,
+    mcpServerStore: McpServerStore,
   ) {
     this.logger = logger.child({ module: "websocket-server" });
     this.serverId = serverId;
@@ -340,6 +340,7 @@ export class VoiceAssistantWebSocketServer {
       throw new Error("VoiceAssistantWebSocketServer requires a checkout diff manager.");
     }
     this.checkoutDiffManager = checkoutDiffManager;
+    this.mcpServerStore = mcpServerStore;
     this.backgroundGitFetchManager = new BackgroundGitFetchManager({
       logger: this.logger,
     });
@@ -362,9 +363,10 @@ export class VoiceAssistantWebSocketServer {
     this.serverCapabilities = buildServerCapabilities({
       readiness: this.speech?.getReadiness() ?? null,
     });
-    this.unsubscribeSpeechReadiness = this.speech?.onReadinessChange((snapshot) => {
-      this.publishSpeechReadiness(snapshot);
-    }) ?? null;
+    this.unsubscribeSpeechReadiness =
+      this.speech?.onReadinessChange((snapshot) => {
+        this.publishSpeechReadiness(snapshot);
+      }) ?? null;
 
     const pushLogger = this.logger.child({ module: "push" });
     this.pushTokenStore = new PushTokenStore(pushLogger, join(paseoHome, "push-tokens.json"));
@@ -527,10 +529,7 @@ export class VoiceAssistantWebSocketServer {
     }
   }
 
-  private sendBinaryToClient(
-    ws: WebSocketLike,
-    frame: Uint8Array,
-  ): void {
+  private sendBinaryToClient(ws: WebSocketLike, frame: Uint8Array): void {
     if (ws.readyState !== 1) {
       return;
     }
@@ -543,10 +542,7 @@ export class VoiceAssistantWebSocketServer {
     }
   }
 
-  private sendBinaryToConnection(
-    connection: SessionConnection,
-    frame: Uint8Array,
-  ): void {
+  private sendBinaryToConnection(connection: SessionConnection, frame: Uint8Array): void {
     for (const ws of connection.sockets) {
       this.sendBinaryToClient(ws, frame);
     }

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -49,12 +49,6 @@ import {
 } from "../server/loop/rpc-schemas.js";
 import type { LiteralUnion } from "./literal-union.js";
 import type {
-  McpServerRecord,
-  McpServerConfig,
-  CreateMcpServerInput,
-  UpdateMcpServerInput,
-} from "../server/mcp/mcp-server-types.js";
-import type {
   AgentCapabilityFlags,
   AgentModelDefinition,
   AgentMode,
@@ -2732,7 +2726,7 @@ export const CreateMcpServerResponseMessageSchema = z.object({
   type: z.literal("create_mcp_server_response"),
   payload: z.object({
     requestId: z.string(),
-    server: McpServerRecordSchema,
+    server: McpServerRecordSchema.nullable(),
     error: z.string().nullable(),
   }),
 });

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1389,6 +1389,69 @@ export const CaptureTerminalRequestSchema = z.object({
   requestId: z.string(),
 });
 
+// ============================================================================
+// MCP Server Messages (inbound)
+// ============================================================================
+
+export const ListMcpServersRequestMessageSchema = z.object({
+  type: z.literal("list_mcp_servers_request"),
+  requestId: z.string(),
+});
+
+export const CreateMcpServerRequestMessageSchema = z.object({
+  type: z.literal("create_mcp_server_request"),
+  payload: z.object({
+    requestId: z.string(),
+    server: z.object({
+      name: z.string(),
+      type: z.enum(["stdio", "http", "sse"]),
+      config: McpServerConfigSchema,
+      enabled: z.boolean().optional(),
+      tags: z.array(z.string()).optional(),
+      description: z.string().optional(),
+    }),
+  }),
+});
+
+export const UpdateMcpServerRequestMessageSchema = z.object({
+  type: z.literal("update_mcp_server_request"),
+  payload: z.object({
+    requestId: z.string(),
+    id: z.string(),
+    updates: z
+      .object({
+        name: z.string().optional(),
+        type: z.enum(["stdio", "http", "sse"]).optional(),
+        config: McpServerConfigSchema.optional(),
+        enabled: z.boolean().optional(),
+        tags: z.array(z.string()).optional(),
+        description: z.string().optional(),
+      })
+      .partial(),
+  }),
+});
+
+export const DeleteMcpServerRequestMessageSchema = z.object({
+  type: z.literal("delete_mcp_server_request"),
+  payload: z.object({
+    requestId: z.string(),
+    id: z.string(),
+  }),
+});
+
+export const ToggleMcpServerRequestMessageSchema = z.object({
+  type: z.literal("toggle_mcp_server_request"),
+  payload: z.object({
+    requestId: z.string(),
+    id: z.string(),
+    enabled: z.boolean(),
+  }),
+});
+
+// ============================================================================
+// Session Inbound Message Schema
+// ============================================================================
+
 export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   VoiceAudioChunkMessageSchema,
   AbortRequestMessageSchema,
@@ -2507,124 +2570,6 @@ export const ProviderDiagnosticResponseMessageSchema = z.object({
   }),
 });
 
-// ============================================================================
-// MCP Server Messages
-// ============================================================================
-
-const McpServerRecordSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  type: z.enum(["stdio", "http", "sse"]),
-  config: McpServerConfigSchema,
-  enabled: z.boolean(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-  tags: z.array(z.string()).optional(),
-  description: z.string().optional(),
-});
-
-export const ListMcpServersRequestMessageSchema = z.object({
-  type: z.literal("list_mcp_servers_request"),
-  requestId: z.string(),
-});
-
-export const ListMcpServersResponseMessageSchema = z.object({
-  type: z.literal("list_mcp_servers_response"),
-  payload: z.object({
-    requestId: z.string(),
-    servers: z.array(McpServerRecordSchema),
-    error: z.string().nullable(),
-  }),
-});
-
-export const CreateMcpServerRequestMessageSchema = z.object({
-  type: z.literal("create_mcp_server_request"),
-  payload: z.object({
-    requestId: z.string(),
-    server: z.object({
-      name: z.string(),
-      type: z.enum(["stdio", "http", "sse"]),
-      config: McpServerConfigSchema,
-      enabled: z.boolean().optional(),
-      tags: z.array(z.string()).optional(),
-      description: z.string().optional(),
-    }),
-  }),
-});
-
-export const CreateMcpServerResponseMessageSchema = z.object({
-  type: z.literal("create_mcp_server_response"),
-  payload: z.object({
-    requestId: z.string(),
-    server: McpServerRecordSchema,
-    error: z.string().nullable(),
-  }),
-});
-
-export const UpdateMcpServerRequestMessageSchema = z.object({
-  type: z.literal("update_mcp_server_request"),
-  payload: z.object({
-    requestId: z.string(),
-    id: z.string(),
-    updates: z
-      .object({
-        name: z.string().optional(),
-        type: z.enum(["stdio", "http", "sse"]).optional(),
-        config: McpServerConfigSchema.optional(),
-        enabled: z.boolean().optional(),
-        tags: z.array(z.string()).optional(),
-        description: z.string().optional(),
-      })
-      .partial(),
-  }),
-});
-
-export const UpdateMcpServerResponseMessageSchema = z.object({
-  type: z.literal("update_mcp_server_response"),
-  payload: z.object({
-    requestId: z.string(),
-    server: McpServerRecordSchema.nullable(),
-    error: z.string().nullable(),
-  }),
-});
-
-export const DeleteMcpServerRequestMessageSchema = z.object({
-  type: z.literal("delete_mcp_server_request"),
-  payload: z.object({
-    requestId: z.string(),
-    id: z.string(),
-  }),
-});
-
-export const DeleteMcpServerResponseMessageSchema = z.object({
-  type: z.literal("delete_mcp_server_response"),
-  payload: z.object({
-    requestId: z.string(),
-    id: z.string(),
-    deleted: z.boolean(),
-    error: z.string().nullable(),
-  }),
-});
-
-export const ToggleMcpServerRequestMessageSchema = z.object({
-  type: z.literal("toggle_mcp_server_request"),
-  payload: z.object({
-    requestId: z.string(),
-    id: z.string(),
-    enabled: z.boolean(),
-  }),
-});
-
-export const ToggleMcpServerResponseMessageSchema = z.object({
-  type: z.literal("toggle_mcp_server_response"),
-  payload: z.object({
-    requestId: z.string(),
-    id: z.string(),
-    enabled: z.boolean(),
-    error: z.string().nullable(),
-  }),
-});
-
 const AgentSlashCommandSchema = z.object({
   name: z.string(),
   description: z.string(),
@@ -2755,6 +2700,69 @@ export const TerminalStreamExitSchema = z.object({
   type: z.literal("terminal_stream_exit"),
   payload: z.object({
     terminalId: z.string(),
+  }),
+});
+
+// ============================================================================
+// MCP Server Messages (outbound)
+// ============================================================================
+
+const McpServerRecordSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(["stdio", "http", "sse"]),
+  config: McpServerConfigSchema,
+  enabled: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  tags: z.array(z.string()).optional(),
+  description: z.string().optional(),
+});
+
+export const ListMcpServersResponseMessageSchema = z.object({
+  type: z.literal("list_mcp_servers_response"),
+  payload: z.object({
+    requestId: z.string(),
+    servers: z.array(McpServerRecordSchema),
+    error: z.string().nullable(),
+  }),
+});
+
+export const CreateMcpServerResponseMessageSchema = z.object({
+  type: z.literal("create_mcp_server_response"),
+  payload: z.object({
+    requestId: z.string(),
+    server: McpServerRecordSchema,
+    error: z.string().nullable(),
+  }),
+});
+
+export const UpdateMcpServerResponseMessageSchema = z.object({
+  type: z.literal("update_mcp_server_response"),
+  payload: z.object({
+    requestId: z.string(),
+    server: McpServerRecordSchema.nullable(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const DeleteMcpServerResponseMessageSchema = z.object({
+  type: z.literal("delete_mcp_server_response"),
+  payload: z.object({
+    requestId: z.string(),
+    id: z.string(),
+    deleted: z.boolean(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const ToggleMcpServerResponseMessageSchema = z.object({
+  type: z.literal("toggle_mcp_server_response"),
+  payload: z.object({
+    requestId: z.string(),
+    id: z.string(),
+    enabled: z.boolean(),
+    error: z.string().nullable(),
   }),
 });
 

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -49,6 +49,12 @@ import {
 } from "../server/loop/rpc-schemas.js";
 import type { LiteralUnion } from "./literal-union.js";
 import type {
+  McpServerRecord,
+  McpServerConfig,
+  CreateMcpServerInput,
+  UpdateMcpServerInput,
+} from "../server/mcp/mcp-server-types.js";
+import type {
   AgentCapabilityFlags,
   AgentModelDefinition,
   AgentMode,
@@ -1480,6 +1486,11 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   LoopInspectRequestSchema,
   LoopLogsRequestSchema,
   LoopStopRequestSchema,
+  ListMcpServersRequestMessageSchema,
+  CreateMcpServerRequestMessageSchema,
+  UpdateMcpServerRequestMessageSchema,
+  DeleteMcpServerRequestMessageSchema,
+  ToggleMcpServerRequestMessageSchema,
 ]);
 
 export type SessionInboundMessage = z.infer<typeof SessionInboundMessageSchema>;
@@ -2496,6 +2507,124 @@ export const ProviderDiagnosticResponseMessageSchema = z.object({
   }),
 });
 
+// ============================================================================
+// MCP Server Messages
+// ============================================================================
+
+const McpServerRecordSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(["stdio", "http", "sse"]),
+  config: McpServerConfigSchema,
+  enabled: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  tags: z.array(z.string()).optional(),
+  description: z.string().optional(),
+});
+
+export const ListMcpServersRequestMessageSchema = z.object({
+  type: z.literal("list_mcp_servers_request"),
+  requestId: z.string(),
+});
+
+export const ListMcpServersResponseMessageSchema = z.object({
+  type: z.literal("list_mcp_servers_response"),
+  payload: z.object({
+    requestId: z.string(),
+    servers: z.array(McpServerRecordSchema),
+    error: z.string().nullable(),
+  }),
+});
+
+export const CreateMcpServerRequestMessageSchema = z.object({
+  type: z.literal("create_mcp_server_request"),
+  payload: z.object({
+    requestId: z.string(),
+    server: z.object({
+      name: z.string(),
+      type: z.enum(["stdio", "http", "sse"]),
+      config: McpServerConfigSchema,
+      enabled: z.boolean().optional(),
+      tags: z.array(z.string()).optional(),
+      description: z.string().optional(),
+    }),
+  }),
+});
+
+export const CreateMcpServerResponseMessageSchema = z.object({
+  type: z.literal("create_mcp_server_response"),
+  payload: z.object({
+    requestId: z.string(),
+    server: McpServerRecordSchema,
+    error: z.string().nullable(),
+  }),
+});
+
+export const UpdateMcpServerRequestMessageSchema = z.object({
+  type: z.literal("update_mcp_server_request"),
+  payload: z.object({
+    requestId: z.string(),
+    id: z.string(),
+    updates: z
+      .object({
+        name: z.string().optional(),
+        type: z.enum(["stdio", "http", "sse"]).optional(),
+        config: McpServerConfigSchema.optional(),
+        enabled: z.boolean().optional(),
+        tags: z.array(z.string()).optional(),
+        description: z.string().optional(),
+      })
+      .partial(),
+  }),
+});
+
+export const UpdateMcpServerResponseMessageSchema = z.object({
+  type: z.literal("update_mcp_server_response"),
+  payload: z.object({
+    requestId: z.string(),
+    server: McpServerRecordSchema.nullable(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const DeleteMcpServerRequestMessageSchema = z.object({
+  type: z.literal("delete_mcp_server_request"),
+  payload: z.object({
+    requestId: z.string(),
+    id: z.string(),
+  }),
+});
+
+export const DeleteMcpServerResponseMessageSchema = z.object({
+  type: z.literal("delete_mcp_server_response"),
+  payload: z.object({
+    requestId: z.string(),
+    id: z.string(),
+    deleted: z.boolean(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const ToggleMcpServerRequestMessageSchema = z.object({
+  type: z.literal("toggle_mcp_server_request"),
+  payload: z.object({
+    requestId: z.string(),
+    id: z.string(),
+    enabled: z.boolean(),
+  }),
+});
+
+export const ToggleMcpServerResponseMessageSchema = z.object({
+  type: z.literal("toggle_mcp_server_response"),
+  payload: z.object({
+    requestId: z.string(),
+    id: z.string(),
+    enabled: z.boolean(),
+    error: z.string().nullable(),
+  }),
+});
+
 const AgentSlashCommandSchema = z.object({
   name: z.string(),
   description: z.string(),
@@ -2727,6 +2856,11 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   LoopInspectResponseSchema,
   LoopLogsResponseSchema,
   LoopStopResponseSchema,
+  ListMcpServersResponseMessageSchema,
+  CreateMcpServerResponseMessageSchema,
+  UpdateMcpServerResponseMessageSchema,
+  DeleteMcpServerResponseMessageSchema,
+  ToggleMcpServerResponseMessageSchema,
 ]);
 
 export type SessionOutboundMessage = z.infer<typeof SessionOutboundMessageSchema>;
@@ -2816,6 +2950,11 @@ export type LoopListResponse = z.infer<typeof LoopListResponseSchema>;
 export type LoopInspectResponse = z.infer<typeof LoopInspectResponseSchema>;
 export type LoopLogsResponse = z.infer<typeof LoopLogsResponseSchema>;
 export type LoopStopResponse = z.infer<typeof LoopStopResponseSchema>;
+export type ListMcpServersResponse = z.infer<typeof ListMcpServersResponseMessageSchema>;
+export type CreateMcpServerResponse = z.infer<typeof CreateMcpServerResponseMessageSchema>;
+export type UpdateMcpServerResponse = z.infer<typeof UpdateMcpServerResponseMessageSchema>;
+export type DeleteMcpServerResponse = z.infer<typeof DeleteMcpServerResponseMessageSchema>;
+export type ToggleMcpServerResponse = z.infer<typeof ToggleMcpServerResponseMessageSchema>;
 
 // Type exports for payload types
 export type ActivityLogPayload = z.infer<typeof ActivityLogPayloadSchema>;
@@ -2835,9 +2974,7 @@ export type CreateAgentRequestMessage = z.infer<typeof CreateAgentRequestMessage
 export type ListProviderModelsRequestMessage = z.infer<
   typeof ListProviderModelsRequestMessageSchema
 >;
-export type ListProviderModesRequestMessage = z.infer<
-  typeof ListProviderModesRequestMessageSchema
->;
+export type ListProviderModesRequestMessage = z.infer<typeof ListProviderModesRequestMessageSchema>;
 export type ListProviderFeaturesRequestMessage = z.infer<
   typeof ListProviderFeaturesRequestMessageSchema
 >;
@@ -2937,6 +3074,11 @@ export type ClientHeartbeatMessage = z.infer<typeof ClientHeartbeatMessageSchema
 export type ListCommandsRequest = z.infer<typeof ListCommandsRequestSchema>;
 export type ListCommandsResponse = z.infer<typeof ListCommandsResponseSchema>;
 export type RegisterPushTokenMessage = z.infer<typeof RegisterPushTokenMessageSchema>;
+export type ListMcpServersRequestMessage = z.infer<typeof ListMcpServersRequestMessageSchema>;
+export type CreateMcpServerRequestMessage = z.infer<typeof CreateMcpServerRequestMessageSchema>;
+export type UpdateMcpServerRequestMessage = z.infer<typeof UpdateMcpServerRequestMessageSchema>;
+export type DeleteMcpServerRequestMessage = z.infer<typeof DeleteMcpServerRequestMessageSchema>;
+export type ToggleMcpServerRequestMessage = z.infer<typeof ToggleMcpServerRequestMessageSchema>;
 
 // Terminal message types
 export type ListTerminalsRequest = z.infer<typeof ListTerminalsRequestSchema>;


### PR DESCRIPTION
## Summary

Implements native macOS notifications with configurable sound, actions to respond to permissions directly from the notification, and dock badge count.

## Changes

### New Features
- **Notification Sound**: Configurable system sound (default: 'Pop') with mute option
- **Notification Actions**: Approve/Deny/View buttons on permission notifications
- **Dock Badge Count**: Badge increments when pending attention, clears on focus

### Technical Details
- Adds `electron-store` for persisting sound preferences
- Adds `NSUserNotificationAlertStyle` entitlement to enable sounds and actions
- Improves diagnostic logging for notifications
- Backward compatible: only affects notifications when using new options