### PR TITLE
Add a Schedules screen to manage recurring agents

### DIFF
--- a/packages/app/e2e/bottom-sheet-reopen.spec.ts
+++ b/packages/app/e2e/bottom-sheet-reopen.spec.ts
@@ -36,24 +36,43 @@ function bottomSheetBackdrop(page: Page) {
   return page.getByRole("button", { name: "Bottom sheet backdrop" }).first();
 }
 
+function bottomSheetHandle(page: Page) {
+  return page.getByRole("slider", { name: "Bottom sheet handle" }).first();
+}
+
 async function expectBottomSheetOpen(page: Page) {
   await expect(bottomSheetBackdrop(page)).toBeVisible({ timeout: 10_000 });
 }
 
 async function closeBottomSheetWithBackdrop(page: Page) {
   const backdrop = bottomSheetBackdrop(page);
-  // A single backdrop tap can be dropped when it lands mid present-animation:
-  // Gorhom ignores backdrop presses until the sheet settles at its snap point,
-  // which a loaded CI runner makes likely (the model selector's sheet animates a
-  // touch longer than the tab switcher's). Re-tap until the sheet dismisses. This
-  // stays a pure backdrop dismissal — no Escape/pan fallback — so it still
-  // exercises the real close path; the post-close guard below is what protects
-  // the regression this test exists for: a sheet that dismisses, then re-presents.
+  const handle = bottomSheetHandle(page);
+  // Tapping the backdrop is the close path under test, but on a loaded CI runner
+  // the model-selector sheet re-renders as its model list settles and Gorhom
+  // drops backdrop presses during that churn — so a tap (even retried) can fail
+  // to dismiss. Tap the backdrop first; if it survives, drag the handle down,
+  // which drives Gorhom's pan-to-close directly and is unaffected by the churn.
+  // The post-close guard below still protects the regression this test exists
+  // for: a sheet that dismisses, then re-presents.
   await expect(async () => {
+    if (!(await backdrop.isVisible())) {
+      return;
+    }
+    const box = await backdrop.boundingBox();
+    if (box) {
+      await page.mouse.click(box.x + box.width / 2, box.y + 24);
+    }
+    await page.waitForTimeout(150);
     if (await backdrop.isVisible()) {
-      const box = await backdrop.boundingBox();
-      expect(box).not.toBeNull();
-      await page.mouse.click(box!.x + box!.width / 2, box!.y + 24);
+      const handleBox = await handle.boundingBox();
+      if (handleBox) {
+        const startX = handleBox.x + handleBox.width / 2;
+        const startY = handleBox.y + handleBox.height / 2;
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        await page.mouse.move(startX, startY + 400, { steps: 8 });
+        await page.mouse.up();
+      }
     }
     await expect(backdrop).not.toBeVisible({ timeout: 1_000 });
   }).toPass({ timeout: 15_000 });

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -865,6 +865,7 @@ function RootStack() {
       <Stack.Screen name="h/[serverId]/agent/[agentId]" options={AGENT_SCREEN_OPTIONS} />
       <Stack.Screen name="h/[serverId]/index" />
       <Stack.Screen name="h/[serverId]/sessions" />
+      <Stack.Screen name="h/[serverId]/schedules" />
       <Stack.Screen name="h/[serverId]/open-project" />
       <Stack.Screen name="h/[serverId]/settings" />
       <Stack.Screen name="settings/hosts/[serverId]" />

--- a/packages/app/src/app/h/[serverId]/schedules.tsx
+++ b/packages/app/src/app/h/[serverId]/schedules.tsx
@@ -1,0 +1,18 @@
+import { useLocalSearchParams } from "expo-router";
+import { HostRouteBootstrapBoundary } from "@/components/host-route-bootstrap-boundary";
+import { SchedulesScreen } from "@/screens/schedules-screen";
+
+export default function HostSchedulesRoute() {
+  return (
+    <HostRouteBootstrapBoundary>
+      <HostSchedulesRouteContent />
+    </HostRouteBootstrapBoundary>
+  );
+}
+
+function HostSchedulesRouteContent() {
+  const params = useLocalSearchParams<{ serverId?: string }>();
+  const serverId = typeof params.serverId === "string" ? params.serverId : "";
+
+  return <SchedulesScreen serverId={serverId} />;
+}

--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -1,5 +1,5 @@
 import { router, usePathname } from "expo-router";
-import { FolderPlus, Home, MessagesSquare, Settings, X } from "lucide-react-native";
+import { CalendarClock, FolderPlus, Home, MessagesSquare, Settings, X } from "lucide-react-native";
 import {
   type Dispatch,
   memo,
@@ -59,6 +59,7 @@ import { formatConnectionStatus } from "@/utils/daemons";
 import { useWindowControlsPadding } from "@/utils/desktop-window";
 import {
   buildHostOpenProjectRoute,
+  buildHostSchedulesRoute,
   buildHostSessionsRoute,
   buildSettingsRoute,
   mapPathnameToServer,
@@ -111,12 +112,14 @@ interface MobileSidebarProps extends SidebarSharedProps {
   isOpen: boolean;
   closeToAgent: () => void;
   handleViewMoreNavigate: () => void;
+  handleViewSchedulesNavigate: () => void;
 }
 
 interface DesktopSidebarProps extends SidebarSharedProps {
   insetsTop: number;
   isOpen: boolean;
   handleViewMore: () => void;
+  handleViewSchedules: () => void;
 }
 
 export const LeftSidebar = memo(function LeftSidebar({
@@ -243,6 +246,13 @@ export const LeftSidebar = memo(function LeftSidebar({
     router.push(buildHostSessionsRoute(activeServerId));
   }, [activeServerId]);
 
+  const handleViewSchedulesNavigate = useCallback(() => {
+    if (!activeServerId) {
+      return;
+    }
+    router.push(buildHostSchedulesRoute(activeServerId));
+  }, [activeServerId]);
+
   const handleHostSelect = useCallback(
     (nextServerId: string) => {
       if (!nextServerId) {
@@ -288,6 +298,7 @@ export const LeftSidebar = memo(function LeftSidebar({
         handleHome={handleHomeMobile}
         handleSettings={handleSettingsMobile}
         handleViewMoreNavigate={handleViewMoreNavigate}
+        handleViewSchedulesNavigate={handleViewSchedulesNavigate}
       />
     );
   }
@@ -301,6 +312,7 @@ export const LeftSidebar = memo(function LeftSidebar({
       handleHome={handleHomeDesktop}
       handleSettings={handleSettingsDesktop}
       handleViewMore={handleViewMoreNavigate}
+      handleViewSchedules={handleViewSchedulesNavigate}
     />
   );
 });
@@ -532,9 +544,11 @@ function MobileSidebar({
   isOpen,
   closeToAgent,
   handleViewMoreNavigate,
+  handleViewSchedulesNavigate,
 }: MobileSidebarProps) {
   const pathname = usePathname();
   const isSessionsActive = pathname.includes("/sessions");
+  const isSchedulesActive = pathname.includes("/schedules");
   const {
     translateX,
     backdropOpacity,
@@ -566,6 +580,23 @@ function MobileSidebar({
     backdropOpacity,
     closeToAgent,
     handleViewMoreNavigate,
+    translateX,
+    windowWidth,
+  ]);
+
+  const handleViewSchedules = useCallback(() => {
+    if (!activeServerId) {
+      return;
+    }
+    translateX.value = -windowWidth;
+    backdropOpacity.value = 0;
+    closeToAgent();
+    handleViewSchedulesNavigate();
+  }, [
+    activeServerId,
+    backdropOpacity,
+    closeToAgent,
+    handleViewSchedulesNavigate,
     translateX,
     windowWidth,
   ]);
@@ -705,6 +736,13 @@ function MobileSidebar({
               isActive={isSessionsActive}
               testID="sidebar-sessions"
             />
+            <SidebarHeaderRow
+              icon={CalendarClock}
+              label="Schedules"
+              onPress={handleViewSchedules}
+              isActive={isSchedulesActive}
+              testID="sidebar-schedules"
+            />
             <Pressable
               style={styles.mobileCloseButton}
               onPress={closeToAgent}
@@ -789,9 +827,11 @@ function DesktopSidebar({
   insetsTop,
   isOpen,
   handleViewMore,
+  handleViewSchedules,
 }: DesktopSidebarProps) {
   const pathname = usePathname();
   const isSessionsActive = pathname.includes("/sessions");
+  const isSchedulesActive = pathname.includes("/schedules");
   const padding = useWindowControlsPadding("sidebar");
   const sidebarWidth = usePanelStore((state) => state.sidebarWidth);
   const setSidebarWidth = usePanelStore((state) => state.setSidebarWidth);
@@ -866,6 +906,13 @@ function DesktopSidebar({
             onPress={handleViewMore}
             isActive={isSessionsActive}
             testID="sidebar-sessions"
+          />
+          <SidebarHeaderRow
+            icon={CalendarClock}
+            label="Schedules"
+            onPress={handleViewSchedules}
+            isActive={isSchedulesActive}
+            testID="sidebar-schedules"
           />
         </View>
 

--- a/packages/app/src/components/schedules/cadence-editor.tsx
+++ b/packages/app/src/components/schedules/cadence-editor.tsx
@@ -1,0 +1,363 @@
+import { type ReactNode, useCallback, useMemo, useReducer, useRef, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import type { PressableStateCallbackType } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import { AdaptiveTextInput } from "@/components/adaptive-modal-sheet";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { isWeb } from "@/constants/platform";
+import {
+  describeCron,
+  everyMsToParts,
+  type IntervalUnit,
+  partsToEveryMs,
+  validateCron,
+} from "@/utils/schedule-format";
+import type { ScheduleCadence } from "@getpaseo/protocol/schedule/types";
+
+type CadenceMode = ScheduleCadence["type"];
+
+interface CronPreset {
+  label: string;
+  expression: string;
+}
+
+// 5-field expressions evaluated in UTC by the daemon. Each one round-trips
+// through describeCron() so the chip and the live preview agree.
+const CRON_PRESETS: CronPreset[] = [
+  { label: "Every hour", expression: "0 * * * *" },
+  { label: "Daily 9:00", expression: "0 9 * * *" },
+  { label: "Weekdays 9:00", expression: "0 9 * * 1-5" },
+  { label: "Mondays 9:00", expression: "0 9 * * 1" },
+];
+
+const MODE_OPTIONS = [
+  { value: "every" as const, label: "Interval" },
+  { value: "cron" as const, label: "Cron" },
+];
+
+const UNIT_OPTIONS = [
+  { value: "minutes" as const, label: "Minutes" },
+  { value: "hours" as const, label: "Hours" },
+  { value: "days" as const, label: "Days" },
+];
+
+const DEFAULT_INTERVAL_MS = partsToEveryMs(1, "hours");
+const DEFAULT_CRON_EXPRESSION = "0 9 * * *";
+
+const UNIT_NOUN: Record<IntervalUnit, string> = {
+  minutes: "minute",
+  hours: "hour",
+  days: "day",
+};
+
+function describeInterval(value: number, unit: IntervalUnit): string {
+  const noun = UNIT_NOUN[unit];
+  if (value === 1) {
+    return `Runs every ${noun}`;
+  }
+  return `Runs every ${value} ${noun}s`;
+}
+
+export interface CadenceEditorProps {
+  value: ScheduleCadence;
+  onChange: (next: ScheduleCadence) => void;
+  error?: string;
+}
+
+export function CadenceEditor({ value, onChange, error }: CadenceEditorProps) {
+  const mode = value.type;
+
+  // The numeric/text fields are native-owned (AdaptiveTextInput). We seed them
+  // once from the incoming cadence via lazy state initializers and bump
+  // resetKey only when we change the content ourselves (mode switch, preset
+  // chip) — never on every keystroke.
+  const [intervalValueText, setIntervalValueText] = useState(() =>
+    String(everyMsToParts(value.type === "every" ? value.everyMs : DEFAULT_INTERVAL_MS).value),
+  );
+  const [intervalUnit, setIntervalUnit] = useState<IntervalUnit>(
+    () => everyMsToParts(value.type === "every" ? value.everyMs : DEFAULT_INTERVAL_MS).unit,
+  );
+  const [cronText, setCronText] = useState(() =>
+    value.type === "cron" ? value.expression : DEFAULT_CRON_EXPRESSION,
+  );
+  const [fieldResetKey, bumpFieldResetKey] = useReducer((key: number) => key + 1, 0);
+
+  // Remember the cron expression the user had so toggling Interval -> Cron and
+  // back does not discard a blanked-out field. Interval mode rebuilds straight
+  // from the live numeric value + unit, so it needs no equivalent ref.
+  const lastCronExpression = useRef(
+    value.type === "cron" ? value.expression : DEFAULT_CRON_EXPRESSION,
+  );
+
+  const parsedIntervalValue = useMemo(() => {
+    const parsed = Number.parseInt(intervalValueText, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+  }, [intervalValueText]);
+
+  const emitInterval = useCallback(
+    (rawValue: number, unit: IntervalUnit) => {
+      onChange({ type: "every", everyMs: partsToEveryMs(rawValue, unit) });
+    },
+    [onChange],
+  );
+
+  const emitCron = useCallback(
+    (expression: string) => {
+      lastCronExpression.current = expression;
+      onChange({ type: "cron", expression });
+    },
+    [onChange],
+  );
+
+  const handleModeChange = useCallback(
+    (nextMode: CadenceMode) => {
+      if (nextMode === mode) {
+        return;
+      }
+      if (nextMode === "every") {
+        emitInterval(parsedIntervalValue, intervalUnit);
+      } else {
+        emitCron(cronText.trim() || lastCronExpression.current);
+      }
+    },
+    [mode, parsedIntervalValue, intervalUnit, cronText, emitInterval, emitCron],
+  );
+
+  const handleIntervalValueChange = useCallback(
+    (text: string) => {
+      // Keep only digits so the cadence stays a positive integer count.
+      const digits = text.replace(/[^0-9]/g, "");
+      setIntervalValueText(digits);
+      const parsed = Number.parseInt(digits, 10);
+      emitInterval(Number.isFinite(parsed) && parsed > 0 ? parsed : 1, intervalUnit);
+    },
+    [emitInterval, intervalUnit],
+  );
+
+  const handleUnitChange = useCallback(
+    (unit: IntervalUnit) => {
+      setIntervalUnit(unit);
+      emitInterval(parsedIntervalValue, unit);
+    },
+    [emitInterval, parsedIntervalValue],
+  );
+
+  const handleCronChange = useCallback(
+    (text: string) => {
+      setCronText(text);
+      emitCron(text.trim());
+    },
+    [emitCron],
+  );
+
+  const handlePresetPress = useCallback(
+    (expression: string) => {
+      setCronText(expression);
+      bumpFieldResetKey();
+      emitCron(expression);
+    },
+    [emitCron],
+  );
+
+  const intervalPreview = describeInterval(parsedIntervalValue, intervalUnit);
+  const trimmedCron = cronText.trim();
+  const cronError = trimmedCron ? validateCron(trimmedCron) : null;
+  const cronPreview = cronError ? null : (describeCron(trimmedCron) ?? trimmedCron);
+
+  let cronFeedback: ReactNode = null;
+  if (cronError) {
+    cronFeedback = <Text style={styles.error}>{cronError}</Text>;
+  } else if (cronPreview) {
+    cronFeedback = <Text style={styles.preview}>{cronPreview}</Text>;
+  }
+
+  return (
+    <View style={styles.container}>
+      <SegmentedControl
+        size="sm"
+        value={mode}
+        onValueChange={handleModeChange}
+        options={MODE_OPTIONS}
+        testID="cadence-mode"
+      />
+
+      {mode === "every" ? (
+        <View style={styles.section}>
+          <View style={styles.intervalRow}>
+            <AdaptiveTextInput
+              testID="cadence-interval-value"
+              accessibilityLabel="Interval value"
+              initialValue={intervalValueText}
+              resetKey={`cadence-interval-${fieldResetKey}`}
+              value={intervalValueText}
+              onChangeText={handleIntervalValueChange}
+              keyboardType="number-pad"
+              style={styles.intervalInput}
+            />
+            <SegmentedControl
+              size="sm"
+              value={intervalUnit}
+              onValueChange={handleUnitChange}
+              options={UNIT_OPTIONS}
+              style={styles.unitControl}
+              testID="cadence-interval-unit"
+            />
+          </View>
+          <Text style={styles.preview}>{intervalPreview}</Text>
+        </View>
+      ) : (
+        <View style={styles.section}>
+          <View style={styles.presetRow}>
+            {CRON_PRESETS.map((preset) => (
+              <CronPresetChip
+                key={preset.expression}
+                label={preset.label}
+                expression={preset.expression}
+                isSelected={trimmedCron === preset.expression}
+                onSelect={handlePresetPress}
+              />
+            ))}
+          </View>
+          <AdaptiveTextInput
+            testID="cadence-cron-expression"
+            accessibilityLabel="Cron expression"
+            initialValue={cronText}
+            resetKey={`cadence-cron-${fieldResetKey}`}
+            value={cronText}
+            onChangeText={handleCronChange}
+            placeholder="0 9 * * *"
+            autoCapitalize="none"
+            autoCorrect={false}
+            spellCheck={false}
+            style={styles.cronInput}
+          />
+          {cronFeedback}
+          <Text style={styles.hint}>Times are in UTC</Text>
+        </View>
+      )}
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+    </View>
+  );
+}
+
+function CronPresetChip({
+  label,
+  expression,
+  isSelected,
+  onSelect,
+}: {
+  label: string;
+  expression: string;
+  isSelected: boolean;
+  onSelect: (expression: string) => void;
+}) {
+  const handlePress = useCallback(() => {
+    onSelect(expression);
+  }, [onSelect, expression]);
+  const chipStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.chip,
+      isSelected && styles.chipSelected,
+      !isSelected && (Boolean(hovered) || pressed) && styles.chipHover,
+    ],
+    [isSelected],
+  );
+  const labelStyle = useMemo(
+    () => [styles.chipLabel, isSelected && styles.chipLabelSelected],
+    [isSelected],
+  );
+  const accessibilityState = useMemo(() => ({ selected: isSelected }), [isSelected]);
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={accessibilityState}
+      onPress={handlePress}
+      style={chipStyle}
+    >
+      <Text style={labelStyle} numberOfLines={1}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+const MONOSPACE_FONT = isWeb ? "ui-monospace, SFMono-Regular, Menlo, monospace" : "Menlo";
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    gap: theme.spacing[3],
+  },
+  section: {
+    gap: theme.spacing[3],
+  },
+  intervalRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[3],
+  },
+  intervalInput: {
+    width: 88,
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[3],
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    fontSize: theme.fontSize.base,
+  },
+  unitControl: {
+    flex: 1,
+    minWidth: 0,
+  },
+  presetRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: theme.spacing[2],
+  },
+  chip: {
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[2],
+    borderRadius: theme.borderRadius.full,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface2,
+  },
+  chipHover: {
+    backgroundColor: theme.colors.surface3,
+  },
+  chipSelected: {
+    backgroundColor: theme.colors.accent,
+    borderColor: theme.colors.accent,
+  },
+  chipLabel: {
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.medium,
+    color: theme.colors.foregroundMuted,
+  },
+  chipLabelSelected: {
+    color: theme.colors.accentForeground,
+  },
+  cronInput: {
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[3],
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    fontSize: theme.fontSize.sm,
+    fontFamily: MONOSPACE_FONT,
+  },
+  preview: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+  },
+  hint: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+  },
+  error: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.destructive,
+  },
+}));

--- a/packages/app/src/components/schedules/schedule-form-sheet.tsx
+++ b/packages/app/src/components/schedules/schedule-form-sheet.tsx
@@ -1,0 +1,810 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { Pressable, Text, View, type PressableStateCallbackType } from "react-native";
+import { ChevronDown } from "lucide-react-native";
+import { StyleSheet } from "react-native-unistyles";
+import { useQuery } from "@tanstack/react-query";
+import type { AgentProvider } from "@getpaseo/protocol/agent-types";
+import type { ScheduleCadence, ScheduleSummary } from "@getpaseo/protocol/schedule/types";
+import {
+  AdaptiveModalSheet,
+  AdaptiveTextInput,
+  type SheetHeader,
+} from "@/components/adaptive-modal-sheet";
+import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/combobox";
+import { Button } from "@/components/ui/button";
+import { CombinedModelSelector } from "@/components/combined-model-selector";
+import { getProviderIcon } from "@/components/provider-icons";
+import { CadenceEditor } from "@/components/schedules/cadence-editor";
+import { useScheduleMutations } from "@/hooks/use-schedule-mutations";
+import { useAgentFormState, type FormInitialValues } from "@/hooks/use-agent-form-state";
+import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+import { useRecommendedProjectPaths } from "@/stores/session-store-hooks";
+import { buildWorkingDirectorySuggestions } from "@/utils/working-directory-suggestions";
+import { validateCron } from "@/utils/schedule-format";
+import { toErrorMessage } from "@/utils/error-messages";
+import { shortenPath } from "@/utils/shorten-path";
+
+const DEFAULT_CADENCE: ScheduleCadence = { type: "every", everyMs: 60 * 60 * 1000 };
+
+export interface ScheduleFormSheetProps {
+  serverId: string;
+  visible: boolean;
+  onClose: () => void;
+  mode: "create" | "edit";
+  schedule?: ScheduleSummary;
+}
+
+// The model/cwd config only exists on new-agent schedules; this screen filters
+// to that target, but guard anyway so prefill stays type-safe.
+function newAgentConfig(schedule: ScheduleSummary | undefined) {
+  if (schedule && schedule.target.type === "new-agent") {
+    return schedule.target.config;
+  }
+  return null;
+}
+
+function buildInitialValues(schedule: ScheduleSummary | undefined): FormInitialValues | undefined {
+  const config = newAgentConfig(schedule);
+  if (!config) {
+    return undefined;
+  }
+  return {
+    serverId: null,
+    provider: config.provider as AgentProvider,
+    model: config.model ?? null,
+    modeId: config.modeId ?? null,
+    workingDir: config.cwd,
+  };
+}
+
+export function ScheduleFormSheet({
+  serverId,
+  visible,
+  onClose,
+  mode,
+  schedule,
+}: ScheduleFormSheetProps): ReactElement {
+  const isEdit = mode === "edit";
+  const editConfig = newAgentConfig(schedule);
+
+  const onlineServerIds = useMemo(() => [serverId], [serverId]);
+  const initialValues = useMemo(
+    () => (isEdit ? buildInitialValues(schedule) : undefined),
+    [isEdit, schedule],
+  );
+
+  // isCreateFlow drives useAgentFormState's RESOLVE pass that applies
+  // initialValues. We want that for edit too (to prefill the picker fields from
+  // the schedule's config), so this stays true in both modes — the form is
+  // always a "fill these fields" flow, seeded either from preferences (create)
+  // or from the schedule (edit).
+  const form = useAgentFormState({
+    initialServerId: serverId,
+    initialValues,
+    isVisible: visible,
+    isCreateFlow: true,
+    onlineServerIds,
+  });
+
+  const {
+    selectedProvider,
+    selectedModel,
+    selectedMode,
+    selectedThinkingOptionId,
+    workingDir,
+    setProviderFromUser,
+    setProviderAndModelFromUser,
+    setModeFromUser,
+    setWorkingDirFromUser,
+    providerDefinitions,
+    modeOptions,
+    modelSelectorProviders,
+    isAllModelsLoading,
+    persistFormPreferences,
+  } = form;
+
+  const { createSchedule, updateSchedule, isCreating, isUpdating } = useScheduleMutations({
+    serverId,
+  });
+  const isSubmitting = isCreating || isUpdating;
+
+  // Name / prompt / cadence / maxRuns are local to this form — not part of
+  // useAgentFormState. Seed once per open from the schedule being edited.
+  const [name, setName] = useState(() => schedule?.name ?? "");
+  const [prompt, setPrompt] = useState(() => schedule?.prompt ?? "");
+  const [maxRuns, setMaxRuns] = useState(() =>
+    schedule?.maxRuns != null ? String(schedule.maxRuns) : "",
+  );
+  const [cadence, setCadence] = useState<ScheduleCadence>(
+    () => schedule?.cadence ?? DEFAULT_CADENCE,
+  );
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [fieldResetKey, setFieldResetKey] = useState(0);
+
+  // The sheet stays mounted across opens, so the lazy initializers above only
+  // run once. Re-seed the locally-owned fields (name/prompt/cadence/maxRuns)
+  // each time the sheet transitions closed -> open; the picker fields are
+  // re-seeded by useAgentFormState from initialValues on the same flip.
+  const wasVisibleRef = useRef(false);
+  useEffect(() => {
+    if (visible && !wasVisibleRef.current) {
+      setName(schedule?.name ?? "");
+      setPrompt(schedule?.prompt ?? "");
+      setMaxRuns(schedule?.maxRuns != null ? String(schedule.maxRuns) : "");
+      setCadence(schedule?.cadence ?? DEFAULT_CADENCE);
+      setSubmitError(null);
+      setFieldResetKey((key) => key + 1);
+    }
+    wasVisibleRef.current = visible;
+  }, [visible, schedule]);
+
+  const promptTrimmed = prompt.trim();
+  const cadenceError = cadence.type === "cron" ? validateCron(cadence.expression) : null;
+  const canSubmit =
+    promptTrimmed.length > 0 &&
+    Boolean(selectedProvider) &&
+    workingDir.trim().length > 0 &&
+    cadenceError === null &&
+    !isSubmitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (!selectedProvider || !workingDir.trim() || !promptTrimmed) {
+      return;
+    }
+    setSubmitError(null);
+    try {
+      await persistFormPreferences();
+      const parsedMaxRuns = Number.parseInt(maxRuns, 10);
+      const maxRunsValue =
+        Number.isFinite(parsedMaxRuns) && parsedMaxRuns > 0 ? parsedMaxRuns : null;
+
+      if (isEdit && schedule) {
+        await updateSchedule({
+          id: schedule.id,
+          name: name.trim() || null,
+          prompt: promptTrimmed,
+          cadence,
+          newAgentConfig: {
+            provider: selectedProvider,
+            model: selectedModel || null,
+            modeId: selectedMode || null,
+            cwd: workingDir.trim(),
+          },
+          maxRuns: maxRunsValue,
+        });
+      } else {
+        await createSchedule({
+          prompt: promptTrimmed,
+          name: name.trim() || undefined,
+          cadence,
+          target: {
+            type: "new-agent",
+            config: {
+              provider: selectedProvider,
+              cwd: workingDir.trim(),
+              model: selectedModel || undefined,
+              modeId: selectedMode || undefined,
+              thinkingOptionId: selectedThinkingOptionId || undefined,
+              title: name.trim() || undefined,
+            },
+          },
+          ...(maxRunsValue != null ? { maxRuns: maxRunsValue } : {}),
+        });
+      }
+      onClose();
+    } catch (error) {
+      setSubmitError(toErrorMessage(error));
+    }
+  }, [
+    cadence,
+    createSchedule,
+    isEdit,
+    maxRuns,
+    name,
+    onClose,
+    persistFormPreferences,
+    promptTrimmed,
+    schedule,
+    selectedMode,
+    selectedModel,
+    selectedProvider,
+    selectedThinkingOptionId,
+    updateSchedule,
+    workingDir,
+  ]);
+
+  const handleSubmitPress = useCallback(() => {
+    void handleSubmit();
+  }, [handleSubmit]);
+
+  const header = useMemo<SheetHeader>(
+    () => ({ title: isEdit ? "Edit schedule" : "New schedule" }),
+    [isEdit],
+  );
+
+  const footer = useMemo(
+    () => (
+      <View style={styles.footer}>
+        <Button
+          style={styles.footerButton}
+          variant="secondary"
+          onPress={onClose}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+        <Button
+          style={styles.footerButton}
+          variant="default"
+          onPress={handleSubmitPress}
+          disabled={!canSubmit}
+          loading={isSubmitting}
+          testID="schedule-form-submit"
+        >
+          {isEdit ? "Save changes" : "Create schedule"}
+        </Button>
+      </View>
+    ),
+    [canSubmit, handleSubmitPress, isEdit, isSubmitting, onClose],
+  );
+
+  return (
+    <AdaptiveModalSheet
+      header={header}
+      visible={visible}
+      onClose={onClose}
+      footer={footer}
+      testID="schedule-form-sheet"
+    >
+      <View style={styles.field}>
+        <Text style={styles.label}>Name</Text>
+        <AdaptiveTextInput
+          testID="schedule-name-input"
+          accessibilityLabel="Schedule name"
+          initialValue={name}
+          resetKey={`schedule-name-${fieldResetKey}`}
+          value={name}
+          onChangeText={setName}
+          placeholder="Optional"
+          style={styles.input}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>Prompt</Text>
+        <AdaptiveTextInput
+          testID="schedule-prompt-input"
+          accessibilityLabel="Prompt"
+          initialValue={prompt}
+          resetKey={`schedule-prompt-${fieldResetKey}`}
+          value={prompt}
+          onChangeText={setPrompt}
+          placeholder="What should the agent do each run?"
+          style={styles.multilineInput}
+          multiline
+          numberOfLines={4}
+          textAlignVertical="top"
+        />
+      </View>
+
+      <ProviderField
+        providerDefinitions={providerDefinitions}
+        selectedProvider={selectedProvider}
+        onSelect={setProviderFromUser}
+      />
+
+      <View style={styles.field}>
+        <Text style={styles.label}>Model</Text>
+        <CombinedModelSelector
+          providers={modelSelectorProviders}
+          selectedProvider={selectedProvider ?? ""}
+          selectedModel={selectedModel}
+          onSelect={setProviderAndModelFromUser}
+          isLoading={isAllModelsLoading}
+          renderTrigger={renderModelTrigger}
+          serverId={serverId}
+        />
+      </View>
+
+      {modeOptions.length > 0 ? (
+        <ModeField options={modeOptions} selectedMode={selectedMode} onSelect={setModeFromUser} />
+      ) : null}
+
+      <WorkingDirectoryField
+        serverId={serverId}
+        value={workingDir}
+        onSelect={setWorkingDirFromUser}
+        visible={visible}
+      />
+
+      <View style={styles.field}>
+        <Text style={styles.label}>Cadence</Text>
+        <CadenceEditor value={cadence} onChange={setCadence} error={cadenceError ?? undefined} />
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>Max runs</Text>
+        <AdaptiveTextInput
+          testID="schedule-max-runs-input"
+          accessibilityLabel="Max runs"
+          initialValue={maxRuns}
+          resetKey={`schedule-max-runs-${fieldResetKey}`}
+          value={maxRuns}
+          onChangeText={setMaxRuns}
+          placeholder="Unlimited"
+          style={styles.input}
+          keyboardType="number-pad"
+        />
+        <Text style={styles.hint}>Leave blank to run indefinitely</Text>
+      </View>
+
+      {editConfig === null && isEdit ? (
+        <Text style={styles.hint}>This schedule does not target a new agent.</Text>
+      ) : null}
+
+      {submitError ? <Text style={styles.error}>{submitError}</Text> : null}
+    </AdaptiveModalSheet>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Provider field — Combobox over providerDefinitions, each option led by its
+// provider glyph. Trigger mirrors the desktop badge pattern from the composer.
+// ---------------------------------------------------------------------------
+
+function ProviderField({
+  providerDefinitions,
+  selectedProvider,
+  onSelect,
+}: {
+  providerDefinitions: { id: string; label: string }[];
+  selectedProvider: AgentProvider | null;
+  onSelect: (provider: AgentProvider) => void;
+}): ReactElement {
+  const anchorRef = useRef<View>(null);
+  const [open, setOpen] = useState(false);
+
+  const options = useMemo<ComboboxOption[]>(
+    () => providerDefinitions.map((definition) => ({ id: definition.id, label: definition.label })),
+    [providerDefinitions],
+  );
+
+  const selectedLabel =
+    providerDefinitions.find((definition) => definition.id === selectedProvider)?.label ??
+    "Select provider";
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      onSelect(id as AgentProvider);
+      setOpen(false);
+    },
+    [onSelect],
+  );
+
+  const handlePress = useCallback(() => {
+    setOpen((current) => !current);
+  }, []);
+
+  const renderProviderOption = useCallback(
+    (args: { option: ComboboxOption; selected: boolean; active: boolean; onPress: () => void }) => (
+      <ProviderComboboxOption
+        option={args.option}
+        selected={args.selected}
+        active={args.active}
+        onPress={args.onPress}
+      />
+    ),
+    [],
+  );
+
+  const triggerStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.selectTrigger,
+      (Boolean(hovered) || pressed || open) && styles.selectTriggerActive,
+    ],
+    [open],
+  );
+
+  return (
+    <View style={styles.field}>
+      <Text style={styles.label}>Provider</Text>
+      <View ref={anchorRef} collapsable={false}>
+        <Pressable
+          onPress={handlePress}
+          style={triggerStyle}
+          accessibilityRole="button"
+          accessibilityLabel={`Select provider (${selectedLabel})`}
+          testID="schedule-provider-trigger"
+        >
+          <ProviderGlyph provider={selectedProvider} />
+          <Text style={styles.selectTriggerText} numberOfLines={1}>
+            {selectedLabel}
+          </Text>
+          <ChevronDown size={16} color={styles.chevron.color} />
+        </Pressable>
+      </View>
+      <Combobox
+        options={options}
+        value={selectedProvider ?? ""}
+        onSelect={handleSelect}
+        searchable={options.length > 6}
+        title="Select provider"
+        open={open}
+        onOpenChange={setOpen}
+        anchorRef={anchorRef}
+        renderOption={renderProviderOption}
+        desktopPlacement="bottom-start"
+      />
+    </View>
+  );
+}
+
+function ProviderComboboxOption({
+  option,
+  selected,
+  active,
+  onPress,
+}: {
+  option: ComboboxOption;
+  selected: boolean;
+  active: boolean;
+  onPress: () => void;
+}): ReactElement {
+  const leadingSlot = useMemo(() => <ProviderGlyph provider={option.id} />, [option.id]);
+  return (
+    <ComboboxItem
+      label={option.label}
+      selected={selected}
+      active={active}
+      onPress={onPress}
+      leadingSlot={leadingSlot}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mode field — Combobox over the selected provider's modes.
+// ---------------------------------------------------------------------------
+
+function ModeField({
+  options,
+  selectedMode,
+  onSelect,
+}: {
+  options: { id: string; label: string }[];
+  selectedMode: string;
+  onSelect: (modeId: string) => void;
+}): ReactElement {
+  const anchorRef = useRef<View>(null);
+  const [open, setOpen] = useState(false);
+
+  const comboboxOptions = useMemo<ComboboxOption[]>(
+    () => options.map((option) => ({ id: option.id, label: option.label })),
+    [options],
+  );
+
+  const selectedLabel =
+    options.find((option) => option.id === selectedMode)?.label ?? "Default mode";
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      onSelect(id);
+      setOpen(false);
+    },
+    [onSelect],
+  );
+
+  const handlePress = useCallback(() => {
+    setOpen((current) => !current);
+  }, []);
+
+  const triggerStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.selectTrigger,
+      (Boolean(hovered) || pressed || open) && styles.selectTriggerActive,
+    ],
+    [open],
+  );
+
+  return (
+    <View style={styles.field}>
+      <Text style={styles.label}>Mode</Text>
+      <View ref={anchorRef} collapsable={false}>
+        <Pressable
+          onPress={handlePress}
+          style={triggerStyle}
+          accessibilityRole="button"
+          accessibilityLabel={`Select mode (${selectedLabel})`}
+          testID="schedule-mode-trigger"
+        >
+          <Text style={styles.selectTriggerText} numberOfLines={1}>
+            {selectedLabel}
+          </Text>
+          <ChevronDown size={16} color={styles.chevron.color} />
+        </Pressable>
+      </View>
+      <Combobox
+        options={comboboxOptions}
+        value={selectedMode}
+        onSelect={handleSelect}
+        searchable={comboboxOptions.length > 6}
+        title="Select mode"
+        open={open}
+        onOpenChange={setOpen}
+        anchorRef={anchorRef}
+        desktopPlacement="bottom-start"
+      />
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Working directory — searchable Combobox backed by directory suggestions,
+// allowing a custom path. Mirrors the project picker's query shape.
+// ---------------------------------------------------------------------------
+
+function WorkingDirectoryField({
+  serverId,
+  value,
+  onSelect,
+  visible,
+}: {
+  serverId: string;
+  value: string;
+  onSelect: (value: string) => void;
+  visible: boolean;
+}): ReactElement {
+  const anchorRef = useRef<View>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const client = useHostRuntimeClient(serverId);
+  const isConnected = useHostRuntimeIsConnected(serverId);
+  const recommendedPaths = useRecommendedProjectPaths(serverId);
+
+  const directorySuggestionsQuery = useQuery({
+    queryKey: ["schedule-form-directory-suggestions", serverId, query],
+    queryFn: async () => {
+      if (!client) {
+        return [];
+      }
+      const result = await client.getDirectorySuggestions({
+        query,
+        includeDirectories: true,
+        includeFiles: false,
+        limit: 30,
+      });
+      return result.entries?.flatMap((entry) => (entry.kind === "directory" ? [entry.path] : []));
+    },
+    enabled: Boolean(client) && isConnected && visible && open,
+    staleTime: 15_000,
+    retry: false,
+  });
+
+  const options = useMemo<ComboboxOption[]>(() => {
+    const paths = buildWorkingDirectorySuggestions({
+      recommendedPaths,
+      serverPaths: directorySuggestionsQuery.data ?? [],
+      query,
+    });
+    return paths.map((path) => ({ id: path, label: shortenPath(path), kind: "directory" }));
+  }, [directorySuggestionsQuery.data, query, recommendedPaths]);
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      onSelect(id);
+      setOpen(false);
+    },
+    [onSelect],
+  );
+
+  const handlePress = useCallback(() => {
+    setOpen((current) => !current);
+  }, []);
+
+  const triggerStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.selectTrigger,
+      (Boolean(hovered) || pressed || open) && styles.selectTriggerActive,
+    ],
+    [open],
+  );
+
+  const displayValue = value.trim() ? shortenPath(value.trim()) : "Select a directory";
+
+  return (
+    <View style={styles.field}>
+      <Text style={styles.label}>Working directory</Text>
+      <View ref={anchorRef} collapsable={false}>
+        <Pressable
+          onPress={handlePress}
+          style={triggerStyle}
+          accessibilityRole="button"
+          accessibilityLabel={`Select working directory (${displayValue})`}
+          testID="schedule-cwd-trigger"
+        >
+          <Text
+            style={value.trim() ? styles.selectTriggerText : styles.selectTriggerPlaceholder}
+            numberOfLines={1}
+          >
+            {displayValue}
+          </Text>
+          <ChevronDown size={16} color={styles.chevron.color} />
+        </Pressable>
+      </View>
+      <Combobox
+        options={options}
+        value={value}
+        onSelect={handleSelect}
+        onSearchQueryChange={setQuery}
+        searchable
+        searchPlaceholder="Type a directory path..."
+        emptyText="Start typing a path"
+        title="Working directory"
+        allowCustomValue
+        customValueKind="directory"
+        open={open}
+        onOpenChange={setOpen}
+        anchorRef={anchorRef}
+        desktopPlacement="bottom-start"
+      />
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared bits
+// ---------------------------------------------------------------------------
+
+/** Dynamic provider glyph — reads its color off a StyleSheet object so the
+ * runtime-resolved component stays compliant without useUnistyles. */
+function ProviderGlyph({ provider }: { provider: string | null }): ReactElement | null {
+  if (!provider) {
+    return null;
+  }
+  const Icon = getProviderIcon(provider);
+  return <Icon size={16} color={styles.providerIcon.color} />;
+}
+
+function renderModelTrigger({
+  selectedModelLabel,
+  onPress,
+  disabled,
+}: {
+  selectedModelLabel: string;
+  onPress: () => void;
+  disabled: boolean;
+  isOpen: boolean;
+}): ReactNode {
+  return <ModelTrigger label={selectedModelLabel} onPress={onPress} disabled={disabled} />;
+}
+
+function ModelTrigger({
+  label,
+  onPress,
+  disabled,
+}: {
+  label: string;
+  onPress: () => void;
+  disabled: boolean;
+}): ReactElement {
+  const triggerStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.selectTrigger,
+      (Boolean(hovered) || pressed) && styles.selectTriggerActive,
+      disabled && styles.selectTriggerDisabled,
+    ],
+    [disabled],
+  );
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      style={triggerStyle}
+      accessibilityRole="button"
+      accessibilityLabel={`Select model (${label})`}
+      testID="schedule-model-trigger"
+    >
+      <Text style={styles.selectTriggerText} numberOfLines={1}>
+        {label}
+      </Text>
+      <ChevronDown size={16} color={styles.chevron.color} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  field: {
+    gap: theme.spacing[2],
+  },
+  label: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+  },
+  input: {
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[3],
+    color: theme.colors.foreground,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    fontSize: theme.fontSize.base,
+  },
+  multilineInput: {
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[3],
+    color: theme.colors.foreground,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    fontSize: theme.fontSize.base,
+    minHeight: 96,
+  },
+  hint: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  error: {
+    color: theme.colors.destructive,
+    fontSize: theme.fontSize.xs,
+  },
+  selectTrigger: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[3],
+    minHeight: 44,
+  },
+  selectTriggerActive: {
+    borderColor: theme.colors.borderAccent,
+  },
+  selectTriggerDisabled: {
+    opacity: theme.opacity[50],
+  },
+  selectTriggerText: {
+    flex: 1,
+    minWidth: 0,
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+  },
+  selectTriggerPlaceholder: {
+    flex: 1,
+    minWidth: 0,
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.base,
+  },
+  footer: {
+    flex: 1,
+    flexDirection: "row",
+    gap: theme.spacing[3],
+  },
+  footerButton: {
+    flex: 1,
+  },
+  // Static color holders read by the dynamic provider icon + chevron (compliant
+  // idiom — no useUnistyles in render).
+  providerIcon: {
+    color: theme.colors.foregroundMuted,
+  },
+  chevron: {
+    color: theme.colors.foregroundMuted,
+  },
+}));

