### PR TITLE
fix: resubscribe git watch after worktree creation

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -4225,12 +4225,16 @@ export class Session {
 
   private async syncWorkspaceGitWatchTarget(
     cwd: string,
-    options: { isGit: boolean },
+    options: { isGit: boolean; forceResubscribe?: boolean },
   ): Promise<void> {
     const workspaceId = normalizePersistedWorkspaceId(cwd);
     if (!options.isGit) {
       this.removeWorkspaceGitSubscription(workspaceId);
       return;
+    }
+
+    if (options.forceResubscribe && this.workspaceGitSubscriptions.has(workspaceId)) {
+      this.removeWorkspaceGitSubscription(workspaceId);
     }
 
     if (this.workspaceGitSubscriptions.has(workspaceId)) {
@@ -6196,6 +6200,8 @@ export class Session {
         emit: (message) => this.emit(message),
         registerPendingWorktreeWorkspace: (options) =>
           this.registerPendingWorktreeWorkspace(options),
+        syncWorkspaceGitWatchTarget: (cwd, syncOptions) =>
+          this.syncWorkspaceGitWatchTarget(cwd, syncOptions),
         sessionLogger: this.sessionLogger,
         runWorktreeSetupInBackground: (options) => this.runWorktreeSetupInBackground(options),
       },

--- a/packages/server/src/server/session.workspace-git-watch.test.ts
+++ b/packages/server/src/server/session.workspace-git-watch.test.ts
@@ -283,6 +283,28 @@ describe("workspace git watch targets", () => {
     await session.cleanup();
   });
 
+  test("syncWorkspaceGitWatchTarget can force a resubscribe for existing workspaces", async () => {
+    const { session, workspaceGitService, subscriptions } =
+      createSessionForWorkspaceGitWatchTests();
+    const sessionAny = session as any;
+
+    await sessionAny.syncWorkspaceGitWatchTarget("/tmp/repo", { isGit: true });
+    await sessionAny.syncWorkspaceGitWatchTarget("/tmp/repo", { isGit: true });
+
+    expect(workspaceGitService.subscribe).toHaveBeenCalledTimes(1);
+    expect(subscriptions).toHaveLength(1);
+
+    await sessionAny.syncWorkspaceGitWatchTarget("/tmp/repo", {
+      isGit: true,
+      forceResubscribe: true,
+    });
+
+    expect(subscriptions[0]?.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(workspaceGitService.subscribe).toHaveBeenCalledTimes(2);
+
+    await session.cleanup();
+  });
+
   test("checkout_pr_status_request reads pull request status from the workspace git service snapshot", async () => {
     const { session, emitted, workspaceGitService } = createSessionForWorkspaceGitWatchTests();
 

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -85,7 +85,10 @@ type RegisterPendingWorktreeWorkspaceDependencies = {
   }) => PersistedWorkspaceRecord;
   buildProjectPlacement: (cwd: string) => Promise<ProjectPlacementPayload>;
   projectRegistry: Pick<ProjectRegistry, "get" | "upsert">;
-  syncWorkspaceGitWatchTarget: (cwd: string, options: { isGit: boolean }) => Promise<void>;
+  syncWorkspaceGitWatchTarget: (
+    cwd: string,
+    options: { isGit: boolean; forceResubscribe?: boolean },
+  ) => Promise<void>;
   workspaceRegistry: Pick<WorkspaceRegistry, "get" | "upsert">;
   archiveProjectRecordIfEmpty: (projectId: string, archivedAt: string) => Promise<void>;
 };
@@ -108,6 +111,10 @@ type HandleCreatePaseoWorktreeRequestDependencies = {
     worktreePath: string;
     branchName: string;
   }) => Promise<PersistedWorkspaceRecord>;
+  syncWorkspaceGitWatchTarget: (
+    cwd: string,
+    options: { isGit: boolean; forceResubscribe?: boolean },
+  ) => Promise<void>;
   sessionLogger: Logger;
   runWorktreeSetupInBackground: (options: {
     requestCwd: string;
@@ -581,6 +588,11 @@ export async function handleCreatePaseoWorktreeRequest(
       baseBranch,
       worktreeSlug: normalizedSlug,
       paseoHome: dependencies.paseoHome,
+    });
+
+    await dependencies.syncWorkspaceGitWatchTarget(workspace.cwd, {
+      isGit: true,
+      forceResubscribe: true,
     });
 
     const descriptor = await dependencies.describeWorkspaceRecord(workspace);


### PR DESCRIPTION
## Summary
- fix a race where a pending worktree could be subscribed before its path exists, leaving a stale non-git snapshot cached
- force workspace git watch target resubscription after `createAgentWorktree()` succeeds so watchers are rebuilt against the real worktree path
- add a regression test covering `syncWorkspaceGitWatchTarget(..., { forceResubscribe: true })`

## Validation
- npm run typecheck
- npm exec vitest run src/server/session.workspace-git-watch.test.ts