### PR TITLE
Fix iPad sidebar safe area background

### DIFF
--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -791,10 +791,13 @@ function DesktopSidebar({
 
   const paddingTopSpacerStyle = useMemo(() => ({ height: padding.top }), [padding.top]);
   const desktopSidebarStyle = useMemo(
-    () => [staticStyles.desktopSidebar, resizeAnimatedStyle, { paddingTop: insetsTop }],
-    [resizeAnimatedStyle, insetsTop],
+    () => [staticStyles.desktopSidebar, resizeAnimatedStyle],
+    [resizeAnimatedStyle],
   );
-  const desktopSidebarBorderStyle = useMemo(() => [styles.desktopSidebarBorder, { flex: 1 }], []);
+  const desktopSidebarBorderStyle = useMemo(
+    () => [styles.desktopSidebarBorder, { flex: 1, paddingTop: insetsTop }],
+    [insetsTop],
+  );
   const resizeHandleStyle = useMemo(
     () => [styles.resizeHandle, isWeb && ({ cursor: "col-resize" } as object)],
     [],


### PR DESCRIPTION
## Summary

- Moves the desktop/sidebar top safe-area padding onto the sidebar container that already paints `surfaceSidebar`
- Keeps the Reanimated outer wrapper focused on width animation only
- Fixes the white status-bar strip above the main sidebar on iPad wide layout

Fixes #936

## Testing

- `npm run format:files -- packages/app/src/components/left-sidebar.tsx`
- `npm run lint -- packages/app/src/components/left-sidebar.tsx`
- `npm run typecheck --workspace=@getpaseo/app`
- Pre-commit: `npm run typecheck --workspaces --if-present`

## Notes

Real-device before/after context is attached to #936.