### PR TITLE
Fix duplicate command args for generic ACP providers

### DIFF
--- a/packages/app/src/components/message-input.tsx
+++ b/packages/app/src/components/message-input.tsx
@@ -45,6 +45,7 @@ import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
 import { formatShortcut } from "@/utils/format-shortcut";
 import { getShortcutOs } from "@/utils/shortcut-platform";
 import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
+import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
 import {
   markScrollInvestigationEvent,
   markScrollInvestigationRender,
@@ -895,7 +896,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(funct
     // IME composition in progress (e.g. CJK input) — all key events belong to the
     // IME, not the app. keyCode 229 is a Chromium fallback for when isComposing is
     // cleared before the keydown fires.
-    if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) return;
+    if (isImeComposingKeyboardEvent(event.nativeEvent)) return;
 
     // Allow parent to intercept key events (e.g., for autocomplete navigation)
     if (onKeyPressCallback) {

--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -27,6 +27,7 @@ import { getShortcutOs } from "@/utils/shortcut-platform";
 import { useOpenProjectPicker } from "@/hooks/use-open-project-picker";
 import { useKeyboardShortcutOverrides } from "@/hooks/use-keyboard-shortcut-overrides";
 import { isNative } from "@/constants/platform";
+import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
 
 export function useKeyboardShortcuts({
   enabled,
@@ -320,6 +321,12 @@ export function useKeyboardShortcuts({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!shouldHandle()) {
+        return;
+      }
+
+      // During IME composition, Enter confirms the candidate selection and must
+      // not route through global shortcuts like message send.
+      if (isImeComposingKeyboardEvent(event)) {
         return;
       }
 

--- a/packages/app/src/utils/keyboard-ime.test.ts
+++ b/packages/app/src/utils/keyboard-ime.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { isImeComposingKeyboardEvent } from "./keyboard-ime";
+
+describe("isImeComposingKeyboardEvent", () => {
+  it("ignores events while IME composition is active", () => {
+    expect(
+      isImeComposingKeyboardEvent({
+        isComposing: true,
+        keyCode: 13,
+      } as KeyboardEvent),
+    ).toBe(true);
+  });
+
+  it("ignores Chromium IME fallback events with keyCode 229", () => {
+    expect(
+      isImeComposingKeyboardEvent({
+        isComposing: false,
+        keyCode: 229,
+      } as KeyboardEvent),
+    ).toBe(true);
+  });
+
+  it("keeps regular keyboard events eligible for shortcuts", () => {
+    expect(
+      isImeComposingKeyboardEvent({
+        isComposing: false,
+        keyCode: 13,
+      } as KeyboardEvent),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/utils/keyboard-ime.ts
+++ b/packages/app/src/utils/keyboard-ime.ts
@@ -1,0 +1,5 @@
+export function isImeComposingKeyboardEvent(
+  event: Pick<KeyboardEvent, "isComposing" | "keyCode">,
+): boolean {
+  return event.isComposing || event.keyCode === 229;
+}

--- a/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+
+const mockState = vi.hoisted(() => ({
+  superConstructorOptions: [] as unknown[],
+}));
+
+vi.mock("./acp-agent.js", () => ({
+  ACPAgentClient: class ACPAgentClient {
+    readonly provider: string;
+
+    constructor(options: unknown) {
+      this.provider = "acp";
+      mockState.superConstructorOptions.push(options);
+    }
+  },
+}));
+
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+describe("GenericACPAgentClient", () => {
+  test("passes the custom command only as defaultCommand", () => {
+    new GenericACPAgentClient({
+      logger: createTestLogger(),
+      command: ["hermes", "acp"],
+      env: {
+        HERMES_LOG: "info",
+      },
+    });
+
+    expect(mockState.superConstructorOptions).toEqual([
+      {
+        provider: "acp",
+        logger: expect.any(Object),
+        runtimeSettings: {
+          env: {
+            HERMES_LOG: "info",
+          },
+        },
+        defaultCommand: ["hermes", "acp"],
+      },
+    ]);
+  });
+});

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -21,10 +21,6 @@ export class GenericACPAgentClient extends ACPAgentClient {
       provider: "acp",
       logger: options.logger,
       runtimeSettings: {
-        command: {
-          mode: "replace",
-          argv: options.command,
-        },
         env: options.env,
       },
       defaultCommand: options.command as [string, ...string[]],


### PR DESCRIPTION
## Summary
- stop generic ACP providers from passing the same custom command through both defaultCommand and runtimeSettings.command
- add a focused regression test for custom ACP provider command construction

## Verification
- npm run build --workspace=@getpaseo/server
- npm test --workspace=@getpaseo/server -- generic-acp-agent.test.ts
- manual repro with Hermes custom provider now launches `hermes acp` instead of `hermes acp acp`