### PR TITLE
fix(server): authenticate OpenCode SDK client

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -22,6 +22,7 @@ Provider IDs must be lowercase alphanumeric with hyphens (`/^[a-z][a-z0-9-]*$/`)
 ## Table of Contents
 
 - [Extending a built-in provider](#extending-a-built-in-provider)
+- [OpenCode server authentication](#opencode-server-authentication)
 - [Z.AI (Zhipu) coding plan](#zai-zhipu-coding-plan)
 - [Alibaba Cloud (Qwen) coding plan](#alibaba-cloud-qwen-coding-plan)
 - [Multiple profiles for the same provider](#multiple-profiles-for-the-same-provider)
@@ -82,6 +83,31 @@ Custom providers that extend `"codex"` can point Codex at an OpenAI-compatible A
 ```
 
 If the base URL does not end in `/v1`, Paseo appends `/v1` for Codex's OpenAI-compatible provider config. If it already ends in `/v1`, Paseo leaves it as-is.
+
+---
+
+## OpenCode server authentication
+
+OpenCode protects `opencode serve` with HTTP Basic Auth when `OPENCODE_SERVER_PASSWORD` is set. The username defaults to `opencode`; set `OPENCODE_SERVER_USERNAME` only if you changed it.
+
+Configure these values in the built-in OpenCode provider `env` so Paseo starts the OpenCode server with the same credentials and sends matching auth headers when calling the SDK:
+
+```json
+{
+  "agents": {
+    "providers": {
+      "opencode": {
+        "env": {
+          "OPENCODE_SERVER_USERNAME": "opencode",
+          "OPENCODE_SERVER_PASSWORD": "your-password"
+        }
+      }
+    }
+  }
+}
+```
+
+You can omit `OPENCODE_SERVER_USERNAME` when using OpenCode's default username.
 
 ---
 

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -1184,7 +1184,16 @@ describe("OpenCodeAgentClient env", () => {
     const openCodeClient = new TestOpenCodeClient();
     runtime.enqueueClient(openCodeClient);
     const cwd = tmpCwd();
-    const client = new OpenCodeAgentClient(createTestLogger(), undefined, { runtime });
+    const client = new OpenCodeAgentClient(
+      createTestLogger(),
+      {
+        env: {
+          OPENCODE_SERVER_USERNAME: "provider-user",
+          OPENCODE_SERVER_PASSWORD: "provider-password",
+        },
+      },
+      { runtime },
+    );
 
     try {
       const session = await client.createSession(
@@ -1195,6 +1204,8 @@ describe("OpenCodeAgentClient env", () => {
         {
           env: {
             CHUNK14_PROBE: "expected",
+            OPENCODE_SERVER_USERNAME: "launch-user",
+            OPENCODE_SERVER_PASSWORD: "launch-password",
           },
         },
       );
@@ -1204,10 +1215,96 @@ describe("OpenCodeAgentClient env", () => {
         force: false,
         env: {
           CHUNK14_PROBE: "expected",
+          OPENCODE_SERVER_USERNAME: "launch-user",
+          OPENCODE_SERVER_PASSWORD: "launch-password",
         },
+      });
+      expect(runtime.clientCreations[0]?.auth).toEqual({
+        username: "launch-user",
+        password: "launch-password",
       });
     } finally {
       rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("passes provider OpenCode server auth env to SDK clients", async () => {
+    const runtime = new TestOpenCodeRuntime();
+    const openCodeClient = new TestOpenCodeClient();
+    runtime.enqueueClient(openCodeClient);
+    const cwd = tmpCwd();
+    const client = new OpenCodeAgentClient(
+      createTestLogger(),
+      {
+        env: {
+          OPENCODE_SERVER_USERNAME: "provider-user",
+          OPENCODE_SERVER_PASSWORD: "provider-password",
+        },
+      },
+      { runtime },
+    );
+
+    try {
+      const session = await client.createSession({
+        provider: "opencode",
+        cwd,
+      });
+      await session.close();
+
+      expect(runtime.clientCreations[0]?.auth).toEqual({
+        username: "provider-user",
+        password: "provider-password",
+      });
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("defaults OpenCode server auth username when password comes from process env", async () => {
+    const previousUsername = process.env.OPENCODE_SERVER_USERNAME;
+    const previousPassword = process.env.OPENCODE_SERVER_PASSWORD;
+    process.env.OPENCODE_SERVER_PASSWORD = "process-password";
+    delete process.env.OPENCODE_SERVER_USERNAME;
+
+    const runtime = new TestOpenCodeRuntime();
+    const openCodeClient = new TestOpenCodeClient();
+    openCodeClient.providerListResponse = {
+      data: {
+        connected: ["test-provider"],
+        all: [
+          {
+            id: "test-provider",
+            name: "Test Provider",
+            source: "env",
+            models: {
+              "model-a": { name: "Model A" },
+            },
+          },
+        ],
+      },
+    };
+    runtime.enqueueClient(openCodeClient);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, { runtime });
+
+    try {
+      const models = await client.listModels({ cwd: os.homedir(), force: false });
+
+      expect(models).toHaveLength(1);
+      expect(runtime.clientCreations[0]?.auth).toEqual({
+        username: "opencode",
+        password: "process-password",
+      });
+    } finally {
+      if (previousUsername === undefined) {
+        delete process.env.OPENCODE_SERVER_USERNAME;
+      } else {
+        process.env.OPENCODE_SERVER_USERNAME = previousUsername;
+      }
+      if (previousPassword === undefined) {
+        delete process.env.OPENCODE_SERVER_PASSWORD;
+      } else {
+        process.env.OPENCODE_SERVER_PASSWORD = previousPassword;
+      }
     }
   });
 });
@@ -1341,7 +1438,9 @@ describe("OpenCode persisted sessions", () => {
       }),
       { type: "assistant_message", text: "hello back" },
     ]);
-    expect(runtime.clientCreations).toEqual([{ baseUrl: runtime.server.url, directory: cwd }]);
+    expect(runtime.clientCreations).toEqual([
+      expect.objectContaining({ baseUrl: runtime.server.url, directory: cwd }),
+    ]);
     expect(openCodeClient.calls.experimentalSessionList).toEqual([
       { archived: true, roots: true, limit: 200 },
     ]);

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -63,8 +63,10 @@ import { renderPromptAttachmentAsText } from "../prompt-attachments.js";
 import { composeSystemPromptParts } from "../system-prompt.js";
 import {
   createSdkOpenCodeClient,
+  type OpenCodeClientOptions,
   type OpenCodeRuntime,
   type OpenCodeServerAcquisition,
+  type OpenCodeServerAuth,
 } from "./opencode/runtime.js";
 import { normalizeProviderReplayTimestamp } from "../provider-history-timestamps.js";
 
@@ -81,6 +83,9 @@ const OPENCODE_BUILD_MODE_ID = "build";
 const OPENCODE_FULL_ACCESS_MODE_ID = "full-access";
 const OPENCODE_PERSISTED_SESSION_LIMIT = 200;
 const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
+const OPENCODE_SERVER_USERNAME_ENV = "OPENCODE_SERVER_USERNAME";
+const OPENCODE_SERVER_PASSWORD_ENV = "OPENCODE_SERVER_PASSWORD";
+const DEFAULT_OPENCODE_SERVER_USERNAME = "opencode";
 
 const DEFAULT_MODES: AgentMode[] = [
   {
@@ -103,10 +108,25 @@ const DEFAULT_MODES: AgentMode[] = [
 type OpenCodeAgentConfig = AgentSessionConfig & { provider: "opencode" };
 type OpenCodeMessageRole = "user" | "assistant";
 type OpenCodePersistedSession = OpenCodeSession | OpenCodeGlobalSession;
+type OpenCodeServerEnv = Record<string, string | undefined>;
 
 interface OpenCodeSessionMessage {
   info: OpenCodeMessage;
   parts: OpenCodePart[];
+}
+
+function resolveOpenCodeServerAuth(
+  ...overlays: Array<OpenCodeServerEnv | undefined>
+): OpenCodeServerAuth | undefined {
+  const env: OpenCodeServerEnv = Object.assign({}, process.env, ...overlays);
+  const password = env[OPENCODE_SERVER_PASSWORD_ENV];
+  if (!password) {
+    return undefined;
+  }
+  return {
+    username: env[OPENCODE_SERVER_USERNAME_ENV] || DEFAULT_OPENCODE_SERVER_USERNAME,
+    password,
+  };
 }
 
 type OpenCodeMcpConfig =
@@ -972,7 +992,7 @@ class ProductionOpenCodeRuntime implements OpenCodeRuntime {
     return this.serverManager.ensureRunning();
   }
 
-  createClient(options: { baseUrl: string; directory: string }): OpencodeClient {
+  createClient(options: OpenCodeClientOptions): OpencodeClient {
     return createSdkOpenCodeClient(options);
   }
 
@@ -1004,6 +1024,19 @@ export class OpenCodeAgentClient implements AgentClient {
       );
   }
 
+  private createRuntimeClient(options: {
+    baseUrl: string;
+    directory: string;
+    env?: Record<string, string>;
+  }): OpencodeClient {
+    const auth = resolveOpenCodeServerAuth(this.runtimeSettings?.env, options.env);
+    return this.runtime.createClient({
+      baseUrl: options.baseUrl,
+      directory: options.directory,
+      ...(auth ? { auth } : {}),
+    });
+  }
+
   async createSession(
     config: AgentSessionConfig,
     launchContext?: AgentLaunchContext,
@@ -1015,9 +1048,10 @@ export class OpenCodeAgentClient implements AgentClient {
       env: launchContext?.env,
     });
     const { url } = acquisition.server;
-    const client = this.runtime.createClient({
+    const client = this.createRuntimeClient({
       baseUrl: url,
       directory: openCodeConfig.cwd,
+      env: launchContext?.env,
     });
 
     try {
@@ -1074,7 +1108,7 @@ export class OpenCodeAgentClient implements AgentClient {
     const openCodeConfig = this.assertConfig(config);
     const acquisition = await this.runtime.acquireServer({ force: false });
     const { url } = acquisition.server;
-    const client = this.runtime.createClient({
+    const client = this.createRuntimeClient({
       baseUrl: url,
       directory: openCodeConfig.cwd,
     });
@@ -1101,7 +1135,7 @@ export class OpenCodeAgentClient implements AgentClient {
   async listModels(options: ListModelsOptions): Promise<AgentModelDefinition[]> {
     const acquisition = await this.runtime.acquireServer({ force: options.force });
     const { url } = acquisition.server;
-    const client = this.runtime.createClient({
+    const client = this.createRuntimeClient({
       baseUrl: url,
       directory: options.cwd,
     });
@@ -1171,7 +1205,7 @@ export class OpenCodeAgentClient implements AgentClient {
     const acquisition = await this.runtime.acquireServer({ force: options.force });
     const { url } = acquisition.server;
     const directory = options.cwd;
-    const client = this.runtime.createClient({ baseUrl: url, directory });
+    const client = this.createRuntimeClient({ baseUrl: url, directory });
 
     try {
       const response = await withTimeout(
@@ -1203,7 +1237,7 @@ export class OpenCodeAgentClient implements AgentClient {
     const openCodeConfig = this.assertConfig(config);
     const acquisition = await this.runtime.acquireServer({ force: false });
     const { url } = acquisition.server;
-    const client = this.runtime.createClient({
+    const client = this.createRuntimeClient({
       baseUrl: url,
       directory: openCodeConfig.cwd,
     });
@@ -1224,7 +1258,7 @@ export class OpenCodeAgentClient implements AgentClient {
   ): Promise<PersistedAgentDescriptor[]> {
     const acquisition = await this.runtime.acquireServer({ force: false });
     const { url } = acquisition.server;
-    const client = this.runtime.createClient({
+    const client = this.createRuntimeClient({
       baseUrl: url,
       directory: options?.cwd ?? "",
     });

--- a/packages/server/src/server/agent/providers/opencode/runtime.ts
+++ b/packages/server/src/server/agent/providers/opencode/runtime.ts
@@ -1,12 +1,24 @@
+import { Buffer } from "node:buffer";
 import {
   createOpencodeClient,
   type OpencodeClient,
   type OpencodeClientConfig,
 } from "@opencode-ai/sdk/v2/client";
 
+export interface OpenCodeServerAuth {
+  username: string;
+  password: string;
+}
+
 export interface OpenCodeServerAcquisition {
   server: { port: number; url: string };
   release: () => void;
+}
+
+export interface OpenCodeClientOptions {
+  baseUrl: string;
+  directory: string;
+  auth?: OpenCodeServerAuth;
 }
 
 export interface OpenCodeRuntime {
@@ -15,13 +27,21 @@ export interface OpenCodeRuntime {
     env?: Record<string, string>;
   }): Promise<OpenCodeServerAcquisition>;
   ensureServerRunning(): Promise<{ port: number; url: string }>;
-  createClient(options: { baseUrl: string; directory: string }): OpencodeClient;
+  createClient(options: OpenCodeClientOptions): OpencodeClient;
   shutdown(): Promise<void>;
 }
 
-export function createSdkOpenCodeClient(options: {
-  baseUrl: string;
-  directory: string;
-}): OpencodeClient {
-  return createOpencodeClient(options satisfies OpencodeClientConfig & { directory: string });
+function createOpenCodeBasicAuthHeader(auth: OpenCodeServerAuth): string {
+  return `Basic ${Buffer.from(`${auth.username}:${auth.password}`, "utf8").toString("base64")}`;
+}
+
+export function createSdkOpenCodeClient(options: OpenCodeClientOptions): OpencodeClient {
+  const config = {
+    baseUrl: options.baseUrl,
+    directory: options.directory,
+    ...(options.auth
+      ? { headers: { Authorization: createOpenCodeBasicAuthHeader(options.auth) } }
+      : {}),
+  } satisfies OpencodeClientConfig & { directory: string };
+  return createOpencodeClient(config);
 }

--- a/packages/server/src/server/agent/providers/opencode/test-utils/test-opencode-runtime.ts
+++ b/packages/server/src/server/agent/providers/opencode/test-utils/test-opencode-runtime.ts
@@ -1,6 +1,10 @@
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
 
-import type { OpenCodeRuntime, OpenCodeServerAcquisition } from "../runtime.js";
+import type {
+  OpenCodeClientOptions,
+  OpenCodeRuntime,
+  OpenCodeServerAcquisition,
+} from "../runtime.js";
 
 interface OpenCodeResponse {
   data?: unknown;
@@ -13,7 +17,7 @@ export class TestOpenCodeRuntime implements OpenCodeRuntime {
     env?: Record<string, string>;
     releaseCount: number;
   }> = [];
-  readonly clientCreations: Array<{ baseUrl: string; directory: string }> = [];
+  readonly clientCreations: OpenCodeClientOptions[] = [];
   private readonly clients: TestOpenCodeClient[] = [];
 
   server = { port: 1234, url: "http://127.0.0.1:1234" };
@@ -40,7 +44,7 @@ export class TestOpenCodeRuntime implements OpenCodeRuntime {
     return this.server;
   }
 
-  createClient(options: { baseUrl: string; directory: string }): OpencodeClient {
+  createClient(options: OpenCodeClientOptions): OpencodeClient {
     this.clientCreations.push(options);
     const client = this.clients.shift() ?? new TestOpenCodeClient();
     return client.asSdkClient();


### PR DESCRIPTION
### Linked issue

Fixes #1159

<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

After configuring a user password for OpenCode, it was previously impossible to retrieve relevant information. The commits included in this PR resolve this bug, specifically by implementing the following changes:

- Send Basic Auth headers from the OpenCode SDK client when `OPENCODE_SERVER_PASSWORD` is configured.
- Read OpenCode server authentication credentials from process environment variables, provider environment variables, and launch environment variables.
- Document the configuration process for OpenCode server authentication.
- Add tests to verify authentication sources derived from provider environment variables, process environment variables, and launch environment variables.

### How did you verify it

1. First, configure the environment variables `OPENCODE_SERVER_PASSWORD` and `OPENCODE_SERVER_USERNAME`.

<img width="562" height="169" alt="image" src="https://github.com/user-attachments/assets/dfa5f41c-3d46-47c1-89a9-c15b48374712" />

2. Run `opencode serve` and confirm that the configuration was successful, as the account login pop-up window has appeared.

<img width="597" height="452" alt="image" src="https://github.com/user-attachments/assets/592e8fd7-7876-4960-a966-b41fc9055bd9" />

3. Launch Paseo and verify that the model list has been successfully loaded.

<img width="759" height="339" alt="image" src="https://github.com/user-attachments/assets/62993a82-e54a-41c6-9bc7-8d20d34574f3" />

4. Verify that Paseo is indeed utilizing the OpenCode instance configured via the environment variables: within the app, click on `opencode` under the `Providers` section; the startup URL can be found at the top, within the `Diagnostic` section.

<img width="529" height="655" alt="image" src="https://github.com/user-attachments/assets/e9e3968e-a94e-46aa-8f32-531baab022d7" />

5. Access the URL obtained in Step 4 and confirm that a login pop-up window appears.

<img width="563" height="314" alt="image" src="https://github.com/user-attachments/assets/61d54e08-25c7-41d9-a16c-3c41c1411a60" />


6. Verification and fix complete.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
