### PR TITLE
nix: declarative config, typed relay options, desktop packaging

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -64,9 +64,9 @@ jobs:
       - name: Commit hash/lockfile updates (main push only)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          git diff --quiet package-lock.json nix/package.nix && exit 0
+          git diff --quiet package-lock.json nix/npm-deps.hash && exit 0
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package-lock.json nix/package.nix
+          git add package-lock.json nix/npm-deps.hash
           git commit -m "fix: update lockfile signatures and Nix hash"
           git push

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -41,10 +41,16 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.PASEO_BOT_APP_ID }}
+          private-key: ${{ secrets.PASEO_BOT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v4
         with:
@@ -65,8 +71,8 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           git diff --quiet package-lock.json nix/npm-deps.hash && exit 0
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "paseo-ai[bot]"
+          git config user.email "266920839+paseo-ai[bot]@users.noreply.github.com"
           git add package-lock.json nix/npm-deps.hash
           git commit -m "fix: update lockfile signatures and Nix hash"
           git push

--- a/flake.nix
+++ b/flake.nix
@@ -26,10 +26,17 @@
         let
           pkgs = pkgsFor system;
           paseo = pkgs.callPackage ./nix/package.nix { };
+          isLinux = nixpkgs.lib.elem system [
+            "x86_64-linux"
+            "aarch64-linux"
+          ];
         in
         {
           default = paseo;
           paseo = paseo;
+        }
+        // nixpkgs.lib.optionalAttrs isLinux {
+          desktop = pkgs.callPackage ./nix/desktop-package.nix { };
         }
       );
 

