### PR TITLE
refactor(server): extract shared task graph utilities

### DIFF
--- a/packages/server/src/server/checkout/status-projection.test.ts
+++ b/packages/server/src/server/checkout/status-projection.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+
+import { CheckoutPrStatusSchema } from "../../shared/messages.js";
+import { normalizeCheckoutPrStatusPayload } from "./status-projection.js";
+
+describe("checkout status projection", () => {
+  test("includes repository identity fields on the PR status wire payload", () => {
+    const payload = normalizeCheckoutPrStatusPayload({
+      number: 123,
+      repoOwner: "internal-owner",
+      repoName: "internal-repo",
+      url: "https://github.com/getpaseo/paseo/pull/123",
+      title: "Ship PR pane",
+      state: "open",
+      baseRefName: "main",
+      headRefName: "feature/pr-pane",
+      isMerged: false,
+      isDraft: true,
+      mergeable: "MERGEABLE",
+      checks: [
+        {
+          name: "typecheck",
+          status: "success",
+          url: "https://github.com/getpaseo/paseo/actions/runs/1",
+          workflow: "CI",
+          duration: "1m 20s",
+        },
+      ],
+      checksStatus: "success",
+      reviewDecision: "approved",
+    });
+
+    expect(payload).toHaveProperty("repoOwner", "internal-owner");
+    expect(payload).toHaveProperty("repoName", "internal-repo");
+    expect(payload).toHaveProperty("mergeable", "MERGEABLE");
+    expect(CheckoutPrStatusSchema.parse(payload)).toEqual(payload);
+  });
+});

