### PR TITLE
Pass MCP servers to structured helper agents

### DIFF
--- a/packages/server/src/server/session.structured-helper-mcp.test.ts
+++ b/packages/server/src/server/session.structured-helper-mcp.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveStructuredHelperMcpServers } from "./session.js";
+
+describe("resolveStructuredHelperMcpServers", () => {
+  test("prefers a running agent in the same cwd when it has MCP servers", () => {
+    const expected = {
+      task_board_mcp: { type: "http", url: "http://127.0.0.1:6767/mcp/task-board" },
+    };
+
+    const result = resolveStructuredHelperMcpServers({
+      cwd: "C:/workspace/app",
+      agents: [
+        {
+          cwd: "C:/workspace/app",
+          lifecycle: "idle",
+          updatedAt: new Date("2026-04-17T09:00:00.000Z"),
+          config: {
+            provider: "codex",
+            cwd: "C:/workspace/app",
+            mcpServers: {
+              paseo: { type: "http", url: "http://127.0.0.1:6767/mcp" },
+            },
+          },
+        },
+        {
+          cwd: "C:/workspace/app",
+          lifecycle: "running",
+          updatedAt: new Date("2026-04-17T08:00:00.000Z"),
+          config: {
+            provider: "codex",
+            cwd: "C:/workspace/app",
+            mcpServers: expected,
+          },
+        },
+      ],
+    });
+
+    expect(result).toEqual(expected);
+  });
+
+  test("ignores agents from other working directories", () => {
+    const result = resolveStructuredHelperMcpServers({
+      cwd: "C:/workspace/app",
+      agents: [
+        {
+          cwd: "C:/workspace/other",
+          lifecycle: "running",
+          updatedAt: new Date("2026-04-17T08:00:00.000Z"),
+          config: {
+            provider: "codex",
+            cwd: "C:/workspace/other",
+            mcpServers: {
+              task_board_mcp: { type: "http", url: "http://127.0.0.1:6767/mcp/task-board" },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined when no matching agent exposes MCP servers", () => {
+    const result = resolveStructuredHelperMcpServers({
+      cwd: "C:/workspace/app",
+      agents: [
+        {
+          cwd: "C:/workspace/app",
+          lifecycle: "running",
+          updatedAt: new Date("2026-04-17T08:00:00.000Z"),
+          config: {
+            provider: "codex",
+            cwd: "C:/workspace/app",
+          },
+        },
+      ],
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -307,6 +307,30 @@ export function resolveCreateAgentTitles(options: {
   };
 }
 
+type StructuredHelperMcpCandidate = Pick<ManagedAgent, "cwd" | "lifecycle" | "updatedAt" | "config">;
+
+export function resolveStructuredHelperMcpServers(options: {
+  cwd: string;
+  agents: ReadonlyArray<StructuredHelperMcpCandidate>;
+}): AgentSessionConfig["mcpServers"] | undefined {
+  const candidates = options.agents
+    .filter((agent) => agent.cwd === options.cwd)
+    .filter((agent) => {
+      const mcpServers = agent.config.mcpServers;
+      return Boolean(mcpServers && Object.keys(mcpServers).length > 0);
+    })
+    .sort((left, right) => {
+      const leftPriority = left.lifecycle === "running" ? 0 : 1;
+      const rightPriority = right.lifecycle === "running" ? 0 : 1;
+      if (leftPriority !== rightPriority) {
+        return leftPriority - rightPriority;
+      }
+      return right.updatedAt.getTime() - left.updatedAt.getTime();
+    });
+
+  return candidates[0]?.config.mcpServers;
+}
+
 export function resolveWaitForFinishError(options: {
   status: "permission" | "error" | "idle";
   final: AgentSnapshotPayload | null;
@@ -3524,6 +3548,10 @@ export class Session {
   }
 
   private async generateCommitMessage(cwd: string): Promise<string> {
+    const helperMcpServers = resolveStructuredHelperMcpServers({
+      cwd,
+      agents: this.agentManager.listAgents(),
+    });
     const diff = await this.workspaceGitService.getCheckoutDiff(cwd, {
       mode: "uncommitted",
       includeStructured: true,
@@ -3571,6 +3599,7 @@ export class Session {
         agentConfigOverrides: {
           title: "Commit generator",
           internal: true,
+          ...(helperMcpServers ? { mcpServers: helperMcpServers } : {}),
         },
       });
       return result.message;
@@ -3592,6 +3621,10 @@ export class Session {
     title: string;
     body: string;
   }> {
+    const helperMcpServers = resolveStructuredHelperMcpServers({
+      cwd,
+      agents: this.agentManager.listAgents(),
+    });
     const diff = await this.workspaceGitService.getCheckoutDiff(cwd, {
       mode: "base",
       baseRef,
@@ -3637,6 +3670,7 @@ export class Session {
         agentConfigOverrides: {
           title: "PR generator",
           internal: true,
+          ...(helperMcpServers ? { mcpServers: helperMcpServers } : {}),
         },
       });
     } catch (error) {


### PR DESCRIPTION
## Summary
- structured helper agents used for commit message and PR text generation did not inherit `mcpServers` from the live agent session
- this meant helper runs could lose access to MCP-backed tools even when the primary agent in the same workspace had them available

## Reproduction
1. Start an agent in a workspace with MCP servers configured.
2. Trigger a flow that uses a structured helper, such as commit message generation or PR title/body generation.
3. Observe that the helper session is created without inherited `mcpServers`, so MCP-backed tools are unavailable inside the helper.

## Fix
- resolve the best matching live agent for the same `cwd`
- copy that agent's `mcpServers` into the structured helper `agentConfigOverrides`
- apply the same inheritance for both commit message generation and PR text generation