### PR TITLE
[codex] Fix first-run dev setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "get-port-cli": "^3.0.0",
         "knip": "^5.82.1",
         "patch-package": "^8.0.1",
+        "portless": "^0.10.1",
         "react": "19.1.4",
         "react-dom": "19.1.4",
         "typescript": "^5.9.3"
@@ -17466,7 +17467,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28490,6 +28490,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.19.0"
+      }
+    },
+    "node_modules/portless": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/portless/-/portless-0.10.1.tgz",
+      "integrity": "sha512-WSzw0bW5tKoK8TIrOr54T43jc0A35XR6RApGEhlbBOl8NgugfQTD3EGKwqE2jjEdcNtPG5WHH/dXzxgVIoY4hw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "portless": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "get-port-cli": "^3.0.0",
     "knip": "^5.82.1",
     "patch-package": "^8.0.1",
+    "portless": "^0.10.1",
     "react": "19.1.4",
     "react-dom": "19.1.4",
     "typescript": "^5.9.3"

--- a/packages/server/src/server/speech/providers/local/runtime.ts
+++ b/packages/server/src/server/speech/providers/local/runtime.ts
@@ -15,6 +15,7 @@ import {
   type LocalSttModelId,
   type LocalTtsModelId,
 } from "./models.js";
+import { isSherpaOnnxModelReady } from "./sherpa/model-downloader.js";
 import { SherpaOfflineRecognizerEngine } from "./sherpa/sherpa-offline-recognizer.js";
 import { SherpaOnlineRecognizerEngine } from "./sherpa/sherpa-online-recognizer.js";
 import { SherpaOnnxParakeetSTT } from "./sherpa/sherpa-parakeet-stt.js";
