### PR TITLE
Show upstream ACP JSON-RPC errors instead of [object Object]

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -4195,6 +4195,8 @@ test("turn_failed surfaces provider code and diagnostic in system error message"
 
   await expect(manager.runAgent(agent.id, "hello")).rejects.toThrow("Provider execution failed");
 
+  expect(manager.getAgent(agent.id)?.lastError).toBe("Provider execution failed");
+
   const systemError = manager
     .getTimeline(agent.id)
     .find(

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1,7 +1,13 @@
 import { type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import type {
+import {
+  AgentSideConnection,
+  ClientSideConnection,
+  PROTOCOL_VERSION,
+  RequestError,
+  ndJsonStream,
+  type Agent,
   PermissionOption,
   PromptResponse,
   RequestPermissionRequest,
@@ -1574,5 +1580,80 @@ describe("ACPAgentSession", () => {
       error: "prompt failed",
     });
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
+  });
+
+  test("startTurn preserves JSON-RPC error details from a real ACP prompt response", async () => {
+    const session = createSession();
+    const clientToAgent = new TransformStream();
+    const agentToClient = new TransformStream();
+    const upstreamMessage =
+      "Authentication failed: Please authenticate to continue. Run `/login` to log in.";
+    const upstreamData = {
+      cause: "auth_required",
+      errorMessage: "Please authenticate to continue. Run `/login` to log in.",
+    };
+    const agent: Agent = {
+      async initialize() {
+        return {
+          protocolVersion: PROTOCOL_VERSION,
+          agentCapabilities: {},
+          authMethods: [{ id: "windsurf-api-key", name: "API Key" }],
+        };
+      },
+      async newSession() {
+        return { sessionId: "session-1" };
+      },
+      async prompt() {
+        throw new RequestError(-32000, upstreamMessage, upstreamData);
+      },
+      async authenticate() {},
+      async cancel() {},
+    };
+    const agentConnection = new AgentSideConnection(
+      () => agent,
+      ndJsonStream(agentToClient.writable, clientToAgent.readable),
+    );
+    const connection = new ClientSideConnection(
+      () => ({
+        async requestPermission() {
+          return { outcome: { outcome: "cancelled" } };
+        },
+        async sessionUpdate() {},
+      }),
+      ndJsonStream(clientToAgent.writable, agentToClient.readable),
+    );
+    await connection.initialize({
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {},
+      clientInfo: { name: "Paseo test", version: "dev" },
+    });
+    expect(agentConnection.signal.aborted).toBe(false);
+    const sessionResponse = await connection.newSession({
+      cwd: "/tmp/paseo-acp-test",
+      mcpServers: [],
+    });
+    const turnFailed = new Promise<Extract<AgentStreamEvent, { type: "turn_failed" }>>(
+      (resolve) => {
+        session.subscribe((event) => {
+          if (event.type === "turn_failed") {
+            resolve(event);
+          }
+        });
+      },
+    );
+
+    asInternals<ACPSessionInternals>(session).sessionId = sessionResponse.sessionId;
+    asInternals<ACPSessionInternals>(session).connection = connection;
+
+    await session.startTurn("hello");
+
+    await expect(turnFailed).resolves.toMatchObject({
+      error: expect.stringContaining(upstreamMessage),
+      code: "-32000",
+      diagnostic: expect.stringContaining("auth_required"),
+    });
+    await expect(turnFailed).resolves.toMatchObject({
+      error: expect.not.stringContaining("[object Object]"),
+    });
   });
 });

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -107,6 +107,50 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
 }
 
+function stringifyDiagnosticValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function summarizeACPRequestError(error: unknown): {
+  message: string;
+  code?: string;
+  diagnostic?: string;
+} {
+  if (error instanceof Error) {
+    return { message: error.message };
+  }
+
+  if (!isRecord(error)) {
+    return { message: String(error) };
+  }
+
+  const message =
+    typeof error.message === "string" ? error.message : stringifyDiagnosticValue(error);
+  const code =
+    typeof error.code === "number" || typeof error.code === "string"
+      ? String(error.code)
+      : undefined;
+  const details: string[] = [];
+  if (code) {
+    details.push(`code=${code}`);
+  }
+  if ("data" in error) {
+    details.push(`data=${stringifyDiagnosticValue(error.data)}`);
+  }
+  return {
+    message,
+    code,
+    diagnostic: details.length > 0 ? [message, ...details].join(" | ") : undefined,
+  };
+}
+
 function resolveTerminalCommand(
   command: string,
   args?: string[],
@@ -1045,12 +1089,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         return;
       })
       .catch((error) => {
-        const message = error instanceof Error ? error.message : String(error);
+        const summary = summarizeACPRequestError(error);
         this.finishTurn({
           type: "turn_failed",
           provider: this.provider,
-          error: message,
-          diagnostic: this.collectDiagnostic(message),
+          error: summary.message,
+          code: summary.code,
+          diagnostic: this.collectDiagnostic(summary.diagnostic ?? summary.message),
           turnId,
         });
       });

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -11,6 +11,7 @@ import {
   ClientSideConnection,
   PROTOCOL_VERSION,
   type AgentCapabilities as ACPAgentCapabilities,
+  type Error as ACPError,
   type AnyMessage,
   type Client as ACPClient,
   type ClientCapabilities as ACPClientCapabilities,
@@ -107,15 +108,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
 }
 
