### PR TITLE
Fix startup workspace restore

### DIFF
--- a/packages/app/src/app/index.test.tsx
+++ b/packages/app/src/app/index.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HostRuntimeBootstrapState } from "./_layout";
 import type { ActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
 
-const { navigateToWorkspaceMock, redirectMock, state } = vi.hoisted(() => {
+const { redirectMock, state } = vi.hoisted(() => {
   const hoistedState = {
     pathname: "/",
     bootstrapState: {
@@ -23,7 +23,6 @@ const { navigateToWorkspaceMock, redirectMock, state } = vi.hoisted(() => {
   };
 
   return {
-    navigateToWorkspaceMock: vi.fn(),
     redirectMock: vi.fn(),
     state: hoistedState,
   };
@@ -51,7 +50,6 @@ vi.mock("@/screens/startup-splash-screen", () => ({
 }));
 
 vi.mock("@/stores/navigation-active-workspace-store", () => ({
-  navigateToWorkspace: navigateToWorkspaceMock,
   useIsLastWorkspaceSelectionHydrated: () => state.isWorkspaceSelectionLoaded,
   useLastWorkspaceSelection: () => state.workspaceSelection,
 }));
@@ -72,7 +70,6 @@ describe("Index route startup navigation", () => {
     state.anyOnlineHostServerId = null;
     state.isWorkspaceSelectionLoaded = true;
     state.workspaceSelection = null;
-    navigateToWorkspaceMock.mockReset();
     redirectMock.mockReset();
 
     container = document.createElement("div");
@@ -108,7 +105,6 @@ describe("Index route startup navigation", () => {
     await renderIndex();
 
     expect(container.querySelector("[data-testid='startup-splash']")).not.toBeNull();
-    expect(navigateToWorkspaceMock).not.toHaveBeenCalled();
     expect(redirectMock).not.toHaveBeenCalled();
   });
 
@@ -118,11 +114,8 @@ describe("Index route startup navigation", () => {
 
     await renderIndex();
 
-    expect(navigateToWorkspaceMock).toHaveBeenCalledWith("server-1", "workspace-a", {
-      currentPathname: "/",
-    });
-    expect(redirectMock).not.toHaveBeenCalled();
-    expect(container.querySelector("[data-testid='startup-splash']")).not.toBeNull();
+    expect(redirectMock).toHaveBeenCalledWith("/h/server-1/workspace/workspace-a");
+    expect(container.querySelector("[data-testid='redirect']")).not.toBeNull();
   });
 
   it("restores the persisted workspace even when the first online host is different", async () => {
@@ -131,10 +124,7 @@ describe("Index route startup navigation", () => {
 
     await renderIndex();
 
-    expect(navigateToWorkspaceMock).toHaveBeenCalledWith("server-1", "workspace-a", {
-      currentPathname: "/",
-    });
-    expect(redirectMock).not.toHaveBeenCalled();
+    expect(redirectMock).toHaveBeenCalledWith("/h/server-1/workspace/workspace-a");
   });
 
   it("navigates to the host root when no persisted workspace exists", async () => {

--- a/packages/app/src/app/index.tsx
+++ b/packages/app/src/app/index.tsx
@@ -7,11 +7,11 @@ import {
   resolveStartupWorkspaceSelection,
 } from "@/app/host-runtime-bootstrap";
 import {
-  navigateToWorkspace,
   useIsLastWorkspaceSelectionHydrated,
   useLastWorkspaceSelection,
 } from "@/stores/navigation-active-workspace-store";
 import { shouldUseDesktopDaemon } from "@/desktop/daemon/desktop-daemon";
+import { buildHostWorkspaceRoute } from "@/utils/host-routes";
 
 const isDesktop = shouldUseDesktopDaemon();
 
@@ -37,17 +37,15 @@ export default function Index() {
     hasGivenUpWaitingForHost: bootstrapState.hasGivenUpWaitingForHost,
   });
 
-  React.useEffect(() => {
-    if (!startupWorkspaceSelection) {
-      return;
-    }
-    navigateToWorkspace(startupWorkspaceSelection.serverId, startupWorkspaceSelection.workspaceId, {
-      currentPathname: pathname,
-    });
-  }, [pathname, startupWorkspaceSelection]);
-
   if (startupWorkspaceSelection) {
-    return <StartupSplashScreen bootstrapState={isDesktop ? bootstrapState : undefined} />;
+    return (
+      <Redirect
+        href={buildHostWorkspaceRoute(
+          startupWorkspaceSelection.serverId,
+          startupWorkspaceSelection.workspaceId,
+        )}
+      />
+    );
   }
 
   if (redirectRoute) {


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fixes the Playwright redbox affecting current PRs by making startup workspace restore declarative.

When the app has a persisted workspace selection, `src/app/index.tsx` now renders Expo Router `<Redirect>` to the host workspace route instead of calling `navigateToWorkspace()` from startup render effects. That avoids navigating before the root layout has mounted.

This should unblock the Playwright failures currently seen on #1110, #1106, #1105, #1103, and #1091. Those PRs should rebase after this lands.

### How did you verify it

- `npm run test --workspace=@getpaseo/app -- src/app/index.test.tsx`
- `npm run test:e2e --workspace=@getpaseo/app -- e2e/workspace-open-in-editor.spec.ts`
- `npm run format`
- `npm run typecheck`
- `npm run lint`

No visual UI change, so no screenshots/video.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
