### PR TITLE
Add slash commands for ending and restarting agents

### DIFF
--- a/packages/app/e2e/client-slash-commands.spec.ts
+++ b/packages/app/e2e/client-slash-commands.spec.ts
@@ -108,6 +108,14 @@ async function runClientSlashCommand(page: Page, command: "/quit" | "/clear"): P
   await input.press("Enter");
 }
 
+async function selectClientSlashCommand(page: Page, query: string, label: string): Promise<void> {
+  const input = composerLocator(page);
+  await expect(input).toBeEditable({ timeout: 30_000 });
+  await input.fill(query);
+  await expect(page.getByText(label, { exact: true }).first()).toBeVisible({ timeout: 30_000 });
+  await input.press("Enter");
+}
+
 async function expectAgentArchivedInSessions(page: Page, title: string): Promise<void> {
   await openSessions(page);
   await expectSessionRowArchived(page, title);
@@ -166,6 +174,18 @@ test.describe("Client slash commands", () => {
       await expectWorkspaceTabHidden(page, agent.id);
       await expectAgentArchivedInSessions(page, title);
     });
+  });
+
+  test("slash quit selected from autocomplete archives immediately", async ({ page }) => {
+    await withOpenReadyMockAgent(
+      page,
+      { title: "Slash quit autocomplete e2e" },
+      async ({ agent, title }) => {
+        await selectClientSlashCommand(page, "/qu", "/quit");
+        await expectWorkspaceTabHidden(page, agent.id);
+        await expectAgentArchivedInSessions(page, title);
+      },
+    );
   });
 
   test("slash clear replaces the active agent with a matching draft", async ({ page }) => {

--- a/packages/app/e2e/client-slash-commands.spec.ts
+++ b/packages/app/e2e/client-slash-commands.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test, type Page } from "./fixtures";
 import { buildHostWorkspaceRoute } from "@/utils/host-routes";
 import { composerLocator, expectComposerVisible, submitMessage } from "./helpers/composer";
-import { expectAgentIdle } from "./helpers/agent-stream";
 import { connectTerminalClient, type TerminalPerfDaemonClient } from "./helpers/terminal-perf";
 import { createTempGitRepo } from "./helpers/workspace";
 import {
@@ -99,7 +98,6 @@ async function openActiveAgentTab(
   );
   await expectWorkspaceTabVisible(page, input.agentId);
   await expectComposerVisible(page);
-  await expectAgentIdle(page, 30_000);
 }
 
 async function runClientSlashCommand(page: Page, command: "/quit" | "/clear"): Promise<void> {

--- a/packages/app/e2e/client-slash-commands.spec.ts
+++ b/packages/app/e2e/client-slash-commands.spec.ts
@@ -41,7 +41,6 @@ async function withOpenReadyMockAgent(
   const client = await connectTerminalClient();
 
   try {
-    await installCreateAgentRequestRecorder(page);
     await openProject(client, repo.path);
     const agent = await createReadyMockAgent(client, {
       cwd: repo.path,
@@ -56,34 +55,6 @@ async function withOpenReadyMockAgent(
     await client.close();
     await repo.cleanup();
   }
-}
-
-async function installCreateAgentRequestRecorder(page: Page): Promise<void> {
-  await page.addInitScript(() => {
-    const requests: unknown[] = [];
-    (
-      window as typeof window & {
-        __paseoE2eCreateAgentRequests?: unknown[];
-      }
-    ).__paseoE2eCreateAgentRequests = requests;
-    const originalSend = WebSocket.prototype.send;
-    WebSocket.prototype.send = function (data) {
-      if (typeof data === "string") {
-        try {
-          const parsed = JSON.parse(data) as {
-            type?: unknown;
-            message?: { type?: unknown };
-          };
-          if (parsed.type === "session" && parsed.message?.type === "create_agent_request") {
-            requests.push(parsed.message);
-          }
-        } catch {
-          // Ignore non-JSON frames.
-        }
-      }
-      return originalSend.call(this, data);
-    };
-  });
 }
 
 async function openProject(client: TerminalPerfDaemonClient, cwd: string): Promise<void> {
@@ -144,53 +115,16 @@ async function expectAgentArchivedInSessions(page: Page, title: string): Promise
   await expectSessionRowArchived(page, title);
 }
 
-async function expectSeededDraftReady(page: Page): Promise<void> {
+async function expectReplacementDraftMatchesPreviousSetup(page: Page): Promise<void> {
   await expectComposerVisible(page);
+  await expect(
+    page.getByRole("button", { name: "Select model (Ten second stream)" }),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Select agent mode (load-test)" })).toBeVisible();
 }
 
-async function createAgentFromSeededDraft(page: Page): Promise<void> {
+async function createAgentFromReplacementDraft(page: Page): Promise<void> {
   await submitMessage(page, REPLACEMENT_PROMPT);
-}
-
-async function expectReplacementAgentMatchesSetup(input: {
-  page: Page;
-  oldAgentId: string;
-  cwd: string;
-  provider: string;
-  model: string;
-  modeId: string;
-}): Promise<void> {
-  await waitForReplacementAgentId(input.page, input.oldAgentId);
-  await expect
-    .poll(async () => getRecordedReplacementCreateConfig(input.page), { timeout: 30_000 })
-    .toEqual({
-      cwd: input.cwd,
-      modeId: input.modeId,
-      model: input.model,
-      provider: input.provider,
-    });
-}
-
-async function getRecordedReplacementCreateConfig(page: Page): Promise<{
-  cwd?: string;
-  modeId?: string;
-  model?: string;
-  provider?: string;
-} | null> {
-  return page.evaluate((expectedPrompt) => {
-    const requests =
-      (
-        window as typeof window & {
-          __paseoE2eCreateAgentRequests?: Array<{
-            initialPrompt?: string;
-            config?: { cwd?: string; modeId?: string; model?: string; provider?: string };
-          }>;
-        }
-      ).__paseoE2eCreateAgentRequests ?? [];
-
-    const request = requests.find((candidate) => candidate.initialPrompt === expectedPrompt);
-    return request?.config ?? null;
-  }, REPLACEMENT_PROMPT);
 }
 
 async function waitForReplacementAgentId(page: Page, oldAgentId: string): Promise<string> {
@@ -236,23 +170,16 @@ test.describe("Client slash commands", () => {
     });
   });
 
-  test("slash clear replaces the active agent with a seeded draft", async ({ page }) => {
+  test("slash clear replaces the active agent with a matching draft", async ({ page }) => {
     await withOpenReadyMockAgent(
       page,
       { title: "Slash clear e2e", model: "ten-second-stream", modeId: "load-test" },
-      async ({ agent, cwd, title }) => {
+      async ({ agent, title }) => {
         await runClientSlashCommand(page, "/clear");
         await expectWorkspaceTabHidden(page, agent.id);
-        await expectSeededDraftReady(page);
-        await createAgentFromSeededDraft(page);
-        await expectReplacementAgentMatchesSetup({
-          page,
-          oldAgentId: agent.id,
-          cwd,
-          provider: "mock",
-          model: "ten-second-stream",
-          modeId: "load-test",
-        });
+        await expectReplacementDraftMatchesPreviousSetup(page);
+        await createAgentFromReplacementDraft(page);
+        await waitForReplacementAgentId(page, agent.id);
         await expectAgentArchivedInSessions(page, title);
       },
     );

--- a/packages/app/e2e/client-slash-commands.spec.ts
+++ b/packages/app/e2e/client-slash-commands.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "./fixtures";
 import { buildHostWorkspaceRoute } from "@/utils/host-routes";
-import { expectComposerVisible, submitMessage } from "./helpers/composer";
+import { composerLocator, expectComposerVisible, submitMessage } from "./helpers/composer";
 import { expectAgentIdle } from "./helpers/agent-stream";
 import { connectTerminalClient, type TerminalPerfDaemonClient } from "./helpers/terminal-perf";
 import { createTempGitRepo } from "./helpers/workspace";
@@ -132,7 +132,11 @@ async function openActiveAgentTab(
 }
 
 async function runClientSlashCommand(page: Page, command: "/quit" | "/clear"): Promise<void> {
-  await submitMessage(page, command);
+  const input = composerLocator(page);
+  await expect(input).toBeEditable({ timeout: 30_000 });
+  await input.fill(command);
+  await expect(input).toHaveValue(command);
+  await input.press("Enter");
 }
 
 async function expectAgentArchivedInSessions(page: Page, title: string): Promise<void> {

--- a/packages/app/e2e/client-slash-commands.spec.ts
+++ b/packages/app/e2e/client-slash-commands.spec.ts
@@ -1,0 +1,256 @@
+import { expect, test, type Page } from "./fixtures";
+import { buildHostWorkspaceRoute } from "@/utils/host-routes";
+import { expectComposerVisible, submitMessage } from "./helpers/composer";
+import { expectAgentIdle } from "./helpers/agent-stream";
+import { connectTerminalClient, type TerminalPerfDaemonClient } from "./helpers/terminal-perf";
+import { createTempGitRepo } from "./helpers/workspace";
+import {
+  expectSessionRowArchived,
+  expectWorkspaceTabHidden,
+  expectWorkspaceTabVisible,
+  openSessions,
+} from "./helpers/archive-tab";
+
+interface SlashCommandScenario {
+  agent: { id: string };
+  client: TerminalPerfDaemonClient;
+  cwd: string;
+  title: string;
+}
+
+const REPLACEMENT_PROMPT = "Replacement prompt after slash clear.";
+
+function getServerId(): string {
+  const serverId = process.env.E2E_SERVER_ID;
+  if (!serverId) {
+    throw new Error("E2E_SERVER_ID is not set.");
+  }
+  return serverId;
+}
+
+async function withOpenReadyMockAgent(
+  page: Page,
+  input: {
+    title: string;
+    model?: string;
+    modeId?: string;
+  },
+  run: (scenario: SlashCommandScenario) => Promise<void>,
+): Promise<void> {
+  const repo = await createTempGitRepo("client-slash-command-");
+  const client = await connectTerminalClient();
+
+  try {
+    await installCreateAgentRequestRecorder(page);
+    await openProject(client, repo.path);
+    const agent = await createReadyMockAgent(client, {
+      cwd: repo.path,
+      title: input.title,
+      model: input.model,
+      modeId: input.modeId,
+    });
+    await openActiveAgentTab(page, { cwd: repo.path, agentId: agent.id });
+
+    await run({ agent, client, cwd: repo.path, title: input.title });
+  } finally {
+    await client.close();
+    await repo.cleanup();
+  }
+}
+
+async function installCreateAgentRequestRecorder(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const requests: unknown[] = [];
+    (
+      window as typeof window & {
+        __paseoE2eCreateAgentRequests?: unknown[];
+      }
+    ).__paseoE2eCreateAgentRequests = requests;
+    const originalSend = WebSocket.prototype.send;
+    WebSocket.prototype.send = function (data) {
+      if (typeof data === "string") {
+        try {
+          const parsed = JSON.parse(data) as {
+            type?: unknown;
+            message?: { type?: unknown };
+          };
+          if (parsed.type === "session" && parsed.message?.type === "create_agent_request") {
+            requests.push(parsed.message);
+          }
+        } catch {
+          // Ignore non-JSON frames.
+        }
+      }
+      return originalSend.call(this, data);
+    };
+  });
+}
+
+async function openProject(client: TerminalPerfDaemonClient, cwd: string): Promise<void> {
+  const opened = await client.openProject(cwd);
+  if (!opened.workspace) {
+    throw new Error(opened.error ?? `Failed to open project ${cwd}`);
+  }
+}
+
+async function createReadyMockAgent(
+  client: TerminalPerfDaemonClient,
+  input: {
+    cwd: string;
+    title: string;
+    model?: string;
+    modeId?: string;
+  },
+): Promise<{ id: string }> {
+  const agent = await client.createAgent({
+    provider: "mock",
+    cwd: input.cwd,
+    title: input.title,
+    modeId: input.modeId ?? "load-test",
+    model: input.model ?? "ten-second-stream",
+    initialPrompt: "Prepare a client slash command test agent.",
+  });
+  return { id: agent.id };
+}
+
+async function openActiveAgentTab(
+  page: Page,
+  input: { cwd: string; agentId: string },
+): Promise<void> {
+  const agentUrl = `${buildHostWorkspaceRoute(
+    getServerId(),
+    input.cwd,
+  )}?open=${encodeURIComponent(`agent:${input.agentId}`)}`;
+  await page.goto(agentUrl);
+  await page.waitForURL(
+    (url) => url.pathname.includes("/workspace/") && !url.searchParams.has("open"),
+    { timeout: 60_000 },
+  );
+  await expectWorkspaceTabVisible(page, input.agentId);
+  await expectComposerVisible(page);
+  await expectAgentIdle(page, 30_000);
+}
+
+async function runClientSlashCommand(page: Page, command: "/quit" | "/clear"): Promise<void> {
+  await submitMessage(page, command);
+}
+
+async function expectAgentArchivedInSessions(page: Page, title: string): Promise<void> {
+  await openSessions(page);
+  await expectSessionRowArchived(page, title);
+}
+
+async function expectSeededDraftReady(page: Page): Promise<void> {
+  await expectComposerVisible(page);
+}
+
+async function createAgentFromSeededDraft(page: Page): Promise<void> {
+  await submitMessage(page, REPLACEMENT_PROMPT);
+}
+
+async function expectReplacementAgentMatchesSetup(input: {
+  page: Page;
+  oldAgentId: string;
+  cwd: string;
+  provider: string;
+  model: string;
+  modeId: string;
+}): Promise<void> {
+  await waitForReplacementAgentId(input.page, input.oldAgentId);
+  await expect
+    .poll(async () => getRecordedReplacementCreateConfig(input.page), { timeout: 30_000 })
+    .toEqual({
+      cwd: input.cwd,
+      modeId: input.modeId,
+      model: input.model,
+      provider: input.provider,
+    });
+}
+
+async function getRecordedReplacementCreateConfig(page: Page): Promise<{
+  cwd?: string;
+  modeId?: string;
+  model?: string;
+  provider?: string;
+} | null> {
+  return page.evaluate((expectedPrompt) => {
+    const requests =
+      (
+        window as typeof window & {
+          __paseoE2eCreateAgentRequests?: Array<{
+            initialPrompt?: string;
+            config?: { cwd?: string; modeId?: string; model?: string; provider?: string };
+          }>;
+        }
+      ).__paseoE2eCreateAgentRequests ?? [];
+
+    const request = requests.find((candidate) => candidate.initialPrompt === expectedPrompt);
+    return request?.config ?? null;
+  }, REPLACEMENT_PROMPT);
+}
+
+async function waitForReplacementAgentId(page: Page, oldAgentId: string): Promise<string> {
+  let newAgentId: string | null = null;
+  await expect
+    .poll(
+      async () => {
+        const ids = await page
+          .locator('[data-testid^="workspace-tab-agent_"]')
+          .evaluateAll((nodes) =>
+            nodes.flatMap((node) => {
+              if (!(node instanceof HTMLElement)) {
+                return [];
+              }
+              const testId = node.getAttribute("data-testid") ?? "";
+              if (!testId.startsWith("workspace-tab-agent_")) {
+                return [];
+              }
+              if (node.offsetParent === null) {
+                return [];
+              }
+              return [testId.slice("workspace-tab-agent_".length)];
+            }),
+          );
+        newAgentId = ids.find((id) => id !== oldAgentId) ?? null;
+        return newAgentId;
+      },
+      { timeout: 30_000 },
+    )
+    .not.toBeNull();
+  if (!newAgentId) {
+    throw new Error("Replacement agent was not created.");
+  }
+  return newAgentId;
+}
+
+test.describe("Client slash commands", () => {
+  test("slash quit archives the active agent and removes its tab", async ({ page }) => {
+    await withOpenReadyMockAgent(page, { title: "Slash quit e2e" }, async ({ agent, title }) => {
+      await runClientSlashCommand(page, "/quit");
+      await expectWorkspaceTabHidden(page, agent.id);
+      await expectAgentArchivedInSessions(page, title);
+    });
+  });
+
+  test("slash clear replaces the active agent with a seeded draft", async ({ page }) => {
+    await withOpenReadyMockAgent(
+      page,
+      { title: "Slash clear e2e", model: "ten-second-stream", modeId: "load-test" },
+      async ({ agent, cwd, title }) => {
+        await runClientSlashCommand(page, "/clear");
+        await expectWorkspaceTabHidden(page, agent.id);
+        await expectSeededDraftReady(page);
+        await createAgentFromSeededDraft(page);
+        await expectReplacementAgentMatchesSetup({
+          page,
+          oldAgentId: agent.id,
+          cwd,
+          provider: "mock",
+          model: "ten-second-stream",
+          modeId: "load-test",
+        });
+        await expectAgentArchivedInSessions(page, title);
+      },
+    );
+  });
+});

--- a/packages/app/e2e/helpers/terminal-perf.ts
+++ b/packages/app/e2e/helpers/terminal-perf.ts
@@ -29,30 +29,6 @@ export interface TerminalPerfDaemonClient {
     featureValues?: Record<string, unknown>;
     initialPrompt?: string;
   }): Promise<{ id: string; status: string }>;
-  fetchAgent(agentId: string): Promise<{
-    agent: {
-      id: string;
-      status: string;
-      cwd?: string | null;
-      archivedAt?: string | null;
-      model?: string | null;
-      currentModeId?: string | null;
-      runtimeInfo?: { model?: string | null; modeId?: string | null };
-    } | null;
-  } | null>;
-  fetchAgents(): Promise<{
-    entries: Array<{
-      agent: {
-        id: string;
-        status: string;
-        cwd?: string | null;
-        archivedAt?: string | null;
-        model?: string | null;
-        currentModeId?: string | null;
-        runtimeInfo?: { model?: string | null; modeId?: string | null };
-      };
-    }>;
-  }>;
   waitForAgentUpsert(
     agentId: string,
     predicate: (snapshot: { status: string }) => boolean,

--- a/packages/app/e2e/helpers/terminal-perf.ts
+++ b/packages/app/e2e/helpers/terminal-perf.ts
@@ -29,6 +29,35 @@ export interface TerminalPerfDaemonClient {
     featureValues?: Record<string, unknown>;
     initialPrompt?: string;
   }): Promise<{ id: string; status: string }>;
+  fetchAgent(agentId: string): Promise<{
+    agent: {
+      id: string;
+      status: string;
+      cwd?: string | null;
+      archivedAt?: string | null;
+      model?: string | null;
+      currentModeId?: string | null;
+      runtimeInfo?: { model?: string | null; modeId?: string | null };
+    } | null;
+  } | null>;
+  fetchAgents(): Promise<{
+    entries: Array<{
+      agent: {
+        id: string;
+        status: string;
+        cwd?: string | null;
+        archivedAt?: string | null;
+        model?: string | null;
+        currentModeId?: string | null;
+        runtimeInfo?: { model?: string | null; modeId?: string | null };
+      };
+    }>;
+  }>;
+  waitForAgentUpsert(
+    agentId: string,
+    predicate: (snapshot: { status: string }) => boolean,
+    timeout?: number,
+  ): Promise<{ status: string }>;
   sendAgentMessage(agentId: string, text: string): Promise<void>;
   subscribeTerminal(
     terminalId: string,

--- a/packages/app/src/client-slash-commands/index.test.ts
+++ b/packages/app/src/client-slash-commands/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildDraftAgentSetup, resolveClientSlashCommand } from "@/client-slash-commands";
+import {
+  CLIENT_SLASH_COMMANDS,
+  buildDraftAgentSetup,
+  resolveClientSlashCommand,
+} from "@/client-slash-commands";
 import type { Agent } from "@/stores/session-store";
 
 function createAgent(overrides: Partial<Agent> = {}): Agent {
@@ -53,10 +57,21 @@ function createAgent(overrides: Partial<Agent> = {}): Agent {
 }
 
 describe("resolveClientSlashCommand", () => {
+  it("declares the exact client commands that execute immediately", () => {
+    expect(CLIENT_SLASH_COMMANDS.map((command) => [command.name, command.execution])).toEqual([
+      ["quit", "immediate"],
+      ["exit", "immediate"],
+      ["q", "immediate"],
+      ["clear", "immediate"],
+      ["new", "immediate"],
+    ]);
+  });
+
   it("resolves exact client commands after trimming", () => {
-    expect(resolveClientSlashCommand({ text: " /quit ", hasAttachments: false })?.kind).toBe(
-      "archive-agent",
-    );
+    expect(resolveClientSlashCommand({ text: " /quit ", hasAttachments: false })).toMatchObject({
+      kind: "archive-agent",
+      execution: "immediate",
+    });
     expect(resolveClientSlashCommand({ text: "/exit", hasAttachments: false })?.kind).toBe(
       "archive-agent",
     );

--- a/packages/app/src/client-slash-commands/index.test.ts
+++ b/packages/app/src/client-slash-commands/index.test.ts
@@ -1,11 +1,5 @@
-import { describe, expect, it, afterEach } from "vitest";
-import {
-  __private__,
-  buildDraftAgentSetupSeed,
-  consumeDraftAgentSetupSeed,
-  resolveClientSlashCommand,
-  seedDraftAgentSetup,
-} from "@/client-slash-commands";
+import { describe, expect, it } from "vitest";
+import { buildDraftAgentSetup, resolveClientSlashCommand } from "@/client-slash-commands";
 import type { Agent } from "@/stores/session-store";
 
 function createAgent(overrides: Partial<Agent> = {}): Agent {
@@ -58,10 +52,6 @@ function createAgent(overrides: Partial<Agent> = {}): Agent {
   };
 }
 
-afterEach(() => {
-  __private__.clearDraftAgentSetupSeeds();
-});
-
 describe("resolveClientSlashCommand", () => {
   it("resolves exact client commands after trimming", () => {
     expect(resolveClientSlashCommand({ text: " /quit ", hasAttachments: false })?.kind).toBe(
@@ -92,9 +82,9 @@ describe("resolveClientSlashCommand", () => {
   });
 });
 
-describe("draft setup seeds", () => {
+describe("buildDraftAgentSetup", () => {
   it("builds draft setup from the active agent snapshot", () => {
-    expect(buildDraftAgentSetupSeed(createAgent())).toEqual({
+    expect(buildDraftAgentSetup(createAgent())).toEqual({
       provider: "codex",
       cwd: "/repo",
       modeId: "mode-current",
@@ -109,7 +99,7 @@ describe("draft setup seeds", () => {
 
   it("falls back to runtime model setup when top-level fields are absent", () => {
     expect(
-      buildDraftAgentSetupSeed(
+      buildDraftAgentSetup(
         createAgent({
           currentModeId: null,
           model: null,
@@ -121,13 +111,5 @@ describe("draft setup seeds", () => {
       model: "runtime-model",
       thinkingOptionId: "runtime-thinking",
     });
-  });
-
-  it("consumes a seeded setup once by draft id", () => {
-    const setup = buildDraftAgentSetupSeed(createAgent());
-    seedDraftAgentSetup({ draftId: "draft-1", setup });
-
-    expect(consumeDraftAgentSetupSeed("draft-1")).toEqual(setup);
-    expect(consumeDraftAgentSetupSeed("draft-1")).toBeNull();
   });
 });

--- a/packages/app/src/client-slash-commands/index.test.ts
+++ b/packages/app/src/client-slash-commands/index.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, afterEach } from "vitest";
+import {
+  __private__,
+  buildDraftAgentSetupSeed,
+  consumeDraftAgentSetupSeed,
+  resolveClientSlashCommand,
+  seedDraftAgentSetup,
+} from "@/client-slash-commands";
+import type { Agent } from "@/stores/session-store";
+
+function createAgent(overrides: Partial<Agent> = {}): Agent {
+  const now = new Date("2026-05-15T00:00:00.000Z");
+  return {
+    serverId: "server-1",
+    id: "agent-1",
+    provider: "codex",
+    status: "idle",
+    createdAt: now,
+    updatedAt: now,
+    lastUserMessageAt: now,
+    lastActivityAt: now,
+    capabilities: {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: false,
+      supportsReasoningStream: false,
+      supportsToolInvocations: true,
+    },
+    currentModeId: "mode-current",
+    availableModes: [],
+    pendingPermissions: [],
+    persistence: null,
+    runtimeInfo: {
+      provider: "codex",
+      sessionId: "session-1",
+      model: "runtime-model",
+      modeId: "runtime-mode",
+      thinkingOptionId: "runtime-thinking",
+    },
+    title: "Agent",
+    cwd: "/repo",
+    model: "agent-model",
+    thinkingOptionId: "think-hard",
+    features: [
+      { type: "toggle", id: "web-search", label: "Web search", value: true },
+      {
+        type: "select",
+        id: "effort",
+        label: "Effort",
+        value: "high",
+        options: [{ id: "high", label: "High" }],
+      },
+    ],
+    parentAgentId: null,
+    labels: {},
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  __private__.clearDraftAgentSetupSeeds();
+});
+
+describe("resolveClientSlashCommand", () => {
+  it("resolves exact client commands after trimming", () => {
+    expect(resolveClientSlashCommand({ text: " /quit ", hasAttachments: false })?.kind).toBe(
+      "archive-agent",
+    );
+    expect(resolveClientSlashCommand({ text: "/exit", hasAttachments: false })?.kind).toBe(
+      "archive-agent",
+    );
+    expect(resolveClientSlashCommand({ text: "/q", hasAttachments: false })?.kind).toBe(
+      "archive-agent",
+    );
+    expect(resolveClientSlashCommand({ text: "/clear", hasAttachments: false })?.kind).toBe(
+      "replace-agent-with-draft",
+    );
+    expect(resolveClientSlashCommand({ text: "/new", hasAttachments: false })?.kind).toBe(
+      "replace-agent-with-draft",
+    );
+  });
+
+  it("leaves provider commands, arguments, ordinary messages, and attachment submits alone", () => {
+    expect(resolveClientSlashCommand({ text: "/clear now", hasAttachments: false })).toBeNull();
+    expect(resolveClientSlashCommand({ text: "/quit now", hasAttachments: false })).toBeNull();
+    expect(
+      resolveClientSlashCommand({ text: "/provider-command", hasAttachments: false }),
+    ).toBeNull();
+    expect(resolveClientSlashCommand({ text: "hello /quit", hasAttachments: false })).toBeNull();
+    expect(resolveClientSlashCommand({ text: "/quit", hasAttachments: true })).toBeNull();
+  });
+});
+
+describe("draft setup seeds", () => {
+  it("builds draft setup from the active agent snapshot", () => {
+    expect(buildDraftAgentSetupSeed(createAgent())).toEqual({
+      provider: "codex",
+      cwd: "/repo",
+      modeId: "mode-current",
+      model: "agent-model",
+      thinkingOptionId: "think-hard",
+      featureValues: {
+        "web-search": true,
+        effort: "high",
+      },
+    });
+  });
+
+  it("falls back to runtime model setup when top-level fields are absent", () => {
+    expect(
+      buildDraftAgentSetupSeed(
+        createAgent({
+          currentModeId: null,
+          model: null,
+          thinkingOptionId: null,
+        }),
+      ),
+    ).toMatchObject({
+      modeId: "runtime-mode",
+      model: "runtime-model",
+      thinkingOptionId: "runtime-thinking",
+    });
+  });
+
+  it("consumes a seeded setup once by draft id", () => {
+    const setup = buildDraftAgentSetupSeed(createAgent());
+    seedDraftAgentSetup({ draftId: "draft-1", setup });
+
+    expect(consumeDraftAgentSetupSeed("draft-1")).toEqual(setup);
+    expect(consumeDraftAgentSetupSeed("draft-1")).toBeNull();
+  });
+});

--- a/packages/app/src/client-slash-commands/index.ts
+++ b/packages/app/src/client-slash-commands/index.ts
@@ -1,6 +1,5 @@
-import { useEffect, useRef } from "react";
-import type { AgentProvider } from "@server/server/agent/agent-sdk-types";
 import type { Agent } from "@/stores/session-store";
+import type { WorkspaceDraftTabSetup } from "@/stores/workspace-tabs-store";
 
 export type ClientSlashCommandKind = "archive-agent" | "replace-agent-with-draft";
 
@@ -9,15 +8,6 @@ export interface ClientSlashCommand {
   description: string;
   argumentHint: string;
   kind: ClientSlashCommandKind;
-}
-
-export interface DraftAgentSetupSeed {
-  provider: AgentProvider;
-  cwd: string;
-  modeId: string | null;
-  model: string | null;
-  thinkingOptionId: string | null;
-  featureValues: Record<string, unknown>;
 }
 
 export const CLIENT_SLASH_COMMANDS: readonly ClientSlashCommand[] = [
@@ -54,7 +44,6 @@ export const CLIENT_SLASH_COMMANDS: readonly ClientSlashCommand[] = [
 ];
 
 const COMMAND_BY_NAME = new Map(CLIENT_SLASH_COMMANDS.map((command) => [command.name, command]));
-const draftSetupSeeds = new Map<string, DraftAgentSetupSeed>();
 
 export function resolveClientSlashCommand(input: {
   text: string;
@@ -77,7 +66,7 @@ export function resolveClientSlashCommand(input: {
   return COMMAND_BY_NAME.get(commandName) ?? null;
 }
 
-export function buildDraftAgentSetupSeed(agent: Agent): DraftAgentSetupSeed {
+export function buildDraftAgentSetup(agent: Agent): WorkspaceDraftTabSetup {
   const featureValues: Record<string, unknown> = {};
   for (const feature of agent.features ?? []) {
     featureValues[feature.id] = feature.value;
@@ -92,35 +81,3 @@ export function buildDraftAgentSetupSeed(agent: Agent): DraftAgentSetupSeed {
     featureValues,
   };
 }
-
-export function seedDraftAgentSetup(input: { draftId: string; setup: DraftAgentSetupSeed }): void {
-  draftSetupSeeds.set(input.draftId, input.setup);
-}
-
-export function consumeDraftAgentSetupSeed(draftId: string): DraftAgentSetupSeed | null {
-  const seed = draftSetupSeeds.get(draftId) ?? null;
-  draftSetupSeeds.delete(draftId);
-  return seed;
-}
-
-export function useDraftAgentSetupSeed(draftId: string): DraftAgentSetupSeed | null {
-  const seedRef = useRef<{ draftId: string; seed: DraftAgentSetupSeed | null } | null>(null);
-  if (seedRef.current?.draftId !== draftId) {
-    seedRef.current = {
-      draftId,
-      seed: draftSetupSeeds.get(draftId) ?? null,
-    };
-  }
-
-  useEffect(() => {
-    draftSetupSeeds.delete(draftId);
-  }, [draftId]);
-
-  return seedRef.current.seed;
-}
-
-export const __private__ = {
-  clearDraftAgentSetupSeeds: () => {
-    draftSetupSeeds.clear();
-  },
-};

--- a/packages/app/src/client-slash-commands/index.ts
+++ b/packages/app/src/client-slash-commands/index.ts
@@ -2,12 +2,14 @@ import type { Agent } from "@/stores/session-store";
 import type { WorkspaceDraftTabSetup } from "@/stores/workspace-tabs-store";
 
 export type ClientSlashCommandKind = "archive-agent" | "replace-agent-with-draft";
+export type ClientSlashCommandExecution = "immediate" | "insert";
 
 export interface ClientSlashCommand {
   name: string;
   description: string;
   argumentHint: string;
   kind: ClientSlashCommandKind;
+  execution: ClientSlashCommandExecution;
 }
 
 export const CLIENT_SLASH_COMMANDS: readonly ClientSlashCommand[] = [
@@ -16,30 +18,35 @@ export const CLIENT_SLASH_COMMANDS: readonly ClientSlashCommand[] = [
     description: "Archive the current agent",
     argumentHint: "",
     kind: "archive-agent",
+    execution: "immediate",
   },
   {
     name: "exit",
     description: "Archive the current agent",
     argumentHint: "",
     kind: "archive-agent",
+    execution: "immediate",
   },
   {
     name: "q",
     description: "Archive the current agent",
     argumentHint: "",
     kind: "archive-agent",
+    execution: "immediate",
   },
   {
     name: "clear",
     description: "Archive this agent and start a fresh draft",
     argumentHint: "",
     kind: "replace-agent-with-draft",
+    execution: "immediate",
   },
   {
     name: "new",
     description: "Archive this agent and start a fresh draft",
     argumentHint: "",
     kind: "replace-agent-with-draft",
+    execution: "immediate",
   },
 ];
 

--- a/packages/app/src/client-slash-commands/index.ts
+++ b/packages/app/src/client-slash-commands/index.ts
@@ -1,0 +1,126 @@
+import { useEffect, useRef } from "react";
+import type { AgentProvider } from "@server/server/agent/agent-sdk-types";
+import type { Agent } from "@/stores/session-store";
+
+export type ClientSlashCommandKind = "archive-agent" | "replace-agent-with-draft";
+
+export interface ClientSlashCommand {
+  name: string;
+  description: string;
+  argumentHint: string;
+  kind: ClientSlashCommandKind;
+}
+
+export interface DraftAgentSetupSeed {
+  provider: AgentProvider;
+  cwd: string;
+  modeId: string | null;
+  model: string | null;
+  thinkingOptionId: string | null;
+  featureValues: Record<string, unknown>;
+}
+
+export const CLIENT_SLASH_COMMANDS: readonly ClientSlashCommand[] = [
+  {
+    name: "quit",
+    description: "Archive the current agent",
+    argumentHint: "",
+    kind: "archive-agent",
+  },
+  {
+    name: "exit",
+    description: "Archive the current agent",
+    argumentHint: "",
+    kind: "archive-agent",
+  },
+  {
+    name: "q",
+    description: "Archive the current agent",
+    argumentHint: "",
+    kind: "archive-agent",
+  },
+  {
+    name: "clear",
+    description: "Archive this agent and start a fresh draft",
+    argumentHint: "",
+    kind: "replace-agent-with-draft",
+  },
+  {
+    name: "new",
+    description: "Archive this agent and start a fresh draft",
+    argumentHint: "",
+    kind: "replace-agent-with-draft",
+  },
+];
+
+const COMMAND_BY_NAME = new Map(CLIENT_SLASH_COMMANDS.map((command) => [command.name, command]));
+const draftSetupSeeds = new Map<string, DraftAgentSetupSeed>();
+
+export function resolveClientSlashCommand(input: {
+  text: string;
+  hasAttachments: boolean;
+}): ClientSlashCommand | null {
+  if (input.hasAttachments) {
+    return null;
+  }
+
+  const trimmed = input.text.trim();
+  if (!trimmed.startsWith("/")) {
+    return null;
+  }
+
+  const commandName = trimmed.slice(1);
+  if (!commandName || /\s/.test(commandName)) {
+    return null;
+  }
+
+  return COMMAND_BY_NAME.get(commandName) ?? null;
+}
+
+export function buildDraftAgentSetupSeed(agent: Agent): DraftAgentSetupSeed {
+  const featureValues: Record<string, unknown> = {};
+  for (const feature of agent.features ?? []) {
+    featureValues[feature.id] = feature.value;
+  }
+
+  return {
+    provider: agent.provider,
+    cwd: agent.cwd,
+    modeId: agent.currentModeId ?? agent.runtimeInfo?.modeId ?? null,
+    model: agent.model ?? agent.runtimeInfo?.model ?? null,
+    thinkingOptionId: agent.thinkingOptionId ?? agent.runtimeInfo?.thinkingOptionId ?? null,
+    featureValues,
+  };
+}
+
+export function seedDraftAgentSetup(input: { draftId: string; setup: DraftAgentSetupSeed }): void {
+  draftSetupSeeds.set(input.draftId, input.setup);
+}
+
+export function consumeDraftAgentSetupSeed(draftId: string): DraftAgentSetupSeed | null {
+  const seed = draftSetupSeeds.get(draftId) ?? null;
+  draftSetupSeeds.delete(draftId);
+  return seed;
+}
+
+export function useDraftAgentSetupSeed(draftId: string): DraftAgentSetupSeed | null {
+  const seedRef = useRef<{ draftId: string; seed: DraftAgentSetupSeed | null } | null>(null);
+  if (seedRef.current?.draftId !== draftId) {
+    seedRef.current = {
+      draftId,
+      seed: draftSetupSeeds.get(draftId) ?? null,
+    };
+  }
+
+  useEffect(() => {
+    draftSetupSeeds.delete(draftId);
+  }, [draftId]);
+
+  return seedRef.current.seed;
+}
+
+export const __private__ = {
+  clearDraftAgentSetupSeeds: () => {
+    draftSetupSeeds.clear();
+  },
+};

--- a/packages/app/src/components/composer.tsx
+++ b/packages/app/src/components/composer.tsx
@@ -80,7 +80,7 @@ import { useKeyboardActionHandler } from "@/hooks/use-keyboard-action-handler";
 import type { KeyboardActionDefinition } from "@/keyboard/keyboard-action-dispatcher";
 import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
 import { submitAgentInput } from "@/components/agent-input-submit";
-import { useAppSettings } from "@/hooks/use-settings";
+import { useAppSettings, type SendBehavior } from "@/hooks/use-settings";
 import { isWeb, isNative } from "@/constants/platform";
 import type { GitHubSearchItem } from "@server/shared/messages";
 import type {
@@ -108,6 +108,30 @@ type AttachmentListUpdater =
   | ((prev: UserComposerAttachment[]) => UserComposerAttachment[]);
 
 function noop() {}
+
+function resolveActiveClientSlashCommand(input: {
+  text: string;
+  hasAttachments: boolean;
+  canHandleClientSlashCommand: boolean;
+}): ClientSlashCommand | null {
+  if (!input.canHandleClientSlashCommand) {
+    return null;
+  }
+  return resolveClientSlashCommand({
+    text: input.text,
+    hasAttachments: input.hasAttachments,
+  });
+}
+
+function resolveComposerSendBehavior(input: {
+  appSendBehavior: SendBehavior;
+  activeClientSlashCommand: ClientSlashCommand | null;
+}): SendBehavior {
+  if (input.activeClientSlashCommand) {
+    return "interrupt";
+  }
+  return input.appSendBehavior;
+}
 
 function resolveComposerButtonIconSize(): number {
   return isWeb ? ICON_SIZE.md : ICON_SIZE.lg;
@@ -1320,24 +1344,22 @@ export function Composer({
     [attachments, buildOutgoingAttachments, queueMessage],
   );
 
+  const activeClientSlashCommand = resolveActiveClientSlashCommand({
+    text: userInput,
+    hasAttachments: buildOutgoingAttachments(attachments).length > 0,
+    canHandleClientSlashCommand: Boolean(onClientSlashCommand),
+  });
   const hasSendableContent = userInput.trim().length > 0 || selectedAttachments.length > 0;
 
   // Handle keyboard navigation for command autocomplete.
   const handleCommandKeyPress = useCallback(
     (event: { key: string; preventDefault: () => void }) => {
-      if (
-        event.key === "Enter" &&
-        onClientSlashCommand &&
-        resolveClientSlashCommand({
-          text: userInput,
-          hasAttachments: buildOutgoingAttachments(attachments).length > 0,
-        })
-      ) {
+      if (event.key === "Enter" && activeClientSlashCommand) {
         return false;
       }
       return autocompleteOnKeyPressRef.current(event);
     },
-    [attachments, buildOutgoingAttachments, onClientSlashCommand, userInput],
+    [activeClientSlashCommand],
   );
 
   const cancelButtonStyle = useMemo(
@@ -1628,7 +1650,10 @@ export function Composer({
               voiceServerId={serverId}
               voiceAgentId={agentId}
               isAgentRunning={isAgentRunning}
-              defaultSendBehavior={appSettings.sendBehavior}
+              defaultSendBehavior={resolveComposerSendBehavior({
+                appSendBehavior: appSettings.sendBehavior,
+                activeClientSlashCommand,
+              })}
               onQueue={handleQueue}
               onSubmitLoadingPress={submitLoadingPressHandler}
               onKeyPress={handleCommandKeyPress}

--- a/packages/app/src/components/composer.tsx
+++ b/packages/app/src/components/composer.tsx
@@ -36,6 +36,7 @@ import {
   type ImageAttachment,
   type MessageInputRef,
   type AttachmentMenuItem,
+  type MessageInputKeyPressEvent,
 } from "./message-input";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import type { DraftCommandConfig } from "@/hooks/use-agent-commands-query";
@@ -1353,13 +1354,27 @@ export function Composer({
 
   // Handle keyboard navigation for command autocomplete.
   const handleCommandKeyPress = useCallback(
-    (event: { key: string; preventDefault: () => void }) => {
-      if (event.key === "Enter" && activeClientSlashCommand) {
-        return false;
+    (event: MessageInputKeyPressEvent) => {
+      if (event.key === "Enter") {
+        const clientSlashCommand = resolveActiveClientSlashCommand({
+          text: event.text,
+          hasAttachments: event.attachments.length > 0,
+          canHandleClientSlashCommand: Boolean(onClientSlashCommand),
+        });
+        if (clientSlashCommand) {
+          event.preventDefault();
+          handleSubmit({
+            text: event.text,
+            attachments: event.attachments,
+            cwd: event.cwd,
+            forceSend: isAgentRunning || undefined,
+          });
+          return true;
+        }
       }
       return autocompleteOnKeyPressRef.current(event);
     },
-    [activeClientSlashCommand],
+    [handleSubmit, isAgentRunning, onClientSlashCommand],
   );
 
   const cancelButtonStyle = useMemo(

--- a/packages/app/src/components/composer.tsx
+++ b/packages/app/src/components/composer.tsx
@@ -99,6 +99,7 @@ import { useIsDictationReady } from "@/hooks/use-is-dictation-ready";
 import { useGithubSearchQuery } from "@/git/use-github-search-query";
 import { useCheckoutStatusQuery } from "@/git/use-status-query";
 import { useComposerGithubAutoAttach } from "./use-composer-github-auto-attach";
+import { resolveClientSlashCommand, type ClientSlashCommand } from "@/client-slash-commands";
 
 type QueuedMessage = QueuedComposerMessage;
 
@@ -607,6 +608,7 @@ interface ComposerProps {
   serverId: string;
   isPaneFocused: boolean;
   onSubmitMessage?: (payload: MessagePayload) => Promise<void>;
+  onClientSlashCommand?: (command: ClientSlashCommand) => Promise<void>;
   /** When true, the submit button is enabled even without text or images (e.g. external attachment selected). */
   hasExternalContent?: boolean;
   /** When true, the composer can submit even with no text or attachments. */
@@ -807,6 +809,7 @@ export function Composer({
   serverId,
   isPaneFocused,
   onSubmitMessage,
+  onClientSlashCommand,
   hasExternalContent = false,
   allowEmptySubmit = false,
   submitButtonAccessibilityLabel,
@@ -1109,16 +1112,48 @@ export function Composer({
 
   const handleSubmit = useCallback(
     (payload: MessagePayload) => {
+      const outgoingAttachments = buildOutgoingAttachments(attachments);
+      const clientSlashCommand = resolveClientSlashCommand({
+        text: payload.text,
+        hasAttachments: outgoingAttachments.length > 0,
+      });
+      if (clientSlashCommand && onClientSlashCommand) {
+        if (blurOnSubmit) {
+          messageInputRef.current?.blur();
+        }
+        clearDraft("sent");
+        setUserInput("");
+        setSelectedAttachments([]);
+        resetSuppression();
+        setSendError(null);
+        setIsProcessing(true);
+        void onClientSlashCommand(clientSlashCommand)
+          .catch((error) => {
+            console.error("[Composer] Failed to run client slash command:", error);
+            setSendError(error instanceof Error ? error.message : String(error));
+          })
+          .finally(() => {
+            setIsProcessing(false);
+          });
+        return;
+      }
+
       if (blurOnSubmit) {
         messageInputRef.current?.blur();
       }
-      void sendMessageWithContent(
-        payload.text,
-        buildOutgoingAttachments(attachments),
-        payload.forceSend,
-      );
+      void sendMessageWithContent(payload.text, outgoingAttachments, payload.forceSend);
     },
-    [attachments, blurOnSubmit, buildOutgoingAttachments, sendMessageWithContent],
+    [
+      attachments,
+      blurOnSubmit,
+      buildOutgoingAttachments,
+      clearDraft,
+      onClientSlashCommand,
+      resetSuppression,
+      sendMessageWithContent,
+      setSelectedAttachments,
+      setUserInput,
+    ],
   );
 
   const handlePickImage = useCallback(async () => {
@@ -1290,9 +1325,19 @@ export function Composer({
   // Handle keyboard navigation for command autocomplete.
   const handleCommandKeyPress = useCallback(
     (event: { key: string; preventDefault: () => void }) => {
+      if (
+        event.key === "Enter" &&
+        onClientSlashCommand &&
+        resolveClientSlashCommand({
+          text: userInput,
+          hasAttachments: buildOutgoingAttachments(attachments).length > 0,
+        })
+      ) {
+        return false;
+      }
       return autocompleteOnKeyPressRef.current(event);
     },
-    [],
+    [attachments, buildOutgoingAttachments, onClientSlashCommand, userInput],
   );
 
   const cancelButtonStyle = useMemo(

--- a/packages/app/src/components/composer.tsx
+++ b/packages/app/src/components/composer.tsx
@@ -36,7 +36,6 @@ import {
   type ImageAttachment,
   type MessageInputRef,
   type AttachmentMenuItem,
-  type MessageInputKeyPressEvent,
 } from "./message-input";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import type { DraftCommandConfig } from "@/hooks/use-agent-commands-query";
@@ -81,7 +80,7 @@ import { useKeyboardActionHandler } from "@/hooks/use-keyboard-action-handler";
 import type { KeyboardActionDefinition } from "@/keyboard/keyboard-action-dispatcher";
 import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
 import { submitAgentInput } from "@/components/agent-input-submit";
-import { useAppSettings, type SendBehavior } from "@/hooks/use-settings";
+import { useAppSettings } from "@/hooks/use-settings";
 import { isWeb, isNative } from "@/constants/platform";
 import type { GitHubSearchItem } from "@server/shared/messages";
 import type {
@@ -109,30 +108,6 @@ type AttachmentListUpdater =
   | ((prev: UserComposerAttachment[]) => UserComposerAttachment[]);
 
 function noop() {}
-
-function resolveActiveClientSlashCommand(input: {
-  text: string;
-  hasAttachments: boolean;
-  canHandleClientSlashCommand: boolean;
-}): ClientSlashCommand | null {
-  if (!input.canHandleClientSlashCommand) {
-    return null;
-  }
-  return resolveClientSlashCommand({
-    text: input.text,
-    hasAttachments: input.hasAttachments,
-  });
-}
-
-function resolveComposerSendBehavior(input: {
-  appSendBehavior: SendBehavior;
-  activeClientSlashCommand: ClientSlashCommand | null;
-}): SendBehavior {
-  if (input.activeClientSlashCommand) {
-    return "interrupt";
-  }
-  return input.appSendBehavior;
-}
 
 function resolveComposerButtonIconSize(): number {
   return isWeb ? ICON_SIZE.md : ICON_SIZE.lg;
@@ -935,6 +910,41 @@ export function Composer({
     `message-input:${serverId}:${agentId}:${Math.random().toString(36).slice(2)}`,
   );
 
+  const runClientSlashCommand = useCallback(
+    (command: ClientSlashCommand): boolean => {
+      if (command.execution !== "immediate" || !onClientSlashCommand) {
+        return false;
+      }
+
+      if (blurOnSubmit) {
+        messageInputRef.current?.blur();
+      }
+      clearDraft("sent");
+      setUserInput("");
+      setSelectedAttachments([]);
+      resetSuppression();
+      setSendError(null);
+      setIsProcessing(true);
+      void onClientSlashCommand(command)
+        .catch((error) => {
+          console.error("[Composer] Failed to run client slash command:", error);
+          setSendError(error instanceof Error ? error.message : String(error));
+        })
+        .finally(() => {
+          setIsProcessing(false);
+        });
+      return true;
+    },
+    [
+      blurOnSubmit,
+      clearDraft,
+      onClientSlashCommand,
+      resetSuppression,
+      setSelectedAttachments,
+      setUserInput,
+    ],
+  );
+
   const autocomplete = useAgentAutocomplete({
     userInput,
     cursorIndex,
@@ -942,6 +952,8 @@ export function Composer({
     serverId,
     agentId,
     draftConfig: commandDraftConfig,
+    canExecuteClientSlashCommand: buildOutgoingAttachments(attachments).length === 0,
+    onClientSlashCommand: runClientSlashCommand,
     onAutocompleteApplied: () => {
       messageInputRef.current?.focus();
     },
@@ -1142,24 +1154,7 @@ export function Composer({
         text: payload.text,
         hasAttachments: outgoingAttachments.length > 0,
       });
-      if (clientSlashCommand && onClientSlashCommand) {
-        if (blurOnSubmit) {
-          messageInputRef.current?.blur();
-        }
-        clearDraft("sent");
-        setUserInput("");
-        setSelectedAttachments([]);
-        resetSuppression();
-        setSendError(null);
-        setIsProcessing(true);
-        void onClientSlashCommand(clientSlashCommand)
-          .catch((error) => {
-            console.error("[Composer] Failed to run client slash command:", error);
-            setSendError(error instanceof Error ? error.message : String(error));
-          })
-          .finally(() => {
-            setIsProcessing(false);
-          });
+      if (clientSlashCommand && runClientSlashCommand(clientSlashCommand)) {
         return;
       }
 
@@ -1172,12 +1167,8 @@ export function Composer({
       attachments,
       blurOnSubmit,
       buildOutgoingAttachments,
-      clearDraft,
-      onClientSlashCommand,
-      resetSuppression,
+      runClientSlashCommand,
       sendMessageWithContent,
-      setSelectedAttachments,
-      setUserInput,
     ],
   );
 
@@ -1340,41 +1331,26 @@ export function Composer({
 
   const handleQueue = useCallback(
     (payload: MessagePayload) => {
-      queueMessage(payload.text, buildOutgoingAttachments(attachments));
+      const outgoingAttachments = buildOutgoingAttachments(attachments);
+      const clientSlashCommand = resolveClientSlashCommand({
+        text: payload.text,
+        hasAttachments: outgoingAttachments.length > 0,
+      });
+      if (clientSlashCommand && runClientSlashCommand(clientSlashCommand)) {
+        return;
+      }
+      queueMessage(payload.text, outgoingAttachments);
     },
-    [attachments, buildOutgoingAttachments, queueMessage],
+    [attachments, buildOutgoingAttachments, queueMessage, runClientSlashCommand],
   );
 
-  const activeClientSlashCommand = resolveActiveClientSlashCommand({
-    text: userInput,
-    hasAttachments: buildOutgoingAttachments(attachments).length > 0,
-    canHandleClientSlashCommand: Boolean(onClientSlashCommand),
-  });
   const hasSendableContent = userInput.trim().length > 0 || selectedAttachments.length > 0;
 
   // Handle keyboard navigation for command autocomplete.
   const handleCommandKeyPress = useCallback(
-    (event: MessageInputKeyPressEvent) => {
-      if (event.key === "Enter") {
-        const clientSlashCommand = resolveActiveClientSlashCommand({
-          text: event.text,
-          hasAttachments: event.attachments.length > 0,
-          canHandleClientSlashCommand: Boolean(onClientSlashCommand),
-        });
-        if (clientSlashCommand) {
-          event.preventDefault();
-          handleSubmit({
-            text: event.text,
-            attachments: event.attachments,
-            cwd: event.cwd,
-            forceSend: isAgentRunning || undefined,
-          });
-          return true;
-        }
-      }
-      return autocompleteOnKeyPressRef.current(event);
-    },
-    [handleSubmit, isAgentRunning, onClientSlashCommand],
+    (event: { key: string; preventDefault: () => void }) =>
+      autocompleteOnKeyPressRef.current(event),
+    [],
   );
 
   const cancelButtonStyle = useMemo(
@@ -1665,10 +1641,7 @@ export function Composer({
               voiceServerId={serverId}
               voiceAgentId={agentId}
               isAgentRunning={isAgentRunning}
-              defaultSendBehavior={resolveComposerSendBehavior({
-                appSendBehavior: appSettings.sendBehavior,
-                activeClientSlashCommand,
-              })}
+              defaultSendBehavior={appSettings.sendBehavior}
               onQueue={handleQueue}
               onSubmitLoadingPress={submitLoadingPressHandler}
               onKeyPress={handleCommandKeyPress}

--- a/packages/app/src/components/message-input.tsx
+++ b/packages/app/src/components/message-input.tsx
@@ -74,14 +74,6 @@ export interface AttachmentMenuItem {
   icon?: React.ReactElement | null;
 }
 
-export interface MessageInputKeyPressEvent {
-  key: string;
-  preventDefault: () => void;
-  text: string;
-  attachments: ComposerAttachment[];
-  cwd: string;
-}
-
 export interface MessageInputProps {
   value: string;
   onChangeText: (text: string) => void;
@@ -127,7 +119,7 @@ export interface MessageInputProps {
   /** Optional handler used when submit button is in loading state. */
   onSubmitLoadingPress?: () => void;
   /** Intercept key press events before default handling. Return true to prevent default. */
-  onKeyPress?: (event: MessageInputKeyPressEvent) => boolean;
+  onKeyPress?: (event: { key: string; preventDefault: () => void }) => boolean;
   /** Reports cursor selection updates from the underlying input. */
   onSelectionChange?: (selection: { start: number; end: number }) => void;
   onFocusChange?: (focused: boolean) => void;
@@ -372,15 +364,12 @@ function resolveSendTooltipLabel(input: {
 }
 
 interface DesktopKeyPressContext {
-  onKeyPressCallback: ((event: MessageInputKeyPressEvent) => boolean) | undefined;
+  onKeyPressCallback: ((event: { key: string; preventDefault: () => void }) => boolean) | undefined;
   isAgentRunning: boolean;
   onQueue: ((payload: MessagePayload) => void) | undefined;
   isSubmitDisabled: boolean;
   isSubmitLoading: boolean;
   disabled: boolean;
-  value: string;
-  attachments: ComposerAttachment[];
-  cwd: string;
   handleAlternateSendAction: () => void;
   handleDefaultSendAction: () => void;
 }
@@ -395,9 +384,6 @@ function handleDesktopKeyPressImpl(
     const handled = ctx.onKeyPressCallback({
       key: event.nativeEvent.key,
       preventDefault: () => event.preventDefault(),
-      text: ctx.value,
-      attachments: ctx.attachments,
-      cwd: ctx.cwd,
     });
     if (handled) return;
   }
@@ -1106,7 +1092,7 @@ interface ResolvedMessageInputProps {
   defaultSendBehavior: "interrupt" | "queue";
   onQueue: ((payload: MessagePayload) => void) | undefined;
   onSubmitLoadingPress: (() => void) | undefined;
-  onKeyPressCallback: ((event: MessageInputKeyPressEvent) => boolean) | undefined;
+  onKeyPressCallback: ((event: { key: string; preventDefault: () => void }) => boolean) | undefined;
   onSelectionChangeCallback: ((selection: { start: number; end: number }) => void) | undefined;
   onFocusChange: ((focused: boolean) => void) | undefined;
   onHeightChange: ((height: number) => void) | undefined;
@@ -1591,9 +1577,6 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
         isSubmitDisabled,
         isSubmitLoading,
         disabled,
-        value: valueRef.current,
-        attachments,
-        cwd,
         handleAlternateSendAction,
         handleDefaultSendAction,
       });

--- a/packages/app/src/components/message-input.tsx
+++ b/packages/app/src/components/message-input.tsx
@@ -74,6 +74,14 @@ export interface AttachmentMenuItem {
   icon?: React.ReactElement | null;
 }
 
+export interface MessageInputKeyPressEvent {
+  key: string;
+  preventDefault: () => void;
+  text: string;
+  attachments: ComposerAttachment[];
+  cwd: string;
+}
+
 export interface MessageInputProps {
   value: string;
   onChangeText: (text: string) => void;
@@ -119,7 +127,7 @@ export interface MessageInputProps {
   /** Optional handler used when submit button is in loading state. */
   onSubmitLoadingPress?: () => void;
   /** Intercept key press events before default handling. Return true to prevent default. */
-  onKeyPress?: (event: { key: string; preventDefault: () => void }) => boolean;
+  onKeyPress?: (event: MessageInputKeyPressEvent) => boolean;
   /** Reports cursor selection updates from the underlying input. */
   onSelectionChange?: (selection: { start: number; end: number }) => void;
   onFocusChange?: (focused: boolean) => void;
@@ -364,12 +372,15 @@ function resolveSendTooltipLabel(input: {
 }
 
 interface DesktopKeyPressContext {
-  onKeyPressCallback: ((event: { key: string; preventDefault: () => void }) => boolean) | undefined;
+  onKeyPressCallback: ((event: MessageInputKeyPressEvent) => boolean) | undefined;
   isAgentRunning: boolean;
   onQueue: ((payload: MessagePayload) => void) | undefined;
   isSubmitDisabled: boolean;
   isSubmitLoading: boolean;
   disabled: boolean;
+  value: string;
+  attachments: ComposerAttachment[];
+  cwd: string;
   handleAlternateSendAction: () => void;
   handleDefaultSendAction: () => void;
 }
@@ -384,6 +395,9 @@ function handleDesktopKeyPressImpl(
     const handled = ctx.onKeyPressCallback({
       key: event.nativeEvent.key,
       preventDefault: () => event.preventDefault(),
+      text: ctx.value,
+      attachments: ctx.attachments,
+      cwd: ctx.cwd,
     });
     if (handled) return;
   }
@@ -1092,7 +1106,7 @@ interface ResolvedMessageInputProps {
   defaultSendBehavior: "interrupt" | "queue";
   onQueue: ((payload: MessagePayload) => void) | undefined;
   onSubmitLoadingPress: (() => void) | undefined;
-  onKeyPressCallback: ((event: { key: string; preventDefault: () => void }) => boolean) | undefined;
+  onKeyPressCallback: ((event: MessageInputKeyPressEvent) => boolean) | undefined;
   onSelectionChangeCallback: ((selection: { start: number; end: number }) => void) | undefined;
   onFocusChange: ((focused: boolean) => void) | undefined;
   onHeightChange: ((height: number) => void) | undefined;
@@ -1451,7 +1465,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     const handleSendMessage = useCallback(
       () =>
         sendMessageImpl({
-          value,
+          value: valueRef.current,
           attachments,
           hasExternalContent,
           allowEmptySubmit,
@@ -1462,7 +1476,6 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
         }),
       [
         allowEmptySubmit,
-        value,
         attachments,
         cwd,
         onSubmit,
@@ -1475,14 +1488,14 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     const handleQueueMessage = useCallback(
       () =>
         queueMessageImpl({
-          value,
+          value: valueRef.current,
           attachments,
           cwd,
           onQueue,
           onChangeText,
           onMinimizeHeight: minimizeInputHeight,
         }),
-      [value, attachments, cwd, onQueue, onChangeText, minimizeInputHeight],
+      [attachments, cwd, onQueue, onChangeText, minimizeInputHeight],
     );
 
     const handleDefaultSendAction = useCallback(() => {
@@ -1578,6 +1591,9 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
         isSubmitDisabled,
         isSubmitLoading,
         disabled,
+        value: valueRef.current,
+        attachments,
+        cwd,
         handleAlternateSendAction,
         handleDefaultSendAction,
       });
@@ -1623,6 +1639,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
 
     const handleInputChange = useCallback(
       (nextValue: string) => {
+        valueRef.current = nextValue;
         onChangeText(nextValue);
       },
       [onChangeText],

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -1,12 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import type { AutocompleteOption } from "@/components/ui/autocomplete";
-import { useAgentCommandsQuery, type DraftCommandConfig } from "./use-agent-commands-query";
+import {
+  useAgentCommandsQuery,
+  type AgentSlashCommand,
+  type DraftCommandConfig,
+} from "./use-agent-commands-query";
 import { orderAutocompleteOptions } from "@/components/ui/autocomplete-utils";
 import { useAutocomplete } from "./use-autocomplete";
 import { useSessionStore } from "@/stores/session-store";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
-import { CLIENT_SLASH_COMMANDS } from "@/client-slash-commands";
+import { CLIENT_SLASH_COMMANDS, type ClientSlashCommand } from "@/client-slash-commands";
 import {
   applyFileMentionReplacement,
   findActiveFileMention,
@@ -21,10 +25,13 @@ interface UseAgentAutocompleteInput {
   agentId: string;
   draftConfig?: DraftCommandConfig;
   onAutocompleteApplied?: () => void;
+  onClientSlashCommand?: (command: ClientSlashCommand) => void;
+  canExecuteClientSlashCommand?: boolean;
 }
 
 type AgentAutocompleteOption =
-  | (AutocompleteOption & { type: "command" })
+  | (AutocompleteOption & { type: "client_command"; command: ClientSlashCommand })
+  | (AutocompleteOption & { type: "provider_command" })
   | (AutocompleteOption & {
       type: "workspace_entry";
       entryPath: string;
@@ -47,6 +54,10 @@ interface DirectorySuggestionEntry {
   path: string;
   kind: "file" | "directory";
 }
+
+type AvailableCommand =
+  | { source: "client"; command: ClientSlashCommand }
+  | { source: "provider"; command: AgentSlashCommand };
 
 function normalizeDraftCommandConfig(
   draftConfig?: DraftCommandConfig,
@@ -95,6 +106,28 @@ function mapDirectorySuggestionsToEntries(payload: {
     path,
     kind: "directory" as const,
   }));
+}
+
+function mapCommandToOption(entry: AvailableCommand): AgentAutocompleteOption {
+  const command = entry.command;
+  const base = {
+    id: command.name,
+    label: `/${command.name}`,
+    detail: command.argumentHint || undefined,
+    description: command.description,
+    kind: "command" as const,
+  };
+  if (entry.source === "client") {
+    return {
+      ...base,
+      type: "client_command",
+      command: entry.command,
+    };
+  }
+  return {
+    ...base,
+    type: "provider_command",
+  };
 }
 
 type AutocompleteMode = "command" | "file" | null;
@@ -171,6 +204,8 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     agentId,
     draftConfig,
     onAutocompleteApplied,
+    onClientSlashCommand,
+    canExecuteClientSlashCommand,
   } = input;
 
   const showCommandAutocomplete = userInput.startsWith("/") && !userInput.includes(" ");
@@ -278,19 +313,22 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
 
     if (mode === "command") {
       const filterLower = commandFilterQuery.toLowerCase();
-      const availableCommands = isDraftContext ? commands : [...CLIENT_SLASH_COMMANDS, ...commands];
-      const matches = availableCommands.filter((cmd) =>
-        cmd.name.toLowerCase().includes(filterLower),
+      const providerCommands = commands.map(
+        (command): AvailableCommand => ({ source: "provider", command }),
+      );
+      const availableCommands: AvailableCommand[] = isDraftContext
+        ? providerCommands
+        : [
+            ...CLIENT_SLASH_COMMANDS.map(
+              (command): AvailableCommand => ({ source: "client", command }),
+            ),
+            ...providerCommands,
+          ];
+      const matches = availableCommands.filter((entry) =>
+        entry.command.name.toLowerCase().includes(filterLower),
       );
       const orderedMatches = orderAutocompleteOptions(matches);
-      return orderedMatches.map((cmd) => ({
-        type: "command" as const,
-        id: cmd.name,
-        label: `/${cmd.name}`,
-        detail: cmd.argumentHint || undefined,
-        description: cmd.description,
-        kind: "command",
-      }));
+      return orderedMatches.map(mapCommandToOption);
     }
 
     if (mode === "file" && activeFileMention) {
@@ -319,7 +357,17 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
   const onSelectOption = useCallback(
     (option: AutocompleteOption) => {
       const selected = option as AgentAutocompleteOption;
-      if (selected.type === "command") {
+      if (
+        selected.type === "client_command" &&
+        selected.command.execution === "immediate" &&
+        canExecuteClientSlashCommand &&
+        onClientSlashCommand
+      ) {
+        onClientSlashCommand(selected.command);
+        return;
+      }
+
+      if (selected.type === "client_command" || selected.type === "provider_command") {
         setUserInput(`/${selected.id} `);
         onAutocompleteApplied?.();
         return;
@@ -333,7 +381,13 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
       setUserInput(nextInput);
       onAutocompleteApplied?.();
     },
-    [onAutocompleteApplied, setUserInput, userInput],
+    [
+      canExecuteClientSlashCommand,
+      onAutocompleteApplied,
+      onClientSlashCommand,
+      setUserInput,
+      userInput,
+    ],
   );
 
   const { selectedIndex, onKeyPress } = useAutocomplete({

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -6,6 +6,7 @@ import { orderAutocompleteOptions } from "@/components/ui/autocomplete-utils";
 import { useAutocomplete } from "./use-autocomplete";
 import { useSessionStore } from "@/stores/session-store";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+import { CLIENT_SLASH_COMMANDS } from "@/client-slash-commands";
 import {
   applyFileMentionReplacement,
   findActiveFileMention,
@@ -277,7 +278,10 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
 
     if (mode === "command") {
       const filterLower = commandFilterQuery.toLowerCase();
-      const matches = commands.filter((cmd) => cmd.name.toLowerCase().includes(filterLower));
+      const availableCommands = isDraftContext ? commands : [...CLIENT_SLASH_COMMANDS, ...commands];
+      const matches = availableCommands.filter((cmd) =>
+        cmd.name.toLowerCase().includes(filterLower),
+      );
       const orderedMatches = orderAutocompleteOptions(matches);
       return orderedMatches.map((cmd) => ({
         type: "command" as const,
@@ -302,7 +306,15 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     }
 
     return [];
-  }, [activeFileMention, commandFilterQuery, commands, fileSuggestionsQuery.data, isVisible, mode]);
+  }, [
+    activeFileMention,
+    commandFilterQuery,
+    commands,
+    fileSuggestionsQuery.data,
+    isDraftContext,
+    isVisible,
+    mode,
+  ]);
 
   const onSelectOption = useCallback(
     (option: AutocompleteOption) => {

--- a/packages/app/src/hooks/use-agent-commands-query.ts
+++ b/packages/app/src/hooks/use-agent-commands-query.ts
@@ -4,7 +4,7 @@ import type { AgentProvider } from "@server/server/agent/agent-sdk-types";
 
 const COMMANDS_STALE_TIME = 60_000; // Commands rarely change, cache for 1 minute
 
-interface AgentSlashCommand {
+export interface AgentSlashCommand {
   name: string;
   description: string;
   argumentHint: string;

--- a/packages/app/src/hooks/use-agent-input-draft.ts
+++ b/packages/app/src/hooks/use-agent-input-draft.ts
@@ -27,6 +27,7 @@ type AttachmentUpdater =
 interface AgentInputDraftComposerOptions {
   initialServerId: string | null;
   initialValues?: CreateAgentInitialValues;
+  initialFeatureValues?: Record<string, unknown>;
   isVisible?: boolean;
   onlineServerIds?: string[];
   lockedWorkingDir?: string;
@@ -229,6 +230,7 @@ export function useAgentInputDraft(input: UseAgentInputDraftInput): AgentInputDr
     modeId: formState.selectedMode,
     modelId: effectiveModelId,
     thinkingOptionId: effectiveThinkingOptionId,
+    initialFeatureValues: composerOptions?.initialFeatureValues,
   });
 
   const commandDraftConfig = useMemo(

--- a/packages/app/src/hooks/use-draft-agent-features.ts
+++ b/packages/app/src/hooks/use-draft-agent-features.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { AgentProvider, AgentSessionConfig } from "@server/server/agent/agent-sdk-types";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
@@ -21,14 +21,19 @@ export function useDraftAgentFeatures(input: {
   modeId: string | null | undefined;
   modelId: string | null | undefined;
   thinkingOptionId: string | null | undefined;
+  initialFeatureValues?: Record<string, unknown>;
 }) {
-  const { serverId, provider, cwd, modeId, modelId, thinkingOptionId } = input;
-  const [localFeatureValues, setLocalFeatureValues] = useState<Record<string, unknown>>({});
+  const { serverId, provider, cwd, modeId, modelId, thinkingOptionId, initialFeatureValues } =
+    input;
+  const [localFeatureValues, setLocalFeatureValues] = useState<Record<string, unknown>>(
+    () => initialFeatureValues ?? {},
+  );
   const client = useHostRuntimeClient(serverId ?? "");
   const isConnected = useHostRuntimeIsConnected(serverId ?? "");
   const { preferences, updatePreferences } = useFormPreferences();
   const normalizedCwd = cwd?.trim() || "";
   const normalizedProvider = provider ?? null;
+  const previousProviderRef = useRef<AgentProvider | null>(normalizedProvider);
   const persistedFeatureValues = useMemo(
     () => (provider ? (preferences.providerPreferences?.[provider]?.featureValues ?? {}) : {}),
     [preferences.providerPreferences, provider],
@@ -88,15 +93,25 @@ export function useDraftAgentFeatures(input: {
   }, [availableFeatures, featureValues]);
 
   useEffect(() => {
-    setLocalFeatureValues({});
-  }, [provider]);
+    const previousProvider = previousProviderRef.current;
+    previousProviderRef.current = normalizedProvider;
+    if (previousProvider === null) {
+      return;
+    }
+    if (previousProvider !== normalizedProvider) {
+      setLocalFeatureValues({});
+    }
+  }, [normalizedProvider]);
 
   useEffect(() => {
+    if (availableFeaturesRaw === undefined) {
+      return;
+    }
     const next = pruneFeatureValues(localFeatureValues, availableFeatures);
     if (next !== localFeatureValues) {
       setLocalFeatureValues(next);
     }
-  }, [availableFeatures, localFeatureValues]);
+  }, [availableFeatures, availableFeaturesRaw, localFeatureValues]);
 
   const effectiveFeatureValues = Object.keys(featureValues).length > 0 ? featureValues : undefined;
   const setFeatureValue = useCallback(

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -48,7 +48,7 @@ import {
   deriveRouteBottomAnchorRequest,
 } from "@/screens/agent/agent-ready-screen-bottom-anchor";
 import { useCreateFlowStore } from "@/stores/create-flow-store";
-import { buildDraftStoreKey } from "@/stores/draft-keys";
+import { buildDraftStoreKey, generateDraftId } from "@/stores/draft-keys";
 import { usePanelStore } from "@/stores/panel-store";
 import { type Agent, useSessionStore } from "@/stores/session-store";
 import type { Theme } from "@/styles/theme";
@@ -60,6 +60,11 @@ import { derivePendingPermissionKey, normalizeAgentSnapshot } from "@/utils/agen
 import { mergePendingCreateImages } from "@/utils/pending-create-images";
 import { navigateToAgent } from "@/utils/navigate-to-agent";
 import { deriveSidebarStateBucket } from "@/utils/sidebar-agent-state";
+import {
+  buildDraftAgentSetupSeed,
+  seedDraftAgentSetup,
+  type ClientSlashCommand,
+} from "@/client-slash-commands";
 
 interface ChatAgentStateShape {
   serverId: string | null;
@@ -1257,7 +1262,8 @@ function ActiveAgentComposer({
   const insets = useSafeAreaInsets();
   const isCompact = useIsCompactFormFactor();
   const paneContext = usePaneContext();
-  const { workspaceId } = paneContext;
+  const { workspaceId, retargetCurrentTab } = paneContext;
+  const { archiveAgent } = useArchiveAgent();
   const subagentRows = useSubagentsForParent({
     serverId,
     parentAgentId: agentId,
@@ -1305,6 +1311,30 @@ function ActiveAgentComposer({
     [isCompact, openFileExplorerForCheckout, serverId, setExplorerTabForCheckout],
   );
 
+  const handleClientSlashCommand = useCallback(
+    async (command: ClientSlashCommand) => {
+      const agent =
+        useSessionStore.getState().sessions[serverId]?.agents.get(agentId) ??
+        useSessionStore.getState().sessions[serverId]?.agentDetails.get(agentId) ??
+        null;
+      if (!agent) {
+        throw new Error("Agent not found");
+      }
+
+      if (command.kind === "replace-agent-with-draft") {
+        const draftId = generateDraftId();
+        seedDraftAgentSetup({
+          draftId,
+          setup: buildDraftAgentSetupSeed(agent),
+        });
+        retargetCurrentTab({ kind: "draft", draftId });
+      }
+
+      await archiveAgent({ serverId, agentId });
+    },
+    [agentId, archiveAgent, retargetCurrentTab, serverId],
+  );
+
   const inputAreaStyle = useMemo(
     () => [styles.inputAreaWrapper, { paddingBottom: insets.bottom }],
     [insets.bottom],
@@ -1336,6 +1366,7 @@ function ActiveAgentComposer({
         onAddImages={onAddImages}
         onComposerHeightChange={onComposerHeightChange}
         onMessageSent={onMessageSent}
+        onClientSlashCommand={handleClientSlashCommand}
       />
     </View>
   );

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -60,11 +60,7 @@ import { derivePendingPermissionKey, normalizeAgentSnapshot } from "@/utils/agen
 import { mergePendingCreateImages } from "@/utils/pending-create-images";
 import { navigateToAgent } from "@/utils/navigate-to-agent";
 import { deriveSidebarStateBucket } from "@/utils/sidebar-agent-state";
-import {
-  buildDraftAgentSetupSeed,
-  seedDraftAgentSetup,
-  type ClientSlashCommand,
-} from "@/client-slash-commands";
+import { buildDraftAgentSetup, type ClientSlashCommand } from "@/client-slash-commands";
 
 interface ChatAgentStateShape {
   serverId: string | null;
@@ -1313,21 +1309,17 @@ function ActiveAgentComposer({
 
   const handleClientSlashCommand = useCallback(
     async (command: ClientSlashCommand) => {
-      const agent =
-        useSessionStore.getState().sessions[serverId]?.agents.get(agentId) ??
-        useSessionStore.getState().sessions[serverId]?.agentDetails.get(agentId) ??
-        null;
+      const agent = resolveChatAgentFromSession(useSessionStore.getState(), serverId, agentId);
       if (!agent) {
         throw new Error("Agent not found");
       }
 
       if (command.kind === "replace-agent-with-draft") {
-        const draftId = generateDraftId();
-        seedDraftAgentSetup({
-          draftId,
-          setup: buildDraftAgentSetupSeed(agent),
+        retargetCurrentTab({
+          kind: "draft",
+          draftId: generateDraftId(),
+          setup: buildDraftAgentSetup(agent),
         });
-        retargetCurrentTab({ kind: "draft", draftId });
       }
 
       await archiveAgent({ serverId, agentId });

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -51,6 +51,8 @@ import { useCreateFlowStore } from "@/stores/create-flow-store";
 import { buildDraftStoreKey, generateDraftId } from "@/stores/draft-keys";
 import { usePanelStore } from "@/stores/panel-store";
 import { type Agent, useSessionStore } from "@/stores/session-store";
+import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
+import { buildWorkspaceTabPersistenceKey } from "@/stores/workspace-tabs-store";
 import type { Theme } from "@/styles/theme";
 import { SubagentsSection, useArchiveSubagent, useSubagentsForParent } from "@/subagents";
 import type { PendingPermission } from "@/types/shared";
@@ -1258,8 +1260,11 @@ function ActiveAgentComposer({
   const insets = useSafeAreaInsets();
   const isCompact = useIsCompactFormFactor();
   const paneContext = usePaneContext();
-  const { workspaceId, retargetCurrentTab } = paneContext;
+  const { workspaceId, tabId, retargetCurrentTab } = paneContext;
   const { archiveAgent } = useArchiveAgent();
+  const closeWorkspaceTab = useWorkspaceLayoutStore((state) => state.closeTab);
+  const hideWorkspaceAgent = useWorkspaceLayoutStore((state) => state.hideAgent);
+  const unpinWorkspaceAgent = useWorkspaceLayoutStore((state) => state.unpinAgent);
   const subagentRows = useSubagentsForParent({
     serverId,
     parentAgentId: agentId,
@@ -1314,17 +1319,35 @@ function ActiveAgentComposer({
         throw new Error("Agent not found");
       }
 
+      const workspaceKey = buildWorkspaceTabPersistenceKey({ serverId, workspaceId });
+      if (workspaceKey) {
+        unpinWorkspaceAgent(workspaceKey, agentId);
+        hideWorkspaceAgent(workspaceKey, agentId);
+      }
+
       if (command.kind === "replace-agent-with-draft") {
         retargetCurrentTab({
           kind: "draft",
           draftId: generateDraftId(),
           setup: buildDraftAgentSetup(agent),
         });
+      } else if (workspaceKey) {
+        closeWorkspaceTab(workspaceKey, tabId);
       }
 
       await archiveAgent({ serverId, agentId });
     },
-    [agentId, archiveAgent, retargetCurrentTab, serverId],
+    [
+      agentId,
+      archiveAgent,
+      closeWorkspaceTab,
+      hideWorkspaceAgent,
+      retargetCurrentTab,
+      serverId,
+      tabId,
+      unpinWorkspaceAgent,
+      workspaceId,
+    ],
   );
 
   const inputAreaStyle = useMemo(

--- a/packages/app/src/panels/draft-panel.tsx
+++ b/packages/app/src/panels/draft-panel.tsx
@@ -56,6 +56,7 @@ function DraftPanel() {
       workspaceId={workspaceId}
       tabId={tabId}
       draftId={target.draftId}
+      initialSetup={target.setup}
       isPaneFocused={isInteractive}
       onOpenWorkspaceFile={handleOpenWorkspaceFile}
       onCreated={handleCreated}

--- a/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
+++ b/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
@@ -32,7 +32,7 @@ import {
 import type { UserMessageImageAttachment } from "@/types/stream";
 import { MAX_CONTENT_WIDTH, useIsCompactFormFactor } from "@/constants/layout";
 import { isWeb } from "@/constants/platform";
-import { useDraftAgentSetupSeed, type DraftAgentSetupSeed } from "@/client-slash-commands";
+import type { WorkspaceDraftTabSetup } from "@/stores/workspace-tabs-store";
 
 const EMPTY_PENDING_PERMISSIONS = new Map();
 const EMPTY_ONLINE_SERVER_IDS: string[] = [];
@@ -274,31 +274,31 @@ function buildDraftAgentSnapshot(input: {
   };
 }
 
-function buildSeededDraftInitialValues(input: {
+function buildDraftInitialValues(input: {
   workingDir: string | null;
-  seededSetup: DraftAgentSetupSeed | null;
+  initialSetup: WorkspaceDraftTabSetup | null;
 }): CreateAgentInitialValues | undefined {
   if (!input.workingDir) {
     return undefined;
   }
-  if (!input.seededSetup) {
+  if (!input.initialSetup) {
     return { workingDir: input.workingDir };
   }
   return {
     workingDir: input.workingDir,
-    provider: input.seededSetup.provider,
-    modeId: input.seededSetup.modeId,
-    model: input.seededSetup.model,
-    thinkingOptionId: input.seededSetup.thinkingOptionId,
+    provider: input.initialSetup.provider,
+    modeId: input.initialSetup.modeId,
+    model: input.initialSetup.model,
+    thinkingOptionId: input.initialSetup.thinkingOptionId,
   };
 }
 
 function resolveDraftWorkingDirectory(input: {
   workspaceDirectory: string | null;
-  seededSetup: DraftAgentSetupSeed | null;
+  initialSetup: WorkspaceDraftTabSetup | null;
 }): string | null {
-  if (input.seededSetup) {
-    return input.seededSetup.cwd;
+  if (input.initialSetup) {
+    return input.initialSetup.cwd;
   }
   return input.workspaceDirectory;
 }
@@ -315,6 +315,7 @@ interface WorkspaceDraftAgentTabProps {
   workspaceId: string;
   tabId: string;
   draftId: string;
+  initialSetup?: WorkspaceDraftTabSetup;
   isPaneFocused: boolean;
   onCreated: (snapshot: AgentSnapshotPayload) => void;
   onOpenWorkspaceFile: (input: { filePath: string }) => void;
@@ -326,6 +327,7 @@ export function WorkspaceDraftAgentTab({
   workspaceId,
   tabId,
   draftId,
+  initialSetup = undefined,
   isPaneFocused,
   onCreated,
   onOpenWorkspaceFile,
@@ -337,11 +339,14 @@ export function WorkspaceDraftAgentTab({
   const workspaceAuthority = useWorkspaceExecutionAuthority(serverId, workspaceId);
   const workspaceExecutionAuthority = workspaceAuthority?.ok ? workspaceAuthority.authority : null;
   const workspaceDirectory = workspaceExecutionAuthority?.workspaceDirectory ?? null;
-  const seededSetup = useDraftAgentSetupSeed(draftId);
-  const draftWorkingDirectory = resolveDraftWorkingDirectory({ workspaceDirectory, seededSetup });
-  const draftInitialValues = buildSeededDraftInitialValues({
+  const draftSetup = initialSetup ?? null;
+  const draftWorkingDirectory = resolveDraftWorkingDirectory({
+    workspaceDirectory,
+    initialSetup: draftSetup,
+  });
+  const draftInitialValues = buildDraftInitialValues({
     workingDir: draftWorkingDirectory,
-    seededSetup,
+    initialSetup: draftSetup,
   });
   const onlineServerIds = resolveOnlineServerIds({ isConnected, serverId });
   const addImagesRef = useRef<((images: ImageAttachment[]) => void) | null>(null);
@@ -359,7 +364,7 @@ export function WorkspaceDraftAgentTab({
     composer: {
       initialServerId: serverId,
       initialValues: draftInitialValues,
-      initialFeatureValues: seededSetup?.featureValues,
+      initialFeatureValues: draftSetup?.featureValues,
       isVisible: true,
       onlineServerIds,
       lockedWorkingDir: draftWorkingDirectory ?? undefined,

--- a/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
+++ b/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
@@ -10,6 +10,7 @@ import { AgentStreamView } from "@/components/agent-stream-view";
 import { composerWorkspaceAttachment } from "@/attachments/composer-workspace-attachments";
 import type { ImageAttachment } from "@/components/message-input";
 import { useAgentInputDraft } from "@/hooks/use-agent-input-draft";
+import type { CreateAgentInitialValues } from "@/hooks/use-agent-form-state";
 import { useDraftAgentCreateFlow } from "@/hooks/use-draft-agent-create-flow";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { buildWorkspaceDraftAgentConfig } from "@/screens/workspace/workspace-draft-agent-config";
@@ -31,8 +32,10 @@ import {
 import type { UserMessageImageAttachment } from "@/types/stream";
 import { MAX_CONTENT_WIDTH, useIsCompactFormFactor } from "@/constants/layout";
 import { isWeb } from "@/constants/platform";
+import { useDraftAgentSetupSeed, type DraftAgentSetupSeed } from "@/client-slash-commands";
 
 const EMPTY_PENDING_PERMISSIONS = new Map();
+const EMPTY_ONLINE_SERVER_IDS: string[] = [];
 const DRAFT_CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: true,
   supportsSessionPersistence: false,
@@ -271,6 +274,42 @@ function buildDraftAgentSnapshot(input: {
   };
 }
 
+function buildSeededDraftInitialValues(input: {
+  workingDir: string | null;
+  seededSetup: DraftAgentSetupSeed | null;
+}): CreateAgentInitialValues | undefined {
+  if (!input.workingDir) {
+    return undefined;
+  }
+  if (!input.seededSetup) {
+    return { workingDir: input.workingDir };
+  }
+  return {
+    workingDir: input.workingDir,
+    provider: input.seededSetup.provider,
+    modeId: input.seededSetup.modeId,
+    model: input.seededSetup.model,
+    thinkingOptionId: input.seededSetup.thinkingOptionId,
+  };
+}
+
+function resolveDraftWorkingDirectory(input: {
+  workspaceDirectory: string | null;
+  seededSetup: DraftAgentSetupSeed | null;
+}): string | null {
+  if (input.seededSetup) {
+    return input.seededSetup.cwd;
+  }
+  return input.workspaceDirectory;
+}
+
+function resolveOnlineServerIds(input: { isConnected: boolean; serverId: string }): string[] {
+  if (!input.isConnected) {
+    return EMPTY_ONLINE_SERVER_IDS;
+  }
+  return [input.serverId];
+}
+
 interface WorkspaceDraftAgentTabProps {
   serverId: string;
   workspaceId: string;
@@ -298,6 +337,13 @@ export function WorkspaceDraftAgentTab({
   const workspaceAuthority = useWorkspaceExecutionAuthority(serverId, workspaceId);
   const workspaceExecutionAuthority = workspaceAuthority?.ok ? workspaceAuthority.authority : null;
   const workspaceDirectory = workspaceExecutionAuthority?.workspaceDirectory ?? null;
+  const seededSetup = useDraftAgentSetupSeed(draftId);
+  const draftWorkingDirectory = resolveDraftWorkingDirectory({ workspaceDirectory, seededSetup });
+  const draftInitialValues = buildSeededDraftInitialValues({
+    workingDir: draftWorkingDirectory,
+    seededSetup,
+  });
+  const onlineServerIds = resolveOnlineServerIds({ isConnected, serverId });
   const addImagesRef = useRef<((images: ImageAttachment[]) => void) | null>(null);
   const draftStoreKey = useMemo(
     () =>
@@ -312,10 +358,11 @@ export function WorkspaceDraftAgentTab({
     draftKey: draftStoreKey,
     composer: {
       initialServerId: serverId,
-      initialValues: workspaceDirectory ? { workingDir: workspaceDirectory } : undefined,
+      initialValues: draftInitialValues,
+      initialFeatureValues: seededSetup?.featureValues,
       isVisible: true,
-      onlineServerIds: isConnected ? [serverId] : [],
-      lockedWorkingDir: workspaceDirectory ?? undefined,
+      onlineServerIds,
+      lockedWorkingDir: draftWorkingDirectory ?? undefined,
     },
   });
   const composerState = draftInput.composerState;
@@ -381,7 +428,7 @@ export function WorkspaceDraftAgentTab({
         allowsEmptyAutoSubmit,
         composerState,
         autoSubmitConfig,
-        workspaceDirectory,
+        workspaceDirectory: draftWorkingDirectory,
         hasClient: Boolean(client),
       }),
     onBeforeSubmit: () => {
@@ -396,7 +443,7 @@ export function WorkspaceDraftAgentTab({
         attempt,
         serverId,
         tabId,
-        workspaceDirectory,
+        workspaceDirectory: draftWorkingDirectory,
         autoSubmitConfig,
         composerState,
       }),
@@ -407,7 +454,7 @@ export function WorkspaceDraftAgentTab({
         images,
         attachments,
         client,
-        workspaceDirectory,
+        workspaceDirectory: draftWorkingDirectory,
         workspaceExecutionAuthority,
         autoSubmitConfig,
         composerState,
@@ -421,7 +468,7 @@ export function WorkspaceDraftAgentTab({
   const isReadyForPendingAutoSubmit = Boolean(
     pendingAutoSubmit &&
     draftInput.isHydrated &&
-    workspaceDirectory &&
+    draftWorkingDirectory &&
     client &&
     !isSubmitting &&
     !composerState.isModelLoading,

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -75,6 +75,7 @@ export interface AgentRuntimeInfo {
   sessionId: string | null;
   model?: string | null;
   modeId?: string | null;
+  thinkingOptionId?: string | null;
   extra?: Record<string, unknown>;
 }
 

--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -1159,14 +1159,21 @@ export function retargetTabInLayout(
     };
   }
 
+  const nextTabId =
+    currentTab?.target.kind === "draft"
+      ? input.tabId
+      : buildDeterministicWorkspaceTabId(input.target);
+
   return {
-    // Preserve the existing tab id so draft->entity transitions keep the same
-    // React key during the first render. Reconciliation can canonicalize later.
-    tabId: input.tabId,
+    // Preserve draft-origin tab ids so draft->entity transitions keep the same
+    // React key during the first render. Non-draft retargets must take the new
+    // target identity immediately so local tab state cannot masquerade as the
+    // previous agent/terminal/file.
+    tabId: nextTabId,
     layout: {
       root: replaceTabInTree(layout.root, {
         tabId: input.tabId,
-        nextTabId: input.tabId,
+        nextTabId,
         target: input.target,
       }),
       focusedPaneId: layout.focusedPaneId,

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -589,6 +589,32 @@ describe("workspace-layout-store actions", () => {
     ]);
   });
 
+  it("retargetTab gives a non-draft tab the new target identity", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    const agentTabId = store.openTabFocused(workspaceKey, {
+      kind: "agent",
+      agentId: "agent-retarget",
+    });
+    const nextTabId = store.retargetTab(workspaceKey, agentTabId!, {
+      kind: "draft",
+      draftId: "draft-from-agent",
+    });
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+
+    expect(agentTabId).toBe("agent_agent-retarget");
+    expect(nextTabId).toBe("draft-from-agent");
+    expect(findPaneById(layout.root, "main")?.tabIds).toEqual(["draft-from-agent"]);
+    expect(collectAllTabs(layout.root)).toEqual([
+      {
+        tabId: "draft-from-agent",
+        target: { kind: "draft", draftId: "draft-from-agent" },
+        createdAt: expect.any(Number),
+      },
+    ]);
+  });
+
   it("retargetTab closes a draft tab and focuses the existing canonical target tab", () => {
     useWorkspaceLayoutIds("55555555-5555-5555-5555-555555555555");
     const workspaceKey = createWorkspaceKey();

--- a/packages/app/src/stores/workspace-tabs-store.test.ts
+++ b/packages/app/src/stores/workspace-tabs-store.test.ts
@@ -185,6 +185,96 @@ describe("workspace-tabs-store retargetTab", () => {
     ]);
   });
 
+  it("keeps draft setup on a retargeted tab", () => {
+    const key = buildWorkspaceTabPersistenceKey({ serverId: SERVER_ID, workspaceId: WORKSPACE_ID });
+    expect(key).toBeTruthy();
+    const workspaceKey = key as string;
+
+    const tabId = useWorkspaceTabsStore.getState().ensureTab({
+      serverId: SERVER_ID,
+      workspaceId: WORKSPACE_ID,
+      target: { kind: "agent", agentId: "agent-1" },
+    });
+    if (!tabId) {
+      throw new Error("Expected tab id");
+    }
+    expect(tabId).toBe("agent_agent-1");
+
+    useWorkspaceTabsStore.getState().retargetTab({
+      serverId: SERVER_ID,
+      workspaceId: WORKSPACE_ID,
+      tabId,
+      target: {
+        kind: "draft",
+        draftId: "draft-replacement",
+        setup: {
+          provider: "mock",
+          cwd: "/repo/worktree",
+          modeId: "load-test",
+          model: "ten-second-stream",
+          thinkingOptionId: null,
+          featureValues: { effort: "high" },
+        },
+      },
+    });
+
+    expect(useWorkspaceTabsStore.getState().uiTabsByWorkspace[workspaceKey]?.[0]?.target).toEqual({
+      kind: "draft",
+      draftId: "draft-replacement",
+      setup: {
+        provider: "mock",
+        cwd: "/repo/worktree",
+        modeId: "load-test",
+        model: "ten-second-stream",
+        thinkingOptionId: null,
+        featureValues: { effort: "high" },
+      },
+    });
+  });
+
+  it("updates an existing draft tab when the setup changes", () => {
+    const key = buildWorkspaceTabPersistenceKey({ serverId: SERVER_ID, workspaceId: WORKSPACE_ID });
+    expect(key).toBeTruthy();
+    const workspaceKey = key as string;
+
+    const first = useWorkspaceTabsStore.getState().ensureTab({
+      serverId: SERVER_ID,
+      workspaceId: WORKSPACE_ID,
+      target: { kind: "draft", draftId: "draft-1" },
+    });
+    const second = useWorkspaceTabsStore.getState().ensureTab({
+      serverId: SERVER_ID,
+      workspaceId: WORKSPACE_ID,
+      target: {
+        kind: "draft",
+        draftId: "draft-1",
+        setup: {
+          provider: "mock",
+          cwd: "/repo/worktree",
+          modeId: "load-test",
+          model: "ten-second-stream",
+          thinkingOptionId: null,
+          featureValues: {},
+        },
+      },
+    });
+
+    expect(second).toBe(first);
+    expect(useWorkspaceTabsStore.getState().uiTabsByWorkspace[workspaceKey]).toHaveLength(1);
+    expect(useWorkspaceTabsStore.getState().uiTabsByWorkspace[workspaceKey]?.[0]?.target).toEqual({
+      kind: "draft",
+      draftId: "draft-1",
+      setup: {
+        provider: "mock",
+        cwd: "/repo/worktree",
+        modeId: "load-test",
+        model: "ten-second-stream",
+        thinkingOptionId: null,
+        featureValues: {},
+      },
+    });
+  });
+
   it("retargeting a background draft keeps the currently focused tab focused", () => {
     const draftTabId = "draft_background";
     const key = buildWorkspaceTabPersistenceKey({ serverId: SERVER_ID, workspaceId: WORKSPACE_ID });

--- a/packages/app/src/stores/workspace-tabs-store.ts
+++ b/packages/app/src/stores/workspace-tabs-store.ts
@@ -1,14 +1,25 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { AgentProvider } from "@server/server/agent/agent-sdk-types";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import {
   buildDeterministicWorkspaceTabId,
+  normalizeWorkspaceDraftTabSetup,
   normalizeWorkspaceTabTarget,
   workspaceTabTargetsEqual,
 } from "@/utils/workspace-tab-identity";
 
+export interface WorkspaceDraftTabSetup {
+  provider: AgentProvider;
+  cwd: string;
+  modeId: string | null;
+  model: string | null;
+  thinkingOptionId: string | null;
+  featureValues: Record<string, unknown>;
+}
+
 export type WorkspaceTabTarget =
-  | { kind: "draft"; draftId: string }
+  | { kind: "draft"; draftId: string; setup?: WorkspaceDraftTabSetup }
   | { kind: "agent"; agentId: string }
   | { kind: "terminal"; terminalId: string }
   | { kind: "browser"; browserId: string }
@@ -140,7 +151,12 @@ function extractMigrationRawSources(persistedState: unknown): MigrationRawSource
 function coerceWorkspaceTabTarget(raw: Record<string, unknown>): WorkspaceTabTarget | null {
   const kind = typeof raw.kind === "string" ? raw.kind : null;
   if (kind === "draft" && typeof raw.draftId === "string") {
-    return normalizeWorkspaceTabTarget({ kind: "draft", draftId: raw.draftId });
+    const setup = normalizeWorkspaceDraftTabSetup(raw.setup);
+    return normalizeWorkspaceTabTarget({
+      kind: "draft",
+      draftId: raw.draftId,
+      ...(setup ? { setup } : {}),
+    });
   }
   if (kind === "agent" && typeof raw.agentId === "string") {
     return normalizeWorkspaceTabTarget({ kind: "agent", agentId: raw.agentId });

--- a/packages/app/src/utils/workspace-tab-identity.ts
+++ b/packages/app/src/utils/workspace-tab-identity.ts
@@ -1,5 +1,7 @@
 import type { WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
 
+type WorkspaceDraftTabSetup = NonNullable<Extract<WorkspaceTabTarget, { kind: "draft" }>["setup"]>;
+
 export function normalizeWorkspaceTabTarget(
   value: WorkspaceTabTarget | null | undefined,
 ): WorkspaceTabTarget | null {
@@ -8,7 +10,11 @@ export function normalizeWorkspaceTabTarget(
   }
   if (value.kind === "draft") {
     const draftId = trimNonEmpty(value.draftId);
-    return draftId ? { kind: "draft", draftId } : null;
+    if (!draftId) {
+      return null;
+    }
+    const setup = normalizeWorkspaceDraftTabSetup(value.setup);
+    return setup ? { kind: "draft", draftId, setup } : { kind: "draft", draftId };
   }
   if (value.kind === "agent") {
     const agentId = trimNonEmpty(value.agentId);
@@ -33,6 +39,30 @@ export function normalizeWorkspaceTabTarget(
   return null;
 }
 
+export function normalizeWorkspaceDraftTabSetup(
+  value: unknown,
+): WorkspaceDraftTabSetup | undefined {
+  const record = isPlainRecord(value) ? value : null;
+  if (!record) {
+    return undefined;
+  }
+  const provider = trimNonEmpty(typeof record.provider === "string" ? record.provider : null);
+  const cwd = trimNonEmpty(typeof record.cwd === "string" ? record.cwd : null);
+  if (!provider || !cwd) {
+    return undefined;
+  }
+  return {
+    provider,
+    cwd,
+    modeId: trimOptionalString(typeof record.modeId === "string" ? record.modeId : null),
+    model: trimOptionalString(typeof record.model === "string" ? record.model : null),
+    thinkingOptionId: trimOptionalString(
+      typeof record.thinkingOptionId === "string" ? record.thinkingOptionId : null,
+    ),
+    featureValues: isPlainRecord(record.featureValues) ? { ...record.featureValues } : {},
+  };
+}
+
 export function workspaceTabTargetsEqual(
   left: WorkspaceTabTarget,
   right: WorkspaceTabTarget,
@@ -41,7 +71,7 @@ export function workspaceTabTargetsEqual(
     return false;
   }
   if (left.kind === "draft" && right.kind === "draft") {
-    return left.draftId === right.draftId;
+    return left.draftId === right.draftId && workspaceDraftTabSetupsEqual(left.setup, right.setup);
   }
   if (left.kind === "agent" && right.kind === "agent") {
     return left.agentId === right.agentId;
@@ -59,6 +89,39 @@ export function workspaceTabTargetsEqual(
     return left.workspaceId === right.workspaceId;
   }
   return false;
+}
+
+function workspaceDraftTabSetupsEqual(
+  left: WorkspaceDraftTabSetup | undefined,
+  right: WorkspaceDraftTabSetup | undefined,
+): boolean {
+  if (!left || !right) {
+    return left === right;
+  }
+  return (
+    left.provider === right.provider &&
+    left.cwd === right.cwd &&
+    left.modeId === right.modeId &&
+    left.model === right.model &&
+    left.thinkingOptionId === right.thinkingOptionId &&
+    recordsShallowEqual(left.featureValues, right.featureValues)
+  );
+}
+
+function recordsShallowEqual(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  if (leftKeys.length !== Object.keys(right).length) {
+    return false;
+  }
+  for (const key of leftKeys) {
+    if (!Object.hasOwn(right, key) || !Object.is(left[key], right[key])) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function buildDeterministicWorkspaceTabId(target: WorkspaceTabTarget): string {
@@ -86,4 +149,12 @@ function trimNonEmpty(value: string | null | undefined): string | null {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function trimOptionalString(value: string | null | undefined): string | null {
+  return value == null ? null : trimNonEmpty(value);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds client-side slash commands to the active agent composer. `/quit`, `/exit`, and `/q` archive the current agent; `/clear` and `/new` archive it and replace the tab with a fresh draft that preserves the prior provider, cwd, model, mode, thinking option, and feature values.

Client commands are declared in one command table, including whether they execute immediately. Selecting an immediate client command from autocomplete runs it on Enter, while provider slash commands continue to insert into the composer instead of executing as client actions.

The workspace tab cleanup now uses the existing layout store behavior so archived agents are unpinned/hidden/closed or retargeted cleanly, including pinned tabs opened from workspace URLs.

### How did you verify it

- `npx vitest run packages/app/src/client-slash-commands/index.test.ts --bail=1`
- `npx vitest run packages/app/src/stores/workspace-layout-store.test.ts --bail=1`
- `npm run test:e2e --workspace=@getpaseo/app -- client-slash-commands.spec.ts` (`3 passed`)
- `npm run typecheck`
- `npm run format`
- `npm run lint`
- CI for PR #1034 is fully green: app tests, CLI shards, desktop Linux/Windows, format, lint, Playwright, relay tests, server Linux/Windows, and typecheck.

Risk surface: this touches the shared Expo composer/autocomplete path and workspace tab state. Web/Electron behavior is covered by Playwright and desktop CI; a quick native composer smoke on iOS/Android would still be useful before merging because those platforms do not run the same browser E2E path.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense