### PR TITLE
Fix: Se congela en openCode cuando se pide confirmacion desde un sub agente. cuando la confirmacion es de permisos.

### DIFF
--- a/packages/website/src/routes/opencode.tsx
+++ b/packages/website/src/routes/opencode.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { LandingPage } from "~/components/landing-page";
 import { pageMeta } from "~/meta";
 
@@ -14,9 +14,12 @@ export const Route = createFileRoute("/opencode")({
 
 function OpenCodePage() {
   return (
-    <LandingPage
-      title="Run OpenCode from your phone"
-      subtitle="Launch agents, check on builds, and ship code from anywhere. Same setup, same machine, just not at your desk."
-    />
+    <>
+      <LandingPage
+        title="Run OpenCode from your phone"
+        subtitle="Launch agents, check on builds, and ship code from anywhere. Same setup, same machine, just not at your desk."
+      />
+      <Outlet />
+    </>
   );
 }


### PR DESCRIPTION
The issue was that the /opencode route was rendering a static LandingPage component without providing an <Outlet />. In TanStack Router, if a route has nested child routes (such as a permission confirmation dialog or a sub-agent interface), they require an <Outlet /> in the parent component to be rendered. When a sub-agent requested permission, the app likely navigated to or attempted to render a sub-route which remained invisible because the Outlet was missing. This made the UI appear 'frozen' to the user as they were stuck on the landing page while the system waited for a confirmation that wasn't being displayed. I added the <Outlet /> and wrapped the content in a React fragment to ensure nested content can be rendered correctly.

Test: 1. Access the /opencode route on the website/app.
2. Trigger an action from a sub-agent that requires permission confirmation.
3. Verify that the permission prompt (which is likely a nested route or child component) is now visible and interactable.
4. Confirm that the marketing LandingPage remains visible or renders correctly alongside the nested content.