### PR TITLE
fix(app): keep iOS inline markdown emphasis & links inside UITextView

### DIFF
--- a/packages/app/src/assistant-file-links/link.tsx
+++ b/packages/app/src/assistant-file-links/link.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { isNative, isWeb } from "@/constants/platform";
+import { MarkdownTextSpan } from "@/components/markdown-text";
 import { Shortcut } from "@/components/ui/shortcut";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useStableEvent } from "@/hooks/use-stable-event";
@@ -57,16 +58,22 @@ export function AssistantMarkdownLink({
   );
 
   if (isNative) {
+    // Route the text through MarkdownTextSpan, not a plain RN <Text>. On iOS the
+    // assistant paragraph is a native UITextView that only renders UITextViewChild
+    // nodes; a bare <Text> here (e.g. inline-code file links / autolinks, whose
+    // children are a raw string) produces no UITextViewChild and renders empty.
+    // MarkdownTextSpan is a UITextView on iOS and a selectable <Text> on Android.
+    // See issue #1287. (data-pmono is a web-only font marker — not needed here.)
     return (
       <FileLinkHoverTooltip filePath={tooltipPath}>
-        <Text
+        <MarkdownTextSpan
           accessibilityRole="link"
-          dataSet={monoSurface ? CODE_SURFACE_DATASET : undefined}
+          monoSurface={monoSurface}
           onPress={onPress}
           style={style}
         >
           {children}
-        </Text>
+        </MarkdownTextSpan>
       </FileLinkHoverTooltip>
     );
   }

--- a/packages/app/src/components/markdown-text.android.tsx
+++ b/packages/app/src/components/markdown-text.android.tsx
@@ -1,18 +1,32 @@
 import { useMemo, type ReactNode } from "react";
-import { Text, View, type StyleProp, type TextStyle, type ViewStyle } from "react-native";
+import {
+  Text,
+  View,
+  type StyleProp,
+  type TextProps,
+  type TextStyle,
+  type ViewStyle,
+} from "react-native";
 
 interface MarkdownTextSpanProps {
   style?: StyleProp<TextStyle>;
   monoSurface?: boolean;
+  onPress?: TextProps["onPress"];
+  accessibilityRole?: TextProps["accessibilityRole"];
   children: ReactNode;
 }
 
 // Android's <Text selectable> enables per-text-node selection natively. Each
 // sibling Text is its own selection scope — drag can't span across siblings
 // (that requires a single UITextView ancestor and is iOS-only).
-export function MarkdownTextSpan({ style, children }: MarkdownTextSpanProps) {
+export function MarkdownTextSpan({
+  style,
+  onPress,
+  accessibilityRole,
+  children,
+}: MarkdownTextSpanProps) {
   return (
-    <Text selectable style={style}>
+    <Text selectable accessibilityRole={accessibilityRole} onPress={onPress} style={style}>
       {children}
     </Text>
   );

--- a/packages/app/src/components/markdown-text.ios.tsx
+++ b/packages/app/src/components/markdown-text.ios.tsx
@@ -1,10 +1,12 @@
 import { useMemo, type ReactNode } from "react";
-import type { StyleProp, TextStyle, ViewStyle } from "react-native";
+import type { StyleProp, TextProps, TextStyle, ViewStyle } from "react-native";
 import { UITextView } from "react-native-uitextview";
 
 interface MarkdownTextSpanProps {
   style?: StyleProp<TextStyle>;
   monoSurface?: boolean;
+  onPress?: TextProps["onPress"];
+  accessibilityRole?: TextProps["accessibilityRole"];
   children: ReactNode;
 }
 
@@ -12,9 +14,23 @@ interface MarkdownTextSpanProps {
 // Used inside MarkdownParagraphView (which is also a UITextView on iOS); the
 // library's TextAncestorContext hoists these into UITextViewChild nodes so
 // selection drags can cross sibling spans (e.g. plain text → **bold** → code).
-export function MarkdownTextSpan({ style, children }: MarkdownTextSpanProps) {
+// Inline links route their text through here too (rather than a plain RN
+// <Text>), so file-link / autolink inline code stays a UITextViewChild and
+// renders instead of vanishing inside the paragraph UITextView (issue #1287).
+export function MarkdownTextSpan({
+  style,
+  onPress,
+  accessibilityRole,
+  children,
+}: MarkdownTextSpanProps) {
   return (
-    <UITextView uiTextView selectable style={style}>
+    <UITextView
+      uiTextView
+      selectable
+      accessibilityRole={accessibilityRole}
+      onPress={onPress}
+      style={style}
+    >
       {children}
     </UITextView>
   );

--- a/packages/app/src/components/markdown-text.web.tsx
+++ b/packages/app/src/components/markdown-text.web.tsx
@@ -1,10 +1,19 @@
 import { useMemo, type ReactNode } from "react";
-import { Text, View, type StyleProp, type TextStyle, type ViewStyle } from "react-native";
+import {
+  Text,
+  View,
+  type StyleProp,
+  type TextProps,
+  type TextStyle,
+  type ViewStyle,
+} from "react-native";
 import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
 
 interface MarkdownTextSpanProps {
   style?: StyleProp<TextStyle>;
   monoSurface?: boolean;
+  onPress?: TextProps["onPress"];
+  accessibilityRole?: TextProps["accessibilityRole"];
   children: ReactNode;
 }
 
@@ -13,9 +22,20 @@ interface MarkdownTextSpanProps {
 // react-native-uitextview: its transitive import of codegenNativeComponent
 // pulls in setUpReactDevTools, which doesn't resolve under Metro's web
 // target in dev mode.
-export function MarkdownTextSpan({ style, monoSurface, children }: MarkdownTextSpanProps) {
+export function MarkdownTextSpan({
+  style,
+  monoSurface,
+  onPress,
+  accessibilityRole,
+  children,
+}: MarkdownTextSpanProps) {
   return (
-    <Text dataSet={monoSurface ? CODE_SURFACE_DATASET : undefined} style={style}>
+    <Text
+      dataSet={monoSurface ? CODE_SURFACE_DATASET : undefined}
+      accessibilityRole={accessibilityRole}
+      onPress={onPress}
+      style={style}
+    >
       {children}
     </Text>
   );

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -1622,6 +1622,60 @@ export const AssistantMessage = memo(function AssistantMessage({
           {children}
         </MarkdownInheritedText>
       ),
+      // Emphasis (bold / italic / strikethrough) must render through
+      // MarkdownTextSpan rather than react-native-markdown-display's default
+      // rules. On iOS the paragraph is a native UITextView that only draws text
+      // from UITextViewChild nodes (which MarkdownTextSpan produces); the default
+      // strong/em/s rules wrap children in a plain RN <Text>, which the
+      // UITextView drops — so bold/italic text silently disappears. The actual
+      // weight/style still reaches the leaf text via inheritedStyles (AstRenderer
+      // derives it from the parent strong/em/s node), so the wrapper just has to
+      // keep the subtree inside UITextViewChild nodes. See issue #1287.
+      strong: (
+        node: ASTNode,
+        children: ReactNode[],
+        _parent: ASTNode[],
+        styles: MarkdownStyles,
+        inheritedStyles: TextStyle = {},
+      ) => (
+        <MarkdownInheritedText
+          key={node.key}
+          inheritedStyles={inheritedStyles}
+          textStyle={styles.strong}
+        >
+          {children}
+        </MarkdownInheritedText>
+      ),
+      em: (
+        node: ASTNode,
+        children: ReactNode[],
+        _parent: ASTNode[],
+        styles: MarkdownStyles,
+        inheritedStyles: TextStyle = {},
+      ) => (
+        <MarkdownInheritedText
+          key={node.key}
+          inheritedStyles={inheritedStyles}
+          textStyle={styles.em}
+        >
+          {children}
+        </MarkdownInheritedText>
+      ),
+      s: (
+        node: ASTNode,
+        children: ReactNode[],
+        _parent: ASTNode[],
+        styles: MarkdownStyles,
+        inheritedStyles: TextStyle = {},
+      ) => (
+        <MarkdownInheritedText
+          key={node.key}
+          inheritedStyles={inheritedStyles}
+          textStyle={styles.s}
+        >
+          {children}
+        </MarkdownInheritedText>
+      ),
       code_block: (
         node: ASTNode,
         _children: ReactNode[],


### PR DESCRIPTION
## Problem

On iOS, assistant chat messages drop inline Markdown:

- **Inline code that resolves to a file/URL link** (e.g. `settings.json`, `*.sh`, or any autolink) renders **completely empty** — the text inside the backticks vanishes (issue #1287).
- **Bold / italic / strikethrough** don't render.

Plain text and fenced code blocks are fine. **Web and Android are unaffected.**

## Root cause

The assistant paragraph is a native `UITextView` (`react-native-uitextview`, from the iOS native text-selection work). That view only draws text from its `UITextViewChild` nodes, which are produced exclusively by the library's `UITextView` / `MarkdownTextSpan`. Two inline render paths still emitted a plain RN `<Text>`, whose text is dropped inside the paragraph:

1. `strong` / `em` / `s` used `react-native-markdown-display`'s **default** rules (there were no overrides) → plain `<Text>` wrapper.
2. `AssistantMarkdownLink`'s native branch rendered a plain `<Text>`; for inline-code file links / autolinks (whose child is a raw string) that produced **no** `UITextViewChild`, so the inline code rendered empty.

## Fix

- Add custom `strong` / `em` / `s` rules that render through `MarkdownTextSpan`.
- Route `AssistantMarkdownLink`'s native text through `MarkdownTextSpan` as well (extended to forward `onPress` / `accessibilityRole`).

`MarkdownTextSpan` is a `UITextView` on iOS and a plain selectable `<Text>` on web/Android, so **web and Android behavior is unchanged**. Emphasis styling still reaches the leaf text via `inheritedStyles` (the AstRenderer derives it from the parent emphasis node).

## Verification

- `format` ✅ · `lint` ✅ · `typecheck` (all workspaces) ✅ · existing tests ✅ (58)
- **iOS Simulator (iPhone 17, Xcode 26.5):** a throwaway preview route placed a plain RN `<Text>` between `MarkdownTextSpan` spans inside the paragraph — its text vanished (confirming the mechanism), while the fixed `AssistantMarkdownLink` plus **bold / italic / strike** all rendered. The preview route is **not** part of this PR.

Fixes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
