### PR TITLE
Fix old relay pairing URL TLS compat

### DIFF
--- a/packages/app/src/runtime/host-runtime.test.ts
+++ b/packages/app/src/runtime/host-runtime.test.ts
@@ -203,6 +203,15 @@ function makeOffer(input?: Partial<ConnectionOffer>): ConnectionOffer {
   };
 }
 
+function encodeOfferUrl(payload: unknown): string {
+  const encoded = Buffer.from(JSON.stringify(payload), "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+  return `https://app.paseo.sh/#offer=${encoded}`;
+}
+
 function makeDeps(
   latencyByConnectionId: Record<string, number | Error>,
   createdClients: FakeDaemonClient[],
@@ -1726,6 +1735,41 @@ describe("HostRuntimeStore", () => {
         id: "relay:wss:relay.example.com:443",
         type: "relay",
         relayEndpoint: "relay.example.com:443",
+        useTls: true,
+        daemonPublicKeyB64: "pk_test_offer",
+      },
+    ]);
+
+    store.syncHosts([]);
+  });
+
+  it("uses TLS for old pairing URLs that omit relay TLS on port 443", async () => {
+    const store = new HostRuntimeStore({
+      deps: {
+        createClient: () => new FakeDaemonClient() as unknown as DaemonClient,
+        connectToDaemon: async ({ host }) => ({
+          client: makeConnectedProbeClient(5) as unknown as DaemonClient,
+          serverId: host.serverId,
+          hostname: host.label ?? null,
+        }),
+        getClientId: async () => "cid_test_runtime",
+      },
+    });
+    const oldPairingUrl = encodeOfferUrl({
+      v: 2,
+      serverId: "srv_offer",
+      daemonPublicKeyB64: "pk_test_offer",
+      relay: { endpoint: "relay.paseo.sh:443" },
+    });
+
+    await store.upsertConnectionFromOfferUrl(oldPairingUrl, "old relay");
+
+    const pairedHost = store.getHosts().find((host) => host.serverId === "srv_offer");
+    expect(pairedHost?.connections).toEqual([
+      {
+        id: "relay:wss:relay.paseo.sh:443",
+        type: "relay",
+        relayEndpoint: "relay.paseo.sh:443",
         useTls: true,
         daemonPublicKeyB64: "pk_test_offer",
       },

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -1506,10 +1506,12 @@ export class HostRuntimeStore {
   }
 
   async upsertConnectionFromOffer(offer: ConnectionOffer, label?: string): Promise<HostProfile> {
+    // COMPAT(oldRelayOfferTls): added in v0.1.73, remove after 2026-11-10.
+    const useTls = offer.relay.useTls ?? shouldUseTlsForDefaultHostedRelay(offer.relay.endpoint);
     return this.upsertRelayConnection({
       serverId: offer.serverId,
       relayEndpoint: offer.relay.endpoint,
-      useTls: offer.relay.useTls,
+      useTls,
       daemonPublicKeyB64: offer.daemonPublicKeyB64,
       label,
     });

--- a/packages/server/src/shared/connection-offer.test.ts
+++ b/packages/server/src/shared/connection-offer.test.ts
@@ -40,7 +40,7 @@ describe("connection offer", () => {
     expect(parseConnectionOfferFromUrl(`https://app.paseo.sh/#offer=${encoded}`)).toEqual(offer);
   });
 
-  it("defaults relay TLS to false when absent", () => {
+  it("leaves relay TLS unset when absent", () => {
     expect(
       ConnectionOfferSchema.parse({
         v: 2,
@@ -52,7 +52,7 @@ describe("connection offer", () => {
       v: 2,
       serverId: "server-123",
       daemonPublicKeyB64: "pubkey",
-      relay: { endpoint: "relay.example.com:80", useTls: false },
+      relay: { endpoint: "relay.example.com:80" },
     });
   });
 

--- a/packages/server/src/shared/connection-offer.ts
+++ b/packages/server/src/shared/connection-offer.ts
@@ -12,7 +12,7 @@ export const ConnectionOfferV2Schema = z.object({
   daemonPublicKeyB64: z.string().min(1),
   relay: z.object({
     endpoint: z.string().min(1),
-    useTls: z.boolean().optional().default(false),
+    useTls: z.boolean().optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary
- preserve missing relay `useTls` in connection-offer parsing instead of defaulting it to false
- apply the existing port-443 TLS fallback when importing old pairing URLs
- add a regression test proving old hosted-relay URLs import as `wss`

## Test Plan
- RED: `npm run test --workspace=@getpaseo/app -- src/runtime/host-runtime.test.ts --bail=1` failed with `relay:relay.paseo.sh:443` / `useTls: false` before the fix
- GREEN: `npm run test --workspace=@getpaseo/app -- src/runtime/host-runtime.test.ts --bail=1`
- `npx vitest run --config packages/server/vitest.config.ts packages/server/src/shared/connection-offer.test.ts --bail=1`
- `npm run lint -- packages/app/src/runtime/host-runtime.ts packages/app/src/runtime/host-runtime.test.ts packages/server/src/shared/connection-offer.ts packages/server/src/shared/connection-offer.test.ts`
- `npm run typecheck --workspace=@getpaseo/app`
- `npm run typecheck --workspace=@getpaseo/server`
- pre-commit hook also ran lint, format check, and full workspace typecheck