### PR TITLE
fix: add yq to nix dev shell for mise android-sdk

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
             packages = [
               pkgs.nodejs_22
               pkgs.python3
+              pkgs.yq-go
             ];
           };
         }


### PR DESCRIPTION
## Summary
- add  to the Nix dev shell
- fix local  android-sdk plugin usage in environments created from the repo dev shell
- keep the fix scoped to dev environment setup only

## Verification
- reproduced the original  failure: plugin could not run because required  was missing
- confirmed the plugin expects Go  syntax, matching 
- 
> paseo@0.1.55-rc.1 format:check
> biome format . flake.nix: passed
- 
> paseo@0.1.55-rc.1 typecheck
> npm run typecheck --workspaces --if-present


> @getpaseo/expo-two-way-audio@0.1.55-rc.1 typecheck
> tsc


> @getpaseo/highlight@0.1.55-rc.1 typecheck
> tsc --noEmit


> @getpaseo/server@0.1.55-rc.1 typecheck
> tsc -p tsconfig.server.typecheck.json --noEmit


> @getpaseo/app@0.1.55-rc.1 typecheck
> tsc --noEmit


> @getpaseo/relay@0.1.55-rc.1 typecheck
> tsc --noEmit


> @getpaseo/website@0.1.55-rc.1 typecheck
> tsc --noEmit


> @getpaseo/desktop@0.1.55-rc.1 typecheck
> tsc --noEmit -p tsconfig.json


> @getpaseo/cli@0.1.55-rc.1 typecheck
> tsc --noEmit: fails due to pre-existing unrelated errors in 
- tracked the unrelated typecheck issue separately: #343

## Notes
- full end-to-end  verification could not be executed in this shell because  is not installed in the current environment, but the repo fix is declarative and targeted at the missing dependency discovered during reproduction.