-function stringifyDiagnosticValue(value: unknown): string {
-  if (typeof value === "string") {
-    return value;
-  }
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
+function isACPError(value: unknown): value is ACPError {
+  return isRecord(value) && typeof value.message === "string" && typeof value.code === "number";
 }
 
 function summarizeACPRequestError(error: unknown): {
@@ -123,32 +117,22 @@ function summarizeACPRequestError(error: unknown): {
   code?: string;
   diagnostic?: string;
 } {
+  // Promise rejections are untyped, but the ACP SDK rejects JSON-RPC failures as response.error.
+  if (isACPError(error)) {
+    const code = String(error.code);
+    const data = error.data === undefined ? "" : ` | data=${JSON.stringify(error.data)}`;
+    return {
+      message: error.message,
+      code,
+      diagnostic: `${error.message} | code=${code}${data}`,
+    };
+  }
+
   if (error instanceof Error) {
     return { message: error.message };
   }
 
-  if (!isRecord(error)) {
-    return { message: String(error) };
-  }
-
-  const message =
-    typeof error.message === "string" ? error.message : stringifyDiagnosticValue(error);
-  const code =
-    typeof error.code === "number" || typeof error.code === "string"
-      ? String(error.code)
-      : undefined;
-  const details: string[] = [];
-  if (code) {
-    details.push(`code=${code}`);
-  }
-  if ("data" in error) {
-    details.push(`data=${stringifyDiagnosticValue(error.data)}`);
-  }
-  return {
-    message,
-    code,
-    diagnostic: details.length > 0 ? [message, ...details].join(" | ") : undefined,
-  };
+  return { message: String(error) };
 }
 
 function resolveTerminalCommand(


### PR DESCRIPTION
## Summary
- Preserve message/code/data from ACP JSON-RPC prompt failures instead of turning them into `[object Object]`
- Add a real ACP client/server test that reproduces the Devin-style auth error over NDJSON/JSON-RPC
- Confirm the manager surface keeps the provider message in `lastError` and the system error timeline display includes details

## Context
Discord reports from j8ckfi and scouzer: users manually configured Devin CLI as an ACP provider and saw unreliable/crashy behavior. During diagnosis, Devin returned an ACP auth failure (`auth_required`, `Please authenticate to continue. Run `/login` to log in.`), but Paseo surfaced `[object Object]` instead of the upstream ACP error.

Post-auth Devin protocol behavior remains unverified; Mo will handle Devin auth separately.

## Manual QA
Rebuilt `@getpaseo/server`, started isolated daemon with `PASEO_HOME=/tmp/paseo-devin-debug`, `PASEO_LISTEN=127.0.0.1:6868`, custom provider `command: ["/Users/moboudra/.local/bin/devin", "acp"]`, then ran:

```bash
PASEO_HOME=/tmp/paseo-devin-debug PASEO_LISTEN=127.0.0.1:6868 npm run cli -- run --provider devin --cwd "$PWD" --wait-timeout 20s "Say hello in one sentence." --json
```

Before:
```text
handleStreamEvent: turn_failed ... "diagnostic":"[object Object]"
    error: "[object Object]"
```

After:
```text
handleStreamEvent: turn_failed ... "code":"-32000","diagnostic":"Authentication failed: Please authenticate to continue. Run `/login` to log in. | code=-32000"
    error: "Authentication failed: Please authenticate to continue. Run `/login` to log in."
```

Agent record:
```json
"lastError": "Authentication failed: Please authenticate to continue. Run `/login` to log in."
```

Timeline/logs surface:
```text
[System Error] Authentication failed: Please authenticate to continue. Run `/login` to log in.

code: -32000

Authentication failed: Please authenticate to continue. Run `/login` to log in. | code=-32000
```

## Tests
- Red test first: `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1 -t "preserves JSON-RPC error details"` failed with `error: "[object Object]"` and `diagnostic: "[object Object]"`
- `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1`
- `npx vitest run packages/server/src/server/agent/agent-manager.test.ts --bail=1`
- `npm run format:files -- packages/server/src/server/agent/providers/acp-agent.ts packages/server/src/server/agent/providers/acp-agent.test.ts packages/server/src/server/agent/agent-manager.test.ts`
- `npm run lint`
- `npm run typecheck`

Pre-commit also reran lint, format check, and typecheck.
