### PR TITLE
fix(server): stop the daemon supervisor from hot-looping on permanent crashes

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -140,6 +140,12 @@ The supervisor rotates `daemon.log`. Persisted `log.file.rotate` settings in
 `PASEO_LOG_ROTATE_SIZE` and `PASEO_LOG_ROTATE_COUNT` env vars override the
 defaults. The default rotation is `10m` x `3` files everywhere.
 
+The supervisor also bounds crash restarts. When the daemon worker exits
+non-zero repeatedly, the supervisor applies exponential backoff and then exits
+instead of respawning forever. Look for `Worker crash-looped` in
+`daemon.log` when a desktop or CLI-managed daemon stops after repeated startup
+failures such as a stale port owner.
+
 ## paseo.json service scripts
 
 `worktree.setup` and `worktree.teardown` accept either a multiline shell script or an array

--- a/packages/server/scripts/restart-policy.test.ts
+++ b/packages/server/scripts/restart-policy.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "vitest";
+import { decideRestart, isCrash, planWorkerExit, type RestartPolicy } from "./restart-policy.js";
+
+const policy: RestartPolicy = {
+  maxRestarts: 3,
+  windowMs: 10_000,
+  baseDelayMs: 100,
+  maxDelayMs: 1_000,
+};
+
+describe("decideRestart", () => {
+  test("restarts while crashes within the window stay at or below maxRestarts", () => {
+    // Three crashes inside the window (including the current one) is still allowed.
+    const decision = decideRestart([1000, 1100, 1200], 1200, policy);
+    expect(decision.shouldRestart).toBe(true);
+  });
+
+  test("stops restarting once crashes within the window exceed maxRestarts", () => {
+    // The fourth crash inside the window is the crash-loop signal: give up.
+    const decision = decideRestart([1000, 1100, 1200, 1300], 1300, policy);
+    expect(decision.shouldRestart).toBe(false);
+  });
+
+  test("applies exponential backoff as recent crashes accumulate", () => {
+    expect(decideRestart([1000], 1000, policy).delayMs).toBe(100); // base * 2^0
+    expect(decideRestart([1000, 1100], 1100, policy).delayMs).toBe(200); // base * 2^1
+    expect(decideRestart([1000, 1100, 1200], 1200, policy).delayMs).toBe(400); // base * 2^2
+  });
+
+  test("caps the backoff delay at maxDelayMs", () => {
+    const burst = Array.from({ length: 10 }, (_value, index) => 1000 + index);
+    expect(decideRestart(burst, 1009, policy).delayMs).toBe(1_000);
+  });
+
+  test("ignores crashes older than the window so a recovered worker restarts cleanly", () => {
+    // Two ancient crashes far outside the window, plus one fresh crash now.
+    const decision = decideRestart([10, 20, 100_000], 100_000, policy);
+    expect(decision.shouldRestart).toBe(true);
+    expect(decision.delayMs).toBe(100); // only the fresh crash counts → base delay
+    expect(decision.recentCrashes).toBe(1);
+  });
+});
+
+describe("isCrash", () => {
+  test("treats a non-zero exit code as a crash when restartOnCrash is enabled", () => {
+    expect(isCrash(true, 1, null)).toBe(true);
+  });
+
+  test("treats SIGTERM as a clean stop, not a crash", () => {
+    expect(isCrash(true, null, "SIGTERM")).toBe(false);
+  });
+
+  test("treats a zero exit code as a clean exit", () => {
+    expect(isCrash(true, 0, null)).toBe(false);
+  });
+
+  test("never reports a crash when restartOnCrash is disabled", () => {
+    expect(isCrash(false, 1, null)).toBe(false);
+  });
+});
+
+describe("planWorkerExit", () => {
+  const base = {
+    restartOnCrash: true,
+    crashTimestamps: [] as number[],
+    now: 0,
+    policy,
+  };
+
+  test("exits cleanly with code 0 when shutting down", () => {
+    const plan = planWorkerExit({
+      ...base,
+      shuttingDown: true,
+      restarting: false,
+      code: 1,
+      signal: null,
+    });
+    expect(plan).toEqual({ action: "shutdown-exit" });
+  });
+
+  test("restarts immediately for an intentional restart without counting it as a crash", () => {
+    const plan = planWorkerExit({
+      ...base,
+      shuttingDown: false,
+      restarting: true,
+      code: null,
+      signal: "SIGTERM",
+      crashTimestamps: [5, 6],
+    });
+    expect(plan).toEqual({ action: "restart", delayMs: 0, crashTimestamps: [5, 6] });
+  });
+
+  test("does not count a failed intentional restart exit as a crash", () => {
+    const plan = planWorkerExit({
+      ...base,
+      shuttingDown: false,
+      restarting: true,
+      code: 1,
+      signal: null,
+      crashTimestamps: [5, 6],
+    });
+    expect(plan).toEqual({ action: "restart", delayMs: 0, crashTimestamps: [5, 6] });
+  });
+
+  test("restarts a crashed worker with backoff and records the crash", () => {
+    const plan = planWorkerExit({
+      ...base,
+      shuttingDown: false,
+      restarting: false,
+      code: 1,
+      signal: null,
+      crashTimestamps: [1000],
+      now: 1100,
+    });
+    expect(plan.action).toBe("restart");
+    if (plan.action === "restart") {
+      expect(plan.delayMs).toBe(200); // two recent crashes → base * 2
+      expect(plan.crashTimestamps).toEqual([1000, 1100]);
+    }
+  });
+
+  test("gives up with a non-zero code once the worker crash-loops past maxRestarts", () => {
+    const plan = planWorkerExit({
+      ...base,
+      shuttingDown: false,
+      restarting: false,
+      code: 1,
+      signal: null,
+      crashTimestamps: [1000, 1100, 1200],
+      now: 1300,
+    });
+    expect(plan.action).toBe("give-up");
+    if (plan.action === "give-up") {
+      expect(plan.code).toBeGreaterThan(0);
+    }
+  });
+
+  test("exits with the worker's own code on a normal non-crash exit", () => {
+    const plan = planWorkerExit({
+      ...base,
+      shuttingDown: false,
+      restarting: false,
+      code: 0,
+      signal: null,
+    });
+    expect(plan).toEqual({ action: "exit", code: 0 });
+  });
+});

