### PR TITLE
test(codex): regression coverage for app-server JSON-RPC dispatch

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -98,6 +98,122 @@ function markdownImageSource(markdown: string): string {
   return match[1].replace(/\\\)/g, ")");
 }
 
+function createChildProcessStub(): ChildProcessWithoutNullStreams {
+  const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+  child.stdin = new PassThrough() as ChildProcessWithoutNullStreams["stdin"];
+  child.stdout = new PassThrough() as ChildProcessWithoutNullStreams["stdout"];
+  child.stderr = new PassThrough() as ChildProcessWithoutNullStreams["stderr"];
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+    queueMicrotask(() => child.emit("exit", null, signal ?? null));
+    return true;
+  }) as ChildProcessWithoutNullStreams["kill"];
+  return child;
+}
+
+function createScriptedCodexPeer(
+  child: ChildProcessWithoutNullStreams,
+  handlers: Record<string, (params: unknown) => unknown>,
+) {
+  const messages: Record<string, unknown>[] = [];
+  const errors: Error[] = [];
+  const waiters = new Set<{
+    predicate: (message: Record<string, unknown>) => boolean;
+    resolve: (message: Record<string, unknown>) => void;
+  }>();
+  let buffer = "";
+
+  const processMessage = (message: Record<string, unknown>) => {
+    messages.push(message);
+    for (const waiter of Array.from(waiters)) {
+      if (waiter.predicate(message)) {
+        waiters.delete(waiter);
+        waiter.resolve(message);
+      }
+    }
+
+    if (typeof message.id !== "number" || typeof message.method !== "string") {
+      return;
+    }
+
+    const handler = handlers[message.method];
+    if (!handler) {
+      errors.push(new Error(`Unexpected Codex app-server request: ${message.method}`));
+      return;
+    }
+
+    Promise.resolve(handler(message.params))
+      .then((result) => {
+        child.stdout.write(`${JSON.stringify({ id: message.id, result })}\n`);
+        return undefined;
+      })
+      .catch((error) => {
+        child.stdout.write(
+          `${JSON.stringify({
+            id: message.id,
+            error: { message: error instanceof Error ? error.message : String(error) },
+          })}\n`,
+        );
+        return undefined;
+      });
+  };
+
+  child.stdin.on("data", (chunk) => {
+    buffer += chunk.toString();
+    for (;;) {
+      const newlineIndex = buffer.indexOf("\n");
+      if (newlineIndex === -1) {
+        break;
+      }
+      const line = buffer.slice(0, newlineIndex).trim();
+      buffer = buffer.slice(newlineIndex + 1);
+      if (!line) {
+        continue;
+      }
+      try {
+        const parsed: unknown = JSON.parse(line);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          processMessage(parsed as Record<string, unknown>);
+        }
+      } catch (error) {
+        errors.push(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+  });
+
+  return {
+    assertNoErrors() {
+      if (errors.length > 0) {
+        throw errors[0];
+      }
+    },
+    waitForMessage(
+      predicate: (message: Record<string, unknown>) => boolean,
+      label: string,
+    ): Promise<Record<string, unknown>> {
+      const existing = messages.find(predicate);
+      if (existing) {
+        return Promise.resolve(existing);
+      }
+      return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          waiters.delete(waiter);
+          reject(new Error(`Timed out waiting for ${label}`));
+        }, 1000);
+        const waiter = {
+          predicate,
+          resolve: (message: Record<string, unknown>) => {
+            clearTimeout(timeout);
+            resolve(message);
+          },
+        };
+        waiters.add(waiter);
+      });
+    },
+  };
+}
+
 describe("Codex app-server provider", () => {
   test("passes ephemeral: true to thread/start when constructed as ephemeral", async () => {
     const requests: Array<{ method: string; params: unknown }> = [];
@@ -182,6 +298,103 @@ describe("Codex app-server provider", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  test("round-trips server-initiated command approvals through the real app-server transport", async () => {
+    const child = createChildProcessStub();
+    const peer = createScriptedCodexPeer(child, {
+      initialize: () => ({}),
+      "collaborationMode/list": () => ({ data: [] }),
+      "skills/list": () => ({ data: [] }),
+    });
+    const session = new __codexAppServerInternals.CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => child,
+    );
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    await session.connect();
+    peer.assertNoErrors();
+
+    const permissionRequested = new Promise<
+      Extract<AgentStreamEvent, { type: "permission_requested" }>
+    >((resolve, reject) => {
+      const existing = events.find(
+        (event): event is Extract<AgentStreamEvent, { type: "permission_requested" }> =>
+          event.type === "permission_requested",
+      );
+      if (existing) {
+        resolve(existing);
+        return;
+      }
+      const timeout = setTimeout(() => {
+        unsubscribe();
+        reject(new Error("Timed out waiting for permission_requested"));
+      }, 1000);
+      const unsubscribe = session.subscribe((event) => {
+        if (event.type !== "permission_requested") {
+          return;
+        }
+        clearTimeout(timeout);
+        unsubscribe();
+        resolve(event);
+      });
+    });
+
+    child.stdout.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 41,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          itemId: "exec-approval-1",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          command: "git restore README.md",
+          cwd: "/workspace/project",
+          reason: "requires escalated permissions",
+        },
+      })}\n`,
+    );
+
+    const permissionEvent = await permissionRequested;
+    expect(permissionEvent.request).toMatchObject({
+      id: "permission-exec-approval-1",
+      provider: "codex",
+      name: "CodexBash",
+      kind: "tool",
+      title: "Run command: git restore README.md",
+      description: "requires escalated permissions",
+      input: {
+        command: "git restore README.md",
+        cwd: "/workspace/project",
+      },
+      metadata: {
+        itemId: "exec-approval-1",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+    });
+
+    await session.respondToPermission(permissionEvent.request.id, { behavior: "allow" });
+
+    await expect(
+      peer.waitForMessage(
+        (message) =>
+          message.id === 41 &&
+          !("method" in message) &&
+          JSON.stringify(message.result) === JSON.stringify({ decision: "accept" }),
+        "command approval response",
+      ),
+    ).resolves.toMatchObject({
+      id: 41,
+      result: { decision: "accept" },
+    });
+    peer.assertNoErrors();
+    await session.close();
   });
 
   test("lists repo skills using WorkspaceGitService repo-root resolution", async () => {

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.test.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.test.ts
@@ -32,19 +32,27 @@ describe("Codex app-server transport", () => {
     child.stdin.end();
   });
 
-  test("answers server-initiated requests through registered handlers", async () => {
+  test.each([
+    "item/commandExecution/requestApproval",
+    "item/fileChange/requestApproval",
+    "item/tool/requestUserInput",
+    "tool/requestUserInput",
+  ])("answers server-initiated %s requests through registered handlers", async (method) => {
     const child = createChildProcessStub();
     const client = new CodexAppServerClient(child, createTestLogger());
-    client.setRequestHandler("tool/requestUserInput", async (params) => ({ echoed: params }));
+    const handlerCalls: unknown[] = [];
+    client.setRequestHandler(method, async (params) => {
+      handlerCalls.push(params);
+      return { ok: true };
+    });
 
     const response = new Promise<string>((resolve) => {
       child.stdin.once("data", (chunk) => resolve(chunk.toString()));
     });
-    child.stdout.write(
-      '{"id":7,"method":"tool/requestUserInput","params":{"prompt":"Continue?"}}\n',
-    );
+    child.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: 7, method, params: {} })}\n`);
 
-    await expect(response).resolves.toBe('{"id":7,"result":{"echoed":{"prompt":"Continue?"}}}\n');
+    await expect(response).resolves.toBe('{"id":7,"result":{"ok":true}}\n');
+    expect(handlerCalls).toEqual([{}]);
     child.stdout.end();
     child.stderr.end();
     child.stdin.end();


### PR DESCRIPTION
Adds regression tests for the Codex app-server transport so the v0.1.70 classifier regression cannot recur silently.

## Background

In v0.1.70, #758 tightened the JSON-RPC classifier in `CodexAppServerClient.handleLine()` such that server-initiated requests (`{ id, method, params }`, no `result`/`error`) failed the `isJsonRpcResponse` gate and were silently dropped. Codex approval and `request_user_input` prompts never reached the UI; agents stayed `running` forever, and on Windows a localized non-JSON stdout line could crash the daemon worker.

The classifier was rewritten as part of #866 (transport extraction, on main, not yet released). This PR backfills the regression net so a future refactor cannot reintroduce the same shape.

## What this adds

- `codex-app-server-agent.test.ts`: provider-session round-trip test that drives `CodexAppServerAgentSession` against a fake child process using the real `CodexAppServerClient`, scripts the `initialize` / `collaborationMode/list` / `skills/list` handshake, injects an `item/commandExecution/requestApproval` request, asserts a `permission_requested` event, calls `respondToPermission(allow)`, and asserts the JSON-RPC response with `{ decision: "accept" }` is written back to Codex stdin.
- `codex/app-server-transport.test.ts`: parametrized table covering all server-initiated request methods the provider currently registers (`item/commandExecution/requestApproval`, `item/fileChange/requestApproval`, `item/tool/requestUserInput`, legacy `tool/requestUserInput`).

## Regression proof

The provider-session test was verified to fail against the pre-#866 classifier shape. Temporarily reverting `isJsonRpcResponse` to the broken #758 form produced:

```
× round-trips server-initiated command approvals through the real app-server transport
  → Timed out waiting for permission_requested
```

Restored, all tests green.

## Related issues

This PR adds regression coverage for the v0.1.70/0.1.71 reports. The actual fix is in #866, already on main.

- #855: Codex app-server approval prompts hang indefinitely in Paseo UI
- #862: v0.1.70 regression: Codex agent hangs after approval attention is cleared
- #857: Paseo daemon crashes when Codex provider stdout contains non-JSON localized Windows output (covered by the existing transport "ignores non-JSON stdout lines" test added in #866)

## Test plan

- [x] \`packages/server/src/server/agent/providers/codex-app-server-agent.test.ts\` green
- [x] \`packages/server/src/server/agent/providers/codex/app-server-transport.test.ts\` green
- [x] \`npm run typecheck\` green
- [x] \`npm run lint\` green
- [x] Provider-session test verified red against pre-#866 classifier shape