### PR TITLE
test(app/e2e): add desktop-updates spec covering update banner and daemon lifecycle (cluster G4)

### DIFF
--- a/packages/app/e2e/desktop-updates.spec.ts
+++ b/packages/app/e2e/desktop-updates.spec.ts
@@ -1,0 +1,145 @@
+import { test } from "./fixtures";
+import { gotoAppShell } from "./helpers/app";
+import {
+  loadRealDaemonState,
+  injectDesktopBridge,
+  openDesktopSettings,
+  expectUpdateBanner,
+  clickInstallUpdate,
+  expectInstallInProgress,
+  interceptDaemonManagementConfirmDialog,
+  toggleDaemonManagement,
+  expectDaemonManagementConfirmDialog,
+  expectDaemonManagementEnabled,
+  expectDaemonManagementDisabled,
+  expectDaemonStatusPid,
+  expectDaemonStatusLogPath,
+  expectDaemonStatusVersion,
+} from "./helpers/desktop-updates";
+
+function getSeededServerId(): string {
+  const serverId = process.env.E2E_SERVER_ID;
+  if (!serverId) {
+    throw new Error("E2E_SERVER_ID is not set (expected from Playwright globalSetup).");
+  }
+  return serverId;
+}
+
+test.describe("Desktop updates", () => {
+  test("update banner appears in the sidebar when an app update is available", async ({ page }) => {
+    await injectDesktopBridge(page, {
+      serverId: getSeededServerId(),
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+    });
+    await gotoAppShell(page);
+
+    await expectUpdateBanner(page, "1.2.3");
+  });
+
+  test("clicking install shows the installing state on the callout", async ({ page }) => {
+    await injectDesktopBridge(page, {
+      serverId: getSeededServerId(),
+      updateAvailable: true,
+      latestVersion: "1.2.3",
+      slowInstall: true,
+    });
+    await gotoAppShell(page);
+
+    await expectUpdateBanner(page, "1.2.3");
+    await clickInstallUpdate(page);
+    await expectInstallInProgress(page);
+  });
+});
+
+test.describe("Desktop daemon management", () => {
+  test("disabling built-in daemon management shows confirm dialog with correct copy", async ({
+    page,
+  }) => {
+    const serverId = getSeededServerId();
+    await injectDesktopBridge(page, {
+      serverId,
+      manageBuiltInDaemon: true,
+    });
+    await gotoAppShell(page);
+    await openDesktopSettings(page, serverId);
+
+    const dialog = await interceptDaemonManagementConfirmDialog(page);
+    expectDaemonManagementConfirmDialog(dialog);
+
+    await expectDaemonManagementEnabled(page);
+  });
+
+  test("cancelling the confirm dialog leaves the daemon management toggle on", async ({ page }) => {
+    const serverId = getSeededServerId();
+    await injectDesktopBridge(page, {
+      serverId,
+      manageBuiltInDaemon: true,
+    });
+    await gotoAppShell(page);
+    await openDesktopSettings(page, serverId);
+
+    await expectDaemonManagementEnabled(page);
+    await interceptDaemonManagementConfirmDialog(page);
+    await expectDaemonManagementEnabled(page);
+  });
+
+  test("confirming the dialog disables built-in daemon management", async ({ page }) => {
+    const serverId = getSeededServerId();
+    await injectDesktopBridge(page, {
+      serverId,
+      manageBuiltInDaemon: true,
+    });
+    await gotoAppShell(page);
+    await openDesktopSettings(page, serverId);
+
+    await toggleDaemonManagement(page, "disable");
+
+    await expectDaemonManagementDisabled(page);
+  });
+
+  test("daemon status panel renders version, PID, and log path from the real daemon", async ({
+    page,
+  }) => {
+    const serverId = getSeededServerId();
+    const realState = await loadRealDaemonState();
+    await injectDesktopBridge(page, {
+      serverId,
+      manageBuiltInDaemon: false,
+      daemonPid: realState.pid,
+      daemonVersion: realState.version,
+      daemonLogPath: realState.logPath,
+    });
+    await gotoAppShell(page);
+    await openDesktopSettings(page, serverId);
+
+    await expectDaemonStatusVersion(page, realState.version);
+    await expectDaemonStatusPid(page, realState.pid);
+    await expectDaemonStatusLogPath(page, realState.logPath);
+  });
+
+  test("stopping and restarting the daemon updates the PID", async ({ page }) => {
+    const serverId = getSeededServerId();
+    const realState = await loadRealDaemonState();
+    await injectDesktopBridge(page, {
+      serverId,
+      manageBuiltInDaemon: true,
+      daemonPid: realState.pid,
+      daemonVersion: realState.version,
+      daemonLogPath: realState.logPath,
+    });
+    await gotoAppShell(page);
+    await openDesktopSettings(page, serverId);
+
+    await expectDaemonStatusPid(page, realState.pid);
+
+    await toggleDaemonManagement(page, "disable");
+    await expectDaemonManagementDisabled(page);
+    await expectDaemonStatusPid(page, null);
+
+    await toggleDaemonManagement(page, "enable");
+    await expectDaemonManagementEnabled(page);
+    const newPid = realState.pid !== null ? realState.pid + 1000 : 11000;
+    await expectDaemonStatusPid(page, newPid);
+  });
+});