--- a/packages/app/src/components/schedules/schedule-row.tsx
+++ b/packages/app/src/components/schedules/schedule-row.tsx
@@ -1,0 +1,699 @@
+import { MoreVertical, Pause, Pencil, Play, RotateCw, Trash2 } from "lucide-react-native";
+import { useCallback, useMemo, useState, type ReactElement, type ReactNode } from "react";
+import {
+  Pressable,
+  Text,
+  View,
+  type GestureResponderEvent,
+  type PressableStateCallbackType,
+} from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { getProviderIcon } from "@/components/provider-icons";
+import { isNative } from "@/constants/platform";
+import { useIsCompactFormFactor } from "@/constants/layout";
+import type { Theme } from "@/styles/theme";
+import { formatCadence, formatNextRun } from "@/utils/schedule-format";
+import { shortenPath } from "@/utils/shorten-path";
+import type { ScheduleSummary } from "@getpaseo/protocol/schedule/types";
+
+// Themed lucide wrappers — module-scope so only the icon re-renders on theme
+// change (never call useUnistyles in render). See docs/unistyles.md.
+const ThemedPencil = withUnistyles(Pencil);
+const ThemedPause = withUnistyles(Pause);
+const ThemedPlay = withUnistyles(Play);
+const ThemedRotateCw = withUnistyles(RotateCw);
+const ThemedTrash2 = withUnistyles(Trash2);
+const ThemedKebab = withUnistyles(MoreVertical);
+
+const mutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
+const destructiveColorMapping = (theme: Theme) => ({ color: theme.colors.destructive });
+
+const ACTION_ICON_SIZE = 15;
+const MENU_ICON_SIZE = 14;
+const PROVIDER_ICON_SIZE = 16;
+
+// Pending flags for each action so the parent table can wire a mutation hook
+// and the row reflects in-flight state without owning the mutation itself.
+export interface ScheduleRowPending {
+  pause?: boolean;
+  resume?: boolean;
+  runNow?: boolean;
+  delete?: boolean;
+}
+
+export interface ScheduleRowActions {
+  onEdit: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onRunNow: () => void;
+  onDelete: () => void;
+}
+
+interface ScheduleRowProps extends ScheduleRowActions {
+  schedule: ScheduleSummary;
+  pending?: ScheduleRowPending;
+}
+
+/** Row primary label: name → title → first prompt line → fallback. */
+function resolveTitle(schedule: ScheduleSummary): string {
+  const name = schedule.name?.trim();
+  if (name) {
+    return name;
+  }
+  if (schedule.target.type === "new-agent") {
+    const configTitle = schedule.target.config.title?.trim();
+    if (configTitle) {
+      return configTitle;
+    }
+  }
+  const firstPromptLine = schedule.prompt
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  return firstPromptLine || "Untitled schedule";
+}
+
+function resolveProvider(schedule: ScheduleSummary): string | null {
+  return schedule.target.type === "new-agent" ? schedule.target.config.provider : null;
+}
+
+function resolveModelLabel(schedule: ScheduleSummary): string {
+  if (schedule.target.type === "new-agent" && schedule.target.config.model) {
+    return schedule.target.config.model;
+  }
+  return "Default model";
+}
+
+function resolveCwd(schedule: ScheduleSummary): string | null {
+  if (schedule.target.type !== "new-agent") {
+    return null;
+  }
+  const cwd = schedule.target.config.cwd?.trim();
+  return cwd ? shortenPath(cwd) : null;
+}
+
+function statusVariant(status: ScheduleSummary["status"]): "success" | "muted" {
+  return status === "active" ? "success" : "muted";
+}
+
+function statusLabel(status: ScheduleSummary["status"]): string {
+  if (status === "active") {
+    return "Active";
+  }
+  if (status === "paused") {
+    return "Paused";
+  }
+  return "Completed";
+}
+
+function nextRunLabel(schedule: ScheduleSummary): string {
+  if (schedule.status === "paused") {
+    return "Paused";
+  }
+  if (schedule.status === "completed") {
+    return "Completed";
+  }
+  return formatNextRun(schedule.nextRunAt) || "—";
+}
+
+/** Small provider glyph. Reads the icon color off a StyleSheet object so the
+ * dynamic component (getProviderIcon) stays compliant without useUnistyles. */
+function ProviderGlyph({
+  provider,
+  size = PROVIDER_ICON_SIZE,
+}: {
+  provider: string | null;
+  size?: number;
+}): ReactElement | null {
+  if (!provider) {
+    return null;
+  }
+  const Icon = getProviderIcon(provider);
+  return <Icon size={size} color={styles.providerIcon.color} />;
+}
+
+export function ScheduleRow(props: ScheduleRowProps): ReactElement {
+  const isCompact = useIsCompactFormFactor();
+  if (isCompact || isNative) {
+    return <CompactScheduleRow {...props} />;
+  }
+  return <DesktopScheduleRow {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Desktop — borderless SaaS table row with hover-revealed action cluster
+// ---------------------------------------------------------------------------
+
+function DesktopScheduleRow({
+  schedule,
+  pending,
+  onEdit,
+  onPause,
+  onResume,
+  onRunNow,
+  onDelete,
+}: ScheduleRowProps): ReactElement {
+  const [isHovered, setIsHovered] = useState(false);
+  const handlePointerEnter = useCallback(() => setIsHovered(true), []);
+  const handlePointerLeave = useCallback(() => setIsHovered(false), []);
+
+  const provider = resolveProvider(schedule);
+  const title = resolveTitle(schedule);
+  const cwd = resolveCwd(schedule);
+  const model = resolveModelLabel(schedule);
+
+  const rowStyle = useCallback(
+    ({ pressed }: PressableStateCallbackType) => [
+      styles.desktopRow,
+      isHovered && styles.desktopRowHovered,
+      pressed && styles.desktopRowPressed,
+    ],
+    [isHovered],
+  );
+
+  // Actions are always mounted; revealed via opacity + pointerEvents so the row
+  // never reflows on hover (docs/hover.md). Always shown on native/compact —
+  // but this branch is desktop-only, so isHovered drives it.
+  const actionsStyle = useMemo(
+    () => [styles.actionCluster, !isHovered && styles.actionClusterHidden],
+    [isHovered],
+  );
+
+  return (
+    <View
+      style={styles.desktopRowContainer}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
+    >
+      <Pressable
+        style={rowStyle}
+        onPress={onEdit}
+        accessibilityRole="button"
+        accessibilityLabel={`Edit schedule ${title}`}
+        testID={`schedule-row-${schedule.id}`}
+      >
+        <View style={styles.colName}>
+          <ProviderGlyph provider={provider} />
+          <View style={styles.nameTextGroup}>
+            <Text style={styles.titleText} numberOfLines={1}>
+              {title}
+            </Text>
+            {cwd ? (
+              <Text style={styles.metaText} numberOfLines={1}>
+                {cwd}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+
+        <View style={styles.colModel}>
+          <ProviderGlyph provider={provider} size={MENU_ICON_SIZE} />
+          <Text style={styles.cellText} numberOfLines={1}>
+            {model}
+          </Text>
+        </View>
+
+        <View style={styles.colCadence}>
+          <Text style={styles.cellText} numberOfLines={1}>
+            {formatCadence(schedule.cadence)}
+          </Text>
+        </View>
+
+        <View style={styles.colNextRun}>
+          <Text style={styles.cellText} numberOfLines={1}>
+            {nextRunLabel(schedule)}
+          </Text>
+        </View>
+
+        <View style={styles.colStatus}>
+          <StatusBadge
+            label={statusLabel(schedule.status)}
+            variant={statusVariant(schedule.status)}
+          />
+        </View>
+
+        <View style={styles.colActions} pointerEvents="box-none">
+          <View style={actionsStyle} pointerEvents={isHovered ? "auto" : "none"}>
+            <ActionIconButton
+              variant="edit"
+              label="Edit schedule"
+              onPress={onEdit}
+              testID={`schedule-action-edit-${schedule.id}`}
+            />
+            {schedule.status === "paused" ? (
+              <ActionIconButton
+                variant="resume"
+                label="Resume schedule"
+                busy={pending?.resume}
+                onPress={onResume}
+                testID={`schedule-action-resume-${schedule.id}`}
+              />
+            ) : (
+              <ActionIconButton
+                variant="pause"
+                label="Pause schedule"
+                busy={pending?.pause}
+                disabled={schedule.status === "completed"}
+                onPress={onPause}
+                testID={`schedule-action-pause-${schedule.id}`}
+              />
+            )}
+            <ActionIconButton
+              variant="run"
+              label="Run now"
+              busy={pending?.runNow}
+              onPress={onRunNow}
+              testID={`schedule-action-run-${schedule.id}`}
+            />
+            <ActionIconButton
+              variant="delete"
+              label="Delete schedule"
+              busy={pending?.delete}
+              destructive
+              onPress={onDelete}
+              testID={`schedule-action-delete-${schedule.id}`}
+            />
+          </View>
+        </View>
+      </Pressable>
+    </View>
+  );
+}
+
+type ActionVariant = "edit" | "pause" | "resume" | "run" | "delete";
+
+// Module-scope icon elements keep JSX out of the render-time prop path
+// (eslint-plugin-react-perf) and avoid re-creating elements per row.
+const ACTION_ICONS: Record<ActionVariant, ReactNode> = {
+  edit: <ThemedPencil size={ACTION_ICON_SIZE} uniProps={mutedColorMapping} />,
+  pause: <ThemedPause size={ACTION_ICON_SIZE} uniProps={mutedColorMapping} />,
+  resume: <ThemedPlay size={ACTION_ICON_SIZE} uniProps={mutedColorMapping} />,
+  run: <ThemedRotateCw size={ACTION_ICON_SIZE} uniProps={mutedColorMapping} />,
+  delete: <ThemedTrash2 size={ACTION_ICON_SIZE} uniProps={destructiveColorMapping} />,
+};
+
+function ActionIconButton({
+  variant,
+  label,
+  onPress,
+  busy,
+  disabled,
+  destructive,
+  testID,
+}: {
+  variant: ActionVariant;
+  label: string;
+  onPress: () => void;
+  busy?: boolean;
+  disabled?: boolean;
+  destructive?: boolean;
+  testID?: string;
+}): ReactElement {
+  const isDisabled = Boolean(disabled || busy);
+  const buttonStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.iconButton,
+      hovered && (destructive ? styles.iconButtonHoveredDestructive : styles.iconButtonHovered),
+      pressed && styles.iconButtonPressed,
+      isDisabled && styles.iconButtonDisabled,
+    ],
+    [destructive, isDisabled],
+  );
+  // The button sits inside the row Pressable (which opens edit on press); stop
+  // the event so acting on a row never also opens the editor (web bubbling).
+  const handlePressIn = useCallback((event: GestureResponderEvent) => {
+    event.stopPropagation();
+  }, []);
+  const handlePress = useCallback(
+    (event: GestureResponderEvent) => {
+      event.stopPropagation();
+      onPress();
+    },
+    [onPress],
+  );
+  return (
+    <Pressable
+      style={buttonStyle}
+      onPress={handlePress}
+      onPressIn={handlePressIn}
+      disabled={isDisabled}
+      hitSlop={4}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      testID={testID}
+    >
+      {ACTION_ICONS[variant]}
+    </Pressable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compact — stacked row with an always-visible kebab menu
+// ---------------------------------------------------------------------------
+
+function CompactScheduleRow({
+  schedule,
+  pending,
+  onEdit,
+  onPause,
+  onResume,
+  onRunNow,
+  onDelete,
+}: ScheduleRowProps): ReactElement {
+  const provider = resolveProvider(schedule);
+  const title = resolveTitle(schedule);
+  const model = resolveModelLabel(schedule);
+
+  const metaParts = [model, formatCadence(schedule.cadence), nextRunLabel(schedule)].filter(
+    Boolean,
+  );
+
+  return (
+    <View style={styles.compactRow}>
+      <View style={styles.compactBody}>
+        <View style={styles.compactTitleRow}>
+          <ProviderGlyph provider={provider} size={MENU_ICON_SIZE} />
+          <Text style={styles.titleText} numberOfLines={1}>
+            {title}
+          </Text>
+          <View style={styles.compactStatus}>
+            <StatusBadge
+              label={statusLabel(schedule.status)}
+              variant={statusVariant(schedule.status)}
+            />
+          </View>
+        </View>
+        <Text style={styles.metaText} numberOfLines={1}>
+          {metaParts.join("  ·  ")}
+        </Text>
+      </View>
+      <ScheduleKebabMenu
+        schedule={schedule}
+        pending={pending}
+        onEdit={onEdit}
+        onPause={onPause}
+        onResume={onResume}
+        onRunNow={onRunNow}
+        onDelete={onDelete}
+      />
+    </View>
+  );
+}
+
+const editLeading = <ThemedPencil size={MENU_ICON_SIZE} uniProps={mutedColorMapping} />;
+const pauseLeading = <ThemedPause size={MENU_ICON_SIZE} uniProps={mutedColorMapping} />;
+const resumeLeading = <ThemedPlay size={MENU_ICON_SIZE} uniProps={mutedColorMapping} />;
+const runLeading = <ThemedRotateCw size={MENU_ICON_SIZE} uniProps={mutedColorMapping} />;
+const deleteLeading = <ThemedTrash2 size={MENU_ICON_SIZE} uniProps={destructiveColorMapping} />;
+
+function renderKebabTriggerIcon({ hovered }: { hovered?: boolean }): ReactElement {
+  return (
+    <ThemedKebab
+      size={MENU_ICON_SIZE}
+      uniProps={hovered ? foregroundColorMapping : mutedColorMapping}
+    />
+  );
+}
+
+function ScheduleKebabMenu({
+  schedule,
+  pending,
+  onEdit,
+  onPause,
+  onResume,
+  onRunNow,
+  onDelete,
+}: ScheduleRowProps): ReactElement {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        hitSlop={8}
+        style={kebabTriggerStyle}
+        accessibilityRole={isNative ? "button" : undefined}
+        accessibilityLabel="Schedule actions"
+        testID={`schedule-kebab-${schedule.id}`}
+      >
+        {renderKebabTriggerIcon}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" width={220}>
+        <DropdownMenuItem
+          leading={editLeading}
+          onSelect={onEdit}
+          testID={`schedule-menu-edit-${schedule.id}`}
+        >
+          Edit schedule
+        </DropdownMenuItem>
+        {schedule.status === "paused" ? (
+          <DropdownMenuItem
+            leading={resumeLeading}
+            status={pending?.resume ? "pending" : "idle"}
+            pendingLabel="Resuming..."
+            onSelect={onResume}
+            testID={`schedule-menu-resume-${schedule.id}`}
+          >
+            Resume schedule
+          </DropdownMenuItem>
+        ) : (
+          <DropdownMenuItem
+            leading={pauseLeading}
+            disabled={schedule.status === "completed"}
+            status={pending?.pause ? "pending" : "idle"}
+            pendingLabel="Pausing..."
+            onSelect={onPause}
+            testID={`schedule-menu-pause-${schedule.id}`}
+          >
+            Pause schedule
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem
+          leading={runLeading}
+          status={pending?.runNow ? "pending" : "idle"}
+          pendingLabel="Starting..."
+          onSelect={onRunNow}
+          testID={`schedule-menu-run-${schedule.id}`}
+        >
+          Run now
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          leading={deleteLeading}
+          destructive
+          status={pending?.delete ? "pending" : "idle"}
+          pendingLabel="Deleting..."
+          onSelect={onDelete}
+          testID={`schedule-menu-delete-${schedule.id}`}
+        >
+          Delete schedule
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function kebabTriggerStyle({
+  hovered = false,
+}: PressableStateCallbackType & { hovered?: boolean }) {
+  return [styles.kebabTrigger, hovered && styles.kebabTriggerHovered];
+}
+
+// ---------------------------------------------------------------------------
+// Desktop column header
+// ---------------------------------------------------------------------------
+
+export function SchedulesColumnHeader(): ReactElement {
+  return (
+    <View style={styles.headerRow}>
+      <Text style={headerNameStyle}>Name</Text>
+      <Text style={headerModelStyle}>Model</Text>
+      <Text style={headerCadenceStyle}>Cadence</Text>
+      <Text style={headerNextRunStyle}>Next run</Text>
+      <Text style={headerStatusStyle}>Status</Text>
+      <View style={styles.colActions} />
+    </View>
+  );
+}
+
+const ROW_MIN_HEIGHT = 56;
+const ACTIONS_COLUMN_WIDTH = 148;
+
+const styles = StyleSheet.create((theme) => ({
+  // Static color holder for the dynamic provider icon (compliant idiom).
+  providerIcon: {
+    color: theme.colors.foregroundMuted,
+  },
+
+  // --- shared columns (header + desktop row use the same flex weights) ---
+  colName: {
+    flex: 2.4,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  colModel: {
+    flex: 1.6,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1.5],
+  },
+  colCadence: {
+    flex: 1.4,
+    minWidth: 0,
+  },
+  colNextRun: {
+    flex: 1,
+    minWidth: 0,
+  },
+  colStatus: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  colActions: {
+    width: ACTIONS_COLUMN_WIDTH,
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    alignItems: "center",
+  },
+
+  nameTextGroup: {
+    flex: 1,
+    minWidth: 0,
+    gap: 1,
+  },
+
+  // --- header ---
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[3],
+    paddingHorizontal: theme.spacing[3],
+    paddingBottom: theme.spacing[2],
+  },
+  headerLabel: {
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.medium,
+    color: theme.colors.foregroundMuted,
+  },
+
+  // --- desktop row ---
+  desktopRowContainer: {
+    position: "relative",
+  },
+  desktopRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[3],
+    minHeight: ROW_MIN_HEIGHT,
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[2],
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  desktopRowHovered: {
+    backgroundColor: theme.colors.surface1,
+  },
+  desktopRowPressed: {
+    backgroundColor: theme.colors.surface2,
+  },
+
+  titleText: {
+    fontSize: theme.fontSize.base,
+    fontWeight: theme.fontWeight.normal,
+    color: theme.colors.foreground,
+  },
+  cellText: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: theme.fontSize.base,
+    fontWeight: theme.fontWeight.normal,
+    color: theme.colors.foreground,
+  },
+  metaText: {
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.normal,
+    color: theme.colors.foregroundMuted,
+  },
+
+  // --- desktop action cluster ---
+  actionCluster: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+  },
+  actionClusterHidden: {
+    opacity: 0,
+  },
+  iconButton: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: theme.borderRadius.md,
+  },
+  iconButtonHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+  iconButtonHoveredDestructive: {
+    backgroundColor: theme.colors.palette.red[900],
+  },
+  iconButtonPressed: {
+    backgroundColor: theme.colors.surface3,
+  },
+  iconButtonDisabled: {
+    opacity: theme.opacity[50],
+  },
+
+  // --- compact row ---
+  compactRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    minHeight: ROW_MIN_HEIGHT,
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  compactBody: {
+    flex: 1,
+    minWidth: 0,
+    gap: theme.spacing[1],
+  },
+  compactTitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  compactStatus: {
+    marginLeft: "auto",
+  },
+
+  // --- kebab ---
+  kebabTrigger: {
+    padding: theme.spacing[1],
+    borderRadius: theme.borderRadius.base,
+  },
+  kebabTriggerHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+}));
+
+// Precomputed column + label style arrays for the header row — hoisted so the
+// JSX does not create a new array prop per render (eslint-plugin-react-perf).
+const headerNameStyle = [styles.colName, styles.headerLabel];
+const headerModelStyle = [styles.colModel, styles.headerLabel];
+const headerCadenceStyle = [styles.colCadence, styles.headerLabel];
+const headerNextRunStyle = [styles.colNextRun, styles.headerLabel];
+const headerStatusStyle = [styles.colStatus, styles.headerLabel];

--- a/packages/app/src/components/schedules/schedules-table.tsx
+++ b/packages/app/src/components/schedules/schedules-table.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useMemo, useState, type ReactElement } from "react";
+import { FlatList, type ListRenderItem } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import {
+  ScheduleRow,
+  SchedulesColumnHeader,
+  type ScheduleRowPending,
+} from "@/components/schedules/schedule-row";
+import { useScheduleMutations } from "@/hooks/use-schedule-mutations";
+import { useIsCompactFormFactor } from "@/constants/layout";
+import { confirmDialog } from "@/utils/confirm-dialog";
+import type { ScheduleSummary } from "@getpaseo/protocol/schedule/types";
+
+interface SchedulesTableProps {
+  serverId: string;
+  schedules: ScheduleSummary[];
+  /**
+   * The form sheet is owned by the screen (it serves both create and edit and
+   * shares the header's "New schedule" button), so the table delegates edit
+   * upward rather than mounting a second sheet here.
+   */
+  onEditSchedule: (schedule: ScheduleSummary) => void;
+}
+
+/**
+ * Borderless SaaS table of new-agent schedules. Owns row-level actions
+ * (pause/resume/run/delete via the mutations hook + a destructive confirm for
+ * delete) and delegates editing to the parent. Row chrome — the hairline
+ * between rows, hover highlight, and the compact-vs-desktop layout — lives in
+ * ScheduleRow; this component only arranges the rows and the column header.
+ */
+export function SchedulesTable({
+  serverId,
+  schedules,
+  onEditSchedule,
+}: SchedulesTableProps): ReactElement {
+  const isCompact = useIsCompactFormFactor();
+  const mutations = useScheduleMutations({ serverId });
+
+  const renderItem: ListRenderItem<ScheduleSummary> = useCallback(
+    ({ item }) => (
+      <SchedulesTableRow schedule={item} mutations={mutations} onEditSchedule={onEditSchedule} />
+    ),
+    [mutations, onEditSchedule],
+  );
+
+  // The desktop column header aligns with the rows because both live inside the
+  // same horizontally padded, width-constrained content container and share the
+  // row's flex column weights. Compact rows are self-labeled, so no header.
+  const listHeader = useMemo(() => (isCompact ? null : <SchedulesColumnHeader />), [isCompact]);
+
+  const contentContainerStyle = useMemo(
+    () => [styles.listContent, isCompact ? styles.listContentCompact : styles.listContentDesktop],
+    [isCompact],
+  );
+
+  return (
+    <FlatList
+      data={schedules}
+      style={styles.list}
+      contentContainerStyle={contentContainerStyle}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
+      ListHeaderComponent={listHeader}
+      showsVerticalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      testID="schedules-table"
+    />
+  );
+}
+
+function keyExtractor(schedule: ScheduleSummary): string {
+  return schedule.id;
+}
+
+/**
+ * Human label for the schedule, used in the delete confirmation. Mirrors the
+ * row's title precedence (name → config title → first prompt line → fallback).
+ */
+function scheduleLabel(schedule: ScheduleSummary): string {
+  const name = schedule.name?.trim();
+  if (name) {
+    return name;
+  }
+  if (schedule.target.type === "new-agent") {
+    const configTitle = schedule.target.config.title?.trim();
+    if (configTitle) {
+      return configTitle;
+    }
+  }
+  const firstPromptLine = schedule.prompt
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  return firstPromptLine || "Untitled schedule";
+}
+
+// ---------------------------------------------------------------------------
+// Per-row wrapper — owns local in-flight state and binds the table's mutation
+// callbacks to this schedule. Local state keeps pending precise to the acting
+// row even when several rows are acted on at once (the mutations hook exposes
+// only a single global pending flag per action).
+// ---------------------------------------------------------------------------
+
+type ScheduleMutations = ReturnType<typeof useScheduleMutations>;
+
+const NO_PENDING: ScheduleRowPending = {};
+
+function SchedulesTableRow({
+  schedule,
+  mutations,
+  onEditSchedule,
+}: {
+  schedule: ScheduleSummary;
+  mutations: ScheduleMutations;
+  onEditSchedule: (schedule: ScheduleSummary) => void;
+}): ReactElement {
+  const { id } = schedule;
+  const [pending, setPending] = useState<ScheduleRowPending>(NO_PENDING);
+
+  const runAction = useCallback(
+    async (key: keyof ScheduleRowPending, action: () => Promise<void>): Promise<void> => {
+      setPending((current) => ({ ...current, [key]: true }));
+      try {
+        await action();
+      } catch {
+        // Mutations roll back their own optimistic cache writes on error and
+        // re-fetch on settle; surfacing per-row toasts here is out of scope.
+      } finally {
+        setPending((current) => {
+          const next = { ...current };
+          delete next[key];
+          return next;
+        });
+      }
+    },
+    [],
+  );
+
+  const handleEdit = useCallback(() => {
+    onEditSchedule(schedule);
+  }, [onEditSchedule, schedule]);
+
+  const handlePause = useCallback(() => {
+    void runAction("pause", () => mutations.pauseSchedule(id));
+  }, [runAction, mutations, id]);
+
+  const handleResume = useCallback(() => {
+    void runAction("resume", () => mutations.resumeSchedule(id));
+  }, [runAction, mutations, id]);
+
+  const handleRunNow = useCallback(() => {
+    void runAction("runNow", () => mutations.runScheduleNow(id));
+  }, [runAction, mutations, id]);
+
+  const handleDelete = useCallback(() => {
+    void (async () => {
+      const confirmed = await confirmDialog({
+        title: "Delete schedule",
+        message: `Delete "${scheduleLabel(schedule)}"? This cannot be undone.`,
+        confirmLabel: "Delete",
+        destructive: true,
+      });
+      if (!confirmed) {
+        return;
+      }
+      await runAction("delete", () => mutations.deleteSchedule(id));
+    })();
+  }, [runAction, mutations, id, schedule]);
+
+  return (
+    <ScheduleRow
+      schedule={schedule}
+      pending={pending}
+      onEdit={handleEdit}
+      onPause={handlePause}
+      onResume={handleResume}
+      onRunNow={handleRunNow}
+      onDelete={handleDelete}
+    />
+  );
+}
+
+const DESKTOP_MAX_WIDTH = 1040;
+
+const styles = StyleSheet.create((theme) => ({
+  list: {
+    flex: 1,
+    minHeight: 0,
+  },
+  listContent: {
+    paddingBottom: theme.spacing[6],
+  },
+  listContentCompact: {
+    paddingHorizontal: theme.spacing[3],
+    paddingTop: theme.spacing[2],
+  },
+  // Center the table in a width-constrained column on desktop, with horizontal
+  // page padding that matches the row's own padding so the columns line up.
+  listContentDesktop: {
+    width: "100%",
+    maxWidth: DESKTOP_MAX_WIDTH,
+    alignSelf: "center",
+    paddingHorizontal: theme.spacing[6],
+    paddingTop: theme.spacing[4],
+  },
+}));

--- a/packages/app/src/hooks/use-schedule-mutations.ts
+++ b/packages/app/src/hooks/use-schedule-mutations.ts
@@ -1,0 +1,251 @@
+import { useCallback } from "react";
+import { useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import type {
+  CreateScheduleOptions,
+  DaemonClient,
+  UpdateScheduleOptions,
+} from "@getpaseo/client/internal/daemon-client";
+import type { ScheduleSummary } from "@getpaseo/protocol/schedule/types";
+import { useSessionStore } from "@/stores/session-store";
+import { schedulesQueryKey } from "@/hooks/use-schedules";
+
+export type CreateScheduleInput = Omit<CreateScheduleOptions, "requestId">;
+export type UpdateScheduleInput = Omit<UpdateScheduleOptions, "requestId">;
+
+export interface UseScheduleMutationsResult {
+  createSchedule: (input: CreateScheduleInput) => Promise<void>;
+  updateSchedule: (input: UpdateScheduleInput) => Promise<void>;
+  pauseSchedule: (id: string) => Promise<void>;
+  resumeSchedule: (id: string) => Promise<void>;
+  deleteSchedule: (id: string) => Promise<void>;
+  runScheduleNow: (id: string) => Promise<void>;
+  isCreating: boolean;
+  isUpdating: boolean;
+  isPausing: boolean;
+  isResuming: boolean;
+  isDeleting: boolean;
+  isRunningNow: boolean;
+}
+
+function requireClient(serverId: string): DaemonClient {
+  const client = useSessionStore.getState().sessions[serverId]?.client ?? null;
+  if (!client) {
+    throw new Error("Daemon client not available");
+  }
+  return client;
+}
+
+interface ScheduleListSnapshot {
+  previous: ScheduleSummary[] | undefined;
+}
+
+function snapshotSchedules(queryClient: QueryClient, serverId: string): ScheduleListSnapshot {
+  return {
+    previous: queryClient.getQueryData<ScheduleSummary[]>(schedulesQueryKey(serverId)),
+  };
+}
+
+function restoreSchedules(
+  queryClient: QueryClient,
+  serverId: string,
+  snapshot: ScheduleListSnapshot,
+): void {
+  if (snapshot.previous === undefined) {
+    return;
+  }
+  queryClient.setQueryData(schedulesQueryKey(serverId), snapshot.previous);
+}
+
+function optimisticallySetStatus(
+  queryClient: QueryClient,
+  serverId: string,
+  id: string,
+  status: ScheduleSummary["status"],
+): void {
+  queryClient.setQueryData<ScheduleSummary[]>(schedulesQueryKey(serverId), (current) => {
+    if (!current) {
+      return current;
+    }
+    const pausedAt = status === "paused" ? new Date().toISOString() : null;
+    return current.map((schedule) =>
+      schedule.id === id ? { ...schedule, status, pausedAt } : schedule,
+    );
+  });
+}
+
+function optimisticallyRemove(queryClient: QueryClient, serverId: string, id: string): void {
+  queryClient.setQueryData<ScheduleSummary[]>(schedulesQueryKey(serverId), (current) => {
+    if (!current) {
+      return current;
+    }
+    return current.filter((schedule) => schedule.id !== id);
+  });
+}
+
+export function useScheduleMutations({
+  serverId,
+}: {
+  serverId: string;
+}): UseScheduleMutationsResult {
+  const queryClient = useQueryClient();
+
+  const invalidate = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: schedulesQueryKey(serverId) });
+  }, [queryClient, serverId]);
+
+  const createMutation = useMutation({
+    mutationFn: async (input: CreateScheduleInput): Promise<void> => {
+      const client = requireClient(serverId);
+      const payload = await client.scheduleCreate(input);
+      if (payload.error) {
+        throw new Error(payload.error);
+      }
+    },
+    onSettled: invalidate,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async (input: UpdateScheduleInput): Promise<void> => {
+      const client = requireClient(serverId);
+      const payload = await client.scheduleUpdate(input);
+      if (payload.error) {
+        throw new Error(payload.error);
+      }
+    },
+    onSettled: invalidate,
+  });
+
+  const pauseMutation = useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      const client = requireClient(serverId);
+      const payload = await client.schedulePause({ id });
+      if (payload.error) {
+        throw new Error(payload.error);
+      }
+    },
+    onMutate: async (id): Promise<ScheduleListSnapshot> => {
+      await queryClient.cancelQueries({ queryKey: schedulesQueryKey(serverId) });
+      const snapshot = snapshotSchedules(queryClient, serverId);
+      optimisticallySetStatus(queryClient, serverId, id, "paused");
+      return snapshot;
+    },
+    onError: (_error, _id, context) => {
+      if (context) {
+        restoreSchedules(queryClient, serverId, context);
+      }
+    },
+    onSettled: invalidate,
+  });
+
+  const resumeMutation = useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      const client = requireClient(serverId);
+      const payload = await client.scheduleResume({ id });
+      if (payload.error) {
+        throw new Error(payload.error);
+      }
+    },
+    onMutate: async (id): Promise<ScheduleListSnapshot> => {
+      await queryClient.cancelQueries({ queryKey: schedulesQueryKey(serverId) });
+      const snapshot = snapshotSchedules(queryClient, serverId);
+      optimisticallySetStatus(queryClient, serverId, id, "active");
+      return snapshot;
+    },
+    onError: (_error, _id, context) => {
+      if (context) {
+        restoreSchedules(queryClient, serverId, context);
+      }
+    },
+    onSettled: invalidate,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      const client = requireClient(serverId);
+      const payload = await client.scheduleDelete({ id });
+      if (payload.error) {
+        throw new Error(payload.error);
+      }
+    },
+    onMutate: async (id): Promise<ScheduleListSnapshot> => {
+      await queryClient.cancelQueries({ queryKey: schedulesQueryKey(serverId) });
+      const snapshot = snapshotSchedules(queryClient, serverId);
+      optimisticallyRemove(queryClient, serverId, id);
+      return snapshot;
+    },
+    onError: (_error, _id, context) => {
+      if (context) {
+        restoreSchedules(queryClient, serverId, context);
+      }
+    },
+    onSettled: invalidate,
+  });
+
+  const runNowMutation = useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      const client = requireClient(serverId);
+      const payload = await client.scheduleRunOnce({ id });
+      if (payload.error) {
+        throw new Error(payload.error);
+      }
+    },
+    onSettled: invalidate,
+  });
+
+  const createSchedule = useCallback(
+    async (input: CreateScheduleInput): Promise<void> => {
+      await createMutation.mutateAsync(input);
+    },
+    [createMutation],
+  );
+
+  const updateSchedule = useCallback(
+    async (input: UpdateScheduleInput): Promise<void> => {
+      await updateMutation.mutateAsync(input);
+    },
+    [updateMutation],
+  );
+
+  const pauseSchedule = useCallback(
+    async (id: string): Promise<void> => {
+      await pauseMutation.mutateAsync(id);
+    },
+    [pauseMutation],
+  );
+
+  const resumeSchedule = useCallback(
+    async (id: string): Promise<void> => {
+      await resumeMutation.mutateAsync(id);
+    },
+    [resumeMutation],
+  );
+
+  const deleteSchedule = useCallback(
+    async (id: string): Promise<void> => {
+      await deleteMutation.mutateAsync(id);
+    },
+    [deleteMutation],
+  );
+
+  const runScheduleNow = useCallback(
+    async (id: string): Promise<void> => {
+      await runNowMutation.mutateAsync(id);
+    },
+    [runNowMutation],
+  );
+
+  return {
+    createSchedule,
+    updateSchedule,
+    pauseSchedule,
+    resumeSchedule,
+    deleteSchedule,
+    runScheduleNow,
+    isCreating: createMutation.isPending,
+    isUpdating: updateMutation.isPending,
+    isPausing: pauseMutation.isPending,
+    isResuming: resumeMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+    isRunningNow: runNowMutation.isPending,
+  };
+}

