### PR TITLE
feat: Support external OpenCode servers

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -312,6 +312,24 @@ Override the command used to launch any provider with the `command` field. This 
 
 The `command` array completely replaces the default command for that provider. The binary must exist on the system — Paseo checks for its availability and will mark the provider as unavailable if not found.
 
+### Attach to an existing OpenCode server
+
+By default, Paseo starts and manages its own `opencode serve` process. To use an already-running unauthenticated OpenCode server instead, configure `serverUrl` on the built-in `opencode` provider:
+
+```json
+{
+  "agents": {
+    "providers": {
+      "opencode": {
+        "serverUrl": "http://127.0.0.1:4096"
+      }
+    }
+  }
+}
+```
+
+When `serverUrl` is set, Paseo attaches to that server and does not spawn, rotate, or shut down `opencode serve`. The configured server must be able to access the same workspace paths that Paseo sends in OpenCode requests. Authenticated OpenCode servers require OpenCode SDK authentication support; unauthenticated servers work with only `serverUrl`.
+
 ---
 
 ## Disabling a provider
@@ -511,6 +529,7 @@ Every entry under `agents.providers` accepts these fields:
 | `description`      | `string`                 | No                | Short description shown in the UI                                  |
 | `command`          | `string[]`               | Yes (ACP only)    | Command to spawn the agent process                                 |
 | `env`              | `Record<string, string>` | No                | Environment variables to set for the agent process                 |
+| `serverUrl`        | `string`                 | No                | Existing OpenCode server URL to attach to instead of spawning one  |
 | `models`           | `ProviderProfileModel[]` | No                | Static model list (overrides runtime discovery)                    |
 | `additionalModels` | `ProviderProfileModel[]` | No                | Static model additions (merged with runtime discovery or `models`) |
 | `disallowedTools`  | `string[]`               | No                | Tool names to disable for this provider (e.g. `["WebSearch"]`)     |

--- a/packages/server/src/server/agent/provider-launch-config.test.ts
+++ b/packages/server/src/server/agent/provider-launch-config.test.ts
@@ -113,14 +113,24 @@ describe("ProviderOverrideSchema", () => {
       env: {
         FOO: "bar",
       },
+      serverUrl: "http://127.0.0.1:4096",
       enabled: false,
       order: 2,
     });
 
     expect(parsed.command).toEqual(["custom-claude", "--json"]);
     expect(parsed.env?.FOO).toBe("bar");
+    expect(parsed.serverUrl).toBe("http://127.0.0.1:4096");
     expect(parsed.enabled).toBe(false);
     expect(parsed.order).toBe(2);
+  });
+
+  test("rejects non-HTTP server URLs", () => {
+    const parsed = ProviderOverrideSchema.safeParse({
+      serverUrl: "ws://127.0.0.1:4096",
+    });
+
+    expect(parsed.success).toBe(false);
   });
 
   test("accepts models with thinking options", () => {
@@ -273,6 +283,23 @@ describe("migrateProviderSettings", () => {
         env: {
           PATH: "/custom/bin",
         },
+      },
+    });
+  });
+
+  test("preserves external server URLs while migrating old entries", () => {
+    const migrated = migrateProviderSettings(
+      {
+        opencode: {
+          serverUrl: "http://127.0.0.1:4096",
+        },
+      },
+      builtinProviderIds,
+    );
+
+    expect(migrated).toEqual({
+      opencode: {
+        serverUrl: "http://127.0.0.1:4096",
       },
     });
   });

--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -33,10 +33,22 @@ export const ProviderCommandSchema = z.discriminatedUnion("mode", [
   ProviderCommandReplaceSchema,
 ]);
 
+const ProviderServerUrlSchema = z
+  .string()
+  .url()
+  .refine(
+    (value) => {
+      const protocol = new URL(value).protocol;
+      return protocol === "http:" || protocol === "https:";
+    },
+    { message: "Server URL must use http or https" },
+  );
+
 export const ProviderRuntimeSettingsSchema = z
   .object({
     command: ProviderCommandSchema.optional(),
     env: z.record(z.string()).optional(),
+    serverUrl: ProviderServerUrlSchema.optional(),
     disallowedTools: z.array(z.string()).optional(),
   })
   .strict();
