### PR TITLE
fix(app): load older history when chat is shorter than viewport

### DIFF
--- a/packages/app/src/agent-stream/render-strategy.test.ts
+++ b/packages/app/src/agent-stream/render-strategy.test.ts
@@ -10,6 +10,7 @@ import {
   getStreamNeighborIndex,
   getStreamNeighborItem,
   isNearBottomForStreamRenderStrategy,
+  isNearHistoryStartForStreamRenderStrategy,
   orderHeadForStreamRenderStrategy,
   orderTailForStreamRenderStrategy,
   resolveBottomAnchorTransportBehavior,
@@ -295,6 +296,70 @@ describe("scroll/bottom calculations", () => {
         contentHeight: 1000,
       }),
     ).toBe(680);
+  });
+
+  it("treats short forward-stream content as already near the history start", () => {
+    const strategy = resolveStreamRenderStrategy({
+      platform: "web",
+      isMobileBreakpoint: false,
+    });
+
+    expect(
+      isNearHistoryStartForStreamRenderStrategy({
+        strategy,
+        offsetY: 0,
+        viewportHeight: 400,
+        contentHeight: 200,
+        threshold: 96,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats short inverted-stream content as already near the history start", () => {
+    const strategy = resolveStreamRenderStrategy({
+      platform: "ios",
+      isMobileBreakpoint: false,
+    });
+
+    expect(
+      isNearHistoryStartForStreamRenderStrategy({
+        strategy,
+        offsetY: 0,
+        viewportHeight: 400,
+        contentHeight: 200,
+        threshold: 96,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps longer streams away from the history start until the oldest edge is close", () => {
+    const forward = resolveStreamRenderStrategy({
+      platform: "web",
+      isMobileBreakpoint: false,
+    });
+    const inverted = resolveStreamRenderStrategy({
+      platform: "android",
+      isMobileBreakpoint: false,
+    });
+
+    expect(
+      isNearHistoryStartForStreamRenderStrategy({
+        strategy: forward,
+        offsetY: 240,
+        viewportHeight: 400,
+        contentHeight: 1000,
+        threshold: 96,
+      }),
+    ).toBe(false);
+    expect(
+      isNearHistoryStartForStreamRenderStrategy({
+        strategy: inverted,
+        offsetY: 240,
+        viewportHeight: 400,
+        contentHeight: 1000,
+        threshold: 96,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/app/src/agent-stream/strategy-native.tsx
+++ b/packages/app/src/agent-stream/strategy-native.tsx
@@ -24,6 +24,7 @@ import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./
 import {
   createStreamStrategy,
   isNearBottomForStreamRenderStrategy,
+  isNearHistoryStartForStreamRenderStrategy,
   resolveBottomAnchorTransportBehavior,
 } from "./strategy";
 
@@ -149,6 +150,31 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
     scrollToBottom,
   });
 
+  const maybeLoadOlderHistory = useStableEvent(() => {
+    const metrics = streamViewportMetricsRef.current;
+    if (
+      !historyStartReadyRef.current ||
+      !hasOlderHistory ||
+      isLoadingOlderHistory ||
+      metrics.viewportMeasuredForKey !== metrics.containerKey ||
+      metrics.contentMeasuredForKey !== metrics.containerKey ||
+      metrics.viewportHeight <= 0
+    ) {
+      return;
+    }
+    if (
+      isNearHistoryStartForStreamRenderStrategy({
+        strategy,
+        offsetY: metrics.offsetY,
+        threshold: HISTORY_START_THRESHOLD_PX,
+        contentHeight: metrics.contentHeight,
+        viewportHeight: metrics.viewportHeight,
+      })
+    ) {
+      onNearHistoryStart();
+    }
+  });
+
   useEffect(() => {
     streamViewportMetricsRef.current = {
       containerKey: "native-virtualized",
@@ -165,11 +191,16 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
     historyStartReadyRef.current = false;
     const frame = requestAnimationFrame(() => {
       historyStartReadyRef.current = true;
+      maybeLoadOlderHistory();
     });
     return () => {
       cancelAnimationFrame(frame);
     };
-  }, [agentId, clearNativeViewportSettling]);
+  }, [agentId, clearNativeViewportSettling, maybeLoadOlderHistory]);
+
+  useEffect(() => {
+    maybeLoadOlderHistory();
+  }, [hasOlderHistory, isLoadingOlderHistory, maybeLoadOlderHistory]);
 
   useEffect(() => {
     const keyboardEvents = [
@@ -241,17 +272,7 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
     });
     onNearBottomChange(nearBottom);
 
-    const distanceFromOldestEdge =
-      streamViewportMetricsRef.current.contentHeight -
-      streamViewportMetricsRef.current.viewportHeight -
-      contentOffset.y;
-    if (
-      historyStartReadyRef.current &&
-      hasOlderHistory &&
-      distanceFromOldestEdge <= HISTORY_START_THRESHOLD_PX
-    ) {
-      onNearHistoryStart();
-    }
+    maybeLoadOlderHistory();
 
     if (programmaticScrollEventBudgetRef.current > 0 && contentOffset.y <= 8) {
       programmaticScrollEventBudgetRef.current -= 1;
@@ -288,6 +309,7 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
       previousViewportHeight,
       viewportHeight,
     });
+    maybeLoadOlderHistory();
   });
 
   const handleContentSizeChange = useStableEvent((_width: number, height: number) => {
@@ -303,6 +325,7 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
       previousContentHeight,
       contentHeight: nextContentHeight,
     });
+    maybeLoadOlderHistory();
   });
 
   const renderItem = useStableEvent(

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -55,14 +55,19 @@ describe("createWebStreamStrategy", () => {
   let container: HTMLDivElement | null = null;
   let originalScrollTo: HTMLElement["scrollTo"] | undefined;
   let originalOffsetHeight: PropertyDescriptor | undefined;
+  let resizeObserverCallbacks: ResizeObserverCallback[] = [];
 
   beforeEach(() => {
+    resizeObserverCallbacks = [];
     Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
       value: true,
       configurable: true,
     });
     Object.defineProperty(globalThis, "ResizeObserver", {
       value: class ResizeObserver {
+        constructor(callback: ResizeObserverCallback) {
+          resizeObserverCallbacks.push(callback);
+        }
         observe() {}
         unobserve() {}
         disconnect() {}
@@ -201,6 +206,67 @@ describe("createWebStreamStrategy", () => {
 
     act(() => {
       scrollContainer?.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(onNearHistoryStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires near-history-start after measurement when content is too short to scroll", async () => {
+    const strategy = createWebStreamStrategy({ isMobileBreakpoint: true });
+    const viewportRef = React.createRef<StreamViewportHandle>();
+    const onNearHistoryStart = vi.fn();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(
+        <>
+          {strategy.render({
+            agentId: "agent",
+            segments: {
+              historyVirtualized: [],
+              historyMounted: [userMessage(1), userMessage(2)],
+              liveHead: [],
+            },
+            boundary: {
+              hasVirtualizedHistory: false,
+              hasMountedHistory: true,
+              hasLiveHead: false,
+            },
+            renderers: createRenderers(vi.fn()),
+            listEmptyComponent: null,
+            viewportRef,
+            routeBottomAnchorRequest: null,
+            isAuthoritativeHistoryReady: true,
+            onNearBottomChange: vi.fn(),
+            onNearHistoryStart,
+            isLoadingOlderHistory: false,
+            hasOlderHistory: true,
+            scrollEnabled: true,
+            listStyle: null,
+            baseListContentContainerStyle: null,
+            forwardListContentContainerStyle: null,
+          })}
+        </>,
+      );
+    });
+
+    const scrollContainer = container.querySelector('[data-testid="agent-chat-scroll"]');
+    expect(scrollContainer).toBeInstanceOf(HTMLElement);
+
+    await act(async () => {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    });
+    expect(onNearHistoryStart).toHaveBeenCalledTimes(0);
+
+    Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 400 });
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 200 });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 0 });
+    act(() => {
+      for (const callback of resizeObserverCallbacks) {
+        callback([], {} as ResizeObserver);
+      }
     });
 
     expect(onNearHistoryStart).toHaveBeenCalledTimes(1);

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -10,9 +10,10 @@ import React, {
 } from "react";
 import { ActivityIndicator } from "react-native";
 import { measureElement as measureVirtualElement, useVirtualizer } from "@tanstack/react-virtual";
+import { useStableEvent } from "@/hooks/use-stable-event";
 import { estimateStreamItemHeight } from "./web-virtualization";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./strategy";
-import { createStreamStrategy } from "./strategy";
+import { createStreamStrategy, isNearHistoryStartForForwardStream } from "./strategy";
 
 interface CreateWebStreamStrategyInput {
   isMobileBreakpoint: boolean;
@@ -258,14 +259,47 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     scheduleStickToBottom();
   }, [cancelPendingStickToBottom, scheduleStickToBottom, scrollMessagesToBottom]);
 
-  const updateScrollMetrics = useCallback(() => {
-    const scrollContainer = scrollContainerRef.current;
-    if (!scrollContainer) {
-      onNearBottomChange(true);
-      return;
-    }
-    syncNearBottom(scrollContainer, onNearBottomChange);
-  }, [onNearBottomChange]);
+  const maybeLoadOlderHistory = useStableEvent(
+    (options: { useActualScrollOffset?: boolean } = {}) => {
+      const scrollContainer = scrollContainerRef.current;
+      if (
+        !scrollContainer ||
+        !historyStartReadyRef.current ||
+        !hasOlderHistory ||
+        isLoadingOlderHistory ||
+        scrollContainer.clientHeight <= 0
+      ) {
+        return;
+      }
+      const offsetY =
+        options.useActualScrollOffset || !followOutputRef.current
+          ? scrollContainer.scrollTop
+          : Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
+      if (
+        isNearHistoryStartForForwardStream({
+          offsetY,
+          threshold: HISTORY_START_THRESHOLD_PX,
+          contentHeight: scrollContainer.scrollHeight,
+          viewportHeight: scrollContainer.clientHeight,
+        })
+      ) {
+        onNearHistoryStart();
+      }
+    },
+  );
+
+  const updateScrollMetrics = useCallback(
+    (options: { useActualScrollOffset?: boolean } = {}) => {
+      const scrollContainer = scrollContainerRef.current;
+      if (!scrollContainer) {
+        onNearBottomChange(true);
+        return;
+      }
+      syncNearBottom(scrollContainer, onNearBottomChange);
+      maybeLoadOlderHistory(options);
+    },
+    [maybeLoadOlderHistory, onNearBottomChange],
+  );
 
   const handleDomScroll = useCallback(() => {
     const scrollContainer = scrollContainerRef.current;
@@ -294,25 +328,23 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     }
 
     lastKnownScrollTopRef.current = currentScrollTop;
-    updateScrollMetrics();
-    if (
-      historyStartReadyRef.current &&
-      hasOlderHistory &&
-      currentScrollTop <= HISTORY_START_THRESHOLD_PX
-    ) {
-      onNearHistoryStart();
-    }
-  }, [cancelPendingStickToBottom, hasOlderHistory, onNearHistoryStart, updateScrollMetrics]);
+    updateScrollMetrics({ useActualScrollOffset: true });
+  }, [cancelPendingStickToBottom, updateScrollMetrics]);
 
   useEffect(() => {
     const frame = window.requestAnimationFrame(() => {
       historyStartReadyRef.current = true;
+      maybeLoadOlderHistory();
     });
     return () => {
       window.cancelAnimationFrame(frame);
       historyStartReadyRef.current = false;
     };
-  }, [props.agentId]);
+  }, [maybeLoadOlderHistory, props.agentId]);
+
+  useEffect(() => {
+    maybeLoadOlderHistory();
+  }, [hasOlderHistory, isLoadingOlderHistory, maybeLoadOlderHistory]);
 
   useLayoutEffect(() => {
     if (!isActivationReady) {

--- a/packages/app/src/agent-stream/strategy.ts
+++ b/packages/app/src/agent-stream/strategy.ts
@@ -32,10 +32,7 @@ export type StreamNearBottomInput = StreamViewportMetrics & {
   threshold: number;
 };
 
-export type StreamNearHistoryStartInput = StreamViewportMetrics & {
-  offsetY: number;
-  threshold: number;
-};
+export type StreamNearHistoryStartInput = StreamNearBottomInput;
 
 export interface StreamEdgeSlotProps {
   ListHeaderComponent?: ReactElement | ComponentType<unknown> | null;

--- a/packages/app/src/agent-stream/strategy.ts
+++ b/packages/app/src/agent-stream/strategy.ts
@@ -32,6 +32,11 @@ export type StreamNearBottomInput = StreamViewportMetrics & {
   threshold: number;
 };
 
+export type StreamNearHistoryStartInput = StreamViewportMetrics & {
+  offsetY: number;
+  threshold: number;
+};
+
 export interface StreamEdgeSlotProps {
   ListHeaderComponent?: ReactElement | ComponentType<unknown> | null;
   ListHeaderComponentStyle?: StyleProp<ViewStyle>;
@@ -277,6 +282,29 @@ export function isNearBottomForStreamRenderStrategy(
     contentHeight: params.contentHeight,
     viewportHeight: params.viewportHeight,
   });
+}
+
+export function isNearHistoryStartForForwardStream(input: StreamNearHistoryStartInput): boolean {
+  return input.offsetY <= input.threshold;
+}
+
+export function isNearHistoryStartForInvertedStream(input: StreamNearHistoryStartInput): boolean {
+  return input.contentHeight - input.viewportHeight - input.offsetY <= input.threshold;
+}
+
+export function isNearHistoryStartForStreamRenderStrategy(
+  params: StreamNearHistoryStartInput & { strategy: StreamStrategy },
+): boolean {
+  const input = {
+    offsetY: params.offsetY,
+    threshold: params.threshold,
+    contentHeight: params.contentHeight,
+    viewportHeight: params.viewportHeight,
+  };
+  if (params.strategy.getFlatListInverted()) {
+    return isNearHistoryStartForInvertedStream(input);
+  }
+  return isNearHistoryStartForForwardStream(input);
 }
 
 export function getBottomOffsetForStreamRenderStrategy(


### PR DESCRIPTION
## Summary

- load older agent history after viewport/content measurement, not only after user scroll
- share the history-start scroll math across forward web and inverted native stream strategies
- cover short-content cases with pure strategy tests and a web regression test that triggers without a scroll event

## Why

When the initial chat content is shorter than the viewport, there is no scrollable top edge. The existing lazy history loader only ran from scroll handlers, so users could get stuck with a short partial timeline even though `hasOlderHistory` was true.

## Tests

- `npm run test --workspace=@getpaseo/app -- src/agent-stream/render-strategy.test.ts src/agent-stream/strategy-web.test.tsx --bail=1`
- `npm run lint -- packages/app/src/agent-stream/strategy.ts packages/app/src/agent-stream/strategy-native.tsx packages/app/src/agent-stream/strategy-web.tsx packages/app/src/agent-stream/render-strategy.test.ts packages/app/src/agent-stream/strategy-web.test.tsx`
- `npm run typecheck --workspace=@getpaseo/app`
- pre-commit: lint, format check, full workspace typecheck
