### PR TITLE
Show connected host daemon versions on the About page

### DIFF
--- a/packages/app/e2e/helpers/settings.ts
+++ b/packages/app/e2e/helpers/settings.ts
@@ -156,7 +156,7 @@ export async function expectDiagnosticsContent(page: Page): Promise<void> {
 }
 
 export async function expectAboutContent(page: Page): Promise<void> {
-  await expect(page.getByText("Version", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("App version", { exact: true }).first()).toBeVisible();
 }
 
 export async function expectGeneralContent(page: Page): Promise<void> {

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -45,7 +45,14 @@ import {
   type Settings as EffectiveSettings,
 } from "@/hooks/use-settings";
 import { THEME_SWATCHES } from "@/styles/theme";
-import { getHostRuntimeStore, isHostRuntimeConnected, useHosts } from "@/runtime/host-runtime";
+import {
+  getHostRuntimeStore,
+  isHostRuntimeConnected,
+  useHostRuntimeIsConnected,
+  useHosts,
+} from "@/runtime/host-runtime";
+import { useSessionStore } from "@/stores/session-store";
+import type { HostProfile } from "@/types/host-connection";
 import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
 import { useWindowControlsPadding } from "@/utils/desktop-window";
 import { confirmDialog } from "@/utils/confirm-dialog";
@@ -442,26 +449,111 @@ function DiagnosticsSection({
 }
 
 interface AboutSectionProps {
+  appVersion: string | null;
   appVersionText: string;
   isDesktopApp: boolean;
 }
 
-function AboutSection({ appVersionText, isDesktopApp }: AboutSectionProps) {
+function AboutSection({ appVersion, appVersionText, isDesktopApp }: AboutSectionProps) {
   return (
-    <SettingsSection title="About">
-      <View style={settingsStyles.card}>
-        <View style={settingsStyles.row}>
-          <View style={settingsStyles.rowContent}>
-            <Text style={settingsStyles.rowTitle}>Version</Text>
+    <>
+      <SettingsSection title="About">
+        <View style={settingsStyles.card}>
+          <View style={settingsStyles.row}>
+            <View style={settingsStyles.rowContent}>
+              <Text style={settingsStyles.rowTitle}>App version</Text>
+              <Text style={settingsStyles.rowHint}>This device</Text>
+            </View>
+            <Text style={styles.aboutValue}>{appVersionText}</Text>
           </View>
-          <Text style={styles.aboutValue}>{appVersionText}</Text>
+          {isDesktopApp ? <DesktopAppUpdateRow /> : null}
         </View>
-        {isDesktopApp ? <DesktopAppUpdateRow /> : null}
-      </View>
+      </SettingsSection>
+      <ConnectedHostsSection clientVersion={appVersion} />
       <View style={styles.aboutCommunity}>
         <CommunityLinks />
       </View>
+    </>
+  );
+}
+
+function normalizeVersion(version: string | null | undefined): string | null {
+  const trimmed = version?.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/^v/i, "");
+}
+
+function ConnectedHostsSection({ clientVersion }: { clientVersion: string | null }) {
+  const hosts = useHosts();
+  if (hosts.length === 0) {
+    return null;
+  }
+  return (
+    <SettingsSection title="Connected hosts">
+      <View style={settingsStyles.card}>
+        {hosts.map((host, index) => (
+          <HostVersionRow
+            key={host.serverId}
+            host={host}
+            showBorder={index > 0}
+            clientVersion={clientVersion}
+          />
+        ))}
+      </View>
     </SettingsSection>
+  );
+}
+
+function HostVersionRow({
+  host,
+  showBorder,
+  clientVersion,
+}: {
+  host: HostProfile;
+  showBorder: boolean;
+  clientVersion: string | null;
+}) {
+  const isConnected = useHostRuntimeIsConnected(host.serverId);
+  const daemonVersion = useSessionStore(
+    (state) => state.sessions[host.serverId]?.serverInfo?.version ?? null,
+  );
+
+  const rowStyle = useMemo(
+    () => [settingsStyles.row, showBorder && settingsStyles.rowBorder],
+    [showBorder],
+  );
+
+  const normalizedHost = normalizeVersion(daemonVersion);
+  const normalizedClient = normalizeVersion(clientVersion);
+  const isMismatch =
+    normalizedHost !== null && normalizedClient !== null && normalizedHost !== normalizedClient;
+
+  let valueText: string;
+  if (!isConnected) {
+    valueText = "Offline";
+  } else if (normalizedHost) {
+    valueText = formatVersionWithPrefix(normalizedHost);
+  } else {
+    valueText = "—";
+  }
+
+  const valueStyle = useMemo(
+    () => [styles.aboutValue, isMismatch && styles.aboutVersionMismatch],
+    [isMismatch],
+  );
+
+  return (
+    <View style={rowStyle}>
+      <View style={settingsStyles.rowContent}>
+        <Text style={settingsStyles.rowTitle} numberOfLines={1}>
+          {host.label}
+        </Text>
+        {isMismatch ? (
+          <Text style={settingsStyles.rowHint}>Version differs from this device</Text>
+        ) : null}
+      </View>
+      <Text style={valueStyle}>{valueText}</Text>
+    </View>
   );
 }
 
@@ -1106,7 +1198,13 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
             />
           );
         case "about":
-          return <AboutSection appVersionText={appVersionText} isDesktopApp={isDesktopApp} />;
+          return (
+            <AboutSection
+              appVersion={appVersion}
+              appVersionText={appVersionText}
+              isDesktopApp={isDesktopApp}
+            />
+          );
       }
     }
     return null;
@@ -1265,6 +1363,9 @@ const styles = StyleSheet.create((theme) => ({
   aboutValue: {
     color: theme.colors.foregroundMuted,
     fontSize: theme.fontSize.sm,
+  },
+  aboutVersionMismatch: {
+    color: theme.colors.palette.amber[500],
   },
   aboutErrorText: {
     color: theme.colors.palette.red[300],


### PR DESCRIPTION
Adds a "Connected hosts" section to the About page so you can see this device's app version alongside every connected host's daemon version at a glance. When a host's daemon version differs from the app version, the row is flagged in amber so version mismatches are easy to spot.

### Linked issue

<!-- no tracking issue -->

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The About page previously showed only a single "Version" row (the app on this device). It now:

- Relabels that row to "App version" with a "This device" hint, so it's clearly the client.
- Adds a "Connected hosts" section listing each known host with its daemon version (from the `server_info` handshake). Offline hosts show "Offline"; hosts whose version isn't known yet show "—".
- Highlights any host whose daemon version differs from the app version in amber with a "Version differs from this device" hint, making mismatches quick to catch.

Host data comes from the existing `useHosts()` registry; daemon versions come from each session's `serverInfo.version`. No protocol changes.

### How did you verify it

- `npm run typecheck`, `npm run lint`, and `npm run format` all pass (also enforced by the pre-commit hook).
- I have **not** yet run the app or captured screenshots. This is a web/native Expo UI change — before merge it's worth smoking the About screen on at least one mobile build and web/desktop to confirm the rows render and the mismatch styling looks right with a real connected host. The version-comparison and offline/unknown states are pure presentation logic with no new daemon dependency.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [ ] Tests added or updated where it made sense