### PR TITLE
test(app/e2e): sessions-screen empty state (Cluster G7)

### DIFF
--- a/packages/app/e2e/00-sessions-empty.spec.ts
+++ b/packages/app/e2e/00-sessions-empty.spec.ts
@@ -1,0 +1,37 @@
+// "00-" prefix is intentional: this file must sort before every other spec.
+// Sessions history is daemon-global — any agent created by a prior spec hides the empty state.
+// If the beforeAll probe below fails, a spec sorted before this file is creating agents.
+import { test } from "./fixtures";
+import {
+  connectArchiveTabDaemonClient,
+  expectSessionsEmptyState,
+  openSessions,
+} from "./helpers/archive-tab";
+
+test.describe("Sessions screen empty state", () => {
+  test.beforeAll(async () => {
+    const client = await connectArchiveTabDaemonClient();
+    try {
+      const history = await client.fetchAgentHistory({ page: { limit: 1 } });
+      if (history.entries.length > 0) {
+        throw new Error(
+          `Sessions empty-state precondition failed: daemon already has ${history.entries.length} agent(s). ` +
+            `Either a spec that sorts before 00-sessions-empty.spec.ts created agents, ` +
+            `or the daemon has stale history from a previous run.`,
+        );
+      }
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+
+  test("shows empty placeholder when there is no session history", async ({
+    page,
+    withWorkspace,
+  }) => {
+    const workspace = await withWorkspace({ prefix: "sessions-empty-" });
+    await workspace.navigateTo();
+    await openSessions(page);
+    await expectSessionsEmptyState(page);
+  });
+});

--- a/packages/app/e2e/archive-tab.spec.ts
+++ b/packages/app/e2e/archive-tab.spec.ts
@@ -11,6 +11,7 @@ import {
   expectArchivedAgentFocused,
   expectSessionRowArchived,
   expectSessionRowVisible,
+  expectSessionsEmptyState,
   expectWorkspaceArchiveOutcome,
   expectWorkspaceTabHidden,
   openSessions,
@@ -125,5 +126,17 @@ test.describe("Archive tab reconciliation", () => {
     await clickSessionRow(page, archived.title);
 
     await expectArchivedAgentFocused(page, archived.id);
+  });
+});
+
+test.describe("Sessions screen empty state", () => {
+  test("shows empty placeholder when there is no session history", async ({
+    page,
+    withWorkspace,
+  }) => {
+    const workspace = await withWorkspace({ prefix: "sessions-empty-" });
+    await workspace.navigateTo();
+    await openSessions(page);
+    await expectSessionsEmptyState(page);
   });
 });

--- a/packages/app/e2e/archive-tab.spec.ts
+++ b/packages/app/e2e/archive-tab.spec.ts
@@ -21,6 +21,10 @@ import {
   reloadWorkspace,
 } from "./helpers/archive-tab";
 
+// NOTE: This describe block must stay FIRST in this file.
+// Sessions history is global to the daemon — the archive-tab reconciliation tests below
+// each call createIdleAgent, which would pollute the empty-state check.
+// If the precondition fails, move this block back to the top or see expectSessionsEmptyState.
 test.describe("Sessions screen empty state", () => {
   test("shows empty placeholder when there is no session history", async ({
     page,

--- a/packages/app/e2e/archive-tab.spec.ts
+++ b/packages/app/e2e/archive-tab.spec.ts
@@ -21,6 +21,18 @@ import {
   reloadWorkspace,
 } from "./helpers/archive-tab";
 
+test.describe("Sessions screen empty state", () => {
+  test("shows empty placeholder when there is no session history", async ({
+    page,
+    withWorkspace,
+  }) => {
+    const workspace = await withWorkspace({ prefix: "sessions-empty-" });
+    await workspace.navigateTo();
+    await openSessions(page);
+    await expectSessionsEmptyState(page);
+  });
+});
+
 test.describe("Archive tab reconciliation", () => {
   let client: Awaited<ReturnType<typeof connectArchiveTabDaemonClient>>;
   let tempRepo: { path: string; cleanup: () => Promise<void> };
@@ -126,17 +138,5 @@ test.describe("Archive tab reconciliation", () => {
     await clickSessionRow(page, archived.title);
 
     await expectArchivedAgentFocused(page, archived.id);
-  });
-});
-
-test.describe("Sessions screen empty state", () => {
-  test("shows empty placeholder when there is no session history", async ({
-    page,
-    withWorkspace,
-  }) => {
-    const workspace = await withWorkspace({ prefix: "sessions-empty-" });
-    await workspace.navigateTo();
-    await openSessions(page);
-    await expectSessionsEmptyState(page);
   });
 });

--- a/packages/app/e2e/archive-tab.spec.ts
+++ b/packages/app/e2e/archive-tab.spec.ts
@@ -11,7 +11,6 @@ import {
   expectArchivedAgentFocused,
   expectSessionRowArchived,
   expectSessionRowVisible,
-  expectSessionsEmptyState,
   expectWorkspaceArchiveOutcome,
   expectWorkspaceTabHidden,
   openSessions,
@@ -20,22 +19,6 @@ import {
   resetSeededPageState,
   reloadWorkspace,
 } from "./helpers/archive-tab";
-
-// NOTE: This describe block must stay FIRST in this file.
-// Sessions history is global to the daemon — the archive-tab reconciliation tests below
-// each call createIdleAgent, which would pollute the empty-state check.
-// If the precondition fails, move this block back to the top or see expectSessionsEmptyState.
-test.describe("Sessions screen empty state", () => {
-  test("shows empty placeholder when there is no session history", async ({
-    page,
-    withWorkspace,
-  }) => {
-    const workspace = await withWorkspace({ prefix: "sessions-empty-" });
-    await workspace.navigateTo();
-    await openSessions(page);
-    await expectSessionsEmptyState(page);
-  });
-});
 
 test.describe("Archive tab reconciliation", () => {
   let client: Awaited<ReturnType<typeof connectArchiveTabDaemonClient>>;

--- a/packages/app/e2e/helpers/archive-tab.ts
+++ b/packages/app/e2e/helpers/archive-tab.ts
@@ -36,6 +36,9 @@ interface ArchiveTabDaemonClient {
     predicate: (snapshot: { status: string }) => boolean,
     timeout?: number,
   ): Promise<{ status: string }>;
+  fetchAgentHistory(options?: {
+    page?: { limit: number };
+  }): Promise<{ entries: Array<{ id: string }> }>;
 }
 
 function getDaemonPort(): string {
@@ -286,7 +289,7 @@ export async function clickSessionRow(page: Page, title: string): Promise<void> 
 }
 
 export async function expectSessionsEmptyState(page: Page): Promise<void> {
-  // Guard: if session rows appear, a prior test polluted the shared daemon — see archive-tab.spec.ts ordering note.
+  // Guard: if session rows appear, a prior spec polluted the shared daemon — see 00-sessions-empty.spec.ts.
   await expect(page.locator(AGENT_ROW_SELECTOR)).toHaveCount(0, { timeout: 5_000 });
   await expect(page.getByText("No sessions yet")).toBeVisible({ timeout: 30_000 });
 }

--- a/packages/app/e2e/helpers/archive-tab.ts
+++ b/packages/app/e2e/helpers/archive-tab.ts
@@ -283,6 +283,10 @@ export async function clickSessionRow(page: Page, title: string): Promise<void> 
   await row.click();
 }
 
+export async function expectSessionsEmptyState(page: Page): Promise<void> {
+  await expect(page.getByText("No sessions yet")).toBeVisible({ timeout: 30_000 });
+}
+
 export async function archiveAgentFromSessions(
   page: Page,
   input: { agentId: string; title: string },

--- a/packages/app/e2e/helpers/archive-tab.ts
+++ b/packages/app/e2e/helpers/archive-tab.ts
@@ -265,8 +265,10 @@ export async function openSessions(page: Page): Promise<void> {
   });
 }
 
+const AGENT_ROW_SELECTOR = '[data-testid^="agent-row-"]';
+
 function getSessionRowByTitle(page: Page, title: string) {
-  return page.locator('[data-testid^="agent-row-"]').filter({ hasText: title }).first();
+  return page.locator(AGENT_ROW_SELECTOR).filter({ hasText: title }).first();
 }
 
 export async function expectSessionRowVisible(page: Page, title: string): Promise<void> {
@@ -284,6 +286,8 @@ export async function clickSessionRow(page: Page, title: string): Promise<void> 
 }
 
 export async function expectSessionsEmptyState(page: Page): Promise<void> {
+  // Guard: if session rows appear, a prior test polluted the shared daemon — see archive-tab.spec.ts ordering note.
+  await expect(page.locator(AGENT_ROW_SELECTOR)).toHaveCount(0, { timeout: 5_000 });
   await expect(page.getByText("No sessions yet")).toBeVisible({ timeout: 30_000 });
 }
 


### PR DESCRIPTION
## Summary

- Adds one E2E test: opens Sessions on a fresh workspace with zero agents and asserts the "No sessions yet" placeholder renders
- Exports `expectSessionsEmptyState(page)` helper from `archive-tab.ts` for reuse in future session specs
- Uses the `withWorkspace` fixture with no agent seeding — the empty branch was previously untested since every existing sessions spec seeds agents first

## What was deleted

`sessions-screen.test.tsx` (unit test) pinned this empty-state behavior. Its deletion left the empty branch dark. This E2E spec restores coverage at the right layer.

## Test plan

- [ ] CI passes green
- [ ] New test (`Sessions screen empty state > shows empty placeholder when there is no session history`) runs and asserts "No sessions yet" renders