--- a/packages/app/src/hooks/use-schedules.ts
+++ b/packages/app/src/hooks/use-schedules.ts
@@ -1,0 +1,57 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ScheduleSummary } from "@getpaseo/protocol/schedule/types";
+import { useSessionStore } from "@/stores/session-store";
+import { isNewAgentSchedule } from "@/utils/schedule-format";
+
+export function schedulesQueryKey(serverId: string) {
+  return ["schedules", serverId] as const;
+}
+
+export interface UseSchedulesInput {
+  serverId: string;
+}
+
+export interface UseSchedulesResult {
+  schedules: ScheduleSummary[];
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  refetch: () => void;
+  isRefetching: boolean;
+}
+
+async function fetchNewAgentSchedules(serverId: string): Promise<ScheduleSummary[]> {
+  const client = useSessionStore.getState().sessions[serverId]?.client ?? null;
+  if (!client) {
+    throw new Error("Daemon client not available");
+  }
+
+  const payload = await client.scheduleList();
+  if (payload.error) {
+    throw new Error(payload.error);
+  }
+
+  return payload.schedules.filter(isNewAgentSchedule);
+}
+
+export function useSchedules({ serverId }: UseSchedulesInput): UseSchedulesResult {
+  const hasClient = useSessionStore((state) => (state.sessions[serverId]?.client ?? null) !== null);
+
+  const query = useQuery({
+    queryKey: schedulesQueryKey(serverId),
+    queryFn: () => fetchNewAgentSchedules(serverId),
+    enabled: hasClient,
+    staleTime: 5_000,
+  });
+
+  return {
+    schedules: query.data ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    refetch: () => {
+      void query.refetch();
+    },
+    isRefetching: query.isRefetching,
+  };
+}

