### PR TITLE
fix(app): open subagents in parent workspace

### DIFF
--- a/packages/app/src/utils/navigate-to-agent.test.ts
+++ b/packages/app/src/utils/navigate-to-agent.test.ts
@@ -130,4 +130,34 @@ describe("navigateToAgent", () => {
     expect(routerMock.navigate).toHaveBeenCalledWith("/h/server-1/agent/missing-agent");
     expect(routerMock.dismissTo).not.toHaveBeenCalled();
   });
+
+  it("opens subagents through the parent workspace when the child cwd is nested", () => {
+    const parent = createAgent({
+      id: "parent-agent",
+      cwd: "/repo/worktree",
+      parentAgentId: null,
+    });
+    const child = createAgent({
+      id: "child-agent",
+      cwd: "/repo/worktree/packages/app",
+      parentAgentId: "parent-agent",
+    });
+    useSessionStore.getState().setAgents(
+      SERVER_ID,
+      new Map([
+        [parent.id, parent],
+        [child.id, child],
+      ]),
+    );
+
+    const route = navigateToAgent({ serverId: SERVER_ID, agentId: child.id });
+
+    expect(route).toBe("/h/server-1/workspace/workspace-1");
+    expect(routerMock.navigate).not.toHaveBeenCalled();
+    expect(routerMock.dismissTo).toHaveBeenCalledWith("/h/server-1/workspace/workspace-1");
+    const key = `${SERVER_ID}:${WORKSPACE_ID}`;
+    expect(useWorkspaceLayoutStore.getState().getWorkspaceTabs(key)).toEqual([
+      expect.objectContaining({ target: { kind: "agent", agentId: child.id } }),
+    ]);
+  });
 });

--- a/packages/app/src/utils/navigate-to-agent.ts
+++ b/packages/app/src/utils/navigate-to-agent.ts
@@ -14,10 +14,19 @@ interface NavigateToAgentInput {
 export function navigateToAgent(input: NavigateToAgentInput): string {
   const session = useSessionStore.getState().sessions[input.serverId];
   const agent = session?.agents.get(input.agentId) ?? session?.agentDetails.get(input.agentId);
-  const workspaceId = resolveWorkspaceIdByExecutionDirectory({
+  let workspaceId = resolveWorkspaceIdByExecutionDirectory({
     workspaces: session?.workspaces.values(),
     workspaceDirectory: agent?.cwd,
   });
+
+  if (!workspaceId && agent?.parentAgentId && session) {
+    const parentAgent =
+      session.agents.get(agent.parentAgentId) ?? session.agentDetails.get(agent.parentAgentId);
+    workspaceId = resolveWorkspaceIdByExecutionDirectory({
+      workspaces: session.workspaces.values(),
+      workspaceDirectory: parentAgent?.cwd,
+    });
+  }
 
   if (!workspaceId) {
     const route = buildHostAgentDetailRoute(input.serverId, input.agentId);


### PR DESCRIPTION
### Linked issue

Closes #1130

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

`navigateToAgent` now falls back to the parent agent workspace when the target agent is a subagent whose own `cwd` does not resolve to a known workspace. The tab still opens the child agent, but the workspace route comes from the known parent context instead of sending the user through the host agent detail fallback.

This keeps the generic unknown-agent fallback unchanged for agents without a resolvable workspace or parent.

### How did you verify it

Reproduced the bug with a focused unit test before the fix:

- `npm run test --workspace=@getpaseo/app -- src/utils/navigate-to-agent.test.ts --bail=1`
- Before the fix, the new test failed with `Received: "/h/server-1/agent/child-agent"`

After the fix:

- `npm run test --workspace=@getpaseo/app -- src/utils/navigate-to-agent.test.ts --bail=1` passes (3 tests)
- `npm run lint` passes
- `npm run format` ran
- `npm run build:daemon` ran to refresh workspace declarations
- `npm run typecheck` passes
- `git diff --check` passes

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A: no visual UI change; navigation behavior is covered by unit test)
- [x] Tests added or updated where it made sense