### PR TITLE
feat(provider): add Hermes ACP provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   </a>
 </p>
 
-<p align="center">One interface for all your Claude Code, Codex and OpenCode agents.</p>
+<p align="center">One interface for all your Claude Code, Codex, OpenCode, and Hermes agents.</p>
 
 <p align="center">
   <img src="https://paseo.sh/hero-mockup.png" alt="Paseo app screenshot" width="100%">
@@ -34,7 +34,7 @@
 Run agents in parallel on your own machines. Ship from your phone or your desk.
 
 - **Self-hosted:** Agents run on your machine with your full dev environment. Use your tools, your configs, and your skills.
-- **Multi-provider:** Claude Code, Codex, and OpenCode through the same interface. Pick the right model for each job.
+- **Multi-provider:** Claude Code, Codex, OpenCode, and Hermes through the same interface. Pick the right model for each job.
 - **Voice control:** Dictate tasks or talk through problems in voice mode. Hands-free when you need it.
 - **Cross-device:** iOS, Android, desktop, web, and CLI. Start work at your desk, check in from your phone, script it from the terminal.
 - **Privacy-first:** Paseo doesn't have any telemetry, tracking, or forced log-ins.
@@ -50,6 +50,23 @@ You need at least one agent CLI installed and configured with your credentials:
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
 - [Codex](https://github.com/openai/codex)
 - [OpenCode](https://github.com/anomalyco/opencode)
+- [Hermes Agent](https://github.com/NousResearch/hermes-agent)
+
+Hermes is launched through ACP with `hermes acp`. If you use multiple Hermes profiles, point Paseo at a non-default profile by setting `agents.providers.hermes.env.HERMES_HOME` in your Paseo config:
+
+```json
+{
+  "agents": {
+    "providers": {
+      "hermes": {
+        "env": {
+          "HERMES_HOME": "/Users/you/.hermes/profiles/work"
+        }
+      }
+    }
+  }
+}
+```
 
 ### Desktop app (recommended)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,6 +157,7 @@ Each provider implements a common `AgentClient` interface:
 |---|---|---|
 | Claude | Anthropic Agent SDK | `~/.claude/projects/{cwd}/{session-id}.jsonl` |
 | Codex | CodexAppServer | `~/.codex/sessions/{date}/rollout-{ts}-{id}.jsonl` |
+| Hermes | Hermes ACP | Provider-managed under `$HERMES_HOME` |
 | OpenCode | OpenCode CLI | Provider-managed |
 
 All providers:

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -8,7 +8,7 @@ This guide walks through adding a new agent provider end-to-end. There are two i
 
 Extend `ACPAgentClient`. The base class handles process spawning, stdio transport, session lifecycle, streaming, permissions, and model discovery. You provide configuration (command, modes, capabilities) and optionally override `isAvailable()` for auth checks.
 
-Existing ACP providers: `claude-acp`, `copilot`.
+Existing ACP providers: `copilot`, `hermes`, `pi`.
 
 ### Direct
 
@@ -357,3 +357,19 @@ Tests use `isProviderAvailable(provider)` to skip when the binary or credentials
 **`defaultCommand` is a tuple.** The first element is the binary name, the rest are default arguments. The base class uses this to find the executable and spawn the process.
 
 **Runtime settings can override the command.** Users can configure custom binary paths or environment variables per provider via `ProviderRuntimeSettings`. Your factory in the registry should pass `runtimeSettings?.["your-provider"]` through to the constructor.
+
+For example, a Hermes provider can use runtime env overrides to target a non-default profile without adding a new provider ID:
+
+```json
+{
+  "agents": {
+    "providers": {
+      "hermes": {
+        "env": {
+          "HERMES_HOME": "/Users/you/.hermes/profiles/work"
+        }
+      }
+    }
+  }
+}
+```

--- a/packages/server/src/server/agent/provider-manifest.ts
+++ b/packages/server/src/server/agent/provider-manifest.ts
@@ -116,6 +116,8 @@ const OPENCODE_MODES: AgentProviderModeDefinition[] = [
   },
 ];
 
+const HERMES_MODES: AgentProviderModeDefinition[] = [];
+
 export const AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [
   {
     id: "claude",
@@ -158,6 +160,13 @@ export const AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [
       enabled: true,
       defaultModeId: "build",
     },
+  },
+  {
+    id: "hermes",
+    label: "Hermes",
+    description: "Hermes Agent via ACP, using your local Hermes profile and tools",
+    defaultModeId: null,
+    modes: HERMES_MODES,
   },
   {
     id: "pi",

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -11,6 +11,7 @@ import type { Logger } from "pino";
 
 import { ClaudeAgentClient } from "./providers/claude-agent.js";
 import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js";
+import { HermesACPAgentClient } from "./providers/hermes-acp-agent.js";
 import { OpenCodeAgentClient, OpenCodeServerManager } from "./providers/opencode-agent.js";
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { PiACPAgentClient } from "./providers/pi-acp-agent.js";
@@ -51,6 +52,11 @@ const PROVIDER_CLIENT_FACTORIES: Record<string, ProviderClientFactory> = {
     new CopilotACPAgentClient({
       logger,
       runtimeSettings: runtimeSettings?.copilot,
+    }),
+  hermes: (logger, runtimeSettings) =>
+    new HermesACPAgentClient({
+      logger,
+      runtimeSettings: runtimeSettings?.hermes,
     }),
   opencode: (logger, runtimeSettings) =>
     new OpenCodeAgentClient(logger, runtimeSettings?.opencode),

--- a/packages/server/src/server/agent/providers/hermes-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/hermes-acp-agent.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import { HermesACPAgentClient } from "./hermes-acp-agent.js";
+
+const tempDirs: string[] = [];
+
+async function createHermesHome(configYaml?: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "paseo-hermes-home-"));
+  tempDirs.push(dir);
+  if (configYaml) {
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "config.yaml"), configYaml, "utf8");
+  }
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("HermesACPAgentClient", () => {
+  test("listModels returns the default model declared in HERMES_HOME config.yaml", async () => {
+    const hermesHome = await createHermesHome([
+      "model:",
+      "  provider: openai",
+      "  default: gpt-5.4",
+    ].join("\n"));
+    const client = new HermesACPAgentClient({
+      logger: createTestLogger(),
+      runtimeSettings: { env: { HERMES_HOME: hermesHome } },
+    });
+
+    await expect(client.listModels()).resolves.toEqual([
+      {
+        provider: "hermes",
+        id: "gpt-5.4",
+        label: "gpt-5.4 (openai)",
+        description: `Default model from ${hermesHome}/config.yaml`,
+        isDefault: true,
+        metadata: {
+          source: "hermes-profile-default",
+          hermesHome,
+        },
+      },
+    ]);
+  });
+
+  test("listModels returns an empty array when no default model is configured", async () => {
+    const hermesHome = await createHermesHome("provider: openai\n");
+    const client = new HermesACPAgentClient({
+      logger: createTestLogger(),
+      runtimeSettings: { env: { HERMES_HOME: hermesHome } },
+    });
+
+    await expect(client.listModels()).resolves.toEqual([]);
+  });
+
+  test("listModels respects runtime HERMES_HOME overrides", async () => {
+    const defaultHome = await createHermesHome([
+      "model:",
+      "  provider: anthropic",
+      "  default: claude-sonnet-4",
+    ].join("\n"));
+    const overrideHome = await createHermesHome([
+      "model:",
+      "  provider: openai",
+      "  default: gpt-5.4",
+    ].join("\n"));
+
+    const client = new HermesACPAgentClient({
+      logger: createTestLogger(),
+      runtimeSettings: { env: { HERMES_HOME: overrideHome } },
+    });
+
+    const models = await client.listModels();
+    expect(models).toEqual([
+      {
+        provider: "hermes",
+        id: "gpt-5.4",
+        label: "gpt-5.4 (openai)",
+        description: `Default model from ${overrideHome}/config.yaml`,
+        isDefault: true,
+        metadata: {
+          source: "hermes-profile-default",
+          hermesHome: overrideHome,
+        },
+      },
+    ]);
+    expect(models[0]?.description).not.toContain(defaultHome);
+  });
+
+  test("listModes returns no static modes", async () => {
+    const client = new HermesACPAgentClient({ logger: createTestLogger() });
+
+    await expect(client.listModes()).resolves.toEqual([]);
+  });
+});

--- a/packages/server/src/server/agent/providers/hermes-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/hermes-acp-agent.ts
@@ -1,0 +1,199 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Logger } from "pino";
+
+import type { AgentCapabilityFlags, AgentMode, AgentModelDefinition } from "../agent-sdk-types.js";
+import type { ProviderRuntimeSettings } from "../provider-launch-config.js";
+import { findExecutable } from "../../../utils/executable.js";
+import { ACPAgentClient } from "./acp-agent.js";
+import {
+  formatDiagnosticStatus,
+  formatProviderDiagnostic,
+  formatProviderDiagnosticError,
+  resolveBinaryVersion,
+  toDiagnosticErrorMessage,
+} from "./diagnostic-utils.js";
+
+const HERMES_CAPABILITIES: AgentCapabilityFlags = {
+  supportsStreaming: true,
+  supportsSessionPersistence: true,
+  supportsDynamicModes: false,
+  supportsMcpServers: true,
+  supportsReasoningStream: true,
+  supportsToolInvocations: true,
+};
+
+const HERMES_MODES: AgentMode[] = [];
+
+const DEFAULT_HERMES_HOME = join(homedir(), ".hermes");
+type HermesProfileDefaults = {
+  hermesHome: string;
+  modelId: string | null;
+  provider: string | null;
+};
+
+type HermesACPAgentClientOptions = {
+  logger: Logger;
+  runtimeSettings?: ProviderRuntimeSettings;
+};
+
+function parseTopLevelModelDefaults(configPath: string): { modelId: string | null; provider: string | null } {
+  if (!existsSync(configPath)) {
+    return { modelId: null, provider: null };
+  }
+
+  const lines = readFileSync(configPath, "utf8").split(/\r?\n/);
+  let inModel = false;
+  let modelIndent = 0;
+  let modelId: string | null = null;
+  let provider: string | null = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\t/g, "    ");
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const indent = line.length - line.trimStart().length;
+    if (!inModel) {
+      if (trimmed === "model:") {
+        inModel = true;
+        modelIndent = indent;
+      }
+      continue;
+    }
+
+    if (indent <= modelIndent) {
+      break;
+    }
+
+    const match = trimmed.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+    if (!match) {
+      continue;
+    }
+    const [, key, valueRaw] = match;
+    const value = valueRaw.trim().replace(/^['"]|['"]$/g, "");
+    if (key === "default" && value) {
+      modelId = value;
+    } else if (key === "provider" && value) {
+      provider = value;
+    }
+  }
+
+  return { modelId, provider };
+}
+
+function resolveHermesProfileDefaults(explicitHermesHome?: string | null): HermesProfileDefaults {
+  const hermesHome = explicitHermesHome?.trim() || DEFAULT_HERMES_HOME;
+  const configPath = join(hermesHome, "config.yaml");
+  const parsed = parseTopLevelModelDefaults(configPath);
+  return {
+    hermesHome,
+    modelId: parsed.modelId,
+    provider: parsed.provider,
+  };
+}
+
+function buildSyntheticModel(providerId: string, defaults: HermesProfileDefaults): AgentModelDefinition[] {
+  if (!defaults.modelId) {
+    return [];
+  }
+
+  const label = defaults.provider ? `${defaults.modelId} (${defaults.provider})` : defaults.modelId;
+  return [
+    {
+      provider: providerId,
+      id: defaults.modelId,
+      label,
+      description: `Default model from ${defaults.hermesHome}/config.yaml`,
+      isDefault: true,
+      metadata: {
+        source: "hermes-profile-default",
+        hermesHome: defaults.hermesHome,
+      },
+    },
+  ];
+}
+
+function mergeRuntimeSettings(
+  runtimeSettings: ProviderRuntimeSettings | undefined,
+  defaultEnv?: Record<string, string>,
+): ProviderRuntimeSettings | undefined {
+  if (!runtimeSettings && !defaultEnv) {
+    return undefined;
+  }
+  return {
+    ...(runtimeSettings ?? {}),
+    env: {
+      ...(defaultEnv ?? {}),
+      ...(runtimeSettings?.env ?? {}),
+    },
+  };
+}
+
+export class HermesACPAgentClient extends ACPAgentClient {
+  private readonly profileDefaults: HermesProfileDefaults;
+  private readonly binaryName = "hermes";
+  private readonly displayName = "Hermes";
+
+  constructor(options: HermesACPAgentClientOptions) {
+    const mergedRuntimeSettings = mergeRuntimeSettings(options.runtimeSettings, {
+      HERMES_HOME: DEFAULT_HERMES_HOME,
+    });
+    const effectiveHermesHome = mergedRuntimeSettings?.env?.HERMES_HOME ?? DEFAULT_HERMES_HOME;
+    const profileDefaults = resolveHermesProfileDefaults(effectiveHermesHome);
+    super({
+      provider: "hermes",
+      logger: options.logger,
+      runtimeSettings: mergedRuntimeSettings,
+      defaultCommand: ["hermes", "acp"],
+      defaultModes: HERMES_MODES,
+      capabilities: HERMES_CAPABILITIES,
+    });
+    this.profileDefaults = profileDefaults;
+  }
+
+  override async listModels(): Promise<AgentModelDefinition[]> {
+    return buildSyntheticModel(this.provider, this.profileDefaults);
+  }
+
+  override async listModes(): Promise<AgentMode[]> {
+    return [];
+  }
+
+  override async isAvailable(): Promise<boolean> {
+    return super.isAvailable();
+  }
+
+  async getDiagnostic(): Promise<{ diagnostic: string }> {
+    try {
+      const available = await this.isAvailable();
+      const resolvedBinary = await findExecutable(this.binaryName);
+      const models = await this.listModels().catch((error) => {
+        throw new Error(`model discovery failed: ${toDiagnosticErrorMessage(error)}`);
+      });
+      const modelValue =
+        models.length > 0 ? models.map((model) => model.id).join(", ") : "No profile default model found";
+      return {
+        diagnostic: formatProviderDiagnostic(this.displayName, [
+          { label: "Binary", value: resolvedBinary ?? "not found" },
+          {
+            label: "Version",
+            value: resolvedBinary ? await resolveBinaryVersion(resolvedBinary) : "unknown",
+          },
+          { label: "Hermes home", value: this.profileDefaults.hermesHome },
+          { label: "Models", value: modelValue },
+          { label: "Status", value: formatDiagnosticStatus(available) },
+        ]),
+      };
+    } catch (error) {
+      return {
+        diagnostic: formatProviderDiagnosticError(this.displayName, error),
+      };
+    }
+  }
+}
+
+

--- a/packages/server/src/server/daemon-e2e/agent-configs.ts
+++ b/packages/server/src/server/daemon-e2e/agent-configs.ts
@@ -1,6 +1,6 @@
 /**
  * Shared agent configurations for e2e tests.
- * Enables running the same tests against Claude, Codex, and OpenCode providers.
+ * Enables running the same tests against real provider implementations.
  */
 import { existsSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
@@ -49,6 +49,9 @@ export const agentConfigs = {
       ask: "https://agentclientprotocol.com/protocol/session-modes#agent",
     },
   },
+  hermes: {
+    provider: "hermes",
+  },
   opencode: {
     provider: "opencode",
     model: "opencode/glm-5-free",
@@ -70,12 +73,14 @@ export type AgentProvider = keyof typeof agentConfigs;
  */
 export function getFullAccessConfig(provider: AgentProvider) {
   const config = agentConfigs[provider];
+  const model = "model" in config ? config.model : undefined;
   const thinkingOptionId = "thinkingOptionId" in config ? config.thinkingOptionId : undefined;
+  const modes = "modes" in config ? config.modes : undefined;
   return {
     provider: config.provider,
-    ...(config.model ? { model: config.model } : {}),
+    ...(model ? { model } : {}),
     ...(thinkingOptionId ? { thinkingOptionId } : {}),
-    ...(config.modes?.full ? { modeId: config.modes.full } : {}),
+    ...(modes?.full ? { modeId: modes.full } : {}),
   };
 }
 
@@ -84,12 +89,14 @@ export function getFullAccessConfig(provider: AgentProvider) {
  */
 export function getAskModeConfig(provider: AgentProvider) {
   const config = agentConfigs[provider];
+  const model = "model" in config ? config.model : undefined;
   const thinkingOptionId = "thinkingOptionId" in config ? config.thinkingOptionId : undefined;
+  const modes = "modes" in config ? config.modes : undefined;
   return {
     provider: config.provider,
-    ...(config.model ? { model: config.model } : {}),
+    ...(model ? { model } : {}),
     ...(thinkingOptionId ? { thinkingOptionId } : {}),
-    ...(config.modes?.ask ? { modeId: config.modes.ask } : {}),
+    ...(modes?.ask ? { modeId: modes.ask } : {}),
   };
 }
 
@@ -115,6 +122,8 @@ export function isProviderAvailable(provider: AgentProvider): boolean {
       );
     case "copilot":
       return isCommandAvailableSync("copilot");
+    case "hermes":
+      return isCommandAvailableSync("hermes");
     case "opencode":
       return isCommandAvailableSync("opencode");
     case "pi":
@@ -135,6 +144,7 @@ export const allProviders: AgentProvider[] = [
   "claude",
   "codex",
   "copilot",
+  "hermes",
   "opencode",
   "pi",
 ];


### PR DESCRIPTION
## Summary

Adds Hermes as a first-class Paseo provider via ACP.

Closes #278.

This is intentionally a small provider PR:
- one new provider: `hermes`
- one integration path: `hermes acp`
- no new settings UI
- no new protocol surface
- no unrelated runtime or bootstrap changes

## Why this fits Paseo

Hermes already exposes an ACP server over stdio, and Paseo already has an ACP provider base class.

That makes Hermes a good fit for the existing provider architecture without introducing a new transport or bespoke integration layer. This PR follows the same pattern Paseo already uses for ACP-backed providers instead of adding a one-off implementation.

## What this adds

Server:
- `HermesACPAgentClient` implemented as a thin `ACPAgentClient` subclass
- `hermes` added to the provider manifest
- `hermes` added to the provider registry
- Hermes added to the shared real-provider E2E config list

Tests:
- provider-specific unit tests covering:
  - default model discovery from Hermes `config.yaml`
  - empty-model fallback
  - runtime `HERMES_HOME` override behavior
  - no static modes

Docs:
- README now lists Hermes as a supported agent CLI
- architecture doc now includes Hermes in the provider table
- provider authoring doc now reflects current ACP providers and shows how Hermes profiles can be targeted through runtime env overrides

## Implementation details

The provider launches Hermes with:

```bash
hermes acp
```

Hermes currently does not expose rich enough model metadata through ACP for Paseo to populate the model picker cleanly from the protocol alone.

To keep the provider usable without adding Hermes-specific protocol handling, the provider synthesizes a default model entry from `<HERMES_HOME>/config.yaml` by reading:
- `model.default`
- `model.provider`

That gives Paseo a stable default model entry while keeping the integration small and local to the provider.

## Profile support

This PR supports non-default Hermes profiles through existing Paseo provider runtime settings rather than through new UI.

Example:

```json
{
  "agents": {
    "providers": {
      "hermes": {
        "env": {
          "HERMES_HOME": "/Users/you/.hermes/profiles/work"
        }
      }
    }
  }
}
```

Why this approach:
- it supports multiple Hermes installs/profiles immediately
- it uses an existing Paseo configuration mechanism
- it avoids expanding the product surface in this PR

## Deliberate non-goals

Not included here:
- profile-selection UI
- custom Hermes icon assets
- Hermes-side ACP changes
- unrelated cleanup in other providers or bootstrap/runtime code

Those may be reasonable follow-ups, but they would broaden a PR that can stay focused as “add Hermes as an ACP provider.”

## Verification

Hermes-specific verification completed:

- `cd packages/server && npx vitest run src/server/agent/providers/hermes-acp-agent.test.ts`
  - passes (`4 tests`)
- live smoke through Paseo’s daemon test harness using the real local Hermes binary
  - agent creation succeeded with provider `hermes`
  - a real round-trip completed successfully
  - final assistant text was `HERMES_SMOKE_OK`
  - persistence returned with provider `hermes`

## Notes on repo-wide checks

I also ran broader checks, but this checkout currently has unrelated failures outside the Hermes change:
- `npm run typecheck` fails in unrelated server/website code
- broad server test entrypoints currently hit unrelated existing failures before they reach the Hermes-specific path

I did not bundle fixes for those unrelated failures into this PR, to keep the scope narrow and reviewable.

## UI impact

This changes provider availability and provider documentation, but does not add new UI components or layouts. Hermes currently uses the existing generic provider icon fallback in the app.
