### PR TITLE
Fix relay E2EE reconnect races

### DIFF
--- a/packages/app/src/runtime/host-runtime.test.ts
+++ b/packages/app/src/runtime/host-runtime.test.ts
@@ -302,6 +302,58 @@ function makeProbeMap(
 }
 
 describe("HostRuntimeController", () => {
+  it("replaces the active relay client when re-pairing changes the daemon public key", async () => {
+    const oldRelay: HostConnection = {
+      id: "relay:wss:relay.paseo.sh:443",
+      type: "relay",
+      relayEndpoint: "relay.paseo.sh:443",
+      useTls: true,
+      daemonPublicKeyB64: "pk_old",
+    };
+    const newRelay: HostConnection = {
+      ...oldRelay,
+      daemonPublicKeyB64: "pk_new",
+    };
+    const createdClients: Array<{ client: FakeDaemonClient; connection: HostConnection }> = [];
+    const controller = new HostRuntimeController({
+      host: makeHost({
+        connections: [oldRelay],
+        preferredConnectionId: oldRelay.id,
+      }),
+      deps: {
+        createClient: ({ connection }) => {
+          const client = new FakeDaemonClient();
+          createdClients.push({ client, connection });
+          return client as unknown as DaemonClient;
+        },
+        connectToDaemon: async ({ host, connection }) => ({
+          client: makeConnectedProbeClient(5) as unknown as DaemonClient,
+          serverId: host.serverId,
+          hostname: connection.id,
+        }),
+        getClientId: async () => "cid_test_runtime",
+      },
+    });
+
+    await (
+      controller as unknown as {
+        switchToConnection: (input: { connectionId: string }) => Promise<void>;
+      }
+    ).switchToConnection({ connectionId: oldRelay.id });
+    expect(controller.getSnapshot().client).toBe(createdClients[0]?.client);
+
+    await controller.updateHost(
+      makeHost({
+        connections: [newRelay],
+        preferredConnectionId: newRelay.id,
+      }),
+    );
+
+    expect(createdClients.map((entry) => entry.connection)).toEqual([oldRelay, newRelay]);
+    expect(createdClients[0]?.client.closeCalls).toBe(1);
+    expect(controller.getSnapshot().client).toBe(createdClients[1]?.client);
+  });
+
   it("keeps known hosts in connecting when a created client reports idle during connect", async () => {
     const host = makeHost({
       connections: [

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -602,8 +602,20 @@ export class HostRuntimeController {
   }
 
   async updateHost(host: HostProfile): Promise<void> {
+    const activeConnectionId = this.snapshot.activeConnectionId;
+    const previousActiveConnection = findConnectionById(this.host, activeConnectionId);
     this.host = host;
     this.trackConnectionFirstSeen();
+    const nextActiveConnection = findConnectionById(this.host, activeConnectionId);
+    if (
+      activeConnectionId &&
+      previousActiveConnection &&
+      nextActiveConnection &&
+      !equal(previousActiveConnection, nextActiveConnection)
+    ) {
+      this.connectionLastProbedAt.delete(activeConnectionId);
+      await this.switchToConnection({ connectionId: activeConnectionId });
+    }
     await this.runProbeCycleNow();
   }
 

--- a/packages/relay/src/cloudflare-adapter.ts
+++ b/packages/relay/src/cloudflare-adapter.ts
@@ -201,6 +201,9 @@ export class RelayDurableObject {
       const parsed: unknown = JSON.parse(message);
       const parsedRecord = isRecord(parsed) ? parsed : null;
       if (parsedRecord?.type !== "ping") return;
+      // Logged so the daemon-side e2e idle test can assert no JSON ping reached the DO
+      // (which would indicate a regression to app-level pings that wake the DO).
+      console.log("[Relay DO] legacy_json_ping_received");
       try {
         ws.send(JSON.stringify({ type: "pong", ts: Date.now() }));
       } catch {

--- a/packages/relay/src/cloudflare-adapter.ts
+++ b/packages/relay/src/cloudflare-adapter.ts
@@ -192,6 +192,10 @@ export class RelayDurableObject {
     }
   }
 
+  // COMPAT(relay-json-ping): Old daemons (< v0.1.76) send JSON {type:"ping"} on the control
+  // socket and rely on a JSON {type:"pong"} reply to keep controlLastSeenAt fresh. New daemons
+  // use WebSocket protocol pings (auto-answered at the edge, DO stays hibernated). Remove this
+  // handler once the supported-daemon floor is >= v0.1.76 (target: 2026-11-13).
   private handleControlKeepalive(ws: WebSocket, message: string): void {
     try {
       const parsed: unknown = JSON.parse(message);

--- a/packages/server/src/server/daemon-e2e/relay-transport.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/relay-transport.e2e.test.ts
@@ -10,6 +10,14 @@ import { Buffer } from "node:buffer";
 import { generateLocalPairingOffer } from "../pairing-offer.js";
 import { createTestPaseoDaemon } from "../test-utils/paseo-daemon.js";
 import { createClientChannel, type Transport } from "@getpaseo/relay/e2ee";
+import {
+  deriveSharedKey,
+  decrypt,
+  encrypt,
+  exportPublicKey,
+  generateKeyPair,
+  importPublicKey,
+} from "@getpaseo/relay";
 import { buildRelayWebSocketUrl } from "../../shared/daemon-endpoints.js";
 import { ConnectionOfferSchema } from "../../shared/connection-offer.js";
 import { WSOutboundMessageSchema } from "../../shared/messages.js";
@@ -63,6 +71,23 @@ function decodeOfferFromFragmentUrl(url: string): {
   const json = Buffer.from(encoded, "base64url").toString("utf8");
   const offer = ConnectionOfferSchema.parse(JSON.parse(json));
   return { serverId: offer.serverId, daemonPublicKeyB64: offer.daemonPublicKeyB64 };
+}
+
+function encodeCiphertext(ciphertext: ArrayBuffer): string {
+  return Buffer.from(new Uint8Array(ciphertext)).toString("base64");
+}
+
+function decodeCiphertext(text: string): ArrayBuffer {
+  const buffer = Buffer.from(text, "base64");
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+}
+
+function parseEncryptedJson(sharedKey: Uint8Array, text: string): unknown {
+  const plaintext = decrypt(sharedKey, decodeCiphertext(text));
+  if (typeof plaintext !== "string") {
+    throw new Error("Expected encrypted relay frame to contain UTF-8 JSON");
+  }
+  return JSON.parse(plaintext);
 }
 
 async function getAvailablePort(): Promise<number> {
@@ -448,6 +473,146 @@ async function waitForRelayWebSocketReady(port: number, timeout = 60000): Promis
       });
 
       expect(received).toEqual({ type: "pong" });
+    } catch (err) {
+      const tail = lines.slice(-50).join("");
+      // eslint-disable-next-line no-console
+      console.error("daemon logs (tail):\n", tail);
+      throw err;
+    } finally {
+      await daemon.close();
+      await stopRelay();
+    }
+  }, 90000);
+
+  test("daemon accepts a relay client that pipelines app hello after E2EE hello", async () => {
+    process.env.PASEO_PRIMARY_LAN_IP = "192.168.1.12";
+
+    const { logger, lines } = createCapturingLogger();
+    await startRelay();
+
+    const daemon = await createTestPaseoDaemon({
+      listen: "127.0.0.1",
+      logger,
+      relayEnabled: true,
+      relayEndpoint: `127.0.0.1:${relayPort}`,
+    });
+
+    try {
+      const offerUrl = await getPairingOfferUrl({
+        paseoHome: daemon.paseoHome,
+        relayEnabled: daemon.config.relayEnabled,
+        relayEndpoint: daemon.config.relayEndpoint,
+        relayPublicEndpoint: daemon.config.relayPublicEndpoint,
+        appBaseUrl: daemon.config.appBaseUrl,
+      });
+      const { serverId, daemonPublicKeyB64 } = decodeOfferFromFragmentUrl(offerUrl);
+      const clientKeyPair = generateKeyPair();
+      const sharedKey = deriveSharedKey(
+        clientKeyPair.secretKey,
+        importPublicKey(daemonPublicKeyB64),
+      );
+
+      const ws = new WebSocket(
+        buildRelayWebSocketUrl({
+          endpoint: `127.0.0.1:${relayPort}`,
+          useTls: false,
+          serverId,
+          role: "client",
+        }),
+      );
+
+      const received = await new Promise<unknown>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          ws.close();
+          reject(new Error("timed out waiting for server_info"));
+        }, 20000);
+
+        const settleResolve = (value: unknown) => {
+          clearTimeout(timeout);
+          resolve(value);
+          ws.close();
+        };
+        const settleReject = (reason: unknown) => {
+          clearTimeout(timeout);
+          reject(reason);
+          ws.close();
+        };
+
+        ws.on("open", () => {
+          ws.send(
+            JSON.stringify({
+              type: "e2ee_hello",
+              key: exportPublicKey(clientKeyPair.publicKey),
+            }),
+          );
+          ws.send(
+            encodeCiphertext(
+              encrypt(
+                sharedKey,
+                JSON.stringify({
+                  type: "hello",
+                  clientId: "cid_relay_pipelined_hello",
+                  clientType: "cli",
+                  protocolVersion: 1,
+                }),
+              ),
+            ),
+          );
+        });
+
+        ws.on("message", (data) => {
+          try {
+            const text = typeof data === "string" ? data : data.toString();
+            const maybePlaintext = JSON.parse(text) as unknown;
+            if (
+              maybePlaintext &&
+              typeof maybePlaintext === "object" &&
+              "type" in maybePlaintext &&
+              maybePlaintext.type === "e2ee_ready"
+            ) {
+              return;
+            }
+          } catch {
+            // encrypted frame; parse below
+          }
+
+          try {
+            const parsed = WSOutboundMessageSchema.parse(
+              parseEncryptedJson(sharedKey, data.toString()),
+            );
+            if (
+              parsed.type === "session" &&
+              parsed.message.type === "status" &&
+              parsed.message.payload?.status === "server_info"
+            ) {
+              settleResolve({
+                type: parsed.type,
+                message: {
+                  type: parsed.message.type,
+                  payload: { status: parsed.message.payload.status },
+                },
+              });
+            }
+          } catch (error) {
+            settleReject(error);
+          }
+        });
+
+        ws.on("close", (code, reason) => {
+          settleReject(new Error(`relay client closed before server_info: ${code} ${reason}`));
+        });
+        ws.on("error", (err) => {
+          settleReject(err);
+        });
+      });
+
+      expect(received).toEqual({
+        type: "session",
+        message: {
+          type: "status",
+          payload: { status: "server_info" },
+        },
+      });
     } catch (err) {
       const tail = lines.slice(-50).join("");
       // eslint-disable-next-line no-console

--- a/packages/server/src/server/daemon-e2e/relay-transport.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/relay-transport.e2e.test.ts
@@ -33,7 +33,7 @@ function createCapturingLogger() {
       cb();
     },
   });
-  const logger = pino({ level: "info" }, stream);
+  const logger = pino({ level: "debug" }, stream);
   return { logger, lines };
 }
 
@@ -390,6 +390,15 @@ async function waitForRelayWebSocketReady(port: number, timeout = 60000): Promis
         line.includes("relay_e2ee_handshake_failed"),
       );
       expect(handshakeFailures.length).toBe(0);
+
+      // Protocol pings (RFC 6455 control frames) are auto-answered at the Cloudflare edge
+      // without waking the hibernated relay Durable Object. After 12s, the keepalive interval
+      // (10s) must have fired at least once and received a pong. If this assertion fails, the
+      // daemon may have regressed to app-level JSON pings (which wake the DO and cost CPU).
+      const pongLines = lines.filter((l) => l.includes("relay_control_pong_received"));
+      expect(pongLines.length).toBeGreaterThan(0);
+      const staleLines = lines.filter((l) => l.includes("relay_control_stale_terminating"));
+      expect(staleLines.length).toBe(0);
 
       const ws = new WebSocket(
         buildRelayWebSocketUrl({

--- a/packages/server/src/server/daemon-e2e/relay-transport.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/relay-transport.e2e.test.ts
@@ -167,8 +167,10 @@ async function waitForRelayWebSocketReady(port: number, timeout = 60000): Promis
 (shouldRunRelayE2e ? describe : describe.skip)("Relay transport (E2EE) - daemon E2E", () => {
   let relayPort: number;
   let relayProcess: ChildProcess | null = null;
+  let relayStdoutLines: string[] = [];
 
   const startRelay = async () => {
+    relayStdoutLines = [];
     relayPort = await getAvailablePort();
     const relayDir = path.resolve(process.cwd(), "../relay");
     relayProcess = spawn(
@@ -198,6 +200,7 @@ async function waitForRelayWebSocketReady(port: number, timeout = 60000): Promis
         .split("\n")
         .filter((l) => l.trim());
       for (const line of lines) {
+        relayStdoutLines.push(line);
         // eslint-disable-next-line no-console
         console.log(`[relay] ${line}`);
       }
@@ -399,6 +402,13 @@ async function waitForRelayWebSocketReady(port: number, timeout = 60000): Promis
       expect(pongLines.length).toBeGreaterThan(0);
       const staleLines = lines.filter((l) => l.includes("relay_control_stale_terminating"));
       expect(staleLines.length).toBe(0);
+      // Guard against the dual-ping regression: if a JSON {type:"ping"} reaches the DO during
+      // the idle window, the DO logs `legacy_json_ping_received`. The current daemon code must
+      // not send JSON pings on the control socket — only protocol pings via socket.ping().
+      const legacyPingLines = relayStdoutLines.filter((l) =>
+        l.includes("legacy_json_ping_received"),
+      );
+      expect(legacyPingLines.length).toBe(0);
 
       const ws = new WebSocket(
         buildRelayWebSocketUrl({

--- a/packages/server/src/server/relay-transport.test.ts
+++ b/packages/server/src/server/relay-transport.test.ts
@@ -31,6 +31,7 @@ class FakeRelayWebSocket {
   readyState = FakeRelayWebSocket.CONNECTING;
   sent: Array<string | Uint8Array | ArrayBuffer> = [];
   terminateCalls = 0;
+  pingCalls = 0;
   private readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
 
   constructor(readonly url: string) {}
@@ -67,6 +68,13 @@ class FakeRelayWebSocket {
     this.sent.push(data);
   }
 
+  ping() {
+    if (this.readyState !== FakeRelayWebSocket.OPEN) {
+      throw new Error(`WebSocket not open (readyState=${this.readyState})`);
+    }
+    this.pingCalls += 1;
+  }
+
   open() {
     this.readyState = FakeRelayWebSocket.OPEN;
     this.emit("open");
@@ -74,6 +82,10 @@ class FakeRelayWebSocket {
 
   message(data: unknown) {
     this.emit("message", data);
+  }
+
+  pong() {
+    this.emit("pong");
   }
 
   private off(event: string, listener: (...args: unknown[]) => void) {
@@ -135,9 +147,9 @@ describe("relay-transport control lifecycle", () => {
 
     control.open();
     expect(hasLogMessage(logger, "info", "relay_control_connected")).toBe(false);
-    expect(control.sent.length).toBeGreaterThan(0);
+    expect(control.pingCalls).toBeGreaterThan(0);
 
-    control.message(JSON.stringify({ type: "pong", ts: Date.now() }));
+    control.message(JSON.stringify({ type: "sync", connectionIds: [] }));
     expect(hasLogMessage(logger, "info", "relay_control_connected")).toBe(true);
   });
 
@@ -180,7 +192,7 @@ describe("relay-transport control lifecycle", () => {
 
     const control = relay.sockets[0];
     control.open();
-    control.message(JSON.stringify({ type: "pong", ts: Date.now() }));
+    control.message(JSON.stringify({ type: "sync", connectionIds: [] }));
     logger.messages.length = 0;
 
     vi.advanceTimersByTime(40_000);
@@ -208,7 +220,7 @@ describe("relay-transport control lifecycle", () => {
 
     const control = relay.sockets[0];
     control.open();
-    control.message(JSON.stringify({ type: "pong", ts: Date.now() }));
+    control.message(JSON.stringify({ type: "sync", connectionIds: [] }));
     control.message(JSON.stringify({ type: "connected", connectionId: "clt_test" }));
 
     const dataSocket = relay.sockets[1];
@@ -240,7 +252,7 @@ describe("relay-transport control lifecycle", () => {
 
     const control = relay.sockets[0];
     control.open();
-    control.message(JSON.stringify({ type: "pong", ts: Date.now() }));
+    control.message(JSON.stringify({ type: "sync", connectionIds: [] }));
     control.message(JSON.stringify({ type: "connected", connectionId: "clt_test" }));
 
     expect(relay.sockets[0]?.url).toMatch(/^wss:\/\/\[::1\]\/ws\?/);

--- a/packages/server/src/server/relay-transport.ts
+++ b/packages/server/src/server/relay-transport.ts
@@ -35,8 +35,9 @@ interface RelaySocketLike {
 
 interface RelayWebSocketLike extends RelaySocketLike {
   terminate: () => void;
+  ping: () => void;
   on: (
-    event: "open" | "message" | "close" | "error",
+    event: "open" | "message" | "close" | "error" | "pong",
     listener: (...args: unknown[]) => void,
   ) => void;
 }
@@ -228,7 +229,9 @@ export function startRelayTransport({
         const now = Date.now();
         const staleForMs = now - controlLastSeenAt;
         // If the control socket is half-open or silently dropped, ws may never emit "close".
-        // Use app-level ping/pong to detect staleness and force a reconnect.
+        // Use a WebSocket protocol ping to detect staleness and force a reconnect.
+        // Cloudflare's runtime auto-responds to protocol pings at the edge without waking the
+        // hibernated relay Durable Object, so this keepalive does not incur DO CPU billing.
         if (staleForMs > CONTROL_STALE_TIMEOUT_MS) {
           relayLogger.warn(
             { url, staleForMs, connectionId, staleTimeoutMs: CONTROL_STALE_TIMEOUT_MS },
@@ -243,7 +246,7 @@ export function startRelayTransport({
         }
 
         try {
-          socket.send(JSON.stringify({ type: "ping", ts: now }));
+          socket.ping();
         } catch (error) {
           relayLogger.warn({ err: error, connectionId }, "relay_control_ping_send_failed");
           try {
@@ -254,7 +257,7 @@ export function startRelayTransport({
         }
       }, CONTROL_PING_INTERVAL_MS);
       try {
-        socket.send(JSON.stringify({ type: "ping", ts: Date.now() }));
+        socket.ping();
       } catch (error) {
         relayLogger.warn({ err: error, connectionId }, "relay_control_ping_send_failed");
         try {
@@ -288,6 +291,11 @@ export function startRelayTransport({
       if (controlWs !== socket) return;
       relayLogger.warn({ err, connectionId }, "relay_error");
       // close event will schedule reconnect
+    });
+
+    socket.on("pong", () => {
+      if (controlWs !== socket) return;
+      controlLastSeenAt = Date.now();
     });
 
     socket.on("message", (data) => {

--- a/packages/server/src/server/relay-transport.ts
+++ b/packages/server/src/server/relay-transport.ts
@@ -296,6 +296,7 @@ export function startRelayTransport({
     socket.on("pong", () => {
       if (controlWs !== socket) return;
       controlLastSeenAt = Date.now();
+      relayLogger.debug({ connectionId }, "relay_control_pong_received");
     });
 
     socket.on("message", (data) => {

--- a/packages/server/src/server/relay-transport.ts
+++ b/packages/server/src/server/relay-transport.ts
@@ -423,8 +423,17 @@ async function attachEncryptedSocket(
   try {
     const relayTransport = createRelayTransportAdapter(socket, logger);
     const emitter = new EventEmitter();
+    const pendingMessages: Array<string | ArrayBuffer> = [];
+    let attached = false;
+    const emitMessage = (data: string | ArrayBuffer) => {
+      if (attached) {
+        emitter.emit("message", data);
+        return;
+      }
+      pendingMessages.push(data);
+    };
     const channel = await createDaemonChannel(relayTransport, daemonKeyPair, {
-      onmessage: (data) => emitter.emit("message", data),
+      onmessage: emitMessage,
       onclose: (code, reason) => emitter.emit("close", code, reason),
       onerror: (error) => {
         logger.warn({ err: error }, "relay_e2ee_error");
@@ -433,6 +442,11 @@ async function attachEncryptedSocket(
     });
     const encryptedSocket = createEncryptedSocket(channel, emitter);
     await attachSocket(encryptedSocket, metadata);
+    attached = true;
+    for (const message of pendingMessages) {
+      emitter.emit("message", message);
+    }
+    pendingMessages.length = 0;
   } catch (error) {
     logger.warn({ err: error }, "relay_e2ee_handshake_failed");
     try {


### PR DESCRIPTION
## Summary
- queue decrypted relay app frames until the daemon websocket handler is attached, so pipelined E2EE hello/app hello does not race the daemon setup
- rebuild an active host runtime connection when the selected connection's settings change, so a re-paired relay client does not keep using stale E2EE settings
- add focused app runtime coverage and a real local-wrangler daemon E2E relay test

## Verification
- `npm run build --workspace=@getpaseo/relay`
- `npx vitest run src/types/host-connection.test.ts src/utils/connection-selection.test.ts src/utils/test-daemon-connection.test.ts src/app/host-runtime-bootstrap.test.ts src/runtime/host-runtime.test.ts --bail=1` from `packages/app`
- `npx vitest run src/server/relay-transport.test.ts src/server/daemon-e2e/relay-transport.e2e.test.ts --bail=1` from `packages/server`
- `npm run lint -- packages/app/src/runtime/host-runtime.ts packages/app/src/runtime/host-runtime.test.ts packages/server/src/server/relay-transport.ts packages/server/src/server/daemon-e2e/relay-transport.e2e.test.ts`
- `npm run typecheck`
