### PR TITLE
Add session resume flow

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,7 +86,7 @@ Cross-platform React Native app that connects to one or more daemons.
 
 Commander.js CLI with Docker-style commands. Common agent operations are also exposed at the top level (e.g. `paseo ls`, `paseo run`).
 
-- `paseo agent ls/run/import/attach/logs/stop/delete/send/inspect/wait/archive/reload/update/mode`
+- `paseo agent ls/run/import/resume/attach/logs/stop/delete/send/inspect/wait/archive/reload/update/mode`
 - `paseo daemon start/stop/restart/status/pair/set-password`
 - `paseo chat ls/create/inspect/post/read/wait/delete`
 - `paseo terminal ls/create/capture/send-keys/kill`

--- a/packages/app/e2e/helpers/archive-tab.ts
+++ b/packages/app/e2e/helpers/archive-tab.ts
@@ -244,7 +244,7 @@ export async function closeWorkspaceAgentTab(page: Page, agentId: string): Promi
 export async function expectArchivedAgentFocused(page: Page, agentId: string): Promise<void> {
   await expectWorkspaceTabVisible(page, agentId);
   await expect(
-    page.getByText("This agent is archived").filter({ visible: true }).first(),
+    page.getByText("This session is archived").filter({ visible: true }).first(),
   ).toBeVisible({
     timeout: 30_000,
   });

--- a/packages/app/src/components/archived-agent-callout.tsx
+++ b/packages/app/src/components/archived-agent-callout.tsx
@@ -5,6 +5,7 @@ import Animated from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FOOTER_HEIGHT, MAX_CONTENT_WIDTH } from "@/constants/layout";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+import { useAgentInitialization } from "@/hooks/use-agent-initialization";
 import { useKeyboardShiftStyle } from "@/hooks/use-keyboard-shift-style";
 import { Button } from "@/components/ui/button";
 import type { Theme } from "@/styles/theme";
