### PR TITLE
Add worktree setting to disable git hooks during creation

### DIFF
--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -27,6 +27,8 @@ Projects are grouped in the sidebar, detected automatically from your filesystem
 
 Each project opens as a workspace. For git projects, the default workspace is the main checkout. Users can create additional workspaces, which are isolated copies (git worktrees) where agents work without affecting main.
 
+Global settings can define repo-relative "worktree copy paths" (for example `AGENTS.md` or `.env.local`) so git-ignored local files are copied from the main checkout into each newly created worktree.
+
 ### Inside a workspace
 
 A workspace is a flexible canvas:

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -28,6 +28,7 @@ Projects are grouped in the sidebar, detected automatically from your filesystem
 Each project opens as a workspace. For git projects, the default workspace is the main checkout. Users can create additional workspaces, which are isolated copies (git worktrees) where agents work without affecting main.
 
 Global settings can define repo-relative "worktree copy paths" (for example `AGENTS.md` or `.env.local`) so git-ignored local files are copied from the main checkout into each newly created worktree.
+Global settings can also disable git hooks during worktree creation for repositories with heavy hook tooling.
 
 ### Inside a workspace
 

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -476,6 +476,7 @@ function GeneralSection({
   const iconSize = theme.iconSize.md;
   const iconColor = theme.colors.foregroundMuted;
   const configuredWorktreeCopyPaths = config?.worktree?.copyFromRepoPaths ?? [];
+  const worktreeDisableGitHooks = config?.worktree?.disableGitHooks === true;
   const worktreePathValidation = useMemo(
     () => validateWorktreeCopyPathsInput(worktreePathsDraft),
     [worktreePathsDraft],
@@ -567,6 +568,31 @@ function GeneralSection({
               options={[
                 { value: "on", label: "On" },
                 { value: "off", label: "Off" },
+              ]}
+            />
+          </View>
+        ) : null}
+        {routeServerId.length > 0 && isConnected ? (
+          <View style={[styles.audioRow, styles.audioRowBorder]}>
+            <View style={styles.audioRowContent}>
+              <Text style={styles.audioRowTitle}>Disable git hooks for worktree creation</Text>
+              <Text style={styles.audioRowSubtitle}>
+                Skip repository git hooks when creating new Paseo worktrees
+              </Text>
+            </View>
+            <SegmentedControl
+              size="sm"
+              value={worktreeDisableGitHooks ? "on" : "off"}
+              onValueChange={(value) => {
+                void patchConfig({
+                  worktree: {
+                    disableGitHooks: value === "on",
+                  },
+                });
+              }}
+              options={[
+                { value: "off", label: "Off" },
+                { value: "on", label: "On" },
               ]}
             />
           </View>

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import type { MutableRefObject, ComponentType } from "react";
 import { View, Text, ScrollView, Alert, Pressable } from "react-native";
 import { router, useLocalSearchParams } from "expo-router";
@@ -414,6 +414,54 @@ const THEME_LABELS: Record<AppSettings["theme"], string> = {
   auto: "System",
 };
 
+function parseWorktreeCopyPathsInput(input: string): string[] {
+  const seen = new Set<string>();
+  const parsedPaths: string[] = [];
+  for (const line of input.split(/\r?\n/)) {
+    const path = line.trim();
+    if (!path || seen.has(path)) {
+      continue;
+    }
+    seen.add(path);
+    parsedPaths.push(path);
+  }
+  return parsedPaths;
+}
+
+type WorktreeCopyPathValidationResult = {
+  copyFromRepoPaths: string[];
+  errors: string[];
+};
+
+function validateWorktreeCopyPathsInput(input: string): WorktreeCopyPathValidationResult {
+  const copyFromRepoPaths = parseWorktreeCopyPathsInput(input);
+  const errors: string[] = [];
+
+  for (const path of copyFromRepoPaths) {
+    const normalizedPath = path.replace(/\\/g, "/");
+
+    const isWindowsAbsolutePath = /^[A-Za-z]:\//.test(normalizedPath);
+    if (normalizedPath.startsWith("/") || isWindowsAbsolutePath) {
+      errors.push(`\`${path}\` must be relative`);
+      continue;
+    }
+
+    if (normalizedPath === "." || normalizedPath === ".git" || normalizedPath.startsWith(".git/")) {
+      errors.push(`\`${path}\` cannot target .git or repository root`);
+      continue;
+    }
+
+    if (normalizedPath.split("/").includes("..")) {
+      errors.push(`\`${path}\` cannot include '..' segments`);
+    }
+  }
+
+  return {
+    copyFromRepoPaths,
+    errors,
+  };
+}
+
 function GeneralSection({
   routeServerId,
   settings,
@@ -423,8 +471,22 @@ function GeneralSection({
   const { theme } = useUnistyles();
   const isConnected = useHostRuntimeIsConnected(routeServerId);
   const { config, patchConfig } = useDaemonConfig(routeServerId);
+  const [isWorktreePathsModalVisible, setIsWorktreePathsModalVisible] = useState(false);
+  const [worktreePathsDraft, setWorktreePathsDraft] = useState("");
   const iconSize = theme.iconSize.md;
   const iconColor = theme.colors.foregroundMuted;
+  const configuredWorktreeCopyPaths = config?.worktree?.copyFromRepoPaths ?? [];
+  const worktreePathValidation = useMemo(
+    () => validateWorktreeCopyPathsInput(worktreePathsDraft),
+    [worktreePathsDraft],
+  );
+
+  useEffect(() => {
+    if (!isWorktreePathsModalVisible) {
+      return;
+    }
+    setWorktreePathsDraft(configuredWorktreeCopyPaths.join("\n"));
+  }, [configuredWorktreeCopyPaths, isWorktreePathsModalVisible]);
 
   return (
     <View style={settingsStyles.section}>
@@ -509,7 +571,84 @@ function GeneralSection({
             />
           </View>
         ) : null}
+        {routeServerId.length > 0 && isConnected ? (
+          <View style={[styles.audioRow, styles.audioRowBorder]}>
+            <View style={styles.audioRowContent}>
+              <Text style={styles.audioRowTitle}>Worktree copy paths</Text>
+              <Text style={styles.audioRowSubtitle}>
+                One relative path per line. These paths are copied from your repo root into new
+                worktrees.
+              </Text>
+              {configuredWorktreeCopyPaths.length > 0 ? (
+                <Text style={styles.worktreePathsPreview} numberOfLines={2}>
+                  {configuredWorktreeCopyPaths.join(", ")}
+                </Text>
+              ) : null}
+            </View>
+            <Button
+              variant="outline"
+              size="sm"
+              onPress={() => {
+                setIsWorktreePathsModalVisible(true);
+              }}
+            >
+              Edit
+            </Button>
+          </View>
+        ) : null}
       </View>
+      <AdaptiveModalSheet
+        title="Worktree copy paths"
+        visible={isWorktreePathsModalVisible}
+        onClose={() => {
+          setIsWorktreePathsModalVisible(false);
+        }}
+      >
+        <View style={styles.formField}>
+          <Text style={styles.label}>Paths</Text>
+          <AdaptiveTextInput
+            style={[styles.input, styles.multilineInput]}
+            value={worktreePathsDraft}
+            onChangeText={setWorktreePathsDraft}
+            multiline
+            placeholder={`AGENTS.md\n.env.local`}
+            placeholderTextColor={theme.colors.foregroundMuted}
+          />
+          <Text style={styles.audioRowSubtitle}>
+            Paths must be relative to the repository root (for example: AGENTS.md or .env.local).
+          </Text>
+          {worktreePathValidation.errors.length > 0 ? (
+            <Text style={styles.worktreePathsError}>
+              {worktreePathValidation.errors.join("\n")}
+            </Text>
+          ) : null}
+        </View>
+        <View style={styles.formActionsRow}>
+          <Button
+            variant="secondary"
+            size="sm"
+            onPress={() => {
+              setIsWorktreePathsModalVisible(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            disabled={worktreePathValidation.errors.length > 0}
+            onPress={() => {
+              void patchConfig({
+                worktree: {
+                  copyFromRepoPaths: worktreePathValidation.copyFromRepoPaths,
+                },
+              });
+              setIsWorktreePathsModalVisible(false);
+            }}
+          >
+            Save
+          </Button>
+        </View>
+      </AdaptiveModalSheet>
     </View>
   );
 }
@@ -1770,6 +1909,10 @@ const styles = StyleSheet.create((theme) => ({
     borderColor: theme.colors.border,
     fontSize: theme.fontSize.base,
   },
+  multilineInput: {
+    minHeight: 120,
+    textAlignVertical: "top",
+  },
   // Host card styles
   hostCard: {
     marginBottom: theme.spacing[3],
@@ -1979,6 +2122,15 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.mutedForeground,
     fontSize: theme.fontSize.sm,
     marginTop: theme.spacing[1],
+  },
+  worktreePathsPreview: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    marginTop: theme.spacing[2],
+  },
+  worktreePathsError: {
+    color: theme.colors.palette.red[300],
+    fontSize: theme.fontSize.xs,
   },
   providerActions: {
     flexDirection: "row",

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -164,6 +164,7 @@ export type PaseoDaemonConfig = {
   allowedHosts?: AllowedHostsConfig;
   mcpEnabled?: boolean;
   mcpInjectIntoAgents?: boolean;
+  worktreeCopyFromRepoPaths?: string[];
   staticDir: string;
   mcpDebug: boolean;
   agentClients: Partial<Record<AgentProvider, AgentClient>>;
@@ -206,6 +207,9 @@ export async function createPaseoDaemon(
     config.paseoHome,
     {
       mcp: { injectIntoAgents: config.mcpInjectIntoAgents ?? true },
+      worktree: {
+        copyFromRepoPaths: config.worktreeCopyFromRepoPaths ?? [],
+      },
     },
     logger,
   );

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -165,6 +165,7 @@ export type PaseoDaemonConfig = {
   mcpEnabled?: boolean;
   mcpInjectIntoAgents?: boolean;
   worktreeCopyFromRepoPaths?: string[];
+  worktreeDisableGitHooks?: boolean;
   staticDir: string;
   mcpDebug: boolean;
   agentClients: Partial<Record<AgentProvider, AgentClient>>;
@@ -209,6 +210,7 @@ export async function createPaseoDaemon(
       mcp: { injectIntoAgents: config.mcpInjectIntoAgents ?? true },
       worktree: {
         copyFromRepoPaths: config.worktreeCopyFromRepoPaths ?? [],
+        disableGitHooks: config.worktreeDisableGitHooks ?? false,
       },
     },
     logger,

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -143,6 +143,7 @@ export function loadConfig(
   const mcpInjectIntoAgents =
     options?.cli?.mcpInjectIntoAgents ?? persisted.daemon?.mcp?.injectIntoAgents ?? false;
   const worktreeCopyFromRepoPaths = persisted.daemon?.worktree?.copyFromRepoPaths ?? [];
+  const worktreeDisableGitHooks = persisted.daemon?.worktree?.disableGitHooks ?? false;
 
   const relayEnabled =
     options?.cli?.relayEnabled ??
@@ -186,6 +187,7 @@ export function loadConfig(
     mcpEnabled,
     mcpInjectIntoAgents,
     worktreeCopyFromRepoPaths,
+    worktreeDisableGitHooks,
     mcpDebug: env.MCP_DEBUG === "1",
     agentStoragePath: path.join(paseoHome, "agents"),
     staticDir: "public",

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -142,6 +142,7 @@ export function loadConfig(
   const mcpEnabled = options?.cli?.mcpEnabled ?? persisted.daemon?.mcp?.enabled ?? true;
   const mcpInjectIntoAgents =
     options?.cli?.mcpInjectIntoAgents ?? persisted.daemon?.mcp?.injectIntoAgents ?? false;
+  const worktreeCopyFromRepoPaths = persisted.daemon?.worktree?.copyFromRepoPaths ?? [];
 
   const relayEnabled =
     options?.cli?.relayEnabled ??
@@ -184,6 +185,7 @@ export function loadConfig(
     allowedHosts,
     mcpEnabled,
     mcpInjectIntoAgents,
+    worktreeCopyFromRepoPaths,
     mcpDebug: env.MCP_DEBUG === "1",
     agentStoragePath: path.join(paseoHome, "agents"),
     staticDir: "public",

--- a/packages/server/src/server/daemon-config-store.ts
+++ b/packages/server/src/server/daemon-config-store.ts
@@ -156,6 +156,10 @@ function mergeMutableConfigIntoPersistedConfig(params: {
         ...persisted.daemon?.mcp,
         injectIntoAgents: mutable.mcp.injectIntoAgents,
       },
+      worktree: {
+        ...persisted.daemon?.worktree,
+        copyFromRepoPaths: mutable.worktree?.copyFromRepoPaths ?? [],
+      },
     },
   };
 }

--- a/packages/server/src/server/daemon-config-store.ts
+++ b/packages/server/src/server/daemon-config-store.ts
@@ -159,6 +159,7 @@ function mergeMutableConfigIntoPersistedConfig(params: {
       worktree: {
         ...persisted.daemon?.worktree,
         copyFromRepoPaths: mutable.worktree?.copyFromRepoPaths ?? [],
+        disableGitHooks: mutable.worktree?.disableGitHooks ?? false,
       },
     },
   };

--- a/packages/server/src/server/persisted-config.test.ts
+++ b/packages/server/src/server/persisted-config.test.ts
@@ -342,6 +342,20 @@ describe("provider overrides (new format)", () => {
   });
 });
 
+describe("PersistedConfigSchema daemon worktree config", () => {
+  test("accepts worktree copy path settings", () => {
+    const parsed = PersistedConfigSchema.parse({
+      daemon: {
+        worktree: {
+          copyFromRepoPaths: ["AGENTS.md", ".env.local"],
+        },
+      },
+    });
+
+    expect(parsed.daemon?.worktree?.copyFromRepoPaths).toEqual(["AGENTS.md", ".env.local"]);
+  });
+});
+
 describe("PersistedConfigSchema logging config", () => {
   test("accepts destination-specific logging config", () => {
     const parsed = PersistedConfigSchema.parse({

--- a/packages/server/src/server/persisted-config.test.ts
+++ b/packages/server/src/server/persisted-config.test.ts
@@ -343,16 +343,18 @@ describe("provider overrides (new format)", () => {
 });
 
 describe("PersistedConfigSchema daemon worktree config", () => {
-  test("accepts worktree copy path settings", () => {
+  test("accepts worktree copy path and hook settings", () => {
     const parsed = PersistedConfigSchema.parse({
       daemon: {
         worktree: {
           copyFromRepoPaths: ["AGENTS.md", ".env.local"],
+          disableGitHooks: true,
         },
       },
     });
 
     expect(parsed.daemon?.worktree?.copyFromRepoPaths).toEqual(["AGENTS.md", ".env.local"]);
+    expect(parsed.daemon?.worktree?.disableGitHooks).toBe(true);
   });
 });
 

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -253,6 +253,7 @@ export const PersistedConfigSchema = z
         worktree: z
           .object({
             copyFromRepoPaths: z.array(z.string()).optional(),
+            disableGitHooks: z.boolean().optional(),
           })
           .strict()
           .optional(),

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -250,6 +250,12 @@ export const PersistedConfigSchema = z
           })
           .strict()
           .optional(),
+        worktree: z
+          .object({
+            copyFromRepoPaths: z.array(z.string()).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -3173,6 +3173,7 @@ export class Session {
       {
         paseoHome: this.paseoHome,
         sessionLogger: this.sessionLogger,
+        worktreeCopyFromRepoPaths: this.daemonConfigStore.get().worktree?.copyFromRepoPaths,
         checkoutExistingBranch: (cwd, branch) => this.checkoutExistingBranch(cwd, branch),
         createBranchFromBase: (params) => this.createBranchFromBase(params),
       },

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -3174,6 +3174,7 @@ export class Session {
         paseoHome: this.paseoHome,
         sessionLogger: this.sessionLogger,
         worktreeCopyFromRepoPaths: this.daemonConfigStore.get().worktree?.copyFromRepoPaths,
+        worktreeDisableGitHooks: this.daemonConfigStore.get().worktree?.disableGitHooks,
         checkoutExistingBranch: (cwd, branch) => this.checkoutExistingBranch(cwd, branch),
         createBranchFromBase: (params) => this.createBranchFromBase(params),
       },

--- a/packages/server/src/server/worktree-bootstrap.ts
+++ b/packages/server/src/server/worktree-bootstrap.ts
@@ -40,6 +40,7 @@ export interface CreateAgentWorktreeOptions {
   baseBranch: string;
   worktreeSlug: string;
   copyFromRepoPaths?: string[];
+  disableGitHooks?: boolean;
   paseoHome?: string;
 }
 
@@ -178,6 +179,7 @@ export async function createAgentWorktree(
     baseBranch: options.baseBranch,
     worktreeSlug: options.worktreeSlug,
     copyFromRepoPaths: options.copyFromRepoPaths,
+    disableGitHooks: options.disableGitHooks,
     runSetup: false,
     paseoHome: options.paseoHome,
   });

--- a/packages/server/src/server/worktree-bootstrap.ts
+++ b/packages/server/src/server/worktree-bootstrap.ts
@@ -39,6 +39,7 @@ export interface CreateAgentWorktreeOptions {
   branchName: string;
   baseBranch: string;
   worktreeSlug: string;
+  copyFromRepoPaths?: string[];
   paseoHome?: string;
 }
 
@@ -176,6 +177,7 @@ export async function createAgentWorktree(
     cwd: options.cwd,
     baseBranch: options.baseBranch,
     worktreeSlug: options.worktreeSlug,
+    copyFromRepoPaths: options.copyFromRepoPaths,
     runSetup: false,
     paseoHome: options.paseoHome,
   });

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -51,6 +51,7 @@ type EmitSessionMessage = (message: SessionOutboundMessage) => void;
 type BuildAgentSessionConfigDependencies = {
   paseoHome?: string;
   sessionLogger: Logger;
+  worktreeCopyFromRepoPaths?: string[];
   checkoutExistingBranch: (cwd: string, branch: string) => Promise<void>;
   createBranchFromBase: (params: {
     cwd: string;
@@ -173,6 +174,7 @@ export async function buildAgentSessionConfig(
       cwd,
       baseBranch,
       worktreeSlug: normalized.worktreeSlug ?? targetBranch,
+      copyFromRepoPaths: dependencies.worktreeCopyFromRepoPaths,
       paseoHome: dependencies.paseoHome,
     });
     cwd = createdWorktree.worktreePath;

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -52,6 +52,7 @@ type BuildAgentSessionConfigDependencies = {
   paseoHome?: string;
   sessionLogger: Logger;
   worktreeCopyFromRepoPaths?: string[];
+  worktreeDisableGitHooks?: boolean;
   checkoutExistingBranch: (cwd: string, branch: string) => Promise<void>;
   createBranchFromBase: (params: {
     cwd: string;
@@ -175,6 +176,7 @@ export async function buildAgentSessionConfig(
       baseBranch,
       worktreeSlug: normalized.worktreeSlug ?? targetBranch,
       copyFromRepoPaths: dependencies.worktreeCopyFromRepoPaths,
+      disableGitHooks: dependencies.worktreeDisableGitHooks,
       paseoHome: dependencies.paseoHome,
     });
     cwd = createdWorktree.worktreePath;

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -61,6 +61,7 @@ export const MutableDaemonConfigSchema = z
     worktree: z
       .object({
         copyFromRepoPaths: z.array(z.string()).optional(),
+        disableGitHooks: z.boolean().optional(),
       })
       .passthrough()
       .optional(),

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -58,12 +58,19 @@ export const MutableDaemonConfigSchema = z
         injectIntoAgents: z.boolean(),
       })
       .passthrough(),
+    worktree: z
+      .object({
+        copyFromRepoPaths: z.array(z.string()).optional(),
+      })
+      .passthrough()
+      .optional(),
   })
   .passthrough();
 
 export const MutableDaemonConfigPatchSchema = z
   .object({
     mcp: MutableDaemonConfigSchema.shape.mcp.partial().optional(),
+    worktree: MutableDaemonConfigSchema.shape.worktree.unwrap().partial().optional(),
   })
   .partial()
   .passthrough();

--- a/packages/server/src/utils/worktree.test.ts
+++ b/packages/server/src/utils/worktree.test.ts
@@ -337,6 +337,42 @@ describe.skipIf(process.platform === "win32")("createWorktree", () => {
     expect(existsSync(join(result.worktreePath, "setup.log"))).toBe(false);
   });
 
+  it("copies configured repo-relative paths into new worktrees", async () => {
+    writeFileSync(join(repoDir, ".gitignore"), "AGENTS.md\n");
+    execSync('git add .gitignore && git -c commit.gpgsign=false commit -m "ignore agents"', {
+      cwd: repoDir,
+    });
+    writeFileSync(join(repoDir, "AGENTS.md"), "local-only instructions\n");
+
+    const result = await createWorktree({
+      branchName: "main",
+      cwd: repoDir,
+      baseBranch: "main",
+      worktreeSlug: "copy-paths-test",
+      copyFromRepoPaths: ["AGENTS.md"],
+      runSetup: false,
+      paseoHome,
+    });
+
+    expect(readFileSync(join(result.worktreePath, "AGENTS.md"), "utf8")).toBe(
+      "local-only instructions\n",
+    );
+  });
+
+  it("rejects copy paths that escape the repository root", async () => {
+    await expect(
+      createWorktree({
+        branchName: "main",
+        cwd: repoDir,
+        baseBranch: "main",
+        worktreeSlug: "copy-paths-invalid",
+        copyFromRepoPaths: ["../outside.txt"],
+        runSetup: false,
+        paseoHome,
+      }),
+    ).rejects.toThrow("escapes repository root");
+  });
+
   it("streams setup command progress events while commands are executing", async () => {
     const paseoConfig = {
       worktree: {

--- a/packages/server/src/utils/worktree.test.ts
+++ b/packages/server/src/utils/worktree.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
+  buildWorktreeAddCommand,
   createWorktree,
   deriveWorktreeProjectHash,
   deletePaseoWorktree,
@@ -371,6 +372,36 @@ describe.skipIf(process.platform === "win32")("createWorktree", () => {
         paseoHome,
       }),
     ).rejects.toThrow("escapes repository root");
+  });
+
+  it("builds worktree add command with git hooks disabled when configured", () => {
+    const command = buildWorktreeAddCommand({
+      worktreePath: "/tmp/worktree",
+      branchName: "feature/test",
+      baseRef: "main",
+      disableGitHooks: true,
+    });
+
+    expect(command).toEqual([
+      "-c",
+      "core.hooksPath=/dev/null",
+      "worktree",
+      "add",
+      "/tmp/worktree",
+      "-b",
+      "feature/test",
+      "main",
+    ]);
+  });
+
+  it("builds worktree add command without hook override by default", () => {
+    const command = buildWorktreeAddCommand({
+      worktreePath: "/tmp/worktree",
+      branchName: "feature/test",
+      baseRef: "main",
+    });
+
+    expect(command).toEqual(["worktree", "add", "/tmp/worktree", "-b", "feature/test", "main"]);
   });
 
   it("streams setup command progress events while commands are executing", async () => {

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1,7 +1,7 @@
 import { exec } from "child_process";
 import { promisify } from "util";
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync } from "fs";
-import { join, basename, dirname, resolve, sep } from "path";
+import { cpSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync } from "fs";
+import { isAbsolute, join, basename, dirname, relative, resolve, sep } from "path";
 import net from "node:net";
 import { createHash } from "node:crypto";
 import { createNameId } from "mnemonic-id";
@@ -127,8 +127,64 @@ interface CreateWorktreeOptions {
   cwd: string;
   baseBranch: string;
   worktreeSlug?: string;
+  copyFromRepoPaths?: string[];
   runSetup?: boolean;
   paseoHome?: string;
+}
+
+function isPathWithinRoot(rootPath: string, candidatePath: string): boolean {
+  const relativePath = relative(rootPath, candidatePath);
+  return relativePath !== "" && !relativePath.startsWith("..") && !isAbsolute(relativePath);
+}
+
+function normalizeWorktreeCopyPath(path: string): string | null {
+  const trimmedPath = path.trim();
+  if (!trimmedPath) {
+    return null;
+  }
+  const normalizedPath = trimmedPath.replace(/\\/g, "/");
+  return normalizedPath;
+}
+
+export function copyConfiguredPathsIntoWorktree(options: {
+  repoRoot: string;
+  worktreePath: string;
+  copyFromRepoPaths?: string[];
+}): void {
+  const copyPaths = options.copyFromRepoPaths ?? [];
+  for (const rawPath of copyPaths) {
+    const normalizedPath = normalizeWorktreeCopyPath(rawPath);
+    if (!normalizedPath) {
+      continue;
+    }
+
+    if (isAbsolute(normalizedPath)) {
+      throw new Error(`Worktree copy path must be relative: ${rawPath}`);
+    }
+
+    if (normalizedPath === ".git" || normalizedPath.startsWith(".git/")) {
+      throw new Error(`Worktree copy path cannot target .git: ${rawPath}`);
+    }
+
+    const sourcePath = resolve(options.repoRoot, normalizedPath);
+    if (!isPathWithinRoot(options.repoRoot, sourcePath)) {
+      throw new Error(`Worktree copy path escapes repository root: ${rawPath}`);
+    }
+    if (!existsSync(sourcePath)) {
+      continue;
+    }
+
+    const destinationPath = resolve(options.worktreePath, normalizedPath);
+    if (!isPathWithinRoot(options.worktreePath, destinationPath)) {
+      throw new Error(`Worktree copy path escapes worktree root: ${rawPath}`);
+    }
+
+    mkdirSync(dirname(destinationPath), { recursive: true });
+    cpSync(sourcePath, destinationPath, {
+      recursive: true,
+      force: true,
+    });
+  }
 }
 
 function readPaseoConfig(repoRoot: string): PaseoConfig | null {
@@ -921,6 +977,7 @@ export async function createWorktree({
   cwd,
   baseBranch,
   worktreeSlug,
+  copyFromRepoPaths,
   runSetup = true,
   paseoHome,
 }: CreateWorktreeOptions): Promise<WorktreeConfig> {
@@ -1005,6 +1062,12 @@ export async function createWorktree({
   worktreePath = normalizePathForOwnership(finalWorktreePath);
 
   writePaseoWorktreeMetadata(worktreePath, { baseRefName: normalizedBaseBranch });
+
+  copyConfiguredPathsIntoWorktree({
+    repoRoot: cwd,
+    worktreePath,
+    copyFromRepoPaths,
+  });
 
   if (runSetup) {
     await runWorktreeSetupCommands({

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -128,8 +128,22 @@ interface CreateWorktreeOptions {
   baseBranch: string;
   worktreeSlug?: string;
   copyFromRepoPaths?: string[];
+  disableGitHooks?: boolean;
   runSetup?: boolean;
   paseoHome?: string;
+}
+
+export function buildWorktreeAddCommand(options: {
+  worktreePath: string;
+  branchName: string;
+  baseRef: string;
+  disableGitHooks?: boolean;
+}): string[] {
+  const args = ["worktree", "add", options.worktreePath, "-b", options.branchName, options.baseRef];
+  if (!options.disableGitHooks) {
+    return args;
+  }
+  return ["-c", "core.hooksPath=/dev/null", ...args];
 }
 
 function isPathWithinRoot(rootPath: string, candidatePath: string): boolean {
@@ -978,6 +992,7 @@ export async function createWorktree({
   baseBranch,
   worktreeSlug,
   copyFromRepoPaths,
+  disableGitHooks,
   runSetup = true,
   paseoHome,
 }: CreateWorktreeOptions): Promise<WorktreeConfig> {
@@ -1055,7 +1070,13 @@ export async function createWorktree({
     pathSuffix++;
   }
 
-  await runGitCommand(["worktree", "add", finalWorktreePath, "-b", newBranchName, base], {
+  const worktreeAddCommand = buildWorktreeAddCommand({
+    worktreePath: finalWorktreePath,
+    branchName: newBranchName,
+    baseRef: base,
+    disableGitHooks,
+  });
+  await runGitCommand(worktreeAddCommand, {
     cwd,
     timeout: 120_000,
   });


### PR DESCRIPTION
## Summary
- add a persisted daemon setting `worktree.disableGitHooks` and expose it through mutable daemon config
- thread the setting through session/worktree bootstrap and prefix `git worktree add` with `-c core.hooksPath=/dev/null` when enabled
- add a Settings toggle, test coverage for command generation + persisted config parsing, and product docs note

## Testing
- npm run format
- npm run typecheck
- npm run test:unit --workspace @getpaseo/server -- src/utils/worktree.test.ts src/server/persisted-config.test.ts src/server/worktree-bootstrap.test.ts

## Notes
- Stacked follow-up to #473. GitHub cannot target that PR branch as base in `getpaseo/paseo` because the base branch exists only on the fork, so this PR targets `main` and should merge after #473.