### PR TITLE
Normalize HEIC image attachments on the client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21769,6 +21769,18 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-image-manipulator": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-14.0.8.tgz",
+      "integrity": "sha512-sXsXjm7rIxLWZe0j2A41J/Ph53PpFJRdyzJ3EQ/qetxLUvS2m3K1sP5xy37px43qCf0l79N/i6XgFgenFV36/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-image-picker": {
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.10.tgz",
@@ -38886,6 +38898,7 @@
         "expo-file-system": "~19.0.17",
         "expo-haptics": "~15.0.7",
         "expo-image": "~3.0.10",
+        "expo-image-manipulator": "~14.0.8",
         "expo-image-picker": "^17.0.8",
         "expo-keep-awake": "^15.0.7",
         "expo-linking": "~8.0.8",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -63,6 +63,7 @@
     "expo-file-system": "~19.0.17",
     "expo-haptics": "~15.0.7",
     "expo-image": "~3.0.10",
+    "expo-image-manipulator": "~14.0.8",
     "expo-image-picker": "^17.0.8",
     "expo-keep-awake": "^15.0.7",
     "expo-linking": "~8.0.8",

--- a/packages/app/src/hooks/image-attachment-picker.native.test.ts
+++ b/packages/app/src/hooks/image-attachment-picker.native.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("expo-image-manipulator", () => ({
+  SaveFormat: { JPEG: "jpeg" },
+  ImageManipulator: {
+    manipulate: (_source: string) => ({
+      async renderAsync() {
+        return {
+          release() {},
+          async saveAsync(options: { format?: string }) {
+            return {
+              uri:
+                options.format === "jpeg"
+                  ? "file:///cache/ImageManipulator/safe-picked.jpg"
+                  : "file:///cache/ImageManipulator/unsafe-picked.png",
+              width: 100,
+              height: 100,
+            };
+          },
+        };
+      },
+      release() {},
+    }),
+  },
+}));
+
+import { normalizePickedImageAssets } from "./image-attachment-picker.native";
+
+describe("native image attachment picker", () => {
+  it("turns a native picked HEIC-like asset into a JPEG attachment input", async () => {
+    const result = await normalizePickedImageAssets([
+      {
+        uri: "file:///photos/IMG_0001.HEIC",
+        mimeType: "image/png",
+        fileName: "picked.png",
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        source: { kind: "file_uri", uri: "file:///cache/ImageManipulator/safe-picked.jpg" },
+        mimeType: "image/jpeg",
+        fileName: "picked.jpg",
+      },
+    ]);
+  });
+});

--- a/packages/app/src/hooks/image-attachment-picker.native.test.ts
+++ b/packages/app/src/hooks/image-attachment-picker.native.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("expo-image-manipulator", () => ({
-  SaveFormat: { JPEG: "jpeg" },
+  SaveFormat: { PNG: "png" },
   ImageManipulator: {
     manipulate: (_source: string) => ({
       async renderAsync() {
@@ -10,9 +10,9 @@ vi.mock("expo-image-manipulator", () => ({
           async saveAsync(options: { format?: string }) {
             return {
               uri:
-                options.format === "jpeg"
-                  ? "file:///cache/ImageManipulator/safe-picked.jpg"
-                  : "file:///cache/ImageManipulator/unsafe-picked.png",
+                options.format === "png"
+                  ? "file:///cache/ImageManipulator/safe-picked.png"
+                  : "file:///cache/ImageManipulator/unsafe-picked.jpg",
               width: 100,
               height: 100,
             };
@@ -27,7 +27,35 @@ vi.mock("expo-image-manipulator", () => ({
 import { normalizePickedImageAssets } from "./image-attachment-picker.native";
 
 describe("native image attachment picker", () => {
-  it("turns a native picked HEIC-like asset into a JPEG attachment input", async () => {
+  it("preserves native picked JPEG and PNG attachment inputs", async () => {
+    const result = await normalizePickedImageAssets([
+      {
+        uri: "file:///photos/IMG_0001.JPG",
+        mimeType: "image/jpeg",
+        fileName: "picked.jpeg",
+      },
+      {
+        uri: "file:///photos/screenshot.png",
+        mimeType: "image/png",
+        fileName: "screenshot.png",
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        source: { kind: "file_uri", uri: "file:///photos/IMG_0001.JPG" },
+        mimeType: "image/jpeg",
+        fileName: "picked.jpg",
+      },
+      {
+        source: { kind: "file_uri", uri: "file:///photos/screenshot.png" },
+        mimeType: "image/png",
+        fileName: "screenshot.png",
+      },
+    ]);
+  });
+
+  it("turns a native picked HEIC-like asset into a PNG attachment input", async () => {
     const result = await normalizePickedImageAssets([
       {
         uri: "file:///photos/IMG_0001.HEIC",
@@ -38,9 +66,9 @@ describe("native image attachment picker", () => {
 
     expect(result).toEqual([
       {
-        source: { kind: "file_uri", uri: "file:///cache/ImageManipulator/safe-picked.jpg" },
-        mimeType: "image/jpeg",
-        fileName: "picked.jpg",
+        source: { kind: "file_uri", uri: "file:///cache/ImageManipulator/safe-picked.png" },
+        mimeType: "image/png",
+        fileName: "picked.png",
       },
     ]);
   });

--- a/packages/app/src/hooks/image-attachment-picker.native.ts
+++ b/packages/app/src/hooks/image-attachment-picker.native.ts
@@ -1,0 +1,61 @@
+import { ImageManipulator, SaveFormat } from "expo-image-manipulator";
+
+export type PickedImageSource = { kind: "file_uri"; uri: string } | { kind: "blob"; blob: Blob };
+
+export interface PickedImageAttachmentInput {
+  source: PickedImageSource;
+  mimeType?: string | null;
+  fileName?: string | null;
+}
+
+export interface ExpoImagePickerAssetLike {
+  uri: string;
+  mimeType?: string | null;
+  fileName?: string | null;
+  file?: File | null;
+}
+
+function replaceWithJpegExtension(fileName: string | null | undefined): string | null {
+  if (!fileName) {
+    return null;
+  }
+
+  return fileName.replace(/\.[^./\\]+$/, "") + ".jpg";
+}
+
+async function exportPickedImageAsJpeg(uri: string): Promise<string> {
+  const context = ImageManipulator.manipulate(uri);
+  let image: Awaited<ReturnType<typeof context.renderAsync>> | null = null;
+
+  try {
+    image = await context.renderAsync();
+    const result = await image.saveAsync({
+      compress: 0.92,
+      format: SaveFormat.JPEG,
+    });
+    return result.uri;
+  } finally {
+    image?.release();
+    context.release();
+  }
+}
+
+export async function normalizePickedImageAssets(
+  assets: readonly ExpoImagePickerAssetLike[],
+): Promise<PickedImageAttachmentInput[]> {
+  return await Promise.all(
+    assets.map(async (asset) => {
+      const convertedUri = await exportPickedImageAsJpeg(asset.uri);
+
+      return {
+        source: { kind: "file_uri", uri: convertedUri },
+        mimeType: "image/jpeg",
+        fileName: replaceWithJpegExtension(asset.fileName),
+      };
+    }),
+  );
+}
+
+export async function openImagePathsWithDesktopDialog(): Promise<string[]> {
+  throw new Error("Desktop dialog API is not available on native.");
+}

--- a/packages/app/src/hooks/image-attachment-picker.native.ts
+++ b/packages/app/src/hooks/image-attachment-picker.native.ts
@@ -15,23 +15,82 @@ export interface ExpoImagePickerAssetLike {
   file?: File | null;
 }
 
-function replaceWithJpegExtension(fileName: string | null | undefined): string | null {
+interface SupportedPickedImageFormat {
+  mimeType: "image/jpeg" | "image/png";
+  extension: "jpg" | "png";
+}
+
+const JPEG_FORMAT: SupportedPickedImageFormat = {
+  mimeType: "image/jpeg",
+  extension: "jpg",
+};
+
+const PNG_FORMAT: SupportedPickedImageFormat = {
+  mimeType: "image/png",
+  extension: "png",
+};
+
+function extensionFromPath(path: string | null | undefined): string | null {
+  const match = path?.match(/\.([a-z0-9]+)(?:[?#].*)?$/i);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+function supportedFormatForExtension(extension: string | null): SupportedPickedImageFormat | null {
+  if (extension === "jpg" || extension === "jpeg") {
+    return JPEG_FORMAT;
+  }
+  if (extension === "png") {
+    return PNG_FORMAT;
+  }
+  return null;
+}
+
+function supportedFormatForMimeType(
+  mimeType: string | null | undefined,
+): SupportedPickedImageFormat | null {
+  const normalizedMimeType = mimeType?.toLowerCase();
+  if (normalizedMimeType === "image/jpeg" || normalizedMimeType === "image/jpg") {
+    return JPEG_FORMAT;
+  }
+  if (normalizedMimeType === "image/png") {
+    return PNG_FORMAT;
+  }
+  return null;
+}
+
+function pickedAssetSupportedFormat(
+  asset: ExpoImagePickerAssetLike,
+): SupportedPickedImageFormat | null {
+  const uriExtension = extensionFromPath(asset.uri);
+  if (uriExtension) {
+    return supportedFormatForExtension(uriExtension);
+  }
+
+  return (
+    supportedFormatForExtension(extensionFromPath(asset.fileName)) ??
+    supportedFormatForMimeType(asset.mimeType)
+  );
+}
+
+function replaceFileExtension(
+  fileName: string | null | undefined,
+  extension: SupportedPickedImageFormat["extension"],
+): string | null {
   if (!fileName) {
     return null;
   }
 
-  return fileName.replace(/\.[^./\\]+$/, "") + ".jpg";
+  return fileName.replace(/\.[^./\\]+$/, "") + `.${extension}`;
 }
 
-async function exportPickedImageAsJpeg(uri: string): Promise<string> {
+async function exportPickedImageAsPng(uri: string): Promise<string> {
   const context = ImageManipulator.manipulate(uri);
   let image: Awaited<ReturnType<typeof context.renderAsync>> | null = null;
 
   try {
     image = await context.renderAsync();
     const result = await image.saveAsync({
-      compress: 0.92,
-      format: SaveFormat.JPEG,
+      format: SaveFormat.PNG,
     });
     return result.uri;
   } finally {
@@ -45,12 +104,21 @@ export async function normalizePickedImageAssets(
 ): Promise<PickedImageAttachmentInput[]> {
   return await Promise.all(
     assets.map(async (asset) => {
-      const convertedUri = await exportPickedImageAsJpeg(asset.uri);
+      const supportedFormat = pickedAssetSupportedFormat(asset);
+      if (supportedFormat) {
+        return {
+          source: { kind: "file_uri", uri: asset.uri },
+          mimeType: supportedFormat.mimeType,
+          fileName: replaceFileExtension(asset.fileName, supportedFormat.extension),
+        };
+      }
+
+      const convertedUri = await exportPickedImageAsPng(asset.uri);
 
       return {
         source: { kind: "file_uri", uri: convertedUri },
-        mimeType: "image/jpeg",
-        fileName: replaceWithJpegExtension(asset.fileName),
+        mimeType: PNG_FORMAT.mimeType,
+        fileName: replaceFileExtension(asset.fileName, PNG_FORMAT.extension),
       };
     }),
   );


### PR DESCRIPTION
## Summary
- Normalize native image picker results before attachment persistence so unsupported mobile picks, including HEIC/HEIF, are exported to supported image bytes before the store sees them.
- Preserve picked JPEG as `image/jpeg` and picked PNG as `image/png`. Native picked images that are neither JPEG nor PNG are exported through `expo-image-manipulator` as PNG to keep the conversion lossless and preserve alpha.
- Keep attachment persistence unchanged: the attachment store persists the source it is given, and the normalization lives at the native picker boundary.

Fixes #700

## Boundary and platform behavior
- `use-image-attachment-picker.ts` imports `@/hooks/image-attachment-picker`. On native, Metro resolves that import to `image-attachment-picker.native.ts`; web/Electron continue to use the base `image-attachment-picker.ts` implementation.
- iOS/Android native: picked JPEG/PNG assets pass through with corrected MIME/extension metadata. Other picked image formats are exported to PNG before persistence.
- Web/Electron: no generic byte sniffing or transcoding was added. The existing base picker implementation remains in use.
- `openImagePathsWithDesktopDialog` remains in the base/web implementation. Native gets `image-attachment-picker.native.ts` instead, so the desktop dialog path is not used on native.

## Verification
- `npx vitest run packages/app/src/hooks/image-attachment-picker.test.ts packages/app/src/hooks/image-attachment-picker.native.test.ts packages/app/src/attachments/service.test.ts --bail=1`
- `npm run format`
- `npm run lint -- packages/app/src/hooks/image-attachment-picker.native.ts packages/app/src/hooks/image-attachment-picker.native.test.ts packages/app/src/hooks/image-attachment-picker.ts packages/app/src/hooks/image-attachment-picker.test.ts`
- `npm run typecheck --workspace=@getpaseo/app`
- Pre-commit also ran format check, targeted lint, and workspace typecheck.