### PR TITLE
ci: trigger required checks on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Adds the `merge_group:` event trigger to the CI workflow.

Without this, PRs entering the merge queue fail because none of the required checks (format, lint, typecheck, build, test, etc.) ever report a status against the merge_group ref. The doc is explicit: workflows must listen for `merge_group` to gate the queue.

## Test plan
- [ ] Merge queue accepts and processes a queued PR after this lands.