@@ -18,7 +19,8 @@ export function ArchivedAgentCallout({ serverId, agentId }: ArchivedAgentCallout
   const insets = useSafeAreaInsets();
   const client = useHostRuntimeClient(serverId);
   const isConnected = useHostRuntimeIsConnected(serverId);
-  const [isUnarchiving, setIsUnarchiving] = useState(false);
+  const [isResuming, setIsResuming] = useState(false);
+  const { resumeAgentSession } = useAgentInitialization({ serverId, client });
 
   const { style: keyboardAnimatedStyle } = useKeyboardShiftStyle({ mode: "translate" });
 
@@ -27,30 +29,30 @@ export function ArchivedAgentCallout({ serverId, agentId }: ArchivedAgentCallout
     [insets.bottom, keyboardAnimatedStyle],
   );
 
-  const handleUnarchive = useCallback(async () => {
-    if (!client || !isConnected || isUnarchiving) return;
-    setIsUnarchiving(true);
+  const handleResume = useCallback(async () => {
+    if (!client || !isConnected || isResuming) return;
+    setIsResuming(true);
     try {
-      await client.refreshAgent(agentId);
+      await resumeAgentSession(agentId);
     } catch (error) {
-      console.error("[ArchivedAgentCallout] Failed to unarchive agent:", error);
-      setIsUnarchiving(false);
+      console.error("[ArchivedAgentCallout] Failed to resume agent:", error);
+      setIsResuming(false);
     }
-  }, [client, isConnected, isUnarchiving, agentId]);
+  }, [client, isConnected, isResuming, agentId, resumeAgentSession]);
 
   return (
     <Animated.View style={containerStyle}>
       <View style={styles.inputAreaContainer}>
         <View style={styles.inputAreaContent}>
           <View style={styles.callout}>
-            <Text style={styles.calloutText}>This agent is archived</Text>
+            <Text style={styles.calloutText}>This session is archived</Text>
             <Button
               size="sm"
               variant="secondary"
-              onPress={handleUnarchive}
-              disabled={!isConnected || isUnarchiving}
+              onPress={handleResume}
+              disabled={!isConnected || isResuming}
             >
-              Unarchive
+              {isResuming ? "Resuming..." : "Resume"}
             </Button>
           </View>
         </View>

--- a/packages/app/src/hooks/use-agent-initialization.test.ts
+++ b/packages/app/src/hooks/use-agent-initialization.test.ts
@@ -14,6 +14,7 @@ function makeClient() {
   return {
     fetchAgentTimeline: vi.fn().mockResolvedValue(undefined),
     refreshAgent: vi.fn().mockResolvedValue(undefined),
+    resumeAgentSession: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -111,6 +112,24 @@ describe("useAgentInitialization", () => {
     });
 
     expect(client.refreshAgent).toHaveBeenCalledWith(agentId);
+    expect(client.fetchAgentTimeline).toHaveBeenCalledWith(agentId, {
+      direction: "tail",
+      limit: TIMELINE_FETCH_PAGE_SIZE,
+      projection: "canonical",
+    });
+  });
+
+  it("resume fetches a bounded canonical tail after resuming the agent session", async () => {
+    const client = makeClient();
+    const { result } = renderHook(() =>
+      useAgentInitialization({ serverId, client: client as never }),
+    );
+
+    await act(async () => {
+      await result.current.resumeAgentSession(agentId);
+    });
+
+    expect(client.resumeAgentSession).toHaveBeenCalledWith(agentId);
     expect(client.fetchAgentTimeline).toHaveBeenCalledWith(agentId, {
       direction: "tail",
       limit: TIMELINE_FETCH_PAGE_SIZE,

--- a/packages/app/src/hooks/use-agent-initialization.ts
+++ b/packages/app/src/hooks/use-agent-initialization.ts
@@ -12,12 +12,15 @@ import { TIMELINE_FETCH_PAGE_SIZE } from "@/timeline/timeline-fetch-policy";
 
 const INIT_TIMEOUT_MS = 30_000;
 
+type AgentInitializationClient = Pick<DaemonClient, "fetchAgentTimeline" | "resumeAgentSession"> &
+  Partial<Pick<DaemonClient, "refreshAgent">>;
+
 export function useAgentInitialization({
   serverId,
   client,
 }: {
   serverId: string;
-  client: DaemonClient | null;
+  client: AgentInitializationClient | null;
 }) {
   const setInitializingAgents = useSessionStore((state) => state.setInitializingAgents);
   const setAgentInitializing = useCallback(
@@ -88,15 +91,15 @@ export function useAgentInitialization({
     [client, serverId, setAgentInitializing],
   );
 
-  const refreshAgent = useCallback(
-    async (agentId: string) => {
+  const loadAgentTailAfter = useCallback(
+    async (agentId: string, action: (agentId: string) => Promise<unknown>) => {
       if (!client) {
         throw new Error("Host is not connected");
       }
       setAgentInitializing(agentId, true);
 
       try {
-        await client.refreshAgent(agentId);
+        await action(agentId);
         await client.fetchAgentTimeline(agentId, {
           direction: "tail",
           limit: TIMELINE_FETCH_PAGE_SIZE,
@@ -110,5 +113,28 @@ export function useAgentInitialization({
     [client, setAgentInitializing],
   );
 
-  return { ensureAgentIsInitialized, refreshAgent };
+  const refreshAgent = useCallback(
+    async (agentId: string) => {
+      if (!client?.refreshAgent) {
+        throw new Error("Host is not connected");
+      }
+      const refresh = client.refreshAgent;
+      await loadAgentTailAfter(agentId, (targetAgentId) => refresh(targetAgentId));
+    },
+    [client, loadAgentTailAfter],
+  );
+
+  const resumeAgentSession = useCallback(
+    async (agentId: string) => {
+      if (!client) {
+        throw new Error("Host is not connected");
+      }
+      await loadAgentTailAfter(agentId, (targetAgentId) =>
+        client.resumeAgentSession(targetAgentId),
+      );
+    },
+    [client, loadAgentTailAfter],
+  );
+
+  return { ensureAgentIsInitialized, refreshAgent, resumeAgentSession };
 }

--- a/packages/app/src/screens/workspace/workspace-import-sheet.test.tsx
+++ b/packages/app/src/screens/workspace/workspace-import-sheet.test.tsx
@@ -53,10 +53,6 @@ vi.mock("react-native-unistyles", () => ({
     },
 }));
 
-vi.mock("@/constants/layout", () => ({
-  useIsCompactFormFactor: () => false,
-}));
-
 vi.mock("@/components/provider-icons", () => ({
   getProviderIcon: () => () => null,
 }));
@@ -142,6 +138,8 @@ vi.mock("@/hooks/use-providers-snapshot", () => ({
   }),
 }));
 
+type ImportSessionsClient = Pick<DaemonClient, "fetchRecentProviderSessions" | "importAgent">;
+
 interface RenderOptions {
   visible?: boolean;
   onClose?: () => void;
@@ -152,10 +150,7 @@ interface RenderOptions {
   };
 }
 
-function renderSheet(
-  client: Pick<DaemonClient, "fetchRecentProviderSessions" | "importAgent">,
-  options?: RenderOptions,
-) {
+function renderSheet(client: ImportSessionsClient, options?: RenderOptions) {
   mockSnapshot.current = {
     entries: options?.snapshot?.entries,
     supportsSnapshot: options?.snapshot?.supportsSnapshot ?? false,
@@ -182,20 +177,21 @@ function renderSheet(
   );
 }
 
-function createRecentSessionsClient(
-  fetchRecentProviderSessions: Pick<
-    DaemonClient,
-    "fetchRecentProviderSessions"
-  >["fetchRecentProviderSessions"],
-  importAgent: Pick<DaemonClient, "importAgent">["importAgent"],
-): Pick<DaemonClient, "fetchRecentProviderSessions" | "importAgent"> {
-  return { fetchRecentProviderSessions, importAgent };
+function createClient(overrides?: Partial<ImportSessionsClient>): ImportSessionsClient {
+  return {
+    fetchRecentProviderSessions: vi.fn(async () => ({
+      requestId: "recent-provider-sessions",
+      entries: [],
+    })),
+    importAgent: vi.fn(async () => createImportedAgentSnapshot("agent-imported")),
+    ...overrides,
+  };
 }
 
 function createImportedAgentSnapshot(id: string): Awaited<ReturnType<DaemonClient["importAgent"]>> {
   return {
     id,
-    provider: "custom-provider",
+    provider: "claude",
     cwd: "/repo/paseo",
     model: null,
     createdAt: "2026-04-30T10:00:00.000Z",
@@ -223,8 +219,8 @@ function createProviderSessionEntry(
   overrides?: Partial<FetchRecentProviderSessionEntry>,
 ): FetchRecentProviderSessionEntry {
   return {
-    providerId: "custom-provider",
-    providerLabel: "Custom Agent",
+    providerId: "claude",
+    providerLabel: "Claude Code",
     providerHandleId: "provider-thread-1",
     cwd: "/repo/paseo",
     title: "Import me",
@@ -235,12 +231,6 @@ function createProviderSessionEntry(
   };
 }
 
-const PROVIDER_LABELS: Record<string, string> = {
-  claude: "Claude Code",
-  codex: "Codex",
-  opencode: "OpenCode",
-};
-
 function createSnapshotEntry(
   provider: string,
   overrides?: Partial<ProviderSnapshotEntry>,
@@ -249,7 +239,7 @@ function createSnapshotEntry(
     provider,
     status: "ready",
     enabled: true,
-    label: PROVIDER_LABELS[provider] ?? provider,
+    label: provider === "claude" ? "Claude Code" : provider,
     ...overrides,
   };
 }
@@ -261,127 +251,35 @@ describe("WorkspaceImportSheet", () => {
   });
 
   it("shows an update-host message when the daemon does not support provider snapshots", async () => {
-    const fetchRecentProviderSessions = vi.fn();
-    const importAgent = vi.fn();
+    const client = createClient();
 
-    renderSheet({ fetchRecentProviderSessions, importAgent } as Pick<
-      DaemonClient,
-      "fetchRecentProviderSessions" | "importAgent"
-    >);
+    renderSheet(client);
 
     await screen.findByText("Update the host to import sessions.");
-    expect(fetchRecentProviderSessions).not.toHaveBeenCalled();
+    expect(client.fetchRecentProviderSessions).not.toHaveBeenCalled();
   });
 
-  it("shows a loading state while provider snapshot is loading", async () => {
-    const fetchRecentProviderSessions = vi.fn(
-      () => new Promise<Awaited<ReturnType<DaemonClient["fetchRecentProviderSessions"]>>>(() => {}),
-    );
-    const importAgent = vi.fn();
-
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        snapshot: { supportsSnapshot: true, entries: undefined },
-      },
-    );
-
-    await screen.findByText("Loading recent sessions...");
-    expect(fetchRecentProviderSessions).not.toHaveBeenCalled();
-  });
-
-  it("shows an empty state when there are no recent provider sessions to import", async () => {
-    const fetchRecentProviderSessions = vi.fn(async () => ({
-      requestId: "recent-provider-sessions",
-      entries: [],
-    }));
-    const importAgent = vi.fn();
-
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("claude")] },
-      },
-    );
-
-    await screen.findByText("No recent sessions to import.");
-  });
-
-  it("shows the all-already-imported empty state when filteredAlreadyImportedCount is positive", async () => {
-    const fetchRecentProviderSessions = vi.fn(async () => ({
-      requestId: "recent-provider-sessions",
-      entries: [],
-      filteredAlreadyImportedCount: 3,
-    }));
-    const importAgent = vi.fn();
-
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("claude")] },
-      },
-    );
-
-    await screen.findByText("All recent sessions are already imported.");
-    expect(screen.queryByText("No recent sessions to import.")).toBeNull();
-  });
-
-  it("shows a fetch error state when recent provider sessions cannot be loaded", async () => {
-    const fetchRecentProviderSessions = vi.fn(async () => {
-      throw new Error("recent sessions unavailable");
-    });
-    const importAgent = vi.fn();
-
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("claude")] },
-      },
-    );
-
-    await screen.findByText("Could not load recent sessions.");
-  });
-
-  it("loads recent provider sessions for the workspace and renders descriptor-owned labels", async () => {
+  it("loads recent provider sessions for the workspace", async () => {
     vi.setSystemTime(new Date("2026-04-30T12:00:00.000Z"));
-    const fetchRecentProviderSessions = vi.fn(async () => ({
-      requestId: "recent-provider-sessions",
-      entries: [
-        createProviderSessionEntry({
-          providerId: "claude",
-          providerLabel: "Claude Code",
-          title: null,
-          firstPromptPreview: "Implement the importer sheet",
-          lastPromptPreview: "Make the rows readable and provider opaque",
-        }),
-      ],
-    }));
-    const importAgent = vi.fn();
+    const client = createClient({
+      fetchRecentProviderSessions: vi.fn(async () => ({
+        requestId: "recent-provider-sessions",
+        entries: [
+          createProviderSessionEntry({
+            title: null,
+            firstPromptPreview: "Implement the importer sheet",
+            lastPromptPreview: "Make the rows readable and provider opaque",
+          }),
+        ],
+      })),
+    });
 
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("claude")] },
-      },
-    );
+    renderSheet(client, {
+      snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("claude")] },
+    });
 
     await waitFor(() => {
-      expect(fetchRecentProviderSessions).toHaveBeenCalledWith({
+      expect(client.fetchRecentProviderSessions).toHaveBeenCalledWith({
         cwd: "/repo/paseo",
         providers: ["claude"],
         limit: 15,
@@ -393,89 +291,26 @@ describe("WorkspaceImportSheet", () => {
     screen.getByText("Make the rows readable and provider opaque");
   });
 
-  it("keeps cached rows visible and revalidates when reopened", async () => {
-    const fetchRecentProviderSessions = vi.fn(async () => ({
-      requestId: "recent-provider-sessions",
-      entries: [
-        createProviderSessionEntry({
-          providerId: "claude",
-          providerLabel: "Claude Code",
-          title: "Cached importable session",
-        }),
-      ],
-    }));
-    const importAgent = vi.fn();
-    const client = createRecentSessionsClient(fetchRecentProviderSessions, importAgent);
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false },
-        mutations: { retry: false },
-      },
+  it("imports a selected session by provider handle", async () => {
+    const client = createClient({
+      fetchRecentProviderSessions: vi.fn(async () => ({
+        requestId: "recent-provider-sessions",
+        entries: [createProviderSessionEntry()],
+      })),
     });
-    mockSnapshot.current = {
-      entries: [createSnapshotEntry("claude")],
-      supportsSnapshot: true,
-    };
-
-    function TestSheet({ visible }: { visible: boolean }) {
-      return (
-        <QueryClientProvider client={queryClient}>
-          <WorkspaceImportSheet
-            visible={visible}
-            client={client}
-            serverId="server-1"
-            workspaceDirectory="/repo/paseo"
-            onClose={vi.fn()}
-            onImportedAgent={vi.fn()}
-          />
-        </QueryClientProvider>
-      );
-    }
-
-    const { rerender } = render(<TestSheet visible />);
-
-    await screen.findByText("Cached importable session");
-    expect(fetchRecentProviderSessions).toHaveBeenCalledTimes(1);
-
-    rerender(<TestSheet visible={false} />);
-    fetchRecentProviderSessions.mockClear();
-    rerender(<TestSheet visible />);
-
-    await screen.findByText("Cached importable session");
-    await waitFor(() => {
-      expect(fetchRecentProviderSessions).toHaveBeenCalledWith({
-        cwd: "/repo/paseo",
-        providers: ["claude"],
-        limit: 15,
-      });
-    });
-  });
-
-  it("imports a selected session by provider handle and reports the imported agent", async () => {
-    const fetchRecentProviderSessions = vi.fn(async () => ({
-      requestId: "recent-provider-sessions",
-      entries: [createProviderSessionEntry({ providerId: "claude", providerLabel: "Claude Code" })],
-    }));
-    const importAgent = vi.fn(async () => createImportedAgentSnapshot("agent-imported"));
     const onClose = vi.fn();
     const onImportedAgent = vi.fn();
 
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        onClose,
-        onImportedAgent,
-        snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("claude")] },
-      },
-    );
+    renderSheet(client, {
+      onClose,
+      onImportedAgent,
+      snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("claude")] },
+    });
 
     fireEvent.click(await screen.findByTestId("workspace-import-session-claude-provider-thread-1"));
 
     await waitFor(() => {
-      expect(importAgent).toHaveBeenCalledWith({
+      expect(client.importAgent).toHaveBeenCalledWith({
         providerId: "claude",
         providerHandleId: "provider-thread-1",
         cwd: "/repo/paseo",
@@ -486,238 +321,59 @@ describe("WorkspaceImportSheet", () => {
   });
 
   it("shows an import error state without closing when selected session import fails", async () => {
-    const fetchRecentProviderSessions = vi.fn(async () => ({
-      requestId: "recent-provider-sessions",
-      entries: [createProviderSessionEntry({ providerId: "claude", providerLabel: "Claude Code" })],
-    }));
-    const importAgent = vi.fn(async () => {
-      throw new Error("import unavailable");
+    const client = createClient({
+      fetchRecentProviderSessions: vi.fn(async () => ({
+        requestId: "recent-provider-sessions",
+        entries: [createProviderSessionEntry()],
+      })),
+      importAgent: vi.fn(async () => {
+        throw new Error("import unavailable");
+      }),
     });
     const onClose = vi.fn();
     const onImportedAgent = vi.fn();
 
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        onClose,
-        onImportedAgent,
-        snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("claude")] },
-      },
-    );
+    renderSheet(client, {
+      onClose,
+      onImportedAgent,
+      snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("claude")] },
+    });
 
     fireEvent.click(await screen.findByTestId("workspace-import-session-claude-provider-thread-1"));
 
     await screen.findByText("Could not import selected session.");
-    expect(importAgent).toHaveBeenCalledWith({
-      providerId: "claude",
-      providerHandleId: "provider-thread-1",
-      cwd: "/repo/paseo",
-    });
     expect(onImportedAgent).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("fans out one request per enabled importable provider when snapshot is supported", async () => {
-    const fetchRecentProviderSessions = vi.fn(
-      async (options: { providers?: string[] } | undefined) => ({
-        requestId: `recent-${options?.providers?.[0] ?? "all"}`,
-        entries: [
-          createProviderSessionEntry({
-            providerId: options?.providers?.[0] ?? "custom-provider",
-            providerLabel: options?.providers?.[0] ?? "Custom",
-            providerHandleId: `${options?.providers?.[0] ?? "custom-provider"}-thread`,
-            title: `Session ${options?.providers?.[0] ?? "all"}`,
-            lastActivityAt: "2026-04-30T10:00:00.000Z",
-          }),
-        ],
-      }),
-    );
-    const importAgent = vi.fn();
-
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        snapshot: {
-          supportsSnapshot: true,
-          entries: [
-            createSnapshotEntry("claude"),
-            createSnapshotEntry("codex"),
-            createSnapshotEntry("opencode", { enabled: false }),
-            createSnapshotEntry("z-ai"),
-          ],
-        },
-      },
-    );
-
-    await waitFor(() => {
-      expect(fetchRecentProviderSessions).toHaveBeenCalledWith({
-        cwd: "/repo/paseo",
-        providers: ["claude"],
-        limit: 15,
-      });
+  it("shows all-already-imported empty state when provider sessions were filtered", async () => {
+    const client = createClient({
+      fetchRecentProviderSessions: vi.fn(async () => ({
+        requestId: "recent-provider-sessions",
+        entries: [],
+        filteredAlreadyImportedCount: 3,
+      })),
     });
-    expect(fetchRecentProviderSessions).toHaveBeenCalledWith({
-      cwd: "/repo/paseo",
-      providers: ["codex"],
-      limit: 15,
+
+    renderSheet(client, {
+      snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("claude")] },
     });
-    expect(fetchRecentProviderSessions).not.toHaveBeenCalledWith(
-      expect.objectContaining({ providers: ["opencode"] }),
-    );
-    expect(fetchRecentProviderSessions).not.toHaveBeenCalledWith(
-      expect.objectContaining({ providers: ["z-ai"] }),
-    );
 
-    await screen.findByText("Session claude");
-    await screen.findByText("Session codex");
+    await screen.findByText("All recent sessions are already in Paseo.");
+    expect(screen.queryByText("No recent sessions to import.")).toBeNull();
   });
 
-  it("shows partial-failure note when one provider request fails but others succeed", async () => {
-    const fetchRecentProviderSessions = vi.fn(
-      async (options: { providers?: string[] } | undefined) => {
-        const provider = options?.providers?.[0];
-        if (provider === "claude") {
-          throw new Error("claude offline");
-        }
-        return {
-          requestId: `recent-${provider ?? "all"}`,
-          entries: [
-            createProviderSessionEntry({
-              providerId: provider ?? "custom-provider",
-              providerHandleId: `${provider}-thread`,
-              providerLabel: provider ?? "Custom",
-              title: `Session ${provider}`,
-            }),
-          ],
-        };
+  it("shows no-importable-providers message when no enabled provider can be imported", async () => {
+    const client = createClient();
+
+    renderSheet(client, {
+      snapshot: {
+        supportsSnapshot: true,
+        entries: [createSnapshotEntry("claude", { enabled: false }), createSnapshotEntry("z-ai")],
       },
-    );
-    const importAgent = vi.fn();
-
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        snapshot: {
-          supportsSnapshot: true,
-          entries: [createSnapshotEntry("claude"), createSnapshotEntry("codex")],
-        },
-      },
-    );
-
-    await screen.findByText("Session codex");
-    await screen.findByText("Could not load sessions for Claude Code.");
-  });
-
-  it("filters the merged list when a provider badge is selected and restores it on All", async () => {
-    const fetchRecentProviderSessions = vi.fn(
-      async (options: { providers?: string[] } | undefined) => {
-        const provider = options?.providers?.[0] ?? "claude";
-        return {
-          requestId: `recent-${provider}`,
-          entries: [
-            createProviderSessionEntry({
-              providerId: provider,
-              providerLabel: provider === "claude" ? "Claude Code" : "Codex",
-              providerHandleId: `${provider}-thread`,
-              title: `Session ${provider}`,
-              lastActivityAt:
-                provider === "claude" ? "2026-04-30T09:00:00.000Z" : "2026-04-30T10:00:00.000Z",
-            }),
-          ],
-        };
-      },
-    );
-    const importAgent = vi.fn();
-
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        snapshot: {
-          supportsSnapshot: true,
-          entries: [createSnapshotEntry("claude"), createSnapshotEntry("codex")],
-        },
-      },
-    );
-
-    await screen.findByText("Session claude");
-    await screen.findByText("Session codex");
-
-    fireEvent.click(screen.getByTestId("workspace-import-filter-codex"));
-
-    screen.getByText("Session codex");
-    expect(screen.queryByText("Session claude")).toBeNull();
-
-    fireEvent.click(screen.getByTestId("workspace-import-filter-all"));
-
-    screen.getByText("Session claude");
-    screen.getByText("Session codex");
-  });
-
-  it("does not render filter badges when only one importable provider is enabled", async () => {
-    const fetchRecentProviderSessions = vi.fn(async () => ({
-      requestId: "recent-codex",
-      entries: [createProviderSessionEntry({ providerId: "codex", providerLabel: "Codex" })],
-    }));
-    const importAgent = vi.fn();
-
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        snapshot: {
-          supportsSnapshot: true,
-          entries: [
-            createSnapshotEntry("codex"),
-            createSnapshotEntry("claude", { enabled: false }),
-          ],
-        },
-      },
-    );
-
-    await waitFor(() => {
-      expect(fetchRecentProviderSessions).toHaveBeenCalled();
     });
-    expect(screen.queryByTestId("workspace-import-filters")).toBeNull();
-    expect(screen.queryByTestId("workspace-import-filter-all")).toBeNull();
-  });
-
-  it("shows a no-importable-providers message when snapshot has no enabled importable providers", async () => {
-    const fetchRecentProviderSessions = vi.fn();
-    const importAgent = vi.fn();
-
-    renderSheet(
-      { fetchRecentProviderSessions, importAgent } as Pick<
-        DaemonClient,
-        "fetchRecentProviderSessions" | "importAgent"
-      >,
-      {
-        snapshot: {
-          supportsSnapshot: true,
-          entries: [
-            createSnapshotEntry("claude", { enabled: false }),
-            createSnapshotEntry("codex", { enabled: false }),
-            createSnapshotEntry("opencode", { enabled: false }),
-            createSnapshotEntry("z-ai"),
-          ],
-        },
-      },
-    );
 
     await screen.findByText("No importable providers are enabled.");
-    expect(fetchRecentProviderSessions).not.toHaveBeenCalled();
+    expect(client.fetchRecentProviderSessions).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/screens/workspace/workspace-import-sheet.tsx
+++ b/packages/app/src/screens/workspace/workspace-import-sheet.tsx
@@ -218,7 +218,7 @@ function SheetStatusMessages({
       {showEmptyState ? (
         <Text style={styles.statusText}>
           {allAlreadyImported
-            ? "All recent sessions are already imported."
+            ? "All recent sessions are already in Paseo."
             : "No recent sessions to import."}
         </Text>
       ) : null}

--- a/packages/app/src/screens/workspace/workspace-resume-sheet.test.tsx
+++ b/packages/app/src/screens/workspace/workspace-resume-sheet.test.tsx
@@ -1,0 +1,545 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React, { type ReactNode } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { DaemonClient, FetchAgentsEntry } from "@server/client/daemon-client";
+import type { AgentSnapshotPayload } from "@server/shared/messages";
+import { PARENT_AGENT_ID_LABEL } from "@server/shared/agent-labels";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceResumeSheet } from "@/screens/workspace/workspace-resume-sheet";
+
+const { theme } = vi.hoisted(() => ({
+  theme: {
+    spacing: { 1: 4, 1.5: 6, 2: 8, 3: 12, 4: 16, 6: 24 },
+    borderWidth: { 1: 1 },
+    borderRadius: { md: 6, lg: 8, full: 9999 },
+    fontSize: { xs: 11, sm: 13, base: 15 },
+    fontWeight: { normal: "400", medium: "500", semibold: "600" },
+    iconSize: { sm: 14, md: 16 },
+    opacity: { 50: 0.5 },
+    colors: {
+      foreground: "#fff",
+      foregroundMuted: "#aaa",
+      surface0: "#000",
+      surface1: "#111",
+      surface2: "#222",
+      surface3: "#333",
+      border: "#444",
+      borderAccent: "#555",
+    },
+  },
+}));
+
+vi.hoisted(() => {
+  (globalThis as unknown as { __DEV__: boolean }).__DEV__ = false;
+});
+
+vi.mock("react-native-unistyles", () => ({
+  StyleSheet: {
+    create: (factory: unknown) => (typeof factory === "function" ? factory(theme) : factory),
+  },
+  useUnistyles: () => ({ theme }),
+  withUnistyles:
+    (Component: React.ComponentType<Record<string, unknown>>) =>
+    ({
+      uniProps,
+      ...rest
+    }: {
+      uniProps?: (theme: unknown) => Record<string, unknown>;
+    } & Record<string, unknown>) => {
+      const themed = uniProps ? uniProps(theme) : {};
+      return React.createElement(Component, { ...rest, ...themed });
+    },
+}));
+
+vi.mock("@/constants/layout", () => ({
+  useIsCompactFormFactor: () => false,
+}));
+
+vi.mock("@/components/provider-icons", () => ({
+  getProviderIcon: () => () => null,
+}));
+
+vi.mock("@/components/ui/loading-spinner", () => ({
+  LoadingSpinner: () =>
+    React.createElement("span", { "data-testid": "workspace-resume-loading-spinner" }),
+}));
+
+vi.mock("@/components/ui/segmented-control", () => ({
+  SegmentedControl: ({
+    options,
+    value,
+    onValueChange,
+    testID,
+  }: {
+    options: ReadonlyArray<{ value: string; label: string; testID?: string }>;
+    value: string;
+    onValueChange: (value: string) => void;
+    testID?: string;
+  }) =>
+    React.createElement(
+      "div",
+      { "data-testid": testID },
+      options.map((option) =>
+        React.createElement(
+          "button",
+          {
+            key: option.value,
+            type: "button",
+            "data-testid": option.testID,
+            "data-selected": value === option.value,
+            onClick: () => onValueChange(option.value),
+          },
+          option.label,
+        ),
+      ),
+    ),
+}));
+
+vi.mock("@/components/adaptive-modal-sheet", () => ({
+  AdaptiveModalSheet: ({
+    visible,
+    title,
+    children,
+    testID,
+  }: {
+    visible: boolean;
+    title: string;
+    children: ReactNode;
+    testID?: string;
+  }) =>
+    visible ? (
+      <section data-testid={testID}>
+        <h1>{title}</h1>
+        {children}
+      </section>
+    ) : null,
+}));
+
+vi.mock("react-native", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("react-native");
+  return actual;
+});
+
+type ResumeSessionsClient = Pick<
+  DaemonClient,
+  "fetchAgents" | "fetchAgentTimeline" | "resumeAgentSession"
+>;
+
+interface RenderOptions {
+  visible?: boolean;
+  onClose?: () => void;
+  onResumedAgent?: (agentId: string) => void;
+  openAgentIds?: ReadonlySet<string>;
+  serverId?: string | null;
+  workspaceDirectory?: string | null;
+}
+
+function renderSheet(client: ResumeSessionsClient | null, options?: RenderOptions) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <WorkspaceResumeSheet
+        visible={options?.visible ?? true}
+        client={client}
+        serverId={options?.serverId === undefined ? "server-1" : options.serverId}
+        workspaceDirectory={
+          options?.workspaceDirectory === undefined ? "/repo/paseo" : options.workspaceDirectory
+        }
+        openAgentIds={options?.openAgentIds}
+        onClose={options?.onClose ?? vi.fn()}
+        onResumedAgent={options?.onResumedAgent ?? vi.fn()}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+function createResumeSessionsClient(
+  overrides?: Partial<ResumeSessionsClient>,
+): ResumeSessionsClient {
+  return {
+    fetchAgents: vi.fn(async () => createFetchAgentsPayload([])),
+    fetchAgentTimeline: vi.fn(async () => createTimelinePayload()),
+    resumeAgentSession: vi.fn(async (agentId: string) => createAgentSnapshot({ id: agentId })),
+    ...overrides,
+  };
+}
+
+function createFetchAgentsPayload(entries: FetchAgentsEntry[]) {
+  return {
+    requestId: "fetch-agents",
+    entries,
+    pageInfo: {
+      nextCursor: null,
+      prevCursor: null,
+      hasMore: false,
+    },
+  } satisfies Awaited<ReturnType<DaemonClient["fetchAgents"]>>;
+}
+
+function createTimelinePayload(): Awaited<ReturnType<DaemonClient["fetchAgentTimeline"]>> {
+  return {
+    requestId: "timeline",
+    agentId: "agent-1",
+    agent: null,
+    direction: "tail",
+    projection: "canonical",
+    epoch: "epoch-1",
+    reset: false,
+    staleCursor: false,
+    gap: false,
+    window: { minSeq: 0, maxSeq: 0, nextSeq: 0 },
+    startCursor: null,
+    endCursor: null,
+    hasOlder: false,
+    hasNewer: false,
+    entries: [],
+    error: null,
+  };
+}
+
+function createAgentEntry(agent: AgentSnapshotPayload): FetchAgentsEntry {
+  return {
+    agent,
+    project: {
+      projectKey: "project-1",
+      projectName: "Paseo",
+      checkout: {
+        cwd: agent.cwd,
+        isGit: false,
+        currentBranch: null,
+        remoteUrl: null,
+        worktreeRoot: null,
+        isPaseoOwnedWorktree: false,
+        mainRepoRoot: null,
+      },
+    },
+  };
+}
+
+function createAgentSnapshot(overrides?: Partial<AgentSnapshotPayload>): AgentSnapshotPayload {
+  return {
+    id: "agent-1",
+    provider: "claude",
+    cwd: "/repo/paseo",
+    model: "claude-opus-4-7",
+    createdAt: "2026-04-30T09:00:00.000Z",
+    updatedAt: "2026-04-30T10:00:00.000Z",
+    lastUserMessageAt: "2026-04-30T09:30:00.000Z",
+    status: "closed",
+    capabilities: {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: false,
+      supportsMcpServers: false,
+      supportsReasoningStream: false,
+      supportsToolInvocations: true,
+    },
+    currentModeId: null,
+    availableModes: [],
+    pendingPermissions: [],
+    persistence: {
+      provider: "claude",
+      sessionId: "session-1",
+    },
+    title: "Archived session",
+    labels: {},
+    archivedAt: "2026-04-30T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("WorkspaceResumeSheet", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("shows a connect message and does not fetch when the workspace is unavailable", async () => {
+    const client = createResumeSessionsClient();
+
+    renderSheet(client, { workspaceDirectory: null });
+
+    await screen.findByText("Connect to a workspace to resume sessions");
+    expect(client.fetchAgents).not.toHaveBeenCalled();
+  });
+
+  it("shows a loading state while sessions are loading", async () => {
+    const client = createResumeSessionsClient({
+      fetchAgents: vi.fn(
+        () => new Promise<Awaited<ReturnType<DaemonClient["fetchAgents"]>>>(() => {}),
+      ),
+    });
+
+    renderSheet(client);
+
+    await screen.findByText("Loading sessions...");
+  });
+
+  it("loads archived workspace sessions and filters sessions that are active, open, external, or not resumable", async () => {
+    vi.setSystemTime(new Date("2026-04-30T12:00:00.000Z"));
+    const visibleArchived = createAgentSnapshot({
+      id: "agent-archived",
+      title: "Resume this archived session",
+      provider: "claude",
+    });
+    const closedUnarchived = createAgentSnapshot({
+      id: "agent-closed",
+      title: "Resume this closed session",
+      provider: "codex",
+      status: "closed",
+      archivedAt: null,
+      updatedAt: "2026-04-30T11:00:00.000Z",
+    });
+    const activeAgent = createAgentSnapshot({
+      id: "agent-active",
+      title: "Active session",
+      status: "idle",
+      archivedAt: null,
+    });
+    const openArchived = createAgentSnapshot({
+      id: "agent-open",
+      title: "Already in tabbar",
+    });
+    const otherWorkspace = createAgentSnapshot({
+      id: "agent-other-workspace",
+      title: "Other workspace",
+      cwd: "/repo/other",
+    });
+    const noPersistence = createAgentSnapshot({
+      id: "agent-no-persistence",
+      title: "Missing persistence",
+      persistence: null,
+    });
+    const subagent = createAgentSnapshot({
+      id: "agent-subagent",
+      title: "Subagent",
+      labels: { [PARENT_AGENT_ID_LABEL]: "parent-agent" },
+    });
+    const client = createResumeSessionsClient({
+      fetchAgents: vi.fn(async () =>
+        createFetchAgentsPayload(
+          [
+            visibleArchived,
+            closedUnarchived,
+            activeAgent,
+            openArchived,
+            otherWorkspace,
+            noPersistence,
+            subagent,
+          ].map(createAgentEntry),
+        ),
+      ),
+    });
+
+    renderSheet(client, { openAgentIds: new Set(["agent-open"]) });
+
+    await waitFor(() => {
+      expect(client.fetchAgents).toHaveBeenCalledWith({
+        filter: { includeArchived: true },
+        sort: [{ key: "updated_at", direction: "desc" }],
+        page: { limit: 200 },
+      });
+    });
+
+    await screen.findByText("Resume this archived session");
+    screen.getByText("Resume this closed session");
+    screen.getByText("1h ago");
+    expect(screen.queryByText("Active session")).toBeNull();
+    expect(screen.queryByText("Already in tabbar")).toBeNull();
+    expect(screen.queryByText("Other workspace")).toBeNull();
+    expect(screen.queryByText("Missing persistence")).toBeNull();
+    expect(screen.queryByText("Subagent")).toBeNull();
+  });
+
+  it("shows an empty state when there are no sessions to resume", async () => {
+    const client = createResumeSessionsClient({
+      fetchAgents: vi.fn(async () => createFetchAgentsPayload([])),
+    });
+
+    renderSheet(client);
+
+    await screen.findByText("No sessions to resume.");
+  });
+
+  it("shows a fetch error state when sessions cannot be loaded", async () => {
+    const client = createResumeSessionsClient({
+      fetchAgents: vi.fn(async () => {
+        throw new Error("agents unavailable");
+      }),
+    });
+
+    renderSheet(client);
+
+    await screen.findByText("Could not load sessions.");
+  });
+
+  it("keeps cached rows visible and revalidates when reopened", async () => {
+    const client = createResumeSessionsClient({
+      fetchAgents: vi.fn(async () =>
+        createFetchAgentsPayload([
+          createAgentEntry(
+            createAgentSnapshot({ id: "agent-cached", title: "Cached resumable session" }),
+          ),
+        ]),
+      ),
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    function TestSheet({ visible }: { visible: boolean }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <WorkspaceResumeSheet
+            visible={visible}
+            client={client}
+            serverId="server-1"
+            workspaceDirectory="/repo/paseo"
+            onClose={vi.fn()}
+            onResumedAgent={vi.fn()}
+          />
+        </QueryClientProvider>
+      );
+    }
+
+    const { rerender } = render(<TestSheet visible />);
+
+    await screen.findByText("Cached resumable session");
+    expect(client.fetchAgents).toHaveBeenCalledTimes(1);
+
+    rerender(<TestSheet visible={false} />);
+    vi.mocked(client.fetchAgents).mockClear();
+    rerender(<TestSheet visible />);
+
+    await screen.findByText("Cached resumable session");
+    await waitFor(() => {
+      expect(client.fetchAgents).toHaveBeenCalledWith({
+        filter: { includeArchived: true },
+        sort: [{ key: "updated_at", direction: "desc" }],
+        page: { limit: 200 },
+      });
+    });
+  });
+
+  it("resumes a selected session by agent id and reports the resumed agent", async () => {
+    const client = createResumeSessionsClient({
+      fetchAgents: vi.fn(async () =>
+        createFetchAgentsPayload([
+          createAgentEntry(createAgentSnapshot({ id: "agent-resume", title: "Resume me" })),
+        ]),
+      ),
+    });
+    const onClose = vi.fn();
+    const onResumedAgent = vi.fn();
+
+    renderSheet(client, { onClose, onResumedAgent });
+
+    fireEvent.click(await screen.findByTestId("workspace-resume-session-agent-resume"));
+
+    await waitFor(() => {
+      expect(client.resumeAgentSession).toHaveBeenCalledWith("agent-resume");
+    });
+    expect(client.fetchAgentTimeline).toHaveBeenCalledWith("agent-resume", {
+      direction: "tail",
+      limit: 100,
+      projection: "canonical",
+    });
+    expect(onResumedAgent).toHaveBeenCalledWith("agent-resume");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a resume error state without closing when selected session resume fails", async () => {
+    const client = createResumeSessionsClient({
+      fetchAgents: vi.fn(async () =>
+        createFetchAgentsPayload([
+          createAgentEntry(createAgentSnapshot({ id: "agent-fails", title: "Resume fails" })),
+        ]),
+      ),
+      resumeAgentSession: vi.fn(async () => {
+        throw new Error("resume unavailable");
+      }),
+    });
+    const onClose = vi.fn();
+    const onResumedAgent = vi.fn();
+
+    renderSheet(client, { onClose, onResumedAgent });
+
+    fireEvent.click(await screen.findByTestId("workspace-resume-session-agent-fails"));
+
+    await screen.findByText("Could not resume selected session.");
+    expect(client.resumeAgentSession).toHaveBeenCalledWith("agent-fails");
+    expect(onResumedAgent).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("filters the merged list when a provider badge is selected and restores it on All", async () => {
+    const client = createResumeSessionsClient({
+      fetchAgents: vi.fn(async () =>
+        createFetchAgentsPayload([
+          createAgentEntry(
+            createAgentSnapshot({
+              id: "agent-claude",
+              provider: "claude",
+              title: "Session claude",
+              updatedAt: "2026-04-30T09:00:00.000Z",
+            }),
+          ),
+          createAgentEntry(
+            createAgentSnapshot({
+              id: "agent-codex",
+              provider: "codex",
+              title: "Session codex",
+              updatedAt: "2026-04-30T10:00:00.000Z",
+            }),
+          ),
+        ]),
+      ),
+    });
+
+    renderSheet(client);
+
+    await screen.findByText("Session claude");
+    await screen.findByText("Session codex");
+
+    fireEvent.click(screen.getByTestId("workspace-resume-filter-codex"));
+
+    screen.getByText("Session codex");
+    expect(screen.queryByText("Session claude")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("workspace-resume-filter-all"));
+
+    screen.getByText("Session claude");
+    screen.getByText("Session codex");
+  });
+
+  it("does not render filter badges when only one provider is present", async () => {
+    const client = createResumeSessionsClient({
+      fetchAgents: vi.fn(async () =>
+        createFetchAgentsPayload([
+          createAgentEntry(createAgentSnapshot({ id: "agent-codex", provider: "codex" })),
+        ]),
+      ),
+    });
+
+    renderSheet(client);
+
+    await waitFor(() => {
+      expect(client.fetchAgents).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("workspace-resume-filters")).toBeNull();
+    expect(screen.queryByTestId("workspace-resume-filter-all")).toBeNull();
+  });
+});

--- a/packages/app/src/screens/workspace/workspace-resume-sheet.tsx
+++ b/packages/app/src/screens/workspace/workspace-resume-sheet.tsx
@@ -1,0 +1,448 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Pressable, type PressableStateCallbackType, ScrollView, Text, View } from "react-native";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { DaemonClient, FetchAgentsEntry } from "@server/client/daemon-client";
+import type { AgentSnapshotPayload } from "@server/shared/messages";
+import { PARENT_AGENT_ID_LABEL } from "@server/shared/agent-labels";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { AdaptiveModalSheet } from "@/components/adaptive-modal-sheet";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { SegmentedControl, type SegmentedControlOption } from "@/components/ui/segmented-control";
+import { getProviderIcon } from "@/components/provider-icons";
+import { useAgentInitialization } from "@/hooks/use-agent-initialization";
+import { formatTimeAgo } from "@/utils/time";
+import { normalizeWorkspacePath } from "@/utils/workspace-identity";
+
+const AGENT_DIRECTORY_PAGE_LIMIT = 200;
+const IMPORT_SHEET_SNAP_POINTS = ["70%", "92%"];
+const DISABLED_ACCESSIBILITY_STATE = { disabled: true };
+const ALL_FILTER_VALUE = "__all__";
+
+type ResumeSessionsClient = Pick<
+  DaemonClient,
+  "fetchAgents" | "fetchAgentTimeline" | "resumeAgentSession"
+>;
+
+interface WorkspaceResumeSheetProps {
+  visible: boolean;
+  client: ResumeSessionsClient | null;
+  serverId: string | null;
+  workspaceDirectory: string | null;
+  openAgentIds?: ReadonlySet<string>;
+  onClose: () => void;
+  onResumedAgent: (agentId: string) => void;
+}
+
+async function fetchAllAgentDirectoryEntries(
+  client: Pick<DaemonClient, "fetchAgents">,
+): Promise<FetchAgentsEntry[]> {
+  const entries: FetchAgentsEntry[] = [];
+  let cursor: string | null = null;
+
+  while (true) {
+    const payload = await client.fetchAgents({
+      filter: { includeArchived: true },
+      sort: [{ key: "updated_at", direction: "desc" }],
+      page: cursor
+        ? { limit: AGENT_DIRECTORY_PAGE_LIMIT, cursor }
+        : { limit: AGENT_DIRECTORY_PAGE_LIMIT },
+    });
+
+    entries.push(...payload.entries);
+
+    if (!payload.pageInfo.hasMore || !payload.pageInfo.nextCursor) {
+      break;
+    }
+    cursor = payload.pageInfo.nextCursor;
+  }
+
+  return entries;
+}
+
+function isRootAgent(agent: AgentSnapshotPayload): boolean {
+  return !agent.labels[PARENT_AGENT_ID_LABEL]?.trim();
+}
+
+function isResumableAgent(agent: AgentSnapshotPayload): boolean {
+  return Boolean(
+    agent.persistence && isRootAgent(agent) && (agent.archivedAt || agent.status === "closed"),
+  );
+}
+
+function isInWorkspace(agent: AgentSnapshotPayload, workspaceDirectory: string): boolean {
+  return normalizeWorkspacePath(agent.cwd) === normalizeWorkspacePath(workspaceDirectory);
+}
+
+function listResumableWorkspaceAgents(input: {
+  entries: ReadonlyArray<FetchAgentsEntry>;
+  workspaceDirectory: string;
+}): AgentSnapshotPayload[] {
+  const seen = new Set<string>();
+  const agents: AgentSnapshotPayload[] = [];
+
+  for (const entry of input.entries) {
+    const agent = entry.agent;
+    if (seen.has(agent.id)) continue;
+    seen.add(agent.id);
+    if (!isInWorkspace(agent, input.workspaceDirectory)) continue;
+    if (!isResumableAgent(agent)) continue;
+    agents.push(agent);
+  }
+
+  return agents.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+}
+
+function filterOpenAgents(
+  agents: ReadonlyArray<AgentSnapshotPayload>,
+  openAgentIds: ReadonlySet<string> | undefined,
+): AgentSnapshotPayload[] {
+  if (!openAgentIds || openAgentIds.size === 0) {
+    return [...agents];
+  }
+  return agents.filter((agent) => !openAgentIds.has(agent.id));
+}
+
+function buildProviderLabelMap(agents: ReadonlyArray<AgentSnapshotPayload>): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const agent of agents) {
+    map.set(agent.provider, agent.provider);
+  }
+  return map;
+}
+
+function getAgentTitle(agent: AgentSnapshotPayload): string {
+  const title = agent.title?.trim();
+  if (title) {
+    return title;
+  }
+  return `Session ${agent.id.slice(0, 8)}`;
+}
+
+function getAgentPreview(agent: AgentSnapshotPayload): string {
+  const status = agent.archivedAt ? "Archived" : "Closed";
+  const model = agent.model?.trim();
+  return [status, agent.provider, model].filter(Boolean).join(" · ");
+}
+
+interface SheetStatusMessagesProps {
+  isClientReady: boolean;
+  isLoadingSessions: boolean;
+  isLoadError: boolean;
+  resumeErrored: boolean;
+  showEmptyState: boolean;
+}
+
+function SheetStatusMessages({
+  isClientReady,
+  isLoadingSessions,
+  isLoadError,
+  resumeErrored,
+  showEmptyState,
+}: SheetStatusMessagesProps) {
+  const { theme } = useUnistyles();
+  if (!isClientReady) {
+    return <Text style={styles.statusText}>Connect to a workspace to resume sessions</Text>;
+  }
+  return (
+    <>
+      {isLoadingSessions ? (
+        <View style={styles.statusRow}>
+          <LoadingSpinner color={theme.colors.foregroundMuted} />
+          <Text style={styles.statusText}>Loading sessions...</Text>
+        </View>
+      ) : null}
+      {isLoadError ? <Text style={styles.statusText}>Could not load sessions.</Text> : null}
+      {resumeErrored ? (
+        <Text style={styles.statusText}>Could not resume selected session.</Text>
+      ) : null}
+      {showEmptyState ? <Text style={styles.statusText}>No sessions to resume.</Text> : null}
+    </>
+  );
+}
+
+function buildProviderFilterOptions(
+  providers: ReadonlyArray<string>,
+  providerLabelById: ReadonlyMap<string, string>,
+): SegmentedControlOption<string>[] {
+  const options: SegmentedControlOption<string>[] = [
+    { value: ALL_FILTER_VALUE, label: "All", testID: "workspace-resume-filter-all" },
+  ];
+  for (const provider of providers) {
+    const ProviderIcon = getProviderIcon(provider);
+    options.push({
+      value: provider,
+      label: providerLabelById.get(provider) ?? provider,
+      testID: `workspace-resume-filter-${provider}`,
+      icon: ({ color, size }) => <ProviderIcon color={color} size={size} />,
+    });
+  }
+  return options;
+}
+
+function WorkspaceImportSheetRow({
+  agent,
+  disabled,
+  resuming,
+  onResumeSession,
+}: {
+  agent: AgentSnapshotPayload;
+  disabled: boolean;
+  resuming: boolean;
+  onResumeSession: (agent: AgentSnapshotPayload) => void;
+}) {
+  const { theme } = useUnistyles();
+  const title = getAgentTitle(agent);
+  const preview = getAgentPreview(agent);
+  const lastActivity = formatTimeAgo(new Date(agent.updatedAt));
+  const ProviderIcon = getProviderIcon(agent.provider);
+  const accessibilityState = useMemo(
+    () => (disabled ? DISABLED_ACCESSIBILITY_STATE : undefined),
+    [disabled],
+  );
+  const handlePress = useCallback(() => {
+    onResumeSession(agent);
+  }, [agent, onResumeSession]);
+  const pressableStyle = useCallback(
+    ({ pressed, hovered = false }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.row,
+      Boolean(hovered) && styles.rowHovered,
+      pressed && styles.rowPressed,
+    ],
+    [],
+  );
+
+  return (
+    <Pressable
+      disabled={disabled}
+      onPress={handlePress}
+      accessibilityRole="button"
+      accessibilityState={accessibilityState}
+      style={pressableStyle}
+      testID={`workspace-resume-session-${agent.id}`}
+    >
+      <View style={styles.rowIconWrap}>
+        <ProviderIcon size={theme.iconSize.md} color={theme.colors.foregroundMuted} />
+      </View>
+      <View style={styles.rowContent}>
+        <View style={styles.rowHeader}>
+          <Text style={styles.rowTitle} numberOfLines={1}>
+            {title}
+          </Text>
+          <Text style={styles.rowMeta}>{resuming ? "Resuming..." : lastActivity}</Text>
+        </View>
+        <Text style={styles.rowPreview} numberOfLines={2}>
+          {preview}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+export function WorkspaceResumeSheet({
+  visible,
+  client,
+  serverId,
+  workspaceDirectory,
+  openAgentIds,
+  onClose,
+  onResumedAgent,
+}: WorkspaceResumeSheetProps) {
+  const queryClient = useQueryClient();
+  const resolvedServerId = serverId ?? "";
+  const { resumeAgentSession } = useAgentInitialization({
+    serverId: resolvedServerId,
+    client,
+  });
+  const isClientReady = Boolean(client && serverId && workspaceDirectory);
+  const sessionsQueryRoot = useMemo(
+    () => ["resumable-workspace-sessions", serverId, workspaceDirectory] as const,
+    [serverId, workspaceDirectory],
+  );
+
+  const agentsQuery = useQuery({
+    queryKey: sessionsQueryRoot,
+    enabled: visible && isClientReady,
+    queryFn: async () => {
+      if (!client || !workspaceDirectory) {
+        throw new Error("Host is not connected");
+      }
+      const entries = await fetchAllAgentDirectoryEntries(client);
+      return listResumableWorkspaceAgents({ entries, workspaceDirectory });
+    },
+  });
+
+  const resumableEntries = useMemo(
+    () => filterOpenAgents(agentsQuery.data ?? [], openAgentIds),
+    [agentsQuery.data, openAgentIds],
+  );
+
+  const filterProviders = useMemo(
+    () => Array.from(new Set(resumableEntries.map((entry) => entry.provider))).sort(),
+    [resumableEntries],
+  );
+
+  const providerLabelById = useMemo(
+    () => buildProviderLabelMap(resumableEntries),
+    [resumableEntries],
+  );
+
+  const [selectedProvider, setSelectedProvider] = useState<string>(ALL_FILTER_VALUE);
+
+  useEffect(() => {
+    if (
+      !visible ||
+      (selectedProvider !== ALL_FILTER_VALUE && !filterProviders.includes(selectedProvider))
+    ) {
+      setSelectedProvider(ALL_FILTER_VALUE);
+    }
+  }, [visible, filterProviders, selectedProvider]);
+
+  const visibleEntries = useMemo(() => {
+    if (selectedProvider === ALL_FILTER_VALUE) return resumableEntries;
+    return resumableEntries.filter((entry) => entry.provider === selectedProvider);
+  }, [resumableEntries, selectedProvider]);
+
+  const filterOptions = useMemo(
+    () => buildProviderFilterOptions(filterProviders, providerLabelById),
+    [filterProviders, providerLabelById],
+  );
+
+  const resumeMutation = useMutation({
+    mutationFn: async (agent: AgentSnapshotPayload) => {
+      await resumeAgentSession(agent.id);
+      return agent;
+    },
+    onSuccess: async (agent) => {
+      await queryClient.invalidateQueries({ queryKey: sessionsQueryRoot });
+      onClose();
+      onResumedAgent(agent.id);
+    },
+  });
+
+  const resumingAgentId = resumeMutation.isPending ? resumeMutation.variables?.id : null;
+
+  const handleResumeSession = useCallback(
+    (agent: AgentSnapshotPayload) => {
+      resumeMutation.mutate(agent);
+    },
+    [resumeMutation],
+  );
+
+  const isLoadingSessions = agentsQuery.isPending;
+  const showEmptyState = !isLoadingSessions && !agentsQuery.isError && visibleEntries.length === 0;
+  const showFilter = filterProviders.length > 1;
+
+  return (
+    <AdaptiveModalSheet
+      visible={visible}
+      onClose={onClose}
+      title="Resume session"
+      testID="workspace-resume-sheet"
+      desktopMaxWidth={560}
+      snapPoints={IMPORT_SHEET_SNAP_POINTS}
+    >
+      {showFilter ? (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.filterRow}
+        >
+          <SegmentedControl
+            testID="workspace-resume-filters"
+            size="sm"
+            options={filterOptions}
+            value={selectedProvider}
+            onValueChange={setSelectedProvider}
+          />
+        </ScrollView>
+      ) : null}
+      <SheetStatusMessages
+        isClientReady={isClientReady}
+        isLoadingSessions={isLoadingSessions}
+        isLoadError={agentsQuery.isError}
+        resumeErrored={resumeMutation.isError}
+        showEmptyState={showEmptyState}
+      />
+      {visibleEntries.length > 0 ? (
+        <View style={styles.list}>
+          {visibleEntries.map((agent) => (
+            <WorkspaceImportSheetRow
+              key={agent.id}
+              agent={agent}
+              disabled={resumeMutation.isPending}
+              resuming={resumingAgentId === agent.id}
+              onResumeSession={handleResumeSession}
+            />
+          ))}
+        </View>
+      ) : null}
+    </AdaptiveModalSheet>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  filterRow: {
+    flexDirection: "row",
+    paddingBottom: theme.spacing[2],
+  },
+  list: {
+    gap: theme.spacing[1],
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: theme.spacing[2],
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[2],
+    marginHorizontal: -theme.spacing[2],
+    borderRadius: theme.borderRadius.lg,
+  },
+  rowHovered: {
+    backgroundColor: theme.colors.surface1,
+  },
+  rowPressed: {
+    backgroundColor: theme.colors.surface2,
+  },
+  rowIconWrap: {
+    width: theme.iconSize.md,
+    paddingTop: 2,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  rowContent: {
+    flex: 1,
+    minWidth: 0,
+    gap: theme.spacing[1],
+  },
+  rowHeader: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: theme.spacing[2],
+  },
+  rowTitle: {
+    flex: 1,
+    minWidth: 0,
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+  },
+  rowMeta: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  rowPreview: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    lineHeight: 20,
+  },
+  statusRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    paddingVertical: theme.spacing[2],
+  },
+  statusText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+}));

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -59,6 +59,7 @@ import { WorkspaceGitActions } from "@/git/workspace-actions";
 import { WorkspaceOpenInEditorButton } from "@/screens/workspace/workspace-open-in-editor-button";
 import { WorkspaceScriptsButton } from "@/screens/workspace/workspace-scripts-button";
 import { WorkspaceImportSheet } from "@/screens/workspace/workspace-import-sheet";
+import { WorkspaceResumeSheet } from "@/screens/workspace/workspace-resume-sheet";
 import { ExplorerSidebarAnimationProvider } from "@/contexts/explorer-sidebar-animation-context";
 import { useToast } from "@/contexts/toast-context";
 import { useExplorerOpenGesture } from "@/hooks/use-explorer-open-gesture";
@@ -783,7 +784,7 @@ interface WorkspaceHeaderMenuProps {
   showCreateBrowserTab: boolean;
   isMobile: boolean;
   createTerminalDisabled: boolean;
-  importAgentDisabled: boolean;
+  resumeSessionDisabled: boolean;
   menuNewAgentIcon: ReactElement;
   menuNewTerminalIcon: ReactElement;
   menuNewBrowserIcon: ReactElement;
@@ -793,7 +794,7 @@ interface WorkspaceHeaderMenuProps {
   onCreateDraftTab: () => void;
   onCreateTerminal: () => void;
   onCreateBrowser: () => void;
-  onOpenImportSheet: () => void;
+  onOpenResumeSheet: () => void;
   onCopyWorkspacePath: () => void;
   onCopyBranchName: () => void;
   onOpenSetupTab: () => void;
@@ -820,7 +821,7 @@ function WorkspaceHeaderMenu({
   showCreateBrowserTab,
   isMobile,
   createTerminalDisabled,
-  importAgentDisabled,
+  resumeSessionDisabled,
   menuNewAgentIcon,
   menuNewTerminalIcon,
   menuNewBrowserIcon,
@@ -830,7 +831,7 @@ function WorkspaceHeaderMenu({
   onCreateDraftTab,
   onCreateTerminal,
   onCreateBrowser,
-  onOpenImportSheet,
+  onOpenResumeSheet,
   onCopyWorkspacePath,
   onCopyBranchName,
   onOpenSetupTab,
@@ -880,10 +881,10 @@ function WorkspaceHeaderMenu({
         <DropdownMenuItem
           testID="workspace-header-import-agent"
           leading={menuImportIcon}
-          disabled={importAgentDisabled}
-          onSelect={onOpenImportSheet}
+          disabled={resumeSessionDisabled}
+          onSelect={onOpenResumeSheet}
         >
-          Import session
+          Resume session
         </DropdownMenuItem>
         <DropdownMenuItem
           testID="workspace-header-copy-path"
@@ -932,7 +933,7 @@ interface WorkspaceHeaderTitleBarProps {
   showCreateBrowserTab: boolean;
   isMobile: boolean;
   createTerminalDisabled: boolean;
-  importAgentDisabled: boolean;
+  resumeSessionDisabled: boolean;
   menuNewAgentIcon: ReactElement;
   menuNewTerminalIcon: ReactElement;
   menuNewBrowserIcon: ReactElement;
@@ -942,7 +943,7 @@ interface WorkspaceHeaderTitleBarProps {
   onCreateDraftTab: () => void;
   onCreateTerminal: () => void;
   onCreateBrowser: () => void;
-  onOpenImportSheet: () => void;
+  onOpenResumeSheet: () => void;
   onCopyWorkspacePath: () => void;
   onCopyBranchName: () => void;
   onOpenSetupTab: () => void;
@@ -961,7 +962,7 @@ function WorkspaceHeaderTitleBar({
   showCreateBrowserTab,
   isMobile,
   createTerminalDisabled,
-  importAgentDisabled,
+  resumeSessionDisabled,
   menuNewAgentIcon,
   menuNewTerminalIcon,
   menuNewBrowserIcon,
@@ -971,7 +972,7 @@ function WorkspaceHeaderTitleBar({
   onCreateDraftTab,
   onCreateTerminal,
   onCreateBrowser,
-  onOpenImportSheet,
+  onOpenResumeSheet,
   onCopyWorkspacePath,
   onCopyBranchName,
   onOpenSetupTab,
@@ -1009,7 +1010,7 @@ function WorkspaceHeaderTitleBar({
         showCreateBrowserTab={showCreateBrowserTab}
         isMobile={isMobile}
         createTerminalDisabled={createTerminalDisabled}
-        importAgentDisabled={importAgentDisabled}
+        resumeSessionDisabled={resumeSessionDisabled}
         menuNewAgentIcon={menuNewAgentIcon}
         menuNewTerminalIcon={menuNewTerminalIcon}
         menuNewBrowserIcon={menuNewBrowserIcon}
@@ -1019,7 +1020,7 @@ function WorkspaceHeaderTitleBar({
         onCreateDraftTab={onCreateDraftTab}
         onCreateTerminal={onCreateTerminal}
         onCreateBrowser={onCreateBrowser}
-        onOpenImportSheet={onOpenImportSheet}
+        onOpenResumeSheet={onOpenResumeSheet}
         onCopyWorkspacePath={onCopyWorkspacePath}
         onCopyBranchName={onCopyBranchName}
         onOpenSetupTab={onOpenSetupTab}
@@ -1473,12 +1474,19 @@ function WorkspaceScreenContent({
   const { workspaceDirectory, isMissingWorkspaceExecutionAuthority } =
     resolveWorkspaceAuthorityState(workspaceAuthority, workspaceDescriptor);
   const [isImportSheetVisible, setIsImportSheetVisible] = useState(false);
+  const [isResumeSheetVisible, setIsResumeSheetVisible] = useState(false);
   const canOpenImportSheet = [client, isConnected, workspaceDirectory].every(Boolean);
   const openImportSheet = useCallback(() => {
     setIsImportSheetVisible(true);
   }, []);
   const closeImportSheet = useCallback(() => {
     setIsImportSheetVisible(false);
+  }, []);
+  const openResumeSheet = useCallback(() => {
+    setIsResumeSheetVisible(true);
+  }, []);
+  const closeResumeSheet = useCallback(() => {
+    setIsResumeSheetVisible(false);
   }, []);
 
   // Warm the global provider snapshot so the model picker is ready when opened.
@@ -1678,6 +1686,15 @@ function WorkspaceScreenContent({
     () => (workspaceLayout ? collectAllTabs(workspaceLayout.root) : EMPTY_UI_TABS),
     [workspaceLayout],
   );
+  const openAgentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const tab of uiTabs) {
+      if (tab.target.kind === "agent") {
+        ids.add(tab.target.agentId);
+      }
+    }
+    return ids;
+  }, [uiTabs]);
   useSyncWorkspaceActiveBrowser({ workspaceLayout, isRouteFocused });
   const openWorkspaceTabInBackground = useWorkspaceLayoutStore(
     (state) => state.openTabInBackground,
@@ -1855,7 +1872,7 @@ function WorkspaceScreenContent({
     },
     [focusWorkspaceTab, persistenceKey],
   );
-  const handleImportedAgent = useCallback(
+  const openAgentTab = useCallback(
     (agentId: string) => {
       if (!persistenceKey) {
         return;
@@ -3140,7 +3157,7 @@ function WorkspaceScreenContent({
                         showCreateBrowserTab={showCreateBrowserTab}
                         isMobile={isMobile}
                         createTerminalDisabled={createTerminalDisabled}
-                        importAgentDisabled={!canOpenImportSheet}
+                        resumeSessionDisabled={!canOpenImportSheet}
                         menuNewAgentIcon={menuNewAgentIcon}
                         menuNewTerminalIcon={menuNewTerminalIcon}
                         menuNewBrowserIcon={MENU_NEW_BROWSER_ICON}
@@ -3150,7 +3167,7 @@ function WorkspaceScreenContent({
                         onCreateDraftTab={handleCreateDraftTab}
                         onCreateTerminal={handleCreateTerminal}
                         onCreateBrowser={handleCreateBrowserTab}
-                        onOpenImportSheet={openImportSheet}
+                        onOpenResumeSheet={openResumeSheet}
                         onCopyWorkspacePath={handleCopyWorkspacePath}
                         onCopyBranchName={handleCopyBranchName}
                         onOpenSetupTab={handleOpenSetupTab}
@@ -3238,7 +3255,16 @@ function WorkspaceScreenContent({
             serverId={normalizedServerId}
             workspaceDirectory={workspaceDirectory}
             onClose={closeImportSheet}
-            onImportedAgent={handleImportedAgent}
+            onImportedAgent={openAgentTab}
+          />
+          <WorkspaceResumeSheet
+            visible={isResumeSheetVisible}
+            client={client}
+            serverId={normalizedServerId}
+            workspaceDirectory={workspaceDirectory}
+            openAgentIds={openAgentIds}
+            onClose={closeResumeSheet}
+            onResumedAgent={openAgentTab}
           />
         </View>
       </WorkspaceFocusProvider>

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -23,6 +23,7 @@ import { addWaitOptions, runWaitCommand } from "./commands/agent/wait.js";
 import { addArchiveOptions, runArchiveCommand } from "./commands/agent/archive.js";
 import { addAttachOptions, runAttachCommand } from "./commands/agent/attach.js";
 import { addImportOptions, runImportCommand } from "./commands/agent/import.js";
+import { addResumeOptions, runResumeCommand } from "./commands/agent/resume.js";
 import { withOutput } from "./output/index.js";
 import { onboardCommand } from "./commands/onboard.js";
 import {
@@ -63,6 +64,10 @@ export function createCli(): Command {
 
   addJsonAndDaemonHostOptions(addImportOptions(program.command("import"))).action(
     withOutput(runImportCommand),
+  );
+
+  addJsonAndDaemonHostOptions(addResumeOptions(program.command("resume"))).action(
+    withOutput(runResumeCommand),
   );
 
   addDaemonHostOption(addAttachOptions(program.command("attach"))).action(runAttachCommand);

--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -11,6 +11,7 @@ import { addInspectOptions, runInspectCommand } from "./inspect.js";
 import { addWaitOptions, runWaitCommand } from "./wait.js";
 import { addAttachOptions, runAttachCommand } from "./attach.js";
 import { addReloadOptions, runReloadCommand } from "./reload.js";
+import { addResumeOptions, runResumeCommand } from "./resume.js";
 import { addImportOptions, runImportCommand } from "./import.js";
 import { runUpdateCommand } from "./update.js";
 import { withOutput } from "../../output/index.js";
@@ -32,6 +33,10 @@ export function createAgentCommand(): Command {
 
   addJsonAndDaemonHostOptions(addImportOptions(agent.command("import"))).action(
     withOutput(runImportCommand),
+  );
+
+  addJsonAndDaemonHostOptions(addResumeOptions(agent.command("resume"))).action(
+    withOutput(runResumeCommand),
   );
 
   addDaemonHostOption(addAttachOptions(agent.command("attach"))).action(runAttachCommand);

--- a/packages/cli/src/commands/agent/resume.ts
+++ b/packages/cli/src/commands/agent/resume.ts
@@ -1,0 +1,104 @@
+import { Command } from "commander";
+import type { DaemonClient } from "@getpaseo/server";
+import { connectToDaemon, getDaemonHost, resolveAgentId } from "../../utils/client.js";
+import type {
+  CommandOptions,
+  SingleResult,
+  OutputSchema,
+  CommandError,
+} from "../../output/index.js";
+
+export interface AgentResumeResult {
+  agentId: string;
+  status: "resumed";
+}
+
+export const resumeSchema: OutputSchema<AgentResumeResult> = {
+  idField: "agentId",
+  columns: [
+    { header: "AGENT ID", field: "agentId" },
+    { header: "STATUS", field: "status" },
+  ],
+};
+
+export function addResumeOptions(cmd: Command): Command {
+  return cmd
+    .description("Resume an archived or closed agent session")
+    .argument("<id>", "Agent ID, prefix, or name");
+}
+
+export interface AgentResumeOptions extends CommandOptions {
+  host?: string;
+}
+
+export type AgentResumeCommandResult = SingleResult<AgentResumeResult>;
+
+export async function runResumeCommand(
+  agentIdArg: string,
+  options: AgentResumeOptions,
+  _command: Command,
+): Promise<AgentResumeCommandResult> {
+  const host = getDaemonHost({ host: options.host });
+
+  if (!agentIdArg || agentIdArg.trim().length === 0) {
+    const error: CommandError = {
+      code: "MISSING_AGENT_ID",
+      message: "Agent ID is required",
+      details: "Usage: paseo agent resume <id-or-name>",
+    };
+    throw error;
+  }
+
+  let client: DaemonClient;
+  try {
+    client = await connectToDaemon({ host: options.host });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const error: CommandError = {
+      code: "DAEMON_NOT_RUNNING",
+      message: `Cannot connect to daemon at ${host}: ${message}`,
+      details: "Start the daemon with: paseo daemon start",
+    };
+    throw error;
+  }
+
+  try {
+    const agentsPayload = await client.fetchAgents({ filter: { includeArchived: true } });
+    const agents = agentsPayload.entries.map((entry) => entry.agent);
+    const agentId = resolveAgentId(agentIdArg, agents);
+    if (!agentId) {
+      const error: CommandError = {
+        code: "AGENT_NOT_FOUND",
+        message: `Agent not found: ${agentIdArg}`,
+        details: 'Use "paseo ls -a" to list archived agents',
+      };
+      throw error;
+    }
+
+    const agent = await client.resumeAgentSession(agentId);
+
+    await client.close();
+
+    return {
+      type: "single",
+      data: {
+        agentId: agent.id,
+        status: "resumed",
+      },
+      schema: resumeSchema,
+    };
+  } catch (err) {
+    await client.close().catch(() => {});
+
+    if (err && typeof err === "object" && "code" in err) {
+      throw err;
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    const error: CommandError = {
+      code: "RESUME_FAILED",
+      message: `Failed to resume agent: ${message}`,
+    };
+    throw error;
+  }
+}

--- a/packages/cli/tests/34-agent-resume.test.ts
+++ b/packages/cli/tests/34-agent-resume.test.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env npx tsx
+
+import assert from "node:assert";
+import { $ } from "zx";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+$.verbose = false;
+
+console.log("=== Agent Resume Command Tests ===\n");
+
+const port = 10000 + Math.floor(Math.random() * 50000);
+const paseoHome = await mkdtemp(join(tmpdir(), "paseo-test-home-"));
+
+try {
+  {
+    console.log("Test 1: agent resume --help shows options");
+    const result = await $`npx paseo agent resume --help`.nothrow();
+    assert.strictEqual(result.exitCode, 0, "agent resume --help should exit 0");
+    assert(result.stdout.includes("--host"), "help should mention --host option");
+    assert(result.stdout.includes("<id>"), "help should mention required id argument");
+    console.log("✓ agent resume --help shows options\n");
+  }
+
+  {
+    console.log("Test 2: top-level resume --help shows options");
+    const result = await $`npx paseo resume --help`.nothrow();
+    assert.strictEqual(result.exitCode, 0, "resume --help should exit 0");
+    assert(result.stdout.includes("--host"), "help should mention --host option");
+    assert(result.stdout.includes("<id>"), "help should mention required id argument");
+    console.log("✓ top-level resume --help shows options\n");
+  }
+
+  {
+    console.log("Test 3: agent resume requires ID argument");
+    const result =
+      await $`PASEO_HOST=localhost:${port} PASEO_HOME=${paseoHome} npx paseo agent resume`.nothrow();
+    assert.notStrictEqual(result.exitCode, 0, "should fail without id");
+    const output = result.stdout + result.stderr;
+    const hasError =
+      output.toLowerCase().includes("missing") ||
+      output.toLowerCase().includes("required") ||
+      output.toLowerCase().includes("argument");
+    assert(hasError, "error should mention missing argument");
+    console.log("✓ agent resume requires ID argument\n");
+  }
+
+  {
+    console.log("Test 4: agent resume handles daemon not running");
+    const result =
+      await $`PASEO_HOST=localhost:${port} PASEO_HOME=${paseoHome} npx paseo agent resume abc123`.nothrow();
+    assert.notStrictEqual(result.exitCode, 0, "should fail when daemon not running");
+    const output = result.stdout + result.stderr;
+    const hasError =
+      output.toLowerCase().includes("daemon") ||
+      output.toLowerCase().includes("connect") ||
+      output.toLowerCase().includes("cannot");
+    assert(hasError, "error message should mention connection issue");
+    console.log("✓ agent resume handles daemon not running\n");
+  }
+
+  {
+    console.log("Test 5: agent --help shows resume subcommand");
+    const result = await $`npx paseo agent --help`.nothrow();
+    assert.strictEqual(result.exitCode, 0, "agent --help should exit 0");
+    assert(result.stdout.includes("resume"), "help should mention resume subcommand");
+    console.log("✓ agent --help shows resume subcommand\n");
+  }
+} finally {
+  await rm(paseoHome, { recursive: true, force: true });
+}
+
+console.log("=== All agent resume tests passed ===");

--- a/packages/server/src/client/daemon-client.test.ts
+++ b/packages/server/src/client/daemon-client.test.ts
@@ -2028,6 +2028,128 @@ test("imports an agent by provider handle id", async () => {
   });
 });
 
+test("resumes an agent session by agent id", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const promise = client.resumeAgentSession("agent-1");
+
+  expect(mock.sent).toHaveLength(1);
+  const request = JSON.parse(String(mock.sent[0])) as {
+    type: "session";
+    message: {
+      type: "resume_agent_session_request";
+      requestId: string;
+      agentId: string;
+    };
+  };
+  expect(request.message).toMatchObject({
+    type: "resume_agent_session_request",
+    agentId: "agent-1",
+  });
+
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "status",
+      payload: {
+        status: "agent_resumed",
+        requestId: request.message.requestId,
+        agentId: "agent-1",
+        timelineSize: 0,
+        agent: {
+          id: "agent-1",
+          provider: "custom-codex",
+          cwd: "/tmp/repo",
+          model: null,
+          features: [],
+          thinkingOptionId: null,
+          effectiveThinkingOptionId: null,
+          createdAt: "2026-04-30T00:00:00.000Z",
+          updatedAt: "2026-04-30T00:00:00.000Z",
+          lastUserMessageAt: null,
+          status: "idle",
+          capabilities: {
+            supportsStreaming: false,
+            supportsSessionPersistence: false,
+            supportsDynamicModes: false,
+            supportsMcpServers: false,
+            supportsReasoningStream: false,
+            supportsToolInvocations: false,
+          },
+          currentModeId: null,
+          availableModes: [],
+          pendingPermissions: [],
+          persistence: {
+            provider: "custom-codex",
+            sessionId: "thread-1",
+            nativeHandle: "thread-1",
+          },
+          title: null,
+          labels: {},
+          requiresAttention: false,
+          attentionReason: null,
+        },
+      },
+    }),
+  );
+
+  await expect(promise).resolves.toMatchObject({
+    id: "agent-1",
+    provider: "custom-codex",
+  });
+});
+
+test("rejects when session resume fails", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const promise = client.resumeAgentSession("agent-1");
+  const request = JSON.parse(String(mock.sent[0])) as {
+    type: "session";
+    message: { requestId: string };
+  };
+
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "status",
+      payload: {
+        status: "agent_resume_failed",
+        requestId: request.message.requestId,
+        agentId: "agent-1",
+        error: "missing persistence",
+      },
+    }),
+  );
+
+  await expect(promise).rejects.toThrow("missing persistence");
+});
+
 test("uses server-provided dictation finish timeout budget", async () => {
   vi.useFakeTimers();
   const logger = createMockLogger();

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -4,6 +4,7 @@ import {
   AgentCreateFailedStatusPayloadSchema,
   AgentCreatedStatusPayloadSchema,
   AgentRefreshedStatusPayloadSchema,
+  AgentResumeFailedStatusPayloadSchema,
   AgentResumedStatusPayloadSchema,
   parseServerInfoStatusPayload,
   RestartRequestedStatusPayloadSchema,
@@ -1942,9 +1943,53 @@ export class DaemonClient {
         if (resumed.success && resumed.data.requestId === requestId) {
           return resumed.data;
         }
+        const failed = AgentResumeFailedStatusPayloadSchema.safeParse(msg.payload);
+        if (failed.success && failed.data.requestId === requestId) {
+          return failed.data;
+        }
         return null;
       },
     });
+
+    if (status.status === "agent_resume_failed") {
+      throw new Error(status.error);
+    }
+
+    return status.agent;
+  }
+
+  async resumeAgentSession(agentId: string, requestId?: string): Promise<AgentSnapshotPayload> {
+    const resolvedRequestId = this.createRequestId(requestId);
+    const message = SessionInboundMessageSchema.parse({
+      type: "resume_agent_session_request",
+      agentId,
+      requestId: resolvedRequestId,
+    });
+
+    const status = await this.sendRequest({
+      requestId: resolvedRequestId,
+      message,
+      timeout: 15000,
+      options: { skipQueue: true },
+      select: (msg) => {
+        if (msg.type !== "status") {
+          return null;
+        }
+        const resumed = AgentResumedStatusPayloadSchema.safeParse(msg.payload);
+        if (resumed.success && resumed.data.requestId === resolvedRequestId) {
+          return resumed.data;
+        }
+        const failed = AgentResumeFailedStatusPayloadSchema.safeParse(msg.payload);
+        if (failed.success && failed.data.requestId === resolvedRequestId) {
+          return failed.data;
+        }
+        return null;
+      },
+    });
+
+    if (status.status === "agent_resume_failed") {
+      throw new Error(status.error);
+    }
 
     return status.agent;
   }

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1764,6 +1764,8 @@ export class Session {
         return this.handleCreateAgentRequest(msg);
       case "resume_agent_request":
         return this.handleResumeAgentRequest(msg);
+      case "resume_agent_session_request":
+        return this.handleResumeAgentSessionRequest(msg);
       case "import_agent_request":
         return this.handleImportAgentRequest(msg);
       case "refresh_agent_request":
@@ -3085,16 +3087,105 @@ export class Session {
       }
     } catch (error) {
       this.sessionLogger.error({ err: error }, "Failed to resume agent");
+      const message = getErrorMessage(error);
+      if (requestId) {
+        this.emit({
+          type: "status",
+          payload: {
+            status: "agent_resume_failed",
+            requestId,
+            error: message,
+          },
+        });
+      }
       this.emit({
         type: "activity_log",
         payload: {
           id: uuidv4(),
           timestamp: new Date(),
           type: "error",
-          content: `Failed to resume agent: ${getErrorMessage(error)}`,
+          content: `Failed to resume agent: ${message}`,
         },
       });
     }
+  }
+
+  private async handleResumeAgentSessionRequest(
+    msg: Extract<SessionInboundMessage, { type: "resume_agent_session_request" }>,
+  ): Promise<void> {
+    const { agentId, requestId } = msg;
+    this.sessionLogger.info({ agentId }, `Resuming agent session ${agentId}`);
+
+    try {
+      const snapshot = await this.resumeAgentSessionById(agentId);
+      await this.agentManager.hydrateTimelineFromProvider(snapshot.id);
+      await this.forwardAgentUpdate(snapshot);
+      const timelineSize = this.agentManager.getTimeline(snapshot.id).length;
+      const agentPayload = await this.buildAgentPayload(snapshot);
+      this.emit({
+        type: "status",
+        payload: {
+          status: "agent_resumed",
+          agentId: snapshot.id,
+          requestId,
+          timelineSize,
+          agent: agentPayload,
+        },
+      });
+    } catch (error) {
+      const message = getErrorMessage(error);
+      this.sessionLogger.error(
+        { err: error, agentId },
+        `Failed to resume agent session ${agentId}`,
+      );
+      this.emit({
+        type: "status",
+        payload: {
+          status: "agent_resume_failed",
+          agentId,
+          requestId,
+          error: message,
+        },
+      });
+      this.emit({
+        type: "activity_log",
+        payload: {
+          id: uuidv4(),
+          timestamp: new Date(),
+          type: "error",
+          content: `Failed to resume agent: ${message}`,
+        },
+      });
+    }
+  }
+
+  private async resumeAgentSessionById(agentId: string): Promise<ManagedAgent> {
+    const existing = this.agentManager.getAgent(agentId);
+    await unarchiveAgentState(this.agentStorage, this.agentManager, agentId);
+    if (existing) {
+      return this.agentManager.getAgent(agentId) ?? existing;
+    }
+
+    const record = await this.agentStorage.get(agentId);
+    if (!record) {
+      throw new Error(`Agent not found: ${agentId}`);
+    }
+
+    const providerRegistry = this.getProviderRegistry();
+    if (!isStoredAgentProviderAvailable(record, Object.keys(providerRegistry))) {
+      throw new Error(`Agent ${agentId} references unavailable provider '${record.provider}'`);
+    }
+    const handle = toAgentPersistenceHandle(providerRegistry, record.persistence);
+    if (!handle) {
+      throw new Error(`Agent ${agentId} cannot be resumed because it lacks persistence`);
+    }
+
+    return await this.agentManager.resumeAgentFromPersistence(
+      handle,
+      buildConfigOverrides(record),
+      agentId,
+      extractTimestamps(record),
+    );
   }
 
   private async handleImportAgentRequest(

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1090,6 +1090,12 @@ export const ResumeAgentRequestMessageSchema = z.object({
   requestId: z.string(),
 });
 
+export const ResumeAgentSessionRequestMessageSchema = z.object({
+  type: z.literal("resume_agent_session_request"),
+  agentId: z.string(),
+  requestId: z.string(),
+});
+
 export const ImportAgentRequestMessageSchema = z.object({
   type: z.literal("import_agent_request"),
   provider: AgentProviderSchema.optional(),
@@ -1741,6 +1747,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   RefreshProvidersSnapshotRequestMessageSchema,
   ProviderDiagnosticRequestMessageSchema,
   ResumeAgentRequestMessageSchema,
+  ResumeAgentSessionRequestMessageSchema,
   ImportAgentRequestMessageSchema,
   RefreshAgentRequestMessageSchema,
   CancelAgentRequestMessageSchema,
@@ -2053,6 +2060,13 @@ export const AgentResumedStatusPayloadSchema = z
   })
   .extend(AgentStatusWithTimelineSchema.shape);
 
+export const AgentResumeFailedStatusPayloadSchema = z.object({
+  status: z.literal("agent_resume_failed"),
+  requestId: z.string(),
+  agentId: z.string().optional(),
+  error: z.string(),
+});
+
 export const AgentRefreshedStatusPayloadSchema = z
   .object({
     status: z.literal("agent_refreshed"),
@@ -2083,6 +2097,7 @@ export const KnownStatusPayloadSchema = z.discriminatedUnion("status", [
   AgentCreatedStatusPayloadSchema,
   AgentCreateFailedStatusPayloadSchema,
   AgentResumedStatusPayloadSchema,
+  AgentResumeFailedStatusPayloadSchema,
   AgentRefreshedStatusPayloadSchema,
   ShutdownRequestedStatusPayloadSchema,
   RestartRequestedStatusPayloadSchema,
@@ -3634,6 +3649,9 @@ export type LoopInspectRequest = z.infer<typeof LoopInspectRequestSchema>;
 export type LoopLogsRequest = z.infer<typeof LoopLogsRequestSchema>;
 export type LoopStopRequest = z.infer<typeof LoopStopRequestSchema>;
 export type ResumeAgentRequestMessage = z.infer<typeof ResumeAgentRequestMessageSchema>;
+export type ResumeAgentSessionRequestMessage = z.infer<
+  typeof ResumeAgentSessionRequestMessageSchema
+>;
 export type DeleteAgentRequestMessage = z.infer<typeof DeleteAgentRequestMessageSchema>;
 export type UpdateAgentRequestMessage = z.infer<typeof UpdateAgentRequestMessageSchema>;
 export type SetAgentModeRequestMessage = z.infer<typeof SetAgentModeRequestMessageSchema>;


### PR DESCRIPTION
## Summary
- Add a Paseo session resume flow across app, CLI, daemon client, and server messages.
- Add workspace resume UI and tests, plus CLI support for `agent resume`.
- Wire resume initialization so existing agent sessions can be continued from the app.

## Test plan
- `npx vitest run packages/app/src/screens/workspace/workspace-import-sheet.test.tsx --bail=1`
- `npx vitest run packages/app/src/screens/workspace/workspace-resume-sheet.test.tsx --bail=1`
- `npx vitest run packages/app/src/hooks/use-agent-initialization.test.ts --bail=1`
- `npx vitest run packages/server/src/client/daemon-client.test.ts --bail=1`
- `npx tsx packages/cli/tests/34-agent-resume.test.ts`
- `npm run build:daemon`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- Playwright smoke test against the Expo web app on `http://localhost:8082/`