### PR TITLE
Fix false unpushed commit warnings for worktree archive

### DIFF
--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -493,6 +493,29 @@ const x = 1;
     expect(status.aheadOfOrigin).toBeNull();
   });
 
+  it("does not report full history as unpushed for fresh no-track Paseo worktrees", async () => {
+    setupRemoteTrackingMain(repoDir, tempDir);
+    commitFile(repoDir, "second.txt", "second\n", "second commit");
+    execFileSync("git", ["push"], { cwd: repoDir });
+
+    const worktree = await createLegacyWorktreeForTest({
+      branchName: "fresh-feature",
+      cwd: repoDir,
+      baseBranch: "main",
+      worktreeSlug: "fresh-feature",
+      paseoHome,
+    });
+
+    const status = await getCheckoutStatus(worktree.worktreePath, { paseoHome });
+    expect(status).toMatchObject({
+      isGit: true,
+      isPaseoOwnedWorktree: true,
+      baseRef: "main",
+      aheadBehind: { ahead: 0, behind: 0 },
+      aheadOfOrigin: null,
+    });
+  });
+
   it("does not report incoming additions when the base branch is behind its remote", async () => {
     const { cloneDir } = setupRemoteTrackingMain(repoDir, tempDir);
     commitFile(cloneDir, "file.txt", "remote one\nremote two\n", "remote update");

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -512,7 +512,31 @@ const x = 1;
       isPaseoOwnedWorktree: true,
       baseRef: "main",
       aheadBehind: { ahead: 0, behind: 0 },
-      aheadOfOrigin: null,
+      aheadOfOrigin: 0,
+    });
+  });
+
+  it("reports local-only worktree commits as unpushed relative to base", async () => {
+    setupRemoteTrackingMain(repoDir, tempDir);
+    commitFile(repoDir, "second.txt", "second\n", "second commit");
+    execFileSync("git", ["push"], { cwd: repoDir });
+
+    const worktree = await createLegacyWorktreeForTest({
+      branchName: "fresh-feature",
+      cwd: repoDir,
+      baseBranch: "main",
+      worktreeSlug: "fresh-feature",
+      paseoHome,
+    });
+    commitFile(worktree.worktreePath, "feature.txt", "feature\n", "feature commit");
+
+    const status = await getCheckoutStatus(worktree.worktreePath, { paseoHome });
+    expect(status).toMatchObject({
+      isGit: true,
+      isPaseoOwnedWorktree: true,
+      baseRef: "main",
+      aheadBehind: { ahead: 1, behind: 0 },
+      aheadOfOrigin: 1,
     });
   });
 

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1268,6 +1268,7 @@ async function getAheadBehind(
 async function getAheadOfOrigin(
   cwd: string,
   currentBranch: string,
+  baseRef: string | null,
   context?: CheckoutContext,
 ): Promise<number | null> {
   if (!currentBranch) {
@@ -1283,7 +1284,23 @@ async function getAheadOfOrigin(
     const count = Number.parseInt(stdout.trim(), 10);
     return Number.isNaN(count) ? null : count;
   } catch {
-    return null;
+    if (trackedOriginBranch) {
+      return null;
+    }
+    if (!baseRef || normalizeLocalBranchRefName(baseRef) === currentBranch) {
+      return null;
+    }
+    try {
+      const comparisonBaseRef = await resolveBestComparisonBaseRef(cwd, baseRef, context);
+      const { stdout } = await runGitCommand(
+        ["rev-list", "--count", `${comparisonBaseRef}..${currentBranch}`],
+        { cwd, envOverlay: READ_ONLY_GIT_ENV, logger: context?.logger },
+      );
+      const count = Number.parseInt(stdout.trim(), 10);
+      return Number.isNaN(count) ? null : count;
+    } catch {
+      return null;
+    }
   }
 }
 
@@ -1490,7 +1507,7 @@ export async function getCheckoutStatus(
       ? getAheadBehind(cwd, baseRef, currentBranch, context)
       : Promise.resolve(null),
     hasRemote && currentBranch
-      ? getAheadOfOrigin(cwd, currentBranch, context)
+      ? getAheadOfOrigin(cwd, currentBranch, baseRef, context)
       : Promise.resolve(null),
     hasRemote && currentBranch
       ? getBehindOfOrigin(cwd, currentBranch, context)

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1283,20 +1283,7 @@ async function getAheadOfOrigin(
     const count = Number.parseInt(stdout.trim(), 10);
     return Number.isNaN(count) ? null : count;
   } catch {
-    if (trackedOriginBranch) {
-      return null;
-    }
-    try {
-      const { stdout } = await runGitCommand(["rev-list", "--count", currentBranch], {
-        cwd,
-        envOverlay: READ_ONLY_GIT_ENV,
-        logger: context?.logger,
-      });
-      const count = Number.parseInt(stdout.trim(), 10);
-      return Number.isNaN(count) ? null : count;
-    } catch {
-      return null;
-    }
+    return null;
   }
 }
 


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fresh Paseo worktrees no longer show every commit in the repository history as "unpushed commits" when the user opens the archive warning.

The status check still preserves the original local-only branch behavior: when a branch has commits ahead of its base but no remote branch yet, those commits count as unpushed. The fix is that the fallback now compares against the known base ref instead of counting the entire branch history.

### How did you verify it

Reproduced the bug with a red regression test for a fresh no-track Paseo worktree: before the fix it reported the full branch history as ahead even though it had no commits ahead of base.

Added coverage for both sides of the behavior:

- a fresh no-track worktree at its base reports `aheadOfOrigin: 0`
- a local-only worktree with one commit ahead of base reports `aheadOfOrigin: 1`
- the existing deleted-upstream case still reports `aheadOfOrigin: null`

Verified with:

- `npx vitest run packages/server/src/utils/checkout-git.test.ts --bail=1`
- `npm run format:files -- packages/server/src/utils/checkout-git.ts packages/server/src/utils/checkout-git.test.ts`
- `npm run lint -- packages/server/src/utils/checkout-git.ts packages/server/src/utils/checkout-git.test.ts`
- `npm run typecheck`
- `npm run format`

The commit hook also reran targeted lint, format check, and typecheck successfully.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A: no UI changes)
- [x] Tests added or updated where it made sense