### PR TITLE
temporary fix(server): skip local speech on Windows to prevent daemon crash loop (#495)

### DIFF
--- a/packages/server/src/server/speech/providers/local/runtime.ts
+++ b/packages/server/src/server/speech/providers/local/runtime.ts
@@ -42,6 +42,14 @@ type LocalSpeechAvailability = {
   modelsDir: string | null;
 };
 
+function isTruthyEnvFlag(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
 export type InitializedLocalSpeech = {
   turnDetectionService: TurnDetectionProvider | null;
   sttService: SpeechToTextProvider | null;
@@ -189,6 +197,27 @@ export async function initializeLocalSpeechServices(params: {
   logger: Logger;
 }): Promise<InitializedLocalSpeech> {
   const { providers, logger, speechConfig } = params;
+
+  if (process.platform === "win32" && !isTruthyEnvFlag(process.env.PASEO_ENABLE_UNSAFE_WINDOWS_LOCAL_SPEECH)) {
+    logger.warn(
+      {
+        envFlag: "PASEO_ENABLE_UNSAFE_WINDOWS_LOCAL_SPEECH",
+      },
+      "Skipping local speech provider initialization on Windows to avoid native runtime crashes",
+    );
+
+    return {
+      turnDetectionService: null,
+      sttService: null,
+      ttsService: null,
+      dictationSttService: null,
+      localVoiceTtsProvider: null,
+      localModelConfig: null,
+      availability: getLocalSpeechAvailability(speechConfig),
+      cleanup: () => {},
+    };
+  }
+
   const localConfig = speechConfig?.local ?? null;
   const localModels = resolveConfiguredLocalModels(speechConfig);
 


### PR DESCRIPTION
### Summary
Skip local (Sherpa-based) speech provider initialization on Windows to prevent the daemon from crashing in a restart loop.

### Problem
On Windows, the daemon crash-loops on startup with exit code 3221226505 (0xC0000135 = STATUS_DLL_NOT_FOUND) when trying to initialize Sherpa native libraries.

### Temporary Solution
Skip local speech provider initialization on Windows by default. 

### Changes
packages/server/src/server/speech/providers/local/runtime.ts (+29 lines):
- Add isTruthyEnvFlag() helper
- Early return when on Windows (unless env flag is set)
### Testing
Dev server starts successfully on Windows without crash loop.

Closes #495 