### PR TITLE
fix: normalize Claude AskUserQuestion answers (#755)

### DIFF
--- a/packages/server/src/server/agent/providers/claude-agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test, vi } from "vitest";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 
 import { createTestLogger } from "../../../test-utils/test-logger.js";
-import { ClaudeAgentClient, convertClaudeHistoryEntry } from "./claude-agent.js";
+import {
+  ClaudeAgentClient,
+  convertClaudeHistoryEntry,
+  normalizeClaudeAskUserQuestionUpdatedInput,
+} from "./claude-agent.js";
 import type { AgentTimelineItem, AgentUsage, AgentStreamEvent } from "../agent-sdk-types.js";
 
 interface TestClaudeSession {
@@ -361,6 +365,138 @@ describe("ClaudeAgentClient.listModels", () => {
 
     const defaultModel = models.find((m) => m.isDefault);
     expect(defaultModel?.id).toBe("claude-opus-4-6");
+  });
+});
+
+describe("normalizeClaudeAskUserQuestionUpdatedInput", () => {
+  test("maps frontend header-keyed answers to Claude question text keys", () => {
+    expect(
+      normalizeClaudeAskUserQuestionUpdatedInput(
+        {
+          questions: [
+            {
+              question: "Which provider should I use?",
+              header: "Provider",
+              options: [],
+              multiSelect: false,
+            },
+          ],
+          answers: { Provider: "Claude" },
+        },
+        undefined,
+      ),
+    ).toEqual({
+      questions: [
+        {
+          question: "Which provider should I use?",
+          header: "Provider",
+          options: [],
+          multiSelect: false,
+        },
+      ],
+      answers: { "Which provider should I use?": "Claude" },
+    });
+  });
+
+  test("uses fallback request questions when response only includes answers", () => {
+    expect(
+      normalizeClaudeAskUserQuestionUpdatedInput(
+        {
+          answers: { Provider: "Codex" },
+        },
+        {
+          questions: [
+            {
+              question: "Which provider should I use?",
+              header: "Provider",
+              options: [],
+              multiSelect: false,
+            },
+          ],
+        },
+      ),
+    ).toEqual({
+      questions: [
+        {
+          question: "Which provider should I use?",
+          header: "Provider",
+          options: [],
+          multiSelect: false,
+        },
+      ],
+      answers: { "Which provider should I use?": "Codex" },
+    });
+  });
+
+  test("respondToPermission preserves full question input when UI returns answers-only payload", async () => {
+    const client = new ClaudeAgentClient({ logger: createTestLogger() });
+    const session = await client.createSession({
+      provider: "claude",
+      cwd: process.cwd(),
+    });
+
+    const request = {
+      id: "permission-question-1",
+      provider: "claude",
+      name: "AskUserQuestion",
+      kind: "question",
+      input: {
+        questions: [
+          {
+            question: "Which provider should I use?",
+            header: "Provider",
+            options: [],
+            multiSelect: false,
+          },
+        ],
+      },
+    };
+
+    const resultPromise = new Promise<unknown>((resolve, reject) => {
+      (
+        session as unknown as {
+          pendingPermissions: Map<
+            string,
+            {
+              request: typeof request;
+              resolve: (value: unknown) => void;
+              reject: (error: Error) => void;
+            }
+          >;
+        }
+      ).pendingPermissions.set(request.id, {
+        request,
+        resolve,
+        reject,
+      });
+    });
+
+    try {
+      await session.respondToPermission(request.id, {
+        behavior: "allow",
+        updatedInput: {
+          answers: { Provider: "Claude" },
+        },
+      });
+
+      await expect(resultPromise).resolves.toEqual({
+        behavior: "allow",
+        updatedInput: {
+          questions: [
+            {
+              question: "Which provider should I use?",
+              header: "Provider",
+              options: [],
+              multiSelect: false,
+            },
+          ],
+          answers: { "Which provider should I use?": "Claude" },
+        },
+        updatedPermissions: undefined,
+      });
+    } finally {
+      await session.close();
+    }
   });
 });
 

