### PR TITLE
Extract agent lifecycle commands

### DIFF
--- a/packages/server/src/server/agent/lifecycle-command.test.ts
+++ b/packages/server/src/server/agent/lifecycle-command.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "vitest";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import type { StoredAgentRecord } from "./agent-storage.js";
+import {
+  archiveAgentCommand,
+  cancelAgentRunCommand,
+  setAgentModeCommand,
+  updateAgentCommand,
+  type LifecycleAgentSnapshot,
+  type LifecycleAgentManager,
+  type LifecycleAgentStorage,
+} from "./lifecycle-command.js";
+
+class FakeLifecycleAgentStorage implements LifecycleAgentStorage {
+  readonly records = new Map<string, StoredAgentRecord>();
+
+  async get(agentId: string): Promise<StoredAgentRecord | null> {
+    return this.records.get(agentId) ?? null;
+  }
+}
+
+class FakeLifecycleAgentManager implements LifecycleAgentManager {
+  readonly liveAgents = new Map<string, LifecycleAgentSnapshot>();
+  readonly cancelledAgentIds: string[] = [];
+  readonly clearedAttentionAgentIds: string[] = [];
+  readonly archivedAgentIds: string[] = [];
+  readonly closedAgentIds: string[] = [];
+  readonly metadataUpdates: Array<{
+    agentId: string;
+    updates: { title?: string; labels?: Record<string, string> };
+  }> = [];
+  readonly modeUpdates: Array<{ agentId: string; modeId: string }> = [];
+  inFlightAgentIds = new Set<string>();
+
+  constructor(private readonly storage: FakeLifecycleAgentStorage) {}
+
+  getAgent(agentId: string): LifecycleAgentSnapshot | null {
+    return this.liveAgents.get(agentId) ?? null;
+  }
+
+  hasInFlightRun(agentId: string): boolean {
+    return this.inFlightAgentIds.has(agentId);
+  }
+
+  async cancelAgentRun(agentId: string): Promise<boolean> {
+    this.cancelledAgentIds.push(agentId);
+    return this.inFlightAgentIds.delete(agentId);
+  }
+
+  async clearAgentAttention(agentId: string): Promise<void> {
+    this.clearedAttentionAgentIds.push(agentId);
+  }
+
+  async archiveAgent(agentId: string): Promise<{ archivedAt: string }> {
+    this.archivedAgentIds.push(agentId);
+    this.liveAgents.delete(agentId);
+    const archivedAt = "2026-05-10T10:00:00.000Z";
+    const existing = this.storage.records.get(agentId) ?? storedAgent(agentId);
+    this.storage.records.set(agentId, {
+      ...existing,
+      archivedAt,
+    });
+    return { archivedAt };
+  }
+
+  async archiveSnapshot(agentId: string, archivedAt: string): Promise<StoredAgentRecord> {
+    const existing = this.storage.records.get(agentId);
+    if (!existing) {
+      throw new Error(`Agent not found: ${agentId}`);
+    }
+    const archived = {
+      ...existing,
+      archivedAt,
+    };
+    this.storage.records.set(agentId, archived);
+    return archived;
+  }
+
+  async closeAgent(agentId: string): Promise<void> {
+    this.closedAgentIds.push(agentId);
+    this.liveAgents.delete(agentId);
+  }
+
+  async updateAgentMetadata(
+    agentId: string,
+    updates: { title?: string; labels?: Record<string, string> },
+  ): Promise<void> {
+    this.metadataUpdates.push({ agentId, updates });
+  }
+
+  async setAgentMode(agentId: string, modeId: string): Promise<void> {
+    this.modeUpdates.push({ agentId, modeId });
+  }
+}
+
+const logger = createTestLogger();
+
+describe("agent lifecycle commands", () => {
+  test("cancels only when the agent has an in-flight run", async () => {
+    const storage = new FakeLifecycleAgentStorage();
+    const manager = new FakeLifecycleAgentManager(storage);
+    manager.liveAgents.set("agent-1", managedAgent("agent-1", "running"));
+    manager.inFlightAgentIds.add("agent-1");
+
+    const result = await cancelAgentRunCommand({ agentManager: manager, logger }, "agent-1");
+
+    expect(result).toEqual({
+      agent: manager.liveAgents.get("agent-1"),
+      cancelled: true,
+    });
+    expect(manager.cancelledAgentIds).toEqual(["agent-1"]);
+  });
+
+  test("archives a live agent after canceling and clearing attention", async () => {
+    const storage = new FakeLifecycleAgentStorage();
+    const manager = new FakeLifecycleAgentManager(storage);
+    manager.liveAgents.set("agent-1", managedAgent("agent-1", "running"));
+    manager.inFlightAgentIds.add("agent-1");
+    storage.records.set("agent-1", storedAgent("agent-1"));
+
+    const result = await archiveAgentCommand(
+      { agentManager: manager, agentStorage: storage, logger },
+      "agent-1",
+    );
+
+    expect(result).toEqual({
+      agentId: "agent-1",
+      archivedAt: "2026-05-10T10:00:00.000Z",
+      record: {
+        ...storedAgent("agent-1"),
+        archivedAt: "2026-05-10T10:00:00.000Z",
+      },
+    });
+    expect(manager.cancelledAgentIds).toEqual(["agent-1"]);
+    expect(manager.clearedAttentionAgentIds).toEqual(["agent-1"]);
+    expect(manager.archivedAgentIds).toEqual(["agent-1"]);
+  });
+
+  test("archives a stored agent when no live agent exists", async () => {
+    const storage = new FakeLifecycleAgentStorage();
+    const manager = new FakeLifecycleAgentManager(storage);
+    storage.records.set("agent-1", storedAgent("agent-1"));
+
+    const result = await archiveAgentCommand(
+      { agentManager: manager, agentStorage: storage, logger },
+      "agent-1",
+    );
+
+    expect(result.agentId).toBe("agent-1");
+    expect(result.archivedAt).toEqual(expect.any(String));
+    expect(result.record.archivedAt).toBe(result.archivedAt);
+    expect(manager.archivedAgentIds).toEqual([]);
+  });
+
+  test("normalizes metadata updates and rejects empty updates", async () => {
+    const storage = new FakeLifecycleAgentStorage();
+    const manager = new FakeLifecycleAgentManager(storage);
+
+    await expect(
+      updateAgentCommand(
+        { agentManager: manager },
+        {
+          agentId: "agent-1",
+          name: "  Renamed agent  ",
+          labels: { team: "infra" },
+        },
+      ),
+    ).resolves.toEqual({ accepted: true, error: null });
+    await expect(
+      updateAgentCommand({ agentManager: manager }, { agentId: "agent-1", name: "   " }),
+    ).resolves.toEqual({
+      accepted: false,
+      error: "Nothing to update (provide name and/or labels)",
+    });
+
+    expect(manager.metadataUpdates).toEqual([
+      {
+        agentId: "agent-1",
+        updates: {
+          title: "Renamed agent",
+          labels: { team: "infra" },
+        },
+      },
+    ]);
+  });
+
+  test("sets an agent mode and returns the accepted mode", async () => {
+    const storage = new FakeLifecycleAgentStorage();
+    const manager = new FakeLifecycleAgentManager(storage);
+
+    await expect(
+      setAgentModeCommand({ agentManager: manager }, { agentId: "agent-1", modeId: "plan" }),
+    ).resolves.toEqual({ modeId: "plan" });
+
+    expect(manager.modeUpdates).toEqual([{ agentId: "agent-1", modeId: "plan" }]);
+  });
+});
+
+function managedAgent(
+  id: string,
+  lifecycle: LifecycleAgentSnapshot["lifecycle"],
+): LifecycleAgentSnapshot {
+  return {
+    id,
+    cwd: "/workspace/project",
+    lifecycle,
+  };
+}
+
+function storedAgent(id: string): StoredAgentRecord {
+  return {
+    id,
+    provider: "codex",
+    cwd: "/workspace/project",
+    createdAt: "2026-05-10T09:00:00.000Z",
+    updatedAt: "2026-05-10T09:00:00.000Z",
+    labels: {},
+    lastStatus: "closed",
+    config: null,
+    persistence: null,
+    archivedAt: null,
+  };
+}

