### PR TITLE
feat(codex): archive native Codex thread when archiving agent

### DIFF
--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -975,6 +975,9 @@ export class AgentManager {
       attentionReason: null,
       attentionTimestamp: null,
     });
+
+    await this.archiveNativeSessionBestEffort(agent.provider, stored.persistence);
+
     this.notifyAgentState(agentId);
     await this.closeAgent(agentId);
 
@@ -1118,6 +1121,9 @@ export class AgentManager {
       attentionTimestamp: null,
     };
     await registry.upsert(nextRecord);
+
+    await this.archiveNativeSessionBestEffort(record.provider, record.persistence);
+
     return nextRecord;
   }
 
@@ -3134,6 +3140,23 @@ export class AgentManager {
       throw new Error(`No client registered for provider '${provider}'`);
     }
     return client;
+  }
+
+  async archiveNativeSessionBestEffort(
+    provider: AgentProvider,
+    persistence: AgentPersistenceHandle | null | undefined,
+  ): Promise<void> {
+    if (!persistence) return;
+    const client = this.clients.get(provider);
+    if (!client?.archiveNativeSession) return;
+    try {
+      await client.archiveNativeSession(persistence);
+    } catch (error) {
+      this.logger.warn(
+        { error, provider, sessionId: persistence.sessionId },
+        "Failed to archive native session (best-effort)",
+      );
+    }
   }
 
   private requireAgent(id: string): LiveManagedAgent {

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -558,4 +558,9 @@ export interface AgentClient {
    */
   isAvailable(): Promise<boolean>;
   getDiagnostic?(): Promise<{ diagnostic: string }>;
+  /**
+   * Archive a persisted session in the native provider (best-effort).
+   * Called when Paseo archives an agent so the provider's own UI reflects the same state.
+   */
+  archiveNativeSession?(handle: AgentPersistenceHandle): Promise<void>;
 }

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -8,6 +8,7 @@ import type {
   AgentMode,
   AgentModelDefinition,
   McpServerConfig,
+  AgentPersistenceHandle,
   AgentPermissionRequest,
   AgentPermissionResponse,
   AgentPermissionResult,
@@ -4899,6 +4900,22 @@ export class CodexAppServerAgentClient implements AgentClient {
           hasConfiguredDefaultModel,
         }),
       );
+    } finally {
+      await client.dispose();
+    }
+  }
+
+  async archiveNativeSession(handle: AgentPersistenceHandle): Promise<void> {
+    const threadId = handle.nativeHandle ?? handle.sessionId;
+    if (!threadId) return;
+
+    const child = await this.spawnAppServer();
+    const client = new CodexAppServerClient(child, this.logger);
+
+    try {
+      await client.request("initialize", buildCodexAppServerInitializeParams());
+      client.notify("initialized", {});
+      await client.request("thread/archive", { threadId });
     } finally {
       await client.dispose();
     }


### PR DESCRIPTION
## Summary
- Archive the native Codex thread when a Codex agent is archived from Paseo
- Calls `thread/archive` JSON-RPC method (best-effort, failures don't block)
- Covers both live agent archive and stored agent archive paths

Closes #822

## Test plan
- [x] Archive a Codex agent from Paseo, verify thread disappears from Codex app session list
- [ ] Verify archive still works when Codex app-server is unavailable (best-effort)
- [ ] CI passes typecheck + lint