### PR TITLE
Support local Claude settings configuration

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -380,6 +380,41 @@ describe("ClaudeAgentClient.listModels", () => {
 describe("ClaudeAgentClient binary resolution", () => {
   const logger = createTestLogger();
 
+  test("loads user, project, and local Claude settings", async () => {
+    const queryReturn = vi.fn();
+    queryReturn.mockResolvedValue(undefined);
+    const queryFactory = vi.fn(() => ({
+      close: vi.fn(),
+      return: queryReturn,
+    }));
+
+    const client = new ClaudeAgentClient({
+      logger,
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    const session = await client.createSession({
+      provider: "claude",
+      cwd: process.cwd(),
+    });
+
+    await expect(
+      (
+        session as unknown as {
+          ensureQuery(): Promise<unknown>;
+        }
+      ).ensureQuery(),
+    ).resolves.toBeDefined();
+
+    expect(queryFactory.mock.calls[0]?.[0].options.settingSources).toEqual([
+      "user",
+      "project",
+      "local",
+    ]);
+
+    await session.close();
+  });
+
   test("uses the replace-command override binary when claude is not on PATH", async () => {
     const customClaudePath = "/path/to/custom-claude";
     vi.spyOn(executableUtils, "findExecutable").mockImplementation(async (name: string) => {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -83,7 +83,11 @@ import { execCommand } from "../../../../utils/spawn.js";
 import { getOrchestratorModeInstructions } from "../../orchestrator-instructions.js";
 
 const fsPromises = promises;
-const CLAUDE_SETTING_SOURCES: NonNullable<ClaudeOptions["settingSources"]> = ["user", "project"];
+const CLAUDE_SETTING_SOURCES: NonNullable<ClaudeOptions["settingSources"]> = [
+  "user",
+  "project",
+  "local",
+];
 
 function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;


### PR DESCRIPTION
## Summary

Add support for local Claude settings alongside user and project settings. This allows users to configure Claude Code behavior via local settings files (e.g., `.claude/settings.local.json`).

## Changes

- Updated `CLAUDE_SETTING_SOURCES` to include `"local"` in addition to `"user"` and `"project"`
- Added test to verify Claude settings are loaded from all three sources (user, project, local)

## Test plan

- [x] New test verifies that `queryFactory` is called with correct `settingSources` including local settings
- [x] Existing tests continue to pass