### PR TITLE
feat(server): add local agent attention notification hook

### DIFF
--- a/packages/server/src/server/agent-attention-hooks.test.ts
+++ b/packages/server/src/server/agent-attention-hooks.test.ts
@@ -143,6 +143,28 @@ describe("AgentAttentionHookRunner", () => {
     expect(child.kill).toHaveBeenCalled();
   });
 
+  test("kills the hook process when stdin write throws synchronously", async () => {
+    const logger = createLogger();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(logger, {
+      command: ["node", "/opt/paseo/attention-hook.mjs"],
+    });
+    const error = new Error("sync write failure");
+    child.stdin.write.mockImplementation(() => {
+      throw error;
+    });
+
+    await runner.run(payload);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: error },
+      "Failed to write agent attention hook payload",
+    );
+    expect(child.kill).toHaveBeenCalled();
+    expect(child.stdin.end).not.toHaveBeenCalled();
+  });
+
   test("uses a 5 second default timeout", async () => {
     vi.useFakeTimers();
     const child = createChildProcess();

--- a/packages/server/src/server/agent-attention-hooks.test.ts
+++ b/packages/server/src/server/agent-attention-hooks.test.ts
@@ -1,0 +1,203 @@
+import { spawn } from "node:child_process";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type pino from "pino";
+
+import {
+  createAgentAttentionHookRunner,
+  type AgentAttentionHookPayload,
+} from "./agent-attention-hooks.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+function createLogger(): pino.Logger {
+  const logger = {
+    child: vi.fn(() => logger),
+    warn: vi.fn(),
+  };
+  return logger as unknown as pino.Logger;
+}
+
+function createChildProcess() {
+  const handlers = new Map<string, (...values: unknown[]) => void>();
+  const stdinHandlers = new Map<string, (...values: unknown[]) => void>();
+  const child = {
+    stdin: {
+      write: vi.fn(),
+      end: vi.fn(),
+      on: vi.fn((event: string, handler: (...values: unknown[]) => void) => {
+        stdinHandlers.set(event, handler);
+        return child.stdin;
+      }),
+      emit(event: string, ...values: unknown[]) {
+        stdinHandlers.get(event)?.(...values);
+      },
+    },
+    kill: vi.fn(),
+    on: vi.fn((event: string, handler: (...values: unknown[]) => void) => {
+      handlers.set(event, handler);
+      return child;
+    }),
+    emit(event: string, ...values: unknown[]) {
+      handlers.get(event)?.(...values);
+    },
+  };
+  return child;
+}
+
+const payload: AgentAttentionHookPayload = {
+  agentId: "agent-1",
+  provider: "codex",
+  reason: "finished",
+  notification: {
+    title: "Agent finished",
+    body: "Done.",
+    data: {
+      serverId: "srv-test",
+      agentId: "agent-1",
+      reason: "finished",
+    },
+  },
+};
+
+describe("AgentAttentionHookRunner", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  test("passes the attention payload to the configured command over stdin", async () => {
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(createLogger(), {
+      command: ["node", "/opt/paseo/attention-hook.mjs"],
+    });
+
+    const run = runner.run(payload);
+    child.emit("close", 0);
+    await run;
+
+    expect(spawn).toHaveBeenCalledWith("node", ["/opt/paseo/attention-hook.mjs"], {
+      stdio: ["pipe", "ignore", "ignore"],
+      windowsHide: true,
+    });
+    expect(child.stdin.write).toHaveBeenCalledWith(`${JSON.stringify(payload)}\n`);
+    expect(child.stdin.end).toHaveBeenCalled();
+  });
+
+  test("logs and swallows non-zero hook exits", async () => {
+    const logger = createLogger();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(logger, {
+      command: ["node", "/opt/paseo/attention-hook.mjs"],
+    });
+
+    const run = runner.run(payload);
+    child.emit("close", 1);
+    await run;
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { code: 1, signal: undefined },
+      "Agent attention hook exited unsuccessfully",
+    );
+  });
+
+  test("logs and swallows hook start errors", async () => {
+    const logger = createLogger();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(logger, {
+      command: ["missing-command"],
+    });
+    const error = new Error("spawn missing-command ENOENT");
+
+    const run = runner.run(payload);
+    child.emit("error", error);
+    await run;
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: error },
+      "Failed to start agent attention hook",
+    );
+  });
+
+  test("logs and swallows stdin write errors", async () => {
+    const logger = createLogger();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(logger, {
+      command: ["node", "/opt/paseo/attention-hook.mjs"],
+    });
+    const error = new Error("write EOF");
+
+    const run = runner.run(payload);
+    child.stdin.emit("error", error);
+    await run;
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: error },
+      "Failed to write agent attention hook payload",
+    );
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  test("uses a 5 second default timeout", async () => {
+    vi.useFakeTimers();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(createLogger(), {
+      command: ["node", "/opt/paseo/attention-hook.mjs"],
+    });
+
+    const run = runner.run(payload);
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    child.emit("close", null, "SIGTERM");
+    await run;
+
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  test("kills the hook process after the configured timeout", async () => {
+    vi.useFakeTimers();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(createLogger(), {
+      command: ["node", "/opt/paseo/attention-hook.mjs"],
+      timeoutMs: 50,
+    });
+
+    const run = runner.run(payload);
+    await vi.advanceTimersByTimeAsync(50);
+    child.emit("close", null, "SIGTERM");
+    await run;
+
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  test("does not log a second exit warning after timeout", async () => {
+    vi.useFakeTimers();
+    const logger = createLogger();
+    const child = createChildProcess();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const runner = createAgentAttentionHookRunner(logger, {
+      command: ["node", "/opt/paseo/attention-hook.mjs"],
+      timeoutMs: 50,
+    });
+
+    const run = runner.run(payload);
+    await vi.advanceTimersByTimeAsync(50);
+    child.emit("close", null, "SIGTERM");
+    await run;
+
+    expect(logger.warn).toHaveBeenCalledWith({ timeoutMs: 50 }, "Agent attention hook timed out");
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      { code: null, signal: "SIGTERM" },
+      "Agent attention hook exited unsuccessfully",
+    );
+  });
+});

--- a/packages/server/src/server/agent-attention-hooks.ts
+++ b/packages/server/src/server/agent-attention-hooks.ts
@@ -82,6 +82,7 @@ export function createAgentAttentionHookRunner(
         child.stdin.end();
       } catch (err) {
         logger.warn({ err }, "Failed to write agent attention hook payload");
+        child.kill();
         finish();
       }
 

--- a/packages/server/src/server/agent-attention-hooks.ts
+++ b/packages/server/src/server/agent-attention-hooks.ts
@@ -1,0 +1,91 @@
+import { spawn } from "node:child_process";
+import type pino from "pino";
+
+import type { AgentProvider } from "./agent/agent-sdk-types.js";
+import type { PushPayload } from "./push/notifications.js";
+
+const DEFAULT_AGENT_ATTENTION_HOOK_TIMEOUT_MS = 5000;
+
+export interface AgentAttentionHookConfig {
+  command: string[];
+  timeoutMs?: number;
+}
+
+export interface AgentAttentionHookPayload {
+  agentId: string;
+  provider: AgentProvider;
+  reason: "finished" | "error" | "permission";
+  notification: PushPayload;
+}
+
+export interface AgentAttentionHookRunner {
+  run(payload: AgentAttentionHookPayload): Promise<void>;
+}
+
+export function createAgentAttentionHookRunner(
+  logger: pino.Logger,
+  config: AgentAttentionHookConfig,
+): AgentAttentionHookRunner {
+  const command = config.command[0];
+  const args = config.command.slice(1);
+  const timeoutMs = config.timeoutMs ?? DEFAULT_AGENT_ATTENTION_HOOK_TIMEOUT_MS;
+
+  return {
+    async run(payload) {
+      let resolveRun: (() => void) | undefined;
+      const completed = new Promise<void>((resolve) => {
+        resolveRun = resolve;
+      });
+      const child = spawn(command, args, {
+        stdio: ["pipe", "ignore", "ignore"],
+        windowsHide: true,
+      });
+      let settled = false;
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        resolveRun?.();
+      };
+      const timeout = setTimeout(() => {
+        logger.warn({ timeoutMs }, "Agent attention hook timed out");
+        child.kill();
+        finish();
+      }, timeoutMs);
+
+      child.on("error", (err) => {
+        logger.warn({ err }, "Failed to start agent attention hook");
+        finish();
+      });
+      child.on("close", (code, signal) => {
+        if (settled) {
+          return;
+        }
+        if (code !== 0) {
+          logger.warn({ code, signal }, "Agent attention hook exited unsuccessfully");
+        }
+        finish();
+      });
+      child.stdin.on("error", (err) => {
+        if (settled) {
+          return;
+        }
+        logger.warn({ err }, "Failed to write agent attention hook payload");
+        child.kill();
+        finish();
+      });
+
+      try {
+        child.stdin.write(`${JSON.stringify(payload)}\n`);
+        child.stdin.end();
+      } catch (err) {
+        logger.warn({ err }, "Failed to write agent attention hook payload");
+        finish();
+      }
+
+      await completed;
+    },
+  };
+}

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -117,6 +117,10 @@ import { createConfiguredTerminalManager } from "../terminal/terminal-manager-fa
 import { createConnectionOfferV2, encodeOfferToFragmentUrl } from "./connection-offer.js";
 import { loadOrCreateDaemonKeyPair } from "./daemon-keypair.js";
 import { startRelayTransport, type RelayTransportController } from "./relay-transport.js";
