### PR TITLE
[feat] Add support for Factory Droid

### DIFF
--- a/packages/app/src/components/agent-status-bar.tsx
+++ b/packages/app/src/components/agent-status-bar.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { View, Text, Pressable, Keyboard } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { useShallow } from "zustand/shallow";
@@ -942,6 +942,20 @@ export const AgentStatusBar = memo(function AgentStatusBar({
       label: option.label,
     }));
   }, [modelSelection.thinkingOptions]);
+  const [optimisticThinkingOptionId, setOptimisticThinkingOptionId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setOptimisticThinkingOptionId((current) => {
+      if (!current) {
+        return current;
+      }
+      if (current === (modelSelection.selectedThinkingId ?? null)) {
+        return null;
+      }
+      const stillValid = thinkingOptions.some((option) => option.id === current);
+      return stillValid ? current : null;
+    });
+  }, [modelSelection.selectedThinkingId, thinkingOptions]);
 
   if (!agent) {
     return null;
@@ -996,11 +1010,14 @@ export const AgentStatusBar = memo(function AgentStatusBar({
         });
       }}
       thinkingOptions={thinkingOptions.length > 1 ? thinkingOptions : undefined}
-      selectedThinkingOptionId={modelSelection.selectedThinkingId ?? undefined}
+      selectedThinkingOptionId={
+        optimisticThinkingOptionId ?? modelSelection.selectedThinkingId ?? undefined
+      }
       onSelectThinkingOption={(thinkingOptionId) => {
         if (!client) {
           return;
         }
+        setOptimisticThinkingOptionId(thinkingOptionId);
         const activeModelId = modelSelection.activeModelId;
         if (activeModelId) {
           void updatePreferences((current) =>
@@ -1019,6 +1036,7 @@ export const AgentStatusBar = memo(function AgentStatusBar({
           });
         }
         void client.setAgentThinkingOption(agentId, thinkingOptionId).catch((error) => {
+          setOptimisticThinkingOptionId(null);
           console.warn("[AgentStatusBar] setAgentThinkingOption failed", error);
         });
       }}

--- a/packages/cli/src/commands/daemon/status.ts
+++ b/packages/cli/src/commands/daemon/status.ts
@@ -167,6 +167,7 @@ function toStatusRows(status: DaemonStatus): StatusRow[] {
 const PROVIDER_BINARIES: { label: string; binary: string }[] = [
   { label: "Claude", binary: "claude" },
   { label: "Codex", binary: "codex" },
+  { label: "Droid", binary: "droid" },
   { label: "OpenCode", binary: "opencode" },
 ];
 

--- a/packages/cli/src/commands/provider/index.ts
+++ b/packages/cli/src/commands/provider/index.ts
@@ -15,7 +15,7 @@ export function createProviderCommand(): Command {
     provider
       .command("models")
       .description("List models for a provider")
-      .argument("<provider>", "Provider name (claude, codex, opencode)")
+      .argument("<provider>", "Provider name")
       .option("--thinking", "Include thinking option IDs for each model"),
   ).action(withOutput(runModelsCommand));
 

--- a/packages/cli/src/commands/provider/ls.ts
+++ b/packages/cli/src/commands/provider/ls.ts
@@ -17,7 +17,7 @@ const PROVIDERS: ProviderListItem[] = AGENT_PROVIDER_DEFINITIONS.map((def) => ({
   provider: def.id,
   label: def.label,
   status: "available",
-  defaultMode: def.defaultModeId ?? "default",
+  defaultMode: def.defaultModeId ?? "-",
   modes: def.modes.map((m) => m.label).join(", "),
 }));
 
@@ -74,7 +74,7 @@ export async function runLsCommand(
         provider: entry.provider,
         label: entry.label ?? entry.provider,
         status: entry.status === "ready" ? "available" : entry.status,
-        defaultMode: entry.defaultModeId ?? "default",
+        defaultMode: entry.defaultModeId ?? "-",
         modes: (entry.modes ?? []).map((mode) => mode.label).join(", "),
       })),
       schema: providerLsSchema,

--- a/packages/cli/src/utils/client.ts
+++ b/packages/cli/src/utils/client.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { loadConfig, resolvePaseoHome, DaemonClient } from "@getpaseo/server";
 import path from "node:path";
 import WebSocket from "ws";
@@ -12,6 +13,11 @@ export interface ConnectOptions {
 const DEFAULT_HOST = "localhost:6767";
 const DEFAULT_TIMEOUT = 15000;
 const PID_FILENAME = "paseo.pid";
+const require = createRequire(import.meta.url);
+
+type CliPackageJson = {
+  version?: unknown;
+};
 
 type DaemonTarget =
   | {
@@ -23,6 +29,16 @@ type DaemonTarget =
       url: string;
       socketPath: string;
     };
+
+function resolveCliAppVersion(): string | undefined {
+  try {
+    const packageJson = require("../../package.json") as CliPackageJson;
+    if (typeof packageJson.version === "string" && packageJson.version.trim().length > 0) {
+      return packageJson.version.trim();
+    }
+  } catch {}
+  return undefined;
+}
 
 /**
  * Get the daemon host from environment or options
@@ -199,6 +215,7 @@ export async function connectToDaemon(options?: ConnectOptions): Promise<DaemonC
   const clientId = await getOrCreateCliClientId();
   const hosts = resolveDaemonHostCandidates(options);
   const nodeWebSocketFactory = createNodeWebSocketFactory();
+  const appVersion = resolveCliAppVersion();
   let lastError: unknown = null;
 
   for (const host of hosts) {
@@ -207,6 +224,7 @@ export async function connectToDaemon(options?: ConnectOptions): Promise<DaemonC
       url: target.url,
       clientId,
       clientType: "cli",
+      ...(appVersion ? { appVersion } : {}),
       connectTimeoutMs: timeout,
       webSocketFactory: (url: string, config?: { headers?: Record<string, string> }) =>
         nodeWebSocketFactory(url, {

--- a/packages/cli/tests/15-provider.test.ts
+++ b/packages/cli/tests/15-provider.test.ts
@@ -128,6 +128,7 @@ try {
     assert.strictEqual(result.exitCode, 0, "provider ls should exit 0");
     assert(result.stdout.includes("claude"), "output should include claude");
     assert(result.stdout.includes("codex"), "output should include codex");
+    assert(result.stdout.includes("droid"), "output should include droid");
     assert(result.stdout.includes("opencode"), "output should include opencode");
     assert(
       result.stdout.includes("available") ||
@@ -145,7 +146,7 @@ try {
     assert.strictEqual(result.exitCode, 0, "should exit 0");
     const data = JSON.parse(result.stdout.trim());
     assert(Array.isArray(data), "output should be an array");
-    assert(data.length >= 3, `should have at least 3 providers, got ${data.length}`);
+    assert(data.length >= 4, `should have at least 4 providers, got ${data.length}`);
     assert(
       data.some((p: { provider: string }) => p.provider === "claude"),
       "should include claude",
@@ -153,6 +154,10 @@ try {
     assert(
       data.some((p: { provider: string }) => p.provider === "codex"),
       "should include codex",
+    );
+    assert(
+      data.some((p: { provider: string }) => p.provider === "droid"),
+      "should include droid",
     );
     assert(
       data.some((p: { provider: string }) => p.provider === "opencode"),
@@ -167,9 +172,10 @@ try {
     const result = await ctx.paseo(["provider", "ls", "--quiet"]);
     assert.strictEqual(result.exitCode, 0, "should exit 0");
     const lines = result.stdout.trim().split("\n");
-    assert(lines.length >= 3, `should have at least 3 lines, got ${lines.length}`);
+    assert(lines.length >= 4, `should have at least 4 lines, got ${lines.length}`);
     assert(lines.includes("claude"), "should include claude");
     assert(lines.includes("codex"), "should include codex");
+    assert(lines.includes("droid"), "should include droid");
     assert(lines.includes("opencode"), "should include opencode");
     console.log("✓ provider ls --quiet outputs provider names only\n");
   }

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -126,6 +126,59 @@ class TestAgentClient implements AgentClient {
   }
 }
 
+class TestDroidAgentClient implements AgentClient {
+  readonly provider = "droid" as const;
+  readonly capabilities = TEST_CAPABILITIES;
+  lastResumeConfig: Partial<AgentSessionConfig> | undefined;
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+    return new TestDroidAgentSession(config);
+  }
+
+  async listModels() {
+    return [
+      {
+        provider: "droid" as const,
+        id: "gpt-5.4",
+        label: "GPT-5.4",
+        isDefault: true,
+        thinkingOptions: [
+          { id: "medium", label: "medium", isDefault: true },
+          { id: "high", label: "high" },
+        ],
+        defaultThinkingOptionId: "medium",
+      },
+    ];
+  }
+
+  async listModes() {
+    return [
+      { id: "normal", label: "Auto (Off)" },
+      { id: "spec", label: "Spec" },
+    ];
+  }
+
+  async resumeSession(
+    handle: AgentPersistenceHandle,
+    config?: Partial<AgentSessionConfig>,
+    _launchContext?: AgentLaunchContext,
+  ): Promise<AgentSession> {
+    this.lastResumeConfig = config;
+    return new TestDroidAgentSession({
+      ...(handle.metadata ?? {}),
+      provider: "droid",
+      cwd: config?.cwd ?? process.cwd(),
+      model: config?.model,
+      modeId: config?.modeId,
+      thinkingOptionId: config?.thinkingOptionId,
+    });
+  }
+}
+
 class TestAgentSession implements AgentSession {
   readonly provider = "codex" as const;
   readonly capabilities = TEST_CAPABILITIES;
@@ -215,6 +268,21 @@ class TestAgentSession implements AgentSession {
   async close(): Promise<void> {}
 }
 
+class TestDroidAgentSession extends TestAgentSession {
+  readonly provider = "droid" as const;
+
+  override describePersistence() {
+    return {
+      provider: this.provider,
+      sessionId: this.id,
+      metadata: {
+        provider: this.provider,
+        cwd: process.cwd(),
+      },
+    };
+  }
+}
+
 function createFeature(overrides: Partial<AgentFeature> = {}): AgentFeature {
   return {
     type: "toggle",
@@ -271,6 +339,31 @@ describe("AgentManager", () => {
 
     expect(snapshot.config.model).toBe("gpt-5.4");
     expect(snapshot.config.modeId).toBe("auto");
+  });
+
+  test("setAgentThinkingOption reloads droid sessions with the new reasoning effort", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
+    const storagePath = join(workdir, "agents");
+    const storage = new AgentStorage(storagePath, logger);
+    const droidClient = new TestDroidAgentClient();
+    const manager = new AgentManager({
+      clients: {
+        droid: droidClient,
+      },
+      registry: storage,
+      logger,
+      idFactory: () => "00000000-0000-4000-8000-000000000102",
+    });
+
+    const created = await manager.createAgent({
+      provider: "droid",
+      cwd: workdir,
+    });
+
+    await manager.setAgentThinkingOption(created.id, "high");
+
+    expect(droidClient.lastResumeConfig?.thinkingOptionId).toBe("high");
+    expect(manager.getAgent(created.id)?.config.thinkingOptionId).toBe("high");
   });
 
   test("setAgentMode persists the selected mode across session reload", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -987,6 +987,16 @@ export class AgentManager {
         ? thinkingOptionId
         : null;
 
+    if (agent.provider === "droid") {
+      await this.reloadAgentSession(agentId, {
+        thinkingOptionId: normalizedThinkingOptionId ?? undefined,
+      });
+      const refreshedAgent = this.requireAgent(agentId);
+      this.touchUpdatedAt(refreshedAgent);
+      this.emitState(refreshedAgent);
+      return;
+    }
+
     if (agent.session.setThinkingOption) {
       await agent.session.setThinkingOption(normalizedThinkingOptionId);
     }

--- a/packages/server/src/server/agent/provider-launch-config.test.ts
+++ b/packages/server/src/server/agent/provider-launch-config.test.ts
@@ -159,7 +159,7 @@ describe("ProviderOverrideSchema", () => {
 });
 
 describe("migrateProviderSettings", () => {
-  const builtinProviderIds = ["claude", "codex", "copilot", "opencode", "pi"];
+  const builtinProviderIds = ["claude", "codex", "droid", "copilot", "opencode", "pi"];
 
   test("passes through entries already in the new format", () => {
     const migrated = migrateProviderSettings(

--- a/packages/server/src/server/agent/provider-manifest.ts
+++ b/packages/server/src/server/agent/provider-manifest.ts
@@ -75,7 +75,44 @@ const CODEX_MODES: AgentProviderModeDefinition[] = [
   },
 ];
 
-const DROID_MODES: AgentProviderModeDefinition[] = [];
+const DROID_MODES: AgentProviderModeDefinition[] = [
+  {
+    id: "normal",
+    label: "Ask",
+    description:
+      "Read-only mode that still asks before any write or tool action with side effects.",
+    icon: "ShieldCheck",
+    colorTier: "safe",
+  },
+  {
+    id: "spec",
+    label: "Spec",
+    description: "Planning mode for writing specs and analyzing the codebase without changes.",
+    icon: "ShieldCheck",
+    colorTier: "planning",
+  },
+  {
+    id: "auto-low",
+    label: "Auto Low",
+    description: "Automatically approves low-risk actions such as file edits inside the workspace.",
+    icon: "ShieldAlert",
+    colorTier: "moderate",
+  },
+  {
+    id: "auto-medium",
+    label: "Auto Medium",
+    description: "Automatically approves medium-risk actions for broader autonomous work.",
+    icon: "ShieldAlert",
+    colorTier: "moderate",
+  },
+  {
+    id: "auto-high",
+    label: "Auto High",
+    description: "Automatically approves high-risk actions with minimal interruption.",
+    icon: "ShieldOff",
+    colorTier: "dangerous",
+  },
+];
 
 const COPILOT_MODES: AgentProviderModeDefinition[] = [
   {
@@ -148,7 +185,7 @@ export const AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [
     label: "Droid",
     description:
       "Factory's ACP coding agent with multi-model support, MCP tools, and tunable autonomy",
-    defaultModeId: null,
+    defaultModeId: "normal",
     modes: DROID_MODES,
   },
   {

--- a/packages/server/src/server/agent/provider-manifest.ts
+++ b/packages/server/src/server/agent/provider-manifest.ts
@@ -75,6 +75,8 @@ const CODEX_MODES: AgentProviderModeDefinition[] = [
   },
 ];
 
+const DROID_MODES: AgentProviderModeDefinition[] = [];
+
 const COPILOT_MODES: AgentProviderModeDefinition[] = [
   {
     id: "https://agentclientprotocol.com/protocol/session-modes#agent",
@@ -140,6 +142,14 @@ export const AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [
       defaultModeId: "auto",
       defaultModel: "gpt-5.4-mini",
     },
+  },
+  {
+    id: "droid",
+    label: "Droid",
+    description:
+      "Factory's ACP coding agent with multi-model support, MCP tools, and tunable autonomy",
+    defaultModeId: null,
+    modes: DROID_MODES,
   },
   {
     id: "copilot",

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -12,6 +12,7 @@ const mockState = vi.hoisted(() => {
     constructorArgs: {
       claude: [] as ConstructorEntry[],
       codex: [] as ConstructorEntry[],
+      droid: [] as ConstructorEntry[],
       copilot: [] as ConstructorEntry[],
       opencode: [] as ConstructorEntry[],
       pi: [] as ConstructorEntry[],
@@ -149,6 +150,54 @@ vi.mock("./providers/copilot-acp-agent.js", () => ({
     constructor(options: { runtimeSettings?: unknown }) {
       this.runtimeSettings = options.runtimeSettings;
       mockState.constructorArgs.copilot.push({
+        runtimeSettings: options.runtimeSettings,
+      });
+    }
+
+    async createSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async resumeSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async listModels(): Promise<AgentModelDefinition[]> {
+      return mockState.runtimeModels.get(this.provider) ?? [];
+    }
+
+    async listModes(): Promise<[]> {
+      return [];
+    }
+
+    async isAvailable(): Promise<boolean> {
+      const command = (this.runtimeSettings as { command?: { mode?: string; argv?: string[] } })
+        ?.command;
+      if (command?.mode === "replace") {
+        const { isCommandAvailable } = await import("../../utils/executable.js");
+        return await isCommandAvailable(command.argv?.[0] ?? "");
+      }
+      return true;
+    }
+  },
+}));
+
+vi.mock("./providers/droid-acp-agent.js", () => ({
+  DroidACPAgentClient: class DroidACPAgentClient {
+    readonly capabilities = {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    };
+    readonly provider = "droid";
+    readonly runtimeSettings?: unknown;
+
+    constructor(options: { runtimeSettings?: unknown }) {
+      this.runtimeSettings = options.runtimeSettings;
+      mockState.constructorArgs.droid.push({
         runtimeSettings: options.runtimeSettings,
       });
     }

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -23,6 +23,7 @@ import type {
 import { ClaudeAgentClient } from "./providers/claude-agent.js";
 import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js";
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
+import { DroidACPAgentClient } from "./providers/droid-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
 import { OpenCodeAgentClient, OpenCodeServerManager } from "./providers/opencode-agent.js";
 import { PiACPAgentClient } from "./providers/pi-acp-agent.js";
@@ -68,6 +69,11 @@ const PROVIDER_CLIENT_FACTORIES: Record<string, ProviderClientFactory> = {
       runtimeSettings,
     }),
   codex: (logger, runtimeSettings) => new CodexAppServerAgentClient(logger, runtimeSettings),
+  droid: (logger, runtimeSettings) =>
+    new DroidACPAgentClient({
+      logger,
+      runtimeSettings,
+    }),
   copilot: (logger, runtimeSettings) =>
     new CopilotACPAgentClient({
       logger,

--- a/packages/server/src/server/agent/providers/droid-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/droid-acp-agent.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+
+import { buildDroidDefaultCommand, parseDroidExecHelpReasoningMap } from "./droid-acp-agent.js";
+
+describe("parseDroidExecHelpReasoningMap", () => {
+  test("extracts supported reasoning efforts and defaults from droid exec help", () => {
+    const reasoning = parseDroidExecHelpReasoningMap(`
+Usage: droid exec [options] [prompt...]
+
+Model details:
+  - GPT-5.4: supports reasoning: Yes; supported: [low, medium, high, xhigh]; default: medium
+  - DeepSeek R1 0528: supports reasoning: No; supported: [none]; default: none
+`);
+
+    expect(reasoning.get("GPT-5.4")).toEqual({
+      defaultThinkingOptionId: "medium",
+      thinkingOptions: [
+        { id: "low", label: "low", isDefault: false },
+        { id: "medium", label: "medium", isDefault: true },
+        { id: "high", label: "high", isDefault: false },
+        { id: "xhigh", label: "xhigh", isDefault: false },
+      ],
+    });
+    expect(reasoning.get("DeepSeek R1 0528")).toEqual({
+      defaultThinkingOptionId: "none",
+      thinkingOptions: [{ id: "none", label: "none", isDefault: true }],
+    });
+  });
+});
+
+describe("buildDroidDefaultCommand", () => {
+  test("adds mode, model, and reasoning flags for a new session", () => {
+    expect(
+      buildDroidDefaultCommand(["droid", "exec", "--output-format", "acp"], {
+        modeId: "spec",
+        model: "gpt-5.4-mini",
+        thinkingOptionId: "xhigh",
+      }),
+    ).toEqual([
+      "droid",
+      "exec",
+      "--output-format",
+      "acp",
+      "--use-spec",
+      "--model",
+      "gpt-5.4-mini",
+      "--reasoning-effort",
+      "xhigh",
+    ]);
+  });
+});

--- a/packages/server/src/server/agent/providers/droid-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/droid-acp-agent.ts
@@ -1,9 +1,23 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import type { Logger } from "pino";
 
-import type { AgentCapabilityFlags, AgentMode } from "../agent-sdk-types.js";
+import type {
+  AgentCapabilityFlags,
+  AgentLaunchContext,
+  AgentMetadata,
+  AgentMode,
+  AgentModelDefinition,
+  AgentPersistenceHandle,
+  AgentSession,
+  AgentSessionConfig,
+  AgentSlashCommand,
+  ListModelsOptions,
+} from "../agent-sdk-types.js";
 import type { ProviderRuntimeSettings } from "../provider-launch-config.js";
 import { findExecutable } from "../../../utils/executable.js";
-import { ACPAgentClient } from "./acp-agent.js";
+import { ACPAgentClient, ACPAgentSession } from "./acp-agent.js";
+import { listDroidSlashCommands } from "./droid-slash-commands.js";
 import {
   formatDiagnosticStatus,
   formatProviderDiagnostic,
@@ -11,6 +25,8 @@ import {
   resolveBinaryVersion,
   toDiagnosticErrorMessage,
 } from "./diagnostic-utils.js";
+
+const execFileAsync = promisify(execFile);
 
 const DROID_CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: true,
@@ -28,6 +44,199 @@ type DroidACPAgentClientOptions = {
   runtimeSettings?: ProviderRuntimeSettings;
 };
 
+type DroidReasoningEntry = {
+  defaultThinkingOptionId: string | null;
+  thinkingOptions: NonNullable<AgentModelDefinition["thinkingOptions"]>;
+};
+
+const DROID_REASONING_LINE_RE =
+  /^-\s+(?<label>.+?):\s+supports reasoning:\s+(?<supports>yes|no);\s+supported:\s+\[(?<supported>[^\]]*)\];\s+default:\s+(?<default>.+)$/i;
+
+let droidReasoningCache: Promise<Map<string, DroidReasoningEntry>> | null = null;
+
+function coerceDroidSessionConfigMetadata(
+  metadata: AgentMetadata | undefined,
+): Partial<AgentSessionConfig> {
+  if (!metadata || typeof metadata !== "object") {
+    return {};
+  }
+  return metadata as Partial<AgentSessionConfig>;
+}
+
+function normalizeDroidThinkingOptionId(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function parseThinkingList(raw: string): string[] {
+  const ids = raw
+    .split(",")
+    .map((entry) => normalizeDroidThinkingOptionId(entry))
+    .filter((entry): entry is string => entry !== null);
+  return Array.from(new Set(ids));
+}
+
+export function parseDroidExecHelpReasoningMap(helpText: string): Map<string, DroidReasoningEntry> {
+  const result = new Map<string, DroidReasoningEntry>();
+  const modelDetailsIndex = helpText.indexOf("Model details:");
+  if (modelDetailsIndex === -1) {
+    return result;
+  }
+
+  const modelDetailsSection = helpText.slice(modelDetailsIndex + "Model details:".length);
+  for (const rawLine of modelDetailsSection.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line.startsWith("- ")) {
+      continue;
+    }
+
+    const match = line.match(DROID_REASONING_LINE_RE);
+    if (!match?.groups?.label) {
+      continue;
+    }
+
+    const label = match.groups.label.trim();
+    const supportedIds = parseThinkingList(match.groups.supported ?? "");
+    const defaultThinkingOptionId = normalizeDroidThinkingOptionId(match.groups.default ?? null);
+    const thinkingOptions = supportedIds.map((id) => ({
+      id,
+      label: id,
+      isDefault: id === defaultThinkingOptionId,
+    }));
+
+    result.set(label, {
+      defaultThinkingOptionId,
+      thinkingOptions,
+    });
+  }
+
+  return result;
+}
+
+function annotateDroidModels(
+  models: AgentModelDefinition[],
+  reasoningMap: Map<string, DroidReasoningEntry>,
+): AgentModelDefinition[] {
+  return models.map((model) => {
+    const reasoning = reasoningMap.get(model.label);
+    if (!reasoning || reasoning.thinkingOptions.length === 0) {
+      return model;
+    }
+
+    return {
+      ...model,
+      thinkingOptions: reasoning.thinkingOptions,
+      defaultThinkingOptionId:
+        reasoning.defaultThinkingOptionId ??
+        reasoning.thinkingOptions.find((option) => option.isDefault)?.id ??
+        reasoning.thinkingOptions[0]?.id,
+      metadata: {
+        ...(model.metadata ?? {}),
+        defaultReasoningEffort: reasoning.defaultThinkingOptionId,
+        supportedReasoningEfforts: reasoning.thinkingOptions.map((option) => option.id),
+      },
+    };
+  });
+}
+
+async function getDroidReasoningMetadata(): Promise<Map<string, DroidReasoningEntry>> {
+  if (!droidReasoningCache) {
+    droidReasoningCache = (async () => {
+      const resolvedBinary = await findExecutable("droid");
+      if (!resolvedBinary) {
+        return new Map<string, DroidReasoningEntry>();
+      }
+
+      const { stdout } = await execFileAsync(resolvedBinary, ["exec", "--help"], {
+        maxBuffer: 1024 * 1024,
+      });
+      return parseDroidExecHelpReasoningMap(stdout);
+    })().catch(() => new Map<string, DroidReasoningEntry>());
+  }
+
+  return droidReasoningCache;
+}
+
+export function buildDroidDefaultCommand(
+  baseCommand: readonly [string, ...string[]],
+  config: Pick<AgentSessionConfig, "modeId" | "model" | "thinkingOptionId">,
+): [string, ...string[]] {
+  const command = [...baseCommand];
+  const normalizedMode = config.modeId?.trim() ?? "";
+  const normalizedModel = config.model?.trim() ?? "";
+  const normalizedThinking = normalizeDroidThinkingOptionId(config.thinkingOptionId);
+
+  if (normalizedMode === "spec") {
+    command.push("--use-spec");
+  } else if (normalizedMode === "auto-low") {
+    command.push("--auto", "low");
+  } else if (normalizedMode === "auto-medium") {
+    command.push("--auto", "medium");
+  } else if (normalizedMode === "auto-high") {
+    command.push("--auto", "high");
+  }
+
+  if (normalizedModel) {
+    command.push("--model", normalizedModel);
+  }
+
+  if (normalizedThinking) {
+    command.push("--reasoning-effort", normalizedThinking);
+  }
+
+  return command as [string, ...string[]];
+}
+
+function wrapDroidSession(
+  session: AgentSession,
+  config: Pick<AgentSessionConfig, "cwd" | "thinkingOptionId">,
+): AgentSession {
+  let commandsPromise: Promise<AgentSlashCommand[]> | null = null;
+  const cwd = config.cwd;
+  const configuredThinkingOptionId = normalizeDroidThinkingOptionId(config.thinkingOptionId);
+
+  return new Proxy(session, {
+    get(target, prop, receiver) {
+      if (prop === "listCommands") {
+        return async () => {
+          if (!commandsPromise) {
+            commandsPromise = (async () => {
+              const providerCommands = target.listCommands ? await target.listCommands() : [];
+              return listDroidSlashCommands(cwd, providerCommands);
+            })();
+          }
+          return commandsPromise;
+        };
+      }
+
+      if (prop === "getRuntimeInfo") {
+        return async () => {
+          const runtimeInfo = await target.getRuntimeInfo();
+          return {
+            ...runtimeInfo,
+            thinkingOptionId: runtimeInfo.thinkingOptionId ?? configuredThinkingOptionId,
+          };
+        };
+      }
+
+      if (prop === "setThinkingOption") {
+        return async () => {
+          throw new Error(
+            "Droid reasoning effort can only be set when creating or resuming a session.",
+          );
+        };
+      }
+
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
 export class DroidACPAgentClient extends ACPAgentClient {
   constructor(options: DroidACPAgentClientOptions) {
     super({
@@ -42,6 +251,69 @@ export class DroidACPAgentClient extends ACPAgentClient {
 
   override async isAvailable(): Promise<boolean> {
     return super.isAvailable();
+  }
+
+  override async listModels(options?: ListModelsOptions): Promise<AgentModelDefinition[]> {
+    const [models, reasoningMap] = await Promise.all([
+      super.listModels(options),
+      getDroidReasoningMetadata(),
+    ]);
+    return annotateDroidModels(models, reasoningMap);
+  }
+
+  override async createSession(
+    config: AgentSessionConfig,
+    launchContext?: AgentLaunchContext,
+  ): Promise<AgentSession> {
+    const session = new ACPAgentSession(
+      { ...config, provider: this.provider },
+      {
+        provider: this.provider,
+        logger: this.logger,
+        runtimeSettings: this.runtimeSettings,
+        defaultCommand: buildDroidDefaultCommand(this.defaultCommand, config),
+        defaultModes: this.defaultModes,
+        capabilities: this.capabilities,
+        launchEnv: launchContext?.env,
+      },
+    );
+    await session.initializeNewSession();
+    return wrapDroidSession(session, config);
+  }
+
+  override async resumeSession(
+    handle: AgentPersistenceHandle,
+    overrides?: Partial<AgentSessionConfig>,
+    launchContext?: AgentLaunchContext,
+  ): Promise<AgentSession> {
+    if (handle.provider !== this.provider) {
+      throw new Error(`Cannot resume ${handle.provider} handle with ${this.provider} provider`);
+    }
+
+    const storedConfig = coerceDroidSessionConfigMetadata(handle.metadata);
+    const storedCwd = storedConfig.cwd?.trim() ? storedConfig.cwd : null;
+    const mergedConfig: AgentSessionConfig = {
+      ...storedConfig,
+      ...overrides,
+      provider: this.provider,
+      cwd: overrides?.cwd ?? storedCwd ?? process.cwd(),
+    };
+
+    const session = new ACPAgentSession(mergedConfig, {
+      provider: this.provider,
+      logger: this.logger,
+      runtimeSettings: this.runtimeSettings,
+      defaultCommand: buildDroidDefaultCommand(this.defaultCommand, mergedConfig),
+      defaultModes: this.defaultModes,
+      capabilities: this.capabilities,
+      handle,
+      launchEnv: launchContext?.env,
+    });
+    await session.initializeResumedSession();
+    return wrapDroidSession(session, {
+      cwd: mergedConfig.cwd,
+      thinkingOptionId: mergedConfig.thinkingOptionId,
+    });
   }
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {

--- a/packages/server/src/server/agent/providers/droid-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/droid-acp-agent.ts
@@ -1,0 +1,98 @@
+import type { Logger } from "pino";
+
+import type { AgentCapabilityFlags, AgentMode } from "../agent-sdk-types.js";
+import type { ProviderRuntimeSettings } from "../provider-launch-config.js";
+import { findExecutable } from "../../../utils/executable.js";
+import { ACPAgentClient } from "./acp-agent.js";
+import {
+  formatDiagnosticStatus,
+  formatProviderDiagnostic,
+  formatProviderDiagnosticError,
+  resolveBinaryVersion,
+  toDiagnosticErrorMessage,
+} from "./diagnostic-utils.js";
+
+const DROID_CAPABILITIES: AgentCapabilityFlags = {
+  supportsStreaming: true,
+  supportsSessionPersistence: true,
+  supportsDynamicModes: true,
+  supportsMcpServers: true,
+  supportsReasoningStream: true,
+  supportsToolInvocations: true,
+};
+
+const DROID_MODES: AgentMode[] = [];
+
+type DroidACPAgentClientOptions = {
+  logger: Logger;
+  runtimeSettings?: ProviderRuntimeSettings;
+};
+
+export class DroidACPAgentClient extends ACPAgentClient {
+  constructor(options: DroidACPAgentClientOptions) {
+    super({
+      provider: "droid",
+      logger: options.logger,
+      runtimeSettings: options.runtimeSettings,
+      defaultCommand: ["droid", "exec", "--output-format", "acp"],
+      defaultModes: DROID_MODES,
+      capabilities: DROID_CAPABILITIES,
+    });
+  }
+
+  override async isAvailable(): Promise<boolean> {
+    return super.isAvailable();
+  }
+
+  async getDiagnostic(): Promise<{ diagnostic: string }> {
+    try {
+      const available = await this.isAvailable();
+      const resolvedBinary = await findExecutable("droid");
+      let modelsValue = "Not checked";
+      let status = formatDiagnosticStatus(available);
+
+      if (available) {
+        try {
+          const models = await this.listModels();
+          modelsValue = String(models.length);
+        } catch (error) {
+          modelsValue = `Error - ${toDiagnosticErrorMessage(error)}`;
+          status = formatDiagnosticStatus(available, {
+            source: "model fetch",
+            cause: error,
+          });
+        }
+
+        if (!modelsValue.startsWith("Error -")) {
+          try {
+            await this.listModes();
+          } catch (error) {
+            status = formatDiagnosticStatus(available, {
+              source: "mode fetch",
+              cause: error,
+            });
+          }
+        }
+      }
+
+      return {
+        diagnostic: formatProviderDiagnostic("Droid", [
+          {
+            label: "Binary",
+            value: resolvedBinary ?? "not found",
+          },
+          {
+            label: "Version",
+            value: resolvedBinary ? await resolveBinaryVersion(resolvedBinary) : "unknown",
+          },
+          { label: "Models", value: modelsValue },
+          { label: "Status", value: status },
+        ]),
+      };
+    } catch (error) {
+      return {
+        diagnostic: formatProviderDiagnosticError("Droid", error),
+      };
+    }
+  }
+}

--- a/packages/server/src/server/agent/providers/droid-slash-commands.test.ts
+++ b/packages/server/src/server/agent/providers/droid-slash-commands.test.ts
@@ -1,0 +1,159 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { listDroidSlashCommands } from "./droid-slash-commands.js";
+
+function tmpPath(prefix: string): string {
+  return mkdtempSync(path.join(tmpdir(), prefix));
+}
+
+describe("listDroidSlashCommands", () => {
+  let tempHome: string;
+  let repoRoot: string;
+  let nestedCwd: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    tempHome = tmpPath("droid-home-");
+    repoRoot = tmpPath("droid-repo-");
+    nestedCwd = path.join(repoRoot, "apps", "mobile");
+
+    mkdirSync(nestedCwd, { recursive: true });
+    execSync("git init -b main", { cwd: repoRoot, stdio: "ignore" });
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    rmSync(tempHome, { recursive: true, force: true });
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  test("merges base commands, built-ins, workspace skills, legacy commands, and personal skills", async () => {
+    mkdirSync(path.join(repoRoot, ".factory", "skills", "review"), { recursive: true });
+    writeFileSync(
+      path.join(repoRoot, ".factory", "skills", "review", "SKILL.md"),
+      [
+        "---",
+        "name: review",
+        "description: Workspace review skill",
+        "user-invocable: true",
+        "---",
+        "",
+        "Review the current change.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    mkdirSync(path.join(repoRoot, ".factory", "skills", "hidden-context"), { recursive: true });
+    writeFileSync(
+      path.join(repoRoot, ".factory", "skills", "hidden-context", "SKILL.md"),
+      [
+        "---",
+        "name: hidden-context",
+        "description: Hidden helper",
+        "user-invocable: false",
+        "---",
+        "",
+        "Should not appear.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    mkdirSync(path.join(repoRoot, ".factory", "commands"), { recursive: true });
+    writeFileSync(
+      path.join(repoRoot, ".factory", "commands", "Prepare Release.md"),
+      [
+        "---",
+        "description: Prepare the release branch",
+        "argument-hint: VERSION=<semver>",
+        "---",
+        "",
+        "Prepare the release.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    mkdirSync(path.join(repoRoot, ".agent", "skills", "legacy-skill"), { recursive: true });
+    writeFileSync(
+      path.join(repoRoot, ".agent", "skills", "legacy-skill", "SKILL.md"),
+      ["---", "description: Legacy workspace skill", "---", "", "Legacy instructions.", ""].join(
+        "\n",
+      ),
+      "utf8",
+    );
+
+    mkdirSync(path.join(nestedCwd, ".factory", "skills", "review"), { recursive: true });
+    writeFileSync(
+      path.join(nestedCwd, ".factory", "skills", "review", "SKILL.md"),
+      [
+        "---",
+        "name: review",
+        "description: Nested workspace review skill",
+        "user-invocable: true",
+        "---",
+        "",
+        "Prefer this description.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    mkdirSync(path.join(tempHome, ".factory", "skills", "personal-skill"), { recursive: true });
+    writeFileSync(
+      path.join(tempHome, ".factory", "skills", "personal-skill", "SKILL.md"),
+      [
+        "---",
+        "description: >",
+        "  Personal skill",
+        "  with wrapped details",
+        "---",
+        "",
+        "Personal instructions.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const commands = await listDroidSlashCommands(nestedCwd, [
+      {
+        name: "help",
+        description: "Provider help overrides built-in help",
+        argumentHint: "",
+      },
+    ]);
+
+    expect(commands.some((command) => command.name === "skills")).toBe(true);
+    expect(commands.some((command) => command.name === "mcp")).toBe(true);
+    expect(commands.find((command) => command.name === "help")?.description).toBe(
+      "Provider help overrides built-in help",
+    );
+    expect(commands.find((command) => command.name === "review")?.description).toBe(
+      "Nested workspace review skill",
+    );
+    expect(commands.find((command) => command.name === "prepare-release")).toEqual({
+      name: "prepare-release",
+      description: "Prepare the release branch",
+      argumentHint: "VERSION=<semver>",
+    });
+    expect(commands.find((command) => command.name === "legacy-skill")?.description).toBe(
+      "Legacy workspace skill",
+    );
+    expect(commands.find((command) => command.name === "personal-skill")?.description).toBe(
+      "Personal skill with wrapped details",
+    );
+    expect(commands.some((command) => command.name === "hidden-context")).toBe(false);
+  });
+});

--- a/packages/server/src/server/agent/providers/droid-slash-commands.ts
+++ b/packages/server/src/server/agent/providers/droid-slash-commands.ts
@@ -1,0 +1,349 @@
+import { execSync } from "node:child_process";
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type { AgentSlashCommand } from "../agent-sdk-types.js";
+import { slugify } from "../../../utils/worktree.js";
+
+const DROID_BUILTIN_SLASH_COMMANDS: readonly AgentSlashCommand[] = [
+  { name: "account", description: "Open Factory account settings in browser", argumentHint: "" },
+  { name: "billing", description: "View and manage billing settings", argumentHint: "" },
+  { name: "bg-process", description: "Manage background processes", argumentHint: "" },
+  {
+    name: "bug",
+    description: "Create a bug report with session data and logs",
+    argumentHint: "[title]",
+  },
+  { name: "clear", description: "Start a new session", argumentHint: "" },
+  { name: "commands", description: "Manage custom slash commands", argumentHint: "" },
+  {
+    name: "compress",
+    description: "Compress session and move to new one with summary",
+    argumentHint: "[prompt]",
+  },
+  { name: "cost", description: "Show token usage statistics", argumentHint: "" },
+  {
+    name: "create-skill",
+    description: "Create a reusable skill from current session",
+    argumentHint: "",
+  },
+  { name: "droids", description: "Manage custom droids", argumentHint: "" },
+  { name: "enter-mission", description: "Enter Mission mode", argumentHint: "" },
+  { name: "favorite", description: "Mark current session as a favorite", argumentHint: "" },
+  {
+    name: "fork",
+    description: "Duplicate current session with all messages into a new session",
+    argumentHint: "",
+  },
+  { name: "generate_blog", description: "Generate semantic diff blog post", argumentHint: "" },
+  { name: "help", description: "Show available slash commands", argumentHint: "" },
+  { name: "hooks", description: "Manage lifecycle hooks", argumentHint: "" },
+  { name: "ide", description: "Configure IDE integrations", argumentHint: "" },
+  { name: "install-github-app", description: "Install Factory GitHub App", argumentHint: "" },
+  { name: "login", description: "Sign in to Factory", argumentHint: "" },
+  { name: "logout", description: "Sign out of Factory", argumentHint: "" },
+  { name: "mcp", description: "Manage Model Context Protocol servers", argumentHint: "" },
+  { name: "mission", description: "Open Mission Control", argumentHint: "" },
+  { name: "missions", description: "List and select missions to resume", argumentHint: "" },
+  { name: "model", description: "Switch AI model mid-session", argumentHint: "" },
+  { name: "new", description: "Start a new session", argumentHint: "" },
+  { name: "plugins", description: "Manage plugins and marketplaces", argumentHint: "" },
+  { name: "quit", description: "Exit droid", argumentHint: "" },
+  { name: "readiness-report", description: "Generate readiness report", argumentHint: "" },
+  { name: "rename", description: "Rename current session", argumentHint: "" },
+  { name: "review", description: "Start AI-powered code review workflow", argumentHint: "" },
+  {
+    name: "rewind-conversation",
+    description: "Undo recent changes in the session",
+    argumentHint: "",
+  },
+  { name: "sessions", description: "List and select previous sessions", argumentHint: "" },
+  { name: "settings", description: "Configure application settings", argumentHint: "" },
+  { name: "share", description: "Share session with organization", argumentHint: "" },
+  { name: "skills", description: "Manage and invoke skills", argumentHint: "" },
+  { name: "status", description: "Show current droid status and configuration", argumentHint: "" },
+  { name: "statusline", description: "Configure custom status line", argumentHint: "" },
+  {
+    name: "terminal-setup",
+    description: "Configure terminal keybindings for Shift+Enter",
+    argumentHint: "",
+  },
+  { name: "wrapped", description: "Show Droid usage statistics", argumentHint: "" },
+];
+
+type ParsedFrontMatter = {
+  frontMatter: Record<string, string>;
+};
+
+function parseFrontMatter(markdown: string): ParsedFrontMatter {
+  const trimmed = markdown.trimStart();
+  if (!trimmed.startsWith("---")) {
+    return { frontMatter: {} };
+  }
+
+  const newline = trimmed.indexOf("\n");
+  if (newline === -1) {
+    return { frontMatter: {} };
+  }
+
+  const endMarker = trimmed.indexOf("\n---", newline + 1);
+  if (endMarker === -1) {
+    return { frontMatter: {} };
+  }
+
+  const frontMatterText = trimmed.slice(newline + 1, endMarker).trim();
+  const frontMatter: Record<string, string> = {};
+
+  const lines = frontMatterText.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const idx = line.indexOf(":");
+    if (idx === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, idx).trim().toLowerCase();
+    let value = line.slice(idx + 1).trim();
+
+    if ((value === ">" || value === "|") && key) {
+      const separator = value === "|" ? "\n" : " ";
+      const blockLines: string[] = [];
+      while (index + 1 < lines.length) {
+        const nextLine = lines[index + 1] ?? "";
+        if (!/^\s+/.test(nextLine)) {
+          break;
+        }
+        blockLines.push(nextLine.trim());
+        index += 1;
+      }
+      value = blockLines.join(separator).trim();
+    }
+
+    value = value.replace(/^['"]/, "").replace(/['"]$/, "");
+    if (key && value) {
+      frontMatter[key] = value;
+    }
+  }
+
+  return { frontMatter };
+}
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["true", "1", "yes"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "0", "no"].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+function normalizeCommandName(name: string): string {
+  return name.trim().replace(/^\/+/, "");
+}
+
+function normalizeSlashCommand(command: AgentSlashCommand): AgentSlashCommand | null {
+  const name = normalizeCommandName(command.name);
+  if (!name) {
+    return null;
+  }
+
+  return {
+    name,
+    description: command.description.trim(),
+    argumentHint: command.argumentHint.trim(),
+  };
+}
+
+function mergeSlashCommands(
+  ...lists: ReadonlyArray<ReadonlyArray<AgentSlashCommand>>
+): AgentSlashCommand[] {
+  const commandsByName = new Map<string, AgentSlashCommand>();
+
+  for (const list of lists) {
+    for (const command of list) {
+      const normalized = normalizeSlashCommand(command);
+      if (!normalized || commandsByName.has(normalized.name)) {
+        continue;
+      }
+      commandsByName.set(normalized.name, normalized);
+    }
+  }
+
+  return Array.from(commandsByName.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function resolveRepoRoot(cwd: string): string | null {
+  try {
+    const output = execSync("git rev-parse --show-toplevel", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const trimmed = output.trim();
+    return trimmed ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+function getWorkspaceRoots(cwd: string): string[] {
+  const resolvedCwd = path.resolve(cwd);
+  const repoRoot = resolveRepoRoot(resolvedCwd);
+  if (!repoRoot) {
+    return [resolvedCwd];
+  }
+
+  const roots: string[] = [];
+  let current = resolvedCwd;
+  while (true) {
+    roots.push(current);
+    if (current === repoRoot) {
+      break;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  return roots;
+}
+
+async function readDirents(directoryPath: string): Promise<Dirent[]> {
+  try {
+    return await fs.readdir(directoryPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+async function readOptionalFile(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function isShebangFile(filePath: string): Promise<boolean> {
+  const content = await readOptionalFile(filePath);
+  return content?.startsWith("#!") ?? false;
+}
+
+async function listLegacySlashCommands(rootPath: string): Promise<AgentSlashCommand[]> {
+  const commandsDir = path.join(rootPath, ".factory", "commands");
+  const entries = await readDirents(commandsDir);
+  const commands: AgentSlashCommand[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const fullPath = path.join(commandsDir, entry.name);
+    const ext = path.extname(entry.name).toLowerCase();
+    const isMarkdown = ext === ".md";
+    const isExecutable = !isMarkdown && (await isShebangFile(fullPath));
+    if (!isMarkdown && !isExecutable) {
+      continue;
+    }
+
+    const baseName = path.basename(entry.name, ext);
+    const name = slugify(baseName);
+    if (!name) {
+      continue;
+    }
+
+    const content = await readOptionalFile(fullPath);
+    const { frontMatter } = parseFrontMatter(content ?? "");
+    commands.push({
+      name,
+      description:
+        frontMatter.description ??
+        (isExecutable ? "Executable custom command" : "Custom slash command"),
+      argumentHint: frontMatter["argument-hint"] ?? frontMatter.argument_hint ?? "",
+    });
+  }
+
+  return commands.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function readSkillMarkdown(skillDir: string): Promise<string | null> {
+  const candidates = ["SKILL.md", "skill.mdx"];
+  for (const candidate of candidates) {
+    const content = await readOptionalFile(path.join(skillDir, candidate));
+    if (content !== null) {
+      return content;
+    }
+  }
+  return null;
+}
+
+async function listSkillsFromDirectory(skillsDir: string): Promise<AgentSlashCommand[]> {
+  const entries = await readDirents(skillsDir);
+  const commands: AgentSlashCommand[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+      continue;
+    }
+
+    const skillDir = path.join(skillsDir, entry.name);
+    const content = await readSkillMarkdown(skillDir);
+    if (content === null) {
+      continue;
+    }
+
+    const { frontMatter } = parseFrontMatter(content);
+    if (parseBoolean(frontMatter["user-invocable"]) === false) {
+      continue;
+    }
+
+    const configuredName = frontMatter.name?.trim();
+    const name = normalizeCommandName(configuredName || slugify(entry.name));
+    if (!name) {
+      continue;
+    }
+
+    commands.push({
+      name,
+      description: frontMatter.description ?? "Skill",
+      argumentHint: frontMatter["argument-hint"] ?? frontMatter.argument_hint ?? "",
+    });
+  }
+
+  return commands.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function listWorkspaceAndPersonalSlashCommands(cwd: string): Promise<AgentSlashCommand[]> {
+  const roots = getWorkspaceRoots(cwd);
+  const personalRoot = homedir();
+  const customLists: AgentSlashCommand[][] = [];
+
+  for (const root of roots) {
+    customLists.push(await listSkillsFromDirectory(path.join(root, ".factory", "skills")));
+    customLists.push(await listSkillsFromDirectory(path.join(root, ".agent", "skills")));
+    customLists.push(await listLegacySlashCommands(root));
+  }
+
+  customLists.push(await listSkillsFromDirectory(path.join(personalRoot, ".factory", "skills")));
+  customLists.push(await listLegacySlashCommands(personalRoot));
+
+  return mergeSlashCommands(...customLists);
+}
+
+export async function listDroidSlashCommands(
+  cwd: string,
+  baseCommands: readonly AgentSlashCommand[] = [],
+): Promise<AgentSlashCommand[]> {
+  const customCommands = await listWorkspaceAndPersonalSlashCommands(cwd);
+  return mergeSlashCommands(baseCommands, customCommands, DROID_BUILTIN_SLASH_COMMANDS);
+}

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -118,7 +118,7 @@ const FeatureVoiceModeSchema = z
   })
   .strict();
 
-const BUILTIN_PROVIDER_IDS = ["claude", "codex", "copilot", "opencode", "pi"] as const;
+const BUILTIN_PROVIDER_IDS = ["claude", "codex", "droid", "copilot", "opencode", "pi"] as const;
 const PROVIDER_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
 
 const ProviderOverridesSchema = z


### PR DESCRIPTION
## Summary

This PR adds support for Factory Droid in Paseo.

It completes the Droid integration across the daemon and app by adding:
- slash command autocomplete
- thinking/reasoning controls
- Droid mode metadata for the UI
- live thinking updates via session reload
- immediate visual updates when thinking selection changes

## Details

- discover Droid built-in slash commands plus workspace/personal Factory skills and custom commands
- parse `droid exec --help` to expose supported reasoning levels per model
- launch Droid sessions with the selected model, mode, and reasoning effort
- mark Droid `spec` mode as planning mode in the UI
- reload live Droid sessions when thinking changes, since ACP does not support mutating that setting in place
- fix the status bar so selected thinking values appear immediately without a page refresh

## Testing

Ran:
- `npx vitest run packages/server/src/server/agent/agent-manager.test.ts
packages/server/src/server/agent/providers/droid-acp-agent.test.ts
packages/server/src/server/agent/providers/droid-slash-commands.test.ts`
- `npm run typecheck --workspace=@getpaseo/app`
- `npm run typecheck --workspace=@getpaseo/server`
- `npm run build:daemon`