### PR TITLE
refactor(app): remove unnecessary String() and Boolean() conversions from type-aware lint fixes

### DIFF
--- a/packages/app/e2e/file-explorer-collapse.spec.ts
+++ b/packages/app/e2e/file-explorer-collapse.spec.ts
@@ -31,7 +31,7 @@ test.beforeAll(async () => {
   if (!result.workspace) {
     throw new Error(result.error ?? "Failed to seed workspace");
   }
-  workspaceId = String(result.workspace.id);
+  workspaceId = result.workspace.id;
 });
 
 test.afterAll(async () => {

--- a/packages/app/e2e/helpers/workspace-setup.ts
+++ b/packages/app/e2e/helpers/workspace-setup.ts
@@ -265,7 +265,7 @@ export async function createWorkspaceThroughDaemon(
     throw new Error(result.error ?? `Failed to create workspace for ${input.cwd}`);
   }
   return {
-    id: String(result.workspace.id),
+    id: result.workspace.id,
     name: result.workspace.name,
   };
 }
@@ -291,7 +291,7 @@ export async function findWorktreeWorkspaceForProject(
     throw new Error(`Failed to find created worktree workspace for ${repoPath}`);
   }
   return {
-    id: String(workspace.id),
+    id: workspace.id,
     name: workspace.name,
     projectRootPath: workspace.projectRootPath,
     workspaceDirectory: workspace.workspaceDirectory,
@@ -308,7 +308,7 @@ export async function fetchWorkspaceById(
   projectRootPath: string;
 }> {
   const payload = await client.fetchWorkspaces();
-  const workspace = payload.entries.find((entry) => String(entry.id) === workspaceId) ?? null;
+  const workspace = payload.entries.find((entry) => entry.id === workspaceId) ?? null;
   if (!workspace) {
     throw new Error(`Workspace not found: ${workspaceId}`);
   }

--- a/packages/app/e2e/launcher-tab.spec.ts
+++ b/packages/app/e2e/launcher-tab.spec.ts
@@ -32,7 +32,7 @@ test.beforeAll(async () => {
   seedClient = await connectTerminalClient();
   const result = await seedClient.openProject(tempRepo.path);
   if (!result.workspace) throw new Error(result.error ?? "Failed to seed workspace");
-  workspaceId = String(result.workspace.id);
+  workspaceId = result.workspace.id;
 });
 
 test.afterAll(async () => {

--- a/packages/app/e2e/sidebar-workspace.spec.ts
+++ b/packages/app/e2e/sidebar-workspace.spec.ts
@@ -52,7 +52,7 @@ async function openProjectViaDaemon(
     throw new Error(result.error ?? `Failed to open project ${cwd}`);
   }
   return {
-    id: String(result.workspace.id),
+    id: result.workspace.id,
     name: result.workspace.name,
   };
 }

--- a/packages/app/e2e/workspace-cwd.spec.ts
+++ b/packages/app/e2e/workspace-cwd.spec.ts
@@ -45,7 +45,7 @@ test.describe("Workspace cwd correctness", () => {
       if (!workspaceResult.workspace) {
         throw new Error(workspaceResult.error ?? `Failed to open project ${repo.path}`);
       }
-      const workspaceId = String(workspaceResult.workspace.id);
+      const workspaceId = workspaceResult.workspace.id;
 
       // Use sidebar navigation to avoid Expo Router hydration issues
       await openHomeWithProject(page, repo.path);
@@ -95,7 +95,7 @@ test.describe("Workspace cwd correctness", () => {
       if (!workspaceResult.workspace) {
         throw new Error(workspaceResult.error ?? `Failed to open project ${worktreePath}`);
       }
-      const workspaceId = String(workspaceResult.workspace.id);
+      const workspaceId = workspaceResult.workspace.id;
 
       // Use sidebar navigation to avoid Expo Router hydration issues
       // with direct URL navigation to the 2nd+ workspace.

--- a/packages/app/e2e/workspace-lifecycle.spec.ts
+++ b/packages/app/e2e/workspace-lifecycle.spec.ts
@@ -54,7 +54,7 @@ test.describe("Workspace lifecycle", () => {
         if (!workspaceResult.workspace) {
           throw new Error(workspaceResult.error ?? `Failed to open project ${repo.path}`);
         }
-        const workspaceId = String(workspaceResult.workspace.id);
+        const workspaceId = workspaceResult.workspace.id;
 
         await openHomeWithProject(page, repo.path);
         await navigateToWorkspaceViaSidebar(page, workspaceId);
@@ -77,7 +77,7 @@ test.describe("Workspace lifecycle", () => {
         if (!workspaceResult.workspace) {
           throw new Error(workspaceResult.error ?? `Failed to open project ${repo.path}`);
         }
-        const workspaceId = String(workspaceResult.workspace.id);
+        const workspaceId = workspaceResult.workspace.id;
 
         await openHomeWithProject(page, repo.path);
         await navigateToWorkspaceViaSidebar(page, workspaceId);
@@ -120,7 +120,7 @@ test.describe("Workspace lifecycle", () => {
         if (!workspaceResult.workspace) {
           throw new Error(workspaceResult.error ?? `Failed to open project ${worktreePath}`);
         }
-        const workspaceId = String(workspaceResult.workspace.id);
+        const workspaceId = workspaceResult.workspace.id;
 
         await openHomeWithProject(page, repo.path);
         await navigateToWorkspaceViaSidebar(page, workspaceId);
@@ -170,7 +170,7 @@ test.describe("Workspace lifecycle", () => {
         if (!workspaceResult.workspace) {
           throw new Error(workspaceResult.error ?? `Failed to open project ${worktreePath}`);
         }
-        const workspaceId = String(workspaceResult.workspace.id);
+        const workspaceId = workspaceResult.workspace.id;
 
         await openHomeWithProject(page, repo.path);
         await navigateToWorkspaceViaSidebar(page, workspaceId);

--- a/packages/app/e2e/workspace-setup-runtime.spec.ts
+++ b/packages/app/e2e/workspace-setup-runtime.spec.ts
@@ -42,7 +42,7 @@ test.describe("Workspace setup runtime authority", () => {
         cwd: repo.path,
         worktreeSlug: `setup-chat-${Date.now()}`,
       });
-      const workspaceId = String(workspace.id);
+      const workspaceId = workspace.id;
 
       const wsInfo = await findWorktreeWorkspaceForProject(client, repo.path);
       expect(wsInfo.workspaceDirectory).not.toBe(repo.path);
@@ -78,7 +78,7 @@ test.describe("Workspace setup runtime authority", () => {
         throw new Error(result.error ?? "Failed to create workspace");
       }
       const workspaceDir = result.workspace.workspaceDirectory;
-      const workspaceId = String(result.workspace.id);
+      const workspaceId = result.workspace.id;
 
       // Navigate to the worktree workspace via sidebar click (direct URL
       // navigation for freshly created worktree workspaces can race with

--- a/packages/app/e2e/workspace-setup-streaming.spec.ts
+++ b/packages/app/e2e/workspace-setup-streaming.spec.ts
@@ -337,7 +337,7 @@ test.describe("Workspace setup streaming", () => {
         throw new Error(result.error ?? "Failed to create workspace");
       }
       const workspaceDir = result.workspace.workspaceDirectory;
-      const workspaceId = String(result.workspace.id);
+      const workspaceId = result.workspace.id;
 
       await completed;
 

--- a/packages/app/src/components/ui/combobox.tsx
+++ b/packages/app/src/components/ui/combobox.tsx
@@ -228,8 +228,7 @@ export function ComboboxItem({
   const itemPressableStyle = useCallback(
     ({ pressed, hovered = false }: PressableStateCallbackType & { hovered?: boolean }) => [
       styles.comboboxItem,
-      Boolean(hovered) &&
-        (elevated ? styles.comboboxItemHoveredElevated : styles.comboboxItemHovered),
+      hovered && (elevated ? styles.comboboxItemHoveredElevated : styles.comboboxItemHovered),
       pressed && (elevated ? styles.comboboxItemPressedElevated : styles.comboboxItemPressed),
       active && styles.comboboxItemActive,
       disabled && styles.comboboxItemDisabled,

--- a/packages/app/src/components/ui/dropdown-menu.tsx
+++ b/packages/app/src/components/ui/dropdown-menu.tsx
@@ -86,7 +86,7 @@ function useControllableOpenState({
 }): [boolean, (next: boolean) => void] {
   const [internalOpen, setInternalOpen] = useState(Boolean(defaultOpen));
   const isControlled = typeof open === "boolean";
-  const value = isControlled ? Boolean(open) : internalOpen;
+  const value = isControlled ? open : internalOpen;
   const setValue = useCallback(
     (next: boolean) => {
       if (!isControlled) setInternalOpen(next);
@@ -748,12 +748,12 @@ export function DropdownMenuItem({
       return [
         styles.item,
         selectedStyle,
-        selected && (Boolean(hovered) || pressed) && selectedVariant !== "accent"
+        selected && (hovered || pressed) && selectedVariant !== "accent"
           ? styles.itemSelectedInteractive
           : null,
         isDisabled ? styles.itemDisabled : null,
         muted && !isDisabled ? styles.itemMuted : null,
-        Boolean(hovered) && !pressed && !isDisabled ? styles.itemHovered : null,
+        hovered && !pressed && !isDisabled ? styles.itemHovered : null,
         pressed && !isDisabled ? styles.itemPressed : null,
       ];
     },

--- a/packages/app/src/components/ui/tooltip.tsx
+++ b/packages/app/src/components/ui/tooltip.tsx
@@ -113,7 +113,7 @@ function useControllableOpenState({
 }): [boolean, (next: boolean) => void] {
   const [internalOpen, setInternalOpen] = useState(Boolean(defaultOpen));
   const isControlled = typeof open === "boolean";
-  const value = isControlled ? Boolean(open) : internalOpen;
+  const value = isControlled ? open : internalOpen;
   const setValue = useCallback(
     (next: boolean) => {
       if (!isControlled) setInternalOpen(next);

--- a/packages/app/src/polyfills/crypto.ts
+++ b/packages/app/src/polyfills/crypto.ts
@@ -21,7 +21,7 @@ export function polyfillCrypto(): void {
   if (typeof g.TextEncoder !== "function") {
     class BufferTextEncoder {
       encode(input = ""): Uint8Array {
-        return Uint8Array.from(Buffer.from(String(input), "utf8"));
+        return Uint8Array.from(Buffer.from(input, "utf8"));
       }
     }
     g.TextEncoder = BufferTextEncoder as unknown as typeof TextEncoder;

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -130,8 +130,8 @@ export function normalizeWorkspaceDescriptor(
   payload: WorkspaceDescriptorPayload,
 ): WorkspaceDescriptor {
   return {
-    id: normalizeWorkspaceOpaqueId(String(payload.id)) ?? String(payload.id),
-    projectId: String(payload.projectId),
+    id: normalizeWorkspaceOpaqueId(payload.id) ?? payload.id,
+    projectId: payload.projectId,
     projectDisplayName: payload.projectDisplayName,
     projectRootPath: payload.projectRootPath,
     workspaceDirectory: payload.workspaceDirectory,

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -514,7 +514,7 @@ function appendTodoList(
 ): StreamItem[] {
   const normalizedItems = items.map((item) => ({
     text: item.text,
-    completed: Boolean(item.completed),
+    completed: item.completed,
   }));
 
   const lastItem = state[state.length - 1];
@@ -658,7 +658,7 @@ function reduceTimelineEvent(
       }
       const items: TodoEntry[] = (item.items ?? []).map((todo) => ({
         text: todo.text,
-        completed: Boolean(todo.completed),
+        completed: todo.completed,
       }));
       return finalizeActiveThoughts(appendTodoList(state, event.provider, items, timestamp));
     }


### PR DESCRIPTION
## Summary
- Remove unnecessary `String()` conversions on values already typed as string
- Remove unnecessary `Boolean()` conversions on values already typed as boolean
- Values from Zod schemas are already properly typed, making these conversions redundant

## Cluster
- Rule: `no-unnecessary-type-conversion`
- 18 errors fixed across 14 files
- All in `packages/app` (non-test and e2e test files)

## Root cause
Type-aware linting revealed that many `String()` and `Boolean()` conversions were added defensively before strict typing was in place. Values coming from Zod schema validation are already correctly typed, making these runtime conversions redundant.

## Why this is correct beyond satisfying the linter
1. **Type safety**: The conversions were giving a false sense of runtime safety - the types were already guaranteed by Zod
2. **Cleaner code**: Removing redundant calls improves readability
3. **Consistency**: Other parts of the codebase already use the values directly without conversion

## Test plan
- [x] typecheck green
- [x] lint green (typeAware false in committed state)
- [x] no overlap with off-limits set (my own open typeaware PR #695 + PRs <24h)