### PR TITLE
Fix/pr status fallback with fine grained tokens

### DIFF
--- a/packages/server/src/services/github-service.test.ts
+++ b/packages/server/src/services/github-service.test.ts
@@ -20,6 +20,9 @@ import { CheckoutPrStatusResponseSchema } from "../shared/messages.js";
 const EXPECTED_GITHUB_FAST_POLL_MS = 20_000;
 const EXPECTED_GITHUB_SLOW_POLL_MS = 120_000;
 const EXPECTED_GITHUB_ERROR_BACKOFF_CAP_MS = 300_000;
+const CURRENT_PR_STATUS_BASE_FIELDS =
+  "number,url,title,state,isDraft,baseRefName,headRefName,mergedAt,reviewDecision,mergeable,headRepositoryOwner";
+const CURRENT_PR_STATUS_FIELDS = `${CURRENT_PR_STATUS_BASE_FIELDS},statusCheckRollup`;
 
 interface RunnerCall {
   args: string[];
@@ -150,6 +153,16 @@ function noPullRequestError(args: string[] = ["pr", "view"]): GitHubCommandError
     cwd: "/repo",
     exitCode: 1,
     stderr: "no pull requests found for branch",
+  });
+}
+
+function statusCheckRollupPermissionError(args: string[]): GitHubCommandError {
+  return new GitHubCommandError({
+    args,
+    cwd: "/repo",
+    exitCode: 1,
+    stderr:
+      "GraphQL: Resource not accessible by personal access token (repository.pullRequest.statusCheckRollup)",
   });
 }
 
@@ -1077,7 +1090,7 @@ describe("GitHubService", () => {
       "pr",
       "view",
       "--json",
-      "number,url,title,state,isDraft,baseRefName,headRefName,mergedAt,statusCheckRollup,reviewDecision,mergeable,headRepositoryOwner",
+      CURRENT_PR_STATUS_FIELDS,
     ]);
     expect(status).toEqual({
       number: 42,
@@ -1107,6 +1120,38 @@ describe("GitHubService", () => {
       ],
       checksStatus: "success",
       reviewDecision: "pending",
+    });
+  });
+
+  it("retries current PR view without statusCheckRollup when token permissions are insufficient", async () => {
+    const runner = createScriptedRunner([
+      { error: statusCheckRollupPermissionError(["pr", "view", "--json", CURRENT_PR_STATUS_FIELDS]) },
+      currentPullRequestJson({
+        headRefName: "feature/pr-pane",
+        reviewDecision: "APPROVED",
+      }),
+    ]);
+    const service = createGitHubService({
+      runner: runner.runner,
+      resolveGhPath: async () => "/usr/bin/gh",
+      now: () => 100,
+    });
+
+    const status = await service.getCurrentPullRequestStatus({
+      cwd: "/repo",
+      headRef: "feature/pr-pane",
+    });
+
+    expect(runner.calls.map((call) => call.args)).toEqual([
+      ["pr", "view", "--json", CURRENT_PR_STATUS_FIELDS],
+      ["pr", "view", "--json", CURRENT_PR_STATUS_BASE_FIELDS],
+    ]);
+    expect(status).toMatchObject({
+      title: "Fork PR",
+      headRefName: "feature/pr-pane",
+      checks: [],
+      checksStatus: "none",
+      reviewDecision: "approved",
     });
   });
 
