### PR TITLE
fix: file preview shows stale content when re-opening a file

### DIFF
--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -263,7 +263,7 @@ export function FilePane({
       );
       return { file: payload.file ?? null, error: payload.error ?? null };
     },
-    staleTime: 0,
+    staleTime: 5_000,
     refetchOnMount: true,
   });
 

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -263,7 +263,8 @@ export function FilePane({
       );
       return { file: payload.file ?? null, error: payload.error ?? null };
     },
-    staleTime: 5_000,
+    staleTime: 0,
+    refetchOnMount: true,
   });
 
   return (


### PR DESCRIPTION
## Summary

- File preview query inherits `refetchOnMount: false` and `gcTime: Infinity` from the global QueryClient defaults ([`query-client.ts#L3-L11`](https://github.com/getpaseo/paseo/blob/f6579dbeb461e7780e89f0b25ecfafe03efbe4f8/packages/app/src/query/query-client.ts#L3-L11))
- When re-opening a previously viewed file, the content query never re-fetches — it returns cached (stale) content
- The directory tree correctly shows updated modification times, but the file content remains old
- Add `refetchOnMount: true` to the file preview query so stale data is refetched when the component remounts (after the existing 5s `staleTime` window)

Fixes #351

## Test plan

- [ ] Open a file in the file browser
- [ ] Let an agent modify that file (or modify it externally)
- [ ] Close the file preview
- [ ] Re-open the same file after 5+ seconds
- [ ] Verify the latest content is displayed
- [ ] Test on both desktop and iOS