### PR TITLE
[codex] add workspace file previews and robust web downloads

### DIFF
--- a/docs/superpowers/plans/2026-05-05-file-preview-drawio-office.md
+++ b/docs/superpowers/plans/2026-05-05-file-preview-drawio-office.md
@@ -1,0 +1,84 @@
+# File Preview Drawio Office Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add draw.io preview/edit/save and local read-only DOCX/XLSX previews in workspace file tabs.
+
+**Architecture:** Extend the existing file tab and file explorer read path rather than adding a new navigation surface. The server owns scoped workspace writes; the app owns extension-based renderer selection and third-party rendering libraries.
+
+**Tech Stack:** TypeScript, React Native/React Native Web, `react-native-webview`, diagrams.net embed mode, `docx-preview`, SheetJS `xlsx`, Vitest.
+
+---
+
+### Task 1: Workspace File Save Protocol
+
+**Files:**
+
+- Modify: `packages/server/src/shared/messages.ts`
+- Modify: `packages/server/src/shared/messages.test.ts`
+- Modify: `packages/server/src/server/file-explorer/service.ts`
+- Modify: `packages/server/src/server/file-explorer/service.test.ts`
+- Modify: `packages/server/src/client/daemon-client.ts`
+- Modify: `packages/server/src/client/daemon-client.test.ts`
+- Modify: `packages/server/src/server/session.ts`
+- Modify: `packages/server/src/server/session.test.ts`
+
+- [ ] Add failing tests for `workspace_file_save_request`, scoped writes, stale checks, client request/response, and session handling.
+- [ ] Run the targeted server tests and confirm they fail because the save API does not exist.
+- [ ] Add schemas and types with optional compatibility fields.
+- [ ] Add a scoped write helper that accepts base64 content and returns path, size, and modified time.
+- [ ] Add `DaemonClient.saveFile`.
+- [ ] Route the message through `Session`.
+- [ ] Run the targeted tests and confirm they pass.
+
+### Task 2: Preview Mode Routing
+
+**Files:**
+
+- Modify: `packages/app/src/components/file-pane-render-mode.ts`
+- Modify: `packages/app/src/components/file-pane-render-mode.test.ts`
+
+- [ ] Add failing tests for draw.io, docx, xlsx, and existing markdown behavior.
+- [ ] Implement `getWorkspaceFilePreviewMode(filePath)`.
+- [ ] Run the targeted app test and confirm it passes.
+
+### Task 3: Third-Party Preview Components
+
+**Files:**
+
+- Modify: `packages/app/package.json`
+- Modify: `package-lock.json`
+- Create: `packages/app/src/components/workspace-file-previews/drawio-preview.web.tsx`
+- Create: `packages/app/src/components/workspace-file-previews/drawio-preview.native.tsx`
+- Create: `packages/app/src/components/workspace-file-previews/drawio-preview.tsx`
+- Create: `packages/app/src/components/workspace-file-previews/docx-preview.web.tsx`
+- Create: `packages/app/src/components/workspace-file-previews/docx-preview.native.tsx`
+- Create: `packages/app/src/components/workspace-file-previews/spreadsheet-preview.web.tsx`
+- Create: `packages/app/src/components/workspace-file-previews/spreadsheet-preview.native.tsx`
+
+- [ ] Install `docx-preview` and `xlsx` in `@getpaseo/app`.
+- [ ] Add focused renderer components using the libraries, with native WebView fallbacks where needed.
+- [ ] Keep DOM access inside `.web.tsx` files and WebView HTML inside `.native.tsx` files.
+
+### Task 4: FilePane Integration
+
+**Files:**
+
+- Modify: `packages/app/src/components/file-pane.tsx`
+
+- [ ] Route special preview modes before existing text/image/binary rendering.
+- [ ] Pass bytes, metadata, and save callback to draw.io.
+- [ ] Keep existing previews unchanged for all other files.
+
+### Task 5: Verification
+
+**Files:**
+
+- All modified files.
+
+- [ ] Run targeted Vitest files touched by the change.
+- [ ] Run `npm run build:daemon` if generated daemon declarations are needed.
+- [ ] Run `npm run typecheck`.
+- [ ] Run `npm run lint`.
+- [ ] Run `npm run format`.
+- [ ] Run `npm run format:check`.

--- a/docs/superpowers/specs/2026-05-05-file-preview-drawio-office-design.md
+++ b/docs/superpowers/specs/2026-05-05-file-preview-drawio-office-design.md
@@ -1,0 +1,41 @@
+# File Preview Drawio Office Design
+
+## Goal
+
+Add local workspace file previews for `.drawio`, `.drawio.xml`, `.docx`, `.xlsx`, and `.xls`, with draw.io editing and save-back support.
+
+## Scope
+
+- Draw.io files open in a file tab, render through the diagrams.net embed surface, allow editing, and save the updated XML back to the same workspace path.
+- Word and Excel files open in a file tab and render read-only previews using client-side libraries.
+- File bytes stay local to the connected daemon/app. The Office preview path does not use Microsoft, Google, or other hosted document viewers.
+- Password-protected Office files, macros, formula execution, collaborative editing, and draw.io conflict resolution UI are out of scope.
+
+## Architecture
+
+The server keeps the workspace boundary as the authority. Existing file reads continue through `file_explorer_request`; a new save request writes base64 bytes to a path after resolving it under the workspace root and optionally checking the previously loaded size and modified time.
+
+The app keeps file tabs as the entry point. `FilePane` chooses a specialized preview mode by file extension: draw.io editor, DOCX preview, spreadsheet preview, or the existing text/image/binary preview. Platform-specific renderer files carry DOM/iframe/WebView code so native bundles do not import raw DOM APIs.
+
+## Components
+
+- Server file service: add a write helper beside `readExplorerFileBytes`.
+- Shared messages and daemon client: add backward-compatible file save request/response shapes and a `saveFile` client method.
+- File preview mode utility: centralize extension detection for markdown, draw.io, Word, and spreadsheet files.
+- Draw.io preview component: embed diagrams.net, load XML, receive save events, and call `client.saveFile`.
+- DOCX preview component: use `docx-preview` to render bytes into a local container.
+- Spreadsheet preview component: use SheetJS `xlsx` to render workbook sheets into a read-only table view.
+
+## Error Handling
+
+The server rejects empty cwd, paths outside the workspace, non-file parents, and optional stale-write checks. The client shows existing center-state errors when reads fail and a compact save error in the draw.io toolbar when writes fail.
+
+## Testing
+
+Use targeted tests only:
+
+- `packages/server/src/shared/messages.test.ts`
+- `packages/server/src/server/file-explorer/service.test.ts`
+- `packages/server/src/client/daemon-client.test.ts`
+- `packages/server/src/server/session.test.ts`
+- `packages/app/src/components/file-pane-render-mode.test.ts`

--- a/package-lock.json
+++ b/package-lock.json
@@ -15576,6 +15576,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/adm-zip": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
@@ -17457,6 +17466,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -17925,6 +17947,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
@@ -18217,7 +18248,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -18246,6 +18276,18 @@
       "optional": true,
       "dependencies": {
         "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/crc/node_modules/buffer": {
@@ -19100,6 +19142,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/docx-preview": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/docx-preview/-/docx-preview-0.3.7.tgz",
+      "integrity": "sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jszip": ">=3.0.0"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -24427,6 +24478,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/framer-motion": {
       "version": "12.35.2",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.35.2.tgz",
@@ -25723,7 +25783,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -27661,7 +27720,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dev": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
@@ -28008,7 +28066,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
@@ -31468,7 +31525,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
@@ -32212,7 +32268,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/process-warning": {
@@ -33497,7 +33552,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -33513,14 +33567,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/readdirp": {
@@ -35137,6 +35189,18 @@
         "node": ">=20.16.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ssri": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
@@ -35328,7 +35392,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -35338,7 +35401,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-length": {
@@ -37329,7 +37391,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -38038,11 +38099,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/wonka": {
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.5.tgz",
       "integrity": "sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw==",
       "license": "MIT"
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -38223,6 +38302,27 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-lexer": {
@@ -38574,6 +38674,7 @@
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "buffer": "^6.0.3",
+        "docx-preview": "^0.3.7",
         "expo": "^54.0.18",
         "expo-asset": "~12.0.12",
         "expo-audio": "~1.0.13",
@@ -38618,6 +38719,7 @@
         "react-native-worklets": "0.5.1",
         "tiny-invariant": "^1.3.3",
         "use-sync-external-store": "^1.6.0",
+        "xlsx": "^0.18.5",
         "zod": "^3.23.8",
         "zustand": "^5.0.9"
       },
@@ -39338,33 +39440,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "packages/website/node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/website/node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
-    "packages/website/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
     }
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -51,6 +51,7 @@
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "buffer": "^6.0.3",
+    "docx-preview": "^0.3.7",
     "expo": "^54.0.18",
     "expo-asset": "~12.0.12",
     "expo-audio": "~1.0.13",
