### PR TITLE
fix(desktop): bound external CLI output capture

### DIFF
--- a/packages/desktop/src/daemon/cli/external.test.ts
+++ b/packages/desktop/src/daemon/cli/external.test.ts
@@ -88,4 +88,36 @@ describe("external CLI", () => {
       localDaemon: "running",
     });
   });
+
+  it("bounds captured stdout from text commands", async () => {
+    const suffix = "daemon still running\n";
+    const largeOutput = `${"x".repeat(512 * 1024)}${suffix}`;
+    mockExternalCliOutput({ stdout: largeOutput });
+
+    const output = await runExternalCliTextCommand(["daemon", "status"]);
+
+    expect(output.length).toBeLessThanOrEqual(64 * 1024);
+    expect(output.endsWith(suffix.trimEnd())).toBe(true);
+  });
+
+  it("bounds captured stderr in failure messages", async () => {
+    const suffix = "fatal: daemon exploded\n";
+    mockExternalCliOutput({
+      stdout: "",
+      stderr: `${"x".repeat(512 * 1024)}${suffix}`,
+      exitCode: 1,
+    });
+
+    await runExternalCliTextCommand(["daemon", "status"]).then(
+      () => {
+        throw new Error("Expected external CLI command to fail");
+      },
+      (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).toContain(`output truncated to the last ${64 * 1024} chars`);
+        expect(message).toContain(suffix.trimEnd());
+        expect(message.length).toBeLessThan(70 * 1024);
+      },
+    );
+  });
 });

--- a/packages/desktop/src/daemon/cli/external.ts
+++ b/packages/desktop/src/daemon/cli/external.ts
@@ -4,6 +4,40 @@ import type { NodeEntrypointInvocation } from "../node-entrypoint-launcher.js";
 import { createNodeEntrypointInvocation } from "../runtime-paths.js";
 import { resolveExternalCliEntrypoint } from "./entrypoints.js";
 