--- a/packages/server/src/server/agent/lifecycle-command.ts
+++ b/packages/server/src/server/agent/lifecycle-command.ts
@@ -1,0 +1,186 @@
+import type { Logger } from "pino";
+
+import type { ManagedAgent } from "./agent-manager.js";
+import type { StoredAgentRecord } from "./agent-storage.js";
+
+export type LifecycleAgentSnapshot = Pick<ManagedAgent, "id" | "cwd" | "lifecycle">;
+
+export interface LifecycleAgentManager {
+  getAgent(agentId: string): LifecycleAgentSnapshot | null;
+  hasInFlightRun(agentId: string): boolean;
+  cancelAgentRun(agentId: string): Promise<boolean>;
+  clearAgentAttention(agentId: string): Promise<void>;
+  archiveAgent(agentId: string): Promise<{ archivedAt: string }>;
+  archiveSnapshot(agentId: string, archivedAt: string): Promise<StoredAgentRecord>;
+  closeAgent(agentId: string): Promise<void>;
+  updateAgentMetadata(
+    agentId: string,
+    updates: {
+      title?: string;
+      labels?: Record<string, string>;
+    },
+  ): Promise<void>;
+  setAgentMode(agentId: string, modeId: string): Promise<void>;
+}
+
+export interface LifecycleAgentStorage {
+  get(agentId: string): Promise<StoredAgentRecord | null>;
+}
+
+export interface AgentLifecycleCommandDependencies {
+  agentManager: LifecycleAgentManager;
+  agentStorage: LifecycleAgentStorage;
+  logger: Logger;
+}
+
+export interface CancelAgentRunResult {
+  agent: LifecycleAgentSnapshot;
+  cancelled: boolean;
+}
+
+export async function cancelAgentRunCommand(
+  dependencies: Pick<AgentLifecycleCommandDependencies, "agentManager" | "logger">,
+  agentId: string,
+): Promise<CancelAgentRunResult> {
+  const { agentManager, logger } = dependencies;
+  const agent = agentManager.getAgent(agentId);
+  if (!agent) {
+    logger.trace({ agentId }, "cancelAgentRunCommand: agent not found");
+    throw new Error(`Agent ${agentId} not found`);
+  }
+
+  const hasInFlightRun = agentManager.hasInFlightRun(agentId);
+  if (!hasInFlightRun) {
+    logger.trace(
+      { agentId, lifecycle: agent.lifecycle, hasInFlightRun },
+      "cancelAgentRunCommand: skipping because agent is not running",
+    );
+    return { agent, cancelled: false };
+  }
+
+  logger.debug(
+    { agentId, lifecycle: agent.lifecycle, hasInFlightRun },
+    "cancelAgentRunCommand: interrupting",
+  );
+  const startedAt = Date.now();
+  const cancelled = await agentManager.cancelAgentRun(agentId);
+  logger.debug(
+    { agentId, cancelled, durationMs: Date.now() - startedAt },
+    "cancelAgentRunCommand: cancelAgentRun completed",
+  );
+
+  if (!cancelled) {
+    logger.warn(
+      { agentId },
+      "cancelAgentRunCommand: reported running but no active run was cancelled",
+    );
+  }
+
+  return {
+    agent,
+    cancelled,
+  };
+}
+
+export interface ArchiveAgentResult {
+  agentId: string;
+  archivedAt: string;
+  record: StoredAgentRecord;
+}
+
+export async function archiveAgentCommand(
+  dependencies: AgentLifecycleCommandDependencies,
+  agentId: string,
+): Promise<ArchiveAgentResult> {
+  const liveAgent = dependencies.agentManager.getAgent(agentId);
+  if (liveAgent) {
+    await cancelAgentRunCommand(dependencies, agentId);
+    await dependencies.agentManager.clearAgentAttention(agentId).catch(() => undefined);
+    await dependencies.agentManager.archiveAgent(agentId);
+  } else {
+    await archiveStoredAgent(dependencies, agentId);
+  }
+
+  const record = await dependencies.agentStorage.get(agentId);
+  if (!record) {
+    throw new Error(`Agent not found in storage after archive: ${agentId}`);
+  }
+  if (!record.archivedAt) {
+    throw new Error(`Agent missing archivedAt after archive: ${agentId}`);
+  }
+
+  return {
+    agentId,
+    archivedAt: record.archivedAt,
+    record,
+  };
+}
+
+export async function closeAgentCommand(
+  dependencies: Pick<AgentLifecycleCommandDependencies, "agentManager">,
+  agentId: string,
+): Promise<void> {
+  await dependencies.agentManager.closeAgent(agentId);
+}
+
+export interface UpdateAgentResult {
+  accepted: boolean;
+  error: string | null;
+}
+
+export async function updateAgentCommand(
+  dependencies: Pick<AgentLifecycleCommandDependencies, "agentManager">,
+  input: {
+    agentId: string;
+    name?: string;
+    labels?: Record<string, string>;
+  },
+): Promise<UpdateAgentResult> {
+  const title = input.name?.trim();
+  const labels = input.labels && Object.keys(input.labels).length > 0 ? input.labels : undefined;
+
+  if (!title && !labels) {
+    return {
+      accepted: false,
+      error: "Nothing to update (provide name and/or labels)",
+    };
+  }
+
+  await dependencies.agentManager.updateAgentMetadata(input.agentId, {
+    ...(title ? { title } : {}),
+    ...(labels ? { labels } : {}),
+  });
+
+  return {
+    accepted: true,
+    error: null,
+  };
+}
+
+export async function setAgentModeCommand(
+  dependencies: Pick<AgentLifecycleCommandDependencies, "agentManager">,
+  input: {
+    agentId: string;
+    modeId: string;
+  },
+): Promise<{ modeId: string }> {
+  await dependencies.agentManager.setAgentMode(input.agentId, input.modeId);
+  return { modeId: input.modeId };
+}
+
+async function archiveStoredAgent(
+  dependencies: Pick<AgentLifecycleCommandDependencies, "agentManager" | "agentStorage">,
+  agentId: string,
+): Promise<void> {
+  const existing = await dependencies.agentStorage.get(agentId);
+  if (!existing) {
+    throw new Error(`Agent not found: ${agentId}`);
+  }
+
+  if (existing.archivedAt) {
+    return;
+  }
+
+  const archivedAt = new Date().toISOString();
+  await dependencies.agentManager.archiveSnapshot(agentId, archivedAt);
+}

