### PR TITLE
docs: add star history to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ npm run build:daemon
 npm run typecheck
 ```
 
+<p align="center">
+  <a href="https://star-history.com/#getpaseo/paseo&Date">
+    <img src="https://api.star-history.com/svg?repos=getpaseo/paseo&type=Date" alt="Star history chart for getpaseo/paseo" width="100%">
+  </a>
+</p>
+
 ## License
 
 AGPL-3.0


### PR DESCRIPTION
## Summary
- add a star history chart to the root README

## Testing
- npm run format
- npm run typecheck *(fails due to existing unrelated workspace type errors in packages/server, packages/app, and packages/cli)*