### PR TITLE
Add browser pane element picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,14 @@ The app runs on iOS, Android, web (browser), and web (Electron desktop). Code is
     use-audio-recorder.native.ts ← uses expo-audio
   ```
   Import as `@/hooks/use-audio-recorder` — Metro picks the right file automatically.
+- **Use `.electron.ts` / `.electron.tsx` for Electron-only web modules.** Electron is still the Metro `web` platform, but desktop dev/build sets `PASEO_WEB_PLATFORM=electron`, so Metro first looks for `.electron.*` files and falls back to normal `.web.*` files. Use this when the implementation depends on Electron-only behavior such as `webviewTag`, desktop preload APIs, or the Electron bridge. Keep plain browser web in `.web.*`, and keep native fallbacks in the base file or `.native.*`.
+  ```
+  components/
+    browser-pane.electron.tsx ← Electron <webview> implementation
+    browser-pane.web.tsx      ← plain web fallback
+    browser-pane.tsx          ← native fallback
+  ```
+  Import as `@/components/browser-pane` — Electron desktop gets the `.electron.tsx` file, browser web gets `.web.tsx`, and native gets the native/base implementation.
 - **NEVER use raw DOM APIs without `isWeb` guard.** DOM APIs crash native. Casting a RN ref to `HTMLElement` is a red flag — ensure the block is web-only.
 - **NEVER use `onPointerEnter`/`onPointerLeave`.** They don't fire on native iOS.
 - **Hover only works on web.** React Native's `onHoverIn`/`onHoverOut` on `Pressable` does NOT fire on native iOS/iPad — the underlying W3C pointer events are behind disabled experimental flags. For hover-to-show UI (kebab menus, action buttons), use `isHovered || isNative || isCompact` so the controls are always visible on native and hover-to-show on web.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "web": "npm run web --workspace=@getpaseo/app",
     "dev:desktop": "npm run dev --workspace=@getpaseo/desktop",
     "dev:win:desktop": "npm run dev:win --workspace=@getpaseo/desktop",
-    "build:desktop": "npm run version:sync-internal && npm run build:web --workspace=@getpaseo/app && npm run build --workspace=@getpaseo/desktop",
+    "build:desktop": "npm run version:sync-internal && PASEO_WEB_PLATFORM=electron npm run build:web --workspace=@getpaseo/app && npm run build --workspace=@getpaseo/desktop",
     "db:query": "npm run db:query --workspace=@getpaseo/server --",
     "cli": "npx tsx packages/cli/src/index.js",
     "version": "npm run version:sync-internal && npm run release:prepare && git add -A",

--- a/packages/app/src/attachments/composer-workspace-attachments.tsx
+++ b/packages/app/src/attachments/composer-workspace-attachments.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useMemo, useState, type ReactElement } from "react";
 import { Text, View } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
-import { CircleDot } from "lucide-react-native";
+import { CircleDot, MousePointer2 } from "lucide-react-native";
 import type {
   ComposerAttachment,
   UserComposerAttachment,
   WorkspaceComposerAttachment,
 } from "@/attachments/types";
 import { AttachmentPill } from "@/components/attachment-pill";
+import { useWorkspaceAttachmentsStore } from "@/attachments/workspace-attachments-store";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import type { AgentAttachment } from "@server/shared/messages";
 import { useClearReviewDraft } from "@/review/store";
@@ -43,6 +44,16 @@ interface ComposerWorkspaceAttachmentBinding {
 }
 
 function getAttachmentKey(attachment: WorkspaceComposerAttachment): string {
+  if (attachment.kind === "browser_element") {
+    return JSON.stringify({
+      type: "browser_element",
+      url: attachment.attachment.url,
+      selector: attachment.attachment.selector,
+      tag: attachment.attachment.tag,
+      text: attachment.attachment.text,
+      html: attachment.attachment.outerHTML,
+    });
+  }
   return JSON.stringify({
     type: "review",
     cwd: attachment.attachment.cwd,
@@ -61,23 +72,32 @@ function getAttachmentKey(attachment: WorkspaceComposerAttachment): string {
 function isWorkspaceAttachment(
   attachment: ComposerAttachment | undefined,
 ): attachment is WorkspaceComposerAttachment {
-  return attachment?.kind === "review";
+  return attachment?.kind === "review" || attachment?.kind === "browser_element";
 }
 
 function userAttachmentsOnly(attachments: readonly ComposerAttachment[]): UserComposerAttachment[] {
   return attachments.filter(
-    (attachment): attachment is UserComposerAttachment => attachment.kind !== "review",
+    (attachment): attachment is UserComposerAttachment =>
+      attachment.kind !== "review" && attachment.kind !== "browser_element",
   );
 }
 
 function toSubmitAttachment(attachment: ComposerAttachment): AgentAttachment | null {
-  return isWorkspaceAttachment(attachment) ? attachment.attachment : null;
+  if (attachment.kind === "browser_element") {
+    return {
+      type: "text",
+      mimeType: "text/plain",
+      title: `Browser element · ${attachment.attachment.tag}`,
+      text: attachment.attachment.formatted,
+    };
+  }
+  return attachment.kind === "review" ? attachment.attachment : null;
 }
 
 function renderPill(args: RenderWorkspaceAttachmentPillArgs): ReactElement {
   return (
     <WorkspaceAttachmentPill
-      key={`workspace:${args.attachment.attachment.cwd}:${args.attachment.attachment.mode}`}
+      key={`workspace:${getAttachmentKey(args.attachment)}`}
       {...args}
       attachment={args.attachment}
     />
@@ -90,6 +110,9 @@ function useWorkspaceAttachmentBinding({
   onOpenWorkspaceAttachment,
 }: WorkspaceAttachmentBindingInput): ComposerWorkspaceAttachmentBinding {
   const clearReviewDraft = useClearReviewDraft();
+  const setWorkspaceAttachments = useWorkspaceAttachmentsStore(
+    (state) => state.setWorkspaceAttachments,
+  );
   const [suppressedKeys, setSuppressedKeys] = useState<readonly string[]>([]);
   const workspaceAttachmentKeys = useMemo(
     () => workspaceAttachments.map(getAttachmentKey),
@@ -136,7 +159,7 @@ function useWorkspaceAttachmentBinding({
   const clearSentAttachments = useCallback(
     (attachments: readonly ComposerAttachment[]) => {
       for (const attachment of attachments) {
-        if (isWorkspaceAttachment(attachment)) {
+        if (attachment.kind === "review") {
           clearReviewDraft({ key: attachment.reviewDraftKey });
         }
       }
@@ -148,17 +171,30 @@ function useWorkspaceAttachmentBinding({
     ({ selectedAttachments: current, index }: RemoveWorkspaceAttachmentInput) => {
       const selected = current[index];
       if (isWorkspaceAttachment(selected)) {
+        if (selected.kind === "browser_element") {
+          const selectedKey = getAttachmentKey(selected);
+          const { attachmentsByScope } = useWorkspaceAttachmentsStore.getState();
+          for (const [scopeKey, attachments] of Object.entries(attachmentsByScope)) {
+            const nextAttachments = attachments.filter(
+              (attachment) => getAttachmentKey(attachment) !== selectedKey,
+            );
+            if (nextAttachments.length !== attachments.length) {
+              setWorkspaceAttachments({ scopeKey, attachments: nextAttachments });
+            }
+          }
+          return true;
+        }
         suppressWorkspaceAttachment(selected);
         return true;
       }
       return false;
     },
-    [suppressWorkspaceAttachment],
+    [setWorkspaceAttachments, suppressWorkspaceAttachment],
   );
 
   const openAttachment = useCallback(
     ({ attachment }: OpenWorkspaceAttachmentInput) => {
-      if (!isWorkspaceAttachment(attachment)) {
+      if (!isWorkspaceAttachment(attachment) || attachment.kind !== "review") {
         return false;
       }
       onOpenWorkspaceAttachment?.(attachment);
@@ -216,10 +252,15 @@ function WorkspaceAttachmentPill({
   onOpen,
   onRemove,
 }: WorkspaceAttachmentPillProps) {
-  const label =
-    attachment.commentCount === 1
-      ? "Review · 1 comment"
-      : `Review · ${attachment.commentCount} comments`;
+  let label: string;
+  if (attachment.kind === "browser_element") {
+    label = `Element · ${attachment.attachment.tag}`;
+  } else {
+    label =
+      attachment.commentCount === 1
+        ? "Review · 1 comment"
+        : `Review · ${attachment.commentCount} comments`;
+  }
   const handleOpen = useCallback(() => {
     onOpen(attachment);
   }, [onOpen, attachment]);
@@ -231,13 +272,25 @@ function WorkspaceAttachmentPill({
       testID="composer-review-attachment-pill"
       onOpen={handleOpen}
       onRemove={handleRemove}
-      openAccessibilityLabel="Open review attachment"
-      removeAccessibilityLabel="Remove review attachment"
+      openAccessibilityLabel={
+        attachment.kind === "browser_element"
+          ? "Open browser element attachment"
+          : "Open review attachment"
+      }
+      removeAccessibilityLabel={
+        attachment.kind === "browser_element"
+          ? "Remove browser element attachment"
+          : "Remove review attachment"
+      }
       disabled={disabled}
     >
       <View style={styles.pillBody}>
         <View style={styles.pillIcon}>
-          <ThemedCircleDot size={ICON_SIZE.sm} uniProps={iconForegroundMutedMapping} />
+          {attachment.kind === "browser_element" ? (
+            <ThemedMousePointer2 size={ICON_SIZE.sm} uniProps={iconForegroundMutedMapping} />
+          ) : (
+            <ThemedCircleDot size={ICON_SIZE.sm} uniProps={iconForegroundMutedMapping} />
+          )}
         </View>
         <Text style={styles.pillText} numberOfLines={1}>
           {label}
@@ -280,4 +333,5 @@ const styles = StyleSheet.create((theme: Theme) => ({
 })) as unknown as Record<string, object>;
 
 const ThemedCircleDot = withUnistyles(CircleDot);
+const ThemedMousePointer2 = withUnistyles(MousePointer2);
 const iconForegroundMutedMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });

--- a/packages/app/src/attachments/types.ts
+++ b/packages/app/src/attachments/types.ts
@@ -17,10 +17,38 @@ export interface AttachmentMetadata {
   createdAt: number;
 }
 
+export interface BrowserElementAttachment {
+  url: string;
+  selector: string;
+  tag: string;
+  text: string;
+  outerHTML: string;
+  computedStyles: Record<string, string>;
+  boundingRect: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  reactSource: {
+    fileName: string | null;
+    lineNumber: number | null;
+    columnNumber: number | null;
+    componentName: string | null;
+  } | null;
+  parentChain: string[];
+  children: string[];
+  formatted: string;
+}
+
 export type ComposerAttachment =
   | { kind: "image"; metadata: AttachmentMetadata }
   | { kind: "github_issue"; item: GitHubSearchItem }
   | { kind: "github_pr"; item: GitHubSearchItem }
+  | {
+      kind: "browser_element";
+      attachment: BrowserElementAttachment;
+    }
   | {
       kind: "review";
       attachment: Extract<AgentAttachment, { type: "review" }>;
@@ -28,9 +56,15 @@ export type ComposerAttachment =
       commentCount: number;
     };
 
-export type UserComposerAttachment = Exclude<ComposerAttachment, { kind: "review" }>;
+export type UserComposerAttachment = Exclude<
+  ComposerAttachment,
+  { kind: "review" } | { kind: "browser_element" }
+>;
 
-export type WorkspaceComposerAttachment = Extract<ComposerAttachment, { kind: "review" }>;
+export type WorkspaceComposerAttachment = Extract<
+  ComposerAttachment,
+  { kind: "review" } | { kind: "browser_element" }
+>;
 
 export type AttachmentDataSource =
   | { kind: "bytes"; bytes: Uint8Array }

--- a/packages/app/src/components/browser-pane.electron.tsx
+++ b/packages/app/src/components/browser-pane.electron.tsx
@@ -184,7 +184,30 @@ function buildBrowserAttachmentScopeKey(input: {
 }
 
 function executeWebviewJavaScript(webview: ElectronWebview, code: string): Promise<unknown> {
-  return webview.executeJavaScript?.(code) ?? Promise.resolve(null);
+  if (!webview.isConnected) {
+    return Promise.resolve(null);
+  }
+  try {
+    return webview.executeJavaScript?.(code) ?? Promise.resolve(null);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+}
+
+function ignoreWebviewJavaScriptError() {}
+
+function destroyWebviewSelector(webview: ElectronWebview): void {
+  void executeWebviewJavaScript(
+    webview,
+    "if(window.__paseoSelector) window.__paseoSelector.destroy();",
+  ).catch(ignoreWebviewJavaScriptError);
+}
+
+function clearWebviewSelector(webview: ElectronWebview): void {
+  void executeWebviewJavaScript(
+    webview,
+    "if(window.__paseoSelector) window.__paseoSelector.destroy(); window.__paseoSelectorResult = null;",
+  ).catch(ignoreWebviewJavaScriptError);
 }
 
 function getTextInputNativeElement(current: WebTextInput | null): HTMLInputElement | null {
@@ -250,12 +273,14 @@ export function BrowserPane({
   workspaceId,
   cwd,
   isInteractive,
+  onFocusPane,
 }: {
   browserId: string;
   serverId: string;
   workspaceId: string;
   cwd: string | null;
   isInteractive?: boolean;
+  onFocusPane?: () => void;
 }) {
   const { theme } = useUnistyles();
   const browser = useBrowserStore((state) => state.browsersById[browserId] ?? null);
@@ -439,6 +464,9 @@ export function BrowserPane({
       domReadyRef.current = true;
       syncNavigationState();
     };
+    const handleWebviewFocus = () => {
+      onFocusPane?.();
+    };
 
     webview.addEventListener("did-start-loading", handleStartLoading);
     webview.addEventListener("did-stop-loading", handleStopLoading);
@@ -449,6 +477,8 @@ export function BrowserPane({
     webview.addEventListener("page-favicon-updated", handleFaviconUpdated);
     webview.addEventListener("did-fail-load", handleLoadFailed);
     webview.addEventListener("dom-ready", handleDomReady);
+    webview.addEventListener("focus", handleWebviewFocus);
+    webview.addEventListener("mousedown", handleWebviewFocus);
 
     host.appendChild(webview);
     if (initialUnsafeNavigationMessage) {
@@ -468,6 +498,8 @@ export function BrowserPane({
       webview.removeEventListener("page-favicon-updated", handleFaviconUpdated);
       webview.removeEventListener("did-fail-load", handleLoadFailed);
       webview.removeEventListener("dom-ready", handleDomReady);
+      webview.removeEventListener("focus", handleWebviewFocus);
+      webview.removeEventListener("mousedown", handleWebviewFocus);
       if (host.contains(webview)) {
         host.removeChild(webview);
       }
@@ -477,7 +509,7 @@ export function BrowserPane({
       domReadyRef.current = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [browserId]);
+  }, [browserId, onFocusPane]);
 
   const navigate = useCallback((nextUrl: string) => {
     const normalizedUrl = normalizeWorkspaceBrowserUrl(nextUrl);
@@ -568,11 +600,17 @@ export function BrowserPane({
       return;
     }
     const unsubscribe = getDesktopHost()?.events?.on?.("browser-shortcut", (payload) => {
-      if (
-        !isDesktopBrowserShortcutEvent(payload) ||
-        (payload.browserId && payload.browserId !== browserIdRef.current) ||
-        !isInteractive
-      ) {
+      if (!isDesktopBrowserShortcutEvent(payload)) {
+        return;
+      }
+      if (payload.browserId) {
+        if (payload.browserId !== browserIdRef.current) {
+          return;
+        }
+        focusUrlBar();
+        return;
+      }
+      if (!isInteractive) {
         return;
       }
       focusUrlBar();
@@ -773,22 +811,26 @@ export function BrowserPane({
     `;
 
     try {
-      void executeWebviewJavaScript(webview, js).then(() => {
-        const poll = startSelectorResultPolling({
-          webview,
-          onSelection: addElementAttachment,
-          onDone: () => setSelectorActive(false),
-        });
-        window.setTimeout(() => {
-          window.clearInterval(poll);
-          setSelectorActive(false);
-          void executeWebviewJavaScript(
+      void executeWebviewJavaScript(webview, js)
+        .then(() => {
+          const poll = startSelectorResultPolling({
             webview,
-            "if(window.__paseoSelector) window.__paseoSelector.destroy();",
-          );
-        }, 30000);
-        return undefined;
-      });
+            onSelection: addElementAttachment,
+            onDone: () => setSelectorActive(false),
+          });
+          window.setTimeout(() => {
+            window.clearInterval(poll);
+            setSelectorActive(false);
+            if (webviewRef.current !== webview || !domReadyRef.current) {
+              return;
+            }
+            destroyWebviewSelector(webview);
+          }, 30000);
+          return undefined;
+        })
+        .catch(() => {
+          setSelectorActive(false);
+        });
     } catch {
       setSelectorActive(false);
     }
