### PR TITLE
fix(app): Show background task progress in badges

### DIFF
--- a/packages/app/src/utils/tool-call-display.test.ts
+++ b/packages/app/src/utils/tool-call-display.test.ts
@@ -60,7 +60,59 @@ describe("tool-call-display", () => {
 
     expect(display).toEqual({
       displayName: "Explore",
-      summary: "Inspect repository structure",
+      summary: "Running - Inspect repository structure - Read README.md",
+    });
+  });
+
+  it("shows completed sub-agent progress in the summary", () => {
+    const display = buildToolCallDisplayModel({
+      name: "task",
+      status: "completed",
+      error: null,
+      detail: {
+        type: "sub_agent",
+        subAgentType: "Explore",
+        description: "Inspect repository structure",
+        log: "[Read] README.md\n[Edit] src/index.ts",
+        actions: [
+          {
+            index: 1,
+            toolName: "Read",
+            summary: "README.md",
+          },
+          {
+            index: 2,
+            toolName: "Edit",
+            summary: "src/index.ts",
+          },
+        ],
+      },
+    });
+
+    expect(display).toEqual({
+      displayName: "Explore",
+      summary: "Completed - Inspect repository structure - Edit src/index.ts - 2 steps",
+    });
+  });
+
+  it("uses task input to label unknown running sub-agents before detail upgrades", () => {
+    const display = buildToolCallDisplayModel({
+      name: "Task",
+      status: "running",
+      error: null,
+      detail: {
+        type: "unknown",
+        input: {
+          subagent_type: "Explore",
+          description: "Inspect repository structure",
+        },
+        output: null,
+      },
+    });
+
+    expect(display).toEqual({
+      displayName: "Explore",
+      summary: "Running - Inspect repository structure",
     });
   });
 

--- a/packages/server/src/server/agent/providers/opencode/tool-call-detail-parser.ts
+++ b/packages/server/src/server/agent/providers/opencode/tool-call-detail-parser.ts
@@ -18,6 +18,7 @@ import {
   toWriteToolDetail,
   toolDetailBranchByToolName,
 } from "../tool-call-detail-primitives.js";
+import { nonEmptyString } from "../tool-call-mapper-utils.js";
 
 const OpencodeKnownToolDetailSchema = z.union([
   toolDetailBranchByToolName(
@@ -82,6 +83,25 @@ const OpencodeKnownToolDetailSchema = z.union([
   ),
   toolDetailBranchByToolName("web_search", ToolSearchInputSchema, z.unknown(), (input) =>
     toSearchToolDetail({ input, toolName: "web_search" }),
+  ),
+  toolDetailBranchByToolName(
+    "task",
+    z
+      .object({
+        subagent_type: z.string().optional(),
+        description: z.string().optional(),
+      })
+      .passthrough(),
+    z.unknown(),
+    (input, output): ToolCallDetail => ({
+      type: "sub_agent",
+      ...(input && nonEmptyString(input.subagent_type)
+        ? { subAgentType: input.subagent_type }
+        : {}),
+      ...(input && nonEmptyString(input.description) ? { description: input.description } : {}),
+      log: typeof output === "string" ? output : "",
+      actions: [],
+    }),
   ),
 ]);
 

--- a/packages/server/src/server/agent/providers/opencode/tool-call-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/opencode/tool-call-mapper.test.ts
@@ -235,6 +235,30 @@ describe("opencode tool-call mapper", () => {
     });
   });
 
