### PR TITLE
refactor: explicit returns + void floating promises (T3.a typeaware sweep)

### DIFF
--- a/packages/app/src/components/agent-status-bar.utils.ts
+++ b/packages/app/src/components/agent-status-bar.utils.ts
@@ -11,6 +11,8 @@ export function getStatusSelectorHint(selector: ExplainedStatusSelector): string
       return "Change model";
     case "mode":
       return "Change permission mode";
+    default:
+      throw new Error("unreachable");
   }
 }
 

--- a/packages/app/src/components/ui/dropdown-menu.tsx
+++ b/packages/app/src/components/ui/dropdown-menu.tsx
@@ -445,7 +445,7 @@ export function DropdownMenuContent({
       setTriggerRect(null);
       setContentSize(null);
       setPosition(null);
-      return;
+      return undefined;
     }
 
     // Capture status bar height synchronously before async measurement.
@@ -454,8 +454,8 @@ export function DropdownMenuContent({
     const statusBarHeight = Platform.OS === "android" ? (StatusBar.currentHeight ?? 0) : 0;
     let cancelled = false;
 
-    measureElement(triggerRef.current).then((rect) => {
-      if (cancelled) return;
+    void measureElement(triggerRef.current).then((rect) => {
+      if (cancelled) return undefined;
       // On Android with statusBarTranslucent, measureInWindow returns coordinates
       // relative to below the status bar, but Modal content starts from screen top.
       // Add status bar height to align coordinate systems (same as react-native-popover-view).
@@ -463,7 +463,7 @@ export function DropdownMenuContent({
         ...rect,
         y: rect.y + statusBarHeight,
       });
-      return;
+      return undefined;
     });
 
     return () => {

--- a/packages/app/src/hooks/resolve-agent-form.ts
+++ b/packages/app/src/hooks/resolve-agent-form.ts
@@ -553,5 +553,7 @@ export function resolveAgentForm(
 
     case "RESET":
       return { ...state, userModified: INITIAL_USER_MODIFIED };
+    default:
+      throw new Error("unreachable");
   }
 }

--- a/packages/app/src/hooks/use-agent-form-state.ts
+++ b/packages/app/src/hooks/use-agent-form-state.ts
@@ -459,7 +459,7 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
   }, []);
 
   const refreshProviderModels = useCallback(() => {
-    refreshSnapshot();
+    void refreshSnapshot();
   }, [refreshSnapshot]);
 
   const refetchProviderModelsIfStale = useCallback(() => {

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -1055,6 +1055,8 @@ function resolvePayload(
       return { delta: def.delta };
     case "message-input":
       return { kind: def.kind };
+    default:
+      throw new Error("unreachable");
   }
 }
 

--- a/packages/cli/src/commands/onboard.ts
+++ b/packages/cli/src/commands/onboard.ts
@@ -432,7 +432,7 @@ async function waitForDaemonReadyWithUi(args: {
     } else {
       log.error(message);
     }
-    process.exit(1);
+    return process.exit(1);
   }
 }
 

--- a/packages/cli/src/commands/worktree/create.ts
+++ b/packages/cli/src/commands/worktree/create.ts
@@ -123,6 +123,8 @@ export function toDaemonCreateInput(parsed: ParsedWorktreeCreateInput) {
         action: "checkout" as const,
         githubPrNumber: parsed.target.prNumber,
       };
+    default:
+      throw new Error("unreachable");
   }
 }
 

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1647,7 +1647,7 @@ export class AgentManager {
         { agentId, foregroundTurnId },
         "cancelAgentRun: foreground turn still active after timeout, force-canceling",
       );
-      this.dispatchSessionEvent(agent, {
+      void this.dispatchSessionEvent(agent, {
         type: "turn_canceled",
         provider: agent.provider,
         reason: "interrupted",

--- a/packages/server/src/server/agent/mcp-server.ts
+++ b/packages/server/src/server/agent/mcp-server.ts
@@ -2104,6 +2104,8 @@ function mcpCreateWorktreeInput(
       return {
         input: { ...base, action: "checkout", githubPrNumber: target.prNumber },
       };
+    default:
+      throw new Error("unreachable");
   }
 }
 

--- a/packages/server/src/server/agent/mcp-shared.ts
+++ b/packages/server/src/server/agent/mcp-shared.ts
@@ -327,11 +327,11 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
           return;
         }
         if (event.agent.lifecycle === "error") {
-          notify("errored");
+          void notify("errored");
           return;
         }
         if (event.agent.lifecycle === "idle" && hasSeenRunning) {
-          notify("finished");
+          void notify("finished");
           return;
         }
         if (event.agent.lifecycle === "closed") {
@@ -343,7 +343,7 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
       }
 
       if (event.event.type === "permission_requested") {
-        notify("needs permission");
+        void notify("needs permission");
       }
     },
     { agentId: childAgentId, replayState: false },
@@ -362,7 +362,7 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
   if (childSnapshot.lifecycle === "running") {
     hasSeenRunning = true;
   } else if (childSnapshot.lifecycle === "error") {
-    notify("errored");
+    void notify("errored");
   }
 }
 

--- a/packages/server/src/server/agent/prompt-attachments.ts
+++ b/packages/server/src/server/agent/prompt-attachments.ts
@@ -54,6 +54,8 @@ export function renderPromptAttachmentAsText(attachment: AgentAttachment): strin
       });
       return lines.join("\n");
     }
