### PR TITLE
feat(cli): expose --effort flag on schedule create/update

### DIFF
--- a/packages/cli/src/commands/schedule/create.ts
+++ b/packages/cli/src/commands/schedule/create.ts
@@ -17,7 +17,7 @@ export interface ScheduleCreateOptions extends ScheduleCommandOptions {
   target?: string;
   provider?: string;
   mode?: string;
-  thinking?: string;
+  effort?: string;
   cwd?: string;
   maxRuns?: string;
   expiresIn?: string;
@@ -39,7 +39,7 @@ export async function runCreateCommand(
     target: options.target,
     provider: options.provider,
     mode: options.mode,
-    thinking: options.thinking,
+    effort: options.effort,
     cwd: options.cwd,
     host: options.host,
     maxRuns: options.maxRuns,

--- a/packages/cli/src/commands/schedule/create.ts
+++ b/packages/cli/src/commands/schedule/create.ts
@@ -17,6 +17,7 @@ export interface ScheduleCreateOptions extends ScheduleCommandOptions {
   target?: string;
   provider?: string;
   mode?: string;
+  thinking?: string;
   cwd?: string;
   maxRuns?: string;
   expiresIn?: string;
@@ -38,6 +39,7 @@ export async function runCreateCommand(
     target: options.target,
     provider: options.provider,
     mode: options.mode,
+    thinking: options.thinking,
     cwd: options.cwd,
     host: options.host,
     maxRuns: options.maxRuns,

--- a/packages/cli/src/commands/schedule/index.ts
+++ b/packages/cli/src/commands/schedule/index.ts
@@ -31,6 +31,10 @@ export function createScheduleCommand(): Command {
         "--mode <mode>",
         "Provider-specific mode (e.g. claude bypassPermissions, opencode build)",
       )
+      .option(
+        "--thinking <id>",
+        "Provider-specific thinking effort (e.g. claude low|medium|high|xhigh|max)",
+      )
       .option("--cwd <path>", "Working directory (default: current; required with --host)")
       .option("--run-now", "Fire one immediate run on creation (only with --cron)")
       .option("--no-run-now", "Wait the full interval before the first run (only with --every)")
@@ -90,6 +94,10 @@ export function createScheduleCommand(): Command {
       )
       .option("--model <model>", "New agent model (only for new-agent target)")
       .option("--mode <mode>", "New agent provider mode (only for new-agent target)")
+      .option(
+        "--thinking <id>",
+        "New agent thinking effort, e.g. claude low|medium|high|xhigh|max (only for new-agent target)",
+      )
       .option("--cwd <path>", "New working directory (only for new-agent target)")
       .option("--max-runs <n>", "Set or change maximum number of runs")
       .option("--no-max-runs", "Clear the max-runs limit")

--- a/packages/cli/src/commands/schedule/index.ts
+++ b/packages/cli/src/commands/schedule/index.ts
@@ -32,8 +32,8 @@ export function createScheduleCommand(): Command {
         "Provider-specific mode (e.g. claude bypassPermissions, opencode build)",
       )
       .option(
-        "--thinking <id>",
-        "Provider-specific thinking effort (e.g. claude low|medium|high|xhigh|max)",
+        "--effort <id>",
+        "Provider-specific reasoning effort (e.g. claude low|medium|high|xhigh|max)",
       )
       .option("--cwd <path>", "Working directory (default: current; required with --host)")
       .option("--run-now", "Fire one immediate run on creation (only with --cron)")
@@ -95,8 +95,8 @@ export function createScheduleCommand(): Command {
       .option("--model <model>", "New agent model (only for new-agent target)")
       .option("--mode <mode>", "New agent provider mode (only for new-agent target)")
       .option(
-        "--thinking <id>",
-        "New agent thinking effort, e.g. claude low|medium|high|xhigh|max (only for new-agent target)",
+        "--effort <id>",
+        "New agent reasoning effort, e.g. claude low|medium|high|xhigh|max (only for new-agent target)",
       )
       .option("--cwd <path>", "New working directory (only for new-agent target)")
       .option("--max-runs <n>", "Set or change maximum number of runs")

--- a/packages/cli/src/commands/schedule/shared.test.ts
+++ b/packages/cli/src/commands/schedule/shared.test.ts
@@ -116,11 +116,11 @@ describe("parseScheduleCreateInput agent config flags", () => {
     vi.restoreAllMocks();
   });
 
-  test("--mode and --thinking are written to new-agent config", () => {
+  test("--mode and --effort are written to new-agent config", () => {
     const input = parseScheduleCreateInput({
       ...baseOptions,
       mode: "bypassPermissions",
-      thinking: "max",
+      effort: "max",
     });
     expect(input.target).toEqual({
       type: "new-agent",
@@ -133,12 +133,12 @@ describe("parseScheduleCreateInput agent config flags", () => {
     });
   });
 
-  test("--provider model shorthand carries through with --thinking", () => {
+  test("--provider model shorthand carries through with --effort", () => {
     const input = parseScheduleCreateInput({
       ...baseOptions,
       provider: "claude/claude-opus-4-7[1m]",
       mode: "bypassPermissions",
-      thinking: "max",
+      effort: "max",
     });
     expect(input.target).toEqual({
       type: "new-agent",
@@ -152,17 +152,17 @@ describe("parseScheduleCreateInput agent config flags", () => {
     });
   });
 
-  test("--thinking on a non-new-agent target is rejected", () => {
+  test("--effort on a non-new-agent target is rejected", () => {
     expect(() =>
       parseScheduleCreateInput({
         ...baseOptions,
         target: "11111111-1111-1111-1111-111111111111",
-        thinking: "max",
+        effort: "max",
       }),
     ).toThrow(
       expect.objectContaining({
         code: "INVALID_TARGET",
-        message: expect.stringContaining("--thinking"),
+        message: expect.stringContaining("--effort"),
       }),
     );
   });
@@ -244,12 +244,12 @@ describe("parseScheduleUpdateInput", () => {
     });
   });
 
-  test("--thinking sets thinkingOptionId; empty value clears it", () => {
-    expect(parseScheduleUpdateInput({ id: "abc", thinking: "max" })).toEqual({
+  test("--effort sets thinkingOptionId; empty value clears it", () => {
+    expect(parseScheduleUpdateInput({ id: "abc", effort: "max" })).toEqual({
       id: "abc",
       newAgentConfig: { thinkingOptionId: "max" },
     });
-    expect(parseScheduleUpdateInput({ id: "abc", thinking: "" })).toEqual({
+    expect(parseScheduleUpdateInput({ id: "abc", effort: "" })).toEqual({
       id: "abc",
       newAgentConfig: { thinkingOptionId: null },
     });

--- a/packages/cli/src/commands/schedule/shared.test.ts
+++ b/packages/cli/src/commands/schedule/shared.test.ts
@@ -107,6 +107,67 @@ describe("parseScheduleCreateInput first-run timing", () => {
   });
 });
 
+describe("parseScheduleCreateInput agent config flags", () => {
+  beforeEach(() => {
+    vi.spyOn(process, "cwd").mockReturnValue("/local/project");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("--mode and --thinking are written to new-agent config", () => {
+    const input = parseScheduleCreateInput({
+      ...baseOptions,
+      mode: "bypassPermissions",
+      thinking: "max",
+    });
+    expect(input.target).toEqual({
+      type: "new-agent",
+      config: {
+        provider: "claude",
+        cwd: "/local/project",
+        modeId: "bypassPermissions",
+        thinkingOptionId: "max",
+      },
+    });
+  });
+
+  test("--provider model shorthand carries through with --thinking", () => {
+    const input = parseScheduleCreateInput({
+      ...baseOptions,
+      provider: "claude/claude-opus-4-7[1m]",
+      mode: "bypassPermissions",
+      thinking: "max",
+    });
+    expect(input.target).toEqual({
+      type: "new-agent",
+      config: {
+        provider: "claude",
+        cwd: "/local/project",
+        model: "claude-opus-4-7[1m]",
+        modeId: "bypassPermissions",
+        thinkingOptionId: "max",
+      },
+    });
+  });
+
+  test("--thinking on a non-new-agent target is rejected", () => {
+    expect(() =>
+      parseScheduleCreateInput({
+        ...baseOptions,
+        target: "11111111-1111-1111-1111-111111111111",
+        thinking: "max",
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: "INVALID_TARGET",
+        message: expect.stringContaining("--thinking"),
+      }),
+    );
+  });
+});
+
 describe("parseScheduleUpdateInput", () => {
   test("rejects calls with no fields to update", () => {
     expect(() => parseScheduleUpdateInput({ id: "abc" })).toThrow(
@@ -180,6 +241,17 @@ describe("parseScheduleUpdateInput", () => {
     expect(parseScheduleUpdateInput({ id: "abc", mode: "" })).toEqual({
       id: "abc",
       newAgentConfig: { modeId: null },
+    });
+  });
+
+  test("--thinking sets thinkingOptionId; empty value clears it", () => {
+    expect(parseScheduleUpdateInput({ id: "abc", thinking: "max" })).toEqual({
+      id: "abc",
+      newAgentConfig: { thinkingOptionId: "max" },
+    });
+    expect(parseScheduleUpdateInput({ id: "abc", thinking: "" })).toEqual({
+      id: "abc",
+      newAgentConfig: { thinkingOptionId: null },
     });
   });
 

--- a/packages/cli/src/commands/schedule/shared.ts
+++ b/packages/cli/src/commands/schedule/shared.ts
@@ -107,7 +107,7 @@ function resolveScheduleTarget(args: {
   if (hasExplicitNewAgentOption) {
     throw {
       code: "INVALID_TARGET",
-      message: "--provider/--mode/--thinking can only be used with a new-agent target",
+      message: "--provider/--mode/--effort can only be used with a new-agent target",
       details: "Use --target new-agent or omit --target to create a new agent schedule",
     } satisfies CommandError;
   }
@@ -133,7 +133,7 @@ export function parseScheduleCreateInput(options: {
   target?: string;
   provider?: string;
   mode?: string;
-  thinking?: string;
+  effort?: string;
   cwd?: string;
   host?: string;
   maxRuns?: string;
@@ -169,9 +169,9 @@ export function parseScheduleCreateInput(options: {
 
   const targetValue = options.target?.trim();
   const modeId = options.mode?.trim();
-  const thinkingOptionId = options.thinking?.trim();
+  const thinkingOptionId = options.effort?.trim();
   const hasExplicitNewAgentOption =
-    options.provider !== undefined || options.mode !== undefined || options.thinking !== undefined;
+    options.provider !== undefined || options.mode !== undefined || options.effort !== undefined;
   const createNewAgentTarget = (): ScheduleTarget => {
     const resolvedProviderModel = resolveProviderAndModel({
       provider: options.provider,
@@ -241,7 +241,7 @@ export interface ScheduleUpdateOptionsInput {
   provider?: string;
   model?: string;
   mode?: string;
-  thinking?: string;
+  effort?: string;
   cwd?: string;
   maxRuns?: string;
   expiresIn?: string;
@@ -381,8 +381,8 @@ function buildNewAgentConfigPatch(
     const trimmed = options.mode.trim();
     patch.modeId = trimmed.length > 0 ? trimmed : null;
   }
-  if (options.thinking !== undefined) {
-    const trimmed = options.thinking.trim();
+  if (options.effort !== undefined) {
+    const trimmed = options.effort.trim();
     patch.thinkingOptionId = trimmed.length > 0 ? trimmed : null;
   }
   if (options.cwd !== undefined) {

--- a/packages/cli/src/commands/schedule/shared.ts
+++ b/packages/cli/src/commands/schedule/shared.ts
@@ -107,7 +107,7 @@ function resolveScheduleTarget(args: {
   if (hasExplicitNewAgentOption) {
     throw {
       code: "INVALID_TARGET",
-      message: "--provider/--mode can only be used with a new-agent target",
+      message: "--provider/--mode/--thinking can only be used with a new-agent target",
       details: "Use --target new-agent or omit --target to create a new agent schedule",
     } satisfies CommandError;
   }
@@ -133,6 +133,7 @@ export function parseScheduleCreateInput(options: {
   target?: string;
   provider?: string;
   mode?: string;
+  thinking?: string;
   cwd?: string;
   host?: string;
   maxRuns?: string;
@@ -168,7 +169,9 @@ export function parseScheduleCreateInput(options: {
 
   const targetValue = options.target?.trim();
   const modeId = options.mode?.trim();
-  const hasExplicitNewAgentOption = options.provider !== undefined || options.mode !== undefined;
+  const thinkingOptionId = options.thinking?.trim();
+  const hasExplicitNewAgentOption =
+    options.provider !== undefined || options.mode !== undefined || options.thinking !== undefined;
   const createNewAgentTarget = (): ScheduleTarget => {
     const resolvedProviderModel = resolveProviderAndModel({
       provider: options.provider,
@@ -180,6 +183,7 @@ export function parseScheduleCreateInput(options: {
         cwd: cwdInput ?? process.cwd(),
         ...(resolvedProviderModel.model ? { model: resolvedProviderModel.model } : {}),
         ...(modeId ? { modeId } : {}),
+        ...(thinkingOptionId ? { thinkingOptionId } : {}),
       },
     };
   };
@@ -237,6 +241,7 @@ export interface ScheduleUpdateOptionsInput {
   provider?: string;
   model?: string;
   mode?: string;
+  thinking?: string;
   cwd?: string;
   maxRuns?: string;
   expiresIn?: string;
@@ -375,6 +380,10 @@ function buildNewAgentConfigPatch(
   if (options.mode !== undefined) {
     const trimmed = options.mode.trim();
     patch.modeId = trimmed.length > 0 ? trimmed : null;
+  }
+  if (options.thinking !== undefined) {
+    const trimmed = options.thinking.trim();
+    patch.thinkingOptionId = trimmed.length > 0 ? trimmed : null;
   }
   if (options.cwd !== undefined) {
     const trimmed = options.cwd.trim();

--- a/packages/cli/src/commands/schedule/types.ts
+++ b/packages/cli/src/commands/schedule/types.ts
@@ -140,6 +140,7 @@ export interface UpdateScheduleNewAgentConfig {
   provider?: string;
   model?: string | null;
   modeId?: string | null;
+  thinkingOptionId?: string | null;
   cwd?: string;
 }
 

--- a/packages/cli/src/commands/schedule/update.ts
+++ b/packages/cli/src/commands/schedule/update.ts
@@ -20,7 +20,7 @@ export interface ScheduleUpdateOptions extends ScheduleCommandOptions {
   provider?: string;
   model?: string;
   mode?: string;
-  thinking?: string;
+  effort?: string;
   cwd?: string;
   maxRuns?: string;
   noMaxRuns?: boolean;
@@ -42,7 +42,7 @@ export async function runUpdateCommand(
     provider: options.provider,
     model: options.model,
     mode: options.mode,
-    thinking: options.thinking,
+    effort: options.effort,
     cwd: options.cwd,
     maxRuns: options.maxRuns,
     expiresIn: options.expiresIn,

--- a/packages/cli/src/commands/schedule/update.ts
+++ b/packages/cli/src/commands/schedule/update.ts
@@ -20,6 +20,7 @@ export interface ScheduleUpdateOptions extends ScheduleCommandOptions {
   provider?: string;
   model?: string;
   mode?: string;
+  thinking?: string;
   cwd?: string;
   maxRuns?: string;
   noMaxRuns?: boolean;
@@ -41,6 +42,7 @@ export async function runUpdateCommand(
     provider: options.provider,
     model: options.model,
     mode: options.mode,
+    thinking: options.thinking,
     cwd: options.cwd,
     maxRuns: options.maxRuns,
     expiresIn: options.expiresIn,

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -560,6 +560,7 @@ export interface UpdateScheduleNewAgentConfig {
   provider?: string;
   model?: string | null;
   modeId?: string | null;
+  thinkingOptionId?: string | null;
   cwd?: string;
 }
 export interface UpdateScheduleOptions {

--- a/packages/server/src/server/schedule/rpc-schemas.ts
+++ b/packages/server/src/server/schedule/rpc-schemas.ts
@@ -79,6 +79,7 @@ const ScheduleUpdateNewAgentConfigSchema = z.object({
   provider: z.string().trim().min(1).optional(),
   model: z.string().trim().min(1).nullable().optional(),
   modeId: z.string().trim().min(1).nullable().optional(),
+  thinkingOptionId: z.string().trim().min(1).nullable().optional(),
   cwd: z.string().trim().min(1).optional(),
 });
 

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -72,6 +72,14 @@ function applyNewAgentConfig(
       delete config.modeId;
     }
   }
+  if (patch.thinkingOptionId !== undefined) {
+    const trimmed = patch.thinkingOptionId?.trim();
+    if (trimmed) {
+      config.thinkingOptionId = trimmed;
+    } else {
+      delete config.thinkingOptionId;
+    }
+  }
   return { ...target, config };
 }
 

--- a/packages/server/src/server/schedule/types.ts
+++ b/packages/server/src/server/schedule/types.ts
@@ -97,6 +97,7 @@ export interface UpdateScheduleNewAgentConfig {
   provider?: string;
   model?: string | null;
   modeId?: string | null;
+  thinkingOptionId?: string | null;
   cwd?: string;
 }
 


### PR DESCRIPTION
## Summary

- The schedule schema (`ScheduleTargetSchema.config.thinkingOptionId`) and the executor (`service.executeSchedule`) already plumbed a per-schedule reasoning effort all the way to `AgentSessionConfig`, but the CLI had no flag to set it.
- As a result, schedule-triggered agents always fell back to the model's first effort option (e.g. `low` for Claude) — even when the user wanted `max`.
- This PR adds `--effort <id>` to both `paseo schedule create` and `paseo schedule update`, mirroring the existing `--mode` plumbing.

## Changes

- CLI: `--effort <id>` on `schedule create` and `schedule update`
- CLI parsers (`parseScheduleCreate/UpdateInput`) accept and forward the value; on update, empty string clears it (mirroring `--mode`)
- `UpdateScheduleNewAgentConfig` gains `thinkingOptionId?: string | null` in CLI types, server types, and daemon-client
- Zod: `ScheduleUpdateNewAgentConfigSchema` validates the new field
- Server: `applyNewAgentConfig` writes/clears `config.thinkingOptionId`

Schedule create already accepted `thinkingOptionId` server-side; this PR just wires the CLI flag. The internal field name stays `thinkingOptionId` for wire compatibility — only the user-facing flag is `--effort`.

## Example

Before this PR, the only way to ship a schedule with a non-default reasoning effort was to construct the WebSocket message by hand. After:

```bash
paseo schedule create \
  --provider 'claude/claude-opus-4-7[1m]' \
  --mode bypassPermissions \
  --effort max \
  --cron '0 * * * *' \
  'your prompt'
```

## Test plan

- [x] `npx vitest run packages/cli/src/commands/schedule/shared.test.ts` — 29/29 pass (4 new cases covering create with `--mode`/`--effort`, provider-model shorthand interaction, rejection on non-new-agent targets, and update set/clear)
- [x] `npx vitest run packages/server/src/server/schedule/service.test.ts` — 21/21 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 warnings/0 errors
- [x] `npm run format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)