### PR TITLE
Make provider availability snapshot reliable for MCP-heavy providers

### DIFF
--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -4,6 +4,8 @@ import { resolve } from "node:path";
 
 import type { Logger } from "pino";
 
+import pLimit from "p-limit";
+
 import { expandTilde } from "../../utils/path.js";
 import { withTimeout } from "../../utils/promise-timeout.js";
 import type {
@@ -38,6 +40,15 @@ const DEFAULT_REFRESH_TIMEOUT_MS = 60_000;
 const DEFAULT_DIAGNOSTIC_TIMEOUT_MS = 120_000;
 const REFRESH_TIMEOUT_ENV_VAR = "PASEO_PROVIDER_REFRESH_TIMEOUT_MS";
 export const GLOBAL_PROVIDER_SNAPSHOT_KEY = "paseo:global";
+
+// MCP-heavy providers (omp/pi with many configured MCP servers, opencode) each
+// spawn an RPC session and connect every configured MCP server during their
+// availability probe. Probing every provider at once starves CPU/IO on smaller
+// hosts, so probes flake with spurious timeouts/crashes; those failures are then
+// cached and gate on-demand model fetches. Bounding probe concurrency keeps the
+// contention low while still populating the snapshot in a few parallel waves
+// rather than fully serially.
+const PROVIDER_PROBE_CONCURRENCY = 2;
 
 // Provider refresh probes can be slow on cold starts (e.g. Copilot's first
 // `copilot --acp` invocation, OpenCode workspace probes with many MCP servers).
@@ -666,8 +677,14 @@ export class ProviderSnapshotManager {
   }
 
   private async loadProviders(options: ProviderLoadOptions): Promise<void> {
-    await Promise.allSettled(
-      options.providers.map((provider) => this.loadProvider({ ...options, provider })),
+    // Bound how many providers probe at once (see PROVIDER_PROBE_CONCURRENCY).
+    // Each probe's own failure is swallowed so one slow/broken provider never
+    // blocks the rest of the snapshot from populating.
+    const limit = pLimit(PROVIDER_PROBE_CONCURRENCY);
+    await Promise.all(
+      options.providers.map((provider) =>
+        limit(() => this.loadProvider({ ...options, provider }).catch(() => undefined)),
+      ),
     );
   }
 


### PR DESCRIPTION
Closes #1446.

## What

Makes the provider availability snapshot reliable for **MCP-heavy providers**, in one file (`provider-snapshot-manager.ts`).

`loadProviders` previously probed **every provider at once** — `Promise.allSettled(providers.map(...))`. Providers that start an RPC session and connect their configured MCP servers during the probe (Pi/OMP with many MCP servers, OpenCode) then contend for CPU/IO on smaller hosts; the resulting timeouts/crashes get cached and **gate on-demand model fetches** (`paseo provider models <id>` returns "not available").

This PR **bounds probe concurrency** with `p-limit` (concurrency = 2) instead of firing all probes simultaneously. Each probe's own failure stays swallowed so one slow/broken provider never blocks the rest of the snapshot.

## Why bounded concurrency (not fully sequential, not a bigger timeout)

An earlier revision of this PR went fully sequential + bumped `DEFAULT_REFRESH_TIMEOUT_MS` 30s→90s. Two reasons this version is better:

- **`main` already raised the timeout to 60s**, so that hunk is redundant — dropped it.
- **Fully sequential regresses the healthy case** (snapshot populates in `sum(probe times)` instead of `max(...)`). Bounding to 2 removes the contention that causes the flake while still populating in a few parallel waves — low healthy-case latency, no pathological N×timeout worst case.

`p-limit` is already the in-repo pattern for exactly this (`run-git-command.ts` `gitLimit`, `opencode-agent.ts` `openCodeMetadataLimit`), so this introduces no new dependency or abstraction.

## Relationship to #1724

#1724 ("Keep provider diagnostics useful when discovery is slow") makes the *diagnostic sheet* keep reporting when a probe is slow/errors — it's complementary and left `loadProviders` concurrent. This PR fixes the *root cause* of the flakiness (probe contention), so the two compose: fewer probes flake, and the ones that do are still reported usefully.

## Scope

Single file, `+19 / −2`. No protocol changes, no provider-specific code.

## Testing

- `@getpaseo/server` `typecheck` — clean (full-workspace typecheck via pre-commit hook, exit 0)
- `npx vitest run packages/server/src/server/agent/provider-snapshot-manager.test.ts` — 41 pass
- `oxlint` / `oxfmt` — clean
- Verified live on a real multi-provider daemon (OMP 15.x with ~13 MCP servers + OpenCode + Pi): with concurrent probing these flapped to `error`; with bounded concurrency they consistently resolve to `available`.