+  it("maps task tools to canonical sub-agent detail", () => {
+    const item = expectMapped(
+      mapOpencodeToolCall({
+        toolName: "task",
+        callId: "opencode-task-1",
+        status: "running",
+        input: {
+          subagent_type: "gsd-executor",
+          description: "Execute plan 03-04",
+        },
+        output: null,
+      }),
+    );
+
+    expect(item.name).toBe("task");
+    expect(item.detail).toEqual({
+      type: "sub_agent",
+      subAgentType: "gsd-executor",
+      description: "Execute plan 03-04",
+      log: "",
+      actions: [],
+    });
+  });
+
   it("does not apply cross-provider speak normalization in opencode mapper", () => {
     const item = expectMapped(
       mapOpencodeToolCall({

--- a/packages/server/src/shared/tool-call-display.test.ts
+++ b/packages/server/src/shared/tool-call-display.test.ts
@@ -60,7 +60,59 @@ describe("shared tool-call display mapping", () => {
 
     expect(display).toEqual({
       displayName: "Explore",
-      summary: "Inspect repository structure",
+      summary: "Running - Inspect repository structure - Read README.md",
+    });
+  });
+
+  it("shows completed sub-agent progress in the summary", () => {
+    const display = buildToolCallDisplayModel({
+      name: "task",
+      status: "completed",
+      error: null,
+      detail: {
+        type: "sub_agent",
+        subAgentType: "Explore",
+        description: "Inspect repository structure",
+        log: "[Read] README.md\n[Edit] src/index.ts",
+        actions: [
+          {
+            index: 1,
+            toolName: "Read",
+            summary: "README.md",
+          },
+          {
+            index: 2,
+            toolName: "Edit",
+            summary: "src/index.ts",
+          },
+        ],
+      },
+    });
+
+    expect(display).toEqual({
+      displayName: "Explore",
+      summary: "Completed - Inspect repository structure - Edit src/index.ts - 2 steps",
+    });
+  });
+
+  it("uses task input to label unknown running sub-agents before detail upgrades", () => {
+    const display = buildToolCallDisplayModel({
+      name: "Task",
+      status: "running",
+      error: null,
+      detail: {
+        type: "unknown",
+        input: {
+          subagent_type: "Explore",
+          description: "Inspect repository structure",
+        },
+        output: null,
+      },
+    });
+
+    expect(display).toEqual({
+      displayName: "Explore",
+      summary: "Running - Inspect repository structure",
     });
   });
 

--- a/packages/server/src/shared/tool-call-display.ts
+++ b/packages/server/src/shared/tool-call-display.ts
@@ -20,6 +20,74 @@ type DetailDisplay = {
   summary?: string;
 };
 
+function pluralize(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function joinSummarySegments(...segments: Array<string | undefined>): string | undefined {
+  const definedSegments = segments.filter((segment) => Boolean(segment));
+  return definedSegments.length > 0 ? definedSegments.join(" - ") : undefined;
+}
+
+function formatToolCallStatus(status: ToolCallDisplayInput["status"]): string {
+  switch (status) {
+    case "running":
+      return "Running";
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "canceled":
+      return "Canceled";
+  }
+}
+
+function getLatestSubAgentActionSummary(
+  input: Extract<ToolCallDisplayInput["detail"], { type: "sub_agent" }>,
+): string | undefined {
+  const latestAction = input.actions[input.actions.length - 1];
+  if (!latestAction) {
+    return undefined;
+  }
+
+  return latestAction.summary
+    ? `${latestAction.toolName} ${latestAction.summary}`
+    : latestAction.toolName;
+}
+
+function buildSubAgentSummary(input: ToolCallDisplayInput): string | undefined {
+  if (input.detail.type !== "sub_agent") {
+    return undefined;
+  }
+
+  const description = readString(input.detail.description);
+  const actionCount = input.detail.actions.length;
+  return joinSummarySegments(
+    formatToolCallStatus(input.status),
+    description,
+    getLatestSubAgentActionSummary(input.detail),
+    actionCount > 1 ? pluralize(actionCount, "step", "steps") : undefined,
+  );
+}
+
+function buildUnknownTaskDisplay(input: ToolCallDisplayInput): DetailDisplay {
+  if (input.detail.type !== "unknown" || input.name.trim().toLowerCase() !== "task") {
+    return {};
+  }
+
+  const taskInput = isRecord(input.detail.input) ? input.detail.input : null;
+  const subAgentType = taskInput ? readString(taskInput.subagent_type) : undefined;
+  const description = taskInput ? readString(taskInput.description) : undefined;
+  const activity = isRecord(input.metadata)
+    ? readString(input.metadata.subAgentActivity)
+    : undefined;
+
+  return {
+    displayName: subAgentType ?? "Task",
+    summary: joinSummarySegments(formatToolCallStatus(input.status), activity ?? description),
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -110,7 +178,7 @@ function buildCanonicalDetailDisplay(input: ToolCallDisplayInput): DetailDisplay
     case "sub_agent":
       return {
         displayName: readString(input.detail.subAgentType) ?? "Task",
-        summary: readString(input.detail.description),
+        summary: buildSubAgentSummary(input),
       };
     case "plain_text":
       return {
@@ -128,10 +196,7 @@ function buildCanonicalDetailDisplay(input: ToolCallDisplayInput): DetailDisplay
 function buildUnknownDetailOverride(input: ToolCallDisplayInput): DetailDisplay {
   const lowerName = input.name.trim().toLowerCase();
   if (input.detail.type === "unknown" && lowerName === "task") {
-    return {
-      displayName: "Task",
-      summary: isRecord(input.metadata) ? readString(input.metadata.subAgentActivity) : undefined,
-    };
+    return buildUnknownTaskDisplay(input);
   }
   if (input.detail.type === "unknown" && lowerName === "thinking") {
     return {


### PR DESCRIPTION
## Summary
- show sub-agent type and status more clearly in task badges so background work is readable at a glance
- map OpenCode `task` tool calls to canonical `sub_agent` detail so the shared task UI renders instead of the generic unknown-tool view
- keep the change narrow and add regression tests for shared display formatting and OpenCode task mapping

## Testing
- `rtk npm exec vitest run \"packages/server/src/shared/tool-call-display.test.ts\"`
- `rtk npm run test --workspace=@getpaseo/app -- src/utils/tool-call-display.test.ts`
- `rtk npm exec vitest run \"packages/server/src/server/agent/providers/opencode/tool-call-mapper.test.ts\"`
- `rtk npm run typecheck`

## Contributing Notes
- This PR is intentionally scoped to one focused UX/regression fix.
- I am opening this without linking prior discussion.
- UI screenshots/videos are not included in this PR.