### PR TITLE
Fix agent module loading issue in CI

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -69,6 +69,7 @@
     "@isaacs/ttlcache": "^2.1.4",
     "@modelcontextprotocol/sdk": "^1.20.1",
     "@mariozechner/pi-coding-agent": "^0.65.2",
+    "@sinclair/typebox": "^0.34.0",
     "@opencode-ai/sdk": "1.2.6",
     "@sctg/sentencepiece-js": "^1.1.0",
     "@xterm/headless": "^6.0.0",


### PR DESCRIPTION
This change resolves a crash occurring when tests load the agent module. The issue was caused by the missing `@sinclair/typebox` dependency in the dependency graph.

**Changes:**
* Added `@sinclair/typebox` to `packages/server/package.json`.
* Verified that the `pi-direct-agent.ts` code remains unchanged.
* Confirmed that all packages compile correctly and the CI test runner crash is resolved.