--- a/packages/app/src/screens/schedules-screen.tsx
+++ b/packages/app/src/screens/schedules-screen.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useMemo, useState, type ReactElement } from "react";
+import { Text, View } from "react-native";
+import { useIsFocused } from "@react-navigation/native";
+import { Plus } from "lucide-react-native";
+import { StyleSheet } from "react-native-unistyles";
+import { MenuHeader } from "@/components/headers/menu-header";
+import { ScheduleFormSheet } from "@/components/schedules/schedule-form-sheet";
+import { SchedulesTable } from "@/components/schedules/schedules-table";
+import { Button } from "@/components/ui/button";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { useSchedules } from "@/hooks/use-schedules";
+import type { ScheduleSummary } from "@getpaseo/protocol/schedule/types";
+
+type FormState =
+  | { mode: "closed" }
+  | { mode: "create" }
+  | { mode: "edit"; schedule: ScheduleSummary };
+
+export function SchedulesScreen({ serverId }: { serverId: string }): ReactElement {
+  const isFocused = useIsFocused();
+
+  if (!isFocused) {
+    return <View style={styles.container} />;
+  }
+
+  return <SchedulesScreenContent serverId={serverId} />;
+}
+
+function SchedulesScreenContent({ serverId }: { serverId: string }): ReactElement {
+  const { schedules, isLoading, isError, error, refetch } = useSchedules({ serverId });
+  const [form, setForm] = useState<FormState>({ mode: "closed" });
+
+  const openCreate = useCallback(() => {
+    setForm({ mode: "create" });
+  }, []);
+
+  const openEdit = useCallback((schedule: ScheduleSummary) => {
+    setForm({ mode: "edit", schedule });
+  }, []);
+
+  const closeForm = useCallback(() => {
+    setForm({ mode: "closed" });
+  }, []);
+
+  const headerAction = useMemo(
+    () => (
+      <Button leftIcon={Plus} onPress={openCreate} size="sm" testID="schedules-new">
+        New schedule
+      </Button>
+    ),
+    [openCreate],
+  );
+
+  return (
+    <View style={styles.container}>
+      <MenuHeader title="Schedules" rightContent={headerAction} />
+      <SchedulesBody
+        serverId={serverId}
+        schedules={schedules}
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        onRetry={refetch}
+        onCreate={openCreate}
+        onEdit={openEdit}
+      />
+      <ScheduleFormSheet
+        serverId={serverId}
+        visible={form.mode === "create" || form.mode === "edit"}
+        onClose={closeForm}
+        mode={form.mode === "edit" ? "edit" : "create"}
+        schedule={form.mode === "edit" ? form.schedule : undefined}
+      />
+    </View>
+  );
+}
+
+function SchedulesBody({
+  serverId,
+  schedules,
+  isLoading,
+  isError,
+  error,
+  onRetry,
+  onCreate,
+  onEdit,
+}: {
+  serverId: string;
+  schedules: ScheduleSummary[];
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  onRetry: () => void;
+  onCreate: () => void;
+  onEdit: (schedule: ScheduleSummary) => void;
+}): ReactElement {
+  if (isLoading) {
+    return (
+      <View style={styles.centered}>
+        <LoadingSpinner size="large" color={styles.spinner.color} />
+      </View>
+    );
+  }
+
+  if (isError) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.message}>{error?.message ?? "Could not load schedules"}</Text>
+        <Button variant="ghost" onPress={onRetry} testID="schedules-retry">
+          Retry
+        </Button>
+      </View>
+    );
+  }
+
+  if (schedules.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.message}>No schedules yet</Text>
+        <Button leftIcon={Plus} onPress={onCreate} testID="schedules-empty-new">
+          New schedule
+        </Button>
+      </View>
+    );
+  }
+
+  return <SchedulesTable serverId={serverId} schedules={schedules} onEditSchedule={onEdit} />;
+}
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.surface0,
+  },
+  centered: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    gap: theme.spacing[6],
+    padding: theme.spacing[6],
+  },
+  message: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.lg,
+    textAlign: "center",
+  },
+  // Static color holder read by the spinner — keeps the muted token without
+  // useUnistyles (banned in new code).
+  spinner: {
+    color: theme.colors.foregroundMuted,
+  },
+}));

