### PR TITLE
feat: support opening workspace files at line and column

### DIFF
--- a/packages/app/src/app/h/[serverId]/workspace/[workspaceId]/index.tsx
+++ b/packages/app/src/app/h/[serverId]/workspace/[workspaceId]/index.tsx
@@ -37,7 +37,12 @@ function getOpenIntentTarget(openIntent: WorkspaceOpenIntent): WorkspaceTabTarge
     return { kind: "terminal", terminalId: openIntent.terminalId };
   }
   if (openIntent.kind === "file") {
-    return { kind: "file", path: openIntent.path };
+    return {
+      kind: "file",
+      path: openIntent.path,
+      lineStart: openIntent.lineStart,
+      columnStart: openIntent.columnStart,
+    };
   }
   if (openIntent.kind === "setup") {
     return { kind: "setup", workspaceId: openIntent.workspaceId };

--- a/packages/app/src/components/agent-stream-view.tsx
+++ b/packages/app/src/components/agent-stream-view.tsx
@@ -242,7 +242,11 @@ export interface AgentStreamViewProps {
   routeBottomAnchorRequest?: BottomAnchorRouteRequest | null;
   isAuthoritativeHistoryReady?: boolean;
   toast?: ToastApi | null;
-  onOpenWorkspaceFile?: (input: { filePath: string }) => void;
+  onOpenWorkspaceFile?: (input: {
+    filePath: string;
+    lineStart?: number;
+    columnStart?: number;
+  }) => void;
 }
 
 const EMPTY_STREAM_HEAD: StreamItem[] = [];
@@ -304,6 +308,8 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     });
     const openWorkspaceFile = useStableEvent(function openWorkspaceFile(input: {
       filePath: string;
+      lineStart?: number;
+      columnStart?: number;
     }) {
       onOpenWorkspaceFile?.(input);
     });
@@ -335,7 +341,11 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
 
         if (normalized.file) {
           if (onOpenWorkspaceFile) {
-            openWorkspaceFile({ filePath: normalized.file });
+            openWorkspaceFile({
+              filePath: normalized.file,
+              lineStart: target.lineStart,
+              columnStart: target.columnStart,
+            });
             return;
           }
 
@@ -343,7 +353,12 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             navigateToPreparedWorkspaceTab({
               serverId: resolvedServerId,
               workspaceId,
-              target: { kind: "file", path: normalized.file },
+              target: {
+                kind: "file",
+                path: normalized.file,
+                lineStart: target.lineStart,
+                columnStart: target.columnStart,
+              },
             });
           }
           return;

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { FileReadResult } from "@server/client/daemon-client";
 import Markdown, { MarkdownIt } from "react-native-markdown-display";
