### PR TITLE
Add  reasoning effort option for Opus 4.6 models

### DIFF
--- a/packages/server/src/server/agent/providers/claude/claude-models.ts
+++ b/packages/server/src/server/agent/providers/claude/claude-models.ts
@@ -4,6 +4,7 @@ const CLAUDE_THINKING_OPTIONS = [
   { id: "low", label: "Low" },
   { id: "medium", label: "Medium" },
   { id: "high", label: "High" },
+  { id: "max", label: "Max" },
 ] as const;
 
 const CLAUDE_MODELS: AgentModelDefinition[] = [


### PR DESCRIPTION
## Summary

The codebase already has full backend support for `"max"` effort in types, validation, SDK passthrough, and error handling. The only missing piece was the `CLAUDE_THINKING_OPTIONS` array, which didn't surface `"max"` in the UI dropdown.

- Adds `{ id: "max", label: "Max" }` to the static thinking options array
- All downstream code already handles `"max"` correctly (type guards, SDK passthrough, error handling)

## Test plan

- [x] Live tested `claude --effort max` — works without errors
- [x] Live tested all four effort levels (`low`, `medium`, `high`, `max`) — all work
- [x] Existing integration test expects `supportedEffortLevels: ["low", "medium", "high", "max"]`
- [x] Existing redesign test verifies `effort: "max"` is passed to SDK
- [x] Existing E2E test exercises `thinkingOptionId: "max"`

Fixes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)