### PR TITLE
feat(app): add Projects/Sessions tabs to desktop sidebar

### DIFF
--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -34,7 +34,12 @@ import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
 import { router, usePathname } from "expo-router";
 import { usePanelStore, MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH } from "@/stores/panel-store";
 import { SidebarWorkspaceList } from "./sidebar-workspace-list";
+import { SidebarSessionList } from "./sidebar-session-list";
 import { SidebarAgentListSkeleton } from "./sidebar-agent-list-skeleton";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { FolderGit2 } from "lucide-react-native";
+import { useAllAgentsList } from "@/hooks/use-all-agents-list";
+import type { AggregatedAgent } from "@/hooks/use-aggregated-agents";
 import { useSidebarShortcutModel } from "@/hooks/use-sidebar-shortcut-model";
 import {
   useSidebarWorkspacesList,
@@ -68,6 +73,8 @@ type SidebarTheme = ReturnType<typeof useUnistyles>["theme"];
 interface LeftSidebarProps {
   selectedAgentId?: string;
 }
+
+type SidebarTab = "projects" | "sessions";
 
 interface SidebarSharedProps {
   theme: SidebarTheme;
@@ -108,14 +115,17 @@ interface MobileSidebarProps extends SidebarSharedProps {
 interface DesktopSidebarProps extends SidebarSharedProps {
   insetsTop: number;
   isOpen: boolean;
-  handleViewMore: () => void;
+  activeTab: SidebarTab;
+  setActiveTab: Dispatch<SetStateAction<SidebarTab>>;
+  sessions: AggregatedAgent[];
+  isSessionsInitialLoad: boolean;
+  isSessionsRevalidating: boolean;
+  handleSessionsRefresh: () => void;
+  isSessionsManualRefresh: boolean;
+  selectedAgentId?: string;
 }
 
-export const LeftSidebar = memo(function LeftSidebar({
-  selectedAgentId: _selectedAgentId,
-}: LeftSidebarProps) {
-  void _selectedAgentId;
-
+export const LeftSidebar = memo(function LeftSidebar({ selectedAgentId }: LeftSidebarProps) {
   const { theme } = useUnistyles();
   const insets = useSafeAreaInsets();
   const isCompactLayout = useIsCompactFormFactor();
@@ -188,10 +198,34 @@ export const LeftSidebar = memo(function LeftSidebar({
 
   const isOpen = isCompactLayout ? mobileView === "agent-list" : desktopAgentListOpen;
 
+  const [activeTab, setActiveTab] = useState<SidebarTab>("projects");
+
   const { projects, isInitialLoad, isRevalidating, refreshAll } = useSidebarWorkspacesList({
     serverId: activeServerId,
     enabled: isOpen,
   });
+
+  // Sessions data for desktop Sessions tab. Hook always runs for stable hook order;
+  // the data only renders when the Sessions tab is active on desktop.
+  const {
+    agents: sessions,
+    isInitialLoad: isSessionsInitialLoad,
+    isRevalidating: isSessionsRevalidating,
+    refreshAll: refreshSessions,
+  } = useAllAgentsList({ serverId: activeServerId, includeArchived: false });
+
+  const [isSessionsManualRefresh, setIsSessionsManualRefresh] = useState(false);
+
+  const handleSessionsRefresh = useCallback(() => {
+    setIsSessionsManualRefresh(true);
+    refreshSessions();
+  }, [refreshSessions]);
+
+  useEffect(() => {
+    if (!isSessionsRevalidating && isSessionsManualRefresh) {
+      setIsSessionsManualRefresh(false);
+    }
+  }, [isSessionsRevalidating, isSessionsManualRefresh]);
   const { collapsedProjectKeys, shortcutIndexByWorkspaceKey, toggleProjectCollapsed } =
     useSidebarShortcutModel(projects);
 
@@ -296,7 +330,14 @@ export const LeftSidebar = memo(function LeftSidebar({
       isOpen={isOpen}
       handleOpenProject={handleOpenProjectDesktop}
       handleSettings={handleSettingsDesktop}
-      handleViewMore={handleViewMoreNavigate}
+      activeTab={activeTab}
+      setActiveTab={setActiveTab}
+      sessions={sessions}
+      isSessionsInitialLoad={isSessionsInitialLoad}
+      isSessionsRevalidating={isSessionsRevalidating}
+      handleSessionsRefresh={handleSessionsRefresh}
+      isSessionsManualRefresh={isSessionsManualRefresh}
+      selectedAgentId={selectedAgentId}
     />
   );
 });
@@ -673,7 +714,14 @@ function DesktopSidebar({
   handleSettings,
   insetsTop,
   isOpen,
-  handleViewMore,
+  activeTab,
+  setActiveTab,
+  sessions,
+  isSessionsInitialLoad,
+  isSessionsRevalidating,
+  handleSessionsRefresh,
+  isSessionsManualRefresh,
+  selectedAgentId,
 }: DesktopSidebarProps) {
   const newAgentKeys = useShortcutKeys("new-agent");
   const padding = useWindowControlsPadding("sidebar");
@@ -734,23 +782,54 @@ function DesktopSidebar({
           {padding.top > 0 ? <View style={{ height: padding.top }} /> : null}
           <View style={styles.sidebarHeader}>
             <View style={styles.sidebarHeaderRow}>
-              <SessionsButton onPress={handleViewMore} />
+              <SegmentedControl<SidebarTab>
+                testID="sidebar-tab-switcher"
+                options={[
+                  {
+                    value: "projects",
+                    label: "Projects",
+                    icon: ({ color, size }) => <FolderGit2 color={color} size={size} />,
+                    testID: "sidebar-tab-projects",
+                  },
+                  {
+                    value: "sessions",
+                    label: "Sessions",
+                    icon: ({ color, size }) => <MessagesSquare color={color} size={size} />,
+                    testID: "sidebar-tab-sessions",
+                  },
+                ]}
+                value={activeTab}
+                onValueChange={setActiveTab}
+                size="sm"
+                style={styles.tabSwitcher}
+              />
             </View>
           </View>
         </View>
 
-        {isInitialLoad ? (
+        {activeTab === "projects" ? (
+          isInitialLoad ? (
+            <SidebarAgentListSkeleton />
+          ) : (
+            <SidebarWorkspaceList
+              serverId={activeServerId}
+              collapsedProjectKeys={collapsedProjectKeys}
+              onToggleProjectCollapsed={toggleProjectCollapsed}
+              shortcutIndexByWorkspaceKey={shortcutIndexByWorkspaceKey}
+              projects={projects}
+              isRefreshing={isManualRefresh && isRevalidating}
+              onRefresh={handleRefresh}
+              onAddProject={handleOpenProject}
+            />
+          )
+        ) : isSessionsInitialLoad ? (
           <SidebarAgentListSkeleton />
         ) : (
-          <SidebarWorkspaceList
-            serverId={activeServerId}
-            collapsedProjectKeys={collapsedProjectKeys}
-            onToggleProjectCollapsed={toggleProjectCollapsed}
-            shortcutIndexByWorkspaceKey={shortcutIndexByWorkspaceKey}
-            projects={projects}
-            isRefreshing={isManualRefresh && isRevalidating}
-            onRefresh={handleRefresh}
-            onAddProject={handleOpenProject}
+          <SidebarSessionList
+            agents={sessions}
+            isRefreshing={isSessionsManualRefresh && isSessionsRevalidating}
+            onRefresh={handleSessionsRefresh}
+            selectedAgentId={selectedAgentId}
           />
         )}
 
@@ -897,6 +976,10 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     justifyContent: "space-between",
     gap: theme.spacing[2],
+  },
+  tabSwitcher: {
+    flex: 1,
+    justifyContent: "center",
   },
   newAgentButton: {
     flex: 1,

--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -57,7 +57,6 @@ import {
   useIsCompactFormFactor,
 } from "@/constants/layout";
 import {
-  buildHostSessionsRoute,
   buildHostSettingsRoute,
   mapPathnameToServer,
   parseServerIdFromPathname,
@@ -109,7 +108,14 @@ interface MobileSidebarProps extends SidebarSharedProps {
   insetsBottom: number;
   isOpen: boolean;
   closeToAgent: () => void;
-  handleViewMoreNavigate: () => void;
+  activeTab: SidebarTab;
+  setActiveTab: Dispatch<SetStateAction<SidebarTab>>;
+  sessions: AggregatedAgent[];
+  isSessionsInitialLoad: boolean;
+  isSessionsRevalidating: boolean;
+  handleSessionsRefresh: () => void;
+  isSessionsManualRefresh: boolean;
+  selectedAgentId?: string;
 }
 
 interface DesktopSidebarProps extends SidebarSharedProps {
@@ -268,13 +274,6 @@ export const LeftSidebar = memo(function LeftSidebar({ selectedAgentId }: LeftSi
     router.push(buildHostSettingsRoute(activeServerId));
   }, [activeServerId]);
 
-  const handleViewMoreNavigate = useCallback(() => {
-    if (!activeServerId) {
-      return;
-    }
-    router.push(buildHostSessionsRoute(activeServerId));
-  }, [activeServerId]);
-
   const handleHostSelect = useCallback(
     (nextServerId: string) => {
       if (!nextServerId) {
@@ -318,7 +317,14 @@ export const LeftSidebar = memo(function LeftSidebar({ selectedAgentId }: LeftSi
         closeToAgent={closeToAgent}
         handleOpenProject={handleOpenProjectMobile}
         handleSettings={handleSettingsMobile}
-        handleViewMoreNavigate={handleViewMoreNavigate}
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+        sessions={sessions}
+        isSessionsInitialLoad={isSessionsInitialLoad}
+        isSessionsRevalidating={isSessionsRevalidating}
+        handleSessionsRefresh={handleSessionsRefresh}
+        isSessionsManualRefresh={isSessionsManualRefresh}
+        selectedAgentId={selectedAgentId}
       />
     );
   }
@@ -369,44 +375,6 @@ function HostSwitchOption({
   );
 }
 
-function SessionsButton({ onPress }: { onPress: () => void }) {
-  const { theme } = useUnistyles();
-  const pathname = usePathname();
-  const isActive = pathname.includes("/sessions");
-
-  return (
-    <Pressable
-      style={({ hovered }) => [
-        styles.newAgentButton,
-        hovered && styles.newAgentButtonHovered,
-        isActive && styles.newAgentButtonActive,
-      ]}
-      testID="sidebar-sessions"
-      accessible
-      accessibilityRole="button"
-      accessibilityLabel="Sessions"
-      onPress={onPress}
-    >
-      {({ hovered }) => (
-        <>
-          <MessagesSquare
-            size={theme.iconSize.md}
-            color={hovered || isActive ? theme.colors.foreground : theme.colors.foregroundMuted}
-          />
-          <Text
-            style={[
-              styles.newAgentButtonText,
-              (hovered || isActive) && styles.newAgentButtonTextHovered,
-            ]}
-          >
-            Sessions
-          </Text>
-        </>
-      )}
-    </Pressable>
-  );
-}
-
 function MobileSidebar({
   theme,
   activeServerId,
@@ -432,7 +400,14 @@ function MobileSidebar({
   insetsBottom,
   isOpen,
   closeToAgent,
-  handleViewMoreNavigate,
+  activeTab,
+  setActiveTab,
+  sessions,
+  isSessionsInitialLoad,
+  isSessionsRevalidating,
+  handleSessionsRefresh,
+  isSessionsManualRefresh,
+  selectedAgentId,
 }: MobileSidebarProps) {
   const newAgentKeys = useShortcutKeys("new-agent");
   const {
@@ -452,23 +427,6 @@ function MobileSidebar({
     gestureAnimatingRef.current = true;
     closeToAgent();
   }, [closeToAgent, gestureAnimatingRef]);
-
-  const handleViewMore = useCallback(() => {
-    if (!activeServerId) {
-      return;
-    }
-    translateX.value = -windowWidth;
-    backdropOpacity.value = 0;
-    closeToAgent();
-    handleViewMoreNavigate();
-  }, [
-    activeServerId,
-    backdropOpacity,
-    closeToAgent,
-    handleViewMoreNavigate,
-    translateX,
-    windowWidth,
-  ]);
 
   const closeGesture = useMemo(
     () =>
@@ -587,24 +545,56 @@ function MobileSidebar({
           <View style={styles.sidebarContent} pointerEvents="auto">
             <View style={styles.sidebarHeader}>
               <View style={styles.sidebarHeaderRow}>
-                <SessionsButton onPress={handleViewMore} />
+                <SegmentedControl<SidebarTab>
+                  testID="sidebar-tab-switcher"
+                  options={[
+                    {
+                      value: "projects",
+                      label: "Projects",
+                      icon: ({ color, size }) => <FolderGit2 color={color} size={size} />,
+                      testID: "sidebar-tab-projects",
+                    },
+                    {
+                      value: "sessions",
+                      label: "Sessions",
+                      icon: ({ color, size }) => <MessagesSquare color={color} size={size} />,
+                      testID: "sidebar-tab-sessions",
+                    },
+                  ]}
+                  value={activeTab}
+                  onValueChange={setActiveTab}
+                  size="sm"
+                  style={styles.tabSwitcher}
+                />
               </View>
             </View>
 
-            {isInitialLoad ? (
+            {activeTab === "projects" ? (
+              isInitialLoad ? (
+                <SidebarAgentListSkeleton />
+              ) : (
+                <SidebarWorkspaceList
+                  serverId={activeServerId}
+                  collapsedProjectKeys={collapsedProjectKeys}
+                  onToggleProjectCollapsed={toggleProjectCollapsed}
+                  shortcutIndexByWorkspaceKey={shortcutIndexByWorkspaceKey}
+                  projects={projects}
+                  isRefreshing={isManualRefresh && isRevalidating}
+                  onRefresh={handleRefresh}
+                  onWorkspacePress={() => closeToAgent()}
+                  onAddProject={handleOpenProject}
+                  parentGestureRef={closeGestureRef}
+                />
+              )
+            ) : isSessionsInitialLoad ? (
               <SidebarAgentListSkeleton />
             ) : (
-              <SidebarWorkspaceList
-                serverId={activeServerId}
-                collapsedProjectKeys={collapsedProjectKeys}
-                onToggleProjectCollapsed={toggleProjectCollapsed}
-                shortcutIndexByWorkspaceKey={shortcutIndexByWorkspaceKey}
-                projects={projects}
-                isRefreshing={isManualRefresh && isRevalidating}
-                onRefresh={handleRefresh}
-                onWorkspacePress={() => closeToAgent()}
-                onAddProject={handleOpenProject}
-                parentGestureRef={closeGestureRef}
+              <SidebarSessionList
+                agents={sessions}
+                isRefreshing={isSessionsManualRefresh && isSessionsRevalidating}
+                onRefresh={handleSessionsRefresh}
+                selectedAgentId={selectedAgentId}
+                onAgentPress={() => closeToAgent()}
               />
             )}
 
@@ -980,29 +970,6 @@ const styles = StyleSheet.create((theme) => ({
   tabSwitcher: {
     flex: 1,
     justifyContent: "center",
-  },
-  newAgentButton: {
-    flex: 1,
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[2],
-    paddingVertical: theme.spacing[2],
-    paddingHorizontal: theme.spacing[3],
-    borderRadius: theme.borderRadius.lg,
-  },
-  newAgentButtonText: {
-    fontSize: theme.fontSize.base,
-    fontWeight: theme.fontWeight.normal,
-    color: theme.colors.foregroundMuted,
-  },
-  newAgentButtonTextHovered: {
-    color: theme.colors.foreground,
-  },
-  newAgentButtonHovered: {
-    backgroundColor: theme.colors.surfaceSidebarHover,
-  },
-  newAgentButtonActive: {
-    backgroundColor: theme.colors.surfaceSidebarHover,
   },
   hostTrigger: {
     flexDirection: "row",

--- a/packages/app/src/components/sidebar-session-list.tsx
+++ b/packages/app/src/components/sidebar-session-list.tsx
@@ -1,0 +1,266 @@
+import { useCallback, useMemo } from "react";
+import { FlatList, Pressable, RefreshControl, Text, View, type ListRenderItem } from "react-native";
+import { router } from "expo-router";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { MessagesSquare } from "lucide-react-native";
+import type { AggregatedAgent } from "@/hooks/use-aggregated-agents";
+import { formatTimeAgo } from "@/utils/time";
+import { prepareWorkspaceTab } from "@/utils/workspace-navigation";
+
+function deriveDateSectionLabel(lastActivityAt: Date): string {
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterdayStart = new Date(todayStart.getTime() - 24 * 60 * 60 * 1000);
+  const activityStart = new Date(
+    lastActivityAt.getFullYear(),
+    lastActivityAt.getMonth(),
+    lastActivityAt.getDate(),
+  );
+
+  if (activityStart.getTime() >= todayStart.getTime()) {
+    return "Today";
+  }
+  if (activityStart.getTime() >= yesterdayStart.getTime()) {
+    return "Yesterday";
+  }
+
+  const diffTime = todayStart.getTime() - activityStart.getTime();
+  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+  if (diffDays <= 7) {
+    return "This week";
+  }
+  if (diffDays <= 30) {
+    return "This month";
+  }
+  return "Older";
+}
+
+function basename(cwd: string): string {
+  if (!cwd) return "";
+  const trimmed = cwd.replace(/\/+$/, "");
+  const idx = trimmed.lastIndexOf("/");
+  return idx === -1 ? trimmed : trimmed.slice(idx + 1);
+}
+
+type SidebarSessionListItem =
+  | { type: "header"; key: string; title: string }
+  | { type: "agent"; key: string; agent: AggregatedAgent };
+
+interface SidebarSessionListProps {
+  agents: AggregatedAgent[];
+  isRefreshing?: boolean;
+  onRefresh?: () => void;
+  selectedAgentId?: string;
+}
+
+export function SidebarSessionList({
+  agents,
+  isRefreshing = false,
+  onRefresh,
+  selectedAgentId,
+}: SidebarSessionListProps) {
+  const { theme } = useUnistyles();
+
+  const items = useMemo((): SidebarSessionListItem[] => {
+    const order = ["Today", "Yesterday", "This week", "This month", "Older"] as const;
+    const buckets = new Map<string, AggregatedAgent[]>();
+    for (const agent of agents) {
+      const label = deriveDateSectionLabel(agent.lastActivityAt);
+      const existing = buckets.get(label) ?? [];
+      existing.push(agent);
+      buckets.set(label, existing);
+    }
+    const result: SidebarSessionListItem[] = [];
+    for (const label of order) {
+      const data = buckets.get(label);
+      if (!data || data.length === 0) continue;
+      result.push({ type: "header", key: `header:${label}`, title: label });
+      for (const agent of data) {
+        result.push({ type: "agent", key: `${agent.serverId}:${agent.id}`, agent });
+      }
+    }
+    return result;
+  }, [agents]);
+
+  const handleAgentPress = useCallback((agent: AggregatedAgent) => {
+    const route = prepareWorkspaceTab({
+      serverId: agent.serverId,
+      workspaceId: agent.cwd,
+      target: { kind: "agent", agentId: agent.id },
+      pin: Boolean(agent.archivedAt),
+    });
+    router.navigate(route);
+  }, []);
+
+  const renderItem: ListRenderItem<SidebarSessionListItem> = useCallback(
+    ({ item }) => {
+      if (item.type === "header") {
+        return (
+          <View style={styles.sectionHeading}>
+            <Text style={styles.sectionTitle}>{item.title}</Text>
+          </View>
+        );
+      }
+      const agent = item.agent;
+      const key = `${agent.serverId}:${agent.id}`;
+      const isActive = selectedAgentId === key;
+      const project = basename(agent.cwd);
+      const timeAgo = formatTimeAgo(agent.lastActivityAt);
+      return (
+        <Pressable
+          onPress={() => handleAgentPress(agent)}
+          testID={`sidebar-session-row-${agent.serverId}-${agent.id}`}
+          style={({ hovered, pressed }) => [
+            styles.row,
+            hovered && styles.rowHovered,
+            pressed && styles.rowPressed,
+            isActive && styles.rowActive,
+          ]}
+        >
+          <View style={styles.titleRow}>
+            <Text style={[styles.title, isActive && styles.titleActive]} numberOfLines={1}>
+              {agent.title || "New session"}
+            </Text>
+            {agent.requiresAttention ? <View style={styles.attentionDot} /> : null}
+          </View>
+          <View style={styles.metaRow}>
+            {project ? (
+              <Text style={styles.metaText} numberOfLines={1}>
+                {project}
+              </Text>
+            ) : null}
+            {project ? <Text style={styles.metaSeparator}>·</Text> : null}
+            <Text style={styles.metaTime}>{timeAgo}</Text>
+          </View>
+        </Pressable>
+      );
+    },
+    [handleAgentPress, selectedAgentId],
+  );
+
+  const keyExtractor = useCallback((item: SidebarSessionListItem) => item.key, []);
+
+  if (agents.length === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <MessagesSquare size={24} color={theme.colors.foregroundMuted} />
+        <Text style={styles.emptyText}>No sessions yet</Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={items}
+      style={styles.list}
+      contentContainerStyle={styles.listContent}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
+      showsVerticalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      refreshControl={
+        onRefresh ? (
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={onRefresh}
+            tintColor={theme.colors.foregroundMuted}
+            colors={[theme.colors.foregroundMuted]}
+          />
+        ) : undefined
+      }
+    />
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  list: {
+    flex: 1,
+    minHeight: 0,
+  },
+  listContent: {
+    paddingHorizontal: theme.spacing[2],
+    paddingTop: theme.spacing[2],
+    paddingBottom: theme.spacing[4],
+  },
+  sectionHeading: {
+    paddingHorizontal: theme.spacing[2],
+    paddingTop: theme.spacing[3],
+    paddingBottom: theme.spacing[1],
+  },
+  sectionTitle: {
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.medium,
+    color: theme.colors.foregroundMuted,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  row: {
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: theme.spacing[2],
+    borderRadius: theme.borderRadius.md,
+    gap: 2,
+  },
+  rowHovered: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  rowPressed: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  rowActive: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  title: {
+    flex: 1,
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foreground,
+    opacity: 0.86,
+  },
+  titleActive: {
+    opacity: 1,
+    fontWeight: theme.fontWeight.medium,
+  },
+  attentionDot: {
+    width: 6,
+    height: 6,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.palette.red[500],
+    flexShrink: 0,
+  },
+  metaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+  },
+  metaText: {
+    flexShrink: 1,
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+  },
+  metaSeparator: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+    opacity: 0.6,
+  },
+  metaTime: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+    flexShrink: 0,
+  },
+  emptyContainer: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: theme.spacing[3],
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[6],
+  },
+  emptyText: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foregroundMuted,
+  },
+}));

--- a/packages/app/src/components/sidebar-session-list.tsx
+++ b/packages/app/src/components/sidebar-session-list.tsx
@@ -51,6 +51,7 @@ interface SidebarSessionListProps {
   isRefreshing?: boolean;
   onRefresh?: () => void;
   selectedAgentId?: string;
+  onAgentPress?: () => void;
 }
 
 export function SidebarSessionList({
@@ -58,6 +59,7 @@ export function SidebarSessionList({
   isRefreshing = false,
   onRefresh,
   selectedAgentId,
+  onAgentPress,
 }: SidebarSessionListProps) {
   const { theme } = useUnistyles();
 
@@ -82,15 +84,19 @@ export function SidebarSessionList({
     return result;
   }, [agents]);
 
-  const handleAgentPress = useCallback((agent: AggregatedAgent) => {
-    const route = prepareWorkspaceTab({
-      serverId: agent.serverId,
-      workspaceId: agent.cwd,
-      target: { kind: "agent", agentId: agent.id },
-      pin: Boolean(agent.archivedAt),
-    });
-    router.navigate(route);
-  }, []);
+  const handleAgentPress = useCallback(
+    (agent: AggregatedAgent) => {
+      onAgentPress?.();
+      const route = prepareWorkspaceTab({
+        serverId: agent.serverId,
+        workspaceId: agent.cwd,
+        target: { kind: "agent", agentId: agent.id },
+        pin: Boolean(agent.archivedAt),
+      });
+      router.navigate(route);
+    },
+    [onAgentPress],
+  );
 
   const renderItem: ListRenderItem<SidebarSessionListItem> = useCallback(
     ({ item }) => {


### PR DESCRIPTION
## Summary

- Replace the single **Sessions** button at the top of the sidebar (both desktop and mobile) with a `SegmentedControl` that switches between **Projects** (the existing workspace list) and **Sessions** (a new compact, date-grouped session list).
- When **Sessions** is selected the sidebar renders `SidebarSessionList` inline, so users can jump between sessions without leaving the sidebar. Tapping a session on mobile also closes the sidebar overlay — same UX as picking a workspace.
- Retires the now-unused `SessionsButton` component and the sidebar's `/sessions` route navigation.


Screenshot with mocked data:
<img width="1075" height="810" alt="image" src="https://github.com/user-attachments/assets/bc6fd0b4-64bb-44d4-9352-4ecb521716be" />
<img width="1080" height="809" alt="image" src="https://github.com/user-attachments/assets/e322903a-5f85-4414-a4e1-1ade3352b20d" />

Mobile:
<img width="371" height="737" alt="image" src="https://github.com/user-attachments/assets/65d64d4a-b974-457d-9cf9-acf65ca6ea39" />
<img width="371" height="738" alt="image" src="https://github.com/user-attachments/assets/e93a971c-d163-4713-be00-69fe5c59e02d" />



Closes getpaseo/paseo#324

## Test plan

**Desktop**
- [ ] Switch the sidebar to the **Sessions** tab and confirm the grouped list (Today / Yesterday / This week / This month / Older) renders.
- [ ] Click a session row and confirm it opens the corresponding workspace + agent tab.
- [ ] Pull-to-refresh in the Sessions tab revalidates the agent directory.
- [ ] Switch back to **Projects** and confirm the existing workspace list, "Add project" button, collapse state, and shortcuts still work.

**Mobile**
- [ ] Open the sidebar and confirm the **Projects / Sessions** segmented control is in the header.
- [ ] Tap **Sessions**, tap a session row, and confirm the sidebar overlay closes and the workspace opens with that agent selected.
- [ ] Pull-to-refresh in the Sessions tab works.
- [ ] **Projects** tab still behaves exactly as before (workspace list, add-project, settings, host switcher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)