### PR TITLE
fix: enable reconnect for daemon client

### DIFF
--- a/packages/app/src/utils/test-daemon-connection.ts
+++ b/packages/app/src/utils/test-daemon-connection.ts
@@ -56,7 +56,7 @@ export async function buildClientConfig(
     clientType: "mobile" as const,
     appVersion: resolveAppVersion() ?? undefined,
     suppressSendErrors: true,
-    reconnect: { enabled: false },
+    reconnect: { enabled: true },
     ...(connection.type === "directSocket" || connection.type === "directPipe"
       ? localTransportFactory
         ? { transportFactory: localTransportFactory }


### PR DESCRIPTION
Enables reconnection for the daemon client to handle connection drops gracefully.