### PR TITLE
Add Cursor agent provider via headless Cursor CLI

### DIFF
--- a/packages/app/src/utils/provider-command-templates.ts
+++ b/packages/app/src/utils/provider-command-templates.ts
@@ -17,6 +17,9 @@ export const PROVIDER_COMMAND_TEMPLATES: Record<
   claude: {
     resume: "claude --resume {sessionId}",
   },
+  cursor: {
+    resume: "agent --resume {sessionId}",
+  },
 };
 
 function renderTemplate(template: string, vars: Record<string, string>): string {

--- a/packages/cli/src/commands/daemon/status.ts
+++ b/packages/cli/src/commands/daemon/status.ts
@@ -166,6 +166,7 @@ function toStatusRows(status: DaemonStatus): StatusRow[] {
 const PROVIDER_BINARIES: { label: string; binary: string }[] = [
   { label: "Claude", binary: "claude" },
   { label: "Codex", binary: "codex" },
+  { label: "Cursor", binary: "agent" },
   { label: "OpenCode", binary: "opencode" },
 ];
 

--- a/packages/cli/tests/15-provider.test.ts
+++ b/packages/cli/tests/15-provider.test.ts
@@ -20,7 +20,10 @@
  */
 
 import assert from "node:assert";
+import { AGENT_PROVIDER_DEFINITIONS } from "@getpaseo/server";
 import { createE2ETestContext } from "./helpers/test-daemon.ts";
+
+const MANIFEST_PROVIDER_IDS_SORTED = AGENT_PROVIDER_DEFINITIONS.map((d) => d.id).sort();
 
 console.log("=== Provider Commands ===\n");
 
@@ -126,9 +129,12 @@ try {
     console.log("Test 2: provider ls lists all providers");
     const result = await ctx.paseo(["provider", "ls"]);
     assert.strictEqual(result.exitCode, 0, "provider ls should exit 0");
-    assert(result.stdout.includes("claude"), "output should include claude");
-    assert(result.stdout.includes("codex"), "output should include codex");
-    assert(result.stdout.includes("opencode"), "output should include opencode");
+    for (const id of AGENT_PROVIDER_DEFINITIONS) {
+      assert(
+        result.stdout.includes(id.id),
+        `provider ls output should include manifest provider ${id.id}`,
+      );
+    }
     assert(result.stdout.includes("available"), "output should show available status");
     console.log("✓ provider ls lists all providers\n");
   }
@@ -140,27 +146,17 @@ try {
     assert.strictEqual(result.exitCode, 0, "should exit 0");
     const data = JSON.parse(result.stdout.trim());
     assert(Array.isArray(data), "output should be an array");
-    assert.strictEqual(data.length, 5, "should have 5 providers");
-    assert(
-      data.some((p: { provider: string }) => p.provider === "claude"),
-      "should include claude",
+    assert.strictEqual(
+      data.length,
+      AGENT_PROVIDER_DEFINITIONS.length,
+      "should list every manifest provider",
     );
-    assert(
-      data.some((p: { provider: string }) => p.provider === "codex"),
-      "should include codex",
-    );
-    assert(
-      data.some((p: { provider: string }) => p.provider === "opencode"),
-      "should include opencode",
-    );
-    assert(
-      data.some((p: { provider: string }) => p.provider === "copilot"),
-      "should include copilot",
-    );
-    assert(
-      data.some((p: { provider: string }) => p.provider === "pi"),
-      "should include pi",
-    );
+    for (const def of AGENT_PROVIDER_DEFINITIONS) {
+      assert(
+        data.some((p: { provider: string }) => p.provider === def.id),
+        `should include provider ${def.id}`,
+      );
+    }
     console.log("✓ provider ls --json outputs valid JSON\n");
   }
 
@@ -169,13 +165,13 @@ try {
     console.log("Test 4: provider ls --quiet outputs provider names only");
     const result = await ctx.paseo(["provider", "ls", "--quiet"]);
     assert.strictEqual(result.exitCode, 0, "should exit 0");
-    const lines = result.stdout.trim().split("\n");
-    assert.strictEqual(lines.length, 5, "should have 5 lines");
-    assert(lines.includes("claude"), "should include claude");
-    assert(lines.includes("codex"), "should include codex");
-    assert(lines.includes("opencode"), "should include opencode");
-    assert(lines.includes("copilot"), "should include copilot");
-    assert(lines.includes("pi"), "should include pi");
+    const lines = result.stdout.trim().split("\n").filter(Boolean);
+    assert.strictEqual(
+      lines.length,
+      AGENT_PROVIDER_DEFINITIONS.length,
+      "should have one line per manifest provider",
+    );
+    assert.deepStrictEqual([...lines].sort(), MANIFEST_PROVIDER_IDS_SORTED);
     console.log("✓ provider ls --quiet outputs provider names only\n");
   }
 
@@ -227,7 +223,28 @@ try {
       data.every((m) => m.model && m.id && m.description !== undefined),
       "every opencode model should have model, id, and description fields",
     );
+    const hasOpenRouterOpenAi = ids.some((id) => id.startsWith("openrouter/openai/"));
+    if (!hasOpenRouterOpenAi) {
+      console.log(
+        "(note) opencode model list had no openrouter/openai/* entries in this environment\n",
+      );
+    }
     console.log("✓ provider models opencode returns namespaced model IDs\n");
+  }
+
+  // Test 7b: provider models cursor (best-effort; requires Cursor CLI auth on the machine)
+  {
+    console.log("Test 7b: provider models cursor (best-effort)");
+    const result = await ctx.paseo(["provider", "models", "cursor", "--json"]);
+    if (result.exitCode === 0) {
+      const data = JSON.parse(result.stdout.trim()) as ProviderModel[];
+      assert(data.length >= 1, "cursor model list should be non-empty when CLI is authenticated");
+      const ids = data.map((m) => m.id);
+      assert.strictEqual(new Set(ids).size, ids.length, "cursor model IDs should be unique");
+    } else {
+      console.log("(skipped) provider models cursor did not exit 0 — likely no `agent` auth\n");
+    }
+    console.log("✓ provider models cursor check completed\n");
   }
 
   // Test 8: provider models unknown fails with error

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -433,6 +433,7 @@ export type AgentSessionConfig = {
   extra?: {
     codex?: AgentMetadata;
     claude?: Partial<ClaudeAgentOptions>;
+    cursor?: AgentMetadata;
   };
   mcpServers?: Record<string, McpServerConfig>;
   /**

--- a/packages/server/src/server/agent/provider-manifest.ts
+++ b/packages/server/src/server/agent/provider-manifest.ts
@@ -116,6 +116,30 @@ const OPENCODE_MODES: AgentProviderModeDefinition[] = [
   },
 ];
 
+const CURSOR_MODES: AgentProviderModeDefinition[] = [
+  {
+    id: "agent",
+    label: "Agent",
+    description: "Full tool access for edits, terminal, and search (Cursor Agent CLI)",
+    icon: "ShieldAlert",
+    colorTier: "moderate",
+  },
+  {
+    id: "plan",
+    label: "Plan",
+    description: "Read-only planning and analysis without applying edits",
+    icon: "ShieldCheck",
+    colorTier: "planning",
+  },
+  {
+    id: "ask",
+    label: "Ask",
+    description: "Q&A-style explanations without modifying the workspace",
+    icon: "ShieldCheck",
+    colorTier: "safe",
+  },
+];
+
 export const AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [
   {
     id: "claude",
@@ -165,6 +189,14 @@ export const AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [
     description: "Minimal terminal-based coding agent with multi-provider LLM support",
     defaultModeId: null,
     modes: [],
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    description:
+      "Cursor Agent via headless CLI (`agent -p --force`); install the `agent` binary and run `agent login`",
+    defaultModeId: "agent",
+    modes: CURSOR_MODES,
   },
 ];
 

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -14,6 +14,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { OpenCodeAgentClient, OpenCodeServerManager } from "./providers/opencode-agent.js";
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { PiACPAgentClient } from "./providers/pi-acp-agent.js";
+import { CursorCliAgentClient } from "./providers/cursor-cli-agent.js";
 
 import {
   AGENT_PROVIDER_DEFINITIONS,
@@ -55,6 +56,11 @@ const PROVIDER_CLIENT_FACTORIES: Record<string, ProviderClientFactory> = {
   opencode: (logger, runtimeSettings) => new OpenCodeAgentClient(logger, runtimeSettings?.opencode),
   pi: (logger, runtimeSettings) =>
     new PiACPAgentClient({ logger, runtimeSettings: runtimeSettings?.pi }),
+  cursor: (logger, runtimeSettings) =>
+    new CursorCliAgentClient({
+      logger,
+      runtimeSettings: runtimeSettings?.cursor,
+    }),
 };
 
 function getProviderClientFactory(provider: string): ProviderClientFactory {

--- a/packages/server/src/server/agent/providers/cursor-cli-agent.test.ts
+++ b/packages/server/src/server/agent/providers/cursor-cli-agent.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+
+import { CursorCliAgentClient } from "./cursor-cli-agent.js";
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+
+describe("CursorCliAgentClient", () => {
+  test("exposes cursor provider id and capabilities", () => {
+    const client = new CursorCliAgentClient({ logger: createTestLogger() });
+    expect(client.provider).toBe("cursor");
+    expect(client.capabilities.supportsStreaming).toBe(true);
+    expect(client.capabilities.supportsSessionPersistence).toBe(true);
+  });
+});

--- a/packages/server/src/server/agent/providers/cursor-cli-agent.test.ts
+++ b/packages/server/src/server/agent/providers/cursor-cli-agent.test.ts
@@ -54,10 +54,14 @@ describe("CursorCliAgentClient", () => {
           role: "assistant",
           message: {
             content: [
-              { type: "text", text: "first reply" },
+              { type: "text", text: "first reply\n\n[REDACTED]" },
               { type: "tool_use", name: "Shell", input: { command: "pwd" } },
             ],
           },
+        }),
+        JSON.stringify({
+          role: "assistant",
+          message: { content: [{ type: "text", text: "[REDACTED]" }] },
         }),
         JSON.stringify({
           role: "assistant",
@@ -103,5 +107,22 @@ describe("CursorCliAgentClient", () => {
       replayedAgain.push(event);
     }
     expect(replayedAgain).toEqual([]);
+  });
+
+  test("streamHistory ignores unsafe session ids for transcript lookup", async () => {
+    const session = new CursorCliAgentSession(
+      { provider: "cursor", cwd: "/Users/test/workspace/paseo" },
+      {
+        logger: createTestLogger(),
+        resumeChatId: "../cursor-session-1",
+      },
+    );
+
+    const events = [];
+    for await (const event of session.streamHistory()) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([]);
   });
 });

--- a/packages/server/src/server/agent/providers/cursor-cli-agent.test.ts
+++ b/packages/server/src/server/agent/providers/cursor-cli-agent.test.ts
@@ -1,7 +1,22 @@
-import { describe, expect, test } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
-import { CursorCliAgentClient } from "./cursor-cli-agent.js";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { CursorCliAgentClient, CursorCliAgentSession } from "./cursor-cli-agent.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
+
+const originalHome = process.env.HOME;
+
+afterEach(() => {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  vi.restoreAllMocks();
+});
 
 describe("CursorCliAgentClient", () => {
   test("exposes cursor provider id and capabilities", () => {
@@ -9,5 +24,84 @@ describe("CursorCliAgentClient", () => {
     expect(client.provider).toBe("cursor");
     expect(client.capabilities.supportsStreaming).toBe(true);
     expect(client.capabilities.supportsSessionPersistence).toBe(true);
+  });
+
+  test("streamHistory replays transcript history from .cursor/projects", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "cursor-home-"));
+    process.env.HOME = home;
+
+    const cwd = "/Users/test/workspace/paseo";
+    const sessionId = "cursor-session-1";
+    const transcriptDir = path.join(
+      home,
+      ".cursor",
+      "projects",
+      "Users-test-workspace-paseo",
+      "agent-transcripts",
+      sessionId,
+    );
+    await mkdir(transcriptDir, { recursive: true });
+    await writeFile(
+      path.join(transcriptDir, `${sessionId}.jsonl`),
+      [
+        JSON.stringify({
+          role: "user",
+          message: {
+            content: [{ type: "text", text: "<user_query>\nhello cursor\n</user_query>" }],
+          },
+        }),
+        JSON.stringify({
+          role: "assistant",
+          message: {
+            content: [
+              { type: "text", text: "first reply" },
+              { type: "tool_use", name: "Shell", input: { command: "pwd" } },
+            ],
+          },
+        }),
+        JSON.stringify({
+          role: "assistant",
+          message: { content: [{ type: "text", text: "second reply" }] },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    const session = new CursorCliAgentSession(
+      { provider: "cursor", cwd },
+      {
+        logger: createTestLogger(),
+        resumeChatId: sessionId,
+      },
+    );
+
+    const events = [];
+    for await (const event of session.streamHistory()) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      {
+        type: "timeline",
+        provider: "cursor",
+        item: { type: "user_message", text: "hello cursor" },
+      },
+      {
+        type: "timeline",
+        provider: "cursor",
+        item: { type: "assistant_message", text: "first reply" },
+      },
+      {
+        type: "timeline",
+        provider: "cursor",
+        item: { type: "assistant_message", text: "second reply" },
+      },
+    ]);
+
+    const replayedAgain = [];
+    for await (const event of session.streamHistory()) {
+      replayedAgain.push(event);
+    }
+    expect(replayedAgain).toEqual([]);
   });
 });

--- a/packages/server/src/server/agent/providers/cursor-cli-agent.ts
+++ b/packages/server/src/server/agent/providers/cursor-cli-agent.ts
@@ -1,8 +1,11 @@
 import { execFile } from "node:child_process";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
-import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import readline from "node:readline";
+import { promisify } from "node:util";
 import type { Logger } from "pino";
 
 import type {
@@ -101,6 +104,74 @@ function extractAssistantText(message: unknown): string {
       return p.type === "text" && typeof p.text === "string" ? p.text : "";
     })
     .join("");
+}
+
+function unwrapCursorHistoryText(text: string): string {
+  const trimmed = text.trim();
+  const userQuery = /^<user_query>\s*\n?([\s\S]*?)\n?<\/user_query>$/u.exec(trimmed);
+  if (userQuery?.[1]) {
+    return userQuery[1].trim();
+  }
+  return trimmed;
+}
+
+function extractCursorHistoryText(message: unknown): string {
+  return unwrapCursorHistoryText(extractAssistantText(message));
+}
+
+function resolveCursorTranscriptPath(cwd: string, sessionId: string): string {
+  const projectDir = cwd.replace(/[\\/:\.]+/g, "-").replace(/^-+|-+$/g, "");
+  return path.join(
+    os.homedir(),
+    ".cursor",
+    "projects",
+    projectDir,
+    "agent-transcripts",
+    sessionId,
+    `${sessionId}.jsonl`,
+  );
+}
+
+function parseCursorTranscriptLine(line: string): AgentTimelineItem[] {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  let entry: { role?: unknown; message?: unknown };
+  try {
+    entry = JSON.parse(trimmed) as { role?: unknown; message?: unknown };
+  } catch {
+    return [];
+  }
+
+  if (entry.role === "user") {
+    const text = extractCursorHistoryText(entry.message);
+    return text ? [{ type: "user_message", text }] : [];
+  }
+  if (entry.role === "assistant") {
+    const text = extractCursorHistoryText(entry.message);
+    return text ? [{ type: "assistant_message", text }] : [];
+  }
+  return [];
+}
+
+function loadCursorTranscriptHistory(cwd: string, sessionId: string): AgentTimelineItem[] {
+  const transcriptPath = resolveCursorTranscriptPath(cwd, sessionId);
+  if (!fs.existsSync(transcriptPath)) {
+    return [];
+  }
+
+  try {
+    const content = fs.readFileSync(transcriptPath, "utf8");
+    const timeline: AgentTimelineItem[] = [];
+    for (const line of content.split(/\r?\n/)) {
+      timeline.push(...parseCursorTranscriptLine(line));
+    }
+    return timeline;
+  } catch {
+    return [];
+  }
 }
 
 function mapStreamJsonUsage(raw: unknown): AgentUsage | undefined {
@@ -463,6 +534,8 @@ export class CursorCliAgentSession implements AgentSession {
   private child: ChildProcessWithoutNullStreams | null = null;
   private closed = false;
   private bootstrapThreadEventPending = true;
+  private persistedHistory: AgentTimelineItem[] = [];
+  private historyPending = false;
 
   constructor(config: AgentSessionConfig, options: CursorCliAgentSessionOptions) {
     this.logger = options.logger.child({ module: "agent", provider: CURSOR_PROVIDER });
@@ -472,6 +545,10 @@ export class CursorCliAgentSession implements AgentSession {
     this.config = config;
     this.currentModel = config.model ?? null;
     this.currentMode = config.modeId ?? "agent";
+    if (this.resumeChatId) {
+      this.persistedHistory = loadCursorTranscriptHistory(this.config.cwd, this.resumeChatId);
+      this.historyPending = this.persistedHistory.length > 0;
+    }
   }
 
   subscribe(callback: (event: AgentStreamEvent) => void): () => void {
@@ -489,7 +566,15 @@ export class CursorCliAgentSession implements AgentSession {
   }
 
   async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
-    /* Cursor headless CLI does not replay prior transcript here */
+    if (!this.historyPending || this.persistedHistory.length === 0) {
+      return;
+    }
+    const history = this.persistedHistory;
+    this.persistedHistory = [];
+    this.historyPending = false;
+    for (const item of history) {
+      yield { type: "timeline", provider: this.provider, item };
+    }
   }
 
   async getRuntimeInfo(): Promise<AgentRuntimeInfo> {

--- a/packages/server/src/server/agent/providers/cursor-cli-agent.ts
+++ b/packages/server/src/server/agent/providers/cursor-cli-agent.ts
@@ -769,15 +769,11 @@ export class CursorCliAgentSession implements AgentSession {
     }
 
     if (type === "user") {
-      const text = extractAssistantText(record.message);
-      if (text) {
-        this.pushEvent({
-          type: "timeline",
-          provider: this.provider,
-          turnId,
-          item: { type: "user_message", text },
-        });
-      }
+      // Cursor stream-json replays the submitted prompt as `user` messages. Paseo already
+      // inserts the canonical bubble via AgentManager.recordUserMessage() before streaming.
+      // Those rows carry client messageId; CLI output does not, so handleStreamEvent cannot
+      // dedupe and the UI shows duplicate bubbles. Tool / continuation traffic is not
+      // modeled as `user` in this headless print path.
       return;
     }
 

--- a/packages/server/src/server/agent/providers/cursor-cli-agent.ts
+++ b/packages/server/src/server/agent/providers/cursor-cli-agent.ts
@@ -1,0 +1,849 @@
+import { execFile } from "node:child_process";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { promisify } from "node:util";
+import { randomUUID } from "node:crypto";
+import readline from "node:readline";
+import type { Logger } from "pino";
+
+import type {
+  AgentCapabilityFlags,
+  AgentClient,
+  AgentLaunchContext,
+  AgentMode,
+  AgentModelDefinition,
+  AgentPersistenceHandle,
+  AgentPromptInput,
+  AgentRunOptions,
+  AgentRunResult,
+  AgentRuntimeInfo,
+  AgentSession,
+  AgentSessionConfig,
+  AgentStreamEvent,
+  AgentTimelineItem,
+  AgentUsage,
+  ListModelsOptions,
+  ListModesOptions,
+  ToolCallTimelineItem,
+} from "../agent-sdk-types.js";
+import {
+  applyProviderEnv,
+  resolveProviderCommandPrefix,
+  type ProviderRuntimeSettings,
+} from "../provider-launch-config.js";
+import { findExecutable } from "../../../utils/executable.js";
+import { spawnProcess } from "../../../utils/spawn.js";
+import {
+  formatDiagnosticStatus,
+  formatProviderDiagnostic,
+  formatProviderDiagnosticError,
+  resolveBinaryVersion,
+  toDiagnosticErrorMessage,
+} from "./diagnostic-utils.js";
+
+const execFileAsync = promisify(execFile);
+
+const CURSOR_PROVIDER = "cursor" as const;
+
+const CURSOR_CAPABILITIES: AgentCapabilityFlags = {
+  supportsStreaming: true,
+  supportsSessionPersistence: true,
+  supportsDynamicModes: false,
+  supportsMcpServers: false,
+  supportsReasoningStream: false,
+  supportsToolInvocations: true,
+};
+
+const CURSOR_MODES: AgentMode[] = [
+  {
+    id: "agent",
+    label: "Agent",
+    description: "Full tool access (headless `agent -p` with --force).",
+  },
+  {
+    id: "plan",
+    label: "Plan",
+    description: "Read-only planning (`--mode plan`).",
+  },
+  {
+    id: "ask",
+    label: "Ask",
+    description: "Q&A without edits (`--mode ask`).",
+  },
+];
+
+// #region helpers
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function extractPromptText(prompt: AgentPromptInput): string {
+  if (typeof prompt === "string") {
+    return prompt;
+  }
+  return prompt.map((block) => (block.type === "text" ? block.text : "")).join("");
+}
+
+function extractAssistantText(message: unknown): string {
+  if (!message || typeof message !== "object") {
+    return "";
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((part) => {
+      if (!part || typeof part !== "object") {
+        return "";
+      }
+      const p = part as { type?: string; text?: string };
+      return p.type === "text" && typeof p.text === "string" ? p.text : "";
+    })
+    .join("");
+}
+
+function mapStreamJsonUsage(raw: unknown): AgentUsage | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const u = raw as Record<string, unknown>;
+  const input = typeof u.inputTokens === "number" ? u.inputTokens : undefined;
+  const output = typeof u.outputTokens === "number" ? u.outputTokens : undefined;
+  const cacheRead = typeof u.cacheReadTokens === "number" ? u.cacheReadTokens : undefined;
+  if (input === undefined && output === undefined && cacheRead === undefined) {
+    return undefined;
+  }
+  return {
+    ...(typeof input === "number" ? { inputTokens: input } : {}),
+    ...(typeof output === "number" ? { outputTokens: output } : {}),
+    ...(typeof cacheRead === "number" ? { cachedInputTokens: cacheRead } : {}),
+  };
+}
+
+function parseListModelsFromStdout(stdout: string): AgentModelDefinition[] {
+  const text = stripAnsi(stdout);
+  const lines = text.split("\n");
+  const start = lines.findIndex((l) => l.trim().toLowerCase().startsWith("available models"));
+  const slice = start >= 0 ? lines.slice(start + 1) : lines;
+  const models: AgentModelDefinition[] = [];
+  for (const line of slice) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("Loading")) {
+      continue;
+    }
+    const m = /^([a-z0-9][a-z0-9._-]*)\s+-\s+(.+)$/i.exec(trimmed);
+    if (!m) {
+      continue;
+    }
+    const id = m[1]!;
+    const label = m[2]!.replace(/\s*\(default\)\s*$/i, "").trim();
+    const isDefault = /\bdefault\b/i.test(m[2]!);
+    models.push({
+      provider: CURSOR_PROVIDER,
+      id,
+      label,
+      ...(isDefault ? { isDefault: true } : {}),
+    });
+  }
+  return models;
+}
+
+function buildPrintArgv(
+  config: AgentSessionConfig,
+  promptText: string,
+  resumeChatId: string | null,
+): string[] {
+  const argv = [
+    "-p",
+    "--force",
+    "--trust",
+    "--output-format",
+    "stream-json",
+    "--workspace",
+    config.cwd,
+  ];
+  if (config.model && config.model.trim()) {
+    argv.push("--model", config.model.trim());
+  }
+  const modeId = config.modeId?.trim();
+  if (modeId === "plan") {
+    argv.push("--mode", "plan");
+  } else if (modeId === "ask") {
+    argv.push("--mode", "ask");
+  }
+  if (resumeChatId) {
+    argv.push("--resume", resumeChatId);
+  }
+  const body =
+    typeof config.systemPrompt === "string" && config.systemPrompt.trim()
+      ? `${config.systemPrompt.trim()}\n\n${promptText}`
+      : promptText;
+  argv.push(body);
+  return argv;
+}
+
+function firstToolCallKey(toolCall: unknown): string | null {
+  if (!toolCall || typeof toolCall !== "object") {
+    return null;
+  }
+  const keys = Object.keys(toolCall as object);
+  return keys[0] ?? null;
+}
+
+function mapToolCallToTimeline(
+  callId: string,
+  subtype: string,
+  payload: unknown,
+): ToolCallTimelineItem | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const toolCall = (payload as { tool_call?: unknown }).tool_call;
+  if (!toolCall || typeof toolCall !== "object") {
+    return null;
+  }
+  const key = firstToolCallKey(toolCall);
+  if (key === "shellToolCall") {
+    const shell = (toolCall as { shellToolCall?: Record<string, unknown> }).shellToolCall;
+    const args = shell?.args as { command?: string } | undefined;
+    const command = typeof args?.command === "string" ? args.command : "";
+    if (subtype === "started") {
+      return {
+        type: "tool_call",
+        callId,
+        name: "Shell",
+        detail: { type: "shell", command },
+        status: "running",
+        error: null,
+      };
+    }
+    const shellResult = shell?.result as Record<string, unknown> | undefined;
+    const rejected = shellResult?.rejected as { reason?: string } | undefined;
+    const success = shellResult?.success as { output?: string; exitCode?: number } | undefined;
+    if (rejected) {
+      return {
+        type: "tool_call",
+        callId,
+        name: "Shell",
+        detail: {
+          type: "shell",
+          command,
+          output: typeof rejected.reason === "string" ? rejected.reason : "",
+          exitCode: 1,
+        },
+        status: "failed",
+        error: rejected.reason ?? "rejected",
+      };
+    }
+    if (success) {
+      return {
+        type: "tool_call",
+        callId,
+        name: "Shell",
+        detail: {
+          type: "shell",
+          command,
+          output: typeof success.output === "string" ? success.output : "",
+          exitCode: typeof success.exitCode === "number" ? success.exitCode : 0,
+        },
+        status: "completed",
+        error: null,
+      };
+    }
+    return {
+      type: "tool_call",
+      callId,
+      name: "Shell",
+      detail: { type: "unknown", input: shell ?? null, output: null },
+      status: "completed",
+      error: null,
+    };
+  }
+
+  if (subtype === "started") {
+    return {
+      type: "tool_call",
+      callId,
+      name: key ?? "Tool",
+      detail: { type: "unknown", input: toolCall, output: null },
+      status: "running",
+      error: null,
+    };
+  }
+  return {
+    type: "tool_call",
+    callId,
+    name: key ?? "Tool",
+    detail: { type: "unknown", input: null, output: toolCall },
+    status: "completed",
+    error: null,
+  };
+}
+
+async function resolveAgentLaunchPrefix(
+  runtimeSettings?: ProviderRuntimeSettings,
+): Promise<{ command: string; args: string[] }> {
+  const resolved = await findExecutable("agent");
+  return resolveProviderCommandPrefix(runtimeSettings?.command, () => {
+    if (!resolved) {
+      throw new Error(
+        "Cursor Agent CLI not found. Install it (https://cursor.com/docs/cli/installation) and ensure `agent` is on PATH.",
+      );
+    }
+    return resolved;
+  });
+}
+
+// #endregion
+
+// #region CursorCliAgentClient
+
+type CursorCliAgentClientOptions = {
+  logger: Logger;
+  runtimeSettings?: ProviderRuntimeSettings;
+};
+
+export class CursorCliAgentClient implements AgentClient {
+  readonly provider = CURSOR_PROVIDER;
+  readonly capabilities = CURSOR_CAPABILITIES;
+
+  private readonly logger: Logger;
+  private readonly runtimeSettings?: ProviderRuntimeSettings;
+
+  constructor(options: CursorCliAgentClientOptions) {
+    this.logger = options.logger.child({ module: "agent", provider: CURSOR_PROVIDER });
+    this.runtimeSettings = options.runtimeSettings;
+  }
+
+  async createSession(
+    config: AgentSessionConfig,
+    launchContext?: AgentLaunchContext,
+  ): Promise<AgentSession> {
+    this.assertProvider(config);
+    return new CursorCliAgentSession(
+      { ...config, provider: CURSOR_PROVIDER },
+      {
+        logger: this.logger,
+        runtimeSettings: this.runtimeSettings,
+        resumeChatId: null,
+        launchEnv: launchContext?.env,
+      },
+    );
+  }
+
+  async resumeSession(
+    handle: AgentPersistenceHandle,
+    overrides: Partial<AgentSessionConfig> | undefined,
+    launchContext?: AgentLaunchContext,
+  ): Promise<AgentSession> {
+    if (handle.provider !== CURSOR_PROVIDER) {
+      throw new Error(`Cannot resume ${handle.provider} with Cursor CLI client`);
+    }
+    const cwd = overrides?.cwd ?? (handle.metadata as { cwd?: string } | undefined)?.cwd;
+    if (!cwd || typeof cwd !== "string") {
+      throw new Error("Cursor resume requires cwd in overrides or persistence metadata");
+    }
+    const merged: AgentSessionConfig = {
+      ...(handle.metadata as AgentSessionConfig),
+      ...overrides,
+      provider: CURSOR_PROVIDER,
+      cwd,
+    };
+    return new CursorCliAgentSession(merged, {
+      logger: this.logger,
+      runtimeSettings: this.runtimeSettings,
+      resumeChatId: handle.nativeHandle ?? handle.sessionId,
+      launchEnv: launchContext?.env,
+    });
+  }
+
+  async listModels(options?: ListModelsOptions): Promise<AgentModelDefinition[]> {
+    const cwd = options?.cwd ?? process.cwd();
+    const { command, args } = await resolveAgentLaunchPrefix(this.runtimeSettings);
+    const { stdout } = await execFileAsync(command, [...args, "--list-models"], {
+      cwd,
+      encoding: "utf8",
+      maxBuffer: 20_000_000,
+      env: applyProviderEnv(
+        process.env as Record<string, string | undefined>,
+        this.runtimeSettings,
+      ),
+    });
+    return parseListModelsFromStdout(stdout);
+  }
+
+  async listModes(_options?: ListModesOptions): Promise<AgentMode[]> {
+    return [...CURSOR_MODES];
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await resolveAgentLaunchPrefix(this.runtimeSettings);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getDiagnostic(): Promise<{ diagnostic: string }> {
+    try {
+      const available = await this.isAvailable();
+      const resolvedBinary = await findExecutable("agent");
+      let modelsValue = "Not checked";
+      let status = formatDiagnosticStatus(available);
+
+      if (available) {
+        try {
+          const models = await this.listModels();
+          modelsValue = String(models.length);
+        } catch (error) {
+          modelsValue = `Error - ${toDiagnosticErrorMessage(error)}`;
+          status = formatDiagnosticStatus(available, {
+            source: "model fetch",
+            cause: error,
+          });
+        }
+      }
+
+      return {
+        diagnostic: formatProviderDiagnostic("Cursor", [
+          {
+            label: "Binary",
+            value: resolvedBinary ?? "not found (https://cursor.com/docs/cli/installation)",
+          },
+          {
+            label: "Version",
+            value: resolvedBinary ? await resolveBinaryVersion(resolvedBinary) : "unknown",
+          },
+          { label: "Models", value: modelsValue },
+          { label: "Status", value: status },
+        ]),
+      };
+    } catch (error) {
+      return {
+        diagnostic: formatProviderDiagnosticError("Cursor", error),
+      };
+    }
+  }
+
+  private assertProvider(config: AgentSessionConfig): void {
+    if (config.provider !== CURSOR_PROVIDER) {
+      throw new Error(`Expected provider ${CURSOR_PROVIDER}`);
+    }
+  }
+}
+
+// #endregion
+
+// #region CursorCliAgentSession
+
+type CursorCliAgentSessionOptions = {
+  logger: Logger;
+  runtimeSettings?: ProviderRuntimeSettings;
+  resumeChatId: string | null;
+  launchEnv?: Record<string, string>;
+};
+
+export class CursorCliAgentSession implements AgentSession {
+  readonly provider = CURSOR_PROVIDER;
+  readonly capabilities = CURSOR_CAPABILITIES;
+  readonly id: string | null = null;
+
+  private readonly logger: Logger;
+  private readonly runtimeSettings?: ProviderRuntimeSettings;
+  private readonly launchEnv?: Record<string, string>;
+  private readonly resumeChatId: string | null;
+  private config: AgentSessionConfig;
+  private sessionId: string | null = null;
+  private currentModel: string | null = null;
+  private currentMode: string | null = null;
+  private subscribers = new Set<(event: AgentStreamEvent) => void>();
+  private activeForegroundTurnId: string | null = null;
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private closed = false;
+  private bootstrapThreadEventPending = true;
+
+  constructor(config: AgentSessionConfig, options: CursorCliAgentSessionOptions) {
+    this.logger = options.logger.child({ module: "agent", provider: CURSOR_PROVIDER });
+    this.runtimeSettings = options.runtimeSettings;
+    this.launchEnv = options.launchEnv;
+    this.resumeChatId = options.resumeChatId;
+    this.config = config;
+    this.currentModel = config.model ?? null;
+    this.currentMode = config.modeId ?? "agent";
+  }
+
+  subscribe(callback: (event: AgentStreamEvent) => void): () => void {
+    this.subscribers.add(callback);
+    if (this.sessionId) {
+      callback({
+        type: "thread_started",
+        provider: this.provider,
+        sessionId: this.sessionId,
+      });
+    }
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+    /* Cursor headless CLI does not replay prior transcript here */
+  }
+
+  async getRuntimeInfo(): Promise<AgentRuntimeInfo> {
+    return {
+      provider: this.provider,
+      sessionId: this.sessionId,
+      model: this.currentModel,
+      modeId: this.currentMode,
+      extra: {
+        title: this.config.title ?? undefined,
+      },
+    };
+  }
+
+  async getAvailableModes(): Promise<AgentMode[]> {
+    return [...CURSOR_MODES];
+  }
+
+  async getCurrentMode(): Promise<string | null> {
+    return this.currentMode;
+  }
+
+  async setMode(modeId: string): Promise<void> {
+    this.config = { ...this.config, modeId };
+    this.currentMode = modeId;
+  }
+
+  async setModel(modelId: string | null): Promise<void> {
+    this.config = { ...this.config, model: modelId ?? undefined };
+    this.currentModel = modelId;
+  }
+
+  getPendingPermissions() {
+    return [];
+  }
+
+  async respondToPermission(): Promise<void> {
+    throw new Error("Cursor CLI print mode does not support interactive permission responses");
+  }
+
+  describePersistence(): AgentPersistenceHandle | null {
+    if (!this.sessionId) {
+      return null;
+    }
+    return {
+      provider: this.provider,
+      sessionId: this.sessionId,
+      nativeHandle: this.sessionId,
+      metadata: {
+        ...this.config,
+        cwd: this.config.cwd,
+      },
+    };
+  }
+
+  async interrupt(): Promise<void> {
+    if (this.child && !this.child.killed) {
+      this.child.kill("SIGTERM");
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    await this.interrupt();
+    this.subscribers.clear();
+  }
+
+  async run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult> {
+    const timeline: AgentTimelineItem[] = [];
+    let finalText = "";
+    let usage: AgentUsage | undefined;
+    let turnId: string | null = null;
+    let settled = false;
+    let resolveCompletion!: () => void;
+    let rejectCompletion!: (error: Error) => void;
+    const buffered: AgentStreamEvent[] = [];
+
+    const completion = new Promise<void>((resolve, reject) => {
+      resolveCompletion = resolve;
+      rejectCompletion = reject;
+    });
+
+    const processEvent = (event: AgentStreamEvent) => {
+      if (settled) {
+        return;
+      }
+      if (turnId && "turnId" in event && event.turnId && event.turnId !== turnId) {
+        return;
+      }
+      if (event.type === "timeline") {
+        timeline.push(event.item);
+        if (event.item.type === "assistant_message") {
+          finalText = event.item.text.startsWith(finalText)
+            ? event.item.text
+            : `${finalText}${event.item.text}`;
+        }
+        return;
+      }
+      if (event.type === "turn_completed") {
+        usage = event.usage;
+        settled = true;
+        resolveCompletion();
+        return;
+      }
+      if (event.type === "turn_failed") {
+        settled = true;
+        rejectCompletion(new Error(event.error));
+        return;
+      }
+      if (event.type === "turn_canceled") {
+        settled = true;
+        resolveCompletion();
+      }
+    };
+
+    const unsubscribe = this.subscribe((event) => {
+      if (!turnId) {
+        buffered.push(event);
+        return;
+      }
+      processEvent(event);
+    });
+
+    try {
+      const started = await this.startTurn(prompt, options);
+      turnId = started.turnId;
+      for (const event of buffered) {
+        processEvent(event);
+      }
+      if (!settled) {
+        await completion;
+      }
+    } finally {
+      unsubscribe();
+    }
+
+    return {
+      sessionId: this.sessionId ?? randomUUID(),
+      finalText,
+      usage,
+      timeline,
+    };
+  }
+
+  async startTurn(
+    prompt: AgentPromptInput,
+    _options?: AgentRunOptions,
+  ): Promise<{ turnId: string }> {
+    if (this.closed) {
+      throw new Error("Cursor CLI session is closed");
+    }
+    if (this.activeForegroundTurnId) {
+      throw new Error("A foreground turn is already active");
+    }
+
+    const turnId = randomUUID();
+    this.activeForegroundTurnId = turnId;
+    this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+
+    const promptText = extractPromptText(prompt);
+    void this.runAgentProcess(promptText, turnId).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      this.finishTurn({
+        type: "turn_failed",
+        provider: this.provider,
+        error: message,
+        turnId,
+      });
+    });
+
+    return { turnId };
+  }
+
+  private async runAgentProcess(promptText: string, turnId: string): Promise<void> {
+    const { command, args } = await resolveAgentLaunchPrefix(this.runtimeSettings);
+    const resumeTarget = this.sessionId ?? this.resumeChatId;
+    const argv = [...args, ...buildPrintArgv(this.config, promptText, resumeTarget)];
+
+    const child = spawnProcess(command, argv, {
+      cwd: this.config.cwd,
+      env: {
+        ...applyProviderEnv(
+          process.env as Record<string, string | undefined>,
+          this.runtimeSettings,
+        ),
+        ...(this.launchEnv ?? {}),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    }) as ChildProcessWithoutNullStreams;
+
+    this.logger.trace(
+      { command, argvLength: argv.length, cwd: this.config.cwd },
+      "cursor-cli spawn",
+    );
+    this.child = child;
+    const stderrChunks: string[] = [];
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderrChunks.push(chunk.toString());
+    });
+
+    const rl = readline.createInterface({ input: child.stdout });
+    try {
+      for await (const line of rl) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("{")) {
+          continue;
+        }
+        let record: Record<string, unknown>;
+        try {
+          record = JSON.parse(trimmed) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+        this.dispatchStreamRecord(record, turnId, stderrChunks);
+      }
+    } finally {
+      rl.close();
+      this.child = null;
+    }
+
+    await new Promise<void>((resolve) => {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        resolve();
+        return;
+      }
+      child.once("exit", () => resolve());
+    });
+
+    const code = child.exitCode;
+    if (this.activeForegroundTurnId !== turnId) {
+      return;
+    }
+
+    const diagnostic = stderrChunks.join("").trim();
+    if (code !== 0 && code !== null) {
+      this.finishTurn({
+        type: "turn_failed",
+        provider: this.provider,
+        error: `Cursor agent exited with code ${code}`,
+        diagnostic: diagnostic || undefined,
+        turnId,
+      });
+      return;
+    }
+
+    this.finishTurn({
+      type: "turn_completed",
+      provider: this.provider,
+      turnId,
+    });
+  }
+
+  private dispatchStreamRecord(
+    record: Record<string, unknown>,
+    turnId: string,
+    stderrChunks: string[],
+  ): void {
+    if (this.activeForegroundTurnId !== turnId) {
+      return;
+    }
+
+    const type = record.type;
+    if (type === "system" && record.subtype === "init") {
+      const sid = typeof record.session_id === "string" ? record.session_id : null;
+      if (sid) {
+        this.sessionId = sid;
+        if (this.bootstrapThreadEventPending) {
+          this.bootstrapThreadEventPending = false;
+          this.pushEvent({
+            type: "thread_started",
+            provider: this.provider,
+            sessionId: sid,
+          });
+        }
+      }
+      return;
+    }
+
+    if (type === "user") {
+      const text = extractAssistantText(record.message);
+      if (text) {
+        this.pushEvent({
+          type: "timeline",
+          provider: this.provider,
+          turnId,
+          item: { type: "user_message", text },
+        });
+      }
+      return;
+    }
+
+    if (type === "assistant") {
+      const text = extractAssistantText(record.message);
+      if (text) {
+        this.pushEvent({
+          type: "timeline",
+          provider: this.provider,
+          turnId,
+          item: { type: "assistant_message", text },
+        });
+      }
+      return;
+    }
+
+    if (type === "tool_call") {
+      const callId = typeof record.call_id === "string" ? record.call_id : randomUUID();
+      const subtype = typeof record.subtype === "string" ? record.subtype : "";
+      const item = mapToolCallToTimeline(callId, subtype, record);
+      if (item) {
+        this.pushEvent({ type: "timeline", provider: this.provider, turnId, item });
+      }
+      return;
+    }
+
+    if (type === "result") {
+      const isError = Boolean(record.is_error);
+      const usage = mapStreamJsonUsage(record.usage);
+      if (isError) {
+        const msg =
+          typeof record.result === "string"
+            ? record.result
+            : typeof record.error === "string"
+              ? record.error
+              : "Cursor agent run failed";
+        this.finishTurn({
+          type: "turn_failed",
+          provider: this.provider,
+          error: msg,
+          diagnostic: stderrChunks.join("").trim() || undefined,
+          turnId,
+        });
+        return;
+      }
+      this.finishTurn({
+        type: "turn_completed",
+        provider: this.provider,
+        usage,
+        turnId,
+      });
+    }
+  }
+
+  private pushEvent(event: AgentStreamEvent): void {
+    for (const subscriber of this.subscribers) {
+      subscriber(event);
+    }
+  }
+
+  private finishTurn(
+    event: Extract<AgentStreamEvent, { type: "turn_completed" | "turn_failed" | "turn_canceled" }>,
+  ): void {
+    this.activeForegroundTurnId = null;
+    this.pushEvent(event);
+  }
+}
+
+// #endregion

