### PR TITLE
Add model mapping support for 3rd-party Claude Code provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17466,7 +17466,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/packages/server/src/server/agent/provider-launch-config.test.ts
+++ b/packages/server/src/server/agent/provider-launch-config.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test, vi } from "vitest";
 import {
   resolveProviderCommandPrefix,
   applyProviderEnv,
+  resolveModelViaMap,
+  reverseResolveModelViaMap,
   type ProviderRuntimeSettings,
 } from "./provider-launch-config.js";
 
@@ -101,5 +103,51 @@ describe("applyProviderEnv", () => {
     expect(env.CLAUDE_CODE_SSE_PORT).toBeUndefined();
     expect(env.CLAUDE_AGENT_SDK_VERSION).toBeUndefined();
     expect(env.CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING).toBeUndefined();
+  });
+});
+
+describe("resolveModelViaMap", () => {
+  const modelMap = {
+    "claude-opus-4-6": "qwen3.6-plus",
+    "claude-sonnet-4-6": "qwen3.5-plus",
+    "claude-haiku-4-5": "qwen3-coder-plus",
+  };
+
+  test("translates a known model ID", () => {
+    expect(resolveModelViaMap("claude-opus-4-6", modelMap)).toBe("qwen3.6-plus");
+    expect(resolveModelViaMap("claude-sonnet-4-6", modelMap)).toBe("qwen3.5-plus");
+  });
+
+  test("passes through an unmapped model ID", () => {
+    expect(resolveModelViaMap("unknown-model", modelMap)).toBe("unknown-model");
+  });
+
+  test("returns null/undefined as-is when modelId is empty", () => {
+    expect(resolveModelViaMap(null, modelMap)).toBeNull();
+    expect(resolveModelViaMap(undefined, modelMap)).toBeUndefined();
+  });
+
+  test("returns modelId as-is when modelMap is undefined", () => {
+    expect(resolveModelViaMap("claude-opus-4-6", undefined)).toBe("claude-opus-4-6");
+  });
+});
+
+describe("reverseResolveModelViaMap", () => {
+  const modelMap = {
+    "claude-opus-4-6": "qwen3.6-plus",
+    "claude-sonnet-4-6": "qwen3.5-plus",
+  };
+
+  test("reverse-maps a runtime model to Paseo model ID", () => {
+    expect(reverseResolveModelViaMap("qwen3.6-plus", modelMap)).toBe("claude-opus-4-6");
+    expect(reverseResolveModelViaMap("qwen3.5-plus", modelMap)).toBe("claude-sonnet-4-6");
+  });
+
+  test("returns null for an unknown runtime model", () => {
+    expect(reverseResolveModelViaMap("unknown-runtime", modelMap)).toBeNull();
+  });
+
+  test("returns null when modelMap is undefined", () => {
+    expect(reverseResolveModelViaMap("qwen3.6-plus", undefined)).toBeNull();
   });
 });

--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -34,6 +34,7 @@ export const ProviderRuntimeSettingsSchema = z
   .object({
     command: ProviderCommandSchema.optional(),
     env: z.record(z.string()).optional(),
+    modelMap: z.record(z.string()).optional(),
   })
   .strict();
 
@@ -100,6 +101,31 @@ export function applyProviderEnv(
     delete merged[key];
   }
   return merged;
