### PR TITLE
fix: keep @ file mention responsive on very large projects

### DIFF
--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import type { AutocompleteOption } from "@/components/ui/autocomplete";
 import { useAgentCommandsQuery, type DraftCommandConfig } from "./use-agent-commands-query";
@@ -185,6 +185,12 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
   );
   const showFileAutocomplete = activeFileMention !== null;
   const fileFilterQuery = activeFileMention?.query ?? "";
+  const [debouncedFileFilterQuery, setDebouncedFileFilterQuery] = useState(fileFilterQuery);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedFileFilterQuery(fileFilterQuery), 180);
+    return () => clearTimeout(timer);
+  }, [fileFilterQuery]);
 
   const normalizedDraftConfig = useMemo(
     () => normalizeDraftCommandConfig(draftConfig),
@@ -229,14 +235,21 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
   });
 
   const fileSuggestionsQuery = useQuery({
-    queryKey: ["directorySuggestions", serverId, autocompleteCwd, fileFilterQuery, true, true],
+    queryKey: [
+      "directorySuggestions",
+      serverId,
+      autocompleteCwd,
+      debouncedFileFilterQuery,
+      true,
+      true,
+    ],
     queryFn: async (): Promise<DirectorySuggestionEntry[]> => {
       if (!client) {
         throw new Error("Daemon client unavailable");
       }
       const response = await client.getDirectorySuggestions({
         cwd: autocompleteCwd,
-        query: fileFilterQuery,
+        query: debouncedFileFilterQuery,
         limit: 50,
         includeFiles: true,
         includeDirectories: true,

--- a/packages/server/src/utils/directory-suggestions.test.ts
+++ b/packages/server/src/utils/directory-suggestions.test.ts
@@ -265,4 +265,34 @@ describe("searchWorkspaceEntries", () => {
     });
     expect(results.some((entry) => entry.path.startsWith("node_modules/"))).toBe(false);
   });
+
+  it("ignores common build/cache directories so large generated trees do not exhaust scan budget", async () => {
+    mkdirSync(path.join(workspaceDir, "packages", "app", "src"), { recursive: true });
+    writeFileSync(path.join(workspaceDir, "packages", "app", "src", "needle.ts"), "");
+
+    const heavyDirs = ["dist", "build", "target", "out", "coverage", "vendor", "__pycache__"];
+    for (const heavyDir of heavyDirs) {
+      for (let index = 0; index < 30; index += 1) {
+        mkdirSync(path.join(workspaceDir, heavyDir, `bundle-${index}`), { recursive: true });
+        writeFileSync(path.join(workspaceDir, heavyDir, `bundle-${index}`, "needle.ts"), "");
+      }
+    }
+
+    const results = await searchWorkspaceEntries({
+      cwd: workspaceDir,
+      query: "needle.ts",
+      limit: 20,
+      includeFiles: true,
+      includeDirectories: true,
+      maxEntriesScanned: 80,
+    });
+
+    expect(results).toContainEqual({
+      path: "packages/app/src/needle.ts",
+      kind: "file",
+    });
+    for (const heavyDir of heavyDirs) {
+      expect(results.some((entry) => entry.path.startsWith(`${heavyDir}/`))).toBe(false);
+    }
+  });
 });

--- a/packages/server/src/utils/directory-suggestions.ts
+++ b/packages/server/src/utils/directory-suggestions.ts
@@ -73,7 +73,16 @@ const directoryListCache = new Map<string, DirectoryListCacheEntry>();
 const workspaceEntryListCache = new Map<string, WorkspaceEntryListCacheEntry>();
 const NO_SEGMENT_INDEX = Number.MAX_SAFE_INTEGER;
 const NO_MATCH_OFFSET = Number.MAX_SAFE_INTEGER;
-const WORKSPACE_IGNORED_DIRECTORY_NAMES = new Set(["node_modules"]);
+const WORKSPACE_IGNORED_DIRECTORY_NAMES = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  "target",
+  "out",
+  "coverage",
+  "vendor",
+  "__pycache__",
+]);
 
 export async function searchHomeDirectories(
   options: SearchHomeDirectoriesOptions,


### PR DESCRIPTION
## Summary
- Debounce the `@` file-mention query (180 ms) so a burst of keystrokes coalesces into one daemon request instead of firing one per character.
- Extend the workspace search ignore list with `dist`, `build`, `target`, `out`, `coverage`, `vendor`, `__pycache__` so the BFS scan budget is no longer exhausted by generated trees on large projects.

Fixes #599.

## Why
On very large workspaces, typing `@components/c` previously fired ~13 concurrent `directory_suggestions_request` messages, each kicking off a fresh 5,000-entry BFS on the daemon. The only ignored directory was `node_modules`, so heavy generated dirs (`dist`, `build`, `target`, …) burned the budget before any real source file was reached. The combination saturated the daemon's I/O loop and made the whole app appear frozen until the keystroke storm cleared. See #599 for full repro and analysis.

## Test plan
- [x] `npx vitest run packages/server/src/utils/directory-suggestions.test.ts` — 14/14 pass, including a new regression test that proves a deep source file is still reachable when seven heavy build dirs each contain 30 bait files (the test fails before the ignore-list expansion).
- [x] `npm run lint -- packages/app/src/hooks/use-agent-autocomplete.ts packages/server/src/utils/directory-suggestions.ts packages/server/src/utils/directory-suggestions.test.ts` — clean.
- [x] `npm run format:check:files -- …` — clean.
- [x] Workspace-aware typecheck for the touched packages (`@getpaseo/app`, `@getpaseo/server`) — clean. Note: the full `npm run typecheck` reports two pre-existing `envMode` errors in `@getpaseo/desktop` and `@getpaseo/cli` from `15df680a` (#585), unrelated to this change.
- [ ] Manual smoke: open a real large workspace, type `@` + characters; autocomplete responds without freezing the app.

## Compatibility
No WebSocket or schema changes. Server still accepts the same request, just returns faster. Client still sends the same request, just with a short debounce on the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)