### PR TITLE
fix: CLI path prefix collision, UNC path support, and label filter crash

### DIFF
--- a/packages/cli/src/classify.test.ts
+++ b/packages/cli/src/classify.test.ts
@@ -174,6 +174,8 @@ describe("path helpers", () => {
     expect(isPathLikeArg("~")).toBe(true);
     expect(isPathLikeArg("~/project")).toBe(true);
     expect(isPathLikeArg("C:\\project")).toBe(true);
+    expect(isPathLikeArg("C:/project")).toBe(true);
+    expect(isPathLikeArg("\\\\server\\share")).toBe(true);
     expect(isPathLikeArg("status")).toBe(false);
   });
 

--- a/packages/cli/src/classify.ts
+++ b/packages/cli/src/classify.ts
@@ -15,7 +15,8 @@ export function isPathLikeArg(arg: string): boolean {
     arg.startsWith("/") ||
     arg === "~" ||
     arg.startsWith("~/") ||
-    /^[A-Za-z]:[\\/]/.test(arg)
+    /^[A-Za-z]:[\\/]/.test(arg) ||
+    arg.startsWith("\\\\")
   );
 }
 

--- a/packages/cli/src/commands/agent/inspect.ts
+++ b/packages/cli/src/commands/agent/inspect.ts
@@ -80,7 +80,7 @@ function createInspectSchema(agent: AgentInspect): OutputSchema<InspectRow> {
 /** Shorten home directory in path */
 function shortenPath(path: string): string {
   const home = process.env.HOME;
-  if (home && path.startsWith(home)) {
+  if (home && (path === home || path.startsWith(home + "/") || path.startsWith(home + "\\"))) {
     return "~" + path.slice(home.length);
   }
   return path;

--- a/packages/cli/src/commands/agent/ls.ts
+++ b/packages/cli/src/commands/agent/ls.ts
@@ -46,7 +46,7 @@ function relativeTime(date: Date | string): string {
 /** Shorten home directory in path */
 function shortenPath(path: string): string {
   const home = process.env.HOME;
-  if (home && path.startsWith(home)) {
+  if (home && (path === home || path.startsWith(home + "/") || path.startsWith(home + "\\"))) {
     return "~" + path.slice(home.length);
   }
   return path;
@@ -200,7 +200,7 @@ export async function runLsCommand(
     // Apply label filtering only when explicitly requested.
     if (Object.keys(labelFilters).length > 0) {
       agents = agents.filter((a) => {
-        const agentLabels = a.labels;
+        const agentLabels = a.labels ?? {};
         for (const [key, value] of Object.entries(labelFilters)) {
           if (agentLabels[key] !== value) {
             return false;


### PR DESCRIPTION
## Summary

Fixes 3 bugs in the CLI package:

### 1. `shortenPath` path prefix collision (`agent ls`, `agent inspect`)
`path.startsWith(home)` incorrectly matched paths that merely *start with* the HOME directory string but aren't inside it. For example, when `HOME=/Users/jo`, a path `/Users/john/project` would be wrongly shortened to `~hn/project`.

**Before:** `shortenPath("/Users/john/project")` → `"~hn/project"` (when HOME=/Users/jo)
**After:** `shortenPath("/Users/john/project")` → `"/Users/john/project"` (correctly unchanged)

Fix: Require a path separator (`/` or `\`) after HOME before shortening.

### 2. `isPathLikeArg` missing UNC path support (`classify.ts`)
Windows UNC paths (`\\server\share`) were not recognized as path-like arguments, causing them to be treated as CLI commands instead of project paths.

**Before:** `isPathLikeArg("\\\\server\\share")` → `false`
**After:** `isPathLikeArg("\\\\server\\share")` → `true`

### 3. `--label` filter crash when agent has no labels (`agent ls`)
When filtering agents by label, agents with `undefined` labels would cause a TypeError crash: `Cannot read properties of undefined (reading 'key')`.

**Before:** `agents.filter(a => { const agentLabels = a.labels; ... })` — crashes if `a.labels` is undefined
**After:** `const agentLabels = a.labels ?? {};` — safely handles missing labels

## Test plan

- [ ] Run `npm test --workspace=@getpaseo/cli` — existing classify test updated with UNC path and forward-slash Windows cases
- [ ] Verify `paseo agent ls --label key=value` doesn't crash when some agents lack labels
- [ ] Verify path shortening is correct when HOME is a prefix of another user's home directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)