### PR TITLE
Show diff file paths in a tooltip

### DIFF
--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -867,10 +867,12 @@ const DiffFileHeader = memo(function DiffFileHeader({
     () => [styles.fileSectionHeaderContainer, isExpanded && styles.fileSectionHeaderExpanded],
     [isExpanded],
   );
+  const fileHeaderTitleProps = isWeb ? { title: file.path } : {};
 
   return (
     <View style={containerStyle} onLayout={handleLayout} testID={testID}>
       <Pressable
+        {...fileHeaderTitleProps}
         testID={testID ? `${testID}-toggle` : undefined}
         style={fileHeaderPressableStyle}
         // Android: prevent parent pan/scroll gestures from canceling the tap release.

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -867,42 +867,49 @@ const DiffFileHeader = memo(function DiffFileHeader({
     () => [styles.fileSectionHeaderContainer, isExpanded && styles.fileSectionHeaderExpanded],
     [isExpanded],
   );
-  const fileHeaderTitleProps = isWeb ? { title: file.path } : {};
 
   return (
     <View style={containerStyle} onLayout={handleLayout} testID={testID}>
-      <Pressable
-        {...fileHeaderTitleProps}
-        testID={testID ? `${testID}-toggle` : undefined}
-        style={fileHeaderPressableStyle}
-        // Android: prevent parent pan/scroll gestures from canceling the tap release.
-        cancelable={false}
-        onPressIn={handlePressIn}
-        onPressOut={handlePressOut}
-        onPress={toggleExpanded}
-      >
-        <View style={styles.fileHeaderLeft}>
-          <Text style={styles.fileName} numberOfLines={1}>
-            {file.path.split("/").pop()}
-          </Text>
-          <Text style={styles.fileDir} numberOfLines={1}>
-            {file.path.includes("/") ? ` ${file.path.slice(0, file.path.lastIndexOf("/"))}` : ""}
-          </Text>
-          {file.isNew && (
-            <View style={styles.newBadge}>
-              <Text style={styles.newBadgeText}>New</Text>
+      <Tooltip delayDuration={300} enabledOnDesktop enabledOnMobile={false}>
+        <TooltipTrigger asChild>
+          <Pressable
+            testID={testID ? `${testID}-toggle` : undefined}
+            style={fileHeaderPressableStyle}
+            // Android: prevent parent pan/scroll gestures from canceling the tap release.
+            cancelable={false}
+            onPressIn={handlePressIn}
+            onPressOut={handlePressOut}
+            onPress={toggleExpanded}
+          >
+            <View style={styles.fileHeaderLeft}>
+              <Text style={styles.fileName} numberOfLines={1}>
+                {file.path.split("/").pop()}
+              </Text>
+              <Text style={styles.fileDir} numberOfLines={1}>
+                {file.path.includes("/")
+                  ? ` ${file.path.slice(0, file.path.lastIndexOf("/"))}`
+                  : ""}
+              </Text>
+              {file.isNew && (
+                <View style={styles.newBadge}>
+                  <Text style={styles.newBadgeText}>New</Text>
+                </View>
+              )}
+              {file.isDeleted && (
+                <View style={styles.deletedBadge}>
+                  <Text style={styles.deletedBadgeText}>Deleted</Text>
+                </View>
+              )}
             </View>
-          )}
-          {file.isDeleted && (
-            <View style={styles.deletedBadge}>
-              <Text style={styles.deletedBadgeText}>Deleted</Text>
+            <View style={styles.fileHeaderRight}>
+              <DiffStat additions={file.additions} deletions={file.deletions} />
             </View>
-          )}
-        </View>
-        <View style={styles.fileHeaderRight}>
-          <DiffStat additions={file.additions} deletions={file.deletions} />
-        </View>
-      </Pressable>
+          </Pressable>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="start" offset={6} maxWidth={520}>
+          <Text style={styles.tooltipText}>{file.path}</Text>
+        </TooltipContent>
+      </Tooltip>
     </View>
   );
 });

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -68,7 +68,6 @@ import { useSessionStore, type WorkspaceDescriptor } from "@/stores/session-stor
 import {
   buildWorkspaceTabPersistenceKey,
   collectAllTabs,
-  createDefaultLayout,
   getFocusedBrowserId,
   type WorkspaceLayout,
   useWorkspaceLayoutStore,
@@ -1674,24 +1673,14 @@ function WorkspaceScreenContent({
     persistenceKey ? (state.layoutByWorkspace[persistenceKey] ?? null) : null,
   );
   const hasHydratedWorkspaceLayoutStore = useWorkspaceLayoutStoreHydrated();
-  const defaultWorkspaceLayout = useMemo(() => createDefaultLayout(), []);
-  // The desktop split container owns the tab row. Once persistence has hydrated,
-  // render a default layout even before the first workspace action stores one.
-  const renderWorkspaceLayout = useMemo(
-    () =>
-      hasHydratedWorkspaceLayoutStore
-        ? (workspaceLayout ?? defaultWorkspaceLayout)
-        : workspaceLayout,
-    [defaultWorkspaceLayout, hasHydratedWorkspaceLayoutStore, workspaceLayout],
-  );
   const workspaceSetupSnapshot = useWorkspaceSetupStore((state) =>
     persistenceKey ? (state.snapshots[persistenceKey] ?? null) : null,
   );
   const upsertWorkspaceSetupProgress = useWorkspaceSetupStore((state) => state.upsertProgress);
   const showWorkspaceSetup = shouldShowWorkspaceSetup(workspaceSetupSnapshot);
   const uiTabs = useMemo(
-    () => (renderWorkspaceLayout ? collectAllTabs(renderWorkspaceLayout.root) : EMPTY_UI_TABS),
-    [renderWorkspaceLayout],
+    () => (workspaceLayout ? collectAllTabs(workspaceLayout.root) : EMPTY_UI_TABS),
+    [workspaceLayout],
   );
   useSyncWorkspaceActiveBrowser({ workspaceLayout, isRouteFocused });
   const openWorkspaceTabInBackground = useWorkspaceLayoutStore(
@@ -1751,10 +1740,10 @@ function WorkspaceScreenContent({
   const focusedPaneTabState = useMemo(
     () =>
       deriveWorkspacePaneState({
-        layout: renderWorkspaceLayout,
+        layout: workspaceLayout,
         tabs: uiTabs,
       }),
-    [renderWorkspaceLayout, uiTabs],
+    [uiTabs, workspaceLayout],
   );
   const setFocusedAgentId = useSessionStore((state) => state.setFocusedAgentId);
   const focusedPaneAgentId = useMemo(() => {
@@ -3105,12 +3094,12 @@ function WorkspaceScreenContent({
     [isFocusModeEnabled, isMobile],
   );
   const desktopContent = useMemo(() => {
-    if (!canRenderDesktopPaneSplits || !renderWorkspaceLayout || !persistenceKey) {
+    if (!canRenderDesktopPaneSplits || !workspaceLayout || !persistenceKey) {
       return content;
     }
     return (
       <SplitContainer
-        layout={renderWorkspaceLayout}
+        layout={workspaceLayout}
         focusModeEnabled={desktopFocusModeEnabled}
         workspaceKey={persistenceKey}
         normalizedServerId={normalizedServerId}
@@ -3146,7 +3135,7 @@ function WorkspaceScreenContent({
   }, [
     content,
     canRenderDesktopPaneSplits,
-    renderWorkspaceLayout,
+    workspaceLayout,
     persistenceKey,
     desktopFocusModeEnabled,
     normalizedServerId,

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -68,6 +68,7 @@ import { useSessionStore, type WorkspaceDescriptor } from "@/stores/session-stor
 import {
   buildWorkspaceTabPersistenceKey,
   collectAllTabs,
+  createDefaultLayout,
   getFocusedBrowserId,
   type WorkspaceLayout,
   useWorkspaceLayoutStore,
@@ -1673,14 +1674,24 @@ function WorkspaceScreenContent({
     persistenceKey ? (state.layoutByWorkspace[persistenceKey] ?? null) : null,
   );
   const hasHydratedWorkspaceLayoutStore = useWorkspaceLayoutStoreHydrated();
+  const defaultWorkspaceLayout = useMemo(() => createDefaultLayout(), []);
+  // The desktop split container owns the tab row. Once persistence has hydrated,
+  // render a default layout even before the first workspace action stores one.
+  const renderWorkspaceLayout = useMemo(
+    () =>
+      hasHydratedWorkspaceLayoutStore
+        ? (workspaceLayout ?? defaultWorkspaceLayout)
+        : workspaceLayout,
+    [defaultWorkspaceLayout, hasHydratedWorkspaceLayoutStore, workspaceLayout],
+  );
   const workspaceSetupSnapshot = useWorkspaceSetupStore((state) =>
     persistenceKey ? (state.snapshots[persistenceKey] ?? null) : null,
   );
   const upsertWorkspaceSetupProgress = useWorkspaceSetupStore((state) => state.upsertProgress);
   const showWorkspaceSetup = shouldShowWorkspaceSetup(workspaceSetupSnapshot);
   const uiTabs = useMemo(
-    () => (workspaceLayout ? collectAllTabs(workspaceLayout.root) : EMPTY_UI_TABS),
-    [workspaceLayout],
+    () => (renderWorkspaceLayout ? collectAllTabs(renderWorkspaceLayout.root) : EMPTY_UI_TABS),
+    [renderWorkspaceLayout],
   );
   useSyncWorkspaceActiveBrowser({ workspaceLayout, isRouteFocused });
   const openWorkspaceTabInBackground = useWorkspaceLayoutStore(
@@ -1740,10 +1751,10 @@ function WorkspaceScreenContent({
   const focusedPaneTabState = useMemo(
     () =>
       deriveWorkspacePaneState({
-        layout: workspaceLayout,
+        layout: renderWorkspaceLayout,
         tabs: uiTabs,
       }),
-    [uiTabs, workspaceLayout],
+    [renderWorkspaceLayout, uiTabs],
   );
   const setFocusedAgentId = useSessionStore((state) => state.setFocusedAgentId);
   const focusedPaneAgentId = useMemo(() => {
@@ -3094,12 +3105,12 @@ function WorkspaceScreenContent({
     [isFocusModeEnabled, isMobile],
   );
   const desktopContent = useMemo(() => {
-    if (!canRenderDesktopPaneSplits || !workspaceLayout || !persistenceKey) {
+    if (!canRenderDesktopPaneSplits || !renderWorkspaceLayout || !persistenceKey) {
       return content;
     }
     return (
       <SplitContainer
-        layout={workspaceLayout}
+        layout={renderWorkspaceLayout}
         focusModeEnabled={desktopFocusModeEnabled}
         workspaceKey={persistenceKey}
         normalizedServerId={normalizedServerId}
@@ -3135,7 +3146,7 @@ function WorkspaceScreenContent({
   }, [
     content,
     canRenderDesktopPaneSplits,
-    workspaceLayout,
+    renderWorkspaceLayout,
     persistenceKey,
     desktopFocusModeEnabled,
     normalizedServerId,


### PR DESCRIPTION
Summary:
- Show each changed file's workspace-relative path in the diff file header tooltip.
- Use the app's React Native Tooltip instead of relying on DOM title attributes.
- Keep the tooltip desktop/web-only so mobile header taps only expand and collapse files.

Tests:
- npm run format:files -- packages/app/src/git/diff-pane.tsx
- npm run typecheck
- npm run lint -- packages/app/src/git/diff-pane.tsx
- npm run lint