### PR TITLE
fix: tighten claude agent stream and image typing

### DIFF
--- a/packages/server/src/server/agent/providers/claude-agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.test.ts
@@ -356,6 +356,40 @@ describe("ClaudeAgentClient.listModels", () => {
   });
 });
 
+describe("ClaudeAgentClient prompt normalization", () => {
+  const logger = createTestLogger();
+
+  test("skips unsupported image mime types when building Claude SDK user messages", async () => {
+    const client = new ClaudeAgentClient({ logger });
+    const session = await client.createSession({
+      provider: "claude",
+      cwd: process.cwd(),
+    });
+
+    try {
+      const sdkMessage = session.toSdkUserMessage([
+        { type: "text", text: "before" },
+        { type: "image", mimeType: "image/png", data: "png-data" },
+        { type: "image", mimeType: "image/svg+xml", data: "svg-data" },
+      ]);
+
+      expect(sdkMessage.message.content).toEqual([
+        { type: "text", text: "before" },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "png-data",
+          },
+        },
+      ]);
+    } finally {
+      await session.close();
+    }
+  });
+});
+
 describe("ClaudeAgentSession context window usage", () => {
   const logger = createTestLogger();
 

--- a/packages/server/src/server/agent/providers/claude-agent.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.ts
@@ -77,6 +77,17 @@ import { execCommand, spawnProcess } from "../../../utils/spawn.js";
 import { getOrchestratorModeInstructions } from "../orchestrator-instructions.js";
 
 const fsPromises = promises;
+type ClaudeImageMimeType = "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+
+function isClaudeImageMimeType(value: string): value is ClaudeImageMimeType {
+  return (
+    value === "image/jpeg" ||
+    value === "image/png" ||
+    value === "image/gif" ||
+    value === "image/webp"
+  );
+}
+
 const CLAUDE_SETTING_SOURCES: NonNullable<Options["settingSources"]> = ["user", "project"];
 
 type TurnState = "idle" | "foreground" | "autonomous";
@@ -771,7 +782,7 @@ class TimelineAssembler {
     runId: string | null,
     messageIdHint: string | null,
   ): AgentTimelineItem[] {
-    const event = message.event as Record<string, unknown>;
+    const event = message.event as unknown as Record<string, unknown>;
     const eventType = readTrimmedString(event.type);
     const streamEventMessageId = this.readMessageIdFromStreamEvent(event) ?? messageIdHint;
 
@@ -2165,13 +2176,16 @@ class ClaudeAgentSession implements AgentSession {
   private toSdkUserMessage(prompt: AgentPromptInput): SDKUserMessage {
     const content: Array<
       | { type: "text"; text: string }
-      | { type: "image"; source: { type: "base64"; media_type: string; data: string } }
+      | { type: "image"; source: { type: "base64"; media_type: ClaudeImageMimeType; data: string } }
     > = [];
     if (Array.isArray(prompt)) {
       for (const chunk of prompt) {
         if (chunk.type === "text") {
           content.push({ type: "text", text: chunk.text });
         } else if (chunk.type === "image") {
+          if (!isClaudeImageMimeType(chunk.mimeType)) {
+            continue;
+          }
           content.push({
             type: "image",
             source: {


### PR DESCRIPTION
## Summary
- bridge Claude stream-event objects through  before record-style inspection
- narrow Claude image MIME handling to the SDK-supported image MIME types
- add a regression test covering unsupported image MIME filtering

## Verification
- 
> @getpaseo/server@0.1.55-rc.1 typecheck
> tsc -p tsconfig.server.typecheck.json --noEmit
- 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.4 [39m[90m/home/chethan/opensource/paseo[39m

 [32m✓[39m .worktrees/fix-claude-agent-typecheck/packages/server/src/server/agent/providers/claude-agent.test.ts [2m([22m[2m24 tests[22m[2m)[22m[32m 28[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m24 passed[39m[22m[90m (24)[39m
[2m   Start at [22m 21:59:18
[2m   Duration [22m 568ms[2m (transform 240ms, setup 0ms, import 378ms, tests 28ms, environment 0ms)[22m
- 
> paseo@0.1.55-rc.1 format:check
> biome format . packages/server/src/server/agent/providers/claude-agent.ts packages/server/src/server/agent/providers/claude-agent.test.ts

## Context
This follows up on #343, which was discovered while shipping the separate mise/yq fix.
