### PR TITLE
feat(push): add ServerChan notifications

### DIFF
--- a/packages/server/src/server/push/notifications.test.ts
+++ b/packages/server/src/server/push/notifications.test.ts
@@ -1,0 +1,51 @@
+import type pino from "pino";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createPushNotificationSender } from "./notifications.js";
+import type { PushTokenStore } from "./token-store.js";
+
+function createLogger(): pino.Logger {
+  const logger = {
+    child: () => logger,
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+  return logger as unknown as pino.Logger;
+}
+
+function createTokenStore(tokens: string[]): PushTokenStore {
+  return {
+    getAllTokens: () => tokens,
+    removeToken: vi.fn(),
+  } as unknown as PushTokenStore;
+}
+
+describe("createPushNotificationSender", () => {
+  const originalSendKey = process.env["PASEO_SERVERCHAN_SENDKEY"];
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    if (originalSendKey === undefined) {
+      delete process.env["PASEO_SERVERCHAN_SENDKEY"];
+    } else {
+      process.env["PASEO_SERVERCHAN_SENDKEY"] = originalSendKey;
+    }
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test("sends ServerChan notification even when there are no Expo push tokens", async () => {
+    process.env["PASEO_SERVERCHAN_SENDKEY"] = "SCT123";
+    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+    globalThis.fetch = fetchImpl as unknown as typeof fetch;
+    const sender = createPushNotificationSender(createLogger(), createTokenStore([]));
+
+    await sender.send({ title: "Agent finished", body: "Done." });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://sctapi.ftqq.com/SCT123.send");
+    expect(init.body).toBeInstanceOf(URLSearchParams);
+    expect((init.body as URLSearchParams).get("title")).toBe("Agent finished");
+  });
+});

--- a/packages/server/src/server/push/notifications.ts
+++ b/packages/server/src/server/push/notifications.ts
@@ -1,6 +1,7 @@
 import type pino from "pino";
 
 import { PushService, type PushPayload } from "./push-service.js";
+import { ServerChanService } from "./serverchan-service.js";
 import type { PushTokenStore } from "./token-store.js";
 
 export type { PushPayload };
@@ -14,9 +15,15 @@ export function createPushNotificationSender(
   tokenStore: PushTokenStore,
 ): PushNotificationSender {
   const pushService = new PushService(logger, tokenStore);
+  const serverChanService = new ServerChanService(logger);
 
   return {
     async send(payload) {
+      if (serverChanService.enabled) {
+        logger.info("Sending ServerChan notification");
+        await serverChanService.send(payload);
+      }
+
       const tokens = tokenStore.getAllTokens();
       logger.info({ tokenCount: tokens.length }, "Sending push notification");
       if (tokens.length === 0) {

--- a/packages/server/src/server/push/notifications.ts
+++ b/packages/server/src/server/push/notifications.ts
@@ -6,8 +6,14 @@ import type { PushTokenStore } from "./token-store.js";
 
 export type { PushPayload };
 
+export interface PushNotificationSendOptions {
+  expo?: boolean;
+  serverChan?: boolean;
+}
+
 export interface PushNotificationSender {
-  send(payload: PushPayload): Promise<void>;
+  readonly serverChanEnabled?: boolean;
+  send(payload: PushPayload, options?: PushNotificationSendOptions): Promise<void>;
 }
 
 export function createPushNotificationSender(
@@ -18,10 +24,18 @@ export function createPushNotificationSender(
   const serverChanService = new ServerChanService(logger);
 
   return {
-    async send(payload) {
-      if (serverChanService.enabled) {
+    serverChanEnabled: serverChanService.enabled,
+    async send(payload, options = {}) {
+      const shouldSendServerChan = options.serverChan ?? true;
+      const shouldSendExpo = options.expo ?? true;
+
+      if (shouldSendServerChan && serverChanService.enabled) {
         logger.info("Sending ServerChan notification");
         await serverChanService.send(payload);
+      }
+
+      if (!shouldSendExpo) {
+        return;
       }
 
       const tokens = tokenStore.getAllTokens();

--- a/packages/server/src/server/push/serverchan-service.test.ts
+++ b/packages/server/src/server/push/serverchan-service.test.ts
@@ -1,0 +1,58 @@
+import type pino from "pino";
+import { describe, expect, test, vi } from "vitest";
+
+import { ServerChanService } from "./serverchan-service.js";
+
+function createLogger(): pino.Logger {
+  const logger = {
+    child: () => logger,
+    warn: vi.fn(),
+  };
+  return logger as unknown as pino.Logger;
+}
+
+describe("ServerChanService", () => {
+  test("skips sending when no send key is configured", async () => {
+    const fetchImpl = vi.fn();
+    const service = new ServerChanService(createLogger(), { sendKey: "", fetchImpl });
+
+    await service.send({ title: "Agent finished", body: "Done." });
+
+    expect(service.enabled).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test("sends ServerChan form payload when configured", async () => {
+    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+    const service = new ServerChanService(createLogger(), {
+      sendKey: "SCT123",
+      fetchImpl,
+    });
+
+    await service.send({ title: "Agent finished", body: "Done." });
+
+    expect(service.enabled).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://sctapi.ftqq.com/SCT123.send");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+    });
+    expect(init.body).toBeInstanceOf(URLSearchParams);
+    const body = init.body as URLSearchParams;
+    expect(body.get("title")).toBe("Agent finished");
+    expect(body.get("desp")).toBe("Done.");
+    expect(body.get("short")).toBe("Done.");
+  });
+
+  test("logs and swallows ServerChan failures", async () => {
+    const logger = createLogger();
+    const fetchImpl = vi.fn(async () => new Response("bad", { status: 500 }));
+    const service = new ServerChanService(logger, { sendKey: "SCT123", fetchImpl });
+
+    await expect(service.send({ title: "Agent finished", body: "Done." })).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/server/push/serverchan-service.ts
+++ b/packages/server/src/server/push/serverchan-service.ts
@@ -1,0 +1,71 @@
+import type pino from "pino";
+
+import type { PushPayload } from "./push-service.js";
+
+const SERVERCHAN_BASE_URL = "https://sctapi.ftqq.com";
+const SERVERCHAN_SEND_TIMEOUT_MS = 10_000;
+
+export interface ServerChanOptions {
+  sendKey?: string | null;
+  fetchImpl?: typeof fetch;
+}
+
+export class ServerChanService {
+  private readonly logger: pino.Logger;
+  private readonly sendKey: string | null;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(logger: pino.Logger, options: ServerChanOptions = {}) {
+    this.logger = logger.child({ component: "serverchan-service" });
+    this.sendKey = normalizeSendKey(options.sendKey ?? process.env["PASEO_SERVERCHAN_SENDKEY"]);
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  get enabled(): boolean {
+    return this.sendKey !== null;
+  }
+
+  async send(payload: PushPayload): Promise<void> {
+    if (!this.sendKey) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), SERVERCHAN_SEND_TIMEOUT_MS);
+
+    try {
+      const response = await this.fetchImpl(`${SERVERCHAN_BASE_URL}/${this.sendKey}.send`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        },
+        body: encodePayload(payload),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        this.logger.warn(
+          { status: response.status, statusText: response.statusText },
+          "ServerChan notification failed",
+        );
+      }
+    } catch (error) {
+      this.logger.warn({ err: error }, "Failed to send ServerChan notification");
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function normalizeSendKey(sendKey: string | null | undefined): string | null {
+  const normalized = sendKey?.trim();
+  return normalized ? normalized : null;
+}
+
+function encodePayload(payload: PushPayload): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("title", payload.title);
+  params.set("desp", payload.body);
+  params.set("short", payload.body);
+  return params;
+}

--- a/packages/server/src/server/websocket-server.notifications.test.ts
+++ b/packages/server/src/server/websocket-server.notifications.test.ts
@@ -66,14 +66,24 @@ function createLogger() {
 
 class RecordingPushNotificationSender implements PushNotificationSender {
   readonly sent: PushPayload[] = [];
+  readonly options: Array<Parameters<PushNotificationSender["send"]>[1]> = [];
 
-  async send(payload: PushPayload): Promise<void> {
+  constructor(readonly serverChanEnabled = false) {}
+
+  async send(
+    payload: PushPayload,
+    options?: Parameters<PushNotificationSender["send"]>[1],
+  ): Promise<void> {
     this.sent.push(payload);
+    this.options.push(options);
   }
 }
 
-function createServer(agentManagerOverrides?: Record<string, unknown>) {
-  const pushNotifications = new RecordingPushNotificationSender();
+function createServer(
+  agentManagerOverrides?: Record<string, unknown>,
+  options: { serverChanEnabled?: boolean } = {},
+) {
+  const pushNotifications = new RecordingPushNotificationSender(options.serverChanEnabled);
   const agentManager = {
     setAgentAttentionCallback: vi.fn(),
     getAgent: vi.fn(() => null),
@@ -285,6 +295,26 @@ describe("VoiceAssistantWebSocketServer notification payloads", () => {
     expect(readAttentionRequiredMessage(electronWs).shouldNotify).toBe(true);
     expect(readAttentionRequiredMessage(firefoxWs).shouldNotify).toBe(false);
     expect(pushNotifications.sent).toEqual([]);
+  });
+
+  it("sends ServerChan when Expo push is suppressed by a present client", async () => {
+    const { server, pushNotifications } = createServer(undefined, { serverChanEnabled: true });
+    const nowMs = Date.now();
+    connectClient(server, {
+      deviceType: "mobile",
+      appVisible: true,
+      focusedAgentId: "agent-present",
+      lastActivityAt: new Date(nowMs - 5_000),
+    });
+
+    await asInternals<WebSocketServerInternals>(server).broadcastAgentAttention({
+      agentId: "agent-present",
+      provider: "claude",
+      reason: "finished",
+    });
+
+    expect(pushNotifications.sent).toHaveLength(1);
+    expect(pushNotifications.options).toEqual([{ expo: false, serverChan: true }]);
   });
 
   it("pushes non-error attention when the only connected client has never sent a heartbeat", async () => {

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1670,10 +1670,13 @@ export class VoiceAssistantWebSocketServer {
       nowMs,
     });
 
-    if (plan.shouldPush) {
-      void this.pushNotificationSender.send(notification).catch((err) => {
-        this.logger.warn({ err, agentId: params.agentId }, "Failed to send push notification");
-      });
+    const shouldSendServerChan = this.pushNotificationSender.serverChanEnabled === true;
+    if (plan.shouldPush || shouldSendServerChan) {
+      void this.pushNotificationSender
+        .send(notification, { expo: plan.shouldPush, serverChan: shouldSendServerChan })
+        .catch((err) => {
+          this.logger.warn({ err, agentId: params.agentId }, "Failed to send push notification");
+        });
     }
 
     for (const [clientIndex, { ws }] of clientEntries.entries()) {


### PR DESCRIPTION
## Summary

Adds optional ServerChan (Server酱) push notifications for agent completion events.

When `PASEO_SERVERCHAN_SENDKEY` is set, the server sends a ServerChan notification in addition to the existing Expo push flow. This gives users in environments where Expo/FCM push delivery is unreliable a server-side notification fallback without changing mobile client behavior.

## Behavior

- Uses `PASEO_SERVERCHAN_SENDKEY` as the opt-in configuration switch.
- Sends ServerChan notifications even when no Expo push tokens are registered.
- Keeps the existing Expo push token flow intact.
- Logs and swallows ServerChan failures so notification delivery cannot interrupt agent lifecycle handling.

## Validation

- `rtk npx --yes oxfmt@0.46.0 --check packages/server/src/server/push/notifications.ts packages/server/src/server/push/notifications.test.ts packages/server/src/server/push/serverchan-service.ts packages/server/src/server/push/serverchan-service.test.ts`
- `rtk npx --yes oxlint@1.61.0 packages/server/src/server/push/notifications.ts packages/server/src/server/push/notifications.test.ts packages/server/src/server/push/serverchan-service.ts packages/server/src/server/push/serverchan-service.test.ts`
- `rtk git diff --check`

Full Vitest/typecheck were not run in this checkout because the workspace install currently fails on local dependency resolution issues unrelated to this change.