@@ -95,6 +96,7 @@
     "react-native-worklets": "0.5.1",
     "tiny-invariant": "^1.3.3",
     "use-sync-external-store": "^1.6.0",
+    "xlsx": "^0.18.5",
     "zod": "^3.23.8",
     "zustand": "^5.0.9"
   },

--- a/packages/app/src/components/file-explorer-pane.tsx
+++ b/packages/app/src/components/file-explorer-pane.tsx
@@ -258,12 +258,16 @@ export function FileExplorerPane({
       : undefined,
   );
 
-  const { requestDirectoryListing, requestFileDownloadToken, selectExplorerEntry } =
-    useFileExplorerActions({
-      serverId,
-      workspaceId,
-      workspaceRoot: normalizedWorkspaceRoot,
-    });
+  const {
+    requestDirectoryListing,
+    requestFileDownloadToken,
+    requestFileBytes,
+    selectExplorerEntry,
+  } = useFileExplorerActions({
+    serverId,
+    workspaceId,
+    workspaceRoot: normalizedWorkspaceRoot,
+  });
   const sortOption = usePanelStore((state) => state.explorerSortOption);
   const setSortOption = usePanelStore((state) => state.setExplorerSortOption);
   const expandedPathsArray = usePanelStore((state) =>
@@ -367,8 +371,16 @@ export function FileExplorerPane({
         daemonProfile,
         startDownload,
         requestFileDownloadToken,
+        requestFileBytes,
       }),
-    [daemonProfile, requestFileDownloadToken, serverId, startDownload, workspaceScopeId],
+    [
+      daemonProfile,
+      requestFileBytes,
+      requestFileDownloadToken,
+      serverId,
+      startDownload,
+      workspaceScopeId,
+    ],
   );
 
   const handleSortCycle = useCallback(() => {
@@ -734,6 +746,7 @@ function downloadExplorerEntry({
   daemonProfile,
   startDownload,
   requestFileDownloadToken,
+  requestFileBytes,
 }: {
   entry: ExplorerEntry;
   workspaceScopeId: string | undefined;
@@ -743,6 +756,7 @@ function downloadExplorerEntry({
   requestFileDownloadToken: (
     targetPath: string,
   ) => ReturnType<StartDownloadParams["requestFileDownloadToken"]>;
+  requestFileBytes: NonNullable<StartDownloadParams["requestFileBytes"]>;
 }): void {
   if (!workspaceScopeId || entry.kind !== "file") {
     return;
@@ -754,6 +768,7 @@ function downloadExplorerEntry({
     path: entry.path,
     daemonProfile,
     requestFileDownloadToken: (targetPath) => requestFileDownloadToken(targetPath),
+    requestFileBytes: (targetPath) => requestFileBytes(targetPath),
   });
 }
 

--- a/packages/app/src/components/file-pane-render-mode.test.ts
+++ b/packages/app/src/components/file-pane-render-mode.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { isRenderedMarkdownFile } from "@/components/file-pane-render-mode";
+import {
+  getWorkspaceFilePreviewMode,
+  isRenderedMarkdownFile,
+} from "@/components/file-pane-render-mode";
 
 describe("isRenderedMarkdownFile", () => {
   it("detects .md files", () => {
@@ -19,5 +22,23 @@ describe("isRenderedMarkdownFile", () => {
   it("does not treat other text files as rendered markdown", () => {
     expect(isRenderedMarkdownFile("src/index.ts")).toBe(false);
     expect(isRenderedMarkdownFile("README.md.txt")).toBe(false);
+  });
+});
+
+describe("getWorkspaceFilePreviewMode", () => {
+  it("routes draw.io diagrams to the drawio preview", () => {
+    expect(getWorkspaceFilePreviewMode("architecture.drawio")).toBe("drawio");
+    expect(getWorkspaceFilePreviewMode("docs/flow.DRAWIO.XML")).toBe("drawio");
+  });
+
+  it("routes Office documents to local read-only previews", () => {
+    expect(getWorkspaceFilePreviewMode("notes.docx")).toBe("docx");
+    expect(getWorkspaceFilePreviewMode("reports/plan.XLSX")).toBe("spreadsheet");
+    expect(getWorkspaceFilePreviewMode("reports/legacy.xls")).toBe("spreadsheet");
+  });
+
+  it("preserves existing markdown and default routing", () => {
+    expect(getWorkspaceFilePreviewMode("README.md")).toBe("markdown");
+    expect(getWorkspaceFilePreviewMode("src/index.ts")).toBe("default");
   });
 });

--- a/packages/app/src/components/file-pane-render-mode.ts
+++ b/packages/app/src/components/file-pane-render-mode.ts
@@ -1,4 +1,23 @@
+export type WorkspaceFilePreviewMode = "default" | "markdown" | "drawio" | "docx" | "spreadsheet";
+
 export function isRenderedMarkdownFile(filePath: string): boolean {
   const normalizedPath = filePath.trim().toLowerCase();
   return normalizedPath.endsWith(".md") || normalizedPath.endsWith(".markdown");
+}
+
+export function getWorkspaceFilePreviewMode(filePath: string): WorkspaceFilePreviewMode {
+  const normalizedPath = filePath.trim().toLowerCase();
+  if (isRenderedMarkdownFile(normalizedPath)) {
+    return "markdown";
+  }
+  if (normalizedPath.endsWith(".drawio") || normalizedPath.endsWith(".drawio.xml")) {
+    return "drawio";
+  }
+  if (normalizedPath.endsWith(".docx")) {
+    return "docx";
+  }
+  if (normalizedPath.endsWith(".xlsx") || normalizedPath.endsWith(".xls")) {
+    return "spreadsheet";
+  }
+  return "default";
 }

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useRef } from "react";
-import { useQuery } from "@tanstack/react-query";
+import React, { useCallback, useMemo, useRef } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { FileReadResult } from "@server/client/daemon-client";
 import Markdown, { MarkdownIt } from "react-native-markdown-display";
 import {
@@ -23,7 +23,10 @@ import {
   type HighlightStyle,
 } from "@getpaseo/highlight";
 import { lineNumberGutterWidth } from "@/components/code-insets";
-import { isRenderedMarkdownFile } from "@/components/file-pane-render-mode";
+import {
+  getWorkspaceFilePreviewMode,
+  isRenderedMarkdownFile,
+} from "@/components/file-pane-render-mode";
 import { isWeb } from "@/constants/platform";
 import { createMarkdownStyles } from "@/styles/markdown-styles";
 import type { AttachmentMetadata } from "@/attachments/types";
@@ -31,6 +34,9 @@ import { useAttachmentPreviewUrl } from "@/attachments/use-attachment-preview-ur
 import { persistAttachmentFromBytes } from "@/attachments/service";
 import { createPreviewAttachmentId, getFileNameFromPath } from "@/attachments/utils";
 import { explorerFileFromReadResult } from "@/file-explorer/read-result";
+import { WorkspaceDrawioPreview } from "@/components/workspace-file-previews/drawio-preview";
+import { WorkspaceDocxPreview } from "@/components/workspace-file-previews/docx-preview";
+import { WorkspaceSpreadsheetPreview } from "@/components/workspace-file-previews/spreadsheet-preview";
 
 interface CodeLineProps {
   tokens: HighlightToken[];
@@ -352,29 +358,41 @@ export function FilePane({
 }) {
   const isMobile = useIsCompactFormFactor();
   const showDesktopWebScrollbar = isWeb && !isMobile;
+  const queryClient = useQueryClient();
 
   const client = useSessionStore((state) => state.sessions[serverId]?.client ?? null);
   const normalizedWorkspaceRoot = useMemo(() => workspaceRoot.trim(), [workspaceRoot]);
   const normalizedFilePath = useMemo(() => trimNonEmpty(filePath), [filePath]);
+  const workspaceFileQueryKey = useMemo(
+    () => ["workspaceFile", serverId, normalizedWorkspaceRoot, normalizedFilePath],
+    [normalizedFilePath, normalizedWorkspaceRoot, serverId],
+  );
 
   const query = useQuery({
-    queryKey: ["workspaceFile", serverId, normalizedWorkspaceRoot, normalizedFilePath],
+    queryKey: workspaceFileQueryKey,
     enabled: Boolean(client && normalizedWorkspaceRoot && normalizedFilePath),
     queryFn: async () => {
       if (!client || !normalizedWorkspaceRoot || !normalizedFilePath) {
-        return { file: null as ExplorerFile | null, error: "Host is not connected" };
+        return {
+          file: null as ExplorerFile | null,
+          readResult: null as FileReadResult | null,
+          imageAttachment: null as AttachmentMetadata | null,
+          error: "Host is not connected",
+        };
       }
       try {
         const file = await client.readFile(normalizedWorkspaceRoot, normalizedFilePath);
         const preview = await createFilePanePreview(file);
         return {
           file: preview.file,
+          readResult: file,
           imageAttachment: preview.imageAttachment,
           error: null,
         };
       } catch (error) {
         return {
           file: null,
+          readResult: null,
           imageAttachment: null,
           error: error instanceof Error ? error.message : "Failed to load file",
         };
@@ -384,6 +402,73 @@ export function FilePane({
     refetchOnMount: true,
   });
   const imagePreviewUri = useAttachmentPreviewUrl(query.data?.imageAttachment ?? null);
+  const previewMode = useMemo(
+    () => (normalizedFilePath ? getWorkspaceFilePreviewMode(normalizedFilePath) : "default"),
+    [normalizedFilePath],
+  );
+  const handleSaveBytes = useCallback(
+    async ({
+      bytes,
+      expectedModifiedAt,
+      expectedSize,
+    }: {
+      bytes: Uint8Array;
+      expectedModifiedAt: string;
+      expectedSize: number;
+    }) => {
+      if (!client || !normalizedWorkspaceRoot || !normalizedFilePath) {
+        throw new Error("Host is not connected");
+      }
+      await client.saveFile(normalizedWorkspaceRoot, normalizedFilePath, bytes, {
+        expectedModifiedAt,
+        expectedSize,
+      });
+      await queryClient.invalidateQueries({ queryKey: workspaceFileQueryKey });
+    },
+    [client, normalizedFilePath, normalizedWorkspaceRoot, queryClient, workspaceFileQueryKey],
+  );
+
+  const readResult = query.data?.readResult ?? null;
+  const specialPreview = useMemo(() => {
+    if (!readResult) {
+      return null;
+    }
+    if (previewMode === "drawio") {
+      return (
+        <WorkspaceDrawioPreview
+          filePath={filePath}
+          bytes={readResult.bytes}
+          mimeType={readResult.mime}
+          size={readResult.size}
+          modifiedAt={readResult.modifiedAt}
+          onSave={handleSaveBytes}
+        />
+      );
+    }
+    if (previewMode === "docx") {
+      return (
+        <WorkspaceDocxPreview
+          filePath={filePath}
+          bytes={readResult.bytes}
+          mimeType={readResult.mime}
+          size={readResult.size}
+          modifiedAt={readResult.modifiedAt}
+        />
+      );
+    }
+    if (previewMode === "spreadsheet") {
+      return (
+        <WorkspaceSpreadsheetPreview
+          filePath={filePath}
+          bytes={readResult.bytes}
+          mimeType={readResult.mime}
+          size={readResult.size}
+          modifiedAt={readResult.modifiedAt}
+        />
+      );
+    }
+    return null;
+  }, [filePath, handleSaveBytes, previewMode, readResult]);
 
   return (
     <View style={styles.container} testID="workspace-file-pane">
@@ -393,14 +478,16 @@ export function FilePane({
         </View>
       ) : null}
 
-      <FilePreviewBody
-        preview={query.data?.file ?? null}
-        isLoading={query.isFetching}
-        showDesktopWebScrollbar={showDesktopWebScrollbar}
-        isMobile={isMobile}
-        filePath={filePath}
-        imagePreviewUri={imagePreviewUri}
-      />
+      {specialPreview ?? (
+        <FilePreviewBody
+          preview={query.data?.file ?? null}
+          isLoading={query.isFetching}
+          showDesktopWebScrollbar={showDesktopWebScrollbar}
+          isMobile={isMobile}
+          filePath={filePath}
+          imagePreviewUri={imagePreviewUri}
+        />
+      )}
     </View>
   );
 }

--- a/packages/app/src/components/workspace-file-previews/bytes.ts
+++ b/packages/app/src/components/workspace-file-previews/bytes.ts
@@ -1,0 +1,13 @@
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    const chunk = bytes.subarray(index, index + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return globalThis.btoa(binary);
+}
+
+export function bytesToUtf8(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}

--- a/packages/app/src/components/workspace-file-previews/docx-preview.native.tsx
+++ b/packages/app/src/components/workspace-file-previews/docx-preview.native.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from "react";
+import NativeWebView from "react-native-webview";
+import { StyleSheet } from "react-native-unistyles";
+import { bytesToBase64 } from "@/components/workspace-file-previews/bytes";
+import type { WorkspaceFilePreviewProps } from "@/components/workspace-file-previews/types";
+
+const WEBVIEW_ORIGIN_WHITELIST = ["*"];
+
+function buildDocxHtml(base64: string): string {
+  return `<!doctype html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<style>
+body{margin:0;background:#fff;color:#111;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+#root{padding:12px;overflow:auto}
+#state{padding:24px;color:#555;font-size:14px}
+</style>
+</head>
+<body>
+<div id="state">Loading document...</div>
+<div id="root"></div>
+<script src="https://unpkg.com/jszip@3.10.1/dist/jszip.min.js"></script>
+<script src="https://unpkg.com/docx-preview@0.3.7/dist/docx-preview.min.js"></script>
+<script>
+function bytesFromBase64(value){const binary=atob(value);const bytes=new Uint8Array(binary.length);for(let i=0;i<binary.length;i++)bytes[i]=binary.charCodeAt(i);return bytes;}
+window.addEventListener('load',function(){
+  const state=document.getElementById('state');
+  const root=document.getElementById('root');
+  const blob=new Blob([bytesFromBase64(${JSON.stringify(base64)})],{type:'application/vnd.openxmlformats-officedocument.wordprocessingml.document'});
+  window.docx.renderAsync(blob,root,undefined,{className:'paseo-docx-preview',inWrapper:true,ignoreFonts:true})
+    .then(function(){state.remove();})
+    .catch(function(error){state.textContent=error && error.message ? error.message : 'Failed to render document';});
+});
+</script>
+</body>
+</html>`;
+}
+
+export function WorkspaceDocxPreview({ bytes }: WorkspaceFilePreviewProps) {
+  const html = useMemo(() => buildDocxHtml(bytesToBase64(bytes)), [bytes]);
+  const source = useMemo(() => ({ html }), [html]);
+  return (
+    <NativeWebView
+      originWhitelist={WEBVIEW_ORIGIN_WHITELIST}
+      source={source}
+      javaScriptEnabled
+      domStorageEnabled
+      style={styles.webview}
+    />
+  );
+}
+
+const styles = StyleSheet.create(() => ({
+  webview: {
+    flex: 1,
+  },
+}));

--- a/packages/app/src/components/workspace-file-previews/docx-preview.tsx
+++ b/packages/app/src/components/workspace-file-previews/docx-preview.tsx
@@ -1,0 +1,26 @@
+import { Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import type { WorkspaceFilePreviewProps } from "@/components/workspace-file-previews/types";
+
+export function WorkspaceDocxPreview(_props: WorkspaceFilePreviewProps) {
+  return (
+    <View style={styles.centerState}>
+      <Text style={styles.emptyText}>DOCX preview is unavailable on this platform.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  centerState: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: theme.spacing[4],
+    backgroundColor: theme.colors.surface0,
+  },
+  emptyText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    textAlign: "center",
+  },
+}));

--- a/packages/app/src/components/workspace-file-previews/docx-preview.web.tsx
+++ b/packages/app/src/components/workspace-file-previews/docx-preview.web.tsx
@@ -1,0 +1,102 @@
+import { createElement, useEffect, useMemo, useRef, useState } from "react";
+import { ActivityIndicator, Text, View } from "react-native";
+import { renderAsync } from "docx-preview";
+import { StyleSheet } from "react-native-unistyles";
+import type { WorkspaceFilePreviewProps } from "@/components/workspace-file-previews/types";
+
+export function WorkspaceDocxPreview({ bytes }: WorkspaceFilePreviewProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const hostStyle = useMemo(
+    () => [styles.webHost, (loading || error) && styles.hiddenHost],
+    [error, loading],
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    container.innerHTML = "";
+    setLoading(true);
+    setError(null);
+    const buffer = new ArrayBuffer(bytes.byteLength);
+    new Uint8Array(buffer).set(bytes);
+    const blob = new Blob([buffer], {
+      type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    void renderAsync(blob, container, undefined, {
+      className: "paseo-docx-preview",
+      inWrapper: true,
+      ignoreFonts: true,
+    })
+      .catch((renderError: unknown) => {
+        setError(renderError instanceof Error ? renderError.message : "Failed to render document");
+      })
+      .finally(() => setLoading(false));
+  }, [bytes]);
+
+  const host = createElement("div", {
+    ref: containerRef,
+    style: {
+      boxSizing: "border-box",
+      minHeight: "100%",
+      padding: 16,
+      overflow: "auto",
+    },
+  });
+
+  return (
+    <View style={styles.container}>
+      {loading ? (
+        <View style={styles.centerState}>
+          <ActivityIndicator size="small" />
+          <Text style={styles.loadingText}>Loading document...</Text>
+        </View>
+      ) : null}
+      {error ? (
+        <View style={styles.centerState}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      ) : null}
+      <View style={hostStyle}>{host}</View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    flex: 1,
+    minHeight: 0,
+    backgroundColor: theme.colors.surface0,
+  },
+  webHost: {
+    flex: 1,
+    minHeight: 0,
+  },
+  hiddenHost: {
+    opacity: 0,
+    position: "absolute",
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  },
+  centerState: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: theme.spacing[4],
+  },
+  loadingText: {
+    marginTop: theme.spacing[2],
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  errorText: {
+    color: theme.colors.destructive,
+    fontSize: theme.fontSize.sm,
+    textAlign: "center",
+  },
+}));

--- a/packages/app/src/components/workspace-file-previews/drawio-preview.native.tsx
+++ b/packages/app/src/components/workspace-file-previews/drawio-preview.native.tsx
@@ -1,0 +1,185 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { ActivityIndicator, Pressable, Text, View } from "react-native";
+import { Save } from "lucide-react-native";
+import NativeWebView, { type WebViewMessageEvent } from "react-native-webview";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { bytesToUtf8 } from "@/components/workspace-file-previews/bytes";
+import type { WorkspaceDrawioPreviewProps } from "@/components/workspace-file-previews/types";
+
+const WEBVIEW_ORIGIN_WHITELIST = ["*"];
+
+function escapeScriptString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function buildDrawioHtml(title: string): string {
+  return `<!doctype html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<style>html,body,#frame{margin:0;width:100%;height:100%;overflow:hidden}iframe{border:0;width:100%;height:100%}</style>
+</head>
+<body>
+<iframe id="frame" title="${title.replace(/"/g, "&quot;")}" src="https://embed.diagrams.net/?embed=1&proto=json&spin=1&ui=min&libraries=1&saveAndExit=0&noExitBtn=1"></iframe>
+<script>
+const frame = document.getElementById('frame');
+window.__paseoPostToDrawio = function(payload) {
+  frame.contentWindow.postMessage(payload, 'https://embed.diagrams.net');
+};
+window.addEventListener('message', function(event) {
+  if (event.origin === 'https://embed.diagrams.net') {
+    window.ReactNativeWebView.postMessage(event.data);
+  }
+});
+</script>
+</body>
+</html>`;
+}
+
+export function WorkspaceDrawioPreview({
+  filePath,
+  bytes,
+  size,
+  modifiedAt,
+  onSave,
+}: WorkspaceDrawioPreviewProps) {
+  const { theme } = useUnistyles();
+  const webViewRef = useRef<NativeWebView>(null);
+  const [status, setStatus] = useState<"loading" | "ready" | "saving" | "saved" | "error">(
+    "loading",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const xml = useMemo(() => bytesToUtf8(bytes), [bytes]);
+  const title = useMemo(() => filePath.split("/").findLast(Boolean) ?? filePath, [filePath]);
+  const html = useMemo(() => buildDrawioHtml(title), [title]);
+
+  const postToDrawio = useCallback((payload: Record<string, unknown>) => {
+    webViewRef.current?.injectJavaScript(
+      `window.__paseoPostToDrawio(${escapeScriptString(JSON.stringify(payload))}); true;`,
+    );
+  }, []);
+
+  const handleSavePress = useCallback(() => {
+    postToDrawio({ action: "save" });
+  }, [postToDrawio]);
+
+  const webViewSource = useMemo(() => ({ html }), [html]);
+  const handleMessage = useCallback(
+    (event: WebViewMessageEvent) => {
+      let payload: Record<string, unknown> | null = null;
+      try {
+        const parsed = JSON.parse(event.nativeEvent.data);
+        payload =
+          parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : null;
+      } catch {
+        payload = null;
+      }
+      if (!payload) {
+        return;
+      }
+      if (payload.event === "init") {
+        postToDrawio({ action: "load", autosave: 0, title, xml });
+        setStatus("ready");
+        return;
+      }
+      if (payload.event !== "save" || typeof payload.xml !== "string") {
+        return;
+      }
+      setStatus("saving");
+      setError(null);
+      void (async () => {
+        try {
+          await onSave({
+            bytes: new TextEncoder().encode(payload.xml as string),
+            expectedModifiedAt: modifiedAt,
+            expectedSize: size,
+          });
+          setStatus("saved");
+          postToDrawio({ action: "status", message: "Saved", modified: false });
+        } catch (saveError) {
+          setStatus("error");
+          setError(saveError instanceof Error ? saveError.message : "Failed to save diagram");
+          postToDrawio({ action: "status", message: "Save failed", modified: true });
+        }
+      })();
+    },
+    [modifiedAt, onSave, postToDrawio, size, title, xml],
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.toolbar}>
+        <View style={styles.statusSlot}>
+          {status === "loading" || status === "saving" ? <ActivityIndicator size="small" /> : null}
+          <Text style={styles.statusText} numberOfLines={1}>
+            {error ?? (status === "saved" ? "Saved" : "Draw.io")}
+          </Text>
+        </View>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Save diagram"
+          onPress={handleSavePress}
+          style={styles.saveButton}
+        >
+          <Save size={16} color={theme.colors.foreground} />
+          <Text style={styles.saveButtonText}>Save</Text>
+        </Pressable>
+      </View>
+      <NativeWebView
+        ref={webViewRef}
+        originWhitelist={WEBVIEW_ORIGIN_WHITELIST}
+        source={webViewSource}
+        onMessage={handleMessage}
+        javaScriptEnabled
+        domStorageEnabled
+        style={styles.webview}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.surface0,
+  },
+  toolbar: {
+    height: 44,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: theme.colors.border,
+  },
+  statusSlot: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  statusText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  saveButton: {
+    height: 32,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.sm,
+    backgroundColor: theme.colors.surface1,
+  },
+  saveButtonText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  webview: {
+    flex: 1,
+  },
+}));

--- a/packages/app/src/components/workspace-file-previews/drawio-preview.tsx
+++ b/packages/app/src/components/workspace-file-previews/drawio-preview.tsx
@@ -1,0 +1,26 @@
+import { Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import type { WorkspaceDrawioPreviewProps } from "@/components/workspace-file-previews/types";
+
+export function WorkspaceDrawioPreview(_props: WorkspaceDrawioPreviewProps) {
+  return (
+    <View style={styles.centerState}>
+      <Text style={styles.emptyText}>Draw.io preview is unavailable on this platform.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  centerState: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: theme.spacing[4],
+    backgroundColor: theme.colors.surface0,
+  },
+  emptyText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    textAlign: "center",
+  },
+}));

--- a/packages/app/src/components/workspace-file-previews/drawio-preview.web.tsx
+++ b/packages/app/src/components/workspace-file-previews/drawio-preview.web.tsx
@@ -1,0 +1,189 @@
+import { createElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ActivityIndicator, Pressable, Text, View } from "react-native";
+import { Save } from "lucide-react-native";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { bytesToUtf8 } from "@/components/workspace-file-previews/bytes";
+import type { WorkspaceDrawioPreviewProps } from "@/components/workspace-file-previews/types";
+
+const DRAWIO_ORIGIN = "https://embed.diagrams.net";
+const DRAWIO_TARGET_ORIGIN = "*";
+const DRAWIO_URL =
+  "https://embed.diagrams.net/?embed=1&proto=json&spin=1&ui=min&libraries=1&saveAndExit=0&noExitBtn=1";
+
+function parseDrawioMessage(data: unknown): Record<string, unknown> | null {
+  if (typeof data !== "string") {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(data);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function WorkspaceDrawioPreview({
+  filePath,
+  bytes,
+  size,
+  modifiedAt,
+  onSave,
+}: WorkspaceDrawioPreviewProps) {
+  const { theme } = useUnistyles();
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [status, setStatus] = useState<"loading" | "ready" | "saving" | "saved" | "error">(
+    "loading",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const xml = useMemo(() => bytesToUtf8(bytes), [bytes]);
+  const title = useMemo(() => filePath.split("/").findLast(Boolean) ?? filePath, [filePath]);
+
+  const postToDrawio = useCallback((payload: Record<string, unknown>) => {
+    iframeRef.current?.contentWindow?.postMessage(JSON.stringify(payload), DRAWIO_TARGET_ORIGIN);
+  }, []);
+  const handleSavePress = useCallback(() => {
+    postToDrawio({ action: "save" });
+  }, [postToDrawio]);
+  const saveButtonStyle = useCallback(
+    ({ hovered, pressed }: { hovered?: boolean; pressed?: boolean }) => [
+      styles.saveButton,
+      (hovered || pressed) && styles.saveButtonActive,
+    ],
+    [],
+  );
+
+  useEffect(() => {
+    const listener = (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow && event.origin !== DRAWIO_ORIGIN) {
+        return;
+      }
+      const payload = parseDrawioMessage(event.data);
+      if (!payload) {
+        return;
+      }
+      if (payload.event === "init") {
+        postToDrawio({
+          action: "load",
+          autosave: 0,
+          title,
+          xml,
+        });
+        setStatus("ready");
+        return;
+      }
+      if (payload.event !== "save") {
+        return;
+      }
+      const nextXml = typeof payload.xml === "string" ? payload.xml : null;
+      if (!nextXml) {
+        return;
+      }
+      setStatus("saving");
+      setError(null);
+      void (async () => {
+        try {
+          await onSave({
+            bytes: new TextEncoder().encode(nextXml),
+            expectedModifiedAt: modifiedAt,
+            expectedSize: size,
+          });
+          setStatus("saved");
+          postToDrawio({ action: "status", message: "Saved", modified: false });
+        } catch (saveError) {
+          setStatus("error");
+          setError(saveError instanceof Error ? saveError.message : "Failed to save diagram");
+          postToDrawio({ action: "status", message: "Save failed", modified: true });
+        }
+      })();
+    };
+    window.addEventListener("message", listener);
+    return () => window.removeEventListener("message", listener);
+  }, [modifiedAt, onSave, postToDrawio, size, title, xml]);
+
+  const iframe = createElement("iframe", {
+    ref: iframeRef,
+    src: DRAWIO_URL,
+    title,
+    sandbox: "allow-scripts allow-forms allow-popups allow-downloads",
+    style: {
+      border: 0,
+      flex: 1,
+      height: "100%",
+      width: "100%",
+    },
+  });
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.toolbar}>
+        <View style={styles.statusSlot}>
+          {status === "loading" || status === "saving" ? <ActivityIndicator size="small" /> : null}
+          <Text style={styles.statusText} numberOfLines={1}>
+            {error ?? (status === "saved" ? "Saved" : "Draw.io")}
+          </Text>
+        </View>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Save diagram"
+          onPress={handleSavePress}
+          style={saveButtonStyle}
+        >
+          <Save size={14} color={theme.colors.foreground} />
+          <Text style={styles.saveButtonText}>Save</Text>
+        </Pressable>
+      </View>
+      <View style={styles.frame}>{iframe}</View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    flex: 1,
+    minHeight: 0,
+    backgroundColor: theme.colors.surface0,
+  },
+  toolbar: {
+    height: 40,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: theme.colors.border,
+  },
+  statusSlot: {
+    minWidth: 0,
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  statusText: {
+    minWidth: 0,
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  saveButton: {
+    height: 28,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.sm,
+  },
+  saveButtonActive: {
+    backgroundColor: theme.colors.surface2,
+  },
+  saveButtonText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  frame: {
+    flex: 1,
+    minHeight: 0,
+  },
+}));

--- a/packages/app/src/components/workspace-file-previews/spreadsheet-preview.tsx
+++ b/packages/app/src/components/workspace-file-previews/spreadsheet-preview.tsx
@@ -1,0 +1,172 @@
+import { useMemo } from "react";
+import { ScrollView, Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import * as XLSX from "xlsx";
+import type { WorkspaceFilePreviewProps } from "@/components/workspace-file-previews/types";
+
+const MAX_ROWS = 200;
+const MAX_COLUMNS = 40;
+
+function stringifyCell(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (value instanceof Date) {
+    return value.toLocaleString();
+  }
+  return String(value);
+}
+
+function parseWorkbook(bytes: Uint8Array): {
+  sheetName: string;
+  rows: { key: string; cells: { key: string; value: string }[] }[];
+  truncated: boolean;
+  error: string | null;
+} {
+  try {
+    const workbook = XLSX.read(bytes, { type: "array", cellDates: true });
+    const sheetName = workbook.SheetNames[0] ?? "Sheet 1";
+    const sheet = workbook.Sheets[sheetName];
+    if (!sheet) {
+      return { sheetName, rows: [], truncated: false, error: null };
+    }
+    const rawRows = XLSX.utils.sheet_to_json<unknown[]>(sheet, {
+      header: 1,
+      blankrows: false,
+      raw: false,
+    });
+    const rows = rawRows.slice(0, MAX_ROWS).map((row, rowIndex) => ({
+      key: `row-${rowIndex + 1}-${row.map((cell) => stringifyCell(cell)).join("|")}`,
+      cells: row.slice(0, MAX_COLUMNS).map((cell, columnIndex) => ({
+        key: `column-${columnIndex + 1}-${stringifyCell(cell)}`,
+        value: stringifyCell(cell),
+      })),
+    }));
+    return {
+      sheetName,
+      rows,
+      truncated: rawRows.length > MAX_ROWS || rawRows.some((row) => row.length > MAX_COLUMNS),
+      error: null,
+    };
+  } catch (error) {
+    return {
+      sheetName: "Spreadsheet",
+      rows: [],
+      truncated: false,
+      error: error instanceof Error ? error.message : "Failed to render spreadsheet",
+    };
+  }
+}
+
+export function WorkspaceSpreadsheetPreview({ bytes }: WorkspaceFilePreviewProps) {
+  const preview = useMemo(() => parseWorkbook(bytes), [bytes]);
+
+  if (preview.error) {
+    return (
+      <View style={styles.centerState}>
+        <Text style={styles.errorText}>{preview.error}</Text>
+      </View>
+    );
+  }
+
+  if (preview.rows.length === 0) {
+    return (
+      <View style={styles.centerState}>
+        <Text style={styles.emptyText}>Spreadsheet is empty</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title} numberOfLines={1}>
+          {preview.sheetName}
+        </Text>
+        {preview.truncated ? <Text style={styles.meta}>Preview limited</Text> : null}
+      </View>
+      <ScrollView style={styles.scroll}>
+        <ScrollView horizontal contentContainerStyle={styles.table}>
+          {preview.rows.map((row) => (
+            <View key={row.key} style={styles.row}>
+              {row.cells.map((cell) => (
+                <View key={cell.key} style={styles.cell}>
+                  <Text style={styles.cellText} numberOfLines={2}>
+                    {cell.value}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          ))}
+        </ScrollView>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    flex: 1,
+    minHeight: 0,
+    backgroundColor: theme.colors.surface0,
+  },
+  header: {
+    height: 40,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[3],
+    paddingHorizontal: theme.spacing[3],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: theme.colors.border,
+  },
+  title: {
+    flex: 1,
+    minWidth: 0,
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    fontWeight: "500",
+  },
+  meta: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  scroll: {
+    flex: 1,
+  },
+  table: {
+    padding: theme.spacing[3],
+  },
+  row: {
+    flexDirection: "row",
+  },
+  cell: {
+    width: 160,
+    minHeight: 34,
+    justifyContent: "center",
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: theme.spacing[1],
+    borderRightWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: theme.colors.border,
+  },
+  cellText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  centerState: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: theme.spacing[4],
+    backgroundColor: theme.colors.surface0,
+  },
+  emptyText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  errorText: {
+    color: theme.colors.destructive,
+    fontSize: theme.fontSize.sm,
+    textAlign: "center",
+  },
+}));

--- a/packages/app/src/components/workspace-file-previews/types.ts
+++ b/packages/app/src/components/workspace-file-previews/types.ts
@@ -1,0 +1,15 @@
+export interface WorkspaceFilePreviewProps {
+  filePath: string;
+  bytes: Uint8Array;
+  mimeType: string;
+  size: number;
+  modifiedAt: string;
+}
+
+export interface WorkspaceDrawioPreviewProps extends WorkspaceFilePreviewProps {
+  onSave: (input: {
+    bytes: Uint8Array;
+    expectedModifiedAt: string;
+    expectedSize: number;
+  }) => Promise<void>;
+}

--- a/packages/app/src/hooks/use-file-explorer-actions.ts
+++ b/packages/app/src/hooks/use-file-explorer-actions.ts
@@ -243,6 +243,23 @@ export function useFileExplorerActions(params: { serverId: string } & FileExplor
     [client, normalizedWorkspaceRoot],
   );
 
+  const requestFileBytes = useCallback(
+    async (path: string) => {
+      if (!normalizedWorkspaceRoot) {
+        throw new Error("Workspace is unavailable");
+      }
+      if (!client) {
+        throw new Error("Host is not connected");
+      }
+      const file = await client.readFile(normalizedWorkspaceRoot, path);
+      return {
+        bytes: file.bytes,
+        mimeType: file.mime,
+      };
+    },
+    [client, normalizedWorkspaceRoot],
+  );
+
   const selectExplorerEntry = useCallback(
     (path: string | null) => {
       updateExplorerState((state) => ({
@@ -258,6 +275,7 @@ export function useFileExplorerActions(params: { serverId: string } & FileExplor
     requestDirectoryListing,
     requestFilePreview,
     requestFileDownloadToken,
+    requestFileBytes,
     selectExplorerEntry,
   };
 }

--- a/packages/app/src/stores/download-store.test.ts
+++ b/packages/app/src/stores/download-store.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/constants/platform", () => ({
+  isWeb: true,
+}));
+
+vi.mock("expo-file-system", () => ({
+  File: vi.fn(),
+  Paths: {},
+}));
+
+vi.mock("expo-file-system/legacy", () => ({
+  createDownloadResumable: vi.fn(),
+}));
+
+vi.mock("expo-sharing", () => ({
+  isAvailableAsync: vi.fn(async () => false),
+  shareAsync: vi.fn(),
+}));
+
+vi.mock("@/utils/open-external-url", () => ({
+  openExternalUrl: vi.fn(),
+}));
+
+describe("download store", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("falls back to WebSocket file bytes when web download host is unavailable", async () => {
+    const createObjectURL = vi.fn(() => "blob:paseo-download");
+    const revokeObjectURL = vi.fn();
+    const click = vi.fn();
+    const appendChild = vi.fn();
+    const remove = vi.fn();
+
+    vi.stubGlobal("URL", {
+      createObjectURL,
+      revokeObjectURL,
+    });
+    vi.stubGlobal(
+      "Blob",
+      class MockBlob {
+        readonly parts: unknown[];
+        readonly options: unknown;
+
+        constructor(parts: unknown[], options: unknown) {
+          this.parts = parts;
+          this.options = options;
+        }
+      },
+    );
+    vi.stubGlobal("document", {
+      createElement: vi.fn(() => ({
+        click,
+        remove,
+        href: "",
+        download: "",
+        rel: "",
+      })),
+      body: { appendChild },
+    });
+
+    const { useDownloadStore } = await import("@/stores/download-store");
+    const bytes = new TextEncoder().encode("docx bytes");
+
+    await useDownloadStore.getState().startDownload({
+      serverId: "srv",
+      scopeId: "ws",
+      fileName: "report.docx",
+      path: "report.docx",
+      daemonProfile: {
+        serverId: "srv",
+        label: "srv",
+        lifecycle: {},
+        connections: [],
+        preferredConnectionId: null,
+        createdAt: "2026-05-05T00:00:00.000Z",
+        updatedAt: "2026-05-05T00:00:00.000Z",
+      },
+      requestFileDownloadToken: vi.fn(async () => {
+        throw new Error("should not request token without a download host");
+      }),
+      requestFileBytes: vi.fn(async () => ({
+        bytes,
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      })),
+    });
+
+    const download = Array.from(useDownloadStore.getState().downloads.values())[0];
+    expect(download?.status).toBe("complete");
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(appendChild).toHaveBeenCalledTimes(1);
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/stores/download-store.ts
+++ b/packages/app/src/stores/download-store.ts
@@ -42,6 +42,10 @@ interface DownloadState {
       mimeType: string | null;
       error: string | null;
     }>;
+    requestFileBytes?: (path: string) => Promise<{
+      bytes: Uint8Array;
+      mimeType: string | null;
+    }>;
   }) => Promise<void>;
 
   updateProgress: (id: string, progress: DownloadProgress) => void;
@@ -66,6 +70,7 @@ export const useDownloadStore = create<DownloadState>()((set, get) => ({
     path,
     daemonProfile,
     requestFileDownloadToken,
+    requestFileBytes,
   }) => {
     const id = generateDownloadId();
     const download: Download = {
@@ -83,12 +88,26 @@ export const useDownloadStore = create<DownloadState>()((set, get) => ({
     }));
 
     try {
+      const downloadTarget = resolveDaemonDownloadTarget(daemonProfile);
+      if (isWeb && !downloadTarget.baseUrl) {
+        if (!requestFileBytes) {
+          throw new Error("Download host is unavailable.");
+        }
+        const file = await requestFileBytes(path);
+        triggerBrowserBytesDownload(
+          file.bytes,
+          fileName,
+          file.mimeType ?? "application/octet-stream",
+        );
+        get().completeDownload(id);
+        return;
+      }
+
       const tokenResponse = await requestFileDownloadToken(path);
       if (tokenResponse.error || !tokenResponse.token) {
         throw new Error(tokenResponse.error ?? "Failed to request download token.");
       }
 
-      const downloadTarget = resolveDaemonDownloadTarget(daemonProfile);
       if (!downloadTarget.baseUrl) {
         throw new Error("Download host is unavailable.");
       }
@@ -311,6 +330,21 @@ function triggerBrowserDownload(url: string, fileName: string) {
   document.body.appendChild(link);
   link.click();
   link.remove();
+}
+
+function triggerBrowserBytesDownload(bytes: Uint8Array, fileName: string, mimeType: string) {
+  if (typeof URL === "undefined") {
+    throw new Error("Browser download API is unavailable.");
+  }
+
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  const objectUrl = URL.createObjectURL(new Blob([buffer], { type: mimeType }));
+  try {
+    triggerBrowserDownload(objectUrl, fileName);
+  } finally {
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+  }
 }
 
 function resolveDownloadTargetFile(fileName: string): FSFile {

--- a/packages/server/src/client/daemon-client.test.ts
+++ b/packages/server/src/client/daemon-client.test.ts
@@ -484,6 +484,71 @@ test("readFile resolves from binary file frames when the daemon supports them", 
   expect(new TextDecoder().decode(result.bytes)).toBe("hello");
 });
 
+test("saveFile sends workspace file save request and returns saved metadata", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const responsePromise = client.saveFile(
+    "/tmp/project",
+    "diagram.drawio",
+    new TextEncoder().encode("<mxfile />"),
+    {
+      requestId: "req-save",
+      expectedModifiedAt: "2026-05-05T00:00:00.000Z",
+      expectedSize: 10,
+    },
+  );
+
+  expect(JSON.parse(String(mock.sent[0]))).toEqual({
+    type: "session",
+    message: {
+      type: "workspace_file_save_request",
+      cwd: "/tmp/project",
+      path: "diagram.drawio",
+      contentBase64: "PG14ZmlsZSAvPg==",
+      expectedModifiedAt: "2026-05-05T00:00:00.000Z",
+      expectedSize: 10,
+      requestId: "req-save",
+    },
+  });
+
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "workspace_file_save_response",
+      payload: {
+        cwd: "/tmp/project",
+        path: "diagram.drawio",
+        size: 10,
+        modifiedAt: "2026-05-05T00:00:01.000Z",
+        error: null,
+        requestId: "req-save",
+      },
+    }),
+  );
+
+  await expect(responsePromise).resolves.toEqual({
+    cwd: "/tmp/project",
+    path: "diagram.drawio",
+    size: 10,
+    modifiedAt: "2026-05-05T00:00:01.000Z",
+    error: null,
+    requestId: "req-save",
+  });
+});
+
 test("normalizes workspace_setup_progress into a workspace-scoped daemon event", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();

--- a/packages/server/src/client/daemon-client.test.ts
+++ b/packages/server/src/client/daemon-client.test.ts
@@ -484,6 +484,51 @@ test("readFile resolves from binary file frames when the daemon supports them", 
   expect(new TextDecoder().decode(result.bytes)).toBe("hello");
 });
 
+test("readFile allows longer-running file content transfers", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  vi.useFakeTimers();
+  try {
+    let settled = false;
+    let rejection: Error | null = null;
+    const responsePromise = client.readFile("/tmp/project", "report.docx", "req-slow-file").then(
+      () => {
+        settled = true;
+        return undefined;
+      },
+      (error: unknown) => {
+        settled = true;
+        rejection = error instanceof Error ? error : new Error(String(error));
+        return undefined;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(50_000);
+    await responsePromise;
+    expect(settled).toBe(true);
+    expect(rejection?.message).toContain("Timeout waiting for message (60000ms)");
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 test("saveFile sends workspace file save request and returns saved metadata", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -674,6 +674,7 @@ const DEFAULT_SEND_QUEUE_TIMEOUT_MS = 10000;
 const DEFAULT_DICTATION_FINISH_ACCEPT_TIMEOUT_MS = 15000;
 const DEFAULT_DICTATION_FINISH_FALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_DICTATION_FINISH_TIMEOUT_GRACE_MS = 5000;
+const FILE_CONTENT_OPERATION_TIMEOUT_MS = 60000;
 
 function isWaiterTimeoutError(error: unknown): boolean {
   return error instanceof Error && error.message.startsWith("Timeout waiting for message");
@@ -3002,7 +3003,7 @@ export class DaemonClient {
         ...(acceptBinary ? { acceptBinary: true } : {}),
       },
       responseType: "file_explorer_response",
-      timeout: 10000,
+      timeout: mode === "file" ? FILE_CONTENT_OPERATION_TIMEOUT_MS : 10000,
     });
   }
 
@@ -3057,7 +3058,7 @@ export class DaemonClient {
         path,
       },
       responseType: "file_download_token_response",
-      timeout: 10000,
+      timeout: FILE_CONTENT_OPERATION_TIMEOUT_MS,
     });
   }
 
@@ -3082,7 +3083,7 @@ export class DaemonClient {
         ...(options.expectedSize !== undefined ? { expectedSize: options.expectedSize } : {}),
       },
       responseType: "workspace_file_save_response",
-      timeout: 10000,
+      timeout: FILE_CONTENT_OPERATION_TIMEOUT_MS,
     });
     if (payload.error) {
       throw new Error(payload.error);

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -20,6 +20,7 @@ import type {
   CreateAgentRequestMessage,
   CreatePaseoWorktreeRequest,
   FileDownloadTokenResponse,
+  WorkspaceFileSaveResponse,
   FileExplorerResponse,
   FetchAgentTimelineResponseMessage,
   GitSetupOptions,
@@ -291,6 +292,7 @@ export interface FileReadResult {
   modifiedAt: string;
 }
 type FileDownloadTokenPayload = FileDownloadTokenResponse["payload"];
+export type WorkspaceFileSavePayload = WorkspaceFileSaveResponse["payload"];
 type ListProviderFeaturesPayload = ListProviderFeaturesResponseMessage["payload"];
 type ListProviderModelsPayload = ListProviderModelsResponseMessage["payload"];
 type ListProviderModesPayload = ListProviderModesResponseMessage["payload"];
@@ -692,6 +694,16 @@ function decodeBase64ToBytes(base64: string): Uint8Array {
     bytes[index] = binary.charCodeAt(index);
   }
   return bytes;
+}
+
+function encodeBytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    const chunk = bytes.subarray(index, index + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return globalThis.btoa(binary);
 }
 
 function legacyExplorerFileToBytes(file: LegacyFileExplorerFilePayload): FileReadResult {
@@ -3047,6 +3059,35 @@ export class DaemonClient {
       responseType: "file_download_token_response",
       timeout: 10000,
     });
+  }
+
+  async saveFile(
+    cwd: string,
+    path: string,
+    bytes: Uint8Array,
+    options: {
+      requestId?: string;
+      expectedModifiedAt?: string;
+      expectedSize?: number;
+    } = {},
+  ): Promise<WorkspaceFileSavePayload> {
+    const payload = await this.sendCorrelatedSessionRequest({
+      requestId: options.requestId,
+      message: {
+        type: "workspace_file_save_request",
+        cwd,
+        path,
+        contentBase64: encodeBytesToBase64(bytes),
+        ...(options.expectedModifiedAt ? { expectedModifiedAt: options.expectedModifiedAt } : {}),
+        ...(options.expectedSize !== undefined ? { expectedSize: options.expectedSize } : {}),
+      },
+      responseType: "workspace_file_save_response",
+      timeout: 10000,
+    });
+    if (payload.error) {
+      throw new Error(payload.error);
+    }
+    return payload;
   }
 
   async requestProjectIcon(

--- a/packages/server/src/server/file-explorer/service.test.ts
+++ b/packages/server/src/server/file-explorer/service.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { listDirectoryEntries, readExplorerFile } from "./service.js";
+import { listDirectoryEntries, readExplorerFile, writeExplorerFile } from "./service.js";
 
 async function createHomeTempDir(prefix: string): Promise<string> {
   return mkdtemp(path.join(os.homedir(), prefix));
@@ -98,6 +98,67 @@ describe("file explorer service", () => {
       expect(result.mimeType).toBe("application/octet-stream");
     } finally {
       await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("writes base64 file content inside the workspace", async () => {
+    const root = await createTempDir("paseo-file-explorer-");
+
+    try {
+      await mkdir(path.join(root, "docs"), { recursive: true });
+      const result = await writeExplorerFile({
+        root,
+        relativePath: "docs/diagram.drawio",
+        contentBase64: Buffer.from("<mxfile />", "utf8").toString("base64"),
+      });
+
+      expect(result.path).toBe("docs/diagram.drawio");
+      expect(result.size).toBe(10);
+
+      const readBack = await readExplorerFile({
+        root,
+        relativePath: "docs/diagram.drawio",
+      });
+      expect(readBack.content).toBe("<mxfile />");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects stale writes when size or modified time changed", async () => {
+    const root = await createTempDir("paseo-file-explorer-");
+
+    try {
+      await writeFile(path.join(root, "diagram.drawio"), "old", "utf-8");
+
+      await expect(
+        writeExplorerFile({
+          root,
+          relativePath: "diagram.drawio",
+          contentBase64: Buffer.from("new", "utf8").toString("base64"),
+          expectedSize: 10,
+        }),
+      ).rejects.toThrow("File changed on disk");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not write outside the workspace", async () => {
+    const root = await createTempDir("paseo-file-explorer-");
+    const outside = await createTempDir("paseo-file-explorer-outside-");
+
+    try {
+      await expect(
+        writeExplorerFile({
+          root,
+          relativePath: path.relative(root, path.join(outside, "diagram.drawio")),
+          contentBase64: Buffer.from("secret", "utf8").toString("base64"),
+        }),
+      ).rejects.toThrow("Access outside of workspace is not allowed");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
     }
   });
 

--- a/packages/server/src/server/file-explorer/service.ts
+++ b/packages/server/src/server/file-explorer/service.ts
@@ -16,6 +16,14 @@ export interface ReadFileParams {
   relativePath: string;
 }
 
+export interface WriteFileParams {
+  root: string;
+  relativePath: string;
+  contentBase64: string;
+  expectedModifiedAt?: string;
+  expectedSize?: number;
+}
+
 export interface FileExplorerEntry {
   name: string;
   path: string;
@@ -45,6 +53,12 @@ export interface FileExplorerFileBytes {
   encoding: "utf-8" | "binary";
   bytes: Uint8Array;
   mimeType: string;
+  size: number;
+  modifiedAt: string;
+}
+
+export interface FileExplorerWriteResult {
+  path: string;
   size: number;
   modifiedAt: string;
 }
@@ -215,6 +229,44 @@ export async function readExplorerFileBytes({
   };
 }
 
+export async function writeExplorerFile({
+  root,
+  relativePath,
+  contentBase64,
+  expectedModifiedAt,
+  expectedSize,
+}: WriteFileParams): Promise<FileExplorerWriteResult> {
+  const filePath = await resolveScopedWritableFilePath({ root, relativePath });
+
+  try {
+    const existing = await fs.stat(filePath);
+    if (!existing.isFile()) {
+      throw new Error("Requested path is not a file");
+    }
+    const changedSize = expectedSize !== undefined && existing.size !== expectedSize;
+    const changedModifiedAt =
+      expectedModifiedAt !== undefined && existing.mtime.toISOString() !== expectedModifiedAt;
+    if (changedSize || changedModifiedAt) {
+      throw new Error("File changed on disk");
+    }
+  } catch (error) {
+    if (!isMissingEntryError(error)) {
+      throw error;
+    }
+    if (expectedSize !== undefined || expectedModifiedAt !== undefined) {
+      throw new Error("File changed on disk", { cause: error });
+    }
+  }
+
+  await fs.writeFile(filePath, Buffer.from(contentBase64, "base64"));
+  const stats = await fs.stat(filePath);
+  return {
+    path: normalizeRelativePath({ root, targetPath: filePath }),
+    size: stats.size,
+    modifiedAt: stats.mtime.toISOString(),
+  };
+}
+
 export async function getDownloadableFileInfo({ root, relativePath }: ReadFileParams): Promise<{
   path: string;
   absolutePath: string;
@@ -281,6 +333,21 @@ async function resolveScopedPath({ root, relativePath = "." }: ScopedPathParams)
     }
     throw error;
   }
+}
+
+async function resolveScopedWritableFilePath({
+  root,
+  relativePath,
+}: {
+  root: string;
+  relativePath: string;
+}): Promise<string> {
+  const parentPath = await resolveScopedPath({ root, relativePath: path.dirname(relativePath) });
+  const parentStats = await fs.stat(parentPath);
+  if (!parentStats.isDirectory()) {
+    throw new Error("Requested parent path is not a directory");
+  }
+  return path.join(parentPath, path.basename(relativePath));
 }
 
 async function buildEntryPayload({

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
 import { EventEmitter } from "events";
-import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 import pino from "pino";
@@ -643,6 +643,37 @@ describe("file explorer binary responses", () => {
       requestId: "req-new-client",
       payload: new Uint8Array(),
     });
+  });
+
+  test("saves workspace file content through a scoped request", async () => {
+    const cwd = makeRoot();
+    const messages: unknown[] = [];
+    const binaryMessages: Uint8Array[] = [];
+    const session = createSessionForTest({ messages, binaryMessages });
+
+    await session.handleMessage({
+      type: "workspace_file_save_request",
+      cwd,
+      path: "diagram.drawio",
+      contentBase64: Buffer.from("<mxfile />", "utf8").toString("base64"),
+      requestId: "req-save",
+    });
+
+    expect(binaryMessages).toEqual([]);
+    expect(messages).toEqual([
+      {
+        type: "workspace_file_save_response",
+        payload: expect.objectContaining({
+          cwd,
+          path: "diagram.drawio",
+          size: 10,
+          modifiedAt: expect.any(String),
+          error: null,
+          requestId: "req-save",
+        }),
+      },
+    ]);
+    expect(readFileSync(join(cwd, "diagram.drawio"), "utf8")).toBe("<mxfile />");
   });
 });
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -19,6 +19,7 @@ import {
   type SessionOutboundMessage,
   type FileExplorerRequest,
   type FileDownloadTokenRequest,
+  type WorkspaceFileSaveRequest,
   type GitSetupOptions,
   type CheckoutPrStatusResponse,
   type CheckoutStatusResponse,
@@ -156,6 +157,7 @@ import {
   readExplorerFile,
   readExplorerFileBytes,
   getDownloadableFileInfo,
+  writeExplorerFile,
 } from "./file-explorer/service.js";
 import { DownloadTokenStore } from "./file-download/token-store.js";
 import { PushTokenStore } from "./push/token-store.js";
@@ -2085,6 +2087,8 @@ export class Session {
         return this.handleProjectIconRequest(msg);
       case "file_download_token_request":
         return this.handleFileDownloadTokenRequest(msg);
+      case "workspace_file_save_request":
+        return this.handleWorkspaceFileSaveRequest(msg);
       default:
         return undefined;
     }
@@ -5557,6 +5561,63 @@ export class Session {
           mode,
           directory: null,
           file: null,
+          error: getErrorMessage(error),
+          requestId,
+        },
+      });
+    }
+  }
+
+  private async handleWorkspaceFileSaveRequest(request: WorkspaceFileSaveRequest): Promise<void> {
+    const { cwd: workspaceCwd, path: requestedPath, requestId } = request;
+    const cwd = workspaceCwd.trim();
+    if (!cwd) {
+      this.emit({
+        type: "workspace_file_save_response",
+        payload: {
+          cwd: workspaceCwd,
+          path: requestedPath,
+          size: null,
+          modifiedAt: null,
+          error: "cwd is required",
+          requestId,
+        },
+      });
+      return;
+    }
+
+    try {
+      const file = await writeExplorerFile({
+        root: cwd,
+        relativePath: requestedPath,
+        contentBase64: request.contentBase64,
+        expectedModifiedAt: request.expectedModifiedAt,
+        expectedSize: request.expectedSize,
+      });
+
+      this.emit({
+        type: "workspace_file_save_response",
+        payload: {
+          cwd,
+          path: file.path,
+          size: file.size,
+          modifiedAt: file.modifiedAt,
+          error: null,
+          requestId,
+        },
+      });
+    } catch (error) {
+      this.sessionLogger.error(
+        { err: error, cwd, path: requestedPath },
+        `Failed to save workspace file for ${cwd}`,
+      );
+      this.emit({
+        type: "workspace_file_save_response",
+        payload: {
+          cwd,
+          path: requestedPath,
+          size: null,
+          modifiedAt: null,
           error: getErrorMessage(error),
           requestId,
         },

--- a/packages/server/src/shared/messages.test.ts
+++ b/packages/server/src/shared/messages.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { FileExplorerRequestSchema, SessionOutboundMessageSchema } from "./messages.js";
+import {
+  FileExplorerRequestSchema,
+  SessionInboundMessageSchema,
+  SessionOutboundMessageSchema,
+} from "./messages.js";
 
 function workspaceDescriptor(overrides: Record<string, unknown> = {}) {
   return {
@@ -158,6 +162,52 @@ describe("file explorer request compatibility", () => {
       type: "file_explorer_request",
       requestId: "req-new",
       acceptBinary: true,
+    });
+  });
+});
+
+describe("workspace file save message compatibility", () => {
+  test("save request accepts optional stale-write guards", () => {
+    const parsed = SessionInboundMessageSchema.parse({
+      type: "workspace_file_save_request",
+      cwd: "/repo/app",
+      path: "docs/diagram.drawio",
+      contentBase64: "PGRpYWdyYW0vPg==",
+      requestId: "req-save",
+      expectedModifiedAt: "2026-05-05T00:00:00.000Z",
+      expectedSize: 12,
+    });
+
+    expect(parsed).toMatchObject({
+      type: "workspace_file_save_request",
+      cwd: "/repo/app",
+      path: "docs/diagram.drawio",
+      requestId: "req-save",
+      expectedModifiedAt: "2026-05-05T00:00:00.000Z",
+      expectedSize: 12,
+    });
+  });
+
+  test("save response parses with nullable error for old-compatible clients", () => {
+    const parsed = SessionOutboundMessageSchema.parse({
+      type: "workspace_file_save_response",
+      payload: {
+        cwd: "/repo/app",
+        path: "docs/diagram.drawio",
+        size: 14,
+        modifiedAt: "2026-05-05T00:00:01.000Z",
+        error: null,
+        requestId: "req-save",
+      },
+    });
+
+    expect(parsed).toMatchObject({
+      type: "workspace_file_save_response",
+      payload: {
+        path: "docs/diagram.drawio",
+        size: 14,
+        error: null,
+      },
     });
   });
 });

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1538,6 +1538,16 @@ export const FileDownloadTokenRequestSchema = z.object({
   requestId: z.string(),
 });
 
+export const WorkspaceFileSaveRequestSchema = z.object({
+  type: z.literal("workspace_file_save_request"),
+  cwd: z.string(),
+  path: z.string(),
+  contentBase64: z.string(),
+  requestId: z.string(),
+  expectedModifiedAt: z.string().optional(),
+  expectedSize: z.number().optional(),
+});
+
 export const ClearAgentAttentionMessageSchema = z.object({
   type: z.literal("clear_agent_attention"),
   agentId: z.union([z.string(), z.array(z.string())]),
@@ -1740,6 +1750,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   FileExplorerRequestSchema,
   ProjectIconRequestSchema,
   FileDownloadTokenRequestSchema,
+  WorkspaceFileSaveRequestSchema,
   ClearAgentAttentionMessageSchema,
   ClientHeartbeatMessageSchema,
   PingMessageSchema,
@@ -3054,6 +3065,18 @@ export const FileDownloadTokenResponseSchema = z.object({
   }),
 });
 
+export const WorkspaceFileSaveResponseSchema = z.object({
+  type: z.literal("workspace_file_save_response"),
+  payload: z.object({
+    cwd: z.string(),
+    path: z.string(),
+    size: z.number().nullable(),
+    modifiedAt: z.string().nullable(),
+    error: z.string().nullable(),
+    requestId: z.string(),
+  }),
+});
+
 export const ListProviderModelsResponseMessageSchema = z.object({
   type: z.literal("list_provider_models_response"),
   payload: z.object({
@@ -3354,6 +3377,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   FileExplorerResponseSchema,
   ProjectIconResponseSchema,
   FileDownloadTokenResponseSchema,
+  WorkspaceFileSaveResponseSchema,
   ListProviderModelsResponseMessageSchema,
   ListProviderModesResponseMessageSchema,
   ListProviderFeaturesResponseMessageSchema,
@@ -3626,6 +3650,8 @@ export type ProjectIconResponse = z.infer<typeof ProjectIconResponseSchema>;
 export type ProjectIcon = z.infer<typeof ProjectIconSchema>;
 export type FileDownloadTokenRequest = z.infer<typeof FileDownloadTokenRequestSchema>;
 export type FileDownloadTokenResponse = z.infer<typeof FileDownloadTokenResponseSchema>;
+export type WorkspaceFileSaveRequest = z.infer<typeof WorkspaceFileSaveRequestSchema>;
+export type WorkspaceFileSaveResponse = z.infer<typeof WorkspaceFileSaveResponseSchema>;
 export type RestartServerRequestMessage = z.infer<typeof RestartServerRequestMessageSchema>;
 export type ShutdownServerRequestMessage = z.infer<typeof ShutdownServerRequestMessageSchema>;
 export type ClearAgentAttentionMessage = z.infer<typeof ClearAgentAttentionMessageSchema>;


### PR DESCRIPTION
## Summary

Adds workspace file previews and fixes web downloads for remote browser sessions.

- Add draw.io preview/edit/save support for workspace `.drawio` and `.drawio.xml` files.
- Add web previews for `.docx` and spreadsheet files using third-party viewers/parsers.
- Fall back to WebSocket file bytes for web downloads when no direct daemon download host is available.
- Extend workspace file content operations from 10s to 60s so larger preview/download/save operations can complete over relay or another machine's browser.

## Root Cause

Cross-machine browser sessions cannot assume a direct local daemon download host. The previous web download path required a direct HTTP target, while previews and fallback downloads use `readFile` over the active WebSocket. Larger docx/xlsx/drawio files could also exceed the generic 10s correlated request timeout.

## Validation

- `npx vitest run packages/app/src/stores/download-store.test.ts --bail=1`
- `npx vitest run packages/server/src/client/daemon-client.test.ts packages/app/src/stores/download-store.test.ts --bail=1`
- `npm run format && npm run format:check`
- `npm run typecheck`
- `npm run lint`
- `npm run build:web --workspace=@getpaseo/app`

## Deployment

Cloudflare Pages production has been updated and verified to serve bundle `_expo/static/js/web/index-039df1bc75b0910f36fae94c96de6032.js`.

- Production: https://paseo-app-eef.pages.dev
- Deployment: https://937efaa0.paseo-app-eef.pages.dev