### PR TITLE
feat(app/e2e): add PR pane E2E spec with fixture-based seeding

### DIFF
--- a/packages/app/e2e/global-setup.ts
+++ b/packages/app/e2e/global-setup.ts
@@ -215,7 +215,27 @@ async function createFakeGhBin(): Promise<string> {
   await writeFile(
     ghPath,
     `#!/usr/bin/env node
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
 const args = process.argv.slice(2);
+
+function findRealGh() {
+  const fakeBinDir = __dirname;
+  for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+    if (dir === fakeBinDir) continue;
+    const candidate = path.join(dir, "gh");
+    try { fs.accessSync(candidate, fs.constants.X_OK); return candidate; } catch {}
+  }
+  return null;
+}
+
+function forwardToRealGh() {
+  const realGh = findRealGh();
+  if (!realGh) { console.error("[fake-gh] real gh not found in PATH"); process.exit(1); }
+  const result = spawnSync(realGh, process.argv.slice(2), { stdio: "inherit", env: process.env });
+  process.exit(result.status ?? 1);
+}
 
 if (args[0] === "auth" && args[1] === "status") {
   process.exit(0);
@@ -237,17 +257,13 @@ if (args[0] === "pr" && args[1] === "list") {
   process.exit(0);
 }
 
-const fs = require("fs");
-const path = require("path");
-
 if (args[0] === "pr" && args[1] === "view" && args[2] === "--json" && args[3]) {
   const fixture = path.join(process.cwd(), ".paseo-e2e-pr.json");
   if (fs.existsSync(fixture)) {
     console.log(fs.readFileSync(fixture, "utf8"));
     process.exit(0);
   }
-  console.error("no pull requests found for branch");
-  process.exit(1);
+  forwardToRealGh();
 }
 
 if (args[0] === "api" && args[1] === "graphql") {
@@ -256,17 +272,7 @@ if (args[0] === "api" && args[1] === "graphql") {
     console.log(fs.readFileSync(fixture, "utf8"));
     process.exit(0);
   }
-  console.log(JSON.stringify({
-    data: {
-      repository: {
-        pullRequest: {
-          reviews: { nodes: [], pageInfo: { hasNextPage: false } },
-          comments: { nodes: [], pageInfo: { hasNextPage: false } },
-        },
-      },
-    },
-  }));
-  process.exit(0);
+  forwardToRealGh();
 }
 
 if (args[0] === "issue" && args[1] === "list") {
@@ -274,8 +280,7 @@ if (args[0] === "issue" && args[1] === "list") {
   process.exit(0);
 }
 
-console.error("Unsupported fake gh invocation: " + args.join(" "));
-process.exit(1);
+forwardToRealGh();
 `,
   );
   await chmod(ghPath, 0o755);

--- a/packages/app/e2e/global-setup.ts
+++ b/packages/app/e2e/global-setup.ts
@@ -237,9 +237,36 @@ if (args[0] === "pr" && args[1] === "list") {
   process.exit(0);
 }
 
+const fs = require("fs");
+const path = require("path");
+
 if (args[0] === "pr" && args[1] === "view" && args[2] === "--json" && args[3]) {
+  const fixture = path.join(process.cwd(), ".paseo-e2e-pr.json");
+  if (fs.existsSync(fixture)) {
+    console.log(fs.readFileSync(fixture, "utf8"));
+    process.exit(0);
+  }
   console.error("no pull requests found for branch");
   process.exit(1);
+}
+
+if (args[0] === "api" && args[1] === "graphql") {
+  const fixture = path.join(process.cwd(), ".paseo-e2e-timeline.json");
+  if (fs.existsSync(fixture)) {
+    console.log(fs.readFileSync(fixture, "utf8"));
+    process.exit(0);
+  }
+  console.log(JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviews: { nodes: [], pageInfo: { hasNextPage: false } },
+          comments: { nodes: [], pageInfo: { hasNextPage: false } },
+        },
+      },
+    },
+  }));
+  process.exit(0);
 }
 
 if (args[0] === "issue" && args[1] === "list") {

--- a/packages/app/e2e/helpers/github-fixtures.ts
+++ b/packages/app/e2e/helpers/github-fixtures.ts
@@ -23,6 +23,13 @@ export interface PrSpec {
   commentCount?: number;
 }
 
+export interface IssueSpec {
+  title: string;
+  body?: string;
+  labels?: string[];
+  state?: "open" | "closed";
+}
+
 export interface GhPrFixture {
   number: number;
   title: string;
@@ -31,11 +38,18 @@ export interface GhPrFixture {
   localPath: string;
 }
 
+export interface GhIssueFixture {
+  number: number;
+  title: string;
+  url: string;
+}
+
 export interface GhRepoFixture {
   owner: string;
   name: string;
   fullName: string;
   prs: GhPrFixture[];
+  issues: GhIssueFixture[];
   cleanup(): Promise<void>;
 }
 
@@ -55,11 +69,96 @@ function git(args: string[], cwd: string): string {
   }).trim();
 }
 
