### PR TITLE
fix(server): don't treat a recycled PID as a running daemon

### DIFF
--- a/packages/server/src/server/pid-lock.test.ts
+++ b/packages/server/src/server/pid-lock.test.ts
@@ -1,9 +1,20 @@
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 
 import { acquirePidLock, getPidLockInfo, releasePidLock, updatePidLock } from "./pid-lock.js";
+
+// Independently derive the real OS start time of a live PID, so the staleness
+// tests don't depend on the implementation's own start-time helper.
+function realProcessStartIso(pid: number): string {
+  const out = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+    env: { ...process.env, LC_ALL: "C" },
+    encoding: "utf8",
+  }).trim();
+  return new Date(out).toISOString();
+}
 
 describe("pid-lock ownership", () => {
   test("writes and releases lock for explicit owner pid", async () => {
@@ -45,6 +56,58 @@ describe("pid-lock ownership", () => {
       )(paseoHome, { ownerPid });
       const lockAfterOwnerRelease = await getPidLockInfo(paseoHome);
       expect(lockAfterOwnerRelease).toBeNull();
+    } finally {
+      await rm(paseoHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("pid-lock staleness (PID reuse)", () => {
+  test("treats lock as stale when its PID was recycled by a different process", async () => {
+    const paseoHome = await mkdtemp(join(tmpdir(), "paseo-pid-lock-reuse-"));
+
+    try {
+      // Reproduce the real incident: the lock points at a PID that IS alive
+      // (here, this test process — like a recycled `printtool`), but it is not
+      // the daemon. Its recorded startedAt is long before that process began.
+      const staleLock = {
+        pid: process.pid,
+        startedAt: "2020-01-01T00:00:00.000Z",
+        hostname: hostname(),
+        uid: process.getuid?.() ?? 0,
+        listen: "127.0.0.1:6767",
+      };
+      await writeFile(join(paseoHome, "paseo.pid"), JSON.stringify(staleLock));
+
+      const ownerPid = process.pid + 10_000;
+      await acquirePidLock(paseoHome, null, { ownerPid });
+
+      const lock = await getPidLockInfo(paseoHome);
+      expect(lock?.pid).toBe(ownerPid);
+    } finally {
+      await rm(paseoHome, { recursive: true, force: true });
+    }
+  });
+
+  test("still rejects when the lock PID is the same live process", async () => {
+    const paseoHome = await mkdtemp(join(tmpdir(), "paseo-pid-lock-live-"));
+
+    try {
+      // A genuinely-live daemon: its recorded startedAt matches the real OS
+      // start time of the PID. The guard must still reject a second acquirer.
+      const liveLock = {
+        pid: process.pid,
+        startedAt: realProcessStartIso(process.pid),
+        hostname: hostname(),
+        uid: process.getuid?.() ?? 0,
+        listen: "127.0.0.1:6767",
+      };
+      await writeFile(join(paseoHome, "paseo.pid"), JSON.stringify(liveLock));
+
+      const ownerPid = process.pid + 10_000;
+      await expect(acquirePidLock(paseoHome, null, { ownerPid })).rejects.toThrow(
+        /already running/,
+      );
     } finally {
       await rm(paseoHome, { recursive: true, force: true });
     }

--- a/packages/server/src/server/pid-lock.ts
+++ b/packages/server/src/server/pid-lock.ts
@@ -1,8 +1,18 @@
+import { execFileSync } from "node:child_process";
 import { open, readFile, unlink, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { hostname } from "node:os";
 import { z } from "zod";
+
+// The OS reuses PIDs. A stale lock left by an unclean daemon shutdown can name a
+// PID the OS has since handed to an unrelated process, so a bare "is this PID
+// alive?" check is not enough to prove the daemon is still running. If the live
+// process started materially later than the lock was written, the PID was
+// recycled and the lock is stale. lstart is second-granularity and the lock is
+// written a beat after the daemon starts, so a genuine daemon's two timestamps
+// sit within a few seconds; a recycled PID differs by the daemon's whole lifetime.
+const PID_REUSE_TOLERANCE_MS = 60_000;
 
 export const pidLockInfoSchema = z.object({
   pid: z.number(),
@@ -43,6 +53,42 @@ function isPidRunning(pid: number): boolean {
   }
 }
 
+// Wall-clock start time of a live process, or null if it can't be determined
+// (process gone, or `ps` unavailable e.g. on Windows). `ps -o lstart` is the
+// portable keyword present on both macOS (BSD) and Linux; LC_ALL=C forces an
+// English, Date.parse-able timestamp regardless of the user's locale.
+function getProcessStartTimeMs(pid: number): number | null {
+  try {
+    const output = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+      encoding: "utf8",
+      env: { ...process.env, LC_ALL: "C" },
+    }).trim();
+    if (!output) {
+      return null;
+    }
+    const parsed = Date.parse(output);
+    return Number.isNaN(parsed) ? null : parsed;
+  } catch {
+    return null;
+  }
+}
+
+// Whether the lock's PID still belongs to the daemon that wrote the lock, as
+// opposed to an unrelated process that inherited the PID after reuse.
+function isLockProcessAlive(lock: PidLockInfo): boolean {
+  if (!isPidRunning(lock.pid)) {
+    return false;
+  }
+  const liveStartMs = getProcessStartTimeMs(lock.pid);
+  const lockStartMs = Date.parse(lock.startedAt);
+  if (liveStartMs === null || Number.isNaN(lockStartMs)) {
+    // Can't compare start times — stay conservative and assume the daemon is
+    // still running rather than risk launching a second one.
+    return true;
+  }
+  return Math.abs(liveStartMs - lockStartMs) <= PID_REUSE_TOLERANCE_MS;
+}
+
 function getPidFilePath(paseoHome: string): string {
   return join(paseoHome, "paseo.pid");
 }
@@ -78,17 +124,17 @@ export async function acquirePidLock(
   // Check if existing lock is stale
   const lockOwnerPid = resolveOwnerPid(options?.ownerPid);
   if (existingLock) {
-    if (isPidRunning(existingLock.pid)) {
-      if (existingLock.pid === lockOwnerPid) {
-        return;
-      }
+    if (existingLock.pid === lockOwnerPid && isPidRunning(existingLock.pid)) {
+      return;
+    }
 
+    if (isLockProcessAlive(existingLock)) {
       throw new PidLockError(
         `Another Paseo daemon is already running (PID ${existingLock.pid}, started ${existingLock.startedAt})`,
         existingLock,
       );
     }
-    // Stale lock - remove it
+    // Stale lock (process gone, or its PID was recycled by another process) - remove it
     await unlink(pidPath).catch(() => {});
   }
 
@@ -197,7 +243,7 @@ export async function isLocked(
   if (!info) {
     return { locked: false };
   }
-  if (!isPidRunning(info.pid)) {
+  if (!isLockProcessAlive(info)) {
     return { locked: false, info };
   }
   return { locked: true, info };


### PR DESCRIPTION
Closes #1304.

## Problem

The PID lock's liveness check is identity-blind: `isPidRunning()` (used by both `acquirePidLock()` and `isLocked()` in `packages/server/src/server/pid-lock.ts`) only does `process.kill(pid, 0)`, which tells you *a* process with that PID exists — not that it's still the daemon. After an unclean shutdown the stale `~/.paseo/paseo.pid` survives; once the OS recycles that PID to an unrelated process, the daemon refuses to start (`Another Paseo daemon is already running`), exits 1, never binds 6767, and every client hangs on "connecting". Full evidence in #1304.

## Fix

Verify process identity before trusting the lock: compare the live process's start time (`ps -o lstart`, the portable keyword on both macOS and Linux; `LC_ALL=C` for a parseable timestamp) against the lock's `startedAt`. If they diverge beyond a 60s tolerance, the PID was reused → clear the stale lock and start.

`lstart` is second-granularity and the lock is written a beat after the daemon starts, so a genuine daemon's two timestamps sit within a few seconds, while a recycled PID differs by the daemon's whole lifetime. When the start time can't be determined (e.g. `ps` unavailable on Windows), it falls back to the previous conservative behaviour, so there's no regression there.

## Testing

- Added two cases in `pid-lock.test.ts`: one reproduces the recycled-PID bug (fails on `main`, passes with the fix), one confirms a genuinely-live daemon is still rejected (guards against over-correcting).
- `oxfmt`, `oxlint`, and `tsgo` typecheck across the whole workspace all pass (via the repo's lefthook pre-commit hook).

No protocol/schema changes.


I actually hit this myself — both the desktop app and the CLI were stuck on "connecting" indefinitely. Digging into the logs, the daemon had exited uncleanly the night before and left ~/.paseo/paseo.pid behind, and the OS had since recycled that PID to an unrelated printtool process, so the lock check thought a daemon was still running. Deleting ~/.paseo/paseo.pid and relaunching fixed it immediately, which confirmed the root cause. I tested this change locally: the new test reproduces the recycled-PID case (fails on main, passes with the fix), the guard test confirms a genuinely-live daemon is still rejected, and typecheck/lint/format all pass via the pre-commit hook. Happy to adjust the approach (tolerance value, or verifying identity a different way) if you'd prefer.
