### PR TITLE
fix(app): avoid Android white screen in permission mode menu (#1053)

### DIFF
--- a/packages/app/src/components/agent-status-bar.tsx
+++ b/packages/app/src/components/agent-status-bar.tsx
@@ -16,7 +16,7 @@ import {
   type StyleProp,
   type ViewStyle,
 } from "react-native";
-import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { StyleSheet, useUnistyles, withUnistyles } from "react-native-unistyles";
 import { useShallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import {
@@ -58,6 +58,7 @@ import type {
 } from "@server/server/agent/agent-sdk-types";
 import type { AgentProviderDefinition } from "@server/server/agent/provider-manifest";
 import { getModeVisuals, type AgentModeColorTier } from "@server/server/agent/provider-manifest";
+import type { Theme } from "@/styles/theme";
 import {
   getFeatureHighlightColor,
   getFeatureTooltip,
@@ -182,6 +183,21 @@ const MODE_ICONS = {
   ShieldAlert,
   ShieldOff,
   ShieldQuestionMark,
+} as const;
+const ThemedShieldCheck = withUnistyles(ShieldCheck);
+const ThemedShieldAlert = withUnistyles(ShieldAlert);
+const ThemedShieldOff = withUnistyles(ShieldOff);
+const ThemedShieldQuestionMark = withUnistyles(ShieldQuestionMark);
+
+const foregroundColorMapping = (theme: Theme) => ({
+  color: theme.colors.foreground,
+});
+
+const MODE_MENU_LEADING_ICONS = {
+  ShieldCheck: <ThemedShieldCheck size={16} uniProps={foregroundColorMapping} />,
+  ShieldAlert: <ThemedShieldAlert size={16} uniProps={foregroundColorMapping} />,
+  ShieldOff: <ThemedShieldOff size={16} uniProps={foregroundColorMapping} />,
+  ShieldQuestionMark: <ThemedShieldQuestionMark size={16} uniProps={foregroundColorMapping} />,
 } as const;
 
 function alwaysTrue() {
@@ -1606,18 +1622,11 @@ function ModeMenuItem({
   selected: boolean;
   onSelectMode?: (modeId: string) => void;
 }) {
-  const { theme } = useUnistyles();
   const visuals = getModeVisuals(provider, mode.id, providerDefinitions);
-  const Icon = visuals?.icon ? MODE_ICONS[visuals.icon] : ShieldCheck;
-
+  const leadingIcon = visuals?.icon ? MODE_MENU_LEADING_ICONS[visuals.icon] : null;
   const handleSelect = useCallback(() => {
     onSelectMode?.(mode.id);
   }, [mode.id, onSelectMode]);
-
-  const leadingIcon = useMemo(
-    () => <Icon size={16} color={theme.colors.foreground} />,
-    [Icon, theme.colors.foreground],
-  );
 
   return (
     <DropdownMenuItem selected={selected} onSelect={handleSelect} leading={leadingIcon}>


### PR DESCRIPTION
Closes #1053

## Change

Adjust the Android/mobile permission mode menu icon rendering to use stable themed leading icons without changing permission mode behavior.

## Testing

- `npm run format:files -- packages/app/src/components/agent-status-bar.tsx`
- `npm run lint -- packages/app/src/components/agent-status-bar.tsx`
- `npm run typecheck --workspace=@getpaseo/app`
- `npx vitest run packages/app/src/components/agent-status-bar.test.ts --bail=1`
- `git diff --check`
- Manual QA on Android: verified the permission selector opens and icons render without the white screen

## Platform coverage

Tested on Android only.

I did not verify whether iOS, desktop, or web show the same bug or need this change.

## Screenshots / video

- Android screenshot:
<img width="1080" height="2400" alt="Screenshot_1778967155" src="https://github.com/user-attachments/assets/ab9f60b2-7ab5-4aa8-be8b-e89b21f5cacf" />
