### PR TITLE
Add yolo mode shortcut for CLI runs

### DIFF
--- a/packages/cli/src/commands/agent/run.test.ts
+++ b/packages/cli/src/commands/agent/run.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import { resolveYoloModeFromProviderSnapshot } from "./yolo-mode.js";
+
+function providerEntry(
+  provider: string,
+  modes: Array<{ id: string; label?: string }> | undefined,
+): { provider: string; status: string; modes?: Array<{ id: string; label: string }> } {
+  return {
+    provider,
+    status: "ready",
+    modes: modes?.map((mode) => ({
+      id: mode.id,
+      label: mode.label ?? mode.id,
+    })),
+  };
+}
+
+describe("resolveYoloModeFromProviderSnapshot", () => {
+  test("maps Codex to full-access", () => {
+    expect(
+      resolveYoloModeFromProviderSnapshot("codex", [
+        providerEntry("codex", [{ id: "auto" }, { id: "full-access" }]),
+      ]),
+    ).toBe("full-access");
+  });
+
+  test("maps Claude to bypassPermissions", () => {
+    expect(
+      resolveYoloModeFromProviderSnapshot("claude", [
+        providerEntry("claude", [
+          { id: "default" },
+          { id: "acceptEdits" },
+          { id: "plan" },
+          { id: "bypassPermissions" },
+        ]),
+      ]),
+    ).toBe("bypassPermissions");
+  });
+
+  test("maps ACP autopilot when full access modes are unavailable", () => {
+    expect(
+      resolveYoloModeFromProviderSnapshot("copilot", [
+        providerEntry("copilot", [
+          { id: "https://agentclientprotocol.com/protocol/session-modes#agent" },
+          { id: "https://agentclientprotocol.com/protocol/session-modes#autopilot" },
+        ]),
+      ]),
+    ).toBe("https://agentclientprotocol.com/protocol/session-modes#autopilot");
+  });
+
+  test("maps OpenCode to build as the best available non-plan mode", () => {
+    expect(
+      resolveYoloModeFromProviderSnapshot("opencode", [
+        providerEntry("opencode", [{ id: "plan" }, { id: "build" }]),
+      ]),
+    ).toBe("build");
+  });
+
+  test("returns null for providers without a yolo mode", () => {
+    expect(
+      resolveYoloModeFromProviderSnapshot("pi", [providerEntry("pi", [{ id: "default" }])]),
+    ).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/agent/run.ts
+++ b/packages/cli/src/commands/agent/run.ts
@@ -17,6 +17,7 @@ import { lookup } from "mime-types";
 import { parseDuration } from "../../utils/duration.js";
 import { collectMultiple } from "../../utils/command-options.js";
 import { resolveProviderAndModel } from "../../utils/provider-model.js";
+import { resolveYoloModeFromProviderSnapshot } from "./yolo-mode.js";
 
 export { resolveProviderAndModel } from "../../utils/provider-model.js";
 
@@ -37,6 +38,7 @@ export function addRunOptions(cmd: Command): Command {
     )
     .option("--thinking <id>", "Thinking option ID to use for this run")
     .option("--mode <mode>", "Provider-specific mode (e.g., plan, default, bypass)")
+    .option("--yolo", "Use the provider's most permissive available mode")
     .option("--worktree <name>", "Create agent in a new git worktree")
     .option("--base <branch>", "Base branch for worktree (default: current branch)")
     .option(
@@ -91,6 +93,7 @@ export interface AgentRunOptions extends CommandOptions {
   model?: string;
   thinking?: string;
   mode?: string;
+  yolo?: boolean;
   worktree?: string;
   base?: string;
   image?: string[];
@@ -276,6 +279,14 @@ function validateRunOptions(prompt: string, options: AgentRunOptions, outputSche
       details: "Structured output requires waiting for the agent to finish",
     } satisfies CommandError;
   }
+
+  if (options.yolo && options.mode) {
+    throw {
+      code: "INVALID_OPTIONS",
+      message: "--yolo cannot be used with --mode",
+      details: "Use either --yolo or a provider-specific --mode value, not both",
+    } satisfies CommandError;
+  }
 }
 
 function parseWaitTimeoutOption(waitTimeout: string | undefined): number {
@@ -353,6 +364,36 @@ async function connectToDaemonOrThrow(
   }
 }
 
+async function resolveYoloModeOrThrow(options: {
+  client: ConnectedDaemonClient;
+  provider: string;
+  cwd: string;
+}): Promise<string> {
+  const snapshot = await options.client.getProvidersSnapshot({ cwd: options.cwd });
+  const cachedMode = resolveYoloModeFromProviderSnapshot(options.provider, snapshot.entries);
+  if (cachedMode) {
+    return cachedMode;
+  }
+
+  await options.client.refreshProvidersSnapshot({
+    cwd: options.cwd,
+    providers: [options.provider],
+  });
+  const refreshedSnapshot = await options.client.getProvidersSnapshot({ cwd: options.cwd });
+  const refreshedMode = resolveYoloModeFromProviderSnapshot(
+    options.provider,
+    refreshedSnapshot.entries,
+  );
+  if (refreshedMode) {
+    return refreshedMode;
+  }
+
+  throw {
+    code: "INVALID_OPTIONS",
+    message: `Provider ${options.provider} does not expose a yolo/no-prompt mode`,
+  } satisfies CommandError;
+}
+
 export async function runRunCommand(
   prompt: string,
   options: AgentRunOptions,
@@ -372,6 +413,13 @@ export async function runRunCommand(
   try {
     // Resolve working directory
     const cwd = options.cwd ?? process.cwd();
+    const modeId = options.yolo
+      ? await resolveYoloModeOrThrow({
+          client,
+          provider: resolvedProviderModel.provider,
+          cwd,
+        })
+      : options.mode;
     const thinkingOptionId = options.thinking?.trim();
     if (options.thinking !== undefined && !thinkingOptionId) {
       const error: CommandError = {
@@ -404,7 +452,7 @@ export async function runRunCommand(
             provider: resolvedProviderModel.provider,
             cwd,
             title: resolvedTitle,
-            modeId: options.mode,
+            modeId,
             model: resolvedProviderModel.model,
             thinkingOptionId,
             initialPrompt: structuredPrompt,
@@ -474,7 +522,7 @@ export async function runRunCommand(
       provider: resolvedProviderModel.provider,
       cwd,
       title: resolvedTitle,
-      modeId: options.mode,
+      modeId,
       model: resolvedProviderModel.model,
       thinkingOptionId,
       initialPrompt: prompt,

--- a/packages/cli/src/commands/agent/yolo-mode.ts
+++ b/packages/cli/src/commands/agent/yolo-mode.ts
@@ -1,0 +1,31 @@
+interface ProviderModeLike {
+  id: string;
+}
+
+interface ProviderSnapshotEntryLike {
+  provider: string;
+  modes?: ProviderModeLike[];
+}
+
+const YOLO_MODE_PRIORITY = [
+  "full-access",
+  "bypassPermissions",
+  "https://agentclientprotocol.com/protocol/session-modes#autopilot",
+  "build",
+] as const;
+
+export function resolveYoloModeFromModes(modes: ProviderModeLike[] | undefined): string | null {
+  if (!modes || modes.length === 0) {
+    return null;
+  }
+  const modeIds = new Set(modes.map((mode) => mode.id));
+  return YOLO_MODE_PRIORITY.find((modeId) => modeIds.has(modeId)) ?? null;
+}
+
+export function resolveYoloModeFromProviderSnapshot(
+  provider: string,
+  entries: ProviderSnapshotEntryLike[],
+): string | null {
+  const entry = entries.find((item) => item.provider === provider);
+  return resolveYoloModeFromModes(entry?.modes);
+}

--- a/packages/cli/tests/05-agent-run.test.ts
+++ b/packages/cli/tests/05-agent-run.test.ts
@@ -17,6 +17,7 @@
  * - run --name flag is accepted
  * - run --provider flag is accepted
  * - run --mode flag is accepted
+ * - run --yolo flag is accepted
  * - run --cwd flag is accepted
  */
 
@@ -57,6 +58,7 @@ try {
     assert(result.stdout.includes("--title"), "help should mention --title option");
     assert(result.stdout.includes("--provider"), "help should mention --provider option");
     assert(result.stdout.includes("--mode"), "help should mention --mode option");
+    assert(result.stdout.includes("--yolo"), "help should mention --yolo option");
     assert(result.stdout.includes("--cwd"), "help should mention --cwd option");
     assert(result.stdout.includes("--output-schema"), "help should mention --output-schema option");
     assert(result.stdout.includes("--host"), "help should mention --host option");
@@ -85,7 +87,7 @@ try {
   {
     console.log("Test 3: run handles daemon not running");
     const result =
-      await $`PASEO_HOST=localhost:${port} PASEO_HOME=${paseoHome} npx paseo run "test prompt"`.nothrow();
+      await $`PASEO_HOST=localhost:${port} PASEO_HOME=${paseoHome} npx paseo run --provider codex "test prompt"`.nothrow();
     // Should fail because daemon not running
     assert.notStrictEqual(result.exitCode, 0, "should fail when daemon not running");
     const output = result.stdout + result.stderr;
@@ -163,6 +165,17 @@ try {
     console.log("✓ run --cwd flag is accepted\n");
   }
 
+  // Test 8b: run --yolo flag is accepted
+  {
+    console.log("Test 8b: run --yolo flag is accepted");
+    const result =
+      await $`PASEO_HOST=localhost:${port} PASEO_HOME=${paseoHome} npx paseo run --yolo "test prompt"`.nothrow();
+    const output = result.stdout + result.stderr;
+    assert(!output.includes("unknown option"), "should accept --yolo flag");
+    assert(!output.includes("error: option"), "should not have option parsing error");
+    console.log("✓ run --yolo flag is accepted\n");
+  }
+
   // Test 9: run --output-schema flag is accepted
   {
     console.log("Test 9: run --output-schema flag is accepted");
@@ -222,6 +235,20 @@ try {
       "should explain conflicting model inputs",
     );
     console.log("✓ conflicting provider/model syntax is rejected\n");
+  }
+
+  // Test 12c: run --yolo cannot be combined with --mode
+  {
+    console.log("Test 12c: run --yolo cannot be combined with --mode");
+    const result =
+      await $`PASEO_HOST=localhost:${port} PASEO_HOME=${paseoHome} npx paseo run --yolo --mode full-access "test prompt"`.nothrow();
+    assert.notStrictEqual(result.exitCode, 0, "should fail with --yolo and --mode");
+    const output = result.stdout + result.stderr;
+    assert(
+      output.includes("--yolo cannot be used with --mode"),
+      "error should explain yolo/mode incompatibility",
+    );
+    console.log("✓ run --yolo cannot be combined with --mode\n");
   }
 
   // Test 13: paseo --help shows run command


### PR DESCRIPTION
## Summary
- add `--yolo` to `paseo run` and `paseo agent run`
- resolve provider-specific no-prompt modes from provider snapshots
- reject `--yolo` when combined with explicit `--mode`

## Tests
- `npx vitest run packages/cli/src/commands/agent/run.test.ts --bail=1`
- `npx tsx packages/cli/tests/05-agent-run.test.ts`
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`