@@ -1194,7 +1239,7 @@ describe("GitHubService", () => {
         "pr",
         "view",
         "--json",
-        "number,url,title,state,isDraft,baseRefName,headRefName,mergedAt,statusCheckRollup,reviewDecision,mergeable,headRepositoryOwner",
+        CURRENT_PR_STATUS_FIELDS,
       ],
       ["repo", "view", "--json", "owner,name,parent"],
       [
@@ -1206,10 +1251,107 @@ describe("GitHubService", () => {
         "all",
         "--head",
         "forkOwner:feature/fork",
-        "--json",
-        "number,url,title,state,isDraft,baseRefName,headRefName,mergedAt,statusCheckRollup,reviewDecision,mergeable,headRepositoryOwner",
         "--limit",
         "10",
+        "--json",
+        CURRENT_PR_STATUS_FIELDS,
+      ],
+    ]);
+  });
+
+  it("retries scoped PR list without statusCheckRollup when token permissions are insufficient", async () => {
+    const runner = createScriptedRunner([
+      currentPullRequestJson({
+        number: 7,
+        url: "https://github.com/parentOwner/parentRepo/pull/7",
+        title: "Stale tracking PR",
+        headRefName: "old-branch",
+      }),
+      JSON.stringify({
+        owner: { login: "forkOwner" },
+        name: "parentRepo",
+        parent: { owner: { login: "parentOwner" }, name: "parentRepo" },
+      }),
+      {
+        error: statusCheckRollupPermissionError([
+          "pr",
+          "list",
+          "--repo",
+          "parentOwner/parentRepo",
+          "--state",
+          "all",
+          "--head",
+          "forkOwner:feature/fork",
+          "--json",
+          CURRENT_PR_STATUS_FIELDS,
+          "--limit",
+          "10",
+        ]),
+      },
+      JSON.stringify([
+        {
+          number: 42,
+          url: "https://github.com/parentOwner/parentRepo/pull/42",
+          title: "Real fork PR",
+          state: "OPEN",
+          isDraft: false,
+          baseRefName: "main",
+          headRefName: "feature/fork",
+          mergedAt: null,
+          reviewDecision: "REVIEW_REQUIRED",
+          headRepositoryOwner: { login: "forkOwner" },
+        },
+      ]),
+    ]);
+    const service = createGitHubService({
+      runner: runner.runner,
+      resolveGhPath: async () => "/usr/bin/gh",
+      now: () => 100,
+    });
+
+    const status = await service.getCurrentPullRequestStatus({
+      cwd: "/repo",
+      headRef: "feature/fork",
+    });
+
+    expect(status).toMatchObject({
+      number: 42,
+      repoOwner: "parentOwner",
+      repoName: "parentRepo",
+      headRefName: "feature/fork",
+      checks: [],
+      checksStatus: "none",
+    });
+    expect(runner.calls.map((call) => call.args)).toEqual([
+      ["pr", "view", "--json", CURRENT_PR_STATUS_FIELDS],
+      ["repo", "view", "--json", "owner,name,parent"],
+      [
+        "pr",
+        "list",
+        "--repo",
+        "parentOwner/parentRepo",
+        "--state",
+        "all",
+        "--head",
+        "forkOwner:feature/fork",
+        "--limit",
+        "10",
+        "--json",
+        CURRENT_PR_STATUS_FIELDS,
+      ],
+      [
+        "pr",
+        "list",
+        "--repo",
+        "parentOwner/parentRepo",
+        "--state",
+        "all",
+        "--head",
+        "forkOwner:feature/fork",
+        "--limit",
+        "10",
+        "--json",
+        CURRENT_PR_STATUS_BASE_FIELDS,
       ],
     ]);
   });
@@ -1267,7 +1409,7 @@ describe("GitHubService", () => {
         "pr",
         "view",
         "--json",
-        "number,url,title,state,isDraft,baseRefName,headRefName,mergedAt,statusCheckRollup,reviewDecision,mergeable,headRepositoryOwner",
+        CURRENT_PR_STATUS_FIELDS,
       ],
       ["repo", "view", "--json", "owner,name,parent"],
     ]);
@@ -1328,7 +1470,7 @@ describe("GitHubService", () => {
         "pr",
         "view",
         "--json",
-        "number,url,title,state,isDraft,baseRefName,headRefName,mergedAt,statusCheckRollup,reviewDecision,mergeable,headRepositoryOwner",
+        CURRENT_PR_STATUS_FIELDS,
       ],
       [
         "pr",
@@ -1337,10 +1479,10 @@ describe("GitHubService", () => {
         "all",
         "--head",
         "main",
-        "--json",
-        "number,url,title,state,isDraft,baseRefName,headRefName,mergedAt,statusCheckRollup,reviewDecision,mergeable,headRepositoryOwner",
         "--limit",
         "10",
+        "--json",
+        CURRENT_PR_STATUS_FIELDS,
       ],
     ]);
   });

--- a/packages/server/src/services/github-service.test.ts
+++ b/packages/server/src/services/github-service.test.ts
@@ -1086,12 +1086,7 @@ describe("GitHubService", () => {
       headRef: "feature/pr-pane",
     });
 
