### PR TITLE
feat(app): add configurable mobile history bootstrap limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -31,8 +31,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -55,8 +55,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Fetch origin/main (worktree tests)
         run: git fetch --no-tags origin main:refs/remotes/origin/main
@@ -85,8 +85,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -123,8 +123,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -135,15 +135,34 @@ jobs:
       - name: Run app unit tests
         run: npm run test --workspace=@getpaseo/app
 
+  playwright-preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      has_openai_api_key: ${{ steps.secret-check.outputs.has_openai_api_key }}
+    steps:
+      - name: Detect OpenAI key availability
+        id: secret-check
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -n "$OPENAI_API_KEY" ]; then
+            echo "has_openai_api_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_openai_api_key=false" >> "$GITHUB_OUTPUT"
+          fi
+
   playwright:
+    needs: playwright-preflight
+    if: ${{ needs.playwright-preflight.outputs.has_openai_api_key == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -185,8 +204,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -204,8 +223,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -219,6 +238,6 @@ jobs:
       - name: Run CLI tests
         run: npm run test --workspace=@getpaseo/cli
         env:
-          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: '0'
-          PASEO_DICTATION_ENABLED: '0'
-          PASEO_VOICE_MODE_ENABLED: '0'
+          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: "0"
+          PASEO_DICTATION_ENABLED: "0"
+          PASEO_VOICE_MODE_ENABLED: "0"

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -3,14 +3,15 @@ name: Deploy App
 on:
   push:
     tags:
-      - 'v*'
-      - '!v*-rc.*'
-      - 'app-v*'
-      - '!app-v*-rc.*'
+      - "v*"
+      - "!v*-rc.*"
+      - "app-v*"
+      - "!app-v*-rc.*"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -18,10 +19,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@boudra'
+          node-version: "22"
+          cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@boudra"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/app --include-workspace-root

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/relay/**'
-      - '.github/workflows/deploy-relay.yml'
+      - "packages/relay/**"
+      - ".github/workflows/deploy-relay.yml"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -17,8 +18,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/relay --include-workspace-root
@@ -30,4 +31,3 @@ jobs:
         run: cd packages/relay && npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/website/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'patches/**'
-      - '.github/workflows/deploy-website.yml'
+      - "packages/website/**"
+      - "package.json"
+      - "package-lock.json"
+      - "patches/**"
+      - ".github/workflows/deploy-website.yml"
   release:
     types: [published, edited]
   workflow_dispatch:
 
 jobs:
   deploy:
-    if: ${{ github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft) }}
+    if: ${{ github.repository == 'getpaseo/paseo' && (github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft)) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -23,8 +23,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/website --include-workspace-root

--- a/packages/app/metro.config.cjs
+++ b/packages/app/metro.config.cjs
@@ -7,7 +7,10 @@ const projectRoot = __dirname;
 const appNodeModulesRoot = path.resolve(projectRoot, "node_modules");
 const appSrcRoot = path.resolve(projectRoot, "src");
 const serverSrcRoot = path.resolve(projectRoot, "../server/src");
+const relayPackageRoot = path.resolve(projectRoot, "../relay");
 const relaySrcRoot = path.resolve(projectRoot, "../relay/src");
+const highlightPackageRoot = path.resolve(projectRoot, "../highlight");
+const expoTwoWayAudioPackageRoot = path.resolve(projectRoot, "../expo-two-way-audio");
 const customWebPlatform = (process.env.PASEO_WEB_PLATFORM ?? "")
   .trim()
   .replace(/^\./, "")
@@ -23,11 +26,26 @@ const pathSeparatorPattern = "[\\\\/]";
 
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules ?? {}),
+  "@server": serverSrcRoot,
+  "@relay": relaySrcRoot,
+  "@getpaseo/relay": relayPackageRoot,
+  "@getpaseo/highlight": highlightPackageRoot,
+  "@getpaseo/expo-two-way-audio": expoTwoWayAudioPackageRoot,
   react: path.join(appNodeModulesRoot, "react"),
   "react-dom": path.join(appNodeModulesRoot, "react-dom"),
   "react/jsx-runtime": path.join(appNodeModulesRoot, "react/jsx-runtime"),
   "react/jsx-dev-runtime": path.join(appNodeModulesRoot, "react/jsx-dev-runtime"),
 };
+config.watchFolders = [
+  ...new Set([
+    ...(config.watchFolders ?? []),
+    serverSrcRoot,
+    relayPackageRoot,
+    relaySrcRoot,
+    highlightPackageRoot,
+    expoTwoWayAudioPackageRoot,
+  ]),
+];
 config.resolver.blockList = new RegExp(
   `(^${escapedAppSrcRoot}${pathSeparatorPattern}.*\\.(test|spec)\\.(ts|tsx)$|${pathSeparatorPattern}__tests__${pathSeparatorPattern}.*)$`,
 );

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -659,7 +659,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
     }
 
     const serverInfo = client.getLastServerInfoMessage();
-    if (!serverInfo?.features?.providersSnapshot) {
+    if (serverInfo?.features?.providersSnapshot === false) {
       return;
     }
 

--- a/packages/app/src/hooks/use-agent-initialization.test.ts
+++ b/packages/app/src/hooks/use-agent-initialization.test.ts
@@ -74,6 +74,14 @@ describe("useAgentInitialization timeline request policy", () => {
     ).toBe(500);
   });
 
+  it("defaults mobile platforms to the bounded native bootstrap window", () => {
+    expect(
+      __private__.resolveInitialTimelineLimit({
+        platform: "android",
+      }),
+    ).toBe(100);
+  });
+
   it("keeps web bootstraps unbounded regardless of the native setting", () => {
     expect(
       __private__.resolveInitialTimelineLimit({

--- a/packages/app/src/hooks/use-agent-initialization.test.ts
+++ b/packages/app/src/hooks/use-agent-initialization.test.ts
@@ -65,6 +65,24 @@ describe("useAgentInitialization timeline request policy", () => {
     });
   });
 
+  it("uses the configured native message limit on mobile platforms", () => {
+    expect(
+      __private__.resolveInitialTimelineLimit({
+        platform: "ios",
+        nativeInitialTimelineLimit: 500,
+      }),
+    ).toBe(500);
+  });
+
+  it("keeps web bootstraps unbounded regardless of the native setting", () => {
+    expect(
+      __private__.resolveInitialTimelineLimit({
+        platform: "web",
+        nativeInitialTimelineLimit: 500,
+      }),
+    ).toBe(0);
+  });
+
   it("does not expose an RPC-success init fallback", () => {
     expect("shouldResolveInitFromRpcSuccess" in __private__).toBe(false);
   });

--- a/packages/app/src/hooks/use-agent-initialization.ts
+++ b/packages/app/src/hooks/use-agent-initialization.ts
@@ -10,10 +10,9 @@ import {
   rejectInitDeferred,
 } from "@/utils/agent-initialization";
 import { deriveInitialTimelineRequest } from "@/contexts/session-timeline-bootstrap-policy";
-import { useAppSettings } from "@/hooks/use-settings";
+import { DEFAULT_APP_SETTINGS, useAppSettings } from "@/hooks/use-settings";
 
 const INIT_TIMEOUT_MS = 5 * 60_000;
-const NATIVE_INITIAL_TIMELINE_LIMIT = 200;
 const UNBOUNDED_TIMELINE_LIMIT = 0;
 
 function resolveInitialTimelineLimit(input?: {
@@ -24,7 +23,7 @@ function resolveInitialTimelineLimit(input?: {
   if (platform === "web") {
     return UNBOUNDED_TIMELINE_LIMIT;
   }
-  return input?.nativeInitialTimelineLimit ?? NATIVE_INITIAL_TIMELINE_LIMIT;
+  return input?.nativeInitialTimelineLimit ?? DEFAULT_APP_SETTINGS.nativeInitialTimelineLimit;
 }
 
 export const __private__ = {

--- a/packages/app/src/hooks/use-agent-initialization.ts
+++ b/packages/app/src/hooks/use-agent-initialization.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { Platform } from "react-native";
 import { useSessionStore } from "@/stores/session-store";
 import type { DaemonClient } from "@server/client/daemon-client";
 import {
@@ -9,14 +10,21 @@ import {
   rejectInitDeferred,
 } from "@/utils/agent-initialization";
 import { deriveInitialTimelineRequest } from "@/contexts/session-timeline-bootstrap-policy";
-import { isWeb } from "@/constants/platform";
+import { useAppSettings } from "@/hooks/use-settings";
 
 const INIT_TIMEOUT_MS = 5 * 60_000;
 const NATIVE_INITIAL_TIMELINE_LIMIT = 200;
 const UNBOUNDED_TIMELINE_LIMIT = 0;
 
-function resolveInitialTimelineLimit(): number {
-  return isWeb ? UNBOUNDED_TIMELINE_LIMIT : NATIVE_INITIAL_TIMELINE_LIMIT;
+function resolveInitialTimelineLimit(input?: {
+  platform?: string;
+  nativeInitialTimelineLimit?: number;
+}): number {
+  const platform = input?.platform ?? Platform.OS;
+  if (platform === "web") {
+    return UNBOUNDED_TIMELINE_LIMIT;
+  }
+  return input?.nativeInitialTimelineLimit ?? NATIVE_INITIAL_TIMELINE_LIMIT;
 }
 
 export const __private__ = {
@@ -31,6 +39,7 @@ export function useAgentInitialization({
   serverId: string;
   client: DaemonClient | null;
 }) {
+  const { settings } = useAppSettings();
   const setInitializingAgents = useSessionStore((state) => state.setInitializingAgents);
   const setAgentInitializing = useCallback(
     (agentId: string, initializing: boolean) => {
@@ -56,7 +65,9 @@ export function useAgentInitialization({
 
       const session = useSessionStore.getState().sessions[serverId];
       const cursor = session?.agentTimelineCursor.get(agentId);
-      const initialTimelineLimit = resolveInitialTimelineLimit();
+      const initialTimelineLimit = resolveInitialTimelineLimit({
+        nativeInitialTimelineLimit: settings.nativeInitialTimelineLimit,
+      });
       const hasAuthoritativeHistory =
         session?.agentAuthoritativeHistoryApplied.get(agentId) === true;
       const timelineRequest = deriveInitialTimelineRequest({
@@ -91,7 +102,7 @@ export function useAgentInitialization({
 
       return deferred.promise;
     },
-    [client, serverId, setAgentInitializing],
+    [client, serverId, setAgentInitializing, settings.nativeInitialTimelineLimit],
   );
 
   const refreshAgent = useCallback(
@@ -103,7 +114,9 @@ export function useAgentInitialization({
 
       try {
         await client.refreshAgent(agentId);
-        const initialTimelineLimit = resolveInitialTimelineLimit();
+        const initialTimelineLimit = resolveInitialTimelineLimit({
+          nativeInitialTimelineLimit: settings.nativeInitialTimelineLimit,
+        });
         await client.fetchAgentTimeline(agentId, {
           direction: "tail",
           limit: initialTimelineLimit,
@@ -114,7 +127,7 @@ export function useAgentInitialization({
         throw error;
       }
     },
-    [client, setAgentInitializing],
+    [client, setAgentInitializing, settings.nativeInitialTimelineLimit],
   );
 
   return { ensureAgentIsInitialized, refreshAgent };

--- a/packages/app/src/hooks/use-providers-snapshot.ts
+++ b/packages/app/src/hooks/use-providers-snapshot.ts
@@ -25,16 +25,17 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
   const queryClient = useQueryClient();
   const client = useHostRuntimeClient(serverId ?? "");
   const isConnected = useHostRuntimeIsConnected(serverId ?? "");
-  const supportsSnapshot = useSessionForServer(
+  const serverSupportsSnapshot = useSessionForServer(
     serverId,
-    (session) => session?.serverInfo?.features?.providersSnapshot === true,
+    (session) => session?.serverInfo?.features?.providersSnapshot,
   );
+  const supportsSnapshot = serverSupportsSnapshot !== false;
 
   const queryKey = useMemo(() => providersSnapshotQueryKey(serverId), [serverId]);
 
   const snapshotQuery = useQuery({
     queryKey,
-    enabled: Boolean(supportsSnapshot && serverId && client && isConnected),
+    enabled: Boolean(serverId && client && isConnected && supportsSnapshot),
     staleTime: 60_000,
     queryFn: async () => {
       if (!client) {
@@ -55,7 +56,7 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
   const { mutateAsync: refreshSnapshot, isPending: isRefreshing } = refreshMutation;
 
   useEffect(() => {
-    if (!supportsSnapshot || !client || !isConnected || !serverId) {
+    if (!client || !isConnected || !serverId || !supportsSnapshot) {
       return;
     }
 

--- a/packages/app/src/hooks/use-settings.test.ts
+++ b/packages/app/src/hooks/use-settings.test.ts
@@ -40,12 +40,13 @@ describe("use-settings", () => {
     expect(result.theme).toBe("auto");
   });
 
-  it("loads persisted built-in daemon management state", async () => {
+  it("loads persisted built-in daemon management state and normalizes the native limit", async () => {
     asyncStorageMock.getItem.mockImplementation(async (key: string) => {
       if (key === "@paseo:app-settings") {
         return JSON.stringify({
           theme: "light",
           manageBuiltInDaemon: false,
+          nativeInitialTimelineLimit: 500,
         });
       }
       return null;
@@ -58,7 +59,31 @@ describe("use-settings", () => {
       theme: "light",
       manageBuiltInDaemon: false,
       sendBehavior: "interrupt",
+      nativeInitialTimelineLimit: 500,
     });
     expect(asyncStorageMock.setItem).not.toHaveBeenCalled();
+  });
+});
+
+describe("app settings normalization", () => {
+  it("accepts supported native initial timeline limits", async () => {
+    const mod = await import("./use-settings");
+
+    expect(mod.__private__.normalizeNativeInitialTimelineLimit(500)).toBe(500);
+    expect(mod.__private__.normalizeNativeInitialTimelineLimit(0)).toBe(0);
+  });
+
+  it("falls back to the default limit for unsupported values", async () => {
+    const mod = await import("./use-settings");
+
+    expect(mod.__private__.normalizeNativeInitialTimelineLimit(-1)).toBe(
+      mod.DEFAULT_APP_SETTINGS.nativeInitialTimelineLimit,
+    );
+    expect(mod.__private__.normalizeNativeInitialTimelineLimit(123)).toBe(
+      mod.DEFAULT_APP_SETTINGS.nativeInitialTimelineLimit,
+    );
+    expect(mod.__private__.normalizeNativeInitialTimelineLimit("500")).toBe(
+      mod.DEFAULT_APP_SETTINGS.nativeInitialTimelineLimit,
+    );
   });
 });

--- a/packages/app/src/hooks/use-settings.test.ts
+++ b/packages/app/src/hooks/use-settings.test.ts
@@ -40,6 +40,16 @@ describe("use-settings", () => {
     expect(result.theme).toBe("auto");
   });
 
+  it("defaults the native history bootstrap limit to a bounded mobile window", async () => {
+    asyncStorageMock.getItem.mockResolvedValue(null);
+    asyncStorageMock.setItem.mockResolvedValue();
+
+    const mod = await import("./use-settings");
+    const result = await mod.loadSettingsFromStorage();
+
+    expect(result.nativeInitialTimelineLimit).toBe(100);
+  });
+
   it("loads persisted built-in daemon management state and normalizes the native limit", async () => {
     asyncStorageMock.getItem.mockImplementation(async (key: string) => {
       if (key === "@paseo:app-settings") {

--- a/packages/app/src/hooks/use-settings.ts
+++ b/packages/app/src/hooks/use-settings.ts
@@ -5,6 +5,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 export const APP_SETTINGS_KEY = "@paseo:app-settings";
 const LEGACY_SETTINGS_KEY = "@paseo:settings";
 const APP_SETTINGS_QUERY_KEY = ["app-settings"];
+const SUPPORTED_NATIVE_INITIAL_TIMELINE_LIMITS = new Set<number>([0, 100, 200, 500, 1000]);
 
 import { THEME_TO_UNISTYLES, type ThemeName } from "@/styles/theme";
 
@@ -16,12 +17,14 @@ export interface AppSettings {
   theme: ThemeName | "auto";
   manageBuiltInDaemon: boolean;
   sendBehavior: SendBehavior;
+  nativeInitialTimelineLimit: number;
 }
 
 export const DEFAULT_APP_SETTINGS: AppSettings = {
   theme: "auto",
   manageBuiltInDaemon: true,
   sendBehavior: "interrupt",
+  nativeInitialTimelineLimit: 200,
 };
 
 export interface UseAppSettingsReturn {
@@ -85,6 +88,9 @@ export async function loadSettingsFromStorage(): Promise<AppSettings> {
       if (parsed.theme && !VALID_THEMES.has(parsed.theme)) {
         parsed.theme = DEFAULT_APP_SETTINGS.theme;
       }
+      parsed.nativeInitialTimelineLimit = normalizeNativeInitialTimelineLimit(
+        parsed.nativeInitialTimelineLimit,
+      );
       return { ...DEFAULT_APP_SETTINGS, ...parsed };
     }
 
@@ -119,3 +125,17 @@ function pickAppSettingsFromLegacy(legacy: Record<string, unknown>): Partial<App
 }
 
 export const useSettings = useAppSettings;
+
+export function normalizeNativeInitialTimelineLimit(value: unknown): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    return DEFAULT_APP_SETTINGS.nativeInitialTimelineLimit;
+  }
+  if (!SUPPORTED_NATIVE_INITIAL_TIMELINE_LIMITS.has(value)) {
+    return DEFAULT_APP_SETTINGS.nativeInitialTimelineLimit;
+  }
+  return value;
+}
+
+export const __private__ = {
+  normalizeNativeInitialTimelineLimit,
+};

--- a/packages/app/src/hooks/use-settings.ts
+++ b/packages/app/src/hooks/use-settings.ts
@@ -24,7 +24,7 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   theme: "auto",
   manageBuiltInDaemon: true,
   sendBehavior: "interrupt",
-  nativeInitialTimelineLimit: 200,
+  nativeInitialTimelineLimit: 100,
 };
 
 export interface UseAppSettingsReturn {

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -367,6 +367,7 @@ interface GeneralSectionProps {
   settings: AppSettings;
   handleThemeChange: (theme: AppSettings["theme"]) => void;
   handleSendBehaviorChange: (behavior: SendBehavior) => void;
+  handleNativeInitialTimelineLimitChange: (limit: number) => void;
 }
 
 function ThemeIcon({
@@ -415,11 +416,20 @@ const THEME_LABELS: Record<AppSettings["theme"], string> = {
   auto: "System",
 };
 
+const NATIVE_INITIAL_TIMELINE_LIMIT_LABELS: Record<number, string> = {
+  0: "All",
+  100: "100",
+  200: "200",
+  500: "500",
+  1000: "1000",
+};
+
 function GeneralSection({
   routeServerId,
   settings,
   handleThemeChange,
   handleSendBehaviorChange,
+  handleNativeInitialTimelineLimitChange,
 }: GeneralSectionProps) {
   const { theme } = useUnistyles();
   const isConnected = useHostRuntimeIsConnected(routeServerId);
@@ -484,6 +494,39 @@ function GeneralSection({
               { value: "queue", label: "Queue" },
             ]}
           />
+        </View>
+        <View style={[styles.audioRow, styles.audioRowBorder]}>
+          <View style={styles.audioRowContent}>
+            <Text style={styles.audioRowTitle}>Mobile history window</Text>
+            <Text style={styles.audioRowSubtitle}>
+              Maximum canonical messages fetched when a mobile session opens
+            </Text>
+          </View>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              style={({ pressed }) => [styles.themeTrigger, pressed && { opacity: 0.85 }]}
+            >
+              <Text style={styles.themeTriggerText}>
+                {
+                  NATIVE_INITIAL_TIMELINE_LIMIT_LABELS[
+                    settings.nativeInitialTimelineLimit as keyof typeof NATIVE_INITIAL_TIMELINE_LIMIT_LABELS
+                  ]
+                }
+              </Text>
+              <ChevronDown size={theme.iconSize.sm} color={iconColor} />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="bottom" align="end" width={140}>
+              {([100, 200, 500, 1000, 0] as const).map((limit) => (
+                <DropdownMenuItem
+                  key={String(limit)}
+                  selected={settings.nativeInitialTimelineLimit === limit}
+                  onSelect={() => handleNativeInitialTimelineLimitChange(limit)}
+                >
+                  {NATIVE_INITIAL_TIMELINE_LIMIT_LABELS[limit]}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </View>
         {routeServerId.length > 0 && isConnected ? (
           <View style={[styles.audioRow, styles.audioRowBorder]}>
@@ -1079,6 +1122,13 @@ export default function SettingsScreen() {
     [updateSettings],
   );
 
+  const handleNativeInitialTimelineLimitChange = useCallback(
+    (limit: number) => {
+      void updateSettings({ nativeInitialTimelineLimit: limit });
+    },
+    [updateSettings],
+  );
+
   const handlePlaybackTest = useCallback(async () => {
     if (!voiceAudioEngine || isPlaybackTestRunning) {
       return;
@@ -1147,6 +1197,7 @@ export default function SettingsScreen() {
     settings,
     handleThemeChange,
     handleSendBehaviorChange,
+    handleNativeInitialTimelineLimitChange,
   };
 
   const diagnosticsProps: DiagnosticsSectionProps = {

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -417,7 +417,7 @@ const THEME_LABELS: Record<AppSettings["theme"], string> = {
 };
 
 const NATIVE_INITIAL_TIMELINE_LIMIT_LABELS: Record<number, string> = {
-  0: "All",
+  0: "All (slow)",
   100: "100",
   200: "200",
   500: "500",
@@ -499,7 +499,8 @@ function GeneralSection({
           <View style={styles.audioRowContent}>
             <Text style={styles.audioRowTitle}>Mobile history window</Text>
             <Text style={styles.audioRowSubtitle}>
-              Maximum canonical messages fetched when a mobile session opens
+              Maximum canonical messages fetched when a mobile session opens. Larger windows cost
+              more memory, network, and reconnect time.
             </Text>
           </View>
           <DropdownMenu>

--- a/packages/server/src/client/daemon-client.test.ts
+++ b/packages/server/src/client/daemon-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, expectTypeOf, test, vi } from "vitest";
 import { DaemonClient, type DaemonTransport } from "./daemon-client";
+import * as SharedMessages from "../shared/messages.js";
 import {
   asUint8Array,
   decodeTerminalResizePayload,
@@ -1824,6 +1825,91 @@ describe("DaemonClient", () => {
       expect(firstEntry.item.error).toBeNull();
       expect(firstEntry.item.detail.type).toBe("shell");
     }
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test("falls back to raw session handling when outbound schema parsing throws", async () => {
+    const logger = createMockLogger();
+    const mock = createMockTransport();
+
+    const client = new DaemonClient({
+      url: "ws://test",
+      clientId: "clsk_unit_test",
+      logger,
+      reconnect: { enabled: false },
+      transportFactory: () => mock.transport,
+    });
+    clients.push(client);
+
+    const connectPromise = client.connect();
+    mock.triggerOpen();
+    await connectPromise;
+
+    const received: unknown[] = [];
+    const unsubscribe = client.on("fetch_agent_timeline_response", (msg) => {
+      received.push(msg);
+    });
+
+    const safeParseSpy = vi
+      .spyOn(SharedMessages.WSOutboundMessageSchema, "safeParse")
+      .mockImplementationOnce(() => {
+        throw new TypeError("Cannot read property '_zod' of undefined");
+      });
+
+    mock.triggerMessage(
+      wrapSessionMessage({
+        type: "fetch_agent_timeline_response",
+        payload: {
+          requestId: "req-fallback",
+          agentId: "agent_cli",
+          agent: null,
+          direction: "tail",
+          projection: "projected",
+          epoch: "epoch-1",
+          reset: false,
+          staleCursor: false,
+          gap: false,
+          window: { minSeq: 1, maxSeq: 1, nextSeq: 2 },
+          startCursor: { epoch: "epoch-1", seq: 1 },
+          endCursor: { epoch: "epoch-1", seq: 1 },
+          hasOlder: false,
+          hasNewer: false,
+          entries: [
+            {
+              timestamp: "2026-02-08T20:20:00.000Z",
+              provider: "codex",
+              seqStart: 1,
+              seqEnd: 1,
+              sourceSeqRanges: [{ startSeq: 1, endSeq: 1 }],
+              collapsed: [],
+              item: {
+                type: "tool_call",
+                callId: "call_cli_fallback",
+                name: "shell",
+                status: "running",
+                detail: {
+                  type: "shell",
+                  command: "pwd",
+                },
+                error: null,
+              },
+            },
+          ],
+          error: null,
+        },
+      }),
+    );
+
+    safeParseSpy.mockRestore();
+    unsubscribe();
+
+    expect(received).toHaveLength(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msgType: "fetch_agent_timeline_response",
+      }),
+      "Message schema parse threw; falling back to raw session handling",
+    );
     expect(logger.warn).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -108,6 +108,20 @@ const consoleLogger: Logger = {
   error: (obj, msg) => console.error(msg, obj),
 };
 
+function getRawSessionMessage(
+  payload: unknown,
+): { type: string } & Record<string, unknown> | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const record = payload as { type?: unknown; message?: unknown };
+  if (record.type !== "session" || !record.message || typeof record.message !== "object") {
+    return null;
+  }
+  const message = record.message as { type?: unknown } & Record<string, unknown>;
+  return typeof message.type === "string" ? message : null;
+}
+
 export type {
   DaemonTransport,
   DaemonTransportFactory,
@@ -3609,7 +3623,30 @@ export class DaemonClient {
       return;
     }
 
-    const parsed = WSOutboundMessageSchema.safeParse(parsedJson);
+    let parsed: ReturnType<typeof WSOutboundMessageSchema.safeParse>;
+    try {
+      parsed = WSOutboundMessageSchema.safeParse(parsedJson);
+    } catch (error) {
+      const rawSessionMessage = getRawSessionMessage(parsedJson);
+      if (rawSessionMessage) {
+        this.logger.debug(
+          {
+            msgType: rawSessionMessage.type,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Message schema parse threw; falling back to raw session handling",
+        );
+        this.handleSessionMessage(rawSessionMessage as SessionOutboundMessage);
+        return;
+      }
+      this.logger.warn(
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Message schema parse threw",
+      );
+      return;
+    }
     if (!parsed.success) {
       const msgType = (parsedJson as { type?: string })?.type ?? "unknown";
       this.logger.warn({ msgType, error: parsed.error.message }, "Message validation failed");

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -110,7 +110,7 @@ const consoleLogger: Logger = {
 
 function getRawSessionMessage(
   payload: unknown,
-): { type: string } & Record<string, unknown> | null {
+): ({ type: string } & Record<string, unknown>) | null {
   if (!payload || typeof payload !== "object") {
     return null;
   }
@@ -119,7 +119,9 @@ function getRawSessionMessage(
     return null;
   }
   const message = record.message as { type?: unknown } & Record<string, unknown>;
-  return typeof message.type === "string" ? message : null;
+  return typeof message.type === "string"
+    ? ({ ...message, type: message.type } as { type: string } & Record<string, unknown>)
+    : null;
 }
 
 export type {

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -855,7 +855,7 @@ export const GetProvidersSnapshotRequestMessageSchema = z.object({
 export const RefreshProvidersSnapshotRequestMessageSchema = z.object({
   type: z.literal("refresh_providers_snapshot_request"),
   cwd: z.string().optional(),
-  providers: z.array(AgentProviderSchema).optional(),
+  providers: z.array(AgentProviderValueSchema).optional(),
   requestId: z.string(),
 });
 

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -3,7 +3,8 @@ import { AGENT_LIFECYCLE_STATUSES } from "./agent-lifecycle.js";
 import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "../server/agent/agent-title-limits.js";
 import { AgentProviderSchema as ImportedAgentProviderSchema } from "../server/agent/provider-manifest.js";
 // COMPAT(rn-dev-client): Metro can evaluate this import path as undefined during circular init.
-const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ?? z.string()) as z.ZodType<string>;
+const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ??
+  z.string()) as z.ZodType<string>;
 import { TOOL_CALL_ICON_NAMES } from "../server/agent/agent-sdk-types.js";
 import {
   ChatCreateRequestSchema,

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 import { AGENT_LIFECYCLE_STATUSES } from "./agent-lifecycle.js";
 import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "../server/agent/agent-title-limits.js";
-import { AgentProviderSchema } from "../server/agent/provider-manifest.js";
+import { AgentProviderSchema as ImportedAgentProviderSchema } from "../server/agent/provider-manifest.js";
+// COMPAT(rn-dev-client): Metro can evaluate this import path as undefined during circular init.
+const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ?? z.string()) as z.ZodType<string>;
 import { TOOL_CALL_ICON_NAMES } from "../server/agent/agent-sdk-types.js";
 import {
   ChatCreateRequestSchema,
@@ -139,7 +141,7 @@ export const AgentFeatureSchema = z.discriminatedUnion("type", [
 ]);
 
 const AgentModelDefinitionSchema: z.ZodType<AgentModelDefinition> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   id: z.string(),
   label: z.string(),
   description: z.string().optional(),
@@ -150,7 +152,7 @@ const AgentModelDefinitionSchema: z.ZodType<AgentModelDefinition> = z.object({
 });
 
 const ProviderSnapshotEntrySchema: z.ZodType<ProviderSnapshotEntry> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   status: ProviderStatusSchema,
   error: z.string().optional(),
   models: z.array(AgentModelDefinitionSchema).optional(),
@@ -205,7 +207,7 @@ const McpServerConfigSchema = z.discriminatedUnion("type", [
 ]);
 
 const AgentSessionConfigSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   modeId: z.string().optional(),
   model: z.string().optional(),
@@ -253,7 +255,7 @@ export const AgentPermissionResponseSchema: z.ZodType<AgentPermissionResponse> =
 
 export const AgentPermissionRequestPayloadSchema: z.ZodType<AgentPermissionRequest> = z.object({
   id: z.string(),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   name: z.string(),
   kind: z.enum(["tool", "plan", "question", "mode", "other"]),
   title: z.string().optional(),
@@ -467,48 +469,48 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("thread_started"),
     sessionId: z.string(),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
   }),
   z.object({
     type: z.literal("turn_started"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
   }),
   z.object({
     type: z.literal("turn_completed"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     usage: AgentUsageSchema.optional(),
   }),
   z.object({
     type: z.literal("turn_failed"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     error: z.string(),
     code: z.string().optional(),
     diagnostic: z.string().optional(),
   }),
   z.object({
     type: z.literal("turn_canceled"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     reason: z.string(),
   }),
   z.object({
     type: z.literal("timeline"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     item: AgentTimelineItemPayloadSchema,
   }),
   z.object({
     type: z.literal("permission_requested"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     request: AgentPermissionRequestPayloadSchema,
   }),
   z.object({
     type: z.literal("permission_resolved"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     requestId: z.string(),
     resolution: AgentPermissionResponseSchema,
   }),
   z.object({
     type: z.literal("attention_required"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     reason: z.enum(["finished", "error", "permission"]),
     timestamp: z.string(),
     shouldNotify: z.boolean(),
@@ -528,7 +530,7 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
 
 const AgentPersistenceHandleSchema: z.ZodType<AgentPersistenceHandle | null> = z
   .object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     sessionId: z.string(),
     nativeHandle: z.string().optional(),
     metadata: z.record(z.unknown()).optional(),
@@ -536,7 +538,7 @@ const AgentPersistenceHandleSchema: z.ZodType<AgentPersistenceHandle | null> = z
   .nullable();
 
 const AgentRuntimeInfoSchema: z.ZodType<AgentRuntimeInfo> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   sessionId: z.string().nullable(),
   model: z.string().nullable().optional(),
   thinkingOptionId: z.string().nullable().optional(),
@@ -546,7 +548,7 @@ const AgentRuntimeInfoSchema: z.ZodType<AgentRuntimeInfo> = z.object({
 
 export const AgentSnapshotPayloadSchema = z.object({
   id: z.string(),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   model: z.string().nullable(),
   features: z.array(AgentFeatureSchema).optional(),
@@ -826,14 +828,14 @@ export const CreateAgentRequestMessageSchema = z.object({
 
 export const ListProviderModelsRequestMessageSchema = z.object({
   type: z.literal("list_provider_models_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string().optional(),
   requestId: z.string(),
 });
 
 export const ListProviderModesRequestMessageSchema = z.object({
   type: z.literal("list_provider_modes_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string().optional(),
   requestId: z.string(),
 });
@@ -858,7 +860,7 @@ export const RefreshProvidersSnapshotRequestMessageSchema = z.object({
 
 export const ProviderDiagnosticRequestMessageSchema = z.object({
   type: z.literal("provider_diagnostic_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   requestId: z.string(),
 });
 
@@ -1329,7 +1331,7 @@ export const PingMessageSchema = z.object({
 });
 
 const ListCommandsDraftConfigSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   modeId: z.string().optional(),
   model: z.string().optional(),
@@ -2071,7 +2073,7 @@ const AgentTimelineSeqRangeSchema = z.object({
 });
 
 export const AgentTimelineEntryPayloadSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   item: AgentTimelineItemPayloadSchema,
   timestamp: z.string(),
   seqStart: z.number().int().nonnegative(),
@@ -2548,7 +2550,7 @@ export const FileDownloadTokenResponseSchema = z.object({
 export const ListProviderModelsResponseMessageSchema = z.object({
   type: z.literal("list_provider_models_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     models: z.array(AgentModelDefinitionSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2559,7 +2561,7 @@ export const ListProviderModelsResponseMessageSchema = z.object({
 export const ListProviderModesResponseMessageSchema = z.object({
   type: z.literal("list_provider_modes_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     modes: z.array(AgentModeSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2570,7 +2572,7 @@ export const ListProviderModesResponseMessageSchema = z.object({
 export const ListProviderFeaturesResponseMessageSchema = z.object({
   type: z.literal("list_provider_features_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     features: z.array(AgentFeatureSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2579,7 +2581,7 @@ export const ListProviderFeaturesResponseMessageSchema = z.object({
 });
 
 const ProviderAvailabilitySchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   available: z.boolean(),
   error: z.string().nullable().optional(),
 });
@@ -2627,7 +2629,7 @@ export const RefreshProvidersSnapshotResponseMessageSchema = z.object({
 export const ProviderDiagnosticResponseMessageSchema = z.object({
   type: z.literal("provider_diagnostic_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     diagnostic: z.string(),
     requestId: z.string(),
   }),


### PR DESCRIPTION
## Status Update (2026-05-08)
- Mobile history bootstrap handling is included in the updated forward-port branch on PR #333.
- The latest external-session recovery and history-sync behavior restoration is also carried there (commit `8e31f672`).

## Recommendation
- Keep this PR for historical traceability only.
- Prefer reviewing and merging #333 as the consolidated path.