--- a/packages/server/src/server/agent/mcp-server.ts
+++ b/packages/server/src/server/agent/mcp-server.ts
@@ -58,6 +58,13 @@ import {
 } from "./mcp-shared.js";
 import { sendPromptToAgent, setupFinishNotification } from "./agent-prompt.js";
 import { respondToAgentPermission } from "./permission-response.js";
+import {
+  archiveAgentCommand,
+  cancelAgentRunCommand,
+  closeAgentCommand,
+  setAgentModeCommand,
+  updateAgentCommand,
+} from "./lifecycle-command.js";
 import type { GitHubService } from "../../services/github-service.js";
 import type { WorkspaceGitService } from "../workspace-git-service.js";
 import type { CreatePaseoWorktreeInput } from "../paseo-worktree-service.js";
@@ -1054,13 +1061,16 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
       },
     },
     async ({ agentId }) => {
-      const success = await agentManager.cancelAgentRun(agentId);
-      if (success) {
+      const { cancelled } = await cancelAgentRunCommand(
+        { agentManager, logger: childLogger },
+        agentId,
+      );
+      if (cancelled) {
         waitTracker.cancel(agentId, "Agent run cancelled");
       }
       return {
         content: [],
-        structuredContent: ensureValidJson({ success }),
+        structuredContent: ensureValidJson({ success: cancelled }),
       };
     },
   );
