### PR TITLE
Add OMP (Oh-My-Pi) as a first-class importable provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### Added
+
+- **OMP (Oh-My-Pi) as a first-class importable provider** alongside Pi. OMP is a downstream fork of Pi (`@oh-my-pi/pi-coding-agent`) that ships its own binary (`omp`) and home directory (`~/.omp`) but preserves Pi's `--mode rpc` wire protocol and JSONL session schema. The Pi adapter is now parameterized over a `PiFamilyConfig` so both providers share session lifecycle, history mapping, tool-call translation, permission dialogs, and the RPC client.
+  - Surfaces as **OMP** in `paseo provider ls`, the in-app provider picker, and `paseo import --provider omp`
+  - OMP sessions started outside Paseo (in the terminal) are discovered by reading `~/.omp/agent/sessions/**/*.jsonl` (overridable via `$OMP_CODING_AGENT_DIR`, `$OMP_CODING_AGENT_SESSION_DIR`, or `settings.json:sessionDir`)
+  - Custom providers can `extends: "omp"` in `~/.paseo/config.json` for alternative OMP binaries or wrappers
+
 # Changelog
 
 ## 0.1.89 - 2026-06-02

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -14,7 +14,7 @@ The only built-in ACP provider today is `copilot` (`copilot-acp-agent.ts`). `Gen
 
 Implement the `AgentClient` and `AgentSession` interfaces from `agent-sdk-types.ts` yourself. This gives full control but requires you to handle process management, streaming, permissions, and session persistence from scratch.
 
-Existing direct providers: `claude` (in `providers/claude/agent.ts`), `codex` (`codex-app-server-agent.ts`), `opencode` (`opencode-agent.ts`), `pi` (`providers/pi/agent.ts`). The dev-only `mock` provider (`mock-load-test-agent.ts`) is also direct.
+Existing direct providers: `claude` (in `providers/claude/agent.ts`), `codex` (`codex-app-server-agent.ts`), `opencode` (`opencode-agent.ts`), `pi` (`providers/pi/agent.ts`), `omp` (`providers/omp/agent.ts`). The dev-only `mock` provider (`mock-load-test-agent.ts`) is also direct.
 
 Pi is a process-backed provider. Paseo requires the user to have the `pi` binary installed and talks to it through `pi --mode rpc`; the server package does not embed Pi's SDK/runtime packages.
 
@@ -25,6 +25,10 @@ Pi MCP support depends on the open-source `pi-mcp-adapter` extension being loade
 Pi import discovery reads Pi's persisted JSONL session files because Pi RPC does not expose a recent-session listing command. Resume and full history hydration still go through `pi --mode rpc` using the session file as `nativeHandle`.
 
 Pi RPC extension UI dialog requests (`select`, `input`, `editor`, `confirm`) are bridged into Paseo question permissions and answered with `extension_ui_response`. Pi extensions such as `ask_user` may chain dialogs: for example, a `select` can be followed by an optional-comment `input`. When an `ask_user` tool call declares `allowComment: true`, Paseo presents the selection and optional comment as one question permission, answers Pi's initial `select` immediately, then auto-answers the follow-up optional `input` with the comment the user already supplied (or an empty string). Preserve placeholders and optional/skip semantics for standalone optional inputs so the app can still distinguish "skip this optional input" from "cancel the whole dialog." Fire-and-forget extension UI requests such as notifications are intentionally ignored by the provider adapter unless Paseo grows first-class UI for them.
+
+OMP (Oh-My-Pi, https://github.com/oh-my-pi/pi-coding-agent) is a downstream fork of Pi that ships its own binary (`omp`) and home directory (`~/.omp`). Because OMP preserves Pi's `--mode rpc` protocol and JSONL session schema byte-for-byte, the `omp` provider reuses the Pi adapter via a `PiFamilyConfig` parameter declared in `providers/pi/family-config.ts` (`PI_FAMILY` and `OMP_FAMILY`). `OmpRpcAgentClient` in `providers/omp/agent.ts` is a thin subclass of `PiRpcAgentClient` that injects `OMP_FAMILY`. Both providers share session lifecycle, history mapping, tool-call translation, MCP adapter detection, and the RPC client; only the binary name, home dir, env-var prefix (`OMP_CODING_AGENT_*` instead of `PI_CODING_AGENT_*`), and display label differ.
+
+OMP import discovery reads OMP's persisted JSONL session files via `providers/omp/session-descriptor.ts` (resolving `OMP_CODING_AGENT_DIR`, `OMP_CODING_AGENT_SESSION_DIR`, `~/.omp/agent/settings.json:sessionDir`, `<cwd>/.omp/settings.json:sessionDir`, then defaulting to `~/.omp/agent/sessions/`). Pi's runtime-side capture (`paseo_capture_entries` extension) is the canonical Pi import path; offline JSONL parsing for Pi was removed in #1154.
 
 OpenCode MCP injection is dynamic and session-scoped. Call OpenCode's `mcp.add` endpoint with the MCP server config and do not follow it with `mcp.connect`; `connect` only toggles MCP servers already present in OpenCode's own config. New OpenCode versions return `McpServerNotFoundError`/404 for `connect` after a dynamic add because the server is not config-backed, while older versions silently swallowed the same missing-config path.
 

--- a/packages/cli/src/commands/agent/import.ts
+++ b/packages/cli/src/commands/agent/import.ts
@@ -5,7 +5,7 @@ import type { CommandError, CommandOptions, SingleResult } from "../../output/in
 import { agentRunSchema, type AgentRunResult } from "./run.js";
 import type { AgentSnapshotPayload } from "@getpaseo/protocol/messages";
 
-const IMPORT_PROVIDER_LIST = ["claude", "codex", "opencode", "pi", "acp"] as const;
+const IMPORT_PROVIDER_LIST = ["claude", "codex", "opencode", "pi", "omp", "acp"] as const;
 const IMPORT_PROVIDERS = new Set<string>(IMPORT_PROVIDER_LIST);
 const IMPORT_PROVIDER_HELP = IMPORT_PROVIDER_LIST.join(", ");
 

--- a/packages/protocol/src/importable-providers.ts
+++ b/packages/protocol/src/importable-providers.ts
@@ -3,4 +3,4 @@
  * providers (gemini, copilot, generic acp) are excluded because they either
  * don't expose persisted history quickly or duplicate other providers.
  */
-export const IMPORTABLE_PROVIDERS = ["claude", "codex", "opencode", "pi"] as const;
+export const IMPORTABLE_PROVIDERS = ["claude", "codex", "opencode", "pi", "omp"] as const;

--- a/packages/protocol/src/provider-config.ts
+++ b/packages/protocol/src/provider-config.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { AgentProvider } from "./agent-types.js";
-import { AgentProviderSchema } from "./provider-manifest.js";
+import { AgentProviderSchema, BUILTIN_PROVIDER_IDS } from "./provider-manifest.js";
 
 const ProviderCommandDefaultSchema = z.object({
   mode: z.literal("default"),
@@ -56,7 +56,8 @@ export const ProviderOverrideSchema = z.object({
   order: z.number().optional(),
 });
 
-const BUILTIN_PROVIDER_IDS = ["claude", "codex", "copilot", "opencode", "pi"] as const;
+// BUILTIN_PROVIDER_IDS is imported from provider-manifest (single source of truth,
+// derived from AGENT_PROVIDER_DEFINITIONS) so new builtin providers stay in sync.
 const PROVIDER_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
 
 export const ProviderOverridesSchema = z

--- a/packages/protocol/src/provider-manifest.ts
+++ b/packages/protocol/src/provider-manifest.ts
@@ -211,6 +211,13 @@ export const AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [
     defaultModeId: null,
     modes: [],
   },
+  {
+    id: "omp",
+    label: "OMP",
+    description: "Oh-My-Pi: Pi fork with extended plugin ecosystem (~/.omp)",
+    defaultModeId: null,
+    modes: [],
+  },
 ];
 
 export const DEV_AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -36,6 +36,7 @@ import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
 import { PiRpcAgentClient } from "./providers/pi/agent.js";
+import { OmpRpcAgentClient } from "./providers/omp/agent.js";
 import { MockLoadTestAgentClient } from "./providers/mock-load-test-agent.js";
 import { MockSlowProviderClient } from "./providers/mock-slow-provider.js";
 import {
@@ -131,6 +132,11 @@ const PROVIDER_CLIENT_FACTORIES: Record<string, ProviderClientFactory> = {
   opencode: (logger, runtimeSettings) => new OpenCodeAgentClient(logger, runtimeSettings),
   pi: (logger, runtimeSettings) =>
     new PiRpcAgentClient({
+      logger,
+      runtimeSettings,
+    }),
+  omp: (logger, runtimeSettings) =>
+    new OmpRpcAgentClient({
       logger,
       runtimeSettings,
     }),

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -1,0 +1,152 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { describe, expect, test } from "vitest";
+
+import type { AgentSessionConfig } from "../../agent-sdk-types.js";
+import { FakePi } from "../pi/test-utils/fake-pi.js";
+import type { PiRuntime } from "../pi/runtime.js";
+import { OmpRpcAgentClient } from "./agent.js";
+
+function createClientWithOmpAgentDir(agentDir: string): OmpRpcAgentClient {
+  return new OmpRpcAgentClient({
+    logger: pino({ level: "silent" }),
+    runtime: new FakePi(),
+    runtimeSettings: { env: { OMP_CODING_AGENT_DIR: agentDir } },
+  });
+}
+
+function createConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSessionConfig {
+  return {
+    provider: "omp",
+    cwd: "/tmp/paseo-omp-rpc-test",
+    ...overrides,
+  };
+}
+
+describe("OmpRpcAgentClient", () => {
+  test("identifies itself with the omp provider id", () => {
+    const client = new OmpRpcAgentClient({
+      logger: pino({ level: "silent" }),
+      runtime: new FakePi(),
+    });
+    expect(client.provider).toBe("omp");
+  });
+
+  test("creates a session that reports the omp provider", async () => {
+    const client = new OmpRpcAgentClient({
+      logger: pino({ level: "silent" }),
+      runtime: new FakePi(),
+    });
+
+    const session = await client.createSession(createConfig());
+    expect(session.provider).toBe("omp");
+    await session.close();
+  });
+
+  test("lists persisted OMP sessions from the configured OMP agent directory", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "paseo-omp-client-"));
+    const cwd = path.join(root, "workspace");
+    const agentDir = path.join(root, "agent");
+    const sessionsDir = path.join(agentDir, "sessions", "--workspace--");
+    mkdirSync(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "20260101_session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "omp-session",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          cwd,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "entry-1",
+          parentId: null,
+          timestamp: "2026-01-01T00:00:01.000Z",
+          message: { role: "user", content: "remember this" },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const client = createClientWithOmpAgentDir(agentDir);
+
+    await expect(client.listPersistedAgents({ cwd })).resolves.toMatchObject([
+      {
+        provider: "omp",
+        sessionId: "omp-session",
+        cwd,
+        persistence: {
+          provider: "omp",
+          sessionId: "omp-session",
+          nativeHandle: sessionFile,
+          metadata: { provider: "omp", cwd },
+        },
+        timeline: [{ type: "user_message", text: "remember this" }],
+      },
+    ]);
+  });
+
+  test("ignores PI_CODING_AGENT_DIR when running as the OMP provider", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "paseo-omp-isolation-"));
+    const cwd = path.join(root, "workspace");
+    const piAgentDir = path.join(root, "pi-agent");
+    const ompAgentDir = path.join(root, "omp-agent");
+    const piSessionsDir = path.join(piAgentDir, "sessions");
+    const ompSessionsDir = path.join(ompAgentDir, "sessions");
+    mkdirSync(piSessionsDir, { recursive: true });
+    mkdirSync(ompSessionsDir, { recursive: true });
+
+    const sessionRecord = (id: string) =>
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id,
+          timestamp: "2026-01-01T00:00:00.000Z",
+          cwd,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "entry-1",
+          parentId: null,
+          timestamp: "2026-01-01T00:00:01.000Z",
+          message: { role: "user", content: id },
+        }),
+      ].join("\n") + "\n";
+    writeFileSync(path.join(piSessionsDir, "pi.jsonl"), sessionRecord("pi-only"), "utf8");
+    writeFileSync(path.join(ompSessionsDir, "omp.jsonl"), sessionRecord("omp-only"), "utf8");
+
+    const client = new OmpRpcAgentClient({
+      logger: pino({ level: "silent" }),
+      runtime: new FakePi(),
+      runtimeSettings: {
+        env: {
+          PI_CODING_AGENT_DIR: piAgentDir,
+          OMP_CODING_AGENT_DIR: ompAgentDir,
+        },
+      },
+    });
+
+    const descriptors = await client.listPersistedAgents({ cwd });
+    expect(descriptors.map((d) => d.sessionId)).toEqual(["omp-only"]);
+  });
+
+  test("isAvailable resolves only the binary, without starting an RPC session", async () => {
+    const throwingRuntime = {
+      startSession() {
+        throw new Error("isAvailable must not start an RPC session");
+      },
+    } as unknown as PiRuntime;
+    const client = new OmpRpcAgentClient({
+      logger: pino({ level: "silent" }),
+      runtime: throwingRuntime,
+      runtimeSettings: { command: { mode: "replace", argv: [process.execPath] } },
+    });
+
+    await expect(client.isAvailable()).resolves.toBe(true);
+  });
+});

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -1,0 +1,70 @@
+import type { Logger } from "pino";
+
+import type {
+  ListPersistedAgentsOptions,
+  PersistedAgentDescriptor,
+} from "../../agent-sdk-types.js";
+import {
+  checkProviderLaunchAvailable,
+  resolveProviderLaunch,
+  type ProviderRuntimeSettings,
+} from "../../provider-launch-config.js";
+import { PiRpcAgentClient } from "../pi/agent.js";
+import { OMP_FAMILY, resolveFamilyBinaryName } from "../pi/family-config.js";
+import type { PiRuntime } from "../pi/runtime.js";
+
+import { listOmpPersistedAgents } from "./session-descriptor.js";
+
+/**
+ * OMP (Oh-My-Pi, https://github.com/oh-my-pi/pi-coding-agent) is a downstream
+ * fork of Pi that ships its own binary (`omp`), home directory (`~/.omp`), and
+ * plugin ecosystem. It preserves Pi's `--mode rpc` wire protocol and JSONL
+ * session schema verbatim, so the entire Pi adapter is reused — only family
+ * defaults differ.
+ *
+ * Unlike Pi (which uses Paseo-injected `paseo_capture_entries` extensions to
+ * track session identity at runtime), OMP sessions started outside Paseo —
+ * e.g. via `omp` invoked directly in the terminal — are discovered by reading
+ * the JSONL session files on disk. The `omp/session-descriptor.ts` module
+ * mirrors the historical Pi descriptor (removed upstream in #1154) but scoped
+ * to OMP paths.
+ */
+export interface OmpRpcAgentClientOptions {
+  logger: Logger;
+  runtimeSettings?: ProviderRuntimeSettings;
+  runtime?: PiRuntime;
+}
+
+export class OmpRpcAgentClient extends PiRpcAgentClient {
+  constructor(options: OmpRpcAgentClientOptions) {
+    super({ ...options, family: OMP_FAMILY });
+  }
+
+  /**
+   * Lightweight availability probe matching the `claude`, `codex`, and
+   * `opencode` providers: a present, launchable `omp` binary is treated as
+   * available. The Pi base class additionally starts an RPC session and calls
+   * `getAvailableModels()`, but OMP eagerly connects every configured MCP
+   * server (`~/.omp/agent/mcp.json`) on `omp --mode rpc` startup, so that probe
+   * routinely exceeds the daemon's availability budget under multi-provider
+   * contention. Model/MCP loading is deferred to real sessions, so capability
+   * is unaffected.
+   */
+  override async isAvailable(): Promise<boolean> {
+    const launch = await resolveProviderLaunch({
+      commandConfig: this.runtimeSettings?.command,
+      defaultBinary: resolveFamilyBinaryName(OMP_FAMILY),
+    });
+    const availability = await checkProviderLaunchAvailable(launch);
+    return availability.available;
+  }
+
+  override async listPersistedAgents(
+    options?: ListPersistedAgentsOptions,
+  ): Promise<PersistedAgentDescriptor[]> {
+    return await listOmpPersistedAgents({
+      ...options,
+      runtimeSettings: this.runtimeSettings,
+    });
+  }
+}

--- a/packages/server/src/server/agent/providers/omp/session-descriptor.test.ts
+++ b/packages/server/src/server/agent/providers/omp/session-descriptor.test.ts
@@ -1,0 +1,342 @@
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { listOmpPersistedAgents } from "./session-descriptor.js";
+
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+
+function tempRoot(): string {
+  return mkdtempSync(path.join(tmpdir(), "paseo-omp-sessions-"));
+}
+
+function writeJsonl(filePath: string, entries: unknown[]): string {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, "utf8");
+  return filePath;
+}
+
+function ompSession(overrides: {
+  id: string;
+  cwd: string;
+  timestamp?: string;
+  entries?: unknown[];
+}): unknown[] {
+  return [
+    {
+      type: "session",
+      version: 3,
+      id: overrides.id,
+      timestamp: overrides.timestamp ?? "2026-01-01T00:00:00.000Z",
+      cwd: overrides.cwd,
+    },
+    ...(overrides.entries ?? []),
+  ];
+}
+
+function message(input: {
+  role: "user" | "assistant";
+  content: unknown;
+  timestamp: string;
+}): unknown {
+  return {
+    type: "message",
+    id: `entry-${input.timestamp}`,
+    parentId: null,
+    timestamp: input.timestamp,
+    message: {
+      role: input.role,
+      content: input.content,
+    },
+  };
+}
+
+function sessionInfo(name: string, timestamp: string): unknown {
+  return {
+    type: "session_info",
+    id: `info-${timestamp}`,
+    parentId: null,
+    timestamp,
+    name,
+  };
+}
+
+describe("listOmpPersistedAgents", () => {
+  test("lists OMP sessions from the configured agent dir and stamps provider=omp", async () => {
+    const root = tempRoot();
+    const cwd = path.join(root, "project");
+    const sessionsDir = path.join(root, "agent", "sessions", "--project--");
+    const sessionFile = writeJsonl(
+      path.join(sessionsDir, "20260101_session-a.jsonl"),
+      ompSession({
+        id: "session-a",
+        cwd,
+        entries: [
+          message({
+            role: "user",
+            content: "first prompt",
+            timestamp: "2026-01-01T00:00:01.000Z",
+          }),
+          message({
+            role: "assistant",
+            content: [{ type: "text", text: "answer" }],
+            timestamp: "2026-01-01T00:00:02.000Z",
+          }),
+          message({
+            role: "user",
+            content: [{ type: "text", text: "last prompt" }],
+            timestamp: "2026-01-01T00:00:03.000Z",
+          }),
+          sessionInfo("Named OMP Session", "2026-01-01T00:00:10.000Z"),
+        ],
+      }),
+    );
+
+    const descriptors = await listOmpPersistedAgents({
+      cwd,
+      env: { OMP_CODING_AGENT_DIR: path.join(root, "agent") },
+      homeDir: root,
+    });
+
+    expect(descriptors).toEqual([
+      {
+        provider: "omp",
+        sessionId: "session-a",
+        cwd,
+        title: "Named OMP Session",
+        lastActivityAt: new Date("2026-01-01T00:00:03.000Z"),
+        persistence: {
+          provider: "omp",
+          sessionId: "session-a",
+          nativeHandle: sessionFile,
+          metadata: {
+            provider: "omp",
+            cwd,
+          },
+        },
+        timeline: [
+          { type: "user_message", text: "first prompt" },
+          { type: "user_message", text: "last prompt" },
+        ],
+      },
+    ]);
+  });
+
+  test("falls back to ~/.omp/agent/sessions when no env or settings override is present", async () => {
+    const root = tempRoot();
+    const cwd = path.join(root, "project");
+    const sessionsDir = path.join(root, ".omp", "agent", "sessions");
+    writeJsonl(
+      path.join(sessionsDir, "default.jsonl"),
+      ompSession({
+        id: "default-session",
+        cwd,
+        entries: [
+          message({
+            role: "user",
+            content: "default path",
+            timestamp: "2026-01-01T00:00:01.000Z",
+          }),
+        ],
+      }),
+    );
+
+    const descriptors = await listOmpPersistedAgents({
+      cwd,
+      env: {},
+      homeDir: root,
+    });
+
+    expect(descriptors.map((descriptor) => descriptor.sessionId)).toEqual(["default-session"]);
+  });
+
+  test("uses the runtime OMP_CODING_AGENT_SESSION_DIR override before settings", async () => {
+    const root = tempRoot();
+    const cwd = path.join(root, "project");
+    const agentDir = path.join(root, "agent");
+    const runtimeSessionsDir = path.join(root, "runtime-sessions");
+    const settingsSessionsDir = path.join(root, "settings-sessions");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      path.join(agentDir, "settings.json"),
+      JSON.stringify({ sessionDir: settingsSessionsDir }),
+      "utf8",
+    );
+    writeJsonl(
+      path.join(settingsSessionsDir, "ignored.jsonl"),
+      ompSession({ id: "settings-session", cwd }),
+    );
+    writeJsonl(
+      path.join(runtimeSessionsDir, "selected.jsonl"),
+      ompSession({
+        id: "runtime-session",
+        cwd,
+        entries: [
+          message({
+            role: "user",
+            content: "from runtime dir",
+            timestamp: "2026-01-01T00:00:01.000Z",
+          }),
+        ],
+      }),
+    );
+
+    const descriptors = await listOmpPersistedAgents({
+      cwd,
+      runtimeSettings: {
+        env: {
+          OMP_CODING_AGENT_DIR: agentDir,
+          OMP_CODING_AGENT_SESSION_DIR: runtimeSessionsDir,
+        },
+      },
+      env: {},
+      homeDir: root,
+    });
+
+    expect(descriptors.map((descriptor) => descriptor.sessionId)).toEqual(["runtime-session"]);
+  });
+
+  test("resolves project settings sessionDir relative to the requested cwd", async () => {
+    const root = tempRoot();
+    const cwd = path.join(root, "project");
+    const projectSettingsDir = path.join(cwd, ".omp");
+    const sessionsDir = path.join(cwd, "relative-sessions");
+    mkdirSync(projectSettingsDir, { recursive: true });
+    writeFileSync(
+      path.join(projectSettingsDir, "settings.json"),
+      JSON.stringify({ sessionDir: "relative-sessions" }),
+      "utf8",
+    );
+    writeJsonl(
+      path.join(sessionsDir, "relative.jsonl"),
+      ompSession({
+        id: "relative-session",
+        cwd,
+        entries: [
+          message({
+            role: "user",
+            content: "relative settings",
+            timestamp: "2026-01-01T00:00:01.000Z",
+          }),
+        ],
+      }),
+    );
+
+    const descriptors = await listOmpPersistedAgents({
+      cwd,
+      env: { OMP_CODING_AGENT_DIR: path.join(root, "agent") },
+      homeDir: root,
+    });
+
+    expect(descriptors.map((descriptor) => descriptor.sessionId)).toEqual(["relative-session"]);
+  });
+
+  test("matches sessions stored with the real cwd when the requested cwd is symlinked", async () => {
+    const root = tempRoot();
+    const realCwd = path.join(root, "real-project");
+    const linkedCwd = path.join(root, "linked-project");
+    mkdirSync(realCwd, { recursive: true });
+    symlinkSync(realCwd, linkedCwd, directorySymlinkType);
+    const persistedCwd = realpathSync(linkedCwd);
+    const sessionsDir = path.join(root, "agent", "sessions");
+    writeJsonl(
+      path.join(sessionsDir, "symlinked.jsonl"),
+      ompSession({
+        id: "symlinked-session",
+        cwd: persistedCwd,
+        entries: [
+          message({
+            role: "user",
+            content: "through symlink",
+            timestamp: "2026-01-01T00:00:01.000Z",
+          }),
+        ],
+      }),
+    );
+
+    const descriptors = await listOmpPersistedAgents({
+      cwd: linkedCwd,
+      env: { OMP_CODING_AGENT_DIR: path.join(root, "agent") },
+      homeDir: root,
+    });
+
+    expect(descriptors.map((descriptor) => descriptor.sessionId)).toEqual(["symlinked-session"]);
+  });
+
+  test("filters by cwd, sorts by activity, and ignores invalid session files", async () => {
+    const root = tempRoot();
+    const cwd = path.join(root, "project");
+    const otherCwd = path.join(root, "other");
+    const sessionsDir = path.join(root, "agent", "sessions");
+    writeJsonl(
+      path.join(sessionsDir, "older.jsonl"),
+      ompSession({
+        id: "older",
+        cwd,
+        entries: [
+          message({
+            role: "user",
+            content: "older",
+            timestamp: "2026-01-01T00:00:01.000Z",
+          }),
+        ],
+      }),
+    );
+    writeJsonl(
+      path.join(sessionsDir, "newer.jsonl"),
+      ompSession({
+        id: "newer",
+        cwd,
+        entries: [
+          message({
+            role: "user",
+            content: "newer",
+            timestamp: "2026-01-01T00:00:02.000Z",
+          }),
+        ],
+      }),
+    );
+    writeJsonl(
+      path.join(sessionsDir, "outside.jsonl"),
+      ompSession({
+        id: "outside",
+        cwd: otherCwd,
+        entries: [
+          message({
+            role: "user",
+            content: "outside",
+            timestamp: "2026-01-01T00:00:03.000Z",
+          }),
+        ],
+      }),
+    );
+    writeFileSync(path.join(sessionsDir, "broken.jsonl"), '{"type":"nope"}\n', "utf8");
+
+    const descriptors = await listOmpPersistedAgents({
+      cwd,
+      limit: 1,
+      env: { OMP_CODING_AGENT_DIR: path.join(root, "agent") },
+      homeDir: root,
+    });
+
+    expect(descriptors.map((descriptor) => descriptor.sessionId)).toEqual(["newer"]);
+  });
+
+  test("only sees OMP sessions when both ~/.pi and ~/.omp exist", async () => {
+    const root = tempRoot();
+    const cwd = path.join(root, "project");
+    const piSessionsDir = path.join(root, ".pi", "agent", "sessions");
+    const ompSessionsDir = path.join(root, ".omp", "agent", "sessions");
+    writeJsonl(path.join(piSessionsDir, "pi-only.jsonl"), ompSession({ id: "pi-only", cwd }));
+    writeJsonl(path.join(ompSessionsDir, "omp-only.jsonl"), ompSession({ id: "omp-only", cwd }));
+
+    const ompDescriptors = await listOmpPersistedAgents({
+      cwd,
+      env: {},
+      homeDir: root,
+    });
+    expect(ompDescriptors.map((d) => d.sessionId)).toEqual(["omp-only"]);
+    expect(ompDescriptors[0].provider).toBe("omp");
+  });
+});

--- a/packages/server/src/server/agent/providers/omp/session-descriptor.ts
+++ b/packages/server/src/server/agent/providers/omp/session-descriptor.ts
@@ -1,0 +1,400 @@
+import { open, readdir, readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type {
+  AgentPersistenceHandle,
+  AgentTimelineItem,
+  ListPersistedAgentsOptions,
+  PersistedAgentDescriptor,
+} from "../../agent-sdk-types.js";
+import type { ProviderRuntimeSettings } from "../../provider-launch-config.js";
+import { OMP_FAMILY, type PiFamilyConfig } from "../pi/family-config.js";
+import { createRealpathAwarePathMatcher } from "../../../../utils/path.js";
+
+/**
+ * Offline OMP session discovery.
+ *
+ * Mirrors the historical Pi session-descriptor (removed upstream in #1154 in
+ * favor of runtime extension-based capture) but scoped to the OMP family.
+ * OMP plugins running outside Paseo still write JSONL session files with the
+ * same `{type:"session",version:3,id,cwd,...}` header as Pi, so the offline
+ * discovery pattern remains the right fit.
+ *
+ * The function is parameterized over PiFamilyConfig so future Pi-family
+ * forks can reuse it.
+ */
+
+const HEAD_BYTES = 64 * 1024;
+const TAIL_BYTES = 256 * 1024;
+const FULL_SCAN_LINE_LIMIT = 2_000;
+
+interface OmpSessionDescriptorOptions extends ListPersistedAgentsOptions {
+  runtimeSettings?: ProviderRuntimeSettings;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  family?: PiFamilyConfig;
+}
+
+interface OmpSessionHeader {
+  sessionId: string;
+  cwd: string;
+  createdAt: Date | null;
+}
+
+interface OmpSessionTail {
+  title: string | null;
+  lastActivityAt: Date | null;
+  lastUserMessage: string | null;
+}
+
+export async function listOmpPersistedAgents(
+  options: OmpSessionDescriptorOptions = {},
+): Promise<PersistedAgentDescriptor[]> {
+  const family = options.family ?? OMP_FAMILY;
+  const sessionsDir = await resolveSessionsDir(family, options);
+  const files = await walkJsonlFiles(sessionsDir);
+  const matchesCwd = options.cwd ? createRealpathAwarePathMatcher(options.cwd) : null;
+  const limit = options.limit ?? 20;
+  const descriptors: PersistedAgentDescriptor[] = [];
+
+  for (const file of files) {
+    const descriptor = await readSessionDescriptor(file, family);
+    if (!descriptor) continue;
+    if (matchesCwd && !matchesCwd(descriptor.cwd)) continue;
+    descriptors.push(descriptor);
+  }
+
+  return descriptors
+    .sort((left, right) => right.lastActivityAt.getTime() - left.lastActivityAt.getTime())
+    .slice(0, limit);
+}
+
+async function resolveSessionsDir(
+  family: PiFamilyConfig,
+  options: OmpSessionDescriptorOptions,
+): Promise<string> {
+  const env = options.env ?? process.env;
+  const homeDir = options.homeDir ?? homedir();
+  const baseDir = options.cwd ?? process.cwd();
+  const agentDir = resolveAgentDir(family, {
+    runtimeSettings: options.runtimeSettings,
+    env,
+    homeDir,
+  });
+
+  const envSessionDir =
+    options.runtimeSettings?.env?.[family.sessionDirEnv] ?? env[family.sessionDirEnv];
+  if (envSessionDir?.trim()) {
+    return resolveConfigPath(envSessionDir, { baseDir, homeDir });
+  }
+
+  const settingsSessionDir = await readConfiguredSessionDir({
+    agentDir,
+    cwd: options.cwd,
+    family,
+  });
+  if (settingsSessionDir?.trim()) {
+    return resolveConfigPath(settingsSessionDir, { baseDir, homeDir });
+  }
+
+  return path.join(agentDir, "sessions");
+}
+
+function resolveAgentDir(
+  family: PiFamilyConfig,
+  input: {
+    runtimeSettings?: ProviderRuntimeSettings;
+    env: NodeJS.ProcessEnv;
+    homeDir: string;
+  },
+): string {
+  const configured =
+    input.runtimeSettings?.env?.[family.agentDirEnv] ?? input.env[family.agentDirEnv];
+  if (configured?.trim()) {
+    return resolveConfigPath(configured, { baseDir: process.cwd(), homeDir: input.homeDir });
+  }
+  return path.join(input.homeDir, family.homeDirName, "agent");
+}
+
+async function readConfiguredSessionDir(input: {
+  agentDir: string;
+  cwd: string | undefined;
+  family: PiFamilyConfig;
+}): Promise<string | null> {
+  const values = await Promise.all([
+    readSessionDirFromSettings(path.join(input.agentDir, "settings.json")),
+    input.cwd
+      ? readSessionDirFromSettings(path.join(input.cwd, input.family.homeDirName, "settings.json"))
+      : null,
+  ]);
+  return values[1] ?? values[0] ?? null;
+}
+
+async function readSessionDirFromSettings(settingsPath: string): Promise<string | null> {
+  try {
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    const sessionDir = Reflect.get(parsed, "sessionDir");
+    return typeof sessionDir === "string" && sessionDir.trim() ? sessionDir : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveConfigPath(value: string, options: { baseDir: string; homeDir: string }): string {
+  if (value === "~") {
+    return options.homeDir;
+  }
+  if (value.startsWith("~/")) {
+    return path.join(options.homeDir, value.slice(2));
+  }
+  return path.isAbsolute(value) ? value : path.resolve(options.baseDir, value);
+}
+
+async function walkJsonlFiles(root: string): Promise<string[]> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(root, entry.name);
+      if (entry.isDirectory()) {
+        return await walkJsonlFiles(entryPath);
+      }
+      return entry.isFile() && entry.name.endsWith(".jsonl") ? [entryPath] : [];
+    }),
+  );
+  return files.flat();
+}
+
+async function readSessionDescriptor(
+  filePath: string,
+  family: PiFamilyConfig,
+): Promise<PersistedAgentDescriptor | null> {
+  const firstLine = await readFirstLine(filePath);
+  if (!firstLine) return null;
+  const header = parseSessionHeader(firstLine);
+  if (!header) return null;
+
+  const tail = await readTail(filePath).catch(() => "");
+  const tailInfo = parseSessionTail(tail);
+  const headInfo = await scanSessionHead(filePath);
+  const title = tailInfo.title ?? headInfo.title ?? headInfo.firstUserMessage;
+  const lastActivityAt =
+    tailInfo.lastActivityAt ?? (await readFileMtime(filePath)) ?? header.createdAt ?? new Date(0);
+  const timeline = buildPreviewTimeline({
+    firstUserMessage: headInfo.firstUserMessage,
+    lastUserMessage: tailInfo.lastUserMessage,
+  });
+
+  const persistence: AgentPersistenceHandle = {
+    provider: family.providerId,
+    sessionId: header.sessionId,
+    nativeHandle: filePath,
+    metadata: {
+      provider: family.providerId,
+      cwd: header.cwd,
+    },
+  };
+
+  return {
+    provider: family.providerId,
+    sessionId: header.sessionId,
+    cwd: header.cwd,
+    title,
+    lastActivityAt,
+    persistence,
+    timeline,
+  };
+}
+
+async function readFirstLine(filePath: string): Promise<string | null> {
+  const handle = await open(filePath, "r").catch(() => null);
+  if (!handle) return null;
+  try {
+    const buffer = Buffer.alloc(HEAD_BYTES);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead <= 0) return null;
+    const chunk = buffer.subarray(0, bytesRead).toString("utf8");
+    const newlineIndex = chunk.indexOf("\n");
+    return (newlineIndex === -1 ? chunk : chunk.slice(0, newlineIndex)).trim();
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
+async function readTail(filePath: string): Promise<string> {
+  const fileStats = await stat(filePath);
+  const start = Math.max(0, fileStats.size - TAIL_BYTES);
+  const length = fileStats.size - start;
+  const handle = await open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, start);
+    return buffer.subarray(0, bytesRead).toString("utf8");
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
+async function readFileMtime(filePath: string): Promise<Date | null> {
+  try {
+    return (await stat(filePath)).mtime;
+  } catch {
+    return null;
+  }
+}
+
+function parseSessionHeader(firstLine: string): OmpSessionHeader | null {
+  const entry = parseJsonRecord(firstLine);
+  if (!entry || entry.type !== "session") return null;
+  const sessionId = typeof entry.id === "string" ? entry.id : null;
+  const cwd = typeof entry.cwd === "string" ? entry.cwd : null;
+  if (!sessionId || !cwd) return null;
+  const createdAt = parseDate(entry.timestamp);
+  return { sessionId, cwd, createdAt };
+}
+
+function parseSessionTail(tail: string): OmpSessionTail {
+  const lines = tail.split(/\r?\n/);
+  let title: string | null = null;
+  let lastActivityAt: Date | null = null;
+  let fallbackTimestamp: Date | null = null;
+  let lastUserMessage: string | null = null;
+
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const entry = parseJsonRecord(lines[index].trim());
+    if (!entry) continue;
+
+    if (!title && entry.type === "session_info") {
+      title = readNonEmptyString(entry.name);
+    }
+
+    const entryTimestamp = parseDate(entry.timestamp);
+    if (!fallbackTimestamp && entryTimestamp) {
+      fallbackTimestamp = entryTimestamp;
+    }
+
+    if (entry.type !== "message") {
+      continue;
+    }
+
+    if (!lastActivityAt && entryTimestamp) {
+      lastActivityAt = entryTimestamp;
+    }
+
+    if (!lastUserMessage && isRecord(entry.message) && entry.message.role === "user") {
+      lastUserMessage = extractMessageText(entry.message.content);
+    }
+
+    if (title && lastActivityAt && lastUserMessage) {
+      break;
+    }
+  }
+
+  return { title, lastActivityAt: lastActivityAt ?? fallbackTimestamp, lastUserMessage };
+}
+
+async function scanSessionHead(filePath: string): Promise<{
+  title: string | null;
+  firstUserMessage: string | null;
+}> {
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch {
+    return { title: null, firstUserMessage: null };
+  }
+
+  let title: string | null = null;
+  let firstUserMessage: string | null = null;
+  let lineCount = 0;
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    lineCount += 1;
+    const entry = parseJsonRecord(rawLine.trim());
+    if (!entry) continue;
+
+    if (entry.type === "session_info") {
+      title = readNonEmptyString(entry.name) ?? title;
+    }
+
+    if (!firstUserMessage && entry.type === "message" && isRecord(entry.message)) {
+      if (entry.message.role === "user") {
+        firstUserMessage = extractMessageText(entry.message.content);
+      }
+    }
+
+    if (title && firstUserMessage) {
+      break;
+    }
+    if (lineCount >= FULL_SCAN_LINE_LIMIT && firstUserMessage) {
+      break;
+    }
+  }
+
+  return { title, firstUserMessage };
+}
+
+function buildPreviewTimeline(input: {
+  firstUserMessage: string | null;
+  lastUserMessage: string | null;
+}): AgentTimelineItem[] {
+  const items: AgentTimelineItem[] = [];
+  if (input.firstUserMessage) {
+    items.push({ type: "user_message", text: input.firstUserMessage });
+  }
+  if (input.lastUserMessage && input.lastUserMessage !== input.firstUserMessage) {
+    items.push({ type: "user_message", text: input.lastUserMessage });
+  }
+  return items;
+}
+
+function parseJsonRecord(line: string): Record<string, unknown> | null {
+  if (!line) return null;
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function parseDate(value: unknown): Date | null {
+  if (typeof value !== "string" && typeof value !== "number") {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function extractMessageText(content: unknown): string | null {
+  if (typeof content === "string") {
+    return content.trim() || null;
+  }
+  if (!Array.isArray(content)) {
+    return null;
+  }
+  const text = content
+    .flatMap((part) =>
+      isRecord(part) && part.type === "text" && typeof part.text === "string" ? [part.text] : [],
+    )
+    .join("\n\n")
+    .trim();
+  return text || null;
+}

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -845,4 +845,26 @@ describe("transformPiModels", () => {
       },
     ]);
   });
+
+  test("keeps the provider prefix when keepProviderInLabel is set (OMP)", () => {
+    expect(
+      transformPiModels(
+        [
+          {
+            provider: "omp",
+            id: "openrouter/google/gemini-2.5-flash-lite",
+            label: "openrouter/google/gemini_2.5 flash lite",
+          },
+        ],
+        { keepProviderInLabel: true },
+      ),
+    ).toEqual([
+      {
+        provider: "omp",
+        id: "openrouter/google/gemini-2.5-flash-lite",
+        label: "openrouter/google/gemini 2.5 flash lite",
+        description: "openrouter/google/gemini_2.5 flash lite",
+      },
+    ]);
+  });
 });

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -52,6 +52,7 @@ import {
 } from "./history-mapper.js";
 import { PiCliRuntime } from "./cli-runtime.js";
 import { revertPiConversation } from "./rewind.js";
+import { PI_FAMILY, type PiFamilyConfig, resolveFamilyBinaryName } from "./family-config.js";
 import type { PiRuntime, PiRuntimeSession } from "./runtime.js";
 import type {
   PiAgentSessionEvent,
@@ -73,9 +74,7 @@ import {
   type PiTrackedToolCall,
 } from "./tool-call-mapper.js";
 
-const PI_PROVIDER = "pi";
 const DEFAULT_PI_THINKING_LEVEL: PiThinkingLevel = "medium";
-const PI_BINARY_COMMAND = process.env.PI_COMMAND ?? process.env.PI_ACP_PI_COMMAND ?? "pi";
 const PASEO_PI_TREE_EXTENSION_COMMAND = "paseo_tree";
 const PASEO_PI_CAPTURE_EXTENSION_COMMAND = "paseo_capture_entries";
 const PASEO_PI_ENTRY_CAPTURE_MARKER = "PASEO_ENTRY_CAPTURE";
@@ -116,6 +115,7 @@ interface PiRpcAgentClientOptions {
   logger: Logger;
   runtimeSettings?: ProviderRuntimeSettings;
   runtime?: PiRuntime;
+  family?: PiFamilyConfig;
 }
 
 interface PiPromptPayload {
@@ -145,6 +145,7 @@ interface PiRpcAgentSessionOptions {
   initialState: PiSessionState;
   capabilities: AgentCapabilityFlags;
   cleanup?: () => void;
+  family: PiFamilyConfig;
 }
 
 interface PiResumeConfig {
@@ -209,7 +210,10 @@ function normalizePiModelLabel(label: string): string {
   return label.trim().replace(/[_\s]+/g, " ");
 }
 
-export function transformPiModels(models: AgentModelDefinition[]): AgentModelDefinition[] {
+export function transformPiModels(
+  models: AgentModelDefinition[],
+  options: { keepProviderInLabel?: boolean } = {},
+): AgentModelDefinition[] {
   return models.map((model) => {
     if (!model.label.includes("/")) {
       return model;
@@ -221,9 +225,16 @@ export function transformPiModels(models: AgentModelDefinition[]): AgentModelDef
       return model;
     }
 
+    // OMP exposes the same model name across many upstream providers; keep the
+    // provider prefix so the picker can distinguish e.g. anthropic vs
+    // github-copilot vs openrouter variants of the same model.
+    const nextLabel = options.keepProviderInLabel
+      ? normalizePiModelLabel(model.label)
+      : normalizePiModelLabel(rawLabel);
+
     return {
       ...model,
-      label: normalizePiModelLabel(rawLabel),
+      label: nextLabel,
       description: model.description ?? model.label,
     };
   });
@@ -364,6 +375,7 @@ function parsePersistenceMetadata(metadata: AgentMetadata | undefined): PiPersis
 function buildResumeConfig(
   metadata: PiPersistenceMetadata,
   overrides: Partial<AgentSessionConfig> | undefined,
+  family: PiFamilyConfig,
 ): PiResumeConfig {
   const overrideConfig = overrides ?? {};
   const cwd = overrideConfig.cwd ?? metadata.cwd ?? process.cwd();
@@ -375,7 +387,7 @@ function buildResumeConfig(
     thinkingOptionId,
     config: {
       ...overrideConfig,
-      provider: PI_PROVIDER,
+      provider: family.providerId,
       cwd,
       model,
       thinkingOptionId,
@@ -518,14 +530,14 @@ function combineCleanup(cleanups: Array<(() => void) | undefined>): (() => void)
   };
 }
 
-function isPiMcpAdapterCommand(command: PiRpcSlashCommand): boolean {
+function isPiMcpAdapterCommand(command: PiRpcSlashCommand, family: PiFamilyConfig): boolean {
   if (command.source !== "extension" || !/^mcp(?::\d+)?$/.test(command.name)) {
     return false;
   }
   if (!command.sourceInfo) {
     return true;
   }
-  return JSON.stringify(command.sourceInfo).includes("pi-mcp-adapter");
+  return JSON.stringify(command.sourceInfo).includes(family.mcpAdapterMarker);
 }
 
 function withPiMcpCapability(supportsMcpServers: boolean): AgentCapabilityFlags {
@@ -683,19 +695,20 @@ function isPiAskUserFreeformOption(option: string): boolean {
 
 function mapExtensionUiRequestToPermission(
   event: Extract<PiRuntimeEvent, { type: "extension_ui_request" }>,
+  family: PiFamilyConfig,
   options: ExtensionUiMappingOptions = {},
 ): AgentPermissionRequest | null {
   switch (event.method) {
     case "select": {
       const selectOptions = readStringArray(event.options);
       if (options.combineOptionalComment) {
-        return buildCombinedAskUserQuestionPermission(event, {
+        return buildCombinedAskUserQuestionPermission(event, family, {
           question: optionalString(event.title) ?? "Select an option",
           options: selectOptions,
           allowFreeform: options.allowFreeform === true,
         });
       }
-      return buildExtensionUiQuestionPermission(event, {
+      return buildExtensionUiQuestionPermission(event, family, {
         question: optionalString(event.title) ?? "Select an option",
         options: selectOptions,
         multiSelect: false,
@@ -705,7 +718,7 @@ function mapExtensionUiRequestToPermission(
       const placeholder = optionalString(event.placeholder);
       const title = optionalString(event.title);
       const allowEmpty = isOptionalInputPlaceholder(placeholder);
-      return buildExtensionUiQuestionPermission(event, {
+      return buildExtensionUiQuestionPermission(event, family, {
         question: getInputQuestionTitle(title, placeholder),
         options: [],
         multiSelect: false,
@@ -714,13 +727,13 @@ function mapExtensionUiRequestToPermission(
       });
     }
     case "editor":
-      return buildExtensionUiQuestionPermission(event, {
+      return buildExtensionUiQuestionPermission(event, family, {
         question: optionalString(event.title) ?? "Edit text",
         options: [],
         multiSelect: false,
       });
     case "confirm":
-      return buildExtensionUiQuestionPermission(event, {
+      return buildExtensionUiQuestionPermission(event, family, {
         question: [optionalString(event.title), optionalString(event.message)]
           .filter(Boolean)
           .join("\n\n"),
@@ -734,6 +747,7 @@ function mapExtensionUiRequestToPermission(
 
 function buildExtensionUiQuestionPermission(
   event: Extract<PiRuntimeEvent, { type: "extension_ui_request" }>,
+  family: PiFamilyConfig,
   input: {
     question: string;
     options: string[];
@@ -745,8 +759,8 @@ function buildExtensionUiQuestionPermission(
 ): AgentPermissionRequest {
   return {
     id: event.id,
-    provider: PI_PROVIDER,
-    name: `Pi ${event.method}`,
+    provider: family.providerId,
+    name: `${family.displayLabel} ${event.method}`,
     kind: "question",
     title: input.question,
     input: {
@@ -771,6 +785,7 @@ function buildExtensionUiQuestionPermission(
 
 function buildCombinedAskUserQuestionPermission(
   event: Extract<PiRuntimeEvent, { type: "extension_ui_request" }>,
+  family: PiFamilyConfig,
   input: {
     question: string;
     options: string[];
@@ -781,8 +796,8 @@ function buildCombinedAskUserQuestionPermission(
   const allowOther = input.allowFreeform || visibleOptions.length !== input.options.length;
   return {
     id: event.id,
-    provider: PI_PROVIDER,
-    name: "Pi ask_user",
+    provider: family.providerId,
+    name: `${family.displayLabel} ask_user`,
     kind: "question",
     title: input.question,
     input: {
@@ -886,9 +901,9 @@ function buildExtensionUiResponse(
   return { value: answer };
 }
 
-function mapPiModel(model: PiModel): AgentModelDefinition {
+function mapPiModel(model: PiModel, family: PiFamilyConfig): AgentModelDefinition {
   return {
-    provider: PI_PROVIDER,
+    provider: family.providerId,
     id: `${model.provider}/${model.id}`,
     label: `${model.provider}/${model.name ?? model.id}`,
     description: `${model.provider}/${model.id}`,
@@ -901,14 +916,20 @@ function mapPiModel(model: PiModel): AgentModelDefinition {
   };
 }
 
-function createRuntime(logger: Logger, runtimeSettings?: ProviderRuntimeSettings): PiRuntime {
-  return new PiCliRuntime({ logger, runtimeSettings });
+function createRuntime(
+  logger: Logger,
+  runtimeSettings: ProviderRuntimeSettings | undefined,
+  family: PiFamilyConfig,
+): PiRuntime {
+  return new PiCliRuntime({ logger, runtimeSettings, family });
 }
 
 export class PiRpcAgentSession implements AgentSession {
-  readonly provider = PI_PROVIDER;
+  readonly provider: string;
   readonly capabilities: AgentCapabilityFlags;
 
+  private readonly family: PiFamilyConfig;
+  private readonly providerId: string;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private readonly activeToolCalls = new Map<string, PiTrackedToolCall>();
   private readonly pendingExtensionUiRequests = new Map<string, AgentPermissionRequest>();
@@ -926,6 +947,9 @@ export class PiRpcAgentSession implements AgentSession {
   private closed = false;
 
   constructor(options: PiRpcAgentSessionOptions) {
+    this.family = options.family;
+    this.providerId = options.family.providerId;
+    this.provider = options.family.providerId;
     this.runtimeSession = options.runtimeSession;
     this.config = options.config;
     this.state = options.initialState;
@@ -976,7 +1000,7 @@ export class PiRpcAgentSession implements AgentSession {
       if (isPiRequestAbortError(error)) {
         this.emit({
           type: "turn_canceled",
-          provider: PI_PROVIDER,
+          provider: this.providerId,
           turnId: failedTurnId,
           reason: toDiagnosticErrorMessage(error),
         });
@@ -984,7 +1008,7 @@ export class PiRpcAgentSession implements AgentSession {
       }
       this.emit({
         type: "turn_failed",
-        provider: PI_PROVIDER,
+        provider: this.providerId,
         turnId: failedTurnId,
         error: toDiagnosticErrorMessage(error),
       });
@@ -1003,7 +1027,7 @@ export class PiRpcAgentSession implements AgentSession {
   async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
     await this.requestEntryCapture("history");
     yield* streamPiHistory(
-      PI_PROVIDER,
+      this.providerId,
       await this.runtimeSession.getMessages(),
       this.capturedUserEntries,
     );
@@ -1012,7 +1036,7 @@ export class PiRpcAgentSession implements AgentSession {
   async getRuntimeInfo(): Promise<AgentRuntimeInfo> {
     await this.refreshState();
     return {
-      provider: PI_PROVIDER,
+      provider: this.providerId,
       sessionId: this.state.sessionId,
       model: modelToId(this.state.model),
       thinkingOptionId: resolveThinkingOptionId(
@@ -1059,7 +1083,7 @@ export class PiRpcAgentSession implements AgentSession {
     }
     this.emit({
       type: "permission_resolved",
-      provider: PI_PROVIDER,
+      provider: this.providerId,
       requestId,
       resolution: response,
       turnId: this.currentTurnIdForEvent(),
@@ -1068,7 +1092,7 @@ export class PiRpcAgentSession implements AgentSession {
 
   describePersistence(): AgentPersistenceHandle | null {
     return {
-      provider: PI_PROVIDER,
+      provider: this.providerId,
       sessionId: this.state.sessionId,
       nativeHandle: this.state.sessionFile,
       metadata: {
@@ -1243,7 +1267,7 @@ export class PiRpcAgentSession implements AgentSession {
       index -= 1;
       this.emit({
         type: "timeline",
-        provider: PI_PROVIDER,
+        provider: this.providerId,
         turnId: pending.turnId,
         item: {
           type: "user_message",
@@ -1302,7 +1326,7 @@ export class PiRpcAgentSession implements AgentSession {
       event.method === "select" &&
       this.activeAskUserDialog?.allowComment === true &&
       this.activeAskUserDialog.allowMultiple === false;
-    const request = mapExtensionUiRequestToPermission(event, {
+    const request = mapExtensionUiRequestToPermission(event, this.family, {
       combineOptionalComment: shouldCombineOptionalComment,
       allowFreeform: this.activeAskUserDialog?.allowFreeform,
     });
@@ -1313,7 +1337,7 @@ export class PiRpcAgentSession implements AgentSession {
     this.pendingExtensionUiRequests.set(request.id, request);
     this.emit({
       type: "permission_requested",
-      provider: PI_PROVIDER,
+      provider: this.providerId,
       request,
       turnId: this.currentTurnIdForEvent(),
     });
@@ -1367,7 +1391,7 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeTurnId = null;
     this.emit({
       type: "turn_failed",
-      provider: PI_PROVIDER,
+      provider: this.providerId,
       turnId,
       error,
     });
@@ -1380,14 +1404,14 @@ export class PiRpcAgentSession implements AgentSession {
       case "agent_start":
         this.emit({
           type: "thread_started",
-          provider: PI_PROVIDER,
+          provider: this.providerId,
           sessionId: this.state.sessionId,
         });
         return;
       case "turn_start":
         this.emit({
           type: "turn_started",
-          provider: PI_PROVIDER,
+          provider: this.providerId,
           turnId,
         });
         return;
@@ -1435,7 +1459,7 @@ export class PiRpcAgentSession implements AgentSession {
       case "compaction_start":
         this.emit({
           type: "timeline",
-          provider: PI_PROVIDER,
+          provider: this.providerId,
           turnId,
           item: {
             type: "compaction",
@@ -1447,7 +1471,7 @@ export class PiRpcAgentSession implements AgentSession {
       case "compaction_end":
         this.emit({
           type: "timeline",
-          provider: PI_PROVIDER,
+          provider: this.providerId,
           turnId,
           item: {
             type: "compaction",
@@ -1473,7 +1497,7 @@ export class PiRpcAgentSession implements AgentSession {
     if (event.assistantMessageEvent.type === "text_delta") {
       this.emit({
         type: "timeline",
-        provider: PI_PROVIDER,
+        provider: this.providerId,
         turnId,
         item: {
           type: "assistant_message",
@@ -1485,7 +1509,7 @@ export class PiRpcAgentSession implements AgentSession {
     if (event.assistantMessageEvent.type === "thinking_delta") {
       this.emit({
         type: "timeline",
-        provider: PI_PROVIDER,
+        provider: this.providerId,
         turnId,
         item: {
           type: "reasoning",
@@ -1504,7 +1528,7 @@ export class PiRpcAgentSession implements AgentSession {
       if (text) {
         this.emit({
           type: "timeline",
-          provider: PI_PROVIDER,
+          provider: this.providerId,
           turnId,
           item: { type: "assistant_message", text },
         });
@@ -1525,7 +1549,7 @@ export class PiRpcAgentSession implements AgentSession {
       const message = error instanceof Error ? error.message : String(error);
       this.emit({
         type: "turn_failed",
-        provider: PI_PROVIDER,
+        provider: this.providerId,
         turnId,
         error: message,
       });
@@ -1551,7 +1575,7 @@ export class PiRpcAgentSession implements AgentSession {
       status === "failed" ? { ...baseItem, status, error } : { ...baseItem, status, error: null };
     this.emit({
       type: "timeline",
-      provider: PI_PROVIDER,
+      provider: this.providerId,
       turnId,
       item,
     });
@@ -1563,7 +1587,7 @@ export class PiRpcAgentSession implements AgentSession {
     if (typeof errorMessage === "string" && errorMessage.length > 0) {
       this.emit({
         type: "turn_failed",
-        provider: PI_PROVIDER,
+        provider: this.providerId,
         turnId,
         error: errorMessage,
       });
@@ -1571,7 +1595,7 @@ export class PiRpcAgentSession implements AgentSession {
     }
     this.emit({
       type: "turn_completed",
-      provider: PI_PROVIDER,
+      provider: this.providerId,
       turnId,
     });
     void this.refreshAfterTurn(turnId);
@@ -1590,7 +1614,7 @@ export class PiRpcAgentSession implements AgentSession {
     if (usage) {
       this.emit({
         type: "usage_updated",
-        provider: PI_PROVIDER,
+        provider: this.providerId,
         turnId,
         usage,
       });
@@ -1599,17 +1623,21 @@ export class PiRpcAgentSession implements AgentSession {
 }
 
 export class PiRpcAgentClient implements AgentClient {
-  readonly provider = PI_PROVIDER;
+  readonly provider: string;
   readonly capabilities = PI_CAPABILITIES;
 
+  protected readonly family: PiFamilyConfig;
   private readonly logger: Logger;
-  private readonly runtimeSettings?: ProviderRuntimeSettings;
+  protected readonly runtimeSettings?: ProviderRuntimeSettings;
   private readonly runtime: PiRuntime;
 
   constructor(options: PiRpcAgentClientOptions) {
+    this.family = options.family ?? PI_FAMILY;
+    this.provider = this.family.providerId;
     this.logger = options.logger;
     this.runtimeSettings = options.runtimeSettings;
-    this.runtime = options.runtime ?? createRuntime(options.logger, options.runtimeSettings);
+    this.runtime =
+      options.runtime ?? createRuntime(options.logger, options.runtimeSettings, this.family);
   }
 
   async createSession(
@@ -1645,6 +1673,7 @@ export class PiRpcAgentClient implements AgentClient {
         initialState: await runtimeSession.getState(),
         capabilities: withPiMcpCapability(mcpConfig !== null),
         cleanup: combineCleanup([mcpConfig?.cleanup, paseoExtension.cleanup]),
+        family: this.family,
       });
     } catch (error) {
       await runtimeSession.close().catch(() => undefined);
@@ -1661,11 +1690,11 @@ export class PiRpcAgentClient implements AgentClient {
   ): Promise<AgentSession> {
     const sessionFile = handle.nativeHandle;
     if (!sessionFile) {
-      throw new Error("Pi resume requires a native session file handle");
+      throw new Error(`${this.family.displayLabel} resume requires a native session file handle`);
     }
 
     const persistenceMetadata = parsePersistenceMetadata(handle.metadata);
-    const resumeConfig = buildResumeConfig(persistenceMetadata, overrides);
+    const resumeConfig = buildResumeConfig(persistenceMetadata, overrides, this.family);
 
     const mcpConfig = await this.prepareMcpConfig(resumeConfig.cwd, resumeConfig.config.mcpServers);
     const paseoExtension = createPiPaseoExtensionFile();
@@ -1695,6 +1724,7 @@ export class PiRpcAgentClient implements AgentClient {
         initialState: await runtimeSession.getState(),
         capabilities: withPiMcpCapability(mcpConfig !== null),
         cleanup: combineCleanup([mcpConfig?.cleanup, paseoExtension.cleanup]),
+        family: this.family,
       });
     } catch (error) {
       await runtimeSession.close().catch(() => undefined);
@@ -1707,7 +1737,10 @@ export class PiRpcAgentClient implements AgentClient {
   async listModels(options: ListModelsOptions): Promise<AgentModelDefinition[]> {
     const runtimeSession = await this.runtime.startSession({ cwd: options.cwd });
     try {
-      return transformPiModels((await runtimeSession.getAvailableModels()).map(mapPiModel));
+      return transformPiModels(
+        (await runtimeSession.getAvailableModels()).map((model) => mapPiModel(model, this.family)),
+        { keepProviderInLabel: this.family.keepModelProviderInLabel },
+      );
     } finally {
       await runtimeSession.close();
     }
@@ -1743,11 +1776,13 @@ export class PiRpcAgentClient implements AgentClient {
   }
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
+    const label = this.family.displayLabel;
+    const homeDir = this.family.homeDirName;
     try {
       const launch = await this.resolvePiLaunch();
       const availability = await checkProviderLaunchAvailable(launch);
       const available = availability.available;
-      const authConfigPath = join(homedir(), ".pi", "agent", "auth.json");
+      const authConfigPath = join(homedir(), homeDir, "agent", "auth.json");
       let modelsValue = "Not checked";
       let configuredProvidersValue = "none";
       let mcpToolsValue = "Not checked";
@@ -1773,9 +1808,9 @@ export class PiRpcAgentClient implements AgentClient {
             configuredProvidersValue =
               configuredProviders.length > 0 ? configuredProviders.join(", ") : "none";
             const commands = await runtimeSession.getCommands();
-            mcpToolsValue = commands.some(isPiMcpAdapterCommand)
-              ? "yes (pi-mcp-adapter loaded)"
-              : "no (install pi-mcp-adapter)";
+            mcpToolsValue = commands.some((command) => isPiMcpAdapterCommand(command, this.family))
+              ? `yes (${this.family.mcpAdapterMarker} loaded)`
+              : `no (install ${this.family.mcpAdapterMarker})`;
           } catch (error) {
             modelsValue = `Error - ${toDiagnosticErrorMessage(error)}`;
             mcpToolsValue = `Error - ${toDiagnosticErrorMessage(error)}`;
@@ -1790,11 +1825,11 @@ export class PiRpcAgentClient implements AgentClient {
       }
 
       return {
-        diagnostic: formatProviderDiagnostic("Pi", [
+        diagnostic: formatProviderDiagnostic(label, [
           ...(await buildBinaryDiagnosticRows(launch, availability)),
           { label: "Configured providers", value: configuredProvidersValue },
           {
-            label: "Auth config (~/.pi/agent/auth.json)",
+            label: `Auth config (~/${homeDir}/agent/auth.json)`,
             value: existsSync(authConfigPath) ? "found" : "not found",
           },
           { label: "Models", value: modelsValue },
@@ -1803,9 +1838,9 @@ export class PiRpcAgentClient implements AgentClient {
         ]),
       };
     } catch (error) {
-      this.logger.debug({ err: error }, "Pi diagnostic lookup failed");
+      this.logger.debug({ err: error }, `${label} diagnostic lookup failed`);
       return {
-        diagnostic: formatProviderDiagnosticError("Pi", error),
+        diagnostic: formatProviderDiagnosticError(label, error),
       };
     }
   }
@@ -1825,16 +1860,24 @@ export class PiRpcAgentClient implements AgentClient {
 
   private async detectMcpAdapter(cwd: string): Promise<boolean> {
     const runtimeSession = await this.runtime.startSession({ cwd }).catch((error) => {
-      this.logger.debug({ err: error, cwd }, "Pi MCP adapter probe failed to start");
+      this.logger.debug(
+        { err: error, cwd },
+        `${this.family.displayLabel} MCP adapter probe failed to start`,
+      );
       return null;
     });
     if (!runtimeSession) {
       return false;
     }
     try {
-      return (await runtimeSession.getCommands()).some(isPiMcpAdapterCommand);
+      return (await runtimeSession.getCommands()).some((command) =>
+        isPiMcpAdapterCommand(command, this.family),
+      );
     } catch (error) {
-      this.logger.debug({ err: error, cwd }, "Pi MCP adapter probe failed");
+      this.logger.debug(
+        { err: error, cwd },
+        `${this.family.displayLabel} MCP adapter probe failed`,
+      );
       return false;
     } finally {
       await runtimeSession.close().catch(() => undefined);
@@ -1844,7 +1887,7 @@ export class PiRpcAgentClient implements AgentClient {
   private async resolvePiLaunch(): Promise<ResolvedProviderLaunch> {
     return resolveProviderLaunch({
       commandConfig: this.runtimeSettings?.command,
-      defaultBinary: PI_BINARY_COMMAND,
+      defaultBinary: resolveFamilyBinaryName(this.family),
     });
   }
 }

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.ts
@@ -4,6 +4,7 @@ import type { Logger } from "pino";
 import { spawnProcess } from "../../../../utils/spawn.js";
 import { terminateWithTreeKill } from "../../../../utils/tree-kill.js";
 import type { ProviderRuntimeSettings } from "../../provider-launch-config.js";
+import { PI_FAMILY, type PiFamilyConfig, resolveFamilyBinaryName } from "./family-config.js";
 import {
   buildPiLaunch,
   type PiRuntime,
@@ -22,9 +23,9 @@ import type {
   PiSessionStats,
 } from "./rpc-types.js";
 
-const DEFAULT_PI_COMMAND: [string, ...string[]] = [
-  process.env.PI_COMMAND ?? process.env.PI_ACP_PI_COMMAND ?? "pi",
-];
+function defaultCommandForFamily(family: PiFamilyConfig): [string, ...string[]] {
+  return [resolveFamilyBinaryName(family)];
+}
 const DEFAULT_TIMEOUT_MS = 30_000;
 const STDERR_BUFFER_LIMIT = 8192;
 const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 2_000;
@@ -32,9 +33,10 @@ const FORCE_SHUTDOWN_TIMEOUT_MS = 1_000;
 
 function assertChildWithPipes(
   child: ChildProcess,
+  label: string,
 ): asserts child is ChildProcessWithoutNullStreams {
   if (!child.stdin || !child.stdout || !child.stderr) {
-    throw new Error("Pi process was spawned without stdio streams");
+    throw new Error(`${label} process was spawned without stdio streams`);
   }
 }
 
@@ -49,24 +51,28 @@ export interface PiCliRuntimeOptions {
   runtimeSettings?: ProviderRuntimeSettings;
   command?: [string, ...string[]];
   spawnProcess?: (launch: PiRuntimeLaunch) => ChildProcessWithoutNullStreams;
+  family?: PiFamilyConfig;
 }
 
 export class PiCliRuntime implements PiRuntime {
   private readonly command: [string, ...string[]];
   private readonly spawnProcess: (launch: PiRuntimeLaunch) => ChildProcessWithoutNullStreams;
+  private readonly family: PiFamilyConfig;
 
   constructor(private readonly options: PiCliRuntimeOptions) {
-    this.command = options.command ?? DEFAULT_PI_COMMAND;
+    this.family = options.family ?? PI_FAMILY;
+    this.command = options.command ?? defaultCommandForFamily(this.family);
+    const label = this.family.displayLabel;
     this.spawnProcess =
       options.spawnProcess ??
-      ((launch) => {
+      ((launch): ChildProcessWithoutNullStreams => {
         const [command, ...args] = launch.argv;
         const child = spawnProcess(command, args, {
           cwd: launch.cwd,
           envOverlay: launch.env,
           stdio: ["pipe", "pipe", "pipe"],
         });
-        assertChildWithPipes(child);
+        assertChildWithPipes(child, label);
         return child;
       });
   }

--- a/packages/server/src/server/agent/providers/pi/family-config.ts
+++ b/packages/server/src/server/agent/providers/pi/family-config.ts
@@ -1,0 +1,87 @@
+/**
+ * Configuration shared by Pi-compatible providers.
+ *
+ * Pi (https://github.com/earendil-works/pi-coding-agent) and OMP (Oh-My-Pi,
+ * https://github.com/oh-my-pi/pi-coding-agent) speak the same JSONL session
+ * format and the same `--mode rpc` wire protocol. They differ only in binary
+ * name and home directory. Everything else — message schema, tool calls,
+ * permission dialogs, MCP adapter, model labels, Paseo's `paseo_capture_entries`
+ * / `paseo_tree` extension commands — is identical.
+ *
+ * The Pi adapter is parameterized over this family config so OMP can reuse
+ * the entire implementation by swapping a handful of identifiers.
+ */
+export interface PiFamilyConfig {
+  /** Provider id used in AgentStreamEvent payloads and the provider registry. */
+  readonly providerId: string;
+  /** Default binary name on PATH. */
+  readonly binaryName: string;
+  /**
+   * Environment variables, in priority order, that override the binary path.
+   * The first non-empty value wins. Variables not in this list are ignored.
+   */
+  readonly binaryEnvVars: ReadonlyArray<string>;
+  /** Home dotdir for the agent (e.g. `.pi`, `.omp`). */
+  readonly homeDirName: string;
+  /** Environment variable that overrides the agent directory location. */
+  readonly agentDirEnv: string;
+  /** Environment variable that overrides the sessions directory location. */
+  readonly sessionDirEnv: string;
+  /** Human-readable label used in diagnostics and error messages. */
+  readonly displayLabel: string;
+  /**
+   * Substring used to detect the MCP adapter command via Pi's `get_commands`
+   * RPC. Pi ships `pi-mcp-adapter`; OMP currently reuses the same adapter
+   * package via its plugin loader, so both families share the marker.
+   */
+  readonly mcpAdapterMarker: string;
+  /**
+   * When true, keep the upstream LLM provider prefix in model labels (e.g.
+   * `anthropic/Claude Opus 4.5`). OMP exposes ~980 models across ~15 providers,
+   * so the same model name recurs under several providers; without the prefix
+   * the picker shows indistinguishable duplicates. Pi has a small, mostly
+   * unique model set and keeps the cleaner provider-less label.
+   */
+  readonly keepModelProviderInLabel: boolean;
+}
+
+export const PI_FAMILY: PiFamilyConfig = {
+  providerId: "pi",
+  binaryName: "pi",
+  binaryEnvVars: ["PI_COMMAND", "PI_ACP_PI_COMMAND"],
+  homeDirName: ".pi",
+  agentDirEnv: "PI_CODING_AGENT_DIR",
+  sessionDirEnv: "PI_CODING_AGENT_SESSION_DIR",
+  displayLabel: "Pi",
+  mcpAdapterMarker: "pi-mcp-adapter",
+  keepModelProviderInLabel: false,
+};
+
+export const OMP_FAMILY: PiFamilyConfig = {
+  providerId: "omp",
+  binaryName: "omp",
+  binaryEnvVars: ["OMP_COMMAND", "OMP_ACP_OMP_COMMAND"],
+  homeDirName: ".omp",
+  agentDirEnv: "OMP_CODING_AGENT_DIR",
+  sessionDirEnv: "OMP_CODING_AGENT_SESSION_DIR",
+  displayLabel: "OMP",
+  mcpAdapterMarker: "pi-mcp-adapter",
+  keepModelProviderInLabel: true,
+};
+
+/**
+ * Resolve the binary path defined by the family's env variables. Returns the
+ * first non-empty match, falling back to the family's default binary name.
+ */
+export function resolveFamilyBinaryName(
+  family: PiFamilyConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  for (const name of family.binaryEnvVars) {
+    const value = env[name];
+    if (value?.trim()) {
+      return value;
+    }
+  }
+  return family.binaryName;
+}

--- a/packages/server/src/server/daemon-e2e/agent-configs.ts
+++ b/packages/server/src/server/daemon-e2e/agent-configs.ts
@@ -92,4 +92,4 @@ export function getAskModeConfig(provider: AgentProvider) {
 /**
  * Helper to run a test for each provider.
  */
-export const allProviders: AgentProvider[] = ["claude", "codex", "opencode", "pi"];
+export const allProviders: AgentProvider[] = ["claude", "codex", "opencode", "pi", "omp"];

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -151,7 +151,7 @@ const AgentMetadataGenerationSchema = z
   })
   .strict();
 
-const BUILTIN_PROVIDER_IDS = ["claude", "codex", "copilot", "opencode", "pi"] as const;
+const BUILTIN_PROVIDER_IDS = ["claude", "codex", "copilot", "opencode", "pi", "omp"] as const;
 
 function isLegacyProviderEntry(value: unknown): boolean {
   if (!value || typeof value !== "object" || Array.isArray(value)) {

--- a/public-docs/supported-providers.md
+++ b/public-docs/supported-providers.md
@@ -17,6 +17,7 @@ Work out of the box once the underlying CLI is installed and authenticated.
 - [Codex CLI](https://github.com/openai/codex). OpenAI's workspace agent with sandbox controls and optional network access.
 - [OpenCode](https://opencode.ai/). Open-source coding assistant with multi-provider model support.
 - [pi](https://github.com/svkozak/pi-acp). Minimal terminal-based coding agent with multi-provider LLM support.
+- [OMP (Oh-My-Pi)](https://github.com/oh-my-pi/pi-coding-agent). Pi fork with an extended plugin ecosystem (`~/.omp`). Reuses Pi's RPC protocol and session schema, but ships its own `omp` binary and home directory.
 
 ## ACP catalog
 


### PR DESCRIPTION
Closes #1176.

> **Updated 2026-06-03:** rebased onto current `main` (resolves the earlier conflicts), and the layout now matches upstream's move of the provider manifest / importable list into `@getpaseo/protocol`. Also folds in three small fixes found while running this against a real OMP daemon (see **Fixes from live testing** below). A companion, independently-mergeable infra PR is linked at the bottom.

## What

Adds [OMP](https://github.com/oh-my-pi/pi-coding-agent) — Oh-My-Pi, a downstream fork of Pi — as a first-class provider alongside `claude`, `codex`, `opencode`, and `pi`. OMP ships its own binary (`omp`), home directory (`~/.omp`), and plugin ecosystem, but preserves Pi's `--mode rpc` wire protocol and JSONL session schema verbatim.

After this PR, OMP users can:

- See **OMP** in `paseo provider ls`, the in-app provider catalog, and the agent picker
- Import OMP sessions started in the terminal: `paseo import <session-id> --provider omp --cwd <cwd>`
- Define custom providers that `extends: "omp"` in `~/.paseo/config.json`

## Why

OMP is a real-world Pi fork with its own `omp` CLI and `~/.omp/agent/sessions/<sanitized-cwd>/<ts>_<uuid>.jsonl` storage layout. Today OMP users either run Paseo against vanilla Pi (losing OMP plugins/extensions/history) or hack the Pi provider via `PI_CODING_AGENT_DIR` + an `extends: "pi"` custom provider (UI still says "Pi", session metadata is stamped `provider: "pi"`, and any future Pi/OMP divergence breaks silently).

OMP and Pi are binary-compatible (same JSONL header `{type:"session",version:3,id,cwd,...}`, same RPC shape, same `pi-mcp-adapter` extension), so first-class support is a near-zero-cost integration that mirrors the existing Pi adapter pattern.

## How

The Pi adapter is parameterized over a new `PiFamilyConfig`:

```ts
// packages/server/src/server/agent/providers/pi/family-config.ts
export interface PiFamilyConfig {
  readonly providerId: string;            // "pi" / "omp"
  readonly binaryName: string;            // "pi" / "omp"
  readonly binaryEnvVars: readonly string[];
  readonly homeDirName: string;           // ".pi" / ".omp"
  readonly agentDirEnv: string;
  readonly sessionDirEnv: string;
  readonly displayLabel: string;
  readonly mcpAdapterMarker: string;      // "pi-mcp-adapter" — OMP reuses Pi's adapter
  readonly keepModelProviderInLabel: boolean; // see "Fixes from live testing" #3
}

