### PR TITLE
fix(app): add aria-checked to Switch so E2E toBeChecked() works

### DIFF
--- a/packages/app/src/components/ui/switch.test.tsx
+++ b/packages/app/src/components/ui/switch.test.tsx
@@ -32,6 +32,7 @@ vi.mock("react-native-reanimated", () => ({
 
 vi.mock("react-native", () => ({
   Pressable: ({
+    "aria-checked": ariaChecked,
     accessibilityLabel,
     accessibilityRole,
     accessibilityState,
@@ -40,6 +41,7 @@ vi.mock("react-native", () => ({
     onPress,
     testID,
   }: {
+    "aria-checked"?: boolean;
     accessibilityLabel?: string;
     accessibilityRole?: string;
     accessibilityState?: { checked?: boolean; disabled?: boolean };
@@ -51,7 +53,7 @@ vi.mock("react-native", () => ({
     React.createElement(
       "button",
       {
-        "aria-checked": accessibilityState?.checked,
+        "aria-checked": ariaChecked ?? accessibilityState?.checked,
         "aria-disabled": accessibilityState?.disabled,
         "aria-label": accessibilityLabel,
         "data-disabled": disabled,

--- a/packages/app/src/components/ui/switch.tsx
+++ b/packages/app/src/components/ui/switch.tsx
@@ -100,6 +100,7 @@ export function Switch({
       accessibilityRole="switch"
       accessibilityState={accessibilityState}
       accessibilityLabel={accessibilityLabel}
+      aria-checked={value}
       testID={testID}
       style={pressableStyle}
     >


### PR DESCRIPTION
## Summary

- React Native Web doesn't map `accessibilityState.checked` to `aria-checked` for `role="switch"`, so Playwright's `toBeChecked()` found the switch element but always saw it as unchecked (missing attribute).
- `expectDaemonManagementEnabled` in the cancel-path tests always timed out (10 s) because the attribute was never present.
- `expectDaemonManagementDisabled` (`not.toBeChecked()`) always passed for the same reason — making the confirm-path test a false positive.
- Fix: add `aria-checked={value}` directly to the `Pressable` in `switch.tsx`. RN Web passes explicit `aria-*` props through to the DOM.
- Update `switch.test.tsx` mock to accept and forward the explicit `aria-checked` prop, keeping it faithful to the fixed component.

Fixes tests at lines 58, 76, and 126 in `desktop-updates.spec.ts`.

## Test plan

- [ ] `npx vitest run packages/app/src/components/ui/switch.test.tsx` green
- [ ] typecheck + lint + format green (pre-commit hook passed)
- [ ] CI green on this PR