### PR TITLE
feat(app):  display worktree slug in tab headers

### DIFF
--- a/packages/app/src/components/agent-list.tsx
+++ b/packages/app/src/components/agent-list.tsx
@@ -14,6 +14,7 @@ import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { formatTimeAgo } from "@/utils/time";
 import { shortenPath } from "@/utils/shorten-path";
+import { extractWorktreeSlug } from "@/utils/worktree-slug";
 import { type AggregatedAgent } from "@/hooks/use-aggregated-agents";
 import { useSessionStore } from "@/stores/session-store";
 import { Archive } from "lucide-react-native";
@@ -193,6 +194,7 @@ function SessionRow({
   const isSelected = selectedAgentId === agentKey;
   const statusLabel = formatStatusLabel(agent.status);
   const projectPath = shortenPath(agent.cwd);
+  const worktreeSlug = extractWorktreeSlug(agent.cwd);
   const ProviderIcon = getProviderIcon(agent.provider);
 
   const pressableStyle = useCallback(
@@ -246,6 +248,14 @@ function SessionRow({
             <Text style={styles.sessionMetaText} numberOfLines={1}>
               {projectPath}
             </Text>
+            {worktreeSlug ? (
+              <>
+                <Text style={styles.sessionMetaSeparator}>·</Text>
+                <Text style={styles.sessionMetaText} numberOfLines={1}>
+                  {worktreeSlug}
+                </Text>
+              </>
+            ) : null}
             <Text style={styles.sessionMetaSeparator}>·</Text>
             <Text style={styles.sessionMetaText}>{statusLabel}</Text>
             <Text style={styles.sessionMetaSeparator}>·</Text>
@@ -264,7 +274,7 @@ function SessionRow({
       {!isMobile && (
         <>
           <Text style={styles.columnMeta} numberOfLines={1}>
-            {projectPath}
+            {worktreeSlug ? `${projectPath} · ${worktreeSlug}` : projectPath}
           </Text>
           <Text style={styles.columnMetaFixed}>{statusLabel}</Text>
           <Text style={styles.columnMetaFixed}>{timeAgo}</Text>

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -68,6 +68,7 @@ import {
   type SidebarProjectEntry,
   type SidebarWorkspaceEntry,
 } from "@/hooks/use-sidebar-workspaces-list";
+import { shouldShowWorktreeSlug } from "@/utils/worktree-slug";
 import { useSidebarOrderStore } from "@/stores/sidebar-order-store";
 import { useShowShortcutBadges } from "@/hooks/use-show-shortcut-badges";
 import {
@@ -1402,6 +1403,9 @@ function WorkspaceRowInner({
     ],
     [isHovered, isCreating],
   );
+
+  const shouldShowSlug = shouldShowWorktreeSlug(workspace.worktreeSlug, workspace.name);
+
   return (
     <WorkspaceHoverCard workspace={workspace} prHint={prHint} isDragging={isDragging}>
       <View
@@ -1431,9 +1435,16 @@ function WorkspaceRowInner({
                 workspaceKind={workspace.workspaceKind}
                 loading={isArchiving || isCreating}
               />
-              <Text style={workspaceBranchTextStyle} numberOfLines={1}>
-                {workspace.name}
-              </Text>
+              <View style={styles.workspaceNameGroup}>
+                <Text style={workspaceBranchTextStyle} numberOfLines={1}>
+                  {workspace.name}
+                </Text>
+                {shouldShowSlug ? (
+                  <Text style={styles.workspaceSlugText} numberOfLines={1}>
+                    {workspace.worktreeSlug}
+                  </Text>
+                ) : null}
+              </View>
             </View>
             <WorkspaceRowRightGroup
               workspace={workspace}
@@ -2895,14 +2906,24 @@ const styles = StyleSheet.create((theme) => ({
     fontWeight: "400",
     lineHeight: 20,
     opacity: 0.76,
-    flex: 1,
-    minWidth: 0,
   },
   workspaceBranchTextCreating: {
     opacity: 0.92,
   },
   workspaceBranchTextHovered: {
     opacity: 1,
+  },
+  workspaceNameGroup: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  workspaceSlugText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    fontWeight: "400",
+    lineHeight: 16,
+    opacity: 0.7,
   },
   workspacePrBadgeRow: {
     flexDirection: "row",

--- a/packages/app/src/hooks/use-sidebar-workspaces-list.ts
+++ b/packages/app/src/hooks/use-sidebar-workspaces-list.ts
@@ -5,6 +5,7 @@ import {
   useSessionStore,
   type WorkspaceDescriptor,
 } from "@/stores/session-store";
+import { extractWorktreeSlug } from "@/utils/worktree-slug";
 import {
   useWorkspaceStructure,
   type WorkspaceStructureProject,
@@ -28,6 +29,8 @@ export interface SidebarWorkspaceEntry {
   projectKind: WorkspaceDescriptor["projectKind"];
   workspaceKind: WorkspaceDescriptor["workspaceKind"];
   name: string;
+  /** The worktree directory slug (last path component of workspaceDirectory). Null for non-worktrees. */
+  worktreeSlug: string | null;
   statusBucket: SidebarStateBucket;
   archivingAt: string | null;
   diffStat: { additions: number; deletions: number } | null;
@@ -68,6 +71,7 @@ function createStructuralWorkspaceEntry(input: {
     projectKind: input.project.projectKind,
     workspaceKind: "checkout",
     name: input.workspaceId,
+    worktreeSlug: null,
     statusBucket: "done",
     archivingAt: null,
     diffStat: null,
@@ -92,6 +96,10 @@ export function createSidebarWorkspaceEntry(input: {
     projectKind: input.workspace.projectKind,
     workspaceKind: input.workspace.workspaceKind,
     name: input.workspace.name,
+    worktreeSlug:
+      input.workspace.workspaceKind === "worktree"
+        ? extractWorktreeSlug(input.workspace.workspaceDirectory)
+        : null,
     statusBucket: input.workspace.status,
     archivingAt: input.workspace.archivingAt,
     diffStat: input.workspace.diffStat,

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -13,6 +13,7 @@ import { Composer } from "@/components/composer";
 import { FileDropZone } from "@/components/file-drop-zone";
 import type { ImageAttachment } from "@/components/message-input";
 import { getProviderIcon } from "@/components/provider-icons";
+import { extractWorktreeSlug } from "@/utils/worktree-slug";
 import { ToastViewport, useToastHost } from "@/components/toast-host";
 import type { WorkspaceComposerAttachment } from "@/attachments/types";
 import {
@@ -253,25 +254,39 @@ function useAgentPanelDescriptor(
       const session = state.sessions[context.serverId];
       const agent =
         session?.agents?.get(target.agentId) ?? session?.agentDetails?.get(target.agentId) ?? null;
+      if (!agent) {
+        return {
+          provider: "codex" as const,
+          title: null,
+          status: null,
+          cwd: null,
+          pendingPermissionCount: 0,
+          requiresAttention: false,
+          attentionReason: null,
+        };
+      }
       return {
-        provider: agent?.provider ?? "codex",
-        title: agent?.title ?? null,
-        status: agent?.status ?? null,
-        pendingPermissionCount: agent?.pendingPermissions.length ?? 0,
-        requiresAttention: agent?.requiresAttention ?? false,
-        attentionReason: agent?.attentionReason ?? null,
+        provider: agent.provider,
+        title: agent.title ?? null,
+        status: agent.status ?? null,
+        cwd: agent.cwd ?? null,
+        pendingPermissionCount: agent.pendingPermissions.length,
+        requiresAttention: agent.requiresAttention ?? false,
+        attentionReason: agent.attentionReason ?? null,
       };
     }),
   );
   const provider = descriptorState.provider;
   const label = resolveWorkspaceAgentTabLabel(descriptorState.title);
   const icon = getProviderIcon(provider);
+  const worktreeSlug = extractWorktreeSlug(descriptorState.cwd);
 
   return {
     label: label ?? "",
     subtitle: `${formatProviderLabel(provider)} agent`,
     titleState: label ? "ready" : "loading",
     icon,
+    worktreeSlug,
     statusBucket: descriptorState.status
       ? deriveSidebarStateBucket({
           status: descriptorState.status,

--- a/packages/app/src/panels/panel-registry.ts
+++ b/packages/app/src/panels/panel-registry.ts
@@ -13,6 +13,7 @@ export interface PanelDescriptor {
   titleState: "ready" | "loading";
   icon: ComponentType<PanelIconProps>;
   statusBucket: SidebarStateBucket | null;
+  worktreeSlug?: string | null;
 }
 
 export interface PanelDescriptorContext {

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -224,6 +224,8 @@ function TabHandleContent({
   tabLabelSkeletonStyle: React.ComponentProps<typeof View>["style"];
   tabLabelStyle: React.ComponentProps<typeof Text>["style"];
 }) {
+  const hasSlug = Boolean(presentation.worktreeSlug);
+  const slugStyle = useMemo(() => [tabLabelStyle, styles.tabWorktreeSlug], [tabLabelStyle]);
   return (
     <View style={styles.tabHandle}>
       <View style={styles.tabIcon}>
@@ -233,9 +235,16 @@ function TabHandleContent({
         <View style={tabLabelSkeletonStyle} />
       ) : null}
       {showLabel && presentation.titleState !== "loading" ? (
-        <Text style={tabLabelStyle} selectable={false} numberOfLines={1} ellipsizeMode="tail">
-          {presentation.label}
-        </Text>
+        <View style={styles.tabLabelRow}>
+          <Text style={tabLabelStyle} selectable={false} numberOfLines={1} ellipsizeMode="tail">
+            {presentation.label}
+          </Text>
+          {hasSlug ? (
+            <Text style={slugStyle} selectable={false} numberOfLines={1}>
+              {presentation.worktreeSlug}
+            </Text>
+          ) : null}
+        </View>
       ) : null}
     </View>
   );
@@ -1016,6 +1025,18 @@ const styles = StyleSheet.create((theme) => ({
   },
   tabLabelActive: {
     color: theme.colors.foreground,
+  },
+  tabLabelRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    flex: 1,
+    minWidth: 0,
+  },
+  tabWorktreeSlug: {
+    color: theme.colors.foregroundMuted,
+    opacity: 0.7,
+    flexShrink: 0,
   },
   tabCloseButton: {
     width: 18,

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -44,6 +44,7 @@ import { ScreenHeader } from "@/components/headers/screen-header";
 import { BranchSwitcher } from "@/components/branch-switcher";
 import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
 import { Shortcut } from "@/components/ui/shortcut";
+import { extractWorktreeSlug, shouldShowWorktreeSlug } from "@/utils/worktree-slug";
 import type { ShortcutKey } from "@/utils/format-shortcut";
 import {
   DropdownMenu,
@@ -947,6 +948,7 @@ interface WorkspaceHeaderTitleBarProps {
   showSubtitle: boolean;
   currentBranchName: string | null;
   isGitCheckout: boolean;
+  worktreeSlug: string | null;
   normalizedServerId: string;
   normalizedWorkspaceId: string;
   showWorkspaceSetup: boolean;
@@ -976,6 +978,7 @@ function WorkspaceHeaderTitleBar({
   showSubtitle,
   currentBranchName,
   isGitCheckout,
+  worktreeSlug,
   normalizedServerId,
   normalizedWorkspaceId,
   showWorkspaceSetup,
@@ -1019,6 +1022,17 @@ function WorkspaceHeaderTitleBar({
               numberOfLines={1}
             >
               {subtitle}
+            </Text>
+          ) : null}
+          {/* Shown independently of showSubtitle — the slug is a directory
+              identifier, not a subtitle duplicate, so it has its own gate. */}
+          {worktreeSlug ? (
+            <Text
+              testID="workspace-header-worktree-slug"
+              style={styles.headerWorktreeSlug}
+              numberOfLines={1}
+            >
+              {worktreeSlug}
             </Text>
           ) : null}
         </View>
@@ -1136,6 +1150,7 @@ interface WorkspaceHeaderFields {
   shouldShowWorkspaceHeaderSubtitle: boolean;
   isGitCheckout: boolean;
   currentBranchName: string | null;
+  worktreeSlug: string | null;
 }
 
 function buildWorkspaceHeaderCheckoutState(input: {
@@ -1171,8 +1186,18 @@ function deriveWorkspaceHeaderFields(input: {
       shouldShowWorkspaceHeaderSubtitle: false,
       isGitCheckout: false,
       currentBranchName: null,
+      worktreeSlug: null,
     };
   }
+
+  // Only extract and show the worktree slug for actual worktree workspaces
+  // where the slug differs from the branch name.
+  const isWorktree = input.workspace?.workspaceKind === "worktree";
+  const rawSlug = isWorktree ? extractWorktreeSlug(input.workspace?.workspaceDirectory) : null;
+  const worktreeSlug = shouldShowWorktreeSlug(rawSlug, renderState.currentBranchName)
+    ? rawSlug
+    : null;
+
   return {
     isWorkspaceHeaderLoading: false,
     workspaceHeaderTitle: renderState.title,
@@ -1180,6 +1205,7 @@ function deriveWorkspaceHeaderFields(input: {
     shouldShowWorkspaceHeaderSubtitle: renderState.shouldShowSubtitle,
     isGitCheckout: renderState.isGitCheckout,
     currentBranchName: renderState.currentBranchName,
+    worktreeSlug,
   };
 }
 
@@ -1607,6 +1633,7 @@ function WorkspaceScreenContent({
     shouldShowWorkspaceHeaderSubtitle,
     isGitCheckout,
     currentBranchName,
+    worktreeSlug,
   } = deriveWorkspaceHeaderFields({
     workspace: workspaceDescriptor,
     checkoutState: workspaceHeaderCheckoutState,
@@ -3254,6 +3281,7 @@ function WorkspaceScreenContent({
                         showSubtitle={shouldShowWorkspaceHeaderSubtitle}
                         currentBranchName={currentBranchName}
                         isGitCheckout={isGitCheckout}
+                        worktreeSlug={worktreeSlug}
                         normalizedServerId={normalizedServerId}
                         normalizedWorkspaceId={normalizedWorkspaceId}
                         showWorkspaceSetup={showWorkspaceSetup}
@@ -3443,6 +3471,14 @@ const styles = StyleSheet.create((theme) => ({
     flexShrink: 1,
     minWidth: 0,
     maxWidth: "60%",
+  },
+  headerWorktreeSlug: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    fontWeight: "400",
+    opacity: 0.7,
+    flexShrink: 1,
+    minWidth: 0,
   },
   headerTitleSkeleton: {
     width: 220,

--- a/packages/app/src/screens/workspace/workspace-source-of-truth.test.ts
+++ b/packages/app/src/screens/workspace/workspace-source-of-truth.test.ts
@@ -159,4 +159,92 @@ describe("workspace source of truth consumption", () => {
       }),
     ).toBe(false);
   });
+
+  describe("worktree slug in sidebar entry", () => {
+    it("sets worktreeSlug for worktree workspace with worktree path", () => {
+      const sidebar = createSidebarWorkspaceEntry({
+        serverId: "srv",
+        workspace: createWorkspaceDescriptor({
+          workspaceKind: "worktree",
+          workspaceDirectory: "/Users/dev/.paseo/worktrees/a1b2c3d4/puny-impala",
+          name: "feat/login",
+        }),
+      });
+      expect(sidebar.worktreeSlug).toBe("puny-impala");
+    });
+
+    it("sets worktreeSlug to null for non-worktree workspace even with worktree-like path", () => {
+      const sidebar = createSidebarWorkspaceEntry({
+        serverId: "srv",
+        workspace: createWorkspaceDescriptor({
+          workspaceKind: "local_checkout",
+          workspaceDirectory: "/Users/dev/.paseo/worktrees/a1b2c3d4/puny-impala",
+          name: "feat/login",
+        }),
+      });
+      expect(sidebar.worktreeSlug).toBeNull();
+    });
+
+    it("sets worktreeSlug to null for worktree workspace with non-worktree path", () => {
+      const sidebar = createSidebarWorkspaceEntry({
+        serverId: "srv",
+        workspace: createWorkspaceDescriptor({
+          workspaceKind: "worktree",
+          workspaceDirectory: "/Users/dev/projects/my-app",
+          name: "feat/login",
+        }),
+      });
+      expect(sidebar.worktreeSlug).toBeNull();
+    });
+
+    it("sets worktreeSlug to null when workspaceDirectory is undefined", () => {
+      const sidebar = createSidebarWorkspaceEntry({
+        serverId: "srv",
+        workspace: createWorkspaceDescriptor({
+          workspaceKind: "worktree",
+          workspaceDirectory: undefined,
+          name: "feat/login",
+        }),
+      });
+      expect(sidebar.worktreeSlug).toBeNull();
+    });
+  });
+
+  describe("worktree slug in workspace header", () => {
+    it("resolveWorkspaceHeaderRenderState still returns correct branch for worktree workspace", () => {
+      const state = resolveWorkspaceHeaderRenderState({
+        workspace: createWorkspaceDescriptor({
+          workspaceKind: "worktree",
+          workspaceDirectory: "/Users/dev/.paseo/worktrees/a1b2c3d4/puny-impala",
+          name: "feat/login",
+        }),
+        checkoutState: {
+          kind: "ready",
+          checkout: { isGit: true, currentBranch: "feat/login" },
+        },
+      });
+      expect(state.kind).toBe("ready");
+      if (state.kind === "ready") {
+        expect(state.currentBranchName).toBe("feat/login");
+      }
+    });
+
+    it("resolveWorkspaceHeaderRenderState handles non-worktree workspace with worktree-like path", () => {
+      const state = resolveWorkspaceHeaderRenderState({
+        workspace: createWorkspaceDescriptor({
+          workspaceKind: "local_checkout",
+          workspaceDirectory: "/Users/dev/.paseo/worktrees/a1b2c3d4/puny-impala",
+          name: "feat/login",
+        }),
+        checkoutState: {
+          kind: "ready",
+          checkout: { isGit: true, currentBranch: "feat/login" },
+        },
+      });
+      expect(state.kind).toBe("ready");
+      if (state.kind === "ready") {
+        expect(state.currentBranchName).toBe("feat/login");
+      }
+    });
+  });
 });

--- a/packages/app/src/screens/workspace/workspace-tab-presentation.tsx
+++ b/packages/app/src/screens/workspace/workspace-tab-presentation.tsx
@@ -20,6 +20,7 @@ export interface WorkspaceTabPresentation {
   titleState: "ready" | "loading";
   icon: React.ComponentType<{ size: number; color: string }>;
   statusBucket: SidebarStateBucket | null;
+  worktreeSlug: string | null;
 }
 
 const DEFAULT_STATUS_DOT_SIZE = 7;
@@ -82,6 +83,7 @@ function WorkspaceTabPresentationResolverInner({
       titleState: descriptor.titleState,
       icon: descriptor.icon,
       statusBucket: descriptor.statusBucket,
+      worktreeSlug: descriptor.worktreeSlug ?? null,
     }),
     [
       descriptor.icon,
@@ -89,6 +91,7 @@ function WorkspaceTabPresentationResolverInner({
       descriptor.statusBucket,
       descriptor.subtitle,
       descriptor.titleState,
+      descriptor.worktreeSlug,
       tab.key,
       tab.kind,
     ],
@@ -202,6 +205,11 @@ export function WorkspaceTabOptionRow({
           <Text numberOfLines={1} style={styles.optionLabel}>
             {presentation.titleState === "loading" ? "Loading..." : presentation.label}
           </Text>
+          {presentation.worktreeSlug ? (
+            <Text numberOfLines={1} style={styles.optionWorktreeSlug}>
+              {presentation.worktreeSlug}
+            </Text>
+          ) : null}
         </View>
       </Pressable>
       {selected ? (
@@ -293,6 +301,11 @@ const styles = StyleSheet.create((theme) => ({
   optionLabel: {
     fontSize: theme.fontSize.sm,
     color: theme.colors.foreground,
+  },
+  optionWorktreeSlug: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+    opacity: 0.7,
   },
   optionTrailingSlot: {
     width: 16,

--- a/packages/app/src/subagents/section.tsx
+++ b/packages/app/src/subagents/section.tsx
@@ -69,6 +69,7 @@ function buildRowPresentation(row: SubagentRow): WorkspaceTabPresentation {
     subtitle: "",
     titleState: label ? "ready" : "loading",
     icon: getProviderIcon(row.provider),
+    worktreeSlug: null,
     statusBucket: deriveSidebarStateBucket({
       status: row.status,
       requiresAttention: false,

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -18,6 +18,7 @@ function workspace(overrides: Partial<SidebarWorkspaceEntry> = {}): SidebarWorks
     projectKind: "git",
     workspaceKind: "checkout",
     name: "paseo",
+    worktreeSlug: null,
     statusBucket: "done",
     diffStat: null,
     archiveHasUncommittedChanges: null,

--- a/packages/app/src/utils/sidebar-shortcuts.test.ts
+++ b/packages/app/src/utils/sidebar-shortcuts.test.ts
@@ -22,6 +22,7 @@ function workspace(input: {
     projectKind: "git",
     workspaceKind: "checkout",
     name: input.name,
+    worktreeSlug: null,
     statusBucket: "done",
     archivingAt: null,
     diffStat: null,

--- a/packages/app/src/utils/worktree-slug.test.ts
+++ b/packages/app/src/utils/worktree-slug.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { extractWorktreeSlug, shouldShowWorktreeSlug } from "./worktree-slug";
+
+describe("extractWorktreeSlug", () => {
+  describe("canonical worktree paths", () => {
+    it("extracts slug from a POSIX worktree path", () => {
+      expect(extractWorktreeSlug("/Users/dev/.paseo/worktrees/a1b2c3d4/puny-impala")).toBe(
+        "puny-impala",
+      );
+    });
+
+    it("extracts slug from a home-relative worktree path", () => {
+      expect(extractWorktreeSlug("~/.paseo/worktrees/1vnnm9k3/tidy-fox")).toBe("tidy-fox");
+    });
+
+    it("extracts slug from a Linux home path", () => {
+      expect(extractWorktreeSlug("/home/dev/.paseo/worktrees/abcdef12/my-feature")).toBe(
+        "my-feature",
+      );
+    });
+
+    it("extracts slug when path has trailing content (nested dir)", () => {
+      expect(
+        extractWorktreeSlug("/Users/dev/.paseo/worktrees/a1b2c3d4/puny-impala/projects/app"),
+      ).toBe("puny-impala");
+    });
+
+    it("handles slashes in the slug (branch-style slugs)", () => {
+      expect(
+        extractWorktreeSlug("/Users/dev/.paseo/worktrees/a1b2c3d4/feature/login-refactor"),
+      ).toBe("feature");
+    });
+
+    it("handles trailing slashes", () => {
+      expect(extractWorktreeSlug("/Users/dev/.paseo/worktrees/a1b2c3d4/puny-impala/")).toBe(
+        "puny-impala",
+      );
+    });
+  });
+
+  describe("Windows paths", () => {
+    it("extracts slug from a Windows worktree path", () => {
+      expect(extractWorktreeSlug("C:\\Users\\dev\\.paseo\\worktrees\\a1b2c3d4\\puny-impala")).toBe(
+        "puny-impala",
+      );
+    });
+
+    it("handles Windows trailing slash", () => {
+      expect(
+        extractWorktreeSlug("C:\\Users\\dev\\.paseo\\worktrees\\a1b2c3d4\\puny-impala\\"),
+      ).toBe("puny-impala");
+    });
+  });
+
+  describe("non-worktree paths", () => {
+    it("returns null for a regular project directory", () => {
+      expect(extractWorktreeSlug("/Users/dev/projects/my-app")).toBeNull();
+    });
+
+    it("returns null for a Linux home project directory", () => {
+      expect(extractWorktreeSlug("/home/dev/projects/my-app")).toBeNull();
+    });
+
+    it("returns null for a relative path", () => {
+      expect(extractWorktreeSlug("projects/my-app")).toBeNull();
+    });
+
+    it("returns null for undefined", () => {
+      expect(extractWorktreeSlug(undefined)).toBeNull();
+    });
+
+    it("returns null for null", () => {
+      expect(extractWorktreeSlug(null)).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(extractWorktreeSlug("")).toBeNull();
+    });
+
+    it("returns null for whitespace-only string", () => {
+      expect(extractWorktreeSlug("   ")).toBeNull();
+    });
+  });
+
+  describe("malformed paths", () => {
+    it("returns null when only /worktrees/ with no hash or slug", () => {
+      expect(extractWorktreeSlug("/worktrees/")).toBeNull();
+    });
+
+    it("returns null when /worktrees/ has only hash but no slug", () => {
+      expect(extractWorktreeSlug("/worktrees/a1b2c3d4")).toBeNull();
+    });
+
+    it("returns null when /worktrees/ is at the end with trailing slash only", () => {
+      expect(extractWorktreeSlug("/some/path/worktrees/")).toBeNull();
+    });
+  });
+});
+
+describe("shouldShowWorktreeSlug", () => {
+  it("returns false when slug is null", () => {
+    expect(shouldShowWorktreeSlug(null, "main")).toBe(false);
+  });
+
+  it("returns false when slug is empty", () => {
+    expect(shouldShowWorktreeSlug("", "main")).toBe(false);
+  });
+
+  it("returns false when slug equals branch name", () => {
+    expect(shouldShowWorktreeSlug("feature-login", "feature-login")).toBe(false);
+  });
+
+  it("returns true when slug differs from branch name", () => {
+    expect(shouldShowWorktreeSlug("puny-impala", "feature/login")).toBe(true);
+  });
+
+  it("returns true when branch name is null and slug is valid", () => {
+    expect(shouldShowWorktreeSlug("puny-impala", null)).toBe(true);
+  });
+
+  it("returns true when branch name is empty and slug is valid", () => {
+    expect(shouldShowWorktreeSlug("puny-impala", "")).toBe(true);
+  });
+
+  it("is case-sensitive (different case means show)", () => {
+    expect(shouldShowWorktreeSlug("Main", "main")).toBe(true);
+  });
+});

--- a/packages/app/src/utils/worktree-slug.ts
+++ b/packages/app/src/utils/worktree-slug.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared worktree slug extraction and display logic.
+ *
+ * Paseo worktrees live under $PASEO_HOME/worktrees/<projectHash>/<slug>.
+ * This utility ONLY recognizes that canonical path pattern — it never returns
+ * a bare "last path component" to avoid false positives on regular directories.
+ */
+
+/**
+ * Extract the worktree slug from a path that follows the canonical pattern:
+ *   .../worktrees/<projectHash>/<slug>[/...]
+ *
+ * Returns null for any path that does not contain the /worktrees/ marker
+ * with both a hash and slug component following it.
+ *
+ * Handles both POSIX and Windows path separators.
+ */
+export function extractWorktreeSlug(path: string | undefined | null): string | null {
+  if (!path) {
+    return null;
+  }
+  const normalized = path.trim().replace(/\\/g, "/");
+  if (!normalized) {
+    return null;
+  }
+
+  const marker = "/worktrees/";
+  const index = normalized.indexOf(marker);
+  if (index === -1) {
+    return null;
+  }
+
+  const after = normalized.slice(index + marker.length);
+  const parts = after.split("/").filter(Boolean);
+  if (parts.length < 2) {
+    return null;
+  }
+
+  const slug = parts[1];
+  return slug.length > 0 ? slug : null;
+}
+
+/**
+ * Determine whether a worktree slug should be shown alongside a branch name.
+ * Returns false when the slug is null, empty, or identical to the branch name
+ * (case-sensitive) to avoid redundant display.
+ */
+export function shouldShowWorktreeSlug(slug: string | null, branchName: string | null): boolean {
+  if (!slug || slug.length === 0) {
+    return false;
+  }
+  if (!branchName || branchName.length === 0) {
+    return true;
+  }
+  return slug !== branchName;
+}


### PR DESCRIPTION
feat(app):  display worktree slug in tab headers

Show the worktree slug (basename of workspace path) as a muted secondary label alongside the branch/agent name across the UI:

- Add extractWorktreeSlug() and shouldShowWorktreeSlug() utilities
- Sidebar workspace list: show slug under branch name
- Agent list: show slug in meta row (mobile) and column (desktop)
- Workspace header: show slug below the title bar
- Tab headers: show slug next to agent title in tab chip and option row
- Add worktreeSlug to PanelDescriptor and thread through resolver
- Add tests for slug extraction and sidebar/workspace integration

Closes #1008

<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
-->


### Linked issue

Closes #1008

### Type of change

- [x] New feature (with prior issue + design alignment)

### What does this PR do

Show the worktree slug (basename of workspace path) as a muted secondary label alongside the branch/agent name across the UI. Previously the UI only showed the branch name, making it hard to identify which Docker container or external tool to point at for a given worktree.

Changes:
- Add `extractWorktreeSlug()` and `shouldShowWorktreeSlug()` shared utilities that parse the canonical `$PASEO_HOME/worktrees/<hash>/<slug>` path pattern
- Sidebar workspace list: show slug under the branch name
- Agent list: show slug in meta row (mobile) and column (desktop)
- Workspace header: show slug below the title bar
- Tab headers: show slug next to the agent title in both the tab chip and the dropdown option row
- Add `worktreeSlug` to `PanelDescriptor` and thread it through the `WorkspaceTabPresentation` resolver
- Add tests for slug extraction and sidebar/workspace integration

### How did you verify it

- `npm run typecheck` — passes across all workspaces
- `npm run lint` — 0 errors, 0 warnings
- `npm run format` — all files formatted
- Manual review of the diff for correctness

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