--- a/packages/server/src/server/checkout/status-projection.ts
+++ b/packages/server/src/server/checkout/status-projection.ts
@@ -1,0 +1,134 @@
+import type {
+  CheckoutPrStatusResponse,
+  CheckoutStatusResponse,
+  SessionOutboundMessage,
+} from "../../shared/messages.js";
+import type { WorkspaceGitRuntimeSnapshot } from "../workspace-git-service.js";
+
+type CheckoutPrStatusPayload = Extract<
+  SessionOutboundMessage,
+  { type: "checkout_pr_status_response" }
+>["payload"];
+type CheckoutPrStatusPayloadStatus = NonNullable<CheckoutPrStatusPayload["status"]>;
+
+export function buildCheckoutStatusPayloadFromSnapshot({
+  cwd,
+  requestId,
+  snapshot,
+}: {
+  cwd: string;
+  requestId: string;
+  snapshot: WorkspaceGitRuntimeSnapshot;
+}): CheckoutStatusResponse["payload"] {
+  if (!snapshot.git.isGit) {
+    return {
+      cwd,
+      isGit: false,
+      repoRoot: null,
+      currentBranch: null,
+      isDirty: null,
+      baseRef: null,
+      aheadBehind: null,
+      aheadOfOrigin: null,
+      behindOfOrigin: null,
+      hasRemote: false,
+      remoteUrl: null,
+      isPaseoOwnedWorktree: false,
+      error: null,
+      requestId,
+    };
+  }
+
+  if (snapshot.git.repoRoot === null || snapshot.git.isDirty === null) {
+    throw new Error("Workspace git snapshot is missing required checkout status fields");
+  }
+
+  if (snapshot.git.isPaseoOwnedWorktree) {
+    if (snapshot.git.mainRepoRoot === null || snapshot.git.baseRef === null) {
+      throw new Error("Workspace git snapshot is missing required worktree status fields");
+    }
+
+    return {
+      cwd,
+      isGit: true,
+      repoRoot: snapshot.git.repoRoot,
+      mainRepoRoot: snapshot.git.mainRepoRoot,
+      currentBranch: snapshot.git.currentBranch ?? null,
+      isDirty: snapshot.git.isDirty,
+      baseRef: snapshot.git.baseRef,
+      aheadBehind: snapshot.git.aheadBehind ?? null,
+      aheadOfOrigin: snapshot.git.aheadOfOrigin ?? null,
+      behindOfOrigin: snapshot.git.behindOfOrigin ?? null,
+      hasRemote: snapshot.git.hasRemote,
+      remoteUrl: snapshot.git.remoteUrl,
+      isPaseoOwnedWorktree: true,
+      error: null,
+      requestId,
+    };
+  }
+
+  return {
+    cwd,
+    isGit: true,
+    repoRoot: snapshot.git.repoRoot,
+    mainRepoRoot: snapshot.git.mainRepoRoot,
+    currentBranch: snapshot.git.currentBranch ?? null,
+    isDirty: snapshot.git.isDirty,
+    baseRef: snapshot.git.baseRef ?? null,
+    aheadBehind: snapshot.git.aheadBehind ?? null,
+    aheadOfOrigin: snapshot.git.aheadOfOrigin ?? null,
+    behindOfOrigin: snapshot.git.behindOfOrigin ?? null,
+    hasRemote: snapshot.git.hasRemote,
+    remoteUrl: snapshot.git.remoteUrl,
+    isPaseoOwnedWorktree: false,
+    error: null,
+    requestId,
+  };
+}
+
+export function buildCheckoutPrStatusPayloadFromSnapshot({
+  cwd,
+  requestId,
+  snapshot,
+}: {
+  cwd: string;
+  requestId: string;
+  snapshot: WorkspaceGitRuntimeSnapshot;
+}): CheckoutPrStatusResponse["payload"] {
+  return {
+    cwd,
+    status: normalizeCheckoutPrStatusPayload(snapshot.github.pullRequest),
+    githubFeaturesEnabled: snapshot.github.featuresEnabled,
+    error: snapshot.github.error
+      ? {
+          code: "UNKNOWN",
+          message: snapshot.github.error.message,
+        }
+      : null,
+    requestId,
+  };
+}
+
+export function normalizeCheckoutPrStatusPayload(
+  status: WorkspaceGitRuntimeSnapshot["github"]["pullRequest"],
+): CheckoutPrStatusPayloadStatus | null {
+  if (!status) {
+    return null;
+  }
+  return {
+    number: status.number,
+    url: status.url,
+    title: status.title,
+    state: status.state,
+    repoOwner: status.repoOwner,
+    repoName: status.repoName,
+    baseRefName: status.baseRefName,
+    headRefName: status.headRefName,
+    isMerged: status.isMerged,
+    isDraft: status.isDraft ?? false,
+    mergeable: status.mergeable ?? "UNKNOWN",
+    checks: status.checks ?? [],
+    checksStatus: status.checksStatus,
+    reviewDecision: status.reviewDecision,
+  };
+}

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -6,10 +6,9 @@ import { join } from "path";
 import pino from "pino";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { CheckoutPrStatusSchema } from "../shared/messages.js";
 import type { WorkspaceDescriptorPayload } from "../shared/messages.js";
 import { decodeFileTransferFrame, FileTransferOpcode } from "../shared/binary-frames/index.js";
-import { normalizeCheckoutPrStatusPayload, Session } from "./session.js";
+import { Session } from "./session.js";
 import { StructuredAgentFallbackError } from "./agent/agent-response-loop.js";
 import type {
   AgentClient,
@@ -1188,40 +1187,6 @@ describe("session agent import", () => {
         explicitTitle: null,
       }),
     );
