### PR TITLE
Add manual refresh button to git diff controls

### DIFF
--- a/packages/app/src/git/actions-store.test.ts
+++ b/packages/app/src/git/actions-store.test.ts
@@ -170,6 +170,46 @@ describe("checkout-git-actions-store", () => {
     ).toBe("idle");
   });
 
+  it("refreshes git and GitHub state and reports success", async () => {
+    const client = {
+      checkoutRefresh: vi.fn(async () => ({ success: true, error: null })),
+    };
+    useSessionStore.setState((state) => ({
+      ...state,
+      sessions: {
+        ...state.sessions,
+        [serverId]: { client } as unknown as (typeof state.sessions)[string],
+      },
+    }));
+
+    await useCheckoutGitActionsStore.getState().refresh({ serverId, cwd });
+
+    expect(client.checkoutRefresh).toHaveBeenCalledWith(cwd);
+    expect(
+      useCheckoutGitActionsStore.getState().getStatus({ serverId, cwd, actionId: "refresh" }),
+    ).toBe("success");
+  });
+
+  it("surfaces a refresh error and returns to idle", async () => {
+    const client = {
+      checkoutRefresh: vi.fn(async () => ({ error: { message: "not a git repository" } })),
+    };
+    useSessionStore.setState((state) => ({
+      ...state,
+      sessions: {
+        ...state.sessions,
+        [serverId]: { client } as unknown as (typeof state.sessions)[string],
+      },
+    }));
+
+    await expect(useCheckoutGitActionsStore.getState().refresh({ serverId, cwd })).rejects.toThrow(
+      "not a git repository",
+    );
+    expect(
+      useCheckoutGitActionsStore.getState().getStatus({ serverId, cwd, actionId: "refresh" }),
+    ).toBe("idle");
+  });
+
   it("enables PR auto-merge when the daemon advertises auto-merge actions", async () => {
     const client = {
       checkoutGithubSetAutoMerge: vi.fn(async () => ({

--- a/packages/app/src/git/actions-store.ts
+++ b/packages/app/src/git/actions-store.ts
@@ -28,6 +28,7 @@ export type CheckoutGitAsyncActionId =
   | "pull"
   | "push"
   | "pull-and-push"
+  | "refresh"
   | "create-pr"
   | "merge-pr-squash"
   | "merge-pr-merge"
@@ -236,6 +237,7 @@ interface CheckoutGitActionsStoreState {
   pull: (params: { serverId: string; cwd: string }) => Promise<void>;
   push: (params: { serverId: string; cwd: string }) => Promise<void>;
   pullAndPush: (params: { serverId: string; cwd: string }) => Promise<void>;
+  refresh: (params: { serverId: string; cwd: string }) => Promise<void>;
   createPr: (params: { serverId: string; cwd: string }) => Promise<void>;
   mergePr: (params: {
     serverId: string;
@@ -353,6 +355,21 @@ export const useCheckoutGitActionsStore = create<CheckoutGitActionsStoreState>()
       run: async () => {
         const client = resolveClient(serverId);
         const payload = await client.checkoutPush(cwd);
+        if (payload.error) {
+          throw new Error(payload.error.message);
+        }
+      },
+    });
+  },
+
+  refresh: async ({ serverId, cwd }) => {
+    await runCheckoutAction({
+      serverId,
+      cwd,
+      actionId: "refresh",
+      run: async () => {
+        const client = resolveClient(serverId);
+        const payload = await client.checkoutRefresh(cwd);
         if (payload.error) {
           throw new Error(payload.error.message);
         }

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -26,7 +26,7 @@ import {
   type TextStyle,
 } from "react-native";
 import { StyleSheet, useUnistyles, withUnistyles } from "react-native-unistyles";
-import type { Theme } from "@/styles/theme";
+import { ICON_SIZE, type Theme } from "@/styles/theme";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import {
   AlignJustify,
@@ -42,7 +42,7 @@ import {
   ListChevronsUpDown,
   Pilcrow,
   RefreshCcw,
-  RefreshCw,
+  RotateCw,
   Upload,
   WrapText,
 } from "lucide-react-native";
@@ -83,7 +83,7 @@ import { useGitActions } from "@/git/use-actions";
 import { useCheckoutGitActionsStore } from "@/git/actions-store";
 import { useToast } from "@/contexts/toast-context";
 import { useSessionStore } from "@/stores/session-store";
-import { SyncedLoader } from "@/components/synced-loader";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { usePanelStore } from "@/stores/panel-store";
 import { buildWorkspaceExplorerStateKey } from "@/hooks/use-file-explorer-actions";
@@ -1230,38 +1230,33 @@ function DiffFilesToolbar({
 
 interface DiffRefreshButtonProps {
   isRefreshing: boolean;
-  isMobile: boolean;
   toggleStyle: PressableStyleFn;
   onPress: () => void;
 }
 
-const ThemedRefreshCw = withUnistyles(RefreshCw);
-const ThemedSyncedLoader = withUnistyles(SyncedLoader);
+const ThemedRotateCw = withUnistyles(RotateCw);
+const ThemedLoadingSpinner = withUnistyles(LoadingSpinner);
 const refreshIconColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
 
-function DiffRefreshButton({
-  isRefreshing,
-  isMobile,
-  toggleStyle,
-  onPress,
-}: DiffRefreshButtonProps) {
-  const iconSize = isMobile ? 18 : 14;
+function DiffRefreshButton({ isRefreshing, toggleStyle, onPress }: DiffRefreshButtonProps) {
   return (
     <Tooltip delayDuration={300}>
       <TooltipTrigger asChild>
         <Pressable
           accessibilityRole="button"
-          accessibilityLabel="Refresh git and GitHub state"
+          accessibilityLabel={isRefreshing ? "Refreshing" : "Refresh git and GitHub state"}
           testID="changes-refresh"
           style={toggleStyle}
           onPress={onPress}
           disabled={isRefreshing}
         >
-          {isRefreshing ? (
-            <ThemedSyncedLoader size={iconSize} uniProps={refreshIconColorMapping} />
-          ) : (
-            <ThemedRefreshCw size={iconSize} uniProps={refreshIconColorMapping} />
-          )}
+          <View style={styles.refreshIcon}>
+            {isRefreshing ? (
+              <ThemedLoadingSpinner size={ICON_SIZE.sm} uniProps={refreshIconColorMapping} />
+            ) : (
+              <ThemedRotateCw size={ICON_SIZE.sm} uniProps={refreshIconColorMapping} />
+            )}
+          </View>
         </Pressable>
       </TooltipTrigger>
       <TooltipContent side="bottom">
@@ -2163,7 +2158,6 @@ export function GitDiffPane({
               {refreshSupported ? (
                 <DiffRefreshButton
                   isRefreshing={isRefreshing}
-                  isMobile={isMobile}
                   toggleStyle={refreshToggleStyle}
                   onPress={handleRefresh}
                 />
@@ -2295,6 +2289,12 @@ const styles = StyleSheet.create((theme) => ({
   },
   toggleButtonSelected: {
     backgroundColor: theme.colors.surface2,
+  },
+  refreshIcon: {
+    width: ICON_SIZE.md,
+    height: ICON_SIZE.md,
+    alignItems: "center",
+    justifyContent: "center",
   },
   expandAllButton: {
     flexDirection: "row",

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -41,6 +41,7 @@ import {
   ListChevronsUpDown,
   Pilcrow,
   RefreshCcw,
+  RefreshCw,
   Upload,
   WrapText,
 } from "lucide-react-native";
@@ -78,6 +79,11 @@ import { lineNumberGutterWidth } from "@/components/code-insets";
 import { useWebScrollViewScrollbar } from "@/components/use-web-scrollbar";
 import { GitActionsSplitButton } from "@/git/actions-split-button";
 import { useGitActions } from "@/git/use-actions";
+import { invalidateCheckoutGitQueriesForClient } from "@/git/query-keys";
+import { useToast } from "@/contexts/toast-context";
+import { useHostRuntimeClient } from "@/runtime/host-runtime";
+import { useSessionStore } from "@/stores/session-store";
+import { useQueryClient } from "@tanstack/react-query";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { usePanelStore } from "@/stores/panel-store";
 import { buildWorkspaceExplorerStateKey } from "@/hooks/use-file-explorer-actions";
@@ -1222,6 +1228,46 @@ function DiffFilesToolbar({
   );
 }
 
+interface DiffRefreshButtonProps {
+  isRefreshing: boolean;
+  isMobile: boolean;
+  toggleStyle: PressableStyleFn;
+  onPress: () => void;
+}
+
+function DiffRefreshButton({
+  isRefreshing,
+  isMobile,
+  toggleStyle,
+  onPress,
+}: DiffRefreshButtonProps) {
+  const { theme } = useUnistyles();
+  const iconSize = isMobile ? 18 : 14;
+  return (
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Refresh git and GitHub state"
+          testID="changes-refresh"
+          style={toggleStyle}
+          onPress={onPress}
+          disabled={isRefreshing}
+        >
+          {isRefreshing ? (
+            <ActivityIndicator size="small" color={theme.colors.foregroundMuted} />
+          ) : (
+            <RefreshCw size={iconSize} color={theme.colors.foregroundMuted} />
+          )}
+        </Pressable>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        <Text style={styles.tooltipText}>Refresh</Text>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 type DiffFlatItem =
   | { type: "header"; file: ParsedDiffFile; fileIndex: number; isExpanded: boolean }
   | { type: "body"; file: ParsedDiffFile; fileIndex: number };
@@ -1558,6 +1604,43 @@ export function GitDiffPane({
     () => buildExpandAllButtonStyle(controlSurfaceColor),
     [controlSurfaceColor],
   );
+
+  const refreshToggleStyle = useMemo(
+    () => buildExpandAllButtonStyle(controlSurfaceColor),
+    [controlSurfaceColor],
+  );
+
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const refreshClient = useHostRuntimeClient(serverId);
+  const refreshSupported = useSessionStore(
+    (s) => s.sessions[serverId]?.serverInfo?.features?.checkoutRefresh === true,
+  );
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleRefresh = useCallback(() => {
+    if (isRefreshing) {
+      return;
+    }
+    if (!refreshClient) {
+      toast.error("Host is offline. Reconnect to refresh.");
+      return;
+    }
+    setIsRefreshing(true);
+    void (async () => {
+      try {
+        const payload = await refreshClient.checkoutRefresh(cwd);
+        if (payload.error) {
+          throw new Error(payload.error.message);
+        }
+        await invalidateCheckoutGitQueriesForClient(queryClient, { serverId, cwd });
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to refresh git state.");
+      } finally {
+        setIsRefreshing(false);
+      }
+    })();
+  }, [cwd, isRefreshing, queryClient, refreshClient, serverId, toast]);
 
   const {
     status,
@@ -2086,6 +2169,14 @@ export function GitDiffPane({
                   expandAllToggleStyle={expandAllToggleStyle}
                   onToggleWrapLines={handleToggleWrapLines}
                   onToggleExpandAll={handleToggleExpandAll}
+                />
+              ) : null}
+              {refreshSupported ? (
+                <DiffRefreshButton
+                  isRefreshing={isRefreshing}
+                  isMobile={isMobile}
+                  toggleStyle={refreshToggleStyle}
+                  onPress={handleRefresh}
                 />
               ) : null}
             </View>

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -80,11 +80,9 @@ import { lineNumberGutterWidth } from "@/components/code-insets";
 import { useWebScrollViewScrollbar } from "@/components/use-web-scrollbar";
 import { GitActionsSplitButton } from "@/git/actions-split-button";
 import { useGitActions } from "@/git/use-actions";
-import { invalidateCheckoutGitQueriesForClient } from "@/git/query-keys";
+import { useCheckoutGitActionsStore } from "@/git/actions-store";
 import { useToast } from "@/contexts/toast-context";
-import { useHostRuntimeClient } from "@/runtime/host-runtime";
 import { useSessionStore } from "@/stores/session-store";
-import { useQueryClient } from "@tanstack/react-query";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { usePanelStore } from "@/stores/panel-store";
 import { buildWorkspaceExplorerStateKey } from "@/hooks/use-file-explorer-actions";
@@ -1615,36 +1613,22 @@ export function GitDiffPane({
   );
 
   const toast = useToast();
-  const queryClient = useQueryClient();
-  const refreshClient = useHostRuntimeClient(serverId);
   const refreshSupported = useSessionStore(
     (s) => s.sessions[serverId]?.serverInfo?.features?.checkoutRefresh === true,
   );
-  const [isRefreshing, setIsRefreshing] = useState(false);
+  const runRefresh = useCheckoutGitActionsStore((s) => s.refresh);
+  const isRefreshing =
+    useCheckoutGitActionsStore((s) => s.getStatus({ serverId, cwd, actionId: "refresh" })) ===
+    "pending";
 
   const handleRefresh = useCallback(() => {
     if (isRefreshing) {
       return;
     }
-    if (!refreshClient) {
-      toast.error("Host is offline. Reconnect to refresh.");
-      return;
-    }
-    setIsRefreshing(true);
-    void (async () => {
-      try {
-        const payload = await refreshClient.checkoutRefresh(cwd);
-        if (payload.error) {
-          throw new Error(payload.error.message);
-        }
-        await invalidateCheckoutGitQueriesForClient(queryClient, { serverId, cwd });
-      } catch (error) {
-        toast.error(error instanceof Error ? error.message : "Failed to refresh git state.");
-      } finally {
-        setIsRefreshing(false);
-      }
-    })();
-  }, [cwd, isRefreshing, queryClient, refreshClient, serverId, toast]);
+    void runRefresh({ serverId, cwd }).catch((error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to refresh git state.");
+    });
+  }, [cwd, isRefreshing, runRefresh, serverId, toast]);
 
   const {
     status,

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -25,7 +25,8 @@ import {
   type ViewStyle,
   type TextStyle,
 } from "react-native";
-import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { StyleSheet, useUnistyles, withUnistyles } from "react-native-unistyles";
+import type { Theme } from "@/styles/theme";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import {
   AlignJustify,
@@ -1235,13 +1236,16 @@ interface DiffRefreshButtonProps {
   onPress: () => void;
 }
 
+const ThemedRefreshCw = withUnistyles(RefreshCw);
+const ThemedRefreshActivityIndicator = withUnistyles(ActivityIndicator);
+const refreshIconColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+
 function DiffRefreshButton({
   isRefreshing,
   isMobile,
   toggleStyle,
   onPress,
 }: DiffRefreshButtonProps) {
-  const { theme } = useUnistyles();
   const iconSize = isMobile ? 18 : 14;
   return (
     <Tooltip delayDuration={300}>
@@ -1255,9 +1259,9 @@ function DiffRefreshButton({
           disabled={isRefreshing}
         >
           {isRefreshing ? (
-            <ActivityIndicator size="small" color={theme.colors.foregroundMuted} />
+            <ThemedRefreshActivityIndicator size="small" uniProps={refreshIconColorMapping} />
           ) : (
-            <RefreshCw size={iconSize} color={theme.colors.foregroundMuted} />
+            <ThemedRefreshCw size={iconSize} uniProps={refreshIconColorMapping} />
           )}
         </Pressable>
       </TooltipTrigger>

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -83,6 +83,7 @@ import { useGitActions } from "@/git/use-actions";
 import { useCheckoutGitActionsStore } from "@/git/actions-store";
 import { useToast } from "@/contexts/toast-context";
 import { useSessionStore } from "@/stores/session-store";
+import { SyncedLoader } from "@/components/synced-loader";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { usePanelStore } from "@/stores/panel-store";
 import { buildWorkspaceExplorerStateKey } from "@/hooks/use-file-explorer-actions";
@@ -1235,7 +1236,7 @@ interface DiffRefreshButtonProps {
 }
 
 const ThemedRefreshCw = withUnistyles(RefreshCw);
-const ThemedRefreshActivityIndicator = withUnistyles(ActivityIndicator);
+const ThemedSyncedLoader = withUnistyles(SyncedLoader);
 const refreshIconColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
 
 function DiffRefreshButton({
@@ -1257,7 +1258,7 @@ function DiffRefreshButton({
           disabled={isRefreshing}
         >
           {isRefreshing ? (
-            <ThemedRefreshActivityIndicator size="small" uniProps={refreshIconColorMapping} />
+            <ThemedSyncedLoader size={iconSize} uniProps={refreshIconColorMapping} />
           ) : (
             <ThemedRefreshCw size={iconSize} uniProps={refreshIconColorMapping} />
           )}

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -31,6 +31,7 @@ import type {
   CheckoutMergeFromBaseResponse,
   CheckoutPullResponse,
   CheckoutPushResponse,
+  CheckoutRefreshResponse,
   CheckoutPrCreateResponse,
   CheckoutPrMergeResponse,
   CheckoutPrMergeMethod,
@@ -288,6 +289,7 @@ type CheckoutMergePayload = CheckoutMergeResponse["payload"];
 type CheckoutMergeFromBasePayload = CheckoutMergeFromBaseResponse["payload"];
 type CheckoutPullPayload = CheckoutPullResponse["payload"];
 type CheckoutPushPayload = CheckoutPushResponse["payload"];
+type CheckoutRefreshPayload = CheckoutRefreshResponse["payload"];
 type CheckoutPrCreatePayload = CheckoutPrCreateResponse["payload"];
 type CheckoutPrMergePayload = CheckoutPrMergeResponse["payload"];
 type CheckoutGithubSetAutoMergePayload = CheckoutGithubSetAutoMergeResponse["payload"];
@@ -2946,6 +2948,18 @@ export class DaemonClient {
         cwd,
       },
       responseType: "checkout_push_response",
+      timeout: 60000,
+    });
+  }
+
+  async checkoutRefresh(cwd: string, requestId?: string): Promise<CheckoutRefreshPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "checkout_refresh_request",
+        cwd,
+      },
+      responseType: "checkout_refresh_response",
       timeout: 60000,
     });
   }

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -2956,10 +2956,10 @@ export class DaemonClient {
     return this.sendCorrelatedSessionRequest({
       requestId,
       message: {
-        type: "checkout_refresh_request",
+        type: "checkout.refresh.request",
         cwd,
       },
-      responseType: "checkout_refresh_response",
+      responseType: "checkout.refresh.response",
       timeout: 60000,
     });
   }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1383,7 +1383,7 @@ export const CheckoutPushRequestSchema = z.object({
 });
 
 export const CheckoutRefreshRequestSchema = z.object({
-  type: z.literal("checkout_refresh_request"),
+  type: z.literal("checkout.refresh.request"),
   cwd: z.string(),
   requestId: z.string(),
 });
@@ -3085,7 +3085,7 @@ export const CheckoutPushResponseSchema = z.object({
 });
 
 export const CheckoutRefreshResponseSchema = z.object({
-  type: z.literal("checkout_refresh_response"),
+  type: z.literal("checkout.refresh.response"),
   payload: z.object({
     cwd: z.string(),
     success: z.boolean(),

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1382,6 +1382,12 @@ export const CheckoutPushRequestSchema = z.object({
   requestId: z.string(),
 });
 
+export const CheckoutRefreshRequestSchema = z.object({
+  type: z.literal("checkout_refresh_request"),
+  cwd: z.string(),
+  requestId: z.string(),
+});
+
 export const CheckoutPrCreateRequestSchema = z.object({
   type: z.literal("checkout_pr_create_request"),
   cwd: z.string(),
@@ -1887,6 +1893,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   CheckoutMergeFromBaseRequestSchema,
   CheckoutPullRequestSchema,
   CheckoutPushRequestSchema,
+  CheckoutRefreshRequestSchema,
   CheckoutPrCreateRequestSchema,
   CheckoutPrMergeRequestSchema,
   CheckoutGithubSetAutoMergeRequestSchema,
@@ -2121,6 +2128,8 @@ export const ServerInfoStatusPayloadSchema = z
         "terminal-restore-modes": z.boolean().optional(),
         // COMPAT(rewind): added in v0.1.X, drop the gate when floor >= v0.1.X.
         rewind: z.boolean().optional(),
+        // COMPAT(checkoutRefresh): added in v0.1.86, remove gate after 2026-11-29.
+        checkoutRefresh: z.boolean().optional(),
       })
       .optional(),
   })
@@ -3075,6 +3084,16 @@ export const CheckoutPushResponseSchema = z.object({
   }),
 });
 
+export const CheckoutRefreshResponseSchema = z.object({
+  type: z.literal("checkout_refresh_response"),
+  payload: z.object({
+    cwd: z.string(),
+    success: z.boolean(),
+    error: CheckoutErrorSchema.nullable(),
+    requestId: z.string(),
+  }),
+});
+
 export const CheckoutPrCreateResponseSchema = z.object({
   type: z.literal("checkout_pr_create_response"),
   payload: z.object({
@@ -3687,6 +3706,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   CheckoutMergeFromBaseResponseSchema,
   CheckoutPullResponseSchema,
   CheckoutPushResponseSchema,
+  CheckoutRefreshResponseSchema,
   CheckoutPrCreateResponseSchema,
   CheckoutPrMergeResponseSchema,
   CheckoutGithubSetAutoMergeResponseSchema,
@@ -3949,6 +3969,8 @@ export type CheckoutPullRequest = z.infer<typeof CheckoutPullRequestSchema>;
 export type CheckoutPullResponse = z.infer<typeof CheckoutPullResponseSchema>;
 export type CheckoutPushRequest = z.infer<typeof CheckoutPushRequestSchema>;
 export type CheckoutPushResponse = z.infer<typeof CheckoutPushResponseSchema>;
+export type CheckoutRefreshRequest = z.infer<typeof CheckoutRefreshRequestSchema>;
+export type CheckoutRefreshResponse = z.infer<typeof CheckoutRefreshResponseSchema>;
 export type CheckoutPrCreateRequest = z.infer<typeof CheckoutPrCreateRequestSchema>;
 export type CheckoutPrCreateResponse = z.infer<typeof CheckoutPrCreateResponseSchema>;
 export type CheckoutPrMergeRequest = z.infer<typeof CheckoutPrMergeRequestSchema>;

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -2569,7 +2569,7 @@ describe("session checkout refresh handling", () => {
     });
 
     await asSessionInternals(session).handleCheckoutRefreshRequest({
-      type: "checkout_refresh_request",
+      type: "checkout.refresh.request",
       cwd: "/tmp/request-worktree",
       requestId: "request-refresh",
     });
@@ -2582,7 +2582,7 @@ describe("session checkout refresh handling", () => {
     });
     expect(checkoutDiffManager.scheduleRefreshForCwd).toHaveBeenCalledWith("/tmp/request-worktree");
     expect(messages).toContainEqual({
-      type: "checkout_refresh_response",
+      type: "checkout.refresh.response",
       payload: {
         cwd: "/tmp/request-worktree",
         success: true,
@@ -2607,14 +2607,14 @@ describe("session checkout refresh handling", () => {
     });
 
     await asSessionInternals(session).handleCheckoutRefreshRequest({
-      type: "checkout_refresh_request",
+      type: "checkout.refresh.request",
       cwd: "/tmp/request-worktree",
       requestId: "request-refresh-error",
     });
 
     expect(checkoutDiffManager.scheduleRefreshForCwd).not.toHaveBeenCalled();
     expect(messages).toContainEqual({
-      type: "checkout_refresh_response",
+      type: "checkout.refresh.response",
       payload: {
         cwd: "/tmp/request-worktree",
         success: false,

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -63,6 +63,7 @@ interface SessionHandlerInternals {
   handleCheckoutGithubSetAutoMergeRequest(params: unknown): Promise<unknown>;
   handleCheckoutPullRequest(params: unknown): Promise<unknown>;
   handleCheckoutPushRequest(params: unknown): Promise<unknown>;
+  handleCheckoutRefreshRequest(params: unknown): Promise<unknown>;
   handleCheckoutStatusRequest(params: unknown): Promise<unknown>;
   describeWorkspaceRecord(...args: unknown[]): Promise<WorkspaceDescriptorPayload>;
   describeWorkspaceRecordWithGitData(...args: unknown[]): Promise<WorkspaceDescriptorPayload>;
@@ -2549,6 +2550,76 @@ describe("session checkout pull and push handling", () => {
         success: true,
         error: null,
         requestId: "request-push",
+      },
+    });
+  });
+});
+
+describe("session checkout refresh handling", () => {
+  test("forces a git, GitHub, and diff refresh on demand", async () => {
+    const messages: unknown[] = [];
+    const github = { invalidate: vi.fn() };
+    const workspaceGitService = { getSnapshot: vi.fn().mockResolvedValue({}) };
+    const checkoutDiffManager = { scheduleRefreshForCwd: vi.fn() };
+    const session = createSessionForTest({
+      github,
+      workspaceGitService,
+      checkoutDiffManager,
+      messages,
+    });
+
+    await asSessionInternals(session).handleCheckoutRefreshRequest({
+      type: "checkout_refresh_request",
+      cwd: "/tmp/request-worktree",
+      requestId: "request-refresh",
+    });
+
+    expect(github.invalidate).toHaveBeenCalledWith({ cwd: "/tmp/request-worktree" });
+    expect(workspaceGitService.getSnapshot).toHaveBeenCalledWith("/tmp/request-worktree", {
+      force: true,
+      includeGitHub: true,
+      reason: "manual-refresh",
+    });
+    expect(checkoutDiffManager.scheduleRefreshForCwd).toHaveBeenCalledWith("/tmp/request-worktree");
+    expect(messages).toContainEqual({
+      type: "checkout_refresh_response",
+      payload: {
+        cwd: "/tmp/request-worktree",
+        success: true,
+        error: null,
+        requestId: "request-refresh",
+      },
+    });
+  });
+
+  test("reports an error when the snapshot refresh fails", async () => {
+    const messages: unknown[] = [];
+    const github = { invalidate: vi.fn() };
+    const workspaceGitService = {
+      getSnapshot: vi.fn().mockRejectedValue(new Error("not a git repository")),
+    };
+    const checkoutDiffManager = { scheduleRefreshForCwd: vi.fn() };
+    const session = createSessionForTest({
+      github,
+      workspaceGitService,
+      checkoutDiffManager,
+      messages,
+    });
+
+    await asSessionInternals(session).handleCheckoutRefreshRequest({
+      type: "checkout_refresh_request",
+      cwd: "/tmp/request-worktree",
+      requestId: "request-refresh-error",
+    });
+
+    expect(checkoutDiffManager.scheduleRefreshForCwd).not.toHaveBeenCalled();
+    expect(messages).toContainEqual({
+      type: "checkout_refresh_response",
+      payload: {
+        cwd: "/tmp/request-worktree",
+        success: false,
+        error: { code: "UNKNOWN", message: "not a git repository" },
+        requestId: "request-refresh-error",
       },
     });
   });

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2056,7 +2056,7 @@ export class Session {
         return this.handleCheckoutPullRequest(msg);
       case "checkout_push_request":
         return this.handleCheckoutPushRequest(msg);
-      case "checkout_refresh_request":
+      case "checkout.refresh.request":
         return this.handleCheckoutRefreshRequest(msg);
       case "checkout_pr_create_request":
         return this.handleCheckoutPrCreateRequest(msg);
@@ -5323,7 +5323,7 @@ export class Session {
   }
 
   private async handleCheckoutRefreshRequest(
-    msg: Extract<SessionInboundMessage, { type: "checkout_refresh_request" }>,
+    msg: Extract<SessionInboundMessage, { type: "checkout.refresh.request" }>,
   ): Promise<void> {
     const { cwd, requestId } = msg;
 
@@ -5336,7 +5336,7 @@ export class Session {
       });
       this.checkoutDiffManager.scheduleRefreshForCwd(cwd);
       this.emit({
-        type: "checkout_refresh_response",
+        type: "checkout.refresh.response",
         payload: {
           cwd,
           success: true,
@@ -5346,7 +5346,7 @@ export class Session {
       });
     } catch (error) {
       this.emit({
-        type: "checkout_refresh_response",
+        type: "checkout.refresh.response",
         payload: {
           cwd,
           success: false,

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2056,6 +2056,8 @@ export class Session {
         return this.handleCheckoutPullRequest(msg);
       case "checkout_push_request":
         return this.handleCheckoutPushRequest(msg);
+      case "checkout_refresh_request":
+        return this.handleCheckoutRefreshRequest(msg);
       case "checkout_pr_create_request":
         return this.handleCheckoutPrCreateRequest(msg);
       case "checkout_pr_merge_request":
@@ -5310,6 +5312,41 @@ export class Session {
     } catch (error) {
       this.emit({
         type: "checkout_push_response",
+        payload: {
+          cwd,
+          success: false,
+          error: toCheckoutError(error),
+          requestId,
+        },
+      });
+    }
+  }
+
+  private async handleCheckoutRefreshRequest(
+    msg: Extract<SessionInboundMessage, { type: "checkout_refresh_request" }>,
+  ): Promise<void> {
+    const { cwd, requestId } = msg;
+
+    try {
+      this.github.invalidate({ cwd });
+      await this.workspaceGitService.getSnapshot(cwd, {
+        force: true,
+        includeGitHub: true,
+        reason: "manual-refresh",
+      });
+      this.checkoutDiffManager.scheduleRefreshForCwd(cwd);
+      this.emit({
+        type: "checkout_refresh_response",
+        payload: {
+          cwd,
+          success: true,
+          error: null,
+          requestId,
+        },
+      });
+    } catch (error) {
+      this.emit({
+        type: "checkout_refresh_response",
         payload: {
           cwd,
           success: false,

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1049,6 +1049,8 @@ export class VoiceAssistantWebSocketServer {
         "terminal-restore-modes": true,
         // COMPAT(rewind): added in v0.1.X, drop the gate when floor >= v0.1.X.
         rewind: true,
+        // COMPAT(checkoutRefresh): added in v0.1.86, remove gate after 2026-11-29.
+        checkoutRefresh: true,
       },
     };
   }


### PR DESCRIPTION
## Summary

Adds a **refresh button** next to the git diff controls. It's an escape hatch for when the polled git/GitHub state goes stale (reported on Discord: diff view lagging ~30 min behind GitHub, and push-from-UI failing after a CLI commit because the UI works off a stale ahead/behind snapshot).

Pressing it forces the daemon to re-read everything from scratch — no caches, no waiting for the next poll:

- New `checkout_refresh` RPC. The handler invalidates the GitHub cache, forces a full git snapshot recompute (`force: true, includeGitHub: true`), and schedules a diff refresh. The recomputed state is pushed to the client through the existing subscription updates.
- The button is feature-gated on `server_info.features.checkoutRefresh` so old daemons simply don't show it (no degraded fallback path, per the project's compat rules).
- Shows a spinner while in flight and a toast on error (offline host, git failure, etc.).

## Changes

- `packages/protocol` — `checkout_refresh_request`/`checkout_refresh_response` schemas + `features.checkoutRefresh` flag (tagged `COMPAT(checkoutRefresh)`).
- `packages/client` — `checkoutRefresh()` client method.
- `packages/server` — `handleCheckoutRefreshRequest` + dispatch; advertise the feature.
- `packages/app` — `DiffRefreshButton` in the diff controls row, wired to the RPC with loading state and error toast.

## Test plan

- [x] `npm run typecheck` (all workspaces) — green
- [x] `npm run lint` / `npm run format:check` on changed files — green
- [x] Server unit tests for the handler (success + error paths): `npx vitest run src/server/session.test.ts -t "checkout refresh handling"`
- [ ] **QA:** commit via CLI, confirm the diff/ahead-behind state updates immediately after pressing refresh; verify push-from-UI works without dropping to the CLI.
- [ ] **QA:** error toast shows when the host is offline.
- [ ] **QA:** button is hidden when connected to a pre-0.1.86 daemon.