### PR TITLE
[codex] Fix terminal tab rendering

### DIFF
--- a/packages/app/metro.config.cjs
+++ b/packages/app/metro.config.cjs
@@ -66,8 +66,37 @@ function resolveWithCustomWebOverlay(context, moduleName, platform) {
   return defaultResolveRequest(context, moduleName, platform);
 }
 
+function resolveExpoDomGeneratedSourceImport(context, moduleName) {
+  const origin = context.originModulePath;
+  if (
+    !origin ||
+    !origin.endsWith(`${path.sep}node_modules${path.sep}expo${path.sep}dom${path.sep}entry.js`) ||
+    !moduleName.startsWith(".")
+  ) {
+    return null;
+  }
+
+  const candidatePath = path.resolve(path.dirname(origin), moduleName);
+  if (
+    fs.existsSync(candidatePath) &&
+    candidatePath.includes(`${path.sep}packages${path.sep}app${path.sep}src${path.sep}`)
+  ) {
+    return {
+      type: "sourceFile",
+      filePath: candidatePath,
+    };
+  }
+
+  return null;
+}
+
 config.resolver.resolveRequest = (context, moduleName, platform) => {
   const origin = context.originModulePath;
+  const expoDomGeneratedSourceImport = resolveExpoDomGeneratedSourceImport(context, moduleName);
+  if (expoDomGeneratedSourceImport) {
+    return expoDomGeneratedSourceImport;
+  }
+
   if (
     origin &&
     (origin.startsWith(serverSrcRoot) || origin.startsWith(relaySrcRoot)) &&

--- a/packages/app/src/panels/terminal-panel.tsx
+++ b/packages/app/src/panels/terminal-panel.tsx
@@ -7,6 +7,7 @@ import type { ListTerminalsResponse } from "@server/shared/messages";
 import { TerminalPane } from "@/components/terminal-pane";
 import { usePaneContext, usePaneFocus } from "@/panels/pane-context";
 import type { PanelDescriptor, PanelRegistration } from "@/panels/panel-registry";
+import { queryClient } from "@/query/query-client";
 import { usePanelStore } from "@/stores/panel-store";
 import { useSessionStore } from "@/stores/session-store";
 import { useWorkspaceExecutionAuthority } from "@/stores/session-store-hooks";
@@ -30,21 +31,24 @@ function useTerminalPanelDescriptor(
   const workspaceDirectory = workspaceAuthority.ok
     ? workspaceAuthority.authority.workspaceDirectory
     : null;
-  const terminalsQuery = useQuery({
-    queryKey: ["terminals", context.serverId, workspaceDirectory] as const,
-    enabled: Boolean(client && workspaceDirectory),
-    queryFn: async (): Promise<ListTerminalsPayload> => {
-      if (!client || !workspaceDirectory) {
-        throw new Error(
-          workspaceAuthority.ok
-            ? "Workspace execution directory not found"
-            : workspaceAuthority.message,
-        );
-      }
-      return client.listTerminals(workspaceDirectory);
+  const terminalsQuery = useQuery(
+    {
+      queryKey: ["terminals", context.serverId, workspaceDirectory] as const,
+      enabled: Boolean(client && workspaceDirectory),
+      queryFn: async (): Promise<ListTerminalsPayload> => {
+        if (!client || !workspaceDirectory) {
+          throw new Error(
+            workspaceAuthority.ok
+              ? "Workspace execution directory not found"
+              : workspaceAuthority.message,
+          );
+        }
+        return client.listTerminals(workspaceDirectory);
+      },
+      staleTime: 5_000,
     },
-    staleTime: 5_000,
-  });
+    queryClient,
+  );
   const terminal =
     terminalsQuery.data?.terminals.find((entry) => entry.id === target.terminalId) ?? null;
 


### PR DESCRIPTION
## Summary

- Use the app QueryClient explicitly when resolving terminal tab descriptors so mobile tab option rendering does not require a QueryClientProvider at the render location.
- Add a Metro resolver path for Expo DOM generated source imports so DOM component bundling can resolve generated imports from the Expo DOM entry module, including sibling worktree paths.

## Why

Terminal tabs could crash in the mobile tab switcher because the terminal descriptor called React Query from a render path that can be mounted outside the React Query provider. Separately, Expo DOM bundling could fail resolving the generated import for terminal-emulator.tsx when the live app was running from a sibling worktree.

## Validation

- npm run format
- npm run typecheck
- Verified the Metro resolver resolves the generated Expo DOM import path for both /Users/moboudra/dev/paseo and /Users/moboudra/dev/paseo-dev.
