### PR TITLE
Add configurable helper providers in settings

### DIFF
--- a/packages/app/src/hooks/use-settings.test.ts
+++ b/packages/app/src/hooks/use-settings.test.ts
@@ -69,6 +69,7 @@ describe("use-settings", () => {
       manageBuiltInDaemon: false,
       sendBehavior: "interrupt",
       releaseChannel: "stable",
+      helperProviders: [],
     });
     expect(asyncStorageMock.setItem).not.toHaveBeenCalled();
   });
@@ -87,5 +88,27 @@ describe("use-settings", () => {
     const result = await mod.loadSettingsFromStorage();
 
     expect(result.releaseChannel).toBe("beta");
+  });
+
+  it("loads persisted helper provider preferences", async () => {
+    asyncStorageMock.getItem.mockImplementation(async (key: string) => {
+      if (key === "@paseo:app-settings") {
+        return JSON.stringify({
+          helperProviders: [
+            { provider: "codex", model: "gpt-5.4-mini" },
+            { provider: "claude", model: null },
+          ],
+        });
+      }
+      return null;
+    });
+
+    const mod = await import("./use-settings");
+    const result = await mod.loadSettingsFromStorage();
+
+    expect(result.helperProviders).toEqual([
+      { provider: "codex", model: "gpt-5.4-mini" },
+      { provider: "claude", model: null },
+    ]);
   });
 });

--- a/packages/app/src/hooks/use-settings.ts
+++ b/packages/app/src/hooks/use-settings.ts
@@ -4,9 +4,13 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const APP_SETTINGS_KEY = "@paseo:app-settings";
 const LEGACY_SETTINGS_KEY = "@paseo:settings";
-const APP_SETTINGS_QUERY_KEY = ["app-settings"];
+export const APP_SETTINGS_QUERY_KEY = ["app-settings"];
 
 import { THEME_TO_UNISTYLES, type ThemeName } from "@/styles/theme";
+import {
+  normalizeHelperProviderPreferences,
+  type HelperProviderPreference,
+} from "@/utils/helper-provider-preferences";
 
 export type SendBehavior = "interrupt" | "queue";
 export type ReleaseChannel = "stable" | "beta";
