### PR TITLE
fix: add Windows dev-client validation bootstrap and fork-safe CI guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -31,8 +31,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -55,8 +55,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Fetch origin/main (worktree tests)
         run: git fetch --no-tags origin main:refs/remotes/origin/main
@@ -85,8 +85,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -123,8 +123,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -136,14 +136,15 @@ jobs:
         run: npm run test --workspace=@getpaseo/app
 
   playwright:
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -185,8 +186,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -204,8 +205,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install
@@ -219,6 +220,6 @@ jobs:
       - name: Run CLI tests
         run: npm run test --workspace=@getpaseo/cli
         env:
-          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: '0'
-          PASEO_DICTATION_ENABLED: '0'
-          PASEO_VOICE_MODE_ENABLED: '0'
+          PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: "0"
+          PASEO_DICTATION_ENABLED: "0"
+          PASEO_VOICE_MODE_ENABLED: "0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,26 @@ jobs:
       - name: Run app unit tests
         run: npm run test --workspace=@getpaseo/app
 
+  playwright-preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      has_openai_api_key: ${{ steps.secret-check.outputs.has_openai_api_key }}
+    steps:
+      - name: Detect OpenAI key availability
+        id: secret-check
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -n "$OPENAI_API_KEY" ]; then
+            echo "has_openai_api_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_openai_api_key=false" >> "$GITHUB_OUTPUT"
+          fi
+
   playwright:
