### PR TITLE
Fix CLI/daemon environment inconsistency in `daemon status` and `daemon pair` commands

### DIFF
--- a/docs/rpc-namespacing.md
+++ b/docs/rpc-namespacing.md
@@ -11,7 +11,7 @@ The namespace reads left to right:
 
 - Domain: `checkout`
 - Provider or subsystem: `github`
-- Operation: `set_auto_merge`
+- Operation: `set_auto_merge`; this segment is a verb, not a noun. If you would name an RPC `noun.request`, name it `get_noun.request` instead.
 - Direction: `request` or `response`
 
 Use dots, not slashes. Dots are protocol namespaces; slashes imply paths or transport routing.

--- a/packages/cli/src/commands/daemon/local-daemon.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.ts
@@ -395,6 +395,11 @@ export function resolveLocalDaemonState(options: { home?: string } = {}): LocalD
     PASEO_LISTEN: undefined,
     PASEO_HOSTNAMES: undefined,
     PASEO_ALLOWED_HOSTS: undefined,
+    PASEO_RELAY_ENABLED: undefined,
+    PASEO_RELAY_ENDPOINT: undefined,
+    PASEO_RELAY_PUBLIC_ENDPOINT: undefined,
+    PASEO_RELAY_USE_TLS: undefined,
+    PASEO_RELAY_PUBLIC_USE_TLS: undefined,
   };
   const home = resolvePaseoHome(env);
   const config = loadConfig(home, { env });

