### PR TITLE
fix(desktop): allow localhost origins in dev

### DIFF
--- a/packages/desktop/scripts/dev.sh
+++ b/packages/desktop/scripts/dev.sh
@@ -13,6 +13,11 @@ npm run build:main
 EXPO_PORT=$("$ROOT_DIR/node_modules/.bin/get-port")
 export EXPO_PORT
 
+# Allow any origin in dev so Electron on random localhost ports can reach
+# the daemon websocket. Safe here because this script is development-only
+# and the daemon still binds to localhost.
+export PASEO_CORS_ORIGINS="*"
+
 echo "══════════════════════════════════════════════════════"
 echo "  Paseo Desktop Dev"
 echo "══════════════════════════════════════════════════════"


### PR DESCRIPTION
## Summary
- export `PASEO_CORS_ORIGINS=\"*\"` from the macOS desktop dev script so Electron's random localhost dev origin can connect to the daemon websocket
- align the macOS desktop dev flow with the existing Windows script behavior for local development
- avoid repeated `Rejected connection from origin` websocket failures when running the desktop app locally

## Test plan
- [x] Inspect daemon logs and confirm rejected websocket connections were due to Electron's random localhost origin
- [x] Verify the macOS desktop dev script now exports the same dev-only CORS override as the Windows script
- [ ] Restart the local daemon and run `npm run dev:desktop` on macOS to confirm the desktop app connects successfully