### PR TITLE
feat: add custom models and fix context window overflow

### DIFF
--- a/packages/server/src/server/agent/providers/claude-agent.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.ts
@@ -2131,6 +2131,7 @@ class ClaudeAgentSession implements AgentSession {
       ...(this.claudeSessionId ? { resume: this.claudeSessionId } : {}),
       ...(thinking ? { thinking } : {}),
       ...(effort ? { effort } : {}),
+      ...this.calculateMaxTokens(),
       ...this.config.extra?.claude,
     };
 
@@ -2150,6 +2151,40 @@ class ClaudeAgentSession implements AgentSession {
 
   private applyRuntimeSettings(options: ClaudeOptions): ClaudeOptions {
     return applyRuntimeSettingsToClaudeOptions(options, this.runtimeSettings, this.launchEnv);
+  }
+
+  /**
+   * Calculate the maximum output tokens based on remaining context window space.
+   * This prevents "input tokens + output tokens exceeds context limit" errors.
+   *
+   * When using thinking: { type: "adaptive" }, the SDK defaults to 32000 max_tokens,
+   * which can exceed the context window for long-running sessions with accumulated history.
+   *
+   * @returns An object with maxTokens property, or empty object if context window info is unavailable.
+   */
+  private calculateMaxTokens(): { maxTokens: number } | {} {
+    // If we don't have context window info yet, let the SDK use its default
+    if (this.lastContextWindowMaxTokens === undefined) {
+      return {};
+    }
+
+    const maxTokens = this.lastContextWindowMaxTokens;
+    const usedTokens = this.lastContextWindowUsedTokens ?? 0;
+    const remainingTokens = maxTokens - usedTokens;
+
+    // Leave a 10% buffer for safety and intermediate operations
+    const bufferRatio = 0.1;
+    const safeMaxTokens = Math.floor(remainingTokens * (1 - bufferRatio));
+
+    // Ensure we have at least 4096 tokens for reasonable responses
+    // but don't exceed what's actually available
+    const minTokens = 4096;
+    const result = Math.max(minTokens, safeMaxTokens);
+
+    // If even the minimum exceeds remaining space, use what's available
+    const finalMaxTokens = remainingTokens < minTokens ? Math.max(1024, remainingTokens) : result;
+
+    return { maxTokens: finalMaxTokens };
   }
 
   private normalizeMcpServers(

--- a/packages/server/src/server/agent/providers/claude/claude-models.ts
+++ b/packages/server/src/server/agent/providers/claude/claude-models.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { AgentModelDefinition } from "../../agent-sdk-types.js";
 
 const CLAUDE_THINKING_OPTIONS = [
@@ -38,8 +41,60 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
   },
 ];
 
-export function getClaudeModels(): AgentModelDefinition[] {
-  return CLAUDE_MODELS.map((model) => ({ ...model }));
+interface ClaudeSettings {
+  model?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Read custom model from ~/.claude/settings.json if configured.
+ * Returns the custom model definition or null if not configured.
+ */
+async function readCustomModelFromSettings(): Promise<AgentModelDefinition | null> {
+  try {
+    const configDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+    const settingsPath = path.join(configDir, "settings.json");
+
+    const settingsContent = await fs.promises.readFile(settingsPath, "utf8");
+    const settings: ClaudeSettings = JSON.parse(settingsContent);
+
+    const customModel = settings.model;
+    if (!customModel || typeof customModel !== "string") {
+      return null;
+    }
+
+    // Don't return custom model if it's already in the built-in list
+    const existingModelIds = new Set(CLAUDE_MODELS.map((m) => m.id));
+    if (existingModelIds.has(customModel)) {
+      return null;
+    }
+
+    return {
+      provider: "claude",
+      id: customModel,
+      label: customModel,
+      description: "Custom model from ~/.claude/settings.json",
+    };
+  } catch (error) {
+    // Silently ignore errors - settings.json may not exist or be invalid
+    return null;
+  }
+}
+
+/**
+ * Get Claude models including custom models from ~/.claude/settings.json.
+ * The custom model (if configured and not already in the built-in list) is prepended.
+ */
+export async function getClaudeModels(): Promise<AgentModelDefinition[]> {
+  const customModel = await readCustomModelFromSettings();
+
+  const models = CLAUDE_MODELS.map((model) => ({ ...model }));
+
+  if (customModel) {
+    models.unshift(customModel);
+  }
+
+  return models;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add custom model support reading from ~/.claude/settings.json
- Dynamically calculate max_tokens to prevent context overflow errors

## Test plan
- [ ] Typecheck passes
- [ ] Custom models are read from ~/.claude/settings.json
- [ ] Context window overflow errors are prevented