### PR TITLE
add agent unarchive command

### DIFF
--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -12,6 +12,7 @@ import { addWaitOptions, runWaitCommand } from "./wait.js";
 import { addAttachOptions, runAttachCommand } from "./attach.js";
 import { addReloadOptions, runReloadCommand } from "./reload.js";
 import { addImportOptions, runImportCommand } from "./import.js";
+import { addUnarchiveOptions, runUnarchiveCommand } from "./unarchive.js";
 import { runUpdateCommand } from "./update.js";
 import { withOutput } from "../../output/index.js";
 import {
@@ -70,6 +71,10 @@ export function createAgentCommand(): Command {
 
   addJsonAndDaemonHostOptions(addArchiveOptions(agent.command("archive"))).action(
     withOutput(runArchiveCommand),
+  );
+
+  addJsonAndDaemonHostOptions(addUnarchiveOptions(agent.command("unarchive"))).action(
+    withOutput(runUnarchiveCommand),
   );
 
   addJsonAndDaemonHostOptions(addReloadOptions(agent.command("reload"))).action(

--- a/packages/cli/src/commands/agent/unarchive.test.ts
+++ b/packages/cli/src/commands/agent/unarchive.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { runUnarchiveCommand } from "./unarchive.js";
+
+const { close, fetchAgents, refreshAgent } = vi.hoisted(() => ({
+  close: vi.fn(),
+  fetchAgents: vi.fn(),
+  refreshAgent: vi.fn(),
+}));
+
+vi.mock("../../utils/client.js", () => {
+  return {
+    connectToDaemon: vi.fn(async () => ({
+      fetchAgents,
+      refreshAgent,
+      close,
+    })),
+    getDaemonHost: vi.fn(() => "localhost:6767"),
+    resolveAgentId: vi.fn((idOrName: string, agents: Array<{ id: string; title?: string }>) => {
+      return (
+        agents.find((agent) => agent.id === idOrName)?.id ??
+        agents.find((agent) => agent.id.startsWith(idOrName))?.id ??
+        agents.find((agent) => agent.title === idOrName)?.id ??
+        null
+      );
+    }),
+  };
+});
+
+const archivedAgent = {
+  id: "agent-123456789",
+  title: "Archived Session",
+  status: "idle",
+  cwd: "/tmp/project",
+  archivedAt: "2026-05-22T00:00:00.000Z",
+};
+
+describe("runUnarchiveCommand", () => {
+  beforeEach(() => {
+    fetchAgents.mockReset();
+    refreshAgent.mockReset();
+    close.mockReset();
+    close.mockResolvedValue(undefined);
+  });
+
+  it("refreshes an archived agent resolved by prefix", async () => {
+    fetchAgents.mockResolvedValueOnce({ entries: [{ agent: archivedAgent }] });
+    refreshAgent.mockResolvedValueOnce({
+      agentId: archivedAgent.id,
+      status: "agent_refreshed",
+      requestId: "request-1",
+      timelineSize: 4,
+    });
+
+    const result = await runUnarchiveCommand("agent-123", {}, {} as never);
+
+    expect(fetchAgents).toHaveBeenCalledWith({ filter: { includeArchived: true } });
+    expect(refreshAgent).toHaveBeenCalledWith(archivedAgent.id);
+    expect(result.data).toEqual({
+      agentId: archivedAgent.id,
+      status: "unarchived",
+      timelineSize: 4,
+    });
+  });
+
+  it("rejects agents that are not archived", async () => {
+    fetchAgents.mockResolvedValueOnce({
+      entries: [{ agent: { ...archivedAgent, archivedAt: null } }],
+    });
+
+    await expect(runUnarchiveCommand("Archived Session", {}, {} as never)).rejects.toMatchObject({
+      code: "AGENT_NOT_ARCHIVED",
+    });
+    expect(refreshAgent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/agent/unarchive.ts
+++ b/packages/cli/src/commands/agent/unarchive.ts
@@ -1,0 +1,120 @@
+import { Command } from "commander";
+import type { DaemonClient } from "@getpaseo/server";
+import { connectToDaemon, getDaemonHost, resolveAgentId } from "../../utils/client.js";
+import type {
+  CommandOptions,
+  SingleResult,
+  OutputSchema,
+  CommandError,
+} from "../../output/index.js";
+
+export interface AgentUnarchiveResult {
+  agentId: string;
+  status: "unarchived";
+  timelineSize: number;
+}
+
+export const unarchiveSchema: OutputSchema<AgentUnarchiveResult> = {
+  idField: "agentId",
+  columns: [
+    { header: "AGENT ID", field: "agentId" },
+    { header: "STATUS", field: "status" },
+    { header: "TIMELINE", field: "timelineSize" },
+  ],
+};
+
+export function addUnarchiveOptions(cmd: Command): Command {
+  return cmd
+    .description("Unarchive an agent and reload it from persistence")
+    .argument("<id>", "Agent ID, prefix, or name");
+}
+
+export interface AgentUnarchiveOptions extends CommandOptions {
+  host?: string;
+}
+
+export type AgentUnarchiveCommandResult = SingleResult<AgentUnarchiveResult>;
+
+export async function runUnarchiveCommand(
+  agentIdArg: string,
+  options: AgentUnarchiveOptions,
+  _command: Command,
+): Promise<AgentUnarchiveCommandResult> {
+  const host = getDaemonHost({ host: options.host });
+
+  if (!agentIdArg || agentIdArg.trim().length === 0) {
+    const error: CommandError = {
+      code: "MISSING_AGENT_ID",
+      message: "Agent ID is required",
+      details: "Usage: paseo agent unarchive <id-or-name>",
+    };
+    throw error;
+  }
+
+  let client: DaemonClient;
+  try {
+    client = await connectToDaemon({ host: options.host });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const error: CommandError = {
+      code: "DAEMON_NOT_RUNNING",
+      message: `Cannot connect to daemon at ${host}: ${message}`,
+      details: "Start the daemon with: paseo daemon start",
+    };
+    throw error;
+  }
+
+  try {
+    const agentsPayload = await client.fetchAgents({ filter: { includeArchived: true } });
+    const agents = agentsPayload.entries.map((entry) => entry.agent);
+    const agentId = resolveAgentId(agentIdArg, agents);
+    if (!agentId) {
+      const error: CommandError = {
+        code: "AGENT_NOT_FOUND",
+        message: `Agent not found: ${agentIdArg}`,
+        details: 'Use "paseo agent ls --all" to list archived agents',
+      };
+      throw error;
+    }
+
+    const agent = agents.find((entry) => entry.id === agentId);
+    if (!agent) {
+      throw new Error(`Resolved agent missing from fetched agents: ${agentId}`);
+    }
+
+    if (!agent.archivedAt) {
+      const error: CommandError = {
+        code: "AGENT_NOT_ARCHIVED",
+        message: `Agent ${agentId.slice(0, 7)} is not archived`,
+        details: "Only archived agents can be unarchived",
+      };
+      throw error;
+    }
+
+    const result = await client.refreshAgent(agentId);
+    await client.close();
+
+    return {
+      type: "single",
+      data: {
+        agentId: result.agentId,
+        status: "unarchived",
+        timelineSize: result.timelineSize ?? 0,
+      },
+      schema: unarchiveSchema,
+    };
+  } catch (err) {
+    await client.close().catch(() => {});
+
+    if (err && typeof err === "object" && "code" in err) {
+      throw err;
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    const error: CommandError = {
+      code: "UNARCHIVE_FAILED",
+      message: `Failed to unarchive agent: ${message}`,
+    };
+    throw error;
+  }
+}


### PR DESCRIPTION
Fixes #957.

## Summary
- Add `paseo agent unarchive <id>` to match the existing archive command.
- Resolve archived agents by id, prefix, or name before calling the daemon.
- Reuse the existing `refreshAgent` path, which is already used by the app's Unarchive action.
- Return a clear error when the selected agent is not archived.

## Test plan
- `npx vitest run packages/cli/src/commands/agent/ls.test.ts packages/cli/src/commands/agent/import.test.ts packages/cli/src/commands/agent/unarchive.test.ts`
- `npm run typecheck --workspace=@getpaseo/cli`
- `npm run build --workspace=@getpaseo/cli`
- `npm run lint -- packages/cli/src/commands/agent/unarchive.ts packages/cli/src/commands/agent/unarchive.test.ts packages/cli/src/commands/agent/index.ts`
- `npx oxfmt --check packages/cli/src/commands/agent/unarchive.ts packages/cli/src/commands/agent/unarchive.test.ts packages/cli/src/commands/agent/index.ts`
- `npx paseo agent unarchive --help`