### PR TITLE
test(server): align worktree tests with explicit PR context

### DIFF
--- a/packages/server/src/client/daemon-client.test.ts
+++ b/packages/server/src/client/daemon-client.test.ts
@@ -562,7 +562,7 @@ test("omitting create_agent_request worktree base-ref fields preserves legacy wi
   await expect(createPromise).rejects.toThrow("legacy git shape sentinel");
 });
 
-test("sends structured attachments with create_paseo_worktree_request", async () => {
+test("sends structured first-agent context attachments with create_paseo_worktree_request", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();
 
@@ -582,15 +582,17 @@ test("sends structured attachments with create_paseo_worktree_request", async ()
   const createPromise = client.createPaseoWorktree({
     cwd: "/tmp/project",
     worktreeSlug: "review-pr-123",
-    attachments: [
-      {
-        type: "github_pr",
-        mimeType: "application/github-pr",
-        number: 123,
-        title: "Fix race in worktree setup",
-        url: "https://github.com/getpaseo/paseo/pull/123",
-      },
-    ],
+    firstAgentContext: {
+      attachments: [
+        {
+          type: "github_pr",
+          mimeType: "application/github-pr",
+          number: 123,
+          title: "Fix race in worktree setup",
+          url: "https://github.com/getpaseo/paseo/pull/123",
+        },
+      ],
+    },
   });
 
   expect(mock.sent).toHaveLength(1);
@@ -599,10 +601,12 @@ test("sends structured attachments with create_paseo_worktree_request", async ()
     message: {
       type: "create_paseo_worktree_request";
       requestId: string;
-      attachments: Array<{ type: string; mimeType: string; number: number }>;
+      firstAgentContext: {
+        attachments: Array<{ type: string; mimeType: string; number: number }>;
+      };
     };
   };
-  expect(request.message.attachments).toEqual([
+  expect(request.message.firstAgentContext.attachments).toEqual([
     {
       type: "github_pr",
       mimeType: "application/github-pr",

--- a/packages/server/src/server/worktree-core.test.ts
+++ b/packages/server/src/server/worktree-core.test.ts
@@ -182,7 +182,6 @@ describe.skipIf(process.platform === "win32")("createWorktreeCore", () => {
       {
         cwd: repoDir,
         worktreeSlug: "legacy-rpc",
-        attachments: [],
         paseoHome,
         runSetup: false,
       },
@@ -199,7 +198,7 @@ describe.skipIf(process.platform === "win32")("createWorktreeCore", () => {
     expect(existsSync(result.worktree.worktreePath)).toBe(true);
   });
 
-  test("checks out the legacy RPC GitHub PR attachment branch", async () => {
+  test("checks out an explicit GitHub PR branch with legacy RPC fields", async () => {
     const { tempDir, repoDir, paseoHome } = createGitHubPrRemoteRepo();
     cleanupPaths.push(tempDir);
 
@@ -207,19 +206,10 @@ describe.skipIf(process.platform === "win32")("createWorktreeCore", () => {
       {
         cwd: repoDir,
         worktreeSlug: "review-pr-123",
+        githubPrNumber: 123,
+        refName: "feature/review-pr",
         paseoHome,
         runSetup: false,
-        attachments: [
-          {
-            type: "github_pr",
-            mimeType: "application/github-pr",
-            number: 123,
-            title: "Review branch",
-            url: "https://github.com/getpaseo/paseo/pull/123",
-            baseRefName: "main",
-            headRefName: "feature/review-pr",
-          },
-        ],
       },
       createCoreDeps(),
     );
@@ -240,19 +230,10 @@ describe.skipIf(process.platform === "win32")("createWorktreeCore", () => {
     const result = await createCoreWorktree(
       {
         cwd: repoDir,
+        githubPrNumber: 123,
+        refName: "feature/review-pr",
         paseoHome,
         runSetup: false,
-        attachments: [
-          {
-            type: "github_pr",
-            mimeType: "application/github-pr",
-            number: 123,
-            title: "Review branch",
-            url: "https://github.com/getpaseo/paseo/pull/123",
-            baseRefName: "main",
-            headRefName: "feature/review-pr",
-          },
-        ],
       },
       createCoreDeps(),
     );
@@ -549,19 +530,10 @@ describe.skipIf(process.platform === "win32")("createWorktreeCore", () => {
     const deps = createCoreDeps();
     const input = {
       cwd: repoDir,
+      githubPrNumber: 123,
+      refName: "feature/review-pr",
       paseoHome,
       runSetup: false,
-      attachments: [
-        {
-          type: "github_pr" as const,
-          mimeType: "application/github-pr" as const,
-          number: 123,
-          title: "Review branch",
-          url: "https://github.com/getpaseo/paseo/pull/123",
-          baseRefName: "main",
-          headRefName: "feature/review-pr",
-        },
-      ],
     };
 
     const first = await createCoreWorktree(input, deps);
@@ -588,18 +560,9 @@ describe.skipIf(process.platform === "win32")("createWorktreeCore", () => {
       {
         cwd: repoDir,
         worktreeSlug: "stubbed-github",
+        githubPrNumber: 123,
         paseoHome,
         runSetup: false,
-        attachments: [
-          {
-            type: "github_pr",
-            mimeType: "application/github-pr",
-            number: 123,
-            title: "Review branch",
-            url: "https://github.com/getpaseo/paseo/pull/123",
-            baseRefName: "main",
-          },
-        ],
       },
       createCoreDeps({ github }),
     );


### PR DESCRIPTION
## Summary
- classify the red server tests as test drift from 2f177dde
- update worktree-core PR checkout tests to use explicit githubPrNumber/refName instead of attachment fallback
- update daemon-client worktree attachment assertion to the firstAgentContext wire shape

## Verification
- npm run format
- npm run typecheck
- npm run lint
- npx vitest run packages/server/src/server/worktree-core.test.ts packages/server/src/client/daemon-client.test.ts --bail=1