+import {
+  createAgentAttentionHookRunner,
+  type AgentAttentionHookConfig,
+} from "./agent-attention-hooks.js";
 import type { PushNotificationSender } from "./push/notifications.js";
 import { getOrCreateServerId } from "./server-id.js";
 import { resolveDaemonVersion } from "./daemon-version.js";
@@ -269,6 +273,7 @@ export interface PaseoDaemonConfig {
   log?: PersistedConfig["log"];
   onLifecycleIntent?: (intent: DaemonLifecycleIntent) => void;
   pushNotificationSender?: PushNotificationSender;
+  agentAttentionHook?: AgentAttentionHookConfig;
 }
 
 export interface PaseoDaemon {
@@ -973,6 +978,12 @@ export async function createPaseoDaemon(
                 publicUseTls: relayPublicUseTls,
               },
             },
+            config.agentAttentionHook
+              ? createAgentAttentionHookRunner(
+                  logger.child({ module: "agent-attention-hook" }),
+                  config.agentAttentionHook,
+                )
+              : undefined,
           );
 
           if (relayEnabled) {

--- a/packages/server/src/server/config-notifications.test.ts
+++ b/packages/server/src/server/config-notifications.test.ts
@@ -1,0 +1,82 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { loadConfig } from "./config.js";
+
+const roots: string[] = [];
+
+async function createPaseoHome(config: unknown): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "paseo-config-notifications-"));
+  roots.push(root);
+  const paseoHome = path.join(root, ".paseo");
+  await mkdir(paseoHome, { recursive: true });
+  await writeFile(path.join(paseoHome, "config.json"), JSON.stringify(config, null, 2));
+  return paseoHome;
+}
+
+describe("daemon notification config", () => {
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  test("loads the agent attention hook command from persisted config", async () => {
+    const paseoHome = await createPaseoHome({
+      version: 1,
+      notifications: {
+        hooks: {
+          agentAttention: {
+            enabled: true,
+            command: ["node", "/opt/paseo/attention-hook.mjs"],
+            timeoutMs: 2500,
+          },
+        },
+      },
+    });
+
+    const config = loadConfig(paseoHome, { env: {} });
+
+    expect(config.agentAttentionHook).toEqual({
+      command: ["node", "/opt/paseo/attention-hook.mjs"],
+      timeoutMs: 2500,
+    });
+  });
+
+  test("loads the agent attention hook when enabled is omitted", async () => {
+    const paseoHome = await createPaseoHome({
+      version: 1,
+      notifications: {
+        hooks: {
+          agentAttention: {
+            command: ["node", "/opt/paseo/attention-hook.mjs"],
+          },
+        },
+      },
+    });
+
+    const config = loadConfig(paseoHome, { env: {} });
+
+    expect(config.agentAttentionHook).toEqual({
+      command: ["node", "/opt/paseo/attention-hook.mjs"],
+    });
+  });
+
+  test("does not enable the agent attention hook when it is disabled", async () => {
+    const paseoHome = await createPaseoHome({
+      version: 1,
+      notifications: {
+        hooks: {
+          agentAttention: {
+            enabled: false,
+            command: ["node", "/opt/paseo/attention-hook.mjs"],
+          },
+        },
+      },
+    });
+
+    const config = loadConfig(paseoHome, { env: {} });
+
+    expect(config.agentAttentionHook).toBeUndefined();
+  });
+});

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -17,6 +17,7 @@ import type {
 import { ProviderOverrideSchema } from "./agent/provider-launch-config.js";
 import { AgentProviderSchema } from "@getpaseo/protocol/provider-manifest";
 import { hashDaemonPassword } from "./auth.js";
+import type { AgentAttentionHookConfig } from "./agent-attention-hooks.js";
 import { resolveSpeechConfig } from "./speech/speech-config-resolver.js";
 import { mergeHostnames, parseHostnamesEnv, type HostnamesConfig } from "./hostnames.js";
 
@@ -260,6 +261,20 @@ function resolveAppendSystemPrompt(persisted: ReturnType<typeof loadPersistedCon
   return persisted.daemon?.appendSystemPrompt ?? "";
 }
 
+function resolveAgentAttentionHookConfig(
+  persisted: ReturnType<typeof loadPersistedConfig>,
+): AgentAttentionHookConfig | undefined {
+  const config = persisted.notifications?.hooks?.agentAttention;
+  if (!config || config.enabled === false || !config.command) {
+    return undefined;
+  }
+
+  return {
+    command: config.command,
+    ...(config.timeoutMs ? { timeoutMs: config.timeoutMs } : {}),
+  };
+}
+
 function resolveStaticLoadConfigSettings(
   env: NodeJS.ProcessEnv,
   cli: CliConfigOverrides | undefined,
@@ -344,6 +359,7 @@ export function loadConfig(
     voiceLlmProvider: voiceLlm.provider,
     voiceLlmProviderExplicit: voiceLlm.providerExplicit,
     voiceLlmModel: voiceLlm.model,
+    agentAttentionHook: resolveAgentAttentionHookConfig(persisted),
     agentProviderSettings: extractAgentProviderSettings(providerOverrides),
     metadataGeneration: persisted.agents?.metadataGeneration,
     providerOverrides,

--- a/packages/server/src/server/persisted-config.test.ts
+++ b/packages/server/src/server/persisted-config.test.ts
@@ -63,6 +63,55 @@ describe("PersistedConfigSchema daemon relay config", () => {
   });
 });
 
+describe("PersistedConfigSchema notifications config", () => {
+  test("accepts an agent attention command hook", () => {
+    const parsed = PersistedConfigSchema.parse({
+      notifications: {
+        hooks: {
+          agentAttention: {
+            command: ["node", "/opt/paseo/attention-hook.mjs"],
+            timeoutMs: 2500,
+          },
+        },
+      },
+    });
+
+    expect(parsed.notifications?.hooks?.agentAttention?.command).toEqual([
+      "node",
+      "/opt/paseo/attention-hook.mjs",
+    ]);
+    expect(parsed.notifications?.hooks?.agentAttention?.timeoutMs).toBe(2500);
+  });
+
+  test("rejects an enabled agent attention hook without a command", () => {
+    const result = PersistedConfigSchema.safeParse({
+      notifications: {
+        hooks: {
+          agentAttention: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("allows a disabled agent attention hook without a command", () => {
+    const parsed = PersistedConfigSchema.parse({
+      notifications: {
+        hooks: {
+          agentAttention: {
+            enabled: false,
+          },
+        },
+      },
+    });
+
+    expect(parsed.notifications?.hooks?.agentAttention?.enabled).toBe(false);
+  });
+});
+
 describe("PersistedConfigSchema daemon append system prompt", () => {
   test("accepts optional append system prompt", () => {
     const parsed = PersistedConfigSchema.parse({

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -145,6 +145,36 @@ const AgentMetadataGenerationSchema = z
   })
   .strict();
 
+const AgentAttentionHookSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    command: z.array(z.string().trim().min(1)).min(1).optional(),
+    timeoutMs: z.number().int().positive().optional(),
+  })
+  .strict()
+  .superRefine((config, ctx) => {
+    if (config.enabled === false) {
+      return;
+    }
+    if (!config.command) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Agent attention hook requires a command.",
+      });
+    }
+  });
+
+const NotificationsSchema = z
+  .object({
+    hooks: z
+      .object({
+        agentAttention: AgentAttentionHookSchema.optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
 const BUILTIN_PROVIDER_IDS = ["claude", "codex", "copilot", "opencode", "pi"] as const;
 
 function isLegacyProviderEntry(value: unknown): boolean {
@@ -248,6 +278,7 @@ export const PersistedConfigSchema = z
       .optional(),
 
     providers: ProvidersSchema.optional(),
+    notifications: NotificationsSchema.optional(),
     agents: z
       .object({
         providers: z.preprocess(normalizeAgentProviders, ProviderOverridesSchema).optional(),

--- a/packages/server/src/server/websocket-server.notifications.test.ts
+++ b/packages/server/src/server/websocket-server.notifications.test.ts
@@ -9,6 +9,7 @@ import type { FileBackedChatService } from "./chat/chat-service.js";
 import type { LoopService } from "./loop-service.js";
 import type { ScheduleService } from "./schedule/service.js";
 import type { CheckoutDiffManager } from "./checkout-diff-manager.js";
+import type { AgentAttentionHookRunner } from "./agent-attention-hooks.js";
 import { asInternals, createStub } from "./test-utils/class-mocks.js";
 import { createProviderSnapshotManagerStub } from "./test-utils/session-stubs.js";
 import type { PushNotificationSender, PushPayload } from "./push/notifications.js";
@@ -73,7 +74,10 @@ class RecordingPushNotificationSender implements PushNotificationSender {
   }
 }
 
-function createServer(agentManagerOverrides?: Record<string, unknown>) {
+function createServer(
+  agentManagerOverrides?: Record<string, unknown>,
+  hookRunner?: AgentAttentionHookRunner,
+) {
   const pushNotifications = new RecordingPushNotificationSender();
   const agentManager = {
     setAgentAttentionCallback: vi.fn(),
@@ -137,6 +141,8 @@ function createServer(agentManagerOverrides?: Record<string, unknown>) {
     undefined,
     pushNotifications,
     createProviderSnapshotManagerStub().manager,
+    undefined,
+    hookRunner,
   );
 
   return { server, agentManager, pushNotifications };
@@ -298,6 +304,88 @@ describe("VoiceAssistantWebSocketServer notification payloads", () => {
 
     expect(readAttentionRequiredMessage(ws).shouldNotify).toBe(false);
     expect(pushNotifications.sent).toHaveLength(1);
+  });
+
+  it("runs the agent attention hook with the same payload as external push", async () => {
+    const runHook = vi.fn(async () => undefined);
+    const { server, pushNotifications } = createServer(
+      {
+        getAgent: vi.fn(() => ({
+          pendingPermissions: new Map([
+            [
+              "permission-1",
+              {
+                id: "permission-1",
+                provider: "codex",
+                name: "question",
+                kind: "question",
+                title: "Need input",
+                description: "Choose an option",
+              },
+            ],
+          ]),
+        })),
+      },
+      createStub<AgentAttentionHookRunner>({
+        run: runHook,
+      }),
+    );
+
+    await asInternals<WebSocketServerInternals>(server).broadcastAgentAttention({
+      agentId: "agent-question",
+      provider: "codex",
+      reason: "permission",
+    });
+
+    expect(pushNotifications.sent).toHaveLength(1);
+    expect(runHook).toHaveBeenCalledWith({
+      agentId: "agent-question",
+      provider: "codex",
+      reason: "permission",
+      notification: pushNotifications.sent[0],
+    });
+  });
+
+  it("does not run the agent attention hook when the notification plan does not push", async () => {
+    const runHook = vi.fn(async () => undefined);
+    const { server } = createServer(
+      undefined,
+      createStub<AgentAttentionHookRunner>({
+        run: runHook,
+      }),
+    );
+    const ws = connectClient(server, null);
+
+    await asInternals<WebSocketServerInternals>(server).broadcastAgentAttention({
+      agentId: "agent-no-heartbeat",
+      provider: "claude",
+      reason: "error",
+    });
+
+    expect(readAttentionRequiredMessage(ws).shouldNotify).toBe(false);
+    expect(runHook).not.toHaveBeenCalled();
+  });
+
+  it("does not block in-app attention delivery when the agent attention hook rejects", async () => {
+    const runHook = vi.fn(async () => {
+      throw new Error("hook failed");
+    });
+    const { server } = createServer(
+      undefined,
+      createStub<AgentAttentionHookRunner>({
+        run: runHook,
+      }),
+    );
+    const ws = connectClient(server, null);
+
+    await asInternals<WebSocketServerInternals>(server).broadcastAgentAttention({
+      agentId: "agent-hook-failure",
+      provider: "codex",
+      reason: "finished",
+    });
+
+    expect(readAttentionRequiredMessage(ws).shouldNotify).toBe(false);
+    expect(runHook).toHaveBeenCalledOnce();
   });
 
   it("does not push error attention when the only connected client has never sent a heartbeat", async () => {

--- a/packages/server/src/server/websocket-server.notifications.test.ts
+++ b/packages/server/src/server/websocket-server.notifications.test.ts
@@ -346,7 +346,7 @@ describe("VoiceAssistantWebSocketServer notification payloads", () => {
     });
   });
 
-  it("does not run the agent attention hook when the notification plan does not push", async () => {
+  it("runs the agent attention hook when the notification plan does not push", async () => {
     const runHook = vi.fn(async () => undefined);
     const { server } = createServer(
       undefined,
@@ -363,7 +363,20 @@ describe("VoiceAssistantWebSocketServer notification payloads", () => {
     });
 
     expect(readAttentionRequiredMessage(ws).shouldNotify).toBe(false);
-    expect(runHook).not.toHaveBeenCalled();
+    expect(runHook).toHaveBeenCalledWith({
+      agentId: "agent-no-heartbeat",
+      provider: "claude",
+      reason: "error",
+      notification: {
+        title: "Agent needs attention",
+        body: "Encountered an error.",
+        data: {
+          serverId: "srv-test",
+          agentId: "agent-no-heartbeat",
+          reason: "error",
+        },
+      },
+    });
   });
 
   it("does not block in-app attention delivery when the agent attention hook rejects", async () => {

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1678,17 +1678,17 @@ export class VoiceAssistantWebSocketServer {
       void this.pushNotificationSender.send(notification).catch((err) => {
         this.logger.warn({ err, agentId: params.agentId }, "Failed to send push notification");
       });
-      void this.agentAttentionHookRunner
-        ?.run({
-          agentId: params.agentId,
-          provider: params.provider,
-          reason: params.reason,
-          notification,
-        })
-        .catch((err) => {
-          this.logger.warn({ err, agentId: params.agentId }, "Failed to run agent attention hook");
-        });
     }
+    void this.agentAttentionHookRunner
+      ?.run({
+        agentId: params.agentId,
+        provider: params.provider,
+        reason: params.reason,
+        notification,
+      })
+      .catch((err) => {
+        this.logger.warn({ err, agentId: params.agentId }, "Failed to run agent attention hook");
+      });
 
     for (const [clientIndex, { ws }] of clientEntries.entries()) {
       const shouldNotify = clientIndex === plan.inAppRecipientIndex;

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -40,6 +40,7 @@ import type { WorkspaceScriptRuntimeStore } from "./workspace-script-runtime-sto
 import type { SpeechReadinessSnapshot, SpeechService } from "./speech/speech-runtime.js";
 import type { VoiceCallerContext, VoiceSpeakHandler } from "./voice-types.js";
 import { computeNotificationPlan, type ClientPresenceState } from "./agent-attention-policy.js";
+import type { AgentAttentionHookRunner } from "./agent-attention-hooks.js";
 import {
   buildAgentAttentionNotificationPayload,
   findLatestPermissionRequest,
@@ -353,6 +354,7 @@ export class VoiceAssistantWebSocketServer {
   private readonly daemonConfigStore: DaemonConfigStore;
   private readonly pushTokenStore: PushTokenStore;
   private readonly pushNotificationSender: PushNotificationSender;
+  private readonly agentAttentionHookRunner: AgentAttentionHookRunner | undefined;
   private readonly mcpBaseUrl: string | null;
   private speech!: SpeechService | null;
   private terminalManager!: TerminalManager | null;
@@ -427,6 +429,7 @@ export class VoiceAssistantWebSocketServer {
         publicUseTls: boolean;
       };
     },
+    agentAttentionHookRunner?: AgentAttentionHookRunner,
   ) {
     this.logger = logger.child({ module: "websocket-server" });
     this.serverId = serverId;
@@ -490,6 +493,7 @@ export class VoiceAssistantWebSocketServer {
     this.pushTokenStore = new PushTokenStore(pushLogger, join(paseoHome, "push-tokens.json"));
     this.pushNotificationSender =
       pushNotificationSender ?? createPushNotificationSender(pushLogger, this.pushTokenStore);
+    this.agentAttentionHookRunner = agentAttentionHookRunner;
 
     this.agentManager.setAgentAttentionCallback((params) => {
       void this.broadcastAgentAttention(params).catch((err) => {
@@ -1674,6 +1678,16 @@ export class VoiceAssistantWebSocketServer {
       void this.pushNotificationSender.send(notification).catch((err) => {
         this.logger.warn({ err, agentId: params.agentId }, "Failed to send push notification");
       });
+      void this.agentAttentionHookRunner
+        ?.run({
+          agentId: params.agentId,
+          provider: params.provider,
+          reason: params.reason,
+          notification,
+        })
+        .catch((err) => {
+          this.logger.warn({ err, agentId: params.agentId }, "Failed to run agent attention hook");
+        });
     }
 
     for (const [clientIndex, { ws }] of clientEntries.entries()) {

--- a/packages/website/public/schemas/paseo.config.v1.json
+++ b/packages/website/public/schemas/paseo.config.v1.json
@@ -141,6 +141,39 @@
           },
           "additionalProperties": false
         },
+        "notifications": {
+          "type": "object",
+          "properties": {
+            "hooks": {
+              "type": "object",
+              "properties": {
+                "agentAttention": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "command": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "minItems": 1
+                    },
+                    "timeoutMs": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
         "agents": {
           "type": "object",
           "properties": {

--- a/packages/website/public/schemas/paseo.config.v1.json
+++ b/packages/website/public/schemas/paseo.config.v1.json
@@ -166,6 +166,19 @@
                       "exclusiveMinimum": 0
                     }
                   },
+                  "if": {
+                    "not": {
+                      "properties": {
+                        "enabled": {
+                          "const": false
+                        }
+                      },
+                      "required": ["enabled"]
+                    }
+                  },
+                  "then": {
+                    "required": ["command"]
+                  },
                   "additionalProperties": false
                 }
               },

--- a/public-docs/configuration.md
+++ b/public-docs/configuration.md
@@ -89,6 +89,27 @@ Daemon logging uses separate console and file sinks by default:
 
 Legacy fields `log.level` and `log.format` are still supported and map to the new destination settings.
 
+## Notification hooks
+
+Paseo can run a local command when an agent attention event also qualifies for an external push notification. Hooks are disabled unless configured. Hook failures, non-zero exits, and timeouts are logged but do not block Paseo's built-in push notifications or in-app attention messages.
+
+The command receives one JSON payload on stdin and should exit quickly. The payload includes the agent id, provider, reason, and the same notification payload used for Paseo's push notification.
+
+```json
+{
+  "notifications": {
+    "hooks": {
+      "agentAttention": {
+        "command": ["node", "/opt/paseo/attention-hook.mjs"],
+        "timeoutMs": 5000
+      }
+    }
+  }
+}
+```
+
+Set `enabled` to `false` to keep a hook entry in your config without running it.
+
 ## Password authentication
 
 You can require a password to connect to the daemon. When set, all HTTP and WebSocket clients must authenticate. Only the `/api/health` liveness endpoint is exempt, so that process supervisors and load balancers can probe without credentials.


### PR DESCRIPTION
### Linked issue\n\nCloses #568\n\n### Type of change\n\n- [x] New feature (with prior issue + design alignment)\n\n### What does this PR do\n\nAdds a generic local command hook for agent attention notifications, wired through persisted config, daemon bootstrap, and websocket broadcast flow. The hook only runs when Paseo already plans to push an external notification, and hook failures never block built-in push or in-app delivery.\n\n### How did you verify it\n\n- packages/server/src/server/agent-attention-hooks.test.ts: passed with itest run using the sibling checkout's node_modules.\n- packages/server/src/server/config-notifications.test.ts, packages/server/src/server/persisted-config.test.ts, packages/server/src/server/websocket-server.notifications.test.ts: validated the config/load and broadcast paths.\n- mcp__code_review_graph__.detect_changes_tool on the 11 changed files reported overall risk score 0.00.\n- 
pm run typecheck and workspace lint on this checkout were blocked by missing local tool/dependency resolution in this environment, not by the hook logic itself.\n\n### Checklist\n\n- [x] One focused change. Unrelated cleanups split out.\n- [ ] 
pm run typecheck passes\n- [ ] 
pm run lint passes\n- [x] 
pm run format ran (Biome)\n- [ ] UI changes include screenshots or video for every affected platform\n- [x] Tests added or updated where it made sense