### PR TITLE
fix(server): capture Codex skill warnings during agent creation

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -521,6 +521,54 @@ describe("Codex app-server provider", () => {
     ]);
   });
 
+  test("surfaces invalid SKILL.md entries from skills/list in stream history", async () => {
+    const session = new __codexAppServerInternals.CodexAppServerAgentSession(
+      createConfig(),
+      null,
+      createTestLogger(),
+      () => {
+        throw new Error("Test session cannot spawn Codex app-server");
+      },
+    ) as unknown as AgentSession & { [key: string]: unknown };
+
+    session.client = {
+      request: vi.fn().mockResolvedValue({
+        data: [
+          {
+            cwd: "/tmp/codex-question-test",
+            skills: [],
+            errors: [
+              {
+                path: "/tmp/codex-question-test/.codex/skills/bad-skill/SKILL.md",
+                message: "missing YAML frontmatter delimited by ---",
+              },
+            ],
+          },
+        ],
+      }),
+    };
+
+    await (session as any).loadSkills();
+
+    const history: AgentStreamEvent[] = [];
+    for await (const event of session.streamHistory()) {
+      history.push(event);
+    }
+
+    expect(history).toEqual([
+      {
+        type: "timeline",
+        provider: "codex",
+        item: {
+          type: "error",
+          message:
+            "Skipped loading 1 skill due to invalid SKILL.md file.\n" +
+            "/tmp/codex-question-test/.codex/skills/bad-skill/SKILL.md: missing YAML frontmatter delimited by ---",
+        },
+      },
+    ]);
+  });
+
   test("maps question responses from headers back to question ids and completes the tool call", async () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -1000,6 +1000,22 @@ function formatCodexQuestionPrompts(questions: CodexQuestionPrompt[]): string {
     .trim();
 }
 
+function formatCodexSkillWarningMessage(warnings: string[]): string {
+  const normalized = warnings
+    .map((warning) => warning.trim())
+    .filter((warning) => warning.length > 0);
+  if (normalized.length === 0) {
+    return "";
+  }
+  const count = normalized.length;
+  const noun = count === 1 ? "skill" : "skills";
+  const fileNoun = count === 1 ? "file" : "files";
+  return [
+    `Skipped loading ${count} ${noun} due to invalid SKILL.md ${fileNoun}.`,
+    ...normalized,
+  ].join("\n");
+}
+
 function mapCodexQuestionRequestToToolCall(params: {
   callId: string;
   questions: CodexQuestionPrompt[];
@@ -2497,6 +2513,7 @@ class CodexAppServerAgentSession implements AgentSession {
     name: string;
   } | null = null;
   private cachedSkills: Array<{ name: string; description: string; path: string }> = [];
+  private latestSkillWarningMessage: string | null = null;
 
   constructor(
     config: AgentSessionConfig,
@@ -2589,6 +2606,7 @@ class CodexAppServerAgentSession implements AgentSession {
       })) as { data?: Array<any> };
       const entries = Array.isArray(response?.data) ? response.data : [];
       const skills: Array<{ name: string; description: string; path: string }> = [];
+      const skillWarnings: string[] = [];
       for (const entry of entries) {
         const list = Array.isArray(entry.skills) ? entry.skills : [];
         for (const skill of list) {
@@ -2599,12 +2617,57 @@ class CodexAppServerAgentSession implements AgentSession {
             path: skill.path,
           });
         }
+        const errors = Array.isArray(entry.errors) ? entry.errors : [];
+        for (const error of errors) {
+          if (!error || typeof error !== "object") {
+            continue;
+          }
+          const record = error as { path?: unknown; message?: unknown };
+          const message = nonEmptyString(
+            typeof record.message === "string" ? record.message : undefined,
+          );
+          if (!message) {
+            continue;
+          }
+          const skillPath = nonEmptyString(
+            typeof record.path === "string" ? record.path : undefined,
+          );
+          skillWarnings.push(skillPath ? `${skillPath}: ${message}` : message);
+        }
       }
       this.cachedSkills = skills;
+      this.publishSkillWarnings(skillWarnings);
     } catch (error) {
       this.logger.trace({ error }, "Failed to load skills list");
       this.cachedSkills = [];
+      this.publishSkillWarnings([]);
     }
