### PR TITLE
fix(app): redirect optimistically when archiving worktree from toolbar

### DIFF
--- a/packages/app/src/git/use-actions.ts
+++ b/packages/app/src/git/use-actions.ts
@@ -1,14 +1,16 @@
 import { useState, useCallback, useEffect, useMemo, type ReactElement } from "react";
+import { router, type Href } from "expo-router";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { type CheckoutGitActionStatus, useCheckoutGitActionsStore } from "@/git/actions-store";
 import { type CheckoutStatusPayload, useCheckoutStatusQuery } from "@/git/use-status-query";
 import { type CheckoutPrStatusPayload, useCheckoutPrStatusQuery } from "@/git/use-pr-status-query";
 import { buildGitActions, narrowPullRequestState, type GitActions } from "@/git/policy";
 import type { CheckoutPrMergeMethod } from "@server/shared/messages";
-import { resolveNewAgentWorkingDir } from "@/utils/new-agent-routing";
 import { openExternalUrl } from "@/utils/open-external-url";
 import { useToast } from "@/contexts/toast-context";
-import { navigateToWorkspace } from "@/hooks/use-workspace-navigation";
+import { useSessionStore } from "@/stores/session-store";
+import { resolveWorkspaceIdByExecutionDirectory } from "@/utils/workspace-execution";
+import { buildWorkspaceArchiveRedirectRoute } from "@/utils/workspace-archive-navigation";
 
 export type { GitActionId, GitAction, GitActions } from "@/git/policy";
 
@@ -393,15 +395,22 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
       toast.error("Worktree path unavailable");
       return;
     }
-    const targetWorkingDir = resolveNewAgentWorkingDir(cwd, status ?? null);
-    void runArchiveWorktree({ serverId, cwd, worktreePath })
-      .then(() => {
-        navigateToWorkspace(serverId, targetWorkingDir);
-        return;
-      })
-      .catch((err) => {
-        toastActionError(err, "Failed to archive worktree");
-      });
+    const workspaces = useSessionStore.getState().sessions[serverId]?.workspaces;
+    const archivedWorkspaceId =
+      resolveWorkspaceIdByExecutionDirectory({
+        workspaces: workspaces?.values(),
+        workspaceDirectory: worktreePath,
+      }) ?? worktreePath;
+    router.replace(
+      buildWorkspaceArchiveRedirectRoute({
+        serverId,
+        archivedWorkspaceId,
+        workspaces: workspaces?.values() ?? [],
+      }) as Href,
+    );
+    void runArchiveWorktree({ serverId, cwd, worktreePath }).catch((err) => {
+      toastActionError(err, "Failed to archive worktree");
+    });
   }, [cwd, runArchiveWorktree, serverId, status, toast, toastActionError]);
 
   const baseRefLabel = useMemo(() => formatBaseRefLabel(baseRef), [baseRef]);


### PR DESCRIPTION
## Summary

- Toolbar archive (split-button) was deferring its redirect until the server confirmed the archive. In the meantime, the workspace was already optimistically removed from the session store, so the screen flashed the `WorkspaceMissing` ("workspace not found") gate, and on reconcile the user was sent to the main checkout's workspace route.
- Mirror the sidebar pattern: synchronously `router.replace` to the project's new-workspace screen (`/h/<server>/new?dir=<projectRoot>`) before kicking off `archiveWorktree`. Reconcile now only updates the store — no second navigation.
- If the server rejects the archive, the workspace is restored in the store (so it reappears in the sidebar) and an error toast fires; the user just stays on the new-workspace screen.

## Test plan

- [ ] From a worktree, click the toolbar archive button — verify you land directly on the new-workspace screen for the project, with no "workspace not found" flash and no follow-up redirect to the main checkout.
- [ ] Confirm the existing sidebar archive still behaves correctly (regression check).
- [ ] Force a server-side archive failure (e.g. busy worktree) — verify the workspace reappears in the sidebar and an error toast shows.