--- a/packages/app/e2e/desktop-updates.spec.ts
+++ b/packages/app/e2e/desktop-updates.spec.ts
@@ -25,6 +25,8 @@ function getSeededServerId(): string {
   return serverId;
 }
 
+// No Playwright Electron runner exists; we simulate the desktop bridge via
+// addInitScript so Electron-gated UI activates without a real Electron process.
 test.describe("Desktop updates", () => {
   test("update banner appears in the sidebar when an app update is available", async ({ page }) => {
     await injectDesktopBridge(page, {
@@ -60,12 +62,13 @@ test.describe("Desktop daemon management", () => {
     await injectDesktopBridge(page, {
       serverId,
       manageBuiltInDaemon: true,
+      confirmShouldAccept: false,
     });
     await gotoAppShell(page);
     await openDesktopSettings(page, serverId);
 
-    const dialog = await interceptDaemonManagementConfirmDialog(page);
-    expectDaemonManagementConfirmDialog(dialog);
+    const dialogArgs = await interceptDaemonManagementConfirmDialog(page);
+    expectDaemonManagementConfirmDialog(dialogArgs);
 
     await expectDaemonManagementEnabled(page);
   });
@@ -75,12 +78,13 @@ test.describe("Desktop daemon management", () => {
     await injectDesktopBridge(page, {
       serverId,
       manageBuiltInDaemon: true,
+      confirmShouldAccept: false,
     });
     await gotoAppShell(page);
     await openDesktopSettings(page, serverId);
 
     await expectDaemonManagementEnabled(page);
-    await interceptDaemonManagementConfirmDialog(page);
+    await toggleDaemonManagement(page, "disable");
     await expectDaemonManagementEnabled(page);
   });
 
@@ -89,6 +93,7 @@ test.describe("Desktop daemon management", () => {
     await injectDesktopBridge(page, {
       serverId,
       manageBuiltInDaemon: true,
+      confirmShouldAccept: true,
     });
     await gotoAppShell(page);
     await openDesktopSettings(page, serverId);
@@ -127,6 +132,7 @@ test.describe("Desktop daemon management", () => {
       daemonPid: realState.pid,
       daemonVersion: realState.version,
       daemonLogPath: realState.logPath,
+      confirmShouldAccept: true,
     });
     await gotoAppShell(page);
     await openDesktopSettings(page, serverId);

--- a/packages/app/e2e/global-setup.ts
+++ b/packages/app/e2e/global-setup.ts
@@ -705,6 +705,7 @@ export default async function globalSetup() {
     process.env.E2E_SERVER_ID = offer.serverId;
     process.env.E2E_RELAY_DAEMON_PUBLIC_KEY = offer.daemonPublicKeyB64;
     process.env.E2E_METRO_PORT = String(metroPort);
+    process.env.E2E_PASEO_HOME = paseoHome;
     console.log(
       `[e2e] Test daemon started on port ${port}, Metro on port ${metroPort}, home: ${paseoHome}`,
     );

--- a/packages/app/e2e/helpers/desktop-updates.ts
+++ b/packages/app/e2e/helpers/desktop-updates.ts
@@ -1,0 +1,265 @@
+import { readFileSync } from "node:fs";
+import { expect, type Dialog, type Page } from "@playwright/test";
+import { openSettings } from "./app";
+import { openSettingsHost } from "./settings";
+
+interface DaemonApiStatus {
+  version: string;
+  serverId: string;
+  hostname: string;
+}
+
+interface PidFileContent {
+  pid: number;
+  desktopManaged: boolean;
+}
+
+export interface RealDaemonState {
+  version: string;
+  pid: number | null;
+  logPath: string;
+}
+
+/**
+ * Reads live state from the running E2E test daemon: version from the HTTP
+ * status endpoint, PID from the paseo.pid lock file, log path from the
+ * E2E_PASEO_HOME directory. Call this in Node test code (not in the browser).
+ */
+export async function loadRealDaemonState(): Promise<RealDaemonState> {
+  const port = process.env.E2E_DAEMON_PORT;
+  const paseoHome = process.env.E2E_PASEO_HOME;
+  if (!port) throw new Error("E2E_DAEMON_PORT not set — globalSetup must run first");
+  if (!paseoHome) throw new Error("E2E_PASEO_HOME not set — globalSetup must run first");
+
+  const resp = await fetch(`http://127.0.0.1:${port}/api/status`);
+  const data = (await resp.json()) as DaemonApiStatus;
+
+  let pid: number | null = null;
+  try {
+    const raw = readFileSync(`${paseoHome}/paseo.pid`, "utf8");
+    pid = (JSON.parse(raw) as PidFileContent).pid ?? null;
+  } catch {
+    // PID file may not be present yet on a very fresh daemon start
+  }
+
+  return { version: data.version, pid, logPath: `${paseoHome}/daemon.log` };
+}
+
+export interface DesktopBridgeConfig {
+  serverId: string;
+  updateAvailable?: boolean;
+  latestVersion?: string;
+  slowInstall?: boolean;
+  /** Initial PID reported by desktop_daemon_status. Defaults to null. */
+  daemonPid?: number | null;
+  daemonVersion?: string | null;
+  daemonLogPath?: string;
+  /** Initial manageBuiltInDaemon setting. Defaults to false. */
+  manageBuiltInDaemon?: boolean;
+}
+
+/**
+ * Injects window.paseoDesktop before app load so all Electron-gated code
+ * activates. The update-check IPC is mocked at the boundary so the real
+ * auto-updater never fires. Daemon start/stop commands are stateful: the mock
+ * tracks running state and assigns a fresh PID on each start, letting tests
+ * observe PID changes without touching the real E2E daemon process.
+ */
+export async function injectDesktopBridge(page: Page, config: DesktopBridgeConfig): Promise<void> {
+  await page.addInitScript((cfg) => {
+    // Mutable state shared across IPC calls within this page
+    let manageDaemon = cfg.manageBuiltInDaemon ?? false;
+    let daemonRunning = true;
+    let currentPid: number | null = cfg.daemonPid ?? null;
+    let startCount = 0;
+
+    function buildDaemonStatus() {
+      return {
+        serverId: cfg.serverId,
+        status: daemonRunning ? "running" : "stopped",
+        listen: null,
+        hostname: null,
+        pid: currentPid,
+        home: "",
+        version: cfg.daemonVersion ?? null,
+        desktopManaged: manageDaemon,
+        error: null,
+      };
+    }
+
+    (window as unknown as { paseoDesktop: unknown }).paseoDesktop = {
+      platform: "darwin",
+      invoke: async (command: string, args?: Record<string, unknown>) => {
+        if (command === "check_app_update") {
+          return cfg.updateAvailable
+            ? {
+                hasUpdate: true,
+                readyToInstall: true,
+                currentVersion: "1.0.0",
+                latestVersion: cfg.latestVersion ?? "1.2.3",
+                body: null,
+                date: null,
+              }
+            : {
+                hasUpdate: false,
+                readyToInstall: false,
+                currentVersion: "1.0.0",
+                latestVersion: null,
+                body: null,
+                date: null,
+              };
+        }
+
+        if (command === "install_app_update") {
+          if (cfg.slowInstall) {
+            await new Promise<void>((resolve) => setTimeout(resolve, 3000));
+          }
+          return {
+            installed: true,
+            version: cfg.latestVersion ?? "1.2.3",
+            message: "App update installed. Restart required.",
+          };
+        }
+
+        if (command === "desktop_daemon_status") {
+          return buildDaemonStatus();
+        }
+
+        if (command === "desktop_daemon_logs") {
+          return { logPath: cfg.daemonLogPath ?? "", contents: "" };
+        }
+
+        if (command === "get_desktop_settings") {
+          return {
+            releaseChannel: "stable",
+            daemon: { manageBuiltInDaemon: manageDaemon, keepRunningAfterQuit: true },
+          };
+        }
+
+        if (command === "patch_desktop_settings") {
+          const patchDaemon =
+            args?.daemon && typeof args.daemon === "object"
+              ? (args.daemon as Record<string, unknown>)
+              : {};
+          if (typeof patchDaemon.manageBuiltInDaemon === "boolean") {
+            manageDaemon = patchDaemon.manageBuiltInDaemon;
+          }
+          return {
+            releaseChannel: "stable",
+            daemon: { manageBuiltInDaemon: manageDaemon, keepRunningAfterQuit: true },
+          };
+        }
+
+        if (command === "stop_desktop_daemon") {
+          daemonRunning = false;
+          currentPid = null;
+          return buildDaemonStatus();
+        }
+
+        if (command === "start_desktop_daemon") {
+          startCount += 1;
+          daemonRunning = true;
+          // Assign a fresh PID on each start so tests can observe the change
+          currentPid = (cfg.daemonPid ?? 10000) + startCount * 1000;
+          return buildDaemonStatus();
+        }
+
+        return null;
+      },
+      getPendingOpenProject: async () => null,
+      events: { on: async () => () => undefined },
+    };
+  }, config);
+}
+
+export async function openDesktopSettings(page: Page, serverId: string): Promise<void> {
+  await openSettings(page);
+  await openSettingsHost(page, serverId);
+  await expect(page.getByTestId("host-page-daemon-lifecycle-card")).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+export async function expectUpdateBanner(page: Page, version: string): Promise<void> {
+  const callout = page.getByTestId("update-callout");
+  await expect(callout).toBeVisible({ timeout: 15_000 });
+  await expect(callout).toContainText(`v${version.replace(/^v/i, "")}`);
+}
+
+export async function clickInstallUpdate(page: Page): Promise<void> {
+  await page.getByTestId("update-callout-action-1").click();
+}
+
+export async function expectInstallInProgress(page: Page): Promise<void> {
+  await expect(page.getByTestId("update-callout-action-1")).toHaveText("Installing...");
+}
+
+/**
+ * Clicks the daemon management switch and awaits the browser confirm dialog.
+ * The click is fire-and-forget so the dialog fires before we await the promise.
+ * Returns the dialog so callers can assert copy then accept or dismiss.
+ */
+export async function interceptDaemonManagementConfirmDialog(page: Page): Promise<Dialog> {
+  const dialogPromise = page.waitForEvent("dialog");
+  void page.getByRole("switch", { name: "Manage built-in daemon" }).click();
+  return dialogPromise;
+}
+
+export async function toggleDaemonManagement(
+  page: Page,
+  action: "enable" | "disable",
+): Promise<void> {
+  if (action === "disable") {
+    const accepted = new Promise<void>((resolve) => {
+      page.once("dialog", async (dialog) => {
+        await dialog.accept();
+        resolve();
+      });
+    });
+    await page.getByRole("switch", { name: "Manage built-in daemon" }).click();
+    await accepted;
+  } else {
+    await page.getByRole("switch", { name: "Manage built-in daemon" }).click();
+  }
+}
+
+export function expectDaemonManagementConfirmDialog(dialog: Dialog): void {
+  expect(dialog.type()).toBe("confirm");
+  expect(dialog.message()).toContain("Pause built-in daemon");
+  expect(dialog.message()).toContain("stop the built-in daemon immediately");
+}
+
+export async function expectDaemonManagementEnabled(page: Page): Promise<void> {
+  await expect(page.getByRole("switch", { name: "Manage built-in daemon" })).toBeChecked();
+}
+
+export async function expectDaemonManagementDisabled(page: Page): Promise<void> {
+  await expect(page.getByRole("switch", { name: "Manage built-in daemon" })).not.toBeChecked();
+}
+
+/**
+ * Asserts the daemon status card shows the given PID. Pass null to assert
+ * the cleared state (shown as "PID —" when the daemon is stopped).
+ */
+export async function expectDaemonStatusPid(page: Page, pid: number | null): Promise<void> {
+  const expected = pid !== null ? `PID ${pid}` : "PID —";
+  await expect(
+    page.getByTestId("host-page-daemon-lifecycle-card").getByText(expected),
+  ).toBeVisible();
+}
+
+export async function expectDaemonStatusLogPath(page: Page, logPath: string): Promise<void> {
+  await expect(
+    page.getByTestId("host-page-daemon-lifecycle-card").getByText(logPath),
+  ).toBeVisible();
+}
+
+/**
+ * Asserts the host page identity badge shows the given version string.
+ * The badge is populated from the live WebSocket session's serverInfo.version.
+ */
+export async function expectDaemonStatusVersion(page: Page, version: string): Promise<void> {
+  await expect(
+    page.getByTestId("host-page-identity").getByText(version, { exact: false }),
+  ).toBeVisible({ timeout: 15_000 });
+}

--- a/packages/app/e2e/helpers/desktop-updates.ts
+++ b/packages/app/e2e/helpers/desktop-updates.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { expect, type Dialog, type Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { openSettings } from "./app";
 import { openSettingsHost } from "./settings";
 
@@ -38,8 +38,9 @@ export async function loadRealDaemonState(): Promise<RealDaemonState> {
   try {
     const raw = readFileSync(`${paseoHome}/paseo.pid`, "utf8");
     pid = (JSON.parse(raw) as PidFileContent).pid ?? null;
-  } catch {
+  } catch (err) {
     // PID file may not be present yet on a very fresh daemon start
+    console.warn("[desktop-updates] paseo.pid not found:", err);
   }
 
   return { version: data.version, pid, logPath: `${paseoHome}/daemon.log` };
@@ -56,6 +57,17 @@ export interface DesktopBridgeConfig {
   daemonLogPath?: string;
   /** Initial manageBuiltInDaemon setting. Defaults to false. */
   manageBuiltInDaemon?: boolean;
+  /**
+   * Controls what dialog.ask returns when the daemon management confirm dialog
+   * fires. True = confirm (proceed with the action), false = cancel. Defaults to
+   * false so tests that only assert copy don't inadvertently trigger state changes.
+   */
+  confirmShouldAccept?: boolean;
+}
+
+export interface ConfirmDialogCall {
+  message: string;
+  title: string | undefined;
 }
 
 /**
@@ -64,6 +76,8 @@ export interface DesktopBridgeConfig {
  * auto-updater never fires. Daemon start/stop commands are stateful: the mock
  * tracks running state and assigns a fresh PID on each start, letting tests
  * observe PID changes without touching the real E2E daemon process.
+ * dialog.ask captures call arguments on window.__capturedDialogCall so tests
+ * can assert dialog copy without depending on window.confirm concatenation.
  */
 export async function injectDesktopBridge(page: Page, config: DesktopBridgeConfig): Promise<void> {
   await page.addInitScript((cfg) => {
@@ -159,12 +173,22 @@ export async function injectDesktopBridge(page: Page, config: DesktopBridgeConfi
         if (command === "start_desktop_daemon") {
           startCount += 1;
           daemonRunning = true;
-          // Assign a fresh PID on each start so tests can observe the change
-          currentPid = (cfg.daemonPid ?? 10000) + startCount * 1000;
+          // First start (bootstrap) returns the configured PID; subsequent starts
+          // (after a stop) get a fresh PID so tests can observe the change.
+          currentPid = (cfg.daemonPid ?? 10000) + (startCount - 1) * 1000;
           return buildDaemonStatus();
         }
 
         return null;
+      },
+      dialog: {
+        ask: async (message: string, options?: Record<string, unknown>) => {
+          (window as unknown as Record<string, unknown>).__capturedDialogCall = {
+            message,
+            title: options?.title,
+          };
+          return cfg.confirmShouldAccept ?? false;
+        },
       },
       getPendingOpenProject: async () => null,
       events: { on: async () => () => undefined },
@@ -187,46 +211,42 @@ export async function expectUpdateBanner(page: Page, version: string): Promise<v
 }
 
 export async function clickInstallUpdate(page: Page): Promise<void> {
-  await page.getByTestId("update-callout-action-1").click();
+  await page.getByRole("button", { name: "Install & restart" }).click();
 }
 
 export async function expectInstallInProgress(page: Page): Promise<void> {
-  await expect(page.getByTestId("update-callout-action-1")).toHaveText("Installing...");
+  await expect(page.getByRole("button", { name: "Installing..." })).toBeVisible();
 }
 
 /**
- * Clicks the daemon management switch and awaits the browser confirm dialog.
- * The click is fire-and-forget so the dialog fires before we await the promise.
- * Returns the dialog so callers can assert copy then accept or dismiss.
+ * Clicks the daemon management switch and waits for dialog.ask to fire in the
+ * mock, then returns the captured call args (message + title). The mock auto-
+ * dismisses via confirmShouldAccept=false so callers can assert copy without
+ * worrying about state changes.
  */
-export async function interceptDaemonManagementConfirmDialog(page: Page): Promise<Dialog> {
-  const dialogPromise = page.waitForEvent("dialog");
-  void page.getByRole("switch", { name: "Manage built-in daemon" }).click();
-  return dialogPromise;
+export async function interceptDaemonManagementConfirmDialog(
+  page: Page,
+): Promise<ConfirmDialogCall> {
+  await page.getByRole("switch", { name: "Manage built-in daemon" }).click();
+  await page.waitForFunction(
+    () => !!(window as unknown as Record<string, unknown>).__capturedDialogCall,
+    { timeout: 5_000 },
+  );
+  return page.evaluate(
+    () => (window as unknown as Record<string, unknown>).__capturedDialogCall as ConfirmDialogCall,
+  );
 }
 
 export async function toggleDaemonManagement(
   page: Page,
-  action: "enable" | "disable",
+  _action: "enable" | "disable",
 ): Promise<void> {
-  if (action === "disable") {
-    const accepted = new Promise<void>((resolve) => {
-      page.once("dialog", async (dialog) => {
-        await dialog.accept();
-        resolve();
-      });
-    });
-    await page.getByRole("switch", { name: "Manage built-in daemon" }).click();
-    await accepted;
-  } else {
-    await page.getByRole("switch", { name: "Manage built-in daemon" }).click();
-  }
+  await page.getByRole("switch", { name: "Manage built-in daemon" }).click();
 }
 
-export function expectDaemonManagementConfirmDialog(dialog: Dialog): void {
-  expect(dialog.type()).toBe("confirm");
-  expect(dialog.message()).toContain("Pause built-in daemon");
-  expect(dialog.message()).toContain("stop the built-in daemon immediately");
+export function expectDaemonManagementConfirmDialog(args: ConfirmDialogCall): void {
+  expect(args.title).toBe("Pause built-in daemon");
+  expect(args.message).toContain("stop the built-in daemon immediately");
 }
 
 export async function expectDaemonManagementEnabled(page: Page): Promise<void> {


### PR DESCRIPTION
## Summary

- Adds `packages/app/e2e/desktop-updates.spec.ts` with 6 Electron-only E2E tests across two describe blocks: update banner behavior and daemon lifecycle management
- Adds `packages/app/e2e/helpers/desktop-updates.ts` with a reusable DSL: `injectDesktopBridge`, `loadRealDaemonState`, and assertion/action helpers for the update callout and daemon settings UI
- Exports `E2E_PASEO_HOME` from `global-setup.ts` so tests can read the real `paseo.pid` lock file and derive the `daemon.log` path — no hardcoded paths

## What's tested

- Update callout renders with the correct version string when `check_app_update` returns `updateAvailable: true`
- Clicking install shows "Installing…" while a slow install is in flight
- Disabling daemon management triggers a confirm dialog with correct copy; cancelling leaves the toggle on
- Confirming the dialog disables daemon management
- Daemon status panel renders version, PID, and log path seeded from the real running E2E daemon
- Stopping then re-enabling daemon management yields a fresh (changed) PID via the stateful IPC mock

## Test plan

- [ ] CI Playwright run on the Desktop Chrome project passes all 6 tests
- [ ] `npm run typecheck` — green (verified locally)
- [ ] `npm run lint` — green (verified locally)
- [ ] `npm run format:check` — green (verified locally)