--- a/packages/server/src/server/agent/providers/cursor-cli-agent.ts
+++ b/packages/server/src/server/agent/providers/cursor-cli-agent.ts
@@ -107,7 +107,12 @@ function extractAssistantText(message: unknown): string {
 }
 
 function unwrapCursorHistoryText(text: string): string {
-  const trimmed = text.trim();
+  const withoutRedacted = text
+    .split(/\n{2,}/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0 && part !== "[REDACTED]")
+    .join("\n\n");
+  const trimmed = withoutRedacted.trim();
   const userQuery = /^<user_query>\s*\n?([\s\S]*?)\n?<\/user_query>$/u.exec(trimmed);
   if (userQuery?.[1]) {
     return userQuery[1].trim();
@@ -119,7 +124,14 @@ function extractCursorHistoryText(message: unknown): string {
   return unwrapCursorHistoryText(extractAssistantText(message));
 }
 
-function resolveCursorTranscriptPath(cwd: string, sessionId: string): string {
+function isSafeCursorSessionId(sessionId: string): boolean {
+  return /^[A-Za-z0-9-]+$/u.test(sessionId);
+}
+
+function resolveCursorTranscriptPath(cwd: string, sessionId: string): string | null {
+  if (!isSafeCursorSessionId(sessionId)) {
+    return null;
+  }
   const projectDir = cwd.replace(/[\\/:\.]+/g, "-").replace(/^-+|-+$/g, "");
   return path.join(
     os.homedir(),
@@ -158,7 +170,7 @@ function parseCursorTranscriptLine(line: string): AgentTimelineItem[] {
 
 function loadCursorTranscriptHistory(cwd: string, sessionId: string): AgentTimelineItem[] {
   const transcriptPath = resolveCursorTranscriptPath(cwd, sessionId);
-  if (!fs.existsSync(transcriptPath)) {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
     return [];
   }
 

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -215,6 +215,7 @@ const AgentSessionConfigSchema = z.object({
     .object({
       codex: z.record(z.unknown()).optional(),
       claude: z.record(z.unknown()).optional(),
+      cursor: z.record(z.unknown()).optional(),
     })
     .partial()
     .optional(),


### PR DESCRIPTION
## Summary

Adds first-class **Cursor** as a daemon agent provider by driving the headless Cursor Agent CLI (`agent`), so Paseo can list Cursor alongside other providers, spawn Cursor-backed sessions, and stream output into the existing timeline model.

## What changed

- **Server**: `CursorCliAgentClient` / session implementation (`agent -p`, stream-json), provider manifest + registry wiring, `extra.cursor` on session config (types + Zod), and a small Vitest smoke test for the client.
- **CLI / UX**: `provider ls` tests follow `AGENT_PROVIDER_DEFINITIONS`; optional `provider models cursor` check when `agent` is authenticated; `daemon status` lists the `agent` binary; app resume template for Cursor.
- **Docs in code**: manifest description points users to installing the CLI and `agent login`.

## Testing

- `npm run typecheck`
- Server unit test for `CursorCliAgentClient` metadata/capabilities
- CLI phase-15 provider tests (Cursor model list is best-effort when not logged in)

Fixes #246