### PR TITLE
Extract create agent command

### DIFF
--- a/packages/server/src/server/agent/create-agent/create.ts
+++ b/packages/server/src/server/agent/create-agent/create.ts
@@ -1,0 +1,528 @@
+import type { Logger } from "pino";
+
+import { PARENT_AGENT_ID_LABEL } from "../../../shared/agent-labels.js";
+import type { TerminalManager } from "../../../terminal/terminal-manager.js";
+import type { CreatePaseoWorktreeInput } from "../../paseo-worktree-service.js";
+import { expandUserPath, resolvePathFromBase } from "../../path-utils.js";
+import { toWorktreeRequestError } from "../../worktree-errors.js";
+import type { WorkspaceGitService } from "../../workspace-git-service.js";
+import type {
+  AgentWorktreeSetupContinuation,
+  CreatePaseoWorktreeSetupContinuationInput,
+  CreatePaseoWorktreeWorkflowFn,
+  CreatePaseoWorktreeWorkflowResult,
+} from "../../worktree-session.js";
+import type { AgentAttachment, FirstAgentContext, GitSetupOptions } from "../../messages.js";
+import type { AgentManager, ManagedAgent } from "../agent-manager.js";
+import { scheduleAgentMetadataGeneration } from "../agent-metadata-generator.js";
+import type {
+  AgentProvider,
+  AgentPromptContentBlock,
+  AgentPromptInput,
+  AgentRunOptions,
+  AgentSessionConfig,
+} from "../agent-sdk-types.js";
+import type { AgentStorage } from "../agent-storage.js";
+import { getAgentProviderDefinition } from "../provider-manifest.js";
+import type { ProviderDefinition } from "../provider-registry.js";
+import { sendPromptToAgent, setupFinishNotification } from "../agent-prompt.js";
+import { resolveAndValidateCreateAgentMode } from "../create-agent-mode.js";
+import { resolveCreateAgentTitles } from "../create-agent-title.js";
+import { resolveRequiredProviderModel } from "../mcp-shared.js";
+import {
+  appendTimelineItemIfAgentKnown,
+  emitLiveTimelineItemIfAgentKnown,
+} from "../timeline-append.js";
+
+export interface CreateAgentWorkspace {
+  workspaceId: string;
+}
+
+export interface CreateAgentSessionWorktreeResult {
+  sessionConfig: AgentSessionConfig;
+  setupContinuation?: AgentWorktreeSetupContinuation;
+}
+
+interface CreateAgentCommandDependencies {
+  agentManager: AgentManager;
+  agentStorage: AgentStorage;
+  logger: Logger;
+  paseoHome?: string;
+  workspaceGitService?: Pick<
+    WorkspaceGitService,
+    "getSnapshot" | "listWorktrees" | "resolveRepoRoot"
+  >;
+  terminalManager?: TerminalManager | null;
+  providerRegistry?: Record<AgentProvider, ProviderDefinition> | null;
+  createPaseoWorktree?: CreatePaseoWorktreeWorkflowFn;
+}
+
+export interface CreateAgentFromSessionInput {
+  kind: "session";
+  config: AgentSessionConfig;
+  workspaceId?: string;
+  worktreeName?: string;
+  initialPrompt?: string;
+  clientMessageId?: string;
+  outputSchema?: Record<string, unknown>;
+  images?: Array<{ data: string; mimeType: string }>;
+  attachments?: AgentAttachment[];
+  git?: GitSetupOptions;
+  labels: Record<string, string>;
+  buildSessionConfig: (
+    config: AgentSessionConfig,
+    gitOptions?: GitSetupOptions,
+    legacyWorktreeName?: string,
+    firstAgentContext?: FirstAgentContext,
+  ) => Promise<CreateAgentSessionWorktreeResult>;
+  resolveWorkspace: (input: { cwd: string; workspaceId?: string }) => Promise<CreateAgentWorkspace>;
+}
+
+export interface CreateAgentFromMcpInput {
+  kind: "mcp";
+  provider: string;
+  title: string;
+  initialPrompt: string;
+  cwd?: string;
+  thinking?: string;
+  labels?: Record<string, string>;
+  mode?: string;
+  background: boolean;
+  notifyOnFinish: boolean;
+  callerAgentId?: string;
+  callerContext?: {
+    lockedCwd?: string;
+    allowCustomCwd?: boolean;
+    childAgentDefaultLabels?: Record<string, string>;
+  } | null;
+  worktree?: {
+    worktreeName?: string;
+    baseBranch?: string;
+    refName?: string;
+    action?: "branch-off" | "checkout";
+    githubPrNumber?: number;
+  };
+}
+
+export type CreateAgentCommandInput = CreateAgentFromSessionInput | CreateAgentFromMcpInput;
+
+export interface CreateAgentCommandResult {
+  snapshot: ManagedAgent;
+  background: boolean;
+  initialPromptStarted: boolean;
+}
+
+interface ResolvedCreateAgent {
+  config: AgentSessionConfig;
+  createOptions?: AgentCreateOptions;
+  metadataInitialPrompt?: string;
+  initialPromptText?: string;
+  prompt?: AgentPromptInput;
+  messageId?: string;
+  runOptions?: AgentRunOptions;
+  explicitTitle: string | null;
+  setupContinuation?: AgentWorktreeSetupContinuation;
+  background: boolean;
+  promptFailure: "throw" | "log";
+}
+
+interface AgentCreateOptions {
+  labels?: Record<string, string>;
+  workspaceId?: string;
+  initialPrompt?: string;
+}
+
+export async function createAgentCommand(
+  dependencies: CreateAgentCommandDependencies,
+  input: CreateAgentCommandInput,
+): Promise<CreateAgentCommandResult> {
+  const resolved =
+    input.kind === "session"
+      ? await resolveSessionCreateAgent(dependencies, input)
+      : await resolveMcpCreateAgent(dependencies, input);
+
+  const snapshot = await dependencies.agentManager.createAgent(
+    resolved.config,
+    undefined,
+    resolved.createOptions,
+  );
+
+  resolved.setupContinuation?.startAfterAgentCreate({
+    agentId: snapshot.id,
+  });
+
+  let initialPromptStarted = false;
+  if (resolved.prompt && resolved.initialPromptText !== undefined) {
+    initialPromptStarted = await sendInitialPrompt(dependencies, resolved, snapshot);
+  }
+
+  if (input.kind === "mcp" && input.notifyOnFinish && input.callerAgentId && initialPromptStarted) {
+    setupFinishNotification({
+      agentManager: dependencies.agentManager,
+      agentStorage: dependencies.agentStorage,
+      childAgentId: snapshot.id,
+      callerAgentId: input.callerAgentId,
+      logger: dependencies.logger,
+    });
+  }
+
+  return {
+    snapshot,
+    background: resolved.background,
+    initialPromptStarted,
+  };
+}
+
+async function resolveSessionCreateAgent(
+  _dependencies: CreateAgentCommandDependencies,
+  input: CreateAgentFromSessionInput,
+): Promise<ResolvedCreateAgent> {
+  const trimmedPrompt = input.initialPrompt?.trim();
+  const { explicitTitle, provisionalTitle } = resolveCreateAgentTitles({
+    configTitle: input.config.title,
+    initialPrompt: trimmedPrompt,
+  });
+  const resolvedConfig: AgentSessionConfig = {
+    ...input.config,
+    ...(provisionalTitle ? { title: provisionalTitle } : {}),
+  };
+  const firstAgentContext: FirstAgentContext = {
+    ...(trimmedPrompt ? { prompt: trimmedPrompt } : {}),
+    ...(input.attachments && input.attachments.length > 0
+      ? { attachments: input.attachments }
+      : {}),
+  };
+  const { sessionConfig, setupContinuation } = await input.buildSessionConfig(
+    resolvedConfig,
+    input.git,
+    input.worktreeName,
+    firstAgentContext,
+  );
+  const workspace = await input.resolveWorkspace({
+    cwd: sessionConfig.cwd,
+    workspaceId: input.workspaceId,
+  });
+  const prompt = buildAgentPrompt(trimmedPrompt ?? "", input.images, input.attachments);
+  const hasPromptContent = Array.isArray(prompt) ? prompt.length > 0 : prompt.length > 0;
+
+  return {
+    config: sessionConfig,
+    createOptions: {
+      labels: input.labels,
+      workspaceId: workspace.workspaceId,
+      initialPrompt: trimmedPrompt,
+    },
+    metadataInitialPrompt: trimmedPrompt,
+    initialPromptText: hasPromptContent ? (trimmedPrompt ?? "") : undefined,
+    prompt: hasPromptContent ? prompt : undefined,
+    messageId: input.clientMessageId,
+    runOptions: input.outputSchema ? { outputSchema: input.outputSchema } : undefined,
+    explicitTitle,
+    setupContinuation,
+    background: true,
+    promptFailure: "throw",
+  };
+}
+
+async function resolveMcpCreateAgent(
+  dependencies: CreateAgentCommandDependencies,
+  input: CreateAgentFromMcpInput,
+): Promise<ResolvedCreateAgent> {
+  const resolvedProviderModel = resolveRequiredProviderModel(input.provider);
+  const provider = resolvedProviderModel.provider;
+  const parentAgent = input.callerAgentId
+    ? requireParentAgent(dependencies.agentManager, input.callerAgentId)
+    : null;
+  const cwd = parentAgent
+    ? resolveChildAgentCwd({
+        parentCwd: parentAgent.cwd,
+        requestedCwd: input.cwd,
+        lockedCwd: input.callerContext?.lockedCwd,
+        allowCustomCwd: input.callerContext?.allowCustomCwd ?? true,
+      })
+    : expandUserPath(input.cwd ?? process.cwd());
+  const { resolvedCwd, setupContinuation } = await resolveMcpCwd({
+    dependencies,
+    cwd,
+    worktree: input.worktree,
+    initialPrompt: input.initialPrompt,
+  });
+  const resolvedMode = resolveAndValidateCreateAgentMode({
+    requestedMode: input.mode,
+    targetProvider: provider,
+    parent: parentAgent
+      ? {
+          provider: parentAgent.provider,
+          modeId: parentAgent.currentModeId,
+          isUnattended: isParentInUnattendedMode(
+            dependencies,
+            parentAgent.provider,
+            parentAgent.currentModeId,
+          ),
+        }
+      : null,
+    availableModes: getAvailableModeIds(dependencies, provider),
+    targetUnattendedMode: getUnattendedModeId(dependencies, provider),
+  });
+  const labels = mergeLabels(
+    input.callerAgentId,
+    input.callerContext?.childAgentDefaultLabels,
+    input.labels,
+  );
+
+  return {
+    config: {
+      provider,
+      cwd: resolvedCwd,
+      modeId: resolvedMode,
+      title: input.title.trim(),
+      model: resolvedProviderModel.model,
+      thinkingOptionId: input.thinking,
+    },
+    createOptions: labels ? { labels } : undefined,
+    metadataInitialPrompt: input.initialPrompt.trim(),
+    initialPromptText: input.initialPrompt.trim(),
+    prompt: input.initialPrompt.trim(),
+    explicitTitle: input.title.trim(),
+    setupContinuation,
+    background: input.background,
+    promptFailure: "log",
+  };
+}
+
+async function sendInitialPrompt(
+  dependencies: CreateAgentCommandDependencies,
+  resolved: ResolvedCreateAgent,
+  snapshot: ManagedAgent,
+): Promise<boolean> {
+  scheduleAgentMetadataGeneration({
+    agentManager: dependencies.agentManager,
+    agentId: snapshot.id,
+    cwd: snapshot.cwd,
+    workspaceGitService: dependencies.workspaceGitService,
+    initialPrompt: resolved.metadataInitialPrompt,
+    explicitTitle: resolved.explicitTitle,
+    paseoHome: dependencies.paseoHome,
+    logger: dependencies.logger,
+  });
+
+  try {
+    const prompt = resolved.prompt;
+    if (!prompt) {
+      return false;
+    }
+    await sendPromptToAgent({
+      agentManager: dependencies.agentManager,
+      agentStorage: dependencies.agentStorage,
+      agentId: snapshot.id,
+      userMessageText: resolved.initialPromptText,
+      prompt,
+      messageId: resolved.messageId,
+      runOptions: resolved.runOptions,
+      logger: dependencies.logger,
+    });
+    return true;
+  } catch (error) {
+    if (resolved.promptFailure === "throw") {
+      throw error;
+    }
+    dependencies.logger.error({ err: error, agentId: snapshot.id }, "Failed to run initial prompt");
+    return false;
+  }
+}
+
+function buildAgentPrompt(
+  text: string,
+  images?: Array<{ data: string; mimeType: string }>,
+  attachments?: AgentAttachment[],
+): AgentPromptInput {
+  const normalized = text.trim();
+  const hasImages = (images?.length ?? 0) > 0;
+  const hasAttachments = (attachments?.length ?? 0) > 0;
+  if (!hasImages && !hasAttachments) {
+    return normalized;
+  }
+  const blocks: AgentPromptContentBlock[] = [];
+  if (normalized.length > 0) {
+    blocks.push({ type: "text", text: normalized });
+  }
+  for (const image of images ?? []) {
+    blocks.push({ type: "image", data: image.data, mimeType: image.mimeType });
+  }
+  for (const attachment of attachments ?? []) {
+    blocks.push(attachment);
+  }
+  return blocks;
+}
+
+function requireParentAgent(agentManager: AgentManager, parentAgentId: string): ManagedAgent {
+  const parentAgent = agentManager.getAgent(parentAgentId);
+  if (!parentAgent) {
+    throw new Error(`Parent agent ${parentAgentId} not found`);
+  }
+  return parentAgent;
+}
+
+function resolveChildAgentCwd(params: {
+  parentCwd: string;
+  requestedCwd?: string;
+  lockedCwd?: string;
+  allowCustomCwd: boolean;
+}): string {
+  const lockedCwd = params.lockedCwd?.trim();
+  if (lockedCwd) {
+    return expandUserPath(lockedCwd);
+  }
+
+  const requestedCwd = params.requestedCwd?.trim();
+  if (!requestedCwd || !params.allowCustomCwd) {
+    return params.parentCwd;
+  }
+
+  return resolvePathFromBase(params.parentCwd, requestedCwd);
+}
+
+async function resolveMcpCwd(params: {
+  dependencies: CreateAgentCommandDependencies;
+  cwd: string;
+  initialPrompt: string;
+  worktree: CreateAgentFromMcpInput["worktree"];
+}): Promise<{ resolvedCwd: string; setupContinuation?: AgentWorktreeSetupContinuation }> {
+  const { dependencies, worktree } = params;
+  if (!worktree) {
+    return { resolvedCwd: params.cwd };
+  }
+  const shouldCreateWorktree = Boolean(
+    worktree.worktreeName || worktree.refName || worktree.action || worktree.githubPrNumber,
+  );
+  if (!shouldCreateWorktree) {
+    return { resolvedCwd: params.cwd };
+  }
+  if (
+    worktree.worktreeName &&
+    !worktree.baseBranch &&
+    !worktree.refName &&
+    !worktree.action &&
+    worktree.githubPrNumber === undefined
+  ) {
+    throw new Error("baseBranch is required when creating a worktree");
+  }
+  const baseBranch = worktree.baseBranch;
+  const createdWorktree = await createMcpWorktree({
+    input: {
+      cwd: params.cwd,
+      worktreeSlug: worktree.worktreeName,
+      refName: worktree.refName,
+      action: worktree.action,
+      githubPrNumber: worktree.githubPrNumber,
+      ...(params.initialPrompt ? { firstAgentContext: { prompt: params.initialPrompt } } : {}),
+      runSetup: false,
+      paseoHome: dependencies.paseoHome,
+    },
+    createPaseoWorktree: dependencies.createPaseoWorktree,
+    resolveDefaultBranch: baseBranch ? async () => baseBranch : undefined,
+    setupContinuation: {
+      kind: "agent",
+      terminalManager: dependencies.terminalManager ?? null,
+      appendTimelineItem: ({ agentId, item }) =>
+        appendTimelineItemIfAgentKnown({
+          agentManager: dependencies.agentManager,
+          agentId,
+          item,
+        }),
+      emitLiveTimelineItem: ({ agentId, item }) =>
+        emitLiveTimelineItemIfAgentKnown({
+          agentManager: dependencies.agentManager,
+          agentId,
+          item,
+        }),
+      logger: dependencies.logger,
+    },
+  });
+  return {
+    resolvedCwd: createdWorktree.worktree.worktreePath,
+    setupContinuation: createdWorktree.setupContinuation,
+  };
+}
+
+interface CreateMcpWorktreeOptions {
+  input: CreatePaseoWorktreeInput;
+  createPaseoWorktree: CreatePaseoWorktreeWorkflowFn | undefined;
+  resolveDefaultBranch?: (repoRoot: string) => Promise<string>;
+  setupContinuation?: CreatePaseoWorktreeSetupContinuationInput;
+}
+
+async function createMcpWorktree(
+  options: CreateMcpWorktreeOptions,
+): Promise<CreatePaseoWorktreeWorkflowResult> {
+  try {
+    if (!options.createPaseoWorktree) {
+      throw new Error("Paseo worktree service is not configured");
+    }
+    return await options.createPaseoWorktree(options.input, {
+      ...(options.resolveDefaultBranch
+        ? { resolveDefaultBranch: options.resolveDefaultBranch }
+        : {}),
+      ...(options.setupContinuation ? { setupContinuation: options.setupContinuation } : {}),
+    });
+  } catch (error) {
+    throw toWorktreeRequestError(error);
+  }
+}
+
+function mergeLabels(
+  callerAgentId: string | undefined,
+  childAgentDefaultLabels: Record<string, string> | undefined,
+  labels: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  const mergedLabels = {
+    ...(callerAgentId ? { [PARENT_AGENT_ID_LABEL]: callerAgentId } : {}),
+    ...childAgentDefaultLabels,
+    ...labels,
+  };
+  return Object.keys(mergedLabels).length > 0 ? mergedLabels : undefined;
+}
+
+function getProviderModes(
+  dependencies: CreateAgentCommandDependencies,
+  provider: AgentProvider,
+): ProviderDefinition["modes"] | undefined {
+  const fromRegistry = dependencies.providerRegistry?.[provider];
+  if (fromRegistry) {
+    return fromRegistry.modes;
+  }
+  try {
+    return getAgentProviderDefinition(provider).modes;
+  } catch {
+    return undefined;
+  }
+}
+
+function getAvailableModeIds(
+  dependencies: CreateAgentCommandDependencies,
+  provider: AgentProvider,
+): string[] | undefined {
+  return getProviderModes(dependencies, provider)?.map((mode) => mode.id);
+}
+
+function getUnattendedModeId(
+  dependencies: CreateAgentCommandDependencies,
+  provider: AgentProvider,
+): string | undefined {
+  return getProviderModes(dependencies, provider)?.find((mode) => mode.isUnattended)?.id;
+}
+
+function isParentInUnattendedMode(
+  dependencies: CreateAgentCommandDependencies,
+  provider: AgentProvider,
+  modeId: string | null,
+): boolean {
+  if (modeId === null) {
+    return false;
+  }
+  const modes = getProviderModes(dependencies, provider);
+  if (!modes) {
+    return false;
+  }
+  return modes.some((mode) => mode.id === modeId && mode.isUnattended === true);
+}

