### PR TITLE
Add Kiro CLI to ACP provider catalog

### DIFF
--- a/packages/app/src/components/provider-icons.ts
+++ b/packages/app/src/components/provider-icons.ts
@@ -1,4 +1,4 @@
-import { Bot } from "lucide-react-native";
+import { Bot, PackagePlus } from "lucide-react-native";
 import { ClaudeIcon } from "@/components/icons/claude-icon";
 import { CodexIcon } from "@/components/icons/codex-icon";
 import { CopilotIcon } from "@/components/icons/copilot-icon";
@@ -9,6 +9,7 @@ const PROVIDER_ICONS: Record<string, typeof Bot> = {
   claude: ClaudeIcon as unknown as typeof Bot,
   codex: CodexIcon as unknown as typeof Bot,
   copilot: CopilotIcon as unknown as typeof Bot,
+  kiro: PackagePlus,
   opencode: OpenCodeIcon as unknown as typeof Bot,
   pi: PiIcon as unknown as typeof Bot,
 };

--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -241,6 +241,15 @@ const CATALOG_DATA = [
     command: ["kilo", "acp"],
   },
   {
+    id: "kiro",
+    title: "Kiro CLI",
+    description: "Amazon's AI coding agent with native ACP support",
+    version: "manual",
+    iconId: null,
+    installLink: "https://kiro.dev/docs/cli/acp/",
+    command: ["kiro-cli", "acp"],
+  },
+  {
     id: "kimi",
     title: "Kimi CLI",
     description: "Moonshot AI's coding assistant",

--- a/packages/app/src/hooks/use-acp-provider-catalog.test.ts
+++ b/packages/app/src/hooks/use-acp-provider-catalog.test.ts
@@ -26,7 +26,7 @@ describe("ACP provider catalog", () => {
   });
 
   it("bundles SVG icons for catalog entries that declare an icon", () => {
-    const entriesWithIcons = ACP_PROVIDER_CATALOG.filter((entry) => entry.id !== "hermes");
+    const entriesWithIcons = ACP_PROVIDER_CATALOG.filter((entry) => entry.iconSvg !== null);
 
     expect(entriesWithIcons.length).toBeGreaterThan(0);
     for (const entry of entriesWithIcons) {
@@ -39,6 +39,7 @@ describe("ACP provider catalog", () => {
     expect(findProvider("cursor").command).toEqual(["cursor-agent", "acp"]);
     expect(findProvider("goose").command).toEqual(["goose", "acp"]);
     expect(findProvider("junie").command).toEqual(["junie", "--acp", "true"]);
+    expect(findProvider("kiro").command).toEqual(["kiro-cli", "acp"]);
     expect(findProvider("poolside").command).toEqual(["pool", "acp"]);
   });
 

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1438,6 +1438,26 @@ describe("ACPAgentSession slash commands", () => {
 });
 
 describe("ACPAgentSession", () => {
+  test("accepts ACP extension notifications without failing the JSON-RPC connection", async () => {
+    const logger = createTestLogger();
+    const trace = vi.spyOn(logger, "trace");
+    const session = createSessionWithConfig({ provider: "kiro" }, logger);
+
+    await expect(
+      session.extNotification("_kiro.dev/session/initialized", {
+        sessionId: "session-1",
+      }),
+    ).resolves.toBeUndefined();
+    expect(trace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "kiro",
+        method: "_kiro.dev/session/initialized",
+        sessionId: "session-1",
+      }),
+      "provider.acp.extension_notification",
+    );
+  });
+
   test("emits assistant and reasoning chunks as deltas while user chunks stay accumulated", async () => {
     const session = createSession();
     const events: Array<{ type: string; item?: { type: string; text?: string } }> = [];

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1667,6 +1667,19 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
+  async extNotification(method: string, params: Record<string, unknown>): Promise<void> {
+    this.logger.trace(
+      {
+        agentId: this.agentId,
+        provider: this.provider,
+        sessionId: typeof params.sessionId === "string" ? params.sessionId : undefined,
+        method,
+        rawEvent: params,
+      },
+      "provider.acp.extension_notification",
+    );
+  }
+
   async readTextFile(params: ReadTextFileRequest): Promise<{ content: string }> {
     const raw = await fs.readFile(params.path, "utf8");
     if (!params.line && !params.limit) {


### PR DESCRIPTION
## Summary

- Add Kiro CLI as an opt-in ACP provider catalog entry using `kiro-cli acp`
- Keep Kiro out of the default built-in provider list
- Handle generic ACP extension notifications so vendor-specific notifications do not fail JSON-RPC
- Use the existing generic provider icon fallback for Kiro

## Testing

- `npx vitest run packages/app/src/hooks/use-acp-provider-catalog.test.ts packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1`
- `npm run lint -- packages/app/src/components/provider-icons.ts packages/app/src/data/acp-provider-catalog.ts packages/app/src/hooks/use-acp-provider-catalog.test.ts packages/server/src/server/agent/providers/acp-agent.ts packages/server/src/server/agent/providers/acp-agent.test.ts`
- `npm run format:check:files -- packages/app/src/components/provider-icons.ts packages/app/src/data/acp-provider-catalog.ts packages/app/src/hooks/use-acp-provider-catalog.test.ts packages/server/src/server/agent/providers/acp-agent.ts packages/server/src/server/agent/providers/acp-agent.test.ts`
- `npm run typecheck --workspace=@getpaseo/app`
- `npm run typecheck:daemon`
