### PR TITLE
fix(cli): mention remote daemon host on ls connect failure

### DIFF
--- a/packages/cli/src/commands/agent/ls.ts
+++ b/packages/cli/src/commands/agent/ls.ts
@@ -178,7 +178,8 @@ export async function runLsCommand(
     const error: CommandError = {
       code: "DAEMON_NOT_RUNNING",
       message: `Cannot connect to daemon at ${host}: ${message}`,
-      details: "Start the daemon with: paseo daemon start",
+      details:
+        "Start the daemon with: paseo daemon start\nFor a remote daemon, pass --host <host:port> or set PASEO_HOST.",
     };
     throw error;
   }

--- a/packages/cli/tests/04-agent-ls.test.ts
+++ b/packages/cli/tests/04-agent-ls.test.ts
@@ -70,6 +70,8 @@ try {
       output.toLowerCase().includes("connect") ||
       output.toLowerCase().includes("cannot");
     assert(hasError, "error message should mention connection issue");
+    assert(output.includes("--host <host:port>"), "error message should mention --host");
+    assert(output.includes("PASEO_HOST"), "error message should mention PASEO_HOST");
     console.log("✓ paseo ls handles daemon not running\n");
   }
 


### PR DESCRIPTION
## Summary
- Add a remote-daemon hint to the `paseo ls` daemon connection error.
- Cover the human-readable error path so it mentions both `--host <host:port>` and `PASEO_HOST`.

Addresses #961.

## Testing
- `npm run build:daemon`
- `npx tsx packages/cli/tests/04-agent-ls.test.ts`
- `npm run lint -- packages/cli/src/commands/agent/ls.ts packages/cli/tests/04-agent-ls.test.ts`
- `npm run typecheck:daemon`
- pre-commit hook: format, lint, typecheck