--- a/packages/cli/src/commands/daemon/local-daemon.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.ts
@@ -392,6 +392,7 @@ export function resolveLocalDaemonState(options: { home?: string } = {}): LocalD
   const env: NodeJS.ProcessEnv = {
     ...envWithHome(options.home),
     // Status should reflect local persisted config + pid file, not inherited daemon env overrides.
+    // This is CLI-side defensive scrubbing; the daemon RPC is authoritative when available.
     PASEO_LISTEN: undefined,
     PASEO_HOSTNAMES: undefined,
     PASEO_ALLOWED_HOSTS: undefined,

--- a/packages/cli/src/commands/daemon/pair.ts
+++ b/packages/cli/src/commands/daemon/pair.ts
@@ -1,6 +1,8 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { generateLocalPairingOffer, loadConfig, resolvePaseoHome } from "@getpaseo/server";
+import { tryConnectToDaemon } from "../../utils/client.js";
+import { resolveLocalDaemonState, resolveTcpHostFromListen } from "./local-daemon.js";
 import { addJsonOption } from "../../utils/command-options.js";
 
 interface PairOptions {
@@ -22,6 +24,33 @@ export async function runPairCommand(options: PairOptions): Promise<void> {
   }
 
   const paseoHome = resolvePaseoHome();
+  const state = resolveLocalDaemonState({ home: paseoHome });
+  const host = resolveTcpHostFromListen(state.listen);
+
+  // Try to get the pairing offer from the running daemon first.
+  if (host) {
+    const client = await tryConnectToDaemon({ host, timeout: 1500 });
+    if (client) {
+      const supportsDaemonStatusRpc =
+        client.getLastServerInfoMessage()?.features?.daemonStatusRpc === true;
+      if (supportsDaemonStatusRpc) {
+        try {
+          const offer = await client.getDaemonPairingOffer();
+          await client.close().catch(() => {});
+          outputPairingResult(
+            { relayEnabled: offer.relayEnabled, url: offer.url, qr: offer.qr ?? null },
+            options,
+          );
+          return;
+        } catch {
+          // Fall through to local generation
+        }
+      }
+      await client.close().catch(() => {});
+    }
+  }
+
+  // Fall back to local pairing offer generation.
   const config = loadConfig(paseoHome);
   const pairing = await generateLocalPairingOffer({
     paseoHome,
@@ -34,6 +63,13 @@ export async function runPairCommand(options: PairOptions): Promise<void> {
     includeQr: true,
   });
 
+  outputPairingResult(pairing, options);
+}
+
+function outputPairingResult(
+  pairing: { relayEnabled: boolean; url: string | null; qr: string | null },
+  options: PairOptions,
+): void {
   if (!pairing.relayEnabled || !pairing.url) {
     console.error(chalk.red("Relay pairing is disabled for this daemon config."));
     console.error(chalk.yellow("Enable relay and run this command again."));

--- a/packages/cli/src/commands/daemon/pair.ts
+++ b/packages/cli/src/commands/daemon/pair.ts
@@ -43,7 +43,9 @@ export async function runPairCommand(options: PairOptions): Promise<void> {
           );
           return;
         } catch {
-          // Fall through to local generation
+          // COMPAT(daemon-rpc-rollout): fall back to CLI-side pairing generation while
+          // old daemons lack daemonStatusRpc. Remove once the daemon floor is past
+          // v0.1.76; pairing should come from daemon.get_pairing_offer.
         }
       }
       await client.close().catch(() => {});

--- a/packages/cli/src/commands/daemon/status.ts
+++ b/packages/cli/src/commands/daemon/status.ts
@@ -10,6 +10,7 @@ interface ProviderBinaryStatus {
   label: string;
   path: string | null;
   version: string | null;
+  source?: "daemon" | "local";
 }
 
 interface DaemonStatus {
@@ -99,7 +100,7 @@ function createStatusSchema(status: DaemonStatus): OutputSchema<StatusRow> {
             return "red";
           }
           if (item.key.startsWith("  ")) {
-            if (item.value === "not found") return "red";
+            if (item.value === "not found" || item.value === "not found (daemon)") return "red";
             if (item.value.endsWith("(--version failed)")) return "yellow";
             return "green";
           }
@@ -149,7 +150,13 @@ function toStatusRows(status: DaemonStatus): StatusRow[] {
   rows.push({ key: "", value: "" });
   rows.push({ key: "Providers", value: "" });
   for (const provider of status.providers) {
-    if (!provider.path) {
+    if (provider.source === "daemon") {
+      if (!provider.path) {
+        rows.push({ key: `  ${provider.label}`, value: "not found (daemon)" });
+      } else {
+        rows.push({ key: `  ${provider.label}`, value: `${provider.path} (daemon)` });
+      }
+    } else if (!provider.path) {
       rows.push({ key: `  ${provider.label}`, value: "not found" });
     } else if (!provider.version) {
       rows.push({ key: `  ${provider.label}`, value: `${provider.path} (--version failed)` });
@@ -210,6 +217,7 @@ interface DaemonProbeResult {
   runningAgents?: number;
   idleAgents?: number;
   daemonNodeOverride?: string;
+  daemonProviders?: ProviderBinaryStatus[];
   note?: string;
 }
 
@@ -231,11 +239,29 @@ async function probeDaemonOverWebsocket(args: {
   }
 
   const daemonVersion = client.getLastServerInfoMessage()?.version ?? null;
+  const supportsDaemonStatusRpc =
+    client.getLastServerInfoMessage()?.features?.daemonStatusRpc === true;
   try {
     const agentsPayload = await client.fetchAgents({ filter: { includeArchived: true } });
     const agents = agentsPayload.entries.map((entry) => entry.agent);
     const runningAgents = agents.filter((a) => a.status === "running").length;
     const idleAgents = agents.filter((a) => a.status === "idle").length;
+
+    let daemonProviders: ProviderBinaryStatus[] | undefined;
+    if (supportsDaemonStatusRpc) {
+      try {
+        const statusPayload = await client.getDaemonStatus();
+        const labelMap = new Map(PROVIDER_BINARIES.map((p) => [p.binary, p.label]));
+        daemonProviders = statusPayload.providers.map((p) => ({
+          label: labelMap.get(p.provider) ?? p.provider,
+          path: p.available ? "available" : null,
+          version: p.available ? null : (p.error ?? null),
+          source: "daemon" as const,
+        }));
+      } catch {
+        // Non-fatal: fall through to local provider check
+      }
+    }
 
     if (!state.running) {
       return {
@@ -244,6 +270,7 @@ async function probeDaemonOverWebsocket(args: {
         runningAgents,
         idleAgents,
         daemonNodeOverride: "unknown (API reachable, PID unresolved)",
+        daemonProviders,
         note: state.pidInfo
           ? `Connected daemon is reachable at ${host} even though local daemon PID ${state.pidInfo.pid} is stale`
           : `Connected daemon is reachable at ${host} but no local daemon PID file was found`,
@@ -255,6 +282,7 @@ async function probeDaemonOverWebsocket(args: {
       daemonVersion,
       runningAgents,
       idleAgents,
+      daemonProviders,
     };
   } catch {
     return {
@@ -278,6 +306,7 @@ interface ProbeMergeState {
   daemonVersion: string | null;
   runningAgents: number | null;
   idleAgents: number | null;
+  daemonProviders: ProviderBinaryStatus[] | undefined;
   note: string | undefined;
 }
 
@@ -290,6 +319,7 @@ function applyProbeToStatus(input: ProbeMergeState): Omit<ProbeMergeState, "prob
     daemonVersion: probe.daemonVersion !== undefined ? probe.daemonVersion : input.daemonVersion,
     runningAgents: probe.runningAgents !== undefined ? probe.runningAgents : input.runningAgents,
     idleAgents: probe.idleAgents !== undefined ? probe.idleAgents : input.idleAgents,
+    daemonProviders: probe.daemonProviders ?? input.daemonProviders,
     note: probe.note ? appendNote(input.note, probe.note) : input.note,
   };
 }
@@ -338,6 +368,7 @@ export async function runStatusCommand(
   let runningAgents: number | null = null;
   let idleAgents: number | null = null;
   let daemonVersion: string | null = null;
+  let daemonProviders: ProviderBinaryStatus[] | undefined;
   let note: string | undefined;
 
   if (!state.running && state.stalePidFile && state.pidInfo) {
@@ -347,17 +378,26 @@ export async function runStatusCommand(
 
   if (host) {
     const probe = await probeDaemonOverWebsocket({ host, state });
-    ({ connectedDaemon, localDaemon, daemonNode, daemonVersion, runningAgents, idleAgents, note } =
-      applyProbeToStatus({
-        probe,
-        connectedDaemon,
-        localDaemon,
-        daemonNode,
-        daemonVersion,
-        runningAgents,
-        idleAgents,
-        note,
-      }));
+    ({
+      connectedDaemon,
+      localDaemon,
+      daemonNode,
+      daemonVersion,
+      runningAgents,
+      idleAgents,
+      daemonProviders,
+      note,
+    } = applyProbeToStatus({
+      probe,
+      connectedDaemon,
+      localDaemon,
+      daemonNode,
+      daemonVersion,
+      runningAgents,
+      idleAgents,
+      daemonProviders,
+      note,
+    }));
   } else {
     note = appendNote(note, "Daemon is configured for unix socket listen; API probe skipped");
   }
@@ -370,7 +410,7 @@ export async function runStatusCommand(
     note = appendNote(note, serverIdResult.error);
   }
 
-  const providers = await checkProviderBinaries();
+  const providers = daemonProviders ?? (await checkProviderBinaries());
 
   const daemonStatus: DaemonStatus = {
     serverId,

--- a/packages/cli/src/commands/daemon/status.ts
+++ b/packages/cli/src/commands/daemon/status.ts
@@ -259,7 +259,9 @@ async function probeDaemonOverWebsocket(args: {
           source: "daemon" as const,
         }));
       } catch {
-        // Non-fatal: fall through to local provider check
+        // COMPAT(daemon-rpc-rollout): fall back to CLI-side provider resolution while
+        // old daemons lack daemonStatusRpc. Remove once the daemon floor is past
+        // v0.1.76; status should come from daemon.get_status.
       }
     }
 

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -60,6 +60,8 @@ import type {
   GetProvidersSnapshotResponseMessage,
   RefreshProvidersSnapshotResponseMessage,
   ProviderDiagnosticResponseMessage,
+  DaemonStatusResponse,
+  DaemonPairingOfferResponse,
   ListTerminalsResponse,
   CreateTerminalResponse,
   SubscribeTerminalResponse,
@@ -317,6 +319,8 @@ type ListAvailableProvidersPayload = ListAvailableProvidersResponse["payload"];
 type GetProvidersSnapshotPayload = GetProvidersSnapshotResponseMessage["payload"];
 type RefreshProvidersSnapshotPayload = RefreshProvidersSnapshotResponseMessage["payload"];
 type ProviderDiagnosticPayload = ProviderDiagnosticResponseMessage["payload"];
+type DaemonStatusPayload = DaemonStatusResponse["payload"];
+type DaemonPairingOfferPayload = DaemonPairingOfferResponse["payload"];
 type ReadProjectConfigPayload = Extract<
   SessionOutboundMessage,
   { type: "read_project_config_response" }
@@ -3294,6 +3298,28 @@ export class DaemonClient {
         type: "get_daemon_config_request",
       },
       responseType: "get_daemon_config_response",
+      timeout: 10000,
+    });
+  }
+
+  async getDaemonStatus(requestId?: string): Promise<DaemonStatusPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "daemon.status.request",
+      },
+      responseType: "daemon.status.response",
+      timeout: 10000,
+    });
+  }
+
+  async getDaemonPairingOffer(requestId?: string): Promise<DaemonPairingOfferPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "daemon.pairing_offer.request",
+      },
+      responseType: "daemon.pairing_offer.response",
       timeout: 10000,
     });
   }

--- a/packages/server/src/client/daemon-client.ts
+++ b/packages/server/src/client/daemon-client.ts
@@ -60,8 +60,8 @@ import type {
   GetProvidersSnapshotResponseMessage,
   RefreshProvidersSnapshotResponseMessage,
   ProviderDiagnosticResponseMessage,
-  DaemonStatusResponse,
-  DaemonPairingOfferResponse,
+  DaemonGetStatusResponse,
+  DaemonGetPairingOfferResponse,
   ListTerminalsResponse,
   CreateTerminalResponse,
   SubscribeTerminalResponse,
@@ -319,8 +319,8 @@ type ListAvailableProvidersPayload = ListAvailableProvidersResponse["payload"];
 type GetProvidersSnapshotPayload = GetProvidersSnapshotResponseMessage["payload"];
 type RefreshProvidersSnapshotPayload = RefreshProvidersSnapshotResponseMessage["payload"];
 type ProviderDiagnosticPayload = ProviderDiagnosticResponseMessage["payload"];
-type DaemonStatusPayload = DaemonStatusResponse["payload"];
-type DaemonPairingOfferPayload = DaemonPairingOfferResponse["payload"];
+type DaemonStatusPayload = DaemonGetStatusResponse["payload"];
+type DaemonPairingOfferPayload = DaemonGetPairingOfferResponse["payload"];
 type ReadProjectConfigPayload = Extract<
   SessionOutboundMessage,
   { type: "read_project_config_response" }
@@ -3306,9 +3306,9 @@ export class DaemonClient {
     return this.sendCorrelatedSessionRequest({
       requestId,
       message: {
-        type: "daemon.status.request",
+        type: "daemon.get_status.request",
       },
-      responseType: "daemon.status.response",
+      responseType: "daemon.get_status.response",
       timeout: 10000,
     });
   }
@@ -3317,9 +3317,9 @@ export class DaemonClient {
     return this.sendCorrelatedSessionRequest({
       requestId,
       message: {
-        type: "daemon.pairing_offer.request",
+        type: "daemon.get_pairing_offer.request",
       },
-      responseType: "daemon.pairing_offer.response",
+      responseType: "daemon.get_pairing_offer.response",
       timeout: 10000,
     });
   }

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -936,6 +936,16 @@ export async function createPaseoDaemon(
             workspaceGitService,
             github,
             config.pushNotificationSender,
+            {
+              listen: formatListenTarget(boundListenTarget ?? listenTarget),
+              relay: {
+                enabled: relayEnabled,
+                endpoint: relayEndpoint,
+                publicEndpoint: relayPublicEndpoint,
+                useTls: relayUseTls,
+                publicUseTls: relayPublicUseTls,
+              },
+            },
           );
 
           if (relayEnabled) {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1887,10 +1887,10 @@ export class Session {
           payload: { requestId: msg.requestId, config: this.daemonConfigStore.get() },
         });
         return undefined;
-      case "daemon.status.request":
-        return this.handleDaemonStatusRequest(msg);
-      case "daemon.pairing_offer.request":
-        return this.handleDaemonPairingOfferRequest(msg);
+      case "daemon.get_status.request":
+        return this.handleDaemonGetStatusRequest(msg);
+      case "daemon.get_pairing_offer.request":
+        return this.handleDaemonGetPairingOfferRequest(msg);
       case "set_daemon_config_request":
         this.emit({
           type: "set_daemon_config_response",
@@ -3840,8 +3840,8 @@ export class Session {
     }
   }
 
-  private async handleDaemonStatusRequest(
-    msg: Extract<SessionInboundMessage, { type: "daemon.status.request" }>,
+  private async handleDaemonGetStatusRequest(
+    msg: Extract<SessionInboundMessage, { type: "daemon.get_status.request" }>,
   ): Promise<void> {
     try {
       const pidInfo = await getPidLockInfo(this.paseoHome);
@@ -3851,7 +3851,7 @@ export class Session {
         error: p.error ?? null,
       }));
       this.emit({
-        type: "daemon.status.response",
+        type: "daemon.get_status.response",
         payload: {
           requestId: msg.requestId,
           serverId: this.serverId ?? "",
@@ -3867,7 +3867,7 @@ export class Session {
     } catch (error) {
       this.sessionLogger.error({ err: error }, "Failed to handle daemon status request");
       this.emit({
-        type: "daemon.status.response",
+        type: "daemon.get_status.response",
         payload: {
           requestId: msg.requestId,
           serverId: this.serverId ?? "",
@@ -3883,8 +3883,8 @@ export class Session {
     }
   }
 
-  private async handleDaemonPairingOfferRequest(
-    msg: Extract<SessionInboundMessage, { type: "daemon.pairing_offer.request" }>,
+  private async handleDaemonGetPairingOfferRequest(
+    msg: Extract<SessionInboundMessage, { type: "daemon.get_pairing_offer.request" }>,
   ): Promise<void> {
     try {
       const relay = this.daemonRuntimeConfig?.relay;
@@ -3899,7 +3899,7 @@ export class Session {
         logger: this.sessionLogger,
       });
       this.emit({
-        type: "daemon.pairing_offer.response",
+        type: "daemon.get_pairing_offer.response",
         payload: {
           requestId: msg.requestId,
           url: pairing.url ?? "",
@@ -3913,7 +3913,7 @@ export class Session {
         type: "rpc_error",
         payload: {
           requestId: msg.requestId,
-          requestType: "daemon.pairing_offer.request",
+          requestType: "daemon.get_pairing_offer.request",
           error: error instanceof Error ? error.message : String(error),
         },
       });

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -47,6 +47,8 @@ import type { TurnDetectionProvider } from "./speech/turn-detection-provider.js"
 import { maybePersistTtsDebugAudio } from "./agent/tts-debug.js";
 import { isPaseoDictationDebugEnabled } from "./agent/recordings-debug.js";
 import { listAvailableEditorTargets, openInEditorTarget } from "./editor-targets.js";
+import { getPidLockInfo } from "./pid-lock.js";
+import { generateLocalPairingOffer } from "./pairing-offer.js";
 import {
   DictationStreamManager,
   type DictationStreamOutboundMessage,
@@ -595,6 +597,18 @@ export interface SessionOptions {
   agentProviderRuntimeSettings?: AgentProviderRuntimeSettingsMap;
   providerOverrides?: Record<string, ProviderOverride>;
   isDev?: boolean;
+  serverId?: string;
+  daemonVersion?: string;
+  daemonRuntimeConfig?: {
+    listen: string | null;
+    relay: {
+      enabled: boolean;
+      endpoint: string;
+      publicEndpoint: string;
+      useTls: boolean;
+      publicUseTls: boolean;
+    } | null;
+  };
 }
 
 export type SessionLifecycleIntent =
@@ -805,6 +819,9 @@ export class Session {
   private readonly agentProviderRuntimeSettings: AgentProviderRuntimeSettingsMap | undefined;
   private readonly providerOverrides: Record<string, ProviderOverride> | undefined;
   private readonly isDev: boolean;
+  private readonly serverId: string | undefined;
+  private readonly daemonVersion: string | undefined;
+  private readonly daemonRuntimeConfig: SessionOptions["daemonRuntimeConfig"];
   private voiceModeAgentId: string | null = null;
   private voiceModeBaseConfig: VoiceModeBaseConfig | null = null;
 
@@ -850,6 +867,9 @@ export class Session {
       agentProviderRuntimeSettings,
       providerOverrides,
       isDev,
+      serverId,
+      daemonVersion,
+      daemonRuntimeConfig,
     } = options;
     this.clientId = clientId;
     this.appVersion = appVersion ?? null;
@@ -901,6 +921,9 @@ export class Session {
     this.agentProviderRuntimeSettings = agentProviderRuntimeSettings;
     this.providerOverrides = providerOverrides;
     this.isDev = isDev === true;
+    this.serverId = serverId;
+    this.daemonVersion = daemonVersion;
+    this.daemonRuntimeConfig = daemonRuntimeConfig;
     this.abortController = new AbortController();
     this.workspaceDirectory = new WorkspaceDirectory({
       logger: this.sessionLogger,
@@ -1864,6 +1887,10 @@ export class Session {
           payload: { requestId: msg.requestId, config: this.daemonConfigStore.get() },
         });
         return undefined;
+      case "daemon.status.request":
+        return this.handleDaemonStatusRequest(msg);
+      case "daemon.pairing_offer.request":
+        return this.handleDaemonPairingOfferRequest(msg);
       case "set_daemon_config_request":
         this.emit({
           type: "set_daemon_config_response",
@@ -3808,6 +3835,86 @@ export class Session {
           error: getErrorMessage(error),
           fetchedAt,
           requestId: msg.requestId,
+        },
+      });
+    }
+  }
+
+  private async handleDaemonStatusRequest(
+    msg: Extract<SessionInboundMessage, { type: "daemon.status.request" }>,
+  ): Promise<void> {
+    try {
+      const pidInfo = await getPidLockInfo(this.paseoHome);
+      const providers = (await this.agentManager.listProviderAvailability()).map((p) => ({
+        provider: p.provider,
+        available: p.available,
+        error: p.error ?? null,
+      }));
+      this.emit({
+        type: "daemon.status.response",
+        payload: {
+          requestId: msg.requestId,
+          serverId: this.serverId ?? "",
+          version: this.daemonVersion ?? null,
+          pid: process.pid,
+          nodePath: process.execPath,
+          startedAt: pidInfo?.startedAt ?? null,
+          listen: this.daemonRuntimeConfig?.listen ?? null,
+          relay: this.daemonRuntimeConfig?.relay ?? null,
+          providers,
+        },
+      });
+    } catch (error) {
+      this.sessionLogger.error({ err: error }, "Failed to handle daemon status request");
+      this.emit({
+        type: "daemon.status.response",
+        payload: {
+          requestId: msg.requestId,
+          serverId: this.serverId ?? "",
+          version: this.daemonVersion ?? null,
+          pid: process.pid,
+          nodePath: process.execPath,
+          startedAt: null,
+          listen: null,
+          relay: null,
+          providers: [],
+        },
+      });
+    }
+  }
+
+  private async handleDaemonPairingOfferRequest(
+    msg: Extract<SessionInboundMessage, { type: "daemon.pairing_offer.request" }>,
+  ): Promise<void> {
+    try {
+      const relay = this.daemonRuntimeConfig?.relay;
+      const pairing = await generateLocalPairingOffer({
+        paseoHome: this.paseoHome,
+        relayEnabled: relay?.enabled ?? true,
+        relayEndpoint: relay?.endpoint,
+        relayPublicEndpoint: relay?.publicEndpoint,
+        relayUseTls: relay?.useTls,
+        relayPublicUseTls: relay?.publicUseTls,
+        includeQr: true,
+        logger: this.sessionLogger,
+      });
+      this.emit({
+        type: "daemon.pairing_offer.response",
+        payload: {
+          requestId: msg.requestId,
+          url: pairing.url ?? "",
+          qr: pairing.qr ?? null,
+          relayEnabled: pairing.relayEnabled,
+        },
+      });
+    } catch (error) {
+      this.sessionLogger.error({ err: error }, "Failed to handle daemon pairing offer request");
+      this.emit({
+        type: "rpc_error",
+        payload: {
+          requestId: msg.requestId,
+          requestType: "daemon.pairing_offer.request",
+          error: error instanceof Error ? error.message : String(error),
         },
       });
     }

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -332,6 +332,18 @@ export class VoiceAssistantWebSocketServer {
   private readonly externalSessionsByKey: Map<string, SessionConnection> = new Map();
   private readonly serverId: string;
   private readonly daemonVersion: string;
+  private readonly daemonRuntimeConfig:
+    | {
+        listen: string | null;
+        relay: {
+          enabled: boolean;
+          endpoint: string;
+          publicEndpoint: string;
+          useTls: boolean;
+          publicUseTls: boolean;
+        };
+      }
+    | undefined;
   private readonly agentManager: AgentManager;
   private readonly agentStorage: AgentStorage;
   private readonly projectRegistry: ProjectRegistry;
@@ -416,6 +428,16 @@ export class VoiceAssistantWebSocketServer {
     workspaceGitService?: WorkspaceGitService,
     github?: GitHubService,
     pushNotificationSender?: PushNotificationSender,
+    daemonRuntimeConfig?: {
+      listen: string | null;
+      relay: {
+        enabled: boolean;
+        endpoint: string;
+        publicEndpoint: string;
+        useTls: boolean;
+        publicUseTls: boolean;
+      };
+    },
   ) {
     this.logger = logger.child({ module: "websocket-server" });
     this.serverId = serverId;
@@ -423,6 +445,7 @@ export class VoiceAssistantWebSocketServer {
       throw new MissingDaemonVersionError();
     }
     this.daemonVersion = daemonVersion.trim();
+    this.daemonRuntimeConfig = daemonRuntimeConfig;
     this.agentManager = agentManager;
     this.agentStorage = agentStorage;
     this.projectRegistry = projectRegistry ?? createNoopProjectRegistry();
@@ -921,6 +944,9 @@ export class VoiceAssistantWebSocketServer {
       agentProviderRuntimeSettings: this.agentProviderRuntimeSettings,
       providerOverrides: this.providerOverrides,
       isDev: this.isDev,
+      serverId: this.serverId,
+      daemonVersion: this.daemonVersion,
+      daemonRuntimeConfig: this.daemonRuntimeConfig,
     });
 
     connection = {
@@ -1053,6 +1079,8 @@ export class VoiceAssistantWebSocketServer {
         providersSnapshot: true,
         // COMPAT(checkoutGithubSetAutoMerge): added in v0.1.75, remove gate after 2026-11-13.
         checkoutGithubSetAutoMerge: true,
+        // COMPAT(daemonStatusRpc): added in v0.1.78, remove gate after 2026-11-18.
+        daemonStatusRpc: true,
       },
     };
   }

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1079,7 +1079,7 @@ export class VoiceAssistantWebSocketServer {
         providersSnapshot: true,
         // COMPAT(checkoutGithubSetAutoMerge): added in v0.1.75, remove gate after 2026-11-13.
         checkoutGithubSetAutoMerge: true,
-        // COMPAT(daemonStatusRpc): added in v0.1.78, remove gate after 2026-11-18.
+        // COMPAT(daemonStatusRpc): added in v0.1.76, remove gate after 2026-11-18.
         daemonStatusRpc: true,
       },
     };

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -979,6 +979,16 @@ export const WaitForFinishRequestSchema = z.object({
   timeoutMs: z.number().int().positive().optional(),
 });
 
+export const DaemonStatusRequestSchema = z.object({
+  type: z.literal("daemon.status.request"),
+  requestId: z.string(),
+});
+
+export const DaemonPairingOfferRequestSchema = z.object({
+  type: z.literal("daemon.pairing_offer.request"),
+  requestId: z.string(),
+});
+
 export const GetDaemonConfigRequestMessageSchema = z.object({
   type: z.literal("get_daemon_config_request"),
   requestId: z.string(),
@@ -1764,6 +1774,8 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   SetVoiceModeMessageSchema,
   SendAgentMessageRequestSchema,
   WaitForFinishRequestSchema,
+  DaemonStatusRequestSchema,
+  DaemonPairingOfferRequestSchema,
   GetDaemonConfigRequestMessageSchema,
   SetDaemonConfigRequestMessageSchema,
   ReadProjectConfigRequestMessageSchema,
@@ -2026,6 +2038,7 @@ export const ServerInfoStatusPayloadSchema = z
       .object({
         providersSnapshot: z.boolean().optional(),
         checkoutGithubSetAutoMerge: z.boolean().optional(),
+        daemonStatusRpc: z.boolean().optional(),
       })
       .optional(),
   })
@@ -2582,6 +2595,50 @@ export const GetDaemonConfigResponseMessageSchema = z.object({
     .object({
       requestId: z.string(),
       config: MutableDaemonConfigSchema,
+    })
+    .passthrough(),
+});
+
+export const DaemonStatusResponseSchema = z.object({
+  type: z.literal("daemon.status.response"),
+  payload: z
+    .object({
+      requestId: z.string(),
+      serverId: z.string(),
+      version: z.string().nullable().optional(),
+      pid: z.number(),
+      nodePath: z.string(),
+      startedAt: z.string().nullable().optional(),
+      listen: z.string().nullable(),
+      relay: z
+        .object({
+          enabled: z.boolean(),
+          endpoint: z.string(),
+          publicEndpoint: z.string(),
+          useTls: z.boolean(),
+          publicUseTls: z.boolean(),
+        })
+        .nullable()
+        .optional(),
+      providers: z.array(
+        z.object({
+          provider: z.string(),
+          available: z.boolean(),
+          error: z.string().nullable().optional(),
+        }),
+      ),
+    })
+    .passthrough(),
+});
+
+export const DaemonPairingOfferResponseSchema = z.object({
+  type: z.literal("daemon.pairing_offer.response"),
+  payload: z
+    .object({
+      requestId: z.string(),
+      url: z.string(),
+      qr: z.string().nullable().optional(),
+      relayEnabled: z.boolean(),
     })
     .passthrough(),
 });
@@ -3481,6 +3538,8 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   ClearAgentAttentionResponseMessageSchema,
   SendAgentMessageResponseMessageSchema,
   SetVoiceModeResponseMessageSchema,
+  DaemonStatusResponseSchema,
+  DaemonPairingOfferResponseSchema,
   GetDaemonConfigResponseMessageSchema,
   SetDaemonConfigResponseMessageSchema,
   ReadProjectConfigResponseMessageSchema,
@@ -3643,6 +3702,8 @@ export type ListProviderFeaturesResponseMessage = z.infer<
   typeof ListProviderFeaturesResponseMessageSchema
 >;
 export type ListAvailableProvidersResponse = z.infer<typeof ListAvailableProvidersResponseSchema>;
+export type DaemonStatusResponse = z.infer<typeof DaemonStatusResponseSchema>;
+export type DaemonPairingOfferResponse = z.infer<typeof DaemonPairingOfferResponseSchema>;
 export type GetProvidersSnapshotResponseMessage = z.infer<
   typeof GetProvidersSnapshotResponseMessageSchema
 >;

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -2038,6 +2038,7 @@ export const ServerInfoStatusPayloadSchema = z
       .object({
         providersSnapshot: z.boolean().optional(),
         checkoutGithubSetAutoMerge: z.boolean().optional(),
+        // COMPAT(daemonStatusRpc): added in v0.1.76, remove gate after 2026-11-18.
         daemonStatusRpc: z.boolean().optional(),
       })
       .optional(),

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -979,13 +979,13 @@ export const WaitForFinishRequestSchema = z.object({
   timeoutMs: z.number().int().positive().optional(),
 });
 
-export const DaemonStatusRequestSchema = z.object({
-  type: z.literal("daemon.status.request"),
+export const DaemonGetStatusRequestSchema = z.object({
+  type: z.literal("daemon.get_status.request"),
   requestId: z.string(),
 });
 
-export const DaemonPairingOfferRequestSchema = z.object({
-  type: z.literal("daemon.pairing_offer.request"),
+export const DaemonGetPairingOfferRequestSchema = z.object({
+  type: z.literal("daemon.get_pairing_offer.request"),
   requestId: z.string(),
 });
 
@@ -1774,8 +1774,8 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   SetVoiceModeMessageSchema,
   SendAgentMessageRequestSchema,
   WaitForFinishRequestSchema,
-  DaemonStatusRequestSchema,
-  DaemonPairingOfferRequestSchema,
+  DaemonGetStatusRequestSchema,
+  DaemonGetPairingOfferRequestSchema,
   GetDaemonConfigRequestMessageSchema,
   SetDaemonConfigRequestMessageSchema,
   ReadProjectConfigRequestMessageSchema,
@@ -2599,8 +2599,8 @@ export const GetDaemonConfigResponseMessageSchema = z.object({
     .passthrough(),
 });
 
-export const DaemonStatusResponseSchema = z.object({
-  type: z.literal("daemon.status.response"),
+export const DaemonGetStatusResponseSchema = z.object({
+  type: z.literal("daemon.get_status.response"),
   payload: z
     .object({
       requestId: z.string(),
@@ -2631,8 +2631,8 @@ export const DaemonStatusResponseSchema = z.object({
     .passthrough(),
 });
 
-export const DaemonPairingOfferResponseSchema = z.object({
-  type: z.literal("daemon.pairing_offer.response"),
+export const DaemonGetPairingOfferResponseSchema = z.object({
+  type: z.literal("daemon.get_pairing_offer.response"),
   payload: z
     .object({
       requestId: z.string(),
@@ -3538,8 +3538,8 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   ClearAgentAttentionResponseMessageSchema,
   SendAgentMessageResponseMessageSchema,
   SetVoiceModeResponseMessageSchema,
-  DaemonStatusResponseSchema,
-  DaemonPairingOfferResponseSchema,
+  DaemonGetStatusResponseSchema,
+  DaemonGetPairingOfferResponseSchema,
   GetDaemonConfigResponseMessageSchema,
   SetDaemonConfigResponseMessageSchema,
   ReadProjectConfigResponseMessageSchema,
@@ -3702,8 +3702,8 @@ export type ListProviderFeaturesResponseMessage = z.infer<
   typeof ListProviderFeaturesResponseMessageSchema
 >;
 export type ListAvailableProvidersResponse = z.infer<typeof ListAvailableProvidersResponseSchema>;
-export type DaemonStatusResponse = z.infer<typeof DaemonStatusResponseSchema>;
-export type DaemonPairingOfferResponse = z.infer<typeof DaemonPairingOfferResponseSchema>;
+export type DaemonGetStatusResponse = z.infer<typeof DaemonGetStatusResponseSchema>;
+export type DaemonGetPairingOfferResponse = z.infer<typeof DaemonGetPairingOfferResponseSchema>;
 export type GetProvidersSnapshotResponseMessage = z.infer<
   typeof GetProvidersSnapshotResponseMessageSchema
 >;


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
-->

### Linked issue

Closes #1081

<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

<!-- A short description of the change in your own words. What was wrong, what you changed, why it works. If you can't explain this briefly, the PR is probably too big. -->

When the daemon runs in a different environment than the CLI (e.g. systemd), `status` reported providers from the CLI's `PATH` and `pair` generated pairing URLs using CLI's env vars — both potentially wrong from the daemon's perspective.

Add two new daemon RPCs (`daemon.status`, `daemon.pairing_offer`) that let the CLI query the daemon's own provider availability and relay config. Both commands fall back to local checks when the daemon is unreachable.

Also strip `PASEO_RELAY_*` env vars in `resolveLocalDaemonState()` so the CLI reads relay config from config.json rather than the current shell env.


### How did you verify it

<!--
This is the section I read most carefully. I need to see that *you* tested this, not that the diff looks plausible.

- For UI changes: a screenshot or short video on every affected platform (mobile, web, desktop). UI claims without visual proof are not enough.
- For behavior changes: the actual steps you ran, and what you observed.
- For bug fixes: how you reproduced the bug before, and confirmed it's fixed after.

AI-generated PR descriptions are fine in principle. AI-generated *verification claims* with no actual testing behind them are not, and they're easy to spot.
-->

I have add and run all the tests, and run the checklist

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
