### PR TITLE
fix(server): harden OpenCode session resume and lifecycle handling

### DIFF
--- a/packages/app/src/components/question-form-card.tsx
+++ b/packages/app/src/components/question-form-card.tsx
@@ -123,7 +123,7 @@ export function QuestionFormCard({ permission, onRespond, isResponding }: Questi
   function handleSubmit() {
     if (!allAnswered || isResponding) return;
     setRespondingAction("submit");
-    const answers: Record<string, string> = {};
+    const answers: Record<string, string | string[]> = {};
     for (let i = 0; i < questions!.length; i++) {
       const q = questions![i];
       const selected = selections[i];
@@ -133,7 +133,7 @@ export function QuestionFormCard({ permission, onRespond, isResponding }: Questi
         answers[q.header] = otherText;
       } else if (selected && selected.size > 0) {
         const labels = Array.from(selected).map((idx) => q.options[idx].label);
-        answers[q.header] = labels.join(", ");
+        answers[q.header] = labels;
       }
     }
 

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -2010,7 +2010,27 @@ class OpenCodeAgentSession implements AgentSession {
   }
 
   async close(): Promise<void> {
-    this.abortController?.abort();
+    const activeTurnId = this.activeForegroundTurnId;
+    if (activeTurnId) {
+      this.finishForegroundTurn(
+        { type: "turn_canceled", provider: "opencode", reason: "session_closed" },
+        activeTurnId,
+      );
+    } else {
+      this.abortController?.abort();
+      this.abortController = null;
+      this.runningToolCalls.clear();
+    }
+
+    for (const requestId of this.pendingPermissions.keys()) {
+      this.notifySubscribers({
+        type: "permission_resolved",
+        provider: "opencode",
+        requestId,
+        resolution: { behavior: "deny", message: "Session closed" },
+      });
+    }
+    this.pendingPermissions.clear();
     this.subscribers.clear();
     this.activeForegroundTurnId = null;
   }

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -749,7 +749,9 @@ export class OpenCodeAgentClient implements AgentClient {
     ]);
 
     if (response.error) {
-      throw new Error(`Failed to create OpenCode session: ${JSON.stringify(response.error)}`);
+      throw new Error(
+        `Failed to create OpenCode session: ${normalizeTurnFailureError(response.error)}`,
+      );
     }
 
     const session = response.data;
@@ -831,7 +833,9 @@ export class OpenCodeAgentClient implements AgentClient {
     ]);
 
     if (response.error) {
-      throw new Error(`Failed to fetch OpenCode providers: ${JSON.stringify(response.error)}`);
+      throw new Error(
+        `Failed to fetch OpenCode providers: ${normalizeTurnFailureError(response.error)}`,
+      );
     }
 
     const providers = response.data;

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -1241,6 +1241,21 @@ export function translateOpenCodeEvent(
       break;
     }
 
+    case "permission.replied": {
+      if (event.properties.sessionID !== state.sessionId) {
+        break;
+      }
+
+      events.push({
+        type: "permission_resolved",
+        provider: "opencode",
+        requestId: event.properties.requestID,
+        resolution:
+          event.properties.reply === "reject" ? { behavior: "deny" } : { behavior: "allow" },
+      });
+      break;
+    }
+
     case "question.asked": {
       if (event.properties.sessionID !== state.sessionId) {
         break;
@@ -1284,6 +1299,34 @@ export function translateOpenCodeEvent(
             ...(event.properties.tool ?? {}),
           },
         },
+      });
+      break;
+    }
+
+    case "question.replied": {
+      if (event.properties.sessionID !== state.sessionId) {
+        break;
+      }
+
+      events.push({
+        type: "permission_resolved",
+        provider: "opencode",
+        requestId: event.properties.requestID,
+        resolution: { behavior: "allow" },
+      });
+      break;
+    }
+
+    case "question.rejected": {
+      if (event.properties.sessionID !== state.sessionId) {
+        break;
+      }
+
+      events.push({
+        type: "permission_resolved",
+        provider: "opencode",
+        requestId: event.properties.requestID,
+        resolution: { behavior: "deny", message: "Question rejected" },
       });
       break;
     }
