### PR TITLE
feat(app): support renaming agent and terminal tabs

### DIFF
--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -85,6 +85,7 @@ interface SplitContainerProps {
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onRenameTab: (input: { tab: WorkspaceTabDescriptor; currentLabel: string }) => Promise<void> | void;
   onCloseTabsToLeft: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
@@ -255,6 +256,7 @@ export function SplitContainer({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onRenameTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
@@ -525,6 +527,7 @@ export function SplitContainer({
         onCopyResumeCommand={onCopyResumeCommand}
         onCopyAgentId={onCopyAgentId}
         onReloadAgent={onReloadAgent}
+        onRenameTab={onRenameTab}
         onCloseTabsToLeft={onCloseTabsToLeft}
         onCloseTabsToRight={onCloseTabsToRight}
         onCloseOtherTabs={onCloseOtherTabs}
@@ -648,6 +651,7 @@ function SplitNodeView({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onRenameTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
@@ -684,6 +688,7 @@ function SplitNodeView({
         onCopyResumeCommand={onCopyResumeCommand}
         onCopyAgentId={onCopyAgentId}
         onReloadAgent={onReloadAgent}
+        onRenameTab={onRenameTab}
         onCloseTabsToLeft={onCloseTabsToLeft}
         onCloseTabsToRight={onCloseTabsToRight}
         onCloseOtherTabs={onCloseOtherTabs}
@@ -735,6 +740,7 @@ function SplitNodeView({
               onCopyResumeCommand={onCopyResumeCommand}
               onCopyAgentId={onCopyAgentId}
               onReloadAgent={onReloadAgent}
+              onRenameTab={onRenameTab}
               onCloseTabsToLeft={onCloseTabsToLeft}
               onCloseTabsToRight={onCloseTabsToRight}
               onCloseOtherTabs={onCloseOtherTabs}
@@ -785,6 +791,7 @@ function SplitPaneView({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onRenameTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
@@ -897,6 +904,7 @@ function SplitPaneView({
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
           onReloadAgent={onReloadAgent}
+          onRenameTab={onRenameTab}
           onCloseTabsToLeft={(tabId) => onCloseTabsToLeft(tabId, paneTabs)}
           onCloseTabsToRight={(tabId) => onCloseTabsToRight(tabId, paneTabs)}
           onCloseOtherTabs={(tabId) => onCloseOtherTabs(tabId, paneTabs)}

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -81,6 +81,7 @@ type WorkspaceDesktopTabsRowProps = {
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onRenameTab: (input: { tab: WorkspaceTabDescriptor; currentLabel: string }) => Promise<void> | void;
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
@@ -334,6 +335,8 @@ function TabChip({
                     return <Copy size={16} color={iconColor} />;
                   case "rotate-cw":
                     return <RotateCw size={16} color={iconColor} />;
+                  case "square-pen":
+                    return <SquarePen size={16} color={iconColor} />;
                   case "arrow-left-to-line":
                     return <ArrowLeftToLine size={16} color={iconColor} />;
                   case "arrow-right-to-line":
@@ -375,6 +378,7 @@ export function WorkspaceDesktopTabsRow({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onRenameTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
@@ -498,6 +502,7 @@ export function WorkspaceDesktopTabsRow({
                 onCopyResumeCommand={onCopyResumeCommand}
                 onCopyAgentId={onCopyAgentId}
                 onReloadAgent={onReloadAgent}
+                onRenameTab={onRenameTab}
                 onCloseTabsToLeft={onCloseTabsToLeft}
                 onCloseTabsToRight={onCloseTabsToRight}
                 onCloseOtherTabs={onCloseOtherTabs}
@@ -627,6 +632,7 @@ function ResolvedDesktopTabChip({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onRenameTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
@@ -651,6 +657,7 @@ function ResolvedDesktopTabChip({
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onRenameTab: (input: { tab: WorkspaceTabDescriptor; currentLabel: string }) => Promise<void> | void;
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
@@ -665,34 +672,6 @@ function ResolvedDesktopTabChip({
   showDropIndicatorBefore: boolean;
   showDropIndicatorAfter: boolean;
 }) {
-  const resolvedTab = useMemo(
-    () =>
-      buildWorkspaceDesktopTabActions({
-        tab: item.tab,
-        index,
-        tabCount,
-        onCopyResumeCommand,
-        onCopyAgentId,
-        onReloadAgent,
-        onCloseTab,
-        onCloseTabsToLeft,
-        onCloseTabsToRight,
-        onCloseOtherTabs,
-      }),
-    [
-      index,
-      item.tab,
-      onCloseOtherTabs,
-      onCloseTab,
-      onCloseTabsToLeft,
-      onCloseTabsToRight,
-      onCopyAgentId,
-      onCopyResumeCommand,
-      onReloadAgent,
-      tabCount,
-    ],
-  );
-
   return (
     <WorkspaceTabPresentationResolver
       tab={item.tab}
@@ -700,6 +679,24 @@ function ResolvedDesktopTabChip({
       workspaceId={normalizedWorkspaceId}
     >
       {(presentation) => {
+        const resolvedTab = buildWorkspaceDesktopTabActions({
+          tab: item.tab,
+          index,
+          tabCount,
+          onCopyResumeCommand,
+          onCopyAgentId,
+          onReloadAgent,
+          onRenameTab: () => {
+            void onRenameTab({
+              tab: item.tab,
+              currentLabel: presentation.label,
+            });
+          },
+          onCloseTab,
+          onCloseTabsToLeft,
+          onCloseTabsToRight,
+          onCloseOtherTabs,
+        });
         const tooltipLabel =
           presentation.titleState === "loading" ? "Loading agent title" : presentation.label;
 

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -35,6 +35,8 @@ import { SidebarMenuToggle } from "@/components/headers/menu-header";
 import { HeaderToggleButton } from "@/components/headers/header-toggle-button";
 import { ScreenHeader } from "@/components/headers/screen-header";
 import { BranchSwitcher } from "@/components/branch-switcher";
+import { AdaptiveModalSheet, AdaptiveTextInput } from "@/components/adaptive-modal-sheet";
+import { Button } from "@/components/ui/button";
 import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
 import { Shortcut } from "@/components/ui/shortcut";
 import {
@@ -133,6 +135,13 @@ type WorkspaceScreenProps = {
   workspaceId: string;
 };
 
+type RenameableWorkspaceTabKind = "agent" | "terminal";
+
+interface RenameTabDialogState {
+  tabId: string;
+  kind: RenameableWorkspaceTabKind;
+}
+
 function trimNonEmpty(value: string | null | undefined): string | null {
   if (typeof value !== "string") {
     return null;
@@ -187,6 +196,7 @@ type MobileWorkspaceTabSwitcherProps = {
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onRenameTab: (input: { tab: WorkspaceTabDescriptor; currentLabel: string }) => Promise<void> | void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsAbove: (tabId: string) => Promise<void> | void;
   onCloseTabsBelow: (tabId: string) => Promise<void> | void;
@@ -263,6 +273,71 @@ function WorkspaceDocumentTitleEffect({
   return null;
 }
 
+function RenameTabDialog({
+  visible,
+  kind,
+  value,
+  onChangeValue,
+  onClose,
+  onSave,
+}: {
+  visible: boolean;
+  kind: RenameableWorkspaceTabKind | null;
+  value: string;
+  onChangeValue: (value: string) => void;
+  onClose: () => void;
+  onSave: () => void;
+}) {
+  const { theme } = useUnistyles();
+
+  return (
+    <AdaptiveModalSheet
+      title={kind ? getRenameTabDialogTitle(kind) : "Rename tab"}
+      visible={visible}
+      onClose={onClose}
+      testID="workspace-rename-tab-modal"
+    >
+      <View style={styles.renameTabField}>
+        <Text style={styles.renameTabLabel}>Name</Text>
+        <AdaptiveTextInput
+          testID="workspace-rename-tab-input"
+          style={styles.renameTabInput}
+          value={value}
+          onChangeText={onChangeValue}
+          placeholder={kind === "terminal" ? "Terminal" : "Agent"}
+          placeholderTextColor={theme.colors.foregroundMuted}
+          autoCapitalize="none"
+          autoCorrect={false}
+          onSubmitEditing={() => {
+            onSave();
+          }}
+        />
+        <Text style={styles.renameTabHint}>
+          Delete the name and save to restore the default title.
+        </Text>
+      </View>
+      <View style={styles.renameTabActions}>
+        <Button
+          size="sm"
+          variant="secondary"
+          onPress={onClose}
+          testID="workspace-rename-tab-cancel"
+        >
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          variant="default"
+          onPress={onSave}
+          testID="workspace-rename-tab-save"
+        >
+          Save
+        </Button>
+      </View>
+    </AdaptiveModalSheet>
+  );
+}
+
 function MobileWorkspaceTabOption({
   tab,
   tabIndex,
@@ -275,6 +350,7 @@ function MobileWorkspaceTabOption({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onRenameTab,
   onCloseTab,
   onCloseTabsAbove,
   onCloseTabsBelow,
@@ -291,6 +367,7 @@ function MobileWorkspaceTabOption({
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onRenameTab: (input: { tab: WorkspaceTabDescriptor; currentLabel: string }) => Promise<void> | void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsAbove: (tabId: string) => Promise<void> | void;
   onCloseTabsBelow: (tabId: string) => Promise<void> | void;
@@ -298,20 +375,6 @@ function MobileWorkspaceTabOption({
 }) {
   const { theme } = useUnistyles();
   const menuTestIDBase = `workspace-tab-menu-${tab.key}`;
-  const menuEntries = buildWorkspaceTabMenuEntries({
-    surface: "mobile",
-    tab,
-    index: tabIndex,
-    tabCount,
-    menuTestIDBase,
-    onCopyResumeCommand,
-    onCopyAgentId,
-    onReloadAgent,
-    onCloseTab,
-    onCloseTabsBefore: onCloseTabsAbove,
-    onCloseTabsAfter: onCloseTabsBelow,
-    onCloseOtherTabs,
-  });
 
   return (
     <WorkspaceTabPresentationResolver
@@ -319,74 +382,103 @@ function MobileWorkspaceTabOption({
       serverId={normalizedServerId}
       workspaceId={normalizedWorkspaceId}
     >
-      {(presentation) => (
-        <WorkspaceTabOptionRow
-          presentation={presentation}
-          selected={selected}
-          active={active}
-          onPress={onPress}
-          trailingAccessory={
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                testID={`${menuTestIDBase}-trigger`}
-                accessibilityRole="button"
-                accessibilityLabel={`Open menu for ${presentation.label}`}
-                hitSlop={8}
-                style={({ open, pressed }) => [
-                  styles.mobileTabMenuTrigger,
-                  (open || pressed) && styles.mobileTabMenuTriggerActive,
-                ]}
-              >
-                <Ellipsis size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent side="bottom" align="end" width={220} testID={menuTestIDBase}>
-                {menuEntries.map((entry) =>
-                  entry.kind === "separator" ? (
-                    <DropdownMenuSeparator key={entry.key} />
-                  ) : (
-                    <DropdownMenuItem
-                      key={entry.key}
-                      testID={entry.testID}
-                      disabled={entry.disabled}
-                      destructive={entry.destructive}
-                      onSelect={entry.onSelect}
-                      tooltip={entry.tooltip}
-                      leading={(() => {
-                        const iconColor = theme.colors.foregroundMuted;
-                        switch (entry.icon) {
-                          case "copy":
-                            return <Copy size={16} color={iconColor} />;
-                          case "rotate-cw":
-                            return <RotateCw size={16} color={iconColor} />;
-                          case "arrow-left-to-line":
-                            return <ArrowLeftToLine size={16} color={iconColor} />;
-                          case "arrow-right-to-line":
-                            return <ArrowRightToLine size={16} color={iconColor} />;
-                          case "copy-x":
-                            return <CopyX size={16} color={iconColor} />;
-                          case "x":
-                            return <X size={16} color={iconColor} />;
-                          default:
-                            return undefined;
+      {(presentation) => {
+        const menuEntries = buildWorkspaceTabMenuEntries({
+          surface: "mobile",
+          tab,
+          index: tabIndex,
+          tabCount,
+          menuTestIDBase,
+          onCopyResumeCommand,
+          onCopyAgentId,
+          onReloadAgent,
+          onRenameTab: () => {
+            void onRenameTab({
+              tab,
+              currentLabel: presentation.label,
+            });
+          },
+          onCloseTab,
+          onCloseTabsBefore: onCloseTabsAbove,
+          onCloseTabsAfter: onCloseTabsBelow,
+          onCloseOtherTabs,
+        });
+
+        return (
+          <WorkspaceTabOptionRow
+            presentation={presentation}
+            selected={selected}
+            active={active}
+            onPress={onPress}
+            trailingAccessory={
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  testID={`${menuTestIDBase}-trigger`}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open menu for ${presentation.label}`}
+                  hitSlop={8}
+                  style={({ open, pressed }) => [
+                    styles.mobileTabMenuTrigger,
+                    (open || pressed) && styles.mobileTabMenuTriggerActive,
+                  ]}
+                >
+                  <Ellipsis size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side="bottom" align="end" width={220} testID={menuTestIDBase}>
+                  {menuEntries.map((entry) =>
+                    entry.kind === "separator" ? (
+                      <DropdownMenuSeparator key={entry.key} />
+                    ) : (
+                      <DropdownMenuItem
+                        key={entry.key}
+                        testID={entry.testID}
+                        disabled={entry.disabled}
+                        destructive={entry.destructive}
+                        onSelect={entry.onSelect}
+                        tooltip={entry.tooltip}
+                        leading={(() => {
+                          const iconColor = theme.colors.foregroundMuted;
+                          switch (entry.icon) {
+                            case "copy":
+                              return <Copy size={16} color={iconColor} />;
+                            case "rotate-cw":
+                              return <RotateCw size={16} color={iconColor} />;
+                            case "square-pen":
+                              return <SquarePen size={16} color={iconColor} />;
+                            case "arrow-left-to-line":
+                              return <ArrowLeftToLine size={16} color={iconColor} />;
+                            case "arrow-right-to-line":
+                              return <ArrowRightToLine size={16} color={iconColor} />;
+                            case "copy-x":
+                              return <CopyX size={16} color={iconColor} />;
+                            case "x":
+                              return <X size={16} color={iconColor} />;
+                            default:
+                              return undefined;
+                          }
+                        })()}
+                        trailing={
+                          entry.hint ? (
+                            <Text style={styles.menuItemHint}>{entry.hint}</Text>
+                          ) : undefined
                         }
-                      })()}
-                      trailing={
-                        entry.hint ? (
-                          <Text style={styles.menuItemHint}>{entry.hint}</Text>
-                        ) : undefined
-                      }
-                    >
-                      {entry.label}
-                    </DropdownMenuItem>
-                  ),
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          }
-        />
-      )}
+                      >
+                        {entry.label}
+                      </DropdownMenuItem>
+                    ),
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            }
+          />
+        );
+      }}
     </WorkspaceTabPresentationResolver>
   );
+}
+
+function getRenameTabDialogTitle(kind: RenameableWorkspaceTabKind): string {
+  return kind === "agent" ? "Rename agent tab" : "Rename terminal tab";
 }
 
 const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
@@ -401,6 +493,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onRenameTab,
   onCloseTab,
   onCloseTabsAbove,
   onCloseTabsBelow,
@@ -473,6 +566,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
               onCopyResumeCommand={onCopyResumeCommand}
               onCopyAgentId={onCopyAgentId}
               onReloadAgent={onReloadAgent}
+              onRenameTab={onRenameTab}
               onCloseTab={onCloseTab}
               onCloseTabsAbove={onCloseTabsAbove}
               onCloseTabsBelow={onCloseTabsBelow}
@@ -871,6 +965,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
   const paneFocusSuppressedRef = useRef(false);
   const resizeWorkspaceSplit = useWorkspaceLayoutStore((state) => state.resizeSplit);
   const reorderWorkspaceTabsInPane = useWorkspaceLayoutStore((state) => state.reorderTabsInPane);
+  const renameWorkspaceTab = useWorkspaceLayoutStore((state) => state.renameTab);
   const pinnedAgentIds = useWorkspaceLayoutStore((state) =>
     persistenceKey
       ? (state.pinnedAgentIdsByWorkspace[persistenceKey] ?? EMPTY_PINNED_AGENT_IDS)
@@ -1128,6 +1223,8 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
 
   const [hoveredTabKey, setHoveredTabKey] = useState<string | null>(null);
   const [hoveredCloseTabKey, setHoveredCloseTabKey] = useState<string | null>(null);
+  const [renameTabDialog, setRenameTabDialog] = useState<RenameTabDialogState | null>(null);
+  const [renameTabDraft, setRenameTabDraft] = useState("");
 
   const tabByKey = useMemo(() => {
     const map = new Map<string, WorkspaceTabDescriptor>();
@@ -1397,6 +1494,34 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
     },
     [client, isConnected, toast],
   );
+
+  const handleRequestRenameTab = useCallback(
+    (input: { tab: WorkspaceTabDescriptor; currentLabel: string }) => {
+      if (input.tab.target.kind !== "agent" && input.tab.target.kind !== "terminal") {
+        return;
+      }
+      setRenameTabDialog({
+        tabId: input.tab.tabId,
+        kind: input.tab.target.kind,
+      });
+      setRenameTabDraft(input.currentLabel);
+    },
+    [],
+  );
+
+  const handleCloseRenameTabDialog = useCallback(() => {
+    setRenameTabDialog(null);
+    setRenameTabDraft("");
+  }, []);
+
+  const handleSaveRenameTab = useCallback(() => {
+    if (!renameTabDialog || !persistenceKey) {
+      handleCloseRenameTabDialog();
+      return;
+    }
+    renameWorkspaceTab(persistenceKey, renameTabDialog.tabId, renameTabDraft);
+    handleCloseRenameTabDialog();
+  }, [handleCloseRenameTabDialog, persistenceKey, renameTabDialog, renameTabDraft, renameWorkspaceTab]);
 
   const handleCopyWorkspacePath = useCallback(async () => {
     if (!isAbsolutePath(normalizedWorkspaceId)) {
@@ -2185,6 +2310,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
               onCopyResumeCommand={handleCopyResumeCommand}
               onCopyAgentId={handleCopyAgentId}
               onReloadAgent={handleReloadAgent}
+              onRenameTab={handleRequestRenameTab}
               onCloseTab={handleCloseTabById}
               onCloseTabsAbove={handleCloseTabsToLeft}
               onCloseTabsBelow={handleCloseTabsToRight}
@@ -2206,6 +2332,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
               onCopyResumeCommand={handleCopyResumeCommand}
               onCopyAgentId={handleCopyAgentId}
               onReloadAgent={handleReloadAgent}
+              onRenameTab={handleRequestRenameTab}
               onCloseTabsToLeft={handleCloseTabsToLeft}
               onCloseTabsToRight={handleCloseTabsToRight}
               onCloseOtherTabs={handleCloseOtherTabs}
@@ -2243,6 +2370,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
                     onCopyResumeCommand={handleCopyResumeCommand}
                     onCopyAgentId={handleCopyAgentId}
                     onReloadAgent={handleReloadAgent}
+                    onRenameTab={handleRequestRenameTab}
                     onCloseTabsToLeft={handleCloseTabsToLeftInPane}
                     onCloseTabsToRight={handleCloseTabsToRightInPane}
                     onCloseOtherTabs={handleCloseOtherTabsInPane}
@@ -2276,6 +2404,14 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
           />
         )}
       </View>
+      <RenameTabDialog
+        visible={renameTabDialog !== null}
+        kind={renameTabDialog?.kind ?? null}
+        value={renameTabDraft}
+        onChangeValue={setRenameTabDraft}
+        onClose={handleCloseRenameTabDialog}
+        onSave={handleSaveRenameTab}
+      />
     </View>
   );
 }
@@ -2466,6 +2602,34 @@ const styles = StyleSheet.create((theme) => ({
   menuItemHint: {
     color: theme.colors.foregroundMuted,
     fontSize: theme.fontSize.xs,
+  },
+  renameTabField: {
+    gap: theme.spacing[2],
+  },
+  renameTabLabel: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+  },
+  renameTabInput: {
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.md,
+    backgroundColor: theme.colors.surface0,
+    color: theme.colors.foreground,
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[2],
+    fontSize: theme.fontSize.sm,
+  },
+  renameTabHint: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  renameTabActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: theme.spacing[2],
+    marginTop: theme.spacing[1],
   },
   tabsContainer: {
     borderBottomWidth: 1,

--- a/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
@@ -16,6 +16,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
     const onCopyResumeCommand = vi.fn();
     const onCopyAgentId = vi.fn();
     const onReloadAgent = vi.fn();
+    const onRenameTab = vi.fn();
     const onCloseTab = vi.fn();
     const onCloseTabsBefore = vi.fn();
     const onCloseTabsAfter = vi.fn();
@@ -30,6 +31,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyResumeCommand,
       onCopyAgentId,
       onReloadAgent,
+      onRenameTab,
       onCloseTab,
       onCloseTabsBefore,
       onCloseTabsAfter,
@@ -39,6 +41,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
     expect(entries.filter((entry) => entry.kind === "item").map((entry) => entry.label)).toEqual([
       "Copy resume command",
       "Copy agent id",
+      "Rename",
       "Close to the left",
       "Close to the right",
       "Close other tabs",
@@ -57,6 +60,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
       onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
       onCloseTab: vi.fn(),
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
@@ -66,6 +70,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
     expect(entries.filter((entry) => entry.kind === "item").map((entry) => entry.label)).toEqual([
       "Copy resume command",
       "Copy agent id",
+      "Rename",
       "Close tabs above",
       "Close tabs below",
       "Close other tabs",
@@ -89,6 +94,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
       onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
       onCloseTab: vi.fn(),
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
@@ -96,6 +102,9 @@ describe("buildWorkspaceTabMenuEntries", () => {
     });
 
     expect(entries.some((entry) => entry.kind === "item" && entry.label === "Copy agent id")).toBe(
+      false,
+    );
+    expect(entries.some((entry) => entry.kind === "item" && entry.label === "Rename")).toBe(
       false,
     );
     expect(entries.some((entry) => entry.kind === "item" && entry.label === "Reload agent")).toBe(
@@ -114,6 +123,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
       onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
       onCloseTab: vi.fn(),
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
@@ -125,6 +135,37 @@ describe("buildWorkspaceTabMenuEntries", () => {
         kind: "item",
         key: "reload-agent",
         tooltip: "Reload agent to update skills, MCPs or login status.",
+      }),
+    );
+  });
+
+  it("includes rename for terminal tabs", () => {
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab: {
+        key: "terminal_term-1",
+        tabId: "terminal_term-1",
+        kind: "terminal",
+        target: { kind: "terminal", terminalId: "term-1" },
+      },
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: "workspace-tab-context-terminal_term-1",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        kind: "item",
+        key: "rename",
+        label: "Rename",
       }),
     );
   });

--- a/packages/app/src/screens/workspace/workspace-tab-menu.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.ts
@@ -11,6 +11,7 @@ export type WorkspaceTabMenuEntry =
       icon?:
         | "copy"
         | "rotate-cw"
+        | "square-pen"
         | "arrow-left-to-line"
         | "arrow-right-to-line"
         | "copy-x"
@@ -36,6 +37,7 @@ interface BuildWorkspaceTabMenuEntriesInput {
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onRenameTab: (tab: WorkspaceTabDescriptor) => Promise<void> | void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsBefore: (tabId: string) => Promise<void> | void;
   onCloseTabsAfter: (tabId: string) => Promise<void> | void;
@@ -49,6 +51,7 @@ interface BuildWorkspaceDesktopTabActionsInput {
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onRenameTab: (tab: WorkspaceTabDescriptor) => Promise<void> | void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
@@ -90,6 +93,10 @@ function getCloseButtonTestId(tab: WorkspaceTabDescriptor): string {
   return `workspace-file-close-${encodeFilePathForPathSegment(tab.target.path)}`;
 }
 
+function canRenameTab(tab: WorkspaceTabDescriptor): boolean {
+  return tab.target.kind === "agent" || tab.target.kind === "terminal";
+}
+
 export function buildWorkspaceTabMenuEntries(
   input: BuildWorkspaceTabMenuEntriesInput,
 ): WorkspaceTabMenuEntry[] {
@@ -102,6 +109,7 @@ export function buildWorkspaceTabMenuEntries(
     onCopyResumeCommand,
     onCopyAgentId,
     onReloadAgent,
+    onRenameTab,
     onCloseTab,
     onCloseTabsBefore,
     onCloseTabsAfter,
@@ -138,6 +146,23 @@ export function buildWorkspaceTabMenuEntries(
     entries.push({
       kind: "separator",
       key: "copy-separator",
+    });
+  }
+
+  if (canRenameTab(tab)) {
+    entries.push({
+      kind: "item",
+      key: "rename",
+      label: "Rename",
+      icon: "square-pen",
+      testID: `${menuTestIDBase}-rename`,
+      onSelect: () => {
+        void onRenameTab(tab);
+      },
+    });
+    entries.push({
+      kind: "separator",
+      key: "rename-separator",
     });
   }
 
@@ -217,6 +242,7 @@ export function buildWorkspaceDesktopTabActions(
       onCopyResumeCommand: input.onCopyResumeCommand,
       onCopyAgentId: input.onCopyAgentId,
       onReloadAgent: input.onReloadAgent,
+      onRenameTab: input.onRenameTab,
       onCloseTab: input.onCloseTab,
       onCloseTabsBefore: input.onCloseTabsToLeft,
       onCloseTabsAfter: input.onCloseTabsToRight,

--- a/packages/app/src/screens/workspace/workspace-tab-presentation.tsx
+++ b/packages/app/src/screens/workspace/workspace-tab-presentation.tsx
@@ -7,6 +7,10 @@ import { SyncedLoader } from "@/components/synced-loader";
 import { ensurePanelsRegistered } from "@/panels/register-panels";
 import { getPanelRegistration } from "@/panels/panel-registry";
 import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
+import {
+  buildWorkspaceTabPersistenceKey,
+  useWorkspaceLayoutStore,
+} from "@/stores/workspace-layout-store";
 import type { SidebarStateBucket } from "@/utils/sidebar-agent-state";
 import { getStatusDotColor, isEmphasizedStatusDotBucket } from "@/utils/status-dot-color";
 import { shouldRenderSyncedStatusLoader } from "@/utils/status-loader";
@@ -67,6 +71,13 @@ function WorkspaceTabPresentationResolverInner({
   workspaceId,
   children,
 }: WorkspaceTabPresentationResolverInnerProps): ReactElement {
+  const workspaceKey = buildWorkspaceTabPersistenceKey({ serverId, workspaceId });
+  const customLabel = useWorkspaceLayoutStore((state) => {
+    if (!workspaceKey) {
+      return null;
+    }
+    return state.tabLabelsByWorkspace[workspaceKey]?.[tab.tabId] ?? null;
+  });
   const descriptor = registration.useDescriptor(tab.target as never, {
     serverId,
     workspaceId,
@@ -76,13 +87,14 @@ function WorkspaceTabPresentationResolverInner({
     () => ({
       key: tab.key,
       kind: tab.kind,
-      label: descriptor.label,
+      label: customLabel ?? descriptor.label,
       subtitle: descriptor.subtitle,
-      titleState: descriptor.titleState,
+      titleState: customLabel ? "ready" : descriptor.titleState,
       icon: descriptor.icon,
       statusBucket: descriptor.statusBucket,
     }),
     [
+      customLabel,
       descriptor.icon,
       descriptor.label,
       descriptor.statusBucket,

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -224,6 +224,7 @@ describe("workspace-layout-store actions", () => {
       layoutByWorkspace: {},
       splitSizesByWorkspace: {},
       pinnedAgentIdsByWorkspace: {},
+      tabLabelsByWorkspace: {},
     });
     vi.restoreAllMocks();
   });
@@ -700,6 +701,22 @@ describe("workspace-layout-store actions", () => {
     expect(partialize?.(state)).toEqual({
       layoutByWorkspace: {},
       splitSizesByWorkspace: {},
+      tabLabelsByWorkspace: {},
     });
+  });
+
+  it("renames workspace tabs and clears labels when the saved name is empty", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = useWorkspaceLayoutStore.getState();
+    const tabId = store.openTab(workspaceKey, { kind: "terminal", terminalId: "term-1" });
+
+    expect(tabId).toBe("terminal_term-1");
+    store.renameTab(workspaceKey, tabId!, " Build shell ");
+    expect(useWorkspaceLayoutStore.getState().tabLabelsByWorkspace[workspaceKey]).toEqual({
+      [tabId as string]: "Build shell",
+    });
+
+    store.renameTab(workspaceKey, tabId!, "   ");
+    expect(useWorkspaceLayoutStore.getState().tabLabelsByWorkspace[workspaceKey]).toBeUndefined();
   });
 });

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -54,11 +54,13 @@ interface WorkspaceLayoutStore {
   layoutByWorkspace: Record<string, WorkspaceLayout>;
   splitSizesByWorkspace: Record<string, Record<string, number[]>>;
   pinnedAgentIdsByWorkspace: Record<string, Set<string>>;
+  tabLabelsByWorkspace: Record<string, Record<string, string>>;
   openTab: (workspaceKey: string, target: WorkspaceTabTarget) => string | null;
   closeTab: (workspaceKey: string, tabId: string) => void;
   focusTab: (workspaceKey: string, tabId: string) => void;
   retargetTab: (workspaceKey: string, tabId: string, target: WorkspaceTabTarget) => string | null;
   reorderTabs: (workspaceKey: string, tabIds: string[]) => void;
+  renameTab: (workspaceKey: string, tabId: string, label: string) => void;
   getWorkspaceTabs: (workspaceKey: string) => WorkspaceTab[];
   splitPane: (
     workspaceKey: string,
@@ -106,6 +108,7 @@ export const useWorkspaceLayoutStore = create<WorkspaceLayoutStore>()(
       layoutByWorkspace: {},
       splitSizesByWorkspace: {},
       pinnedAgentIdsByWorkspace: {},
+      tabLabelsByWorkspace: {},
       openTab: (workspaceKey, target) => {
         const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
         const normalizedTarget = normalizeWorkspaceTabTarget(target);
@@ -221,6 +224,52 @@ export const useWorkspaceLayoutStore = create<WorkspaceLayoutStore>()(
             layoutByWorkspace: {
               ...state.layoutByWorkspace,
               [normalizedWorkspaceKey]: nextLayout,
+            },
+          };
+        });
+      },
+      renameTab: (workspaceKey, tabId, label) => {
+        const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
+        const normalizedTabId = trimNonEmpty(tabId);
+        if (!normalizedWorkspaceKey || !normalizedTabId) {
+          return;
+        }
+
+        const normalizedLabel = trimNonEmpty(label);
+        set((state) => {
+          const currentWorkspaceLabels = state.tabLabelsByWorkspace[normalizedWorkspaceKey] ?? {};
+          const currentLabel = currentWorkspaceLabels[normalizedTabId] ?? null;
+          if (currentLabel === normalizedLabel) {
+            return state;
+          }
+
+          if (!normalizedLabel) {
+            if (!(normalizedTabId in currentWorkspaceLabels)) {
+              return state;
+            }
+            const nextWorkspaceLabels = { ...currentWorkspaceLabels };
+            delete nextWorkspaceLabels[normalizedTabId];
+            if (Object.keys(nextWorkspaceLabels).length === 0) {
+              const { [normalizedWorkspaceKey]: _removed, ...rest } = state.tabLabelsByWorkspace;
+              return {
+                tabLabelsByWorkspace: rest,
+              };
+            }
+            return {
+              tabLabelsByWorkspace: {
+                ...state.tabLabelsByWorkspace,
+                [normalizedWorkspaceKey]: nextWorkspaceLabels,
+              },
+            };
+          }
+
+          return {
+            tabLabelsByWorkspace: {
+              ...state.tabLabelsByWorkspace,
+              [normalizedWorkspaceKey]: {
+                ...currentWorkspaceLabels,
+                [normalizedTabId]: normalizedLabel,
+              },
             },
           };
         });
@@ -464,9 +513,27 @@ export const useWorkspaceLayoutStore = create<WorkspaceLayoutStore>()(
         for (const key in state.layoutByWorkspace) {
           layoutByWorkspace[key] = normalizeLayout(state.layoutByWorkspace[key]);
         }
+        const tabLabelsByWorkspace: Record<string, Record<string, string>> = {};
+        for (const key in state.tabLabelsByWorkspace) {
+          const labels = state.tabLabelsByWorkspace[key] ?? {};
+          const normalizedEntries = Object.entries(labels)
+            .map(([tabId, label]) => {
+              const normalizedTabId = trimNonEmpty(tabId);
+              const normalizedLabel = trimNonEmpty(label);
+              if (!normalizedTabId || !normalizedLabel) {
+                return null;
+              }
+              return [normalizedTabId, normalizedLabel] as const;
+            })
+            .filter((entry): entry is readonly [string, string] => entry !== null);
+          if (normalizedEntries.length > 0) {
+            tabLabelsByWorkspace[key] = Object.fromEntries(normalizedEntries);
+          }
+        }
         return {
           layoutByWorkspace,
           splitSizesByWorkspace: state.splitSizesByWorkspace,
+          tabLabelsByWorkspace,
         };
       },
     },


### PR DESCRIPTION
## Summary
- Add a `Rename` action for Agent and Terminal tabs in desktop and mobile tab menus.
- Persist custom tab labels per workspace in the workspace layout store.
- Resolve tab presentation labels from persisted overrides, including split-pane tab rows.
- Add unit tests for menu rename entries and tab label persistence behavior.

## Validation
- `npm run test --workspace=@getpaseo/app -- src/screens/workspace/workspace-tab-menu.test.ts src/stores/workspace-layout-store.test.ts`
- `npm run build:workspace-deps --workspace=@getpaseo/app`
- `npm run typecheck --workspace=@getpaseo/app`
