### PR TITLE
Add allow-always actions for OpenCode permissions

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-agent.permission-actions.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.permission-actions.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import { OpenCodeAgentClient } from "./opencode-agent.js";
+import {
+  idleEvent,
+  TestOpenCodeClient,
+  TestOpenCodeRuntime,
+} from "./opencode/test-utils/test-opencode-runtime.js";
+
+function mockOpenCodeClient(events: unknown[]) {
+  const runtime = new TestOpenCodeRuntime();
+  const openCodeClient = new TestOpenCodeClient();
+  openCodeClient.sessionPromptAsyncEvents = events;
+  runtime.enqueueClient(openCodeClient);
+
+  return { openCodeClient, runtime };
+}
+
+function toolPermissionEvent(): unknown {
+  return {
+    type: "permission.asked",
+    properties: {
+      id: "permission-1",
+      sessionID: "session-1",
+      permission: "external_directory",
+      patterns: ["/tmp/outside/*"],
+      metadata: {
+        reason: "Inspect files outside the project",
+      },
+    },
+  };
+}
+
+describe("OpenCode permission actions", () => {
+  test("allow always sends OpenCode's always reply", async () => {
+    const { openCodeClient, runtime } = mockOpenCodeClient([toolPermissionEvent(), idleEvent()]);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, { runtime });
+    const session = await client.createSession({
+      provider: "opencode",
+      cwd: "/tmp/project",
+      modeId: "build",
+    });
+
+    await session.run("Inspect outside files");
+    const permission = session.getPendingPermissions()[0]!;
+    await session.respondToPermission(permission.id, {
+      behavior: "allow",
+      selectedActionId: "allow_always",
+    });
+
+    expect(openCodeClient.calls.permissionReply).toEqual([
+      {
+        requestID: "permission-1",
+        directory: "/tmp/project",
+        reply: "always",
+      },
+    ]);
+    expect(session.getPendingPermissions()).toEqual([]);
+
+    await session.close();
+  });
+
+  test("plain allow keeps the backward-compatible once reply", async () => {
+    const { openCodeClient, runtime } = mockOpenCodeClient([toolPermissionEvent(), idleEvent()]);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, { runtime });
+    const session = await client.createSession({
+      provider: "opencode",
+      cwd: "/tmp/project",
+      modeId: "build",
+    });
+
+    await session.run("Inspect outside files");
+    const permission = session.getPendingPermissions()[0]!;
+    await session.respondToPermission(permission.id, {
+      behavior: "allow",
+    });
+
+    expect(openCodeClient.calls.permissionReply).toEqual([
+      {
+        requestID: "permission-1",
+        directory: "/tmp/project",
+        reply: "once",
+      },
+    ]);
+    expect(session.getPendingPermissions()).toEqual([]);
+
+    await session.close();
+  });
+});

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -24,6 +24,7 @@ import {
   type AgentLaunchContext,
   type AgentMode,
   type AgentModelDefinition,
+  type AgentPermissionAction,
   type AgentPermissionRequest,
   type AgentPermissionResponse,
   type AgentPersistenceHandle,
@@ -81,6 +82,8 @@ const OPENCODE_BUILD_MODE_ID = "build";
 const OPENCODE_FULL_ACCESS_MODE_ID = "full-access";
 const OPENCODE_PERSISTED_SESSION_LIMIT = 200;
 const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
+const OPENCODE_PERMISSION_ACTION_ALLOW_ONCE = "allow_once";
+const OPENCODE_PERMISSION_ACTION_ALLOW_ALWAYS = "allow_always";
 
 const DEFAULT_MODES: AgentMode[] = [
   {
@@ -99,6 +102,44 @@ const DEFAULT_MODES: AgentMode[] = [
     description: "Automatically approves all tool permission prompts for the session",
   },
 ];
+
+function buildOpenCodePermissionActions(): AgentPermissionAction[] {
+  return [
+    {
+      id: "deny",
+      label: "Deny",
+      behavior: "deny",
+      variant: "danger",
+      intent: "dismiss",
+    },
+    {
+      id: OPENCODE_PERMISSION_ACTION_ALLOW_ALWAYS,
+      label: "Allow always",
+      behavior: "allow",
+      variant: "secondary",
+    },
+    {
+      id: OPENCODE_PERMISSION_ACTION_ALLOW_ONCE,
+      label: "Allow once",
+      behavior: "allow",
+      variant: "primary",
+    },
+  ];
+}
+
+function resolveOpenCodePermissionReply(
+  response: AgentPermissionResponse,
+): "once" | "always" | "reject" {
+  if (response.behavior === "deny") {
+    return "reject";
+  }
+
+  if (response.selectedActionId === OPENCODE_PERMISSION_ACTION_ALLOW_ALWAYS) {
+    return "always";
+  }
+
+  return "once";
+}
 
 type OpenCodeAgentConfig = AgentSessionConfig & { provider: "opencode" };
 type OpenCodeMessageRole = "user" | "assistant";
@@ -2182,6 +2223,7 @@ function appendOpenCodePermissionAsked(
       ...(description ? { description } : {}),
       input,
       detail,
+      actions: buildOpenCodePermissionActions(),
     },
   });
 }
