### PR TITLE
feat(speech): make OpenAI realtime transcription URL configurable

### DIFF
--- a/packages/server/src/server/speech/providers/openai/realtime-transcription-session.ts
+++ b/packages/server/src/server/speech/providers/openai/realtime-transcription-session.ts
@@ -102,7 +102,8 @@ export class OpenAIRealtimeTranscriptionSession
 
     this.closing = false;
     this.ready = new Promise<void>((resolve, reject) => {
-      const url = "wss://api.openai.com/v1/realtime?intent=transcription";
+      const url =
+        process.env.OPENAI_REALTIME_URL ?? "wss://api.openai.com/v1/realtime?intent=transcription";
       const ws = new WebSocket(url, {
         headers: {
           Authorization: `Bearer ${this.apiKey}`,


### PR DESCRIPTION
## Summary

- One-line change: read the realtime transcription endpoint from `OPENAI_REALTIME_URL` env var, falling back to the current hardcoded `wss://api.openai.com/v1/realtime?intent=transcription` value.
- Default behavior is byte-identical to today — zero risk for existing users.
- Unblocks pointing the realtime session at any OpenAI Realtime API protocol-compatible backend (Azure OpenAI, Alibaba Bailian / DashScope, self-hosted compat layers) without further code changes.

Closes #569.

## Why

The OpenAI provider's HTTP paths (`stt.ts`, `tts.ts`) already inherit `OPENAI_BASE_URL` overrides via the OpenAI SDK, so users can route Whisper-style transcription and TTS to compatible backends. But `realtime-transcription-session.ts:105` builds its own `WebSocket` directly and hardcoded the URL, leaving voice mode locked to `api.openai.com` even when the rest of the OpenAI provider has been redirected.

Concrete motivating backends:
- **Alibaba Cloud Bailian (DashScope)** — `wss://dashscope.aliyuncs.com/api-ws/v1/realtime` (Beijing) or `wss://dashscope-intl.aliyuncs.com/api-ws/v1/realtime` (Singapore). Models: `qwen3-omni-flash-realtime`, `qwen3-asr-flash-realtime`. Aliyun's official docs require OpenAI Python SDK ≥ 1.52.0 / Node SDK ≥ 4.68.0 — the exact versions that introduced OpenAI Realtime support — i.e. the wire protocol is OpenAI-compatible.
- **Azure OpenAI Realtime** — `wss://<resource>.openai.azure.com/openai/realtime?api-version=...&deployment=...`.
- **Self-hosted gateways** (LiteLLM, vLLM realtime, etc.).

This particularly helps Chinese-speaking users (#279, #482) who currently can't use voice mode with strong Chinese models.

## Why a full URL, not just a base

Compatible backends don't share path or query layout:
- OpenAI: `/v1/realtime?intent=transcription`
- Bailian: `/api-ws/v1/realtime` (no `intent`)
- Azure: `/openai/realtime?api-version=...&deployment=...`

A single `OPENAI_REALTIME_URL` lets each backend specify whatever path/query it needs.

## Out of scope

- Translating any message-level protocol differences (`session.update` shape, etc.) if a given backend diverges from OpenAI's events. That's the user's problem — or a follow-up dedicated provider.
- Per-feature URL overrides (separate URL for voice mode vs dictation). Not needed today since paseo only has one realtime session class.

## Backward compatibility

- Default value byte-identical → no behavior diff for existing users.
- New env var is additive → schema/wire compat unaffected.

## Test plan

- [x] `npm run typecheck` green across all workspaces
- [x] `npm run format:check` clean (oxfmt)
- [x] Pre-commit hooks (format / lint / typecheck) all passed
- [ ] Manual smoke (reviewer): unset `OPENAI_REALTIME_URL` → existing voice mode behavior preserved
- [ ] Manual smoke (reviewer, optional): set `OPENAI_REALTIME_URL=wss://dashscope-intl.aliyuncs.com/api-ws/v1/realtime` + appropriate `STT_MODEL` → realtime session connects to Bailian

🤖 Generated with [Claude Code](https://claude.com/claude-code)