### PR TITLE
feat: add MiniMax TTS provider support

### DIFF
--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -1,12 +1,12 @@
-import express from "express";
-import { createServer as createHTTPServer } from "http";
-import { createReadStream, unlinkSync, existsSync } from "fs";
-import { stat } from "fs/promises";
 import { randomUUID } from "node:crypto";
 import { hostname as getHostname } from "node:os";
 import path from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import express from "express";
+import { createReadStream, existsSync, unlinkSync } from "fs";
+import { stat } from "fs/promises";
+import { createServer as createHTTPServer } from "http";
 import type { Logger } from "pino";
 
 export type ListenTarget =
@@ -85,37 +85,38 @@ function formatListenTarget(listenTarget: ListenTarget | null): string | null {
   return listenTarget.path;
 }
 
-import { VoiceAssistantWebSocketServer } from "./websocket-server.js";
-import { DownloadTokenStore } from "./file-download/token-store.js";
-import type { OpenAiSpeechProviderConfig } from "./speech/providers/openai/config.js";
-import type { LocalSpeechProviderConfig } from "./speech/providers/local/config.js";
-import type { RequestedSpeechProviders } from "./speech/speech-types.js";
-import { createSpeechService } from "./speech/speech-runtime.js";
+import { createTerminalManager, type TerminalManager } from "../terminal/terminal-manager.js";
 import { AgentManager } from "./agent/agent-manager.js";
+import type { AgentClient, AgentProvider } from "./agent/agent-sdk-types.js";
 import { AgentStorage } from "./agent/agent-storage.js";
-import { attachAgentStoragePersistence } from "./persistence-hooks.js";
 import { createAgentMcpServer } from "./agent/mcp-server.js";
+import type { AgentProviderRuntimeSettingsMap } from "./agent/provider-launch-config.js";
 import {
   buildProviderRegistry,
   createAllClients,
   shutdownProviders,
 } from "./agent/provider-registry.js";
-import { bootstrapWorkspaceRegistries } from "./workspace-registry-bootstrap.js";
-import { FileBackedProjectRegistry, FileBackedWorkspaceRegistry } from "./workspace-registry.js";
+import { type AllowedHostsConfig, isHostAllowed } from "./allowed-hosts.js";
 import { FileBackedChatService } from "./chat/chat-service.js";
 import { CheckoutDiffManager } from "./checkout-diff-manager.js";
-import { LoopService } from "./loop-service.js";
-import { ScheduleService } from "./schedule/service.js";
-import { DaemonConfigStore } from "./daemon-config-store.js";
-import { createTerminalManager, type TerminalManager } from "../terminal/terminal-manager.js";
 import { createConnectionOfferV2, encodeOfferToFragmentUrl } from "./connection-offer.js";
+import { DaemonConfigStore } from "./daemon-config-store.js";
 import { loadOrCreateDaemonKeyPair } from "./daemon-keypair.js";
-import { startRelayTransport, type RelayTransportController } from "./relay-transport.js";
-import { getOrCreateServerId } from "./server-id.js";
 import { resolveDaemonVersion } from "./daemon-version.js";
-import type { AgentClient, AgentProvider } from "./agent/agent-sdk-types.js";
-import type { AgentProviderRuntimeSettingsMap } from "./agent/provider-launch-config.js";
-import { isHostAllowed, type AllowedHostsConfig } from "./allowed-hosts.js";
+import { DownloadTokenStore } from "./file-download/token-store.js";
+import { LoopService } from "./loop-service.js";
+import { attachAgentStoragePersistence } from "./persistence-hooks.js";
+import { type RelayTransportController, startRelayTransport } from "./relay-transport.js";
+import { ScheduleService } from "./schedule/service.js";
+import { getOrCreateServerId } from "./server-id.js";
+import type { LocalSpeechProviderConfig } from "./speech/providers/local/config.js";
+import type { MiniMaxSpeechProviderConfig } from "./speech/providers/minimax/config.js";
+import type { OpenAiSpeechProviderConfig } from "./speech/providers/openai/config.js";
+import { createSpeechService } from "./speech/speech-runtime.js";
+import type { RequestedSpeechProviders } from "./speech/speech-types.js";
+import { VoiceAssistantWebSocketServer } from "./websocket-server.js";
+import { FileBackedProjectRegistry, FileBackedWorkspaceRegistry } from "./workspace-registry.js";
+import { bootstrapWorkspaceRegistries } from "./workspace-registry-bootstrap.js";
 
 type AgentMcpTransportMap = Map<string, StreamableHTTPServerTransport>;
 
