### PR TITLE
Fix pairing base URL handling

### DIFF
--- a/.github/workflows/weekly-upstream-pages-deploy.yml
+++ b/.github/workflows/weekly-upstream-pages-deploy.yml
@@ -1,8 +1,6 @@
 name: Weekly upstream Pages deploy
 
 on:
-  schedule:
-    - cron: "0 3 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/weekly-upstream-pages-deploy.yml
+++ b/.github/workflows/weekly-upstream-pages-deploy.yml
@@ -1,0 +1,54 @@
+name: Weekly upstream Pages deploy
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: weekly-upstream-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Fetch upstream main
+        run: |
+          git remote add upstream https://github.com/getpaseo/paseo.git 2>/dev/null || git remote set-url upstream https://github.com/getpaseo/paseo.git
+          git fetch --depth=1 upstream main
+          git checkout --detach FETCH_HEAD
+          echo "UPSTREAM_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --include-workspace-root
+
+      - name: Build app web bundle
+        run: npm run build:web --workspace=@getpaseo/app
+
+      - name: Deploy to Cloudflare Pages
+        run: >-
+          npm exec -- wrangler pages deploy packages/app/dist
+          --project-name paseo-zijieapi-de5-net
+          --branch main
+          --commit-hash "$UPSTREAM_SHA"
+          --commit-message "Weekly upstream sync from getpaseo/paseo@$UPSTREAM_SHA"
+          --commit-dirty false
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: 835cd580057df97323a7854a8069c5f1

--- a/docs/diagnostics/weekly-upstream-pages-deploy.md
+++ b/docs/diagnostics/weekly-upstream-pages-deploy.md
@@ -1,0 +1,29 @@
+# Weekly upstream Pages deploy
+
+We keep the Cloudflare Pages app deployment in sync with the official upstream repository by running a scheduled GitHub Actions workflow in the fork.
+
+## What it does
+
+- runs every Monday at 03:00 UTC
+- can also be triggered manually from GitHub Actions
+- fetches `getpaseo/paseo@main`
+- builds `packages/app`
+- deploys to Cloudflare Pages project `paseo-zijieapi-de5-net`
+
+## Required repository secrets
+
+- `CLOUDFLARE_API_TOKEN`
+
+## Required repository variables
+
+- `CLOUDFLARE_ACCOUNT_ID`
+
+## Workflow file
+
+- `.github/workflows/weekly-upstream-pages-deploy.yml`
+
+## Notes
+
+- The workflow deploys the upstream commit directly.
+- The fork branch does not need to mirror upstream history for the deployment itself.
+- If the app build changes, update the workflow build command in the same file.

--- a/packages/server/src/server/bootstrap.smoke.test.ts
+++ b/packages/server/src/server/bootstrap.smoke.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { createPaseoDaemon, parseListenString, type PaseoDaemonConfig } from "./bootstrap.js";
 import { generateLocalPairingOffer } from "./pairing-offer.js";
-import { createTestPaseoDaemon } from "./test-utils/paseo-daemon.js";
+import { createTestPaseoDaemon, DaemonClient } from "./test-utils/index.js";
 import { createTestAgentClients } from "./test-utils/fake-agent-client.js";
 import { isPlatform } from "../test-utils/platform.js";
 
@@ -251,4 +251,25 @@ describe("paseo daemon bootstrap", () => {
       }
     },
   );
+
+  test("daemon pairing offer respects custom app base URL", async () => {
+    const appBaseUrl = "https://paseo.zijieapi.de5.net/welcome";
+    const daemonHandle = await createTestPaseoDaemon({
+      relayEnabled: true,
+      appBaseUrl,
+    });
+    const client = new DaemonClient({
+      url: `ws://127.0.0.1:${daemonHandle.port}/ws`,
+    });
+
+    try {
+      await client.connect();
+      const pairing = await client.getDaemonPairingOffer();
+      expect(pairing.relayEnabled).toBe(true);
+      expect(pairing.url.startsWith(`${appBaseUrl}/#offer=`)).toBe(true);
+    } finally {
+      await client.close();
+      await daemonHandle.close();
+    }
+  });
 });

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -972,6 +972,7 @@ export async function createPaseoDaemon(
                 useTls: relayUseTls,
                 publicUseTls: relayPublicUseTls,
               },
+              appBaseUrl,
             },
           );
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -622,6 +622,7 @@ export interface SessionOptions {
       useTls: boolean;
       publicUseTls: boolean;
     } | null;
+    appBaseUrl?: string;
   };
 }
 
@@ -3819,6 +3820,7 @@ export class Session {
         relayPublicEndpoint: relay?.publicEndpoint,
         relayUseTls: relay?.useTls,
         relayPublicUseTls: relay?.publicUseTls,
+        appBaseUrl: this.daemonRuntimeConfig?.appBaseUrl,
         includeQr: true,
         logger: this.sessionLogger,
       });

--- a/packages/server/src/server/test-utils/paseo-daemon.ts
+++ b/packages/server/src/server/test-utils/paseo-daemon.ts
@@ -33,6 +33,7 @@ interface TestPaseoDaemonOptions {
   dictationFinalTimeoutMs?: number;
   auth?: PaseoDaemonConfig["auth"];
   pushNotificationSender?: PushNotificationSender;
+  appBaseUrl?: string;
 }
 
 export interface TestPaseoDaemon {
@@ -158,7 +159,7 @@ async function prepareTestDaemonConfig(
     agentStoragePath: path.join(paseoHome, "agents"),
     relayEnabled: options.relayEnabled ?? false,
     relayEndpoint: options.relayEndpoint ?? "relay.paseo.sh:443",
-    appBaseUrl: "https://app.paseo.sh",
+    appBaseUrl: options.appBaseUrl ?? "https://app.paseo.sh",
     auth: options.auth,
     pushNotificationSender: options.pushNotificationSender,
     openai: options.openai,

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -426,6 +426,7 @@ export class VoiceAssistantWebSocketServer {
         useTls: boolean;
         publicUseTls: boolean;
       };
+      appBaseUrl?: string;
     },
   ) {
     this.logger = logger.child({ module: "websocket-server" });


### PR DESCRIPTION
## Summary\n- Propagate custom app.baseUrl through daemon pairing offer generation\n- Add regression coverage for daemon RPC pairing URL\n- Disable the weekly upstream Pages deploy schedule in the fork workflow\n\n## Verification\n- vitest run --exclude "**/*.e2e.test.ts" src/server/bootstrap.smoke.test.ts