### PR TITLE
fix(app): keep iOS input right actions visible with long model names

### DIFF
--- a/packages/app/src/components/message-input.tsx
+++ b/packages/app/src/components/message-input.tsx
@@ -1283,11 +1283,14 @@ const styles = StyleSheet.create(((theme: any) => ({
     justifyContent: "space-between",
   },
   leftButtonGroup: {
+    flex: 1,
+    minWidth: 0,
     flexDirection: "row",
     alignItems: "flex-end",
     gap: theme.spacing[1],
   },
   rightButtonGroup: {
+    flexShrink: 0,
     flexDirection: "row",
     alignItems: "center",
     gap: Platform.OS === "web" ? theme.spacing[2] : theme.spacing[1],


### PR DESCRIPTION
## Summary
- prevent the right action area (send/voice) from being squeezed out by long model labels in the iOS message input
- make left button group shrinkable and keep right button group non-shrinking

## Changes
- leftButtonGroup: add flex: 1 and minWidth: 0
- rightButtonGroup: add flexShrink: 0

## Why
Long model names could consume horizontal space and push the right-side action buttons out of view. This change ensures the model label area yields first, preserving send/voice visibility and tap target.

## Scope
- UI layout only
- no behavior/protocol/schema changes

## Validation
- verified layout logic in MessageInput styles
- repository-wide npm run typecheck currently has pre-existing unrelated failures in other workspaces