### PR TITLE
Add WeChat direct channel MVP

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -33,6 +33,9 @@ env:
   SOURCE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
   DESKTOP_WORKSPACE: '@getpaseo/desktop'
   DESKTOP_PACKAGE_PATH: 'packages/desktop'
+  RELEASE_REPOSITORY: ${{ github.repository }}
+  RELEASE_REPOSITORY_OWNER: ${{ github.repository_owner }}
+  RELEASE_REPOSITORY_NAME: ${{ github.event.repository.name }}
 
 jobs:
   create-release:
@@ -55,7 +58,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+          if gh release view "$RELEASE_TAG" --repo "$RELEASE_REPOSITORY" > /dev/null 2>&1; then
             echo "Release $RELEASE_TAG already exists, skipping creation"
           else
             prerelease_flag=""
@@ -63,7 +66,7 @@ jobs:
               prerelease_flag="--prerelease"
             fi
             gh release create "$RELEASE_TAG" \
-              --repo "${{ github.repository }}" \
+              --repo "$RELEASE_REPOSITORY" \
               --title "Paseo $RELEASE_TAG" \
               --generate-notes \
               $prerelease_flag
@@ -145,6 +148,8 @@ jobs:
           if [[ "$IS_SMOKE_TAG" != "true" ]]; then
             publish_mode="always"
             publish_args+=("-c.publish.releaseType=$RELEASE_TYPE")
+            publish_args+=("-c.publish.owner=$RELEASE_REPOSITORY_OWNER")
+            publish_args+=("-c.publish.repo=$RELEASE_REPOSITORY_NAME")
           fi
 
           npm run build --workspace="$DESKTOP_WORKSPACE" -- --publish "$publish_mode" --mac --${{ matrix.electron_arch }} "${publish_args[@]}"
@@ -251,7 +256,7 @@ jobs:
         if: env.IS_SMOKE_TAG != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$RELEASE_TAG" latest-mac.yml --clobber --repo "${{ github.repository }}"
+        run: gh release upload "$RELEASE_TAG" latest-mac.yml --clobber --repo "$RELEASE_REPOSITORY"
 
   publish-linux:
     needs: [create-release]
@@ -316,6 +321,8 @@ jobs:
           if [[ "$IS_SMOKE_TAG" != "true" ]]; then
             publish_mode="always"
             publish_args+=("-c.publish.releaseType=$RELEASE_TYPE")
+            publish_args+=("-c.publish.owner=$RELEASE_REPOSITORY_OWNER")
+            publish_args+=("-c.publish.repo=$RELEASE_REPOSITORY_NAME")
           fi
 
           npm run build --workspace="$DESKTOP_WORKSPACE" -- --publish "$publish_mode" --linux --x64 "${publish_args[@]}"
@@ -391,6 +398,8 @@ jobs:
           if [[ "$IS_SMOKE_TAG" != "true" ]]; then
             publish_mode="always"
             publish_args+=("-c.publish.releaseType=$RELEASE_TYPE")
+            publish_args+=("-c.publish.owner=$RELEASE_REPOSITORY_OWNER")
+            publish_args+=("-c.publish.repo=$RELEASE_REPOSITORY_NAME")
           fi
 
           npm run build --workspace="$DESKTOP_WORKSPACE" -- --publish "$publish_mode" --win --x64 "${publish_args[@]}"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   </a>
 </p>
 
-<p align="center">One interface for all your Claude Code, Codex and OpenCode agents.</p>
+<p align="center">统一管理 Claude Code、Codex 和 OpenCode 代理的单一界面。</p>
 
 <p align="center">
   <img src="https://paseo.sh/hero-mockup.png" alt="Paseo app screenshot" width="100%">
@@ -31,117 +31,182 @@
 
 ---
 
-Run agents in parallel on your own machines. Ship from your phone or your desk.
+让多个代理在你自己的机器上并行运行。无论你在手机前还是电脑前，都能随时推进工作。
 
-- **Self-hosted:** Agents run on your machine with your full dev environment. Use your tools, your configs, and your skills.
-- **Multi-provider:** Claude Code, Codex, and OpenCode through the same interface. Pick the right model for each job.
-- **Voice control:** Dictate tasks or talk through problems in voice mode. Hands-free when you need it.
-- **Cross-device:** iOS, Android, desktop, web, and CLI. Start work at your desk, check in from your phone, script it from the terminal.
-- **Privacy-first:** Paseo doesn't have any telemetry, tracking, or forced log-ins.
+- **自托管：** 代理直接运行在你的机器上，使用你现有的开发环境、工具、配置和技能。
+- **多 Provider：** 在同一个界面中统一接入 Claude Code、Codex 和 OpenCode，为不同任务选择合适的模型。
+- **语音控制：** 可通过语音输入任务或边说边梳理问题，需要时可以解放双手。
+- **跨设备：** 支持 iOS、Android、桌面端、Web 和 CLI。你可以在桌面上开始任务，在手机上查看进度，也可以在终端里脚本化操作。
+- **隐私优先：** Paseo 不包含遥测、追踪或强制登录。
 
-## Getting Started
+## 快速开始
 
-Paseo runs a local server called the daemon that manages your coding agents. Clients like the desktop app, mobile app, web app, and CLI connect to it.
+Paseo 会运行一个本地服务，称为 `daemon`，专门负责管理你的编码代理。桌面端、移动端、Web 端和 CLI 等客户端都通过它进行连接。
 
-### Prerequisites
+### 前置条件
 
