### PR TITLE
Guard assistant file link parsing against malformed URI sequences

### DIFF
--- a/packages/app/src/assistant-file-links/parse.test.ts
+++ b/packages/app/src/assistant-file-links/parse.test.ts
@@ -105,6 +105,11 @@ describe("parseFileProtocolUrl", () => {
     expect(parseFileProtocolUrl("https://example.com/test.ts#L10")).toBeNull();
     expect(parseFileProtocolUrl("file:///Users/test/project/src/app.tsx#L20-L12")).toBeNull();
   });
+
+  it("returns null and does not throw for malformed percent-encoding in file URLs", () => {
+    expect(() => parseFileProtocolUrl("file:///Users/test/project/bad%file.ts")).not.toThrow();
+    expect(parseFileProtocolUrl("file:///Users/test/project/bad%file.ts")).toBeNull();
+  });
 });
 
 describe("classifyAssistantFileLink", () => {
@@ -356,6 +361,19 @@ describe("parseAssistantFileLink", () => {
   it("rejects invalid line fragments", () => {
     expect(
       parseAssistantFileLink("/Users/test/project/src/app.tsx#L20-L12", {
+        workspaceRoot: "/Users/test/project",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null and does not throw for malformed percent-encoding in absolute paths", () => {
+    expect(() =>
+      parseAssistantFileLink("/Users/test/project/bad%file.ts", {
+        workspaceRoot: "/Users/test/project",
+      }),
+    ).not.toThrow();
+    expect(
+      parseAssistantFileLink("/Users/test/project/bad%file.ts", {
         workspaceRoot: "/Users/test/project",
       }),
     ).toBeNull();

--- a/packages/app/src/assistant-file-links/parse.ts
+++ b/packages/app/src/assistant-file-links/parse.ts
@@ -1,5 +1,13 @@
 import { isAbsolutePath } from "@/utils/path";
 
+function safeDecodeURIComponent(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
 export interface InlinePathTarget {
   raw: string;
   path: string;
@@ -343,6 +351,14 @@ export function parseAssistantFileLink(
     return null;
   }
 
+  return parseAbsoluteHrefAsFileLink(value, trimmed, options.workspaceRoot);
+}
+
+function parseAbsoluteHrefAsFileLink(
+  raw: string,
+  trimmed: string,
+  workspaceRoot: string | undefined,
+): InlinePathTarget | null {
   let parsedUrl: URL;
   try {
     parsedUrl = new URL(trimmed, "http://paseo.invalid");
@@ -350,12 +366,17 @@ export function parseAssistantFileLink(
     return null;
   }
 
-  const normalizedPath = normalizePathToken(decodeURIComponent(parsedUrl.pathname));
+  const decodedPathname = safeDecodeURIComponent(parsedUrl.pathname);
+  if (decodedPathname === null) {
+    return null;
+  }
+
+  const normalizedPath = normalizePathToken(decodedPathname);
   if (!normalizedPath || !isAbsolutePath(normalizedPath)) {
     return null;
   }
 
-  if (!isAllowedAbsolutePath(normalizedPath, options.workspaceRoot)) {
+  if (!isAllowedAbsolutePath(normalizedPath, workspaceRoot)) {
     return null;
   }
 
@@ -365,7 +386,7 @@ export function parseAssistantFileLink(
   }
 
   return {
-    raw: value,
+    raw,
     path: normalizedPath,
     ...lines,
   };
@@ -659,7 +680,7 @@ function normalizeFileUrlPath(pathname: string): string | null {
     return null;
   }
 
-  const decoded = decodeURIComponent(pathname).replace(/\\/g, "/");
+  const decoded = safeDecodeURIComponent(pathname)?.replace(/\\/g, "/");
   if (!decoded) {
     return null;
   }


### PR DESCRIPTION
This fixes a crash where assistant-rendered file links containing malformed percent-encoding could throw URIError from decodeURIComponent during file-link classification. The parser now safely rejects malformed URI paths instead of crashing the workspace tab.

## Changes

- Added `safeDecodeURIComponent` wrapper that returns `null` instead of throwing on invalid percent-encoded sequences
- Replaced bare `decodeURIComponent` call in `normalizeFileUrlPath` with the safe wrapper
- Extracted absolute-href parsing in `parseAssistantFileLink` into `parseAbsoluteHrefAsFileLink` helper (keeps complexity within lint limit) and guarded the `decodeURIComponent` call there
- Added two regression tests: one for `parseFileProtocolUrl` and one for `parseAssistantFileLink` with malformed `%file` sequences

## Test

```
cd packages/app && npx vitest run src/assistant-file-links/parse.test.ts
# 36 tests pass
```