### PR TITLE
Show workspace scripts in mobile header

### DIFF
--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -172,6 +172,12 @@ const EMPTY_PINNED_AGENT_IDS = new Set<string>();
 const EMPTY_SET = new Set<string>();
 const COMPACT_WEB_GESTURE_TOUCH_ACTION = isWeb ? "auto" : "pan-y";
 
+function getWorkspaceScripts(
+  workspaceDescriptor: WorkspaceDescriptor | null | undefined,
+): WorkspaceDescriptor["scripts"] {
+  return workspaceDescriptor?.scripts ?? EMPTY_WORKSPACE_SCRIPTS;
+}
+
 const ThemedActivityIndicator = withUnistyles(ActivityIndicator);
 const ThemedEllipsis = withUnistyles(Ellipsis);
 const ThemedEllipsisVertical = withUnistyles(EllipsisVertical);
@@ -935,6 +941,8 @@ interface WorkspaceHeaderTitleBarProps {
   isGitCheckout: boolean;
   normalizedServerId: string;
   normalizedWorkspaceId: string;
+  workspaceScripts: WorkspaceDescriptor["scripts"];
+  liveTerminalIds: string[];
   showWorkspaceSetup: boolean;
   showCreateBrowserTab: boolean;
   isMobile: boolean;
@@ -953,6 +961,9 @@ interface WorkspaceHeaderTitleBarProps {
   onCopyWorkspacePath: () => void;
   onCopyBranchName: () => void;
   onOpenSetupTab: () => void;
+  onScriptTerminalStarted: (terminalId: string) => void;
+  onViewScriptTerminal: (terminalId: string) => void;
+  onOpenUrlInBrowserTab: (url: string) => void;
 }
 
 function WorkspaceHeaderTitleBar({
@@ -964,6 +975,8 @@ function WorkspaceHeaderTitleBar({
   isGitCheckout,
   normalizedServerId,
   normalizedWorkspaceId,
+  workspaceScripts,
+  liveTerminalIds,
   showWorkspaceSetup,
   showCreateBrowserTab,
   isMobile,
@@ -982,6 +995,9 @@ function WorkspaceHeaderTitleBar({
   onCopyWorkspacePath,
   onCopyBranchName,
   onOpenSetupTab,
+  onScriptTerminalStarted,
+  onViewScriptTerminal,
+  onOpenUrlInBrowserTab,
 }: WorkspaceHeaderTitleBarProps) {
   return (
     <View style={styles.headerTitleContainer}>
@@ -1031,6 +1047,18 @@ function WorkspaceHeaderTitleBar({
         onCopyBranchName={onCopyBranchName}
         onOpenSetupTab={onOpenSetupTab}
       />
+      {isMobile && workspaceScripts.length > 0 ? (
+        <WorkspaceScriptsButton
+          serverId={normalizedServerId}
+          workspaceId={normalizedWorkspaceId}
+          scripts={workspaceScripts}
+          liveTerminalIds={liveTerminalIds}
+          onScriptTerminalStarted={onScriptTerminalStarted}
+          onViewTerminal={onViewScriptTerminal}
+          onOpenUrlInBrowserTab={onOpenUrlInBrowserTab}
+          hideLabels
+        />
+      ) : null}
     </View>
   );
 }
@@ -1457,6 +1485,7 @@ function WorkspaceScreenContent({
     [workspaceId],
   );
   const workspaceDescriptor = useWorkspace(normalizedServerId, normalizedWorkspaceId);
+  const workspaceScripts = getWorkspaceScripts(workspaceDescriptor);
   const { handleRetryHost, handleManageHost, handleDismissMissingWorkspace } =
     useWorkspaceRouteActions(normalizedServerId);
 
@@ -1553,7 +1582,7 @@ function WorkspaceScreenContent({
     normalizedServerId,
     normalizedWorkspaceId,
     workspaceDirectory,
-    workspaceScripts: workspaceDescriptor?.scripts ?? EMPTY_WORKSPACE_SCRIPTS,
+    workspaceScripts,
     hasHydratedWorkspaces,
     isMissingWorkspaceExecutionAuthority,
     onTerminalCreated: handleTerminalCreated,
@@ -3230,6 +3259,8 @@ function WorkspaceScreenContent({
                         isGitCheckout={isGitCheckout}
                         normalizedServerId={normalizedServerId}
                         normalizedWorkspaceId={normalizedWorkspaceId}
+                        workspaceScripts={workspaceScripts}
+                        liveTerminalIds={liveTerminalIds}
                         showWorkspaceSetup={showWorkspaceSetup}
                         showCreateBrowserTab={showCreateBrowserTab}
                         isMobile={isMobile}
@@ -3248,6 +3279,9 @@ function WorkspaceScreenContent({
                         onCopyWorkspacePath={handleCopyWorkspacePath}
                         onCopyBranchName={handleCopyBranchName}
                         onOpenSetupTab={handleOpenSetupTab}
+                        onScriptTerminalStarted={handleScriptTerminalStarted}
+                        onViewScriptTerminal={handleViewScriptTerminal}
+                        onOpenUrlInBrowserTab={handleOpenUrlInBrowserTab}
                       />
                     </>
                   }


### PR DESCRIPTION
### Linked issue

N/A - small objective UI bug fix.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Workspace scripts were only available from the desktop workspace header. On compact/mobile layouts, the header menu did not expose the existing scripts dropdown, so users could not start or view workspace scripts from mobile web.

This reuses the existing `WorkspaceScriptsButton` in the compact workspace header, rendered icon-only next to the workspace header menu. Desktop behavior is unchanged.

### How did you verify it

Manual verification:

- Reproduced the mobile web header without a scripts button.
- Verified on mobile web that the scripts button appears next to the three-dot workspace menu after this change.
- Opened the scripts dropdown from mobile web and confirmed workspace scripts are accessible.
- Confirmed the desktop header keeps the existing scripts button behavior.

Commands run on the PR branch:

- `npm run format:files -- packages/app/src/screens/workspace/workspace-screen.tsx`
- `npm run lint -- packages/app/src/screens/workspace/workspace-screen.tsx`
- `npx vitest run packages/app/src/screens/workspace/workspace-scripts-button.test.tsx --bail=1`

Additional validation on the fork `dev` branch after cherry-picking the same commit:

- `npm run lint -- packages/app/src/screens/workspace/workspace-screen.tsx`
- `npx vitest run packages/app/src/screens/workspace/workspace-scripts-button.test.tsx --bail=1`
- `npm run typecheck --workspace=@getpaseo/app`

Typecheck note:

- I attempted the full `npm run typecheck` pre-commit check on the main-based PR branch.
- That full workspace check is currently blocked in this local checkout by package/type issues outside this PR: `expo-image-manipulator`, OpenCode SDK/Pi package types, and CLI generated type mismatches.
- I left the checklist `npm run typecheck passes` item unchecked because the template asks specifically for the full command. The changed app file linted cleanly, the targeted component test passed, and app workspace typecheck passed on the fork `dev` branch with the same commit.

UI evidence:

- Mobile web before/after screenshots are attached below.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

<img width="228" height="476" alt="Screenshot_20260519113033" src="https://github.com/user-attachments/assets/6ccccea4-38f1-47eb-9193-f09651c78a56" />
<img width="221" height="471" alt="Screenshot_20260519113112" src="https://github.com/user-attachments/assets/6f8e8235-3528-4c3b-bf08-d26bf6644d2a" />