### PR TITLE
fix(cli-tests): prepend root node_modules/.bin to PATH so npx paseo resolves locally

### DIFF
--- a/packages/cli/tests/run-all.ts
+++ b/packages/cli/tests/run-all.ts
@@ -11,10 +11,14 @@
 import { spawn } from "child_process";
 import { $ } from "zx";
 import { readdir, writeFile } from "fs/promises";
-import { join, dirname } from "path";
+import { join, dirname, delimiter } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// npm workspace scripts only add the local node_modules/.bin to PATH; hoisted
+// packages live in the root. Prepend it so `npx paseo` resolves locally.
+const rootNodeModulesBin = join(__dirname, "..", "..", "..", "node_modules", ".bin");
 const args = process.argv.slice(2);
 const testEnvDefaults = {
   PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: process.env.PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD ?? "0",
@@ -193,6 +197,7 @@ async function runSingleTest(testFile: string): Promise<TestOutcome> {
     const proc = spawn("npx", ["tsx", testPath], {
       env: {
         ...process.env,
+        PATH: [rootNodeModulesBin, process.env.PATH].filter(Boolean).join(delimiter),
         PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: testEnvDefaults.PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD,
         PASEO_DICTATION_ENABLED: testEnvDefaults.PASEO_DICTATION_ENABLED,
         PASEO_VOICE_MODE_ENABLED: testEnvDefaults.PASEO_VOICE_MODE_ENABLED,


### PR DESCRIPTION
## Summary

- **Root cause**: `npm run test --workspace=@getpaseo/cli` only adds `packages/cli/node_modules/.bin` to PATH (which doesn't exist since packages are hoisted). `npx paseo` couldn't find the local binary and fell back to a stale npm registry cache entry for `@getpaseo/cli` that was missing `bin/paseo`, causing a chmod ENOENT and exit 254.
- **Why only 07-agent-stop**: It's the first test in shard 2/3 to invoke `npx paseo` without spinning up a daemon (pure help flag check), so it reliably hit the broken cache path before npm could resolve it.
- **Fix**: In `run-all.ts`, prepend `root/node_modules/.bin` to PATH in the spawn env for every test subprocess.

## Test plan

- [ ] Run `npx tsx packages/cli/tests/07-agent-stop.test.ts` locally — all 8 tests pass
- [ ] typecheck, lint, format all green
- [ ] Push and watch cli-tests shard 2/3 on this PR