### PR TITLE
fix(app/e2e): fix composer-lock test — mock provider + prompt so lock releases

### DIFF
--- a/packages/app/e2e/composer-attachments.spec.ts
+++ b/packages/app/e2e/composer-attachments.spec.ts
@@ -24,9 +24,9 @@ import {
   openGithubWorkspace,
 } from "./helpers/composer";
 import {
-  clickNewWorkspaceButton,
   connectNewWorkspaceDaemonClient,
   delayBrowserAgentCreatedStatus,
+  openNewWorkspaceComposer,
   openProjectViaDaemon,
 } from "./helpers/new-workspace";
 import { gotoAppShell } from "./helpers/app";
@@ -255,10 +255,16 @@ test.describe("Composer attachments", () => {
         targetWorkspacePath: openedProject.workspaceId,
       });
 
-      await clickNewWorkspaceButton(page, {
+      await openNewWorkspaceComposer(page, {
         projectKey: openedProject.projectKey,
         projectDisplayName: openedProject.projectDisplayName,
       });
+      await fillComposerDraft(page, "lock test prompt");
+      const createButton = page
+        .getByTestId("message-input-root")
+        .getByRole("button", { name: "Create" });
+      await expect(createButton).toBeVisible({ timeout: 30_000 });
+      await createButton.click();
 
       await agentCreatedDelay.waitForCreateRequest();
       await agentCreatedDelay.waitForDelayedCreatedStatus();

--- a/packages/app/e2e/helpers/composer.ts
+++ b/packages/app/e2e/helpers/composer.ts
@@ -22,7 +22,9 @@ export async function expectComposerVisible(
 }
 
 export async function expectComposerDisabled(page: Page): Promise<void> {
-  await expect(composerInput(page)).toBeDisabled({ timeout: 10_000 });
+  // React Native TextInput with editable={false} renders as <textarea readonly> on web,
+  // not <textarea disabled>. Use not.toBeEditable() to match either form.
+  await expect(composerInput(page)).not.toBeEditable({ timeout: 10_000 });
 }
 
 export async function expectComposerDraft(page: Page, text: string): Promise<void> {

--- a/packages/app/e2e/helpers/daemon-registry.ts
+++ b/packages/app/e2e/helpers/daemon-registry.ts
@@ -30,10 +30,15 @@ export function buildSeededHost(input: {
   };
 }
 
+export const TEST_MOCK_PROVIDER_PREFERENCES = {
+  ...TEST_PROVIDER_PREFERENCES,
+  mock: { model: "ten-second-stream" },
+} as const;
+
 export function buildCreateAgentPreferences(serverId: string) {
   return {
     serverId,
-    provider: "codex" as const,
-    providerPreferences: TEST_PROVIDER_PREFERENCES,
+    provider: "mock" as const,
+    providerPreferences: TEST_MOCK_PROVIDER_PREFERENCES,
   };
 }

--- a/packages/app/src/components/ui/switch.test.tsx
+++ b/packages/app/src/components/ui/switch.test.tsx
@@ -32,6 +32,7 @@ vi.mock("react-native-reanimated", () => ({
 
 vi.mock("react-native", () => ({
   Pressable: ({
+    "aria-checked": ariaChecked,
     accessibilityLabel,
     accessibilityRole,
     accessibilityState,
@@ -40,6 +41,7 @@ vi.mock("react-native", () => ({
     onPress,
     testID,
   }: {
+    "aria-checked"?: boolean;
     accessibilityLabel?: string;
     accessibilityRole?: string;
     accessibilityState?: { checked?: boolean; disabled?: boolean };
@@ -51,7 +53,7 @@ vi.mock("react-native", () => ({
     React.createElement(
       "button",
       {
-        "aria-checked": accessibilityState?.checked,
+        "aria-checked": ariaChecked ?? accessibilityState?.checked,
         "aria-disabled": accessibilityState?.disabled,
         "aria-label": accessibilityLabel,
         "data-disabled": disabled,

--- a/packages/app/src/components/ui/switch.tsx
+++ b/packages/app/src/components/ui/switch.tsx
@@ -100,6 +100,7 @@ export function Switch({
       accessibilityRole="switch"
       accessibilityState={accessibilityState}
       accessibilityLabel={accessibilityLabel}
+      aria-checked={value}
       testID={testID}
       style={pressableStyle}
     >


### PR DESCRIPTION
## Summary

- `expectComposerDisabled` was using `toBeDisabled()` but React Native's `TextInput` with `editable={false}` renders as `<textarea readonly>` on web, not `<textarea disabled>`. Fixed to `not.toBeEditable()`.
- The lock test created a workspace agent with no prompt, leaving the agent permanently in the `"idle"` state. `showPendingCreateSubmitLoading` only clears when `authoritativeStatus` is non-bootstrapping, but `"idle"` counts as bootstrapping — so the composer lock never released. Fixed by filling a prompt before clicking Create, so the mock agent transitions to `"running"` after `agent_created` is released.
- Switches `buildCreateAgentPreferences` default to `provider: "mock"` with `ten-second-stream` model so E2E tests don't depend on real provider availability in CI.

## Test plan

- [ ] CI green on this PR
- [ ] `composer is locked while new workspace agent is being created` passes