### PR TITLE
fix: pass appBaseUrl to generateLocalPairingOffer in daemon pair RPC

### DIFF
--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -1124,6 +1124,7 @@ export async function createPaseoDaemon(
               {
                 listen: formatListenTarget(boundListenTarget ?? listenTarget),
                 worktreesRoot: config.worktreesRoot,
+                appBaseUrl: config.appBaseUrl,
                 relay: {
                   enabled: relayEnabled,
                   endpoint: relayEndpoint,

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -624,6 +624,7 @@ export interface SessionOptions {
   daemonVersion?: string;
   daemonRuntimeConfig?: {
     listen: string | null;
+    appBaseUrl?: string;
     relay: {
       enabled: boolean;
       endpoint: string;
@@ -3872,6 +3873,7 @@ export class Session {
         relayPublicEndpoint: relay?.publicEndpoint,
         relayUseTls: relay?.useTls,
         relayPublicUseTls: relay?.publicUseTls,
+        appBaseUrl: this.daemonRuntimeConfig?.appBaseUrl,
         includeQr: true,
         logger: this.sessionLogger,
       });

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -352,6 +352,7 @@ export class VoiceAssistantWebSocketServer {
   private readonly daemonRuntimeConfig:
     | {
         listen: string | null;
+        appBaseUrl?: string;
         relay: {
           enabled: boolean;
           endpoint: string;
@@ -447,6 +448,7 @@ export class VoiceAssistantWebSocketServer {
     daemonRuntimeConfig?: {
       listen: string | null;
       worktreesRoot?: string;
+      appBaseUrl?: string;
       relay: {
         enabled: boolean;
         endpoint: string;


### PR DESCRIPTION
Fixes #1186

## Problem

When `app.baseUrl` is configured in `~/.paseo/config.json`, running `paseo daemon pair` always generates a URL starting with `https://app.paseo.sh` instead of the configured value.

## Root Cause

`handleDaemonGetPairingOfferRequest` in `session.ts` calls `generateLocalPairingOffer` without passing `appBaseUrl`, so it always falls back to the hardcoded default:

```typescript
// pairing-offer.ts
const appBaseUrl = args.appBaseUrl ?? "https://app.paseo.sh"; // always this
```

Note: the CLI-side fallback in `pair.js` already passes `config.appBaseUrl` correctly — this bug only affects the RPC path (i.e. when the daemon is running and `daemonStatusRpc` is available).

## Fix

Three small changes:

1. **`session.ts`** — add `appBaseUrl?: string` to the `daemonRuntimeConfig` type and forward it into `generateLocalPairingOffer`
2. **`websocket-server.ts`** — add `appBaseUrl?: string` to the constructor parameter type
3. **`bootstrap.ts`** — pass `config.appBaseUrl` when constructing the `daemonRuntimeConfig` object

## Testing

Set `app.baseUrl` in `~/.paseo/config.json`, restart the daemon, run `paseo daemon pair` — the generated URL now uses the configured base URL.