### PR TITLE
feat: add global HTTP/HTTPS proxy for agent child processes

### DIFF
--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -149,6 +149,8 @@ export function HostPage({ serverId, onHostRemoved }: HostPageProps) {
 
       <DaemonSection host={host} isLocalDaemon={isLocalDaemon} />
 
+      <NetworkSection serverId={serverId} />
+
       <ProvidersSection serverId={serverId} />
 
       <RemoveHostSection host={host} onRemoved={onHostRemoved} />
@@ -576,6 +578,161 @@ function InjectPaseoToolsCard({ serverId }: { serverId: string }) {
   );
 }
 
+function NetworkSection({ serverId }: { serverId: string }) {
+  const isConnected = useHostRuntimeIsConnected(serverId);
+  if (!isConnected) return null;
+
+  return (
+    <SettingsSection title="Network">
+      <ProxyCard serverId={serverId} />
+    </SettingsSection>
+  );
+}
+
+function ProxyCard({ serverId }: { serverId: string }) {
+  const { theme } = useUnistyles();
+  const { config, patchConfig } = useDaemonConfig(serverId);
+  const proxy = config?.network?.proxy;
+  const enabled = proxy?.enabled ?? false;
+
+  const [httpsUrl, setHttpsUrl] = useState(proxy?.httpsUrl ?? "");
+  const [httpUrl, setHttpUrl] = useState(proxy?.httpUrl ?? "");
+  const [noProxy, setNoProxy] = useState(proxy?.noProxy ?? "");
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Re-sync when the daemon pushes a new config (e.g. another client saved)
+  // but not while the user is in the middle of editing locally.
+  useEffect(() => {
+    if (isDirty) return;
+    setHttpsUrl(proxy?.httpsUrl ?? "");
+    setHttpUrl(proxy?.httpUrl ?? "");
+    setNoProxy(proxy?.noProxy ?? "");
+  }, [proxy?.httpUrl, proxy?.httpsUrl, proxy?.noProxy, isDirty]);
+
+  const handleToggle = useCallback(
+    (value: string) => {
+      void patchConfig({
+        network: {
+          proxy: {
+            enabled: value === "on",
+            httpsUrl: httpsUrl.trim() || undefined,
+            httpUrl: httpUrl.trim() || undefined,
+            noProxy: noProxy.trim() || undefined,
+          },
+        },
+      });
+    },
+    [httpUrl, httpsUrl, noProxy, patchConfig],
+  );
+
+  const handleSave = useCallback(async () => {
+    if (isSaving) return;
+    setIsSaving(true);
+    try {
+      await patchConfig({
+        network: {
+          proxy: {
+            enabled,
+            httpsUrl: httpsUrl.trim() || undefined,
+            httpUrl: httpUrl.trim() || undefined,
+            noProxy: noProxy.trim() || undefined,
+          },
+        },
+      });
+      setIsDirty(false);
+    } catch (error) {
+      console.error("[HostPage] Failed to save proxy config", error);
+      Alert.alert("Error", "Unable to save proxy settings");
+    } finally {
+      setIsSaving(false);
+    }
+  }, [enabled, httpUrl, httpsUrl, isSaving, noProxy, patchConfig]);
+
+  const placeholderColor = theme.colors.foregroundMuted;
+
+  return (
+    <View style={settingsStyles.card} testID="host-page-proxy-card">
+      <View style={settingsStyles.row}>
+        <View style={settingsStyles.rowContent}>
+          <Text style={settingsStyles.rowTitle}>Agent proxy</Text>
+          <Text style={settingsStyles.rowHint}>
+            Routes outbound traffic from every agent (Claude, Codex, OpenCode) through an HTTP/HTTPS
+            proxy. Restart running agents to pick up changes. Applies only to agent child processes,
+            not the daemon itself.
+          </Text>
+        </View>
+        <SegmentedControl
+          size="sm"
+          value={enabled ? "on" : "off"}
+          onValueChange={handleToggle}
+          options={[
+            { value: "on", label: "On" },
+            { value: "off", label: "Off" },
+          ]}
+        />
+      </View>
+      <View style={[settingsStyles.row, settingsStyles.rowBorder, proxyStyles.formRow]}>
+        <Text style={proxyStyles.inputLabel}>HTTPS proxy URL</Text>
+        <TextInput
+          value={httpsUrl}
+          onChangeText={(value) => {
+            setHttpsUrl(value);
+            setIsDirty(true);
+          }}
+          placeholder="http://user:pass@127.0.0.1:7890"
+          placeholderTextColor={placeholderColor}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isSaving}
+          style={proxyStyles.input}
+          testID="host-page-proxy-https-url"
+        />
+        <Text style={[proxyStyles.inputLabel, proxyStyles.inputLabelSpaced]}>HTTP proxy URL</Text>
+        <TextInput
+          value={httpUrl}
+          onChangeText={(value) => {
+            setHttpUrl(value);
+            setIsDirty(true);
+          }}
+          placeholder="http://user:pass@127.0.0.1:7890"
+          placeholderTextColor={placeholderColor}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isSaving}
+          style={proxyStyles.input}
+          testID="host-page-proxy-http-url"
+        />
+        <Text style={[proxyStyles.inputLabel, proxyStyles.inputLabelSpaced]}>No proxy</Text>
+        <TextInput
+          value={noProxy}
+          onChangeText={(value) => {
+            setNoProxy(value);
+            setIsDirty(true);
+          }}
+          placeholder="localhost,127.0.0.1,.internal"
+          placeholderTextColor={placeholderColor}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isSaving}
+          style={proxyStyles.input}
+          testID="host-page-proxy-no-proxy"
+        />
+        <View style={proxyStyles.actions}>
+          <Button
+            size="sm"
+            onPress={() => void handleSave()}
+            disabled={isSaving || !isDirty}
+            testID="host-page-proxy-save"
+          >
+            {isSaving ? "Saving..." : "Save"}
+          </Button>
+        </View>
+      </View>
+    </View>
+  );
+}
+
 function PairDeviceRow() {
   const { theme } = useUnistyles();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -779,5 +936,35 @@ const styles = StyleSheet.create((theme) => ({
     flexDirection: "row",
     alignItems: "center",
     gap: theme.spacing[2],
+  },
+}));
+
+const proxyStyles = StyleSheet.create((theme) => ({
+  formRow: {
+    flexDirection: "column",
+    alignItems: "stretch",
+    gap: theme.spacing[1],
+  },
+  inputLabel: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  inputLabelSpaced: {
+    marginTop: theme.spacing[3],
+  },
+  input: {
+    backgroundColor: theme.colors.surface0,
+    color: theme.colors.foreground,
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    borderRadius: theme.borderRadius.md,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    fontSize: theme.fontSize.sm,
+  },
+  actions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    marginTop: theme.spacing[3],
   },
 }));

