### PR TITLE
Reduce hidden terminal renderer battery drain

### DIFF
--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -97,6 +97,7 @@ interface SplitContainerProps {
   newTabAgentOptionId?: "__new_tab_agent__" | "__new_tab_terminal__";
   buildPaneContentModel: (input: {
     paneId: string;
+    isPaneVisible: boolean;
     isPaneFocused: boolean;
     tab: WorkspaceTabDescriptor;
   }) => WorkspacePaneContentModel;
@@ -166,6 +167,7 @@ interface MountedTabSlotProps {
   paneId: string;
   buildPaneContentModel: (input: {
     paneId: string;
+    isPaneVisible: boolean;
     isPaneFocused: boolean;
     tab: WorkspaceTabDescriptor;
   }) => WorkspacePaneContentModel;
@@ -181,11 +183,12 @@ const MountedTabSlot = memo(function MountedTabSlot({
   const content = useMemo(
     () =>
       buildPaneContentModel({
+        isPaneVisible: isVisible,
         paneId,
         isPaneFocused,
         tab: tabDescriptor,
       }),
-    [buildPaneContentModel, isPaneFocused, paneId, tabDescriptor],
+    [buildPaneContentModel, isPaneFocused, isVisible, paneId, tabDescriptor],
   );
 
   return (

--- a/packages/app/src/components/terminal-pane.tsx
+++ b/packages/app/src/components/terminal-pane.tsx
@@ -118,6 +118,7 @@ export function TerminalPane({ serverId, cwd, terminalId, isPaneFocused }: Termi
   const keyboardRefitTimeoutsRef = useRef<Array<ReturnType<typeof setTimeout>>>([]);
   const lastAutoFocusKeyRef = useRef<string | null>(null);
   const initialSnapshot = workspaceTerminalSession.snapshots.get({ terminalId });
+  const shouldAttachTerminalStream = isScreenFocused && isAppVisible;
 
   useEffect(() => {
     terminalIdRef.current = terminalId;
@@ -274,7 +275,7 @@ export function TerminalPane({ serverId, cwd, terminalId, isPaneFocused }: Termi
 
     streamControllerRef.current = controller;
     controller.setTerminal({
-      terminalId: isScreenFocused ? terminalIdRef.current : null,
+      terminalId: shouldAttachTerminalStream ? terminalIdRef.current : null,
     });
 
     return () => {
@@ -287,17 +288,17 @@ export function TerminalPane({ serverId, cwd, terminalId, isPaneFocused }: Termi
     client,
     handleStreamControllerStatus,
     isConnected,
-    isScreenFocused,
+    shouldAttachTerminalStream,
     workspaceTerminalSession.snapshots,
   ]);
 
   useEffect(() => {
     pendingTerminalInputRef.current = [];
-    const nextTerminalId = isScreenFocused ? terminalId : null;
+    const nextTerminalId = shouldAttachTerminalStream ? terminalId : null;
     streamControllerRef.current?.setTerminal({
       terminalId: nextTerminalId,
     });
-  }, [isScreenFocused, terminalId]);
+  }, [shouldAttachTerminalStream, terminalId]);
 
   const enqueuePendingTerminalInput = useCallback((entry: PendingTerminalInput) => {
     const queue = pendingTerminalInputRef.current;
@@ -550,7 +551,7 @@ export function TerminalPane({ serverId, cwd, terminalId, isPaneFocused }: Termi
   return (
     <Animated.View style={[styles.container, keyboardPaddingStyle]}>
       <View style={styles.outputContainer}>
-        {isScreenFocused ? (
+        {shouldAttachTerminalStream ? (
           <View style={styles.terminalGestureContainer}>
             <TerminalEmulator
               ref={emulatorRef}
@@ -594,7 +595,7 @@ export function TerminalPane({ serverId, cwd, terminalId, isPaneFocused }: Termi
           <View style={styles.terminalGestureContainer} />
         )}
 
-        {isAttaching && isScreenFocused ? (
+        {isAttaching && shouldAttachTerminalStream ? (
           <View style={styles.attachOverlay} pointerEvents="none" testID="terminal-attach-loading">
             <ActivityIndicator size="small" color={theme.colors.foregroundMuted} />
           </View>

--- a/packages/app/src/panels/pane-context.tsx
+++ b/packages/app/src/panels/pane-context.tsx
@@ -6,6 +6,7 @@ export interface PaneContextValue {
   serverId: string;
   workspaceId: string;
   tabId: string;
+  isPaneVisible: boolean;
   isPaneFocused: boolean;
   target: WorkspaceTabTarget;
   openTab(target: WorkspaceTabTarget): void;

--- a/packages/app/src/panels/terminal-panel.tsx
+++ b/packages/app/src/panels/terminal-panel.tsx
@@ -49,10 +49,10 @@ function useTerminalPanelDescriptor(
 
 function TerminalPanel() {
   const isFocused = useIsFocused();
-  const { serverId, workspaceId, target, isPaneFocused } = usePaneContext();
+  const { serverId, workspaceId, target, isPaneFocused, isPaneVisible } = usePaneContext();
   invariant(target.kind === "terminal", "TerminalPanel requires terminal target");
 
-  if (!isFocused) {
+  if (!isFocused || !isPaneVisible) {
     return <View style={{ flex: 1 }} />;
   }
 

--- a/packages/app/src/screens/workspace/workspace-pane-content.tsx
+++ b/packages/app/src/screens/workspace/workspace-pane-content.tsx
@@ -15,6 +15,7 @@ export interface BuildWorkspacePaneContentModelInput {
   tab: WorkspaceTabDescriptor;
   normalizedServerId: string;
   normalizedWorkspaceId: string;
+  isPaneVisible: boolean;
   isPaneFocused: boolean;
   onOpenTab: (target: WorkspaceTabDescriptor["target"]) => void;
   onCloseCurrentTab: () => void;
@@ -26,6 +27,7 @@ export function buildWorkspacePaneContentModel({
   tab,
   normalizedServerId,
   normalizedWorkspaceId,
+  isPaneVisible,
   isPaneFocused,
   onOpenTab,
   onCloseCurrentTab,
@@ -42,6 +44,7 @@ export function buildWorkspacePaneContentModel({
       serverId: normalizedServerId,
       workspaceId: normalizedWorkspaceId,
       tabId: tab.tabId,
+      isPaneVisible,
       isPaneFocused,
       target: tab.target,
       openTab: onOpenTab,

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -496,6 +496,7 @@ interface MobileMountedTabSlotProps {
   paneId: string | null;
   buildPaneContentModel: (input: {
     paneId: string | null;
+    isPaneVisible: boolean;
     isPaneFocused: boolean;
     tab: WorkspaceTabDescriptor;
   }) => WorkspacePaneContentModel;
@@ -511,11 +512,12 @@ const MobileMountedTabSlot = memo(function MobileMountedTabSlot({
   const content = useMemo(
     () =>
       buildPaneContentModel({
+        isPaneVisible: isVisible,
         paneId,
         isPaneFocused,
         tab: tabDescriptor,
       }),
-    [buildPaneContentModel, isPaneFocused, paneId, tabDescriptor],
+    [buildPaneContentModel, isPaneFocused, isVisible, paneId, tabDescriptor],
   );
 
   return (
@@ -1732,6 +1734,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
     (input: {
       tab: WorkspaceTabDescriptor;
       paneId?: string | null;
+      isPaneVisible: boolean;
       isPaneFocused: boolean;
       focusPaneBeforeOpen?: boolean;
     }) =>
@@ -1739,6 +1742,7 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
         tab: input.tab,
         normalizedServerId,
         normalizedWorkspaceId,
+        isPaneVisible: input.isPaneVisible,
         isPaneFocused: input.isPaneFocused,
         onOpenTab: (target) => {
           if (!persistenceKey) {
@@ -1795,12 +1799,14 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
   const buildMobilePaneContentModel = useCallback(
     function buildMobilePaneContentModel(input: {
       paneId: string | null;
+      isPaneVisible: boolean;
       tab: WorkspaceTabDescriptor;
       isPaneFocused: boolean;
     }) {
       return buildPaneContentModel({
         tab: input.tab,
         paneId: input.paneId,
+        isPaneVisible: input.isPaneVisible,
         isPaneFocused: input.isPaneFocused,
         focusPaneBeforeOpen: false,
       });
@@ -1849,12 +1855,14 @@ function WorkspaceScreenContent({ serverId, workspaceId }: WorkspaceScreenProps)
   const buildDesktopPaneContentModel = useCallback(
     function buildDesktopPaneContentModel(input: {
       paneId: string;
+      isPaneVisible: boolean;
       tab: WorkspaceTabDescriptor;
       isPaneFocused: boolean;
     }) {
       return buildPaneContentModel({
         tab: input.tab,
         paneId: input.paneId,
+        isPaneVisible: input.isPaneVisible,
         isPaneFocused: input.isPaneFocused,
         focusPaneBeforeOpen: true,
       });

--- a/packages/app/src/terminal/runtime/terminal-stream-controller.test.ts
+++ b/packages/app/src/terminal/runtime/terminal-stream-controller.test.ts
@@ -178,4 +178,49 @@ describe("terminal-stream-controller", () => {
       error: null,
     });
   });
+
+  it("re-subscribes after detaching the current terminal", async () => {
+    const harness = createHarness();
+    harness.client.nextSubscribeResults.push({ terminalId: "term-1", error: null });
+    harness.client.nextSubscribeResults.push({ terminalId: "term-1", error: null });
+
+    harness.controller.setTerminal({ terminalId: "term-1" });
+    await flushAsyncWork();
+
+    harness.client.emit({
+      terminalId: "term-1",
+      type: "output",
+      data: new TextEncoder().encode("before"),
+    });
+
+    harness.controller.setTerminal({ terminalId: null });
+    await flushAsyncWork();
+
+    harness.client.emit({
+      terminalId: "term-1",
+      type: "output",
+      data: new TextEncoder().encode("ignored"),
+    });
+
+    harness.controller.setTerminal({ terminalId: "term-1" });
+    await flushAsyncWork();
+
+    harness.client.emit({
+      terminalId: "term-1",
+      type: "output",
+      data: new TextEncoder().encode(" after"),
+    });
+
+    expect(harness.client.subscribeCalls).toEqual(["term-1", "term-1"]);
+    expect(harness.client.unsubscribeCalls).toEqual(["term-1"]);
+    expect(harness.outputs).toEqual([
+      { terminalId: "term-1", text: "before" },
+      { terminalId: "term-1", text: " after" },
+    ]);
+    expect(harness.statuses).toContainEqual({
+      terminalId: null,
+      isAttaching: false,
+      error: null,
+    });
+  });
 });


### PR DESCRIPTION
Closes #468

- Hidden terminal tabs in split view stayed mounted, so xterm kept doing offscreen renderer work.
- This change threads pane visibility through pane context, avoids mounting `TerminalPane` for hidden terminal tabs, and detaches the terminal stream while the app is backgrounded.
- Tradeoff: hidden terminals now remount on reveal, so resume may be slightly less instant. Visible but unfocused split panes still stay mounted to avoid a split-view UX regression.

Validation:
- `npx vitest run packages/app/src/terminal/runtime/terminal-stream-controller.test.ts --bail=1`
- `npm run build --workspace=@getpaseo/highlight`
- `npm run typecheck --workspace=@getpaseo/app`
