### PR TITLE
fix: progressive narrowing for composer controls in narrow panes (#1281)

### DIFF
--- a/packages/app/src/composer/agent-controls/index.tsx
+++ b/packages/app/src/composer/agent-controls/index.tsx
@@ -98,6 +98,12 @@ interface ControlledAgentControlsProps {
   desktopExtras?: ReactNode;
   modelSelectorServerId?: string | null;
   isCompactLayout?: boolean;
+  /**
+   * Progressive compact level (0–2) for desktop mode narrowing.
+   * Level 0: full text badges. Level 1: icon-only. Level 2: minimal.
+   * Ignored when isCompact is true (sheet mode).
+   */
+  compactLevel?: number;
 }
 
 export interface DraftAgentControlsProps {
@@ -126,6 +132,7 @@ export interface DraftAgentControlsProps {
   disabled?: boolean;
   modelSelectorServerId?: string | null;
   isCompactLayout?: boolean;
+  compactLevel?: number;
 }
 
 interface AgentControlsProps {
@@ -133,6 +140,7 @@ interface AgentControlsProps {
   serverId: string;
   onDropdownClose?: () => void;
   isCompactLayout?: boolean;
+  compactLevel?: number;
 }
 
 function findOptionLabel(
@@ -413,6 +421,7 @@ function ControlledAgentControls({
   desktopExtras,
   modelSelectorServerId = null,
   isCompactLayout,
+  compactLevel = 0,
 }: ControlledAgentControlsProps) {
   const { theme } = useUnistyles();
   const isCompactFormFactor = useIsCompactFormFactor();
@@ -618,6 +627,13 @@ function ControlledAgentControls({
           renderThinkingOption={renderThinkingOption}
           extras={desktopExtras}
           modelSelectorServerId={modelSelectorServerId}
+          compactLevel={compactLevel}
+          activeSheet={activeSheet}
+          handleOpenSheet={handleOpenSheet}
+          handleCloseSheet={handleCloseSheet}
+          handleSelectThinkingAndClose={handleSelectThinkingAndClose}
+          ProviderIcon={ProviderIcon}
+          handleSheetModelSelect={handleSheetModelSelect}
         />
       ) : (
         <SheetAgentControlsContent
@@ -703,6 +719,97 @@ interface DesktopAgentControlsContentProps {
   }) => ReactElement;
   extras?: ReactNode;
   modelSelectorServerId: string | null;
+  compactLevel?: number;
+  /** Sheet-related props for compactLevel >= 2 minimal features button. */
+  activeSheet?: ActiveSheet;
+  handleOpenSheet?: (sheet: Exclude<ActiveSheet, null>) => void;
+  handleCloseSheet?: () => void;
+  handleSelectThinkingAndClose?: (thinkingOptionId: string) => void;
+  ProviderIcon?: ReturnType<typeof getProviderIcon> | null;
+  handleSheetModelSelect?: (providerId: string, modelId: string) => void;
+}
+
+interface DesktopFeaturesSectionProps {
+  compactLevel: number;
+  features?: AgentFeature[];
+  disabled: boolean;
+  openSelector: AgentControlSelector | null;
+  handleOpenChange: (selector: AgentControlSelector) => (nextOpen: boolean) => void;
+  onSetFeature?: (featureId: string, value: unknown) => void;
+  activeSheet?: ActiveSheet;
+  handleOpenSheet?: (sheet: Exclude<ActiveSheet, null>) => void;
+  handleCloseSheet?: () => void;
+}
+
+function DesktopFeaturesSection({
+  compactLevel,
+  features,
+  disabled,
+  openSelector,
+  handleOpenChange,
+  onSetFeature,
+  activeSheet,
+  handleOpenSheet,
+  handleCloseSheet,
+}: DesktopFeaturesSectionProps) {
+  const { theme } = useUnistyles();
+  const handleOpenFeatures = useCallback(() => handleOpenSheet?.("features"), [handleOpenSheet]);
+  const featuresAnchorRef = useRef<View | null>(null);
+  const handleFeaturesRef = useCallback((r: View | null) => {
+    featuresAnchorRef.current = r;
+  }, []);
+
+  const hasFeatures = Boolean(features && features.length > 0);
+  const minimal = compactLevel >= 2;
+  const iconOnly = compactLevel >= 1;
+
+  if (minimal || !hasFeatures) return null;
+
+  if (iconOnly && handleOpenSheet && handleCloseSheet && activeSheet !== undefined) {
+    return (
+      <>
+        <Pressable
+          ref={handleFeaturesRef}
+          onPress={handleOpenFeatures}
+          disabled={disabled}
+          style={styles.modeIconBadge}
+          accessibilityRole="button"
+          accessibilityLabel="Open agent features"
+          testID="agent-controls-features"
+        >
+          <Settings2 size={theme.iconSize.md} color={theme.colors.foregroundMuted} />
+        </Pressable>
+        <AdaptiveModalSheet
+          header={FEATURES_SHEET_HEADER}
+          visible={activeSheet === "features"}
+          onClose={handleCloseSheet}
+          testID="agent-features-sheet"
+        >
+          {(features ?? []).map((feature) => (
+            <SheetFeatureItem
+              key={`feature-${feature.id}`}
+              feature={feature}
+              disabled={disabled}
+              openSelector={openSelector}
+              handleOpenChange={handleOpenChange}
+              onSetFeature={onSetFeature}
+            />
+          ))}
+        </AdaptiveModalSheet>
+      </>
+    );
+  }
+
+  return features?.map((feature) => (
+    <DesktopFeatureItem
+      key={`feature-${feature.id}`}
+      feature={feature}
+      disabled={disabled}
+      openSelector={openSelector}
+      handleOpenChange={handleOpenChange}
+      onSetFeature={onSetFeature}
+    />
+  ));
 }
 
 const DESKTOP_SEARCH_THRESHOLD = 6;
@@ -751,25 +858,92 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
     renderThinkingOption,
     extras,
     modelSelectorServerId,
+    compactLevel = 0,
+    activeSheet,
+    handleOpenSheet,
+    handleCloseSheet,
+    handleSelectThinkingAndClose: _handleSelectThinkingAndClose,
+    ProviderIcon,
+    handleSheetModelSelect,
   } = props;
+
+  const iconOnly = compactLevel >= 1;
+
+  const providerIconPressableStyle = useCallback(
+    ({ pressed, hovered }: PressableStateCallbackType) => [
+      styles.modeIconBadge,
+      hovered && styles.modeBadgeHovered,
+      (pressed || openSelector === "provider") && styles.modeBadgePressed,
+      disabled && styles.disabledBadge,
+    ],
+    [openSelector, disabled],
+  );
+
+  const thinkingIconPressableStyle = useCallback(
+    ({ pressed, hovered }: PressableStateCallbackType) => [
+      styles.modeIconBadge,
+      hovered && styles.modeBadgeHovered,
+      (pressed || openSelector === "thinking") && styles.modeBadgePressed,
+      disabled && styles.disabledBadge,
+    ],
+    [openSelector, disabled],
+  );
+
+  const compactModelTrigger = useMemo(() => {
+    if (!iconOnly || !handleSheetModelSelect) return undefined;
+    return ({
+      selectedModelLabel: _selectedModelLabel,
+    }: {
+      selectedModelLabel: string;
+      onPress: () => void;
+      disabled: boolean;
+      isOpen: boolean;
+    }) => (
+      <View pointerEvents="none" style={styles.prefsButton} testID="agent-controls-model">
+        {ProviderIcon ? (
+          <ProviderIcon size={theme.iconSize.lg} color={theme.colors.foregroundMuted} />
+        ) : null}
+        <ChevronDown size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+      </View>
+    );
+  }, [
+    iconOnly,
+    handleSheetModelSelect,
+    ProviderIcon,
+    theme.iconSize,
+    theme.colors.foregroundMuted,
+  ]);
 
   return (
     <>
       {providerOptions && providerOptions.length > 0 ? (
         <>
-          <Pressable
-            ref={providerAnchorRef}
-            collapsable={false}
-            disabled={disabled || !canSelectProvider}
-            onPress={handleProviderPress}
-            style={providerPressableStyle}
-            accessibilityRole="button"
-            accessibilityLabel="Select agent provider"
-            testID="agent-provider-selector"
-          >
-            <Text style={styles.modeBadgeText}>{displayProvider}</Text>
-            <ChevronDown size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
-          </Pressable>
+          <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
+            <TooltipTrigger asChild triggerRefProp="ref">
+              <Pressable
+                ref={providerAnchorRef}
+                collapsable={false}
+                disabled={disabled || !canSelectProvider}
+                onPress={handleProviderPress}
+                style={iconOnly ? providerIconPressableStyle : providerPressableStyle}
+                accessibilityRole="button"
+                accessibilityLabel="Select agent provider"
+                testID="agent-provider-selector"
+              >
+                {iconOnly && ProviderIcon ? (
+                  <ProviderIcon size={theme.iconSize.md} color={theme.colors.foregroundMuted} />
+                ) : (
+                  <Text style={styles.modeBadgeText}>{displayProvider}</Text>
+                )}
+                <ChevronDown size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+              </Pressable>
+            </TooltipTrigger>
+            {iconOnly ? (
+              <TooltipContent side="top" align="center" offset={8}>
+                <Text style={styles.tooltipText}>{displayProvider}</Text>
+              </TooltipContent>
+            ) : null}
+          </Tooltip>
           <Combobox
             options={comboboxProviderOptions}
             value={selectedProviderId ?? ""}
@@ -801,6 +975,7 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
                 onRetryProvider={onRetryModelProvider}
                 isRetryingProvider={isRetryingModelProvider}
                 serverId={modelSelectorServerId}
+                renderTrigger={compactModelTrigger}
               />
             </View>
           </TooltipTrigger>
@@ -819,18 +994,24 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
                 collapsable={false}
                 disabled={disabled || !canSelectThinking}
                 onPress={handleThinkingPress}
-                style={thinkingPressableStyle}
+                style={iconOnly ? thinkingIconPressableStyle : thinkingPressableStyle}
                 accessibilityRole="button"
                 accessibilityLabel={`Select thinking option (${displayThinking})`}
                 testID="agent-thinking-selector"
               >
                 <Brain size={theme.iconSize.md} color={theme.colors.foregroundMuted} />
-                <Text style={styles.modeBadgeText}>{displayThinking}</Text>
-                <ChevronDown size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+                {iconOnly ? null : (
+                  <>
+                    <Text style={styles.modeBadgeText}>{displayThinking}</Text>
+                    <ChevronDown size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+                  </>
+                )}
               </Pressable>
             </TooltipTrigger>
             <TooltipContent side="top" align="center" offset={8}>
-              <Text style={styles.tooltipText}>{getAgentControlHint("thinking")}</Text>
+              <Text style={styles.tooltipText}>
+                {iconOnly ? displayThinking : getAgentControlHint("thinking")}
+              </Text>
             </TooltipContent>
           </Tooltip>
           <Combobox
@@ -849,16 +1030,17 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
 
       {extras}
 
-      {features?.map((feature) => (
-        <DesktopFeatureItem
-          key={`feature-${feature.id}`}
-          feature={feature}
-          disabled={disabled}
-          openSelector={openSelector}
-          handleOpenChange={handleOpenChange}
-          onSetFeature={onSetFeature}
-        />
-      ))}
+      <DesktopFeaturesSection
+        compactLevel={compactLevel}
+        features={features}
+        disabled={disabled}
+        openSelector={openSelector}
+        handleOpenChange={handleOpenChange}
+        onSetFeature={onSetFeature}
+        activeSheet={activeSheet}
+        handleOpenSheet={handleOpenSheet}
+        handleCloseSheet={handleCloseSheet}
+      />
     </>
   );
 }
@@ -1351,6 +1533,7 @@ export const AgentControls = memo(function AgentControls({
   serverId,
   onDropdownClose,
   isCompactLayout,
+  compactLevel,
 }: AgentControlsProps) {
   const { preferences, updatePreferences } = useFormPreferences();
   const agent = useSessionStore(
@@ -1530,9 +1713,10 @@ export const AgentControls = memo(function AgentControls({
         agentId={agentId}
         placement="toolbar"
         isCompactLayout={isCompactLayout}
+        hideLabel={compactLevel >= 1}
       />
     ),
-    [serverId, agentId, isCompactLayout],
+    [serverId, agentId, isCompactLayout, compactLevel],
   );
 
   if (!agent) {
@@ -1562,6 +1746,7 @@ export const AgentControls = memo(function AgentControls({
       desktopExtras={modeChip}
       modelSelectorServerId={serverId}
       isCompactLayout={isCompactLayout}
+      compactLevel={compactLevel}
     />
   );
 });
@@ -1592,6 +1777,7 @@ export function DraftAgentControls({
   disabled = false,
   modelSelectorServerId = null,
   isCompactLayout,
+  compactLevel = 0,
 }: DraftAgentControlsProps) {
   const { preferences, updatePreferences } = useFormPreferences();
   const isCompactFormFactor = useIsCompactFormFactor();
@@ -1642,6 +1828,7 @@ export function DraftAgentControls({
         onSelectMode={onSelectMode}
         disabled={disabled}
         isCompactLayout={isCompactLayout}
+        hideLabel={compactLevel >= 1}
       />
     ),
     [
@@ -1652,6 +1839,7 @@ export function DraftAgentControls({
       onSelectMode,
       disabled,
       isCompactLayout,
+      compactLevel,
     ],
   );
 
@@ -1687,6 +1875,7 @@ export function DraftAgentControls({
             disabled={disabled}
             desktopExtras={draftModeChip}
             isCompactLayout={isCompactLayout}
+            compactLevel={compactLevel}
           />
         ) : null}
       </View>

--- a/packages/app/src/composer/agent-controls/index.tsx
+++ b/packages/app/src/composer/agent-controls/index.tsx
@@ -754,10 +754,6 @@ function DesktopFeaturesSection({
 }: DesktopFeaturesSectionProps) {
   const { theme } = useUnistyles();
   const handleOpenFeatures = useCallback(() => handleOpenSheet?.("features"), [handleOpenSheet]);
-  const featuresAnchorRef = useRef<View | null>(null);
-  const handleFeaturesRef = useCallback((r: View | null) => {
-    featuresAnchorRef.current = r;
-  }, []);
 
   const hasFeatures = Boolean(features && features.length > 0);
   const minimal = compactLevel >= 2;
@@ -769,7 +765,6 @@ function DesktopFeaturesSection({
     return (
       <>
         <Pressable
-          ref={handleFeaturesRef}
           onPress={handleOpenFeatures}
           disabled={disabled}
           style={styles.modeIconBadge}
@@ -864,7 +859,7 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
     handleCloseSheet,
     handleSelectThinkingAndClose: _handleSelectThinkingAndClose,
     ProviderIcon,
-    handleSheetModelSelect,
+    handleSheetModelSelect: _handleSheetModelSelect,
   } = props;
 
   const iconOnly = compactLevel >= 1;
@@ -890,7 +885,7 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
   );
 
   const compactModelTrigger = useMemo(() => {
-    if (!iconOnly || !handleSheetModelSelect) return undefined;
+    if (!iconOnly) return undefined;
     return ({
       selectedModelLabel: _selectedModelLabel,
     }: {
@@ -906,13 +901,7 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
         <ChevronDown size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
       </View>
     );
-  }, [
-    iconOnly,
-    handleSheetModelSelect,
-    ProviderIcon,
-    theme.iconSize,
-    theme.colors.foregroundMuted,
-  ]);
+  }, [iconOnly, ProviderIcon, theme.iconSize, theme.colors.foregroundMuted]);
 
   return (
     <>

--- a/packages/app/src/composer/agent-controls/mode-control.tsx
+++ b/packages/app/src/composer/agent-controls/mode-control.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react-native";
 import { type SheetHeader } from "@/components/adaptive-modal-sheet";
 import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/combobox";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useSessionStore } from "@/stores/session-store";
 import { useProvidersSnapshot } from "@/hooks/use-providers-snapshot";
 import { resolveProviderDefinition } from "@/utils/provider-definitions";
@@ -93,6 +94,8 @@ interface AgentModeControlViewProps {
   selectedModeId: string | null | undefined;
   onSelectMode: (modeId: string) => void;
   disabled?: boolean;
+  /** When true, hides the mode label and chevron (icon-only for narrow panes). */
+  hideLabel?: boolean;
 }
 
 function normalizeSearchQuery(value: string): string {
@@ -106,6 +109,7 @@ function AgentModeControlView({
   selectedModeId,
   onSelectMode,
   disabled = false,
+  hideLabel = false,
 }: AgentModeControlViewProps) {
   const { theme } = useUnistyles();
   const anchorRef = useRef<View>(null);
@@ -170,12 +174,12 @@ function AgentModeControlView({
 
   const pressableStyle = useCallback(
     ({ pressed, hovered }: PressableStateCallbackType) => [
-      styles.chip,
+      hideLabel ? styles.iconChip : styles.chip,
       hovered && styles.chipHovered,
       (pressed || open) && styles.chipPressed,
       disabled && styles.chipDisabled,
     ],
-    [open, disabled],
+    [open, disabled, hideLabel],
   );
 
   const labelStyle = styles.chipLabel;
@@ -196,20 +200,33 @@ function AgentModeControlView({
 
   return (
     <>
-      <Pressable
-        ref={anchorRef}
-        collapsable={false}
-        disabled={disabled}
-        onPress={handlePress}
-        style={pressableStyle}
-        accessibilityRole="button"
-        accessibilityLabel={`Select agent mode (${selectedModeLabel})`}
-        testID="mode-control"
-      >
-        {Icon ? <Icon size={theme.iconSize.md} color={iconColor} /> : null}
-        <Text style={labelStyle}>{selectedModeLabel}</Text>
-        <ChevronDown size={theme.iconSize.sm} color={iconColor} />
-      </Pressable>
+      <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
+        <TooltipTrigger asChild triggerRefProp="ref">
+          <Pressable
+            ref={anchorRef}
+            collapsable={false}
+            disabled={disabled}
+            onPress={handlePress}
+            style={pressableStyle}
+            accessibilityRole="button"
+            accessibilityLabel={`Select agent mode (${selectedModeLabel})`}
+            testID="mode-control"
+          >
+            {Icon ? <Icon size={theme.iconSize.md} color={iconColor} /> : null}
+            {hideLabel ? null : (
+              <>
+                <Text style={labelStyle}>{selectedModeLabel}</Text>
+                <ChevronDown size={theme.iconSize.sm} color={iconColor} />
+              </>
+            )}
+          </Pressable>
+        </TooltipTrigger>
+        {hideLabel ? (
+          <TooltipContent side="top" align="center" offset={8}>
+            <Text style={styles.tooltipText}>{selectedModeLabel}</Text>
+          </TooltipContent>
+        ) : null}
+      </Tooltip>
       <Combobox
         options={options}
         value={selectedMode.id}
@@ -236,6 +253,8 @@ interface AgentModeControlProps {
   agentId: string;
   placement: AgentModeControlPlacement;
   isCompactLayout?: boolean;
+  /** When true, hides the mode label and chevron (icon-only for narrow panes). */
+  hideLabel?: boolean;
 }
 
 export const AgentModeControl = memo(function AgentModeControl({
@@ -243,6 +262,7 @@ export const AgentModeControl = memo(function AgentModeControl({
   agentId,
   placement,
   isCompactLayout,
+  hideLabel,
 }: AgentModeControlProps) {
   const isCompactFormFactor = useIsCompactFormFactor();
   const isCompact = isCompactLayout ?? isCompactFormFactor;
@@ -294,6 +314,7 @@ export const AgentModeControl = memo(function AgentModeControl({
       selectedModeId={slice.currentModeId}
       onSelectMode={handleSelectMode}
       disabled={!client}
+      hideLabel={hideLabel}
     />
   );
 });
@@ -307,6 +328,8 @@ export interface DraftAgentModeControlProps {
   disabled?: boolean;
   placement: AgentModeControlPlacement;
   isCompactLayout?: boolean;
+  /** When true, hides the mode label and chevron (icon-only for narrow panes). */
+  hideLabel?: boolean;
 }
 
 export function DraftAgentModeControl({
@@ -318,6 +341,7 @@ export function DraftAgentModeControl({
   disabled,
   placement,
   isCompactLayout,
+  hideLabel,
 }: DraftAgentModeControlProps) {
   const isCompactFormFactor = useIsCompactFormFactor();
   const isCompact = isCompactLayout ?? isCompactFormFactor;
@@ -331,6 +355,7 @@ export function DraftAgentModeControl({
       selectedModeId={selectedMode}
       onSelectMode={onSelectMode}
       disabled={disabled}
+      hideLabel={hideLabel}
     />
   );
 }
@@ -358,5 +383,18 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foregroundMuted,
     fontSize: theme.fontSize.sm,
     fontWeight: theme.fontWeight.normal,
+  },
+  iconChip: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "transparent",
+    borderRadius: theme.borderRadius.full,
+  },
+  tooltipText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    lineHeight: theme.fontSize.sm * 1.4,
   },
 }));

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -40,6 +40,7 @@ import type { UserMessageImageAttachment } from "@/types/stream";
 import {
   COMPACT_FORM_FACTOR_WIDTH,
   MAX_CONTENT_WIDTH,
+  useComposerCompactLevel,
   useIsCompactFormFactor,
 } from "@/constants/layout";
 import { isWeb } from "@/constants/platform";
@@ -386,9 +387,19 @@ export function WorkspaceDraftAgentTab({
   }, [pendingAutoSubmit, pendingCreateAttempt]);
   const allowsEmptyAutoSubmit = pendingAutoSubmit?.allowEmptyText === true;
   const isCompactFormFactor = useIsCompactFormFactor();
-  const { onLayout: onInputAreaLayout, isBelow: isCompactComposerLayout } = useContainerWidthBelow(
+  const { onLayout: onCompactLayout, isBelow: isCompactComposerLayout } = useContainerWidthBelow(
     COMPACT_FORM_FACTOR_WIDTH,
     { initialIsBelow: isCompactFormFactor },
+  );
+  const { onLayout: onLevelLayout, level: composerCompactLevel } = useComposerCompactLevel({
+    initialLevel: isCompactFormFactor ? 2 : 0,
+  });
+  const onInputAreaLayout = useCallback(
+    (e: import("react-native").LayoutChangeEvent) => {
+      onCompactLayout(e);
+      onLevelLayout(e);
+    },
+    [onCompactLayout, onLevelLayout],
   );
   const workspaceAttachmentScopeKey = useWorkspaceAttachmentScopeKey({
     serverId,
@@ -706,6 +717,7 @@ export function WorkspaceDraftAgentTab({
             agentControls={composerAgentControls}
             footer={composerFooter}
             isCompactLayout={isCompactComposerLayout}
+            compactLevel={composerCompactLevel}
           />
         </ReanimatedAnimated.View>
       </View>

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -228,12 +228,19 @@ interface RenderLeftContentArgs {
   serverId: string;
   focusInput: () => void;
   isCompactLayout: boolean;
+  compactLevel: number;
 }
 
 function renderLeftContent(args: RenderLeftContentArgs): ReactElement {
-  const { agentControls, agentId, serverId, focusInput, isCompactLayout } = args;
+  const { agentControls, agentId, serverId, focusInput, isCompactLayout, compactLevel } = args;
   if (resolveAgentControlsMode(agentControls) === "draft" && agentControls) {
-    return <DraftAgentControls {...agentControls} isCompactLayout={isCompactLayout} />;
+    return (
+      <DraftAgentControls
+        {...agentControls}
+        isCompactLayout={isCompactLayout}
+        compactLevel={compactLevel}
+      />
+    );
   }
   return (
     <AgentControls
@@ -241,6 +248,7 @@ function renderLeftContent(args: RenderLeftContentArgs): ReactElement {
       serverId={serverId}
       onDropdownClose={focusInput}
       isCompactLayout={isCompactLayout}
+      compactLevel={compactLevel}
     />
   );
 }
@@ -688,6 +696,11 @@ interface ComposerProps {
   externalKeyboardShift?: boolean;
   /** Optional panel/container layout breakpoint. Defaults to the screen breakpoint. */
   isCompactLayout?: boolean;
+  /**
+   * Progressive compact level (0–2) for composer controls.
+   * Level 0: full text badges. Level 1: icon-only. Level 2: minimal.
+   */
+  compactLevel?: number;
 }
 
 const EMPTY_ARRAY: readonly QueuedMessage[] = [];
@@ -884,6 +897,7 @@ export function Composer({
   footer,
   externalKeyboardShift,
   isCompactLayout: isCompactLayoutOverride,
+  compactLevel = 0,
 }: ComposerProps) {
   const buttonIconSize = resolveComposerButtonIconSize();
   const client = useHostRuntimeClient(serverId);
@@ -1565,8 +1579,16 @@ export function Composer({
   );
 
   const leftContent = useMemo(
-    () => renderLeftContent({ agentControls, agentId, serverId, focusInput, isCompactLayout }),
-    [agentId, focusInput, serverId, agentControls, isCompactLayout],
+    () =>
+      renderLeftContent({
+        agentControls,
+        agentId,
+        serverId,
+        focusInput,
+        isCompactLayout,
+        compactLevel,
+      }),
+    [agentId, focusInput, serverId, agentControls, isCompactLayout, compactLevel],
   );
 
   const handleAttachButtonRef = useCallback((node: View | null) => {

--- a/packages/app/src/constants/layout.ts
+++ b/packages/app/src/constants/layout.ts
@@ -1,3 +1,5 @@
+import { useCallback, useState } from "react";
+import type { LayoutChangeEvent } from "react-native";
 import { useUnistyles } from "react-native-unistyles";
 import { isWeb } from "@/constants/platform";
 
@@ -14,6 +16,15 @@ export const HEADER_TOP_PADDING_MOBILE = 8;
 // Max width for chat content (stream view, input area, new agent form)
 export const MAX_CONTENT_WIDTH = 820;
 export const COMPACT_FORM_FACTOR_WIDTH = 768;
+
+// Progressive narrowing thresholds for the composer controls row.
+// At each level the controls strip down further to fit narrow panes.
+// Level 0: full desktop (text badges, all controls inline)
+// Level 1: icon-only badges (hide text, collapse features to single button)
+// Level 2: minimal (hide features, keep provider + model + thinking)
+// Level 3: sheet mode (existing compact layout, threshold = COMPACT_FORM_FACTOR_WIDTH)
+export const COMPOSER_COMPACT_LEVEL_1_WIDTH = 560;
+export const COMPOSER_COMPACT_LEVEL_2_WIDTH = 400;
 
 // Desktop app constants for macOS traffic light buttons
 // These buttons (close/minimize/maximize) overlay the top-left corner
@@ -43,4 +54,35 @@ export function useIsCompactFormFactor(): boolean {
 // can use the desktop shell without entering web-only code paths.
 export function supportsDesktopPaneSplits(): boolean {
   return isWeb;
+}
+
+/**
+ * Tracks the progressive compact level for composer controls based on
+ * container width. Returns a level 0-2 where higher means more compact.
+ *
+ * Level 0: full desktop (text badges, all controls inline)
+ * Level 1: icon-only badges (hide text, collapse features to single button)
+ * Level 2: minimal (hide features, keep provider + model + thinking)
+ *
+ * The full sheet/compact mode (level 3) is handled separately by
+ * useContainerWidthBelow(COMPACT_FORM_FACTOR_WIDTH).
+ */
+export function useComposerCompactLevel(options?: { initialLevel?: number }): {
+  onLayout: (e: LayoutChangeEvent) => void;
+  level: number;
+} {
+  const [level, setLevel] = useState(options?.initialLevel ?? 0);
+  return {
+    onLayout: useCallback((e: LayoutChangeEvent) => {
+      const w = e.nativeEvent.layout.width;
+      let next = 0;
+      if (w < COMPOSER_COMPACT_LEVEL_2_WIDTH) {
+        next = 2;
+      } else if (w < COMPOSER_COMPACT_LEVEL_1_WIDTH) {
+        next = 1;
+      }
+      setLevel((prev) => (prev === next ? prev : next));
+    }, []),
+    level,
+  };
 }

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -22,7 +22,11 @@ import {
   useWorkspaceAttachments,
   useWorkspaceAttachmentScopeKey,
 } from "@/attachments/workspace-attachments-store";
-import { COMPACT_FORM_FACTOR_WIDTH, useIsCompactFormFactor } from "@/constants/layout";
+import {
+  COMPACT_FORM_FACTOR_WIDTH,
+  useComposerCompactLevel,
+  useIsCompactFormFactor,
+} from "@/constants/layout";
 import { isNative, isWeb } from "@/constants/platform";
 import { useAgentAttentionClear } from "@/hooks/use-agent-attention-clear";
 import { useAgentInitialization } from "@/hooks/use-agent-initialization";
@@ -1319,9 +1323,19 @@ function ActiveAgentComposer({
 }) {
   const insets = useSafeAreaInsets();
   const isCompactFormFactor = useIsCompactFormFactor();
-  const { onLayout: onInputAreaLayout, isBelow: isCompactComposerLayout } = useContainerWidthBelow(
+  const { onLayout: onCompactLayout, isBelow: isCompactComposerLayout } = useContainerWidthBelow(
     COMPACT_FORM_FACTOR_WIDTH,
     { initialIsBelow: isCompactFormFactor },
+  );
+  const { onLayout: onLevelLayout, level: composerCompactLevel } = useComposerCompactLevel({
+    initialLevel: isCompactFormFactor ? 2 : 0,
+  });
+  const onInputAreaLayout = useCallback(
+    (e: import("react-native").LayoutChangeEvent) => {
+      onCompactLayout(e);
+      onLevelLayout(e);
+    },
+    [onCompactLayout, onLevelLayout],
   );
   const paneContext = usePaneContext();
   const { workspaceId, tabId, retargetCurrentTab } = paneContext;
@@ -1460,6 +1474,7 @@ function ActiveAgentComposer({
         onClientSlashCommand={handleClientSlashCommand}
         footer={composerFooter}
         isCompactLayout={isCompactComposerLayout}
+        compactLevel={composerCompactLevel}
       />
     </ReanimatedAnimated.View>
   );


### PR DESCRIPTION
### Linked issue

Closes #1281

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The composer controls row (provider selector, model selector, thinking control, feature badges, mode chip) used a binary threshold at 768px — either full desktop mode or compact sheet mode. Between ~400-768px, the text badges overflowed and overlapped each other, making controls unreadable and inaccessible (see screenshot in #1281).

This PR introduces **progressive compact levels** that gracefully strip down the controls as the pane narrows, without ever using overlay:

| Level | Width | Behavior |
|-------|-------|----------|
| 0 | ≥560px | Full desktop — text badges, all controls inline |
| 1 | <560px | Icon-only — text labels hidden, features collapsed to single Settings2 button |
| 2 | <400px | Minimal — features hidden entirely, only provider + model + thinking remain |
| 3 | <768px | Sheet mode (existing compact layout, unchanged) |

**Narrowing priority** (what hides first → last):
1. Text labels hide first (level 1) — icons remain with tooltips
2. Features/option buttons hide last (level 2) — they collapse to a single icon before disappearing
3. Provider, model, and thinking controls always stay visible
4. The send button (right side) is never affected

**Changes:**
- `constants/layout.ts` — New `useComposerCompactLevel` hook that tracks container width and returns level 0-2, plus threshold constants (`COMPOSER_COMPACT_LEVEL_1_WIDTH = 560`, `COMPOSER_COMPACT_LEVEL_2_WIDTH = 400`)
- `agent-controls/index.tsx` — `DesktopAgentControlsContent` renders icon-only badges at level 1 (provider shows icon instead of name, thinking shows Brain icon only, features collapse to Settings2 button opening a sheet). Level 2 hides features entirely. Extracted `DesktopFeaturesSection` to keep complexity manageable.
- `agent-controls/mode-control.tsx` — Added `hideLabel` prop to `AgentModeControl`/`DraftAgentModeControl`. At level 1+, mode chip shows only the icon with a tooltip for the label.
- `composer/index.tsx` — Threads `compactLevel` prop through to `AgentControls`/`DraftAgentControls`
- `panels/agent-panel.tsx` + `draft/workspace-tab.tsx` — Uses `useComposerCompactLevel` alongside existing `useContainerWidthBelow`, combining both into a single `onLayout` handler

### How did you verify it

Verified that all related unit tests pass:
```
$ npx vitest run packages/app/src/composer/agent-controls/mode.test.ts packages/app/src/composer/agent-controls/utils.test.ts packages/app/src/composer/agent-controls/model-loading.test.ts --bail=1
 ✓ 3 test files  19 tests passed
```

Verified lint passes on all changed files (the only remaining lint error is a pre-existing `Composer` complexity warning on main):
```
$ npm run lint
Found 0 warnings and 1 error  ← pre-existing, exists on main
```

Verified formatting ran:
```
$ npm run format
Finished in 3280ms on 2159 files
```

Typecheck shows no new errors in changed files (pre-existing CLI package errors are unrelated).

**Note:** I was unable to run the dev server or capture screenshots/video in this environment. A visual verification of the progressive narrowing behavior at different pane widths (≥560px, ~450px, ~350px) would be valuable before merging.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes (no new errors in changed files)
- [x] `npm run lint` passes (0 new warnings/errors)
- [x] `npm run format` ran (Biome/oxfmt)
- [x] Tests added or updated where it made sense (existing tests pass, no new test files needed for rendering changes)