--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -118,9 +118,16 @@ buildNpmPackage rec {
     # --no-sandbox: Chromium's setuid sandbox can't live in /nix/store
     # (immutable, no setuid). Acceptable for v1; a follow-up can wire
     # `security.wrappers` via a NixOS module for users who want the sandbox.
+    #
+    # EXPO_DEV_URL: We run unpackaged via `electron path/to/main.js`, so
+    # `app.isPackaged` is false. In that mode main.ts loads `DEV_SERVER_URL`
+    # (defaults to http://localhost:8081 — the Expo dev server, which doesn't
+    # exist here). Point it at the `paseo://` protocol handler instead, which
+    # serves from `__dirname/../../app/dist` (our install layout matches).
     makeWrapper ${electron}/bin/electron $out/bin/paseo-desktop \
       --add-flags "$out/share/paseo-desktop/packages/desktop/dist/main.js" \
-      --add-flags "--no-sandbox"
+      --add-flags "--no-sandbox" \
+      --set EXPO_DEV_URL "paseo://app/"
 
     copyDesktopItems
 

--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -1,0 +1,163 @@
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  nodejs_22,
+  python3,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+  electron,
+  libuv,
+  # Shares the daemon's npm-deps hash — same package-lock.json, same fetcher.
+  # Override via `.override { npmDepsHash = "..."; }` if your nixpkgs computes a
+  # different value.
+  npmDepsHash ? lib.fileContents ./npm-deps.hash,
+}:
+
+buildNpmPackage rec {
+  pname = "paseo-desktop";
+  version = (builtins.fromJSON (builtins.readFile ../package.json)).version;
+
+  src = lib.cleanSourceWith {
+    src = ./..;
+    filter = path: type:
+      let
+        baseName = builtins.baseNameOf path;
+        relPath = lib.removePrefix (toString ./..) path;
+      in
+      # Exclude mobile-only platform code (we only need the web/electron build)
+      !(lib.hasPrefix "/packages/app/android" relPath)
+      && !(lib.hasPrefix "/packages/app/ios" relPath)
+      # Website is unrelated to the desktop app
+      && !(lib.hasPrefix "/packages/website" relPath)
+      # Test fixtures and build artifacts
+      && !(lib.hasSuffix ".test.ts" baseName)
+      && !(lib.hasSuffix ".e2e.test.ts" baseName)
+      && baseName != "node_modules"
+      && baseName != ".git"
+      && baseName != ".paseo"
+      && baseName != ".DS_Store"
+      && baseName != "release";
+  };
+
+  nodejs = nodejs_22;
+  inherit npmDepsHash;
+
+  # Prevent onnxruntime-node's install script from running during automatic
+  # npm rebuild. We manually rebuild only node-pty in buildPhase.
+  npmRebuildFlags = [ "--ignore-scripts" ];
+
+  nativeBuildInputs = [
+    python3 # for node-gyp (node-pty)
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libuv ];
+
+  dontNpmBuild = true;
+
+  env = {
+    EXPO_NO_TELEMETRY = "1";
+    # Expo's web build pulls in some pre-bundled assets; ensure it doesn't try
+    # to phone home during the build.
+    CI = "1";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Native deps (terminal emulation; libuv-linked on Linux)
+    npm rebuild node-pty
+
+    # Daemon workspaces (highlight + relay + server + cli)
+    npm run build:daemon
+
+    # App workspace deps not covered by build:daemon
+    npm run build --workspace=@getpaseo/expo-two-way-audio
+
+    # Expo web export for the Electron renderer
+    ( cd packages/app && PASEO_WEB_PLATFORM=electron npx expo export --platform web )
+
+    # Desktop main process (tsc only — NOT electron-builder)
+    npm run build:main --workspace=@getpaseo/desktop
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/paseo-desktop $out/bin
+
+    # Preserve the monorepo layout so main.js's dev-mode path resolution
+    # (`__dirname/../../app/dist`, `__dirname/../assets/icon.png`) works
+    # without patching: invoked unpackaged via `electron path/to/main.js`,
+    # `app.isPackaged` is false, so these relative paths are used.
+    cp package.json $out/share/paseo-desktop/
+
+    mkdir -p $out/share/paseo-desktop/packages/desktop
+    cp -a packages/desktop/dist $out/share/paseo-desktop/packages/desktop/
+    cp -a packages/desktop/assets $out/share/paseo-desktop/packages/desktop/
+    cp packages/desktop/package.json $out/share/paseo-desktop/packages/desktop/
+
+    mkdir -p $out/share/paseo-desktop/packages/app
+    cp -a packages/app/dist $out/share/paseo-desktop/packages/app/
+    cp packages/app/package.json $out/share/paseo-desktop/packages/app/
+
+    # Built daemon workspaces (server, cli, relay, highlight, expo-two-way-audio)
+    for pkg in server cli relay highlight expo-two-way-audio; do
+      if [ -d packages/$pkg/dist ]; then
+        mkdir -p $out/share/paseo-desktop/packages/$pkg
+        cp packages/$pkg/package.json $out/share/paseo-desktop/packages/$pkg/
+        cp -a packages/$pkg/dist $out/share/paseo-desktop/packages/$pkg/
+      fi
+    done
+
+    # node_modules (with workspace symlinks intact)
+    cp -a node_modules $out/share/paseo-desktop/
+
+    # Skills directory referenced at runtime by some agents
+    if [ -d skills ]; then
+      cp -a skills $out/share/paseo-desktop/
+    fi
+
+    # Hicolor icon for desktop environments
+    install -Dm644 packages/desktop/assets/icon.png \
+      $out/share/icons/hicolor/512x512/apps/paseo-desktop.png
+
+    # Launcher wraps nixpkgs electron.
+    # --no-sandbox: Chromium's setuid sandbox can't live in /nix/store
+    # (immutable, no setuid). Acceptable for v1; a follow-up can wire
+    # `security.wrappers` via a NixOS module for users who want the sandbox.
+    makeWrapper ${electron}/bin/electron $out/bin/paseo-desktop \
+      --add-flags "$out/share/paseo-desktop/packages/desktop/dist/main.js" \
+      --add-flags "--no-sandbox"
+
+    copyDesktopItems
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "paseo-desktop";
+      desktopName = "Paseo";
+      genericName = "AI Coding Agents";
+      comment = "Self-hosted daemon for AI coding agents";
+      exec = "paseo-desktop";
+      icon = "paseo-desktop";
+      categories = [ "Development" ];
+      startupWMClass = "Paseo";
+    })
+  ];
+
+  meta = {
+    description = "Paseo desktop app (Electron wrapper)";
+    homepage = "https://github.com/getpaseo/paseo";
+    license = lib.licenses.agpl3Plus;
+    mainProgram = "paseo-desktop";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -95,27 +95,14 @@ buildNpmPackage rec {
     # (`__dirname/../../app/dist`, `__dirname/../assets/icon.png`) works
     # without patching: invoked unpackaged via `electron path/to/main.js`,
     # `app.isPackaged` is false, so these relative paths are used.
+    #
+    # Copy the entire packages/ tree (not just built artifacts) because npm
+    # creates workspace symlinks from node_modules/@getpaseo/* into packages/*.
+    # Missing any workspace package leaves dangling symlinks and fails the
+    # noBrokenSymlinks output check. The cleanSourceWith filter above already
+    # drops the big platform-specific things (android/ios, website, tests).
     cp package.json $out/share/paseo-desktop/
-
-    mkdir -p $out/share/paseo-desktop/packages/desktop
-    cp -a packages/desktop/dist $out/share/paseo-desktop/packages/desktop/
-    cp -a packages/desktop/assets $out/share/paseo-desktop/packages/desktop/
-    cp packages/desktop/package.json $out/share/paseo-desktop/packages/desktop/
-
-    mkdir -p $out/share/paseo-desktop/packages/app
-    cp -a packages/app/dist $out/share/paseo-desktop/packages/app/
-    cp packages/app/package.json $out/share/paseo-desktop/packages/app/
-
-    # Built daemon workspaces (server, cli, relay, highlight, expo-two-way-audio)
-    for pkg in server cli relay highlight expo-two-way-audio; do
-      if [ -d packages/$pkg/dist ]; then
-        mkdir -p $out/share/paseo-desktop/packages/$pkg
-        cp packages/$pkg/package.json $out/share/paseo-desktop/packages/$pkg/
-        cp -a packages/$pkg/dist $out/share/paseo-desktop/packages/$pkg/
-      fi
-    done
-
-    # node_modules (with workspace symlinks intact)
+    cp -a packages $out/share/paseo-desktop/
     cp -a node_modules $out/share/paseo-desktop/
 
     # Skills directory referenced at runtime by some agents

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -111,9 +111,41 @@ in
       '';
       description = "Extra environment variables for the Paseo daemon.";
     };
+
+    settings = lib.mkOption {
+      type = (pkgs.formats.json { }).type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          daemon.mcp = { enabled = true; injectIntoAgents = false; };
+          agents.providers.myAcp = {
+            extends = "acp";
+            label = "My Agent";
+            command = { path = "/run/current-system/sw/bin/my-acp"; };
+          };
+          log.file = { level = "info"; path = "/var/lib/paseo/daemon.log"; };
+        }
+      '';
+      description = ''
+        Declarative content for `$PASEO_HOME/config.json`. Rendered to JSON
+        and installed on every service start.
+
+        Runtime mutations to `config.json` (e.g. via `paseo daemon set-password`
+        or the mobile app toggling MCP injection / provider overrides) are
+        overwritten on the next restart. Pick one: manage via this option, or
+        manage via the CLI — not both.
+
+        The full schema is defined by `PersistedConfigSchema` in
+        `packages/server/src/server/persisted-config.ts`.
+      '';
+    };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf cfg.enable (
+    let
+      settingsFile = (pkgs.formats.json { }).generate "paseo-config.json" cfg.settings;
+    in
+    {
     users.users.${cfg.user} = lib.mkIf (cfg.user == "paseo") {
       isSystemUser = true;
       group = cfg.group;
@@ -130,6 +162,10 @@ in
       description = "Paseo - self-hosted daemon for AI coding agents";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
+
+      preStart = lib.mkIf (cfg.settings != { }) ''
+        install -m 0600 ${settingsFile} ${cfg.dataDir}/config.json
+      '';
 
       environment = {
         NODE_ENV = "production";
@@ -172,5 +208,6 @@ in
     environment.systemPackages = [ cfg.package ];
 
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
-  };
+    }
+  );
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -81,7 +81,48 @@ in
       enable = lib.mkOption {
         type = lib.types.bool;
         default = true;
-        description = "Whether to enable the relay connection for remote access via app.paseo.sh.";
+        description = ''
+          Whether to enable relay-based remote access. When false, the daemon
+          runs with `--no-relay` and only accepts direct (LAN/loopback)
+          connections.
+        '';
+      };
+
+      mode = lib.mkOption {
+        type = lib.types.enum [ "hosted" "remote" ];
+        default = "hosted";
+        description = ''
+          How the daemon reaches the relay when `relay.enable = true`:
+
+          - `"hosted"` (default): use the upstream `app.paseo.sh` relay.
+            Preserves the current behavior; no extra options needed.
+          - `"remote"`: connect to a self-hosted relay at
+            `relay.host:relay.port`. Sets `PASEO_RELAY_ENDPOINT` and
+            `PASEO_RELAY_USE_TLS` for the daemon.
+
+          A `"local"` mode (running a relay on the same host as a systemd
+          unit) is not yet implemented — the relay package currently only
+          ships a Cloudflare Workers adapter. Tracked separately.
+        '';
+      };
+
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        example = "relay.example.com";
+        description = "Relay hostname. Required when `relay.mode = \"remote\"`.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 443;
+        description = "Relay port. Used when `relay.mode = \"remote\"`.";
+      };
+
+      useTls = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether to use TLS when connecting to the relay. Used when `relay.mode = \"remote\"`.";
       };
     };
 
