### PR TITLE
fix(server): git subprocess concurrency pool to prevent zombie accumulation

### DIFF
--- a/packages/server/src/server/checkout-diff-manager.ts
+++ b/packages/server/src/server/checkout-diff-manager.ts
@@ -1,15 +1,12 @@
 import { watch, type FSWatcher } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
-import { exec } from "child_process";
-import { promisify } from "util";
 import type pino from "pino";
 import type { SubscribeCheckoutDiffRequest, SessionOutboundMessage } from "./messages.js";
 import { getCheckoutDiff } from "../utils/checkout-git.js";
 import { expandTilde } from "../utils/path.js";
 import { READ_ONLY_GIT_ENV, resolveCheckoutGitDir, toCheckoutError } from "./checkout-git-utils.js";
-
-const execAsync = promisify(exec);
+import { gitExec } from "../utils/git-process-pool.js";
 
 const CHECKOUT_DIFF_WATCH_DEBOUNCE_MS = 150;
 const CHECKOUT_DIFF_FALLBACK_REFRESH_MS = 5_000;
@@ -177,7 +174,7 @@ export class CheckoutDiffManager {
 
   private async resolveCheckoutWatchRoot(cwd: string): Promise<string | null> {
     try {
-      const { stdout } = await execAsync("git rev-parse --path-format=absolute --show-toplevel", {
+      const { stdout } = await gitExec("git rev-parse --path-format=absolute --show-toplevel", {
         cwd,
         env: READ_ONLY_GIT_ENV,
       });

--- a/packages/server/src/server/checkout-git-utils.ts
+++ b/packages/server/src/server/checkout-git-utils.ts
@@ -1,12 +1,9 @@
-import { exec } from "child_process";
-import { promisify } from "util";
 import {
   MergeConflictError,
   MergeFromBaseConflictError,
   NotGitRepoError,
 } from "../utils/checkout-git.js";
-
-const execAsync = promisify(exec);
+import { gitExec } from "../utils/git-process-pool.js";
 
 export const READ_ONLY_GIT_ENV: NodeJS.ProcessEnv = {
   ...process.env,
@@ -22,7 +19,7 @@ export type CheckoutErrorPayload = {
 
 export async function resolveCheckoutGitDir(cwd: string): Promise<string | null> {
   try {
-    const { stdout } = await execAsync("git rev-parse --absolute-git-dir", {
+    const { stdout } = await gitExec("git rev-parse --absolute-git-dir", {
       cwd,
       env: READ_ONLY_GIT_ENV,
     });

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 import { stat } from "fs/promises";
 import { exec, execFile } from "node:child_process";
 import { promisify } from "util";
+import { gitExec, gitExecFile } from "../utils/git-process-pool.js";
 import { resolve, sep } from "path";
 import { homedir } from "node:os";
 import { z } from "zod";
@@ -181,8 +182,19 @@ import {
   registerPendingWorktreeWorkspace as registerPendingWorktreeWorkspaceSession,
 } from "./worktree-session.js";
 
-const execAsync = promisify(exec);
-const execFileAsync = promisify(execFile);
+const rawExecAsync = promisify(exec);
+const rawExecFileAsync = promisify(execFile);
+
+const execAsync = (
+  command: string,
+  options: Parameters<typeof rawExecAsync>[1] & { timeout?: number } = {},
+) => gitExec(command, options as Parameters<typeof gitExec>[1]);
+
+const execFileAsync = (
+  file: string,
+  args: string[],
+  options: Parameters<typeof rawExecFileAsync>[2] & { timeout?: number } = {},
+) => gitExecFile(file, args, options as Parameters<typeof gitExecFile>[2]);
 const MAX_INITIAL_AGENT_TITLE_CHARS = Math.min(60, MAX_EXPLICIT_AGENT_TITLE_CHARS);
 const pendingAgentInitializations = new Map<string, Promise<ManagedAgent>>();
 const DEFAULT_AGENT_PROVIDER = AGENT_PROVIDER_IDS[0];

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -1,8 +1,6 @@
-import { execFile } from "node:child_process";
 import { watch, type FSWatcher } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
-import { promisify } from "node:util";
 import type pino from "pino";
 import type { CheckoutContext } from "../utils/checkout-git.js";
 import {
@@ -14,8 +12,7 @@ import {
   resolveAbsoluteGitDir,
 } from "../utils/checkout-git.js";
 import { normalizeWorkspaceId } from "./workspace-registry-model.js";
-
-const execFileAsync = promisify(execFile);
+import { gitExecFile } from "../utils/git-process-pool.js";
 
 const WORKSPACE_GIT_WATCH_DEBOUNCE_MS = 500;
 const BACKGROUND_GIT_FETCH_INTERVAL_MS = 180_000;
@@ -587,8 +584,9 @@ function buildNotGitSnapshot(cwd: string): WorkspaceGitRuntimeSnapshot {
 }
 
 async function runGitFetch(cwd: string): Promise<void> {
-  await execFileAsync("git", ["fetch", "origin", "--prune"], {
+  await gitExecFile("git", ["fetch", "origin", "--prune"], {
     cwd,
+    timeout: 120_000,
     env: {
       ...process.env,
       GIT_TERMINAL_PROMPT: "0",

--- a/packages/server/src/server/worktree-bootstrap.ts
+++ b/packages/server/src/server/worktree-bootstrap.ts
@@ -1,7 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
 import type { Logger } from "pino";
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
 import { sep } from "node:path";
 import type { TerminalManager } from "../terminal/terminal-manager.js";
 import type { TerminalSession } from "../terminal/terminal.js";
@@ -50,7 +48,11 @@ const READ_ONLY_GIT_ENV: NodeJS.ProcessEnv = {
   ...process.env,
   GIT_OPTIONAL_LOCKS: "0",
 };
-const execAsync = promisify(exec);
+import { gitExec } from "../utils/git-process-pool.js";
+const execAsync = (
+  command: string,
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number } = {},
+) => gitExec(command, options);
 const worktreeSetupEligibility = new WeakMap<WorktreeConfig, boolean>();
 
 type MiddleTruncationAccumulator = {

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -1,5 +1,3 @@
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
 import type { Logger } from "pino";
 import { v4 as uuidv4 } from "uuid";
 
@@ -38,7 +36,11 @@ import {
 } from "../utils/worktree.js";
 import { READ_ONLY_GIT_ENV, toCheckoutError } from "./checkout-git-utils.js";
 
-const execAsync = promisify(exec);
+import { gitExec } from "../utils/git-process-pool.js";
+const execAsync = (
+  command: string,
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number } = {},
+) => gitExec(command, options);
 const SAFE_GIT_REF_PATTERN = /^[A-Za-z0-9._\/-]+$/;
 
 export type NormalizedGitOptions = {

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -10,9 +10,22 @@ import { parseAndHighlightDiff } from "../server/utils/diff-highlighter.js";
 import { findExecutable } from "./executable.js";
 import { isPaseoOwnedWorktreeCwd } from "./worktree.js";
 import { requirePaseoWorktreeBaseRefName } from "./worktree-metadata.js";
+import { gitExec, gitExecFile, acquireGitSlot } from "./git-process-pool.js";
 
-const execAsync = promisify(exec);
-const execFileAsync = promisify(execFile);
+const rawExecAsync = promisify(exec);
+const rawExecFileAsync = promisify(execFile);
+
+// Pool-aware wrappers: concurrency-limited + 30s default timeout.
+const execAsync = (
+  command: string,
+  options: Parameters<typeof rawExecAsync>[1] & { timeout?: number } = {},
+) => gitExec(command, options as Parameters<typeof gitExec>[1]);
+
+const execFileAsync = (
+  file: string,
+  args: string[],
+  options: Parameters<typeof rawExecFileAsync>[2] & { timeout?: number } = {},
+) => gitExecFile(file, args, options as Parameters<typeof gitExecFile>[2]);
 const READ_ONLY_GIT_ENV: NodeJS.ProcessEnv = {
   ...process.env,
   GIT_OPTIONAL_LOCKS: "0",
@@ -77,6 +90,8 @@ type LimitedTextResult = {
   signal: NodeJS.Signals | null;
 };
 
+const SPAWN_TIMEOUT_MS = 30_000;
+
 async function spawnLimitedText(params: {
   cmd: string;
   args: string[];
@@ -87,65 +102,89 @@ async function spawnLimitedText(params: {
 }): Promise<LimitedTextResult> {
   const accept = new Set(params.acceptExitCodes ?? [0]);
 
-  return new Promise((resolvePromise, rejectPromise) => {
-    const child = spawnProcess(params.cmd, params.args, {
-      cwd: params.cwd,
-      env: params.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+  const slot = await acquireGitSlot();
+  try {
+    return await new Promise<LimitedTextResult>((resolvePromise, rejectPromise) => {
+      const child = spawnProcess(params.cmd, params.args, {
+        cwd: params.cwd,
+        env: params.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
 
-    const stdoutChunks: Buffer[] = [];
-    let stdoutBytes = 0;
-    let truncated = false;
+      const stdoutChunks: Buffer[] = [];
+      let stdoutBytes = 0;
+      let truncated = false;
+      let settled = false;
 
-    const stop = () => {
-      if (child.killed) return;
-      try {
-        child.kill("SIGKILL");
-      } catch {
-        // ignore
-      }
-    };
+      const stop = () => {
+        if (child.killed) return;
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // ignore
+        }
+      };
 
-    child.stdout!.on("data", (chunk: Buffer) => {
-      if (truncated) return;
-      stdoutBytes += chunk.length;
-      if (stdoutBytes > params.maxBytes) {
-        truncated = true;
-        stop();
-        return;
-      }
-      stdoutChunks.push(chunk);
-    });
+      const timer = setTimeout(() => {
+        if (!settled) {
+          stop();
+          settled = true;
+          rejectPromise(
+            new Error(
+              `Timed out after ${SPAWN_TIMEOUT_MS}ms: ${params.cmd} ${params.args.join(" ")}`,
+            ),
+          );
+        }
+      }, SPAWN_TIMEOUT_MS);
 
-    // We don't buffer stderr (it can be large too). Keep it minimal for debugging.
-    let stderrPreview = "";
-    child.stderr!.on("data", (chunk: Buffer) => {
-      if (stderrPreview.length > 2048) return;
-      stderrPreview += chunk.toString("utf8");
-    });
+      child.stdout!.on("data", (chunk: Buffer) => {
+        if (truncated) return;
+        stdoutBytes += chunk.length;
+        if (stdoutBytes > params.maxBytes) {
+          truncated = true;
+          stop();
+          return;
+        }
+        stdoutChunks.push(chunk);
+      });
 
-    child.on("error", (error) => {
-      rejectPromise(error);
-    });
+      // We don't buffer stderr (it can be large too). Keep it minimal for debugging.
+      let stderrPreview = "";
+      child.stderr!.on("data", (chunk: Buffer) => {
+        if (stderrPreview.length > 2048) return;
+        stderrPreview += chunk.toString("utf8");
+      });
 
-    child.on("close", (code, signal) => {
-      if (code !== null && !accept.has(code) && !truncated) {
-        rejectPromise(
-          new Error(
-            `Command failed: ${params.cmd} ${params.args.join(" ")} (code ${code})\n${stderrPreview}`,
-          ),
-        );
-        return;
-      }
-      resolvePromise({
-        text: Buffer.concat(stdoutChunks).toString("utf8"),
-        truncated,
-        exitCode: code,
-        signal,
+      child.on("error", (error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        rejectPromise(error);
+      });
+
+      child.on("close", (code, signal) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (code !== null && !accept.has(code) && !truncated) {
+          rejectPromise(
+            new Error(
+              `Command failed: ${params.cmd} ${params.args.join(" ")} (code ${code})\n${stderrPreview}`,
+            ),
+          );
+          return;
+        }
+        resolvePromise({
+          text: Buffer.concat(stdoutChunks).toString("utf8"),
+          truncated,
+          exitCode: code,
+          signal,
+        });
       });
     });
-  });
+  } finally {
+    slot.release();
+  }
 }
 
 type CheckoutFileChange = {
@@ -1817,7 +1856,7 @@ export async function pullCurrentBranch(cwd: string): Promise<void> {
     throw new Error("Remote 'origin' is not configured.");
   }
   try {
-    await execAsync("git pull", { cwd });
+    await execAsync("git pull", { cwd, timeout: 120_000 });
   } catch (error) {
     await abortGitPullConflictState(cwd);
     throw error;
@@ -1834,7 +1873,7 @@ export async function pushCurrentBranch(cwd: string): Promise<void> {
   if (!hasRemote) {
     throw new Error("Remote 'origin' is not configured.");
   }
-  await execAsync(`git push -u origin ${currentBranch}`, { cwd });
+  await execAsync(`git push -u origin ${currentBranch}`, { cwd, timeout: 120_000 });
 }
 
 export interface CreatePullRequestOptions {
@@ -1954,7 +1993,7 @@ export async function createPullRequest(
     throw new Error(`Base ref mismatch: expected ${base}, got ${options.base}`);
   }
 
-  await execAsync(`git push -u origin ${head}`, { cwd });
+  await execAsync(`git push -u origin ${head}`, { cwd, timeout: 120_000 });
 
   const ghEnv: NodeJS.ProcessEnv = { ...process.env, GIT_TERMINAL_PROMPT: "0" };
   const args = ["api", "-X", "POST", `repos/${repo}/pulls`, "-f", `title=${options.title}`];

--- a/packages/server/src/utils/git-process-pool.ts
+++ b/packages/server/src/utils/git-process-pool.ts
@@ -1,0 +1,111 @@
+import { exec, execFile, type ExecOptions, type ExecFileOptions } from "node:child_process";
+import { promisify } from "node:util";
+
+const rawExecAsync = promisify(exec);
+const rawExecFileAsync = promisify(execFile);
+
+/**
+ * Default timeout for read-only git operations (30 seconds).
+ * Mutating operations (merge, push, fetch) should pass a longer timeout.
+ */
+const DEFAULT_GIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Maximum concurrent git subprocesses. Prevents the event loop from becoming
+ * saturated, which in turn prevents zombie accumulation (SIGCHLD can't be
+ * processed when the loop is starved).
+ */
+const MAX_CONCURRENT_GIT_PROCESSES = 8;
+
+// ---------------------------------------------------------------------------
+// Semaphore – bounds the number of concurrent git subprocesses
+// ---------------------------------------------------------------------------
+
+class Semaphore {
+  private available: number;
+  private readonly waiters: (() => void)[] = [];
+
+  constructor(max: number) {
+    this.available = max;
+  }
+
+  async acquire(): Promise<void> {
+    if (this.available > 0) {
+      this.available--;
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    } else {
+      this.available++;
+    }
+  }
+}
+
+const gitSemaphore = new Semaphore(MAX_CONCURRENT_GIT_PROCESSES);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Concurrency-limited, timeout-aware wrapper around `child_process.exec`.
+ *
+ * This goes through the shell (`sh -c "…"`). Prefer `gitExecFile` when
+ * the command can be expressed as a program + args array — it avoids
+ * spawning an extra shell process.
+ */
+export async function gitExec(
+  command: string,
+  options: ExecOptions & { maxBuffer?: number },
+): Promise<{ stdout: string; stderr: string }> {
+  const timeout = options.timeout ?? DEFAULT_GIT_TIMEOUT_MS;
+  await gitSemaphore.acquire();
+  try {
+    const result = await rawExecAsync(command, { ...options, timeout });
+    return { stdout: String(result.stdout), stderr: String(result.stderr) };
+  } finally {
+    gitSemaphore.release();
+  }
+}
+
+/**
+ * Concurrency-limited, timeout-aware wrapper around `child_process.execFile`.
+ *
+ * Does NOT spawn a shell — avoids the extra `sh` process that causes zombie
+ * accumulation on Linux.
+ */
+export async function gitExecFile(
+  file: string,
+  args: string[],
+  options: ExecFileOptions & { maxBuffer?: number },
+): Promise<{ stdout: string; stderr: string }> {
+  const timeout = options.timeout ?? DEFAULT_GIT_TIMEOUT_MS;
+  await gitSemaphore.acquire();
+  try {
+    const result = await rawExecFileAsync(file, args, { ...options, timeout });
+    return { stdout: String(result.stdout), stderr: String(result.stderr) };
+  } finally {
+    gitSemaphore.release();
+  }
+}
+
+/**
+ * Acquire a slot in the git process pool. The caller is responsible for
+ * calling `release()` when their subprocess completes. Use this for
+ * `spawn()`-based flows (e.g. `spawnLimitedText`) that can't use the
+ * higher-level wrappers.
+ */
+export async function acquireGitSlot(): Promise<{ release: () => void }> {
+  await gitSemaphore.acquire();
+  return {
+    release: () => gitSemaphore.release(),
+  };
+}

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -13,6 +13,7 @@ import {
   writePaseoWorktreeRuntimeMetadata,
 } from "./worktree-metadata.js";
 import { resolvePaseoHome } from "../server/paseo-home.js";
+import { gitExec } from "./git-process-pool.js";
 
 interface PaseoConfig {
   worktree?: {
@@ -22,7 +23,20 @@ interface PaseoConfig {
   };
 }
 
-const execAsync = promisify(exec);
+const rawExecAsync = promisify(exec);
+
+function execAsync(
+  command: string,
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number; shell?: string },
+): Promise<{ stdout: string; stderr: string }> {
+  if (options.shell) {
+    return rawExecAsync(command, { ...options, timeout: options.timeout ?? 120_000 }).then((r) => ({
+      stdout: String(r.stdout),
+      stderr: String(r.stderr),
+    }));
+  }
+  return gitExec(command, options);
+}
 const READ_ONLY_GIT_ENV: NodeJS.ProcessEnv = {
   ...process.env,
   GIT_OPTIONAL_LOCKS: "0",


### PR DESCRIPTION
## Summary

- Adds a shared git process pool (`git-process-pool.ts`) with a semaphore capped at 8 concurrent subprocesses
- Adds 30s default timeouts on all git operations (120s for mutations like push/pull/fetch)
- Adds a 30s kill timer to `spawnLimitedText()` for spawned git diff processes
- Routes all git subprocess calls in the server through the pool (8 files updated)

## Problem

On servers with many workspaces (15+), the app's connect sequence fires 40+ git operations simultaneously (`checkout_pr_status_request`, `project_icon_request`, `fetch_workspaces_request`, etc.). Without concurrency limits or timeouts:

1. Hundreds of `sh`/`git` processes spawn at once
2. The Node event loop becomes saturated and can't process SIGCHLD
3. Finished processes become zombies (1000+ within minutes)
4. Daemon becomes unresponsive (26-60s response times)
5. App disconnects, reconnects, fires more requests — snowball effect

## Test plan

- [ ] Verify typecheck passes (`tsc --noEmit -p packages/server/tsconfig.server.typecheck.json`)
- [ ] Deploy to a server with 10+ workspaces and monitor zombie count over 30+ minutes
- [ ] Verify app connects and stays connected without request timeouts
- [ ] Verify git mutations (push, pull, merge) still work with the longer 120s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)