### PR TITLE
feat(app): remember workspace agent defaults

### DIFF
--- a/packages/app/src/hooks/use-agent-form-state.test.ts
+++ b/packages/app/src/hooks/use-agent-form-state.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveWorkspaceAgentDefaults,
+  resolveWorkspaceScopedFormPreferences,
+} from "./use-agent-form-state";
+
+describe("workspace-scoped agent form preferences", () => {
+  it("selects defaults for the requested workspace key only", () => {
+    expect(
+      resolveWorkspaceAgentDefaults({
+        workspaceDefaultsKey: "workspace-a",
+        preferences: {
+          workspaceAgentDefaults: {
+            "workspace-a": {
+              provider: "codex",
+              model: "gpt-5.4",
+            },
+            "workspace-b": {
+              provider: "claude",
+              model: "claude-sonnet-4-6",
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      provider: "codex",
+      model: "gpt-5.4",
+    });
+  });
+
+  it("uses global preferences when no workspace defaults exist", () => {
+    const preferences = {
+      provider: "claude",
+      providerPreferences: {
+        claude: {
+          model: "claude-sonnet-4-6",
+          mode: "plan",
+        },
+      },
+    };
+
+    expect(
+      resolveWorkspaceScopedFormPreferences({
+        preferences,
+        workspaceDefaults: null,
+      }),
+    ).toBe(preferences);
+  });
+
+  it("uses workspace defaults instead of global provider preferences when present", () => {
+    expect(
+      resolveWorkspaceScopedFormPreferences({
+        preferences: {
+          provider: "claude",
+          providerPreferences: {
+            claude: {
+              model: "claude-sonnet-4-6",
+              mode: "plan",
+            },
+            codex: {
+              model: "gpt-5.3-codex",
+              mode: "full-access",
+            },
+          },
+          favoriteModels: [{ provider: "claude", modelId: "claude-sonnet-4-6" }],
+        },
+        workspaceDefaults: {
+          provider: "codex",
+          model: "gpt-5.4",
+          modeId: "auto",
+          thinkingOptionId: "high",
+          featureValues: {
+            webSearch: true,
+          },
+        },
+      }),
+    ).toEqual({
+      provider: "codex",
+      providerPreferences: {
+        codex: {
+          model: "gpt-5.4",
+          mode: "auto",
+          thinkingByModel: {
+            "gpt-5.4": "high",
+          },
+          featureValues: {
+            webSearch: true,
+          },
+        },
+      },
+      favoriteModels: [{ provider: "claude", modelId: "claude-sonnet-4-6" }],
+    });
+  });
+});

--- a/packages/app/src/hooks/use-agent-form-state.ts
+++ b/packages/app/src/hooks/use-agent-form-state.ts
@@ -12,13 +12,16 @@ import { useProvidersSnapshot } from "./use-providers-snapshot";
 import {
   useFormPreferences,
   mergeProviderPreferences,
+  mergeWorkspaceAgentDefaults,
   type FormPreferences,
+  type WorkspaceAgentDefaults,
 } from "./use-form-preferences";
 import {
   resolveAgentForm,
   resolveEffectiveModel,
   normalizeSelectedModelId,
   resolveDefaultModelId,
+  resolveThinkingOptionId,
   mergeSelectedComposerPreferences,
   combineInitialValues,
   buildProviderDefinitionMap,
@@ -39,6 +42,7 @@ export interface UseAgentFormStateOptions {
   isCreateFlow?: boolean;
   isTargetDaemonReady?: boolean;
   onlineServerIds?: string[];
+  workspaceDefaultsKey?: string | null;
 }
 
 export interface UseAgentFormStateResult {
@@ -126,17 +130,80 @@ function buildAllProviderModels(
   return map;
 }
 
+export function resolveWorkspaceAgentDefaults(input: {
+  preferences: FormPreferences;
+  workspaceDefaultsKey?: string | null;
+}): WorkspaceAgentDefaults | null {
+  const key = input.workspaceDefaultsKey?.trim();
+  if (!key) {
+    return null;
+  }
+  const defaults = input.preferences.workspaceAgentDefaults?.[key];
+  return defaults?.provider ? defaults : null;
+}
+
+export function resolveWorkspaceScopedFormPreferences(input: {
+  preferences: FormPreferences;
+  workspaceDefaults: WorkspaceAgentDefaults | null;
+}): FormPreferences {
+  const { preferences, workspaceDefaults } = input;
+  const defaults = workspaceDefaults;
+  if (!defaults) {
+    return preferences;
+  }
+  const provider = defaults.provider?.trim();
+  if (!provider) {
+    return preferences;
+  }
+
+  const model = defaults.model?.trim();
+  const thinkingOptionId = defaults.thinkingOptionId?.trim();
+
+  return {
+    provider,
+    providerPreferences: {
+      [provider]: {
+        ...(model ? { model } : {}),
+        ...(defaults.modeId ? { mode: defaults.modeId } : {}),
+        ...(model && thinkingOptionId ? { thinkingByModel: { [model]: thinkingOptionId } } : {}),
+        ...(defaults.featureValues ? { featureValues: defaults.featureValues } : {}),
+      },
+    },
+    ...(preferences.favoriteModels ? { favoriteModels: preferences.favoriteModels } : {}),
+    ...(preferences.workspaceAgentDefaults
+      ? { workspaceAgentDefaults: preferences.workspaceAgentDefaults }
+      : {}),
+  };
+}
+
 async function persistProviderPreferences(input: {
   provider: AgentProvider;
   formState: FormState;
   availableModels: AgentModelDefinition[] | null;
+  workspaceDefaultsKey?: string | null;
   updatePreferences: (
     updates: Partial<FormPreferences> | ((current: FormPreferences) => FormPreferences),
   ) => Promise<void>;
 }): Promise<void> {
-  const { provider, formState, availableModels, updatePreferences } = input;
+  const { provider, formState, availableModels, workspaceDefaultsKey, updatePreferences } = input;
   const resolvedModel = resolveEffectiveModel(availableModels, formState.model);
   const modelId = resolvedModel?.id ?? formState.model;
+  if (workspaceDefaultsKey) {
+    await updatePreferences((current) =>
+      mergeWorkspaceAgentDefaults({
+        preferences: current,
+        workspaceKey: workspaceDefaultsKey,
+        updates: {
+          provider,
+          model: modelId || undefined,
+          modeId: formState.modeId || undefined,
+          thinkingOptionId: formState.thinkingOptionId || undefined,
+        },
+      }),
+    );
+    return;
+  }
+
   await updatePreferences((current) =>
     mergeProviderPreferences({
       preferences: current,
@@ -160,9 +227,22 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
     isCreateFlow = true,
     isTargetDaemonReady: _isTargetDaemonReady = true,
     onlineServerIds = [],
+    workspaceDefaultsKey = null,
   } = options;
 
   const { preferences, isLoading: isPreferencesLoading, updatePreferences } = useFormPreferences();
+  const workspaceDefaults = useMemo(
+    () => resolveWorkspaceAgentDefaults({ preferences, workspaceDefaultsKey }),
+    [preferences, workspaceDefaultsKey],
+  );
+  const formPreferences = useMemo(
+    () =>
+      resolveWorkspaceScopedFormPreferences({
+        preferences,
+        workspaceDefaults,
+      }),
+    [preferences, workspaceDefaults],
+  );
 
   const daemons = useHosts();
 
@@ -274,9 +354,9 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
     }
 
     if (!hasResolvedRef.current) {
-      hydrationPreferencesRef.current = preferences;
+      hydrationPreferencesRef.current = formPreferences;
     }
-    const hydrationPreferences = hydrationPreferencesRef.current ?? preferences;
+    const hydrationPreferences = hydrationPreferencesRef.current ?? formPreferences;
 
     dispatch({
       type: "RESOLVE",
@@ -292,7 +372,7 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
     isCreateFlow,
     isPreferencesLoading,
     combinedInitialValues,
-    preferences,
+    formPreferences,
     availableModels,
     snapshotResolvableProviderDefinitionMap,
   ]);
@@ -336,7 +416,7 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
       }
       const providerModels = allProviderModels.get(provider) ?? null;
       const providerDef = selectableProviderDefinitionMap.get(provider);
-      const providerPrefs = preferences?.providerPreferences?.[provider];
+      const providerPrefs = formPreferences.providerPreferences?.[provider];
 
       dispatch({
         type: "SET_PROVIDER_FROM_USER",
@@ -345,13 +425,22 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
         providerDef,
         providerPrefs,
       });
-      void updatePreferences({ provider });
+      void updatePreferences((current) =>
+        workspaceDefaultsKey
+          ? mergeWorkspaceAgentDefaults({
+              preferences: current,
+              workspaceKey: workspaceDefaultsKey,
+              updates: { provider },
+            })
+          : { ...current, provider },
+      );
     },
     [
       allProviderModels,
-      preferences?.providerPreferences,
+      formPreferences.providerPreferences,
       selectableProviderDefinitionMap,
       updatePreferences,
+      workspaceDefaultsKey,
     ],
   );
 
@@ -372,17 +461,33 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
         providerDef,
         providerModels,
       });
+      const nextThinkingOptionId = resolveThinkingOptionId({
+        availableModels: providerModels,
+        modelId: nextModelId,
+        requestedThinkingOptionId: "",
+      });
       void updatePreferences((current) =>
-        mergeSelectedComposerPreferences({
-          preferences: current,
-          provider,
-          updates: {
-            model: nextModelId || undefined,
-          },
-        }),
+        workspaceDefaultsKey
+          ? mergeWorkspaceAgentDefaults({
+              preferences: current,
+              workspaceKey: workspaceDefaultsKey,
+              updates: {
+                provider,
+                model: nextModelId || undefined,
+                modeId: providerDef?.defaultModeId ?? undefined,
+                thinkingOptionId: nextThinkingOptionId || undefined,
+              },
+            })
+          : mergeSelectedComposerPreferences({
+              preferences: current,
+              provider,
+              updates: {
+                model: nextModelId || undefined,
+              },
+            }),
       );
     },
-    [allProviderModels, selectableProviderDefinitionMap, updatePreferences],
+    [allProviderModels, selectableProviderDefinitionMap, updatePreferences, workspaceDefaultsKey],
   );
 
   const setModeFromUser = useCallback(
@@ -391,17 +496,26 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
       const provider = reducerStateRef.current.form.provider;
       if (provider) {
         void updatePreferences((current) =>
-          mergeSelectedComposerPreferences({
-            preferences: current,
-            provider,
-            updates: {
-              mode: modeId || undefined,
-            },
-          }),
+          workspaceDefaultsKey
+            ? mergeWorkspaceAgentDefaults({
+                preferences: current,
+                workspaceKey: workspaceDefaultsKey,
+                updates: {
+                  provider,
+                  modeId: modeId || undefined,
+                },
+              })
+            : mergeSelectedComposerPreferences({
+                preferences: current,
+                provider,
+                updates: {
+                  mode: modeId || undefined,
+                },
+              }),
         );
       }
     },
-    [updatePreferences],
+    [updatePreferences, workspaceDefaultsKey],
   );
 
   const setModelFromUser = useCallback(
@@ -411,18 +525,36 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
       if (provider) {
         const normalizedModelId = normalizeSelectedModelId(modelId);
         const nextModelId = normalizedModelId || resolveDefaultModelId(availableModels);
+        const requestedThinkingOptionId = reducerStateRef.current.userModified.thinkingOptionId
+          ? reducerStateRef.current.form.thinkingOptionId
+          : "";
+        const nextThinkingOptionId = resolveThinkingOptionId({
+          availableModels,
+          modelId: nextModelId,
+          requestedThinkingOptionId,
+        });
         void updatePreferences((current) =>
-          mergeSelectedComposerPreferences({
-            preferences: current,
-            provider,
-            updates: {
-              model: nextModelId || undefined,
-            },
-          }),
+          workspaceDefaultsKey
+            ? mergeWorkspaceAgentDefaults({
+                preferences: current,
+                workspaceKey: workspaceDefaultsKey,
+                updates: {
+                  provider,
+                  model: nextModelId || undefined,
+                  thinkingOptionId: nextThinkingOptionId || undefined,
+                },
+              })
+            : mergeSelectedComposerPreferences({
+                preferences: current,
+                provider,
+                updates: {
+                  model: nextModelId || undefined,
+                },
+              }),
         );
       }
     },
