### PR TITLE
feat(server): support defaultModel override in provider runtime settings

### DIFF
--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -34,6 +34,7 @@ export const ProviderRuntimeSettingsSchema = z
   .object({
     command: ProviderCommandSchema.optional(),
     env: z.record(z.string()).optional(),
+    defaultModel: z.string().optional(),
   })
   .strict();
 

--- a/packages/server/src/server/agent/providers/claude-agent.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.ts
@@ -2141,7 +2141,7 @@ class ClaudeAgentSession implements AgentSession {
     }
 
     if (this.config.model) {
-      base.model = this.config.model;
+      base.model = this.runtimeSettings?.defaultModel ?? this.config.model;
     }
     this.lastOptionsModel = base.model ?? null;
     if (this.claudeSessionId) {

--- a/packages/website/public/schemas/paseo.config.v1.json
+++ b/packages/website/public/schemas/paseo.config.v1.json
@@ -166,6 +166,9 @@
                     "additionalProperties": {
                       "type": "string"
                     }
+                  },
+                  "defaultModel": {
+                    "type": "string"
                   }
                 },
                 "additionalProperties": false


### PR DESCRIPTION
## Summary

- Add support for `defaultModel` override in provider runtime settings for Bedrock providers
- Allows users to specify a default model when launching Claude agents through Bedrock

## Changes

- Modified provider launch config to include `defaultModel` in runtime settings
- Updated Claude agent provider to use `defaultModel` from runtime settings when available
- Added schema definition for `defaultModel` in paseo.config.v1.json