### PR TITLE
Interrupting an OpenCode agent should return to idle, not error

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -1653,14 +1653,7 @@ export function translateOpenCodeEvent(
       }
       break;
     case "session.error":
-      if (event.properties.sessionID === state.sessionId) {
-        resetOpenCodeTurnTrackingState(state);
-        events.push({
-          type: "turn_failed",
-          provider: "opencode",
-          error: toDiagnosticErrorMessage(event.properties.error),
-        });
-      }
+      appendOpenCodeSessionError(event, state, events);
       break;
     case "session.status":
       appendOpenCodeSessionStatus(event, state, events);
@@ -2233,6 +2226,36 @@ function appendOpenCodeQuestionAsked(
       },
     },
   });
+}
+
+function appendOpenCodeSessionError(
+  event: Extract<OpenCodeEvent, { type: "session.error" }>,
+  state: OpenCodeEventTranslationState,
+  events: AgentStreamEvent[],
+): void {
+  if (event.properties.sessionID !== state.sessionId) {
+    return;
+  }
+  resetOpenCodeTurnTrackingState(state);
+  const error = event.properties.error;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "MessageAbortedError"
+  ) {
+    events.push({
+      type: "turn_canceled",
+      provider: "opencode",
+      reason: "interrupted",
+    });
+  } else {
+    events.push({
+      type: "turn_failed",
+      provider: "opencode",
+      error: toDiagnosticErrorMessage(error),
+    });
+  }
 }
 
 function appendOpenCodeSessionStatus(

--- a/packages/server/src/server/agent/providers/opencode/event-translator.test.ts
+++ b/packages/server/src/server/agent/providers/opencode/event-translator.test.ts
@@ -924,4 +924,52 @@ describe("translateOpenCodeEvent", () => {
     ]);
     expect(second).toEqual([]);
   });
+
+  it("translates session.error with MessageAbortedError as turn_canceled, not turn_failed", () => {
+    const state = createState();
+
+    const events = translateOpenCodeEvent(
+      {
+        type: "session.error",
+        properties: {
+          sessionID: "session-1",
+          error: {
+            name: "MessageAbortedError",
+            data: { message: "aborted" },
+          },
+        },
+      },
+      state,
+    );
+
+    expect(events).toEqual([
+      { type: "turn_canceled", provider: "opencode", reason: "interrupted" },
+    ]);
+  });
+
+  it("translates session.error with a real error as turn_failed", () => {
+    const state = createState();
+
+    const events = translateOpenCodeEvent(
+      {
+        type: "session.error",
+        properties: {
+          sessionID: "session-1",
+          error: {
+            name: "UnknownError",
+            data: { message: "something broke" },
+          },
+        },
+      },
+      state,
+    );
+
+    expect(events).toEqual([
+      {
+        type: "turn_failed",
+        provider: "opencode",
+        error: '{"name":"UnknownError","data":{"message":"something broke"}}',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
When you cancel a running OpenCode agent (or send a replacement message mid-turn), OpenCode emits a `session.error` event with `MessageAbortedError`. Paseo was treating every `session.error` as `turn_failed`, which set the agent lifecycle to `error` and appended a raw JSON blob (`{"name":"MessageAbortedError","data":{"message":"aborted"}}`) as a system error in the timeline.

Now `MessageAbortedError` maps to `turn_canceled` — the same path as an explicit cancel — so the agent returns to `idle` with no error state. Real errors still produce `turn_failed`.

**Verification.** Two new unit tests in the event translator cover both paths:
- `session.error` with `MessageAbortedError` → `turn_canceled`
- `session.error` with a real error → `turn_failed`

The existing interrupt E2E test (`opencode-send-interrupt.real.e2e.test.ts`) already asserts no `[System Error]` text appears after interrupt; that test should continue passing. Worth running it against a real OpenCode install to confirm end-to-end.

**Risk surface.** Low. The change is isolated to the OpenCode event translator's `session.error` handler. Other providers are unaffected. The agent-manager already handles `turn_canceled` correctly (lifecycle → idle, no error). Protocol shape is unchanged — `turn_canceled` was already a valid event type on the wire.