### PR TITLE
fix: make code file preview text selectable on iOS

### DIFF
--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -71,7 +71,7 @@ const CodeLine = React.memo(function CodeLine({
       <View style={[codeLineStyles.gutter, { width: gutterWidth }]}>
         <Text style={[codeLineStyles.gutterText, { color: baseColor }]}>{String(lineNumber)}</Text>
       </View>
-      <Text style={codeLineStyles.lineText}>
+      <Text selectable style={codeLineStyles.lineText}>
         {tokens.map((token, index) => (
           <Text
             key={index}


### PR DESCRIPTION
## Summary

- On iOS, `<Text>` components default to `selectable={false}`, so users cannot long-press to select/copy text in file previews
- Desktop/web works fine because CSS `user-select` defaults to `text`
- Add `selectable` prop to the code line `<Text>` in `CodeLine` component
- This does **not** affect desktop/web behavior — `selectable` on web just sets `user-select: text`, which is already the default

**Note:** Markdown file preview (`.md`) has a similar issue but requires a different approach — `react-native-markdown-display` renders its own `<Text>` nodes internally, so fixing that needs custom `rules` or a wrapper. Left for a follow-up.

Refs #238
Related #21

## Test plan

- [ ] Open a `.py` / `.ts` / `.js` file in file preview on iOS
- [ ] Long-press on text content → should show select/copy menu
- [ ] Verify line numbers are still **not** selectable
- [ ] Verify desktop/web behavior is unchanged
- [ ] Open a `.md` file on iOS → text selection still won't work (known, not in scope)