### PR TITLE
test(app/e2e): mobile sidebar open/close transition (Cluster G6)

### DIFF
--- a/packages/app/e2e/helpers/sidebar.ts
+++ b/packages/app/e2e/helpers/sidebar.ts
@@ -19,3 +19,69 @@ export async function expectWorkspaceListed(page: Page, name: string): Promise<v
     page.locator('[data-testid^="sidebar-workspace-row-"]').filter({ hasText: name }).first(),
   ).toBeVisible({ timeout: 30_000 });
 }
+
+interface CdpWsFrameEvent {
+  response: { opcode: number; payloadData: string };
+}
+
+const pageMonitors = new WeakMap<Page, { count: number }>();
+
+/**
+ * Installs a CDP WebSocket frame monitor. Must be called BEFORE page.goto() so the
+ * WebSocket connection is captured. Counts outgoing `fetch_workspaces_request` frames.
+ */
+export async function installWorkspaceFetchMonitor(page: Page): Promise<void> {
+  const state = { count: 0 };
+  pageMonitors.set(page, state);
+  const session = await page.context().newCDPSession(page);
+  await session.send("Network.enable");
+  session.on("Network.webSocketFrameSent", (event: CdpWsFrameEvent) => {
+    if (
+      event.response.opcode === 1 &&
+      event.response.payloadData.includes('"fetch_workspaces_request"')
+    ) {
+      state.count++;
+    }
+  });
+}
+
+/**
+ * Asserts the workspace-list query is active (expected=true) or paused (expected=false).
+ * true: polls until at least one fetch_workspaces_request is observed.
+ * false: waits 400 ms and asserts the frame count did not increase.
+ */
+export async function expectWorkspaceListSubscribed(page: Page, expected: boolean): Promise<void> {
+  const state = pageMonitors.get(page);
+  if (!state) {
+    throw new Error("Call installWorkspaceFetchMonitor before expectWorkspaceListSubscribed");
+  }
+  if (expected) {
+    await expect.poll(() => state.count, { timeout: 10_000 }).toBeGreaterThan(0);
+  } else {
+    const before = state.count;
+    await page.waitForTimeout(400);
+    expect(state.count).toBe(before);
+  }
+}
+
+export async function closeSidebar(page: Page): Promise<void> {
+  await page.getByTestId("menu-button").click();
+}
+
+export async function openMobileAgentSidebar(page: Page): Promise<void> {
+  await page.getByTestId("menu-button").click();
+}
+
+// force=true: the overlay covers the button when the mobile sidebar is open.
+export async function closeMobileAgentSidebar(page: Page): Promise<void> {
+  await page.getByTestId("menu-button").click({ force: true });
+}
+
+// The mobile sidebar panel animates via translateX; toBeInViewport reflects the rendered position.
+export async function expectMobileAgentSidebarVisible(page: Page): Promise<void> {
+  await expect(page.getByTestId("sidebar-sessions")).toBeInViewport({ timeout: 5_000 });
+}
+
+export async function expectMobileAgentSidebarHidden(page: Page): Promise<void> {
+  await expect(page.getByTestId("sidebar-sessions")).not.toBeInViewport({ timeout: 5_000 });
+}

--- a/packages/app/e2e/helpers/sidebar.ts
+++ b/packages/app/e2e/helpers/sidebar.ts
@@ -20,54 +20,6 @@ export async function expectWorkspaceListed(page: Page, name: string): Promise<v
   ).toBeVisible({ timeout: 30_000 });
 }
 
-interface CdpWsFrameEvent {
-  response: { opcode: number; payloadData: string };
-}
-
-const pageMonitors = new WeakMap<Page, { count: number }>();
-
-/**
- * Installs a CDP WebSocket frame monitor. Must be called BEFORE page.goto() so the
- * WebSocket connection is captured. Counts outgoing `fetch_workspaces_request` frames.
- */
-export async function installWorkspaceFetchMonitor(page: Page): Promise<void> {
-  const state = { count: 0 };
-  pageMonitors.set(page, state);
-  const session = await page.context().newCDPSession(page);
-  await session.send("Network.enable");
-  session.on("Network.webSocketFrameSent", (event: CdpWsFrameEvent) => {
-    if (
-      event.response.opcode === 1 &&
-      event.response.payloadData.includes('"fetch_workspaces_request"')
-    ) {
-      state.count++;
-    }
-  });
-}
-
-/**
- * Asserts the workspace-list query is active (expected=true) or paused (expected=false).
- * true: polls until at least one fetch_workspaces_request is observed.
- * false: waits 400 ms and asserts the frame count did not increase.
- */
-export async function expectWorkspaceListSubscribed(page: Page, expected: boolean): Promise<void> {
-  const state = pageMonitors.get(page);
-  if (!state) {
-    throw new Error("Call installWorkspaceFetchMonitor before expectWorkspaceListSubscribed");
-  }
-  if (expected) {
-    await expect.poll(() => state.count, { timeout: 10_000 }).toBeGreaterThan(0);
-  } else {
-    const before = state.count;
-    await page.waitForTimeout(400);
-    expect(state.count).toBe(before);
-  }
-}
-
-export async function closeSidebar(page: Page): Promise<void> {
-  await page.getByTestId("menu-button").click();
-}
-
 export async function openMobileAgentSidebar(page: Page): Promise<void> {
   await page.getByTestId("menu-button").click();
 }

