### PR TITLE
refactor(typeaware): no-unnecessary-type-conversion + unbound-method sweep (T3.b partial)

### DIFF
--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -308,7 +308,7 @@ function HostPickerTrigger({
   const pressableStyle = useCallback(
     ({ hovered = false }: PressableStateCallbackType & { hovered?: boolean }) => [
       styles.hostTrigger,
-      Boolean(hovered) && styles.hostTriggerHovered,
+      hovered && styles.hostTriggerHovered,
     ],
     [],
   );

--- a/packages/app/src/components/ui/autocomplete.tsx
+++ b/packages/app/src/components/ui/autocomplete.tsx
@@ -72,7 +72,7 @@ function AutocompleteRow({
   const pressableStyle = useCallback(
     ({ hovered = false, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
       styles.item,
-      (Boolean(hovered) || pressed || isSelected) && styles.itemActive,
+      (hovered || pressed || isSelected) && styles.itemActive,
     ],
     [isSelected],
   );

--- a/packages/app/src/components/ui/dropdown-menu.tsx
+++ b/packages/app/src/components/ui/dropdown-menu.tsx
@@ -315,7 +315,7 @@ export function DropdownMenuTrigger({
   const pressableStyle = useCallback(
     ({ pressed, hovered = false }: PressableStateCallbackType & { hovered?: boolean }) => {
       if (typeof style === "function") {
-        return style({ pressed, hovered: Boolean(hovered), open: ctx.open });
+        return style({ pressed, hovered, open: ctx.open });
       }
       return style;
     },
@@ -324,7 +324,7 @@ export function DropdownMenuTrigger({
 
   const renderChildren = useCallback(
     ({ pressed, hovered = false }: PressableStateCallbackType & { hovered?: boolean }) => {
-      const state: TriggerState = { pressed, hovered: Boolean(hovered), open: ctx.open };
+      const state: TriggerState = { pressed, hovered, open: ctx.open };
       return typeof children === "function" ? children(state) : children;
     },
     [children, ctx.open],

--- a/packages/app/src/hooks/use-agent-history.ts
+++ b/packages/app/src/hooks/use-agent-history.ts
@@ -141,7 +141,7 @@ export function useAgentHistory(options: {
     isLoading,
     isInitialLoad,
     isRevalidating,
-    hasMore: Boolean(hasNextPage),
+    hasMore: hasNextPage,
     isLoadingMore: isFetchingNextPage,
     refreshAll,
     loadMore,

--- a/packages/app/src/hooks/use-archive-agent.ts
+++ b/packages/app/src/hooks/use-archive-agent.ts
@@ -100,7 +100,7 @@ function isAgentArchiving(input: IsAgentArchivingInput): boolean {
   if (!key) {
     return false;
   }
-  return Boolean(readPendingState(input.queryClient)[key]);
+  return readPendingState(input.queryClient)[key];
 }
 
 function removeAgentFromListPayload<T extends AgentsListQueryData | undefined>(
@@ -420,7 +420,7 @@ export function useArchiveAgent() {
       if (!key) {
         return false;
       }
-      return Boolean((pendingQuery.data ?? {})[key]);
+      return (pendingQuery.data ?? {})[key];
     },
     [pendingQuery.data],
   );

--- a/packages/app/src/hooks/use-archive-agent.ts
+++ b/packages/app/src/hooks/use-archive-agent.ts
@@ -100,7 +100,7 @@ function isAgentArchiving(input: IsAgentArchivingInput): boolean {
   if (!key) {
     return false;
   }
-  return readPendingState(input.queryClient)[key];
+  return readPendingState(input.queryClient)[key] ?? false;
 }
 
 function removeAgentFromListPayload<T extends AgentsListQueryData | undefined>(
@@ -420,7 +420,7 @@ export function useArchiveAgent() {
       if (!key) {
         return false;
       }
-      return (pendingQuery.data ?? {})[key];
+      return (pendingQuery.data ?? {})[key] ?? false;
     },
     [pendingQuery.data],
   );

--- a/packages/app/src/panels/pane-context.tsx
+++ b/packages/app/src/panels/pane-context.tsx
@@ -7,17 +7,17 @@ export interface PaneContextValue {
   workspaceId: string;
   tabId: string;
   target: WorkspaceTabTarget;
-  openTab(target: WorkspaceTabTarget): void;
-  closeCurrentTab(): void;
-  retargetCurrentTab(target: WorkspaceTabTarget): void;
-  openFileInWorkspace(filePath: string): void;
+  openTab: (target: WorkspaceTabTarget) => void;
+  closeCurrentTab: () => void;
+  retargetCurrentTab: (target: WorkspaceTabTarget) => void;
+  openFileInWorkspace: (filePath: string) => void;
 }
 
 export interface PaneFocusContextValue {
   isWorkspaceFocused: boolean;
   isPaneFocused: boolean;
   isInteractive: boolean;
-  focusPane(): void;
+  focusPane: () => void;
 }
 
 const PaneContext = createContext<PaneContextValue | null>(null);

--- a/packages/app/src/utils/confirm-dialog.ts
+++ b/packages/app/src/utils/confirm-dialog.ts
@@ -86,7 +86,7 @@ async function showDesktopConfirmDialog(input: ConfirmDialogInput): Promise<bool
   const desktopAsk = desktopApi.dialog?.ask;
 
   if (typeof desktopAsk === "function") {
-    return Boolean(await desktopAsk(input.message, options));
+    return await desktopAsk(input.message, options);
   }
 
   return null;

--- a/packages/app/src/utils/workspace-execution.ts
+++ b/packages/app/src/utils/workspace-execution.ts
@@ -112,7 +112,7 @@ export function getWorkspaceExecutionAuthority(
       reason: "workspace_missing",
       message:
         "workspaces" in input
-          ? `Workspace not found: ${String(input.workspaceId ?? "")}`
+          ? `Workspace not found: ${input.workspaceId ?? ""}`
           : "Workspace not found.",
     };
   }

--- a/packages/server/src/server/agent/agent-timeline-store.ts
+++ b/packages/server/src/server/agent/agent-timeline-store.ts
@@ -94,7 +94,7 @@ function fetchAfter(ctx: FetchContext): AgentTimelineFetchResult {
     gap: false,
     window,
     hasOlder: selected[0].seq > minSeq,
-    hasNewer: Boolean(lastSelected && lastSelected.seq < maxSeq),
+    hasNewer: lastSelected !== null && lastSelected !== undefined && lastSelected.seq < maxSeq,
     rows: selected.map(cloneRow),
   };
 }

--- a/packages/server/src/server/agent/providers/provider-runner.ts
+++ b/packages/server/src/server/agent/providers/provider-runner.ts
@@ -12,9 +12,9 @@ export type ProviderFinalTextReducer = (params: {
 }) => string;
 
 export interface ProviderTurnRunner {
-  startTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<{ turnId: string }>;
-  subscribe(callback: (event: AgentStreamEvent) => void): () => void;
-  getSessionId(): string | Promise<string>;
+  startTurn: (prompt: AgentPromptInput, options?: AgentRunOptions) => Promise<{ turnId: string }>;
+  subscribe: (callback: (event: AgentStreamEvent) => void) => () => void;
+  getSessionId: () => string | Promise<string>;
 }
 
 export interface RunProviderTurnOptions extends ProviderTurnRunner {

--- a/packages/server/src/server/pairing-qr.ts
+++ b/packages/server/src/server/pairing-qr.ts
@@ -13,7 +13,7 @@ function parseBooleanEnv(value: string | undefined): boolean | undefined {
 function shouldPrintPairingQr(): boolean {
   const env = parseBooleanEnv(process.env.PASEO_PAIRING_QR);
   if (env !== undefined) return env;
-  return Boolean(process.stdout.isTTY);
+  return process.stdout.isTTY ?? false;
 }
 
 export async function renderPairingQr(url: string): Promise<string> {

--- a/packages/server/src/server/speech/providers/local/sherpa/sherpa-realtime-session.ts
+++ b/packages/server/src/server/speech/providers/local/sherpa/sherpa-realtime-session.ts
@@ -59,10 +59,10 @@ export class SherpaRealtimeTranscriptionSession
       }
 
       const rawResult = this.engine.recognizer.getResult(this.stream);
-      const text = String(
+      const text = (
         (typeof rawResult === "object" && rawResult && "text" in rawResult
           ? rawResult.text
-          : undefined) ?? "",
+          : undefined) ?? ""
       ).trim();
       if (text !== this.lastPartialText) {
         this.lastPartialText = text;
@@ -97,10 +97,10 @@ export class SherpaRealtimeTranscriptionSession
       }
 
       const rawFinal = this.engine.recognizer.getResult(this.stream);
-      const finalText = String(
+      const finalText = (
         (typeof rawFinal === "object" && rawFinal && "text" in rawFinal
           ? rawFinal.text
-          : undefined) ?? "",
+          : undefined) ?? ""
       ).trim();
       const segmentId = this.currentSegmentId;
       const previousSegmentId = this.previousSegmentId;

--- a/packages/server/src/server/speech/providers/local/sherpa/sherpa-stt.ts
+++ b/packages/server/src/server/speech/providers/local/sherpa/sherpa-stt.ts
@@ -165,10 +165,10 @@ export class SherpaOnnxSTT implements SpeechToTextProvider {
       }
 
       const rawResult = this.engine.recognizer.getResult(stream);
-      const text = String(
+      const text = (
         (typeof rawResult === "object" && rawResult && "text" in rawResult
           ? rawResult.text
-          : undefined) ?? "",
+          : undefined) ?? ""
       ).trim();
       const duration = Date.now() - start;
       this.logger.debug({ duration, textLength: text.length }, "Sherpa transcription complete");

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -662,7 +662,7 @@ export async function runWorktreeSetupInBackground(
   let setupResults: WorktreeSetupCommandResult[] = [];
   let setupStarted = false;
   const progressAccumulator = createWorktreeSetupProgressAccumulator();
-  const workspaceId = String(options.workspaceId);
+  const workspaceId = options.workspaceId;
 
   const emitSetupProgress = (status: "running" | "completed" | "failed", error: string | null) => {
     const snapshot: WorkspaceSetupSnapshot = {

--- a/packages/server/src/utils/process-tree.ts
+++ b/packages/server/src/utils/process-tree.ts
@@ -75,7 +75,7 @@ export function signalProcessTree(
     }
 
     try {
-      (options.kill ?? process.kill)(-pid, signal);
+      (options.kill ?? process.kill.bind(process))(-pid, signal);
       return;
     } catch {
       // Fall back to the direct child when no separate process group exists.


### PR DESCRIPTION
## Rules fixed
- `typescript-eslint/no-unnecessary-type-conversion` — 17 errors cleared
- `typescript-eslint/unbound-method` — 8 errors cleared (production code only)

## Files changed (15, at cap)

**unbound-method** — interface method shorthand → property function syntax:
- `packages/app/src/panels/pane-context.tsx` — `PaneContextValue` + `PaneFocusContextValue` (fixes unbound destructuring in agent-panel, browser-panel, draft-panel without touching those files)
- `packages/server/src/server/agent/providers/provider-runner.ts` — `ProviderTurnRunner` interface
- `packages/server/src/utils/process-tree.ts` — `process.kill.bind(process)`

**no-unnecessary-type-conversion** — remove redundant `Boolean()`/`String()` wraps:
- `packages/server/src/server/agent/agent-timeline-store.ts`
- `packages/server/src/server/worktree-session.ts`
- `packages/server/src/server/pairing-qr.ts`
- `packages/server/src/server/speech/providers/local/sherpa/sherpa-realtime-session.ts`
- `packages/server/src/server/speech/providers/local/sherpa/sherpa-stt.ts`
- `packages/app/src/utils/workspace-execution.ts`
- `packages/app/src/utils/confirm-dialog.ts`
- `packages/app/src/hooks/use-archive-agent.ts`
- `packages/app/src/hooks/use-agent-history.ts`
- `packages/app/src/components/left-sidebar.tsx`
- `packages/app/src/components/ui/autocomplete.tsx`
- `packages/app/src/components/ui/dropdown-menu.tsx`

## Deferred (9 errors, 7 files — all single-line `Boolean(hovered)` removals)
`project-picker-modal.tsx`, `agent-list.tsx`, `branch-switcher.tsx`, `file-explorer-pane.tsx`, `workspace-open-in-editor-button.tsx`, `browser-pane.electron.tsx`, `sortable-inline-list.web.tsx`

## Verification
- typecheck: green
- lint (typeAware: false): 0 warnings, 0 errors
- pre-commit hooks: all passed