### PR TITLE
fix(app): bubble child agent permissions to the parent panel

### DIFF
--- a/packages/app/src/hooks/use-aggregated-agents.ts
+++ b/packages/app/src/hooks/use-aggregated-agents.ts
@@ -4,6 +4,7 @@ import { useSessionStore } from "@/stores/session-store";
 import type { AgentDirectoryEntry } from "@/types/agent-directory";
 import type { Agent } from "@/stores/session-store";
 import { getHostRuntimeStore, useHosts } from "@/runtime/host-runtime";
+import { buildSubtreePendingPermissionCounts } from "@/utils/agent-hierarchy";
 
 export interface AggregatedAgent extends AgentDirectoryEntry {
   serverId: string;
@@ -56,6 +57,7 @@ export function useAggregatedAgents(options?: {
         continue;
       }
       const serverLabel = serverLabelById.get(serverId) ?? serverId;
+      const pendingPermissionCounts = buildSubtreePendingPermissionCounts(agents.values());
       for (const agent of agents.values()) {
         if (!includeArchived && agent.archivedAt) {
           continue;
@@ -69,7 +71,7 @@ export function useAggregatedAgents(options?: {
           lastActivityAt: agent.lastActivityAt,
           cwd: agent.cwd,
           provider: agent.provider,
-          pendingPermissionCount: agent.pendingPermissions.length,
+          pendingPermissionCount: pendingPermissionCounts.get(agent.id) ?? 0,
           requiresAttention: agent.requiresAttention,
           attentionReason: agent.attentionReason,
           attentionTimestamp: agent.attentionTimestamp,

--- a/packages/app/src/hooks/use-all-agents-list.ts
+++ b/packages/app/src/hooks/use-all-agents-list.ts
@@ -7,6 +7,7 @@ import {
   useHostRuntimeIsDirectoryLoading,
 } from "@/runtime/host-runtime";
 import type { AggregatedAgent, AggregatedAgentsResult } from "@/hooks/use-aggregated-agents";
+import { buildSubtreePendingPermissionCounts } from "@/utils/agent-hierarchy";
 
 function toAggregatedAgent(params: {
   source: Agent;
@@ -39,14 +40,17 @@ function buildAllAgentsList(params: {
   serverLabel: string;
   includeArchived: boolean;
 }): AggregatedAgent[] {
+  const agents = Array.from(params.agents);
+  const pendingPermissionCounts = buildSubtreePendingPermissionCounts(agents);
   const list: AggregatedAgent[] = [];
 
-  for (const agent of params.agents) {
+  for (const agent of agents) {
     const aggregated = toAggregatedAgent({
       source: agent,
       serverId: params.serverId,
       serverLabel: params.serverLabel,
     });
+    aggregated.pendingPermissionCount = pendingPermissionCounts.get(agent.id) ?? 0;
     if (!params.includeArchived && aggregated.archivedAt) {
       continue;
     }

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/runtime/host-runtime";
 import { getInitDeferred, getInitKey } from "@/utils/agent-initialization";
 import { derivePendingPermissionKey, normalizeAgentSnapshot } from "@/utils/agent-snapshots";
+import { buildSubtreePendingPermissionCounts, isAgentInSubtree } from "@/utils/agent-hierarchy";
 import { mergePendingCreateImages } from "@/utils/pending-create-images";
 import { deriveSidebarStateBucket } from "@/utils/sidebar-agent-state";
 import { useCreateFlowStore } from "@/stores/create-flow-store";
@@ -80,12 +81,16 @@ function useAgentPanelDescriptor(
 ): PanelDescriptor {
   const descriptorState = useSessionStore(
     useShallow((state) => {
-      const agent = state.sessions[context.serverId]?.agents?.get(target.agentId) ?? null;
+      const agents = state.sessions[context.serverId]?.agents;
+      const agent = agents?.get(target.agentId) ?? null;
+      const pendingPermissionCounts = agents
+        ? buildSubtreePendingPermissionCounts(agents.values())
+        : null;
       return {
         provider: agent?.provider ?? "codex",
         title: agent?.title ?? null,
         status: agent?.status ?? null,
-        pendingPermissionCount: agent?.pendingPermissions.length ?? 0,
+        pendingPermissionCount: pendingPermissionCounts?.get(target.agentId) ?? 0,
         requiresAttention: agent?.requiresAttention ?? false,
         attentionReason: agent?.attentionReason ?? null,
       };
@@ -297,6 +302,7 @@ function AgentPanelBody({
   const allPendingPermissions = useSessionStore(
     (state) => state.sessions[serverId]?.pendingPermissions,
   );
+  const allAgents = useSessionStore((state) => state.sessions[serverId]?.agents);
   const setAgents = useSessionStore((state) => state.setAgents);
   const setAgentStreamTail = useSessionStore((state) => state.setAgentStreamTail);
   const setPendingPermissions = useSessionStore((state) => state.setPendingPermissions);
@@ -329,17 +335,17 @@ function AgentPanelBody({
   const hasHydratedHistoryBefore = hasAppliedAuthoritativeHistory;
 
   const pendingPermissions = useMemo(() => {
-    if (!allPendingPermissions || !agentId) {
+    if (!allPendingPermissions || !allAgents || !agentId) {
       return new Map<string, PendingPermission>();
     }
     const filtered = new Map<string, PendingPermission>();
     for (const [key, permission] of allPendingPermissions) {
-      if (permission.agentId === agentId) {
+      if (isAgentInSubtree(allAgents, permission.agentId, agentId)) {
         filtered.set(key, permission);
       }
     }
     return filtered;
-  }, [agentId, allPendingPermissions]);
+  }, [agentId, allAgents, allPendingPermissions]);
 
   const attentionController = useAgentAttentionClear({
     agentId,

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -27,6 +27,7 @@ import type {
   WorkspaceDescriptorPayload,
 } from "@server/shared/messages";
 import { normalizeWorkspaceIdentity } from "@/utils/workspace-identity";
+import { buildSubtreePendingPermissionCounts } from "@/utils/agent-hierarchy";
 import {
   createAgentLastActivityCoalescer,
   type AgentLastActivityCommitter,
@@ -1139,6 +1140,9 @@ export const useSessionStore = create<SessionStore>()(
         }
 
         const entries: AgentDirectoryEntry[] = [];
+        const pendingPermissionCounts = buildSubtreePendingPermissionCounts(
+          session.agents.values(),
+        );
         for (const agent of session.agents.values()) {
           // Get lastActivityAt from top-level slice, fallback to agent.lastActivityAt
           const lastActivityAt = state.agentLastActivity.get(agent.id) ?? agent.lastActivityAt;
@@ -1150,7 +1154,7 @@ export const useSessionStore = create<SessionStore>()(
             lastActivityAt,
             cwd: agent.cwd,
             provider: agent.provider,
-            pendingPermissionCount: agent.pendingPermissions.length,
+            pendingPermissionCount: pendingPermissionCounts.get(agent.id) ?? 0,
             requiresAttention: agent.requiresAttention ?? false,
             attentionReason: agent.attentionReason ?? null,
             attentionTimestamp: agent.attentionTimestamp ?? null,

--- a/packages/app/src/utils/agent-hierarchy.test.ts
+++ b/packages/app/src/utils/agent-hierarchy.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSubtreePendingPermissionCounts,
+  getParentAgentId,
+  isAgentInSubtree,
+} from "./agent-hierarchy";
+
+function makeAgent(input: {
+  id: string;
+  parentAgentId?: string;
+  pendingPermissionCount?: number;
+}): {
+  id: string;
+  labels: Record<string, string>;
+  pendingPermissions: { id: string }[];
+} {
+  return {
+    id: input.id,
+    labels: input.parentAgentId ? { "paseo.parent-agent-id": input.parentAgentId } : {},
+    pendingPermissions: Array.from({ length: input.pendingPermissionCount ?? 0 }, (_, index) => ({
+      id: `${input.id}-request-${index}`,
+    })),
+  };
+}
+
+describe("agent-hierarchy", () => {
+  it("reads parent agent ids from labels", () => {
+    expect(getParentAgentId(makeAgent({ id: "child", parentAgentId: "parent" }))).toBe("parent");
+    expect(getParentAgentId(makeAgent({ id: "root" }))).toBeNull();
+  });
+
+  it("treats descendants as part of the parent subtree", () => {
+    const agents = new Map([
+      ["root", makeAgent({ id: "root" })],
+      ["child", makeAgent({ id: "child", parentAgentId: "root" })],
+      ["grandchild", makeAgent({ id: "grandchild", parentAgentId: "child" })],
+      ["other", makeAgent({ id: "other" })],
+    ]);
+
+    expect(isAgentInSubtree(agents, "root", "root")).toBe(true);
+    expect(isAgentInSubtree(agents, "child", "root")).toBe(true);
+    expect(isAgentInSubtree(agents, "grandchild", "root")).toBe(true);
+    expect(isAgentInSubtree(agents, "other", "root")).toBe(false);
+  });
+
+  it("aggregates pending permission counts across descendants", () => {
+    const counts = buildSubtreePendingPermissionCounts([
+      makeAgent({ id: "root", pendingPermissionCount: 1 }),
+      makeAgent({ id: "child", parentAgentId: "root", pendingPermissionCount: 2 }),
+      makeAgent({ id: "grandchild", parentAgentId: "child", pendingPermissionCount: 3 }),
+      makeAgent({ id: "other", pendingPermissionCount: 4 }),
+    ]);
+
+    expect(counts.get("root")).toBe(6);
+    expect(counts.get("child")).toBe(5);
+    expect(counts.get("grandchild")).toBe(3);
+    expect(counts.get("other")).toBe(4);
+  });
+
+  it("stops walking when parent labels form a cycle", () => {
+    const counts = buildSubtreePendingPermissionCounts([
+      makeAgent({ id: "a", parentAgentId: "b", pendingPermissionCount: 1 }),
+      makeAgent({ id: "b", parentAgentId: "a", pendingPermissionCount: 2 }),
+    ]);
+
+    expect(counts.get("a")).toBe(3);
+    expect(counts.get("b")).toBe(3);
+  });
+});

--- a/packages/app/src/utils/agent-hierarchy.ts
+++ b/packages/app/src/utils/agent-hierarchy.ts
@@ -1,0 +1,82 @@
+const PARENT_AGENT_ID_LABEL = "paseo.parent-agent-id";
+
+type HierarchyAgent = {
+  id: string;
+  labels: Record<string, string>;
+  pendingPermissions?: ReadonlyArray<unknown>;
+};
+
+export function getParentAgentId(agent: Pick<HierarchyAgent, "labels">): string | null {
+  const parentId = agent.labels[PARENT_AGENT_ID_LABEL];
+  if (typeof parentId !== "string") {
+    return null;
+  }
+
+  const normalized = parentId.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function isAgentInSubtree(
+  agentsById: ReadonlyMap<string, Pick<HierarchyAgent, "id" | "labels">>,
+  candidateAgentId: string,
+  ancestorAgentId: string,
+): boolean {
+  let currentAgentId: string | null = candidateAgentId;
+  const visited = new Set<string>();
+
+  while (currentAgentId) {
+    if (currentAgentId === ancestorAgentId) {
+      return true;
+    }
+
+    if (visited.has(currentAgentId)) {
+      return false;
+    }
+    visited.add(currentAgentId);
+
+    const currentAgent = agentsById.get(currentAgentId);
+    if (!currentAgent) {
+      return false;
+    }
+
+    currentAgentId = getParentAgentId(currentAgent);
+  }
+
+  return false;
+}
+
+export function buildSubtreePendingPermissionCounts(
+  agents: Iterable<HierarchyAgent>,
+): Map<string, number> {
+  const ownCounts = new Map<string, number>();
+  const counts = new Map<string, number>();
+  const parentById = new Map<string, string | null>();
+
+  for (const agent of agents) {
+    const ownCount = agent.pendingPermissions?.length ?? 0;
+    ownCounts.set(agent.id, ownCount);
+    counts.set(agent.id, ownCount);
+    parentById.set(agent.id, getParentAgentId(agent));
+  }
+
+  for (const [agentId, ownCount] of ownCounts.entries()) {
+    if (ownCount === 0) {
+      continue;
+    }
+
+    const visited = new Set<string>([agentId]);
+    let parentAgentId = parentById.get(agentId) ?? null;
+
+    while (parentAgentId) {
+      if (visited.has(parentAgentId)) {
+        break;
+      }
+      visited.add(parentAgentId);
+
+      counts.set(parentAgentId, (counts.get(parentAgentId) ?? 0) + ownCount);
+      parentAgentId = parentById.get(parentAgentId) ?? null;
+    }
+  }
+
+  return counts;
+}


### PR DESCRIPTION
## Summary
- surface descendant agent permission requests in the parent panel so nested agent flows can be approved in place
- aggregate pending permission counts through the agent hierarchy so panel badges and agent lists stay in sync with the approval UI
- add hierarchy-focused tests and keep the change scoped to this permission flow regression

## Why
Nested OpenCode agent runs can pause on a child permission request while the parent panel looks idle. Bubbling those requests into the parent view keeps the approval flow visible where users are already watching the run.

## Testing
- `rtk npm run test --workspace=@getpaseo/app -- agent-hierarchy.test.ts use-all-agents-list.test.ts`
- `rtk npm run format`
- `rtk npm run typecheck`

## UI
- No screenshots or video attached. This changes the existing permission cards shown in the parent panel rather than introducing new UI chrome.