### PR TITLE
refactor(relay): remove unnecessary awaits from synchronous crypto functions

### DIFF
--- a/packages/relay/src/crypto.test.ts
+++ b/packages/relay/src/crypto.test.ts
@@ -10,113 +10,107 @@ import {
 
 describe("crypto", () => {
   describe("generateKeyPair", () => {
-    it("generates a valid keypair", async () => {
-      const keypair = await generateKeyPair();
+    it("generates a valid keypair", () => {
+      const keypair = generateKeyPair();
       expect(keypair.secretKey).toBeDefined();
       expect(keypair.publicKey).toBeDefined();
     });
   });
 
   describe("exportPublicKey / importPublicKey", () => {
-    it("roundtrips public key through base64", async () => {
-      const keypair = await generateKeyPair();
-      const exported = await exportPublicKey(keypair.publicKey);
+    it("roundtrips public key through base64", () => {
+      const keypair = generateKeyPair();
+      const exported = exportPublicKey(keypair.publicKey);
 
       expect(typeof exported).toBe("string");
       expect(exported.length).toBeGreaterThan(0);
 
-      const imported = await importPublicKey(exported);
+      const imported = importPublicKey(exported);
       expect(imported).toBeDefined();
 
       // Re-export should match
-      const reExported = await exportPublicKey(imported);
+      const reExported = exportPublicKey(imported);
       expect(reExported).toBe(exported);
     });
   });
 
   describe("deriveSharedKey", () => {
-    it("derives the same key on both sides", async () => {
+    it("derives the same key on both sides", () => {
       // Simulate daemon and client
-      const daemonKeyPair = await generateKeyPair();
-      const clientKeyPair = await generateKeyPair();
+      const daemonKeyPair = generateKeyPair();
+      const clientKeyPair = generateKeyPair();
 
       // Export public keys (what would go over the wire)
-      const daemonPubKeyB64 = await exportPublicKey(daemonKeyPair.publicKey);
-      const clientPubKeyB64 = await exportPublicKey(clientKeyPair.publicKey);
+      const daemonPubKeyB64 = exportPublicKey(daemonKeyPair.publicKey);
+      const clientPubKeyB64 = exportPublicKey(clientKeyPair.publicKey);
 
       // Import peer's public key
-      const daemonSeesClientPubKey = await importPublicKey(clientPubKeyB64);
-      const clientSeesDaemonPubKey = await importPublicKey(daemonPubKeyB64);
+      const daemonSeesClientPubKey = importPublicKey(clientPubKeyB64);
+      const clientSeesDaemonPubKey = importPublicKey(daemonPubKeyB64);
 
       // Derive shared keys
-      const daemonSharedKey = await deriveSharedKey(
-        daemonKeyPair.secretKey,
-        daemonSeesClientPubKey,
-      );
-      const clientSharedKey = await deriveSharedKey(
-        clientKeyPair.secretKey,
-        clientSeesDaemonPubKey,
-      );
+      const daemonSharedKey = deriveSharedKey(daemonKeyPair.secretKey, daemonSeesClientPubKey);
+      const clientSharedKey = deriveSharedKey(clientKeyPair.secretKey, clientSeesDaemonPubKey);
 
       // Both should derive the same key - test by encrypting with one, decrypting with other
       const testMessage = "Hello, encrypted world!";
-      const encrypted = await encrypt(daemonSharedKey, testMessage);
-      const decrypted = await decrypt(clientSharedKey, encrypted);
+      const encrypted = encrypt(daemonSharedKey, testMessage);
+      const decrypted = decrypt(clientSharedKey, encrypted);
 
       expect(decrypted).toBe(testMessage);
     });
   });
 
   describe("encrypt / decrypt", () => {
-    it("roundtrips a string message", async () => {
-      const daemonKeyPair = await generateKeyPair();
-      const clientKeyPair = await generateKeyPair();
-      const sharedKey = await deriveSharedKey(daemonKeyPair.secretKey, clientKeyPair.publicKey);
+    it("roundtrips a string message", () => {
+      const daemonKeyPair = generateKeyPair();
+      const clientKeyPair = generateKeyPair();
+      const sharedKey = deriveSharedKey(daemonKeyPair.secretKey, clientKeyPair.publicKey);
 
       const plaintext = "Test message with unicode: 你好世界 🎉";
-      const ciphertext = await encrypt(sharedKey, plaintext);
+      const ciphertext = encrypt(sharedKey, plaintext);
 
       expect(ciphertext).toBeInstanceOf(ArrayBuffer);
       expect(ciphertext.byteLength).toBeGreaterThan(plaintext.length);
 
-      const decrypted = await decrypt(sharedKey, ciphertext);
+      const decrypted = decrypt(sharedKey, ciphertext);
       expect(decrypted).toBe(plaintext);
     });
 
-    it("roundtrips binary data", async () => {
-      const daemonKeyPair = await generateKeyPair();
-      const clientKeyPair = await generateKeyPair();
-      const sharedKey = await deriveSharedKey(daemonKeyPair.secretKey, clientKeyPair.publicKey);
+    it("roundtrips binary data", () => {
+      const daemonKeyPair = generateKeyPair();
+      const clientKeyPair = generateKeyPair();
+      const sharedKey = deriveSharedKey(daemonKeyPair.secretKey, clientKeyPair.publicKey);
 
       const binary = new Uint8Array([0, 1, 2, 255, 254, 253]);
-      const ciphertext = await encrypt(sharedKey, binary.buffer);
+      const ciphertext = encrypt(sharedKey, binary.buffer);
 
-      const decrypted = await decrypt(sharedKey, ciphertext);
+      const decrypted = decrypt(sharedKey, ciphertext);
       expect(new Uint8Array(decrypted as ArrayBuffer)).toEqual(binary);
     });
 
-    it("fails to decrypt with wrong key", async () => {
-      const keypair1 = await generateKeyPair();
-      const keypair2 = await generateKeyPair();
-      const keypair3 = await generateKeyPair();
+    it("fails to decrypt with wrong key", () => {
+      const keypair1 = generateKeyPair();
+      const keypair2 = generateKeyPair();
+      const keypair3 = generateKeyPair();
 
-      const correctKey = await deriveSharedKey(keypair1.secretKey, keypair2.publicKey);
-      const wrongKey = await deriveSharedKey(keypair1.secretKey, keypair3.publicKey);
+      const correctKey = deriveSharedKey(keypair1.secretKey, keypair2.publicKey);
+      const wrongKey = deriveSharedKey(keypair1.secretKey, keypair3.publicKey);
 
-      const ciphertext = await encrypt(correctKey, "secret");
+      const ciphertext = encrypt(correctKey, "secret");
 
       const tryDecrypt = () => decrypt(wrongKey, ciphertext);
       expect(tryDecrypt).toThrow();
     });
 
-    it("produces different ciphertext for same plaintext (random IV)", async () => {
-      const keypair1 = await generateKeyPair();
-      const keypair2 = await generateKeyPair();
-      const sharedKey = await deriveSharedKey(keypair1.secretKey, keypair2.publicKey);
+    it("produces different ciphertext for same plaintext (random IV)", () => {
+      const keypair1 = generateKeyPair();
+      const keypair2 = generateKeyPair();
+      const sharedKey = deriveSharedKey(keypair1.secretKey, keypair2.publicKey);
 
       const plaintext = "Same message";
-      const ciphertext1 = await encrypt(sharedKey, plaintext);
-      const ciphertext2 = await encrypt(sharedKey, plaintext);
+      const ciphertext1 = encrypt(sharedKey, plaintext);
+      const ciphertext2 = encrypt(sharedKey, plaintext);
 
       // Should be different due to random IV
       const arr1 = new Uint8Array(ciphertext1);
@@ -124,49 +118,49 @@ describe("crypto", () => {
       expect(arr1).not.toEqual(arr2);
 
       // But both should decrypt to same plaintext
-      expect(await decrypt(sharedKey, ciphertext1)).toBe(plaintext);
-      expect(await decrypt(sharedKey, ciphertext2)).toBe(plaintext);
+      expect(decrypt(sharedKey, ciphertext1)).toBe(plaintext);
+      expect(decrypt(sharedKey, ciphertext2)).toBe(plaintext);
     });
   });
 
   describe("full handshake simulation", () => {
-    it("simulates complete daemon<->client key exchange", async () => {
+    it("simulates complete daemon<->client key exchange", () => {
       // === DAEMON SIDE (generates session) ===
-      const daemonKeyPair = await generateKeyPair();
-      const daemonPubKeyB64 = await exportPublicKey(daemonKeyPair.publicKey);
+      const daemonKeyPair = generateKeyPair();
+      const daemonPubKeyB64 = exportPublicKey(daemonKeyPair.publicKey);
 
       // QR code would contain: { serverId, daemonPubKeyB64, relay: { endpoint } }
 
       // === CLIENT SIDE (scans QR) ===
-      const clientKeyPair = await generateKeyPair();
-      const clientPubKeyB64 = await exportPublicKey(clientKeyPair.publicKey);
+      const clientKeyPair = generateKeyPair();
+      const clientPubKeyB64 = exportPublicKey(clientKeyPair.publicKey);
 
       // Client imports daemon's public key from QR
-      const daemonPubKeyOnClient = await importPublicKey(daemonPubKeyB64);
+      const daemonPubKeyOnClient = importPublicKey(daemonPubKeyB64);
 
       // Client derives shared key
-      const clientSharedKey = await deriveSharedKey(clientKeyPair.secretKey, daemonPubKeyOnClient);
+      const clientSharedKey = deriveSharedKey(clientKeyPair.secretKey, daemonPubKeyOnClient);
 
       // Client sends hello: { type: "hello", key: clientPubKeyB64 }
 
       // === DAEMON SIDE (receives hello) ===
       // Daemon imports client's public key from hello message
-      const clientPubKeyOnDaemon = await importPublicKey(clientPubKeyB64);
+      const clientPubKeyOnDaemon = importPublicKey(clientPubKeyB64);
 
       // Daemon derives shared key
-      const daemonSharedKey = await deriveSharedKey(daemonKeyPair.secretKey, clientPubKeyOnDaemon);
+      const daemonSharedKey = deriveSharedKey(daemonKeyPair.secretKey, clientPubKeyOnDaemon);
 
       // === VERIFY BOTH HAVE SAME KEY ===
       const testFromDaemon = "Message from daemon";
       const testFromClient = "Message from client";
 
       // Daemon encrypts, client decrypts
-      const encryptedFromDaemon = await encrypt(daemonSharedKey, testFromDaemon);
-      expect(await decrypt(clientSharedKey, encryptedFromDaemon)).toBe(testFromDaemon);
+      const encryptedFromDaemon = encrypt(daemonSharedKey, testFromDaemon);
+      expect(decrypt(clientSharedKey, encryptedFromDaemon)).toBe(testFromDaemon);
 
       // Client encrypts, daemon decrypts
-      const encryptedFromClient = await encrypt(clientSharedKey, testFromClient);
-      expect(await decrypt(daemonSharedKey, encryptedFromClient)).toBe(testFromClient);
+      const encryptedFromClient = encrypt(clientSharedKey, testFromClient);
+      expect(decrypt(daemonSharedKey, encryptedFromClient)).toBe(testFromClient);
     });
   });
 });

--- a/packages/relay/src/e2e.test.ts
+++ b/packages/relay/src/e2e.test.ts
@@ -234,8 +234,8 @@ async function stopRelayProcess(relayProcess: ChildProcess): Promise<void> {
 
       // === DAEMON SIDE ===
       // Generate keypair (public key goes in QR)
-      const daemonKeyPair = await generateKeyPair();
-      const daemonPubKeyB64 = await exportPublicKey(daemonKeyPair.publicKey);
+      const daemonKeyPair = generateKeyPair();
+      const daemonPubKeyB64 = exportPublicKey(daemonKeyPair.publicKey);
 
       // QR would contain: { serverId, daemonPubKeyB64, relay: { endpoint } }
 
@@ -252,12 +252,12 @@ async function stopRelayProcess(relayProcess: ChildProcess): Promise<void> {
       // === CLIENT SIDE ===
       // Client scans QR, gets daemon's public key and session ID
       // Client generates own keypair
-      const clientKeyPair = await generateKeyPair();
-      const clientPubKeyB64 = await exportPublicKey(clientKeyPair.publicKey);
+      const clientKeyPair = generateKeyPair();
+      const clientPubKeyB64 = exportPublicKey(clientKeyPair.publicKey);
 
       // Client imports daemon's public key and derives shared secret
-      const daemonPubKeyOnClient = await importPublicKey(daemonPubKeyB64);
-      const clientSharedKey = await deriveSharedKey(clientKeyPair.secretKey, daemonPubKeyOnClient);
+      const daemonPubKeyOnClient = importPublicKey(daemonPubKeyB64);
+      const clientSharedKey = deriveSharedKey(clientKeyPair.secretKey, daemonPubKeyOnClient);
 
       const waitForClientSeen = new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(
@@ -324,21 +324,21 @@ async function stopRelayProcess(relayProcess: ChildProcess): Promise<void> {
       expect(hello.key).toBe(clientPubKeyB64);
 
       // Daemon imports client's public key and derives shared secret
-      const clientPubKeyOnDaemon = await importPublicKey(hello.key);
-      const daemonSharedKey = await deriveSharedKey(daemonKeyPair.secretKey, clientPubKeyOnDaemon);
+      const clientPubKeyOnDaemon = importPublicKey(hello.key);
+      const daemonSharedKey = deriveSharedKey(daemonKeyPair.secretKey, clientPubKeyOnDaemon);
 
       // === VERIFY BOTH HAVE SAME KEY - Exchange encrypted messages ===
 
       // Daemon sends encrypted "ready" message
       const readyPlaintext = JSON.stringify({ type: "ready" });
-      const readyCiphertext = await encrypt(daemonSharedKey, readyPlaintext);
+      const readyCiphertext = encrypt(daemonSharedKey, readyPlaintext);
       daemonWs.send(Buffer.from(readyCiphertext));
 
       // Client receives and decrypts
       const clientReceivedReady = await new Promise<Buffer>((resolve) => {
         clientWs.once("message", (data) => resolve(data as Buffer));
       });
-      const decryptedReady = await decrypt(
+      const decryptedReady = decrypt(
         clientSharedKey,
         clientReceivedReady.buffer.slice(
           clientReceivedReady.byteOffset,
@@ -349,14 +349,14 @@ async function stopRelayProcess(relayProcess: ChildProcess): Promise<void> {
 
       // Client sends encrypted message
       const clientMessage = "Hello from client!";
-      const clientCiphertext = await encrypt(clientSharedKey, clientMessage);
+      const clientCiphertext = encrypt(clientSharedKey, clientMessage);
       clientWs.send(Buffer.from(clientCiphertext));
 
       // Daemon receives and decrypts
       const daemonReceivedMsg = await new Promise<Buffer>((resolve) => {
         daemonWs.once("message", (data) => resolve(data as Buffer));
       });
-      const decryptedClientMsg = await decrypt(
+      const decryptedClientMsg = decrypt(
         daemonSharedKey,
         daemonReceivedMsg.buffer.slice(
           daemonReceivedMsg.byteOffset,
@@ -367,14 +367,14 @@ async function stopRelayProcess(relayProcess: ChildProcess): Promise<void> {
 
       // Daemon sends encrypted response
       const daemonMessage = "Hello from daemon!";
-      const daemonCiphertext = await encrypt(daemonSharedKey, daemonMessage);
+      const daemonCiphertext = encrypt(daemonSharedKey, daemonMessage);
       daemonWs.send(Buffer.from(daemonCiphertext));
 
       // Client receives and decrypts
       const clientReceivedMsg = await new Promise<Buffer>((resolve) => {
         clientWs.once("message", (data) => resolve(data as Buffer));
       });
-      const decryptedDaemonMsg = await decrypt(
+      const decryptedDaemonMsg = decrypt(
         clientSharedKey,
         clientReceivedMsg.buffer.slice(
           clientReceivedMsg.byteOffset,
@@ -394,17 +394,17 @@ async function stopRelayProcess(relayProcess: ChildProcess): Promise<void> {
     const connectionId = "clt_opaque_" + Date.now() + "_" + Math.random().toString(36).slice(2);
 
     // Setup keys
-    const daemonKeyPair = await generateKeyPair();
-    const clientKeyPair = await generateKeyPair();
+    const daemonKeyPair = generateKeyPair();
+    const clientKeyPair = generateKeyPair();
 
-    const daemonPubKeyB64 = await exportPublicKey(daemonKeyPair.publicKey);
-    const clientPubKeyB64 = await exportPublicKey(clientKeyPair.publicKey);
+    const daemonPubKeyB64 = exportPublicKey(daemonKeyPair.publicKey);
+    const clientPubKeyB64 = exportPublicKey(clientKeyPair.publicKey);
 
-    const clientPubKey = await importPublicKey(clientPubKeyB64);
-    const daemonPubKey = await importPublicKey(daemonPubKeyB64);
+    const clientPubKey = importPublicKey(clientPubKeyB64);
+    const daemonPubKey = importPublicKey(daemonPubKeyB64);
 
-    const daemonSharedKey = await deriveSharedKey(daemonKeyPair.secretKey, clientPubKey);
-    const clientSharedKey = await deriveSharedKey(clientKeyPair.secretKey, daemonPubKey);
+    const daemonSharedKey = deriveSharedKey(daemonKeyPair.secretKey, clientPubKey);
+    const clientSharedKey = deriveSharedKey(clientKeyPair.secretKey, daemonPubKey);
 
     const daemonControlWs = new WebSocket(
       `ws://127.0.0.1:${relayPort}/ws?serverId=${serverId}&role=server&v=2`,
@@ -458,7 +458,7 @@ async function stopRelayProcess(relayProcess: ChildProcess): Promise<void> {
 
     // Send encrypted secret
     const secret = "This is a secret that relay cannot read";
-    const ciphertext = await encrypt(clientSharedKey, secret);
+    const ciphertext = encrypt(clientSharedKey, secret);
     clientWs.send(Buffer.from(ciphertext));
 
     // Daemon receives
@@ -471,7 +471,7 @@ async function stopRelayProcess(relayProcess: ChildProcess): Promise<void> {
     expect(rawString).not.toContain(secret);
 
     // But daemon can decrypt
-    const decrypted = await decrypt(
+    const decrypted = decrypt(
       daemonSharedKey,
       received.buffer.slice(received.byteOffset, received.byteOffset + received.byteLength),
     );
@@ -482,22 +482,22 @@ async function stopRelayProcess(relayProcess: ChildProcess): Promise<void> {
     clientWs.close();
   });
 
-  it("wrong key cannot decrypt", async () => {
+  it("wrong key cannot decrypt", () => {
     // Setup - daemon and client with correct keys
-    const daemonKeyPair = await generateKeyPair();
-    const clientKeyPair = await generateKeyPair();
-    const attackerKeyPair = await generateKeyPair();
+    const daemonKeyPair = generateKeyPair();
+    const clientKeyPair = generateKeyPair();
+    const attackerKeyPair = generateKeyPair();
 
-    const clientPubKey = await importPublicKey(await exportPublicKey(clientKeyPair.publicKey));
-    const daemonSharedKey = await deriveSharedKey(daemonKeyPair.secretKey, clientPubKey);
+    const clientPubKey = importPublicKey(exportPublicKey(clientKeyPair.publicKey));
+    const daemonSharedKey = deriveSharedKey(daemonKeyPair.secretKey, clientPubKey);
 
     // Attacker tries to derive key with their own keypair
-    const attackerPubKey = await importPublicKey(await exportPublicKey(attackerKeyPair.publicKey));
-    const attackerKey = await deriveSharedKey(attackerKeyPair.secretKey, attackerPubKey);
+    const attackerPubKey = importPublicKey(exportPublicKey(attackerKeyPair.publicKey));
+    const attackerKey = deriveSharedKey(attackerKeyPair.secretKey, attackerPubKey);
 
     // Encrypt with daemon's key
     const secret = "Top secret message";
-    const ciphertext = await encrypt(daemonSharedKey, secret);
+    const ciphertext = encrypt(daemonSharedKey, secret);
 
     // Attacker cannot decrypt
     expect(() => decrypt(attackerKey, ciphertext)).toThrow();

--- a/packages/relay/src/encrypted-channel.test.ts
+++ b/packages/relay/src/encrypted-channel.test.ts
@@ -40,8 +40,8 @@ describe("EncryptedChannel", () => {
     const [daemonTransport, clientTransport] = createMockTransportPair();
 
     // Daemon generates keypair (public key goes in QR)
-    const daemonKeyPair = await generateKeyPair();
-    const daemonPubKeyB64 = await exportPublicKey(daemonKeyPair.publicKey);
+    const daemonKeyPair = generateKeyPair();
+    const daemonPubKeyB64 = exportPublicKey(daemonKeyPair.publicKey);
 
     let clientOpenedResolve: (() => void) | null = null;
     const clientOpened = new Promise<void>((resolve) => {
@@ -67,8 +67,8 @@ describe("EncryptedChannel", () => {
   it("exchanges encrypted messages bidirectionally", async () => {
     const [daemonTransport, clientTransport] = createMockTransportPair();
 
-    const daemonKeyPair = await generateKeyPair();
-    const daemonPubKeyB64 = await exportPublicKey(daemonKeyPair.publicKey);
+    const daemonKeyPair = generateKeyPair();
+    const daemonPubKeyB64 = exportPublicKey(daemonKeyPair.publicKey);
 
     const daemonMessages: (string | ArrayBuffer)[] = [];
     const clientMessages: (string | ArrayBuffer)[] = [];
@@ -105,8 +105,8 @@ describe("EncryptedChannel", () => {
   it("encrypted messages are opaque to transport", async () => {
     const [daemonTransport, clientTransport] = createMockTransportPair();
 
-    const daemonKeyPair = await generateKeyPair();
-    const daemonPubKeyB64 = await exportPublicKey(daemonKeyPair.publicKey);
+    const daemonKeyPair = generateKeyPair();
+    const daemonPubKeyB64 = exportPublicKey(daemonKeyPair.publicKey);
 
     let clientOpenedResolve: (() => void) | null = null;
     const clientOpened = new Promise<void>((resolve) => {
@@ -142,8 +142,8 @@ describe("EncryptedChannel", () => {
   it("does not throw uncaught when handshake hello retry send fails", async () => {
     vi.useFakeTimers();
     try {
-      const daemonKeyPair = await generateKeyPair();
-      const daemonPubKeyB64 = await exportPublicKey(daemonKeyPair.publicKey);
+      const daemonKeyPair = generateKeyPair();
+      const daemonPubKeyB64 = exportPublicKey(daemonKeyPair.publicKey);
 
       const transport: Transport = {
         send: vi.fn(),
@@ -183,7 +183,7 @@ describe("EncryptedChannel", () => {
   it("fails handshake on invalid hello", async () => {
     const [daemonTransport] = createMockTransportPair();
 
-    const daemonKeyPair = await generateKeyPair();
+    const daemonKeyPair = generateKeyPair();
 
     const daemonChannelPromise = createDaemonChannel(daemonTransport, daemonKeyPair);
 

--- a/packages/relay/src/encrypted-channel.ts
+++ b/packages/relay/src/encrypted-channel.ts
@@ -331,7 +331,7 @@ export class EncryptedChannel {
       })();
 
       if (ciphertext) {
-        const plaintext = await decrypt(this.sharedKey, ciphertext);
+        const plaintext = decrypt(this.sharedKey, ciphertext);
         this.events.onmessage?.(plaintext);
       }
     } catch (error) {
@@ -361,7 +361,7 @@ export class EncryptedChannel {
       throw new Error("Channel not open");
     }
 
-    const ciphertext = await encrypt(this.sharedKey, data);
+    const ciphertext = encrypt(this.sharedKey, data);
     // Send as base64 for WebSocket text compatibility
     this.transport.send(arrayBufferToBase64(ciphertext));
   }

--- a/packages/relay/src/live-relay.e2e.test.ts
+++ b/packages/relay/src/live-relay.e2e.test.ts
@@ -104,17 +104,14 @@ describe("Live relay (relay.paseo.sh) E2E", () => {
         )}&role=client&connectionId=${encodeURIComponent(connectionId)}&v=2`;
 
         // === Key setup ===
-        const daemonKeyPair = await generateKeyPair();
-        const daemonPubKeyB64 = await exportPublicKey(daemonKeyPair.publicKey);
+        const daemonKeyPair = generateKeyPair();
+        const daemonPubKeyB64 = exportPublicKey(daemonKeyPair.publicKey);
 
-        const clientKeyPair = await generateKeyPair();
-        const clientPubKeyB64 = await exportPublicKey(clientKeyPair.publicKey);
+        const clientKeyPair = generateKeyPair();
+        const clientPubKeyB64 = exportPublicKey(clientKeyPair.publicKey);
 
-        const daemonPubKeyOnClient = await importPublicKey(daemonPubKeyB64);
-        const clientSharedKey = await deriveSharedKey(
-          clientKeyPair.secretKey,
-          daemonPubKeyOnClient,
-        );
+        const daemonPubKeyOnClient = importPublicKey(daemonPubKeyB64);
+        const clientSharedKey = deriveSharedKey(clientKeyPair.secretKey, daemonPubKeyOnClient);
 
         // === Connect ===
         const daemonControlWs = new WebSocket(serverControlUrl);
@@ -149,15 +146,12 @@ describe("Live relay (relay.paseo.sh) E2E", () => {
           expect(hello.type).toBe("hello");
           expect(typeof hello.key).toBe("string");
 
-          const clientPubKeyOnDaemon = await importPublicKey(hello.key!);
-          const daemonSharedKey = await deriveSharedKey(
-            daemonKeyPair.secretKey,
-            clientPubKeyOnDaemon,
-          );
+          const clientPubKeyOnDaemon = importPublicKey(hello.key!);
+          const daemonSharedKey = deriveSharedKey(daemonKeyPair.secretKey, clientPubKeyOnDaemon);
 
           // === Encrypted exchange ===
           const plaintextFromClient = "hello-from-client";
-          const ciphertextFromClient = await encrypt(clientSharedKey, plaintextFromClient);
+          const ciphertextFromClient = encrypt(clientSharedKey, plaintextFromClient);
           clientWs.send(Buffer.from(ciphertextFromClient));
 
           const daemonReceivedCiphertext = await waitForOnceMessage(
@@ -166,7 +160,7 @@ describe("Live relay (relay.paseo.sh) E2E", () => {
             "Timed out waiting for encrypted message",
           );
 
-          const decryptedOnDaemon = await decrypt(
+          const decryptedOnDaemon = decrypt(
             daemonSharedKey,
             daemonReceivedCiphertext.buffer.slice(
               daemonReceivedCiphertext.byteOffset,
@@ -176,7 +170,7 @@ describe("Live relay (relay.paseo.sh) E2E", () => {
           expect(decryptedOnDaemon).toBe(plaintextFromClient);
 
           const plaintextFromDaemon = "hello-from-daemon";
-          const ciphertextFromDaemon = await encrypt(daemonSharedKey, plaintextFromDaemon);
+          const ciphertextFromDaemon = encrypt(daemonSharedKey, plaintextFromDaemon);
           daemonWs.send(Buffer.from(ciphertextFromDaemon));
 
           const clientReceivedCiphertext = await waitForOnceMessage(
@@ -185,7 +179,7 @@ describe("Live relay (relay.paseo.sh) E2E", () => {
             "Timed out waiting for encrypted response",
           );
 
-          const decryptedOnClient = await decrypt(
+          const decryptedOnClient = decrypt(
             clientSharedKey,
             clientReceivedCiphertext.buffer.slice(
               clientReceivedCiphertext.byteOffset,


### PR DESCRIPTION
## Summary
- Remove `await` from synchronous crypto function calls in relay package tests and encrypted-channel.ts
- Functions like `generateKeyPair()`, `exportPublicKey()`, `importPublicKey()`, `deriveSharedKey()`, `encrypt()`, and `decrypt()` are all synchronous (they don't return Promises)
- The `await` operators were unnecessary and triggering `typescript-eslint(await-thenable)` type-aware lint errors

## Cluster
- **Rule**: `typescript-eslint(await-thenable)`
- **Errors fixed**: 107 errors across 5 files
- **Files**:
  - `packages/relay/src/crypto.test.ts` (50 errors)
  - `packages/relay/src/e2e.test.ts` (34 errors)
  - `packages/relay/src/live-relay.e2e.test.ts` (12 errors)
  - `packages/relay/src/encrypted-channel.test.ts` (9 errors)
  - `packages/relay/src/encrypted-channel.ts` (2 errors)

## Root cause
The crypto functions in `packages/relay/src/crypto.ts` are synchronous wrappers around tweetnacl (NaCl) primitives. They don't perform any async I/O and return values directly. The test files were incorrectly using `await` on these calls, which TypeScript's type-aware lint correctly flagged as unnecessary.

## Why this is correct beyond satisfying the linter
1. **Semantic correctness**: Awaiting a non-Promise value has no effect but adds cognitive overhead - readers may incorrectly assume these operations are async
2. **Test accuracy**: Tests should reflect the actual sync/async behavior of the production code
3. **Performance**: While minimal, awaiting non-Promises still goes through the microtask queue unnecessarily
4. **Type safety**: The fix makes the code's sync nature explicit, matching the function signatures in crypto.ts

## Test plan
- [x] typecheck green (relay package has pre-existing unrelated dependency type issues)
- [x] lint green (typeAware: false in committed state)
- [x] no files touched that overlap with @boudra's open PRs