### PR TITLE
Fix Windows git command console flashing

### DIFF
--- a/packages/desktop/src/login-shell-env.ts
+++ b/packages/desktop/src/login-shell-env.ts
@@ -62,6 +62,7 @@ function resolveShellEnv(): Record<string, string> | undefined {
   const result = spawnSync(shell, [...shellArgs, command], {
     encoding: "utf8",
     timeout: RESOLVE_TIMEOUT_MS,
+    windowsHide: true,
     env: {
       ...shellEnv,
       ELECTRON_RUN_AS_NODE: "1",

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -191,6 +191,7 @@ if (forcedUserDataDir) {
     const topLevel = execFileSync("git", ["rev-parse", "--show-toplevel"], {
       encoding: "utf-8",
       timeout: 3000,
+      windowsHide: true,
     }).trim();
     devWorktreeName = path.basename(topLevel);
     // Main checkout (e.g. "paseo") gets default userData — only worktrees diverge.
@@ -200,6 +201,7 @@ if (forcedUserDataDir) {
         cwd: topLevel,
         encoding: "utf-8",
         timeout: 3000,
+        windowsHide: true,
       }).trim(),
     );
     const isWorktree = path.resolve(topLevel, ".git") !== commonDir;

--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -230,6 +230,7 @@ export function findExecutable(name: string): string | null {
     const result = execFileSync(cmd, [trimmed], {
       encoding: "utf8",
       env: createProviderEnv({ baseEnv: process.env }),
+      windowsHide: true,
     }).trim();
     const lines = result.split(/\r?\n/).filter((l: string) => l.trim());
     const candidate = lines.at(-1)?.trim() ?? null;

--- a/packages/server/src/utils/run-git-command.ts
+++ b/packages/server/src/utils/run-git-command.ts
@@ -54,6 +54,7 @@ export function runGitCommand(
         const child = spawnProcess("git", args, {
           cwd: options.cwd,
           envOverlay: mergeEnvOverlays(options.env, options.envOverlay),
+          shell: false,
           stdio: ["ignore", "pipe", "pipe"],
         });
 

--- a/packages/server/src/utils/run-git-command.windows-shell.test.ts
+++ b/packages/server/src/utils/run-git-command.windows-shell.test.ts
@@ -1,0 +1,42 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runGitCommand } from "./run-git-command.js";
+
+const tempDirs: string[] = [];
+
+function makeTempRepo(): string {
+  const repo = mkdtempSync(path.join(tmpdir(), "paseo-git-shell-"));
+  tempDirs.push(repo);
+  return repo;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+});
+
+describe("runGitCommand shell behavior", () => {
+  it("passes git arguments directly instead of through the platform shell", async () => {
+    const repo = makeTempRepo();
+    const literalName = "%PASEO_GIT_SHELL_SENTINEL%";
+    const expandedName = "expanded-by-cmd";
+
+    await runGitCommand(["init"], { cwd: repo });
+    writeFileSync(path.join(repo, literalName), "literal\n");
+    writeFileSync(path.join(repo, expandedName), "expanded\n");
+    await runGitCommand(["add", literalName, expandedName], { cwd: repo });
+
+    const result = await runGitCommand(["ls-files", "--error-unmatch", literalName], {
+      cwd: repo,
+      envOverlay: {
+        PASEO_GIT_SHELL_SENTINEL: expandedName,
+      },
+    });
+
+    expect(result.stdout.trim()).toBe(literalName);
+  });
+});


### PR DESCRIPTION
Fixes #894.

## What changed
- Spawn background git commands directly instead of through the platform shell, so Windows cmd.exe does not create visible console windows or expand shell metacharacters.
- Add windowsHide: true to the remaining synchronous desktop/provider process probes.
- Add a real git integration test, with no child_process mocking, that catches Windows shell expansion if runGitCommand regresses back through cmd.exe.

## Verification
- npx vitest run packages/server/src/utils/run-git-command.windows-shell.test.ts --bail=1
- npm run format
- npm run lint
- npm run typecheck

Windows CI should run server-tests (windows-latest) and exercise the regression test with real git.