-  });
-});
-
-describe("session PR status payload normalization", () => {
-  test("includes repository identity fields on the wire", () => {
-    const payload = normalizeCheckoutPrStatusPayload({
-      number: 123,
-      repoOwner: "internal-owner",
-      repoName: "internal-repo",
-      url: "https://github.com/getpaseo/paseo/pull/123",
-      title: "Ship PR pane",
-      state: "open",
-      baseRefName: "main",
-      headRefName: "feature/pr-pane",
-      isMerged: false,
-      isDraft: true,
-      mergeable: "MERGEABLE",
-      checks: [
-        {
-          name: "typecheck",
-          status: "success",
-          url: "https://github.com/getpaseo/paseo/actions/runs/1",
-          workflow: "CI",
-          duration: "1m 20s",
-        },
-      ],
-      checksStatus: "success",
-      reviewDecision: "approved",
-    });
-
-    expect(payload).toHaveProperty("repoOwner", "internal-owner");
-    expect(payload).toHaveProperty("repoName", "internal-repo");
-    expect(payload).toHaveProperty("mergeable", "MERGEABLE");
-    expect(CheckoutPrStatusSchema.parse(payload)).toEqual(payload);
   });
 });
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -20,8 +20,6 @@ import {
   type FileExplorerRequest,
   type FileDownloadTokenRequest,
   type GitSetupOptions,
-  type CheckoutPrStatusResponse,
-  type CheckoutStatusResponse,
   type StartWorkspaceScriptRequest,
   type CloseItemsRequest,
   type SubscribeCheckoutDiffRequest,
@@ -192,6 +190,10 @@ import { expandTilde } from "../utils/path.js";
 import { searchHomeDirectories, searchWorkspaceEntries } from "../utils/directory-suggestions.js";
 import { toCheckoutError } from "./checkout-git-utils.js";
 import { CheckoutDiffManager } from "./checkout-diff-manager.js";
+import {
+  buildCheckoutPrStatusPayloadFromSnapshot,
+  buildCheckoutStatusPayloadFromSnapshot,
+} from "./checkout/status-projection.js";
 import type { LocalSpeechModelId } from "./speech/providers/local/models.js";
 import { toResolver, type Resolvable } from "./speech/provider-resolver.js";
 import type { SpeechReadinessSnapshot, SpeechReadinessState } from "./speech/speech-runtime.js";
@@ -636,11 +638,6 @@ export type SessionLifecycleIntent =
       reason?: string;
     };
 
-type CheckoutPrStatusPayload = Extract<
-  SessionOutboundMessage,
-  { type: "checkout_pr_status_response" }
->["payload"];
-type CheckoutPrStatusPayloadStatus = NonNullable<CheckoutPrStatusPayload["status"]>;
 type PullRequestTimelinePayload = Extract<
   SessionOutboundMessage,
   { type: "pull_request_timeline_response" }