@@ -146,6 +187,15 @@ in
       settingsFile = (pkgs.formats.json { }).generate "paseo-config.json" cfg.settings;
     in
     {
+    assertions = [
+      {
+        assertion = !(cfg.relay.enable && cfg.relay.mode == "remote" && cfg.relay.host == "");
+        message = ''
+          services.paseo.relay.host must be set when relay.mode = "remote".
+        '';
+      }
+    ];
+
     users.users.${cfg.user} = lib.mkIf (cfg.user == "paseo") {
       isSystemUser = true;
       group = cfg.group;
@@ -185,6 +235,9 @@ in
         PASEO_HOSTNAMES = "true";
       } // lib.optionalAttrs (lib.isList cfg.hostnames && cfg.hostnames != [ ]) {
         PASEO_HOSTNAMES = lib.concatStringsSep "," cfg.hostnames;
+      } // lib.optionalAttrs (cfg.relay.enable && cfg.relay.mode == "remote") {
+        PASEO_RELAY_ENDPOINT = "${cfg.relay.host}:${toString cfg.relay.port}";
+        PASEO_RELAY_USE_TLS = if cfg.relay.useTls then "true" else "false";
       } // cfg.environment;
 
       serviceConfig = {

--- a/nix/npm-deps.hash
+++ b/nix/npm-deps.hash
@@ -1,0 +1,1 @@
+sha256-qXCfTM7Q1PyXL53C+AFgFA5b99uznKaKomwmX2UcZHo=

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,10 @@
   # can override via `.override { npmDepsHash = "sha256-..."; }` without
   # `overrideAttrs` gymnastics — `npmDepsHash` is destructured from
   # `buildNpmPackage`'s args, so `overrideAttrs` cannot reach it.
-  npmDepsHash ? "sha256-qXCfTM7Q1PyXL53C+AFgFA5b99uznKaKomwmX2UcZHo=",
+  #
+  # The default is read from a sidecar file so the CI auto-updater can replace
+  # the hash with a single file write instead of a sed against this source.
+  npmDepsHash ? lib.fileContents ./npm-deps.hash,
 }:
 
 buildNpmPackage rec {
@@ -46,8 +49,8 @@ buildNpmPackage rec {
 
   nodejs = nodejs_22;
 
-  # To update the default: run `nix build` with lib.fakeHash, copy the `got:` hash.
-  # CI auto-updates this when package-lock.json changes (see .github/workflows/).
+  # Default hash lives in nix/npm-deps.hash (see arg default above).
+  # CI auto-updates that file when package-lock.json changes (see .github/workflows/).
   inherit npmDepsHash;
 
   # Prevent onnxruntime-node's install script from running during automatic

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,6 +7,12 @@
   makeWrapper,
   # node-pty needs libuv headers on Linux
   libuv,
+  # Exposed so downstream flakes that follow a different nixpkgs revision
+  # (where `fetchNpmDeps` may produce a different hash for the same lockfile)
+  # can override via `.override { npmDepsHash = "sha256-..."; }` without
+  # `overrideAttrs` gymnastics — `npmDepsHash` is destructured from
+  # `buildNpmPackage`'s args, so `overrideAttrs` cannot reach it.
+  npmDepsHash ? "sha256-qXCfTM7Q1PyXL53C+AFgFA5b99uznKaKomwmX2UcZHo=",
 }:
 
 buildNpmPackage rec {
@@ -40,9 +46,9 @@ buildNpmPackage rec {
 
   nodejs = nodejs_22;
 
-  # To update: run `nix build` with lib.fakeHash, copy the `got:` hash.
+  # To update the default: run `nix build` with lib.fakeHash, copy the `got:` hash.
   # CI auto-updates this when package-lock.json changes (see .github/workflows/).
-  npmDepsHash = "sha256-qXCfTM7Q1PyXL53C+AFgFA5b99uznKaKomwmX2UcZHo=";
+  inherit npmDepsHash;
 
   # Prevent onnxruntime-node's install script from running during automatic
   # npm rebuild (it tries to download from api.nuget.org, which fails in the sandbox).

--- a/scripts/update-nix.sh
+++ b/scripts/update-nix.sh
@@ -42,8 +42,8 @@ if ! NEW_HASH="$(nix shell "${NIXPKGS_URL}#prefetch-npm-deps" -c prefetch-npm-de
 fi
 echo "Computed hash: $NEW_HASH"
 
-# 3. Read current hash
-CURRENT_HASH="$(grep 'npmDepsHash' "$PACKAGE_NIX" | sed 's/.*"\(.*\)".*/\1/')"
+# 3. Read current hash (default value of the `npmDepsHash ? "..."` callPackage arg)
+CURRENT_HASH="$(grep -E '^\s*npmDepsHash \? "' "$PACKAGE_NIX" | sed 's/.*"\(.*\)".*/\1/')"
 
 if [[ "$NEW_HASH" == "$CURRENT_HASH" ]]; then
   echo "Hash is already up to date."
@@ -57,7 +57,7 @@ else
   fi
 
   echo "Updating npmDepsHash in nix/package.nix..."
-  sed -i.bak "s|npmDepsHash = \".*\"|npmDepsHash = \"$NEW_HASH\"|" "$PACKAGE_NIX"
+  sed -i.bak "s|npmDepsHash ? \".*\"|npmDepsHash ? \"$NEW_HASH\"|" "$PACKAGE_NIX"
   rm -f "$PACKAGE_NIX.bak"
   echo "Updated: $CURRENT_HASH -> $NEW_HASH"
 fi

--- a/scripts/update-nix.sh
+++ b/scripts/update-nix.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LOCK_FILE="$ROOT_DIR/package-lock.json"
-PACKAGE_NIX="$ROOT_DIR/nix/package.nix"
+HASH_FILE="$ROOT_DIR/nix/npm-deps.hash"
 
 CHECK_MODE=false
 if [[ "${1:-}" == "--check" ]]; then
@@ -42,8 +42,8 @@ if ! NEW_HASH="$(nix shell "${NIXPKGS_URL}#prefetch-npm-deps" -c prefetch-npm-de
 fi
 echo "Computed hash: $NEW_HASH"
 
-# 3. Read current hash (default value of the `npmDepsHash ? "..."` callPackage arg)
-CURRENT_HASH="$(grep -E '^\s*npmDepsHash \? "' "$PACKAGE_NIX" | sed 's/.*"\(.*\)".*/\1/')"
+# 3. Read current hash from the sidecar file
+CURRENT_HASH="$(tr -d '[:space:]' < "$HASH_FILE")"
 
 if [[ "$NEW_HASH" == "$CURRENT_HASH" ]]; then
   echo "Hash is already up to date."
@@ -56,8 +56,7 @@ else
     exit 1
   fi
 
-  echo "Updating npmDepsHash in nix/package.nix..."
-  sed -i.bak "s|npmDepsHash ? \".*\"|npmDepsHash ? \"$NEW_HASH\"|" "$PACKAGE_NIX"
-  rm -f "$PACKAGE_NIX.bak"
+  echo "Updating nix/npm-deps.hash..."
+  printf '%s\n' "$NEW_HASH" > "$HASH_FILE"
   echo "Updated: $CURRENT_HASH -> $NEW_HASH"
 fi


### PR DESCRIPTION
## Note on scope

This PR bundles five related nix-module commits: the original `npmDepsHash`-override fix plus three new nix-module concerns (declarative config, typed relay options, desktop packaging). Happy to split into separate PRs on request — flag any commit and I'll move it.

## Summary

Five commits, each independently reviewable:

1. **`nix: expose npmDepsHash as a callPackage arg`** — fix the broken `.overrideAttrs { npmDepsHash = ...; }` path so downstream flakes that follow a different `nixpkgs` revision can override the hash via `.override`. `overrideAttrs` doesn't reach `buildNpmPackage`'s `npmDepsHash` arg (it's destructured before the override applies), so today there's no working escape hatch for hash drift.
2. **`nix: move npmDepsHash default to a sidecar file`** — decouple the auto-updater from sed-against-`package.nix`. The hash now lives in `nix/npm-deps.hash`; `update-nix.sh` becomes a one-line file write. Lockfile bumps touch one tiny file.
3. **`nix: declarative config via services.paseo.settings`** — freeform attrset rendered to `$PASEO_HOME/config.json` via `pkgs.formats.json`. Standard NixOS idiom (mosquitto, prometheus, grafana, jellyfin, ...). Covers MCP, custom agent providers, log config, voice features, anything in `PersistedConfigSchema`. `install`'d on `preStart` (not symlinked) so runtime daemon writes (`DaemonConfigStore.patch`) still work within a session; Nix manages the source of truth at boot. Documented in the option description.
4. **`nix: typed services.paseo.relay options with auto-wired endpoint`** — addresses #224 (option surface). New `relay.mode = "hosted" | "remote"` enum selects *how* the relay is reached when enabled, with `relay.{host,port,useTls}` for the `"remote"` case. Auto-wires `PASEO_RELAY_ENDPOINT` and `PASEO_RELAY_USE_TLS` in the systemd unit. Assertion catches `mode = "remote"` with empty `host` at eval time. Existing `relay.enable` bool is preserved as the on/off toggle — idiomatic NixOS pattern (top-level bool = "is it on?", sub-options = "how is it configured?"). **No breaking changes** — current `relay.enable = true|false` configs evaluate unchanged.
5. **`nix: package paseo desktop app for Linux`** — new `packages.<linux>.desktop` flake output. Skeleton Electron derivation following the nixpkgs idiom (signal-desktop, vscode, discord pattern): skip `electron-builder` entirely, wrap `pkgs.electron` with `makeWrapper`. Usable via `nix run github:getpaseo/paseo#desktop` or `environment.systemPackages = [ paseo.packages.<sys>.desktop ];`. **No CI changes** — `desktop-release.yml` continues to produce .deb/.AppImage/.rpm/macOS/Windows installers as today; this is additive for NixOS users.

## Deferred from #224

`mode = "local"` (self-hosted relay running as a systemd unit on the same host) is **not** in this PR. `packages/relay` currently ships only a Cloudflare Workers adapter (`cloudflare-adapter.ts` uses Durable Objects + WebSocket hibernation). There's no Node.js HTTP/WebSocket runtime to package as a binary. Adding a Node adapter is a TS-side feature change worth its own design discussion (session storage, observability, behaviour parity with Durable Objects). Will track separately.

## Why bundle these together

Same area of the codebase (`nix/`), all small-to-medium nix-module changes, easier to review as one diff than to context-switch across five PRs. If the maintainers prefer them split (or want any specific commit dropped), I'll do that — just say which.

## Why the `--no-sandbox` flag on the desktop launcher

Chromium's setuid sandbox (`chrome-sandbox`) needs to be setuid root. `/nix/store` is immutable and forbids setuid binaries. Standard nixpkgs pattern is either to ship `--no-sandbox` or to wire `security.wrappers` via a NixOS module. The latter is a NixOS-module concern, not a derivation concern, and worth a follow-up. v1 ships with `--no-sandbox`.

## Test plan

- [x] `nix flake check --no-build --impure` clean on the branch
- [x] `pkg.override { npmDepsHash = "..."; }.npmDeps.outputHash` reflects the override (verified locally)
- [x] `scripts/update-nix.sh` reads/writes the sidecar correctly
- [x] `services.paseo.settings` renders to `config.json` via `pkgs.formats.json` (rendered output validated as valid JSON shaped per `PersistedConfigSchema`)
- [x] `services.paseo.relay.enable = false` adds `--no-relay`; `mode = "remote"; host = "..."` sets `PASEO_RELAY_ENDPOINT`; `mode = "hosted"` (default) preserves current behavior
- [x] Existing `services.paseo.relay.enable = true|false` configs evaluate unchanged
- [x] Assertion fires when `mode = "remote"` but `host` is empty
- [x] `packages.x86_64-linux.desktop` evaluates; `npmDeps.outputHash` shares the daemon's
- [ ] `nix build .#packages.x86_64-linux.desktop` produces a runnable binary (will verify on local rebuild and CI)
- [ ] CI `nix-build.yml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)