--- a/packages/server/scripts/restart-policy.ts
+++ b/packages/server/scripts/restart-policy.ts
@@ -1,0 +1,110 @@
+export interface RestartPolicy {
+  /** Maximum crash-restarts permitted within `windowMs` before the supervisor gives up. */
+  maxRestarts: number;
+  /** Sliding window (ms) over which crashes are counted. */
+  windowMs: number;
+  /** Backoff delay (ms) before the first restart in a burst. */
+  baseDelayMs: number;
+  /** Upper bound (ms) on the exponential backoff delay. */
+  maxDelayMs: number;
+}
+
+export interface RestartDecision {
+  shouldRestart: boolean;
+  delayMs: number;
+  recentCrashes: number;
+}
+
+/**
+ * Production defaults: tolerate a brief burst of crash-restarts, but stop a
+ * runaway loop. With these values an unrecoverable failure (e.g. EADDRINUSE
+ * against a live daemon) is retried ~5 times over ~6s with exponential
+ * backoff, then the supervisor gives up instead of hot-looping forever.
+ */
+export const DEFAULT_RESTART_POLICY: RestartPolicy = {
+  maxRestarts: 5,
+  windowMs: 10_000,
+  baseDelayMs: 200,
+  maxDelayMs: 5_000,
+};
+
+export function decideRestart(
+  crashTimestamps: number[],
+  now: number,
+  policy: RestartPolicy,
+): RestartDecision {
+  const recentCrashes = crashTimestamps.filter((at) => now - at < policy.windowMs).length;
+  const shouldRestart = recentCrashes <= policy.maxRestarts;
+  const exponent = Math.max(0, recentCrashes - 1);
+  const delayMs = Math.min(policy.maxDelayMs, policy.baseDelayMs * 2 ** exponent);
+  return { shouldRestart, delayMs, recentCrashes };
+}
+
+export type ExitPlan =
+  | { action: "shutdown-exit" }
+  | { action: "restart"; delayMs: number; crashTimestamps: number[] }
+  | { action: "give-up"; code: number; crashTimestamps: number[] }
+  | { action: "exit"; code: number };
+
+export interface PlanWorkerExitInput {
+  shuttingDown: boolean;
+  restarting: boolean;
+  restartOnCrash: boolean;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  /** Epoch-ms timestamps of prior crashes, not including the exit being planned. */
+  crashTimestamps: number[];
+  now: number;
+  policy: RestartPolicy;
+}
+
+/**
+ * A worker exit counts as a crash only when crash-restart is enabled and the
+ * worker did not exit cleanly (zero code) or via the SIGTERM we send for
+ * intentional restarts/shutdowns.
+ */
+export function isCrash(
+  restartOnCrash: boolean,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): boolean {
+  if (!restartOnCrash) {
+    return false;
+  }
+  const exitedWithError = code !== 0 && code !== null;
+  const killedByUnexpectedSignal = signal !== null && signal !== "SIGTERM";
+  return exitedWithError || killedByUnexpectedSignal;
+}
+
+/**
+ * Decide what the supervisor should do when a worker exits, folding the
+ * shutdown/intentional-restart/crash branches together with the crash-loop
+ * circuit breaker. Pure so the full decision is testable without forking.
+ */
+export function planWorkerExit(input: PlanWorkerExitInput): ExitPlan {
+  if (input.shuttingDown) {
+    return { action: "shutdown-exit" };
+  }
+
+  // Intentional restarts (worker SIGTERMed by requestRestart) bypass the crash
+  // accounting entirely. This preserves the supervisor's restart contract even
+  // if the worker's shutdown path exits non-zero.
+  if (input.restarting) {
+    return { action: "restart", delayMs: 0, crashTimestamps: input.crashTimestamps };
+  }
+
+  const crashed = isCrash(input.restartOnCrash, input.code, input.signal);
+
+  if (crashed) {
+    const crashTimestamps = [...input.crashTimestamps, input.now].filter(
+      (at) => input.now - at < input.policy.windowMs,
+    );
+    const decision = decideRestart(crashTimestamps, input.now, input.policy);
+    if (decision.shouldRestart) {
+      return { action: "restart", delayMs: decision.delayMs, crashTimestamps };
+    }
+    return { action: "give-up", code: 1, crashTimestamps };
+  }
+
+  return { action: "exit", code: typeof input.code === "number" ? input.code : 1 };
+}

