### PR TITLE
Prioritize frequently used slash commands

### DIFF
--- a/packages/app/src/components/agent-input-area.tsx
+++ b/packages/app/src/components/agent-input-area.tsx
@@ -16,6 +16,7 @@ import {
 import { ContextWindowMeter } from "./context-window-meter";
 import { useImageAttachmentPicker } from "@/hooks/use-image-attachment-picker";
 import { useSessionStore } from "@/stores/session-store";
+import { useSlashCommandUsageStore } from "@/stores/slash-command-usage-store";
 import {
   MessageInput,
   type MessagePayload,
@@ -51,6 +52,7 @@ import type { KeyboardActionDefinition } from "@/keyboard/keyboard-action-dispat
 import { submitAgentInput } from "@/components/agent-input-submit";
 import { useAppSettings } from "@/hooks/use-settings";
 import { isWeb, isNative } from "@/constants/platform";
+import { parseSlashCommandName } from "@/utils/slash-command-usage";
 
 type QueuedMessage = {
   id: string;
@@ -235,14 +237,20 @@ export function AgentInputArea({
   const submitMessage = useCallback(
     async (text: string, images?: ImageAttachment[]) => {
       onMessageSent?.();
+      const slashCommandName = parseSlashCommandName(text);
+
       if (onSubmitMessageRef.current) {
         await onSubmitMessageRef.current({ text, images });
-        return;
+      } else {
+        if (!sendAgentMessageRef.current) {
+          throw new Error("Host is not connected");
+        }
+        await sendAgentMessageRef.current(agentIdRef.current, text, images);
       }
-      if (!sendAgentMessageRef.current) {
-        throw new Error("Host is not connected");
+
+      if (slashCommandName) {
+        useSlashCommandUsageStore.getState().recordUsage(slashCommandName);
       }
-      await sendAgentMessageRef.current(agentIdRef.current, text, images);
     },
     [onMessageSent],
   );

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -5,12 +5,14 @@ import { useAgentCommandsQuery, type DraftCommandConfig } from "./use-agent-comm
 import { orderAutocompleteOptions } from "@/components/ui/autocomplete-utils";
 import { useAutocomplete } from "./use-autocomplete";
 import { useSessionStore } from "@/stores/session-store";
+import { useSlashCommandUsageStore } from "@/stores/slash-command-usage-store";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import {
   applyFileMentionReplacement,
   findActiveFileMention,
   type FileMentionRange,
 } from "@/utils/file-mention-autocomplete";
+import { rankSlashCommandsByUsage } from "@/utils/slash-command-usage";
 
 interface UseAgentAutocompleteInput {
   userInput: string;
@@ -46,6 +48,8 @@ interface DirectorySuggestionEntry {
   path: string;
   kind: "file" | "directory";
 }
+
+type AutocompleteMode = "command" | "file" | null;
 
 function normalizeDraftCommandConfig(
   draftConfig?: DraftCommandConfig,
@@ -96,6 +100,75 @@ function mapDirectorySuggestionsToEntries(payload: {
   }));
 }
 
+function getAutocompleteMode(args: {
+  showFileAutocomplete: boolean;
+  showCommandAutocomplete: boolean;
+}): AutocompleteMode {
+  if (args.showFileAutocomplete) {
+    return "file";
+  }
+
+  if (args.showCommandAutocomplete) {
+    return "command";
+  }
+
+  return null;
+}
+
+function getIsAutocompleteVisible(args: {
+  mode: AutocompleteMode;
+  canLoadCommands: boolean;
+  serverId: string;
+  autocompleteCwd: string;
+}): boolean {
+  if (args.mode === "command") {
+    return args.canLoadCommands;
+  }
+
+  if (args.mode === "file") {
+    return Boolean(args.serverId) && args.autocompleteCwd.length > 0;
+  }
+
+  return false;
+}
+
+function getAutocompleteLoadingState(args: {
+  mode: AutocompleteMode;
+  isCommandsLoading: boolean;
+  isFileSuggestionsPending: boolean;
+  isFileSuggestionsLoading: boolean;
+  optionCount: number;
+}): boolean {
+  if (args.mode === "command") {
+    return args.isCommandsLoading;
+  }
+
+  if (args.mode === "file") {
+    return (
+      args.isFileSuggestionsPending || (args.isFileSuggestionsLoading && args.optionCount === 0)
+    );
+  }
+
+  return false;
+}
+
+function getAutocompleteErrorMessage(args: {
+  mode: AutocompleteMode;
+  isCommandError: boolean;
+  commandError: Error | null;
+  fileSuggestionsError: unknown;
+}): string | undefined {
+  if (args.mode === "command") {
+    return args.isCommandError ? (args.commandError?.message ?? "Failed to load") : undefined;
+  }
+
+  if (args.mode === "file" && args.fileSuggestionsError instanceof Error) {
+    return args.fileSuggestionsError.message;
+  }
+
+  return undefined;
+}
+
 export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAutocompleteResult {
   const {
     userInput,
@@ -127,7 +200,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
   );
 
   const isDraftContext = normalizedDraftConfig !== undefined;
-  const queryDraftConfig = isDraftContext ? normalizedDraftConfig : undefined;
+  const queryDraftConfig = normalizedDraftConfig;
   const canLoadCommands = Boolean(serverId) && (Boolean(agentId) || isDraftContext);
 
   const agentCwd = useSessionStore(
@@ -142,18 +215,18 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
 
   const client = useHostRuntimeClient(serverId);
   const isConnected = useHostRuntimeIsConnected(serverId);
+  const commandUsageCounts = useSlashCommandUsageStore((state) => state.usageCountsByCommand);
 
-  const mode: "command" | "file" | null = showFileAutocomplete
-    ? "file"
-    : showCommandAutocomplete
-      ? "command"
-      : null;
-  const isVisible =
-    mode === "command"
-      ? canLoadCommands
-      : mode === "file"
-        ? Boolean(serverId) && autocompleteCwd.length > 0
-        : false;
+  const mode = getAutocompleteMode({
+    showFileAutocomplete,
+    showCommandAutocomplete,
+  });
+  const isVisible = getIsAutocompleteVisible({
+    mode,
+    canLoadCommands,
+    serverId,
+    autocompleteCwd,
+  });
 
   const {
     commands,
@@ -204,7 +277,8 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     if (mode === "command") {
       const filterLower = commandFilterQuery.toLowerCase();
       const matches = commands.filter((cmd) => cmd.name.toLowerCase().includes(filterLower));
-      const orderedMatches = orderAutocompleteOptions(matches);
+      const rankedMatches = rankSlashCommandsByUsage(matches, commandUsageCounts);
+      const orderedMatches = orderAutocompleteOptions(rankedMatches);
       return orderedMatches.map((cmd) => ({
         type: "command" as const,
         id: cmd.name,
@@ -228,7 +302,15 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     }
 
     return [];
-  }, [activeFileMention, commandFilterQuery, commands, fileSuggestionsQuery.data, isVisible, mode]);
+  }, [
+    activeFileMention,
+    commandFilterQuery,
+    commandUsageCounts,
+    commands,
+    fileSuggestionsQuery.data,
+    isVisible,
+    mode,
+  ]);
 
   const onSelectOption = useCallback(
     (option: AutocompleteOption) => {
@@ -258,22 +340,19 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     onEscape: mode === "command" ? () => setUserInput("") : undefined,
   });
 
-  const isLoading =
-    mode === "command"
-      ? isCommandsLoading
-      : mode === "file"
-        ? fileSuggestionsQuery.isPending || (fileSuggestionsQuery.isLoading && options.length === 0)
-        : false;
-  const errorMessage =
-    mode === "command"
-      ? isError
-        ? (error?.message ?? "Failed to load")
-        : undefined
-      : mode === "file"
-        ? fileSuggestionsQuery.error instanceof Error
-          ? fileSuggestionsQuery.error.message
-          : undefined
-        : undefined;
+  const isLoading = getAutocompleteLoadingState({
+    mode,
+    isCommandsLoading,
+    isFileSuggestionsPending: fileSuggestionsQuery.isPending,
+    isFileSuggestionsLoading: fileSuggestionsQuery.isLoading,
+    optionCount: options.length,
+  });
+  const errorMessage = getAutocompleteErrorMessage({
+    mode,
+    isCommandError: isError,
+    commandError: error ?? null,
+    fileSuggestionsError: fileSuggestionsQuery.error,
+  });
 
   const loadingText = mode === "file" ? "Searching workspace..." : "Loading commands...";
   const emptyText = mode === "file" ? "No files or directories found" : "No commands found";

--- a/packages/app/src/hooks/use-agent-commands-query.ts
+++ b/packages/app/src/hooks/use-agent-commands-query.ts
@@ -4,7 +4,7 @@ import type { AgentProvider } from "@server/server/agent/agent-sdk-types";
 
 const COMMANDS_STALE_TIME = 60_000; // Commands rarely change, cache for 1 minute
 
-interface AgentSlashCommand {
+export interface AgentSlashCommand {
   name: string;
   description: string;
   argumentHint: string;

--- a/packages/app/src/stores/slash-command-usage-store.test.ts
+++ b/packages/app/src/stores/slash-command-usage-store.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@react-native-async-storage/async-storage", () => {
+  const storage = new Map<string, string>();
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage.get(key) ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage.set(key, value);
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        storage.delete(key);
+      }),
+    },
+  };
+});
+
+import { useSlashCommandUsageStore } from "@/stores/slash-command-usage-store";
+
+describe("slash-command-usage-store", () => {
+  beforeEach(() => {
+    useSlashCommandUsageStore.setState({
+      usageCountsByCommand: {},
+      recordUsage: useSlashCommandUsageStore.getState().recordUsage,
+    });
+  });
+
+  it("increments usage counts by command name", () => {
+    const store = useSlashCommandUsageStore.getState();
+
+    store.recordUsage("gsd-plan-phase");
+    store.recordUsage("gsd-plan-phase");
+    store.recordUsage("gsd-debug");
+
+    expect(useSlashCommandUsageStore.getState().usageCountsByCommand).toEqual({
+      "gsd-debug": 1,
+      "gsd-plan-phase": 2,
+    });
+  });
+
+  it("ignores blank command names", () => {
+    useSlashCommandUsageStore.getState().recordUsage("   ");
+
+    expect(useSlashCommandUsageStore.getState().usageCountsByCommand).toEqual({});
+  });
+});

--- a/packages/app/src/stores/slash-command-usage-store.ts
+++ b/packages/app/src/stores/slash-command-usage-store.ts
@@ -1,0 +1,36 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+interface SlashCommandUsageState {
+  usageCountsByCommand: Record<string, number>;
+  recordUsage: (commandName: string) => void;
+}
+
+export const useSlashCommandUsageStore = create<SlashCommandUsageState>()(
+  persist(
+    (set) => ({
+      usageCountsByCommand: {},
+      recordUsage: (commandName) => {
+        const normalized = commandName.trim();
+        if (!normalized) {
+          return;
+        }
+
+        set((state) => ({
+          usageCountsByCommand: {
+            ...state.usageCountsByCommand,
+            [normalized]: (state.usageCountsByCommand[normalized] ?? 0) + 1,
+          },
+        }));
+      },
+    }),
+    {
+      name: "slash-command-usage",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        usageCountsByCommand: state.usageCountsByCommand,
+      }),
+    },
+  ),
+);

--- a/packages/app/src/utils/slash-command-usage.test.ts
+++ b/packages/app/src/utils/slash-command-usage.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { orderAutocompleteOptions } from "@/components/ui/autocomplete-utils";
+import type { AgentSlashCommand } from "@/hooks/use-agent-commands-query";
+import { parseSlashCommandName, rankSlashCommandsByUsage } from "./slash-command-usage";
+
+const COMMANDS: AgentSlashCommand[] = [
+  { name: "gsd-debug", description: "", argumentHint: "" },
+  { name: "gsd-plan-phase", description: "", argumentHint: "" },
+  { name: "gsd-review", description: "", argumentHint: "" },
+];
+
+describe("parseSlashCommandName", () => {
+  it("returns the first slash command token", () => {
+    expect(parseSlashCommandName("  /gsd-plan-phase add auth  ")).toBe("gsd-plan-phase");
+  });
+
+  it("returns null for plain prompts and invalid slash inputs", () => {
+    expect(parseSlashCommandName("build the thing")).toBeNull();
+    expect(parseSlashCommandName("/")).toBeNull();
+    expect(parseSlashCommandName("/foo/bar")).toBeNull();
+  });
+});
+
+describe("rankSlashCommandsByUsage", () => {
+  it("sorts higher-usage commands first before above-input reversal", () => {
+    const ranked = rankSlashCommandsByUsage(COMMANDS, {
+      "gsd-plan-phase": 7,
+      "gsd-debug": 2,
+      "gsd-review": 1,
+    });
+
+    expect(ranked.map((command) => command.name)).toEqual([
+      "gsd-plan-phase",
+      "gsd-debug",
+      "gsd-review",
+    ]);
+
+    const rendered = orderAutocompleteOptions(ranked);
+    expect(rendered.at(-1)?.name).toBe("gsd-plan-phase");
+  });
+
+  it("falls back to alphabetical order when usage matches", () => {
+    const ranked = rankSlashCommandsByUsage(COMMANDS, {});
+
+    expect(ranked.map((command) => command.name)).toEqual([
+      "gsd-debug",
+      "gsd-plan-phase",
+      "gsd-review",
+    ]);
+  });
+});

--- a/packages/app/src/utils/slash-command-usage.ts
+++ b/packages/app/src/utils/slash-command-usage.ts
@@ -1,0 +1,33 @@
+import type { AgentSlashCommand } from "@/hooks/use-agent-commands-query";
+
+export function parseSlashCommandName(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("/") || trimmed.length <= 1) {
+    return null;
+  }
+
+  const withoutPrefix = trimmed.slice(1);
+  const firstWhitespaceIndex = withoutPrefix.search(/\s/);
+  const commandName =
+    firstWhitespaceIndex === -1 ? withoutPrefix : withoutPrefix.slice(0, firstWhitespaceIndex);
+
+  if (!commandName || commandName.includes("/")) {
+    return null;
+  }
+
+  return commandName;
+}
+
+export function rankSlashCommandsByUsage(
+  commands: readonly AgentSlashCommand[],
+  usageCounts: Readonly<Record<string, number>>,
+): AgentSlashCommand[] {
+  return [...commands].sort((left, right) => {
+    const usageDelta = (usageCounts[right.name] ?? 0) - (usageCounts[left.name] ?? 0);
+    if (usageDelta !== 0) {
+      return usageDelta;
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+}


### PR DESCRIPTION
## Summary
- track slash command usage locally per app install so ranking works across all projects on that device
- rank slash command autocomplete results by usage before the existing above-input reversal so the most-used match stays nearest the composer
- add focused tests for slash command parsing, ranking, and usage persistence while keeping the change scoped to the app client

## Testing
- npm run test --workspace=@getpaseo/app -- src/utils/slash-command-usage.test.ts src/stores/slash-command-usage-store.test.ts