### PR TITLE
fix(cli): avoid heavy fetches in status and worktree ls

### DIFF
--- a/packages/cli/src/commands/daemon/status.ts
+++ b/packages/cli/src/commands/daemon/status.ts
@@ -242,7 +242,7 @@ async function probeDaemonOverWebsocket(args: {
   const supportsDaemonStatusRpc =
     client.getLastServerInfoMessage()?.features?.daemonStatusRpc === true;
   try {
-    const agentsPayload = await client.fetchAgents({ filter: { includeArchived: true } });
+    const agentsPayload = await client.fetchAgents({ scope: "active" });
     const agents = agentsPayload.entries.map((entry) => entry.agent);
     const runningAgents = agents.filter((a) => a.status === "running").length;
     const idleAgents = agents.filter((a) => a.status === "idle").length;
@@ -290,10 +290,9 @@ async function probeDaemonOverWebsocket(args: {
     return {
       connectedDaemon: "reachable",
       daemonVersion,
-      localDaemonOverride: state.running ? "unresponsive" : undefined,
       note: state.running
-        ? `Local daemon PID is running but API requests to ${host} failed`
-        : `Connected daemon websocket is reachable at ${host} but fetch_agents failed`,
+        ? `Local daemon PID is running and websocket is reachable at ${host}, but active agent counts are unavailable`
+        : `Connected daemon websocket is reachable at ${host} but active agent counts are unavailable`,
     };
   } finally {
     await client.close().catch(() => {});

--- a/packages/cli/src/commands/worktree/archive.ts
+++ b/packages/cli/src/commands/worktree/archive.ts
@@ -8,6 +8,7 @@ import type {
   OutputSchema,
   CommandError,
 } from "../../output/index.js";
+import { findManagedWorktreeByNameOrBranch, listManagedWorktrees } from "./ls.js";
 
 /** Result type for worktree archive command */
 export interface WorktreeArchiveResult {
@@ -34,6 +35,33 @@ export interface WorktreeArchiveOptions extends CommandOptions {
 }
 
 export type WorktreeArchiveCommandResult = SingleResult<WorktreeArchiveResult>;
+
+async function resolveWorktreeFromDaemon(client: DaemonClient, nameArg: string) {
+  const listResponse = await client.getPaseoWorktreeList({});
+
+  if (listResponse.error) {
+    const error: CommandError = {
+      code: "WORKTREE_LIST_FAILED",
+      message: `Failed to list worktrees: ${listResponse.error.message}`,
+    };
+    throw error;
+  }
+
+  return findManagedWorktreeByNameOrBranch(
+    listResponse.worktrees.map((worktree) => ({
+      worktreePath: worktree.worktreePath,
+      createdAt: worktree.createdAt,
+      branchName: worktree.branchName ?? null,
+      head: worktree.head ?? null,
+    })),
+    nameArg,
+  );
+}
+
+async function resolveWorktreeForArchive(client: DaemonClient, nameArg: string) {
+  const localMatch = findManagedWorktreeByNameOrBranch(await listManagedWorktrees(), nameArg);
+  return localMatch ?? (await resolveWorktreeFromDaemon(client, nameArg));
+}
 
 export async function runArchiveCommand(
   nameArg: string,
@@ -66,23 +94,7 @@ export async function runArchiveCommand(
   }
 
   try {
-    // Get the list of worktrees first to resolve the name
-    const listResponse = await client.getPaseoWorktreeList({});
-
-    if (listResponse.error) {
-      const error: CommandError = {
-        code: "WORKTREE_LIST_FAILED",
-        message: `Failed to list worktrees: ${listResponse.error.message}`,
-      };
-      throw error;
-    }
-
-    // Find the worktree by name or branch
-    const worktree = listResponse.worktrees.find((wt) => {
-      const name = path.basename(wt.worktreePath);
-      return name === nameArg || wt.branchName === nameArg;
-    });
-
+    const worktree = await resolveWorktreeForArchive(client, nameArg);
     if (!worktree) {
       const error: CommandError = {
         code: "WORKTREE_NOT_FOUND",
@@ -93,9 +105,18 @@ export async function runArchiveCommand(
     }
 
     // Archive the worktree
-    const response = await client.archivePaseoWorktree({
+    let response = await client.archivePaseoWorktree({
       worktreePath: worktree.worktreePath,
     });
+
+    if (response.error?.code === "NOT_ALLOWED") {
+      const daemonWorktree = await resolveWorktreeFromDaemon(client, nameArg);
+      if (daemonWorktree && daemonWorktree.worktreePath !== worktree.worktreePath) {
+        response = await client.archivePaseoWorktree({
+          worktreePath: daemonWorktree.worktreePath,
+        });
+      }
+    }
 
     await client.close();
 

--- a/packages/cli/src/commands/worktree/ls.ts
+++ b/packages/cli/src/commands/worktree/ls.ts
@@ -133,6 +133,19 @@ export function parseGitWorktreeList(output: string): PaseoWorktreeListEntry[] {
   return entries;
 }
 
+export function findManagedWorktreeByNameOrBranch(
+  worktrees: PaseoWorktreeListEntry[],
+  nameArg: string,
+): PaseoWorktreeListEntry | null {
+  const target = nameArg.trim();
+  return (
+    worktrees.find((worktree) => {
+      const name = basename(worktree.worktreePath);
+      return name === target || worktree.branchName === target;
+    }) ?? null
+  );
+}
+
 function resolveCreatedAt(worktreePath: string): string {
   try {
     const stats = statSync(worktreePath);
@@ -167,7 +180,7 @@ function listGitWorktreeCandidateCwds(projectDir: string): string[] {
   }
 }
 
-async function listManagedWorktrees(): Promise<PaseoWorktreeListEntry[]> {
+export async function listManagedWorktrees(): Promise<PaseoWorktreeListEntry[]> {
   const worktreesByPath = new Map<string, PaseoWorktreeListEntry>();
 
   for (const projectDir of listManagedWorktreeProjectDirs()) {

--- a/packages/cli/src/commands/worktree/ls.ts
+++ b/packages/cli/src/commands/worktree/ls.ts
@@ -1,7 +1,8 @@
 import type { Command } from "commander";
+import { readdirSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join, sep } from "node:path";
-import type { DaemonClient } from "@getpaseo/server";
+import { basename, join, resolve, sep } from "node:path";
+import { execCommand, type DaemonClient } from "@getpaseo/server";
 import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
 import type { CommandOptions, ListResult, OutputSchema, CommandError } from "../../output/index.js";
 
@@ -40,6 +41,34 @@ function isAgentInManagedWorktree(agentCwd: string): boolean {
   return agentCwd === worktreesDir || agentCwd.startsWith(worktreesDir + sep);
 }
 
+function getManagedWorktreeRootForCwd(agentCwd: string): string | null {
+  if (!isAgentInManagedWorktree(agentCwd)) {
+    return null;
+  }
+
+  const worktreesDir = resolvePaseoWorktreesDir();
+  const relativePath = agentCwd.slice(worktreesDir.length + sep.length);
+  const [projectDir, worktreeDir] = relativePath.split(sep).filter((part) => part.length > 0);
+  return projectDir && worktreeDir ? join(worktreesDir, projectDir, worktreeDir) : null;
+}
+
+function normalizePath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function isPathWithinOrEqual(parent: string, candidate: string): boolean {
+  const normalizedParent = normalizePath(parent);
+  const normalizedCandidate = normalizePath(candidate);
+  return (
+    normalizedCandidate === normalizedParent ||
+    normalizedCandidate.startsWith(normalizedParent + sep)
+  );
+}
+
 /** Schema for worktree ls output */
 export const worktreeLsSchema: OutputSchema<WorktreeListItem> = {
   idField: "name",
@@ -55,6 +84,124 @@ export type WorktreeLsResult = ListResult<WorktreeListItem>;
 
 export interface WorktreeLsOptions extends CommandOptions {
   host?: string;
+}
+
+export interface PaseoWorktreeListEntry {
+  worktreePath: string;
+  createdAt: string;
+  branchName: string | null;
+  head: string | null;
+}
+
+export function parseGitWorktreeList(output: string): PaseoWorktreeListEntry[] {
+  const entries: PaseoWorktreeListEntry[] = [];
+  let current: { worktreePath: string; branchName: string | null; head: string | null } | null =
+    null;
+
+  for (const line of output.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      if (current) {
+        entries.push({ ...current, createdAt: resolveCreatedAt(current.worktreePath) });
+      }
+      current = {
+        worktreePath: line.slice("worktree ".length).trim(),
+        branchName: null,
+        head: null,
+      };
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    if (line.startsWith("branch ")) {
+      const ref = line.slice("branch ".length).trim();
+      current.branchName = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+    } else if (line.startsWith("HEAD ")) {
+      current.head = line.slice("HEAD ".length).trim() || null;
+    } else if (line.trim().length === 0) {
+      entries.push({ ...current, createdAt: resolveCreatedAt(current.worktreePath) });
+      current = null;
+    }
+  }
+
+  if (current) {
+    entries.push({ ...current, createdAt: resolveCreatedAt(current.worktreePath) });
+  }
+
+  return entries;
+}
+
+function resolveCreatedAt(worktreePath: string): string {
+  try {
+    const stats = statSync(worktreePath);
+    const createdAtMs =
+      Number.isFinite(stats.birthtimeMs) && stats.birthtimeMs > 0
+        ? stats.birthtimeMs
+        : stats.ctimeMs;
+    return new Date(createdAtMs).toISOString();
+  } catch {
+    return new Date(0).toISOString();
+  }
+}
+
+function listManagedWorktreeProjectDirs(): string[] {
+  const worktreesDir = resolvePaseoWorktreesDir();
+  try {
+    return readdirSync(worktreesDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(worktreesDir, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+function listGitWorktreeCandidateCwds(projectDir: string): string[] {
+  try {
+    return readdirSync(projectDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(projectDir, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+async function listManagedWorktrees(): Promise<PaseoWorktreeListEntry[]> {
+  const worktreesByPath = new Map<string, PaseoWorktreeListEntry>();
+
+  for (const projectDir of listManagedWorktreeProjectDirs()) {
+    const candidateCwds = listGitWorktreeCandidateCwds(projectDir);
+    if (candidateCwds.length === 0) {
+      continue;
+    }
+
+    let stdout: string | null = null;
+    for (const cwd of candidateCwds) {
+      try {
+        ({ stdout } = await execCommand("git", ["worktree", "list", "--porcelain"], {
+          cwd,
+          timeout: 10_000,
+        }));
+        break;
+      } catch {
+        continue;
+      }
+    }
+
+    if (stdout === null) {
+      continue;
+    }
+
+    for (const worktree of parseGitWorktreeList(stdout)) {
+      if (!isPathWithinOrEqual(projectDir, worktree.worktreePath)) {
+        continue;
+      }
+      worktreesByPath.set(worktree.worktreePath, worktree);
+    }
+  }
+
+  return Array.from(worktreesByPath.values());
 }
 
 export async function runLsCommand(
@@ -77,31 +224,24 @@ export async function runLsCommand(
   }
 
   try {
-    const agentsPayload = await client.fetchAgents({ filter: { includeArchived: true } });
+    const [agentsPayload, worktrees] = await Promise.all([
+      client.fetchAgents({ scope: "active" }),
+      listManagedWorktrees(),
+    ]);
     const agents = agentsPayload.entries.map((entry) => entry.agent);
 
-    // Get worktree list from daemon
-    const response = await client.getPaseoWorktreeList({});
-
     await client.close();
-
-    if (response.error) {
-      const error: CommandError = {
-        code: "WORKTREE_LIST_FAILED",
-        message: `Failed to list worktrees: ${response.error.message}`,
-      };
-      throw error;
-    }
 
     // Build a map of worktree paths to agent IDs
     const worktreeAgentMap = new Map<string, string>();
     for (const agent of agents) {
-      if (isAgentInManagedWorktree(agent.cwd)) {
-        worktreeAgentMap.set(agent.cwd, agent.id.slice(0, 7));
+      const worktreeRoot = getManagedWorktreeRootForCwd(agent.cwd);
+      if (worktreeRoot) {
+        worktreeAgentMap.set(worktreeRoot, agent.id.slice(0, 7));
       }
     }
 
-    const items: WorktreeListItem[] = response.worktrees.map((wt) => ({
+    const items: WorktreeListItem[] = worktrees.map((wt) => ({
       name: extractWorktreeName(wt.worktreePath),
       branch: wt.branchName ?? "-",
       cwd: shortenPath(wt.worktreePath),

--- a/packages/cli/tests/20-worktree-ls-paths.test.ts
+++ b/packages/cli/tests/20-worktree-ls-paths.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
+  findManagedWorktreeByNameOrBranch,
   parseGitWorktreeList,
   resolvePaseoHomePath,
   resolvePaseoWorktreesDir,
@@ -72,6 +73,29 @@ detached
       ],
     );
     console.log("\u2713 git worktree porcelain output is parsed\n");
+  }
+
+  {
+    console.log("Test 4: resolves worktrees by directory name or branch name");
+    const entries = parseGitWorktreeList(`worktree /tmp/paseo-home/worktrees/project/feature-a
+HEAD 2222222222222222222222222222222222222222
+branch refs/heads/feature-a
+
+worktree /tmp/paseo-home/worktrees/project/readable-name
+HEAD 4444444444444444444444444444444444444444
+branch refs/heads/feat/long-branch
+`);
+
+    assert.strictEqual(
+      findManagedWorktreeByNameOrBranch(entries, "feature-a")?.worktreePath,
+      "/tmp/paseo-home/worktrees/project/feature-a",
+    );
+    assert.strictEqual(
+      findManagedWorktreeByNameOrBranch(entries, "feat/long-branch")?.worktreePath,
+      "/tmp/paseo-home/worktrees/project/readable-name",
+    );
+    assert.strictEqual(findManagedWorktreeByNameOrBranch(entries, "missing"), null);
+    console.log("\u2713 worktrees resolve by directory name or branch name\n");
   }
 } finally {
   if (originalPaseoHome === undefined) {

--- a/packages/cli/tests/20-worktree-ls-paths.test.ts
+++ b/packages/cli/tests/20-worktree-ls-paths.test.ts
@@ -3,7 +3,11 @@
 import assert from "node:assert";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { resolvePaseoHomePath, resolvePaseoWorktreesDir } from "../src/commands/worktree/ls.js";
+import {
+  parseGitWorktreeList,
+  resolvePaseoHomePath,
+  resolvePaseoWorktreesDir,
+} from "../src/commands/worktree/ls.js";
 
 console.log("=== Worktree LS Path Helper Tests ===\n");
 
@@ -26,6 +30,48 @@ try {
     assert.strictEqual(resolvePaseoHomePath(), join(homedir(), ".paseo"));
     assert.strictEqual(resolvePaseoWorktreesDir(), join(homedir(), ".paseo", "worktrees"));
     console.log("\u2713 fallback home path is derived from os.homedir()\n");
+  }
+
+  {
+    console.log("Test 3: parses git worktree porcelain output");
+    const entries = parseGitWorktreeList(`worktree /repo
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+worktree /tmp/paseo-home/worktrees/project/feature-a
+HEAD 2222222222222222222222222222222222222222
+branch refs/heads/feature-a
+
+worktree /tmp/paseo-home/worktrees/project/detached
+HEAD 3333333333333333333333333333333333333333
+detached
+`);
+
+    assert.deepStrictEqual(
+      entries.map((entry) => ({
+        worktreePath: entry.worktreePath,
+        branchName: entry.branchName,
+        head: entry.head,
+      })),
+      [
+        {
+          worktreePath: "/repo",
+          branchName: "main",
+          head: "1111111111111111111111111111111111111111",
+        },
+        {
+          worktreePath: "/tmp/paseo-home/worktrees/project/feature-a",
+          branchName: "feature-a",
+          head: "2222222222222222222222222222222222222222",
+        },
+        {
+          worktreePath: "/tmp/paseo-home/worktrees/project/detached",
+          branchName: null,
+          head: "3333333333333333333333333333333333333333",
+        },
+      ],
+    );
+    console.log("\u2713 git worktree porcelain output is parsed\n");
   }
 } finally {
   if (originalPaseoHome === undefined) {


### PR DESCRIPTION
## Summary

- make `paseo daemon status` fetch only active agents instead of archived agents
- avoid marking the daemon unresponsive when the websocket is reachable but agent counts fail
- make `paseo worktree ls` avoid the daemon worktree RPC and list managed worktrees locally with `git worktree list --porcelain`
- make `paseo worktree archive` resolve targets locally first, while still delegating the actual archive/delete operation to the daemon
- keep a daemon-list fallback for archive target resolution when local resolution misses or resolves a path the daemon rejects
- add coverage for parsing git worktree porcelain output and resolving worktrees by directory or branch name

## Why

`daemon status` and `worktree ls` previously fetched archived agents, which can force expensive project placement and git checkout refresh work when a daemon has many persisted agents. `worktree ls` also called the daemon worktree-list RPC, which computes checkout status/shortstat data and can become slow enough to time out.

`worktree archive` used the same daemon worktree-list RPC just to resolve `<name>` to a path before calling the archive RPC. This keeps the archive operation daemon-owned, but avoids the heavy list path in the common local case.

## Verification

- `npm run format:files -- packages/cli/src/commands/daemon/status.ts packages/cli/src/commands/worktree/ls.ts packages/cli/tests/20-worktree-ls-paths.test.ts`
- `npm run format:files -- packages/cli/src/commands/worktree/archive.ts packages/cli/src/commands/worktree/ls.ts packages/cli/tests/20-worktree-ls-paths.test.ts`
- `npm run format:check:files -- packages/cli/src/commands/daemon/status.ts packages/cli/src/commands/worktree/ls.ts packages/cli/tests/20-worktree-ls-paths.test.ts`
- `npm run lint -- packages/cli/src/commands/daemon/status.ts packages/cli/src/commands/worktree/ls.ts packages/cli/tests/20-worktree-ls-paths.test.ts`
- `npm run lint -- packages/cli/src/commands/worktree/archive.ts packages/cli/src/commands/worktree/ls.ts packages/cli/tests/20-worktree-ls-paths.test.ts`
- `npm run typecheck --workspace=@getpaseo/cli`
- `node --import tsx packages/cli/tests/20-worktree-ls-paths.test.ts`
- `npm run build:daemon`
- pre-commit hooks: format, lint, full workspace typecheck

Fixes #1114