--- a/packages/app/e2e/sidebar-workspace.spec.ts
+++ b/packages/app/e2e/sidebar-workspace.spec.ts
@@ -5,12 +5,9 @@ import path from "node:path";
 import { test, expect } from "./fixtures";
 import { gotoAppShell } from "./helpers/app";
 import {
-  closeSidebar,
   closeMobileAgentSidebar,
   expectMobileAgentSidebarHidden,
   expectMobileAgentSidebarVisible,
-  expectWorkspaceListSubscribed,
-  installWorkspaceFetchMonitor,
   openMobileAgentSidebar,
 } from "./helpers/sidebar";
 import { createTempGitRepo } from "./helpers/workspace";
@@ -183,30 +180,6 @@ test.describe("Sidebar workspace list", () => {
 
       expect(workspace.name).toBe("main");
       await expect(await waitForSidebarWorkspace(page, workspace.id)).toContainText("main");
-    } finally {
-      await client.close();
-      await repo.cleanup();
-    }
-  });
-});
-
-test.describe("Sidebar workspace-list query", () => {
-  test("does not refetch after desktop sidebar is hidden", async ({ page }) => {
-    const client = await connectWorkspaceSetupClient();
-    const repo = await createTempGitRepo("sidebar-query-pause-");
-
-    try {
-      const workspace = await openProjectViaDaemon(client, repo.path);
-      // Monitor must be installed before navigation so the WebSocket connection is captured.
-      await installWorkspaceFetchMonitor(page);
-      await gotoAppShell(page);
-      await waitForSidebarWorkspace(page, workspace.id);
-      // Initial hydration sent at least one fetch_workspaces_request — sidebar was active.
-      await expectWorkspaceListSubscribed(page, true);
-      // Closing the sidebar sets enabled:false in useSidebarWorkspacesList — query pauses.
-      await closeSidebar(page);
-      // No new fetch_workspaces_request should be sent while the sidebar is hidden.
-      await expectWorkspaceListSubscribed(page, false);
     } finally {
       await client.close();
       await repo.cleanup();

--- a/packages/app/e2e/sidebar-workspace.spec.ts
+++ b/packages/app/e2e/sidebar-workspace.spec.ts
@@ -4,6 +4,15 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { test, expect } from "./fixtures";
 import { gotoAppShell } from "./helpers/app";
+import {
+  closeSidebar,
+  closeMobileAgentSidebar,
+  expectMobileAgentSidebarHidden,
+  expectMobileAgentSidebarVisible,
+  expectWorkspaceListSubscribed,
+  installWorkspaceFetchMonitor,
+  openMobileAgentSidebar,
+} from "./helpers/sidebar";
 import { createTempGitRepo } from "./helpers/workspace";
 import { expectWorkspaceHeader } from "./helpers/workspace-ui";
 import { connectWorkspaceSetupClient } from "./helpers/workspace-setup";
@@ -178,5 +187,42 @@ test.describe("Sidebar workspace list", () => {
       await client.close();
       await repo.cleanup();
     }
+  });
+});
+
+test.describe("Sidebar workspace-list query", () => {
+  test("does not refetch after desktop sidebar is hidden", async ({ page }) => {
+    const client = await connectWorkspaceSetupClient();
+    const repo = await createTempGitRepo("sidebar-query-pause-");
+
+    try {
+      const workspace = await openProjectViaDaemon(client, repo.path);
+      // Monitor must be installed before navigation so the WebSocket connection is captured.
+      await installWorkspaceFetchMonitor(page);
+      await gotoAppShell(page);
+      await waitForSidebarWorkspace(page, workspace.id);
+      // Initial hydration sent at least one fetch_workspaces_request — sidebar was active.
+      await expectWorkspaceListSubscribed(page, true);
+      // Closing the sidebar sets enabled:false in useSidebarWorkspacesList — query pauses.
+      await closeSidebar(page);
+      // No new fetch_workspaces_request should be sent while the sidebar is hidden.
+      await expectWorkspaceListSubscribed(page, false);
+    } finally {
+      await client.close();
+      await repo.cleanup();
+    }
+  });
+});
+
+test.describe("Mobile sidebar panelState transition", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("showMobileAgent open and close transition", async ({ page }) => {
+    await gotoAppShell(page);
+    await expectMobileAgentSidebarHidden(page);
+    await openMobileAgentSidebar(page);
+    await expectMobileAgentSidebarVisible(page);
+    await closeMobileAgentSidebar(page);
+    await expectMobileAgentSidebarHidden(page);
   });
 });


### PR DESCRIPTION
## Summary

- **G6.1 (deferred)**: Query-pause perf invariant reclassified — counting internal `fetch_workspaces_request` RPC frames in E2E is banned per updated roadmap (same class as store injection: tests implementation, not user behavior). Will be covered in a unit test on `useSidebarWorkspacesList` in a follow-up cluster.
- **G6.2**: Asserts mobile sidebar panel animates in and out at 390×844 viewport. Uses `toBeInViewport()` against the `translateX`-animated `sidebar-sessions` element — no CDP, no RPC counting.

Adds 4 helpers to `packages/app/e2e/helpers/sidebar.ts`:
- `openMobileAgentSidebar` / `closeMobileAgentSidebar` (close uses `force: true` to bypass overlay)
- `expectMobileAgentSidebarVisible` / `expectMobileAgentSidebarHidden`

## Test plan

- [ ] G6.2 test: `sidebar-workspace.spec.ts > Mobile sidebar panelState transition > showMobileAgent open and close transition`
- [ ] Typecheck: green (pre-commit hook verified)
- [ ] Lint: 0 warnings/errors
- [ ] Format: clean