### PR TITLE
fix(server): skip home directory in workspace prefix matching

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -6010,8 +6010,10 @@ export class Session {
       return exact.workspaceId;
     }
 
+    const userHome = homedir();
     let bestMatch: PersistedWorkspaceRecord | null = null;
     for (const workspace of workspaces) {
+      if (workspace.cwd === userHome) continue;
       const prefix = workspace.cwd.endsWith(sep) ? workspace.cwd : `${workspace.cwd}${sep}`;
       if (!normalizedCwd.startsWith(prefix)) {
         continue;

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
 import { Session } from "./session.js";
@@ -47,6 +47,10 @@ interface SessionTestAccess {
   getAgentPayloadById(agentId: string): Promise<unknown>;
   buildProjectPlacementForCwd(cwd: string): Promise<unknown>;
   buildProjectPlacement(cwd: string): Promise<unknown>;
+  resolveRegisteredWorkspaceIdForCwd(
+    cwd: string,
+    workspaces: ReturnType<typeof createPersistedWorkspaceRecord>[],
+  ): string;
   buildWorkspaceDescriptorMap(...args: unknown[]): Promise<Map<string, unknown>>;
   describeWorkspaceRecord(...args: unknown[]): Promise<unknown>;
   describeWorkspaceRecordWithGitData(...args: unknown[]): Promise<unknown>;
@@ -3041,4 +3045,22 @@ test("subscribed fetch_workspaces includes git enrichment in the initial snapsho
   ) as Array<{ type: "workspace_update"; payload: Record<string, unknown> }>;
   expect(workspaceUpdates).toEqual([]);
   expect(session.describeWorkspaceRecordWithGitData).toHaveBeenCalledWith(gitWorkspace, gitProject);
+});
+
+test("resolveRegisteredWorkspaceIdForCwd does not match home directory as a prefix", () => {
+  const session = createSessionForWorkspaceTests();
+  const home = homedir();
+  const childCwd = path.join(home, "projects/new-app");
+  const homeWorkspace = createPersistedWorkspaceRecord({
+    workspaceId: home,
+    projectId: "proj-home",
+    cwd: home,
+    kind: "directory",
+    displayName: "home",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+
+  expect(session.resolveRegisteredWorkspaceIdForCwd(childCwd, [homeWorkspace])).toBe(childCwd);
+  expect(session.resolveRegisteredWorkspaceIdForCwd(home, [homeWorkspace])).toBe(home);
 });


### PR DESCRIPTION
### Problem

When a user's home directory (`~`) is registered as a Paseo workspace, any new project created under the home directory gets incorrectly associated with the home workspace via prefix matching, preventing creation of an independent workspace.

See issue #562 for full details.

### Change

Added a check in `resolveRegisteredWorkspaceIdForCwd` to skip the home directory (`homedir()`) during prefix matching. Exact matches for the home directory still work correctly.

### Before
```ts
let bestMatch: PersistedWorkspaceRecord | null = null;
for (const workspace of workspaces) {
  const prefix = workspace.cwd.endsWith(sep) ? workspace.cwd : `${workspace.cwd}${sep}`;
  // ...prefix match logic including homedir...
}
```

### After
```ts
const userHome = homedir();
let bestMatch: PersistedWorkspaceRecord | null = null;
for (const workspace of workspaces) {
  if (workspace.cwd === userHome) continue;
  const prefix = workspace.cwd.endsWith(sep) ? workspace.cwd : `${workspace.cwd}${sep}`;
  // ...prefix match logic excluding homedir...
}
```

### Verification

- Tested locally on Paseo v0.1.62 with the patched `session.js`
- Workspace resolution for paths under `~` now returns the `normalizedCwd` (new workspace) instead of the home workspace
- Exact match for `~` still resolves to the home workspace

Closes #562