-    if: ${{ secrets.OPENAI_API_KEY != '' }}
+    needs: playwright-preflight
+    if: ${{ needs.playwright-preflight.outputs.has_openai_api_key == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -3,14 +3,15 @@ name: Deploy App
 on:
   push:
     tags:
-      - 'v*'
-      - '!v*-rc.*'
-      - 'app-v*'
-      - '!app-v*-rc.*'
+      - "v*"
+      - "!v*-rc.*"
+      - "app-v*"
+      - "!app-v*-rc.*"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -18,10 +19,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@boudra'
+          node-version: "22"
+          cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@boudra"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/app --include-workspace-root

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/relay/**'
-      - '.github/workflows/deploy-relay.yml'
+      - "packages/relay/**"
+      - ".github/workflows/deploy-relay.yml"
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'getpaseo/paseo' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -17,8 +18,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/relay --include-workspace-root
@@ -30,4 +31,3 @@ jobs:
         run: cd packages/relay && npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/website/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'patches/**'
-      - '.github/workflows/deploy-website.yml'
+      - "packages/website/**"
+      - "package.json"
+      - "package-lock.json"
+      - "patches/**"
+      - ".github/workflows/deploy-website.yml"
   release:
     types: [published, edited]
   workflow_dispatch:
 
 jobs:
   deploy:
-    if: ${{ github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft) }}
+    if: ${{ github.repository == 'getpaseo/paseo' && (github.event_name != 'release' || (!github.event.release.prerelease && !github.event.release.draft)) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -23,8 +23,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm install --workspace=@getpaseo/website --include-workspace-root

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -4,9 +4,9 @@
 
 Controlled by `APP_VARIANT` in `packages/app/app.config.js` (vanilla Expo, no custom Gradle plugin):
 
-| Variant | App name | Package ID |
-|---|---|---|
-| `production` | Paseo | `sh.paseo` |
+| Variant       | App name    | Package ID       |
+| ------------- | ----------- | ---------------- |
+| `production`  | Paseo       | `sh.paseo`       |
 | `development` | Paseo Debug | `sh.paseo.debug` |
 
 EAS profiles: `development`, `production`, and `production-apk` in `packages/app/eas.json`.
@@ -43,6 +43,33 @@ rm -rf android
 ```bash
 adb exec-out screencap -p > screenshot.png
 ```
+
+## Windows real-device Expo validation
+
+For clean-worktree Android dev-client validation on Windows, use the repo script from `packages/app`:
+
+```powershell
+npm run validate:windows-dev-client -- `
+  --device-id f66d9150 `
+  --port 8097 `
+  --host lan `
+  --env EXPO_NO_METRO_WORKSPACE_ROOT=1
+```
+
+What it does:
+
+- optionally runs `npm run build:workspace-deps`
+- starts Expo in the foreground and records `expo.log`
+- clears proxy env for the Expo child unless `--keep-proxy-env` is set
+- runs `adb reverse`, launches the dev-client deep link, and captures screenshot, UI dump, logcat, and top activity
+- writes artifacts to a temp directory outside the checkout by default so the worktree stays clean
+
+Exit codes are classification-oriented, not just process-oriented:
+
+- `0` if the configured success text is visible in the dumped UI tree
+- `2` if Android logcat shows a dev-client socket/read timeout
+- `3` if `adb am start` fails to launch the target package
+- `4` if artifacts were captured but no known success or failure signature was found
 
 ## Cloud build + submit (EAS)
 

--- a/docs/MOBILE_TESTING.md
+++ b/docs/MOBILE_TESTING.md
@@ -95,6 +95,29 @@ Two reusable flows handle Expo dev client screens after launch:
 - `flows/launch.yaml` — handles dev launcher, dismisses dev menu, asserts "Welcome to Paseo"
 - `flows/dev-client.yaml` — same but without asserting a particular app route
 
+### Windows Android dev-client bootstrap
+
+Real-device Windows validation has a specific false-positive trap: detached Metro processes can leave the port briefly open and then die before the device completes the first request. Treat `ECONNREFUSED` and "port is listening" as insufficient evidence on their own.
+
+Use the foreground bootstrap script instead:
+
+```powershell
+cd packages/app
+npm run validate:windows-dev-client -- `
+  --device-id f66d9150 `
+  --port 8097 `
+  --host lan
+```
+
+The script is intentionally evidence-first:
+
+- it writes artifacts to a temp directory outside the checkout by default
+- it captures `expo.log`, an HTTP probe, `adb start` output, screenshot, UI XML, top activity, and logcat
+- it clears proxy env for the Expo child by default so proxy noise is explicit rather than ambient
+- it classifies the result as `app_loaded`, `dev_client_read_timeout`, `launch_failed`, or `unknown`
+
+This is a bootstrap verifier, not a full product oracle. A `dev_client_read_timeout` result means the device reached the dev client but did not finish the first HTTP exchange. That is materially different from a dead Expo process and should be debugged separately from app-level reconnect logic.
+
 ## Self-verification loops
 
 Maestro can only interact with the app UI — it can't toggle iOS appearance, change locale, or simulate network conditions. For bugs that depend on system-level state, wrap Maestro in a bash script that handles the system changes between Maestro runs.
@@ -165,7 +188,7 @@ const styles = StyleSheet.create((theme) => ({
   },
 }));
 
-<Animated.View style={[styles.sidebar, animatedStyle]} />
+<Animated.View style={[styles.sidebar, animatedStyle]} />;
 ```
 
 ```tsx
@@ -185,8 +208,12 @@ const staticStyles = RNStyleSheet.create({
 const { theme } = useUnistyles();
 
 <Animated.View
-  style={[staticStyles.sidebar, animatedStyle, { backgroundColor: theme.colors.surfaceSidebar }]}
-/>
+  style={[
+    staticStyles.sidebar,
+    animatedStyle,
+    { backgroundColor: theme.colors.surfaceSidebar },
+  ]}
+/>;
 ```
 
 Regular `View` components can safely use Unistyles dynamic styles — the conflict is specific to `Animated.View`.

--- a/packages/app/metro.config.cjs
+++ b/packages/app/metro.config.cjs
@@ -23,11 +23,14 @@ const pathSeparatorPattern = "[\\\\/]";
 
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules ?? {}),
+  "@server": serverSrcRoot,
+  "@relay": relaySrcRoot,
   react: path.join(appNodeModulesRoot, "react"),
   "react-dom": path.join(appNodeModulesRoot, "react-dom"),
   "react/jsx-runtime": path.join(appNodeModulesRoot, "react/jsx-runtime"),
   "react/jsx-dev-runtime": path.join(appNodeModulesRoot, "react/jsx-dev-runtime"),
 };
+config.watchFolders = [...new Set([...(config.watchFolders ?? []), serverSrcRoot, relaySrcRoot])];
 config.resolver.blockList = new RegExp(
   `(^${escapedAppSrcRoot}${pathSeparatorPattern}.*\\.(test|spec)\\.(ts|tsx)$|${pathSeparatorPattern}__tests__${pathSeparatorPattern}.*)$`,
 );

--- a/packages/app/metro.config.cjs
+++ b/packages/app/metro.config.cjs
@@ -7,7 +7,10 @@ const projectRoot = __dirname;
 const appNodeModulesRoot = path.resolve(projectRoot, "node_modules");
 const appSrcRoot = path.resolve(projectRoot, "src");
 const serverSrcRoot = path.resolve(projectRoot, "../server/src");
+const relayPackageRoot = path.resolve(projectRoot, "../relay");
 const relaySrcRoot = path.resolve(projectRoot, "../relay/src");
+const highlightPackageRoot = path.resolve(projectRoot, "../highlight");
+const expoTwoWayAudioPackageRoot = path.resolve(projectRoot, "../expo-two-way-audio");
 const customWebPlatform = (process.env.PASEO_WEB_PLATFORM ?? "")
   .trim()
   .replace(/^\./, "")
@@ -25,12 +28,24 @@ config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules ?? {}),
   "@server": serverSrcRoot,
   "@relay": relaySrcRoot,
+  "@getpaseo/relay": relayPackageRoot,
+  "@getpaseo/highlight": highlightPackageRoot,
+  "@getpaseo/expo-two-way-audio": expoTwoWayAudioPackageRoot,
   react: path.join(appNodeModulesRoot, "react"),
   "react-dom": path.join(appNodeModulesRoot, "react-dom"),
   "react/jsx-runtime": path.join(appNodeModulesRoot, "react/jsx-runtime"),
   "react/jsx-dev-runtime": path.join(appNodeModulesRoot, "react/jsx-dev-runtime"),
 };
-config.watchFolders = [...new Set([...(config.watchFolders ?? []), serverSrcRoot, relaySrcRoot])];
+config.watchFolders = [
+  ...new Set([
+    ...(config.watchFolders ?? []),
+    serverSrcRoot,
+    relayPackageRoot,
+    relaySrcRoot,
+    highlightPackageRoot,
+    expoTwoWayAudioPackageRoot,
+  ]),
+];
 config.resolver.blockList = new RegExp(
   `(^${escapedAppSrcRoot}${pathSeparatorPattern}.*\\.(test|spec)\\.(ts|tsx)$|${pathSeparatorPattern}__tests__${pathSeparatorPattern}.*)$`,
 );

--- a/packages/app/metro.config.node-test.cjs
+++ b/packages/app/metro.config.node-test.cjs
@@ -5,7 +5,10 @@ const path = require("node:path");
 const config = require("./metro.config.cjs");
 
 const serverSrcRoot = path.resolve(__dirname, "../server/src");
+const relayPackageRoot = path.resolve(__dirname, "../relay");
 const relaySrcRoot = path.resolve(__dirname, "../relay/src");
+const highlightPackageRoot = path.resolve(__dirname, "../highlight");
+const expoTwoWayAudioPackageRoot = path.resolve(__dirname, "../expo-two-way-audio");
 
 test("metro config exposes @server to Metro as a concrete source root", () => {
   assert.equal(config.resolver.extraNodeModules["@server"], serverSrcRoot);
@@ -14,4 +17,19 @@ test("metro config exposes @server to Metro as a concrete source root", () => {
 test("metro config watches sibling server and relay source trees", () => {
   assert.ok(config.watchFolders.includes(serverSrcRoot));
   assert.ok(config.watchFolders.includes(relaySrcRoot));
+});
+
+test("metro config exposes workspace packages through concrete package roots", () => {
+  assert.equal(config.resolver.extraNodeModules["@getpaseo/relay"], relayPackageRoot);
+  assert.equal(config.resolver.extraNodeModules["@getpaseo/highlight"], highlightPackageRoot);
+  assert.equal(
+    config.resolver.extraNodeModules["@getpaseo/expo-two-way-audio"],
+    expoTwoWayAudioPackageRoot,
+  );
+});
+
+test("metro config watches sibling workspace package trees used by the app bundle", () => {
+  assert.ok(config.watchFolders.includes(relayPackageRoot));
+  assert.ok(config.watchFolders.includes(highlightPackageRoot));
+  assert.ok(config.watchFolders.includes(expoTwoWayAudioPackageRoot));
 });

--- a/packages/app/metro.config.node-test.cjs
+++ b/packages/app/metro.config.node-test.cjs
@@ -1,0 +1,17 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const config = require("./metro.config.cjs");
+
+const serverSrcRoot = path.resolve(__dirname, "../server/src");
+const relaySrcRoot = path.resolve(__dirname, "../relay/src");
+
+test("metro config exposes @server to Metro as a concrete source root", () => {
+  assert.equal(config.resolver.extraNodeModules["@server"], serverSrcRoot);
+});
+
+test("metro config watches sibling server and relay source trees", () => {
+  assert.ok(config.watchFolders.includes(serverSrcRoot));
+  assert.ok(config.watchFolders.includes(relaySrcRoot));
+});

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -7,6 +7,7 @@
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
     "build:workspace-deps": "npm run build --workspace=@getpaseo/highlight && npm run build --workspace=@getpaseo/expo-two-way-audio",
+    "validate:windows-dev-client": "node ./scripts/windows-dev-client-validation.cjs",
     "eas-build-post-install": "npm run build:workspace-deps",
     "android": "npm run android:development",
     "android:development": "APP_VARIANT=development expo prebuild --platform android --non-interactive && APP_VARIANT=development expo run:android --variant=debug",

--- a/packages/app/scripts/windows-dev-client-validation.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.cjs
@@ -1,0 +1,1266 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const DEFAULT_PORT = 8081;
+const DEFAULT_HOST = "lan";
+const DEFAULT_LAUNCH_HOST = "127.0.0.1";
+const DEFAULT_APP_ID = "sh.paseo.debug";
+const DEFAULT_SCHEME = "exp+voice-mobile";
+const DEFAULT_SUCCESS_TEXT = "Welcome to Paseo";
+const DEFAULT_WAIT_MS = 15000;
+const DEFAULT_STARTUP_TIMEOUT_MS = 120000;
+const HTTP_PROBE_TIMEOUT_MS = 2000;
+const HTTP_MANIFEST_PROBE_TIMEOUT_MS = 20000;
+const HTTP_PROBE_BODY_LIMIT = 32768;
+const HTTP_CAPTURE_BODY_LIMIT = 65536;
+const HTTP_REPLAY_TIMEOUT_MS = 15000;
+const WORKSPACE_UI_MARKERS = [
+  "workspace-header-title",
+  "message-input-root",
+  "agent-chat-scroll",
+  "workspace-tabs-row",
+  "workspace-open-in-editor-primary",
+  "permission-request-question",
+];
+const HOP_BY_HOP_REQUEST_HEADERS = new Set([
+  "connection",
+  "proxy-connection",
+  "keep-alive",
+  "transfer-encoding",
+  "content-length",
+]);
+const PROXY_ENV_KEYS = [
+  "ALL_PROXY",
+  "all_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+];
+
+function printHelp() {
+  console.log(`Usage: node packages/app/scripts/windows-dev-client-validation.cjs [options]
+
+Options:
+  --port <number>                 Expo dev server port (default: ${DEFAULT_PORT})
+  --host <lan|localhost|tunnel>   Expo host mode (default: ${DEFAULT_HOST})
+  --launch-host <host>            Host embedded in the dev-client deep link (default: ${DEFAULT_LAUNCH_HOST})
+  --device-id <id>                Optional adb device id
+  --app-id <id>                   Android package id (default: ${DEFAULT_APP_ID})
+  --scheme <scheme>               Expo dev-client scheme (default: ${DEFAULT_SCHEME})
+  --output-dir <path>             Artifact directory (default: temp dir)
+  --wait-ms <number>              Delay after launch before collecting evidence
+  --startup-timeout-ms <number>   Expo readiness timeout
+  --success-text <text>           UI text that indicates a successful app boot
+  --env KEY=VALUE                 Additional environment override (repeatable)
+  --capture-first-request         Put an HTTP capture proxy in front of Metro and record the first requests
+  --retry-on-timeout              Relaunch once if the first attempt hits the Expo timeout screen
+  --keep-proxy-env                Do not clear proxy env vars for Expo
+  --skip-build-workspace-deps     Skip npm run build:workspace-deps
+  --skip-adb-reverse              Skip adb reverse tcp:<port> tcp:<port>
+  --skip-screenshot               Skip adb screencap capture
+  --skip-ui-dump                  Skip adb uiautomator dump capture
+  --skip-clear-logcat             Skip adb logcat -c before launch
+  --help                          Print this help
+`);
+}
+
+function parsePositiveInteger(label, value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Expected ${label} to be a positive integer, received: ${value}`);
+  }
+  return parsed;
+}
+
+function parseEnvAssignment(value) {
+  const separatorIndex = value.indexOf("=");
+  if (separatorIndex <= 0) {
+    throw new Error(`Expected KEY=VALUE for --env, received: ${value}`);
+  }
+
+  return {
+    key: value.slice(0, separatorIndex),
+    value: value.slice(separatorIndex + 1),
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    port: DEFAULT_PORT,
+    host: DEFAULT_HOST,
+    launchHost: DEFAULT_LAUNCH_HOST,
+    deviceId: null,
+    appId: DEFAULT_APP_ID,
+    scheme: DEFAULT_SCHEME,
+    outputDir: null,
+    waitMs: DEFAULT_WAIT_MS,
+    startupTimeoutMs: DEFAULT_STARTUP_TIMEOUT_MS,
+    successText: DEFAULT_SUCCESS_TEXT,
+    envOverrides: {},
+    keepProxyEnv: false,
+    buildWorkspaceDeps: true,
+    adbReverse: true,
+    captureScreenshot: true,
+    captureUiDump: true,
+    clearLogcat: true,
+    help: false,
+    captureFirstRequest: false,
+    retryOnTimeout: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    switch (argument) {
+      case "--port":
+        options.port = parsePositiveInteger("--port", argv[++index]);
+        break;
+      case "--host":
+        options.host = argv[++index];
+        break;
+      case "--launch-host":
+        options.launchHost = argv[++index];
+        break;
+      case "--device-id":
+        options.deviceId = argv[++index];
+        break;
+      case "--app-id":
+        options.appId = argv[++index];
+        break;
+      case "--scheme":
+        options.scheme = argv[++index];
+        break;
+      case "--output-dir":
+        options.outputDir = argv[++index];
+        break;
+      case "--wait-ms":
+        options.waitMs = parsePositiveInteger("--wait-ms", argv[++index]);
+        break;
+      case "--startup-timeout-ms":
+        options.startupTimeoutMs = parsePositiveInteger("--startup-timeout-ms", argv[++index]);
+        break;
+      case "--success-text":
+        options.successText = argv[++index];
+        break;
+      case "--env": {
+        const assignment = parseEnvAssignment(argv[++index]);
+        options.envOverrides[assignment.key] = assignment.value;
+        break;
+      }
+      case "--keep-proxy-env":
+        options.keepProxyEnv = true;
+        break;
+      case "--capture-first-request":
+        options.captureFirstRequest = true;
+        break;
+      case "--retry-on-timeout":
+        options.retryOnTimeout = true;
+        break;
+      case "--skip-build-workspace-deps":
+        options.buildWorkspaceDeps = false;
+        break;
+      case "--skip-adb-reverse":
+        options.adbReverse = false;
+        break;
+      case "--skip-screenshot":
+        options.captureScreenshot = false;
+        break;
+      case "--skip-ui-dump":
+        options.captureUiDump = false;
+        break;
+      case "--skip-clear-logcat":
+        options.clearLogcat = false;
+        break;
+      case "--help":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${argument}`);
+    }
+
+    if (argument.startsWith("--") && index >= argv.length) {
+      throw new Error(`Missing value for ${argument}`);
+    }
+  }
+
+  if (!["lan", "localhost", "tunnel"].includes(options.host)) {
+    throw new Error(`Unsupported Expo host mode: ${options.host}`);
+  }
+
+  return options;
+}
+
+function buildDeepLinkUrl({ scheme, launchHost, port }) {
+  return `${scheme}://expo-development-client/?url=${encodeURIComponent(
+    `http://${launchHost}:${port}`,
+  )}`;
+}
+
+function uniqueCsv(values) {
+  return [...new Set(values.filter(Boolean))].join(",");
+}
+
+function buildExpoEnv(baseEnv, options) {
+  const env = { ...baseEnv };
+
+  if (!options.keepProxyEnv) {
+    for (const proxyKey of PROXY_ENV_KEYS) {
+      delete env[proxyKey];
+    }
+  }
+
+  const nextNoProxy = uniqueCsv([
+    ...(String(env.NO_PROXY ?? "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean)),
+    "localhost",
+    "127.0.0.1",
+  ]);
+
+  env.NO_PROXY = nextNoProxy;
+  env.no_proxy = nextNoProxy;
+
+  for (const [key, value] of Object.entries(options.envOverrides ?? {})) {
+    env[key] = value;
+  }
+
+  return env;
+}
+
+function hasVisibleWorkspaceUi(uiDumpXml) {
+  const xml = String(uiDumpXml ?? "");
+  let matchedMarkers = 0;
+
+  for (const marker of WORKSPACE_UI_MARKERS) {
+    if (xml.includes(marker)) {
+      matchedMarkers += 1;
+    }
+  }
+
+  return matchedMarkers >= 2;
+}
+
+function classifyValidationResult({ uiDumpXml, logcatText, launchOutput, successText }) {
+  const uiXml = String(uiDumpXml ?? "");
+  const deviceLogcat = String(logcatText ?? "");
+  const launchText = String(launchOutput ?? "");
+
+  if (successText && uiXml.includes(successText)) {
+    return {
+      status: "app_loaded",
+      reason: "success_text_visible",
+    };
+  }
+
+  if (
+    /There was a problem loading the project\./i.test(uiXml) &&
+    /SocketTimeoutException|Read timed out|timeout waiting for response headers/i.test(uiXml)
+  ) {
+    return {
+      status: "dev_client_read_timeout",
+      reason: "ui_dump_socket_timeout",
+    };
+  }
+
+  if (hasVisibleWorkspaceUi(uiXml)) {
+    return {
+      status: "app_loaded",
+      reason: "workspace_ui_visible",
+    };
+  }
+
+  if (
+    /SocketTimeoutException|Read timed out|timeout waiting for response headers/i.test(deviceLogcat) &&
+    /sh\.paseo(?:\.debug)?|DevLauncherErrorActivity|expo\.modules\.devlauncher/i.test(deviceLogcat)
+  ) {
+    return {
+      status: "dev_client_read_timeout",
+      reason: "logcat_socket_timeout",
+    };
+  }
+
+  if (/Activity not started|Error: Activity class|unable to resolve Intent/i.test(launchText)) {
+    return {
+      status: "launch_failed",
+      reason: "adb_launch_error",
+    };
+  }
+
+  return {
+    status: "unknown",
+    reason: "no_success_or_failure_signature",
+  };
+}
+
+function inferRepoRoot() {
+  return path.resolve(__dirname, "../../..");
+}
+
+function resolveNetworkPlan(options) {
+  return {
+    publicPort: options.port,
+    metroPort: options.captureFirstRequest ? options.port + 1 : options.port,
+  };
+}
+
+function resolveOutputDir(outputDir, now = new Date()) {
+  if (outputDir) {
+    return path.resolve(outputDir);
+  }
+
+  const timestamp = now.toISOString().replace(/[:.]/g, "-");
+  return path.join(os.tmpdir(), "paseo-windows-dev-client-validation", timestamp);
+}
+
+function buildConfig(options, overrides = {}) {
+  const repoRoot = overrides.repoRoot ?? inferRepoRoot();
+  const appDir = overrides.appDir ?? path.join(repoRoot, "packages", "app");
+  const outputDir = resolveOutputDir(options.outputDir, overrides.now);
+  const networkPlan = resolveNetworkPlan(options);
+
+  return {
+    ...options,
+    repoRoot,
+    appDir,
+    outputDir,
+    publicPort: networkPlan.publicPort,
+    metroPort: networkPlan.metroPort,
+    deepLinkUrl: buildDeepLinkUrl({
+      scheme: options.scheme,
+      launchHost: options.launchHost,
+      port: networkPlan.publicPort,
+    }),
+    expoEnv: buildExpoEnv(overrides.baseEnv ?? process.env, options),
+    artifactPaths: {
+      adbDevices: path.join(outputDir, "adb-devices.txt"),
+      activityTop: path.join(outputDir, "activity-top.txt"),
+      buildWorkspaceDeps: path.join(outputDir, "build-workspace-deps.log"),
+      expoLog: path.join(outputDir, "expo.log"),
+      expoProbe: path.join(outputDir, "expo-probe.json"),
+      launch: path.join(outputDir, "adb-start.txt"),
+      logcat: path.join(outputDir, "logcat.txt"),
+      requestCapture: path.join(outputDir, "request-capture.json"),
+      requestReplay: path.join(outputDir, "request-replay.json"),
+      retryLaunch: path.join(outputDir, "adb-start-retry.txt"),
+      retryActivityTop: path.join(outputDir, "activity-top-retry.txt"),
+      retryLogcat: path.join(outputDir, "logcat-retry.txt"),
+      retryScreenshot: path.join(outputDir, "device-retry.png"),
+      retryUiDump: path.join(outputDir, "device-retry.xml"),
+      screenshot: path.join(outputDir, "device-loaded.png"),
+      summary: path.join(outputDir, "summary.json"),
+      uiDump: path.join(outputDir, "device-ui.xml"),
+    },
+  };
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function writeTextFile(filePath, contents) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, contents, "utf8");
+}
+
+function writeJsonFile(filePath, value) {
+  writeTextFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function shellCommandName(command, platform = process.platform) {
+  if (platform === "win32" && (command === "npm" || command === "npx")) {
+    return `${command}.cmd`;
+  }
+  return command;
+}
+
+function buildSpawnInvocation(command, args, platform = process.platform) {
+  const resolvedCommand = shellCommandName(command, platform);
+
+  if (platform === "win32" && resolvedCommand.endsWith(".cmd")) {
+    return {
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", resolvedCommand, ...args],
+    };
+  }
+
+  return {
+    command: resolvedCommand,
+    args,
+  };
+}
+
+function spawnCapture(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const invocation = buildSpawnInvocation(command, args);
+    const child = spawn(invocation.command, invocation.args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdoutChunks = [];
+    const stderrChunks = [];
+
+    child.stdout.on("data", (chunk) => stdoutChunks.push(Buffer.from(chunk)));
+    child.stderr.on("data", (chunk) => stderrChunks.push(Buffer.from(chunk)));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+      const stderr = Buffer.concat(stderrChunks).toString("utf8");
+      if (code !== 0 && !options.allowFailure) {
+        reject(
+          new Error(
+            `${command} ${args.join(" ")} exited with code ${code}\n${stdout}${stderr}`,
+          ),
+        );
+        return;
+      }
+
+      resolve({
+        code,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+function captureBinaryToFile(command, args, outputPath, options = {}) {
+  return new Promise((resolve, reject) => {
+    ensureDir(path.dirname(outputPath));
+    const file = fs.createWriteStream(outputPath);
+    const invocation = buildSpawnInvocation(command, args);
+    const child = spawn(invocation.command, invocation.args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stderrChunks = [];
+
+    child.stdout.pipe(file);
+    child.stderr.on("data", (chunk) => stderrChunks.push(Buffer.from(chunk)));
+    child.on("error", (error) => {
+      file.destroy();
+      reject(error);
+    });
+    child.on("close", (code) => {
+      file.end();
+      const stderr = Buffer.concat(stderrChunks).toString("utf8");
+      if (code !== 0) {
+        reject(new Error(`${command} ${args.join(" ")} exited with code ${code}\n${stderr}`));
+        return;
+      }
+      resolve({
+        code,
+        stderr,
+      });
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function probeRequest(requestOptions) {
+  const options =
+    typeof requestOptions === "string"
+      ? {
+          url: requestOptions,
+          method: "GET",
+        }
+      : {
+          method: "GET",
+          ...requestOptions,
+        };
+  const timeoutMs = options.timeoutMs ?? HTTP_PROBE_TIMEOUT_MS;
+
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      options.url,
+      {
+        method: options.method,
+        headers: options.headers,
+        timeout: timeoutMs,
+      },
+      (response) => {
+        if (String(options.method ?? "GET").toUpperCase() === "HEAD") {
+          response.resume();
+          resolve({
+            ok: true,
+            statusCode: response.statusCode ?? null,
+            headers: response.headers,
+            bodyPreview: "",
+          });
+          return;
+        }
+        const bodyChunks = [];
+        let bodyLength = 0;
+        response.on("data", (chunk) => {
+          if (bodyLength >= HTTP_PROBE_BODY_LIMIT) {
+            return;
+          }
+          const buffer = Buffer.from(chunk);
+          bodyLength += buffer.length;
+          bodyChunks.push(buffer.slice(0, Math.max(0, HTTP_PROBE_BODY_LIMIT - bodyLength)));
+        });
+        response.on("end", () => {
+          resolve({
+            ok: true,
+            statusCode: response.statusCode ?? null,
+            headers: response.headers,
+            bodyPreview: Buffer.concat(bodyChunks).toString("utf8"),
+          });
+        });
+      },
+    );
+
+    request.on("timeout", () => {
+      request.destroy(new Error(`Timed out probing ${options.url}`));
+    });
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+function probeHttp(url) {
+  return probeRequest({ url });
+}
+
+function cloneHeaders(headers) {
+  return Object.fromEntries(
+    Object.entries(headers ?? {}).map(([key, value]) => [key, Array.isArray(value) ? value.join(", ") : value]),
+  );
+}
+
+function summarizeBuffer(buffer) {
+  return buffer.subarray(0, HTTP_CAPTURE_BODY_LIMIT).toString("utf8");
+}
+
+function deriveValidationOutcome(initialClassification, retryClassification) {
+  if (
+    initialClassification.status === "dev_client_read_timeout" &&
+    retryClassification?.status === "app_loaded"
+  ) {
+    return {
+      status: "app_loaded_after_retry",
+      reason: "retry_recovered_after_timeout",
+    };
+  }
+
+  return initialClassification;
+}
+
+function buildUpstreamRequestHeaders(headers, config) {
+  const nextHeaders = {};
+
+  for (const [key, value] of Object.entries(headers ?? {})) {
+    const normalizedKey = String(key).toLowerCase();
+    if (HOP_BY_HOP_REQUEST_HEADERS.has(normalizedKey)) {
+      continue;
+    }
+    if (value === undefined) {
+      continue;
+    }
+    nextHeaders[normalizedKey] = value;
+  }
+
+  nextHeaders.host = `127.0.0.1:${config.metroPort}`;
+  return nextHeaders;
+}
+
+function shouldEndUpstreamImmediately({ method, headers }) {
+  const normalizedMethod = String(method ?? "GET").toUpperCase();
+  if (!["GET", "HEAD"].includes(normalizedMethod)) {
+    return false;
+  }
+
+  const requestHeaders = Object.fromEntries(
+    Object.entries(headers ?? {}).map(([key, value]) => [String(key).toLowerCase(), value]),
+  );
+
+  return !requestHeaders["content-length"] && !requestHeaders["transfer-encoding"];
+}
+
+function buildDevClientProbeHeaders(config) {
+  return {
+    host: `127.0.0.1:${config.metroPort}`,
+    "expo-platform": "android",
+    accept: "application/expo+json,application/json",
+    "user-agent": "paseo-validation-probe",
+  };
+}
+
+function isExpoManifestResponse(probeResult) {
+  return /application\/expo\+json/i.test(String(probeResult?.headers?.["content-type"] ?? ""));
+}
+
+function isMetroStatusResponse(probeResult) {
+  return (
+    Number(probeResult?.statusCode) === 200 &&
+    /packager-status:running/i.test(String(probeResult?.bodyPreview ?? ""))
+  );
+}
+
+function rewriteExpoManifestResponse(headers, bodyText, config) {
+  const contentType = String(headers?.["content-type"] ?? "");
+  if (!/(application\/expo\+json|multipart\/mixed)/i.test(contentType)) {
+    return {
+      rewritten: false,
+      headers,
+      bodyText,
+    };
+  }
+
+  const upstreamHost = `127.0.0.1:${config.metroPort}`;
+  const publicHost = `127.0.0.1:${config.publicPort}`;
+  if (!String(bodyText).includes(upstreamHost)) {
+    return {
+      rewritten: false,
+      headers,
+      bodyText,
+    };
+  }
+
+  const rewrittenBody = String(bodyText).split(upstreamHost).join(publicHost);
+  return {
+    rewritten: true,
+    headers: {
+      ...headers,
+      "content-length": String(Buffer.byteLength(rewrittenBody)),
+    },
+    bodyText: rewrittenBody,
+  };
+}
+
+function startRequestCaptureProxy(config) {
+  if (!config.captureFirstRequest) {
+    return null;
+  }
+
+  const entries = [];
+  const server = http.createServer((request, response) => {
+    const entry = {
+      id: entries.length + 1,
+      method: request.method ?? "GET",
+      url: request.url ?? "/",
+      headers: cloneHeaders(request.headers),
+      startedAt: new Date().toISOString(),
+      requestBodyPreview: "",
+      requestBodyBytes: 0,
+      responseBodyPreview: "",
+      responseBodyBytes: 0,
+      clientAborted: false,
+    };
+    entries.push(entry);
+
+    const requestChunks = [];
+    request.on("data", (chunk) => {
+      const buffer = Buffer.from(chunk);
+      entry.requestBodyBytes += buffer.length;
+      if (Buffer.concat(requestChunks).length < HTTP_CAPTURE_BODY_LIMIT) {
+        requestChunks.push(buffer);
+      }
+    });
+    request.on("aborted", () => {
+      entry.clientAborted = true;
+    });
+
+    let upstreamEnded = false;
+    const upstreamRequest = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: config.metroPort,
+        method: request.method,
+        path: request.url,
+        headers: buildUpstreamRequestHeaders(request.headers, config),
+      },
+      (upstreamResponse) => {
+        entry.responseStatusCode = upstreamResponse.statusCode ?? null;
+        const responseHeaders = cloneHeaders(upstreamResponse.headers);
+        entry.responseHeaders = responseHeaders;
+        if (String(request.method ?? "GET").toUpperCase() === "HEAD") {
+          response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+          upstreamResponse.resume();
+          response.end();
+          entry.completedAt = new Date().toISOString();
+          return;
+        }
+
+        const responseChunks = [];
+        upstreamResponse.on("data", (chunk) => {
+          responseChunks.push(Buffer.from(chunk));
+        });
+        upstreamResponse.on("end", () => {
+          const upstreamBody = Buffer.concat(responseChunks).toString("utf8");
+          const rewrittenResponse = rewriteExpoManifestResponse(
+            responseHeaders,
+            upstreamBody,
+            config,
+          );
+          const responseBodyBuffer = Buffer.from(rewrittenResponse.bodyText, "utf8");
+          entry.responseHeaders = rewrittenResponse.headers;
+          entry.responseBodyBytes = responseBodyBuffer.length;
+          entry.responseBodyPreview = summarizeBuffer(responseBodyBuffer);
+          response.writeHead(upstreamResponse.statusCode ?? 502, rewrittenResponse.headers);
+          response.end(responseBodyBuffer);
+          entry.completedAt = new Date().toISOString();
+        });
+      },
+    );
+    upstreamRequest.setTimeout(HTTP_REPLAY_TIMEOUT_MS);
+
+    upstreamRequest.on("timeout", () => {
+      entry.upstreamError = "upstream_request_timeout";
+      upstreamRequest.destroy(new Error("Upstream request timed out"));
+    });
+    upstreamRequest.on("error", (error) => {
+      entry.upstreamError = String(error.message ?? error);
+      if (!response.headersSent) {
+        response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
+      }
+      response.end(`Proxy upstream error: ${entry.upstreamError}`);
+      entry.completedAt = new Date().toISOString();
+    });
+
+    const finishUpstreamRequest = () => {
+      if (upstreamEnded) {
+        return;
+      }
+      upstreamEnded = true;
+      entry.requestBodyPreview = summarizeBuffer(Buffer.concat(requestChunks));
+      const requestBody = Buffer.concat(requestChunks);
+      if (requestBody.length > 0) {
+        upstreamRequest.end(requestBody);
+        return;
+      }
+      upstreamRequest.end();
+    };
+
+    request.on("end", () => {
+      finishUpstreamRequest();
+    });
+    request.on("error", (error) => {
+      entry.upstreamError = String(error.message ?? error);
+      upstreamRequest.destroy(error);
+    });
+
+    if (shouldEndUpstreamImmediately({ method: request.method, headers: request.headers })) {
+      request.resume();
+      finishUpstreamRequest();
+    }
+  });
+
+  return {
+    entries,
+    async start() {
+      await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(config.publicPort, "127.0.0.1", () => {
+          server.off("error", reject);
+          resolve();
+        });
+      });
+    },
+    async stop() {
+      writeJsonFile(config.artifactPaths.requestCapture, {
+        publicPort: config.publicPort,
+        metroPort: config.metroPort,
+        entries,
+      });
+      await new Promise((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+function replayCapturedRequest(config, entry) {
+  return new Promise((resolve) => {
+    if (!entry) {
+      resolve({
+        ok: false,
+        skipped: true,
+        reason: "no_captured_request",
+      });
+      return;
+    }
+
+    const request = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: config.metroPort,
+        method: entry.method,
+        path: entry.url,
+        headers: buildUpstreamRequestHeaders(entry.headers, config),
+        timeout: HTTP_REPLAY_TIMEOUT_MS,
+      },
+      (response) => {
+        const resolvedHeaders = cloneHeaders(response.headers);
+        if (String(entry.method ?? "GET").toUpperCase() === "HEAD") {
+          response.resume();
+          resolve({
+            ok: true,
+            statusCode: response.statusCode ?? null,
+            headers: resolvedHeaders,
+            bodyPreview: "",
+          });
+          return;
+        }
+        const bodyChunks = [];
+        let bodyLength = 0;
+        response.on("data", (chunk) => {
+          const buffer = Buffer.from(chunk);
+          bodyLength += buffer.length;
+          if (bodyLength <= HTTP_CAPTURE_BODY_LIMIT) {
+            bodyChunks.push(buffer);
+          }
+        });
+        response.on("end", () => {
+          resolve({
+            ok: true,
+            statusCode: response.statusCode ?? null,
+            headers: resolvedHeaders,
+            bodyPreview: summarizeBuffer(Buffer.concat(bodyChunks)),
+          });
+        });
+      },
+    );
+    request.setTimeout(HTTP_REPLAY_TIMEOUT_MS);
+
+    request.on("timeout", () => {
+      request.destroy(new Error("Replay request timed out"));
+    });
+    request.on("error", (error) => {
+      resolve({
+        ok: false,
+        error: String(error.message ?? error),
+      });
+    });
+    request.end(entry.requestBodyPreview);
+  });
+}
+
+function startExpoProcess(config) {
+  ensureDir(path.dirname(config.artifactPaths.expoLog));
+  const logStream = fs.createWriteStream(config.artifactPaths.expoLog);
+  const invocation = buildSpawnInvocation("npx", [
+      "expo",
+      "start",
+      "--dev-client",
+      "--host",
+      config.host,
+      "--port",
+      String(config.metroPort),
+    ]);
+  const child = spawn(invocation.command, invocation.args, {
+    cwd: config.appDir,
+    env: config.expoEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let combinedOutput = "";
+  const onChunk = (chunk) => {
+    const text = Buffer.from(chunk).toString("utf8");
+    combinedOutput += text;
+    logStream.write(text);
+    process.stdout.write(text);
+  };
+
+  child.stdout.on("data", onChunk);
+  child.stderr.on("data", onChunk);
+
+  return {
+    child,
+    getOutput() {
+      return combinedOutput;
+    },
+    async stop() {
+      if (child.exitCode !== null || child.killed) {
+        logStream.end();
+        return;
+      }
+
+      child.kill("SIGINT");
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      if (child.exitCode === null) {
+        if (process.platform === "win32") {
+          await spawnCapture("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+            allowFailure: true,
+          });
+        } else {
+          child.kill("SIGKILL");
+        }
+      }
+
+      logStream.end();
+    },
+  };
+}
+
+async function waitForExpoReady(config, expoProcess, dependencies = {}) {
+  const now = dependencies.now ?? Date.now;
+  const sleepFn = dependencies.sleep ?? sleep;
+  const probe = dependencies.probe ?? probeRequest;
+  const writeJson = dependencies.writeJson ?? ((filePath, value) => writeJsonFile(filePath, value));
+  const getOutput = dependencies.getOutput ?? (() => expoProcess.getOutput());
+  const startedAt = now();
+  const probeUrl = `http://127.0.0.1:${config.metroPort}`;
+  let metroStatusReadyProbe = null;
+
+  while (now() - startedAt < config.startupTimeoutMs) {
+    if (expoProcess.child.exitCode !== null) {
+      throw new Error("Expo process exited before it became ready");
+    }
+
+    const waitingBannerObserved = /Waiting on http:\/\/localhost:|Logs for your project/i.test(
+      getOutput(),
+    );
+
+    let lastProbeError = null;
+    let lastNonManifestProbe = null;
+    let lastManifestProbeError = null;
+
+    try {
+      const statusProbeResult = await probe({
+        probeType: "metro_status",
+        url: `${probeUrl}/status`,
+      });
+
+      if (isMetroStatusResponse(statusProbeResult)) {
+        metroStatusReadyProbe = statusProbeResult;
+      } else {
+        lastNonManifestProbe = {
+          probeType: "metro_status",
+          ...statusProbeResult,
+        };
+      }
+    } catch (error) {
+      lastProbeError = error;
+    }
+
+    if (metroStatusReadyProbe) {
+      try {
+        const manifestProbeResult = await probe({
+          probeType: "dev_client_manifest",
+          url: probeUrl,
+          method: "HEAD",
+          headers: buildDevClientProbeHeaders(config),
+          timeoutMs: HTTP_MANIFEST_PROBE_TIMEOUT_MS,
+        });
+
+        if (isExpoManifestResponse(manifestProbeResult)) {
+          writeJson(config.artifactPaths.expoProbe, {
+            url: probeUrl,
+            probeType: "dev_client_manifest",
+            waitingBannerObserved,
+            ...manifestProbeResult,
+          });
+          return manifestProbeResult;
+        }
+
+        lastNonManifestProbe = {
+          probeType: "dev_client_manifest",
+          ...manifestProbeResult,
+        };
+      } catch (error) {
+        lastManifestProbeError = error;
+      }
+
+      writeJson(config.artifactPaths.expoProbe, {
+        url: probeUrl,
+        probeType: "metro_status",
+        waitingBannerObserved,
+        ...metroStatusReadyProbe,
+        manifestProbeError: String(
+          lastManifestProbeError?.message ??
+            lastManifestProbeError ??
+            "dev-client manifest probe pending",
+        ),
+      });
+      await sleepFn(1500);
+      continue;
+    }
+
+    writeJson(config.artifactPaths.expoProbe, {
+      url: probeUrl,
+      waitingBannerObserved,
+      ...(lastNonManifestProbe ?? {
+        probeType: "pending",
+        ok: false,
+      }),
+      probeError: String(lastProbeError?.message ?? lastProbeError ?? "probe failed"),
+    });
+
+    await sleepFn(1500);
+  }
+
+  throw new Error(`Timed out waiting for Expo on port ${config.port}`);
+}
+
+async function captureDeviceState(config, adbPrefix, artifactPaths) {
+  let uiDumpXml = "";
+
+  if (artifactPaths.screenshot && config.captureScreenshot) {
+    await captureBinaryToFile(
+      "adb",
+      [...adbPrefix, "exec-out", "screencap", "-p"],
+      artifactPaths.screenshot,
+    );
+  }
+
+  if (artifactPaths.uiDump && config.captureUiDump) {
+    const remoteUiDumpPath = `/sdcard/paseo-dev-client-validation-${path.basename(artifactPaths.uiDump)}`;
+    await spawnCapture("adb", [...adbPrefix, "shell", "uiautomator", "dump", remoteUiDumpPath]);
+    await spawnCapture("adb", [...adbPrefix, "pull", remoteUiDumpPath, artifactPaths.uiDump]);
+    uiDumpXml = fs.readFileSync(artifactPaths.uiDump, "utf8");
+  }
+
+  const activityTop = await spawnCapture("adb", [...adbPrefix, "shell", "dumpsys", "activity", "top"]);
+  writeTextFile(artifactPaths.activityTop, `${activityTop.stdout}${activityTop.stderr}`);
+
+  const logcat = await spawnCapture("adb", [...adbPrefix, "logcat", "-d", "-v", "time"], {
+    allowFailure: true,
+  });
+  const logcatText = `${logcat.stdout}${logcat.stderr}`;
+  writeTextFile(artifactPaths.logcat, logcatText);
+
+  return {
+    uiDumpXml,
+    logcatText,
+  };
+}
+
+async function runValidation(config) {
+  ensureDir(config.outputDir);
+  writeJsonFile(config.artifactPaths.summary, {
+    phase: "starting",
+    outputDir: config.outputDir,
+    port: config.publicPort,
+    metroPort: config.metroPort,
+    host: config.host,
+    launchHost: config.launchHost,
+    appId: config.appId,
+    scheme: config.scheme,
+    deepLinkUrl: config.deepLinkUrl,
+    buildWorkspaceDeps: config.buildWorkspaceDeps,
+    adbReverse: config.adbReverse,
+    captureScreenshot: config.captureScreenshot,
+    captureUiDump: config.captureUiDump,
+    clearLogcat: config.clearLogcat,
+    captureFirstRequest: config.captureFirstRequest,
+    retryOnTimeout: config.retryOnTimeout,
+    envOverrides: config.envOverrides,
+  });
+
+  const adbPrefix = config.deviceId ? ["-s", config.deviceId] : [];
+  const adbDevices = await spawnCapture("adb", ["devices"]);
+  writeTextFile(config.artifactPaths.adbDevices, `${adbDevices.stdout}${adbDevices.stderr}`);
+
+  if (config.buildWorkspaceDeps) {
+    const buildResult = await spawnCapture("npm", ["run", "build:workspace-deps"], {
+      cwd: config.appDir,
+      env: config.expoEnv,
+    });
+    writeTextFile(
+      config.artifactPaths.buildWorkspaceDeps,
+      `${buildResult.stdout}${buildResult.stderr}`,
+    );
+  }
+
+  if (config.clearLogcat) {
+    await spawnCapture("adb", [...adbPrefix, "logcat", "-c"], {
+      allowFailure: true,
+    });
+  }
+
+  const requestProxy = startRequestCaptureProxy(config);
+  if (requestProxy) {
+    await requestProxy.start();
+  }
+
+  const expoProcess = startExpoProcess(config);
+  let launchResult = "";
+  let initialClassification = {
+    status: "unknown",
+    reason: "validation_interrupted",
+  };
+  let retrySummary = null;
+  let replaySummary = null;
+
+  try {
+    await waitForExpoReady(config, expoProcess);
+
+    if (config.adbReverse) {
+      const reverseResult = await spawnCapture("adb", [
+        ...adbPrefix,
+        "reverse",
+        `tcp:${config.publicPort}`,
+        `tcp:${config.publicPort}`,
+      ]);
+      writeTextFile(
+        path.join(config.outputDir, "adb-reverse.txt"),
+        `${reverseResult.stdout}${reverseResult.stderr}`,
+      );
+    }
+
+    const launch = await spawnCapture("adb", [
+      ...adbPrefix,
+      "shell",
+      "am",
+      "start",
+      "-W",
+      "-a",
+      "android.intent.action.VIEW",
+      "-d",
+      config.deepLinkUrl,
+      config.appId,
+    ]);
+    launchResult = `${launch.stdout}${launch.stderr}`;
+    writeTextFile(config.artifactPaths.launch, launchResult);
+
+    await sleep(config.waitMs);
+
+    const initialState = await captureDeviceState(config, adbPrefix, {
+      activityTop: config.artifactPaths.activityTop,
+      screenshot: config.artifactPaths.screenshot,
+      uiDump: config.artifactPaths.uiDump,
+      logcat: config.artifactPaths.logcat,
+    });
+
+    initialClassification = classifyValidationResult({
+      uiDumpXml: initialState.uiDumpXml,
+      logcatText: initialState.logcatText,
+      launchOutput: launchResult,
+      successText: config.successText,
+    });
+
+    if (requestProxy) {
+      replaySummary = await replayCapturedRequest(config, requestProxy.entries[0]);
+      writeJsonFile(config.artifactPaths.requestReplay, replaySummary);
+    }
+
+    if (config.retryOnTimeout && initialClassification.status === "dev_client_read_timeout") {
+      const retryLaunch = await spawnCapture("adb", [
+        ...adbPrefix,
+        "shell",
+        "am",
+        "start",
+        "-W",
+        "-a",
+        "android.intent.action.VIEW",
+        "-d",
+        config.deepLinkUrl,
+        config.appId,
+      ]);
+      const retryLaunchText = `${retryLaunch.stdout}${retryLaunch.stderr}`;
+      writeTextFile(config.artifactPaths.retryLaunch, retryLaunchText);
+
+      await sleep(config.waitMs);
+
+      const retryState = await captureDeviceState(config, adbPrefix, {
+        activityTop: config.artifactPaths.retryActivityTop,
+        screenshot: config.artifactPaths.retryScreenshot,
+        uiDump: config.artifactPaths.retryUiDump,
+        logcat: config.artifactPaths.retryLogcat,
+      });
+      const retryClassification = classifyValidationResult({
+        uiDumpXml: retryState.uiDumpXml,
+        logcatText: retryState.logcatText,
+        launchOutput: retryLaunchText,
+        successText: config.successText,
+      });
+
+      retrySummary = {
+        launch: retryLaunchText,
+        ...retryClassification,
+      };
+    }
+
+    const finalOutcome = deriveValidationOutcome(initialClassification, retrySummary);
+
+    const summary = {
+      phase: "completed",
+      status: finalOutcome.status,
+      reason: finalOutcome.reason,
+      outputDir: config.outputDir,
+      port: config.publicPort,
+      metroPort: config.metroPort,
+      host: config.host,
+      launchHost: config.launchHost,
+      appId: config.appId,
+      scheme: config.scheme,
+      deepLinkUrl: config.deepLinkUrl,
+      artifactPaths: config.artifactPaths,
+      initial: {
+        launch: launchResult,
+        ...initialClassification,
+      },
+      replay: replaySummary,
+      retry: retrySummary,
+    };
+    writeJsonFile(config.artifactPaths.summary, summary);
+    return summary;
+  } finally {
+    if (requestProxy) {
+      await requestProxy.stop();
+    }
+    await expoProcess.stop();
+  }
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  if (process.platform !== "win32") {
+    throw new Error("windows-dev-client-validation.cjs must run on Windows");
+  }
+
+  const config = buildConfig(options);
+  console.log(`Artifacts: ${config.outputDir}`);
+  console.log(`Deep link: ${config.deepLinkUrl}`);
+  const summary = await runValidation(config);
+  console.log(`Validation status: ${summary.status} (${summary.reason})`);
+
+  if (summary.status === "app_loaded" || summary.status === "app_loaded_after_retry") {
+    return;
+  }
+
+  process.exitCode =
+    summary.status === "dev_client_read_timeout"
+      ? 2
+      : summary.status === "launch_failed"
+        ? 3
+        : 4;
+}
+
+module.exports = {
+  buildSpawnInvocation,
+  buildUpstreamRequestHeaders,
+  buildConfig,
+  buildDeepLinkUrl,
+  buildExpoEnv,
+  classifyValidationResult,
+  deriveValidationOutcome,
+  parseArgs,
+  rewriteExpoManifestResponse,
+  waitForExpoReady,
+  shouldEndUpstreamImmediately,
+  runValidation,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.stack || String(error));
+    process.exitCode = 1;
+  });
+}

--- a/packages/app/scripts/windows-dev-client-validation.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.cjs
@@ -14,6 +14,10 @@ const DEFAULT_SCHEME = "exp+voice-mobile";
 const DEFAULT_SUCCESS_TEXT = "Welcome to Paseo";
 const DEFAULT_WAIT_MS = 15000;
 const DEFAULT_STARTUP_TIMEOUT_MS = 120000;
+const DEFAULT_ADB_COMMAND_TIMEOUT_MS = 15000;
+const DEFAULT_BUILD_WORKSPACE_DEPS_TIMEOUT_MS = 180000;
+const DEFAULT_LAUNCH_COMMAND_TIMEOUT_MS = 30000;
+const DEFAULT_DEVICE_CAPTURE_TIMEOUT_MS = 15000;
 const HTTP_PROBE_TIMEOUT_MS = 2000;
 const HTTP_MANIFEST_PROBE_TIMEOUT_MS = 20000;
 const HTTP_PROBE_BODY_LIMIT = 32768;
@@ -375,6 +379,89 @@ function writeJsonFile(filePath, value) {
   writeTextFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function buildValidationSummary(config, summary) {
+  return {
+    outputDir: config.outputDir,
+    port: config.publicPort,
+    metroPort: config.metroPort,
+    host: config.host,
+    launchHost: config.launchHost,
+    appId: config.appId,
+    scheme: config.scheme,
+    deepLinkUrl: config.deepLinkUrl,
+    buildWorkspaceDeps: config.buildWorkspaceDeps,
+    adbReverse: config.adbReverse,
+    captureScreenshot: config.captureScreenshot,
+    captureUiDump: config.captureUiDump,
+    clearLogcat: config.clearLogcat,
+    captureFirstRequest: config.captureFirstRequest,
+    retryOnTimeout: config.retryOnTimeout,
+    envOverrides: config.envOverrides,
+    ...summary,
+  };
+}
+
+function createCommandTimeoutError({ command, args, timeoutMs, stdout = "", stderr = "" }) {
+  const error = new Error(`${command} ${args.join(" ")} timed out after ${timeoutMs}ms`);
+  error.code = "COMMAND_TIMEOUT";
+  error.timedOut = true;
+  error.command = command;
+  error.args = [...args];
+  error.timeoutMs = timeoutMs;
+  error.stdout = stdout;
+  error.stderr = stderr;
+  return error;
+}
+
+function createCommandExitError({ command, args, exitCode, stdout = "", stderr = "" }) {
+  const error = new Error(
+    `${command} ${args.join(" ")} exited with code ${exitCode}\n${stdout}${stderr}`,
+  );
+  error.code = "COMMAND_EXIT";
+  error.command = command;
+  error.args = [...args];
+  error.commandExitCode = exitCode;
+  error.stdout = stdout;
+  error.stderr = stderr;
+  return error;
+}
+
+function failureArtifactPathForPhase(config, phase) {
+  switch (phase) {
+    case "adb_devices":
+      return config.artifactPaths.adbDevices;
+    case "build_workspace_deps":
+      return config.artifactPaths.buildWorkspaceDeps;
+    case "launch_app":
+      return config.artifactPaths.launch;
+    case "retry_launch":
+      return config.artifactPaths.retryLaunch;
+    default:
+      return null;
+  }
+}
+
+function terminateChildProcess(child, platform = process.platform) {
+  return new Promise((resolve) => {
+    if (!child?.pid || child.exitCode !== null || child.killed) {
+      resolve();
+      return;
+    }
+
+    if (platform === "win32") {
+      const killer = spawn("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+        stdio: "ignore",
+      });
+      killer.on("error", () => resolve());
+      killer.on("close", () => resolve());
+      return;
+    }
+
+    child.kill("SIGKILL");
+    resolve();
+  });
+}
+
 function shellCommandName(command, platform = process.platform) {
   if (platform === "win32" && (command === "npm" || command === "npx")) {
     return `${command}.cmd`;
@@ -408,26 +495,68 @@ function spawnCapture(command, args, options = {}) {
     });
     const stdoutChunks = [];
     const stderrChunks = [];
+    let settled = false;
+    let timeoutHandle = null;
+
+    const settle = (callback) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      callback();
+    };
 
     child.stdout.on("data", (chunk) => stdoutChunks.push(Buffer.from(chunk)));
     child.stderr.on("data", (chunk) => stderrChunks.push(Buffer.from(chunk)));
-    child.on("error", reject);
+    child.on("error", (error) => settle(() => reject(error)));
     child.on("close", (code) => {
-      const stdout = Buffer.concat(stdoutChunks).toString("utf8");
-      const stderr = Buffer.concat(stderrChunks).toString("utf8");
-      if (code !== 0 && !options.allowFailure) {
-        reject(
-          new Error(`${command} ${args.join(" ")} exited with code ${code}\n${stdout}${stderr}`),
-        );
-        return;
-      }
+      settle(() => {
+        const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+        if (code !== 0 && !options.allowFailure) {
+          reject(
+            createCommandExitError({
+              command,
+              args,
+              exitCode: code,
+              stdout,
+              stderr,
+            }),
+          );
+          return;
+        }
 
-      resolve({
-        code,
-        stdout,
-        stderr,
+        resolve({
+          code,
+          stdout,
+          stderr,
+        });
       });
     });
+
+    if (options.timeoutMs) {
+      timeoutHandle = setTimeout(() => {
+        const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+        const timeoutError = createCommandTimeoutError({
+          command,
+          args,
+          timeoutMs: options.timeoutMs,
+          stdout,
+          stderr,
+        });
+        terminateChildProcess(child).finally(() => {
+          settle(() => reject(timeoutError));
+        });
+      }, options.timeoutMs);
+
+      if (typeof timeoutHandle.unref === "function") {
+        timeoutHandle.unref();
+      }
+    }
   });
 }
 
@@ -442,25 +571,71 @@ function captureBinaryToFile(command, args, outputPath, options = {}) {
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stderrChunks = [];
+    let settled = false;
+    let timeoutHandle = null;
+
+    const settle = (callback) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      callback();
+    };
 
     child.stdout.pipe(file);
     child.stderr.on("data", (chunk) => stderrChunks.push(Buffer.from(chunk)));
     child.on("error", (error) => {
-      file.destroy();
-      reject(error);
-    });
-    child.on("close", (code) => {
-      file.end();
-      const stderr = Buffer.concat(stderrChunks).toString("utf8");
-      if (code !== 0) {
-        reject(new Error(`${command} ${args.join(" ")} exited with code ${code}\n${stderr}`));
-        return;
-      }
-      resolve({
-        code,
-        stderr,
+      settle(() => {
+        file.destroy();
+        reject(error);
       });
     });
+    child.on("close", (code) => {
+      settle(() => {
+        file.end();
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+        if (code !== 0) {
+          reject(
+            createCommandExitError({
+              command,
+              args,
+              exitCode: code,
+              stderr,
+            }),
+          );
+          return;
+        }
+        resolve({
+          code,
+          stderr,
+        });
+      });
+    });
+
+    if (options.timeoutMs) {
+      timeoutHandle = setTimeout(() => {
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+        const timeoutError = createCommandTimeoutError({
+          command,
+          args,
+          timeoutMs: options.timeoutMs,
+          stderr,
+        });
+        terminateChildProcess(child).finally(() => {
+          settle(() => {
+            file.destroy();
+            reject(timeoutError);
+          });
+        });
+      }, options.timeoutMs);
+
+      if (typeof timeoutHandle.unref === "function") {
+        timeoutHandle.unref();
+      }
+    }
   });
 }
 
@@ -1014,27 +1189,35 @@ async function captureDeviceState(config, adbPrefix, artifactPaths) {
       "adb",
       [...adbPrefix, "exec-out", "screencap", "-p"],
       artifactPaths.screenshot,
+      {
+        timeoutMs: DEFAULT_DEVICE_CAPTURE_TIMEOUT_MS,
+      },
     );
   }
 
   if (artifactPaths.uiDump && config.captureUiDump) {
     const remoteUiDumpPath = `/sdcard/paseo-dev-client-validation-${path.basename(artifactPaths.uiDump)}`;
-    await spawnCapture("adb", [...adbPrefix, "shell", "uiautomator", "dump", remoteUiDumpPath]);
-    await spawnCapture("adb", [...adbPrefix, "pull", remoteUiDumpPath, artifactPaths.uiDump]);
+    await spawnCapture("adb", [...adbPrefix, "shell", "uiautomator", "dump", remoteUiDumpPath], {
+      timeoutMs: DEFAULT_DEVICE_CAPTURE_TIMEOUT_MS,
+    });
+    await spawnCapture("adb", [...adbPrefix, "pull", remoteUiDumpPath, artifactPaths.uiDump], {
+      timeoutMs: DEFAULT_DEVICE_CAPTURE_TIMEOUT_MS,
+    });
     uiDumpXml = fs.readFileSync(artifactPaths.uiDump, "utf8");
   }
 
-  const activityTop = await spawnCapture("adb", [
-    ...adbPrefix,
-    "shell",
-    "dumpsys",
-    "activity",
-    "top",
-  ]);
+  const activityTop = await spawnCapture(
+    "adb",
+    [...adbPrefix, "shell", "dumpsys", "activity", "top"],
+    {
+      timeoutMs: DEFAULT_DEVICE_CAPTURE_TIMEOUT_MS,
+    },
+  );
   writeTextFile(artifactPaths.activityTop, `${activityTop.stdout}${activityTop.stderr}`);
 
   const logcat = await spawnCapture("adb", [...adbPrefix, "logcat", "-d", "-v", "time"], {
     allowFailure: true,
+    timeoutMs: DEFAULT_DEVICE_CAPTURE_TIMEOUT_MS,
   });
   const logcatText = `${logcat.stdout}${logcat.stderr}`;
   writeTextFile(artifactPaths.logcat, logcatText);
@@ -1045,55 +1228,30 @@ async function captureDeviceState(config, adbPrefix, artifactPaths) {
   };
 }
 
-async function runValidation(config) {
+async function runValidation(config, dependencies = {}) {
+  const spawnCaptureFn = dependencies.spawnCapture ?? spawnCapture;
+  const startRequestCaptureProxyFn =
+    dependencies.startRequestCaptureProxy ?? startRequestCaptureProxy;
+  const startExpoProcessFn = dependencies.startExpoProcess ?? startExpoProcess;
+  const waitForExpoReadyFn = dependencies.waitForExpoReady ?? waitForExpoReady;
+  const captureDeviceStateFn = dependencies.captureDeviceState ?? captureDeviceState;
   ensureDir(config.outputDir);
-  writeJsonFile(config.artifactPaths.summary, {
-    phase: "starting",
-    outputDir: config.outputDir,
-    port: config.publicPort,
-    metroPort: config.metroPort,
-    host: config.host,
-    launchHost: config.launchHost,
-    appId: config.appId,
-    scheme: config.scheme,
-    deepLinkUrl: config.deepLinkUrl,
-    buildWorkspaceDeps: config.buildWorkspaceDeps,
-    adbReverse: config.adbReverse,
-    captureScreenshot: config.captureScreenshot,
-    captureUiDump: config.captureUiDump,
-    clearLogcat: config.clearLogcat,
-    captureFirstRequest: config.captureFirstRequest,
-    retryOnTimeout: config.retryOnTimeout,
-    envOverrides: config.envOverrides,
-  });
+  let currentPhase = "starting";
+  const writeSummary = (summary) =>
+    writeJsonFile(config.artifactPaths.summary, buildValidationSummary(config, summary));
+  const setPhase = (phase, extra = {}) => {
+    currentPhase = phase;
+    writeSummary({
+      phase,
+      ...extra,
+    });
+  };
+
+  setPhase("starting");
 
   const adbPrefix = config.deviceId ? ["-s", config.deviceId] : [];
-  const adbDevices = await spawnCapture("adb", ["devices"]);
-  writeTextFile(config.artifactPaths.adbDevices, `${adbDevices.stdout}${adbDevices.stderr}`);
-
-  if (config.buildWorkspaceDeps) {
-    const buildResult = await spawnCapture("npm", ["run", "build:workspace-deps"], {
-      cwd: config.appDir,
-      env: config.expoEnv,
-    });
-    writeTextFile(
-      config.artifactPaths.buildWorkspaceDeps,
-      `${buildResult.stdout}${buildResult.stderr}`,
-    );
-  }
-
-  if (config.clearLogcat) {
-    await spawnCapture("adb", [...adbPrefix, "logcat", "-c"], {
-      allowFailure: true,
-    });
-  }
-
-  const requestProxy = startRequestCaptureProxy(config);
-  if (requestProxy) {
-    await requestProxy.start();
-  }
-
-  const expoProcess = startExpoProcess(config);
+  let requestProxy = null;
+  let expoProcess = null;
   let launchResult = "";
   let initialClassification = {
     status: "unknown",
@@ -1103,39 +1261,87 @@ async function runValidation(config) {
   let replaySummary = null;
 
   try {
-    await waitForExpoReady(config, expoProcess);
+    setPhase("adb_devices");
+    const adbDevices = await spawnCaptureFn("adb", ["devices"], {
+      timeoutMs: DEFAULT_ADB_COMMAND_TIMEOUT_MS,
+    });
+    writeTextFile(config.artifactPaths.adbDevices, `${adbDevices.stdout}${adbDevices.stderr}`);
+
+    if (config.buildWorkspaceDeps) {
+      setPhase("build_workspace_deps");
+      const buildResult = await spawnCaptureFn("npm", ["run", "build:workspace-deps"], {
+        cwd: config.appDir,
+        env: config.expoEnv,
+        timeoutMs: DEFAULT_BUILD_WORKSPACE_DEPS_TIMEOUT_MS,
+      });
+      writeTextFile(
+        config.artifactPaths.buildWorkspaceDeps,
+        `${buildResult.stdout}${buildResult.stderr}`,
+      );
+    }
+
+    if (config.clearLogcat) {
+      setPhase("clear_logcat");
+      await spawnCaptureFn("adb", [...adbPrefix, "logcat", "-c"], {
+        allowFailure: true,
+        timeoutMs: DEFAULT_ADB_COMMAND_TIMEOUT_MS,
+      });
+    }
+
+    setPhase("start_request_capture");
+    requestProxy = startRequestCaptureProxyFn(config);
+    if (requestProxy) {
+      await requestProxy.start();
+    }
+
+    setPhase("start_expo");
+    expoProcess = startExpoProcessFn(config);
+
+    setPhase("wait_for_expo");
+    await waitForExpoReadyFn(config, expoProcess);
 
     if (config.adbReverse) {
-      const reverseResult = await spawnCapture("adb", [
-        ...adbPrefix,
-        "reverse",
-        `tcp:${config.publicPort}`,
-        `tcp:${config.publicPort}`,
-      ]);
+      setPhase("adb_reverse");
+      const reverseResult = await spawnCaptureFn(
+        "adb",
+        [...adbPrefix, "reverse", `tcp:${config.publicPort}`, `tcp:${config.publicPort}`],
+        {
+          timeoutMs: DEFAULT_ADB_COMMAND_TIMEOUT_MS,
+        },
+      );
       writeTextFile(
         path.join(config.outputDir, "adb-reverse.txt"),
         `${reverseResult.stdout}${reverseResult.stderr}`,
       );
     }
 
-    const launch = await spawnCapture("adb", [
-      ...adbPrefix,
-      "shell",
-      "am",
-      "start",
-      "-W",
-      "-a",
-      "android.intent.action.VIEW",
-      "-d",
-      config.deepLinkUrl,
-      config.appId,
-    ]);
+    setPhase("launch_app");
+    const launch = await spawnCaptureFn(
+      "adb",
+      [
+        ...adbPrefix,
+        "shell",
+        "am",
+        "start",
+        "-W",
+        "-a",
+        "android.intent.action.VIEW",
+        "-d",
+        config.deepLinkUrl,
+        config.appId,
+      ],
+      {
+        timeoutMs: DEFAULT_LAUNCH_COMMAND_TIMEOUT_MS,
+      },
+    );
     launchResult = `${launch.stdout}${launch.stderr}`;
     writeTextFile(config.artifactPaths.launch, launchResult);
 
+    setPhase("wait_for_app");
     await sleep(config.waitMs);
 
-    const initialState = await captureDeviceState(config, adbPrefix, {
+    setPhase("capture_device_state");
+    const initialState = await captureDeviceStateFn(config, adbPrefix, {
       activityTop: config.artifactPaths.activityTop,
       screenshot: config.artifactPaths.screenshot,
       uiDump: config.artifactPaths.uiDump,
@@ -1150,29 +1356,39 @@ async function runValidation(config) {
     });
 
     if (requestProxy) {
+      setPhase("replay_captured_request");
       replaySummary = await replayCapturedRequest(config, requestProxy.entries[0]);
       writeJsonFile(config.artifactPaths.requestReplay, replaySummary);
     }
 
     if (config.retryOnTimeout && initialClassification.status === "dev_client_read_timeout") {
-      const retryLaunch = await spawnCapture("adb", [
-        ...adbPrefix,
-        "shell",
-        "am",
-        "start",
-        "-W",
-        "-a",
-        "android.intent.action.VIEW",
-        "-d",
-        config.deepLinkUrl,
-        config.appId,
-      ]);
+      setPhase("retry_launch");
+      const retryLaunch = await spawnCaptureFn(
+        "adb",
+        [
+          ...adbPrefix,
+          "shell",
+          "am",
+          "start",
+          "-W",
+          "-a",
+          "android.intent.action.VIEW",
+          "-d",
+          config.deepLinkUrl,
+          config.appId,
+        ],
+        {
+          timeoutMs: DEFAULT_LAUNCH_COMMAND_TIMEOUT_MS,
+        },
+      );
       const retryLaunchText = `${retryLaunch.stdout}${retryLaunch.stderr}`;
       writeTextFile(config.artifactPaths.retryLaunch, retryLaunchText);
 
+      setPhase("wait_for_retry");
       await sleep(config.waitMs);
 
-      const retryState = await captureDeviceState(config, adbPrefix, {
+      setPhase("capture_retry_device_state");
+      const retryState = await captureDeviceStateFn(config, adbPrefix, {
         activityTop: config.artifactPaths.retryActivityTop,
         screenshot: config.artifactPaths.retryScreenshot,
         uiDump: config.artifactPaths.retryUiDump,
@@ -1213,13 +1429,46 @@ async function runValidation(config) {
       replay: replaySummary,
       retry: retrySummary,
     };
-    writeJsonFile(config.artifactPaths.summary, summary);
+    writeSummary(summary);
     return summary;
+  } catch (error) {
+    const failureArtifactPath = failureArtifactPathForPhase(config, currentPhase);
+    if (failureArtifactPath && (error?.stdout || error?.stderr)) {
+      writeTextFile(failureArtifactPath, `${error.stdout ?? ""}${error.stderr ?? ""}`);
+    }
+
+    const summary = {
+      phase: "completed",
+      status: error?.timedOut ? "command_timeout" : "validation_failed",
+      reason: error?.timedOut ? `${currentPhase}_timeout` : `${currentPhase}_failed`,
+      failedPhase: currentPhase,
+      artifactPaths: config.artifactPaths,
+      error: String(error?.stack || error?.message || error),
+      failedCommand: error?.command
+        ? {
+            command: error.command,
+            args: error.args,
+            exitCode: error.commandExitCode ?? null,
+            timeoutMs: error.timeoutMs ?? null,
+          }
+        : null,
+      timedOutCommand: error?.timedOut
+        ? {
+            command: error.command,
+            args: error.args,
+            timeoutMs: error.timeoutMs,
+          }
+        : null,
+    };
+    writeSummary(summary);
+    return buildValidationSummary(config, summary);
   } finally {
     if (requestProxy) {
       await requestProxy.stop();
     }
-    await expoProcess.stop();
+    if (expoProcess) {
+      await expoProcess.stop();
+    }
   }
 }
 
@@ -1260,6 +1509,7 @@ module.exports = {
   rewriteExpoManifestResponse,
   waitForExpoReady,
   shouldEndUpstreamImmediately,
+  spawnCapture,
   runValidation,
 };
 

--- a/packages/app/scripts/windows-dev-client-validation.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.cjs
@@ -11,6 +11,7 @@ const DEFAULT_HOST = "lan";
 const DEFAULT_LAUNCH_HOST = "127.0.0.1";
 const DEFAULT_APP_ID = "sh.paseo.debug";
 const DEFAULT_SCHEME = "exp+voice-mobile";
+const DEFAULT_PAIRING_SCHEME = "paseo";
 const DEFAULT_SUCCESS_TEXT = "Welcome to Paseo";
 const DEFAULT_WAIT_MS = 15000;
 const DEFAULT_STARTUP_TIMEOUT_MS = 120000;
@@ -31,6 +32,7 @@ const WORKSPACE_UI_MARKERS = [
   "workspace-open-in-editor-primary",
   "permission-request-question",
 ];
+const HOST_UI_MARKERS = ["open-project-submit"];
 const HOP_BY_HOP_REQUEST_HEADERS = new Set([
   "connection",
   "proxy-connection",
@@ -45,6 +47,11 @@ const PROXY_ENV_KEYS = [
   "http_proxy",
   "HTTPS_PROXY",
   "https_proxy",
+];
+const SYSTEM_PERMISSION_DIALOG_PACKAGES = [
+  "com.android.permissioncontroller",
+  "com.google.android.permissioncontroller",
+  "com.lbe.security.miui",
 ];
 
 function printHelp() {
@@ -61,6 +68,9 @@ Options:
   --wait-ms <number>              Delay after launch before collecting evidence
   --startup-timeout-ms <number>   Expo readiness timeout
   --success-text <text>           UI text that indicates a successful app boot
+  --pairing-offer-url <url>       Optional pairing offer URL to import after app boot
+  --pairing-scheme <scheme>       App scheme used for pairing-link import (default: ${DEFAULT_PAIRING_SCHEME})
+  --pairing-wait-ms <number>      Delay after importing pairing link before collecting evidence
   --env KEY=VALUE                 Additional environment override (repeatable)
   --capture-first-request         Put an HTTP capture proxy in front of Metro and record the first requests
   --retry-on-timeout              Relaunch once if the first attempt hits the Expo timeout screen
@@ -106,6 +116,9 @@ function parseArgs(argv) {
     waitMs: DEFAULT_WAIT_MS,
     startupTimeoutMs: DEFAULT_STARTUP_TIMEOUT_MS,
     successText: DEFAULT_SUCCESS_TEXT,
+    pairingOfferUrl: null,
+    pairingScheme: DEFAULT_PAIRING_SCHEME,
+    pairingWaitMs: DEFAULT_WAIT_MS,
     envOverrides: {},
     keepProxyEnv: false,
     buildWorkspaceDeps: true,
@@ -151,6 +164,15 @@ function parseArgs(argv) {
         break;
       case "--success-text":
         options.successText = argv[++index];
+        break;
+      case "--pairing-offer-url":
+        options.pairingOfferUrl = argv[++index];
+        break;
+      case "--pairing-scheme":
+        options.pairingScheme = argv[++index];
+        break;
+      case "--pairing-wait-ms":
+        options.pairingWaitMs = parsePositiveInteger("--pairing-wait-ms", argv[++index]);
         break;
       case "--env": {
         const assignment = parseEnvAssignment(argv[++index]);
@@ -206,6 +228,30 @@ function buildDeepLinkUrl({ scheme, launchHost, port }) {
   )}`;
 }
 
+function extractOfferFragment(offerUrl) {
+  const marker = "#offer=";
+  const normalizedUrl = String(offerUrl ?? "").trim();
+  const markerIndex = normalizedUrl.indexOf(marker);
+  if (markerIndex === -1) {
+    throw new Error("Pairing offer URL must include #offer=...");
+  }
+
+  const encodedOffer = normalizedUrl.slice(markerIndex + marker.length).trim();
+  if (!encodedOffer) {
+    throw new Error("Pairing offer payload is empty");
+  }
+
+  return encodedOffer;
+}
+
+function buildPairingImportUrl({ pairingOfferUrl, pairingScheme }) {
+  if (!pairingOfferUrl) {
+    return null;
+  }
+
+  return `${pairingScheme}:///#offer=${extractOfferFragment(pairingOfferUrl)}`;
+}
+
 function uniqueCsv(values) {
   return [...new Set(values.filter(Boolean))].join(",");
 }
@@ -238,6 +284,88 @@ function buildExpoEnv(baseEnv, options) {
   return env;
 }
 
+function readXmlAttr(nodeTag, attributeName) {
+  const match = nodeTag.match(new RegExp(`${attributeName}="([^"]*)"`, "i"));
+  return match ? match[1] : "";
+}
+
+function parseBoundsCenter(boundsText) {
+  const match = String(boundsText ?? "").match(/\[(\d+),(\d+)\]\[(\d+),(\d+)\]/);
+  if (!match) {
+    return null;
+  }
+
+  const left = Number.parseInt(match[1], 10);
+  const top = Number.parseInt(match[2], 10);
+  const right = Number.parseInt(match[3], 10);
+  const bottom = Number.parseInt(match[4], 10);
+  return {
+    x: Math.round((left + right) / 2),
+    y: Math.round((top + bottom) / 2),
+  };
+}
+
+function findPermissionDialogAllowButton(uiDumpXml) {
+  const xml = String(uiDumpXml ?? "");
+  if (!/Paseo/i.test(xml)) {
+    return null;
+  }
+
+  const nodeTags = xml.match(/<node\b[^>]*\/>/g) ?? [];
+  const buttons = [];
+
+  for (const nodeTag of nodeTags) {
+    const packageName = readXmlAttr(nodeTag, "package");
+    if (!SYSTEM_PERMISSION_DIALOG_PACKAGES.includes(packageName)) {
+      continue;
+    }
+
+    if (readXmlAttr(nodeTag, "class") !== "android.widget.Button") {
+      continue;
+    }
+
+    if (readXmlAttr(nodeTag, "clickable") !== "true" || readXmlAttr(nodeTag, "enabled") !== "true") {
+      continue;
+    }
+
+    const center = parseBoundsCenter(readXmlAttr(nodeTag, "bounds"));
+    if (!center) {
+      continue;
+    }
+
+    buttons.push({
+      packageName,
+      x: center.x,
+      y: center.y,
+    });
+  }
+
+  if (buttons.length < 2) {
+    return null;
+  }
+
+  return buttons.sort((left, right) => right.x - left.x)[0];
+}
+
+function isBenignTopInstanceDelivery(launchText) {
+  return /intent has been delivered to currently running top-most instance/i.test(
+    String(launchText ?? ""),
+  );
+}
+
+function hasAdbLaunchFailure(launchText) {
+  const text = String(launchText ?? "");
+  if (/Error: Activity class|unable to resolve Intent/i.test(text)) {
+    return true;
+  }
+
+  if (/Activity not started/i.test(text) && !isBenignTopInstanceDelivery(text)) {
+    return true;
+  }
+
+  return false;
+}
+
 function hasVisibleWorkspaceUi(uiDumpXml) {
   const xml = String(uiDumpXml ?? "");
   let matchedMarkers = 0;
@@ -249,6 +377,11 @@ function hasVisibleWorkspaceUi(uiDumpXml) {
   }
 
   return matchedMarkers >= 2;
+}
+
+function hasVisibleHostUi(uiDumpXml) {
+  const xml = String(uiDumpXml ?? "");
+  return HOST_UI_MARKERS.some((marker) => xml.includes(marker));
 }
 
 function classifyValidationResult({ uiDumpXml, logcatText, launchOutput, successText }) {
@@ -280,6 +413,13 @@ function classifyValidationResult({ uiDumpXml, logcatText, launchOutput, success
     };
   }
 
+  if (hasVisibleHostUi(uiXml)) {
+    return {
+      status: "app_loaded",
+      reason: "host_ui_visible",
+    };
+  }
+
   if (
     /SocketTimeoutException|Read timed out|timeout waiting for response headers/i.test(
       deviceLogcat,
@@ -292,7 +432,7 @@ function classifyValidationResult({ uiDumpXml, logcatText, launchOutput, success
     };
   }
 
-  if (/Activity not started|Error: Activity class|unable to resolve Intent/i.test(launchText)) {
+  if (hasAdbLaunchFailure(launchText)) {
     return {
       status: "launch_failed",
       reason: "adb_launch_error",
@@ -302,6 +442,56 @@ function classifyValidationResult({ uiDumpXml, logcatText, launchOutput, success
   return {
     status: "unknown",
     reason: "no_success_or_failure_signature",
+  };
+}
+
+function classifyPairingResult({ uiDumpXml, logcatText, launchOutput, successText }) {
+  const uiXml = String(uiDumpXml ?? "");
+  const deviceLogcat = String(logcatText ?? "");
+  const launchText = String(launchOutput ?? "");
+
+  if (hasVisibleWorkspaceUi(uiXml)) {
+    return {
+      status: "paired_workspace_loaded",
+      reason: "workspace_ui_visible_after_pairing",
+    };
+  }
+
+  if (hasVisibleHostUi(uiXml)) {
+    return {
+      status: "paired_host_loaded",
+      reason: "host_ui_visible_after_pairing",
+    };
+  }
+
+  if (successText && uiXml.includes(successText)) {
+    return {
+      status: "pairing_failed",
+      reason: "still_on_welcome_screen",
+    };
+  }
+
+  if (
+    /Unable to pair host|Pairing failed|Missing #offer= fragment|Offer payload is empty/i.test(
+      `${uiXml}\n${deviceLogcat}\n${launchText}`,
+    )
+  ) {
+    return {
+      status: "pairing_failed",
+      reason: "pairing_error_visible",
+    };
+  }
+
+  if (hasAdbLaunchFailure(launchText)) {
+    return {
+      status: "launch_failed",
+      reason: "adb_launch_error",
+    };
+  }
+
+  return {
+    status: "pairing_failed",
+    reason: "workspace_ui_not_visible_after_pairing",
   };
 }
 
@@ -330,6 +520,8 @@ function buildConfig(options, overrides = {}) {
   const appDir = overrides.appDir ?? path.join(repoRoot, "packages", "app");
   const outputDir = resolveOutputDir(options.outputDir, overrides.now);
   const networkPlan = resolveNetworkPlan(options);
+  const pairingScheme = options.pairingScheme ?? DEFAULT_PAIRING_SCHEME;
+  const pairingWaitMs = options.pairingWaitMs ?? options.waitMs ?? DEFAULT_WAIT_MS;
 
   return {
     ...options,
@@ -338,6 +530,12 @@ function buildConfig(options, overrides = {}) {
     outputDir,
     publicPort: networkPlan.publicPort,
     metroPort: networkPlan.metroPort,
+    pairingScheme,
+    pairingWaitMs,
+    pairingImportUrl: buildPairingImportUrl({
+      pairingOfferUrl: options.pairingOfferUrl,
+      pairingScheme,
+    }),
     deepLinkUrl: buildDeepLinkUrl({
       scheme: options.scheme,
       launchHost: options.launchHost,
@@ -352,6 +550,14 @@ function buildConfig(options, overrides = {}) {
       expoProbe: path.join(outputDir, "expo-probe.json"),
       launch: path.join(outputDir, "adb-start.txt"),
       logcat: path.join(outputDir, "logcat.txt"),
+      pairingActivityTop: path.join(outputDir, "activity-top-pairing.txt"),
+      pairingLaunch: path.join(outputDir, "adb-start-pairing.txt"),
+      pairingLogcat: path.join(outputDir, "logcat-pairing.txt"),
+      pairingPermissionDialogMeta: path.join(outputDir, "pairing-permission-dialog.json"),
+      pairingPermissionDialogScreenshot: path.join(outputDir, "device-pairing-permission-dialog.png"),
+      pairingPermissionDialogUiDump: path.join(outputDir, "device-pairing-permission-dialog.xml"),
+      pairingScreenshot: path.join(outputDir, "device-pairing.png"),
+      pairingUiDump: path.join(outputDir, "device-pairing.xml"),
       requestCapture: path.join(outputDir, "request-capture.json"),
       requestReplay: path.join(outputDir, "request-replay.json"),
       retryLaunch: path.join(outputDir, "adb-start-retry.txt"),
@@ -379,6 +585,15 @@ function writeJsonFile(filePath, value) {
   writeTextFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function copyArtifactIfPresent(sourcePath, destinationPath) {
+  if (!sourcePath || !destinationPath || !fs.existsSync(sourcePath)) {
+    return;
+  }
+
+  ensureDir(path.dirname(destinationPath));
+  fs.copyFileSync(sourcePath, destinationPath);
+}
+
 function buildValidationSummary(config, summary) {
   return {
     outputDir: config.outputDir,
@@ -396,6 +611,9 @@ function buildValidationSummary(config, summary) {
     clearLogcat: config.clearLogcat,
     captureFirstRequest: config.captureFirstRequest,
     retryOnTimeout: config.retryOnTimeout,
+    pairingRequested: Boolean(config.pairingImportUrl),
+    pairingScheme: config.pairingScheme,
+    pairingWaitMs: config.pairingWaitMs,
     envOverrides: config.envOverrides,
     ...summary,
   };
@@ -436,6 +654,8 @@ function failureArtifactPathForPhase(config, phase) {
       return config.artifactPaths.launch;
     case "retry_launch":
       return config.artifactPaths.retryLaunch;
+    case "launch_pairing_offer":
+      return config.artifactPaths.pairingLaunch;
     default:
       return null;
   }
@@ -637,6 +857,14 @@ function captureBinaryToFile(command, args, outputPath, options = {}) {
       }
     }
   });
+}
+
+function assertSupportedPlatform(platform = process.platform) {
+  if (platform !== "win32" && platform !== "linux") {
+    throw new Error(
+      "windows-dev-client-validation.cjs must run on Windows or Linux",
+    );
+  }
 }
 
 function sleep(ms) {
@@ -1258,6 +1486,7 @@ async function runValidation(config, dependencies = {}) {
     reason: "validation_interrupted",
   };
   let retrySummary = null;
+  let pairingSummary = null;
   let replaySummary = null;
 
   try {
@@ -1417,7 +1646,102 @@ async function runValidation(config, dependencies = {}) {
       };
     }
 
-    const finalOutcome = deriveValidationOutcome(initialClassification, retrySummary);
+    let finalOutcome = deriveValidationOutcome(initialClassification, retrySummary);
+
+    if (
+      config.pairingImportUrl &&
+      (finalOutcome.status === "app_loaded" || finalOutcome.status === "app_loaded_after_retry")
+    ) {
+      setPhase("launch_pairing_offer");
+      const pairingLaunch = await spawnCaptureFn(
+        "adb",
+        [
+          ...adbPrefix,
+          "shell",
+          "am",
+          "start",
+          "-W",
+          "-a",
+          "android.intent.action.VIEW",
+          "-d",
+          config.pairingImportUrl,
+          config.appId,
+        ],
+        {
+          timeoutMs: DEFAULT_LAUNCH_COMMAND_TIMEOUT_MS,
+        },
+      );
+      const pairingLaunchText = `${pairingLaunch.stdout}${pairingLaunch.stderr}`;
+      writeTextFile(config.artifactPaths.pairingLaunch, pairingLaunchText);
+
+      setPhase("wait_for_pairing");
+      await sleep(config.pairingWaitMs);
+
+      setPhase("capture_pairing_device_state");
+      const pairingState = await captureDeviceStateFn(config, adbPrefix, {
+        activityTop: config.artifactPaths.pairingActivityTop,
+        screenshot: config.artifactPaths.pairingScreenshot,
+        uiDump: config.artifactPaths.pairingUiDump,
+        logcat: config.artifactPaths.pairingLogcat,
+      });
+      let pairingClassification = classifyPairingResult({
+        uiDumpXml: pairingState.uiDumpXml,
+        logcatText: pairingState.logcatText,
+        launchOutput: pairingLaunchText,
+        successText: config.successText,
+      });
+      let permissionDialog = null;
+
+      const allowButton = findPermissionDialogAllowButton(pairingState.uiDumpXml);
+      if (allowButton && pairingClassification.status !== "paired_workspace_loaded") {
+        permissionDialog = {
+          dismissed: true,
+          ...allowButton,
+        };
+        writeJsonFile(config.artifactPaths.pairingPermissionDialogMeta, permissionDialog);
+        copyArtifactIfPresent(
+          config.artifactPaths.pairingScreenshot,
+          config.artifactPaths.pairingPermissionDialogScreenshot,
+        );
+        copyArtifactIfPresent(
+          config.artifactPaths.pairingUiDump,
+          config.artifactPaths.pairingPermissionDialogUiDump,
+        );
+
+        setPhase("dismiss_pairing_permission_dialog");
+        await spawnCaptureFn(
+          "adb",
+          [...adbPrefix, "shell", "input", "tap", String(allowButton.x), String(allowButton.y)],
+          {
+            timeoutMs: DEFAULT_ADB_COMMAND_TIMEOUT_MS,
+          },
+        );
+
+        setPhase("wait_for_pairing_after_permission_dialog");
+        await sleep(config.pairingWaitMs);
+
+        setPhase("capture_pairing_device_state_after_permission_dialog");
+        const postDialogPairingState = await captureDeviceStateFn(config, adbPrefix, {
+          activityTop: config.artifactPaths.pairingActivityTop,
+          screenshot: config.artifactPaths.pairingScreenshot,
+          uiDump: config.artifactPaths.pairingUiDump,
+          logcat: config.artifactPaths.pairingLogcat,
+        });
+        pairingClassification = classifyPairingResult({
+          uiDumpXml: postDialogPairingState.uiDumpXml,
+          logcatText: postDialogPairingState.logcatText,
+          launchOutput: pairingLaunchText,
+          successText: config.successText,
+        });
+      }
+
+      pairingSummary = {
+        launch: pairingLaunchText,
+        permissionDialog,
+        ...pairingClassification,
+      };
+      finalOutcome = pairingSummary;
+    }
 
     const summary = {
       phase: "completed",
@@ -1438,6 +1762,7 @@ async function runValidation(config, dependencies = {}) {
       },
       replay: replaySummary,
       retry: retrySummary,
+      pairing: pairingSummary,
     };
     writeSummary(summary);
     return summary;
@@ -1489,9 +1814,7 @@ async function main(argv = process.argv.slice(2)) {
     return;
   }
 
-  if (process.platform !== "win32") {
-    throw new Error("windows-dev-client-validation.cjs must run on Windows");
-  }
+  assertSupportedPlatform();
 
   const config = buildConfig(options);
   console.log(`Artifacts: ${config.outputDir}`);
@@ -1499,22 +1822,38 @@ async function main(argv = process.argv.slice(2)) {
   const summary = await runValidation(config);
   console.log(`Validation status: ${summary.status} (${summary.reason})`);
 
-  if (summary.status === "app_loaded" || summary.status === "app_loaded_after_retry") {
+  if (
+    summary.status === "app_loaded" ||
+    summary.status === "app_loaded_after_retry" ||
+    summary.status === "paired_workspace_loaded" ||
+    summary.status === "paired_host_loaded"
+  ) {
     return;
   }
 
   process.exitCode =
-    summary.status === "dev_client_read_timeout" ? 2 : summary.status === "launch_failed" ? 3 : 4;
+    summary.status === "dev_client_read_timeout"
+      ? 2
+      : summary.status === "launch_failed"
+        ? 3
+        : summary.status === "pairing_failed"
+          ? 5
+          : 4;
 }
 
 module.exports = {
+  assertSupportedPlatform,
   buildSpawnInvocation,
   buildUpstreamRequestHeaders,
   buildConfig,
   buildDeepLinkUrl,
+  buildPairingImportUrl,
   buildExpoEnv,
   classifyValidationResult,
+  classifyPairingResult,
   deriveValidationOutcome,
+  findPermissionDialogAllowButton,
+  hasAdbLaunchFailure,
   parseArgs,
   rewriteExpoManifestResponse,
   waitForExpoReady,

--- a/packages/app/scripts/windows-dev-client-validation.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.cjs
@@ -324,7 +324,10 @@ function findPermissionDialogAllowButton(uiDumpXml) {
       continue;
     }
 
-    if (readXmlAttr(nodeTag, "clickable") !== "true" || readXmlAttr(nodeTag, "enabled") !== "true") {
+    if (
+      readXmlAttr(nodeTag, "clickable") !== "true" ||
+      readXmlAttr(nodeTag, "enabled") !== "true"
+    ) {
       continue;
     }
 
@@ -554,7 +557,10 @@ function buildConfig(options, overrides = {}) {
       pairingLaunch: path.join(outputDir, "adb-start-pairing.txt"),
       pairingLogcat: path.join(outputDir, "logcat-pairing.txt"),
       pairingPermissionDialogMeta: path.join(outputDir, "pairing-permission-dialog.json"),
-      pairingPermissionDialogScreenshot: path.join(outputDir, "device-pairing-permission-dialog.png"),
+      pairingPermissionDialogScreenshot: path.join(
+        outputDir,
+        "device-pairing-permission-dialog.png",
+      ),
       pairingPermissionDialogUiDump: path.join(outputDir, "device-pairing-permission-dialog.xml"),
       pairingScreenshot: path.join(outputDir, "device-pairing.png"),
       pairingUiDump: path.join(outputDir, "device-pairing.xml"),
@@ -861,9 +867,7 @@ function captureBinaryToFile(command, args, outputPath, options = {}) {
 
 function assertSupportedPlatform(platform = process.platform) {
   if (platform !== "win32" && platform !== "linux") {
-    throw new Error(
-      "windows-dev-client-validation.cjs must run on Windows or Linux",
-    );
+    throw new Error("windows-dev-client-validation.cjs must run on Windows or Linux");
   }
 }
 

--- a/packages/app/scripts/windows-dev-client-validation.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.cjs
@@ -216,10 +216,10 @@ function buildExpoEnv(baseEnv, options) {
   }
 
   const nextNoProxy = uniqueCsv([
-    ...(String(env.NO_PROXY ?? "")
+    ...String(env.NO_PROXY ?? "")
       .split(",")
       .map((entry) => entry.trim())
-      .filter(Boolean)),
+      .filter(Boolean),
     "localhost",
     "127.0.0.1",
   ]);
@@ -277,7 +277,9 @@ function classifyValidationResult({ uiDumpXml, logcatText, launchOutput, success
   }
 
   if (
-    /SocketTimeoutException|Read timed out|timeout waiting for response headers/i.test(deviceLogcat) &&
+    /SocketTimeoutException|Read timed out|timeout waiting for response headers/i.test(
+      deviceLogcat,
+    ) &&
     /sh\.paseo(?:\.debug)?|DevLauncherErrorActivity|expo\.modules\.devlauncher/i.test(deviceLogcat)
   ) {
     return {
@@ -415,9 +417,7 @@ function spawnCapture(command, args, options = {}) {
       const stderr = Buffer.concat(stderrChunks).toString("utf8");
       if (code !== 0 && !options.allowFailure) {
         reject(
-          new Error(
-            `${command} ${args.join(" ")} exited with code ${code}\n${stdout}${stderr}`,
-          ),
+          new Error(`${command} ${args.join(" ")} exited with code ${code}\n${stdout}${stderr}`),
         );
         return;
       }
@@ -535,7 +535,10 @@ function probeHttp(url) {
 
 function cloneHeaders(headers) {
   return Object.fromEntries(
-    Object.entries(headers ?? {}).map(([key, value]) => [key, Array.isArray(value) ? value.join(", ") : value]),
+    Object.entries(headers ?? {}).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? value.join(", ") : value,
+    ]),
   );
 }
 
@@ -849,14 +852,14 @@ function startExpoProcess(config) {
   ensureDir(path.dirname(config.artifactPaths.expoLog));
   const logStream = fs.createWriteStream(config.artifactPaths.expoLog);
   const invocation = buildSpawnInvocation("npx", [
-      "expo",
-      "start",
-      "--dev-client",
-      "--host",
-      config.host,
-      "--port",
-      String(config.metroPort),
-    ]);
+    "expo",
+    "start",
+    "--dev-client",
+    "--host",
+    config.host,
+    "--port",
+    String(config.metroPort),
+  ]);
   const child = spawn(invocation.command, invocation.args, {
     cwd: config.appDir,
     env: config.expoEnv,
@@ -1021,7 +1024,13 @@ async function captureDeviceState(config, adbPrefix, artifactPaths) {
     uiDumpXml = fs.readFileSync(artifactPaths.uiDump, "utf8");
   }
 
-  const activityTop = await spawnCapture("adb", [...adbPrefix, "shell", "dumpsys", "activity", "top"]);
+  const activityTop = await spawnCapture("adb", [
+    ...adbPrefix,
+    "shell",
+    "dumpsys",
+    "activity",
+    "top",
+  ]);
   writeTextFile(artifactPaths.activityTop, `${activityTop.stdout}${activityTop.stderr}`);
 
   const logcat = await spawnCapture("adb", [...adbPrefix, "logcat", "-d", "-v", "time"], {
@@ -1236,11 +1245,7 @@ async function main(argv = process.argv.slice(2)) {
   }
 
   process.exitCode =
-    summary.status === "dev_client_read_timeout"
-      ? 2
-      : summary.status === "launch_failed"
-        ? 3
-        : 4;
+    summary.status === "dev_client_read_timeout" ? 2 : summary.status === "launch_failed" ? 3 : 4;
 }
 
 module.exports = {

--- a/packages/app/scripts/windows-dev-client-validation.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.cjs
@@ -1315,6 +1315,11 @@ async function runValidation(config, dependencies = {}) {
       );
     }
 
+    setPhase("force_stop_app");
+    await spawnCaptureFn("adb", [...adbPrefix, "shell", "am", "force-stop", config.appId], {
+      timeoutMs: DEFAULT_ADB_COMMAND_TIMEOUT_MS,
+    });
+
     setPhase("launch_app");
     const launch = await spawnCaptureFn(
       "adb",
@@ -1362,6 +1367,11 @@ async function runValidation(config, dependencies = {}) {
     }
 
     if (config.retryOnTimeout && initialClassification.status === "dev_client_read_timeout") {
+      setPhase("retry_force_stop_app");
+      await spawnCaptureFn("adb", [...adbPrefix, "shell", "am", "force-stop", config.appId], {
+        timeoutMs: DEFAULT_ADB_COMMAND_TIMEOUT_MS,
+      });
+
       setPhase("retry_launch");
       const retryLaunch = await spawnCaptureFn(
         "adb",

--- a/packages/app/scripts/windows-dev-client-validation.node-test.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.node-test.cjs
@@ -385,6 +385,115 @@ test("runValidation persists failing adb devices output for later inspection", a
   }
 });
 
+test("runValidation force-stops the dev client before launching and retrying", async () => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "paseo-validation-force-stop-"));
+  const config = buildConfig(
+    {
+      port: 8110,
+      host: "lan",
+      launchHost: "127.0.0.1",
+      deviceId: "f66d9150",
+      appId: "sh.paseo.debug",
+      scheme: "exp+voice-mobile",
+      outputDir,
+      waitMs: 1,
+      startupTimeoutMs: 1000,
+      successText: "Welcome to Paseo",
+      envOverrides: {},
+      keepProxyEnv: false,
+      buildWorkspaceDeps: false,
+      adbReverse: false,
+      captureScreenshot: false,
+      captureUiDump: false,
+      clearLogcat: false,
+      help: false,
+      captureFirstRequest: false,
+      retryOnTimeout: true,
+    },
+    {
+      repoRoot: "/repo",
+      appDir: "/repo/packages/app",
+      baseEnv: {},
+    },
+  );
+  const spawnInvocations = [];
+  let captureCount = 0;
+
+  try {
+    const summary = await runValidation(config, {
+      spawnCapture: async (command, args) => {
+        spawnInvocations.push({ command, args });
+
+        if (command === "adb" && args[0] === "devices") {
+          return { stdout: "List of devices attached\nf66d9150\tdevice\n", stderr: "" };
+        }
+
+        if (command === "adb" && args.includes("force-stop")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        if (command === "adb" && args.includes("start")) {
+          return { stdout: "Starting: Intent { ... }\nComplete\n", stderr: "" };
+        }
+
+        throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+      },
+      startRequestCaptureProxy: () => null,
+      startExpoProcess: () => ({
+        child: { exitCode: null },
+        getOutput: () => "Waiting on http://localhost:8110",
+        stop: async () => {},
+      }),
+      waitForExpoReady: async () => {},
+      captureDeviceState: async () => {
+        captureCount += 1;
+        if (captureCount === 1) {
+          return {
+            uiDumpXml:
+              '<node text="There was a problem loading the project." /><node text="java.net.SocketTimeoutException: timeout" />',
+            logcatText: "",
+          };
+        }
+
+        return {
+          uiDumpXml: '<node text="Welcome to Paseo" />',
+          logcatText: "",
+        };
+      },
+    });
+
+    assert.equal(summary.status, "app_loaded_after_retry");
+    assert.equal(summary.reason, "retry_recovered_after_timeout");
+
+    const initialForceStopIndex = spawnInvocations.findIndex(
+      (invocation) =>
+        invocation.command === "adb" &&
+        invocation.args.join(" ") === "-s f66d9150 shell am force-stop sh.paseo.debug",
+    );
+    const initialLaunchIndex = spawnInvocations.findIndex(
+      (invocation) =>
+        invocation.command === "adb" && invocation.args.includes("start") && invocation.args[0] === "-s",
+    );
+    const retryForceStopIndex = spawnInvocations.findIndex(
+      (invocation, index) =>
+        index > initialLaunchIndex &&
+        invocation.command === "adb" &&
+        invocation.args.join(" ") === "-s f66d9150 shell am force-stop sh.paseo.debug",
+    );
+    const retryLaunchIndex = spawnInvocations.findLastIndex(
+      (invocation) =>
+        invocation.command === "adb" && invocation.args.includes("start") && invocation.args[0] === "-s",
+    );
+
+    assert.notEqual(initialForceStopIndex, -1);
+    assert.notEqual(retryForceStopIndex, -1);
+    assert.ok(initialForceStopIndex < initialLaunchIndex);
+    assert.ok(retryForceStopIndex < retryLaunchIndex);
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
 test("buildUpstreamRequestHeaders rewrites host to Metro and strips hop-by-hop headers", () => {
   assert.deepEqual(
     buildUpstreamRequestHeaders(

--- a/packages/app/scripts/windows-dev-client-validation.node-test.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.node-test.cjs
@@ -472,7 +472,9 @@ test("runValidation force-stops the dev client before launching and retrying", a
     );
     const initialLaunchIndex = spawnInvocations.findIndex(
       (invocation) =>
-        invocation.command === "adb" && invocation.args.includes("start") && invocation.args[0] === "-s",
+        invocation.command === "adb" &&
+        invocation.args.includes("start") &&
+        invocation.args[0] === "-s",
     );
     const retryForceStopIndex = spawnInvocations.findIndex(
       (invocation, index) =>
@@ -482,7 +484,9 @@ test("runValidation force-stops the dev client before launching and retrying", a
     );
     const retryLaunchIndex = spawnInvocations.findLastIndex(
       (invocation) =>
-        invocation.command === "adb" && invocation.args.includes("start") && invocation.args[0] === "-s",
+        invocation.command === "adb" &&
+        invocation.args.includes("start") &&
+        invocation.args[0] === "-s",
     );
 
     assert.notEqual(initialForceStopIndex, -1);

--- a/packages/app/scripts/windows-dev-client-validation.node-test.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.node-test.cjs
@@ -83,12 +83,7 @@ test("parseArgs accepts repeated env overrides and skip flags", () => {
 });
 
 test("parseArgs accepts request capture and retry flags", () => {
-  const args = parseArgs([
-    "--port",
-    "8104",
-    "--capture-first-request",
-    "--retry-on-timeout",
-  ]);
+  const args = parseArgs(["--port", "8104", "--capture-first-request", "--retry-on-timeout"]);
 
   assert.equal(args.port, 8104);
   assert.equal(args.captureFirstRequest, true);
@@ -183,13 +178,10 @@ test("classifyValidationResult ignores unrelated logcat timeouts when the app UI
 });
 
 test("buildSpawnInvocation routes npm.cmd through cmd.exe on Windows", () => {
-  assert.deepEqual(
-    buildSpawnInvocation("npm", ["run", "build:workspace-deps"], "win32"),
-    {
-      command: "cmd.exe",
-      args: ["/d", "/s", "/c", "npm.cmd", "run", "build:workspace-deps"],
-    },
-  );
+  assert.deepEqual(buildSpawnInvocation("npm", ["run", "build:workspace-deps"], "win32"), {
+    command: "cmd.exe",
+    args: ["/d", "/s", "/c", "npm.cmd", "run", "build:workspace-deps"],
+  });
 });
 
 test("buildSpawnInvocation leaves adb untouched on Windows", () => {

--- a/packages/app/scripts/windows-dev-client-validation.node-test.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.node-test.cjs
@@ -170,7 +170,8 @@ test("classifyValidationResult detects a usable workspace UI without relying on 
 
 test("classifyValidationResult accepts host root UI as a successful app boot", () => {
   const result = classifyValidationResult({
-    uiDumpXml: '<node package="sh.paseo.debug" resource-id="open-project-submit" text="Add a project" />',
+    uiDumpXml:
+      '<node package="sh.paseo.debug" resource-id="open-project-submit" text="Add a project" />',
     logcatText: "",
     launchOutput: "Starting: Intent { ... }",
     successText: "Welcome to Paseo",
@@ -235,7 +236,8 @@ test("classifyPairingResult requires workspace UI instead of the welcome screen"
 
 test("classifyPairingResult accepts host root UI after importing pairing link", () => {
   const result = classifyPairingResult({
-    uiDumpXml: '<node package="sh.paseo.debug" resource-id="open-project-submit" text="Add a project" />',
+    uiDumpXml:
+      '<node package="sh.paseo.debug" resource-id="open-project-submit" text="Add a project" />',
     logcatText: "",
     launchOutput: "Starting: Intent { ... }",
     successText: "Welcome to Paseo",
@@ -259,13 +261,15 @@ test("classifyPairingResult does not treat delivered-to-top-instance warnings as
 });
 
 test("findPermissionDialogAllowButton picks right-most allow button from MIUI prompt", () => {
-  const button = findPermissionDialogAllowButton([
-    "<hierarchy>",
-    '<node package="com.lbe.security.miui" text="允许“Paseo Debug”发送通知？" />',
-    '<node package="com.lbe.security.miui" class="android.widget.Button" clickable="true" enabled="true" bounds="[131,2887][698,3070]" text="拒绝" />',
-    '<node package="com.lbe.security.miui" class="android.widget.Button" clickable="true" enabled="true" bounds="[741,2887][1308,3070]" text="始终允许" />',
-    "</hierarchy>",
-  ].join(""));
+  const button = findPermissionDialogAllowButton(
+    [
+      "<hierarchy>",
+      '<node package="com.lbe.security.miui" text="允许“Paseo Debug”发送通知？" />',
+      '<node package="com.lbe.security.miui" class="android.widget.Button" clickable="true" enabled="true" bounds="[131,2887][698,3070]" text="拒绝" />',
+      '<node package="com.lbe.security.miui" class="android.widget.Button" clickable="true" enabled="true" bounds="[741,2887][1308,3070]" text="始终允许" />',
+      "</hierarchy>",
+    ].join(""),
+  );
 
   assert.deepEqual(button, {
     packageName: "com.lbe.security.miui",

--- a/packages/app/scripts/windows-dev-client-validation.node-test.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.node-test.cjs
@@ -5,14 +5,18 @@ const path = require("node:path");
 const os = require("node:os");
 
 const {
+  assertSupportedPlatform,
   buildSpawnInvocation,
   buildConfig,
   buildDeepLinkUrl,
+  buildPairingImportUrl,
   buildExpoEnv,
   rewriteExpoManifestResponse,
   buildUpstreamRequestHeaders,
   classifyValidationResult,
+  classifyPairingResult,
   deriveValidationOutcome,
+  findPermissionDialogAllowButton,
   parseArgs,
   shouldEndUpstreamImmediately,
   spawnCapture,
@@ -93,6 +97,21 @@ test("parseArgs accepts request capture and retry flags", () => {
   assert.equal(args.retryOnTimeout, true);
 });
 
+test("parseArgs accepts pairing import options", () => {
+  const args = parseArgs([
+    "--pairing-offer-url",
+    "https://app.paseo.sh/#offer=abc123",
+    "--pairing-scheme",
+    "paseo-debug",
+    "--pairing-wait-ms",
+    "9000",
+  ]);
+
+  assert.equal(args.pairingOfferUrl, "https://app.paseo.sh/#offer=abc123");
+  assert.equal(args.pairingScheme, "paseo-debug");
+  assert.equal(args.pairingWaitMs, 9000);
+});
+
 test("classifyValidationResult detects successful app boot from the UI dump", () => {
   const result = classifyValidationResult({
     uiDumpXml: '<node text="Welcome to Paseo" />',
@@ -149,6 +168,18 @@ test("classifyValidationResult detects a usable workspace UI without relying on 
   assert.equal(result.reason, "workspace_ui_visible");
 });
 
+test("classifyValidationResult accepts host root UI as a successful app boot", () => {
+  const result = classifyValidationResult({
+    uiDumpXml: '<node package="sh.paseo.debug" resource-id="open-project-submit" text="Add a project" />',
+    logcatText: "",
+    launchOutput: "Starting: Intent { ... }",
+    successText: "Welcome to Paseo",
+  });
+
+  assert.equal(result.status, "app_loaded");
+  assert.equal(result.reason, "host_ui_visible");
+});
+
 test("classifyValidationResult prefers visible workspace UI over timeout-only logcat noise", () => {
   const result = classifyValidationResult({
     uiDumpXml: [
@@ -180,6 +211,69 @@ test("classifyValidationResult ignores unrelated logcat timeouts when the app UI
   assert.equal(result.reason, "no_success_or_failure_signature");
 });
 
+test("buildPairingImportUrl rewrites the offer fragment onto the app scheme", () => {
+  assert.equal(
+    buildPairingImportUrl({
+      pairingOfferUrl: "https://app.paseo.sh/#offer=abc123",
+      pairingScheme: "paseo",
+    }),
+    "paseo:///#offer=abc123",
+  );
+});
+
+test("classifyPairingResult requires workspace UI instead of the welcome screen", () => {
+  const result = classifyPairingResult({
+    uiDumpXml: '<node text="Welcome to Paseo" />',
+    logcatText: "",
+    launchOutput: "Starting: Intent { ... }",
+    successText: "Welcome to Paseo",
+  });
+
+  assert.equal(result.status, "pairing_failed");
+  assert.equal(result.reason, "still_on_welcome_screen");
+});
+
+test("classifyPairingResult accepts host root UI after importing pairing link", () => {
+  const result = classifyPairingResult({
+    uiDumpXml: '<node package="sh.paseo.debug" resource-id="open-project-submit" text="Add a project" />',
+    logcatText: "",
+    launchOutput: "Starting: Intent { ... }",
+    successText: "Welcome to Paseo",
+  });
+
+  assert.equal(result.status, "paired_host_loaded");
+  assert.equal(result.reason, "host_ui_visible_after_pairing");
+});
+
+test("classifyPairingResult does not treat delivered-to-top-instance warnings as adb launch errors", () => {
+  const result = classifyPairingResult({
+    uiDumpXml: "",
+    logcatText: "",
+    launchOutput:
+      "Warning: Activity not started, intent has been delivered to currently running top-most instance.\nComplete\n",
+    successText: "Welcome to Paseo",
+  });
+
+  assert.equal(result.status, "pairing_failed");
+  assert.equal(result.reason, "workspace_ui_not_visible_after_pairing");
+});
+
+test("findPermissionDialogAllowButton picks right-most allow button from MIUI prompt", () => {
+  const button = findPermissionDialogAllowButton([
+    "<hierarchy>",
+    '<node package="com.lbe.security.miui" text="允许“Paseo Debug”发送通知？" />',
+    '<node package="com.lbe.security.miui" class="android.widget.Button" clickable="true" enabled="true" bounds="[131,2887][698,3070]" text="拒绝" />',
+    '<node package="com.lbe.security.miui" class="android.widget.Button" clickable="true" enabled="true" bounds="[741,2887][1308,3070]" text="始终允许" />',
+    "</hierarchy>",
+  ].join(""));
+
+  assert.deepEqual(button, {
+    packageName: "com.lbe.security.miui",
+    x: 1025,
+    y: 2979,
+  });
+});
+
 test("buildSpawnInvocation routes npm.cmd through cmd.exe on Windows", () => {
   assert.deepEqual(buildSpawnInvocation("npm", ["run", "build:workspace-deps"], "win32"), {
     command: "cmd.exe",
@@ -192,6 +286,10 @@ test("buildSpawnInvocation leaves adb untouched on Windows", () => {
     command: "adb",
     args: ["devices"],
   });
+});
+
+test("assertSupportedPlatform allows Linux validation host", () => {
+  assert.doesNotThrow(() => assertSupportedPlatform("linux"));
 });
 
 test("spawnCapture rejects when a command exceeds timeoutMs", async () => {
@@ -493,6 +591,236 @@ test("runValidation force-stops the dev client before launching and retrying", a
     assert.notEqual(retryForceStopIndex, -1);
     assert.ok(initialForceStopIndex < initialLaunchIndex);
     assert.ok(retryForceStopIndex < retryLaunchIndex);
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test("runValidation imports the pairing offer after app boot and waits for workspace UI", async () => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "paseo-validation-pairing-"));
+  const config = buildConfig(
+    {
+      port: 8111,
+      host: "lan",
+      launchHost: "127.0.0.1",
+      deviceId: "f66d9150",
+      appId: "sh.paseo.debug",
+      scheme: "exp+voice-mobile",
+      outputDir,
+      waitMs: 1,
+      startupTimeoutMs: 1000,
+      successText: "Welcome to Paseo",
+      envOverrides: {},
+      keepProxyEnv: false,
+      buildWorkspaceDeps: false,
+      adbReverse: false,
+      captureScreenshot: false,
+      captureUiDump: false,
+      clearLogcat: false,
+      help: false,
+      captureFirstRequest: false,
+      retryOnTimeout: false,
+      pairingOfferUrl: "https://app.paseo.sh/#offer=abc123",
+      pairingScheme: "paseo",
+      pairingWaitMs: 1,
+    },
+    {
+      repoRoot: "/repo",
+      appDir: "/repo/packages/app",
+      baseEnv: {},
+    },
+  );
+  const spawnInvocations = [];
+  let captureCount = 0;
+
+  try {
+    const summary = await runValidation(config, {
+      spawnCapture: async (command, args) => {
+        spawnInvocations.push({ command, args });
+
+        if (command === "adb" && args[0] === "devices") {
+          return { stdout: "List of devices attached\nf66d9150\tdevice\n", stderr: "" };
+        }
+
+        if (command === "adb" && args.includes("force-stop")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        if (command === "adb" && args.includes("start")) {
+          return { stdout: "Starting: Intent { ... }\nComplete\n", stderr: "" };
+        }
+
+        throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+      },
+      startRequestCaptureProxy: () => null,
+      startExpoProcess: () => ({
+        child: { exitCode: null },
+        getOutput: () => "Waiting on http://localhost:8111",
+        stop: async () => {},
+      }),
+      waitForExpoReady: async () => {},
+      captureDeviceState: async () => {
+        captureCount += 1;
+        if (captureCount === 1) {
+          return {
+            uiDumpXml: '<node text="Welcome to Paseo" />',
+            logcatText: "",
+          };
+        }
+
+        return {
+          uiDumpXml: [
+            "<hierarchy>",
+            '<node package="sh.paseo.debug" resource-id="workspace-header-title" text="codex_device_pair_test" />',
+            '<node package="sh.paseo.debug" resource-id="message-input-root" text="" />',
+            '<node package="sh.paseo.debug" resource-id="workspace-tabs-row" text="" />',
+            "</hierarchy>",
+          ].join(""),
+          logcatText: "",
+        };
+      },
+    });
+
+    assert.equal(summary.status, "paired_workspace_loaded");
+    assert.equal(summary.reason, "workspace_ui_visible_after_pairing");
+
+    const appLaunchIndex = spawnInvocations.findIndex(
+      (invocation) =>
+        invocation.command === "adb" &&
+        invocation.args.includes("start") &&
+        invocation.args.includes(config.deepLinkUrl),
+    );
+    const pairingLaunchIndex = spawnInvocations.findIndex(
+      (invocation) =>
+        invocation.command === "adb" &&
+        invocation.args.includes("start") &&
+        invocation.args.includes("paseo:///#offer=abc123"),
+    );
+
+    assert.notEqual(appLaunchIndex, -1);
+    assert.notEqual(pairingLaunchIndex, -1);
+    assert.ok(pairingLaunchIndex > appLaunchIndex);
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test("runValidation dismisses permission dialog during pairing before classifying workspace UI", async () => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "paseo-dev-client-validation-"));
+  const config = buildConfig(
+    {
+      port: 8112,
+      host: "localhost",
+      launchHost: "127.0.0.1",
+      deviceId: "f66d9150",
+      appId: "sh.paseo.debug",
+      scheme: "exp+voice-mobile",
+      outputDir,
+      waitMs: 1,
+      startupTimeoutMs: 10,
+      successText: "Welcome to Paseo",
+      envOverrides: {},
+      keepProxyEnv: false,
+      buildWorkspaceDeps: false,
+      adbReverse: false,
+      captureScreenshot: false,
+      captureUiDump: false,
+      clearLogcat: false,
+      help: false,
+      captureFirstRequest: false,
+      retryOnTimeout: false,
+      pairingOfferUrl: "https://app.paseo.sh/#offer=abc123",
+      pairingScheme: "paseo",
+      pairingWaitMs: 1,
+    },
+    {
+      repoRoot: "/repo",
+      appDir: "/repo/packages/app",
+      baseEnv: {},
+    },
+  );
+  const spawnInvocations = [];
+  let captureCount = 0;
+
+  try {
+    const summary = await runValidation(config, {
+      spawnCapture: async (command, args) => {
+        spawnInvocations.push({ command, args });
+
+        if (command === "adb" && args[0] === "devices") {
+          return { stdout: "List of devices attached\nf66d9150\tdevice\n", stderr: "" };
+        }
+
+        if (command === "adb" && args.includes("force-stop")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        if (command === "adb" && args.includes("start")) {
+          return {
+            stdout:
+              "Warning: Activity not started, intent has been delivered to currently running top-most instance.\nComplete\n",
+            stderr: "",
+          };
+        }
+
+        if (command === "adb" && args.includes("input") && args.includes("tap")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+      },
+      startRequestCaptureProxy: () => null,
+      startExpoProcess: () => ({
+        child: { exitCode: null },
+        getOutput: () => "Waiting on http://localhost:8112",
+        stop: async () => {},
+      }),
+      waitForExpoReady: async () => {},
+      captureDeviceState: async () => {
+        captureCount += 1;
+        if (captureCount === 1) {
+          return {
+            uiDumpXml: '<node text="Welcome to Paseo" />',
+            logcatText: "",
+          };
+        }
+
+        if (captureCount === 2) {
+          return {
+            uiDumpXml: [
+              "<hierarchy>",
+              '<node package="com.lbe.security.miui" text="允许“Paseo Debug”发送通知？" />',
+              '<node package="com.lbe.security.miui" class="android.widget.Button" clickable="true" enabled="true" bounds="[131,2887][698,3070]" text="拒绝" />',
+              '<node package="com.lbe.security.miui" class="android.widget.Button" clickable="true" enabled="true" bounds="[741,2887][1308,3070]" text="始终允许" />',
+              "</hierarchy>",
+            ].join(""),
+            logcatText: "",
+          };
+        }
+
+        return {
+          uiDumpXml: [
+            "<hierarchy>",
+            '<node package="sh.paseo.debug" resource-id="workspace-header-title" text="codex_device_pair_test" />',
+            '<node package="sh.paseo.debug" resource-id="message-input-root" text="" />',
+            '<node package="sh.paseo.debug" resource-id="workspace-tabs-row" text="" />',
+            "</hierarchy>",
+          ].join(""),
+          logcatText: "",
+        };
+      },
+    });
+
+    assert.equal(summary.status, "paired_workspace_loaded");
+    assert.equal(summary.reason, "workspace_ui_visible_after_pairing");
+    assert.equal(captureCount, 3);
+    assert.ok(
+      spawnInvocations.some(
+        (invocation) =>
+          invocation.command === "adb" &&
+          invocation.args.join(" ") === "-s f66d9150 shell input tap 1025 2979",
+      ),
+    );
   } finally {
     fs.rmSync(outputDir, { recursive: true, force: true });
   }

--- a/packages/app/scripts/windows-dev-client-validation.node-test.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.node-test.cjs
@@ -1,5 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const path = require("node:path");
 const os = require("node:os");
 
@@ -14,7 +15,9 @@ const {
   deriveValidationOutcome,
   parseArgs,
   shouldEndUpstreamImmediately,
+  spawnCapture,
   waitForExpoReady,
+  runValidation,
 } = require("./windows-dev-client-validation.cjs");
 
 test("buildDeepLinkUrl encodes the localhost launch target for Expo dev client", () => {
@@ -191,6 +194,22 @@ test("buildSpawnInvocation leaves adb untouched on Windows", () => {
   });
 });
 
+test("spawnCapture rejects when a command exceeds timeoutMs", async () => {
+  await assert.rejects(
+    () =>
+      spawnCapture(process.execPath, ["-e", "setTimeout(() => {}, 1000)"], {
+        timeoutMs: 50,
+      }),
+    (error) => {
+      assert.equal(error.timedOut, true);
+      assert.equal(error.command, process.execPath);
+      assert.equal(error.timeoutMs, 50);
+      assert.match(error.message, /timed out after 50ms/);
+      return true;
+    },
+  );
+});
+
 test("buildConfig offsets Metro to a private upstream port when request capture is enabled", () => {
   const config = buildConfig(
     {
@@ -229,6 +248,141 @@ test("buildConfig offsets Metro to a private upstream port when request capture 
   );
   assert.match(config.artifactPaths.requestCapture, /request-capture\.json$/);
   assert.match(config.artifactPaths.requestReplay, /request-replay\.json$/);
+});
+
+test("runValidation records a completed timeout summary when adb enumeration hangs", async () => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "paseo-validation-timeout-"));
+  const config = buildConfig(
+    {
+      port: 8108,
+      host: "lan",
+      launchHost: "127.0.0.1",
+      deviceId: "f66d9150",
+      appId: "sh.paseo.debug",
+      scheme: "exp+voice-mobile",
+      outputDir,
+      waitMs: 1,
+      startupTimeoutMs: 1000,
+      successText: "Welcome to Paseo",
+      envOverrides: {},
+      keepProxyEnv: false,
+      buildWorkspaceDeps: false,
+      adbReverse: false,
+      captureScreenshot: false,
+      captureUiDump: false,
+      clearLogcat: false,
+      help: false,
+      captureFirstRequest: false,
+      retryOnTimeout: false,
+    },
+    {
+      repoRoot: "/repo",
+      appDir: "/repo/packages/app",
+      baseEnv: {},
+    },
+  );
+  const timeoutError = new Error("adb devices timed out after 25ms");
+  timeoutError.timedOut = true;
+  timeoutError.command = "adb";
+  timeoutError.args = ["devices"];
+  timeoutError.timeoutMs = 25;
+
+  try {
+    const summary = await runValidation(config, {
+      spawnCapture: async (command, args) => {
+        assert.equal(command, "adb");
+        assert.deepEqual(args, ["devices"]);
+        throw timeoutError;
+      },
+      startRequestCaptureProxy: () => {
+        throw new Error("request capture should not start before adb devices succeeds");
+      },
+      startExpoProcess: () => {
+        throw new Error("Expo should not start before adb devices succeeds");
+      },
+    });
+
+    assert.equal(summary.phase, "completed");
+    assert.equal(summary.status, "command_timeout");
+    assert.equal(summary.reason, "adb_devices_timeout");
+    assert.equal(summary.failedPhase, "adb_devices");
+    assert.deepEqual(summary.timedOutCommand, {
+      command: "adb",
+      args: ["devices"],
+      timeoutMs: 25,
+    });
+
+    const writtenSummary = JSON.parse(
+      fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"),
+    );
+    assert.equal(writtenSummary.phase, "completed");
+    assert.equal(writtenSummary.status, "command_timeout");
+    assert.equal(writtenSummary.reason, "adb_devices_timeout");
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test("runValidation persists failing adb devices output for later inspection", async () => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "paseo-validation-adb-failure-"));
+  const config = buildConfig(
+    {
+      port: 8109,
+      host: "lan",
+      launchHost: "127.0.0.1",
+      deviceId: "f66d9150",
+      appId: "sh.paseo.debug",
+      scheme: "exp+voice-mobile",
+      outputDir,
+      waitMs: 1,
+      startupTimeoutMs: 1000,
+      successText: "Welcome to Paseo",
+      envOverrides: {},
+      keepProxyEnv: false,
+      buildWorkspaceDeps: false,
+      adbReverse: false,
+      captureScreenshot: false,
+      captureUiDump: false,
+      clearLogcat: false,
+      help: false,
+      captureFirstRequest: false,
+      retryOnTimeout: false,
+    },
+    {
+      repoRoot: "/repo",
+      appDir: "/repo/packages/app",
+      baseEnv: {},
+    },
+  );
+  const exitError = new Error("adb devices exited with code 1\nadb server version mismatch");
+  exitError.command = "adb";
+  exitError.args = ["devices"];
+  exitError.commandExitCode = 1;
+  exitError.stdout = "List of devices attached\n";
+  exitError.stderr = "adb server version mismatch\n";
+
+  try {
+    const summary = await runValidation(config, {
+      spawnCapture: async () => {
+        throw exitError;
+      },
+    });
+
+    assert.equal(summary.status, "validation_failed");
+    assert.equal(summary.reason, "adb_devices_failed");
+    assert.deepEqual(summary.failedCommand, {
+      command: "adb",
+      args: ["devices"],
+      exitCode: 1,
+      timeoutMs: null,
+    });
+    assert.equal(
+      fs.readFileSync(path.join(outputDir, "adb-devices.txt"), "utf8"),
+      "List of devices attached\nadb server version mismatch\n",
+    );
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
 });
 
 test("buildUpstreamRequestHeaders rewrites host to Metro and strips hop-by-hop headers", () => {

--- a/packages/app/scripts/windows-dev-client-validation.test.cjs
+++ b/packages/app/scripts/windows-dev-client-validation.test.cjs
@@ -1,0 +1,497 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const os = require("node:os");
+
+const {
+  buildSpawnInvocation,
+  buildConfig,
+  buildDeepLinkUrl,
+  buildExpoEnv,
+  rewriteExpoManifestResponse,
+  buildUpstreamRequestHeaders,
+  classifyValidationResult,
+  deriveValidationOutcome,
+  parseArgs,
+  shouldEndUpstreamImmediately,
+  waitForExpoReady,
+} = require("./windows-dev-client-validation.cjs");
+
+test("buildDeepLinkUrl encodes the localhost launch target for Expo dev client", () => {
+  assert.equal(
+    buildDeepLinkUrl({
+      scheme: "exp+voice-mobile",
+      launchHost: "127.0.0.1",
+      port: 8097,
+    }),
+    "exp+voice-mobile://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A8097",
+  );
+});
+
+test("buildExpoEnv clears proxy variables and extends NO_PROXY for localhost", () => {
+  const env = buildExpoEnv(
+    {
+      HTTP_PROXY: "http://proxy.example.test:8080",
+      HTTPS_PROXY: "http://proxy.example.test:8080",
+      ALL_PROXY: "socks5://proxy.example.test:1080",
+      NO_PROXY: "example.test",
+      Path: "C:\\Windows\\System32",
+    },
+    {
+      keepProxyEnv: false,
+      envOverrides: {
+        EXPO_NO_METRO_WORKSPACE_ROOT: "1",
+      },
+    },
+  );
+
+  assert.equal(env.HTTP_PROXY, undefined);
+  assert.equal(env.HTTPS_PROXY, undefined);
+  assert.equal(env.ALL_PROXY, undefined);
+  assert.equal(env.EXPO_NO_METRO_WORKSPACE_ROOT, "1");
+  assert.equal(env.Path, "C:\\Windows\\System32");
+  assert.match(env.NO_PROXY, /(^|,)example\.test(,|$)/);
+  assert.match(env.NO_PROXY, /(^|,)localhost(,|$)/);
+  assert.match(env.NO_PROXY, /(^|,)127\.0\.0\.1(,|$)/);
+});
+
+test("parseArgs accepts repeated env overrides and skip flags", () => {
+  const args = parseArgs([
+    "--port",
+    "8098",
+    "--host",
+    "localhost",
+    "--device-id",
+    "f66d9150",
+    "--env",
+    "EXPO_NO_METRO_WORKSPACE_ROOT=1",
+    "--env",
+    "EXPO_USE_FAST_RESOLVER=0",
+    "--skip-build-workspace-deps",
+    "--skip-ui-dump",
+  ]);
+
+  assert.equal(args.port, 8098);
+  assert.equal(args.host, "localhost");
+  assert.equal(args.deviceId, "f66d9150");
+  assert.equal(args.buildWorkspaceDeps, false);
+  assert.equal(args.captureUiDump, false);
+  assert.deepEqual(args.envOverrides, {
+    EXPO_NO_METRO_WORKSPACE_ROOT: "1",
+    EXPO_USE_FAST_RESOLVER: "0",
+  });
+});
+
+test("parseArgs accepts request capture and retry flags", () => {
+  const args = parseArgs([
+    "--port",
+    "8104",
+    "--capture-first-request",
+    "--retry-on-timeout",
+  ]);
+
+  assert.equal(args.port, 8104);
+  assert.equal(args.captureFirstRequest, true);
+  assert.equal(args.retryOnTimeout, true);
+});
+
+test("classifyValidationResult detects successful app boot from the UI dump", () => {
+  const result = classifyValidationResult({
+    uiDumpXml: '<node text="Welcome to Paseo" />',
+    logcatText: "",
+    launchOutput: "Starting: Intent { ... }",
+    successText: "Welcome to Paseo",
+  });
+
+  assert.equal(result.status, "app_loaded");
+  assert.equal(result.reason, "success_text_visible");
+});
+
+test("classifyValidationResult detects Android read timeouts from logcat", () => {
+  const result = classifyValidationResult({
+    uiDumpXml: '<node text="Loading..." />',
+    logcatText:
+      "sh.paseo.debug expo.modules.devlauncher.launcher.errors.DevLauncherErrorActivity java.net.SocketTimeoutException: Read timed out\nCaused by: java.net.SocketTimeoutException: timeout",
+    launchOutput: "Starting: Intent { ... }",
+    successText: "Welcome to Paseo",
+  });
+
+  assert.equal(result.status, "dev_client_read_timeout");
+  assert.equal(result.reason, "logcat_socket_timeout");
+});
+
+test("classifyValidationResult prefers the Expo error page text from the UI dump", () => {
+  const result = classifyValidationResult({
+    uiDumpXml:
+      '<node text="There was a problem loading the project." /><node text="java.net.SocketTimeoutException: timeout" />',
+    logcatText: "",
+    launchOutput: "Starting: Intent { ... }",
+    successText: "Welcome to Paseo",
+  });
+
+  assert.equal(result.status, "dev_client_read_timeout");
+  assert.equal(result.reason, "ui_dump_socket_timeout");
+});
+
+test("classifyValidationResult detects a usable workspace UI without relying on welcome copy", () => {
+  const result = classifyValidationResult({
+    uiDumpXml: [
+      "<hierarchy>",
+      '<node package="sh.paseo.debug" resource-id="workspace-header-title" text="codex_device_reopen_test" />',
+      '<node package="sh.paseo.debug" resource-id="message-input-root" text="" />',
+      '<node package="sh.paseo.debug" resource-id="agent-chat-scroll" text="" />',
+      "</hierarchy>",
+    ].join(""),
+    logcatText: "",
+    launchOutput: "Starting: Intent { ... }",
+    successText: "Welcome to Paseo",
+  });
+
+  assert.equal(result.status, "app_loaded");
+  assert.equal(result.reason, "workspace_ui_visible");
+});
+
+test("classifyValidationResult prefers visible workspace UI over timeout-only logcat noise", () => {
+  const result = classifyValidationResult({
+    uiDumpXml: [
+      "<hierarchy>",
+      '<node package="sh.paseo.debug" resource-id="workspace-header-title" text="codex_device_reopen_test" />',
+      '<node package="sh.paseo.debug" resource-id="message-input-root" text="" />',
+      "</hierarchy>",
+    ].join(""),
+    logcatText:
+      "sh.paseo.debug expo.modules.devlauncher.launcher.errors.DevLauncherErrorActivity java.net.SocketTimeoutException: Read timed out",
+    launchOutput: "Starting: Intent { ... }",
+    successText: "Welcome to Paseo",
+  });
+
+  assert.equal(result.status, "app_loaded");
+  assert.equal(result.reason, "workspace_ui_visible");
+});
+
+test("classifyValidationResult ignores unrelated logcat timeouts when the app UI is inconclusive", () => {
+  const result = classifyValidationResult({
+    uiDumpXml: '<node text="Loading..." />',
+    logcatText:
+      "Play services background sync failed with java.net.SocketTimeoutException: failed to connect to play.googleapis.com",
+    launchOutput: "Starting: Intent { ... }",
+    successText: "Welcome to Paseo",
+  });
+
+  assert.equal(result.status, "unknown");
+  assert.equal(result.reason, "no_success_or_failure_signature");
+});
+
+test("buildSpawnInvocation routes npm.cmd through cmd.exe on Windows", () => {
+  assert.deepEqual(
+    buildSpawnInvocation("npm", ["run", "build:workspace-deps"], "win32"),
+    {
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", "npm.cmd", "run", "build:workspace-deps"],
+    },
+  );
+});
+
+test("buildSpawnInvocation leaves adb untouched on Windows", () => {
+  assert.deepEqual(buildSpawnInvocation("adb", ["devices"], "win32"), {
+    command: "adb",
+    args: ["devices"],
+  });
+});
+
+test("buildConfig offsets Metro to a private upstream port when request capture is enabled", () => {
+  const config = buildConfig(
+    {
+      port: 8104,
+      host: "lan",
+      launchHost: "127.0.0.1",
+      deviceId: null,
+      appId: "sh.paseo.debug",
+      scheme: "exp+voice-mobile",
+      outputDir: "/tmp/out",
+      waitMs: 15000,
+      startupTimeoutMs: 120000,
+      successText: "Welcome to Paseo",
+      envOverrides: {},
+      keepProxyEnv: false,
+      buildWorkspaceDeps: true,
+      adbReverse: true,
+      captureScreenshot: true,
+      captureUiDump: true,
+      clearLogcat: true,
+      captureFirstRequest: true,
+      retryOnTimeout: false,
+      help: false,
+    },
+    {
+      repoRoot: "/repo",
+      baseEnv: {},
+    },
+  );
+
+  assert.equal(config.publicPort, 8104);
+  assert.equal(config.metroPort, 8105);
+  assert.equal(
+    config.deepLinkUrl,
+    "exp+voice-mobile://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A8104",
+  );
+  assert.match(config.artifactPaths.requestCapture, /request-capture\.json$/);
+  assert.match(config.artifactPaths.requestReplay, /request-replay\.json$/);
+});
+
+test("buildUpstreamRequestHeaders rewrites host to Metro and strips hop-by-hop headers", () => {
+  assert.deepEqual(
+    buildUpstreamRequestHeaders(
+      {
+        host: "127.0.0.1:8106",
+        connection: "Keep-Alive",
+        "proxy-connection": "keep-alive",
+        "keep-alive": "timeout=4",
+        "transfer-encoding": "chunked",
+        "content-length": "0",
+        "expo-platform": "android",
+        accept: "application/expo+json,application/json",
+        "expo-dev-client-id": "cebcd768-706b-416a-9b8e-22c85b93d7f1",
+        "user-agent": "okhttp/4.12.0",
+      },
+      {
+        publicPort: 8106,
+        metroPort: 8107,
+      },
+    ),
+    {
+      host: "127.0.0.1:8107",
+      "expo-platform": "android",
+      accept: "application/expo+json,application/json",
+      "expo-dev-client-id": "cebcd768-706b-416a-9b8e-22c85b93d7f1",
+      "user-agent": "okhttp/4.12.0",
+    },
+  );
+});
+
+test("rewriteExpoManifestResponse rewrites expo+json payload URLs back to the public proxy port", () => {
+  const response = rewriteExpoManifestResponse(
+    {
+      "content-type": "application/expo+json",
+      "content-length": "99",
+    },
+    JSON.stringify({
+      launchAsset: {
+        url: "http://127.0.0.1:8119/packages/app/index.ts.bundle?platform=android",
+      },
+      extra: {
+        expoClient: {
+          hostUri: "127.0.0.1:8119",
+          iconUrl: "http://127.0.0.1:8119/assets/icon.png",
+        },
+      },
+    }),
+    {
+      publicPort: 8118,
+      metroPort: 8119,
+    },
+  );
+
+  assert.equal(response.rewritten, true);
+  assert.match(response.bodyText, /127\.0\.0\.1:8118/);
+  assert.doesNotMatch(response.bodyText, /127\.0\.0\.1:8119/);
+  assert.equal(Number(response.headers["content-length"]), Buffer.byteLength(response.bodyText));
+});
+
+test("rewriteExpoManifestResponse rewrites multipart Expo manifests back to the public proxy port", () => {
+  const bodyText = [
+    "--formdata-123",
+    'Content-Disposition: form-data; name="manifest"',
+    "Content-Type: application/json",
+    "",
+    '{"launchAsset":{"url":"http://127.0.0.1:8119/packages/app/index.ts.bundle?platform=android"},"extra":{"expoClient":{"hostUri":"127.0.0.1:8119"}}}',
+    "--formdata-123--",
+    "",
+  ].join("\r\n");
+  const response = rewriteExpoManifestResponse(
+    {
+      "content-type": "multipart/mixed; boundary=formdata-123",
+      "content-length": String(Buffer.byteLength(bodyText)),
+    },
+    bodyText,
+    {
+      publicPort: 8118,
+      metroPort: 8119,
+    },
+  );
+
+  assert.equal(response.rewritten, true);
+  assert.match(response.bodyText, /127\.0\.0\.1:8118/);
+  assert.doesNotMatch(response.bodyText, /127\.0\.0\.1:8119/);
+  assert.equal(Number(response.headers["content-length"]), Buffer.byteLength(response.bodyText));
+});
+
+test("shouldEndUpstreamImmediately treats HEAD without request-body headers as bodyless", () => {
+  assert.equal(
+    shouldEndUpstreamImmediately({
+      method: "HEAD",
+      headers: {
+        host: "127.0.0.1:8108",
+        connection: "Keep-Alive",
+      },
+    }),
+    true,
+  );
+});
+
+test("shouldEndUpstreamImmediately keeps POST with content-length on the buffered path", () => {
+  assert.equal(
+    shouldEndUpstreamImmediately({
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:8108",
+        "content-length": "42",
+      },
+    }),
+    false,
+  );
+});
+
+test("waitForExpoReady keeps probing until the dev-client manifest probe succeeds", async () => {
+  const probeCalls = [];
+  let writePayload = null;
+  const config = {
+    metroPort: 8111,
+    startupTimeoutMs: 1000,
+    artifactPaths: {
+      expoProbe: path.join(os.tmpdir(), "windows-dev-client-validation-ready-probe.json"),
+    },
+  };
+  const expoProcess = {
+    child: { exitCode: null },
+    getOutput() {
+      return "Waiting on http://localhost:8111\nLogs for your project will appear below.";
+    },
+  };
+
+  const result = await waitForExpoReady(config, expoProcess, {
+    now: (() => {
+      let tick = 0;
+      return () => tick++;
+    })(),
+    sleep: async () => {},
+    writeJson(payloadPath, payload) {
+      assert.equal(payloadPath, config.artifactPaths.expoProbe);
+      writePayload = payload;
+    },
+    probe(requestOptions) {
+      probeCalls.push(requestOptions);
+      if (requestOptions.url.endsWith("/status")) {
+        return Promise.resolve({
+          ok: true,
+          statusCode: 200,
+          headers: {},
+          bodyPreview: "packager-status:running",
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        statusCode: 200,
+        headers: {
+          "content-type": "application/expo+json",
+        },
+        bodyPreview: "",
+      });
+    },
+  });
+
+  assert.equal(result.statusCode, 200);
+  assert.equal(result.headers["content-type"], "application/expo+json");
+  assert.equal(probeCalls.length, 2);
+  assert.match(probeCalls[0].url, /\/status$/);
+  assert.equal(probeCalls[0].headers, undefined);
+  assert.equal(probeCalls[1].headers.accept, "application/expo+json,application/json");
+  assert.equal(probeCalls[1].headers["expo-dev-client-id"], undefined);
+  assert.equal(writePayload.statusCode, 200);
+  assert.equal(writePayload.headers["content-type"], "application/expo+json");
+  assert.equal(writePayload.probeType, "dev_client_manifest");
+});
+
+test("waitForExpoReady keeps warming after Metro status until the manifest probe succeeds", async () => {
+  const probeCalls = [];
+  const writePayloads = [];
+  const config = {
+    metroPort: 8123,
+    startupTimeoutMs: 5000,
+    artifactPaths: {
+      expoProbe: path.join(os.tmpdir(), "windows-dev-client-validation-status-probe.json"),
+    },
+  };
+  const expoProcess = {
+    child: { exitCode: null },
+    getOutput() {
+      return "Waiting on http://localhost:8123\nLogs for your project will appear below.";
+    },
+  };
+
+  const result = await waitForExpoReady(config, expoProcess, {
+    now: (() => {
+      let tick = 0;
+      return () => (tick += 100);
+    })(),
+    sleep: async () => {},
+    writeJson(payloadPath, payload) {
+      assert.equal(payloadPath, config.artifactPaths.expoProbe);
+      writePayloads.push(payload);
+    },
+    async probe(requestOptions) {
+      probeCalls.push(requestOptions);
+      if (requestOptions.url.endsWith("/status")) {
+        return {
+          ok: true,
+          statusCode: 200,
+          headers: {},
+          bodyPreview: "packager-status:running",
+        };
+      }
+
+      if (probeCalls.filter((call) => call.method === "HEAD").length === 1) {
+        throw new Error("probe timeout");
+      }
+
+      return {
+        ok: true,
+        statusCode: 200,
+        headers: {
+          "content-type": "application/expo+json",
+        },
+        bodyPreview: "",
+      };
+    },
+  });
+
+  assert.equal(result.statusCode, 200);
+  assert.equal(result.headers["content-type"], "application/expo+json");
+  assert.equal(probeCalls.length, 4);
+  assert.match(probeCalls[0].url, /\/status$/);
+  assert.equal(probeCalls[1].timeoutMs, 20000);
+  assert.equal(probeCalls[3].timeoutMs, 20000);
+  assert.equal(writePayloads.length, 2);
+  assert.equal(writePayloads[0].probeType, "metro_status");
+  assert.equal(writePayloads[0].manifestProbeError, "probe timeout");
+  assert.equal(writePayloads[1].probeType, "dev_client_manifest");
+});
+
+test("deriveValidationOutcome promotes a successful retry without hiding the initial timeout", () => {
+  assert.deepEqual(
+    deriveValidationOutcome(
+      {
+        status: "dev_client_read_timeout",
+        reason: "ui_dump_socket_timeout",
+      },
+      {
+        status: "app_loaded",
+        reason: "success_text_visible",
+      },
+    ),
+    {
+      status: "app_loaded_after_retry",
+      reason: "retry_recovered_after_timeout",
+    },
+  );
+});

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -659,7 +659,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
     }
 
     const serverInfo = client.getLastServerInfoMessage();
-    if (!serverInfo?.features?.providersSnapshot) {
+    if (serverInfo?.features?.providersSnapshot === false) {
       return;
     }
 

--- a/packages/app/src/hooks/use-providers-snapshot.ts
+++ b/packages/app/src/hooks/use-providers-snapshot.ts
@@ -25,16 +25,17 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
   const queryClient = useQueryClient();
   const client = useHostRuntimeClient(serverId ?? "");
   const isConnected = useHostRuntimeIsConnected(serverId ?? "");
-  const supportsSnapshot = useSessionForServer(
+  const serverSupportsSnapshot = useSessionForServer(
     serverId,
-    (session) => session?.serverInfo?.features?.providersSnapshot === true,
+    (session) => session?.serverInfo?.features?.providersSnapshot,
   );
+  const supportsSnapshot = serverSupportsSnapshot !== false;
 
   const queryKey = useMemo(() => providersSnapshotQueryKey(serverId), [serverId]);
 
   const snapshotQuery = useQuery({
     queryKey,
-    enabled: Boolean(supportsSnapshot && serverId && client && isConnected),
+    enabled: Boolean(serverId && client && isConnected && supportsSnapshot),
     staleTime: 60_000,
     queryFn: async () => {
       if (!client) {
@@ -55,7 +56,7 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
   const { mutateAsync: refreshSnapshot, isPending: isRefreshing } = refreshMutation;
 
   useEffect(() => {
-    if (!supportsSnapshot || !client || !isConnected || !serverId) {
+    if (!client || !isConnected || !serverId || !supportsSnapshot) {
       return;
     }
 

--- a/packages/server/src/client/daemon-client.test.ts
+++ b/packages/server/src/client/daemon-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, expectTypeOf, test, vi } from "vitest";
 import { DaemonClient, type DaemonTransport } from "./daemon-client";
+import * as SharedMessages from "../shared/messages.js";
 import {
   asUint8Array,
   decodeTerminalResizePayload,
@@ -1824,6 +1825,91 @@ describe("DaemonClient", () => {
       expect(firstEntry.item.error).toBeNull();
       expect(firstEntry.item.detail.type).toBe("shell");
     }
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test("falls back to raw session handling when outbound schema parsing throws", async () => {
+    const logger = createMockLogger();
+    const mock = createMockTransport();
+
+    const client = new DaemonClient({
+      url: "ws://test",
+      clientId: "clsk_unit_test",
+      logger,
+      reconnect: { enabled: false },
+      transportFactory: () => mock.transport,
+    });
+    clients.push(client);
+
+    const connectPromise = client.connect();
+    mock.triggerOpen();
+    await connectPromise;
+
+    const received: unknown[] = [];
+    const unsubscribe = client.on("fetch_agent_timeline_response", (msg) => {
+      received.push(msg);
+    });
+
+    const safeParseSpy = vi
+      .spyOn(SharedMessages.WSOutboundMessageSchema, "safeParse")
+      .mockImplementationOnce(() => {
+        throw new TypeError("Cannot read property '_zod' of undefined");
+      });
+
+    mock.triggerMessage(
+      wrapSessionMessage({
+        type: "fetch_agent_timeline_response",
+        payload: {
+          requestId: "req-fallback",
+          agentId: "agent_cli",
+          agent: null,
+          direction: "tail",
+          projection: "projected",
+          epoch: "epoch-1",
+          reset: false,
+          staleCursor: false,
+          gap: false,
+          window: { minSeq: 1, maxSeq: 1, nextSeq: 2 },
+          startCursor: { epoch: "epoch-1", seq: 1 },
+          endCursor: { epoch: "epoch-1", seq: 1 },
+          hasOlder: false,
+          hasNewer: false,
+          entries: [
+            {
+              timestamp: "2026-02-08T20:20:00.000Z",
+              provider: "codex",
+              seqStart: 1,
+              seqEnd: 1,
+              sourceSeqRanges: [{ startSeq: 1, endSeq: 1 }],
+              collapsed: [],
+              item: {
+                type: "tool_call",
+                callId: "call_cli_fallback",
+                name: "shell",
+                status: "running",
+                detail: {
+                  type: "shell",
+                  command: "pwd",
+                },
+                error: null,
+              },
+            },
+          ],
+          error: null,
+        },
+      }),
+    );
+
+    safeParseSpy.mockRestore();
+    unsubscribe();
+
+    expect(received).toHaveLength(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msgType: "fetch_agent_timeline_response",
+      }),
+      "Message schema parse threw; falling back to raw session handling",
+    );
     expect(logger.warn).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -108,6 +108,20 @@ const consoleLogger: Logger = {
   error: (obj, msg) => console.error(msg, obj),
 };
 
+function getRawSessionMessage(
+  payload: unknown,
+): { type: string } & Record<string, unknown> | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const record = payload as { type?: unknown; message?: unknown };
+  if (record.type !== "session" || !record.message || typeof record.message !== "object") {
+    return null;
+  }
+  const message = record.message as { type?: unknown } & Record<string, unknown>;
+  return typeof message.type === "string" ? message : null;
+}
+
 export type {
   DaemonTransport,
   DaemonTransportFactory,
@@ -3609,7 +3623,30 @@ export class DaemonClient {
       return;
     }
 
-    const parsed = WSOutboundMessageSchema.safeParse(parsedJson);
+    let parsed: ReturnType<typeof WSOutboundMessageSchema.safeParse>;
+    try {
+      parsed = WSOutboundMessageSchema.safeParse(parsedJson);
+    } catch (error) {
+      const rawSessionMessage = getRawSessionMessage(parsedJson);
+      if (rawSessionMessage) {
+        this.logger.debug(
+          {
+            msgType: rawSessionMessage.type,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Message schema parse threw; falling back to raw session handling",
+        );
+        this.handleSessionMessage(rawSessionMessage as SessionOutboundMessage);
+        return;
+      }
+      this.logger.warn(
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Message schema parse threw",
+      );
+      return;
+    }
     if (!parsed.success) {
       const msgType = (parsedJson as { type?: string })?.type ?? "unknown";
       this.logger.warn({ msgType, error: parsed.error.message }, "Message validation failed");

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -110,7 +110,7 @@ const consoleLogger: Logger = {
 
 function getRawSessionMessage(
   payload: unknown,
-): { type: string } & Record<string, unknown> | null {
+): ({ type: string } & Record<string, unknown>) | null {
   if (!payload || typeof payload !== "object") {
     return null;
   }
@@ -119,7 +119,9 @@ function getRawSessionMessage(
     return null;
   }
   const message = record.message as { type?: unknown } & Record<string, unknown>;
-  return typeof message.type === "string" ? message : null;
+  return typeof message.type === "string"
+    ? ({ ...message, type: message.type } as { type: string } & Record<string, unknown>)
+    : null;
 }
 
 export type {

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -3,7 +3,8 @@ import { AGENT_LIFECYCLE_STATUSES } from "./agent-lifecycle.js";
 import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "../server/agent/agent-title-limits.js";
 import { AgentProviderSchema as ImportedAgentProviderSchema } from "../server/agent/provider-manifest.js";
 // COMPAT(rn-dev-client): Metro can evaluate this import path as undefined during circular init.
-const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ?? z.string()) as z.ZodType<string>;
+const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ??
+  z.string()) as z.ZodType<string>;
 import { TOOL_CALL_ICON_NAMES } from "../server/agent/agent-sdk-types.js";
 import {
   ChatCreateRequestSchema,

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 import { AGENT_LIFECYCLE_STATUSES } from "./agent-lifecycle.js";
 import { MAX_EXPLICIT_AGENT_TITLE_CHARS } from "../server/agent/agent-title-limits.js";
-import { AgentProviderSchema } from "../server/agent/provider-manifest.js";
+import { AgentProviderSchema as ImportedAgentProviderSchema } from "../server/agent/provider-manifest.js";
+// COMPAT(rn-dev-client): Metro can evaluate this import path as undefined during circular init.
+const AgentProviderValueSchema: z.ZodType<string> = (ImportedAgentProviderSchema ?? z.string()) as z.ZodType<string>;
 import { TOOL_CALL_ICON_NAMES } from "../server/agent/agent-sdk-types.js";
 import {
   ChatCreateRequestSchema,
@@ -139,7 +141,7 @@ export const AgentFeatureSchema = z.discriminatedUnion("type", [
 ]);
 
 const AgentModelDefinitionSchema: z.ZodType<AgentModelDefinition> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   id: z.string(),
   label: z.string(),
   description: z.string().optional(),
@@ -150,7 +152,7 @@ const AgentModelDefinitionSchema: z.ZodType<AgentModelDefinition> = z.object({
 });
 
 const ProviderSnapshotEntrySchema: z.ZodType<ProviderSnapshotEntry> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   status: ProviderStatusSchema,
   error: z.string().optional(),
   models: z.array(AgentModelDefinitionSchema).optional(),
@@ -205,7 +207,7 @@ const McpServerConfigSchema = z.discriminatedUnion("type", [
 ]);
 
 const AgentSessionConfigSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   modeId: z.string().optional(),
   model: z.string().optional(),
@@ -253,7 +255,7 @@ export const AgentPermissionResponseSchema: z.ZodType<AgentPermissionResponse> =
 
 export const AgentPermissionRequestPayloadSchema: z.ZodType<AgentPermissionRequest> = z.object({
   id: z.string(),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   name: z.string(),
   kind: z.enum(["tool", "plan", "question", "mode", "other"]),
   title: z.string().optional(),
@@ -467,48 +469,48 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("thread_started"),
     sessionId: z.string(),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
   }),
   z.object({
     type: z.literal("turn_started"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
   }),
   z.object({
     type: z.literal("turn_completed"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     usage: AgentUsageSchema.optional(),
   }),
   z.object({
     type: z.literal("turn_failed"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     error: z.string(),
     code: z.string().optional(),
     diagnostic: z.string().optional(),
   }),
   z.object({
     type: z.literal("turn_canceled"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     reason: z.string(),
   }),
   z.object({
     type: z.literal("timeline"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     item: AgentTimelineItemPayloadSchema,
   }),
   z.object({
     type: z.literal("permission_requested"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     request: AgentPermissionRequestPayloadSchema,
   }),
   z.object({
     type: z.literal("permission_resolved"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     requestId: z.string(),
     resolution: AgentPermissionResponseSchema,
   }),
   z.object({
     type: z.literal("attention_required"),
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     reason: z.enum(["finished", "error", "permission"]),
     timestamp: z.string(),
     shouldNotify: z.boolean(),
@@ -528,7 +530,7 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
 
 const AgentPersistenceHandleSchema: z.ZodType<AgentPersistenceHandle | null> = z
   .object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     sessionId: z.string(),
     nativeHandle: z.string().optional(),
     metadata: z.record(z.unknown()).optional(),
@@ -536,7 +538,7 @@ const AgentPersistenceHandleSchema: z.ZodType<AgentPersistenceHandle | null> = z
   .nullable();
 
 const AgentRuntimeInfoSchema: z.ZodType<AgentRuntimeInfo> = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   sessionId: z.string().nullable(),
   model: z.string().nullable().optional(),
   thinkingOptionId: z.string().nullable().optional(),
@@ -546,7 +548,7 @@ const AgentRuntimeInfoSchema: z.ZodType<AgentRuntimeInfo> = z.object({
 
 export const AgentSnapshotPayloadSchema = z.object({
   id: z.string(),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   model: z.string().nullable(),
   features: z.array(AgentFeatureSchema).optional(),
@@ -826,14 +828,14 @@ export const CreateAgentRequestMessageSchema = z.object({
 
 export const ListProviderModelsRequestMessageSchema = z.object({
   type: z.literal("list_provider_models_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string().optional(),
   requestId: z.string(),
 });
 
 export const ListProviderModesRequestMessageSchema = z.object({
   type: z.literal("list_provider_modes_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string().optional(),
   requestId: z.string(),
 });
@@ -858,7 +860,7 @@ export const RefreshProvidersSnapshotRequestMessageSchema = z.object({
 
 export const ProviderDiagnosticRequestMessageSchema = z.object({
   type: z.literal("provider_diagnostic_request"),
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   requestId: z.string(),
 });
 
@@ -1329,7 +1331,7 @@ export const PingMessageSchema = z.object({
 });
 
 const ListCommandsDraftConfigSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   cwd: z.string(),
   modeId: z.string().optional(),
   model: z.string().optional(),
@@ -2071,7 +2073,7 @@ const AgentTimelineSeqRangeSchema = z.object({
 });
 
 export const AgentTimelineEntryPayloadSchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   item: AgentTimelineItemPayloadSchema,
   timestamp: z.string(),
   seqStart: z.number().int().nonnegative(),
@@ -2548,7 +2550,7 @@ export const FileDownloadTokenResponseSchema = z.object({
 export const ListProviderModelsResponseMessageSchema = z.object({
   type: z.literal("list_provider_models_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     models: z.array(AgentModelDefinitionSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2559,7 +2561,7 @@ export const ListProviderModelsResponseMessageSchema = z.object({
 export const ListProviderModesResponseMessageSchema = z.object({
   type: z.literal("list_provider_modes_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     modes: z.array(AgentModeSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2570,7 +2572,7 @@ export const ListProviderModesResponseMessageSchema = z.object({
 export const ListProviderFeaturesResponseMessageSchema = z.object({
   type: z.literal("list_provider_features_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     features: z.array(AgentFeatureSchema).optional(),
     error: z.string().nullable().optional(),
     fetchedAt: z.string(),
@@ -2579,7 +2581,7 @@ export const ListProviderFeaturesResponseMessageSchema = z.object({
 });
 
 const ProviderAvailabilitySchema = z.object({
-  provider: AgentProviderSchema,
+  provider: AgentProviderValueSchema,
   available: z.boolean(),
   error: z.string().nullable().optional(),
 });
@@ -2627,7 +2629,7 @@ export const RefreshProvidersSnapshotResponseMessageSchema = z.object({
 export const ProviderDiagnosticResponseMessageSchema = z.object({
   type: z.literal("provider_diagnostic_response"),
   payload: z.object({
-    provider: AgentProviderSchema,
+    provider: AgentProviderValueSchema,
     diagnostic: z.string(),
     requestId: z.string(),
   }),

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -112,7 +112,7 @@ const AgentSelectOptionSchema = z.object({
   label: z.string(),
   description: z.string().optional(),
   isDefault: z.boolean().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const AgentFeatureToggleSchema = z.object({
@@ -147,7 +147,7 @@ const AgentModelDefinitionSchema: z.ZodType<AgentModelDefinition> = z.object({
   label: z.string(),
   description: z.string().optional(),
   isDefault: z.boolean().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   thinkingOptions: z.array(AgentSelectOptionSchema).optional(),
   defaultThinkingOptionId: z.string().optional(),
 });
@@ -186,19 +186,19 @@ const McpStdioServerConfigSchema = z.object({
   type: z.literal("stdio"),
   command: z.string(),
   args: z.array(z.string()).optional(),
-  env: z.record(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
 });
 
 const McpHttpServerConfigSchema = z.object({
   type: z.literal("http"),
   url: z.string(),
-  headers: z.record(z.string()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
 });
 
 const McpSseServerConfigSchema = z.object({
   type: z.literal("sse"),
   url: z.string(),
-  headers: z.record(z.string()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
 });
 
 const McpServerConfigSchema = z.discriminatedUnion("type", [
@@ -213,7 +213,7 @@ const AgentSessionConfigSchema = z.object({
   modeId: z.string().optional(),
   model: z.string().optional(),
   thinkingOptionId: z.string().optional(),
-  featureValues: z.record(z.unknown()).optional(),
+  featureValues: z.record(z.string(), z.unknown()).optional(),
   title: z.string().trim().min(1).max(MAX_EXPLICIT_AGENT_TITLE_CHARS).optional().nullable(),
   approvalPolicy: z.string().optional(),
   sandboxMode: z.string().optional(),
@@ -221,16 +221,16 @@ const AgentSessionConfigSchema = z.object({
   webSearch: z.boolean().optional(),
   extra: z
     .object({
-      codex: z.record(z.unknown()).optional(),
-      claude: z.record(z.unknown()).optional(),
+      codex: z.record(z.string(), z.unknown()).optional(),
+      claude: z.record(z.string(), z.unknown()).optional(),
     })
     .partial()
     .optional(),
   systemPrompt: z.string().optional(),
-  mcpServers: z.record(McpServerConfigSchema).optional(),
+  mcpServers: z.record(z.string(), McpServerConfigSchema).optional(),
 });
 
-const AgentPermissionUpdateSchema = z.record(z.unknown());
+const AgentPermissionUpdateSchema = z.record(z.string(), z.unknown());
 const AgentPermissionActionSchema = z.object({
   id: z.string(),
   label: z.string(),
@@ -243,7 +243,7 @@ export const AgentPermissionResponseSchema: z.ZodType<AgentPermissionResponse> =
   z.object({
     behavior: z.literal("allow"),
     selectedActionId: z.string().optional(),
-    updatedInput: z.record(z.unknown()).optional(),
+    updatedInput: z.record(z.string(), z.unknown()).optional(),
     updatedPermissions: z.array(AgentPermissionUpdateSchema).optional(),
   }),
   z.object({
@@ -261,11 +261,11 @@ export const AgentPermissionRequestPayloadSchema: z.ZodType<AgentPermissionReque
   kind: z.enum(["tool", "plan", "question", "mode", "other"]),
   title: z.string().optional(),
   description: z.string().optional(),
-  input: z.record(z.unknown()).optional(),
+  input: z.record(z.string(), z.unknown()).optional(),
   detail: z.lazy(() => ToolCallDetailPayloadSchema).optional(),
   suggestions: z.array(AgentPermissionUpdateSchema).optional(),
   actions: z.array(AgentPermissionActionSchema).optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 const UnknownValueSchema = z.union([
@@ -397,7 +397,7 @@ const ToolCallBasePayloadSchema = z
     callId: z.string(),
     name: z.string(),
     detail: ToolCallDetailPayloadSchema,
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -534,7 +534,7 @@ const AgentPersistenceHandleSchema: z.ZodType<AgentPersistenceHandle | null> = z
     provider: AgentProviderValueSchema,
     sessionId: z.string(),
     nativeHandle: z.string().optional(),
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .nullable();
 
@@ -544,7 +544,7 @@ const AgentRuntimeInfoSchema: z.ZodType<AgentRuntimeInfo> = z.object({
   model: z.string().nullable().optional(),
   thinkingOptionId: z.string().nullable().optional(),
   modeId: z.string().nullable().optional(),
-  extra: z.record(z.unknown()).optional(),
+  extra: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const AgentSnapshotPayloadSchema = z.object({
@@ -568,7 +568,7 @@ export const AgentSnapshotPayloadSchema = z.object({
   lastUsage: AgentUsageSchema.optional(),
   lastError: z.string().optional(),
   title: z.string().nullable(),
-  labels: z.record(z.string()).default({}),
+  labels: z.record(z.string(), z.string()).default({}),
   requiresAttention: z.boolean().optional(),
   attentionReason: z.enum(["finished", "error", "permission"]).nullable().optional(),
   attentionTimestamp: z.string().nullable().optional(),
@@ -600,7 +600,7 @@ export const AudioPlayedMessageSchema = z.object({
 });
 
 const AgentDirectoryFilterSchema = z.object({
-  labels: z.record(z.string()).optional(),
+  labels: z.record(z.string(), z.string()).optional(),
   projectKeys: z.array(z.string()).optional(),
   statuses: z.array(AgentStatusSchema).optional(),
   includeArchived: z.boolean().optional(),
@@ -631,7 +631,7 @@ export const UpdateAgentRequestMessageSchema = z.object({
   type: z.literal("update_agent_request"),
   agentId: z.string(),
   name: z.string().optional(),
-  labels: z.record(z.string()).optional(),
+  labels: z.record(z.string(), z.string()).optional(),
   requestId: z.string(),
 });
 
@@ -682,6 +682,25 @@ export const FetchAgentsRequestMessageSchema = z.object({
   subscribe: z
     .object({
       subscriptionId: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const FetchRecoverableAgentsRequestMessageSchema = z.object({
+  type: z.literal("fetch_recoverable_agents_request"),
+  requestId: z.string(),
+  sort: z
+    .array(
+      z.object({
+        key: z.enum(["status_priority", "created_at", "updated_at", "title"]),
+        direction: z.enum(["asc", "desc"]),
+      }),
+    )
+    .optional(),
+  page: z
+    .object({
+      limit: z.number().int().positive().max(200),
+      cursor: z.string().min(1).optional(),
     })
     .optional(),
 });
@@ -813,7 +832,7 @@ export const CreateAgentRequestMessageSchema = z.object({
   worktreeName: z.string().optional(),
   initialPrompt: z.string().optional(),
   clientMessageId: z.string().optional(),
-  outputSchema: z.record(z.unknown()).optional(),
+  outputSchema: z.record(z.string(), z.unknown()).optional(),
   images: z
     .array(
       z.object({
@@ -823,7 +842,7 @@ export const CreateAgentRequestMessageSchema = z.object({
     )
     .optional(),
   git: GitSetupOptionsSchema.optional(),
-  labels: z.record(z.string()).default({}),
+  labels: z.record(z.string(), z.string()).default({}),
   requestId: z.string(),
 });
 
@@ -855,7 +874,7 @@ export const GetProvidersSnapshotRequestMessageSchema = z.object({
 export const RefreshProvidersSnapshotRequestMessageSchema = z.object({
   type: z.literal("refresh_providers_snapshot_request"),
   cwd: z.string().optional(),
-  providers: z.array(AgentProviderSchema).optional(),
+  providers: z.array(AgentProviderValueSchema).optional(),
   requestId: z.string(),
 });
 
@@ -1337,7 +1356,7 @@ const ListCommandsDraftConfigSchema = z.object({
   modeId: z.string().optional(),
   model: z.string().optional(),
   thinkingOptionId: z.string().optional(),
-  featureValues: z.record(z.unknown()).optional(),
+  featureValues: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const ListProviderFeaturesRequestMessageSchema = z.object({
@@ -1434,6 +1453,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   AbortRequestMessageSchema,
   AudioPlayedMessageSchema,
   FetchAgentsRequestMessageSchema,
+  FetchRecoverableAgentsRequestMessageSchema,
   FetchWorkspacesRequestMessageSchema,
   FetchAgentRequestMessageSchema,
   DeleteAgentRequestMessageSchema,
@@ -1541,7 +1561,7 @@ export const ActivityLogPayloadSchema = z.object({
   timestamp: z.coerce.date(),
   type: z.enum(["transcript", "assistant", "tool_call", "tool_result", "error", "system"]),
   content: z.string(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const ActivityLogMessageSchema = z.object({
@@ -1980,6 +2000,24 @@ export const FetchAgentsResponseMessageSchema = z.object({
   payload: z.object({
     requestId: z.string(),
     subscriptionId: z.string().nullable().optional(),
+    entries: z.array(
+      z.object({
+        agent: AgentSnapshotPayloadSchema,
+        project: ProjectPlacementPayloadSchema,
+      }),
+    ),
+    pageInfo: z.object({
+      nextCursor: z.string().nullable(),
+      prevCursor: z.string().nullable(),
+      hasMore: z.boolean(),
+    }),
+  }),
+});
+
+export const FetchRecoverableAgentsResponseMessageSchema = z.object({
+  type: z.literal("fetch_recoverable_agents_response"),
+  payload: z.object({
+    requestId: z.string(),
     entries: z.array(
       z.object({
         agent: AgentSnapshotPayloadSchema,
@@ -2789,6 +2827,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   AgentStreamMessageSchema,
   AgentStatusMessageSchema,
   FetchAgentsResponseMessageSchema,
+  FetchRecoverableAgentsResponseMessageSchema,
   FetchWorkspacesResponseMessageSchema,
   OpenProjectResponseMessageSchema,
   ListAvailableEditorsResponseMessageSchema,
@@ -2899,6 +2938,9 @@ export type LegacyEditorTargetId = z.infer<typeof LegacyEditorTargetIdSchema>;
 export type EditorTargetId = LiteralUnion<KnownEditorTargetId, string>;
 export type EditorTargetDescriptorPayload = z.infer<typeof EditorTargetDescriptorPayloadSchema>;
 export type FetchAgentsResponseMessage = z.infer<typeof FetchAgentsResponseMessageSchema>;
+export type FetchRecoverableAgentsResponseMessage = z.infer<
+  typeof FetchRecoverableAgentsResponseMessageSchema
+>;
 export type FetchWorkspacesResponseMessage = z.infer<typeof FetchWorkspacesResponseMessageSchema>;
 export type OpenProjectResponseMessage = z.infer<typeof OpenProjectResponseMessageSchema>;
 export type ListAvailableEditorsResponseMessage = z.infer<
@@ -2968,6 +3010,9 @@ export type ActivityLogPayload = z.infer<typeof ActivityLogPayloadSchema>;
 // Type exports for inbound message types
 export type VoiceAudioChunkMessage = z.infer<typeof VoiceAudioChunkMessageSchema>;
 export type FetchAgentsRequestMessage = z.infer<typeof FetchAgentsRequestMessageSchema>;
+export type FetchRecoverableAgentsRequestMessage = z.infer<
+  typeof FetchRecoverableAgentsRequestMessageSchema
+>;
 export type FetchWorkspacesRequestMessage = z.infer<typeof FetchWorkspacesRequestMessageSchema>;
 export type FetchAgentRequestMessage = z.infer<typeof FetchAgentRequestMessageSchema>;
 export type SendAgentMessageRequest = z.infer<typeof SendAgentMessageRequestSchema>;


### PR DESCRIPTION
## Summary
- Adds Windows dev-client validation bootstrap and fork-safe guards needed for Android dev-client verification against fork worktrees.

## 2026-04-16 Integrated Device Verification
- Verified on physical Android device over USB.
- Direct local connection path: pass.
- Phone message send from current mobile UI: pass.
- Existing tmux-backed Codex session wake: pass.
- Assistant reply render on phone: pass. Exact token `TMUX_MOBILE_PING_4`.
- History scroll check: `428` frames, `3` janky (`0.70%`), `p95 18ms`, `p99 19ms`.
- Sensitive local details, device identifiers, private endpoints, and local artifact paths are intentionally omitted from this public PR.

## Branch-Specific Coverage
- Fresh app reset, permission prompt, dev-client bootstrap, and direct local pairing path all stayed usable in current integrated build.

## Fork CI
- Upstream PR currently reports no native GitHub checks.
- Latest fork `CI` success for this branch: https://github.com/Jacobinwwey/paseo/actions/runs/24544849352
