### PR TITLE
fix(server): derive non-GitHub project display names from remote

### DIFF
--- a/packages/server/src/server/workspace-git-metadata.test.ts
+++ b/packages/server/src/server/workspace-git-metadata.test.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
-import { deriveProjectSlug, parseGitHubRepoNameFromRemote } from "./workspace-git-metadata.js";
+import {
+  buildWorkspaceGitMetadataFromSnapshot,
+  deriveProjectSlug,
+  parseGitHubRepoNameFromRemote,
+} from "./workspace-git-metadata.js";
 
 function runGit(cwd: string, args: string[]): void {
   execFileSync("git", args, {
@@ -164,5 +168,49 @@ describe("deriveProjectSlug", () => {
     mkdirSync(cwd);
 
     expect(deriveProjectSlug(cwd)).toBe("untitled");
+  });
+});
+
+describe("buildWorkspaceGitMetadataFromSnapshot", () => {
+  test("uses owner/repo as the display name for GitHub remotes", () => {
+    const result = buildWorkspaceGitMetadataFromSnapshot({
+      cwd: "/repos/some-dir",
+      directoryName: "some-dir",
+      isGit: true,
+      repoRoot: "/repos/some-dir",
+      mainRepoRoot: null,
+      currentBranch: "main",
+      remoteUrl: "git@github.com:acme/widgets.git",
+    });
+
+    expect(result.projectDisplayName).toBe("acme/widgets");
+  });
+
+  test("uses owner/repo as the display name for non-GitHub remotes", () => {
+    const result = buildWorkspaceGitMetadataFromSnapshot({
+      cwd: "/repos/random-name",
+      directoryName: "random-name",
+      isGit: true,
+      repoRoot: "/repos/random-name",
+      mainRepoRoot: null,
+      currentBranch: "main",
+      remoteUrl: "git@gitlab.com:acme/app.git",
+    });
+
+    expect(result.projectDisplayName).toBe("acme/app");
+  });
+
+  test("falls back to the directory name when there is no remote", () => {
+    const result = buildWorkspaceGitMetadataFromSnapshot({
+      cwd: "/repos/local-only",
+      directoryName: "local-only",
+      isGit: true,
+      repoRoot: "/repos/local-only",
+      mainRepoRoot: null,
+      currentBranch: "main",
+      remoteUrl: null,
+    });
+
+    expect(result.projectDisplayName).toBe("local-only");
   });
 });

--- a/packages/server/src/server/workspace-git-metadata.ts
+++ b/packages/server/src/server/workspace-git-metadata.ts
@@ -1,6 +1,7 @@
 import { basename } from "path";
 import { parseGitHubRemoteUrl } from "../utils/github-remote.js";
 import { slugify } from "../utils/worktree.js";
+import { deriveProjectGroupingKey, deriveProjectGroupingName } from "./workspace-registry-model.js";
 
 export interface WorkspaceGitMetadata {
   projectKind: "git" | "directory";
@@ -57,13 +58,20 @@ export function buildWorkspaceGitMetadataFromSnapshot(input: {
     };
   }
 
-  const githubRepo = input.remoteUrl ? parseGitHubRepoFromRemote(input.remoteUrl) : null;
   const isWorktree =
     input.mainRepoRoot !== null && input.repoRoot !== null && input.mainRepoRoot !== input.repoRoot;
+  const projectKey = deriveProjectGroupingKey({
+    cwd: input.repoRoot ?? input.cwd,
+    remoteUrl: input.remoteUrl,
+    mainRepoRoot: input.mainRepoRoot,
+  });
+  const projectDisplayName = projectKey.startsWith("remote:")
+    ? deriveProjectGroupingName(projectKey)
+    : input.directoryName;
 
   return {
     projectKind: "git",
-    projectDisplayName: githubRepo ?? input.directoryName,
+    projectDisplayName,
     workspaceDisplayName: input.currentBranch ?? input.directoryName,
     gitRemote: input.remoteUrl,
     isWorktree,


### PR DESCRIPTION
## Summary

- E2E `projects-settings.spec.ts:140` ("user edits worktree setup on a non-GitHub remote project") was failing because the projects screen showed the directory name (e.g. `projects-settings-gitlab-4JFEW9`) instead of `acme/app`.
- Root cause: `buildWorkspaceGitMetadataFromSnapshot` only derived `projectDisplayName` from GitHub remotes. After the daemon initially set `displayName = "acme/app"` via the registry pipeline, background reconciliation re-read the metadata via this GitHub-only path and overwrote it with the directory name.
- Fix: reuse `deriveProjectGroupingKey` + `deriveProjectGroupingName` from `workspace-registry-model.ts` so both layers agree on the owner/repo for any host with a parseable remote, falling back to the caller's directory name otherwise.

## Test plan

- [x] `npx vitest run src/server/workspace-git-metadata.test.ts` — 28 passed (added regression cases for GitHub, non-GitHub, and no-remote)
- [x] `npx vitest run src/server/workspace-reconciliation-service.test.ts` — 7 passed
- [x] `npx playwright test e2e/projects-settings.spec.ts` — 2 passed (was failing on `:140` before)
- [x] `npx playwright test e2e/sidebar-workspace.spec.ts e2e/new-workspace.spec.ts e2e/workspace-cwd.spec.ts` — 13 passed
- [x] `npm run typecheck` clean
- [x] CI Playwright suite