### PR TITLE
Add markdown source toggle

### DIFF
--- a/packages/app/src/app/h/[serverId]/workspace/[workspaceId]/index.tsx
+++ b/packages/app/src/app/h/[serverId]/workspace/[workspaceId]/index.tsx
@@ -7,7 +7,7 @@ import {
   type ActiveWorkspaceSelection,
   useActiveWorkspaceSelection,
 } from "@/stores/navigation-active-workspace-store";
-import type { WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
+import type { WorkspaceTabTargetInput } from "@/stores/workspace-tabs-store";
 import { WorkspaceScreen } from "@/screens/workspace/workspace-screen";
 import { useWorkspaceLayoutStoreHydrated } from "@/stores/workspace-layout-store";
 import {
@@ -29,7 +29,7 @@ function getParamValue(value: string | string[] | undefined): string {
   return "";
 }
 
-function getOpenIntentTarget(openIntent: WorkspaceOpenIntent): WorkspaceTabTarget {
+function getOpenIntentTarget(openIntent: WorkspaceOpenIntent): WorkspaceTabTargetInput {
   if (openIntent.kind === "agent") {
     return { kind: "agent", agentId: openIntent.agentId };
   }

--- a/packages/app/src/browser/new-tab-requests/index.test.ts
+++ b/packages/app/src/browser/new-tab-requests/index.test.ts
@@ -9,6 +9,7 @@ function createLayoutWithBrowser(browserId: string): WorkspaceLayout {
     layout: createDefaultLayout(),
     target: { kind: "browser", browserId },
     now: 1,
+    preserveExistingFileRenderMode: false,
   }).layout;
 }
 

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -41,7 +41,7 @@ import { persistAttachmentFromBytes } from "@/attachments/service";
 import { createPreviewAttachmentId, getFileNameFromPath } from "@/attachments/utils";
 import { explorerFileFromReadResult } from "@/file-explorer/read-result";
 import { resolveFilePreviewReadTarget } from "@/file-explorer/preview-target";
-import type { WorkspaceFileLocation } from "@/workspace/file-open";
+import type { WorkspaceFileTabTarget } from "@/workspace/file-open";
 
 interface CodeLineProps {
   tokens: HighlightToken[];
@@ -55,7 +55,7 @@ interface FilePreviewBodyProps {
   isLoading: boolean;
   showDesktopWebScrollbar: boolean;
   isMobile: boolean;
-  location: WorkspaceFileLocation;
+  location: WorkspaceFileTabTarget;
   imagePreviewUri: string | null;
 }
 
@@ -508,7 +508,10 @@ function FilePreviewBody({
   const markdownParser = useMemo(() => MarkdownIt({ typographer: true, linkify: true }), []);
   const markdownRules = useMemo(() => createFilePreviewMarkdownRules(), []);
   const isMarkdownFile =
-    preview?.kind === "text" && isRenderedMarkdownFile(filePath) && !location.lineStart;
+    preview?.kind === "text" &&
+    isRenderedMarkdownFile(filePath) &&
+    !location.lineStart &&
+    location.renderMode !== "source";
 
   const previewScrollRef = useRef<RNScrollView>(null);
   const webScrollbarStyle = useWebScrollbarStyle();
@@ -702,7 +705,7 @@ export function FilePane({
 }: {
   serverId: string;
   workspaceRoot: string;
-  location: WorkspaceFileLocation;
+  location: WorkspaceFileTabTarget;
 }) {
   const isMobile = useIsCompactFormFactor();
   const showDesktopWebScrollbar = isWeb && !isMobile;

--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -86,6 +86,7 @@ interface SplitContainerProps {
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onToggleMarkdownSource: (tab: WorkspaceTabDescriptor) => void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
   onCloseTabsToLeft: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
@@ -364,6 +365,7 @@ export function SplitContainer({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onToggleMarkdownSource,
   onRenameTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
@@ -580,6 +582,7 @@ export function SplitContainer({
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
           onReloadAgent={onReloadAgent}
+          onToggleMarkdownSource={onToggleMarkdownSource}
           onRenameTab={onRenameTab}
           onCloseTabsToLeft={onCloseTabsToLeft}
           onCloseTabsToRight={onCloseTabsToRight}
@@ -720,6 +723,7 @@ function SplitNodeView({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onToggleMarkdownSource,
   onRenameTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
@@ -772,6 +776,7 @@ function SplitNodeView({
         onCopyResumeCommand={onCopyResumeCommand}
         onCopyAgentId={onCopyAgentId}
         onReloadAgent={onReloadAgent}
+        onToggleMarkdownSource={onToggleMarkdownSource}
         onRenameTab={onRenameTab}
         onCloseTabsToLeft={onCloseTabsToLeft}
         onCloseTabsToRight={onCloseTabsToRight}
@@ -817,6 +822,7 @@ function SplitNodeView({
               onCopyResumeCommand={onCopyResumeCommand}
               onCopyAgentId={onCopyAgentId}
               onReloadAgent={onReloadAgent}
+              onToggleMarkdownSource={onToggleMarkdownSource}
               onRenameTab={onRenameTab}
               onCloseTabsToLeft={onCloseTabsToLeft}
               onCloseTabsToRight={onCloseTabsToRight}
@@ -868,6 +874,7 @@ function SplitPaneView({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onToggleMarkdownSource,
   onRenameTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
@@ -1009,6 +1016,7 @@ function SplitPaneView({
             onCopyResumeCommand={onCopyResumeCommand}
             onCopyAgentId={onCopyAgentId}
             onReloadAgent={onReloadAgent}
+            onToggleMarkdownSource={onToggleMarkdownSource}
             onRenameTab={onRenameTab}
             onCloseTabsToLeft={handleCloseTabsToLeft}
             onCloseTabsToRight={handleCloseTabsToRight}

--- a/packages/app/src/panels/file-panel.tsx
+++ b/packages/app/src/panels/file-panel.tsx
@@ -4,6 +4,7 @@ import invariant from "tiny-invariant";
 import { FilePane } from "@/components/file-pane";
 import { usePaneContext } from "@/panels/pane-context";
 import type { PanelRegistration } from "@/panels/panel-registry";
+import type { WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
 import { useWorkspaceExecutionAuthority } from "@/stores/session-store-hooks";
 
 const CENTERED_PADDED_STYLE = {
@@ -13,7 +14,9 @@ const CENTERED_PADDED_STYLE = {
   padding: 16,
 } as const;
 
-function useFilePanelDescriptor(target: { kind: "file"; path: string }) {
+type FilePanelTarget = Extract<WorkspaceTabTarget, { kind: "file" }>;
+
+function useFilePanelDescriptor(target: FilePanelTarget) {
   const fileName = target.path.split("/").findLast(Boolean) ?? target.path;
   return {
     label: fileName,

--- a/packages/app/src/screens/workspace/workspace-bulk-close.test.ts
+++ b/packages/app/src/screens/workspace/workspace-bulk-close.test.ts
@@ -29,7 +29,7 @@ function makeFileTab(path: string): WorkspaceTabDescriptor {
     key: `file_${path}`,
     tabId: `file_${path}`,
     kind: "file",
-    target: { kind: "file", path },
+    target: { kind: "file", path, renderMode: "preview" },
   };
 }
 
@@ -47,7 +47,7 @@ describe("workspace bulk close helpers", () => {
       otherTabs: [
         {
           tabId: "file_/repo/README.md",
-          target: { kind: "file", path: "/repo/README.md" },
+          target: { kind: "file", path: "/repo/README.md", renderMode: "preview" },
         },
       ],
     });
@@ -124,7 +124,10 @@ describe("workspace bulk close helpers", () => {
       { tabId: "agent_a1", target: { kind: "agent", agentId: "a1" } },
       { tabId: "terminal_t1", target: { kind: "terminal", terminalId: "t1" } },
       { tabId: "terminal_t2", target: { kind: "terminal", terminalId: "t2" } },
-      { tabId: "file_/repo/README.md", target: { kind: "file", path: "/repo/README.md" } },
+      {
+        tabId: "file_/repo/README.md",
+        target: { kind: "file", path: "/repo/README.md", renderMode: "preview" },
+      },
     ]);
   });
 
@@ -163,7 +166,10 @@ describe("workspace bulk close helpers", () => {
     expect(cleanupCalls).toEqual([
       { tabId: "agent_a1", target: { kind: "agent", agentId: "a1" } },
       { tabId: "terminal_t1", target: { kind: "terminal", terminalId: "t1" } },
-      { tabId: "file_/repo/README.md", target: { kind: "file", path: "/repo/README.md" } },
+      {
+        tabId: "file_/repo/README.md",
+        target: { kind: "file", path: "/repo/README.md", renderMode: "preview" },
+      },
     ]);
   });
 });

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -20,6 +20,7 @@ import {
   CopyX,
   ArrowLeftToLine,
   ArrowRightToLine,
+  Code2,
   Columns2,
   Copy,
   Pencil,
@@ -69,6 +70,7 @@ const LOADING_TAB_LABEL_SKELETON_WIDTH = 80;
 
 const ThemedActivityIndicator = withUnistyles(ActivityIndicator);
 const ThemedX = withUnistyles(X);
+const ThemedCode2 = withUnistyles(Code2);
 const ThemedCopy = withUnistyles(Copy);
 const ThemedRotateCw = withUnistyles(RotateCw);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
@@ -97,6 +99,8 @@ function TabContextMenuItem({
     switch (entry.icon) {
       case "copy":
         return <ThemedCopy size={16} uniProps={mutedColorMapping} />;
+      case "code":
+        return <ThemedCode2 size={16} uniProps={mutedColorMapping} />;
       case "rotate-cw":
         return <ThemedRotateCw size={16} uniProps={mutedColorMapping} />;
       case "arrow-left-to-line":
@@ -155,6 +159,7 @@ interface WorkspaceDesktopTabsRowProps {
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onToggleMarkdownSource: (tab: WorkspaceTabDescriptor) => void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
@@ -466,6 +471,7 @@ export function WorkspaceDesktopTabsRow({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onToggleMarkdownSource,
   onRenameTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
@@ -599,6 +605,7 @@ export function WorkspaceDesktopTabsRow({
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
           onReloadAgent={onReloadAgent}
+          onToggleMarkdownSource={onToggleMarkdownSource}
           onRenameTab={onRenameTab}
           onCloseTabsToLeft={onCloseTabsToLeft}
           onCloseTabsToRight={onCloseTabsToRight}
@@ -630,6 +637,7 @@ export function WorkspaceDesktopTabsRow({
       onCopyResumeCommand,
       onNavigateTab,
       onReloadAgent,
+      onToggleMarkdownSource,
       onRenameTab,
       setHoveredCloseTabKey,
       tabDropPreviewIndex,
@@ -792,6 +800,7 @@ function ResolvedDesktopTabChip({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onToggleMarkdownSource,
   onRenameTab,
   onCloseTabsToLeft,
   onCloseTabsToRight,
@@ -816,6 +825,7 @@ function ResolvedDesktopTabChip({
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onToggleMarkdownSource: (tab: WorkspaceTabDescriptor) => void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
@@ -839,6 +849,7 @@ function ResolvedDesktopTabChip({
         onCopyResumeCommand,
         onCopyAgentId,
         onReloadAgent,
+        onToggleMarkdownSource,
         onRenameTab,
         onCloseTab,
         onCloseTabsToLeft,
@@ -855,6 +866,7 @@ function ResolvedDesktopTabChip({
       onCopyAgentId,
       onCopyResumeCommand,
       onReloadAgent,
+      onToggleMarkdownSource,
       onRenameTab,
       tabCount,
     ],

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -23,6 +23,7 @@ import {
   Code2,
   Columns2,
   Copy,
+  Eye,
   Pencil,
   RotateCw,
   Rows2,
@@ -71,6 +72,7 @@ const LOADING_TAB_LABEL_SKELETON_WIDTH = 80;
 const ThemedActivityIndicator = withUnistyles(ActivityIndicator);
 const ThemedX = withUnistyles(X);
 const ThemedCode2 = withUnistyles(Code2);
+const ThemedEye = withUnistyles(Eye);
 const ThemedCopy = withUnistyles(Copy);
 const ThemedRotateCw = withUnistyles(RotateCw);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
@@ -101,6 +103,8 @@ function TabContextMenuItem({
         return <ThemedCopy size={16} uniProps={mutedColorMapping} />;
       case "code":
         return <ThemedCode2 size={16} uniProps={mutedColorMapping} />;
+      case "eye":
+        return <ThemedEye size={16} uniProps={mutedColorMapping} />;
       case "rotate-cw":
         return <ThemedRotateCw size={16} uniProps={mutedColorMapping} />;
       case "arrow-left-to-line":

--- a/packages/app/src/screens/workspace/workspace-pane-state.test.ts
+++ b/packages/app/src/screens/workspace/workspace-pane-state.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@/screens/workspace/workspace-pane-state";
 import type { WorkspaceLayout } from "@/stores/workspace-layout-store";
 import type { WorkspaceTab } from "@/stores/workspace-tabs-store";
+import { createWorkspaceFileTabTarget } from "@/workspace/file-open";
 
 function createTab(tabId: string, target: WorkspaceTab["target"]): WorkspaceTab {
   return {
@@ -15,11 +16,15 @@ function createTab(tabId: string, target: WorkspaceTab["target"]): WorkspaceTab 
   };
 }
 
+function fileTarget(path: string) {
+  return createWorkspaceFileTabTarget({ path });
+}
+
 describe("workspace-pane-state", () => {
   it("selects the focused pane and keeps its tab order", () => {
     const tabs: WorkspaceTab[] = [
       createTab("agent_agent-a", { kind: "agent", agentId: "agent-a" }),
-      createTab("file_/repo/README.md", { kind: "file", path: "/repo/README.md" }),
+      createTab("file_/repo/README.md", fileTarget("/repo/README.md")),
       createTab("terminal_term-1", { kind: "terminal", terminalId: "term-1" }),
     ];
     const layout: WorkspaceLayout = {
@@ -90,7 +95,7 @@ describe("workspace-pane-state", () => {
     };
     const tabs: WorkspaceTab[] = [
       createTab("agent_agent-a", { kind: "agent", agentId: "agent-a" }),
-      createTab("file_/repo/README.md", { kind: "file", path: "/repo/README.md" }),
+      createTab("file_/repo/README.md", fileTarget("/repo/README.md")),
     ];
 
     const state = deriveWorkspacePaneState({
@@ -103,6 +108,7 @@ describe("workspace-pane-state", () => {
     expect(state.activeTab?.descriptor.target).toEqual({
       kind: "file",
       path: "/repo/README.md",
+      renderMode: "preview",
     });
   });
 
@@ -118,7 +124,7 @@ describe("workspace-pane-state", () => {
       },
       focusedPaneId: "main",
     };
-    const tabs = [createTab("file_/repo/README.md", { kind: "file", path: "/repo/README.md" })];
+    const tabs = [createTab("file_/repo/README.md", fileTarget("/repo/README.md"))];
 
     expect(
       resolveSideFileOpenPlacement({
@@ -142,7 +148,7 @@ describe("workspace-pane-state", () => {
       },
       focusedPaneId: "main",
     };
-    const tabs = [createTab("file_/repo/README.md", { kind: "file", path: "/repo/README.md" })];
+    const tabs = [createTab("file_/repo/README.md", fileTarget("/repo/README.md"))];
 
     expect(
       resolveSideFileOpenPlacement({

--- a/packages/app/src/screens/workspace/workspace-pane-state.ts
+++ b/packages/app/src/screens/workspace/workspace-pane-state.ts
@@ -3,7 +3,7 @@ import {
   type SplitPane,
   type WorkspaceLayout,
 } from "@/stores/workspace-layout-store";
-import type { WorkspaceTab, WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
+import type { WorkspaceTab, WorkspaceTabTargetInput } from "@/stores/workspace-tabs-store";
 import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
 import {
   buildDeterministicWorkspaceTabId,
@@ -112,7 +112,7 @@ function getActiveTabId(input: {
   tabs: WorkspaceDerivedTab[];
   openTabIds: Set<string>;
   focusedTabId?: string | null;
-  preferredTarget?: WorkspaceTabTarget | null;
+  preferredTarget?: WorkspaceTabTargetInput | null;
 }): string | null {
   const focusedTabId = trimNonEmpty(input.focusedTabId);
   const preferredTarget = normalizeWorkspaceTabTarget(input.preferredTarget ?? null);
@@ -163,7 +163,7 @@ export function deriveWorkspacePaneState(input: {
   paneId?: string | null;
   tabs: WorkspaceTab[];
   focusedTabId?: string | null;
-  preferredTarget?: WorkspaceTabTarget | null;
+  preferredTarget?: WorkspaceTabTargetInput | null;
 }): WorkspacePaneState {
   const pane = getPane({
     layout: input.layout ?? null,
@@ -207,11 +207,15 @@ export function resolveSideFileOpenPlacement(input: {
   layout?: WorkspaceLayout | null;
   sourcePaneId?: string | null;
   tabs: WorkspaceTab[];
-  target: WorkspaceTabTarget;
+  target: WorkspaceTabTargetInput;
 }): WorkspaceSideFileOpenPlacement {
-  const targetTabId = buildDeterministicWorkspaceTabId(input.target);
+  const target = normalizeWorkspaceTabTarget(input.target);
+  if (!target) {
+    return { kind: "split-side-pane", paneId: trimNonEmpty(input.sourcePaneId) ?? "" };
+  }
+  const targetTabId = buildDeterministicWorkspaceTabId(target);
   const existingTab = input.tabs.find(
-    (tab) => tab.tabId === targetTabId || workspaceTabTargetsEqual(tab.target, input.target),
+    (tab) => tab.tabId === targetTabId || workspaceTabTargetsEqual(tab.target, target),
   );
   if (existingTab) {
     return { kind: "open-in-source" };

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -24,6 +24,7 @@ import {
   Copy,
   Ellipsis,
   EllipsisVertical,
+  Eye,
   Globe,
   Import as ImportIcon,
   PanelRight,
@@ -225,6 +226,7 @@ const ThemedEllipsis = withUnistyles(Ellipsis);
 const ThemedEllipsisVertical = withUnistyles(EllipsisVertical);
 const ThemedChevronDown = withUnistyles(ChevronDown);
 const ThemedCode2 = withUnistyles(Code2);
+const ThemedEye = withUnistyles(Eye);
 const ThemedCopy = withUnistyles(Copy);
 const ThemedRotateCw = withUnistyles(RotateCw);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
@@ -482,6 +484,8 @@ function MobileTabDropdownMenuItem({
         return <ThemedCopy size={16} uniProps={mutedColorMapping} />;
       case "code":
         return <ThemedCode2 size={16} uniProps={mutedColorMapping} />;
+      case "eye":
+        return <ThemedEye size={16} uniProps={mutedColorMapping} />;
       case "rotate-cw":
         return <ThemedRotateCw size={16} uniProps={mutedColorMapping} />;
       case "arrow-left-to-line":

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -20,6 +20,7 @@ import {
   ArrowLeftToLine,
   ArrowRightToLine,
   ChevronDown,
+  Code2,
   Copy,
   Ellipsis,
   EllipsisVertical,
@@ -223,6 +224,7 @@ const ThemedActivityIndicator = withUnistyles(ActivityIndicator);
 const ThemedEllipsis = withUnistyles(Ellipsis);
 const ThemedEllipsisVertical = withUnistyles(EllipsisVertical);
 const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedCode2 = withUnistyles(Code2);
 const ThemedCopy = withUnistyles(Copy);
 const ThemedRotateCw = withUnistyles(RotateCw);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
@@ -345,6 +347,7 @@ interface MobileWorkspaceTabSwitcherProps {
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onToggleMarkdownSource: (tab: WorkspaceTabDescriptor) => void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsAbove: (tabId: string) => Promise<void> | void;
@@ -477,6 +480,8 @@ function MobileTabDropdownMenuItem({
     switch (entry.icon) {
       case "copy":
         return <ThemedCopy size={16} uniProps={mutedColorMapping} />;
+      case "code":
+        return <ThemedCode2 size={16} uniProps={mutedColorMapping} />;
       case "rotate-cw":
         return <ThemedRotateCw size={16} uniProps={mutedColorMapping} />;
       case "arrow-left-to-line":
@@ -524,6 +529,7 @@ function MobileWorkspaceTabOption({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onToggleMarkdownSource,
   onRenameTab,
   onCloseTab,
   onCloseTabsAbove,
@@ -541,6 +547,7 @@ function MobileWorkspaceTabOption({
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onToggleMarkdownSource: (tab: WorkspaceTabDescriptor) => void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsAbove: (tabId: string) => Promise<void> | void;
@@ -557,6 +564,7 @@ function MobileWorkspaceTabOption({
     onCopyResumeCommand,
     onCopyAgentId,
     onReloadAgent,
+    onToggleMarkdownSource,
     onRenameTab,
     onCloseTab,
     onCloseTabsBefore: onCloseTabsAbove,
@@ -612,6 +620,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
   onCopyResumeCommand,
   onCopyAgentId,
   onReloadAgent,
+  onToggleMarkdownSource,
   onRenameTab,
   onCloseTab,
   onCloseTabsAbove,
@@ -666,6 +675,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
           onReloadAgent={onReloadAgent}
+          onToggleMarkdownSource={onToggleMarkdownSource}
           onRenameTab={onRenameTab}
           onCloseTab={onCloseTab}
           onCloseTabsAbove={onCloseTabsAbove}
@@ -683,6 +693,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
       onCopyResumeCommand,
       onCopyAgentId,
       onReloadAgent,
+      onToggleMarkdownSource,
       onRenameTab,
       onCloseTab,
       onCloseTabsAbove,
@@ -2552,6 +2563,20 @@ function WorkspaceScreenContent({
     [client, isConnected, normalizedServerId, toast],
   );
 
+  const handleToggleMarkdownSource = useCallback(
+    (tab: WorkspaceTabDescriptor) => {
+      if (!persistenceKey || tab.target.kind !== "file") {
+        return;
+      }
+      const nextRenderMode = tab.target.renderMode === "source" ? "preview" : "source";
+      retargetWorkspaceTab(persistenceKey, tab.tabId, {
+        ...tab.target,
+        renderMode: nextRenderMode,
+      });
+    },
+    [persistenceKey, retargetWorkspaceTab],
+  );
+
   const handleCopyWorkspacePath = useCallback(async () => {
     if (!workspaceDirectory) {
       toast.error("Workspace path not available");
@@ -3296,6 +3321,7 @@ function WorkspaceScreenContent({
         onCopyResumeCommand={handleCopyResumeCommand}
         onCopyAgentId={handleCopyAgentId}
         onReloadAgent={handleReloadAgent}
+        onToggleMarkdownSource={handleToggleMarkdownSource}
         onRenameTab={handleRenameTab}
         onCloseTabsToLeft={handleCloseTabsToLeftInPane}
         onCloseTabsToRight={handleCloseTabsToRightInPane}
@@ -3330,6 +3356,7 @@ function WorkspaceScreenContent({
     handleCopyResumeCommand,
     handleCopyAgentId,
     handleReloadAgent,
+    handleToggleMarkdownSource,
     handleRenameTab,
     handleCloseTabsToLeftInPane,
     handleCloseTabsToRightInPane,
@@ -3409,6 +3436,7 @@ function WorkspaceScreenContent({
           onCopyResumeCommand={handleCopyResumeCommand}
           onCopyAgentId={handleCopyAgentId}
           onReloadAgent={handleReloadAgent}
+          onToggleMarkdownSource={handleToggleMarkdownSource}
           onRenameTab={handleRenameTab}
           onCloseTab={handleCloseTabById}
           onCloseTabsAbove={handleCloseTabsToLeft}
@@ -3430,6 +3458,7 @@ function WorkspaceScreenContent({
           onCopyResumeCommand={handleCopyResumeCommand}
           onCopyAgentId={handleCopyAgentId}
           onReloadAgent={handleReloadAgent}
+          onToggleMarkdownSource={handleToggleMarkdownSource}
           onRenameTab={handleRenameTab}
           onCloseTabsToLeft={handleCloseTabsToLeft}
           onCloseTabsToRight={handleCloseTabsToRight}

--- a/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
@@ -11,6 +11,21 @@ function createAgentTab(): WorkspaceTabDescriptor {
   };
 }
 
+function createMarkdownFileTab(
+  renderMode: "preview" | "source" = "preview",
+): WorkspaceTabDescriptor {
+  return {
+    key: "file_README.md",
+    tabId: "file_README.md",
+    kind: "file",
+    target: {
+      kind: "file",
+      path: "README.md",
+      renderMode,
+    },
+  };
+}
+
 describe("buildWorkspaceTabMenuEntries", () => {
   it("uses desktop tab ordering labels for desktop menus", () => {
     const onCopyResumeCommand = vi.fn();
@@ -77,6 +92,87 @@ describe("buildWorkspaceTabMenuEntries", () => {
       "Reload agent",
       "Close",
     ]);
+  });
+
+  it("adds source toggle for markdown file tabs", () => {
+    const onToggleMarkdownSource = vi.fn();
+    const tab = createMarkdownFileTab();
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab,
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: "workspace-tab-context-file_README.md",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onToggleMarkdownSource,
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    const toggleEntry = entries.find(
+      (entry) => entry.kind === "item" && entry.key === "toggle-markdown-source",
+    );
+    if (!toggleEntry || toggleEntry.kind !== "item") {
+      throw new Error("Markdown source toggle missing");
+    }
+
+    expect(toggleEntry.label).toBe("Show source");
+    expect(toggleEntry.testID).toBe("workspace-tab-context-file_README.md-show-source");
+
+    toggleEntry.onSelect();
+    expect(onToggleMarkdownSource).toHaveBeenCalledWith(tab);
+  });
+
+  it("uses preview copy when a markdown file tab is in source mode", () => {
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab: createMarkdownFileTab("source"),
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: "workspace-tab-context-file_README.md",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    expect(
+      entries.find((entry) => entry.kind === "item" && entry.key === "toggle-markdown-source"),
+    ).toEqual(expect.objectContaining({ label: "Show preview" }));
+  });
+
+  it("does not add source toggle for line-targeted markdown file tabs", () => {
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab: {
+        ...createMarkdownFileTab(),
+        target: { kind: "file", path: "README.md", lineStart: 12, renderMode: "preview" },
+      },
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: "workspace-tab-context-file_README.md",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    expect(
+      entries.some((entry) => entry.kind === "item" && entry.key === "toggle-markdown-source"),
+    ).toBe(false);
   });
 
   it("omits agent copy actions and rename for draft tabs", () => {

--- a/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
@@ -122,6 +122,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
     }
 
     expect(toggleEntry.label).toBe("Show source");
+    expect(toggleEntry.icon).toBe("code");
     expect(toggleEntry.testID).toBe("workspace-tab-context-file_README.md-show-source");
 
     toggleEntry.onSelect();
@@ -147,7 +148,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
 
     expect(
       entries.find((entry) => entry.kind === "item" && entry.key === "toggle-markdown-source"),
-    ).toEqual(expect.objectContaining({ label: "Show preview" }));
+    ).toEqual(expect.objectContaining({ label: "Show preview", icon: "eye" }));
   });
 
   it("does not add source toggle for line-targeted markdown file tabs", () => {

--- a/packages/app/src/screens/workspace/workspace-tab-menu.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.ts
@@ -13,6 +13,7 @@ export type WorkspaceTabMenuEntry =
       icon?:
         | "copy"
         | "code"
+        | "eye"
         | "rotate-cw"
         | "arrow-left-to-line"
         | "arrow-right-to-line"
@@ -180,7 +181,7 @@ export function buildWorkspaceTabMenuEntries(
       kind: "item",
       key: "toggle-markdown-source",
       label: isSourceMode ? "Show preview" : "Show source",
-      icon: "code",
+      icon: isSourceMode ? "eye" : "code",
       testID: `${menuTestIDBase}-${isSourceMode ? "show-preview" : "show-source"}`,
       onSelect: () => {
         onToggleMarkdownSource?.(tab);

--- a/packages/app/src/screens/workspace/workspace-tab-menu.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
+import { isRenderedMarkdownFile } from "@/components/file-pane-render-mode";
 import { encodeFilePathForPathSegment } from "@/utils/host-routes";
 import { buildDeterministicWorkspaceTabId } from "@/workspace-tabs/identity";
 
@@ -11,6 +12,7 @@ export type WorkspaceTabMenuEntry =
       label: string;
       icon?:
         | "copy"
+        | "code"
         | "rotate-cw"
         | "arrow-left-to-line"
         | "arrow-right-to-line"
@@ -38,6 +40,7 @@ interface BuildWorkspaceTabMenuEntriesInput {
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onToggleMarkdownSource?: (tab: WorkspaceTabDescriptor) => void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsBefore: (tabId: string) => Promise<void> | void;
@@ -52,6 +55,7 @@ interface BuildWorkspaceDesktopTabActionsInput {
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
+  onToggleMarkdownSource?: (tab: WorkspaceTabDescriptor) => void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
@@ -112,6 +116,7 @@ export function buildWorkspaceTabMenuEntries(
     onCopyResumeCommand,
     onCopyAgentId,
     onReloadAgent,
+    onToggleMarkdownSource,
     onRenameTab,
     onCloseTab,
     onCloseTabsBefore,
@@ -162,6 +167,28 @@ export function buildWorkspaceTabMenuEntries(
     entries.push({
       kind: "separator",
       key: "rename-separator",
+    });
+  }
+
+  if (
+    tab.target.kind === "file" &&
+    isRenderedMarkdownFile(tab.target.path) &&
+    !tab.target.lineStart
+  ) {
+    const isSourceMode = tab.target.renderMode === "source";
+    entries.push({
+      kind: "item",
+      key: "toggle-markdown-source",
+      label: isSourceMode ? "Show preview" : "Show source",
+      icon: "code",
+      testID: `${menuTestIDBase}-${isSourceMode ? "show-preview" : "show-source"}`,
+      onSelect: () => {
+        onToggleMarkdownSource?.(tab);
+      },
+    });
+    entries.push({
+      kind: "separator",
+      key: "toggle-markdown-source-separator",
     });
   }
 
@@ -241,6 +268,7 @@ export function buildWorkspaceDesktopTabActions(
       onCopyResumeCommand: input.onCopyResumeCommand,
       onCopyAgentId: input.onCopyAgentId,
       onReloadAgent: input.onReloadAgent,
+      onToggleMarkdownSource: input.onToggleMarkdownSource,
       onRenameTab: input.onRenameTab,
       onCloseTab: input.onCloseTab,
       onCloseTabsBefore: input.onCloseTabsToLeft,

--- a/packages/app/src/screens/workspace/workspace-tab-model.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { deriveWorkspaceTabModel } from "@/screens/workspace/workspace-tab-model";
 import type { WorkspaceTab } from "@/stores/workspace-tabs-store";
+import { createWorkspaceFileTabTarget } from "@/workspace/file-open";
 
 describe("deriveWorkspaceTabModel", () => {
   it("keeps normalized tabs in stored order and preserves targets", () => {
@@ -12,7 +13,7 @@ describe("deriveWorkspaceTabModel", () => {
       },
       {
         tabId: "file_/repo/worktree/README.md",
-        target: { kind: "file", path: "/repo/worktree/README.md" },
+        target: createWorkspaceFileTabTarget({ path: "/repo/worktree/README.md" }),
         createdAt: 2,
       },
       {
@@ -36,6 +37,7 @@ describe("deriveWorkspaceTabModel", () => {
     expect(model.tabs[2]?.descriptor.target).toEqual({
       kind: "file",
       path: "/repo/worktree/README.md",
+      renderMode: "preview",
     });
   });
 
@@ -96,7 +98,7 @@ describe("deriveWorkspaceTabModel", () => {
       tabs: [
         {
           tabId: "file_/repo/worktree/README.md",
-          target: { kind: "file", path: "/repo/worktree/README.md" },
+          target: createWorkspaceFileTabTarget({ path: "/repo/worktree/README.md" }),
           createdAt: 1,
         },
         {
@@ -113,6 +115,7 @@ describe("deriveWorkspaceTabModel", () => {
     expect(model.activeTab?.descriptor.target).toEqual({
       kind: "file",
       path: "/repo/worktree/README.md",
+      renderMode: "preview",
     });
   });
 
@@ -138,7 +141,7 @@ describe("deriveWorkspaceTabModel", () => {
       tabs: [
         {
           tabId: "file_path",
-          target: { kind: "file", path: "\\repo\\worktree\\README.md" },
+          target: createWorkspaceFileTabTarget({ path: "\\repo\\worktree\\README.md" }),
           createdAt: 1,
         },
         {
@@ -153,6 +156,7 @@ describe("deriveWorkspaceTabModel", () => {
     expect(model.tabs[0]?.descriptor.target).toEqual({
       kind: "file",
       path: "/repo/worktree/README.md",
+      renderMode: "preview",
     });
   });
 });

--- a/packages/app/src/screens/workspace/workspace-tab-model.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-model.ts
@@ -1,4 +1,8 @@
-import type { WorkspaceTab, WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
+import type {
+  WorkspaceTab,
+  WorkspaceTabTarget,
+  WorkspaceTabTargetInput,
+} from "@/stores/workspace-tabs-store";
 import {
   deriveWorkspacePaneState,
   type WorkspaceDerivedTab,
@@ -18,7 +22,7 @@ export function buildWorkspaceTabId(target: WorkspaceTabTarget): string {
 export function deriveWorkspaceTabModel(input: {
   tabs: WorkspaceTab[];
   focusedTabId?: string | null;
-  preferredTarget?: WorkspaceTabTarget | null;
+  preferredTarget?: WorkspaceTabTargetInput | null;
 }): WorkspaceTabModel {
   const paneState = deriveWorkspacePaneState({
     tabs: input.tabs,

--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -8,6 +8,7 @@ import {
   normalizeWorkspaceTabTarget,
   workspaceTabTargetsEqual,
 } from "@/workspace-tabs/identity";
+import { workspaceFileLocationsEqual } from "@/workspace/file-open";
 
 export interface SplitPane {
   id: string;
@@ -102,6 +103,7 @@ interface OpenTabInLayoutInput {
   layout: WorkspaceLayout;
   target: WorkspaceTabTarget;
   now: number;
+  preserveExistingFileRenderMode: boolean;
 }
 
 interface OpenTabInLayoutResult {
@@ -1072,8 +1074,17 @@ function updateExistingTabTarget(
   layout: WorkspaceLayout,
   tab: WorkspaceTab,
   target: WorkspaceTabTarget,
+  preserveExistingFileRenderMode: boolean,
 ): WorkspaceLayout {
   if (workspaceTabTargetsEqual(tab.target, target)) {
+    return layout;
+  }
+  if (
+    preserveExistingFileRenderMode &&
+    tab.target.kind === "file" &&
+    target.kind === "file" &&
+    workspaceFileLocationsEqual(tab.target, target)
+  ) {
     return layout;
   }
   return withNormalizedParentTabMap({
@@ -1090,7 +1101,12 @@ export function openTabInLayoutFocused(input: OpenTabInLayoutInput): OpenTabInLa
   const layout = asInternalLayout(input.layout);
   const existingTab = findExistingTabForTarget(layout.root, input.target);
   if (existingTab) {
-    const nextLayout = updateExistingTabTarget(input.layout, existingTab, input.target);
+    const nextLayout = updateExistingTabTarget(
+      input.layout,
+      existingTab,
+      input.target,
+      input.preserveExistingFileRenderMode,
+    );
     return {
       tabId: existingTab.tabId,
       layout:
@@ -1110,7 +1126,12 @@ export function openTabInLayoutBackground(input: OpenTabInLayoutInput): OpenTabI
   if (existingTab) {
     return {
       tabId: existingTab.tabId,
-      layout: updateExistingTabTarget(input.layout, existingTab, input.target),
+      layout: updateExistingTabTarget(
+        input.layout,
+        existingTab,
+        input.target,
+        input.preserveExistingFileRenderMode,
+      ),
     };
   }
 

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -380,6 +380,7 @@ describe("workspace-layout-store actions", () => {
           path: "/repo/worktree/a.ts",
           lineStart: 10,
           lineEnd: 12,
+          renderMode: "preview",
         },
         createdAt: expect.any(Number),
       },
@@ -700,7 +701,7 @@ describe("workspace-layout-store actions", () => {
     expect(collectAllTabs(layout.root)).toEqual([
       {
         tabId: draftTabId!,
-        target: { kind: "file", path: "/repo/worktree/retargeted.ts" },
+        target: { kind: "file", path: "/repo/worktree/retargeted.ts", renderMode: "preview" },
         createdAt: expect.any(Number),
       },
     ]);
@@ -832,17 +833,17 @@ describe("workspace-layout-store actions", () => {
       tabs: [
         {
           tabId: thirdTabId,
-          target: { kind: "file", path: "/repo/worktree/c.ts" },
+          target: { kind: "file", path: "/repo/worktree/c.ts", renderMode: "preview" },
           createdAt: expect.any(Number),
         },
         {
           tabId: firstTabId,
-          target: { kind: "file", path: "/repo/worktree/a.ts" },
+          target: { kind: "file", path: "/repo/worktree/a.ts", renderMode: "preview" },
           createdAt: expect.any(Number),
         },
         {
           tabId: secondTabId,
-          target: { kind: "file", path: "/repo/worktree/b.ts" },
+          target: { kind: "file", path: "/repo/worktree/b.ts", renderMode: "preview" },
           createdAt: expect.any(Number),
         },
       ],
@@ -887,12 +888,12 @@ describe("workspace-layout-store actions", () => {
       tabs: [
         {
           tabId: fourthTabId,
-          target: { kind: "file", path: "/repo/worktree/d.ts" },
+          target: { kind: "file", path: "/repo/worktree/d.ts", renderMode: "preview" },
           createdAt: expect.any(Number),
         },
         {
           tabId: thirdTabId,
-          target: { kind: "file", path: "/repo/worktree/c.ts" },
+          target: { kind: "file", path: "/repo/worktree/c.ts", renderMode: "preview" },
           createdAt: expect.any(Number),
         },
       ],

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -387,6 +387,66 @@ describe("workspace-layout-store actions", () => {
     ]);
   });
 
+  it("preserves source mode when opening the same file without a render mode", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    const firstTabId = store.openTabFocused(workspaceKey, {
+      kind: "file",
+      path: "/repo/worktree/README.md",
+      renderMode: "source",
+    });
+    const secondTabId = store.openTabFocused(workspaceKey, {
+      kind: "file",
+      path: "/repo/worktree/README.md",
+    });
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+
+    expect(firstTabId).toBe("file_/repo/worktree/README.md");
+    expect(secondTabId).toBe(firstTabId);
+    expect(collectAllTabs(layout.root)).toEqual([
+      {
+        tabId: "file_/repo/worktree/README.md",
+        target: {
+          kind: "file",
+          path: "/repo/worktree/README.md",
+          renderMode: "source",
+        },
+        createdAt: expect.any(Number),
+      },
+    ]);
+  });
+
+  it("honors an explicit source render mode for an existing preview file tab", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    const firstTabId = store.openTabFocused(workspaceKey, {
+      kind: "file",
+      path: "/repo/worktree/README.md",
+    });
+    const secondTabId = store.openTabFocused(workspaceKey, {
+      kind: "file",
+      path: "/repo/worktree/README.md",
+      renderMode: "source",
+    });
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+
+    expect(firstTabId).toBe("file_/repo/worktree/README.md");
+    expect(secondTabId).toBe(firstTabId);
+    expect(collectAllTabs(layout.root)).toEqual([
+      {
+        tabId: "file_/repo/worktree/README.md",
+        target: {
+          kind: "file",
+          path: "/repo/worktree/README.md",
+          renderMode: "source",
+        },
+        createdAt: expect.any(Number),
+      },
+    ]);
+  });
+
   it("openTabInBackground inserts a tab without stealing focus", () => {
     const workspaceKey = createWorkspaceKey();
     const store = workspaceLayoutStore.getState();

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -5,7 +5,7 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import {
   buildWorkspaceTabPersistenceKey,
   type WorkspaceTab,
-  type WorkspaceTabTarget,
+  type WorkspaceTabTargetInput,
 } from "@/stores/workspace-tabs-store";
 import {
   defaultWorkspaceLayoutIds,
@@ -75,16 +75,20 @@ interface WorkspaceLayoutStore {
   pinnedAgentIdsByWorkspace: Record<string, Set<string>>;
   hiddenAgentIdsByWorkspace: Record<string, Set<string>>;
   focusRestorationByWorkspace: Record<string, WorkspaceFocusRestorationState>;
-  openTabFocused: (workspaceKey: string, target: WorkspaceTabTarget) => string | null;
+  openTabFocused: (workspaceKey: string, target: WorkspaceTabTargetInput) => string | null;
   openChildTabFocused: (
     workspaceKey: string,
-    target: WorkspaceTabTarget,
+    target: WorkspaceTabTargetInput,
     parentTabId: string,
   ) => string | null;
-  openTabInBackground: (workspaceKey: string, target: WorkspaceTabTarget) => string | null;
+  openTabInBackground: (workspaceKey: string, target: WorkspaceTabTargetInput) => string | null;
   closeTab: (workspaceKey: string, tabId: string) => void;
   focusTab: (workspaceKey: string, tabId: string) => void;
-  retargetTab: (workspaceKey: string, tabId: string, target: WorkspaceTabTarget) => string | null;
+  retargetTab: (
+    workspaceKey: string,
+    tabId: string,
+    target: WorkspaceTabTargetInput,
+  ) => string | null;
   convertDraftToAgent: (workspaceKey: string, tabId: string, agentId: string) => string | null;
   reconcileTabs: (workspaceKey: string, snapshot: WorkspaceTabSnapshot) => void;
   reorderTabs: (workspaceKey: string, tabIds: string[]) => void;

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -222,6 +222,10 @@ function attachParentTab(input: {
   });
 }
 
+function shouldPreserveExistingFileRenderMode(target: WorkspaceTabTargetInput): boolean {
+  return target.kind === "file" && target.renderMode == null;
+}
+
 export function createWorkspaceLayoutStore(
   ids: WorkspaceLayoutIdSource = defaultWorkspaceLayoutIds,
 ) {
@@ -244,6 +248,7 @@ export function createWorkspaceLayoutStore(
             layout: getWorkspaceLayout(get().layoutByWorkspace, normalizedWorkspaceKey),
             target: normalizedTarget,
             now: Date.now(),
+            preserveExistingFileRenderMode: shouldPreserveExistingFileRenderMode(target),
           });
 
           set((state) => ({
@@ -276,6 +281,7 @@ export function createWorkspaceLayoutStore(
             layout: getWorkspaceLayout(get().layoutByWorkspace, normalizedWorkspaceKey),
             target: normalizedTarget,
             now: Date.now(),
+            preserveExistingFileRenderMode: shouldPreserveExistingFileRenderMode(target),
           });
 
           set((state) => {
@@ -314,6 +320,7 @@ export function createWorkspaceLayoutStore(
             layout: getWorkspaceLayout(get().layoutByWorkspace, normalizedWorkspaceKey),
             target: normalizedTarget,
             now: Date.now(),
+            preserveExistingFileRenderMode: shouldPreserveExistingFileRenderMode(target),
           });
 
           set((state) => ({

--- a/packages/app/src/stores/workspace-tabs-store/index.ts
+++ b/packages/app/src/stores/workspace-tabs-store/index.ts
@@ -17,10 +17,16 @@ import {
   type WorkspaceTab,
   type WorkspaceTabsCoreState,
   type WorkspaceTabTarget,
+  type WorkspaceTabTargetInput,
 } from "./state";
 
 export { buildWorkspaceTabPersistenceKey } from "./state";
-export type { WorkspaceDraftTabSetup, WorkspaceTab, WorkspaceTabTarget } from "./state";
+export type {
+  WorkspaceDraftTabSetup,
+  WorkspaceTab,
+  WorkspaceTabTarget,
+  WorkspaceTabTargetInput,
+} from "./state";
 
 interface WorkspaceTabsState extends WorkspaceTabsCoreState {
   openDraftTab: (input: {
@@ -31,12 +37,12 @@ interface WorkspaceTabsState extends WorkspaceTabsCoreState {
   ensureTab: (input: {
     serverId: string;
     workspaceId: string;
-    target: WorkspaceTabTarget;
+    target: WorkspaceTabTargetInput;
   }) => string | null;
   openOrFocusTab: (input: {
     serverId: string;
     workspaceId: string;
-    target: WorkspaceTabTarget;
+    target: WorkspaceTabTargetInput;
   }) => string | null;
   focusTab: (input: { serverId: string; workspaceId: string; tabId: string }) => void;
   closeTab: (input: { serverId: string; workspaceId: string; tabId: string }) => void;
@@ -44,7 +50,7 @@ interface WorkspaceTabsState extends WorkspaceTabsCoreState {
     serverId: string;
     workspaceId: string;
     tabId: string;
-    target: WorkspaceTabTarget;
+    target: WorkspaceTabTargetInput;
   }) => string | null;
   reorderTabs: (input: { serverId: string; workspaceId: string; tabIds: string[] }) => void;
   getWorkspaceTabs: (input: { serverId: string; workspaceId: string }) => WorkspaceTab[];

--- a/packages/app/src/stores/workspace-tabs-store/state.test.ts
+++ b/packages/app/src/stores/workspace-tabs-store/state.test.ts
@@ -322,6 +322,77 @@ describe("workspace-tabs-store reducers", () => {
     expect(reopened.state.focusedTabIdByWorkspace[WORKSPACE_KEY]).toBe(fileResult.tabId);
   });
 
+  it("openOrFocusTab preserves source mode when reopening the same file without a render mode", () => {
+    let state = emptyState();
+    const fileResult = applyOpenOrFocusTab(state, {
+      serverId: SERVER_ID,
+      workspaceId: WORKSPACE_ID,
+      target: {
+        kind: "file",
+        path: "/repo/worktree/README.md",
+        renderMode: "source",
+      },
+      now: NOW,
+    });
+    state = fileResult.state;
+
+    const reopened = applyOpenOrFocusTab(state, {
+      serverId: SERVER_ID,
+      workspaceId: WORKSPACE_ID,
+      target: { kind: "file", path: "/repo/worktree/README.md" },
+      now: NOW,
+    });
+
+    expect(reopened.tabId).toBe(fileResult.tabId);
+    expect(reopened.state.uiTabsByWorkspace[WORKSPACE_KEY]).toEqual([
+      {
+        tabId: "file_/repo/worktree/README.md",
+        target: {
+          kind: "file",
+          path: "/repo/worktree/README.md",
+          renderMode: "source",
+        },
+        createdAt: NOW,
+      },
+    ]);
+    expect(reopened.state.focusedTabIdByWorkspace[WORKSPACE_KEY]).toBe(fileResult.tabId);
+  });
+
+  it("openOrFocusTab honors an explicit source render mode for an existing preview file tab", () => {
+    let state = emptyState();
+    const fileResult = applyOpenOrFocusTab(state, {
+      serverId: SERVER_ID,
+      workspaceId: WORKSPACE_ID,
+      target: { kind: "file", path: "/repo/worktree/README.md" },
+      now: NOW,
+    });
+    state = fileResult.state;
+
+    const reopened = applyOpenOrFocusTab(state, {
+      serverId: SERVER_ID,
+      workspaceId: WORKSPACE_ID,
+      target: {
+        kind: "file",
+        path: "/repo/worktree/README.md",
+        renderMode: "source",
+      },
+      now: NOW,
+    });
+
+    expect(reopened.tabId).toBe(fileResult.tabId);
+    expect(reopened.state.uiTabsByWorkspace[WORKSPACE_KEY]).toEqual([
+      {
+        tabId: "file_/repo/worktree/README.md",
+        target: {
+          kind: "file",
+          path: "/repo/worktree/README.md",
+          renderMode: "source",
+        },
+        createdAt: NOW,
+      },
+    ]);
+  });
+
   it("builds a deterministic setup tab keyed by workspace id", () => {
     const result = applyOpenOrFocusTab(initialWorkspaceTabsCoreState, {
       serverId: SERVER_ID,

--- a/packages/app/src/stores/workspace-tabs-store/state.ts
+++ b/packages/app/src/stores/workspace-tabs-store/state.ts
@@ -5,7 +5,11 @@ import {
   normalizeWorkspaceTabTarget,
   workspaceTabTargetsEqual,
 } from "@/workspace-tabs/identity";
-import type { WorkspaceFileTabTarget, WorkspaceFileTabTargetInput } from "@/workspace/file-open";
+import {
+  workspaceFileLocationsEqual,
+  type WorkspaceFileTabTarget,
+  type WorkspaceFileTabTargetInput,
+} from "@/workspace/file-open";
 
 export interface WorkspaceDraftTabSetup {
   provider: AgentProvider;
@@ -107,19 +111,42 @@ function retargetTabAtIndex(
   return index === targetIndex ? { ...tab, target: normalizedTarget } : tab;
 }
 
+function targetsShareFileLocation(left: WorkspaceTabTarget, right: WorkspaceTabTarget): boolean {
+  return left.kind === "file" && right.kind === "file" && workspaceFileLocationsEqual(left, right);
+}
+
+function shouldPreserveExistingFileRenderMode(target: WorkspaceTabTargetInput): boolean {
+  return target.kind === "file" && target.renderMode == null;
+}
+
 function buildNextTabsForEnsure(args: {
   currentTabs: WorkspaceTab[];
   existingIndex: number;
   effectiveTabId: string;
   normalizedTarget: WorkspaceTabTarget;
   createdAt: number;
+  preserveExistingFileRenderMode: boolean;
 }): WorkspaceTab[] {
-  const { currentTabs, existingIndex, effectiveTabId, normalizedTarget, createdAt } = args;
+  const {
+    currentTabs,
+    existingIndex,
+    effectiveTabId,
+    normalizedTarget,
+    createdAt,
+    preserveExistingFileRenderMode,
+  } = args;
   if (existingIndex < 0) {
     return [...currentTabs, { tabId: effectiveTabId, target: normalizedTarget, createdAt }];
   }
   const existing = currentTabs[existingIndex];
   if (existing && workspaceTabTargetsEqual(existing.target, normalizedTarget)) {
+    return currentTabs;
+  }
+  if (
+    preserveExistingFileRenderMode &&
+    existing &&
+    targetsShareFileLocation(existing.target, normalizedTarget)
+  ) {
     return currentTabs;
   }
   return currentTabs.map((tab, index) =>
@@ -147,6 +174,7 @@ export function applyEnsureTab(
     serverId: input.serverId,
     workspaceId: input.workspaceId,
   });
+  const preserveExistingFileRenderMode = shouldPreserveExistingFileRenderMode(input.target);
   const normalizedTarget = normalizeWorkspaceTabTarget(input.target);
   if (!key || !normalizedTarget) {
     return { state, tabId: null };
@@ -167,6 +195,7 @@ export function applyEnsureTab(
     effectiveTabId,
     normalizedTarget,
     createdAt: input.now,
+    preserveExistingFileRenderMode,
   });
 
   const uiTabsByWorkspace =

--- a/packages/app/src/stores/workspace-tabs-store/state.ts
+++ b/packages/app/src/stores/workspace-tabs-store/state.ts
@@ -5,7 +5,7 @@ import {
   normalizeWorkspaceTabTarget,
   workspaceTabTargetsEqual,
 } from "@/workspace-tabs/identity";
-import type { WorkspaceFileTabTarget } from "@/workspace/file-open";
+import type { WorkspaceFileTabTarget, WorkspaceFileTabTargetInput } from "@/workspace/file-open";
 
 export interface WorkspaceDraftTabSetup {
   provider: AgentProvider;
@@ -23,6 +23,10 @@ export type WorkspaceTabTarget =
   | { kind: "browser"; browserId: string }
   | WorkspaceFileTabTarget
   | { kind: "setup"; workspaceId: string };
+
+export type WorkspaceTabTargetInput =
+  | Exclude<WorkspaceTabTarget, WorkspaceFileTabTarget>
+  | WorkspaceFileTabTargetInput;
 
 export interface WorkspaceTab {
   tabId: string;
@@ -126,7 +130,7 @@ function buildNextTabsForEnsure(args: {
 export interface EnsureTabInput {
   serverId: string;
   workspaceId: string;
-  target: WorkspaceTabTarget;
+  target: WorkspaceTabTargetInput;
   now: number;
 }
 
@@ -331,7 +335,7 @@ export interface RetargetTabInput {
   serverId: string;
   workspaceId: string;
   tabId: string;
-  target: WorkspaceTabTarget;
+  target: WorkspaceTabTargetInput;
 }
 
 export function applyRetargetTab(
@@ -519,6 +523,7 @@ function coerceWorkspaceTabTarget(raw: Record<string, unknown>): WorkspaceTabTar
       path: raw.path,
       lineStart: typeof raw.lineStart === "number" ? raw.lineStart : undefined,
       lineEnd: typeof raw.lineEnd === "number" ? raw.lineEnd : undefined,
+      renderMode: raw.renderMode === "source" ? "source" : "preview",
     });
   }
   if (kind === "setup" && typeof raw.workspaceId === "string") {

--- a/packages/app/src/utils/prepare-workspace-tab.ts
+++ b/packages/app/src/utils/prepare-workspace-tab.ts
@@ -1,14 +1,14 @@
 import { generateDraftId } from "@/stores/draft-keys";
 import {
   buildWorkspaceTabPersistenceKey,
-  type WorkspaceTabTarget,
+  type WorkspaceTabTargetInput,
 } from "@/stores/workspace-tabs-store";
 import { buildHostWorkspaceRoute } from "@/utils/host-routes";
 
 export interface PrepareWorkspaceTabInput {
   serverId: string;
   workspaceId: string;
-  target: WorkspaceTabTarget;
+  target: WorkspaceTabTargetInput;
   pin?: boolean;
 }
 
@@ -17,7 +17,7 @@ export interface NavigateToPreparedWorkspaceTabInput extends PrepareWorkspaceTab
 }
 
 export interface PrepareWorkspaceTabDeps {
-  openTabFocused: (workspaceKey: string, target: WorkspaceTabTarget) => string | null;
+  openTabFocused: (workspaceKey: string, target: WorkspaceTabTargetInput) => string | null;
   pinAgent: (workspaceKey: string, agentId: string) => void;
 }
 
@@ -29,7 +29,7 @@ export interface NavigateToPreparedWorkspaceTabDeps extends PrepareWorkspaceTabD
   ) => void;
 }
 
-function getPreparedTarget(target: WorkspaceTabTarget): WorkspaceTabTarget {
+function getPreparedTarget(target: WorkspaceTabTargetInput): WorkspaceTabTargetInput {
   if (target.kind !== "draft" || target.draftId.trim() !== "new") {
     return target;
   }

--- a/packages/app/src/utils/workspace-navigation.test.ts
+++ b/packages/app/src/utils/workspace-navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
+import type { WorkspaceTabTargetInput } from "@/stores/workspace-tabs-store";
 import { navigateToPreparedWorkspaceTab, prepareWorkspaceTab } from "@/utils/prepare-workspace-tab";
 
 const SERVER_ID = "server-1";
@@ -8,7 +8,7 @@ const AGENT_ID = "agent-1";
 
 interface RecordedOpenedTab {
   key: string;
-  target: WorkspaceTabTarget;
+  target: WorkspaceTabTargetInput;
 }
 
 interface RecordedPin {
@@ -28,7 +28,7 @@ function createFakeLayout() {
   return {
     openedTabs,
     pinnedAgents,
-    openTabFocused: (key: string, target: WorkspaceTabTarget) => {
+    openTabFocused: (key: string, target: WorkspaceTabTargetInput) => {
       openedTabs.push({ key, target });
       return target.kind === "agent" ? target.agentId : null;
     },

--- a/packages/app/src/workspace-tabs/identity.ts
+++ b/packages/app/src/workspace-tabs/identity.ts
@@ -1,10 +1,14 @@
-import type { WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
-import { normalizeWorkspaceFileLocation, workspaceFileLocationsEqual } from "@/workspace/file-open";
+import type { WorkspaceTabTarget, WorkspaceTabTargetInput } from "@/stores/workspace-tabs-store";
+import {
+  normalizeWorkspaceFileLocation,
+  normalizeWorkspaceFileRenderMode,
+  workspaceFileTabTargetsEqual,
+} from "@/workspace/file-open";
 
 type WorkspaceDraftTabSetup = NonNullable<Extract<WorkspaceTabTarget, { kind: "draft" }>["setup"]>;
 
 export function normalizeWorkspaceTabTarget(
-  value: WorkspaceTabTarget | null | undefined,
+  value: WorkspaceTabTarget | WorkspaceTabTargetInput | null | undefined,
 ): WorkspaceTabTarget | null {
   if (!value || typeof value !== "object" || typeof value.kind !== "string") {
     return null;
@@ -83,7 +87,7 @@ export function workspaceTabTargetsEqual(
     return left.browserId === right.browserId;
   }
   if (left.kind === "file" && right.kind === "file") {
-    return workspaceFileLocationsEqual(left, right);
+    return workspaceFileTabTargetsEqual(left, right);
   }
   if (left.kind === "setup" && right.kind === "setup") {
     return left.workspaceId === right.workspaceId;
@@ -152,10 +156,11 @@ function trimNonEmpty(value: string | null | undefined): string | null {
 }
 
 function normalizeFileTabTarget(
-  value: Extract<WorkspaceTabTarget, { kind: "file" }>,
+  value: Extract<WorkspaceTabTarget | WorkspaceTabTargetInput, { kind: "file" }>,
 ): WorkspaceTabTarget | null {
   const location = normalizeWorkspaceFileLocation(value);
-  return location ? { kind: "file", ...location } : null;
+  const renderMode = normalizeWorkspaceFileRenderMode(value.renderMode);
+  return location ? { kind: "file", ...location, renderMode } : null;
 }
 
 function trimOptionalString(value: string | null | undefined): string | null {

--- a/packages/app/src/workspace/file-open/index.test.ts
+++ b/packages/app/src/workspace/file-open/index.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   createWorkspaceFileTabTarget,
   normalizeWorkspaceFileLocation,
+  normalizeWorkspaceFileRenderMode,
   resolveWorkspaceFilePaths,
   workspaceFileLocationsEqual,
+  workspaceFileTabTargetsEqual,
 } from ".";
 
 describe("normalizeWorkspaceFileLocation", () => {
@@ -44,6 +46,28 @@ describe("workspace file tab targets", () => {
       kind: "file",
       path: "src/app.ts",
       lineStart: 12,
+      renderMode: "preview",
+    });
+  });
+
+  it("normalizes missing render mode to preview", () => {
+    expect(normalizeWorkspaceFileRenderMode(undefined)).toBe("preview");
+    expect(normalizeWorkspaceFileRenderMode("preview")).toBe("preview");
+    expect(normalizeWorkspaceFileRenderMode("source")).toBe("source");
+    expect(createWorkspaceFileTabTarget({ path: "README.md" })).toEqual({
+      kind: "file",
+      path: "README.md",
+      renderMode: "preview",
+    });
+    expect(createWorkspaceFileTabTarget({ path: "README.md", renderMode: "preview" })).toEqual({
+      kind: "file",
+      path: "README.md",
+      renderMode: "preview",
+    });
+    expect(createWorkspaceFileTabTarget({ path: "README.md", renderMode: "source" })).toEqual({
+      kind: "file",
+      path: "README.md",
+      renderMode: "source",
     });
   });
 
@@ -58,6 +82,21 @@ describe("workspace file tab targets", () => {
       workspaceFileLocationsEqual(
         { path: "src/app.ts", lineStart: 12 },
         { path: "src/app.ts", lineStart: 13 },
+      ),
+    ).toBe(false);
+  });
+
+  it("includes render mode in tab target equality", () => {
+    expect(
+      workspaceFileTabTargetsEqual(
+        { kind: "file", path: "README.md" },
+        { kind: "file", path: "README.md", renderMode: "preview" },
+      ),
+    ).toBe(true);
+    expect(
+      workspaceFileTabTargetsEqual(
+        { kind: "file", path: "README.md" },
+        { kind: "file", path: "README.md", renderMode: "source" },
       ),
     ).toBe(false);
   });

--- a/packages/app/src/workspace/file-open/index.ts
+++ b/packages/app/src/workspace/file-open/index.ts
@@ -8,7 +8,17 @@ export interface WorkspaceFileLocation {
   lineEnd?: number;
 }
 
-export type WorkspaceFileTabTarget = { kind: "file" } & WorkspaceFileLocation;
+export type WorkspaceFileRenderMode = "preview" | "source";
+
+export type WorkspaceFileTabTarget = {
+  kind: "file";
+  renderMode: WorkspaceFileRenderMode;
+} & WorkspaceFileLocation;
+
+export type WorkspaceFileTabTargetInput = {
+  kind: "file";
+  renderMode?: WorkspaceFileRenderMode | null;
+} & WorkspaceFileLocation;
 
 export interface WorkspaceFileOpenRequest {
   location: WorkspaceFileLocation;
@@ -36,6 +46,12 @@ export function normalizeWorkspaceFileLocation(
   };
 }
 
+export function normalizeWorkspaceFileRenderMode(
+  value: WorkspaceFileRenderMode | null | undefined,
+): WorkspaceFileRenderMode {
+  return value === "source" ? "source" : "preview";
+}
+
 export function workspaceFileLocationsEqual(
   left: WorkspaceFileLocation,
   right: WorkspaceFileLocation,
@@ -45,12 +61,26 @@ export function workspaceFileLocationsEqual(
   );
 }
 
+export function workspaceFileTabTargetsEqual(
+  left: WorkspaceFileTabTarget | WorkspaceFileTabTargetInput,
+  right: WorkspaceFileTabTarget | WorkspaceFileTabTargetInput,
+): boolean {
+  return (
+    workspaceFileLocationsEqual(left, right) &&
+    normalizeWorkspaceFileRenderMode(left.renderMode) ===
+      normalizeWorkspaceFileRenderMode(right.renderMode)
+  );
+}
+
 export function createWorkspaceFileTabTarget(
-  location: WorkspaceFileLocation,
+  location: WorkspaceFileLocation & { renderMode?: WorkspaceFileRenderMode | null },
 ): WorkspaceFileTabTarget {
+  const renderMode = normalizeWorkspaceFileRenderMode(location.renderMode);
+  const { renderMode: _renderMode, ...fileLocation } = location;
   return {
     kind: "file",
-    ...location,
+    ...fileLocation,
+    renderMode,
   };
 }
 


### PR DESCRIPTION
### Linked issue

Closes #1264

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Markdown file tabs currently render the preview directly, with no way to inspect the raw Markdown from the same tab. This adds a tab-menu action for rendered Markdown files that toggles the tab between the rendered preview and the highlighted source view.

The tab state now stores an explicit file render mode: `preview` or `source`. Opening a file without a render mode still normalizes to `preview`, so existing open-file paths and older persisted file tabs keep their current behavior. The toggle is wired through the desktop tab menu, mobile tab menu, and split-pane tab rows, and it is intentionally hidden for line-targeted Markdown links because those already need the source/highlighted-line view.

The toggle uses distinct destination icons: `Show source` uses the code icon, and `Show preview` uses the eye icon.

Follow-up review feedback is also covered: reopening an already-open Markdown file without an explicit render mode preserves the user's current preview/source mode, while callers that explicitly request `renderMode: "source"` or `renderMode: "preview"` are still honored.

<img width="963" height="760" alt="Markdown file tab menu with Show source" src="https://github.com/user-attachments/assets/7b61ff27-ba44-4e02-90cc-a3df4c3570b0" />
<img width="1412" height="1114" alt="image" src="https://github.com/user-attachments/assets/9baccced-ef5a-44a9-920f-d4ee4a1d3d49" />

### How did you verify it

- `npx vitest run packages/app/src/workspace/file-open/index.test.ts packages/app/src/screens/workspace/workspace-tab-menu.test.ts packages/app/src/components/file-pane-render-mode.test.ts packages/app/src/screens/workspace/workspace-pane-state.test.ts packages/app/src/screens/workspace/workspace-tab-model.test.ts packages/app/src/screens/workspace/workspace-bulk-close.test.ts packages/app/src/utils/workspace-navigation.test.ts --bail=1`
- `npx vitest run packages/app/src/stores/workspace-tabs-store/state.test.ts packages/app/src/stores/workspace-layout-store.test.ts --bail=1`
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`
- pre-commit hook reran format check, lint, and full typecheck successfully

`workspace-tab-menu.test.ts` also asserts the icon mapping: `Show source` uses `code`, and `Show preview` uses `eye`.

Visual QA is still needed before marking this ready: open a Markdown file tab on desktop/web and mobile, verify the menu shows `Show source`, toggle to the source view, verify the menu changes to `Show preview`, then toggle back.

### Risk surface

This touches workspace tab target normalization and equality for file tabs. The intended behavior is still one tab per file path, with source/preview represented as mutable state on that tab rather than separate tabs.

The main UI risk is that one of the tab menu surfaces could fail to expose or refresh the action correctly after toggling. The main state risk is old persisted file tabs without `renderMode`; those are normalized to `preview` and covered by the file target tests. Reopen/focus behavior for existing file tabs is covered by reducer and split-layout store tests so omitted render mode preserves the current tab mode without blocking explicit render-mode requests.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