@@ -2128,6 +2171,9 @@ class OpenCodeAgentSession implements AgentSession {
     for (const translatedEvent of translated) {
       if (translatedEvent.type === "permission_requested") {
         this.pendingPermissions.set(translatedEvent.request.id, translatedEvent.request);
+      }
+      if (translatedEvent.type === "permission_resolved") {
+        this.pendingPermissions.delete(translatedEvent.requestId);
       }
       if (translatedEvent.type === "turn_completed") {
         if (hasNormalizedOpenCodeUsage(this.accumulatedUsage)) {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -1527,7 +1527,9 @@ class OpenCodeAgentSession implements AgentSession {
       if (event.type === "timeline") {
         timeline.push(event.item);
         if (event.item.type === "assistant_message") {
-          finalText = event.item.text;
+          finalText = event.item.text.startsWith(finalText)
+            ? event.item.text
+            : `${finalText}${event.item.text}`;
         }
         return;
       }

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -780,15 +780,18 @@ export class OpenCodeAgentClient implements AgentClient {
     overrides?: Partial<AgentSessionConfig>,
     _launchContext?: AgentLaunchContext,
   ): Promise<AgentSession> {
-    const cwd = overrides?.cwd ?? (handle.metadata?.cwd as string);
+    const metadata = readOpenCodeRecord(handle.metadata) as Partial<AgentSessionConfig> | null;
+    const metadataCwd = typeof metadata?.cwd === "string" ? metadata.cwd : undefined;
+    const cwd = overrides?.cwd ?? metadataCwd ?? (handle.metadata?.cwd as string);
     if (!cwd) {
       throw new Error("OpenCode resume requires the original working directory");
     }
 
     const config: AgentSessionConfig = {
+      ...(metadata ?? {}),
+      ...overrides,
       provider: "opencode",
       cwd,
-      ...overrides,
     };
     const openCodeConfig = this.assertConfig(config);
     const { url } = await this.serverManager.ensureRunning();
@@ -1925,7 +1928,10 @@ class OpenCodeAgentSession implements AgentSession {
       sessionId: this.sessionId,
       nativeHandle: this.sessionId,
       metadata: {
+        ...this.config,
+        provider: "opencode",
         cwd: this.config.cwd,
+        modeId: this.currentMode,
       },
     };
   }

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -1045,6 +1045,37 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function normalizeOpenCodeQuestionAnswer(
+  rawAnswer: unknown,
+  optionLabels?: ReadonlySet<string>,
+): string[] {
+  if (Array.isArray(rawAnswer)) {
+    return rawAnswer
+      .map((value) => readNonEmptyString(value))
+      .filter((value): value is string => value !== null);
+  }
+
+  const answer = readNonEmptyString(rawAnswer);
+  if (!answer) {
+    return [];
+  }
+
+  if (!optionLabels || !answer.includes(",")) {
+    return [answer];
+  }
+
+  const splitAnswers = answer
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (splitAnswers.length > 1 && splitAnswers.every((entry) => optionLabels.has(entry))) {
+    return splitAnswers;
+  }
+
+  return [answer];
+}
+
 export function translateOpenCodeEvent(
   event: OpenCodeEvent,
   state: OpenCodeEventTranslationState,
@@ -1889,15 +1920,21 @@ class OpenCodeAgentSession implements AgentSession {
         const answersRecord = readOpenCodeRecord(response.updatedInput?.answers);
         const questions = Array.isArray(pending.input?.questions) ? pending.input.questions : [];
         const answers = questions.map((item) => {
-          const header = readNonEmptyString(readOpenCodeRecord(item)?.header);
-          const rawAnswer = header ? readNonEmptyString(answersRecord?.[header]) : null;
-          if (!rawAnswer) {
-            return [];
-          }
-          return rawAnswer
-            .split(",")
-            .map((entry) => entry.trim())
-            .filter((entry) => entry.length > 0);
+          const question = readOpenCodeRecord(item);
+          const header = readNonEmptyString(question?.header);
+          const optionLabels = new Set(
+            Array.isArray(question?.options)
+              ? question.options.flatMap((option) => {
+                  const label = readNonEmptyString(readOpenCodeRecord(option)?.label);
+                  return label ? [label] : [];
+                })
+              : [],
+          );
+          const rawAnswer = header ? answersRecord?.[header] : undefined;
+          return normalizeOpenCodeQuestionAnswer(
+            rawAnswer,
+            optionLabels.size > 0 ? optionLabels : undefined,
+          );
         });
 
         await this.client.question.reply({

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -575,39 +575,31 @@ export const __openCodeInternals = {
 };
 
 export class OpenCodeServerManager {
-  private static instance: OpenCodeServerManager | null = null;
+  private static instances = new Map<string, OpenCodeServerManager>();
   private static exitHandlerRegistered = false;
   private server: ChildProcess | null = null;
   private port: number | null = null;
   private startPromise: Promise<{ port: number; url: string }> | null = null;
   private readonly logger: Logger;
   private readonly runtimeSettings?: ProviderRuntimeSettings;
-  private readonly runtimeSettingsKey: string;
 
   private constructor(logger: Logger, runtimeSettings?: ProviderRuntimeSettings) {
     this.logger = logger;
     this.runtimeSettings = runtimeSettings;
-    this.runtimeSettingsKey = JSON.stringify(runtimeSettings ?? {});
   }
 
   static getInstance(
     logger: Logger,
     runtimeSettings?: ProviderRuntimeSettings,
   ): OpenCodeServerManager {
-    const nextSettingsKey = JSON.stringify(runtimeSettings ?? {});
-    if (!OpenCodeServerManager.instance) {
-      OpenCodeServerManager.instance = new OpenCodeServerManager(logger, runtimeSettings);
+    const settingsKey = JSON.stringify(runtimeSettings ?? {});
+    let manager = OpenCodeServerManager.instances.get(settingsKey);
+    if (!manager) {
+      manager = new OpenCodeServerManager(logger, runtimeSettings);
+      OpenCodeServerManager.instances.set(settingsKey, manager);
       OpenCodeServerManager.registerExitHandler();
-    } else if (OpenCodeServerManager.instance.runtimeSettingsKey !== nextSettingsKey) {
-      logger.warn(
-        {
-          existingRuntimeSettings: OpenCodeServerManager.instance.runtimeSettingsKey,
-          requestedRuntimeSettings: nextSettingsKey,
-        },
-        "OpenCode server manager already initialized with different runtime settings",
-      );
     }
-    return OpenCodeServerManager.instance;
+    return manager;
   }
 
   private static registerExitHandler(): void {
@@ -617,9 +609,10 @@ export class OpenCodeServerManager {
     OpenCodeServerManager.exitHandlerRegistered = true;
 
     const cleanup = () => {
-      const instance = OpenCodeServerManager.instance;
-      if (instance?.server && !instance.server.killed) {
-        instance.server.kill("SIGTERM");
+      for (const instance of OpenCodeServerManager.instances.values()) {
+        if (instance.server && !instance.server.killed) {
+          instance.server.kill("SIGTERM");
+        }
       }
     };
 

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -1962,10 +1962,11 @@ class OpenCodeAgentSession implements AgentSession {
   private async resolveSlashCommandInvocation(
     prompt: AgentPromptInput,
   ): Promise<{ commandName: string; args?: string } | null> {
-    if (typeof prompt !== "string") {
+    const slashCandidate = this.extractSlashCommandCandidate(prompt);
+    if (!slashCandidate) {
       return null;
     }
-    const parsed = this.parseSlashCommandInput(prompt);
+    const parsed = this.parseSlashCommandInput(slashCandidate);
     if (!parsed) {
       return null;
     }
@@ -1979,6 +1980,24 @@ class OpenCodeAgentSession implements AgentSession {
       );
       return null;
     }
+  }
+
+  private extractSlashCommandCandidate(prompt: AgentPromptInput): string | null {
+    if (typeof prompt === "string") {
+      return prompt;
+    }
+
+    for (const part of prompt) {
+      if (part.type !== "text") {
+        continue;
+      }
+
+      if (part.text.trim().length > 0) {
+        return part.text;
+      }
+    }
+
+    return null;
   }
 
   private parseModel(model?: string): { providerID: string; modelID: string } | undefined {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -1045,6 +1045,7 @@ export class OpenCodeAgentClient implements AgentClient {
 
 export type OpenCodeEventTranslationState = {
   sessionId: string;
+  threadStartedEmitted: boolean;
   messageRoles: Map<string, OpenCodeMessageRole>;
   accumulatedUsage: AgentUsage;
   streamedPartKeys: Set<string>;
@@ -1120,7 +1121,8 @@ export function translateOpenCodeEvent(
   switch (event.type) {
     case "session.created":
     case "session.updated": {
-      if (event.properties.info.id === state.sessionId) {
+      if (event.properties.info.id === state.sessionId && !state.threadStartedEmitted) {
+        state.threadStartedEmitted = true;
         events.push({
           type: "thread_started",
           sessionId: state.sessionId,
@@ -1456,6 +1458,7 @@ class OpenCodeAgentSession implements AgentSession {
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private nextTurnOrdinal = 0;
   private activeForegroundTurnId: string | null = null;
+  private threadStartedEmitted = false;
   private readonly runningToolCalls = new Map<string, ToolCallTimelineItem>();
   private selectedModelContextWindowMaxTokens: number | undefined;
   constructor(
@@ -2216,8 +2219,9 @@ class OpenCodeAgentSession implements AgentSession {
   }
 
   private translateEvent(event: OpenCodeEvent): AgentStreamEvent[] {
-    const translated = translateOpenCodeEvent(event, {
+    const translationState: OpenCodeEventTranslationState = {
       sessionId: this.sessionId,
+      threadStartedEmitted: this.threadStartedEmitted,
       messageRoles: this.messageRoles,
       accumulatedUsage: this.accumulatedUsage,
       streamedPartKeys: this.streamedPartKeys,
@@ -2230,7 +2234,9 @@ class OpenCodeAgentSession implements AgentSession {
           this.selectedModelContextWindowMaxTokens = contextWindowMaxTokens;
         }
       },
-    });
+    };
+    const translated = translateOpenCodeEvent(event, translationState);
+    this.threadStartedEmitted = translationState.threadStartedEmitted;
 
     for (const translatedEvent of translated) {
       if (translatedEvent.type === "permission_requested") {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -1189,7 +1189,7 @@ export function translateOpenCodeEvent(
         }
       } else if (part.type === "reasoning") {
         const partKey = resolvePartDedupeKey(part, "reasoning");
-        if (part.time.end) {
+        if (part.time?.end) {
           if (partKey && state.streamedPartKeys.delete(partKey)) {
             break;
           }

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -903,10 +903,48 @@ export class OpenCodeAgentClient implements AgentClient {
   }
 
   async listPersistedAgents(
-    _options?: ListPersistedAgentsOptions,
+    options?: ListPersistedAgentsOptions,
   ): Promise<PersistedAgentDescriptor[]> {
-    // TODO: Implement by listing sessions from OpenCode
-    return [];
+    const { url } = await this.serverManager.ensureRunning();
+    const client = createOpencodeClient({
+      baseUrl: url,
+      directory: process.cwd(),
+    });
+    const limit = options?.limit ?? 20;
+    const response = await client.session.list({ limit });
+    if (response.error || !response.data) {
+      return [];
+    }
+
+    return response.data.slice(0, limit).map((session) => {
+      const cwd = readNonEmptyString(session.directory) ?? process.cwd();
+      const title = readNonEmptyString(session.title);
+      const updatedAtMs =
+        typeof session.time?.updated === "number"
+          ? session.time.updated
+          : typeof session.time?.created === "number"
+            ? session.time.created
+            : Date.now();
+
+      return {
+        provider: "opencode",
+        sessionId: session.id,
+        cwd,
+        title,
+        lastActivityAt: new Date(updatedAtMs),
+        persistence: {
+          provider: "opencode",
+          sessionId: session.id,
+          nativeHandle: session.id,
+          metadata: {
+            provider: "opencode",
+            cwd,
+            ...(title ? { title } : {}),
+          },
+        },
+        timeline: [],
+      } satisfies PersistedAgentDescriptor;
+    });
   }
 
   async isAvailable(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Preserve and restore full OpenCode session configuration on resume, add persisted-session discovery, and parse slash commands from rich prompts so resumed/attachment turns keep expected behavior.
- Fix permission and question lifecycle handling by emitting resolution events, clearing pending state on close, and tightening thread/event translation edge cases (reasoning timestamp safety, thread_started dedupe).
- Improve OpenCode runtime robustness by honoring per-client runtime settings, normalizing non-turn errors, and accumulating streamed assistant chunks into complete finalText; also fix comma-safe question answers across app/server adapters.

## Verification
- npm run format:check
- npm run typecheck
- npm run test:unit --workspace @getpaseo/server -- opencode-agent.test.ts