### PR TITLE
Fix Codex sub-agent status after child tool failures

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -903,6 +903,52 @@ describe("Codex app-server provider", () => {
     });
   });
 
+  test("keeps the parent sub-agent running when a child command fails during the child turn", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "collabAgentToolCall",
+        id: "call-sub-agent-child-command-failure",
+        tool: "spawnAgent",
+        status: "completed",
+        prompt: "Fix the regression test-first.",
+        receiverThreadIds: ["child-thread-1"],
+        agentsStates: {
+          "child-thread-1": { status: "running", message: null },
+        },
+      },
+    });
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "child-thread-1",
+      item: {
+        type: "commandExecution",
+        id: "child-failing-command",
+        status: "failed",
+        command: "npx vitest run packages/server/src/server/agent/providers/opencode-agent.test.ts",
+        aggregatedOutput: "expected false to be true",
+        exitCode: 1,
+        error: { message: "Command failed" },
+      },
+    });
+
+    expect(events.at(-1)?.item).toMatchObject({
+      type: "tool_call",
+      callId: "call-sub-agent-child-command-failure",
+      name: "Sub-agent",
+      status: "running",
+      error: null,
+      detail: {
+        type: "sub_agent",
+        subAgentType: "Sub-agent",
+        description: "Fix the regression test-first.",
+      },
+    });
+  });
+
   test("loads Codex persisted history from the app-server thread", async () => {
     const session = createSession();
     const requests: Array<{ method: string; params: unknown }> = [];

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3786,10 +3786,7 @@ class CodexAppServerAgentSession implements AgentSession {
       this.pendingCommandOutputDeltas.delete(itemId);
       this.pendingFileChangeOutputDeltas.delete(itemId);
     }
-    this.emitSubAgentActivityUpdate(
-      callId,
-      timelineItem.type === "tool_call" && timelineItem.status === "failed" ? "failed" : "running",
-    );
+    this.emitSubAgentActivityUpdate(callId, "running");
   }
 
   private shouldSkipCompletedThreadItem(


### PR DESCRIPTION
## Summary
- keep Codex parent sub-agent tool calls running while child-thread tool calls fail inside an active turn
- leave child turn completion as the authority for whether the sub-agent completed, failed, or was canceled
- add a regression test for the screenshot scenario

## Verification
- npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1 -t "keeps the parent sub-agent running when a child command fails during the child turn"
- npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1
- npm run format
- npm run lint
- npm run typecheck