### PR TITLE
fix(app): submit typed project paths on native

### DIFF
--- a/packages/app/src/components/project-picker-modal.test.tsx
+++ b/packages/app/src/components/project-picker-modal.test.tsx
@@ -1,0 +1,295 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mocks, theme } = vi.hoisted(() => {
+  const keyboardStore = {
+    projectPickerOpen: true,
+    setProjectPickerOpen: vi.fn((open: boolean) => {
+      keyboardStore.projectPickerOpen = open;
+    }),
+  };
+
+  return {
+    mocks: {
+      keyboardStore,
+      recommendedPaths: { value: [] as string[] },
+      getDirectorySuggestions: vi.fn(async () => ({
+        requestId: "request-1",
+        directories: [] as string[],
+        entries: [] as Array<{ path: string; kind: "directory" | "file" }>,
+        error: null as string | null,
+      })),
+      openProject: vi.fn(async () => true),
+      textInput: {
+        onChangeText: null as ((text: string) => void) | null,
+        onSubmitEditing: null as (() => void) | null,
+      },
+    },
+    theme: {
+      spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 12: 48 },
+      borderRadius: { lg: 8 },
+      fontSize: { base: 15, lg: 18 },
+      colors: {
+        border: "#555",
+        foreground: "#fff",
+        foregroundMuted: "#aaa",
+        surface0: "#000",
+        surface1: "#111",
+      },
+      shadow: { lg: {} },
+    },
+  };
+});
+
+vi.mock("@/constants/platform", () => ({
+  isNative: true,
+  isWeb: false,
+}));
+
+vi.mock("@/hooks/use-active-server-id", () => ({
+  useActiveServerId: () => "server-1",
+}));
+
+vi.mock("@/hooks/use-open-project", () => ({
+  useOpenProject: () => mocks.openProject,
+}));
+
+vi.mock("@/runtime/host-runtime", () => ({
+  useHostRuntimeClient: () => ({
+    getDirectorySuggestions: mocks.getDirectorySuggestions,
+  }),
+  useHostRuntimeIsConnected: () => true,
+}));
+
+vi.mock("@/stores/keyboard-shortcuts-store", () => ({
+  useKeyboardShortcutsStore: <T,>(selector: (state: typeof mocks.keyboardStore) => T) =>
+    selector(mocks.keyboardStore),
+}));
+
+vi.mock("@/stores/session-store-hooks", () => ({
+  useRecommendedProjectPaths: () => mocks.recommendedPaths.value,
+}));
+
+vi.mock("lucide-react-native", () => ({
+  Folder: (props: Record<string, unknown>) => React.createElement("span", props),
+}));
+
+vi.mock("react-native-unistyles", () => ({
+  StyleSheet: {
+    absoluteFillObject: {},
+    create: (factory: unknown) => (typeof factory === "function" ? factory(theme) : factory),
+  },
+  useUnistyles: () => ({ theme }),
+}));
+
+interface NativeProps {
+  children?: React.ReactNode | ((state: { hovered: boolean; pressed: boolean }) => React.ReactNode);
+  editable?: boolean;
+  onChangeText?: (text: string) => void;
+  onPress?: () => void;
+  onSubmitEditing?: () => void;
+  placeholder?: string;
+  testID?: string;
+  value?: string;
+  visible?: boolean;
+}
+
+vi.mock("react-native", () => {
+  const renderStaticChildren = (children: NativeProps["children"]): React.ReactNode =>
+    typeof children === "function" ? null : children;
+  const renderPressableChildren = (children: NativeProps["children"]): React.ReactNode =>
+    typeof children === "function" ? children({ hovered: false, pressed: false }) : children;
+
+  const Modal = ({ children, visible = true }: NativeProps) =>
+    visible
+      ? React.createElement(
+          "div",
+          { "data-testid": "project-picker-modal" },
+          renderStaticChildren(children),
+        )
+      : null;
+
+  const Pressable = ({ children, onPress, testID }: NativeProps) =>
+    React.createElement(
+      "button",
+      {
+        "data-testid": testID,
+        onClick: () => onPress?.(),
+        type: "button",
+      },
+      renderPressableChildren(children),
+    );
+
+  const ScrollView = ({ children, testID }: NativeProps) =>
+    React.createElement("div", { "data-testid": testID }, renderStaticChildren(children));
+
+  const Text = ({ children, testID }: NativeProps) =>
+    React.createElement("span", { "data-testid": testID }, renderStaticChildren(children));
+
+  const TextInput = React.forwardRef<HTMLInputElement, NativeProps>(
+    ({ editable = true, onChangeText, onSubmitEditing, placeholder, testID, value }, ref) => {
+      mocks.textInput.onChangeText = onChangeText ?? null;
+      mocks.textInput.onSubmitEditing = onSubmitEditing ?? null;
+
+      return React.createElement("input", {
+        "data-testid": testID,
+        disabled: editable === false,
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+          onChangeText?.(event.currentTarget.value),
+        placeholder,
+        ref,
+        value: value ?? "",
+      });
+    },
+  );
+
+  const View = ({ children, testID }: NativeProps) =>
+    React.createElement("div", { "data-testid": testID }, renderStaticChildren(children));
+
+  return {
+    Modal,
+    Pressable,
+    ScrollView,
+    Text,
+    TextInput,
+    View,
+  };
+});
+
+vi.stubGlobal("React", React);
+vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+
+import { ProjectPickerModal } from "./project-picker-modal";
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await act(async () => {
+    for (let index = 0; index < 3; index += 1) {
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  });
+}
+
+function pathInput(): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>(
+    '[data-testid="project-picker-path-input"]',
+  );
+  if (!input) {
+    throw new Error("Project picker path input not found");
+  }
+  return input;
+}
+
+function setPathInput(value: string): void {
+  pathInput();
+  act(() => {
+    mocks.textInput.onChangeText?.(value);
+  });
+}
+
+function submitPathInput(): void {
+  pathInput();
+  act(() => {
+    mocks.textInput.onSubmitEditing?.();
+  });
+}
+
+function countPathRows(path: string): number {
+  return Array.from(document.querySelectorAll("button")).filter((button) =>
+    button.textContent?.includes(path),
+  ).length;
+}
+
+describe("ProjectPickerModal", () => {
+  let root: Root | null = null;
+  let container: HTMLElement | null = null;
+  let queryClient: QueryClient | null = null;
+
+  beforeEach(() => {
+    mocks.keyboardStore.projectPickerOpen = true;
+    mocks.keyboardStore.setProjectPickerOpen.mockClear();
+    mocks.recommendedPaths.value = [];
+    mocks.getDirectorySuggestions.mockReset();
+    mocks.getDirectorySuggestions.mockResolvedValue({
+      requestId: "request-1",
+      directories: [],
+      entries: [],
+      error: null,
+    });
+    mocks.openProject.mockClear();
+    mocks.openProject.mockResolvedValue(true);
+    mocks.textInput.onChangeText = null;
+    mocks.textInput.onSubmitEditing = null;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = createQueryClient();
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    queryClient?.clear();
+    queryClient = null;
+    root = null;
+    container?.remove();
+    container = null;
+  });
+
+  function renderModal(): void {
+    act(() => {
+      root?.render(
+        <QueryClientProvider client={queryClient!}>
+          <ProjectPickerModal />
+        </QueryClientProvider>,
+      );
+    });
+  }
+
+  it("submits a manually typed Linux path from the native return key", async () => {
+    renderModal();
+
+    setPathInput("/data/source/project");
+    submitPathInput();
+    await flushAsyncWork();
+
+    expect(mocks.openProject).toHaveBeenCalledWith("/data/source/project");
+    expect(mocks.keyboardStore.setProjectPickerOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("shows the current typed path when daemon suggestions are empty", () => {
+    renderModal();
+
+    setPathInput("/workspace/project");
+
+    expect(countPathRows("/workspace/project")).toBe(1);
+  });
+
+  it("does not duplicate the typed path when it already exists in suggestions", () => {
+    mocks.recommendedPaths.value = ["/data/source/project"];
+    renderModal();
+
+    setPathInput("/data/source/project");
+
+    expect(countPathRows("/data/source/project")).toBe(1);
+  });
+});

--- a/packages/app/src/components/project-picker-modal.tsx
+++ b/packages/app/src/components/project-picker-modal.tsx
@@ -103,6 +103,13 @@ export function ProjectPickerModal() {
       }),
     [query, directorySuggestionsQuery.data, recommendedPaths],
   );
+  const visibleOptions = useMemo(() => {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery || options.includes(trimmedQuery)) {
+      return options;
+    }
+    return [trimmedQuery, ...options];
+  }, [options, query]);
 
   const handleClose = useCallback(() => {
     setOpen(false);
@@ -150,10 +157,10 @@ export function ProjectPickerModal() {
   // Clamp active index
   useEffect(() => {
     if (!open) return;
-    if (activeIndex >= options.length) {
-      setActiveIndex(options.length > 0 ? options.length - 1 : 0);
+    if (activeIndex >= visibleOptions.length) {
+      setActiveIndex(visibleOptions.length > 0 ? visibleOptions.length - 1 : 0);
     }
-  }, [activeIndex, options.length, open]);
+  }, [activeIndex, open, visibleOptions.length]);
 
   // Keyboard navigation
   useEffect(() => {
@@ -171,8 +178,8 @@ export function ProjectPickerModal() {
 
       if (key === "Enter") {
         event.preventDefault();
-        if (options.length > 0 && activeIndex < options.length) {
-          void handleSelectPath(options[activeIndex]);
+        if (visibleOptions.length > 0 && activeIndex < visibleOptions.length) {
+          void handleSelectPath(visibleOptions[activeIndex]);
         } else if (query.trim()) {
           handleSubmitCustom();
         }
@@ -180,13 +187,13 @@ export function ProjectPickerModal() {
       }
 
       if (key === "ArrowDown" || key === "ArrowUp") {
-        if (options.length === 0) return;
+        if (visibleOptions.length === 0) return;
         event.preventDefault();
         setActiveIndex((current) => {
           const delta = key === "ArrowDown" ? 1 : -1;
           const next = current + delta;
-          if (next < 0) return options.length - 1;
-          if (next >= options.length) return 0;
+          if (next < 0) return visibleOptions.length - 1;
+          if (next >= visibleOptions.length) return 0;
           return next;
         });
       }
@@ -194,7 +201,7 @@ export function ProjectPickerModal() {
 
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [activeIndex, handleSelectPath, handleSubmitCustom, open, options, query, setOpen]);
+  }, [activeIndex, handleSelectPath, handleSubmitCustom, open, query, setOpen, visibleOptions]);
 
   const panelStyle = useMemo(
     () => [
@@ -239,6 +246,10 @@ export function ProjectPickerModal() {
               autoCorrect={false}
               autoFocus
               editable={!isSubmitting}
+              onSubmitEditing={handleSubmitCustom}
+              returnKeyType="go"
+              submitBehavior="submit"
+              testID="project-picker-path-input"
             />
           </View>
 
@@ -249,12 +260,12 @@ export function ProjectPickerModal() {
             showsVerticalScrollIndicator={false}
           >
             {isSubmitting ? <Text style={emptyTextStyle}>Opening project...</Text> : null}
-            {!isSubmitting && options.length === 0 && !query.trim() ? (
+            {!isSubmitting && visibleOptions.length === 0 && !query.trim() ? (
               <Text style={emptyTextStyle}>Start typing a path</Text>
             ) : null}
-            {!isSubmitting && !(options.length === 0 && !query.trim()) ? (
+            {!isSubmitting && !(visibleOptions.length === 0 && !query.trim()) ? (
               <>
-                {options.map((path, index) => (
+                {visibleOptions.map((path, index) => (
                   <PathRow
                     key={path}
                     path={path}


### PR DESCRIPTION
## Summary

- Allows the native Add project picker to submit the current typed path via the keyboard return key.
- Shows a non-empty typed path as the first selectable row when daemon directory suggestions do not include it, which covers valid Linux paths outside `/Users/lewinma` such as `/data/source/project`.
- Keeps the existing `open_project_request` protocol unchanged and only routes the typed path into the existing `openProject()` flow.

Closes #829.

## Root cause

`ProjectPickerModal` already had a custom submit path, but it was only reachable from the web-only `window` keydown handler. Native clients skip that handler, and the `TextInput` did not wire `onSubmitEditing`, so iOS users could type a valid remote daemon path without a reliable way to submit it unless it appeared in suggestions.

## Test plan

- [x] `npm run test --workspace=@getpaseo/app -- src/components/project-picker-modal.test.tsx --bail=1`
- [x] `npm run typecheck`
- [x] `npm run lint`

## Notes

- No WebSocket or message schema changes.
- No visual layout change; this is a native submit/selection behavior fix.