### PR TITLE
test: add missing test coverage for utility functions

### DIFF
--- a/packages/app/src/utils/agent-grouping.test.ts
+++ b/packages/app/src/utils/agent-grouping.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { deriveProjectDisplayName, deriveRemoteProjectKey, groupAgents } from "./agent-grouping";
+import {
+  deriveProjectDisplayName,
+  deriveProjectKey,
+  deriveProjectName,
+  deriveRemoteProjectKey,
+  groupAgents,
+  parseRepoNameFromRemoteUrl,
+  parseRepoShortNameFromRemoteUrl,
+} from "./agent-grouping";
 import type { AggregatedAgent } from "@/hooks/use-aggregated-agents";
 
 function makeAgent(overrides: Partial<AggregatedAgent> = {}): AggregatedAgent {
@@ -59,6 +67,100 @@ describe("deriveProjectDisplayName", () => {
         projectName: "paseo",
       }),
     ).toBe("paseo");
+  });
+});
+
+describe("deriveProjectKey", () => {
+  it("returns cwd unchanged for regular paths", () => {
+    expect(deriveProjectKey("/Users/me/projects/my-app")).toBe("/Users/me/projects/my-app");
+  });
+
+  it("extracts parent repo path from worktree paths", () => {
+    expect(deriveProjectKey("/Users/me/repo/.paseo/worktrees/feature-branch")).toBe(
+      "/Users/me/repo",
+    );
+  });
+
+  it("handles worktree path without trailing content", () => {
+    expect(deriveProjectKey("/Users/me/repo/.paseo/worktrees/")).toBe("/Users/me/repo");
+  });
+
+  it("strips trailing slash from parent repo path", () => {
+    expect(deriveProjectKey("/Users/me/repo/.paseo/worktrees/fix")).toBe("/Users/me/repo");
+  });
+
+  it("returns simple path unchanged", () => {
+    expect(deriveProjectKey("/tmp")).toBe("/tmp");
+  });
+});
+
+describe("parseRepoNameFromRemoteUrl", () => {
+  it("parses SSH URLs", () => {
+    expect(parseRepoNameFromRemoteUrl("git@github.com:owner/repo.git")).toBe("owner/repo");
+  });
+
+  it("parses SSH URLs without .git suffix", () => {
+    expect(parseRepoNameFromRemoteUrl("git@github.com:owner/repo")).toBe("owner/repo");
+  });
+
+  it("parses HTTPS URLs", () => {
+    expect(parseRepoNameFromRemoteUrl("https://github.com/owner/repo")).toBe("owner/repo");
+  });
+
+  it("parses HTTPS URLs with .git suffix", () => {
+    expect(parseRepoNameFromRemoteUrl("https://github.com/owner/repo.git")).toBe("owner/repo");
+  });
+
+  it("returns null for null input", () => {
+    expect(parseRepoNameFromRemoteUrl(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseRepoNameFromRemoteUrl("")).toBeNull();
+  });
+
+  it("returns null for URLs without a slash in path", () => {
+    expect(parseRepoNameFromRemoteUrl("git@github.com:repo")).toBeNull();
+  });
+});
+
+describe("parseRepoShortNameFromRemoteUrl", () => {
+  it("extracts repo name from SSH URL", () => {
+    expect(parseRepoShortNameFromRemoteUrl("git@github.com:owner/my-repo.git")).toBe("my-repo");
+  });
+
+  it("extracts repo name from HTTPS URL", () => {
+    expect(parseRepoShortNameFromRemoteUrl("https://github.com/owner/my-repo")).toBe("my-repo");
+  });
+
+  it("returns null for null input", () => {
+    expect(parseRepoShortNameFromRemoteUrl(null)).toBeNull();
+  });
+});
+
+describe("deriveProjectName", () => {
+  it("extracts owner/repo from GitHub remote key", () => {
+    expect(deriveProjectName("remote:github.com/owner/repo")).toBe("owner/repo");
+  });
+
+  it("extracts last segment from local path", () => {
+    expect(deriveProjectName("/Users/me/projects/my-app")).toBe("my-app");
+  });
+
+  it("returns the key itself for GitHub remote with no path", () => {
+    expect(deriveProjectName("remote:github.com/")).toBe("remote:github.com/");
+  });
+
+  it("handles nested paths", () => {
+    expect(deriveProjectName("/Users/me/projects/deep/nested/app")).toBe("app");
+  });
+
+  it("handles trailing slashes on local paths", () => {
+    expect(deriveProjectName("/Users/me/projects/app/")).toBe("app");
+  });
+
+  it("handles non-GitHub remote keys", () => {
+    expect(deriveProjectName("remote:gitlab.com/group/repo")).toBe("group/repo");
   });
 });
 

--- a/packages/app/src/utils/shorten-path.test.ts
+++ b/packages/app/src/utils/shorten-path.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { shortenPath } from "./shorten-path";
+
+describe("shortenPath", () => {
+  it("returns empty string for null", () => {
+    expect(shortenPath(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(shortenPath(undefined)).toBe("");
+  });
+
+  it("returns empty string for empty string", () => {
+    expect(shortenPath("")).toBe("");
+  });
+
+  it("shortens macOS home directory path", () => {
+    expect(shortenPath("/Users/john/Documents/project")).toBe("~/Documents/project");
+  });
+
+  it("shortens Linux home directory path", () => {
+    expect(shortenPath("/home/ubuntu/projects/my-app")).toBe("~/projects/my-app");
+  });
+
+  it("replaces only the home directory prefix with tilde", () => {
+    expect(shortenPath("/Users/john")).toBe("~");
+  });
+
+  it("replaces Linux home directory root with tilde", () => {
+    expect(shortenPath("/home/ubuntu")).toBe("~");
+  });
+
+  it("does not modify paths outside home directory", () => {
+    expect(shortenPath("/tmp/project")).toBe("/tmp/project");
+  });
+
+  it("does not modify root path", () => {
+    expect(shortenPath("/")).toBe("/");
+  });
+
+  it("does not modify relative paths", () => {
+    expect(shortenPath("relative/path")).toBe("relative/path");
+  });
+
+  it("handles path with trailing slash", () => {
+    expect(shortenPath("/Users/john/Documents/")).toBe("~/Documents/");
+  });
+
+  it("handles usernames with special characters", () => {
+    expect(shortenPath("/Users/john.doe/projects/app")).toBe("~/projects/app");
+  });
+
+  it("handles usernames with underscores", () => {
+    expect(shortenPath("/Users/john_doe/projects/app")).toBe("~/projects/app");
+  });
+
+  it("does not match partial home directory name", () => {
+    // /UsersX should not match
+    expect(shortenPath("/UsersX/john/projects")).toBe("/UsersX/john/projects");
+  });
+});

--- a/packages/app/src/utils/time.test.ts
+++ b/packages/app/src/utils/time.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { formatTimeAgo } from "./time";
+
+describe("formatTimeAgo", () => {
+  it("returns 'just now' for very recent dates", () => {
+    const result = formatTimeAgo(new Date());
+    expect(result).toBe("just now");
+  });
+
+  it("returns seconds for dates less than a minute ago", () => {
+    const date = new Date(Date.now() - 30_000); // 30 seconds ago
+    const result = formatTimeAgo(date);
+    expect(result).toBe("30s ago");
+  });
+
+  it("returns minutes for dates less than an hour ago", () => {
+    const date = new Date(Date.now() - 5 * 60_000); // 5 minutes ago
+    const result = formatTimeAgo(date);
+    expect(result).toBe("5m ago");
+  });
+
+  it("returns hours for dates less than a day ago", () => {
+    const date = new Date(Date.now() - 3 * 60 * 60_000); // 3 hours ago
+    const result = formatTimeAgo(date);
+    expect(result).toBe("3h ago");
+  });
+
+  it("returns days for dates less than a week ago", () => {
+    const date = new Date(Date.now() - 3 * 24 * 60 * 60_000); // 3 days ago
+    const result = formatTimeAgo(date);
+    expect(result).toBe("3d ago");
+  });
+
+  it("returns month and day for dates older than a week", () => {
+    const date = new Date(Date.now() - 30 * 24 * 60 * 60_000); // 30 days ago
+    const result = formatTimeAgo(date);
+    // Should be something like "Jan 15" depending on the date
+    expect(result).toMatch(/^[A-Z][a-z]{2} \d{1,2}$/);
+  });
+
+  it("handles future dates gracefully by showing 'just now'", () => {
+    // Clock drift can cause future timestamps
+    const futureDate = new Date(Date.now() + 5 * 60_000); // 5 minutes in future
+    const result = formatTimeAgo(futureDate);
+    expect(result).toBe("just now");
+  });
+
+  it("handles near-future dates (1 second ahead)", () => {
+    const futureDate = new Date(Date.now() + 1_000);
+    const result = formatTimeAgo(futureDate);
+    expect(result).toBe("just now");
+  });
+
+  it("handles exactly 10 seconds ago (boundary)", () => {
+    const date = new Date(Date.now() - 10_000); // exactly 10 seconds ago
+    const result = formatTimeAgo(date);
+    expect(result).toBe("10s ago");
+  });
+
+  it("handles exactly 1 minute ago (boundary)", () => {
+    const date = new Date(Date.now() - 60_000); // exactly 1 minute ago
+    const result = formatTimeAgo(date);
+    expect(result).toBe("1m ago");
+  });
+
+  it("handles exactly 1 hour ago (boundary)", () => {
+    const date = new Date(Date.now() - 60 * 60_000); // exactly 1 hour ago
+    const result = formatTimeAgo(date);
+    expect(result).toBe("1h ago");
+  });
+
+  it("handles exactly 1 day ago (boundary)", () => {
+    const date = new Date(Date.now() - 24 * 60 * 60_000); // exactly 1 day ago
+    const result = formatTimeAgo(date);
+    expect(result).toBe("1d ago");
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for 5 previously untested utility functions used across the UI.

### New test files
- **`utils/time.test.ts`** — Tests for `formatTimeAgo`: relative time formatting (seconds, minutes, hours, days), boundary conditions (10s, 1m, 1h, 1d), future date handling (clock drift), and older date formatting
- **`utils/shorten-path.test.ts`** — Tests for `shortenPath`: macOS/Linux home directory replacement, null/undefined/empty inputs, paths outside home, usernames with special characters, and partial match prevention

### Expanded test file
- **`utils/agent-grouping.test.ts`** — Added tests for:
  - `deriveProjectKey`: regular paths, worktree path extraction, trailing slash handling
  - `parseRepoNameFromRemoteUrl`: SSH and HTTPS URLs, .git suffix handling, null/empty inputs, paths without slashes
  - `parseRepoShortNameFromRemoteUrl`: repo name extraction from both URL formats
  - `deriveProjectName`: GitHub remote keys, local paths, trailing slashes, empty GitHub path edge case, non-GitHub remotes

## Why

These utility functions are used in 10+ components across the app (`agent-list`, `command-center`, `file-explorer-pane`, etc.) but had zero test coverage. The new tests cover normal operation, edge cases, and boundary conditions.

## Test plan

- [ ] Run `npm test --workspace=@getpaseo/app` and verify all new tests pass
- [ ] Verify existing tests remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)