### PR TITLE
fix(app): archive agent before closing tab to prevent race condition

### DIFF
--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -2351,19 +2351,22 @@ function WorkspaceScreenContent({
 
         setHoveredTabKey((current) => (current === tabId ? null : current));
         setHoveredCloseTabKey((current) => (current === tabId ? null : current));
+
+        if (closePolicy.kind === "archive-on-close") {
+          try {
+            await archiveAgent({ serverId: normalizedServerId, agentId });
+          } catch {
+            // If archive fails, don't close the tab.
+            return;
+          }
+        }
+
         if (persistenceKey) {
           closeWorkspaceTabWithCleanup({
             tabId,
             target: { kind: "agent", agentId },
           });
         }
-
-        if (closePolicy.kind === "layout-only") {
-          return;
-        }
-
-        // Errors (e.g. timeout) are handled by the mutation's onSettled callback
-        void archiveAgent({ serverId: normalizedServerId, agentId }).catch(() => {});
       });
     },
     [archiveAgent, closeTab, closeWorkspaceTabWithCleanup, normalizedServerId, persistenceKey],


### PR DESCRIPTION
## Summary

Fixes #1182 — when closing the last empty agent tab, multiple "New Agent" tabs were automatically created instead of just one.

## Root cause

Race condition in `handleCloseAgentTab`: `closeWorkspaceTabWithCleanup` removed the tab **synchronously** while `archiveAgent` ran **asynchronously**. The reconciliation effect fired between the two operations, saw the agent still in `autoOpenAgentIds` but missing from layout, and re-created the tab. After the archive completed, the auto-created tab was collapsed, triggering the empty workspace seed to create yet another "New Agent" draft.

## Fix

Reverse the order: `await archiveAgent()` first, then `closeWorkspaceTabWithCleanup()`. This ensures the agent is already archived when the layout updates, so reconciliation won't re-create the tab.

If archive fails, the tab is not closed — better UX than the previous behavior of closing the tab and silently failing the archive.

## Test plan

- [x] Typecheck (app package — pre-existing errors in CLI/terminal are unrelated)
- [x] Lint: 0 warnings, 0 errors
- [x] Format: passed
- [x] Unit tests: 7/7 passing (close-tab-policy, workspace-empty-draft-seed, workspace-subagents-integration)
- [x] Manual test: rebuilt desktop web bundle, verified closing last empty agent tab creates only one "New Agent" draft on desktop (Linux)