### PR TITLE
Harden default host allowlist

### DIFF
--- a/packages/server/src/server/hostnames.test.ts
+++ b/packages/server/src/server/hostnames.test.ts
@@ -11,9 +11,16 @@ describe("hostnames (vite-style)", () => {
     expect(isHostnameAllowed("foo.localhost:6767", undefined)).toBe(true);
   });
 
-  it("allows IP addresses by default", () => {
+  it("allows loopback IP addresses by default", () => {
     expect(isHostnameAllowed("127.0.0.1:6767", undefined)).toBe(true);
+    expect(isHostnameAllowed("127.42.0.1:6767", undefined)).toBe(true);
     expect(isHostnameAllowed("[::1]:6767", undefined)).toBe(true);
+  });
+
+  it("rejects non-loopback IP addresses by default", () => {
+    expect(isHostnameAllowed("192.168.1.20:6767", undefined)).toBe(false);
+    expect(isHostnameAllowed("10.0.0.2:6767", undefined)).toBe(false);
+    expect(isHostnameAllowed("[2001:db8::1]:6767", undefined)).toBe(false);
   });
 
   it("rejects non-default hosts when no allowlist is provided", () => {
@@ -30,6 +37,10 @@ describe("hostnames (vite-style)", () => {
     expect(isHostnameAllowed("foo.example.com:6767", hostnames)).toBe(true);
     expect(isHostnameAllowed("foo.bar.example.com:6767", hostnames)).toBe(true);
     expect(isHostnameAllowed("notexample.com:6767", hostnames)).toBe(false);
+  });
+
+  it("allows explicitly configured IP addresses", () => {
+    expect(isHostnameAllowed("192.168.1.20:6767", ["192.168.1.20"])).toBe(true);
   });
 
   it("merges arrays (append + de-dupe) and short-circuits on true", () => {

--- a/packages/server/src/server/hostnames.ts
+++ b/packages/server/src/server/hostnames.ts
@@ -1,4 +1,4 @@
-import net from "node:net";
+import { isLoopbackHost } from "./loopback-host.js";
 
 export type HostnamesConfig = true | string[] | undefined;
 
@@ -39,11 +39,8 @@ function matchesHostnamePattern(hostname: string, pattern: string): boolean {
 }
 
 function isDefaultAllowedHostname(hostname: string): boolean {
-  // Vite-style defaults: localhost, *.localhost, and all IP addresses.
-  if (hostname === "localhost") return true;
-  if (hostname.endsWith(".localhost")) return true;
-  if (net.isIP(hostname) !== 0) return true;
-  return false;
+  // Vite-style localhost defaults, hardened to loopback-only IP literals.
+  return isLoopbackHost(hostname);
 }
 
 /**
@@ -51,7 +48,7 @@ function isDefaultAllowedHostname(hostname: string): boolean {
  *
  * Semantics:
  * - `hostnames === true` => allow any host.
- * - `hostnames === []` or `undefined` => allow localhost, *.localhost, and all IPs.
+ * - `hostnames === []` or `undefined` => allow localhost, *.localhost, and loopback IPs.
  * - `hostnames === ['.example.com', 'myhost']` => allow those *in addition* to defaults.
  */
 export function isHostnameAllowed(

--- a/packages/server/src/server/loopback-host.ts
+++ b/packages/server/src/server/loopback-host.ts
@@ -1,0 +1,28 @@
+import net from "node:net";
+
+const LOOPBACK_IP_HOSTS = new net.BlockList();
+LOOPBACK_IP_HOSTS.addSubnet("127.0.0.0", 8, "ipv4");
+LOOPBACK_IP_HOSTS.addAddress("::1", "ipv6");
+
+function normalizeHost(host: string): string {
+  const trimmed = host.trim().toLowerCase();
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function isLoopbackHost(host: string): boolean {
+  const normalizedHost = normalizeHost(host);
+  if (normalizedHost === "localhost") return true;
+  if (normalizedHost.endsWith(".localhost")) return true;
+
+  const ipVersion = net.isIP(normalizedHost);
+  if (ipVersion === 4) {
+    return LOOPBACK_IP_HOSTS.check(normalizedHost, "ipv4");
+  }
+  if (ipVersion === 6) {
+    return LOOPBACK_IP_HOSTS.check(normalizedHost, "ipv6");
+  }
+  return false;
+}

--- a/packages/server/src/server/workspace-service-env.test.ts
+++ b/packages/server/src/server/workspace-service-env.test.ts
@@ -37,6 +37,28 @@ describe("buildWorkspaceServiceEnv", () => {
         peers: [{ scriptName: "daemon", port: 5173 }],
       }).HOST,
     ).toBe("127.0.0.1");
+
+    expect(
+      buildWorkspaceServiceEnv({
+        scriptName: "daemon",
+        projectSlug: "paseo",
+        branchName: "main",
+        daemonPort: 6767,
+        daemonListenHost: "127.42.0.1",
+        peers: [{ scriptName: "daemon", port: 5173 }],
+      }).HOST,
+    ).toBe("127.0.0.1");
+
+    expect(
+      buildWorkspaceServiceEnv({
+        scriptName: "daemon",
+        projectSlug: "paseo",
+        branchName: "main",
+        daemonPort: 6767,
+        daemonListenHost: "[::1]",
+        peers: [{ scriptName: "daemon", port: 5173 }],
+      }).HOST,
+    ).toBe("127.0.0.1");
   });
 
   it("uses network host binding when daemon listen host is non-loopback", () => {

--- a/packages/server/src/server/workspace-service-env.ts
+++ b/packages/server/src/server/workspace-service-env.ts
@@ -1,4 +1,5 @@
 import { buildScriptHostname } from "../utils/script-hostname.js";
+import { isLoopbackHost } from "./loopback-host.js";
 
 export interface WorkspaceServicePeer {
   scriptName: string;
@@ -64,7 +65,7 @@ export function buildWorkspaceServiceEnv(
 }
 
 export function resolveServiceBindHost(daemonListenHost: string | null | undefined): string {
-  return isLoopbackListenHost(daemonListenHost) ? "127.0.0.1" : "0.0.0.0";
+  return !daemonListenHost || isLoopbackHost(daemonListenHost) ? "127.0.0.1" : "0.0.0.0";
 }
 
 interface BuildServiceProxyUrlOptions {
@@ -81,20 +82,6 @@ function buildServiceProxyUrl(options: BuildServiceProxyUrlOptions): string {
     scriptName: options.scriptName,
   });
   return `http://${hostname}:${options.daemonPort}`;
-}
-
-function isLoopbackListenHost(host: string | null | undefined): boolean {
-  if (!host) {
-    return true;
-  }
-
-  const normalizedHost = host.trim().toLowerCase();
-  return (
-    normalizedHost === "localhost" ||
-    normalizedHost === "127.0.0.1" ||
-    normalizedHost === "::1" ||
-    normalizedHost === "[::1]"
-  );
 }
 
 export function assertNoServiceEnvNameCollisions(scriptNames: readonly string[]): void {


### PR DESCRIPTION
## Summary
- keep default Host header allowlist to localhost, .localhost, and loopback IP literals
- require explicit hostnames opt-in for LAN or public IP literals
- reuse a shared server loopback-host helper for Host validation and workspace service binding
- cover loopback, rejected non-loopback, explicit IP allowlist, and service binding cases

## Tests
- npm run test:unit --workspace=@getpaseo/server -- src/server/hostnames.test.ts src/server/workspace-service-env.test.ts --bail=1
- npm run format:check:files -- packages/server/src/server/hostnames.ts packages/server/src/server/hostnames.test.ts packages/server/src/server/loopback-host.ts packages/server/src/server/workspace-service-env.ts packages/server/src/server/workspace-service-env.test.ts
- npm run lint -- packages/server/src/server/hostnames.ts packages/server/src/server/hostnames.test.ts packages/server/src/server/loopback-host.ts packages/server/src/server/workspace-service-env.ts packages/server/src/server/workspace-service-env.test.ts
- npm run typecheck --workspace=@getpaseo/server