### PR TITLE
Fix mobile web gestures, DnD activation, iOS zoom, and Enter behavior

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -375,6 +375,8 @@ function QueryProvider({ children }: { children: ReactNode }) {
 
 const rowStyle = { flex: 1, flexDirection: "row" } as const;
 const flexStyle = { flex: 1 } as const;
+const MOBILE_WEB_EDGE_SWIPE_WIDTH = 32;
+const MOBILE_WEB_GESTURE_TOUCH_ACTION = isWeb ? "auto" : "pan-y";
 
 interface AppContainerProps {
   children: ReactNode;
@@ -498,6 +500,7 @@ function MobileGestureWrapper({
     openGestureRef,
   } = useSidebarAnimation();
   const touchStartX = useSharedValue(0);
+  const touchStartY = useSharedValue(0);
   const openGestureEnabled = chromeEnabled && mobileView === "agent";
 
   const handleGestureOpen = useCallback(() => {
@@ -516,6 +519,7 @@ function MobileGestureWrapper({
           const touch = event.changedTouches[0];
           if (touch) {
             touchStartX.value = touch.absoluteX;
+            touchStartY.value = touch.absoluteY;
           }
         })
         .onTouchesMove((event, stateManager) => {
@@ -523,13 +527,31 @@ function MobileGestureWrapper({
           if (!touch || event.numberOfTouches !== 1) return;
 
           const deltaX = touch.absoluteX - touchStartX.value;
+          const deltaY = touch.absoluteY - touchStartY.value;
+          const absDeltaX = Math.abs(deltaX);
+          const absDeltaY = Math.abs(deltaY);
 
           if (horizontalScroll?.isAnyScrolledRight.value) {
             stateManager.fail();
             return;
           }
 
-          if (deltaX > 15) {
+          if (isWeb && touchStartX.value > MOBILE_WEB_EDGE_SWIPE_WIDTH) {
+            stateManager.fail();
+            return;
+          }
+
+          if (deltaX <= -10) {
+            stateManager.fail();
+            return;
+          }
+
+          if (absDeltaY > 10 && absDeltaY > absDeltaX) {
+            stateManager.fail();
+            return;
+          }
+
+          if (deltaX > 15 && absDeltaX > absDeltaY) {
             stateManager.activate();
           }
         })
@@ -571,11 +593,12 @@ function MobileGestureWrapper({
       openGestureRef,
       horizontalScroll?.isAnyScrolledRight,
       touchStartX,
+      touchStartY,
     ],
   );
 
   return (
-    <GestureDetector gesture={openGesture} touchAction="pan-y">
+    <GestureDetector gesture={openGesture} touchAction={MOBILE_WEB_GESTURE_TOUCH_ACTION}>
       {children}
     </GestureDetector>
   );

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -56,6 +56,7 @@ import { useActiveWorktreeNewAction } from "@/hooks/use-active-worktree-new-acti
 import { useFaviconStatus } from "@/hooks/use-favicon-status";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { useLatchedBoolean } from "@/hooks/use-latched-boolean";
+import { useCompactWebViewportZoomLock } from "@/hooks/use-compact-web-viewport-zoom-lock";
 import { useOpenProject } from "@/hooks/use-open-project";
 import { useAppSettings } from "@/hooks/use-settings";
 import { useStableEvent } from "@/hooks/use-stable-event";
@@ -408,6 +409,7 @@ function AppContainer({
   }, [settings.theme, updateSettings]);
 
   const isCompactLayout = useIsCompactFormFactor();
+  useCompactWebViewportZoomLock(isCompactLayout);
   const chromeEnabled = chromeEnabledOverride ?? daemons.length > 0;
   const pathname = usePathname();
   const activeServerId = useMemo(

--- a/packages/app/src/components/draggable-list.web.test.tsx
+++ b/packages/app/src/components/draggable-list.web.test.tsx
@@ -13,6 +13,9 @@ interface DndContextProps {
 }
 
 let latestDndContextProps: DndContextProps | null = null;
+const dndKitMocks = vi.hoisted(() => ({
+  useSensor: vi.fn(() => ({})),
+}));
 
 vi.mock("@dnd-kit/core", () => ({
   DndContext: ({ children, ...props }: React.PropsWithChildren<DndContextProps>) => {
@@ -22,7 +25,7 @@ vi.mock("@dnd-kit/core", () => ({
   closestCenter: vi.fn(),
   KeyboardSensor: vi.fn(),
   PointerSensor: vi.fn(),
-  useSensor: vi.fn(() => ({})),
+  useSensor: dndKitMocks.useSensor,
   useSensors: vi.fn(() => []),
 }));
 
@@ -104,7 +107,7 @@ function renderItem({ item, isActive }: { item: string; isActive: boolean }) {
   );
 }
 
-function renderList(): void {
+function renderList({ useDragHandle = false }: { useDragHandle?: boolean } = {}): void {
   act(() => {
     root?.render(
       <DraggableList
@@ -113,6 +116,7 @@ function renderList(): void {
         onDragEnd={vi.fn()}
         renderItem={renderItem}
         scrollEnabled={false}
+        useDragHandle={useDragHandle}
       />,
     );
   });
@@ -125,6 +129,28 @@ function getItemActiveState(item: string): string | null {
 }
 
 describe("DraggableList web", () => {
+  it("uses distance activation for default draggable rows", () => {
+    renderList();
+
+    expect(dndKitMocks.useSensor).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        activationConstraint: { distance: 6 },
+      }),
+    );
+  });
+
+  it("requires a held pointer before activating handle-based drags", () => {
+    renderList({ useDragHandle: true });
+
+    expect(dndKitMocks.useSensor).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        activationConstraint: { delay: 250, tolerance: 8 },
+      }),
+    );
+  });
+
   it("clears active drag state when a drag is cancelled", () => {
     renderList();
 

--- a/packages/app/src/components/draggable-list.web.tsx
+++ b/packages/app/src/components/draggable-list.web.tsx
@@ -30,6 +30,8 @@ const restrictToVerticalAxis: Modifier = ({ transform }) => ({
 });
 
 const DND_MODIFIERS = [restrictToVerticalAxis];
+const DEFAULT_POINTER_ACTIVATION_CONSTRAINT = { distance: 6 };
+const HANDLE_POINTER_ACTIVATION_CONSTRAINT = { delay: 250, tolerance: 8 };
 
 interface SortableItemProps<T> {
   id: string;
@@ -89,12 +91,6 @@ function SortableItem<T>({
     }),
     [combinedTransform, transition, isDragging],
   );
-  const {
-    role: _dragRole,
-    tabIndex: _dragTabIndex,
-    "aria-roledescription": _dragRoleDescription,
-    ...dragHandleAttributes
-  } = attributes as unknown as Record<string, unknown>;
 
   const info: DraggableRenderItemInfo<T> = {
     item,
@@ -103,7 +99,7 @@ function SortableItem<T>({
     isActive: activeId === id,
     dragHandleProps: useDragHandle
       ? {
-          attributes: dragHandleAttributes,
+          attributes: attributes as unknown as Record<string, unknown>,
           listeners: listeners as unknown as Record<string, unknown>,
           setActivatorNodeRef: setActivatorNodeRef as unknown as (node: unknown) => void,
         }
@@ -149,12 +145,13 @@ export function DraggableList<T>({
   const scrollbar = useWebScrollViewScrollbar(scrollViewRef, {
     enabled: showCustomScrollbar,
   });
+  const pointerActivationConstraint = useDragHandle
+    ? HANDLE_POINTER_ACTIVATION_CONSTRAINT
+    : DEFAULT_POINTER_ACTIVATION_CONSTRAINT;
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 6,
-      },
+      activationConstraint: pointerActivationConstraint,
     }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,

--- a/packages/app/src/components/message-input.tsx
+++ b/packages/app/src/components/message-input.tsx
@@ -53,6 +53,7 @@ import { getShortcutOs } from "@/utils/shortcut-platform";
 import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
 import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
 import { isWeb } from "@/constants/platform";
+import { useIsCompactFormFactor } from "@/constants/layout";
 import { useComposerHeightMirror } from "./composer-height-mirror";
 import { computeCanStartDictation } from "./message-input-state";
 
@@ -365,6 +366,7 @@ function resolveSendTooltipLabel(input: {
 
 interface DesktopKeyPressContext {
   onKeyPressCallback: ((event: { key: string; preventDefault: () => void }) => boolean) | undefined;
+  submitOnEnter: boolean;
   isAgentRunning: boolean;
   onQueue: ((payload: MessagePayload) => void) | undefined;
   isSubmitDisabled: boolean;
@@ -391,6 +393,7 @@ function handleDesktopKeyPressImpl(
   const { shiftKey, metaKey, ctrlKey } = event.nativeEvent;
 
   if (event.nativeEvent.key !== "Enter") return;
+  if (!ctx.submitOnEnter) return;
   if (shiftKey) return;
 
   if ((metaKey || ctrlKey) && ctx.isAgentRunning && ctx.onQueue) {
@@ -1187,6 +1190,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       inputWrapperStyle,
       attachmentSlot,
     } = resolveMessageInputProps(props);
+    const isCompact = useIsCompactFormFactor();
     const buttonIconSize = isWeb ? ICON_SIZE.md : ICON_SIZE.lg;
     const toast = useToast();
     const voice = useVoiceOptional();
@@ -1567,12 +1571,14 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       [onSelectionChangeCallback],
     );
 
-    const shouldHandleDesktopSubmit = isWeb;
+    const shouldHandleWebKeyPress = isWeb;
+    const shouldSubmitOnEnter = isWeb && !isCompact;
 
     function handleDesktopKeyPress(event: WebTextInputKeyPressEvent) {
-      if (!shouldHandleDesktopSubmit) return;
+      if (!shouldHandleWebKeyPress) return;
       handleDesktopKeyPressImpl(event, {
         onKeyPressCallback,
+        submitOnEnter: shouldSubmitOnEnter,
         isAgentRunning,
         onQueue,
         isSubmitDisabled,
@@ -1724,7 +1730,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
               scrollEnabled={isWeb ? inputHeight >= MAX_INPUT_HEIGHT : true}
               onContentSizeChange={handleContentSizeChange}
               editable={!isDictating && !isRealtimeVoiceForCurrentAgent && !disabled}
-              onKeyPress={shouldHandleDesktopSubmit ? handleDesktopKeyPress : undefined}
+              onKeyPress={shouldHandleWebKeyPress ? handleDesktopKeyPress : undefined}
               onSelectionChange={handleSelectionChange}
               autoFocus={isWeb && autoFocus}
             />

--- a/packages/app/src/hooks/use-compact-web-viewport-zoom-lock.ts
+++ b/packages/app/src/hooks/use-compact-web-viewport-zoom-lock.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { isWeb } from "@/constants/platform";
+
+const COMPACT_WEB_VIEWPORT_CONTENT =
+  "width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover";
+const DEFAULT_WEB_VIEWPORT_CONTENT = "width=device-width, initial-scale=1, viewport-fit=cover";
+
+export function useCompactWebViewportZoomLock(isCompactLayout: boolean) {
+  useEffect(() => {
+    if (!isWeb) {
+      return;
+    }
+
+    const viewportMeta =
+      document.querySelector<HTMLMetaElement>('meta[name="viewport"]') ??
+      document.createElement("meta");
+    const hadViewportMeta = viewportMeta.parentElement !== null;
+    const previousContent = viewportMeta.getAttribute("content");
+
+    if (!hadViewportMeta) {
+      viewportMeta.name = "viewport";
+      document.head.appendChild(viewportMeta);
+    }
+
+    viewportMeta.setAttribute(
+      "content",
+      isCompactLayout ? COMPACT_WEB_VIEWPORT_CONTENT : DEFAULT_WEB_VIEWPORT_CONTENT,
+    );
+
+    return () => {
+      if (!hadViewportMeta) {
+        viewportMeta.remove();
+        return;
+      }
+      if (previousContent !== null) {
+        viewportMeta.setAttribute("content", previousContent);
+      }
+    };
+  }, [isCompactLayout]);
+}

--- a/packages/app/src/hooks/use-explorer-open-gesture.ts
+++ b/packages/app/src/hooks/use-explorer-open-gesture.ts
@@ -3,11 +3,14 @@ import { Gesture } from "react-native-gesture-handler";
 import { Extrapolation, interpolate, runOnJS, useSharedValue } from "react-native-reanimated";
 import { useExplorerSidebarAnimation } from "@/contexts/explorer-sidebar-animation-context";
 import { useSidebarAnimation } from "@/contexts/sidebar-animation-context";
+import { isWeb } from "@/constants/platform";
 
 interface UseExplorerOpenGestureParams {
   enabled: boolean;
   onOpen: () => void;
 }
+
+const MOBILE_WEB_EDGE_SWIPE_WIDTH = 32;
 
 export function useExplorerOpenGesture({ enabled, onOpen }: UseExplorerOpenGestureParams) {
   const {
@@ -55,6 +58,12 @@ export function useExplorerOpenGesture({ enabled, onOpen }: UseExplorerOpenGestu
           const deltaY = touch.absoluteY - touchStartY.value;
           const absDeltaX = Math.abs(deltaX);
           const absDeltaY = Math.abs(deltaY);
+
+          // Browser back-swipe owns most of the viewport; keep this gesture on the right edge.
+          if (isWeb && touchStartX.value < windowWidth - MOBILE_WEB_EDGE_SWIPE_WIDTH) {
+            stateManager.fail();
+            return;
+          }
 
           // Fail quickly on rightward or clearly vertical intent.
           if (deltaX >= 10) {

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -164,6 +164,7 @@ const EMPTY_UI_TABS: WorkspaceTab[] = [];
 const EMPTY_WORKSPACE_SCRIPTS: WorkspaceDescriptor["scripts"] = [];
 const EMPTY_PINNED_AGENT_IDS = new Set<string>();
 const EMPTY_SET = new Set<string>();
+const COMPACT_WEB_GESTURE_TOUCH_ACTION = isWeb ? "auto" : "pan-y";
 
 const ThemedActivityIndicator = withUnistyles(ActivityIndicator);
 const ThemedEllipsis = withUnistyles(Ellipsis);
@@ -3213,7 +3214,10 @@ function WorkspaceScreenContent({
 
               <View style={styles.centerContent}>
                 {isMobile ? (
-                  <GestureDetector gesture={explorerOpenGesture} touchAction="pan-y">
+                  <GestureDetector
+                    gesture={explorerOpenGesture}
+                    touchAction={COMPACT_WEB_GESTURE_TOUCH_ACTION}
+                  >
                     <View style={styles.content}>{content}</View>
                   </GestureDetector>
                 ) : (


### PR DESCRIPTION
Extracts the bug fixes from #905. Skips the composer/status-bar product reshape, which needs a separate decision.

All commits authored by @nikuscs.

## What changes for users

- Mobile web sidebar swipe triggers only from the left edge (32px) — fixes text selection being hijacked on iOS.
- Explorer swipe restricted to the right edge for the same reason.
- DnD on the draggable sidebar list requires a 250ms long-press — sideways finger slides no longer trigger accidental drags.
- iOS Safari no longer auto-zooms into focused composer inputs on compact web.
- Enter on the composer in compact web inserts a newline; tap the Send button to submit.
- Workspace content can scroll vertically inside the explorer gesture region.

## What's excluded from #905

The composer right-side reshape (kebab overflow, voice toggle moved into a preferences sheet, model selector reduced to an icon-only trigger) and the new `composer-mobile-controls.spec.ts`. That work reshapes the mobile composer IA and shouldn't ride along with bug fixes.

## Verification

`npm run typecheck`, `npm run lint`, and `npx vitest run src/components/draggable-list.web.test.tsx` all green after each commit.

CI lint + typecheck + unit tests cover the diff. Manual smoke on compact mobile web is the remaining gap before merge — the gesture and zoom behaviors only surface against a real touch device, and there's no Playwright project covering mobile Safari in this repo.

## Risk surface

- All changes gated on `isWeb` and/or `isCompact`. Native iOS/Android, desktop browser, and Electron are untouched (verified in the per-file diff).
- The gates themselves are the right rough proxies but not the most accurate ones — see #1047 for the audit and proposed cleaner gates. This PR doesn't make that worse.

Source: #905 by @nikuscs.