### PR TITLE
refactor(server): remove redundant null from unknown union types

### DIFF
--- a/packages/server/src/server/agent/activity-curator.test.ts
+++ b/packages/server/src/server/agent/activity-curator.test.ts
@@ -6,8 +6,8 @@ function toolCallItem(params: {
   callId: string;
   name: string;
   status?: "running" | "completed" | "failed" | "canceled";
-  input?: unknown | null;
-  output?: unknown | null;
+  input?: unknown;
+  output?: unknown;
   error?: unknown;
   metadata?: Record<string, unknown>;
   detail?: Extract<AgentTimelineItem, { type: "tool_call" }>["detail"];

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -255,8 +255,8 @@ export type ToolCallDetail =
     }
   | {
       type: "unknown";
-      input: unknown | null;
-      output: unknown | null;
+      input: unknown;
+      output: unknown;
     };
 
 interface ToolCallBase {

--- a/packages/server/src/server/agent/providers/claude-agent.integration.test.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.integration.test.ts
@@ -136,7 +136,7 @@ function getLatestCompletedBashCall(events: AgentStreamEvent[]): ToolCallTimelin
 }
 
 function getInternalQuery(session: AgentSession): unknown {
-  return (session as AgentSession & { query?: unknown | null }).query ?? null;
+  return (session as AgentSession & { query?: unknown }).query ?? null;
 }
 
 async function createSession(params?: {

--- a/packages/server/src/server/agent/providers/claude/tool-call-mapper.ts
+++ b/packages/server/src/server/agent/providers/claude/tool-call-mapper.ts
@@ -100,7 +100,7 @@ function resolveDetailName(toolKind: ClaudeToolKind, name: string): string {
 function mapClaudeToolCall(
   params: MapperParams,
   status: ClaudeToolCallStatus,
-  error: unknown | null,
+  error: unknown,
 ): ToolCallTimelineItem | null {
   const parsed = ClaudeRawToolCallSchema.safeParse({ ...params, status, error });
   if (!parsed.success) {

--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
@@ -31,10 +31,10 @@ const CodexRolloutToolCallParamsSchema = z
 interface CodexNormalizedToolCallEnvelope {
   callId: string;
   name: string;
-  input?: unknown | null;
-  output?: unknown | null;
+  input?: unknown;
+  output?: unknown;
   status?: ToolCallTimelineItem["status"];
-  error?: unknown | null;
+  error?: unknown;
   metadata?: Record<string, unknown>;
   cwd?: string | null;
 }

--- a/packages/server/src/server/agent/providers/pi-direct-agent.ts
+++ b/packages/server/src/server/agent/providers/pi-direct-agent.ts
@@ -201,7 +201,7 @@ interface PiLsToolCall {
 interface PiUnknownToolCall {
   kind: "unknown";
   toolName: string;
-  args: unknown | null;
+  args: unknown;
 }
 
 type PiTrackedToolCall =

--- a/packages/server/src/utils/paseo-config-file.ts
+++ b/packages/server/src/utils/paseo-config-file.ts
@@ -46,7 +46,7 @@ export function statPaseoConfigPath(repoRoot: string): PaseoConfigRevision | nul
   };
 }
 
-export function readPaseoConfigJson(repoRoot: string): unknown | null {
+export function readPaseoConfigJson(repoRoot: string): unknown {
   const configPath = resolvePaseoConfigPath(repoRoot);
   if (!existsSync(configPath)) {
     return null;


### PR DESCRIPTION
## Summary
- Removed redundant `| null` from `unknown` union types across the server package
- Fixed 7 files with 11 occurrences of the anti-pattern
- `unknown` is the top type in TypeScript and already includes `null`, making `unknown | null` redundant

## Cluster
- Rule: `no-redundant-type-constituents` (type-aware lint)
- 11 errors across 7 files
- All in `packages/server/src/server/agent/` and `packages/server/src/utils/`

## Root cause
TypeScript's `unknown` type is the universal supertype that includes all possible values, including `null` and `undefined`. Writing `unknown | null` is semantically equivalent to just `unknown`, but adds visual noise and triggers the `no-redundant-type-constituents` lint rule when type-aware linting is enabled.

## Why this is correct beyond satisfying the linter
- **Type accuracy**: The union doesn't actually restrict or expand the type - it's purely cosmetic
- **Consistency**: Aligns with TypeScript best practices where redundant type constituents should be avoided
- **Maintainability**: Cleaner types make the codebase easier to understand and refactor

## Test plan
- [x] typecheck green
- [x] lint green (typeAware false in committed state)
- [x] no files touched that overlap with @boudra's open PRs