### PR TITLE
fix(relay): use TLS for any port-443 relay endpoint

### DIFF
--- a/packages/server/src/shared/daemon-endpoints.test.ts
+++ b/packages/server/src/shared/daemon-endpoints.test.ts
@@ -9,6 +9,7 @@ import {
   parseConnectionUri,
   serializeConnectionUri,
   serializeConnectionUriForStorage,
+  shouldUseTlsForDefaultHostedRelay,
 } from "./daemon-endpoints.js";
 
 describe("connection URI parsing", () => {
@@ -186,5 +187,27 @@ describe("relay websocket URLs", () => {
 
     expect(url.protocol).toBe("wss:");
     expect(extractHostPortFromWebSocketUrl(wsUrl)).toBe("[::1]:443");
+  });
+});
+
+describe("shouldUseTlsForDefaultHostedRelay", () => {
+  test("returns true for the hosted Paseo relay on port 443", () => {
+    expect(shouldUseTlsForDefaultHostedRelay("relay.paseo.sh:443")).toBe(true);
+  });
+
+  test("returns true for any self-hosted relay on port 443", () => {
+    expect(shouldUseTlsForDefaultHostedRelay("relay.example.com:443")).toBe(true);
+  });
+
+  test("returns true for an IPv6 relay on port 443", () => {
+    expect(shouldUseTlsForDefaultHostedRelay("[::1]:443")).toBe(true);
+  });
+
+  test("returns false for a relay on a non-443 port", () => {
+    expect(shouldUseTlsForDefaultHostedRelay("relay.example.com:8080")).toBe(false);
+  });
+
+  test("returns false for malformed endpoints", () => {
+    expect(shouldUseTlsForDefaultHostedRelay("not-an-endpoint")).toBe(false);
   });
 });

--- a/packages/server/src/shared/daemon-endpoints.ts
+++ b/packages/server/src/shared/daemon-endpoints.ts
@@ -204,7 +204,8 @@ export function buildRelayWebSocketUrl(params: {
  */
 export function shouldUseTlsForDefaultHostedRelay(endpoint: string): boolean {
   try {
-    return normalizeHostPort(endpoint) === DEFAULT_RELAY_ENDPOINT;
+    const { port } = parseHostPort(endpoint);
+    return port === 443;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

`shouldUseTlsForDefaultHostedRelay` only returns `true` when the endpoint exactly matches `relay.paseo.sh:443`. Any self-hosted relay on port 443 falls through to `ws://` (plain HTTP), which gets HTTP 400 from the TLS-expecting server.

Fix: use port-based detection — port 443 → `wss`, everything else → `ws`.

This affects `packages/server` (daemon relay transport) and `packages/cli` (client relay connection). The mobile app happens to work because iOS's native WebSocket implementation auto-upgrades TLS on port 443, but the code path is still incorrect.

## Changes

One function in `packages/server/src/shared/daemon-endpoints.ts`:

```diff
 export function shouldUseTlsForDefaultHostedRelay(endpoint: string): boolean {
   try {
-    return normalizeHostPort(endpoint) === DEFAULT_RELAY_ENDPOINT;
+    const { port } = parseHostPort(endpoint);
+    return port === 443;
   } catch {
     return false;
   }
 }
```

## Test plan

- [x] Self-hosted relay on Cloudflare Workers (custom domain, port 443) — daemon connects via `wss://` after fix
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes