### PR TITLE
fix(server): render non-ASCII filenames in git output

### DIFF
--- a/packages/server/src/utils/checkout-git-batching.test.ts
+++ b/packages/server/src/utils/checkout-git-batching.test.ts
@@ -16,8 +16,12 @@ vi.mock("child_process", async () => {
       const [command, commandArgs] = args;
       if (command === "git" && Array.isArray(commandArgs)) {
         const normalizedArgs = commandArgs.map((arg) => String(arg));
+        // `runGitCommand` always prepends `-c core.quotepath=false`; skip it to
+        // find the actual git subcommand.
+        const subcommandIndex =
+          normalizedArgs[0] === "-c" && normalizedArgs[1] === "core.quotepath=false" ? 2 : 0;
         const isTrackedTextDiff =
-          normalizedArgs[0] === "diff" &&
+          normalizedArgs[subcommandIndex] === "diff" &&
           normalizedArgs.includes("HEAD") &&
           !normalizedArgs.includes("--numstat") &&
           !normalizedArgs.includes("--no-index") &&

--- a/packages/server/src/utils/run-git-command.ts
+++ b/packages/server/src/utils/run-git-command.ts
@@ -77,7 +77,9 @@ export function runGitCommand(
           logger.trace(traceContext, "Spawning git command");
         }
 
-        const child = spawnProcess("git", args, {
+        // `core.quotepath=false` makes git emit raw UTF-8 paths instead of
+        // octal-escaping non-ASCII bytes (e.g. `测试文件.txt` vs `"\346\265\213..."`).
+        const child = spawnProcess("git", ["-c", "core.quotepath=false", ...args], {
           cwd: options.cwd,
           envOverlay,
           shell: false,


### PR DESCRIPTION
Fixes #436

## Summary

Git defaults to `core.quotepath=true`, which escapes non-ASCII bytes in path output as `\NNN` octal sequences (e.g. `"\346\265\213\350\257\225..."`). The daemon's `--name-status` / `--porcelain` / `ls-files` parsers split on TAB or newline and don't unwrap that form, so non-ASCII filenames render broken in the changes panel.

Prepending `-c core.quotepath=false` at the `runGitCommand` choke point makes git emit raw UTF-8 paths instead. Same approach GitLens uses for the same reason: [vscode-gitlens/packages/git-cli/src/exec/git.ts#L715](https://github.com/gitkraken/vscode-gitlens/blob/main/packages/git-cli/src/exec/git.ts#L715).

<img width="641" height="69" alt="Screenshot 2026-05-17 at 23 45 09" src="https://github.com/user-attachments/assets/b9b59668-9f97-49eb-a885-188de044f8eb" />

