### PR TITLE
fix: include untracked files in checkout shortstat (#608)

### DIFF
--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -459,6 +459,37 @@ const x = 1;
     expect(shortstat).toEqual({ additions: 1, deletions: 0 });
   });
 
+  it("includes untracked file lines in shortstat additions", async () => {
+    setupRemoteTrackingMain(repoDir, tempDir);
+    execSync("git checkout -b feature", { cwd: repoDir });
+    commitFile(repoDir, "committed.txt", "one\n", "add committed");
+    writeFileSync(join(repoDir, "untracked.txt"), "line1\nline2\nline3\n");
+
+    const shortstat = await getCheckoutShortstat(repoDir);
+
+    expect(shortstat).toEqual({ additions: 4, deletions: 0 });
+  });
+
+  it("reports untracked-only additions when no tracked changes exist", async () => {
+    setupRemoteTrackingMain(repoDir, tempDir);
+    writeFileSync(join(repoDir, "newfile.txt"), "a\nb\n");
+
+    const shortstat = await getCheckoutShortstat(repoDir);
+
+    expect(shortstat).toEqual({ additions: 2, deletions: 0 });
+  });
+
+  it("counts empty untracked files as 0 additions", async () => {
+    setupRemoteTrackingMain(repoDir, tempDir);
+    execSync("git checkout -b feature", { cwd: repoDir });
+    commitFile(repoDir, "committed.txt", "one\n", "add committed");
+    writeFileSync(join(repoDir, "empty.txt"), "");
+
+    const shortstat = await getCheckoutShortstat(repoDir);
+
+    expect(shortstat).toEqual({ additions: 1, deletions: 0 });
+  });
+
   it("uses the merge-base for shortstat when a feature branch diverged from its tracked remote", async () => {
     setupRemoteTrackingMain(repoDir, tempDir);
     execSync("git checkout -b feature", { cwd: repoDir });

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1492,6 +1492,41 @@ function parseCheckoutShortstat(text: string): CheckoutShortstat | null {
   return { additions, deletions };
 }
 
+const UNTRACKED_SHORTSTAT_MAX_FILES = 500;
+
+async function countUntrackedAdditions(cwd: string): Promise<number> {
+  try {
+    const { stdout } = await runGitCommand(["ls-files", "--others", "--exclude-standard"], {
+      cwd,
+      envOverlay: READ_ONLY_GIT_ENV,
+    });
+    const files = stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+
+    let additions = 0;
+    for (const file of files.slice(0, UNTRACKED_SHORTSTAT_MAX_FILES)) {
+      const absolutePath = resolve(cwd, file);
+      try {
+        const metadata = await statFile(absolutePath);
+        if (metadata.size > PER_FILE_DIFF_MAX_BYTES) continue;
+        if (await isLikelyBinaryFile(absolutePath)) continue;
+        const content = await readFile(absolutePath, "utf-8");
+        if (content.length === 0) continue;
+        const normalized = content.replace(/\r\n/g, "\n");
+        const lineCount = normalized.split("\n").length;
+        additions += normalized.endsWith("\n") ? lineCount - 1 : lineCount;
+      } catch {
+        // Skip unreadable files.
+      }
+    }
+    return additions;
+  } catch {
+    return 0;
+  }
+}
+
 async function getCheckoutShortstatUncached(
   cwd: string,
   context?: CheckoutContext,
@@ -1533,11 +1568,23 @@ async function getCheckoutShortstatUncached(
       return null;
     }
 
-    const { stdout } = await runGitCommand(["diff", "--shortstat", mergeBase], {
-      cwd,
-      envOverlay: READ_ONLY_GIT_ENV,
-    });
-    return parseCheckoutShortstat(stdout);
+    const [{ stdout }, untrackedAdditions] = await Promise.all([
+      runGitCommand(["diff", "--shortstat", mergeBase], {
+        cwd,
+        envOverlay: READ_ONLY_GIT_ENV,
+      }),
+      countUntrackedAdditions(cwd),
+    ]);
+
+    const tracked = parseCheckoutShortstat(stdout);
+
+    if (tracked) {
+      return { additions: tracked.additions + untrackedAdditions, deletions: tracked.deletions };
+    }
+    if (untrackedAdditions > 0) {
+      return { additions: untrackedAdditions, deletions: 0 };
+    }
+    return null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes #608 — untracked files were not counted in the checkout shortstat, so the diffstat badge in the app underreported additions.

### Before / After

| Before | After |
|--------|-------|
| <img width="501" height="202" alt="CleanShot 2026-05-05 at 17 46 00" src="https://github.com/user-attachments/assets/0f9e96f0-895e-4bef-8857-a098d1e35244" />| <img width="501" height="202" alt="CleanShot 2026-05-05 at 18 06 04" src="https://github.com/user-attachments/assets/e515ce39-7550-4960-9fc4-459156df35ab" />|

The shortstat badge previously showed `+68 -5`, ignoring untracked file lines. After this fix it correctly shows `+78 -5`, including the 10 lines from the untracked file.

### What changed

- **`countUntrackedAdditions()`** — new function that lists untracked files via `git ls-files --others --exclude-standard`, reads each text file, and counts lines
- **`getCheckoutShortstatUncached()`** — now runs tracked diff and untracked count in parallel via `Promise.all`, merges the results
- **File size guard** — skips files larger than `PER_FILE_DIFF_MAX_BYTES` (1MB) to prevent OOM on large untracked artifacts
- **Binary detection** — uses existing `isLikelyBinaryFile()` to skip binary files
- **Empty file handling** — empty files correctly count as 0 additions
- **CRLF normalization** — `\r\n` normalized to `\n` before counting
- **Safety cap** — limits scanning to 500 untracked files (`UNTRACKED_SHORTSTAT_MAX_FILES`)

## Test plan

- [x] New test: untracked file lines included in shortstat additions (tracked + untracked combined)
- [x] New test: untracked-only additions reported when no tracked changes exist
- [x] New test: empty untracked files count as 0 additions
- [x] All 89 existing checkout-git tests pass
- [x] Typecheck clean across all packages