### PR TITLE
refactor(server): extract worktree archive command

### DIFF
--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
 import { realpathSync } from "node:fs";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { join, resolve as resolvePath } from "node:path";
 import { tmpdir } from "node:os";
 import { z } from "zod";
@@ -1144,6 +1144,75 @@ describe("create_agent MCP tool", () => {
       expect(Array.from(emitWorkspaceUpdatesForWorkspaceIds.mock.calls[0]?.[0] ?? [])).toEqual([
         created.structuredContent.worktreePath,
       ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("archives a worktree by slug", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const tempDir = realpathSync.native(
+      await mkdtemp(join(tmpdir(), "paseo-mcp-archive-worktree-slug-")),
+    );
+    const repoDir = join(tempDir, "repo");
+    const paseoHome = join(tempDir, ".paseo");
+
+    try {
+      execFileSync("git", ["init", repoDir], { stdio: "pipe" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], {
+        cwd: repoDir,
+        stdio: "pipe",
+      });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: repoDir, stdio: "pipe" });
+      execFileSync("git", ["config", "commit.gpgsign", "false"], {
+        cwd: repoDir,
+        stdio: "pipe",
+      });
+      await writeFile(join(repoDir, "README.md"), "hello\n");
+      execFileSync("git", ["add", "README.md"], { cwd: repoDir, stdio: "pipe" });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: repoDir, stdio: "pipe" });
+      execFileSync("git", ["branch", "-M", "main"], { cwd: repoDir, stdio: "pipe" });
+
+      const workspaceGitService = {
+        getSnapshot: vi.fn(async () => null),
+      };
+      const server = await createAgentMcpServer({
+        agentManager,
+        agentStorage,
+        paseoHome,
+        createPaseoWorktree: createPaseoWorktreeForMcpTest({ paseoHome, broadcasts: [] }),
+        workspaceGitService: workspaceGitService as unknown as Pick<
+          WorkspaceGitService,
+          "getSnapshot" | "listWorktrees"
+        >,
+        archiveWorkspaceRecord: vi.fn(async () => undefined),
+        emitWorkspaceUpdatesForWorkspaceIds: vi.fn(async () => undefined),
+        markWorkspaceArchiving: vi.fn(),
+        clearWorkspaceArchiving: vi.fn(),
+        emitSessionMessage: vi.fn(),
+        github: createGitHubServiceStub(),
+        logger,
+      });
+      const createTool = registeredTool(server, "create_worktree");
+      const archiveTool = registeredTool(server, "archive_worktree");
+      const created = await createTool.handler({
+        cwd: repoDir,
+        target: { mode: "branch-off", newBranch: "archive-slug-worktree", base: "main" },
+      });
+
+      const response = await archiveTool.handler({
+        cwd: repoDir,
+        worktreeSlug: "archive-slug-worktree",
+      });
+
+      expect(response.structuredContent).toEqual({ success: true });
+      expect(workspaceGitService.getSnapshot).toHaveBeenCalledWith(repoDir, {
+        force: true,
+        reason: "archive-worktree",
+      });
+      await expect(
+        access(z.string().parse(created.structuredContent.worktreePath)),
+      ).rejects.toThrow();
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }

--- a/packages/server/src/server/agent/mcp-server.ts
+++ b/packages/server/src/server/agent/mcp-server.ts
@@ -24,9 +24,7 @@ import { selectItemsByProjectedLimit } from "./timeline-projection.js";
 import type { AgentStorage } from "./agent-storage.js";
 import { ensureAgentLoaded } from "./agent-loading.js";
 import { isStoredAgentProviderAvailable } from "../persistence-hooks.js";
-import { getPaseoWorktreesRoot } from "../../utils/worktree.js";
 import {
-  archivePaseoWorktree,
   killTerminalsUnderPath,
   type ArchivePaseoWorktreeDependencies,
 } from "../paseo-worktree-archive-service.js";
@@ -69,7 +67,10 @@ import type { GitHubService } from "../../services/github-service.js";
 import type { WorkspaceGitService } from "../workspace-git-service.js";
 import type { CreatePaseoWorktreeInput } from "../paseo-worktree-service.js";
 import { toWorktreeRequestError } from "../worktree-errors.js";
-import { join } from "node:path";
+import {
+  archivePaseoWorktreeCommand,
+  type ArchivePaseoWorktreeCommandDependencies,
+} from "../worktree/commands.js";
 
 export interface AgentMcpServerOptions {
   agentManager: AgentManager;
@@ -1722,63 +1723,23 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
       if (!worktreePath && !worktreeSlug) {
         throw new Error("worktreePath or worktreeSlug is required");
       }
-      if (!options.github) {
-        throw new Error("GitHub service is required to archive worktrees");
-      }
-      if (!options.workspaceGitService) {
-        throw new Error("WorkspaceGitService is required to archive worktrees");
-      }
-      if (!options.archiveWorkspaceRecord) {
-        throw new Error("Workspace registry archiver is required to archive worktrees");
-      }
-      if (!options.emitWorkspaceUpdatesForWorkspaceIds) {
-        throw new Error("Workspace update emitter is required to archive worktrees");
-      }
-      if (!options.markWorkspaceArchiving) {
-        throw new Error("Workspace archiving marker is required to archive worktrees");
-      }
-      if (!options.clearWorkspaceArchiving) {
-        throw new Error("Workspace archiving clearer is required to archive worktrees");
-      }
-      if (!options.emitSessionMessage) {
-        throw new Error("Session message emitter is required to archive worktrees");
-      }
-
-      const targetPath =
-        worktreePath ??
-        join(await getPaseoWorktreesRoot(repoRoot, options.paseoHome), worktreeSlug!);
-
-      await archivePaseoWorktree(
-        {
-          paseoHome: options.paseoHome,
-          github: options.github,
-          workspaceGitService: options.workspaceGitService,
+      const result = await archivePaseoWorktreeCommand(
+        archiveWorktreeDependencies(options, {
           agentManager,
           agentStorage,
-          archiveWorkspaceRecord: options.archiveWorkspaceRecord,
-          emit: options.emitSessionMessage,
-          emitWorkspaceUpdatesForWorkspaceIds: options.emitWorkspaceUpdatesForWorkspaceIds,
-          markWorkspaceArchiving: options.markWorkspaceArchiving,
-          clearWorkspaceArchiving: options.clearWorkspaceArchiving,
-          isPathWithinRoot: isSameOrDescendantPath,
-          killTerminalsUnderPath: (rootPath) =>
-            killTerminalsUnderPath(
-              {
-                terminalManager: terminalManager ?? null,
-                isPathWithinRoot: isSameOrDescendantPath,
-                killTrackedTerminal: () => {},
-                sessionLogger: childLogger,
-              },
-              rootPath,
-            ),
-          sessionLogger: childLogger,
-        },
+          terminalManager: terminalManager ?? null,
+          logger: childLogger,
+        }),
         {
-          targetPath,
-          repoRoot,
           requestId: "mcp:archive_worktree",
+          repoRoot,
+          worktreePath,
+          worktreeSlug,
         },
       );
+      if (!result.ok) {
+        throw new Error(result.message);
+      }
 
       return {
         content: [],
@@ -1938,6 +1899,65 @@ type McpCreateWorktreeTarget =
   | { mode: "branch-off"; newBranch: string; base?: string }
   | { mode: "checkout-branch"; branch: string }
   | { mode: "checkout-pr"; prNumber: number };
+
+interface ArchiveWorktreeCommandContext {
+  agentManager: AgentManager;
+  agentStorage: AgentStorage;
+  terminalManager: TerminalManager | null;
+  logger: Logger;
+}
+
+function archiveWorktreeDependencies(
+  options: AgentMcpServerOptions,
+  context: ArchiveWorktreeCommandContext,
+): ArchivePaseoWorktreeCommandDependencies {
+  if (!options.github) {
+    throw new Error("GitHub service is required to archive worktrees");
+  }
+  if (!options.workspaceGitService) {
+    throw new Error("WorkspaceGitService is required to archive worktrees");
+  }
+  if (!options.archiveWorkspaceRecord) {
+    throw new Error("Workspace registry archiver is required to archive worktrees");
+  }
+  if (!options.emitWorkspaceUpdatesForWorkspaceIds) {
+    throw new Error("Workspace update emitter is required to archive worktrees");
+  }
+  if (!options.markWorkspaceArchiving) {
+    throw new Error("Workspace archiving marker is required to archive worktrees");
+  }
+  if (!options.clearWorkspaceArchiving) {
+    throw new Error("Workspace archiving clearer is required to archive worktrees");
+  }
+  if (!options.emitSessionMessage) {
+    throw new Error("Session message emitter is required to archive worktrees");
+  }
+
+  return {
+    paseoHome: options.paseoHome,
+    github: options.github,
+    workspaceGitService: options.workspaceGitService,
+    agentManager: context.agentManager,
+    agentStorage: context.agentStorage,
+    archiveWorkspaceRecord: options.archiveWorkspaceRecord,
+    emit: options.emitSessionMessage,
+    emitWorkspaceUpdatesForWorkspaceIds: options.emitWorkspaceUpdatesForWorkspaceIds,
+    markWorkspaceArchiving: options.markWorkspaceArchiving,
+    clearWorkspaceArchiving: options.clearWorkspaceArchiving,
+    isPathWithinRoot: isSameOrDescendantPath,
+    killTerminalsUnderPath: (rootPath: string) =>
+      killTerminalsUnderPath(
+        {
+          terminalManager: context.terminalManager,
+          isPathWithinRoot: isSameOrDescendantPath,
+          killTrackedTerminal: () => {},
+          sessionLogger: context.logger,
+        },
+        rootPath,
+      ),
+    sessionLogger: context.logger,
+  };
+}
 
 function mcpCreateWorktreeInput(
   repoRoot: string,

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -27,7 +27,6 @@ import type { CheckoutExistingBranchResult } from "../utils/checkout-git.js";
 import { expandTilde } from "../utils/path.js";
 import {
   getWorktreeSetupCommands,
-  isPaseoOwnedWorktreeCwd,
   resolveWorktreeRuntimeEnv,
   runWorktreeSetupCommands,
   slugify,
@@ -41,11 +40,9 @@ import type {
   CreatePaseoWorktreeInput,
   CreatePaseoWorktreeResult,
 } from "./paseo-worktree-service.js";
-import {
-  archivePaseoWorktree,
-  type ArchivePaseoWorktreeDependencies,
-} from "./paseo-worktree-archive-service.js";
+import type { ArchivePaseoWorktreeDependencies } from "./paseo-worktree-archive-service.js";
 import { toWorktreeWireError } from "./worktree-errors.js";
+import { archivePaseoWorktreeCommand } from "./worktree/commands.js";
 
 const SAFE_GIT_REF_PATTERN = /^[A-Za-z0-9._/-]+$/;
 
@@ -433,37 +430,23 @@ export async function handlePaseoWorktreeArchiveRequest(
   msg: Extract<SessionInboundMessage, { type: "paseo_worktree_archive_request" }>,
 ): Promise<void> {
   const { requestId } = msg;
-  let targetPath = msg.worktreePath;
-  let repoRoot = msg.repoRoot ?? null;
 
   try {
-    if (!targetPath) {
-      if (!repoRoot || !msg.branchName) {
-        throw new Error("worktreePath or repoRoot+branchName is required");
-      }
-      const worktrees = await dependencies.workspaceGitService.listWorktrees(repoRoot);
-      const match = worktrees.find((entry) => entry.branchName === msg.branchName);
-      if (!match) {
-        throw new Error(`Paseo worktree not found for branch ${msg.branchName}`);
-      }
-      targetPath = match.path;
-    }
-    if (!targetPath) {
-      throw new Error("worktreePath could not be resolved");
-    }
-
-    const ownership = await isPaseoOwnedWorktreeCwd(targetPath, {
-      paseoHome: dependencies.paseoHome,
+    const result = await archivePaseoWorktreeCommand(dependencies, {
+      requestId,
+      worktreePath: msg.worktreePath,
+      repoRoot: msg.repoRoot,
+      branchName: msg.branchName,
     });
-    if (!ownership.allowed) {
+    if (!result.ok) {
       dependencies.emit({
         type: "paseo_worktree_archive_response",
         payload: {
           success: false,
-          removedAgents: [],
+          removedAgents: result.removedAgents,
           error: {
-            code: "NOT_ALLOWED",
-            message: "Worktree is not a Paseo-owned worktree",
+            code: result.code,
+            message: result.message,
           },
           requestId,
         },
@@ -471,23 +454,11 @@ export async function handlePaseoWorktreeArchiveRequest(
       return;
     }
 
-    // repoRoot is best-effort: if git has forgotten about the worktree we
-    // still proceed using the path-derived worktreesRoot, since the ownership
-    // check already proved the path lives under $PASEO_HOME/worktrees.
-    repoRoot = ownership.repoRoot ?? repoRoot ?? null;
-
-    const removedAgents = await archivePaseoWorktree(dependencies, {
-      targetPath,
-      repoRoot,
-      worktreesRoot: ownership.worktreeRoot,
-      requestId,
-    });
-
     dependencies.emit({
       type: "paseo_worktree_archive_response",
       payload: {
         success: true,
-        removedAgents,
+        removedAgents: result.removedAgents,
         error: null,
         requestId,
       },

--- a/packages/server/src/server/worktree/commands.ts
+++ b/packages/server/src/server/worktree/commands.ts
@@ -1,0 +1,112 @@
+import { join } from "node:path";
+
+import { getPaseoWorktreesRoot, isPaseoOwnedWorktreeCwd } from "../../utils/worktree.js";
+import {
+  archivePaseoWorktree,
+  type ArchivePaseoWorktreeDependencies,
+} from "../paseo-worktree-archive-service.js";
+import type { WorkspaceGitService } from "../workspace-git-service.js";
+
+export interface ArchivePaseoWorktreeCommandDependencies extends Omit<
+  ArchivePaseoWorktreeDependencies,
+  "workspaceGitService"
+> {
+  workspaceGitService: Pick<WorkspaceGitService, "getSnapshot" | "listWorktrees">;
+}
+
+export interface ArchivePaseoWorktreeCommandInput {
+  requestId: string;
+  repoRoot?: string | null;
+  worktreePath?: string;
+  worktreeSlug?: string;
+  branchName?: string;
+}
+
+export type ArchivePaseoWorktreeCommandResult =
+  | {
+      ok: true;
+      removedAgents: string[];
+    }
+  | {
+      ok: false;
+      code: "NOT_ALLOWED";
+      message: string;
+      removedAgents: [];
+    };
+
+export async function archivePaseoWorktreeCommand(
+  dependencies: ArchivePaseoWorktreeCommandDependencies,
+  input: ArchivePaseoWorktreeCommandInput,
+): Promise<ArchivePaseoWorktreeCommandResult> {
+  const resolvedTarget = await resolveArchiveTarget(dependencies, input);
+  const ownership = await isPaseoOwnedWorktreeCwd(resolvedTarget.targetPath, {
+    paseoHome: dependencies.paseoHome,
+  });
+
+  if (!ownership.allowed) {
+    return {
+      ok: false,
+      code: "NOT_ALLOWED",
+      message: "Worktree is not a Paseo-owned worktree",
+      removedAgents: [],
+    };
+  }
+
+  const repoRoot = ownership.repoRoot ?? resolvedTarget.repoRoot ?? null;
+  const removedAgents = await archivePaseoWorktree(dependencies, {
+    targetPath: resolvedTarget.targetPath,
+    repoRoot,
+    worktreesRoot: ownership.worktreeRoot,
+    requestId: input.requestId,
+  });
+
+  return {
+    ok: true,
+    removedAgents,
+  };
+}
+
+interface ResolvedArchiveTarget {
+  targetPath: string;
+  repoRoot: string | null;
+}
+
+async function resolveArchiveTarget(
+  dependencies: ArchivePaseoWorktreeCommandDependencies,
+  input: ArchivePaseoWorktreeCommandInput,
+): Promise<ResolvedArchiveTarget> {
+  const repoRoot = input.repoRoot ?? null;
+  if (input.worktreePath) {
+    return { targetPath: input.worktreePath, repoRoot };
+  }
+
+  if (input.worktreeSlug) {
+    if (!repoRoot) {
+      throw new Error("repoRoot is required when worktreeSlug is supplied");
+    }
+    return {
+      targetPath: await resolveWorktreeSlugPath(dependencies, repoRoot, input.worktreeSlug),
+      repoRoot,
+    };
+  }
+
+  if (repoRoot && input.branchName) {
+    const worktrees = await dependencies.workspaceGitService.listWorktrees(repoRoot);
+    const match = worktrees.find((entry) => entry.branchName === input.branchName);
+    if (!match) {
+      throw new Error(`Paseo worktree not found for branch ${input.branchName}`);
+    }
+    return { targetPath: match.path, repoRoot };
+  }
+
+  throw new Error("worktreePath, worktreeSlug, or repoRoot+branchName is required");
+}
+
+async function resolveWorktreeSlugPath(
+  dependencies: ArchivePaseoWorktreeCommandDependencies,
+  repoRoot: string,
+  worktreeSlug: string,
+): Promise<string> {
+  const worktreesRoot = await getPaseoWorktreesRoot(repoRoot, dependencies.paseoHome);
+  return join(worktreesRoot, worktreeSlug);
+}


### PR DESCRIPTION
## Summary
- Extract shared `archivePaseoWorktreeCommand` for common worktree archive target resolution, ownership checks, and archive service invocation.
- Make Session and MCP archive handlers entrypoint adapters: Session emits WS response shapes; MCP returns structured content and keeps MCP argument errors local.
- Add MCP coverage for archiving a worktree by slug.

## Risk and Coverage Notes
- Low risk: archive teardown/delete side effects stay in `archivePaseoWorktree`, covered by `worktree-session.test.ts` archive cases for agent close, terminal teardown, archiving state updates, failure cleanup, orphaned git metadata, and snapshot refresh.
- Low risk: MCP archive side effects remain covered by `mcp-server.test.ts` for snapshot refresh and workspace archiving callbacks.
- Newly covered: MCP `archive_worktree` with `worktreeSlug`, proving the shared command preserves slug-to-Paseo-worktree-path behavior and deletes the worktree.
- Intentional transport difference: Session maps `NOT_ALLOWED` to `paseo_worktree_archive_response`; MCP throws the tool error. Both cross the same command result.

## Verification
- `npx vitest run packages/server/src/server/worktree-session.test.ts packages/server/src/server/agent/mcp-server.test.ts --bail=1`
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- pre-commit hook: lint, format:check:files, typecheck

## Refactor Candidate
Chosen: shared archive worktree command.

The deleted duplication was target resolution plus Paseo ownership policy in Session and MCP. Deleting the new command would make `worktree-session.ts` regain branch lookup and ownership checks, and `mcp-server.ts` regain slug/path construction plus archive service assembly.

Next likely slice: standalone create/list worktree commands, if a deletion test shows enough remaining drift beyond the existing `createPaseoWorktreeWorkflow`.
