### PR TITLE
feat(server): add Dirac as a built-in ACP provider

### DIFF
--- a/docs/CUSTOM-PROVIDERS.md
+++ b/docs/CUSTOM-PROVIDERS.md
@@ -364,6 +364,30 @@ Required fields for ACP providers:
 
 Ref: [Gemini CLI ACP mode docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/acp-mode.md)
 
+### Example: Dirac
+
+[Dirac](https://dirac.run) is an autonomous coding agent CLI by Dirac Delta Labs with file editing, command execution, browser automation, and MCP support. It supports ACP via the `--acp` flag.
+
+1. Install: `npm install -g dirac` or see [Dirac docs](https://github.com/dirac-run/dirac)
+2. Add to config.json:
+
+```json
+{
+  "agents": {
+    "providers": {
+      "dirac": {
+        "extends": "acp",
+        "label": "Dirac",
+        "description": "Autonomous coding agent CLI by Dirac Delta Labs",
+        "command": ["dirac", "--acp"]
+      }
+    }
+  }
+}
+```
+
+Ref: [Dirac agent registry](https://github.com/dirac-run/dirac/blob/master/agent-registry/dirac/agent.json)
+
 ### Example: Hermes (Nous Research)
 
 [Hermes](https://github.com/NousResearch/hermes-agent) is an open-source coding agent by Nous Research with persistent memory and multi-provider LLM support. It supports ACP via the `acp` subcommand.
@@ -527,7 +551,7 @@ Use `disallowedTools` to disable unsupported tools:
 
 ### Valid `extends` values
 
-Built-in providers: `claude`, `codex`, `copilot`, `opencode`, `pi`
+Built-in providers: `claude`, `codex`, `copilot`, `dirac`, `opencode`, `pi`
 
 Special value: `acp` — creates a generic ACP provider (requires `command`)
 
@@ -574,6 +598,13 @@ A config.json with multiple custom providers:
         "extends": "acp",
         "label": "Google Gemini",
         "command": ["gemini", "--acp"]
+      },
+
+      "dirac": {
+        "extends": "acp",
+        "label": "Dirac",
+        "description": "Autonomous coding agent CLI by Dirac Delta Labs",
+        "command": ["dirac", "--acp"]
       },
 
       "hermes": {

--- a/packages/cli/src/commands/provider/index.ts
+++ b/packages/cli/src/commands/provider/index.ts
@@ -15,7 +15,7 @@ export function createProviderCommand(): Command {
     provider
       .command("models")
       .description("List models for a provider")
-      .argument("<provider>", "Provider name (claude, codex, opencode)")
+      .argument("<provider>", "Provider name (claude, codex, dirac, opencode)")
       .option("--thinking", "Include thinking option IDs for each model"),
   ).action(withOutput(runModelsCommand));
 

--- a/packages/server/src/server/agent/provider-launch-config.test.ts
+++ b/packages/server/src/server/agent/provider-launch-config.test.ts
@@ -159,7 +159,7 @@ describe("ProviderOverrideSchema", () => {
 });
 
 describe("migrateProviderSettings", () => {
-  const builtinProviderIds = ["claude", "codex", "copilot", "opencode", "pi"];
+  const builtinProviderIds = ["claude", "codex", "copilot", "dirac", "opencode", "pi"];
 
   test("passes through entries already in the new format", () => {
     const migrated = migrateProviderSettings(

--- a/packages/server/src/server/agent/provider-manifest.ts
+++ b/packages/server/src/server/agent/provider-manifest.ts
@@ -123,6 +123,30 @@ const OPENCODE_MODES: AgentProviderModeDefinition[] = [
   },
 ];
 
+const DIRAC_MODES: AgentProviderModeDefinition[] = [
+  {
+    id: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    label: "Agent",
+    description: "Default agent mode for conversational interactions",
+    icon: "ShieldAlert",
+    colorTier: "moderate",
+  },
+  {
+    id: "https://agentclientprotocol.com/protocol/session-modes#plan",
+    label: "Plan",
+    description: "Plan mode for creating and executing multi-step plans",
+    icon: "ShieldCheck",
+    colorTier: "planning",
+  },
+  {
+    id: "https://agentclientprotocol.com/protocol/session-modes#autopilot",
+    label: "Autopilot",
+    description: "Autonomous mode that runs until task completion without user interaction",
+    icon: "ShieldOff",
+    colorTier: "dangerous",
+  },
+];
+
 const MOCK_LOAD_TEST_MODES: AgentProviderModeDefinition[] = [
   {
     id: "load-test",
@@ -164,6 +188,13 @@ export const AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [
     description: "GitHub Copilot via Agent Client Protocol with dynamic modes and session support",
     defaultModeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
     modes: COPILOT_MODES,
+  },
+  {
+    id: "dirac",
+    label: "Dirac",
+    description: "Autonomous coding agent CLI by Dirac Delta Labs with multi-tool and ACP support",
+    defaultModeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    modes: DIRAC_MODES,
   },
   {
     id: "opencode",

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -423,6 +423,10 @@ test("new provider extending acp uses GenericACPAgentClient", () => {
   expect(registry["my-agent"].createClient(logger).provider).toBe("my-agent");
   expect(mockState.constructorArgs.genericAcp).toEqual([
     {
+      command: ["dirac", "--acp"],
+      env: undefined,
+    },
+    {
       command: ["my-agent", "--acp"],
       env: {
         ACP_TOKEN: "secret",

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -90,6 +90,12 @@ const PROVIDER_CLIENT_FACTORIES: Record<string, ProviderClientFactory> = {
       logger,
       runtimeSettings,
     }),
+  dirac: (logger, runtimeSettings) =>
+    new GenericACPAgentClient({
+      logger,
+      command: ["dirac", "--acp"],
+      env: runtimeSettings?.env,
+    }),
   mock: (logger) => new MockLoadTestAgentClient(logger),
 };
 

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -118,7 +118,7 @@ const FeatureVoiceModeSchema = z
   })
   .strict();
 
-const BUILTIN_PROVIDER_IDS = ["claude", "codex", "copilot", "opencode", "pi"] as const;
+const BUILTIN_PROVIDER_IDS = ["claude", "codex", "copilot", "dirac", "opencode", "pi"] as const;
 const PROVIDER_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
 
 const ProviderOverridesSchema = z


### PR DESCRIPTION
## Summary

Adds [Dirac](https://dirac.run) as a built-in provider in Paseo. Dirac is an autonomous coding agent CLI by Dirac Delta Labs with file editing, command execution, browser automation, and MCP support. It supports the Agent Client Protocol (ACP) via the `--acp` flag.

Closes #590

## Changes

- **provider-manifest.ts**: Registered Dirac in `AGENT_PROVIDER_DEFINITIONS` with standard ACP modes (Agent, Plan, Autopilot)
- **provider-registry.ts**: Added Dirac factory using `GenericACPAgentClient` with `["dirac", "--acp"]`
- **persisted-config.ts**: Added `"dirac"` to `BUILTIN_PROVIDER_IDS` for config validation
- **provider-launch-config.test.ts**: Updated test's builtin provider list
- **provider-registry.test.ts**: Updated test to account for Dirac's `GenericACPAgentClient` constructor call
- **CLI help text**: Updated to include `dirac` in provider argument hints
- **CUSTOM-PROVIDERS.md**: Documented Dirac as both a built-in provider and as a custom ACP provider example for users who want to configure it manually

## Testing

- **Unit tests**: All 60 tests pass across `provider-launch-config.test.ts`, `provider-registry.test.ts`, and `persisted-config.test.ts`
- **Formatting**: Passes `oxfmt --check`
- **Linting**: Passes `oxlint` with 0 warnings, 0 errors
- **Note**: The full monorepo typecheck has pre-existing failures (missing `@getpaseo/highlight` build artifacts, implicit `any` types in unrelated files) which are not introduced by this change

## How it works

Dirac is registered as a built-in ACP provider — just like Copilot is a built-in ACP provider. Paseo spawns it with `dirac --acp` and communicates via the ACP protocol over stdio. Models and modes are discovered dynamically at runtime from the Dirac process. Users can also override or customize it via `config.json` using the usual custom provider mechanism.