-    [availableModels, updatePreferences],
+    [availableModels, updatePreferences, workspaceDefaultsKey],
   );
 
   const setThinkingOptionFromUser = useCallback(
@@ -431,19 +563,29 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
       const { provider, model: modelId } = reducerStateRef.current.form;
       if (provider && modelId) {
         void updatePreferences((current) =>
-          mergeSelectedComposerPreferences({
-            preferences: current,
-            provider,
-            updates: {
-              thinkingByModel: {
-                [modelId]: thinkingOptionId,
-              },
-            },
-          }),
+          workspaceDefaultsKey
+            ? mergeWorkspaceAgentDefaults({
+                preferences: current,
+                workspaceKey: workspaceDefaultsKey,
+                updates: {
+                  provider,
+                  model: modelId,
+                  thinkingOptionId: thinkingOptionId || undefined,
+                },
+              })
+            : mergeSelectedComposerPreferences({
+                preferences: current,
+                provider,
+                updates: {
+                  thinkingByModel: {
+                    [modelId]: thinkingOptionId,
+                  },
+                },
+              }),
         );
       }
     },
-    [updatePreferences],
+    [updatePreferences, workspaceDefaultsKey],
   );
 
   const setWorkingDir = useCallback((value: string) => {
@@ -474,9 +616,10 @@ export function useAgentFormState(options: UseAgentFormStateOptions = {}): UseAg
       provider: formState.provider,
       formState,
       availableModels,
+      workspaceDefaultsKey,
       updatePreferences,
     });
