### PR TITLE
feat(server): add generic agent attention hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ At the start of non-trivial work, list `docs/` and skim anything relevant to the
 | [docs/file-icons.md](docs/file-icons.md)                       | Material icon theme integration for the file explorer                                                                          |
 | [docs/providers.md](docs/providers.md)                         | Adding a new agent provider end-to-end                                                                                         |
 | [docs/custom-providers.md](docs/custom-providers.md)           | Custom provider config: Z.AI, Alibaba/Qwen, ACP agents, profiles, custom binaries                                              |
+| [docs/notifications.md](docs/notifications.md)                 | Agent attention notification hooks and examples                                                                                |
 | [docs/development.md](docs/development.md)                     | Dev server, build sync gotchas, CLI reference, agent state, Playwright MCP                                                     |
 | [docs/rpc-namespacing.md](docs/rpc-namespacing.md)             | WebSocket RPC naming convention — dotted namespaces and `.request`/`.response` pairs                                           |
 | [docs/testing.md](docs/testing.md)                             | TDD workflow, determinism, real dependencies over mocks, test organization                                                     |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -151,6 +151,11 @@ Single file, validated with `PersistedConfigSchema`.
     openai: { apiKey: string },
     local: { modelsDir: string }
   },
+  notifications: {
+    hooks: {
+      agentAttention: { enabled: boolean, command: string[], timeoutMs: number }
+    }
+  },
   agents: {
     // ProviderOverrideSchema; legacy entries with `command: { mode, ... }` are migrated to the
     // current shape on load via `migrateProviderSettings`. Custom provider IDs must declare

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,86 @@
+# Notifications
+
+Paseo sends agent attention notifications through mobile push tokens by default. The daemon can also run an optional post-hook for the same external notification decisions.
+
+## Agent Attention Hook
+
+`agentAttention` is a fire-and-forget post-hook. Paseo runs it only when the existing push notification policy decides an external notification should be sent. Hook failures, non-zero exits, and timeouts are logged but do not block Expo push delivery or agent lifecycle handling.
+
+Configure it in `$PASEO_HOME/config.json`:
+
+```json
+{
+  "version": 1,
+  "notifications": {
+    "hooks": {
+      "agentAttention": {
+        "enabled": true,
+        "command": ["node", "/path/to/paseo-agent-attention-hook.mjs"],
+        "timeoutMs": 5000
+      }
+    }
+  }
+}
+```
+
+The hook receives one JSON object on stdin:
+
+```json
+{
+  "agentId": "agent_123",
+  "provider": "codex",
+  "reason": "permission",
+  "notification": {
+    "title": "Agent needs permission",
+    "body": "Need input - Choose an option",
+    "data": {
+      "serverId": "srv_123",
+      "agentId": "agent_123",
+      "reason": "permission"
+    }
+  }
+}
+```
+
+`reason` is one of `finished`, `permission`, or `error`. The current external push policy does not send `error` notifications, so the hook normally receives `finished` and `permission` events. Permission events cover tool approvals, plan approvals, questions, mode changes, and other provider-specific permission prompts.
+
+## ServerChan Example
+
+ServerChan can be implemented in userland with a hook script instead of adding provider-specific code to Paseo. Keep the send key in an environment variable rather than in `config.json`.
+
+```js
+const input = await new Promise((resolve, reject) => {
+  let data = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    data += chunk;
+  });
+  process.stdin.on("end", () => resolve(JSON.parse(data)));
+  process.stdin.on("error", reject);
+});
+
+const sendKey = process.env.PASEO_SERVERCHAN_SENDKEY;
+if (!sendKey) {
+  throw new Error("PASEO_SERVERCHAN_SENDKEY is required");
+}
+
+const turboMatch = sendKey.match(/^sctp(\d+)t/i);
+const endpoint = turboMatch
+  ? `https://${turboMatch[1]}.push.ft07.com/send/${sendKey}.send`
+  : `https://sctapi.ftqq.com/${sendKey}.send`;
+
+const body = new URLSearchParams({
+  title: input.notification.title,
+  desp: input.notification.body,
+});
+
+const response = await fetch(endpoint, {
+  method: "POST",
+  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  body,
+});
+
+if (!response.ok) {
+  throw new Error(`ServerChan request failed with ${response.status}`);
+}
+```

--- a/packages/server/src/server/agent-attention-hooks.test.ts
+++ b/packages/server/src/server/agent-attention-hooks.test.ts
@@ -1,0 +1,181 @@
+import { spawn } from "node:child_process";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type pino from "pino";
+
+import {
+  createAgentAttentionHookRunner,
+  type AgentAttentionHookPayload,
+} from "./agent-attention-hooks.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+function createLogger(): pino.Logger {
+  const logger = {
+    child: vi.fn(() => logger),
+    warn: vi.fn(),
+  };
+  return logger as unknown as pino.Logger;
+}
+
+function createChildProcess() {
+  const handlers = new Map<string, (...values: unknown[]) => void>();
+  const stdinHandlers = new Map<string, (...values: unknown[]) => void>();
+  const child = {
+    stdin: {
+      write: vi.fn(),
+      end: vi.fn(),
+      on: vi.fn((event: string, handler: (...values: unknown[]) => void) => {
+        stdinHandlers.set(event, handler);
+        return child.stdin;
+      }),
+      emit(event: string, ...values: unknown[]) {
+        stdinHandlers.get(event)?.(...values);
+      },
+    },
+    kill: vi.fn(),
+    on: vi.fn((event: string, handler: (...values: unknown[]) => void) => {
+      handlers.set(event, handler);
+      return child;
+    }),
+    emit(event: string, ...values: unknown[]) {
+      handlers.get(event)?.(...values);
+    },
+  };
+  return child;
+}
+
+const payload: AgentAttentionHookPayload = {
+  agentId: "agent-1",
+  provider: "codex",
+  reason: "finished",
+  notification: {
+    title: "Agent finished",
+    body: "Done.",
+    data: {
+      serverId: "srv-test",
+      agentId: "agent-1",
+      reason: "finished",
+    },
+  },
+};
+
+describe("AgentAttentionHookRunner", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  test("passes the attention payload to the configured command over stdin", async () => {
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(createLogger(), {
+      command: ["node", "/opt/paseo/serverchan-hook.mjs"],
+    });
+
+    const run = runner.run(payload);
+    child.emit("close", 0);
+    await run;
+
+    expect(spawn).toHaveBeenCalledWith("node", ["/opt/paseo/serverchan-hook.mjs"], {
+      stdio: ["pipe", "ignore", "ignore"],
+      windowsHide: true,
+    });
+    expect(child.stdin.write).toHaveBeenCalledWith(`${JSON.stringify(payload)}\n`);
+    expect(child.stdin.end).toHaveBeenCalled();
+  });
+
+  test("logs and swallows non-zero hook exits", async () => {
+    const logger = createLogger();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(logger, {
+      command: ["node", "/opt/paseo/serverchan-hook.mjs"],
+    });
+
+    const run = runner.run(payload);
+    child.emit("close", 1);
+    await run;
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { code: 1, signal: undefined },
+      "Agent attention hook exited unsuccessfully",
+    );
+  });
+
+  test("logs and swallows hook start errors", async () => {
+    const logger = createLogger();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(logger, {
+      command: ["missing-command"],
+    });
+    const error = new Error("spawn missing-command ENOENT");
+
+    const run = runner.run(payload);
+    child.emit("error", error);
+    await run;
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: error },
+      "Failed to start agent attention hook",
+    );
+  });
+
+  test("logs and swallows stdin write errors", async () => {
+    const logger = createLogger();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(logger, {
+      command: ["node", "/opt/paseo/serverchan-hook.mjs"],
+    });
+    const error = new Error("write EOF");
+
+    const run = runner.run(payload);
+    child.stdin.emit("error", error);
+    await run;
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: error },
+      "Failed to write agent attention hook payload",
+    );
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  test("uses a 5 second default timeout", async () => {
+    vi.useFakeTimers();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(createLogger(), {
+      command: ["node", "/opt/paseo/serverchan-hook.mjs"],
+    });
+
+    const run = runner.run(payload);
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    child.emit("close", null, "SIGTERM");
+    await run;
+
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  test("kills the hook process after the configured timeout", async () => {
+    vi.useFakeTimers();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(createLogger(), {
+      command: ["node", "/opt/paseo/serverchan-hook.mjs"],
+      timeoutMs: 50,
+    });
+
+    const run = runner.run(payload);
+    await vi.advanceTimersByTimeAsync(50);
+    child.emit("close", null, "SIGTERM");
+    await run;
+
+    expect(child.kill).toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/server/agent-attention-hooks.ts
+++ b/packages/server/src/server/agent-attention-hooks.ts
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+import type pino from "pino";
+
+import type { AgentProvider } from "./agent/agent-sdk-types.js";
+import type { PushPayload } from "./push/notifications.js";
+
+const DEFAULT_AGENT_ATTENTION_HOOK_TIMEOUT_MS = 5000;
+
+export interface AgentAttentionHookConfig {
+  command: string[];
+  timeoutMs?: number;
+}
+
+export interface AgentAttentionHookPayload {
+  agentId: string;
+  provider: AgentProvider;
+  reason: "finished" | "error" | "permission";
+  notification: PushPayload;
+}
+
+export interface AgentAttentionHookRunner {
+  run(payload: AgentAttentionHookPayload): Promise<void>;
+}
+
+export function createAgentAttentionHookRunner(
+  logger: pino.Logger,
+  config: AgentAttentionHookConfig,
+): AgentAttentionHookRunner {
+  const command = config.command[0];
+  const args = config.command.slice(1);
+  const timeoutMs = config.timeoutMs ?? DEFAULT_AGENT_ATTENTION_HOOK_TIMEOUT_MS;
+
+  return {
+    async run(payload) {
+      let resolveRun: (() => void) | undefined;
+      const completed = new Promise<void>((resolve) => {
+        resolveRun = resolve;
+      });
+      const child = spawn(command, args, {
+        stdio: ["pipe", "ignore", "ignore"],
+        windowsHide: true,
+      });
+      let settled = false;
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        resolveRun?.();
+      };
+      const timeout = setTimeout(() => {
+        logger.warn({ timeoutMs }, "Agent attention hook timed out");
+        child.kill();
+      }, timeoutMs);
+
+      child.on("error", (err) => {
+        logger.warn({ err }, "Failed to start agent attention hook");
+        finish();
+      });
+      child.on("close", (code, signal) => {
+        if (code !== 0) {
+          logger.warn({ code, signal }, "Agent attention hook exited unsuccessfully");
+        }
+        finish();
+      });
+      child.stdin.on("error", (err) => {
+        if (settled) {
+          return;
+        }
+        logger.warn({ err }, "Failed to write agent attention hook payload");
+        child.kill();
+        finish();
+      });
+
+      try {
+        child.stdin.write(`${JSON.stringify(payload)}\n`);
+        child.stdin.end();
+      } catch (err) {
+        logger.warn({ err }, "Failed to write agent attention hook payload");
+        finish();
+      }
+
+      await completed;
+    },
+  };
+}

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -121,6 +121,10 @@ import { createConfiguredTerminalManager } from "../terminal/terminal-manager-fa
 import { createConnectionOfferV2, encodeOfferToFragmentUrl } from "./connection-offer.js";
 import { loadOrCreateDaemonKeyPair } from "./daemon-keypair.js";
 import { startRelayTransport, type RelayTransportController } from "./relay-transport.js";
+import {
+  createAgentAttentionHookRunner,
+  type AgentAttentionHookConfig,
+} from "./agent-attention-hooks.js";
 import type { PushNotificationSender } from "./push/notifications.js";
 import { getOrCreateServerId } from "./server-id.js";
 import { resolveDaemonVersion } from "./daemon-version.js";
@@ -255,6 +259,7 @@ export interface PaseoDaemonConfig {
   log?: PersistedConfig["log"];
   onLifecycleIntent?: (intent: DaemonLifecycleIntent) => void;
   pushNotificationSender?: PushNotificationSender;
+  agentAttentionHook?: AgentAttentionHookConfig;
 }
 
 export interface PaseoDaemon {
@@ -952,6 +957,12 @@ export async function createPaseoDaemon(
                 publicUseTls: relayPublicUseTls,
               },
             },
+            config.agentAttentionHook
+              ? createAgentAttentionHookRunner(
+                  logger.child({ module: "agent-attention-hook" }),
+                  config.agentAttentionHook,
+                )
+              : undefined,
           );
 
           if (relayEnabled) {

--- a/packages/server/src/server/config-notifications.test.ts
+++ b/packages/server/src/server/config-notifications.test.ts
@@ -1,0 +1,82 @@
+import { mkdir, mkdtemp, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { loadConfig } from "./config.js";
+
+const roots: string[] = [];
+
+async function createPaseoHome(config: unknown): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "paseo-config-notifications-"));
+  roots.push(root);
+  const paseoHome = path.join(root, ".paseo");
+  await mkdir(paseoHome, { recursive: true });
+  await writeFile(path.join(paseoHome, "config.json"), JSON.stringify(config, null, 2));
+  return paseoHome;
+}
+
+describe("daemon notification config", () => {
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  test("loads the agent attention hook command from persisted config", async () => {
+    const paseoHome = await createPaseoHome({
+      version: 1,
+      notifications: {
+        hooks: {
+          agentAttention: {
+            enabled: true,
+            command: ["node", "/opt/paseo/serverchan-hook.mjs"],
+            timeoutMs: 2500,
+          },
+        },
+      },
+    });
+
+    const config = loadConfig(paseoHome, { env: {} });
+
+    expect(config.agentAttentionHook).toEqual({
+      command: ["node", "/opt/paseo/serverchan-hook.mjs"],
+      timeoutMs: 2500,
+    });
+  });
+
+  test("uses the default agent attention hook timeout", async () => {
+    const paseoHome = await createPaseoHome({
+      version: 1,
+      notifications: {
+        hooks: {
+          agentAttention: {
+            command: ["node", "/opt/paseo/serverchan-hook.mjs"],
+          },
+        },
+      },
+    });
+
+    const config = loadConfig(paseoHome, { env: {} });
+
+    expect(config.agentAttentionHook).toEqual({
+      command: ["node", "/opt/paseo/serverchan-hook.mjs"],
+    });
+  });
+
+  test("does not enable the agent attention hook when it is disabled", async () => {
+    const paseoHome = await createPaseoHome({
+      version: 1,
+      notifications: {
+        hooks: {
+          agentAttention: {
+            enabled: false,
+            command: ["node", "/opt/paseo/serverchan-hook.mjs"],
+          },
+        },
+      },
+    });
+
+    const config = loadConfig(paseoHome, { env: {} });
+
+    expect(config.agentAttentionHook).toBeUndefined();
+  });
+});

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -17,6 +17,7 @@ import type {
 import { ProviderOverrideSchema } from "./agent/provider-launch-config.js";
 import { AgentProviderSchema } from "./agent/provider-manifest.js";
 import { hashDaemonPassword } from "./auth.js";
+import type { AgentAttentionHookConfig } from "./agent-attention-hooks.js";
 import { resolveSpeechConfig } from "./speech/speech-config-resolver.js";
 import { mergeHostnames, parseHostnamesEnv, type HostnamesConfig } from "./hostnames.js";
 
@@ -260,6 +261,21 @@ function resolveAppendSystemPrompt(persisted: ReturnType<typeof loadPersistedCon
   return persisted.daemon?.appendSystemPrompt ?? "";
 }
 
+function resolveAgentAttentionHookConfig(
+  persisted: ReturnType<typeof loadPersistedConfig>,
+): AgentAttentionHookConfig | undefined {
+  const config = persisted.notifications?.hooks?.agentAttention;
+
+  if (!config || config.enabled === false || !config.command) {
+    return undefined;
+  }
+
+  return {
+    command: config.command,
+    timeoutMs: config.timeoutMs,
+  };
+}
+
 function resolveStaticLoadConfigSettings(
   env: NodeJS.ProcessEnv,
   cli: CliConfigOverrides | undefined,
@@ -346,6 +362,7 @@ export function loadConfig(
     voiceLlmModel: voiceLlm.model,
     agentProviderSettings: extractAgentProviderSettings(providerOverrides),
     providerOverrides,
+    agentAttentionHook: resolveAgentAttentionHookConfig(persisted),
     log: resolveLogConfigFromEnv(env, persisted),
   };
 }

--- a/packages/server/src/server/persisted-config.test.ts
+++ b/packages/server/src/server/persisted-config.test.ts
@@ -63,6 +63,56 @@ describe("PersistedConfigSchema daemon relay config", () => {
   });
 });
 
+describe("PersistedConfigSchema notifications config", () => {
+  test("accepts optional agent attention post-hook config", () => {
+    const parsed = PersistedConfigSchema.parse({
+      notifications: {
+        hooks: {
+          agentAttention: {
+            enabled: true,
+            command: ["node", "/opt/paseo/serverchan-hook.mjs"],
+            timeoutMs: 2500,
+          },
+        },
+      },
+    });
+
+    expect(parsed.notifications?.hooks?.agentAttention?.command).toEqual([
+      "node",
+      "/opt/paseo/serverchan-hook.mjs",
+    ]);
+    expect(parsed.notifications?.hooks?.agentAttention?.timeoutMs).toBe(2500);
+  });
+
+  test("rejects enabled agent attention hook config without a command", () => {
+    const result = PersistedConfigSchema.safeParse({
+      notifications: {
+        hooks: {
+          agentAttention: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts disabled agent attention hook config without a command", () => {
+    const parsed = PersistedConfigSchema.parse({
+      notifications: {
+        hooks: {
+          agentAttention: {
+            enabled: false,
+          },
+        },
+      },
+    });
+
+    expect(parsed.notifications?.hooks?.agentAttention?.enabled).toBe(false);
+  });
+});
+
 describe("PersistedConfigSchema daemon append system prompt", () => {
   test("accepts optional append system prompt", () => {
     const parsed = PersistedConfigSchema.parse({

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -131,6 +131,37 @@ const FeatureVoiceModeSchema = z
   })
   .strict();
 
+const AgentAttentionHookSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    command: z.array(z.string().trim().min(1)).min(1).optional(),
+    timeoutMs: z.number().int().positive().optional(),
+  })
+  .strict()
+  .superRefine((config, ctx) => {
+    if (config.enabled === false) {
+      return;
+    }
+
+    if (!config.command) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Agent attention hook requires a command.",
+      });
+    }
+  });
+
+const NotificationsSchema = z
+  .object({
+    hooks: z
+      .object({
+        agentAttention: AgentAttentionHookSchema.optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
 const BUILTIN_PROVIDER_IDS = ["claude", "codex", "copilot", "opencode", "pi"] as const;
 const PROVIDER_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
 
@@ -285,6 +316,7 @@ export const PersistedConfigSchema = z
       .optional(),
 
     providers: ProvidersSchema.optional(),
+    notifications: NotificationsSchema.optional(),
     agents: z
       .object({
         providers: z.preprocess(normalizeAgentProviders, ProviderOverridesSchema).optional(),

--- a/packages/server/src/server/websocket-server.notifications.test.ts
+++ b/packages/server/src/server/websocket-server.notifications.test.ts
@@ -9,6 +9,7 @@ import type { FileBackedChatService } from "./chat/chat-service.js";
 import type { LoopService } from "./loop-service.js";
 import type { ScheduleService } from "./schedule/service.js";
 import type { CheckoutDiffManager } from "./checkout-diff-manager.js";
+import type { AgentAttentionHookRunner } from "./agent-attention-hooks.js";
 import { asInternals, createStub } from "./test-utils/class-mocks.js";
 import type { PushNotificationSender, PushPayload } from "./push/notifications.js";
 
@@ -72,7 +73,10 @@ class RecordingPushNotificationSender implements PushNotificationSender {
   }
 }
 
-function createServer(agentManagerOverrides?: Record<string, unknown>) {
+function createServer(
+  agentManagerOverrides?: Record<string, unknown>,
+  hookRunner?: AgentAttentionHookRunner,
+) {
   const pushNotifications = new RecordingPushNotificationSender();
   const agentManager = {
     setAgentAttentionCallback: vi.fn(),
@@ -138,6 +142,7 @@ function createServer(agentManagerOverrides?: Record<string, unknown>) {
     undefined,
     undefined,
     pushNotifications,
+    hookRunner,
   );
 
   return { server, agentManager, pushNotifications };
@@ -299,6 +304,68 @@ describe("VoiceAssistantWebSocketServer notification payloads", () => {
 
     expect(readAttentionRequiredMessage(ws).shouldNotify).toBe(false);
     expect(pushNotifications.sent).toHaveLength(1);
+  });
+
+  it("runs the agent attention hook with the same payload as external push", async () => {
+    const runHook = vi.fn(async () => undefined);
+    const { server, pushNotifications } = createServer(
+      {
+        getAgent: vi.fn(() => ({
+          pendingPermissions: new Map([
+            [
+              "permission-1",
+              {
+                id: "permission-1",
+                provider: "codex",
+                name: "question",
+                kind: "question",
+                title: "Need input",
+                description: "Choose an option",
+              },
+            ],
+          ]),
+        })),
+      },
+      createStub<AgentAttentionHookRunner>({
+        run: runHook,
+      }),
+    );
+
+    await asInternals<WebSocketServerInternals>(server).broadcastAgentAttention({
+      agentId: "agent-question",
+      provider: "codex",
+      reason: "permission",
+    });
+
+    expect(pushNotifications.sent).toHaveLength(1);
+    expect(runHook).toHaveBeenCalledWith({
+      agentId: "agent-question",
+      provider: "codex",
+      reason: "permission",
+      notification: pushNotifications.sent[0],
+    });
+  });
+
+  it("does not block in-app attention delivery when the agent attention hook rejects", async () => {
+    const runHook = vi.fn(async () => {
+      throw new Error("hook failed");
+    });
+    const { server } = createServer(
+      undefined,
+      createStub<AgentAttentionHookRunner>({
+        run: runHook,
+      }),
+    );
+    const ws = connectClient(server, null);
+
+    await asInternals<WebSocketServerInternals>(server).broadcastAgentAttention({
+      agentId: "agent-hook-failure",
+      provider: "codex",
+      reason: "finished",
+    });
+
+    expect(readAttentionRequiredMessage(ws).shouldNotify).toBe(false);
+    expect(runHook).toHaveBeenCalledOnce();
   });
 
   it("does not push error attention when the only connected client has never sent a heartbeat", async () => {

--- a/packages/server/src/server/websocket-server.notifications.test.ts
+++ b/packages/server/src/server/websocket-server.notifications.test.ts
@@ -142,6 +142,7 @@ function createServer(
     undefined,
     undefined,
     pushNotifications,
+    undefined,
     hookRunner,
   );
 

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -46,6 +46,7 @@ import type { WorkspaceScriptRuntimeStore } from "./workspace-script-runtime-sto
 import type { SpeechReadinessSnapshot, SpeechService } from "./speech/speech-runtime.js";
 import type { VoiceCallerContext, VoiceSpeakHandler } from "./voice-types.js";
 import { computeNotificationPlan, type ClientPresenceState } from "./agent-attention-policy.js";
+import type { AgentAttentionHookRunner } from "./agent-attention-hooks.js";
 import {
   buildAgentAttentionNotificationPayload,
   findLatestPermissionRequest,
@@ -359,6 +360,7 @@ export class VoiceAssistantWebSocketServer {
   private readonly daemonConfigStore: DaemonConfigStore;
   private readonly pushTokenStore: PushTokenStore;
   private readonly pushNotificationSender: PushNotificationSender;
+  private readonly agentAttentionHookRunner: AgentAttentionHookRunner | undefined;
   private readonly mcpBaseUrl: string | null;
   private speech!: SpeechService | null;
   private terminalManager!: TerminalManager | null;
@@ -438,6 +440,7 @@ export class VoiceAssistantWebSocketServer {
         publicUseTls: boolean;
       };
     },
+    agentAttentionHookRunner?: AgentAttentionHookRunner,
   ) {
     this.logger = logger.child({ module: "websocket-server" });
     this.serverId = serverId;
@@ -517,6 +520,7 @@ export class VoiceAssistantWebSocketServer {
     this.pushTokenStore = new PushTokenStore(pushLogger, join(paseoHome, "push-tokens.json"));
     this.pushNotificationSender =
       pushNotificationSender ?? createPushNotificationSender(pushLogger, this.pushTokenStore);
+    this.agentAttentionHookRunner = agentAttentionHookRunner;
 
     this.agentManager.setAgentAttentionCallback((params) => {
       void this.broadcastAgentAttention(params).catch((err) => {
@@ -1708,6 +1712,16 @@ export class VoiceAssistantWebSocketServer {
       void this.pushNotificationSender.send(notification).catch((err) => {
         this.logger.warn({ err, agentId: params.agentId }, "Failed to send push notification");
       });
+      void this.agentAttentionHookRunner
+        ?.run({
+          agentId: params.agentId,
+          provider: params.provider,
+          reason: params.reason,
+          notification,
+        })
+        .catch((err) => {
+          this.logger.warn({ err, agentId: params.agentId }, "Failed to run agent attention hook");
+        });
     }
 
     for (const [clientIndex, { ws }] of clientEntries.entries()) {

--- a/packages/website/public/schemas/paseo.config.v1.json
+++ b/packages/website/public/schemas/paseo.config.v1.json
@@ -141,6 +141,39 @@
           },
           "additionalProperties": false
         },
+        "notifications": {
+          "type": "object",
+          "properties": {
+            "hooks": {
+              "type": "object",
+              "properties": {
+                "agentAttention": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "command": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "minItems": 1
+                    },
+                    "timeoutMs": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
         "agents": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
## Summary

This replaces the provider-specific ServerChan approach with a generic `notifications.hooks.agentAttention` daemon post-hook.

The hook runs only when the existing agent attention policy decides an external push notification should be sent, so it mirrors the current mobile push decisions instead of introducing a separate notification policy. Paseo writes a JSON payload to the hook process stdin and treats hook failures, non-zero exits, stdin write errors, and timeouts as non-blocking daemon warnings.

ServerChan is documented as a userland hook example rather than built into core.

## Why this shape

- Keeps provider-specific notification services out of Paseo core.
- Reuses the existing external push policy for finished and permission attention events.
- Avoids sending secrets to mobile/web/desktop clients; hook scripts can read provider tokens from their own environment.
- Keeps Expo push and in-app attention delivery independent from hook failures.

## Testing

- `rtk vitest packages/server/src/server/agent-attention-hooks.test.ts --bail=1` -> PASS (6)
- `rtk vitest packages/server/src/server/config-notifications.test.ts packages/server/src/server/persisted-config.test.ts packages/server/src/server/agent-attention-hooks.test.ts -t "agent attention|notifications|hook" --bail=1` -> PASS (9)
- `rtk npm run format:check:files -- CLAUDE.md docs/data-model.md docs/notifications.md packages/server/src/server/agent-attention-hooks.ts packages/server/src/server/agent-attention-hooks.test.ts packages/server/src/server/bootstrap.ts packages/server/src/server/config.ts packages/server/src/server/config-notifications.test.ts packages/server/src/server/persisted-config.ts packages/server/src/server/persisted-config.test.ts packages/server/src/server/websocket-server.ts packages/server/src/server/websocket-server.notifications.test.ts packages/website/public/schemas/paseo.config.v1.json` -> PASS
- `rtk npm run lint -- packages/server/src/server/agent-attention-hooks.ts packages/server/src/server/agent-attention-hooks.test.ts packages/server/src/server/bootstrap.ts packages/server/src/server/config.ts packages/server/src/server/config-notifications.test.ts packages/server/src/server/persisted-config.ts packages/server/src/server/persisted-config.test.ts packages/server/src/server/websocket-server.ts packages/server/src/server/websocket-server.notifications.test.ts` -> PASS

I also tried `rtk npm run typecheck --workspace=@getpaseo/server`, but this local checkout currently fails before this change on missing workspace/dependency declarations such as `@getpaseo/relay/e2ee`, `openai`, `onnxruntime-node`, `node-pty`, plus existing Zod v4 type drift.
