### PR TITLE
Allow PR merge when GitHub reports it ready

### DIFF
--- a/packages/app/src/git/policy.test.ts
+++ b/packages/app/src/git/policy.test.ts
@@ -226,6 +226,9 @@ describe("git-actions-policy", () => {
       "merge-from-base",
       "merge-branch",
       "pr",
+      "merge-pr-squash",
+      "merge-pr-merge",
+      "merge-pr-rebase",
     ]);
     expect(
       actions.secondary.some((action) => action.id === "pr" && action.label === "View PR"),
@@ -322,6 +325,45 @@ describe("git-actions-policy", () => {
       id: "merge-pr-squash",
       label: "Squash and merge",
     });
+  });
+
+  it("offers direct PR merge when GitHub says the PR is mergeable even if the local branch is behind", () => {
+    const actions = buildGitActions(
+      createInput({
+        hasRemote: true,
+        isOnBaseBranch: false,
+        aheadCount: 2,
+        behindBaseCount: 3,
+        aheadOfOrigin: 0,
+        behindOfOrigin: 2,
+        hasPullRequest: true,
+        pullRequestUrl: "https://example.com/pr/456",
+        pullRequestState: "open",
+        pullRequestMergeable: "MERGEABLE",
+        pullRequestGithub: githubStatus({ mergeStateStatus: "CLEAN" }),
+        shipDefault: "pr",
+      }),
+    );
+
+    expect(actions.secondary).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "merge-pr-squash",
+          disabled: false,
+          unavailableMessage: undefined,
+        }),
+        expect.objectContaining({
+          id: "merge-pr-merge",
+          disabled: false,
+          unavailableMessage: undefined,
+        }),
+        expect.objectContaining({
+          id: "merge-pr-rebase",
+          disabled: false,
+          unavailableMessage: undefined,
+        }),
+      ]),
+    );
   });
 
   it("respects the ship preference when choosing between PR merge and local merge", () => {

--- a/packages/app/src/git/policy.ts
+++ b/packages/app/src/git/policy.ts
@@ -504,7 +504,7 @@ function canMergeFromBase(input: BuildGitActionsInput): boolean {
 
 function canMergePr(input: BuildGitActionsInput): boolean {
   const github = input.pullRequestGithub;
-  const canMergeFromTopLevelStatus =
+  const canMergeFromPullRequestStatus =
     input.githubFeaturesEnabled &&
     input.hasPullRequest &&
     input.pullRequestState === "open" &&
@@ -512,17 +512,19 @@ function canMergePr(input: BuildGitActionsInput): boolean {
     !input.pullRequestIsMerged &&
     input.pullRequestMergeable !== "CONFLICTING" &&
     input.aheadCount > 0 &&
-    !input.hasUncommittedChanges &&
-    input.behindOfOrigin === 0 &&
-    input.aheadOfOrigin === 0 &&
-    !canMergeFromBase(input);
+    !input.hasUncommittedChanges;
 
-  if (!canMergeFromTopLevelStatus) {
+  if (!canMergeFromPullRequestStatus) {
     return false;
   }
 
   if (!hasPullRequestGithubFacts(github)) {
-    return input.pullRequestMergeable === "MERGEABLE";
+    return (
+      input.pullRequestMergeable === "MERGEABLE" &&
+      input.behindOfOrigin === 0 &&
+      input.aheadOfOrigin === 0 &&
+      !canMergeFromBase(input)
+    );
   }
 
   return (


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

PR merge actions now trust GitHub's mergeability facts instead of hiding behind local branch sync state. If GitHub reports an open PR as ready to merge, the app still offers direct merge actions even when the local checkout is behind origin or behind the base branch.

Legacy daemon payloads without GitHub merge facts keep the previous conservative local-sync checks.

### How did you verify it

- Added a regression test that reproduced the bug: GitHub reports `mergeStateStatus: "CLEAN"`, while the local branch is behind origin and behind base. Before the fix, direct merge actions were missing.
- `npm run test --workspace=@getpaseo/app -- src/git/policy.test.ts --bail=1`
- `npm run lint`
- `npm run typecheck --workspace=@getpaseo/app`
- `npm run format`
- Pre-commit hook also ran `npm run typecheck` across all workspaces successfully.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense