### PR TITLE
Fix Pi extension command output hangs

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -97,6 +97,18 @@ class SessionEvents {
       .map((event) => event.item);
   }
 
+  timelineAndCompletionEvents() {
+    return this.events.flatMap((event) => {
+      if (event.type === "timeline") {
+        return [{ type: "timeline" as const, item: event.item }];
+      }
+      if (event.type === "turn_completed") {
+        return [{ type: "turn_completed" as const }];
+      }
+      return [];
+    });
+  }
+
   nextTurnCompletion(): Promise<Extract<AgentStreamEvent, { type: "turn_completed" }>> {
     return this.nextEvent(
       (event): event is Extract<AgentStreamEvent, { type: "turn_completed" }> =>
@@ -456,6 +468,28 @@ describe("PiRpcAgentSession", () => {
 
     expect(events.timelineItems()).toEqual([
       { type: "user_message", text: "hello", messageId: "entry-user-1" },
+    ]);
+  });
+
+  test("surfaces Pi extension command messages and completes when no agent turn starts", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("/show-status");
+    fakeSession.emit({
+      type: "message_end",
+      message: {
+        role: "custom",
+        content: [{ type: "text", text: "Extension command output" }],
+      },
+    });
+
+    expect(events.timelineAndCompletionEvents()).toEqual([
+      {
+        type: "timeline",
+        item: { type: "assistant_message", text: "Extension command output" },
+      },
+      { type: "turn_completed" },
     ]);
   });
 

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1499,6 +1499,20 @@ export class PiRpcAgentSession implements AgentSession {
     event: Extract<PiAgentSessionEvent, { type: "message_end" }>,
     turnId: string | undefined,
   ): void {
+    if (event.message.role === "custom") {
+      const text = getUserMessageText(event.message.content);
+      if (text) {
+        this.emit({
+          type: "timeline",
+          provider: PI_PROVIDER,
+          turnId,
+          item: { type: "assistant_message", text },
+        });
+      }
+      this.completeTurn(turnId, []);
+      return;
+    }
+
     if (event.message.role !== "user") {
       return;
     }

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -31,6 +31,10 @@ export type PiAgentMessage =
       content: string | Array<PiTextContent | PiImageContent>;
     }
   | {
+      role: "custom";
+      content: string | Array<PiTextContent | PiImageContent>;
+    }
+  | {
       role: "assistant";
       content: PiAssistantContent[];
       provider?: string;


### PR DESCRIPTION
### Linked issue

Closes #1274

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Pi extension commands that send a custom message without starting an agent turn now show that output in chat and complete the turn instead of hanging.

The Pi provider now accepts `role: \"custom\"` messages, maps their text content to an assistant timeline message, and completes the active turn on that command-output path. Normal user and assistant message handling is unchanged.

### How did you verify it

Reproduced the bug with a new Pi provider test: before the fix, a custom `message_end` emitted no timeline output and no `turn_completed` event.

Ran:

- `npm run format:files -- packages/server/src/server/agent/providers/pi/agent.ts packages/server/src/server/agent/providers/pi/agent.test.ts packages/server/src/server/agent/providers/pi/rpc-types.ts`
- `npx vitest run packages/server/src/server/agent/providers/pi/agent.test.ts --bail=1`
- `npm run typecheck --workspace=@getpaseo/server`
- `npm run lint -- packages/server/src/server/agent/providers/pi/agent.ts packages/server/src/server/agent/providers/pi/agent.test.ts packages/server/src/server/agent/providers/pi/rpc-types.ts`

Pre-commit also ran targeted lint, format check, and full workspace typecheck successfully.

Risk surface: this assumes Pi custom command output uses string or text-block content. Non-text custom content is ignored, matching the existing text extraction behavior.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform, n/a no UI changes
- [x] Tests added or updated where it made sense