+const EXTERNAL_CLI_OUTPUT_CAPTURE_LIMIT_CHARS = 64 * 1024;
+
+interface ExternalCliOutputCapture {
+  text: string;
+  truncated: boolean;
+}
+
+function createExternalCliOutputCapture(): ExternalCliOutputCapture {
+  return { text: "", truncated: false };
+}
+
+function appendExternalCliOutput(
+  capture: ExternalCliOutputCapture,
+  chunk: Buffer,
+): ExternalCliOutputCapture {
+  const nextText = capture.text + chunk.toString();
+  if (nextText.length <= EXTERNAL_CLI_OUTPUT_CAPTURE_LIMIT_CHARS) {
+    return { text: nextText, truncated: capture.truncated };
+  }
+
+  return {
+    text: nextText.slice(-EXTERNAL_CLI_OUTPUT_CAPTURE_LIMIT_CHARS),
+    truncated: true,
+  };
+}
+
+function formatExternalCliOutput(capture: ExternalCliOutputCapture): string {
+  if (!capture.truncated) {
+    return capture.text;
+  }
+
+  return `[output truncated to the last ${EXTERNAL_CLI_OUTPUT_CAPTURE_LIMIT_CHARS} chars]\n${capture.text}`;
+}
+
 function createExternalCliInvocation(args: string[]): NodeEntrypointInvocation {
   return createNodeEntrypointInvocation({
     entrypoint: resolveExternalCliEntrypoint(),
@@ -13,9 +47,11 @@ function createExternalCliInvocation(args: string[]): NodeEntrypointInvocation {
   });
 }
 
-function spawnExternalCli(
-  invocation: NodeEntrypointInvocation,
-): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+function spawnExternalCli(invocation: NodeEntrypointInvocation): Promise<{
+  stdout: ExternalCliOutputCapture;
+  stderr: ExternalCliOutputCapture;
+  exitCode: number | null;
+}> {
   return new Promise((resolve, reject) => {
     const child = spawnProcess(invocation.command, invocation.args, {
       envMode: "internal",
@@ -23,14 +59,14 @@ function spawnExternalCli(
       stdio: ["ignore", "pipe", "pipe"],
     });
 
-    let stdout = "";
-    let stderr = "";
+    let stdout = createExternalCliOutputCapture();
+    let stderr = createExternalCliOutputCapture();
 
     child.stdout!.on("data", (data: Buffer) => {
-      stdout += data.toString();
+      stdout = appendExternalCliOutput(stdout, data);
     });
     child.stderr!.on("data", (data: Buffer) => {
-      stderr += data.toString();
+      stderr = appendExternalCliOutput(stderr, data);
     });
 
     child.on("error", reject);
@@ -42,14 +78,18 @@ function spawnExternalCli(
 
 function externalCliFailureMessage(
   exitCode: number | null,
-  stdout: string,
-  stderr: string,
+  stdout: ExternalCliOutputCapture,
+  stderr: ExternalCliOutputCapture,
 ): string {
-  if (stderr.length > 0) {
-    return stderr;
+  const formattedStderr = formatExternalCliOutput(stderr).trim();
+  if (formattedStderr.length > 0) {
+    return formattedStderr;
   }
 
-  return `CLI command failed with exit code ${exitCode}${stdout.length > 0 ? `\nstdout: ${stdout.slice(0, 200)}` : ""}`;
+  const formattedStdout = formatExternalCliOutput(stdout).trim();
+  return `CLI command failed with exit code ${exitCode}${
+    formattedStdout.length > 0 ? `\nstdout: ${formattedStdout.slice(0, 200)}` : ""
+  }`;
 }
 
 export async function runExternalCliTextCommand(args: string[]): Promise<string> {
@@ -57,18 +97,18 @@ export async function runExternalCliTextCommand(args: string[]): Promise<string>
   const result = await spawnExternalCli(invocation);
 
   if (result.exitCode !== 0) {
-    const stderr = result.stderr.trim();
-    const stdout = result.stdout.trim();
+    const stderr = result.stderr.text.trim();
+    const stdout = result.stdout.text.trim();
     log.warn("[desktop external-cli]", "CLI text command failed", {
       args,
       exitCode: result.exitCode,
       stdout: stdout.slice(0, 500),
       stderr: stderr.slice(0, 500),
     });
-    throw new Error(externalCliFailureMessage(result.exitCode, stdout, stderr));
+    throw new Error(externalCliFailureMessage(result.exitCode, result.stdout, result.stderr));
   }
 
-  return result.stdout.trimEnd();
+  return result.stdout.text.trimEnd();
 }
 
 export async function runExternalCliJsonCommand(args: string[]): Promise<unknown> {
@@ -76,8 +116,8 @@ export async function runExternalCliJsonCommand(args: string[]): Promise<unknown
   const result = await spawnExternalCli(invocation);
 
   if (result.exitCode !== 0) {
-    const stderr = result.stderr.trim();
-    const stdout = result.stdout.trim();
+    const stderr = result.stderr.text.trim();
+    const stdout = result.stdout.text.trim();
     log.warn("[desktop external-cli]", "CLI JSON command failed", {
       args,
       exitCode: result.exitCode,
@@ -85,10 +125,10 @@ export async function runExternalCliJsonCommand(args: string[]): Promise<unknown
       stderr: stderr.slice(0, 500),
       command: invocation.command,
     });
-    throw new Error(externalCliFailureMessage(result.exitCode, stdout, stderr));
+    throw new Error(externalCliFailureMessage(result.exitCode, result.stdout, result.stderr));
   }
 
-  const stdout = result.stdout.trim();
+  const stdout = result.stdout.text.trim();
   if (stdout.length === 0) {
     log.warn("[desktop external-cli]", "CLI command produced no output", { args });
     throw new Error("CLI command did not produce JSON output.");


### PR DESCRIPTION
## Summary

- Bound stdout/stderr captured from desktop external CLI child processes to the last 64 KiB.
- Preserve the tail of oversized output and include a truncation note in failure messages.
- Add regression coverage for large stdout and stderr output.

## Why

Desktop daemon management shells out to the bundled CLI for commands like `daemon status`, `daemon status --json`, and `daemon pair --json`. That helper previously appended child stdout/stderr into unbounded strings, so pathological CLI output could grow the Electron main-process heap until V8 throws `RangeError: Invalid string length`.

This mirrors the existing desktop daemon startup-output guard, using the same 64 KiB tail-capture style.

## Platform impact

This affects the Electron desktop helper, so it applies to desktop builds on macOS, Windows, and Linux. It does not affect iOS/iPadOS/Android clients, which do not run this desktop CLI child-process path.

## Test plan

- `NODE_PATH=/Users/zbl/Desktop/paseo/node_modules /Users/zbl/Desktop/paseo/node_modules/.bin/vitest run packages/desktop/src/daemon/cli/external.test.ts --bail=1`
- `npm run format:check:files -- packages/desktop/src/daemon/cli/external.ts packages/desktop/src/daemon/cli/external.test.ts`
- `npm run lint -- packages/desktop/src/daemon/cli/external.ts packages/desktop/src/daemon/cli/external.test.ts`
- `npm run typecheck --workspace=@getpaseo/desktop`

Note: local pre-commit lint/format passed after wiring this isolated worktree to the main checkout's `node_modules`. The hook's full workspace typecheck failed in this isolated worktree due unrelated workspace dependency resolution/type errors; the targeted desktop typecheck above passed.
