### PR TITLE
Add trace logging and tighten daemon log defaults

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -39,7 +39,15 @@ In any worktree-style or portless setup, never assume default ports.
 
 ### Daemon logs
 
-Check `$PASEO_HOME/daemon.log` for trace-level logs.
+Check `$PASEO_HOME/daemon.log` for daemon logs. The default level is `info`; set
+`PASEO_LOG_LEVEL=trace` before launching the daemon when you need full provider,
+session, and agent-manager traces for stuck-state debugging.
+
+The supervisor rotates `daemon.log`. Persisted `log.file.rotate` settings in
+`$PASEO_HOME/config.json` win first. Without persisted config, the optional
+`PASEO_LOG_ROTATE_SIZE` and `PASEO_LOG_ROTATE_COUNT` env vars override the
+defaults. Production defaults are `10m` x `3` files; `PASEO_NODE_ENV=development`
+defaults are `100m` x `10` files.
 
 ## paseo.json service scripts
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,8 +46,7 @@ session, and agent-manager traces for stuck-state debugging.
 The supervisor rotates `daemon.log`. Persisted `log.file.rotate` settings in
 `$PASEO_HOME/config.json` win first. Without persisted config, the optional
 `PASEO_LOG_ROTATE_SIZE` and `PASEO_LOG_ROTATE_COUNT` env vars override the
-defaults. Production defaults are `10m` x `3` files; `PASEO_NODE_ENV=development`
-defaults are `100m` x `10` files.
+defaults. The default rotation is `10m` x `3` files everywhere.
 
 ## paseo.json service scripts
 

--- a/packages/server/scripts/supervisor-entrypoint.ts
+++ b/packages/server/scripts/supervisor-entrypoint.ts
@@ -9,15 +9,13 @@ import {
 } from "../src/server/pid-lock.js";
 import { resolvePaseoHome } from "../src/server/paseo-home.js";
 import { loadPersistedConfig } from "../src/server/persisted-config.js";
-import { resolvePaseoNodeEnv } from "../src/server/paseo-env.js";
+import { parseOptionalPositiveIntegerEnv } from "../src/server/paseo-env.js";
 import { runSupervisor } from "./supervisor.js";
 import { applySherpaLoaderEnv } from "../src/server/speech/providers/local/sherpa/sherpa-runtime-env.js";
 
 const DEFAULT_DAEMON_LOG_FILENAME = "daemon.log";
