### PR TITLE
Fix subagent navigation to parent workspace

### DIFF
--- a/packages/app/src/utils/navigate-to-agent.test.ts
+++ b/packages/app/src/utils/navigate-to-agent.test.ts
@@ -130,4 +130,34 @@ describe("navigateToAgent", () => {
     expect(routerMock.navigate).toHaveBeenCalledWith("/h/server-1/agent/missing-agent");
     expect(routerMock.dismissTo).not.toHaveBeenCalled();
   });
+
+  it("opens subagents in their parent workspace when the child cwd is not a workspace", () => {
+    const parent = createAgent({
+      id: "parent-agent",
+      cwd: "/repo/worktree",
+      parentAgentId: null,
+    });
+    const child = createAgent({
+      id: "child-agent",
+      cwd: "/repo/worktree/packages/app",
+      parentAgentId: "parent-agent",
+    });
+    useSessionStore.getState().setAgents(
+      SERVER_ID,
+      new Map([
+        [parent.id, parent],
+        [child.id, child],
+      ]),
+    );
+
+    const route = navigateToAgent({ serverId: SERVER_ID, agentId: child.id });
+
+    expect(route).toBe("/h/server-1/workspace/workspace-1");
+    expect(routerMock.navigate).not.toHaveBeenCalled();
+    expect(routerMock.dismissTo).toHaveBeenCalledWith("/h/server-1/workspace/workspace-1");
+    const key = `${SERVER_ID}:${WORKSPACE_ID}`;
+    expect(useWorkspaceLayoutStore.getState().getWorkspaceTabs(key)).toEqual([
+      expect.objectContaining({ target: { kind: "agent", agentId: child.id } }),
+    ]);
+  });
 });

--- a/packages/app/src/utils/navigate-to-agent.ts
+++ b/packages/app/src/utils/navigate-to-agent.ts
@@ -14,10 +14,20 @@ interface NavigateToAgentInput {
 export function navigateToAgent(input: NavigateToAgentInput): string {
   const session = useSessionStore.getState().sessions[input.serverId];
   const agent = session?.agents.get(input.agentId) ?? session?.agentDetails.get(input.agentId);
-  const workspaceId = resolveWorkspaceIdByExecutionDirectory({
-    workspaces: session?.workspaces.values(),
-    workspaceDirectory: agent?.cwd,
-  });
+  const workspaceId =
+    resolveWorkspaceIdByExecutionDirectory({
+      workspaces: session?.workspaces.values(),
+      workspaceDirectory: agent?.cwd,
+    }) ??
+    resolveWorkspaceIdByExecutionDirectory({
+      workspaces: session?.workspaces.values(),
+      workspaceDirectory: agent?.parentAgentId
+        ? (
+            session?.agents.get(agent.parentAgentId) ??
+            session?.agentDetails.get(agent.parentAgentId)
+          )?.cwd
+        : null,
+    });
 
   if (!workspaceId) {
     const route = buildHostAgentDetailRoute(input.serverId, input.agentId);


### PR DESCRIPTION
## Summary

- Resolve a subagent's workspace from its parent agent when the child cwd is not a known workspace directory
- Keep the existing host-agent fallback for missing/unknown agents
- Add a regression test for subagent composer navigation into the parent workspace

Closes #1130

## Testing

- `npm run test --workspace=@getpaseo/app -- src/utils/navigate-to-agent.test.ts`
- `npm run format:check:files -- packages/app/src/utils/navigate-to-agent.ts packages/app/src/utils/navigate-to-agent.test.ts`
- `npm run lint -- packages/app/src/utils/navigate-to-agent.ts packages/app/src/utils/navigate-to-agent.test.ts`
- `npm run build --workspace=@getpaseo/relay`
- `npm run build --workspace=@getpaseo/server`
- `npm run typecheck --workspace=@getpaseo/app`
- pre-commit hook: lint, format, and `npm run typecheck --workspaces --if-present`