-You need at least one agent CLI installed and configured with your credentials:
+你至少需要安装并配置好一个代理 CLI，并确保已经完成凭据配置：
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
 - [Codex](https://github.com/openai/codex)
 - [OpenCode](https://github.com/anomalyco/opencode)
 
-### Desktop app (recommended)
+### 桌面应用（推荐）
 
-Download it from [paseo.sh/download](https://paseo.sh/download) or the [GitHub releases page](https://github.com/getpaseo/paseo/releases). Open the app and the daemon starts automatically. Nothing else to install.
+可从 [paseo.sh/download](https://paseo.sh/download) 或 [GitHub Releases](https://github.com/getpaseo/paseo/releases) 下载。打开应用后，`daemon` 会自动启动，不需要额外安装其他组件。
 
-To connect from your phone, scan the QR code shown in Settings.
+如果要从手机连接，只需扫描设置页中展示的二维码。
 
-### CLI / headless
+### CLI / 无头模式
 
-Install the CLI and start Paseo:
+安装 CLI 并启动 Paseo：
 
 ```bash
 npm install -g @getpaseo/cli
 paseo
 ```
 
-This shows a QR code in the terminal. Connect from any client. This path is useful for servers and remote machines.
+终端中会显示一个二维码，任意客户端都可以通过它连接。这个方式特别适合服务器或远程机器。
 
-For full setup and configuration, see:
-- [Docs](https://paseo.sh/docs)
-- [Configuration reference](https://paseo.sh/docs/configuration)
+完整安装与配置说明见：
+- [文档](https://paseo.sh/docs)
+- [配置参考](https://paseo.sh/docs/configuration)
+
+## 微信直连（MVP）
+
+当前仓库已经加入一个参考 `Tencent/openclaw-weixin` 思路实现的微信直连 MVP，目标是让 Paseo 自己完成扫码登录、长轮询收消息，并把微信私聊文本路由到 agent，再把 agent 文本回复发回微信。
+
+目前已支持：
+
+- 扫码登录微信账号
+- 本地持久化微信账号 token / `get_updates_buf`
+- 后台长轮询 `getupdates`
+- 按 `账号 + 对端用户` 自动创建独立 agent 会话
+- 文本消息进 agent、agent 文本回复回微信
+
+当前限制：
+
+- 只支持私聊文本消息
+- 还没有做图片 / 文件 / 语音 / 视频收发
+- 还没有做 typing 状态、复杂多账号路由和精细权限策略
+
+要启用它，在 `~/.paseo/config.json` 的 `channels.wechat` 中加入一段配置：
+
+```json
+{
+  "channels": {
+    "wechat": {
+      "enabled": true,
+      "autoStart": true,
+      "provider": "codex",
+      "cwd": "/absolute/path/to/your/workspace",
+      "modeId": "auto"
+    }
+  }
+}
+```
+
+启动 daemon 后，可用以下接口完成首次绑定：
+
+```bash
+# 1. 获取二维码
+curl -X POST http://127.0.0.1:6767/api/wechat/login/start
+
+# 2. 等待扫码确认
+curl -X POST http://127.0.0.1:6767/api/wechat/login/wait \\
+  -H 'Content-Type: application/json' \\
+  -d '{\"sessionKey\":\"<上一步返回的 sessionKey>\"}'
+
+# 3. 查看已登录账号
+curl http://127.0.0.1:6767/api/wechat/accounts
+```
+
+如果你已经装好了 CLI，也可以直接在终端里扫码登录：
+
+```bash
+# 子命令形式
+paseo wechat login
+
+# 顶层快捷命令
+paseo wechat-login
+```
+
+如果 daemon 不在默认地址：
+
+```bash
+paseo wechat-login --host 127.0.0.1:6767
+```
 
 ## CLI
 
-Everything you can do in the app, you can do from the terminal.
+应用里能做的事情，基本都可以在终端里完成。
 
 ```bash
 paseo run --provider claude/opus-4.6 "implement user authentication"
 paseo run --provider codex/gpt-5.4 --worktree feature-x "implement feature X"
 
-paseo ls                           # list running agents
-paseo attach abc123                # stream live output
-paseo send abc123 "also add tests" # follow-up task
+paseo ls                           # 列出正在运行的代理
+paseo attach abc123                # 实时查看输出流
+paseo send abc123 "also add tests" # 继续补充后续任务
 
-# run on a remote daemon
+# 在远程 daemon 上运行
 paseo --host workstation.local:6767 run "run the full test suite"
 ```
 
-See the [full CLI reference](https://paseo.sh/docs/cli) for more.
+更多内容请参考 [完整 CLI 文档](https://paseo.sh/docs/cli)。
 
-## Orchestration skills (Unstable)
+## 编排技能（不稳定）
 
-Experimental skills that teach agents how to use the Paseo CLI to orchestrate other agents. I am updating these very frequently as I learn new things, expect changes without notice, might be coupled to my own setup, use at your own risk.
+这里提供了一些实验性技能，教代理如何使用 Paseo CLI 去编排其他代理。我还在持续快速迭代这些技能，接口和行为可能随时变化，也可能和我自己的使用环境耦合，请自行评估风险。
 
 ```bash
 npx skills add getpaseo/paseo
 ```
 
-Then use them in any agent conversation:
+然后你就可以在任意代理对话中这样使用：
 
 ```bash
-# Use handoff when you discuss something with an agent but want another one to implement.
-# I use this to plan with Claude and then handoff to Codex to implement.
+# handoff 适合你先和一个代理讨论，再把实现工作交给另一个代理。
+# 例如先用 Claude 做规划，再交给 Codex 实现。
 /paseo-handoff hand off the authentication fix to codex 5.4 in a worktree
 
-# Use loops when you have clear acceptance criteria (aka Ralph loops).
+# loop 适合有明确验收标准的循环任务（也就是 Ralph loops）。
 /paseo-loop loop a codex agent to fix the backend tests, use sonnet to verify, max 10 iterations
 
-# Orchestrator teaches the agent how to create teams and manage them via a chat room.
-# Very opinionated and expects both Codex and Claude to work.
+# orchestrator 用于拉起一个团队，并通过聊天室协调多个代理协作。
+# 这个模式偏强约束，默认假设 Claude 和 Codex 都可用。
 /paseo-orchestrator spin up a team to implement the database refactor, use chat to coordinate. use claude to plan and codex to implement and review
 ```
 
-## Development
+## 开发
 
-Quick monorepo package map:
-- `packages/server`: Paseo daemon (agent process orchestration, WebSocket API, MCP server)
-- `packages/app`: Expo client (iOS, Android, web)
-- `packages/cli`: `paseo` CLI for daemon and agent workflows
-- `packages/desktop`: Electron desktop app
-- `packages/relay`: Relay package for remote connectivity
-- `packages/website`: Marketing site and documentation (`paseo.sh`)
+Monorepo 中各主要包的职责如下：
+- `packages/server`: Paseo daemon，负责代理进程编排、WebSocket API 和 MCP 服务
+- `packages/app`: Expo 客户端（iOS、Android、Web）
+- `packages/cli`: `paseo` CLI，用于 daemon 和代理工作流操作
+- `packages/desktop`: Electron 桌面应用
+- `packages/relay`: 用于远程连接的 Relay 包
+- `packages/website`: 官网与文档站点（`paseo.sh`）
 
-Common commands:
+常用命令：
 
 ```bash
-# run all local dev services
+# 启动所有本地开发服务
 npm run dev
 
-# run individual surfaces
+# 分别启动单个端
 npm run dev:server
 npm run dev:app
 npm run dev:desktop
 npm run dev:website
 
-# build the daemon
+# 构建 daemon
 npm run build:daemon
 
-# repo-wide checks
+# 仓库级类型检查
 npm run typecheck
 ```
 
-## License
+## 许可证
 
 AGPL-3.0

--- a/README.md
+++ b/README.md
@@ -137,7 +137,17 @@ paseo wechat-login
 paseo wechat-login --host 127.0.0.1:6767
 ```
 
-## CLI
+登录完成后，可以继续用下面两条命令查看状态：
+
+```bash
+# 查看已登录微信账号和在线状态
+paseo wechat status
+
+# 查看“微信用户 -> agent 会话”的映射关系
+paseo wechat sessions
+```
+
+## 命令行（CLI）
 
 应用里能做的事情，基本都可以在终端里完成。
 
@@ -205,6 +215,16 @@ npm run build:daemon
 
 # 仓库级类型检查
 npm run typecheck
+```
+
+如果你要在 macOS 上本地构建桌面安装包，可以使用：
+
+```bash
+# 先构建 Web 资源
+npm run build:web --workspace=@getpaseo/app
+
+# 再构建桌面安装包（Apple Silicon 示例）
+npm run build --workspace=@getpaseo/desktop -- --publish never --mac --arm64 -c.mac.notarize=false -c.mac.identity=null
 ```
 
 ## 许可证

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@
 <p align="center">统一管理 Claude Code、Codex 和 OpenCode 代理的单一界面。</p>
 
 <p align="center">
-  <img src="https://paseo.sh/hero-mockup.png" alt="Paseo app screenshot" width="100%">
+  <img src="https://paseo.sh/hero-mockup.png" alt="Paseo 应用截图" width="100%">
 </p>
 
 <p align="center">
-  <img src="https://paseo.sh/mobile-mockup.png" alt="Paseo mobile app" width="100%">
+  <img src="https://paseo.sh/mobile-mockup.png" alt="Paseo 移动端应用" width="100%">
 </p>
 
 ---
@@ -34,7 +34,7 @@
 让多个代理在你自己的机器上并行运行。无论你在手机前还是电脑前，都能随时推进工作。
 
 - **自托管：** 代理直接运行在你的机器上，使用你现有的开发环境、工具、配置和技能。
-- **多 Provider：** 在同一个界面中统一接入 Claude Code、Codex 和 OpenCode，为不同任务选择合适的模型。
+- **多 Provider：** 在同一个界面中统一接入 Claude Code、Codex 和 OpenCode，为不同任务选择合适的模型与代理。
 - **语音控制：** 可通过语音输入任务或边说边梳理问题，需要时可以解放双手。
 - **跨设备：** 支持 iOS、Android、桌面端、Web 和 CLI。你可以在桌面上开始任务，在手机上查看进度，也可以在终端里脚本化操作。
 - **隐私优先：** Paseo 不包含遥测、追踪或强制登录。
@@ -121,17 +121,17 @@ curl -X POST http://127.0.0.1:6767/api/wechat/login/wait \\
 curl http://127.0.0.1:6767/api/wechat/accounts
 ```
 
-如果你已经装好了 CLI，也可以直接在终端里扫码登录：
+如果你已经装好了 CLI，也可以直接在终端中扫码登录：
 
 ```bash
-# 子命令形式
+# 子命令方式
 paseo wechat login
 
 # 顶层快捷命令
 paseo wechat-login
 ```
 
-如果 daemon 不在默认地址：
+如果 daemon 不在默认地址，可以显式指定：
 
 ```bash
 paseo wechat-login --host 127.0.0.1:6767
@@ -152,22 +152,22 @@ paseo wechat sessions
 应用里能做的事情，基本都可以在终端里完成。
 
 ```bash
-paseo run --provider claude/opus-4.6 "implement user authentication"
-paseo run --provider codex/gpt-5.4 --worktree feature-x "implement feature X"
+paseo run --provider claude/opus-4.6 "实现用户认证"
+paseo run --provider codex/gpt-5.4 --worktree feature-x "实现功能 X"
 
-paseo ls                           # 列出正在运行的代理
-paseo attach abc123                # 实时查看输出流
-paseo send abc123 "also add tests" # 继续补充后续任务
+paseo ls                       # 列出正在运行的代理
+paseo attach abc123            # 实时查看输出流
+paseo send abc123 "顺便补上测试" # 继续追加后续任务
 
 # 在远程 daemon 上运行
-paseo --host workstation.local:6767 run "run the full test suite"
+paseo --host workstation.local:6767 run "运行完整测试套件"
 ```
 
 更多内容请参考 [完整 CLI 文档](https://paseo.sh/docs/cli)。
 
 ## 编排技能（不稳定）
 
-这里提供了一些实验性技能，教代理如何使用 Paseo CLI 去编排其他代理。我还在持续快速迭代这些技能，接口和行为可能随时变化，也可能和我自己的使用环境耦合，请自行评估风险。
+这里提供了一些实验性技能，用来教代理如何通过 Paseo CLI 编排其他代理。我还在持续快速迭代这些技能，接口和行为可能随时变化，也可能和我自己的使用环境耦合，请自行评估风险。
 
 ```bash
 npx skills add getpaseo/paseo
@@ -176,24 +176,24 @@ npx skills add getpaseo/paseo
 然后你就可以在任意代理对话中这样使用：
 
 ```bash
-# handoff 适合你先和一个代理讨论，再把实现工作交给另一个代理。
+# handoff 适合先和一个代理讨论，再把实现工作交给另一个代理。
 # 例如先用 Claude 做规划，再交给 Codex 实现。
-/paseo-handoff hand off the authentication fix to codex 5.4 in a worktree
+/paseo-handoff 把认证修复任务交给 codex 5.4，在 worktree 里完成
 
 # loop 适合有明确验收标准的循环任务（也就是 Ralph loops）。
-/paseo-loop loop a codex agent to fix the backend tests, use sonnet to verify, max 10 iterations
+/paseo-loop 循环运行一个 codex agent 来修复后端测试，用 sonnet 做校验，最多 10 轮
 
 # orchestrator 用于拉起一个团队，并通过聊天室协调多个代理协作。
-# 这个模式偏强约束，默认假设 Claude 和 Codex 都可用。
-/paseo-orchestrator spin up a team to implement the database refactor, use chat to coordinate. use claude to plan and codex to implement and review
+# 这个模式约束更强，默认假设 Claude 和 Codex 都可用。
+/paseo-orchestrator 拉起一个团队来完成数据库重构，用聊天协调；用 claude 做规划，用 codex 做实现和 review
 ```
 
 ## 开发
 
-Monorepo 中各主要包的职责如下：
+Monorepo（单仓库）中各主要包的职责如下：
 - `packages/server`: Paseo daemon，负责代理进程编排、WebSocket API 和 MCP 服务
 - `packages/app`: Expo 客户端（iOS、Android、Web）
-- `packages/cli`: `paseo` CLI，用于 daemon 和代理工作流操作
+- `packages/cli`: `paseo` CLI，用于 daemon 管理与代理工作流操作
 - `packages/desktop`: Electron 桌面应用
 - `packages/relay`: 用于远程连接的 Relay 包
 - `packages/website`: 官网与文档站点（`paseo.sh`）

--- a/package-lock.json
+++ b/package-lock.json
@@ -37464,6 +37464,7 @@
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "mime-types": "^2.1.35",
+        "qrcode": "^1.5.4",
         "ws": "^8.14.2",
         "yaml": "^2.8.2"
       },
@@ -37472,6 +37473,7 @@
       },
       "devDependencies": {
         "@types/mime-types": "^3.0.1",
+        "@types/qrcode": "^1.5.6",
         "@types/ws": "^8.5.8",
         "tsx": "^4.6.0",
         "typescript": "^5.2.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,11 +29,13 @@
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "mime-types": "^2.1.35",
+    "qrcode": "^1.5.4",
     "ws": "^8.14.2",
     "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/mime-types": "^3.0.1",
+    "@types/qrcode": "^1.5.6",
     "@types/ws": "^8.5.8",
     "tsx": "^4.6.0",
     "typescript": "^5.2.2",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,8 @@ import { createProviderCommand } from "./commands/provider/index.js";
 import { createScheduleCommand } from "./commands/schedule/index.js";
 import { createSpeechCommand } from "./commands/speech/index.js";
 import { createTerminalCommand } from "./commands/terminal/index.js";
+import { addWeChatLoginOptions, createWeChatCommand } from "./commands/wechat/index.js";
+import { runWeChatLoginCommand } from "./commands/wechat/login.js";
 import { createWorktreeCommand } from "./commands/worktree/index.js";
 import { startCommand as daemonStartCommand } from "./commands/daemon/start.js";
 import { runStatusCommand as runDaemonStatusCommand } from "./commands/daemon/status.js";
@@ -172,6 +174,26 @@ export function createCli(): Command {
 
   // Speech model commands
   program.addCommand(createSpeechCommand());
+
+  // WeChat direct channel commands
+  program.addCommand(createWeChatCommand());
+  addWeChatLoginOptions(
+    program
+      .command("wechat-login")
+      .description('Show a WeChat QR code in the terminal (alias for "paseo wechat login")'),
+  ).action((options, command) => {
+    const commandWithGlobals = command as Command & {
+      optsWithGlobals?: () => Record<string, unknown>;
+    };
+    const mergedOptions =
+      typeof commandWithGlobals.optsWithGlobals === "function"
+        ? {
+            ...commandWithGlobals.optsWithGlobals(),
+            ...options,
+          }
+        : options;
+    return runWeChatLoginCommand(mergedOptions, command);
+  });
 
   // Worktree commands
   program.addCommand(createWorktreeCommand());

--- a/packages/cli/src/commands/wechat/http.ts
+++ b/packages/cli/src/commands/wechat/http.ts
@@ -1,0 +1,73 @@
+import http from "node:http";
+
+import { resolveDaemonTarget } from "../../utils/client.js";
+
+function requestText(
+  host: string,
+  method: "GET" | "POST",
+  pathname: string,
+  body?: Record<string, unknown>,
+): Promise<string> {
+  const target = resolveDaemonTarget(host);
+  const payload = body ? JSON.stringify(body) : null;
+
+  return new Promise<string>((resolve, reject) => {
+    const baseOptions =
+      target.type === "tcp"
+        ? {
+            host: new URL(target.url.replace(/^ws:/u, "http:")).hostname,
+            port: Number(new URL(target.url.replace(/^ws:/u, "http:")).port || 80),
+          }
+        : {
+            socketPath: target.socketPath,
+          };
+
+    const req = http.request(
+      {
+        ...baseOptions,
+        path: pathname,
+        method,
+        headers: payload
+          ? {
+              "Content-Type": "application/json",
+              "Content-Length": String(Buffer.byteLength(payload, "utf8")),
+            }
+          : undefined,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf8");
+          if ((res.statusCode ?? 500) >= 400) {
+            reject(new Error(text || `Daemon request failed with status ${res.statusCode}`));
+            return;
+          }
+          resolve(text);
+        });
+      },
+    );
+
+    req.on("error", reject);
+    if (payload) {
+      req.write(payload);
+    }
+    req.end();
+  });
+}
+
+export async function getDaemonJson<T>(host: string, pathname: string): Promise<T> {
+  const raw = await requestText(host, "GET", pathname);
+  return JSON.parse(raw) as T;
+}
+
+export async function postDaemonJson<T>(
+  host: string,
+  pathname: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const raw = await requestText(host, "POST", pathname, body);
+  return JSON.parse(raw) as T;
+}

--- a/packages/cli/src/commands/wechat/index.ts
+++ b/packages/cli/src/commands/wechat/index.ts
@@ -7,6 +7,7 @@ import {
 } from "../../utils/command-options.js";
 import { withOutput } from "../../output/index.js";
 import { runWeChatLoginCommand } from "./login.js";
+import { runWeChatSessionsCommand } from "./sessions.js";
 import { runWeChatStatusCommand } from "./status.js";
 
 export function addWeChatLoginOptions(command: Command): Command {
@@ -46,6 +47,12 @@ export function createWeChatCommand(): Command {
       .command("status")
       .description("Show connected WeChat accounts and runtime status"),
   ).action(withOutput(runWeChatStatusCommand));
+
+  addJsonAndDaemonHostOptions(
+    wechat
+      .command("sessions")
+      .description("Show WeChat peer-to-agent session mappings"),
+  ).action(withOutput(runWeChatSessionsCommand));
 
   return wechat;
 }

--- a/packages/cli/src/commands/wechat/index.ts
+++ b/packages/cli/src/commands/wechat/index.ts
@@ -1,0 +1,51 @@
+import { Command } from "commander";
+
+import {
+  addDaemonHostOption,
+  addJsonAndDaemonHostOptions,
+  addJsonOption,
+} from "../../utils/command-options.js";
+import { withOutput } from "../../output/index.js";
+import { runWeChatLoginCommand } from "./login.js";
+import { runWeChatStatusCommand } from "./status.js";
+
+export function addWeChatLoginOptions(command: Command): Command {
+  return addDaemonHostOption(addJsonOption(command))
+    .option("--timeout <seconds>", "Wait timeout in seconds before login fails (default: 240)")
+    .option("--bot-type <type>", "Optional upstream WeChat bot type override");
+}
+
+function mergeCommandOptions(options: Record<string, unknown>, command: Command): Record<string, unknown> {
+  const commandWithGlobals = command as Command & {
+    optsWithGlobals?: () => Record<string, unknown>;
+  };
+  const globalOptions =
+    typeof commandWithGlobals.optsWithGlobals === "function"
+      ? commandWithGlobals.optsWithGlobals()
+      : {};
+  return {
+    ...globalOptions,
+    ...options,
+  };
+}
+
+export function createWeChatCommand(): Command {
+  const wechat = new Command("wechat").description("Manage the WeChat direct channel");
+
+  addWeChatLoginOptions(
+    wechat
+      .command("login")
+      .description("Show a WeChat QR code in the terminal and wait for login"),
+  )
+    .action((options, command) =>
+      runWeChatLoginCommand(mergeCommandOptions(options, command), command),
+    );
+
+  addJsonAndDaemonHostOptions(
+    wechat
+      .command("status")
+      .description("Show connected WeChat accounts and runtime status"),
+  ).action(withOutput(runWeChatStatusCommand));
+
+  return wechat;
+}

--- a/packages/cli/src/commands/wechat/login.ts
+++ b/packages/cli/src/commands/wechat/login.ts
@@ -1,0 +1,102 @@
+import QRCode from "qrcode";
+import type { Command } from "commander";
+
+import { getDaemonHost } from "../../utils/client.js";
+import { postDaemonJson } from "./http.js";
+
+export interface WeChatLoginOptions {
+  host?: string;
+  timeout?: string;
+  json?: boolean;
+  botType?: string;
+}
+
+type StartLoginResponse = {
+  sessionKey?: string;
+  qrcodeUrl?: string;
+  message?: string;
+  error?: string;
+};
+
+type WaitLoginResponse = {
+  connected?: boolean;
+  accountId?: string;
+  userId?: string;
+  message?: string;
+  error?: string;
+};
+
+const DEFAULT_TIMEOUT_SECONDS = 240;
+
+function parseTimeoutMs(raw: string | undefined): number {
+  if (!raw || raw.trim().length === 0) {
+    return DEFAULT_TIMEOUT_SECONDS * 1000;
+  }
+
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new Error(`Invalid timeout value: ${raw}`);
+  }
+  return Math.ceil(seconds * 1000);
+}
+
+
+export async function runWeChatLoginCommand(options: WeChatLoginOptions, _command: Command): Promise<void> {
+  const host = getDaemonHost({ host: options.host });
+  const timeoutMs = parseTimeoutMs(options.timeout);
+
+  const start = await postDaemonJson<StartLoginResponse>(host, "/api/wechat/login/start", {
+    ...(options.botType?.trim() ? { botType: options.botType.trim() } : {}),
+  });
+
+  if (!start.sessionKey || !start.qrcodeUrl) {
+    throw new Error(start.error ?? start.message ?? "Failed to start WeChat login");
+  }
+
+  const qr = await QRCode.toString(start.qrcodeUrl, {
+    type: "terminal",
+    small: true,
+  });
+
+  if (!options.json) {
+    process.stdout.write("\nScan this WeChat QR code:\n");
+    process.stdout.write(`${qr}\n`);
+    process.stdout.write(`${start.qrcodeUrl}\n\n`);
+    process.stdout.write("Waiting for WeChat scan confirmation...\n");
+  }
+
+  const waitResult = await postDaemonJson<WaitLoginResponse>(host, "/api/wechat/login/wait", {
+    sessionKey: start.sessionKey,
+    timeoutMs,
+  });
+
+  if (!waitResult.connected) {
+    throw new Error(waitResult.error ?? waitResult.message ?? "WeChat login was not completed");
+  }
+
+  if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          sessionKey: start.sessionKey,
+          qrcodeUrl: start.qrcodeUrl,
+          connected: true,
+          accountId: waitResult.accountId ?? null,
+          userId: waitResult.userId ?? null,
+          message: waitResult.message ?? null,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    return;
+  }
+
+  process.stdout.write("\nWeChat login connected.\n");
+  if (waitResult.accountId) {
+    process.stdout.write(`Account: ${waitResult.accountId}\n`);
+  }
+  if (waitResult.userId) {
+    process.stdout.write(`User: ${waitResult.userId}\n`);
+  }
+}

--- a/packages/cli/src/commands/wechat/sessions.ts
+++ b/packages/cli/src/commands/wechat/sessions.ts
@@ -1,0 +1,89 @@
+import type { Command } from "commander";
+
+import type { CommandOptions, ListResult, OutputSchema } from "../../output/index.js";
+import { getDaemonHost } from "../../utils/client.js";
+import { getDaemonJson } from "./http.js";
+
+interface WeChatSessionItem {
+  accountId: string;
+  accountUserId?: string | null;
+  peerId: string;
+  agentId: string;
+  agentTitle?: string | null;
+  agentStatus?: string | null;
+  contextTokenPresent: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface WeChatSessionsResponse {
+  sessions?: WeChatSessionItem[];
+}
+
+interface WeChatSessionRow {
+  agentId: string;
+  account: string;
+  peer: string;
+  title: string;
+  status: string;
+  context: string;
+  updatedAt: string;
+}
+
+function formatValue(value?: string | null): string {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : "-";
+}
+
+function toSessionRows(sessions: WeChatSessionItem[]): WeChatSessionRow[] {
+  return sessions.map((session) => ({
+    agentId: session.agentId,
+    account: session.accountUserId?.trim() || session.accountId,
+    peer: session.peerId,
+    title: formatValue(session.agentTitle),
+    status: formatValue(session.agentStatus),
+    context: session.contextTokenPresent ? "yes" : "no",
+    updatedAt: formatValue(session.updatedAt),
+  }));
+}
+
+function createSessionsSchema(sessions: WeChatSessionItem[]): OutputSchema<WeChatSessionRow> {
+  return {
+    idField: "agentId",
+    columns: [
+      { header: "AGENT", field: "agentId" },
+      { header: "ACCOUNT", field: "account" },
+      { header: "PEER", field: "peer" },
+      { header: "TITLE", field: "title" },
+      {
+        header: "STATUS",
+        field: "status",
+        color: (value) => {
+          if (value === "idle") return "green";
+          if (value === "running" || value === "initializing") return "yellow";
+          if (value === "error") return "red";
+          return undefined;
+        },
+      },
+      { header: "CTX", field: "context" },
+      { header: "UPDATED", field: "updatedAt" },
+    ],
+    serialize: () => ({ sessions }),
+  };
+}
+
+export type WeChatSessionsResult = ListResult<WeChatSessionRow>;
+
+export async function runWeChatSessionsCommand(
+  options: CommandOptions,
+  _command: Command,
+): Promise<WeChatSessionsResult> {
+  const host = getDaemonHost({ host: typeof options.host === "string" ? options.host : undefined });
+  const response = await getDaemonJson<WeChatSessionsResponse>(host, "/api/wechat/sessions");
+  const sessions = Array.isArray(response.sessions) ? response.sessions : [];
+
+  return {
+    type: "list",
+    data: toSessionRows(sessions),
+    schema: createSessionsSchema(sessions),
+  };
+}

--- a/packages/cli/src/commands/wechat/status.ts
+++ b/packages/cli/src/commands/wechat/status.ts
@@ -1,0 +1,103 @@
+import type { Command } from "commander";
+
+import type { CommandOptions, ListResult, OutputSchema } from "../../output/index.js";
+import { getDaemonHost } from "../../utils/client.js";
+import { getDaemonJson } from "./http.js";
+
+interface WeChatAccountStatus {
+  id: string;
+  rawAccountId: string;
+  userId?: string;
+  baseUrl: string;
+  enabled: boolean;
+  running: boolean;
+  createdAt: string;
+  updatedAt: string;
+  getUpdatesBuf?: string;
+  lastInboundAt?: string;
+  lastOutboundAt?: string;
+  lastError?: string | null;
+}
+
+interface WeChatAccountsResponse {
+  accounts?: WeChatAccountStatus[];
+}
+
+interface WeChatStatusRow {
+  id: string;
+  user: string;
+  running: string;
+  enabled: string;
+  lastInbound: string;
+  lastOutbound: string;
+  error: string;
+}
+
+function formatTimestamp(value?: string): string {
+  return typeof value === "string" && value.trim().length > 0 ? value : "-";
+}
+
+function formatError(value?: string | null): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return "-";
+  }
+  const normalized = value.replace(/\s+/gu, " ").trim();
+  return normalized.length <= 96 ? normalized : `${normalized.slice(0, 93)}...`;
+}
+
+function toStatusRows(accounts: WeChatAccountStatus[]): WeChatStatusRow[] {
+  return accounts.map((account) => ({
+    id: account.id,
+    user: account.userId?.trim() || account.rawAccountId,
+    running: account.running ? "yes" : "no",
+    enabled: account.enabled ? "yes" : "no",
+    lastInbound: formatTimestamp(account.lastInboundAt),
+    lastOutbound: formatTimestamp(account.lastOutboundAt),
+    error: formatError(account.lastError),
+  }));
+}
+
+function createStatusSchema(accounts: WeChatAccountStatus[]): OutputSchema<WeChatStatusRow> {
+  return {
+    idField: "id",
+    columns: [
+      { header: "ACCOUNT", field: "id" },
+      { header: "USER", field: "user" },
+      {
+        header: "RUNNING",
+        field: "running",
+        color: (value) => (value === "yes" ? "green" : "red"),
+      },
+      {
+        header: "ENABLED",
+        field: "enabled",
+        color: (value) => (value === "yes" ? "green" : "yellow"),
+      },
+      { header: "LAST IN", field: "lastInbound" },
+      { header: "LAST OUT", field: "lastOutbound" },
+      {
+        header: "ERROR",
+        field: "error",
+        color: (value) => (value === "-" ? undefined : "red"),
+      },
+    ],
+    serialize: () => ({ accounts }),
+  };
+}
+
+export type WeChatStatusResult = ListResult<WeChatStatusRow>;
+
+export async function runWeChatStatusCommand(
+  options: CommandOptions,
+  _command: Command,
+): Promise<WeChatStatusResult> {
+  const host = getDaemonHost({ host: typeof options.host === "string" ? options.host : undefined });
+  const response = await getDaemonJson<WeChatAccountsResponse>(host, "/api/wechat/accounts");
+  const accounts = Array.isArray(response.accounts) ? response.accounts : [];
+
+  return {
+    type: "list",
+    data: toStatusRows(accounts),
+    schema: createStatusSchema(accounts),
+  };
+}

--- a/packages/cli/tests/33-wechat.test.ts
+++ b/packages/cli/tests/33-wechat.test.ts
@@ -1,0 +1,205 @@
+#!/usr/bin/env npx tsx
+
+import assert from "node:assert";
+import { execFile } from "node:child_process";
+import http from "node:http";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const CLI_SOURCE_ENTRY = join(import.meta.dirname, "..", "src", "index.ts");
+const execFileAsync = promisify(execFile);
+
+console.log("=== WeChat Commands ===\n");
+
+async function runCli(args: string[]): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      ["./node_modules/.bin/tsx", CLI_SOURCE_ENTRY, ...args],
+      {
+        cwd: process.cwd(),
+        env: process.env,
+      },
+    );
+    return { exitCode: 0, stdout, stderr };
+  } catch (error) {
+    const failure = error as {
+      code?: number;
+      stdout?: string;
+      stderr?: string;
+    };
+    return {
+      exitCode: typeof failure.code === "number" ? failure.code : 1,
+      stdout: failure.stdout ?? "",
+      stderr: failure.stderr ?? "",
+    };
+  }
+}
+
+const requests: Array<{ path: string; body: Record<string, unknown> | null }> = [];
+
+const server = http.createServer((req, res) => {
+  const chunks: Buffer[] = [];
+  req.on("data", (chunk) => {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  });
+  req.on("end", () => {
+    const raw = Buffer.concat(chunks).toString("utf8");
+    const body = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+    requests.push({ path: req.url ?? "", body });
+
+    if (req.method === "POST" && req.url === "/api/wechat/login/start") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          sessionKey: "wechat-session-1",
+          qrcodeUrl: "https://example.com/wechat-qr",
+        }),
+      );
+      return;
+    }
+
+    if (req.method === "POST" && req.url === "/api/wechat/login/wait") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          connected: true,
+          accountId: "bot123-im-bot",
+          userId: "owner@im.wechat",
+          message: "ok",
+        }),
+      );
+      return;
+    }
+
+    if (req.method === "GET" && req.url === "/api/wechat/accounts") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          accounts: [
+            {
+              id: "bot123-im-bot",
+              rawAccountId: "bot123@im.bot",
+              userId: "owner@im.wechat",
+              baseUrl: "https://ilinkai.weixin.qq.com",
+              enabled: true,
+              running: true,
+              createdAt: "2026-04-20T12:00:00.000Z",
+              updatedAt: "2026-04-20T12:01:00.000Z",
+              lastInboundAt: "2026-04-20T12:02:00.000Z",
+              lastOutboundAt: "2026-04-20T12:03:00.000Z",
+              lastError: null,
+            },
+          ],
+        }),
+      );
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not found" }));
+  });
+});
+
+await new Promise<void>((resolve) => {
+  server.listen(0, "127.0.0.1", () => resolve());
+});
+
+const address = server.address();
+if (!address || typeof address === "string") {
+  throw new Error("Failed to resolve test server port");
+}
+
+try {
+  // Test 1: help should expose the login command
+  {
+    console.log("Test 1: wechat --help shows login subcommand");
+    const result = await runCli(["wechat", "--help"]);
+    assert.strictEqual(result.exitCode, 0, "wechat --help should exit 0");
+    assert(result.stdout.includes("login"), "help should mention login subcommand");
+    console.log("✓ wechat --help shows login subcommand\n");
+  }
+
+  // Test 2: login renders qr and waits for success
+  {
+    console.log("Test 2: wechat login prints QR and completes login flow");
+    const result = await runCli([
+      "wechat",
+      "login",
+      "--host",
+      `127.0.0.1:${address.port}`,
+      "--timeout",
+      "2",
+    ]);
+    assert.strictEqual(result.exitCode, 0, "wechat login should succeed");
+    assert(result.stdout.includes("Scan this WeChat QR code:"), "output should include QR header");
+    assert(result.stdout.includes("https://example.com/wechat-qr"), "output should include QR URL");
+    assert(result.stdout.includes("WeChat login connected."), "output should confirm success");
+    assert(result.stdout.includes("Account: bot123-im-bot"), "output should include account ID");
+    assert(result.stdout.includes("User: owner@im.wechat"), "output should include user ID");
+    assert.strictEqual(requests.length, 2, "command should call start and wait endpoints");
+    assert.strictEqual(requests[0]?.path, "/api/wechat/login/start");
+    assert.strictEqual(requests[1]?.path, "/api/wechat/login/wait");
+    assert.strictEqual(requests[1]?.body?.sessionKey, "wechat-session-1");
+    assert.strictEqual(requests[1]?.body?.timeoutMs, 2000);
+    console.log("✓ wechat login prints QR and completes login flow\n");
+  }
+
+  // Test 3: top-level alias should complete the same flow
+  {
+    console.log("Test 3: wechat-login alias completes login flow");
+    const result = await runCli([
+      "wechat-login",
+      "--host",
+      `127.0.0.1:${address.port}`,
+      "--timeout",
+      "2",
+      "--json",
+    ]);
+    assert.strictEqual(result.exitCode, 0, "wechat-login should succeed");
+    const payload = JSON.parse(result.stdout);
+    assert.strictEqual(payload.connected, true, "json output should report success");
+    assert.strictEqual(payload.accountId, "bot123-im-bot");
+    assert.strictEqual(payload.userId, "owner@im.wechat");
+    assert.strictEqual(requests[2]?.path, "/api/wechat/login/start");
+    assert.strictEqual(requests[3]?.path, "/api/wechat/login/wait");
+    assert.strictEqual(requests[3]?.body?.timeoutMs, 2000);
+    console.log("✓ wechat-login alias completes login flow\n");
+  }
+  // Test 4: status should list connected accounts
+  {
+    console.log("Test 4: wechat status lists connected accounts");
+    const result = await runCli([
+      "wechat",
+      "status",
+      "--host",
+      `127.0.0.1:${address.port}`,
+      "--json",
+    ]);
+    assert.strictEqual(result.exitCode, 0, "wechat status should succeed");
+    const payload = JSON.parse(result.stdout);
+    assert(Array.isArray(payload.accounts), "json output should contain accounts array");
+    assert.strictEqual(payload.accounts.length, 1, "status should return one account");
+    assert.strictEqual(payload.accounts[0]?.id, "bot123-im-bot");
+    assert.strictEqual(payload.accounts[0]?.running, true);
+    assert.strictEqual(payload.accounts[0]?.enabled, true);
+    assert.strictEqual(requests[4]?.path, "/api/wechat/accounts");
+    console.log("✓ wechat status lists connected accounts\n");
+  }
+} finally {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+console.log("=== All WeChat tests passed ===");

--- a/packages/cli/tests/33-wechat.test.ts
+++ b/packages/cli/tests/33-wechat.test.ts
@@ -100,6 +100,28 @@ const server = http.createServer((req, res) => {
       return;
     }
 
+    if (req.method === "GET" && req.url === "/api/wechat/sessions") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          sessions: [
+            {
+              accountId: "bot123-im-bot",
+              accountUserId: "owner@im.wechat",
+              peerId: "user001@im.wechat",
+              agentId: "agent-1",
+              agentTitle: "WeChat user001@im.wechat",
+              agentStatus: "idle",
+              contextTokenPresent: true,
+              createdAt: "2026-04-20T12:00:00.000Z",
+              updatedAt: "2026-04-20T12:03:00.000Z",
+            },
+          ],
+        }),
+      );
+      return;
+    }
+
     res.writeHead(404, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "not found" }));
   });
@@ -189,6 +211,27 @@ try {
     assert.strictEqual(payload.accounts[0]?.enabled, true);
     assert.strictEqual(requests[4]?.path, "/api/wechat/accounts");
     console.log("✓ wechat status lists connected accounts\n");
+  }
+
+  // Test 5: sessions should list peer-to-agent mappings
+  {
+    console.log("Test 5: wechat sessions lists peer mappings");
+    const result = await runCli([
+      "wechat",
+      "sessions",
+      "--host",
+      `127.0.0.1:${address.port}`,
+      "--json",
+    ]);
+    assert.strictEqual(result.exitCode, 0, "wechat sessions should succeed");
+    const payload = JSON.parse(result.stdout);
+    assert(Array.isArray(payload.sessions), "json output should contain sessions array");
+    assert.strictEqual(payload.sessions.length, 1, "sessions should return one mapping");
+    assert.strictEqual(payload.sessions[0]?.agentId, "agent-1");
+    assert.strictEqual(payload.sessions[0]?.peerId, "user001@im.wechat");
+    assert.strictEqual(payload.sessions[0]?.agentStatus, "idle");
+    assert.strictEqual(requests[5]?.path, "/api/wechat/sessions");
+    console.log("✓ wechat sessions lists peer mappings\n");
   }
 } finally {
   await new Promise<void>((resolve, reject) => {

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -132,6 +132,8 @@ import { ScriptHealthMonitor } from "./script-health-monitor.js";
 import { createScriptStatusEmitter } from "./script-status-projection.js";
 import { WorkspaceScriptRuntimeStore } from "./workspace-script-runtime-store.js";
 import { isHostnameAllowed, type HostnamesConfig } from "./hostnames.js";
+import { PaseoWeChatService } from "./wechat/service.js";
+import type { PaseoWeChatConfig } from "./wechat/types.js";
 
 type AgentMcpTransportMap = Map<string, StreamableHTTPServerTransport>;
 
@@ -196,6 +198,7 @@ export type PaseoDaemonConfig = {
   downloadTokenTtlMs?: number;
   agentProviderSettings?: AgentProviderRuntimeSettingsMap;
   providerOverrides?: Record<string, ProviderOverride>;
+  wechat?: PaseoWeChatConfig;
   onLifecycleIntent?: (intent: DaemonLifecycleIntent) => void;
 };
 
@@ -433,6 +436,15 @@ export async function createPaseoDaemon(
       registry: agentStorage,
       logger,
     });
+    const wechatService = config.wechat
+      ? new PaseoWeChatService({
+          paseoHome: config.paseoHome,
+          config: config.wechat,
+          agentManager,
+          agentStorage,
+          logger,
+        })
+      : null;
     const providerRegistry = buildProviderRegistry(logger, {
       runtimeSettings: config.agentProviderSettings,
       providerOverrides: config.providerOverrides,
@@ -458,6 +470,14 @@ export async function createPaseoDaemon(
     logger.info({ elapsed: elapsed() }, "Workspace registries bootstrapped");
     await chatService.initialize();
     logger.info({ elapsed: elapsed() }, "Chat service initialized");
+    await wechatService?.initialize();
+    if (wechatService) {
+      app.get("/api/wechat/accounts", wechatService.listAccountsHandler());
+      app.post("/api/wechat/login/start", wechatService.startLoginHandler());
+      app.post("/api/wechat/login/wait", wechatService.waitLoginHandler());
+      logger.info("WeChat HTTP endpoints mounted on main app");
+      logger.info({ elapsed: elapsed() }, "WeChat service initialized");
+    }
     const checkoutDiffManager = new CheckoutDiffManager({
       logger,
       paseoHome: config.paseoHome,
@@ -789,10 +809,12 @@ export async function createPaseoDaemon(
       // model loading doesn't block the server from accepting connections.
       speechService.start();
       scriptHealthMonitor.start();
+      await wechatService?.start();
     };
 
     const stop = async () => {
       scriptHealthMonitor.stop();
+      await wechatService?.stop().catch(() => undefined);
       await closeAllAgents(logger, agentManager);
       await agentManager.flush().catch(() => undefined);
       detachAgentStoragePersistence();

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -473,6 +473,7 @@ export async function createPaseoDaemon(
     await wechatService?.initialize();
     if (wechatService) {
       app.get("/api/wechat/accounts", wechatService.listAccountsHandler());
+      app.get("/api/wechat/sessions", wechatService.listSessionsHandler());
       app.post("/api/wechat/login/start", wechatService.startLoginHandler());
       app.post("/api/wechat/login/wait", wechatService.waitLoginHandler());
       logger.info("WeChat HTTP endpoints mounted on main app");

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -12,6 +12,7 @@ import { ProviderOverrideSchema } from "./agent/provider-launch-config.js";
 import { AgentProviderSchema } from "./agent/provider-manifest.js";
 import { resolveSpeechConfig } from "./speech/speech-config-resolver.js";
 import { mergeHostnames, parseHostnamesEnv, type HostnamesConfig } from "./hostnames.js";
+import type { PaseoWeChatConfig } from "./wechat/types.js";
 
 const DEFAULT_PORT = 6767;
 const DEFAULT_RELAY_ENDPOINT = "relay.paseo.sh:443";
@@ -102,6 +103,60 @@ function extractAgentProviderSettings(
     : undefined;
 }
 
+function resolveWeChatConfig(
+  value: Record<string, unknown> | undefined,
+  cwdFallback: string,
+): PaseoWeChatConfig {
+  const enabled = value?.enabled === true;
+  const autoStart = value?.autoStart !== false;
+  const provider =
+    typeof value?.provider === "string" && value.provider.trim().length > 0
+      ? value.provider.trim()
+      : "codex";
+  const cwd =
+    typeof value?.cwd === "string" && value.cwd.trim().length > 0
+      ? value.cwd.trim()
+      : cwdFallback;
+
+  return {
+    enabled,
+    autoStart,
+    provider,
+    cwd,
+    modeId: typeof value?.modeId === "string" ? value.modeId.trim() || undefined : undefined,
+    model:
+      typeof value?.model === "string" && value.model.trim().length > 0
+        ? value.model.trim()
+        : null,
+    systemPrompt:
+      typeof value?.systemPrompt === "string" && value.systemPrompt.trim().length > 0
+        ? value.systemPrompt
+        : undefined,
+    approvalPolicy:
+      typeof value?.approvalPolicy === "string" && value.approvalPolicy.trim().length > 0
+        ? value.approvalPolicy.trim()
+        : undefined,
+    sandboxMode:
+      typeof value?.sandboxMode === "string" && value.sandboxMode.trim().length > 0
+        ? value.sandboxMode.trim()
+        : undefined,
+    networkAccess: value?.networkAccess === true,
+    webSearch: value?.webSearch === true,
+    qrApiBaseUrl:
+      typeof value?.qrApiBaseUrl === "string" && value.qrApiBaseUrl.trim().length > 0
+        ? value.qrApiBaseUrl.trim()
+        : undefined,
+    apiBaseUrl:
+      typeof value?.apiBaseUrl === "string" && value.apiBaseUrl.trim().length > 0
+        ? value.apiBaseUrl.trim()
+        : undefined,
+    pollTimeoutMs:
+      typeof value?.pollTimeoutMs === "number" && Number.isFinite(value.pollTimeoutMs)
+        ? value.pollTimeoutMs
+        : undefined,
+  };
+}
+
 export function loadConfig(
   paseoHome: string,
   options?: {
@@ -170,6 +225,10 @@ export function loadConfig(
   const providerOverrides = extractProviderOverrides(
     persisted.agents?.providers as Record<string, unknown> | undefined,
   );
+  const wechat = resolveWeChatConfig(
+    persisted.channels?.wechat as Record<string, unknown> | undefined,
+    process.cwd(),
+  );
 
   return {
     listen,
@@ -196,5 +255,6 @@ export function loadConfig(
     voiceLlmModel,
     agentProviderSettings: extractAgentProviderSettings(providerOverrides),
     providerOverrides,
+    wechat,
   };
 }

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -118,6 +118,25 @@ const FeatureVoiceModeSchema = z
   })
   .strict();
 
+const WeChatChannelSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    autoStart: z.boolean().optional(),
+    provider: z.string().min(1).optional(),
+    cwd: z.string().min(1).optional(),
+    modeId: z.string().min(1).optional(),
+    model: z.string().min(1).optional(),
+    systemPrompt: z.string().min(1).optional(),
+    approvalPolicy: z.string().min(1).optional(),
+    sandboxMode: z.string().min(1).optional(),
+    networkAccess: z.boolean().optional(),
+    webSearch: z.boolean().optional(),
+    qrApiBaseUrl: z.string().min(1).optional(),
+    apiBaseUrl: z.string().min(1).optional(),
+    pollTimeoutMs: z.number().int().positive().optional(),
+  })
+  .strict();
+
 const BUILTIN_PROVIDER_IDS = ["claude", "codex", "copilot", "opencode", "pi"] as const;
 const PROVIDER_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
 
@@ -267,6 +286,12 @@ export const PersistedConfigSchema = z
       .optional(),
 
     providers: ProvidersSchema.optional(),
+    channels: z
+      .object({
+        wechat: WeChatChannelSchema.optional(),
+      })
+      .strict()
+      .optional(),
     agents: z
       .object({
         providers: z.preprocess(normalizeAgentProviders, ProviderOverridesSchema).optional(),

--- a/packages/server/src/server/test-utils/paseo-daemon.ts
+++ b/packages/server/src/server/test-utils/paseo-daemon.ts
@@ -11,6 +11,7 @@ import {
 } from "../bootstrap.js";
 import type { AgentClient, AgentProvider } from "../agent/agent-sdk-types.js";
 import { createTestAgentClients } from "./fake-agent-client.js";
+import type { PaseoWeChatConfig } from "../wechat/types.js";
 
 type TestPaseoDaemonOptions = {
   downloadTokenTtlMs?: number;
@@ -29,6 +30,7 @@ type TestPaseoDaemonOptions = {
   voiceLlmProviderExplicit?: boolean;
   voiceLlmModel?: string | null;
   dictationFinalTimeoutMs?: number;
+  wechat?: PaseoWeChatConfig;
 };
 
 export type TestPaseoDaemon = {
@@ -101,6 +103,7 @@ export async function createTestPaseoDaemon(
       voiceLlmModel: options.voiceLlmModel ?? null,
       dictationFinalTimeoutMs: options.dictationFinalTimeoutMs,
       downloadTokenTtlMs: options.downloadTokenTtlMs,
+      wechat: options.wechat,
     };
 
     const logger = options.logger ?? pino({ level: "silent" });

--- a/packages/server/src/server/wechat/api.ts
+++ b/packages/server/src/server/wechat/api.ts
@@ -1,0 +1,251 @@
+import { randomBytes, randomUUID } from "node:crypto";
+
+import type { WeChatGetUpdatesResponse, WeChatMessage } from "./types.js";
+
+const DEFAULT_QR_BASE_URL = "https://ilinkai.weixin.qq.com";
+const DEFAULT_API_BASE_URL = "https://ilinkai.weixin.qq.com";
+const DEFAULT_POLL_TIMEOUT_MS = 35_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+const ILINK_APP_ID = "bot";
+const ILINK_APP_CLIENT_VERSION = "0";
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
+function randomWechatUin(): string {
+  const uint32 = randomBytes(4).readUInt32BE(0);
+  return Buffer.from(String(uint32), "utf8").toString("base64");
+}
+
+function createAbortSignal(timeoutMs: number): AbortSignal | undefined {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return undefined;
+  }
+  return AbortSignal.timeout(timeoutMs);
+}
+
+function buildCommonHeaders(): Record<string, string> {
+  return {
+    "iLink-App-Id": ILINK_APP_ID,
+    "iLink-App-ClientVersion": ILINK_APP_CLIENT_VERSION,
+  };
+}
+
+function buildAuthedHeaders(token?: string, body?: string): Record<string, string> {
+  return {
+    ...buildCommonHeaders(),
+    "Content-Type": "application/json",
+    AuthorizationType: "ilink_bot_token",
+    "X-WECHAT-UIN": randomWechatUin(),
+    ...(typeof body === "string"
+      ? {
+          "Content-Length": String(Buffer.byteLength(body, "utf8")),
+        }
+      : {}),
+    ...(token?.trim()
+      ? {
+          Authorization: `Bearer ${token.trim()}`,
+        }
+      : {}),
+  };
+}
+
+async function fetchText(url: string, init: RequestInit): Promise<string> {
+  const response = await fetch(url, init);
+  const raw = await response.text();
+  if (!response.ok) {
+    throw new Error(`WeChat API ${response.status}: ${raw}`);
+  }
+  return raw;
+}
+
+export async function startQrLogin(options?: {
+  qrApiBaseUrl?: string;
+  botType?: string;
+}): Promise<{ qrcode: string; qrcodeUrl: string }> {
+  const baseUrl = ensureTrailingSlash(options?.qrApiBaseUrl ?? DEFAULT_QR_BASE_URL);
+  const botType = options?.botType?.trim() || "3";
+  const url = new URL(`ilink/bot/get_bot_qrcode?bot_type=${encodeURIComponent(botType)}`, baseUrl);
+  const raw = await fetchText(url.toString(), {
+    method: "GET",
+    headers: buildCommonHeaders(),
+    signal: createAbortSignal(DEFAULT_REQUEST_TIMEOUT_MS),
+  });
+  const parsed = JSON.parse(raw) as {
+    qrcode?: string;
+    qrcode_img_content?: string;
+  };
+  if (!parsed.qrcode || !parsed.qrcode_img_content) {
+    throw new Error("WeChat QR login response is missing qrcode data");
+  }
+  return {
+    qrcode: parsed.qrcode,
+    qrcodeUrl: parsed.qrcode_img_content,
+  };
+}
+
+export async function waitForQrLogin(options: {
+  sessionKey: string;
+  qrcode: string;
+  qrApiBaseUrl?: string;
+  timeoutMs?: number;
+}): Promise<{
+  connected: boolean;
+  rawAccountId?: string;
+  token?: string;
+  baseUrl?: string;
+  userId?: string;
+  message: string;
+}> {
+  const baseUrl = ensureTrailingSlash(options.qrApiBaseUrl ?? DEFAULT_QR_BASE_URL);
+  const timeoutMs = Math.max(1_000, options.timeoutMs ?? 240_000);
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const url = new URL(
+      `ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(options.qrcode)}`,
+      baseUrl,
+    );
+
+    let parsed: {
+      status?: string;
+      bot_token?: string;
+      ilink_bot_id?: string;
+      ilink_user_id?: string;
+      baseurl?: string;
+      redirect_host?: string;
+    };
+
+    try {
+      const raw = await fetchText(url.toString(), {
+        method: "GET",
+        headers: buildCommonHeaders(),
+        signal: createAbortSignal(DEFAULT_POLL_TIMEOUT_MS),
+      });
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      if (error instanceof Error && error.name === "TimeoutError") {
+        continue;
+      }
+      throw error;
+    }
+
+    switch (parsed.status) {
+      case "wait":
+      case "scaned":
+      case "scaned_but_redirect":
+        break;
+      case "confirmed":
+        if (!parsed.bot_token || !parsed.ilink_bot_id) {
+          return {
+            connected: false,
+            message: "WeChat login confirmed but token/account ID is missing",
+          };
+        }
+        return {
+          connected: true,
+          rawAccountId: parsed.ilink_bot_id,
+          token: parsed.bot_token,
+          baseUrl: parsed.baseurl?.trim() || DEFAULT_API_BASE_URL,
+          userId: parsed.ilink_user_id?.trim() || undefined,
+          message: "WeChat login confirmed",
+        };
+      case "expired":
+        return {
+          connected: false,
+          message: "WeChat QR code expired",
+        };
+      default:
+        break;
+    }
+  }
+
+  return {
+    connected: false,
+    message: `Timed out waiting for WeChat login for session ${options.sessionKey}`,
+  };
+}
+
+export async function getUpdates(options: {
+  baseUrl?: string;
+  token: string;
+  getUpdatesBuf?: string;
+  timeoutMs?: number;
+}): Promise<WeChatGetUpdatesResponse> {
+  const baseUrl = ensureTrailingSlash(options.baseUrl ?? DEFAULT_API_BASE_URL);
+  const body = JSON.stringify({
+    get_updates_buf: options.getUpdatesBuf ?? "",
+    base_info: {
+      channel_version: "paseo-wechat-mvp",
+    },
+  });
+  const url = new URL("ilink/bot/getupdates", baseUrl);
+  try {
+    const raw = await fetchText(url.toString(), {
+      method: "POST",
+      headers: buildAuthedHeaders(options.token, body),
+      body,
+      signal: createAbortSignal(options.timeoutMs ?? DEFAULT_POLL_TIMEOUT_MS),
+    });
+    return JSON.parse(raw) as WeChatGetUpdatesResponse;
+  } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") {
+      return {
+        ret: 0,
+        msgs: [],
+        get_updates_buf: options.getUpdatesBuf,
+      };
+    }
+    throw error;
+  }
+}
+
+export async function sendTextMessage(options: {
+  baseUrl?: string;
+  token: string;
+  toUserId: string;
+  contextToken?: string;
+  text: string;
+}): Promise<void> {
+  const baseUrl = ensureTrailingSlash(options.baseUrl ?? DEFAULT_API_BASE_URL);
+  const body = JSON.stringify({
+    msg: {
+      from_user_id: "",
+      to_user_id: options.toUserId,
+      client_id: randomUUID(),
+      message_type: 2,
+      message_state: 2,
+      context_token: options.contextToken,
+      item_list: [
+        {
+          type: 1,
+          text_item: {
+            text: options.text,
+          },
+        },
+      ],
+    },
+    base_info: {
+      channel_version: "paseo-wechat-mvp",
+    },
+  });
+  const url = new URL("ilink/bot/sendmessage", baseUrl);
+  await fetchText(url.toString(), {
+    method: "POST",
+    headers: buildAuthedHeaders(options.token, body),
+    body,
+    signal: createAbortSignal(DEFAULT_REQUEST_TIMEOUT_MS),
+  });
+}
+
+export function extractTextBody(message: WeChatMessage): string {
+  const items = message.item_list ?? [];
+  for (const item of items) {
+    const text = item.text_item?.text?.trim();
+    if (item.type === 1 && text) {
+      return text;
+    }
+  }
+  return "";
+}

--- a/packages/server/src/server/wechat/service.test.ts
+++ b/packages/server/src/server/wechat/service.test.ts
@@ -1,0 +1,226 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import pino from "pino";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  startQrLogin: vi.fn(),
+  waitForQrLogin: vi.fn(),
+  getUpdates: vi.fn(),
+  sendTextMessage: vi.fn(),
+}));
+
+const agentMocks = vi.hoisted(() => ({
+  sendPromptToAgent: vi.fn(),
+}));
+
+vi.mock("./api.js", () => ({
+  startQrLogin: apiMocks.startQrLogin,
+  waitForQrLogin: apiMocks.waitForQrLogin,
+  getUpdates: apiMocks.getUpdates,
+  sendTextMessage: apiMocks.sendTextMessage,
+  extractTextBody: (message: { item_list?: Array<{ type?: number; text_item?: { text?: string } }> }) => {
+    for (const item of message.item_list ?? []) {
+      if (item.type === 1 && item.text_item?.text) {
+        return item.text_item.text;
+      }
+    }
+    return "";
+  },
+}));
+
+vi.mock("../agent/mcp-shared.js", () => ({
+  sendPromptToAgent: agentMocks.sendPromptToAgent,
+}));
+
+import { PaseoWeChatService } from "./service.js";
+
+type JsonResponse = {
+  statusCode: number;
+  body: unknown;
+  status: (code: number) => JsonResponse;
+  json: (value: unknown) => JsonResponse;
+};
+
+function createJsonResponse(): JsonResponse {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(value: unknown) {
+      this.body = value;
+      return this;
+    },
+  };
+}
+
+async function waitForCondition(check: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for condition after ${timeoutMs}ms`);
+}
+
+describe("PaseoWeChatService", () => {
+  let paseoHomeRoot: string;
+
+  beforeEach(async () => {
+    paseoHomeRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-wechat-test-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await rm(paseoHomeRoot, { recursive: true, force: true });
+  });
+
+  test("stores login result and relays inbound text through an agent session", async () => {
+    apiMocks.startQrLogin.mockResolvedValue({
+      qrcode: "qr-token",
+      qrcodeUrl: "https://example.com/qr",
+    });
+    apiMocks.waitForQrLogin.mockResolvedValue({
+      connected: true,
+      rawAccountId: "bot123@im.bot",
+      token: "token-123",
+      baseUrl: "https://ilinkai.weixin.qq.com",
+      userId: "owner@im.wechat",
+      message: "ok",
+    });
+
+    let updateCallCount = 0;
+    apiMocks.getUpdates.mockImplementation(async () => {
+      updateCallCount += 1;
+      if (updateCallCount === 1) {
+        return {
+          ret: 0,
+          get_updates_buf: "buf-1",
+          msgs: [
+            {
+              from_user_id: "user001@im.wechat",
+              create_time_ms: 1710000000000,
+              context_token: "ctx-123",
+              item_list: [
+                {
+                  type: 1,
+                  text_item: {
+                    text: "hello from wechat",
+                  },
+                },
+              ],
+            },
+          ],
+        };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return {
+        ret: 0,
+        get_updates_buf: "buf-1",
+        msgs: [],
+      };
+    });
+
+    apiMocks.sendTextMessage.mockResolvedValue(undefined);
+    agentMocks.sendPromptToAgent.mockResolvedValue(undefined);
+
+    const agentManager = {
+      createAgent: vi.fn().mockResolvedValue({ id: "agent-1" }),
+      waitForAgentEvent: vi.fn().mockResolvedValue({
+        status: "idle",
+        permission: null,
+        lastMessage: null,
+      }),
+      fetchTimeline: vi.fn().mockReturnValue({
+        entries: [
+          {
+            item: {
+              type: "assistant_message",
+              text: "agent reply",
+            },
+          },
+        ],
+      }),
+    } as any;
+    const agentStorage = {} as any;
+
+    const service = new PaseoWeChatService({
+      paseoHome: path.join(paseoHomeRoot, ".paseo"),
+      config: {
+        enabled: true,
+        autoStart: true,
+        provider: "codex",
+        cwd: process.cwd(),
+        pollTimeoutMs: 20,
+      },
+      agentManager,
+      agentStorage,
+      logger: pino({ level: "silent" }),
+    });
+    await service.initialize();
+
+    const startRes = createJsonResponse();
+    await service.startLoginHandler()(
+      { body: { sessionKey: "session-1" } } as any,
+      startRes as any,
+      (() => undefined) as any,
+    );
+    expect(startRes.statusCode).toBe(200);
+    expect(startRes.body).toMatchObject({
+      sessionKey: "session-1",
+      qrcodeUrl: "https://example.com/qr",
+    });
+
+    const waitRes = createJsonResponse();
+    await service.waitLoginHandler()(
+      { body: { sessionKey: "session-1", timeoutMs: 1000 } } as any,
+      waitRes as any,
+      (() => undefined) as any,
+    );
+    expect(waitRes.statusCode).toBe(200);
+    expect(waitRes.body).toMatchObject({
+      connected: true,
+      accountId: "bot123-im-bot",
+      userId: "owner@im.wechat",
+    });
+
+    await waitForCondition(() => apiMocks.sendTextMessage.mock.calls.length > 0);
+
+    expect(agentManager.createAgent).toHaveBeenCalledTimes(1);
+    expect(agentMocks.sendPromptToAgent).toHaveBeenCalledTimes(1);
+    expect(apiMocks.sendTextMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "token-123",
+        toUserId: "user001@im.wechat",
+        contextToken: "ctx-123",
+        text: "agent reply",
+      }),
+    );
+
+    const listRes = createJsonResponse();
+    await service.listAccountsHandler()(
+      {} as any,
+      listRes as any,
+      (() => undefined) as any,
+    );
+    expect(listRes.statusCode).toBe(200);
+    expect(listRes.body).toMatchObject({
+      accounts: [
+        expect.objectContaining({
+          id: "bot123-im-bot",
+          running: true,
+          userId: "owner@im.wechat",
+        }),
+      ],
+    });
+
+    await service.stop();
+  });
+});

--- a/packages/server/src/server/wechat/service.test.ts
+++ b/packages/server/src/server/wechat/service.test.ts
@@ -139,7 +139,7 @@ describe("PaseoWeChatService", () => {
         lastMessage: null,
       }),
       fetchTimeline: vi.fn().mockReturnValue({
-        entries: [
+        rows: [
           {
             item: {
               type: "assistant_message",

--- a/packages/server/src/server/wechat/service.ts
+++ b/packages/server/src/server/wechat/service.ts
@@ -81,6 +81,39 @@ export class PaseoWeChatService {
     };
   }
 
+  listSessionsHandler(): RequestHandler {
+    return async (_req, res) => {
+      const [accounts, peerSessions] = await Promise.all([
+        this.store.listAccounts(),
+        this.store.listPeerSessions(),
+      ]);
+      const accountById = new Map(accounts.map((account) => [account.id, account]));
+
+      const sessions = await Promise.all(
+        peerSessions.map(async (session) => {
+          const account = accountById.get(session.accountId) ?? null;
+          const liveAgent = this.agentManager.getAgent(session.agentId);
+          const storedAgent = liveAgent ? null : await this.agentStorage.get(session.agentId);
+
+          return {
+            accountId: session.accountId,
+            accountUserId: account?.userId ?? null,
+            peerId: session.peerId,
+            agentId: session.agentId,
+            agentTitle: liveAgent?.config.title ?? storedAgent?.title ?? null,
+            agentStatus: liveAgent?.lifecycle ?? storedAgent?.lastStatus ?? null,
+            contextTokenPresent:
+              typeof session.contextToken === "string" && session.contextToken.trim().length > 0,
+            createdAt: session.createdAt,
+            updatedAt: session.updatedAt,
+          };
+        }),
+      );
+
+      res.json({ sessions });
+    };
+  }
+
   startLoginHandler(): RequestHandler {
     return async (req, res) => {
       try {
@@ -343,12 +376,12 @@ export class PaseoWeChatService {
         direction: "tail",
         limit: 200,
       });
-      for (let index = timeline.entries.length - 1; index >= 0; index -= 1) {
-        const entry = timeline.entries[index];
-        if (!entry || entry.item.type !== "assistant_message") {
+      for (let index = timeline.rows.length - 1; index >= 0; index -= 1) {
+        const row = timeline.rows[index];
+        if (!row || row.item.type !== "assistant_message") {
           continue;
         }
-        const text = entry.item.text.trim();
+        const text = row.item.text.trim();
         if (text.length > 0) {
           return text;
         }

--- a/packages/server/src/server/wechat/service.ts
+++ b/packages/server/src/server/wechat/service.ts
@@ -1,0 +1,434 @@
+import { randomUUID } from "node:crypto";
+import type pino from "pino";
+import type { RequestHandler } from "express";
+
+import type { AgentSessionConfig } from "../agent/agent-sdk-types.js";
+import type { AgentManager } from "../agent/agent-manager.js";
+import type { AgentStorage } from "../agent/agent-storage.js";
+import { sendPromptToAgent } from "../agent/mcp-shared.js";
+import type { PaseoWeChatConfig, WeChatAccountRecord, WeChatMessage } from "./types.js";
+import { WeChatStateStore, normalizeWeChatAccountId } from "./store.js";
+import { extractTextBody, getUpdates, sendTextMessage, startQrLogin, waitForQrLogin } from "./api.js";
+
+const DEFAULT_SYSTEM_PROMPT = [
+  "You are a WeChat-connected assistant running inside Paseo.",
+  "Reply in plain text only.",
+  "Keep replies concise, helpful, and directly addressed to the WeChat user.",
+  "Do not mention internal agent IDs, JSON, or tooling unless the user explicitly asks.",
+].join(" ");
+
+type ActiveLoginSession = {
+  sessionKey: string;
+  qrcode: string;
+  qrcodeUrl: string;
+  createdAt: number;
+};
+
+export class PaseoWeChatService {
+  private readonly logger: pino.Logger;
+  private readonly store: WeChatStateStore;
+  private readonly config: PaseoWeChatConfig;
+  private readonly agentManager: AgentManager;
+  private readonly agentStorage: AgentStorage;
+  private readonly activeLogins = new Map<string, ActiveLoginSession>();
+  private readonly monitorAbortControllers = new Map<string, AbortController>();
+  private readonly inboundQueues = new Map<string, Promise<void>>();
+
+  constructor(options: {
+    paseoHome: string;
+    config: PaseoWeChatConfig;
+    agentManager: AgentManager;
+    agentStorage: AgentStorage;
+    logger: pino.Logger;
+  }) {
+    this.logger = options.logger.child({ component: "wechat-service" });
+    this.store = new WeChatStateStore({ paseoHome: options.paseoHome, logger: options.logger });
+    this.config = options.config;
+    this.agentManager = options.agentManager;
+    this.agentStorage = options.agentStorage;
+  }
+
+  async initialize(): Promise<void> {
+    await this.store.initialize();
+  }
+
+  async start(): Promise<void> {
+    if (!this.config.enabled || !this.config.autoStart) {
+      return;
+    }
+    const accounts = await this.store.listAccounts();
+    await Promise.all(accounts.filter((account) => account.enabled).map((account) => this.startAccountMonitor(account)));
+  }
+
+  async stop(): Promise<void> {
+    for (const controller of this.monitorAbortControllers.values()) {
+      controller.abort();
+    }
+    this.monitorAbortControllers.clear();
+    this.activeLogins.clear();
+  }
+
+  listAccountsHandler(): RequestHandler {
+    return async (_req, res) => {
+      const accounts = await this.store.listAccounts();
+      res.json({
+        accounts: accounts.map((account) => ({
+          ...account,
+          running: this.monitorAbortControllers.has(account.id),
+          token: undefined,
+        })),
+      });
+    };
+  }
+
+  startLoginHandler(): RequestHandler {
+    return async (req, res) => {
+      try {
+        const requestedSessionKey =
+          typeof req.body?.sessionKey === "string" && req.body.sessionKey.trim().length > 0
+            ? req.body.sessionKey.trim()
+            : randomUUID();
+        const result = await startQrLogin({
+          qrApiBaseUrl: this.config.qrApiBaseUrl,
+          botType:
+            typeof req.body?.botType === "string" && req.body.botType.trim().length > 0
+              ? req.body.botType.trim()
+              : undefined,
+        });
+        this.activeLogins.set(requestedSessionKey, {
+          sessionKey: requestedSessionKey,
+          qrcode: result.qrcode,
+          qrcodeUrl: result.qrcodeUrl,
+          createdAt: Date.now(),
+        });
+        res.json({
+          sessionKey: requestedSessionKey,
+          qrcodeUrl: result.qrcodeUrl,
+          message: "WeChat QR code ready",
+        });
+      } catch (error) {
+        this.logger.error({ err: error }, "Failed to start WeChat QR login");
+        res.status(500).json({ error: error instanceof Error ? error.message : "Failed to start WeChat login" });
+      }
+    };
+  }
+
+  waitLoginHandler(): RequestHandler {
+    return async (req, res) => {
+      const sessionKey =
+        typeof req.body?.sessionKey === "string" && req.body.sessionKey.trim().length > 0
+          ? req.body.sessionKey.trim()
+          : null;
+      if (!sessionKey) {
+        res.status(400).json({ error: "sessionKey is required" });
+        return;
+      }
+      const login = this.activeLogins.get(sessionKey);
+      if (!login) {
+        res.status(404).json({ error: `Unknown WeChat login session: ${sessionKey}` });
+        return;
+      }
+
+      try {
+        const result = await waitForQrLogin({
+          sessionKey,
+          qrcode: login.qrcode,
+          qrApiBaseUrl: this.config.qrApiBaseUrl,
+          timeoutMs:
+            typeof req.body?.timeoutMs === "number" && Number.isFinite(req.body.timeoutMs)
+              ? req.body.timeoutMs
+              : undefined,
+        });
+
+        if (!result.connected || !result.rawAccountId || !result.token) {
+          res.json(result);
+          return;
+        }
+
+        const normalizedId = normalizeWeChatAccountId(result.rawAccountId);
+        const account = await this.store.upsertAccount({
+          id: normalizedId,
+          rawAccountId: result.rawAccountId,
+          userId: result.userId,
+          token: result.token,
+          baseUrl: result.baseUrl ?? this.config.apiBaseUrl ?? "https://ilinkai.weixin.qq.com",
+          enabled: true,
+          lastError: null,
+        });
+
+        this.activeLogins.delete(sessionKey);
+
+        if (this.config.enabled && this.config.autoStart) {
+          await this.startAccountMonitor(account);
+        }
+
+        res.json({
+          connected: true,
+          accountId: account.id,
+          userId: account.userId,
+          message: result.message,
+        });
+      } catch (error) {
+        this.logger.error({ err: error, sessionKey }, "Failed to wait for WeChat QR login");
+        res.status(500).json({ error: error instanceof Error ? error.message : "Failed to complete WeChat login" });
+      }
+    };
+  }
+
+  private async startAccountMonitor(account: WeChatAccountRecord): Promise<void> {
+    if (this.monitorAbortControllers.has(account.id)) {
+      return;
+    }
+
+    const controller = new AbortController();
+    this.monitorAbortControllers.set(account.id, controller);
+
+    void this.runMonitor(account.id, controller.signal).finally(() => {
+      this.monitorAbortControllers.delete(account.id);
+    });
+  }
+
+  private async runMonitor(accountId: string, signal: AbortSignal): Promise<void> {
+    let currentTimeoutMs = this.config.pollTimeoutMs ?? 35_000;
+
+    while (!signal.aborted) {
+      const account = await this.store.getAccount(accountId);
+      if (!account || !account.enabled) {
+        return;
+      }
+
+      try {
+        const response = await getUpdates({
+          baseUrl: account.baseUrl,
+          token: account.token,
+          getUpdatesBuf: account.getUpdatesBuf,
+          timeoutMs: currentTimeoutMs,
+        });
+
+        if (response.longpolling_timeout_ms && response.longpolling_timeout_ms > 0) {
+          currentTimeoutMs = response.longpolling_timeout_ms;
+        }
+
+        if (response.get_updates_buf && response.get_updates_buf !== account.getUpdatesBuf) {
+          await this.store.patchAccount(account.id, {
+            getUpdatesBuf: response.get_updates_buf,
+            lastError: null,
+          });
+        }
+
+        if ((response.ret ?? 0) !== 0 || (response.errcode ?? 0) !== 0) {
+          await this.store.patchAccount(account.id, {
+            lastError: response.errmsg ?? `ret=${response.ret ?? 0} errcode=${response.errcode ?? 0}`,
+          });
+          await this.sleep(2_000, signal);
+          continue;
+        }
+
+        for (const message of response.msgs ?? []) {
+          await this.queueInboundMessage(account.id, message);
+        }
+      } catch (error) {
+        if (signal.aborted) {
+          return;
+        }
+        this.logger.error({ err: error, accountId }, "WeChat long poll failed");
+        await this.store.patchAccount(accountId, {
+          lastError: error instanceof Error ? error.message : String(error),
+        });
+        await this.sleep(2_000, signal);
+      }
+    }
+  }
+
+  private async queueInboundMessage(accountId: string, message: WeChatMessage): Promise<void> {
+    const peerId = message.from_user_id?.trim();
+    if (!peerId) {
+      return;
+    }
+
+    const queueKey = `${accountId}:${peerId}`;
+    const previous = this.inboundQueues.get(queueKey) ?? Promise.resolve();
+    const next = previous
+      .catch(() => undefined)
+      .then(async () => {
+        await this.handleInboundMessage(accountId, message);
+      })
+      .finally(() => {
+        if (this.inboundQueues.get(queueKey) === next) {
+          this.inboundQueues.delete(queueKey);
+        }
+      });
+    this.inboundQueues.set(queueKey, next);
+    await next;
+  }
+
+  private async handleInboundMessage(accountId: string, message: WeChatMessage): Promise<void> {
+    const account = await this.store.getAccount(accountId);
+    if (!account) {
+      return;
+    }
+
+    const peerId = message.from_user_id?.trim();
+    if (!peerId) {
+      return;
+    }
+
+    const text = extractTextBody(message);
+    if (!text) {
+      this.logger.info({ accountId, peerId }, "Skipping non-text WeChat message in MVP bridge");
+      return;
+    }
+
+    const contextToken = message.context_token?.trim() || undefined;
+    const session = await this.ensurePeerSession(accountId, peerId);
+    if (contextToken) {
+      await this.store.upsertPeerSession({
+        accountId,
+        peerId,
+        agentId: session.agentId,
+        contextToken,
+      });
+    }
+
+    const prompt = this.buildInboundPrompt({
+      accountId,
+      peerId,
+      text,
+      createTimeMs: message.create_time_ms,
+    });
+
+    await sendPromptToAgent({
+      agentManager: this.agentManager,
+      agentStorage: this.agentStorage,
+      agentId: session.agentId,
+      userMessageText: text,
+      prompt,
+      logger: this.logger,
+    });
+
+    const result = await this.agentManager.waitForAgentEvent(session.agentId, {
+      waitForActive: true,
+    });
+    const reply = await this.resolveAgentReplyText(session.agentId, result.lastMessage);
+    if (!reply) {
+      return;
+    }
+
+    await sendTextMessage({
+      baseUrl: account.baseUrl,
+      token: account.token,
+      toUserId: peerId,
+      contextToken,
+      text: reply,
+    });
+
+    await this.store.patchAccount(accountId, {
+      lastInboundAt: new Date().toISOString(),
+      lastOutboundAt: new Date().toISOString(),
+      lastError: null,
+    });
+  }
+
+  private async resolveAgentReplyText(
+    agentId: string,
+    lastMessage: string | null,
+  ): Promise<string | null> {
+    const direct = lastMessage?.trim();
+    if (direct) {
+      return direct;
+    }
+
+    try {
+      const timeline = this.agentManager.fetchTimeline(agentId, {
+        direction: "tail",
+        limit: 200,
+      });
+      for (let index = timeline.entries.length - 1; index >= 0; index -= 1) {
+        const entry = timeline.entries[index];
+        if (!entry || entry.item.type !== "assistant_message") {
+          continue;
+        }
+        const text = entry.item.text.trim();
+        if (text.length > 0) {
+          return text;
+        }
+      }
+    } catch (error) {
+      this.logger.warn({ err: error, agentId }, "Failed to resolve agent reply from timeline");
+    }
+
+    return null;
+  }
+
+  private async ensurePeerSession(accountId: string, peerId: string): Promise<{ agentId: string }> {
+    const existing = await this.store.getPeerSession(accountId, peerId);
+    if (existing) {
+      return { agentId: existing.agentId };
+    }
+
+    const snapshot = await this.agentManager.createAgent(this.buildAgentConfig(peerId), undefined, {
+      labels: {
+        channel: "wechat",
+        accountId,
+        peerId,
+      },
+    });
+
+    await this.store.upsertPeerSession({
+      accountId,
+      peerId,
+      agentId: snapshot.id,
+    });
+
+    return { agentId: snapshot.id };
+  }
+
+  private buildAgentConfig(peerId: string): AgentSessionConfig {
+    return {
+      provider: this.config.provider,
+      cwd: this.config.cwd,
+      title: `WeChat ${peerId}`,
+      systemPrompt: this.config.systemPrompt?.trim() || DEFAULT_SYSTEM_PROMPT,
+      modeId: this.config.modeId,
+      model: this.config.model ?? undefined,
+      approvalPolicy: this.config.approvalPolicy,
+      sandboxMode: this.config.sandboxMode,
+      networkAccess: this.config.networkAccess,
+      webSearch: this.config.webSearch,
+    };
+  }
+
+  private buildInboundPrompt(input: {
+    accountId: string;
+    peerId: string;
+    text: string;
+    createTimeMs?: number;
+  }): string {
+    const timestamp =
+      typeof input.createTimeMs === "number"
+        ? new Date(input.createTimeMs).toISOString()
+        : new Date().toISOString();
+    return [
+      "[WeChat inbound]",
+      `Account: ${input.accountId}`,
+      `Peer: ${input.peerId}`,
+      `Timestamp: ${timestamp}`,
+      "",
+      input.text,
+    ].join("\n");
+  }
+
+  private async sleep(ms: number, signal: AbortSignal): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timeout);
+        reject(new Error("aborted"));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    }).catch(() => undefined);
+  }
+}

--- a/packages/server/src/server/wechat/store.ts
+++ b/packages/server/src/server/wechat/store.ts
@@ -1,0 +1,188 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import type pino from "pino";
+
+import type { WeChatAccountRecord, WeChatPeerSessionRecord, WeChatState } from "./types.js";
+
+const WeChatAccountRecordSchema = z.object({
+  id: z.string(),
+  rawAccountId: z.string(),
+  userId: z.string().optional(),
+  token: z.string(),
+  baseUrl: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  enabled: z.boolean(),
+  getUpdatesBuf: z.string().optional(),
+  lastInboundAt: z.string().optional(),
+  lastOutboundAt: z.string().optional(),
+  lastError: z.string().nullable().optional(),
+});
+
+const WeChatPeerSessionRecordSchema = z.object({
+  accountId: z.string(),
+  peerId: z.string(),
+  agentId: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  contextToken: z.string().optional(),
+});
+
+const WeChatStateSchema = z.object({
+  accounts: z.array(WeChatAccountRecordSchema),
+  peerSessions: z.array(WeChatPeerSessionRecordSchema),
+});
+
+function defaultState(): WeChatState {
+  return {
+    accounts: [],
+    peerSessions: [],
+  };
+}
+
+export function normalizeWeChatAccountId(rawAccountId: string): string {
+  const trimmed = rawAccountId.trim().toLowerCase();
+  return trimmed
+    .replace(/@im\.bot$/u, "-im-bot")
+    .replace(/@im\.wechat$/u, "-im-wechat")
+    .replace(/[^a-z0-9._-]+/gu, "-")
+    .replace(/^-+|-+$/gu, "");
+}
+
+export class WeChatStateStore {
+  private readonly filePath: string;
+  private readonly logger: pino.Logger;
+  private loaded = false;
+  private state: WeChatState = defaultState();
+  private persistQueue: Promise<void> = Promise.resolve();
+
+  constructor(options: { paseoHome: string; logger: pino.Logger }) {
+    this.filePath = path.join(options.paseoHome, "wechat", "state.json");
+    this.logger = options.logger.child({ component: "wechat-state-store" });
+  }
+
+  async initialize(): Promise<void> {
+    await this.load();
+  }
+
+  async listAccounts(): Promise<WeChatAccountRecord[]> {
+    await this.load();
+    return [...this.state.accounts].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  }
+
+  async getAccount(accountId: string): Promise<WeChatAccountRecord | null> {
+    await this.load();
+    return this.state.accounts.find((account) => account.id === accountId) ?? null;
+  }
+
+  async upsertAccount(
+    input: Omit<WeChatAccountRecord, "createdAt" | "updatedAt"> & { createdAt?: string; updatedAt?: string },
+  ): Promise<WeChatAccountRecord> {
+    await this.load();
+    const now = new Date().toISOString();
+    const existing = this.state.accounts.find((account) => account.id === input.id) ?? null;
+    const next: WeChatAccountRecord = {
+      ...existing,
+      ...input,
+      createdAt: existing?.createdAt ?? input.createdAt ?? now,
+      updatedAt: input.updatedAt ?? now,
+    };
+
+    this.state.accounts = [
+      ...this.state.accounts.filter((account) => account.id !== input.id),
+      next,
+    ];
+    await this.enqueuePersist();
+    return next;
+  }
+
+  async patchAccount(
+    accountId: string,
+    update: Partial<Omit<WeChatAccountRecord, "id" | "createdAt">>,
+  ): Promise<WeChatAccountRecord | null> {
+    await this.load();
+    const existing = this.state.accounts.find((account) => account.id === accountId) ?? null;
+    if (!existing) {
+      return null;
+    }
+    const next: WeChatAccountRecord = {
+      ...existing,
+      ...update,
+      updatedAt: new Date().toISOString(),
+    };
+    this.state.accounts = [
+      ...this.state.accounts.filter((account) => account.id !== accountId),
+      next,
+    ];
+    await this.enqueuePersist();
+    return next;
+  }
+
+  async getPeerSession(accountId: string, peerId: string): Promise<WeChatPeerSessionRecord | null> {
+    await this.load();
+    return (
+      this.state.peerSessions.find(
+        (session) => session.accountId === accountId && session.peerId === peerId,
+      ) ?? null
+    );
+  }
+
+  async upsertPeerSession(
+    input: Omit<WeChatPeerSessionRecord, "createdAt" | "updatedAt"> & {
+      createdAt?: string;
+      updatedAt?: string;
+    },
+  ): Promise<WeChatPeerSessionRecord> {
+    await this.load();
+    const now = new Date().toISOString();
+    const existing =
+      this.state.peerSessions.find(
+        (session) => session.accountId === input.accountId && session.peerId === input.peerId,
+      ) ?? null;
+    const next: WeChatPeerSessionRecord = {
+      ...existing,
+      ...input,
+      createdAt: existing?.createdAt ?? input.createdAt ?? now,
+      updatedAt: input.updatedAt ?? now,
+    };
+    this.state.peerSessions = [
+      ...this.state.peerSessions.filter(
+        (session) => !(session.accountId === input.accountId && session.peerId === input.peerId),
+      ),
+      next,
+    ];
+    await this.enqueuePersist();
+    return next;
+  }
+
+  private async load(): Promise<void> {
+    if (this.loaded) {
+      return;
+    }
+
+    try {
+      const raw = await readFile(this.filePath, "utf8");
+      const parsed = WeChatStateSchema.safeParse(JSON.parse(raw));
+      if (parsed.success) {
+        this.state = parsed.data;
+      } else {
+        this.logger.warn({ issues: parsed.error.issues }, "Invalid WeChat state; starting fresh");
+        this.state = defaultState();
+      }
+    } catch (error) {
+      this.state = defaultState();
+      this.logger.debug({ err: error }, "WeChat state file not found; starting fresh");
+    }
+
+    this.loaded = true;
+  }
+
+  private async enqueuePersist(): Promise<void> {
+    this.persistQueue = this.persistQueue.then(async () => {
+      await mkdir(path.dirname(this.filePath), { recursive: true });
+      await writeFile(this.filePath, JSON.stringify(this.state, null, 2), "utf8");
+    });
+    await this.persistQueue;
+  }
+}

--- a/packages/server/src/server/wechat/store.ts
+++ b/packages/server/src/server/wechat/store.ts
@@ -128,6 +128,11 @@ export class WeChatStateStore {
     );
   }
 
+  async listPeerSessions(): Promise<WeChatPeerSessionRecord[]> {
+    await this.load();
+    return [...this.state.peerSessions].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  }
+
   async upsertPeerSession(
     input: Omit<WeChatPeerSessionRecord, "createdAt" | "updatedAt"> & {
       createdAt?: string;

--- a/packages/server/src/server/wechat/types.ts
+++ b/packages/server/src/server/wechat/types.ts
@@ -1,0 +1,72 @@
+export type PaseoWeChatConfig = {
+  enabled: boolean;
+  autoStart: boolean;
+  provider: string;
+  cwd: string;
+  modeId?: string;
+  model?: string | null;
+  systemPrompt?: string;
+  approvalPolicy?: string;
+  sandboxMode?: string;
+  networkAccess?: boolean;
+  webSearch?: boolean;
+  qrApiBaseUrl?: string;
+  apiBaseUrl?: string;
+  pollTimeoutMs?: number;
+};
+
+export type WeChatAccountRecord = {
+  id: string;
+  rawAccountId: string;
+  userId?: string;
+  token: string;
+  baseUrl: string;
+  createdAt: string;
+  updatedAt: string;
+  enabled: boolean;
+  getUpdatesBuf?: string;
+  lastInboundAt?: string;
+  lastOutboundAt?: string;
+  lastError?: string | null;
+};
+
+export type WeChatPeerSessionRecord = {
+  accountId: string;
+  peerId: string;
+  agentId: string;
+  createdAt: string;
+  updatedAt: string;
+  contextToken?: string;
+};
+
+export type WeChatState = {
+  accounts: WeChatAccountRecord[];
+  peerSessions: WeChatPeerSessionRecord[];
+};
+
+export type WeChatMessageItem = {
+  type?: number;
+  text_item?: {
+    text?: string;
+  };
+};
+
+export type WeChatMessage = {
+  seq?: number;
+  message_id?: number;
+  from_user_id?: string;
+  to_user_id?: string;
+  create_time_ms?: number;
+  session_id?: string;
+  item_list?: WeChatMessageItem[];
+  context_token?: string;
+};
+
+export type WeChatGetUpdatesResponse = {
+  ret?: number;
+  errcode?: number;
+  errmsg?: string;
+  msgs?: WeChatMessage[];
+  get_updates_buf?: string;
+  longpolling_timeout_ms?: number;
+};


### PR DESCRIPTION
## Summary
- add a WeChat direct-channel MVP to the server with QR login, persisted account state, account monitoring, and text message relay
- add CLI commands for `paseo wechat login`, `paseo wechat status`, and the top-level `paseo wechat-login` alias
- translate the root README to Chinese and document the new WeChat setup and usage flow

## Testing
- `npm run test:unit --workspace=@getpaseo/server -- src/server/wechat/service.test.ts`
- `PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD=0 PASEO_DICTATION_ENABLED=0 PASEO_VOICE_MODE_ENABLED=0 npx tsx packages/cli/tests/33-wechat.test.ts`

## Notes
- verified QR login and live WeChat message relay against the local dev daemon
- the WeChat send payload now includes the upstream-required `client_id`, `message_type`, and `message_state` fields so replies render correctly in WeChat
