### PR TITLE
test(server): real-fs coverage for Linux walker gitignore skip

### DIFF
--- a/packages/server/src/server/workspace-git-service.primitive.test.ts
+++ b/packages/server/src/server/workspace-git-service.primitive.test.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -11,11 +12,13 @@ import {
 import {
   getCheckoutDiff as getCheckoutDiffUncached,
   getCheckoutStatus as getCheckoutStatusUncached,
+  resolveAbsoluteGitDir as resolveAbsoluteGitDirReal,
   type CheckoutDiffCompare,
   type CheckoutDiffResult,
   type CheckoutStatusGit,
   type PullRequestStatusResult,
 } from "../utils/checkout-git.js";
+import { runGitCommand as runGitCommandReal } from "../utils/run-git-command.js";
 import {
   WorkspaceGitServiceImpl,
   type WorkspaceGitRuntimeSnapshot,
@@ -207,6 +210,7 @@ interface CreateServiceOptions {
   runGitFetch?: ReturnType<typeof vi.fn>;
   runGitCommand?: ReturnType<typeof vi.fn>;
   watch?: ReturnType<typeof vi.fn>;
+  readdir?: ReturnType<typeof vi.fn>;
   now?: () => Date;
 }
 
@@ -1453,5 +1457,49 @@ describe("WorkspaceGitServiceImpl D2 read methods", () => {
     expect(getCheckoutDiff).toHaveBeenCalledTimes(3);
 
     service.dispose();
+  });
+
+  test("Linux working tree walker excludes gitignored directories", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+
+    const tempDir = realpathSync(mkdtempSync(join(tmpdir(), "workspace-git-service-ignored-")));
+    const repoDir = join(tempDir, "repo");
+    mkdirSync(join(repoDir, "ignored", "deep"), { recursive: true });
+    mkdirSync(join(repoDir, "kept"), { recursive: true });
+    execSync("git init -b main", { cwd: repoDir, stdio: "pipe" });
+    writeFileSync(join(repoDir, ".gitignore"), "ignored/\n");
+    writeFileSync(join(repoDir, "ignored", "log.txt"), "noise\n");
+    writeFileSync(join(repoDir, "ignored", "deep", "log.txt"), "noise\n");
+    writeFileSync(join(repoDir, "kept", "file.txt"), "keep\n");
+
+    const watchedPaths: string[] = [];
+    const watchSpy = (watchPath: string) => {
+      watchedPaths.push(watchPath);
+      return { close: vi.fn(), on: vi.fn().mockReturnThis() };
+    };
+
+    const service = createService({
+      watch: watchSpy as never,
+      readdir: readdir as never,
+      runGitCommand: runGitCommandReal as never,
+      getCheckoutStatus: getCheckoutStatusUncached as never,
+      resolveAbsoluteGitDir: resolveAbsoluteGitDirReal as never,
+    });
+
+    try {
+      const subscription = await service.requestWorkingTreeWatch(repoDir, vi.fn());
+
+      const ignoredRoot = join(repoDir, "ignored");
+      expect(watchedPaths.filter((path) => path.startsWith(ignoredRoot))).toEqual([]);
+      expect(watchedPaths).toContain(repoDir);
+      expect(watchedPaths).toContain(join(repoDir, "kept"));
+
+      subscription.unsubscribe();
+    } finally {
+      service.dispose();
+      rmSync(tempDir, { recursive: true, force: true });
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
   });
 });


### PR DESCRIPTION
Follow-up to #794. That PR added gitignore-aware skipping to the Linux working-tree walker but only ran the existing mocked tests (which mock `fs.watch`, `readdir`, and `runGitCommand` — the exact surfaces the fix touches).

This adds a real-fs test alongside the existing real-fs harness in `workspace-git-service.primitive.test.ts`:

- `mkdtemp` + `git init` + `.gitignore` with an `ignored/` entry, plus `kept/`
- spoof `process.platform = "linux"` so the walker branch runs on macOS dev too
- pass real `runGitCommand`, real `readdir`, real `getCheckoutStatus`, real `resolveAbsoluteGitDir`; the only spy is a path-recording wrapper around `fs.watch`
- drive through the public `requestWorkingTreeWatch`
- assert no path under `ignored/` was watched, `kept/` and the repo root were

Exercises the actual `git ls-files -o -i --directory --exclude-standard` shell-out, which is the whole point of the fix.

## Follow-up direction (not in this PR)

The mocked Linux test in `workspace-git-service.test.ts:626` would be more useful as a real-fs test against the same harness pattern — the current version only proves the code calls `fs.watch` in the order the implementation calls it. Worth a separate sweep to migrate watcher tests to real fs so they catch real regressions on macOS dev and Linux CI.

## Test plan
- [x] `npx vitest run src/server/workspace-git-service.primitive.test.ts --bail=1` — 42/42, including the new test on macOS
- [x] `npm run typecheck` / `npm run lint` / `npm run format:check` (pre-commit hook)