-  }, [availableModels, formState, updatePreferences]);
+  }, [availableModels, formState, updatePreferences, workspaceDefaultsKey]);
 
   const agentDefinition = formState.provider
     ? providerDefinitionMap.get(formState.provider)

--- a/packages/app/src/hooks/use-agent-input-draft.ts
+++ b/packages/app/src/hooks/use-agent-input-draft.ts
@@ -30,6 +30,7 @@ interface AgentInputDraftComposerOptions {
   isVisible?: boolean;
   onlineServerIds?: string[];
   lockedWorkingDir?: string;
+  workspaceDefaultsKey?: string | null;
 }
 
 interface UseAgentInputDraftInput {
@@ -67,6 +68,7 @@ export function useAgentInputDraft(input: UseAgentInputDraftInput): AgentInputDr
     isVisible: composerOptions?.isVisible ?? false,
     isCreateFlow: true,
     onlineServerIds: composerOptions?.onlineServerIds ?? [],
+    workspaceDefaultsKey: composerOptions?.workspaceDefaultsKey,
   });
   const draftKey = useMemo(
     () =>
@@ -239,6 +241,7 @@ export function useAgentInputDraft(input: UseAgentInputDraftInput): AgentInputDr
     modeId: formState.selectedMode,
     modelId: effectiveModelId,
     thinkingOptionId: effectiveThinkingOptionId,
+    workspaceDefaultsKey: composerOptions?.workspaceDefaultsKey,
   });
 
   const commandDraftConfig = useMemo(

--- a/packages/app/src/hooks/use-draft-agent-features.ts
+++ b/packages/app/src/hooks/use-draft-agent-features.ts
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { AgentProvider, AgentSessionConfig } from "@server/server/agent/agent-sdk-types";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
-import { mergeProviderPreferences, useFormPreferences } from "./use-form-preferences";
+import {
+  mergeProviderPreferences,
+  mergeWorkspaceAgentDefaults,
+  useFormPreferences,
+} from "./use-form-preferences";
 import {
   applyFeatureValues,
   pruneFeatureValues,
@@ -21,18 +25,33 @@ export function useDraftAgentFeatures(input: {
   modeId: string | null | undefined;
   modelId: string | null | undefined;
   thinkingOptionId: string | null | undefined;
+  workspaceDefaultsKey?: string | null;
 }) {
-  const { serverId, provider, cwd, modeId, modelId, thinkingOptionId } = input;
+  const { serverId, provider, cwd, modeId, modelId, thinkingOptionId, workspaceDefaultsKey } =
+    input;
   const [localFeatureValues, setLocalFeatureValues] = useState<Record<string, unknown>>({});
   const client = useHostRuntimeClient(serverId ?? "");
   const isConnected = useHostRuntimeIsConnected(serverId ?? "");
   const { preferences, updatePreferences } = useFormPreferences();
   const normalizedCwd = cwd?.trim() || "";
   const normalizedProvider = provider ?? null;
-  const persistedFeatureValues = useMemo(
-    () => (provider ? (preferences.providerPreferences?.[provider]?.featureValues ?? {}) : {}),
-    [preferences.providerPreferences, provider],
-  );
+  const workspaceDefaults = workspaceDefaultsKey
+    ? preferences.workspaceAgentDefaults?.[workspaceDefaultsKey]
+    : undefined;
+  const persistedFeatureValues = useMemo(() => {
+    if (!provider) {
+      return {};
+    }
+    if (workspaceDefaults?.provider === provider) {
+      return workspaceDefaults.featureValues ?? {};
+    }
+    return preferences.providerPreferences?.[provider]?.featureValues ?? {};
+  }, [
+    preferences.providerPreferences,
+    provider,
+    workspaceDefaults?.featureValues,
+    workspaceDefaults?.provider,
+  ]);
 
   const draftConfig = useMemo<DraftFeatureConfig | null>(() => {
     if (!normalizedProvider || !normalizedCwd) {
@@ -112,20 +131,34 @@ export function useDraftAgentFeatures(input: {
         return;
       }
       void updatePreferences((current) =>
-        mergeProviderPreferences({
-          preferences: current,
-          provider,
-          updates: {
-            featureValues: {
-              [featureId]: value,
-            },
-          },
-        }),
+        workspaceDefaultsKey
+          ? mergeWorkspaceAgentDefaults({
+              preferences: current,
+              workspaceKey: workspaceDefaultsKey,
+              updates: {
+                provider,
+                model: modelId || undefined,
+                modeId: modeId || undefined,
+                thinkingOptionId: thinkingOptionId || undefined,
+                featureValues: {
+                  [featureId]: value,
+                },
+              },
+            })
+          : mergeProviderPreferences({
+              preferences: current,
+              provider,
+              updates: {
+                featureValues: {
+                  [featureId]: value,
+                },
+              },
+            }),
       ).catch((error) => {
         console.warn("[useDraftAgentFeatures] persist feature preference failed", error);
       });
     },
-    [provider, updatePreferences],
+    [modeId, modelId, provider, thinkingOptionId, updatePreferences, workspaceDefaultsKey],
   );
 
   return {

--- a/packages/app/src/hooks/use-form-preferences.test.ts
+++ b/packages/app/src/hooks/use-form-preferences.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildWorkspaceAgentDefaultsKey,
   buildFavoriteModelKey,
   isFavoriteModel,
   mergeProviderPreferences,
+  mergeWorkspaceAgentDefaults,
   toggleFavoriteModel,
 } from "./use-form-preferences";
 
@@ -90,6 +92,118 @@ describe("mergeProviderPreferences", () => {
             fast_mode: true,
             plan_mode: true,
           },
+        },
+      },
+    });
+  });
+});
+
+describe("workspace agent defaults", () => {
+  it("builds a stable key from server and workspace ids", () => {
+    expect(
+      buildWorkspaceAgentDefaultsKey({
+        serverId: "host-1",
+        workspaceId: "/repo/worktree-a",
+      }),
+    ).toBe('["host-1","/repo/worktree-a"]');
+  });
+
+  it("stores workspace-scoped defaults without dropping global preferences", () => {
+    expect(
+      mergeWorkspaceAgentDefaults({
+        preferences: {
+          provider: "claude",
+          providerPreferences: {
+            claude: {
+              model: "claude-sonnet-4-6",
+            },
+          },
+          favoriteModels: [{ provider: "codex", modelId: "gpt-5.4" }],
+        },
+        workspaceKey: "workspace-a",
+        updates: {
+          provider: "codex",
+          model: "gpt-5.4",
+          modeId: "auto",
+          thinkingOptionId: "high",
+        },
+      }),
+    ).toEqual({
+      provider: "claude",
+      providerPreferences: {
+        claude: {
+          model: "claude-sonnet-4-6",
+        },
+      },
+      favoriteModels: [{ provider: "codex", modelId: "gpt-5.4" }],
+      workspaceAgentDefaults: {
+        "workspace-a": {
+          provider: "codex",
+          model: "gpt-5.4",
+          modeId: "auto",
+          thinkingOptionId: "high",
+        },
+      },
+    });
+  });
+
+  it("merges feature defaults for one workspace without touching another", () => {
+    expect(
+      mergeWorkspaceAgentDefaults({
+        preferences: {
+          workspaceAgentDefaults: {
+            "workspace-a": {
+              provider: "codex",
+              featureValues: { webSearch: true },
+            },
+            "workspace-b": {
+              provider: "claude",
+              featureValues: { plan: true },
+            },
+          },
+        },
+        workspaceKey: "workspace-a",
+        updates: {
+          featureValues: { webSearch: false, networkAccess: true },
+        },
+      }),
+    ).toEqual({
+      workspaceAgentDefaults: {
+        "workspace-a": {
+          provider: "codex",
+          featureValues: { webSearch: false, networkAccess: true },
+        },
+        "workspace-b": {
+          provider: "claude",
+          featureValues: { plan: true },
+        },
+      },
+    });
+  });
+
+  it("clears provider-specific defaults when the workspace provider changes", () => {
+    expect(
+      mergeWorkspaceAgentDefaults({
+        preferences: {
+          workspaceAgentDefaults: {
+            "workspace-a": {
+              provider: "codex",
+              model: "gpt-5.4",
+              modeId: "auto",
+              thinkingOptionId: "high",
+              featureValues: { webSearch: true },
+            },
+          },
+        },
+        workspaceKey: "workspace-a",
+        updates: {
+          provider: "claude",
+        },
+      }),
+    ).toEqual({
+      workspaceAgentDefaults: {
+        "workspace-a": {
+          provider: "claude",
         },
       },
     });

--- a/packages/app/src/hooks/use-form-preferences.ts
+++ b/packages/app/src/hooks/use-form-preferences.ts
@@ -21,6 +21,14 @@ export interface FavoriteModelRow {
   description?: string;
 }
 
+const workspaceAgentDefaultsSchema = z.object({
+  provider: z.string().optional(),
+  model: z.string().optional(),
+  modeId: z.string().optional(),
+  thinkingOptionId: z.string().optional(),
+  featureValues: z.record(z.unknown()).optional(),
+});
+
 const providerPreferencesSchema = z.object({
   model: z.string().optional(),
   mode: z.string().optional(),
@@ -39,8 +47,10 @@ const formPreferencesSchema = z.object({
       }),
     )
     .optional(),
+  workspaceAgentDefaults: z.record(workspaceAgentDefaultsSchema).optional(),
 });
 
+export type WorkspaceAgentDefaults = z.infer<typeof workspaceAgentDefaultsSchema>;
 export type ProviderPreferences = z.infer<typeof providerPreferencesSchema>;
 export type FormPreferences = z.infer<typeof formPreferencesSchema>;
 
@@ -93,6 +103,44 @@ export function mergeProviderPreferences(args: {
         ...existing,
         ...updates,
         ...(nextThinkingByModel ? { thinkingByModel: nextThinkingByModel } : {}),
+        ...(nextFeatureValues ? { featureValues: nextFeatureValues } : {}),
+      },
+    },
+  };
+}
+
+export function buildWorkspaceAgentDefaultsKey(input: {
+  serverId: string;
+  workspaceId: string;
+}): string {
+  return JSON.stringify([input.serverId, input.workspaceId]);
+}
+
+export function mergeWorkspaceAgentDefaults(args: {
+  preferences: FormPreferences;
+  workspaceKey: string;
+  updates: Partial<WorkspaceAgentDefaults>;
+}): FormPreferences {
+  const { preferences, workspaceKey, updates } = args;
+  const existingWorkspaceDefaults = preferences.workspaceAgentDefaults ?? {};
+  const existing = existingWorkspaceDefaults[workspaceKey] ?? {};
+  const base =
+    updates.provider && existing.provider && updates.provider !== existing.provider ? {} : existing;
+  const nextFeatureValues =
+    updates.featureValues === undefined
+      ? base.featureValues
+      : {
+          ...base.featureValues,
+          ...updates.featureValues,
+        };
+
+  return {
+    ...preferences,
+    workspaceAgentDefaults: {
+      ...existingWorkspaceDefaults,
+      [workspaceKey]: {
+        ...base,
+        ...updates,
         ...(nextFeatureValues ? { featureValues: nextFeatureValues } : {}),
       },
     },

--- a/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
+++ b/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
@@ -10,6 +10,7 @@ import { composerWorkspaceAttachment } from "@/attachments/composer-workspace-at
 import type { ImageAttachment } from "@/components/message-input";
 import { useAgentInputDraft } from "@/hooks/use-agent-input-draft";
 import { useDraftAgentCreateFlow } from "@/hooks/use-draft-agent-create-flow";
+import { buildWorkspaceAgentDefaultsKey } from "@/hooks/use-form-preferences";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { buildWorkspaceDraftAgentConfig } from "@/screens/workspace/workspace-draft-agent-config";
 import { buildDraftStoreKey } from "@/stores/draft-keys";
@@ -304,6 +305,10 @@ export function WorkspaceDraftAgentTab({
       }),
     [draftId, serverId, tabId],
   );
+  const workspaceDefaultsKey = useMemo(
+    () => buildWorkspaceAgentDefaultsKey({ serverId, workspaceId }),
+    [serverId, workspaceId],
+  );
   const draftInput = useAgentInputDraft({
     draftKey: draftStoreKey,
     initialCwd: workspaceDirectory ?? "",
@@ -313,6 +318,7 @@ export function WorkspaceDraftAgentTab({
       isVisible: true,
       onlineServerIds: isConnected ? [serverId] : [],
       lockedWorkingDir: workspaceDirectory ?? undefined,
+      workspaceDefaultsKey,
     },
   });
   const composerState = draftInput.composerState;


### PR DESCRIPTION
## Summary

- Add workspace-scoped new-agent defaults to form preferences.
- Use the current workspace id + host id to initialize workspace draft agents from their own saved provider/model/mode/thinking/feature defaults.
- Keep existing global provider preferences as the fallback only when a workspace has no saved defaults.

Closes #800.

## Testing

- `npm run test --workspace=@getpaseo/app -- src/hooks/use-form-preferences.test.ts src/hooks/use-agent-form-state.test.ts src/hooks/resolve-agent-form.test.ts --bail=1`
- `npm run lint -- packages/app/src/hooks/use-form-preferences.ts packages/app/src/hooks/use-form-preferences.test.ts packages/app/src/hooks/use-agent-form-state.ts packages/app/src/hooks/use-agent-form-state.test.ts packages/app/src/hooks/use-draft-agent-features.ts packages/app/src/hooks/use-agent-input-draft.ts packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx`
- `npm run format:check:files -- packages/app/src/hooks/use-form-preferences.ts packages/app/src/hooks/use-form-preferences.test.ts packages/app/src/hooks/use-agent-form-state.ts packages/app/src/hooks/use-agent-form-state.test.ts packages/app/src/hooks/use-draft-agent-features.ts packages/app/src/hooks/use-agent-input-draft.ts packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx`
- `npm run typecheck --workspace=@getpaseo/app`
- Pre-commit hook: `format`, `lint`, `typecheck`