@@ -4489,7 +4486,7 @@ export class Session {
       const snapshot = await this.workspaceGitService.getSnapshot(resolvedCwd);
       this.emit({
         type: "checkout_status_response",
-        payload: this.buildCheckoutStatusPayloadFromSnapshot({
+        payload: buildCheckoutStatusPayloadFromSnapshot({
           cwd,
           requestId,
           snapshot,
@@ -4838,116 +4835,18 @@ export class Session {
     this.checkoutDiffSubscriptions.delete(msg.subscriptionId);
   }
 
-  private buildCheckoutStatusPayloadFromSnapshot({
-    cwd,
-    requestId,
-    snapshot,
-  }: {
-    cwd: string;
-    requestId: string;
-    snapshot: WorkspaceGitRuntimeSnapshot;
-  }): CheckoutStatusResponse["payload"] {
-    if (!snapshot.git.isGit) {
-      return {
-        cwd,
-        isGit: false,
-        repoRoot: null,
-        currentBranch: null,
-        isDirty: null,
-        baseRef: null,
-        aheadBehind: null,
-        aheadOfOrigin: null,
-        behindOfOrigin: null,
-        hasRemote: false,
-        remoteUrl: null,
-        isPaseoOwnedWorktree: false,
-        error: null,
-        requestId,
-      };
-    }
-
-    if (snapshot.git.repoRoot === null || snapshot.git.isDirty === null) {
-      throw new Error("Workspace git snapshot is missing required checkout status fields");
-    }
-
-    if (snapshot.git.isPaseoOwnedWorktree) {
-      if (snapshot.git.mainRepoRoot === null || snapshot.git.baseRef === null) {
-        throw new Error("Workspace git snapshot is missing required worktree status fields");
-      }
-
-      return {
-        cwd,
-        isGit: true,
-        repoRoot: snapshot.git.repoRoot,
-        mainRepoRoot: snapshot.git.mainRepoRoot,
-        currentBranch: snapshot.git.currentBranch ?? null,
-        isDirty: snapshot.git.isDirty,
-        baseRef: snapshot.git.baseRef,
-        aheadBehind: snapshot.git.aheadBehind ?? null,
-        aheadOfOrigin: snapshot.git.aheadOfOrigin ?? null,
-        behindOfOrigin: snapshot.git.behindOfOrigin ?? null,
-        hasRemote: snapshot.git.hasRemote,
-        remoteUrl: snapshot.git.remoteUrl,
-        isPaseoOwnedWorktree: true,
-        error: null,
-        requestId,
-      };
-    }
-
-    return {
-      cwd,
-      isGit: true,
-      repoRoot: snapshot.git.repoRoot,
-      mainRepoRoot: snapshot.git.mainRepoRoot,
-      currentBranch: snapshot.git.currentBranch ?? null,
-      isDirty: snapshot.git.isDirty,
-      baseRef: snapshot.git.baseRef ?? null,
-      aheadBehind: snapshot.git.aheadBehind ?? null,
-      aheadOfOrigin: snapshot.git.aheadOfOrigin ?? null,
-      behindOfOrigin: snapshot.git.behindOfOrigin ?? null,
-      hasRemote: snapshot.git.hasRemote,
-      remoteUrl: snapshot.git.remoteUrl,
-      isPaseoOwnedWorktree: false,
-      error: null,
-      requestId,
-    };
-  }
-
-  private buildCheckoutPrStatusPayloadFromSnapshot({
-    cwd,
-    requestId,
-    snapshot,
-  }: {
-    cwd: string;
-    requestId: string;
-    snapshot: WorkspaceGitRuntimeSnapshot;
-  }): CheckoutPrStatusResponse["payload"] {
-    return {
-      cwd,
-      status: normalizeCheckoutPrStatusPayload(snapshot.github.pullRequest),
-      githubFeaturesEnabled: snapshot.github.featuresEnabled,
-      error: snapshot.github.error
-        ? {
-            code: "UNKNOWN",
-            message: snapshot.github.error.message,
-          }
-        : null,
-      requestId,
-    };
-  }
-
   private emitCheckoutStatusUpdate(cwd: string, snapshot: WorkspaceGitRuntimeSnapshot): void {
     try {
       const requestId = `subscription:${cwd}`;
       this.emit({
         type: "checkout_status_update",
         payload: {
-          ...this.buildCheckoutStatusPayloadFromSnapshot({
+          ...buildCheckoutStatusPayloadFromSnapshot({
             cwd,
             requestId,
             snapshot,
           }),
-          prStatus: this.buildCheckoutPrStatusPayloadFromSnapshot({
+          prStatus: buildCheckoutPrStatusPayloadFromSnapshot({
             cwd,
             requestId,
             snapshot,
@@ -5382,18 +5281,11 @@ export class Session {
       const snapshot = await this.workspaceGitService.getSnapshot(cwd);
       this.emit({
         type: "checkout_pr_status_response",
-        payload: {
+        payload: buildCheckoutPrStatusPayloadFromSnapshot({
           cwd,
-          status: normalizeCheckoutPrStatusPayload(snapshot.github.pullRequest),
-          githubFeaturesEnabled: snapshot.github.featuresEnabled,
-          error: snapshot.github.error
-            ? {
-                code: "UNKNOWN",
-                message: snapshot.github.error.message,
-              }
-            : null,
           requestId,
-        },
+          snapshot,
+        }),
       });
     } catch (error) {
       this.emit({
@@ -8893,30 +8785,6 @@ export class Session {
       this.emitLoopRpcError(request, error);
     }
   }
-}
-
-export function normalizeCheckoutPrStatusPayload(
-  status: WorkspaceGitRuntimeSnapshot["github"]["pullRequest"],
-): CheckoutPrStatusPayloadStatus | null {
-  if (!status) {
-    return null;
-  }
-  return {
-    number: status.number,
-    url: status.url,
-    title: status.title,
-    state: status.state,
-    repoOwner: status.repoOwner,
-    repoName: status.repoName,
-    baseRefName: status.baseRefName,
-    headRefName: status.headRefName,
-    isMerged: status.isMerged,
-    isDraft: status.isDraft ?? false,
-    mergeable: status.mergeable ?? "UNKNOWN",
-    checks: status.checks ?? [],
-    checksStatus: status.checksStatus,
-    reviewDecision: status.reviewDecision,
-  };
 }
 
 function isValidPullRequestTimelineIdentity(options: {

--- a/packages/server/src/tasks/execution-order.ts
+++ b/packages/server/src/tasks/execution-order.ts
@@ -1,13 +1,5 @@
 import type { Task, TaskStore } from "./types.js";
-
-function sortByPriorityThenCreated(a: Task, b: Task): number {
-  if (a.priority !== undefined && b.priority === undefined) return -1;
-  if (a.priority === undefined && b.priority !== undefined) return 1;
-  if (a.priority !== undefined && b.priority !== undefined) {
-    if (a.priority !== b.priority) return a.priority - b.priority;
-  }
-  return a.created.localeCompare(b.created);
-}
+import { buildChildrenMap, loadScopedTaskGraph, sortByPriorityThenCreated } from "./task-graph.js";
 
 export interface ExecutionOrderResult {
   /** Tasks in execution order (done first, then pending) */
@@ -30,45 +22,22 @@ export async function computeExecutionOrder(
   store: TaskStore,
   scopeId?: string,
 ): Promise<ExecutionOrderResult> {
-  const allTasks = await store.list();
-  const taskMap = new Map(allTasks.map((t) => [t.id, t]));
+  const graph = await loadScopedTaskGraph(store, scopeId);
 
-  // Get scoped tasks
-  let candidates: Task[];
-  if (scopeId) {
-    const scopeTask = await store.get(scopeId);
-    const descendants = await store.getDescendants(scopeId);
-    candidates = scopeTask ? [scopeTask, ...descendants] : descendants;
-  } else {
-    candidates = allTasks;
-  }
-
-  // Build children map
-  const childrenMap = new Map<string, Task[]>();
-  for (const t of allTasks) {
-    if (t.parentId) {
-      const siblings = childrenMap.get(t.parentId) ?? [];
-      siblings.push(t);
-      childrenMap.set(t.parentId, siblings);
-    }
-  }
-
-  const candidateIds = new Set(candidates.map((t) => t.id));
-
-  // Simulate execution: track done status
-  // Include all done tasks (not just in scope) for dep resolution
-  const simDone = new Set(allTasks.filter((t) => t.status === "done").map((t) => t.id));
+  const simDone = new Set(graph.allTasks.filter((t) => t.status === "done").map((t) => t.id));
   const remaining = new Set(
-    candidates.filter((t) => t.status === "open" || t.status === "in_progress").map((t) => t.id),
+    graph.candidates
+      .filter((t) => t.status === "open" || t.status === "in_progress")
+      .map((t) => t.id),
   );
 
   const isReady = (taskId: string): boolean => {
-    const task = taskMap.get(taskId);
+    const task = graph.taskMap.get(taskId);
     if (!task) return false;
-    // All deps done (deps can be outside scope)
     const depsOk = task.deps.every((depId) => simDone.has(depId));
-    // All children done (only consider children in scope)
-    const children = (childrenMap.get(taskId) ?? []).filter((c) => candidateIds.has(c.id));
+    const children = (graph.childrenMap.get(taskId) ?? []).filter((c) =>
+      graph.candidateIds.has(c.id),
+    );
     const childrenOk = children.every((c) => simDone.has(c.id));
     return depsOk && childrenOk;
   };
@@ -77,8 +46,7 @@ export async function computeExecutionOrder(
   const orderMap = new Map<string, number>();
   let orderIdx = 0;
 
-  // Done tasks first (by created date = historical execution order)
-  const done = candidates
+  const done = graph.candidates
     .filter((t) => t.status === "done")
     .sort((a, b) => a.created.localeCompare(b.created));
   for (const t of done) {
@@ -90,10 +58,10 @@ export async function computeExecutionOrder(
   while (remaining.size > 0) {
     const readyNow = [...remaining]
       .filter(isReady)
-      .map((tid) => taskMap.get(tid)!)
+      .map((tid) => graph.taskMap.get(tid)!)
       .sort(sortByPriorityThenCreated);
 
-    if (readyNow.length === 0) break; // No more can be done (cycle or blocked)
+    if (readyNow.length === 0) break;
 
     const next = readyNow[0];
     timeline.push(next);
@@ -115,17 +83,8 @@ export function buildSortedChildrenMap(
   tasks: Task[],
   orderMap: Map<string, number>,
 ): Map<string, Task[]> {
-  const childrenMap = new Map<string, Task[]>();
+  const childrenMap = buildChildrenMap(tasks);
 
-  for (const t of tasks) {
-    if (t.parentId) {
-      const siblings = childrenMap.get(t.parentId) ?? [];
-      siblings.push(t);
-      childrenMap.set(t.parentId, siblings);
-    }
-  }
-
-  // Sort each group by execution order
   for (const [parentId, children] of childrenMap) {
     children.sort((a, b) => {
       const orderA = orderMap.get(a.id) ?? Infinity;

--- a/packages/server/src/tasks/task-graph.ts
+++ b/packages/server/src/tasks/task-graph.ts
@@ -1,0 +1,66 @@
+import type { Task, TaskStore } from "./types.js";
+
+export interface TaskGraph {
+  allTasks: Task[];
+  candidates: Task[];
+  taskMap: Map<string, Task>;
+  childrenMap: Map<string, Task[]>;
+  candidateIds: Set<string>;
+}
+
+type TaskGraphStore = Pick<TaskStore, "list" | "get" | "getDescendants">;
+
+export function sortByPriorityThenCreated(a: Task, b: Task): number {
+  if (a.priority !== undefined && b.priority === undefined) return -1;
+  if (a.priority === undefined && b.priority !== undefined) return 1;
+  if (a.priority !== undefined && b.priority !== undefined) {
+    if (a.priority !== b.priority) return a.priority - b.priority;
+  }
+  return a.created.localeCompare(b.created);
+}
+
+export function buildTaskMap(tasks: Task[]): Map<string, Task> {
+  return new Map(tasks.map((task) => [task.id, task]));
+}
+
+export function buildChildrenMap(tasks: Task[]): Map<string, Task[]> {
+  const childrenMap = new Map<string, Task[]>();
+  for (const task of tasks) {
+    if (task.parentId) {
+      const siblings = childrenMap.get(task.parentId) ?? [];
+      siblings.push(task);
+      childrenMap.set(task.parentId, siblings);
+    }
+  }
+  return childrenMap;
+}
+
+export async function loadScopedTaskGraph(
+  store: TaskGraphStore,
+  scopeId?: string,
+): Promise<TaskGraph> {
+  const allTasks = await store.list();
+  const candidates = await loadScopedCandidates(store, allTasks, scopeId);
+
+  return {
+    allTasks,
+    candidates,
+    taskMap: buildTaskMap(allTasks),
+    childrenMap: buildChildrenMap(allTasks),
+    candidateIds: new Set(candidates.map((task) => task.id)),
+  };
+}
+
+async function loadScopedCandidates(
+  store: TaskGraphStore,
+  allTasks: Task[],
+  scopeId?: string,
+): Promise<Task[]> {
+  if (!scopeId) {
+    return allTasks;
+  }
+
+  const scopeTask = await store.get(scopeId);
+  const descendants = await store.getDescendants(scopeId);
+  return scopeTask ? [scopeTask, ...descendants] : descendants;
+}

--- a/packages/server/src/tasks/task-store.ts
+++ b/packages/server/src/tasks/task-store.ts
@@ -2,25 +2,10 @@ import { readdir, readFile, writeFile, mkdir, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import type { Task, TaskStore, CreateTaskOptions, TaskStatus } from "./types.js";
+import { loadScopedTaskGraph, sortByPriorityThenCreated } from "./task-graph.js";
 
 function generateId(): string {
   return randomBytes(4).toString("hex");
-}
-
-function sortByPriorityThenCreated(a: Task, b: Task): number {
-  // Tasks with priority come before tasks without
-  if (a.priority !== undefined && b.priority === undefined) return -1;
-  if (a.priority === undefined && b.priority !== undefined) return 1;
-
-  // If both have priority, lower number = higher priority
-  if (a.priority !== undefined && b.priority !== undefined) {
-    if (a.priority !== b.priority) {
-      return a.priority - b.priority;
-    }
-  }
-
-  // Fall back to created date (oldest first)
-  return a.created.localeCompare(b.created);
 }
 
 function serializeTask(task: Task): string {
@@ -267,82 +252,40 @@ export class FileTaskStore implements TaskStore {
   }
 
   async getReady(scopeId?: string): Promise<Task[]> {
-    const allTasks = await this.list();
-    const taskMap = new Map(allTasks.map((t) => [t.id, t]));
-
-    let candidates: Task[];
-    if (scopeId) {
-      // Include the scoped task itself and all its descendants (children tree)
-      const scopeTask = await this.get(scopeId);
-      const descendants = await this.getDescendants(scopeId);
-      candidates = scopeTask ? [scopeTask, ...descendants] : descendants;
-    } else {
-      candidates = allTasks;
-    }
-
-    // Build children map for quick lookup
-    const childrenMap = new Map<string, Task[]>();
-    for (const t of allTasks) {
-      if (t.parentId) {
-        const siblings = childrenMap.get(t.parentId) ?? [];
-        siblings.push(t);
-        childrenMap.set(t.parentId, siblings);
-      }
-    }
+    const graph = await loadScopedTaskGraph(this, scopeId);
 
     const isReady = (task: Task): boolean => {
       if (task.status !== "open") return false;
-      // All deps must be done
       const depsReady = task.deps.every((depId) => {
-        const dep = taskMap.get(depId);
+        const dep = graph.taskMap.get(depId);
         return dep?.status === "done";
       });
       if (!depsReady) return false;
-      // All children must be done (if any exist)
-      const children = childrenMap.get(task.id) ?? [];
+      const children = graph.childrenMap.get(task.id) ?? [];
       return children.every((c) => c.status === "done");
     };
 
-    // Sort by priority first (lower = higher priority), then created date
-    return candidates.filter(isReady).sort(sortByPriorityThenCreated);
+    return graph.candidates.filter(isReady).sort(sortByPriorityThenCreated);
   }
 
   async getBlocked(scopeId?: string): Promise<Task[]> {
-    const allTasks = await this.list();
-    const taskMap = new Map(allTasks.map((t) => [t.id, t]));
-
-    let candidates: Task[];
-    if (scopeId) {
-      const scopeTask = await this.get(scopeId);
-      const descendants = await this.getDescendants(scopeId);
-      candidates = scopeTask ? [scopeTask, ...descendants] : descendants;
-    } else {
-      candidates = allTasks;
-    }
+    const graph = await loadScopedTaskGraph(this, scopeId);
 
     const isBlocked = (task: Task): boolean => {
       if (task.status === "draft" || task.status === "done") return false;
       if (task.deps.length === 0) return false;
       return task.deps.some((depId) => {
-        const dep = taskMap.get(depId);
+        const dep = graph.taskMap.get(depId);
         return dep?.status !== "done";
       });
     };
 
-    return candidates.filter(isBlocked);
+    return graph.candidates.filter(isBlocked);
   }
 
   async getClosed(scopeId?: string): Promise<Task[]> {
-    let candidates: Task[];
-    if (scopeId) {
-      const scopeTask = await this.get(scopeId);
-      const descendants = await this.getDescendants(scopeId);
-      candidates = scopeTask ? [scopeTask, ...descendants] : descendants;
-    } else {
-      candidates = await this.list();
-    }
+    const { candidates } = await loadScopedTaskGraph(this, scopeId);
 
-    // Sort by created date (most recent first) for consistent ordering
     return candidates
       .filter((t) => t.status === "done")
       .sort((a, b) => b.created.localeCompare(a.created));


### PR DESCRIPTION
Consolidate task graph construction and sorting logic into a reusable module.

- Extract `sortByPriorityThenCreated`, `buildTaskMap`, and `buildChildrenMap` utilities to new `task-graph.ts`
- Introduce `TaskGraph` interface encapsulating allTasks, candidates, taskMap, childrenMap, and candidateIds
- Add `loadScopedTaskGraph` to centralize scoped task loading logic (previously duplicated in execution-order.ts and task-store.ts)
- Update `execution-order.ts` and `task-store.ts` to use the new module, eliminating ~130 lines of duplication
- Reduces surface area for bugs and makes task graph operations more maintainable