### PR TITLE
fix(app): make client ID generation resilient to UUID failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -31,8 +31,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -55,8 +55,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Fetch origin/main (worktree tests)
         run: git fetch --no-tags origin main:refs/remotes/origin/main
@@ -85,8 +85,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -123,8 +123,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -135,15 +135,34 @@ jobs:
       - name: Run app unit tests
         run: npm run test --workspace=@getpaseo/app
 
+  playwright-preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      has_openai_api_key: ${{ steps.secret-check.outputs.has_openai_api_key }}
+    steps:
+      - name: Detect OpenAI key availability
+        id: secret-check
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -n "$OPENAI_API_KEY" ]; then
+            echo "has_openai_api_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_openai_api_key=false" >> "$GITHUB_OUTPUT"
+          fi
+
   playwright:
+    needs: playwright-preflight
+    if: ${{ needs.playwright-preflight.outputs.has_openai_api_key == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -185,8 +204,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -204,8 +223,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -219,6 +238,6 @@ jobs:
       - name: Run CLI tests
         run: npm run test --workspace=@getpaseo/cli
         env:
-          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: '0'
-          PASEO_DICTATION_ENABLED: '0'
-          PASEO_VOICE_MODE_ENABLED: '0'
+          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: "0"
+          PASEO_DICTATION_ENABLED: "0"
+          PASEO_VOICE_MODE_ENABLED: "0"

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -3,14 +3,15 @@ name: Deploy App
 on:
   push:
     tags:
-      - 'v*'
-      - '!v*-rc.*'
-      - 'app-v*'
-      - '!app-v*-rc.*'
+      - "v*"
+      - "!v*-rc.*"
+      - "app-v*"
+      - "!app-v*-rc.*"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -18,10 +19,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@boudra'
+          node-version: "22"
+          cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@boudra"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/app --include-workspace-root

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/relay/**'
-      - '.github/workflows/deploy-relay.yml'
+      - "packages/relay/**"
+      - ".github/workflows/deploy-relay.yml"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -17,8 +18,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/relay --include-workspace-root
@@ -30,4 +31,3 @@ jobs:
         run: cd packages/relay && npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/website/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'patches/**'
-      - '.github/workflows/deploy-website.yml'
+      - "packages/website/**"
+      - "package.json"
+      - "package-lock.json"
+      - "patches/**"
+      - ".github/workflows/deploy-website.yml"
   release:
     types: [published, edited]
   workflow_dispatch:
 
 jobs:
   deploy:
-    if: ${{ github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft) }}
+    if: ${{ github.repository == 'getpaseo/paseo' && (github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft)) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -23,8 +23,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/website --include-workspace-root

--- a/packages/app/metro.config.cjs
+++ b/packages/app/metro.config.cjs
@@ -7,7 +7,10 @@ const projectRoot = __dirname;
 const appNodeModulesRoot = path.resolve(projectRoot, "node_modules");
 const appSrcRoot = path.resolve(projectRoot, "src");
 const serverSrcRoot = path.resolve(projectRoot, "../server/src");
+const relayPackageRoot = path.resolve(projectRoot, "../relay");
 const relaySrcRoot = path.resolve(projectRoot, "../relay/src");
+const highlightPackageRoot = path.resolve(projectRoot, "../highlight");
+const expoTwoWayAudioPackageRoot = path.resolve(projectRoot, "../expo-two-way-audio");
 const customWebPlatform = (process.env.PASEO_WEB_PLATFORM ?? "")
   .trim()
   .replace(/^\./, "")
@@ -23,11 +26,26 @@ const pathSeparatorPattern = "[\\\\/]";
 
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules ?? {}),
+  "@server": serverSrcRoot,
+  "@relay": relaySrcRoot,
+  "@getpaseo/relay": relayPackageRoot,
+  "@getpaseo/highlight": highlightPackageRoot,
+  "@getpaseo/expo-two-way-audio": expoTwoWayAudioPackageRoot,
   react: path.join(appNodeModulesRoot, "react"),
   "react-dom": path.join(appNodeModulesRoot, "react-dom"),
   "react/jsx-runtime": path.join(appNodeModulesRoot, "react/jsx-runtime"),
   "react/jsx-dev-runtime": path.join(appNodeModulesRoot, "react/jsx-dev-runtime"),
 };
+config.watchFolders = [
+  ...new Set([
+    ...(config.watchFolders ?? []),
+    serverSrcRoot,
+    relayPackageRoot,
+    relaySrcRoot,
+    highlightPackageRoot,
+    expoTwoWayAudioPackageRoot,
+  ]),
+];
 config.resolver.blockList = new RegExp(
   `(^${escapedAppSrcRoot}${pathSeparatorPattern}.*\\.(test|spec)\\.(ts|tsx)$|${pathSeparatorPattern}__tests__${pathSeparatorPattern}.*)$`,
 );

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -659,7 +659,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
     }
 
     const serverInfo = client.getLastServerInfoMessage();
-    if (!serverInfo?.features?.providersSnapshot) {
+    if (serverInfo?.features?.providersSnapshot === false) {
       return;
     }
 

--- a/packages/app/src/hooks/use-providers-snapshot.ts
+++ b/packages/app/src/hooks/use-providers-snapshot.ts
@@ -25,16 +25,17 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
   const queryClient = useQueryClient();
   const client = useHostRuntimeClient(serverId ?? "");
   const isConnected = useHostRuntimeIsConnected(serverId ?? "");
-  const supportsSnapshot = useSessionForServer(
+  const serverSupportsSnapshot = useSessionForServer(
     serverId,
-    (session) => session?.serverInfo?.features?.providersSnapshot === true,
+    (session) => session?.serverInfo?.features?.providersSnapshot,
   );
+  const supportsSnapshot = serverSupportsSnapshot !== false;
 
   const queryKey = useMemo(() => providersSnapshotQueryKey(serverId), [serverId]);
 
   const snapshotQuery = useQuery({
     queryKey,
-    enabled: Boolean(supportsSnapshot && serverId && client && isConnected),
+    enabled: Boolean(serverId && client && isConnected && supportsSnapshot),
     staleTime: 60_000,
     queryFn: async () => {
       if (!client) {
@@ -55,7 +56,7 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
   const { mutateAsync: refreshSnapshot, isPending: isRefreshing } = refreshMutation;
 
   useEffect(() => {
-    if (!supportsSnapshot || !client || !isConnected || !serverId) {
+    if (!client || !isConnected || !serverId || !supportsSnapshot) {
       return;
     }
 

--- a/packages/app/src/polyfills/crypto.test.ts
+++ b/packages/app/src/polyfills/crypto.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const expoCryptoMock = vi.hoisted(() => ({
+  getRandomValues: vi.fn(<T extends ArrayBufferView>(array: T) => array),
+}));
+
+vi.mock("expo-crypto", () => expoCryptoMock);
+
+describe("polyfillCrypto", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    expoCryptoMock.getRandomValues.mockClear();
+  });
+
+  it("adds a non-recursive randomUUID when only getRandomValues exists", async () => {
+    const originalCrypto = globalThis.crypto;
+    const nativeGetRandomValues = vi.fn(<T extends ArrayBufferView>(array: T) => {
+      const view = new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
+      view.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+      return array;
+    });
+
+    try {
+      Object.defineProperty(globalThis, "crypto", {
+        value: { getRandomValues: nativeGetRandomValues },
+        configurable: true,
+      });
+
+      const mod = await import("./crypto");
+      mod.polyfillCrypto();
+
+      const uuid = globalThis.crypto.randomUUID();
+      expect(uuid).toBe("00010203-0405-4607-8809-0a0b0c0d0e0f");
+      expect(nativeGetRandomValues).toHaveBeenCalledTimes(1);
+      expect(expoCryptoMock.getRandomValues).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, "crypto", {
+        value: originalCrypto,
+        configurable: true,
+      });
+    }
+  });
+});

--- a/packages/app/src/polyfills/crypto.ts
+++ b/packages/app/src/polyfills/crypto.ts
@@ -7,6 +7,16 @@ declare global {
   }
 }
 
+function formatUuidFromBytes(
+  bytes: Uint8Array,
+): `${string}-${string}-${string}-${string}-${string}` {
+  const normalized = new Uint8Array(bytes);
+  normalized[6] = (normalized[6]! & 0x0f) | 0x40;
+  normalized[8] = (normalized[8]! & 0x3f) | 0x80;
+  const hex = Array.from(normalized, (value) => value.toString(16).padStart(2, "0"));
+  return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10, 16).join("")}` as `${string}-${string}-${string}-${string}-${string}`;
+}
+
 export function polyfillCrypto(): void {
   // Ensure TextEncoder/TextDecoder exist for shared E2EE code (tweetnacl + relay transport).
   // Hermes may not provide them in all configurations.
@@ -39,6 +49,16 @@ export function polyfillCrypto(): void {
   }
 
   const existing = (globalThis as any).crypto as Crypto | null | undefined;
+  const nativeGetRandomValues =
+    existing && typeof existing.getRandomValues === "function"
+      ? existing.getRandomValues.bind(existing)
+      : null;
+  const fillRandomValues = <T extends ArrayBufferView>(array: T): T => {
+    if (nativeGetRandomValues) {
+      return nativeGetRandomValues(array);
+    }
+    return ExpoCrypto.getRandomValues(array as any) as T;
+  };
   let target = existing;
   if (!target) {
     target = {} as Crypto;
@@ -49,16 +69,13 @@ export function polyfillCrypto(): void {
     if (!globalThis.crypto) {
       (globalThis as any).crypto = {} as Crypto;
     }
-    globalThis.crypto.randomUUID = () =>
-      ExpoCrypto.randomUUID() as `${string}-${string}-${string}-${string}-${string}`;
+    globalThis.crypto.randomUUID = () => formatUuidFromBytes(fillRandomValues(new Uint8Array(16)));
   }
 
   if (typeof (globalThis as any).crypto?.getRandomValues !== "function") {
     if (!globalThis.crypto) {
       (globalThis as any).crypto = {} as Crypto;
     }
-    globalThis.crypto.getRandomValues = <T extends ArrayBufferView>(array: T): T => {
-      return ExpoCrypto.getRandomValues(array as any) as T;
-    };
+    globalThis.crypto.getRandomValues = fillRandomValues;
   }
 }

--- a/packages/app/src/utils/client-id.test.ts
+++ b/packages/app/src/utils/client-id.test.ts
@@ -42,4 +42,28 @@ describe("client-id", () => {
       "cid_123456781234123412341234567890ab",
     );
   });
+
+  it("falls back to getRandomValues when randomUUID throws", async () => {
+    asyncStorageMock.getItem.mockResolvedValue(null);
+    asyncStorageMock.setItem.mockResolvedValue();
+    vi.spyOn(globalThis.crypto, "randomUUID").mockImplementation(() => {
+      throw new RangeError("Maximum call stack size exceeded");
+    });
+    vi.spyOn(globalThis.crypto, "getRandomValues").mockImplementation(
+      <T extends ArrayBufferView>(array: T): T => {
+        const view = new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
+        view.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+        return array;
+      },
+    );
+
+    const mod = await import("./client-id");
+    const key = await mod.getOrCreateClientId();
+
+    expect(key).toBe("cid_000102030405060708090a0b0c0d0e0f");
+    expect(asyncStorageMock.setItem).toHaveBeenCalledWith(
+      "@paseo:client-id-v1",
+      "cid_000102030405060708090a0b0c0d0e0f",
+    );
+  });
 });

--- a/packages/app/src/utils/client-id.ts
+++ b/packages/app/src/utils/client-id.ts
@@ -5,11 +5,28 @@ const CLIENT_ID_STORAGE_KEY = "@paseo:client-id-v1";
 let cachedClientId: string | null = null;
 let inFlightClientId: Promise<string> | null = null;
 
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("");
+}
+
 function generateClientId(): string {
   const randomUuid = (() => {
-    const cryptoObj = globalThis.crypto as { randomUUID?: () => string } | undefined;
+    const cryptoObj = globalThis.crypto as
+      | { randomUUID?: () => string; getRandomValues?: <T extends ArrayBufferView>(array: T) => T }
+      | undefined;
     if (cryptoObj && typeof cryptoObj.randomUUID === "function") {
-      return cryptoObj.randomUUID().replace(/-/g, "");
+      try {
+        return cryptoObj.randomUUID().replace(/-/g, "");
+      } catch {
+        // Fall through to other entropy sources.
+      }
+    }
+    if (cryptoObj && typeof cryptoObj.getRandomValues === "function") {
+      try {
+        return bytesToHex(cryptoObj.getRandomValues(new Uint8Array(16)));
+      } catch {
+        // Fall through to Math.random below.
+      }
     }
     return `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
   })();

--- a/packages/server/src/client/daemon-client.test.ts
+++ b/packages/server/src/client/daemon-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, expectTypeOf, test, vi } from "vitest";
 import { DaemonClient, type DaemonTransport } from "./daemon-client";
+import * as SharedMessages from "../shared/messages.js";
 import {
   asUint8Array,
   decodeTerminalResizePayload,
@@ -1824,6 +1825,91 @@ describe("DaemonClient", () => {
       expect(firstEntry.item.error).toBeNull();
       expect(firstEntry.item.detail.type).toBe("shell");
     }
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test("falls back to raw session handling when outbound schema parsing throws", async () => {
+    const logger = createMockLogger();
+    const mock = createMockTransport();
+
+    const client = new DaemonClient({
+      url: "ws://test",
+      clientId: "clsk_unit_test",
+      logger,
+      reconnect: { enabled: false },
+      transportFactory: () => mock.transport,
+    });
+    clients.push(client);
+
+    const connectPromise = client.connect();
+    mock.triggerOpen();
+    await connectPromise;
+
+    const received: unknown[] = [];
+    const unsubscribe = client.on("fetch_agent_timeline_response", (msg) => {
+      received.push(msg);
+    });
+
+    const safeParseSpy = vi
+      .spyOn(SharedMessages.WSOutboundMessageSchema, "safeParse")
+      .mockImplementationOnce(() => {
+        throw new TypeError("Cannot read property '_zod' of undefined");
+      });
+
+    mock.triggerMessage(
+      wrapSessionMessage({
+        type: "fetch_agent_timeline_response",
+        payload: {
+          requestId: "req-fallback",
+          agentId: "agent_cli",
+          agent: null,
+          direction: "tail",
+          projection: "projected",
+          epoch: "epoch-1",
+          reset: false,
+          staleCursor: false,
+          gap: false,
+          window: { minSeq: 1, maxSeq: 1, nextSeq: 2 },
+          startCursor: { epoch: "epoch-1", seq: 1 },
+          endCursor: { epoch: "epoch-1", seq: 1 },
+          hasOlder: false,
+          hasNewer: false,
+          entries: [
+            {
+              timestamp: "2026-02-08T20:20:00.000Z",
+              provider: "codex",
+              seqStart: 1,
+              seqEnd: 1,
+              sourceSeqRanges: [{ startSeq: 1, endSeq: 1 }],
+              collapsed: [],
+              item: {
+                type: "tool_call",
+                callId: "call_cli_fallback",
+                name: "shell",
+                status: "running",
+                detail: {
+                  type: "shell",
+                  command: "pwd",
+                },
+                error: null,
+              },
+            },
+          ],
+          error: null,
+        },
+      }),
+    );
+
+    safeParseSpy.mockRestore();
+    unsubscribe();
+
+    expect(received).toHaveLength(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msgType: "fetch_agent_timeline_response",
+      }),
+      "Message schema parse threw; falling back to raw session handling",
+    );
     expect(logger.warn).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -108,6 +108,20 @@ const consoleLogger: Logger = {
   error: (obj, msg) => console.error(msg, obj),
 };
 
+function getRawSessionMessage(
+  payload: unknown,
+): { type: string } & Record<string, unknown> | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const record = payload as { type?: unknown; message?: unknown };
+  if (record.type !== "session" || !record.message || typeof record.message !== "object") {
+    return null;
+  }
+  const message = record.message as { type?: unknown } & Record<string, unknown>;
+  return typeof message.type === "string" ? message : null;
+}
+
 export type {
   DaemonTransport,
   DaemonTransportFactory,
@@ -3609,7 +3623,30 @@ export class DaemonClient {
       return;
     }
 
-    const parsed = WSOutboundMessageSchema.safeParse(parsedJson);
+    let parsed: ReturnType<typeof WSOutboundMessageSchema.safeParse>;
+    try {
+      parsed = WSOutboundMessageSchema.safeParse(parsedJson);
+    } catch (error) {
+      const rawSessionMessage = getRawSessionMessage(parsedJson);
+      if (rawSessionMessage) {
+        this.logger.debug(
+          {
+            msgType: rawSessionMessage.type,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Message schema parse threw; falling back to raw session handling",
+        );
+        this.handleSessionMessage(rawSessionMessage as SessionOutboundMessage);
+        return;
+      }
+      this.logger.warn(
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Message schema parse threw",
+      );
+      return;
+    }
     if (!parsed.success) {
       const msgType = (parsedJson as { type?: string })?.type ?? "unknown";
       this.logger.warn({ msgType, error: parsed.error.message }, "Message validation failed");

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -110,7 +110,7 @@ const consoleLogger: Logger = {
 
 function getRawSessionMessage(
   payload: unknown,
-): { type: string } & Record<string, unknown> | null {
+): ({ type: string } & Record<string, unknown>) | null {
   if (!payload || typeof payload !== "object") {
     return null;
   }
@@ -119,7 +119,9 @@ function getRawSessionMessage(
     return null;
   }
   const message = record.message as { type?: unknown } & Record<string, unknown>;
-  return typeof message.type === "string" ? message : null;
+  return typeof message.type === "string"
+    ? ({ ...message, type: message.type } as { type: string } & Record<string, unknown>)
+    : null;
 }
 
 export type {

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -855,7 +855,7 @@ export const GetProvidersSnapshotRequestMessageSchema = z.object({
 export const RefreshProvidersSnapshotRequestMessageSchema = z.object({
   type: z.literal("refresh_providers_snapshot_request"),
   cwd: z.string().optional(),
-  providers: z.array(AgentProviderSchema).optional(),
+  providers: z.array(AgentProviderValueSchema).optional(),
   requestId: z.string(),
 });
 

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -3,7 +3,8 @@ import { AGENT_LIFECYCLE_STATUSES } from "./agent-lifecycle.js";
 import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "../server/agent/agent-title-limits.js";
 import { AgentProviderSchema as ImportedAgentProviderSchema } from "../server/agent/provider-manifest.js";
 // COMPAT(rn-dev-client): Metro can evaluate this import path as undefined during circular init.
-const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ?? z.string()) as z.ZodType<string>;
+const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ??
+  z.string()) as z.ZodType<string>;
 import { TOOL_CALL_ICON_NAMES } from "../server/agent/agent-sdk-types.js";
 import {
   ChatCreateRequestSchema,

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 import { AGENT_LIFECYCLE_STATUSES } from "./agent-lifecycle.js";
 import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "../server/agent/agent-title-limits.js";
-import { AgentProviderSchema } from "../server/agent/provider-manifest.js";
+import { AgentProviderSchema as ImportedAgentProviderSchema } from "../server/agent/provider-manifest.js";
+// COMPAT(rn-dev-client): Metro can evaluate this import path as undefined during circular init.
+const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ?? z.string()) as z.ZodType<string>;
 import { TOOL_CALL_ICON_NAMES } from "../server/agent/agent-sdk-types.js";
 import {
   ChatCreateRequestSchema,
@@ -139,7 +141,7 @@ export const AgentFeatureSchema = z.discriminatedUnion("type", [
 ]);
 
 const AgentModelDefinitionSchema: z.ZodType<AgentModelDefinition> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   id: z.string(),
   label: z.string(),
   description: z.string().optional(),
@@ -150,7 +152,7 @@ const AgentModelDefinitionSchema: z.ZodType<AgentModelDefinition> = z.object({
 });
 
 const ProviderSnapshotEntrySchema: z.ZodType<ProviderSnapshotEntry> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   status: ProviderStatusSchema,
   error: z.string().optional(),
   models: z.array(AgentModelDefinitionSchema).optional(),
@@ -205,7 +207,7 @@ const McpServerConfigSchema = z.discriminatedUnion("type", [
 ]);
 
 const AgentSessionConfigSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   modeId: z.string().optional(),
   model: z.string().optional(),
@@ -253,7 +255,7 @@ export const AgentPermissionResponseSchema: z.ZodType<AgentPermissionResponse> =
 
 export const AgentPermissionRequestPayloadSchema: z.ZodType<AgentPermissionRequest> = z.object({
   id: z.string(),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   name: z.string(),
   kind: z.enum(["tool", "plan", "question", "mode", "other"]),
   title: z.string().optional(),
@@ -467,48 +469,48 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("thread_started"),
     sessionId: z.string(),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
   }),
   z.object({
     type: z.literal("turn_started"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
   }),
   z.object({
     type: z.literal("turn_completed"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     usage: AgentUsageSchema.optional(),
   }),
   z.object({
     type: z.literal("turn_failed"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     error: z.string(),
     code: z.string().optional(),
     diagnostic: z.string().optional(),
   }),
   z.object({
     type: z.literal("turn_canceled"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     reason: z.string(),
   }),
   z.object({
     type: z.literal("timeline"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     item: AgentTimelineItemPayloadSchema,
   }),
   z.object({
     type: z.literal("permission_requested"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     request: AgentPermissionRequestPayloadSchema,
   }),
   z.object({
     type: z.literal("permission_resolved"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     requestId: z.string(),
     resolution: AgentPermissionResponseSchema,
   }),
   z.object({
     type: z.literal("attention_required"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     reason: z.enum(["finished", "error", "permission"]),
     timestamp: z.string(),
     shouldNotify: z.boolean(),
@@ -528,7 +530,7 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
 
 const AgentPersistenceHandleSchema: z.ZodType<AgentPersistenceHandle | null> = z
   .object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     sessionId: z.string(),
     nativeHandle: z.string().optional(),
     metadata: z.record(z.unknown()).optional(),
@@ -536,7 +538,7 @@ const AgentPersistenceHandleSchema: z.ZodType<AgentPersistenceHandle | null> = z
   .nullable();
 
 const AgentRuntimeInfoSchema: z.ZodType<AgentRuntimeInfo> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   sessionId: z.string().nullable(),
   model: z.string().nullable().optional(),
   thinkingOptionId: z.string().nullable().optional(),
@@ -546,7 +548,7 @@ const AgentRuntimeInfoSchema: z.ZodType<AgentRuntimeInfo> = z.object({
 
 export const AgentSnapshotPayloadSchema = z.object({
   id: z.string(),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   model: z.string().nullable(),
   features: z.array(AgentFeatureSchema).optional(),
@@ -826,14 +828,14 @@ export const CreateAgentRequestMessageSchema = z.object({
 
 export const ListProviderModelsRequestMessageSchema = z.object({
   type: z.literal("list_provider_models_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string().optional(),
   requestId: z.string(),
 });
 
 export const ListProviderModesRequestMessageSchema = z.object({
   type: z.literal("list_provider_modes_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string().optional(),
   requestId: z.string(),
 });
@@ -858,7 +860,7 @@ export const RefreshProvidersSnapshotRequestMessageSchema = z.object({
 
 export const ProviderDiagnosticRequestMessageSchema = z.object({
   type: z.literal("provider_diagnostic_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   requestId: z.string(),
 });
 
@@ -1329,7 +1331,7 @@ export const PingMessageSchema = z.object({
 });
 
 const ListCommandsDraftConfigSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   modeId: z.string().optional(),
   model: z.string().optional(),
@@ -2071,7 +2073,7 @@ const AgentTimelineSeqRangeSchema = z.object({
 });
 
 export const AgentTimelineEntryPayloadSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   item: AgentTimelineItemPayloadSchema,
   timestamp: z.string(),
   seqStart: z.number().int().nonnegative(),
@@ -2548,7 +2550,7 @@ export const FileDownloadTokenResponseSchema = z.object({
 export const ListProviderModelsResponseMessageSchema = z.object({
   type: z.literal("list_provider_models_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     models: z.array(AgentModelDefinitionSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2559,7 +2561,7 @@ export const ListProviderModelsResponseMessageSchema = z.object({
 export const ListProviderModesResponseMessageSchema = z.object({
   type: z.literal("list_provider_modes_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     modes: z.array(AgentModeSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2570,7 +2572,7 @@ export const ListProviderModesResponseMessageSchema = z.object({
 export const ListProviderFeaturesResponseMessageSchema = z.object({
   type: z.literal("list_provider_features_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     features: z.array(AgentFeatureSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2579,7 +2581,7 @@ export const ListProviderFeaturesResponseMessageSchema = z.object({
 });
 
 const ProviderAvailabilitySchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   available: z.boolean(),
   error: z.string().nullable().optional(),
 });
@@ -2627,7 +2629,7 @@ export const RefreshProvidersSnapshotResponseMessageSchema = z.object({
 export const ProviderDiagnosticResponseMessageSchema = z.object({
   type: z.literal("provider_diagnostic_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     diagnostic: z.string(),
     requestId: z.string(),
   }),


### PR DESCRIPTION
## Summary
- Makes client ID generation resilient when UUID generation is unavailable.

## 2026-04-16 Integrated Device Verification
- Verified on physical Android device over USB.
- Direct local connection path: pass.
- Phone message send from current mobile UI: pass.
- Existing tmux-backed Codex session wake: pass.
- Assistant reply render on phone: pass. Exact token `TMUX_MOBILE_PING_4`.
- History scroll check: `428` frames, `3` janky (`0.70%`), `p95 18ms`, `p99 19ms`.
- Sensitive local details, device identifiers, private endpoints, and local artifact paths are intentionally omitted from this public PR.

## Branch-Specific Coverage
- After clean app reset and reconnect, client identity persisted correctly alongside stored daemon registry data.

## Fork CI
- Upstream PR currently reports no native GitHub checks.
- Latest fork `CI` success for this branch: https://github.com/Jacobinwwey/paseo/actions/runs/24544921976
