### PR TITLE
ci(nix): smoke-test daemon boot, build desktop derivation

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -42,3 +42,58 @@ jobs:
 
       - name: Build Nix package
         run: nix build .#default -o result
+
+      - name: Smoke Nix daemon
+        run: |
+          set -euo pipefail
+
+          export PASEO_HOME
+          PASEO_HOME="$(mktemp -d)"
+          export PASEO_LISTEN=127.0.0.1:6767
+
+          WRAPPER_LOG="$PASEO_HOME/paseo-server-wrapper.log"
+
+          cleanup() {
+            if [[ -n "${DAEMON_PID:-}" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+              kill "$DAEMON_PID"
+              wait "$DAEMON_PID" || true
+            fi
+            rm -rf "$PASEO_HOME"
+          }
+          trap cleanup EXIT
+
+          ./result/bin/paseo-server --no-relay >"$WRAPPER_LOG" 2>&1 &
+          DAEMON_PID=$!
+
+          deadline=$((SECONDS + 30))
+          while (( SECONDS < deadline )); do
+            if STATUS_JSON="$(./result/bin/paseo daemon status --json)" \
+              && jq -e '.connectedDaemon == "reachable"' <<<"$STATUS_JSON" >/dev/null; then
+              echo "$STATUS_JSON"
+              exit 0
+            fi
+
+            if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+              echo "Nix daemon exited before becoming reachable."
+              break
+            fi
+
+            sleep 1
+          done
+
+          echo "::group::daemon.log"
+          cat "$PASEO_HOME/daemon.log" 2>/dev/null || echo "<missing>"
+          echo "::endgroup::"
+
+          echo "::group::paseo-server stdout/stderr"
+          cat "$WRAPPER_LOG" 2>/dev/null || echo "<missing>"
+          echo "::endgroup::"
+
+          echo "::group::paseo daemon status"
+          ./result/bin/paseo daemon status || true
+          echo "::endgroup::"
+
+          exit 1
+
+      - name: Build Nix desktop package
+        run: nix build .#desktop -o result-desktop


### PR DESCRIPTION
- Adds a Nix CI smoke step that boots the packaged daemon with an isolated PASEO_HOME and verifies the packaged CLI can reach it.\n- Dumps daemon, wrapper, and status logs on failure so broken Nix-built daemons fail PRs with useful context.\n- Builds the Linux desktop derivation too, covering the expanded Nix surface without adding module eval scope here.