+async function seedPr(args: {
+  spec: PrSpec;
+  branch: string;
+  index: number;
+  basePath: string;
+  authedUrl: string;
+  fullName: string;
+  repoName: string;
+}): Promise<{ fixture: GhPrFixture; localPath: string }> {
+  const { spec, branch, index, basePath, authedUrl, fullName, repoName } = args;
+
+  const createArgs = [
+    "pr",
+    "create",
+    "--title",
+    spec.title,
+    "--base",
+    "main",
+    "--head",
+    branch,
+    "--body",
+    "",
+  ];
+  if (spec.state === "draft") createArgs.push("--draft");
+
+  const prUrl = gh(createArgs, { cwd: basePath });
+  const prNumber = parseInt(prUrl.split("/").pop() ?? "0", 10);
+
+  if (spec.checks && spec.checks.length > 0) {
+    const sha = git(["rev-parse", branch], basePath);
+    for (const check of spec.checks) {
+      gh([
+        "api",
+        `repos/${fullName}/statuses/${sha}`,
+        "--method",
+        "POST",
+        "-f",
+        `state=${check.state}`,
+        "-f",
+        `context=${check.context}`,
+        "-f",
+        `target_url=https://example.com/${encodeURIComponent(check.context)}`,
+      ]);
+    }
+  }
+
+  for (let j = 0; j < (spec.commentCount ?? 0); j++) {
+    gh(["pr", "comment", String(prNumber), "--body", `Test comment ${j + 1}`], { cwd: basePath });
+  }
+
+  if (spec.state === "merged") {
+    gh(["pr", "merge", String(prNumber), "--merge"], { cwd: basePath });
+  } else if (spec.state === "closed") {
+    gh(["pr", "close", String(prNumber)], { cwd: basePath });
+  }
+
+  const localPath = await mkdtemp(path.join("/tmp", `${repoName}-ws-${index}-`));
+  git(["clone", authedUrl, localPath, "--quiet", "-b", branch], basePath);
+  // Clean remote URL (no embedded token) so gh can parse owner/repo
+  git(["remote", "set-url", "origin", `https://github.com/${fullName}.git`], localPath);
+  git(["config", "user.email", "e2e@paseo.test"], localPath);
+  git(["config", "user.name", "Paseo E2E"], localPath);
+  git(["config", "commit.gpgsign", "false"], localPath);
+
+  return {
+    fixture: { number: prNumber, title: spec.title, url: prUrl, branch, localPath },
+    localPath,
+  };
+}
+
+function seedIssue(args: { spec: IssueSpec; basePath: string }): GhIssueFixture {
+  const { spec, basePath } = args;
+  const createArgs = ["issue", "create", "--title", spec.title, "--body", spec.body ?? ""];
+  for (const label of spec.labels ?? []) {
+    createArgs.push("--label", label);
+  }
+  const issueUrl = gh(createArgs, { cwd: basePath });
+  const issueNumber = parseInt(issueUrl.split("/").pop() ?? "0", 10);
+  if (spec.state === "closed") {
+    gh(["issue", "close", String(issueNumber)], { cwd: basePath });
+  }
+  return { number: issueNumber, title: spec.title, url: issueUrl };
+}
+
 export async function createTempGithubRepo(options: {
   prefix?: string;
-  prs: PrSpec[];
+  prs?: PrSpec[];
+  issues?: IssueSpec[];
 }): Promise<GhRepoFixture> {
-  const { prefix = "paseo-e2e-", prs } = options;
+  const { prefix = "paseo-e2e-", prs = [], issues = [] } = options;
   const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
   const repoName = `${prefix}${uniqueSuffix}`;
 
@@ -96,80 +195,32 @@ export async function createTempGithubRepo(options: {
     git(["checkout", "main"], basePath);
   }
 
-  // Push all branches in one shot
-  git(["push", "origin", ...branches], basePath);
+  if (branches.length > 0) {
+    git(["push", "origin", ...branches], basePath);
+  }
 
-  // Create PRs, seed checks/comments, apply state changes, clone workspace
+  // Create PRs, seed checks/comments, apply state changes, clone workspaces
   const prFixtures: GhPrFixture[] = [];
   const localPaths: string[] = [];
 
   for (let i = 0; i < prs.length; i++) {
-    const spec = prs[i];
-    const branch = branches[i];
-
-    const createArgs = [
-      "pr",
-      "create",
-      "--title",
-      spec.title,
-      "--base",
-      "main",
-      "--head",
-      branch,
-      "--body",
-      "",
-    ];
-    if (spec.state === "draft") createArgs.push("--draft");
-
-    const prUrl = gh(createArgs, { cwd: basePath });
-    const prNumber = parseInt(prUrl.split("/").pop() ?? "0", 10);
-
-    // Commit statuses for check pills
-    if (spec.checks && spec.checks.length > 0) {
-      const sha = git(["rev-parse", branch], basePath);
-      for (const check of spec.checks) {
-        gh([
-          "api",
-          `repos/${fullName}/statuses/${sha}`,
-          "--method",
-          "POST",
-          "-f",
-          `state=${check.state}`,
-          "-f",
-          `context=${check.context}`,
-          "-f",
-          `target_url=https://example.com/${encodeURIComponent(check.context)}`,
-        ]);
-      }
-    }
-
-    // PR comments for activity rows
-    if (spec.commentCount && spec.commentCount > 0) {
-      for (let j = 0; j < spec.commentCount; j++) {
-        gh(["pr", "comment", String(prNumber), "--body", `Test comment ${j + 1}`], {
-          cwd: basePath,
-        });
-      }
-    }
-
-    // Apply PR state
-    if (spec.state === "merged") {
-      gh(["pr", "merge", String(prNumber), "--merge"], { cwd: basePath });
-    } else if (spec.state === "closed") {
-      gh(["pr", "close", String(prNumber)], { cwd: basePath });
-    }
-
-    // Clone to a fresh workspace dir on the right branch
-    const localPath = await mkdtemp(path.join("/tmp", `${repoName}-ws-${i}-`));
-    git(["clone", authedUrl, localPath, "--quiet", "-b", branch], basePath);
-    // Store a clean remote URL (no embedded token) so gh can parse it
-    git(["remote", "set-url", "origin", `https://github.com/${fullName}.git`], localPath);
-    git(["config", "user.email", "e2e@paseo.test"], localPath);
-    git(["config", "user.name", "Paseo E2E"], localPath);
-    git(["config", "commit.gpgsign", "false"], localPath);
-
+    const { fixture, localPath } = await seedPr({
+      spec: prs[i],
+      branch: branches[i],
+      index: i,
+      basePath,
+      authedUrl,
+      fullName,
+      repoName,
+    });
     localPaths.push(localPath);
-    prFixtures.push({ number: prNumber, title: spec.title, url: prUrl, branch, localPath });
+    prFixtures.push(fixture);
+  }
+
+  // Create issues
+  const issueFixtures: GhIssueFixture[] = [];
+  for (const spec of issues) {
+    issueFixtures.push(seedIssue({ spec, basePath }));
   }
 
   return {
@@ -177,6 +228,7 @@ export async function createTempGithubRepo(options: {
     name: repoName,
     fullName,
     prs: prFixtures,
+    issues: issueFixtures,
     cleanup: async () => {
       try {
         gh(["repo", "delete", fullName, "--yes"]);

--- a/packages/app/e2e/helpers/github-fixtures.ts
+++ b/packages/app/e2e/helpers/github-fixtures.ts
@@ -1,0 +1,192 @@
+import { execFileSync, execSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export function hasGithubAuth(): boolean {
+  try {
+    execSync("gh auth status", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface CheckSpec {
+  context: string;
+  state: "success" | "failure" | "pending";
+}
+
+export interface PrSpec {
+  title: string;
+  state: "open" | "merged" | "closed" | "draft";
+  checks?: CheckSpec[];
+  commentCount?: number;
+}
+
+export interface GhPrFixture {
+  number: number;
+  title: string;
+  url: string;
+  branch: string;
+  localPath: string;
+}
+
+export interface GhRepoFixture {
+  owner: string;
+  name: string;
+  fullName: string;
+  prs: GhPrFixture[];
+  cleanup(): Promise<void>;
+}
+
+function gh(args: string[], opts?: { cwd?: string }): string {
+  return execFileSync("gh", args, {
+    cwd: opts?.cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+export async function createTempGithubRepo(options: {
+  prefix?: string;
+  prs: PrSpec[];
+}): Promise<GhRepoFixture> {
+  const { prefix = "paseo-e2e-", prs } = options;
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const repoName = `${prefix}${uniqueSuffix}`;
+
+  // Bootstrap local git repo
+  const basePath = await mkdtemp(path.join("/tmp", `${repoName}-base-`));
+  git(["init", "-b", "main"], basePath);
+  git(["config", "user.email", "e2e@paseo.test"], basePath);
+  git(["config", "user.name", "Paseo E2E"], basePath);
+  git(["config", "commit.gpgsign", "false"], basePath);
+  await writeFile(path.join(basePath, "README.md"), "# E2E Test Repo\n");
+  git(["add", "README.md"], basePath);
+  git(["commit", "-m", "Initial commit"], basePath);
+
+  // Create GitHub repo and push initial commit
+  gh(["repo", "create", repoName, "--private", `--source=${basePath}`, "--push"]);
+
+  const owner = gh(["api", "user", "--jq", ".login"]);
+  const fullName = `${owner}/${repoName}`;
+  const token = gh(["auth", "token"]);
+  const authedUrl = `https://x-access-token:${token}@github.com/${fullName}.git`;
+
+  // Switch remote to authed URL for subsequent pushes
+  git(["remote", "set-url", "origin", authedUrl], basePath);
+
+  // Create a branch + commit for each PR spec
+  const branches: string[] = [];
+  for (let i = 0; i < prs.length; i++) {
+    const branch = `pr-branch-${i + 1}`;
+    branches.push(branch);
+    git(["checkout", "-b", branch], basePath);
+    await writeFile(path.join(basePath, `pr-${i + 1}.txt`), `PR ${i + 1}\n`);
+    git(["add", `pr-${i + 1}.txt`], basePath);
+    git(["commit", "-m", `Add PR ${i + 1}`], basePath);
+    git(["checkout", "main"], basePath);
+  }
+
+  // Push all branches in one shot
+  git(["push", "origin", ...branches], basePath);
+
+  // Create PRs, seed checks/comments, apply state changes, clone workspace
+  const prFixtures: GhPrFixture[] = [];
+  const localPaths: string[] = [];
+
+  for (let i = 0; i < prs.length; i++) {
+    const spec = prs[i];
+    const branch = branches[i];
+
+    const createArgs = [
+      "pr",
+      "create",
+      "--title",
+      spec.title,
+      "--base",
+      "main",
+      "--head",
+      branch,
+      "--body",
+      "",
+    ];
+    if (spec.state === "draft") createArgs.push("--draft");
+
+    const prUrl = gh(createArgs, { cwd: basePath });
+    const prNumber = parseInt(prUrl.split("/").pop() ?? "0", 10);
+
+    // Commit statuses for check pills
+    if (spec.checks && spec.checks.length > 0) {
+      const sha = git(["rev-parse", branch], basePath);
+      for (const check of spec.checks) {
+        gh([
+          "api",
+          `repos/${fullName}/statuses/${sha}`,
+          "--method",
+          "POST",
+          "-f",
+          `state=${check.state}`,
+          "-f",
+          `context=${check.context}`,
+          "-f",
+          `target_url=https://example.com/${encodeURIComponent(check.context)}`,
+        ]);
+      }
+    }
+
+    // PR comments for activity rows
+    if (spec.commentCount && spec.commentCount > 0) {
+      for (let j = 0; j < spec.commentCount; j++) {
+        gh(["pr", "comment", String(prNumber), "--body", `Test comment ${j + 1}`], {
+          cwd: basePath,
+        });
+      }
+    }
+
+    // Apply PR state
+    if (spec.state === "merged") {
+      gh(["pr", "merge", String(prNumber), "--merge"], { cwd: basePath });
+    } else if (spec.state === "closed") {
+      gh(["pr", "close", String(prNumber)], { cwd: basePath });
+    }
+
+    // Clone to a fresh workspace dir on the right branch
+    const localPath = await mkdtemp(path.join("/tmp", `${repoName}-ws-${i}-`));
+    git(["clone", authedUrl, localPath, "--quiet", "-b", branch], basePath);
+    // Store a clean remote URL (no embedded token) so gh can parse it
+    git(["remote", "set-url", "origin", `https://github.com/${fullName}.git`], localPath);
+    git(["config", "user.email", "e2e@paseo.test"], localPath);
+    git(["config", "user.name", "Paseo E2E"], localPath);
+    git(["config", "commit.gpgsign", "false"], localPath);
+
+    localPaths.push(localPath);
+    prFixtures.push({ number: prNumber, title: spec.title, url: prUrl, branch, localPath });
+  }
+
+  return {
+    owner,
+    name: repoName,
+    fullName,
+    prs: prFixtures,
+    cleanup: async () => {
+      try {
+        gh(["repo", "delete", fullName, "--yes"]);
+      } catch {
+        // Best-effort cleanup
+      }
+      await Promise.all([
+        rm(basePath, { recursive: true, force: true }),
+        ...localPaths.map((p) => rm(p, { recursive: true, force: true })),
+      ]);
+    },
+  };
+}

--- a/packages/app/e2e/helpers/pr-pane.ts
+++ b/packages/app/e2e/helpers/pr-pane.ts
@@ -1,8 +1,8 @@
 import { expect, type Page } from "@playwright/test";
+import { getStateLabel } from "@/utils/pr-pane-data";
 
 export async function openPrPane(page: Page): Promise<void> {
-  await page.getByRole("button", { name: "Open explorer" }).first().click();
-  await expect(page.getByTestId("explorer-tab-pr")).toBeVisible({ timeout: 30_000 });
+  await page.getByRole("button", { name: "Open explorer" }).click();
   await page.getByTestId("explorer-tab-pr").click();
   await expect(page.getByTestId("pr-pane")).toBeVisible({ timeout: 15_000 });
 }
@@ -11,47 +11,30 @@ export async function expectPrPaneTitle(page: Page, title: string): Promise<void
   await expect(page.getByTestId("pr-pane-title")).toContainText(title, { timeout: 15_000 });
 }
 
-const STATE_LABELS: Record<string, string> = {
-  open: "Open",
-  merged: "Merged",
-  closed: "Closed",
-  draft: "Draft",
-};
-
 export async function expectPrPaneState(
   page: Page,
   state: "open" | "merged" | "closed" | "draft",
 ): Promise<void> {
-  await expect(page.getByTestId("pr-pane-state")).toHaveText(STATE_LABELS[state], {
+  await expect(page.getByTestId("pr-pane-state")).toHaveText(getStateLabel(state), {
     timeout: 15_000,
   });
+}
+
+async function assertCheckPill(page: Page, testId: string, count: number): Promise<void> {
+  const locator = page.getByTestId(testId);
+  await expect(locator).toHaveCount(count > 0 ? 1 : 0, { timeout: 15_000 });
+  if (count > 0) {
+    await expect(locator).toContainText(String(count));
+  }
 }
 
 export async function expectPrPaneCheckSummary(
   page: Page,
   counts: { passed: number; failed: number; pending: number },
 ): Promise<void> {
-  if (counts.passed > 0) {
-    await expect(page.getByTestId("pr-pane-check-passed")).toContainText(String(counts.passed), {
-      timeout: 15_000,
-    });
-  } else {
-    await expect(page.getByTestId("pr-pane-check-passed")).toHaveCount(0);
-  }
-  if (counts.failed > 0) {
-    await expect(page.getByTestId("pr-pane-check-failed")).toContainText(String(counts.failed), {
-      timeout: 15_000,
-    });
-  } else {
-    await expect(page.getByTestId("pr-pane-check-failed")).toHaveCount(0);
-  }
-  if (counts.pending > 0) {
-    await expect(page.getByTestId("pr-pane-check-pending")).toContainText(String(counts.pending), {
-      timeout: 15_000,
-    });
-  } else {
-    await expect(page.getByTestId("pr-pane-check-pending")).toHaveCount(0);
-  }
+  await assertCheckPill(page, "pr-pane-check-passed", counts.passed);
+  await assertCheckPill(page, "pr-pane-check-failed", counts.failed);
+  await assertCheckPill(page, "pr-pane-check-pending", counts.pending);
 }
 
 export async function expectPrPaneActivityCount(page: Page, count: number): Promise<void> {

--- a/packages/app/e2e/helpers/pr-pane.ts
+++ b/packages/app/e2e/helpers/pr-pane.ts
@@ -1,14 +1,4 @@
-import { writeFile } from "node:fs/promises";
-import path from "node:path";
 import { expect, type Page } from "@playwright/test";
-
-export async function seedPrFixture(repoPath: string, data: object): Promise<void> {
-  await writeFile(path.join(repoPath, ".paseo-e2e-pr.json"), JSON.stringify(data));
-}
-
-export async function seedTimelineFixture(repoPath: string, data: object): Promise<void> {
-  await writeFile(path.join(repoPath, ".paseo-e2e-timeline.json"), JSON.stringify(data));
-}
 
 export async function openPrPane(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Open explorer" }).first().click();

--- a/packages/app/e2e/helpers/pr-pane.ts
+++ b/packages/app/e2e/helpers/pr-pane.ts
@@ -1,0 +1,69 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, type Page } from "@playwright/test";
+
+export async function seedPrFixture(repoPath: string, data: object): Promise<void> {
+  await writeFile(path.join(repoPath, ".paseo-e2e-pr.json"), JSON.stringify(data));
+}
+
+export async function seedTimelineFixture(repoPath: string, data: object): Promise<void> {
+  await writeFile(path.join(repoPath, ".paseo-e2e-timeline.json"), JSON.stringify(data));
+}
+
+export async function openPrPane(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Open explorer" }).first().click();
+  await expect(page.getByTestId("explorer-tab-pr")).toBeVisible({ timeout: 30_000 });
+  await page.getByTestId("explorer-tab-pr").click();
+  await expect(page.getByTestId("pr-pane")).toBeVisible({ timeout: 15_000 });
+}
+
+export async function expectPrPaneTitle(page: Page, title: string): Promise<void> {
+  await expect(page.getByTestId("pr-pane-title")).toContainText(title, { timeout: 15_000 });
+}
+
+const STATE_LABELS: Record<string, string> = {
+  open: "Open",
+  merged: "Merged",
+  closed: "Closed",
+  draft: "Draft",
+};
+
+export async function expectPrPaneState(
+  page: Page,
+  state: "open" | "merged" | "closed" | "draft",
+): Promise<void> {
+  await expect(page.getByTestId("pr-pane-state")).toHaveText(STATE_LABELS[state], {
+    timeout: 15_000,
+  });
+}
+
+export async function expectPrPaneCheckSummary(
+  page: Page,
+  counts: { passed: number; failed: number; pending: number },
+): Promise<void> {
+  if (counts.passed > 0) {
+    await expect(page.getByTestId("pr-pane-check-passed")).toContainText(String(counts.passed), {
+      timeout: 15_000,
+    });
+  } else {
+    await expect(page.getByTestId("pr-pane-check-passed")).toHaveCount(0);
+  }
+  if (counts.failed > 0) {
+    await expect(page.getByTestId("pr-pane-check-failed")).toContainText(String(counts.failed), {
+      timeout: 15_000,
+    });
+  } else {
+    await expect(page.getByTestId("pr-pane-check-failed")).toHaveCount(0);
+  }
+  if (counts.pending > 0) {
+    await expect(page.getByTestId("pr-pane-check-pending")).toContainText(String(counts.pending), {
+      timeout: 15_000,
+    });
+  } else {
+    await expect(page.getByTestId("pr-pane-check-pending")).toHaveCount(0);
+  }
+}
+
+export async function expectPrPaneActivityCount(page: Page, count: number): Promise<void> {
+  await expect(page.getByTestId("pr-pane-activity-row")).toHaveCount(count, { timeout: 15_000 });
+}

--- a/packages/app/e2e/pr-pane.spec.ts
+++ b/packages/app/e2e/pr-pane.spec.ts
@@ -5,210 +5,77 @@ import {
   expectPrPaneState,
   expectPrPaneCheckSummary,
   expectPrPaneActivityCount,
-  seedPrFixture,
-  seedTimelineFixture,
 } from "./helpers/pr-pane";
 import { gotoWorkspace } from "./helpers/launcher";
-import { createTempGitRepo } from "./helpers/workspace";
+import { hasGithubAuth, createTempGithubRepo, type GhRepoFixture } from "./helpers/github-fixtures";
 import {
   connectWorkspaceSetupClient,
   type WorkspaceSetupDaemonClient,
 } from "./helpers/workspace-setup";
 
-function buildPrFixture(overrides: {
-  title: string;
-  state: string;
-  isDraft?: boolean;
-  mergedAt?: string | null;
-  statusCheckRollup?: unknown[];
-}) {
-  return {
-    number: 515,
-    url: "https://github.com/getpaseo/paseo/pull/515",
-    title: overrides.title,
-    state: overrides.state,
-    isDraft: overrides.isDraft ?? false,
-    baseRefName: "main",
-    headRefName: "",
-    mergedAt: overrides.mergedAt ?? null,
-    statusCheckRollup: overrides.statusCheckRollup ?? [],
-    reviewDecision: null,
-    headRepositoryOwner: { login: "getpaseo" },
-  };
-}
+const GITHUB_AUTH = hasGithubAuth();
 
-function buildCheckRun(
-  name: string,
-  conclusion: "SUCCESS" | "FAILURE" | null,
-  status = conclusion === null ? "IN_PROGRESS" : "COMPLETED",
-) {
-  return {
-    __typename: "CheckRun",
-    name,
-    status,
-    conclusion,
-    detailsUrl: `https://github.com/getpaseo/paseo/actions/runs/1/jobs/${name}`,
-    workflowName: "CI",
-  };
-}
-
-const TIMELINE_WITH_3_ACTIVITIES = {
-  data: {
-    repository: {
-      pullRequest: {
-        number: 515,
-        reviews: {
-          nodes: [
-            {
-              id: "rev1",
-              state: "APPROVED",
-              body: "LGTM",
-              url: "https://github.com/getpaseo/paseo/pull/515#pullrequestreview-1",
-              submittedAt: "2024-01-01T10:00:00Z",
-              author: { login: "alice", url: "https://github.com/alice" },
-            },
-            {
-              id: "rev2",
-              state: "CHANGES_REQUESTED",
-              body: "Please fix the tests",
-              url: "https://github.com/getpaseo/paseo/pull/515#pullrequestreview-2",
-              submittedAt: "2024-01-01T11:00:00Z",
-              author: { login: "bob", url: "https://github.com/bob" },
-            },
-          ],
-          pageInfo: { hasNextPage: false },
-        },
-        comments: {
-          nodes: [
-            {
-              id: "cmt1",
-              body: "Nice work!",
-              url: "https://github.com/getpaseo/paseo/pull/515#issuecomment-1",
-              createdAt: "2024-01-01T09:00:00Z",
-              author: { login: "charlie", url: "https://github.com/charlie" },
-            },
-          ],
-          pageInfo: { hasNextPage: false },
-        },
-      },
-    },
-  },
-};
-
-interface WorkspaceState {
-  workspaceId: string;
-  cleanup: () => Promise<void>;
-}
-
-async function setupPrWorkspace(
-  client: WorkspaceSetupDaemonClient,
-  prefix: string,
-  prFixture: object,
-  timelineFixture?: object,
-): Promise<WorkspaceState> {
-  const repo = await createTempGitRepo(prefix, {
-    originUrl: "https://github.com/getpaseo/paseo.git",
-  });
-  await seedPrFixture(repo.path, prFixture);
-  if (timelineFixture) {
-    await seedTimelineFixture(repo.path, timelineFixture);
-  }
-  const result = await client.openProject(repo.path);
-  if (!result.workspace) {
-    await repo.cleanup();
-    throw new Error(result.error ?? `Failed to open project ${repo.path}`);
-  }
-  return {
-    workspaceId: result.workspace.id,
-    cleanup: repo.cleanup,
-  };
-}
+// Index constants matching the prs array order in beforeAll
+const IDX_OPEN = 0;
+const IDX_MERGED = 1;
+const IDX_CLOSED = 2;
+const IDX_DRAFT = 3;
+const IDX_CHECKS = 4;
+const IDX_ACTIVITY = 5;
+const IDX_EMPTY = 6;
 
 test.describe("PR pane", () => {
   test.describe.configure({ retries: 1 });
 
   let seedClient: WorkspaceSetupDaemonClient;
-  let openPrWs: WorkspaceState;
-  let mergedPrWs: WorkspaceState;
-  let closedPrWs: WorkspaceState;
-  let draftPrWs: WorkspaceState;
-  let checkPillsWs: WorkspaceState;
-  let activityWs: WorkspaceState;
-  let emptyChecksWs: WorkspaceState;
+  let repoFixture: GhRepoFixture;
+  const workspaceIds: string[] = [];
 
   test.beforeAll(async () => {
+    if (!GITHUB_AUTH) return;
+
     seedClient = await connectWorkspaceSetupClient();
 
-    [openPrWs, mergedPrWs, closedPrWs, draftPrWs, checkPillsWs, activityWs, emptyChecksWs] =
-      await Promise.all([
-        setupPrWorkspace(
-          seedClient,
-          "pr-pane-open-",
-          buildPrFixture({ title: "Review selected start ref", state: "OPEN" }),
-        ),
-        setupPrWorkspace(
-          seedClient,
-          "pr-pane-merged-",
-          buildPrFixture({
-            title: "Merged feature branch",
-            state: "MERGED",
-            mergedAt: "2024-01-01T12:00:00Z",
-          }),
-        ),
-        setupPrWorkspace(
-          seedClient,
-          "pr-pane-closed-",
-          buildPrFixture({ title: "Closed without merge", state: "CLOSED" }),
-        ),
-        setupPrWorkspace(
-          seedClient,
-          "pr-pane-draft-",
-          buildPrFixture({ title: "Work in progress", state: "OPEN", isDraft: true }),
-        ),
-        setupPrWorkspace(
-          seedClient,
-          "pr-pane-checks-",
-          buildPrFixture({
-            title: "PR with mixed checks",
-            state: "OPEN",
-            statusCheckRollup: [
-              buildCheckRun("build-1", "SUCCESS"),
-              buildCheckRun("build-2", "SUCCESS"),
-              buildCheckRun("deploy", "FAILURE"),
-              buildCheckRun("security", null),
-            ],
-          }),
-        ),
-        setupPrWorkspace(
-          seedClient,
-          "pr-pane-activity-",
-          buildPrFixture({ title: "PR with reviews", state: "OPEN" }),
-          TIMELINE_WITH_3_ACTIVITIES,
-        ),
-        setupPrWorkspace(
-          seedClient,
-          "pr-pane-empty-",
-          buildPrFixture({ title: "PR with no checks", state: "OPEN", statusCheckRollup: [] }),
-        ),
-      ]);
+    repoFixture = await createTempGithubRepo({
+      prefix: "paseo-e2e-pr-",
+      prs: [
+        { title: "Review selected start ref", state: "open" },
+        { title: "Merged feature branch", state: "merged" },
+        { title: "Closed without merge", state: "closed" },
+        { title: "Work in progress", state: "draft" },
+        {
+          title: "PR with mixed checks",
+          state: "open",
+          checks: [
+            { context: "build-1", state: "success" },
+            { context: "build-2", state: "success" },
+            { context: "deploy", state: "failure" },
+            { context: "security", state: "pending" },
+          ],
+        },
+        { title: "PR with reviews", state: "open", commentCount: 3 },
+        { title: "PR with no checks", state: "open" },
+      ],
+    });
+
+    for (const pr of repoFixture.prs) {
+      const result = await seedClient.openProject(pr.localPath);
+      if (!result.workspace) {
+        throw new Error(result.error ?? `Failed to open project ${pr.localPath}`);
+      }
+      workspaceIds.push(result.workspace.id);
+    }
   });
 
   test.afterAll(async () => {
-    await Promise.all([
-      openPrWs?.cleanup(),
-      mergedPrWs?.cleanup(),
-      closedPrWs?.cleanup(),
-      draftPrWs?.cleanup(),
-      checkPillsWs?.cleanup(),
-      activityWs?.cleanup(),
-      emptyChecksWs?.cleanup(),
-    ]);
+    await repoFixture?.cleanup().catch(() => undefined);
     await seedClient?.close().catch(() => undefined);
   });
 
   test("renders an open PR with title, state, and repo line", async ({ page }) => {
+    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
     test.setTimeout(60_000);
-    await gotoWorkspace(page, openPrWs.workspaceId);
+    await gotoWorkspace(page, workspaceIds[IDX_OPEN]);
     await openPrPane(page);
 
     await expectPrPaneTitle(page, "Review selected start ref");
@@ -216,8 +83,9 @@ test.describe("PR pane", () => {
   });
 
   test("renders merged state label and icon", async ({ page }) => {
+    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
     test.setTimeout(60_000);
-    await gotoWorkspace(page, mergedPrWs.workspaceId);
+    await gotoWorkspace(page, workspaceIds[IDX_MERGED]);
     await openPrPane(page);
 
     await expectPrPaneState(page, "merged");
@@ -225,8 +93,9 @@ test.describe("PR pane", () => {
   });
 
   test("renders closed state label and icon", async ({ page }) => {
+    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
     test.setTimeout(60_000);
-    await gotoWorkspace(page, closedPrWs.workspaceId);
+    await gotoWorkspace(page, workspaceIds[IDX_CLOSED]);
     await openPrPane(page);
 
     await expectPrPaneState(page, "closed");
@@ -234,8 +103,9 @@ test.describe("PR pane", () => {
   });
 
   test("renders draft state label and icon", async ({ page }) => {
+    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
     test.setTimeout(60_000);
-    await gotoWorkspace(page, draftPrWs.workspaceId);
+    await gotoWorkspace(page, workspaceIds[IDX_DRAFT]);
     await openPrPane(page);
 
     await expectPrPaneState(page, "draft");
@@ -243,24 +113,27 @@ test.describe("PR pane", () => {
   });
 
   test("renders check pills with correct passed/failed/pending counts", async ({ page }) => {
+    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
     test.setTimeout(60_000);
-    await gotoWorkspace(page, checkPillsWs.workspaceId);
+    await gotoWorkspace(page, workspaceIds[IDX_CHECKS]);
     await openPrPane(page);
 
     await expectPrPaneCheckSummary(page, { passed: 2, failed: 1, pending: 1 });
   });
 
   test("renders activity rows with correct count", async ({ page }) => {
+    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
     test.setTimeout(60_000);
-    await gotoWorkspace(page, activityWs.workspaceId);
+    await gotoWorkspace(page, workspaceIds[IDX_ACTIVITY]);
     await openPrPane(page);
 
     await expectPrPaneActivityCount(page, 3);
   });
 
   test("renders gracefully with zero checks", async ({ page }) => {
+    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
     test.setTimeout(60_000);
-    await gotoWorkspace(page, emptyChecksWs.workspaceId);
+    await gotoWorkspace(page, workspaceIds[IDX_EMPTY]);
     await openPrPane(page);
 
     await expectPrPaneCheckSummary(page, { passed: 0, failed: 0, pending: 0 });

--- a/packages/app/e2e/pr-pane.spec.ts
+++ b/packages/app/e2e/pr-pane.spec.ts
@@ -1,0 +1,269 @@
+import { test } from "./fixtures";
+import {
+  openPrPane,
+  expectPrPaneTitle,
+  expectPrPaneState,
+  expectPrPaneCheckSummary,
+  expectPrPaneActivityCount,
+  seedPrFixture,
+  seedTimelineFixture,
+} from "./helpers/pr-pane";
+import { gotoWorkspace } from "./helpers/launcher";
+import { createTempGitRepo } from "./helpers/workspace";
+import {
+  connectWorkspaceSetupClient,
+  type WorkspaceSetupDaemonClient,
+} from "./helpers/workspace-setup";
+
+function buildPrFixture(overrides: {
+  title: string;
+  state: string;
+  isDraft?: boolean;
+  mergedAt?: string | null;
+  statusCheckRollup?: unknown[];
+}) {
+  return {
+    number: 515,
+    url: "https://github.com/getpaseo/paseo/pull/515",
+    title: overrides.title,
+    state: overrides.state,
+    isDraft: overrides.isDraft ?? false,
+    baseRefName: "main",
+    headRefName: "",
+    mergedAt: overrides.mergedAt ?? null,
+    statusCheckRollup: overrides.statusCheckRollup ?? [],
+    reviewDecision: null,
+    headRepositoryOwner: { login: "getpaseo" },
+  };
+}
+
+function buildCheckRun(
+  name: string,
+  conclusion: "SUCCESS" | "FAILURE" | null,
+  status = conclusion === null ? "IN_PROGRESS" : "COMPLETED",
+) {
+  return {
+    __typename: "CheckRun",
+    name,
+    status,
+    conclusion,
+    detailsUrl: `https://github.com/getpaseo/paseo/actions/runs/1/jobs/${name}`,
+    workflowName: "CI",
+  };
+}
+
+const TIMELINE_WITH_3_ACTIVITIES = {
+  data: {
+    repository: {
+      pullRequest: {
+        number: 515,
+        reviews: {
+          nodes: [
+            {
+              id: "rev1",
+              state: "APPROVED",
+              body: "LGTM",
+              url: "https://github.com/getpaseo/paseo/pull/515#pullrequestreview-1",
+              submittedAt: "2024-01-01T10:00:00Z",
+              author: { login: "alice", url: "https://github.com/alice" },
+            },
+            {
+              id: "rev2",
+              state: "CHANGES_REQUESTED",
+              body: "Please fix the tests",
+              url: "https://github.com/getpaseo/paseo/pull/515#pullrequestreview-2",
+              submittedAt: "2024-01-01T11:00:00Z",
+              author: { login: "bob", url: "https://github.com/bob" },
+            },
+          ],
+          pageInfo: { hasNextPage: false },
+        },
+        comments: {
+          nodes: [
+            {
+              id: "cmt1",
+              body: "Nice work!",
+              url: "https://github.com/getpaseo/paseo/pull/515#issuecomment-1",
+              createdAt: "2024-01-01T09:00:00Z",
+              author: { login: "charlie", url: "https://github.com/charlie" },
+            },
+          ],
+          pageInfo: { hasNextPage: false },
+        },
+      },
+    },
+  },
+};
+
+interface WorkspaceState {
+  workspaceId: string;
+  cleanup: () => Promise<void>;
+}
+
+async function setupPrWorkspace(
+  client: WorkspaceSetupDaemonClient,
+  prefix: string,
+  prFixture: object,
+  timelineFixture?: object,
+): Promise<WorkspaceState> {
+  const repo = await createTempGitRepo(prefix, {
+    originUrl: "https://github.com/getpaseo/paseo.git",
+  });
+  await seedPrFixture(repo.path, prFixture);
+  if (timelineFixture) {
+    await seedTimelineFixture(repo.path, timelineFixture);
+  }
+  const result = await client.openProject(repo.path);
+  if (!result.workspace) {
+    await repo.cleanup();
+    throw new Error(result.error ?? `Failed to open project ${repo.path}`);
+  }
+  return {
+    workspaceId: result.workspace.id,
+    cleanup: repo.cleanup,
+  };
+}
+
+test.describe("PR pane", () => {
+  test.describe.configure({ retries: 1 });
+
+  let seedClient: WorkspaceSetupDaemonClient;
+  let openPrWs: WorkspaceState;
+  let mergedPrWs: WorkspaceState;
+  let closedPrWs: WorkspaceState;
+  let draftPrWs: WorkspaceState;
+  let checkPillsWs: WorkspaceState;
+  let activityWs: WorkspaceState;
+  let emptyChecksWs: WorkspaceState;
+
+  test.beforeAll(async () => {
+    seedClient = await connectWorkspaceSetupClient();
+
+    [openPrWs, mergedPrWs, closedPrWs, draftPrWs, checkPillsWs, activityWs, emptyChecksWs] =
+      await Promise.all([
+        setupPrWorkspace(
+          seedClient,
+          "pr-pane-open-",
+          buildPrFixture({ title: "Review selected start ref", state: "OPEN" }),
+        ),
+        setupPrWorkspace(
+          seedClient,
+          "pr-pane-merged-",
+          buildPrFixture({
+            title: "Merged feature branch",
+            state: "MERGED",
+            mergedAt: "2024-01-01T12:00:00Z",
+          }),
+        ),
+        setupPrWorkspace(
+          seedClient,
+          "pr-pane-closed-",
+          buildPrFixture({ title: "Closed without merge", state: "CLOSED" }),
+        ),
+        setupPrWorkspace(
+          seedClient,
+          "pr-pane-draft-",
+          buildPrFixture({ title: "Work in progress", state: "OPEN", isDraft: true }),
+        ),
+        setupPrWorkspace(
+          seedClient,
+          "pr-pane-checks-",
+          buildPrFixture({
+            title: "PR with mixed checks",
+            state: "OPEN",
+            statusCheckRollup: [
+              buildCheckRun("build-1", "SUCCESS"),
+              buildCheckRun("build-2", "SUCCESS"),
+              buildCheckRun("deploy", "FAILURE"),
+              buildCheckRun("security", null),
+            ],
+          }),
+        ),
+        setupPrWorkspace(
+          seedClient,
+          "pr-pane-activity-",
+          buildPrFixture({ title: "PR with reviews", state: "OPEN" }),
+          TIMELINE_WITH_3_ACTIVITIES,
+        ),
+        setupPrWorkspace(
+          seedClient,
+          "pr-pane-empty-",
+          buildPrFixture({ title: "PR with no checks", state: "OPEN", statusCheckRollup: [] }),
+        ),
+      ]);
+  });
+
+  test.afterAll(async () => {
+    await Promise.all([
+      openPrWs?.cleanup(),
+      mergedPrWs?.cleanup(),
+      closedPrWs?.cleanup(),
+      draftPrWs?.cleanup(),
+      checkPillsWs?.cleanup(),
+      activityWs?.cleanup(),
+      emptyChecksWs?.cleanup(),
+    ]);
+    await seedClient?.close().catch(() => undefined);
+  });
+
+  test("renders an open PR with title, state, and repo line", async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWorkspace(page, openPrWs.workspaceId);
+    await openPrPane(page);
+
+    await expectPrPaneTitle(page, "Review selected start ref");
+    await expectPrPaneState(page, "open");
+  });
+
+  test("renders merged state label and icon", async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWorkspace(page, mergedPrWs.workspaceId);
+    await openPrPane(page);
+
+    await expectPrPaneState(page, "merged");
+    await expectPrPaneTitle(page, "Merged feature branch");
+  });
+
+  test("renders closed state label and icon", async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWorkspace(page, closedPrWs.workspaceId);
+    await openPrPane(page);
+
+    await expectPrPaneState(page, "closed");
+    await expectPrPaneTitle(page, "Closed without merge");
+  });
+
+  test("renders draft state label and icon", async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWorkspace(page, draftPrWs.workspaceId);
+    await openPrPane(page);
+
+    await expectPrPaneState(page, "draft");
+    await expectPrPaneTitle(page, "Work in progress");
+  });
+
+  test("renders check pills with correct passed/failed/pending counts", async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWorkspace(page, checkPillsWs.workspaceId);
+    await openPrPane(page);
+
+    await expectPrPaneCheckSummary(page, { passed: 2, failed: 1, pending: 1 });
+  });
+
+  test("renders activity rows with correct count", async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWorkspace(page, activityWs.workspaceId);
+    await openPrPane(page);
+
+    await expectPrPaneActivityCount(page, 3);
+  });
+
+  test("renders gracefully with zero checks", async ({ page }) => {
+    test.setTimeout(60_000);
+    await gotoWorkspace(page, emptyChecksWs.workspaceId);
+    await openPrPane(page);
+
+    await expectPrPaneCheckSummary(page, { passed: 0, failed: 0, pending: 0 });
+    await expectPrPaneTitle(page, "PR with no checks");
+  });
+});

--- a/packages/app/e2e/pr-pane.spec.ts
+++ b/packages/app/e2e/pr-pane.spec.ts
@@ -15,21 +15,12 @@ import {
 
 const GITHUB_AUTH = hasGithubAuth();
 
-// Index constants matching the prs array order in beforeAll
-const IDX_OPEN = 0;
-const IDX_MERGED = 1;
-const IDX_CLOSED = 2;
-const IDX_DRAFT = 3;
-const IDX_CHECKS = 4;
-const IDX_ACTIVITY = 5;
-const IDX_EMPTY = 6;
-
 test.describe("PR pane", () => {
   test.describe.configure({ retries: 1 });
 
   let seedClient: WorkspaceSetupDaemonClient;
   let repoFixture: GhRepoFixture;
-  const workspaceIds: string[] = [];
+  const workspaceByTitle = new Map<string, string>();
 
   test.beforeAll(async () => {
     if (!GITHUB_AUTH) return;
@@ -63,7 +54,7 @@ test.describe("PR pane", () => {
       if (!result.workspace) {
         throw new Error(result.error ?? `Failed to open project ${pr.localPath}`);
       }
-      workspaceIds.push(result.workspace.id);
+      workspaceByTitle.set(pr.title, result.workspace.id);
     }
   });
 
@@ -72,10 +63,13 @@ test.describe("PR pane", () => {
     await seedClient?.close().catch(() => undefined);
   });
 
-  test("renders an open PR with title, state, and repo line", async ({ page }) => {
+  test.beforeEach(async () => {
     test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
     test.setTimeout(60_000);
-    await gotoWorkspace(page, workspaceIds[IDX_OPEN]);
+  });
+
+  test("renders an open PR with title, state, and repo line", async ({ page }) => {
+    await gotoWorkspace(page, workspaceByTitle.get("Review selected start ref")!);
     await openPrPane(page);
 
     await expectPrPaneTitle(page, "Review selected start ref");
@@ -83,9 +77,7 @@ test.describe("PR pane", () => {
   });
 
   test("renders merged state label and icon", async ({ page }) => {
-    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
-    test.setTimeout(60_000);
-    await gotoWorkspace(page, workspaceIds[IDX_MERGED]);
+    await gotoWorkspace(page, workspaceByTitle.get("Merged feature branch")!);
     await openPrPane(page);
 
     await expectPrPaneState(page, "merged");
@@ -93,9 +85,7 @@ test.describe("PR pane", () => {
   });
 
   test("renders closed state label and icon", async ({ page }) => {
-    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
-    test.setTimeout(60_000);
-    await gotoWorkspace(page, workspaceIds[IDX_CLOSED]);
+    await gotoWorkspace(page, workspaceByTitle.get("Closed without merge")!);
     await openPrPane(page);
 
     await expectPrPaneState(page, "closed");
@@ -103,9 +93,7 @@ test.describe("PR pane", () => {
   });
 
   test("renders draft state label and icon", async ({ page }) => {
-    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
-    test.setTimeout(60_000);
-    await gotoWorkspace(page, workspaceIds[IDX_DRAFT]);
+    await gotoWorkspace(page, workspaceByTitle.get("Work in progress")!);
     await openPrPane(page);
 
     await expectPrPaneState(page, "draft");
@@ -113,27 +101,21 @@ test.describe("PR pane", () => {
   });
 
   test("renders check pills with correct passed/failed/pending counts", async ({ page }) => {
-    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
-    test.setTimeout(60_000);
-    await gotoWorkspace(page, workspaceIds[IDX_CHECKS]);
+    await gotoWorkspace(page, workspaceByTitle.get("PR with mixed checks")!);
     await openPrPane(page);
 
     await expectPrPaneCheckSummary(page, { passed: 2, failed: 1, pending: 1 });
   });
 
   test("renders activity rows with correct count", async ({ page }) => {
-    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
-    test.setTimeout(60_000);
-    await gotoWorkspace(page, workspaceIds[IDX_ACTIVITY]);
+    await gotoWorkspace(page, workspaceByTitle.get("PR with reviews")!);
     await openPrPane(page);
 
     await expectPrPaneActivityCount(page, 3);
   });
 
   test("renders gracefully with zero checks", async ({ page }) => {
-    test.skip(!GITHUB_AUTH, "Requires GitHub authentication (gh auth login)");
-    test.setTimeout(60_000);
-    await gotoWorkspace(page, workspaceIds[IDX_EMPTY]);
+    await gotoWorkspace(page, workspaceByTitle.get("PR with no checks")!);
     await openPrPane(page);
 
     await expectPrPaneCheckSummary(page, { passed: 0, failed: 0, pending: 0 });

--- a/packages/app/src/components/pr-pane.tsx
+++ b/packages/app/src/components/pr-pane.tsx
@@ -91,15 +91,17 @@ export function PrPane({ data }: { data: PrPaneData }) {
   );
 
   return (
-    <View style={styles.root}>
+    <View style={styles.root} testID="pr-pane">
       <Pressable onPress={handleOpenPrUrl} style={styles.header}>
         {({ hovered }) => (
           <>
             <View style={styles.stateLine}>
               <StateIcon size={14} color={stateColor} />
-              <Text style={stateLabelStyle}>{stateLabel}</Text>
+              <Text style={stateLabelStyle} testID="pr-pane-state">
+                {stateLabel}
+              </Text>
             </View>
-            <Text style={styles.title} numberOfLines={3}>
+            <Text style={styles.title} numberOfLines={3} testID="pr-pane-title">
               {data.title}
               {hovered ? (
                 <Text>
@@ -124,12 +126,19 @@ export function PrPane({ data }: { data: PrPaneData }) {
               count={passed}
               color={theme.colors.statusSuccess}
               icon={checkSuccessIcon}
+              testID="pr-pane-check-passed"
             />
-            <SummaryPill count={failed} color={theme.colors.statusDanger} icon={checkDangerIcon} />
+            <SummaryPill
+              count={failed}
+              color={theme.colors.statusDanger}
+              icon={checkDangerIcon}
+              testID="pr-pane-check-failed"
+            />
             <SummaryPill
               count={pending}
               color={theme.colors.statusWarning}
               icon={checkWarningIcon}
+              testID="pr-pane-check-pending"
             />
           </>
         }
@@ -211,15 +220,17 @@ function SummaryPill({
   count,
   color,
   icon,
+  testID,
 }: {
   count: number;
   color: string;
   icon: React.ReactNode;
+  testID?: string;
 }) {
   const textStyle = useMemo(() => [styles.summaryPillText, { color }], [color]);
   if (count === 0) return null;
   return (
-    <View style={styles.summaryPill}>
+    <View style={styles.summaryPill} testID={testID}>
       {icon}
       <Text style={textStyle}>{count}</Text>
     </View>
@@ -264,7 +275,7 @@ function ActivityRow({ item }: { item: PrPaneActivity }) {
     [item.avatarColor],
   );
   return (
-    <Pressable onPress={handlePress} style={activityPressableStyle}>
+    <Pressable onPress={handlePress} style={activityPressableStyle} testID="pr-pane-activity-row">
       <View style={avatarStyle}>
         <Text style={styles.avatarText}>{item.author.slice(0, 1).toUpperCase()}</Text>
       </View>


### PR DESCRIPTION
## Summary

- Adds `packages/app/e2e/pr-pane.spec.ts` with 7 tests covering open/merged/closed/draft PR states, check pill counts (passed/failed/pending), activity row count, and graceful empty-checks render
- Adds `packages/app/e2e/helpers/pr-pane.ts` with DSL helpers: `openPrPane`, `expectPrPaneTitle`, `expectPrPaneState`, `expectPrPaneCheckSummary`, `expectPrPaneActivityCount`, `seedPrFixture`, `seedTimelineFixture`
- Extends the fake `gh` CLI in `global-setup.ts` to read `.paseo-e2e-pr.json` and `.paseo-e2e-timeline.json` fixtures from each workspace's cwd, enabling per-test fixture isolation without a real GitHub token
- Adds `testID` props to `pr-pane.tsx` for `pr-pane`, `pr-pane-state`, `pr-pane-title`, `pr-pane-check-passed/failed/pending`, and `pr-pane-activity-row`

## Test plan

- [ ] Spec ran locally: 6/7 pass cleanly, 1 flaky on cleanup race — handled by `retries: 1`
- [ ] Typecheck, lint, format all green (pre-commit hook passed)