### PR TITLE
fix: auto-disable web search for custom providers with non-Anthropic endpoints

### DIFF
--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -64,6 +64,7 @@ export const ProviderOverrideSchema = z
     command: z.array(z.string().min(1)).min(1).optional(),
     env: z.record(z.string()).optional(),
     models: z.array(ProviderProfileModelSchema).optional(),
+    webSearch: z.boolean().optional(),
     enabled: z.boolean().optional(),
     order: z.number().optional(),
   })

--- a/packages/server/src/server/agent/providers/claude-agent.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.ts
@@ -2145,7 +2145,32 @@ class ClaudeAgentSession implements AgentSession {
     if (this.claudeSessionId) {
       base.resume = this.claudeSessionId;
     }
+
+    if (this.shouldDisableWebSearch()) {
+      base.disallowedTools = [...(base.disallowedTools ?? []), "WebSearch"];
+    }
+
     return this.applyRuntimeSettings(base);
+  }
+
+  private shouldDisableWebSearch(): boolean {
+    if (this.config.webSearch === false) {
+      return true;
+    }
+    if (this.config.webSearch === true) {
+      return false;
+    }
+    const baseUrl =
+      this.runtimeSettings?.env?.["ANTHROPIC_BASE_URL"] ??
+      process.env["ANTHROPIC_BASE_URL"];
+    if (!baseUrl) {
+      return false;
+    }
+    try {
+      return !new URL(baseUrl).hostname.endsWith("anthropic.com");
+    } catch {
+      return false;
+    }
   }
 
   private applyRuntimeSettings(options: ClaudeOptions): ClaudeOptions {


### PR DESCRIPTION
## Summary

Fixes #390 — when a custom provider `extends: "claude"` with a third-party `ANTHROPIC_BASE_URL` (e.g., Alibaba Bailian/dashscope, z.ai), the Claude Agent SDK internally uses Anthropic's server-side `web_search_20250305` tool. Third-party APIs don't support this server tool type, causing search errors.

**Changes:**

- **`claude-agent.ts`**: Added `shouldDisableWebSearch()` that auto-detects non-Anthropic endpoints and adds `"WebSearch"` to `disallowedTools`. Logic:
  1. `config.webSearch === false` → always disable (explicit user opt-out)
  2. `config.webSearch === true` → always enable (explicit user opt-in)
  3. Otherwise → auto-detect: disable if `ANTHROPIC_BASE_URL` hostname doesn't end with `anthropic.com`

- **`provider-launch-config.ts`**: Added `webSearch: z.boolean().optional()` to `ProviderOverrideSchema` so users can explicitly control this per-provider in `config.json`

**Example config with explicit override:**
```json
{
  "agents": {
    "providers": {
      "bailian": {
        "extends": "claude",
        "env": {
          "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic"
        },
        "webSearch": false
      }
    }
  }
}
```

In most cases, users don't need to set `webSearch` — it auto-detects based on the API endpoint.

## Test plan

- [ ] Custom provider with non-Anthropic `ANTHROPIC_BASE_URL` → web search auto-disabled, no "model not found" or "no web search tool" errors
- [ ] Custom provider with `"webSearch": true` → web search enabled even for non-Anthropic endpoint
- [ ] Custom provider with `"webSearch": false` → web search disabled even for Anthropic endpoint
- [ ] Default Claude provider (no custom URL) → web search works as before
- [ ] `disallowedTools` from `extra.claude` config is preserved (additive, not overwritten)