-const DEFAULT_PROD_LOG_ROTATE_SIZE = "10m";
-const DEFAULT_PROD_LOG_ROTATE_MAX_FILES = 3;
-const DEFAULT_DEV_LOG_ROTATE_SIZE = "100m";
-const DEFAULT_DEV_LOG_ROTATE_MAX_FILES = 10;
+const DEFAULT_LOG_ROTATE_SIZE = "10m";
+const DEFAULT_LOG_ROTATE_MAX_FILES = 3;
 
 interface DaemonRunnerConfig {
   devMode: boolean;
@@ -87,13 +85,8 @@ export function resolveSupervisorLogFile(
 ) {
   const configuredFile = persistedConfig.log?.file;
   const configuredPath = configuredFile?.path;
-  const isDev = resolvePaseoNodeEnv(env) === "development";
-  const defaultRotateSize = isDev ? DEFAULT_DEV_LOG_ROTATE_SIZE : DEFAULT_PROD_LOG_ROTATE_SIZE;
-  const defaultRotateMaxFiles = isDev
-    ? DEFAULT_DEV_LOG_ROTATE_MAX_FILES
-    : DEFAULT_PROD_LOG_ROTATE_MAX_FILES;
   const envRotateSize = env.PASEO_LOG_ROTATE_SIZE?.trim();
-  const envRotateMaxFiles = parsePositiveIntegerEnv(env.PASEO_LOG_ROTATE_COUNT);
+  const envRotateMaxFiles = parseOptionalPositiveIntegerEnv(env.PASEO_LOG_ROTATE_COUNT);
   let logPath = path.join(paseoHome, DEFAULT_DAEMON_LOG_FILENAME);
   if (configuredPath) {
     logPath = path.isAbsolute(configuredPath)
@@ -104,19 +97,11 @@ export function resolveSupervisorLogFile(
   return {
     path: logPath,
     rotate: {
-      maxSize: configuredFile?.rotate?.maxSize ?? envRotateSize ?? defaultRotateSize,
-      maxFiles: configuredFile?.rotate?.maxFiles ?? envRotateMaxFiles ?? defaultRotateMaxFiles,
+      maxSize: configuredFile?.rotate?.maxSize ?? envRotateSize ?? DEFAULT_LOG_ROTATE_SIZE,
+      maxFiles:
+        configuredFile?.rotate?.maxFiles ?? envRotateMaxFiles ?? DEFAULT_LOG_ROTATE_MAX_FILES,
     },
   };
-}
-
-function parsePositiveIntegerEnv(value: string | undefined): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  const parsed = Number.parseInt(value.trim(), 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 async function main(): Promise<void> {

--- a/packages/server/scripts/supervisor-entrypoint.ts
+++ b/packages/server/scripts/supervisor-entrypoint.ts
@@ -9,13 +9,9 @@ import {
 } from "../src/server/pid-lock.js";
 import { resolvePaseoHome } from "../src/server/paseo-home.js";
 import { loadPersistedConfig } from "../src/server/persisted-config.js";
-import { parseOptionalPositiveIntegerEnv } from "../src/server/paseo-env.js";
 import { runSupervisor } from "./supervisor.js";
+import { resolveSupervisorLogFile } from "./supervisor-log-config.js";
 import { applySherpaLoaderEnv } from "../src/server/speech/providers/local/sherpa/sherpa-runtime-env.js";
-
-const DEFAULT_DAEMON_LOG_FILENAME = "daemon.log";
-const DEFAULT_LOG_ROTATE_SIZE = "10m";
-const DEFAULT_LOG_ROTATE_MAX_FILES = 3;
 
 interface DaemonRunnerConfig {
   devMode: boolean;
@@ -76,32 +72,6 @@ function resolvePackagedNodeEntrypointRunnerPath(currentScriptPath: string): str
   const appRoot = currentScriptPath.slice(0, markerIndex);
   const runnerPath = path.join(appRoot, "dist", "daemon", "node-entrypoint-runner.js");
   return existsSync(runnerPath) ? runnerPath : null;
-}
-
-export function resolveSupervisorLogFile(
-  paseoHome: string,
-  persistedConfig: ReturnType<typeof loadPersistedConfig>,
-  env: NodeJS.ProcessEnv = process.env,
-) {
-  const configuredFile = persistedConfig.log?.file;
-  const configuredPath = configuredFile?.path;
-  const envRotateSize = env.PASEO_LOG_ROTATE_SIZE?.trim();
-  const envRotateMaxFiles = parseOptionalPositiveIntegerEnv(env.PASEO_LOG_ROTATE_COUNT);
-  let logPath = path.join(paseoHome, DEFAULT_DAEMON_LOG_FILENAME);
-  if (configuredPath) {
-    logPath = path.isAbsolute(configuredPath)
-      ? configuredPath
-      : path.resolve(paseoHome, configuredPath);
-  }
-
-  return {
-    path: logPath,
-    rotate: {
-      maxSize: configuredFile?.rotate?.maxSize ?? envRotateSize ?? DEFAULT_LOG_ROTATE_SIZE,
-      maxFiles:
-        configuredFile?.rotate?.maxFiles ?? envRotateMaxFiles ?? DEFAULT_LOG_ROTATE_MAX_FILES,
-    },
-  };
 }
 
 async function main(): Promise<void> {
@@ -175,10 +145,8 @@ async function main(): Promise<void> {
   });
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  void main().catch((error) => {
-    const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
-    process.stderr.write(`${message}\n`);
-    process.exit(1);
-  });
-}
+void main().catch((error) => {
+  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});

--- a/packages/server/scripts/supervisor-entrypoint.ts
+++ b/packages/server/scripts/supervisor-entrypoint.ts
@@ -9,12 +9,15 @@ import {
 } from "../src/server/pid-lock.js";
 import { resolvePaseoHome } from "../src/server/paseo-home.js";
 import { loadPersistedConfig } from "../src/server/persisted-config.js";
+import { resolvePaseoNodeEnv } from "../src/server/paseo-env.js";
 import { runSupervisor } from "./supervisor.js";
 import { applySherpaLoaderEnv } from "../src/server/speech/providers/local/sherpa/sherpa-runtime-env.js";
 
 const DEFAULT_DAEMON_LOG_FILENAME = "daemon.log";
-const DEFAULT_LOG_ROTATE_SIZE = "10m";
-const DEFAULT_LOG_ROTATE_MAX_FILES = 2;
+const DEFAULT_PROD_LOG_ROTATE_SIZE = "10m";
+const DEFAULT_PROD_LOG_ROTATE_MAX_FILES = 3;
+const DEFAULT_DEV_LOG_ROTATE_SIZE = "100m";
+const DEFAULT_DEV_LOG_ROTATE_MAX_FILES = 10;
 
 interface DaemonRunnerConfig {
   devMode: boolean;
@@ -77,12 +80,20 @@ function resolvePackagedNodeEntrypointRunnerPath(currentScriptPath: string): str
   return existsSync(runnerPath) ? runnerPath : null;
 }
 
-function resolveSupervisorLogFile(
+export function resolveSupervisorLogFile(
   paseoHome: string,
   persistedConfig: ReturnType<typeof loadPersistedConfig>,
+  env: NodeJS.ProcessEnv = process.env,
 ) {
   const configuredFile = persistedConfig.log?.file;
   const configuredPath = configuredFile?.path;
+  const isDev = resolvePaseoNodeEnv(env) === "development";
+  const defaultRotateSize = isDev ? DEFAULT_DEV_LOG_ROTATE_SIZE : DEFAULT_PROD_LOG_ROTATE_SIZE;
+  const defaultRotateMaxFiles = isDev
+    ? DEFAULT_DEV_LOG_ROTATE_MAX_FILES
+    : DEFAULT_PROD_LOG_ROTATE_MAX_FILES;
+  const envRotateSize = env.PASEO_LOG_ROTATE_SIZE?.trim();
+  const envRotateMaxFiles = parsePositiveIntegerEnv(env.PASEO_LOG_ROTATE_COUNT);
   let logPath = path.join(paseoHome, DEFAULT_DAEMON_LOG_FILENAME);
   if (configuredPath) {
     logPath = path.isAbsolute(configuredPath)
@@ -93,10 +104,19 @@ function resolveSupervisorLogFile(
   return {
     path: logPath,
     rotate: {
-      maxSize: configuredFile?.rotate?.maxSize ?? DEFAULT_LOG_ROTATE_SIZE,
-      maxFiles: configuredFile?.rotate?.maxFiles ?? DEFAULT_LOG_ROTATE_MAX_FILES,
+      maxSize: configuredFile?.rotate?.maxSize ?? envRotateSize ?? defaultRotateSize,
+      maxFiles: configuredFile?.rotate?.maxFiles ?? envRotateMaxFiles ?? defaultRotateMaxFiles,
     },
   };
+}
+
+function parsePositiveIntegerEnv(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value.trim(), 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 async function main(): Promise<void> {
@@ -113,7 +133,7 @@ async function main(): Promise<void> {
 
   const paseoHome = resolvePaseoHome(workerEnv);
   const persistedConfig = loadPersistedConfig(paseoHome);
-  const supervisorLogFile = resolveSupervisorLogFile(paseoHome, persistedConfig);
+  const supervisorLogFile = resolveSupervisorLogFile(paseoHome, persistedConfig, workerEnv);
 
   try {
     await acquirePidLock(paseoHome, null, {
@@ -170,8 +190,10 @@ async function main(): Promise<void> {
   });
 }
 
-void main().catch((error) => {
-  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
-  process.stderr.write(`${message}\n`);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  void main().catch((error) => {
+    const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/server/scripts/supervisor-log-config.ts
+++ b/packages/server/scripts/supervisor-log-config.ts
@@ -1,0 +1,42 @@
+import path from "node:path";
+
+import type { loadPersistedConfig } from "../src/server/persisted-config.js";
+
+const DEFAULT_DAEMON_LOG_FILENAME = "daemon.log";
+const DEFAULT_LOG_ROTATE_SIZE = "10m";
+const DEFAULT_LOG_ROTATE_MAX_FILES = 3;
+
+export function resolveSupervisorLogFile(
+  paseoHome: string,
+  persistedConfig: ReturnType<typeof loadPersistedConfig>,
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  const configuredFile = persistedConfig.log?.file;
+  const configuredPath = configuredFile?.path;
+  const envRotateSize = env.PASEO_LOG_ROTATE_SIZE?.trim();
+  const envRotateMaxFiles = parseOptionalPositiveInteger(env.PASEO_LOG_ROTATE_COUNT);
+  let logPath = path.join(paseoHome, DEFAULT_DAEMON_LOG_FILENAME);
+  if (configuredPath) {
+    logPath = path.isAbsolute(configuredPath)
+      ? configuredPath
+      : path.resolve(paseoHome, configuredPath);
+  }
+
+  return {
+    path: logPath,
+    rotate: {
+      maxSize: configuredFile?.rotate?.maxSize ?? envRotateSize ?? DEFAULT_LOG_ROTATE_SIZE,
+      maxFiles:
+        configuredFile?.rotate?.maxFiles ?? envRotateMaxFiles ?? DEFAULT_LOG_ROTATE_MAX_FILES,
+    },
+  };
+}
+
+function parseOptionalPositiveInteger(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value.trim(), 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}

--- a/packages/server/scripts/supervisor.logging.test.ts
+++ b/packages/server/scripts/supervisor.logging.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { spawn } from "node:child_process";
 import { describe, expect, test } from "vitest";
 import { isPlatform } from "../src/test-utils/platform.js";
+import { resolveSupervisorLogFile } from "./supervisor-entrypoint.js";
 
 const repoRoot = path.resolve(fileURLToPath(new URL("../../..", import.meta.url)));
 const supervisorPath = fileURLToPath(new URL("./supervisor.ts", import.meta.url));
@@ -87,6 +88,73 @@ async function runSupervisorFixture(options: {
 }
 
 describe("supervisor durable logging", () => {
+  test("resolves production rotation defaults", () => {
+    const logFile = resolveSupervisorLogFile(
+      "/tmp/paseo-home",
+      {},
+      { PASEO_NODE_ENV: "production" },
+    );
+
+    expect(logFile).toEqual({
+      path: "/tmp/paseo-home/daemon.log",
+      rotate: { maxSize: "10m", maxFiles: 3 },
+    });
+  });
+
+  test("resolves development rotation defaults", () => {
+    const logFile = resolveSupervisorLogFile(
+      "/tmp/paseo-home",
+      {},
+      { PASEO_NODE_ENV: "development" },
+    );
+
+    expect(logFile).toEqual({
+      path: "/tmp/paseo-home/daemon.log",
+      rotate: { maxSize: "100m", maxFiles: 10 },
+    });
+  });
+
+  test("lets persisted rotation override env rotation defaults", () => {
+    const logFile = resolveSupervisorLogFile(
+      "/tmp/paseo-home",
+      {
+        log: {
+          file: {
+            path: "logs/daemon.log",
+            rotate: { maxSize: "25m", maxFiles: 4 },
+          },
+        },
+      },
+      {
+        PASEO_NODE_ENV: "development",
+        PASEO_LOG_ROTATE_SIZE: "200m",
+        PASEO_LOG_ROTATE_COUNT: "12",
+      },
+    );
+
+    expect(logFile).toEqual({
+      path: "/tmp/paseo-home/logs/daemon.log",
+      rotate: { maxSize: "25m", maxFiles: 4 },
+    });
+  });
+
+  test("uses env rotation when persisted rotation is absent", () => {
+    const logFile = resolveSupervisorLogFile(
+      "/tmp/paseo-home",
+      {},
+      {
+        PASEO_NODE_ENV: "production",
+        PASEO_LOG_ROTATE_SIZE: "50m",
+        PASEO_LOG_ROTATE_COUNT: "8",
+      },
+    );
+
+    expect(logFile).toEqual({
+      path: "/tmp/paseo-home/daemon.log",
+      rotate: { maxSize: "50m", maxFiles: 8 },
+    });
+  });
+
   test("writes supervised worker stdout and stderr to daemon.log", async () => {
     const result = await runSupervisorFixture({
       workerSource: `

--- a/packages/server/scripts/supervisor.logging.test.ts
+++ b/packages/server/scripts/supervisor.logging.test.ts
@@ -89,17 +89,19 @@ async function runSupervisorFixture(options: {
 
 describe("supervisor durable logging", () => {
   test("resolves rotation defaults", () => {
-    const logFile = resolveSupervisorLogFile("/tmp/paseo-home", {}, {});
+    const paseoHome = path.join(path.sep, "tmp", "paseo-home");
+    const logFile = resolveSupervisorLogFile(paseoHome, {}, {});
 
     expect(logFile).toEqual({
-      path: "/tmp/paseo-home/daemon.log",
+      path: path.join(paseoHome, "daemon.log"),
       rotate: { maxSize: "10m", maxFiles: 3 },
     });
   });
 
   test("lets persisted rotation override env rotation defaults", () => {
+    const paseoHome = path.join(path.sep, "tmp", "paseo-home");
     const logFile = resolveSupervisorLogFile(
-      "/tmp/paseo-home",
+      paseoHome,
       {
         log: {
           file: {
@@ -115,14 +117,15 @@ describe("supervisor durable logging", () => {
     );
 
     expect(logFile).toEqual({
-      path: "/tmp/paseo-home/logs/daemon.log",
+      path: path.join(paseoHome, "logs", "daemon.log"),
       rotate: { maxSize: "25m", maxFiles: 4 },
     });
   });
 
   test("uses env rotation when persisted rotation is absent", () => {
+    const paseoHome = path.join(path.sep, "tmp", "paseo-home");
     const logFile = resolveSupervisorLogFile(
-      "/tmp/paseo-home",
+      paseoHome,
       {},
       {
         PASEO_LOG_ROTATE_SIZE: "50m",
@@ -131,7 +134,7 @@ describe("supervisor durable logging", () => {
     );
 
     expect(logFile).toEqual({
-      path: "/tmp/paseo-home/daemon.log",
+      path: path.join(paseoHome, "daemon.log"),
       rotate: { maxSize: "50m", maxFiles: 8 },
     });
   });

--- a/packages/server/scripts/supervisor.logging.test.ts
+++ b/packages/server/scripts/supervisor.logging.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { spawn } from "node:child_process";
 import { describe, expect, test } from "vitest";
 import { isPlatform } from "../src/test-utils/platform.js";
-import { resolveSupervisorLogFile } from "./supervisor-entrypoint.js";
+import { resolveSupervisorLogFile } from "./supervisor-log-config.js";
 
 const repoRoot = path.resolve(fileURLToPath(new URL("../../..", import.meta.url)));
 const supervisorPath = fileURLToPath(new URL("./supervisor.ts", import.meta.url));

--- a/packages/server/scripts/supervisor.logging.test.ts
+++ b/packages/server/scripts/supervisor.logging.test.ts
@@ -117,7 +117,7 @@ describe("supervisor durable logging", () => {
     );
 
     expect(logFile).toEqual({
-      path: path.join(paseoHome, "logs", "daemon.log"),
+      path: path.resolve(paseoHome, "logs", "daemon.log"),
       rotate: { maxSize: "25m", maxFiles: 4 },
     });
   });

--- a/packages/server/scripts/supervisor.logging.test.ts
+++ b/packages/server/scripts/supervisor.logging.test.ts
@@ -88,29 +88,12 @@ async function runSupervisorFixture(options: {
 }
 
 describe("supervisor durable logging", () => {
-  test("resolves production rotation defaults", () => {
-    const logFile = resolveSupervisorLogFile(
-      "/tmp/paseo-home",
-      {},
-      { PASEO_NODE_ENV: "production" },
-    );
+  test("resolves rotation defaults", () => {
+    const logFile = resolveSupervisorLogFile("/tmp/paseo-home", {}, {});
 
     expect(logFile).toEqual({
       path: "/tmp/paseo-home/daemon.log",
       rotate: { maxSize: "10m", maxFiles: 3 },
-    });
-  });
-
-  test("resolves development rotation defaults", () => {
-    const logFile = resolveSupervisorLogFile(
-      "/tmp/paseo-home",
-      {},
-      { PASEO_NODE_ENV: "development" },
-    );
-
-    expect(logFile).toEqual({
-      path: "/tmp/paseo-home/daemon.log",
-      rotate: { maxSize: "100m", maxFiles: 10 },
     });
   });
 
@@ -126,7 +109,6 @@ describe("supervisor durable logging", () => {
         },
       },
       {
-        PASEO_NODE_ENV: "development",
         PASEO_LOG_ROTATE_SIZE: "200m",
         PASEO_LOG_ROTATE_COUNT: "12",
       },
@@ -143,7 +125,6 @@ describe("supervisor durable logging", () => {
       "/tmp/paseo-home",
       {},
       {
-        PASEO_NODE_ENV: "production",
         PASEO_LOG_ROTATE_SIZE: "50m",
         PASEO_LOG_ROTATE_COUNT: "8",
       },

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -716,6 +716,7 @@ test("createAgent passes daemon launch env through the provider launch context",
     modeId: "auto",
   });
   expect(client.lastLaunchContext).toEqual({
+    agentId: snapshot.id,
     env: {
       PASEO_AGENT_ID: snapshot.id,
     },
@@ -1179,6 +1180,7 @@ test("resumeAgentFromPersistence keeps metadata config, applies overrides, and p
     },
   });
   expect(client.lastResumeLaunchContext).toEqual({
+    agentId: resumed.id,
     env: {
       PASEO_AGENT_ID: resumed.id,
     },
@@ -1283,6 +1285,7 @@ test("reloadAgentSession passes daemon launch env through the provider launch co
   });
 
   expect(client.lastCreateLaunchContext).toEqual({
+    agentId: snapshot.id,
     env: {
       PASEO_AGENT_ID: snapshot.id,
     },
@@ -1293,6 +1296,7 @@ test("reloadAgentSession passes daemon launch env through the provider launch co
   });
 
   expect(client.lastResumeLaunchContext).toEqual({
+    agentId: snapshot.id,
     env: {
       PASEO_AGENT_ID: snapshot.id,
     },

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1008,12 +1008,11 @@ export class AgentManager {
         provider: agent.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId: agent.activeForegroundTurnId ?? undefined,
-        traceKind: "manager_close",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         pendingPermissions: agent.pendingPermissions.size,
       },
-      "closeAgent: start",
+      "agent.manager.close.start",
     );
     const closedAgent = this.prepareAgentForClosure(agent, "agent closed");
     await agent.session.close();
@@ -1025,9 +1024,8 @@ export class AgentManager {
         agentId,
         provider: closedAgent.provider,
         sessionId: closedAgent.persistence?.sessionId ?? undefined,
-        traceKind: "manager_close",
       },
-      "closeAgent: completed",
+      "agent.manager.close.complete",
     );
   }
 
@@ -1485,14 +1483,13 @@ export class AgentManager {
         provider: existingAgent.provider,
         sessionId: existingAgent.persistence?.sessionId ?? undefined,
         turnId: existingAgent.activeForegroundTurnId ?? undefined,
-        traceKind: "manager_stream_start",
         lifecycle: existingAgent.lifecycle,
         activeForegroundTurnId: existingAgent.activeForegroundTurnId,
         hasPendingForegroundRun: this.foregroundRuns.hasPendingRun(agentId),
         promptType: typeof prompt === "string" ? "string" : "structured",
         hasRunOptions: Boolean(options),
       },
-      "streamAgent: requested",
+      "agent.manager.stream.request",
     );
     if (existingAgent.activeForegroundTurnId || this.foregroundRuns.hasPendingRun(agentId)) {
       this.logger.trace(
@@ -1501,11 +1498,10 @@ export class AgentManager {
           provider: existingAgent.provider,
           sessionId: existingAgent.persistence?.sessionId ?? undefined,
           turnId: existingAgent.activeForegroundTurnId ?? undefined,
-          traceKind: "manager_stream_reject",
           lifecycle: existingAgent.lifecycle,
           hasPendingForegroundRun: this.foregroundRuns.hasPendingRun(agentId),
         },
-        "streamAgent: rejected because a foreground run is already in flight",
+        "agent.manager.stream.reject",
       );
       throw new Error(`Agent ${agentId} already has an active run`);
     }
@@ -1545,11 +1541,10 @@ export class AgentManager {
           provider: agent.provider,
           sessionId: agent.persistence?.sessionId ?? undefined,
           turnId,
-          traceKind: "manager_stream_started",
           lifecycle: agent.lifecycle,
           activeForegroundTurnId: agent.activeForegroundTurnId,
         },
-        "streamAgent: started",
+        "agent.manager.stream.start",
       );
 
       turnStream = this.foregroundRuns.createTurnStream(turnId);
@@ -1604,12 +1599,11 @@ export class AgentManager {
         provider: agent.provider,
         sessionId: mutableAgent.persistence?.sessionId ?? undefined,
         turnId,
-        traceKind: "manager_finalize",
         lifecycle: mutableAgent.lifecycle,
         terminalError,
         pendingReplacement: mutableAgent.pendingReplacement,
       },
-      "finalizeForegroundTurn: applying terminal state",
+      "agent.manager.finalize",
     );
     if (!shouldHoldBusyForReplacement) {
       this.touchUpdatedAt(mutableAgent);
@@ -2405,10 +2399,9 @@ export class AgentManager {
         provider: event.provider,
         sessionId: this.agents.get(agentId)?.persistence?.sessionId ?? undefined,
         turnId: readEventTurnId(event),
-        traceKind: "manager_enqueue",
         event,
       },
-      "AgentManager queued session event",
+      "agent.manager.enqueue",
     );
     const previous = this.sessionEventTails.get(agentId) ?? Promise.resolve();
     const next = previous
@@ -2427,10 +2420,9 @@ export class AgentManager {
             provider: event.provider,
             sessionId: current.persistence?.sessionId ?? undefined,
             turnId: readEventTurnId(event),
-            traceKind: "manager_dequeue",
             event,
           },
-          "AgentManager processing session event",
+          "agent.manager.dequeue",
         );
         await this.dispatchSessionEvent(current, event);
         return;
@@ -2455,7 +2447,7 @@ export class AgentManager {
     agent: ActiveManagedAgent,
     event: AgentStreamEvent,
   ): Promise<void> {
-    const turnId = (event as { turnId?: string }).turnId;
+    const turnId = readEventTurnId(event);
     const matchingWaiters = this.foregroundRuns.getMatchingWaiters(agent, turnId);
     this.logger.trace(
       {
@@ -2463,11 +2455,10 @@ export class AgentManager {
         provider: event.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId,
-        traceKind: "manager_dispatch_session_event",
         matchingWaiterCount: matchingWaiters.length,
         event,
       },
-      "AgentManager dispatching session event",
+      "agent.manager.dispatch_session_event",
     );
 
     const shouldNotifyWaiters = await this.handleStreamEvent(agent, event);
@@ -2485,12 +2476,11 @@ export class AgentManager {
         provider: event.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId,
-        traceKind: "manager_waiter_notify",
         notifiedWaiterCount: matchingWaiters.length,
         terminal: isTurnTerminalEvent(event),
         event,
       },
-      "AgentManager notified foreground waiters",
+      "agent.manager.notify_waiters",
     );
   }
 
@@ -2604,7 +2594,7 @@ export class AgentManager {
   }
 
   private notifyForegroundTurnWaiters(agentId: string, event: AgentStreamEvent): void {
-    const turnId = (event as { turnId?: string }).turnId;
+    const turnId = readEventTurnId(event);
     if (turnId == null) {
       return;
     }
@@ -2621,10 +2611,9 @@ export class AgentManager {
         provider: event.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId,
-        traceKind: "manager_waiter_notify",
         event,
       },
-      "AgentManager notified foreground waiters for coalesced event",
+      "agent.manager.notify_waiters.coalesced",
     );
   }
 
@@ -2633,7 +2622,7 @@ export class AgentManager {
     event: AgentStreamEvent,
     options?: HandleStreamEventOptions,
   ): Promise<boolean> {
-    const eventTurnId = (event as { turnId?: string }).turnId;
+    const eventTurnId = readEventTurnId(event);
     const isForegroundEvent = Boolean(eventTurnId && agent.activeForegroundTurnId === eventTurnId);
     this.traceHandleStreamEventStart(agent, event, eventTurnId, isForegroundEvent);
     if (
@@ -2693,13 +2682,12 @@ export class AgentManager {
         provider: event.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId,
-        traceKind: "manager_handle_event_start",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         isForegroundEvent,
         event,
       },
-      "AgentManager handling stream event",
+      "agent.manager.handle_stream_event.start",
     );
   }
 
@@ -2714,10 +2702,9 @@ export class AgentManager {
         provider: event.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId,
-        traceKind: "manager_coalescer_buffered",
         event,
       },
-      "AgentManager buffered stream event for coalescing",
+      "agent.manager.coalescer.buffer",
     );
   }
 
@@ -2733,14 +2720,13 @@ export class AgentManager {
         provider: event.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId,
-        traceKind: "manager_handle_event_end",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         shouldDispatchEvent: flags.shouldDispatchEvent,
         shouldNotifyWaiters: flags.shouldNotifyWaiters,
         event,
       },
-      "AgentManager handled stream event",
+      "agent.manager.handle_stream_event.end",
     );
   }
 
@@ -2903,12 +2889,11 @@ export class AgentManager {
         provider: agent.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId: eventTurnId,
-        traceKind: "manager_turn_completed",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         eventTurnId,
       },
-      "handleStreamEvent: turn_completed",
+      "agent.manager.turn.completed",
     );
     agent.lastUsage = event.usage;
     agent.lastError = undefined;
@@ -2938,7 +2923,6 @@ export class AgentManager {
         provider: agent.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId: eventTurnId,
-        traceKind: "manager_turn_failed",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         eventTurnId,
@@ -2982,12 +2966,11 @@ export class AgentManager {
         provider: agent.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId: eventTurnId,
-        traceKind: "manager_turn_canceled",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         eventTurnId,
       },
-      "handleStreamEvent: turn_canceled",
+      "agent.manager.turn.canceled",
     );
     if (!isForegroundEvent && !agent.pendingReplacement) {
       agent.lifecycle = "idle";
@@ -3011,12 +2994,11 @@ export class AgentManager {
         provider: agent.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId: eventTurnId,
-        traceKind: "manager_turn_started",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         eventTurnId,
       },
-      "handleStreamEvent: turn_started",
+      "agent.manager.turn.started",
     );
     if (!isForegroundEvent) {
       agent.lifecycle = "running";
@@ -3168,13 +3150,12 @@ export class AgentManager {
         provider: agent.provider,
         sessionId: agent.persistence?.sessionId ?? undefined,
         turnId: agent.activeForegroundTurnId ?? undefined,
-        traceKind: "manager_state_emit",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         pendingPermissions: agent.pendingPermissions.size,
         persist: options?.persist !== false,
       },
-      "AgentManager emitting agent state",
+      "agent.manager.emit_state",
     );
 
     this.dispatch({
@@ -3311,11 +3292,10 @@ export class AgentManager {
         provider: event.provider,
         sessionId: agent?.persistence?.sessionId ?? undefined,
         turnId: readEventTurnId(event),
-        traceKind: "manager_stream_dispatch",
         metadata,
         event,
       },
-      "AgentManager dispatching stream event",
+      "agent.manager.dispatch_stream",
     );
     this.dispatch({ type: "agent_stream", agentId, event, ...metadata });
   }
@@ -3412,6 +3392,7 @@ export class AgentManager {
 
   private buildLaunchContext(agentId: string): AgentLaunchContext {
     return {
+      agentId,
       env: {
         PASEO_AGENT_ID: agentId,
       },
@@ -3503,5 +3484,5 @@ export class AgentManager {
 }
 
 function readEventTurnId(event: AgentStreamEvent): string | undefined {
-  return (event as { turnId?: string }).turnId;
+  return "turnId" in event ? event.turnId : undefined;
 }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -10,30 +10,31 @@ import type { Logger } from "pino";
 import { z } from "zod";
 import type { TerminalManager } from "../../terminal/terminal-manager.js";
 
-import type {
-  AgentCapabilityFlags,
-  AgentClient,
-  AgentCreateSessionOptions,
-  AgentFeature,
-  AgentLaunchContext,
-  AgentSlashCommand,
-  AgentMode,
-  AgentPermissionRequest,
-  AgentPermissionResponse,
-  AgentPermissionResult,
-  AgentPersistenceHandle,
-  AgentPromptInput,
-  AgentProvider,
-  AgentRunOptions,
-  AgentRunResult,
-  AgentSession,
-  AgentSessionConfig,
-  AgentStreamEvent,
-  AgentTimelineItem,
-  AgentUsage,
-  AgentRuntimeInfo,
-  ListPersistedAgentsOptions,
-  PersistedAgentDescriptor,
+import {
+  getAgentStreamEventTurnId,
+  type AgentCapabilityFlags,
+  type AgentClient,
+  type AgentCreateSessionOptions,
+  type AgentFeature,
+  type AgentLaunchContext,
+  type AgentSlashCommand,
+  type AgentMode,
+  type AgentPermissionRequest,
+  type AgentPermissionResponse,
+  type AgentPermissionResult,
+  type AgentPersistenceHandle,
+  type AgentPromptInput,
+  type AgentProvider,
+  type AgentRunOptions,
+  type AgentRunResult,
+  type AgentSession,
+  type AgentSessionConfig,
+  type AgentStreamEvent,
+  type AgentTimelineItem,
+  type AgentUsage,
+  type AgentRuntimeInfo,
+  type ListPersistedAgentsOptions,
+  type PersistedAgentDescriptor,
 } from "./agent-sdk-types.js";
 import { buildArchivedAgentRecord, type ArchivedStoredAgentRecord } from "./agent-archive.js";
 import type { StoredAgentRecord, AgentStorage } from "./agent-storage.js";
@@ -2398,7 +2399,7 @@ export class AgentManager {
         agentId,
         provider: event.provider,
         sessionId: this.agents.get(agentId)?.persistence?.sessionId ?? undefined,
-        turnId: readEventTurnId(event),
+        turnId: getAgentStreamEventTurnId(event),
         event,
       },
       "agent.manager.enqueue",
@@ -2419,7 +2420,7 @@ export class AgentManager {
             agentId,
             provider: event.provider,
             sessionId: current.persistence?.sessionId ?? undefined,
-            turnId: readEventTurnId(event),
+            turnId: getAgentStreamEventTurnId(event),
             event,
           },
           "agent.manager.dequeue",
@@ -2447,7 +2448,7 @@ export class AgentManager {
     agent: ActiveManagedAgent,
     event: AgentStreamEvent,
   ): Promise<void> {
-    const turnId = readEventTurnId(event);
+    const turnId = getAgentStreamEventTurnId(event);
     const matchingWaiters = this.foregroundRuns.getMatchingWaiters(agent, turnId);
     this.logger.trace(
       {
@@ -2594,7 +2595,7 @@ export class AgentManager {
   }
 
   private notifyForegroundTurnWaiters(agentId: string, event: AgentStreamEvent): void {
-    const turnId = readEventTurnId(event);
+    const turnId = getAgentStreamEventTurnId(event);
     if (turnId == null) {
       return;
     }
@@ -2622,7 +2623,7 @@ export class AgentManager {
     event: AgentStreamEvent,
     options?: HandleStreamEventOptions,
   ): Promise<boolean> {
-    const eventTurnId = readEventTurnId(event);
+    const eventTurnId = getAgentStreamEventTurnId(event);
     const isForegroundEvent = Boolean(eventTurnId && agent.activeForegroundTurnId === eventTurnId);
     this.traceHandleStreamEventStart(agent, event, eventTurnId, isForegroundEvent);
     if (
@@ -2891,7 +2892,6 @@ export class AgentManager {
         turnId: eventTurnId,
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
-        eventTurnId,
       },
       "agent.manager.turn.completed",
     );
@@ -2996,7 +2996,6 @@ export class AgentManager {
         turnId: eventTurnId,
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
-        eventTurnId,
       },
       "agent.manager.turn.started",
     );
@@ -3291,7 +3290,7 @@ export class AgentManager {
         agentId,
         provider: event.provider,
         sessionId: agent?.persistence?.sessionId ?? undefined,
-        turnId: readEventTurnId(event),
+        turnId: getAgentStreamEventTurnId(event),
         metadata,
         event,
       },
@@ -3481,8 +3480,4 @@ export class AgentManager {
     }
     return agent;
   }
-}
-
-function readEventTurnId(event: AgentStreamEvent): string | undefined {
-  return "turnId" in event ? event.turnId : undefined;
 }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1005,6 +1005,10 @@ export class AgentManager {
     this.logger.trace(
       {
         agentId,
+        provider: agent.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId: agent.activeForegroundTurnId ?? undefined,
+        traceKind: "manager_close",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         pendingPermissions: agent.pendingPermissions.size,
@@ -1016,7 +1020,15 @@ export class AgentManager {
     this.timelineStore.delete(agentId);
     await this.persistSnapshot(closedAgent);
     this.emitClosedAgent(closedAgent, { persist: false });
-    this.logger.trace({ agentId }, "closeAgent: completed");
+    this.logger.trace(
+      {
+        agentId,
+        provider: closedAgent.provider,
+        sessionId: closedAgent.persistence?.sessionId ?? undefined,
+        traceKind: "manager_close",
+      },
+      "closeAgent: completed",
+    );
   }
 
   async archiveAgent(agentId: string): Promise<{ archivedAt: string }> {
@@ -1470,6 +1482,10 @@ export class AgentManager {
     this.logger.trace(
       {
         agentId,
+        provider: existingAgent.provider,
+        sessionId: existingAgent.persistence?.sessionId ?? undefined,
+        turnId: existingAgent.activeForegroundTurnId ?? undefined,
+        traceKind: "manager_stream_start",
         lifecycle: existingAgent.lifecycle,
         activeForegroundTurnId: existingAgent.activeForegroundTurnId,
         hasPendingForegroundRun: this.foregroundRuns.hasPendingRun(agentId),
@@ -1482,6 +1498,10 @@ export class AgentManager {
       this.logger.trace(
         {
           agentId,
+          provider: existingAgent.provider,
+          sessionId: existingAgent.persistence?.sessionId ?? undefined,
+          turnId: existingAgent.activeForegroundTurnId ?? undefined,
+          traceKind: "manager_stream_reject",
           lifecycle: existingAgent.lifecycle,
           hasPendingForegroundRun: this.foregroundRuns.hasPendingRun(agentId),
         },
@@ -1522,6 +1542,10 @@ export class AgentManager {
       this.logger.trace(
         {
           agentId,
+          provider: agent.provider,
+          sessionId: agent.persistence?.sessionId ?? undefined,
+          turnId,
+          traceKind: "manager_stream_started",
           lifecycle: agent.lifecycle,
           activeForegroundTurnId: agent.activeForegroundTurnId,
         },
@@ -1577,6 +1601,10 @@ export class AgentManager {
     this.logger.trace(
       {
         agentId: agent.id,
+        provider: agent.provider,
+        sessionId: mutableAgent.persistence?.sessionId ?? undefined,
+        turnId,
+        traceKind: "manager_finalize",
         lifecycle: mutableAgent.lifecycle,
         terminalError,
         pendingReplacement: mutableAgent.pendingReplacement,
@@ -2371,6 +2399,17 @@ export class AgentManager {
   }
 
   private enqueueSessionEvent(agentId: string, event: AgentStreamEvent): void {
+    this.logger.trace(
+      {
+        agentId,
+        provider: event.provider,
+        sessionId: this.agents.get(agentId)?.persistence?.sessionId ?? undefined,
+        turnId: readEventTurnId(event),
+        traceKind: "manager_enqueue",
+        event,
+      },
+      "AgentManager queued session event",
+    );
     const previous = this.sessionEventTails.get(agentId) ?? Promise.resolve();
     const next = previous
       .catch(() => undefined)
@@ -2382,6 +2421,17 @@ export class AgentManager {
         if (current.session == null) {
           return;
         }
+        this.logger.trace(
+          {
+            agentId,
+            provider: event.provider,
+            sessionId: current.persistence?.sessionId ?? undefined,
+            turnId: readEventTurnId(event),
+            traceKind: "manager_dequeue",
+            event,
+          },
+          "AgentManager processing session event",
+        );
         await this.dispatchSessionEvent(current, event);
         return;
       })
@@ -2407,6 +2457,18 @@ export class AgentManager {
   ): Promise<void> {
     const turnId = (event as { turnId?: string }).turnId;
     const matchingWaiters = this.foregroundRuns.getMatchingWaiters(agent, turnId);
+    this.logger.trace(
+      {
+        agentId: agent.id,
+        provider: event.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId,
+        traceKind: "manager_dispatch_session_event",
+        matchingWaiterCount: matchingWaiters.length,
+        event,
+      },
+      "AgentManager dispatching session event",
+    );
 
     const shouldNotifyWaiters = await this.handleStreamEvent(agent, event);
 
@@ -2417,6 +2479,19 @@ export class AgentManager {
     this.foregroundRuns.notifyWaiters(matchingWaiters, event, {
       terminal: isTurnTerminalEvent(event),
     });
+    this.logger.trace(
+      {
+        agentId: agent.id,
+        provider: event.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId,
+        traceKind: "manager_waiter_notify",
+        notifiedWaiterCount: matchingWaiters.length,
+        terminal: isTurnTerminalEvent(event),
+        event,
+      },
+      "AgentManager notified foreground waiters",
+    );
   }
 
   private async resolveInitialPersistedTitle(
@@ -2540,6 +2615,17 @@ export class AgentManager {
     }
 
     this.foregroundRuns.notifyAgentWaiters(agent, event);
+    this.logger.trace(
+      {
+        agentId,
+        provider: event.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId,
+        traceKind: "manager_waiter_notify",
+        event,
+      },
+      "AgentManager notified foreground waiters for coalesced event",
+    );
   }
 
   private async handleStreamEvent(
@@ -2549,6 +2635,7 @@ export class AgentManager {
   ): Promise<boolean> {
     const eventTurnId = (event as { turnId?: string }).turnId;
     const isForegroundEvent = Boolean(eventTurnId && agent.activeForegroundTurnId === eventTurnId);
+    this.traceHandleStreamEventStart(agent, event, eventTurnId, isForegroundEvent);
     if (
       eventTurnId &&
       isTurnTerminalEvent(event) &&
@@ -2561,6 +2648,7 @@ export class AgentManager {
     if (!options?.fromHistory) {
       this.touchUpdatedAt(agent);
       if (this.agentStreamCoalescer.handle(agent.id, event)) {
+        this.traceCoalescerBuffered(agent, event, eventTurnId);
         return false;
       }
       this.agentStreamCoalescer.flushFor(agent.id);
@@ -2588,7 +2676,72 @@ export class AgentManager {
       this.dispatchStream(agent.id, event);
     }
 
+    this.traceHandleStreamEventEnd(agent, event, eventTurnId, flags);
+
     return flags.shouldNotifyWaiters;
+  }
+
+  private traceHandleStreamEventStart(
+    agent: ActiveManagedAgent,
+    event: AgentStreamEvent,
+    turnId: string | undefined,
+    isForegroundEvent: boolean,
+  ): void {
+    this.logger.trace(
+      {
+        agentId: agent.id,
+        provider: event.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId,
+        traceKind: "manager_handle_event_start",
+        lifecycle: agent.lifecycle,
+        activeForegroundTurnId: agent.activeForegroundTurnId,
+        isForegroundEvent,
+        event,
+      },
+      "AgentManager handling stream event",
+    );
+  }
+
+  private traceCoalescerBuffered(
+    agent: ActiveManagedAgent,
+    event: AgentStreamEvent,
+    turnId: string | undefined,
+  ): void {
+    this.logger.trace(
+      {
+        agentId: agent.id,
+        provider: event.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId,
+        traceKind: "manager_coalescer_buffered",
+        event,
+      },
+      "AgentManager buffered stream event for coalescing",
+    );
+  }
+
+  private traceHandleStreamEventEnd(
+    agent: ActiveManagedAgent,
+    event: AgentStreamEvent,
+    turnId: string | undefined,
+    flags: StreamEventFlags,
+  ): void {
+    this.logger.trace(
+      {
+        agentId: agent.id,
+        provider: event.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId,
+        traceKind: "manager_handle_event_end",
+        lifecycle: agent.lifecycle,
+        activeForegroundTurnId: agent.activeForegroundTurnId,
+        shouldDispatchEvent: flags.shouldDispatchEvent,
+        shouldNotifyWaiters: flags.shouldNotifyWaiters,
+        event,
+      },
+      "AgentManager handled stream event",
+    );
   }
 
   private dispatchStreamEventByType(params: {
@@ -2747,6 +2900,10 @@ export class AgentManager {
     this.logger.trace(
       {
         agentId: agent.id,
+        provider: agent.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId: eventTurnId,
+        traceKind: "manager_turn_completed",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         eventTurnId,
@@ -2778,6 +2935,10 @@ export class AgentManager {
     this.logger.warn(
       {
         agentId: agent.id,
+        provider: agent.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId: eventTurnId,
+        traceKind: "manager_turn_failed",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         eventTurnId,
@@ -2818,6 +2979,10 @@ export class AgentManager {
     this.logger.trace(
       {
         agentId: agent.id,
+        provider: agent.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId: eventTurnId,
+        traceKind: "manager_turn_canceled",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         eventTurnId,
@@ -2843,6 +3008,10 @@ export class AgentManager {
     this.logger.trace(
       {
         agentId: agent.id,
+        provider: agent.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId: eventTurnId,
+        traceKind: "manager_turn_started",
         lifecycle: agent.lifecycle,
         activeForegroundTurnId: agent.activeForegroundTurnId,
         eventTurnId,
@@ -2993,6 +3162,21 @@ export class AgentManager {
 
     this.syncFeaturesFromSession(agent);
 
+    this.logger.trace(
+      {
+        agentId: agent.id,
+        provider: agent.provider,
+        sessionId: agent.persistence?.sessionId ?? undefined,
+        turnId: agent.activeForegroundTurnId ?? undefined,
+        traceKind: "manager_state_emit",
+        lifecycle: agent.lifecycle,
+        activeForegroundTurnId: agent.activeForegroundTurnId,
+        pendingPermissions: agent.pendingPermissions.size,
+        persist: options?.persist !== false,
+      },
+      "AgentManager emitting agent state",
+    );
+
     this.dispatch({
       type: "agent_state",
       agent: { ...agent },
@@ -3120,6 +3304,19 @@ export class AgentManager {
     event: AgentStreamEvent,
     metadata?: { seq?: number; epoch?: string },
   ): void {
+    const agent = this.agents.get(agentId);
+    this.logger.trace(
+      {
+        agentId,
+        provider: event.provider,
+        sessionId: agent?.persistence?.sessionId ?? undefined,
+        turnId: readEventTurnId(event),
+        traceKind: "manager_stream_dispatch",
+        metadata,
+        event,
+      },
+      "AgentManager dispatching stream event",
+    );
     this.dispatch({ type: "agent_stream", agentId, event, ...metadata });
   }
 
@@ -3303,4 +3500,8 @@ export class AgentManager {
     }
     return agent;
   }
+}
+
+function readEventTurnId(event: AgentStreamEvent): string | undefined {
+  return (event as { turnId?: string }).turnId;
 }

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -17,6 +17,19 @@ export function startAgentRun(
   logger: Logger,
   options?: StartAgentRunOptions,
 ): { outOfBand: boolean } {
+  const snapshot = agentManager.getAgent(agentId);
+  logger.trace(
+    {
+      agentId,
+      provider: snapshot?.provider,
+      providerSessionId: snapshot?.persistence?.sessionId ?? undefined,
+      turnId: snapshot?.activeForegroundTurnId ?? undefined,
+      promptType: typeof prompt === "string" ? "string" : "structured",
+      hasRunOptions: Boolean(options?.runOptions),
+      replaceRunning: Boolean(options?.replaceRunning),
+    },
+    "agent.session.start_stream.request",
+  );
   // Out-of-band commands (e.g. /goal pause) must run WITHOUT canceling an
   // in-flight turn — replaceAgentRun would interrupt the running turn. The
   // intercept lives at this layer so it covers every prompt entrypoint.
@@ -28,12 +41,38 @@ export function startAgentRun(
   const iterator = shouldReplace
     ? agentManager.replaceAgentRun(agentId, prompt, runOptions)
     : agentManager.streamAgent(agentId, prompt, runOptions);
+  logger.trace(
+    {
+      agentId,
+      provider: snapshot?.provider,
+      providerSessionId: snapshot?.persistence?.sessionId ?? undefined,
+      shouldReplace,
+    },
+    "agent.session.start_stream.iterator_returned",
+  );
   void (async () => {
     try {
       for await (const _ of iterator) {
         // Events are broadcast via AgentManager subscribers.
       }
+      logger.trace(
+        {
+          agentId,
+          provider: snapshot?.provider,
+          providerSessionId: snapshot?.persistence?.sessionId ?? undefined,
+        },
+        "agent.session.iterator.drained",
+      );
     } catch (error) {
+      logger.trace(
+        {
+          agentId,
+          provider: snapshot?.provider,
+          providerSessionId: snapshot?.persistence?.sessionId ?? undefined,
+          err: error,
+        },
+        "agent.session.iterator.error",
+      );
       logger.error({ err: error, agentId }, "Agent stream failed");
     }
   })();

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -358,6 +358,10 @@ export type AgentStreamEvent =
       timestamp: string;
     };
 
+export function getAgentStreamEventTurnId(event: AgentStreamEvent): string | undefined {
+  return "turnId" in event ? event.turnId : undefined;
+}
+
 export type AgentPermissionRequestKind = "tool" | "plan" | "question" | "mode" | "other";
 
 export type AgentPermissionUpdate = AgentMetadata;

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -476,6 +476,7 @@ export interface AgentSessionConfig {
 }
 
 export interface AgentLaunchContext {
+  agentId?: string;
   env?: Record<string, string>;
 }
 

--- a/packages/server/src/server/agent/foreground-run-state.ts
+++ b/packages/server/src/server/agent/foreground-run-state.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { AgentStreamEvent } from "./agent-sdk-types.js";
+import { getAgentStreamEventTurnId, type AgentStreamEvent } from "./agent-sdk-types.js";
 
 export interface ForegroundTurnWaiter {
   turnId: string;
@@ -105,7 +105,7 @@ export class ForegroundRunState {
     event: AgentStreamEvent,
     options?: { terminal?: boolean },
   ): void {
-    const waiters = this.getMatchingWaiters(agent, eventTurnId(event));
+    const waiters = this.getMatchingWaiters(agent, getAgentStreamEventTurnId(event));
     this.notifyWaiters(waiters, event, { terminal: options?.terminal ?? false });
   }
 
@@ -225,8 +225,4 @@ function settlePendingForegroundRun(pendingRun: PendingForegroundRun): void {
 
   pendingRun.settled = true;
   pendingRun.resolveSettled();
-}
-
-function eventTurnId(event: AgentStreamEvent): string | undefined {
-  return (event as { turnId?: string }).turnId;
 }

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -266,7 +266,7 @@ function prepareConfiguredOverrideSession(
 
 test("ACP setModel only uses config-option fallback when the matching select choice contains the model", async () => {
   const logger = createTestLogger();
-  const childLogger = { warn: vi.fn() };
+  const childLogger = { trace: vi.fn(), warn: vi.fn() };
   vi.spyOn(logger, "child").mockReturnValue(asInternals<typeof logger>(childLogger));
   const session = createSessionWithConfig({}, logger);
   const setSessionConfigOption = vi.fn(async () => ({
@@ -653,7 +653,7 @@ describe("ACPAgentSession Zed parity", () => {
     expect(await validSession.getCurrentMode()).toBe("default");
 
     const logger = createTestLogger();
-    const childLogger = { warn: vi.fn() };
+    const childLogger = { trace: vi.fn(), warn: vi.fn() };
     vi.spyOn(logger, "child").mockReturnValue(asInternals<typeof logger>(childLogger));
     const invalidSession = createSessionWithConfig(
       { modeId: "acceptEdits", model: "opus" },

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -54,35 +54,36 @@ import {
 } from "@agentclientprotocol/sdk";
 import type { Logger } from "pino";
 
-import type {
-  AgentCapabilityFlags,
-  AgentClient,
-  AgentLaunchContext,
-  AgentMetadata,
-  AgentMode,
-  AgentModelDefinition,
-  AgentPermissionRequest,
-  AgentPermissionRequestKind,
-  AgentPermissionResponse,
-  AgentPersistenceHandle,
-  AgentPromptContentBlock,
-  AgentPromptInput,
-  AgentRunOptions,
-  AgentRunResult,
-  AgentRuntimeInfo,
-  AgentSession,
-  AgentSessionConfig,
-  AgentSlashCommand,
-  AgentStreamEvent,
-  AgentTimelineItem,
-  AgentUsage,
-  ListModesOptions,
-  ListModelsOptions,
-  ListPersistedAgentsOptions,
-  McpServerConfig,
-  PersistedAgentDescriptor,
-  ToolCallDetail,
-  ToolCallTimelineItem,
+import {
+  getAgentStreamEventTurnId,
+  type AgentCapabilityFlags,
+  type AgentClient,
+  type AgentLaunchContext,
+  type AgentMetadata,
+  type AgentMode,
+  type AgentModelDefinition,
+  type AgentPermissionRequest,
+  type AgentPermissionRequestKind,
+  type AgentPermissionResponse,
+  type AgentPersistenceHandle,
+  type AgentPromptContentBlock,
+  type AgentPromptInput,
+  type AgentRunOptions,
+  type AgentRunResult,
+  type AgentRuntimeInfo,
+  type AgentSession,
+  type AgentSessionConfig,
+  type AgentSlashCommand,
+  type AgentStreamEvent,
+  type AgentTimelineItem,
+  type AgentUsage,
+  type ListModesOptions,
+  type ListModelsOptions,
+  type ListPersistedAgentsOptions,
+  type McpServerConfig,
+  type PersistedAgentDescriptor,
+  type ToolCallDetail,
+  type ToolCallTimelineItem,
 } from "../agent-sdk-types.js";
 import {
   createProviderEnvSpec,
@@ -1582,7 +1583,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         sessionId: params.sessionId,
         rawEvent: params,
       },
-      "provider.acp.session_notification",
+      "provider.acp.raw_event",
     );
     if (params.sessionId !== this.sessionId) {
       return;
@@ -1598,7 +1599,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         rawEvent: params,
         events,
       },
-      "provider.acp.event_translated",
+      "provider.acp.parsed_event",
     );
     if (this.replayingHistory) {
       for (const event of events) {
@@ -2035,7 +2036,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         agentId: this.agentId,
         provider: this.provider,
         sessionId: this.sessionId,
-        turnId: eventTurnId(event) ?? this.activeForegroundTurnId ?? undefined,
+        turnId: getAgentStreamEventTurnId(event) ?? this.activeForegroundTurnId ?? undefined,
         event,
       },
       "provider.acp.event_emit",
@@ -2679,10 +2680,6 @@ function stringifyUnknown(value: unknown): string | undefined {
   } catch {
     return typeof value === "bigint" ? String(value) : "[unserializable]";
   }
-}
-
-function eventTurnId(event: AgentStreamEvent): string | undefined {
-  return "turnId" in event ? event.turnId : undefined;
 }
 
 function coerceSessionConfigMetadata(

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -265,6 +265,7 @@ interface ACPAgentSessionOptions {
   ) => Promise<void>;
   capabilities: AgentCapabilityFlags;
   handle?: AgentPersistenceHandle;
+  agentId?: string;
   launchEnv?: Record<string, string>;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
@@ -560,6 +561,7 @@ export class ACPAgentClient implements AgentClient {
         beforeModeWriter: this.beforeModeWriter,
         thinkingOptionWriter: this.thinkingOptionWriter,
         capabilities: this.capabilities,
+        agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
@@ -606,6 +608,7 @@ export class ACPAgentClient implements AgentClient {
       thinkingOptionWriter: this.thinkingOptionWriter,
       capabilities: this.capabilities,
       handle,
+      agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
@@ -845,6 +848,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     sessionId: string,
     thinkingOptionId: string,
   ) => Promise<void>;
+  private readonly agentId?: string;
   private readonly launchEnv?: Record<string, string>;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private readonly pendingPermissions = new Map<string, PendingPermission>();
@@ -897,6 +901,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.beforeModeWriter = options.beforeModeWriter;
     this.thinkingOptionWriter = options.thinkingOptionWriter;
     this.availableModes = options.defaultModes;
+    this.agentId = options.agentId;
     this.launchEnv = options.launchEnv;
     this.initialHandle = options.handle;
     this.config = { ...config, provider: options.provider };
@@ -1572,13 +1577,12 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   async sessionUpdate(params: SessionNotification): Promise<void> {
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: this.provider,
         sessionId: params.sessionId,
-        traceKind: "provider_raw_event",
         rawEvent: params,
       },
-      "ACP session notification received",
+      "provider.acp.session_notification",
     );
     if (params.sessionId !== this.sessionId) {
       return;
@@ -1587,15 +1591,14 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     const events = this.translateSessionUpdate(params.update);
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: this.provider,
         sessionId: this.sessionId,
         turnId: this.activeForegroundTurnId ?? undefined,
-        traceKind: "provider_translated_event",
         rawEvent: params,
         events,
       },
-      "ACP session notification translated",
+      "provider.acp.event_translated",
     );
     if (this.replayingHistory) {
       for (const event of events) {
@@ -2029,14 +2032,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private pushEvent(event: AgentStreamEvent): void {
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: this.provider,
         sessionId: this.sessionId,
         turnId: eventTurnId(event) ?? this.activeForegroundTurnId ?? undefined,
-        traceKind: "provider_emit_event",
         event,
       },
-      "ACP event emitted",
+      "provider.acp.event_emit",
     );
     for (const subscriber of this.subscribers) {
       subscriber(event);
@@ -2680,7 +2682,7 @@ function stringifyUnknown(value: unknown): string | undefined {
 }
 
 function eventTurnId(event: AgentStreamEvent): string | undefined {
-  return (event as { turnId?: string }).turnId;
+  return "turnId" in event ? event.turnId : undefined;
 }
 
 function coerceSessionConfigMetadata(

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -519,7 +519,10 @@ export class ACPAgentClient implements AgentClient {
   constructor(options: ACPAgentClientOptions) {
     this.provider = options.provider;
     this.capabilities = options.capabilities ?? DEFAULT_ACP_CAPABILITIES;
-    this.logger = options.logger.child({ module: "agent", provider: options.provider });
+    this.logger = options.logger.child({
+      module: "agent",
+      provider: options.provider,
+    });
     this.runtimeSettings = options.runtimeSettings;
     this.defaultCommand = options.defaultCommand;
     this.defaultModes = options.defaultModes ?? [];
@@ -1567,11 +1570,33 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   async sessionUpdate(params: SessionNotification): Promise<void> {
+    this.logger.trace(
+      {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: this.provider,
+        sessionId: params.sessionId,
+        traceKind: "provider_raw_event",
+        rawEvent: params,
+      },
+      "ACP session notification received",
+    );
     if (params.sessionId !== this.sessionId) {
       return;
     }
 
     const events = this.translateSessionUpdate(params.update);
+    this.logger.trace(
+      {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: this.provider,
+        sessionId: this.sessionId,
+        turnId: this.activeForegroundTurnId ?? undefined,
+        traceKind: "provider_translated_event",
+        rawEvent: params,
+        events,
+      },
+      "ACP session notification translated",
+    );
     if (this.replayingHistory) {
       for (const event of events) {
         if (event.type === "timeline") {
@@ -2002,6 +2027,17 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private pushEvent(event: AgentStreamEvent): void {
+    this.logger.trace(
+      {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: this.provider,
+        sessionId: this.sessionId,
+        turnId: eventTurnId(event) ?? this.activeForegroundTurnId ?? undefined,
+        traceKind: "provider_emit_event",
+        event,
+      },
+      "ACP event emitted",
+    );
     for (const subscriber of this.subscribers) {
       subscriber(event);
     }
@@ -2641,6 +2677,10 @@ function stringifyUnknown(value: unknown): string | undefined {
   } catch {
     return typeof value === "bigint" ? String(value) : "[unserializable]";
   }
+}
+
+function eventTurnId(event: AgentStreamEvent): string | undefined {
+  return (event as { turnId?: string }).turnId;
 }
 
 function coerceSessionConfigMetadata(

--- a/packages/server/src/server/agent/providers/claude/agent.event-stream.integration.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.event-stream.integration.test.ts
@@ -14,7 +14,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import pino from "pino";
 
-import type { AgentSession, AgentStreamEvent } from "../../agent-sdk-types.js";
+import {
+  getAgentStreamEventTurnId,
+  type AgentSession,
+  type AgentStreamEvent,
+} from "../../agent-sdk-types.js";
 import { isProviderAvailable } from "../../../daemon-e2e/agent-configs.js";
 import { ClaudeAgentClient } from "./agent.js";
 
@@ -37,15 +41,14 @@ function isTerminalEvent(event: AgentStreamEvent): boolean {
   );
 }
 
-// turnId is optional on AgentStreamEvent — this narrows to events where it's present.
 type EventWithTurnId = AgentStreamEvent & { turnId: string };
 
 function hasTurnId(event: AgentStreamEvent): event is EventWithTurnId {
-  return "turnId" in event && typeof (event as Record<string, unknown>).turnId === "string";
+  return getAgentStreamEventTurnId(event) !== undefined;
 }
 
 function eventsForTurn(events: AgentStreamEvent[], turnId: string): AgentStreamEvent[] {
-  return events.filter((e) => hasTurnId(e) && e.turnId === turnId);
+  return events.filter((e) => getAgentStreamEventTurnId(e) === turnId);
 }
 
 function userMessagesWithText(events: AgentStreamEvent[], text: string): AgentStreamEvent[] {
@@ -157,7 +160,7 @@ function assertInvariants(events: AgentStreamEvent[], foregroundTurnIds: string[
   // Invariant 2: Every turn_started has exactly one matching terminal
   const turnStartedIds = events
     .filter((e) => e.type === "turn_started" && hasTurnId(e))
-    .map((e) => (e as EventWithTurnId).turnId);
+    .map((e) => e.turnId);
 
   for (const turnId of turnStartedIds) {
     const terminals = eventsForTurn(events, turnId).filter(isTerminalEvent);
@@ -277,7 +280,7 @@ test("Test 3: Lifecycle doesn't get stuck in running", async () => {
 
     // Any turn_started after terminal must have a different turnId
     for (const ts of afterTerminal.filter((e) => e.type === "turn_started" && hasTurnId(e))) {
-      expect((ts as EventWithTurnId).turnId).not.toBe(turnId);
+      expect(ts.turnId).not.toBe(turnId);
     }
 
     assertInvariants(events, [turnId]);
@@ -313,8 +316,9 @@ test("Test 4: Autonomous run", async () => {
 
     // Autonomous turn_started with a different turnId
     const autoStarts = afterForeground.filter(
-      (e) => e.type === "turn_started" && hasTurnId(e) && e.turnId !== fgTurnId,
-    ) as EventWithTurnId[];
+      (e): e is EventWithTurnId =>
+        e.type === "turn_started" && hasTurnId(e) && e.turnId !== fgTurnId,
+    );
     if (autoStarts.length === 0) {
       assertInvariants(events, [fgTurnId]);
       return;

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -42,34 +42,35 @@ import { appendOrReplaceGrowingAssistantMessage, runProviderTurn } from "../prov
 import { renderPromptAttachmentAsText } from "../../prompt-attachments.js";
 import { claudeQuery, type ClaudeOptions, type ClaudeQueryFactory } from "./query.js";
 
-import type {
-  AgentPermissionAction,
-  AgentCapabilityFlags,
-  AgentClient,
-  AgentCreateSessionOptions,
-  AgentLaunchContext,
-  AgentMetadata,
-  AgentMode,
-  AgentModelDefinition,
-  AgentPermissionRequest,
-  AgentPermissionRequestKind,
-  AgentPermissionResponse,
-  AgentPermissionUpdate,
-  AgentPersistenceHandle,
-  AgentPromptInput,
-  AgentRunOptions,
-  AgentRunResult,
-  AgentSession,
-  AgentSessionConfig,
-  AgentSlashCommand,
-  AgentStreamEvent,
-  AgentTimelineItem,
-  AgentUsage,
-  AgentRuntimeInfo,
-  ListModelsOptions,
-  ListPersistedAgentsOptions,
-  McpServerConfig,
-  PersistedAgentDescriptor,
+import {
+  getAgentStreamEventTurnId,
+  type AgentPermissionAction,
+  type AgentCapabilityFlags,
+  type AgentClient,
+  type AgentCreateSessionOptions,
+  type AgentLaunchContext,
+  type AgentMetadata,
+  type AgentMode,
+  type AgentModelDefinition,
+  type AgentPermissionRequest,
+  type AgentPermissionRequestKind,
+  type AgentPermissionResponse,
+  type AgentPermissionUpdate,
+  type AgentPersistenceHandle,
+  type AgentPromptInput,
+  type AgentRunOptions,
+  type AgentRunResult,
+  type AgentSession,
+  type AgentSessionConfig,
+  type AgentSlashCommand,
+  type AgentStreamEvent,
+  type AgentTimelineItem,
+  type AgentUsage,
+  type AgentRuntimeInfo,
+  type ListModelsOptions,
+  type ListPersistedAgentsOptions,
+  type McpServerConfig,
+  type PersistedAgentDescriptor,
 } from "../../agent-sdk-types.js";
 import {
   createProviderEnv,
@@ -2681,7 +2682,7 @@ class ClaudeAgentSession implements AgentSession {
           messageUuid: "uuid" in message ? message.uuid : undefined,
           rawEvent: message,
         },
-        "provider.claude.sdk_message.raw",
+        "provider.claude.raw_event",
       );
     };
     const handlePumpedMessage = async (message: SDKMessage): Promise<boolean> => {
@@ -2804,7 +2805,7 @@ class ClaudeAgentSession implements AgentSession {
         identifiers,
         rawEvent: message,
       },
-      "provider.claude.sdk_message.parsed",
+      "provider.claude.parsed_event",
     );
 
     const messageEvents = this.translateMessageToEvents(message, {
@@ -3524,7 +3525,7 @@ class ClaudeAgentSession implements AgentSession {
         agentId: this.agentId,
         provider: "claude",
         sessionId: this.claudeSessionId,
-        turnId: eventTurnId(tagged),
+        turnId: getAgentStreamEventTurnId(tagged),
         event: tagged,
       },
       "provider.claude.event_emit",
@@ -4643,8 +4644,4 @@ function extractClaudeUserText(messageRaw: unknown): string | null {
     }
   }
   return null;
-}
-
-function eventTurnId(event: AgentStreamEvent): string | undefined {
-  return "turnId" in event ? event.turnId : undefined;
 }

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -250,6 +250,7 @@ interface ClaudeAgentSessionOptions {
   defaults?: { agents?: Record<string, AgentDefinition> };
   runtimeSettings?: ProviderRuntimeSettings;
   handle?: AgentPersistenceHandle;
+  agentId?: string;
   launchEnv?: Record<string, string>;
   persistSession?: boolean;
   logger: Logger;
@@ -1179,6 +1180,7 @@ export class ClaudeAgentClient implements AgentClient {
     return new ClaudeAgentSession(claudeConfig, {
       defaults: this.defaults,
       runtimeSettings: this.runtimeSettings,
+      agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
       persistSession: options?.persistSession,
       logger: this.logger,
@@ -1207,6 +1209,7 @@ export class ClaudeAgentClient implements AgentClient {
       defaults: this.defaults,
       runtimeSettings: this.runtimeSettings,
       handle,
+      agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
       logger: this.logger,
       queryFactory: this.queryFactory,
@@ -1475,6 +1478,7 @@ class ClaudeAgentSession implements AgentSession {
 
   private readonly config: ClaudeAgentConfig;
   private readonly launchEnv?: Record<string, string>;
+  private readonly agentId?: string;
   private readonly defaults?: { agents?: Record<string, AgentDefinition> };
   private readonly runtimeSettings?: ProviderRuntimeSettings;
   private readonly persistSession?: boolean;
@@ -1524,10 +1528,11 @@ class ClaudeAgentSession implements AgentSession {
   constructor(config: ClaudeAgentConfig, options: ClaudeAgentSessionOptions) {
     this.config = config;
     this.launchEnv = options.launchEnv;
+    this.agentId = options.agentId;
     this.defaults = options.defaults;
     this.runtimeSettings = options.runtimeSettings;
     this.persistSession = options.persistSession;
-    this.logger = options.logger.child({ agentId: options.launchEnv?.PASEO_AGENT_ID });
+    this.logger = options.logger.child({ agentId: this.agentId });
     this.queryFactory = options.queryFactory;
     this.resolveBinary = options.resolveBinary;
     const handle = options.handle;
@@ -1867,18 +1872,16 @@ class ClaudeAgentSession implements AgentSession {
   async close(): Promise<void> {
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: "claude",
         sessionId: this.claudeSessionId,
         turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
-        traceKind: "provider_session_close",
-        claudeSessionId: this.claudeSessionId,
         turnState: this.turnState,
         hasQuery: Boolean(this.query),
         hasInput: Boolean(this.input),
         hasActiveForegroundTurnId: Boolean(this.activeForegroundTurnId),
       },
-      "Claude session close: start",
+      "provider.claude.session_close.start",
     );
     this.closed = true;
     this.rejectAllPendingPermissions(new Error("Claude session closed"));
@@ -1914,14 +1917,12 @@ class ClaudeAgentSession implements AgentSession {
     }
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: "claude",
         sessionId: this.claudeSessionId,
-        traceKind: "provider_session_close",
-        claudeSessionId: this.claudeSessionId,
         turnState: this.turnState,
       },
-      "Claude session close: completed",
+      "provider.claude.session_close.complete",
     );
   }
 
@@ -2200,42 +2201,39 @@ class ClaudeAgentSession implements AgentSession {
     if (!promise) {
       this.logger.trace(
         {
-          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          agentId: this.agentId,
           provider: "claude",
           sessionId: this.claudeSessionId,
           turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
-          traceKind: "provider_query_operation",
           label,
         },
-        "Claude query operation skipped (no promise)",
+        "provider.claude.query_operation.skip",
       );
       return;
     }
     const startedAt = Date.now();
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: "claude",
         sessionId: this.claudeSessionId,
         turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
-        traceKind: "provider_query_operation",
         label,
       },
-      "Claude query operation wait start",
+      "provider.claude.query_operation.start",
     );
     try {
       await withTimeout(promise, 3_000, "timeout");
       this.logger.trace(
         {
-          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          agentId: this.agentId,
           provider: "claude",
           sessionId: this.claudeSessionId,
           turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
-          traceKind: "provider_query_operation",
           label,
           durationMs: Date.now() - startedAt,
         },
-        "Claude query operation settled",
+        "provider.claude.query_operation.settled",
       );
     } catch (error) {
       this.logger.warn({ err: error, label }, "Claude query operation did not settle cleanly");
@@ -2633,14 +2631,13 @@ class ClaudeAgentSession implements AgentSession {
     const pump = this.runQueryPump().catch((error) => {
       this.logger.trace(
         {
-          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          agentId: this.agentId,
           provider: "claude",
           sessionId: this.claudeSessionId,
           turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
-          traceKind: "provider_query_pump",
           err: error,
         },
-        "Claude query pump exited unexpectedly",
+        "provider.claude.query_pump.exit_unexpected",
       );
     });
 
@@ -2659,14 +2656,13 @@ class ClaudeAgentSession implements AgentSession {
     } catch (error) {
       this.logger.trace(
         {
-          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          agentId: this.agentId,
           provider: "claude",
           sessionId: this.claudeSessionId,
           turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
-          traceKind: "provider_query_pump",
           err: error,
         },
-        "Failed to initialize Claude query pump",
+        "provider.claude.query_pump.init_failed",
       );
       this.failActiveTurns(error instanceof Error ? error.message : "Claude stream failed");
       return;
@@ -2676,18 +2672,16 @@ class ClaudeAgentSession implements AgentSession {
     const logRawMessage = (message: SDKMessage): void => {
       this.logger.trace(
         {
-          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          agentId: this.agentId,
           provider: "claude",
           sessionId: this.claudeSessionId,
           turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
-          traceKind: "provider_raw_event",
-          claudeSessionId: this.claudeSessionId,
           messageType: message.type,
           messageSubtype: "subtype" in message ? message.subtype : undefined,
           messageUuid: "uuid" in message ? message.uuid : undefined,
           rawEvent: message,
         },
-        "Claude query pump: raw SDK message",
+        "provider.claude.sdk_message.raw",
       );
     };
     const handlePumpedMessage = async (message: SDKMessage): Promise<boolean> => {
@@ -2802,17 +2796,15 @@ class ClaudeAgentSession implements AgentSession {
 
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: "claude",
         sessionId: this.claudeSessionId,
         turnId: turnId ?? undefined,
-        traceKind: "provider_parsed_event",
-        claudeSessionId: this.claudeSessionId,
         messageType: message.type,
         identifiers,
         rawEvent: message,
       },
-      "Claude query pump: SDK message",
+      "provider.claude.sdk_message.parsed",
     );
 
     const messageEvents = this.translateMessageToEvents(message, {
@@ -2881,7 +2873,6 @@ class ClaudeAgentSession implements AgentSession {
 
     this.logger.warn(
       {
-        claudeSessionId: this.claudeSessionId,
         error: staleResumeError,
       },
       "Claude resumed session no longer exists; invalidating persisted session",
@@ -2913,13 +2904,12 @@ class ClaudeAgentSession implements AgentSession {
     if (!queryToInterrupt || typeof queryToInterrupt.interrupt !== "function") {
       this.logger.trace(
         {
-          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          agentId: this.agentId,
           provider: "claude",
           sessionId: this.claudeSessionId,
           turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
-          traceKind: "provider_interrupt",
         },
-        "interruptActiveTurn: no query to interrupt",
+        "provider.claude.interrupt.no_query",
       );
       return;
     }
@@ -3531,14 +3521,13 @@ class ClaudeAgentSession implements AgentSession {
     const tagged = turnId ? { ...event, turnId } : event;
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: "claude",
         sessionId: this.claudeSessionId,
         turnId: eventTurnId(tagged),
-        traceKind: "provider_emit_event",
         event: tagged,
       },
-      "Claude event emitted",
+      "provider.claude.event_emit",
     );
     for (const callback of this.subscribers) {
       try {
@@ -4657,5 +4646,5 @@ function extractClaudeUserText(messageRaw: unknown): string | null {
 }
 
 function eventTurnId(event: AgentStreamEvent): string | undefined {
-  return (event as { turnId?: string }).turnId;
+  return "turnId" in event ? event.turnId : undefined;
 }

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -1152,8 +1152,6 @@ export function readEventIdentifiers(message: SDKMessage): EventIdentifiers {
   };
 }
 
-const claudeDebug = process.env.PASEO_CLAUDE_DEBUG === "1";
-
 export class ClaudeAgentClient implements AgentClient {
   readonly provider = "claude" as const;
   readonly capabilities = CLAUDE_CAPABILITIES;
@@ -1529,7 +1527,7 @@ class ClaudeAgentSession implements AgentSession {
     this.defaults = options.defaults;
     this.runtimeSettings = options.runtimeSettings;
     this.persistSession = options.persistSession;
-    this.logger = options.logger;
+    this.logger = options.logger.child({ agentId: options.launchEnv?.PASEO_AGENT_ID });
     this.queryFactory = options.queryFactory;
     this.resolveBinary = options.resolveBinary;
     const handle = options.handle;
@@ -1869,6 +1867,11 @@ class ClaudeAgentSession implements AgentSession {
   async close(): Promise<void> {
     this.logger.trace(
       {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: "claude",
+        sessionId: this.claudeSessionId,
+        turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
+        traceKind: "provider_session_close",
         claudeSessionId: this.claudeSessionId,
         turnState: this.turnState,
         hasQuery: Boolean(this.query),
@@ -1910,7 +1913,14 @@ class ClaudeAgentSession implements AgentSession {
       }
     }
     this.logger.trace(
-      { claudeSessionId: this.claudeSessionId, turnState: this.turnState },
+      {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: "claude",
+        sessionId: this.claudeSessionId,
+        traceKind: "provider_session_close",
+        claudeSessionId: this.claudeSessionId,
+        turnState: this.turnState,
+      },
       "Claude session close: completed",
     );
   }
@@ -2188,15 +2198,43 @@ class ClaudeAgentSession implements AgentSession {
     label: string,
   ): Promise<void> {
     if (!promise) {
-      this.logger.trace({ label }, "Claude query operation skipped (no promise)");
+      this.logger.trace(
+        {
+          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          provider: "claude",
+          sessionId: this.claudeSessionId,
+          turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
+          traceKind: "provider_query_operation",
+          label,
+        },
+        "Claude query operation skipped (no promise)",
+      );
       return;
     }
     const startedAt = Date.now();
-    this.logger.trace({ label }, "Claude query operation wait start");
+    this.logger.trace(
+      {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: "claude",
+        sessionId: this.claudeSessionId,
+        turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
+        traceKind: "provider_query_operation",
+        label,
+      },
+      "Claude query operation wait start",
+    );
     try {
       await withTimeout(promise, 3_000, "timeout");
       this.logger.trace(
-        { label, durationMs: Date.now() - startedAt },
+        {
+          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          provider: "claude",
+          sessionId: this.claudeSessionId,
+          turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
+          traceKind: "provider_query_operation",
+          label,
+          durationMs: Date.now() - startedAt,
+        },
         "Claude query operation settled",
       );
     } catch (error) {
@@ -2593,7 +2631,17 @@ class ClaudeAgentSession implements AgentSession {
     }
 
     const pump = this.runQueryPump().catch((error) => {
-      this.logger.trace({ err: error }, "Claude query pump exited unexpectedly");
+      this.logger.trace(
+        {
+          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          provider: "claude",
+          sessionId: this.claudeSessionId,
+          turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
+          traceKind: "provider_query_pump",
+          err: error,
+        },
+        "Claude query pump exited unexpectedly",
+      );
     });
 
     this.queryPumpPromise = pump;
@@ -2609,22 +2657,35 @@ class ClaudeAgentSession implements AgentSession {
     try {
       activeQuery = await this.ensureQuery();
     } catch (error) {
-      this.logger.trace({ err: error }, "Failed to initialize Claude query pump");
+      this.logger.trace(
+        {
+          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          provider: "claude",
+          sessionId: this.claudeSessionId,
+          turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
+          traceKind: "provider_query_pump",
+          err: error,
+        },
+        "Failed to initialize Claude query pump",
+      );
       this.failActiveTurns(error instanceof Error ? error.message : "Claude stream failed");
       return;
     }
 
     let consecutiveInterruptAbortRecoveries = 0;
     const logRawMessage = (message: SDKMessage): void => {
-      if (!claudeDebug) {
-        return;
-      }
       this.logger.trace(
         {
+          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          provider: "claude",
+          sessionId: this.claudeSessionId,
+          turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
+          traceKind: "provider_raw_event",
           claudeSessionId: this.claudeSessionId,
           messageType: message.type,
           messageSubtype: "subtype" in message ? message.subtype : undefined,
           messageUuid: "uuid" in message ? message.uuid : undefined,
+          rawEvent: message,
         },
         "Claude query pump: raw SDK message",
       );
@@ -2739,16 +2800,20 @@ class ClaudeAgentSession implements AgentSession {
     const turnId = this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? null;
     const identifiers = readEventIdentifiers(message);
 
-    if (claudeDebug) {
-      this.logger.trace(
-        {
-          claudeSessionId: this.claudeSessionId,
-          messageType: message.type,
-          turnId,
-        },
-        "Claude query pump: SDK message",
-      );
-    }
+    this.logger.trace(
+      {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: "claude",
+        sessionId: this.claudeSessionId,
+        turnId: turnId ?? undefined,
+        traceKind: "provider_parsed_event",
+        claudeSessionId: this.claudeSessionId,
+        messageType: message.type,
+        identifiers,
+        rawEvent: message,
+      },
+      "Claude query pump: SDK message",
+    );
 
     const messageEvents = this.translateMessageToEvents(message, {
       suppressAssistantText: true,
@@ -2846,7 +2911,16 @@ class ClaudeAgentSession implements AgentSession {
   private async interruptActiveTurn(): Promise<void> {
     const queryToInterrupt = this.query;
     if (!queryToInterrupt || typeof queryToInterrupt.interrupt !== "function") {
-      this.logger.trace("interruptActiveTurn: no query to interrupt");
+      this.logger.trace(
+        {
+          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          provider: "claude",
+          sessionId: this.claudeSessionId,
+          turnId: this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? undefined,
+          traceKind: "provider_interrupt",
+        },
+        "interruptActiveTurn: no query to interrupt",
+      );
       return;
     }
     this.pendingInterruptAbort = true;
@@ -3455,6 +3529,17 @@ class ClaudeAgentSession implements AgentSession {
   private notifySubscribers(event: AgentStreamEvent): void {
     const turnId = this.activeForegroundTurnId ?? this.autonomousTurn?.id;
     const tagged = turnId ? { ...event, turnId } : event;
+    this.logger.trace(
+      {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: "claude",
+        sessionId: this.claudeSessionId,
+        turnId: eventTurnId(tagged),
+        traceKind: "provider_emit_event",
+        event: tagged,
+      },
+      "Claude event emitted",
+    );
     for (const callback of this.subscribers) {
       try {
         callback(tagged);
@@ -4569,4 +4654,8 @@ function extractClaudeUserText(messageRaw: unknown): string | null {
     }
   }
   return null;
+}
+
+function eventTurnId(event: AgentStreamEvent): string | undefined {
+  return (event as { turnId?: string }).turnId;
 }

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -2653,8 +2653,13 @@ class CodexAppServerAgentSession implements AgentSession {
     private readonly deps: CodexAppServerAgentDeps = {},
     private readonly ephemeral: boolean = false,
     private readonly goalsEnabled: boolean = false,
+    private readonly launchEnv?: Record<string, string>,
   ) {
-    this.logger = logger.child({ module: "agent", provider: CODEX_PROVIDER });
+    this.logger = logger.child({
+      module: "agent",
+      provider: CODEX_PROVIDER,
+      agentId: this.launchEnv?.PASEO_AGENT_ID,
+    });
     if (config.modeId === undefined) {
       throw new Error("Codex agent requires modeId to be specified");
     }
@@ -2729,7 +2734,17 @@ class CodexAppServerAgentSession implements AgentSession {
         };
       });
     } catch (error) {
-      this.logger.trace({ error }, "Failed to load collaboration modes");
+      this.logger.trace(
+        {
+          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          provider: CODEX_PROVIDER,
+          sessionId: this.currentThreadId,
+          turnId: this.activeForegroundTurnId ?? undefined,
+          traceKind: "provider_metadata_load",
+          error,
+        },
+        "Failed to load collaboration modes",
+      );
       this.collaborationModes = [];
     }
     this.refreshResolvedCollaborationMode();
@@ -2761,7 +2776,17 @@ class CodexAppServerAgentSession implements AgentSession {
       }
       this.cachedSkills = skills;
     } catch (error) {
-      this.logger.trace({ error }, "Failed to load skills list");
+      this.logger.trace(
+        {
+          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          provider: CODEX_PROVIDER,
+          sessionId: this.currentThreadId,
+          turnId: this.activeForegroundTurnId ?? undefined,
+          traceKind: "provider_metadata_load",
+          error,
+        },
+        "Failed to load skills list",
+      );
       this.cachedSkills = [];
     }
   }
@@ -3657,6 +3682,17 @@ class CodexAppServerAgentSession implements AgentSession {
   private notifySubscribers(event: AgentStreamEvent): void {
     const turnId = this.activeForegroundTurnId;
     const tagged = turnId ? { ...event, turnId } : event;
+    this.logger.trace(
+      {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: CODEX_PROVIDER,
+        sessionId: this.currentThreadId,
+        turnId: eventTurnId(tagged),
+        traceKind: "provider_emit_event",
+        event: tagged,
+      },
+      "Codex event emitted",
+    );
     for (const callback of this.subscribers) {
       try {
         callback(tagged);
@@ -3672,6 +3708,7 @@ class CodexAppServerAgentSession implements AgentSession {
 
   private handleNotification(method: string, params: unknown): void {
     const parsed = CodexNotificationSchema.parse({ method, params });
+    this.traceParsedNotification(method, params, parsed);
     switch (parsed.kind) {
       case "thread_started":
         this.handleThreadStartedNotification(parsed);
@@ -3726,6 +3763,26 @@ class CodexAppServerAgentSession implements AgentSession {
       default:
         this.warnUnknownNotificationMethod(parsed.method, parsed.params);
     }
+  }
+
+  private traceParsedNotification(
+    method: string,
+    params: unknown,
+    parsed: z.infer<typeof CodexNotificationSchema>,
+  ): void {
+    this.logger.trace(
+      {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: CODEX_PROVIDER,
+        sessionId: this.currentThreadId,
+        turnId: this.activeForegroundTurnId ?? undefined,
+        traceKind: "provider_parsed_event",
+        method,
+        params,
+        parsed,
+      },
+      "Codex app-server notification parsed",
+    );
   }
 
   private getSubAgentCallIdForThread(threadId: string | null | undefined): string | null {
@@ -4320,7 +4377,18 @@ class CodexAppServerAgentSession implements AgentSession {
       return;
     }
     this.warnedUnknownNotificationMethods.add(method);
-    this.logger.trace({ method, params }, "Unhandled Codex app-server notification method");
+    this.logger.trace(
+      {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: CODEX_PROVIDER,
+        sessionId: this.currentThreadId,
+        turnId: this.activeForegroundTurnId ?? undefined,
+        traceKind: "provider_unhandled_event",
+        method,
+        params,
+      },
+      "Unhandled Codex app-server notification method",
+    );
   }
 
   private warnInvalidNotificationPayload(method: string, params: unknown): void {
@@ -4598,7 +4666,15 @@ export class CodexAppServerAgentClient implements AgentClient {
           const launchPrefix = await resolveCodexLaunchPrefix(this.runtimeSettings);
           const versionOutput = await resolveBinaryVersion(launchPrefix.command);
           const enabled = codexVersionAtLeast(versionOutput, CODEX_GOALS_MIN_VERSION);
-          this.logger.trace({ versionOutput, enabled }, "Resolved codex goals feature gate");
+          this.logger.trace(
+            {
+              provider: CODEX_PROVIDER,
+              traceKind: "provider_config",
+              versionOutput,
+              enabled,
+            },
+            "Resolved codex goals feature gate",
+          );
           return enabled;
         } catch (error) {
           this.logger.warn({ err: error }, "Failed to probe codex version for goals gate");
@@ -4620,6 +4696,9 @@ export class CodexAppServerAgentClient implements AgentClient {
     }
     this.logger.trace(
       {
+        agentId: launchEnv?.PASEO_AGENT_ID,
+        provider: CODEX_PROVIDER,
+        traceKind: "provider_spawn",
         launchPrefix,
         goalsEnabled: options?.goalsEnabled === true,
       },
@@ -4659,6 +4738,7 @@ export class CodexAppServerAgentClient implements AgentClient {
       this.sessionDeps(),
       options?.persistSession === false,
       goalsEnabled,
+      launchContext?.env,
     );
     await session.connect();
     return session;
@@ -4685,6 +4765,7 @@ export class CodexAppServerAgentClient implements AgentClient {
       this.sessionDeps(),
       false,
       goalsEnabled,
+      launchContext?.env,
     );
     await session.connect();
     return session;
@@ -4956,6 +5037,10 @@ function resolveSkillDescription(skill: Record<string, unknown>): string {
     return skill.shortDescription;
   }
   return "Skill";
+}
+
+function eventTurnId(event: AgentStreamEvent): string | undefined {
+  return (event as { turnId?: string }).turnId;
 }
 
 export const __codexAppServerInternals = {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -1,32 +1,33 @@
-import type {
-  AgentPermissionAction,
-  AgentCapabilityFlags,
-  AgentClient,
-  AgentCreateSessionOptions,
-  AgentFeature,
-  AgentLaunchContext,
-  AgentMode,
-  AgentModelDefinition,
-  McpServerConfig,
-  AgentPersistenceHandle,
-  AgentPermissionRequest,
-  AgentPermissionResponse,
-  AgentPermissionResult,
-  AgentPromptContentBlock,
-  AgentPromptInput,
-  AgentRunOptions,
-  AgentRunResult,
-  AgentRuntimeInfo,
-  AgentSession,
-  AgentSessionConfig,
-  AgentSlashCommand,
-  AgentStreamEvent,
-  AgentTimelineItem,
-  ToolCallTimelineItem,
-  AgentUsage,
-  ListModelsOptions,
-  ListPersistedAgentsOptions,
-  PersistedAgentDescriptor,
+import {
+  getAgentStreamEventTurnId,
+  type AgentPermissionAction,
+  type AgentCapabilityFlags,
+  type AgentClient,
+  type AgentCreateSessionOptions,
+  type AgentFeature,
+  type AgentLaunchContext,
+  type AgentMode,
+  type AgentModelDefinition,
+  type McpServerConfig,
+  type AgentPersistenceHandle,
+  type AgentPermissionRequest,
+  type AgentPermissionResponse,
+  type AgentPermissionResult,
+  type AgentPromptContentBlock,
+  type AgentPromptInput,
+  type AgentRunOptions,
+  type AgentRunResult,
+  type AgentRuntimeInfo,
+  type AgentSession,
+  type AgentSessionConfig,
+  type AgentSlashCommand,
+  type AgentStreamEvent,
+  type AgentTimelineItem,
+  type ToolCallTimelineItem,
+  type AgentUsage,
+  type ListModelsOptions,
+  type ListPersistedAgentsOptions,
+  type PersistedAgentDescriptor,
 } from "../agent-sdk-types.js";
 import type { Logger } from "pino";
 import { homedir } from "node:os";
@@ -55,7 +56,10 @@ import { findExecutable, isCommandAvailable } from "../../../utils/executable.js
 import { spawnProcess } from "../../../utils/spawn.js";
 import { extractCodexTerminalSessionId, nonEmptyString } from "./tool-call-mapper-utils.js";
 import { buildCodexFeatures, codexModelSupportsFastMode } from "./codex-feature-definitions.js";
-import { CodexAppServerClient } from "./codex/app-server-transport.js";
+import {
+  CodexAppServerClient,
+  type CodexAppServerTraceContext,
+} from "./codex/app-server-transport.js";
 import {
   renderProviderImageOutputAsAssistantMarkdown,
   type ProviderImageOutput,
@@ -183,6 +187,7 @@ interface CodexAppServerAgentDeps {
   _createCodexClient?: (
     child: ChildProcessWithoutNullStreams,
     logger: Logger,
+    getTraceContext: () => CodexAppServerTraceContext,
   ) => CodexAppServerClientLike;
 }
 
@@ -2696,7 +2701,7 @@ class CodexAppServerAgentSession implements AgentSession {
   async connect(): Promise<void> {
     if (this.connected) return;
     const child = await this.spawnAppServer();
-    this.client = new CodexAppServerClient(child, this.logger);
+    this.client = new CodexAppServerClient(child, this.logger, () => this.traceContext());
     this.client.setNotificationHandler((method, params) => this.handleNotification(method, params));
     this.registerRequestHandlers();
 
@@ -2712,6 +2717,14 @@ class CodexAppServerAgentSession implements AgentSession {
     }
 
     this.connected = true;
+  }
+
+  private traceContext(): CodexAppServerTraceContext {
+    return {
+      agentId: this.agentId,
+      sessionId: this.currentThreadId ?? undefined,
+      turnId: this.activeForegroundTurnId ?? undefined,
+    };
   }
 
   private async loadCollaborationModes(): Promise<void> {
@@ -3685,7 +3698,7 @@ class CodexAppServerAgentSession implements AgentSession {
         agentId: this.agentId,
         provider: CODEX_PROVIDER,
         sessionId: this.currentThreadId,
-        turnId: eventTurnId(tagged),
+        turnId: getAgentStreamEventTurnId(tagged),
         event: tagged,
       },
       "provider.codex.event_emit",
@@ -3777,7 +3790,7 @@ class CodexAppServerAgentSession implements AgentSession {
         params,
         parsed,
       },
-      "provider.codex.event_parsed",
+      "provider.codex.parsed_event",
     );
   }
 
@@ -4771,7 +4784,7 @@ export class CodexAppServerAgentClient implements AgentClient {
   ): Promise<PersistedAgentDescriptor[]> {
     const child = await this.spawnAppServer();
     const client =
-      this.deps._createCodexClient?.(child, this.logger) ??
+      this.deps._createCodexClient?.(child, this.logger, () => ({})) ??
       new CodexAppServerClient(child, this.logger);
 
     try {
@@ -5032,10 +5045,6 @@ function resolveSkillDescription(skill: Record<string, unknown>): string {
     return skill.shortDescription;
   }
   return "Skill";
-}
-
-function eventTurnId(event: AgentStreamEvent): string | undefined {
-  return "turnId" in event ? event.turnId : undefined;
 }
 
 export const __codexAppServerInternals = {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -2653,12 +2653,12 @@ class CodexAppServerAgentSession implements AgentSession {
     private readonly deps: CodexAppServerAgentDeps = {},
     private readonly ephemeral: boolean = false,
     private readonly goalsEnabled: boolean = false,
-    private readonly launchEnv?: Record<string, string>,
+    private readonly agentId?: string,
   ) {
     this.logger = logger.child({
       module: "agent",
       provider: CODEX_PROVIDER,
-      agentId: this.launchEnv?.PASEO_AGENT_ID,
+      agentId: this.agentId,
     });
     if (config.modeId === undefined) {
       throw new Error("Codex agent requires modeId to be specified");
@@ -2736,14 +2736,13 @@ class CodexAppServerAgentSession implements AgentSession {
     } catch (error) {
       this.logger.trace(
         {
-          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          agentId: this.agentId,
           provider: CODEX_PROVIDER,
           sessionId: this.currentThreadId,
           turnId: this.activeForegroundTurnId ?? undefined,
-          traceKind: "provider_metadata_load",
           error,
         },
-        "Failed to load collaboration modes",
+        "provider.codex.metadata.collaboration_modes_failed",
       );
       this.collaborationModes = [];
     }
@@ -2778,14 +2777,13 @@ class CodexAppServerAgentSession implements AgentSession {
     } catch (error) {
       this.logger.trace(
         {
-          agentId: this.launchEnv?.PASEO_AGENT_ID,
+          agentId: this.agentId,
           provider: CODEX_PROVIDER,
           sessionId: this.currentThreadId,
           turnId: this.activeForegroundTurnId ?? undefined,
-          traceKind: "provider_metadata_load",
           error,
         },
-        "Failed to load skills list",
+        "provider.codex.metadata.skills_failed",
       );
       this.cachedSkills = [];
     }
@@ -3684,14 +3682,13 @@ class CodexAppServerAgentSession implements AgentSession {
     const tagged = turnId ? { ...event, turnId } : event;
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: CODEX_PROVIDER,
         sessionId: this.currentThreadId,
         turnId: eventTurnId(tagged),
-        traceKind: "provider_emit_event",
         event: tagged,
       },
-      "Codex event emitted",
+      "provider.codex.event_emit",
     );
     for (const callback of this.subscribers) {
       try {
@@ -3772,16 +3769,15 @@ class CodexAppServerAgentSession implements AgentSession {
   ): void {
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: CODEX_PROVIDER,
         sessionId: this.currentThreadId,
         turnId: this.activeForegroundTurnId ?? undefined,
-        traceKind: "provider_parsed_event",
         method,
         params,
         parsed,
       },
-      "Codex app-server notification parsed",
+      "provider.codex.event_parsed",
     );
   }
 
@@ -4379,15 +4375,14 @@ class CodexAppServerAgentSession implements AgentSession {
     this.warnedUnknownNotificationMethods.add(method);
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: CODEX_PROVIDER,
         sessionId: this.currentThreadId,
         turnId: this.activeForegroundTurnId ?? undefined,
-        traceKind: "provider_unhandled_event",
         method,
         params,
       },
-      "Unhandled Codex app-server notification method",
+      "provider.codex.event_unhandled",
     );
   }
 
@@ -4669,11 +4664,10 @@ export class CodexAppServerAgentClient implements AgentClient {
           this.logger.trace(
             {
               provider: CODEX_PROVIDER,
-              traceKind: "provider_config",
               versionOutput,
               enabled,
             },
-            "Resolved codex goals feature gate",
+            "provider.codex.config.goals_resolved",
           );
           return enabled;
         } catch (error) {
@@ -4687,7 +4681,7 @@ export class CodexAppServerAgentClient implements AgentClient {
 
   private async spawnAppServer(
     launchEnv?: Record<string, string>,
-    options?: { goalsEnabled?: boolean },
+    options?: { goalsEnabled?: boolean; agentId?: string },
   ): Promise<ChildProcessWithoutNullStreams> {
     const launchPrefix = await resolveCodexLaunchPrefix(this.runtimeSettings);
     const args = [...launchPrefix.args, "app-server"];
@@ -4696,13 +4690,12 @@ export class CodexAppServerAgentClient implements AgentClient {
     }
     this.logger.trace(
       {
-        agentId: launchEnv?.PASEO_AGENT_ID,
+        agentId: options?.agentId,
         provider: CODEX_PROVIDER,
-        traceKind: "provider_spawn",
         launchPrefix,
         goalsEnabled: options?.goalsEnabled === true,
       },
-      "Spawning Codex app server",
+      "provider.codex.spawn",
     );
     const child = spawnProcess(launchPrefix.command, args, {
       detached: process.platform !== "win32",
@@ -4734,11 +4727,12 @@ export class CodexAppServerAgentClient implements AgentClient {
       sessionConfig,
       null,
       this.logger,
-      () => this.spawnAppServer(launchContext?.env, { goalsEnabled }),
+      () =>
+        this.spawnAppServer(launchContext?.env, { goalsEnabled, agentId: launchContext?.agentId }),
       this.sessionDeps(),
       options?.persistSession === false,
       goalsEnabled,
-      launchContext?.env,
+      launchContext?.agentId,
     );
     await session.connect();
     return session;
@@ -4761,11 +4755,12 @@ export class CodexAppServerAgentClient implements AgentClient {
       merged,
       handle,
       this.logger,
-      () => this.spawnAppServer(launchContext?.env, { goalsEnabled }),
+      () =>
+        this.spawnAppServer(launchContext?.env, { goalsEnabled, agentId: launchContext?.agentId }),
       this.sessionDeps(),
       false,
       goalsEnabled,
-      launchContext?.env,
+      launchContext?.agentId,
     );
     await session.connect();
     return session;
@@ -5040,7 +5035,7 @@ function resolveSkillDescription(skill: Record<string, unknown>): string {
 }
 
 function eventTurnId(event: AgentStreamEvent): string | undefined {
-  return (event as { turnId?: string }).turnId;
+  return "turnId" in event ? event.turnId : undefined;
 }
 
 export const __codexAppServerInternals = {

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.ts
@@ -35,6 +35,12 @@ interface PendingRequest {
 type RequestHandler = (params: unknown) => unknown;
 type NotificationHandler = (method: string, params: unknown) => void;
 
+export interface CodexAppServerTraceContext {
+  agentId?: string;
+  sessionId?: string;
+  turnId?: string;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
 }
@@ -54,6 +60,24 @@ function isJsonRpcNotification(msg: unknown): msg is JsonRpcNotification {
   return typeof msg.method === "string" && msg.id === undefined;
 }
 
+function readProviderSessionId(params: unknown): string | undefined {
+  if (!isRecord(params)) {
+    return undefined;
+  }
+  return typeof params.threadId === "string" ? params.threadId : undefined;
+}
+
+function readProviderTurnId(params: unknown): string | undefined {
+  if (!isRecord(params)) {
+    return undefined;
+  }
+  if (typeof params.turnId === "string") {
+    return params.turnId;
+  }
+  const turn = params.turn;
+  return isRecord(turn) && typeof turn.id === "string" ? turn.id : undefined;
+}
+
 export class CodexAppServerClient {
   private readonly rl: readline.Interface;
   private readonly pending = new Map<number, PendingRequest>();
@@ -66,6 +90,7 @@ export class CodexAppServerClient {
   constructor(
     private readonly child: ChildProcessWithoutNullStreams,
     private readonly logger: Logger,
+    private readonly getTraceContext: () => CodexAppServerTraceContext = () => ({}),
   ) {
     this.rl = readline.createInterface({ input: child.stdout });
     this.rl.on("line", (line) => {
@@ -224,9 +249,13 @@ export class CodexAppServerClient {
     }
 
     if (isJsonRpcNotification(raw)) {
+      const traceContext = this.getTraceContext();
       this.logger.trace(
         {
           provider: "codex",
+          agentId: traceContext.agentId,
+          sessionId: traceContext.sessionId ?? readProviderSessionId(raw.params),
+          turnId: traceContext.turnId ?? readProviderTurnId(raw.params),
           method: raw.method,
           params: raw.params,
           rawEvent: raw,

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.ts
@@ -227,12 +227,11 @@ export class CodexAppServerClient {
       this.logger.trace(
         {
           provider: "codex",
-          traceKind: "provider_raw_event",
           method: raw.method,
           params: raw.params,
           rawEvent: raw,
         },
-        "Codex app-server JSON-RPC notification received",
+        "provider.codex.raw_event",
       );
       this.notificationHandler?.(raw.method, raw.params);
     }

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.ts
@@ -224,6 +224,16 @@ export class CodexAppServerClient {
     }
 
     if (isJsonRpcNotification(raw)) {
+      this.logger.trace(
+        {
+          provider: "codex",
+          traceKind: "provider_raw_event",
+          method: raw.method,
+          params: raw.params,
+          rawEvent: raw,
+        },
+        "Codex app-server JSON-RPC notification received",
+      );
       this.notificationHandler?.(raw.method, raw.params);
     }
   }

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -286,6 +286,10 @@ function toTerminalTurnEvent(event: AgentStreamEvent): TerminalTurnEvent | null 
   return null;
 }
 
+function eventTurnId(event: AgentStreamEvent): string | undefined {
+  return (event as { turnId?: string }).turnId;
+}
+
 function isOpenCodeNotFoundError(error: unknown): boolean {
   return (
     typeof error === "object" &&
@@ -966,7 +970,7 @@ export class OpenCodeAgentClient implements AgentClient {
 
   async createSession(
     config: AgentSessionConfig,
-    _launchContext?: AgentLaunchContext,
+    launchContext?: AgentLaunchContext,
     options?: AgentCreateSessionOptions,
   ): Promise<AgentSession> {
     const openCodeConfig = this.assertConfig(config);
@@ -1004,6 +1008,7 @@ export class OpenCodeAgentClient implements AgentClient {
         new Map(this.modelContextWindows),
         acquisition.release,
         options?.persistSession,
+        launchContext?.env,
       );
     } catch (error) {
       acquisition.release();
@@ -1014,7 +1019,7 @@ export class OpenCodeAgentClient implements AgentClient {
   async resumeSession(
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,
-    _launchContext?: AgentLaunchContext,
+    launchContext?: AgentLaunchContext,
   ): Promise<AgentSession> {
     const cwd = overrides?.cwd ?? (handle.metadata?.cwd as string);
     if (!cwd) {
@@ -1046,6 +1051,7 @@ export class OpenCodeAgentClient implements AgentClient {
         new Map(this.modelContextWindows),
         acquisition.release,
         undefined,
+        launchContext?.env,
       );
     } catch (error) {
       acquisition.release();
@@ -2141,18 +2147,6 @@ function createDeferred<T>(): Deferred<T> {
   return { promise, resolve, reject };
 }
 
-const OPENCODE_TRACE_ENABLED = process.env.PASEO_OPENCODE_TRACE === "1";
-
-function traceOpenCode(tag: string, data: Record<string, unknown> = {}): void {
-  if (!OPENCODE_TRACE_ENABLED) return;
-  const line = JSON.stringify({ ts: new Date().toISOString(), tag, ...data }, (_k, v) => {
-    if (v instanceof Error) return { name: v.name, message: v.message, stack: v.stack };
-    if (typeof v === "bigint") return v.toString();
-    return v;
-  });
-  process.stderr.write(`[opencode-trace] ${line}\n`);
-}
-
 function unwrapOpenCodeGlobalEvent(event: unknown): OpenCodeEvent | null {
   const record = readOpenCodeRecord(event);
   if (!record) {
@@ -2217,11 +2211,12 @@ class OpenCodeAgentSession implements AgentSession {
     modelContextWindowsByModelKey: ReadonlyMap<string, number> = new Map(),
     releaseServer?: () => void,
     persistSession = true,
+    private readonly launchEnv?: Record<string, string>,
   ) {
     this.config = config;
     this.client = client;
     this.sessionId = sessionId;
-    this.logger = logger;
+    this.logger = logger.child({ agentId: this.launchEnv?.PASEO_AGENT_ID });
     this.modelContextWindowsByModelKey = modelContextWindowsByModelKey;
     this.currentMode = normalizeOpenCodeModeId(config.modeId);
     this.releaseServer = releaseServer ?? null;
@@ -2483,7 +2478,7 @@ class OpenCodeAgentSession implements AgentSession {
       // SDK input validation) is caught alongside async rejections. A plain
       // `.then().catch()` chain would let a sync throw escape unhandled.
       void (async () => {
-        traceOpenCode("promptAsync.start", {
+        this.traceOpenCode("promptAsync.start", {
           turnId,
           sessionId: this.sessionId,
           model,
@@ -2509,7 +2504,7 @@ class OpenCodeAgentSession implements AgentSession {
             ...(effectiveMode ? { agent: effectiveMode } : {}),
             ...(effectiveVariant ? { variant: effectiveVariant } : {}),
           });
-          traceOpenCode("promptAsync.response", {
+          this.traceOpenCode("promptAsync.response", {
             turnId,
             hasError: promptResponse.error !== undefined,
             error: promptResponse.error,
@@ -2526,7 +2521,7 @@ class OpenCodeAgentSession implements AgentSession {
             );
           }
         } catch (error) {
-          traceOpenCode("promptAsync.throw", {
+          this.traceOpenCode("promptAsync.throw", {
             turnId,
             error:
               error instanceof Error
@@ -2560,7 +2555,11 @@ class OpenCodeAgentSession implements AgentSession {
     turnAbortController: AbortController,
     subscriptionReady: Deferred<void>,
   ): Promise<void> {
-    traceOpenCode("subscribe.start", { turnId, sessionId: this.sessionId, cwd: this.config.cwd });
+    this.traceOpenCode("subscribe.start", {
+      turnId,
+      sessionId: this.sessionId,
+      cwd: this.config.cwd,
+    });
     try {
       const result = await this.client.global.event({
         signal: turnAbortController.signal,
@@ -2572,7 +2571,7 @@ class OpenCodeAgentSession implements AgentSession {
         eventCount += 1;
         if (!subscriptionReadyResolved) {
           subscriptionReadyResolved = true;
-          traceOpenCode("subscribe.ready", { turnId, sessionId: this.sessionId });
+          this.traceOpenCode("subscribe.ready", { turnId, sessionId: this.sessionId });
           subscriptionReady.resolve();
         }
         const shouldContinue = await this.consumeOpenCodeStreamEvent({
@@ -2586,7 +2585,7 @@ class OpenCodeAgentSession implements AgentSession {
         }
       }
 
-      traceOpenCode("stream.eof", {
+      this.traceOpenCode("stream.eof", {
         turnId,
         eventCount,
         aborted: turnAbortController.signal.aborted,
@@ -2594,7 +2593,7 @@ class OpenCodeAgentSession implements AgentSession {
       });
 
       if (!turnAbortController.signal.aborted && this.activeForegroundTurnId === turnId) {
-        traceOpenCode("turn.fail.eof", { turnId, eventCount });
+        this.traceOpenCode("turn.fail.eof", { turnId, eventCount });
         if (!subscriptionReadyResolved) {
           subscriptionReady.reject(new Error("OpenCode event stream ended before it became ready"));
         }
@@ -2608,7 +2607,7 @@ class OpenCodeAgentSession implements AgentSession {
         );
       }
     } catch (error) {
-      traceOpenCode("subscribe.error", {
+      this.traceOpenCode("subscribe.error", {
         turnId,
         error:
           error instanceof Error ? { name: error.name, message: error.message } : String(error),
@@ -2649,19 +2648,21 @@ class OpenCodeAgentSession implements AgentSession {
   }): Promise<boolean> {
     const { rawEvent, eventCount, turnId, turnAbortController } = params;
     const event = unwrapOpenCodeGlobalEvent(rawEvent);
-    traceOpenCode("event.raw", {
+    this.traceOpenCode("event.raw", {
       turnId,
+      traceKind: "provider_raw_event",
       n: eventCount,
       type: event?.type,
       rawType: readOpenCodeRecord(rawEvent)?.type,
       directory: readOpenCodeRecord(rawEvent)?.directory,
+      rawEvent,
       properties: event ? (event as { properties?: unknown }).properties : undefined,
     });
     if (!event) {
       return true;
     }
     if (turnAbortController.signal.aborted || this.activeForegroundTurnId !== turnId) {
-      traceOpenCode("event.skip", {
+      this.traceOpenCode("event.skip", {
         turnId,
         n: eventCount,
         aborted: turnAbortController.signal.aborted,
@@ -2672,16 +2673,18 @@ class OpenCodeAgentSession implements AgentSession {
 
     this.armRetryFailureTimerForStatus(event, turnId);
     const translated = await this.translateEvent(event);
-    traceOpenCode("event.translated", {
+    this.traceOpenCode("event.translated", {
       turnId,
+      traceKind: "provider_translated_event",
       n: eventCount,
       count: translated.length,
       types: translated.map((t) => t.type),
+      events: translated,
     });
 
     for (const e of translated) {
       if (this.activeForegroundTurnId !== turnId) {
-        traceOpenCode("event.translated.skip-active", { turnId, type: e.type });
+        this.traceOpenCode("event.translated.skip-active", { turnId, type: e.type });
         return false;
       }
       if (e.type === "timeline" && e.item.type === "tool_call") {
@@ -2689,7 +2692,7 @@ class OpenCodeAgentSession implements AgentSession {
       }
       const terminalEvent = toTerminalTurnEvent(e);
       if (terminalEvent) {
-        traceOpenCode("event.terminal", { turnId, type: terminalEvent.type });
+        this.traceOpenCode("event.terminal", { turnId, type: terminalEvent.type });
         this.finishForegroundTurn(terminalEvent, turnId);
         return false;
       }
@@ -2703,7 +2706,7 @@ class OpenCodeAgentSession implements AgentSession {
     event: Extract<AgentStreamEvent, { type: "turn_completed" | "turn_failed" | "turn_canceled" }>,
     turnId: string,
   ): void {
-    traceOpenCode("finishForegroundTurn", {
+    this.traceOpenCode("finishForegroundTurn", {
       turnId,
       activeTurnId: this.activeForegroundTurnId,
       type: event.type,
@@ -2803,6 +2806,11 @@ class OpenCodeAgentSession implements AgentSession {
   private notifySubscribers(event: AgentStreamEvent, turnIdOverride?: string): void {
     const turnId = turnIdOverride ?? this.activeForegroundTurnId;
     const tagged = turnId ? { ...event, turnId } : event;
+    this.traceOpenCode("provider.emit", {
+      turnId: eventTurnId(tagged),
+      traceKind: "provider_emit_event",
+      event: tagged,
+    });
     for (const callback of this.subscribers) {
       try {
         callback(tagged);
@@ -2814,6 +2822,24 @@ class OpenCodeAgentSession implements AgentSession {
 
   private createTurnId(): string {
     return `opencode-turn-${this.nextTurnOrdinal++}`;
+  }
+
+  private traceOpenCode(tag: string, data: Record<string, unknown> = {}): void {
+    this.logger.trace(
+      {
+        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        provider: "opencode",
+        sessionId: this.sessionId,
+        turnId:
+          typeof data.turnId === "string"
+            ? data.turnId
+            : (this.activeForegroundTurnId ?? undefined),
+        traceKind: typeof data.traceKind === "string" ? data.traceKind : "provider_control_event",
+        tag,
+        ...data,
+      },
+      "OpenCode trace event",
+    );
   }
 
   async *streamHistory(): AsyncGenerator<AgentStreamEvent> {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -287,7 +287,11 @@ function toTerminalTurnEvent(event: AgentStreamEvent): TerminalTurnEvent | null 
 }
 
 function eventTurnId(event: AgentStreamEvent): string | undefined {
-  return (event as { turnId?: string }).turnId;
+  return "turnId" in event ? event.turnId : undefined;
+}
+
+function normalizeTraceTag(tag: string): string {
+  return tag.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 }
 
 function isOpenCodeNotFoundError(error: unknown): boolean {
@@ -1008,7 +1012,7 @@ export class OpenCodeAgentClient implements AgentClient {
         new Map(this.modelContextWindows),
         acquisition.release,
         options?.persistSession,
-        launchContext?.env,
+        launchContext?.agentId,
       );
     } catch (error) {
       acquisition.release();
@@ -1051,7 +1055,7 @@ export class OpenCodeAgentClient implements AgentClient {
         new Map(this.modelContextWindows),
         acquisition.release,
         undefined,
-        launchContext?.env,
+        launchContext?.agentId,
       );
     } catch (error) {
       acquisition.release();
@@ -1281,6 +1285,11 @@ export interface OpenCodeEventTranslationState {
   pendingChildToolPartsBySessionId?: Map<string, OpenCodeToolPartEventPart[]>;
   modelContextWindowsByModelKey?: ReadonlyMap<string, number>;
   onAssistantModelContextWindowResolved?: (contextWindowMaxTokens: number) => void;
+}
+
+interface OpenCodeTraceData {
+  turnId?: string;
+  [key: string]: unknown;
 }
 
 type OpenCodeToolPartEventPart = Extract<
@@ -2211,12 +2220,12 @@ class OpenCodeAgentSession implements AgentSession {
     modelContextWindowsByModelKey: ReadonlyMap<string, number> = new Map(),
     releaseServer?: () => void,
     persistSession = true,
-    private readonly launchEnv?: Record<string, string>,
+    private readonly agentId?: string,
   ) {
     this.config = config;
     this.client = client;
     this.sessionId = sessionId;
-    this.logger = logger.child({ agentId: this.launchEnv?.PASEO_AGENT_ID });
+    this.logger = logger.child({ agentId: this.agentId });
     this.modelContextWindowsByModelKey = modelContextWindowsByModelKey;
     this.currentMode = normalizeOpenCodeModeId(config.modeId);
     this.releaseServer = releaseServer ?? null;
@@ -2650,13 +2659,12 @@ class OpenCodeAgentSession implements AgentSession {
     const event = unwrapOpenCodeGlobalEvent(rawEvent);
     this.traceOpenCode("event.raw", {
       turnId,
-      traceKind: "provider_raw_event",
       n: eventCount,
       type: event?.type,
       rawType: readOpenCodeRecord(rawEvent)?.type,
       directory: readOpenCodeRecord(rawEvent)?.directory,
       rawEvent,
-      properties: event ? (event as { properties?: unknown }).properties : undefined,
+      properties: event?.properties,
     });
     if (!event) {
       return true;
@@ -2675,7 +2683,6 @@ class OpenCodeAgentSession implements AgentSession {
     const translated = await this.translateEvent(event);
     this.traceOpenCode("event.translated", {
       turnId,
-      traceKind: "provider_translated_event",
       n: eventCount,
       count: translated.length,
       types: translated.map((t) => t.type),
@@ -2808,7 +2815,6 @@ class OpenCodeAgentSession implements AgentSession {
     const tagged = turnId ? { ...event, turnId } : event;
     this.traceOpenCode("provider.emit", {
       turnId: eventTurnId(tagged),
-      traceKind: "provider_emit_event",
       event: tagged,
     });
     for (const callback of this.subscribers) {
@@ -2824,21 +2830,16 @@ class OpenCodeAgentSession implements AgentSession {
     return `opencode-turn-${this.nextTurnOrdinal++}`;
   }
 
-  private traceOpenCode(tag: string, data: Record<string, unknown> = {}): void {
+  private traceOpenCode(tag: string, data: OpenCodeTraceData = {}): void {
     this.logger.trace(
       {
-        agentId: this.launchEnv?.PASEO_AGENT_ID,
+        agentId: this.agentId,
         provider: "opencode",
         sessionId: this.sessionId,
-        turnId:
-          typeof data.turnId === "string"
-            ? data.turnId
-            : (this.activeForegroundTurnId ?? undefined),
-        traceKind: typeof data.traceKind === "string" ? data.traceKind : "provider_control_event",
-        tag,
+        turnId: data.turnId ?? this.activeForegroundTurnId ?? undefined,
         ...data,
       },
-      "OpenCode trace event",
+      `provider.opencode.${normalizeTraceTag(tag)}`,
     );
   }
 

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -13,33 +13,34 @@ import { findExecutable, isCommandAvailable } from "../../../utils/executable.js
 import type { Logger } from "pino";
 import { z } from "zod";
 
-import type {
-  AgentCapabilityFlags,
-  AgentClient,
-  AgentCreateSessionOptions,
-  AgentLaunchContext,
-  AgentMode,
-  AgentModelDefinition,
-  AgentPermissionRequest,
-  AgentPermissionResponse,
-  AgentPersistenceHandle,
-  AgentPromptInput,
-  AgentRunOptions,
-  AgentRunResult,
-  AgentRuntimeInfo,
-  AgentSession,
-  AgentSessionConfig,
-  AgentSlashCommand,
-  AgentStreamEvent,
-  AgentTimelineItem,
-  AgentUsage,
-  ListModelsOptions,
-  ListModesOptions,
-  ListPersistedAgentsOptions,
-  McpServerConfig,
-  PersistedAgentDescriptor,
-  ToolCallDetail,
-  ToolCallTimelineItem,
+import {
+  getAgentStreamEventTurnId,
+  type AgentCapabilityFlags,
+  type AgentClient,
+  type AgentCreateSessionOptions,
+  type AgentLaunchContext,
+  type AgentMode,
+  type AgentModelDefinition,
+  type AgentPermissionRequest,
+  type AgentPermissionResponse,
+  type AgentPersistenceHandle,
+  type AgentPromptInput,
+  type AgentRunOptions,
+  type AgentRunResult,
+  type AgentRuntimeInfo,
+  type AgentSession,
+  type AgentSessionConfig,
+  type AgentSlashCommand,
+  type AgentStreamEvent,
+  type AgentTimelineItem,
+  type AgentUsage,
+  type ListModelsOptions,
+  type ListModesOptions,
+  type ListPersistedAgentsOptions,
+  type McpServerConfig,
+  type PersistedAgentDescriptor,
+  type ToolCallDetail,
+  type ToolCallTimelineItem,
 } from "../agent-sdk-types.js";
 import { createProviderEnvSpec, type ProviderRuntimeSettings } from "../provider-launch-config.js";
 import { withTimeout } from "../../../utils/promise-timeout.js";
@@ -284,14 +285,6 @@ function toTerminalTurnEvent(event: AgentStreamEvent): TerminalTurnEvent | null 
     return event;
   }
   return null;
-}
-
-function eventTurnId(event: AgentStreamEvent): string | undefined {
-  return "turnId" in event ? event.turnId : undefined;
-}
-
-function normalizeTraceTag(tag: string): string {
-  return tag.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 }
 
 function isOpenCodeNotFoundError(error: unknown): boolean {
@@ -1291,6 +1284,23 @@ interface OpenCodeTraceData {
   turnId?: string;
   [key: string]: unknown;
 }
+
+type OpenCodeTraceMessage =
+  | "provider.opencode.prompt_async.start"
+  | "provider.opencode.prompt_async.response"
+  | "provider.opencode.prompt_async.throw"
+  | "provider.opencode.subscribe.start"
+  | "provider.opencode.subscribe.ready"
+  | "provider.opencode.stream.eof"
+  | "provider.opencode.turn.fail_eof"
+  | "provider.opencode.subscribe.error"
+  | "provider.opencode.raw_event"
+  | "provider.opencode.event.skip"
+  | "provider.opencode.parsed_event"
+  | "provider.opencode.parsed_event.skip_active"
+  | "provider.opencode.event.terminal"
+  | "provider.opencode.finish_foreground_turn"
+  | "provider.opencode.event_emit";
 
 type OpenCodeToolPartEventPart = Extract<
   Extract<OpenCodeEvent, { type: "message.part.updated" }>["properties"]["part"],
@@ -2487,7 +2497,7 @@ class OpenCodeAgentSession implements AgentSession {
       // SDK input validation) is caught alongside async rejections. A plain
       // `.then().catch()` chain would let a sync throw escape unhandled.
       void (async () => {
-        this.traceOpenCode("promptAsync.start", {
+        this.traceOpenCode("provider.opencode.prompt_async.start", {
           turnId,
           sessionId: this.sessionId,
           model,
@@ -2513,7 +2523,7 @@ class OpenCodeAgentSession implements AgentSession {
             ...(effectiveMode ? { agent: effectiveMode } : {}),
             ...(effectiveVariant ? { variant: effectiveVariant } : {}),
           });
-          this.traceOpenCode("promptAsync.response", {
+          this.traceOpenCode("provider.opencode.prompt_async.response", {
             turnId,
             hasError: promptResponse.error !== undefined,
             error: promptResponse.error,
@@ -2530,7 +2540,7 @@ class OpenCodeAgentSession implements AgentSession {
             );
           }
         } catch (error) {
-          this.traceOpenCode("promptAsync.throw", {
+          this.traceOpenCode("provider.opencode.prompt_async.throw", {
             turnId,
             error:
               error instanceof Error
@@ -2564,7 +2574,7 @@ class OpenCodeAgentSession implements AgentSession {
     turnAbortController: AbortController,
     subscriptionReady: Deferred<void>,
   ): Promise<void> {
-    this.traceOpenCode("subscribe.start", {
+    this.traceOpenCode("provider.opencode.subscribe.start", {
       turnId,
       sessionId: this.sessionId,
       cwd: this.config.cwd,
@@ -2580,7 +2590,10 @@ class OpenCodeAgentSession implements AgentSession {
         eventCount += 1;
         if (!subscriptionReadyResolved) {
           subscriptionReadyResolved = true;
-          this.traceOpenCode("subscribe.ready", { turnId, sessionId: this.sessionId });
+          this.traceOpenCode("provider.opencode.subscribe.ready", {
+            turnId,
+            sessionId: this.sessionId,
+          });
           subscriptionReady.resolve();
         }
         const shouldContinue = await this.consumeOpenCodeStreamEvent({
@@ -2594,7 +2607,7 @@ class OpenCodeAgentSession implements AgentSession {
         }
       }
 
-      this.traceOpenCode("stream.eof", {
+      this.traceOpenCode("provider.opencode.stream.eof", {
         turnId,
         eventCount,
         aborted: turnAbortController.signal.aborted,
@@ -2602,7 +2615,7 @@ class OpenCodeAgentSession implements AgentSession {
       });
 
       if (!turnAbortController.signal.aborted && this.activeForegroundTurnId === turnId) {
-        this.traceOpenCode("turn.fail.eof", { turnId, eventCount });
+        this.traceOpenCode("provider.opencode.turn.fail_eof", { turnId, eventCount });
         if (!subscriptionReadyResolved) {
           subscriptionReady.reject(new Error("OpenCode event stream ended before it became ready"));
         }
@@ -2616,7 +2629,7 @@ class OpenCodeAgentSession implements AgentSession {
         );
       }
     } catch (error) {
-      this.traceOpenCode("subscribe.error", {
+      this.traceOpenCode("provider.opencode.subscribe.error", {
         turnId,
         error:
           error instanceof Error ? { name: error.name, message: error.message } : String(error),
@@ -2657,7 +2670,7 @@ class OpenCodeAgentSession implements AgentSession {
   }): Promise<boolean> {
     const { rawEvent, eventCount, turnId, turnAbortController } = params;
     const event = unwrapOpenCodeGlobalEvent(rawEvent);
-    this.traceOpenCode("event.raw", {
+    this.traceOpenCode("provider.opencode.raw_event", {
       turnId,
       n: eventCount,
       type: event?.type,
@@ -2670,7 +2683,7 @@ class OpenCodeAgentSession implements AgentSession {
       return true;
     }
     if (turnAbortController.signal.aborted || this.activeForegroundTurnId !== turnId) {
-      this.traceOpenCode("event.skip", {
+      this.traceOpenCode("provider.opencode.event.skip", {
         turnId,
         n: eventCount,
         aborted: turnAbortController.signal.aborted,
@@ -2681,7 +2694,7 @@ class OpenCodeAgentSession implements AgentSession {
 
     this.armRetryFailureTimerForStatus(event, turnId);
     const translated = await this.translateEvent(event);
-    this.traceOpenCode("event.translated", {
+    this.traceOpenCode("provider.opencode.parsed_event", {
       turnId,
       n: eventCount,
       count: translated.length,
@@ -2691,7 +2704,7 @@ class OpenCodeAgentSession implements AgentSession {
 
     for (const e of translated) {
       if (this.activeForegroundTurnId !== turnId) {
-        this.traceOpenCode("event.translated.skip-active", { turnId, type: e.type });
+        this.traceOpenCode("provider.opencode.parsed_event.skip_active", { turnId, type: e.type });
         return false;
       }
       if (e.type === "timeline" && e.item.type === "tool_call") {
@@ -2699,7 +2712,10 @@ class OpenCodeAgentSession implements AgentSession {
       }
       const terminalEvent = toTerminalTurnEvent(e);
       if (terminalEvent) {
-        this.traceOpenCode("event.terminal", { turnId, type: terminalEvent.type });
+        this.traceOpenCode("provider.opencode.event.terminal", {
+          turnId,
+          type: terminalEvent.type,
+        });
         this.finishForegroundTurn(terminalEvent, turnId);
         return false;
       }
@@ -2713,7 +2729,7 @@ class OpenCodeAgentSession implements AgentSession {
     event: Extract<AgentStreamEvent, { type: "turn_completed" | "turn_failed" | "turn_canceled" }>,
     turnId: string,
   ): void {
-    this.traceOpenCode("finishForegroundTurn", {
+    this.traceOpenCode("provider.opencode.finish_foreground_turn", {
       turnId,
       activeTurnId: this.activeForegroundTurnId,
       type: event.type,
@@ -2813,8 +2829,8 @@ class OpenCodeAgentSession implements AgentSession {
   private notifySubscribers(event: AgentStreamEvent, turnIdOverride?: string): void {
     const turnId = turnIdOverride ?? this.activeForegroundTurnId;
     const tagged = turnId ? { ...event, turnId } : event;
-    this.traceOpenCode("provider.emit", {
-      turnId: eventTurnId(tagged),
+    this.traceOpenCode("provider.opencode.event_emit", {
+      turnId: getAgentStreamEventTurnId(tagged),
       event: tagged,
     });
     for (const callback of this.subscribers) {
@@ -2830,7 +2846,7 @@ class OpenCodeAgentSession implements AgentSession {
     return `opencode-turn-${this.nextTurnOrdinal++}`;
   }
 
-  private traceOpenCode(tag: string, data: OpenCodeTraceData = {}): void {
+  private traceOpenCode(msg: OpenCodeTraceMessage, data: OpenCodeTraceData = {}): void {
     this.logger.trace(
       {
         agentId: this.agentId,
@@ -2839,7 +2855,7 @@ class OpenCodeAgentSession implements AgentSession {
         turnId: data.turnId ?? this.activeForegroundTurnId ?? undefined,
         ...data,
       },
-      `provider.opencode.${normalizeTraceTag(tag)}`,
+      msg,
     );
   }
 

--- a/packages/server/src/server/agent/providers/pi-direct-agent.ts
+++ b/packages/server/src/server/agent/providers/pi-direct-agent.ts
@@ -30,29 +30,30 @@ import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { Api, ImageContent, Model, TextContent } from "@mariozechner/pi-ai";
 import { z } from "zod";
 
-import type {
-  AgentCapabilityFlags,
-  AgentClient,
-  AgentLaunchContext,
-  AgentMetadata,
-  AgentMode,
-  AgentModelDefinition,
-  AgentPermissionRequest,
-  AgentPermissionResponse,
-  AgentPersistenceHandle,
-  AgentPromptInput,
-  AgentRunOptions,
-  AgentRunResult,
-  AgentRuntimeInfo,
-  AgentSession,
-  AgentSessionConfig,
-  AgentSlashCommand,
-  AgentStreamEvent,
-  AgentTimelineItem,
-  AgentUsage,
-  ListModesOptions,
-  ListModelsOptions,
-  ToolCallDetail,
+import {
+  getAgentStreamEventTurnId,
+  type AgentCapabilityFlags,
+  type AgentClient,
+  type AgentLaunchContext,
+  type AgentMetadata,
+  type AgentMode,
+  type AgentModelDefinition,
+  type AgentPermissionRequest,
+  type AgentPermissionResponse,
+  type AgentPersistenceHandle,
+  type AgentPromptInput,
+  type AgentRunOptions,
+  type AgentRunResult,
+  type AgentRuntimeInfo,
+  type AgentSession,
+  type AgentSessionConfig,
+  type AgentSlashCommand,
+  type AgentStreamEvent,
+  type AgentTimelineItem,
+  type AgentUsage,
+  type ListModesOptions,
+  type ListModelsOptions,
+  type ToolCallDetail,
 } from "../agent-sdk-types.js";
 import type { ProviderRuntimeSettings } from "../provider-launch-config.js";
 import { renderPromptAttachmentAsText } from "../prompt-attachments.js";
@@ -738,21 +739,6 @@ function parsePersistenceMetadata(metadata: AgentMetadata | undefined): PiPersis
   return {};
 }
 
-function getStreamEventTurnId(event: AgentStreamEvent): string | undefined {
-  switch (event.type) {
-    case "turn_started":
-    case "turn_completed":
-    case "turn_failed":
-    case "turn_canceled":
-    case "timeline":
-    case "permission_requested":
-    case "permission_resolved":
-      return event.turnId;
-    default:
-      return undefined;
-  }
-}
-
 function isPiRequestAbortError(error: unknown): boolean {
   if (error instanceof Error && error.name === "AbortError") {
     return true;
@@ -1045,7 +1031,7 @@ export class PiDirectAgentSession implements AgentSession {
         return;
       }
 
-      const eventTurnId = getStreamEventTurnId(event);
+      const eventTurnId = getAgentStreamEventTurnId(event);
       if (turnId && eventTurnId && eventTurnId !== turnId) {
         return;
       }

--- a/packages/server/src/server/agent/providers/provider-runner.ts
+++ b/packages/server/src/server/agent/providers/provider-runner.ts
@@ -1,9 +1,10 @@
-import type {
-  AgentPromptInput,
-  AgentRunOptions,
-  AgentRunResult,
-  AgentStreamEvent,
-  AgentTimelineItem,
+import {
+  getAgentStreamEventTurnId,
+  type AgentPromptInput,
+  type AgentRunOptions,
+  type AgentRunResult,
+  type AgentStreamEvent,
+  type AgentTimelineItem,
 } from "../agent-sdk-types.js";
 
 export type ProviderFinalTextReducer = (params: {
@@ -44,7 +45,7 @@ export async function runProviderTurn({
     if (settled) {
       return;
     }
-    const eventTurnId = "turnId" in event ? event.turnId : undefined;
+    const eventTurnId = getAgentStreamEventTurnId(event);
     if (turnId && eventTurnId && eventTurnId !== turnId) {
       return;
     }

--- a/packages/server/src/server/agent/providers/test-utils/session-stream-adapter.ts
+++ b/packages/server/src/server/agent/providers/test-utils/session-stream-adapter.ts
@@ -1,8 +1,9 @@
-import type {
-  AgentPromptInput,
-  AgentRunOptions,
-  AgentSession,
-  AgentStreamEvent,
+import {
+  getAgentStreamEventTurnId,
+  type AgentPromptInput,
+  type AgentRunOptions,
+  type AgentSession,
+  type AgentStreamEvent,
 } from "../../agent-sdk-types.js";
 
 function isTerminalEvent(event: AgentStreamEvent): boolean {
@@ -29,7 +30,7 @@ export async function* streamSession(
   };
 
   const matchesTurn = (event: AgentStreamEvent): boolean => {
-    const eventTurnId = (event as { turnId?: string }).turnId;
+    const eventTurnId = getAgentStreamEventTurnId(event);
     return turnId == null || eventTurnId == null || eventTurnId === turnId;
   };
 

--- a/packages/server/src/server/logger.test.ts
+++ b/packages/server/src/server/logger.test.ts
@@ -106,6 +106,31 @@ describe("resolveLogConfig", () => {
       },
     });
   });
+
+  it("defaults file output to info when log.file is present without a level", () => {
+    const config: PersistedConfig = {
+      log: {
+        console: {
+          level: "warn",
+        },
+        file: {
+          path: "daemon.log",
+        },
+      },
+    };
+
+    expect(resolveLogConfig(config, { paseoHome })).toEqual({
+      level: "info",
+      console: {
+        level: "warn",
+        format: "json",
+      },
+      file: {
+        level: "info",
+        path: path.resolve(paseoHome, "daemon.log"),
+      },
+    });
+  });
 });
 
 describe("loadConfig logger config", () => {

--- a/packages/server/src/server/logger.ts
+++ b/packages/server/src/server/logger.ts
@@ -43,7 +43,7 @@ const LOG_LEVEL_PRIORITIES: Record<LogLevel, number> = {
 
 const DEFAULT_CONSOLE_LEVEL: LogLevel = "info";
 const DEFAULT_CONSOLE_FORMAT: LogFormat = "json";
-const DEFAULT_FILE_LEVEL: LogLevel = "debug";
+const DEFAULT_FILE_LEVEL: LogLevel = "info";
 const DEFAULT_DAEMON_LOG_FILENAME = "daemon.log";
 const REDACT_PATHS = [
   "authorization",

--- a/packages/server/src/server/paseo-env.ts
+++ b/packages/server/src/server/paseo-env.ts
@@ -79,12 +79,3 @@ export function resolvePaseoNodeEnv(env: NodeJS.ProcessEnv): PaseoNodeEnv | unde
   const value = env[PASEO_NODE_ENV];
   return value === "development" || value === "production" || value === "test" ? value : undefined;
 }
-
-export function parseOptionalPositiveIntegerEnv(value: string | undefined): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  const parsed = Number.parseInt(value.trim(), 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
-}

--- a/packages/server/src/server/paseo-env.ts
+++ b/packages/server/src/server/paseo-env.ts
@@ -79,3 +79,12 @@ export function resolvePaseoNodeEnv(env: NodeJS.ProcessEnv): PaseoNodeEnv | unde
   const value = env[PASEO_NODE_ENV];
   return value === "development" || value === "production" || value === "test" ? value : undefined;
 }
+
+export function parseOptionalPositiveIntegerEnv(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value.trim(), 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -895,7 +895,7 @@ export class Session {
     void this.initializeAgentMcp();
     this.subscribeToAgentEvents();
 
-    this.sessionLogger.trace({ traceKind: "session_lifecycle" }, "Session created");
+    this.sessionLogger.trace({}, "agent.session.lifecycle.created");
   }
 
   updateAppVersion(appVersion: string | null): void {
@@ -1017,10 +1017,7 @@ export class Session {
   private async interruptAgentIfRunning(agentId: string): Promise<void> {
     const snapshot = this.agentManager.getAgent(agentId);
     if (!snapshot) {
-      this.sessionLogger.trace(
-        { agentId, traceKind: "session_interrupt" },
-        "interruptAgentIfRunning: agent not found",
-      );
+      this.sessionLogger.trace({ agentId }, "agent.session.interrupt.not_found");
       throw new Error(`Agent ${agentId} not found`);
     }
 
@@ -1030,11 +1027,10 @@ export class Session {
         {
           agentId,
           provider: snapshot.provider,
-          traceKind: "session_interrupt",
           lifecycle: snapshot.lifecycle,
           hasInFlightRun,
         },
-        "interruptAgentIfRunning: skipping because agent is not running",
+        "agent.session.interrupt.skip_not_running",
       );
       return;
     }
@@ -1076,11 +1072,10 @@ export class Session {
     this.sessionLogger.trace(
       {
         agentId,
-        traceKind: "session_start_stream",
         promptType: typeof prompt === "string" ? "string" : "structured",
         hasRunOptions: Boolean(runOptions),
       },
-      "startAgentStream: requested",
+      "agent.session.start_stream.request",
     );
     let iterator: AsyncGenerator<AgentStreamEvent>;
     try {
@@ -1089,8 +1084,8 @@ export class Session {
         ? this.agentManager.replaceAgentRun(agentId, prompt, runOptions)
         : this.agentManager.streamAgent(agentId, prompt, runOptions);
       this.sessionLogger.trace(
-        { agentId, traceKind: "session_start_stream", shouldReplace },
-        "startAgentStream: agent iterator returned",
+        { agentId, shouldReplace },
+        "agent.session.start_stream.iterator_returned",
       );
     } catch (error) {
       this.handleAgentRunError(agentId, error, "Failed to start agent run");
@@ -1102,15 +1097,9 @@ export class Session {
         for await (const _ of iterator) {
           // Events are forwarded via the session's AgentManager subscription.
         }
-        this.sessionLogger.trace(
-          { agentId, traceKind: "session_iterator_drained" },
-          "startAgentStream: iterator drained",
-        );
+        this.sessionLogger.trace({ agentId }, "agent.session.iterator.drained");
       } catch (error) {
-        this.sessionLogger.trace(
-          { agentId, traceKind: "session_iterator_error", err: error },
-          "startAgentStream: iterator threw",
-        );
+        this.sessionLogger.trace({ agentId, err: error }, "agent.session.iterator.error");
         this.handleAgentRunError(agentId, error, "Agent stream failed");
       }
     })();
@@ -1151,10 +1140,7 @@ export class Session {
 
       this.agentTools = (await this.agentMcpClient.tools()) as ToolSet;
       const agentToolCount = Object.keys(this.agentTools ?? {}).length;
-      this.sessionLogger.trace(
-        { traceKind: "session_mcp_init", agentToolCount },
-        `Agent MCP initialized with ${agentToolCount} tools`,
-      );
+      this.sessionLogger.trace({ agentToolCount }, "agent.session.mcp_init");
     } catch (error) {
       this.sessionLogger.error({ err: error }, "Failed to initialize Agent MCP");
     }
@@ -1232,10 +1218,9 @@ export class Session {
               provider: event.agent.provider,
               sessionId: event.agent.persistence?.sessionId ?? undefined,
               turnId: event.agent.activeForegroundTurnId ?? undefined,
-              traceKind: "session_forward",
               lifecycle: event.agent.lifecycle,
             },
-            "Session forwarding agent update",
+            "agent.session.forward_update",
           );
           void this.forwardAgentUpdate(event.agent);
           return;
@@ -1291,13 +1276,12 @@ export class Session {
           {
             agentId: event.agentId,
             provider: event.event.provider,
-            turnId: (event.event as { turnId?: string }).turnId,
-            traceKind: "session_forward",
+            turnId: agentStreamEventTurnId(event.event),
             seq: event.seq,
             epoch: event.epoch,
             event: event.event,
           },
-          "Session forwarding agent stream",
+          "agent.session.forward_stream",
         );
 
         const payload = {
@@ -1652,11 +1636,10 @@ export class Session {
     try {
       this.sessionLogger.trace(
         {
-          traceKind: "session_inbound",
           messageType: msg.type,
           payloadBytes: JSON.stringify(msg).length,
         },
-        "inbound message",
+        "agent.session.inbound",
       );
       try {
         await this.dispatchInboundMessage(msg);
@@ -7225,11 +7208,10 @@ export class Session {
       this.sessionLogger.trace(
         {
           agentId,
-          traceKind: "session_send_agent_message",
           messageId: msg.messageId,
           textPrefix: msg.text.slice(0, 80),
         },
-        "send_agent_message_request: dispatching shared sendPromptToAgent",
+        "agent.session.send_agent_message",
       );
       let dispatchResult: { outOfBand: boolean };
       try {
@@ -8015,11 +7997,10 @@ export class Session {
   private emit(msg: SessionOutboundMessage): void {
     this.sessionLogger.trace(
       {
-        traceKind: "session_outbound",
         messageType: msg.type,
         payloadBytes: JSON.stringify(msg).length,
       },
-      "outbound message",
+      "agent.session.outbound",
     );
     if (
       msg.type === "audio_output" &&
@@ -8087,7 +8068,7 @@ export class Session {
    * Clean up session resources
    */
   public async cleanup(): Promise<void> {
-    this.sessionLogger.trace({ traceKind: "session_lifecycle" }, "Cleaning up");
+    this.sessionLogger.trace({}, "agent.session.lifecycle.cleanup");
 
     if (this.unsubscribeAgentEvents) {
       this.unsubscribeAgentEvents();
@@ -8706,6 +8687,10 @@ function isValidPullRequestTimelineIdentity(options: {
     return false;
   }
   return isValidGitHubRepoSegment(options.repoOwner) && isValidGitHubRepoSegment(options.repoName);
+}
+
+function agentStreamEventTurnId(event: AgentStreamEvent): string | undefined {
+  return "turnId" in event ? event.turnId : undefined;
 }
 
 function isValidGitHubRepoSegment(value: string): boolean {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -895,7 +895,7 @@ export class Session {
     void this.initializeAgentMcp();
     this.subscribeToAgentEvents();
 
-    this.sessionLogger.trace("Session created");
+    this.sessionLogger.trace({ traceKind: "session_lifecycle" }, "Session created");
   }
 
   updateAppVersion(appVersion: string | null): void {
@@ -1017,14 +1017,23 @@ export class Session {
   private async interruptAgentIfRunning(agentId: string): Promise<void> {
     const snapshot = this.agentManager.getAgent(agentId);
     if (!snapshot) {
-      this.sessionLogger.trace({ agentId }, "interruptAgentIfRunning: agent not found");
+      this.sessionLogger.trace(
+        { agentId, traceKind: "session_interrupt" },
+        "interruptAgentIfRunning: agent not found",
+      );
       throw new Error(`Agent ${agentId} not found`);
     }
 
     const hasInFlightRun = this.agentManager.hasInFlightRun(agentId);
     if (!hasInFlightRun) {
       this.sessionLogger.trace(
-        { agentId, lifecycle: snapshot.lifecycle, hasInFlightRun },
+        {
+          agentId,
+          provider: snapshot.provider,
+          traceKind: "session_interrupt",
+          lifecycle: snapshot.lifecycle,
+          hasInFlightRun,
+        },
         "interruptAgentIfRunning: skipping because agent is not running",
       );
       return;
@@ -1067,6 +1076,7 @@ export class Session {
     this.sessionLogger.trace(
       {
         agentId,
+        traceKind: "session_start_stream",
         promptType: typeof prompt === "string" ? "string" : "structured",
         hasRunOptions: Boolean(runOptions),
       },
@@ -1079,7 +1089,7 @@ export class Session {
         ? this.agentManager.replaceAgentRun(agentId, prompt, runOptions)
         : this.agentManager.streamAgent(agentId, prompt, runOptions);
       this.sessionLogger.trace(
-        { agentId, shouldReplace },
+        { agentId, traceKind: "session_start_stream", shouldReplace },
         "startAgentStream: agent iterator returned",
       );
     } catch (error) {
@@ -1092,9 +1102,15 @@ export class Session {
         for await (const _ of iterator) {
           // Events are forwarded via the session's AgentManager subscription.
         }
-        this.sessionLogger.trace({ agentId }, "startAgentStream: iterator drained");
+        this.sessionLogger.trace(
+          { agentId, traceKind: "session_iterator_drained" },
+          "startAgentStream: iterator drained",
+        );
       } catch (error) {
-        this.sessionLogger.trace({ agentId, err: error }, "startAgentStream: iterator threw");
+        this.sessionLogger.trace(
+          { agentId, traceKind: "session_iterator_error", err: error },
+          "startAgentStream: iterator threw",
+        );
         this.handleAgentRunError(agentId, error, "Agent stream failed");
       }
     })();
@@ -1136,7 +1152,7 @@ export class Session {
       this.agentTools = (await this.agentMcpClient.tools()) as ToolSet;
       const agentToolCount = Object.keys(this.agentTools ?? {}).length;
       this.sessionLogger.trace(
-        { agentToolCount },
+        { traceKind: "session_mcp_init", agentToolCount },
         `Agent MCP initialized with ${agentToolCount} tools`,
       );
     } catch (error) {
@@ -1210,6 +1226,17 @@ export class Session {
     this.unsubscribeAgentEvents = this.agentManager.subscribe(
       (event) => {
         if (event.type === "agent_state") {
+          this.sessionLogger.trace(
+            {
+              agentId: event.agent.id,
+              provider: event.agent.provider,
+              sessionId: event.agent.persistence?.sessionId ?? undefined,
+              turnId: event.agent.activeForegroundTurnId ?? undefined,
+              traceKind: "session_forward",
+              lifecycle: event.agent.lifecycle,
+            },
+            "Session forwarding agent update",
+          );
           void this.forwardAgentUpdate(event.agent);
           return;
         }
@@ -1260,6 +1287,18 @@ export class Session {
         if (!serializedEvent) {
           return;
         }
+        this.sessionLogger.trace(
+          {
+            agentId: event.agentId,
+            provider: event.event.provider,
+            turnId: (event.event as { turnId?: string }).turnId,
+            traceKind: "session_forward",
+            seq: event.seq,
+            epoch: event.epoch,
+            event: event.event,
+          },
+          "Session forwarding agent stream",
+        );
 
         const payload = {
           agentId: event.agentId,
@@ -1612,7 +1651,11 @@ export class Session {
     }
     try {
       this.sessionLogger.trace(
-        { messageType: msg.type, payloadBytes: JSON.stringify(msg).length },
+        {
+          traceKind: "session_inbound",
+          messageType: msg.type,
+          payloadBytes: JSON.stringify(msg).length,
+        },
         "inbound message",
       );
       try {
@@ -7180,7 +7223,12 @@ export class Session {
 
       const prompt = this.buildAgentPrompt(msg.text, msg.images, msg.attachments);
       this.sessionLogger.trace(
-        { agentId, messageId: msg.messageId, textPrefix: msg.text.slice(0, 80) },
+        {
+          agentId,
+          traceKind: "session_send_agent_message",
+          messageId: msg.messageId,
+          textPrefix: msg.text.slice(0, 80),
+        },
         "send_agent_message_request: dispatching shared sendPromptToAgent",
       );
       let dispatchResult: { outOfBand: boolean };
@@ -7966,7 +8014,11 @@ export class Session {
    */
   private emit(msg: SessionOutboundMessage): void {
     this.sessionLogger.trace(
-      { messageType: msg.type, payloadBytes: JSON.stringify(msg).length },
+      {
+        traceKind: "session_outbound",
+        messageType: msg.type,
+        payloadBytes: JSON.stringify(msg).length,
+      },
       "outbound message",
     );
     if (
@@ -8035,7 +8087,7 @@ export class Session {
    * Clean up session resources
    */
   public async cleanup(): Promise<void> {
-    this.sessionLogger.trace("Cleaning up");
+    this.sessionLogger.trace({ traceKind: "session_lifecycle" }, "Cleaning up");
 
     if (this.unsubscribeAgentEvents) {
       this.unsubscribeAgentEvents();

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -119,16 +119,17 @@ import {
   StructuredAgentResponseError,
   generateStructuredAgentResponseWithFallback,
 } from "./agent/agent-response-loop.js";
-import type {
-  AgentPersistenceHandle,
-  AgentPermissionResponse,
-  AgentProvider,
-  AgentPromptContentBlock,
-  AgentPromptInput,
-  AgentRunOptions,
-  AgentSessionConfig,
-  AgentStreamEvent,
-  ProviderSnapshotEntry,
+import {
+  getAgentStreamEventTurnId,
+  type AgentPersistenceHandle,
+  type AgentPermissionResponse,
+  type AgentProvider,
+  type AgentPromptContentBlock,
+  type AgentPromptInput,
+  type AgentRunOptions,
+  type AgentSessionConfig,
+  type AgentStreamEvent,
+  type ProviderSnapshotEntry,
 } from "./agent/agent-sdk-types.js";
 import type { StoredAgentRecord } from "./agent/agent-storage.js";
 import type { AgentStorage } from "./agent/agent-storage.js";
@@ -1216,7 +1217,7 @@ export class Session {
             {
               agentId: event.agent.id,
               provider: event.agent.provider,
-              sessionId: event.agent.persistence?.sessionId ?? undefined,
+              providerSessionId: event.agent.persistence?.sessionId ?? undefined,
               turnId: event.agent.activeForegroundTurnId ?? undefined,
               lifecycle: event.agent.lifecycle,
             },
@@ -1276,7 +1277,7 @@ export class Session {
           {
             agentId: event.agentId,
             provider: event.event.provider,
-            turnId: agentStreamEventTurnId(event.event),
+            turnId: getAgentStreamEventTurnId(event.event),
             seq: event.seq,
             epoch: event.epoch,
             event: event.event,
@@ -8687,10 +8688,6 @@ function isValidPullRequestTimelineIdentity(options: {
     return false;
   }
   return isValidGitHubRepoSegment(options.repoOwner) && isValidGitHubRepoSegment(options.repoName);
-}
-
-function agentStreamEventTurnId(event: AgentStreamEvent): string | undefined {
-  return "turnId" in event ? event.turnId : undefined;
 }
 
 function isValidGitHubRepoSegment(value: string): boolean {


### PR DESCRIPTION
## Summary

- reduce production log volume by defaulting daemon file logging to `info`, matching console logging while keeping `PASEO_LOG_LEVEL` as the single override knob
- make daemon log rotation configurable with `PASEO_LOG_ROTATE_SIZE` and `PASEO_LOG_ROTATE_COUNT`, while preserving persisted `log.file.rotate` precedence
- set rotation defaults to `10m x 3` in production and `100m x 10` for `PASEO_NODE_ENV=development`
- add structured trace logging across provider raw events, translated provider events, provider emitted events, AgentManager state transitions, and Session forwarding paths
- fold Claude/OpenCode debug trace facilities into logger trace so stuck-state debugging uses one knob

## Rationale

This gives production quieter `info` logs by default, but lets development turn on very detailed traces with `PASEO_LOG_LEVEL=trace`. The trace lines include `agentId`, `provider`, `sessionId`, `turnId` when known, and `traceKind`, so a stuck-Codex report like “the turn ended but the agent never transitioned idle” can be debugged from one timeline by grepping for the agent/turn and following provider raw events through manager finalization and session forwarding.

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run packages/server/src/server/logger.test.ts --bail=1`
- `npx vitest run packages/server/scripts/supervisor.logging.test.ts --bail=1`
- `npx vitest run packages/server/src/server/session.test.ts --bail=1`
- `npx vitest run packages/server/src/server/agent/agent-manager.test.ts --bail=1`
- `npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts packages/server/src/server/agent/providers/codex/app-server-transport.test.ts --bail=1`
- `npx vitest run packages/server/src/server/agent/providers/claude/agent.test.ts --bail=1`
- `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1`
- `npx vitest run packages/server/src/server/agent/providers/opencode-agent.test.ts --bail=1`