### PR TITLE
fix: prevent IME composition Enter from triggering send on macOS

### DIFF
--- a/packages/app/src/components/message-input.tsx
+++ b/packages/app/src/components/message-input.tsx
@@ -306,6 +306,9 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(funct
   const overlayTransition = useSharedValue(0);
   const sendAfterTranscriptRef = useRef(false);
   const valueRef = useRef(value);
+  // Tracks IME composition state independently of event.isComposing, which is
+  // unreliable on macOS (compositionend fires before keydown there).
+  const isComposingRef = useRef(false);
   const serverInfo = useSessionStore(
     useCallback(
       (state) => {
@@ -451,6 +454,34 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(funct
     }
     sendAfterTranscriptRef.current = false;
   }, [dictationStatus, isDictating, isDictationProcessing]);
+
+  // On macOS, compositionend fires before the Enter keydown that commits the
+  // composition, so KeyboardEvent.isComposing is already false by the time
+  // our handler runs. Deferring the flag clear with setTimeout(0) fixes this.
+  useEffect(() => {
+    if (!isWeb) return;
+    const current = textInputRef.current as (TextInput & { getNativeRef?: () => unknown }) | null;
+    const el = typeof current?.getNativeRef === "function" ? current.getNativeRef() : current;
+    if (!(el instanceof HTMLElement)) return;
+
+    const onCompositionStart = () => {
+      isComposingRef.current = true;
+    };
+    const onCompositionEnd = () => {
+      setTimeout(() => {
+        isComposingRef.current = false;
+      }, 0);
+    };
+
+    el.addEventListener("compositionstart", onCompositionStart);
+    el.addEventListener("compositionend", onCompositionEnd);
+    return () => {
+      el.removeEventListener("compositionstart", onCompositionStart);
+      el.removeEventListener("compositionend", onCompositionEnd);
+    };
+    // textInputRef and isComposingRef are stable refs; isWeb is a module constant
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const startDictationIfAvailable = useCallback(async () => {
     if (dictationUnavailableMessage) {
@@ -889,9 +920,14 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(funct
     if (!shouldHandleDesktopSubmit) return;
 
     // IME composition in progress (e.g. CJK input) — all key events belong to the
-    // IME, not the app. keyCode 229 is a Chromium fallback for when isComposing is
-    // cleared before the keydown fires.
-    if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) return;
+    // IME, not the app. keyCode 229 is a Chromium fallback; isComposingRef covers
+    // the macOS case where compositionend fires before keydown.
+    if (
+      isComposingRef.current ||
+      event.nativeEvent.isComposing ||
+      event.nativeEvent.keyCode === 229
+    )
+      return;
 
     // Allow parent to intercept key events (e.g., for autocomplete navigation)
     if (onKeyPressCallback) {


### PR DESCRIPTION
## Summary

On macOS, pressing Enter to commit CJK (Chinese/Japanese/Korean) IME composition also triggers the message send action.

The codebase already has an `isComposing` guard in `handleDesktopKeyPress`, but it does not work on macOS due to a platform-specific event ordering difference:

- **Windows / Linux**: `compositionend` fires *after* the Enter `keydown`, so `isComposing` is still `true` when the key handler runs — the guard works correctly.
- **macOS**: `compositionend` fires *before* the Enter `keydown` that commits the composition — so by the time the handler runs, `isComposing` is already `false` and the guard is bypassed.

Fix: attach `compositionstart` / `compositionend` listeners directly to the underlying DOM element and maintain `isComposingRef` independently of `event.nativeEvent.isComposing`. The `compositionend` handler defers the flag clear with `setTimeout(0)` so the keydown handler still sees the composition as active on that tick.

## Changes

- `packages/app/src/components/message-input.tsx`
  - Add `isComposingRef` to track IME composition state independently
  - Add `useEffect` (web-only) to attach native `compositionstart` / `compositionend` listeners via `textInputRef` / `getNativeRef()`
  - Update the IME guard in `handleDesktopKeyPress` to also check `isComposingRef.current`

## Test Plan

Requires manual testing with a real CJK input method. Automated tests cannot simulate IME composition event sequences reliably.

Steps to reproduce the bug (before fix) and verify the fix:

1. Open the web or Electron desktop app
2. Switch system input method to Chinese (e.g. macOS Simplified Chinese Pinyin)
3. Click the message input field
4. Type some English letters — they appear in the IME candidate buffer
5. Press Enter to commit the text to the input
6. **Before fix**: text is committed *and* the message is sent
7. **After fix**: text is committed, message is NOT sent

Typecheck and unit tests pass:
```
npm run typecheck --workspace=@getpaseo/app  ✓
npm run test --workspace=@getpaseo/app       ✓  127 test files, 767 tests
```

Fixes: #314
Related: #241, #264, #309, #312