### PR TITLE
fix subagent workspace navigation

### DIFF
--- a/packages/app/src/utils/navigate-to-agent.test.ts
+++ b/packages/app/src/utils/navigate-to-agent.test.ts
@@ -123,6 +123,36 @@ describe("navigateToAgent", () => {
     );
   });
 
+  it("opens subagents in their parent workspace when the child cwd is nested", () => {
+    const parentAgent = createAgent({
+      id: "parent-agent",
+      cwd: "/repo/worktree",
+      parentAgentId: null,
+    });
+    const childAgent = createAgent({
+      id: "child-agent",
+      cwd: "/repo/worktree/packages/app",
+      parentAgentId: "parent-agent",
+    });
+    useSessionStore.getState().setAgents(
+      SERVER_ID,
+      new Map([
+        [parentAgent.id, parentAgent],
+        [childAgent.id, childAgent],
+      ]),
+    );
+
+    const route = navigateToAgent({ serverId: SERVER_ID, agentId: childAgent.id });
+
+    expect(route).toBe("/h/server-1/workspace/workspace-1");
+    expect(routerMock.navigate).not.toHaveBeenCalled();
+    expect(routerMock.dismissTo).toHaveBeenCalledWith("/h/server-1/workspace/workspace-1");
+    const key = `${SERVER_ID}:${WORKSPACE_ID}`;
+    expect(useWorkspaceLayoutStore.getState().getWorkspaceTabs(key)).toEqual([
+      expect.objectContaining({ target: { kind: "agent", agentId: childAgent.id } }),
+    ]);
+  });
+
   it("falls back to the host agent route when the workspace is unknown", () => {
     const route = navigateToAgent({ serverId: SERVER_ID, agentId: "missing-agent" });
 

--- a/packages/app/src/utils/navigate-to-agent.ts
+++ b/packages/app/src/utils/navigate-to-agent.ts
@@ -3,6 +3,7 @@ import { useSessionStore } from "@/stores/session-store";
 import { buildHostAgentDetailRoute } from "@/utils/host-routes";
 import { resolveWorkspaceIdByExecutionDirectory } from "@/utils/workspace-execution";
 import { navigateToPreparedWorkspaceTab } from "@/utils/workspace-navigation";
+import type { Agent, SessionState, WorkspaceDescriptor } from "@/stores/session-store";
 
 interface NavigateToAgentInput {
   serverId: string;
@@ -11,12 +12,44 @@ interface NavigateToAgentInput {
   pin?: boolean;
 }
 
+function resolveAgentFromSession(
+  session: SessionState | undefined,
+  agentId: string | null | undefined,
+): Agent | null {
+  if (!agentId) {
+    return null;
+  }
+  return session?.agents.get(agentId) ?? session?.agentDetails.get(agentId) ?? null;
+}
+
+function resolveAgentWorkspaceId(input: {
+  agent: Agent | null;
+  session: SessionState | undefined;
+  workspaces: Iterable<WorkspaceDescriptor> | undefined;
+}): string | null {
+  const directWorkspaceId = resolveWorkspaceIdByExecutionDirectory({
+    workspaces: input.workspaces,
+    workspaceDirectory: input.agent?.cwd,
+  });
+  if (directWorkspaceId || !input.agent?.parentAgentId) {
+    return directWorkspaceId;
+  }
+
+  const parentAgent = resolveAgentFromSession(input.session, input.agent.parentAgentId);
+  return resolveWorkspaceIdByExecutionDirectory({
+    workspaces: input.workspaces,
+    workspaceDirectory: parentAgent?.cwd,
+  });
+}
+
 export function navigateToAgent(input: NavigateToAgentInput): string {
   const session = useSessionStore.getState().sessions[input.serverId];
-  const agent = session?.agents.get(input.agentId) ?? session?.agentDetails.get(input.agentId);
-  const workspaceId = resolveWorkspaceIdByExecutionDirectory({
-    workspaces: session?.workspaces.values(),
-    workspaceDirectory: agent?.cwd,
+  const agent = resolveAgentFromSession(session, input.agentId);
+  const workspaces = session ? Array.from(session.workspaces.values()) : undefined;
+  const workspaceId = resolveAgentWorkspaceId({
+    agent,
+    session,
+    workspaces,
   });
 
   if (!workspaceId) {


### PR DESCRIPTION
Fixes #1130.

## Summary
- Resolve subagent rows to the parent workspace when the child cwd is nested under that workspace.
- Keep the existing host-agent fallback when no workspace can be resolved.
- Add a regression test for nested subagent cwd navigation.

## Test plan
- `npm run build:workspace-deps --workspace=@getpaseo/app`
- `npm run test --workspace=@getpaseo/app -- src/utils/navigate-to-agent.test.ts`
- `npm run typecheck --workspace=@getpaseo/app`
- `npm run lint -- packages/app/src/utils/navigate-to-agent.ts packages/app/src/utils/navigate-to-agent.test.ts`