### PR TITLE
Restrict desktop external URL schemes

### DIFF
--- a/packages/desktop/src/features/opener.test.ts
+++ b/packages/desktop/src/features/opener.test.ts
@@ -1,0 +1,53 @@
+import { ipcMain, shell } from "electron";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isAllowedExternalUrl, registerOpenerHandlers } from "./opener";
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: vi.fn() },
+  shell: { openExternal: vi.fn() },
+}));
+
+function getRegisteredOpenUrlHandler(): (_event: unknown, url: unknown) => Promise<void> {
+  registerOpenerHandlers();
+  const handler = vi.mocked(ipcMain.handle).mock.calls.find(([channel]) => {
+    return channel === "paseo:opener:openUrl";
+  })?.[1];
+  if (typeof handler !== "function") {
+    throw new Error("open URL handler was not registered");
+  }
+  return handler as (_event: unknown, url: unknown) => Promise<void>;
+}
+
+describe("desktop opener", () => {
+  beforeEach(() => {
+    vi.mocked(ipcMain.handle).mockReset();
+    vi.mocked(shell.openExternal).mockReset();
+  });
+
+  it("allows only http and https external URLs", () => {
+    expect(isAllowedExternalUrl("https://example.com/path")).toBe(true);
+    expect(isAllowedExternalUrl("http://localhost:8081")).toBe(true);
+    expect(isAllowedExternalUrl("file:///etc/passwd")).toBe(false);
+    expect(isAllowedExternalUrl("javascript:alert(1)")).toBe(false);
+    expect(isAllowedExternalUrl("paseo://settings")).toBe(false);
+    expect(isAllowedExternalUrl("/relative/path")).toBe(false);
+    expect(isAllowedExternalUrl(null)).toBe(false);
+  });
+
+  it("opens allowed URLs through Electron shell", async () => {
+    const handler = getRegisteredOpenUrlHandler();
+
+    await handler({}, "https://example.com");
+
+    expect(shell.openExternal).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("rejects blocked URLs before invoking Electron shell", async () => {
+    const handler = getRegisteredOpenUrlHandler();
+
+    await expect(handler({}, "file:///etc/passwd")).rejects.toThrow("Unsupported external URL");
+
+    expect(shell.openExternal).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/src/features/opener.ts
+++ b/packages/desktop/src/features/opener.ts
@@ -1,7 +1,25 @@
 import { shell, ipcMain } from "electron";
 
+const ALLOWED_EXTERNAL_URL_PROTOCOLS = new Set(["http:", "https:"]);
+
+export function isAllowedExternalUrl(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  try {
+    const url = new URL(value);
+    return ALLOWED_EXTERNAL_URL_PROTOCOLS.has(url.protocol);
+  } catch {
+    return false;
+  }
+}
+
 export function registerOpenerHandlers(): void {
-  ipcMain.handle("paseo:opener:openUrl", async (_event, url: string) => {
+  ipcMain.handle("paseo:opener:openUrl", async (_event, url: unknown) => {
+    if (!isAllowedExternalUrl(url)) {
+      throw new Error("Unsupported external URL");
+    }
     await shell.openExternal(url);
   });
 }


### PR DESCRIPTION
## Summary
- validate renderer-supplied external URLs in the Electron main process
- allow only http: and https: URLs through shell.openExternal
- reject file:, javascript:, custom schemes, relative URLs, and non-string inputs before invoking Electron shell

## Validation
- npm run format:check:files -- packages/desktop/src/features/opener.ts packages/desktop/src/features/opener.test.ts
- npm run test --workspace=@getpaseo/desktop -- src/features/opener.test.ts --bail=1
- npm run typecheck --workspace=@getpaseo/desktop
- npm run build:main --workspace=@getpaseo/desktop