### PR TITLE
feat: add Cmd+, keyboard shortcut to toggle settings

### DIFF
--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useRef } from "react";
-import { usePathname } from "expo-router";
+import { usePathname, useRouter } from "expo-router";
 import { getIsElectronRuntime } from "@/constants/layout";
 import { useHosts } from "@/runtime/host-runtime";
 import { useKeyboardShortcutsStore } from "@/stores/keyboard-shortcuts-store";
 import { setCommandCenterFocusRestoreElement } from "@/utils/command-center-focus-restore";
 import {
+  buildHostSettingsRoute,
   parseHostAgentRouteFromPathname,
   parseServerIdFromPathname,
   parseHostWorkspaceRouteFromPathname,
@@ -47,6 +48,7 @@ export function useKeyboardShortcuts({
   cycleTheme?: () => void;
 }) {
   const pathname = usePathname();
+  const router = useRouter();
   const hosts = useHosts();
   const resetModifiers = useKeyboardShortcutsStore((s) => s.resetModifiers);
   const { overrides } = useKeyboardShortcutOverrides();
@@ -243,6 +245,16 @@ export function useKeyboardShortcuts({
           return navigateRelativeWorkspace(input.payload.delta);
         case "sidebar.toggle.left":
           toggleAgentList();
+          return true;
+        case "settings.toggle":
+          if (pathname.endsWith("/settings")) {
+            router.back();
+            return true;
+          }
+          if (!activeServerId) {
+            return false;
+          }
+          router.push(buildHostSettingsRoute(activeServerId));
           return true;
         case "sidebar.toggle.both":
           if (toggleBothSidebars) {

--- a/packages/app/src/keyboard/actions.ts
+++ b/packages/app/src/keyboard/actions.ts
@@ -37,6 +37,7 @@ export type KeyboardActionId =
   | "sidebar.toggle.left"
   | "sidebar.toggle.right"
   | "sidebar.toggle.both"
+  | "settings.toggle"
   | "command-center.toggle"
   | "shortcuts.dialog.toggle"
   | "workspace.terminal.new"

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -712,6 +712,32 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
     },
   },
 
+  // --- Settings toggle ---
+  {
+    id: "settings-toggle-cmd-comma-mac",
+    action: "settings.toggle",
+    combo: "Cmd+,",
+    when: { mac: true, commandCenter: false },
+    help: {
+      id: "toggle-settings",
+      section: "panels",
+      label: "Toggle settings",
+      keys: ["mod", ","],
+    },
+  },
+  {
+    id: "settings-toggle-ctrl-comma-non-mac",
+    action: "settings.toggle",
+    combo: "Ctrl+,",
+    when: { mac: false, commandCenter: false, terminal: false },
+    help: {
+      id: "toggle-settings",
+      section: "panels",
+      label: "Toggle settings",
+      keys: ["mod", ","],
+    },
+  },
+
   // --- Focus mode ---
   {
     id: "view-toggle-focus-cmd-shift-f-mac",

--- a/packages/app/src/keyboard/shortcut-string.ts
+++ b/packages/app/src/keyboard/shortcut-string.ts
@@ -31,6 +31,7 @@ KEY_MAP["Digit"] = { code: "Digit" };
 KEY_MAP["\\"] = { code: "Backslash" };
 KEY_MAP["["] = { code: "BracketLeft", key: "[" };
 KEY_MAP["]"] = { code: "BracketRight", key: "]" };
+KEY_MAP[","] = { code: "Comma", key: "," };
 KEY_MAP["."] = { code: "Period", key: "." };
 KEY_MAP["`"] = { code: "Backquote", key: "`" };
 KEY_MAP["/"] = { code: "Slash" };


### PR DESCRIPTION
## Summary

- Adds `settings.toggle` keyboard action with `Cmd+,` (Mac) / `Ctrl+,` (non-Mac) bindings
- When already on a settings route, the shortcut navigates back; otherwise it opens host settings
- Adds comma (`,`) to the shortcut key map in `shortcut-string.ts` so the combo parses correctly
- Shortcut appears in the keyboard shortcuts help dialog under "Panels"

## Changes

| File | Change |
|------|--------|
| `packages/app/src/keyboard/actions.ts` | Add `"settings.toggle"` to `KeyboardActionId` |
| `packages/app/src/keyboard/keyboard-shortcuts.ts` | Add Mac/non-Mac shortcut bindings with help entries |
| `packages/app/src/hooks/use-keyboard-shortcuts.ts` | Add route-aware toggle handler |
| `packages/app/src/keyboard/shortcut-string.ts` | Add comma to `KEY_MAP` |

## Test plan

- [ ] Press `Cmd+,` from any agent view — should navigate to settings
- [ ] Press `Cmd+,` while on settings — should navigate back
- [ ] Open keyboard shortcuts help (`?`) — verify "Toggle settings" appears under Panels
- [ ] On non-Mac, verify `Ctrl+,` works the same way
- [ ] Verify shortcut does nothing when command center is open