### PR TITLE
[codex] Add worktree new agent tab action

### DIFF
--- a/packages/app/src/components/sidebar-workspace-list.test.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.test.tsx
@@ -1,7 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-import { act } from "@testing-library/react";
+import { act, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import type { WorkspaceScriptPayload } from "@getpaseo/protocol/messages";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -20,9 +21,56 @@ const pathnameState = vi.hoisted(() => ({
 vi.mock("expo-router", () => ({
   router: {
     dismissTo: vi.fn(),
+    navigate: vi.fn(),
+    replace: vi.fn(),
   },
   useLocalSearchParams: () => ({}),
   usePathname: () => pathnameState.value,
+}));
+
+vi.mock("react-native-unistyles", () => ({
+  StyleSheet: {
+    create: <T,>(factory: T) =>
+      typeof factory === "function"
+        ? factory({
+            borderRadius: { full: 999, lg: 12, md: 8, sm: 4 },
+            borderWidth: { 1: 1 },
+            colors: {
+              border: "#d0d0d0",
+              foreground: "#111111",
+              foregroundMuted: "#666666",
+              palette: {
+                amber: { 500: "#f59e0b", 700: "#b45309" },
+                blue: { 500: "#3b82f6" },
+                green: { 500: "#22c55e" },
+                purple: { 500: "#a855f7" },
+                red: { 500: "#ef4444" },
+              },
+              popoverForeground: "#111111",
+              surface0: "#ffffff",
+              surface1: "#f7f7f7",
+              surface2: "#eeeeee",
+              surfaceSidebarHover: "#f2f2f2",
+            },
+            colorScheme: "light",
+            fontSize: { xs: 12, sm: 14 },
+            fontWeight: { medium: "500", normal: "400" },
+            iconSize: { md: 20 },
+            shadow: { md: {} },
+            spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24 },
+          })
+        : factory,
+  },
+  useUnistyles: () => ({
+    theme: {},
+    rt: {},
+    breakpoint: undefined,
+  }),
+  withUnistyles: (Component: unknown) => Component,
+  UnistylesRuntime: {
+    setTheme: vi.fn(),
+    themeName: "light",
+  },
 }));
 
 import {
@@ -30,6 +78,7 @@ import {
   type SidebarProjectEntry,
 } from "@/hooks/use-sidebar-workspaces-list";
 import { useSidebarWorkspacesList } from "@/hooks/use-sidebar-workspaces-list";
+import { SidebarWorkspaceList } from "@/components/sidebar-workspace-list";
 import { patchWorkspaceScripts } from "@/contexts/session-workspace-scripts";
 import {
   getHostRuntimeStore,
@@ -41,6 +90,7 @@ import { useSessionStore, type WorkspaceDescriptor } from "@/stores/session-stor
 import { useSidebarOrderStore } from "@/stores/sidebar-order-store";
 import { useWorkspaceFields } from "@/stores/session-store-hooks";
 import { useActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
+import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
 
 vi.mock("@react-native-async-storage/async-storage", () => ({
   default: {
@@ -324,6 +374,172 @@ async function renderProbe(counts: RenderCounts): Promise<{ root: Root; containe
 function renderSidebarFrame(root: Root, counts: RenderCounts) {
   root.render(<SidebarFrameProbe counts={counts} />);
 }
+
+function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Infinity,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+function SidebarWorkspaceListHarness({
+  projects,
+  collapsedProjectKeys,
+}: {
+  projects: SidebarProjectEntry[];
+  collapsedProjectKeys: ReadonlySet<string>;
+}): ReactElement {
+  return (
+    <SidebarWorkspaceList
+      projects={projects}
+      serverId={SERVER_ID}
+      collapsedProjectKeys={collapsedProjectKeys}
+      onToggleProjectCollapsed={vi.fn()}
+      shortcutIndexByWorkspaceKey={new Map()}
+    />
+  );
+}
+
+function createSidebarProjectsFixture(): SidebarProjectEntry[] {
+  const workspaces = useSessionStore.getState().sessions[SERVER_ID]?.workspaces;
+  const projectAWorkspaces = ["a-main", "a-one", "a-two"]
+    .map((id) => workspaces?.get(id))
+    .filter((entry): entry is WorkspaceDescriptor => Boolean(entry))
+    .map((entry) => createSidebarWorkspaceEntry({ serverId: SERVER_ID, workspace: entry }));
+
+  return [
+    {
+      projectKey: "project-a",
+      projectName: "Project A",
+      projectKind: "git",
+      iconWorkingDir: "/repo/project-a",
+      workspaces: projectAWorkspaces,
+    },
+  ];
+}
+
+async function renderWorkspaceList(input?: {
+  collapsedProjectKeys?: ReadonlySet<string>;
+}): Promise<{ root: Root; container: HTMLElement; queryClient: QueryClient }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = createTestQueryClient();
+  const projects = createSidebarProjectsFixture();
+
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <SidebarWorkspaceListHarness
+          projects={projects}
+          collapsedProjectKeys={input?.collapsedProjectKeys ?? new Set()}
+        />
+      </QueryClientProvider>,
+    );
+  });
+
+  return { root, container, queryClient };
+}
+
+function resetWorkspaceLayoutStore(): void {
+  useWorkspaceLayoutStore.setState({
+    layoutByWorkspace: {},
+    splitSizesByWorkspace: {},
+    pinnedAgentIdsByWorkspace: {},
+    hiddenAgentIdsByWorkspace: {},
+    focusRestorationByWorkspace: {},
+  });
+}
+
+describe("sidebar workspace row actions", () => {
+  let root: Root | null = null;
+  let container: HTMLElement | null = null;
+  let queryClient: QueryClient | null = null;
+
+  beforeEach(() => {
+    initializeSidebarState(createWorkspaces());
+    resetWorkspaceLayoutStore();
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    queryClient?.clear();
+    queryClient = null;
+    act(() => {
+      pathnameState.value = "/";
+      getHostRuntimeStore().syncHosts([]);
+      useSessionStore.getState().clearSession(SERVER_ID);
+      useSidebarOrderStore.setState({
+        projectOrderByServerId: {},
+        workspaceOrderByServerAndProject: {},
+      });
+      resetWorkspaceLayoutStore();
+    });
+  });
+
+  it("shows the new-agent action only on worktree rows", async () => {
+    ({ root, container, queryClient } = await renderWorkspaceList());
+
+    expect(
+      container.querySelector(
+        '[data-testid="sidebar-workspace-new-agent-sidebar-render-count:a-one"]',
+      ),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(
+        '[data-testid="sidebar-workspace-new-agent-sidebar-render-count:a-main"]',
+      ),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid^="sidebar-project-new-worktree-"]'),
+    ).not.toBeNull();
+  });
+
+  it("opens a fresh draft tab for the selected worktree action", async () => {
+    ({ root, container, queryClient } = await renderWorkspaceList());
+
+    const row = container.querySelector(
+      '[data-testid="sidebar-workspace-row-sidebar-render-count:a-one"]',
+    );
+    if (!(row instanceof HTMLElement) || !(row.parentElement instanceof HTMLElement)) {
+      throw new Error("Expected worktree row to render");
+    }
+
+    await act(async () => {
+      fireEvent.pointerEnter(row.parentElement);
+    });
+
+    const button = container.querySelector(
+      '[data-testid="sidebar-workspace-new-agent-sidebar-render-count:a-one"]',
+    );
+    if (!(button instanceof HTMLElement)) {
+      throw new Error("Expected worktree new-agent button to render");
+    }
+
+    await act(async () => {
+      button.click();
+    });
+
+    const tabs = useWorkspaceLayoutStore.getState().getWorkspaceTabs(`${SERVER_ID}:a-one`);
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]?.target.kind).toBe("draft");
+    expect(tabs[0]?.target.kind === "draft" ? tabs[0].target.draftId : null).not.toBe("new");
+  });
+});
 
 describe("sidebar workspace render isolation", () => {
   let root: Root | null = null;

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -28,6 +28,7 @@ import {
 } from "react";
 import { router, usePathname, type Href } from "expo-router";
 import { navigateToWorkspace } from "@/stores/navigation-active-workspace-store";
+import { navigateToPreparedWorkspaceTab } from "@/utils/workspace-navigation";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import type { Theme } from "@/styles/theme";
 import { type GestureType } from "react-native-gesture-handler";
@@ -144,6 +145,7 @@ const ThemedSyncedLoader = withUnistyles(SyncedLoader);
 const ThemedMonitor = withUnistyles(Monitor);
 const ThemedFolderGit2 = withUnistyles(FolderGit2);
 const ThemedFolderPlus = withUnistyles(FolderPlus);
+const ThemedPlus = withUnistyles(Plus);
 const ThemedGlobe = withUnistyles(Globe);
 const ThemedSquareTerminal = withUnistyles(SquareTerminal);
 const ThemedMoreVertical = withUnistyles(MoreVertical);
@@ -238,6 +240,7 @@ interface WorkspaceRowInnerProps {
   onCopyBranchName?: () => void;
   onCopyPath?: () => void;
   onRename?: () => void;
+  onCreateDraftTab?: () => void;
   archiveShortcutKeys?: ShortcutKey[][] | null;
 }
 
@@ -635,6 +638,7 @@ function WorkspaceRowRightGroup({
   workspace,
   isHovered,
   isTouchPlatform,
+  isCompact,
   showScriptsIcon,
   hasRunningService,
   isCreating,
@@ -648,10 +652,12 @@ function WorkspaceRowRightGroup({
   onCopyBranchName,
   onCopyPath,
   onRename,
+  onCreateDraftTab,
 }: {
   workspace: SidebarWorkspaceEntry;
   isHovered: boolean;
   isTouchPlatform: boolean;
+  isCompact: boolean;
   showScriptsIcon: boolean;
   hasRunningService: boolean;
   isCreating: boolean;
@@ -665,8 +671,12 @@ function WorkspaceRowRightGroup({
   onCopyBranchName?: () => void;
   onCopyPath?: () => void;
   onRename?: () => void;
+  onCreateDraftTab?: () => void;
 }) {
   const showKebab = Boolean(onArchive && (isHovered || isTouchPlatform));
+  const showRowActions = isHovered || isTouchPlatform || isCompact;
+  const canCreateDraftTab = Boolean(workspace.workspaceKind === "worktree" && onCreateDraftTab);
+  const showCreateDraftTab = canCreateDraftTab && showRowActions;
   return (
     <View style={styles.workspaceRowRight}>
       {showScriptsIcon ? (
@@ -679,6 +689,14 @@ function WorkspaceRowRightGroup({
         </View>
       ) : null}
       {isCreating ? <Text style={styles.workspaceCreatingText}>Creating...</Text> : null}
+      {canCreateDraftTab && onCreateDraftTab ? (
+        <NewWorkspaceAgentButton
+          workspaceName={workspace.name}
+          onPress={onCreateDraftTab}
+          visible={showCreateDraftTab}
+          testID={`sidebar-workspace-new-agent-${workspace.workspaceKey}`}
+        />
+      ) : null}
       {showKebab && onArchive ? (
         <WorkspaceKebabMenu
           workspaceKey={workspace.workspaceKey}
@@ -703,6 +721,61 @@ function WorkspaceRowRightGroup({
           <Text style={styles.shortcutBadgeText}>{shortcutNumber}</Text>
         </View>
       ) : null}
+    </View>
+  );
+}
+
+function NewWorkspaceAgentButton({
+  workspaceName,
+  onPress,
+  visible,
+  testID,
+}: {
+  workspaceName: string;
+  onPress: () => void;
+  visible: boolean;
+  testID: string;
+}) {
+  const pressableStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.workspaceIconActionButton,
+      !visible && styles.workspaceIconActionButtonHidden,
+      visible && (Boolean(hovered) || pressed) && styles.workspaceIconActionButtonHovered,
+    ],
+    [visible],
+  );
+
+  const handlePress = useCallback(
+    (event: GestureResponderEvent) => {
+      event.stopPropagation();
+      onPress();
+    },
+    [onPress],
+  );
+
+  return (
+    <View style={styles.workspaceTrailingControlSlot} pointerEvents={visible ? "auto" : "none"}>
+      <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
+        <TooltipTrigger asChild disabled={!visible}>
+          <Pressable
+            style={pressableStyle}
+            onPress={handlePress}
+            accessibilityRole={platformIsWeb ? undefined : "button"}
+            accessibilityLabel={`New agent tab in ${workspaceName}`}
+            testID={testID}
+          >
+            {({ hovered, pressed }) => (
+              <ThemedPlus
+                size={14}
+                uniProps={hovered || pressed ? foregroundColorMapping : foregroundMutedColorMapping}
+              />
+            )}
+          </Pressable>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="center" offset={8}>
+          <Text style={styles.projectActionTooltipText}>New agent tab</Text>
+        </TooltipContent>
+      </Tooltip>
     </View>
   );
 }
@@ -1341,9 +1414,10 @@ function WorkspaceRowInner({
   onCopyBranchName,
   onCopyPath,
   onRename,
+  onCreateDraftTab,
   archiveShortcutKeys,
 }: WorkspaceRowInnerProps) {
-  const _isCompact = useIsCompactFormFactor();
+  const isCompact = useIsCompactFormFactor();
   const [isHovered, setIsHovered] = useState(false);
   const isTouchPlatform = platformIsNative;
   const prHint = workspace.prHint;
@@ -1432,6 +1506,7 @@ function WorkspaceRowInner({
               workspace={workspace}
               isHovered={isHovered}
               isTouchPlatform={isTouchPlatform}
+              isCompact={isCompact}
               showScriptsIcon={showScriptsIcon}
               hasRunningService={hasRunningService}
               isCreating={isCreating}
@@ -1445,6 +1520,7 @@ function WorkspaceRowInner({
               onCopyBranchName={onCopyBranchName}
               onCopyPath={onCopyPath}
               onRename={onRename}
+              onCreateDraftTab={onCreateDraftTab}
             />
           </View>
           {prHint ? (
@@ -1664,6 +1740,14 @@ function WorkspaceRowWithMenu({
 
   const archiveShortcutKeys = useShortcutKeys("archive-worktree");
 
+  const handleCreateDraftTab = useCallback(() => {
+    navigateToPreparedWorkspaceTab({
+      serverId: workspace.serverId,
+      workspaceId: workspace.workspaceId,
+      target: { kind: "draft", draftId: "new" },
+    });
+  }, [workspace.serverId, workspace.workspaceId]);
+
   useKeyboardActionHandler({
     handlerId: `worktree-archive-${workspace.workspaceKey}`,
     actions: ["worktree.archive"],
@@ -1700,6 +1784,7 @@ function WorkspaceRowWithMenu({
         onCopyBranchName={canCopyBranchName ? handleCopyBranchName : undefined}
         onCopyPath={handleCopyPath}
         onRename={canCopyBranchName ? handleOpenRename : undefined}
+        onCreateDraftTab={isWorktree ? handleCreateDraftTab : undefined}
         archiveShortcutKeys={selected ? archiveShortcutKeys : null}
       />
       <AdaptiveRenameModal
@@ -2827,6 +2912,27 @@ const styles = StyleSheet.create((theme) => ({
     flexDirection: "row",
     alignItems: "center",
     gap: theme.spacing[2],
+    flexShrink: 0,
+  },
+  workspaceIconActionButton: {
+    width: 24,
+    height: 24,
+    borderRadius: theme.borderRadius.md,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  workspaceIconActionButtonHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+  workspaceIconActionButtonHidden: {
+    opacity: 0,
+  },
+  workspaceTrailingControlSlot: {
+    width: 24,
+    height: 24,
+    alignItems: "center",
+    justifyContent: "center",
     flexShrink: 0,
   },
   workspaceRowHovered: {


### PR DESCRIPTION
## Summary

cc @getpaseo

Adds a worktree-row action in the sidebar for starting a fresh agent conversation directly from an existing worktree.

- Shows a `New agent tab` action on worktree rows only.
- Reuses `navigateToPreparedWorkspaceTab` with `draftId: "new"` so each click opens a fresh draft tab in the selected workspace.
- Keeps the existing project-row `New workspace` action and local checkout rows unchanged.
- Adds coverage for worktree-only visibility and draft-tab creation.

## Validation

- Passed: `oxfmt packages/app/src/components/sidebar-workspace-list.tsx packages/app/src/components/sidebar-workspace-list.test.tsx`
- Passed: `oxlint packages/app/src/components/sidebar-workspace-list.tsx packages/app/src/components/sidebar-workspace-list.test.tsx`
- Passed: `git diff --check`
- GitNexus: impact LOW for the touched sidebar row symbols; no affected execution flows.
- Blocked locally: `vitest run packages/app/src/components/sidebar-workspace-list.test.tsx --bail=1` because this clean worktree has no installed `node_modules`, and the fallback `npx` Vitest run cannot resolve `vitest/config`/`jsdom`.
