### PR TITLE
Fix native diff row expansion

### DIFF
--- a/packages/app/src/utils/diff-highlighter.test.ts
+++ b/packages/app/src/utils/diff-highlighter.test.ts
@@ -185,6 +185,18 @@ describe("parseDiff", () => {
     expect(hunk.lines[3].content).toBe("const bar = 3;");
   });
 
+  it("parses no-prefix git diff headers", () => {
+    const files = parseDiff(
+      SIMPLE_DIFF.replace("a/example.ts b/example.ts", "example.ts example.ts"),
+    );
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("example.ts");
+    expect(files[0].additions).toBe(1);
+    expect(files[0].deletions).toBe(1);
+    expect(files[0].hunks).toHaveLength(1);
+  });
+
   it("parses a diff with multiple hunks", () => {
     const files = parseDiff(MULTI_HUNK_DIFF);
 

--- a/packages/app/src/utils/diff-highlighter.test.ts
+++ b/packages/app/src/utils/diff-highlighter.test.ts
@@ -187,7 +187,9 @@ describe("parseDiff", () => {
 
   it("parses no-prefix git diff headers", () => {
     const files = parseDiff(
-      SIMPLE_DIFF.replace("a/example.ts b/example.ts", "example.ts example.ts"),
+      SIMPLE_DIFF.replace("a/example.ts b/example.ts", "example.ts example.ts")
+        .replace("--- a/example.ts", "--- example.ts")
+        .replace("+++ b/example.ts", "+++ example.ts"),
     );
 
     expect(files).toHaveLength(1);
@@ -195,6 +197,44 @@ describe("parseDiff", () => {
     expect(files[0].additions).toBe(1);
     expect(files[0].deletions).toBe(1);
     expect(files[0].hunks).toHaveLength(1);
+  });
+
+  it("parses paths with spaces", () => {
+    const files = parseDiff(SIMPLE_DIFF.replaceAll("example.ts", "file with space.ts"));
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("file with space.ts");
+    expect(files[0].hunks).toHaveLength(1);
+  });
+
+  it("parses no-prefix paths with spaces", () => {
+    const files = parseDiff(
+      SIMPLE_DIFF.replaceAll("example.ts", "file with space.ts")
+        .replace(
+          "a/file with space.ts b/file with space.ts",
+          "file with space.ts file with space.ts",
+        )
+        .replace("--- a/file with space.ts", "--- file with space.ts")
+        .replace("+++ b/file with space.ts", "+++ file with space.ts"),
+    );
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("file with space.ts");
+    expect(files[0].hunks).toHaveLength(1);
+  });
+
+  it("preserves no-prefix paths that start with a or b", () => {
+    const files = parseDiff(
+      `${SIMPLE_DIFF.replace(
+        "diff --git a/example.ts b/example.ts",
+        "diff --git a/example.ts a/example.ts",
+      ).replace("--- a/example.ts\n+++ b/example.ts", "--- a/example.ts\n+++ a/example.ts")}
+${SIMPLE_DIFF.replaceAll("example.ts", "other.ts")
+  .replace("diff --git a/other.ts b/other.ts", "diff --git b/other.ts b/other.ts")
+  .replace("--- a/other.ts\n+++ b/other.ts", "--- b/other.ts\n+++ b/other.ts")}`,
+    );
+
+    expect(files.map((file) => file.path)).toEqual(["a/example.ts", "b/other.ts"]);
   });
 
   it("parses a diff with multiple hunks", () => {

--- a/packages/app/src/utils/diff-highlighter.ts
+++ b/packages/app/src/utils/diff-highlighter.ts
@@ -30,17 +30,40 @@ function isDiffMetadataLine(line: string): boolean {
   return DIFF_METADATA_PREFIXES.some((prefix) => line.startsWith(prefix));
 }
 
-// Git's default patch headers use a/path and b/path, while diff.noprefix emits
-// plain paths. Normalize both forms so parsed hunks match checkout file entries.
-function stripDiffPathPrefix(path: string): string {
-  return path.startsWith("a/") || path.startsWith("b/") ? path.slice(2) : path;
+// Git's default patch headers use paired a/path and b/path prefixes, while
+// diff.noprefix emits plain paths that may legitimately start with a/ or b/.
+function usesDiffPathPrefixes(oldPath: string, newPath: string): boolean {
+  return oldPath.startsWith("a/") && newPath.startsWith("b/");
 }
 
-function extractDiffPath(firstLine: string): string {
+function extractPathFromMetadata(lines: string[], prefix: "--- " | "+++ "): string | null {
+  const line = lines.find((candidate) => candidate.startsWith(prefix));
+  if (!line) {
+    return null;
+  }
+
+  const path = line.slice(prefix.length).replace(/\t.*$/, "").trimEnd();
+  return path === "/dev/null" ? null : path;
+}
+
+function extractDiffPath(lines: string[]): string {
+  const firstLine = lines[0] ?? "";
+  const prefixedPathMatch = firstLine.match(/^a\/(.+) b\/(.+)$/);
+  if (prefixedPathMatch) {
+    return prefixedPathMatch[2];
+  }
+
+  const metadataPath =
+    extractPathFromMetadata(lines, "+++ ") ?? extractPathFromMetadata(lines, "--- ");
+  if (metadataPath) {
+    return metadataPath;
+  }
+
   const pathMatch = firstLine.match(/^(\S+)\s+(\S+)$/);
   if (pathMatch) {
     const [, oldPath, newPath] = pathMatch;
-    return stripDiffPathPrefix(newPath === "/dev/null" ? oldPath : newPath);
+    const path = newPath === "/dev/null" ? oldPath : newPath;
+    return usesDiffPathPrefixes(oldPath, newPath) ? path.slice(2) : path;
   }
   return "unknown";
 }
@@ -121,11 +144,10 @@ export function parseDiff(diffText: string): ParsedDiffFile[] {
 
   for (const section of fileSections) {
     const lines = section.split("\n");
-    const firstLine = lines[0];
 
     const isNew = section.includes("new file mode") || section.includes("--- /dev/null");
     const isDeleted = section.includes("deleted file mode") || section.includes("+++ /dev/null");
-    const path = extractDiffPath(firstLine);
+    const path = extractDiffPath(lines);
     const { hunks, additions, deletions } = parseHunks(lines);
 
     files.push({ path, isNew, isDeleted, additions, deletions, hunks });

--- a/packages/app/src/utils/diff-highlighter.ts
+++ b/packages/app/src/utils/diff-highlighter.ts
@@ -30,14 +30,17 @@ function isDiffMetadataLine(line: string): boolean {
   return DIFF_METADATA_PREFIXES.some((prefix) => line.startsWith(prefix));
 }
 
+// Git's default patch headers use a/path and b/path, while diff.noprefix emits
+// plain paths. Normalize both forms so parsed hunks match checkout file entries.
+function stripDiffPathPrefix(path: string): string {
+  return path.startsWith("a/") || path.startsWith("b/") ? path.slice(2) : path;
+}
+
 function extractDiffPath(firstLine: string): string {
-  const pathMatch = firstLine.match(/a\/(.*?) b\//);
+  const pathMatch = firstLine.match(/^(\S+)\s+(\S+)$/);
   if (pathMatch) {
-    return pathMatch[1];
-  }
-  const newFileMatch = firstLine.match(/b\/(.+)$/);
-  if (newFileMatch) {
-    return newFileMatch[1];
+    const [, oldPath, newPath] = pathMatch;
+    return stripDiffPathPrefix(newPath === "/dev/null" ? oldPath : newPath);
   }
   return "unknown";
 }

--- a/packages/server/src/server/utils/diff-highlighter.test.ts
+++ b/packages/server/src/server/utils/diff-highlighter.test.ts
@@ -188,6 +188,18 @@ describe("parseDiff", () => {
     expect(hunk.lines[3].content).toBe("const bar = 3;");
   });
 
+  it("parses no-prefix git diff headers", () => {
+    const files = parseDiff(
+      SIMPLE_DIFF.replace("a/example.ts b/example.ts", "example.ts example.ts"),
+    );
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("example.ts");
+    expect(files[0].additions).toBe(1);
+    expect(files[0].deletions).toBe(1);
+    expect(files[0].hunks).toHaveLength(1);
+  });
+
   it("parses a diff with multiple hunks", () => {
     const files = parseDiff(MULTI_HUNK_DIFF);
 

--- a/packages/server/src/server/utils/diff-highlighter.test.ts
+++ b/packages/server/src/server/utils/diff-highlighter.test.ts
@@ -190,7 +190,9 @@ describe("parseDiff", () => {
 
   it("parses no-prefix git diff headers", () => {
     const files = parseDiff(
-      SIMPLE_DIFF.replace("a/example.ts b/example.ts", "example.ts example.ts"),
+      SIMPLE_DIFF.replace("a/example.ts b/example.ts", "example.ts example.ts")
+        .replace("--- a/example.ts", "--- example.ts")
+        .replace("+++ b/example.ts", "+++ example.ts"),
     );
 
     expect(files).toHaveLength(1);
@@ -198,6 +200,44 @@ describe("parseDiff", () => {
     expect(files[0].additions).toBe(1);
     expect(files[0].deletions).toBe(1);
     expect(files[0].hunks).toHaveLength(1);
+  });
+
+  it("parses paths with spaces", () => {
+    const files = parseDiff(SIMPLE_DIFF.replaceAll("example.ts", "file with space.ts"));
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("file with space.ts");
+    expect(files[0].hunks).toHaveLength(1);
+  });
+
+  it("parses no-prefix paths with spaces", () => {
+    const files = parseDiff(
+      SIMPLE_DIFF.replaceAll("example.ts", "file with space.ts")
+        .replace(
+          "a/file with space.ts b/file with space.ts",
+          "file with space.ts file with space.ts",
+        )
+        .replace("--- a/file with space.ts", "--- file with space.ts")
+        .replace("+++ b/file with space.ts", "+++ file with space.ts"),
+    );
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("file with space.ts");
+    expect(files[0].hunks).toHaveLength(1);
+  });
+
+  it("preserves no-prefix paths that start with a or b", () => {
+    const files = parseDiff(
+      `${SIMPLE_DIFF.replace(
+        "diff --git a/example.ts b/example.ts",
+        "diff --git a/example.ts a/example.ts",
+      ).replace("--- a/example.ts\n+++ b/example.ts", "--- a/example.ts\n+++ a/example.ts")}
+${SIMPLE_DIFF.replaceAll("example.ts", "other.ts")
+  .replace("diff --git a/other.ts b/other.ts", "diff --git b/other.ts b/other.ts")
+  .replace("--- a/other.ts\n+++ b/other.ts", "--- b/other.ts\n+++ b/other.ts")}`,
+    );
+
+    expect(files.map((file) => file.path)).toEqual(["a/example.ts", "b/other.ts"]);
   });
 
   it("parses a diff with multiple hunks", () => {

--- a/packages/server/src/server/utils/diff-highlighter.ts
+++ b/packages/server/src/server/utils/diff-highlighter.ts
@@ -39,17 +39,40 @@ interface ParseAndHighlightDiffOptions {
 /**
  * Parse a unified diff into structured data
  */
-// Git's default patch headers use a/path and b/path, while diff.noprefix emits
-// plain paths. Normalize both forms so parsed hunks match checkout file entries.
-function stripDiffPathPrefix(path: string): string {
-  return path.startsWith("a/") || path.startsWith("b/") ? path.slice(2) : path;
+// Git's default patch headers use paired a/path and b/path prefixes, while
+// diff.noprefix emits plain paths that may legitimately start with a/ or b/.
+function usesDiffPathPrefixes(oldPath: string, newPath: string): boolean {
+  return oldPath.startsWith("a/") && newPath.startsWith("b/");
 }
 
-function extractPathFromDiffHeader(firstLine: string): string {
+function extractPathFromMetadata(lines: string[], prefix: "--- " | "+++ "): string | null {
+  const line = lines.find((candidate) => candidate.startsWith(prefix));
+  if (!line) {
+    return null;
+  }
+
+  const path = line.slice(prefix.length).replace(/\t.*$/, "").trimEnd();
+  return path === "/dev/null" ? null : path;
+}
+
+function extractPathFromDiffHeader(lines: string[]): string {
+  const firstLine = lines[0] ?? "";
+  const prefixedPathMatch = firstLine.match(/^a\/(.+) b\/(.+)$/);
+  if (prefixedPathMatch) {
+    return prefixedPathMatch[2];
+  }
+
+  const metadataPath =
+    extractPathFromMetadata(lines, "+++ ") ?? extractPathFromMetadata(lines, "--- ");
+  if (metadataPath) {
+    return metadataPath;
+  }
+
   const pathMatch = firstLine.match(/^(\S+)\s+(\S+)$/);
   if (pathMatch) {
     const [, oldPath, newPath] = pathMatch;
-    return stripDiffPathPrefix(newPath === "/dev/null" ? oldPath : newPath);
+    const path = newPath === "/dev/null" ? oldPath : newPath;
+    return usesDiffPathPrefixes(oldPath, newPath) ? path.slice(2) : path;
   }
   return "unknown";
 }
@@ -130,11 +153,10 @@ export function parseDiff(diffText: string): ParsedDiffFile[] {
 
   for (const section of fileSections) {
     const lines = section.split("\n");
-    const firstLine = lines[0];
 
     const isNew = section.includes("new file mode") || section.includes("--- /dev/null");
     const isDeleted = section.includes("deleted file mode") || section.includes("+++ /dev/null");
-    const path = extractPathFromDiffHeader(firstLine);
+    const path = extractPathFromDiffHeader(lines);
 
     const { hunks, additions, deletions } = parseSectionBody(lines);
 

--- a/packages/server/src/server/utils/diff-highlighter.ts
+++ b/packages/server/src/server/utils/diff-highlighter.ts
@@ -39,11 +39,18 @@ interface ParseAndHighlightDiffOptions {
 /**
  * Parse a unified diff into structured data
  */
+// Git's default patch headers use a/path and b/path, while diff.noprefix emits
+// plain paths. Normalize both forms so parsed hunks match checkout file entries.
+function stripDiffPathPrefix(path: string): string {
+  return path.startsWith("a/") || path.startsWith("b/") ? path.slice(2) : path;
+}
+
 function extractPathFromDiffHeader(firstLine: string): string {
-  const pathMatch = firstLine.match(/a\/(.*?) b\//);
-  if (pathMatch) return pathMatch[1];
-  const newFileMatch = firstLine.match(/b\/(.+)$/);
-  if (newFileMatch) return newFileMatch[1];
+  const pathMatch = firstLine.match(/^(\S+)\s+(\S+)$/);
+  if (pathMatch) {
+    const [, oldPath, newPath] = pathMatch;
+    return stripDiffPathPrefix(newPath === "/dev/null" ? oldPath : newPath);
+  }
   return "unknown";
 }
 

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -313,6 +313,27 @@ const x = 1;
     expect(removedLine?.tokens).toEqual([{ text: "old comment line", style: "comment" }]);
   });
 
+  it("preserves no-prefix structured paths that start with a or b", async () => {
+    mkdirSync(join(repoDir, "a"));
+    mkdirSync(join(repoDir, "b"));
+    commitFile(repoDir, "a/example.ts", "const value = 1;\n", "add a-prefixed path");
+    commitFile(repoDir, "b/other.ts", "const value = 1;\n", "add b-prefixed path");
+    commitFile(repoDir, "file with space.ts", "const value = 1;\n", "add path with space");
+    execFileSync("git", ["config", "diff.noprefix", "true"], { cwd: repoDir });
+
+    writeFileSync(join(repoDir, "a/example.ts"), "const value = 2;\n");
+    writeFileSync(join(repoDir, "b/other.ts"), "const value = 2;\n");
+    writeFileSync(join(repoDir, "file with space.ts"), "const value = 2;\n");
+
+    const diff = await getCheckoutDiff(repoDir, { mode: "uncommitted", includeStructured: true });
+
+    expect(diff.structured?.map((file) => [file.path, file.hunks.length])).toEqual([
+      ["a/example.ts", 1],
+      ["b/other.ts", 1],
+      ["file with space.ts", 1],
+    ]);
+  });
+
   it("returns checkout root metadata for normal repos", async () => {
     const status = await getCheckoutStatus(repoDir);
     expect(status.isGit).toBe(true);


### PR DESCRIPTION
## Summary

- Fix structured diff parsing for git headers without `a/` / `b/` prefixes, e.g. `diff --git path path`.
- Keep support for the normal prefixed form, e.g. `diff --git a/path b/path`.
- Apply the same parser fix to both the server and app parser copies.
- Add regression tests for no-prefix diff headers.

## Root cause

This was not a row press/tap handling issue.

Git patch output usually includes source/destination prefixes:

```diff
diff --git a/packages/app/src/git/diff-pane.tsx b/packages/app/src/git/diff-pane.tsx
```

However, git can emit no-prefix paths when patch output is configured to omit source/destination prefixes. In the affected checkout, `git diff` emitted headers like:

```diff
diff --git packages/app/src/git/diff-pane.tsx packages/app/src/git/diff-pane.tsx
```

The server-side structured diff parser only understood the prefixed `a/... b/...` form. When it saw the no-prefix form, it failed to extract the file path, so checkout diff assembly could not match the parsed hunks back to the file entry.

The row click worked, but the expanded body had no hunks to render, making it look like the row only expanded by about 1px.

The app parser had the same header assumption, so it was updated too to keep parser behavior consistent and avoid the same bug if that parser path is used later.

## How to reproduce

1. In a checkout, configure git diff output to omit source/destination prefixes:

   ```sh
   git config diff.noprefix true
   ```

2. Make any tracked file change.

3. Confirm git now emits no-prefix diff headers:

   ```sh
   git diff --patch --raw
   ```

   The patch header will look like:

   ```diff
   diff --git path/to/file.ts path/to/file.ts
   ```

   instead of:

   ```diff
   diff --git a/path/to/file.ts b/path/to/file.ts
   ```

4. Open the checkout in Paseo and go to the Changes diff panel.

5. Click the changed file row to expand it.

Before this fix, the click was handled but the structured diff had no hunks for that file, so the row appeared to expand only slightly / render an empty body.

After this fix, the same row expands with the expected hunk content.

## Test plan

- [x] `agent-browser` verification with isolated daemon: collapsing removes `diff-file-0-body`; expanding restores a populated body with hunk text.
- [x] Direct `getCheckoutDiff(..., { includeStructured: true })` check: affected file returns populated hunks instead of `hunks: []`.
- [x] `npx vitest run packages/server/src/server/utils/diff-highlighter.test.ts packages/app/src/utils/diff-highlighter.test.ts --bail=1`
- [x] `npm run lint`
- [x] `npm run typecheck`
