### PR TITLE
Fix provider binary diagnostics for command overrides

### DIFF
--- a/packages/server/src/server/agent/provider-launch-config.test.ts
+++ b/packages/server/src/server/agent/provider-launch-config.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 
 import {
+  checkProviderLaunchAvailable,
   createProviderEnv,
   migrateProviderSettings,
   ProviderOverrideSchema,
@@ -108,18 +109,16 @@ describe("resolveProviderLaunch", () => {
   test("uses replace override as the spawned command", async () => {
     const binDir = makeTempDir();
     const shim = createExecutable(binDir, "custom-provider");
-    process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
 
-    const launch = await resolveProviderLaunch(
-      { mode: "replace", argv: [shim.command, "--wrapped"] },
-      "provider",
-    );
+    const launch = await resolveProviderLaunch({
+      commandConfig: { mode: "replace", argv: [shim.command, "--wrapped"] },
+      defaultBinary: "provider",
+    });
 
     expect(launch).toEqual({
       command: shim.command,
       args: ["--wrapped"],
       source: "override",
-      resolvedPath: shim.path,
     });
   });
 
@@ -127,16 +126,15 @@ describe("resolveProviderLaunch", () => {
     const binDir = makeTempDir();
     const shim = createExecutable(binDir, "custom-provider", "exit 42\n");
 
-    const launch = await resolveProviderLaunch(
-      { mode: "replace", argv: [shim.path, "--wrapped"] },
-      "provider",
-    );
+    const launch = await resolveProviderLaunch({
+      commandConfig: { mode: "replace", argv: [shim.path, "--wrapped"] },
+      defaultBinary: "provider",
+    });
 
     expect(launch).toEqual({
       command: shim.path,
       args: ["--wrapped"],
       source: "override",
-      resolvedPath: shim.path,
     });
   });
 
@@ -145,16 +143,15 @@ describe("resolveProviderLaunch", () => {
     const binary = createExecutable(binDir, "default-provider");
     process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
 
-    const launch = await resolveProviderLaunch(
-      { mode: "append", args: ["--profile", "work"] },
-      binary.command,
-    );
+    const launch = await resolveProviderLaunch({
+      commandConfig: { mode: "append", args: ["--profile", "work"] },
+      defaultBinary: binary.command,
+    });
 
     expect(launch).toEqual({
-      command: binary.path,
+      command: binary.command,
       args: ["--profile", "work"],
-      source: "path",
-      resolvedPath: binary.path,
+      source: "append",
     });
   });
 
@@ -163,25 +160,57 @@ describe("resolveProviderLaunch", () => {
     const binary = createExecutable(binDir, "default-provider");
     process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
 
-    const launch = await resolveProviderLaunch(undefined, binary.command);
+    const launch = await resolveProviderLaunch({
+      defaultBinary: binary.command,
+    });
 
     expect(launch).toEqual({
-      command: binary.path,
+      command: binary.command,
       args: [],
-      source: "path",
-      resolvedPath: binary.path,
+      source: "default",
     });
   });
 
-  test("reports not_found when the default binary is missing", async () => {
+  test("keeps the default command when the default binary is missing", async () => {
     process.env.PATH = makeTempDir();
 
-    const launch = await resolveProviderLaunch(undefined, "paseo-provider-missing");
+    const launch = await resolveProviderLaunch({
+      defaultBinary: "paseo-provider-missing",
+    });
 
     expect(launch).toEqual({
       command: "paseo-provider-missing",
       args: [],
-      source: "not_found",
+      source: "default",
+    });
+  });
+});
+
+describe("checkProviderLaunchAvailable", () => {
+  test("reports available with a resolved path", async () => {
+    const binDir = makeTempDir();
+    const binary = createExecutable(binDir, "default-provider");
+    process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+
+    const launch = await resolveProviderLaunch({
+      defaultBinary: binary.command,
+    });
+
+    await expect(checkProviderLaunchAvailable(launch)).resolves.toEqual({
+      available: true,
+      resolvedPath: binary.path,
+    });
+  });
+
+  test("reports missing override commands as unavailable", async () => {
+    process.env.PATH = makeTempDir();
+    const launch = await resolveProviderLaunch({
+      commandConfig: { mode: "replace", argv: ["paseo-provider-missing"] },
+      defaultBinary: "provider",
+    });
+
+    await expect(checkProviderLaunchAvailable(launch)).resolves.toEqual({
+      available: false,
       resolvedPath: null,
     });
   });

--- a/packages/server/src/server/agent/provider-launch-config.test.ts
+++ b/packages/server/src/server/agent/provider-launch-config.test.ts
@@ -28,11 +28,21 @@ function makeTempDir(): string {
   return dir;
 }
 
-function createExecutable(dir: string, name: string, body = "echo test-version\n"): string {
-  const file = path.join(dir, name);
-  writeFileSync(file, `#!/bin/sh\n${body}`, "utf8");
+interface TestExecutable {
+  command: string;
+  path: string;
+}
+
+function createExecutable(dir: string, name: string, body = "echo test-version\n"): TestExecutable {
+  const command = process.platform === "win32" ? `${name}.cmd` : name;
+  const file = path.join(dir, command);
+  const contents = process.platform === "win32" ? "@echo test-version\r\n" : `#!/bin/sh\n${body}`;
+  writeFileSync(file, contents, "utf8");
   chmodSync(file, 0o755);
-  return file;
+  return {
+    command,
+    path: file,
+  };
 }
 
 describe("resolveProviderCommandPrefix", () => {
@@ -101,15 +111,15 @@ describe("resolveProviderLaunch", () => {
     process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
 
     const launch = await resolveProviderLaunch(
-      { mode: "replace", argv: ["custom-provider", "--wrapped"] },
+      { mode: "replace", argv: [shim.command, "--wrapped"] },
       "provider",
     );
 
     expect(launch).toEqual({
-      command: "custom-provider",
+      command: shim.command,
       args: ["--wrapped"],
       source: "override",
-      resolvedPath: shim,
+      resolvedPath: shim.path,
     });
   });
 
@@ -118,15 +128,15 @@ describe("resolveProviderLaunch", () => {
     const shim = createExecutable(binDir, "custom-provider", "exit 42\n");
 
     const launch = await resolveProviderLaunch(
-      { mode: "replace", argv: [shim, "--wrapped"] },
+      { mode: "replace", argv: [shim.path, "--wrapped"] },
       "provider",
     );
 
     expect(launch).toEqual({
-      command: shim,
+      command: shim.path,
       args: ["--wrapped"],
       source: "override",
-      resolvedPath: shim,
+      resolvedPath: shim.path,
     });
   });
 
@@ -137,14 +147,14 @@ describe("resolveProviderLaunch", () => {
 
     const launch = await resolveProviderLaunch(
       { mode: "append", args: ["--profile", "work"] },
-      "default-provider",
+      binary.command,
     );
 
     expect(launch).toEqual({
-      command: binary,
+      command: binary.path,
       args: ["--profile", "work"],
       source: "path",
-      resolvedPath: binary,
+      resolvedPath: binary.path,
     });
   });
 
@@ -153,13 +163,13 @@ describe("resolveProviderLaunch", () => {
     const binary = createExecutable(binDir, "default-provider");
     process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
 
-    const launch = await resolveProviderLaunch(undefined, "default-provider");
+    const launch = await resolveProviderLaunch(undefined, binary.command);
 
     expect(launch).toEqual({
-      command: binary,
+      command: binary.path,
       args: [],
       source: "path",
-      resolvedPath: binary,
+      resolvedPath: binary.path,
     });
   });
 

--- a/packages/server/src/server/agent/provider-launch-config.test.ts
+++ b/packages/server/src/server/agent/provider-launch-config.test.ts
@@ -1,25 +1,60 @@
-import { describe, expect, test, vi } from "vitest";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
 
 import {
   createProviderEnv,
   migrateProviderSettings,
   ProviderOverrideSchema,
+  resolveProviderLaunch,
   resolveProviderCommandPrefix,
   type ProviderRuntimeSettings,
 } from "./provider-launch-config.js";
 
+const originalPath = process.env.PATH;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  process.env.PATH = originalPath;
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "paseo-provider-launch-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createExecutable(dir: string, name: string, body = "echo test-version\n"): string {
+  const file = path.join(dir, name);
+  writeFileSync(file, `#!/bin/sh\n${body}`, "utf8");
+  chmodSync(file, 0o755);
+  return file;
+}
+
 describe("resolveProviderCommandPrefix", () => {
   test("uses resolved default command in default mode", async () => {
-    const resolveDefault = vi.fn(() => "/usr/local/bin/claude");
+    let calls = 0;
+    const resolveDefault = () => {
+      calls += 1;
+      return "/usr/local/bin/claude";
+    };
 
     const resolved = await resolveProviderCommandPrefix(undefined, resolveDefault);
 
-    expect(resolveDefault).toHaveBeenCalledTimes(1);
+    expect(calls).toBe(1);
     expect(resolved).toEqual({ command: "/usr/local/bin/claude", args: [] });
   });
 
   test("appends args in append mode", async () => {
-    const resolveDefault = vi.fn(() => "/usr/local/bin/claude");
+    let calls = 0;
+    const resolveDefault = () => {
+      calls += 1;
+      return "/usr/local/bin/claude";
+    };
 
     const resolved = await resolveProviderCommandPrefix(
       {
@@ -29,7 +64,7 @@ describe("resolveProviderCommandPrefix", () => {
       resolveDefault,
     );
 
-    expect(resolveDefault).toHaveBeenCalledTimes(1);
+    expect(calls).toBe(1);
     expect(resolved).toEqual({
       command: "/usr/local/bin/claude",
       args: ["--chrome"],
@@ -37,7 +72,11 @@ describe("resolveProviderCommandPrefix", () => {
   });
 
   test("replaces command in replace mode without resolving default", async () => {
-    const resolveDefault = vi.fn(() => "/usr/local/bin/claude");
+    let calls = 0;
+    const resolveDefault = () => {
+      calls += 1;
+      return "/usr/local/bin/claude";
+    };
 
     const resolved = await resolveProviderCommandPrefix(
       {
@@ -47,10 +86,93 @@ describe("resolveProviderCommandPrefix", () => {
       resolveDefault,
     );
 
-    expect(resolveDefault).not.toHaveBeenCalled();
+    expect(calls).toBe(0);
     expect(resolved).toEqual({
       command: "docker",
       args: ["run", "--rm", "my-wrapper"],
+    });
+  });
+});
+
+describe("resolveProviderLaunch", () => {
+  test("uses replace override as the spawned command", async () => {
+    const binDir = makeTempDir();
+    const shim = createExecutable(binDir, "custom-provider");
+    process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+
+    const launch = await resolveProviderLaunch(
+      { mode: "replace", argv: ["custom-provider", "--wrapped"] },
+      "provider",
+    );
+
+    expect(launch).toEqual({
+      command: "custom-provider",
+      args: ["--wrapped"],
+      source: "override",
+      resolvedPath: shim,
+    });
+  });
+
+  test("keeps an absolute replace override when the path exists", async () => {
+    const binDir = makeTempDir();
+    const shim = createExecutable(binDir, "custom-provider", "exit 42\n");
+
+    const launch = await resolveProviderLaunch(
+      { mode: "replace", argv: [shim, "--wrapped"] },
+      "provider",
+    );
+
+    expect(launch).toEqual({
+      command: shim,
+      args: ["--wrapped"],
+      source: "override",
+      resolvedPath: shim,
+    });
+  });
+
+  test("resolves append mode through the default binary", async () => {
+    const binDir = makeTempDir();
+    const binary = createExecutable(binDir, "default-provider");
+    process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+
+    const launch = await resolveProviderLaunch(
+      { mode: "append", args: ["--profile", "work"] },
+      "default-provider",
+    );
+
+    expect(launch).toEqual({
+      command: binary,
+      args: ["--profile", "work"],
+      source: "path",
+      resolvedPath: binary,
+    });
+  });
+
+  test("resolves the default binary when no override is configured", async () => {
+    const binDir = makeTempDir();
+    const binary = createExecutable(binDir, "default-provider");
+    process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+
+    const launch = await resolveProviderLaunch(undefined, "default-provider");
+
+    expect(launch).toEqual({
+      command: binary,
+      args: [],
+      source: "path",
+      resolvedPath: binary,
+    });
+  });
+
+  test("reports not_found when the default binary is missing", async () => {
+    process.env.PATH = makeTempDir();
+
+    const launch = await resolveProviderLaunch(undefined, "paseo-provider-missing");
+
+    expect(launch).toEqual({
+      command: "paseo-provider-missing",
+      args: [],
+      source: "not_found",
+      resolvedPath: null,
     });
   });
 });

--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 
-import { execFileSync } from "node:child_process";
-import path from "node:path";
-import { isCommandAvailable } from "../../utils/executable.js";
+import { isAbsolute } from "node:path";
+import { executableExists, findExecutable } from "../../utils/executable.js";
 import { createExternalProcessEnv, type ProcessEnvRecord } from "../paseo-env.js";
 import type { AgentProvider } from "./agent-sdk-types.js";
 import { AgentProviderSchema } from "./provider-manifest.js";
@@ -93,27 +92,94 @@ export interface ProviderCommandPrefix {
   args: string[];
 }
 
+export type ProviderLaunchSource = "override" | "path" | "not_found";
+
+export interface ResolvedProviderLaunch {
+  command: string;
+  args: string[];
+  source: ProviderLaunchSource;
+  resolvedPath: string | null;
+}
+
+export interface ProviderLaunchDefault {
+  command: string;
+  resolvePath?: () => Promise<string | null>;
+}
+
+function normalizeLaunchDefault(
+  defaultBinary: string | ProviderLaunchDefault,
+): ProviderLaunchDefault {
+  if (typeof defaultBinary === "string") {
+    return { command: defaultBinary };
+  }
+  return defaultBinary;
+}
+
+async function resolveLaunchPath(command: string): Promise<string | null> {
+  const found = await findExecutable(command);
+  if (found) {
+    return found;
+  }
+  if (isAbsolute(command)) {
+    return executableExists(command);
+  }
+  return null;
+}
+
+async function resolveDefaultLaunchPath(
+  defaultBinary: ProviderLaunchDefault,
+): Promise<string | null> {
+  return defaultBinary.resolvePath
+    ? await defaultBinary.resolvePath()
+    : await resolveLaunchPath(defaultBinary.command);
+}
+
+export async function resolveProviderLaunch(
+  commandConfig: ProviderCommand | undefined,
+  defaultBinary: string | ProviderLaunchDefault,
+): Promise<ResolvedProviderLaunch> {
+  const normalizedDefault = normalizeLaunchDefault(defaultBinary);
+
+  if (commandConfig?.mode === "replace") {
+    const command = commandConfig.argv[0];
+    return {
+      command,
+      args: commandConfig.argv.slice(1),
+      source: "override",
+      resolvedPath: await resolveLaunchPath(command),
+    };
+  }
+
+  const resolvedPath = await resolveDefaultLaunchPath(normalizedDefault);
+  const args = commandConfig?.mode === "append" ? [...(commandConfig.args ?? [])] : [];
+  return {
+    command: resolvedPath ?? normalizedDefault.command,
+    args,
+    source: resolvedPath ? "path" : "not_found",
+    resolvedPath,
+  };
+}
+
 export async function resolveProviderCommandPrefix(
   commandConfig: ProviderCommand | undefined,
   resolveDefaultCommand: () => string | Promise<string>,
 ): Promise<ProviderCommandPrefix> {
-  if (!commandConfig || commandConfig.mode === "default") {
+  if (commandConfig?.mode === "replace") {
+    const launch = await resolveProviderLaunch(commandConfig, "");
     return {
-      command: await resolveDefaultCommand(),
-      args: [],
+      command: launch.command,
+      args: launch.args,
     };
   }
 
-  if (commandConfig.mode === "append") {
-    return {
-      command: await resolveDefaultCommand(),
-      args: [...(commandConfig.args ?? [])],
-    };
-  }
-
+  const defaultCommand = await resolveDefaultCommand();
+  const launch = await resolveProviderLaunch(commandConfig, {
+    command: defaultCommand,
+    resolvePath: async () => defaultCommand,
+  });
   return {
-    command: commandConfig.argv[0],
-    args: commandConfig.argv.slice(1),
+    command: launch.command,
+    args: launch.args,
   };
 }
 
@@ -213,39 +279,22 @@ export function createProviderEnv(options: ProviderEnvOptions = {}): NodeJS.Proc
   return createExternalProcessEnv(spec.baseEnv ?? process.env, spec.envOverlay);
 }
 
-export function findExecutable(name: string): string | null {
-  const trimmed = name.trim();
-  if (!trimmed) return null;
-  if (trimmed.includes("/") || trimmed.includes("\\")) {
-    try {
-      const { existsSync } = require("node:fs");
-      return existsSync(trimmed) ? trimmed : null;
-    } catch {
-      return null;
-    }
-  }
-  try {
-    const cmd = process.platform === "win32" ? "where.exe" : "which";
-    const result = execFileSync(cmd, [trimmed], {
-      encoding: "utf8",
-      env: createProviderEnv({ baseEnv: process.env }),
-      windowsHide: true,
-    }).trim();
-    const lines = result.split(/\r?\n/).filter((l: string) => l.trim());
-    const candidate = lines.at(-1)?.trim() ?? null;
-    return candidate && path.isAbsolute(candidate) ? candidate : null;
-  } catch {
-    return null;
-  }
-}
-
 export async function isProviderCommandAvailable(
   commandConfig: ProviderCommand | undefined,
   resolveDefaultCommand: () => string | Promise<string>,
 ): Promise<boolean> {
   try {
-    const prefix = await resolveProviderCommandPrefix(commandConfig, resolveDefaultCommand);
-    return isCommandAvailable(prefix.command);
+    if (commandConfig?.mode === "replace") {
+      const launch = await resolveProviderLaunch(commandConfig, "");
+      return launch.source !== "not_found";
+    }
+
+    const defaultCommand = await resolveDefaultCommand();
+    const launch = await resolveProviderLaunch(commandConfig, {
+      command: defaultCommand,
+      resolvePath: async () => defaultCommand,
+    });
+    return launch.source !== "not_found";
   } catch {
     return false;
   }

--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -92,12 +92,16 @@ export interface ProviderCommandPrefix {
   args: string[];
 }
 
-export type ProviderLaunchSource = "override" | "path" | "not_found";
+export type ProviderLaunchSource = "default" | "append" | "override";
 
 export interface ResolvedProviderLaunch {
   command: string;
   args: string[];
   source: ProviderLaunchSource;
+}
+
+export interface ProviderLaunchAvailability {
+  available: boolean;
   resolvedPath: string | null;
 }
 
@@ -134,28 +138,46 @@ async function resolveDefaultLaunchPath(
     : await resolveLaunchPath(defaultBinary.command);
 }
 
-export async function resolveProviderLaunch(
-  commandConfig: ProviderCommand | undefined,
-  defaultBinary: string | ProviderLaunchDefault,
-): Promise<ResolvedProviderLaunch> {
-  const normalizedDefault = normalizeLaunchDefault(defaultBinary);
+export interface ResolveProviderLaunchOptions {
+  commandConfig?: ProviderCommand;
+  defaultBinary?: string | ProviderLaunchDefault;
+}
 
+export async function resolveProviderLaunch({
+  commandConfig,
+  defaultBinary,
+}: ResolveProviderLaunchOptions): Promise<ResolvedProviderLaunch> {
   if (commandConfig?.mode === "replace") {
     const command = commandConfig.argv[0];
     return {
       command,
       args: commandConfig.argv.slice(1),
       source: "override",
-      resolvedPath: await resolveLaunchPath(command),
     };
   }
 
-  const resolvedPath = await resolveDefaultLaunchPath(normalizedDefault);
+  if (defaultBinary === undefined) {
+    throw new Error("defaultBinary is required when provider command is not replaced");
+  }
+  const normalizedDefault = normalizeLaunchDefault(defaultBinary);
   const args = commandConfig?.mode === "append" ? [...(commandConfig.args ?? [])] : [];
   return {
-    command: resolvedPath ?? normalizedDefault.command,
+    command: normalizedDefault.command,
     args,
-    source: resolvedPath ? "path" : "not_found",
+    source: commandConfig?.mode === "append" ? "append" : "default",
+  };
+}
+
+export async function checkProviderLaunchAvailable(
+  launch: ResolvedProviderLaunch,
+  defaultBinary?: ProviderLaunchDefault,
+): Promise<ProviderLaunchAvailability> {
+  const resolvedPath =
+    defaultBinary && launch.source !== "override"
+      ? await resolveDefaultLaunchPath(defaultBinary)
+      : await resolveLaunchPath(launch.command);
+  return {
+    available: resolvedPath !== null,
     resolvedPath,
   };
 }
@@ -165,7 +187,9 @@ export async function resolveProviderCommandPrefix(
   resolveDefaultCommand: () => string | Promise<string>,
 ): Promise<ProviderCommandPrefix> {
   if (commandConfig?.mode === "replace") {
-    const launch = await resolveProviderLaunch(commandConfig, "");
+    const launch = await resolveProviderLaunch({
+      commandConfig,
+    });
     return {
       command: launch.command,
       args: launch.args,
@@ -173,9 +197,12 @@ export async function resolveProviderCommandPrefix(
   }
 
   const defaultCommand = await resolveDefaultCommand();
-  const launch = await resolveProviderLaunch(commandConfig, {
-    command: defaultCommand,
-    resolvePath: async () => defaultCommand,
+  const launch = await resolveProviderLaunch({
+    commandConfig,
+    defaultBinary: {
+      command: defaultCommand,
+      resolvePath: async () => defaultCommand,
+    },
   });
   return {
     command: launch.command,
@@ -285,16 +312,21 @@ export async function isProviderCommandAvailable(
 ): Promise<boolean> {
   try {
     if (commandConfig?.mode === "replace") {
-      const launch = await resolveProviderLaunch(commandConfig, "");
-      return launch.source !== "not_found";
+      const launch = await resolveProviderLaunch({
+        commandConfig,
+      });
+      const availability = await checkProviderLaunchAvailable(launch);
+      return availability.available;
     }
 
     const defaultCommand = await resolveDefaultCommand();
-    const launch = await resolveProviderLaunch(commandConfig, {
+    const defaultBinary = {
       command: defaultCommand,
       resolvePath: async () => defaultCommand,
-    });
-    return launch.source !== "not_found";
+    };
+    const launch = await resolveProviderLaunch({ commandConfig, defaultBinary });
+    const availability = await checkProviderLaunchAvailable(launch, defaultBinary);
+    return availability.available;
   } catch {
     return false;
   }

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -87,6 +87,7 @@ import {
   type ToolCallTimelineItem,
 } from "../agent-sdk-types.js";
 import {
+  checkProviderLaunchAvailable,
   createProviderEnvSpec,
   resolveProviderLaunch,
   type ProviderRuntimeSettings,
@@ -861,11 +862,12 @@ export class ACPAgentClient implements AgentClient {
   }
 
   protected async resolveLaunchCommand(): Promise<{ command: string; args: string[] }> {
-    const prefix = await resolveProviderLaunch(
-      this.runtimeSettings?.command,
-      this.defaultCommand[0],
-    );
-    if (prefix.source === "not_found") {
+    const prefix = await resolveProviderLaunch({
+      commandConfig: this.runtimeSettings?.command,
+      defaultBinary: this.defaultCommand[0],
+    });
+    const availability = await checkProviderLaunchAvailable(prefix);
+    if (!availability.available) {
       throw new Error(`${this.provider} command '${this.defaultCommand[0]}' not found`);
     }
     return {
@@ -1806,11 +1808,12 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private async spawnProcess(): Promise<SpawnedACPProcess> {
-    const prefix = await resolveProviderLaunch(
-      this.runtimeSettings?.command,
-      this.defaultCommand[0],
-    );
-    if (prefix.source === "not_found") {
+    const prefix = await resolveProviderLaunch({
+      commandConfig: this.runtimeSettings?.command,
+      defaultBinary: this.defaultCommand[0],
+    });
+    const availability = await checkProviderLaunchAvailable(prefix);
+    if (!availability.available) {
       throw new Error(`${this.provider} command '${this.defaultCommand[0]}' not found`);
     }
 

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -88,12 +88,11 @@ import {
 } from "../agent-sdk-types.js";
 import {
   createProviderEnvSpec,
-  resolveProviderCommandPrefix,
+  resolveProviderLaunch,
   type ProviderRuntimeSettings,
 } from "../provider-launch-config.js";
 import { renderPromptAttachmentAsText } from "../prompt-attachments.js";
 import { appendOrReplaceGrowingAssistantMessage, runProviderTurn } from "./provider-runner.js";
-import { findExecutable } from "../../../utils/executable.js";
 import { platformShell, spawnProcess } from "../../../utils/spawn.js";
 
 function assertChildWithPipes(
@@ -862,13 +861,13 @@ export class ACPAgentClient implements AgentClient {
   }
 
   protected async resolveLaunchCommand(): Promise<{ command: string; args: string[] }> {
-    const resolved = await findExecutable(this.defaultCommand[0]);
-    const prefix = await resolveProviderCommandPrefix(this.runtimeSettings?.command, () => {
-      if (!resolved) {
-        throw new Error(`${this.provider} command '${this.defaultCommand[0]}' not found`);
-      }
-      return resolved;
-    });
+    const prefix = await resolveProviderLaunch(
+      this.runtimeSettings?.command,
+      this.defaultCommand[0],
+    );
+    if (prefix.source === "not_found") {
+      throw new Error(`${this.provider} command '${this.defaultCommand[0]}' not found`);
+    }
     return {
       command: prefix.command,
       args: [...prefix.args, ...this.defaultCommand.slice(1)],
@@ -1807,13 +1806,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private async spawnProcess(): Promise<SpawnedACPProcess> {
-    const resolved = await findExecutable(this.defaultCommand[0]);
-    const prefix = await resolveProviderCommandPrefix(this.runtimeSettings?.command, () => {
-      if (!resolved) {
-        throw new Error(`${this.provider} command '${this.defaultCommand[0]}' not found`);
-      }
-      return resolved;
-    });
+    const prefix = await resolveProviderLaunch(
+      this.runtimeSettings?.command,
+      this.defaultCommand[0],
+    );
+    if (prefix.source === "not_found") {
+      throw new Error(`${this.provider} command '${this.defaultCommand[0]}' not found`);
+    }
 
     const command = prefix.command;
     const args = [...prefix.args, ...this.defaultCommand.slice(1)];

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -76,6 +76,7 @@ import {
   type PersistedAgentDescriptor,
 } from "../../agent-sdk-types.js";
 import {
+  checkProviderLaunchAvailable,
   createProviderEnv,
   createProviderEnvSpec,
   resolveProviderLaunch,
@@ -1337,16 +1338,25 @@ export class ClaudeAgentClient implements AgentClient {
   }
 
   async isAvailable(): Promise<boolean> {
-    return (
-      (await resolveProviderLaunch(this.runtimeSettings?.command, "claude")).source !== "not_found"
-    );
+    const launch = await resolveProviderLaunch({
+      commandConfig: this.runtimeSettings?.command,
+      defaultBinary: "claude",
+    });
+    const availability = await checkProviderLaunchAvailable(launch);
+    return availability.available;
   }
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
     try {
-      const launch = await resolveProviderLaunch(this.runtimeSettings?.command, "claude");
-      const available = await this.isAvailable();
-      const auth = available ? await resolveClaudeAuth(launch, this.runtimeSettings) : null;
+      const launch = await resolveProviderLaunch({
+        commandConfig: this.runtimeSettings?.command,
+        defaultBinary: "claude",
+      });
+      const availability = await checkProviderLaunchAvailable(launch);
+      const available = availability.available;
+      const auth = available
+        ? await resolveClaudeAuth(launch, availability, this.runtimeSettings)
+        : null;
       let modelsValue = "Not checked";
       let status = formatDiagnosticStatus(available);
 
@@ -1368,7 +1378,7 @@ export class ClaudeAgentClient implements AgentClient {
 
       return {
         diagnostic: formatProviderDiagnostic("Claude Code", [
-          ...(await buildBinaryDiagnosticRows(launch)),
+          ...(await buildBinaryDiagnosticRows(launch, availability)),
           ...(auth ? [{ label: "Auth", value: auth }] : []),
           { label: "Models", value: modelsValue },
           { label: "Status", value: status },
@@ -1390,9 +1400,13 @@ export class ClaudeAgentClient implements AgentClient {
 }
 
 async function resolveClaudeBinary(runtimeSettings?: ProviderRuntimeSettings): Promise<string> {
-  const launch = await resolveProviderLaunch(runtimeSettings?.command, "claude");
-  if (launch.source !== "not_found") {
-    return launch.command;
+  const launch = await resolveProviderLaunch({
+    commandConfig: runtimeSettings?.command,
+    defaultBinary: "claude",
+  });
+  const availability = await checkProviderLaunchAvailable(launch);
+  if (availability.available) {
+    return availability.resolvedPath ?? launch.command;
   }
   throw new Error(
     "Claude binary not found. Install Claude Code (https://github.com/anthropics/claude-code) and ensure it is available in your shell PATH.",
@@ -1401,6 +1415,7 @@ async function resolveClaudeBinary(runtimeSettings?: ProviderRuntimeSettings): P
 
 async function resolveClaudeAuth(
   launch: ResolvedProviderLaunch,
+  availability: { resolvedPath: string | null },
   runtimeSettings?: ProviderRuntimeSettings,
 ): Promise<string | null> {
   const run = async (
@@ -1422,10 +1437,7 @@ async function resolveClaudeAuth(
   };
 
   try {
-    if (launch.source === "not_found") {
-      return null;
-    }
-    const executable = launch.resolvedPath ?? launch.command;
+    const executable = availability.resolvedPath ?? launch.command;
     const result = await run(executable, [...launch.args, "auth", "status"]);
 
     const combined = [result.stdout, result.stderr]

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -33,6 +33,7 @@ import { getClaudeModelsWithSettings, normalizeClaudeRuntimeModelId } from "./mo
 import { parsePartialJsonObject } from "./partial-json.js";
 import { ClaudeSidechainTracker } from "./sidechain-tracker.js";
 import {
+  buildBinaryDiagnosticRows,
   formatDiagnosticStatus,
   formatProviderDiagnostic,
   formatProviderDiagnosticError,
@@ -77,9 +78,10 @@ import {
 import {
   createProviderEnv,
   createProviderEnvSpec,
+  resolveProviderLaunch,
   type ProviderRuntimeSettings,
+  type ResolvedProviderLaunch,
 } from "../../provider-launch-config.js";
-import { findExecutable, isCommandAvailable } from "../../../../utils/executable.js";
 import { withTimeout } from "../../../../utils/promise-timeout.js";
 import { execCommand } from "../../../../utils/spawn.js";
 import { composeSystemPromptParts } from "../../system-prompt.js";
@@ -1335,19 +1337,16 @@ export class ClaudeAgentClient implements AgentClient {
   }
 
   async isAvailable(): Promise<boolean> {
-    const command = this.runtimeSettings?.command;
-    if (command?.mode === "replace") {
-      return await isCommandAvailable(command.argv[0]);
-    }
-    return await isCommandAvailable("claude");
+    return (
+      (await resolveProviderLaunch(this.runtimeSettings?.command, "claude")).source !== "not_found"
+    );
   }
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
     try {
-      const resolvedBinary = (await findExecutable("claude")) ?? "not found";
+      const launch = await resolveProviderLaunch(this.runtimeSettings?.command, "claude");
       const available = await this.isAvailable();
-      const version = await resolveClaudeVersion(this.runtimeSettings);
-      const auth = available ? await resolveClaudeAuth(this.runtimeSettings) : null;
+      const auth = available ? await resolveClaudeAuth(launch, this.runtimeSettings) : null;
       let modelsValue = "Not checked";
       let status = formatDiagnosticStatus(available);
 
@@ -1369,8 +1368,7 @@ export class ClaudeAgentClient implements AgentClient {
 
       return {
         diagnostic: formatProviderDiagnostic("Claude Code", [
-          { label: "Binary", value: resolvedBinary },
-          ...(version ? [{ label: "Version", value: version }] : []),
+          ...(await buildBinaryDiagnosticRows(launch)),
           ...(auth ? [{ label: "Auth", value: auth }] : []),
           { label: "Models", value: modelsValue },
           { label: "Status", value: status },
@@ -1392,59 +1390,19 @@ export class ClaudeAgentClient implements AgentClient {
 }
 
 async function resolveClaudeBinary(runtimeSettings?: ProviderRuntimeSettings): Promise<string> {
-  const command = runtimeSettings?.command;
-  if (command?.mode === "replace") {
-    const foundOverride = await findExecutable(command.argv[0]);
-    if (foundOverride) {
-      return foundOverride;
-    }
-  }
-
-  const found = await findExecutable("claude");
-  if (found) {
-    return found;
+  const launch = await resolveProviderLaunch(runtimeSettings?.command, "claude");
+  if (launch.source !== "not_found") {
+    return launch.command;
   }
   throw new Error(
     "Claude binary not found. Install Claude Code (https://github.com/anthropics/claude-code) and ensure it is available in your shell PATH.",
   );
 }
 
-async function resolveClaudeVersion(
-  runtimeSettings?: ProviderRuntimeSettings,
-): Promise<string | null> {
-  const command = runtimeSettings?.command;
-  const envSpec = createProviderEnvSpec({ runtimeSettings });
-
-  try {
-    if (command?.mode === "replace") {
-      const { stdout } = await execCommand(
-        command.argv[0],
-        [...command.argv.slice(1), "--version"],
-        { ...envSpec, timeout: 5_000 },
-      );
-      return stdout.trim() || null;
-    }
-
-    const executable = await findExecutable("claude");
-    if (!executable) {
-      return null;
-    }
-
-    const { stdout } = await execCommand(executable, ["--version"], {
-      ...envSpec,
-      timeout: 5_000,
-    });
-    return stdout.trim() || null;
-  } catch {
-    return null;
-  }
-}
-
 async function resolveClaudeAuth(
+  launch: ResolvedProviderLaunch,
   runtimeSettings?: ProviderRuntimeSettings,
 ): Promise<string | null> {
-  const command = runtimeSettings?.command;
-
   const run = async (
     executable: string,
     args: string[],
@@ -1464,16 +1422,11 @@ async function resolveClaudeAuth(
   };
 
   try {
-    let result: { stdout: string; stderr: string };
-    if (command?.mode === "replace") {
-      result = await run(command.argv[0], [...command.argv.slice(1), "auth", "status"]);
-    } else {
-      const executable = await findExecutable("claude");
-      if (!executable) {
-        return null;
-      }
-      result = await run(executable, ["auth", "status"]);
+    if (launch.source === "not_found") {
+      return null;
     }
+    const executable = launch.resolvedPath ?? launch.command;
+    const result = await run(executable, [...launch.args, "auth", "status"]);
 
     const combined = [result.stdout, result.stderr]
       .map((s) => s.trim())

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -50,10 +50,11 @@ import {
 import {
   createProviderEnv,
   createProviderEnvSpec,
-  resolveProviderCommandPrefix,
+  resolveProviderLaunch,
   type ProviderRuntimeSettings,
+  type ResolvedProviderLaunch,
 } from "../provider-launch-config.js";
-import { findExecutable, isCommandAvailable, probeExecutable } from "../../../utils/executable.js";
+import { findExecutable, probeExecutable } from "../../../utils/executable.js";
 import { createPathEquivalenceMatcher } from "../../../utils/path.js";
 import { spawnProcess } from "../../../utils/spawn.js";
 import { extractCodexTerminalSessionId, nonEmptyString } from "./tool-call-mapper-utils.js";
@@ -78,6 +79,7 @@ import {
   formatDiagnosticStatus,
   formatProviderDiagnostic,
   formatProviderDiagnosticError,
+  buildBinaryDiagnosticRows,
   resolveBinaryVersion,
   toDiagnosticErrorMessage,
 } from "./diagnostic-utils.js";
@@ -441,21 +443,29 @@ export async function findDefaultCodexBinary(): Promise<string | null> {
   return (await findExecutable("codex")) ?? (await findCodexMicrosoftStoreBinary());
 }
 
-async function resolveCodexBinary(): Promise<string> {
-  const found = await findDefaultCodexBinary();
-  if (found) {
-    return found;
-  }
-  throw new Error(
-    "Codex binary not found. Install the Codex CLI (https://github.com/openai/codex) and ensure it is available in your shell PATH.",
-  );
-}
-
 async function resolveCodexLaunchPrefix(runtimeSettings?: ProviderRuntimeSettings): Promise<{
   command: string;
   args: string[];
 }> {
-  return resolveProviderCommandPrefix(runtimeSettings?.command, resolveCodexBinary);
+  const launch = await resolveCodexLaunch(runtimeSettings);
+  if (launch.source === "not_found") {
+    throw new Error(
+      "Codex binary not found. Install the Codex CLI (https://github.com/openai/codex) and ensure it is available in your shell PATH.",
+    );
+  }
+  return {
+    command: launch.command,
+    args: launch.args,
+  };
+}
+
+async function resolveCodexLaunch(
+  runtimeSettings?: ProviderRuntimeSettings,
+): Promise<ResolvedProviderLaunch> {
+  return resolveProviderLaunch(runtimeSettings?.command, {
+    command: "codex",
+    resolvePath: findDefaultCodexBinary,
+  });
 }
 
 function resolveCodexHomeDir(): string {
@@ -5570,26 +5580,15 @@ export class CodexAppServerAgentClient implements AgentClient {
   }
 
   async isAvailable(): Promise<boolean> {
-    const command = this.runtimeSettings?.command;
-    if (command?.mode === "replace") {
-      return await isCommandAvailable(command.argv[0]);
-    }
-    return (await findDefaultCodexBinary()) !== null;
+    return (await resolveCodexLaunch(this.runtimeSettings)).source !== "not_found";
   }
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
     try {
+      const launch = await resolveCodexLaunch(this.runtimeSettings);
       const available = await this.isAvailable();
-      const resolvedBinary = await findDefaultCodexBinary();
       const entries: Array<{ label: string; value: string }> = [
-        {
-          label: "Binary",
-          value: resolvedBinary ?? "not found",
-        },
-        {
-          label: "Version",
-          value: resolvedBinary ? await resolveBinaryVersion(resolvedBinary) : "unknown",
-        },
+        ...(await buildBinaryDiagnosticRows(launch)),
       ];
       let status = formatDiagnosticStatus(available);
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -48,6 +48,7 @@ import {
   mapCodexToolCallFromThreadItem,
 } from "./codex/tool-call-mapper.js";
 import {
+  checkProviderLaunchAvailable,
   createProviderEnv,
   createProviderEnvSpec,
   resolveProviderLaunch,
@@ -448,13 +449,15 @@ async function resolveCodexLaunchPrefix(runtimeSettings?: ProviderRuntimeSetting
   args: string[];
 }> {
   const launch = await resolveCodexLaunch(runtimeSettings);
-  if (launch.source === "not_found") {
+  const availability = await checkCodexLaunchAvailable(launch);
+  if (!availability.available) {
     throw new Error(
       "Codex binary not found. Install the Codex CLI (https://github.com/openai/codex) and ensure it is available in your shell PATH.",
     );
   }
   return {
-    command: launch.command,
+    command:
+      launch.source === "override" ? launch.command : (availability.resolvedPath ?? launch.command),
     args: launch.args,
   };
 }
@@ -462,7 +465,17 @@ async function resolveCodexLaunchPrefix(runtimeSettings?: ProviderRuntimeSetting
 async function resolveCodexLaunch(
   runtimeSettings?: ProviderRuntimeSettings,
 ): Promise<ResolvedProviderLaunch> {
-  return resolveProviderLaunch(runtimeSettings?.command, {
+  return resolveProviderLaunch({
+    commandConfig: runtimeSettings?.command,
+    defaultBinary: {
+      command: "codex",
+      resolvePath: findDefaultCodexBinary,
+    },
+  });
+}
+
+async function checkCodexLaunchAvailable(launch: ResolvedProviderLaunch) {
+  return checkProviderLaunchAvailable(launch, {
     command: "codex",
     resolvePath: findDefaultCodexBinary,
   });
@@ -5580,15 +5593,18 @@ export class CodexAppServerAgentClient implements AgentClient {
   }
 
   async isAvailable(): Promise<boolean> {
-    return (await resolveCodexLaunch(this.runtimeSettings)).source !== "not_found";
+    const launch = await resolveCodexLaunch(this.runtimeSettings);
+    const availability = await checkCodexLaunchAvailable(launch);
+    return availability.available;
   }
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
     try {
       const launch = await resolveCodexLaunch(this.runtimeSettings);
-      const available = await this.isAvailable();
+      const availability = await checkCodexLaunchAvailable(launch);
+      const available = availability.available;
       const entries: Array<{ label: string; value: string }> = [
-        ...(await buildBinaryDiagnosticRows(launch)),
+        ...(await buildBinaryDiagnosticRows(launch, availability)),
       ];
       let status = formatDiagnosticStatus(available);
 

--- a/packages/server/src/server/agent/providers/copilot-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/copilot-acp-agent.ts
@@ -3,8 +3,7 @@ import { homedir } from "node:os";
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 
 import type { AgentCapabilityFlags, AgentMode } from "../agent-sdk-types.js";
-import type { ProviderRuntimeSettings } from "../provider-launch-config.js";
-import { findExecutable } from "../../../utils/executable.js";
+import { resolveProviderLaunch, type ProviderRuntimeSettings } from "../provider-launch-config.js";
 import {
   ACPAgentClient,
   type ACPBeforeModeWriteResult,
@@ -16,7 +15,7 @@ import {
   formatDiagnosticStatus,
   formatProviderDiagnostic,
   formatProviderDiagnosticError,
-  resolveBinaryVersion,
+  buildBinaryDiagnosticRows,
   toDiagnosticErrorMessage,
 } from "./diagnostic-utils.js";
 
@@ -88,8 +87,8 @@ export class CopilotACPAgentClient extends ACPAgentClient {
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
     try {
+      const launch = await resolveProviderLaunch(this.runtimeSettings?.command, "copilot");
       const available = await this.isAvailable();
-      const resolvedBinary = await findExecutable("copilot");
       let modelsValue = "Not checked";
       let status = formatDiagnosticStatus(available);
 
@@ -119,14 +118,7 @@ export class CopilotACPAgentClient extends ACPAgentClient {
 
       return {
         diagnostic: formatProviderDiagnostic("Copilot", [
-          {
-            label: "Binary",
-            value: resolvedBinary ?? "not found",
-          },
-          {
-            label: "Version",
-            value: resolvedBinary ? await resolveBinaryVersion(resolvedBinary) : "unknown",
-          },
+          ...(await buildBinaryDiagnosticRows(launch)),
           { label: "Models", value: modelsValue },
           { label: "Status", value: status },
         ]),

--- a/packages/server/src/server/agent/providers/copilot-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/copilot-acp-agent.ts
@@ -3,7 +3,11 @@ import { homedir } from "node:os";
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 
 import type { AgentCapabilityFlags, AgentMode } from "../agent-sdk-types.js";
-import { resolveProviderLaunch, type ProviderRuntimeSettings } from "../provider-launch-config.js";
+import {
+  checkProviderLaunchAvailable,
+  resolveProviderLaunch,
+  type ProviderRuntimeSettings,
+} from "../provider-launch-config.js";
 import {
   ACPAgentClient,
   type ACPBeforeModeWriteResult,
@@ -87,8 +91,12 @@ export class CopilotACPAgentClient extends ACPAgentClient {
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
     try {
-      const launch = await resolveProviderLaunch(this.runtimeSettings?.command, "copilot");
-      const available = await this.isAvailable();
+      const launch = await resolveProviderLaunch({
+        commandConfig: this.runtimeSettings?.command,
+        defaultBinary: "copilot",
+      });
+      const availability = await checkProviderLaunchAvailable(launch);
+      const available = availability.available;
       let modelsValue = "Not checked";
       let status = formatDiagnosticStatus(available);
 
@@ -118,7 +126,7 @@ export class CopilotACPAgentClient extends ACPAgentClient {
 
       return {
         diagnostic: formatProviderDiagnostic("Copilot", [
-          ...(await buildBinaryDiagnosticRows(launch)),
+          ...(await buildBinaryDiagnosticRows(launch, availability)),
           { label: "Models", value: modelsValue },
           { label: "Status", value: status },
         ]),

--- a/packages/server/src/server/agent/providers/diagnostic-utils.ts
+++ b/packages/server/src/server/agent/providers/diagnostic-utils.ts
@@ -1,5 +1,6 @@
 import {
   createProviderEnvSpec,
+  type ProviderLaunchAvailability,
   type ProviderRuntimeSettings,
   type ResolvedProviderLaunch,
 } from "../provider-launch-config.js";
@@ -167,22 +168,28 @@ async function resolveCommandVersion(invocation: BinaryDiagnosticVersionCommand)
 
 export async function buildBinaryDiagnosticRows(
   launch: ResolvedProviderLaunch,
+  availability: ProviderLaunchAvailability,
   options: BinaryDiagnosticRowsOptions = {},
 ): Promise<DiagnosticEntry[]> {
   const defaultBinaryLabel = launch.source === "override" ? "Binary (override)" : "Binary";
   const binaryLabel = options.binaryLabel ?? defaultBinaryLabel;
-  const versionCommand =
-    launch.source === "not_found" ? null : (launch.resolvedPath ?? launch.command);
   let version = "unknown";
-  if (options.versionCommand) {
+  if (options.versionCommand && availability.available) {
     version = await resolveCommandVersion(options.versionCommand);
-  } else if (versionCommand) {
-    version = await resolveBinaryVersion(versionCommand);
+  } else if (availability.available) {
+    version = await resolveCommandVersion({
+      command: availability.resolvedPath ?? launch.command,
+      args: [...launch.args, "--version"],
+    });
   }
   return [
     {
       label: binaryLabel,
-      value: launch.source === "not_found" ? "not found" : launch.command,
+      value: launch.command,
+    },
+    {
+      label: "Resolved path",
+      value: availability.resolvedPath ?? "not found",
     },
     {
       label: "Version",

--- a/packages/server/src/server/agent/providers/diagnostic-utils.ts
+++ b/packages/server/src/server/agent/providers/diagnostic-utils.ts
@@ -1,7 +1,11 @@
-import { createProviderEnvSpec, type ProviderRuntimeSettings } from "../provider-launch-config.js";
+import {
+  createProviderEnvSpec,
+  type ProviderRuntimeSettings,
+  type ResolvedProviderLaunch,
+} from "../provider-launch-config.js";
 import { execCommand } from "../../../utils/spawn.js";
 
-interface DiagnosticEntry {
+export interface DiagnosticEntry {
   label: string;
   value: string;
 }
@@ -136,6 +140,55 @@ export async function resolveBinaryVersion(binaryPath: string): Promise<string> 
   } catch (error) {
     return `error: ${toDiagnosticErrorMessage(error)}`;
   }
+}
+
+export interface BinaryDiagnosticVersionCommand {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+export interface BinaryDiagnosticRowsOptions {
+  binaryLabel?: string;
+  versionCommand?: BinaryDiagnosticVersionCommand;
+}
+
+async function resolveCommandVersion(invocation: BinaryDiagnosticVersionCommand): Promise<string> {
+  try {
+    const { stdout, stderr } = await execCommand(invocation.command, invocation.args, {
+      ...createProviderEnvSpec({ runtimeSettings: { env: invocation.env } }),
+      timeout: 5_000,
+    });
+    return stdout.trim() || stderr.trim() || "unknown";
+  } catch (error) {
+    return `error: ${toDiagnosticErrorMessage(error)}`;
+  }
+}
+
+export async function buildBinaryDiagnosticRows(
+  launch: ResolvedProviderLaunch,
+  options: BinaryDiagnosticRowsOptions = {},
+): Promise<DiagnosticEntry[]> {
+  const defaultBinaryLabel = launch.source === "override" ? "Binary (override)" : "Binary";
+  const binaryLabel = options.binaryLabel ?? defaultBinaryLabel;
+  const versionCommand =
+    launch.source === "not_found" ? null : (launch.resolvedPath ?? launch.command);
+  let version = "unknown";
+  if (options.versionCommand) {
+    version = await resolveCommandVersion(options.versionCommand);
+  } else if (versionCommand) {
+    version = await resolveBinaryVersion(versionCommand);
+  }
+  return [
+    {
+      label: binaryLabel,
+      value: launch.source === "not_found" ? "not found" : launch.command,
+    },
+    {
+      label: "Version",
+      value: version,
+    },
+  ];
 }
 
 export function formatConfiguredCommand(

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -1,10 +1,8 @@
 import { homedir } from "node:os";
 import type { Logger } from "pino";
 
-import { findExecutable, isCommandAvailable } from "../../../utils/executable.js";
-import { execCommand } from "../../../utils/spawn.js";
 import type { AgentProvider } from "../agent-sdk-types.js";
-import { createProviderEnvSpec } from "../provider-launch-config.js";
+import { resolveProviderLaunch } from "../provider-launch-config.js";
 import {
   ACPAgentClient,
   deriveModelDefinitionsFromACP,
@@ -15,6 +13,7 @@ import {
   formatDiagnosticStatus,
   formatProviderDiagnostic,
   formatProviderDiagnosticError,
+  buildBinaryDiagnosticRows,
   toDiagnosticErrorMessage,
 } from "./diagnostic-utils.js";
 
@@ -61,15 +60,15 @@ export class GenericACPAgentClient extends ACPAgentClient {
   }
 
   override async isAvailable(): Promise<boolean> {
-    return isCommandAvailable(this.command[0]);
+    return (await this.resolveConfiguredLaunch()).source !== "not_found";
   }
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
     const providerName = formatProviderName(this.label, this.providerId);
 
     try {
-      const resolvedBinary = await findExecutable(this.command[0]);
-      const available = resolvedBinary !== null;
+      const launch = await this.resolveConfiguredLaunch();
+      const available = launch.source !== "not_found";
       const versionProbe = buildVersionProbeCommand(this.command);
       const probeResult = available
         ? await this.runDiagnosticACPProbe()
@@ -85,16 +84,17 @@ export class GenericACPAgentClient extends ACPAgentClient {
         diagnostic: formatProviderDiagnostic(providerName, [
           { label: "Provider ID", value: this.providerId ?? "unknown" },
           { label: "Configured command", value: this.command.join(" ") },
-          { label: "Launcher binary", value: resolvedBinary ?? "not found" },
+          ...(await buildBinaryDiagnosticRows(launch, {
+            binaryLabel: "Launcher binary",
+            versionCommand: {
+              command: versionProbe.command,
+              args: versionProbe.args,
+              env: this.runtimeSettings?.env,
+            },
+          })),
           {
             label: "Version command",
             value: formatCommand(versionProbe.command, versionProbe.args),
-          },
-          {
-            label: "Version",
-            value: resolvedBinary
-              ? await resolveCommandVersion(versionProbe, this.runtimeSettings?.env)
-              : "unknown",
           },
           { label: "ACP initialize", value: probeResult.initialize },
           { label: "ACP session/new", value: probeResult.session },
@@ -108,6 +108,10 @@ export class GenericACPAgentClient extends ACPAgentClient {
         diagnostic: formatProviderDiagnosticError(providerName, error),
       };
     }
+  }
+
+  private async resolveConfiguredLaunch() {
+    return resolveProviderLaunch({ mode: "replace", argv: this.command }, this.command[0]);
   }
 
   private async runDiagnosticACPProbe(): Promise<ACPDiagnosticProbeResult> {
@@ -275,21 +279,6 @@ function formatProbeError(currentValue: string, error: unknown): string {
     return currentValue;
   }
   return `Error - ${toDiagnosticErrorMessage(error)}`;
-}
-
-async function resolveCommandVersion(
-  invocation: CommandInvocation,
-  env: Record<string, string> | undefined,
-): Promise<string> {
-  try {
-    const { stdout, stderr } = await execCommand(invocation.command, invocation.args, {
-      ...createProviderEnvSpec({ runtimeSettings: { env } }),
-      timeout: 5_000,
-    });
-    return stdout.trim() || stderr.trim() || "unknown";
-  } catch (error) {
-    return `error: ${toDiagnosticErrorMessage(error)}`;
-  }
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import type { Logger } from "pino";
 
 import type { AgentProvider } from "../agent-sdk-types.js";
-import { resolveProviderLaunch } from "../provider-launch-config.js";
+import { checkProviderLaunchAvailable, resolveProviderLaunch } from "../provider-launch-config.js";
 import {
   ACPAgentClient,
   deriveModelDefinitionsFromACP,
@@ -60,7 +60,9 @@ export class GenericACPAgentClient extends ACPAgentClient {
   }
 
   override async isAvailable(): Promise<boolean> {
-    return (await this.resolveConfiguredLaunch()).source !== "not_found";
+    const launch = await this.resolveConfiguredLaunch();
+    const availability = await checkProviderLaunchAvailable(launch);
+    return availability.available;
   }
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
@@ -68,7 +70,8 @@ export class GenericACPAgentClient extends ACPAgentClient {
 
     try {
       const launch = await this.resolveConfiguredLaunch();
-      const available = launch.source !== "not_found";
+      const availability = await checkProviderLaunchAvailable(launch);
+      const available = availability.available;
       const versionProbe = buildVersionProbeCommand(this.command);
       const probeResult = available
         ? await this.runDiagnosticACPProbe()
@@ -84,7 +87,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
         diagnostic: formatProviderDiagnostic(providerName, [
           { label: "Provider ID", value: this.providerId ?? "unknown" },
           { label: "Configured command", value: this.command.join(" ") },
-          ...(await buildBinaryDiagnosticRows(launch, {
+          ...(await buildBinaryDiagnosticRows(launch, availability, {
             binaryLabel: "Launcher binary",
             versionCommand: {
               command: versionProbe.command,
@@ -111,7 +114,10 @@ export class GenericACPAgentClient extends ACPAgentClient {
   }
 
   private async resolveConfiguredLaunch() {
-    return resolveProviderLaunch({ mode: "replace", argv: this.command }, this.command[0]);
+    return resolveProviderLaunch({
+      commandConfig: { mode: "replace", argv: this.command },
+      defaultBinary: this.command[0],
+    });
   }
 
   private async runDiagnosticACPProbe(): Promise<ACPDiagnosticProbeResult> {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -46,6 +46,7 @@ import {
   type ToolCallTimelineItem,
 } from "../agent-sdk-types.js";
 import {
+  checkProviderLaunchAvailable,
   createProviderEnvSpec,
   resolveProviderLaunch,
   type ProviderRuntimeSettings,
@@ -1394,16 +1395,22 @@ export class OpenCodeAgentClient implements AgentClient {
   }
 
   async isAvailable(): Promise<boolean> {
-    return (
-      (await resolveProviderLaunch(this.runtimeSettings?.command, "opencode")).source !==
-      "not_found"
-    );
+    const launch = await resolveProviderLaunch({
+      commandConfig: this.runtimeSettings?.command,
+      defaultBinary: "opencode",
+    });
+    const availability = await checkProviderLaunchAvailable(launch);
+    return availability.available;
   }
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
     try {
-      const launch = await resolveProviderLaunch(this.runtimeSettings?.command, "opencode");
-      const available = await this.isAvailable();
+      const launch = await resolveProviderLaunch({
+        commandConfig: this.runtimeSettings?.command,
+        defaultBinary: "opencode",
+      });
+      const availability = await checkProviderLaunchAvailable(launch);
+      const available = availability.available;
       let serverStatus = "Not running";
       let modelsValue = "Not checked";
       let status = formatDiagnosticStatus(available);
@@ -1416,14 +1423,19 @@ export class OpenCodeAgentClient implements AgentClient {
       }
 
       let authValue = "Not checked";
-      const authCommand =
-        launch.source === "not_found" ? null : (launch.resolvedPath ?? launch.command);
+      const authCommand = availability.available
+        ? (availability.resolvedPath ?? launch.command)
+        : null;
       if (authCommand) {
         try {
-          const { stdout, stderr } = await execCommand(authCommand, ["auth", "list"], {
-            ...createProviderEnvSpec(),
-            timeout: 5_000,
-          });
+          const { stdout, stderr } = await execCommand(
+            authCommand,
+            [...launch.args, "auth", "list"],
+            {
+              ...createProviderEnvSpec(),
+              timeout: 5_000,
+            },
+          );
           const text = (stdout.trim() || stderr.trim()).trim();
           authValue = text ? `\n    ${text.replace(/\n/g, "\n    ")}` : "(empty)";
         } catch (error) {
@@ -1457,7 +1469,7 @@ export class OpenCodeAgentClient implements AgentClient {
 
       return {
         diagnostic: formatProviderDiagnostic("OpenCode", [
-          ...(await buildBinaryDiagnosticRows(launch)),
+          ...(await buildBinaryDiagnosticRows(launch, availability)),
           { label: "Server", value: serverStatus },
           { label: "Auth", value: authValue },
           { label: "Models", value: modelsValue },

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -10,7 +10,6 @@ import {
   type Session as OpenCodeSession,
   type TextPartInput as OpenCodeTextPartInput,
 } from "@opencode-ai/sdk/v2/client";
-import { findExecutable, isCommandAvailable } from "../../../utils/executable.js";
 import { createPathEquivalenceMatcher } from "../../../utils/path.js";
 import type { Logger } from "pino";
 import { z } from "zod";
@@ -46,7 +45,11 @@ import {
   type ToolCallDetail,
   type ToolCallTimelineItem,
 } from "../agent-sdk-types.js";
-import { createProviderEnvSpec, type ProviderRuntimeSettings } from "../provider-launch-config.js";
+import {
+  createProviderEnvSpec,
+  resolveProviderLaunch,
+  type ProviderRuntimeSettings,
+} from "../provider-launch-config.js";
 import { withTimeout } from "../../../utils/promise-timeout.js";
 import { execCommand } from "../../../utils/spawn.js";
 import { buildToolCallDisplayModel } from "../../../shared/tool-call-display.js";
@@ -56,7 +59,7 @@ import {
   formatDiagnosticStatus,
   formatProviderDiagnostic,
   formatProviderDiagnosticError,
-  resolveBinaryVersion,
+  buildBinaryDiagnosticRows,
   toDiagnosticErrorMessage,
 } from "./diagnostic-utils.js";
 import { runProviderTurn } from "./provider-runner.js";
@@ -1391,17 +1394,16 @@ export class OpenCodeAgentClient implements AgentClient {
   }
 
   async isAvailable(): Promise<boolean> {
-    const command = this.runtimeSettings?.command;
-    if (command?.mode === "replace") {
-      return await isCommandAvailable(command.argv[0]);
-    }
-    return await isCommandAvailable("opencode");
+    return (
+      (await resolveProviderLaunch(this.runtimeSettings?.command, "opencode")).source !==
+      "not_found"
+    );
   }
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
     try {
+      const launch = await resolveProviderLaunch(this.runtimeSettings?.command, "opencode");
       const available = await this.isAvailable();
-      const resolvedBinary = await findExecutable("opencode");
       let serverStatus = "Not running";
       let modelsValue = "Not checked";
       let status = formatDiagnosticStatus(available);
@@ -1414,9 +1416,11 @@ export class OpenCodeAgentClient implements AgentClient {
       }
 
       let authValue = "Not checked";
-      if (resolvedBinary) {
+      const authCommand =
+        launch.source === "not_found" ? null : (launch.resolvedPath ?? launch.command);
+      if (authCommand) {
         try {
-          const { stdout, stderr } = await execCommand(resolvedBinary, ["auth", "list"], {
+          const { stdout, stderr } = await execCommand(authCommand, ["auth", "list"], {
             ...createProviderEnvSpec(),
             timeout: 5_000,
           });
@@ -1453,14 +1457,7 @@ export class OpenCodeAgentClient implements AgentClient {
 
       return {
         diagnostic: formatProviderDiagnostic("OpenCode", [
-          {
-            label: "Binary",
-            value: resolvedBinary ?? "not found",
-          },
-          {
-            label: "Version",
-            value: resolvedBinary ? await resolveBinaryVersion(resolvedBinary) : "unknown",
-          },
+          ...(await buildBinaryDiagnosticRows(launch)),
           { label: "Server", value: serverStatus },
           { label: "Auth", value: authValue },
           { label: "Models", value: modelsValue },

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -30,15 +30,18 @@ import {
   type PersistedAgentDescriptor,
 } from "../../agent-sdk-types.js";
 import { runProviderTurn } from "../provider-runner.js";
-import type { ProviderRuntimeSettings } from "../../provider-launch-config.js";
+import {
+  resolveProviderLaunch,
+  type ProviderRuntimeSettings,
+  type ResolvedProviderLaunch,
+} from "../../provider-launch-config.js";
 import { renderPromptAttachmentAsText } from "../../prompt-attachments.js";
 import { composeSystemPromptParts } from "../../system-prompt.js";
-import { findExecutable } from "../../../../utils/executable.js";
 import {
+  buildBinaryDiagnosticRows,
   formatDiagnosticStatus,
   formatProviderDiagnostic,
   formatProviderDiagnosticError,
-  resolveBinaryVersion,
   toDiagnosticErrorMessage,
 } from "../diagnostic-utils.js";
 import {
@@ -1484,8 +1487,8 @@ export class PiRpcAgentClient implements AgentClient {
   }
 
   async isAvailable(): Promise<boolean> {
-    const binary = await this.resolvePiBinary();
-    if (!binary) {
+    const launch = await this.resolvePiLaunch();
+    if (launch.source === "not_found") {
       return false;
     }
     const runtimeSession = await this.runtime.startSession({ cwd: homedir() }).catch(() => null);
@@ -1503,16 +1506,15 @@ export class PiRpcAgentClient implements AgentClient {
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
     try {
+      const launch = await this.resolvePiLaunch();
       const available = await this.isAvailable();
-      const binary = await this.resolvePiBinary();
-      const version = binary ? await resolveBinaryVersion(binary) : "unknown";
       const authConfigPath = join(homedir(), ".pi", "agent", "auth.json");
       let modelsValue = "Not checked";
       let configuredProvidersValue = "none";
       let mcpToolsValue = "Not checked";
       let status = formatDiagnosticStatus(available);
 
-      if (binary) {
+      if (launch.source !== "not_found") {
         const runtimeSession = await this.runtime
           .startSession({ cwd: homedir() })
           .catch((error) => {
@@ -1550,8 +1552,7 @@ export class PiRpcAgentClient implements AgentClient {
 
       return {
         diagnostic: formatProviderDiagnostic("Pi", [
-          { label: "Binary", value: binary ?? "not found" },
-          { label: "Version", value: version },
+          ...(await buildBinaryDiagnosticRows(launch)),
           { label: "Configured providers", value: configuredProvidersValue },
           {
             label: "Auth config (~/.pi/agent/auth.json)",
@@ -1601,11 +1602,7 @@ export class PiRpcAgentClient implements AgentClient {
     }
   }
 
-  private async resolvePiBinary(): Promise<string | null> {
-    const command = this.runtimeSettings?.command;
-    if (command?.mode === "replace" && command.argv[0]) {
-      return await findExecutable(command.argv[0]);
-    }
-    return await findExecutable(PI_BINARY_COMMAND);
+  private async resolvePiLaunch(): Promise<ResolvedProviderLaunch> {
+    return resolveProviderLaunch(this.runtimeSettings?.command, PI_BINARY_COMMAND);
   }
 }

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -31,6 +31,7 @@ import {
 } from "../../agent-sdk-types.js";
 import { runProviderTurn } from "../provider-runner.js";
 import {
+  checkProviderLaunchAvailable,
   resolveProviderLaunch,
   type ProviderRuntimeSettings,
   type ResolvedProviderLaunch,
@@ -1488,7 +1489,8 @@ export class PiRpcAgentClient implements AgentClient {
 
   async isAvailable(): Promise<boolean> {
     const launch = await this.resolvePiLaunch();
-    if (launch.source === "not_found") {
+    const availability = await checkProviderLaunchAvailable(launch);
+    if (!availability.available) {
       return false;
     }
     const runtimeSession = await this.runtime.startSession({ cwd: homedir() }).catch(() => null);
@@ -1507,14 +1509,15 @@ export class PiRpcAgentClient implements AgentClient {
   async getDiagnostic(): Promise<{ diagnostic: string }> {
     try {
       const launch = await this.resolvePiLaunch();
-      const available = await this.isAvailable();
+      const availability = await checkProviderLaunchAvailable(launch);
+      const available = availability.available;
       const authConfigPath = join(homedir(), ".pi", "agent", "auth.json");
       let modelsValue = "Not checked";
       let configuredProvidersValue = "none";
       let mcpToolsValue = "Not checked";
       let status = formatDiagnosticStatus(available);
 
-      if (launch.source !== "not_found") {
+      if (availability.available) {
         const runtimeSession = await this.runtime
           .startSession({ cwd: homedir() })
           .catch((error) => {
@@ -1552,7 +1555,7 @@ export class PiRpcAgentClient implements AgentClient {
 
       return {
         diagnostic: formatProviderDiagnostic("Pi", [
-          ...(await buildBinaryDiagnosticRows(launch)),
+          ...(await buildBinaryDiagnosticRows(launch, availability)),
           { label: "Configured providers", value: configuredProvidersValue },
           {
             label: "Auth config (~/.pi/agent/auth.json)",
@@ -1603,6 +1606,9 @@ export class PiRpcAgentClient implements AgentClient {
   }
 
   private async resolvePiLaunch(): Promise<ResolvedProviderLaunch> {
-    return resolveProviderLaunch(this.runtimeSettings?.command, PI_BINARY_COMMAND);
+    return resolveProviderLaunch({
+      commandConfig: this.runtimeSettings?.command,
+      defaultBinary: PI_BINARY_COMMAND,
+    });
   }
 }


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

Provider diagnostics now resolve command overrides through the same launch shape used for startup. Command overrides stay visible in the Binary row, version/auth probes include override args, and availability checks no longer infer runnable state from launch-config provenance.

Launch config resolution now answers only which command and args should run. A separate availability helper probes whether that launch target is runnable and returns the resolved path for diagnostics.

### How did you verify it

- `npm run format`
- `npm run typecheck`
- `npm run lint -- packages/server/src/server/agent/provider-launch-config.ts packages/server/src/server/agent/provider-launch-config.test.ts packages/server/src/server/agent/providers/diagnostic-utils.ts packages/server/src/server/agent/providers/acp-agent.ts packages/server/src/server/agent/providers/claude/agent.ts packages/server/src/server/agent/providers/codex-app-server-agent.ts packages/server/src/server/agent/providers/copilot-acp-agent.ts packages/server/src/server/agent/providers/generic-acp-agent.ts packages/server/src/server/agent/providers/opencode-agent.ts packages/server/src/server/agent/providers/pi/agent.ts`
- `npx vitest run packages/server/src/server/agent/provider-launch-config.test.ts --bail=1 --reporter=verbose`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (no UI changes)
- [x] Tests added or updated where it made sense

### Risk surface

Touches provider process launch resolution, availability, and diagnostics. CI covers type/lint and the resolver unit tests; provider-specific wrapper commands still deserve manual smoke testing where available.