### PR TITLE
Fix Codex sub-agent failure projection from child state

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -1352,6 +1352,40 @@ describe("Codex app-server provider", () => {
     });
   });
 
+  test("does not synthesize a parent sub-agent failure from child error state alone", () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "collabAgentToolCall",
+        id: "call-sub-agent-transient-child-error",
+        tool: "spawnAgent",
+        status: "completed",
+        prompt: "Validate the child agent result.",
+        receiverThreadIds: ["child-thread-1"],
+        agentsStates: {
+          "child-thread-1": { status: "error", message: "Sub-agent failed" },
+        },
+      },
+    });
+
+    expect(events.at(-1)?.item).toMatchObject({
+      type: "tool_call",
+      callId: "call-sub-agent-transient-child-error",
+      name: "Sub-agent",
+      status: "running",
+      error: null,
+      detail: {
+        type: "sub_agent",
+        subAgentType: "Sub-agent",
+        description: "Validate the child agent result.",
+      },
+    });
+  });
+
   test("loads Codex persisted history from the app-server thread", async () => {
     const session = createSession();
     const requests: Array<{ method: string; params: unknown }> = [];

--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
@@ -212,6 +212,64 @@ describe("codex tool-call mapper", () => {
     });
   });
 
+  it("does not fail a collabAgentToolCall from child error state alone", () => {
+    const item = mapCodexToolCallFromThreadItem({
+      type: "collabAgentToolCall",
+      id: "call-sub-agent-transient-child-error",
+      tool: "spawnAgent",
+      status: "completed",
+      prompt: "Inspect the Codex stream path.",
+      receiverThreadIds: ["child-thread-1"],
+      agentsStates: {
+        "child-thread-1": { status: "error", message: "Sub-agent failed" },
+      },
+    });
+
+    expect(item).toEqual({
+      type: "tool_call",
+      callId: "call-sub-agent-transient-child-error",
+      name: "Sub-agent",
+      status: "running",
+      error: null,
+      detail: {
+        type: "sub_agent",
+        subAgentType: "Sub-agent",
+        description: "Inspect the Codex stream path.",
+        log: "",
+        actions: [],
+      },
+    });
+  });
+
+  it("still fails a collabAgentToolCall from an explicitly failed child state", () => {
+    const item = mapCodexToolCallFromThreadItem({
+      type: "collabAgentToolCall",
+      id: "call-sub-agent-child-failed",
+      tool: "spawnAgent",
+      status: "completed",
+      prompt: "Inspect the Codex stream path.",
+      receiverThreadIds: ["child-thread-1"],
+      agentsStates: {
+        "child-thread-1": { status: "failed", message: "Child failed" },
+      },
+    });
+
+    expect(item).toEqual({
+      type: "tool_call",
+      callId: "call-sub-agent-child-failed",
+      name: "Sub-agent",
+      status: "failed",
+      error: { message: "Sub-agent failed" },
+      detail: {
+        type: "sub_agent",
+        subAgentType: "Sub-agent",
+        description: "Inspect the Codex stream path.",
+        log: "",
+        actions: [],
+      },
+    });
+  });
+
   it("maps mcp read_file completion with detail", () => {
     const item = mapCodexToolCallFromThreadItem(
       {

--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
@@ -544,6 +544,14 @@ function readStatus(value: unknown): string | undefined {
   return typeof value.status === "string" ? value.status : undefined;
 }
 
+function normalizeCollabAgentChildStatus(status: string): ToolCallTimelineItem["status"] {
+  const normalized = status.trim().toLowerCase();
+  if (normalized === "error" || normalized === "errored") {
+    return "running";
+  }
+  return normalizeToolCallStatus(status, null, null);
+}
+
 function resolveCollabAgentStatus(
   item: z.infer<typeof CodexCollabAgentToolCallItemSchema>,
 ): ToolCallTimelineItem["status"] {
@@ -551,10 +559,15 @@ function resolveCollabAgentStatus(
     return "failed";
   }
 
+  const parentStatus = normalizeToolCallStatus(item.status, null, null);
+  if (parentStatus === "failed") {
+    return "failed";
+  }
+
   const childStatuses = Object.values(item.agentsStates ?? {})
     .map(readStatus)
     .filter((status): status is string => typeof status === "string" && status.trim().length > 0)
-    .map((status) => normalizeToolCallStatus(status, null, null));
+    .map(normalizeCollabAgentChildStatus);
 
   if (childStatuses.some((status) => status === "failed")) {
     return "failed";
@@ -566,7 +579,7 @@ function resolveCollabAgentStatus(
     return childStatuses.every((status) => status === "completed") ? "completed" : "running";
   }
 
-  return normalizeToolCallStatus(item.status, item.error ?? null, null);
+  return parentStatus;
 }
 
 function buildMcpToolName(server: string | undefined, tool: string): string {


### PR DESCRIPTION
### Linked issue

Closes #1071

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Prevents a Codex parent Sub-agent item from being marked failed solely because a child `agentsStates` entry has a generic `error` or `errored` status.

The parent still fails when the parent call has an explicit error, the parent call status itself is failed, or a child state is explicitly `failed`. Child canceled/completed/running behavior is preserved.

This PR is scoped to the Codex provider. I did not change or test Claude Code or OpenCode behavior.

### How did you verify it

```bash
npm ci --ignore-scripts
# added 2710 packages

npm run build --workspace=@getpaseo/highlight
# passed

npm run typecheck --workspace=@getpaseo/server
# passed

node node_modules/vitest/vitest.mjs run packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
# 2 files passed, 97 tests passed

npm run format:files -- packages/server/src/server/agent/providers/codex/tool-call-mapper.ts packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
# passed

npm run lint
# Found 0 warnings and 0 errors.
```

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
