### PR TITLE
fix(terminal): send SIGINT for hardware Ctrl+C on iPad (#1049)

### DIFF
--- a/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
+++ b/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
@@ -15,6 +15,7 @@ import {
 } from "@server/shared/terminal-input-mode";
 import {
   type PendingTerminalModifiers,
+  isAppleHandheldPlatform,
   isTerminalModifierDomKey,
   mergeTerminalModifiers,
   normalizeDomTerminalKey,
@@ -83,6 +84,14 @@ const isMac =
   typeof navigator !== "undefined" &&
   (/Macintosh|Mac OS/i.test(navigator.userAgent ?? "") ||
     /Mac/i.test((navigator as Navigator & { platform?: string }).platform ?? ""));
+
+const isAppleHandheld =
+  typeof navigator !== "undefined" &&
+  isAppleHandheldPlatform({
+    userAgent: navigator.userAgent,
+    platform: (navigator as Navigator & { platform?: string }).platform,
+    maxTouchPoints: navigator.maxTouchPoints,
+  });
 
 const DEFAULT_TOUCH_SCROLL_LINE_HEIGHT_PX = 18;
 const FIT_TIMEOUT_DELAYS_MS = [0, 16, 48, 120, 250, 500, 1_000, 2_000];
@@ -365,6 +374,7 @@ export class TerminalEmulatorRuntime {
           metaKey: event.metaKey,
           pendingModifiers: this.pendingModifiers,
           enhancedInputActive: this.inputModeTracker.supportsModifiedEnter(),
+          isAppleHandheld,
         })
       ) {
         return true;

--- a/packages/app/src/utils/terminal-keys.test.ts
+++ b/packages/app/src/utils/terminal-keys.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   hasPendingTerminalModifiers,
+  isAppleHandheldPlatform,
   isTerminalModifierDomKey,
   mapTerminalDataToKey,
   mergeTerminalModifiers,
@@ -9,6 +10,13 @@ import {
   resolvePendingModifierDataInput,
   shouldInterceptDomTerminalKey,
 } from "./terminal-keys";
+
+const IPAD_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Safari/605.1.15";
+const MAC_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+const IPHONE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
 
 describe("terminal key helpers", () => {
   it("normalizes supported DOM keys", () => {
@@ -153,6 +161,140 @@ describe("terminal key helpers", () => {
         altKey: false,
         metaKey: false,
         pendingModifiers: { ctrl: false, shift: false, alt: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("intercepts plain Ctrl+C on iPad so xterm's keyCode-13 quirk never reaches the PTY (#1049)", () => {
+    // See COMPAT(xterm-ipad-ctrl-c) in terminal-keys.ts.
+    expect(
+      shouldInterceptDomTerminalKey({
+        key: "c",
+        ctrlKey: true,
+        shiftKey: false,
+        altKey: false,
+        metaKey: false,
+        pendingModifiers: { ctrl: false, shift: false, alt: false },
+        isAppleHandheld: true,
+      }),
+    ).toBe(true);
+    // Uppercase variant in case Caps Lock is on.
+    expect(
+      shouldInterceptDomTerminalKey({
+        key: "C",
+        ctrlKey: true,
+        shiftKey: false,
+        altKey: false,
+        metaKey: false,
+        pendingModifiers: { ctrl: false, shift: false, alt: false },
+        isAppleHandheld: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not intercept other Ctrl+letter combos on iPad (xterm handles them correctly)", () => {
+    for (const key of ["b", "d", "z", "a", "r", "l"]) {
+      expect(
+        shouldInterceptDomTerminalKey({
+          key,
+          ctrlKey: true,
+          shiftKey: false,
+          altKey: false,
+          metaKey: false,
+          pendingModifiers: { ctrl: false, shift: false, alt: false },
+          isAppleHandheld: true,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("does not intercept Ctrl+C on real macOS / Windows / Linux", () => {
+    expect(
+      shouldInterceptDomTerminalKey({
+        key: "c",
+        ctrlKey: true,
+        shiftKey: false,
+        altKey: false,
+        metaKey: false,
+        pendingModifiers: { ctrl: false, shift: false, alt: false },
+        isAppleHandheld: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not intercept Cmd+C on iPad (Cmd-based shortcuts stay with the OS)", () => {
+    expect(
+      shouldInterceptDomTerminalKey({
+        key: "c",
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        metaKey: true,
+        pendingModifiers: { ctrl: false, shift: false, alt: false },
+        isAppleHandheld: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not intercept Ctrl+Shift+C / Ctrl+Alt+C on iPad", () => {
+    // Only bare Ctrl+C is affected by the WebKit quirk; modified variants stay with xterm.
+    expect(
+      shouldInterceptDomTerminalKey({
+        key: "c",
+        ctrlKey: true,
+        shiftKey: true,
+        altKey: false,
+        metaKey: false,
+        pendingModifiers: { ctrl: false, shift: false, alt: false },
+        isAppleHandheld: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldInterceptDomTerminalKey({
+        key: "c",
+        ctrlKey: true,
+        shiftKey: false,
+        altKey: true,
+        metaKey: false,
+        pendingModifiers: { ctrl: false, shift: false, alt: false },
+        isAppleHandheld: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("detects iPad masquerading as macOS via maxTouchPoints", () => {
+    expect(
+      isAppleHandheldPlatform({ userAgent: IPAD_UA, platform: "MacIntel", maxTouchPoints: 5 }),
+    ).toBe(true);
+  });
+
+  it("detects iPhone/iPod by UA", () => {
+    expect(
+      isAppleHandheldPlatform({ userAgent: IPHONE_UA, platform: "iPhone", maxTouchPoints: 5 }),
+    ).toBe(true);
+  });
+
+  it("does not flag real macOS desktop as a handheld", () => {
+    expect(
+      isAppleHandheldPlatform({ userAgent: MAC_UA, platform: "MacIntel", maxTouchPoints: 0 }),
+    ).toBe(false);
+  });
+
+  it("does not flag macOS when maxTouchPoints == 1 (some trackpad contexts)", () => {
+    expect(
+      isAppleHandheldPlatform({ userAgent: MAC_UA, platform: "MacIntel", maxTouchPoints: 1 }),
+    ).toBe(false);
+  });
+
+  it("tolerates null/undefined navigator-style inputs", () => {
+    expect(isAppleHandheldPlatform({ userAgent: null, platform: null, maxTouchPoints: null })).toBe(
+      false,
+    );
+    expect(
+      isAppleHandheldPlatform({
+        userAgent: undefined,
+        platform: undefined,
+        maxTouchPoints: undefined,
       }),
     ).toBe(false);
   });

--- a/packages/app/src/utils/terminal-keys.ts
+++ b/packages/app/src/utils/terminal-keys.ts
@@ -82,6 +82,27 @@ export function hasPendingTerminalModifiers(modifiers: PendingTerminalModifiers)
   return modifiers.ctrl || modifiers.shift || modifiers.alt;
 }
 
+export interface AppleHandheldDetectionInput {
+  userAgent: string | null | undefined;
+  platform: string | null | undefined;
+  maxTouchPoints: number | null | undefined;
+}
+
+// iPadOS 13+ WKWebView reports navigator.platform="MacIntel" and a Mac UA string. Distinguish
+// iPad/iPhone from real macOS via maxTouchPoints, which is 0 on macOS and >1 on iPadOS/iOS.
+export function isAppleHandheldPlatform(input: AppleHandheldDetectionInput): boolean {
+  const userAgent = input.userAgent ?? "";
+  const platform = input.platform ?? "";
+  const touchPoints = input.maxTouchPoints ?? 0;
+  if (/iPad|iPhone|iPod/.test(userAgent)) {
+    return true;
+  }
+  if (/Mac/i.test(platform) && touchPoints > 1) {
+    return true;
+  }
+  return false;
+}
+
 export function shouldInterceptDomTerminalKey(args: {
   key: string;
   ctrlKey: boolean;
@@ -90,12 +111,26 @@ export function shouldInterceptDomTerminalKey(args: {
   metaKey: boolean;
   pendingModifiers: PendingTerminalModifiers;
   enhancedInputActive?: boolean;
+  isAppleHandheld?: boolean;
 }): boolean {
   if (hasPendingTerminalModifiers(args.pendingModifiers)) {
     return true;
   }
   if (args.key === "Enter" && (args.shiftKey || args.ctrlKey || args.altKey || args.metaKey)) {
     return Boolean(args.enhancedInputActive);
+  }
+  // COMPAT(xterm-ipad-ctrl-c): WebKit sends keyCode=13 for hardware-kbd Ctrl+C on iPad, so
+  // xterm.js 6.x emits \r instead of \x03. Fixed upstream in xtermjs/xterm.js#5742 (6.1.0-beta).
+  // Drop this branch and the isAppleHandheld plumbing once @xterm/xterm >= 6.1.0 stable.
+  if (
+    args.isAppleHandheld &&
+    args.ctrlKey &&
+    !args.metaKey &&
+    !args.altKey &&
+    !args.shiftKey &&
+    (args.key === "c" || args.key === "C")
+  ) {
+    return true;
   }
   return false;
 }

--- a/packages/app/src/utils/terminal-keys.ts
+++ b/packages/app/src/utils/terminal-keys.ts
@@ -82,7 +82,7 @@ export function hasPendingTerminalModifiers(modifiers: PendingTerminalModifiers)
   return modifiers.ctrl || modifiers.shift || modifiers.alt;
 }
 
-export interface AppleHandheldDetectionInput {
+interface AppleHandheldDetectionInput {
   userAgent: string | null | undefined;
   platform: string | null | undefined;
   maxTouchPoints: number | null | undefined;

--- a/packages/app/src/utils/terminal-keys.ts
+++ b/packages/app/src/utils/terminal-keys.ts
@@ -120,8 +120,8 @@ export function shouldInterceptDomTerminalKey(args: {
     return Boolean(args.enhancedInputActive);
   }
   // COMPAT(xterm-ipad-ctrl-c): WebKit sends keyCode=13 for hardware-kbd Ctrl+C on iPad, so
-  // xterm.js 6.x emits \r instead of \x03. Fixed upstream in xtermjs/xterm.js#5742 (6.1.0-beta).
-  // Drop this branch and the isAppleHandheld plumbing once @xterm/xterm >= 6.1.0 stable.
+  // xterm.js emits \r instead of \x03. Upstream: xtermjs/xterm.js#5721, targeting xterm.js 7.0.0.
+  // Drop this block and the isAppleHandheld plumbing once @xterm/xterm is bumped past it.
   if (
     args.isAppleHandheld &&
     args.ctrlKey &&


### PR DESCRIPTION
## Summary

- WebKit on iPad sends `keyCode 13` (Return) for hardware-kbd Ctrl+C, so xterm.js emits `\r` instead of `\x03` and the PTY treats it as Enter, not SIGINT.
- Workaround: detect iPad via `navigator.maxTouchPoints` (iPadOS lies about platform/UA) and route bare Ctrl+C through our daemon-side encoder so the PTY gets `\x03`. Other Ctrl+letter combos are unaffected.
- Upstream: [xtermjs/xterm.js#5721](https://github.com/xtermjs/xterm.js/issues/5721), targeting xterm.js 7.0.0. The new \`if\`-block is tagged \`// COMPAT(xterm-ipad-ctrl-c)\` per the repo convention — searching the codebase for that tag surfaces the workaround (and the \`isAppleHandheld\` plumbing) to remove when we bump xterm.

Fixes #1049.

## Test plan

- [x] \`npx vitest run packages/app/src/utils/terminal-keys.test.ts\` (24 passing — adds positive cases for c/C, negative for b/d/z/a/r/l, real macOS, Cmd+C, Ctrl+Shift+C, Ctrl+Alt+C, plus 5 platform-detection variants)
- [x] \`npm run typecheck\`
- [x] \`npm run lint -- <changed files>\`
- [x] Manual repro on iPad Pro 11" M5 sim (iPadOS 26.5) with Mac hardware kbd — \`sleep 30\` + Ctrl+C now interrupts; was advancing a new prompt line before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)