### PR TITLE
refactor(server): share worktree create/list commands

### DIFF
--- a/packages/server/src/server/agent/lifecycle-command.ts
+++ b/packages/server/src/server/agent/lifecycle-command.ts
@@ -31,6 +31,7 @@ export interface AgentLifecycleCommandDependencies {
   agentManager: LifecycleAgentManager;
   agentStorage: LifecycleAgentStorage;
   logger: Logger;
+  cancelLiveRun?: (agentId: string) => Promise<void>;
 }
 
 export interface CancelAgentRunResult {
@@ -94,7 +95,11 @@ export async function archiveAgentCommand(
 ): Promise<ArchiveAgentResult> {
   const liveAgent = dependencies.agentManager.getAgent(agentId);
   if (liveAgent) {
-    await cancelAgentRunCommand(dependencies, agentId);
+    if (dependencies.cancelLiveRun) {
+      await dependencies.cancelLiveRun(agentId);
+    } else {
+      await cancelAgentRunCommand(dependencies, agentId);
+    }
     await dependencies.agentManager.clearAgentAttention(agentId).catch(() => undefined);
     await dependencies.agentManager.archiveAgent(agentId);
   } else {

--- a/packages/server/src/server/agent/mcp-server.ts
+++ b/packages/server/src/server/agent/mcp-server.ts
@@ -33,11 +33,7 @@ import { createAgentCommand } from "./create-agent/create.js";
 import type { VoiceCallerContext, VoiceSpeakHandler } from "../voice-types.js";
 import { expandUserPath, isSameOrDescendantPath, resolvePathFromBase } from "../path-utils.js";
 import type { TerminalManager } from "../../terminal/terminal-manager.js";
-import type {
-  CreatePaseoWorktreeSetupContinuationInput,
-  CreatePaseoWorktreeWorkflowFn,
-  CreatePaseoWorktreeWorkflowResult,
-} from "../worktree-session.js";
+import type { CreatePaseoWorktreeWorkflowFn } from "../worktree-session.js";
 import type { ScheduleService } from "../schedule/service.js";
 import { ScheduleSummarySchema, StoredScheduleSchema } from "../schedule/types.js";
 import type { ProviderDefinition } from "./provider-registry.js";
@@ -65,11 +61,13 @@ import {
 } from "./lifecycle-command.js";
 import type { GitHubService } from "../../services/github-service.js";
 import type { WorkspaceGitService } from "../workspace-git-service.js";
-import type { CreatePaseoWorktreeInput } from "../paseo-worktree-service.js";
-import { toWorktreeRequestError } from "../worktree-errors.js";
+import { WorktreeRequestError } from "../worktree-errors.js";
 import {
   archivePaseoWorktreeCommand,
   type ArchivePaseoWorktreeCommandDependencies,
+  createPaseoWorktreeCommand,
+  type CreatePaseoWorktreeCommandInput,
+  listPaseoWorktreesCommand,
 } from "../worktree/commands.js";
 
 export interface AgentMcpServerOptions {
@@ -1629,9 +1627,13 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
       if (!options.workspaceGitService) {
         throw new Error("WorkspaceGitService is required to list worktrees");
       }
-      const worktrees = await options.workspaceGitService.listWorktrees(resolvedCwd, {
-        reason: "mcp:list-worktrees",
-      });
+      const worktrees = await listPaseoWorktreesCommand(
+        { workspaceGitService: options.workspaceGitService },
+        {
+          cwd: resolvedCwd,
+          reason: "mcp:list-worktrees",
+        },
+      );
 
       return {
         content: [],
@@ -1683,13 +1685,17 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
     },
     async ({ cwd, target }) => {
       const repoRoot = resolveScopedCwd(cwd, { required: true });
-      const mcpInput = mcpCreateWorktreeInput(repoRoot, target, options.paseoHome);
-      const createdWorktree = await createMcpWorktree({
-        input: mcpInput.input,
-        createPaseoWorktree: options.createPaseoWorktree,
-        resolveDefaultBranch: mcpInput.resolveDefaultBranch,
-      });
-      const { worktree } = createdWorktree;
+      const commandResult = await createPaseoWorktreeCommand(
+        {
+          paseoHome: options.paseoHome,
+          createPaseoWorktreeWorkflow: options.createPaseoWorktree,
+        },
+        createMcpWorktreeCommandInput(repoRoot, target),
+      );
+      if (!commandResult.ok) {
+        throw new WorktreeRequestError(commandResult.error);
+      }
+      const { worktree } = commandResult.createdWorktree;
 
       return {
         content: [],
@@ -1959,57 +1965,24 @@ function archiveWorktreeDependencies(
   };
 }
 
-function mcpCreateWorktreeInput(
+function createMcpWorktreeCommandInput(
   repoRoot: string,
   target: McpCreateWorktreeTarget,
-  paseoHome: string | undefined,
-): { input: CreatePaseoWorktreeInput; resolveDefaultBranch?: (root: string) => Promise<string> } {
-  const base = { cwd: repoRoot, runSetup: false, paseoHome } as const;
+): CreatePaseoWorktreeCommandInput {
+  const base = { cwd: repoRoot } as const;
   switch (target.mode) {
     case "branch-off":
       return {
-        input: {
-          ...base,
-          worktreeSlug: target.newBranch,
-          action: "branch-off",
-          ...(target.base ? { refName: target.base } : {}),
-        },
+        ...base,
+        worktreeSlug: target.newBranch,
+        action: "branch-off",
+        ...(target.base ? { refName: target.base } : {}),
       };
     case "checkout-branch":
-      return {
-        input: { ...base, action: "checkout", refName: target.branch },
-      };
+      return { ...base, action: "checkout", refName: target.branch };
     case "checkout-pr":
-      return {
-        input: { ...base, action: "checkout", githubPrNumber: target.prNumber },
-      };
+      return { ...base, action: "checkout", githubPrNumber: target.prNumber };
     default:
       throw new Error("unreachable");
-  }
-}
-
-interface CreateMcpWorktreeOptions {
-  input: CreatePaseoWorktreeInput;
-  createPaseoWorktree: CreatePaseoWorktreeWorkflowFn | undefined;
-  resolveDefaultBranch?: (repoRoot: string) => Promise<string>;
-  setupContinuation?: CreatePaseoWorktreeSetupContinuationInput;
-}
-
-async function createMcpWorktree(
-  options: CreateMcpWorktreeOptions,
-): Promise<CreatePaseoWorktreeWorkflowResult> {
-  try {
-    if (!options.createPaseoWorktree) {
-      throw new Error("Paseo worktree service is not configured");
-    }
-    const result = await options.createPaseoWorktree(options.input, {
-      ...(options.resolveDefaultBranch
-        ? { resolveDefaultBranch: options.resolveDefaultBranch }
-        : {}),
-      ...(options.setupContinuation ? { setupContinuation: options.setupContinuation } : {}),
-    });
-    return result;
-  } catch (error) {
-    throw toWorktreeRequestError(error);
   }
 }

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2210,6 +2210,7 @@ export class Session {
         agentManager: this.agentManager,
         agentStorage: this.agentStorage,
         logger: this.sessionLogger,
+        cancelLiveRun: (liveAgentId) => this.interruptAgentIfRunning(liveAgentId),
       },
       agentId,
     );

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -42,7 +42,11 @@ import type {
 } from "./paseo-worktree-service.js";
 import type { ArchivePaseoWorktreeDependencies } from "./paseo-worktree-archive-service.js";
 import { toWorktreeWireError } from "./worktree-errors.js";
-import { archivePaseoWorktreeCommand } from "./worktree/commands.js";
+import {
+  archivePaseoWorktreeCommand,
+  createPaseoWorktreeCommand,
+  listPaseoWorktreesCommand,
+} from "./worktree/commands.js";
 
 const SAFE_GIT_REF_PATTERN = /^[A-Za-z0-9._/-]+$/;
 
@@ -392,7 +396,10 @@ export async function handlePaseoWorktreeListRequest(
   }
 
   try {
-    const worktrees = await dependencies.workspaceGitService.listWorktrees(cwd);
+    const worktrees = await listPaseoWorktreesCommand(
+      { workspaceGitService: dependencies.workspaceGitService },
+      { cwd },
+    );
     dependencies.emit({
       type: "paseo_worktree_list_response",
       payload: {
@@ -481,17 +488,40 @@ export async function handleCreatePaseoWorktreeRequest(
   request: Extract<SessionInboundMessage, { type: "create_paseo_worktree_request" }>,
 ): Promise<void> {
   try {
-    const createdWorktree = await dependencies.createPaseoWorktreeWorkflow({
-      cwd: request.cwd,
-      worktreeSlug: request.worktreeSlug,
-      firstAgentContext: normalizeFirstAgentContext(request),
-      refName: request.refName,
-      action: request.action,
-      githubPrNumber: request.githubPrNumber,
-      runSetup: false,
-      paseoHome: dependencies.paseoHome,
-    });
+    const commandResult = await createPaseoWorktreeCommand(
+      {
+        paseoHome: dependencies.paseoHome,
+        createPaseoWorktreeWorkflow: dependencies.createPaseoWorktreeWorkflow,
+      },
+      {
+        cwd: request.cwd,
+        worktreeSlug: request.worktreeSlug,
+        firstAgentContext: normalizeFirstAgentContext(request),
+        refName: request.refName,
+        action: request.action,
+        githubPrNumber: request.githubPrNumber,
+      },
+    );
 
+    if (!commandResult.ok) {
+      dependencies.sessionLogger.error(
+        { err: commandResult.cause, cwd: request.cwd, worktreeSlug: request.worktreeSlug },
+        "Failed to create worktree",
+      );
+      dependencies.emit({
+        type: "create_paseo_worktree_response",
+        payload: {
+          workspace: null,
+          error: commandResult.error.message,
+          errorCode: commandResult.error.code,
+          setupTerminalId: null,
+          requestId: request.requestId,
+        },
+      });
+      return;
+    }
+
+    const createdWorktree = commandResult.createdWorktree;
     const descriptor = await dependencies.describeWorkspaceRecord(createdWorktree);
     dependencies.emit({
       type: "create_paseo_worktree_response",

--- a/packages/server/src/server/worktree/commands.ts
+++ b/packages/server/src/server/worktree/commands.ts
@@ -5,7 +5,84 @@ import {
   archivePaseoWorktree,
   type ArchivePaseoWorktreeDependencies,
 } from "../paseo-worktree-archive-service.js";
-import type { WorkspaceGitService } from "../workspace-git-service.js";
+import type {
+  CreatePaseoWorktreeInput,
+  CreatePaseoWorktreeResult,
+} from "../paseo-worktree-service.js";
+import { toWorktreeWireError, type WorktreeWireError } from "../worktree-errors.js";
+import type { WorkspaceGitService, WorkspaceGitWorktreeInfo } from "../workspace-git-service.js";
+
+export interface ListPaseoWorktreesCommandDependencies {
+  workspaceGitService: Pick<WorkspaceGitService, "listWorktrees">;
+}
+
+export interface ListPaseoWorktreesCommandInput {
+  cwd: string;
+  reason?: string;
+}
+
+export async function listPaseoWorktreesCommand(
+  dependencies: ListPaseoWorktreesCommandDependencies,
+  input: ListPaseoWorktreesCommandInput,
+): Promise<WorkspaceGitWorktreeInfo[]> {
+  if (input.reason) {
+    return dependencies.workspaceGitService.listWorktrees(input.cwd, { reason: input.reason });
+  }
+  return dependencies.workspaceGitService.listWorktrees(input.cwd);
+}
+
+type CreatePaseoWorktreeWorkflow<Result extends CreatePaseoWorktreeResult> = (
+  input: CreatePaseoWorktreeInput,
+) => Promise<Result>;
+
+export interface CreatePaseoWorktreeCommandDependencies<
+  Result extends CreatePaseoWorktreeResult = CreatePaseoWorktreeResult,
+> {
+  paseoHome?: string;
+  createPaseoWorktreeWorkflow?: CreatePaseoWorktreeWorkflow<Result>;
+}
+
+export type CreatePaseoWorktreeCommandInput = Omit<
+  CreatePaseoWorktreeInput,
+  "paseoHome" | "runSetup"
+> & {
+  paseoHome?: string;
+};
+
+export type CreatePaseoWorktreeCommandResult<Result extends CreatePaseoWorktreeResult> =
+  | {
+      ok: true;
+      createdWorktree: Result;
+    }
+  | {
+      ok: false;
+      error: WorktreeWireError;
+      cause: unknown;
+    };
+
+export async function createPaseoWorktreeCommand<Result extends CreatePaseoWorktreeResult>(
+  dependencies: CreatePaseoWorktreeCommandDependencies<Result>,
+  input: CreatePaseoWorktreeCommandInput,
+): Promise<CreatePaseoWorktreeCommandResult<Result>> {
+  try {
+    if (!dependencies.createPaseoWorktreeWorkflow) {
+      throw new Error("Paseo worktree service is not configured");
+    }
+
+    const createdWorktree = await dependencies.createPaseoWorktreeWorkflow({
+      ...input,
+      runSetup: false,
+      paseoHome: input.paseoHome ?? dependencies.paseoHome,
+    });
+    return { ok: true, createdWorktree };
+  } catch (error) {
+    return {
+      ok: false,
+      error: toWorktreeWireError(error),
+      cause: error,
+    };
+  }
+}
 
 export interface ArchivePaseoWorktreeCommandDependencies extends Omit<
   ArchivePaseoWorktreeDependencies,


### PR DESCRIPTION
## Summary
- Add shared worktree create/list commands to `packages/server/src/server/worktree/commands.ts`.
- Route Session worktree list/create handlers through the shared command surface while keeping WS response/update shaping in `worktree-session.ts`.
- Route MCP `list_worktrees` / `create_worktree` through the same command surface while keeping MCP target parsing and structuredContent shaping in `mcp-server.ts`.

## Risk / coverage notes
- Session list branch: covered by `packages/server/src/server/worktree-session.test.ts` (`handlePaseoWorktreeListRequest > lists worktrees through the workspace git service`). This caught and fixed an exact call-shape drift during the refactor.
- Session create success, workspace update, setup continuation, git warmup, and error-code branches: covered by `packages/server/src/server/worktree-session.test.ts` create/workflow tests.
- MCP create target validation and create/list tool behavior: covered by `packages/server/src/server/agent/mcp-server.test.ts`.
- Lower-level registered worktree side effects remain covered by `packages/server/src/server/paseo-worktree-service.test.ts`; this PR does not move that service behavior.
- MCP real worktree create/list remains indirectly covered by `packages/server/src/server/agent/mcp-parity.e2e.test.ts`, not rerun locally per targeted-test rule.

## Verification
- `npx vitest run packages/server/src/server/worktree-session.test.ts --bail=1` (pre-refactor: green; post-refactor: one call-shape drift found, fixed; rerun green)
- `npx vitest run packages/server/src/server/agent/mcp-server.test.ts --bail=1` (pre-refactor green; post-refactor green)
- `npm run format`
- `npm run typecheck`
- `npm run lint`

## Unslop check
- Kept transport-specific response/error payload shaping in Session and MCP.
- Removed the MCP-only create wrapper instead of adding another coordinator.
- Command deletion test: deleting the new create/list command paths makes direct `listWorktrees`, `runSetup: false`, paseoHome forwarding, and worktree error conversion reappear in both Session and MCP.
