### PR TITLE
feat(app): focus sent messages in the stream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -31,8 +31,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -55,8 +55,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Fetch origin/main (worktree tests)
         run: git fetch --no-tags origin main:refs/remotes/origin/main
@@ -85,8 +85,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -123,8 +123,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -135,15 +135,34 @@ jobs:
       - name: Run app unit tests
         run: npm run test --workspace=@getpaseo/app
 
+  playwright-preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      has_openai_api_key: ${{ steps.secret-check.outputs.has_openai_api_key }}
+    steps:
+      - name: Detect OpenAI key availability
+        id: secret-check
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -n "$OPENAI_API_KEY" ]; then
+            echo "has_openai_api_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_openai_api_key=false" >> "$GITHUB_OUTPUT"
+          fi
+
   playwright:
+    needs: playwright-preflight
+    if: ${{ needs.playwright-preflight.outputs.has_openai_api_key == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -185,8 +204,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -204,8 +223,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -219,6 +238,6 @@ jobs:
       - name: Run CLI tests
         run: npm run test --workspace=@getpaseo/cli
         env:
-          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: '0'
-          PASEO_DICTATION_ENABLED: '0'
-          PASEO_VOICE_MODE_ENABLED: '0'
+          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: "0"
+          PASEO_DICTATION_ENABLED: "0"
+          PASEO_VOICE_MODE_ENABLED: "0"

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -3,14 +3,15 @@ name: Deploy App
 on:
   push:
     tags:
-      - 'v*'
-      - '!v*-rc.*'
-      - 'app-v*'
-      - '!app-v*-rc.*'
+      - "v*"
+      - "!v*-rc.*"
+      - "app-v*"
+      - "!app-v*-rc.*"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -18,10 +19,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@boudra'
+          node-version: "22"
+          cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@boudra"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/app --include-workspace-root

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/relay/**'
-      - '.github/workflows/deploy-relay.yml'
+      - "packages/relay/**"
+      - ".github/workflows/deploy-relay.yml"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -17,8 +18,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/relay --include-workspace-root
@@ -30,4 +31,3 @@ jobs:
         run: cd packages/relay && npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/website/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'patches/**'
-      - '.github/workflows/deploy-website.yml'
+      - "packages/website/**"
+      - "package.json"
+      - "package-lock.json"
+      - "patches/**"
+      - ".github/workflows/deploy-website.yml"
   release:
     types: [published, edited]
   workflow_dispatch:
 
 jobs:
   deploy:
-    if: ${{ github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft) }}
+    if: ${{ github.repository == 'getpaseo/paseo' && (github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft)) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -23,8 +23,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/website --include-workspace-root

--- a/packages/app/metro.config.cjs
+++ b/packages/app/metro.config.cjs
@@ -7,7 +7,10 @@ const projectRoot = __dirname;
 const appNodeModulesRoot = path.resolve(projectRoot, "node_modules");
 const appSrcRoot = path.resolve(projectRoot, "src");
 const serverSrcRoot = path.resolve(projectRoot, "../server/src");
+const relayPackageRoot = path.resolve(projectRoot, "../relay");
 const relaySrcRoot = path.resolve(projectRoot, "../relay/src");
+const highlightPackageRoot = path.resolve(projectRoot, "../highlight");
+const expoTwoWayAudioPackageRoot = path.resolve(projectRoot, "../expo-two-way-audio");
 const customWebPlatform = (process.env.PASEO_WEB_PLATFORM ?? "")
   .trim()
   .replace(/^\./, "")
@@ -23,11 +26,26 @@ const pathSeparatorPattern = "[\\\\/]";
 
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules ?? {}),
+  "@server": serverSrcRoot,
+  "@relay": relaySrcRoot,
+  "@getpaseo/relay": relayPackageRoot,
+  "@getpaseo/highlight": highlightPackageRoot,
+  "@getpaseo/expo-two-way-audio": expoTwoWayAudioPackageRoot,
   react: path.join(appNodeModulesRoot, "react"),
   "react-dom": path.join(appNodeModulesRoot, "react-dom"),
   "react/jsx-runtime": path.join(appNodeModulesRoot, "react/jsx-runtime"),
   "react/jsx-dev-runtime": path.join(appNodeModulesRoot, "react/jsx-dev-runtime"),
 };
+config.watchFolders = [
+  ...new Set([
+    ...(config.watchFolders ?? []),
+    serverSrcRoot,
+    relayPackageRoot,
+    relaySrcRoot,
+    highlightPackageRoot,
+    expoTwoWayAudioPackageRoot,
+  ]),
+];
 config.resolver.blockList = new RegExp(
   `(^${escapedAppSrcRoot}${pathSeparatorPattern}.*\\.(test|spec)\\.(ts|tsx)$|${pathSeparatorPattern}__tests__${pathSeparatorPattern}.*)$`,
 );

--- a/packages/app/src/components/agent-input-area.tsx
+++ b/packages/app/src/components/agent-input-area.tsx
@@ -83,7 +83,7 @@ interface AgentInputAreaProps {
   /** Optional draft context for listing commands before an agent exists. */
   commandDraftConfig?: DraftCommandConfig;
   /** Called when a message is about to be sent (any path: keyboard, dictation, queued). */
-  onMessageSent?: () => void;
+  onMessageSent?: (input: { clientMessageId: string | null }) => void;
   onComposerHeightChange?: (height: number) => void;
   onAttentionInputFocus?: () => void;
   onAttentionPromptSend?: () => void;
@@ -234,8 +234,8 @@ export function AgentInputArea({
 
   const submitMessage = useCallback(
     async (text: string, images?: ImageAttachment[]) => {
-      onMessageSent?.();
       if (onSubmitMessageRef.current) {
+        onMessageSent?.({ clientMessageId: null });
         await onSubmitMessageRef.current({ text, images });
         return;
       }
@@ -291,6 +291,7 @@ export function AgentInputArea({
           return updated;
         });
       }
+      onMessageSent?.({ clientMessageId });
       const imagesData = await encodeImages(images);
       await client.sendAgentMessage(agentId, text, {
         messageId: clientMessageId,
@@ -298,7 +299,14 @@ export function AgentInputArea({
       });
       onAttentionPromptSend?.();
     };
-  }, [client, onAttentionPromptSend, serverId, setAgentStreamTail, setAgentStreamHead]);
+  }, [
+    client,
+    onAttentionPromptSend,
+    onMessageSent,
+    serverId,
+    setAgentStreamTail,
+    setAgentStreamHead,
+  ]);
 
   useEffect(() => {
     onSubmitMessageRef.current = onSubmitMessage;

--- a/packages/app/src/components/agent-stream-view.tsx
+++ b/packages/app/src/components/agent-stream-view.tsx
@@ -67,6 +67,7 @@ import {
 import { MAX_CONTENT_WIDTH } from "@/constants/layout";
 import { normalizeInlinePathTarget } from "@/utils/inline-path";
 import { prepareWorkspaceTab } from "@/utils/workspace-navigation";
+import type { StreamFocusRequest } from "@/utils/stream-focus-request";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import {
   getWorkingIndicatorDotStrength,
@@ -90,8 +91,10 @@ export interface AgentStreamViewProps {
   streamItems: StreamItem[];
   pendingPermissions: Map<string, PendingPermission>;
   routeBottomAnchorRequest?: BottomAnchorRouteRequest | null;
+  focusRequest?: StreamFocusRequest | null;
   isAuthoritativeHistoryReady?: boolean;
   onOpenWorkspaceFile?: (input: { filePath: string }) => void;
+  onFocusRequestHandled?: (requestKey: string) => void;
 }
 
 const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamViewProps>(
@@ -103,8 +106,10 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       streamItems,
       pendingPermissions,
       routeBottomAnchorRequest = null,
+      focusRequest = null,
       isAuthoritativeHistoryReady = true,
       onOpenWorkspaceFile,
+      onFocusRequestHandled,
     },
     ref,
   ) {
@@ -460,7 +465,10 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
           });
 
         return (
-          <View style={[stylesheet.streamItemWrapper, { marginBottom: gapBelow }]}>
+          <View
+            style={[stylesheet.streamItemWrapper, { marginBottom: gapBelow }]}
+            testID={`stream-item-${item.id}`}
+          >
             {content}
             {isEndOfAssistantTurn ? <TurnCopyButton getContent={getTurnContent} /> : null}
           </View>
@@ -610,7 +618,9 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
               listEmptyComponent,
               viewportRef,
               routeBottomAnchorRequest,
+              focusRequest,
               isAuthoritativeHistoryReady,
+              onFocusRequestHandled,
               onNearBottomChange: setIsNearBottom,
               scrollEnabled: streamScrollEnabled,
               listStyle: stylesheet.list,

--- a/packages/app/src/components/stream-strategy-native.tsx
+++ b/packages/app/src/components/stream-strategy-native.tsx
@@ -15,6 +15,7 @@ import {
   isNearBottomForStreamRenderStrategy,
   resolveBottomAnchorTransportBehavior,
 } from "./stream-strategy";
+import { resolveStreamFocusTarget } from "@/utils/stream-focus-request";
 
 const DEFAULT_MAINTAIN_VISIBLE_CONTENT_POSITION = Object.freeze({
   minIndexForVisible: 0,
@@ -30,7 +31,9 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
     listEmptyComponent,
     viewportRef,
     routeBottomAnchorRequest,
+    focusRequest,
     isAuthoritativeHistoryReady,
+    onFocusRequestHandled,
     onNearBottomChange,
     scrollEnabled,
     listStyle,
@@ -58,6 +61,11 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
     }
     return [...segments.historyVirtualized, ...segments.historyMounted];
   }, [segments.historyMounted, segments.historyVirtualized]);
+  const historyItemIds = useMemo(() => historyRows.map((item) => item.id), [historyRows]);
+  const liveHeadItemIds = useMemo(
+    () => segments.liveHead.map((item) => item.id),
+    [segments.liveHead],
+  );
 
   const clearNativeViewportSettling = useCallback(() => {
     if (nativeViewportSettlingFrameIdRef.current !== null) {
@@ -168,6 +176,50 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
   useEffect(() => {
     bottomAnchorController.prepareForStickyContentChange();
   }, [bottomAnchorController, historyRows, segments.liveHead]);
+
+  useEffect(() => {
+    if (!focusRequest) {
+      return;
+    }
+
+    const target = resolveStreamFocusTarget({
+      itemId: focusRequest.itemId,
+      historyItemIds,
+      liveHeadItemIds,
+    });
+    if (target.kind === "missing") {
+      return;
+    }
+    if (target.kind === "live-head") {
+      bottomAnchorController.requestLocalAnchor({
+        agentId,
+        reason: "message-sent",
+      });
+      onFocusRequestHandled?.(focusRequest.requestKey);
+      return;
+    }
+
+    const frameId = requestAnimationFrame(() => {
+      programmaticScrollEventBudgetRef.current = 3;
+      flatListRef.current?.scrollToIndex({
+        index: target.index,
+        animated: true,
+        viewPosition: 0.5,
+      });
+      onFocusRequestHandled?.(focusRequest.requestKey);
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [
+    agentId,
+    bottomAnchorController,
+    focusRequest,
+    historyItemIds,
+    liveHeadItemIds,
+    onFocusRequestHandled,
+  ]);
 
   useEffect(() => {
     const handle: StreamViewportHandle = {

--- a/packages/app/src/components/stream-strategy-web.tsx
+++ b/packages/app/src/components/stream-strategy-web.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 import { measureElement as measureVirtualElement, useVirtualizer } from "@tanstack/react-virtual";
+import { resolveStreamFocusTarget } from "@/utils/stream-focus-request";
 import { estimateStreamItemHeight } from "./agent-stream-web-virtualization";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./stream-strategy";
 import { createStreamStrategy } from "./stream-strategy";
@@ -100,7 +101,9 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     listEmptyComponent,
     viewportRef,
     routeBottomAnchorRequest,
+    focusRequest,
     isAuthoritativeHistoryReady,
+    onFocusRequestHandled,
     onNearBottomChange,
     scrollEnabled,
     isMobileBreakpoint,
@@ -180,6 +183,17 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   }, [rowVirtualizer]);
   const virtualRows = rowVirtualizer.getVirtualItems();
   const virtualTotalSize = rowVirtualizer.getTotalSize();
+  const historyItemIds = useMemo(
+    () => [
+      ...segments.historyVirtualized.map((item) => item.id),
+      ...segments.historyMounted.map((item) => item.id),
+    ],
+    [segments.historyMounted, segments.historyVirtualized],
+  );
+  const liveHeadItemIds = useMemo(
+    () => segments.liveHead.map((item) => item.id),
+    [segments.liveHead],
+  );
 
   const cancelPendingStickToBottom = useCallback(() => {
     const pendingFrame = pendingAutoScrollFrameRef.current;
@@ -251,6 +265,24 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     scrollMessagesToBottom("auto");
     scheduleStickToBottom();
   }, [cancelPendingStickToBottom, scheduleStickToBottom, scrollMessagesToBottom]);
+
+  const scrollMessageNodeIntoView = useCallback((itemId: string) => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer || typeof scrollContainer.querySelector !== "function") {
+      return false;
+    }
+    const messageNode = scrollContainer.querySelector(
+      `[data-testid="stream-item-${itemId}"]`,
+    ) as HTMLElement | null;
+    if (!messageNode) {
+      return false;
+    }
+    messageNode.scrollIntoView({
+      block: "center",
+      behavior: "smooth",
+    });
+    return true;
+  }, []);
 
   const updateScrollMetrics = useCallback(() => {
     const scrollContainer = scrollContainerRef.current;
@@ -353,6 +385,59 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       window.clearTimeout(timeout);
     };
   }, [activationKey, forceStickToBottom, isActivationReady, scheduleStickToBottom]);
+
+  useEffect(() => {
+    if (!focusRequest) {
+      return;
+    }
+
+    const target = resolveStreamFocusTarget({
+      itemId: focusRequest.itemId,
+      historyItemIds,
+      liveHeadItemIds,
+    });
+    if (target.kind === "missing") {
+      return;
+    }
+
+    cancelPendingStickToBottom();
+    if (target.kind === "live-head") {
+      setFollowOutput(true);
+      forceStickToBottom();
+      onFocusRequestHandled?.(focusRequest.requestKey);
+      return;
+    }
+
+    if (target.index < segments.historyVirtualized.length) {
+      setFollowOutput(true);
+      rowVirtualizer.scrollToIndex(target.index, {
+        align: "center",
+      });
+      onFocusRequestHandled?.(focusRequest.requestKey);
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      const didScroll = scrollMessageNodeIntoView(focusRequest.itemId);
+      if (didScroll) {
+        onFocusRequestHandled?.(focusRequest.requestKey);
+      }
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [
+    cancelPendingStickToBottom,
+    focusRequest,
+    forceStickToBottom,
+    historyItemIds,
+    liveHeadItemIds,
+    onFocusRequestHandled,
+    rowVirtualizer,
+    scrollMessageNodeIntoView,
+    segments.historyVirtualized.length,
+  ]);
 
   useEffect(() => {
     if (!followOutputRef.current) {

--- a/packages/app/src/components/stream-strategy.ts
+++ b/packages/app/src/components/stream-strategy.ts
@@ -1,6 +1,7 @@
 import type { ComponentType, ReactElement, ReactNode, RefObject } from "react";
 import type { StyleProp, ViewStyle } from "react-native";
 import type { StreamItem } from "@/types/stream";
+import type { StreamFocusRequest } from "@/utils/stream-focus-request";
 import type { StreamHistoryBoundary, StreamRenderSegments } from "./agent-stream-render-model";
 import type {
   BottomAnchorLocalRequest,
@@ -60,7 +61,9 @@ export type StreamRenderInput = {
   listEmptyComponent: ReactNode;
   viewportRef: RefObject<StreamViewportHandle | null>;
   routeBottomAnchorRequest: BottomAnchorRouteRequest | null;
+  focusRequest: StreamFocusRequest | null;
   isAuthoritativeHistoryReady: boolean;
+  onFocusRequestHandled?: (requestKey: string) => void;
   onNearBottomChange: (value: boolean) => void;
   scrollEnabled: boolean;
   listStyle: StyleProp<ViewStyle>;

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -659,7 +659,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
     }
 
     const serverInfo = client.getLastServerInfoMessage();
-    if (!serverInfo?.features?.providersSnapshot) {
+    if (serverInfo?.features?.providersSnapshot === false) {
       return;
     }
 

--- a/packages/app/src/hooks/use-providers-snapshot.ts
+++ b/packages/app/src/hooks/use-providers-snapshot.ts
@@ -25,16 +25,17 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
   const queryClient = useQueryClient();
   const client = useHostRuntimeClient(serverId ?? "");
   const isConnected = useHostRuntimeIsConnected(serverId ?? "");
-  const supportsSnapshot = useSessionForServer(
+  const serverSupportsSnapshot = useSessionForServer(
     serverId,
-    (session) => session?.serverInfo?.features?.providersSnapshot === true,
+    (session) => session?.serverInfo?.features?.providersSnapshot,
   );
+  const supportsSnapshot = serverSupportsSnapshot !== false;
 
   const queryKey = useMemo(() => providersSnapshotQueryKey(serverId), [serverId]);
 
   const snapshotQuery = useQuery({
     queryKey,
-    enabled: Boolean(supportsSnapshot && serverId && client && isConnected),
+    enabled: Boolean(serverId && client && isConnected && supportsSnapshot),
     staleTime: 60_000,
     queryFn: async () => {
       if (!client) {
@@ -55,7 +56,7 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
   const { mutateAsync: refreshSnapshot, isPending: isRefreshing } = refreshMutation;
 
   useEffect(() => {
-    if (!supportsSnapshot || !client || !isConnected || !serverId) {
+    if (!client || !isConnected || !serverId || !supportsSnapshot) {
       return;
     }
 

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/runtime/host-runtime";
 import { getInitDeferred, getInitKey } from "@/utils/agent-initialization";
 import { derivePendingPermissionKey, normalizeAgentSnapshot } from "@/utils/agent-snapshots";
+import type { StreamFocusRequest } from "@/utils/stream-focus-request";
 import { mergePendingCreateImages } from "@/utils/pending-create-images";
 import { deriveSidebarStateBucket } from "@/utils/sidebar-agent-state";
 import { useCreateFlowStore } from "@/stores/create-flow-store";
@@ -234,10 +235,12 @@ function AgentPanelBody({
   const wasPaneFocusedRef = useRef(isPaneFocused);
   const reconnectToastArmedRef = useRef(false);
   const initAttemptTokenRef = useRef(0);
+  const messageFocusSequenceRef = useRef(0);
   const routeBottomAnchorRequestRef = useRef<{
     routeKey: string;
     reason: "initial-entry" | "resume";
   } | null>(null);
+  const [messageFocusRequest, setMessageFocusRequest] = useState<StreamFocusRequest | null>(null);
   const agentInputDraft = useAgentInputDraft(
     buildDraftStoreKey({
       serverId,
@@ -612,8 +615,41 @@ function AgentPanelBody({
 
   useEffect(() => {
     initAttemptTokenRef.current += 1;
+    messageFocusSequenceRef.current = 0;
+    setMessageFocusRequest(null);
     setMissingAgentState({ kind: "idle" });
   }, [agentId, serverId]);
+
+  const handleMessageSent = useCallback(
+    ({ clientMessageId }: { clientMessageId: string | null }) => {
+      if (!agentId || !clientMessageId) {
+        logWebStickyBottom("screen_message_sent_scroll_to_bottom", {
+          agentId,
+        });
+        streamViewRef.current?.scrollToBottom("message-sent");
+        return;
+      }
+
+      messageFocusSequenceRef.current += 1;
+      const requestKey = `${serverId}:${agentId}:${clientMessageId}:${messageFocusSequenceRef.current}`;
+      setMessageFocusRequest({
+        itemId: clientMessageId,
+        requestKey,
+      });
+      logWebStickyBottom("screen_message_sent_focus_request", {
+        agentId,
+        clientMessageId,
+        requestKey,
+      });
+    },
+    [agentId, serverId],
+  );
+
+  const handleMessageFocusRequestHandled = useCallback((requestKey: string) => {
+    setMessageFocusRequest((current) =>
+      current?.requestKey === requestKey ? null : current,
+    );
+  }, []);
 
   useEffect(() => {
     if (!agentId) {
@@ -749,12 +785,14 @@ function AgentPanelBody({
                 agentId={effectiveAgent.id}
                 serverId={serverId}
                 agent={effectiveAgent}
-                streamItems={shouldUseOptimisticStream ? mergedStreamItems : streamItems}
-                pendingPermissions={pendingPermissions}
-                routeBottomAnchorRequest={routeBottomAnchorRequest}
-                isAuthoritativeHistoryReady={hasAppliedAuthoritativeHistory}
-                onOpenWorkspaceFile={onOpenWorkspaceFile}
-              />
+              streamItems={shouldUseOptimisticStream ? mergedStreamItems : streamItems}
+              pendingPermissions={pendingPermissions}
+              routeBottomAnchorRequest={routeBottomAnchorRequest}
+              focusRequest={messageFocusRequest}
+              isAuthoritativeHistoryReady={hasAppliedAuthoritativeHistory}
+              onOpenWorkspaceFile={onOpenWorkspaceFile}
+              onFocusRequestHandled={handleMessageFocusRequestHandled}
+            />
             </ReanimatedAnimated.View>
           </View>
 
@@ -780,12 +818,7 @@ function AgentPanelBody({
                 });
                 streamViewRef.current?.prepareForViewportChange();
               }}
-              onMessageSent={() => {
-                logWebStickyBottom("screen_message_sent_scroll_to_bottom", {
-                  agentId,
-                });
-                streamViewRef.current?.scrollToBottom("message-sent");
-              }}
+              onMessageSent={handleMessageSent}
             />
           ) : agentId && agentState.archivedAt ? (
             <ArchivedAgentCallout serverId={serverId} agentId={agentId} />

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -646,9 +646,7 @@ function AgentPanelBody({
   );
 
   const handleMessageFocusRequestHandled = useCallback((requestKey: string) => {
-    setMessageFocusRequest((current) =>
-      current?.requestKey === requestKey ? null : current,
-    );
+    setMessageFocusRequest((current) => (current?.requestKey === requestKey ? null : current));
   }, []);
 
   useEffect(() => {
@@ -785,14 +783,14 @@ function AgentPanelBody({
                 agentId={effectiveAgent.id}
                 serverId={serverId}
                 agent={effectiveAgent}
-              streamItems={shouldUseOptimisticStream ? mergedStreamItems : streamItems}
-              pendingPermissions={pendingPermissions}
-              routeBottomAnchorRequest={routeBottomAnchorRequest}
-              focusRequest={messageFocusRequest}
-              isAuthoritativeHistoryReady={hasAppliedAuthoritativeHistory}
-              onOpenWorkspaceFile={onOpenWorkspaceFile}
-              onFocusRequestHandled={handleMessageFocusRequestHandled}
-            />
+                streamItems={shouldUseOptimisticStream ? mergedStreamItems : streamItems}
+                pendingPermissions={pendingPermissions}
+                routeBottomAnchorRequest={routeBottomAnchorRequest}
+                focusRequest={messageFocusRequest}
+                isAuthoritativeHistoryReady={hasAppliedAuthoritativeHistory}
+                onOpenWorkspaceFile={onOpenWorkspaceFile}
+                onFocusRequestHandled={handleMessageFocusRequestHandled}
+              />
             </ReanimatedAnimated.View>
           </View>
 

--- a/packages/app/src/utils/stream-focus-request.test.ts
+++ b/packages/app/src/utils/stream-focus-request.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveStreamFocusTarget } from "./stream-focus-request";
+
+describe("resolveStreamFocusTarget", () => {
+  it("targets live-head items before authoritative history settles", () => {
+    expect(
+      resolveStreamFocusTarget({
+        itemId: "msg-2",
+        historyItemIds: ["msg-1"],
+        liveHeadItemIds: ["msg-2", "msg-3"],
+      }),
+    ).toEqual({
+      kind: "live-head",
+    });
+  });
+
+  it("targets a concrete history index once the requested item is in history", () => {
+    expect(
+      resolveStreamFocusTarget({
+        itemId: "msg-2",
+        historyItemIds: ["msg-1", "msg-2", "msg-3"],
+        liveHeadItemIds: [],
+      }),
+    ).toEqual({
+      kind: "history",
+      index: 1,
+    });
+  });
+
+  it("returns missing when the requested item has not rendered yet", () => {
+    expect(
+      resolveStreamFocusTarget({
+        itemId: "msg-9",
+        historyItemIds: ["msg-1", "msg-2", "msg-3"],
+        liveHeadItemIds: [],
+      }),
+    ).toEqual({
+      kind: "missing",
+    });
+  });
+});

--- a/packages/app/src/utils/stream-focus-request.ts
+++ b/packages/app/src/utils/stream-focus-request.ts
@@ -1,0 +1,26 @@
+export type StreamFocusTarget =
+  | { kind: "history"; index: number }
+  | { kind: "live-head" }
+  | { kind: "missing" };
+
+export type StreamFocusRequest = {
+  itemId: string;
+  requestKey: string;
+};
+
+export function resolveStreamFocusTarget(input: {
+  itemId: string;
+  historyItemIds: readonly string[];
+  liveHeadItemIds: readonly string[];
+}): StreamFocusTarget {
+  if (input.liveHeadItemIds.includes(input.itemId)) {
+    return { kind: "live-head" };
+  }
+
+  const historyIndex = input.historyItemIds.indexOf(input.itemId);
+  if (historyIndex >= 0) {
+    return { kind: "history", index: historyIndex };
+  }
+
+  return { kind: "missing" };
+}

--- a/packages/server/src/client/daemon-client.test.ts
+++ b/packages/server/src/client/daemon-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, expectTypeOf, test, vi } from "vitest";
 import { DaemonClient, type DaemonTransport } from "./daemon-client";
+import * as SharedMessages from "../shared/messages.js";
 import {
   asUint8Array,
   decodeTerminalResizePayload,
@@ -1824,6 +1825,91 @@ describe("DaemonClient", () => {
       expect(firstEntry.item.error).toBeNull();
       expect(firstEntry.item.detail.type).toBe("shell");
     }
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test("falls back to raw session handling when outbound schema parsing throws", async () => {
+    const logger = createMockLogger();
+    const mock = createMockTransport();
+
+    const client = new DaemonClient({
+      url: "ws://test",
+      clientId: "clsk_unit_test",
+      logger,
+      reconnect: { enabled: false },
+      transportFactory: () => mock.transport,
+    });
+    clients.push(client);
+
+    const connectPromise = client.connect();
+    mock.triggerOpen();
+    await connectPromise;
+
+    const received: unknown[] = [];
+    const unsubscribe = client.on("fetch_agent_timeline_response", (msg) => {
+      received.push(msg);
+    });
+
+    const safeParseSpy = vi
+      .spyOn(SharedMessages.WSOutboundMessageSchema, "safeParse")
+      .mockImplementationOnce(() => {
+        throw new TypeError("Cannot read property '_zod' of undefined");
+      });
+
+    mock.triggerMessage(
+      wrapSessionMessage({
+        type: "fetch_agent_timeline_response",
+        payload: {
+          requestId: "req-fallback",
+          agentId: "agent_cli",
+          agent: null,
+          direction: "tail",
+          projection: "projected",
+          epoch: "epoch-1",
+          reset: false,
+          staleCursor: false,
+          gap: false,
+          window: { minSeq: 1, maxSeq: 1, nextSeq: 2 },
+          startCursor: { epoch: "epoch-1", seq: 1 },
+          endCursor: { epoch: "epoch-1", seq: 1 },
+          hasOlder: false,
+          hasNewer: false,
+          entries: [
+            {
+              timestamp: "2026-02-08T20:20:00.000Z",
+              provider: "codex",
+              seqStart: 1,
+              seqEnd: 1,
+              sourceSeqRanges: [{ startSeq: 1, endSeq: 1 }],
+              collapsed: [],
+              item: {
+                type: "tool_call",
+                callId: "call_cli_fallback",
+                name: "shell",
+                status: "running",
+                detail: {
+                  type: "shell",
+                  command: "pwd",
+                },
+                error: null,
+              },
+            },
+          ],
+          error: null,
+        },
+      }),
+    );
+
+    safeParseSpy.mockRestore();
+    unsubscribe();
+
+    expect(received).toHaveLength(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msgType: "fetch_agent_timeline_response",
+      }),
+      "Message schema parse threw; falling back to raw session handling",
+    );
     expect(logger.warn).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -108,6 +108,20 @@ const consoleLogger: Logger = {
   error: (obj, msg) => console.error(msg, obj),
 };
 
+function getRawSessionMessage(
+  payload: unknown,
+): { type: string } & Record<string, unknown> | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const record = payload as { type?: unknown; message?: unknown };
+  if (record.type !== "session" || !record.message || typeof record.message !== "object") {
+    return null;
+  }
+  const message = record.message as { type?: unknown } & Record<string, unknown>;
+  return typeof message.type === "string" ? message : null;
+}
+
 export type {
   DaemonTransport,
   DaemonTransportFactory,
@@ -3609,7 +3623,30 @@ export class DaemonClient {
       return;
     }
 
-    const parsed = WSOutboundMessageSchema.safeParse(parsedJson);
+    let parsed: ReturnType<typeof WSOutboundMessageSchema.safeParse>;
+    try {
+      parsed = WSOutboundMessageSchema.safeParse(parsedJson);
+    } catch (error) {
+      const rawSessionMessage = getRawSessionMessage(parsedJson);
+      if (rawSessionMessage) {
+        this.logger.debug(
+          {
+            msgType: rawSessionMessage.type,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Message schema parse threw; falling back to raw session handling",
+        );
+        this.handleSessionMessage(rawSessionMessage as SessionOutboundMessage);
+        return;
+      }
+      this.logger.warn(
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Message schema parse threw",
+      );
+      return;
+    }
     if (!parsed.success) {
       const msgType = (parsedJson as { type?: string })?.type ?? "unknown";
       this.logger.warn({ msgType, error: parsed.error.message }, "Message validation failed");

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -110,7 +110,7 @@ const consoleLogger: Logger = {
 
 function getRawSessionMessage(
   payload: unknown,
-): { type: string } & Record<string, unknown> | null {
+): ({ type: string } & Record<string, unknown>) | null {
   if (!payload || typeof payload !== "object") {
     return null;
   }
@@ -119,7 +119,9 @@ function getRawSessionMessage(
     return null;
   }
   const message = record.message as { type?: unknown } & Record<string, unknown>;
-  return typeof message.type === "string" ? message : null;
+  return typeof message.type === "string"
+    ? ({ ...message, type: message.type } as { type: string } & Record<string, unknown>)
+    : null;
 }
 
 export type {

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -855,7 +855,7 @@ export const GetProvidersSnapshotRequestMessageSchema = z.object({
 export const RefreshProvidersSnapshotRequestMessageSchema = z.object({
   type: z.literal("refresh_providers_snapshot_request"),
   cwd: z.string().optional(),
-  providers: z.array(AgentProviderSchema).optional(),
+  providers: z.array(AgentProviderValueSchema).optional(),
   requestId: z.string(),
 });
 

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -3,7 +3,8 @@ import { AGENT_LIFECYCLE_STATUSES } from "./agent-lifecycle.js";
 import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "../server/agent/agent-title-limits.js";
 import { AgentProviderSchema as ImportedAgentProviderSchema } from "../server/agent/provider-manifest.js";
 // COMPAT(rn-dev-client): Metro can evaluate this import path as undefined during circular init.
-const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ?? z.string()) as z.ZodType<string>;
+const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ??
+  z.string()) as z.ZodType<string>;
 import { TOOL_CALL_ICON_NAMES } from "../server/agent/agent-sdk-types.js";
 import {
   ChatCreateRequestSchema,

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 import { AGENT_LIFECYCLE_STATUSES } from "./agent-lifecycle.js";
 import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "../server/agent/agent-title-limits.js";
-import { AgentProviderSchema } from "../server/agent/provider-manifest.js";
+import { AgentProviderSchema as ImportedAgentProviderSchema } from "../server/agent/provider-manifest.js";
+// COMPAT(rn-dev-client): Metro can evaluate this import path as undefined during circular init.
+const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ?? z.string()) as z.ZodType<string>;
 import { TOOL_CALL_ICON_NAMES } from "../server/agent/agent-sdk-types.js";
 import {
   ChatCreateRequestSchema,
@@ -139,7 +141,7 @@ export const AgentFeatureSchema = z.discriminatedUnion("type", [
 ]);
 
 const AgentModelDefinitionSchema: z.ZodType<AgentModelDefinition> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   id: z.string(),
   label: z.string(),
   description: z.string().optional(),
@@ -150,7 +152,7 @@ const AgentModelDefinitionSchema: z.ZodType<AgentModelDefinition> = z.object({
 });
 
 const ProviderSnapshotEntrySchema: z.ZodType<ProviderSnapshotEntry> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   status: ProviderStatusSchema,
   error: z.string().optional(),
   models: z.array(AgentModelDefinitionSchema).optional(),
@@ -205,7 +207,7 @@ const McpServerConfigSchema = z.discriminatedUnion("type", [
 ]);
 
 const AgentSessionConfigSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   modeId: z.string().optional(),
   model: z.string().optional(),
@@ -253,7 +255,7 @@ export const AgentPermissionResponseSchema: z.ZodType<AgentPermissionResponse> =
 
 export const AgentPermissionRequestPayloadSchema: z.ZodType<AgentPermissionRequest> = z.object({
   id: z.string(),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   name: z.string(),
   kind: z.enum(["tool", "plan", "question", "mode", "other"]),
   title: z.string().optional(),
@@ -467,48 +469,48 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("thread_started"),
     sessionId: z.string(),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
   }),
   z.object({
     type: z.literal("turn_started"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
   }),
   z.object({
     type: z.literal("turn_completed"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     usage: AgentUsageSchema.optional(),
   }),
   z.object({
     type: z.literal("turn_failed"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     error: z.string(),
     code: z.string().optional(),
     diagnostic: z.string().optional(),
   }),
   z.object({
     type: z.literal("turn_canceled"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     reason: z.string(),
   }),
   z.object({
     type: z.literal("timeline"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     item: AgentTimelineItemPayloadSchema,
   }),
   z.object({
     type: z.literal("permission_requested"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     request: AgentPermissionRequestPayloadSchema,
   }),
   z.object({
     type: z.literal("permission_resolved"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     requestId: z.string(),
     resolution: AgentPermissionResponseSchema,
   }),
   z.object({
     type: z.literal("attention_required"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     reason: z.enum(["finished", "error", "permission"]),
     timestamp: z.string(),
     shouldNotify: z.boolean(),
@@ -528,7 +530,7 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
 
 const AgentPersistenceHandleSchema: z.ZodType<AgentPersistenceHandle | null> = z
   .object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     sessionId: z.string(),
     nativeHandle: z.string().optional(),
     metadata: z.record(z.unknown()).optional(),
@@ -536,7 +538,7 @@ const AgentPersistenceHandleSchema: z.ZodType<AgentPersistenceHandle | null> = z
   .nullable();
 
 const AgentRuntimeInfoSchema: z.ZodType<AgentRuntimeInfo> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   sessionId: z.string().nullable(),
   model: z.string().nullable().optional(),
   thinkingOptionId: z.string().nullable().optional(),
@@ -546,7 +548,7 @@ const AgentRuntimeInfoSchema: z.ZodType<AgentRuntimeInfo> = z.object({
 
 export const AgentSnapshotPayloadSchema = z.object({
   id: z.string(),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   model: z.string().nullable(),
   features: z.array(AgentFeatureSchema).optional(),
@@ -826,14 +828,14 @@ export const CreateAgentRequestMessageSchema = z.object({
 
 export const ListProviderModelsRequestMessageSchema = z.object({
   type: z.literal("list_provider_models_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string().optional(),
   requestId: z.string(),
 });
 
 export const ListProviderModesRequestMessageSchema = z.object({
   type: z.literal("list_provider_modes_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string().optional(),
   requestId: z.string(),
 });
@@ -858,7 +860,7 @@ export const RefreshProvidersSnapshotRequestMessageSchema = z.object({
 
 export const ProviderDiagnosticRequestMessageSchema = z.object({
   type: z.literal("provider_diagnostic_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   requestId: z.string(),
 });
 
@@ -1329,7 +1331,7 @@ export const PingMessageSchema = z.object({
 });
 
 const ListCommandsDraftConfigSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   modeId: z.string().optional(),
   model: z.string().optional(),
@@ -2071,7 +2073,7 @@ const AgentTimelineSeqRangeSchema = z.object({
 });
 
 export const AgentTimelineEntryPayloadSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   item: AgentTimelineItemPayloadSchema,
   timestamp: z.string(),
   seqStart: z.number().int().nonnegative(),
@@ -2548,7 +2550,7 @@ export const FileDownloadTokenResponseSchema = z.object({
 export const ListProviderModelsResponseMessageSchema = z.object({
   type: z.literal("list_provider_models_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     models: z.array(AgentModelDefinitionSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2559,7 +2561,7 @@ export const ListProviderModelsResponseMessageSchema = z.object({
 export const ListProviderModesResponseMessageSchema = z.object({
   type: z.literal("list_provider_modes_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     modes: z.array(AgentModeSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2570,7 +2572,7 @@ export const ListProviderModesResponseMessageSchema = z.object({
 export const ListProviderFeaturesResponseMessageSchema = z.object({
   type: z.literal("list_provider_features_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     features: z.array(AgentFeatureSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2579,7 +2581,7 @@ export const ListProviderFeaturesResponseMessageSchema = z.object({
 });
 
 const ProviderAvailabilitySchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   available: z.boolean(),
   error: z.string().nullable().optional(),
 });
@@ -2627,7 +2629,7 @@ export const RefreshProvidersSnapshotResponseMessageSchema = z.object({
 export const ProviderDiagnosticResponseMessageSchema = z.object({
   type: z.literal("provider_diagnostic_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     diagnostic: z.string(),
     requestId: z.string(),
   }),


### PR DESCRIPTION
## Summary
- Keeps just-sent messages focused in stream so mobile user stays anchored on newest send.

## 2026-04-16 Integrated Device Verification
- Verified on physical Android device over USB.
- Direct local connection path: pass.
- Phone message send from current mobile UI: pass.
- Existing tmux-backed Codex session wake: pass.
- Assistant reply render on phone: pass. Exact token `TMUX_MOBILE_PING_4`.
- History scroll check: `428` frames, `3` janky (`0.70%`), `p95 18ms`, `p99 19ms`.
- Sensitive local details, device identifiers, private endpoints, and local artifact paths are intentionally omitted from this public PR.

## Branch-Specific Coverage
- Sent message stayed visible immediately after send in live capture, and assistant response arrived without losing stream focus.

## Fork CI
- Upstream PR currently reports no native GitHub checks.
- Latest fork `CI` success for this branch: https://github.com/Jacobinwwey/paseo/actions/runs/24545431819
