### PR TITLE
Reject replayed relay frames

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ The daemon requires a valid cryptographic handshake before processing any comman
 - **Send commands as you** — The daemon only accepts traffic that decrypts and authenticates under a shared key derived with its own secret key. The phone's keypair is ephemeral per connection, so there is no persistent phone-side secret to steal; protection comes from the daemon's secret key never leaving the daemon.
 - **Read your traffic** — All messages are encrypted with XSalsa20-Poly1305 (NaCl box) after the handshake
 - **Forge messages** — NaCl box provides authenticated encryption; tampered messages are rejected
-- **Replay old messages across sessions** — Each session derives fresh encryption keys, so ciphertext from one session cannot be replayed into another session. Within a live session, replay protection is not yet implemented; the protocol uses random nonces and does not track nonce reuse or message counters.
+- **Replay old messages across sessions** — Each session derives fresh encryption keys, so ciphertext from one session cannot be replayed into another session. Within a live session, each receiver tracks accepted frame nonces and closes the channel before delivering a repeated nonce.
 
 ### Trust model
 

--- a/packages/relay/src/crypto.ts
+++ b/packages/relay/src/crypto.ts
@@ -22,7 +22,7 @@ export interface KeyPair {
 
 export type SharedKey = Uint8Array; // 32 bytes (box.before)
 
-const NONCE_LENGTH = nacl.box.nonceLength; // 24
+export const NONCE_LENGTH = nacl.box.nonceLength; // 24
 
 let prngReady = false;
 

--- a/packages/relay/src/encrypted-channel.test.ts
+++ b/packages/relay/src/encrypted-channel.test.ts
@@ -238,6 +238,46 @@ describe("EncryptedChannel", () => {
     expect(daemonMessages).toEqual(["still encrypted with original key"]);
   });
 
+  it("closes the receiver when an encrypted frame is replayed", async () => {
+    const [daemonTransport, clientTransport] = createMockTransportPair();
+
+    const daemonKeyPair = generateKeyPair();
+    const daemonPubKeyB64 = exportPublicKey(daemonKeyPair.publicKey);
+    const daemonMessages: (string | ArrayBuffer)[] = [];
+
+    let clientOpenedResolve: (() => void) | null = null;
+    const clientOpened = new Promise<void>((resolve) => {
+      clientOpenedResolve = resolve;
+    });
+
+    const daemonChannelPromise = createDaemonChannel(daemonTransport, daemonKeyPair, {
+      onmessage: (data) => daemonMessages.push(data),
+    });
+
+    const clientChannel = await createClientChannel(clientTransport, daemonPubKeyB64, {
+      onopen: () => clientOpenedResolve?.(),
+    });
+
+    await daemonChannelPromise;
+    await clientOpened;
+
+    (clientTransport.send as ReturnType<typeof vi.fn>).mockClear();
+
+    await clientChannel.send("execute once");
+    await waitForAsyncDelivery();
+
+    expect(daemonMessages).toEqual(["execute once"]);
+
+    const replayedFrame = (clientTransport.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(typeof replayedFrame).toBe("string");
+
+    daemonTransport.onmessage?.(replayedFrame as string);
+    await waitForAsyncDelivery();
+
+    expect(daemonMessages).toEqual(["execute once"]);
+    expect(daemonTransport.close).toHaveBeenCalledWith(1008, "E2EE replayed frame");
+  });
+
   it("closes an open daemon channel when a different client key sends hello", async () => {
     const [daemonTransport, clientTransport] = createMockTransportPair();
 

--- a/packages/relay/src/encrypted-channel.ts
+++ b/packages/relay/src/encrypted-channel.ts
@@ -13,6 +13,7 @@ import {
   deriveSharedKey,
   encrypt,
   decrypt,
+  NONCE_LENGTH,
   type KeyPair,
   type SharedKey,
 } from "./crypto.js";
@@ -92,6 +93,8 @@ function buildInvalidHelloError(rawText: string, parsed?: unknown): Error {
 
 const HANDSHAKE_RETRY_MS = 1000;
 const MAX_PENDING_SENDS = 200;
+const REPLAYED_FRAME_CLOSE_CODE = 1008;
+const REPLAYED_FRAME_CLOSE_REASON = "E2EE replayed frame";
 const REHANDSHAKE_KEY_MISMATCH_CLOSE_CODE = 1008;
 const REHANDSHAKE_KEY_MISMATCH_CLOSE_REASON = "E2EE re-handshake key mismatch";
 
@@ -270,6 +273,7 @@ export class EncryptedChannel {
   private pendingSends: Array<string | ArrayBuffer> = [];
   private onOpenCallbacks: Array<() => void> = [];
   private onCloseCallbacks: Array<() => void> = [];
+  private seenInboundNonces = new Set<string>();
 
   constructor(
     transport: Transport,
@@ -365,7 +369,17 @@ export class EncryptedChannel {
       })();
 
       if (ciphertext) {
+        const inboundNonceKey = extractNonceKey(ciphertext);
+        if (inboundNonceKey && this.seenInboundNonces.has(inboundNonceKey)) {
+          this.state = "closed";
+          this.transport.close(REPLAYED_FRAME_CLOSE_CODE, REPLAYED_FRAME_CLOSE_REASON);
+          return;
+        }
+
         const plaintext = decrypt(this.sharedKey, ciphertext);
+        if (inboundNonceKey) {
+          this.seenInboundNonces.add(inboundNonceKey);
+        }
         this.events.onmessage?.(plaintext);
       }
     } catch (error) {
@@ -457,4 +471,10 @@ function keysEqual(a: Uint8Array, b: Uint8Array): boolean {
     difference |= a[i] ^ b[i];
   }
   return difference === 0;
+}
+
+function extractNonceKey(ciphertext: ArrayBuffer): string | null {
+  const bytes = new Uint8Array(ciphertext);
+  if (bytes.byteLength < NONCE_LENGTH) return null;
+  return arrayBufferToBase64(bytes.slice(0, NONCE_LENGTH).buffer);
 }


### PR DESCRIPTION
## Summary
- track accepted inbound encrypted frame nonces for each relay channel
- close the channel before delivery when a nonce is repeated, preventing exact ciphertext replay within a live session
- export the relay crypto nonce length for channel parsing and update SECURITY.md to document live-session replay rejection

## Tests
- npm run test --workspace=@getpaseo/relay -- src/encrypted-channel.test.ts --bail=1
- npm run format:files -- SECURITY.md packages/relay/src/crypto.ts packages/relay/src/encrypted-channel.ts packages/relay/src/encrypted-channel.test.ts
- npm run format:check:files -- SECURITY.md packages/relay/src/crypto.ts packages/relay/src/encrypted-channel.ts packages/relay/src/encrypted-channel.test.ts
- npm run lint -- packages/relay/src/crypto.ts packages/relay/src/encrypted-channel.ts packages/relay/src/encrypted-channel.test.ts
- npm run typecheck --workspace=@getpaseo/relay
- npm run build --workspace=@getpaseo/relay