### PR TITLE
fix(app): auto-set ref picker from a single attached PR

### DIFF
--- a/packages/app/src/screens/new-workspace-picker-state.test.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { UserComposerAttachment } from "@/attachments/types";
 import type { GitHubSearchItem } from "@server/shared/messages";
 import {
-  derivePickerSelectionFromAttachments,
-  type PickerSelection,
+  deriveAutoPickerItemFromAttachments,
   syncPickerPrAttachment,
 } from "./new-workspace-picker-state";
 
@@ -99,116 +98,34 @@ describe("syncPickerPrAttachment", () => {
   });
 });
 
-describe("derivePickerSelectionFromAttachments", () => {
-  function manualBranch(name: string): PickerSelection {
-    return { item: { kind: "branch", name }, attachedPrNumber: null, source: "manual" };
-  }
-
-  function manualPr(pr: GitHubSearchItem, ownsAttachment: boolean): PickerSelection {
-    return {
-      item: { kind: "github-pr", item: pr },
-      attachedPrNumber: ownsAttachment ? pr.number : null,
-      source: "manual",
-    };
-  }
-
-  function autoPr(pr: GitHubSearchItem): PickerSelection {
-    return {
-      item: { kind: "github-pr", item: pr },
-      attachedPrNumber: null,
-      source: "attachment",
-    };
-  }
-
-  it("returns null when there are no attachments and nothing is selected", () => {
-    expect(derivePickerSelectionFromAttachments({ attachments: [], current: null })).toBeNull();
+describe("deriveAutoPickerItemFromAttachments", () => {
+  it("returns null when there are no attachments", () => {
+    expect(deriveAutoPickerItemFromAttachments([])).toBeNull();
   });
 
-  it("auto-promotes a single PR attachment when nothing is selected", () => {
+  it("returns the PR when exactly one is attached", () => {
     const pr = makePrItem(923, "Nix overridable npm deps hash");
-    const result = derivePickerSelectionFromAttachments({
-      attachments: [prAttachment(pr)],
-      current: null,
+    expect(deriveAutoPickerItemFromAttachments([prAttachment(pr)])).toEqual({
+      kind: "github-pr",
+      item: pr,
     });
-    expect(result).toEqual(autoPr(pr));
   });
 
-  it("does not auto-promote when multiple PRs are attached", () => {
+  it("returns null when multiple PRs are attached", () => {
     const a = makePrItem(101, "A");
     const b = makePrItem(202, "B");
-    expect(
-      derivePickerSelectionFromAttachments({
-        attachments: [prAttachment(a), prAttachment(b)],
-        current: null,
-      }),
-    ).toBeNull();
-  });
-
-  it("preserves a manual branch selection even when a PR is attached", () => {
-    const pr = makePrItem(923, "Nix overridable npm deps hash");
-    const current = manualBranch("main");
-    const result = derivePickerSelectionFromAttachments({
-      attachments: [prAttachment(pr)],
-      current,
-    });
-    expect(result).toBe(current);
-  });
-
-  it("preserves a manual PR selection when other PRs become attached", () => {
-    const picked = makePrItem(101, "Picked");
-    const extra = makePrItem(202, "Extra");
-    const current = manualPr(picked, true);
-    const result = derivePickerSelectionFromAttachments({
-      attachments: [prAttachment(picked), prAttachment(extra)],
-      current,
-    });
-    expect(result).toBe(current);
-  });
-
-  it("keeps the auto-promoted PR while its attachment is still present", () => {
-    const pr = makePrItem(923, "Nix overridable npm deps hash");
-    const current = autoPr(pr);
-    const result = derivePickerSelectionFromAttachments({
-      attachments: [prAttachment(pr)],
-      current,
-    });
-    expect(result).toBe(current);
-  });
-
-  it("clears the auto-promoted selection when its attachment is removed", () => {
-    const pr = makePrItem(923, "Nix overridable npm deps hash");
-    const result = derivePickerSelectionFromAttachments({
-      attachments: [],
-      current: autoPr(pr),
-    });
-    expect(result).toBeNull();
-  });
-
-  it("re-promotes a different PR when the auto-promoted one is replaced", () => {
-    const a = makePrItem(101, "A");
-    const b = makePrItem(202, "B");
-    const result = derivePickerSelectionFromAttachments({
-      attachments: [prAttachment(b)],
-      current: autoPr(a),
-    });
-    expect(result).toEqual(autoPr(b));
-  });
-
-  it("does not auto-promote when the auto-promoted PR is gone and ambiguity arises", () => {
-    const a = makePrItem(101, "A");
-    const b = makePrItem(202, "B");
-    const c = makePrItem(303, "C");
-    const result = derivePickerSelectionFromAttachments({
-      attachments: [prAttachment(b), prAttachment(c)],
-      current: autoPr(a),
-    });
-    expect(result).toBeNull();
+    expect(deriveAutoPickerItemFromAttachments([prAttachment(a), prAttachment(b)])).toBeNull();
   });
 
   it("ignores non-PR attachments", () => {
-    const issue = issueAttachment(44);
-    expect(
-      derivePickerSelectionFromAttachments({ attachments: [issue], current: null }),
-    ).toBeNull();
+    expect(deriveAutoPickerItemFromAttachments([issueAttachment(44)])).toBeNull();
+  });
+
+  it("returns the lone PR even when other non-PR attachments are present", () => {
+    const pr = makePrItem(923, "Nix overridable npm deps hash");
+    expect(deriveAutoPickerItemFromAttachments([issueAttachment(44), prAttachment(pr)])).toEqual({
+      kind: "github-pr",
+      item: pr,
+    });
   });
 });

--- a/packages/app/src/screens/new-workspace-picker-state.test.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { UserComposerAttachment } from "@/attachments/types";
 import type { GitHubSearchItem } from "@server/shared/messages";
-import { syncPickerPrAttachment } from "./new-workspace-picker-state";
+import {
+  derivePickerSelectionFromAttachments,
+  type PickerSelection,
+  syncPickerPrAttachment,
+} from "./new-workspace-picker-state";
 
 function makePrItem(number: number, title: string, headRefName = "feature/x"): GitHubSearchItem {
   return {
@@ -92,5 +96,119 @@ describe("syncPickerPrAttachment", () => {
     });
     expect(result.attachedPrNumber).toBeNull();
     expect(result.attachments).toHaveLength(1);
+  });
+});
+
+describe("derivePickerSelectionFromAttachments", () => {
+  function manualBranch(name: string): PickerSelection {
+    return { item: { kind: "branch", name }, attachedPrNumber: null, source: "manual" };
+  }
+
+  function manualPr(pr: GitHubSearchItem, ownsAttachment: boolean): PickerSelection {
+    return {
+      item: { kind: "github-pr", item: pr },
+      attachedPrNumber: ownsAttachment ? pr.number : null,
+      source: "manual",
+    };
+  }
+
+  function autoPr(pr: GitHubSearchItem): PickerSelection {
+    return {
+      item: { kind: "github-pr", item: pr },
+      attachedPrNumber: null,
+      source: "attachment",
+    };
+  }
+
+  it("returns null when there are no attachments and nothing is selected", () => {
+    expect(derivePickerSelectionFromAttachments({ attachments: [], current: null })).toBeNull();
+  });
+
+  it("auto-promotes a single PR attachment when nothing is selected", () => {
+    const pr = makePrItem(923, "Nix overridable npm deps hash");
+    const result = derivePickerSelectionFromAttachments({
+      attachments: [prAttachment(pr)],
+      current: null,
+    });
+    expect(result).toEqual(autoPr(pr));
+  });
+
+  it("does not auto-promote when multiple PRs are attached", () => {
+    const a = makePrItem(101, "A");
+    const b = makePrItem(202, "B");
+    expect(
+      derivePickerSelectionFromAttachments({
+        attachments: [prAttachment(a), prAttachment(b)],
+        current: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("preserves a manual branch selection even when a PR is attached", () => {
+    const pr = makePrItem(923, "Nix overridable npm deps hash");
+    const current = manualBranch("main");
+    const result = derivePickerSelectionFromAttachments({
+      attachments: [prAttachment(pr)],
+      current,
+    });
+    expect(result).toBe(current);
+  });
+
+  it("preserves a manual PR selection when other PRs become attached", () => {
+    const picked = makePrItem(101, "Picked");
+    const extra = makePrItem(202, "Extra");
+    const current = manualPr(picked, true);
+    const result = derivePickerSelectionFromAttachments({
+      attachments: [prAttachment(picked), prAttachment(extra)],
+      current,
+    });
+    expect(result).toBe(current);
+  });
+
+  it("keeps the auto-promoted PR while its attachment is still present", () => {
+    const pr = makePrItem(923, "Nix overridable npm deps hash");
+    const current = autoPr(pr);
+    const result = derivePickerSelectionFromAttachments({
+      attachments: [prAttachment(pr)],
+      current,
+    });
+    expect(result).toBe(current);
+  });
+
+  it("clears the auto-promoted selection when its attachment is removed", () => {
+    const pr = makePrItem(923, "Nix overridable npm deps hash");
+    const result = derivePickerSelectionFromAttachments({
+      attachments: [],
+      current: autoPr(pr),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("re-promotes a different PR when the auto-promoted one is replaced", () => {
+    const a = makePrItem(101, "A");
+    const b = makePrItem(202, "B");
+    const result = derivePickerSelectionFromAttachments({
+      attachments: [prAttachment(b)],
+      current: autoPr(a),
+    });
+    expect(result).toEqual(autoPr(b));
+  });
+
+  it("does not auto-promote when the auto-promoted PR is gone and ambiguity arises", () => {
+    const a = makePrItem(101, "A");
+    const b = makePrItem(202, "B");
+    const c = makePrItem(303, "C");
+    const result = derivePickerSelectionFromAttachments({
+      attachments: [prAttachment(b), prAttachment(c)],
+      current: autoPr(a),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("ignores non-PR attachments", () => {
+    const issue = issueAttachment(44);
+    expect(
+      derivePickerSelectionFromAttachments({ attachments: [issue], current: null }),
+    ).toBeNull();
   });
 });

--- a/packages/app/src/screens/new-workspace-picker-state.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.ts
@@ -1,6 +1,17 @@
 import type { UserComposerAttachment } from "@/attachments/types";
 import type { PickerItem } from "./new-workspace-picker-item";
 
+export interface PickerSelection {
+  item: PickerItem;
+  // PR number whose attachment the picker created (and therefore owns). `null` when
+  // the picker is on a branch, or when the picker reflects a PR attachment that was
+  // already there (manual dedup or auto-promotion).
+  attachedPrNumber: number | null;
+  // How the selection got there: "manual" if the user clicked it in the ref picker,
+  // "attachment" if it was auto-promoted from a single PR attachment in the composer.
+  source: "manual" | "attachment";
+}
+
 // The picker "owns" at most one PR attachment at a time. When the user selects
 // a different item the previously-owned PR is removed before the new one is added.
 // User-added attachments for other PRs/issues are left untouched.
@@ -32,4 +43,40 @@ export function syncPickerPrAttachment(input: {
   }
 
   return { attachments: nextAttachments, attachedPrNumber };
+}
+
+// Auto-promote a single attached PR into the ref picker. A user who attached
+// exactly one PR and didn't touch the ref picker almost always wants the
+// worktree based on that PR — surface it instead of silently branching off main.
+// Manual picker selections are never overridden. Auto-promoted selections are
+// cleared when their backing attachment goes away.
+export function derivePickerSelectionFromAttachments(input: {
+  attachments: ReadonlyArray<UserComposerAttachment>;
+  current: PickerSelection | null;
+}): PickerSelection | null {
+  if (input.current?.source === "manual") {
+    return input.current;
+  }
+
+  const prAttachments = input.attachments.filter(
+    (attachment): attachment is Extract<UserComposerAttachment, { kind: "github_pr" }> =>
+      attachment.kind === "github_pr",
+  );
+
+  if (input.current?.source === "attachment" && input.current.item.kind === "github-pr") {
+    const currentNumber = input.current.item.item.number;
+    if (prAttachments.some((attachment) => attachment.item.number === currentNumber)) {
+      return input.current;
+    }
+  }
+
+  if (prAttachments.length !== 1) {
+    return null;
+  }
+
+  return {
+    item: { kind: "github-pr", item: prAttachments[0].item },
+    attachedPrNumber: null,
+    source: "attachment",
+  };
 }

--- a/packages/app/src/screens/new-workspace-picker-state.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.ts
@@ -1,17 +1,6 @@
 import type { UserComposerAttachment } from "@/attachments/types";
 import type { PickerItem } from "./new-workspace-picker-item";
 
-export interface PickerSelection {
-  item: PickerItem;
-  // PR number whose attachment the picker created (and therefore owns). `null` when
-  // the picker is on a branch, or when the picker reflects a PR attachment that was
-  // already there (manual dedup or auto-promotion).
-  attachedPrNumber: number | null;
-  // How the selection got there: "manual" if the user clicked it in the ref picker,
-  // "attachment" if it was auto-promoted from a single PR attachment in the composer.
-  source: "manual" | "attachment";
-}
-
 // The picker "owns" at most one PR attachment at a time. When the user selects
 // a different item the previously-owned PR is removed before the new one is added.
 // User-added attachments for other PRs/issues are left untouched.
@@ -45,38 +34,18 @@ export function syncPickerPrAttachment(input: {
   return { attachments: nextAttachments, attachedPrNumber };
 }
 
-// Auto-promote a single attached PR into the ref picker. A user who attached
-// exactly one PR and didn't touch the ref picker almost always wants the
-// worktree based on that PR — surface it instead of silently branching off main.
-// Manual picker selections are never overridden. Auto-promoted selections are
-// cleared when their backing attachment goes away.
-export function derivePickerSelectionFromAttachments(input: {
-  attachments: ReadonlyArray<UserComposerAttachment>;
-  current: PickerSelection | null;
-}): PickerSelection | null {
-  if (input.current?.source === "manual") {
-    return input.current;
+// Suggest a ref picker target derived from composer attachments alone. When the
+// user attaches exactly one PR they almost always want the worktree based on
+// that PR — surface it as the picker's default so the worktree isn't silently
+// branched off main. The caller is responsible for letting manual picks win.
+export function deriveAutoPickerItemFromAttachments(
+  attachments: ReadonlyArray<UserComposerAttachment>,
+): PickerItem | null {
+  let onlyPr: Extract<UserComposerAttachment, { kind: "github_pr" }> | null = null;
+  for (const attachment of attachments) {
+    if (attachment.kind !== "github_pr") continue;
+    if (onlyPr) return null;
+    onlyPr = attachment;
   }
-
-  const prAttachments = input.attachments.filter(
-    (attachment): attachment is Extract<UserComposerAttachment, { kind: "github_pr" }> =>
-      attachment.kind === "github_pr",
-  );
-
-  if (input.current?.source === "attachment" && input.current.item.kind === "github-pr") {
-    const currentNumber = input.current.item.item.number;
-    if (prAttachments.some((attachment) => attachment.item.number === currentNumber)) {
-      return input.current;
-    }
-  }
-
-  if (prAttachments.length !== 1) {
-    return null;
-  }
-
-  return {
-    item: { kind: "github-pr", item: prAttachments[0].item },
-    attachedPrNumber: null,
-    source: "attachment",
-  };
+  return onlyPr ? { kind: "github-pr", item: onlyPr.item } : null;
 }

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -34,9 +34,8 @@ import type { AgentProvider } from "@server/server/agent/agent-sdk-types";
 import { isEmptyWorkspaceSubmission, runCreateEmptyWorkspace } from "./new-workspace-empty";
 import { pickerItemToCheckoutRequest, type PickerItem } from "./new-workspace-picker-item";
 import {
-  derivePickerSelectionFromAttachments,
+  deriveAutoPickerItemFromAttachments,
   syncPickerPrAttachment,
-  type PickerSelection,
 } from "./new-workspace-picker-state";
 
 interface NewWorkspaceScreenProps {
@@ -48,6 +47,22 @@ interface NewWorkspaceScreenProps {
 interface PickerOptionData {
   options: ComboboxOptionType[];
   itemById: Map<string, PickerItem>;
+}
+
+interface PickerSelection {
+  item: PickerItem;
+  attachedPrNumber: number | null;
+}
+
+// Manual picks always win; the auto-promoted item is a fallback so the user
+// doesn't silently get "main" when they meant the PR they just attached.
+function combinePickerSelection(
+  manual: PickerSelection | null,
+  autoItem: PickerItem | null,
+): PickerSelection | null {
+  if (manual) return manual;
+  if (autoItem) return { item: autoItem, attachedPrNumber: null };
+  return null;
 }
 
 const BRANCH_OPTION_PREFIX = "branch:";
@@ -399,7 +414,7 @@ export function NewWorkspaceScreen({
     typeof normalizeWorkspaceDescriptor
   > | null>(null);
   const [pendingAction, setPendingAction] = useState<"chat" | "empty" | null>(null);
-  const [pickerSelection, setPickerSelection] = useState<PickerSelection | null>(null);
+  const [manualPickerSelection, setManualPickerSelection] = useState<PickerSelection | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerSearchQuery, setPickerSearchQuery] = useState("");
   const [debouncedPickerSearchQuery, setDebouncedPickerSearchQuery] = useState("");
@@ -413,7 +428,6 @@ export function NewWorkspaceScreen({
 
   const displayName = displayNameProp?.trim() ?? "";
   const workspace = createdWorkspace;
-  const selectedItem = pickerSelection?.item ?? null;
   const isPending = pendingAction !== null;
   const client = useHostRuntimeClient(serverId);
   const isConnected = useHostRuntimeIsConnected(serverId);
@@ -429,14 +443,12 @@ export function NewWorkspaceScreen({
   });
   const composerState = chatDraft.composerState;
 
-  useEffect(() => {
-    setPickerSelection((current) =>
-      derivePickerSelectionFromAttachments({
-        attachments: chatDraft.attachments,
-        current,
-      }),
-    );
-  }, [chatDraft.attachments]);
+  const autoPickerItem = useMemo(
+    () => deriveAutoPickerItemFromAttachments(chatDraft.attachments),
+    [chatDraft.attachments],
+  );
+  const pickerSelection = combinePickerSelection(manualPickerSelection, autoPickerItem);
+  const selectedItem = pickerSelection?.item ?? null;
 
   const withConnectedClient = useCallback(() => {
     if (!client || !isConnected) {
@@ -533,10 +545,9 @@ export function NewWorkspaceScreen({
         item,
       });
 
-      setPickerSelection({
+      setManualPickerSelection({
         item,
         attachedPrNumber: next.attachedPrNumber,
-        source: "manual",
       });
       if (next.attachments !== chatDraft.attachments) {
         chatDraft.setAttachments(next.attachments);

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -33,7 +33,11 @@ import type { AgentAttachment, GitHubSearchItem } from "@server/shared/messages"
 import type { AgentProvider } from "@server/server/agent/agent-sdk-types";
 import { isEmptyWorkspaceSubmission, runCreateEmptyWorkspace } from "./new-workspace-empty";
 import { pickerItemToCheckoutRequest, type PickerItem } from "./new-workspace-picker-item";
-import { syncPickerPrAttachment } from "./new-workspace-picker-state";
+import {
+  derivePickerSelectionFromAttachments,
+  syncPickerPrAttachment,
+  type PickerSelection,
+} from "./new-workspace-picker-state";
 
 interface NewWorkspaceScreenProps {
   serverId: string;
@@ -44,11 +48,6 @@ interface NewWorkspaceScreenProps {
 interface PickerOptionData {
   options: ComboboxOptionType[];
   itemById: Map<string, PickerItem>;
-}
-
-interface PickerSelection {
-  item: PickerItem;
-  attachedPrNumber: number | null;
 }
 
 const BRANCH_OPTION_PREFIX = "branch:";
@@ -430,6 +429,15 @@ export function NewWorkspaceScreen({
   });
   const composerState = chatDraft.composerState;
 
+  useEffect(() => {
+    setPickerSelection((current) =>
+      derivePickerSelectionFromAttachments({
+        attachments: chatDraft.attachments,
+        current,
+      }),
+    );
+  }, [chatDraft.attachments]);
+
   const withConnectedClient = useCallback(() => {
     if (!client || !isConnected) {
       throw new Error("Host is not connected");
@@ -528,6 +536,7 @@ export function NewWorkspaceScreen({
       setPickerSelection({
         item,
         attachedPrNumber: next.attachedPrNumber,
+        source: "manual",
       });
       if (next.attachments !== chatDraft.attachments) {
         chatDraft.setAttachments(next.attachments);


### PR DESCRIPTION
## Summary

Attaching a PR to the composer on the new-workspace screen used to be a context-only action — the ref picker stayed on the default branch, so the worktree was created off `main` even though the composer chip made it look like a PR checkout. That mismatch is especially confusing for external/fork PRs, where users expect the worktree to be checked out on the PR head with a push remote configured (the same behavior the MCP `create_worktree` tool gives agents).

When exactly one PR is attached and the user hasn't manually picked a ref, auto-promote that PR into the ref picker. Manual picker selections are preserved; auto-promoted ones are cleared when their backing attachment is removed. The user can still pick another ref (or main) explicitly to override.

- New pure helper `derivePickerSelectionFromAttachments` in `new-workspace-picker-state.ts`, covered by unit tests.
- `PickerSelection` gains a `source: "manual" | "attachment"` flag to distinguish auto-promotions from explicit picks.
- `NewWorkspaceScreen` runs the helper as a sync effect on `chatDraft.attachments`.

## Test plan

- [x] `npx vitest run packages/app/src/screens/new-workspace-picker-state.test.ts` — 15 passing
- [x] `npm run typecheck`
- [x] `npm run lint -- <changed files>`
- [ ] Manual: attach a PR in the new-workspace composer → ref picker chip flips to the PR; worktree is created on the PR head with `paseo-pr-<n>` push remote and the PR badge in the sidebar
- [ ] Manual: attach a PR, then manually pick `main` in the ref picker → picker stays on `main` (manual wins)
- [ ] Manual: auto-promoted PR → detach the PR → picker returns to default