### PR TITLE
Fix provider snapshot cache collisions across workspaces

### DIFF
--- a/packages/app/src/components/agent-status-bar.tsx
+++ b/packages/app/src/components/agent-status-bar.tsx
@@ -879,7 +879,7 @@ export const AgentStatusBar = memo(function AgentStatusBar({
     isLoading: snapshotIsLoading,
     isFetching: snapshotIsFetching,
     invalidate: invalidateSnapshot,
-  } = useProvidersSnapshot(serverId);
+  } = useProvidersSnapshot(serverId, agent?.cwd);
 
   const snapshotModels = useMemo(() => {
     if (!snapshotEntries || !agent?.provider) {

--- a/packages/app/src/hooks/use-agent-form-state.ts
+++ b/packages/app/src/hooks/use-agent-form-state.ts
@@ -366,7 +366,7 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
     error: snapshotError,
     refresh: refreshSnapshot,
     invalidate: invalidateSnapshot,
-  } = useProvidersSnapshot(formState.serverId);
+  } = useProvidersSnapshot(formState.serverId, formState.workingDir);
 
   const allProviderEntries = useMemo(() => snapshotEntries ?? [], [snapshotEntries]);
   const snapshotProviderDefinitions = useMemo(

--- a/packages/app/src/hooks/use-providers-snapshot.test.ts
+++ b/packages/app/src/hooks/use-providers-snapshot.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { providersSnapshotQueryKey } from "./use-providers-snapshot";
+
+describe("providersSnapshotQueryKey", () => {
+  it("includes cwd in the cache key", () => {
+    expect(providersSnapshotQueryKey("server-1", "E:\\evolution")).toEqual([
+      "providersSnapshot",
+      "server-1",
+      "E:/evolution",
+    ]);
+  });
+
+  it("normalizes Windows separators so equivalent cwd values share a key", () => {
+    expect(providersSnapshotQueryKey("server-1", "E:\\lzzy")).toEqual(
+      providersSnapshotQueryKey("server-1", "E:/lzzy"),
+    );
+  });
+
+  it("keeps different cwd values isolated under the same server", () => {
+    expect(providersSnapshotQueryKey("server-1", "E:\\evolution")).not.toEqual(
+      providersSnapshotQueryKey("server-1", "E:\\lzzy"),
+    );
+  });
+
+  it("falls back to a server-level cache entry when cwd is absent", () => {
+    expect(providersSnapshotQueryKey("server-1")).toEqual(["providersSnapshot", "server-1", null]);
+  });
+});

--- a/packages/app/src/hooks/use-providers-snapshot.ts
+++ b/packages/app/src/hooks/use-providers-snapshot.ts
@@ -5,9 +5,10 @@ import type { DaemonClient } from "@server/client/daemon-client";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { useSessionForServer } from "./use-session-directory";
 import { queryClient as singletonQueryClient } from "@/query/query-client";
+import { normalizeWorkspaceIdentity } from "@/utils/workspace-identity";
 
-export function providersSnapshotQueryKey(serverId: string | null) {
-  return ["providersSnapshot", serverId] as const;
+export function providersSnapshotQueryKey(serverId: string | null, cwd?: string | null) {
+  return ["providersSnapshot", serverId, normalizeWorkspaceIdentity(cwd) ?? null] as const;
 }
 
 interface UseProvidersSnapshotResult {
@@ -21,7 +22,10 @@ interface UseProvidersSnapshotResult {
   invalidate: () => void;
 }
 
-export function useProvidersSnapshot(serverId: string | null): UseProvidersSnapshotResult {
+export function useProvidersSnapshot(
+  serverId: string | null,
+  cwd?: string | null,
+): UseProvidersSnapshotResult {
   const queryClient = useQueryClient();
   const client = useHostRuntimeClient(serverId ?? "");
   const isConnected = useHostRuntimeIsConnected(serverId ?? "");
@@ -29,8 +33,12 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
     serverId,
     (session) => session?.serverInfo?.features?.providersSnapshot === true,
   );
+  const normalizedCwd = useMemo(() => normalizeWorkspaceIdentity(cwd) ?? null, [cwd]);
 
-  const queryKey = useMemo(() => providersSnapshotQueryKey(serverId), [serverId]);
+  const queryKey = useMemo(
+    () => providersSnapshotQueryKey(serverId, normalizedCwd),
+    [normalizedCwd, serverId],
+  );
 
   const snapshotQuery = useQuery({
     queryKey,
@@ -40,7 +48,7 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
       if (!client) {
         throw new Error("Host is not connected");
       }
-      return client.getProvidersSnapshot();
+      return client.getProvidersSnapshot(normalizedCwd ? { cwd: normalizedCwd } : undefined);
     },
   });
 
@@ -63,13 +71,17 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
       if (message.type !== "providers_snapshot_update") {
         return;
       }
+      const messageCwd = normalizeWorkspaceIdentity(message.payload.cwd) ?? null;
+      if (messageCwd !== normalizedCwd) {
+        return;
+      }
       queryClient.setQueryData(queryKey, {
         entries: message.payload.entries,
         generatedAt: message.payload.generatedAt,
         requestId: "providers_snapshot_update",
       });
     });
-  }, [client, isConnected, serverId, queryClient, queryKey, supportsSnapshot]);
+  }, [client, isConnected, normalizedCwd, serverId, queryClient, queryKey, supportsSnapshot]);
 
   const refresh = useCallback(
     async (providers?: AgentProvider[]) => {
@@ -94,11 +106,16 @@ export function useProvidersSnapshot(serverId: string | null): UseProvidersSnaps
   };
 }
 
-export function prefetchProvidersSnapshot(serverId: string, client: DaemonClient): void {
-  const queryKey = providersSnapshotQueryKey(serverId);
+export function prefetchProvidersSnapshot(
+  serverId: string,
+  client: DaemonClient,
+  cwd?: string | null,
+): void {
+  const normalizedCwd = normalizeWorkspaceIdentity(cwd) ?? null;
+  const queryKey = providersSnapshotQueryKey(serverId, normalizedCwd);
   void singletonQueryClient.prefetchQuery({
     queryKey,
     staleTime: 60_000,
-    queryFn: () => client.getProvidersSnapshot(),
+    queryFn: () => client.getProvidersSnapshot(normalizedCwd ? { cwd: normalizedCwd } : undefined),
   });
 }


### PR DESCRIPTION
## Summary
- key provider snapshot cache entries by both `serverId` and `cwd`
- request provider snapshots with the current workspace cwd when the agent form or status bar needs workspace-specific provider state
- ignore `providers_snapshot_update` events that belong to a different cwd
- add a focused test covering Windows path normalization and per-cwd cache isolation

## Root Cause
The daemon serves provider snapshots per workspace `cwd`, but the app cached them only by `serverId`.
That let one workspace overwrite another workspace's provider state, which could make `codex` appear available in one folder and missing in another.

## Verification
- reproduced against a live daemon where both `E:\evolution` and `E:\lzzy` supported `codex` server-side
- added a focused unit test for the new cache key behavior

## Notes
I could not complete a full local app typecheck on this Windows machine because a fresh workspace install is currently blocked by an npm workspace symlink failure:
`EISDIR: illegal operation on a directory, symlink '...packages\\website' -> '...node_modules\\@getpaseo\\website'`