### PR TITLE
fix(server): allow same-host origins across different ports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -31,8 +31,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -55,8 +55,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Fetch origin/main (worktree tests)
         run: git fetch --no-tags origin main:refs/remotes/origin/main
@@ -85,8 +85,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -123,8 +123,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -135,15 +135,34 @@ jobs:
       - name: Run app unit tests
         run: npm run test --workspace=@getpaseo/app
 
+  playwright-preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      has_openai_api_key: ${{ steps.secret-check.outputs.has_openai_api_key }}
+    steps:
+      - name: Detect OpenAI key availability
+        id: secret-check
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -n "$OPENAI_API_KEY" ]; then
+            echo "has_openai_api_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_openai_api_key=false" >> "$GITHUB_OUTPUT"
+          fi
+
   playwright:
+    needs: playwright-preflight
+    if: ${{ needs.playwright-preflight.outputs.has_openai_api_key == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -185,8 +204,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -204,8 +223,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -219,6 +238,6 @@ jobs:
       - name: Run CLI tests
         run: npm run test --workspace=@getpaseo/cli
         env:
-          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: '0'
-          PASEO_DICTATION_ENABLED: '0'
-          PASEO_VOICE_MODE_ENABLED: '0'
+          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: "0"
+          PASEO_DICTATION_ENABLED: "0"
+          PASEO_VOICE_MODE_ENABLED: "0"

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -3,14 +3,15 @@ name: Deploy App
 on:
   push:
     tags:
-      - 'v*'
-      - '!v*-rc.*'
-      - 'app-v*'
-      - '!app-v*-rc.*'
+      - "v*"
+      - "!v*-rc.*"
+      - "app-v*"
+      - "!app-v*-rc.*"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -18,10 +19,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@boudra'
+          node-version: "22"
+          cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@boudra"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/app --include-workspace-root

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/relay/**'
-      - '.github/workflows/deploy-relay.yml'
+      - "packages/relay/**"
+      - ".github/workflows/deploy-relay.yml"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -17,8 +18,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/relay --include-workspace-root
@@ -30,4 +31,3 @@ jobs:
         run: cd packages/relay && npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/website/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'patches/**'
-      - '.github/workflows/deploy-website.yml'
+      - "packages/website/**"
+      - "package.json"
+      - "package-lock.json"
+      - "patches/**"
+      - ".github/workflows/deploy-website.yml"
   release:
     types: [published, edited]
   workflow_dispatch:
 
 jobs:
   deploy:
-    if: ${{ github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft) }}
+    if: ${{ github.repository == 'getpaseo/paseo' && (github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft)) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -23,8 +23,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/website --include-workspace-root

--- a/packages/server/src/server/bootstrap.smoke.test.ts
+++ b/packages/server/src/server/bootstrap.smoke.test.ts
@@ -40,6 +40,22 @@ describe("paseo daemon bootstrap", () => {
     }
   });
 
+  test("allows same-host origins across different ports for HTTP requests", async () => {
+    const daemonHandle = await createTestPaseoDaemon();
+    const origin = "http://127.0.0.1:5173";
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${daemonHandle.port}/api/health`, {
+        headers: { Origin: origin },
+      });
+
+      expect(response.ok).toBe(true);
+      expect(response.headers.get("access-control-allow-origin")).toBe(origin);
+    } finally {
+      await daemonHandle.close();
+    }
+  });
+
   test("fails fast when OpenAI speech provider is configured without credentials", async () => {
     const paseoHomeRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-openai-config-"));
     const paseoHome = path.join(paseoHomeRoot, ".paseo");

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "pino";
+import { isOriginAllowed } from "./origin-policy.js";
 
 export type ListenTarget =
   | { type: "tcp"; host: string; port: number }
@@ -256,7 +257,15 @@ export async function createPaseoDaemon(
 
     app.use((req, res, next) => {
       const origin = req.headers.origin;
-      if (origin && (allowedOrigins.has("*") || allowedOrigins.has(origin))) {
+      const requestHost = typeof req.headers.host === "string" ? req.headers.host : null;
+      if (
+        origin &&
+        isOriginAllowed({
+          origin,
+          requestHost,
+          allowedOrigins,
+        })
+      ) {
         res.setHeader("Access-Control-Allow-Origin", origin);
         res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
         res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");

--- a/packages/server/src/server/origin-policy.test.ts
+++ b/packages/server/src/server/origin-policy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import { isOriginAllowed, isSameHostOrigin } from "./origin-policy.js";
+
+describe("origin policy", () => {
+  test("allows same host across different ports", () => {
+    expect(isSameHostOrigin("http://192.0.2.10:5173", "192.0.2.10:6767")).toBe(true);
+    expect(isSameHostOrigin("https://devbox.example.test:8443", "devbox.example.test:6767")).toBe(
+      true,
+    );
+  });
+
+  test("rejects different hosts unless explicitly allowlisted", () => {
+    expect(
+      isOriginAllowed({
+        origin: "http://127.0.0.1:5173",
+        requestHost: "192.0.2.10:6767",
+        allowedOrigins: new Set<string>(),
+      }),
+    ).toBe(false);
+
+    expect(
+      isOriginAllowed({
+        origin: "http://127.0.0.1:5173",
+        requestHost: "192.0.2.10:6767",
+        allowedOrigins: new Set<string>(["http://127.0.0.1:5173"]),
+      }),
+    ).toBe(true);
+  });
+
+  test("allows missing origin for native and CLI clients", () => {
+    expect(
+      isOriginAllowed({
+        origin: undefined,
+        requestHost: "192.0.2.10:6767",
+        allowedOrigins: new Set<string>(),
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/server/src/server/origin-policy.ts
+++ b/packages/server/src/server/origin-policy.ts
@@ -1,0 +1,53 @@
+function parseOriginUrl(origin: string): URL | null {
+  try {
+    const parsed = new URL(origin);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function parseHostHeader(hostHeader: string): URL | null {
+  try {
+    return new URL(`http://${hostHeader}`);
+  } catch {
+    return null;
+  }
+}
+
+export function isSameHostOrigin(
+  origin: string | undefined,
+  requestHost: string | null | undefined,
+): boolean {
+  if (!origin || !requestHost) {
+    return false;
+  }
+
+  const originUrl = parseOriginUrl(origin);
+  const requestUrl = parseHostHeader(requestHost);
+  if (!originUrl || !requestUrl) {
+    return false;
+  }
+
+  return originUrl.hostname.toLowerCase() === requestUrl.hostname.toLowerCase();
+}
+
+export function isOriginAllowed(input: {
+  origin: string | undefined;
+  requestHost: string | null | undefined;
+  allowedOrigins: ReadonlySet<string>;
+}): boolean {
+  const { origin, requestHost, allowedOrigins } = input;
+  if (!origin) {
+    return true;
+  }
+
+  if (allowedOrigins.has("*") || allowedOrigins.has(origin)) {
+    return true;
+  }
+
+  return isSameHostOrigin(origin, requestHost);
+}

--- a/packages/server/src/server/websocket-server.origin-policy.test.ts
+++ b/packages/server/src/server/websocket-server.origin-policy.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test, vi } from "vitest";
+
+const wsModuleMock = vi.hoisted(() => {
+  class MockWebSocketServer {
+    static instances: MockWebSocketServer[] = [];
+    readonly handlers = new Map<string, (...args: any[]) => void>();
+    readonly options: Record<string, unknown>;
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      MockWebSocketServer.instances.push(this);
+    }
+
+    on(event: string, handler: (...args: any[]) => void) {
+      this.handlers.set(event, handler);
+      return this;
+    }
+
+    close() {
+      // no-op
+    }
+  }
+
+  return { MockWebSocketServer };
+});
+
+const sessionMock = vi.hoisted(() => {
+  class MockSession {
+    cleanup = vi.fn(async () => {});
+    handleMessage = vi.fn(async () => {});
+    handleBinaryFrame = vi.fn((_frame: unknown) => {});
+    getClientActivity = vi.fn(() => null);
+    resetPeakInflight = vi.fn(() => {});
+    getRuntimeMetrics = vi.fn(() => ({
+      checkoutDiffTargetCount: 0,
+      checkoutDiffSubscriptionCount: 0,
+      checkoutDiffWatcherCount: 0,
+      checkoutDiffFallbackRefreshTargetCount: 0,
+      terminalDirectorySubscriptionCount: 0,
+      terminalSubscriptionCount: 0,
+      inflightRequests: 0,
+      peakInflightRequests: 0,
+    }));
+  }
+
+  return { MockSession };
+});
+
+vi.mock("ws", () => ({
+  WebSocketServer: wsModuleMock.MockWebSocketServer,
+}));
+
+vi.mock("./session.js", () => ({
+  Session: sessionMock.MockSession,
+}));
+
+vi.mock("./push/token-store.js", () => ({
+  PushTokenStore: class {
+    getAllTokens(): string[] {
+      return [];
+    }
+  },
+}));
+
+vi.mock("./push/push-service.js", () => ({
+  PushService: class {
+    async sendPush(): Promise<void> {
+      // no-op
+    }
+  },
+}));
+
+import { VoiceAssistantWebSocketServer } from "./websocket-server.js";
+
+function createLogger() {
+  const logger = {
+    child: vi.fn(() => logger),
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return logger;
+}
+
+function createServer(allowedOrigins: Set<string> = new Set()) {
+  wsModuleMock.MockWebSocketServer.instances.length = 0;
+
+  return new VoiceAssistantWebSocketServer(
+    {} as any,
+    createLogger() as any,
+    "srv_test",
+    {
+      setAgentAttentionCallback: vi.fn(),
+      getAgent: vi.fn(() => null),
+      getMetricsSnapshot: vi.fn(() => ({
+        totalAgents: 0,
+        idleAgents: 0,
+        runningAgents: 0,
+        pendingPermissionAgents: 0,
+        erroredAgents: 0,
+      })),
+    } as any,
+    {} as any,
+    {} as any,
+    "/tmp/paseo-test",
+    {
+      onChange: vi.fn(() => () => {}),
+    } as any,
+    null,
+    { allowedOrigins },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    "1.2.3-test",
+    undefined,
+    undefined,
+    undefined,
+    {} as any,
+    {} as any,
+    {} as any,
+    {
+      subscribe: vi.fn(),
+      scheduleRefreshForCwd: vi.fn(),
+      getMetrics: vi.fn(() => ({
+        checkoutDiffTargetCount: 0,
+        checkoutDiffSubscriptionCount: 0,
+        checkoutDiffWatcherCount: 0,
+        checkoutDiffFallbackRefreshTargetCount: 0,
+      })),
+      dispose: vi.fn(),
+    } as any,
+  );
+}
+
+function getVerifyClient() {
+  const server = wsModuleMock.MockWebSocketServer.instances.at(-1);
+  expect(server).toBeDefined();
+  const verifyClient = server?.options.verifyClient;
+  expect(typeof verifyClient).toBe("function");
+  return verifyClient as (
+    info: { req: { headers?: Record<string, string>; socket?: { remoteAddress?: string } } },
+    callback: (result: boolean, code?: number, message?: string) => void,
+  ) => void;
+}
+
+describe("websocket server origin policy", () => {
+  test("accepts same-host websocket origins across different ports", () => {
+    createServer();
+    const verifyClient = getVerifyClient();
+    const callback = vi.fn();
+
+    verifyClient(
+      {
+        req: {
+          headers: {
+            host: "192.0.2.10:6767",
+            origin: "http://192.0.2.10:5173",
+          },
+        },
+      },
+      callback,
+    );
+
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
+  test("rejects different hosts that are not allowlisted", () => {
+    createServer();
+    const verifyClient = getVerifyClient();
+    const callback = vi.fn();
+
+    verifyClient(
+      {
+        req: {
+          headers: {
+            host: "192.0.2.10:6767",
+            origin: "http://198.51.100.20:5173",
+          },
+        },
+      },
+      callback,
+    );
+
+    expect(callback).toHaveBeenCalledWith(false, 403, "Origin not allowed");
+  });
+});

--- a/packages/server/src/server/websocket-server.origin-policy.test.ts
+++ b/packages/server/src/server/websocket-server.origin-policy.test.ts
@@ -114,6 +114,7 @@ function createServer(allowedOrigins: Set<string> = new Set()) {
     undefined,
     undefined,
     undefined,
+    undefined,
     "1.2.3-test",
     undefined,
     undefined,

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -38,6 +38,7 @@ import { PushTokenStore } from "./push/token-store.js";
 import { PushService } from "./push/push-service.js";
 import type { SpeechReadinessSnapshot, SpeechService } from "./speech/speech-runtime.js";
 import type { VoiceCallerContext, VoiceSpeakHandler } from "./voice-types.js";
+import { isOriginAllowed } from "./origin-policy.js";
 import {
   computeShouldNotifyClient,
   computeShouldSendPush,
@@ -450,12 +451,13 @@ export class VoiceAssistantWebSocketServer {
           callback(false, 403, "Host not allowed");
           return;
         }
-        const sameOrigin =
-          !!origin &&
-          !!requestHost &&
-          (origin === `http://${requestHost}` || origin === `https://${requestHost}`);
-
-        if (!origin || allowedOrigins.has("*") || allowedOrigins.has(origin) || sameOrigin) {
+        if (
+          isOriginAllowed({
+            origin,
+            requestHost,
+            allowedOrigins,
+          })
+        ) {
           callback(true);
         } else {
           this.incrementRuntimeCounter("originRejected");

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1,7 +1,13 @@
 import { z } from "zod";
 import { AGENT_LIFECYCLE_STATUSES } from "./agent-lifecycle.js";
 import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "../server/agent/agent-title-limits.js";
-import { AgentProviderSchema } from "../server/agent/provider-manifest.js";
+import {
+  AgentProviderSchema,
+  AgentProviderSchema as ImportedAgentProviderSchema,
+} from "../server/agent/provider-manifest.js";
+// COMPAT(rn-dev-client): Metro can evaluate this import path as undefined during circular init.
+const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ??
+  z.string()) as z.ZodType<string>;
 import { TOOL_CALL_ICON_NAMES } from "../server/agent/agent-sdk-types.js";
 import {
   ChatCreateRequestSchema,

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -852,7 +852,7 @@ export const GetProvidersSnapshotRequestMessageSchema = z.object({
 export const RefreshProvidersSnapshotRequestMessageSchema = z.object({
   type: z.literal("refresh_providers_snapshot_request"),
   cwd: z.string().optional(),
-  providers: z.array(AgentProviderSchema).optional(),
+  providers: z.array(AgentProviderValueSchema).optional(),
   requestId: z.string(),
 });
 


### PR DESCRIPTION
## Summary
- Allows same-host origins across different ports so phone and dev-client flows can reach local daemon safely.

## 2026-04-16 Integrated Device Verification
- Verified on physical Android device over USB.
- Direct local connection path: pass.
- Phone message send from current mobile UI: pass.
- Existing tmux-backed Codex session wake: pass.
- Assistant reply render on phone: pass. Exact token `TMUX_MOBILE_PING_4`.
- History scroll check: `428` frames, `3` janky (`0.70%`), `p95 18ms`, `p99 19ms`.
- Sensitive local details, device identifiers, private endpoints, and local artifact paths are intentionally omitted from this public PR.

## Branch-Specific Coverage
- Same-host cross-port local connection path was exercised successfully during current direct-connect device run.

## Fork CI
- Upstream PR currently reports no native GitHub checks.
- Latest fork `CI` success for this branch: https://github.com/Jacobinwwey/paseo/actions/runs/24545930971