export const PI_FAMILY: PiFamilyConfig = { ... };
export const OMP_FAMILY: PiFamilyConfig = { ... };
```

`PiRpcAgentClient` / `PiRpcAgentSession` / `PiCliRuntime` accept the family via constructor and thread `family.providerId` through all `AgentStreamEvent` emissions, `AgentPersistenceHandle` metadata, diagnostic output, and MCP adapter detection. Pi-side defaults (`PI_FAMILY`) are unchanged — all existing Pi tests pass byte-for-byte.

`OmpRpcAgentClient` in `providers/omp/agent.ts` is a thin subclass of `PiRpcAgentClient` that injects `OMP_FAMILY`, overrides `listPersistedAgents` for OMP-specific offline JSONL discovery, and overrides `isAvailable` (see fix #2).

Registered in:

- `packages/protocol/src/provider-manifest.ts` — `AGENT_PROVIDER_DEFINITIONS`
- `packages/protocol/src/importable-providers.ts` — `IMPORTABLE_PROVIDERS`
- `packages/server/src/server/agent/provider-registry.ts` — provider client factory
- `packages/server/src/server/persisted-config.ts` — `BUILTIN_PROVIDER_IDS`
- `packages/server/src/server/daemon-e2e/agent-configs.ts` — `allProviders`
- `packages/cli/src/commands/agent/import.ts` — `IMPORT_PROVIDER_LIST`

## Session discovery: deliberately split from Pi

#1154 removed `providers/pi/session-descriptor.ts` and made Pi's `listPersistedAgents` return `[]`, because Pi now uses the runtime `paseo_capture_entries` extension to track session identity for sessions started inside Paseo. That doesn't help users who run `omp` directly in their terminal and later want to import that session.

For OMP this PR adds `providers/omp/session-descriptor.ts` (offline JSONL discovery of `~/.omp/agent/sessions/**/*.jsonl`, resolution order `OMP_CODING_AGENT_SESSION_DIR` → `OMP_CODING_AGENT_DIR/settings.json:sessionDir` → `<cwd>/.omp/settings.json:sessionDir` → `~/.omp/agent/sessions/`), parameterized over `PiFamilyConfig`. Pi is untouched and keeps the runtime-extension path as its canonical import strategy.

## Fixes from live testing

Running this against a real OMP install (`omp` 15.x, 13 configured MCP servers, ~980 models) surfaced three small issues, all fixed here:

1. **Config schema rejected `omp`.** `@getpaseo/protocol`'s `provider-config.ts` carried a *second*, hardcoded `BUILTIN_PROVIDER_IDS` list (separate from the manifest-derived one), so `{ "omp": { "enabled": true } }` in `config.json` failed validation with *"Custom provider \"omp\" must declare extends/label."* Fixed by importing the manifest's single source of truth (`provider-manifest.ts` → `BUILTIN_PROVIDER_IDS`), which also prevents future drift.

2. **`isAvailable()` probe was too heavy for OMP.** The Pi base class confirms availability by starting an RPC session and calling `getAvailableModels()`. OMP eagerly connects every configured MCP server on `omp --mode rpc` startup, so under the daemon's snapshot-refresh budget the probe could time out and show `error`. `OmpRpcAgentClient.isAvailable()` now does the lightweight binary-presence check used by `claude`/`codex`/`opencode`; model/MCP loading is deferred to real sessions, so capability is unaffected.

3. **Model picker couldn't distinguish providers.** `transformPiModels` strips the upstream LLM-provider prefix from model labels (fine for Pi's ~50 models). OMP exposes ~980 models across ~15 providers, so the same name (e.g. *Claude Opus 4.5*) recurs under `anthropic`, `github-copilot`, `openrouter`, … and the stripped labels were indistinguishable. Added a family flag `keepModelProviderInLabel` (**true for OMP, false for Pi**) so OMP labels keep the provider prefix (`anthropic/Claude Opus 4.5`). Pi is unchanged.

## Testing

| Layer | Result |
| --- | --- |
| **Pi regression** | all pre-existing Pi tests pass unchanged (`PI_FAMILY` defaults are byte-identical) |
| **OMP + Pi unit** | 50 passing in `providers/pi/` + `providers/omp/` (incl. 7 session-descriptor, OMP provider-id/session/listPersistedAgents/env-isolation, the new `isAvailable`-is-lightweight test, and the `keepProviderInLabel` transform test) |
| **Format / lint / typecheck** | `oxfmt --check`, `oxlint`, and `@getpaseo/protocol` / `@getpaseo/server` / `@getpaseo/cli` `typecheck` clean |
| **Live smoke (real OMP install)** | `OmpRpcAgentClient.listPersistedAgents()` returned 15 well-formed `PersistedAgentDescriptor`s (`provider:"omp"`, correct cwds/titles/JSONL handles); `paseo provider ls` shows **OMP** as available; `paseo provider models omp` lists 980 models with provider-qualified labels |

## What this does NOT change

- Pi adapter behavior, Pi env vars, Pi defaults, Pi's `listPersistedAgents` (`return []`), the runtime resume contract.

## Files

18 files, +1225 / −75. New: `pi/family-config.ts`, `omp/agent.ts`, `omp/session-descriptor.ts`, `omp/agent.test.ts`, `omp/session-descriptor.test.ts`. Modified: `pi/agent.ts`, `pi/agent.test.ts`, `pi/cli-runtime.ts`, `protocol/{provider-manifest,importable-providers,provider-config}.ts`, `provider-registry.ts`, `persisted-config.ts`, `daemon-e2e/agent-configs.ts`, CLI `agent/import.ts`, `docs/providers.md`, `public-docs/supported-providers.md`, `CHANGELOG.md`.

## Related

- Companion infra PR (independent, optional): **provider snapshot reliability for MCP-heavy providers** — sequential provider probing + a larger refresh budget so heavy MCP providers (OMP/Pi with many MCP servers, OpenCode) don't spuriously show `error`/`unavailable` under concurrent startup. Not required to merge this PR.

## Follow-ups (out of scope)

- Lift `omp/session-descriptor.ts` to `providers/pi-family/session-descriptor.ts` if you want Pi imports restored on the same offline path.
- Add an `omp` icon + one-click install to the in-app provider catalog (matches Pi's generic terminal icon for now).
