### PR TITLE
fix(server): yield to an existing healthy daemon on EADDRINUSE

### DIFF
--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -9,6 +9,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "pino";
 import { createBranchChangeRouteHandler } from "./script-route-branch-handler.js";
+import { PASEO_HEALTH_HEADER, PASEO_HEALTH_HEADER_VALUE } from "./daemon-port-conflict.js";
 
 export type ListenTarget =
   | { type: "tcp"; host: string; port: number }
@@ -420,6 +421,7 @@ export async function createPaseoDaemon(
 
   // Health check endpoint
   app.get("/api/health", (_req, res) => {
+    res.setHeader(PASEO_HEALTH_HEADER, PASEO_HEALTH_HEADER_VALUE);
     res.json({ status: "ok", timestamp: new Date().toISOString() });
   });
 

--- a/packages/server/src/server/daemon-port-conflict.test.ts
+++ b/packages/server/src/server/daemon-port-conflict.test.ts
@@ -1,0 +1,86 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  isAddressInUseError,
+  isHealthyPaseoDaemonAt,
+  PASEO_HEALTH_HEADER,
+  PASEO_HEALTH_HEADER_VALUE,
+} from "./daemon-port-conflict.js";
+
+describe("isAddressInUseError", () => {
+  test("detects EADDRINUSE errors", () => {
+    expect(isAddressInUseError({ code: "EADDRINUSE" })).toBe(true);
+  });
+
+  test("ignores other error shapes", () => {
+    expect(isAddressInUseError({ code: "ECONNREFUSED" })).toBe(false);
+    expect(isAddressInUseError(new Error("boom"))).toBe(false);
+    expect(isAddressInUseError(null)).toBe(false);
+  });
+});
+
+describe("isHealthyPaseoDaemonAt", () => {
+  let server: Server | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      const closing = server;
+      server = null;
+      await new Promise<void>((resolve) => closing.close(() => resolve()));
+    }
+  });
+
+  async function startServer(handler: Parameters<typeof createServer>[1]): Promise<number> {
+    server = createServer(handler);
+    await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", () => resolve()));
+    return (server!.address() as AddressInfo).port;
+  }
+
+  test("returns true when the port serves the Paseo health endpoint", async () => {
+    const port = await startServer((req, res) => {
+      if (req.url === "/api/health") {
+        res.writeHead(200, {
+          "content-type": "application/json",
+          [PASEO_HEALTH_HEADER]: PASEO_HEALTH_HEADER_VALUE,
+        });
+        res.end(JSON.stringify({ status: "ok", timestamp: "now" }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    expect(await isHealthyPaseoDaemonAt("127.0.0.1", port)).toBe(true);
+  });
+
+  test("returns false for a non-Paseo server occupying the port", async () => {
+    const port = await startServer((_req, res) => {
+      res.writeHead(200);
+      res.end("hello from something else");
+    });
+    expect(await isHealthyPaseoDaemonAt("127.0.0.1", port)).toBe(false);
+  });
+
+  test("returns false for a generic health endpoint with the same JSON shape", async () => {
+    const port = await startServer((req, res) => {
+      if (req.url === "/api/health") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ status: "ok", timestamp: "now" }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    expect(await isHealthyPaseoDaemonAt("127.0.0.1", port)).toBe(false);
+  });
+
+  test("returns false when nothing is listening on the port", async () => {
+    // Bind then immediately release a port so we know it is free.
+    const probe = createServer();
+    await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", () => resolve()));
+    const freePort = (probe.address() as AddressInfo).port;
+    await new Promise<void>((resolve) => probe.close(() => resolve()));
+
+    expect(await isHealthyPaseoDaemonAt("127.0.0.1", freePort, { timeoutMs: 500 })).toBe(false);
+  });
+});

--- a/packages/server/src/server/daemon-port-conflict.ts
+++ b/packages/server/src/server/daemon-port-conflict.ts
@@ -1,0 +1,52 @@
+export interface ProbeOptions {
+  timeoutMs?: number;
+}
+
+const DEFAULT_PROBE_TIMEOUT_MS = 1_000;
+export const PASEO_HEALTH_HEADER = "x-paseo-daemon";
+export const PASEO_HEALTH_HEADER_VALUE = "1";
+
+/** True when an error is Node's "port already bound" listen failure. */
+export function isAddressInUseError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "EADDRINUSE"
+  );
+}
+
+/**
+ * Probe whether a healthy Paseo daemon already owns `host:port` by hitting its
+ * unauthenticated `/api/health` endpoint. Used when a worker hits EADDRINUSE so
+ * it can yield to the existing daemon instead of fighting for the port.
+ * Returns false on any error, non-2xx, or non-Paseo response.
+ */
+export async function isHealthyPaseoDaemonAt(
+  host: string,
+  port: number,
+  options?: ProbeOptions,
+): Promise<boolean> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`http://${host}:${port}/api/health`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return false;
+    }
+    if (response.headers.get(PASEO_HEALTH_HEADER) !== PASEO_HEALTH_HEADER_VALUE) {
+      return false;
+    }
+    const body: unknown = await response.json().catch(() => null);
+    return (
+      typeof body === "object" && body !== null && (body as { status?: unknown }).status === "ok"
+    );
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/server/src/server/daemon-worker.ts
+++ b/packages/server/src/server/daemon-worker.ts
@@ -1,5 +1,6 @@
-import { createPaseoDaemon } from "./bootstrap.js";
+import { createPaseoDaemon, parseListenString } from "./bootstrap.js";
 import { loadConfig } from "./config.js";
+import { isAddressInUseError, isHealthyPaseoDaemonAt } from "./daemon-port-conflict.js";
 import { resolvePaseoHome } from "./paseo-home.js";
 import { createRootLogger } from "./logger.js";
 import type { DaemonLifecycleIntent } from "./bootstrap.js";
@@ -163,6 +164,26 @@ async function main() {
     throw err;
   }
 
+  // When the listen address is already taken by a healthy Paseo daemon, yield
+  // to it instead of treating EADDRINUSE as a crash. Exiting 0 lets the
+  // supervisor stop cleanly (no restart) while the existing daemon keeps serving.
+  const yieldToHealthyDaemonOnPort = async (): Promise<boolean> => {
+    const target = parseListenString(config.listen);
+    if (target.type !== "tcp") {
+      return false;
+    }
+    const probeHost = target.host === "0.0.0.0" || target.host === "::" ? "127.0.0.1" : target.host;
+    if (!(await isHealthyPaseoDaemonAt(probeHost, target.port))) {
+      return false;
+    }
+    logger.warn(
+      { listen: config.listen },
+      "Listen address already owned by a healthy Paseo daemon; exiting without restart so the existing daemon keeps serving",
+    );
+    exitAfterPinoFlush(0);
+    return true;
+  };
+
   try {
     await daemon.start();
     const listenTarget = daemon.getListenTarget();
@@ -175,6 +196,9 @@ async function main() {
     }
     sendSupervisorLifecycleMessage({ type: "paseo:ready", listen });
   } catch (err) {
+    if (isAddressInUseError(err) && (await yieldToHealthyDaemonOnPort())) {
+      return;
+    }
     logger.fatal({ err }, "Daemon failed to start listening");
     throw err;
   }
@@ -196,8 +220,8 @@ async function main() {
 // Give pino async streams a moment to flush the fatal log entry to daemon.log
 // before the process exits. Without this, the last few entries that explain
 // why the daemon crashed can be lost.
-function exitAfterPinoFlush(): void {
-  setTimeout(() => process.exit(1), 200);
+function exitAfterPinoFlush(code = 1): void {
+  setTimeout(() => process.exit(code), 200);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Problem

When a Paseo daemon worker can't bind its listen port because **a healthy daemon already owns it** — most commonly an orphaned daemon still serving `127.0.0.1:6767` — the worker throws on `listen`, the supervisor treats it as a crash, and (without #1258) respawns forever.

## Fix

On `EADDRINUSE`, the worker probes the occupant's unauthenticated `/api/health` endpoint. If a live Paseo daemon answers, the worker logs and **exits cleanly (code 0)** so the supervisor stops without restarting — the existing daemon keeps serving its agents. Any other listen failure (foreign process, unix socket) falls through to the original throw.

- `daemon-port-conflict.ts` — `isAddressInUseError` + `isHealthyPaseoDaemonAt` (probe `/api/health`, expects 200 + `{status:"ok"}`), unit-tested against real ephemeral HTTP servers.
- `daemon-worker.ts` — thin wiring in the start-`catch`; the yield runs before the SIGTERM handlers register, and the code-0 exit means the supervisor won't restart.

## Relationship to #1258

Complementary and independent (different files; branches off `main`):
- **#1258** (circuit breaker) bounds *any* crash loop — the safety net.
- **This** resolves the common port collision on the **first** attempt with zero wasted restarts — the cooperative path.

Together: a collision yields immediately; anything unexpected is still bounded.

Known limits (non-blocking): unix-socket listen targets aren't probed; an IPv6-literal listen host isn't bracketed in the probe URL (default is IPv4 `127.0.0.1`). Both fall through safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)