+    default:
+      throw new Error("unreachable");
   }
 }
 

--- a/packages/server/src/server/daemon-e2e/agent-configs.ts
+++ b/packages/server/src/server/daemon-e2e/agent-configs.ts
@@ -134,6 +134,8 @@ export function isProviderAvailable(provider: AgentProvider): Promise<boolean> {
             Boolean(process.env.OPENROUTER_API_KEY) ||
             existsSync(join(homedir(), ".pi", "agent", "auth.json")))
         );
+      default:
+        return false;
     }
   })();
 

--- a/packages/server/src/server/workspace-directory.ts
+++ b/packages/server/src/server/workspace-directory.ts
@@ -116,6 +116,8 @@ export class WorkspaceDirectory {
           return workspace.name.toLocaleLowerCase();
         case "project_id":
           return workspace.projectId.toLocaleLowerCase();
+        default:
+          throw new Error("unreachable");
       }
     },
   });

--- a/packages/server/src/shared/tool-call-display.ts
+++ b/packages/server/src/shared/tool-call-display.ts
@@ -122,6 +122,8 @@ function buildCanonicalDetailDisplay(input: ToolCallDisplayInput): DetailDisplay
       };
     case "unknown":
       return {};
+    default:
+      throw new Error("unreachable");
   }
 }
 

--- a/packages/server/src/terminal/terminal-session-controller.ts
+++ b/packages/server/src/terminal/terminal-session-controller.ts
@@ -145,6 +145,8 @@ export class TerminalSessionController {
         return this.handleKillTerminalRequest(msg);
       case "capture_terminal_request":
         return this.handleCaptureTerminalRequest(msg);
+      default:
+        return undefined;
     }
   }
 


### PR DESCRIPTION
## Cluster T3.a

Mechanical fixes for `consistent-return` (99 total) and `no-floating-promises` (44 total). Hit the 15-file cap — this PR is the first batch.

## Errors cleared

| Rule | Fixed |
|---|---|
| `consistent-return` | 12 (11 exhaustive-switch default cases + 1 catch-block return) |
| `no-floating-promises` | 6 (1 × agent-manager, 4 × mcp-shared, 1 × use-agent-form-state) |
| `promise/always-return` | 1 (dropdown-menu .then callback) |

## Files touched (15)

**server**
- `shared/tool-call-display.ts` — default throw in `buildCanonicalDetailDisplay` switch
- `agent/prompt-attachments.ts` — default throw in `renderPromptAttachmentAsText` switch
- `workspace-directory.ts` — default throw in `getSortValue` switch
- `agent/mcp-server.ts` — default throw in `mcpCreateWorktreeInput` switch
- `terminal/terminal-session-controller.ts` — default return in `dispatch` switch
- `daemon-e2e/agent-configs.ts` — default `return false` in `isProviderAvailable` async switch
- `agent/agent-manager.ts` — `void` the fire-and-forget `dispatchSessionEvent` call
- `agent/mcp-shared.ts` — `void` 4 `notify()` floating calls

**app**
- `components/agent-status-bar.utils.ts` — default throw in `getStatusSelectorHint` switch
- `keyboard/keyboard-shortcuts.ts` — default throw in `resolvePayload` switch
- `hooks/resolve-agent-form.ts` — default throw in `resolveAgentForm` switch
- `components/ui/dropdown-menu.tsx` — `void .then()` + `return undefined` for `promise/always-return`
- `hooks/use-agent-form-state.ts` — `void refreshSnapshot()` floating call

**cli**
- `commands/worktree/create.ts` — default throw in `toDaemonCreateInput` switch
- `commands/onboard.ts` — `return process.exit(1)` to give consistent-return a return on the catch path

## Deferred

- `server/worktree-session.ts` — `getSortValue` (same pattern, 15-file cap reached)
- Files in T2's EXCLUDE list skipped per spec