### PR TITLE
test(app): tighten weak assertions in utils tests

### DIFF
--- a/packages/app/src/utils/diff-highlighter.test.ts
+++ b/packages/app/src/utils/diff-highlighter.test.ts
@@ -285,18 +285,12 @@ describe("highlightDiffFile", () => {
 
     // First content line: "const foo = 1;"
     const constLine = hunk.lines[1];
-    expect(constLine.tokens).toBeDefined();
-    expect(constLine.tokens!.length).toBeGreaterThan(0);
-
-    // Should have a "keyword" token for "const"
-    const constToken = constLine.tokens!.find((t) => t.text === "const");
-    expect(constToken).toBeDefined();
-    expect(constToken!.style).toBe("keyword");
-
-    // Should have a "number" token for "1"
-    const numberToken = constLine.tokens!.find((t) => t.text === "1");
-    expect(numberToken).toBeDefined();
-    expect(numberToken!.style).toBe("number");
+    expect(constLine.tokens).toContainEqual(
+      expect.objectContaining({ text: "const", style: "keyword" }),
+    );
+    expect(constLine.tokens).toContainEqual(
+      expect.objectContaining({ text: "1", style: "number" }),
+    );
   });
 
   it("highlights both added and removed lines correctly", () => {
@@ -306,15 +300,15 @@ describe("highlightDiffFile", () => {
 
     // Removed line: "const bar = 2;"
     const removedLine = hunk.lines.find((l) => l.type === "remove" && l.content.includes("bar"));
-    expect(removedLine?.tokens).toBeDefined();
-    const removedNumber = removedLine!.tokens!.find((t) => t.text === "2");
-    expect(removedNumber?.style).toBe("number");
+    expect(removedLine?.tokens).toContainEqual(
+      expect.objectContaining({ text: "2", style: "number" }),
+    );
 
     // Added line: "const bar = 3;"
     const addedLine = hunk.lines.find((l) => l.type === "add" && l.content.includes("bar"));
-    expect(addedLine?.tokens).toBeDefined();
-    const addedNumber = addedLine!.tokens!.find((t) => t.text === "3");
-    expect(addedNumber?.style).toBe("number");
+    expect(addedLine?.tokens).toContainEqual(
+      expect.objectContaining({ text: "3", style: "number" }),
+    );
   });
 
   it("does not modify unsupported file types", () => {
@@ -351,15 +345,16 @@ describe("highlightDiffFile", () => {
     const highlighted = highlightDiffFile(files[0]);
     const hunk = highlighted.hunks[0];
 
-    const fnLine = hunk.lines[1];
-    expect(fnLine.tokens).toBeDefined();
-    expect(fnLine.tokens!.some((t) => t.text === "fn" && t.style === "keyword")).toBe(true);
+    expect(hunk.lines[1].tokens).toContainEqual(
+      expect.objectContaining({ text: "fn", style: "keyword" }),
+    );
 
     const addedLine = hunk.lines.find(
       (line) => line.type === "add" && line.content.includes("version"),
     );
-    expect(addedLine?.tokens).toBeDefined();
-    expect(addedLine!.tokens!.some((t) => t.text === "2" && t.style === "number")).toBe(true);
+    expect(addedLine?.tokens).toContainEqual(
+      expect.objectContaining({ text: "2", style: "number" }),
+    );
   });
 
   it("adds syntax highlighting tokens to C code", () => {
@@ -367,15 +362,14 @@ describe("highlightDiffFile", () => {
     const highlighted = highlightDiffFile(files[0]);
     const hunk = highlighted.hunks[0];
 
-    const mainLine = hunk.lines[1];
-    expect(mainLine.tokens).toBeDefined();
-    expect(mainLine.tokens!.length).toBeGreaterThan(0);
+    expect(hunk.lines[1].tokens?.length).toBeGreaterThan(0);
 
     const addedLine = hunk.lines.find(
       (line) => line.type === "add" && line.content.includes("version"),
     );
-    expect(addedLine?.tokens).toBeDefined();
-    expect(addedLine!.tokens!.some((t) => t.text === "2" && t.style === "number")).toBe(true);
+    expect(addedLine?.tokens).toContainEqual(
+      expect.objectContaining({ text: "2", style: "number" }),
+    );
   });
 
   it("adds syntax highlighting tokens to Java code", () => {
@@ -383,15 +377,16 @@ describe("highlightDiffFile", () => {
     const highlighted = highlightDiffFile(files[0]);
     const hunk = highlighted.hunks[0];
 
-    const classLine = hunk.lines[1];
-    expect(classLine.tokens).toBeDefined();
-    expect(classLine.tokens!.some((t) => t.text === "public" && t.style === "keyword")).toBe(true);
+    expect(hunk.lines[1].tokens).toContainEqual(
+      expect.objectContaining({ text: "public", style: "keyword" }),
+    );
 
     const addedLine = hunk.lines.find(
       (line) => line.type === "add" && line.content.includes("version"),
     );
-    expect(addedLine?.tokens).toBeDefined();
-    expect(addedLine!.tokens!.some((t) => t.text === "2" && t.style === "number")).toBe(true);
+    expect(addedLine?.tokens).toContainEqual(
+      expect.objectContaining({ text: "2", style: "number" }),
+    );
   });
 
   it("adds syntax highlighting tokens to Objective-C file extensions", () => {
@@ -402,8 +397,9 @@ describe("highlightDiffFile", () => {
     const addedLine = hunk.lines.find(
       (line) => line.type === "add" && line.content.includes("version"),
     );
-    expect(addedLine?.tokens).toBeDefined();
-    expect(addedLine!.tokens!.some((t) => t.text === "2" && t.style === "number")).toBe(true);
+    expect(addedLine?.tokens).toContainEqual(
+      expect.objectContaining({ text: "2", style: "number" }),
+    );
   });
 
   it("adds syntax highlighting tokens to Go code", () => {
@@ -413,8 +409,9 @@ describe("highlightDiffFile", () => {
       (line) => line.type === "add" && line.content.includes("version"),
     );
 
-    expect(addedLine?.tokens).toBeDefined();
-    expect(addedLine!.tokens!.some((t) => t.text === "2" && t.style === "number")).toBe(true);
+    expect(addedLine?.tokens).toContainEqual(
+      expect.objectContaining({ text: "2", style: "number" }),
+    );
   });
 
   it("adds syntax highlighting tokens to PHP code", () => {
@@ -424,8 +421,9 @@ describe("highlightDiffFile", () => {
       (line) => line.type === "add" && line.content.includes("$version"),
     );
 
-    expect(addedLine?.tokens).toBeDefined();
-    expect(addedLine!.tokens!.some((t) => t.text === "2" && t.style === "number")).toBe(true);
+    expect(addedLine?.tokens).toContainEqual(
+      expect.objectContaining({ text: "2", style: "number" }),
+    );
   });
 
   it("adds syntax highlighting tokens to YAML code", () => {
@@ -435,8 +433,7 @@ describe("highlightDiffFile", () => {
       (line) => line.type === "add" && line.content.includes("count"),
     );
 
-    expect(addedLine?.tokens).toBeDefined();
-    expect(addedLine!.tokens!.length).toBeGreaterThan(0);
+    expect(addedLine?.tokens?.length).toBeGreaterThan(0);
   });
 
   it("adds syntax highlighting tokens to XML code", () => {
@@ -446,8 +443,7 @@ describe("highlightDiffFile", () => {
       (line) => line.type === "add" && line.content.includes("<count>"),
     );
 
-    expect(addedLine?.tokens).toBeDefined();
-    expect(addedLine!.tokens!.some((t) => t.style === "tag")).toBe(true);
+    expect(addedLine?.tokens).toContainEqual(expect.objectContaining({ style: "tag" }));
   });
 });
 
@@ -456,7 +452,9 @@ describe("parseAndHighlightDiff", () => {
     const files = parseAndHighlightDiff(SIMPLE_DIFF);
 
     expect(files).toHaveLength(1);
-    expect(files[0].hunks[0].lines[1].tokens).toBeDefined();
+    expect(files[0].hunks[0].lines[1].tokens).toContainEqual(
+      expect.objectContaining({ text: "const", style: "keyword" }),
+    );
   });
 
   it("handles multiple files", () => {

--- a/packages/app/src/utils/project-config-form.test.ts
+++ b/packages/app/src/utils/project-config-form.test.ts
@@ -49,7 +49,7 @@ describe("configToDraft", () => {
     expect(devRow.commandOriginalKind).toBe("string");
     expect(devRow.type).toBe("long-running");
     expect(devRow.portText).toBe("3000");
-    expect(devRow.id).toBeTruthy();
+    expect(devRow.id).toMatch(/^script-draft-\d+$/);
     expect(buildRow.name).toBe("build");
     expect(buildRow.commandText).toBe("npm\nrun\nbuild");
     expect(buildRow.commandOriginalKind).toBe("array");


### PR DESCRIPTION
## Summary

- Replace `toBeDefined()` / `toBeTruthy()` guards with concrete shape assertions in `packages/app/src/utils/diff-highlighter.test.ts` and `packages/app/src/utils/project-config-form.test.ts`
- Token presence checks collapsed from find+toBeDefined+style into `toContainEqual(expect.objectContaining({ text, style }))`
- ID check tightened from `toBeTruthy()` to `toMatch(/^script-draft-\d+$/)` matching the actual format from the source

## Test plan

- [ ] `npx vitest run packages/app/src/utils/diff-highlighter.test.ts packages/app/src/utils/project-config-form.test.ts` — 36 tests pass
- [ ] typecheck, lint, format — all green (verified via pre-commit hooks)