@@ -135,6 +136,7 @@ function createAgentMcpBaseUrl(listenTarget: ListenTarget | null): string | null
 
 export type PaseoOpenAIConfig = OpenAiSpeechProviderConfig;
 export type PaseoLocalSpeechConfig = LocalSpeechProviderConfig;
+export type PaseoMiniMaxConfig = MiniMaxSpeechProviderConfig;
 
 export type PaseoSpeechConfig = {
   providers: RequestedSpeechProviders;
@@ -170,6 +172,7 @@ export type PaseoDaemonConfig = {
   relayPublicEndpoint?: string;
   appBaseUrl?: string;
   openai?: PaseoOpenAIConfig;
+  minimax?: PaseoMiniMaxConfig;
   speech?: PaseoSpeechConfig;
   voiceLlmProvider?: AgentProvider | null;
   voiceLlmProviderExplicit?: boolean;
@@ -537,6 +540,7 @@ export async function createPaseoDaemon(
     const speechService = createSpeechService({
       logger,
       openaiConfig: config.openai,
+      minimaxConfig: config.minimax,
       speechConfig: config.speech,
     });
     logger.info({ elapsed: elapsed() }, "Speech service created");

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -1,16 +1,15 @@
 import path from "node:path";
 import { z } from "zod";
-
-import type { PaseoDaemonConfig } from "./bootstrap.js";
-import { loadPersistedConfig } from "./persisted-config.js";
 import type { AgentProvider } from "./agent/agent-sdk-types.js";
 import { AgentProviderSchema } from "./agent/provider-manifest.js";
-import { resolveSpeechConfig } from "./speech/speech-config-resolver.js";
 import {
+  type AllowedHostsConfig,
   mergeAllowedHosts,
   parseAllowedHostsEnv,
-  type AllowedHostsConfig,
 } from "./allowed-hosts.js";
+import type { PaseoDaemonConfig } from "./bootstrap.js";
+import { loadPersistedConfig } from "./persisted-config.js";
+import { resolveSpeechConfig } from "./speech/speech-config-resolver.js";
 
 const DEFAULT_PORT = 6767;
 const DEFAULT_RELAY_ENDPOINT = "relay.paseo.sh:443";
@@ -103,7 +102,7 @@ export function loadConfig(
 
   const appBaseUrl = env.PASEO_APP_BASE_URL ?? persisted.app?.baseUrl ?? DEFAULT_APP_BASE_URL;
 
-  const { openai, speech } = resolveSpeechConfig({
+  const { openai, minimax, speech } = resolveSpeechConfig({
     paseoHome,
     env,
     persisted,
@@ -136,6 +135,7 @@ export function loadConfig(
     relayPublicEndpoint,
     appBaseUrl,
     openai,
+    minimax,
     speech,
     voiceLlmProvider,
     voiceLlmProviderExplicit,

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -54,6 +54,7 @@ const ProvidersSchema = z
   .object({
     openai: ProviderCredentialsSchema.optional(),
     local: LocalSpeechProviderSchema.optional(),
+    minimax: ProviderCredentialsSchema.optional(),
   })
   .strict();
 
@@ -61,7 +62,7 @@ const SpeechProviderIdSchema = z
   .string()
   .trim()
   .toLowerCase()
-  .pipe(z.enum(["openai", "local"]));
+  .pipe(z.enum(["openai", "local", "minimax"]));
 
 const FeatureDictationSchema = z
   .object({
@@ -104,7 +105,12 @@ const FeatureVoiceModeSchema = z
       .object({
         provider: SpeechProviderIdSchema.optional(),
         model: z.string().min(1).optional(),
-        voice: z.enum(["alloy", "echo", "fable", "onyx", "nova", "shimmer"]).optional(),
+        voice: z
+          .union([
+            z.enum(["alloy", "echo", "fable", "onyx", "nova", "shimmer"]),
+            z.string().trim().min(1),
+          ])
+          .optional(),
         speakerId: z.number().int().optional(),
         speed: z.number().optional(),
       })

--- a/packages/server/src/server/speech/providers/minimax/config.ts
+++ b/packages/server/src/server/speech/providers/minimax/config.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+import type { MiniMaxTTSConfig, MiniMaxTTSVoice } from "./tts.js";
+
+export const DEFAULT_MINIMAX_TTS_MODEL = "speech-2.8-hd";
+export const DEFAULT_MINIMAX_TTS_VOICE: MiniMaxTTSVoice = "English_Graceful_Lady";
+
+export type MiniMaxSpeechProviderConfig = {
+  apiKey: string;
+  tts?: Partial<MiniMaxTTSConfig>;
+};
+
+const MiniMaxTtsVoiceSchema = z.enum([
+  "English_Graceful_Lady",
+  "English_Insightful_Speaker",
+  "English_radiant_girl",
+  "English_Persuasive_Man",
+  "English_Lucky_Robot",
+  "English_expressive_narrator",
+]);
+
+const MiniMaxTtsModelSchema = z.enum(["speech-2.8-hd", "speech-2.8-turbo"]);
+
+const OptionalTrimmedStringSchema = z
+  .string()
+  .trim()
+  .optional()
+  .transform((value) => (value && value.length > 0 ? value : undefined));
+
+const MiniMaxSpeechResolutionSchema = z.object({
+  apiKey: OptionalTrimmedStringSchema,
+  ttsVoice: z.string().trim().pipe(MiniMaxTtsVoiceSchema).default(DEFAULT_MINIMAX_TTS_VOICE),
+  ttsModel: z.string().trim().pipe(MiniMaxTtsModelSchema).default(DEFAULT_MINIMAX_TTS_MODEL),
+  ttsBaseUrl: OptionalTrimmedStringSchema,
+});
+
+export function resolveMiniMaxSpeechConfig(params: {
+  env: NodeJS.ProcessEnv;
+}): MiniMaxSpeechProviderConfig | undefined {
+  const parsed = MiniMaxSpeechResolutionSchema.parse({
+    apiKey: params.env.MINIMAX_API_KEY,
+    ttsVoice: params.env.MINIMAX_TTS_VOICE ?? DEFAULT_MINIMAX_TTS_VOICE,
+    ttsModel: params.env.MINIMAX_TTS_MODEL ?? DEFAULT_MINIMAX_TTS_MODEL,
+    ttsBaseUrl: params.env.MINIMAX_BASE_URL,
+  });
+
+  if (!parsed.apiKey) {
+    return undefined;
+  }
+
+  return {
+    apiKey: parsed.apiKey,
+    tts: {
+      apiKey: parsed.apiKey,
+      model: parsed.ttsModel,
+      voice: parsed.ttsVoice,
+      ...(parsed.ttsBaseUrl ? { baseUrl: parsed.ttsBaseUrl } : {}),
+    },
+  };
+}

--- a/packages/server/src/server/speech/providers/minimax/minimax-tts.test.ts
+++ b/packages/server/src/server/speech/providers/minimax/minimax-tts.test.ts
@@ -1,0 +1,259 @@
+import { Readable } from "node:stream";
+import pino from "pino";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveMiniMaxSpeechConfig } from "./config.js";
+import { MiniMaxTTS } from "./tts.js";
+
+const silentLogger = pino({ level: "silent" });
+
+describe("MiniMaxTTS", () => {
+  it("creates instance with valid config", () => {
+    const tts = new MiniMaxTTS({ apiKey: "test-key" }, silentLogger);
+    expect(tts).toBeDefined();
+  });
+
+  it("uses default model and voice", () => {
+    const tts = new MiniMaxTTS({ apiKey: "test-key" }, silentLogger);
+    const config = tts.getConfig();
+    expect(config.model).toBe("speech-2.8-hd");
+    expect(config.voice).toBe("English_Graceful_Lady");
+  });
+
+  it("uses default base URL", () => {
+    const tts = new MiniMaxTTS({ apiKey: "test-key" }, silentLogger);
+    const config = tts.getConfig();
+    expect(config.baseUrl).toBe("https://api.minimax.io");
+  });
+
+  it("accepts custom model and voice", () => {
+    const tts = new MiniMaxTTS(
+      { apiKey: "test-key", model: "speech-2.8-turbo", voice: "English_Persuasive_Man" },
+      silentLogger,
+    );
+    const config = tts.getConfig();
+    expect(config.model).toBe("speech-2.8-turbo");
+    expect(config.voice).toBe("English_Persuasive_Man");
+  });
+
+  it("accepts custom base URL", () => {
+    const tts = new MiniMaxTTS(
+      { apiKey: "test-key", baseUrl: "https://custom.example.com" },
+      silentLogger,
+    );
+    const config = tts.getConfig();
+    expect(config.baseUrl).toBe("https://custom.example.com");
+  });
+
+  it("throws on empty text", async () => {
+    const tts = new MiniMaxTTS({ apiKey: "test-key" }, silentLogger);
+    await expect(tts.synthesizeSpeech("")).rejects.toThrow("Cannot synthesize empty text");
+    await expect(tts.synthesizeSpeech("   ")).rejects.toThrow("Cannot synthesize empty text");
+  });
+
+  it("synthesizes speech and returns mp3 stream", async () => {
+    const hexAudio = Buffer.from("fake-audio-data").toString("hex");
+    const sseResponse = [
+      `data: ${JSON.stringify({ data: { audio: hexAudio, status: 1 }, base_resp: { status_code: 0 } })}\n\n`,
+      `data: ${JSON.stringify({ data: { audio: "", status: 2 }, base_resp: { status_code: 0 } })}\n\n`,
+    ].join("");
+
+    const mockBody = {
+      getReader: () => {
+        const encoder = new TextEncoder();
+        const data = encoder.encode(sseResponse);
+        let done = false;
+        return {
+          read: async () => {
+            if (done) return { done: true, value: undefined };
+            done = true;
+            return { done: false, value: data };
+          },
+          releaseLock: () => {},
+        };
+      },
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      body: mockBody,
+    });
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    try {
+      const tts = new MiniMaxTTS({ apiKey: "test-key" }, silentLogger);
+      const result = await tts.synthesizeSpeech("Hello, world!");
+
+      expect(result.format).toBe("mp3");
+      expect(result.stream).toBeInstanceOf(Readable);
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of result.stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      const audioBuffer = Buffer.concat(chunks);
+      expect(audioBuffer.equals(Buffer.from("fake-audio-data"))).toBe(true);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.minimax.io/v1/t2a_v2",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-key",
+            "Content-Type": "application/json",
+          }),
+        }),
+      );
+
+      const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      expect(requestBody.model).toBe("speech-2.8-hd");
+      expect(requestBody.stream).toBe(true);
+      expect(requestBody.voice_setting.voice_id).toBe("English_Graceful_Lady");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("throws when API returns error status", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => "Unauthorized",
+    });
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    try {
+      const tts = new MiniMaxTTS({ apiKey: "bad-key" }, silentLogger);
+      await expect(tts.synthesizeSpeech("Hello")).rejects.toThrow("MiniMax TTS synthesis failed");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("throws when API returns error in SSE body", async () => {
+    const sseResponse = `data: ${JSON.stringify({ base_resp: { status_code: 2013, status_msg: "invalid voice_id" } })}\n\n`;
+
+    const mockBody = {
+      getReader: () => {
+        const encoder = new TextEncoder();
+        const data = encoder.encode(sseResponse);
+        let done = false;
+        return {
+          read: async () => {
+            if (done) return { done: true, value: undefined };
+            done = true;
+            return { done: false, value: data };
+          },
+          releaseLock: () => {},
+        };
+      },
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      body: mockBody,
+    });
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    try {
+      const tts = new MiniMaxTTS({ apiKey: "test-key" }, silentLogger);
+      await expect(tts.synthesizeSpeech("Hello")).rejects.toThrow("MiniMax TTS synthesis failed");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("removes trailing slash from base URL", async () => {
+    const hexAudio = Buffer.from("audio").toString("hex");
+    const sseResponse = `data: ${JSON.stringify({ data: { audio: hexAudio, status: 2 }, base_resp: { status_code: 0 } })}\n\n`;
+
+    const mockBody = {
+      getReader: () => {
+        const encoder = new TextEncoder();
+        const data = encoder.encode(sseResponse);
+        let done = false;
+        return {
+          read: async () => {
+            if (done) return { done: true, value: undefined };
+            done = true;
+            return { done: false, value: data };
+          },
+          releaseLock: () => {},
+        };
+      },
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, body: mockBody });
+    vi.stubGlobal("fetch", mockFetch);
+
+    try {
+      const tts = new MiniMaxTTS(
+        { apiKey: "test-key", baseUrl: "https://api.minimax.io/" },
+        silentLogger,
+      );
+      await tts.synthesizeSpeech("Hello");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.minimax.io/v1/t2a_v2",
+        expect.any(Object),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("resolveMiniMaxSpeechConfig", () => {
+  it("returns undefined when MINIMAX_API_KEY is not set", () => {
+    const result = resolveMiniMaxSpeechConfig({ env: {} as NodeJS.ProcessEnv });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when MINIMAX_API_KEY is empty", () => {
+    const result = resolveMiniMaxSpeechConfig({
+      env: { MINIMAX_API_KEY: "" } as NodeJS.ProcessEnv,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("resolves config with API key", () => {
+    const result = resolveMiniMaxSpeechConfig({
+      env: { MINIMAX_API_KEY: "test-key" } as NodeJS.ProcessEnv,
+    });
+    expect(result).toBeDefined();
+    expect(result?.apiKey).toBe("test-key");
+    expect(result?.tts?.model).toBe("speech-2.8-hd");
+    expect(result?.tts?.voice).toBe("English_Graceful_Lady");
+  });
+
+  it("applies custom model from env", () => {
+    const result = resolveMiniMaxSpeechConfig({
+      env: {
+        MINIMAX_API_KEY: "test-key",
+        MINIMAX_TTS_MODEL: "speech-2.8-turbo",
+      } as NodeJS.ProcessEnv,
+    });
+    expect(result?.tts?.model).toBe("speech-2.8-turbo");
+  });
+
+  it("applies custom voice from env", () => {
+    const result = resolveMiniMaxSpeechConfig({
+      env: {
+        MINIMAX_API_KEY: "test-key",
+        MINIMAX_TTS_VOICE: "English_Persuasive_Man",
+      } as NodeJS.ProcessEnv,
+    });
+    expect(result?.tts?.voice).toBe("English_Persuasive_Man");
+  });
+
+  it("applies custom base URL from env", () => {
+    const result = resolveMiniMaxSpeechConfig({
+      env: {
+        MINIMAX_API_KEY: "test-key",
+        MINIMAX_BASE_URL: "https://custom.api.com",
+      } as NodeJS.ProcessEnv,
+    });
+    expect(result?.tts?.baseUrl).toBe("https://custom.api.com");
+  });
+});

--- a/packages/server/src/server/speech/providers/minimax/runtime.ts
+++ b/packages/server/src/server/speech/providers/minimax/runtime.ts
@@ -1,0 +1,47 @@
+import type { Logger } from "pino";
+
+import type { TextToSpeechProvider } from "../../speech-provider.js";
+import type { RequestedSpeechProviders } from "../../speech-types.js";
+import type { MiniMaxSpeechProviderConfig } from "./config.js";
+import { DEFAULT_MINIMAX_TTS_MODEL, DEFAULT_MINIMAX_TTS_VOICE } from "./config.js";
+import { MiniMaxTTS } from "./tts.js";
+
+export type MiniMaxSpeechServices = {
+  ttsService: TextToSpeechProvider | null;
+};
+
+export function initializeMiniMaxSpeechServices(params: {
+  providers: RequestedSpeechProviders;
+  minimaxConfig: MiniMaxSpeechProviderConfig | undefined;
+  existing: { ttsService: TextToSpeechProvider | null };
+  logger: Logger;
+}): MiniMaxSpeechServices {
+  const { providers, minimaxConfig, existing, logger } = params;
+
+  let ttsService = existing.ttsService;
+
+  const needsMiniMaxTts =
+    !ttsService &&
+    providers.voiceTts.enabled !== false &&
+    providers.voiceTts.provider === "minimax";
+
+  if (needsMiniMaxTts) {
+    if (!minimaxConfig?.apiKey) {
+      logger.warn("MiniMax TTS provider is configured but MINIMAX_API_KEY is missing");
+    } else {
+      const { apiKey: _ttsApiKey, ...ttsConfig } = minimaxConfig.tts ?? {};
+      ttsService = new MiniMaxTTS(
+        {
+          apiKey: minimaxConfig.apiKey,
+          model: DEFAULT_MINIMAX_TTS_MODEL,
+          voice: DEFAULT_MINIMAX_TTS_VOICE,
+          ...ttsConfig,
+        },
+        logger,
+      );
+      logger.info("MiniMax TTS provider initialized");
+    }
+  }
+
+  return { ttsService };
+}

--- a/packages/server/src/server/speech/providers/minimax/tts.ts
+++ b/packages/server/src/server/speech/providers/minimax/tts.ts
@@ -1,0 +1,172 @@
+import { Readable } from "node:stream";
+import type pino from "pino";
+import type { SpeechStreamResult, TextToSpeechProvider } from "../../speech-provider.js";
+
+export type { SpeechStreamResult };
+
+export type MiniMaxTTSVoice =
+  | "English_Graceful_Lady"
+  | "English_Insightful_Speaker"
+  | "English_radiant_girl"
+  | "English_Persuasive_Man"
+  | "English_Lucky_Robot"
+  | "English_expressive_narrator";
+
+export interface MiniMaxTTSConfig {
+  apiKey: string;
+  model?: "speech-2.8-hd" | "speech-2.8-turbo";
+  voice?: MiniMaxTTSVoice;
+  baseUrl?: string;
+}
+
+const DEFAULT_MINIMAX_TTS_MODEL = "speech-2.8-hd";
+const DEFAULT_MINIMAX_TTS_VOICE: MiniMaxTTSVoice = "English_Graceful_Lady";
+const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io";
+
+export class MiniMaxTTS implements TextToSpeechProvider {
+  private readonly config: Required<MiniMaxTTSConfig>;
+  private readonly logger: pino.Logger;
+
+  constructor(ttsConfig: MiniMaxTTSConfig, parentLogger: pino.Logger) {
+    this.config = {
+      model: DEFAULT_MINIMAX_TTS_MODEL,
+      voice: DEFAULT_MINIMAX_TTS_VOICE,
+      baseUrl: DEFAULT_MINIMAX_BASE_URL,
+      ...ttsConfig,
+    };
+    this.logger = parentLogger.child({ module: "agent", provider: "minimax", component: "tts" });
+
+    this.logger.info(
+      { voice: this.config.voice, model: this.config.model },
+      "TTS (MiniMax) initialized",
+    );
+  }
+
+  public getConfig(): Required<MiniMaxTTSConfig> {
+    return this.config;
+  }
+
+  public async synthesizeSpeech(text: string): Promise<SpeechStreamResult> {
+    if (!text || text.trim().length === 0) {
+      throw new Error("Cannot synthesize empty text");
+    }
+
+    const startTime = Date.now();
+
+    try {
+      this.logger.debug(
+        { textLength: text.length, preview: text.substring(0, 50) },
+        "Synthesizing speech via MiniMax",
+      );
+
+      const baseUrl = this.config.baseUrl.replace(/\/$/, "");
+      const response = await fetch(`${baseUrl}/v1/t2a_v2`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.config.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: this.config.model,
+          text,
+          stream: true,
+          voice_setting: {
+            voice_id: this.config.voice,
+            speed: 1,
+            vol: 1,
+            pitch: 0,
+          },
+          audio_setting: {
+            sample_rate: 32000,
+            bitrate: 128000,
+            format: "mp3",
+            channel: 1,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        throw new Error(`MiniMax TTS API error ${response.status}: ${errorText}`);
+      }
+
+      if (!response.body) {
+        throw new Error("MiniMax TTS API returned no response body");
+      }
+
+      const audioChunks = await this.collectSseAudioChunks(response);
+      const duration = Date.now() - startTime;
+
+      if (audioChunks.length === 0) {
+        throw new Error("MiniMax TTS returned no audio data");
+      }
+
+      const audioBuffer = Buffer.concat(audioChunks);
+      this.logger.debug(
+        { duration, byteLength: audioBuffer.length },
+        "MiniMax TTS synthesis complete",
+      );
+
+      return {
+        stream: Readable.from([audioBuffer]),
+        format: "mp3",
+      };
+    } catch (error: any) {
+      this.logger.error({ err: error }, "MiniMax TTS synthesis error");
+      throw new Error(`MiniMax TTS synthesis failed: ${error.message}`);
+    }
+  }
+
+  private async collectSseAudioChunks(response: Response): Promise<Buffer[]> {
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    const audioChunks: Buffer[] = [];
+    let buffer = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data:")) continue;
+          const jsonStr = line.slice(5).trim();
+          if (!jsonStr || jsonStr === "[DONE]") continue;
+
+          try {
+            const eventData = JSON.parse(jsonStr) as {
+              data?: { audio?: string; status?: number };
+              base_resp?: { status_code?: number; status_msg?: string };
+            };
+
+            if (
+              eventData.base_resp?.status_code !== undefined &&
+              eventData.base_resp.status_code !== 0
+            ) {
+              throw new Error(
+                `MiniMax TTS API error: ${eventData.base_resp.status_msg ?? "unknown error"}`,
+              );
+            }
+
+            if (eventData.data?.audio) {
+              audioChunks.push(Buffer.from(eventData.data.audio, "hex"));
+            }
+          } catch (parseError: any) {
+            if (parseError.message?.startsWith("MiniMax TTS")) {
+              throw parseError;
+            }
+            // Skip malformed SSE events
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return audioChunks;
+  }
+}

--- a/packages/server/src/server/speech/speech-config-resolver.ts
+++ b/packages/server/src/server/speech/speech-config-resolver.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
-
+import type { PaseoMiniMaxConfig, PaseoOpenAIConfig, PaseoSpeechConfig } from "../bootstrap.js";
 import type { PersistedConfig } from "../persisted-config.js";
-import type { PaseoOpenAIConfig, PaseoSpeechConfig } from "../bootstrap.js";
 import { resolveLocalSpeechConfig } from "./providers/local/config.js";
+import { resolveMiniMaxSpeechConfig } from "./providers/minimax/config.js";
 import { resolveOpenAiSpeechConfig } from "./providers/openai/config.js";
 import {
-  SpeechProviderIdSchema,
   type RequestedSpeechProvider,
   type RequestedSpeechProviders,
+  SpeechProviderIdSchema,
 } from "./speech-types.js";
 
 const OptionalSpeechProviderSchema = z
@@ -134,6 +134,7 @@ export function resolveSpeechConfig(params: {
   persisted: PersistedConfig;
 }): {
   openai: PaseoOpenAIConfig | undefined;
+  minimax: PaseoMiniMaxConfig | undefined;
   speech: PaseoSpeechConfig;
 } {
   const providers = resolveRequestedSpeechProviders({
@@ -154,8 +155,13 @@ export function resolveSpeechConfig(params: {
     providers,
   });
 
+  const minimax = resolveMiniMaxSpeechConfig({
+    env: params.env,
+  });
+
   return {
     openai,
+    minimax,
     speech: {
       providers,
       ...(local.local ? { local: local.local } : {}),

--- a/packages/server/src/server/speech/speech-runtime.ts
+++ b/packages/server/src/server/speech/speech-runtime.ts
@@ -2,7 +2,7 @@ import { stat } from "node:fs/promises";
 import { join } from "node:path";
 import type { Logger } from "pino";
 
-import type { PaseoOpenAIConfig, PaseoSpeechConfig } from "../bootstrap.js";
+import type { PaseoMiniMaxConfig, PaseoOpenAIConfig, PaseoSpeechConfig } from "../bootstrap.js";
 import type { LocalSpeechModelId } from "./providers/local/config.js";
 import {
   ensureLocalSpeechModels,
@@ -10,6 +10,7 @@ import {
   listLocalSpeechModels,
 } from "./providers/local/models.js";
 import { initializeLocalSpeechServices } from "./providers/local/runtime.js";
+import { initializeMiniMaxSpeechServices } from "./providers/minimax/runtime.js";
 import {
   getOpenAiSpeechAvailability,
   initializeOpenAiSpeechServices,
@@ -318,6 +319,7 @@ function resolveEffectiveProviderIds(params: {
   ttsService: TextToSpeechProvider | null;
   dictationSttService: SpeechToTextProvider | null;
   localVoiceTtsProvider: TextToSpeechProvider | null;
+  minimaxVoiceTtsProvider: TextToSpeechProvider | null;
 }): {
   dictationStt: string;
   voiceTurnDetection: string;
@@ -332,7 +334,9 @@ function resolveEffectiveProviderIds(params: {
       ? "unavailable"
       : params.ttsService === params.localVoiceTtsProvider
         ? "local"
-        : "openai",
+        : params.ttsService === params.minimaxVoiceTtsProvider
+          ? "minimax"
+          : "openai",
   };
 }
 
@@ -351,11 +355,13 @@ export type SpeechService = {
 export function createSpeechService(params: {
   logger: Logger;
   openaiConfig?: PaseoOpenAIConfig;
+  minimaxConfig?: PaseoMiniMaxConfig;
   speechConfig?: PaseoSpeechConfig;
 }): SpeechService {
   const logger = params.logger.child({ module: "speech-runtime" });
   const speechConfig = params.speechConfig ?? null;
   const openaiConfig = params.openaiConfig;
+  const minimaxConfig = params.minimaxConfig;
   const providers = resolveRequestedSpeechProviders(speechConfig);
   const requestedProviders = describeRequestedProviders(providers);
 
@@ -385,6 +391,7 @@ export function createSpeechService(params: {
   } | null = null;
   let localCleanup = () => {};
   let localVoiceTtsProvider: TextToSpeechProvider | null = null;
+  let minimaxVoiceTtsProvider: TextToSpeechProvider | null = null;
 
   let missingLocalModelIds: LocalSpeechModelId[] = [];
   let backgroundDownloadInProgress = false;
@@ -508,14 +515,21 @@ export function createSpeechService(params: {
       },
       logger,
     });
+    const nextMiniMaxSpeech = initializeMiniMaxSpeechServices({
+      providers,
+      minimaxConfig,
+      existing: { ttsService: nextOpenAiSpeech.ttsService },
+      logger,
+    });
 
     const previousLocalCleanup = localCleanup;
     turnDetectionService = nextOpenAiSpeech.turnDetectionService;
     sttService = nextOpenAiSpeech.sttService;
-    ttsService = nextOpenAiSpeech.ttsService;
+    ttsService = nextMiniMaxSpeech.ttsService;
     dictationSttService = nextOpenAiSpeech.dictationSttService;
     localModelConfig = nextLocalSpeech.localModelConfig;
     localVoiceTtsProvider = nextLocalSpeech.localVoiceTtsProvider;
+    minimaxVoiceTtsProvider = nextMiniMaxSpeech.ttsService;
     localCleanup = nextLocalSpeech.cleanup;
     previousLocalCleanup();
 
@@ -527,6 +541,7 @@ export function createSpeechService(params: {
       ttsService,
       dictationSttService,
       localVoiceTtsProvider,
+      minimaxVoiceTtsProvider,
     });
     const unavailableFeatures = [
       providers.dictationStt.enabled !== false && !dictationSttService ? "dictation.stt" : null,

--- a/packages/server/src/server/speech/speech-types.ts
+++ b/packages/server/src/server/speech/speech-types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const SpeechProviderIdSchema = z.enum(["openai", "local"]);
+export const SpeechProviderIdSchema = z.enum(["openai", "local", "minimax"]);
 export type SpeechProviderId = z.infer<typeof SpeechProviderIdSchema>;
 
 export const RequestedSpeechProviderSchema = z.object({


### PR DESCRIPTION
## Summary

- Add MiniMax as a new TTS (text-to-speech) provider for Paseo voice mode
- Implement MiniMaxTTS class using MiniMax T2A v2 SSE streaming API to synthesize MP3 audio
- Register minimax as a valid SpeechProviderId alongside openai and local
- Add MINIMAX_API_KEY environment variable support (also supports MINIMAX_BASE_URL, MINIMAX_TTS_MODEL, MINIMAX_TTS_VOICE)

## Usage

Set PASEO_VOICE_TTS_PROVIDER=minimax and MINIMAX_API_KEY to enable MiniMax TTS.

Available models: speech-2.8-hd (default), speech-2.8-turbo
Available voices: English_Graceful_Lady (default), English_Insightful_Speaker, English_radiant_girl, English_Persuasive_Man, English_Lucky_Robot, English_expressive_narrator

## Test plan

- [x] Unit tests: 16 tests covering instantiation, config resolution, SSE audio parsing, error handling
- [x] Integration test: successfully received 71 KB of MP3 audio from MiniMax T2A v2 API
- [x] Existing speech config resolver tests pass (6 tests)
- [x] Existing persisted config schema tests pass (7 tests)
- [x] TypeScript typecheck passes

## API reference

- TTS: https://platform.minimax.io/docs/api-reference/speech-t2a-http