@@ -799,10 +841,7 @@ export function BrowserPane({
     setSelectorActive(false);
     if (webview && domReadyRef.current) {
       try {
-        void executeWebviewJavaScript(
-          webview,
-          "if(window.__paseoSelector) window.__paseoSelector.destroy(); window.__paseoSelectorResult = null;",
-        );
+        clearWebviewSelector(webview);
       } catch {}
     }
   }, []);

--- a/packages/app/src/components/browser-pane.electron.tsx
+++ b/packages/app/src/components/browser-pane.electron.tsx
@@ -8,14 +8,7 @@ import {
   createElement,
 } from "react";
 import { Pressable, Text, TextInput, View } from "react-native";
-import {
-  ArrowLeft,
-  ArrowRight,
-  Globe,
-  MousePointer2,
-  RefreshCw,
-  Search,
-} from "lucide-react-native";
+import { ArrowLeft, ArrowRight, MousePointer2, RefreshCw } from "lucide-react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import {
   buildWorkspaceAttachmentScopeKey,
@@ -33,7 +26,7 @@ type ElectronWebview = HTMLElement & {
   goForward?: () => void;
   reload?: () => void;
   stop?: () => void;
-  loadURL?: (url: string) => void;
+  loadURL?: (url: string) => Promise<void>;
   getURL?: () => string;
   openDevTools?: () => void;
   executeJavaScript?: (code: string) => Promise<unknown>;
@@ -45,8 +38,62 @@ type BrowserElementSelection = Omit<BrowserElementAttachment, "formatted"> & {
   attributes?: Record<string, string>;
 };
 
+const ERR_ABORTED = -3;
+const ALLOWED_BROWSER_PROTOCOLS = new Set(["http:", "https:"]);
+
 function truncateText(value: string, maxLength: number): string {
   return value.length > maxLength ? `${value.slice(0, maxLength).trim()}...` : value;
+}
+
+function getWebviewLoadErrorMessage(event: Event): string | null {
+  const details = event as Event & {
+    errorCode?: unknown;
+    errorDescription?: unknown;
+    isMainFrame?: unknown;
+    validatedURL?: unknown;
+  };
+  if (details.isMainFrame === false || details.errorCode === ERR_ABORTED) {
+    return null;
+  }
+
+  const description =
+    typeof details.errorDescription === "string" && details.errorDescription.trim()
+      ? details.errorDescription.trim()
+      : "Failed to load page";
+  const url =
+    typeof details.validatedURL === "string" && details.validatedURL.trim()
+      ? details.validatedURL.trim()
+      : null;
+
+  return url ? `${description}: ${url}` : description;
+}
+
+function getLoadUrlRejectionMessage(error: unknown): string | null {
+  if (error instanceof Error && error.message.trim()) {
+    if (error.message.includes("ERR_ABORTED") || error.message.includes("ERR_BLOCKED_BY_CLIENT")) {
+      return null;
+    }
+    return error.message.trim();
+  }
+  if (typeof error === "string" && error.trim()) {
+    if (error.includes("ERR_ABORTED") || error.includes("ERR_BLOCKED_BY_CLIENT")) {
+      return null;
+    }
+    return error.trim();
+  }
+  return "Failed to load page";
+}
+
+function getUnsafeNavigationMessage(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (ALLOWED_BROWSER_PROTOCOLS.has(parsed.protocol) || parsed.href === "about:blank") {
+      return null;
+    }
+    return `Blocked unsupported browser URL: ${parsed.protocol}`;
+  } catch {
+    return "Invalid browser URL";
+  }
 }
 
 function formatElementAttachment(selection: BrowserElementSelection): string {
@@ -254,13 +301,17 @@ export function BrowserPane({
 
     host.replaceChildren();
 
+    const initialUnsafeNavigationMessage = getUnsafeNavigationMessage(initialUrlRef.current);
     const webview = document.createElement("webview") as ElectronWebview;
     webviewRef.current = webview;
     webview.setAttribute("partition", `persist:paseo-browser-${browserId}`);
     webview.setAttribute("allowpopups", "true");
     webview.setAttribute("spellcheck", "false");
     webview.setAttribute("autosize", "on");
-    webview.setAttribute("src", initialUrlRef.current);
+    webview.setAttribute(
+      "src",
+      initialUnsafeNavigationMessage ? "about:blank" : initialUrlRef.current,
+    );
     webview.style.display = "flex";
     webview.style.flex = "1";
     webview.style.width = "100%";
@@ -269,11 +320,11 @@ export function BrowserPane({
     webview.style.background = "transparent";
 
     const handleStartLoading = () => {
-      updateBrowser(browserId, { isLoading: true, lastError: null });
+      updateBrowser(browserId, { isLoading: true, faviconUrl: null, lastError: null });
       syncNavigationState();
     };
     const handleStopLoading = () => {
-      updateBrowser(browserId, { isLoading: false, lastError: null });
+      updateBrowser(browserId, { isLoading: false });
       syncNavigationState();
     };
     const handleNavigate = (event: Event) => {
@@ -305,18 +356,17 @@ export function BrowserPane({
       updateBrowserRef.current(browserIdRef.current, { faviconUrl: favicons[0] ?? null });
     };
     const handleLoadFailed = (event: Event) => {
-      const errorDescription =
-        typeof (event as Event & { errorDescription?: unknown }).errorDescription === "string"
-          ? ((event as Event & { errorDescription?: string }).errorDescription ?? "")
-          : "Failed to load page";
+      const message = getWebviewLoadErrorMessage(event);
+      if (!message) {
+        return;
+      }
       updateBrowserRef.current(browserIdRef.current, {
         isLoading: false,
-        lastError: errorDescription,
+        lastError: message,
       });
     };
     const handleDomReady = () => {
       domReadyRef.current = true;
-      updateBrowserRef.current(browserIdRef.current, { isLoading: false });
       syncNavigationState();
     };
 
@@ -330,6 +380,12 @@ export function BrowserPane({
     webview.addEventListener("dom-ready", handleDomReady);
 
     host.appendChild(webview);
+    if (initialUnsafeNavigationMessage) {
+      updateBrowserRef.current(browserIdRef.current, {
+        isLoading: false,
+        lastError: initialUnsafeNavigationMessage,
+      });
+    }
 
     return () => {
       webview.removeEventListener("did-start-loading", handleStartLoading);
@@ -354,14 +410,31 @@ export function BrowserPane({
   const navigate = useCallback((nextUrl: string) => {
     const normalizedUrl = normalizeWorkspaceBrowserUrl(nextUrl);
     const webview = webviewRef.current;
+    const unsafeNavigationMessage = getUnsafeNavigationMessage(normalizedUrl);
     updateBrowserRef.current(browserIdRef.current, {
       url: normalizedUrl,
-      isLoading: true,
+      isLoading: unsafeNavigationMessage === null,
       lastError: null,
     });
     setDraftUrl((current) => (current === normalizedUrl ? current : normalizedUrl));
+    if (unsafeNavigationMessage) {
+      updateBrowserRef.current(browserIdRef.current, {
+        isLoading: false,
+        lastError: unsafeNavigationMessage,
+      });
+      return;
+    }
     if (webview?.loadURL) {
-      webview.loadURL(normalizedUrl);
+      void webview.loadURL(normalizedUrl).catch((error: unknown) => {
+        const message = getLoadUrlRejectionMessage(error);
+        if (!message) {
+          return;
+        }
+        updateBrowserRef.current(browserIdRef.current, {
+          isLoading: false,
+          lastError: message,
+        });
+      });
       return;
     }
     if (webview) {
@@ -704,17 +777,6 @@ export function BrowserPane({
           </Pressable>
         </View>
         <View style={styles.urlBarWrap}>
-          <View style={styles.urlBarIconWrap}>
-            {browser?.faviconUrl ? (
-              createElement("img", {
-                alt: "",
-                src: browser.faviconUrl,
-                style: { width: 14, height: 14, borderRadius: 3 } satisfies CSSProperties,
-              })
-            ) : (
-              <Globe size={14} color={theme.colors.foregroundMuted} />
-            )}
-          </View>
           <TextInput
             accessibilityLabel="Browser URL"
             autoCapitalize="none"
@@ -728,14 +790,6 @@ export function BrowserPane({
           />
         </View>
         <View style={styles.chromeRight}>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Go to URL"
-            onPress={handleNavigateDraftUrl}
-            style={baseIconButtonStyle}
-          >
-            <Search size={16} color={theme.colors.foregroundMuted} />
-          </Pressable>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={selectorActive ? "Cancel element selector" : "Select element"}
@@ -825,16 +879,10 @@ const styles = StyleSheet.create((theme) => ({
     borderWidth: 1,
     borderColor: theme.colors.surface3,
   },
-  urlBarIconWrap: {
-    width: 14,
-    height: 14,
-    alignItems: "center",
-    justifyContent: "center",
-  },
   urlInput: {
     flex: 1,
     minWidth: 0,
-    fontSize: 12,
+    fontSize: theme.fontSize.sm,
     paddingVertical: 0,
     paddingHorizontal: 0,
   },

--- a/packages/app/src/components/browser-pane.electron.tsx
+++ b/packages/app/src/components/browser-pane.electron.tsx
@@ -16,7 +16,12 @@ import {
   useWorkspaceAttachmentsStore,
 } from "@/attachments/workspace-attachments-store";
 import type { BrowserElementAttachment } from "@/attachments/types";
-import { isElectronRuntime } from "@/desktop/host";
+import { WORKSPACE_SECONDARY_HEADER_HEIGHT } from "@/constants/layout";
+import {
+  getDesktopHost,
+  isElectronRuntime,
+  type DesktopBrowserShortcutEvent,
+} from "@/desktop/host";
 import { useBrowserStore, normalizeWorkspaceBrowserUrl } from "@/stores/browser-store";
 
 type ElectronWebview = HTMLElement & {
@@ -30,8 +35,13 @@ type ElectronWebview = HTMLElement & {
   getURL?: () => string;
   openDevTools?: () => void;
   executeJavaScript?: (code: string) => Promise<unknown>;
+  focus?: () => void;
   addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
   removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
+};
+
+type WebTextInput = TextInput & {
+  getNativeRef?: () => unknown;
 };
 
 type BrowserElementSelection = Omit<BrowserElementAttachment, "formatted"> & {
@@ -177,6 +187,30 @@ function executeWebviewJavaScript(webview: ElectronWebview, code: string): Promi
   return webview.executeJavaScript?.(code) ?? Promise.resolve(null);
 }
 
+function getTextInputNativeElement(current: WebTextInput | null): HTMLInputElement | null {
+  const native = current?.getNativeRef?.() ?? current;
+  return native instanceof HTMLInputElement ? native : null;
+}
+
+function isBrowserShortcutKey(event: KeyboardEvent, key: "l" | "r"): boolean {
+  if (event.altKey || event.shiftKey) {
+    return false;
+  }
+  if (!event.metaKey && !event.ctrlKey) {
+    return false;
+  }
+  const eventKey = event.key.toLowerCase();
+  return eventKey === key || event.code === `Key${key.toUpperCase()}`;
+}
+
+function isDesktopBrowserShortcutEvent(payload: unknown): payload is DesktopBrowserShortcutEvent {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+  const event = payload as Partial<DesktopBrowserShortcutEvent>;
+  return event.action === "focus-url";
+}
+
 function startSelectorResultPolling(input: {
   webview: ElectronWebview;
   onSelection: (selection: BrowserElementSelection) => void;
@@ -215,20 +249,26 @@ export function BrowserPane({
   serverId,
   workspaceId,
   cwd,
+  isInteractive,
 }: {
   browserId: string;
   serverId: string;
   workspaceId: string;
   cwd: string | null;
+  isInteractive?: boolean;
 }) {
   const { theme } = useUnistyles();
   const browser = useBrowserStore((state) => state.browsersById[browserId] ?? null);
   const updateBrowser = useBrowserStore((state) => state.updateBrowser);
   const webviewRef = useRef<ElectronWebview | null>(null);
   const webviewHostRef = useRef<HTMLDivElement | null>(null);
+  const urlInputRef = useRef<WebTextInput | null>(null);
   const initialUrlRef = useRef(browser?.url ?? "https://example.com");
   const browserIdRef = useRef(browserId);
   browserIdRef.current = browserId;
+  const browserRef = useRef(browser);
+  browserRef.current = browser;
+  const pendingNavigationUrlRef = useRef<string | null>(null);
   const domReadyRef = useRef(false);
   const [selectorActive, setSelectorActive] = useState(false);
   const [draftUrl, setDraftUrl] = useState(browser?.url ?? "https://example.com");
@@ -271,7 +311,14 @@ export function BrowserPane({
   const updateBrowserRef = useRef(updateBrowser);
   updateBrowserRef.current = updateBrowser;
 
-  const syncNavigationState = useCallback(() => {
+  const focusUrlBar = useCallback(() => {
+    urlInputRef.current?.focus();
+    window.setTimeout(() => {
+      getTextInputNativeElement(urlInputRef.current)?.select();
+    }, 0);
+  }, []);
+
+  const syncNavigationState = useCallback((input?: { syncUrl?: boolean }) => {
     const webview = webviewRef.current;
     if (!webview || !domReadyRef.current) {
       return;
@@ -279,11 +326,14 @@ export function BrowserPane({
 
     try {
       const currentUrl = webview.getURL?.() ?? webview.getAttribute("src") ?? "";
-      updateBrowserRef.current(browserIdRef.current, {
-        url: normalizeWorkspaceBrowserUrl(currentUrl),
+      const patch = {
         canGoBack: webview.canGoBack?.() ?? false,
         canGoForward: webview.canGoForward?.() ?? false,
-      });
+        ...(input?.syncUrl === false
+          ? {}
+          : { url: normalizeWorkspaceBrowserUrl(pendingNavigationUrlRef.current ?? currentUrl) }),
+      };
+      updateBrowserRef.current(browserIdRef.current, patch);
     } catch {
       // webview not yet attached
     }
@@ -320,8 +370,8 @@ export function BrowserPane({
     webview.style.background = "transparent";
 
     const handleStartLoading = () => {
-      updateBrowser(browserId, { isLoading: true, faviconUrl: null, lastError: null });
-      syncNavigationState();
+      updateBrowser(browserId, { isLoading: true, lastError: null });
+      syncNavigationState({ syncUrl: false });
     };
     const handleStopLoading = () => {
       updateBrowser(browserId, { isLoading: false });
@@ -332,15 +382,35 @@ export function BrowserPane({
         typeof (event as Event & { url?: unknown }).url === "string"
           ? ((event as Event & { url?: string }).url ?? "")
           : (webview.getURL?.() ?? webview.getAttribute("src") ?? "");
+      const normalized = normalizeWorkspaceBrowserUrl(nextUrl);
+      const previousUrl = browserRef.current?.url ?? initialUrlRef.current;
+      pendingNavigationUrlRef.current = null;
       updateBrowser(browserIdRef.current, {
-        url: normalizeWorkspaceBrowserUrl(nextUrl),
+        url: normalized,
+        ...(normalized !== previousUrl ? { faviconUrl: null } : {}),
         lastError: null,
       });
       setDraftUrl((current) => {
-        const normalized = normalizeWorkspaceBrowserUrl(nextUrl);
         return current === normalized ? current : normalized;
       });
       syncNavigationState();
+    };
+    const handleWillNavigate = (event: Event) => {
+      const nextUrl =
+        typeof (event as Event & { url?: unknown }).url === "string"
+          ? ((event as Event & { url?: string }).url ?? "")
+          : "";
+      if (!nextUrl) {
+        return;
+      }
+      const normalized = normalizeWorkspaceBrowserUrl(nextUrl);
+      pendingNavigationUrlRef.current = normalized;
+      updateBrowserRef.current(browserIdRef.current, {
+        url: normalized,
+        ...(normalized !== browserRef.current?.url ? { faviconUrl: null } : {}),
+        lastError: null,
+      });
+      setDraftUrl((current) => (current === normalized ? current : normalized));
     };
     const handleTitleUpdated = (event: Event) => {
       const title =
@@ -372,6 +442,7 @@ export function BrowserPane({
 
     webview.addEventListener("did-start-loading", handleStartLoading);
     webview.addEventListener("did-stop-loading", handleStopLoading);
+    webview.addEventListener("will-navigate", handleWillNavigate);
     webview.addEventListener("did-navigate", handleNavigate);
     webview.addEventListener("did-navigate-in-page", handleNavigate);
     webview.addEventListener("page-title-updated", handleTitleUpdated);
@@ -390,6 +461,7 @@ export function BrowserPane({
     return () => {
       webview.removeEventListener("did-start-loading", handleStartLoading);
       webview.removeEventListener("did-stop-loading", handleStopLoading);
+      webview.removeEventListener("will-navigate", handleWillNavigate);
       webview.removeEventListener("did-navigate", handleNavigate);
       webview.removeEventListener("did-navigate-in-page", handleNavigate);
       webview.removeEventListener("page-title-updated", handleTitleUpdated);
@@ -411,9 +483,12 @@ export function BrowserPane({
     const normalizedUrl = normalizeWorkspaceBrowserUrl(nextUrl);
     const webview = webviewRef.current;
     const unsafeNavigationMessage = getUnsafeNavigationMessage(normalizedUrl);
+    const previousUrl = browserRef.current?.url ?? initialUrlRef.current;
+    pendingNavigationUrlRef.current = unsafeNavigationMessage ? null : normalizedUrl;
     updateBrowserRef.current(browserIdRef.current, {
       url: normalizedUrl,
       isLoading: unsafeNavigationMessage === null,
+      ...(normalizedUrl !== previousUrl ? { faviconUrl: null } : {}),
       lastError: null,
     });
     setDraftUrl((current) => (current === normalizedUrl ? current : normalizedUrl));
@@ -460,6 +535,56 @@ export function BrowserPane({
     }
     webviewRef.current?.reload?.();
   }, [browser?.isLoading, browserId, updateBrowser]);
+
+  useEffect(() => {
+    if (!isElectronRuntime() || !isInteractive) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isBrowserShortcutKey(event, "l")) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        focusUrlBar();
+        return;
+      }
+      if (isBrowserShortcutKey(event, "r")) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        handleRefresh();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [focusUrlBar, handleRefresh, isInteractive]);
+
+  useEffect(() => {
+    if (!isElectronRuntime()) {
+      return;
+    }
+    const unsubscribe = getDesktopHost()?.events?.on?.("browser-shortcut", (payload) => {
+      if (
+        !isDesktopBrowserShortcutEvent(payload) ||
+        (payload.browserId && payload.browserId !== browserIdRef.current) ||
+        !isInteractive
+      ) {
+        return;
+      }
+      focusUrlBar();
+    });
+
+    if (typeof unsubscribe === "function") {
+      return unsubscribe;
+    }
+    return () => {
+      void unsubscribe?.then((dispose) => dispose());
+    };
+  }, [focusUrlBar, isInteractive]);
 
   const handleNavigateDraftUrl = useCallback(() => {
     navigate(draftUrl);
@@ -785,6 +910,7 @@ export function BrowserPane({
             onSubmitEditing={handleNavigateDraftUrl}
             placeholder="Enter URL"
             placeholderTextColor={theme.colors.foregroundMuted}
+            ref={urlInputRef}
             style={urlInputStyle}
             value={draftUrl}
           />
@@ -829,30 +955,29 @@ const styles = StyleSheet.create((theme) => ({
     backgroundColor: theme.colors.surface0,
   },
   chromeRow: {
-    minHeight: 40,
+    height: WORKSPACE_SECONDARY_HEADER_HEIGHT,
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
-    paddingHorizontal: 8,
-    paddingVertical: 6,
+    gap: theme.spacing[2],
+    paddingHorizontal: theme.spacing[2],
     borderBottomWidth: 1,
-    borderBottomColor: theme.colors.surface3,
-    backgroundColor: theme.colors.surface1,
+    borderBottomColor: theme.colors.border,
+    backgroundColor: theme.colors.surface0,
   },
   chromeLeft: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 4,
+    gap: theme.spacing[1],
   },
   chromeRight: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 4,
+    gap: theme.spacing[1],
   },
   iconButton: {
     width: 28,
     height: 28,
-    borderRadius: 8,
+    borderRadius: theme.borderRadius.md,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -868,16 +993,14 @@ const styles = StyleSheet.create((theme) => ({
   urlBarWrap: {
     flex: 1,
     minWidth: 0,
-    height: 30,
-    borderRadius: 10,
-    paddingLeft: 10,
-    paddingRight: 8,
+    height: 28,
+    borderRadius: theme.borderRadius.md,
+    paddingHorizontal: theme.spacing[2],
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
-    backgroundColor: theme.colors.surface0,
+    backgroundColor: theme.colors.surface1,
     borderWidth: 1,
-    borderColor: theme.colors.surface3,
+    borderColor: theme.colors.border,
   },
   urlInput: {
     flex: 1,
@@ -887,14 +1010,14 @@ const styles = StyleSheet.create((theme) => ({
     paddingHorizontal: 0,
   },
   errorRow: {
-    paddingHorizontal: 10,
-    paddingVertical: 4,
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: theme.spacing[1],
     borderBottomWidth: 1,
-    borderBottomColor: theme.colors.surface3,
+    borderBottomColor: theme.colors.border,
     backgroundColor: theme.colors.surface0,
   },
   metaError: {
-    fontSize: 11,
+    fontSize: theme.fontSize.xs,
   },
   webviewWrap: {
     flex: 1,

--- a/packages/app/src/components/browser-pane.electron.tsx
+++ b/packages/app/src/components/browser-pane.electron.tsx
@@ -1,0 +1,870 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  createElement,
+} from "react";
+import { Pressable, Text, TextInput, View } from "react-native";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Globe,
+  MousePointer2,
+  RefreshCw,
+  Search,
+} from "lucide-react-native";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import {
+  buildWorkspaceAttachmentScopeKey,
+  useWorkspaceAttachments,
+  useWorkspaceAttachmentsStore,
+} from "@/attachments/workspace-attachments-store";
+import type { BrowserElementAttachment } from "@/attachments/types";
+import { isElectronRuntime } from "@/desktop/host";
+import { useBrowserStore, normalizeWorkspaceBrowserUrl } from "@/stores/browser-store";
+
+type ElectronWebview = HTMLElement & {
+  canGoBack?: () => boolean;
+  canGoForward?: () => boolean;
+  goBack?: () => void;
+  goForward?: () => void;
+  reload?: () => void;
+  stop?: () => void;
+  loadURL?: (url: string) => void;
+  getURL?: () => string;
+  openDevTools?: () => void;
+  executeJavaScript?: (code: string) => Promise<unknown>;
+  addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
+  removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
+};
+
+type BrowserElementSelection = Omit<BrowserElementAttachment, "formatted"> & {
+  attributes?: Record<string, string>;
+};
+
+function truncateText(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength).trim()}...` : value;
+}
+
+function formatElementAttachment(selection: BrowserElementSelection): string {
+  const textPreview = truncateText(selection.text.trim(), 200);
+  const html = truncateText(selection.outerHTML.trim(), 800);
+  const parts: string[] = [];
+
+  if (selection.reactSource?.fileName) {
+    const loc = [
+      selection.reactSource.fileName,
+      selection.reactSource.lineNumber != null ? `:${selection.reactSource.lineNumber}` : "",
+      selection.reactSource.columnNumber != null ? `:${selection.reactSource.columnNumber}` : "",
+    ].join("");
+    parts.push(`source: ${selection.reactSource.componentName ?? selection.tag} @ ${loc}`);
+  }
+
+  parts.push(`selector: ${selection.selector}`);
+
+  if (textPreview) {
+    parts.push(`text: ${JSON.stringify(textPreview)}`);
+  }
+
+  parts.push(`size: ${selection.boundingRect.width}x${selection.boundingRect.height}`);
+
+  const keyStyles = Object.entries(selection.computedStyles)
+    .filter(([key]) =>
+      ["display", "position", "font-size", "color", "background-color"].includes(key),
+    )
+    .map(([key, value]) => `${key}: ${value}`)
+    .join("; ");
+  if (keyStyles) {
+    parts.push(`styles: ${keyStyles}`);
+  }
+
+  if (selection.parentChain.length > 0) {
+    parts.push(`parents: ${selection.parentChain.slice(0, 3).join(" > ")}`);
+  }
+
+  return [
+    `<browser-element url="${selection.url}">`,
+    parts.map((part) => `  ${part}`).join("\n"),
+    `  html: ${html}`,
+    `</browser-element>`,
+  ].join("\n");
+}
+
+function buildBrowserElementAttachment(
+  selection: BrowserElementSelection,
+): BrowserElementAttachment {
+  return {
+    url: selection.url,
+    selector: selection.selector,
+    tag: selection.tag,
+    text: selection.text,
+    outerHTML: truncateText(selection.outerHTML, 2000),
+    computedStyles: selection.computedStyles,
+    boundingRect: selection.boundingRect,
+    reactSource: selection.reactSource,
+    parentChain: selection.parentChain,
+    children: selection.children,
+    formatted: formatElementAttachment(selection),
+  };
+}
+
+function buildBrowserAttachmentScopeKey(input: {
+  cwd: string | null;
+  serverId: string;
+  workspaceId: string;
+}): string | null {
+  if (!input.cwd) {
+    return null;
+  }
+  return buildWorkspaceAttachmentScopeKey({
+    serverId: input.serverId,
+    workspaceId: input.workspaceId,
+    cwd: input.cwd,
+  });
+}
+
+function executeWebviewJavaScript(webview: ElectronWebview, code: string): Promise<unknown> {
+  return webview.executeJavaScript?.(code) ?? Promise.resolve(null);
+}
+
+function startSelectorResultPolling(input: {
+  webview: ElectronWebview;
+  onSelection: (selection: BrowserElementSelection) => void;
+  onDone: () => void;
+}): number {
+  const { webview, onSelection, onDone } = input;
+  const poll = window.setInterval(() => {
+    void (async () => {
+      try {
+        const raw = await executeWebviewJavaScript(
+          webview,
+          "JSON.stringify(window.__paseoSelectorResult || null)",
+        );
+        const result = typeof raw === "string" ? JSON.parse(raw) : null;
+        if (!result) {
+          return;
+        }
+        window.clearInterval(poll);
+        onDone();
+        await executeWebviewJavaScript(webview, "window.__paseoSelectorResult = null;");
+        if (!result.__cancelled) {
+          onSelection(result as BrowserElementSelection);
+        }
+      } catch {
+        // Keep polling; cross-origin/webview timing can make this transient.
+      }
+    })();
+  }, 200);
+
+  return poll;
+}
+
+// eslint-disable-next-line complexity
+export function BrowserPane({
+  browserId,
+  serverId,
+  workspaceId,
+  cwd,
+}: {
+  browserId: string;
+  serverId: string;
+  workspaceId: string;
+  cwd: string | null;
+}) {
+  const { theme } = useUnistyles();
+  const browser = useBrowserStore((state) => state.browsersById[browserId] ?? null);
+  const updateBrowser = useBrowserStore((state) => state.updateBrowser);
+  const webviewRef = useRef<ElectronWebview | null>(null);
+  const webviewHostRef = useRef<HTMLDivElement | null>(null);
+  const initialUrlRef = useRef(browser?.url ?? "https://example.com");
+  const browserIdRef = useRef(browserId);
+  browserIdRef.current = browserId;
+  const domReadyRef = useRef(false);
+  const [selectorActive, setSelectorActive] = useState(false);
+  const [draftUrl, setDraftUrl] = useState(browser?.url ?? "https://example.com");
+  const workspaceAttachmentScopeKey = useMemo(
+    () => buildBrowserAttachmentScopeKey({ cwd, serverId, workspaceId }),
+    [cwd, serverId, workspaceId],
+  );
+  const workspaceAttachments = useWorkspaceAttachments(workspaceAttachmentScopeKey ?? "");
+  const setWorkspaceAttachments = useWorkspaceAttachmentsStore(
+    (state) => state.setWorkspaceAttachments,
+  );
+  const titleStyle = useMemo(
+    () => [styles.unavailableTitle, { color: theme.colors.foreground }],
+    [theme.colors.foreground],
+  );
+  const subtitleStyle = useMemo(
+    () => [styles.unavailableSubtitle, { color: theme.colors.foregroundMuted }],
+    [theme.colors.foregroundMuted],
+  );
+  const urlInputStyle = useMemo(
+    () => [
+      styles.urlInput,
+      {
+        color: theme.colors.foreground,
+        outlineStyle: "none",
+      } as object,
+    ],
+    [theme.colors.foreground],
+  );
+  const errorTextStyle = useMemo(
+    () => [styles.metaError, { color: theme.colors.palette.red[500] }],
+    [theme.colors.palette.red],
+  );
+
+  useEffect(() => {
+    const nextUrl = browser?.url ?? "https://example.com";
+    setDraftUrl((current) => (current === nextUrl ? current : nextUrl));
+  }, [browser?.url]);
+
+  const updateBrowserRef = useRef(updateBrowser);
+  updateBrowserRef.current = updateBrowser;
+
+  const syncNavigationState = useCallback(() => {
+    const webview = webviewRef.current;
+    if (!webview || !domReadyRef.current) {
+      return;
+    }
+
+    try {
+      const currentUrl = webview.getURL?.() ?? webview.getAttribute("src") ?? "";
+      updateBrowserRef.current(browserIdRef.current, {
+        url: normalizeWorkspaceBrowserUrl(currentUrl),
+        canGoBack: webview.canGoBack?.() ?? false,
+        canGoForward: webview.canGoForward?.() ?? false,
+      });
+    } catch {
+      // webview not yet attached
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isElectronRuntime()) {
+      return;
+    }
+
+    const host = webviewHostRef.current;
+    if (!host) {
+      return;
+    }
+
+    host.replaceChildren();
+
+    const webview = document.createElement("webview") as ElectronWebview;
+    webviewRef.current = webview;
+    webview.setAttribute("partition", `persist:paseo-browser-${browserId}`);
+    webview.setAttribute("allowpopups", "true");
+    webview.setAttribute("spellcheck", "false");
+    webview.setAttribute("autosize", "on");
+    webview.setAttribute("src", initialUrlRef.current);
+    webview.style.display = "flex";
+    webview.style.flex = "1";
+    webview.style.width = "100%";
+    webview.style.height = "100%";
+    webview.style.border = "0";
+    webview.style.background = "transparent";
+
+    const handleStartLoading = () => {
+      updateBrowser(browserId, { isLoading: true, lastError: null });
+      syncNavigationState();
+    };
+    const handleStopLoading = () => {
+      updateBrowser(browserId, { isLoading: false, lastError: null });
+      syncNavigationState();
+    };
+    const handleNavigate = (event: Event) => {
+      const nextUrl =
+        typeof (event as Event & { url?: unknown }).url === "string"
+          ? ((event as Event & { url?: string }).url ?? "")
+          : (webview.getURL?.() ?? webview.getAttribute("src") ?? "");
+      updateBrowser(browserIdRef.current, {
+        url: normalizeWorkspaceBrowserUrl(nextUrl),
+        lastError: null,
+      });
+      setDraftUrl((current) => {
+        const normalized = normalizeWorkspaceBrowserUrl(nextUrl);
+        return current === normalized ? current : normalized;
+      });
+      syncNavigationState();
+    };
+    const handleTitleUpdated = (event: Event) => {
+      const title =
+        typeof (event as Event & { title?: unknown }).title === "string"
+          ? ((event as Event & { title?: string }).title ?? "")
+          : "";
+      updateBrowserRef.current(browserIdRef.current, { title });
+    };
+    const handleFaviconUpdated = (event: Event) => {
+      const favicons = Array.isArray((event as Event & { favicons?: unknown[] }).favicons)
+        ? (((event as Event & { favicons?: string[] }).favicons as string[] | undefined) ?? [])
+        : [];
+      updateBrowserRef.current(browserIdRef.current, { faviconUrl: favicons[0] ?? null });
+    };
+    const handleLoadFailed = (event: Event) => {
+      const errorDescription =
+        typeof (event as Event & { errorDescription?: unknown }).errorDescription === "string"
+          ? ((event as Event & { errorDescription?: string }).errorDescription ?? "")
+          : "Failed to load page";
+      updateBrowserRef.current(browserIdRef.current, {
+        isLoading: false,
+        lastError: errorDescription,
+      });
+    };
+    const handleDomReady = () => {
+      domReadyRef.current = true;
+      updateBrowserRef.current(browserIdRef.current, { isLoading: false });
+      syncNavigationState();
+    };
+
+    webview.addEventListener("did-start-loading", handleStartLoading);
+    webview.addEventListener("did-stop-loading", handleStopLoading);
+    webview.addEventListener("did-navigate", handleNavigate);
+    webview.addEventListener("did-navigate-in-page", handleNavigate);
+    webview.addEventListener("page-title-updated", handleTitleUpdated);
+    webview.addEventListener("page-favicon-updated", handleFaviconUpdated);
+    webview.addEventListener("did-fail-load", handleLoadFailed);
+    webview.addEventListener("dom-ready", handleDomReady);
+
+    host.appendChild(webview);
+
+    return () => {
+      webview.removeEventListener("did-start-loading", handleStartLoading);
+      webview.removeEventListener("did-stop-loading", handleStopLoading);
+      webview.removeEventListener("did-navigate", handleNavigate);
+      webview.removeEventListener("did-navigate-in-page", handleNavigate);
+      webview.removeEventListener("page-title-updated", handleTitleUpdated);
+      webview.removeEventListener("page-favicon-updated", handleFaviconUpdated);
+      webview.removeEventListener("did-fail-load", handleLoadFailed);
+      webview.removeEventListener("dom-ready", handleDomReady);
+      if (host.contains(webview)) {
+        host.removeChild(webview);
+      }
+      if (webviewRef.current === webview) {
+        webviewRef.current = null;
+      }
+      domReadyRef.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [browserId]);
+
+  const navigate = useCallback((nextUrl: string) => {
+    const normalizedUrl = normalizeWorkspaceBrowserUrl(nextUrl);
+    const webview = webviewRef.current;
+    updateBrowserRef.current(browserIdRef.current, {
+      url: normalizedUrl,
+      isLoading: true,
+      lastError: null,
+    });
+    setDraftUrl((current) => (current === normalizedUrl ? current : normalizedUrl));
+    if (webview?.loadURL) {
+      webview.loadURL(normalizedUrl);
+      return;
+    }
+    if (webview) {
+      webview.setAttribute("src", normalizedUrl);
+    }
+  }, []);
+
+  const handleBack = useCallback(() => {
+    webviewRef.current?.goBack?.();
+    syncNavigationState();
+  }, [syncNavigationState]);
+
+  const handleForward = useCallback(() => {
+    webviewRef.current?.goForward?.();
+    syncNavigationState();
+  }, [syncNavigationState]);
+
+  const handleRefresh = useCallback(() => {
+    if (browser?.isLoading) {
+      webviewRef.current?.stop?.();
+      updateBrowser(browserId, { isLoading: false });
+      return;
+    }
+    webviewRef.current?.reload?.();
+  }, [browser?.isLoading, browserId, updateBrowser]);
+
+  const handleNavigateDraftUrl = useCallback(() => {
+    navigate(draftUrl);
+  }, [draftUrl, navigate]);
+
+  const addElementAttachment = useCallback(
+    (selection: BrowserElementSelection) => {
+      if (!workspaceAttachmentScopeKey) {
+        return;
+      }
+      setWorkspaceAttachments({
+        scopeKey: workspaceAttachmentScopeKey,
+        attachments: [
+          ...workspaceAttachments,
+          {
+            kind: "browser_element",
+            attachment: buildBrowserElementAttachment(selection),
+          },
+        ],
+      });
+    },
+    [setWorkspaceAttachments, workspaceAttachmentScopeKey, workspaceAttachments],
+  );
+
+  const startElementSelector = useCallback(() => {
+    const webview = webviewRef.current;
+    if (!webview || !domReadyRef.current || !workspaceAttachmentScopeKey) return;
+    setSelectorActive(true);
+
+    const js = `
+      (function() {
+        if (window.__paseoSelector) { window.__paseoSelector.destroy(); }
+        var overlay = null;
+        var style = document.createElement('style');
+        style.textContent = [
+          '.__paseo-hover { outline: 2px solid #3b82f6 !important; outline-offset: 2px !important; cursor: crosshair !important; }',
+          '.__paseo-select-mode, .__paseo-select-mode * { cursor: crosshair !important; pointer-events: auto !important; user-select: none !important; }',
+          '.__paseo-select-mode *, .__paseo-select-mode *::before, .__paseo-select-mode *::after { animation: none !important; transition: none !important; }',
+          '.__paseo-select-mode a, .__paseo-select-mode button, .__paseo-select-mode input, .__paseo-select-mode select, .__paseo-select-mode textarea, .__paseo-select-mode [role="button"], .__paseo-select-mode [onclick] { pointer-events: none !important; }',
+          '.__paseo-select-mode iframe, .__paseo-select-mode video, .__paseo-select-mode audio { pointer-events: none !important; }',
+        ].join('\\n');
+        document.head.appendChild(style);
+        document.documentElement.classList.add('__paseo-select-mode');
+        var last = null;
+        function onMove(e) {
+          e.preventDefault();
+          e.stopPropagation();
+          if (last) last.classList.remove('__paseo-hover');
+          e.target.classList.add('__paseo-hover');
+          last = e.target;
+        }
+        function buildSelector(el) {
+          if (el.id) return '#' + el.id;
+          var path = [];
+          while (el && el.nodeType === 1) {
+            var seg = el.tagName.toLowerCase();
+            if (el.id) { path.unshift('#' + el.id); break; }
+            var sib = el, nth = 1;
+            while (sib = sib.previousElementSibling) { if (sib.tagName === el.tagName) nth++; }
+            if (nth > 1) seg += ':nth-of-type(' + nth + ')';
+            path.unshift(seg);
+            el = el.parentElement;
+          }
+          return path.join(' > ');
+        }
+        function getReactSource(el) {
+          var keys = Object.keys(el);
+          for (var i = 0; i < keys.length; i++) {
+            if (keys[i].startsWith('__reactFiber$') || keys[i].startsWith('__reactInternalInstance$')) {
+              var fiber = el[keys[i]];
+              while (fiber) {
+                if (fiber._debugSource) {
+                  return {
+                    fileName: fiber._debugSource.fileName || null,
+                    lineNumber: fiber._debugSource.lineNumber || null,
+                    columnNumber: fiber._debugSource.columnNumber || null,
+                    componentName: (fiber.type && (typeof fiber.type === 'string' ? fiber.type : fiber.type.displayName || fiber.type.name)) || null
+                  };
+                }
+                if (fiber._debugOwner) { fiber = fiber._debugOwner; }
+                else if (fiber.return) { fiber = fiber.return; }
+                else break;
+              }
+            }
+          }
+          return null;
+        }
+        function getParentChain(el, depth) {
+          var chain = [];
+          var cur = el.parentElement;
+          for (var i = 0; i < (depth || 5) && cur; i++) {
+            var desc = cur.tagName.toLowerCase();
+            if (cur.id) desc += '#' + cur.id;
+            if (cur.className && typeof cur.className === 'string') { var cls = cur.className.trim().replace(/  +/g, ' ').split(' ').slice(0,2).join('.'); if (cls) desc += '.' + cls; }
+            chain.push(desc);
+            cur = cur.parentElement;
+          }
+          return chain;
+        }
+        function getChildSummary(el, max) {
+          var kids = [];
+          for (var i = 0; i < Math.min(el.children.length, max || 8); i++) {
+            var c = el.children[i];
+            var desc = c.tagName.toLowerCase();
+            if (c.id) desc += '#' + c.id;
+            kids.push(desc);
+          }
+          if (el.children.length > (max || 8)) kids.push('...(' + el.children.length + ' total)');
+          return kids;
+        }
+        function getRelevantStyles(el) {
+          var cs = window.getComputedStyle(el);
+          var pick = ['display','position','width','height','color','background-color','font-size','font-family','padding','margin','border','flex','grid-template-columns','gap','overflow','opacity','z-index'];
+          var out = {};
+          pick.forEach(function(p) {
+            var v = cs.getPropertyValue(p);
+            if (v && v !== 'none' && v !== 'normal' && v !== 'auto' && v !== '0px' && v !== 'rgba(0, 0, 0, 0)') out[p] = v;
+          });
+          return out;
+        }
+        function onClick(e) {
+          e.preventDefault();
+          e.stopPropagation();
+          e.stopImmediatePropagation();
+          var el = e.target;
+          if (last) last.classList.remove('__paseo-hover');
+          var attrs = {};
+          for (var i = 0; i < el.attributes.length; i++) {
+            attrs[el.attributes[i].name] = el.attributes[i].value;
+          }
+          var rect = el.getBoundingClientRect();
+          var result = {
+            tag: el.tagName.toLowerCase(),
+            text: (el.innerText || '').substring(0, 500),
+            selector: buildSelector(el),
+            attributes: attrs,
+            url: location.href,
+            outerHTML: el.outerHTML.substring(0, 2000),
+            computedStyles: getRelevantStyles(el),
+            boundingRect: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) },
+            reactSource: getReactSource(el),
+            parentChain: getParentChain(el, 5),
+            children: getChildSummary(el, 8)
+          };
+          destroy();
+          window.__paseoSelectorResult = result;
+        }
+        function onKey(e) {
+          if (e.key === 'Escape') { destroy(); window.__paseoSelectorResult = { __cancelled: true }; }
+        }
+        function blockEvent(e) {
+          e.preventDefault();
+          e.stopPropagation();
+          e.stopImmediatePropagation();
+        }
+        function destroy() {
+          document.removeEventListener('mousemove', onMove, true);
+          document.removeEventListener('click', onClick, true);
+          document.removeEventListener('keydown', onKey, true);
+          document.removeEventListener('mousedown', blockEvent, true);
+          document.removeEventListener('mouseup', blockEvent, true);
+          document.removeEventListener('pointerdown', blockEvent, true);
+          document.removeEventListener('pointerup', blockEvent, true);
+          document.removeEventListener('touchstart', blockEvent, true);
+          document.removeEventListener('touchend', blockEvent, true);
+          document.removeEventListener('focus', blockEvent, true);
+          document.removeEventListener('submit', blockEvent, true);
+          document.documentElement.classList.remove('__paseo-select-mode');
+          if (last) last.classList.remove('__paseo-hover');
+          style.remove();
+          window.__paseoSelector = null;
+        }
+        document.addEventListener('mousemove', onMove, true);
+        document.addEventListener('click', onClick, true);
+        document.addEventListener('keydown', onKey, true);
+        document.addEventListener('mousedown', blockEvent, true);
+        document.addEventListener('mouseup', blockEvent, true);
+        document.addEventListener('pointerdown', blockEvent, true);
+        document.addEventListener('pointerup', blockEvent, true);
+        document.addEventListener('touchstart', blockEvent, true);
+        document.addEventListener('touchend', blockEvent, true);
+        document.addEventListener('focus', blockEvent, true);
+        document.addEventListener('submit', blockEvent, true);
+        window.__paseoSelector = { destroy: destroy };
+      })()
+    `;
+
+    try {
+      void executeWebviewJavaScript(webview, js).then(() => {
+        const poll = startSelectorResultPolling({
+          webview,
+          onSelection: addElementAttachment,
+          onDone: () => setSelectorActive(false),
+        });
+        window.setTimeout(() => {
+          window.clearInterval(poll);
+          setSelectorActive(false);
+          void executeWebviewJavaScript(
+            webview,
+            "if(window.__paseoSelector) window.__paseoSelector.destroy();",
+          );
+        }, 30000);
+        return undefined;
+      });
+    } catch {
+      setSelectorActive(false);
+    }
+  }, [addElementAttachment, workspaceAttachmentScopeKey]);
+
+  const cancelElementSelector = useCallback(() => {
+    const webview = webviewRef.current;
+    setSelectorActive(false);
+    if (webview && domReadyRef.current) {
+      try {
+        void executeWebviewJavaScript(
+          webview,
+          "if(window.__paseoSelector) window.__paseoSelector.destroy(); window.__paseoSelectorResult = null;",
+        );
+      } catch {}
+    }
+  }, []);
+
+  const handleToggleElementSelector = useCallback(() => {
+    if (selectorActive) {
+      cancelElementSelector();
+      return;
+    }
+    startElementSelector();
+  }, [cancelElementSelector, selectorActive, startElementSelector]);
+
+  const baseIconButtonStyle = useCallback(
+    ({ hovered, pressed }: { hovered?: boolean; pressed?: boolean }) => [
+      styles.iconButton,
+      (hovered || pressed) && styles.iconButtonHovered,
+    ],
+    [],
+  );
+  const backIconButtonStyle = useCallback(
+    ({ hovered, pressed }: { hovered?: boolean; pressed?: boolean }) => [
+      styles.iconButton,
+      (hovered || pressed) && styles.iconButtonHovered,
+      !browser?.canGoBack && styles.iconButtonDisabled,
+    ],
+    [browser?.canGoBack],
+  );
+  const forwardIconButtonStyle = useCallback(
+    ({ hovered, pressed }: { hovered?: boolean; pressed?: boolean }) => [
+      styles.iconButton,
+      (hovered || pressed) && styles.iconButtonHovered,
+      !browser?.canGoForward && styles.iconButtonDisabled,
+    ],
+    [browser?.canGoForward],
+  );
+  const selectorIconButtonStyle = useCallback(
+    ({ hovered, pressed }: { hovered?: boolean; pressed?: boolean }) => [
+      styles.iconButton,
+      selectorActive && styles.selectorActiveButton,
+      (hovered || pressed) && styles.iconButtonHovered,
+    ],
+    [selectorActive],
+  );
+
+  const webviewHostStyle = useMemo<CSSProperties>(
+    () => ({
+      display: "flex",
+      flex: 1,
+      width: "100%",
+      height: "100%",
+      minHeight: 0,
+      background: theme.colors.surface0,
+    }),
+    [theme.colors.surface0],
+  );
+
+  if (!isElectronRuntime()) {
+    return (
+      <View style={styles.unavailableState}>
+        <Text style={titleStyle}>Browser is desktop-only</Text>
+        <Text style={subtitleStyle}>
+          Open this workspace in Electron to use the built-in browser.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.chromeRow}>
+        <View style={styles.chromeLeft}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+            disabled={!browser?.canGoBack}
+            onPress={handleBack}
+            style={backIconButtonStyle}
+          >
+            <ArrowLeft size={16} color={theme.colors.foregroundMuted} />
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Forward"
+            disabled={!browser?.canGoForward}
+            onPress={handleForward}
+            style={forwardIconButtonStyle}
+          >
+            <ArrowRight size={16} color={theme.colors.foregroundMuted} />
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={browser?.isLoading ? "Stop loading" : "Refresh"}
+            onPress={handleRefresh}
+            style={baseIconButtonStyle}
+          >
+            <RefreshCw size={16} color={theme.colors.foregroundMuted} />
+          </Pressable>
+        </View>
+        <View style={styles.urlBarWrap}>
+          <View style={styles.urlBarIconWrap}>
+            {browser?.faviconUrl ? (
+              createElement("img", {
+                alt: "",
+                src: browser.faviconUrl,
+                style: { width: 14, height: 14, borderRadius: 3 } satisfies CSSProperties,
+              })
+            ) : (
+              <Globe size={14} color={theme.colors.foregroundMuted} />
+            )}
+          </View>
+          <TextInput
+            accessibilityLabel="Browser URL"
+            autoCapitalize="none"
+            autoCorrect={false}
+            onChangeText={setDraftUrl}
+            onSubmitEditing={handleNavigateDraftUrl}
+            placeholder="Enter URL"
+            placeholderTextColor={theme.colors.foregroundMuted}
+            style={urlInputStyle}
+            value={draftUrl}
+          />
+        </View>
+        <View style={styles.chromeRight}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Go to URL"
+            onPress={handleNavigateDraftUrl}
+            style={baseIconButtonStyle}
+          >
+            <Search size={16} color={theme.colors.foregroundMuted} />
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={selectorActive ? "Cancel element selector" : "Select element"}
+            onPress={handleToggleElementSelector}
+            style={selectorIconButtonStyle}
+          >
+            <MousePointer2
+              size={16}
+              color={selectorActive ? theme.colors.accent : theme.colors.foregroundMuted}
+            />
+          </Pressable>
+        </View>
+      </View>
+      {browser?.lastError ? (
+        <View style={styles.errorRow}>
+          <Text numberOfLines={1} style={errorTextStyle}>
+            {browser.lastError}
+          </Text>
+        </View>
+      ) : null}
+      <View style={styles.webviewWrap}>
+        {createElement("div", {
+          ref: (node: HTMLDivElement | null) => {
+            webviewHostRef.current = node;
+          },
+          style: webviewHostStyle,
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    flex: 1,
+    minHeight: 0,
+    backgroundColor: theme.colors.surface0,
+  },
+  chromeRow: {
+    minHeight: 40,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.surface3,
+    backgroundColor: theme.colors.surface1,
+  },
+  chromeLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  chromeRight: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  iconButton: {
+    width: 28,
+    height: 28,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  selectorActiveButton: {
+    backgroundColor: `${String(theme.colors.accent)}20`,
+  },
+  iconButtonHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+  iconButtonDisabled: {
+    opacity: 0.45,
+  },
+  urlBarWrap: {
+    flex: 1,
+    minWidth: 0,
+    height: 30,
+    borderRadius: 10,
+    paddingLeft: 10,
+    paddingRight: 8,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    backgroundColor: theme.colors.surface0,
+    borderWidth: 1,
+    borderColor: theme.colors.surface3,
+  },
+  urlBarIconWrap: {
+    width: 14,
+    height: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  urlInput: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 12,
+    paddingVertical: 0,
+    paddingHorizontal: 0,
+  },
+  errorRow: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.surface3,
+    backgroundColor: theme.colors.surface0,
+  },
+  metaError: {
+    fontSize: 11,
+  },
+  webviewWrap: {
+    flex: 1,
+    minHeight: 0,
+    overflow: "hidden",
+  },
+  unavailableState: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+    gap: 8,
+  },
+  unavailableTitle: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  unavailableSubtitle: {
+    fontSize: 12,
+  },
+}));

--- a/packages/app/src/components/browser-pane.tsx
+++ b/packages/app/src/components/browser-pane.tsx
@@ -1,0 +1,46 @@
+import { Text, View } from "react-native";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { useMemo } from "react";
+
+interface BrowserPaneProps {
+  browserId: string;
+  serverId: string;
+  workspaceId: string;
+  cwd: string | null;
+}
+
+export function BrowserPane({ browserId }: BrowserPaneProps) {
+  const { theme } = useUnistyles();
+  const titleStyle = useMemo(
+    () => [styles.title, { color: theme.colors.foreground }],
+    [theme.colors.foreground],
+  );
+  const subtitleStyle = useMemo(
+    () => [styles.subtitle, { color: theme.colors.foregroundMuted }],
+    [theme.colors.foregroundMuted],
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={titleStyle}>Browser is desktop-only</Text>
+      <Text style={subtitleStyle}>Browser session {browserId}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create(() => ({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    padding: 16,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  subtitle: {
+    fontSize: 12,
+  },
+}));

--- a/packages/app/src/components/browser-pane.tsx
+++ b/packages/app/src/components/browser-pane.tsx
@@ -7,6 +7,7 @@ interface BrowserPaneProps {
   serverId: string;
   workspaceId: string;
   cwd: string | null;
+  isInteractive?: boolean;
 }
 
 export function BrowserPane({ browserId }: BrowserPaneProps) {

--- a/packages/app/src/components/browser-pane.tsx
+++ b/packages/app/src/components/browser-pane.tsx
@@ -8,6 +8,7 @@ interface BrowserPaneProps {
   workspaceId: string;
   cwd: string | null;
   isInteractive?: boolean;
+  onFocusPane?: () => void;
 }
 
 export function BrowserPane({ browserId }: BrowserPaneProps) {

--- a/packages/app/src/components/browser-pane.web.tsx
+++ b/packages/app/src/components/browser-pane.web.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+import { Text, View } from "react-native";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+
+interface BrowserPaneProps {
+  browserId: string;
+  serverId: string;
+  workspaceId: string;
+  cwd: string | null;
+}
+
+export function BrowserPane({ browserId }: BrowserPaneProps) {
+  const { theme } = useUnistyles();
+  const titleStyle = useMemo(
+    () => [styles.title, { color: theme.colors.foreground }],
+    [theme.colors.foreground],
+  );
+  const subtitleStyle = useMemo(
+    () => [styles.subtitle, { color: theme.colors.foregroundMuted }],
+    [theme.colors.foregroundMuted],
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={titleStyle}>Browser is desktop-only</Text>
+      <Text style={subtitleStyle}>
+        Open this workspace in Electron to use the built-in browser.
+      </Text>
+      <Text style={subtitleStyle}>Browser session {browserId}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create(() => ({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    padding: 16,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  subtitle: {
+    fontSize: 12,
+  },
+}));

--- a/packages/app/src/components/browser-pane.web.tsx
+++ b/packages/app/src/components/browser-pane.web.tsx
@@ -7,6 +7,7 @@ interface BrowserPaneProps {
   serverId: string;
   workspaceId: string;
   cwd: string | null;
+  isInteractive?: boolean;
 }
 
 export function BrowserPane({ browserId }: BrowserPaneProps) {

--- a/packages/app/src/components/browser-pane.web.tsx
+++ b/packages/app/src/components/browser-pane.web.tsx
@@ -8,6 +8,7 @@ interface BrowserPaneProps {
   workspaceId: string;
   cwd: string | null;
   isInteractive?: boolean;
+  onFocusPane?: () => void;
 }
 
 export function BrowserPane({ browserId }: BrowserPaneProps) {

--- a/packages/app/src/components/composer.test.tsx
+++ b/packages/app/src/components/composer.test.tsx
@@ -225,6 +225,7 @@ vi.mock("lucide-react-native", () => {
     Pencil: createIcon("Pencil"),
     AudioLines: createIcon("AudioLines"),
     CircleDot: createIcon("CircleDot"),
+    MousePointer2: createIcon("MousePointer2"),
     GitPullRequest: createIcon("GitPullRequest"),
     X: createIcon("X"),
     Mic: createIcon("Mic"),
@@ -574,6 +575,7 @@ let workspaceBindingRenderCount = 0;
 
 type ReviewComposerAttachment = Extract<ComposerAttachment, { kind: "review" }>;
 type ReviewAttachment = Extract<AgentAttachment, { type: "review" }>;
+type BrowserElementComposerAttachment = Extract<ComposerAttachment, { kind: "browser_element" }>;
 
 function reviewAttachment(body: string): ReviewAttachment {
   return {
@@ -616,6 +618,30 @@ function reviewComposerAttachment(body: string): ReviewComposerAttachment {
     reviewDraftKey: `review:${body}`,
     commentCount: 1,
     attachment: reviewAttachment(body),
+  };
+}
+
+function browserElementComposerAttachment(): BrowserElementComposerAttachment {
+  return {
+    kind: "browser_element",
+    attachment: {
+      url: "https://example.com/page",
+      selector: "button.primary",
+      tag: "button",
+      text: "Save",
+      outerHTML: '<button class="primary">Save</button>',
+      computedStyles: { display: "flex" },
+      boundingRect: { x: 1, y: 2, width: 80, height: 32 },
+      reactSource: {
+        fileName: "src/save-button.tsx",
+        lineNumber: 12,
+        columnNumber: 3,
+        componentName: "SaveButton",
+      },
+      parentChain: ["form.settings"],
+      children: [],
+      formatted: '<browser-element url="https://example.com/page">button.primary</browser-element>',
+    },
   };
 }
 
@@ -1040,6 +1066,21 @@ describe("Composer attachments", () => {
     expect(splitComposerAttachmentsForSubmit([review])).toEqual({
       images: [],
       attachments: [review.attachment],
+    });
+  });
+
+  it("serializes browser element workspace attachments as generic text attachments", async () => {
+    const browserElement = browserElementComposerAttachment();
+    expect(splitComposerAttachmentsForSubmit([browserElement])).toEqual({
+      images: [],
+      attachments: [
+        {
+          type: "text",
+          mimeType: "text/plain",
+          title: "Browser element · button",
+          text: browserElement.attachment.formatted,
+        },
+      ],
     });
   });
 

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -426,6 +426,8 @@ function getUserMessageAttachmentLabel(attachment: AgentAttachment): string {
       return `PR #${attachment.number}`;
     case "github_issue":
       return `Issue #${attachment.number}`;
+    case "text":
+      return attachment.title ?? "Text attachment";
   }
 }
 

--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -160,6 +160,7 @@ interface MountedTabSlotProps {
   isWorkspaceFocused: boolean;
   isPaneFocused: boolean;
   paneId: string;
+  onFocusPane: (paneId: string) => void;
   buildPaneContentModel: (input: {
     paneId: string;
     tab: WorkspaceTabDescriptor;
@@ -172,6 +173,7 @@ const MountedTabSlot = memo(function MountedTabSlot({
   isWorkspaceFocused,
   isPaneFocused,
   paneId,
+  onFocusPane,
   buildPaneContentModel,
 }: MountedTabSlotProps) {
   const content = useMemo(
@@ -187,6 +189,9 @@ const MountedTabSlot = memo(function MountedTabSlot({
     () => ({ display: (isVisible ? "flex" : "none") as "flex" | "none", flex: 1 }),
     [isVisible],
   );
+  const handleFocusPane = useCallback(() => {
+    onFocusPane(paneId);
+  }, [onFocusPane, paneId]);
 
   return (
     <View style={wrapperStyle}>
@@ -194,6 +199,7 @@ const MountedTabSlot = memo(function MountedTabSlot({
         content={content}
         isWorkspaceFocused={isWorkspaceFocused}
         isPaneFocused={isPaneFocused}
+        onFocusPane={handleFocusPane}
       />
     </View>
   );
@@ -1020,6 +1026,7 @@ function SplitPaneView({
                   isWorkspaceFocused={isWorkspaceFocused}
                   isPaneFocused={isFocused && tabId === activeTabDescriptor?.tabId}
                   paneId={pane.id}
+                  onFocusPane={stableOnFocusPane}
                   buildPaneContentModel={buildPaneContentModel}
                 />
               );

--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -91,6 +91,8 @@ interface SplitContainerProps {
   onCloseOtherTabs: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCreateDraftTab: (input: { paneId?: string }) => void;
   onCreateTerminalTab: (input: { paneId?: string }) => void;
+  onCreateBrowserTab: (input: { paneId?: string }) => void;
+  showCreateBrowserTab?: boolean;
   buildPaneContentModel: (input: {
     paneId: string;
     tab: WorkspaceTabDescriptor;
@@ -339,6 +341,8 @@ export function SplitContainer({
   onCloseOtherTabs,
   onCreateDraftTab,
   onCreateTerminalTab,
+  onCreateBrowserTab,
+  showCreateBrowserTab,
   buildPaneContentModel,
   onFocusPane,
   onSplitPane,
@@ -557,6 +561,8 @@ export function SplitContainer({
         onCloseOtherTabs={onCloseOtherTabs}
         onCreateDraftTab={onCreateDraftTab}
         onCreateTerminalTab={onCreateTerminalTab}
+        onCreateBrowserTab={onCreateBrowserTab}
+        showCreateBrowserTab={showCreateBrowserTab}
         buildPaneContentModel={buildPaneContentModel}
         onFocusPane={onFocusPane}
         onSplitPane={onSplitPane}
@@ -694,6 +700,8 @@ function SplitNodeView({
   onCloseOtherTabs,
   onCreateDraftTab,
   onCreateTerminalTab,
+  onCreateBrowserTab,
+  showCreateBrowserTab,
   buildPaneContentModel,
   onFocusPane,
   onSplitPane,
@@ -744,6 +752,8 @@ function SplitNodeView({
         onCloseOtherTabs={onCloseOtherTabs}
         onCreateDraftTab={onCreateDraftTab}
         onCreateTerminalTab={onCreateTerminalTab}
+        onCreateBrowserTab={onCreateBrowserTab}
+        showCreateBrowserTab={showCreateBrowserTab}
         buildPaneContentModel={buildPaneContentModel}
         onFocusPane={onFocusPane}
         onSplitPane={onSplitPane}
@@ -787,6 +797,8 @@ function SplitNodeView({
               onCloseOtherTabs={onCloseOtherTabs}
               onCreateDraftTab={onCreateDraftTab}
               onCreateTerminalTab={onCreateTerminalTab}
+              onCreateBrowserTab={onCreateBrowserTab}
+              showCreateBrowserTab={showCreateBrowserTab}
               buildPaneContentModel={buildPaneContentModel}
               onFocusPane={onFocusPane}
               onSplitPane={onSplitPane}
@@ -836,6 +848,8 @@ function SplitPaneView({
   onCloseOtherTabs,
   onCreateDraftTab,
   onCreateTerminalTab,
+  onCreateBrowserTab,
+  showCreateBrowserTab,
   buildPaneContentModel,
   onFocusPane,
   onSplitPane: _onSplitPane,
@@ -977,6 +991,8 @@ function SplitPaneView({
           onCloseOtherTabs={handleCloseOtherTabs}
           onCreateDraftTab={onCreateDraftTab}
           onCreateTerminalTab={onCreateTerminalTab}
+          onCreateBrowserTab={onCreateBrowserTab}
+          showCreateBrowserTab={showCreateBrowserTab}
           onReorderTabs={handleReorderTabs}
           onSplitRight={handleSplitRight}
           onSplitDown={handleSplitDown}

--- a/packages/app/src/desktop/host.ts
+++ b/packages/app/src/desktop/host.ts
@@ -69,6 +69,11 @@ export interface DesktopEventsBridge {
   on?: (event: string, handler: (payload: unknown) => void) => Promise<() => void> | (() => void);
 }
 
+export interface DesktopBrowserShortcutEvent {
+  browserId?: string;
+  action: "focus-url";
+}
+
 export interface DesktopInvokeBridge {
   invoke?: (command: string, args?: Record<string, unknown>) => Promise<unknown>;
 }

--- a/packages/app/src/panels/agent-panel.test.tsx
+++ b/packages/app/src/panels/agent-panel.test.tsx
@@ -314,6 +314,7 @@ async function renderAgentPanel(
     isWorkspaceFocused: true,
     isPaneFocused: false,
     isInteractive: false,
+    focusPane: vi.fn(),
   },
 ) {
   const AgentPanel = agentPanelRegistration.component;
@@ -462,6 +463,7 @@ describe("AgentPanel render isolation", () => {
       isWorkspaceFocused: false,
       isPaneFocused: true,
       isInteractive: false,
+      focusPane: vi.fn(),
     });
 
     expect(latestComposerIsPaneFocused.current).toBe(false);
@@ -545,6 +547,7 @@ describe("AgentPanel render isolation", () => {
       isWorkspaceFocused: true,
       isPaneFocused: true,
       isInteractive: true,
+      focusPane: vi.fn(),
     });
 
     const timeoutAt = Date.now() + 300;

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -1264,6 +1264,9 @@ function ActiveAgentComposer({
   const setExplorerTabForCheckout = usePanelStore((state) => state.setExplorerTabForCheckout);
   const handleOpenWorkspaceAttachment = useCallback(
     (attachment: WorkspaceComposerAttachment) => {
+      if (attachment.kind !== "review") {
+        return;
+      }
       const checkout = {
         serverId,
         cwd: attachment.attachment.cwd,

--- a/packages/app/src/panels/browser-panel.tsx
+++ b/packages/app/src/panels/browser-panel.tsx
@@ -1,0 +1,58 @@
+import { Globe } from "lucide-react-native";
+import invariant from "tiny-invariant";
+import { BrowserPane } from "@/components/browser-pane";
+import { usePaneContext } from "@/panels/pane-context";
+import type { PanelDescriptor, PanelRegistration } from "@/panels/panel-registry";
+import { useBrowserStore } from "@/stores/browser-store";
+import { useWorkspaceExecutionAuthority } from "@/stores/session-store-hooks";
+
+function getBrowserLabel(input: { title: string; url: string }): string {
+  const title = input.title.trim();
+  if (title) {
+    return title;
+  }
+
+  try {
+    const parsed = new URL(input.url);
+    return parsed.hostname || input.url;
+  } catch {
+    return input.url;
+  }
+}
+
+function useBrowserPanelDescriptor(target: {
+  kind: "browser";
+  browserId: string;
+}): PanelDescriptor {
+  const browser = useBrowserStore((state) => state.browsersById[target.browserId] ?? null);
+  const url = browser?.url ?? "https://example.com";
+
+  return {
+    label: getBrowserLabel({ title: browser?.title ?? "", url }),
+    subtitle: url,
+    titleState: "ready",
+    icon: Globe,
+    statusBucket: null,
+  };
+}
+
+function BrowserPanel() {
+  const { serverId, workspaceId, target } = usePaneContext();
+  const workspaceAuthority = useWorkspaceExecutionAuthority(serverId, workspaceId)!;
+  const cwd = workspaceAuthority.ok ? workspaceAuthority.authority.workspaceDirectory : null;
+  invariant(target.kind === "browser", "BrowserPanel requires browser target");
+  return (
+    <BrowserPane
+      browserId={target.browserId}
+      serverId={serverId}
+      workspaceId={workspaceId}
+      cwd={cwd}
+    />
+  );
+}
+
+export const browserPanelRegistration: PanelRegistration<"browser"> = {
+  kind: "browser",
+  component: BrowserPanel,
+  useDescriptor: useBrowserPanelDescriptor,
+};

--- a/packages/app/src/panels/browser-panel.tsx
+++ b/packages/app/src/panels/browser-panel.tsx
@@ -1,8 +1,10 @@
+import { useMemo } from "react";
+import { Image } from "react-native";
 import { Globe } from "lucide-react-native";
 import invariant from "tiny-invariant";
 import { BrowserPane } from "@/components/browser-pane";
 import { usePaneContext } from "@/panels/pane-context";
-import type { PanelDescriptor, PanelRegistration } from "@/panels/panel-registry";
+import type { PanelDescriptor, PanelIconProps, PanelRegistration } from "@/panels/panel-registry";
 import { useBrowserStore } from "@/stores/browser-store";
 import { useWorkspaceExecutionAuthority } from "@/stores/session-store-hooks";
 
@@ -20,19 +22,33 @@ function getBrowserLabel(input: { title: string; url: string }): string {
   }
 }
 
+function createBrowserTabIcon(faviconUrl: string | null) {
+  return function BrowserTabIcon({ size, color }: PanelIconProps) {
+    const source = useMemo(() => (faviconUrl ? { uri: faviconUrl } : undefined), []);
+    const imageStyle = useMemo(() => ({ width: size, height: size, borderRadius: 3 }), [size]);
+
+    if (faviconUrl) {
+      return <Image accessibilityIgnoresInvertColors source={source} style={imageStyle} />;
+    }
+
+    return <Globe size={size} color={color} />;
+  };
+}
+
 function useBrowserPanelDescriptor(target: {
   kind: "browser";
   browserId: string;
 }): PanelDescriptor {
   const browser = useBrowserStore((state) => state.browsersById[target.browserId] ?? null);
   const url = browser?.url ?? "https://example.com";
+  const icon = createBrowserTabIcon(browser?.faviconUrl ?? null);
 
   return {
     label: getBrowserLabel({ title: browser?.title ?? "", url }),
     subtitle: url,
     titleState: "ready",
-    icon: Globe,
-    statusBucket: null,
+    icon,
+    statusBucket: browser?.isLoading ? "running" : null,
   };
 }
 

--- a/packages/app/src/panels/browser-panel.tsx
+++ b/packages/app/src/panels/browser-panel.tsx
@@ -3,7 +3,7 @@ import { Image } from "react-native";
 import { Globe } from "lucide-react-native";
 import invariant from "tiny-invariant";
 import { BrowserPane } from "@/components/browser-pane";
-import { usePaneContext } from "@/panels/pane-context";
+import { usePaneContext, usePaneFocus } from "@/panels/pane-context";
 import type { PanelDescriptor, PanelIconProps, PanelRegistration } from "@/panels/panel-registry";
 import { useBrowserStore } from "@/stores/browser-store";
 import { useWorkspaceExecutionAuthority } from "@/stores/session-store-hooks";
@@ -54,6 +54,7 @@ function useBrowserPanelDescriptor(target: {
 
 function BrowserPanel() {
   const { serverId, workspaceId, target } = usePaneContext();
+  const { isInteractive } = usePaneFocus();
   const workspaceAuthority = useWorkspaceExecutionAuthority(serverId, workspaceId)!;
   const cwd = workspaceAuthority.ok ? workspaceAuthority.authority.workspaceDirectory : null;
   invariant(target.kind === "browser", "BrowserPanel requires browser target");
@@ -63,6 +64,7 @@ function BrowserPanel() {
       serverId={serverId}
       workspaceId={workspaceId}
       cwd={cwd}
+      isInteractive={isInteractive}
     />
   );
 }

--- a/packages/app/src/panels/browser-panel.tsx
+++ b/packages/app/src/panels/browser-panel.tsx
@@ -54,7 +54,7 @@ function useBrowserPanelDescriptor(target: {
 
 function BrowserPanel() {
   const { serverId, workspaceId, target } = usePaneContext();
-  const { isInteractive } = usePaneFocus();
+  const { focusPane, isInteractive } = usePaneFocus();
   const workspaceAuthority = useWorkspaceExecutionAuthority(serverId, workspaceId)!;
   const cwd = workspaceAuthority.ok ? workspaceAuthority.authority.workspaceDirectory : null;
   invariant(target.kind === "browser", "BrowserPanel requires browser target");
@@ -65,6 +65,7 @@ function BrowserPanel() {
       workspaceId={workspaceId}
       cwd={cwd}
       isInteractive={isInteractive}
+      onFocusPane={focusPane}
     />
   );
 }

--- a/packages/app/src/panels/pane-context.test.ts
+++ b/packages/app/src/panels/pane-context.test.ts
@@ -12,6 +12,7 @@ describe("createPaneFocusContextValue", () => {
       isWorkspaceFocused: true,
       isPaneFocused: true,
       isInteractive: true,
+      focusPane: expect.any(Function),
     });
     expect(
       createPaneFocusContextValue({
@@ -22,6 +23,7 @@ describe("createPaneFocusContextValue", () => {
       isWorkspaceFocused: false,
       isPaneFocused: true,
       isInteractive: false,
+      focusPane: expect.any(Function),
     });
   });
 });

--- a/packages/app/src/panels/pane-context.tsx
+++ b/packages/app/src/panels/pane-context.tsx
@@ -17,19 +17,23 @@ export interface PaneFocusContextValue {
   isWorkspaceFocused: boolean;
   isPaneFocused: boolean;
   isInteractive: boolean;
+  focusPane(): void;
 }
 
 const PaneContext = createContext<PaneContextValue | null>(null);
 const PaneFocusContext = createContext<PaneFocusContextValue | null>(null);
+const noopFocusPane = () => {};
 
 export function createPaneFocusContextValue(input: {
   isWorkspaceFocused: boolean;
   isPaneFocused: boolean;
+  onFocusPane?: () => void;
 }): PaneFocusContextValue {
   return {
     isWorkspaceFocused: input.isWorkspaceFocused,
     isPaneFocused: input.isPaneFocused,
     isInteractive: input.isWorkspaceFocused && input.isPaneFocused,
+    focusPane: input.onFocusPane ?? noopFocusPane,
   };
 }
 

--- a/packages/app/src/panels/register-panels.ts
+++ b/packages/app/src/panels/register-panels.ts
@@ -1,4 +1,5 @@
 import { agentPanelRegistration } from "@/panels/agent-panel";
+import { browserPanelRegistration } from "@/panels/browser-panel";
 import { draftPanelRegistration } from "@/panels/draft-panel";
 import { filePanelRegistration } from "@/panels/file-panel";
 import { registerPanel } from "@/panels/panel-registry";
@@ -15,6 +16,7 @@ export function ensurePanelsRegistered(): void {
   registerPanel(agentPanelRegistration);
   registerPanel(setupPanelRegistration);
   registerPanel(terminalPanelRegistration);
+  registerPanel(browserPanelRegistration);
   registerPanel(filePanelRegistration);
   panelsRegistered = true;
 }

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -24,6 +24,7 @@ import {
   Copy,
   RotateCw,
   Rows2,
+  Globe,
   SquarePen,
   SquareTerminal,
   X,
@@ -72,6 +73,7 @@ const ThemedArrowRightToLine = withUnistyles(ArrowRightToLine);
 const ThemedCopyX = withUnistyles(CopyX);
 const ThemedSquarePen = withUnistyles(SquarePen);
 const ThemedSquareTerminal = withUnistyles(SquareTerminal);
+const ThemedGlobe = withUnistyles(Globe);
 const ThemedColumns2 = withUnistyles(Columns2);
 const ThemedRows2 = withUnistyles(Rows2);
 
@@ -153,6 +155,8 @@ interface WorkspaceDesktopTabsRowProps {
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
   onCreateDraftTab: (input: { paneId?: string }) => void;
   onCreateTerminalTab: (input: { paneId?: string }) => void;
+  onCreateBrowserTab: (input: { paneId?: string }) => void;
+  showCreateBrowserTab?: boolean;
   disableCreateTerminal?: boolean;
   isWaitingOnTerminalReadiness?: boolean;
   onReorderTabs: (nextTabs: WorkspaceTabDescriptor[]) => void;
@@ -468,6 +472,8 @@ export function WorkspaceDesktopTabsRow({
   onCloseOtherTabs,
   onCreateDraftTab,
   onCreateTerminalTab,
+  onCreateBrowserTab,
+  showCreateBrowserTab = false,
   disableCreateTerminal = false,
   isWaitingOnTerminalReadiness = false,
   onReorderTabs,
@@ -548,6 +554,10 @@ export function WorkspaceDesktopTabsRow({
   const handleCreateTerminal = useCallback(() => {
     onCreateTerminalTab({ paneId });
   }, [onCreateTerminalTab, paneId]);
+
+  const handleCreateBrowser = useCallback(() => {
+    onCreateBrowserTab({ paneId });
+  }, [onCreateBrowserTab, paneId]);
 
   const terminalDisabled = disableCreateTerminal || isWaitingOnTerminalReadiness;
   const newTerminalActionButtonStyle = useCallback(
@@ -707,6 +717,24 @@ export function WorkspaceDesktopTabsRow({
             </View>
           </TooltipContent>
         </Tooltip>
+        {showCreateBrowserTab ? (
+          <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
+            <TooltipTrigger
+              testID="workspace-new-browser"
+              onPress={handleCreateBrowser}
+              accessibilityRole="button"
+              accessibilityLabel="New browser tab"
+              style={newTabActionButtonStyle}
+            >
+              <ThemedGlobe size={14} uniProps={mutedColorMapping} />
+            </TooltipTrigger>
+            <TooltipContent side="bottom" align="center" offset={8}>
+              <View style={styles.newTabTooltipRow}>
+                <Text style={styles.newTabTooltipText}>New browser tab</Text>
+              </View>
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
         {showPaneSplitActions ? (
           <>
             <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>

--- a/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
+++ b/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
@@ -342,6 +342,9 @@ export function WorkspaceDraftAgentTab({
   const setExplorerTabForCheckout = usePanelStore((state) => state.setExplorerTabForCheckout);
   const handleOpenWorkspaceAttachment = useCallback(
     (attachment: WorkspaceComposerAttachment) => {
+      if (attachment.kind !== "review") {
+        return;
+      }
       const checkout = {
         serverId,
         cwd: attachment.attachment.cwd,

--- a/packages/app/src/screens/workspace/workspace-pane-content.test.tsx
+++ b/packages/app/src/screens/workspace/workspace-pane-content.test.tsx
@@ -110,11 +110,13 @@ describe("WorkspacePaneContent", () => {
       isWorkspaceFocused: true,
       isPaneFocused: false,
       isInteractive: false,
+      focusPane: expect.any(Function),
     });
     expect(snapshots[1]?.focus).toEqual({
       isWorkspaceFocused: true,
       isPaneFocused: true,
       isInteractive: true,
+      focusPane: expect.any(Function),
     });
   });
 });

--- a/packages/app/src/screens/workspace/workspace-pane-content.tsx
+++ b/packages/app/src/screens/workspace/workspace-pane-content.tsx
@@ -58,12 +58,14 @@ export interface WorkspacePaneContentProps {
   content: WorkspacePaneContentModel;
   isWorkspaceFocused: boolean;
   isPaneFocused: boolean;
+  onFocusPane?: () => void;
 }
 
 export function WorkspacePaneContent({
   content,
   isWorkspaceFocused,
   isPaneFocused,
+  onFocusPane,
 }: WorkspacePaneContentProps) {
   const { Component, key, paneContextValue } = content;
   const paneFocusValue = useMemo(
@@ -71,8 +73,9 @@ export function WorkspacePaneContent({
       createPaneFocusContextValue({
         isWorkspaceFocused,
         isPaneFocused,
+        onFocusPane,
       }),
-    [isPaneFocused, isWorkspaceFocused],
+    [isPaneFocused, isWorkspaceFocused, onFocusPane],
   );
 
   return (

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -13,6 +13,7 @@ import {
   Copy,
   Ellipsis,
   EllipsisVertical,
+  Globe,
   PanelRight,
   RotateCw,
   Settings,
@@ -80,6 +81,7 @@ import { upsertTerminalListEntry } from "@/utils/terminal-list";
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { useArchiveAgent } from "@/hooks/use-archive-agent";
 import { useStableEvent } from "@/hooks/use-stable-event";
+import { createWorkspaceBrowser } from "@/stores/browser-store";
 import { buildProviderCommand } from "@/utils/provider-command-templates";
 import { generateDraftId } from "@/stores/draft-keys";
 import {
@@ -127,7 +129,7 @@ import {
 import { findAdjacentPane } from "@/utils/split-navigation";
 import { isAbsolutePath } from "@/utils/path";
 import { useIsCompactFormFactor, supportsDesktopPaneSplits } from "@/constants/layout";
-import { isWeb, isNative } from "@/constants/platform";
+import { getIsElectron, isNative, isWeb } from "@/constants/platform";
 import { useContainerWidthBelow } from "@/hooks/use-container-width";
 
 const TERMINALS_QUERY_STALE_TIME = 5_000;
@@ -148,6 +150,7 @@ const ThemedCopyX = withUnistyles(CopyX);
 const ThemedX = withUnistyles(X);
 const ThemedSquarePen = withUnistyles(SquarePen);
 const ThemedSquareTerminal = withUnistyles(SquareTerminal);
+const ThemedGlobe = withUnistyles(Globe);
 const ThemedSettings = withUnistyles(Settings);
 const ThemedPanelRight = withUnistyles(PanelRight);
 const ThemedSourceControlPanelIcon = withUnistyles(SourceControlPanelIcon);
@@ -159,6 +162,7 @@ const sourceControlPanelStrokeWidth15 = { strokeWidth: 1.5 };
 
 const MENU_NEW_AGENT_ICON = <ThemedSquarePen size={16} uniProps={mutedColorMapping} />;
 const MENU_NEW_TERMINAL_ICON = <ThemedSquareTerminal size={16} uniProps={mutedColorMapping} />;
+const MENU_NEW_BROWSER_ICON = <ThemedGlobe size={16} uniProps={mutedColorMapping} />;
 const MENU_COPY_ICON = <ThemedCopy size={16} uniProps={mutedColorMapping} />;
 const MENU_SETTINGS_ICON = <ThemedSettings size={16} uniProps={mutedColorMapping} />;
 
@@ -198,6 +202,9 @@ function getFallbackTabOptionLabel(tab: WorkspaceTabDescriptor): string {
   if (tab.target.kind === "terminal") {
     return "Terminal";
   }
+  if (tab.target.kind === "browser") {
+    return "Browser";
+  }
   if (tab.target.kind === "file") {
     return tab.target.path.split("/").findLast(Boolean) ?? tab.target.path;
   }
@@ -216,6 +223,9 @@ function getFallbackTabOptionDescription(tab: WorkspaceTabDescriptor): string {
   }
   if (tab.target.kind === "terminal") {
     return "Terminal";
+  }
+  if (tab.target.kind === "browser") {
+    return "Browser";
   }
   return tab.target.path;
 }
@@ -722,14 +732,17 @@ interface WorkspaceHeaderMenuProps {
   normalizedWorkspaceId: string;
   currentBranchName: string | null;
   showWorkspaceSetup: boolean;
+  showCreateBrowserTab: boolean;
   isMobile: boolean;
   createTerminalDisabled: boolean;
   menuNewAgentIcon: ReactElement;
   menuNewTerminalIcon: ReactElement;
+  menuNewBrowserIcon: ReactElement;
   menuCopyIcon: ReactElement;
   menuSettingsIcon: ReactElement;
   onCreateDraftTab: () => void;
   onCreateTerminal: () => void;
+  onCreateBrowser: () => void;
   onCopyWorkspacePath: () => void;
   onCopyBranchName: () => void;
   onOpenSetupTab: () => void;
@@ -753,14 +766,17 @@ function WorkspaceHeaderMenu({
   normalizedWorkspaceId,
   currentBranchName,
   showWorkspaceSetup,
+  showCreateBrowserTab,
   isMobile,
   createTerminalDisabled,
   menuNewAgentIcon,
   menuNewTerminalIcon,
+  menuNewBrowserIcon,
   menuCopyIcon,
   menuSettingsIcon,
   onCreateDraftTab,
   onCreateTerminal,
+  onCreateBrowser,
   onCopyWorkspacePath,
   onCopyBranchName,
   onOpenSetupTab,
@@ -798,6 +814,15 @@ function WorkspaceHeaderMenu({
         >
           New terminal
         </DropdownMenuItem>
+        {showCreateBrowserTab ? (
+          <DropdownMenuItem
+            testID="workspace-header-new-browser"
+            leading={menuNewBrowserIcon}
+            onSelect={onCreateBrowser}
+          >
+            New browser tab
+          </DropdownMenuItem>
+        ) : null}
         <DropdownMenuItem
           testID="workspace-header-copy-path"
           leading={menuCopyIcon}
@@ -842,14 +867,17 @@ interface WorkspaceHeaderTitleBarProps {
   normalizedServerId: string;
   normalizedWorkspaceId: string;
   showWorkspaceSetup: boolean;
+  showCreateBrowserTab: boolean;
   isMobile: boolean;
   createTerminalDisabled: boolean;
   menuNewAgentIcon: ReactElement;
   menuNewTerminalIcon: ReactElement;
+  menuNewBrowserIcon: ReactElement;
   menuCopyIcon: ReactElement;
   menuSettingsIcon: ReactElement;
   onCreateDraftTab: () => void;
   onCreateTerminal: () => void;
+  onCreateBrowser: () => void;
   onCopyWorkspacePath: () => void;
   onCopyBranchName: () => void;
   onOpenSetupTab: () => void;
@@ -865,14 +893,17 @@ function WorkspaceHeaderTitleBar({
   normalizedServerId,
   normalizedWorkspaceId,
   showWorkspaceSetup,
+  showCreateBrowserTab,
   isMobile,
   createTerminalDisabled,
   menuNewAgentIcon,
   menuNewTerminalIcon,
+  menuNewBrowserIcon,
   menuCopyIcon,
   menuSettingsIcon,
   onCreateDraftTab,
   onCreateTerminal,
+  onCreateBrowser,
   onCopyWorkspacePath,
   onCopyBranchName,
   onOpenSetupTab,
@@ -907,14 +938,17 @@ function WorkspaceHeaderTitleBar({
         normalizedWorkspaceId={normalizedWorkspaceId}
         currentBranchName={currentBranchName}
         showWorkspaceSetup={showWorkspaceSetup}
+        showCreateBrowserTab={showCreateBrowserTab}
         isMobile={isMobile}
         createTerminalDisabled={createTerminalDisabled}
         menuNewAgentIcon={menuNewAgentIcon}
         menuNewTerminalIcon={menuNewTerminalIcon}
+        menuNewBrowserIcon={menuNewBrowserIcon}
         menuCopyIcon={menuCopyIcon}
         menuSettingsIcon={menuSettingsIcon}
         onCreateDraftTab={onCreateDraftTab}
         onCreateTerminal={onCreateTerminal}
+        onCreateBrowser={onCreateBrowser}
         onCopyWorkspacePath={onCopyWorkspacePath}
         onCopyBranchName={onCopyBranchName}
         onOpenSetupTab={onOpenSetupTab}
@@ -1927,6 +1961,20 @@ function WorkspaceScreenContent({
     toast.show("Preparing workspace, opening terminal when ready...");
   });
 
+  const handleCreateBrowserTab = useCallback(
+    (input?: { paneId?: string }) => {
+      if (!persistenceKey || !getIsElectron()) {
+        return;
+      }
+      if (input?.paneId) {
+        focusWorkspacePane(persistenceKey, input.paneId);
+      }
+      const { browserId } = createWorkspaceBrowser();
+      openWorkspaceTabFocused(persistenceKey, { kind: "browser", browserId });
+    },
+    [focusWorkspacePane, openWorkspaceTabFocused, persistenceKey],
+  );
+
   const handleSelectSwitcherTab = useCallback(
     (key: string) => {
       navigateToTabId(key);
@@ -2822,6 +2870,7 @@ function WorkspaceScreenContent({
     () => createTerminalMutation.isPending || pendingTerminalCreateInput !== null,
     [createTerminalMutation.isPending, pendingTerminalCreateInput],
   );
+  const showCreateBrowserTab = getIsElectron();
   const focusedPaneIdOrUndefined = useMemo(() => focusedPaneId ?? undefined, [focusedPaneId]);
   const desktopFocusModeEnabled = useMemo(
     () => isFocusModeEnabled && !isMobile,
@@ -2854,6 +2903,8 @@ function WorkspaceScreenContent({
         onCloseOtherTabs={handleCloseOtherTabsInPane}
         onCreateDraftTab={handleCreateDraftTab}
         onCreateTerminalTab={handleCreateTerminal}
+        onCreateBrowserTab={handleCreateBrowserTab}
+        showCreateBrowserTab={showCreateBrowserTab}
         buildPaneContentModel={buildDesktopPaneContentModel}
         onFocusPane={handleFocusPane}
         onSplitPane={handleSplitPane}
@@ -2886,6 +2937,8 @@ function WorkspaceScreenContent({
     handleCloseOtherTabsInPane,
     handleCreateDraftTab,
     handleCreateTerminal,
+    handleCreateBrowserTab,
+    showCreateBrowserTab,
     buildDesktopPaneContentModel,
     handleFocusPane,
     handleSplitPane,
@@ -2930,14 +2983,17 @@ function WorkspaceScreenContent({
                     normalizedServerId={normalizedServerId}
                     normalizedWorkspaceId={normalizedWorkspaceId}
                     showWorkspaceSetup={showWorkspaceSetup}
+                    showCreateBrowserTab={showCreateBrowserTab}
                     isMobile={isMobile}
                     createTerminalDisabled={createTerminalDisabled}
                     menuNewAgentIcon={menuNewAgentIcon}
                     menuNewTerminalIcon={menuNewTerminalIcon}
+                    menuNewBrowserIcon={MENU_NEW_BROWSER_ICON}
                     menuCopyIcon={menuCopyIcon}
                     menuSettingsIcon={menuSettingsIcon}
                     onCreateDraftTab={handleCreateDraftTab}
                     onCreateTerminal={handleCreateTerminal}
+                    onCreateBrowser={handleCreateBrowserTab}
                     onCopyWorkspacePath={handleCopyWorkspacePath}
                     onCopyBranchName={handleCopyBranchName}
                     onOpenSetupTab={handleOpenSetupTab}
@@ -2987,6 +3043,8 @@ function WorkspaceScreenContent({
               onCloseOtherTabs={handleCloseOtherTabs}
               onCreateDraftTab={handleCreateDraftTab}
               onCreateTerminalTab={handleCreateTerminal}
+              onCreateBrowserTab={handleCreateBrowserTab}
+              showCreateBrowserTab={showCreateBrowserTab}
               disableCreateTerminal={createTerminalMutation.isPending}
               isWaitingOnTerminalReadiness={pendingTerminalCreateInput !== null}
               onReorderTabs={handleReorderTabsInFocusedPane}

--- a/packages/app/src/screens/workspace/workspace-tab-menu.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.ts
@@ -81,6 +81,9 @@ function getCloseButtonTestId(tab: WorkspaceTabDescriptor): string {
   if (tab.target.kind === "draft") {
     return `workspace-draft-close-${tab.target.draftId}`;
   }
+  if (tab.target.kind === "browser") {
+    return `workspace-browser-close-${tab.target.browserId}`;
+  }
   if (tab.target.kind === "setup") {
     return `workspace-setup-close-${encodeFilePathForPathSegment(tab.target.workspaceId)}`;
   }

--- a/packages/app/src/stores/browser-store.test.ts
+++ b/packages/app/src/stores/browser-store.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { normalizeWorkspaceBrowserUrl, useBrowserStore } from "./browser-store";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+describe("browser store", () => {
+  it("normalizes local development hosts to http by default", () => {
+    expect(normalizeWorkspaceBrowserUrl("localhost:8081")).toBe("http://localhost:8081");
+    expect(normalizeWorkspaceBrowserUrl("localhost/path")).toBe("http://localhost/path");
+    expect(normalizeWorkspaceBrowserUrl("127.0.0.1:3000/path")).toBe("http://127.0.0.1:3000/path");
+    expect(normalizeWorkspaceBrowserUrl("192.168.0.8")).toBe("http://192.168.0.8");
+    expect(normalizeWorkspaceBrowserUrl("[::1]:5173")).toBe("http://[::1]:5173");
+  });
+
+  it("normalizes public hosts to https by default", () => {
+    expect(normalizeWorkspaceBrowserUrl("example.com")).toBe("https://example.com");
+    expect(normalizeWorkspaceBrowserUrl("//example.com/path")).toBe("https://example.com/path");
+  });
+
+  it("keeps explicit protocols unchanged", () => {
+    expect(normalizeWorkspaceBrowserUrl("http://localhost:8081")).toBe("http://localhost:8081");
+    expect(normalizeWorkspaceBrowserUrl("https://localhost:8081")).toBe("https://localhost:8081");
+    expect(normalizeWorkspaceBrowserUrl("file:///tmp/example.html")).toBe(
+      "file:///tmp/example.html",
+    );
+  });
+
+  it("normalizes browser URLs when creating and updating records", () => {
+    useBrowserStore.setState({ browsersById: {} });
+
+    const browserId = useBrowserStore.getState().createBrowser({ initialUrl: "localhost:8081" });
+    expect(useBrowserStore.getState().browsersById[browserId]?.url).toBe("http://localhost:8081");
+
+    useBrowserStore.getState().updateBrowser(browserId, { url: "example.com/path" });
+    expect(useBrowserStore.getState().browsersById[browserId]?.url).toBe(
+      "https://example.com/path",
+    );
+  });
+});

--- a/packages/app/src/stores/browser-store.ts
+++ b/packages/app/src/stores/browser-store.ts
@@ -1,0 +1,169 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+export interface BrowserRecord {
+  browserId: string;
+  url: string;
+  title: string;
+  isLoading: boolean;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  faviconUrl: string | null;
+  lastError: string | null;
+  createdAt: number;
+}
+
+type BrowserRecordPatch = Partial<Omit<BrowserRecord, "browserId" | "createdAt">>;
+
+interface BrowserStoreState {
+  browsersById: Record<string, BrowserRecord>;
+  createBrowser: (input?: { initialUrl?: string }) => string;
+  updateBrowser: (browserId: string, patch: BrowserRecordPatch) => void;
+  removeBrowser: (browserId: string) => void;
+}
+
+function trimNonEmpty(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeBrowserUrl(value: string | null | undefined): string {
+  const trimmed = trimNonEmpty(value);
+  if (!trimmed) {
+    return "https://example.com";
+  }
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("//")) {
+    return `https:${trimmed}`;
+  }
+  return `https://${trimmed}`;
+}
+
+function createBrowserId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export const useBrowserStore = create<BrowserStoreState>()(
+  persist(
+    (set) => ({
+      browsersById: {},
+      createBrowser: (input) => {
+        const browserId = createBrowserId();
+        const now = Date.now();
+        const initialUrl = normalizeBrowserUrl(input?.initialUrl);
+
+        set((state) => ({
+          browsersById: {
+            ...state.browsersById,
+            [browserId]: {
+              browserId,
+              url: initialUrl,
+              title: "",
+              isLoading: false,
+              canGoBack: false,
+              canGoForward: false,
+              faviconUrl: null,
+              lastError: null,
+              createdAt: now,
+            },
+          },
+        }));
+
+        return browserId;
+      },
+      updateBrowser: (browserId, patch) => {
+        const normalizedBrowserId = trimNonEmpty(browserId);
+        if (!normalizedBrowserId) {
+          return;
+        }
+
+        set((state) => {
+          const existing = state.browsersById[normalizedBrowserId];
+          if (!existing) {
+            return state;
+          }
+
+          const nextRecord: BrowserRecord = {
+            ...existing,
+            ...patch,
+            url: normalizeBrowserUrl(patch.url ?? existing.url),
+          };
+
+          if (
+            nextRecord.url === existing.url &&
+            nextRecord.title === existing.title &&
+            nextRecord.isLoading === existing.isLoading &&
+            nextRecord.canGoBack === existing.canGoBack &&
+            nextRecord.canGoForward === existing.canGoForward &&
+            nextRecord.faviconUrl === existing.faviconUrl &&
+            nextRecord.lastError === existing.lastError
+          ) {
+            return state;
+          }
+
+          return {
+            browsersById: {
+              ...state.browsersById,
+              [normalizedBrowserId]: nextRecord,
+            },
+          };
+        });
+      },
+      removeBrowser: (browserId) => {
+        const normalizedBrowserId = trimNonEmpty(browserId);
+        if (!normalizedBrowserId) {
+          return;
+        }
+
+        set((state) => {
+          if (!state.browsersById[normalizedBrowserId]) {
+            return state;
+          }
+          const next = { ...state.browsersById };
+          delete next[normalizedBrowserId];
+          return { browsersById: next };
+        });
+      },
+    }),
+    {
+      name: "workspace-browser-store",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        browsersById: state.browsersById,
+      }),
+    },
+  ),
+);
+
+export function getBrowserRecord(browserId: string): BrowserRecord | null {
+  const normalizedBrowserId = trimNonEmpty(browserId);
+  if (!normalizedBrowserId) {
+    return null;
+  }
+  return useBrowserStore.getState().browsersById[normalizedBrowserId] ?? null;
+}
+
+export function createWorkspaceBrowser(input?: { initialUrl?: string }): {
+  browserId: string;
+  url: string;
+} {
+  const browserId = useBrowserStore.getState().createBrowser(input);
+  const record = getBrowserRecord(browserId);
+  return {
+    browserId,
+    url: record?.url ?? normalizeBrowserUrl(input?.initialUrl),
+  };
+}
+
+export function normalizeWorkspaceBrowserUrl(value: string | null | undefined): string {
+  return normalizeBrowserUrl(value);
+}

--- a/packages/app/src/stores/browser-store.ts
+++ b/packages/app/src/stores/browser-store.ts
@@ -36,6 +36,9 @@ function normalizeBrowserUrl(value: string | null | undefined): string {
   if (!trimmed) {
     return "https://example.com";
   }
+  if (/^(localhost|\d{1,3}(?:\.\d{1,3}){3}|\[[\da-fA-F:.]+])(?::\d+)?(?:[/?#]|$)/.test(trimmed)) {
+    return `http://${trimmed}`;
+  }
   if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)) {
     return trimmed;
   }
@@ -138,7 +141,12 @@ export const useBrowserStore = create<BrowserStoreState>()(
       name: "workspace-browser-store",
       storage: createJSONStorage(() => AsyncStorage),
       partialize: (state) => ({
-        browsersById: state.browsersById,
+        browsersById: Object.fromEntries(
+          Object.entries(state.browsersById).map(([browserId, browser]) => [
+            browserId,
+            { ...browser, isLoading: false, lastError: null },
+          ]),
+        ),
       }),
     },
   ),

--- a/packages/app/src/stores/workspace-tabs-store.ts
+++ b/packages/app/src/stores/workspace-tabs-store.ts
@@ -11,6 +11,7 @@ export type WorkspaceTabTarget =
   | { kind: "draft"; draftId: string }
   | { kind: "agent"; agentId: string }
   | { kind: "terminal"; terminalId: string }
+  | { kind: "browser"; browserId: string }
   | { kind: "file"; path: string }
   | { kind: "setup"; workspaceId: string };
 

--- a/packages/app/src/utils/workspace-tab-identity.ts
+++ b/packages/app/src/utils/workspace-tab-identity.ts
@@ -18,6 +18,10 @@ export function normalizeWorkspaceTabTarget(
     const terminalId = trimNonEmpty(value.terminalId);
     return terminalId ? { kind: "terminal", terminalId } : null;
   }
+  if (value.kind === "browser") {
+    const browserId = trimNonEmpty(value.browserId);
+    return browserId ? { kind: "browser", browserId } : null;
+  }
   if (value.kind === "file") {
     const path = trimNonEmpty(value.path);
     return path ? { kind: "file", path: path.replace(/\\/g, "/") } : null;
@@ -45,6 +49,9 @@ export function workspaceTabTargetsEqual(
   if (left.kind === "terminal" && right.kind === "terminal") {
     return left.terminalId === right.terminalId;
   }
+  if (left.kind === "browser" && right.kind === "browser") {
+    return left.browserId === right.browserId;
+  }
   if (left.kind === "file" && right.kind === "file") {
     return left.path === right.path;
   }
@@ -63,6 +70,9 @@ export function buildDeterministicWorkspaceTabId(target: WorkspaceTabTarget): st
   }
   if (target.kind === "terminal") {
     return `terminal_${target.terminalId}`;
+  }
+  if (target.kind === "browser") {
+    return `browser_${target.browserId}`;
   }
   if (target.kind === "setup") {
     return `setup_${target.workspaceId}`;

--- a/packages/desktop/scripts/dev.ps1
+++ b/packages/desktop/scripts/dev.ps1
@@ -33,5 +33,5 @@ Write-Host @"
     --kill-others `
     --names "metro,electron" `
     --prefix-colors "magenta,cyan" `
-    "cd `"$AppDir`" && npx expo start --port $($env:EXPO_PORT)" `
+    "cd `"$AppDir`" && `$env:PASEO_WEB_PLATFORM = `"electron`"; npx expo start --port $($env:EXPO_PORT)" `
     "npx wait-on tcp:$($env:EXPO_PORT) && npx electron `"$DesktopDir`""

--- a/packages/desktop/scripts/dev.sh
+++ b/packages/desktop/scripts/dev.sh
@@ -30,5 +30,5 @@ exec "$ROOT_DIR/node_modules/.bin/concurrently" \
   --kill-others \
   --names "metro,electron" \
   --prefix-colors "magenta,cyan" \
-  "cd '$APP_DIR' && npx expo start --port $EXPO_PORT" \
+  "cd '$APP_DIR' && PASEO_WEB_PLATFORM=electron npx expo start --port $EXPO_PORT" \
   "$ROOT_DIR/node_modules/.bin/wait-on tcp:$EXPO_PORT && EXPO_DEV_URL=http://localhost:$EXPO_PORT electron '$DESKTOP_DIR'"

--- a/packages/desktop/src/features/browser-webviews.ts
+++ b/packages/desktop/src/features/browser-webviews.ts
@@ -1,0 +1,17 @@
+import type { WebContents } from "electron";
+
+const browserIdsByWebContentsId = new Map<number, string>();
+
+export function registerPaseoBrowserWebContents(contents: WebContents, browserId: string): void {
+  browserIdsByWebContentsId.set(contents.id, browserId);
+  contents.once("destroyed", () => {
+    browserIdsByWebContentsId.delete(contents.id);
+  });
+}
+
+export function getPaseoBrowserIdForWebContents(contents: WebContents | null): string | null {
+  if (!contents || contents.isDestroyed()) {
+    return null;
+  }
+  return browserIdsByWebContentsId.get(contents.id) ?? null;
+}

--- a/packages/desktop/src/features/menu.ts
+++ b/packages/desktop/src/features/menu.ts
@@ -1,4 +1,5 @@
-import { app, Menu, BrowserWindow, ipcMain } from "electron";
+import { app, Menu, BrowserWindow, ipcMain, webContents } from "electron";
+import { getPaseoBrowserIdForWebContents } from "./browser-webviews.js";
 
 interface ShowContextMenuInput {
   kind?: "terminal";
@@ -12,6 +13,33 @@ function withBrowserWindow(
     const win = baseWin instanceof BrowserWindow ? baseWin : BrowserWindow.getFocusedWindow();
     if (win) callback(win);
   };
+}
+
+function getFocusedPaseoBrowserWebContents(): Electron.WebContents | null {
+  const focusedContents = webContents.getFocusedWebContents();
+  return getPaseoBrowserIdForWebContents(focusedContents) ? focusedContents : null;
+}
+
+function reloadFocusedContentsOrWindow(win: BrowserWindow, options?: { ignoreCache?: boolean }) {
+  const browserContents = getFocusedPaseoBrowserWebContents();
+  if (browserContents) {
+    if (options?.ignoreCache) {
+      browserContents.reloadIgnoringCache();
+      return;
+    }
+    if (browserContents.isLoadingMainFrame()) {
+      browserContents.stop();
+      return;
+    }
+    browserContents.reload();
+    return;
+  }
+
+  if (options?.ignoreCache) {
+    win.webContents.reloadIgnoringCache();
+    return;
+  }
+  win.webContents.reload();
 }
 
 export function setupApplicationMenu(): void {
@@ -73,8 +101,20 @@ export function setupApplicationMenu(): void {
           }),
         },
         { type: "separator" },
-        { role: "reload" },
-        { role: "forceReload" },
+        {
+          label: "Reload",
+          accelerator: "CmdOrCtrl+R",
+          click: withBrowserWindow((win) => {
+            reloadFocusedContentsOrWindow(win);
+          }),
+        },
+        {
+          label: "Force Reload",
+          accelerator: "CmdOrCtrl+Shift+R",
+          click: withBrowserWindow((win) => {
+            reloadFocusedContentsOrWindow(win, { ignoreCache: true });
+          }),
+        },
         { role: "toggleDevTools" },
         { type: "separator" },
         { role: "togglefullscreen" },

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -71,9 +71,33 @@ function preventUnsafeBrowserWebviewNavigation(
   }
 }
 const OPEN_PROJECT_EVENT = "paseo:event:open-project";
+const BROWSER_SHORTCUT_EVENT = "paseo:event:browser-shortcut";
 const DESKTOP_SMOKE_ENV = "PASEO_DESKTOP_SMOKE";
 const DESKTOP_SMOKE_STOP_REQUEST = "paseo-smoke-stop";
 app.setName("Paseo");
+
+function getBrowserIdFromWebviewPartition(partition: string | undefined): string | null {
+  const prefix = "persist:paseo-browser-";
+  if (!partition?.startsWith(prefix)) {
+    return null;
+  }
+  const browserId = partition.slice(prefix.length).trim();
+  return browserId.length > 0 ? browserId : null;
+}
+
+function isBrowserRefreshInput(input: Electron.Input): boolean {
+  if (input.type !== "keyDown" || input.alt || input.shift) {
+    return false;
+  }
+  return (input.meta || input.control) && input.key.toLowerCase() === "r";
+}
+
+function isBrowserLocationInput(input: Electron.Input): boolean {
+  if (input.type !== "keyDown" || input.alt || input.shift) {
+    return false;
+  }
+  return (input.meta || input.control) && input.key.toLowerCase() === "l";
+}
 
 // In dev mode, detect git worktrees and isolate each instance so multiple
 // Electron windows can run side-by-side (separate userData = separate lock).
@@ -246,6 +270,11 @@ async function createMainWindow(): Promise<void> {
       event.preventDefault();
       return;
     }
+    const browserId = getBrowserIdFromWebviewPartition(params.partition);
+    if (!browserId) {
+      event.preventDefault();
+      return;
+    }
     webPreferences.nodeIntegration = false;
     webPreferences.nodeIntegrationInSubFrames = false;
     webPreferences.nodeIntegrationInWorker = false;
@@ -260,6 +289,23 @@ async function createMainWindow(): Promise<void> {
     delete (params as { preloadURL?: string }).preloadURL;
   });
   mainWindow.webContents.on("did-attach-webview", (_event, contents) => {
+    contents.on("before-input-event", (event, input) => {
+      if (isBrowserRefreshInput(input)) {
+        event.preventDefault();
+        if (contents.isLoadingMainFrame()) {
+          contents.stop();
+        } else {
+          contents.reload();
+        }
+        return;
+      }
+      if (isBrowserLocationInput(input)) {
+        event.preventDefault();
+        mainWindow.webContents.send(BROWSER_SHORTCUT_EVENT, {
+          action: "focus-url",
+        });
+      }
+    });
     contents.setWindowOpenHandler(({ url }) => {
       if (!isAllowedBrowserWebviewUrl(url)) {
         return { action: "deny" };

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -33,6 +33,10 @@ import {
 } from "./features/notifications.js";
 import { registerOpenerHandlers } from "./features/opener.js";
 import { setupApplicationMenu } from "./features/menu.js";
+import {
+  getPaseoBrowserIdForWebContents,
+  registerPaseoBrowserWebContents,
+} from "./features/browser-webviews.js";
 import { parseOpenProjectPathFromArgv } from "./open-project-routing.js";
 import { getDesktopSettingsStore } from "./settings/desktop-settings-electron.js";
 import {
@@ -84,6 +88,8 @@ function getBrowserIdFromWebviewPartition(partition: string | undefined): string
   const browserId = partition.slice(prefix.length).trim();
   return browserId.length > 0 ? browserId : null;
 }
+
+const pendingBrowserWebviewIds: string[] = [];
 
 function isBrowserRefreshInput(input: Electron.Input): boolean {
   if (input.type !== "keyDown" || input.alt || input.shift) {
@@ -275,6 +281,7 @@ async function createMainWindow(): Promise<void> {
       event.preventDefault();
       return;
     }
+    pendingBrowserWebviewIds.push(browserId);
     webPreferences.nodeIntegration = false;
     webPreferences.nodeIntegrationInSubFrames = false;
     webPreferences.nodeIntegrationInWorker = false;
@@ -289,6 +296,10 @@ async function createMainWindow(): Promise<void> {
     delete (params as { preloadURL?: string }).preloadURL;
   });
   mainWindow.webContents.on("did-attach-webview", (_event, contents) => {
+    const browserId = pendingBrowserWebviewIds.shift() ?? null;
+    if (browserId) {
+      registerPaseoBrowserWebContents(contents, browserId);
+    }
     contents.on("before-input-event", (event, input) => {
       if (isBrowserRefreshInput(input)) {
         event.preventDefault();
@@ -301,8 +312,10 @@ async function createMainWindow(): Promise<void> {
       }
       if (isBrowserLocationInput(input)) {
         event.preventDefault();
+        const focusedBrowserId = getPaseoBrowserIdForWebContents(contents);
         mainWindow.webContents.send(BROWSER_SHORTCUT_EVENT, {
           action: "focus-url",
+          ...(focusedBrowserId ? { browserId: focusedBrowserId } : {}),
         });
       }
     });

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -47,6 +47,29 @@ import { autoUpdateSkillsIfInstalled } from "./integrations/integrations-manager
 
 const DEV_SERVER_URL = process.env.EXPO_DEV_URL ?? "http://localhost:8081";
 const APP_SCHEME = "paseo";
+
+function isAllowedBrowserWebviewUrl(value: string | undefined): boolean {
+  if (!value) {
+    return true;
+  }
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.protocol === "http:" || parsed.protocol === "https:" || parsed.href === "about:blank"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function preventUnsafeBrowserWebviewNavigation(
+  event: Electron.Event,
+  url: string | undefined,
+): void {
+  if (!isAllowedBrowserWebviewUrl(url)) {
+    event.preventDefault();
+  }
+}
 const OPEN_PROJECT_EVENT = "paseo:event:open-project";
 const DESKTOP_SMOKE_ENV = "PASEO_DESKTOP_SMOKE";
 const DESKTOP_SMOKE_STOP_REQUEST = "paseo-smoke-stop";
@@ -218,15 +241,40 @@ async function createMainWindow(): Promise<void> {
   setupWindowResizeEvents(mainWindow);
   setupDefaultContextMenu(mainWindow);
   setupDragDropPrevention(mainWindow);
-  mainWindow.webContents.on("will-attach-webview", (_event, webPreferences) => {
+  mainWindow.webContents.on("will-attach-webview", (event, webPreferences, params) => {
+    if (!isAllowedBrowserWebviewUrl(params.src)) {
+      event.preventDefault();
+      return;
+    }
     webPreferences.nodeIntegration = false;
+    webPreferences.nodeIntegrationInSubFrames = false;
+    webPreferences.nodeIntegrationInWorker = false;
     webPreferences.contextIsolation = true;
+    webPreferences.sandbox = true;
+    webPreferences.webSecurity = true;
+    webPreferences.webviewTag = false;
+    webPreferences.allowRunningInsecureContent = false;
     delete webPreferences.preload;
+    delete params.preload;
+    delete (webPreferences as { preloadURL?: string }).preloadURL;
+    delete (params as { preloadURL?: string }).preloadURL;
   });
   mainWindow.webContents.on("did-attach-webview", (_event, contents) => {
     contents.setWindowOpenHandler(({ url }) => {
+      if (!isAllowedBrowserWebviewUrl(url)) {
+        return { action: "deny" };
+      }
       contents.loadURL(url).catch(() => undefined);
       return { action: "deny" };
+    });
+    contents.on("will-navigate", (event) => {
+      preventUnsafeBrowserWebviewNavigation(event, event.url);
+    });
+    contents.on("will-frame-navigate", (event) => {
+      preventUnsafeBrowserWebviewNavigation(event, event.url);
+    });
+    contents.on("will-redirect", (event) => {
+      preventUnsafeBrowserWebviewNavigation(event, event.url);
     });
   });
 

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -206,6 +206,7 @@ async function createMainWindow(): Promise<void> {
       preload: getPreloadPath(),
       contextIsolation: true,
       nodeIntegration: false,
+      webviewTag: true,
     },
   });
 
@@ -217,6 +218,17 @@ async function createMainWindow(): Promise<void> {
   setupWindowResizeEvents(mainWindow);
   setupDefaultContextMenu(mainWindow);
   setupDragDropPrevention(mainWindow);
+  mainWindow.webContents.on("will-attach-webview", (_event, webPreferences) => {
+    webPreferences.nodeIntegration = false;
+    webPreferences.contextIsolation = true;
+    delete webPreferences.preload;
+  });
+  mainWindow.webContents.on("did-attach-webview", (_event, contents) => {
+    contents.setWindowOpenHandler(({ url }) => {
+      contents.loadURL(url).catch(() => undefined);
+      return { action: "deny" };
+    });
+  });
 
   mainWindow.once("ready-to-show", () => {
     mainWindow.show();

--- a/packages/server/src/server/agent/prompt-attachments.test.ts
+++ b/packages/server/src/server/agent/prompt-attachments.test.ts
@@ -85,6 +85,17 @@ describe("prompt attachments", () => {
     ).toContain("GitHub Issue #55: Issue");
   });
 
+  it("renders text attachments as their client-provided prompt text", () => {
+    expect(
+      renderPromptAttachmentAsText({
+        type: "text",
+        mimeType: "text/plain",
+        title: "Browser element",
+        text: "<browser-element>button.primary</browser-element>",
+      }),
+    ).toBe("<browser-element>button.primary</browser-element>");
+  });
+
   it("returns undefined when firstAgentContext is empty", () => {
     expect(buildAgentBranchNameSeed(undefined)).toBeUndefined();
     expect(buildAgentBranchNameSeed({})).toBeUndefined();

--- a/packages/server/src/server/agent/prompt-attachments.ts
+++ b/packages/server/src/server/agent/prompt-attachments.ts
@@ -24,6 +24,9 @@ export function renderPromptAttachmentAsText(attachment: AgentAttachment): strin
       }
       return lines.join("\n");
     }
+    case "text": {
+      return attachment.text;
+    }
     case "review": {
       const lines = [`Paseo review attachment (${attachment.mode})`, `CWD: ${attachment.cwd}`];
       if (attachment.baseRef) {

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -737,6 +737,13 @@ export const GitHubIssueAttachmentSchema = z.object({
   body: z.string().nullable().optional(),
 });
 
+export const TextAttachmentSchema = z.object({
+  type: z.literal("text"),
+  mimeType: z.literal("text/plain"),
+  title: z.string().nullable().optional(),
+  text: z.string(),
+});
+
 export const ReviewAttachmentContextLineSchema = z.object({
   oldLineNumber: z.number().int().positive().nullable(),
   newLineNumber: z.number().int().positive().nullable(),
@@ -768,6 +775,7 @@ export const ReviewAttachmentSchema = z.object({
 export const AgentAttachmentSchema = z.discriminatedUnion("type", [
   GitHubPrAttachmentSchema,
   GitHubIssueAttachmentSchema,
+  TextAttachmentSchema,
   ReviewAttachmentSchema,
 ]);
 


### PR DESCRIPTION
## Summary
- Port the Electron browser pane from PR #198, including webview setup, browser chrome, favicon/title/loading state, and native/plain-web desktop-only fallbacks
- Add workspace browser tabs and an Electron-only "New browser tab" action in the workspace UI
- Route picked elements through workspace attachments as removable client-side `browser_element` pills that serialize to generic `text/plain` prompt attachments on submit
- Add generic text attachment schema support so future client-owned attachments do not need bespoke daemon protocol variants

Thanks @jasonkneen for the original browser pane and element picker work in #198. I ported the browser/picker pieces here while leaving Canvas out of scope and adapting the picker routing to the newer workspace attachment pattern.

## Test plan
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npm run format:check`
- `npx vitest run packages/app/src/components/composer.test.tsx --bail=1`
- `npx vitest run packages/server/src/server/agent/prompt-attachments.test.ts --bail=1`
- `npx vitest run packages/app/src/screens/workspace/workspace-tab-menu.test.ts packages/app/src/attachments/workspace-attachments-store.test.ts --bail=1`