@@ -38,6 +38,8 @@ interface CodeLineProps {
   gutterWidth: number;
   colorMap: Record<HighlightStyle, string>;
   baseColor: string;
+  isTargetLine: boolean;
+  targetGutterColor: string;
 }
 
 interface FilePreviewBodyProps {
@@ -46,8 +48,13 @@ interface FilePreviewBodyProps {
   showDesktopWebScrollbar: boolean;
   isMobile: boolean;
   filePath: string;
+  lineStart?: number;
+  columnStart?: number;
   imagePreviewUri: string | null;
 }
+
+const CODE_LINE_HEIGHT_MULTIPLIER = 1.45;
+const TARGET_LINE_CONTEXT_LINES = 3;
 
 function trimNonEmpty(value: string | null | undefined): string | null {
   if (typeof value !== "string") {
@@ -105,18 +112,29 @@ const CodeLine = React.memo(function CodeLine({
   gutterWidth,
   colorMap,
   baseColor,
+  isTargetLine,
+  targetGutterColor,
 }: CodeLineProps) {
+  const lineStyle = useMemo(
+    () => [codeLineStyles.line, isTargetLine && codeLineStyles.targetLine],
+    [isTargetLine],
+  );
   const gutterStyle = useMemo(() => [codeLineStyles.gutter, { width: gutterWidth }], [gutterWidth]);
+  const gutterTextColor = isTargetLine ? targetGutterColor : baseColor;
   const gutterTextStyle = useMemo(
-    () => [codeLineStyles.gutterText, { color: baseColor }],
-    [baseColor],
+    () => [
+      codeLineStyles.gutterText,
+      { color: gutterTextColor },
+      isTargetLine && codeLineStyles.targetGutterText,
+    ],
+    [gutterTextColor, isTargetLine],
   );
   const keyedTokens = useMemo(
     () => tokens.map((token, index) => ({ key: `${index}-${token.text}`, token })),
     [tokens],
   );
   return (
-    <View style={codeLineStyles.line}>
+    <View style={lineStyle}>
       <View style={gutterStyle}>
         <Text numberOfLines={1} style={gutterTextStyle}>
           {String(lineNumber)}
@@ -148,6 +166,12 @@ function CodeLineToken({ color, text }: CodeLineTokenProps) {
 const codeLineStyles = StyleSheet.create((theme) => ({
   line: {
     flexDirection: "row",
+    borderLeftWidth: 2,
+    borderLeftColor: "transparent",
+  },
+  targetLine: {
+    backgroundColor: theme.colors.surface2,
+    borderLeftColor: theme.colors.primary,
   },
   gutter: {
     alignItems: "flex-end",
@@ -157,14 +181,17 @@ const codeLineStyles = StyleSheet.create((theme) => ({
   gutterText: {
     fontFamily: Fonts.mono,
     fontSize: theme.fontSize.sm,
-    lineHeight: theme.fontSize.sm * 1.45,
+    lineHeight: theme.fontSize.sm * CODE_LINE_HEIGHT_MULTIPLIER,
     opacity: 0.4,
     userSelect: "none",
+  },
+  targetGutterText: {
+    opacity: 1,
   },
   lineText: {
     fontFamily: Fonts.mono,
     fontSize: theme.fontSize.sm,
-    lineHeight: theme.fontSize.sm * 1.45,
+    lineHeight: theme.fontSize.sm * CODE_LINE_HEIGHT_MULTIPLIER,
     flex: 1,
   },
 }));
@@ -175,6 +202,8 @@ function FilePreviewBody({
   showDesktopWebScrollbar,
   isMobile,
   filePath,
+  lineStart,
+  columnStart: _columnStart,
   imagePreviewUri,
 }: FilePreviewBodyProps) {
   const { theme } = useUnistyles();
@@ -183,7 +212,14 @@ function FilePreviewBody({
   const baseColor = isDark ? "#c9d1d9" : "#24292f";
   const markdownStyles = useMemo(() => createMarkdownStyles(theme), [theme]);
   const markdownParser = useMemo(() => MarkdownIt({ typographer: true, linkify: true }), []);
-  const isMarkdownFile = preview?.kind === "text" && isRenderedMarkdownFile(filePath);
+  const targetLine = useMemo(() => {
+    if (!lineStart || !Number.isFinite(lineStart) || lineStart <= 0) {
+      return null;
+    }
+    return Math.floor(lineStart);
+  }, [lineStart]);
+  const isMarkdownFile =
+    preview?.kind === "text" && !targetLine && isRenderedMarkdownFile(filePath);
 
   const previewScrollRef = useRef<RNScrollView>(null);
   const webScrollbarStyle = useWebScrollbarStyle();
@@ -203,6 +239,30 @@ function FilePreviewBody({
     if (!highlightedLines) return 0;
     return lineNumberGutterWidth(highlightedLines.length, theme.fontSize.sm);
   }, [highlightedLines, theme.fontSize.sm]);
+  const boundedTargetLine = useMemo(() => {
+    if (!targetLine || !highlightedLines?.length) {
+      return null;
+    }
+    return Math.min(targetLine, highlightedLines.length);
+  }, [highlightedLines, targetLine]);
+  const codeLineHeight = theme.fontSize.sm * CODE_LINE_HEIGHT_MULTIPLIER;
+  const previewPadding = theme.spacing[4];
+
+  useEffect(() => {
+    if (!boundedTargetLine || !preview || preview.kind !== "text" || isMarkdownFile) {
+      return;
+    }
+
+    const offsetY = Math.max(
+      0,
+      previewPadding + (boundedTargetLine - 1 - TARGET_LINE_CONTEXT_LINES) * codeLineHeight,
+    );
+    const timer = setTimeout(() => {
+      previewScrollRef.current?.scrollTo({ y: offsetY, animated: false });
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [boundedTargetLine, codeLineHeight, isMarkdownFile, preview, previewPadding]);
 
   const imageSource = useMemo(
     () => (imagePreviewUri ? { uri: imagePreviewUri } : null),
@@ -265,6 +325,8 @@ function FilePreviewBody({
             gutterWidth={gutterWidth}
             colorMap={colorMap}
             baseColor={baseColor}
+            isTargetLine={boundedTargetLine === lineNumber}
+            targetGutterColor={theme.colors.primary}
           />
         ))}
       </View>
@@ -345,10 +407,14 @@ export function FilePane({
   serverId,
   workspaceRoot,
   filePath,
+  lineStart,
+  columnStart,
 }: {
   serverId: string;
   workspaceRoot: string;
   filePath: string;
+  lineStart?: number;
+  columnStart?: number;
 }) {
   const isMobile = useIsCompactFormFactor();
   const showDesktopWebScrollbar = isWeb && !isMobile;
@@ -399,6 +465,8 @@ export function FilePane({
         showDesktopWebScrollbar={showDesktopWebScrollbar}
         isMobile={isMobile}
         filePath={filePath}
+        lineStart={lineStart}
+        columnStart={columnStart}
         imagePreviewUri={imagePreviewUri}
       />
     </View>

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -33,7 +33,7 @@ import {
 import { useArchiveAgent } from "@/hooks/use-archive-agent";
 import { useKeyboardShiftStyle } from "@/hooks/use-keyboard-shift-style";
 import { useStableEvent } from "@/hooks/use-stable-event";
-import { usePaneContext, usePaneFocus } from "@/panels/pane-context";
+import { type OpenWorkspaceFileInput, usePaneContext, usePaneFocus } from "@/panels/pane-context";
 import type { PanelDescriptor, PanelRegistration } from "@/panels/panel-registry";
 import {
   type HostRuntimeConnectionStatus,
@@ -285,8 +285,8 @@ function AgentPanel() {
   const { isInteractive } = usePaneFocus();
   invariant(target.kind === "agent", "AgentPanel requires agent target");
 
-  function openWorkspaceFile(input: { filePath: string }) {
-    openFileInWorkspace(input.filePath);
+  function openWorkspaceFile(input: OpenWorkspaceFileInput) {
+    openFileInWorkspace(input);
   }
 
   const handleOpenWorkspaceFile = useStableEvent(openWorkspaceFile);
@@ -362,7 +362,7 @@ function AgentPanelContent({
   serverId: string;
   agentId: string;
   isPaneFocused: boolean;
-  onOpenWorkspaceFile?: (input: { filePath: string }) => void;
+  onOpenWorkspaceFile?: (input: OpenWorkspaceFileInput) => void;
 }) {
   const resolvedAgentId = agentId.trim() || undefined;
   const resolvedServerId = serverId.trim() || undefined;
@@ -424,7 +424,7 @@ function AgentPanelBody({
   client: NonNullable<ReturnType<typeof useHostRuntimeClient>>;
   isConnected: boolean;
   connectionStatus: HostRuntimeConnectionStatus;
-  onOpenWorkspaceFile?: (input: { filePath: string }) => void;
+  onOpenWorkspaceFile?: (input: OpenWorkspaceFileInput) => void;
 }) {
   const { isArchivingAgent: _isArchivingAgent } = useArchiveAgent();
   const hasSession = useSessionStore((state) => Boolean(state.sessions[serverId]));
@@ -589,7 +589,7 @@ function ChatAgentContent({
   client: NonNullable<ReturnType<typeof useHostRuntimeClient>>;
   isConnected: boolean;
   connectionStatus: HostRuntimeConnectionStatus;
-  onOpenWorkspaceFile?: (input: { filePath: string }) => void;
+  onOpenWorkspaceFile?: (input: OpenWorkspaceFileInput) => void;
 }) {
   const panelToast = useToastHost();
   const { isArchivingAgent } = useArchiveAgent();
@@ -1038,7 +1038,7 @@ function AgentStreamSection({
   routeBottomAnchorRequest: RouteBottomAnchorRequest;
   hasAppliedAuthoritativeHistory: boolean;
   toast: ReturnType<typeof useToastHost>["api"];
-  onOpenWorkspaceFile?: (input: { filePath: string }) => void;
+  onOpenWorkspaceFile?: (input: OpenWorkspaceFileInput) => void;
 }) {
   const streamItemsRaw = useSessionStore((state) =>
     agentId ? state.sessions[serverId]?.agentStreamTail?.get(agentId) : undefined,

--- a/packages/app/src/panels/draft-panel.tsx
+++ b/packages/app/src/panels/draft-panel.tsx
@@ -2,7 +2,7 @@ import { SquarePen } from "lucide-react-native";
 import { useCallback } from "react";
 import invariant from "tiny-invariant";
 import { WorkspaceDraftAgentTab } from "@/screens/workspace/workspace-draft-agent-tab";
-import { usePaneContext, usePaneFocus } from "@/panels/pane-context";
+import { type OpenWorkspaceFileInput, usePaneContext, usePaneFocus } from "@/panels/pane-context";
 import type { PanelRegistration } from "@/panels/panel-registry";
 import { useSessionStore } from "@/stores/session-store";
 import { normalizeAgentSnapshot } from "@/utils/agent-snapshots";
@@ -31,8 +31,8 @@ function DraftPanel() {
   invariant(target.kind === "draft", "DraftPanel requires draft target");
 
   const handleOpenWorkspaceFile = useCallback(
-    ({ filePath }: { filePath: string }) => {
-      openFileInWorkspace(filePath);
+    (input: OpenWorkspaceFileInput) => {
+      openFileInWorkspace(input);
     },
     [openFileInWorkspace],
   );

--- a/packages/app/src/panels/file-panel.tsx
+++ b/packages/app/src/panels/file-panel.tsx
@@ -38,7 +38,15 @@ function FilePanel() {
       </View>
     );
   }
-  return <FilePane serverId={serverId} workspaceRoot={workspaceDirectory} filePath={target.path} />;
+  return (
+    <FilePane
+      serverId={serverId}
+      workspaceRoot={workspaceDirectory}
+      filePath={target.path}
+      lineStart={target.lineStart}
+      columnStart={target.columnStart}
+    />
+  );
 }
 
 export const filePanelRegistration: PanelRegistration<"file"> = {

--- a/packages/app/src/panels/pane-context.tsx
+++ b/packages/app/src/panels/pane-context.tsx
@@ -2,6 +2,12 @@ import React, { createContext, useContext, type ReactNode } from "react";
 import invariant from "tiny-invariant";
 import type { WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
 
+export interface OpenWorkspaceFileInput {
+  filePath: string;
+  lineStart?: number;
+  columnStart?: number;
+}
+
 export interface PaneContextValue {
   serverId: string;
   workspaceId: string;
@@ -10,7 +16,7 @@ export interface PaneContextValue {
   openTab: (target: WorkspaceTabTarget) => void;
   closeCurrentTab: () => void;
   retargetCurrentTab: (target: WorkspaceTabTarget) => void;
-  openFileInWorkspace: (filePath: string) => void;
+  openFileInWorkspace: (input: OpenWorkspaceFileInput) => void;
   openImportSheet: () => void;
 }
 

--- a/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
+++ b/packages/app/src/screens/workspace/workspace-draft-agent-tab.tsx
@@ -7,6 +7,7 @@ import { Composer } from "@/components/composer";
 import { ComposerImportPill } from "@/screens/workspace/composer-import-pill";
 import { FileDropZone } from "@/components/file-drop-zone";
 import { AgentStreamView } from "@/components/agent-stream-view";
+import type { OpenWorkspaceFileInput } from "@/panels/pane-context";
 import { composerWorkspaceAttachment } from "@/attachments/composer-workspace-attachments";
 import type { ImageAttachment } from "@/components/message-input";
 import { useAgentInputDraft } from "@/hooks/use-agent-input-draft";
@@ -278,7 +279,7 @@ interface WorkspaceDraftAgentTabProps {
   draftId: string;
   isPaneFocused: boolean;
   onCreated: (snapshot: AgentSnapshotPayload) => void;
-  onOpenWorkspaceFile: (input: { filePath: string }) => void;
+  onOpenWorkspaceFile: (input: OpenWorkspaceFileInput) => void;
   onOpenImportSheet?: () => void;
 }
 

--- a/packages/app/src/screens/workspace/workspace-pane-content.tsx
+++ b/packages/app/src/screens/workspace/workspace-pane-content.tsx
@@ -5,6 +5,7 @@ import {
   PaneFocusProvider,
   PaneProvider,
   type PaneContextValue,
+  type OpenWorkspaceFileInput,
 } from "@/panels/pane-context";
 import { getPanelRegistration } from "@/panels/panel-registry";
 import { ensurePanelsRegistered } from "@/panels/register-panels";
@@ -23,7 +24,7 @@ export interface BuildWorkspacePaneContentModelInput {
   onOpenTab: (target: WorkspaceTabDescriptor["target"]) => void;
   onCloseCurrentTab: () => void;
   onRetargetCurrentTab: (target: WorkspaceTabDescriptor["target"]) => void;
-  onOpenWorkspaceFile: (filePath: string) => void;
+  onOpenWorkspaceFile: (input: OpenWorkspaceFileInput) => void;
   onOpenImportSheet: () => void;
 }
 

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -61,6 +61,7 @@ import { WorkspaceScriptsButton } from "@/screens/workspace/workspace-scripts-bu
 import { WorkspaceImportSheet } from "@/screens/workspace/workspace-import-sheet";
 import { ExplorerSidebarAnimationProvider } from "@/contexts/explorer-sidebar-animation-context";
 import { useToast } from "@/contexts/toast-context";
+import type { OpenWorkspaceFileInput } from "@/panels/pane-context";
 import { useExplorerOpenGesture } from "@/hooks/use-explorer-open-gesture";
 import { selectIsFileExplorerOpen, usePanelStore } from "@/stores/panel-store";
 import { type ExplorerCheckoutContext } from "@/stores/explorer-checkout-context";
@@ -2028,14 +2029,32 @@ function WorkspaceScreenContent({
   );
 
   const handleOpenFileFromChat = useCallback(
-    ({ filePath }: { filePath: string }) => {
+    ({ filePath, lineStart, columnStart }: OpenWorkspaceFileInput) => {
       const normalizedFilePath = filePath.trim();
       if (!normalizedFilePath) {
         return;
       }
-      handleOpenFileFromExplorer(normalizedFilePath);
+      if (isMobile) {
+        showMobileAgent();
+      }
+      if (!persistenceKey) {
+        return;
+      }
+      const target = normalizeWorkspaceTabTarget({
+        kind: "file",
+        path: normalizedFilePath,
+        lineStart,
+        columnStart,
+      });
+      if (!target || target.kind !== "file") {
+        return;
+      }
+      const tabId = openWorkspaceTabFocused(persistenceKey, target);
+      if (tabId) {
+        navigateToTabId(tabId);
+      }
     },
-    [handleOpenFileFromExplorer],
+    [isMobile, navigateToTabId, openWorkspaceTabFocused, persistenceKey, showMobileAgent],
   );
 
   const [_hoveredTabKey, setHoveredTabKey] = useState<string | null>(null);
@@ -2706,11 +2725,11 @@ function WorkspaceScreenContent({
           }
           retargetWorkspaceTab(persistenceKey, input.tab.tabId, target);
         },
-        onOpenWorkspaceFile: (filePath) => {
+        onOpenWorkspaceFile: (fileInput) => {
           if (input.focusPaneBeforeOpen && input.paneId && persistenceKey) {
             focusWorkspacePane(persistenceKey, input.paneId);
           }
-          handleOpenFileFromChat({ filePath });
+          handleOpenFileFromChat(fileInput);
         },
         onOpenImportSheet: openImportSheet,
       }),

--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -129,6 +129,38 @@ interface ConvertDraftToAgentInLayoutResult {
   tabId: string;
 }
 
+function shouldReplaceExistingTabTarget(
+  currentTarget: WorkspaceTabTarget,
+  nextTarget: WorkspaceTabTarget,
+): boolean {
+  if (currentTarget.kind !== "file" || nextTarget.kind !== "file") {
+    return false;
+  }
+  if (currentTarget.path !== nextTarget.path) {
+    return false;
+  }
+  return (
+    (currentTarget.lineStart ?? null) !== (nextTarget.lineStart ?? null) ||
+    (currentTarget.columnStart ?? null) !== (nextTarget.columnStart ?? null)
+  );
+}
+
+function replaceExistingTabTarget(
+  layout: WorkspaceLayout,
+  tabId: string,
+  target: WorkspaceTabTarget,
+): WorkspaceLayout {
+  const internalLayout = asInternalLayout(layout);
+  return {
+    root: replaceTabInTree(internalLayout.root, {
+      tabId,
+      nextTabId: tabId,
+      target,
+    }),
+    focusedPaneId: internalLayout.focusedPaneId,
+  };
+}
+
 interface ReorderFocusedPaneTabsInLayoutInput {
   layout: WorkspaceLayout;
   tabIds: string[];
@@ -1057,13 +1089,17 @@ export function openTabInLayoutFocused(input: OpenTabInLayoutInput): OpenTabInLa
     workspaceTabTargetsEqual(tab.target, input.target),
   );
   if (existingTab) {
+    const focusedLayout =
+      focusTabInLayout({
+        layout,
+        tabId: existingTab.tabId,
+      }) ?? input.layout;
+    const nextLayout = shouldReplaceExistingTabTarget(existingTab.target, input.target)
+      ? replaceExistingTabTarget(focusedLayout, existingTab.tabId, input.target)
+      : focusedLayout;
     return {
       tabId: existingTab.tabId,
-      layout:
-        focusTabInLayout({
-          layout,
-          tabId: existingTab.tabId,
-        }) ?? input.layout,
+      layout: nextLayout,
     };
   }
 
@@ -1076,7 +1112,12 @@ export function openTabInLayoutBackground(input: OpenTabInLayoutInput): OpenTabI
     workspaceTabTargetsEqual(tab.target, input.target),
   );
   if (existingTab) {
-    return { tabId: existingTab.tabId, layout: input.layout };
+    return {
+      tabId: existingTab.tabId,
+      layout: shouldReplaceExistingTabTarget(existingTab.target, input.target)
+        ? replaceExistingTabTarget(input.layout, existingTab.tabId, input.target)
+        : input.layout,
+    };
   }
 
   return insertNewTabIntoFocusedPane({ ...input, focus: false });

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -353,6 +353,34 @@ describe("workspace-layout-store actions", () => {
     ]);
   });
 
+  it("updates the line target when reopening an existing file tab", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    const firstTabId = store.openTabFocused(workspaceKey, {
+      kind: "file",
+      path: "/repo/worktree/a.ts",
+      lineStart: 10,
+    });
+    const secondTabId = store.openTabFocused(workspaceKey, {
+      kind: "file",
+      path: "/repo/worktree/a.ts",
+      lineStart: 42,
+      columnStart: 7,
+    });
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey]!;
+    const tabs = collectAllTabs(layout.root);
+
+    expect(secondTabId).toBe(firstTabId);
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]?.target).toEqual({
+      kind: "file",
+      path: "/repo/worktree/a.ts",
+      lineStart: 42,
+      columnStart: 7,
+    });
+  });
+
   it("openTabInBackground inserts a tab without stealing focus", () => {
     const workspaceKey = createWorkspaceKey();
     const store = workspaceLayoutStore.getState();

--- a/packages/app/src/stores/workspace-tabs-store.ts
+++ b/packages/app/src/stores/workspace-tabs-store.ts
@@ -12,7 +12,7 @@ export type WorkspaceTabTarget =
   | { kind: "agent"; agentId: string }
   | { kind: "terminal"; terminalId: string }
   | { kind: "browser"; browserId: string }
-  | { kind: "file"; path: string }
+  | { kind: "file"; path: string; lineStart?: number; columnStart?: number }
   | { kind: "setup"; workspaceId: string };
 
 export interface WorkspaceTab {
@@ -152,7 +152,12 @@ function coerceWorkspaceTabTarget(raw: Record<string, unknown>): WorkspaceTabTar
     return normalizeWorkspaceTabTarget({ kind: "browser", browserId: raw.browserId });
   }
   if (kind === "file" && typeof raw.path === "string") {
-    return normalizeWorkspaceTabTarget({ kind: "file", path: raw.path });
+    return normalizeWorkspaceTabTarget({
+      kind: "file",
+      path: raw.path,
+      lineStart: typeof raw.lineStart === "number" ? raw.lineStart : undefined,
+      columnStart: typeof raw.columnStart === "number" ? raw.columnStart : undefined,
+    });
   }
   if (kind === "setup" && typeof raw.workspaceId === "string") {
     return normalizeWorkspaceTabTarget({ kind: "setup", workspaceId: raw.workspaceId });

--- a/packages/app/src/utils/host-routes.test.ts
+++ b/packages/app/src/utils/host-routes.test.ts
@@ -101,6 +101,12 @@ describe("workspace route parsing", () => {
       kind: "file",
       path: "src/index.ts",
     });
+    expect(parseWorkspaceOpenIntent("file:c3JjL2luZGV4LnRz:12:4")).toEqual({
+      kind: "file",
+      path: "src/index.ts",
+      lineStart: 12,
+      columnStart: 4,
+    });
     expect(parseWorkspaceOpenIntent("setup:L3RtcC9yZXBv")).toEqual({
       kind: "setup",
       workspaceId: "/tmp/repo",

--- a/packages/app/src/utils/host-routes.ts
+++ b/packages/app/src/utils/host-routes.ts
@@ -103,9 +103,38 @@ function isLegacyPathLikeWorkspaceValue(value: string): boolean {
 export type WorkspaceOpenIntent =
   | { kind: "agent"; agentId: string }
   | { kind: "terminal"; terminalId: string }
-  | { kind: "file"; path: string }
+  | { kind: "file"; path: string; lineStart?: number; columnStart?: number }
   | { kind: "draft"; draftId: string }
   | { kind: "setup"; workspaceId: string };
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseFileOpenIntentPayload(
+  payload: string,
+): Extract<WorkspaceOpenIntent, { kind: "file" }> | null {
+  const match = payload.match(/^([^:]+)(?::([0-9]+)(?::([0-9]+))?)?$/);
+  if (!match) {
+    return null;
+  }
+  const decodedPath = decodeFilePathFromPathSegment(match[1] ?? "");
+  if (!decodedPath) {
+    return null;
+  }
+  const lineStart = parsePositiveInteger(match[2]);
+  const columnStart = parsePositiveInteger(match[3]);
+  return {
+    kind: "file",
+    path: decodedPath,
+    ...(lineStart ? { lineStart } : {}),
+    ...(columnStart ? { columnStart } : {}),
+  };
+}
 
 export function parseWorkspaceOpenIntent(
   value: string | null | undefined,
@@ -136,11 +165,7 @@ export function parseWorkspaceOpenIntent(
     return { kind: "draft", draftId: payload };
   }
   if (kind === "file") {
-    const decodedPath = decodeFilePathFromPathSegment(payload);
-    if (!decodedPath) {
-      return null;
-    }
-    return { kind: "file", path: decodedPath };
+    return parseFileOpenIntentPayload(payload);
   }
   if (kind === "setup") {
     const workspaceId = decodeWorkspaceIdFromPathSegment(payload);

--- a/packages/app/src/utils/inline-path.test.ts
+++ b/packages/app/src/utils/inline-path.test.ts
@@ -31,6 +31,16 @@ describe("parseInlinePathToken", () => {
     });
   });
 
+  it("parses filename:line:column", () => {
+    expect(parseInlinePathToken("src/app.ts:12:5")).toEqual({
+      raw: "src/app.ts:12:5",
+      path: "src/app.ts",
+      lineStart: 12,
+      lineEnd: undefined,
+      columnStart: 5,
+    });
+  });
+
   it("rejects range-only :line tokens", () => {
     expect(parseInlinePathToken(":12")).toBeNull();
     expect(parseInlinePathToken(":12-20")).toBeNull();
@@ -53,6 +63,16 @@ describe("parseFileProtocolUrl", () => {
       path: "/Users/test/project/src/app.tsx",
       lineStart: undefined,
       lineEnd: undefined,
+    });
+  });
+
+  it("parses file URLs with trailing line suffixes", () => {
+    expect(parseFileProtocolUrl("file:///Users/test/project/src/app.tsx:81:4")).toEqual({
+      raw: "file:///Users/test/project/src/app.tsx:81:4",
+      path: "/Users/test/project/src/app.tsx",
+      lineStart: 81,
+      lineEnd: undefined,
+      columnStart: 4,
     });
   });
 
@@ -231,6 +251,30 @@ describe("parseAssistantFileLink", () => {
       path: "/Users/test/project/src/app.tsx",
       lineStart: 33,
       lineEnd: undefined,
+    });
+  });
+
+  it("parses absolute POSIX hrefs with trailing line suffixes inside the active workspace", () => {
+    expect(
+      parseAssistantFileLink("/Users/test/project/src/app.tsx:33:2", {
+        workspaceRoot: "/Users/test/project",
+      }),
+    ).toEqual({
+      raw: "/Users/test/project/src/app.tsx:33:2",
+      path: "/Users/test/project/src/app.tsx",
+      lineStart: 33,
+      lineEnd: undefined,
+      columnStart: 2,
+    });
+  });
+
+  it("parses relative hrefs with trailing line suffixes", () => {
+    expect(parseAssistantFileLink("src/app.tsx:33:2")).toEqual({
+      raw: "src/app.tsx:33:2",
+      path: "src/app.tsx",
+      lineStart: 33,
+      lineEnd: undefined,
+      columnStart: 2,
     });
   });
 

--- a/packages/app/src/utils/inline-path.ts
+++ b/packages/app/src/utils/inline-path.ts
@@ -5,6 +5,7 @@ export interface InlinePathTarget {
   path: string;
   lineStart?: number;
   lineEnd?: number;
+  columnStart?: number;
 }
 
 const FILE_PROTOCOL = "file:";
@@ -66,6 +67,16 @@ const ASSISTANT_FILE_EXTENSIONS = new Set([
   "yml",
   "zsh",
 ]);
+const INLINE_PATH_LINE_COLUMN_SUFFIX = /^(.+):([0-9]+):([0-9]+)$/;
+const INLINE_PATH_LINE_RANGE_SUFFIX = /^(.+):([0-9]+)-([0-9]+)$/;
+const INLINE_PATH_LINE_SUFFIX = /^(.+):([0-9]+)$/;
+
+interface PathLocationSuffixMatch {
+  basePathRaw: string;
+  lineStartRaw: string;
+  lineEndRaw?: string;
+  columnStartRaw?: string;
+}
 
 export interface AssistantHrefParseOptions {
   workspaceRoot?: string;
@@ -124,11 +135,131 @@ function parseLineFragment(value: string): Pick<InlinePathTarget, "lineStart" | 
   return { lineStart, lineEnd };
 }
 
+function matchPathLocationSuffix(value: string): PathLocationSuffixMatch | null {
+  const columnMatch = value.match(INLINE_PATH_LINE_COLUMN_SUFFIX);
+  if (columnMatch) {
+    return {
+      basePathRaw: columnMatch[1] ?? "",
+      lineStartRaw: columnMatch[2] ?? "",
+      columnStartRaw: columnMatch[3],
+    };
+  }
+
+  const rangeMatch = value.match(INLINE_PATH_LINE_RANGE_SUFFIX);
+  if (rangeMatch) {
+    return {
+      basePathRaw: rangeMatch[1] ?? "",
+      lineStartRaw: rangeMatch[2] ?? "",
+      lineEndRaw: rangeMatch[3],
+    };
+  }
+
+  const lineMatch = value.match(INLINE_PATH_LINE_SUFFIX);
+  if (!lineMatch) {
+    return null;
+  }
+
+  return {
+    basePathRaw: lineMatch[1] ?? "",
+    lineStartRaw: lineMatch[2] ?? "",
+  };
+}
+
+function parsePositiveIntegerToken(value: string | undefined): number | null {
+  const parsed = parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseLineEndToken(
+  value: string | undefined,
+  lineStart: number,
+): number | undefined | null {
+  if (!value) {
+    return undefined;
+  }
+  const lineEnd = parsePositiveIntegerToken(value);
+  if (!lineEnd || lineEnd < lineStart) {
+    return null;
+  }
+  return lineEnd;
+}
+
+function parseColumnStartToken(value: string | undefined): number | undefined | null {
+  if (!value) {
+    return undefined;
+  }
+  return parsePositiveIntegerToken(value);
+}
+
+function parsePathLocationSuffix(
+  value: string,
+): Pick<InlinePathTarget, "path" | "lineStart" | "lineEnd" | "columnStart"> | null {
+  const match = matchPathLocationSuffix(value);
+  if (!match) {
+    return null;
+  }
+
+  const basePathRaw = match.basePathRaw.trim();
+  if (!basePathRaw) {
+    return null;
+  }
+
+  const normalizedPath = normalizePathToken(basePathRaw);
+  if (!normalizedPath) {
+    return null;
+  }
+
+  const lineStart = parsePositiveIntegerToken(match.lineStartRaw);
+  if (!lineStart) {
+    return null;
+  }
+
+  const lineEnd = parseLineEndToken(match.lineEndRaw, lineStart);
+  if (lineEnd === null) {
+    return null;
+  }
+
+  const columnStart = parseColumnStartToken(match.columnStartRaw);
+  if (columnStart === null) {
+    return null;
+  }
+
+  return {
+    path: normalizedPath,
+    lineStart,
+    lineEnd,
+    ...(columnStart ? { columnStart } : {}),
+  };
+}
+
+function parseHrefPathAndLines(
+  pathValue: string,
+  hash: string,
+): Pick<InlinePathTarget, "path" | "lineStart" | "lineEnd" | "columnStart"> | null {
+  const fragmentLines = parseLineFragment(hash);
+  if (!fragmentLines) {
+    return null;
+  }
+
+  const suffixLocation = parsePathLocationSuffix(pathValue);
+  if (!hash) {
+    if (suffixLocation) {
+      return suffixLocation;
+    }
+  }
+
+  return {
+    path: suffixLocation?.path ?? pathValue,
+    ...fragmentLines,
+  };
+}
+
 /**
  * Strict VSCode-style markers only.
  *
  * Supported:
  * - `filename:linenumber`
+ * - `filename:linenumber:columnnumber`
  * - `filename:lineStart-lineEnd`
  *
  * Not supported (by design):
@@ -142,46 +273,19 @@ export function parseInlinePathToken(value: string): InlinePathTarget | null {
     return null;
   }
 
-  const match = trimmed.match(/^(.+?):([0-9]+)(?:-([0-9]+))?$/);
-  if (!match) {
-    return null;
-  }
-
-  const basePathRaw = match[1]?.trim();
-  if (!basePathRaw) {
-    return null;
-  }
-
   // Avoid accidentally treating URLs as file paths.
-  if (basePathRaw.includes("://")) {
+  if (trimmed.includes("://")) {
     return null;
   }
 
-  const normalizedPath = normalizePathToken(basePathRaw);
-  if (!normalizedPath) {
+  const location = parsePathLocationSuffix(trimmed);
+  if (!location) {
     return null;
-  }
-
-  const lineStart = parseInt(match[2], 10);
-  if (!Number.isFinite(lineStart) || lineStart <= 0) {
-    return null;
-  }
-
-  const lineEnd = match[3] ? parseInt(match[3], 10) : undefined;
-  if (lineEnd !== undefined) {
-    if (!Number.isFinite(lineEnd) || lineEnd <= 0) {
-      return null;
-    }
-    if (lineEnd < lineStart) {
-      return null;
-    }
   }
 
   return {
     raw: rawValue,
-    path: normalizedPath,
-    lineStart,
-    lineEnd,
+    ...location,
   };
 }
 
@@ -207,15 +311,14 @@ export function parseFileProtocolUrl(value: string): InlinePathTarget | null {
     return null;
   }
 
-  const lines = parseLineFragment(parsedUrl.hash);
-  if (!lines) {
+  const hrefPath = parseHrefPathAndLines(normalizedPath, parsedUrl.hash);
+  if (!hrefPath) {
     return null;
   }
 
   return {
     raw: value,
-    path: normalizedPath,
-    ...lines,
+    ...hrefPath,
   };
 }
 
@@ -240,6 +343,96 @@ function parseAssistantInlinePathLink(
   return {
     ...inlinePathTarget,
     path: normalizedPath,
+  };
+}
+
+function parseWindowsAssistantFileLink(
+  raw: string,
+  trimmed: string,
+  options: AssistantHrefParseOptions,
+): InlinePathTarget | null {
+  const windowsPathMatch = trimmed.match(/^([A-Za-z]:[\\/][^?#]*)(#[^?]+)?$/);
+  if (!windowsPathMatch) {
+    return null;
+  }
+
+  const normalizedPath = normalizePathToken(windowsPathMatch[1] ?? "");
+  const hrefPath = normalizedPath
+    ? parseHrefPathAndLines(normalizedPath, windowsPathMatch[2] ?? "")
+    : null;
+  if (!hrefPath || !isAllowedAbsolutePath(hrefPath.path, options.workspaceRoot)) {
+    return null;
+  }
+
+  return {
+    raw,
+    ...hrefPath,
+  };
+}
+
+function parseRelativeLocationAssistantFileLink(
+  raw: string,
+  trimmed: string,
+  options: AssistantHrefParseOptions,
+): InlinePathTarget | null {
+  const relativeLocation = parsePathLocationSuffix(trimmed);
+  if (!relativeLocation || isAbsolutePath(relativeLocation.path)) {
+    return null;
+  }
+
+  if (!isPlausibleAssistantLocalPath(relativeLocation.path)) {
+    return null;
+  }
+
+  const workspaceRoot = normalizePathInput(options.workspaceRoot);
+  if (!workspaceRoot) {
+    return {
+      raw,
+      ...relativeLocation,
+    };
+  }
+
+  const normalizedPath = resolveRelativePathUnderRoot(relativeLocation.path, workspaceRoot);
+  if (!normalizedPath) {
+    return null;
+  }
+
+  return {
+    raw,
+    ...relativeLocation,
+    path: normalizedPath,
+  };
+}
+
+function parseAbsoluteAssistantFileLink(
+  raw: string,
+  trimmed: string,
+  options: AssistantHrefParseOptions,
+): InlinePathTarget | null {
+  if (!isAbsolutePath(trimmed)) {
+    return null;
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(trimmed, "http://paseo.invalid");
+  } catch {
+    return null;
+  }
+
+  const normalizedPath = normalizePathToken(decodeURIComponent(parsedUrl.pathname));
+  const hrefPath = normalizedPath ? parseHrefPathAndLines(normalizedPath, parsedUrl.hash) : null;
+  if (!hrefPath || !isAbsolutePath(hrefPath.path)) {
+    return null;
+  }
+
+  if (!isAllowedAbsolutePath(hrefPath.path, options.workspaceRoot)) {
+    return null;
+  }
+
+  return {
+    raw,
+    ...hrefPath,
   };
 }
 
@@ -303,23 +496,14 @@ export function parseAssistantFileLink(
     return inlinePathTarget;
   }
 
-  const windowsPathMatch = trimmed.match(/^([A-Za-z]:[\\/][^?#]*)(#[^?]+)?$/);
-  if (windowsPathMatch) {
-    const normalizedPath = normalizePathToken(windowsPathMatch[1] ?? "");
-    if (!normalizedPath || !isAllowedAbsolutePath(normalizedPath, options.workspaceRoot)) {
-      return null;
-    }
+  const windowsTarget = parseWindowsAssistantFileLink(value, trimmed, options);
+  if (windowsTarget) {
+    return windowsTarget;
+  }
 
-    const lines = parseLineFragment(windowsPathMatch[2] ?? "");
-    if (!lines) {
-      return null;
-    }
-
-    return {
-      raw: value,
-      path: normalizedPath,
-      ...lines,
-    };
+  const relativeLocationTarget = parseRelativeLocationAssistantFileLink(value, trimmed, options);
+  if (relativeLocationTarget) {
+    return relativeLocationTarget;
   }
 
   const relativeTarget = parseWorkspaceRelativeFileLink(trimmed, {
@@ -329,36 +513,7 @@ export function parseAssistantFileLink(
     return relativeTarget;
   }
 
-  if (!isAbsolutePath(trimmed)) {
-    return null;
-  }
-
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(trimmed, "http://paseo.invalid");
-  } catch {
-    return null;
-  }
-
-  const normalizedPath = normalizePathToken(decodeURIComponent(parsedUrl.pathname));
-  if (!normalizedPath || !isAbsolutePath(normalizedPath)) {
-    return null;
-  }
-
-  if (!isAllowedAbsolutePath(normalizedPath, options.workspaceRoot)) {
-    return null;
-  }
-
-  const lines = parseLineFragment(parsedUrl.hash);
-  if (!lines) {
-    return null;
-  }
-
-  return {
-    raw: value,
-    path: normalizedPath,
-    ...lines,
-  };
+  return parseAbsoluteAssistantFileLink(value, trimmed, options);
 }
 
 export function isFileLookingAssistantToken(value: string): boolean {
@@ -403,7 +558,7 @@ function parseWorkspaceRelativeFileLink(
 
 function parseLocalPathParts(
   value: string,
-): { path: string; lines: Pick<InlinePathTarget, "lineStart" | "lineEnd"> } | null {
+): { path: string; lines: Pick<InlinePathTarget, "lineStart" | "lineEnd" | "columnStart"> } | null {
   const normalized = normalizePathToken(value);
   if (!normalized || normalized.includes("?")) {
     return null;
@@ -428,6 +583,7 @@ function parseLocalPathParts(
       lines: {
         lineStart: inlinePathTarget.lineStart,
         lineEnd: inlinePathTarget.lineEnd,
+        columnStart: inlinePathTarget.columnStart,
       },
     };
   }

--- a/packages/app/src/utils/workspace-tab-identity.ts
+++ b/packages/app/src/utils/workspace-tab-identity.ts
@@ -1,5 +1,12 @@
 import type { WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
 
+function normalizePositiveInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
 export function normalizeWorkspaceTabTarget(
   value: WorkspaceTabTarget | null | undefined,
 ): WorkspaceTabTarget | null {
@@ -24,7 +31,17 @@ export function normalizeWorkspaceTabTarget(
   }
   if (value.kind === "file") {
     const path = trimNonEmpty(value.path);
-    return path ? { kind: "file", path: path.replace(/\\/g, "/") } : null;
+    if (!path) {
+      return null;
+    }
+    const lineStart = normalizePositiveInteger(value.lineStart);
+    const columnStart = normalizePositiveInteger(value.columnStart);
+    return {
+      kind: "file",
+      path: path.replace(/\\/g, "/"),
+      ...(lineStart ? { lineStart } : {}),
+      ...(columnStart ? { columnStart } : {}),
+    };
   }
   if (value.kind === "setup") {
     const workspaceId = trimNonEmpty(value.workspaceId);

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "f
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 import pino from "pino";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { WorkspaceDescriptorPayload } from "../shared/messages.js";
 import { decodeFileTransferFrame, FileTransferOpcode } from "../shared/binary-frames/index.js";
@@ -107,6 +107,7 @@ const checkoutGitMocks = vi.hoisted(() => ({
   createPullRequest: vi.fn(),
   getCachedCheckoutShortstat: vi.fn(),
   getCheckoutStatus: vi.fn(),
+  getTitleGenerationPromptContext: vi.fn(),
   listBranchSuggestions: vi.fn(),
   mergeFromBase: vi.fn(),
   mergeToBase: vi.fn(),
@@ -198,6 +199,7 @@ vi.mock("../utils/checkout-git.js", async (importOriginal) => {
     createPullRequest: checkoutGitMocks.createPullRequest,
     getCachedCheckoutShortstat: checkoutGitMocks.getCachedCheckoutShortstat,
     getCheckoutStatus: checkoutGitMocks.getCheckoutStatus,
+    getTitleGenerationPromptContext: checkoutGitMocks.getTitleGenerationPromptContext,
     listBranchSuggestions: checkoutGitMocks.listBranchSuggestions,
     mergeFromBase: checkoutGitMocks.mergeFromBase,
     mergeToBase: checkoutGitMocks.mergeToBase,
@@ -927,6 +929,10 @@ function createWorkspaceGitSnapshot(
   };
 }
 
+beforeEach(() => {
+  checkoutGitMocks.getTitleGenerationPromptContext.mockResolvedValue(null);
+});
+
 afterEach(() => {
   vi.clearAllMocks();
 });
@@ -1573,6 +1579,58 @@ diff --git a/file.txt b/file.txt
     expect(fileListIndex).toBeLessThan(patchIndex);
   });
 
+  test("adds configured title guidance when generating commit messages", async () => {
+    const messages: unknown[] = [];
+    const workspaceGitService = {
+      getCheckoutDiff: vi.fn().mockResolvedValue({
+        diff: "diff --git a/file.txt b/file.txt\n+hello\n",
+        structured: [
+          {
+            path: "file.txt",
+            additions: 1,
+            deletions: 0,
+            isNew: false,
+            isDeleted: false,
+            hunks: [],
+            status: "ok",
+          },
+        ],
+      }),
+      getSnapshot: vi.fn().mockResolvedValue({}),
+    };
+    checkoutGitMocks.getTitleGenerationPromptContext.mockResolvedValue({
+      source: "config",
+      instruction: "conventional-commit",
+    });
+    agentResponseMocks.generateStructuredAgentResponseWithFallback.mockResolvedValue({
+      message: "feat: update file",
+    });
+    checkoutGitMocks.commitChanges.mockResolvedValue(undefined);
+    const session = createSessionForTest({ workspaceGitService, messages });
+
+    await asSessionInternals(session).handleCheckoutCommitRequest({
+      type: "checkout_commit_request",
+      cwd: "/tmp/request-worktree",
+      message: "",
+      addAll: true,
+      requestId: "request-generated-commit",
+    });
+
+    expect(checkoutGitMocks.getTitleGenerationPromptContext).toHaveBeenCalledWith(
+      "/tmp/request-worktree",
+    );
+    const prompt =
+      agentResponseMocks.generateStructuredAgentResponseWithFallback.mock.calls[0]?.[0]?.prompt;
+    expect(prompt).toContain("Commit title style guidance:");
+    expect(prompt).toContain("git config --local paseo.prompt.title");
+    expect(prompt).toContain("Conventional Commits");
+    expect(prompt).toContain("type(scope): summary");
+    expect(checkoutGitMocks.commitChanges).toHaveBeenCalledWith("/tmp/request-worktree", {
+      message: "feat: update file",
+      addAll: true,
+    });
+  });
+
   test("keeps the commit fallback when structured generation fails", async () => {
     const messages: unknown[] = [];
     const workspaceGitService = {
@@ -1872,6 +1930,69 @@ diff --git a/file.txt b/file.txt
     });
     expect(schema?.safeParse?.({ title: "Update file", body: "Updates file." }).success).toBe(true);
     expect(schema?.safeParse?.({ title: "Update file" }).success).toBe(false);
+  });
+
+  test("adds recent commit title examples when generating PR text", async () => {
+    const messages: unknown[] = [];
+    const workspaceGitService = {
+      getCheckoutDiff: vi.fn().mockResolvedValue({
+        diff: "diff --git a/file.txt b/file.txt\n+hello\n",
+        structured: [
+          {
+            path: "file.txt",
+            additions: 1,
+            deletions: 0,
+            isNew: false,
+            isDeleted: false,
+            hunks: [],
+            status: "ok",
+          },
+        ],
+      }),
+    };
+    checkoutGitMocks.getTitleGenerationPromptContext.mockResolvedValue({
+      source: "history",
+      ref: "main",
+      titles: ["Add project picker", "Fix git sync labels"],
+    });
+    agentResponseMocks.generateStructuredAgentResponseWithFallback.mockResolvedValue({
+      title: "Add checkout title guidance",
+      body: "Adds title guidance.",
+    });
+    checkoutGitMocks.createPullRequest.mockResolvedValue({
+      url: "https://github.com/getpaseo/paseo/pull/3",
+      number: 3,
+    });
+    const session = createSessionForTest({ workspaceGitService, messages });
+
+    await asSessionInternals(session).handleCheckoutPrCreateRequest({
+      type: "checkout_pr_create_request",
+      cwd: "/tmp/request-worktree",
+      baseRef: "main",
+      title: "",
+      body: "",
+      requestId: "request-generated-pr",
+    });
+
+    expect(checkoutGitMocks.getTitleGenerationPromptContext).toHaveBeenCalledWith(
+      "/tmp/request-worktree",
+      { baseRef: "main" },
+    );
+    const prompt =
+      agentResponseMocks.generateStructuredAgentResponseWithFallback.mock.calls[0]?.[0]?.prompt;
+    expect(prompt).toContain("Pull request title style examples from recent commits on main:");
+    expect(prompt).toContain("1. Add project picker");
+    expect(prompt).toContain("2. Fix git sync labels");
+    expect(prompt).toContain("Use these examples for style");
+    expect(checkoutGitMocks.createPullRequest).toHaveBeenCalledWith(
+      "/tmp/request-worktree",
+      {
+        title: "Add checkout title guidance",
+        body: "Adds title guidance.",
+        base: "main",
+      },
+      expect.anything(),
+    );
   });
 
   test("keeps the PR fallback when structured generation fails", async () => {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -192,6 +192,8 @@ import {
   pullCurrentBranch,
   pushCurrentBranch,
   createPullRequest,
+  getTitleGenerationPromptContext,
+  type TitleGenerationPromptContext,
 } from "../utils/checkout-git.js";
 import { getProjectIcon } from "../utils/project-icon.js";
 import { expandTilde } from "../utils/path.js";
@@ -3936,11 +3938,51 @@ export class Session {
     return resolvedCandidate.startsWith(resolvedRoot + sep);
   }
 
+  private formatTitleGenerationPromptContext(
+    context: TitleGenerationPromptContext | null | undefined,
+    target: "commit title" | "pull request title",
+  ): string | null {
+    if (!context) {
+      return null;
+    }
+
+    const label = target === "commit title" ? "Commit title" : "Pull request title";
+    if (context.source === "config") {
+      const instruction = context.instruction.trim();
+      const normalizedInstruction = instruction.toLowerCase();
+      if (normalizedInstruction === "conventional-commit") {
+        return [
+          `${label} style guidance:`,
+          "- Source: git config --local paseo.prompt.title",
+          "- Follow the Conventional Commits standard, for example: type(scope): summary.",
+          `- Apply that format to the ${target} while still describing the diff below accurately.`,
+        ].join("\n");
+      }
+
+      return [
+        `${label} style guidance:`,
+        "- Source: git config --local paseo.prompt.title",
+        `- Instruction: ${instruction}`,
+        `- Apply this instruction to the ${target} while still describing the diff below accurately.`,
+      ].join("\n");
+    }
+
+    return [
+      `${label} style examples from recent commits on ${context.ref}:`,
+      "Use these examples for style, tone, casing, and prefix patterns only; base the content on the diff below.",
+      ...context.titles.map((title, index) => `${index + 1}. ${title}`),
+    ].join("\n");
+  }
+
   private async generateCommitMessage(cwd: string): Promise<string> {
     const diff = await this.workspaceGitService.getCheckoutDiff(cwd, {
       mode: "uncommitted",
       includeStructured: true,
     });
+    const titlePromptContext = this.formatTitleGenerationPromptContext(
+      await getTitleGenerationPromptContext(cwd),
+      "commit title",
+    );
     const schema = z.object({
       message: z
         .string()
@@ -3970,6 +4012,7 @@ export class Session {
       configKey: "commitMessage",
       before: "Write a concise git commit message for the changes below.",
       after: [
+        ...(titlePromptContext ? [titlePromptContext, ""] : []),
         "Return JSON only with a single field 'message'.",
         "",
         fileList,
@@ -4016,6 +4059,10 @@ export class Session {
       baseRef,
       includeStructured: true,
     });
+    const titlePromptContext = this.formatTitleGenerationPromptContext(
+      await getTitleGenerationPromptContext(cwd, { baseRef }),
+      "pull request title",
+    );
     const schema = z.object({
       title: z.string().min(1).max(72),
       body: z.string().min(1),
@@ -4042,6 +4089,7 @@ export class Session {
       configKey: "pullRequest",
       before: "Write a pull request title and body for the changes below.",
       after: [
+        ...(titlePromptContext ? [titlePromptContext, ""] : []),
         "Return JSON only with fields 'title' and 'body'.",
         "",
         fileList,

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -22,6 +22,7 @@ import {
   getCheckoutShortstat,
   getPullRequestStatus,
   getCheckoutStatus,
+  getTitleGenerationPromptContext,
   checkoutResolvedBranch,
   listBranchSuggestions,
   mergeToBase,
@@ -284,6 +285,52 @@ describe("checkout git utilities", () => {
       .toString()
       .trim();
     expect(message).toBe("update file");
+  });
+
+  it("uses local paseo title prompt config before sampling history", async () => {
+    commitFile(repoDir, "history.txt", "history\n", "Add history sample");
+    execFileSync("git", ["config", "--local", "paseo.prompt.title", "conventional-commit"], {
+      cwd: repoDir,
+    });
+
+    const context = await getTitleGenerationPromptContext(repoDir);
+
+    expect(context).toEqual({
+      source: "config",
+      instruction: "conventional-commit",
+    });
+  });
+
+  it("samples recent commit titles from the main branch when title config is unset", async () => {
+    commitFile(repoDir, "main-style.txt", "main\n", "Add main style");
+    execFileSync("git", ["checkout", "-b", "feature/title-sampling"], { cwd: repoDir });
+    commitFile(repoDir, "feature-only.txt", "feature\n", "feature-only style");
+
+    const context = await getTitleGenerationPromptContext(repoDir);
+
+    expect(context?.source).toBe("history");
+    if (context?.source !== "history") {
+      throw new Error("Expected history title prompt context");
+    }
+    expect(context.ref).toBe("main");
+    expect(context.titles).toContain("Add main style");
+    expect(context.titles).not.toContain("feature-only style");
+  });
+
+  it("limits title history samples to the recent 15 commit titles", async () => {
+    for (let i = 1; i <= 16; i += 1) {
+      commitFile(repoDir, `sample-${i}.txt`, `${i}\n`, `Add sample ${i}`);
+    }
+
+    const context = await getTitleGenerationPromptContext(repoDir);
+
+    expect(context?.source).toBe("history");
+    if (context?.source !== "history") {
+      throw new Error("Expected history title prompt context");
+    }
+    expect(context.titles).toHaveLength(15);
+    expect(context.titles[0]).toBe("Add sample 16");
+    expect(context.titles).not.toContain("initial");
   });
 
   it("hides whitespace-only changes when requested", async () => {

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -29,6 +29,8 @@ const DEFAULT_PULL_REQUEST_STATUS_CACHE_TTL_MS = 30_000;
 const PULL_REQUEST_STATUS_CACHE_MAX = 1_000;
 const DEFAULT_SHORTSTAT_CACHE_TTL_MS = 15_000;
 const SHORTSTAT_CACHE_MAX = 1_000;
+const TITLE_PROMPT_CONFIG_KEY = "paseo.prompt.title";
+const TITLE_PROMPT_SAMPLE_LIMIT = 15;
 
 let pullRequestStatusCacheTtlMs = DEFAULT_PULL_REQUEST_STATUS_CACHE_TTL_MS;
 let pullRequestStatusCache = createPullRequestStatusCache(pullRequestStatusCacheTtlMs);
@@ -725,6 +727,10 @@ export interface CheckoutContext {
   logger?: Pick<Logger, "trace">;
 }
 
+export type TitleGenerationPromptContext =
+  | { source: "config"; instruction: string }
+  | { source: "history"; ref: string; titles: string[] };
+
 function isGitError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
@@ -1157,6 +1163,134 @@ function normalizeLocalBranchRefName(input: string): string {
     return input.slice("origin/".length);
   }
   return input;
+}
+
+async function readConfiguredTitlePrompt(cwd: string): Promise<string | null> {
+  try {
+    const { stdout, exitCode } = await runGitCommand(
+      ["config", "--local", "--get", TITLE_PROMPT_CONFIG_KEY],
+      {
+        cwd,
+        env: READ_ONLY_GIT_ENV,
+        acceptExitCodes: [0, 1],
+        maxOutputBytes: 4096,
+      },
+    );
+    if (exitCode !== 0) {
+      return null;
+    }
+    const instruction = stdout.trim();
+    return instruction.length > 0 ? instruction : null;
+  } catch {
+    return null;
+  }
+}
+
+function addTitlePromptRefCandidate(
+  candidates: string[],
+  seen: Set<string>,
+  input?: string | null,
+) {
+  const ref = input?.trim();
+  if (!ref || seen.has(ref)) {
+    return;
+  }
+  seen.add(ref);
+  candidates.push(ref);
+}
+
+function buildTitlePromptRefCandidates(
+  baseRef?: string | null,
+  defaultRef?: string | null,
+): string[] {
+  const candidates: string[] = [];
+  const seen = new Set<string>();
+
+  for (const ref of [baseRef, defaultRef, "main", "origin/main", "master", "origin/master"]) {
+    const trimmed = ref?.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const localName = normalizeLocalBranchRefName(trimmed);
+    addTitlePromptRefCandidate(candidates, seen, trimmed);
+    addTitlePromptRefCandidate(candidates, seen, localName);
+    if (!localName.startsWith("origin/")) {
+      addTitlePromptRefCandidate(candidates, seen, `origin/${localName}`);
+    }
+  }
+
+  return candidates;
+}
+
+async function resolveTitlePromptSampleRef(cwd: string, baseRef?: string): Promise<string | null> {
+  let defaultRef: string | null = null;
+  try {
+    defaultRef = await resolveRepositoryDefaultBranch(cwd);
+  } catch {
+    defaultRef = null;
+  }
+
+  for (const candidate of buildTitlePromptRefCandidates(baseRef, defaultRef)) {
+    try {
+      const result = await runGitCommand(
+        ["rev-parse", "--verify", "--quiet", `${candidate}^{commit}`],
+        {
+          cwd,
+          env: READ_ONLY_GIT_ENV,
+          acceptExitCodes: [0, 1],
+        },
+      );
+      if (result.exitCode === 0) {
+        return candidate;
+      }
+    } catch {
+      // Ignore invalid or unavailable refs and try the next candidate.
+    }
+  }
+
+  return null;
+}
+
+async function sampleRecentCommitTitles(cwd: string, ref: string): Promise<string[]> {
+  try {
+    const { stdout } = await runGitCommand(
+      ["log", `--max-count=${TITLE_PROMPT_SAMPLE_LIMIT}`, "--format=%s", ref, "--"],
+      {
+        cwd,
+        env: READ_ONLY_GIT_ENV,
+        maxOutputBytes: 16 * 1024,
+      },
+    );
+    return stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .slice(0, TITLE_PROMPT_SAMPLE_LIMIT);
+  } catch {
+    return [];
+  }
+}
+
+export async function getTitleGenerationPromptContext(
+  cwd: string,
+  options?: { baseRef?: string },
+): Promise<TitleGenerationPromptContext | null> {
+  const configuredPrompt = await readConfiguredTitlePrompt(cwd);
+  if (configuredPrompt) {
+    return { source: "config", instruction: configuredPrompt };
+  }
+
+  const sampleRef = await resolveTitlePromptSampleRef(cwd, options?.baseRef);
+  if (!sampleRef) {
+    return null;
+  }
+
+  const titles = await sampleRecentCommitTitles(cwd, sampleRef);
+  if (titles.length === 0) {
+    return null;
+  }
+
+  return { source: "history", ref: sampleRef, titles };
 }
 
 interface ComparisonBaseRefName {


### PR DESCRIPTION
### Linked issue

No related issues.

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

In short it identifies a common syntax that used by agents in markdown outputs.

> file:path:line:column
> e.g. /home/user/paseo/README.md:1:1

Supports opening workspace file tabs at a specific line and column from assistant file links and workspace open intents.

This preserves the current workspace deck/index route structure while carrying line and column targets through inline path parsing, workspace tab targets, route open intents, and file pane rendering. Reopening an existing file tab with a different line target updates that tab instead of creating a duplicate.

### How did you verify it

- 
> paseo@0.1.76 format
> oxfmt .

Finished in 545ms on 1891 files using 24 threads.
- 
 RUN  v3.2.4 /home/kamiyoru/work/ts/paseo

 ✓ packages/app/src/utils/host-routes.test.ts (20 tests) 7ms
 ✓ packages/app/src/utils/inline-path.test.ts (32 tests) 10ms
 ✓ packages/app/src/stores/workspace-layout-store.test.ts (44 tests) 17ms

 Test Files  3 passed (3)
      Tests  96 passed (96)
   Start at  18:13:37
   Duration  350ms (transform 232ms, setup 0ms, collect 314ms, tests 34ms, environment 0ms, prepare 203ms) — 96 tests passed
- 
> paseo@0.1.76 lint
> oxlint

Found 0 warnings and 0 errors.
Finished in 410ms on 1749 files with 177 rules using 24 threads.
- 
> paseo@0.1.76 typecheck
> npm run typecheck --workspaces --if-present


> @getpaseo/expo-two-way-audio@0.1.76 typecheck
> tsgo --noEmit


> @getpaseo/highlight@0.1.76 typecheck
> tsgo --noEmit


> @getpaseo/server@0.1.76 typecheck
> tsgo -p tsconfig.server.typecheck.json --noEmit


> @getpaseo/app@0.1.76 typecheck
> tsgo --noEmit


> @getpaseo/relay@0.1.76 typecheck
> tsgo --noEmit


> @getpaseo/website@0.1.76 typecheck
> tsgo --noEmit


> @getpaseo/desktop@0.1.76 typecheck
> tsgo --noEmit -p tsconfig.json

src/daemon/cli/external.ts(21,7): error TS2353: Object literal may only specify known properties, and 'envMode' does not exist in type 'SpawnOptions'.
src/daemon/daemon-manager.ts(377,5): error TS2353: Object literal may only specify known properties, and 'envMode' does not exist in type 'SpawnOptions'.

> @getpaseo/cli@0.1.76 typecheck
> tsgo --noEmit

src/commands/agent/import.ts(145,32): error TS2339: Property 'importAgent' does not exist on type 'DaemonClient'.
src/commands/agent/inspect.ts(2,10): error TS2305: Module '"@getpaseo/server"' has no exported member 'PARENT_AGENT_ID_LABEL'.
src/commands/daemon/local-daemon.ts(411,25): error TS2339: Property 'relayUseTls' does not exist on type 'PaseoDaemonConfig'.
src/commands/daemon/local-daemon.ts(443,7): error TS2353: Object literal may only specify known properties, and 'envMode' does not exist in type 'SpawnOptions'.
src/commands/daemon/pair.ts(31,5): error TS2353: Object literal may only specify known properties, and 'relayUseTls' does not exist in type '{ paseoHome: string; relayEnabled?: boolean | undefined; relayEndpoint?: string | undefined; relayPublicEndpoint?: string | undefined; appBaseUrl?: string | undefined; includeQr?: boolean | undefined; logger?: Logger | undefined; }'.
src/commands/daemon/pair.ts(31,25): error TS2339: Property 'relayUseTls' does not exist on type 'PaseoDaemonConfig'.
src/commands/daemon/set-password.ts(5,3): error TS2305: Module '"@getpaseo/server"' has no exported member 'hashDaemonPassword'.
src/commands/daemon/set-password.ts(7,3): error TS2724: '"@getpaseo/server"' has no exported member named 'savePersistedConfig'. Did you mean 'PersistedConfig'?
src/commands/daemon/set-password.ts(91,7): error TS2353: Object literal may only specify known properties, and 'auth' does not exist in type '{ mcp?: objectOutputType<{ enabled: ZodOptional<ZodBoolean>; injectIntoAgents: ZodOptional<ZodBoolean>; }, ZodTypeAny, "passthrough"> | undefined; listen?: string | undefined; hostnames?: true | ... 1 more ... | undefined; cors?: { ...; } | undefined; relay?: { ...; } | undefined; }'.
src/commands/daemon/set-password.ts(92,30): error TS2339: Property 'auth' does not exist on type '{ mcp?: objectOutputType<{ enabled: ZodOptional<ZodBoolean>; injectIntoAgents: ZodOptional<ZodBoolean>; }, ZodTypeAny, "passthrough"> | undefined; listen?: string | undefined; hostnames?: true | ... 1 more ... | undefined; cors?: { ...; } | undefined; relay?: { ...; } | undefined; }'.
src/commands/onboard.ts(494,5): error TS2353: Object literal may only specify known properties, and 'relayUseTls' does not exist in type '{ paseoHome: string; relayEnabled?: boolean | undefined; relayEndpoint?: string | undefined; relayPublicEndpoint?: string | undefined; appBaseUrl?: string | undefined; includeQr?: boolean | undefined; logger?: Logger | undefined; }'.
src/commands/onboard.ts(494,25): error TS2339: Property 'relayUseTls' does not exist on type 'PaseoDaemonConfig'.
src/utils/client.ts(3,3): error TS2305: Module '"@getpaseo/server"' has no exported member 'buildDaemonWebSocketUrl'.
src/utils/client.ts(4,3): error TS2305: Module '"@getpaseo/server"' has no exported member 'buildRelayWebSocketUrl'.
src/utils/client.ts(6,3): error TS2305: Module '"@getpaseo/server"' has no exported member 'normalizeHostPort'.
src/utils/client.ts(7,3): error TS2305: Module '"@getpaseo/server"' has no exported member 'parseConnectionUri'.
src/utils/client.ts(8,3): error TS2305: Module '"@getpaseo/server"' has no exported member 'parseConnectionOfferFromUrl'.
src/utils/client.ts(11,3): error TS2305: Module '"@getpaseo/server"' has no exported member 'shouldUseTlsForDefaultHostedRelay'.
src/utils/client.ts(12,8): error TS2305: Module '"@getpaseo/server"' has no exported member 'ConnectionOffer'.
src/utils/client.ts(13,8): error TS2305: Module '"@getpaseo/server"' has no exported member 'WebSocketLike'.
src/utils/client.ts(261,5): error TS2353: Object literal may only specify known properties, and 'password' does not exist in type 'DaemonClientConfig'. — attempted locally, but this checkout currently fails on unrelated baseline/dependency issues outside this change, including missing local modules (, , , ) and existing server/desktop/cli type mismatches. PR CI runs a clean  and dependency builds before typecheck.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [ ] 
> paseo@0.1.76 typecheck
> npm run typecheck --workspaces --if-present


> @getpaseo/expo-two-way-audio@0.1.76 typecheck
> tsgo --noEmit


> @getpaseo/highlight@0.1.76 typecheck
> tsgo --noEmit


> @getpaseo/server@0.1.76 typecheck
> tsgo -p tsconfig.server.typecheck.json --noEmit


> @getpaseo/app@0.1.76 typecheck
> tsgo --noEmit


> @getpaseo/relay@0.1.76 typecheck
> tsgo --noEmit


> @getpaseo/website@0.1.76 typecheck
> tsgo --noEmit


> @getpaseo/desktop@0.1.76 typecheck
> tsgo --noEmit -p tsconfig.json


> @getpaseo/cli@0.1.76 typecheck
> tsgo --noEmit passes
- [x] 
> paseo@0.1.76 lint
> oxlint passes
- [x] 
> paseo@0.1.76 format
> oxfmt . ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense