### PR TITLE
Avoid probing extra executable candidates

### DIFF
--- a/packages/server/src/utils/executable.ts
+++ b/packages/server/src/utils/executable.ts
@@ -126,11 +126,12 @@ export async function findExecutable(
   }
 
   const candidates = await enumerateCandidates(trimmed);
-  const probeResults = await Promise.all(
-    candidates.map((candidate) => probeExecutable(candidate, probeTimeoutMs)),
-  );
-  const firstMatch = probeResults.findIndex((result) => result);
-  return firstMatch === -1 ? null : candidates[firstMatch];
+  for (const candidate of candidates) {
+    if (await probeExecutable(candidate, probeTimeoutMs)) {
+      return candidate;
+    }
+  }
+  return null;
 }
 
 export async function isCommandAvailable(command: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Probe PATH executable candidates sequentially instead of in parallel
- Stop after the first working candidate so later duplicate/quarantined binaries are not launched unnecessarily

## Why
Paseo provider discovery can enumerate multiple `codex` binaries. The previous parallel probe executed every candidate, which could trigger macOS Gatekeeper malware alerts for a later stale/quarantined duplicate even when the first `codex` worked.

## Verification
- `npx vitest run packages/server/src/utils/executable.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
