### PR TITLE
Fix flaky mobile bottom-sheet reopen e2e test

### DIFF
--- a/packages/app/e2e/bottom-sheet-reopen.spec.ts
+++ b/packages/app/e2e/bottom-sheet-reopen.spec.ts
@@ -41,13 +41,25 @@ async function expectBottomSheetOpen(page: Page) {
 }
 
 async function closeBottomSheetWithBackdrop(page: Page) {
-  const box = await bottomSheetBackdrop(page).boundingBox();
-  expect(box).not.toBeNull();
-  await page.mouse.click(box!.x + box!.width / 2, box!.y + 24);
-  await expect(bottomSheetBackdrop(page)).not.toBeVisible({ timeout: 10_000 });
+  const backdrop = bottomSheetBackdrop(page);
+  // A single backdrop tap can be dropped when it lands mid present-animation:
+  // Gorhom ignores backdrop presses until the sheet settles at its snap point,
+  // which a loaded CI runner makes likely (the model selector's sheet animates a
+  // touch longer than the tab switcher's). Re-tap until the sheet dismisses. This
+  // stays a pure backdrop dismissal — no Escape/pan fallback — so it still
+  // exercises the real close path; the post-close guard below is what protects
+  // the regression this test exists for: a sheet that dismisses, then re-presents.
+  await expect(async () => {
+    if (await backdrop.isVisible()) {
+      const box = await backdrop.boundingBox();
+      expect(box).not.toBeNull();
+      await page.mouse.click(box!.x + box!.width / 2, box!.y + 24);
+    }
+    await expect(backdrop).not.toBeVisible({ timeout: 1_000 });
+  }).toPass({ timeout: 15_000 });
   // Guard against the regression where the sheet starts dismissing, then re-presents.
   await page.waitForTimeout(500);
-  await expect(bottomSheetBackdrop(page)).not.toBeVisible({ timeout: 1_000 });
+  await expect(backdrop).not.toBeVisible({ timeout: 1_000 });
 }
 
 async function openTabSwitcher(page: Page) {


### PR DESCRIPTION
The `bottom-sheet-reopen.spec.ts › model selector can open, close, reopen, and close again` test is flaky on CI and is currently red on `main` (and on any branch built from it). This makes the e2e job a blocker even for unrelated changes.

## Root cause
The test dismisses the sheet with a single backdrop tap. On a loaded CI runner the tap can land while the sheet is still present-animating, and `@gorhom/bottom-sheet` ignores backdrop presses until the sheet settles at its snap point — so the tap is dropped, the sheet stays open, and `expect(backdrop).not.toBeVisible()` times out. The model selector's sheet animates slightly longer than the tab switcher's, which is why only that case fails.

This is test-interaction fragility, not a product regression: the reopen behaviour is correct (the visibility tracker is unit-tested), and the spec passes locally 3× for both cases.

## Fix
Re-tap the backdrop until the sheet dismisses, mirroring the resilient close loop already used in `e2e/helpers/app.ts`. It stays a **pure backdrop dismissal** — no Escape/pan fallback — so the real close path is still exercised, and the post-close "stays hidden" guard that protects the dismiss-then-re-present regression is unchanged.

## How to verify beyond CI
- Test-only change (`packages/app/e2e/bottom-sheet-reopen.spec.ts`); no product code touched.
- Locally: `cd packages/app && npx playwright test e2e/bottom-sheet-reopen.spec.ts --repeat-each=3` → 6/6 pass.
- lint + app typecheck clean.
- The real signal is the `playwright` job on this PR going green (it reproduces the load conditions this fixes).

## Risk surface
- None to product behaviour — only the e2e close helper changed. Worst case the test is still flaky on CI, in which case the next step is to also wait for the sheet to fully settle before the first tap.