### PR TITLE
fix(app): prune stale file-explorer paths during hydration

### DIFF
--- a/packages/app/src/components/file-explorer-pane.tsx
+++ b/packages/app/src/components/file-explorer-pane.tsx
@@ -40,8 +40,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useFileExplorerActions } from "@/hooks/use-file-explorer-actions";
-import { buildWorkspaceExplorerStateKey } from "@/hooks/use-file-explorer-actions";
+import {
+  buildWorkspaceExplorerStateKey,
+  dropFailedExpandedPaths,
+  useFileExplorerActions,
+} from "@/hooks/use-file-explorer-actions";
 import { usePanelStore, type SortOption } from "@/stores/panel-store";
 import { formatTimeAgo } from "@/utils/time";
 import { buildAbsoluteExplorerPath } from "@/utils/explorer-paths";
@@ -929,7 +932,7 @@ async function initializeExplorer({
   workspaceStateKey: string | null;
   requestDirectoryListing: (
     path: string,
-    opts?: { recordHistory?: boolean; setCurrentPath?: boolean },
+    opts?: { recordHistory?: boolean; setCurrentPath?: boolean; silent?: boolean },
   ) => Promise<boolean>;
 }): Promise<void> {
   if (!hasWorkspaceScope || hasInitializedRef.current) {
@@ -944,31 +947,54 @@ async function initializeExplorer({
     hasInitializedRef.current = false;
     return;
   }
-  requestPersistedExpandedPaths({ workspaceStateKey, requestDirectoryListing });
+  void requestPersistedExpandedPaths({ workspaceStateKey, requestDirectoryListing });
 }
 
-function requestPersistedExpandedPaths({
+async function requestPersistedExpandedPaths({
   workspaceStateKey,
   requestDirectoryListing,
 }: {
   workspaceStateKey: string | null;
   requestDirectoryListing: (
     path: string,
-    opts?: { recordHistory?: boolean; setCurrentPath?: boolean },
+    opts?: { recordHistory?: boolean; setCurrentPath?: boolean; silent?: boolean },
   ) => Promise<boolean>;
-}): void {
-  const showHiddenFiles = usePanelStore.getState().explorerShowHiddenFiles;
-  const persistedPaths = usePanelStore.getState().expandedPathsByWorkspace[workspaceStateKey ?? ""];
-  if (!persistedPaths) {
+}): Promise<void> {
+  if (!workspaceStateKey) {
     return;
   }
-  for (const path of persistedPaths) {
-    if (path !== "." && (showHiddenFiles || !isHiddenExplorerPath(path))) {
-      void requestDirectoryListing(path, {
+  const persistedPaths = usePanelStore.getState().expandedPathsByWorkspace[workspaceStateKey];
+  if (!persistedPaths || persistedPaths.length === 0) {
+    return;
+  }
+  const showHiddenFiles = usePanelStore.getState().explorerShowHiddenFiles;
+  const candidates = persistedPaths.filter(
+    (path) => path !== "." && (showHiddenFiles || !isHiddenExplorerPath(path)),
+  );
+  if (candidates.length === 0) {
+    return;
+  }
+  // Hydrate persisted expansions silently so that one missing subdirectory
+  // (e.g. deleted on disk while the app was closed) does not poison the
+  // whole panel with a panel-level error. Prune the failed entries from
+  // the persisted state so subsequent opens stay clean.
+  const results = await Promise.all(
+    candidates.map((path) =>
+      requestDirectoryListing(path, {
         recordHistory: false,
         setCurrentPath: false,
-      });
-    }
+        silent: true,
+      }).then((ok) => ({ path, ok })),
+    ),
+  );
+  const failed = new Set(results.filter((r) => !r.ok).map((r) => r.path));
+  if (failed.size === 0) {
+    return;
+  }
+  const latest = usePanelStore.getState().expandedPathsByWorkspace[workspaceStateKey] ?? [];
+  const pruned = dropFailedExpandedPaths(latest, failed);
+  if (pruned.length !== latest.length) {
+    usePanelStore.getState().setExpandedPathsForWorkspace(workspaceStateKey, pruned);
   }
 }
 

--- a/packages/app/src/hooks/use-file-explorer-actions.test.ts
+++ b/packages/app/src/hooks/use-file-explorer-actions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { dropFailedExpandedPaths } from "./use-file-explorer-actions";
+
+describe("dropFailedExpandedPaths", () => {
+  it("returns a copy of the input when nothing failed", () => {
+    const input = [".", "src", "src/utils"];
+    const result = dropFailedExpandedPaths(input, new Set());
+    expect(result).toEqual([".", "src", "src/utils"]);
+    expect(result).not.toBe(input);
+  });
+
+  it("removes failed paths and keeps survivors plus '.'", () => {
+    expect(
+      dropFailedExpandedPaths([".", "vendor", "src", "src/utils"], new Set(["vendor"])),
+    ).toEqual([".", "src", "src/utils"]);
+  });
+
+  it("removes multiple failed paths in a nested tree", () => {
+    expect(
+      dropFailedExpandedPaths(
+        [".", "a/b", "vendor/foo", "vendor/bar", "src"],
+        new Set(["vendor/foo", "vendor/bar"]),
+      ),
+    ).toEqual([".", "a/b", "src"]);
+  });
+
+  it("ignores failures that are not in the current list", () => {
+    expect(dropFailedExpandedPaths([".", "src"], new Set(["does-not-exist"]))).toEqual([
+      ".",
+      "src",
+    ]);
+  });
+});

--- a/packages/app/src/hooks/use-file-explorer-actions.ts
+++ b/packages/app/src/hooks/use-file-explorer-actions.ts
@@ -51,6 +51,16 @@ export function buildWorkspaceExplorerStateKey(scope: FileExplorerWorkspaceScope
   return `root:${normalizedWorkspaceRoot}`;
 }
 
+export function dropFailedExpandedPaths(
+  current: readonly string[],
+  failed: ReadonlySet<string>,
+): string[] {
+  if (failed.size === 0) {
+    return [...current];
+  }
+  return current.filter((path) => !failed.has(path));
+}
+
 export function useFileExplorerActions(params: { serverId: string } & FileExplorerWorkspaceScope) {
   const { t } = useTranslation();
   const { serverId, workspaceId, workspaceRoot } = params;
@@ -87,7 +97,7 @@ export function useFileExplorerActions(params: { serverId: string } & FileExplor
   const requestDirectoryListing = useCallback(
     async (
       path: string,
-      options?: { recordHistory?: boolean; setCurrentPath?: boolean },
+      options?: { recordHistory?: boolean; setCurrentPath?: boolean; silent?: boolean },
     ): Promise<boolean> => {
       if (!workspaceStateKey) {
         return false;
@@ -95,11 +105,12 @@ export function useFileExplorerActions(params: { serverId: string } & FileExplor
       const normalizedPath = path && path.length > 0 ? path : ".";
       const shouldSetCurrentPath = options?.setCurrentPath ?? true;
       const shouldRecordHistory = options?.recordHistory ?? shouldSetCurrentPath;
+      const silent = options?.silent ?? false;
 
       updateExplorerState((state) => ({
         ...state,
         isLoading: true,
-        lastError: null,
+        lastError: silent ? state.lastError : null,
         pendingRequest: { path: normalizedPath, mode: "list" },
         ...(shouldSetCurrentPath
           ? {
@@ -116,7 +127,7 @@ export function useFileExplorerActions(params: { serverId: string } & FileExplor
         updateExplorerState((state) => ({
           ...state,
           isLoading: false,
-          lastError: t("workspace.fileExplorer.states.unavailable"),
+          lastError: silent ? state.lastError : t("workspace.fileExplorer.states.unavailable"),
           pendingRequest: null,
         }));
         return false;
@@ -126,7 +137,7 @@ export function useFileExplorerActions(params: { serverId: string } & FileExplor
         updateExplorerState((state) => ({
           ...state,
           isLoading: false,
-          lastError: t("workspace.terminal.hostDisconnected"),
+          lastError: silent ? state.lastError : t("workspace.terminal.hostDisconnected"),
           pendingRequest: null,
         }));
         return false;
@@ -138,7 +149,9 @@ export function useFileExplorerActions(params: { serverId: string } & FileExplor
           const nextState: AgentFileExplorerState = {
             ...state,
             isLoading: false,
-            lastError: null,
+            // Silent calls must not touch lastError so a background hydration
+            // success does not clear an unrelated, user-visible error.
+            lastError: silent ? state.lastError : null,
             pendingRequest: null,
             directories: state.directories,
             files: state.files,
@@ -152,13 +165,14 @@ export function useFileExplorerActions(params: { serverId: string } & FileExplor
         });
         return true;
       } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : t("workspace.fileExplorer.errors.failedToListDirectory");
         updateExplorerState((state) => ({
           ...state,
           isLoading: false,
-          lastError:
-            error instanceof Error
-              ? error.message
-              : t("workspace.fileExplorer.errors.failedToListDirectory"),
+          lastError: silent ? state.lastError : message,
           pendingRequest: null,
         }));
         return false;


### PR DESCRIPTION
Fixes #1145.

## Problem

Opening the file-explorer panel for a workspace fires a directory listing for every entry in `expandedPathsByWorkspace`. When one of those subdirectories has been removed outside the app, the listing returns an ENOENT, which writes to the shared `lastError` and renders the whole panel as an error banner with a Retry button. Retry recovers the current session, but the failed path stays in `expandedPathsByWorkspace`, so the same error returns on the next open.

I hit this on macOS with 0.1.80 after deleting a directory I'd previously expanded. Once I confirmed the stale paths were sitting in `panel-state` localStorage and that pruning them by hand made the banner go away, the cause was clear.

## Fix

In the hydration `useEffect` of `FileExplorerPane`:

1. `await` the persisted listings instead of fire-and-forget.
2. Pass a new `silent` flag to `requestDirectoryListing` so a failed listing does not overwrite the panel's `lastError`.
3. Remove any failed paths from `expandedPathsByWorkspace` after hydration so the persisted state self-heals.

The interactive paths (toggle, Retry, ancestor expand, navigation) don't pass `silent`, so their error-reporting behaviour is unchanged.

A small pure helper `dropFailedExpandedPaths` is exported and unit-tested so the prune logic is covered without rendering the React tree.

## Verification

Only tested on **macOS desktop (relay transport)** — other platforms not exercised.

- `npm run typecheck --workspace=@getpaseo/app` ✓
- `npm run format:check` ✓
- `npm run lint --workspace=@getpaseo/app -- src/hooks/use-file-explorer-actions.ts src/hooks/use-file-explorer-actions.test.ts src/components/file-explorer-pane.tsx` — no new findings (8 pre-existing warnings in `file-explorer-pane.tsx` on `main` are unrelated)
- `npx vitest run src/hooks/use-file-explorer-actions.test.ts` ✓ 4/4

Bug repro & root-cause confirmation:

1. Inspected `panel-state` in localStorage; found the stale paths under the workspace key.
2. Cross-checked `~/.paseo/daemon.log`: every open of the panel emits `Failed to fulfill file explorer request for workspace … path: <stale-path>` for every stale entry.
3. Manually pruning the stale entries from `expandedPathsByWorkspace` made the banner stop appearing — confirming that the persisted state is the trigger, which is exactly what this patch removes automatically on hydration.

I didn't rebuild the Electron desktop app to run the patched code end-to-end, but the patch only changes the front-end hydration flow and is covered by the unit test plus the manual root-cause evidence above.