### PR TITLE
refactor(app): remove redundant type constituents for type-aware lint

### DIFF
--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -64,9 +64,9 @@ export type MessageEntry =
       id: string;
       timestamp: number;
       toolName: string;
-      args: unknown | null;
-      result?: unknown | null;
-      error?: unknown | null;
+      args: unknown;
+      result?: unknown;
+      error?: unknown;
       status: "executing" | "completed" | "failed";
     };
 

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -99,7 +99,7 @@ export interface AgentToolCallData {
   callId: string;
   name: string;
   status: AgentToolCallStatus;
-  error: unknown | null;
+  error: unknown;
   detail: ToolCallDetail;
   metadata?: Record<string, unknown>;
 }
@@ -331,7 +331,7 @@ function hasNonEmptyObject(value: unknown): boolean {
   return isRecord(value) && Object.keys(value).length > 0;
 }
 
-function mergeUnknownValue(existing: unknown | null, incoming: unknown | null): unknown | null {
+function mergeUnknownValue(existing: unknown, incoming: unknown): unknown {
   if (incoming === null) {
     return existing;
   }
@@ -406,7 +406,7 @@ export function mergeToolCallDetail(
   return incoming;
 }
 
-function inputFromUnknownDetail(detail: ToolCallDetail): unknown | null {
+function inputFromUnknownDetail(detail: ToolCallDetail): unknown {
   return detail.type === "unknown" ? detail.input : null;
 }
 

--- a/packages/app/src/utils/format-shortcut.ts
+++ b/packages/app/src/utils/format-shortcut.ts
@@ -1,4 +1,4 @@
-export type ShortcutKey = "mod" | "shift" | "alt" | "ctrl" | "meta" | string;
+export type ShortcutKey = string;
 
 export type ShortcutOs = "mac" | "non-mac";
 


### PR DESCRIPTION
## Summary
- Remove redundant 
| null from unknown types (unknown already includes null)
- Simplify ShortcutKey type from redundant union of literals with string

## Cluster
Rule: typescript-eslint(no-redundant-type-constituents)
Count: 19 errors across 3 files
Files: format-shortcut.ts, session-store.ts, stream.ts

## Root cause
1. Using unknown | null where unknown already encompasses all types including null
2. Combining string literal types ("mod" | "shift" | ...) with string makes the literals meaningless since string covers all cases

## Why this is correct beyond satisfying the linter
- More accurate types: unknown already includes null, so the union was misleading
- Cleaner type definitions: Removing redundancy makes intent clearer
- Better developer experience: No confusion about whether null is a special case

## Test plan
- [x] typecheck green
- [x] lint green (typeAware false in committed state)
- [x] no files touched that overlap with @boudra's open PRs