### PR TITLE
fix(acp): improve resume recall behavior

### DIFF
--- a/packages/server/src/server/agent/agent-loading.test.ts
+++ b/packages/server/src/server/agent/agent-loading.test.ts
@@ -1,0 +1,75 @@
+import pino from "pino";
+import { expect, test, vi } from "vitest";
+import { ensureAgentLoaded } from "./agent-loading.js";
+import type { AgentManager, ManagedAgent } from "./agent-manager.js";
+import type { AgentStorage, StoredAgentRecord } from "./agent-storage.js";
+
+test("ensureAgentLoaded replays provider history when resuming persisted sessions", async () => {
+  const agentId = "11111111-1111-4111-8111-111111111111";
+  const now = "2026-05-12T00:00:00.000Z";
+  const record: StoredAgentRecord = {
+    id: agentId,
+    provider: "droid",
+    cwd: "/tmp/project",
+    createdAt: now,
+    updatedAt: now,
+    lastActivityAt: "2026-05-12T00:01:00.000Z",
+    lastUserMessageAt: "2026-05-12T00:02:00.000Z",
+    labels: { kind: "custom-acp" },
+    lastStatus: "closed",
+    lastModeId: "auto-high",
+    config: {
+      model: "custom:GPT-5.5-Medium-1",
+      title: "Droid session",
+    },
+    persistence: {
+      provider: "droid",
+      sessionId: "droid-session-1",
+      metadata: { provider: "droid", cwd: "/tmp/project" },
+    },
+  };
+  const snapshot = { id: agentId, provider: "droid" } as ManagedAgent;
+  const resumeAgentFromPersistence = vi.fn().mockResolvedValue(snapshot);
+  const agentManager = {
+    getAgent: vi.fn().mockReturnValue(null),
+    getRegisteredProviderIds: vi.fn().mockReturnValue(["droid"]),
+    resumeAgentFromPersistence,
+    hydrateTimelineFromProvider: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AgentManager;
+  const agentStorage = {
+    get: vi.fn().mockResolvedValue(record),
+  } as unknown as AgentStorage;
+
+  await expect(
+    ensureAgentLoaded(agentId, {
+      agentManager,
+      agentStorage,
+      logger: pino({ level: "silent" }),
+    }),
+  ).resolves.toBe(snapshot);
+
+  expect(resumeAgentFromPersistence).toHaveBeenCalledWith(
+    {
+      provider: "droid",
+      sessionId: "droid-session-1",
+      metadata: { provider: "droid", cwd: "/tmp/project" },
+    },
+    {
+      cwd: "/tmp/project",
+      modeId: "auto-high",
+      model: "custom:GPT-5.5-Medium-1",
+      title: "Droid session",
+    },
+    agentId,
+    {
+      createdAt: new Date(now),
+      updatedAt: new Date("2026-05-12T00:01:00.000Z"),
+      lastUserMessageAt: new Date("2026-05-12T00:02:00.000Z"),
+      labels: { kind: "custom-acp" },
+      resumeSessionOptions: {
+        historyReplay: true,
+        configReplayPolicy: "best-effort",
+      },
+    },
+  );
+});

--- a/packages/server/src/server/agent/agent-loading.ts
+++ b/packages/server/src/server/agent/agent-loading.ts
@@ -53,7 +53,13 @@ export async function ensureAgentLoaded(
         handle,
         buildConfigOverrides(record),
         agentId,
-        extractTimestamps(record),
+        {
+          ...extractTimestamps(record),
+          resumeSessionOptions: {
+            historyReplay: true,
+            configReplayPolicy: "best-effort",
+          },
+        },
       );
       deps.logger.info({ agentId, provider: record.provider }, "Agent resumed from persistence");
     } else {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -25,6 +25,7 @@ import {
   type AgentPersistenceHandle,
   type AgentPromptInput,
   type AgentProvider,
+  type AgentResumeSessionOptions,
   type AgentRunOptions,
   type AgentRunResult,
   type AgentSession,
@@ -838,6 +839,7 @@ export class AgentManager {
       updatedAt?: Date;
       lastUserMessageAt?: Date | null;
       labels?: Record<string, string>;
+      resumeSessionOptions?: AgentResumeSessionOptions;
     },
   ): Promise<ManagedAgent> {
     const resolvedAgentId = validateAgentId(
@@ -876,6 +878,10 @@ export class AgentManager {
       handle,
       hasResumeOverrides ? resumeOverrides : undefined,
       launchContext,
+      options?.resumeSessionOptions ?? {
+        historyReplay: false,
+        configReplayPolicy: "best-effort",
+      },
     );
     return this.registerSession(session, normalizedConfig, resolvedAgentId, options);
   }
@@ -913,7 +919,10 @@ export class AgentManager {
     const launchContext = this.buildLaunchContext(agentId);
 
     const session = handle
-      ? await client.resumeSession(handle, normalizedConfig, launchContext)
+      ? await client.resumeSession(handle, normalizedConfig, launchContext, {
+          historyReplay: rehydrateFromDisk,
+          configReplayPolicy: "strict",
+        })
       : await client.createSession(normalizedConfig, launchContext);
 
     this.agentStreamCoalescer.flushAndDiscard(agentId);

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -492,6 +492,19 @@ export interface AgentCreateSessionOptions {
   persistSession?: boolean;
 }
 
+export interface AgentResumeSessionOptions {
+  /**
+   * Whether resume should ask the provider to replay native history.
+   * Defaults to false; normal Paseo recall uses durable Paseo timeline rows.
+   */
+  historyReplay?: boolean;
+  /**
+   * Strict replay is for explicit reload/config changes. Best-effort replay is
+   * for automatic recall where unsupported optional ACP settings must not block loading.
+   */
+  configReplayPolicy?: "strict" | "best-effort";
+}
+
 /**
  * Returned by respondToPermission when the permission resolution requires
  * a follow-up turn (e.g. Codex plan approval → implementation).
@@ -560,6 +573,7 @@ export interface AgentClient {
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
+    options?: AgentResumeSessionOptions,
   ): Promise<AgentSession>;
   listModels(options: ListModelsOptions): Promise<AgentModelDefinition[]>;
   listModes?(options: ListModesOptions): Promise<AgentMode[]>;

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -379,7 +379,13 @@ test("importProviderSession resumes by provider handle, hydrates the timeline, a
     descriptor.persistence,
     { cwd },
     undefined,
-    { labels: undefined },
+    {
+      labels: undefined,
+      resumeSessionOptions: {
+        historyReplay: true,
+        configReplayPolicy: "best-effort",
+      },
+    },
   );
   expect(agentManager.hydrateTimelineFromProvider).toHaveBeenCalledWith(snapshot.id);
   expect(agentManager.setTitle).toHaveBeenCalledWith(snapshot.id, "Trace recent provider sessions");
@@ -437,7 +443,13 @@ test("importProviderSession builds a fallback handle when a non-OpenCode provide
     },
     { cwd },
     undefined,
-    { labels: undefined },
+    {
+      labels: undefined,
+      resumeSessionOptions: {
+        historyReplay: true,
+        configReplayPolicy: "best-effort",
+      },
+    },
   );
 });
 

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -165,6 +165,10 @@ export async function importProviderSession(
     undefined,
     {
       labels,
+      resumeSessionOptions: {
+        historyReplay: true,
+        configReplayPolicy: "best-effort",
+      },
     },
   );
   await unarchiveAgentState(input.agentStorage, input.agentManager, snapshot.id);

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -264,12 +264,53 @@ vi.mock("./providers/generic-acp-agent.js", () => ({
       });
     }
 
-    async createSession(): Promise<never> {
-      throw new Error("not implemented");
+    async createSession() {
+      return this.createMockSession();
     }
 
-    async resumeSession(): Promise<never> {
-      throw new Error("not implemented");
+    async resumeSession() {
+      return this.createMockSession();
+    }
+
+    private createMockSession() {
+      return {
+        provider: "acp",
+        id: "inner-session",
+        capabilities: this.capabilities,
+        async run() {
+          return { text: "" };
+        },
+        async startTurn() {
+          return { turnId: "turn-1" };
+        },
+        subscribe() {
+          return () => undefined;
+        },
+        async *streamHistory() {},
+        async getRuntimeInfo() {
+          return { provider: "acp", sessionId: "inner-session" };
+        },
+        async getAvailableModes() {
+          return [];
+        },
+        async getCurrentMode() {
+          return null;
+        },
+        async setMode() {},
+        getPendingPermissions() {
+          return [];
+        },
+        async respondToPermission() {},
+        describePersistence() {
+          return {
+            provider: "acp",
+            sessionId: "inner-session",
+            metadata: { provider: "acp", cwd: "/tmp/acp" },
+          };
+        },
+        async interrupt() {},
+        async close() {},
+      };
     }
 
     async listModels(): Promise<AgentModelDefinition[]> {
@@ -408,6 +449,30 @@ test("new provider extending acp uses GenericACPAgentClient", () => {
       label: "My Agent",
     },
   ]);
+});
+
+test("custom ACP session persistence rewrites inner metadata provider to outer provider", async () => {
+  const registry = buildProviderRegistry(logger, {
+    providerOverrides: {
+      "my-agent": {
+        extends: "acp",
+        label: "My Agent",
+        command: ["my-agent", "--acp"],
+      },
+    },
+  });
+
+  const session = await registry["my-agent"].createClient(logger).resumeSession({
+    provider: "my-agent",
+    sessionId: "inner-session",
+    metadata: { provider: "my-agent", cwd: "/tmp/acp" },
+  });
+
+  expect(session.describePersistence()).toEqual({
+    provider: "my-agent",
+    sessionId: "inner-session",
+    metadata: { provider: "my-agent", cwd: "/tmp/acp" },
+  });
 });
 
 test('extends: "acp" without command throws', () => {

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -41,6 +41,10 @@ function isNonEmptyStringArray(value: string[]): value is [string, ...string[]] 
   return value.length > 0;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export type { AgentProviderDefinition };
 
 export { AGENT_PROVIDER_DEFINITIONS, getAgentProviderDefinition };
@@ -207,10 +211,12 @@ function mapPersistenceHandle(
   if (!handle) {
     return null;
   }
+  const metadata = isRecord(handle.metadata) ? { ...handle.metadata, provider } : handle.metadata;
 
   return {
     ...handle,
     provider,
+    ...(metadata !== undefined ? { metadata } : {}),
   };
 }
 
@@ -356,7 +362,7 @@ function wrapClientProvider(
           launchContext,
         ),
       ),
-    resumeSession: async (handle, overrides, launchContext) =>
+    resumeSession: async (handle, overrides, launchContext, options) =>
       wrapSessionProvider(
         provider,
         await inner.resumeSession(
@@ -371,6 +377,7 @@ function wrapClientProvider(
               }
             : undefined,
           launchContext,
+          options,
         ),
       ),
     listModels: async (options) =>

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -72,7 +72,7 @@ interface ACPConfiguredOverrideInternals {
   availableModels: Array<{ modelId: string; name: string; description?: string | null }> | null;
   currentMode: string | null;
   currentModel: string | null;
-  applyConfiguredOverrides(): Promise<void>;
+  applyConfiguredOverrides(options?: { policy?: "strict" | "best-effort" }): Promise<void>;
 }
 
 function createSession(): ACPAgentSession {
@@ -263,6 +263,94 @@ function prepareConfiguredOverrideSession(
 
   return { internals, setSessionMode, unstableSetSessionModel, setSessionConfigOption };
 }
+
+function stubResumeSpawn(
+  session: ACPAgentSession,
+  options?: {
+    loadSession?: ReturnType<typeof vi.fn>;
+    resumeSession?: ReturnType<typeof vi.fn>;
+    agentCapabilities?: SpawnedACPProcess["initialize"]["agentCapabilities"];
+  },
+): { loadSession: ReturnType<typeof vi.fn>; resumeSession: ReturnType<typeof vi.fn> } {
+  const loadSession = options?.loadSession ?? vi.fn(async () => ({}));
+  const resumeSession = options?.resumeSession ?? vi.fn(async () => ({}));
+  asInternals<{ spawnProcess: () => Promise<SpawnedACPProcess> }>(session).spawnProcess =
+    async () =>
+      ({
+        child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+        connection: {
+          loadSession,
+          unstable_resumeSession: resumeSession,
+        },
+        initialize: {
+          agentCapabilities: options?.agentCapabilities ?? {
+            loadSession: true,
+            sessionCapabilities: { resume: {} },
+          },
+        },
+      }) as unknown as SpawnedACPProcess;
+  return { loadSession, resumeSession };
+}
+
+function createResumedSession(options?: {
+  historyReplay?: boolean;
+  configReplayPolicy?: "strict" | "best-effort";
+}): ACPAgentSession {
+  return new ACPAgentSession(
+    {
+      provider: "claude-acp",
+      cwd: "/tmp/paseo-acp-test",
+    },
+    {
+      provider: "claude-acp",
+      logger: createTestLogger(),
+      defaultCommand: ["claude", "--acp"],
+      defaultModes: [],
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      handle: {
+        provider: "claude-acp",
+        sessionId: "session-1",
+        metadata: { cwd: "/tmp/paseo-acp-test" },
+      },
+      resumeOptions: options,
+    },
+  );
+}
+
+test("ACP resume prefers session/resume over session/load for normal recall", async () => {
+  const session = createResumedSession({ historyReplay: false });
+  const { loadSession, resumeSession } = stubResumeSpawn(session);
+
+  await session.initializeResumedSession();
+
+  expect(resumeSession).toHaveBeenCalledWith({
+    sessionId: "session-1",
+    cwd: "/tmp/paseo-acp-test",
+    mcpServers: [],
+  });
+  expect(loadSession).not.toHaveBeenCalled();
+});
+
+test("ACP resume uses session/load when history replay is requested", async () => {
+  const session = createResumedSession({ historyReplay: true, configReplayPolicy: "best-effort" });
+  const { loadSession, resumeSession } = stubResumeSpawn(session);
+
+  await session.initializeResumedSession();
+
+  expect(loadSession).toHaveBeenCalledWith({
+    sessionId: "session-1",
+    cwd: "/tmp/paseo-acp-test",
+    mcpServers: [],
+  });
+  expect(resumeSession).not.toHaveBeenCalled();
+});
 
 test("ACP setModel only uses config-option fallback when the matching select choice contains the model", async () => {
   const logger = createTestLogger();
@@ -696,6 +784,79 @@ describe("ACPAgentSession Zed parity", () => {
 
     await expect(internals.applyConfiguredOverrides()).resolves.toBeUndefined();
     expect(setSessionConfigOption).not.toHaveBeenCalled();
+  });
+
+  test("optimistically replays ACP model and mode when session state omits advertised options", async () => {
+    const session = createSessionWithConfig({ modeId: "auto-high", model: "custom-model" });
+    const { internals, setSessionMode, unstableSetSessionModel, setSessionConfigOption } =
+      prepareConfiguredOverrideSession(session, {
+        currentMode: "normal",
+        currentModel: "default-model",
+        availableModes: [],
+        availableModels: null,
+      });
+
+    await expect(
+      internals.applyConfiguredOverrides({ policy: "best-effort" }),
+    ).resolves.toBeUndefined();
+
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "auto-high" });
+    expect(unstableSetSessionModel).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modelId: "custom-model",
+    });
+    expect(setSessionConfigOption).not.toHaveBeenCalled();
+  });
+
+  test("best-effort configured override replay warns and continues when optional ACP methods fail", async () => {
+    const logger = createTestLogger();
+    const childLogger = { trace: vi.fn(), warn: vi.fn() };
+    vi.spyOn(logger, "child").mockReturnValue(asInternals<typeof logger>(childLogger));
+    const session = createSessionWithConfig({ modeId: "auto-high", model: "custom-model" }, logger);
+    const { internals } = prepareConfiguredOverrideSession(session, {
+      currentMode: "normal",
+      currentModel: "default-model",
+      availableModes: [],
+      availableModels: null,
+      connection: {
+        setSessionMode: vi.fn(async () => {
+          throw new Error("mode method missing");
+        }),
+        unstable_setSessionModel: vi.fn(async () => {
+          throw new Error("model method missing");
+        }),
+      },
+    });
+
+    await expect(
+      internals.applyConfiguredOverrides({ policy: "best-effort" }),
+    ).resolves.toBeUndefined();
+
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      { err: expect.any(Error), value: "auto-high" },
+      expect.stringContaining("ACP mode replay failed"),
+    );
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      { err: expect.any(Error), value: "custom-model" },
+      expect.stringContaining("ACP model replay failed"),
+    );
+  });
+
+  test("strict configured override replay fails when optional ACP methods fail", async () => {
+    const session = createSessionWithConfig({ modeId: "auto-high" });
+    const { internals } = prepareConfiguredOverrideSession(session, {
+      currentMode: "normal",
+      availableModes: [],
+      connection: {
+        setSessionMode: vi.fn(async () => {
+          throw new Error("mode method missing");
+        }),
+      },
+    });
+
+    await expect(internals.applyConfiguredOverrides({ policy: "strict" })).rejects.toThrow(
+      "mode method missing",
+    );
   });
 
   test("routes config_option_update and refreshes derived mode, model, and thinking state", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -68,6 +68,7 @@ import {
   type AgentPersistenceHandle,
   type AgentPromptContentBlock,
   type AgentPromptInput,
+  type AgentResumeSessionOptions,
   type AgentRunOptions,
   type AgentRunResult,
   type AgentRuntimeInfo,
@@ -268,9 +269,12 @@ interface ACPAgentSessionOptions {
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
+  resumeOptions?: AgentResumeSessionOptions;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
 }
+
+type ACPConfigReplayPolicy = NonNullable<AgentResumeSessionOptions["configReplayPolicy"]>;
 
 export interface SpawnedACPProcess {
   child: ChildProcessWithoutNullStreams;
@@ -576,6 +580,7 @@ export class ACPAgentClient implements AgentClient {
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
+    options?: AgentResumeSessionOptions,
   ): Promise<AgentSession> {
     if (handle.provider !== this.provider) {
       throw new Error(`Cannot resume ${handle.provider} handle with ${this.provider} provider`);
@@ -611,6 +616,7 @@ export class ACPAgentClient implements AgentClient {
       handle,
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
+      resumeOptions: options,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
     });
@@ -874,6 +880,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   ) => Promise<void>;
   private readonly agentId?: string;
   private readonly launchEnv?: Record<string, string>;
+  private readonly resumeOptions?: AgentResumeSessionOptions;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private readonly pendingPermissions = new Map<string, PendingPermission>();
   private readonly messageAssemblies = new Map<string, MessageAssemblyState>();
@@ -927,6 +934,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.availableModes = options.defaultModes;
     this.agentId = options.agentId;
     this.launchEnv = options.launchEnv;
+    this.resumeOptions = options.resumeOptions;
     this.initialHandle = options.handle;
     this.config = { ...config, provider: options.provider };
     this.currentMode = config.modeId ?? null;
@@ -970,29 +978,51 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.sessionId = handle.sessionId;
     this.bootstrapThreadEventPending = true;
 
+    const historyReplay = this.resumeOptions?.historyReplay === true;
     const sessionCapabilities = this.agentCapabilities?.sessionCapabilities;
-    if (this.agentCapabilities?.loadSession) {
-      this.replayingHistory = true;
+    if (!historyReplay && sessionCapabilities?.resume) {
+      await this.resumeWithoutHistoryReplay(handle);
+    } else if (this.agentCapabilities?.loadSession) {
+      await this.loadWithHistoryReplay(handle);
+    } else if (sessionCapabilities?.resume) {
+      await this.resumeWithoutHistoryReplay(handle);
+    } else {
+      throw new Error(`${this.provider} does not support ACP session resume`);
+    }
+
+    await this.applyConfiguredOverrides({
+      policy: this.resumeOptions?.configReplayPolicy ?? "strict",
+    });
+  }
+
+  private async resumeWithoutHistoryReplay(handle: AgentPersistenceHandle): Promise<void> {
+    if (!this.connection) {
+      throw new Error("ACP session not initialized");
+    }
+    const response = await this.connection.unstable_resumeSession({
+      sessionId: handle.sessionId,
+      cwd: this.config.cwd,
+      mcpServers: normalizeMcpServers(this.config.mcpServers),
+    });
+    this.applySessionState(response);
+  }
+
+  private async loadWithHistoryReplay(handle: AgentPersistenceHandle): Promise<void> {
+    if (!this.connection) {
+      throw new Error("ACP session not initialized");
+    }
+    this.replayingHistory = true;
+    try {
       const response = await this.connection.loadSession({
         sessionId: handle.sessionId,
         cwd: this.config.cwd,
         mcpServers: normalizeMcpServers(this.config.mcpServers),
       });
-      this.replayingHistory = false;
       this.historyPending = this.persistedHistory.length > 0;
       this.applySessionState(response);
-    } else if (sessionCapabilities?.resume) {
-      const response = await this.connection.unstable_resumeSession({
-        sessionId: handle.sessionId,
-        cwd: this.config.cwd,
-        mcpServers: normalizeMcpServers(this.config.mcpServers),
-      });
-      this.applySessionState(response);
-    } else {
-      throw new Error(`${this.provider} does not support ACP session resume`);
+    } finally {
+      this.replayingHistory = false;
     }
-
-    await this.applyConfiguredOverrides();
   }
 
   async run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult> {
@@ -1169,9 +1199,11 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private async setModeWithSelection({
     modeId,
     selection,
+    allowOptimisticMethod = false,
   }: {
     modeId: string;
     selection: ACPModeSelection;
+    allowOptimisticMethod?: boolean;
   }): Promise<void> {
     if (!this.connection || !this.sessionId) {
       throw new Error("ACP session not initialized");
@@ -1209,6 +1241,17 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     } else {
       const modeOption = selection.configOption;
       if (!modeOption) {
+        if (allowOptimisticMethod) {
+          await this.connection.setSessionMode({ sessionId: this.sessionId, modeId });
+          this.currentMode = modeId;
+          this.pushEvent({
+            type: "mode_changed",
+            provider: this.provider,
+            currentModeId: this.currentMode,
+            availableModes: [...this.availableModes],
+          });
+          return;
+        }
         throw new Error(`${this.provider} does not expose ACP mode switching`);
       }
       if (!selection.configChoice) {
@@ -1307,9 +1350,11 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private async setModelWithSelection({
     modelId,
     selection,
+    allowOptimisticMethod = false,
   }: {
     modelId: string;
     selection: ACPModelSelection;
+    allowOptimisticMethod?: boolean;
   }): Promise<void> {
     if (!this.connection || !this.sessionId) {
       throw new Error("ACP session not initialized");
@@ -1349,6 +1394,19 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
     const modelOption = selection.configOption;
     if (!modelOption) {
+      if (allowOptimisticMethod && typeof this.connection.unstable_setSessionModel === "function") {
+        await this.connection.unstable_setSessionModel({
+          sessionId: this.sessionId,
+          modelId,
+        });
+        this.currentModel = modelId;
+        this.pushEvent({
+          type: "model_changed",
+          provider: this.provider,
+          runtimeInfo: this.runtimeInfo(),
+        });
+        return;
+      }
       throw new Error(`${this.provider} does not expose ACP model selection`);
     }
     if (!selection.configChoice) {
@@ -1825,7 +1883,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     return this.modeIdTransformer ? this.modeIdTransformer(modeId) : modeId;
   }
 
-  private async applyConfiguredOverrides(): Promise<void> {
+  private async applyConfiguredOverrides(options?: {
+    policy?: ACPConfigReplayPolicy;
+  }): Promise<void> {
+    const policy = options?.policy ?? "strict";
     const configuredModeId = this.config.modeId;
     if (configuredModeId && configuredModeId !== this.currentMode) {
       const selection = resolveACPModeSelection({
@@ -1833,7 +1894,17 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         availableModes: this.availableModes,
         configOptions: this.configOptions,
       });
-      await this.setModeWithSelection({ modeId: configuredModeId, selection });
+      await this.applyConfiguredOverride(
+        "mode",
+        configuredModeId,
+        () =>
+          this.setModeWithSelection({
+            modeId: configuredModeId,
+            selection,
+            allowOptimisticMethod: true,
+          }),
+        policy,
+      );
     }
     const configuredModelId = this.config.model;
     if (configuredModelId && configuredModelId !== this.currentModel) {
@@ -1842,10 +1913,45 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         availableModels: this.availableModels,
         configOptions: this.configOptions,
       });
-      await this.setModelWithSelection({ modelId: configuredModelId, selection });
+      await this.applyConfiguredOverride(
+        "model",
+        configuredModelId,
+        () =>
+          this.setModelWithSelection({
+            modelId: configuredModelId,
+            selection,
+            allowOptimisticMethod: true,
+          }),
+        policy,
+      );
     }
-    if (this.config.thinkingOptionId && this.config.thinkingOptionId !== this.thinkingOptionId) {
-      await this.setThinkingOption(this.config.thinkingOptionId);
+    const configuredThinkingOptionId = this.config.thinkingOptionId;
+    if (configuredThinkingOptionId && configuredThinkingOptionId !== this.thinkingOptionId) {
+      await this.applyConfiguredOverride(
+        "thinking option",
+        configuredThinkingOptionId,
+        () => this.setThinkingOption(configuredThinkingOptionId),
+        policy,
+      );
+    }
+  }
+
+  private async applyConfiguredOverride(
+    label: string,
+    value: string,
+    apply: () => Promise<void>,
+    policy: ACPConfigReplayPolicy,
+  ): Promise<void> {
+    try {
+      await apply();
+    } catch (error) {
+      if (policy === "strict") {
+        throw error;
+      }
+      this.logger.warn(
+        { err: error, value },
+        `ACP ${label} replay failed during resume; continuing with provider state`,
+      );
     }
   }
 


### PR DESCRIPTION
Type of change
•
[x] Bug fix
•
[ ] New feature (with prior issue + design alignment)
•
[ ] Refactor / code improvement
•
[ ] Docs
What does this PR do
Fixes ACP session recall/resume behavior.
Previously, normal persisted-agent recall could use ACP session/load, which asks providers to replay native history. For providers with ACP replay quirks, that could duplicate or corrupt recalled timelines and make resume less reliable.
This PR separates ACP resume paths:
•
normal recall now prefers ACP session/resume without native history replay
•
explicit import/reload flows can still request session/load history replay
•
persisted config replay can run in best-effort mode so unsupported optional ACP mode/model/thinking settings do not block loading
•
custom ACP provider persistence metadata is normalized to the outer provider id
How did you verify it
Ran focused tests for the changed ACP resume/recall paths:
npx vitest run \
  packages/server/src/server/agent/providers/acp-agent.test.ts \
  packages/server/src/server/agent/provider-registry.test.ts \
  packages/server/src/server/agent/import-sessions.test.ts \
  packages/server/src/server/agent/agent-loading.test.ts \
  --bail=1
Observed: 75 passed
Also ran repo checks:

npm run typecheck
npm run lint
npm run format:check
All passed.

Verified functional with factory droid acp.

Checklist
•
[x] One focused change. Unrelated cleanups split out.
•
[x] npm run typecheck passes
•
[x] npm run lint passes
•
[x] npm run format ran (Biome)
•
[ ] UI changes include screenshots or video for every affected platform
•
[x] Tests added or updated where it made sense
Message the agent, tag @files, or use /commands and /skills
