### PR TITLE
fix(desktop): stop pinning macOS displays at max refresh rate

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -59,6 +59,12 @@ GPU process so Chromium rebuilds the display link. The probe is skipped while
 the screen is locked or the window is hidden or minimized, since a window
 legitimately stops producing frames then.
 
+The watchdog deliberately leaves background throttling **enabled**. Calling
+`webContents.setBackgroundThrottling(false)` would keep the compositor producing
+frames non-stop, pinning ProMotion displays at 120Hz forever and draining the
+battery while the app is idle — so do not re-add it. The probe's visibility
+guards already prevent throttling from causing a false stall.
+
 ### Daemon logs
 
 Check `$PASEO_HOME/daemon.log` for daemon logs. The default level is `info`; set

--- a/packages/desktop/src/window/compositor-watchdog/index.ts
+++ b/packages/desktop/src/window/compositor-watchdog/index.ts
@@ -67,8 +67,15 @@ export function setupDarwinCompositorWatchdog(win: BrowserWindow): void {
     return;
   }
 
-  // Keep producing frames while occluded so the probe is not fooled by throttling.
-  win.webContents.setBackgroundThrottling(false);
+  // Deliberately do NOT call win.webContents.setBackgroundThrottling(false) here.
+  // Disabling background throttling keeps Chromium's compositor producing frames
+  // continuously, which pins ProMotion displays at their max refresh rate (120Hz)
+  // forever and drains the battery even while the app sits idle. The probe does
+  // not need it: the visibility guards below (screen lock / isVisible /
+  // isMinimized / document.visibilityState) already skip windows that legitimately
+  // stop producing frames, so throttling cannot fool the probe into a false stall.
+  // The freeze this watchdog targets happens while the window is visible and
+  // focused (just after display wake), where background throttling never applies.
 
   let stalledChecks = 0;
   let recovering = false;


### PR DESCRIPTION
### Linked issue

_No filed issue — found while dogfooding the desktop app on macOS (ProMotion display)._

### Type of change

- [x] Bug fix

### What does this PR do

The macOS compositor watchdog (added in #745) calls `webContents.setBackgroundThrottling(false)` unconditionally for the window's whole lifetime. That disables Chromium's idle frame-rate throttling, so the GPU process's `CADisplayLink` never idles — pinning ProMotion panels at their maximum refresh rate (120Hz) continuously, even while the app is idle or occluded, which drains the battery.

The call isn't needed: the probe already skips non-producing windows via its screen-lock / `isVisible` / `isMinimized` / `document.visibilityState` guards, and the freeze it targets happens while the window is **visible and focused**, where background throttling never applies. Removing it lets the compositor idle and the display drop to a low adaptive rate when nothing animates; freeze detection is unaffected. A comment and a `docs/development.md` note keep it from being re-added.

### How did you verify it

- **A/B on the same Electron the app ships (41):** two windows loading the same static page — one reproducing the old `setBackgroundThrottling(false)`, one with the default. Hidden for 4s: the old one keeps rendering ~120fps (480 frames); the fixed one produces **0 frames**. Visible + animating, both track the display (expected).
- **Real app:** built the desktop app with the fix and ran it on a ProMotion Mac — opening the window no longer pins the display at its max refresh; it drops to an adaptive rate when idle.
- Existing `shouldRecoverFromFrameStall` unit test still passes; desktop `typecheck` + `lint` clean.

### Checklist

- [x] One focused change. Unrelated cleanups split out (the SyncedLoader animation fix is a separate PR).
- [x] `typecheck` passes (desktop workspace)
- [x] `lint` passes
- [x] `format` ran (Biome)
- [ ] UI changes include screenshots — n/a (Electron main-process behavior, no UI change)
- [ ] Tests added — existing watchdog unit test covers the pure logic; the removed call is main-process Electron behavior, verified via the A/B above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
