### PR TITLE
refactor(server): remove unnecessary String() conversions from type-aware lint fixes

### DIFF
--- a/packages/server/src/server/agent/providers/mock-load-test-agent.ts
+++ b/packages/server/src/server/agent/providers/mock-load-test-agent.ts
@@ -398,7 +398,7 @@ export class MockLoadTestAgentClient implements AgentClient {
     const metadata = (handle.metadata ?? {}) as Partial<AgentSessionConfig>;
     return new MockLoadTestAgentSession({
       config: {
-        cwd: String(metadata.cwd ?? overrides?.cwd ?? process.cwd()),
+        cwd: metadata.cwd ?? overrides?.cwd ?? process.cwd(),
         ...metadata,
         ...overrides,
         provider: MOCK_LOAD_TEST_PROVIDER_ID,

--- a/packages/server/src/server/voice-local-agent.e2e.test.ts
+++ b/packages/server/src/server/voice-local-agent.e2e.test.ts
@@ -17,7 +17,7 @@ type SessionMessage<T extends SessionOutboundMessage["type"]> = Extract<
 function makeTranscriptionHandler(resolve: (value: string) => void) {
   return (msg: SessionMessage<"transcription_result">) => {
     if (msg.type !== "transcription_result") return;
-    const text = String(msg.payload.text ?? "").trim();
+    const text = (msg.payload.text ?? "").trim();
     if (!text) return;
     resolve(text);
   };
@@ -27,7 +27,7 @@ function makeErrorHandler(reject: (error: Error) => void) {
   return (msg: SessionMessage<"activity_log">) => {
     if (msg.type !== "activity_log") return;
     if (msg.payload.type !== "error") return;
-    reject(new Error(String(msg.payload.content)));
+    reject(new Error(msg.payload.content));
   };
 }
 
@@ -37,7 +37,7 @@ function makeSpeakToolHandler(resolve: (value: string) => void) {
     if (msg.payload.event.type !== "timeline") return;
     const item = msg.payload.event.item;
     if (item.type !== "tool_call") return;
-    const name = String(item.name ?? "");
+    const name = item.name ?? "";
     if (!name.toLowerCase().includes("speak")) return;
     resolve(name);
   };

--- a/packages/server/src/server/voice-roundtrip.e2e.test.ts
+++ b/packages/server/src/server/voice-roundtrip.e2e.test.ts
@@ -31,7 +31,7 @@ function makeTranscriptionHandler(
       return;
     }
     resolve({
-      text: String(message.payload.text ?? ""),
+      text: message.payload.text ?? "",
       isLowConfidence: Boolean(message.payload.isLowConfidence),
     });
   };
@@ -83,7 +83,7 @@ function makeActivityErrorHandler(reject: (error: Error) => void) {
     if (message.payload.type !== "error") {
       return;
     }
-    reject(new Error(String(message.payload.content)));
+    reject(new Error(message.payload.content));
   };
 }
 
@@ -237,7 +237,7 @@ for (const targetProvider of [
           return;
         }
         timelineToolAgentIds.add(message.payload.agentId);
-        timelineTools.push(String(item.name ?? ""));
+        timelineTools.push(item.name ?? "");
       });
       const offErrors = ctx.client.on("activity_log", (message) => {
         if (message.type !== "activity_log") {
@@ -246,7 +246,7 @@ for (const targetProvider of [
         if (message.payload.type !== "error") {
           return;
         }
-        activityErrors.push(String(message.payload.content ?? ""));
+        activityErrors.push(message.payload.content ?? "");
       });
 
       const inputSpeech = await withTimeout(

--- a/packages/server/src/server/workspace-directory.ts
+++ b/packages/server/src/server/workspace-directory.ts
@@ -259,14 +259,14 @@ export class WorkspaceDirectory {
     }
 
     if (filter.idPrefix && filter.idPrefix.trim().length > 0) {
-      if (!String(workspace.id).startsWith(filter.idPrefix.trim())) {
+      if (!workspace.id.startsWith(filter.idPrefix.trim())) {
         return false;
       }
     }
 
     if (filter.query && filter.query.trim().length > 0) {
       const query = filter.query.trim().toLocaleLowerCase();
-      const haystacks = [workspace.name, String(workspace.projectId), String(workspace.id)];
+      const haystacks = [workspace.name, workspace.projectId, workspace.id];
       if (!haystacks.some((value) => value.toLocaleLowerCase().includes(query))) {
         return false;
       }


### PR DESCRIPTION
## Summary
- Remove redundant `String()` calls from server test and source files
- 11 total conversions removed across 4 files

## Cluster
- Rule: `typescript-eslint/no-unnecessary-type-conversion`
- 11 errors fixed across:
  - `voice-roundtrip.e2e.test.ts` (4 errors)
  - `workspace-directory.ts` (3 errors)
  - `voice-local-agent.e2e.test.ts` (3 errors)
  - `mock-load-test-agent.ts` (1 error)

## Root cause
The `String()` wrapper was being used defensively on values that were already typed as strings (or had string fallbacks via `??`). This is unnecessary type conversion that adds no runtime value and reduces code clarity.

## Why this is correct beyond satisfying the linter
- **Type safety**: The values are already typed as strings by TypeScript's discriminated unions and message payload types
- **Code clarity**: Removing redundant conversions makes the code more readable and maintains the invariant that TypeScript types match runtime behavior
- **No runtime change**: These are purely type-level cleanups with zero functional impact

## Test plan
- [x] typecheck green
- [x] lint green (typeAware false in committed state)
- [x] no files touched that overlap with @boudra's open PRs