@@ -3027,7 +3069,7 @@ class OpenCodeAgentSession implements AgentSession {
       return;
     }
 
-    const reply = response.behavior === "allow" ? "once" : "reject";
+    const reply = resolveOpenCodePermissionReply(response);
     await this.client.permission.reply({
       requestID: requestId,
       directory: this.config.cwd,

--- a/packages/server/src/server/agent/providers/opencode/event-translator.test.ts
+++ b/packages/server/src/server/agent/providers/opencode/event-translator.test.ts
@@ -2,6 +2,28 @@ import { describe, expect, it } from "vitest";
 
 import { translateOpenCodeEvent, type OpenCodeEventTranslationState } from "../opencode-agent.js";
 
+const openCodePermissionActions = [
+  {
+    id: "deny",
+    label: "Deny",
+    behavior: "deny",
+    variant: "danger",
+    intent: "dismiss",
+  },
+  {
+    id: "allow_always",
+    label: "Allow always",
+    behavior: "allow",
+    variant: "secondary",
+  },
+  {
+    id: "allow_once",
+    label: "Allow once",
+    behavior: "allow",
+    variant: "primary",
+  },
+];
+
 function createState(sessionId = "session-1"): OpenCodeEventTranslationState {
   return {
     sessionId,
@@ -306,6 +328,7 @@ describe("translateOpenCodeEvent", () => {
             type: "shell",
             command: "ls /home/user/secrets",
           },
+          actions: openCodePermissionActions,
         },
       },
     ]);
@@ -358,6 +381,7 @@ describe("translateOpenCodeEvent", () => {
             },
             output: null,
           },
+          actions: openCodePermissionActions,
         },
       },
     ]);


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

OpenCode permission prompts in Paseo now surface the provider's richer choices instead of collapsing everything to a generic accept action.

Users can choose Deny, Allow once, or Allow always. Allow always maps back to OpenCode's persistent permission reply, while older clients or fallback allow responses still approve only once. Full Access mode keeps its existing session auto-approval behavior.

### How did you verify it

- `npx vitest run packages/server/src/server/agent/providers/opencode/event-translator.test.ts --bail=1`
- `npx vitest run packages/server/src/server/agent/providers/opencode-agent.permission-actions.test.ts --bail=1`
- `npx vitest run packages/server/src/server/agent/providers/opencode-agent.full-access.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

### Risk surface

This changes only the OpenCode provider's normalized permission payload and response mapping. The app already renders provider-supplied permission actions generically; the main compatibility surface is old clients sending allow without `selectedActionId`, which remains mapped to one-time approval.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

UI screenshot/video is not included because this PR changes provider action data and uses the existing permission action renderer without changing app UI code.