### PR TITLE
fix: prevent args doubling when ACP command mode is "replace"

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -570,7 +570,10 @@ export class ACPAgentClient implements AgentClient {
     });
     return {
       command: prefix.command,
-      args: [...prefix.args, ...this.defaultCommand.slice(1)],
+      args:
+        this.runtimeSettings?.command?.mode === "replace"
+          ? prefix.args
+          : [...prefix.args, ...this.defaultCommand.slice(1)],
     };
   }
 
@@ -1328,7 +1331,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     });
 
     const command = prefix.command;
-    const args = [...prefix.args, ...this.defaultCommand.slice(1)];
+    const args =
+      this.runtimeSettings?.command?.mode === "replace"
+        ? prefix.args
+        : [...prefix.args, ...this.defaultCommand.slice(1)];
     const child = spawnProcess(command, args, {
       cwd: this.config.cwd,
       env: {


### PR DESCRIPTION
## Summary

Fixes a bug where ACP provider subcommands are doubled when `command.mode` is set to `"replace"`.

## Bug

When an ACP provider is configured with a custom command like:

```json
{
  "command": {
    "mode": "replace",
    "argv": ["/path/to/binary", "subcommand"]
  }
}
```

The spawned process receives `["subcommand", "subcommand"]` instead of just `["subcommand"]`.

## Root Cause

`resolveProviderCommandPrefix()` (in `provider-launch-config.ts`) already returns the complete argument list for `"replace"` mode via `argv.slice(1)`. However, both `resolveLaunchCommand()` and `spawnProcess()` in `acp-agent.ts` unconditionally concatenated `this.defaultCommand.slice(1)` onto `prefix.args`, resulting in duplicated arguments.

## Fix

In both call sites (`resolveLaunchCommand` at ~L573 and `spawnProcess` at ~L1331), conditionally skip the default command args when mode is `"replace"`:

```typescript
const args = this.runtimeSettings?.command?.mode === "replace"
    ? prefix.args
    : [...prefix.args, ...this.defaultCommand.slice(1)];
```

For `"default"` and `"append"` modes, behavior is unchanged — `prefix.args` is empty or user-specified respectively, and the default command args are still appended.

## Testing

- Verified no new TypeScript errors introduced (pre-existing errors unrelated to this change)
- Biome formatting applied