### PR TITLE
Serve web client as self-hosted target

### DIFF
--- a/packages/app/src/polyfills/crypto.ts
+++ b/packages/app/src/polyfills/crypto.ts
@@ -47,11 +47,6 @@ export function polyfillCrypto(): void {
     g.crypto = {} as Crypto;
   }
 
-  if (typeof g.crypto.randomUUID !== "function") {
-    g.crypto.randomUUID = () =>
-      ExpoCrypto.randomUUID() as `${string}-${string}-${string}-${string}-${string}`;
-  }
-
   if (typeof g.crypto.getRandomValues !== "function") {
     g.crypto.getRandomValues = <T extends ArrayBufferView | null>(array: T): T => {
       if (array === null) return array;
@@ -59,5 +54,18 @@ export function polyfillCrypto(): void {
         array as unknown as Parameters<typeof ExpoCrypto.getRandomValues>[0],
       ) as unknown as T;
     };
+  }
+
+  if (typeof g.crypto.randomUUID !== "function") {
+    g.crypto.randomUUID = (() => {
+      const bytes = new Uint8Array(16);
+      g.crypto!.getRandomValues(bytes);
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex: string[] = [];
+      for (let i = 0; i < 16; i++) hex.push(bytes[i].toString(16).padStart(2, "0"));
+      const h = hex.join("");
+      return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20, 32)}` as `${string}-${string}-${string}-${string}-${string}`;
+    }) as Crypto["randomUUID"];
   }
 }

--- a/packages/server/src/shared/connection-offer.ts
+++ b/packages/server/src/shared/connection-offer.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import { z } from "zod";
 
 /**
@@ -24,7 +23,10 @@ export type ConnectionOffer = ConnectionOfferV2;
 function decodeBase64UrlToUtf8(input: string): string {
   const base64 = input.replace(/-/g, "+").replace(/_/g, "/");
   const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
-  return Buffer.from(padded, "base64").toString("utf8");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
 }
 
 export function decodeOfferFragmentPayload(encoded: string): unknown {


### PR DESCRIPTION
This pull request refactors how `randomUUID` is polyfilled in the browser and updates base64 decoding logic to remove a Node.js dependency, making the code more portable and compatible with browser environments. This makes it possible to run the web client on the target machine without the needs to pairing, which greatly benefits environment where security is already established through a Zero-Trust VPN such as Netbird or Tailscale.

### Crypto polyfill improvements

* Replaces the previous `randomUUID` polyfill (which used `ExpoCrypto`) with a new implementation that generates a UUID using `getRandomValues` and manual formatting, making it independent of external libraries and more suitable for browser environments. [[1]](diffhunk://#diff-581248f07914249942649be05ebf43b9b432d6498bc9b0f8ee783abeb7ef875cL50-L54) [[2]](diffhunk://#diff-581248f07914249942649be05ebf43b9b432d6498bc9b0f8ee783abeb7ef875cR58-R70)

### Node.js dependency removal

* Removes the import of `Buffer` from `node:buffer` in `connection-offer.ts`, and rewrites the base64 decoding logic to use `atob` and `TextDecoder` instead of `Buffer.from`, increasing compatibility with browsers and non-Node.js environments. [[1]](diffhunk://#diff-ed6ffa441589a501fe72fed5609e92e03e3175293547065577ddbfa216a313f5L1) [[2]](diffhunk://#diff-ed6ffa441589a501fe72fed5609e92e03e3175293547065577ddbfa216a313f5L27-R29)