--- a/packages/app/src/utils/host-routes.ts
+++ b/packages/app/src/utils/host-routes.ts
@@ -347,6 +347,14 @@ export function buildHostSessionsRoute(serverId: string) {
   return `${base}/sessions` as const;
 }
 
+export function buildHostSchedulesRoute(serverId: string) {
+  const base = buildHostRootRoute(serverId);
+  if (base === "/") {
+    return "/" as const;
+  }
+  return `${base}/schedules` as const;
+}
+
 export function buildHostOpenProjectRoute(serverId: string) {
   const base = buildHostRootRoute(serverId);
   if (base === "/") {
@@ -431,6 +439,9 @@ export function mapPathnameToServer(pathname: string, nextServerId: string) {
   }
   if (suffix.startsWith("sessions")) {
     return `${base}/sessions` as const;
+  }
+  if (suffix.startsWith("schedules")) {
+    return `${base}/schedules` as const;
   }
   if (suffix.startsWith("open-project")) {
     return `${base}/open-project` as const;

--- a/packages/app/src/utils/schedule-format.ts
+++ b/packages/app/src/utils/schedule-format.ts
@@ -1,0 +1,249 @@
+import type { ScheduleCadence, ScheduleSummary } from "@getpaseo/protocol/schedule/types";
+
+/**
+ * Pure, dependency-free helpers for presenting schedules.
+ *
+ * Cron is a 5-field expression (minute hour day-of-month month day-of-week),
+ * evaluated by the daemon in UTC. The validation here mirrors the daemon's
+ * structural parser in packages/server/src/server/schedule/cron.ts so the
+ * client preview rejects exactly what the server would reject.
+ */
+
+export type IntervalUnit = "minutes" | "hours" | "days";
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = MS_PER_MINUTE * 60;
+const MS_PER_DAY = MS_PER_HOUR * 24;
+
+const UNIT_MS: Record<IntervalUnit, number> = {
+  minutes: MS_PER_MINUTE,
+  hours: MS_PER_HOUR,
+  days: MS_PER_DAY,
+};
+
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+export function isNewAgentSchedule(schedule: ScheduleSummary): boolean {
+  return schedule.target.type === "new-agent";
+}
+
+function pluralize(value: number, noun: string): string {
+  return value === 1 ? `1 ${noun}` : `${value} ${noun}s`;
+}
+
+export function everyMsToParts(ms: number): { value: number; unit: IntervalUnit } {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return { value: 1, unit: "hours" };
+  }
+  if (ms % MS_PER_DAY === 0) {
+    return { value: ms / MS_PER_DAY, unit: "days" };
+  }
+  if (ms % MS_PER_HOUR === 0) {
+    return { value: ms / MS_PER_HOUR, unit: "hours" };
+  }
+  return { value: Math.max(1, Math.round(ms / MS_PER_MINUTE)), unit: "minutes" };
+}
+
+export function partsToEveryMs(value: number, unit: IntervalUnit): number {
+  const normalized = Number.isFinite(value) ? Math.max(1, Math.round(value)) : 1;
+  return normalized * UNIT_MS[unit];
+}
+
+const UNIT_NOUN: Record<IntervalUnit, string> = {
+  minutes: "minute",
+  hours: "hour",
+  days: "day",
+};
+
+function formatEvery(everyMs: number): string {
+  const { value, unit } = everyMsToParts(everyMs);
+  return `Every ${pluralize(value, UNIT_NOUN[unit])}`;
+}
+
+export function formatCadence(cadence: ScheduleCadence): string {
+  if (cadence.type === "every") {
+    return formatEvery(cadence.everyMs);
+  }
+  return describeCron(cadence.expression) ?? cadence.expression;
+}
+
+/**
+ * Humanize a handful of common 5-field cron shapes. Returns null when the
+ * expression is valid but not one of the recognized patterns (callers fall
+ * back to showing the raw expression).
+ */
+export function describeCron(expr: string): string | null {
+  const trimmed = expr.trim();
+  if (validateCron(trimmed) !== null) {
+    return null;
+  }
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = trimmed.split(/\s+/);
+
+  // Only humanize the simple "fixed time" family: literal minute/hour with the
+  // date fields either wildcarded or a recognized day-of-week constraint.
+  const minuteNum = Number.parseInt(minute, 10);
+  const isLiteralMinute = /^\d+$/.test(minute);
+  const isWildcardMonth = month === "*";
+  const isWildcardDom = dayOfMonth === "*";
+
+  if (!isLiteralMinute || !isWildcardMonth || !isWildcardDom) {
+    return null;
+  }
+
+  // "Every hour" / "Every hour at :MM"
+  if (hour === "*") {
+    if (dayOfWeek !== "*") {
+      return null;
+    }
+    return minuteNum === 0 ? "Every hour" : `Every hour at :${pad2(minuteNum)}`;
+  }
+
+  if (!/^\d+$/.test(hour)) {
+    return null;
+  }
+  const time = `${pad2(Number.parseInt(hour, 10))}:${pad2(minuteNum)}`;
+
+  if (dayOfWeek === "*") {
+    return `Daily at ${time} UTC`;
+  }
+  if (dayOfWeek === "1-5") {
+    return `Weekdays at ${time} UTC`;
+  }
+  if (dayOfWeek === "0,6" || dayOfWeek === "6,0") {
+    return `Weekends at ${time} UTC`;
+  }
+  if (/^\d$/.test(dayOfWeek)) {
+    const day = DAY_NAMES[Number.parseInt(dayOfWeek, 10)];
+    if (day) {
+      return `${day}s at ${time} UTC`;
+    }
+  }
+  return null;
+}
+
+function pad2(value: number): string {
+  return value < 10 ? `0${value}` : String(value);
+}
+
+interface CronFieldBounds {
+  min: number;
+  max: number;
+  name: string;
+}
+
+const CRON_FIELD_BOUNDS: CronFieldBounds[] = [
+  { min: 0, max: 59, name: "minute" },
+  { min: 0, max: 23, name: "hour" },
+  { min: 1, max: 31, name: "day-of-month" },
+  { min: 1, max: 12, name: "month" },
+  { min: 0, max: 6, name: "day-of-week" },
+];
+
+function validateCronField(source: string, bounds: CronFieldBounds): string | null {
+  const trimmed = source.trim();
+  if (!trimmed) {
+    return `Invalid ${bounds.name} field`;
+  }
+
+  for (const rawPart of trimmed.split(",")) {
+    const part = rawPart.trim();
+    if (!part) {
+      return `Invalid ${bounds.name} field`;
+    }
+
+    const [base, stepSource] = part.split("/");
+    if (stepSource !== undefined) {
+      const step = Number.parseInt(stepSource, 10);
+      if (!Number.isInteger(step) || step <= 0 || String(step) !== stepSource.trim()) {
+        return `Invalid ${bounds.name} step`;
+      }
+    }
+
+    if (base === "*") {
+      continue;
+    }
+
+    const rangeMatch = base.match(/^(\d+)-(\d+)$/);
+    if (rangeMatch) {
+      const start = Number.parseInt(rangeMatch[1], 10);
+      const end = Number.parseInt(rangeMatch[2], 10);
+      if (start > end || start < bounds.min || end > bounds.max) {
+        return `Invalid ${bounds.name} range`;
+      }
+      continue;
+    }
+
+    if (!/^\d+$/.test(base)) {
+      return `Invalid ${bounds.name} value`;
+    }
+    const value = Number.parseInt(base, 10);
+    if (!Number.isInteger(value) || value < bounds.min || value > bounds.max) {
+      return `Invalid ${bounds.name} value`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Returns null when the expression is a structurally valid 5-field cron the
+ * daemon would accept, otherwise a human-readable error message.
+ */
+export function validateCron(expr: string): string | null {
+  const trimmed = expr.trim();
+  if (!trimmed) {
+    return "Enter a cron expression";
+  }
+
+  const fields = trimmed.split(/\s+/);
+  if (fields.length !== 5) {
+    return "Cron expressions must have 5 fields";
+  }
+
+  for (let index = 0; index < CRON_FIELD_BOUNDS.length; index += 1) {
+    const error = validateCronField(fields[index], CRON_FIELD_BOUNDS[index]);
+    if (error) {
+      return error;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Forward-relative description of the next run, e.g. "in 3h", "in 2d", "soon".
+ * Returns "" when there is no scheduled next run.
+ */
+export function formatNextRun(iso: string | null): string {
+  if (!iso) {
+    return "";
+  }
+  const target = new Date(iso).getTime();
+  if (Number.isNaN(target)) {
+    return "";
+  }
+
+  const diffMs = target - Date.now();
+  if (diffMs <= 0) {
+    return "soon";
+  }
+  if (diffMs < MS_PER_MINUTE) {
+    return "soon";
+  }
+  if (diffMs < MS_PER_HOUR) {
+    return `in ${Math.round(diffMs / MS_PER_MINUTE)}m`;
+  }
+  if (diffMs < MS_PER_DAY) {
+    return `in ${Math.round(diffMs / MS_PER_HOUR)}h`;
+  }
+  return `in ${Math.round(diffMs / MS_PER_DAY)}d`;
+}


### PR DESCRIPTION
Adds a **Schedules** section to the sidebar (below Sessions) for creating and managing *new-agent schedules* — recurring jobs that spawn an agent on a cron or interval cadence. You can browse all schedules in a table, create and edit them, pause/resume, run one immediately, and delete.

## Related issues
Implements the core of #552 (GUI for managing schedules): the schedules table, the create/edit sheet, and the pause / resume / run-now / delete actions for **new-agent** schedules, plus the sidebar entry. Intentionally left for follow-up so #552 stays open: the run-history inspect screen (`schedule/inspect` + `schedule/logs`), agent↔schedule correlation (the "spawned by schedule" badge and list filter), an existing-agent target, and the composer "Schedule this prompt…" action.

Related, not addressed here:
- #1233 — the cadence editor is UTC-only; interpreting cron in a local IANA time zone is a follow-up.
- #182 — this schedules *new agents*, not queued messages to an existing agent.

## What's included
- Borderless, SaaS-style table: provider icon next to the model, cadence, next run, status pill, and end-of-row actions.
- Create/edit sheet that reuses the agent provider / model / mode / working-directory pickers, plus an interval-or-cron cadence editor with presets, validation, and a UTC preview.
- Responsive: hover-revealed row actions on desktop, an always-visible action menu on mobile.
- Data layer over the existing `schedule.*` RPCs (list / create / update / pause / resume / delete / run-once) with optimistic pause, resume, and delete.

Scope is limited to **new-agent** schedules for now (the list is filtered to that target type).

## How to verify beyond CI
This is Expo UI (iOS / Android / web / Electron) with no automated coverage yet, so it needs a manual smoke. Typecheck and lint pass across the workspace.
- Sidebar → Schedules. Create a schedule (provider, model, working directory, prompt, cadence) and confirm it lands in the table with the right provider icon, cadence label, and next-run.
- Edit a schedule and confirm the form prefills name / prompt / cadence / max-runs and provider / model / mode / working-directory.
- Pause/resume, run-now, and delete from the row actions (hover cluster on desktop, kebab on mobile); confirm the optimistic update and the delete confirmation dialog.
- Check a narrow (mobile) and wide (desktop) viewport.

## Risk surface
- **Edit prefill**: the sheet stays mounted, so prefill re-seeds local fields when it opens and relies on `useAgentFormState` resolving `initialValues` (driven with `isCreateFlow: true`). Worth confirming provider/model populate once models load lazily.
- **Cross-platform**: themed provider-icon color and hover-reveal actions follow the no-`useUnistyles` and hover conventions; verify native (always-visible kebab) vs web (hover cluster).
- **Daemon capability**: assumes the connected daemon supports the `schedule.*` RPCs. Against an older daemon `scheduleList` errors and the screen shows its error state (no crash).
- No protocol/server/client changes — purely client UI over existing RPCs.