### PR TITLE
[untested] pi-direct-agent: recover stale 413 overflow sessions

### DIFF
--- a/packages/server/src/server/agent/providers/pi-direct-agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi-direct-agent.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, test, vi } from "vitest";
-import type { Api, Model } from "@mariozechner/pi-ai";
+import type { Api, AssistantMessage, Model } from "@mariozechner/pi-ai";
 import pino from "pino";
 
 import type { AgentStreamEvent } from "../agent-sdk-types.js";
@@ -13,12 +13,49 @@ import {
   type PiDirectSessionAdapter,
 } from "./pi-direct-agent.js";
 
-function createPiSession(prompt: () => Promise<void>): PiDirectSessionAdapter {
+interface CreatePiSessionOptions {
+  prompt?: () => Promise<void>;
+  compact?: () => Promise<void>;
+  messages?: PiDirectSessionAdapter["messages"];
+  errorMessage?: string | null;
+}
+
+function createPiAssistantErrorMessage(errorMessage: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api: "openai-completions",
+    provider: "github-copilot",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "error",
+    errorMessage,
+    timestamp: Date.now(),
+  };
+}
+
+function createPiSession(options: CreatePiSessionOptions = {}): PiDirectSessionAdapter {
+  const prompt = options.prompt ?? vi.fn(async () => undefined);
+  const compact = options.compact ?? vi.fn(async () => undefined);
+
   return {
     sessionId: "pi-session-1",
     thinkingLevel: "medium",
     model: undefined,
-    messages: [],
+    messages: options.messages ?? [],
     extensionRunner: undefined,
     promptTemplates: [],
     resourceLoader: {
@@ -27,7 +64,7 @@ function createPiSession(prompt: () => Promise<void>): PiDirectSessionAdapter {
     agent: {
       state: {
         systemPrompt: "",
-        errorMessage: null,
+        errorMessage: options.errorMessage ?? null,
       },
     },
     sessionManager: {
@@ -36,6 +73,7 @@ function createPiSession(prompt: () => Promise<void>): PiDirectSessionAdapter {
     },
     subscribe: vi.fn(),
     prompt,
+    compact,
     abort: vi.fn(),
     dispose: vi.fn(),
     getSessionStats: vi.fn(() => ({})),
@@ -72,7 +110,9 @@ function createPiModel(provider: string, id: string): Model<Api> {
 describe("PiDirectAgentSession", () => {
   test("treats SDK request abort rejections as turn cancellations", async () => {
     const session = new PiDirectAgentSession(
-      createPiRuntime(createPiSession(() => Promise.reject(new Error("Request was aborted.")))),
+      createPiRuntime(
+        createPiSession({ prompt: () => Promise.reject(new Error("Request was aborted.")) }),
+      ),
       { find: vi.fn(), getAll: vi.fn(() => []) },
       {
         provider: "pi",
@@ -95,8 +135,111 @@ describe("PiDirectAgentSession", () => {
     ]);
   });
 
+  test("compacts stale overflow sessions before prompting again", async () => {
+    const callOrder: string[] = [];
+    const sdkSession = createPiSession({
+      compact: vi.fn(async () => {
+        callOrder.push("compact");
+      }),
+      prompt: vi.fn(async () => {
+        callOrder.push("prompt");
+      }),
+      messages: [createPiAssistantErrorMessage("413 failed to parse request")],
+      errorMessage: "413 failed to parse request",
+    });
+    const session = new PiDirectAgentSession(
+      createPiRuntime(sdkSession),
+      { find: vi.fn(), getAll: vi.fn(() => []) },
+      {
+        provider: "pi",
+        cwd: "/tmp/paseo-pi-test",
+      },
+    );
+
+    await session.startTurn("continue");
+
+    expect(sdkSession.compact).toHaveBeenCalledTimes(1);
+    expect(sdkSession.prompt).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(["compact", "prompt"]);
+  });
+
+  test("does not compact before prompting for non-overflow errors", async () => {
+    const sdkSession = createPiSession({
+      messages: [createPiAssistantErrorMessage("429 rate limit")],
+      errorMessage: "429 rate limit",
+    });
+    const session = new PiDirectAgentSession(
+      createPiRuntime(sdkSession),
+      { find: vi.fn(), getAll: vi.fn(() => []) },
+      {
+        provider: "pi",
+        cwd: "/tmp/paseo-pi-test",
+      },
+    );
+
+    await session.startTurn("continue");
+
+    expect(sdkSession.compact).not.toHaveBeenCalled();
+    expect(sdkSession.prompt).toHaveBeenCalledTimes(1);
+  });
+
+  test("ignores harmless compaction errors and still prompts", async () => {
+    const sdkSession = createPiSession({
+      compact: vi.fn(async () => {
+        throw new Error("Already compacted");
+      }),
+      messages: [createPiAssistantErrorMessage("413 failed to parse request")],
+      errorMessage: "413 failed to parse request",
+    });
+    const session = new PiDirectAgentSession(
+      createPiRuntime(sdkSession),
+      { find: vi.fn(), getAll: vi.fn(() => []) },
+      {
+        provider: "pi",
+        cwd: "/tmp/paseo-pi-test",
+      },
+    );
+
+    await session.startTurn("continue");
+
+    expect(sdkSession.compact).toHaveBeenCalledTimes(1);
+    expect(sdkSession.prompt).toHaveBeenCalledTimes(1);
+  });
+
+  test("emits turn_failed when pre-prompt compaction fails", async () => {
+    const sdkSession = createPiSession({
+      compact: vi.fn(async () => {
+        throw new Error("Compaction exploded");
+      }),
+      messages: [createPiAssistantErrorMessage("413 failed to parse request")],
+      errorMessage: "413 failed to parse request",
+    });
+    const session = new PiDirectAgentSession(
+      createPiRuntime(sdkSession),
+      { find: vi.fn(), getAll: vi.fn(() => []) },
+      {
+        provider: "pi",
+        cwd: "/tmp/paseo-pi-test",
+      },
+    );
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const { turnId } = await session.startTurn("continue");
+
+    expect(sdkSession.prompt).not.toHaveBeenCalled();
+    expect(events).toEqual([
+      {
+        type: "turn_failed",
+        provider: "pi",
+        turnId,
+        error: "Compaction exploded",
+      },
+    ]);
+  });
+
   test("setModel creates a minimal model for new ids under a known provider", async () => {
-    const sdkSession = createPiSession(async () => undefined);
+    const sdkSession = createPiSession();
     const session = new PiDirectAgentSession(
       createPiRuntime(sdkSession),
       {

--- a/packages/server/src/server/agent/providers/pi-direct-agent.ts
+++ b/packages/server/src/server/agent/providers/pi-direct-agent.ts
@@ -27,7 +27,14 @@ import {
   type WriteToolInput,
 } from "@mariozechner/pi-coding-agent";
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
-import type { Api, ImageContent, Model, TextContent } from "@mariozechner/pi-ai";
+import {
+  isContextOverflow,
+  type Api,
+  type AssistantMessage,
+  type ImageContent,
+  type Model,
+  type TextContent,
+} from "@mariozechner/pi-ai";
 import { z } from "zod";
 
 import {
@@ -116,6 +123,7 @@ export type PiDirectSessionAdapter = Pick<
   PiAgentSession,
   | "abort"
   | "agent"
+  | "compact"
   | "dispose"
   | "extensionRunner"
   | "getSessionStats"
@@ -739,6 +747,71 @@ function parsePersistenceMetadata(metadata: AgentMetadata | undefined): PiPersis
   return {};
 }
 
+const PI_STALE_OVERFLOW_ERROR_PATTERNS = [/^413\b.*failed to parse request$/i] as const;
+
+function createPiOverflowProbeMessage(errorMessage: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api: "openai-completions",
+    provider: "github-copilot",
+    model: "pi-overflow-probe",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "error",
+    errorMessage,
+    timestamp: 0,
+  };
+}
+
+function isPiOverflowErrorMessage(errorMessage: string | null | undefined): boolean {
+  const normalized = errorMessage?.trim();
+  if (!normalized) {
+    return false;
+  }
+
+  if (isContextOverflow(createPiOverflowProbeMessage(normalized))) {
+    return true;
+  }
+
+  return PI_STALE_OVERFLOW_ERROR_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function getLatestAssistantErrorMessage(session: PiDirectSessionAdapter): string | null {
+  for (let index = session.messages.length - 1; index >= 0; index -= 1) {
+    const message = session.messages[index];
+    if (message.role !== "assistant") {
+      continue;
+    }
+    return message.stopReason === "error" ? (message.errorMessage?.trim() ?? null) : null;
+  }
+  return null;
+}
+
+function shouldCompactBeforePrompt(session: PiDirectSessionAdapter): boolean {
+  if (isPiOverflowErrorMessage(getLatestAssistantErrorMessage(session))) {
+    return true;
+  }
+  return isPiOverflowErrorMessage(session.agent.state.errorMessage);
+}
+
+function isHarmlessPiCompactionError(error: unknown): boolean {
+  const message = toDiagnosticErrorMessage(error);
+  return /already compacted|nothing to compact/i.test(message);
+}
+
 function isPiRequestAbortError(error: unknown): boolean {
   if (error instanceof Error && error.name === "AbortError") {
     return true;
@@ -1095,6 +1168,27 @@ export class PiDirectAgentSession implements AgentSession {
     const payload = convertPromptInput(prompt);
     const turnId = randomUUID();
     this.activeTurnId = turnId;
+
+    try {
+      if (shouldCompactBeforePrompt(this.session)) {
+        try {
+          await this.session.compact();
+        } catch (error) {
+          if (!isHarmlessPiCompactionError(error)) {
+            throw error;
+          }
+        }
+      }
+    } catch (error) {
+      this.activeTurnId = null;
+      this.emit({
+        type: "turn_failed",
+        provider: PI_PROVIDER,
+        turnId,
+        error: toDiagnosticErrorMessage(error),
+      });
+      return { turnId };
+    }
 
     void this.session
       .prompt(payload.text, payload.images ? { images: payload.images } : undefined)


### PR DESCRIPTION
### Linked issue

Closes #970

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

**UNTESTED AGAINST A LIVE PI/GITHUB-COPILOT 413 REPRO.**

This teaches the Pi provider adapter to recover stale Pi sessions that already died with a context-overflow-like error before sending the next prompt.

Specifically, if the last persisted Pi assistant error looks like a context overflow, `PiDirectAgentSession.startTurn()` now runs `session.compact()` before calling `session.prompt(...)`. I also added a narrow fallback for the Copilot wording we hit in the wild (`413 failed to parse request`), because the bundled Pi overflow detector recognizes Copilot's explicit `prompt token count ... exceeds the limit ...` message but not that shorter 413 string.

The diff is intentionally small and Pi-only:

- expose `compact()` on the Pi session adapter
- detect stale overflow-like Pi errors before the next prompt
- compact once before prompting again
- ignore harmless `Already compacted` / `Nothing to compact` errors so we don't make the wedge worse
- add focused unit tests for the recovery path

### How did you verify it

**Untested code warning:** I did **not** re-run this against a live Pi/github-copilot session that was actually wedged on `413 failed to parse request`. The verification here is unit/integration-at-the-adapter-layer only.

I verified with:

- `cd packages/server && npx vitest run src/server/agent/providers/pi-direct-agent.test.ts --bail=1`
- `npm run format`
- `npm run lint`
- `npm run build:daemon`
- `npm run typecheck`

The added test coverage checks that:

- stale `413 failed to parse request` Pi sessions compact before the next prompt
- non-overflow errors do **not** trigger compaction
- harmless compaction errors still allow prompting
- real compaction failures surface as `turn_failed`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A — no UI changes)
- [x] Tests added or updated where it made sense
