### PR TITLE
fix(server): prune ignored Linux diff watchers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17466,7 +17466,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -35402,6 +35401,7 @@
         "express-basic-auth": "^1.2.1",
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.1.0",
+        "ignore": "^7.0.5",
         "mnemonic-id": "^3.2.7",
         "node-pty": "1.2.0-beta.11",
         "onnxruntime-node": "^1.23.0",
@@ -35638,6 +35638,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "packages/server/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "packages/server/node_modules/media-typer": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -78,6 +78,7 @@
     "express-basic-auth": "^1.2.1",
     "fast-deep-equal": "^3.1.3",
     "fast-uri": "^3.1.0",
+    "ignore": "^7.0.5",
     "mnemonic-id": "^3.2.7",
     "node-pty": "1.2.0-beta.11",
     "onnxruntime-node": "^1.23.0",

--- a/packages/server/src/server/checkout-diff-manager.test.ts
+++ b/packages/server/src/server/checkout-diff-manager.test.ts
@@ -1,47 +1,92 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-const { getCheckoutDiffMock, resolveCheckoutGitDirMock, readdirMock, watchCalls } = vi.hoisted(
-  () => {
-    const hoistedWatchCalls: Array<{ path: string; close: ReturnType<typeof vi.fn> }> = [];
-    return {
-      getCheckoutDiffMock: vi.fn(async () => ({ diff: "", structured: [] })),
-      resolveCheckoutGitDirMock: vi.fn(async () => "/tmp/repo/.git"),
-      readdirMock: vi.fn(async (directory: string) => {
-        if (directory === "/tmp/repo") {
-          return [
-            { name: "packages", isDirectory: () => true },
-            { name: ".git", isDirectory: () => true },
-            { name: "README.md", isDirectory: () => false },
-          ];
-        }
-        if (directory === path.join("/tmp/repo", "packages")) {
-          return [
-            { name: "server", isDirectory: () => true },
-            { name: "app", isDirectory: () => true },
-          ];
-        }
-        if (directory === path.join("/tmp/repo", "packages", "server")) {
-          return [{ name: "src", isDirectory: () => true }];
-        }
-        if (directory === path.join("/tmp/repo", "packages", "server", "src")) {
-          return [{ name: "server", isDirectory: () => true }];
-        }
-        return [];
-      }),
-      watchCalls: hoistedWatchCalls,
-    };
-  },
-);
+const {
+  getCheckoutDiffMock,
+  resolveCheckoutGitDirMock,
+  runGitCommandMock,
+  readdirMock,
+  readFileMock,
+  watchCalls,
+  gitIgnoreContents,
+  trackedFiles,
+} = vi.hoisted(() => {
+  const hoistedWatchCalls: Array<{
+    path: string;
+    close: ReturnType<typeof vi.fn>;
+    callback: () => void;
+  }> = [];
+  const hoistedGitIgnoreContents = {
+    root: "vendor/\nnode_modules/\n",
+  };
+  const hoistedTrackedFiles = {
+    root: ["packages/server/src/server/index.ts"],
+  };
+  return {
+    getCheckoutDiffMock: vi.fn(async () => ({ diff: "", structured: [] })),
+    resolveCheckoutGitDirMock: vi.fn(async () => "/tmp/repo/.git"),
+    runGitCommandMock: vi.fn(async (args: string[]) => {
+      if (args[0] === "rev-parse") {
+        return {
+          stdout: "/tmp/repo\n",
+          stderr: "",
+          truncated: false,
+          exitCode: 0,
+          signal: null,
+        };
+      }
+
+      if (args[0] === "ls-files") {
+        return {
+          stdout: `${hoistedTrackedFiles.root.join("\n")}\n`,
+          stderr: "",
+          truncated: false,
+          exitCode: 0,
+          signal: null,
+        };
+      }
+
+      throw new Error(`Unexpected git command: ${args.join(" ")}`);
+    }),
+    readdirMock: vi.fn(async (directory: string) => {
+      if (directory === "/tmp/repo") {
+        return [
+          { name: "packages", isDirectory: () => true },
+          { name: "vendor", isDirectory: () => true },
+          { name: "node_modules", isDirectory: () => true },
+          { name: ".git", isDirectory: () => true },
+          { name: ".gitignore", isDirectory: () => false },
+          { name: "README.md", isDirectory: () => false },
+        ];
+      }
+      if (directory === path.join("/tmp/repo", "packages")) {
+        return [
+          { name: "server", isDirectory: () => true },
+          { name: "app", isDirectory: () => true },
+        ];
+      }
+      if (directory === path.join("/tmp/repo", "packages", "server")) {
+        return [{ name: "src", isDirectory: () => true }];
+      }
+      if (directory === path.join("/tmp/repo", "packages", "server", "src")) {
+        return [{ name: "server", isDirectory: () => true }];
+      }
+      return [];
+    }),
+    readFileMock: vi.fn(async (filePath: string) => {
+      if (filePath === path.join("/tmp/repo", ".gitignore")) {
+        return hoistedGitIgnoreContents.root;
+      }
+      throw new Error(`Unexpected readFile: ${filePath}`);
+    }),
+    gitIgnoreContents: hoistedGitIgnoreContents,
+    trackedFiles: hoistedTrackedFiles,
+    watchCalls: hoistedWatchCalls,
+  };
+});
 
 vi.mock("../utils/run-git-command.js", () => ({
-  runGitCommand: vi.fn(async () => ({
-    stdout: "/tmp/repo\n",
-    stderr: "",
-    truncated: false,
-    exitCode: 0,
-    signal: null,
-  })),
+  runGitCommand: runGitCommandMock,
 }));
 
 vi.mock("node:fs/promises", async () => {
@@ -49,6 +94,7 @@ vi.mock("node:fs/promises", async () => {
   return {
     ...actual,
     readdir: readdirMock,
+    readFile: readFileMock,
   };
 });
 
@@ -56,9 +102,9 @@ vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
   return {
     ...actual,
-    watch: vi.fn((watchPath: string) => {
+    watch: vi.fn((watchPath: string, _options: unknown, callback: () => void) => {
       const close = vi.fn();
-      watchCalls.push({ path: watchPath, close });
+      watchCalls.push({ path: watchPath, close, callback });
       return {
         close,
         on: vi.fn().mockReturnThis(),
@@ -88,7 +134,11 @@ describe("CheckoutDiffManager Linux watchers", () => {
     watchCalls.length = 0;
     getCheckoutDiffMock.mockClear();
     resolveCheckoutGitDirMock.mockClear();
+    runGitCommandMock.mockClear();
     readdirMock.mockClear();
+    readFileMock.mockClear();
+    gitIgnoreContents.root = "vendor/\nnode_modules/\n";
+    trackedFiles.root = ["packages/server/src/server/index.ts"];
     Object.defineProperty(process, "platform", {
       configurable: true,
       value: "linux",
@@ -130,6 +180,137 @@ describe("CheckoutDiffManager Linux watchers", () => {
       "/tmp/repo/packages/server/src",
       "/tmp/repo/packages/server/src/server",
     ]);
+
+    subscription.unsubscribe();
+    manager.dispose();
+  });
+
+  test("skips directories ignored by .gitignore on Linux", async () => {
+    const logger = {
+      child: () => logger,
+      warn: vi.fn(),
+    };
+    const manager = new CheckoutDiffManager({
+      logger: logger as any,
+      paseoHome: "/tmp/paseo-test",
+    });
+
+    const subscription = await manager.subscribe(
+      {
+        cwd: path.join("/tmp/repo", "packages", "server"),
+        compare: { mode: "uncommitted" },
+      },
+      () => {},
+    );
+
+    const watchedPaths = watchCalls.map((entry) => entry.path);
+    expect(watchedPaths).not.toContain(path.join("/tmp/repo", "vendor"));
+    expect(watchedPaths).not.toContain(path.join("/tmp/repo", "node_modules"));
+
+    subscription.unsubscribe();
+    manager.dispose();
+  });
+
+  test("prunes stale watchers after .gitignore starts ignoring a directory", async () => {
+    const logger = {
+      child: () => logger,
+      warn: vi.fn(),
+    };
+    gitIgnoreContents.root = "node_modules/\n";
+    const manager = new CheckoutDiffManager({
+      logger: logger as any,
+      paseoHome: "/tmp/paseo-test",
+    });
+
+    const subscription = await manager.subscribe(
+      {
+        cwd: path.join("/tmp/repo", "packages", "server"),
+        compare: { mode: "uncommitted" },
+      },
+      () => {},
+    );
+
+    const vendorWatcher = watchCalls.find(
+      (entry) => entry.path === path.join("/tmp/repo", "vendor"),
+    );
+    expect(vendorWatcher).toBeDefined();
+
+    gitIgnoreContents.root = "vendor/\nnode_modules/\n";
+    const rootWatcher = watchCalls.find((entry) => entry.path === "/tmp/repo");
+    expect(rootWatcher).toBeDefined();
+
+    rootWatcher?.callback();
+    await vi.waitFor(() => {
+      expect(vendorWatcher?.close).toHaveBeenCalledTimes(1);
+    });
+
+    subscription.unsubscribe();
+    manager.dispose();
+  });
+
+  test("keeps watching ignored directories that contain tracked files", async () => {
+    const logger = {
+      child: () => logger,
+      warn: vi.fn(),
+    };
+    trackedFiles.root = ["packages/server/src/server/index.ts", "vendor/kept.txt"];
+    const manager = new CheckoutDiffManager({
+      logger: logger as any,
+      paseoHome: "/tmp/paseo-test",
+    });
+
+    const subscription = await manager.subscribe(
+      {
+        cwd: path.join("/tmp/repo", "packages", "server"),
+        compare: { mode: "uncommitted" },
+      },
+      () => {},
+    );
+
+    expect(watchCalls.map((entry) => entry.path)).toContain(path.join("/tmp/repo", "vendor"));
+
+    subscription.unsubscribe();
+    manager.dispose();
+  });
+
+  test("keeps ignored directories watched when tracked file lookup fails", async () => {
+    const logger = {
+      child: () => logger,
+      warn: vi.fn(),
+    };
+    runGitCommandMock.mockImplementationOnce(async (args: string[]) => {
+      if (args[0] === "rev-parse") {
+        return {
+          stdout: "/tmp/repo\n",
+          stderr: "",
+          truncated: false,
+          exitCode: 0,
+          signal: null,
+        };
+      }
+
+      throw new Error(`Unexpected git command: ${args.join(" ")}`);
+    });
+    runGitCommandMock.mockImplementationOnce(async () => {
+      throw new Error("git ls-files failed");
+    });
+
+    const manager = new CheckoutDiffManager({
+      logger: logger as any,
+      paseoHome: "/tmp/paseo-test",
+    });
+
+    const subscription = await manager.subscribe(
+      {
+        cwd: path.join("/tmp/repo", "packages", "server"),
+        compare: { mode: "uncommitted" },
+      },
+      () => {},
+    );
+
+    const watchedPaths = watchCalls.map((entry) => entry.path);
+    expect(watchedPaths).toContain(path.join("/tmp/repo", "vendor"));
+    expect(watchedPaths).toContain(path.join("/tmp/repo", "node_modules"));
 
     subscription.unsubscribe();
     manager.dispose();

--- a/packages/server/src/server/checkout-diff-manager.ts
+++ b/packages/server/src/server/checkout-diff-manager.ts
@@ -1,6 +1,7 @@
 import { watch, type FSWatcher } from "node:fs";
-import { readdir } from "node:fs/promises";
-import { join } from "node:path";
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+import ignore, { type Ignore } from "ignore";
 import type pino from "pino";
 import type { SubscribeCheckoutDiffRequest, SessionOutboundMessage } from "./messages.js";
 import { getCheckoutDiff } from "../utils/checkout-git.js";
@@ -31,7 +32,7 @@ type CheckoutDiffWatchTarget = {
   diffCwd: string;
   compare: CheckoutDiffCompareInput;
   listeners: Set<(snapshot: CheckoutDiffSnapshotPayload) => void>;
-  watchers: FSWatcher[];
+  watchers: Map<string, FSWatcher>;
   fallbackRefreshInterval: NodeJS.Timeout | null;
   debounceTimer: NodeJS.Timeout | null;
   refreshPromise: Promise<void> | null;
@@ -43,6 +44,15 @@ type CheckoutDiffWatchTarget = {
   linuxTreeRefreshPromise: Promise<void> | null;
   linuxTreeRefreshQueued: boolean;
 };
+
+type GitIgnoreMatcher = {
+  basePath: string;
+  matcher: Ignore;
+};
+
+interface LinuxWatchTraversalState {
+  trackedDirectories: ReadonlySet<string> | null;
+}
 
 export class CheckoutDiffManager {
   private readonly logger: pino.Logger;
@@ -98,7 +108,7 @@ export class CheckoutDiffManager {
 
     for (const target of this.targets.values()) {
       checkoutDiffSubscriptionCount += target.listeners.size;
-      checkoutDiffWatcherCount += target.watchers.length;
+      checkoutDiffWatcherCount += target.watchers.size;
       if (target.fallbackRefreshInterval) {
         checkoutDiffFallbackRefreshTargetCount += 1;
       }
@@ -148,10 +158,10 @@ export class CheckoutDiffManager {
       clearInterval(target.fallbackRefreshInterval);
       target.fallbackRefreshInterval = null;
     }
-    for (const watcher of target.watchers) {
+    for (const watcher of target.watchers.values()) {
       watcher.close();
     }
-    target.watchers = [];
+    target.watchers.clear();
     target.watchedPaths.clear();
     target.listeners.clear();
   }
@@ -281,7 +291,7 @@ export class CheckoutDiffManager {
       diffCwd: watchRoot ?? cwd,
       compare,
       listeners: new Set(),
-      watchers: [],
+      watchers: new Map<string, FSWatcher>(),
       fallbackRefreshInterval: null,
       debounceTimer: null,
       refreshPromise: null,
@@ -319,7 +329,7 @@ export class CheckoutDiffManager {
     }
 
     const missingRepoCoverage = !hasRecursiveRepoCoverage;
-    if (target.watchers.length === 0 || missingRepoCoverage) {
+    if (target.watchers.size === 0 || missingRepoCoverage) {
       target.fallbackRefreshInterval = setInterval(() => {
         this.scheduleTargetRefresh(target);
       }, CHECKOUT_DIFF_FALLBACK_REFRESH_MS);
@@ -329,7 +339,7 @@ export class CheckoutDiffManager {
           compare,
           intervalMs: CHECKOUT_DIFF_FALLBACK_REFRESH_MS,
           reason:
-            target.watchers.length === 0 ? "no_watchers" : "missing_recursive_repo_root_coverage",
+            target.watchers.size === 0 ? "no_watchers" : "missing_recursive_repo_root_coverage",
         },
         "Checkout diff watchers unavailable; using timed refresh fallback",
       );
@@ -398,7 +408,7 @@ export class CheckoutDiffManager {
     watcher.on("error", (error) => {
       this.logger.warn({ err: error, watchPath, cwd, compare }, "Checkout diff watcher error");
     });
-    target.watchers.push(watcher);
+    target.watchers.set(watchPath, watcher);
     target.watchedPaths.add(watchPath);
     return watcherIsRecursive;
   }
@@ -407,7 +417,9 @@ export class CheckoutDiffManager {
     target: CheckoutDiffWatchTarget,
     rootPath: string,
   ): Promise<boolean> {
-    const directories = await this.listLinuxWatchDirectories(rootPath);
+    const traversalState = await this.createLinuxWatchTraversalState(rootPath);
+    const directories = await this.listLinuxWatchDirectories(rootPath, traversalState);
+    this.pruneLinuxRepoTreeWatchers(target, new Set(directories));
     let complete = true;
     for (const directory of directories) {
       const watcherWasRecursive = this.addWatcher(target, directory, false);
@@ -416,6 +428,31 @@ export class CheckoutDiffManager {
       }
     }
     return complete && target.watchedPaths.has(rootPath);
+  }
+
+  private async createLinuxWatchTraversalState(
+    rootPath: string,
+  ): Promise<LinuxWatchTraversalState> {
+    return {
+      trackedDirectories: await this.listTrackedDirectories(rootPath),
+    };
+  }
+
+  private pruneLinuxRepoTreeWatchers(
+    target: CheckoutDiffWatchTarget,
+    nextDirectories: ReadonlySet<string>,
+  ): void {
+    for (const [watchPath, watcher] of target.watchers) {
+      if (watchPath === target.repoWatchPath || watchPath.endsWith(`${sep}.git`)) {
+        continue;
+      }
+      if (nextDirectories.has(watchPath)) {
+        continue;
+      }
+      watcher.close();
+      target.watchers.delete(watchPath);
+      target.watchedPaths.delete(watchPath);
+    }
   }
 
   private async refreshLinuxRepoTreeWatchers(target: CheckoutDiffWatchTarget): Promise<void> {
@@ -454,15 +491,22 @@ export class CheckoutDiffManager {
     }
   }
 
-  private async listLinuxWatchDirectories(rootPath: string): Promise<string[]> {
+  private async listLinuxWatchDirectories(
+    rootPath: string,
+    traversalState: LinuxWatchTraversalState,
+  ): Promise<string[]> {
     const directories: string[] = [];
-    const pending = [rootPath];
+    const pending: Array<{ directory: string; gitIgnoreMatchers: readonly GitIgnoreMatcher[] }> = [
+      { directory: rootPath, gitIgnoreMatchers: [] },
+    ];
 
     while (pending.length > 0) {
-      const directory = pending.pop();
-      if (!directory) {
+      const current = pending.pop();
+      if (!current) {
         continue;
       }
+
+      const { directory } = current;
       directories.push(directory);
 
       let entries;
@@ -472,14 +516,114 @@ export class CheckoutDiffManager {
         continue;
       }
 
+      const localGitIgnoreMatcher = await this.loadGitIgnoreMatcher(directory, entries);
+      const gitIgnoreMatchers = localGitIgnoreMatcher
+        ? [...current.gitIgnoreMatchers, localGitIgnoreMatcher]
+        : current.gitIgnoreMatchers;
+
       for (const entry of entries) {
         if (!entry.isDirectory() || entry.name === ".git") {
           continue;
         }
-        pending.push(join(directory, entry.name));
+        const childDirectory = join(directory, entry.name);
+        if (
+          this.isGitIgnoredDirectory(childDirectory, gitIgnoreMatchers) &&
+          traversalState.trackedDirectories !== null &&
+          !traversalState.trackedDirectories.has(childDirectory)
+        ) {
+          continue;
+        }
+        pending.push({ directory: childDirectory, gitIgnoreMatchers });
       }
     }
 
     return directories;
+  }
+
+  private async listTrackedDirectories(rootPath: string): Promise<Set<string> | null> {
+    try {
+      const { stdout } = await runGitCommand(["ls-files"], {
+        cwd: rootPath,
+        env: READ_ONLY_GIT_ENV,
+      });
+      const trackedDirectories = new Set<string>();
+
+      for (const filePath of stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)) {
+        const pathSegments = filePath.split("/");
+        if (pathSegments.length < 2) {
+          continue;
+        }
+
+        let currentPath = rootPath;
+        for (const pathSegment of pathSegments.slice(0, -1)) {
+          currentPath = join(currentPath, pathSegment);
+          trackedDirectories.add(currentPath);
+        }
+      }
+
+      return trackedDirectories;
+    } catch {
+      return null;
+    }
+  }
+
+  private async loadGitIgnoreMatcher(
+    directory: string,
+    entries: Array<{ name: string }>,
+  ): Promise<GitIgnoreMatcher | null> {
+    if (!entries.some((entry) => entry.name === ".gitignore")) {
+      return null;
+    }
+
+    try {
+      const contents = await readFile(join(directory, ".gitignore"), "utf8");
+      return {
+        basePath: directory,
+        matcher: ignore().add(contents),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private isGitIgnoredDirectory(
+    directory: string,
+    gitIgnoreMatchers: readonly GitIgnoreMatcher[],
+  ): boolean {
+    let ignored = false;
+
+    for (const gitIgnoreMatcher of gitIgnoreMatchers) {
+      const relativePath = relative(gitIgnoreMatcher.basePath, directory);
+      if (
+        relativePath.length === 0 ||
+        relativePath === "." ||
+        relativePath.startsWith(`..${sep}`) ||
+        relativePath === ".."
+      ) {
+        continue;
+      }
+
+      const result = gitIgnoreMatcher.matcher.test(this.toGitIgnorePath(relativePath, true));
+      if (result.ignored) {
+        ignored = true;
+        continue;
+      }
+      if (result.unignored) {
+        ignored = false;
+      }
+    }
+
+    return ignored;
+  }
+
+  private toGitIgnorePath(targetPath: string, isDirectory: boolean): string {
+    const normalizedPath = targetPath.split(sep).join("/");
+    if (!isDirectory || normalizedPath.endsWith("/")) {
+      return normalizedPath;
+    }
+    return `${normalizedPath}/`;
   }
 }


### PR DESCRIPTION
## Summary
- prune Linux checkout diff watchers for directories ignored by `.gitignore` to reduce open file pressure
- keep ignored directories watched when they still contain tracked files so diff updates stay correct
- fail open when tracked path discovery fails and add regression tests around watcher pruning behavior

## Verification
- npm run format
- cd packages/server && npm run test:unit -- src/server/checkout-diff-manager.test.ts
- cd packages/server && npm run typecheck