### PR TITLE
fix: read Claude context usage from SDK

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -396,6 +396,47 @@ test("normalizeConfig strips legacy 'default' model id", async () => {
   expect(snapshot.config.modeId).toBe("auto");
 });
 
+test("usage_updated merges into existing last usage", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const client = new TestAgentClient();
+  const manager = new AgentManager({
+    clients: {
+      codex: client,
+    },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000105",
+  });
+
+  const snapshot = await manager.createAgent({
+    provider: "codex",
+    cwd: workdir,
+  });
+  const session = manager.getAgent(snapshot.id)?.session as TestAgentSession;
+
+  session.pushEvent({
+    type: "usage_updated",
+    provider: "codex",
+    usage: { inputTokens: 10, outputTokens: 3, totalCostUsd: 0.25 },
+  });
+  session.pushEvent({
+    type: "usage_updated",
+    provider: "codex",
+    usage: { contextWindowUsedTokens: 42_000, contextWindowMaxTokens: 200_000 },
+  });
+  await manager.flush();
+
+  expect(manager.getAgent(snapshot.id)?.lastUsage).toEqual({
+    inputTokens: 10,
+    outputTokens: 3,
+    totalCostUsd: 0.25,
+    contextWindowUsedTokens: 42_000,
+    contextWindowMaxTokens: 200_000,
+  });
+});
+
 test("createAgent injects daemon append system prompt at runtime only", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2802,7 +2802,7 @@ export class AgentManager {
         this.onStreamThreadStarted(agent);
         return undefined;
       case "usage_updated":
-        agent.lastUsage = event.usage;
+        agent.lastUsage = { ...agent.lastUsage, ...event.usage };
         this.emitState(agent);
         return undefined;
       case "mode_changed":

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -354,26 +354,42 @@ describe("ClaudeAgentClient.listModels", () => {
   const logger = createTestLogger();
 
   test("returns hardcoded claude models", async () => {
-    const client = new ClaudeAgentClient({ logger, resolveBinary: async () => "/test/claude/bin" });
-    const models = await client.listModels({ cwd: "/tmp/claude-models", force: false });
+    const tmpConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "paseo-claude-models-"));
+    const previousConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = tmpConfigDir;
 
-    expect(models.map((m) => m.id)).toEqual([
-      "claude-opus-4-7[1m]",
-      "claude-opus-4-7",
-      "claude-opus-4-6[1m]",
-      "claude-opus-4-6",
-      "claude-sonnet-4-6[1m]",
-      "claude-sonnet-4-6",
-      "claude-haiku-4-5",
-    ]);
+    try {
+      const client = new ClaudeAgentClient({
+        logger,
+        resolveBinary: async () => "/test/claude/bin",
+      });
+      const models = await client.listModels({ cwd: "/tmp/claude-models", force: false });
 
-    for (const model of models) {
-      expect(model.provider).toBe("claude");
-      expect(model.label.length).toBeGreaterThan(0);
+      expect(models.map((m) => m.id)).toEqual([
+        "claude-opus-4-7[1m]",
+        "claude-opus-4-7",
+        "claude-opus-4-6[1m]",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6[1m]",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+      ]);
+
+      for (const model of models) {
+        expect(model.provider).toBe("claude");
+        expect(model.label.length).toBeGreaterThan(0);
+      }
+
+      const defaultModel = models.find((m) => m.isDefault);
+      expect(defaultModel?.id).toBe("claude-opus-4-6");
+    } finally {
+      if (previousConfigDir === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIR;
+      } else {
+        process.env.CLAUDE_CONFIG_DIR = previousConfigDir;
+      }
+      await fs.rm(tmpConfigDir, { recursive: true, force: true });
     }
-
-    const defaultModel = models.find((m) => m.isDefault);
-    expect(defaultModel?.id).toBe("claude-opus-4-6");
   });
 });
 
@@ -612,11 +628,20 @@ describe("ClaudeAgentSession context window usage", () => {
     return session as unknown as TestClaudeSession;
   }
 
-  function createQueryFactoryForTurns(turns: Array<Array<Record<string, unknown>>>) {
+  interface ContextUsageFixture {
+    totalTokens: number;
+    maxTokens: number;
+  }
+
+  function createQueryFactoryForTurns(
+    turns: Array<Array<Record<string, unknown>>>,
+    contextUsageFixtures: ContextUsageFixture[] = [],
+  ) {
     return vi.fn(({ prompt }: { prompt: AsyncIterable<unknown> }) => {
       const queuedMessages: Array<Record<string, unknown>> = [];
       const waiters: Array<() => void> = [];
       let turnIndex = 0;
+      let contextUsageIndex = 0;
       const closedRef = { value: false };
 
       function wakeNextWaiter() {
@@ -668,6 +693,27 @@ describe("ClaudeAgentSession context window usage", () => {
         supportedModels: vi.fn(async () => []),
         supportedCommands: vi.fn(async () => []),
         rewindFiles: vi.fn(async () => ({ canRewind: true })),
+        getContextUsage: vi.fn(async () => {
+          const fixture = contextUsageFixtures[contextUsageIndex];
+          if (fixture) {
+            contextUsageIndex += 1;
+            return {
+              ...fixture,
+              rawMaxTokens: fixture.maxTokens,
+              percentage: (fixture.totalTokens / fixture.maxTokens) * 100,
+              model: "claude-sonnet-4-6",
+              isAutoCompactEnabled: true,
+            };
+          }
+          return {
+            totalTokens: 0,
+            maxTokens: 200_000,
+            rawMaxTokens: 200_000,
+            percentage: 0,
+            model: "claude-sonnet-4-6",
+            isAutoCompactEnabled: true,
+          };
+        }),
         [Symbol.asyncIterator]() {
           return this;
         },
@@ -866,37 +912,7 @@ describe("ClaudeAgentSession context window usage", () => {
     }
   });
 
-  test("convertUsage includes contextWindowMaxTokens and derives used tokens from result usage as initial fallback", async () => {
-    const session = await createSessionForTest();
-
-    const usage = session.convertUsage(
-      {
-        type: "result",
-        subtype: "success",
-        usage: {
-          input_tokens: 10,
-          cache_read_input_tokens: 5,
-          output_tokens: 7,
-        },
-        total_cost_usd: 0.12,
-      },
-      {
-        "claude-sonnet-4-6": { contextWindow: 200_000 },
-        "claude-opus-4-6": { contextWindow: 1_000_000 },
-      },
-    );
-
-    expect(usage).toEqual({
-      inputTokens: 10,
-      cachedInputTokens: 5,
-      outputTokens: 7,
-      totalCostUsd: 0.12,
-      contextWindowMaxTokens: 1_000_000,
-      contextWindowUsedTokens: 22,
-    });
-  });
-
-  test("contextWindowUsedTokens falls back to result usage when no task_progress was received", async () => {
+  test("convertUsage does not derive context window usage from result totals", async () => {
     const session = await createSessionForTest();
 
     const usage = session.convertUsage({
@@ -916,67 +932,10 @@ describe("ClaudeAgentSession context window usage", () => {
       cachedInputTokens: 5,
       outputTokens: 7,
       totalCostUsd: 0.12,
-      contextWindowUsedTokens: 25,
     });
   });
 
-  test("contextWindowUsedTokens is populated from task_progress usage data", async () => {
-    const session = await createSessionForTest();
-
-    session.translateMessageToEvents({
-      type: "system",
-      subtype: "task_progress",
-      task_id: "task-1",
-      description: "Processing",
-      usage: {
-        total_tokens: 999,
-        tool_uses: 1,
-        duration_ms: 50,
-        input_tokens: 345,
-        cache_read_input_tokens: 55,
-      },
-      uuid: "task-progress-1",
-      session_id: "session-1",
-    });
-
-    const events = session.translateMessageToEvents({
-      type: "result",
-      subtype: "success",
-      duration_ms: 100,
-      duration_api_ms: 75,
-      is_error: false,
-      num_turns: 1,
-      result: "done",
-      stop_reason: null,
-      total_cost_usd: 0.25,
-      usage: {
-        input_tokens: 10,
-        cache_read_input_tokens: 5,
-        output_tokens: 7,
-      },
-      modelUsage: {
-        "claude-sonnet-4-6": { contextWindow: 200_000 },
-      },
-      permission_denials: [],
-      uuid: "result-1",
-      session_id: "session-1",
-    });
-
-    expect(events).toContainEqual({
-      type: "turn_completed",
-      provider: "claude",
-      usage: {
-        inputTokens: 10,
-        cachedInputTokens: 5,
-        outputTokens: 7,
-        totalCostUsd: 0.25,
-        contextWindowMaxTokens: 200_000,
-        contextWindowUsedTokens: 999,
-      },
-    });
-  });
-
-  test("task_progress emits a usage_updated event", async () => {
+  test("task_progress does not emit context window usage", async () => {
     const session = await createSessionForTest();
 
     const events = session.translateMessageToEvents({
@@ -993,16 +952,10 @@ describe("ClaudeAgentSession context window usage", () => {
       session_id: "session-1",
     });
 
-    expect(events).toContainEqual({
-      type: "usage_updated",
-      provider: "claude",
-      usage: {
-        contextWindowUsedTokens: 999,
-      },
-    });
+    expect(events.some((event) => event.type === "usage_updated")).toBe(false);
   });
 
-  test("task_notification emits a usage_updated event", async () => {
+  test("task_notification does not emit context window usage", async () => {
     const session = await createSessionForTest();
 
     const events = session.translateMessageToEvents({
@@ -1020,19 +973,13 @@ describe("ClaudeAgentSession context window usage", () => {
       session_id: "session-1",
     } as unknown as SDKMessage);
 
-    expect(events).toContainEqual({
-      type: "usage_updated",
-      provider: "claude",
-      usage: {
-        contextWindowUsedTokens: 777,
-      },
-    });
+    expect(events.some((event) => event.type === "usage_updated")).toBe(false);
   });
 
-  test("message_start stream events emit usage_updated with per-request usage", async () => {
+  test("stream usage events do not emit context window usage", async () => {
     const session = await createSessionForTest();
 
-    const events = session.translateMessageToEvents({
+    const startEvents = session.translateMessageToEvents({
       type: "stream_event",
       event: {
         type: "message_start",
@@ -1046,35 +993,7 @@ describe("ClaudeAgentSession context window usage", () => {
       },
       session_id: "session-1",
     } as unknown as SDKMessage);
-
-    expect(events).toContainEqual({
-      type: "usage_updated",
-      provider: "claude",
-      usage: {
-        contextWindowUsedTokens: 150,
-      },
-    });
-  });
-
-  test("message_delta stream events update per-request usage", async () => {
-    const session = await createSessionForTest();
-
-    session.translateMessageToEvents({
-      type: "stream_event",
-      event: {
-        type: "message_start",
-        message: {
-          usage: {
-            input_tokens: 100,
-            cache_creation_input_tokens: 20,
-            cache_read_input_tokens: 30,
-          },
-        },
-      },
-      session_id: "session-1",
-    } as unknown as SDKMessage);
-
-    const events = session.translateMessageToEvents({
+    const deltaEvents = session.translateMessageToEvents({
       type: "stream_event",
       event: {
         type: "message_delta",
@@ -1085,138 +1004,132 @@ describe("ClaudeAgentSession context window usage", () => {
       session_id: "session-1",
     } as unknown as SDKMessage);
 
-    expect(events).toContainEqual({
-      type: "usage_updated",
-      provider: "claude",
-      usage: {
-        contextWindowUsedTokens: 175,
-      },
-    });
+    expect([...startEvents, ...deltaEvents].some((event) => event.type === "usage_updated")).toBe(
+      false,
+    );
   });
 
-  test("task_progress usage takes priority over derived result usage", async () => {
-    const session = await createSessionForTest();
-
-    session.translateMessageToEvents({
-      type: "system",
-      subtype: "task_progress",
-      task_id: "task-1",
-      description: "Processing",
-      usage: {
-        total_tokens: 999,
-        tool_uses: 1,
-        duration_ms: 50,
-        input_tokens: 345,
-        cache_read_input_tokens: 55,
-      },
-      uuid: "task-progress-1",
-      session_id: "session-1",
-    });
-
-    const usage = session.convertUsage({
-      type: "result",
-      subtype: "success",
-      usage: {
-        input_tokens: 10,
-        cache_creation_input_tokens: 3,
-        cache_read_input_tokens: 5,
-        output_tokens: 7,
-      },
-      total_cost_usd: 0.12,
-    });
-
-    expect(usage).toEqual({
-      inputTokens: 10,
-      cachedInputTokens: 5,
-      outputTokens: 7,
-      totalCostUsd: 0.12,
-      contextWindowUsedTokens: 999,
-    });
-  });
-
-  test("contextWindowUsedTokens persists across turns from last task_progress", async () => {
-    const queryFactory = createQueryFactoryForTurns([
+  test("run reads context window usage from the SDK control plane", async () => {
+    const queryFactory = createQueryFactoryForTurns(
       [
-        {
-          type: "system",
-          subtype: "init",
-          session_id: "session-1",
-          permissionMode: "default",
-          model: "claude-sonnet-4-6",
-        },
-        {
-          type: "system",
-          subtype: "task_progress",
-          task_id: "task-1",
-          description: "Processing",
-          usage: {
-            total_tokens: 999,
-            tool_uses: 1,
-            duration_ms: 50,
-            input_tokens: 345,
-            cache_read_input_tokens: 55,
+        [
+          {
+            type: "system",
+            subtype: "init",
+            session_id: "session-1",
+            permissionMode: "default",
+            model: "claude-sonnet-4-6",
           },
-          uuid: "task-progress-1",
-          session_id: "session-1",
-        },
-        {
-          type: "result",
-          subtype: "success",
-          duration_ms: 100,
-          duration_api_ms: 75,
-          is_error: false,
-          num_turns: 1,
-          result: "done",
-          stop_reason: null,
-          total_cost_usd: 0.25,
-          usage: {
-            input_tokens: 10,
-            cache_read_input_tokens: 5,
-            output_tokens: 7,
+          {
+            type: "result",
+            subtype: "success",
+            duration_ms: 100,
+            duration_api_ms: 75,
+            is_error: false,
+            num_turns: 1,
+            result: "done",
+            stop_reason: null,
+            total_cost_usd: 0.25,
+            usage: {
+              input_tokens: 10,
+              cache_read_input_tokens: 5,
+              output_tokens: 7,
+            },
+            permission_denials: [],
+            uuid: "result-1",
+            session_id: "session-1",
           },
-          modelUsage: {
-            "claude-sonnet-4-6": { contextWindow: 200_000 },
-          },
-          permission_denials: [],
-          uuid: "result-1",
-          session_id: "session-1",
-        },
+        ],
       ],
-      [
-        {
-          type: "result",
-          subtype: "success",
-          duration_ms: 110,
-          duration_api_ms: 80,
-          is_error: false,
-          num_turns: 1,
-          result: "still done",
-          stop_reason: null,
-          total_cost_usd: 0.1,
-          usage: {
-            input_tokens: 11,
-            cache_creation_input_tokens: 3,
-            cache_read_input_tokens: 6,
-            output_tokens: 8,
-          },
-          modelUsage: {
-            "claude-sonnet-4-6": { contextWindow: 200_000 },
-          },
-          permission_denials: [],
-          uuid: "result-2",
-          session_id: "session-1",
-        },
-      ],
-    ]);
+      [{ totalTokens: 42_000, maxTokens: 200_000 }],
+    );
     const client = new ClaudeAgentClient({
       logger,
       queryFactory,
       resolveBinary: async () => "/test/claude/bin",
     });
-    const session = await client.createSession({
-      provider: "claude",
-      cwd: process.cwd(),
+    const session = await client.createSession({ provider: "claude", cwd: process.cwd() });
+
+    try {
+      const result = await session.run("turn 1");
+
+      expect(result.usage).toEqual({
+        inputTokens: 10,
+        cachedInputTokens: 5,
+        outputTokens: 7,
+        totalCostUsd: 0.25,
+        contextWindowUsedTokens: 42_000,
+        contextWindowMaxTokens: 200_000,
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("context window usage is refreshed on every completed turn", async () => {
+    const queryFactory = createQueryFactoryForTurns(
+      [
+        [
+          {
+            type: "system",
+            subtype: "init",
+            session_id: "session-1",
+            permissionMode: "default",
+            model: "claude-sonnet-4-6",
+          },
+          {
+            type: "result",
+            subtype: "success",
+            duration_ms: 100,
+            duration_api_ms: 75,
+            is_error: false,
+            num_turns: 1,
+            result: "done",
+            stop_reason: null,
+            total_cost_usd: 0.25,
+            usage: {
+              input_tokens: 10,
+              cache_read_input_tokens: 5,
+              output_tokens: 7,
+            },
+            permission_denials: [],
+            uuid: "result-1",
+            session_id: "session-1",
+          },
+        ],
+        [
+          {
+            type: "result",
+            subtype: "success",
+            duration_ms: 110,
+            duration_api_ms: 80,
+            is_error: false,
+            num_turns: 1,
+            result: "still done",
+            stop_reason: null,
+            total_cost_usd: 0.1,
+            usage: {
+              input_tokens: 11,
+              cache_read_input_tokens: 6,
+              output_tokens: 8,
+            },
+            permission_denials: [],
+            uuid: "result-2",
+            session_id: "session-1",
+          },
+        ],
+      ],
+      [
+        { totalTokens: 42_000, maxTokens: 200_000 },
+        { totalTokens: 12_000, maxTokens: 200_000 },
+      ],
+    );
+    const client = new ClaudeAgentClient({
+      logger,
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
     });
+    const session = await client.createSession({ provider: "claude", cwd: process.cwd() });
 
     try {
       const firstTurn = await session.run("turn 1");
@@ -1227,175 +1140,53 @@ describe("ClaudeAgentSession context window usage", () => {
         cachedInputTokens: 5,
         outputTokens: 7,
         totalCostUsd: 0.25,
+        contextWindowUsedTokens: 42_000,
         contextWindowMaxTokens: 200_000,
-        contextWindowUsedTokens: 999,
       });
-      // Turn 2 has no task_progress, so contextWindowUsedTokens retains the
-      // last known value from turn 1 rather than deriving from accumulated
-      // result.usage (which would be incorrect — those are session-level totals).
       expect(secondTurn.usage).toEqual({
         inputTokens: 11,
         cachedInputTokens: 6,
         outputTokens: 8,
         totalCostUsd: 0.1,
+        contextWindowUsedTokens: 12_000,
         contextWindowMaxTokens: 200_000,
-        contextWindowUsedTokens: 999,
       });
     } finally {
       await session.close();
     }
   });
 
-  test("convertUsage derives used tokens from result usage as fallback when task_progress is missing", async () => {
+  test("compact boundary post tokens update context window usage immediately", async () => {
     const session = await createSessionForTest();
 
-    const usage = session.convertUsage({
-      type: "result",
-      subtype: "success",
-      usage: {
-        input_tokens: 10,
-        cache_read_input_tokens: 5,
-        output_tokens: 7,
+    const events = session.translateMessageToEvents({
+      type: "system",
+      subtype: "compact_boundary",
+      compact_metadata: {
+        trigger: "auto",
+        pre_tokens: 180_000,
+        post_tokens: 12_345,
       },
-      total_cost_usd: 0.12,
-    });
-
-    expect(usage).toEqual({
-      inputTokens: 10,
-      cachedInputTokens: 5,
-      outputTokens: 7,
-      totalCostUsd: 0.12,
-      contextWindowUsedTokens: 22,
-    });
-  });
-
-  test("convertUsage uses per-request stream usage when no task_progress is available", async () => {
-    const session = await createSessionForTest();
-
-    session.translateMessageToEvents({
-      type: "stream_event",
-      event: {
-        type: "message_start",
-        message: {
-          usage: {
-            input_tokens: 100,
-            cache_creation_input_tokens: 20,
-            cache_read_input_tokens: 30,
-          },
-        },
-      },
-      session_id: "session-1",
-    } as unknown as SDKMessage);
-    session.translateMessageToEvents({
-      type: "stream_event",
-      event: {
-        type: "message_delta",
-        usage: {
-          output_tokens: 25,
-        },
-      },
+      uuid: "compact-1",
       session_id: "session-1",
     } as unknown as SDKMessage);
 
-    const usage = session.convertUsage({
-      type: "result",
-      subtype: "success",
-      usage: {
-        input_tokens: 10,
-        cache_read_input_tokens: 5,
-        output_tokens: 7,
-      },
-      total_cost_usd: 0.12,
-    });
-
-    expect(usage).toEqual({
-      inputTokens: 10,
-      cachedInputTokens: 5,
-      outputTokens: 7,
-      totalCostUsd: 0.12,
-      contextWindowUsedTokens: 175,
-    });
-  });
-
-  test("per-request stream usage is not cumulative across API calls in a turn", async () => {
-    const session = await createSessionForTest();
-
-    session.translateMessageToEvents({
-      type: "stream_event",
-      event: {
-        type: "message_start",
-        message: {
-          usage: {
-            input_tokens: 100,
-            cache_creation_input_tokens: 20,
-            cache_read_input_tokens: 30,
-          },
-        },
-      },
-      session_id: "session-1",
-    } as unknown as SDKMessage);
-    session.translateMessageToEvents({
-      type: "stream_event",
-      event: {
-        type: "message_delta",
-        usage: {
-          output_tokens: 25,
-        },
-      },
-      session_id: "session-1",
-    } as unknown as SDKMessage);
-
-    const secondStartEvents = session.translateMessageToEvents({
-      type: "stream_event",
-      event: {
-        type: "message_start",
-        message: {
-          usage: {
-            input_tokens: 40,
-            cache_creation_input_tokens: 5,
-            cache_read_input_tokens: 10,
-          },
-        },
-      },
-      session_id: "session-1",
-    } as unknown as SDKMessage);
-
-    expect(secondStartEvents).toContainEqual({
+    expect(events).toContainEqual({
       type: "usage_updated",
       provider: "claude",
       usage: {
-        contextWindowUsedTokens: 55,
+        contextWindowUsedTokens: 12_345,
       },
     });
-
-    session.translateMessageToEvents({
-      type: "stream_event",
-      event: {
-        type: "message_delta",
-        usage: {
-          output_tokens: 7,
-        },
+    expect(events).toContainEqual({
+      type: "timeline",
+      provider: "claude",
+      item: {
+        type: "compaction",
+        status: "completed",
+        trigger: "auto",
+        preTokens: 180_000,
       },
-      session_id: "session-1",
-    } as unknown as SDKMessage);
-
-    const usage = session.convertUsage({
-      type: "result",
-      subtype: "success",
-      usage: {
-        input_tokens: 10,
-        cache_read_input_tokens: 5,
-        output_tokens: 7,
-      },
-      total_cost_usd: 0.12,
-    });
-
-    expect(usage).toEqual({
-      inputTokens: 10,
-      cachedInputTokens: 5,
-      outputTokens: 7,
-      totalCostUsd: 0.12,
-      contextWindowUsedTokens: 62,
     });
   });
 

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -13,7 +13,6 @@ import {
   type Query,
   type SDKMessage,
   type SDKPartialAssistantMessage,
-  type SDKTaskProgressMessage,
   type SDKResultMessage,
   type SDKSystemMessage,
   type SDKUserMessage,
@@ -1442,85 +1441,12 @@ async function resolveClaudeAuth(
   }
 }
 
-function extractContextWindowSize(modelUsage: unknown): number | undefined {
-  const usageRecord = toObjectRecord(modelUsage);
-  if (!usageRecord) {
-    return undefined;
-  }
-
-  let maxContextWindow: number | undefined;
-  for (const value of Object.values(usageRecord)) {
-    const valueRecord = toObjectRecord(value);
-    if (!valueRecord) {
-      continue;
-    }
-    const contextWindow = valueRecord.contextWindow;
-    if (
-      typeof contextWindow !== "number" ||
-      !Number.isFinite(contextWindow) ||
-      contextWindow <= 0
-    ) {
-      continue;
-    }
-    maxContextWindow = Math.max(maxContextWindow ?? 0, contextWindow);
-  }
-
-  return maxContextWindow;
+function readFiniteNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
-function readUsageTotalTokens(usage: unknown): number | undefined {
-  if (!usage || typeof usage !== "object") {
-    return undefined;
-  }
-  const totalTokens = (usage as { total_tokens?: unknown }).total_tokens;
-  if (typeof totalTokens !== "number" || !Number.isFinite(totalTokens) || totalTokens < 0) {
-    return undefined;
-  }
-  return totalTokens;
-}
-
-function readContextWindowUsedTokensFromTaskProgress(
-  message: SDKTaskProgressMessage,
-): number | undefined {
-  return readUsageTotalTokens(message.usage);
-}
-
-function readUsageFromTaskNotification(message: { usage?: unknown }): number | undefined {
-  return readUsageTotalTokens(message.usage);
-}
-
-function readStreamRequestInputTokens(event: Record<string, unknown>): number | undefined {
-  const messageUsage = toObjectRecord(toObjectRecord(event.message)?.usage);
-  if (!messageUsage) {
-    return undefined;
-  }
-  const usage = messageUsage;
-  const inputTokens =
-    typeof usage.input_tokens === "number" && Number.isFinite(usage.input_tokens)
-      ? usage.input_tokens
-      : undefined;
-  const cacheCreationInputTokens =
-    typeof usage.cache_creation_input_tokens === "number" &&
-    Number.isFinite(usage.cache_creation_input_tokens)
-      ? usage.cache_creation_input_tokens
-      : 0;
-  const cacheReadInputTokens =
-    typeof usage.cache_read_input_tokens === "number" &&
-    Number.isFinite(usage.cache_read_input_tokens)
-      ? usage.cache_read_input_tokens
-      : 0;
-  if (typeof inputTokens !== "number" || inputTokens < 0) {
-    return undefined;
-  }
-  return inputTokens + cacheCreationInputTokens + cacheReadInputTokens;
-}
-
-function readStreamRequestOutputTokens(event: Record<string, unknown>): number | undefined {
-  const outputTokens = toObjectRecord(event.usage)?.output_tokens;
-  if (typeof outputTokens !== "number" || !Number.isFinite(outputTokens) || outputTokens < 0) {
-    return undefined;
-  }
-  return outputTokens;
+function readFinitePositiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
 class ClaudeAgentSession implements AgentSession {
@@ -1571,8 +1497,6 @@ class ClaudeAgentSession implements AgentSession {
   private activeTurnHasAssistantText = false;
   private lastContextWindowUsedTokens: number | undefined;
   private lastContextWindowMaxTokens: number | undefined;
-  private lastStreamRequestInputTokens: number | undefined;
-  private lastStreamRequestOutputTokens: number | undefined;
   private userMessageIds: string[] = [];
   private recentStderr = "";
   private closed = false;
@@ -2759,7 +2683,7 @@ class ClaudeAgentSession implements AgentSession {
       if (await this.handleMissingResumedConversation(message, activeQuery)) {
         return true;
       }
-      this.routeSdkMessageFromPump(message);
+      await this.routeSdkMessageFromPump(message, activeQuery);
       return false;
     };
     const drainActiveQuery = async (): Promise<boolean> => {
@@ -2847,7 +2771,7 @@ class ClaudeAgentSession implements AgentSession {
     );
   }
 
-  private routeSdkMessageFromPump(message: SDKMessage): void {
+  private async routeSdkMessageFromPump(message: SDKMessage, activeQuery: Query): Promise<void> {
     if (this.shouldSuppressStaleResult(message)) {
       return;
     }
@@ -2859,6 +2783,8 @@ class ClaudeAgentSession implements AgentSession {
     if (!isForeground && !this.autonomousTurn && message.type === "result") {
       return;
     }
+
+    const contextUsageEvent = await this.readContextUsageEventForMessage(message, activeQuery);
 
     const turnId = this.activeForegroundTurnId ?? this.autonomousTurn?.id ?? null;
     const identifiers = readEventIdentifiers(message);
@@ -2900,19 +2826,16 @@ class ClaudeAgentSession implements AgentSession {
       (event) => !this.isEchoedForegroundUserMessage(event),
     );
 
-    const events = [...filteredMessageEvents, ...assistantTimelineEvents];
+    const events = [
+      ...(contextUsageEvent ? [contextUsageEvent] : []),
+      ...filteredMessageEvents,
+      ...assistantTimelineEvents,
+    ];
 
     if (events.length === 0) {
       return;
     }
-    if (
-      this.pendingInterruptAbort &&
-      message.type === "result" &&
-      events.some((event) => event.type === "turn_completed" || event.type === "turn_failed") &&
-      (!this.activeForegroundTurnId || !this.foregroundHasVisibleActivity)
-    ) {
-      this.pendingInterruptAbort = false;
-      this.logger.debug("Suppressing stale Claude interrupt terminal result");
+    if (this.suppressPendingInterruptTerminalResult(message, events)) {
       return;
     }
     if (
@@ -2933,6 +2856,38 @@ class ClaudeAgentSession implements AgentSession {
     }
 
     this.dispatchEvents(events);
+  }
+
+  private suppressPendingInterruptTerminalResult(
+    message: SDKMessage,
+    events: AgentStreamEvent[],
+  ): boolean {
+    if (!this.pendingInterruptAbort) {
+      return false;
+    }
+    if (message.type !== "result") {
+      return false;
+    }
+    if (!events.some((event) => event.type === "turn_completed" || event.type === "turn_failed")) {
+      return false;
+    }
+    if (this.activeForegroundTurnId && this.foregroundHasVisibleActivity) {
+      return false;
+    }
+
+    this.pendingInterruptAbort = false;
+    this.logger.debug("Suppressing stale Claude interrupt terminal result");
+    return true;
+  }
+
+  private async readContextUsageEventForMessage(
+    message: SDKMessage,
+    activeQuery: Query,
+  ): Promise<AgentStreamEvent | null> {
+    if (message.type !== "result") {
+      return null;
+    }
+    return await this.readContextUsageEvent(activeQuery);
   }
 
   private async handleMissingResumedConversation(
@@ -3095,6 +3050,10 @@ class ClaudeAgentSession implements AgentSession {
     }
     if (message.subtype === "compact_boundary") {
       const compactMetadata = readCompactionMetadata(message);
+      if (compactMetadata?.postTokens !== undefined) {
+        this.lastContextWindowUsedTokens = compactMetadata.postTokens;
+        events.push(this.createContextUsageUpdatedEvent());
+      }
       events.push({
         type: "timeline",
         item: {
@@ -3109,14 +3068,6 @@ class ClaudeAgentSession implements AgentSession {
     }
     if (message.subtype === "task_notification") {
       this.appendTaskNotificationEvents(message, events);
-      return;
-    }
-    if (message.subtype === "task_progress") {
-      this.lastContextWindowUsedTokens =
-        readContextWindowUsedTokensFromTaskProgress(message) ?? this.lastContextWindowUsedTokens;
-      if (typeof this.lastContextWindowUsedTokens === "number") {
-        events.push(this.createUsageUpdatedEvent(this.lastContextWindowUsedTokens));
-      }
     }
   }
 
@@ -3141,11 +3092,6 @@ class ClaudeAgentSession implements AgentSession {
         item: taskNotificationItem,
         provider: "claude",
       });
-    }
-    const usage = readUsageFromTaskNotification(message);
-    if (typeof usage === "number") {
-      this.lastContextWindowUsedTokens = usage;
-      events.push(this.createUsageUpdatedEvent(usage));
     }
   }
 
@@ -3221,10 +3167,6 @@ class ClaudeAgentSession implements AgentSession {
     events: AgentStreamEvent[],
     options: { suppressAssistantText?: boolean; suppressReasoning?: boolean } | undefined,
   ): void {
-    const usageUpdatedEvent = this.trackStreamEventUsage(message.event);
-    if (usageUpdatedEvent) {
-      events.push(usageUpdatedEvent);
-    }
     const timelineItems = this.mapPartialEvent(message.event, {
       suppressAssistantText: options?.suppressAssistantText ?? false,
       suppressReasoning: options?.suppressReasoning ?? false,
@@ -3238,7 +3180,7 @@ class ClaudeAgentSession implements AgentSession {
     message: Extract<SDKMessage, { type: "result" }>,
     events: AgentStreamEvent[],
   ): void {
-    const usage = this.convertUsage(message, message.modelUsage);
+    const usage = this.convertUsage(message);
     if (message.subtype === "success") {
       // Built-in slash commands (e.g. /voice, /usage, "Unknown command: …")
       // run client-side in the Claude CLI with no model turn — output_tokens
@@ -3399,7 +3341,7 @@ class ClaudeAgentSession implements AgentSession {
     return null;
   }
 
-  private convertUsage(message: SDKResultMessage, modelUsage?: unknown): AgentUsage | undefined {
+  private convertUsage(message: SDKResultMessage): AgentUsage | undefined {
     if (!message.usage) {
       return undefined;
     }
@@ -3409,89 +3351,48 @@ class ClaudeAgentSession implements AgentSession {
       outputTokens: message.usage.output_tokens,
       totalCostUsd: message.total_cost_usd,
     };
-    const contextWindowMaxTokens = extractContextWindowSize(modelUsage ?? message.modelUsage);
-    if (contextWindowMaxTokens !== undefined) {
-      this.lastContextWindowMaxTokens = contextWindowMaxTokens;
-      usage.contextWindowMaxTokens = contextWindowMaxTokens;
-    } else if (this.lastContextWindowMaxTokens !== undefined) {
-      usage.contextWindowMaxTokens = this.lastContextWindowMaxTokens;
-    }
-    if (typeof this.lastContextWindowUsedTokens === "number") {
-      // task_progress.total_tokens is the accurate context window fill level.
-      // Prefer it over result.usage which contains accumulated session totals.
-      usage.contextWindowUsedTokens = this.lastContextWindowUsedTokens;
-    } else if (
-      typeof this.lastStreamRequestInputTokens === "number" &&
-      typeof this.lastStreamRequestOutputTokens === "number"
-    ) {
-      usage.contextWindowUsedTokens =
-        this.lastStreamRequestInputTokens + this.lastStreamRequestOutputTokens;
-    } else if (message.usage) {
-      // Fallback: derive from result.usage when no task_progress has been
-      // received yet. These values are accumulated across all API calls, but
-      // for the first turn they equal the per-call values so the estimate is
-      // reasonable. Once a task_progress arrives it takes over permanently.
-      const usageWithCacheCreation = message.usage as typeof message.usage & {
-        cache_creation_input_tokens?: number;
-      };
-      const derived =
-        (message.usage.input_tokens ?? 0) +
-        (usageWithCacheCreation.cache_creation_input_tokens ?? 0) +
-        (message.usage.cache_read_input_tokens ?? 0) +
-        (message.usage.output_tokens ?? 0);
-      if (Number.isFinite(derived) && derived > 0) {
-        usage.contextWindowUsedTokens = derived;
-      }
-    }
+    this.addLastContextUsage(usage);
     return usage;
   }
 
-  private createUsageUpdatedEvent(contextWindowUsedTokens: number): AgentStreamEvent {
-    const usage: AgentUsage = {
-      contextWindowUsedTokens,
-    };
+  private async readContextUsageEvent(activeQuery: Query): Promise<AgentStreamEvent | null> {
+    try {
+      const contextUsage = await withTimeout(
+        activeQuery.getContextUsage(),
+        3_000,
+        "getContextUsage timeout",
+      );
+      const usedTokens = readFiniteNonNegativeNumber(contextUsage.totalTokens);
+      const maxTokens = readFinitePositiveNumber(contextUsage.maxTokens);
+      if (usedTokens === undefined || maxTokens === undefined) {
+        return null;
+      }
+      this.lastContextWindowUsedTokens = usedTokens;
+      this.lastContextWindowMaxTokens = maxTokens;
+      return this.createContextUsageUpdatedEvent();
+    } catch (error) {
+      this.logger.warn({ err: error }, "Failed to read Claude context usage");
+      return null;
+    }
+  }
+
+  private addLastContextUsage(usage: AgentUsage): void {
+    if (this.lastContextWindowUsedTokens !== undefined) {
+      usage.contextWindowUsedTokens = this.lastContextWindowUsedTokens;
+    }
     if (this.lastContextWindowMaxTokens !== undefined) {
       usage.contextWindowMaxTokens = this.lastContextWindowMaxTokens;
     }
+  }
+
+  private createContextUsageUpdatedEvent(): AgentStreamEvent {
+    const usage: AgentUsage = {};
+    this.addLastContextUsage(usage);
     return {
       type: "usage_updated",
       provider: "claude",
       usage,
     };
-  }
-
-  private trackStreamEventUsage(event: unknown): AgentStreamEvent | null {
-    const streamEvent = toObjectRecord(event);
-    if (!streamEvent) {
-      return null;
-    }
-    const eventType = readTrimmedString(streamEvent.type);
-    if (eventType === "message_start") {
-      const inputTokens = readStreamRequestInputTokens(streamEvent);
-      if (typeof inputTokens !== "number") {
-        return null;
-      }
-      this.lastStreamRequestInputTokens = inputTokens;
-      this.lastStreamRequestOutputTokens = 0;
-    } else if (eventType === "message_delta") {
-      const outputTokens = readStreamRequestOutputTokens(streamEvent);
-      if (typeof outputTokens !== "number") {
-        return null;
-      }
-      this.lastStreamRequestOutputTokens = outputTokens;
-    } else {
-      return null;
-    }
-
-    if (
-      typeof this.lastStreamRequestInputTokens !== "number" ||
-      typeof this.lastStreamRequestOutputTokens !== "number"
-    ) {
-      return null;
-    }
-    return this.createUsageUpdatedEvent(
-      this.lastStreamRequestInputTokens + this.lastStreamRequestOutputTokens,
-    );
   }
 
   private handlePermissionRequest: CanUseTool = async (
@@ -4365,7 +4266,9 @@ function hasToolLikeBlock(block?: ClaudeContentChunk | null): boolean {
   return type.includes("tool");
 }
 
-function readCompactionMetadata(source: unknown): { trigger?: string; preTokens?: number } | null {
+function readCompactionMetadata(
+  source: unknown,
+): { trigger?: string; preTokens?: number; postTokens?: number } | null {
   const sourceRecord = toObjectRecord(source);
   if (!sourceRecord) {
     return null;
@@ -4381,9 +4284,9 @@ function readCompactionMetadata(source: unknown): { trigger?: string; preTokens?
       continue;
     }
     const trigger = typeof metadata.trigger === "string" ? metadata.trigger : undefined;
-    const preTokensRaw = metadata.preTokens ?? metadata.pre_tokens;
-    const preTokens = typeof preTokensRaw === "number" ? preTokensRaw : undefined;
-    return { trigger, preTokens };
+    const preTokens = readFiniteNonNegativeNumber(metadata.preTokens ?? metadata.pre_tokens);
+    const postTokens = readFiniteNonNegativeNumber(metadata.postTokens ?? metadata.post_tokens);
+    return { trigger, preTokens, postTokens };
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Read Claude context window usage from SDK message usage instead of deriving it from streamed content blocks.
- Merge incremental `usage_updated` events so context usage and token/cost usage are preserved together.
- Update Claude provider fixtures and add agent-manager coverage for usage merging.

## Test plan
- [ ] Not run during this PR creation session.