### PR TITLE
fix(server): preserve fatal log on crash and guard socket.send against close races

### DIFF
--- a/packages/server/src/server/index.ts
+++ b/packages/server/src/server/index.ts
@@ -207,19 +207,23 @@ async function main() {
 
   process.on("uncaughtException", (err) => {
     logger.fatal({ err }, "Uncaught exception — daemon crashing");
-    process.exit(1);
+    exitAfterPinoFlush();
   });
 
   process.on("unhandledRejection", (reason) => {
     logger.fatal({ err: reason }, "Unhandled promise rejection — daemon crashing");
-    process.exit(1);
+    exitAfterPinoFlush();
   });
+}
+
+// Give pino async streams a moment to flush the fatal log entry to daemon.log
+// before the process exits. Without this, the last few entries that explain
+// why the daemon crashed can be lost.
+function exitAfterPinoFlush(): void {
+  setTimeout(() => process.exit(1), 200);
 }
 
 main().catch((err) => {
   process.stderr.write(`${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
-  // Give pino streams a moment to flush the fatal log entry to daemon.log
-  // before the process exits. Without this, async file streams may lose the
-  // last few entries that explain why the daemon crashed.
-  setTimeout(() => process.exit(1), 200);
+  exitAfterPinoFlush();
 });

--- a/packages/server/src/server/relay-transport.ts
+++ b/packages/server/src/server/relay-transport.ts
@@ -396,7 +396,7 @@ async function attachEncryptedSocket(
   metadata?: ExternalSocketMetadata,
 ): Promise<void> {
   try {
-    const relayTransport = createRelayTransportAdapter(socket);
+    const relayTransport = createRelayTransportAdapter(socket, logger);
     const emitter = new EventEmitter();
     const channel = await createDaemonChannel(relayTransport, daemonKeyPair, {
       onmessage: (data) => emitter.emit("message", data),
@@ -418,9 +418,18 @@ async function attachEncryptedSocket(
   }
 }
 
-function createRelayTransportAdapter(socket: WebSocket): RelayTransport {
+function createRelayTransportAdapter(socket: WebSocket, logger: pino.Logger): RelayTransport {
   const relayTransport: RelayTransport = {
-    send: (data) => socket.send(data),
+    send: (data) => {
+      try {
+        socket.send(data);
+      } catch (err) {
+        // Socket likely transitioned to closed between checks; let onclose/onerror
+        // drive cleanup. Without this guard the synchronous throw would propagate
+        // up as an uncaughtException and take down the daemon.
+        logger.warn({ err }, "relay_socket_send_failed");
+      }
+    },
     close: (code?: number, reason?: string) => socket.close(code, reason),
     onmessage: null,
     onclose: null,

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -738,10 +738,17 @@ export class VoiceAssistantWebSocketServer {
   }
 
   private sendToClient(ws: WebSocketLike, message: WSOutboundMessage): void {
-    // WebSocket.OPEN = 1
-    if (ws.readyState === 1) {
+    // WebSocket.OPEN = 1. The check is a fast path; the socket can still
+    // transition to closed between here and ws.send(), so guard the send too —
+    // a synchronous throw here would propagate as an uncaughtException.
+    if (ws.readyState !== 1) {
+      return;
+    }
+    try {
       ws.send(JSON.stringify(message));
       this.recordOutboundMessage(message, ws);
+    } catch (err) {
+      this.logger.warn({ err }, "ws_send_failed");
     }
   }
 
@@ -749,8 +756,12 @@ export class VoiceAssistantWebSocketServer {
     if (ws.readyState !== 1) {
       return;
     }
-    ws.send(frame);
-    this.recordOutboundBinaryFrame(ws);
+    try {
+      ws.send(frame);
+      this.recordOutboundBinaryFrame(ws);
+    } catch (err) {
+      this.logger.warn({ err }, "ws_send_binary_failed");
+    }
   }
 
   private sendToConnection(connection: SessionConnection, message: WSOutboundMessage): void {


### PR DESCRIPTION
## Summary

- `index.ts` — pull `setTimeout(() => process.exit(1), 200)` into a shared `exitAfterPinoFlush()` and use it from `uncaughtException` / `unhandledRejection` so fatal log entries actually reach `daemon.log` before the process dies (pino is async).
- `relay-transport.ts` — wrap `socket.send(...)` in the relay adapter with try/catch and warn-log; lets `onclose`/`onerror` drive cleanup instead of an uncaughtException.
- `websocket-server.ts` — same guard on `sendToClient` / `sendBinaryToClient`. Keep the `readyState === 1` fast path; it's still useful, but it's a fast path, not a guarantee.

Closes #612.

## Why

Observed a daemon that vanished mid-stream with no fatal entry in the log. Investigation traced it to two compounding bugs:

1. The fatal handlers in `index.ts:208-216` exit immediately after `logger.fatal(...)`, but pino is configured async (`logger.ts:277,281-285` — `sync: false` console + rotating-file-stream). The same code base already worked around this for `main().catch` at line 224 — the process-level handlers just hadn't been updated to match.
2. `socket.send()` and `ws.send()` were unprotected at three call sites. `ws` throws synchronously on send-after-close, and the `readyState === 1` check has a race window. During an active foreground turn streaming `agent_stream` output, a peer-side disconnect could escalate into an uncaughtException — which #1 then ate.

Together: the bug had no diagnostic trail. Fix #1 makes the next crash recoverable; fix #2 prevents the most likely trigger.

## Test plan

- [x] `npm run typecheck` (clean — pre-commit hook ran)
- [x] `npm run lint -- <changed files>` (0 warnings)
- [x] `npm run format:check:files -- <changed files>` (clean)
- [ ] Smoke test on local daemon: start `npm run dev`, force-quit the Electron app while a turn is streaming, confirm daemon stays up and `ws_send_failed` warns appear in `daemon.log`
- [ ] Optionally: deliberately throw from a setImmediate to verify the fatal entry now lands in `daemon.log` before exit

## Not in scope

- Server-side WebSocket ping/pong heartbeats — separate concern.
- The `ProcessTransport is not ready for writing` warning from the Claude SDK observed near the crash — already caught and logged; not the trigger.
- The `read_project_config_request` validation noise from forward-compat clients — harmless, separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)