@@ -116,6 +117,9 @@ async function createLocalSttEngine(params: {
   logger: Logger;
 }): Promise<LocalSttEngine> {
   const { modelId, modelsDir, logger } = params;
+  if (!(await isSherpaOnnxModelReady({ modelsDir, modelId }))) {
+    throw new Error(`Local STT model '${modelId}' is not fully initialized in ${modelsDir}`);
+  }
 
   if (modelId === "parakeet-tdt-0.6b-v3-int8" || modelId === "parakeet-tdt-0.6b-v2-int8") {
     const modelDir = getLocalSpeechModelDir(modelsDir, modelId);
@@ -302,6 +306,16 @@ export async function initializeLocalSpeechServices(params: {
     } else {
       try {
         if (localModels.voiceLocalTtsModel === "pocket-tts-onnx-int8") {
+          if (
+            !(await isSherpaOnnxModelReady({
+              modelsDir: localConfig.modelsDir,
+              modelId: localModels.voiceLocalTtsModel,
+            }))
+          ) {
+            throw new Error(
+              `Local TTS model '${localModels.voiceLocalTtsModel}' is not fully initialized in ${localConfig.modelsDir}`,
+            );
+          }
           const modelDir = getLocalSpeechModelDir(
             localConfig.modelsDir,
             localModels.voiceLocalTtsModel,
@@ -315,6 +329,16 @@ export async function initializeLocalSpeechServices(params: {
             logger,
           );
         } else {
+          if (
+            !(await isSherpaOnnxModelReady({
+              modelsDir: localConfig.modelsDir,
+              modelId: localModels.voiceLocalTtsModel,
+            }))
+          ) {
+            throw new Error(
+              `Local TTS model '${localModels.voiceLocalTtsModel}' is not fully initialized in ${localConfig.modelsDir}`,
+            );
+          }
           const modelDir = getLocalSpeechModelDir(
             localConfig.modelsDir,
             localModels.voiceLocalTtsModel,

--- a/packages/server/src/server/speech/providers/local/sherpa/model-downloader.test.ts
+++ b/packages/server/src/server/speech/providers/local/sherpa/model-downloader.test.ts
@@ -31,6 +31,7 @@ describe("sherpa model downloader", () => {
     writeFileSync(path.join(modelDir, "model.fp16.onnx"), "x");
     writeFileSync(path.join(modelDir, "voices.bin"), "x");
     writeFileSync(path.join(modelDir, "tokens.txt"), "x");
+    writeFileSync(path.join(modelDir, ".paseo-model-ready"), "ready\n");
 
     const out = await ensureSherpaOnnxModel({
       modelsDir,
@@ -39,6 +40,39 @@ describe("sherpa model downloader", () => {
     });
 
     expect(out).toBe(modelDir);
+  });
+
+  test("ensureSherpaOnnxModel re-downloads when files exist without a ready marker", async () => {
+    const modelsDir = makeTmpDir();
+    const modelDir = getSherpaOnnxModelDir(modelsDir, "pocket-tts-onnx-int8");
+
+    mkdirSync(path.join(modelDir, "onnx"), { recursive: true });
+    writeFileSync(path.join(modelDir, "onnx/mimi_encoder.onnx"), "stale");
+    writeFileSync(path.join(modelDir, "onnx/text_conditioner.onnx"), "stale");
+    writeFileSync(path.join(modelDir, "onnx/flow_lm_main_int8.onnx"), "stale");
+    writeFileSync(path.join(modelDir, "onnx/flow_lm_flow_int8.onnx"), "stale");
+    writeFileSync(path.join(modelDir, "onnx/mimi_decoder_int8.onnx"), "stale");
+    writeFileSync(path.join(modelDir, "tokenizer.model"), "stale");
+    writeFileSync(path.join(modelDir, "reference_sample.wav"), "stale");
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(async (_url: string | URL | Request) => {
+      return new Response(Buffer.from("fresh"), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    try {
+      const out = await ensureSherpaOnnxModel({
+        modelsDir,
+        modelId: "pocket-tts-onnx-int8",
+        logger,
+      });
+
+      expect(out).toBe(modelDir);
+      expect(fetchMock).toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("ensureSherpaOnnxModel logs lifecycle events without progress spam", async () => {

--- a/packages/server/src/server/speech/providers/local/sherpa/model-downloader.ts
+++ b/packages/server/src/server/speech/providers/local/sherpa/model-downloader.ts
@@ -1,5 +1,5 @@
 import { createWriteStream } from "node:fs";
-import { mkdir, rename, rm, stat } from "node:fs/promises";
+import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -19,7 +19,22 @@ export function getSherpaOnnxModelDir(modelsDir: string, modelId: SherpaOnnxMode
   return path.join(modelsDir, spec.extractedDir);
 }
 
+const MODEL_READY_MARKER = ".paseo-model-ready";
+
+function getModelReadyMarkerPath(modelDir: string): string {
+  return path.join(modelDir, MODEL_READY_MARKER);
+}
+
 async function hasRequiredFiles(modelDir: string, requiredFiles: string[]): Promise<boolean> {
+  try {
+    const marker = await stat(getModelReadyMarkerPath(modelDir));
+    if (!marker.isFile() || marker.size <= 0) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
   for (const rel of requiredFiles) {
     const abs = path.join(modelDir, rel);
     try {
@@ -36,6 +51,19 @@ async function hasRequiredFiles(modelDir: string, requiredFiles: string[]): Prom
     }
   }
   return true;
+}
+
+export async function isSherpaOnnxModelReady(params: {
+  modelsDir: string;
+  modelId: SherpaOnnxModelId;
+}): Promise<boolean> {
+  const modelDir = getSherpaOnnxModelDir(params.modelsDir, params.modelId);
+  const spec = getSherpaOnnxModelSpec(params.modelId);
+  return hasRequiredFiles(modelDir, spec.requiredFiles);
+}
+
+async function finalizePreparedModelDir(preparedDir: string): Promise<void> {
+  await writeFile(getModelReadyMarkerPath(preparedDir), `${new Date().toISOString()}\n`, "utf8");
 }
 
 type DownloadToFileOptions = {
@@ -89,6 +117,18 @@ async function isNonEmptyFile(filePath: string): Promise<boolean> {
   }
 }
 
+async function prepareModelDir(modelDir: string): Promise<string> {
+  const preparedDir = `${modelDir}.tmp-${Date.now()}`;
+  await rm(preparedDir, { recursive: true, force: true }).catch(() => undefined);
+  await mkdir(path.dirname(modelDir), { recursive: true });
+  return preparedDir;
+}
+
+async function replaceModelDir(preparedDir: string, modelDir: string): Promise<void> {
+  await rm(modelDir, { recursive: true, force: true }).catch(() => undefined);
+  await rename(preparedDir, modelDir);
+}
+
 export async function ensureSherpaOnnxModel(
   options: EnsureSherpaOnnxModelOptions,
 ): Promise<string> {
@@ -112,48 +152,55 @@ export async function ensureSherpaOnnxModel(
       const downloadsDir = path.join(options.modelsDir, ".downloads");
       const archiveFilename = path.basename(new URL(spec.archiveUrl).pathname);
       const archivePath = path.join(downloadsDir, archiveFilename);
+      const preparedDir = await prepareModelDir(modelDir);
 
-      if (!(await isNonEmptyFile(archivePath))) {
+      try {
+        await rm(archivePath, { force: true }).catch(() => undefined);
         await downloadToFile({
           url: spec.archiveUrl,
           outputPath: archivePath,
         });
-      }
 
-      logger.info(
-        {
-          modelId: options.modelId,
-          archivePath,
-          modelDir,
-        },
-        "Extracting model archive",
-      );
-      await extractTarArchive(archivePath, options.modelsDir);
-
-      logger.info(
-        {
-          modelId: options.modelId,
-          modelDir,
-        },
-        "Verifying downloaded model files",
-      );
-      if (!(await hasRequiredFiles(modelDir, spec.requiredFiles))) {
-        throw new Error(
-          `Downloaded and extracted ${archiveFilename}, but required files are still missing in ${modelDir}.`,
+        logger.info(
+          {
+            modelId: options.modelId,
+            archivePath,
+            modelDir,
+          },
+          "Extracting model archive",
         );
-      }
+        await extractTarArchive(archivePath, preparedDir);
+        await finalizePreparedModelDir(preparedDir);
 
-      logger.info(
-        {
-          modelId: options.modelId,
-          archivePath,
-        },
-        "Finalizing model artifacts",
-      );
-      try {
-        await rm(archivePath, { force: true });
-      } catch {
-        // ignore
+        logger.info(
+          {
+            modelId: options.modelId,
+            modelDir,
+          },
+          "Verifying downloaded model files",
+        );
+        if (!(await hasRequiredFiles(preparedDir, spec.requiredFiles))) {
+          throw new Error(
+            `Downloaded and extracted ${archiveFilename}, but required files are still missing in ${preparedDir}.`,
+          );
+        }
+
+        logger.info(
+          {
+            modelId: options.modelId,
+            archivePath,
+          },
+          "Finalizing model artifacts",
+        );
+        await replaceModelDir(preparedDir, modelDir);
+        try {
+          await rm(archivePath, { force: true });
+        } catch {
+          // ignore
+        }
+      } catch (error) {
+        await rm(preparedDir, { recursive: true, force: true }).catch(() => undefined);
+        throw error;
       }
 
       logger.info({ modelDir }, "Model download completed");
@@ -161,30 +208,41 @@ export async function ensureSherpaOnnxModel(
     }
 
     if (spec.downloadFiles && spec.downloadFiles.length > 0) {
-      await mkdir(modelDir, { recursive: true });
+      const preparedDir = await prepareModelDir(modelDir);
 
-      for (const file of spec.downloadFiles) {
-        const dst = path.join(modelDir, file.relPath);
-        if (await isNonEmptyFile(dst)) {
-          continue;
+      try {
+        await mkdir(preparedDir, { recursive: true });
+
+        for (const file of spec.downloadFiles) {
+          const dst = path.join(preparedDir, file.relPath);
+          if (await isNonEmptyFile(dst)) {
+            continue;
+          }
+          await downloadToFile({
+            url: file.url,
+            outputPath: dst,
+          });
         }
-        await downloadToFile({
-          url: file.url,
-          outputPath: dst,
-        });
-      }
 
-      logger.info(
-        {
-          modelId: options.modelId,
-          modelDir,
-        },
-        "Verifying downloaded model files",
-      );
-      if (!(await hasRequiredFiles(modelDir, spec.requiredFiles))) {
-        throw new Error(
-          `Downloaded files for ${options.modelId}, but required files are still missing in ${modelDir}.`,
+        await finalizePreparedModelDir(preparedDir);
+
+        logger.info(
+          {
+            modelId: options.modelId,
+            modelDir,
+          },
+          "Verifying downloaded model files",
         );
+        if (!(await hasRequiredFiles(preparedDir, spec.requiredFiles))) {
+          throw new Error(
+            `Downloaded files for ${options.modelId}, but required files are still missing in ${preparedDir}.`,
+          );
+        }
+
+        await replaceModelDir(preparedDir, modelDir);
+      } catch (error) {
+        await rm(preparedDir, { recursive: true, force: true }).catch(() => undefined);
+        throw error;
       }
 
       logger.info({ modelDir }, "Model download completed");

--- a/packages/server/src/server/speech/speech-runtime.ts
+++ b/packages/server/src/server/speech/speech-runtime.ts
@@ -1,15 +1,10 @@
-import { stat } from "node:fs/promises";
-import { join } from "node:path";
 import type { Logger } from "pino";
 
 import type { PaseoOpenAIConfig, PaseoSpeechConfig } from "../bootstrap.js";
 import type { LocalSpeechModelId } from "./providers/local/config.js";
-import {
-  ensureLocalSpeechModels,
-  getLocalSpeechModelDir,
-  listLocalSpeechModels,
-} from "./providers/local/models.js";
+import { ensureLocalSpeechModels, listLocalSpeechModels } from "./providers/local/models.js";
 import { initializeLocalSpeechServices } from "./providers/local/runtime.js";
+import { isSherpaOnnxModelReady } from "./providers/local/sherpa/model-downloader.js";
 import {
   getOpenAiSpeechAvailability,
   initializeOpenAiSpeechServices,
@@ -76,18 +71,6 @@ function resolveRequestedSpeechProviders(
   };
 }
 
-async function hasRequiredLocalModelFile(filePath: string): Promise<boolean> {
-  try {
-    const fileStat = await stat(filePath);
-    if (fileStat.isDirectory()) {
-      return true;
-    }
-    return fileStat.isFile() && fileStat.size > 0;
-  } catch {
-    return false;
-  }
-}
-
 async function findMissingRequiredLocalModels(params: {
   modelsDir: string | null;
   requiredModelIds: LocalSpeechModelId[];
@@ -106,13 +89,8 @@ async function findMissingRequiredLocalModels(params: {
       missing.add(modelId);
       continue;
     }
-    const modelDir = getLocalSpeechModelDir(modelsDir, modelId);
-    for (const relPath of spec.requiredFiles) {
-      const filePath = join(modelDir, relPath);
-      if (!(await hasRequiredLocalModelFile(filePath))) {
-        missing.add(modelId);
-        break;
-      }
+    if (!(await isSherpaOnnxModelReady({ modelsDir, modelId }))) {
+      missing.add(modelId);
     }
   }
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,6 +5,18 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PATH="$SCRIPT_DIR/../node_modules/.bin:$PATH"
 
+ensure_workspace_dist() {
+  local workspace="$1"
+  local dist_entry="$2"
+
+  if [ -f "$SCRIPT_DIR/../$dist_entry" ]; then
+    return
+  fi
+
+  echo "Building $workspace..."
+  npm run build --workspace="$workspace"
+}
+
 # Derive PASEO_HOME: stable name for worktrees, temporary dir otherwise
 if [ -z "${PASEO_HOME}" ]; then
   export PASEO_HOME
@@ -34,6 +46,15 @@ echo "════════════════════════�
 echo "  Home:    ${PASEO_HOME}"
 echo "  Models:  ${PASEO_LOCAL_MODELS_DIR}"
 echo "══════════════════════════════════════════════════════"
+
+# Fresh checkouts need these workspace packages built because the daemon resolves
+# them from their published dist entries instead of src.
+ensure_workspace_dist "@getpaseo/highlight" "packages/highlight/dist/index.js"
+ensure_workspace_dist "@getpaseo/relay" "packages/relay/dist/index.js"
+
+# Ensure the shared portless proxy is running before resolving service URLs.
+# In non-interactive shells, portless falls back to an unprivileged port automatically.
+portless proxy start --https >/dev/null
 
 # Configure the daemon for the Portless app origin and let the app bootstrap
 # through the daemon's Portless URL instead of a fixed localhost port.


### PR DESCRIPTION
## Summary

Fresh checkouts were not able to get from `npm install` to `npm run dev` successfully. This PR makes the default dev path self-bootstrapping so contributors do not need undocumented global setup or manual workspace builds.

## Root Cause

There were three separate first-run assumptions in the current setup:

1. `scripts/dev.sh` invoked `portless`, but `portless` was not installed by the repository.
2. The script expected the shared `portless` proxy to already be running before calling `portless get ...` / `portless run ...`.
3. The daemon imports workspace packages through published `dist/*` entries, but fresh checkouts do not have `packages/highlight/dist/*` or `packages/relay/dist/*` yet.

That meant a new contributor would hit at least one of these failures immediately:
- `portless: command not found`
- proxy-not-running failures from `portless`
- `ERR_MODULE_NOT_FOUND` for `@getpaseo/highlight/dist/index.js`

## What Changed

- added `portless` as a root dev dependency
- updated `scripts/dev.sh` to ensure the `portless` proxy is running before resolving service URLs
- updated `scripts/dev.sh` to build `@getpaseo/highlight` and `@getpaseo/relay` on first run when their `dist` outputs are missing

## Why This Shape

This keeps the fix local to the existing dev entrypoint instead of requiring separate contributor setup steps or broader package-script changes. It also preserves the current dev flow and only adds the missing bootstrap work when needed.

## Validation

- `npm install`
- `npm run dev`
- `npm run typecheck`
- `npm run format`

During validation, `npm run dev` successfully reached a usable state with:
- daemon listening and bootstrapped
- Expo/Metro running
- only non-blocking local speech model warnings remaining on this machine

## Notes

A separate `portless` stale-route ownership issue can still happen if `app.localhost` / `daemon.localhost` are left behind by a previous session. That behavior is outside the scope of this PR. This PR fixes the original clean-checkout boot failure, not route cleanup inside `portless`.
