### PR TITLE
feat(server): add recoverable agent directory rpc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -31,8 +31,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -55,8 +55,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Fetch origin/main (worktree tests)
         run: git fetch --no-tags origin main:refs/remotes/origin/main
@@ -85,8 +85,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -123,8 +123,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -135,15 +135,34 @@ jobs:
       - name: Run app unit tests
         run: npm run test --workspace=@getpaseo/app
 
+  playwright-preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      has_openai_api_key: ${{ steps.secret-check.outputs.has_openai_api_key }}
+    steps:
+      - name: Detect OpenAI key availability
+        id: secret-check
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -n "$OPENAI_API_KEY" ]; then
+            echo "has_openai_api_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_openai_api_key=false" >> "$GITHUB_OUTPUT"
+          fi
+
   playwright:
+    needs: playwright-preflight
+    if: ${{ needs.playwright-preflight.outputs.has_openai_api_key == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -185,8 +204,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -204,8 +223,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -219,6 +238,6 @@ jobs:
       - name: Run CLI tests
         run: npm run test --workspace=@getpaseo/cli
         env:
-          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: '0'
-          PASEO_DICTATION_ENABLED: '0'
-          PASEO_VOICE_MODE_ENABLED: '0'
+          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: "0"
+          PASEO_DICTATION_ENABLED: "0"
+          PASEO_VOICE_MODE_ENABLED: "0"

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -3,14 +3,15 @@ name: Deploy App
 on:
   push:
     tags:
-      - 'v*'
-      - '!v*-rc.*'
-      - 'app-v*'
-      - '!app-v*-rc.*'
+      - "v*"
+      - "!v*-rc.*"
+      - "app-v*"
+      - "!app-v*-rc.*"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -18,10 +19,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@boudra'
+          node-version: "22"
+          cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@boudra"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/app --include-workspace-root

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/relay/**'
-      - '.github/workflows/deploy-relay.yml'
+      - "packages/relay/**"
+      - ".github/workflows/deploy-relay.yml"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -17,8 +18,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/relay --include-workspace-root
@@ -30,4 +31,3 @@ jobs:
         run: cd packages/relay && npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/website/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'patches/**'
-      - '.github/workflows/deploy-website.yml'
+      - "packages/website/**"
+      - "package.json"
+      - "package-lock.json"
+      - "patches/**"
+      - ".github/workflows/deploy-website.yml"
   release:
     types: [published, edited]
   workflow_dispatch:
 
 jobs:
   deploy:
-    if: ${{ github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft) }}
+    if: ${{ github.repository == 'getpaseo/paseo' && (github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft)) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -23,8 +23,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/website --include-workspace-root

--- a/packages/server/src/client/daemon-client.test.ts
+++ b/packages/server/src/client/daemon-client.test.ts
@@ -1012,6 +1012,90 @@ describe("DaemonClient", () => {
     vi.useRealTimers();
   });
 
+  test("sends fetch_recoverable_agents_request via fetchRecoverableAgents", async () => {
+    const logger = createMockLogger();
+    const mock = createMockTransport();
+
+    const client = new DaemonClient({
+      url: "ws://test",
+      clientId: "clsk_unit_test",
+      logger,
+      reconnect: { enabled: false },
+      transportFactory: () => mock.transport,
+    });
+    clients.push(client);
+
+    const connectPromise = client.connect();
+    mock.triggerOpen();
+    await connectPromise;
+
+    const runtimeClient = client as unknown as {
+      fetchRecoverableAgents: (options?: {
+        sort?: Array<{
+          key: "status_priority" | "created_at" | "updated_at" | "title";
+          direction: "asc" | "desc";
+        }>;
+        page?: { limit: number; cursor?: string };
+        requestId?: string;
+      }) => Promise<{
+        requestId: string;
+        entries: unknown[];
+        pageInfo: { nextCursor: string | null; prevCursor: string | null; hasMore: boolean };
+      }>;
+    };
+
+    const promise = runtimeClient.fetchRecoverableAgents({
+      sort: [{ key: "updated_at", direction: "desc" }],
+      page: { limit: 50, cursor: "recoverable-page-2" },
+    });
+
+    expect(mock.sent).toHaveLength(1);
+    const request = JSON.parse(mock.sent[0]) as {
+      type: "session";
+      message: {
+        type: "fetch_recoverable_agents_request";
+        requestId: string;
+        sort?: Array<{
+          key: "status_priority" | "created_at" | "updated_at" | "title";
+          direction: "asc" | "desc";
+        }>;
+        page?: { limit: number; cursor?: string };
+      };
+    };
+
+    expect(request.message).toEqual({
+      type: "fetch_recoverable_agents_request",
+      requestId: request.message.requestId,
+      sort: [{ key: "updated_at", direction: "desc" }],
+      page: { limit: 50, cursor: "recoverable-page-2" },
+    });
+
+    mock.triggerMessage(
+      wrapSessionMessage({
+        type: "fetch_recoverable_agents_response",
+        payload: {
+          requestId: request.message.requestId,
+          entries: [],
+          pageInfo: {
+            nextCursor: null,
+            prevCursor: "recoverable-page-2",
+            hasMore: false,
+          },
+        },
+      }),
+    );
+
+    await expect(promise).resolves.toEqual({
+      requestId: request.message.requestId,
+      entries: [],
+      pageInfo: {
+        nextCursor: null,
+        prevCursor: "recoverable-page-2",
+        hasMore: false,
+      },
+    });
+  });
+
   test("resolves dictation finish when final arrives after finish accepted", async () => {
     const logger = createMockLogger();
     const mock = createMockTransport();

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -347,6 +347,20 @@ export type FetchAgentsOptions = Omit<FetchAgentsRequest, "type" | "requestId"> 
 };
 export type FetchAgentsEntry = FetchAgentsPayload["entries"][number];
 export type FetchAgentsPageInfo = FetchAgentsPayload["pageInfo"];
+type FetchRecoverableAgentsPayload = Extract<
+  SessionOutboundMessage,
+  { type: "fetch_recoverable_agents_response" }
+>["payload"];
+type FetchRecoverableAgentsRequest = Extract<
+  SessionInboundMessage,
+  { type: "fetch_recoverable_agents_request" }
+>;
+export type FetchRecoverableAgentsOptions = Omit<
+  FetchRecoverableAgentsRequest,
+  "type" | "requestId"
+> & {
+  requestId?: string;
+};
 type FetchWorkspacesPayload = Extract<
   SessionOutboundMessage,
   { type: "fetch_workspaces_response" }
@@ -1289,6 +1303,33 @@ export class DaemonClient {
       options: { skipQueue: true },
       select: (msg) => {
         if (msg.type !== "fetch_agents_response") {
+          return null;
+        }
+        if (msg.payload.requestId !== resolvedRequestId) {
+          return null;
+        }
+        return msg.payload;
+      },
+    });
+  }
+
+  async fetchRecoverableAgents(
+    options?: FetchRecoverableAgentsOptions,
+  ): Promise<FetchRecoverableAgentsPayload> {
+    const resolvedRequestId = this.createRequestId(options?.requestId);
+    const message = SessionInboundMessageSchema.parse({
+      type: "fetch_recoverable_agents_request",
+      requestId: resolvedRequestId,
+      ...(options?.sort ? { sort: options.sort } : {}),
+      ...(options?.page ? { page: options.page } : {}),
+    });
+    return this.sendRequest({
+      requestId: resolvedRequestId,
+      message,
+      timeout: 10000,
+      options: { skipQueue: true },
+      select: (msg) => {
+        if (msg.type !== "fetch_recoverable_agents_response") {
           return null;
         }
         if (msg.payload.requestId !== resolvedRequestId) {

--- a/packages/server/src/server/session.recoverable-agents.test.ts
+++ b/packages/server/src/server/session.recoverable-agents.test.ts
@@ -36,7 +36,8 @@ function createRecord(overrides: Partial<StoredAgentRecord>): StoredAgentRecord 
     runtimeInfo: overrides.runtimeInfo,
     features: overrides.features,
     persistence:
-      Object.prototype.hasOwnProperty.call(overrides, "persistence") && overrides.persistence === null
+      Object.prototype.hasOwnProperty.call(overrides, "persistence") &&
+      overrides.persistence === null
         ? null
         : (overrides.persistence ?? {
             provider: overrides.provider ?? "codex",

--- a/packages/server/src/server/session.recoverable-agents.test.ts
+++ b/packages/server/src/server/session.recoverable-agents.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("../utils/checkout-git.js", () => ({
+  getCheckoutDiff: vi.fn(),
+  getCheckoutStatus: vi.fn(),
+  listBranchSuggestions: vi.fn(),
+  commitChanges: vi.fn(),
+  mergeToBase: vi.fn(),
+  mergeFromBase: vi.fn(),
+  pullCurrentBranch: vi.fn(),
+  pushCurrentBranch: vi.fn(),
+  createPullRequest: vi.fn(),
+}));
+
+import { Session } from "./session.js";
+import type { StoredAgentRecord } from "./agent/agent-storage.js";
+
+function createRecord(overrides: Partial<StoredAgentRecord>): StoredAgentRecord {
+  const id = overrides.id ?? "agent-record";
+  const cwd = overrides.cwd ?? `/tmp/${id}`;
+  const now = "2026-04-01T00:00:00.000Z";
+
+  return {
+    id,
+    provider: overrides.provider ?? "codex",
+    cwd,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    lastActivityAt: overrides.lastActivityAt,
+    lastUserMessageAt: overrides.lastUserMessageAt ?? null,
+    title: overrides.title ?? null,
+    labels: overrides.labels ?? {},
+    lastStatus: overrides.lastStatus ?? "closed",
+    lastModeId: overrides.lastModeId ?? null,
+    config: overrides.config ?? {},
+    runtimeInfo: overrides.runtimeInfo,
+    features: overrides.features,
+    persistence:
+      Object.prototype.hasOwnProperty.call(overrides, "persistence") && overrides.persistence === null
+        ? null
+        : (overrides.persistence ?? {
+            provider: overrides.provider ?? "codex",
+            sessionId: `session-${id}`,
+          }),
+    requiresAttention: overrides.requiresAttention,
+    attentionReason: overrides.attentionReason,
+    attentionTimestamp: overrides.attentionTimestamp,
+    internal: overrides.internal,
+    archivedAt: overrides.archivedAt ?? null,
+  };
+}
+
+function createSessionForRecoverableTests(input: {
+  emitted: Array<{ type: string; payload: unknown }>;
+  records: StoredAgentRecord[];
+  liveAgentIds?: string[];
+}): Session {
+  const logger = {
+    child: () => logger,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  const session = new Session({
+    clientId: "test-client",
+    onMessage: (message) => input.emitted.push(message as any),
+    logger: logger as any,
+    downloadTokenStore: {} as any,
+    pushTokenStore: {} as any,
+    paseoHome: "/tmp/paseo-test",
+    agentManager: {
+      subscribe: () => () => {},
+      listAgents: () => (input.liveAgentIds ?? []).map((id) => ({ id })),
+      getAgent: () => null,
+    } as any,
+    agentStorage: {
+      list: async () => input.records,
+      get: async (agentId: string) => input.records.find((record) => record.id === agentId) ?? null,
+    } as any,
+    projectRegistry: {
+      initialize: async () => {},
+      existsOnDisk: async () => true,
+      list: async () => [],
+      get: async () => null,
+      upsert: async () => {},
+      archive: async () => {},
+      remove: async () => {},
+    } as any,
+    workspaceRegistry: {
+      initialize: async () => {},
+      existsOnDisk: async () => true,
+      list: async () => [],
+      get: async () => null,
+      upsert: async () => {},
+      archive: async () => {},
+      remove: async () => {},
+    } as any,
+    checkoutDiffManager: {
+      subscribe: async () => ({
+        initial: { cwd: "/tmp", files: [], error: null },
+        unsubscribe: () => {},
+      }),
+      scheduleRefreshForCwd: () => {},
+      getMetrics: () => ({
+        checkoutDiffTargetCount: 0,
+        checkoutDiffSubscriptionCount: 0,
+        checkoutDiffWatcherCount: 0,
+        checkoutDiffFallbackRefreshTargetCount: 0,
+      }),
+      dispose: () => {},
+    } as any,
+    workspaceGitService: {
+      subscribe: async (params: { cwd: string }) => ({
+        initial: {
+          cwd: params.cwd,
+          git: {
+            isGit: false,
+            repoRoot: null,
+            mainRepoRoot: null,
+            currentBranch: null,
+            remoteUrl: null,
+            isPaseoOwnedWorktree: false,
+            isDirty: null,
+            aheadBehind: null,
+            aheadOfOrigin: null,
+            behindOfOrigin: null,
+            diffStat: null,
+          },
+          github: {
+            featuresEnabled: false,
+            pullRequest: null,
+            error: null,
+            refreshedAt: null,
+          },
+        },
+        unsubscribe: () => {},
+      }),
+      peekSnapshot: () => null,
+      getSnapshot: async (cwd: string) => ({
+        cwd,
+        git: {
+          isGit: false,
+          repoRoot: null,
+          mainRepoRoot: null,
+          currentBranch: null,
+          remoteUrl: null,
+          isPaseoOwnedWorktree: false,
+          isDirty: null,
+          aheadBehind: null,
+          aheadOfOrigin: null,
+          behindOfOrigin: null,
+          diffStat: null,
+        },
+        github: {
+          featuresEnabled: false,
+          pullRequest: null,
+          error: null,
+          refreshedAt: null,
+        },
+      }),
+      refresh: async () => {},
+      dispose: () => {},
+    } as any,
+    mcpBaseUrl: null,
+    stt: null,
+    tts: null,
+    terminalManager: null,
+  }) as any;
+
+  session.buildProjectPlacement = async (cwd: string) => ({
+    projectKey: cwd,
+    projectName: cwd.split("/").pop() ?? cwd,
+    checkout: {
+      cwd,
+      isGit: false,
+      currentBranch: null,
+      remoteUrl: null,
+      worktreeRoot: null,
+      isPaseoOwnedWorktree: false,
+      mainRepoRoot: null,
+    },
+  });
+
+  return session;
+}
+
+describe("recoverable agent directory", () => {
+  test("fetch_recoverable_agents_request only returns closed non-archived persisted agents", async () => {
+    const emitted: Array<{ type: string; payload: any }> = [];
+    const session = createSessionForRecoverableTests({
+      emitted,
+      liveAgentIds: ["agent-live-duplicate"],
+      records: [
+        createRecord({
+          id: "agent-recoverable",
+          updatedAt: "2026-04-10T12:00:00.000Z",
+        }),
+        createRecord({
+          id: "agent-archived",
+          archivedAt: "2026-04-10T13:00:00.000Z",
+        }),
+        createRecord({
+          id: "agent-open",
+          lastStatus: "idle",
+        }),
+        createRecord({
+          id: "agent-without-persistence",
+          persistence: null,
+        }),
+        createRecord({
+          id: "agent-internal",
+          internal: true,
+        }),
+        createRecord({
+          id: "agent-live-duplicate",
+        }),
+        createRecord({
+          id: "agent-invalid-persistence",
+          persistence: {
+            provider: "unknown-provider",
+            sessionId: "bad-session",
+          },
+        }),
+      ],
+    });
+
+    await session.handleMessage({
+      type: "fetch_recoverable_agents_request",
+      requestId: "req-recoverable-1",
+    } as any);
+
+    const response = emitted.find(
+      (message) => message.type === "fetch_recoverable_agents_response",
+    ) as { type: string; payload: any } | undefined;
+
+    expect(response?.payload.requestId).toBe("req-recoverable-1");
+    expect(response?.payload.entries.map((entry: any) => entry.agent.id)).toEqual([
+      "agent-recoverable",
+    ]);
+    expect(response?.payload.entries[0].agent.persistence).toMatchObject({
+      provider: "codex",
+      sessionId: "session-agent-recoverable",
+    });
+    expect(response?.payload.pageInfo).toEqual({
+      nextCursor: null,
+      prevCursor: null,
+      hasMore: false,
+    });
+  });
+
+  test("fetch_recoverable_agents_request paginates by updated_at desc", async () => {
+    const emitted: Array<{ type: string; payload: any }> = [];
+    const session = createSessionForRecoverableTests({
+      emitted,
+      records: [
+        createRecord({
+          id: "agent-old",
+          updatedAt: "2026-04-01T09:00:00.000Z",
+        }),
+        createRecord({
+          id: "agent-new",
+          updatedAt: "2026-04-02T09:00:00.000Z",
+        }),
+      ],
+    });
+
+    await session.handleMessage({
+      type: "fetch_recoverable_agents_request",
+      requestId: "req-recoverable-page-1",
+      page: { limit: 1 },
+    } as any);
+
+    const firstResponse = emitted.find(
+      (message) =>
+        message.type === "fetch_recoverable_agents_response" &&
+        message.payload.requestId === "req-recoverable-page-1",
+    ) as { type: string; payload: any };
+
+    expect(firstResponse.payload.entries.map((entry: any) => entry.agent.id)).toEqual([
+      "agent-new",
+    ]);
+    expect(firstResponse.payload.pageInfo.hasMore).toBe(true);
+    expect(typeof firstResponse.payload.pageInfo.nextCursor).toBe("string");
+
+    await session.handleMessage({
+      type: "fetch_recoverable_agents_request",
+      requestId: "req-recoverable-page-2",
+      page: {
+        limit: 1,
+        cursor: firstResponse.payload.pageInfo.nextCursor,
+      },
+    } as any);
+
+    const secondResponse = emitted.find(
+      (message) =>
+        message.type === "fetch_recoverable_agents_response" &&
+        message.payload.requestId === "req-recoverable-page-2",
+    ) as { type: string; payload: any };
+
+    expect(secondResponse.payload.entries.map((entry: any) => entry.agent.id)).toEqual([
+      "agent-old",
+    ]);
+    expect(secondResponse.payload.pageInfo.hasMore).toBe(false);
+    expect(secondResponse.payload.pageInfo.nextCursor).toBeNull();
+  });
+});

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -297,20 +297,12 @@ type FetchAgentsResponsePayload = Extract<
 >["payload"];
 type FetchAgentsResponseEntry = FetchAgentsResponsePayload["entries"][number];
 type FetchAgentsResponsePageInfo = FetchAgentsResponsePayload["pageInfo"];
-type FetchRecoverableAgentsRequestMessage = Extract<
-  SessionInboundMessage,
-  { type: "fetch_recoverable_agents_request" }
->;
-type FetchRecoverableAgentsRequestSort = NonNullable<
-  FetchRecoverableAgentsRequestMessage["sort"]
->[number];
 type FetchRecoverableAgentsResponsePayload = Extract<
   SessionOutboundMessage,
   { type: "fetch_recoverable_agents_response" }
 >["payload"];
 type FetchRecoverableAgentsResponseEntry = FetchRecoverableAgentsResponsePayload["entries"][number];
-type FetchRecoverableAgentsResponsePageInfo =
-  FetchRecoverableAgentsResponsePayload["pageInfo"];
+type FetchRecoverableAgentsResponsePageInfo = FetchRecoverableAgentsResponsePayload["pageInfo"];
 type AgentUpdatePayload = Extract<SessionOutboundMessage, { type: "agent_update" }>["payload"];
 type AgentUpdatesFilter = FetchAgentsRequestFilter;
 type AgentUpdatesSubscriptionState = {
@@ -5220,7 +5212,9 @@ export class Session {
     entries: FetchRecoverableAgentsResponseEntry[];
     pageInfo: FetchRecoverableAgentsResponsePageInfo;
   }> {
-    const sort = this.normalizeFetchAgentsSort(request.sort as FetchAgentsRequestSort[] | undefined);
+    const sort = this.normalizeFetchAgentsSort(
+      request.sort as FetchAgentsRequestSort[] | undefined,
+    );
     let candidates = await this.listRecoverableAgentPayloads();
 
     candidates.sort((left, right) => this.compareFetchAgentsAgents(left, right, sort));
@@ -6000,15 +5994,9 @@ export class Session {
       });
     } catch (error) {
       const code =
-        error instanceof SessionRequestError
-          ? error.code
-          : "fetch_recoverable_agents_failed";
-      const message =
-        error instanceof Error ? error.message : "Failed to fetch recoverable agents";
-      this.sessionLogger.error(
-        { err: error },
-        "Failed to handle fetch_recoverable_agents_request",
-      );
+        error instanceof SessionRequestError ? error.code : "fetch_recoverable_agents_failed";
+      const message = error instanceof Error ? error.message : "Failed to fetch recoverable agents";
+      this.sessionLogger.error({ err: error }, "Failed to handle fetch_recoverable_agents_request");
       this.emit({
         type: "rpc_error",
         payload: {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -297,6 +297,20 @@ type FetchAgentsResponsePayload = Extract<
 >["payload"];
 type FetchAgentsResponseEntry = FetchAgentsResponsePayload["entries"][number];
 type FetchAgentsResponsePageInfo = FetchAgentsResponsePayload["pageInfo"];
+type FetchRecoverableAgentsRequestMessage = Extract<
+  SessionInboundMessage,
+  { type: "fetch_recoverable_agents_request" }
+>;
+type FetchRecoverableAgentsRequestSort = NonNullable<
+  FetchRecoverableAgentsRequestMessage["sort"]
+>[number];
+type FetchRecoverableAgentsResponsePayload = Extract<
+  SessionOutboundMessage,
+  { type: "fetch_recoverable_agents_response" }
+>["payload"];
+type FetchRecoverableAgentsResponseEntry = FetchRecoverableAgentsResponsePayload["entries"][number];
+type FetchRecoverableAgentsResponsePageInfo =
+  FetchRecoverableAgentsResponsePayload["pageInfo"];
 type AgentUpdatePayload = Extract<SessionOutboundMessage, { type: "agent_update" }>["payload"];
 type AgentUpdatesFilter = FetchAgentsRequestFilter;
 type AgentUpdatesSubscriptionState = {
@@ -1445,6 +1459,10 @@ export class Session {
 
           case "fetch_agents_request":
             await this.handleFetchAgents(msg);
+            break;
+
+          case "fetch_recoverable_agents_request":
+            await this.handleFetchRecoverableAgents(msg);
             break;
 
           case "fetch_workspaces_request":
@@ -4821,6 +4839,19 @@ export class Session {
     return agents;
   }
 
+  private async listRecoverableAgentPayloads(): Promise<AgentSnapshotPayload[]> {
+    const liveIds = new Set(this.agentManager.listAgents().map((agent) => agent.id));
+    const registryRecords = await this.agentStorage.list();
+
+    return registryRecords
+      .filter((record) => !liveIds.has(record.id) && !record.internal)
+      .map((record) => this.buildStoredAgentPayload(record))
+      .filter(
+        (agent) =>
+          agent.status === "closed" && agent.archivedAt == null && agent.persistence != null,
+      );
+  }
+
   private async resolveAgentIdentifier(
     identifier: string,
   ): Promise<{ ok: true; agentId: string } | { ok: false; error: string }> {
@@ -5175,6 +5206,55 @@ export class Session {
 
     return {
       entries: pagedEntries,
+      pageInfo: {
+        nextCursor,
+        prevCursor: request.page?.cursor ?? null,
+        hasMore,
+      },
+    };
+  }
+
+  private async listFetchRecoverableAgentsEntries(
+    request: Extract<SessionInboundMessage, { type: "fetch_recoverable_agents_request" }>,
+  ): Promise<{
+    entries: FetchRecoverableAgentsResponseEntry[];
+    pageInfo: FetchRecoverableAgentsResponsePageInfo;
+  }> {
+    const sort = this.normalizeFetchAgentsSort(request.sort as FetchAgentsRequestSort[] | undefined);
+    let candidates = await this.listRecoverableAgentPayloads();
+
+    candidates.sort((left, right) => this.compareFetchAgentsAgents(left, right, sort));
+    const cursorToken = request.page?.cursor;
+    if (cursorToken) {
+      const cursor = this.decodeFetchAgentsCursor(cursorToken, sort);
+      candidates = candidates.filter(
+        (agent) => this.compareAgentWithCursor(agent, cursor, sort) > 0,
+      );
+    }
+
+    const limit = request.page?.limit ?? 200;
+    const pagedAgents = candidates.slice(0, limit);
+    const hasMore = candidates.length > limit;
+    const nextCursor =
+      hasMore && pagedAgents.length > 0
+        ? this.encodeFetchAgentsCursor(
+            {
+              agent: pagedAgents[pagedAgents.length - 1],
+              project: await this.buildProjectPlacement(pagedAgents[pagedAgents.length - 1].cwd),
+            },
+            sort,
+          )
+        : null;
+
+    const entries = await Promise.all(
+      pagedAgents.map(async (agent) => ({
+        agent,
+        project: await this.buildProjectPlacement(agent.cwd),
+      })),
+    );
+
+    return {
+      entries,
       pageInfo: {
         nextCursor,
         prevCursor: request.page?.cursor ?? null,
@@ -5889,6 +5969,46 @@ export class Session {
       const code = error instanceof SessionRequestError ? error.code : "fetch_agents_failed";
       const message = error instanceof Error ? error.message : "Failed to fetch agents";
       this.sessionLogger.error({ err: error }, "Failed to handle fetch_agents_request");
+      this.emit({
+        type: "rpc_error",
+        payload: {
+          requestId: request.requestId,
+          requestType: request.type,
+          error: message,
+          code,
+        },
+      });
+    }
+  }
+
+  private async handleFetchRecoverableAgents(
+    request: Extract<SessionInboundMessage, { type: "fetch_recoverable_agents_request" }>,
+  ): Promise<void> {
+    try {
+      const payload = await this.listFetchRecoverableAgentsEntries(request);
+
+      payload.entries = payload.entries.filter((entry) =>
+        this.isProviderVisibleToClient(entry.agent.provider),
+      );
+
+      this.emit({
+        type: "fetch_recoverable_agents_response",
+        payload: {
+          requestId: request.requestId,
+          ...payload,
+        },
+      });
+    } catch (error) {
+      const code =
+        error instanceof SessionRequestError
+          ? error.code
+          : "fetch_recoverable_agents_failed";
+      const message =
+        error instanceof Error ? error.message : "Failed to fetch recoverable agents";
+      this.sessionLogger.error(
+        { err: error },
+        "Failed to handle fetch_recoverable_agents_request",
+      );
       this.emit({
         type: "rpc_error",
         payload: {

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -683,6 +683,25 @@ export const FetchAgentsRequestMessageSchema = z.object({
     .optional(),
 });
 
+export const FetchRecoverableAgentsRequestMessageSchema = z.object({
+  type: z.literal("fetch_recoverable_agents_request"),
+  requestId: z.string(),
+  sort: z
+    .array(
+      z.object({
+        key: z.enum(["status_priority", "created_at", "updated_at", "title"]),
+        direction: z.enum(["asc", "desc"]),
+      }),
+    )
+    .optional(),
+  page: z
+    .object({
+      limit: z.number().int().positive().max(200),
+      cursor: z.string().min(1).optional(),
+    })
+    .optional(),
+});
+
 const WorkspaceStateBucketSchema = z.enum([
   "needs_input",
   "failed",
@@ -1431,6 +1450,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   AbortRequestMessageSchema,
   AudioPlayedMessageSchema,
   FetchAgentsRequestMessageSchema,
+  FetchRecoverableAgentsRequestMessageSchema,
   FetchWorkspacesRequestMessageSchema,
   FetchAgentRequestMessageSchema,
   DeleteAgentRequestMessageSchema,
@@ -1977,6 +1997,24 @@ export const FetchAgentsResponseMessageSchema = z.object({
   payload: z.object({
     requestId: z.string(),
     subscriptionId: z.string().nullable().optional(),
+    entries: z.array(
+      z.object({
+        agent: AgentSnapshotPayloadSchema,
+        project: ProjectPlacementPayloadSchema,
+      }),
+    ),
+    pageInfo: z.object({
+      nextCursor: z.string().nullable(),
+      prevCursor: z.string().nullable(),
+      hasMore: z.boolean(),
+    }),
+  }),
+});
+
+export const FetchRecoverableAgentsResponseMessageSchema = z.object({
+  type: z.literal("fetch_recoverable_agents_response"),
+  payload: z.object({
+    requestId: z.string(),
     entries: z.array(
       z.object({
         agent: AgentSnapshotPayloadSchema,
@@ -2786,6 +2824,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   AgentStreamMessageSchema,
   AgentStatusMessageSchema,
   FetchAgentsResponseMessageSchema,
+  FetchRecoverableAgentsResponseMessageSchema,
   FetchWorkspacesResponseMessageSchema,
   OpenProjectResponseMessageSchema,
   ListAvailableEditorsResponseMessageSchema,
@@ -2896,6 +2935,9 @@ export type LegacyEditorTargetId = z.infer<typeof LegacyEditorTargetIdSchema>;
 export type EditorTargetId = LiteralUnion<KnownEditorTargetId, string>;
 export type EditorTargetDescriptorPayload = z.infer<typeof EditorTargetDescriptorPayloadSchema>;
 export type FetchAgentsResponseMessage = z.infer<typeof FetchAgentsResponseMessageSchema>;
+export type FetchRecoverableAgentsResponseMessage = z.infer<
+  typeof FetchRecoverableAgentsResponseMessageSchema
+>;
 export type FetchWorkspacesResponseMessage = z.infer<typeof FetchWorkspacesResponseMessageSchema>;
 export type OpenProjectResponseMessage = z.infer<typeof OpenProjectResponseMessageSchema>;
 export type ListAvailableEditorsResponseMessage = z.infer<
@@ -2965,6 +3007,9 @@ export type ActivityLogPayload = z.infer<typeof ActivityLogPayloadSchema>;
 // Type exports for inbound message types
 export type VoiceAudioChunkMessage = z.infer<typeof VoiceAudioChunkMessageSchema>;
 export type FetchAgentsRequestMessage = z.infer<typeof FetchAgentsRequestMessageSchema>;
+export type FetchRecoverableAgentsRequestMessage = z.infer<
+  typeof FetchRecoverableAgentsRequestMessageSchema
+>;
 export type FetchWorkspacesRequestMessage = z.infer<typeof FetchWorkspacesRequestMessageSchema>;
 export type FetchAgentRequestMessage = z.infer<typeof FetchAgentRequestMessageSchema>;
 export type SendAgentMessageRequest = z.infer<typeof SendAgentMessageRequestSchema>;

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1,7 +1,13 @@
 import { z } from "zod";
 import { AGENT_LIFECYCLE_STATUSES } from "./agent-lifecycle.js";
 import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "../server/agent/agent-title-limits.js";
-import { AgentProviderSchema } from "../server/agent/provider-manifest.js";
+import {
+  AgentProviderSchema,
+  AgentProviderSchema as ImportedAgentProviderSchema,
+} from "../server/agent/provider-manifest.js";
+// COMPAT(rn-dev-client): Metro can evaluate this import path as undefined during circular init.
+const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ??
+  z.string()) as z.ZodType<string>;
 import { TOOL_CALL_ICON_NAMES } from "../server/agent/agent-sdk-types.js";
 import {
   ChatCreateRequestSchema,

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -871,7 +871,7 @@ export const GetProvidersSnapshotRequestMessageSchema = z.object({
 export const RefreshProvidersSnapshotRequestMessageSchema = z.object({
   type: z.literal("refresh_providers_snapshot_request"),
   cwd: z.string().optional(),
-  providers: z.array(AgentProviderSchema).optional(),
+  providers: z.array(AgentProviderValueSchema).optional(),
   requestId: z.string(),
 });
 


### PR DESCRIPTION
## Summary
- Adds recoverable agent-directory RPC support for mobile and external-session recovery flows.

## 2026-04-16 Integrated Device Verification
- Verified on physical Android device over USB.
- Direct local connection path: pass.
- Phone message send from current mobile UI: pass.
- Existing tmux-backed Codex session wake: pass.
- Assistant reply render on phone: pass. Exact token `TMUX_MOBILE_PING_4`.
- History scroll check: `428` frames, `3` janky (`0.70%`), `p95 18ms`, `p99 19ms`.
- Sensitive local details, device identifiers, private endpoints, and local artifact paths are intentionally omitted from this public PR.

## Branch-Specific Coverage
- Device session loaded workspace and recoverable agent directory data successfully during live use.

## Fork CI
- Upstream PR currently reports no native GitHub checks.
- Latest fork `CI` success for this branch: https://github.com/Jacobinwwey/paseo/actions/runs/24545428563
