### PR TITLE
Add Devin CLI to the ACP provider catalog

### DIFF
--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -145,6 +145,15 @@ const CATALOG_DATA = [
     command: ["deepseek", "serve", "--acp"],
   },
   {
+    id: "devin",
+    title: "Devin CLI",
+    description: "Cognition's Devin for Terminal via Agent Client Protocol",
+    version: "manual",
+    iconId: null,
+    installLink: "https://cli.devin.ai/docs",
+    command: ["devin", "acp"],
+  },
+  {
     id: "dimcode",
     title: "DimCode",
     description: "A coding agent that puts leading models at your command.",

--- a/packages/app/src/hooks/use-acp-provider-catalog.test.ts
+++ b/packages/app/src/hooks/use-acp-provider-catalog.test.ts
@@ -38,6 +38,7 @@ describe("ACP provider catalog", () => {
     expect(findProvider("amp-acp").command).toEqual(["amp-acp"]);
     expect(findProvider("cursor").command).toEqual(["cursor-agent", "acp"]);
     expect(findProvider("deepseek-tui").command).toEqual(["deepseek", "serve", "--acp"]);
+    expect(findProvider("devin").command).toEqual(["devin", "acp"]);
     expect(findProvider("goose").command).toEqual(["goose", "acp"]);
     expect(findProvider("junie").command).toEqual(["junie", "--acp", "true"]);
     expect(findProvider("kiro").command).toEqual(["kiro-cli", "acp"]);


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds Devin CLI to the in-app ACP provider catalog. The catalog entry uses Devin's ACP server command, `devin acp`, so users can add Devin for Terminal through the existing custom ACP provider flow.

The catalog test now pins the Devin command shape alongside the other PATH-distributed ACP providers.

### How did you verify it

Verified the catalog entry with the targeted app test:

- `npm run test --workspace=packages/app -- src/hooks/use-acp-provider-catalog.test.ts --bail=1`

Result: 1 test file passed, 5 tests passed.

Also manually verified the provider flow in a local dev daemon/app session:

- Added `Devin CLI` from the ACP provider catalog.
- Started an agent with `--provider devin` against the local daemon.
- Confirmed the created agent used provider `devin` and reached the normal Paseo permission flow.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A: catalog data only; no visible component changes)
- [x] Tests added or updated where it made sense