### PR TITLE
fix(app): submit typed path from iOS project picker (#829)

### DIFF
--- a/packages/app/src/components/project-picker-modal.tsx
+++ b/packages/app/src/components/project-picker-modal.tsx
@@ -94,15 +94,18 @@ export function ProjectPickerModal() {
     retry: false,
   });
 
-  const options = useMemo(
-    () =>
-      buildWorkingDirectorySuggestions({
-        recommendedPaths,
-        serverPaths: directorySuggestionsQuery.data ?? [],
-        query,
-      }),
-    [query, directorySuggestionsQuery.data, recommendedPaths],
-  );
+  const options = useMemo(() => {
+    const suggestedPaths = buildWorkingDirectorySuggestions({
+      recommendedPaths,
+      serverPaths: directorySuggestionsQuery.data ?? [],
+      query,
+    });
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery || suggestedPaths.includes(trimmedQuery)) {
+      return suggestedPaths;
+    }
+    return [trimmedQuery, ...suggestedPaths];
+  }, [query, directorySuggestionsQuery.data, recommendedPaths]);
 
   const handleClose = useCallback(() => {
     setOpen(false);
@@ -239,6 +242,8 @@ export function ProjectPickerModal() {
               autoCorrect={false}
               autoFocus
               editable={!isSubmitting}
+              returnKeyType="go"
+              onSubmitEditing={handleSubmitCustom}
             />
           </View>
 


### PR DESCRIPTION
## Summary

- iOS return key now submits the typed daemon-side path in the project picker via the existing `open_project_request` flow.
- A non-empty typed path is prepended to the options list when it is not already in suggestions, so it is tappable and integrates with keyboard nav on web.
- No suggestion-search backend, schema, or `open_project_request` contract changes.

Closes #829.

Same fix unblocks the user-facing complaint in #414 (typing `D:\foo` or any path outside daemon `$HOME`), without expanding the suggestion search.

## Test plan

- [ ] iOS app against a remote Linux daemon: type `/data/source/project`, hit return, project opens.
- [ ] iOS app: type a path outside `$HOME`, see it as a row, tap it, project opens.
- [ ] Web: Enter still submits when no suggestion matches; arrow keys still navigate the typed-path row plus suggestions.
- [ ] No duplicate row when the typed path matches an existing suggestion.