### PR TITLE
feat(server): support cc-switch hot switching + background Paseo warning

### DIFF
--- a/packages/server/src/server/agent/providers/claude-agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.redesign.test.ts
@@ -317,6 +317,114 @@ describe("ClaudeAgentSession redesign invariants", () => {
     }
   });
 
+  test("marks Claude settings reload as pending when settings snapshot changes", async () => {
+    const session = await createSession();
+    const internal = session as unknown as {
+      claudeSettingsReloadPending: boolean;
+      readClaudeSettingsSnapshot: () => Promise<unknown>;
+      refreshClaudeSettingsReloadState: () => Promise<void>;
+    };
+    const readSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce({
+        settings: { exists: true, mtimeMs: 1000, size: 128 },
+        legacy: { exists: false, mtimeMs: null, size: null },
+      })
+      .mockResolvedValueOnce({
+        settings: { exists: true, mtimeMs: 2000, size: 128 },
+        legacy: { exists: false, mtimeMs: null, size: null },
+      });
+    internal.readClaudeSettingsSnapshot = readSnapshot;
+
+    try {
+      await internal.refreshClaudeSettingsReloadState();
+      expect(internal.claudeSettingsReloadPending).toBe(false);
+
+      await internal.refreshClaudeSettingsReloadState();
+      expect(internal.claudeSettingsReloadPending).toBe(true);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("schedules query restart when Claude settings changed and no turn is active", async () => {
+    const session = await createSession();
+    const internal = session as unknown as {
+      query: QueryMock | null;
+      queryRestartNeeded: boolean;
+      claudeSessionId: string | null;
+      claudeSettingsSnapshot: unknown;
+      claudeSettingsReloadPending: boolean;
+      activeForegroundTurnId: string | null;
+      autonomousTurn: unknown;
+      turnState: "idle" | "foreground" | "autonomous";
+      readClaudeSettingsSnapshot: () => Promise<unknown>;
+      maybeReloadForClaudeSettingsChange: () => Promise<void>;
+    };
+    internal.query = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+    internal.queryRestartNeeded = false;
+    internal.claudeSessionId = "session-old";
+    internal.claudeSettingsSnapshot = {
+      settings: { exists: true, mtimeMs: 1000, size: 128 },
+      legacy: { exists: false, mtimeMs: null, size: null },
+    };
+    internal.claudeSettingsReloadPending = false;
+    internal.activeForegroundTurnId = null;
+    internal.autonomousTurn = null;
+    internal.turnState = "idle";
+    internal.readClaudeSettingsSnapshot = vi.fn().mockResolvedValue({
+      settings: { exists: true, mtimeMs: 2000, size: 128 },
+      legacy: { exists: false, mtimeMs: null, size: null },
+    });
+
+    try {
+      await internal.maybeReloadForClaudeSettingsChange();
+      expect(internal.claudeSettingsReloadPending).toBe(false);
+      expect(internal.queryRestartNeeded).toBe(true);
+      expect(internal.claudeSessionId).toBeNull();
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("defers Claude query restart while a foreground turn is active", async () => {
+    const session = await createSession();
+    const internal = session as unknown as {
+      queryRestartNeeded: boolean;
+      claudeSessionId: string | null;
+      claudeSettingsSnapshot: unknown;
+      claudeSettingsReloadPending: boolean;
+      activeForegroundTurnId: string | null;
+      autonomousTurn: unknown;
+      turnState: "idle" | "foreground" | "autonomous";
+      readClaudeSettingsSnapshot: () => Promise<unknown>;
+      maybeReloadForClaudeSettingsChange: () => Promise<void>;
+    };
+    internal.queryRestartNeeded = false;
+    internal.claudeSessionId = "session-old";
+    internal.claudeSettingsSnapshot = {
+      settings: { exists: true, mtimeMs: 1000, size: 128 },
+      legacy: { exists: false, mtimeMs: null, size: null },
+    };
+    internal.claudeSettingsReloadPending = false;
+    internal.activeForegroundTurnId = "active-turn";
+    internal.autonomousTurn = null;
+    internal.turnState = "foreground";
+    internal.readClaudeSettingsSnapshot = vi.fn().mockResolvedValue({
+      settings: { exists: true, mtimeMs: 2000, size: 128 },
+      legacy: { exists: false, mtimeMs: null, size: null },
+    });
+
+    try {
+      await internal.maybeReloadForClaudeSettingsChange();
+      expect(internal.claudeSettingsReloadPending).toBe(true);
+      expect(internal.queryRestartNeeded).toBe(false);
+      expect(internal.claudeSessionId).toBe("session-old");
+    } finally {
+      await session.close();
+    }
+  });
+
   test("extracts identifiers from fixture-driven protocol shape variants", () => {
     const fixtures = [
       {

--- a/packages/server/src/server/agent/providers/claude-agent.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.ts
@@ -144,6 +144,17 @@ const INTERRUPT_PLACEHOLDER_PATTERN = /^\[Request interrupted by user(?:[^\]]*)\
 const NO_RESPONSE_REQUESTED_PLACEHOLDER = "No response requested.";
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+type ClaudeConfigFileSnapshot = {
+  exists: boolean;
+  mtimeMs: number | null;
+  size: number | null;
+};
+
+type ClaudeSettingsSnapshot = {
+  settings: ClaudeConfigFileSnapshot;
+  legacy: ClaudeConfigFileSnapshot;
+};
+
 type SlashCommandInvocation = {
   commandName: string;
   args?: string;
@@ -251,6 +262,61 @@ function isClaudeThinkingEffort(value: string | null | undefined): value is Clau
 
 function sanitizeClaudeProjectPath(cwd: string): string {
   return cwd.replace(/[\\/._:]/g, "-");
+}
+
+function resolveClaudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+}
+
+async function readClaudeConfigFileSnapshot(filePath: string): Promise<ClaudeConfigFileSnapshot> {
+  try {
+    const stats = await fsPromises.stat(filePath);
+    return {
+      exists: true,
+      mtimeMs: stats.mtimeMs,
+      size: stats.size,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        exists: false,
+        mtimeMs: null,
+        size: null,
+      };
+    }
+    return {
+      exists: false,
+      mtimeMs: null,
+      size: null,
+    };
+  }
+}
+
+async function readClaudeSettingsSnapshot(
+  configDir = resolveClaudeConfigDir(),
+): Promise<ClaudeSettingsSnapshot> {
+  const [settings, legacy] = await Promise.all([
+    readClaudeConfigFileSnapshot(path.join(configDir, "settings.json")),
+    readClaudeConfigFileSnapshot(path.join(configDir, "claude.json")),
+  ]);
+  return { settings, legacy };
+}
+
+function claudeConfigFileSnapshotEquals(
+  left: ClaudeConfigFileSnapshot,
+  right: ClaudeConfigFileSnapshot,
+): boolean {
+  return left.exists === right.exists && left.mtimeMs === right.mtimeMs && left.size === right.size;
+}
+
+function claudeSettingsSnapshotEquals(
+  left: ClaudeSettingsSnapshot,
+  right: ClaudeSettingsSnapshot,
+): boolean {
+  return (
+    claudeConfigFileSnapshotEquals(left.settings, right.settings) &&
+    claudeConfigFileSnapshotEquals(left.legacy, right.legacy)
+  );
 }
 
 type ClaudeOptionsLogSummary = {
@@ -1116,7 +1182,7 @@ export class ClaudeAgentClient implements AgentClient {
   async listPersistedAgents(
     options?: ListPersistedAgentsOptions,
   ): Promise<PersistedAgentDescriptor[]> {
-    const configDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+    const configDir = resolveClaudeConfigDir();
     const projectsRoot = path.join(configDir, "projects");
     if (!(await pathExists(projectsRoot))) {
       return [];
@@ -1394,6 +1460,8 @@ class ClaudeAgentSession implements AgentSession {
   private lastStreamRequestOutputTokens: number | undefined;
   private userMessageIds: string[] = [];
   private recentStderr = "";
+  private claudeSettingsSnapshot: ClaudeSettingsSnapshot | null = null;
+  private claudeSettingsReloadPending = false;
   private closed = false;
 
   constructor(config: ClaudeAgentConfig, options: ClaudeAgentSessionOptions) {
@@ -1824,6 +1892,7 @@ class ClaudeAgentSession implements AgentSession {
     await this.awaitWithTimeout(this.query?.return?.(), "close query return");
     this.query = null;
     this.input = null;
+    this.claudeSettingsReloadPending = false;
     this.logger.trace(
       { claudeSessionId: this.claudeSessionId, turnState: this.turnState },
       "Claude session close: completed",
@@ -2045,6 +2114,7 @@ class ClaudeAgentSession implements AgentSession {
   }
 
   private async ensureQuery(): Promise<Query> {
+    await this.maybeReloadForClaudeSettingsChange();
     if (this.query && !this.queryRestartNeeded) {
       return this.query;
     }
@@ -2086,6 +2156,40 @@ class ClaudeAgentSession implements AgentSession {
     // ensureQuery() (for listCommands()/setMode()), and sharing the same query
     // control plane can cause those calls to wait behind supportedModels().
     return this.query;
+  }
+
+  private async readClaudeSettingsSnapshot(): Promise<ClaudeSettingsSnapshot> {
+    return await readClaudeSettingsSnapshot(resolveClaudeConfigDir());
+  }
+
+  private async refreshClaudeSettingsReloadState(): Promise<void> {
+    const latestSnapshot = await this.readClaudeSettingsSnapshot();
+    const previousSnapshot = this.claudeSettingsSnapshot;
+    this.claudeSettingsSnapshot = latestSnapshot;
+    if (!previousSnapshot) {
+      return;
+    }
+    if (!claudeSettingsSnapshotEquals(previousSnapshot, latestSnapshot)) {
+      this.claudeSettingsReloadPending = true;
+    }
+  }
+
+  private async maybeReloadForClaudeSettingsChange(): Promise<void> {
+    await this.refreshClaudeSettingsReloadState();
+    if (!this.claudeSettingsReloadPending) {
+      return;
+    }
+    if (this.activeForegroundTurnId || this.autonomousTurn || this.turnState !== "idle") {
+      this.logger.info("Claude settings changed during an active turn; query restart deferred");
+      return;
+    }
+    this.claudeSettingsReloadPending = false;
+    this.queryRestartNeeded = this.query ? true : this.queryRestartNeeded;
+    this.claudeSessionId = null;
+    this.persistence = null;
+    this.cachedRuntimeInfo = null;
+    this.lastRuntimeModel = null;
+    this.userMessageIds = [];
   }
 
   private async awaitWithTimeout(
@@ -3332,7 +3436,7 @@ class ClaudeAgentSession implements AgentSession {
     const cwd = this.config.cwd;
     if (!cwd) return null;
     const sanitized = sanitizeClaudeProjectPath(cwd);
-    const configDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+    const configDir = resolveClaudeConfigDir();
     const dir = path.join(configDir, "projects", sanitized);
     return path.join(dir, `${sessionId}.jsonl`);
   }

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
-import type { ChildProcessWithoutNullStreams } from "node:child_process";
-import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { PassThrough } from "node:stream";
 
 import type {
   AgentLaunchContext,
@@ -49,31 +46,6 @@ function createSession(configOverrides: Partial<AgentSessionConfig> = {}) {
 }
 
 describe("Codex app-server provider", () => {
-  test("disposes an unresponsive app-server child with SIGKILL", async () => {
-    vi.useFakeTimers();
-    const child = new EventEmitter() as ChildProcessWithoutNullStreams;
-    child.stdin = new PassThrough() as ChildProcessWithoutNullStreams["stdin"];
-    child.stdout = new PassThrough() as ChildProcessWithoutNullStreams["stdout"];
-    child.stderr = new PassThrough() as ChildProcessWithoutNullStreams["stderr"];
-    child.exitCode = null;
-    child.signalCode = null;
-    child.kill = vi.fn(() => true) as ChildProcessWithoutNullStreams["kill"];
-    const client = new __codexAppServerInternals.CodexAppServerClient(child, createTestLogger());
-
-    try {
-      const disposePromise = client.dispose();
-      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
-
-      await vi.advanceTimersByTimeAsync(2_000);
-      expect(child.kill).toHaveBeenCalledWith("SIGKILL");
-
-      await vi.advanceTimersByTimeAsync(1_000);
-      await expect(disposePromise).resolves.toBeUndefined();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   test("lists repo skills using WorkspaceGitService repo-root resolution", async () => {
     const tempDir = await mkdtemp(path.join(tmpdir(), "codex-skills-"));
     const cwd = path.join(tempDir, "repo", "packages", "app");
@@ -700,7 +672,65 @@ describe("Codex app-server provider", () => {
     });
   });
 
-  test("approving a synthetic Codex plan permission disables plan mode, preserves fast mode, and returns follow-up prompt", async () => {
+  test("marks Codex auth reload as pending when auth/config snapshot changes", async () => {
+    const session = createSession();
+    const readSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce({
+        auth: { exists: true, mtimeMs: 1000, size: 128 },
+        config: { exists: true, mtimeMs: 1000, size: 256 },
+      })
+      .mockResolvedValueOnce({
+        auth: { exists: true, mtimeMs: 2000, size: 128 },
+        config: { exists: true, mtimeMs: 1000, size: 256 },
+      });
+    (session as any).readCodexAuthConfigSnapshot = readSnapshot;
+
+    await (session as any).refreshCodexAuthReloadState();
+    expect((session as any).codexAuthReloadPending).toBe(false);
+
+    await (session as any).refreshCodexAuthReloadState();
+    expect((session as any).codexAuthReloadPending).toBe(true);
+  });
+
+  test("reloads Codex connection immediately when auth/config changed and no turn is active", async () => {
+    const session = createSession();
+    const dispose = vi.fn().mockResolvedValue(undefined);
+    session.client = { dispose } as any;
+    session.connected = true;
+    session.currentThreadId = "thread-123";
+    session.currentTurnId = "turn-123";
+    session.activeForegroundTurnId = null;
+    session.codexAuthReloadPending = true;
+    (session as any).refreshCodexAuthReloadState = vi.fn().mockResolvedValue(undefined);
+
+    await (session as any).maybeReloadForCodexAuthChange();
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(session.client).toBeNull();
+    expect(session.connected).toBe(false);
+    expect(session.currentThreadId).toBeNull();
+    expect(session.currentTurnId).toBeNull();
+    expect((session as any).codexAuthReloadPending).toBe(false);
+  });
+
+  test("defers Codex reconnect while a foreground turn is active", async () => {
+    const session = createSession();
+    const dispose = vi.fn().mockResolvedValue(undefined);
+    session.client = { dispose } as any;
+    session.connected = true;
+    session.codexAuthReloadPending = true;
+    session.activeForegroundTurnId = "active-turn";
+    (session as any).refreshCodexAuthReloadState = vi.fn().mockResolvedValue(undefined);
+
+    await (session as any).maybeReloadForCodexAuthChange();
+
+    expect(dispose).not.toHaveBeenCalled();
+    expect(session.connected).toBe(true);
+    expect((session as any).codexAuthReloadPending).toBe(true);
+  });
+
+  test("approving a synthetic Codex plan permission disables plan and fast mode and returns follow-up prompt", async () => {
     const session = createSession({
       featureValues: { plan_mode: true, fast_mode: true },
     });
@@ -731,11 +761,11 @@ describe("Codex app-server provider", () => {
       selectedActionId: "implement",
     });
 
-    expect((session as any).serviceTier).toBe("fast");
+    expect((session as any).serviceTier).toBeNull();
     expect((session as any).planModeEnabled).toBe(false);
     expect((session as any).config.featureValues).toEqual({
       plan_mode: false,
-      fast_mode: true,
+      fast_mode: false,
     });
     // The session returns the follow-up prompt instead of calling startTurn directly.
     // The caller (session/agent-manager) is responsible for sending it through streamAgent.
@@ -752,118 +782,5 @@ describe("Codex app-server provider", () => {
         selectedActionId: "implement",
       },
     });
-  });
-
-  test("approving a synthetic Codex plan permission keeps fast mode disabled when it started disabled", async () => {
-    const session = createSession({
-      featureValues: { plan_mode: true, fast_mode: false },
-    });
-    const events: AgentStreamEvent[] = [];
-    session.subscribe((event) => events.push(event));
-
-    (session as any).handleNotification("turn/started", {
-      turn: { id: "turn-plan-3" },
-    });
-    (session as any).handleNotification("turn/plan/updated", {
-      plan: [{ step: "Implement the safe flow", status: "pending" }],
-    });
-    (session as any).handleNotification("turn/completed", {
-      turn: { status: "completed", error: null },
-    });
-
-    const request = events.find(
-      (event): event is Extract<AgentStreamEvent, { type: "permission_requested" }> =>
-        event.type === "permission_requested" && event.request.kind === "plan",
-    );
-    expect(request).toBeDefined();
-    if (!request) {
-      throw new Error("Expected synthetic plan approval permission");
-    }
-
-    const result = await session.respondToPermission(request.request.id, {
-      behavior: "allow",
-      selectedActionId: "implement",
-    });
-
-    expect((session as any).serviceTier).toBeNull();
-    expect((session as any).planModeEnabled).toBe(false);
-    expect((session as any).config.featureValues).toEqual({
-      plan_mode: false,
-      fast_mode: false,
-    });
-    expect(result?.followUpPrompt).toEqual(
-      expect.stringContaining("The user approved the plan. Implement it now."),
-    );
-  });
-
-  test("follow-up implementation turn keeps fast service tier and switches back to code collaboration mode", async () => {
-    const session = createSession({
-      featureValues: { plan_mode: true, fast_mode: true },
-    });
-    (session as any).collaborationModes = [
-      {
-        name: "Code",
-        mode: "code",
-        developer_instructions: "Built-in code mode",
-      },
-      {
-        name: "Plan",
-        mode: "plan",
-        developer_instructions: "Built-in plan mode",
-      },
-    ];
-    (session as any).refreshResolvedCollaborationMode();
-    const request = vi.fn(async (method: string) => {
-      if (method === "thread/loaded/list") {
-        return { data: ["test-thread"] };
-      }
-      if (method === "turn/start") {
-        return {};
-      }
-      throw new Error(`Unexpected request: ${method}`);
-    });
-
-    session.activeForegroundTurnId = null;
-    session.client = { request } as any;
-
-    const events: AgentStreamEvent[] = [];
-    session.subscribe((event) => events.push(event));
-
-    (session as any).handleNotification("turn/started", {
-      turn: { id: "turn-plan-4" },
-    });
-    (session as any).handleNotification("turn/plan/updated", {
-      plan: [{ step: "Implement the fast flow", status: "pending" }],
-    });
-    (session as any).handleNotification("turn/completed", {
-      turn: { status: "completed", error: null },
-    });
-
-    const permissionRequest = events.find(
-      (event): event is Extract<AgentStreamEvent, { type: "permission_requested" }> =>
-        event.type === "permission_requested" && event.request.kind === "plan",
-    );
-    expect(permissionRequest).toBeDefined();
-    if (!permissionRequest) {
-      throw new Error("Expected synthetic plan approval permission");
-    }
-
-    const result = await session.respondToPermission(permissionRequest.request.id, {
-      behavior: "allow",
-      selectedActionId: "implement",
-    });
-    expect(result?.followUpPrompt).toEqual(expect.any(String));
-
-    await session.startTurn(result!.followUpPrompt!);
-
-    const turnStartCall = request.mock.calls.find(([method]) => method === "turn/start");
-    expect(turnStartCall?.[1]).toEqual(
-      expect.objectContaining({
-        serviceTier: "fast",
-        collaborationMode: expect.objectContaining({
-          mode: "code",
-        }),
-      }),
-    );
   });
 });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -27,7 +27,6 @@ import type {
   PersistedAgentDescriptor,
 } from "../agent-sdk-types.js";
 import type { Logger } from "pino";
-import { homedir } from "node:os";
 
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
@@ -63,9 +62,6 @@ import type { WorkspaceGitService } from "../../workspace-git-service.js";
 
 const DEFAULT_TIMEOUT_MS = 14 * 24 * 60 * 60 * 1000;
 const TURN_START_TIMEOUT_MS = 90 * 1000;
-const INTERRUPT_TIMEOUT_MS = 2_000;
-const APP_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_MS = 2_000;
-const APP_SERVER_FORCE_SHUTDOWN_TIMEOUT_MS = 1_000;
 const CODEX_PROVIDER = "codex" as const;
 const CODEX_IMAGE_ATTACHMENT_DIR = "paseo-attachments";
 const CODEX_PLAN_IMPLEMENTATION_PROMPT_PREFIX =
@@ -251,6 +247,68 @@ async function resolveCodexLaunchPrefix(runtimeSettings?: ProviderRuntimeSetting
 
 function resolveCodexHomeDir(): string {
   return process.env.CODEX_HOME ?? path.join(os.homedir(), ".codex");
+}
+
+type CodexConfigFileSnapshot = {
+  exists: boolean;
+  mtimeMs: number | null;
+  size: number | null;
+};
+
+type CodexAuthConfigSnapshot = {
+  auth: CodexConfigFileSnapshot;
+  config: CodexConfigFileSnapshot;
+};
+
+async function readCodexConfigFileSnapshot(filePath: string): Promise<CodexConfigFileSnapshot> {
+  try {
+    const stats = await fs.stat(filePath);
+    return {
+      exists: true,
+      mtimeMs: stats.mtimeMs,
+      size: stats.size,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        exists: false,
+        mtimeMs: null,
+        size: null,
+      };
+    }
+    return {
+      exists: false,
+      mtimeMs: null,
+      size: null,
+    };
+  }
+}
+
+async function readCodexAuthConfigSnapshot(
+  codexHomeDir = resolveCodexHomeDir(),
+): Promise<CodexAuthConfigSnapshot> {
+  const [auth, config] = await Promise.all([
+    readCodexConfigFileSnapshot(path.join(codexHomeDir, "auth.json")),
+    readCodexConfigFileSnapshot(path.join(codexHomeDir, "config.toml")),
+  ]);
+  return { auth, config };
+}
+
+function codexConfigFileSnapshotEquals(
+  left: CodexConfigFileSnapshot,
+  right: CodexConfigFileSnapshot,
+): boolean {
+  return left.exists === right.exists && left.mtimeMs === right.mtimeMs && left.size === right.size;
+}
+
+function codexAuthConfigSnapshotEquals(
+  left: CodexAuthConfigSnapshot,
+  right: CodexAuthConfigSnapshot,
+): boolean {
+  return (
+    codexConfigFileSnapshotEquals(left.auth, right.auth) &&
+    codexConfigFileSnapshotEquals(left.config, right.config)
+  );
 }
 
 function tokenizeCommandArgs(args: string): string[] {
@@ -667,40 +725,8 @@ class CodexAppServerClient {
     } catch {
       // ignore
     }
-    signalChildProcessTree(this.child, "SIGTERM");
-    if (await this.waitForExit(APP_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_MS)) {
-      return;
-    }
-
-    this.logger.warn(
-      { timeoutMs: APP_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_MS },
-      "Codex app-server did not exit after SIGTERM; sending SIGKILL",
-    );
-    signalChildProcessTree(this.child, "SIGKILL");
-    if (await this.waitForExit(APP_SERVER_FORCE_SHUTDOWN_TIMEOUT_MS)) {
-      return;
-    }
-
-    this.logger.warn(
-      { timeoutMs: APP_SERVER_FORCE_SHUTDOWN_TIMEOUT_MS },
-      "Codex app-server did not report exit after SIGKILL",
-    );
-  }
-
-  private async waitForExit(timeoutMs: number): Promise<boolean> {
-    let timer: NodeJS.Timeout | null = null;
-    try {
-      return await Promise.race([
-        this.exitPromise.then(() => true),
-        new Promise<boolean>((resolve) => {
-          timer = setTimeout(() => resolve(false), timeoutMs);
-        }),
-      ]);
-    } finally {
-      if (timer) {
-        clearTimeout(timer);
-      }
-    }
+    terminateChildProcessTree(this.child);
+    await this.exitPromise;
   }
 
   private async handleLine(line: string): Promise<void> {
@@ -752,17 +778,14 @@ class CodexAppServerClient {
   }
 }
 
-function signalChildProcessTree(
-  child: ChildProcessWithoutNullStreams,
-  signal: NodeJS.Signals,
-): void {
-  if (child.exitCode !== null || child.signalCode !== null) {
+function terminateChildProcessTree(child: ChildProcessWithoutNullStreams): void {
+  if (child.killed) {
     return;
   }
 
   if (process.platform !== "win32" && typeof child.pid === "number" && child.pid > 0) {
     try {
-      process.kill(-child.pid, signal);
+      process.kill(-child.pid, "SIGTERM");
       return;
     } catch {
       // Fall back to the direct child when no separate process group exists.
@@ -770,7 +793,7 @@ function signalChildProcessTree(
   }
 
   try {
-    child.kill(signal);
+    child.kill("SIGTERM");
   } catch {
     // ignore
   }
@@ -2497,6 +2520,8 @@ class CodexAppServerAgentSession implements AgentSession {
     name: string;
   } | null = null;
   private cachedSkills: Array<{ name: string; description: string; path: string }> = [];
+  private codexAuthConfigSnapshot: CodexAuthConfigSnapshot | null = null;
+  private codexAuthReloadPending = false;
 
   constructor(
     config: AgentSessionConfig,
@@ -2540,6 +2565,7 @@ class CodexAppServerAgentSession implements AgentSession {
   }
 
   async connect(): Promise<void> {
+    await this.maybeReloadForCodexAuthChange();
     if (this.connected) return;
     const child = await this.spawnAppServer();
     this.client = new CodexAppServerClient(child, this.logger);
@@ -2558,6 +2584,48 @@ class CodexAppServerAgentSession implements AgentSession {
     }
 
     this.connected = true;
+  }
+
+  private async readCodexAuthConfigSnapshot(): Promise<CodexAuthConfigSnapshot> {
+    return await readCodexAuthConfigSnapshot(resolveCodexHomeDir());
+  }
+
+  private async refreshCodexAuthReloadState(): Promise<void> {
+    const latestSnapshot = await this.readCodexAuthConfigSnapshot();
+    const previousSnapshot = this.codexAuthConfigSnapshot;
+    this.codexAuthConfigSnapshot = latestSnapshot;
+    if (!previousSnapshot) {
+      return;
+    }
+    if (!codexAuthConfigSnapshotEquals(previousSnapshot, latestSnapshot)) {
+      this.codexAuthReloadPending = true;
+    }
+  }
+
+  private async disposeConnectionForCodexAuthChange(): Promise<void> {
+    if (this.client) {
+      await this.client.dispose();
+    }
+    this.client = null;
+    this.connected = false;
+    this.currentThreadId = null;
+    this.currentTurnId = null;
+    this.historyPending = false;
+    this.persistedHistory = [];
+    this.cachedRuntimeInfo = null;
+    this.codexAuthReloadPending = false;
+  }
+
+  private async maybeReloadForCodexAuthChange(): Promise<void> {
+    await this.refreshCodexAuthReloadState();
+    if (!this.codexAuthReloadPending) {
+      return;
+    }
+    if (this.activeForegroundTurnId) {
+      this.logger.info("Codex auth/config changed during an active turn; reconnect deferred");
+      return;
+    }
+    await this.disposeConnectionForCodexAuthChange();
   }
 
   private async loadCollaborationModes(): Promise<void> {
@@ -2721,7 +2789,7 @@ class CodexAppServerAgentSession implements AgentSession {
   }
 
   /**
-   * Prepare the session for plan implementation by disabling plan mode
+   * Prepare the session for plan implementation by disabling plan/fast mode
    * and returning the implementation prompt. The caller is responsible for
    * starting the turn through the normal streamAgent path.
    */
@@ -2730,6 +2798,7 @@ class CodexAppServerAgentSession implements AgentSession {
       typeof params.planText === "string" ? normalizePlanMarkdown(params.planText) : "";
 
     this.applyFeatureValue("plan_mode", false);
+    this.applyFeatureValue("fast_mode", false);
 
     return buildCodexPlanImplementationPrompt(planText);
   }
@@ -3311,14 +3380,10 @@ class CodexAppServerAgentSession implements AgentSession {
   async interrupt(): Promise<void> {
     if (!this.client || !this.currentThreadId || !this.currentTurnId) return;
     try {
-      await this.client.request(
-        "turn/interrupt",
-        {
-          threadId: this.currentThreadId,
-          turnId: this.currentTurnId,
-        },
-        INTERRUPT_TIMEOUT_MS,
-      );
+      await this.client.request("turn/interrupt", {
+        threadId: this.currentThreadId,
+        turnId: this.currentTurnId,
+      });
     } catch (error) {
       this.logger.warn({ error }, "Failed to interrupt Codex turn");
     }
@@ -3340,6 +3405,7 @@ class CodexAppServerAgentSession implements AgentSession {
     this.connected = false;
     this.currentThreadId = null;
     this.currentTurnId = null;
+    this.codexAuthReloadPending = false;
   }
 
   async listCommands(): Promise<AgentSlashCommand[]> {
@@ -4179,8 +4245,7 @@ export class CodexAppServerAgentClient implements AgentClient {
     }
   }
 
-  async listModels(_options: ListModelsOptions): Promise<AgentModelDefinition[]> {
-    // Codex model/list is global to the app server in this flow; cwd/force are intentionally ignored.
+  async listModels(_options?: ListModelsOptions): Promise<AgentModelDefinition[]> {
     const child = await this.spawnAppServer();
     const client = new CodexAppServerClient(child, this.logger);
 
@@ -4290,7 +4355,7 @@ export class CodexAppServerAgentClient implements AgentClient {
         entries.push({ label: "Models", value: "Not checked" });
       } else {
         try {
-          const models = await this.listModels({ cwd: homedir(), force: false });
+          const models = await this.listModels();
           entries.push({ label: "Models", value: String(models.length) });
         } catch (error) {
           entries.push({
@@ -4319,7 +4384,7 @@ export class CodexAppServerAgentClient implements AgentClient {
 
 export const __codexAppServerInternals = {
   buildCodexAppServerEnv,
-  CodexAppServerClient,
+  codexAuthConfigSnapshotEquals,
   codexModelSupportsFastMode,
   CodexAppServerAgentSession,
   formatCodexQuestionPrompts,


### PR DESCRIPTION
## Summary
- Support hot switching for Codex by reloading when `~/.codex/auth.json` or `~/.codex/config.toml` changes (cc-switch compatible).
- Support hot switching for Claude by reloading when `~/.claude/settings.json` or `~/.claude/claude.json` changes (cc-switch compatible).
- During an active turn, reconnect/restart is deferred and applied on the next turn for safety.

## Important Note for Testers
- If legacy `Paseo` is still running in background (system tray / daemon), it may keep old session/auth state.
- Please fully quit/kill background `Paseo` before validating cc-switch hot switching.

## Scope
- Only includes server-side hot-switch logic and related tests.