-    expect(runner.calls[0]?.args).toEqual([
-      "pr",
-      "view",
-      "--json",
-      CURRENT_PR_STATUS_FIELDS,
-    ]);
+    expect(runner.calls[0]?.args).toEqual(["pr", "view", "--json", CURRENT_PR_STATUS_FIELDS]);
     expect(status).toEqual({
       number: 42,
       repoOwner: "acme",
@@ -1125,7 +1120,9 @@ describe("GitHubService", () => {
 
   it("retries current PR view without statusCheckRollup when token permissions are insufficient", async () => {
     const runner = createScriptedRunner([
-      { error: statusCheckRollupPermissionError(["pr", "view", "--json", CURRENT_PR_STATUS_FIELDS]) },
+      {
+        error: statusCheckRollupPermissionError(["pr", "view", "--json", CURRENT_PR_STATUS_FIELDS]),
+      },
       currentPullRequestJson({
         headRefName: "feature/pr-pane",
         reviewDecision: "APPROVED",
@@ -1235,12 +1232,7 @@ describe("GitHubService", () => {
       headRefName: "feature/fork",
     });
     expect(runner.calls.map((call) => call.args)).toEqual([
-      [
-        "pr",
-        "view",
-        "--json",
-        CURRENT_PR_STATUS_FIELDS,
-      ],
+      ["pr", "view", "--json", CURRENT_PR_STATUS_FIELDS],
       ["repo", "view", "--json", "owner,name,parent"],
       [
         "pr",
@@ -1405,12 +1397,7 @@ describe("GitHubService", () => {
       }),
     ).resolves.toBeNull();
     expect(calls.map((call) => call.args)).toEqual([
-      [
-        "pr",
-        "view",
-        "--json",
-        CURRENT_PR_STATUS_FIELDS,
-      ],
+      ["pr", "view", "--json", CURRENT_PR_STATUS_FIELDS],
       ["repo", "view", "--json", "owner,name,parent"],
     ]);
   });
@@ -1466,12 +1453,7 @@ describe("GitHubService", () => {
       headRefName: "main",
     });
     expect(runner.calls.map((call) => call.args)).toEqual([
-      [
-        "pr",
-        "view",
-        "--json",
-        CURRENT_PR_STATUS_FIELDS,
-      ],
+      ["pr", "view", "--json", CURRENT_PR_STATUS_FIELDS],
       [
         "pr",
         "list",

--- a/packages/server/src/services/github-service.ts
+++ b/packages/server/src/services/github-service.ts
@@ -236,8 +236,9 @@ query PullRequestCheckoutTarget($owner: String!, $name: String!, $number: Int!) 
   }
 }`;
 
-const CURRENT_PR_STATUS_FIELDS =
-  "number,url,title,state,isDraft,baseRefName,headRefName,mergedAt,statusCheckRollup,reviewDecision,mergeable,headRepositoryOwner";
+const CURRENT_PR_STATUS_BASE_FIELDS =
+  "number,url,title,state,isDraft,baseRefName,headRefName,mergedAt,reviewDecision,mergeable,headRepositoryOwner";
+const CURRENT_PR_STATUS_FIELDS = `${CURRENT_PR_STATUS_BASE_FIELDS},statusCheckRollup`;
 
 const PULL_REQUEST_TIMELINE_QUERY = `
 query PullRequestTimeline($owner: String!, $name: String!, $number: Int!) {
@@ -1314,6 +1315,21 @@ function isNoPullRequestFoundError(error: unknown): boolean {
   return text.includes("no pull requests found");
 }
 
+function isStatusCheckRollupPermissionError(error: unknown): boolean {
+  if (!(error instanceof GitHubCommandError)) {
+    return false;
+  }
+  const text = error.stderr.toLowerCase();
+  if (text.includes("statuscheckrollup")) {
+    return true;
+  }
+  return (
+    text.includes("resource not accessible by personal access token") ||
+    text.includes("requires one of the following scopes") ||
+    text.includes("insufficient permission")
+  );
+}
+
 async function resolveCurrentPullRequestView(options: {
   cwd: string;
   headRef: string;
@@ -1370,8 +1386,10 @@ async function tryCurrentPullRequestView(options: {
   run: (args: string[], options: GitHubCommandRunnerOptions) => Promise<string>;
 }): Promise<ResolvedPullRequestCandidate | null> {
   try {
-    const stdout = await options.run(["pr", "view", "--json", CURRENT_PR_STATUS_FIELDS], {
+    const stdout = await runCurrentPullRequestStatusCommand({
       cwd: options.cwd,
+      run: options.run,
+      args: ["pr", "view"],
     });
     return parseCurrentPullRequestCandidate(stdout, options.headRef);
   } catch (error) {
@@ -1397,19 +1415,40 @@ async function listCurrentPullRequestCandidates(options: {
     "all",
     "--head",
     options.headRef,
-    "--json",
-    CURRENT_PR_STATUS_FIELDS,
     "--limit",
     "10",
   );
   try {
-    const stdout = await options.run(args, { cwd: options.cwd });
+    const stdout = await runCurrentPullRequestStatusCommand({
+      cwd: options.cwd,
+      run: options.run,
+      args,
+    });
     return parseCurrentPullRequestCandidateList(stdout, options.headRef);
   } catch (error) {
     if (isNoPullRequestFoundError(error)) {
       return [];
     }
     throw error;
+  }
+}
+
+async function runCurrentPullRequestStatusCommand(options: {
+  cwd: string;
+  run: (args: string[], options: GitHubCommandRunnerOptions) => Promise<string>;
+  args: string[];
+}): Promise<string> {
+  try {
+    return await options.run([...options.args, "--json", CURRENT_PR_STATUS_FIELDS], {
+      cwd: options.cwd,
+    });
+  } catch (error) {
+    if (!isStatusCheckRollupPermissionError(error)) {
+      throw error;
+    }
+    return options.run([...options.args, "--json", CURRENT_PR_STATUS_BASE_FIELDS], {
+      cwd: options.cwd,
+    });
   }
 }
 

--- a/packages/server/src/services/github-service.ts
+++ b/packages/server/src/services/github-service.ts
@@ -1319,15 +1319,7 @@ function isStatusCheckRollupPermissionError(error: unknown): boolean {
   if (!(error instanceof GitHubCommandError)) {
     return false;
   }
-  const text = error.stderr.toLowerCase();
-  if (text.includes("statuscheckrollup")) {
-    return true;
-  }
-  return (
-    text.includes("resource not accessible by personal access token") ||
-    text.includes("requires one of the following scopes") ||
-    text.includes("insufficient permission")
-  );
+  return error.stderr.toLowerCase().includes("statuscheckrollup");
 }
 
 async function resolveCurrentPullRequestView(options: {
@@ -1410,14 +1402,7 @@ async function listCurrentPullRequestCandidates(options: {
   if (options.repo) {
     args.push("--repo", options.repo);
   }
-  args.push(
-    "--state",
-    "all",
-    "--head",
-    options.headRef,
-    "--limit",
-    "10",
-  );
+  args.push("--state", "all", "--head", options.headRef, "--limit", "10");
   try {
     const stdout = await runCurrentPullRequestStatusCommand({
       cwd: options.cwd,


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
-->

### Linked issue

Closes #926

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fixes a regression in `v0.1.74` where PR status lookup could fail entirely for users authenticated with fine-grained GitHub tokens.

Issue analysis:
- `getCurrentPullRequestStatus` requests PR metadata through `gh pr view --json ...` and `gh pr list --json ...`.
- In `v0.1.74`, those requests included `statusCheckRollup` so the desktop app could surface CI check state.
- On fine-grained tokens, `statusCheckRollup` can require permissions that are not granted, so `gh` exits with an error instead of returning partial data.
- Paseo then surfaced that command failure rather than degrading gracefully, which broke the whole PR status fetch instead of only dropping checks.

Solution:
- Split the PR status field set into a base query and an enhanced query that adds `statusCheckRollup`.
- Try the enhanced query first so existing behavior is preserved when permissions are available.
- If `gh pr view` or `gh pr list` fails with a permission error tied to `statusCheckRollup`, retry automatically with the base field set.
- In the fallback path, PR metadata, mergeability, and review decision still load; only the checks list degrades to empty.

This keeps the diff narrow and preserves the existing richer status path for tokens that can read checks.

### How did you verify it

Reproduced and verified at the service layer with targeted tests:

- Ran `npm run test:unit --workspace=@getpaseo/server -- src/services/github-service.test.ts`
- Confirmed the existing PR status tests still pass.
- Added a regression test for `gh pr view` failing on `statusCheckRollup` permissions and verified the code retries with a reduced `--json` field set.
- Added a regression test for the fork-parent fallback path where `gh pr list` hits the same permission error and verified it also retries successfully.

Observed result after the change:
- PR status lookup still succeeds when `statusCheckRollup` is not accessible.
- `checks` and `checksStatus` degrade to empty / `none` in the fallback path instead of failing the whole request.

I did not run the full repo `typecheck` or `lint`; only the targeted server unit test file above.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