--- a/packages/server/scripts/supervisor.logging.test.ts
+++ b/packages/server/scripts/supervisor.logging.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { spawn } from "node:child_process";
 import { describe, expect, test } from "vitest";
 import { isPlatform } from "../src/test-utils/platform.js";
+import type { RestartPolicy } from "./restart-policy.js";
 import { resolveSupervisorLogFile } from "./supervisor-log-config.js";
 
 const repoRoot = path.resolve(fileURLToPath(new URL("../../..", import.meta.url)));
@@ -13,6 +14,7 @@ const supervisorPath = fileURLToPath(new URL("./supervisor.ts", import.meta.url)
 async function runSupervisorFixture(options: {
   workerSource: string;
   restartOnCrash?: boolean;
+  restartPolicy?: RestartPolicy;
 }): Promise<{
   code: number | null;
   signal: NodeJS.Signals | null;
@@ -26,6 +28,9 @@ async function runSupervisorFixture(options: {
   const runnerPath = path.join(tempDir, "runner.mjs");
 
   await writeFile(workerPath, options.workerSource);
+  const restartPolicySource = options.restartPolicy
+    ? `restartPolicy: ${JSON.stringify(options.restartPolicy)},`
+    : "";
   await writeFile(
     runnerPath,
     `
@@ -39,6 +44,7 @@ async function runSupervisorFixture(options: {
         workerEnv: process.env,
         workerExecArgv: [],
         restartOnCrash: ${JSON.stringify(options.restartOnCrash ?? false)},
+        ${restartPolicySource}
         logFile: {
           path: ${JSON.stringify(logPath)},
           rotate: { maxSize: "1m", maxFiles: 2 },
@@ -186,4 +192,30 @@ describe("supervisor durable logging", () => {
       expect(result.log).toContain("Supervisor exiting");
     },
   );
+});
+
+describe("supervisor crash restart policy", () => {
+  test("backs off and gives up after repeated worker crashes", async () => {
+    const result = await runSupervisorFixture({
+      workerSource: "process.exit(1);",
+      restartOnCrash: true,
+      restartPolicy: {
+        maxRestarts: 2,
+        windowMs: 5_000,
+        baseDelayMs: 10,
+        maxDelayMs: 20,
+      },
+    });
+
+    const restartLogs =
+      result.stderr.match(/Worker crashed \(code 1\)\. Restarting worker in \d+ms/g) ?? [];
+
+    expect(result.code).toBe(1);
+    expect(result.signal).toBeNull();
+    expect(restartLogs).toHaveLength(2);
+    expect(result.stderr).toContain(
+      "Worker crash-looped (3 crashes within 5000ms). Supervisor giving up.",
+    );
+    expect(result.log).toContain('"msg":"Worker crash-looped');
+  });
 });

--- a/packages/server/scripts/supervisor.ts
+++ b/packages/server/scripts/supervisor.ts
@@ -2,6 +2,12 @@ import { fork, spawn, type ChildProcess } from "child_process";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { createStream as createRotatingFileStream } from "rotating-file-stream";
+import {
+  DEFAULT_RESTART_POLICY,
+  isCrash,
+  planWorkerExit,
+  type RestartPolicy,
+} from "./restart-policy.js";
 
 interface SupervisorLogFileOptions {
   path: string;
@@ -38,6 +44,7 @@ interface SupervisorOptions {
   } | null;
   onWorkerReady?: (message: { listen: string }) => Promise<void> | void;
   restartOnCrash?: boolean;
+  restartPolicy?: RestartPolicy;
   onSupervisorExit?: () => Promise<void> | void;
   logFile?: SupervisorLogFileOptions;
 }
@@ -98,6 +105,7 @@ function createSupervisorLogStream(options: SupervisorLogFileOptions | undefined
 
 export function runSupervisor(options: SupervisorOptions): void {
   const restartOnCrash = options.restartOnCrash ?? false;
+  const restartPolicy = options.restartPolicy ?? DEFAULT_RESTART_POLICY;
   const workerArgs = options.workerArgs ?? process.argv.slice(2);
   const workerEnv = options.workerEnv ?? process.env;
   const workerExecArgv = options.workerExecArgv ?? ["--import", "tsx"];
@@ -107,6 +115,8 @@ export function runSupervisor(options: SupervisorOptions): void {
   let restarting = false;
   let shuttingDown = false;
   let exiting = false;
+  let crashTimestamps: number[] = [];
+  let pendingRestart: ReturnType<typeof setTimeout> | null = null;
   const logStream = createSupervisorLogStream(options.logFile);
 
   const writeDurableChunk = (chunk: string | Buffer): void => {
@@ -227,30 +237,61 @@ export function runSupervisor(options: SupervisorOptions): void {
       const exitDescriptor = describeExit(code, signal);
       writeLifecycleLog("Worker exited", { code, signal, exit: exitDescriptor });
 
-      if (shuttingDown) {
-        log(`Worker exited (${exitDescriptor}). Supervisor shutting down.`);
-        exitSupervisor(0);
-        return;
+      const plan = planWorkerExit({
+        shuttingDown,
+        restarting,
+        restartOnCrash,
+        code,
+        signal,
+        crashTimestamps,
+        now: Date.now(),
+        policy: restartPolicy,
+      });
+
+      switch (plan.action) {
+        case "shutdown-exit":
+          log(`Worker exited (${exitDescriptor}). Supervisor shutting down.`);
+          exitSupervisor(0);
+          return;
+        case "restart": {
+          restarting = false;
+          crashTimestamps = plan.crashTimestamps;
+          log(
+            isCrash(restartOnCrash, code, signal)
+              ? `Worker crashed (${exitDescriptor}). Restarting worker in ${plan.delayMs}ms...`
+              : `Worker exited (${exitDescriptor}). Restarting worker...`,
+          );
+          scheduleRestart(plan.delayMs);
+          return;
+        }
+        case "give-up":
+          restarting = false;
+          crashTimestamps = plan.crashTimestamps;
+          log(
+            `Worker crash-looped (${plan.crashTimestamps.length} crashes within ${restartPolicy.windowMs}ms). Supervisor giving up.`,
+          );
+          exitSupervisor(plan.code);
+          return;
+        case "exit":
+          log(`Worker exited (${exitDescriptor}). Supervisor exiting.`);
+          exitSupervisor(plan.code);
+          return;
       }
-
-      const crashed =
-        restartOnCrash &&
-        ((code !== 0 && code !== null) || (signal !== null && signal !== "SIGTERM"));
-
-      if (restarting || crashed) {
-        restarting = false;
-        log(
-          crashed
-            ? `Worker crashed (${exitDescriptor}). Restarting worker...`
-            : `Worker exited (${exitDescriptor}). Restarting worker...`,
-        );
-        spawnWorker();
-        return;
-      }
-
-      log(`Worker exited (${exitDescriptor}). Supervisor exiting.`);
-      exitSupervisor(typeof code === "number" ? code : 1);
     });
+  };
+
+  const scheduleRestart = (delayMs: number): void => {
+    if (delayMs <= 0) {
+      spawnWorker();
+      return;
+    }
+    pendingRestart = setTimeout(() => {
+      pendingRestart = null;
+      if (shuttingDown) {
+        return;
+      }
+      spawnWorker();
+    }, delayMs);
   };
 
   const requestRestart = (reason: string) => {
@@ -271,6 +312,14 @@ export function runSupervisor(options: SupervisorOptions): void {
     restarting = false;
     writeLifecycleLog("Supervisor shutdown requested", { reason });
     log(`${reason}. Stopping worker...`);
+    if (pendingRestart) {
+      // A crashed worker was waiting to respawn — cancel the timer and exit
+      // cleanly, since no worker is currently live to SIGTERM.
+      clearTimeout(pendingRestart);
+      pendingRestart = null;
+      exitSupervisor(0);
+      return;
+    }
     if (!child) {
       exitSupervisor(0);
       return;


### PR DESCRIPTION
## Problem

A desktop/CLI-managed Paseo daemon could peg a CPU core indefinitely. Observed in the wild: load average **31**, a `Paseo Daemon` worker respawning ~2×/second for **9+ hours**.

Root cause: the supervisor restarts its worker on **every** non-zero exit with **no backoff and no limit**. When the worker can never start — e.g. it hits `EADDRINUSE` because an orphaned daemon (a worker that outlived its supervisor and reparented to launchd) still owns `127.0.0.1:6767` — that unrecoverable failure becomes an infinite hot respawn loop, each cycle a full daemon bootstrap thrown away in milliseconds.

## Fix

A crash-loop circuit breaker, expressed as pure, unit-tested helpers so the decision logic is testable without forking:

- `decideRestart(crashTimestamps, now, policy)` — windowed crash count → `{ shouldRestart, delayMs }` with exponential backoff.
- `planWorkerExit(input)` — folds the existing shutdown / intentional-restart / crash / clean-exit branches together with the breaker into one `ExitPlan`.
- `supervisor.ts` close handler executes the plan: backoff via `setTimeout`, give up (clean non-zero exit) after `maxRestarts` crashes within the window, and cancel a pending restart on shutdown.

Default policy: **5 restarts within 10s**, exponential backoff (200ms → 5s cap). An unrecoverable failure now retries ~5× over ~6s, then the supervisor exits with a clear `Worker crash-looped …` log instead of looping forever. Intentional restarts and clean/SIGTERM exits are unaffected.

## Tests

- `restart-policy.test.ts` — unit tests for `decideRestart` / `isCrash` / `planWorkerExit` (backoff, give-up, window expiry, intentional-restart bypass).
- `supervisor.logging.test.ts` — subprocess integration test: an always-crashing worker backs off twice, then the supervisor gives up with exit 1 and logs `Worker crash-looped (3 crashes within 5000ms)`.

## Scope / follow-up

This is the defense-in-depth half. A follow-up will add **cooperative handoff** — the worker detects `EADDRINUSE` from a healthy Paseo daemon and yields; the desktop attaches to the existing daemon — so a collision resolves on the first attempt instead of after the backoff budget.

Known limitation: intentional restarts (`paseo:restart` IPC) bypass the breaker by design; they're externally triggered so they don't self-loop, but bounding their frequency could be a later hardening step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)