--- a/packages/server/src/server/agent/provider-launch-config.test.ts
+++ b/packages/server/src/server/agent/provider-launch-config.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
   applyProviderEnv,
+  buildProxyEnv,
   migrateProviderSettings,
   ProviderOverrideSchema,
   resolveProviderCommandPrefix,
+  setGlobalAgentEnv,
   type ProviderRuntimeSettings,
 } from "./provider-launch-config.js";
 
@@ -55,7 +57,67 @@ describe("resolveProviderCommandPrefix", () => {
   });
 });
 
+describe("buildProxyEnv", () => {
+  test("returns empty env when proxy is undefined", () => {
+    expect(buildProxyEnv(undefined)).toEqual({});
+  });
+
+  test("returns empty env when proxy is disabled", () => {
+    expect(
+      buildProxyEnv({
+        enabled: false,
+        httpsUrl: "http://127.0.0.1:7890",
+      }),
+    ).toEqual({});
+  });
+
+  test("sets both upper- and lower-case HTTPS_PROXY/ALL_PROXY when httpsUrl is set", () => {
+    const env = buildProxyEnv({
+      enabled: true,
+      httpsUrl: "http://user:pass@127.0.0.1:7890",
+    });
+    expect(env.HTTPS_PROXY).toBe("http://user:pass@127.0.0.1:7890");
+    expect(env.https_proxy).toBe("http://user:pass@127.0.0.1:7890");
+    expect(env.ALL_PROXY).toBe("http://user:pass@127.0.0.1:7890");
+    expect(env.all_proxy).toBe("http://user:pass@127.0.0.1:7890");
+    expect(env.HTTP_PROXY).toBeUndefined();
+  });
+
+  test("sets HTTP_PROXY when httpUrl is set", () => {
+    const env = buildProxyEnv({
+      enabled: true,
+      httpUrl: "http://127.0.0.1:7890",
+    });
+    expect(env.HTTP_PROXY).toBe("http://127.0.0.1:7890");
+    expect(env.http_proxy).toBe("http://127.0.0.1:7890");
+    expect(env.HTTPS_PROXY).toBeUndefined();
+  });
+
+  test("sets NO_PROXY when noProxy is set", () => {
+    const env = buildProxyEnv({
+      enabled: true,
+      noProxy: "localhost,127.0.0.1",
+    });
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
+    expect(env.no_proxy).toBe("localhost,127.0.0.1");
+  });
+
+  test("ignores empty/whitespace URL strings", () => {
+    const env = buildProxyEnv({
+      enabled: true,
+      httpsUrl: "   ",
+      httpUrl: "",
+    });
+    expect(env.HTTPS_PROXY).toBeUndefined();
+    expect(env.HTTP_PROXY).toBeUndefined();
+  });
+});
+
 describe("applyProviderEnv", () => {
+  afterEach(() => {
+    setGlobalAgentEnv({});
+  });
+
   test("merges provider env overrides", () => {
     const base = {
       PATH: "/usr/bin",
@@ -83,6 +145,50 @@ describe("applyProviderEnv", () => {
     const env = applyProviderEnv(base, runtime);
 
     expect(env.PATH).toBe("/custom/path");
+  });
+
+  test("merges the global agent env (proxy) into provider env", () => {
+    setGlobalAgentEnv({ HTTPS_PROXY: "http://127.0.0.1:7890" });
+    const base = { PATH: "/usr/bin" };
+
+    const env = applyProviderEnv(base);
+
+    expect(env.HTTPS_PROXY).toBe("http://127.0.0.1:7890");
+    expect(env.PATH).toBe("/usr/bin");
+  });
+
+  test("global agent env overrides baseEnv of the same name", () => {
+    setGlobalAgentEnv({ HTTPS_PROXY: "http://proxy.config:7890" });
+    const base = {
+      PATH: "/usr/bin",
+      HTTPS_PROXY: "http://shell.env:1111",
+    };
+
+    const env = applyProviderEnv(base);
+
+    expect(env.HTTPS_PROXY).toBe("http://proxy.config:7890");
+  });
+
+  test("per-provider runtimeSettings env beats global agent env", () => {
+    setGlobalAgentEnv({ HTTPS_PROXY: "http://global:7890" });
+    const base = { PATH: "/usr/bin" };
+    const runtime: ProviderRuntimeSettings = {
+      env: { HTTPS_PROXY: "http://per-provider:1234" },
+    };
+
+    const env = applyProviderEnv(base, runtime);
+
+    expect(env.HTTPS_PROXY).toBe("http://per-provider:1234");
+  });
+
+  test("no global env and disabled proxy leaves base env untouched", () => {
+    setGlobalAgentEnv({});
+    const base = { PATH: "/usr/bin" };
+
+    const env = applyProviderEnv(base);
+
+    expect(env.HTTPS_PROXY).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin");
   });
 
   test("strips parent Claude Code session env vars", () => {

--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -178,12 +178,62 @@ const PARENT_SESSION_ENV_VARS = [
   "CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING",
 ];
 
+// Daemon-wide env injected into every agent child process (proxy config etc).
+// Lower precedence than per-provider overrides so users can still opt a single
+// provider out by setting its env.
+let globalAgentEnv: Record<string, string> = {};
+
+export function setGlobalAgentEnv(env: Record<string, string>): void {
+  globalAgentEnv = { ...env };
+}
+
+export function getGlobalAgentEnv(): Record<string, string> {
+  return { ...globalAgentEnv };
+}
+
+export interface ProxyEnvSource {
+  enabled: boolean;
+  httpUrl?: string;
+  httpsUrl?: string;
+  noProxy?: string;
+}
+
+export function buildProxyEnv(proxy: ProxyEnvSource | undefined): Record<string, string> {
+  if (!proxy || !proxy.enabled) {
+    return {};
+  }
+  const env: Record<string, string> = {};
+  const httpsUrl = proxy.httpsUrl?.trim();
+  const httpUrl = proxy.httpUrl?.trim();
+  const noProxy = proxy.noProxy?.trim();
+
+  // Mirror the convention used by curl / undici / Node fetch: both upper- and
+  // lower-case names are honored by different clients, so we set both.
+  if (httpsUrl) {
+    env.HTTPS_PROXY = httpsUrl;
+    env.https_proxy = httpsUrl;
+    // ALL_PROXY is used by some SOCKS-capable clients as a last-resort default.
+    env.ALL_PROXY = httpsUrl;
+    env.all_proxy = httpsUrl;
+  }
+  if (httpUrl) {
+    env.HTTP_PROXY = httpUrl;
+    env.http_proxy = httpUrl;
+  }
+  if (noProxy) {
+    env.NO_PROXY = noProxy;
+    env.no_proxy = noProxy;
+  }
+  return env;
+}
+
 export function applyProviderEnv(
   baseEnv: Record<string, string | undefined>,
   runtimeSettings?: ProviderRuntimeSettings,
 ): Record<string, string | undefined> {
   const merged: Record<string, string | undefined> = {
     ...baseEnv,
+    ...globalAgentEnv,
     ...(runtimeSettings?.env ?? {}),
   };
   for (const key of PARENT_SESSION_ENV_VARS) {

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -123,6 +123,8 @@ import type {
   AgentProviderRuntimeSettingsMap,
   ProviderOverride,
 } from "./agent/provider-launch-config.js";
+import { buildProxyEnv, setGlobalAgentEnv } from "./agent/provider-launch-config.js";
+import type { ProxyConfig } from "../shared/messages.js";
 import {
   ScriptRouteStore,
   createScriptProxyMiddleware,
@@ -178,6 +180,7 @@ export type PaseoDaemonConfig = {
   hostnames?: HostnamesConfig;
   mcpEnabled?: boolean;
   mcpInjectIntoAgents?: boolean;
+  proxy?: ProxyConfig;
   staticDir: string;
   mcpDebug: boolean;
   isDev?: boolean;
@@ -219,13 +222,29 @@ export async function createPaseoDaemon(
   const bootstrapStart = performance.now();
   const elapsed = () => `${(performance.now() - bootstrapStart).toFixed(0)}ms`;
   const daemonVersion = resolveDaemonVersion(import.meta.url);
+  const initialProxy: ProxyConfig | undefined = config.proxy
+    ? {
+        enabled: config.proxy.enabled,
+        httpUrl: config.proxy.httpUrl,
+        httpsUrl: config.proxy.httpsUrl,
+        noProxy: config.proxy.noProxy,
+      }
+    : undefined;
   const daemonConfigStore = new DaemonConfigStore(
     config.paseoHome,
     {
       mcp: { injectIntoAgents: config.mcpInjectIntoAgents ?? true },
+      ...(initialProxy ? { network: { proxy: initialProxy } } : {}),
     },
     logger,
   );
+
+  // Seed the global agent env with the persisted proxy so every provider
+  // spawned after bootstrap inherits it.
+  setGlobalAgentEnv(buildProxyEnv(initialProxy));
+  daemonConfigStore.onFieldChange("network.proxy", (value) => {
+    setGlobalAgentEnv(buildProxyEnv(value as ProxyConfig | undefined));
+  });
 
   try {
     const serverId = getOrCreateServerId(config.paseoHome, { logger });

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { z } from "zod";
 
 import type { PaseoDaemonConfig } from "./bootstrap.js";
+import type { ProxyConfig } from "../shared/messages.js";
 import { loadPersistedConfig } from "./persisted-config.js";
 import type { AgentProvider } from "./agent/agent-sdk-types.js";
 import type {
@@ -171,6 +172,16 @@ export function loadConfig(
     persisted.agents?.providers as Record<string, unknown> | undefined,
   );
 
+  const persistedProxy = persisted.daemon?.network?.proxy;
+  const proxy: ProxyConfig | undefined = persistedProxy
+    ? {
+        enabled: persistedProxy.enabled ?? false,
+        httpUrl: persistedProxy.httpUrl,
+        httpsUrl: persistedProxy.httpsUrl,
+        noProxy: persistedProxy.noProxy,
+      }
+    : undefined;
+
   return {
     listen,
     paseoHome,
@@ -196,5 +207,6 @@ export function loadConfig(
     voiceLlmModel,
     agentProviderSettings: extractAgentProviderSettings(providerOverrides),
     providerOverrides,
+    proxy,
   };
 }

--- a/packages/server/src/server/daemon-config-store.ts
+++ b/packages/server/src/server/daemon-config-store.ts
@@ -148,6 +148,20 @@ function mergeMutableConfigIntoPersistedConfig(params: {
   mutable: MutableDaemonConfig;
 }): PersistedConfig {
   const { persisted, mutable } = params;
+  const mutableProxy = mutable.network?.proxy;
+  const nextNetwork = mutableProxy
+    ? {
+        ...persisted.daemon?.network,
+        proxy: {
+          ...persisted.daemon?.network?.proxy,
+          enabled: mutableProxy.enabled,
+          httpUrl: mutableProxy.httpUrl,
+          httpsUrl: mutableProxy.httpsUrl,
+          noProxy: mutableProxy.noProxy,
+        },
+      }
+    : persisted.daemon?.network;
+
   return {
     ...persisted,
     daemon: {
@@ -156,6 +170,7 @@ function mergeMutableConfigIntoPersistedConfig(params: {
         ...persisted.daemon?.mcp,
         injectIntoAgents: mutable.mcp.injectIntoAgents,
       },
+      ...(nextNetwork ? { network: nextNetwork } : {}),
     },
   };
 }

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -219,6 +219,21 @@ function normalizeAgentProviders(value: unknown): unknown {
   };
 }
 
+const PersistedProxyConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    httpUrl: z.string().optional(),
+    httpsUrl: z.string().optional(),
+    noProxy: z.string().optional(),
+  })
+  .strict();
+
+const PersistedNetworkConfigSchema = z
+  .object({
+    proxy: PersistedProxyConfigSchema.optional(),
+  })
+  .strict();
+
 export const PersistedConfigSchema = z
   .object({
     // v1 schema marker
@@ -251,6 +266,7 @@ export const PersistedConfigSchema = z
           })
           .strict()
           .optional(),
+        network: PersistedNetworkConfigSchema.optional(),
       })
       .strict()
       .transform(({ allowedHosts, ...daemon }) => {

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -51,6 +51,23 @@ import {
 // Mutable daemon config schemas (shared between server store and client)
 // ---------------------------------------------------------------------------
 
+// All new fields stay optional so old clients talking to new daemons (and
+// vice versa) continue to parse successfully.
+export const ProxyConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    httpUrl: z.string().optional(),
+    httpsUrl: z.string().optional(),
+    noProxy: z.string().optional(),
+  })
+  .passthrough();
+
+export const NetworkConfigSchema = z
+  .object({
+    proxy: ProxyConfigSchema.optional(),
+  })
+  .passthrough();
+
 export const MutableDaemonConfigSchema = z
   .object({
     mcp: z
@@ -58,16 +75,25 @@ export const MutableDaemonConfigSchema = z
         injectIntoAgents: z.boolean(),
       })
       .passthrough(),
+    network: NetworkConfigSchema.optional(),
   })
   .passthrough();
 
 export const MutableDaemonConfigPatchSchema = z
   .object({
     mcp: MutableDaemonConfigSchema.shape.mcp.partial().optional(),
+    network: z
+      .object({
+        proxy: ProxyConfigSchema.partial().optional(),
+      })
+      .partial()
+      .passthrough()
+      .optional(),
   })
   .partial()
   .passthrough();
 
+export type ProxyConfig = z.infer<typeof ProxyConfigSchema>;
 export type MutableDaemonConfig = z.infer<typeof MutableDaemonConfigSchema>;
 export type MutableDaemonConfigPatch = z.infer<typeof MutableDaemonConfigPatchSchema>;
 import type { LiteralUnion } from "./literal-union.js";


### PR DESCRIPTION
## Summary

Adds a per-host **Network → Agent proxy** setting. The daemon injects `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` / `NO_PROXY` (and lower-case variants) into every spawned agent process (Claude, Codex, OpenCode, ACP), so users behind a proxy can reach provider APIs without editing `config.json` for each provider.

Closes #253

## Motivation

Agents like Claude Code / Codex call provider APIs over HTTPS. Users in regions where those APIs are hard to reach directly (e.g. mainland China) need a proxy. Today the only way to set one is manually editing `agents.providers.<id>.env` in `config.json` **per provider** — no UI, easy to forget, easy to get wrong. #253 asks for proper proxy support. This PR adds it as a first-class setting.

## How it works

- `MutableDaemonConfigSchema` gains an optional `network.proxy` field (`enabled`, `httpUrl?`, `httpsUrl?`, `noProxy?`).
- `applyProviderEnv` now merges a process-wide `globalAgentEnv` layer between `baseEnv` and `runtimeSettings.env`. **Precedence stays: `process.env` < global proxy config < per-provider env override**, so users who already set per-provider env keep winning.
- `bootstrap` seeds `globalAgentEnv` from the persisted config on startup and re-applies on `network.proxy` changes via `daemonConfigStore.onFieldChange`. No daemon restart needed — new agents pick up the change immediately. (Already-running agents keep the env they were spawned with — this is an intentional no-surprise choice.)
- UI: a new **Network** section on the Host settings page with a **Agent proxy** card (on/off toggle + HTTPS / HTTP / NoProxy fields + Save). Only renders when the daemon is connected. Uses the existing \`useDaemonConfig\` / \`patchConfig\` hook, so no new WS round trips or transport work needed.

## Backward compatibility

All new schema fields are \`.optional()\` with \`.passthrough()\`, following the project's "does a 6-month-old client still parse this?" rule:

- Old client ↔ new daemon: old clients ignore the new \`network\` field.
- New client ↔ old daemon: new UI just doesn't see any proxy config; the Save patch against an old daemon is rejected cleanly (old schema has no \`network\`) — an edge case since paired clients/daemons typically upgrade together.

## Scope — what this PR does **not** do

- Does not affect the daemon's own outbound traffic (relay, update check). Only agent child processes. Happy to extend if maintainers want — the \`globalAgentEnv\` singleton makes that a one-liner.
- Does not add a CLI override for proxy (users configure via the UI or directly in \`config.json\`). Easy follow-up.

## Testing

- Unit: \`packages/server/src/server/agent/provider-launch-config.test.ts\` — 10 new cases for \`buildProxyEnv\` + \`applyProviderEnv\` precedence. All 23 tests in that file pass.
- Format + app typecheck clean.
- Built and installed the produced \`.app\` locally on macOS arm64. Configured proxy via the UI, created a Claude Code agent, verified traffic going through the proxy. Toggling off and back on takes effect immediately for new agents.

## Test plan

- [ ] Open Settings → select a host → scroll to Network, toggle Agent proxy on, set HTTPS URL (e.g. \`http://127.0.0.1:7890\`), Save.
- [ ] Spawn a new Claude / Codex / OpenCode agent, run a task that hits the provider API, verify the proxy sees the traffic.
- [ ] Set a per-provider \`env.HTTPS_PROXY\` in \`config.json\` and confirm it wins over the global setting (precedence).
- [ ] Toggle off; new agents no longer route via proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)