### PR TITLE
Fix relay encryption docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,7 +103,7 @@ Communicates with the daemon via the same WebSocket protocol as the app.
 
 Enables remote access when the daemon is behind a firewall.
 
-- ECDH key exchange + AES-256-GCM encryption
+- Curve25519 ECDH key exchange + XSalsa20-Poly1305 (NaCl `box`) encryption
 - Relay server is zero-knowledge — it routes encrypted bytes, cannot read content
 - Client and daemon channels with identical API (`createClientChannel`, `createDaemonChannel`)
 - Pairing via QR code transfers the daemon's public key to the client

--- a/packages/website/src/routes/privacy.tsx
+++ b/packages/website/src/routes/privacy.tsx
@@ -40,8 +40,9 @@ function Privacy() {
             <li>Session IDs</li>
           </ul>
           <p>
-            All messages between your phone and daemon are end-to-end encrypted with AES-256-GCM.
-            The relay cannot read your messages, see your code, or decrypt your traffic.
+            All messages between your phone and daemon are end-to-end encrypted with
+            XSalsa20-Poly1305. The relay cannot read your messages, see your code, or decrypt your
+            traffic.
           </p>
         </section>
 

--- a/public-docs/security.md
+++ b/public-docs/security.md
@@ -31,7 +31,8 @@ The relay is the simplest way to connect from your phone. It requires no VPN set
 1. The daemon generates a persistent ECDH keypair and stores it in `$PASEO_HOME/daemon-keypair.json`
 2. When you scan the QR code or click the pairing link, your phone receives the daemon's public key
 3. Your phone sends a handshake message with its own public key. The daemon will not accept any commands until this handshake completes.
-4. Both sides perform an ECDH key exchange to derive a shared secret. All subsequent messages are encrypted with AES-256-GCM.
+4. Both sides perform a Curve25519 ECDH key exchange to derive a shared key. All subsequent
+   messages are encrypted with XSalsa20-Poly1305 (NaCl `box`).
 
 The relay sees only: IP addresses, timing, message sizes, and session IDs. It cannot read message contents, forge messages, or derive encryption keys from observing the handshake.
 
@@ -40,8 +41,8 @@ The relay sees only: IP addresses, timing, message sizes, and session IDs. It ca
 The daemon requires a valid cryptographic handshake before processing any commands. A compromised relay cannot:
 
 - **Send commands**, Without your phone's private key, it cannot complete the handshake
-- **Read your traffic**, All messages are encrypted with AES-256-GCM after the handshake
-- **Forge messages**, GCM provides authenticated encryption; tampered messages are rejected
+- **Read your traffic**, All messages are encrypted with XSalsa20-Poly1305 (NaCl `box`) after the handshake
+- **Forge messages**, NaCl `box` provides authenticated encryption; tampered messages are rejected
 - **Replay old messages**, Each session derives fresh encryption keys
 
 ### Trust model


### PR DESCRIPTION
## Summary
- replace stale AES-256-GCM relay encryption references with the implemented Curve25519 + XSalsa20-Poly1305 / NaCl box wording
- align public security docs, architecture docs, and website privacy copy with SECURITY.md and packages/relay/src/crypto.ts

## Validation
- npm run format:check:files -- packages/website/src/routes/privacy.tsx public-docs/security.md docs/architecture.md
- npm run typecheck --workspace=@getpaseo/website
- rg "AES-256-GCM|AES[^A-Za-z]|GCM provides" public-docs docs packages/website/src/routes -n