### PR TITLE
Fix zsh integration runtime modes

### DIFF
--- a/packages/server/src/terminal/terminal.posix.test.ts
+++ b/packages/server/src/terminal/terminal.posix.test.ts
@@ -20,7 +20,7 @@ import {
 } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { tmpdir, userInfo } from "node:os";
 
 const hasZsh = existsSync("/bin/zsh");
 
@@ -216,6 +216,13 @@ function lastNonEmptyLineIsPrompt(state: ReturnType<TerminalSession["getState"]>
   return last === "$";
 }
 
+function removeZshShellIntegrationRuntimeDir(): void {
+  rmSync(join(tmpdir(), `${userInfo().username || "unknown"}-paseo-zsh`), {
+    recursive: true,
+    force: true,
+  });
+}
+
 describe.skipIf(isPlatform("win32"))("terminal POSIX-only", () => {
   it("sets zsh wrapper env when spawning zsh", () => {
     const resolvedEnv = buildTerminalEnvironment({
@@ -231,6 +238,27 @@ describe.skipIf(isPlatform("win32"))("terminal POSIX-only", () => {
     expect(resolvedEnv.ZDOTDIR).not.toBe("/tmp/paseo-zdotdir");
     expect(existsSync(join(resolvedEnv.ZDOTDIR, ".zshenv"))).toBe(true);
     expect(existsSync(join(resolvedEnv.ZDOTDIR, "paseo-integration.zsh"))).toBe(true);
+  });
+
+  it("reuses zsh shell integration copied from read-only source files", () => {
+    const integrationSourceDir = mkdtempSync(join(tmpdir(), "paseo-zsh-readonly-source-"));
+    const tmpHome = mkdtempSync(join(tmpdir(), "paseo-zsh-readonly-home-"));
+    temporaryDirs.push(integrationSourceDir, tmpHome);
+    cpSync(resolveZshShellIntegrationDir(), integrationSourceDir, { recursive: true });
+    chmodSync(join(integrationSourceDir, ".zshenv"), 0o444);
+    chmodSync(join(integrationSourceDir, "paseo-integration.zsh"), 0o444);
+    removeZshShellIntegrationRuntimeDir();
+
+    const buildEnvironment = () =>
+      buildTerminalEnvironment({
+        shell: "/bin/zsh",
+        env: { HOME: tmpHome },
+        zshShellIntegrationDir: integrationSourceDir,
+      });
+
+    buildEnvironment();
+
+    expect(buildEnvironment).not.toThrow();
   });
 
   describe("send input", () => {

--- a/packages/server/src/terminal/terminal.ts
+++ b/packages/server/src/terminal/terminal.ts
@@ -1,12 +1,13 @@
 import * as pty from "node-pty";
 import xterm, { type Terminal as TerminalType } from "@xterm/headless";
 import { randomUUID } from "crypto";
-import { chmodSync, copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { tmpdir, userInfo } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { createExternalProcessEnv } from "../server/paseo-env.js";
+import { writePrivateFileAtomicSync } from "../server/private-files.js";
 import type { TerminalCell, TerminalState } from "../shared/messages.js";
 
 const { Terminal } = xterm;
@@ -202,10 +203,13 @@ function prepareZshShellIntegrationRuntimeDir(sourceDir = resolveZshShellIntegra
   const runtimeDir = resolveZshShellIntegrationRuntimeDir();
   mkdirSync(runtimeDir, { recursive: true, mode: 0o700 });
   chmodSync(runtimeDir, 0o700);
-  copyFileSync(join(readableSourceDir, ".zshenv"), join(runtimeDir, ".zshenv"));
-  copyFileSync(
-    join(readableSourceDir, "paseo-integration.zsh"),
+  writePrivateFileAtomicSync(
+    join(runtimeDir, ".zshenv"),
+    readFileSync(join(readableSourceDir, ".zshenv")),
+  );
+  writePrivateFileAtomicSync(
     join(runtimeDir, "paseo-integration.zsh"),
+    readFileSync(join(readableSourceDir, "paseo-integration.zsh")),
   );
   return runtimeDir;
 }


### PR DESCRIPTION
## Summary
- reproduce the Nix/read-only source failure with a POSIX test that calls buildTerminalEnvironment twice against real 0444 zsh integration files
- replace copyFileSync with atomic private-file writes from source bytes so runtime files are created writable and private

## Bug
PR #544 changed zsh shell integration from pointing ZDOTDIR at the source directory to copying the integration files into /tmp/<user>-paseo-zsh so zsh can load them outside Electron .asar paths. On Linux/macOS, copyFileSync propagates source mode bits when creating the destination. If the resolved source is read-only, as in a Nix store path with 0444 files, the first terminal creates 0444 runtime files and the next createTerminal/buildTerminalEnvironment cannot overwrite them, failing with EACCES.

Discord report: https://discord.com/channels/1481169421832814616/1491287786370633929/1503886567356371005

## Approach
I chose explicit writes over chmod-after-copy and over asar-only branching. Reading the tiny source files and writing them through writePrivateFileAtomicSync avoids source-mode propagation entirely, keeps the runtime files at the repo-standard private file mode, and also replaces already-bad 0444 runtime files left behind by older builds. The asar path handling stays unchanged because resolveExternalProcessPath still selects the readable source before we read bytes.

## Test
The new POSIX test copies the real zsh integration source into a temp directory, chmods both files to 0444, removes the shared runtime dir, and calls buildTerminalEnvironment twice. Before the fix the second call fails with EACCES; after the fix it passes.

## Verification
- npx vitest run packages/server/src/terminal/terminal.posix.test.ts --bail=1
- npm run typecheck
- npm run lint -- packages/server/src/terminal/terminal.ts
- npm run format
