### PR TITLE
Support GitHub SSH host aliases for PR actions

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -5190,7 +5190,6 @@ export class Session {
           base: msg.baseRef,
         },
         this.github,
-        this.workspaceGitService,
       );
       await this.notifyGitMutation(cwd, "create-pr", { invalidateGithub: true });
 

--- a/packages/server/src/server/workspace-git-metadata.ts
+++ b/packages/server/src/server/workspace-git-metadata.ts
@@ -1,4 +1,5 @@
 import { basename } from "path";
+import { parseGitHubRemoteUrl } from "../utils/github-remote.js";
 import { slugify } from "../utils/worktree.js";
 
 export interface WorkspaceGitMetadata {
@@ -14,41 +15,7 @@ export interface WorkspaceGitMetadata {
 }
 
 export function parseGitHubRepoFromRemote(remoteUrl: string): string | null {
-  let cleaned = remoteUrl.trim();
-  if (!cleaned) {
-    return null;
-  }
-
-  if (cleaned.startsWith("git@github.com:")) {
-    cleaned = cleaned.slice("git@github.com:".length);
-  } else {
-    let parsed: URL;
-    try {
-      parsed = new URL(cleaned);
-    } catch {
-      return null;
-    }
-
-    if (parsed.hostname !== "github.com") {
-      return null;
-    }
-
-    try {
-      cleaned = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
-    } catch {
-      return null;
-    }
-  }
-
-  if (cleaned.endsWith(".git")) {
-    cleaned = cleaned.slice(0, -".git".length);
-  }
-
-  if (!cleaned.includes("/")) {
-    return null;
-  }
-
-  return cleaned;
+  return parseGitHubRemoteUrl(remoteUrl)?.repo ?? null;
 }
 
 export function parseGitHubRepoNameFromRemote(remoteUrl: string): string | null {

--- a/packages/server/src/server/workspace-git-service.primitive.test.ts
+++ b/packages/server/src/server/workspace-git-service.primitive.test.ts
@@ -782,6 +782,32 @@ describe("WorkspaceGitServiceImpl primitive refresh entrypoint", () => {
     service.dispose();
   });
 
+  test("subscription starts GitHub self-heal polling for ssh.github.com remotes", async () => {
+    const retainCurrentPullRequestStatusPoll = vi.fn(() => ({ unsubscribe: vi.fn() }));
+    const github = {
+      ...createGitHubServiceStub(),
+      retainCurrentPullRequestStatusPoll,
+    };
+    const getCheckoutStatus = vi.fn(async (cwd: string) =>
+      createCheckoutStatus(cwd, {
+        remoteUrl: "ssh://git@ssh.github.com/acme/repo.git",
+      }),
+    );
+    const service = createService({
+      getCheckoutStatus,
+      github,
+    });
+    const subscription = service.registerWorkspace({ cwd: "/tmp/repo" }, vi.fn());
+    await flushPromises();
+
+    await vi.waitFor(() => {
+      expect(retainCurrentPullRequestStatusPoll).toHaveBeenCalledTimes(1);
+    });
+
+    subscription.unsubscribe();
+    service.dispose();
+  });
+
   test("multiple subscribers on the same target share one self-heal timer", async () => {
     let nowMs = 0;
     const getCheckoutStatus = vi.fn(async (cwd: string) => createCheckoutStatus(cwd));

--- a/packages/server/src/server/workspace-git-service.test.ts
+++ b/packages/server/src/server/workspace-git-service.test.ts
@@ -8,6 +8,7 @@ import {
   WorkspaceGitServiceImpl,
   type WorkspaceGitRuntimeSnapshot,
 } from "./workspace-git-service.js";
+import { resolveGitHubRemote } from "../utils/github-remote.js";
 
 interface ServiceInternals {
   workingTreeWatchTargets: Map<string, { fallbackRefreshInterval: unknown; repoWatchPath: string }>;
@@ -188,6 +189,7 @@ interface CreateServiceTestOptions {
   readdir?: ReturnType<typeof vi.fn>;
   watch?: ReturnType<typeof vi.fn>;
   now?: () => Date;
+  resolveGitHubRemote?: typeof resolveGitHubRemote;
 }
 
 function buildDefaultTestServiceDeps() {
@@ -212,6 +214,7 @@ function buildDefaultTestServiceDeps() {
       signal: null,
     })),
     now: () => new Date("2026-04-12T00:00:00.000Z"),
+    resolveGitHubRemote,
   };
 }
 
@@ -337,7 +340,34 @@ describe("WorkspaceGitServiceImpl", () => {
     service.dispose();
   });
 
-  test("cold getSnapshot calls share one workspace target and cache the snapshot", async () => {
+  test("getSnapshot treats SSH aliases that resolve to GitHub as GitHub remotes", async () => {
+    const getPullRequestStatus = vi.fn(async () => createPullRequestStatusResult());
+    const resolveViaSshAlias = vi.fn((input: { remoteUrl: string }) =>
+      resolveGitHubRemote({
+        remoteUrl: input.remoteUrl,
+        resolveSshHostname: async ({ host }) => (host === "github-work" ? "github.com" : null),
+      }),
+    );
+    const service = createService({
+      getCheckoutStatus: vi.fn(async (cwd: string) =>
+        createCheckoutStatus(cwd, {
+          remoteUrl: "git@github-work:acme/repo.git",
+        }),
+      ),
+      getPullRequestStatus,
+      resolveGitHubRemote: resolveViaSshAlias,
+    });
+
+    const snapshot = await service.getSnapshot("/tmp/repo");
+
+    expect(snapshot.github.featuresEnabled).toBe(true);
+    expect(getPullRequestStatus).toHaveBeenCalledTimes(1);
+    expect(resolveViaSshAlias).toHaveBeenCalledWith({ remoteUrl: "git@github-work:acme/repo.git" });
+
+    service.dispose();
+  });
+
+  test("cold getSnapshot calls share one workspace target setup and cache the snapshot", async () => {
     const checkoutStatusDeferred = createDeferred<CheckoutStatusGit>();
     const getCheckoutStatus = vi.fn(async () => checkoutStatusDeferred.promise);
     const getPullRequestStatus = vi.fn(async () => createPullRequestStatusResult());

--- a/packages/server/src/server/workspace-git-service.test.ts
+++ b/packages/server/src/server/workspace-git-service.test.ts
@@ -8,7 +8,6 @@ import {
   WorkspaceGitServiceImpl,
   type WorkspaceGitRuntimeSnapshot,
 } from "./workspace-git-service.js";
-import { resolveGitHubRemote } from "../utils/github-remote.js";
 
 interface ServiceInternals {
   workingTreeWatchTargets: Map<string, { fallbackRefreshInterval: unknown; repoWatchPath: string }>;
@@ -189,7 +188,6 @@ interface CreateServiceTestOptions {
   readdir?: ReturnType<typeof vi.fn>;
   watch?: ReturnType<typeof vi.fn>;
   now?: () => Date;
-  resolveGitHubRemote?: typeof resolveGitHubRemote;
 }
 
 function buildDefaultTestServiceDeps() {
@@ -214,7 +212,6 @@ function buildDefaultTestServiceDeps() {
       signal: null,
     })),
     now: () => new Date("2026-04-12T00:00:00.000Z"),
-    resolveGitHubRemote,
   };
 }
 
@@ -340,32 +337,6 @@ describe("WorkspaceGitServiceImpl", () => {
     service.dispose();
   });
 
-  test("getSnapshot treats SSH aliases that resolve to GitHub as GitHub remotes", async () => {
-    const getPullRequestStatus = vi.fn(async () => createPullRequestStatusResult());
-    const resolveViaSshAlias = vi.fn((input: { remoteUrl: string }) =>
-      resolveGitHubRemote({
-        remoteUrl: input.remoteUrl,
-        resolveSshHostname: async ({ host }) => (host === "github-work" ? "github.com" : null),
-      }),
-    );
-    const service = createService({
-      getCheckoutStatus: vi.fn(async (cwd: string) =>
-        createCheckoutStatus(cwd, {
-          remoteUrl: "git@github-work:acme/repo.git",
-        }),
-      ),
-      getPullRequestStatus,
-      resolveGitHubRemote: resolveViaSshAlias,
-    });
-
-    const snapshot = await service.getSnapshot("/tmp/repo");
-
-    expect(snapshot.github.featuresEnabled).toBe(true);
-    expect(getPullRequestStatus).toHaveBeenCalledTimes(1);
-    expect(resolveViaSshAlias).toHaveBeenCalledWith({ remoteUrl: "git@github-work:acme/repo.git" });
-
-    service.dispose();
-  });
 
   test("cold getSnapshot calls share one workspace target setup and cache the snapshot", async () => {
     const checkoutStatusDeferred = createDeferred<CheckoutStatusGit>();

--- a/packages/server/src/server/workspace-git-service.test.ts
+++ b/packages/server/src/server/workspace-git-service.test.ts
@@ -337,7 +337,6 @@ describe("WorkspaceGitServiceImpl", () => {
     service.dispose();
   });
 
-
   test("cold getSnapshot calls share one workspace target setup and cache the snapshot", async () => {
     const checkoutStatusDeferred = createDeferred<CheckoutStatusGit>();
     const getCheckoutStatus = vi.fn(async () => checkoutStatusDeferred.promise);

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -1046,7 +1046,10 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
     }
 
     const headRef = snapshot.git.currentBranch;
-    if (!headRef || !hasGitHubRemoteUrl(snapshot.git.remoteUrl)) {
+    const hasGitHubRemote =
+      target.cachedGitHubRemote?.remoteUrl === snapshot.git.remoteUrl &&
+      target.cachedGitHubRemote.identity !== null;
+    if (!headRef || !hasGitHubRemote) {
       this.stopGitHubPollForTarget(target);
       return;
     }
@@ -1640,18 +1643,6 @@ async function loadGitHubSnapshot(options: {
       },
     };
   }
-}
-
-function hasGitHubRemoteUrl(remoteUrl: string | null): boolean {
-  if (!remoteUrl) {
-    return false;
-  }
-
-  return (
-    remoteUrl.includes("github.com/") ||
-    remoteUrl.startsWith("git@github.com:") ||
-    remoteUrl.startsWith("ssh://git@github.com/")
-  );
 }
 
 function parseWorkspaceGitStashList(

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -23,7 +23,7 @@ import {
 import { createGitHubService, type GitHubService } from "../services/github-service.js";
 import { parseGitRevParsePath } from "../utils/git-rev-parse-path.js";
 import { runGitCommand } from "../utils/run-git-command.js";
-import { resolveGitHubRemote } from "../utils/github-remote.js";
+import { resolveGitHubRemote, type GitHubRemoteIdentity } from "../utils/github-remote.js";
 import { listPaseoWorktrees, type PaseoWorktreeInfo } from "../utils/worktree.js";
 import { READ_ONLY_GIT_ENV } from "./checkout-git-utils.js";
 import {
@@ -233,7 +233,6 @@ interface WorkspaceGitServiceDependencies {
   runGitFetch: (cwd: string) => Promise<void>;
   runGitCommand: typeof runGitCommand;
   now: () => Date;
-  resolveGitHubRemote: typeof resolveGitHubRemote;
 }
 
 interface WorkspaceGitServiceOptions {
@@ -256,6 +255,7 @@ interface WorkspaceGitTarget {
   latestFingerprint: string | null;
   lastShellOutAtMs: number | null;
   repoGitRoot: string | null;
+  cachedGitHubRemote: { remoteUrl: string; identity: GitHubRemoteIdentity | null } | null;
   observationSetupPromise: Promise<void> | null;
   observationSetupComplete: boolean;
   closed: boolean;
@@ -306,7 +306,6 @@ function buildDefaultWorkspaceGitServiceDeps(): WorkspaceGitServiceDependencies 
     runGitFetch,
     runGitCommand,
     now: () => new Date(),
-    resolveGitHubRemote,
   };
 }
 
@@ -755,10 +754,12 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
       latestFingerprint: null,
       lastShellOutAtMs: null,
       repoGitRoot: null,
+      cachedGitHubRemote: null,
       observationSetupPromise: null,
       observationSetupComplete: false,
       closed: false,
     };
+
 
     this.workspaceTargets.set(cwd, target);
     return target;
@@ -1317,6 +1318,22 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
     );
   }
 
+  private async resolveGitHubRemoteForTarget(
+    target: WorkspaceGitTarget,
+    remoteUrl: string | null,
+  ): Promise<GitHubRemoteIdentity | null> {
+    if (!remoteUrl) {
+      target.cachedGitHubRemote = null;
+      return null;
+    }
+    if (target.cachedGitHubRemote?.remoteUrl === remoteUrl) {
+      return target.cachedGitHubRemote.identity;
+    }
+    const identity = await resolveGitHubRemote({ remoteUrl });
+    target.cachedGitHubRemote = { remoteUrl, identity };
+    return identity;
+  }
+
   private shouldThrottleNonForcedRefresh(
     target: WorkspaceGitTarget,
   ): target is WorkspaceGitTarget & {
@@ -1389,15 +1406,42 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
     if (forceGitHub) {
       this.deps.github.invalidate({ cwd: target.cwd });
     }
-    const snapshot = await loadWorkspaceGitRuntimeSnapshot(
-      target.cwd,
-      { paseoHome: this.paseoHome },
-      now,
-      this.deps,
-      { force: request.force, forceGitHub, reason: request.reason },
-    );
+
+    const cwd = target.cwd;
+    const context: CheckoutContext = { paseoHome: this.paseoHome };
+    const checkoutStatus = await this.deps.getCheckoutStatus(cwd, context);
+    if (!checkoutStatus.isGit) {
+      target.latestSnapshotLoadedAtMs = now.getTime();
+      return buildNotGitSnapshot(cwd);
+    }
+
+    const githubRemote = await this.resolveGitHubRemoteForTarget(target, checkoutStatus.remoteUrl);
+
+    const [diffStat, github] = await Promise.all([
+      this.deps.getCheckoutShortstat(cwd, context, { force: request.force }).catch(() => null),
+      loadGitHubSnapshot({ cwd, githubRemote, now, deps: this.deps, force: forceGitHub, reason: request.reason }),
+    ]);
+
     target.latestSnapshotLoadedAtMs = now.getTime();
-    return snapshot;
+    return {
+      cwd,
+      git: {
+        isGit: true,
+        repoRoot: checkoutStatus.repoRoot,
+        mainRepoRoot: checkoutStatus.mainRepoRoot,
+        currentBranch: checkoutStatus.currentBranch,
+        remoteUrl: checkoutStatus.remoteUrl,
+        isPaseoOwnedWorktree: checkoutStatus.isPaseoOwnedWorktree,
+        isDirty: checkoutStatus.isDirty,
+        baseRef: checkoutStatus.baseRef,
+        aheadBehind: checkoutStatus.aheadBehind,
+        aheadOfOrigin: checkoutStatus.aheadOfOrigin,
+        behindOfOrigin: checkoutStatus.behindOfOrigin,
+        hasRemote: checkoutStatus.hasRemote,
+        diffStat,
+      },
+      github,
+    };
   }
 
   private rememberSnapshot(
@@ -1545,73 +1589,15 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
   }
 }
 
-async function loadWorkspaceGitRuntimeSnapshot(
-  cwd: string,
-  context: CheckoutContext,
-  now: Date,
-  deps: Pick<
-    WorkspaceGitServiceDependencies,
-    | "getCheckoutStatus"
-    | "getCheckoutShortstat"
-    | "getPullRequestStatus"
-    | "github"
-    | "resolveGitHubRemote"
-  >,
-  options?: { force?: boolean; forceGitHub?: boolean; reason?: string },
-): Promise<WorkspaceGitRuntimeSnapshot> {
-  const checkoutStatus = await deps.getCheckoutStatus(cwd, context);
-  if (!checkoutStatus.isGit) {
-    return buildNotGitSnapshot(cwd);
-  }
-
-  const [diffStat, github] = await Promise.all([
-    deps.getCheckoutShortstat(cwd, context, { force: options?.force }).catch(() => null),
-    loadGitHubSnapshot({
-      cwd,
-      remoteUrl: checkoutStatus.remoteUrl,
-      now,
-      deps,
-      force: options?.forceGitHub,
-      reason: options?.reason,
-    }),
-  ]);
-
-  return {
-    cwd,
-    git: {
-      isGit: true,
-      repoRoot: checkoutStatus.repoRoot,
-      mainRepoRoot: checkoutStatus.mainRepoRoot,
-      currentBranch: checkoutStatus.currentBranch,
-      remoteUrl: checkoutStatus.remoteUrl,
-      isPaseoOwnedWorktree: checkoutStatus.isPaseoOwnedWorktree,
-      isDirty: checkoutStatus.isDirty,
-      baseRef: checkoutStatus.baseRef,
-      aheadBehind: checkoutStatus.aheadBehind,
-      aheadOfOrigin: checkoutStatus.aheadOfOrigin,
-      behindOfOrigin: checkoutStatus.behindOfOrigin,
-      hasRemote: checkoutStatus.hasRemote,
-      diffStat,
-    },
-    github,
-  };
-}
-
 async function loadGitHubSnapshot(options: {
   cwd: string;
-  remoteUrl: string | null;
+  githubRemote: GitHubRemoteIdentity | null;
   now: Date;
-  deps: Pick<
-    WorkspaceGitServiceDependencies,
-    "getPullRequestStatus" | "github" | "resolveGitHubRemote"
-  >;
+  deps: Pick<WorkspaceGitServiceDependencies, "getPullRequestStatus" | "github">;
   force?: boolean;
   reason?: string;
 }): Promise<WorkspaceGitRuntimeSnapshot["github"]> {
-  const githubRemote = options.remoteUrl
-    ? await options.deps.resolveGitHubRemote({ remoteUrl: options.remoteUrl })
-    : null;
-  if (!githubRemote) {
+  if (!options.githubRemote) {
     return {
       featuresEnabled: false,
       pullRequest: null,

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -760,7 +760,6 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
       closed: false,
     };
 
-
     this.workspaceTargets.set(cwd, target);
     return target;
   }
@@ -1419,7 +1418,14 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
 
     const [diffStat, github] = await Promise.all([
       this.deps.getCheckoutShortstat(cwd, context, { force: request.force }).catch(() => null),
-      loadGitHubSnapshot({ cwd, githubRemote, now, deps: this.deps, force: forceGitHub, reason: request.reason }),
+      loadGitHubSnapshot({
+        cwd,
+        githubRemote,
+        now,
+        deps: this.deps,
+        force: forceGitHub,
+        reason: request.reason,
+      }),
     ]);
 
     target.latestSnapshotLoadedAtMs = now.getTime();
@@ -1683,7 +1689,6 @@ function parseWorkspaceGitStashList(
 
   return entries;
 }
-
 
 function buildNotGitSnapshot(cwd: string): WorkspaceGitRuntimeSnapshot {
   return {

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -23,6 +23,7 @@ import {
 import { createGitHubService, type GitHubService } from "../services/github-service.js";
 import { parseGitRevParsePath } from "../utils/git-rev-parse-path.js";
 import { runGitCommand } from "../utils/run-git-command.js";
+import { resolveGitHubRemote } from "../utils/github-remote.js";
 import { listPaseoWorktrees, type PaseoWorktreeInfo } from "../utils/worktree.js";
 import { READ_ONLY_GIT_ENV } from "./checkout-git-utils.js";
 import {
@@ -232,6 +233,7 @@ interface WorkspaceGitServiceDependencies {
   runGitFetch: (cwd: string) => Promise<void>;
   runGitCommand: typeof runGitCommand;
   now: () => Date;
+  resolveGitHubRemote: typeof resolveGitHubRemote;
 }
 
 interface WorkspaceGitServiceOptions {
@@ -304,6 +306,7 @@ function buildDefaultWorkspaceGitServiceDeps(): WorkspaceGitServiceDependencies 
     runGitFetch,
     runGitCommand,
     now: () => new Date(),
+    resolveGitHubRemote,
   };
 }
 
@@ -1548,7 +1551,11 @@ async function loadWorkspaceGitRuntimeSnapshot(
   now: Date,
   deps: Pick<
     WorkspaceGitServiceDependencies,
-    "getCheckoutStatus" | "getCheckoutShortstat" | "getPullRequestStatus" | "github"
+    | "getCheckoutStatus"
+    | "getCheckoutShortstat"
+    | "getPullRequestStatus"
+    | "github"
+    | "resolveGitHubRemote"
   >,
   options?: { force?: boolean; forceGitHub?: boolean; reason?: string },
 ): Promise<WorkspaceGitRuntimeSnapshot> {
@@ -1594,11 +1601,17 @@ async function loadGitHubSnapshot(options: {
   cwd: string;
   remoteUrl: string | null;
   now: Date;
-  deps: Pick<WorkspaceGitServiceDependencies, "getPullRequestStatus" | "github">;
+  deps: Pick<
+    WorkspaceGitServiceDependencies,
+    "getPullRequestStatus" | "github" | "resolveGitHubRemote"
+  >;
   force?: boolean;
   reason?: string;
 }): Promise<WorkspaceGitRuntimeSnapshot["github"]> {
-  if (!hasGitHubRemoteUrl(options.remoteUrl)) {
+  const githubRemote = options.remoteUrl
+    ? await options.deps.resolveGitHubRemote({ remoteUrl: options.remoteUrl })
+    : null;
+  if (!githubRemote) {
     return {
       featuresEnabled: false,
       pullRequest: null,
@@ -1684,6 +1697,7 @@ function parseWorkspaceGitStashList(
 
   return entries;
 }
+
 
 function buildNotGitSnapshot(cwd: string): WorkspaceGitRuntimeSnapshot {
   return {

--- a/packages/server/src/services/github-service.test.ts
+++ b/packages/server/src/services/github-service.test.ts
@@ -1,3 +1,7 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   GitHubAuthenticationError,
@@ -1837,16 +1841,20 @@ describe("GitHubService", () => {
     expect(valid.reason).toBe("test");
   });
 
-  it("resolves GitHub repos from a WorkspaceGitService-owned remote URL", async () => {
-    const workspaceGitService = {
-      resolveRepoRemoteUrl: async (cwd: string) => {
-        expect(cwd).toBe("/repo");
-        return "git@github.com:getpaseo/paseo.git";
-      },
-    };
+  it("resolves GitHub repos from the origin remote URL", async () => {
+    vi.useRealTimers();
+    const cwd = mkdtempSync(join(tmpdir(), "github-service-repo-"));
 
-    await expect(resolveGitHubRepo("/repo", { workspaceGitService })).resolves.toBe(
-      "getpaseo/paseo",
-    );
+    try {
+      execFileSync("git", ["init", "-b", "main"], { cwd, stdio: "ignore" });
+      execFileSync("git", ["remote", "add", "origin", "git@github.com:getpaseo/paseo.git"], {
+        cwd,
+        stdio: "ignore",
+      });
+
+      await expect(resolveGitHubRepo(cwd)).resolves.toBe("getpaseo/paseo");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/server/src/services/github-service.ts
+++ b/packages/server/src/services/github-service.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import type { GitHubSearchKind } from "../shared/messages.js";
 import { findExecutable } from "../utils/executable.js";
+import { resolveGitHubRemote, type SshHostnameResolver } from "../utils/github-remote.js";
+import { runGitCommand } from "../utils/run-git-command.js";
 import { execCommand } from "../utils/spawn.js";
 
 const DEFAULT_GITHUB_CACHE_TTL_MS = 30_000;
@@ -1865,46 +1867,21 @@ function mapReviewDecision(value: unknown): PullRequestReviewDecision {
   return null;
 }
 
-export interface GitHubRepoRemoteUrlResolver {
-  resolveRepoRemoteUrl(cwd: string, options?: GitHubReadOptions): Promise<string | null>;
-}
-
-export async function resolveGitHubRepo(
-  cwd: string,
-  options: { workspaceGitService: GitHubRepoRemoteUrlResolver; readOptions?: GitHubReadOptions },
-): Promise<string | null> {
+export async function resolveGitHubRepo(options: {
+  cwd: string;
+  resolveSshHostname?: SshHostnameResolver;
+}): Promise<string | null> {
   try {
-    const remoteUrl = await options.workspaceGitService.resolveRepoRemoteUrl(
-      cwd,
-      options.readOptions,
-    );
-    return parseGitHubRepoFromRemote(remoteUrl?.trim() ?? "");
+    const { stdout } = await runGitCommand(["config", "--get", "remote.origin.url"], {
+      cwd: options.cwd,
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+    });
+    const remote = await resolveGitHubRemote({
+      remoteUrl: stdout.trim(),
+      resolveSshHostname: options.resolveSshHostname,
+    });
+    return remote?.repo ?? null;
   } catch {
     return null;
   }
-}
-
-function parseGitHubRepoFromRemote(url: string): string | null {
-  if (!url) {
-    return null;
-  }
-  let cleaned = url;
-  if (cleaned.startsWith("git@github.com:")) {
-    cleaned = cleaned.slice("git@github.com:".length);
-  } else if (cleaned.startsWith("https://github.com/")) {
-    cleaned = cleaned.slice("https://github.com/".length);
-  } else if (cleaned.startsWith("http://github.com/")) {
-    cleaned = cleaned.slice("http://github.com/".length);
-  } else {
-    const marker = "github.com/";
-    const index = cleaned.indexOf(marker);
-    if (index === -1) {
-      return null;
-    }
-    cleaned = cleaned.slice(index + marker.length);
-  }
-  if (cleaned.endsWith(".git")) {
-    cleaned = cleaned.slice(0, -".git".length);
-  }
-  return cleaned.includes("/") ? cleaned : null;
 }

--- a/packages/server/src/services/github-service.ts
+++ b/packages/server/src/services/github-service.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { GitHubSearchKind } from "../shared/messages.js";
 import { findExecutable } from "../utils/executable.js";
-import { resolveGitHubRemote, type SshHostnameResolver } from "../utils/github-remote.js";
+import { resolveGitHubRemote } from "../utils/github-remote.js";
 import { runGitCommand } from "../utils/run-git-command.js";
 import { execCommand } from "../utils/spawn.js";
 
@@ -1867,19 +1867,13 @@ function mapReviewDecision(value: unknown): PullRequestReviewDecision {
   return null;
 }
 
-export async function resolveGitHubRepo(options: {
-  cwd: string;
-  resolveSshHostname?: SshHostnameResolver;
-}): Promise<string | null> {
+export async function resolveGitHubRepo(cwd: string): Promise<string | null> {
   try {
     const { stdout } = await runGitCommand(["config", "--get", "remote.origin.url"], {
-      cwd: options.cwd,
+      cwd,
       env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
     });
-    const remote = await resolveGitHubRemote({
-      remoteUrl: stdout.trim(),
-      resolveSshHostname: options.resolveSshHostname,
-    });
+    const remote = await resolveGitHubRemote({ remoteUrl: stdout.trim() });
     return remote?.repo ?? null;
   } catch {
     return null;

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -11,7 +11,6 @@ import {
   GitHubCommandError,
   createGitHubService,
   resolveGitHubRepo,
-  type GitHubRepoRemoteUrlResolver,
   type GitHubService,
 } from "../services/github-service.js";
 import { parseGitRevParsePath, resolveGitRevParsePath } from "./git-rev-parse-path.js";
@@ -2277,11 +2276,10 @@ export async function createPullRequest(
   cwd: string,
   options: CreatePullRequestOptions,
   github: GitHubService = createGitHubService(),
-  workspaceGitService: GitHubRepoRemoteUrlResolver,
   context?: CheckoutContext,
 ): Promise<{ url: string; number: number }> {
   await requireGitRepo(cwd);
-  const repo = await resolveGitHubRepo(cwd, { workspaceGitService });
+  const repo = await resolveGitHubRepo({ cwd });
   if (!repo) {
     throw new Error("Unable to determine GitHub repo from git remote");
   }

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -2279,7 +2279,7 @@ export async function createPullRequest(
   context?: CheckoutContext,
 ): Promise<{ url: string; number: number }> {
   await requireGitRepo(cwd);
-  const repo = await resolveGitHubRepo({ cwd });
+  const repo = await resolveGitHubRepo(cwd);
   if (!repo) {
     throw new Error("Unable to determine GitHub repo from git remote");
   }

--- a/packages/server/src/utils/github-remote.test.ts
+++ b/packages/server/src/utils/github-remote.test.ts
@@ -38,6 +38,21 @@ describe("resolveGitHubRemote", () => {
     ).resolves.toEqual({ owner: "acme", name: "repo", repo: "acme/repo" });
   });
 
+  it("resolves a dotted SSH alias that maps to github.com", async () => {
+    await expect(
+      resolveGitHubRemote({
+        remoteUrl: "git@mindnexus.github.com:JakubMindNexus/postline.git",
+        resolveSshHostname: createSshHostnameResolver({
+          "mindnexus.github.com": "github.com",
+        }),
+      }),
+    ).resolves.toEqual({
+      owner: "JakubMindNexus",
+      name: "postline",
+      repo: "JakubMindNexus/postline",
+    });
+  });
+
   it("resolves an SSH alias that maps to ssh.github.com", async () => {
     await expect(
       resolveGitHubRemote({
@@ -68,6 +83,26 @@ describe("resolveGitHubRemote", () => {
         },
       }),
     ).resolves.toEqual({ owner: "acme", name: "repo", repo: "acme/repo" });
+
+    expect(resolverCalls).toBe(0);
+  });
+
+  it.each([
+    "git@-oProxyCommand=evil:acme/repo.git",
+    "ssh://git@-oProxyCommand=evil/acme/repo.git",
+    "git@host with space:acme/repo.git",
+  ])("rejects malformed hostnames without invoking the SSH resolver: %s", async (remoteUrl) => {
+    let resolverCalls = 0;
+
+    await expect(
+      resolveGitHubRemote({
+        remoteUrl,
+        resolveSshHostname: async (host) => {
+          resolverCalls += 1;
+          return host;
+        },
+      }),
+    ).resolves.toBeNull();
 
     expect(resolverCalls).toBe(0);
   });

--- a/packages/server/src/utils/github-remote.test.ts
+++ b/packages/server/src/utils/github-remote.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseGitHubRemoteUrl,
+  resolveGitHubRemote,
+  type ResolveSshHostnameInput,
+} from "./github-remote.js";
+
+function createSshHostnameResolver(hostnameByAlias: Record<string, string | null>) {
+  return async ({ host }: ResolveSshHostnameInput): Promise<string | null> => {
+    return hostnameByAlias[host] ?? null;
+  };
+}
+
+describe("parseGitHubRemoteUrl", () => {
+  it.each([
+    ["https://github.com/acme/repo.git", { owner: "acme", name: "repo", repo: "acme/repo" }],
+    ["http://github.com/acme/repo.git", { owner: "acme", name: "repo", repo: "acme/repo" }],
+    ["git@github.com:acme/repo.git", { owner: "acme", name: "repo", repo: "acme/repo" }],
+    ["ssh://git@github.com/acme/repo.git", { owner: "acme", name: "repo", repo: "acme/repo" }],
+    ["ssh://git@ssh.github.com/acme/repo.git", { owner: "acme", name: "repo", repo: "acme/repo" }],
+  ])("parses direct GitHub remotes: %s", (remoteUrl, expected) => {
+    expect(parseGitHubRemoteUrl(remoteUrl)).toEqual(expected);
+  });
+
+  it("returns null for non-GitHub remotes", () => {
+    expect(parseGitHubRemoteUrl("git@gitlab.com:acme/repo.git")).toBeNull();
+  });
+
+  it("returns null for SSH aliases before hostname resolution", () => {
+    expect(parseGitHubRemoteUrl("git@github-work:acme/repo.git")).toBeNull();
+  });
+});
+
+describe("resolveGitHubRemote", () => {
+  it("resolves an SSH alias that maps to github.com", async () => {
+    await expect(
+      resolveGitHubRemote({
+        remoteUrl: "git@github-work:acme/repo.git",
+        resolveSshHostname: createSshHostnameResolver({ "github-work": "github.com" }),
+      }),
+    ).resolves.toEqual({ owner: "acme", name: "repo", repo: "acme/repo" });
+  });
+
+  it("resolves an SSH alias that maps to ssh.github.com", async () => {
+    await expect(
+      resolveGitHubRemote({
+        remoteUrl: "ssh://git@github-work/acme/repo.git",
+        resolveSshHostname: createSshHostnameResolver({ "github-work": "ssh.github.com" }),
+      }),
+    ).resolves.toEqual({ owner: "acme", name: "repo", repo: "acme/repo" });
+  });
+
+  it("returns null when an SSH alias resolves to a non-GitHub host", async () => {
+    await expect(
+      resolveGitHubRemote({
+        remoteUrl: "git@github-work:acme/repo.git",
+        resolveSshHostname: createSshHostnameResolver({ "github-work": "gitlab.com" }),
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("does not use SSH hostname resolution for HTTPS remotes", async () => {
+    let resolverCalls = 0;
+
+    await expect(
+      resolveGitHubRemote({
+        remoteUrl: "https://github.com/acme/repo.git",
+        resolveSshHostname: async () => {
+          resolverCalls += 1;
+          return "github.com";
+        },
+      }),
+    ).resolves.toEqual({ owner: "acme", name: "repo", repo: "acme/repo" });
+
+    expect(resolverCalls).toBe(0);
+  });
+});

--- a/packages/server/src/utils/github-remote.test.ts
+++ b/packages/server/src/utils/github-remote.test.ts
@@ -1,13 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  parseGitHubRemoteUrl,
-  resolveGitHubRemote,
-  type ResolveSshHostnameInput,
-} from "./github-remote.js";
+import { parseGitHubRemoteUrl, resolveGitHubRemote } from "./github-remote.js";
 
 function createSshHostnameResolver(hostnameByAlias: Record<string, string | null>) {
-  return async ({ host }: ResolveSshHostnameInput): Promise<string | null> => {
+  return async (host: string): Promise<string | null> => {
     return hostnameByAlias[host] ?? null;
   };
 }

--- a/packages/server/src/utils/github-remote.ts
+++ b/packages/server/src/utils/github-remote.ts
@@ -1,0 +1,225 @@
+import { findExecutable } from "./executable.js";
+import { execCommand } from "./spawn.js";
+
+const GITHUB_HOSTS = new Set(["github.com", "ssh.github.com"]);
+const SSH_ENV: NodeJS.ProcessEnv = {
+  ...process.env,
+  GIT_TERMINAL_PROMPT: "0",
+};
+
+let sshExecutableLookup: Promise<string | null> | null = null;
+const sshHostnameResolutionCache = new Map<string, Promise<string | null>>();
+
+interface GitRemoteLocation {
+  transport: "scp" | "ssh" | "http" | "https";
+  host: string;
+  path: string;
+}
+
+export interface GitHubRemoteIdentity {
+  owner: string;
+  name: string;
+  repo: string;
+}
+
+export interface ResolveGitHubRemoteInput {
+  remoteUrl: string;
+  resolveSshHostname?: SshHostnameResolver;
+}
+
+export interface ResolveSshHostnameInput {
+  host: string;
+}
+
+export type SshHostnameResolver = (input: ResolveSshHostnameInput) => Promise<string | null>;
+
+export function parseGitHubRemoteUrl(remoteUrl: string): GitHubRemoteIdentity | null {
+  const location = parseGitRemoteLocation(remoteUrl);
+  if (!location) {
+    return null;
+  }
+  if (!isGitHubHost(location.host)) {
+    return null;
+  }
+  return parseGitHubRemoteIdentity(location.path);
+}
+
+export async function resolveGitHubRemote(
+  input: ResolveGitHubRemoteInput,
+): Promise<GitHubRemoteIdentity | null> {
+  const location = parseGitRemoteLocation(input.remoteUrl);
+  if (!location) {
+    return null;
+  }
+  if (isGitHubHost(location.host)) {
+    return parseGitHubRemoteIdentity(location.path);
+  }
+  if (!isSshTransport(location.transport)) {
+    return null;
+  }
+
+  const resolveHostname = input.resolveSshHostname ?? resolveSshHostname;
+  const resolvedHost = await resolveHostname({ host: location.host });
+  if (!resolvedHost || !isGitHubHost(resolvedHost)) {
+    return null;
+  }
+
+  return parseGitHubRemoteIdentity(location.path);
+}
+
+export async function resolveSshHostname(input: ResolveSshHostnameInput): Promise<string | null> {
+  const host = normalizeHost(input.host);
+  if (!host) {
+    return null;
+  }
+
+  const cached = sshHostnameResolutionCache.get(host);
+  if (cached) {
+    return cached;
+  }
+
+  const resolution = loadResolvedSshHostname({ host }).catch(() => null);
+  sshHostnameResolutionCache.set(host, resolution);
+  return resolution;
+}
+
+async function loadResolvedSshHostname(input: ResolveSshHostnameInput): Promise<string | null> {
+  const sshPath = await resolveSshExecutablePath();
+  if (!sshPath) {
+    return null;
+  }
+
+  try {
+    const { stdout } = await execCommand(sshPath, ["-G", input.host], {
+      env: SSH_ENV,
+      maxBuffer: 1024 * 1024,
+    });
+    return parseResolvedSshHostname(stdout);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveSshExecutablePath(): Promise<string | null> {
+  sshExecutableLookup ??= findExecutable("ssh");
+  return sshExecutableLookup;
+}
+
+function parseResolvedSshHostname(stdout: string): string | null {
+  for (const line of stdout.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const [key, ...valueParts] = trimmed.split(/\s+/u);
+    if (key?.toLowerCase() !== "hostname") {
+      continue;
+    }
+
+    const value = normalizeHost(valueParts.join(" "));
+    if (value) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function parseGitRemoteLocation(remoteUrl: string): GitRemoteLocation | null {
+  const trimmed = remoteUrl.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const scpLike = trimmed.match(/^[^@]+@([^:]+):(.+)$/u);
+  if (scpLike) {
+    const host = normalizeHost(scpLike[1] ?? "");
+    const path = normalizeRemotePath(scpLike[2] ?? "");
+    if (!host || !path) {
+      return null;
+    }
+    return { transport: "scp", host, path };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  const protocol = parsed.protocol.toLowerCase();
+  if (protocol !== "https:" && protocol !== "http:" && protocol !== "ssh:") {
+    return null;
+  }
+
+  const host = normalizeHost(parsed.hostname);
+  const decodedPath = decodeRemotePath(parsed.pathname);
+  const path = normalizeRemotePath(decodedPath);
+  if (!host || !path) {
+    return null;
+  }
+
+  return {
+    transport: protocol === "ssh:" ? "ssh" : protocol === "http:" ? "http" : "https",
+    host,
+    path,
+  };
+}
+
+function parseGitHubRemoteIdentity(path: string): GitHubRemoteIdentity | null {
+  const segments = path.split("/").filter((segment) => segment.length > 0);
+  if (segments.length !== 2) {
+    return null;
+  }
+
+  const [owner, name] = segments;
+  if (!owner || !name) {
+    return null;
+  }
+
+  return {
+    owner,
+    name,
+    repo: `${owner}/${name}`,
+  };
+}
+
+function decodeRemotePath(path: string): string | null {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeRemotePath(path: string | null): string | null {
+  if (!path) {
+    return null;
+  }
+
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  let normalized = trimmed.replace(/^\/+|\/+$/gu, "");
+  if (normalized.endsWith(".git")) {
+    normalized = normalized.slice(0, -".git".length);
+  }
+
+  return normalized || null;
+}
+
+function normalizeHost(host: string): string {
+  return host.trim().replace(/\.+$/u, "").toLowerCase();
+}
+
+function isGitHubHost(host: string): boolean {
+  return GITHUB_HOSTS.has(normalizeHost(host));
+}
+
+function isSshTransport(transport: GitRemoteLocation["transport"]): boolean {
+  return transport === "scp" || transport === "ssh";
+}

--- a/packages/server/src/utils/github-remote.ts
+++ b/packages/server/src/utils/github-remote.ts
@@ -2,10 +2,9 @@ import { findExecutable } from "./executable.js";
 import { execCommand } from "./spawn.js";
 
 const GITHUB_HOSTS = new Set(["github.com", "ssh.github.com"]);
-const SSH_ENV: NodeJS.ProcessEnv = {
-  ...process.env,
-  GIT_TERMINAL_PROMPT: "0",
-};
+function getSshEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, GIT_TERMINAL_PROMPT: "0" };
+}
 
 let sshExecutableLookup: Promise<string | null> | null = null;
 const sshHostnameResolutionCache = new Map<string, Promise<string | null>>();
@@ -91,7 +90,7 @@ async function loadResolvedSshHostname(input: ResolveSshHostnameInput): Promise<
 
   try {
     const { stdout } = await execCommand(sshPath, ["-G", input.host], {
-      env: SSH_ENV,
+      env: getSshEnv(),
       maxBuffer: 1024 * 1024,
     });
     return parseResolvedSshHostname(stdout);

--- a/packages/server/src/utils/github-remote.ts
+++ b/packages/server/src/utils/github-remote.ts
@@ -3,6 +3,12 @@ import { execCommand } from "./spawn.js";
 
 const GITHUB_HOSTS = new Set(["github.com", "ssh.github.com"]);
 
+const TRANSPORT_BY_PROTOCOL: Record<string, GitRemoteLocation["transport"]> = {
+  "https:": "https",
+  "http:": "http",
+  "ssh:": "ssh",
+};
+
 let sshExecutableLookup: Promise<string | null> | null = null;
 const sshHostnameResolutionCache = new Map<string, Promise<string | null>>();
 
@@ -89,7 +95,7 @@ function parseGitRemoteLocation(remoteUrl: string): GitRemoteLocation | null {
   if (scpLike) {
     const host = normalizeHost(scpLike[1] ?? "");
     const path = normalizeRemotePath(scpLike[2] ?? "");
-    if (!host || !path) return null;
+    if (!isValidRemoteHost(host) || !path) return null;
     return { transport: "scp", host, path };
   }
 
@@ -100,8 +106,8 @@ function parseGitRemoteLocation(remoteUrl: string): GitRemoteLocation | null {
     return null;
   }
 
-  const protocol = parsed.protocol.toLowerCase();
-  if (protocol !== "https:" && protocol !== "http:" && protocol !== "ssh:") return null;
+  const transport = TRANSPORT_BY_PROTOCOL[parsed.protocol.toLowerCase()];
+  if (!transport) return null;
 
   const host = normalizeHost(parsed.hostname);
   let path: string;
@@ -111,13 +117,9 @@ function parseGitRemoteLocation(remoteUrl: string): GitRemoteLocation | null {
     return null;
   }
   const normalizedPath = normalizeRemotePath(path);
-  if (!host || !normalizedPath) return null;
+  if (!isValidRemoteHost(host) || !normalizedPath) return null;
 
-  return {
-    transport: protocol === "ssh:" ? "ssh" : protocol === "http:" ? "http" : "https",
-    host,
-    path: normalizedPath,
-  };
+  return { transport, host, path: normalizedPath };
 }
 
 function parseGitHubRemoteIdentity(path: string): GitHubRemoteIdentity | null {
@@ -136,4 +138,8 @@ function normalizeRemotePath(path: string): string | null {
 
 function normalizeHost(host: string): string {
   return host.trim().replace(/\.+$/u, "").toLowerCase();
+}
+
+function isValidRemoteHost(host: string): boolean {
+  return /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/u.test(host);
 }

--- a/packages/server/src/utils/github-remote.ts
+++ b/packages/server/src/utils/github-remote.ts
@@ -2,9 +2,6 @@ import { findExecutable } from "./executable.js";
 import { execCommand } from "./spawn.js";
 
 const GITHUB_HOSTS = new Set(["github.com", "ssh.github.com"]);
-function getSshEnv(): NodeJS.ProcessEnv {
-  return { ...process.env, GIT_TERMINAL_PROMPT: "0" };
-}
 
 let sshExecutableLookup: Promise<string | null> | null = null;
 const sshHostnameResolutionCache = new Map<string, Promise<string | null>>();
@@ -21,123 +18,78 @@ export interface GitHubRemoteIdentity {
   repo: string;
 }
 
-export interface ResolveGitHubRemoteInput {
-  remoteUrl: string;
-  resolveSshHostname?: SshHostnameResolver;
-}
-
-export interface ResolveSshHostnameInput {
-  host: string;
-}
-
-export type SshHostnameResolver = (input: ResolveSshHostnameInput) => Promise<string | null>;
+export type SshHostnameResolver = (host: string) => Promise<string | null>;
 
 export function parseGitHubRemoteUrl(remoteUrl: string): GitHubRemoteIdentity | null {
   const location = parseGitRemoteLocation(remoteUrl);
-  if (!location) {
-    return null;
-  }
-  if (!isGitHubHost(location.host)) {
-    return null;
-  }
+  if (!location || !GITHUB_HOSTS.has(location.host)) return null;
   return parseGitHubRemoteIdentity(location.path);
 }
 
-export async function resolveGitHubRemote(
-  input: ResolveGitHubRemoteInput,
-): Promise<GitHubRemoteIdentity | null> {
+export async function resolveGitHubRemote(input: {
+  remoteUrl: string;
+  resolveSshHostname?: SshHostnameResolver;
+}): Promise<GitHubRemoteIdentity | null> {
   const location = parseGitRemoteLocation(input.remoteUrl);
-  if (!location) {
-    return null;
-  }
-  if (isGitHubHost(location.host)) {
-    return parseGitHubRemoteIdentity(location.path);
-  }
-  if (!isSshTransport(location.transport)) {
-    return null;
-  }
+  if (!location) return null;
+  if (GITHUB_HOSTS.has(location.host)) return parseGitHubRemoteIdentity(location.path);
+  if (location.transport !== "scp" && location.transport !== "ssh") return null;
 
-  const resolveHostname = input.resolveSshHostname ?? resolveSshHostname;
-  const resolvedHost = await resolveHostname({ host: location.host });
-  if (!resolvedHost || !isGitHubHost(resolvedHost)) {
-    return null;
-  }
-
+  const resolve = input.resolveSshHostname ?? resolveSshHostname;
+  const resolvedHost = await resolve(location.host);
+  if (!resolvedHost || !GITHUB_HOSTS.has(resolvedHost)) return null;
   return parseGitHubRemoteIdentity(location.path);
 }
 
-export async function resolveSshHostname(input: ResolveSshHostnameInput): Promise<string | null> {
-  const host = normalizeHost(input.host);
-  if (!host) {
-    return null;
-  }
+export async function resolveSshHostname(host: string): Promise<string | null> {
+  const normalized = normalizeHost(host);
+  if (!normalized) return null;
 
-  const cached = sshHostnameResolutionCache.get(host);
-  if (cached) {
-    return cached;
-  }
+  const cached = sshHostnameResolutionCache.get(normalized);
+  if (cached) return cached;
 
-  const resolution = loadResolvedSshHostname({ host }).catch(() => null);
-  sshHostnameResolutionCache.set(host, resolution);
+  const resolution = runSshHostnameLookup(normalized);
+  sshHostnameResolutionCache.set(normalized, resolution);
   return resolution;
 }
 
-async function loadResolvedSshHostname(input: ResolveSshHostnameInput): Promise<string | null> {
-  const sshPath = await resolveSshExecutablePath();
-  if (!sshPath) {
-    return null;
-  }
+async function runSshHostnameLookup(host: string): Promise<string | null> {
+  sshExecutableLookup ??= findExecutable("ssh");
+  const sshPath = await sshExecutableLookup;
+  if (!sshPath) return null;
 
   try {
-    const { stdout } = await execCommand(sshPath, ["-G", input.host], {
-      env: getSshEnv(),
+    const { stdout } = await execCommand(sshPath, ["-G", host], {
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
       maxBuffer: 1024 * 1024,
     });
-    return parseResolvedSshHostname(stdout);
+    return parseSshHostname(stdout);
   } catch {
     return null;
   }
 }
 
-async function resolveSshExecutablePath(): Promise<string | null> {
-  sshExecutableLookup ??= findExecutable("ssh");
-  return sshExecutableLookup;
-}
-
-function parseResolvedSshHostname(stdout: string): string | null {
+function parseSshHostname(stdout: string): string | null {
   for (const line of stdout.split(/\r?\n/u)) {
     const trimmed = line.trim();
-    if (!trimmed) {
-      continue;
-    }
-
-    const [key, ...valueParts] = trimmed.split(/\s+/u);
-    if (key?.toLowerCase() !== "hostname") {
-      continue;
-    }
-
-    const value = normalizeHost(valueParts.join(" "));
-    if (value) {
-      return value;
-    }
+    if (!trimmed) continue;
+    const [key, value] = trimmed.split(/\s+/u);
+    if (key?.toLowerCase() !== "hostname") continue;
+    const normalized = normalizeHost(value ?? "");
+    if (normalized) return normalized;
   }
-
   return null;
 }
 
 function parseGitRemoteLocation(remoteUrl: string): GitRemoteLocation | null {
   const trimmed = remoteUrl.trim();
-  if (!trimmed) {
-    return null;
-  }
+  if (!trimmed) return null;
 
   const scpLike = trimmed.match(/^[^@]+@([^:]+):(.+)$/u);
   if (scpLike) {
     const host = normalizeHost(scpLike[1] ?? "");
     const path = normalizeRemotePath(scpLike[2] ?? "");
-    if (!host || !path) {
-      return null;
-    }
+    if (!host || !path) return null;
     return { transport: "scp", host, path };
   }
 
@@ -149,76 +101,39 @@ function parseGitRemoteLocation(remoteUrl: string): GitRemoteLocation | null {
   }
 
   const protocol = parsed.protocol.toLowerCase();
-  if (protocol !== "https:" && protocol !== "http:" && protocol !== "ssh:") {
-    return null;
-  }
+  if (protocol !== "https:" && protocol !== "http:" && protocol !== "ssh:") return null;
 
   const host = normalizeHost(parsed.hostname);
-  const decodedPath = decodeRemotePath(parsed.pathname);
-  const path = normalizeRemotePath(decodedPath);
-  if (!host || !path) {
+  let path: string;
+  try {
+    path = decodeURIComponent(parsed.pathname);
+  } catch {
     return null;
   }
+  const normalizedPath = normalizeRemotePath(path);
+  if (!host || !normalizedPath) return null;
 
   return {
     transport: protocol === "ssh:" ? "ssh" : protocol === "http:" ? "http" : "https",
     host,
-    path,
+    path: normalizedPath,
   };
 }
 
 function parseGitHubRemoteIdentity(path: string): GitHubRemoteIdentity | null {
-  const segments = path.split("/").filter((segment) => segment.length > 0);
-  if (segments.length !== 2) {
-    return null;
-  }
-
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length !== 2) return null;
   const [owner, name] = segments;
-  if (!owner || !name) {
-    return null;
-  }
-
-  return {
-    owner,
-    name,
-    repo: `${owner}/${name}`,
-  };
+  if (!owner || !name) return null;
+  return { owner, name, repo: `${owner}/${name}` };
 }
 
-function decodeRemotePath(path: string): string | null {
-  try {
-    return decodeURIComponent(path);
-  } catch {
-    return null;
-  }
-}
-
-function normalizeRemotePath(path: string | null): string | null {
-  if (!path) {
-    return null;
-  }
-
-  const trimmed = path.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  let normalized = trimmed.replace(/^\/+|\/+$/gu, "");
-  if (normalized.endsWith(".git")) {
-    normalized = normalized.slice(0, -".git".length);
-  }
-
+function normalizeRemotePath(path: string): string | null {
+  let normalized = path.trim().replace(/^\/+|\/+$/gu, "");
+  if (normalized.endsWith(".git")) normalized = normalized.slice(0, -4);
   return normalized || null;
 }
 
 function normalizeHost(host: string): string {
   return host.trim().replace(/\.+$/u, "").toLowerCase();
-}
-
-function isGitHubHost(host: string): boolean {
-  return GITHUB_HOSTS.has(normalizeHost(host));
-}
-
-function isSshTransport(transport: GitRemoteLocation["transport"]): boolean {
-  return transport === "scp" || transport === "ssh";
 }


### PR DESCRIPTION
## Summary
- support GitHub SSH host aliases by resolving SSH config hostnames locally via `ssh -G`
- centralize GitHub remote parsing/resolution in a new server utility and reuse it across PR status + PR creation paths
- add focused tests for direct remotes, SSH aliases, and workspace GitHub detection

## Problem
Paseo currently only treats remotes that literally look like `github.com` as GitHub remotes.

That breaks setups like:

```bash
git@github-work:owner/repo.git
```

where `github-work` is an SSH alias that resolves to `github.com` via `~/.ssh/config`.

In that setup, Git and `gh` work correctly, but Paseo reports GitHub as disconnected and disables `Create PR`. Even if the UI were bypassed, PR creation would still fail because the server could not derive the GitHub repo from the aliased remote.

## Solution
This change introduces a centralized GitHub remote resolver that:

1. parses standard GitHub remotes directly
2. for SSH remotes with non-literal hosts, resolves the effective SSH hostname with `ssh -G`
3. treats aliases that resolve to `github.com` or `ssh.github.com` as GitHub remotes

That resolver is now used by:
- workspace GitHub feature detection / PR status loading
- GitHub repo resolution for PR creation
- workspace Git metadata's direct GitHub parsing path

This keeps the fast path local for standard remotes and adds local-only SSH alias resolution for alias-based setups, without introducing a `gh repo view` network/API dependency.

## Testing
- `npm exec --workspace=@getpaseo/server -- vitest run src/utils/github-remote.test.ts src/server/workspace-git-service.test.ts src/server/workspace-git-metadata.test.ts --bail=1`
- `npm run typecheck --workspace=@getpaseo/server`

## Notes
I also manually verified the real-world alias case with:

```bash
ssh -G mindnexus.github.com | rg '^hostname '
```

which resolves to `github.com`, and the new resolver correctly maps:

```bash
git@mindnexus.github.com:JakubMindNexus/postline.git
```

to `JakubMindNexus/postline`.
