### PR TITLE
refactor(app): centralize tool call presentation

### DIFF
--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -67,6 +67,7 @@ import type { TodoEntry, UserMessageImageAttachment } from "@/types/stream";
 import type { AgentAttachment } from "@server/shared/messages";
 import type { ToolCallDetail } from "@server/server/agent/agent-sdk-types";
 import { buildToolCallPresentation } from "@/tool-calls/presentation";
+import { resolveToolCallIcon } from "@/utils/tool-call-icon";
 import {
   parseAssistantFileLink,
   parseInlinePathToken,
@@ -2877,6 +2878,7 @@ export const ToolCall = memo(function ToolCall({
         detail: effectiveDetail,
         metadata,
         cwd,
+        resolveIcon: resolveToolCallIcon,
       }),
     [toolName, status, error, effectiveDetail, metadata, cwd],
   );

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -66,13 +66,7 @@ import * as Clipboard from "expo-clipboard";
 import type { TodoEntry, UserMessageImageAttachment } from "@/types/stream";
 import type { AgentAttachment } from "@server/shared/messages";
 import type { ToolCallDetail } from "@server/server/agent/agent-sdk-types";
-import { buildToolCallDisplayModel } from "@/utils/tool-call-display";
-import { resolveToolCallIcon } from "@/utils/tool-call-icon";
-import { extractToolCallFilePath } from "@/utils/extract-tool-call-file-path";
-import {
-  hasMeaningfulToolCallDetail,
-  isPendingToolCallDetail,
-} from "@/utils/tool-call-detail-state";
+import { buildToolCallPresentation } from "@/tool-calls/presentation";
 import {
   parseAssistantFileLink,
   parseInlinePathToken,
@@ -2858,7 +2852,6 @@ export const ToolCall = memo(function ToolCall({
   const { openToolCall } = useToolCallSheet();
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // Check if we're on mobile (use bottom sheet) or desktop (inline expand)
   const isMobile = useIsCompactFormFactor();
 
   const effectiveDetail = useMemo<ToolCallDetail | undefined>(() => {
@@ -2875,63 +2868,35 @@ export const ToolCall = memo(function ToolCall({
     return undefined;
   }, [detail, args, result]);
 
-  const displayDetail = useMemo<ToolCallDetail>(
+  const presentation = useMemo(
     () =>
-      effectiveDetail ?? {
-        type: "unknown",
-        input: null,
-        output: null,
-      },
-    [effectiveDetail],
-  );
-
-  const displayModel = useMemo(
-    () =>
-      buildToolCallDisplayModel({
-        name: toolName,
-        status: status === "executing" ? "running" : status,
+      buildToolCallPresentation({
+        toolName,
+        status,
         error: error ?? null,
-        detail: displayDetail,
+        detail: effectiveDetail,
         metadata,
         cwd,
       }),
-    [toolName, status, error, displayDetail, metadata, cwd],
-  );
-  const displayName = displayModel.displayName;
-  const summary = displayModel.summary;
-  const errorText = displayModel.errorText;
-  const IconComponent = resolveToolCallIcon(toolName, effectiveDetail);
-  const isLoadingDetails = isPendingToolCallDetail({
-    detail: effectiveDetail,
-    status,
-    error,
-  });
-  const secondaryLabel = summary;
-
-  // Check if there's any content to display
-  const hasDetails = Boolean(error) || hasMeaningfulToolCallDetail(effectiveDetail);
-  const canOpenDetails = hasDetails || isLoadingDetails;
-
-  const extractedFilePath = useMemo(
-    () => extractToolCallFilePath(effectiveDetail),
-    [effectiveDetail],
+    [toolName, status, error, effectiveDetail, metadata, cwd],
   );
   const handleOpenFile = useMemo(() => {
-    if (!extractedFilePath || !onOpenFilePath) {
+    const openFilePath = presentation.openFilePath;
+    if (!openFilePath || !onOpenFilePath) {
       return undefined;
     }
-    return () => onOpenFilePath(extractedFilePath);
-  }, [extractedFilePath, onOpenFilePath]);
+    return () => onOpenFilePath(openFilePath);
+  }, [presentation.openFilePath, onOpenFilePath]);
 
   const handleToggle = useCallback(() => {
     if (isMobile) {
       openToolCall({
-        toolName,
-        displayName,
-        summary: secondaryLabel,
+        displayName: presentation.displayName,
+        summary: presentation.summary,
         detail: effectiveDetail,
-        errorText,
-        showLoadingSkeleton: isLoadingDetails,
+        errorText: presentation.errorText,
+        icon: presentation.icon,
+        showLoadingSkeleton: presentation.isLoadingDetails,
       });
     } else {
       setIsExpanded((prev) => !prev);
@@ -2939,12 +2904,12 @@ export const ToolCall = memo(function ToolCall({
   }, [
     isMobile,
     openToolCall,
-    toolName,
-    displayName,
-    secondaryLabel,
+    presentation.displayName,
+    presentation.summary,
+    presentation.errorText,
+    presentation.icon,
+    presentation.isLoadingDetails,
     effectiveDetail,
-    errorText,
-    isLoadingDetails,
   ]);
 
   useEffect(() => {
@@ -2980,14 +2945,14 @@ export const ToolCall = memo(function ToolCall({
     return (
       <ToolCallDetailsContent
         detail={effectiveDetail}
-        errorText={errorText}
+        errorText={presentation.errorText}
         maxHeight={400}
-        showLoadingSkeleton={isLoadingDetails}
+        showLoadingSkeleton={presentation.isLoadingDetails}
       />
     );
-  }, [isMobile, effectiveDetail, errorText, isLoadingDetails]);
+  }, [isMobile, effectiveDetail, presentation.errorText, presentation.isLoadingDetails]);
 
-  if (effectiveDetail?.type === "plan") {
+  if (presentation.isPlan && effectiveDetail?.type === "plan") {
     return (
       <PlanCard
         title="Plan"
@@ -3001,13 +2966,13 @@ export const ToolCall = memo(function ToolCall({
   return (
     <ExpandableBadge
       testID="tool-call-badge"
-      label={displayName}
-      secondaryLabel={secondaryLabel}
-      icon={IconComponent}
+      label={presentation.displayName}
+      secondaryLabel={presentation.summary}
+      icon={presentation.icon}
       isExpanded={!isMobile && isExpanded}
-      onToggle={canOpenDetails ? handleToggle : undefined}
+      onToggle={presentation.canOpenDetails ? handleToggle : undefined}
       onOpenFile={handleOpenFile}
-      renderDetails={canOpenDetails && !isMobile ? renderDetails : undefined}
+      renderDetails={presentation.canOpenDetails && !isMobile ? renderDetails : undefined}
       isLoading={status === "running" || status === "executing"}
       isError={status === "failed"}
       isLastInSequence={isLastInSequence}

--- a/packages/app/src/components/tool-call-sheet.tsx
+++ b/packages/app/src/components/tool-call-sheet.tsx
@@ -14,17 +14,17 @@ import {
   IsolatedBottomSheetModal,
   useIsolatedBottomSheetVisibility,
 } from "@/components/ui/isolated-bottom-sheet-modal";
-import { resolveToolCallIcon } from "@/utils/tool-call-icon";
+import type { ToolCallIconComponent } from "@/utils/tool-call-icon";
 import { ToolCallDetailsContent } from "./tool-call-details";
 
 // ----- Types -----
 
 export interface ToolCallSheetData {
-  toolName: string;
   displayName: string;
   summary?: string;
   detail?: ToolCallDetail;
   errorText?: string;
+  icon: ToolCallIconComponent;
   showLoadingSkeleton?: boolean;
 }
 
@@ -139,9 +139,7 @@ interface ToolCallSheetContentProps {
 
 function ToolCallSheetContent({ data, onClose }: ToolCallSheetContentProps) {
   const { theme } = useUnistyles();
-  const { toolName, displayName, detail, errorText, showLoadingSkeleton } = data;
-
-  const IconComponent = resolveToolCallIcon(toolName, detail);
+  const { displayName, detail, errorText, icon: IconComponent, showLoadingSkeleton } = data;
 
   return (
     <View style={styles.container}>

--- a/packages/app/src/tool-calls/presentation.test.ts
+++ b/packages/app/src/tool-calls/presentation.test.ts
@@ -1,20 +1,29 @@
-import { describe, expect, it, vi } from "vitest";
+import type { ToolCallDetail } from "@server/server/agent/agent-sdk-types";
+import { describe, expect, it } from "vitest";
 
-const iconMocks = vi.hoisted(() => ({
-  Bot: () => null,
-  Brain: () => null,
-  Eye: () => null,
-  MicVocal: () => null,
-  Pencil: () => null,
-  Search: () => null,
-  Sparkles: () => null,
-  SquareTerminal: () => null,
-  Wrench: () => null,
-}));
+import { buildToolCallPresentation, type ToolCallPresentationIcon } from "./presentation";
 
-vi.mock("lucide-react-native", () => iconMocks);
+const fakeIcons = {
+  brain: (() => null) as ToolCallPresentationIcon,
+  eye: (() => null) as ToolCallPresentationIcon,
+  wrench: (() => null) as ToolCallPresentationIcon,
+};
 
-import { buildToolCallPresentation } from "./presentation";
+function fakeResolveIcon(
+  toolName: string,
+  detail: ToolCallDetail | undefined,
+): ToolCallPresentationIcon {
+  if (detail?.type === "plan") {
+    return fakeIcons.brain;
+  }
+  if (detail?.type === "read") {
+    return fakeIcons.eye;
+  }
+  if (toolName === "exec_command") {
+    return fakeIcons.wrench;
+  }
+  return fakeIcons.wrench;
+}
 
 describe("tool-call presentation", () => {
   it("builds badge, detail, icon, and file-open policy in one model", () => {
@@ -28,12 +37,13 @@ describe("tool-call presentation", () => {
         filePath: "/tmp/repo/src/index.ts",
         content: "console.log('hi');",
       },
+      resolveIcon: fakeResolveIcon,
     });
 
     expect(presentation).toMatchObject({
       displayName: "Read",
       summary: "src/index.ts",
-      icon: iconMocks.Eye,
+      icon: fakeIcons.eye,
       isLoadingDetails: false,
       hasDetails: true,
       canOpenDetails: true,
@@ -52,11 +62,12 @@ describe("tool-call presentation", () => {
         input: {},
         output: null,
       },
+      resolveIcon: fakeResolveIcon,
     });
 
     expect(presentation).toMatchObject({
       displayName: "Exec Command",
-      icon: iconMocks.Wrench,
+      icon: fakeIcons.wrench,
       isLoadingDetails: true,
       hasDetails: false,
       canOpenDetails: true,
@@ -74,9 +85,10 @@ describe("tool-call presentation", () => {
         type: "plan",
         text: "1. Do the thing",
       },
+      resolveIcon: fakeResolveIcon,
     });
 
     expect(presentation.isPlan).toBe(true);
-    expect(presentation.icon).toBe(iconMocks.Brain);
+    expect(presentation.icon).toBe(fakeIcons.brain);
   });
 });

--- a/packages/app/src/tool-calls/presentation.test.ts
+++ b/packages/app/src/tool-calls/presentation.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+
+const iconMocks = vi.hoisted(() => ({
+  Bot: () => null,
+  Brain: () => null,
+  Eye: () => null,
+  MicVocal: () => null,
+  Pencil: () => null,
+  Search: () => null,
+  Sparkles: () => null,
+  SquareTerminal: () => null,
+  Wrench: () => null,
+}));
+
+vi.mock("lucide-react-native", () => iconMocks);
+
+import { buildToolCallPresentation } from "./presentation";
+
+describe("tool-call presentation", () => {
+  it("builds badge, detail, icon, and file-open policy in one model", () => {
+    const presentation = buildToolCallPresentation({
+      toolName: "read_file",
+      status: "completed",
+      error: null,
+      cwd: "/tmp/repo",
+      detail: {
+        type: "read",
+        filePath: "/tmp/repo/src/index.ts",
+        content: "console.log('hi');",
+      },
+    });
+
+    expect(presentation).toMatchObject({
+      displayName: "Read",
+      summary: "src/index.ts",
+      icon: iconMocks.Eye,
+      isLoadingDetails: false,
+      hasDetails: true,
+      canOpenDetails: true,
+      openFilePath: "/tmp/repo/src/index.ts",
+      isPlan: false,
+    });
+  });
+
+  it("marks running calls without meaningful detail as loading details", () => {
+    const presentation = buildToolCallPresentation({
+      toolName: "exec_command",
+      status: "running",
+      error: null,
+      detail: {
+        type: "unknown",
+        input: {},
+        output: null,
+      },
+    });
+
+    expect(presentation).toMatchObject({
+      displayName: "Exec Command",
+      icon: iconMocks.Wrench,
+      isLoadingDetails: true,
+      hasDetails: false,
+      canOpenDetails: true,
+      openFilePath: null,
+      isPlan: false,
+    });
+  });
+
+  it("keeps plan calls out of the expandable badge path", () => {
+    const presentation = buildToolCallPresentation({
+      toolName: "ExitPlanMode",
+      status: "completed",
+      error: null,
+      detail: {
+        type: "plan",
+        text: "1. Do the thing",
+      },
+    });
+
+    expect(presentation.isPlan).toBe(true);
+    expect(presentation.icon).toBe(iconMocks.Brain);
+  });
+});

--- a/packages/app/src/tool-calls/presentation.ts
+++ b/packages/app/src/tool-calls/presentation.ts
@@ -1,0 +1,72 @@
+import type { ToolCallDetail } from "@server/server/agent/agent-sdk-types";
+import type { ToolCallDisplayInput } from "@/utils/tool-call-display";
+import { buildToolCallDisplayModel } from "@/utils/tool-call-display";
+import { extractToolCallFilePath } from "@/utils/extract-tool-call-file-path";
+import {
+  hasMeaningfulToolCallDetail,
+  isPendingToolCallDetail,
+} from "@/utils/tool-call-detail-state";
+import { resolveToolCallIcon, type ToolCallIconComponent } from "@/utils/tool-call-icon";
+
+type ToolCallStatus = "executing" | "running" | "completed" | "failed" | "canceled";
+
+interface BuildToolCallPresentationInput {
+  toolName: string;
+  status: ToolCallStatus;
+  error: unknown;
+  detail?: ToolCallDetail;
+  cwd?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ToolCallPresentation {
+  displayName: string;
+  summary?: string;
+  errorText?: string;
+  icon: ToolCallIconComponent;
+  isLoadingDetails: boolean;
+  hasDetails: boolean;
+  canOpenDetails: boolean;
+  openFilePath: string | null;
+  isPlan: boolean;
+}
+
+function displayStatus(status: ToolCallStatus): ToolCallDisplayInput["status"] {
+  return status === "executing" ? "running" : status;
+}
+
+function displayDetail(detail: ToolCallDetail | undefined): ToolCallDetail {
+  return detail ?? { type: "unknown", input: null, output: null };
+}
+
+export function buildToolCallPresentation(
+  input: BuildToolCallPresentationInput,
+): ToolCallPresentation {
+  const detailForDisplay = displayDetail(input.detail);
+  const displayModel = buildToolCallDisplayModel({
+    name: input.toolName,
+    status: displayStatus(input.status),
+    error: input.error ?? null,
+    detail: detailForDisplay,
+    metadata: input.metadata,
+    cwd: input.cwd,
+  });
+  const isLoadingDetails = isPendingToolCallDetail({
+    detail: input.detail,
+    status: input.status,
+    error: input.error,
+  });
+  const hasDetails = Boolean(input.error) || hasMeaningfulToolCallDetail(input.detail);
+
+  return {
+    displayName: displayModel.displayName,
+    summary: displayModel.summary,
+    errorText: displayModel.errorText,
+    icon: resolveToolCallIcon(input.toolName, input.detail),
+    isLoadingDetails,
+    hasDetails,
+    canOpenDetails: hasDetails || isLoadingDetails,
+    openFilePath: extractToolCallFilePath(input.detail),
+    isPlan: input.detail?.type === "plan",
+  };
+}

--- a/packages/app/src/tool-calls/presentation.ts
+++ b/packages/app/src/tool-calls/presentation.ts
@@ -1,3 +1,4 @@
+import type { ComponentType } from "react";
 import type { ToolCallDetail } from "@server/server/agent/agent-sdk-types";
 import type { ToolCallDisplayInput } from "@/utils/tool-call-display";
 import { buildToolCallDisplayModel } from "@/utils/tool-call-display";
@@ -6,9 +7,9 @@ import {
   hasMeaningfulToolCallDetail,
   isPendingToolCallDetail,
 } from "@/utils/tool-call-detail-state";
-import { resolveToolCallIcon, type ToolCallIconComponent } from "@/utils/tool-call-icon";
 
 type ToolCallStatus = "executing" | "running" | "completed" | "failed" | "canceled";
+export type ToolCallPresentationIcon = ComponentType<{ size?: number; color?: string }>;
 
 interface BuildToolCallPresentationInput {
   toolName: string;
@@ -17,19 +18,25 @@ interface BuildToolCallPresentationInput {
   detail?: ToolCallDetail;
   cwd?: string;
   metadata?: Record<string, unknown>;
+  resolveIcon: ToolCallIconResolver;
 }
 
 export interface ToolCallPresentation {
   displayName: string;
   summary?: string;
   errorText?: string;
-  icon: ToolCallIconComponent;
+  icon: ToolCallPresentationIcon;
   isLoadingDetails: boolean;
   hasDetails: boolean;
   canOpenDetails: boolean;
   openFilePath: string | null;
   isPlan: boolean;
 }
+
+export type ToolCallIconResolver = (
+  toolName: string,
+  detail: ToolCallDetail | undefined,
+) => ToolCallPresentationIcon;
 
 function displayStatus(status: ToolCallStatus): ToolCallDisplayInput["status"] {
   return status === "executing" ? "running" : status;
@@ -62,7 +69,7 @@ export function buildToolCallPresentation(
     displayName: displayModel.displayName,
     summary: displayModel.summary,
     errorText: displayModel.errorText,
-    icon: resolveToolCallIcon(input.toolName, input.detail),
+    icon: input.resolveIcon(input.toolName, input.detail),
     isLoadingDetails,
     hasDetails,
     canOpenDetails: hasDetails || isLoadingDetails,


### PR DESCRIPTION
## Summary
- add a tool-call presentation module that owns display, icon, detail-open, pending, and file-open policy
- make the timeline badge and mobile sheet consume the presentation model instead of recomputing pieces separately
- cover the new presentation boundary with focused unit tests

## Verification
- npm run test --workspace=@getpaseo/app -- src/tool-calls/presentation.test.ts --bail=1
- npm run typecheck
- npm run lint
- npm run format