--- a/packages/server/src/server/agent/mcp-server.ts
+++ b/packages/server/src/server/agent/mcp-server.ts
@@ -24,10 +24,6 @@ import { selectItemsByProjectedLimit } from "./timeline-projection.js";
 import type { AgentStorage } from "./agent-storage.js";
 import { ensureAgentLoaded } from "./agent-loading.js";
 import { isStoredAgentProviderAvailable } from "../persistence-hooks.js";
-import {
-  appendTimelineItemIfAgentKnown,
-  emitLiveTimelineItemIfAgentKnown,
-} from "./timeline-append.js";
 import { getPaseoWorktreesRoot } from "../../utils/worktree.js";
 import {
   archivePaseoWorktree,
@@ -35,13 +31,11 @@ import {
   type ArchivePaseoWorktreeDependencies,
 } from "../paseo-worktree-archive-service.js";
 import { WaitForAgentTracker } from "./wait-for-agent-tracker.js";
-import { scheduleAgentMetadataGeneration } from "./agent-metadata-generator.js";
+import { createAgentCommand } from "./create-agent/create.js";
 import type { VoiceCallerContext, VoiceSpeakHandler } from "../voice-types.js";
 import { expandUserPath, isSameOrDescendantPath, resolvePathFromBase } from "../path-utils.js";
-import { PARENT_AGENT_ID_LABEL } from "../../shared/agent-labels.js";
 import type { TerminalManager } from "../../terminal/terminal-manager.js";
 import type {
-  AgentWorktreeSetupContinuation,
   CreatePaseoWorktreeSetupContinuationInput,
   CreatePaseoWorktreeWorkflowFn,
   CreatePaseoWorktreeWorkflowResult,
@@ -49,8 +43,6 @@ import type {
 import type { ScheduleService } from "../schedule/service.js";
 import { ScheduleSummarySchema, StoredScheduleSchema } from "../schedule/types.js";
 import type { ProviderDefinition } from "./provider-registry.js";
-import { getAgentProviderDefinition } from "./provider-manifest.js";
-import { resolveAndValidateCreateAgentMode } from "./create-agent-mode.js";
 import { resolveSnapshotCwd } from "./provider-snapshot-manager.js";
 import {
   AgentModelSchema,
@@ -64,7 +56,7 @@ import {
   toScheduleSummary,
   waitForAgentWithTimeout,
 } from "./mcp-shared.js";
-import { sendPromptToAgent, setupFinishNotification, startAgentRun } from "./agent-prompt.js";
+import { sendPromptToAgent, setupFinishNotification } from "./agent-prompt.js";
 import { respondToAgentPermission } from "./permission-response.js";
 import type { GitHubService } from "../../services/github-service.js";
 import type { WorkspaceGitService } from "../workspace-git-service.js";
@@ -580,6 +572,7 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
   const createAgentInputSchema = callerAgentId ? agentToAgentInputSchema : topLevelInputSchema;
   const agentToAgentCreateAgentArgsSchema = z.object(agentToAgentInputSchema).strict();
   const topLevelCreateAgentArgsSchema = z.object(topLevelInputSchema).strict();
+  type TopLevelCreateAgentArgs = z.infer<typeof topLevelCreateAgentArgsSchema>;
 
   if (options.voiceOnly || options.enableVoiceTools || callerContext?.enableVoiceTools) {
     server.registerTool(
@@ -624,163 +617,6 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
     return server;
   }
 
-  interface ResolvedCreateAgentArgs {
-    provider: AgentProvider;
-    initialPrompt: string;
-    background: boolean;
-    normalizedTitle: string | null;
-    model: string | undefined;
-    thinking: string | undefined;
-    labels: Record<string, string> | undefined;
-    notifyOnFinish: boolean;
-    resolvedCwd: string;
-    resolvedMode: string | undefined;
-    setupContinuation: AgentWorktreeSetupContinuation | undefined;
-  }
-
-  const getProviderModes = (provider: AgentProvider) => {
-    const fromRegistry = providerRegistry?.[provider];
-    if (fromRegistry) {
-      return fromRegistry.modes;
-    }
-    try {
-      return getAgentProviderDefinition(provider).modes;
-    } catch {
-      return undefined;
-    }
-  };
-
-  const getAvailableModeIds = (provider: AgentProvider): string[] | undefined => {
-    return getProviderModes(provider)?.map((mode) => mode.id);
-  };
-
-  const getUnattendedModeId = (provider: AgentProvider): string | undefined => {
-    return getProviderModes(provider)?.find((mode) => mode.isUnattended)?.id;
-  };
-
-  const isParentInUnattendedMode = (provider: AgentProvider, modeId: string | null): boolean => {
-    if (modeId === null) return false;
-    const modes = getProviderModes(provider);
-    if (!modes) return false;
-    return modes.some((mode) => mode.id === modeId && mode.isUnattended === true);
-  };
-
-  const resolveCallerCreateAgentArgs = (
-    args: unknown,
-    parentAgentId: string,
-  ): ResolvedCreateAgentArgs => {
-    const callerArgs = agentToAgentCreateAgentArgsSchema.parse(args);
-    const resolvedProviderModel = resolveRequiredProviderModel(callerArgs.provider);
-    const parentAgent = agentManager.getAgent(parentAgentId);
-    if (!parentAgent) {
-      throw new Error(`Parent agent ${parentAgentId} not found`);
-    }
-    const provider = resolvedProviderModel.provider;
-    const resolvedCwd = resolveChildAgentCwd({
-      parentCwd: parentAgent.cwd,
-      requestedCwd: callerArgs.cwd,
-      lockedCwd: callerContext?.lockedCwd,
-      allowCustomCwd: callerContext?.allowCustomCwd ?? true,
-    });
-    const resolvedMode = resolveAndValidateCreateAgentMode({
-      requestedMode: callerArgs.mode,
-      targetProvider: provider,
-      parent: {
-        provider: parentAgent.provider,
-        modeId: parentAgent.currentModeId,
-        isUnattended: isParentInUnattendedMode(parentAgent.provider, parentAgent.currentModeId),
-      },
-      availableModes: getAvailableModeIds(provider),
-      targetUnattendedMode: getUnattendedModeId(provider),
-    });
-    return {
-      provider,
-      initialPrompt: callerArgs.initialPrompt,
-      background: callerArgs.background ?? false,
-      normalizedTitle: callerArgs.title.trim(),
-      model: resolvedProviderModel.model,
-      thinking: callerArgs.thinking,
-      labels: callerArgs.labels,
-      notifyOnFinish: callerArgs.notifyOnFinish ?? false,
-      resolvedCwd,
-      resolvedMode,
-      setupContinuation: undefined,
-    };
-  };
-
-  const resolveTopLevelCreateAgentArgs = async (
-    args: unknown,
-  ): Promise<ResolvedCreateAgentArgs> => {
-    const topLevelArgs = topLevelCreateAgentArgsSchema.parse(args);
-    const resolvedProviderModel = resolveRequiredProviderModel(topLevelArgs.provider);
-    const { cwd, mode, worktreeName, baseBranch, refName, action, githubPrNumber } = topLevelArgs;
-    const resolvedMode = resolveAndValidateCreateAgentMode({
-      requestedMode: mode,
-      targetProvider: resolvedProviderModel.provider,
-      parent: null,
-      availableModes: getAvailableModeIds(resolvedProviderModel.provider),
-      targetUnattendedMode: getUnattendedModeId(resolvedProviderModel.provider),
-    });
-    let resolvedCwd = expandUserPath(cwd);
-    let setupContinuation: AgentWorktreeSetupContinuation | undefined;
-
-    const shouldCreateWorktree = Boolean(worktreeName || refName || action || githubPrNumber);
-    if (shouldCreateWorktree) {
-      if (worktreeName && !baseBranch && !refName && !action && githubPrNumber === undefined) {
-        throw new Error("baseBranch is required when creating a worktree");
-      }
-      const createdWorktree = await createMcpWorktree({
-        input: {
-          cwd: resolvedCwd,
-          worktreeSlug: worktreeName,
-          refName,
-          action,
-          githubPrNumber,
-          ...(topLevelArgs.initialPrompt
-            ? { firstAgentContext: { prompt: topLevelArgs.initialPrompt } }
-            : {}),
-          runSetup: false,
-          paseoHome: options.paseoHome,
-        },
-        createPaseoWorktree: options.createPaseoWorktree,
-        resolveDefaultBranch: baseBranch ? async () => baseBranch : undefined,
-        setupContinuation: {
-          kind: "agent",
-          terminalManager: terminalManager ?? null,
-          appendTimelineItem: ({ agentId, item }) =>
-            appendTimelineItemIfAgentKnown({
-              agentManager,
-              agentId,
-              item,
-            }),
-          emitLiveTimelineItem: ({ agentId, item }) =>
-            emitLiveTimelineItemIfAgentKnown({
-              agentManager,
-              agentId,
-              item,
-            }),
-          logger: childLogger,
-        },
-      });
-      resolvedCwd = createdWorktree.worktree.worktreePath;
-      setupContinuation = createdWorktree.setupContinuation;
-    }
-
-    return {
-      provider: resolvedProviderModel.provider,
-      initialPrompt: topLevelArgs.initialPrompt,
-      background: topLevelArgs.background ?? false,
-      normalizedTitle: topLevelArgs.title.trim(),
-      model: resolvedProviderModel.model,
-      thinking: topLevelArgs.thinking,
-      labels: topLevelArgs.labels,
-      notifyOnFinish: topLevelArgs.notifyOnFinish ?? false,
-      resolvedCwd,
-      resolvedMode,
-      setupContinuation,
-    };
-  };
-
   server.registerTool(
     "create_agent",
     {
@@ -806,87 +642,44 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
       },
     },
     async (args: unknown) => {
-      const resolved = callerAgentId
-        ? resolveCallerCreateAgentArgs(args, callerAgentId)
-        : await resolveTopLevelCreateAgentArgs(args);
-      const {
-        provider,
-        initialPrompt,
-        background,
-        normalizedTitle,
-        model,
-        thinking,
-        labels,
-        notifyOnFinish,
-        resolvedCwd,
-        resolvedMode,
-        setupContinuation,
-      } = resolved;
-
-      const childAgentDefaultLabels = callerContext?.childAgentDefaultLabels;
-      const mergedLabels = {
-        ...(callerAgentId ? { [PARENT_AGENT_ID_LABEL]: callerAgentId } : {}),
-        ...childAgentDefaultLabels,
-        ...labels,
-      };
-      const snapshot = await agentManager.createAgent(
+      const { parsedArgs, worktree } = resolveCreateAgentToolArgs(args);
+      const { snapshot, background, initialPromptStarted } = await createAgentCommand(
         {
-          provider,
-          cwd: resolvedCwd,
-          modeId: resolvedMode,
-          title: normalizedTitle ?? undefined,
-          model,
-          thinkingOptionId: thinking,
+          agentManager,
+          agentStorage,
+          logger: childLogger,
+          paseoHome: options.paseoHome,
+          workspaceGitService: options.workspaceGitService,
+          terminalManager,
+          providerRegistry,
+          createPaseoWorktree: options.createPaseoWorktree,
         },
-        undefined,
-        Object.keys(mergedLabels).length > 0 ? { labels: mergedLabels } : undefined,
+        {
+          kind: "mcp",
+          provider: parsedArgs.provider,
+          title: parsedArgs.title,
+          initialPrompt: parsedArgs.initialPrompt,
+          cwd: parsedArgs.cwd,
+          thinking: parsedArgs.thinking,
+          labels: parsedArgs.labels,
+          mode: parsedArgs.mode,
+          background: parsedArgs.background ?? false,
+          notifyOnFinish: parsedArgs.notifyOnFinish ?? false,
+          callerAgentId,
+          callerContext,
+          worktree,
+        },
       );
 
-      setupContinuation?.startAfterAgentCreate({
-        agentId: snapshot.id,
-      });
-
-      const trimmedPrompt = initialPrompt.trim();
-      scheduleAgentMetadataGeneration({
-        agentManager,
-        agentId: snapshot.id,
-        cwd: snapshot.cwd,
-        workspaceGitService: options.workspaceGitService,
-        initialPrompt: trimmedPrompt,
-        explicitTitle: snapshot.config.title,
-        paseoHome: options.paseoHome,
-        logger: childLogger,
-      });
-
       try {
-        agentManager.recordUserMessage(snapshot.id, trimmedPrompt, {
-          emitState: false,
-        });
-      } catch (error) {
-        childLogger.error({ err: error, agentId: snapshot.id }, "Failed to record initial prompt");
-      }
-
-      try {
-        startAgentRun(agentManager, snapshot.id, trimmedPrompt, childLogger);
-        if (notifyOnFinish && callerAgentId) {
-          setupFinishNotification({
-            agentManager,
-            agentStorage,
-            childAgentId: snapshot.id,
-            callerAgentId,
-            logger: childLogger,
-          });
-        }
-
-        // If not running in background, wait for completion
-        if (!background) {
+        if (!background && initialPromptStarted) {
           const result = await waitForAgentWithTimeout(agentManager, snapshot.id, {
             waitForActive: true,
           });
 
           const responseData = {
             agentId: snapshot.id,
-            type: provider,
+            type: snapshot.provider,
             status: result.status,
             cwd: snapshot.cwd,
             currentModeId: snapshot.currentModeId,
@@ -911,7 +704,7 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
         content: [],
         structuredContent: ensureValidJson({
           agentId: snapshot.id,
-          type: provider,
+          type: snapshot.provider,
           status: snapshot.lifecycle,
           cwd: snapshot.cwd,
           currentModeId: snapshot.currentModeId,
@@ -923,6 +716,43 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
       return response;
     },
   );
+
+  function resolveCreateAgentToolArgs(args: unknown): {
+    parsedArgs:
+      | z.infer<typeof agentToAgentCreateAgentArgsSchema>
+      | z.infer<typeof topLevelCreateAgentArgsSchema>;
+    worktree: ReturnType<typeof resolveTopLevelCreateAgentWorktree>;
+  } {
+    if (callerAgentId) {
+      return {
+        parsedArgs: agentToAgentCreateAgentArgsSchema.parse(args),
+        worktree: undefined,
+      };
+    }
+    const parsedArgs = topLevelCreateAgentArgsSchema.parse(args);
+    return {
+      parsedArgs,
+      worktree: resolveTopLevelCreateAgentWorktree(parsedArgs),
+    };
+  }
+
+  function resolveTopLevelCreateAgentWorktree(args: TopLevelCreateAgentArgs):
+    | {
+        worktreeName?: string;
+        baseBranch?: string;
+        refName?: string;
+        action?: "branch-off" | "checkout";
+        githubPrNumber?: number;
+      }
+    | undefined {
+    return {
+      worktreeName: args.worktreeName,
+      baseBranch: args.baseBranch,
+      refName: args.refName,
+      action: args.action,
+      githubPrNumber: args.githubPrNumber,
+    };
+  }
 
   server.registerTool(
     "wait_for_agent",
@@ -1296,22 +1126,10 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
     },
     async ({ agentId, name, labels }) => {
       const trimmedName = name?.trim();
-      if (trimmedName) {
-        const record = await agentStorage.get(agentId);
-        if (!record) {
-          throw new Error(`Agent ${agentId} not found`);
-        }
-        await agentStorage.upsert({
-          ...record,
-          title: trimmedName,
-          updatedAt: new Date().toISOString(),
-        });
-        agentManager.notifyAgentState(agentId);
-      }
-
-      if (labels) {
-        await agentManager.setLabels(agentId, labels);
-      }
+      await agentManager.updateAgentMetadata(agentId, {
+        ...(trimmedName ? { title: trimmedName } : {}),
+        ...(labels ? { labels } : {}),
+      });
 
       return {
         content: [],

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -97,8 +97,7 @@ import type {
   AgentTimelineFetchDirection,
   ManagedAgent,
 } from "./agent/agent-manager.js";
-import { scheduleAgentMetadataGeneration } from "./agent/agent-metadata-generator.js";
-import { resolveCreateAgentTitles } from "./agent/create-agent-title.js";
+import { createAgentCommand } from "./agent/create-agent/create.js";
 import {
   buildStoredAgentPayload,
   resolveEffectiveThinkingOptionId,
@@ -199,7 +198,6 @@ import type { LocalSpeechModelId } from "./speech/providers/local/models.js";
 import { toResolver, type Resolvable } from "./speech/provider-resolver.js";
 import type { SpeechReadinessSnapshot, SpeechReadinessState } from "./speech/speech-runtime.js";
 import type pino from "pino";
-import { resolveClientMessageId } from "./client-message-id.js";
 import {
   ChatServiceError,
   FileBackedChatService,
@@ -2865,49 +2863,38 @@ export class Session {
     );
 
     try {
-      const trimmedPrompt = initialPrompt?.trim();
-      const { explicitTitle, provisionalTitle } = resolveCreateAgentTitles({
-        configTitle: config.title,
-        initialPrompt: trimmedPrompt,
-      });
-      const resolvedConfig: AgentSessionConfig = {
-        ...config,
-        ...(provisionalTitle ? { title: provisionalTitle } : {}),
-      };
-
-      const firstAgentContext: FirstAgentContext = {
-        ...(trimmedPrompt ? { prompt: trimmedPrompt } : {}),
-        ...(attachments && attachments.length > 0 ? { attachments } : {}),
-      };
-      const { sessionConfig, setupContinuation } = await this.buildAgentSessionConfig(
-        resolvedConfig,
-        git,
-        worktreeName,
-        firstAgentContext,
+      const { snapshot } = await createAgentCommand(
+        {
+          agentManager: this.agentManager,
+          agentStorage: this.agentStorage,
+          logger: this.sessionLogger,
+          paseoHome: this.paseoHome,
+          workspaceGitService: this.workspaceGitService,
+        },
+        {
+          kind: "session",
+          config,
+          workspaceId: msg.workspaceId,
+          worktreeName,
+          initialPrompt,
+          clientMessageId,
+          outputSchema,
+          images,
+          attachments,
+          git,
+          labels,
+          buildSessionConfig: (sessionConfig, gitOptions, legacyWorktreeName, firstAgentContext) =>
+            this.buildAgentSessionConfig(
+              sessionConfig,
+              gitOptions,
+              legacyWorktreeName,
+              firstAgentContext,
+            ),
+          resolveWorkspace: ({ cwd, workspaceId }) =>
+            this.resolveCreateAgentWorkspace(cwd, workspaceId),
+        },
       );
-      let resolvedWorkspace = msg.workspaceId
-        ? await this.workspaceRegistry.get(msg.workspaceId)
-        : ((await this.findWorkspaceByDirectory(sessionConfig.cwd)) ??
-          (await this.findOrCreateWorkspaceForDirectory(sessionConfig.cwd)));
-      if (!resolvedWorkspace) {
-        throw new Error(`Workspace not found: ${msg.workspaceId}`);
-      }
-      const snapshot = await this.agentManager.createAgent(sessionConfig, undefined, {
-        labels,
-        workspaceId: resolvedWorkspace.workspaceId,
-        initialPrompt: trimmedPrompt,
-      });
       await this.forwardAgentUpdate(snapshot);
-
-      await this.sendInitialCreateAgentPrompt({
-        snapshot,
-        trimmedPrompt,
-        images,
-        attachments,
-        clientMessageId,
-        outputSchema,
-        explicitTitle,
-      });
 
       if (requestId) {
         const agentPayload = await this.buildAgentPayload(snapshot);
@@ -2921,10 +2908,6 @@ export class Session {
           },
         });
       }
-
-      setupContinuation?.startAfterAgentCreate({
-        agentId: snapshot.id,
-      });
 
       this.sessionLogger.info(
         { agentId: snapshot.id, provider: snapshot.provider },
@@ -2956,44 +2939,18 @@ export class Session {
     }
   }
 
-  private async sendInitialCreateAgentPrompt(params: {
-    snapshot: { id: string; cwd: string };
-    trimmedPrompt: string | undefined;
-    images: Array<{ data: string; mimeType: string }> | undefined;
-    attachments: AgentAttachment[] | undefined;
-    clientMessageId: string | undefined;
-    outputSchema: Record<string, unknown> | undefined;
-    explicitTitle: string | null;
-  }): Promise<void> {
-    const { snapshot, trimmedPrompt, images, attachments, clientMessageId, outputSchema } = params;
-    const hasPrompt = Boolean(trimmedPrompt);
-    const hasImages = (images?.length ?? 0) > 0;
-    const hasAttachments = (attachments?.length ?? 0) > 0;
-    if (!hasPrompt && !hasImages && !hasAttachments) {
-      return;
+  private async resolveCreateAgentWorkspace(
+    cwd: string,
+    workspaceId?: string,
+  ): Promise<{ workspaceId: string }> {
+    const resolvedWorkspace = workspaceId
+      ? await this.workspaceRegistry.get(workspaceId)
+      : ((await this.findWorkspaceByDirectory(cwd)) ??
+        (await this.findOrCreateWorkspaceForDirectory(cwd)));
+    if (!resolvedWorkspace) {
+      throw new Error(`Workspace not found: ${workspaceId}`);
     }
-    scheduleAgentMetadataGeneration({
-      agentManager: this.agentManager,
-      agentId: snapshot.id,
-      cwd: snapshot.cwd,
-      workspaceGitService: this.workspaceGitService,
-      initialPrompt: trimmedPrompt,
-      explicitTitle: params.explicitTitle,
-      paseoHome: this.paseoHome,
-      logger: this.sessionLogger,
-    });
-
-    const started = await this.handleSendAgentMessage(
-      snapshot.id,
-      trimmedPrompt || "",
-      resolveClientMessageId(clientMessageId),
-      images,
-      attachments,
-      outputSchema ? { outputSchema } : undefined,
-    );
-    if (!started.ok) {
-      throw new Error(started.error);
-    }
+    return { workspaceId: resolvedWorkspace.workspaceId };
   }
 
   private async handleResumeAgentRequest(


### PR DESCRIPTION
## Summary
- Extract shared create-agent orchestration into `packages/server/src/server/agent/create-agent/create.ts`
- Make WebSocket `Session` create-agent handling a transport adapter for request parsing, workspace response emission, and errors
- Make MCP `create_agent` a transport adapter for schema parsing, wait/response shaping, and MCP output
- Route MCP `update_agent` through `agentManager.updateAgentMetadata` so title and label updates persist together

## Verification
- `npx vitest run packages/server/src/server/session.create-agent-title.test.ts packages/server/src/server/agent/create-agent-mode.test.ts packages/server/src/server/session.workspaces.test.ts packages/server/src/server/agent/mcp-server.test.ts --bail=1`
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- Pre-commit hook: lint, format check, typecheck

## Notes
- Also ran `npx vitest run packages/server/src/server/agent/mcp-parity.e2e.test.ts packages/server/src/server/agent/agent-mcp.e2e.test.ts --bail=1`. `agent-mcp.e2e.test.ts` passed. `mcp-parity.e2e.test.ts` first exposed and this PR fixes the MCP `update_agent` title/labels persistence issue; it then failed later in schedule tooling because `create_schedule` returned no `id`, which is outside this create-agent refactor.
