### PR TITLE
chore: issue forms, PR template, contributor guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,121 @@
+name: Bug report
+description: Something is broken or doesn't behave the way it should.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening, please:
+
+        - search existing issues for the same symptom
+        - try to reproduce on the latest version
+        - if it's a UI bug, capture a screenshot or short video. text descriptions of UI bugs almost always lose detail.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What's broken
+      description: What happened, and what did you expect to happen instead?
+      placeholder: |
+        I tried to X, expected Y, got Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The shortest sequence that triggers the bug. If you can't reproduce on demand, say so.
+      placeholder: |
+        1. Open the desktop app
+        2. Pair a daemon
+        3. Click X
+        4. ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where did this happen
+      description: The surface you saw the bug on. Pick the closest match.
+      options:
+        - iOS app
+        - Android app
+        - Web (browser)
+        - Desktop (Electron)
+        - CLI
+        - Daemon
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: paseo-version
+    attributes:
+      label: Paseo version
+      description: Settings → About in the app, or `paseo --version` from the CLI.
+      placeholder: "0.1.71"
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      description: Only relevant for desktop, CLI, or daemon issues. Skip for mobile or web.
+      placeholder: "macOS 15.2, Windows 11, Ubuntu 24.04"
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: Agent provider
+      description: If the bug involves a specific agent provider, pick which one.
+      options:
+        - Not relevant
+        - Claude Code
+        - Codex
+        - OpenCode
+        - Custom provider
+
+  - type: textarea
+    id: provider-details
+    attributes:
+      label: Provider configuration
+      description: |
+        If the bug involves an agent, what version are you on and what API are you using? Provider behavior changes a lot across versions and API backends.
+      placeholder: |
+        Claude Code v1.2.3 with Anthropic API
+        Codex CLI v0.5.0 with OpenAI API
+        OpenCode v0.3.1
+        (or paste the relevant section of ~/.paseo/config.json for custom providers)
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Paste relevant log output. Strongly preferred for crashes and daemon issues.
+
+        - **Daemon log:** `~/.paseo/daemon.log` (override with `$PASEO_HOME`)
+        - **Electron log (macOS):** `~/Library/Logs/Paseo/main.log`
+        - **Electron log (Windows):** `%APPDATA%\Paseo\logs\main.log`
+        - **Electron log (Linux):** `~/.config/Paseo/logs/main.log`
+
+        Paste the **full log around the time of the bug**, not a summary. If you used an AI to investigate, paste the raw log it read, not the AI's interpretation. AI summaries skew the signal and waste my time.
+      render: text
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or video
+      description: |
+        **Required for UI bugs.** Drag and drop directly into this field. Short videos beat screenshots for anything involving interaction or animation.
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        **A note on AI-assisted reports.** Using an agent to gather information (logs, repro steps, version checks) is fine and useful. Using an agent to *diagnose* the bug and then submitting only that diagnosis is not. Agents routinely correlate adjacent log lines as cause-and-effect when they aren't related, and once a report is filtered through an AI summary I lose the signal I need to actually fix the bug. Paste the raw inputs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord
+    url: https://discord.gg/jz8T2uahpH
+    about: Quick questions, sharing a video of a bug, or anything that's better as a chat. A lot of issues start better here.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Propose a new feature or a change to existing behavior.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Paseo is opinionated and BDFL-run. Feature proposals get evaluated against product fit, not just usefulness. Big ideas are better discussed in [Discord](https://discord.gg/jz8T2uahpH) before opening an issue.
+
+        Please don't open a feature request and a PR at the same time. Get alignment on the idea first.
+
+  - type: checkboxes
+    id: prior-search
+    attributes:
+      label: Prior search
+      options:
+        - label: I searched existing issues and discussions, and this isn't already proposed.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the problem
+      description: What are you actually trying to do, and why is the current behavior in the way?
+      placeholder: |
+        When I'm doing X, I want to Y, but Paseo currently Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would solve it
+      description: A rough sketch of the change. Mockups, screenshots from other apps, or a short video are very welcome, especially for UI proposals.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: Optional. What else did you try, and why doesn't it work?

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -6,9 +6,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Paseo is opinionated and BDFL-run. Feature proposals get evaluated against product fit, not just usefulness. Big ideas are better discussed in [Discord](https://discord.gg/jz8T2uahpH) before opening an issue.
+        Paseo is opinionated and maintained by one person. Feature requests are welcome, but they get evaluated against product fit, not just usefulness, and the bar is whether the change keeps the product lean enough for one person to maintain.
 
-        Please don't open a feature request and a PR at the same time. Get alignment on the idea first.
+        Big ideas are better discussed in [Discord](https://discord.gg/jz8T2uahpH) first. And please don't open a feature request and a PR at the same time, get alignment on the idea before writing code.
 
   - type: checkboxes
     id: prior-search

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!--
+Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.
+
+If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
+-->
+
+### Linked issue
+
+Closes #
+
+<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->
+
+### Type of change
+
+- [ ] Bug fix
+- [ ] New feature (with prior issue + design alignment)
+- [ ] Refactor / code improvement
+- [ ] Docs
+
+### What does this PR do
+
+<!-- A short description of the change in your own words. What was wrong, what you changed, why it works. If you can't explain this briefly, the PR is probably too big. -->
+
+### How did you verify it
+
+<!--
+This is the section I read most carefully. I need to see that *you* tested this, not that the diff looks plausible.
+
+- For UI changes: a screenshot or short video on every affected platform (mobile, web, desktop). UI claims without visual proof are not enough.
+- For behavior changes: the actual steps you ran, and what you observed.
+- For bug fixes: how you reproduced the bug before, and confirmed it's fixed after.
+
+AI-generated PR descriptions are fine in principle. AI-generated *verification claims* with no actual testing behind them are not, and they're easy to spot.
+-->
+
+### Checklist
+
+- [ ] One focused change. Unrelated cleanups split out.
+- [ ] `npm run typecheck` passes
+- [ ] `npm run lint` passes
+- [ ] `npm run format` ran (Biome)
+- [ ] UI changes include screenshots or video for every affected platform
+- [ ] Tests added or updated where it made sense

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,23 @@
 # Contributing to Paseo
 
-Thanks for taking the time to contribute.
-
 ## How this project works
 
-Paseo is opinionated, and it's a one-person project. I read every issue and PR myself, so the cost of reviewing a contribution is real.
+Paseo is opinionated and maintained by one person. I read every issue and PR myself, so review cost is real.
 
-That shapes what does and doesn't work here:
+- **Feature requests are welcome.** Open an issue describing the problem. Get a thumbs up before writing code. Big ideas are better discussed in [Discord](https://discord.gg/jz8T2uahpH) first.
+- **Objective bug fixes don't need a prior issue.** Reference what's broken, keep the diff narrow, open the PR.
+- **The product stays lean.** I'll close, scope down, or rewrite PRs that add surface area I don't want to maintain, even if the code is fine.
 
-- **Feature requests are welcome.** Open an issue describing the problem you're hitting. I take that input seriously, and a lot of what's in Paseo today came from someone explaining their pain in a thread.
-- **Drive-by feature PRs without a prior issue are not.** A large over-indexed feature that solves one person's edge case is the exact thing that holds the product back, and saying no after the code is written is expensive for both of us. Open the issue first, get a thumbs up on the shape, then write the code.
-- **Objective bug fixes don't need a prior issue.** If something is provably broken and your PR fixes it without dragging in unrelated changes, just open it.
-- The product stays lean. I'll close, scope down, or rewrite PRs that add surface area I don't want to maintain, even if the code is fine.
-- I may rewrite, split, cherry-pick from, or close any PR at my discretion. There's no obligation to merge as-submitted.
+## Reporting bugs
 
-This isn't meant to discourage you. If you've taken the time to write up a problem clearly, that already puts you ahead.
+Fill in the bug report form. The fields are there because asking back for the surface, version, provider config, and logs is where most of my time on a bad report goes.
 
-## How to contribute
-
-1. **For features or behavior changes: open an issue first.** Describe the problem and the proposed change. Get a thumbs up before writing code. PRs that try to land a feature without an issue are the most common reason a contribution gets rejected.
-2. **For objective bug fixes: just open the PR.** Reference the bug, keep the diff narrow, and show that you tested it. No prior issue needed if the bug is clear.
-3. **Keep it small.** One bug, one flow, one focused change.
-
-If you want to propose a direction change, start a conversation in [Discord](https://discord.gg/jz8T2uahpH) before opening anything.
-
-## Reporting issues
-
-The bug report form asks for the surface, version, provider configuration, logs, and screenshots. Fill it in. Most of my time on a bad report goes into asking back for what should already be in the issue.
-
-A few things that make reports useful:
-
-- **Full logs, not AI summaries.** Using an agent to grab the relevant log section is fine. Submitting only the agent's _interpretation_ of the log is not. Agents routinely correlate adjacent log lines as cause-and-effect when they aren't, and once a report is filtered through that, the signal I need to fix the bug is gone. Paste the raw log.
-- **Use agents for information gathering, not diagnosis.** An agent that grabs the daemon log, the version, and the OS for you is helpful. An agent that submits its own theory of the bug is noise 99% of the time.
-- **Screenshots and videos for UI bugs.** Text descriptions of UI bugs lose detail. A 10-second screen recording is worth a paragraph.
-- **One bug per issue.** If you found three things, open three issues.
+- **Full logs, not AI summaries.** Use an agent to grab the relevant log section if you want, but paste the raw log. Agents routinely correlate adjacent lines as cause-and-effect when they aren't, and once a report is filtered through that the signal I need is gone.
+- **Agents for information gathering, not diagnosis.** A bot that grabs your daemon log, version, and OS is helpful. A bot that submits its own theory of the bug is noise 99% of the time.
+- **Screenshots or video for UI bugs.** A 10-second recording beats a paragraph.
+- **One bug per issue.** Three findings, three issues.
 
 ## Before you start
-
-Please read these first:
 
 - [README.md](README.md)
 - [docs/architecture.md](docs/architecture.md)
@@ -48,146 +28,36 @@ Please read these first:
 
 ## What is most helpful
 
-The most useful contributions right now are:
-
-- bug fixes
-- windows and linux specific fixes
+- bug fixes (especially Windows and Linux)
 - regression fixes
 - doc improvements
-- packaging / platform fixes
-- focused UX improvements that fit the existing product direction
+- packaging and platform fixes
+- focused UX improvements that fit the product direction
 - tests that lock down important behavior
-
-## Scope expectations
-
-Please keep PRs narrow.
-
-Good:
-
-- fix one bug
-- improve one flow
-- add one focused panel or command
-- tighten one piece of UI
-
-Bad:
-
-- combine multiple product ideas in one PR
-- bundle unrelated refactors with a feature
-- sneak in roadmap decisions
-
-If a contribution contains multiple ideas, split it up.
-
-## Product fit matters
-
-Paseo is an opinionated product.
-
-When reviewing contributions, the bar is not just:
-
-- is this useful?
-- is this well implemented?
-
-It is also:
-
-- does this fit Paseo?
-- does this add product surface that will be hard to maintain?
-- does the value justify the maintenance surface it adds?
-- does this solve a common need or over-serve an edge case?
-- does this preserve the product's current direction?
 
 ## Development setup
 
-### Prerequisites
-
-- Node.js matching `.tool-versions`
-- npm workspaces
-
-### Start local development
-
 ```bash
-# runs both daemon and expo app
-npm run dev
-```
-
-Useful commands:
-
-```bash
+npm run dev               # daemon + expo
 npm run dev:server
 npm run dev:app
 npm run dev:desktop
 npm run dev:website
-npm run cli -- ls -a -g
 ```
 
-Read [docs/development.md](docs/development.md) for build-sync gotchas, local state, ports, and daemon details.
+[docs/development.md](docs/development.md) covers build sync, local state, and ports. Coding rules live in [docs/coding-standards.md](docs/coding-standards.md).
 
-## Multi-platform testing
+## Pull requests
 
-Paseo ships to mobile (iOS/Android), web, and desktop (Electron). Every UI change must be tested on mobile and web at minimum, and desktop if relevant. Things that look fine on one surface regularly break on another.
+- One focused change per PR. Split unrelated cleanups out.
+- Reference the issue you're fixing, unless it's a small objective bug.
+- UI changes need screenshots or video on every affected platform (mobile, web, desktop). Things that look fine on one surface regularly break on another.
+- `npm run typecheck` and `npm run lint` must pass.
+- Don't make breaking WebSocket or protocol changes. Old apps and old daemons coexist in the wild.
+- The PR template applies whether you used the web UI or `gh pr create`. Don't strip it out.
 
-Common checks:
-
-```bash
-npm run typecheck
-npm run test --workspaces --if-present
-```
-
-Important rules:
-
-- always run `npm run typecheck` after changes
-- tests should be deterministic
-- prefer real dependencies over mocks when possible
-- do not make breaking WebSocket / protocol changes
-- app and daemon versions in the wild lag each other, so compatibility matters
-
-If you touch protocol or shared client/server behavior, read the compatibility notes in [CLAUDE.md](CLAUDE.md).
-
-## Coding standards
-
-Paseo has explicit standards. Follow them.
-
-The full guide lives in [docs/coding-standards.md](docs/coding-standards.md).
-
-## PR checklist
-
-Before opening a PR, make sure:
-
-- there was prior discussion and alignment on scope (issue or conversation), unless it's an objective bug fix
-- the change is focused, one idea per PR
-- the PR description explains what changed and why, in your own words
-- **UI changes include screenshots or videos** for every affected platform (mobile, web, desktop)
-- UI changes have been tested on mobile and web at minimum
-- typecheck passes
-- tests pass, or you clearly explain what could not be run
-- relevant docs were updated if needed
-
-The PR template applies whether you opened the PR through the web UI or `gh pr create`. Don't strip it out.
-
-## On AI-assisted contributions
-
-AI is fine. I use it. The bar isn't whether AI helped you write the code or the description, the bar is whether _you_ tested it and understand why it works.
-
-What that looks like in practice:
-
-- **Verification is the section I read most carefully.** "I ran X, observed Y" with a screenshot or a log snippet beats any amount of plausible-looking prose.
-- **A wall of confident AI-generated description with no evidence of testing is a red flag.** It often means the PR was generated end-to-end and never run. If that's what I'm seeing, I'll usually close.
-- **If you don't understand why your change works, say so.** I'd rather see "I'm not sure why this fixes it but here's the repro before and after" than a fabricated explanation.
-
-## Communication
-
-If you are unsure whether something fits, ask first.
-
-That is especially true for:
-
-- new core UX
-- naming / terminology changes
-- new extension points
-- new orchestration models
-- anything that would be hard to remove later
-
-Early alignment saves everyone time.
+**On AI-assisted PRs.** AI in the loop is fine. The bar is whether _you_ tested the change and can explain why it works. A confident wall of AI prose with no evidence of testing is a red flag and usually gets closed. If you don't fully understand why your fix works, say so directly. "Here's the repro before and after, not sure why this fixes it" is much better than a fabricated explanation.
 
 ## Forks are fine
 
-If you want to explore a different product direction, a fork is completely fine.
-
-Paseo is open source on purpose. Not every idea needs to land in the main repo to be valuable.
+If you want to explore a different product direction, fork. Paseo is open source on purpose. Not every idea needs to land here to be valuable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,17 @@ Thanks for taking the time to contribute.
 
 ## How this project works
 
-Paseo is a BDFL project. Product direction, scope, and what ships are the maintainer's call.
+Paseo is opinionated, and it's a one-person project. I read every issue and PR myself, so the cost of reviewing a contribution is real.
 
-This means:
+That shapes what does and doesn't work here:
 
-- Feature PRs without prior discussion will likely be closed, scoped down, or heavily modified. Open an issue first.
-- Objective bug fixes are welcome without prior discussion. If something is provably broken and your PR fixes it without dragging in unrelated changes, just open it.
-- The maintainer may rewrite, split, cherry-pick from, or close any PR at their discretion.
-- There is no obligation to merge a PR as-submitted, regardless of code quality.
+- **Feature requests are welcome.** Open an issue describing the problem you're hitting. I take that input seriously, and a lot of what's in Paseo today came from someone explaining their pain in a thread.
+- **Drive-by feature PRs without a prior issue are not.** A large over-indexed feature that solves one person's edge case is the exact thing that holds the product back, and saying no after the code is written is expensive for both of us. Open the issue first, get a thumbs up on the shape, then write the code.
+- **Objective bug fixes don't need a prior issue.** If something is provably broken and your PR fixes it without dragging in unrelated changes, just open it.
+- The product stays lean. I'll close, scope down, or rewrite PRs that add surface area I don't want to maintain, even if the code is fine.
+- I may rewrite, split, cherry-pick from, or close any PR at my discretion. There's no obligation to merge as-submitted.
 
-This is not meant to discourage contributions. It is meant to set clear expectations so nobody wastes their time.
+This isn't meant to discourage you. If you've taken the time to write up a problem clearly, that already puts you ahead.
 
 ## How to contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ Paseo is a BDFL project. Product direction, scope, and what ships are the mainta
 
 This means:
 
-- PRs submitted without prior discussion will likely be rejected, heavily modified, or scoped down.
+- Feature PRs without prior discussion will likely be closed, scoped down, or heavily modified. Open an issue first.
+- Objective bug fixes are welcome without prior discussion. If something is provably broken and your PR fixes it without dragging in unrelated changes, just open it.
 - The maintainer may rewrite, split, cherry-pick from, or close any PR at their discretion.
 - There is no obligation to merge a PR as-submitted, regardless of code quality.
 
@@ -16,11 +17,22 @@ This is not meant to discourage contributions. It is meant to set clear expectat
 
 ## How to contribute
 
-1. **Open an issue first.** Describe the problem or improvement. Get a thumbs up before writing code.
-2. **Keep it small.** One bug, one flow, one focused change.
-3. **Open a PR** once there is alignment on scope.
+1. **For features or behavior changes: open an issue first.** Describe the problem and the proposed change. Get a thumbs up before writing code. PRs that try to land a feature without an issue are the most common reason a contribution gets rejected.
+2. **For objective bug fixes: just open the PR.** Reference the bug, keep the diff narrow, and show that you tested it. No prior issue needed if the bug is clear.
+3. **Keep it small.** One bug, one flow, one focused change.
 
-If you want to propose a direction change, start a conversation.
+If you want to propose a direction change, start a conversation in [Discord](https://discord.gg/jz8T2uahpH) before opening anything.
+
+## Reporting issues
+
+The bug report form asks for the surface, version, provider configuration, logs, and screenshots. Fill it in. Most of my time on a bad report goes into asking back for what should already be in the issue.
+
+A few things that make reports useful:
+
+- **Full logs, not AI summaries.** Using an agent to grab the relevant log section is fine. Submitting only the agent's _interpretation_ of the log is not. Agents routinely correlate adjacent log lines as cause-and-effect when they aren't, and once a report is filtered through that, the signal I need to fix the bug is gone. Paste the raw log.
+- **Use agents for information gathering, not diagnosis.** An agent that grabs the daemon log, the version, and the OS for you is helpful. An agent that submits its own theory of the bug is noise 99% of the time.
+- **Screenshots and videos for UI bugs.** Text descriptions of UI bugs lose detail. A 10-second screen recording is worth a paragraph.
+- **One bug per issue.** If you found three things, open three issues.
 
 ## Before you start
 
@@ -138,14 +150,26 @@ The full guide lives in [docs/coding-standards.md](docs/coding-standards.md).
 
 Before opening a PR, make sure:
 
-- there was prior discussion and alignment on scope (issue or conversation)
+- there was prior discussion and alignment on scope (issue or conversation), unless it's an objective bug fix
 - the change is focused, one idea per PR
-- the PR description explains what changed and why
+- the PR description explains what changed and why, in your own words
 - **UI changes include screenshots or videos** for every affected platform (mobile, web, desktop)
 - UI changes have been tested on mobile and web at minimum
 - typecheck passes
 - tests pass, or you clearly explain what could not be run
 - relevant docs were updated if needed
+
+The PR template applies whether you opened the PR through the web UI or `gh pr create`. Don't strip it out.
+
+## On AI-assisted contributions
+
+AI is fine. I use it. The bar isn't whether AI helped you write the code or the description, the bar is whether _you_ tested it and understand why it works.
+
+What that looks like in practice:
+
+- **Verification is the section I read most carefully.** "I ran X, observed Y" with a screenshot or a log snippet beats any amount of plausible-looking prose.
+- **A wall of confident AI-generated description with no evidence of testing is a red flag.** It often means the PR was generated end-to-end and never run. If that's what I'm seeing, I'll usually close.
+- **If you don't understand why your change works, say so.** I'd rather see "I'm not sure why this fixes it but here's the repro before and after" than a fabricated explanation.
 
 ## Communication
 


### PR DESCRIPTION
## Summary

Borrowed the high-leverage pieces from [opencode's GitHub setup](https://github.com/sst/opencode/tree/dev/.github) and adapted them for Paseo's scale. Skipped the heavy-handed parts (no auto-close bot, no vouch system, no LLM duplicate checker).

What's new:

- **Issue forms** under `.github/ISSUE_TEMPLATE/` with structured fields so I stop having to ask back for OS, version, provider, logs every time.
  - `bug-report.yml`: description, repro, surface (iOS/Android/Web/Desktop/CLI/Daemon), Paseo version, OS version, agent provider, provider config, logs (with paths to daemon and electron logs), screenshots/video. Closes with a note codifying the agent-noise gripe (use agents to gather info, not to diagnose; paste full logs not AI summaries).
  - `feature-request.yml`: short. Routes big ideas to Discord first.
  - `config.yml`: blank issues disabled, casual questions routed to Discord.
- **PR template** at `.github/PULL_REQUEST_TEMPLATE.md`. Single template, type-of-change checkboxes, explicit verification section ("how did you verify it"), checklist with screenshots/video required for UI on every platform. AI-assisted PRs aren't banned, but the bar is proof of testing.
- **CONTRIBUTING.md** softened in two ways:
  - Drive-by *bug fixes* are now explicitly welcome. The strict stance stays for feature PRs without a prior issue.
  - New "Reporting issues" section codifying full-log-over-AI-summary and "agents for info gathering, not diagnosis."
  - New "On AI-assisted contributions" section explaining the actual bar (verification + understanding) instead of banning AI prose.

## Test plan

- [x] YAML validates (issue forms parse with `yaml.safe_load`)
- [x] `npm run format` clean
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean (lefthook ran on commit)
- [ ] Once merged, sanity-check that the bug-report form renders correctly when opening a new issue on the repo
- [ ] Verify Discord link from `config.yml` shows up on the "New issue" picker page