### PR TITLE
fix(app): widen host switcher popover

### DIFF
--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -472,6 +472,7 @@ function SidebarFooter({
         searchable={false}
         title="Switch host"
         searchPlaceholder="Search hosts..."
+        desktopMinWidth={280}
         open={isHostPickerOpen}
         onOpenChange={setIsHostPickerOpen}
         anchorRef={hostTriggerRef}


### PR DESCRIPTION
## Summary

- Set a host-switcher-only desktop popover minimum width of 280px
- Keep the shared `Combobox` primitive untouched, following the maintainer feedback on #952

Fixes #946.

## Verification

- `npm run format:check:files -- packages/app/src/components/left-sidebar.tsx`
- `npm run lint -- packages/app/src/components/left-sidebar.tsx`
- `npm run build:workspace-deps --workspace=@getpaseo/app`
- `npm run typecheck --workspace=@getpaseo/app`
- pre-commit hook: `lint`, `format`, `typecheck`
