### PR TITLE
feat: support git submodule diffs in the Changes panel

### DIFF
--- a/packages/app/src/components/git-diff-pane.tsx
+++ b/packages/app/src/components/git-diff-pane.tsx
@@ -72,6 +72,7 @@ import { openExternalUrl } from "@/utils/open-external-url";
 import { GitActionsSplitButton } from "@/components/git-actions-split-button";
 import { usePanelStore } from "@/stores/panel-store";
 import { buildWorkspaceExplorerStateKey } from "@/hooks/use-file-explorer-actions";
+import { buildAbsoluteExplorerPath } from "@/utils/explorer-paths";
 import { useToast } from "@/contexts/toast-context";
 import {
   formatDiffContentText,
@@ -488,13 +489,142 @@ const DiffFileHeader = memo(function DiffFileHeader({
           )}
         </View>
         <View style={styles.fileHeaderRight}>
-          <Text style={styles.additions}>+{file.additions}</Text>
-          <Text style={styles.deletions}>-{file.deletions}</Text>
+          {file.isSubmodule ? (
+            <>
+              {file.submodule?.isDirty && <Text style={styles.additions}>+dirty</Text>}
+              <Text style={styles.additions}>+{file.submodule?.newCommit?.slice(0, 7) ?? "?"}</Text>
+              <Text style={styles.deletions}>-{file.submodule?.oldCommit?.slice(0, 7) ?? "?"}</Text>
+            </>
+          ) : (
+            <>
+              <Text style={styles.additions}>+{file.additions}</Text>
+              <Text style={styles.deletions}>-{file.deletions}</Text>
+            </>
+          )}
         </View>
       </Pressable>
     </View>
   );
 });