--- a/packages/server/src/server/agent/providers/claude-agent.ts
+++ b/packages/server/src/server/agent/providers/claude-agent.ts
@@ -87,6 +87,61 @@ import { getOrchestratorModeInstructions } from "../orchestrator-instructions.js
 const fsPromises = promises;
 const CLAUDE_SETTING_SOURCES: NonNullable<Options["settingSources"]> = ["user", "project"];
 
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+export function normalizeClaudeAskUserQuestionUpdatedInput(
+  updatedInput: AgentMetadata | undefined,
+  fallbackInput: AgentMetadata | undefined,
+): AgentMetadata {
+  const fallback = isMetadata(fallbackInput) ? fallbackInput : {};
+  const base = isMetadata(updatedInput) ? updatedInput : {};
+  // Paseo's shared question UI serializes answers by question header, but Claude's
+  // AskUserQuestion tool expects answer keys to match the full question text. Merge
+  // the original request payload back in so provider callbacks that only return
+  // `{ answers }` still satisfy Claude's full tool input schema.
+  const merged = { ...fallback, ...base };
+  const questions =
+    (Array.isArray(base.questions) ? base.questions : null) ??
+    (Array.isArray(fallback.questions) ? fallback.questions : null);
+  const answers = isMetadata(base.answers) ? base.answers : null;
+
+  if (!questions || !answers) {
+    return merged;
+  }
+
+  const normalizedAnswers: Record<string, string> = {};
+  for (const item of questions) {
+    const question = isMetadata(item) ? item : null;
+    if (!question) {
+      continue;
+    }
+
+    const questionText = readNonEmptyString(question.question);
+    if (!questionText) {
+      continue;
+    }
+
+    const header = readNonEmptyString(question.header);
+    const answer =
+      readNonEmptyString(answers[questionText]) ??
+      (header ? readNonEmptyString(answers[header]) : null);
+    if (answer) {
+      normalizedAnswers[questionText] = answer;
+    }
+  }
+
+  if (Object.keys(normalizedAnswers).length === 0) {
+    return merged;
+  }
+
+  return {
+    ...merged,
+    answers: normalizedAnswers,
+  };
+}
+
 type TurnState = "idle" | "foreground" | "autonomous";
 
 interface EventIdentifiers {
@@ -1772,9 +1827,16 @@ class ClaudeAgentSession implements AgentSession {
           }),
         );
       }
+      const updatedInput =
+        pending.request.kind === "question"
+          ? normalizeClaudeAskUserQuestionUpdatedInput(
+              response.updatedInput,
+              pending.request.input ?? undefined,
+            )
+          : (response.updatedInput ?? pending.request.input ?? {});
       const result: PermissionResult = {
         behavior: "allow",
-        updatedInput: response.updatedInput ?? pending.request.input ?? {},
+        updatedInput,
         updatedPermissions: this.normalizePermissionUpdates(response.updatedPermissions),
       };
       pending.resolve(result);


### PR DESCRIPTION
## Summary
- normalize Claude AskUserQuestion answers from Paseo's header-keyed UI shape into the question-text keyed shape Claude expects
- preserve the original question payload when permission callbacks return an answers-only `updatedInput`
- add regression coverage for both the normalization helper and the question permission response flow

## Problem
Claude question prompts in Paseo were capturing the user's selection in the UI, but the answer was not reaching Claude correctly. The shared question form submits answers keyed by question header, while Claude's `AskUserQuestion` contract expects answers keyed by the full question text. That mismatch left Claude with empty or unusable answers.

## Validation
- `npm run format:files -- packages/server/src/server/agent/providers/claude-agent.ts packages/server/src/server/agent/providers/claude-agent.test.ts`
- `npm run lint -- packages/server/src/server/agent/providers/claude-agent.ts packages/server/src/server/agent/providers/claude-agent.test.ts`
- `cd packages/server && npx vitest run src/server/agent/providers/claude-agent.test.ts`
- `npm run typecheck`

Fixes #755