### PR TITLE
Apply optional gitConfig after worktree creation in create_agent_request

### DIFF
--- a/packages/server/src/server/agent/create-agent-lifecycle-dispatch.ts
+++ b/packages/server/src/server/agent/create-agent-lifecycle-dispatch.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type pino from "pino";
 
 import type { GitHubService } from "../../services/github-service.js";
+import { runGitCommand } from "../../utils/run-git-command.js";
 import { isPaseoOwnedWorktreeCwd } from "../../utils/worktree.js";
 import { archivePaseoWorktree } from "../paseo-worktree-archive-service.js";
 import type {
@@ -11,6 +12,7 @@ import type {
 import type { WorkspaceGitService } from "../workspace-git-service.js";
 import type {
   CreateAgentWorktreeTarget,
+  CreateAgentWorktreeGitConfig,
   FirstAgentContext,
   SessionOutboundMessage,
 } from "../messages.js";
@@ -54,7 +56,13 @@ export class CreateAgentLifecycleDispatch {
       return null;
     }
 
-    return this.createWorktreeForTarget(input.cwd, input.target, input.firstAgentContext);
+    const createdWorktree = await this.createWorktreeForTarget(
+      input.cwd,
+      input.target,
+      input.firstAgentContext,
+    );
+    await applyWorktreeGitConfig(createdWorktree.worktree.worktreePath, input.target.gitConfig);
+    return createdWorktree;
   }
 
   registerAutoArchiveIfRequested(input: {
@@ -223,5 +231,30 @@ export class CreateAgentLifecycleDispatch {
     if (options.agentId) {
       this.dependencies.emitAgentRemove(options.agentId);
     }
+  }
+}
+
+async function applyWorktreeGitConfig(
+  worktreePath: string,
+  gitConfig: CreateAgentWorktreeGitConfig | undefined,
+): Promise<void> {
+  if (gitConfig === undefined) {
+    return;
+  }
+
+  if (gitConfig.userName !== undefined) {
+    await runGitCommand(["config", "--local", "user.name", gitConfig.userName], {
+      cwd: worktreePath,
+    });
+  }
+  if (gitConfig.userEmail !== undefined) {
+    await runGitCommand(["config", "--local", "user.email", gitConfig.userEmail], {
+      cwd: worktreePath,
+    });
+  }
+  if (gitConfig.remoteUrl !== undefined) {
+    await runGitCommand(["remote", "set-url", "origin", gitConfig.remoteUrl], {
+      cwd: worktreePath,
+    });
   }
 }

--- a/packages/server/src/server/session.create-agent-worktree-autoarchive.e2e.test.ts
+++ b/packages/server/src/server/session.create-agent-worktree-autoarchive.e2e.test.ts
@@ -152,6 +152,50 @@ test("create_agent_request creates a worktree and auto-archives both after the f
   await expectWorktreeAbsentFromList(repoDir, created.cwd);
 }, 30000);
 
+test("create_agent_request applies worktree git config before starting the agent", async () => {
+  const repoDir = createGitRepo();
+  execFileSync("git", ["remote", "add", "origin", "git@github.com:boudra/faro.git"], {
+    cwd: repoDir,
+    stdio: "pipe",
+  });
+  const created = await ctx.client.createAgent({
+    config: {
+      ...getFullAccessConfig("codex"),
+      cwd: repoDir,
+    },
+    worktree: {
+      mode: "branch-off",
+      newBranch: "agent-lifecycle-git-config",
+      base: "main",
+      gitConfig: {
+        userName: "paseo-ai[bot]",
+        userEmail: "123456+paseo-ai[bot]@users.noreply.github.com",
+        remoteUrl: "https://x-access-token:ghs_install_token@github.com/boudra/faro.git",
+      },
+    },
+    initialPrompt: "Say done.",
+  });
+
+  expect(
+    execFileSync("git", ["config", "--local", "user.name"], {
+      cwd: created.cwd,
+      encoding: "utf8",
+    }).trim(),
+  ).toBe("paseo-ai[bot]");
+  expect(
+    execFileSync("git", ["config", "--local", "user.email"], {
+      cwd: created.cwd,
+      encoding: "utf8",
+    }).trim(),
+  ).toBe("123456+paseo-ai[bot]@users.noreply.github.com");
+  expect(
+    execFileSync("git", ["remote", "get-url", "origin"], {
+      cwd: created.cwd,
+      encoding: "utf8",
+    }).trim(),
+  ).toBe("https://x-access-token:ghs_install_token@github.com/boudra/faro.git");
+}, 30000);
+
 test("create_agent_request with autoArchive archives only the agent when no worktree was created", async () => {
   const repoDir = createGitRepo();
   const created = await ctx.client.createAgent({

--- a/packages/server/src/shared/messages.create-agent-worktree-autoarchive.test.ts
+++ b/packages/server/src/shared/messages.create-agent-worktree-autoarchive.test.ts
@@ -15,6 +15,11 @@ describe("create_agent_request worktree and autoArchive fields", () => {
         mode: "branch-off",
         newBranch: "agent-lifecycle-dispatch",
         base: "main",
+        gitConfig: {
+          userName: "paseo-ai[bot]",
+          userEmail: "123456+paseo-ai[bot]@users.noreply.github.com",
+          remoteUrl: "https://x-access-token:ghs_install_token@github.com/boudra/faro.git",
+        },
       },
       autoArchive: true,
     });
@@ -30,6 +35,11 @@ describe("create_agent_request worktree and autoArchive fields", () => {
         mode: "branch-off",
         newBranch: "agent-lifecycle-dispatch",
         base: "main",
+        gitConfig: {
+          userName: "paseo-ai[bot]",
+          userEmail: "123456+paseo-ai[bot]@users.noreply.github.com",
+          remoteUrl: "https://x-access-token:ghs_install_token@github.com/boudra/faro.git",
+        },
       },
       autoArchive: true,
       labels: {},

--- a/packages/server/src/shared/messages.ts
+++ b/packages/server/src/shared/messages.ts
@@ -1058,22 +1058,32 @@ const GitSetupOptionsSchema = z.object({
 
 export type GitSetupOptions = z.infer<typeof GitSetupOptionsSchema>;
 
+export const CreateAgentWorktreeGitConfigSchema = z.object({
+  userName: z.string().min(1).optional(),
+  userEmail: z.string().min(1).optional(),
+  remoteUrl: z.string().min(1).optional(),
+});
+
 export const CreateAgentWorktreeTargetSchema = z.discriminatedUnion("mode", [
   z.object({
     mode: z.literal("branch-off"),
     newBranch: z.string().min(1),
     base: z.string().min(1).optional(),
+    gitConfig: CreateAgentWorktreeGitConfigSchema.optional(),
   }),
   z.object({
     mode: z.literal("checkout-branch"),
     branch: z.string().min(1),
+    gitConfig: CreateAgentWorktreeGitConfigSchema.optional(),
   }),
   z.object({
     mode: z.literal("checkout-pr"),
     prNumber: z.number().int().positive(),
+    gitConfig: CreateAgentWorktreeGitConfigSchema.optional(),
   }),
 ]);
 
+export type CreateAgentWorktreeGitConfig = z.infer<typeof CreateAgentWorktreeGitConfigSchema>;
 export type CreateAgentWorktreeTarget = z.infer<typeof CreateAgentWorktreeTargetSchema>;
 
 export const CreateAgentRequestMessageSchema = z.object({


### PR DESCRIPTION
## Summary
- New optional `worktree.gitConfig: { userName?, userEmail?, remoteUrl? }` on `create_agent_request`.
- After worktree creation, the daemon applies each provided field via `git -C <path> config --local user.name|user.email` and `git remote set-url origin`.
- Backward compatible.

## Why
paseo-cloud needs to push commits authored by the GitHub App's bot user (verified, attributable). The cloud knows the right identity per trigger; the daemon is the right place to apply it because it's where the worktree is created. Daemon stays GitHub-agnostic.

## Test plan
- [x] `messages.create-agent-worktree-autoarchive.test.ts` schema cases
- [x] `session.create-agent-worktree-autoarchive.e2e.test.ts` real-component worktree test
- [x] Daemon server typecheck + lint
- [ ] CI green