### PR TITLE
Fix iPad Settings sidebar safe area

### DIFF
--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -720,9 +720,16 @@ function SettingsSidebar({
   }, [hosts, localServerId]);
   const isDesktopApp = isElectronRuntime();
   const items = SIDEBAR_SECTION_ITEMS.filter((item) => !item.desktopOnly || isDesktopApp);
+  const insets = useSafeAreaInsets();
   const padding = useWindowControlsPadding("sidebar");
   const isDesktop = layout === "desktop";
-  const containerStyle = isDesktop ? sidebarStyles.desktopContainer : sidebarStyles.mobileContainer;
+  const containerStyle = useMemo(
+    () => [
+      isDesktop ? sidebarStyles.desktopContainer : sidebarStyles.mobileContainer,
+      isDesktop ? { paddingTop: insets.top } : null,
+    ],
+    [insets.top, isDesktop],
+  );
   const selectedSectionId = view.kind === "section" ? view.section : null;
   const selectedServerId = view.kind === "host" ? view.serverId : null;
   const isProjectsSelected = view.kind === "projects" || view.kind === "project";


### PR DESCRIPTION
## Summary

Fixes #921.

This keeps the Settings sidebar `Back` header below the native iPadOS top safe area when the app is using the wider/tablet sidebar layout.

The change mirrors the existing native sidebar treatment used elsewhere: native safe-area padding belongs on the sidebar container, while the existing Electron window-control spacer remains separate.

## Testing

- `npm run format:files -- packages/app/src/screens/settings-screen.tsx`
- `npm run lint -- packages/app/src/screens/settings-screen.tsx`
- `npm run typecheck --workspace=@getpaseo/app`
- `npm run build:workspace-deps --workspace=@getpaseo/app`
- pre-commit hook: targeted lint, targeted format check, full workspace `npm run typecheck --workspaces --if-present`
- loaded the branch through a development client on a physical iPad and confirmed the Settings sidebar `Back` row no longer overlaps the iPadOS status bar