+  }
+
+  private publishSkillWarnings(warnings: string[]): void {
+    if (warnings.length === 0) {
+      this.latestSkillWarningMessage = null;
+      return;
+    }
+
+    const message = formatCodexSkillWarningMessage(warnings);
+    if (!message || message === this.latestSkillWarningMessage) {
+      return;
+    }
+
+    this.latestSkillWarningMessage = message;
+    const item: AgentTimelineItem = {
+      type: "error",
+      message,
+    };
+
+    if (this.connected) {
+      this.emitEvent({ type: "timeline", provider: CODEX_PROVIDER, item });
+      return;
+    }
+
+    this.persistedHistory.push(item);
+    this.historyPending = true;
   }
 
   private findCollaborationMode(target: "code" | "plan"): {
@@ -2793,7 +2856,7 @@ class CodexAppServerAgentSession implements AgentSession {
       const timeline = rolloutTimeline.length > 0 ? rolloutTimeline : threadTimeline;
 
       if (timeline.length > 0) {
-        this.persistedHistory = timeline;
+        this.persistedHistory = [...this.persistedHistory, ...timeline];
         this.historyPending = true;
       }
     } catch (error) {

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -123,6 +123,7 @@ vi.mock("./worktree-bootstrap.js", async (importOriginal) => {
 });
 
 function createSessionForTest(options?: {
+  agentManager?: Record<string, unknown>;
   github?: {
     invalidate: ReturnType<typeof vi.fn>;
     isAuthenticated?: ReturnType<typeof vi.fn>;
@@ -179,9 +180,11 @@ function createSessionForTest(options?: {
     downloadTokenStore: {} as any,
     pushTokenStore: {} as any,
     paseoHome: "/tmp/paseo-home",
-    agentManager: {
-      subscribe: vi.fn(() => () => {}),
-    } as any,
+    agentManager:
+      options?.agentManager ??
+      ({
+        subscribe: vi.fn(() => () => {}),
+      } as any),
     agentStorage: {} as any,
     projectRegistry: {} as any,
     workspaceRegistry:
@@ -1100,6 +1103,110 @@ describe("session branch validation", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("session agent creation", () => {
+  test("hydrates provider timeline after creating an agent", async () => {
+    const createdAt = new Date("2026-04-21T00:00:00.000Z");
+    const snapshot = {
+      id: "agent-1",
+      provider: "codex",
+      cwd: "/tmp/workspace",
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: false,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      config: {
+        provider: "codex",
+        cwd: "/tmp/workspace",
+        modeId: "auto",
+      },
+      runtimeInfo: {
+        provider: "codex",
+        sessionId: "thread-1",
+        modeId: "auto",
+      },
+      createdAt,
+      updatedAt: createdAt,
+      availableModes: [],
+      currentModeId: "auto",
+      pendingPermissions: new Map(),
+      bufferedPermissionResolutions: new Map(),
+      inFlightPermissionResponses: new Set(),
+      pendingReplacement: false,
+      persistence: { provider: "codex", sessionId: "thread-1" },
+      historyPrimed: false,
+      lastUserMessageAt: null,
+      attention: {
+        requiresAttention: false,
+        attentionReason: null,
+        attentionTimestamp: null,
+      },
+      foregroundTurnWaiters: new Set(),
+      unsubscribeSession: null,
+      labels: {},
+      lifecycle: "idle",
+      activeForegroundTurnId: null,
+      session: null,
+    };
+    const agentManager = {
+      subscribe: vi.fn(() => () => {}),
+      createAgent: vi.fn().mockResolvedValue(snapshot),
+      hydrateTimelineFromProvider: vi.fn().mockResolvedValue(undefined),
+    };
+    const workspaceRegistry = {
+      get: vi.fn().mockResolvedValue(null),
+    };
+    const session = createSessionForTest({
+      agentManager,
+      workspaceRegistry,
+    });
+
+    (session as any).buildAgentSessionConfig = vi.fn().mockResolvedValue({
+      sessionConfig: {
+        provider: "codex",
+        cwd: "/tmp/workspace",
+        modeId: "auto",
+        title: "Test Agent",
+      },
+      worktreeBootstrap: null,
+    });
+    (session as any).findWorkspaceByDirectory = vi.fn().mockResolvedValue({
+      workspaceId: "workspace-1",
+      cwd: "/tmp/workspace",
+    });
+    (session as any).forwardAgentUpdate = vi.fn().mockResolvedValue(undefined);
+
+    await (session as any).handleCreateAgentRequest({
+      type: "create_agent_request",
+      config: {
+        provider: "codex",
+        cwd: "/tmp/workspace",
+        modeId: "auto",
+        title: "Test Agent",
+      },
+      attachments: [],
+      labels: {},
+      requestId: "request-create-agent",
+    });
+
+    expect(agentManager.createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "codex",
+        cwd: "/tmp/workspace",
+        modeId: "auto",
+      }),
+      undefined,
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+      }),
+    );
+    expect(agentManager.hydrateTimelineFromProvider).toHaveBeenCalledWith("agent-1");
   });
 });
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2809,6 +2809,7 @@ export class Session {
           initialPrompt: trimmedPrompt,
         },
       );
+      await this.agentManager.hydrateTimelineFromProvider(snapshot.id);
       await this.forwardAgentUpdate(snapshot);
 
       if (trimmedPrompt || (images?.length ?? 0) > 0 || (attachments?.length ?? 0) > 0) {


### PR DESCRIPTION
## Summary
- surface Codex `skills/list` validation failures as timeline errors instead of silently dropping them
- hydrate provider history immediately after `createAgent` so startup warnings are recorded for newly created Codex agents
- add regression coverage for both the provider warning mapping and the create-agent hydration path

## Bug
When Codex returns startup warnings from `skills/list` such as invalid `SKILL.md` files, Paseo only exposed them through provider history. Resume and refresh flows hydrated that history, but the create-agent flow did not. As a result, a newly created Codex agent could start with a warning like `Skipped loading 1 skill due to invalid SKILL.md file`, yet the daemon timeline stayed empty and the desktop app showed nothing.

## Repro
1. Create an invalid `.codex/skills/*/SKILL.md`.
2. Start the daemon and create a brand new Codex agent.
3. Observe that Codex reports the warning internally, but the new agent timeline in Paseo/desktop does not show the error.

## Fix
The provider now turns `skills/list.errors[]` into timeline `error` items, and the create-agent path now calls `hydrateTimelineFromProvider(snapshot.id)` before forwarding the new agent snapshot. That makes the startup warning durable and visible to desktop on first creation, not only after resume/refresh.

## Testing
- `./node_modules/.bin/vitest run packages/server/src/server/session.test.ts packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1`
