### PR TITLE
nix: include home-manager profile paths when inheriting user PATH

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -135,8 +135,9 @@ in
 
         When Paseo runs as a real user (not the default system user), AI agents
         need access to the user's tools (git, ssh, etc.). This adds the user's
-        NixOS profile and system paths so agents can use them without manually
-        setting PATH.
+        NixOS profile, home-manager profile (`~/.nix-profile/bin` and
+        `~/.local/state/nix/profile/bin`), and system paths so agents can use
+        them without manually setting PATH.
 
         Enabled by default when `user` is set to a non-default value.
       '';
@@ -221,17 +222,31 @@ in
         NODE_ENV = "production";
         PASEO_HOME = cfg.dataDir;
         PASEO_LISTEN = "${cfg.listenAddress}:${toString cfg.port}";
-      } // lib.optionalAttrs cfg.inheritUserEnvironment {
-        # mkForce overrides the default PATH from NixOS's systemd module (which
-        # only includes store paths for coreutils/grep/sed/systemd). Our PATH
-        # includes /run/current-system/sw/bin which is a superset of those.
-        PATH = lib.mkForce (lib.concatStringsSep ":" [
-          "/etc/profiles/per-user/${cfg.user}/bin"
-          "/run/current-system/sw/bin"
-          "/run/wrappers/bin"
-          "/nix/var/nix/profiles/default/bin"
-        ]);
-      } // lib.optionalAttrs (cfg.hostnames == true) {
+      } // lib.optionalAttrs cfg.inheritUserEnvironment (
+        let
+          # Match dataDir's convention. We can't read users.users.<name>.home
+          # because the user may be managed outside NixOS.
+          userHome = "/home/${cfg.user}";
+        in {
+          # mkForce overrides the default PATH from NixOS's systemd module (which
+          # only includes store paths for coreutils/grep/sed/systemd). When the
+          # daemon runs as a real user, also include home-manager profile paths
+          # so user-installed CLIs (claude, opencode, codex, ...) are reachable
+          # by agent processes the daemon spawns.
+          PATH = lib.mkForce (lib.concatStringsSep ":" (
+            lib.optionals (cfg.user != "paseo") [
+              "${userHome}/.nix-profile/bin"
+              "${userHome}/.local/state/nix/profile/bin"
+            ]
+            ++ [
+              "/etc/profiles/per-user/${cfg.user}/bin"
+              "/run/current-system/sw/bin"
+              "/run/wrappers/bin"
+              "/nix/var/nix/profiles/default/bin"
+            ]
+          ));
+        }
+      ) // lib.optionalAttrs (cfg.hostnames == true) {
         PASEO_HOSTNAMES = "true";
       } // lib.optionalAttrs (lib.isList cfg.hostnames && cfg.hostnames != [ ]) {
         PASEO_HOSTNAMES = lib.concatStringsSep "," cfg.hostnames;


### PR DESCRIPTION
## Summary

When `services.paseo.inheritUserEnvironment` is enabled (the default for non-default users), the systemd unit's PATH is overridden to include the user's NixOS profile and system paths — but **not** the home-manager profile (`~/.nix-profile/bin` and `~/.local/state/nix/profile/bin`). On NixOS, that's where most users actually install per-user CLIs like `claude`, `opencode`, and `codex` via home-manager.

Result: the daemon throws `Provider 'claude' is not available. Please ensure the CLI is installed.` even when the user has the CLI installed and reachable from their shell. The option's docstring already promises "the user's tools (git, ssh, etc.)" — this restores that promise for the common home-manager case.

## What changed

`nix/module.nix` — prepend `${userHome}/.nix-profile/bin` and `${userHome}/.local/state/nix/profile/bin` to the inherited PATH when `cfg.user != "paseo"`. `userHome` is derived as `/home/${cfg.user}` for consistency with the `dataDir` default (we can't read `users.users.<name>.home` because the user may be managed outside NixOS, e.g. by a separate identity module). Option doc updated to mention the home-manager paths.

No change for the default `paseo` system user — only the `inheritUserEnvironment` branch is touched.

## Test plan

- [x] `nix-instantiate --parse nix/module.nix` — syntax OK
- [x] `nix eval .#nixosConfigurations.<host>.config.systemd.services.paseo.environment.PATH` against a real consumer flake shows the home-manager paths prepended
- [x] After `nixos-rebuild switch`, `systemctl show paseo -p Environment` reports the new PATH and the daemon can spawn agent CLIs installed via home-manager (verified against `claude` and `opencode`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)