### PR TITLE
Fix bottom sheet reopen after dismiss

### DIFF
--- a/packages/app/src/components/ui/isolated-bottom-sheet-modal/visibility-tracker.test.ts
+++ b/packages/app/src/components/ui/isolated-bottom-sheet-modal/visibility-tracker.test.ts
@@ -118,4 +118,18 @@ describe("bottom sheet visibility tracker", () => {
     tracker.handleSheetIndexChange(-1);
     expect(closeCount()).toBe(2);
   });
+
+  it("allows presenting again when the controller detaches during dismissal", () => {
+    const { sheet, tracker } = setup();
+    tracker.attachController(sheet);
+    tracker.syncDesired({ visible: true });
+
+    tracker.handleSheetIndexChange(-1);
+    tracker.attachController(null);
+    tracker.syncDesired({ visible: false });
+    tracker.attachController(sheet);
+    tracker.syncDesired({ visible: true });
+
+    expect(sheet.events).toEqual([{ type: "present" }, { type: "present" }]);
+  });
 });

--- a/packages/app/src/components/ui/isolated-bottom-sheet-modal/visibility-tracker.ts
+++ b/packages/app/src/components/ui/isolated-bottom-sheet-modal/visibility-tracker.ts
@@ -46,6 +46,10 @@ export function createBottomSheetVisibilityTracker(opts: {
   return {
     attachController(next) {
       controller = next;
+      if (!next) {
+        isPresented = false;
+        return;
+      }
       if (next && visible && isEnabled !== false) {
         present();
       }

--- a/packages/app/src/components/ui/isolated-bottom-sheet-modal/visibility-tracker.ts
+++ b/packages/app/src/components/ui/isolated-bottom-sheet-modal/visibility-tracker.ts
@@ -50,7 +50,7 @@ export function createBottomSheetVisibilityTracker(opts: {
         isPresented = false;
         return;
       }
-      if (next && visible && isEnabled !== false) {
+      if (visible && isEnabled !== false) {
         present();
       }
     },


### PR DESCRIPTION
## Summary
- Reset isolated bottom sheet presented state when its controller detaches
- Add regression coverage for dismiss/detach followed by presenting again

## Testing
- npx vitest run packages/app/src/components/ui/isolated-bottom-sheet-modal/visibility-tracker.test.ts --bail=1
- npm run lint -- packages/app/src/components/ui/isolated-bottom-sheet-modal/visibility-tracker.ts packages/app/src/components/ui/isolated-bottom-sheet-modal/visibility-tracker.test.ts
- npm run typecheck --workspace=@getpaseo/app
- pre-commit: lint, format check, full workspace typecheck