### PR TITLE
Fix upstream-gone ahead count

### DIFF
--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -378,6 +378,22 @@ const x = 1;
     expect(divergedStatus.behindOfOrigin).toBe(1);
   });
 
+  it("does not report the full branch history as ahead when the current branch remote is gone", async () => {
+    setupRemoteTrackingMain(repoDir, tempDir);
+    execFileSync("git", ["checkout", "-b", "feature"], { cwd: repoDir });
+    commitFile(repoDir, "feature.txt", "feature\n", "feature commit");
+    execFileSync("git", ["push", "-u", "origin", "feature"], { cwd: repoDir });
+    execFileSync("git", ["push", "origin", "--delete", "feature"], { cwd: repoDir });
+    execFileSync("git", ["fetch", "--prune", "origin"], { cwd: repoDir });
+
+    const status = await getCheckoutStatus(repoDir);
+    expect(status.isGit).toBe(true);
+    if (!status.isGit) {
+      return;
+    }
+    expect(status.aheadOfOrigin).toBeNull();
+  });
+
   it("does not report incoming additions when the base branch is behind its remote", async () => {
     const { cloneDir } = setupRemoteTrackingMain(repoDir, tempDir);
     commitFile(cloneDir, "file.txt", "remote one\nremote two\n", "remote update");

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1241,14 +1241,19 @@ async function getAheadOfOrigin(cwd: string, currentBranch: string): Promise<num
   if (!currentBranch) {
     return null;
   }
+  const trackedOriginBranch = await getTrackedOriginBranch(cwd, currentBranch);
+  const originBranch = trackedOriginBranch ?? currentBranch;
   try {
     const { stdout } = await runGitCommand(
-      ["rev-list", "--count", `origin/${currentBranch}..${currentBranch}`],
+      ["rev-list", "--count", `origin/${originBranch}..${currentBranch}`],
       { cwd, envOverlay: READ_ONLY_GIT_ENV },
     );
     const count = Number.parseInt(stdout.trim(), 10);
     return Number.isNaN(count) ? null : count;
   } catch {
+    if (trackedOriginBranch) {
+      return null;
+    }
     try {
       const { stdout } = await runGitCommand(["rev-list", "--count", currentBranch], {
         cwd,
@@ -1260,6 +1265,16 @@ async function getAheadOfOrigin(cwd: string, currentBranch: string): Promise<num
       return null;
     }
   }
+}
+
+async function getTrackedOriginBranch(cwd: string, currentBranch: string): Promise<string | null> {
+  const remoteName = await getGitConfigValue(cwd, `branch.${currentBranch}.remote`);
+  if (remoteName !== "origin") {
+    return null;
+  }
+
+  const mergeRef = await getGitConfigValue(cwd, `branch.${currentBranch}.merge`);
+  return parseBranchMergeHeadRef(mergeRef);
 }
 
 async function getBehindOfOrigin(cwd: string, currentBranch: string): Promise<number | null> {


### PR DESCRIPTION
## Summary
- Treat a configured origin upstream that has been pruned as an unknown ahead count instead of falling back to full branch history
- Use the configured origin merge ref when computing ahead-of-origin
- Add a regression test for deleted/pruned branch remotes

## Tests
- npx vitest run packages/server/src/utils/checkout-git.test.ts --bail=1
- npm run lint -- packages/server/src/utils/checkout-git.ts packages/server/src/utils/checkout-git.test.ts
- npm run typecheck
- npm run format:files -- packages/server/src/utils/checkout-git.ts packages/server/src/utils/checkout-git.test.ts