@@ -19,6 +23,7 @@ export interface AppSettings {
   manageBuiltInDaemon: boolean;
   sendBehavior: SendBehavior;
   releaseChannel: ReleaseChannel;
+  helperProviders: HelperProviderPreference[];
 }
 
 export const DEFAULT_APP_SETTINGS: AppSettings = {
@@ -26,6 +31,7 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   manageBuiltInDaemon: true,
   sendBehavior: "interrupt",
   releaseChannel: "stable",
+  helperProviders: [],
 };
 
 export interface UseAppSettingsReturn {
@@ -92,6 +98,7 @@ export async function loadSettingsFromStorage(): Promise<AppSettings> {
       if (parsed.releaseChannel && !VALID_RELEASE_CHANNELS.has(parsed.releaseChannel)) {
         parsed.releaseChannel = DEFAULT_APP_SETTINGS.releaseChannel;
       }
+      parsed.helperProviders = normalizeHelperProviderPreferences(parsed.helperProviders);
       return { ...DEFAULT_APP_SETTINGS, ...parsed };
     }
 

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -13,6 +13,8 @@ import {
   Monitor,
   Blocks,
   ChevronDown,
+  ArrowUp,
+  ArrowDown,
   Settings,
   Server,
   Keyboard,
@@ -29,6 +31,7 @@ import { HeaderIconBadge } from "@/components/headers/header-icon-badge";
 import { SettingsSection } from "@/screens/settings/settings-section";
 import { useAppSettings, type AppSettings, type SendBehavior } from "@/hooks/use-settings";
 import { THEME_SWATCHES } from "@/styles/theme";
+import { DraggableList, type DraggableRenderItemInfo } from "@/components/draggable-list";
 import {
   getHostRuntimeStore,
   isHostRuntimeConnected,
@@ -79,7 +82,10 @@ import { ProviderDiagnosticSheet } from "@/components/provider-diagnostic-sheet"
 import { SpinningRefreshIcon } from "@/components/spinning-refresh-icon";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { buildProviderDefinitions } from "@/utils/provider-definitions";
-import { resolveHelperProviderPreferences } from "@/utils/helper-provider-preferences";
+import {
+  resolveHelperProviderPreferences,
+  type HelperProviderPreference,
+} from "@/utils/helper-provider-preferences";
 
 // ---------------------------------------------------------------------------
 // View model
@@ -300,6 +306,106 @@ function ProvidersSection({ routeServerId }: ProvidersSectionProps) {
     [helperProviders, updateHelperProviders],
   );
 
+  const renderHelperProvider = useCallback(
+    ({
+      item: helper,
+      index,
+      drag,
+      dragHandleProps,
+    }: DraggableRenderItemInfo<HelperProviderPreference>) => {
+      const entry = readyEntries.find((candidate) => candidate.provider === helper.provider);
+      const ProviderIcon = getProviderIcon(helper.provider);
+      const selectedModel =
+        entry?.models?.find((candidate) => candidate.id === helper.model) ?? null;
+      const helperModelLabel = selectedModel?.label ?? "Default helper model";
+
+      return (
+        <View style={[styles.audioRow, index > 0 ? styles.audioRowBorder : null]}>
+          <View style={styles.audioRowContent}>
+            <View style={{ flexDirection: "row", alignItems: "center", gap: theme.spacing[2] }}>
+              <Pressable
+                {...(dragHandleProps?.attributes as object)}
+                {...(dragHandleProps?.listeners as object)}
+                ref={dragHandleProps?.setActivatorNodeRef as never}
+                onLongPress={drag}
+                delayLongPress={150}
+                style={({ pressed }) => [
+                  styles.helperDragHandle,
+                  pressed ? styles.helperMoveButtonPressed : null,
+                ]}
+              >
+                <Text style={styles.helperDragHandleText}>⋮⋮</Text>
+              </Pressable>
+              <ProviderIcon size={theme.iconSize.sm} color={theme.colors.foreground} />
+              <Text style={styles.audioRowTitle}>{entry?.label ?? helper.provider}</Text>
+            </View>
+            <Text style={styles.audioRowSubtitle}>Model: {helperModelLabel}</Text>
+          </View>
+
+          <View style={styles.helperControls}>
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                style={({ pressed }) => [
+                  styles.helperModelTrigger,
+                  pressed && { opacity: 0.85 },
+                ]}
+              >
+                <Text style={styles.helperModelTriggerText}>{helperModelLabel}</Text>
+                <ChevronDown size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="bottom" align="end" width={260}>
+                <DropdownMenuItem
+                  selected={!helper.model}
+                  onSelect={() => setHelperProviderModel(helper.provider, null)}
+                >
+                  Default helper model
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                {(entry?.models ?? []).map((model) => (
+                  <DropdownMenuItem
+                    key={model.id}
+                    selected={helper.model === model.id}
+                    onSelect={() => setHelperProviderModel(helper.provider, model.id)}
+                  >
+                    {model.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <View style={styles.helperMoveButtons}>
+              <Pressable
+                disabled={index === 0}
+                onPress={() => moveHelperProvider(index, -1)}
+                style={({ pressed }) => [
+                  styles.helperMoveButton,
+                  index === 0 ? styles.helperMoveButtonDisabled : null,
+                  pressed && index !== 0 ? styles.helperMoveButtonPressed : null,
+                ]}
+              >
+                <ArrowUp size={theme.iconSize.sm} color={theme.colors.foreground} />
+              </Pressable>
+              <Pressable
+                disabled={index === helperProviders.length - 1}
+                onPress={() => moveHelperProvider(index, 1)}
+                style={({ pressed }) => [
+                  styles.helperMoveButton,
+                  index === helperProviders.length - 1 ? styles.helperMoveButtonDisabled : null,
+                  pressed && index !== helperProviders.length - 1
+                    ? styles.helperMoveButtonPressed
+                    : null,
+                ]}
+              >
+                <ArrowDown size={theme.iconSize.sm} color={theme.colors.foreground} />
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      );
+    },
+    [helperProviders.length, moveHelperProvider, readyEntries, setHelperProviderModel, theme],
+  );
+
   return (
     <>
       <SettingsSection title="Providers">
@@ -416,96 +522,17 @@ function ProvidersSection({ routeServerId }: ProvidersSectionProps) {
                   </View>
                 </View>
               ) : (
-                helperProviders.map((helper, index) => {
-                  const entry = readyEntries.find((candidate) => candidate.provider === helper.provider);
-                  const ProviderIcon = getProviderIcon(helper.provider);
-                  const selectedModel =
-                    entry?.models?.find((candidate) => candidate.id === helper.model) ?? null;
-                  const helperModelLabel = selectedModel?.label ?? "Default helper model";
-
-                  return (
-                    <View
-                      key={helper.provider}
-                      style={[styles.audioRow, index > 0 ? styles.audioRowBorder : null]}
-                    >
-                      <View style={styles.audioRowContent}>
-                        <View
-                          style={{ flexDirection: "row", alignItems: "center", gap: theme.spacing[2] }}
-                        >
-                          <ProviderIcon size={theme.iconSize.sm} color={theme.colors.foreground} />
-                          <Text style={styles.audioRowTitle}>
-                            {entry?.label ?? helper.provider}
-                          </Text>
-                        </View>
-                        <Text style={styles.audioRowSubtitle}>Model: {helperModelLabel}</Text>
-                      </View>
-
-                      <View style={styles.helperControls}>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger
-                            style={({ pressed }) => [
-                              styles.helperModelTrigger,
-                              pressed && { opacity: 0.85 },
-                            ]}
-                          >
-                            <Text style={styles.helperModelTriggerText}>{helperModelLabel}</Text>
-                            <ChevronDown
-                              size={theme.iconSize.sm}
-                              color={theme.colors.foregroundMuted}
-                            />
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent side="bottom" align="end" width={260}>
-                            <DropdownMenuItem
-                              selected={!helper.model}
-                              onSelect={() => setHelperProviderModel(helper.provider, null)}
-                            >
-                              Default helper model
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
-                            {(entry?.models ?? []).map((model) => (
-                              <DropdownMenuItem
-                                key={model.id}
-                                selected={helper.model === model.id}
-                                onSelect={() => setHelperProviderModel(helper.provider, model.id)}
-                              >
-                                {model.label}
-                              </DropdownMenuItem>
-                            ))}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-
-                        <View style={styles.helperMoveButtons}>
-                          <Pressable
-                            disabled={index === 0}
-                            onPress={() => moveHelperProvider(index, -1)}
-                            style={({ pressed }) => [
-                              styles.helperMoveButton,
-                              index === 0 ? styles.helperMoveButtonDisabled : null,
-                              pressed && index !== 0 ? styles.helperMoveButtonPressed : null,
-                            ]}
-                          >
-                            <Text style={styles.helperMoveButtonText}>Up</Text>
-                          </Pressable>
-                          <Pressable
-                            disabled={index === helperProviders.length - 1}
-                            onPress={() => moveHelperProvider(index, 1)}
-                            style={({ pressed }) => [
-                              styles.helperMoveButton,
-                              index === helperProviders.length - 1
-                                ? styles.helperMoveButtonDisabled
-                                : null,
-                              pressed && index !== helperProviders.length - 1
-                                ? styles.helperMoveButtonPressed
-                                : null,
-                            ]}
-                          >
-                            <Text style={styles.helperMoveButtonText}>Dn</Text>
-                          </Pressable>
-                        </View>
-                      </View>
-                    </View>
-                  );
-                })
+                <DraggableList
+                  data={helperProviders}
+                  keyExtractor={(item) => item.provider}
+                  renderItem={renderHelperProvider}
+                  onDragEnd={(next) => {
+                    void updateHelperProviders(next);
+                  }}
+                  scrollEnabled={false}
+                  useDragHandle
+                  containerStyle={styles.helperListContainer}
+                />
               )}
             </View>
           </>
@@ -1328,6 +1355,25 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     gap: theme.spacing[2],
   },
+  helperListContainer: {
+    width: "100%",
+  },
+  helperDragHandle: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: theme.borderRadius.md,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface1,
+  },
+  helperDragHandleText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    lineHeight: 14,
+    letterSpacing: -1,
+  },
   helperModelTrigger: {
     flexDirection: "row",
     alignItems: "center",
@@ -1364,11 +1410,6 @@ const styles = StyleSheet.create((theme) => ({
   },
   helperMoveButtonPressed: {
     backgroundColor: theme.colors.surface2,
-  },
-  helperMoveButtonText: {
-    color: theme.colors.foreground,
-    fontSize: theme.fontSize.base,
-    lineHeight: 16,
   },
   audioCard: {
     overflow: "hidden",

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -11,6 +11,7 @@ import {
   Sun,
   Moon,
   Monitor,
+  Blocks,
   ChevronDown,
   Settings,
   Server,
@@ -28,7 +29,12 @@ import { HeaderIconBadge } from "@/components/headers/header-icon-badge";
 import { SettingsSection } from "@/screens/settings/settings-section";
 import { useAppSettings, type AppSettings, type SendBehavior } from "@/hooks/use-settings";
 import { THEME_SWATCHES } from "@/styles/theme";
-import { getHostRuntimeStore, isHostRuntimeConnected, useHosts } from "@/runtime/host-runtime";
+import {
+  getHostRuntimeStore,
+  isHostRuntimeConnected,
+  useHostRuntimeIsConnected,
+  useHosts,
+} from "@/runtime/host-runtime";
 import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
 import { useWindowControlsPadding } from "@/utils/desktop-window";
 import { confirmDialog } from "@/utils/confirm-dialog";
@@ -59,6 +65,7 @@ import { useVoiceAudioEngineOptional } from "@/contexts/voice-context";
 import { HostPage, HostRenameButton } from "@/screens/settings/host-page";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useLocalDaemonServerId } from "@/hooks/use-is-local-daemon";
+import { useProvidersSnapshot } from "@/hooks/use-providers-snapshot";
 import {
   buildHostOpenProjectRoute,
   buildHostWorkspaceRoute,
@@ -67,6 +74,12 @@ import {
   type SettingsSectionSlug,
 } from "@/utils/host-routes";
 import { getLastNavigationWorkspaceRouteSelection } from "@/stores/navigation-active-workspace-store";
+import { getProviderIcon } from "@/components/provider-icons";
+import { ProviderDiagnosticSheet } from "@/components/provider-diagnostic-sheet";
+import { SpinningRefreshIcon } from "@/components/spinning-refresh-icon";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { buildProviderDefinitions } from "@/utils/provider-definitions";
+import { resolveHelperProviderPreferences } from "@/utils/helper-provider-preferences";
 
 // ---------------------------------------------------------------------------
 // View model
@@ -88,6 +101,7 @@ const SIDEBAR_SECTION_ITEMS: SidebarSectionItem[] = [
   { id: "general", label: "General", icon: Settings },
   { id: "shortcuts", label: "Shortcuts", icon: Keyboard, desktopOnly: true },
   { id: "integrations", label: "Integrations", icon: Puzzle, desktopOnly: true },
+  { id: "providers", label: "Providers", icon: Blocks, desktopOnly: true },
   { id: "permissions", label: "Permissions", icon: Shield, desktopOnly: true },
   { id: "diagnostics", label: "Diagnostics", icon: Stethoscope },
   { id: "about", label: "About", icon: Info },
@@ -221,6 +235,292 @@ function GeneralSection({
         </View>
       </View>
     </SettingsSection>
+  );
+}
+
+interface ProvidersSectionProps {
+  routeServerId: string;
+}
+
+function ProvidersSection({ routeServerId }: ProvidersSectionProps) {
+  const { theme } = useUnistyles();
+  const isConnected = useHostRuntimeIsConnected(routeServerId);
+  const { settings, updateSettings } = useAppSettings();
+  const { entries, isLoading, isRefreshing, refresh } = useProvidersSnapshot(routeServerId);
+  const [diagnosticProvider, setDiagnosticProvider] = useState<string | null>(null);
+  const providerDefinitions = buildProviderDefinitions(entries);
+  const readyEntries = useMemo(
+    () => (entries ?? []).filter((entry) => entry.status === "ready"),
+    [entries],
+  );
+  const helperProviders = useMemo(
+    () =>
+      resolveHelperProviderPreferences({
+        entries,
+        savedPreferences: settings.helperProviders,
+      }),
+    [entries, settings.helperProviders],
+  );
+  const providerRefreshInFlight =
+    isRefreshing || (entries?.some((entry) => entry.status === "loading") ?? false);
+  const hasServer = routeServerId.trim().length > 0;
+
+  const updateHelperProviders = useCallback(
+    async (next: typeof helperProviders) => {
+      await updateSettings({ helperProviders: next });
+    },
+    [helperProviders, updateSettings],
+  );
+
+  const moveHelperProvider = useCallback(
+    (index: number, direction: -1 | 1) => {
+      const targetIndex = index + direction;
+      if (targetIndex < 0 || targetIndex >= helperProviders.length) {
+        return;
+      }
+
+      const next = [...helperProviders];
+      const [moved] = next.splice(index, 1);
+      if (!moved) {
+        return;
+      }
+      next.splice(targetIndex, 0, moved);
+      void updateHelperProviders(next);
+    },
+    [helperProviders, updateHelperProviders],
+  );
+
+  const setHelperProviderModel = useCallback(
+    (provider: string, model: string | null) => {
+      const next = helperProviders.map((entry) =>
+        entry.provider === provider ? { ...entry, model } : entry,
+      );
+      void updateHelperProviders(next);
+    },
+    [helperProviders, updateHelperProviders],
+  );
+
+  return (
+    <>
+      <SettingsSection title="Providers">
+        {!hasServer || !isConnected ? (
+          <View style={[settingsStyles.card, styles.emptyCard]}>
+            <Text style={styles.emptyText}>Connect to a host to see providers</Text>
+          </View>
+        ) : isLoading ? (
+          <View style={[settingsStyles.card, styles.emptyCard]}>
+            <Text style={styles.emptyText}>Loading providers...</Text>
+          </View>
+        ) : (
+          <>
+            <View style={[settingsStyles.card, styles.audioCard]}>
+              <View style={styles.providerCardHeader}>
+                <View style={styles.audioRowContent}>
+                  <Text style={styles.audioRowTitle}>Available providers</Text>
+                  <Text style={styles.audioRowSubtitle}>
+                    Inspect installed providers and the models they currently expose.
+                  </Text>
+                </View>
+                <Pressable
+                  onPress={() => {
+                    void refresh();
+                  }}
+                  disabled={providerRefreshInFlight}
+                  hitSlop={8}
+                  accessibilityRole="button"
+                  accessibilityLabel="Refresh providers"
+                  style={({ hovered, pressed }) => [
+                    styles.providerRefreshButton,
+                    (hovered || pressed) && styles.providerRefreshButtonHovered,
+                    providerRefreshInFlight ? styles.providerRefreshButtonDisabled : null,
+                  ]}
+                >
+                  <SpinningRefreshIcon
+                    spinning={providerRefreshInFlight}
+                    size={theme.iconSize.sm}
+                    color={theme.colors.foregroundMuted}
+                  />
+                </Pressable>
+              </View>
+              {providerDefinitions.map((def, index) => {
+                const entry = entries?.find((candidate) => candidate.provider === def.id);
+                const status = entry?.status ?? "unavailable";
+                const ProviderIcon = getProviderIcon(def.id);
+                const providerError =
+                  status === "error" &&
+                  typeof entry?.error === "string" &&
+                  entry.error.trim().length > 0
+                    ? entry.error.trim()
+                    : null;
+                const modelCount = entry?.models?.length ?? 0;
+
+                return (
+                  <Pressable
+                    key={def.id}
+                    style={[styles.audioRow, index > 0 ? styles.audioRowBorder : null]}
+                    onPress={() => setDiagnosticProvider(def.id)}
+                    accessibilityRole="button"
+                  >
+                    <View style={styles.audioRowContent}>
+                      <View
+                        style={{ flexDirection: "row", alignItems: "center", gap: theme.spacing[2] }}
+                      >
+                        <ProviderIcon size={theme.iconSize.sm} color={theme.colors.foreground} />
+                        <Text style={styles.audioRowTitle}>{def.label}</Text>
+                      </View>
+                      {providerError ? (
+                        <Text style={styles.aboutErrorText} numberOfLines={3}>
+                          {providerError}
+                        </Text>
+                      ) : status === "ready" && modelCount > 0 ? (
+                        <Text style={styles.audioRowSubtitle}>
+                          {modelCount === 1 ? "1 model" : `${modelCount} models`}
+                        </Text>
+                      ) : null}
+                    </View>
+                    <StatusBadge
+                      label={
+                        status === "ready"
+                          ? "Available"
+                          : status === "error"
+                            ? "Error"
+                            : status === "loading"
+                              ? "Loading..."
+                              : "Not installed"
+                      }
+                      variant={
+                        status === "ready" ? "success" : status === "error" ? "error" : "muted"
+                      }
+                    />
+                  </Pressable>
+                );
+              })}
+            </View>
+
+            <View style={[settingsStyles.card, styles.audioCard, styles.helperCard]}>
+              <View style={styles.helperSectionHeader}>
+                <Text style={styles.audioRowTitle}>Helper provider order</Text>
+                <Text style={styles.audioRowSubtitle}>
+                  Structured helper providers for commit messages and PR text. Only ready
+                  providers appear here.
+                </Text>
+              </View>
+
+              {helperProviders.length === 0 ? (
+                <View style={[styles.audioRow, styles.audioRowBorder]}>
+                  <View style={styles.audioRowContent}>
+                    <Text style={styles.audioRowTitle}>No helper providers available</Text>
+                    <Text style={styles.audioRowSubtitle}>
+                      Install or enable a provider above to configure helper order and models.
+                    </Text>
+                  </View>
+                </View>
+              ) : (
+                helperProviders.map((helper, index) => {
+                  const entry = readyEntries.find((candidate) => candidate.provider === helper.provider);
+                  const ProviderIcon = getProviderIcon(helper.provider);
+                  const selectedModel =
+                    entry?.models?.find((candidate) => candidate.id === helper.model) ?? null;
+                  const helperModelLabel = selectedModel?.label ?? "Default helper model";
+
+                  return (
+                    <View
+                      key={helper.provider}
+                      style={[styles.audioRow, index > 0 ? styles.audioRowBorder : null]}
+                    >
+                      <View style={styles.audioRowContent}>
+                        <View
+                          style={{ flexDirection: "row", alignItems: "center", gap: theme.spacing[2] }}
+                        >
+                          <ProviderIcon size={theme.iconSize.sm} color={theme.colors.foreground} />
+                          <Text style={styles.audioRowTitle}>
+                            {entry?.label ?? helper.provider}
+                          </Text>
+                        </View>
+                        <Text style={styles.audioRowSubtitle}>Model: {helperModelLabel}</Text>
+                      </View>
+
+                      <View style={styles.helperControls}>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            style={({ pressed }) => [
+                              styles.helperModelTrigger,
+                              pressed && { opacity: 0.85 },
+                            ]}
+                          >
+                            <Text style={styles.helperModelTriggerText}>{helperModelLabel}</Text>
+                            <ChevronDown
+                              size={theme.iconSize.sm}
+                              color={theme.colors.foregroundMuted}
+                            />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent side="bottom" align="end" width={260}>
+                            <DropdownMenuItem
+                              selected={!helper.model}
+                              onSelect={() => setHelperProviderModel(helper.provider, null)}
+                            >
+                              Default helper model
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            {(entry?.models ?? []).map((model) => (
+                              <DropdownMenuItem
+                                key={model.id}
+                                selected={helper.model === model.id}
+                                onSelect={() => setHelperProviderModel(helper.provider, model.id)}
+                              >
+                                {model.label}
+                              </DropdownMenuItem>
+                            ))}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+
+                        <View style={styles.helperMoveButtons}>
+                          <Pressable
+                            disabled={index === 0}
+                            onPress={() => moveHelperProvider(index, -1)}
+                            style={({ pressed }) => [
+                              styles.helperMoveButton,
+                              index === 0 ? styles.helperMoveButtonDisabled : null,
+                              pressed && index !== 0 ? styles.helperMoveButtonPressed : null,
+                            ]}
+                          >
+                            <Text style={styles.helperMoveButtonText}>Up</Text>
+                          </Pressable>
+                          <Pressable
+                            disabled={index === helperProviders.length - 1}
+                            onPress={() => moveHelperProvider(index, 1)}
+                            style={({ pressed }) => [
+                              styles.helperMoveButton,
+                              index === helperProviders.length - 1
+                                ? styles.helperMoveButtonDisabled
+                                : null,
+                              pressed && index !== helperProviders.length - 1
+                                ? styles.helperMoveButtonPressed
+                                : null,
+                            ]}
+                          >
+                            <Text style={styles.helperMoveButtonText}>Dn</Text>
+                          </Pressable>
+                        </View>
+                      </View>
+                    </View>
+                  );
+                })
+              )}
+            </View>
+          </>
+        )}
+      </SettingsSection>
+
+      {diagnosticProvider ? (
+        <ProviderDiagnosticSheet
+          provider={diagnosticProvider}
+          visible
+          onClose={() => setDiagnosticProvider(null)}
+          serverId={routeServerId}
+        />
+      ) : null}
+    </>
   );
 }
 
@@ -598,8 +898,13 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
   const isCompactLayout = useIsCompactFormFactor();
   const insets = useSafeAreaInsets();
   const hosts = useHosts();
+  const localDaemonServerId = useLocalDaemonServerId();
   const hostServerIds = useMemo(() => hosts.map((host) => host.serverId), [hosts]);
   const anyOnlineServerId = useAnyOnlineHostServerId(hostServerIds);
+  const providerServerId = useMemo(
+    () => localDaemonServerId ?? anyOnlineServerId ?? "",
+    [anyOnlineServerId, localDaemonServerId],
+  );
 
   const handleThemeChange = useCallback(
     (nextTheme: AppSettings["theme"]) => {
@@ -782,6 +1087,8 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
           return isDesktopApp ? <KeyboardShortcutsSection /> : null;
         case "integrations":
           return isDesktopApp ? <IntegrationsSection /> : null;
+        case "providers":
+          return isDesktopApp ? <ProvidersSection routeServerId={providerServerId} /> : null;
         case "permissions":
           return isDesktopApp ? <DesktopPermissionsSection /> : null;
         case "diagnostics":
@@ -986,6 +1293,118 @@ const styles = StyleSheet.create((theme) => ({
   themeTriggerText: {
     color: theme.colors.foreground,
     fontSize: theme.fontSize.sm,
+  },
+  providerCardHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[3],
+    paddingVertical: theme.spacing[4],
+    paddingHorizontal: theme.spacing[4],
+  },
+  providerRefreshButton: {
+    width: 30,
+    height: 30,
+    borderRadius: theme.borderRadius.full,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  providerRefreshButtonHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+  providerRefreshButtonDisabled: {
+    opacity: 0.5,
+  },
+  helperCard: {
+    marginTop: theme.spacing[3],
+  },
+  helperSectionHeader: {
+    paddingHorizontal: theme.spacing[4],
+    paddingTop: theme.spacing[4],
+    paddingBottom: theme.spacing[2],
+    gap: theme.spacing[1],
+  },
+  helperControls: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  helperModelTrigger: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    paddingVertical: theme.spacing[1],
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.md,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    maxWidth: 220,
+  },
+  helperModelTriggerText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    flexShrink: 1,
+  },
+  helperMoveButtons: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+  },
+  helperMoveButton: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: theme.borderRadius.md,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface1,
+  },
+  helperMoveButtonDisabled: {
+    opacity: 0.4,
+  },
+  helperMoveButtonPressed: {
+    backgroundColor: theme.colors.surface2,
+  },
+  helperMoveButtonText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+    lineHeight: 16,
+  },
+  audioCard: {
+    overflow: "hidden",
+  },
+  audioRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: theme.spacing[4],
+    paddingHorizontal: theme.spacing[4],
+  },
+  audioRowBorder: {
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+  },
+  audioRowContent: {
+    flex: 1,
+    marginRight: theme.spacing[3],
+  },
+  audioRowTitle: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+  },
+  audioRowSubtitle: {
+    color: theme.colors.mutedForeground,
+    fontSize: theme.fontSize.sm,
+    marginTop: theme.spacing[1],
+  },
+  emptyCard: {
+    padding: theme.spacing[4],
+    marginBottom: theme.spacing[3],
+  },
+  emptyText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    textAlign: "center",
   },
 }));
 

--- a/packages/app/src/stores/checkout-git-actions-store.ts
+++ b/packages/app/src/stores/checkout-git-actions-store.ts
@@ -1,12 +1,20 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { create } from "zustand";
+import type { ProviderSnapshotEntry } from "@server/server/agent/agent-sdk-types";
 import { queryClient as appQueryClient } from "@/query/query-client";
+import {
+  APP_SETTINGS_QUERY_KEY,
+  loadSettingsFromStorage,
+  type AppSettings,
+} from "@/hooks/use-settings";
+import { providersSnapshotQueryKey } from "@/hooks/use-providers-snapshot";
 import {
   buildWorkspaceTabPersistenceKey,
   useWorkspaceLayoutStore,
 } from "@/stores/workspace-layout-store";
 import { useSessionStore } from "@/stores/session-store";
 import { useWorkspaceTabsStore } from "@/stores/workspace-tabs-store";
+import { resolveHelperProviderPreferences } from "@/utils/helper-provider-preferences";
 
 const SUCCESS_DISPLAY_MS = 1000;
 
@@ -35,6 +43,20 @@ function resolveClient(serverId: string) {
     throw new Error("Daemon client unavailable");
   }
   return client;
+}
+
+async function resolveStructuredHelperInput(serverId: string) {
+  const settings =
+    appQueryClient.getQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY) ??
+    (await loadSettingsFromStorage());
+  const snapshot = appQueryClient.getQueryData<{ entries?: ProviderSnapshotEntry[] }>(
+    providersSnapshotQueryKey(serverId),
+  );
+
+  return resolveHelperProviderPreferences({
+    entries: snapshot?.entries,
+    savedPreferences: settings.helperProviders,
+  });
 }
 
 function setStatus(
@@ -256,7 +278,8 @@ export const useCheckoutGitActionsStore = create<CheckoutGitActionsStoreState>()
       actionId: "commit",
       run: async () => {
         const client = resolveClient(serverId);
-        const payload = await client.checkoutCommit(cwd, { addAll: true });
+        const helperProviders = await resolveStructuredHelperInput(serverId);
+        const payload = await client.checkoutCommit(cwd, { addAll: true, helperProviders });
         if (payload.error) {
           throw new Error(payload.error.message);
         }
@@ -301,7 +324,8 @@ export const useCheckoutGitActionsStore = create<CheckoutGitActionsStoreState>()
       actionId: "create-pr",
       run: async () => {
         const client = resolveClient(serverId);
-        const payload = await client.checkoutPrCreate(cwd, {});
+        const helperProviders = await resolveStructuredHelperInput(serverId);
+        const payload = await client.checkoutPrCreate(cwd, { helperProviders });
         if (payload.error) {
           throw new Error(payload.error.message);
         }

--- a/packages/app/src/utils/helper-provider-preferences.test.ts
+++ b/packages/app/src/utils/helper-provider-preferences.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeHelperProviderPreferences,
+  resolveHelperProviderPreferences,
+} from "./helper-provider-preferences";
+
+describe("helper-provider-preferences", () => {
+  it("filters invalid and duplicate saved helper providers", () => {
+    expect(
+      normalizeHelperProviderPreferences([
+        { provider: "codex", model: "gpt-5.4-mini" },
+        { provider: "codex", model: "ignored" },
+        { provider: "claude", model: "" },
+        { provider: "", model: "bad" },
+        null,
+      ]),
+    ).toEqual([
+      { provider: "codex", model: "gpt-5.4-mini" },
+      { provider: "claude", model: null },
+    ]);
+  });
+
+  it("keeps helper order within currently ready providers and appends new ones", () => {
+    expect(
+      resolveHelperProviderPreferences({
+        entries: [
+          {
+            provider: "codex",
+            status: "ready",
+            models: [{ provider: "codex", id: "gpt-5.4-mini", label: "GPT-5.4 Mini" }],
+          },
+          {
+            provider: "claude",
+            status: "ready",
+            models: [{ provider: "claude", id: "haiku", label: "Haiku" }],
+          },
+          {
+            provider: "opencode",
+            status: "error",
+          },
+        ],
+        savedPreferences: [
+          { provider: "claude", model: "haiku" },
+          { provider: "opencode", model: "opencode/gpt-5-nano" },
+        ],
+      }),
+    ).toEqual([
+      { provider: "claude", model: "haiku" },
+      { provider: "codex", model: null },
+    ]);
+  });
+
+  it("drops saved models that no longer exist for a ready provider", () => {
+    expect(
+      resolveHelperProviderPreferences({
+        entries: [
+          {
+            provider: "codex",
+            status: "ready",
+            models: [{ provider: "codex", id: "gpt-5.4", label: "GPT-5.4" }],
+          },
+        ],
+        savedPreferences: [{ provider: "codex", model: "gpt-5.4-mini" }],
+      }),
+    ).toEqual([{ provider: "codex", model: null }]);
+  });
+
+  it("falls back to saved preferences when no provider snapshot is available", () => {
+    expect(
+      resolveHelperProviderPreferences({
+        entries: undefined,
+        savedPreferences: [{ provider: "codex", model: "gpt-5.4-mini" }],
+      }),
+    ).toEqual([{ provider: "codex", model: "gpt-5.4-mini" }]);
+  });
+});

--- a/packages/app/src/utils/helper-provider-preferences.ts
+++ b/packages/app/src/utils/helper-provider-preferences.ts
@@ -1,0 +1,109 @@
+import type { AgentProvider, ProviderSnapshotEntry } from "@server/server/agent/agent-sdk-types";
+
+export interface HelperProviderPreference {
+  provider: AgentProvider;
+  model?: string | null;
+}
+
+function isAgentProvider(value: unknown): value is AgentProvider {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeHelperProviderPreference(
+  value: unknown,
+): HelperProviderPreference | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const candidate = value as { provider?: unknown; model?: unknown };
+  if (!isAgentProvider(candidate.provider)) {
+    return null;
+  }
+
+  const model =
+    typeof candidate.model === "string" && candidate.model.trim().length > 0
+      ? candidate.model.trim()
+      : null;
+
+  return {
+    provider: candidate.provider,
+    model,
+  };
+}
+
+function normalizeModelForEntry(
+  model: string | null | undefined,
+  entry: ProviderSnapshotEntry | undefined,
+): string | null {
+  if (!entry || !model) {
+    return null;
+  }
+
+  return entry.models?.some((candidate) => candidate.id === model) ? model : null;
+}
+
+export function normalizeHelperProviderPreferences(
+  values: unknown,
+): HelperProviderPreference[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  const seen = new Set<AgentProvider>();
+  const result: HelperProviderPreference[] = [];
+
+  for (const value of values) {
+    const normalized = normalizeHelperProviderPreference(value);
+    if (!normalized || seen.has(normalized.provider)) {
+      continue;
+    }
+    seen.add(normalized.provider);
+    result.push(normalized);
+  }
+
+  return result;
+}
+
+export function resolveHelperProviderPreferences(options: {
+  entries: ProviderSnapshotEntry[] | undefined;
+  savedPreferences: HelperProviderPreference[] | undefined;
+}): HelperProviderPreference[] {
+  const saved = normalizeHelperProviderPreferences(options.savedPreferences ?? []);
+  const readyEntries = (options.entries ?? []).filter((entry) => entry.status === "ready");
+  const entriesByProvider = new Map(readyEntries.map((entry) => [entry.provider, entry]));
+
+  if (readyEntries.length === 0) {
+    return saved;
+  }
+
+  const seen = new Set<AgentProvider>();
+  const result: HelperProviderPreference[] = [];
+
+  for (const preference of saved) {
+    const entry = entriesByProvider.get(preference.provider);
+    if (!entry || seen.has(preference.provider)) {
+      continue;
+    }
+
+    seen.add(preference.provider);
+    result.push({
+      provider: preference.provider,
+      model: normalizeModelForEntry(preference.model, entry),
+    });
+  }
+
+  for (const entry of readyEntries) {
+    if (seen.has(entry.provider)) {
+      continue;
+    }
+
+    seen.add(entry.provider);
+    result.push({
+      provider: entry.provider,
+      model: null,
+    });
+  }
+
+  return result;
+}

--- a/packages/app/src/utils/host-routes.ts
+++ b/packages/app/src/utils/host-routes.ts
@@ -376,6 +376,7 @@ export const SETTINGS_SECTION_SLUGS = [
   "general",
   "shortcuts",
   "integrations",
+  "providers",
   "permissions",
   "diagnostics",
   "about",

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -2457,7 +2457,11 @@ export class DaemonClient {
 
   async checkoutCommit(
     cwd: string,
-    input: { message?: string; addAll?: boolean },
+    input: {
+      message?: string;
+      addAll?: boolean;
+      helperProviders?: Array<{ provider: AgentProvider; model?: string | null }>;
+    },
     requestId?: string,
   ): Promise<CheckoutCommitPayload> {
     return this.sendCorrelatedSessionRequest({
@@ -2467,6 +2471,7 @@ export class DaemonClient {
         cwd,
         message: input.message,
         addAll: input.addAll,
+        helperProviders: input.helperProviders,
       },
       responseType: "checkout_commit_response",
       timeout: 60000,
@@ -2536,7 +2541,12 @@ export class DaemonClient {
 
   async checkoutPrCreate(
     cwd: string,
-    input: { title?: string; body?: string; baseRef?: string },
+    input: {
+      title?: string;
+      body?: string;
+      baseRef?: string;
+      helperProviders?: Array<{ provider: AgentProvider; model?: string | null }>;
+    },
     requestId?: string,
   ): Promise<CheckoutPrCreatePayload> {
     return this.sendCorrelatedSessionRequest({
@@ -2547,6 +2557,7 @@ export class DaemonClient {
         title: input.title,
         body: input.body,
         baseRef: input.baseRef,
+        helperProviders: input.helperProviders,
       },
       responseType: "checkout_pr_create_response",
       timeout: 60000,

--- a/packages/server/src/server/session.structured-helper-mcp.test.ts
+++ b/packages/server/src/server/session.structured-helper-mcp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { resolveStructuredHelperMcpServers } from "./session.js";
+import { resolveStructuredHelperMcpServers, resolveStructuredHelperProviders } from "./session.js";
 
 describe("resolveStructuredHelperMcpServers", () => {
   test("prefers a running agent in the same cwd when it has MCP servers", () => {
@@ -78,5 +78,29 @@ describe("resolveStructuredHelperMcpServers", () => {
     });
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe("resolveStructuredHelperProviders", () => {
+  test("uses default structured helper order when no helper preferences are configured", () => {
+    expect(resolveStructuredHelperProviders()).toEqual([
+      { provider: "claude", model: "haiku" },
+      { provider: "codex", model: "gpt-5.4-mini", thinkingOptionId: "low" },
+      { provider: "opencode", model: "opencode/gpt-5-nano" },
+    ]);
+  });
+
+  test("respects configured provider order and model overrides", () => {
+    expect(
+      resolveStructuredHelperProviders({
+        helperProviders: [
+          { provider: "codex", model: "gpt-5.4" },
+          { provider: "claude", model: null },
+        ],
+      }),
+    ).toEqual([
+      { provider: "codex", model: "gpt-5.4", thinkingOptionId: "low" },
+      { provider: "claude", model: "haiku" },
+    ]);
   });
 });

--- a/packages/server/src/server/session.structured-helper-mcp.test.ts
+++ b/packages/server/src/server/session.structured-helper-mcp.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveStructuredHelperMcpServers } from "./session.js";
+
+describe("resolveStructuredHelperMcpServers", () => {
+  test("prefers a running agent in the same cwd when it has MCP servers", () => {
+    const expected = {
+      task_board_mcp: { type: "http", url: "http://127.0.0.1:6767/mcp/task-board" },
+    };
+
+    const result = resolveStructuredHelperMcpServers({
+      cwd: "C:/workspace/app",
+      agents: [
+        {
+          cwd: "C:/workspace/app",
+          lifecycle: "idle",
+          updatedAt: new Date("2026-04-17T09:00:00.000Z"),
+          config: {
+            provider: "codex",
+            cwd: "C:/workspace/app",
+            mcpServers: {
+              paseo: { type: "http", url: "http://127.0.0.1:6767/mcp" },
+            },
+          },
+        },
+        {
+          cwd: "C:/workspace/app",
+          lifecycle: "running",
+          updatedAt: new Date("2026-04-17T08:00:00.000Z"),
+          config: {
+            provider: "codex",
+            cwd: "C:/workspace/app",
+            mcpServers: expected,
+          },
+        },
+      ],
+    });
+
+    expect(result).toEqual(expected);
+  });
+
+  test("ignores agents from other working directories", () => {
+    const result = resolveStructuredHelperMcpServers({
+      cwd: "C:/workspace/app",
+      agents: [
+        {
+          cwd: "C:/workspace/other",
+          lifecycle: "running",
+          updatedAt: new Date("2026-04-17T08:00:00.000Z"),
+          config: {
+            provider: "codex",
+            cwd: "C:/workspace/other",
+            mcpServers: {
+              task_board_mcp: { type: "http", url: "http://127.0.0.1:6767/mcp/task-board" },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined when no matching agent exposes MCP servers", () => {
+    const result = resolveStructuredHelperMcpServers({
+      cwd: "C:/workspace/app",
+      agents: [
+        {
+          cwd: "C:/workspace/app",
+          lifecycle: "running",
+          updatedAt: new Date("2026-04-17T08:00:00.000Z"),
+          config: {
+            provider: "codex",
+            cwd: "C:/workspace/app",
+          },
+        },
+      ],
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -307,6 +307,30 @@ export function resolveCreateAgentTitles(options: {
   };
 }
 
+type StructuredHelperMcpCandidate = Pick<ManagedAgent, "cwd" | "lifecycle" | "updatedAt" | "config">;
+
+export function resolveStructuredHelperMcpServers(options: {
+  cwd: string;
+  agents: ReadonlyArray<StructuredHelperMcpCandidate>;
+}): AgentSessionConfig["mcpServers"] | undefined {
+  const candidates = options.agents
+    .filter((agent) => agent.cwd === options.cwd)
+    .filter((agent) => {
+      const mcpServers = agent.config.mcpServers;
+      return Boolean(mcpServers && Object.keys(mcpServers).length > 0);
+    })
+    .sort((left, right) => {
+      const leftPriority = left.lifecycle === "running" ? 0 : 1;
+      const rightPriority = right.lifecycle === "running" ? 0 : 1;
+      if (leftPriority !== rightPriority) {
+        return leftPriority - rightPriority;
+      }
+      return right.updatedAt.getTime() - left.updatedAt.getTime();
+    });
+
+  return candidates[0]?.config.mcpServers;
+}
+
 export function resolveWaitForFinishError(options: {
   status: "permission" | "error" | "idle";
   final: AgentSnapshotPayload | null;
@@ -3524,6 +3548,10 @@ export class Session {
   }
 
   private async generateCommitMessage(cwd: string): Promise<string> {
+    const helperMcpServers = resolveStructuredHelperMcpServers({
+      cwd,
+      agents: this.agentManager.listAgents(),
+    });
     const diff = await this.workspaceGitService.getCheckoutDiff(cwd, {
       mode: "uncommitted",
       includeStructured: true,
@@ -3571,6 +3599,7 @@ export class Session {
         agentConfigOverrides: {
           title: "Commit generator",
           internal: true,
+          ...(helperMcpServers ? { mcpServers: helperMcpServers } : {}),
         },
       });
       return result.message;
@@ -3592,6 +3621,10 @@ export class Session {
     title: string;
     body: string;
   }> {
+    const helperMcpServers = resolveStructuredHelperMcpServers({
+      cwd,
+      agents: this.agentManager.listAgents(),
+    });
     const diff = await this.workspaceGitService.getCheckoutDiff(cwd, {
       mode: "base",
       baseRef,
@@ -3637,6 +3670,7 @@ export class Session {
         agentConfigOverrides: {
           title: "PR generator",
           internal: true,
+          ...(helperMcpServers ? { mcpServers: helperMcpServers } : {}),
         },
       });
     } catch (error) {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -117,6 +117,7 @@ import {
   StructuredAgentFallbackError,
   StructuredAgentResponseError,
   generateStructuredAgentResponseWithFallback,
+  type StructuredGenerationProvider,
 } from "./agent/agent-response-loop.js";
 import type {
   AgentPersistenceHandle,
@@ -308,6 +309,10 @@ export function resolveCreateAgentTitles(options: {
 }
 
 type StructuredHelperMcpCandidate = Pick<ManagedAgent, "cwd" | "lifecycle" | "updatedAt" | "config">;
+type StructuredHelperPreference = {
+  provider: AgentProvider;
+  model?: string | null;
+};
 
 export function resolveStructuredHelperMcpServers(options: {
   cwd: string;
@@ -329,6 +334,44 @@ export function resolveStructuredHelperMcpServers(options: {
     });
 
   return candidates[0]?.config.mcpServers;
+}
+
+export function resolveStructuredHelperProviders(options?: {
+  helperProviders?: ReadonlyArray<StructuredHelperPreference> | undefined;
+}): StructuredGenerationProvider[] {
+  const configured = options?.helperProviders ?? [];
+  if (configured.length === 0) {
+    return [...DEFAULT_STRUCTURED_GENERATION_PROVIDERS];
+  }
+
+  const defaultsByProvider = new Map(
+    DEFAULT_STRUCTURED_GENERATION_PROVIDERS.map((candidate) => [candidate.provider, candidate]),
+  );
+  const seen = new Set<AgentProvider>();
+  const resolved: StructuredGenerationProvider[] = [];
+
+  for (const helper of configured) {
+    if (seen.has(helper.provider)) {
+      continue;
+    }
+    seen.add(helper.provider);
+
+    const fallback = defaultsByProvider.get(helper.provider);
+    if (fallback) {
+      resolved.push({
+        ...fallback,
+        ...(helper.model ? { model: helper.model } : {}),
+      });
+      continue;
+    }
+
+    resolved.push({
+      provider: helper.provider,
+      ...(helper.model ? { model: helper.model } : {}),
+    });
+  }
+
+  return resolved.length > 0 ? resolved : [...DEFAULT_STRUCTURED_GENERATION_PROVIDERS];
 }
 
 export function resolveWaitForFinishError(options: {
@@ -3547,7 +3590,10 @@ export class Session {
     return resolvedCandidate.startsWith(resolvedRoot + sep);
   }
 
-  private async generateCommitMessage(cwd: string): Promise<string> {
+  private async generateCommitMessage(
+    cwd: string,
+    helperProviders?: ReadonlyArray<StructuredHelperPreference>,
+  ): Promise<string> {
     const helperMcpServers = resolveStructuredHelperMcpServers({
       cwd,
       agents: this.agentManager.listAgents(),
@@ -3595,7 +3641,7 @@ export class Session {
         schema,
         schemaName: "CommitMessage",
         maxRetries: 2,
-        providers: DEFAULT_STRUCTURED_GENERATION_PROVIDERS,
+        providers: resolveStructuredHelperProviders({ helperProviders }),
         agentConfigOverrides: {
           title: "Commit generator",
           internal: true,
@@ -3617,6 +3663,7 @@ export class Session {
   private async generatePullRequestText(
     cwd: string,
     baseRef?: string,
+    helperProviders?: ReadonlyArray<StructuredHelperPreference>,
   ): Promise<{
     title: string;
     body: string;
@@ -3666,7 +3713,7 @@ export class Session {
         schema,
         schemaName: "PullRequest",
         maxRetries: 2,
-        providers: DEFAULT_STRUCTURED_GENERATION_PROVIDERS,
+        providers: resolveStructuredHelperProviders({ helperProviders }),
         agentConfigOverrides: {
           title: "PR generator",
           internal: true,
@@ -4745,7 +4792,7 @@ export class Session {
     try {
       let message = msg.message?.trim() ?? "";
       if (!message) {
-        message = await this.generateCommitMessage(cwd);
+        message = await this.generateCommitMessage(cwd, msg.helperProviders);
       }
       if (!message) {
         throw new Error("Commit message is required");
@@ -4955,7 +5002,7 @@ export class Session {
       let body = msg.body?.trim() ?? "";
 
       if (!title || !body) {
-        const generated = await this.generatePullRequestText(cwd, msg.baseRef);
+        const generated = await this.generatePullRequestText(cwd, msg.baseRef, msg.helperProviders);
         if (!title) title = generated.title;
         if (!body) body = generated.body;
       }

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1134,6 +1134,14 @@ export const CheckoutCommitRequestSchema = z.object({
   cwd: z.string(),
   message: z.string().optional(),
   addAll: z.boolean().optional(),
+  helperProviders: z
+    .array(
+      z.object({
+        provider: AgentProviderSchema,
+        model: z.string().nullable().optional(),
+      }),
+    )
+    .optional(),
   requestId: z.string(),
 });
 
@@ -1172,6 +1180,14 @@ export const CheckoutPrCreateRequestSchema = z.object({
   title: z.string().optional(),
   body: z.string().optional(),
   baseRef: z.string().optional(),
+  helperProviders: z
+    .array(
+      z.object({
+        provider: AgentProviderSchema,
+        model: z.string().nullable().optional(),
+      }),
+    )
+    .optional(),
   requestId: z.string(),
 });
 


### PR DESCRIPTION
## Summary
- add a Helper subsection under Settings > Providers
- allow configuring helper provider order from ready providers only
- allow selecting a model per helper provider and pass that configuration into structured helper generation

## Validation
- npm.cmd run typecheck
- cmd /c ..\\..\\node_modules\\.bin\\vitest.cmd run src\\hooks\\use-settings.test.ts src\\utils\\helper-provider-preferences.test.ts
- cmd /c ..\\..\\node_modules\\.bin\\vitest.cmd run src\\server\\session.structured-helper-mcp.test.ts

## Notes
- stacked on top of #470