### PR TITLE
Stabilize mobile sidebar close test

### DIFF
--- a/packages/app/e2e/helpers/sidebar.ts
+++ b/packages/app/e2e/helpers/sidebar.ts
@@ -24,9 +24,10 @@ export async function openMobileAgentSidebar(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Open menu" }).click();
 }
 
-// force=true: the overlay covers the button when the mobile sidebar is open.
 export async function closeMobileAgentSidebar(page: Page): Promise<void> {
-  await page.getByRole("button", { name: "Close menu" }).click({ force: true });
+  const closeButton = page.getByTestId("sidebar-close");
+  await expect(closeButton).toBeInViewport({ timeout: 5_000 });
+  await closeButton.click({ force: true });
 }
 
 // The mobile sidebar panel animates via translateX; toBeInViewport reflects the rendered position.


### PR DESCRIPTION
### Linked issue



### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Stabilizes the mobile sidebar Playwright helper by closing the overlay through the real `sidebar-close` control after it has entered the viewport.

The test keeps the same semantics: open the mobile agent sidebar, assert it becomes visible, close it, and assert it leaves the viewport. The previous helper could resolve the covered page header menu button instead of the overlay close button, and could race the sidebar opening animation.

### How did you verify it

Reproduced before the fix:

- `npm run test:e2e --workspace=@getpaseo/app -- e2e/sidebar-workspace.spec.ts -g "showMobileAgent open and close transition" --repeat-each=10 --workers=1 --reporter=line`
- Observed repeated failures on `expect(page.getByTestId("sidebar-sessions")).not.toBeInViewport()` after clicking `Close menu`.

Confirmed after the fix:

- `npm run test:e2e --workspace=@getpaseo/app -- e2e/sidebar-workspace.spec.ts -g "showMobileAgent open and close transition" --repeat-each=10 --workers=1 --reporter=line` passed 10/10
- `npm run lint -- packages/app/e2e/helpers/sidebar.ts` passed
- `npm run typecheck` passed
- `npm run format` ran

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