@@ -1079,7 +1089,14 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
       },
     },
     async ({ agentId }) => {
-      await agentManager.archiveAgent(agentId);
+      await archiveAgentCommand(
+        {
+          agentManager,
+          agentStorage,
+          logger: childLogger,
+        },
+        agentId,
+      );
       waitTracker.cancel(agentId, "Agent archived");
       return {
         content: [],
@@ -1101,7 +1118,7 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
       },
     },
     async ({ agentId }) => {
-      await agentManager.closeAgent(agentId);
+      await closeAgentCommand({ agentManager }, agentId);
       waitTracker.cancel(agentId, "Agent terminated");
       return {
         content: [],
@@ -1125,15 +1142,10 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
       },
     },
     async ({ agentId, name, labels }) => {
-      const trimmedName = name?.trim();
-      await agentManager.updateAgentMetadata(agentId, {
-        ...(trimmedName ? { title: trimmedName } : {}),
-        ...(labels ? { labels } : {}),
-      });
-
+      const result = await updateAgentCommand({ agentManager }, { agentId, name, labels });
       return {
         content: [],
-        structuredContent: ensureValidJson({ success: true }),
+        structuredContent: ensureValidJson({ success: result.accepted }),
       };
     },
   );
@@ -1847,10 +1859,10 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
       },
     },
     async ({ agentId, modeId }) => {
-      await agentManager.setAgentMode(agentId, modeId);
+      const result = await setAgentModeCommand({ agentManager }, { agentId, modeId });
       return {
         content: [],
-        structuredContent: ensureValidJson({ success: true, newMode: modeId }),
+        structuredContent: ensureValidJson({ success: true, newMode: result.modeId }),
       };
     },
   );

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -99,6 +99,13 @@ import type {
 } from "./agent/agent-manager.js";
 import { createAgentCommand } from "./agent/create-agent/create.js";
 import {
+  archiveAgentCommand,
+  cancelAgentRunCommand,
+  closeAgentCommand,
+  setAgentModeCommand,
+  updateAgentCommand,
+} from "./agent/lifecycle-command.js";
+import {
   buildStoredAgentPayload,
   resolveEffectiveThinkingOptionId,
   resolveStoredAgentPayloadUpdatedAt,
@@ -2141,7 +2148,7 @@ export class Session {
     beginAgentDeleteIfSupported(this.agentStorage, agentId);
 
     try {
-      await this.agentManager.closeAgent(agentId);
+      await closeAgentCommand({ agentManager: this.agentManager }, agentId);
     } catch (error) {
       this.sessionLogger.warn(
         { err: error, agentId },
@@ -2195,43 +2202,17 @@ export class Session {
     });
   }
 
-  private async archiveStoredAgentForClose(
-    agentId: string,
-  ): Promise<{ agentId: string; archivedAt: string }> {
-    const existing = await this.agentStorage.get(agentId);
-    if (!existing) {
-      throw new Error(`Agent not found: ${agentId}`);
-    }
-
-    if (existing.archivedAt) {
-      return {
-        agentId,
-        archivedAt: existing.archivedAt,
-      };
-    }
-
-    const archivedAt = new Date().toISOString();
-    await this.agentManager.archiveSnapshot(agentId, archivedAt);
-
-    return { agentId, archivedAt };
-  }
-
   private async archiveAgentForClose(
     agentId: string,
   ): Promise<{ agentId: string; archivedAt: string }> {
-    const liveAgent = this.agentManager.getAgent(agentId);
-    if (liveAgent) {
-      await this.interruptAgentIfRunning(agentId);
-      await this.agentManager.clearAgentAttention(agentId).catch(() => undefined);
-      await this.agentManager.archiveAgent(agentId);
-    } else {
-      await this.archiveStoredAgentForClose(agentId);
-    }
-
-    const archivedRecord = await this.agentStorage.get(agentId);
-    if (!archivedRecord) {
-      throw new Error(`Agent not found in storage after archive: ${agentId}`);
-    }
+    const { archivedAt, record: archivedRecord } = await archiveAgentCommand(
+      {
+        agentManager: this.agentManager,
+        agentStorage: this.agentStorage,
+        logger: this.sessionLogger,
+      },
+      agentId,
+    );
 
     if (this.agentUpdatesSubscription) {
       const payload = this.buildStoredAgentPayload(archivedRecord);
@@ -2264,11 +2245,7 @@ export class Session {
       await this.emitWorkspaceUpdateForCwd(payload.cwd);
     }
 
-    if (!archivedRecord.archivedAt) {
-      throw new Error(`Agent missing archivedAt after archive: ${agentId}`);
-    }
-
-    return { agentId, archivedAt: archivedRecord.archivedAt };
+    return { agentId, archivedAt };
   }
 
   private async handleCloseItemsRequest(msg: CloseItemsRequest): Promise<void> {
@@ -2343,27 +2320,24 @@ export class Session {
       "session: update_agent_request",
     );
 
-    const normalizedName = name?.trim();
-    const normalizedLabels = labels && Object.keys(labels).length > 0 ? labels : undefined;
-
-    if (!normalizedName && !normalizedLabels) {
-      this.emit({
-        type: "update_agent_response",
-        payload: {
-          requestId,
-          agentId,
-          accepted: false,
-          error: "Nothing to update (provide name and/or labels)",
-        },
-      });
-      return;
-    }
-
     try {
-      await this.agentManager.updateAgentMetadata(agentId, {
-        ...(normalizedName ? { title: normalizedName } : {}),
-        ...(normalizedLabels ? { labels: normalizedLabels } : {}),
-      });
+      const result = await updateAgentCommand(
+        { agentManager: this.agentManager },
+        { agentId, name, labels },
+      );
+
+      if (!result.accepted) {
+        this.emit({
+          type: "update_agent_response",
+          payload: {
+            requestId,
+            agentId,
+            accepted: false,
+            error: result.error,
+          },
+        });
+        return;
+      }
 
       this.emit({
         type: "update_agent_response",
@@ -3140,7 +3114,10 @@ export class Session {
     this.sessionLogger.info({ agentId }, `Cancel request received for agent ${agentId}`);
 
     try {
-      await this.interruptAgentIfRunning(agentId);
+      await cancelAgentRunCommand(
+        { agentManager: this.agentManager, logger: this.sessionLogger },
+        agentId,
+      );
       if (requestId) {
         const agent = this.agentManager.getAgent(agentId);
         const payload = agent ? await this.buildAgentPayload(agent) : null;
@@ -3903,7 +3880,7 @@ export class Session {
     this.sessionLogger.info({ agentId, modeId, requestId }, "session: set_agent_mode_request");
 
     try {
-      await this.agentManager.setAgentMode(agentId, modeId);
+      await setAgentModeCommand({ agentManager: this.agentManager }, { agentId, modeId });
       this.sessionLogger.info(
         { agentId, modeId, requestId },
         "session: set_agent_mode_request success",


### PR DESCRIPTION
## Summary
- Extract shared agent lifecycle mutation commands for cancel, archive, close, update metadata, and set mode.
- Route Session and Agent MCP lifecycle mutation entrypoints through the shared command boundary while keeping WS/MCP response shaping local.
- Add focused command tests with typed in-memory fakes.

## Verification
- npm run format
- npm run typecheck
- npm run lint
- npx vitest run packages/server/src/server/agent/lifecycle-command.test.ts --bail=1
- npx vitest run packages/server/src/server/agent/mcp-parity.e2e.test.ts --bail=1 (relevant lifecycle cases pass; existing Suite C schedule test fails at packages/server/src/server/agent/mcp-parity.e2e.test.ts:484 because z.string().parse receives undefined)

Stacked on refactor-create-agent-command.