@@ -67,6 +79,7 @@ export const ProviderOverrideSchema = z
     description: z.string().optional(),
     command: z.array(z.string().min(1)).min(1).optional(),
     env: z.record(z.string()).optional(),
+    serverUrl: ProviderServerUrlSchema.optional(),
     models: z.array(ProviderProfileModelSchema).optional(),
     additionalModels: z.array(ProviderProfileModelSchema).optional(),
     disallowedTools: z.array(z.string()).optional(),
@@ -156,6 +169,9 @@ export function migrateProviderSettings(
     }
     if (parsedOld.data.env) {
       nextEntry.env = parsedOld.data.env;
+    }
+    if (parsedOld.data.serverUrl) {
+      nextEntry.serverUrl = parsedOld.data.serverUrl;
     }
     if (!builtinProviderIdSet.has(providerId) && nextEntry.extends === undefined) {
       delete nextEntry.extends;

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -150,7 +150,7 @@ function getProviderClientFactory(provider: string): ProviderClientFactory {
 }
 
 function toRuntimeSettings(override?: ProviderOverride): ProviderRuntimeSettings | undefined {
-  if (!override?.command && !override?.env && !override?.disallowedTools) {
+  if (!override?.command && !override?.env && !override?.serverUrl && !override?.disallowedTools) {
     return undefined;
   }
 
@@ -162,8 +162,34 @@ function toRuntimeSettings(override?: ProviderOverride): ProviderRuntimeSettings
         }
       : undefined,
     env: override.env,
+    serverUrl: override.serverUrl,
     disallowedTools: override.disallowedTools,
   };
+}
+
+function mergeProviderEnv(
+  base: ProviderRuntimeSettings | undefined,
+  override: ProviderRuntimeSettings | undefined,
+): Record<string, string> | undefined {
+  if (!base?.env && !override?.env) {
+    return undefined;
+  }
+
+  return {
+    ...base?.env,
+    ...override?.env,
+  };
+}
+
+function mergeDisallowedTools(
+  base: ProviderRuntimeSettings | undefined,
+  override: ProviderRuntimeSettings | undefined,
+): string[] | undefined {
+  if (!base?.disallowedTools && !override?.disallowedTools) {
+    return undefined;
+  }
+
+  return [...(base?.disallowedTools ?? []), ...(override?.disallowedTools ?? [])];
 }
 
 function mergeRuntimeSettings(
@@ -176,17 +202,9 @@ function mergeRuntimeSettings(
 
   return {
     command: override?.command ?? base?.command,
-    env:
-      base?.env || override?.env
-        ? {
-            ...base?.env,
-            ...override?.env,
-          }
-        : undefined,
-    disallowedTools:
-      base?.disallowedTools || override?.disallowedTools
-        ? [...(base?.disallowedTools ?? []), ...(override?.disallowedTools ?? [])]
-        : undefined,
+    env: mergeProviderEnv(base, override),
+    serverUrl: override?.serverUrl ?? base?.serverUrl,
+    disallowedTools: mergeDisallowedTools(base, override),
   };
 }
 

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -95,6 +95,24 @@ const hasOpenCode = isBinaryInstalled("opencode");
 const hasOpenRouterKey = Boolean(process.env.OPENROUTER_API_KEY);
 const canRunLiveOpenCodeTurns = hasOpenCode && hasOpenRouterKey;
 
+describe("OpenCodeAgentClient external server configuration", () => {
+  test("does not initialize the managed server singleton when serverUrl is configured", async () => {
+    const getInstance = vi.spyOn(OpenCodeServerManager, "getInstance").mockImplementation(() => {
+      throw new Error("managed OpenCode server should not initialize");
+    });
+
+    try {
+      const client = new OpenCodeAgentClient(createTestLogger(), {
+        serverUrl: "http://127.0.0.1:4096",
+      });
+
+      expect(client.provider).toBe("opencode");
+    } finally {
+      getInstance.mockRestore();
+    }
+  });
+});
+
 (canRunLiveOpenCodeTurns ? describe : describe.skip)("OpenCodeAgentClient smoke tests", () => {
   const logger = createTestLogger();
   const buildConfig = (cwd: string): AgentSessionConfig => ({

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -170,6 +170,7 @@ type OpenCodeMcpConfig =
 
 const MCP_ALREADY_PRESENT_ERROR_TOKENS = ["already", "exists", "connected"] as const;
 const OPENCODE_PROVIDER_LIST_TIMEOUT_MS = 30_000;
+const OPENCODE_EXTERNAL_HEALTH_TIMEOUT_MS = 2_000;
 const OPENCODE_HANDLED_BUILTIN_SLASH_COMMANDS: AgentSlashCommand[] = [
   { name: "compact", description: "Compact the current session", argumentHint: "" },
   { name: "summarize", description: "Compact the current session", argumentHint: "" },
@@ -1051,17 +1052,71 @@ interface OpenCodeAgentClientDeps {
   runtime?: OpenCodeRuntime;
 }
 
+function acquireExternalOpenCodeServer(serverUrl: string): OpenCodeServerAcquisition {
+  const url = normalizeOpenCodeServerUrl(serverUrl);
+  return {
+    server: { port: resolveOpenCodeServerPort(url), url },
+    release: () => {},
+  };
+}
+
+function normalizeOpenCodeServerUrl(serverUrl: string): string {
+  const parsed = new URL(serverUrl);
+  parsed.hash = "";
+  parsed.search = "";
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  return parsed.toString().replace(/\/$/, "");
+}
+
+function resolveOpenCodeServerPort(serverUrl: string): number {
+  const parsed = new URL(serverUrl);
+  if (parsed.port) {
+    return Number(parsed.port);
+  }
+  return parsed.protocol === "https:" ? 443 : 80;
+}
+
+async function isExternalOpenCodeServerAvailable(serverUrl: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OPENCODE_EXTERNAL_HEALTH_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${normalizeOpenCodeServerUrl(serverUrl)}/global/health`, {
+      signal: controller.signal,
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 class ProductionOpenCodeRuntime implements OpenCodeRuntime {
-  constructor(private readonly serverManager: OpenCodeServerManager) {}
+  constructor(
+    private readonly serverManager: OpenCodeServerManager | null,
+    private readonly externalServerUrl?: string,
+  ) {}
 
   async acquireServer(options: {
     force: boolean;
     env?: Record<string, string>;
   }): Promise<OpenCodeServerAcquisition> {
+    if (this.externalServerUrl) {
+      return acquireExternalOpenCodeServer(this.externalServerUrl);
+    }
+    if (!this.serverManager) {
+      throw new Error("OpenCode server manager is not configured");
+    }
     return this.serverManager.acquire(options);
   }
 
   async ensureServerRunning(): Promise<{ port: number; url: string }> {
+    if (this.externalServerUrl) {
+      return acquireExternalOpenCodeServer(this.externalServerUrl).server;
+    }
+    if (!this.serverManager) {
+      throw new Error("OpenCode server manager is not configured");
+    }
     return this.serverManager.ensureRunning();
   }
 
@@ -1070,7 +1125,7 @@ class ProductionOpenCodeRuntime implements OpenCodeRuntime {
   }
 
   async shutdown(): Promise<void> {
-    await this.serverManager.shutdown();
+    await this.serverManager?.shutdown();
   }
 }
 
@@ -1093,7 +1148,10 @@ export class OpenCodeAgentClient implements AgentClient {
     this.runtime =
       deps.runtime ??
       new ProductionOpenCodeRuntime(
-        OpenCodeServerManager.getInstance(this.logger, runtimeSettings),
+        runtimeSettings?.serverUrl
+          ? null
+          : OpenCodeServerManager.getInstance(this.logger, runtimeSettings),
+        runtimeSettings?.serverUrl,
       );
   }
 
@@ -1330,6 +1388,11 @@ export class OpenCodeAgentClient implements AgentClient {
   }
 
   async isAvailable(): Promise<boolean> {
+    const serverUrl = this.runtimeSettings?.serverUrl;
+    if (serverUrl) {
+      return await isExternalOpenCodeServerAvailable(serverUrl);
+    }
+
     const command = this.runtimeSettings?.command;
     if (command?.mode === "replace") {
       return await isCommandAvailable(command.argv[0]);
@@ -1347,7 +1410,7 @@ export class OpenCodeAgentClient implements AgentClient {
 
       try {
         const { url } = await this.runtime.ensureServerRunning();
-        serverStatus = `Running (${url})`;
+        serverStatus = this.runtimeSettings?.serverUrl ? `External (${url})` : `Running (${url})`;
       } catch (error) {
         serverStatus = `Unavailable (${toDiagnosticErrorMessage(error)})`;
       }

--- a/packages/server/src/server/agent/providers/provider-availability.test.ts
+++ b/packages/server/src/server/agent/providers/provider-availability.test.ts
@@ -1,4 +1,5 @@
 import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import http from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -37,6 +38,32 @@ function isolateCodexDefaultDiscoveryTo(dir: string): void {
   if (process.platform === "win32") {
     process.env.LOCALAPPDATA = dir;
   }
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (typeof address === "object" && address) {
+        resolve(address.port);
+      } else {
+        reject(new Error("server did not bind to a TCP port"));
+      }
+    });
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
 }
 
 afterEach(() => {
@@ -112,6 +139,40 @@ describe("default provider availability", () => {
     const binDir = makeTempDir("provider-availability-opencode-");
     isolatePathTo(binDir);
     const client = new OpenCodeAgentClient(createTestLogger());
+
+    await expect(client.isAvailable()).resolves.toBe(false);
+  });
+
+  test("OpenCode reports available with an external server URL", async () => {
+    const binDir = makeTempDir("provider-availability-opencode-external-");
+    isolatePathTo(binDir);
+    const server = http.createServer((request, response) => {
+      if (request.url === "/global/health") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ healthy: true, version: "test" }));
+        return;
+      }
+      response.writeHead(404);
+      response.end();
+    });
+    const port = await listen(server);
+    const client = new OpenCodeAgentClient(createTestLogger(), {
+      serverUrl: `http://127.0.0.1:${port}`,
+    });
+
+    try {
+      await expect(client.isAvailable()).resolves.toBe(true);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  test("OpenCode reports unavailable when the external server health check fails", async () => {
+    const binDir = makeTempDir("provider-availability-opencode-external-down-");
+    isolatePathTo(binDir);
+    const client = new OpenCodeAgentClient(createTestLogger(), {
+      serverUrl: "http://127.0.0.1:1",
+    });
 
     await expect(client.isAvailable()).resolves.toBe(false);
   });


### PR DESCRIPTION
### Linked issue

Closes #1178 

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Adds explicit support for attaching Paseo's OpenCode provider to an already-running `opencode serve` instance.

A new `agents.providers.opencode.serverUrl` config field can point Paseo at an external OpenCode HTTP server:

```json
{
  "agents": {
    "providers": {
      "opencode": {
        "serverUrl": "http://127.0.0.1:4096"
      }
    }
  }
}
```

When `serverUrl` is configured, Paseo uses that URL for OpenCode SDK requests and does not initialize its managed `OpenCodeServerManager`, so it will not spawn, rotate, or shut down `opencode serve`.

The existing managed-server behavior remains unchanged when `serverUrl` is not set.

This also:

- restricts `serverUrl` to `http` / `https`
- probes `/global/health` for external-server availability
- carries `serverUrl` through provider overrides/runtime settings
- documents the config and external workspace-path assumption

### How did you verify it

Ran focused tests:

```bash
npx vitest run packages/server/src/server/agent/providers/opencode-server-manager.test.ts --bail=1
npx vitest run packages/server/src/server/agent/providers/provider-availability.test.ts --bail=1
npx vitest run packages/server/src/server/agent/provider-launch-config.test.ts --bail=1
npx vitest run packages/server/src/server/agent/providers/opencode-agent.test.ts --bail=1
```

Ran lint:

```bash
npm run lint
```

Ran server typecheck:

```bash
npm run typecheck --workspace=@getpaseo/server
```

Also smoke-tested local Paseo 0.1.81 dev startup using a direct daemon/app setup:

- daemon on `127.0.0.1:6777`
- app on `localhost:4421`
- app connected over `ws://localhost:6777/ws` after enabling dev CORS

Full workspace `npm run typecheck` is currently blocked by unrelated app/CLI type errors in this checkout, including `@testing-library/react` test export errors in `packages/app` and stale CLI/server declaration errors. The touched server code passes targeted tests, lint, and server typecheck.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [ ] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