+
+function NestedDiffList({
+  serverId,
+  cwd,
+  layout,
+  wrapLines,
+}: {
+  serverId: string;
+  cwd: string;
+  layout: "unified" | "split";
+  wrapLines: boolean;
+}) {
+  const { status, isLoading: isStatusLoading } = useCheckoutStatusQuery({ serverId, cwd });
+  const gitStatus = status && status.isGit ? status : null;
+  const baseRef = gitStatus?.baseRef ?? undefined;
+  const hasUncommittedChanges = Boolean(gitStatus?.isDirty);
+  const diffMode = hasUncommittedChanges ? "uncommitted" : "base";
+
+  const { files, isLoading: isDiffLoading } = useCheckoutDiffQuery({
+    serverId,
+    cwd,
+    mode: diffMode,
+    baseRef,
+    enabled: Boolean(gitStatus),
+  });
+
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
+
+  const handleToggle = useCallback((path: string) => {
+    setExpandedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }, []);
+
+  if (isStatusLoading || isDiffLoading) {
+    return (
+      <View style={styles.nestedDiffLoading}>
+        <ActivityIndicator size="small" />
+      </View>
+    );
+  }
+
+  if (files.length === 0) {
+    return (
+      <View style={styles.nestedDiffEmpty}>
+        <Text style={styles.nestedDiffEmptyText}>No changes in submodule</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.nestedDiffList}>
+      {files.map((nestedFile) => {
+        const isExpanded = expandedPaths.has(nestedFile.path);
+        return (
+          <View key={nestedFile.path}>
+            <DiffFileHeader
+              file={nestedFile}
+              isExpanded={isExpanded}
+              onToggle={handleToggle}
+              testID={undefined}
+            />
+            {isExpanded && (
+              <DiffFileBody
+                file={nestedFile}
+                layout={layout}
+                wrapLines={wrapLines}
+                testID={undefined}
+                cwd={cwd}
+                serverId={serverId}
+              />
+            )}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function SubmoduleDiffBody({
+  file,
+  cwd,
+  serverId,
+  layout,
+  wrapLines,
+}: {
+  file: ParsedDiffFile;
+  cwd: string;
+  serverId: string;
+  layout: "unified" | "split";
+  wrapLines: boolean;
+}) {
+  const submodulePath = buildAbsoluteExplorerPath({
+    workspaceRoot: cwd,
+    entryPath: file.path,
+  });
+
+  const { theme } = useUnistyles();
+
+  return (
+    <View style={styles.submoduleBody}>
+      {file.submodule?.logSummary && (
+        <Text style={styles.submoduleLogSummary(theme)}>{file.submodule.logSummary}</Text>
+      )}
+      <NestedDiffList
+        serverId={serverId}
+        cwd={submodulePath}
+        layout={layout}
+        wrapLines={wrapLines}
+      />
+    </View>
+  );
+}
 
 function DiffFileBody({
   file,
@@ -502,12 +632,16 @@ function DiffFileBody({
   wrapLines,
   onBodyHeightChange,
   testID,
+  cwd,
+  serverId,
 }: {
   file: ParsedDiffFile;
   layout: "unified" | "split";
   wrapLines: boolean;
   onBodyHeightChange?: (path: string, height: number) => void;
   testID?: string;
+  cwd: string;
+  serverId: string;
 }) {
   const [scrollViewWidth, setScrollViewWidth] = useState(0);
   const [bodyWidth, setBodyWidth] = useState(0);
@@ -522,6 +656,18 @@ function DiffFileBody({
       testID={testID}
     >
       {(() => {
+        if (file.isSubmodule) {
+          return (
+            <SubmoduleDiffBody
+              file={file}
+              cwd={cwd}
+              serverId={serverId}
+              layout={layout}
+              wrapLines={wrapLines}
+            />
+          );
+        }
+
         if (file.status === "too_large" || file.status === "binary") {
           return (
             <View style={styles.statusMessageContainer}>
@@ -1074,6 +1220,8 @@ export function GitDiffPane({ serverId, workspaceId, cwd, hideHeaderRow }: GitDi
           wrapLines={wrapLines}
           onBodyHeightChange={handleBodyHeightChange}
           testID={`diff-file-${item.fileIndex}-body`}
+          cwd={cwd}
+          serverId={serverId}
         />
       );
     },
@@ -1083,6 +1231,8 @@ export function GitDiffPane({ serverId, workspaceId, cwd, hideHeaderRow }: GitDi
       handleHeaderHeightChange,
       handleToggleExpanded,
       wrapLines,
+      cwd,
+      serverId,
     ],
   );
 
@@ -1822,6 +1972,37 @@ const styles = StyleSheet.create((theme) => ({
     fontSize: theme.fontSize.xs,
     fontWeight: theme.fontWeight.normal,
     color: theme.colors.diffDeletion,
+  },
+  submoduleBody: {
+    padding: theme.spacing[4],
+    gap: theme.spacing[3],
+    borderTopWidth: theme.borderWidth[1],
+    borderTopColor: theme.colors.border,
+    backgroundColor: theme.colors.surface1,
+  },
+  submoduleLogSummary: (t: typeof theme) => ({
+    fontSize: t.fontSize.xs,
+    color: t.colors.foregroundMuted,
+    lineHeight: t.fontSize.xs * 1.5,
+  }),
+  nestedDiffList: {
+    marginTop: theme.spacing[2],
+    borderRadius: theme.borderRadius.base,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    overflow: "hidden",
+  },
+  nestedDiffLoading: {
+    padding: theme.spacing[4],
+    alignItems: "center",
+  },
+  nestedDiffEmpty: {
+    padding: theme.spacing[4],
+    alignItems: "center",
+  },
+  nestedDiffEmptyText: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
   },
   diffContent: {
     borderTopWidth: theme.borderWidth[1],

--- a/packages/app/src/utils/diff-highlighter.ts
+++ b/packages/app/src/utils/diff-highlighter.ts
@@ -22,6 +22,14 @@ export interface ParsedDiffFile {
   additions: number;
   deletions: number;
   hunks: DiffHunk[];
+  status?: "ok" | "too_large" | "binary";
+  isSubmodule?: boolean;
+  submodule?: {
+    oldCommit: string | null;
+    newCommit: string | null;
+    isDirty?: boolean;
+    logSummary?: string;
+  };
 }
 
 /**

--- a/packages/server/src/server/utils/diff-highlighter.ts
+++ b/packages/server/src/server/utils/diff-highlighter.ts
@@ -24,6 +24,13 @@ export interface ParsedDiffFile {
   deletions: number;
   hunks: DiffHunk[];
   status?: "ok" | "too_large" | "binary";
+  isSubmodule?: boolean;
+  submodule?: {
+    oldCommit: string | null;
+    newCommit: string | null;
+    isDirty?: boolean;
+    logSummary?: string;
+  };
 }
 
 interface HighlightDiffWithFileContentOptions {

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1251,6 +1251,15 @@ const DiffHunkSchema = z.object({
   lines: z.array(DiffLineSchema),
 });
 
+const SubmoduleDiffSchema = z
+  .object({
+    oldCommit: z.string().nullable(),
+    newCommit: z.string().nullable(),
+    isDirty: z.boolean().optional(),
+    logSummary: z.string().optional(),
+  })
+  .optional();
+
 const ParsedDiffFileSchema = z.object({
   path: z.string(),
   isNew: z.boolean(),
@@ -1259,6 +1268,8 @@ const ParsedDiffFileSchema = z.object({
   deletions: z.number(),
   hunks: z.array(DiffHunkSchema),
   status: z.enum(["ok", "too_large", "binary"]).optional(),
+  isSubmodule: z.boolean().optional(),
+  submodule: SubmoduleDiffSchema,
 });
 
 const FileExplorerEntrySchema = z.object({

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -65,6 +65,7 @@ type CheckoutFileChange = {
   isNew: boolean;
   isDeleted: boolean;
   isUntracked?: boolean;
+  isSubmodule?: boolean;
 };
 
 function normalizeBranchSuggestionName(raw: string): string | null {
@@ -202,6 +203,7 @@ async function listCheckoutFileChanges(
   cwd: string,
   ref: string,
   ignoreWhitespace = false,
+  submodulePaths: Set<string> = new Set(),
 ): Promise<CheckoutFileChange[]> {
   const changes: CheckoutFileChange[] = [];
 
@@ -231,6 +233,7 @@ async function listCheckoutFileChanges(
           status: rawStatus,
           isNew: false,
           isDeleted: false,
+          isSubmodule: submodulePaths.has(newPath),
         });
       }
       continue;
@@ -244,6 +247,7 @@ async function listCheckoutFileChanges(
       status: rawStatus,
       isNew: code === "A",
       isDeleted: code === "D",
+      isSubmodule: submodulePaths.has(path),
     });
   }
 
@@ -1212,6 +1216,144 @@ export async function getCheckoutShortstat(
   }
 }
 
+async function listSubmodulePaths(cwd: string): Promise<Set<string>> {
+  try {
+    const { stdout } = await runGitCommand(["ls-files", "--stage"], {
+      cwd,
+      env: READ_ONLY_GIT_ENV,
+    });
+    const paths = new Set<string>();
+    for (const line of stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean)) {
+      // format: "<mode> <sha> <stage>\t<path>"
+      const tabParts = line.split("\t");
+      if (tabParts.length < 2) continue;
+      const metaParts = tabParts[0].split(/\s+/);
+      const mode = metaParts[0];
+      const filePath = tabParts[1];
+      if (mode === "160000" && filePath) {
+        paths.add(filePath);
+      }
+    }
+    return paths;
+  } catch {
+    return new Set();
+  }
+}
+
+async function getSubmoduleDiffInfo(
+  cwd: string,
+  ref: string,
+  path: string,
+): Promise<{
+  oldCommit: string | null;
+  newCommit: string | null;
+  isDirty: boolean;
+  logSummary?: string;
+}> {
+  let oldCommit: string | null = null;
+  let newCommit: string | null = null;
+  let isDirty = false;
+
+  try {
+    const { stdout } = await runGitCommand(["rev-parse", `${ref}:${path}`], {
+      cwd,
+      env: READ_ONLY_GIT_ENV,
+    });
+    oldCommit = stdout.trim() || null;
+  } catch {
+    oldCommit = null;
+  }
+
+  if (ref === "HEAD") {
+    // For uncommitted diffs, the "new" commit is the submodule's current HEAD in the working tree.
+    try {
+      const { stdout } = await runGitCommand(["rev-parse", "HEAD"], {
+        cwd: `${cwd}/${path}`,
+        env: READ_ONLY_GIT_ENV,
+      });
+      newCommit = stdout.trim() || null;
+    } catch {
+      newCommit = null;
+    }
+
+    // If working tree HEAD matches the old commit, check the index in case a new pointer was staged.
+    if (newCommit === oldCommit) {
+      try {
+        const { stdout } = await runGitCommand(["ls-files", "--stage", path], {
+          cwd,
+          env: READ_ONLY_GIT_ENV,
+        });
+        const parts = stdout.trim().split(/\s+/);
+        if (parts[1]) {
+          newCommit = parts[1];
+        }
+      } catch {
+        // keep working tree value
+      }
+    }
+  } else {
+    // For base diffs, the "new" commit is the one recorded in the current branch HEAD.
+    try {
+      const { stdout } = await runGitCommand(["rev-parse", `HEAD:${path}`], {
+        cwd,
+        env: READ_ONLY_GIT_ENV,
+      });
+      newCommit = stdout.trim() || null;
+    } catch {
+      newCommit = null;
+    }
+  }
+
+  // Detect uncommitted changes inside the submodule (working tree or staged).
+  try {
+    const wtResult = await runGitCommand(["diff", "--quiet"], {
+      cwd: `${cwd}/${path}`,
+      env: READ_ONLY_GIT_ENV,
+      acceptExitCodes: [0, 1],
+    });
+    isDirty = wtResult.exitCode === 1;
+  } catch {
+    isDirty = false;
+  }
+
+  if (!isDirty) {
+    try {
+      const stagedResult = await runGitCommand(["diff", "--cached", "--quiet"], {
+        cwd: `${cwd}/${path}`,
+        env: READ_ONLY_GIT_ENV,
+        acceptExitCodes: [0, 1],
+      });
+      isDirty = stagedResult.exitCode === 1;
+    } catch {
+      // keep previous value
+    }
+  }
+
+  let logSummary: string | undefined;
+  if (oldCommit && newCommit && oldCommit !== newCommit) {
+    try {
+      const { stdout } = await runGitCommand(
+        ["log", "--oneline", "--no-decorate", `${oldCommit}..${newCommit}`],
+        { cwd: `${cwd}/${path}`, env: READ_ONLY_GIT_ENV },
+      );
+      const lines = stdout.split("\n").filter(Boolean);
+      if (lines.length > 0) {
+        logSummary =
+          lines.length === 1
+            ? lines[0]
+            : `${lines.length} commits: ${lines[0]}${lines[1] ? ", " + lines[1] : ""}`;
+      }
+    } catch {
+      // ignore failures to gather log summary
+    }
+  }
+
+  return { oldCommit, newCommit, isDirty, logSummary };
+}
+
 export async function getCheckoutDiff(
   cwd: string,
   compare: CheckoutDiffCompare,
@@ -1239,7 +1381,8 @@ export async function getCheckoutDiff(
   }
 
   const ignoreWhitespace = compare.ignoreWhitespace === true;
-  const changes = await listCheckoutFileChanges(cwd, refForDiff, ignoreWhitespace);
+  const submodulePaths = await listSubmodulePaths(cwd);
+  const changes = await listCheckoutFileChanges(cwd, refForDiff, ignoreWhitespace, submodulePaths);
   changes.sort((a, b) => {
     if (a.path === b.path) return 0;
     return a.path < b.path ? -1 : 1;
@@ -1266,10 +1409,14 @@ export async function getCheckoutDiff(
 
   const trackedChanges = changes.filter((change) => !change.isUntracked);
   const untrackedChanges = changes.filter((change) => change.isUntracked === true);
+
+  const submoduleChanges = trackedChanges.filter((change) => change.isSubmodule);
+  const regularTrackedChanges = trackedChanges.filter((change) => !change.isSubmodule);
+
   const trackedChangeByPath = new Map(trackedChanges.map((change) => [change.path, change]));
 
   const trackedNumstatByPath =
-    trackedChanges.length > 0
+    regularTrackedChanges.length > 0
       ? await getTrackedNumstatByPath(cwd, refForDiff, ignoreWhitespace)
       : new Map<string, FileStat>();
   const trackedDiffPaths: string[] = [];
@@ -1278,7 +1425,7 @@ export async function getCheckoutDiff(
     { status: "binary" | "too_large"; stat: FileStat }
   >();
 
-  for (const change of trackedChanges) {
+  for (const change of regularTrackedChanges) {
     const stat = trackedNumstatByPath.get(change.path) ?? null;
     if (stat?.isBinary) {
       trackedPlaceholderByPath.set(change.path, { status: "binary", stat });
@@ -1325,6 +1472,31 @@ export async function getCheckoutDiff(
   };
 
   if (compare.includeStructured) {
+    // Process submodule changes first so they don't participate in the regular diff batch.
+    const submoduleDiffInfos = await Promise.all(
+      submoduleChanges.map((change) =>
+        getSubmoduleDiffInfo(cwd, refForDiff, change.path).then((info) => ({ change, info })),
+      ),
+    );
+    for (const { change, info } of submoduleDiffInfos) {
+      structured.push({
+        path: change.path,
+        isNew: change.isNew,
+        isDeleted: change.isDeleted,
+        additions: 0,
+        deletions: 0,
+        hunks: [],
+        status: "ok",
+        isSubmodule: true,
+        submodule: {
+          oldCommit: info.oldCommit,
+          newCommit: info.newCommit,
+          isDirty: info.isDirty,
+          logSummary: info.logSummary,
+        },
+      });
+    }
+
     const parsedTrackedFiles =
       trackedDiffText.length > 0
         ? await parseAndHighlightDiff(trackedDiffText, cwd, {
@@ -1340,7 +1512,7 @@ export async function getCheckoutDiff(
         : [];
     const parsedTrackedByPath = new Map(parsedTrackedFiles.map((file) => [file.path, file]));
 
-    for (const change of trackedChanges) {
+    for (const change of regularTrackedChanges) {
       const placeholder = trackedPlaceholderByPath.get(change.path);
       if (placeholder) {
         structured.push(
@@ -1384,7 +1556,7 @@ export async function getCheckoutDiff(
       });
     }
   } else {
-    for (const change of trackedChanges) {
+    for (const change of regularTrackedChanges) {
       const placeholder = trackedPlaceholderByPath.get(change.path);
       if (placeholder) {
         appendTrackedPlaceholderComment(change, placeholder.status);


### PR DESCRIPTION
## Summary

Closes #308

This PR adds first-class support for git submodules in the Changes panel:

- **Server-side detection**: submodules are identified via `git ls-files --stage` (mode `160000`) instead of relying on `git submodule status`, which can miss uninitialized entries.
- **Commit range extraction**: for each submodule change we compute the old commit (from the base ref) and the new commit (from the working tree or index). A short `git log --oneline` summary is also generated when the pointer moved.
- **Dirty state detection**: submodules with uncommitted working-tree or staged changes are flagged using `git diff --quiet` / `git diff --cached --quiet`.
- **Schema update**: `ParsedDiffFile` now carries optional `isSubmodule` and `submodule` fields (backward-compatible for old clients).
- **UI rendering**:
  - Submodule entries show the new short hash in green (`+`) and the old short hash in red (`-`) inline in the file header.
  - If the submodule is dirty but the pointer hasn't moved, `+dirty` is shown.
  - Expanding a submodule reveals its log summary and a nested diff list of the submodule's own changes.

## Screenshots

### Desktop
<img height="300" alt="paseo-pc-submodule-example" src="https://github.com/user-attachments/assets/17d78ba0-9af9-4f1f-b9d0-803f9c89e76c" />


### Mobile
<img height="300" alt="paseo-submodule-mobile-example" src="https://github.com/user-attachments/assets/8ff93e1d-5e61-4b4f-8785-bd4c83923cf9" />



## Test plan

- [x] Verified submodule entries appear with correct `+newHash -oldHash` badges
- [x] Verified dirty submodules show `+dirty`
- [x] Verified nested diff loads when expanding a submodule
- [x] Verified `.gitmodules` changes still render as normal file diffs
- [x] `npm run typecheck` passes
- [x] `npm run format` passes

## Backward compatibility

All new schema fields are `.optional()`, so old mobile clients connecting to a newer daemon will continue to work without changes.