+}
+
+export function resolveModelViaMap(
+  modelId: string | null | undefined,
+  modelMap: Record<string, string> | undefined,
+): string | null | undefined {
+  if (!modelId || !modelMap) {
+    return modelId;
+  }
+  return modelMap[modelId] ?? modelId;
+}
+
+export function reverseResolveModelViaMap(
+  runtimeModel: string,
+  modelMap: Record<string, string> | undefined,
+): string | null {
+  if (!modelMap) {
+    return null;
+  }
+  for (const [paseoId, mappedId] of Object.entries(modelMap)) {
+    if (mappedId === runtimeModel) {
+      return paseoId;
+    }
+  }
+  return null;
 }
 
 export async function isProviderCommandAvailable(

--- a/packages/server/src/server/agent/providers/claude-agent.env.test.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.env.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import type { AgentLaunchContext } from "../agent-sdk-types.js";
+import type { ProviderRuntimeSettings } from "../provider-launch-config.js";
 import { ClaudeAgentClient } from "./claude-agent.js";
 
 function createQueryMock(events: unknown[]) {
@@ -81,6 +82,169 @@ describe("Claude agent env", () => {
       expect(result.sessionId).toBe("managed-agent-env-session");
       expect(capturedEnv?.PASEO_AGENT_ID).toBe(launchContext.env?.PASEO_AGENT_ID);
       expect(capturedEnv?.PASEO_TEST_FLAG).toBe(launchContext.env?.PASEO_TEST_FLAG);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("translates model via modelMap in options", async () => {
+    let capturedModel: string | undefined;
+    const runtimeSettings: ProviderRuntimeSettings = {
+      modelMap: {
+        "claude-opus-4-6": "qwen3.6-plus",
+        "claude-sonnet-4-6": "qwen3.5-plus",
+      },
+    };
+    const queryFactory = vi.fn(
+      ({ options }: { options: { model?: string } }) => {
+        capturedModel = options.model;
+        return createQueryMock([
+          {
+            type: "system",
+            subtype: "init",
+            session_id: "modelmap-session",
+            permissionMode: "default",
+            model: "qwen3.6-plus",
+          },
+          {
+            type: "assistant",
+            message: { content: "done" },
+          },
+          {
+            type: "result",
+            subtype: "success",
+            usage: {
+              input_tokens: 1,
+              cache_read_input_tokens: 0,
+              output_tokens: 1,
+            },
+            total_cost_usd: 0,
+          },
+        ]);
+      },
+    );
+
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      runtimeSettings,
+      queryFactory: queryFactory as never,
+    });
+    const session = await client.createSession({
+      provider: "claude",
+      cwd: process.cwd(),
+      model: "claude-opus-4-6",
+    });
+
+    try {
+      await session.run("modelmap check");
+      expect(capturedModel).toBe("qwen3.6-plus");
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("passes model as-is when no modelMap is configured", async () => {
+    let capturedModel: string | undefined;
+    const queryFactory = vi.fn(
+      ({ options }: { options: { model?: string } }) => {
+        capturedModel = options.model;
+        return createQueryMock([
+          {
+            type: "system",
+            subtype: "init",
+            session_id: "no-modelmap-session",
+            permissionMode: "default",
+            model: "claude-opus-4-6",
+          },
+          {
+            type: "assistant",
+            message: { content: "done" },
+          },
+          {
+            type: "result",
+            subtype: "success",
+            usage: {
+              input_tokens: 1,
+              cache_read_input_tokens: 0,
+              output_tokens: 1,
+            },
+            total_cost_usd: 0,
+          },
+        ]);
+      },
+    );
+
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      queryFactory: queryFactory as never,
+    });
+    const session = await client.createSession({
+      provider: "claude",
+      cwd: process.cwd(),
+      model: "claude-opus-4-6",
+    });
+
+    try {
+      await session.run("no modelmap check");
+      expect(capturedModel).toBe("claude-opus-4-6");
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("translates model via modelMap in setModel", async () => {
+    const runtimeSettings: ProviderRuntimeSettings = {
+      modelMap: {
+        "claude-opus-4-6": "qwen3.6-plus",
+        "claude-sonnet-4-6": "qwen3.5-plus",
+      },
+    };
+    let setModelArg: string | undefined;
+    const queryFactory = vi.fn(() => {
+      const mock = createQueryMock([
+        {
+          type: "system",
+          subtype: "init",
+          session_id: "setmodel-map-session",
+          permissionMode: "default",
+          model: "qwen3.6-plus",
+        },
+        {
+          type: "assistant",
+          message: { content: "done" },
+        },
+        {
+          type: "result",
+          subtype: "success",
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 0,
+            output_tokens: 1,
+          },
+          total_cost_usd: 0,
+        },
+      ]);
+      mock.setModel = vi.fn(async (m?: string) => { setModelArg = m; });
+      return mock;
+    });
+
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      runtimeSettings,
+      queryFactory: queryFactory as never,
+    });
+    const session = await client.createSession({
+      provider: "claude",
+      cwd: process.cwd(),
+      model: "claude-opus-4-6",
+    });
+
+    try {
+      await session.run("setup session");
+      await session.setModel!("claude-sonnet-4-6");
+      expect(setModelArg).toBe("qwen3.5-plus");
+      const info = await session.getRuntimeInfo();
+      expect(info.model).toBe("claude-sonnet-4-6");
     } finally {
       await session.close();
     }

--- a/packages/server/src/server/agent/providers/claude-agent.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.ts
@@ -72,7 +72,12 @@ import type {
   McpServerConfig,
   PersistedAgentDescriptor,
 } from "../agent-sdk-types.js";
-import { applyProviderEnv, type ProviderRuntimeSettings } from "../provider-launch-config.js";
+import {
+  applyProviderEnv,
+  resolveModelViaMap,
+  reverseResolveModelViaMap,
+  type ProviderRuntimeSettings,
+} from "../provider-launch-config.js";
 import { findExecutable } from "../../../utils/executable.js";
 import { spawnProcess } from "../../../utils/spawn.js";
 import { getOrchestratorModeInstructions } from "../orchestrator-instructions.js";
@@ -1633,8 +1638,9 @@ class ClaudeAgentSession implements AgentSession {
   async setModel(modelId: string | null): Promise<void> {
     const normalizedModelId =
       typeof modelId === "string" && modelId.trim().length > 0 ? modelId : null;
+    const mappedModelId = resolveModelViaMap(normalizedModelId, this.runtimeSettings?.modelMap) ?? normalizedModelId;
     const query = await this.ensureQuery();
-    await query.setModel(normalizedModelId ?? undefined);
+    await query.setModel(mappedModelId ?? undefined);
     this.config.model = normalizedModelId ?? undefined;
     this.lastOptionsModel = normalizedModelId ?? this.lastOptionsModel;
     this.lastRuntimeModel = null;
@@ -2141,9 +2147,9 @@ class ClaudeAgentSession implements AgentSession {
     }
 
     if (this.config.model) {
-      base.model = this.config.model;
+      base.model = resolveModelViaMap(this.config.model, this.runtimeSettings?.modelMap) ?? this.config.model;
     }
-    this.lastOptionsModel = base.model ?? null;
+    this.lastOptionsModel = this.config.model ?? null;
     if (this.claudeSessionId) {
       base.resume = this.claudeSessionId;
     }
@@ -2932,11 +2938,14 @@ class ClaudeAgentSession implements AgentSession {
     this.persistence = null;
     if (message.model) {
       const normalizedRuntimeModel = normalizeClaudeRuntimeModelId(message.model);
+      const reverseMapped = reverseResolveModelViaMap(message.model, this.runtimeSettings?.modelMap);
       this.logger.debug(
-        { runtimeModel: message.model, normalizedRuntimeModel },
+        { runtimeModel: message.model, normalizedRuntimeModel, reverseMapped },
         "Captured runtime model from SDK init",
       );
-      if (normalizedRuntimeModel) {
+      if (reverseMapped) {
+        this.lastOptionsModel = reverseMapped;
+      } else if (normalizedRuntimeModel) {
         this.lastOptionsModel = normalizedRuntimeModel;
       } else if (!this.lastOptionsModel) {
         this.lastOptionsModel = this.config.model ?? null;

--- a/packages/server/src/server/persisted-config.test.ts
+++ b/packages/server/src/server/persisted-config.test.ts
@@ -41,6 +41,24 @@ describe("PersistedConfigSchema agent provider runtime settings", () => {
     expect(parsed.agents?.providers?.codex?.command?.mode).toBe("replace");
   });
 
+  test("accepts modelMap configuration", () => {
+    const parsed = PersistedConfigSchema.parse({
+      agents: {
+        providers: {
+          claude: {
+            modelMap: {
+              "claude-opus-4-6": "qwen3.6-plus",
+              "claude-sonnet-4-6": "qwen3.5-plus",
+            },
+          },
+        },
+      },
+    });
+
+    expect(parsed.agents?.providers?.claude?.modelMap?.["claude-opus-4-6"]).toBe("qwen3.6-plus");
+    expect(parsed.agents?.providers?.claude?.modelMap?.["claude-sonnet-4-6"]).toBe("qwen3.5-plus");
+  });
+
   test("rejects replace command without argv", () => {
     const result = PersistedConfigSchema.safeParse({
       agents: {


### PR DESCRIPTION
## Summary

Adds a `modelMap` configuration option for the 3rd party Claude Code provider, enabling Paseo to translate Paseo model IDs to third-party Claude-compatible provider model names at runtime.

## Motivation

Third-party Claude-compatible providers (e.g., Alibaba Cloud's DashScope Coding Plan) expose the Claude API but use their own model identifiers instead of Anthropic's official model IDs (e.g., `claude-opus-4-6`, `claude-sonnet-4-6`). Previously, Paseo had no way to translate between these two naming conventions — users had to select models by their provider-specific names, which was confusing and broke Paseo's UI model picker. This PR adds bidirectional model ID mapping so that Paseo always presents its standard model names to the user while sending the correct provider-specific model ID to the underlying agent.

## Changes

- **`ProviderRuntimeSettingsSchema`**: Added optional `modelMap` field (`Record<string, string>`) to provider runtime settings and persisted config schema.
- **`resolveModelViaMap` / `reverseResolveModelViaMap`**: New utility functions in `provider-launch-config.ts` for forward and reverse model ID lookup.
- **`ClaudeAgentSession`**: Integrated model mapping into three paths:
  - **Session initialization** — translates `config.model` before passing to the Claude SDK.
  - **`setModel()`** — translates the user-selected model when switching models mid-session.
  - **Runtime model capture** — reverse-maps the model ID reported by the SDK back to the Paseo model ID, so the UI consistently shows the standard name.
- **Tests**: Added unit tests for both mapping utilities and integration tests verifying model translation in session creation, `setModel`, and passthrough when no mapping is configured.

## Configuration

Add a `modelMap` to the Claude provider settings in your Paseo daemon config (`~/.paseo/config.json`):

```json
{
  "agents": {
    "providers": {
      "claude": {
        "modelMap": {
          "claude-opus-4-6": "qwen3.6-plus",
          "claude-sonnet-4-6": "qwen3.5-plus",
          "claude-haiku-4-5": "qwen3-coder-plus"
        }
      }
    }
  }
}