### PR TITLE
test(app/e2e): stream auto-scroll and working-indicator→copy-button (Cluster G5)

### DIFF
--- a/packages/app/e2e/agent-stream-ui.spec.ts
+++ b/packages/app/e2e/agent-stream-ui.spec.ts
@@ -4,10 +4,9 @@ import {
   expectAgentIdle,
   expectInlineWorkingIndicator,
   expectTurnCopyButton,
-  expectScrolledToBottom,
+  expectScrollFollowsNewContent,
 } from "./helpers/agent-stream";
 import { startRunningMockAgent } from "./helpers/composer";
-import { readScrollMetrics, waitForContentGrowth } from "./helpers/agent-bottom-anchor";
 
 test.describe("Agent stream UI", () => {
   test("auto-scroll sticks to bottom across token bursts", async ({ page }) => {
@@ -19,11 +18,7 @@ test.describe("Agent stream UI", () => {
     });
     try {
       await awaitAssistantMessage(page);
-      await expectScrolledToBottom(page);
-
-      const { contentHeight } = await readScrollMetrics(page);
-      await waitForContentGrowth(page, contentHeight);
-      await expectScrolledToBottom(page);
+      await expectScrollFollowsNewContent(page);
     } finally {
       await client.close();
       await repo.cleanup();
@@ -38,6 +33,7 @@ test.describe("Agent stream UI", () => {
       prompt: "Stream briefly for indicator transition test.",
     });
     try {
+      await awaitAssistantMessage(page);
       await expectInlineWorkingIndicator(page);
       await expectAgentIdle(page, 30_000);
       await expectTurnCopyButton(page);

--- a/packages/app/e2e/agent-stream-ui.spec.ts
+++ b/packages/app/e2e/agent-stream-ui.spec.ts
@@ -1,0 +1,49 @@
+import { test } from "./fixtures";
+import {
+  awaitAssistantMessage,
+  expectAgentIdle,
+  expectInlineWorkingIndicator,
+  expectTurnCopyButton,
+  expectScrolledToBottom,
+} from "./helpers/agent-stream";
+import { startRunningMockAgent } from "./helpers/composer";
+import { readScrollMetrics, waitForContentGrowth } from "./helpers/agent-bottom-anchor";
+
+test.describe("Agent stream UI", () => {
+  test("auto-scroll sticks to bottom across token bursts", async ({ page }) => {
+    test.setTimeout(120_000);
+    const { client, repo } = await startRunningMockAgent(page, {
+      prefix: "stream-scroll-",
+      model: "one-minute-stream",
+      prompt: "Stream for auto-scroll test.",
+    });
+    try {
+      await awaitAssistantMessage(page);
+      await expectScrolledToBottom(page);
+
+      const { contentHeight } = await readScrollMetrics(page);
+      await waitForContentGrowth(page, contentHeight);
+      await expectScrolledToBottom(page);
+    } finally {
+      await client.close();
+      await repo.cleanup();
+    }
+  });
+
+  test("working-indicator transitions to copy-button when stream ends", async ({ page }) => {
+    test.setTimeout(60_000);
+    const { client, repo } = await startRunningMockAgent(page, {
+      prefix: "stream-indicator-",
+      model: "ten-second-stream",
+      prompt: "Stream briefly for indicator transition test.",
+    });
+    try {
+      await expectInlineWorkingIndicator(page);
+      await expectAgentIdle(page, 30_000);
+      await expectTurnCopyButton(page);
+    } finally {
+      await client.close();
+      await repo.cleanup();
+    }
+  });
+});

--- a/packages/app/e2e/helpers/agent-stream.ts
+++ b/packages/app/e2e/helpers/agent-stream.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from "@playwright/test";
+import { expectNearBottom } from "./agent-bottom-anchor";
 
 export async function awaitAssistantMessage(page: Page, hasText?: string | RegExp): Promise<void> {
   const messages = page.getByTestId("assistant-message");
@@ -14,4 +15,18 @@ export async function awaitToolCall(page: Page, toolName: string | RegExp): Prom
 
 export async function expectAgentIdle(page: Page, timeout = 30_000): Promise<void> {
   await expect(page.getByRole("button", { name: /stop|cancel/i })).toHaveCount(0, { timeout });
+}
+
+export async function expectInlineWorkingIndicator(page: Page): Promise<void> {
+  await expect(page.getByTestId("turn-working-indicator")).toBeVisible({ timeout: 30_000 });
+}
+
+export async function expectTurnCopyButton(page: Page): Promise<void> {
+  await expect(page.getByRole("button", { name: "Copy turn" }).first()).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+export async function expectScrolledToBottom(page: Page): Promise<void> {
+  await expectNearBottom(page);
 }

--- a/packages/app/e2e/helpers/agent-stream.ts
+++ b/packages/app/e2e/helpers/agent-stream.ts
@@ -1,5 +1,5 @@
 import { expect, type Page } from "@playwright/test";
-import { expectNearBottom } from "./agent-bottom-anchor";
+import { readScrollMetrics, waitForContentGrowth, expectNearBottom } from "./agent-bottom-anchor";
 
 export async function awaitAssistantMessage(page: Page, hasText?: string | RegExp): Promise<void> {
   const messages = page.getByTestId("assistant-message");
@@ -17,6 +17,7 @@ export async function expectAgentIdle(page: Page, timeout = 30_000): Promise<voi
   await expect(page.getByRole("button", { name: /stop|cancel/i })).toHaveCount(0, { timeout });
 }
 
+// The working indicator is an animated spinner View — no semantic ARIA role, testId is correct.
 export async function expectInlineWorkingIndicator(page: Page): Promise<void> {
   await expect(page.getByTestId("turn-working-indicator")).toBeVisible({ timeout: 30_000 });
 }
@@ -27,6 +28,8 @@ export async function expectTurnCopyButton(page: Page): Promise<void> {
   });
 }
 
-export async function expectScrolledToBottom(page: Page): Promise<void> {
+export async function expectScrollFollowsNewContent(page: Page): Promise<void> {
+  const { contentHeight } = await readScrollMetrics(page);
+  await waitForContentGrowth(page, contentHeight);
   await expectNearBottom(page);
 }


### PR DESCRIPTION
## Summary

- Adds `expectInlineWorkingIndicator`, `expectTurnCopyButton`, and `expectScrollFollowsNewContent` helpers to `helpers/agent-stream.ts`, wiring in the previously unused `agent-bottom-anchor.ts`
- Adds `agent-stream-ui.spec.ts` with two new tests using the mock provider (no real LLM in CI):
  1. **auto-scroll sticks to bottom across token bursts** — asserts the bottom anchor holds while the mock `one-minute-stream` model streams and content grows (`expectScrollFollowsNewContent` encapsulates `readScrollMetrics → waitForContentGrowth → expectNearBottom`)
  2. **working-indicator transitions to copy-button when stream ends** — asserts the inline `turn-working-indicator` is visible during streaming, then the `Copy turn` button appears after the `ten-second-stream` model finishes

## Why a new spec file rather than extending workspace-setup-streaming.spec.ts

The plan said "extend `workspace-setup-streaming.spec.ts` (or the most appropriate existing stream-related spec)." After reading the existing spec, the separation is justified:

`workspace-setup-streaming.spec.ts` tests the **workspace setup pipeline** — daemon-level worktree creation, setup command streaming, script terminal launching. None of its tests open the agent chat UI.

`agent-stream-ui.spec.ts` tests **agent chat UI behavior** — scroll anchoring and working-indicator DOM transitions during an active agent turn. These are different domains that share the word "stream" but nothing else in terms of setup, fixtures, or assertions.

Putting chat-stream UI tests inside a workspace-setup spec would make that file harder to navigate and mix two unrelated concerns.

## Test plan

- [x] Both tests pass locally (2 passed, ~26s)
- [x] Typecheck green (pre-commit hook, all workspaces)
- [x] Lint green (oxlint, 0 warnings/errors)
- [x] Format green (oxfmt)
- [x] `/unslop` applied — 0 high, 0 medium, 0 low on final diff
- [x] Review blockers addressed: DSL leak removed, `expectScrolledToBottom` wrapper replaced, `awaitAssistantMessage` added before indicator check, testId comment added
- [ ] CI green — hold for full green before merge