### PR TITLE
feat(app): readline-style prompt history navigation in composer

### DIFF
--- a/packages/app/src/components/composer.tsx
+++ b/packages/app/src/components/composer.tsx
@@ -65,6 +65,8 @@ import { Shortcut } from "@/components/ui/shortcut";
 import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
 import { Autocomplete } from "@/components/ui/autocomplete";
 import { useAgentAutocomplete } from "@/hooks/use-agent-autocomplete";
+import { usePromptHistory } from "@/hooks/use-prompt-history";
+import { useGlobalPromptHistoryStore } from "@/stores/prompt-history-store";
 import {
   useHostRuntimeAgentDirectoryStatus,
   useHostRuntimeClient,
@@ -919,6 +921,18 @@ export function Composer({
   const autocompleteOnKeyPressRef = useRef(autocomplete.onKeyPress);
   autocompleteOnKeyPressRef.current = autocomplete.onKeyPress;
 
+  const promptHistory = usePromptHistory({
+    value: userInput,
+    cursorIndex,
+    agentId,
+    serverId,
+    onApply: setUserInput,
+  });
+  const promptHistoryOnKeyPressRef = useRef(promptHistory.onKeyPress);
+  promptHistoryOnKeyPressRef.current = promptHistory.onKeyPress;
+  const promptHistoryResetRef = useRef(promptHistory.reset);
+  promptHistoryResetRef.current = promptHistory.reset;
+
   // Clear send error when user edits the input
   useEffect(() => {
     if (sendError && userInput) {
@@ -1086,6 +1100,10 @@ export function Composer({
           console.error("[AgentInput] Failed to send message:", error);
         },
       });
+      if (result === "submitted" || result === "queued") {
+        useGlobalPromptHistoryStore.getState().pushPrompt(outgoingMessage);
+        promptHistoryResetRef.current();
+      }
       completeSubmit({
         result,
         outgoingAttachments,
@@ -1287,7 +1305,8 @@ export function Composer({
   // Handle keyboard navigation for command autocomplete.
   const handleCommandKeyPress = useCallback(
     (event: { key: string; preventDefault: () => void }) => {
-      return autocompleteOnKeyPressRef.current(event);
+      if (autocompleteOnKeyPressRef.current(event)) return true;
+      return promptHistoryOnKeyPressRef.current(event);
     },
     [],
   );

--- a/packages/app/src/hooks/use-prompt-history.test.ts
+++ b/packages/app/src/hooks/use-prompt-history.test.ts
@@ -1,0 +1,352 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn(async () => null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+import { useGlobalPromptHistoryStore } from "@/stores/prompt-history-store";
+import { useSessionStore, type SessionState } from "@/stores/session-store";
+import type { StreamItem } from "@/types/stream";
+import {
+  mergePromptHistorySources,
+  usePromptHistory,
+  type UsePromptHistoryArgs,
+  type UsePromptHistoryResult,
+} from "@/hooks/use-prompt-history";
+
+const SERVER_ID = "server-1";
+const AGENT_ID = "agent-1";
+
+function makeUserMessage(id: string, text: string, ts = Date.now()): StreamItem {
+  return {
+    kind: "user_message",
+    id,
+    text,
+    timestamp: new Date(ts),
+  };
+}
+
+function makeAssistantMessage(id: string, text: string, ts = Date.now()): StreamItem {
+  return {
+    kind: "assistant_message",
+    id,
+    text,
+    timestamp: new Date(ts),
+  } as StreamItem;
+}
+
+function seedSessionUserMessages(messages: StreamItem[]): void {
+  const session = {
+    agentStreamTail: new Map([[AGENT_ID, messages]]),
+    agentStreamHead: new Map<string, StreamItem[]>(),
+  } as Partial<SessionState> as SessionState;
+  useSessionStore.setState({
+    sessions: { [SERVER_ID]: session },
+  } as Partial<ReturnType<typeof useSessionStore.getState>>);
+}
+
+function seedGlobalHistory(entries: string[]): void {
+  useGlobalPromptHistoryStore.setState({ entries });
+}
+
+function resetStores(): void {
+  useGlobalPromptHistoryStore.setState({ entries: [] });
+  useSessionStore.setState({ sessions: {} } as Partial<
+    ReturnType<typeof useSessionStore.getState>
+  >);
+}
+
+interface KeyEventFake {
+  key: string;
+  preventDefault: ReturnType<typeof vi.fn>;
+}
+
+function makeEvent(key: string): KeyEventFake {
+  return { key, preventDefault: vi.fn() };
+}
+
+interface HostState {
+  value: string;
+  cursorIndex: number;
+}
+
+function renderPromptHistory(initial: HostState) {
+  const onApply = vi.fn();
+  const state = { ...initial };
+  const hook = renderHook<
+    UsePromptHistoryResult,
+    Pick<UsePromptHistoryArgs, "value" | "cursorIndex">
+  >(
+    ({ value, cursorIndex }) =>
+      usePromptHistory({
+        value,
+        cursorIndex,
+        agentId: AGENT_ID,
+        serverId: SERVER_ID,
+        onApply,
+      }),
+    { initialProps: state },
+  );
+  return {
+    onApply,
+    result: hook.result,
+    rerender: (next: HostState) => {
+      state.value = next.value;
+      state.cursorIndex = next.cursorIndex;
+      hook.rerender({ ...state });
+    },
+  };
+}
+
+describe("mergePromptHistorySources", () => {
+  it("returns global entries when no local messages", () => {
+    expect(
+      mergePromptHistorySources({
+        localTail: [],
+        localHead: [],
+        globalEntries: ["older", "newer"],
+      }),
+    ).toEqual(["older", "newer"]);
+  });
+
+  it("appends local user messages after deduped global entries", () => {
+    expect(
+      mergePromptHistorySources({
+        localTail: [makeUserMessage("u1", "hello")],
+        localHead: [makeUserMessage("u2", "world")],
+        globalEntries: ["older", "hello"],
+      }),
+    ).toEqual(["older", "hello", "world"]);
+  });
+
+  it("ignores assistant messages and empty user messages", () => {
+    expect(
+      mergePromptHistorySources({
+        localTail: [
+          makeUserMessage("u1", "  "),
+          makeAssistantMessage("a1", "should be skipped"),
+          makeUserMessage("u2", "real prompt"),
+        ],
+        localHead: [],
+        globalEntries: [],
+      }),
+    ).toEqual(["real prompt"]);
+  });
+
+  it("dedupes within local list (oldest first wins)", () => {
+    expect(
+      mergePromptHistorySources({
+        localTail: [makeUserMessage("u1", "dup"), makeUserMessage("u2", "dup")],
+        localHead: [],
+        globalEntries: [],
+      }),
+    ).toEqual(["dup"]);
+  });
+});
+
+describe("usePromptHistory", () => {
+  beforeEach(resetStores);
+
+  it("returns false on ArrowUp when no history is available", () => {
+    const { result } = renderPromptHistory({ value: "", cursorIndex: 0 });
+    const event = makeEvent("ArrowUp");
+    let consumed = false;
+    act(() => {
+      consumed = result.current.onKeyPress(event);
+    });
+    expect(consumed).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("returns false on non-arrow keys", () => {
+    seedGlobalHistory(["one", "two"]);
+    const { result } = renderPromptHistory({ value: "", cursorIndex: 0 });
+    const event = makeEvent("Enter");
+    let consumed = false;
+    act(() => {
+      consumed = result.current.onKeyPress(event);
+    });
+    expect(consumed).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ArrowUp on empty input recalls the latest entry", () => {
+    seedGlobalHistory(["older", "newest"]);
+    const { result, onApply } = renderPromptHistory({ value: "", cursorIndex: 0 });
+    const event = makeEvent("ArrowUp");
+    let consumed = false;
+    act(() => {
+      consumed = result.current.onKeyPress(event);
+    });
+    expect(consumed).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(onApply).toHaveBeenCalledWith("newest");
+  });
+
+  it("ArrowUp when cursor is not on first line is a no-op", () => {
+    seedGlobalHistory(["older", "newest"]);
+    const { result, onApply } = renderPromptHistory({
+      value: "line1\nline2",
+      cursorIndex: 8, // somewhere in line2
+    });
+    const event = makeEvent("ArrowUp");
+    let consumed = false;
+    act(() => {
+      consumed = result.current.onKeyPress(event);
+    });
+    expect(consumed).toBe(false);
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
+  it("repeated ArrowUp walks further back, stops at oldest", () => {
+    seedGlobalHistory(["a", "b", "c"]);
+    const { result, onApply, rerender } = renderPromptHistory({ value: "", cursorIndex: 0 });
+
+    act(() => {
+      result.current.onKeyPress(makeEvent("ArrowUp"));
+    });
+    expect(onApply).toHaveBeenLastCalledWith("c");
+    rerender({ value: "c", cursorIndex: 1 });
+
+    act(() => {
+      result.current.onKeyPress(makeEvent("ArrowUp"));
+    });
+    expect(onApply).toHaveBeenLastCalledWith("b");
+    rerender({ value: "b", cursorIndex: 1 });
+
+    act(() => {
+      result.current.onKeyPress(makeEvent("ArrowUp"));
+    });
+    expect(onApply).toHaveBeenLastCalledWith("a");
+    rerender({ value: "a", cursorIndex: 1 });
+
+    // One more ArrowUp at oldest: still consumed (so cursor doesn't jump)
+    // but onApply should NOT fire again.
+    onApply.mockClear();
+    const event = makeEvent("ArrowUp");
+    let consumed = false;
+    act(() => {
+      consumed = result.current.onKeyPress(event);
+    });
+    expect(consumed).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
+  it("ArrowDown after ArrowUp walks toward newest, then restores draft", () => {
+    seedGlobalHistory(["a", "b", "c"]);
+    const { result, onApply, rerender } = renderPromptHistory({ value: "draft", cursorIndex: 5 });
+
+    // Up x 2
+    act(() => result.current.onKeyPress(makeEvent("ArrowUp")));
+    rerender({ value: "c", cursorIndex: 1 });
+    act(() => result.current.onKeyPress(makeEvent("ArrowUp")));
+    rerender({ value: "b", cursorIndex: 1 });
+    expect(onApply).toHaveBeenLastCalledWith("b");
+
+    // Down: back to "c"
+    act(() => result.current.onKeyPress(makeEvent("ArrowDown")));
+    expect(onApply).toHaveBeenLastCalledWith("c");
+    rerender({ value: "c", cursorIndex: 1 });
+
+    // Down again: restore the original draft and exit navigation.
+    act(() => result.current.onKeyPress(makeEvent("ArrowDown")));
+    expect(onApply).toHaveBeenLastCalledWith("draft");
+  });
+
+  it("ArrowDown when not navigating returns false (default cursor behavior)", () => {
+    seedGlobalHistory(["a"]);
+    const { result, onApply } = renderPromptHistory({ value: "", cursorIndex: 0 });
+    const event = makeEvent("ArrowDown");
+    let consumed = false;
+    act(() => {
+      consumed = result.current.onKeyPress(event);
+    });
+    expect(consumed).toBe(false);
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
+  it("user typing during navigation drops the saved draft (drift unhook)", () => {
+    seedGlobalHistory(["older", "newest"]);
+    const { result, onApply, rerender } = renderPromptHistory({ value: "draft", cursorIndex: 5 });
+
+    act(() => result.current.onKeyPress(makeEvent("ArrowUp")));
+    expect(onApply).toHaveBeenLastCalledWith("newest");
+
+    // Simulate user editing the recalled value.
+    rerender({ value: "newest!", cursorIndex: 7 });
+
+    // ArrowDown should now be a no-op (no navigation state to walk back from).
+    onApply.mockClear();
+    const downEvent = makeEvent("ArrowDown");
+    let consumed = false;
+    act(() => {
+      consumed = result.current.onKeyPress(downEvent);
+    });
+    expect(consumed).toBe(false);
+    expect(onApply).not.toHaveBeenCalled();
+
+    // Next ArrowUp starts a fresh navigation, capturing the edited value as draft.
+    act(() => result.current.onKeyPress(makeEvent("ArrowUp")));
+    expect(onApply).toHaveBeenLastCalledWith("newest");
+    rerender({ value: "newest", cursorIndex: 6 });
+
+    // ArrowDown now restores the user's edited draft, not the original "draft".
+    act(() => result.current.onKeyPress(makeEvent("ArrowDown")));
+    expect(onApply).toHaveBeenLastCalledWith("newest!");
+  });
+
+  it("local agent messages take priority and are not duplicated by global history", () => {
+    seedSessionUserMessages([
+      makeUserMessage("u1", "local-1", 1),
+      makeUserMessage("u2", "shared", 2),
+    ]);
+    seedGlobalHistory(["older-global", "shared", "stale-global"]);
+
+    const { result, onApply, rerender } = renderPromptHistory({ value: "", cursorIndex: 0 });
+
+    // Walking up should: shared, stale-global ... no wait, we de-dupe. Final
+    // merged list (oldest-first) = [older-global, stale-global, local-1, shared].
+    // First ArrowUp gives the newest = "shared".
+    act(() => result.current.onKeyPress(makeEvent("ArrowUp")));
+    expect(onApply).toHaveBeenLastCalledWith("shared");
+    rerender({ value: "shared", cursorIndex: 6 });
+
+    act(() => result.current.onKeyPress(makeEvent("ArrowUp")));
+    expect(onApply).toHaveBeenLastCalledWith("local-1");
+    rerender({ value: "local-1", cursorIndex: 7 });
+
+    act(() => result.current.onKeyPress(makeEvent("ArrowUp")));
+    expect(onApply).toHaveBeenLastCalledWith("stale-global");
+    rerender({ value: "stale-global", cursorIndex: 12 });
+
+    act(() => result.current.onKeyPress(makeEvent("ArrowUp")));
+    expect(onApply).toHaveBeenLastCalledWith("older-global");
+  });
+
+  it("reset() drops navigation state so next ArrowUp starts fresh", () => {
+    seedGlobalHistory(["a", "b"]);
+    const { result, onApply, rerender } = renderPromptHistory({ value: "draft", cursorIndex: 5 });
+
+    act(() => result.current.onKeyPress(makeEvent("ArrowUp")));
+    expect(onApply).toHaveBeenLastCalledWith("b");
+
+    act(() => {
+      result.current.reset();
+    });
+    rerender({ value: "", cursorIndex: 0 });
+
+    onApply.mockClear();
+    act(() => result.current.onKeyPress(makeEvent("ArrowUp")));
+    // Fresh navigation: should call with newest again.
+    expect(onApply).toHaveBeenLastCalledWith("b");
+  });
+});

--- a/packages/app/src/hooks/use-prompt-history.ts
+++ b/packages/app/src/hooks/use-prompt-history.ts
@@ -1,0 +1,209 @@
+import { useCallback, useMemo, useRef } from "react";
+import { useGlobalPromptHistoryStore } from "@/stores/prompt-history-store";
+import { useSessionStore } from "@/stores/session-store";
+import type { StreamItem } from "@/types/stream";
+import { isCursorOnFirstLine, isCursorOnLastLine } from "@/utils/cursor-line-position";
+
+const EMPTY_STREAM: readonly StreamItem[] = [];
+
+export interface UsePromptHistoryArgs {
+  /** Current value of the input. */
+  value: string;
+  /** Cursor position (collapsed selection). When start !== end, callers should
+   * pass `selection.start` — selection mode is not treated as a recall trigger. */
+  cursorIndex: number;
+  /** Active agent — drives per-agent history priority. */
+  agentId: string;
+  /** Active server — drives per-agent history priority. */
+  serverId: string;
+  /** Called when the hook wants to replace the input with a different value. */
+  onApply: (text: string) => void;
+}
+
+export interface UsePromptHistoryResult {
+  /**
+   * Key handler that follows the autocomplete contract: returns `true` when
+   * the event was consumed (caller should NOT run default behavior), `false`
+   * when the caller should let default behavior happen (e.g. cursor move).
+   */
+  onKeyPress: (event: { key: string; preventDefault: () => void }) => boolean;
+  /** Clears any in-progress history navigation. Call after submit / on blur. */
+  reset: () => void;
+}
+
+interface NavigationState {
+  /** 0 = newest history entry, 1 = second newest, etc. */
+  index: number;
+  /** What the input held when the user first pressed ArrowUp. Restored when
+   * ArrowDown walks back past index 0. */
+  draft: string;
+  /** Snapshot of the merged entry list at navigation start. Frozen for the
+   * duration of navigation so new incoming messages don't shift the index. */
+  snapshot: string[];
+  /** What we last set the input to. Used to detect that the user has typed
+   * (drift), at which point we drop the draft and exit navigation. */
+  appliedValue: string;
+}
+
+interface PromptHistoryRefState {
+  entries: string[];
+  value: string;
+  cursorIndex: number;
+  onApply: (text: string) => void;
+}
+
+function collectUserPrompts(items: readonly StreamItem[], out: string[], seen: Set<string>): void {
+  for (const item of items) {
+    if (item.kind !== "user_message") continue;
+    const trimmed = item.text.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+}
+
+/**
+ * Returns the merged history list, oldest-first. Entries from the current
+ * agent's session take priority (they appear at their natural recency); the
+ * global cross-agent history fills in everything else, deduplicated.
+ *
+ * Internal export for unit tests.
+ */
+export function mergePromptHistorySources(input: {
+  localTail: readonly StreamItem[];
+  localHead: readonly StreamItem[];
+  globalEntries: readonly string[];
+}): string[] {
+  const seen = new Set<string>();
+  const localPrompts: string[] = [];
+  // Tail came first chronologically, then Head. See session-context.tsx where
+  // late chunks are appended to head while finished turns sit in tail.
+  collectUserPrompts(input.localTail, localPrompts, seen);
+  collectUserPrompts(input.localHead, localPrompts, seen);
+
+  const supplemental: string[] = [];
+  for (const entry of input.globalEntries) {
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    supplemental.push(entry);
+  }
+
+  // Result ordering: oldest-first. Global supplemental comes first because
+  // those are presumed to be from earlier (other) sessions; the local list is
+  // the most recent stuff the user has been doing in this agent.
+  return [...supplemental, ...localPrompts];
+}
+
+export function usePromptHistory(args: UsePromptHistoryArgs): UsePromptHistoryResult {
+  const { value, cursorIndex, agentId, serverId, onApply } = args;
+
+  const localTail = useSessionStore(
+    (state) => state.sessions[serverId]?.agentStreamTail.get(agentId) ?? EMPTY_STREAM,
+  );
+  const localHead = useSessionStore(
+    (state) => state.sessions[serverId]?.agentStreamHead.get(agentId) ?? EMPTY_STREAM,
+  );
+  const globalEntries = useGlobalPromptHistoryStore((state) => state.entries);
+
+  const entries = useMemo(
+    () => mergePromptHistorySources({ localTail, localHead, globalEntries }),
+    [localTail, localHead, globalEntries],
+  );
+
+  // Render-time ref sync (same pattern composer.tsx already uses for autocomplete).
+  // Lets us return a stable onKeyPress whose deps don't churn on every keystroke.
+  const stateRef = useRef<PromptHistoryRefState>({ entries, value, cursorIndex, onApply });
+  stateRef.current = { entries, value, cursorIndex, onApply };
+
+  const navigationRef = useRef<NavigationState | null>(null);
+
+  const reset = useCallback(() => {
+    navigationRef.current = null;
+  }, []);
+
+  const onKeyPress = useCallback((event: { key: string; preventDefault: () => void }): boolean => {
+    const {
+      entries: live,
+      value: liveValue,
+      cursorIndex: liveCursor,
+      onApply: liveApply,
+    } = stateRef.current;
+
+    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return false;
+
+    // Drift detection: the user typed since we last set the value, so they
+    // intentionally left the navigation. Drop the saved draft.
+    if (navigationRef.current && navigationRef.current.appliedValue !== liveValue) {
+      navigationRef.current = null;
+    }
+
+    if (event.key === "ArrowUp") {
+      if (!isCursorOnFirstLine(liveValue, liveCursor)) return false;
+
+      if (!navigationRef.current) {
+        // Fresh navigation: snapshot live history, save current draft, fill latest.
+        if (live.length === 0) return false;
+        const latest = live[live.length - 1];
+        if (latest === undefined) return false;
+        navigationRef.current = {
+          index: 0,
+          draft: liveValue,
+          snapshot: live.slice(),
+          appliedValue: latest,
+        };
+        event.preventDefault();
+        liveApply(latest);
+        return true;
+      }
+
+      // Already navigating: walk one step further into the past.
+      const { snapshot, index } = navigationRef.current;
+      const oldestIndex = snapshot.length - 1;
+      if (index >= oldestIndex) {
+        // Already at the oldest entry. Swallow so cursor doesn't jump.
+        event.preventDefault();
+        return true;
+      }
+      const nextIndex = index + 1;
+      const text = snapshot[snapshot.length - 1 - nextIndex];
+      if (text === undefined) return false;
+      navigationRef.current = {
+        ...navigationRef.current,
+        index: nextIndex,
+        appliedValue: text,
+      };
+      event.preventDefault();
+      liveApply(text);
+      return true;
+    }
+
+    // ArrowDown: only meaningful while navigating.
+    if (!navigationRef.current) return false;
+    if (!isCursorOnLastLine(liveValue, liveCursor)) return false;
+
+    const { snapshot, index, draft } = navigationRef.current;
+
+    if (index === 0) {
+      // Walk back to the live draft, exit navigation.
+      navigationRef.current = null;
+      event.preventDefault();
+      liveApply(draft);
+      return true;
+    }
+
+    const nextIndex = index - 1;
+    const text = snapshot[snapshot.length - 1 - nextIndex];
+    if (text === undefined) return false;
+    navigationRef.current = {
+      ...navigationRef.current,
+      index: nextIndex,
+      appliedValue: text,
+    };
+    event.preventDefault();
+    liveApply(text);
+    return true;
+  }, []);
+
+  return { onKeyPress, reset };
+}

--- a/packages/app/src/stores/prompt-history-store.test.ts
+++ b/packages/app/src/stores/prompt-history-store.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn(async () => null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+import {
+  PROMPT_HISTORY_MAX_ENTRIES,
+  useGlobalPromptHistoryStore,
+} from "@/stores/prompt-history-store";
+
+function reset(): void {
+  useGlobalPromptHistoryStore.setState({ entries: [] });
+}
+
+describe("prompt-history-store", () => {
+  beforeEach(reset);
+
+  it("starts empty", () => {
+    expect(useGlobalPromptHistoryStore.getState().entries).toEqual([]);
+  });
+
+  it("pushes prompts oldest-first", () => {
+    const { pushPrompt } = useGlobalPromptHistoryStore.getState();
+    pushPrompt("first");
+    pushPrompt("second");
+    pushPrompt("third");
+    expect(useGlobalPromptHistoryStore.getState().entries).toEqual(["first", "second", "third"]);
+  });
+
+  it("trims whitespace from incoming prompts", () => {
+    useGlobalPromptHistoryStore.getState().pushPrompt("  hello world  \n");
+    expect(useGlobalPromptHistoryStore.getState().entries).toEqual(["hello world"]);
+  });
+
+  it("ignores empty and whitespace-only prompts", () => {
+    const { pushPrompt } = useGlobalPromptHistoryStore.getState();
+    pushPrompt("");
+    pushPrompt("   ");
+    pushPrompt("\n\t");
+    expect(useGlobalPromptHistoryStore.getState().entries).toEqual([]);
+  });
+
+  it("deduplicates by moving the prior occurrence to the end", () => {
+    const { pushPrompt } = useGlobalPromptHistoryStore.getState();
+    pushPrompt("a");
+    pushPrompt("b");
+    pushPrompt("c");
+    pushPrompt("a");
+    expect(useGlobalPromptHistoryStore.getState().entries).toEqual(["b", "c", "a"]);
+  });
+
+  it("treats a repeat of the most recent entry as a no-op (still moved to end)", () => {
+    const { pushPrompt } = useGlobalPromptHistoryStore.getState();
+    pushPrompt("hello");
+    pushPrompt("hello");
+    expect(useGlobalPromptHistoryStore.getState().entries).toEqual(["hello"]);
+  });
+
+  it("caps the list at PROMPT_HISTORY_MAX_ENTRIES, dropping the oldest", () => {
+    const { pushPrompt } = useGlobalPromptHistoryStore.getState();
+    for (let i = 0; i < PROMPT_HISTORY_MAX_ENTRIES + 5; i += 1) {
+      pushPrompt(`prompt-${i}`);
+    }
+    const entries = useGlobalPromptHistoryStore.getState().entries;
+    expect(entries).toHaveLength(PROMPT_HISTORY_MAX_ENTRIES);
+    // Oldest 5 should have been dropped; newest is "prompt-204".
+    expect(entries[0]).toBe("prompt-5");
+    expect(entries.at(-1)).toBe(`prompt-${PROMPT_HISTORY_MAX_ENTRIES + 4}`);
+  });
+
+  it("clear() empties the store", () => {
+    const { pushPrompt, clear } = useGlobalPromptHistoryStore.getState();
+    pushPrompt("a");
+    pushPrompt("b");
+    clear();
+    expect(useGlobalPromptHistoryStore.getState().entries).toEqual([]);
+  });
+
+  it("partialize only keeps the entries array", () => {
+    useGlobalPromptHistoryStore.setState({ entries: ["x", "y"] });
+    const partialize = useGlobalPromptHistoryStore.persist.getOptions().partialize;
+    expect(partialize?.(useGlobalPromptHistoryStore.getState())).toEqual({ entries: ["x", "y"] });
+  });
+
+  it("merge sanitizes persisted state on rehydrate", () => {
+    const merge = useGlobalPromptHistoryStore.persist.getOptions().merge;
+    const merged = merge?.(
+      // includes empty, dup, non-string entries
+      { entries: ["a", "  b  ", "", "a", 42, "c"] } as unknown,
+      useGlobalPromptHistoryStore.getState(),
+    );
+    expect(merged?.entries).toEqual(["a", "b", "c"]);
+  });
+
+  it("merge returns empty entries when persisted state is missing or invalid", () => {
+    const merge = useGlobalPromptHistoryStore.persist.getOptions().merge;
+    expect(merge?.(undefined, useGlobalPromptHistoryStore.getState())?.entries).toEqual([]);
+    expect(
+      merge?.({ entries: "not-an-array" } as unknown, useGlobalPromptHistoryStore.getState())
+        ?.entries,
+    ).toEqual([]);
+  });
+});

--- a/packages/app/src/stores/prompt-history-store.ts
+++ b/packages/app/src/stores/prompt-history-store.ts
@@ -1,0 +1,71 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+const MAX_PROMPT_HISTORY_ENTRIES = 200;
+
+interface PromptHistoryState {
+  /** Stored oldest-first; the most recently submitted prompt is the last element. */
+  entries: string[];
+  /**
+   * Adds a prompt to the history. Trims whitespace, drops empty/whitespace-only
+   * input, deduplicates by removing any prior occurrence so the latest position
+   * wins, and caps the list at {@link MAX_PROMPT_HISTORY_ENTRIES}.
+   */
+  pushPrompt: (text: string) => void;
+  clear: () => void;
+}
+
+interface PersistedPromptHistoryState {
+  entries?: unknown;
+}
+
+function sanitizeEntries(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const trimmed = item.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  if (result.length > MAX_PROMPT_HISTORY_ENTRIES) {
+    return result.slice(result.length - MAX_PROMPT_HISTORY_ENTRIES);
+  }
+  return result;
+}
+
+export const useGlobalPromptHistoryStore = create<PromptHistoryState>()(
+  persist(
+    (set) => ({
+      entries: [],
+      pushPrompt: (text) => {
+        const trimmed = text.trim();
+        if (!trimmed) return;
+        set((state) => {
+          const filtered = state.entries.filter((entry) => entry !== trimmed);
+          filtered.push(trimmed);
+          const overflow = filtered.length - MAX_PROMPT_HISTORY_ENTRIES;
+          const next = overflow > 0 ? filtered.slice(overflow) : filtered;
+          return { entries: next };
+        });
+      },
+      clear: () => set({ entries: [] }),
+    }),
+    {
+      name: "paseo-prompt-history",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({ entries: state.entries }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as PersistedPromptHistoryState | undefined;
+        const sanitized = sanitizeEntries(persisted?.entries);
+        return { ...currentState, entries: sanitized };
+      },
+    },
+  ),
+);
+
+export const PROMPT_HISTORY_MAX_ENTRIES = MAX_PROMPT_HISTORY_ENTRIES;

--- a/packages/app/src/utils/cursor-line-position.test.ts
+++ b/packages/app/src/utils/cursor-line-position.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { isCursorOnFirstLine, isCursorOnLastLine } from "./cursor-line-position";
+
+describe("isCursorOnFirstLine", () => {
+  it("returns true for empty string at position 0", () => {
+    expect(isCursorOnFirstLine("", 0)).toBe(true);
+  });
+
+  it("returns true for single-line string at any position", () => {
+    expect(isCursorOnFirstLine("hello", 0)).toBe(true);
+    expect(isCursorOnFirstLine("hello", 3)).toBe(true);
+    expect(isCursorOnFirstLine("hello", 5)).toBe(true);
+  });
+
+  it("returns true when cursor is before the first newline", () => {
+    expect(isCursorOnFirstLine("foo\nbar", 0)).toBe(true);
+    expect(isCursorOnFirstLine("foo\nbar", 3)).toBe(true);
+  });
+
+  it("returns false when cursor is on or after the first newline", () => {
+    // Position 4 is right after "\n", which is on the second line.
+    expect(isCursorOnFirstLine("foo\nbar", 4)).toBe(false);
+    expect(isCursorOnFirstLine("foo\nbar", 7)).toBe(false);
+  });
+
+  it("returns false when text begins with a newline and cursor is past it", () => {
+    expect(isCursorOnFirstLine("\nabc", 1)).toBe(false);
+  });
+
+  it("returns true when text begins with a newline and cursor is at position 0", () => {
+    expect(isCursorOnFirstLine("\nabc", 0)).toBe(true);
+  });
+
+  it("CRLF: \\r counts as part of the first line, the \\n is the boundary", () => {
+    // "foo\r\nbar" — first line is "foo\r" (positions 0..4), \n at index 4.
+    expect(isCursorOnFirstLine("foo\r\nbar", 0)).toBe(true);
+    expect(isCursorOnFirstLine("foo\r\nbar", 4)).toBe(true);
+    expect(isCursorOnFirstLine("foo\r\nbar", 5)).toBe(false);
+  });
+});
+
+describe("isCursorOnLastLine", () => {
+  it("returns true for empty string at position 0", () => {
+    expect(isCursorOnLastLine("", 0)).toBe(true);
+  });
+
+  it("returns true for single-line string at any position", () => {
+    expect(isCursorOnLastLine("hello", 0)).toBe(true);
+    expect(isCursorOnLastLine("hello", 3)).toBe(true);
+    expect(isCursorOnLastLine("hello", 5)).toBe(true);
+  });
+
+  it("returns true when cursor is after the last newline", () => {
+    expect(isCursorOnLastLine("foo\nbar", 4)).toBe(true);
+    expect(isCursorOnLastLine("foo\nbar", 7)).toBe(true);
+  });
+
+  it("returns false when cursor is before the last newline", () => {
+    expect(isCursorOnLastLine("foo\nbar", 0)).toBe(false);
+    expect(isCursorOnLastLine("foo\nbar", 3)).toBe(false);
+  });
+
+  it("returns true at end-of-string even when string ends with newline", () => {
+    // Empty trailing line is still "last line".
+    expect(isCursorOnLastLine("foo\n", 4)).toBe(true);
+  });
+
+  it("returns false on a middle line of a 3-line string", () => {
+    // "a\nb\nc" — middle line "b" is at index 2.
+    expect(isCursorOnLastLine("a\nb\nc", 2)).toBe(false);
+    expect(isCursorOnLastLine("a\nb\nc", 3)).toBe(false);
+    expect(isCursorOnLastLine("a\nb\nc", 4)).toBe(true);
+  });
+
+  it("CRLF: \\n is the boundary, so \\r right before \\n is not on last line", () => {
+    // "foo\r\nbar" — last line starts at index 5.
+    expect(isCursorOnLastLine("foo\r\nbar", 4)).toBe(false);
+    expect(isCursorOnLastLine("foo\r\nbar", 5)).toBe(true);
+    expect(isCursorOnLastLine("foo\r\nbar", 8)).toBe(true);
+  });
+
+  it("consecutive newlines: each empty line is its own line", () => {
+    // "a\n\nb" — three lines: "a", "", "b". Index 2 is on the empty middle line.
+    expect(isCursorOnLastLine("a\n\nb", 2)).toBe(false);
+    expect(isCursorOnLastLine("a\n\nb", 3)).toBe(true);
+  });
+});

--- a/packages/app/src/utils/cursor-line-position.ts
+++ b/packages/app/src/utils/cursor-line-position.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns true when the cursor sits on the first visual line of `value`.
+ * The first line is the substring before the first `\n`. Position 0 in an
+ * empty string also counts as "first line".
+ */
+export function isCursorOnFirstLine(value: string, cursorIndex: number): boolean {
+  if (cursorIndex <= 0) return true;
+  return value.lastIndexOf("\n", cursorIndex - 1) === -1;
+}
+
+/**
+ * Returns true when the cursor sits on the last visual line of `value`.
+ * The last line is the substring after the final `\n`. End-of-string also
+ * counts as "last line".
+ */
+export function isCursorOnLastLine(value: string, cursorIndex: number): boolean {
+  if (cursorIndex >= value.length) return true;
+  return value.indexOf("\n", cursorIndex) === -1;
+}


### PR DESCRIPTION
## Summary

Adds ArrowUp/ArrowDown prompt history recall to the composer. Empty input + ArrowUp recalls the most recently sent prompt; further ArrowUp walks further into the past; ArrowDown walks back to the original draft.

Pure client-side change. No server, schema, WebSocket, or persisted-format changes.



## notes

- This is a desktop / web feature. Native iOS / Android have no physical keyboard, so the hook is a no-op there
- Tested on macOS in the browser via `npm run dev` against `~/.paseo-yellow-swan`.

## Screenshots
<img width="1144" height="720" alt="ezgif-7476cd0e05393b1f" src="https://github.com/user-attachments/assets/db3a107c-7c3e-4d1b-9aa3-b503a3e619f2" />



## Test plan

- [x] `npm run typecheck` (all workspaces)
- [x] `npm run lint -- <8 touched files>` (0 warnings, 0 errors)
- [x] `npm run format:check`
- [x] `npx vitest run packages/app/src/utils/cursor-line-position.test.ts --bail=1` (15 tests)
- [x] `npx vitest run packages/app/src/stores/prompt-history-store.test.ts --bail=1` (11 tests)
- [x] `npx vitest run packages/app/src/hooks/use-prompt-history.test.ts --bail=1` (14 tests)
- [x] `npx vitest run packages/app/src/components/composer.test.tsx --bail=1` (33 tests, 31 pre-existing + 2 new)
- [x] Manual on macOS desktop browser: empty/ArrowUp recalls; multi-line editing keeps cursor movement; autocomplete popover takes priority; ArrowDown walks back to draft; cross-agent global recall works; localStorage persistence survives tab reload
- [ ] CI green

## Notes

- No prior issue — happy to close and discuss first if preferred.