### PR TITLE
Enable Cursor ACP sessions to be imported

### DIFF
--- a/packages/app/src/screens/workspace/workspace-import-sheet.test.tsx
+++ b/packages/app/src/screens/workspace/workspace-import-sheet.test.tsx
@@ -238,6 +238,7 @@ function createProviderSessionEntry(
 const PROVIDER_LABELS: Record<string, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  cursor: "Cursor",
   opencode: "OpenCode",
 };
 
@@ -548,6 +549,7 @@ describe("WorkspaceImportSheet", () => {
           entries: [
             createSnapshotEntry("claude"),
             createSnapshotEntry("codex"),
+            createSnapshotEntry("cursor"),
             createSnapshotEntry("opencode", { enabled: false }),
             createSnapshotEntry("z-ai"),
           ],
@@ -567,6 +569,11 @@ describe("WorkspaceImportSheet", () => {
       providers: ["codex"],
       limit: 15,
     });
+    expect(fetchRecentProviderSessions).toHaveBeenCalledWith({
+      cwd: "/repo/paseo",
+      providers: ["cursor"],
+      limit: 15,
+    });
     expect(fetchRecentProviderSessions).not.toHaveBeenCalledWith(
       expect.objectContaining({ providers: ["opencode"] }),
     );
@@ -576,6 +583,52 @@ describe("WorkspaceImportSheet", () => {
 
     await screen.findByText("Session claude");
     await screen.findByText("Session codex");
+    await screen.findByText("Session cursor");
+  });
+
+  it("imports a cursor session when its row is pressed", async () => {
+    const fetchRecentProviderSessions = vi.fn(async () => ({
+      requestId: "recent-cursor",
+      entries: [
+        createProviderSessionEntry({
+          providerId: "cursor",
+          providerLabel: "Cursor",
+          providerHandleId: "a7e6271b-a371-476d-98a6-0b2251617c46",
+          title: "Import Session Brainstorm",
+        }),
+      ],
+    }));
+    const importAgent = vi.fn(async () => ({ id: "imported-cursor-agent" }));
+    const onImportedAgent = vi.fn();
+    const onClose = vi.fn();
+
+    renderSheet(
+      { fetchRecentProviderSessions, importAgent } as Pick<
+        DaemonClient,
+        "fetchRecentProviderSessions" | "importAgent"
+      >,
+      {
+        snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("cursor")] },
+        onImportedAgent,
+        onClose,
+      },
+    );
+
+    fireEvent.click(
+      await screen.findByTestId(
+        "workspace-import-session-cursor-a7e6271b-a371-476d-98a6-0b2251617c46",
+      ),
+    );
+
+    await waitFor(() => {
+      expect(importAgent).toHaveBeenCalledWith({
+        providerId: "cursor",
+        providerHandleId: "a7e6271b-a371-476d-98a6-0b2251617c46",
+        cwd: "/repo/paseo",
+      });
+    });
+    expect(onImportedAgent).toHaveBeenCalledWith("imported-cursor-agent");
+    expect(onClose).toHaveBeenCalled();
   });
 
   it("shows partial-failure note when one provider request fails but others succeed", async () => {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -5920,6 +5920,22 @@ test.each([
   },
 );
 
+test("listImportablePersistedAgents includes cursor when enabled", async () => {
+  const cursorClient = new RecordingPersistedAgentsClient("cursor");
+  const manager = new AgentManager({
+    clients: { cursor: cursorClient },
+    providerDefinitions: {
+      cursor: { enabled: true, derivedFromProviderId: null },
+    },
+    logger,
+  });
+
+  const result = await manager.listImportablePersistedAgents();
+
+  expect(cursorClient.calls).toBe(1);
+  expect(result.map((descriptor) => descriptor.provider)).toEqual(["cursor"]);
+});
+
 test("listImportablePersistedAgents narrows to the providerFilter when supplied", async () => {
   const claudeClient = new RecordingPersistedAgentsClient("claude");
   const codexClient = new RecordingPersistedAgentsClient("codex");

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -313,6 +313,56 @@ test("listImportableProviderSessions keeps realpath-equivalent cwd matches", asy
   expect(result.entries.map((entry) => entry.providerHandleId)).toEqual(["pi-handle"]);
 });
 
+test("listImportableProviderSessions projects cursor ACP sessions", async () => {
+  const cwd = "/tmp/paseo";
+  const descriptors = [
+    makeDescriptor({
+      provider: "cursor",
+      sessionId: "a7e6271b-a371-476d-98a6-0b2251617c46",
+      nativeHandle: "a7e6271b-a371-476d-98a6-0b2251617c46",
+      cwd,
+      title: "Import Session Brainstorm",
+      lastActivityAt: "2026-05-20T07:31:52.505Z",
+      firstPrompt: "Let's brainstorm import session support",
+    }),
+  ];
+
+  const result = await listImportableProviderSessions({
+    request: makeRequest({ cwd, providers: ["cursor"], limit: 15 }),
+    agentManager: {
+      listAgents: () => [],
+      listImportablePersistedAgents: async (options) => {
+        expect(options).toEqual({
+          limit: 200,
+          providerFilter: new Set(["cursor"]),
+          cwd,
+        });
+        return descriptors;
+      },
+    } satisfies Pick<AgentManager, "listAgents" | "listImportablePersistedAgents">,
+    agentStorage: {
+      list: async () => [],
+    } satisfies Pick<AgentStorage, "list">,
+    providerRegistry: { cursor: { label: "Cursor" } },
+  });
+
+  expect(result).toEqual({
+    filteredAlreadyImportedCount: 0,
+    entries: [
+      {
+        providerId: "cursor",
+        providerLabel: "Cursor",
+        providerHandleId: "a7e6271b-a371-476d-98a6-0b2251617c46",
+        cwd,
+        title: "Import Session Brainstorm",
+        firstPromptPreview: "Let's brainstorm import session support",
+        lastPromptPreview: "Let's brainstorm import session support",
+        lastActivityAt: "2026-05-20T07:31:52.505Z",
+      },
+    ],
+  });
+});
+
 test("listImportableProviderSessions rejects invalid since values", async () => {
   await expect(
     listImportableProviderSessions({
@@ -431,6 +481,70 @@ test("importProviderSession resumes by provider handle, hydrates the timeline, a
       explicitTitle: null,
     }),
   );
+  expect(result).toEqual({ snapshot, timelineSize: 2 });
+});
+
+test("importProviderSession resumes cursor sessions by ACP handle", async () => {
+  const cwd = "/tmp/paseo";
+  const timeline: AgentTimelineItem[] = [
+    { type: "user_message", text: "Fix the agent command" },
+    { type: "assistant_message", text: "I will inspect the launch path." },
+  ];
+  const snapshot = makeManagedAgent({
+    id: "00000000-0000-4000-8000-000000000634",
+    provider: "cursor",
+    cwd,
+    sessionId: "658a241d-2528-4be5-9bc6-c0c31714c547",
+    nativeHandle: "658a241d-2528-4be5-9bc6-c0c31714c547",
+    title: "Agent Command Fix",
+  });
+  const descriptor = makeDescriptor({
+    provider: "cursor",
+    sessionId: "658a241d-2528-4be5-9bc6-c0c31714c547",
+    nativeHandle: "658a241d-2528-4be5-9bc6-c0c31714c547",
+    cwd,
+    title: "Agent Command Fix",
+    firstPrompt: "Fix the agent command",
+    lastActivityAt: "2026-05-19T13:58:40.129Z",
+  });
+  const agentManager = {
+    findPersistedAgent: vi.fn().mockResolvedValue(descriptor),
+    resumeAgentFromPersistence: vi.fn().mockResolvedValue(snapshot),
+    hydrateTimelineFromProvider: vi.fn().mockResolvedValue(undefined),
+    getTimeline: vi.fn().mockReturnValue(timeline),
+    setTitle: vi.fn().mockResolvedValue(undefined),
+    notifyAgentState: vi.fn(),
+  } as unknown as AgentManager;
+  const agentStorage = {
+    list: vi.fn().mockResolvedValue([]),
+    get: vi.fn().mockResolvedValue(null),
+  } as unknown as AgentStorage;
+
+  const result = await importProviderSession({
+    request: {
+      requestId: "import-cursor-session",
+      provider: "cursor",
+      providerHandleId: "658a241d-2528-4be5-9bc6-c0c31714c547",
+      cwd,
+    },
+    agentManager,
+    agentStorage,
+    logger: { warn: vi.fn(), error: vi.fn() } as never,
+  });
+
+  expect(agentManager.findPersistedAgent).toHaveBeenCalledWith(
+    "cursor",
+    "658a241d-2528-4be5-9bc6-c0c31714c547",
+    { cwd },
+  );
+  expect(agentManager.resumeAgentFromPersistence).toHaveBeenCalledWith(
+    descriptor.persistence,
+    { cwd },
+    undefined,
+    { labels: undefined },
+  );
+  expect(agentManager.hydrateTimelineFromProvider).toHaveBeenCalledWith(snapshot.id);
+  expect(agentManager.setTitle).not.toHaveBeenCalled();
   expect(result).toEqual({ snapshot, timelineSize: 2 });
 });
 

--- a/packages/server/src/shared/importable-providers.test.ts
+++ b/packages/server/src/shared/importable-providers.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "vitest";
+
+import { IMPORTABLE_PROVIDERS } from "./importable-providers.js";
+
+test("IMPORTABLE_PROVIDERS includes cursor for ACP session import", () => {
+  expect(IMPORTABLE_PROVIDERS).toContain("cursor");
+});
+
+test("IMPORTABLE_PROVIDERS keeps the existing first-party import providers", () => {
+  expect(IMPORTABLE_PROVIDERS).toEqual(
+    expect.arrayContaining(["claude", "codex", "opencode", "pi"]),
+  );
+});
+
+test("IMPORTABLE_PROVIDERS excludes generic ACP catalog providers", () => {
+  expect(IMPORTABLE_PROVIDERS).not.toContain("gemini");
+  expect(IMPORTABLE_PROVIDERS).not.toContain("copilot");
+});

--- a/packages/server/src/shared/importable-providers.ts
+++ b/packages/server/src/shared/importable-providers.ts
@@ -1,6 +1,7 @@
 /**
- * Providers eligible for "import recent session" discovery. ACP-based
- * providers (gemini, copilot, generic acp) are excluded because they either
- * don't expose persisted history quickly or duplicate other providers.
+ * Providers eligible for "import recent session" discovery. Generic ACP catalog
+ * providers (gemini, copilot, etc.) stay excluded — they either don't expose
+ * persisted history quickly or duplicate other providers. Cursor is included
+ * because cursor-agent exposes ACP session list/resume for CLI ACP sessions.
  */
-export const IMPORTABLE_PROVIDERS = ["claude", "codex", "opencode", "pi"] as const;
+export const IMPORTABLE_PROVIDERS = ["claude", "codex", "cursor", "opencode", "pi"] as const;


### PR DESCRIPTION
## Summary
- Add `cursor` to `IMPORTABLE_PROVIDERS` so the workspace "Import session" sheet can discover and import `cursor-agent acp` sessions through the existing list/resume flow.
- Cover the allowlist, daemon import pipeline, agent manager fan-out, and import sheet UI with focused tests.

## Test plan
- [x] `npx vitest run packages/server/src/shared/importable-providers.test.ts --bail=1`
- [x] `npx vitest run packages/server/src/server/agent/import-sessions.test.ts -t "cursor" --bail=1`
- [x] `npx vitest run packages/server/src/server/agent/agent-manager.test.ts -t "listImportablePersistedAgents includes cursor" --bail=1`
- [x] `npx vitest run packages/app/src/screens/workspace/workspace-import-sheet.test.tsx -t "cursor|fans out" --bail=1`