### PR TITLE
fix: resolve symlinks in workspace path normalization

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1580,7 +1580,11 @@ export class Session {
   ): Promise<PersistedWorkspaceRecord | null> {
     const normalizedCwd = await this.resolveWorkspaceDirectory(cwd, options);
     const workspaces = await this.workspaceRegistry.list();
-    return workspaces.find((workspace) => workspace.cwd === normalizedCwd) ?? null;
+    return (
+      workspaces.find(
+        (workspace) => normalizePersistedWorkspaceId(workspace.cwd) === normalizedCwd,
+      ) ?? null
+    );
   }
 
   private async resolveWorkspaceDirectory(

--- a/packages/server/src/server/workspace-directory.ts
+++ b/packages/server/src/server/workspace-directory.ts
@@ -222,7 +222,7 @@ export class WorkspaceDirectory {
       return exact.workspaceId;
     }
 
-    const userHome = homedir();
+    const userHome = normalizeWorkspaceId(homedir());
     let bestMatch: { workspace: PersistedWorkspaceRecord; normalizedCwd: string } | null = null;
     for (const workspace of workspaces) {
       if (workspace.archivedAt) continue;

--- a/packages/server/src/server/workspace-directory.ts
+++ b/packages/server/src/server/workspace-directory.ts
@@ -215,26 +215,29 @@ export class WorkspaceDirectory {
 
   resolveRegisteredWorkspaceIdForCwd(cwd: string, workspaces: PersistedWorkspaceRecord[]): string {
     const normalizedCwd = normalizeWorkspaceId(cwd);
-    const exact = workspaces.find((workspace) => workspace.cwd === normalizedCwd);
+    const exact = workspaces.find(
+      (workspace) => normalizeWorkspaceId(workspace.cwd) === normalizedCwd,
+    );
     if (exact) {
       return exact.workspaceId;
     }
 
     const userHome = homedir();
-    let bestMatch: PersistedWorkspaceRecord | null = null;
+    let bestMatch: { workspace: PersistedWorkspaceRecord; normalizedCwd: string } | null = null;
     for (const workspace of workspaces) {
-      if (workspace.cwd === userHome) continue;
       if (workspace.archivedAt) continue;
-      const prefix = workspace.cwd.endsWith(sep) ? workspace.cwd : `${workspace.cwd}${sep}`;
+      const normalizedWsCwd = normalizeWorkspaceId(workspace.cwd);
+      if (normalizedWsCwd === userHome) continue;
+      const prefix = normalizedWsCwd.endsWith(sep) ? normalizedWsCwd : `${normalizedWsCwd}${sep}`;
       if (!normalizedCwd.startsWith(prefix)) {
         continue;
       }
-      if (!bestMatch || workspace.cwd.length > bestMatch.cwd.length) {
-        bestMatch = workspace;
+      if (!bestMatch || normalizedWsCwd.length > bestMatch.normalizedCwd.length) {
+        bestMatch = { workspace, normalizedCwd: normalizedWsCwd };
       }
     }
 
-    return bestMatch?.workspaceId ?? normalizedCwd;
+    return bestMatch?.workspace.workspaceId ?? normalizedCwd;
   }
 
   async listDescriptors(): Promise<WorkspaceDescriptorPayload[]> {

--- a/packages/server/src/server/workspace-registry-model.test.ts
+++ b/packages/server/src/server/workspace-registry-model.test.ts
@@ -219,7 +219,7 @@ describe("normalizeWorkspaceId", () => {
     mkdirSync(realDir, { recursive: true });
     symlinkSync(realDir, linkPath);
 
-    expect(normalizeWorkspaceId(linkPath)).toBe(realPathSync(realDir));
+    expect(normalizeWorkspaceId(linkPath)).toBe(realpathSync(realDir));
   });
 
   test("returns resolved path when no symlink is involved", () => {

--- a/packages/server/src/server/workspace-registry-model.test.ts
+++ b/packages/server/src/server/workspace-registry-model.test.ts
@@ -1,3 +1,7 @@
+import { mkdirSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, test, vi } from "vitest";
 
 import {
@@ -195,5 +199,39 @@ describe("git worktree grouping", () => {
         mainRepoRoot: "/tmp/repo",
       }),
     ).toBe("worktree");
+  });
+});
+
+describe("normalizeWorkspaceId", () => {
+  const testDir = join(tmpdir(), "paseo-test-normalize");
+
+  afterEach(() => {
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test("resolves symlinks to their real path", () => {
+    const realDir = join(testDir, "real-dir");
+    const linkPath = join(testDir, "link-to-dir");
+    mkdirSync(realDir, { recursive: true });
+    symlinkSync(realDir, linkPath);
+
+    expect(normalizeWorkspaceId(linkPath)).toBe(realPathSync(realDir));
+  });
+
+  test("returns resolved path when no symlink is involved", () => {
+    expect(normalizeWorkspaceId("/tmp")).toBe(realpathSync("/tmp"));
+  });
+
+  test("returns resolved path for non-existent paths (realpathSync fails gracefully)", () => {
+    const result = normalizeWorkspaceId("/nonexistent/path");
+    expect(result).toBe("/nonexistent/path");
+  });
+
+  test("returns empty string unchanged", () => {
+    expect(normalizeWorkspaceId("")).toBe("");
   });
 });

--- a/packages/server/src/server/workspace-registry-model.ts
+++ b/packages/server/src/server/workspace-registry-model.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
 
 import type {
@@ -32,7 +33,12 @@ export function normalizeWorkspaceId(cwd: string): string {
   if (!trimmed) {
     return cwd;
   }
-  return resolve(trimmed);
+  const resolved = resolve(trimmed);
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
 }
 
 export function deriveWorkspaceId(cwd: string, checkout: ProjectCheckoutLitePayload): string {


### PR DESCRIPTION
  ## Summary

  - `normalizeWorkspaceId` used `path.resolve()` which does not follow symlinks
  - When `--cwd` uses a symlink path (e.g. `/data/app` → `/data1/app`), workspace lookup fails because stored paths are real paths but input
  paths are symlink paths
  - Add `fs.realpathSync` to `normalizeWorkspaceId`, and normalize both input and stored paths in all comparison sites
 
  ## Changes

  - **`workspace-registry-model.ts`**: Add `realpathSync` with `try/catch` fallback to `normalizeWorkspaceId`
  - **`workspace-directory.ts`**: Normalize stored `workspace.cwd` in both exact match and prefix match paths of
  `resolveRegisteredWorkspaceIdForCwd`
  - **`session.ts`**: Normalize stored `workspace.cwd` in `findExactWorkspaceByDirectory`
  - **`workspace-registry-model.test.ts`**: Add symlink resolution tests
