### PR TITLE
Keep child agents unattended across providers

### DIFF
--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -94,11 +94,20 @@ export interface ProviderSnapshotEntry {
   defaultModeId?: string | null;
 }
 
-export interface AgentCreateConfigParent {
+export interface AgentCreateConfigAgentParent {
+  kind: "agent";
   provider: AgentProvider;
   modeId: string | null;
   isUnattended: boolean;
 }
+
+export interface AgentCreateConfigSystemUnattendedParent {
+  kind: "system-unattended";
+}
+
+export type AgentCreateConfigParent =
+  | AgentCreateConfigAgentParent
+  | AgentCreateConfigSystemUnattendedParent;
 
 export interface ResolveAgentCreateConfigInput {
   provider: AgentProvider;

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -94,26 +94,18 @@ export interface ProviderSnapshotEntry {
   defaultModeId?: string | null;
 }
 
-export interface AgentCreateConfigAgentParent {
-  kind: "agent";
+export interface AgentCreateConfigParent {
   provider: AgentProvider;
   modeId: string | null;
   isUnattended: boolean;
 }
-
-export interface AgentCreateConfigSystemUnattendedParent {
-  kind: "system-unattended";
-}
-
-export type AgentCreateConfigParent =
-  | AgentCreateConfigAgentParent
-  | AgentCreateConfigSystemUnattendedParent;
 
 export interface ResolveAgentCreateConfigInput {
   provider: AgentProvider;
   requestedMode: string | undefined;
   featureValues: Record<string, unknown> | undefined;
   parent: AgentCreateConfigParent | null;
+  unattended: boolean;
   availableModes: AgentMode[] | undefined;
 }
 

--- a/packages/server/src/server/agent/create-agent-mode.test.ts
+++ b/packages/server/src/server/agent/create-agent-mode.test.ts
@@ -6,7 +6,7 @@ const OPENCODE_MODES = ["build", "plan"];
 const CODEX_MODES = ["auto", "full-access"];
 
 function agentParent(provider: string, modeId: string | null, isUnattended = false) {
-  return { kind: "agent" as const, provider, modeId, isUnattended };
+  return { provider, modeId, isUnattended };
 }
 
 describe("resolveAndValidateCreateAgentMode", () => {
@@ -15,6 +15,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
       requestedMode: "plan",
       targetProvider: "opencode",
       parent: null,
+      unattended: false,
       availableModes: OPENCODE_MODES,
     });
     expect(resolved).toBe("plan");
@@ -26,6 +27,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
         requestedMode: "bypassPermissions",
         targetProvider: "opencode",
         parent: null,
+        unattended: false,
         availableModes: OPENCODE_MODES,
       }),
     ).toThrow(
@@ -38,6 +40,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
       requestedMode: undefined,
       targetProvider: "claude",
       parent: null,
+      unattended: false,
       availableModes: CLAUDE_MODES,
     });
     expect(resolved).toBeUndefined();
@@ -48,6 +51,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
       requestedMode: undefined,
       targetProvider: "claude",
       parent: agentParent("claude", "bypassPermissions"),
+      unattended: false,
       availableModes: CLAUDE_MODES,
     });
     expect(resolved).toBe("bypassPermissions");
@@ -58,6 +62,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
       requestedMode: undefined,
       targetProvider: "claude",
       parent: agentParent("claude", null),
+      unattended: false,
       availableModes: CLAUDE_MODES,
     });
     expect(resolved).toBeUndefined();
@@ -69,6 +74,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
         requestedMode: undefined,
         targetProvider: "opencode",
         parent: agentParent("claude", "bypassPermissions"),
+        unattended: false,
         availableModes: OPENCODE_MODES,
       }),
     ).toThrow(
@@ -82,6 +88,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
         requestedMode: undefined,
         targetProvider: "codex",
         parent: agentParent("opencode", null),
+        unattended: false,
         availableModes: CODEX_MODES,
       }),
     ).toThrow(
@@ -94,6 +101,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
       requestedMode: "default",
       targetProvider: "zai-custom",
       parent: null,
+      unattended: false,
       availableModes: undefined,
     });
     expect(resolved).toBe("default");
@@ -105,6 +113,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
         requestedMode: undefined,
         targetProvider: "zai-custom",
         parent: agentParent("claude", "default"),
+        unattended: false,
         availableModes: undefined,
       }),
     ).toThrow("Available modes for 'zai-custom': unknown");
@@ -115,17 +124,19 @@ describe("resolveAndValidateCreateAgentMode", () => {
       requestedMode: undefined,
       targetProvider: "codex",
       parent: agentParent("claude", "bypassPermissions", true),
+      unattended: false,
       availableModes: CODEX_MODES,
       targetUnattendedMode: "full-access",
     });
     expect(resolved).toBe("full-access");
   });
 
-  it("inherits target's unattended mode for system unattended creation", () => {
+  it("inherits target's unattended mode for unattended creation without a parent", () => {
     const resolved = resolveAndValidateCreateAgentMode({
       requestedMode: undefined,
       targetProvider: "codex",
-      parent: { kind: "system-unattended" },
+      parent: null,
+      unattended: true,
       availableModes: CODEX_MODES,
       targetUnattendedMode: "full-access",
     });
@@ -138,6 +149,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
         requestedMode: undefined,
         targetProvider: "codex",
         parent: agentParent("claude", "default"),
+        unattended: false,
         availableModes: CODEX_MODES,
         targetUnattendedMode: "full-access",
       }),
@@ -152,6 +164,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
         requestedMode: undefined,
         targetProvider: "zai-custom",
         parent: agentParent("claude", "bypassPermissions", true),
+        unattended: false,
         availableModes: undefined,
         targetUnattendedMode: undefined,
       }),
@@ -165,6 +178,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
       requestedMode: "auto",
       targetProvider: "codex",
       parent: agentParent("claude", "bypassPermissions", true),
+      unattended: false,
       availableModes: CODEX_MODES,
       targetUnattendedMode: "full-access",
     });

--- a/packages/server/src/server/agent/create-agent-mode.test.ts
+++ b/packages/server/src/server/agent/create-agent-mode.test.ts
@@ -5,6 +5,10 @@ const CLAUDE_MODES = ["default", "acceptEdits", "plan", "bypassPermissions"];
 const OPENCODE_MODES = ["build", "plan"];
 const CODEX_MODES = ["auto", "full-access"];
 
+function agentParent(provider: string, modeId: string | null, isUnattended = false) {
+  return { kind: "agent" as const, provider, modeId, isUnattended };
+}
+
 describe("resolveAndValidateCreateAgentMode", () => {
   it("returns the requested mode when it is valid for the target provider", () => {
     const resolved = resolveAndValidateCreateAgentMode({
@@ -43,7 +47,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
     const resolved = resolveAndValidateCreateAgentMode({
       requestedMode: undefined,
       targetProvider: "claude",
-      parent: { provider: "claude", modeId: "bypassPermissions" },
+      parent: agentParent("claude", "bypassPermissions"),
       availableModes: CLAUDE_MODES,
     });
     expect(resolved).toBe("bypassPermissions");
@@ -53,7 +57,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
     const resolved = resolveAndValidateCreateAgentMode({
       requestedMode: undefined,
       targetProvider: "claude",
-      parent: { provider: "claude", modeId: null },
+      parent: agentParent("claude", null),
       availableModes: CLAUDE_MODES,
     });
     expect(resolved).toBeUndefined();
@@ -64,7 +68,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
       resolveAndValidateCreateAgentMode({
         requestedMode: undefined,
         targetProvider: "opencode",
-        parent: { provider: "claude", modeId: "bypassPermissions" },
+        parent: agentParent("claude", "bypassPermissions"),
         availableModes: OPENCODE_MODES,
       }),
     ).toThrow(
@@ -77,7 +81,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
       resolveAndValidateCreateAgentMode({
         requestedMode: undefined,
         targetProvider: "codex",
-        parent: { provider: "opencode", modeId: null },
+        parent: agentParent("opencode", null),
         availableModes: CODEX_MODES,
       }),
     ).toThrow(
@@ -100,7 +104,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
       resolveAndValidateCreateAgentMode({
         requestedMode: undefined,
         targetProvider: "zai-custom",
-        parent: { provider: "claude", modeId: "default" },
+        parent: agentParent("claude", "default"),
         availableModes: undefined,
       }),
     ).toThrow("Available modes for 'zai-custom': unknown");
@@ -110,7 +114,18 @@ describe("resolveAndValidateCreateAgentMode", () => {
     const resolved = resolveAndValidateCreateAgentMode({
       requestedMode: undefined,
       targetProvider: "codex",
-      parent: { provider: "claude", modeId: "bypassPermissions", isUnattended: true },
+      parent: agentParent("claude", "bypassPermissions", true),
+      availableModes: CODEX_MODES,
+      targetUnattendedMode: "full-access",
+    });
+    expect(resolved).toBe("full-access");
+  });
+
+  it("inherits target's unattended mode for system unattended creation", () => {
+    const resolved = resolveAndValidateCreateAgentMode({
+      requestedMode: undefined,
+      targetProvider: "codex",
+      parent: { kind: "system-unattended" },
       availableModes: CODEX_MODES,
       targetUnattendedMode: "full-access",
     });
@@ -122,7 +137,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
       resolveAndValidateCreateAgentMode({
         requestedMode: undefined,
         targetProvider: "codex",
-        parent: { provider: "claude", modeId: "default", isUnattended: false },
+        parent: agentParent("claude", "default"),
         availableModes: CODEX_MODES,
         targetUnattendedMode: "full-access",
       }),
@@ -136,7 +151,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
       resolveAndValidateCreateAgentMode({
         requestedMode: undefined,
         targetProvider: "zai-custom",
-        parent: { provider: "claude", modeId: "bypassPermissions", isUnattended: true },
+        parent: agentParent("claude", "bypassPermissions", true),
         availableModes: undefined,
         targetUnattendedMode: undefined,
       }),
@@ -149,7 +164,7 @@ describe("resolveAndValidateCreateAgentMode", () => {
     const resolved = resolveAndValidateCreateAgentMode({
       requestedMode: "auto",
       targetProvider: "codex",
-      parent: { provider: "claude", modeId: "bypassPermissions", isUnattended: true },
+      parent: agentParent("claude", "bypassPermissions", true),
       availableModes: CODEX_MODES,
       targetUnattendedMode: "full-access",
     });

--- a/packages/server/src/server/agent/create-agent-mode.ts
+++ b/packages/server/src/server/agent/create-agent-mode.ts
@@ -11,6 +11,7 @@ export interface ResolveCreateAgentModeInput {
   requestedMode: string | undefined;
   targetProvider: AgentProvider;
   parent: AgentCreateConfigParent | null;
+  unattended: boolean;
   // `undefined` = target provider's modes unknown: explicit modes pass through
   // unvalidated, but cross-provider inheritance is still refused.
   availableModes: string[] | undefined;
@@ -27,17 +28,15 @@ function listModes(modes: string[] | undefined): string {
 }
 
 function isUnattendedCreateConfigParent(parent: AgentCreateConfigParent): boolean {
-  return parent.kind === "system-unattended" || parent.isUnattended;
+  return parent.isUnattended;
 }
 
 function formatCreateConfigParentMode(parent: AgentCreateConfigParent): string {
-  return parent.kind === "agent" ? (parent.modeId ?? "<none>") : "<system-unattended>";
+  return parent.modeId ?? "<none>";
 }
 
 function formatCreateConfigParentSource(parent: AgentCreateConfigParent): string {
-  return parent.kind === "agent"
-    ? `caller (provider '${parent.provider}')`
-    : "system unattended request";
+  return `caller (provider '${parent.provider}')`;
 }
 
 export function resolveAndValidateCreateAgentMode(
@@ -55,14 +54,20 @@ export function resolveAndValidateCreateAgentMode(
   }
 
   if (!parent) {
+    if (input.unattended && input.targetUnattendedMode !== undefined) {
+      return input.targetUnattendedMode;
+    }
     return undefined;
   }
 
-  if (parent.kind === "agent" && parent.provider === targetProvider) {
+  if (parent.provider === targetProvider) {
     return parent.modeId ?? undefined;
   }
 
-  if (isUnattendedCreateConfigParent(parent) && input.targetUnattendedMode !== undefined) {
+  if (
+    (input.unattended || isUnattendedCreateConfigParent(parent)) &&
+    input.targetUnattendedMode !== undefined
+  ) {
     return input.targetUnattendedMode;
   }
 
@@ -80,6 +85,7 @@ export function resolveDefaultAgentCreateConfig(
       requestedMode: input.requestedMode,
       targetProvider: input.provider,
       parent: input.parent,
+      unattended: input.unattended,
       availableModes: availableModeIds,
       targetUnattendedMode: input.availableModes?.find(isUnattendedMode)?.id,
     }),

--- a/packages/server/src/server/agent/create-agent-mode.ts
+++ b/packages/server/src/server/agent/create-agent-mode.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentCreateConfigParent,
   AgentCreateConfigUnattendedInput,
   AgentMode,
   AgentProvider,
@@ -6,16 +7,10 @@ import type {
   ResolveAgentCreateConfigResult,
 } from "./agent-sdk-types.js";
 
-interface CreateAgentModeParent {
-  provider: AgentProvider;
-  modeId: string | null;
-  isUnattended: boolean;
-}
-
 export interface ResolveCreateAgentModeInput {
   requestedMode: string | undefined;
   targetProvider: AgentProvider;
-  parent: CreateAgentModeParent | null;
+  parent: AgentCreateConfigParent | null;
   // `undefined` = target provider's modes unknown: explicit modes pass through
   // unvalidated, but cross-provider inheritance is still refused.
   availableModes: string[] | undefined;
@@ -29,6 +24,20 @@ function listModes(modes: string[] | undefined): string {
     return "unknown";
   }
   return modes.length > 0 ? modes.join(", ") : "(none)";
+}
+
+function isUnattendedCreateConfigParent(parent: AgentCreateConfigParent): boolean {
+  return parent.kind === "system-unattended" || parent.isUnattended;
+}
+
+function formatCreateConfigParentMode(parent: AgentCreateConfigParent): string {
+  return parent.kind === "agent" ? (parent.modeId ?? "<none>") : "<system-unattended>";
+}
+
+function formatCreateConfigParentSource(parent: AgentCreateConfigParent): string {
+  return parent.kind === "agent"
+    ? `caller (provider '${parent.provider}')`
+    : "system unattended request";
 }
 
 export function resolveAndValidateCreateAgentMode(
@@ -49,16 +58,16 @@ export function resolveAndValidateCreateAgentMode(
     return undefined;
   }
 
-  if (parent.provider === targetProvider) {
+  if (parent.kind === "agent" && parent.provider === targetProvider) {
     return parent.modeId ?? undefined;
   }
 
-  if (parent.isUnattended && input.targetUnattendedMode !== undefined) {
+  if (isUnattendedCreateConfigParent(parent) && input.targetUnattendedMode !== undefined) {
     return input.targetUnattendedMode;
   }
 
   throw new Error(
-    `cannot inherit mode '${parent.modeId ?? "<none>"}' from caller (provider '${parent.provider}') for new agent (provider '${targetProvider}'). Pass an explicit mode. Available modes for '${targetProvider}': ${listModes(availableModes)}`,
+    `cannot inherit mode '${formatCreateConfigParentMode(parent)}' from ${formatCreateConfigParentSource(parent)} for new agent (provider '${targetProvider}'). Pass an explicit mode. Available modes for '${targetProvider}': ${listModes(availableModes)}`,
   );
 }
 

--- a/packages/server/src/server/agent/create-agent/create.ts
+++ b/packages/server/src/server/agent/create-agent/create.ts
@@ -256,6 +256,7 @@ async function resolveMcpCreateAgent(
       requestedMode: input.mode,
       featureValues: input.features,
       parent: parentAgent,
+      unattended: false,
     });
 
   const labels = mergeLabels({

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -14,6 +14,7 @@ import type { AgentManager, ManagedAgent } from "./agent-manager.js";
 import type { AgentStorage, StoredAgentRecord } from "./agent-storage.js";
 import type { AgentMode, AgentProvider, ProviderSnapshotEntry } from "./agent-sdk-types.js";
 import { resolveDefaultAgentCreateConfig } from "./create-agent-mode.js";
+import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
 import { createProviderSnapshotManagerStub } from "../test-utils/session-stubs.js";
 import {
   AgentListItemPayloadSchema,
@@ -217,6 +218,7 @@ function createTerminalManagerStub(overrides: Partial<TerminalManager> = {}): Te
 }
 
 type ProviderSnapshotManagerStub = ReturnType<typeof createProviderSnapshotManagerStub>;
+const OPEN_CODE_CREATE_CONFIG_RESOLVER = new OpenCodeAgentClient(createTestLogger());
 
 interface ConfigureProviderEntry {
   provider: AgentProvider;
@@ -225,6 +227,27 @@ interface ConfigureProviderEntry {
   enabled?: boolean;
   defaultModeId?: string;
   modes?: AgentMode[];
+}
+
+function isStubParentUnattended(
+  parent: ManagedAgent | null,
+  modesByProvider: Record<string, AgentMode[]>,
+  openCodeProviderIds: Set<AgentProvider>,
+): boolean {
+  const parentModes = parent ? (modesByProvider[parent.provider] ?? []) : [];
+  const parentMode = parentModes.find((mode) => mode.id === parent?.currentModeId);
+  if (!parent || !openCodeProviderIds.has(parent.provider)) {
+    return parentMode?.isUnattended === true;
+  }
+  return (
+    parentMode?.isUnattended === true ||
+    OPEN_CODE_CREATE_CONFIG_RESOLVER.isCreateConfigUnattended({
+      modeId: parent?.currentModeId ?? null,
+      config: parent?.config ?? {},
+      features: parent?.features ?? [],
+      availableModes: parentModes,
+    })
+  );
 }
 
 // Builds a ProviderSnapshotEntry for tests that need to configure listProviders /
@@ -255,25 +278,34 @@ function buildSnapshotEntry(entry: ConfigureProviderEntry): ProviderSnapshotEntr
 }
 
 // Shared helper used by ~60 create_agent / update_agent / list_agents tests that
-// only need a "normal" provider catalog (claude, codex, opencode) and the
-// OpenCode resolveCreateConfig quirk: requestedMode="full-access" or an
-// unattended parent maps to build mode + auto_accept feature.
+// only need a "normal" provider catalog (claude, codex, opencode). OpenCode
+// create-config behavior delegates to the production provider client.
 //
 // NOTE: This is NOT a registry. It directly configures the public stub surface.
 // Per-test customization is done by overriding individual stub methods after
 // calling this helper.
-function configureOpenCodeProviderStub(stub: ProviderSnapshotManagerStub): void {
+interface ConfigureOpenCodeProviderStubOptions {
+  customOpenCodeProvider?: AgentProvider;
+}
+
+function configureOpenCodeProviderStub(
+  stub: ProviderSnapshotManagerStub,
+  options: ConfigureOpenCodeProviderStubOptions = {},
+): void {
+  const openCodeCreateConfigResolver = new OpenCodeAgentClient(createTestLogger());
   const claudeModes: AgentMode[] = [
     { id: "default", label: "Default", description: "Ask first" },
     { id: "bypassPermissions", label: "Bypass", description: "No prompts", isUnattended: true },
   ];
   const codexModes: AgentMode[] = [
     { id: "default", label: "Default", description: "Default" },
-    { id: "auto", label: "Auto", description: "Auto", isUnattended: true },
+    { id: "auto", label: "Auto", description: "Auto" },
+    { id: "full-access", label: "Full Access", description: "No prompts", isUnattended: true },
   ];
   const opencodeModes: AgentMode[] = [
     { id: "build", label: "Build", description: "Can edit" },
     { id: "plan", label: "Plan", description: "Read-only" },
+    { id: "paseo-custom", label: "Paseo Custom", description: "Custom OpenCode agent" },
   ];
   const entries: ProviderSnapshotEntry[] = [
     buildSnapshotEntry({
@@ -298,13 +330,33 @@ function configureOpenCodeProviderStub(stub: ProviderSnapshotManagerStub): void 
       modes: opencodeModes,
     }),
   ];
+  const customOpenCodeModes: AgentMode[] = [
+    ...opencodeModes,
+    { id: "paseo-custom", label: "Paseo Custom" },
+  ];
+  if (options.customOpenCodeProvider) {
+    entries.push(
+      buildSnapshotEntry({
+        provider: options.customOpenCodeProvider,
+        label: "OpenCode Custom",
+        description: "Custom OpenCode agent",
+        defaultModeId: "build",
+        modes: customOpenCodeModes,
+      }),
+    );
+  }
   const modesByProvider: Record<string, AgentMode[]> = {
     claude: claudeModes,
     codex: codexModes,
     opencode: opencodeModes,
   };
+  const openCodeProviderIds = new Set<AgentProvider>(["opencode"]);
+  if (options.customOpenCodeProvider) {
+    modesByProvider[options.customOpenCodeProvider] = customOpenCodeModes;
+    openCodeProviderIds.add(options.customOpenCodeProvider);
+  }
 
-  stub.listRegisteredProviderIds.mockReturnValue(["claude", "codex", "opencode"]);
+  stub.listRegisteredProviderIds.mockReturnValue(entries.map((entry) => entry.provider));
   stub.hasProvider.mockImplementation((provider) =>
     Object.prototype.hasOwnProperty.call(modesByProvider, provider),
   );
@@ -336,40 +388,38 @@ function configureOpenCodeProviderStub(stub: ProviderSnapshotManagerStub): void 
       featureValues: Record<string, unknown> | undefined;
       parent: ManagedAgent | null;
     };
-    if (opts.provider === "opencode") {
-      if (opts.requestedMode === "full-access") {
-        return {
-          modeId: "build",
-          featureValues: { ...opts.featureValues, auto_accept: true },
-        };
-      }
-      // Cross-provider unattended inheritance: caller is in unattended mode and
-      // requested no explicit mode — map to build + auto_accept.
-      if (opts.requestedMode === undefined && opts.parent) {
-        const parentModes = modesByProvider[opts.parent.provider] ?? [];
-        const parentMode = parentModes.find((m) => m.id === opts.parent?.currentModeId);
-        if (parentMode?.isUnattended === true) {
-          return {
-            modeId: "build",
-            featureValues: { ...opts.featureValues, auto_accept: true },
-          };
-        }
-      }
-    }
+    const parentIsUnattended = isStubParentUnattended(
+      opts.parent,
+      modesByProvider,
+      openCodeProviderIds,
+    );
     const availableModes = modesByProvider[opts.provider] ?? [];
-    const parentModes = opts.parent ? (modesByProvider[opts.parent.provider] ?? []) : [];
-    const parentMode = opts.parent
-      ? parentModes.find((m) => m.id === opts.parent?.currentModeId)
-      : null;
+    if (openCodeProviderIds.has(opts.provider)) {
+      return openCodeCreateConfigResolver.resolveCreateConfig({
+        provider: opts.provider,
+        requestedMode: opts.requestedMode,
+        featureValues: opts.featureValues,
+        parent: opts.parent
+          ? {
+              kind: "agent",
+              provider: opts.parent.provider,
+              modeId: opts.parent.currentModeId,
+              isUnattended: parentIsUnattended,
+            }
+          : null,
+        availableModes,
+      });
+    }
     return resolveDefaultAgentCreateConfig({
       provider: opts.provider,
       requestedMode: opts.requestedMode,
       featureValues: opts.featureValues,
       parent: opts.parent
         ? {
+            kind: "agent",
             provider: opts.parent.provider,
             modeId: opts.parent.currentModeId,
-            isUnattended: parentMode?.isUnattended === true,
+            isUnattended: parentIsUnattended,
           }
         : null,
       availableModes,
@@ -378,12 +428,12 @@ function configureOpenCodeProviderStub(stub: ProviderSnapshotManagerStub): void 
 }
 
 // Quick helper: returns a manager configured with the standard OpenCode catalog.
-function createOpenCodeManager(): {
+function createOpenCodeManager(options?: ConfigureOpenCodeProviderStubOptions): {
   manager: ProviderSnapshotManagerStub["manager"];
   stub: ProviderSnapshotManagerStub;
 } {
   const stub = createProviderSnapshotManagerStub();
-  configureOpenCodeProviderStub(stub);
+  configureOpenCodeProviderStub(stub, options);
   return { manager: stub.manager, stub };
 }
 
@@ -2128,6 +2178,166 @@ describe("create_agent MCP tool", () => {
 
     expect(spies.agentManager.createAgent).toHaveBeenCalledWith(
       expect.objectContaining({ modeId: "build", featureValues: { auto_accept: true } }),
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it("maps unattended Claude callers to Codex full access", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    spies.agentManager.getAgent.mockReturnValue({
+      id: "parent-agent",
+      cwd: existingCwd,
+      provider: "claude",
+      currentModeId: "bypassPermissions",
+    } as ManagedAgent);
+    spies.agentManager.createAgent.mockResolvedValue({
+      id: "child-agent",
+      cwd: existingCwd,
+      lifecycle: "idle",
+      currentModeId: "full-access",
+      availableModes: [],
+      config: { title: "Child", modeId: "full-access" },
+    } as ManagedAgent);
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      callerAgentId: "parent-agent",
+      providerSnapshotManager: createOpenCodeManager().manager,
+      logger,
+    });
+    const tool = registeredTool(server, "create_agent");
+    await tool.handler({
+      title: "Child",
+      provider: "codex/gpt-5.4",
+      initialPrompt: "Do work",
+    });
+
+    expect(spies.agentManager.createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ modeId: "full-access" }),
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it("preserves an OpenCode custom parent agent while inheriting auto accept", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    spies.agentManager.getAgent.mockReturnValue({
+      id: "parent-agent",
+      cwd: existingCwd,
+      provider: "opencode",
+      currentModeId: "paseo-custom",
+      config: {
+        provider: "opencode",
+        cwd: existingCwd,
+        modeId: "paseo-custom",
+        featureValues: { auto_accept: true },
+      },
+      features: [
+        {
+          type: "toggle",
+          id: "auto_accept",
+          label: "Auto Accept",
+          value: true,
+        },
+      ],
+      availableModes: [
+        { id: "build", label: "Build" },
+        { id: "plan", label: "Plan" },
+        { id: "paseo-custom", label: "Paseo Custom" },
+      ],
+    } as ManagedAgent);
+    spies.agentManager.createAgent.mockResolvedValue({
+      id: "child-agent",
+      cwd: existingCwd,
+      lifecycle: "idle",
+      currentModeId: "paseo-custom",
+      availableModes: [],
+      config: { title: "Child", featureValues: { auto_accept: true } },
+    } as ManagedAgent);
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      callerAgentId: "parent-agent",
+      providerSnapshotManager: createOpenCodeManager().manager,
+      logger,
+    });
+    const tool = registeredTool(server, "create_agent");
+    await tool.handler({
+      title: "Child",
+      provider: "opencode/gpt-5.4",
+      initialPrompt: "Do work",
+    });
+
+    expect(spies.agentManager.createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modeId: "paseo-custom",
+        featureValues: { auto_accept: true },
+      }),
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it("preserves a custom OpenCode provider parent agent while inheriting auto accept", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const provider = "opencode-custom";
+    spies.agentManager.getAgent.mockReturnValue({
+      id: "parent-agent",
+      cwd: existingCwd,
+      provider,
+      currentModeId: "paseo-custom",
+      config: {
+        provider,
+        cwd: existingCwd,
+        modeId: "paseo-custom",
+        featureValues: { auto_accept: true },
+      },
+      features: [
+        {
+          type: "toggle",
+          id: "auto_accept",
+          label: "Auto Accept",
+          value: true,
+        },
+      ],
+      availableModes: [
+        { id: "build", label: "Build" },
+        { id: "plan", label: "Plan" },
+        { id: "paseo-custom", label: "Paseo Custom" },
+      ],
+    } as ManagedAgent);
+    spies.agentManager.createAgent.mockResolvedValue({
+      id: "child-agent",
+      cwd: existingCwd,
+      lifecycle: "idle",
+      currentModeId: "paseo-custom",
+      availableModes: [],
+      config: { title: "Child", featureValues: { auto_accept: true } },
+    } as ManagedAgent);
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      callerAgentId: "parent-agent",
+      providerSnapshotManager: createOpenCodeManager({ customOpenCodeProvider: provider }).manager,
+      logger,
+    });
+    const tool = registeredTool(server, "create_agent");
+    await tool.handler({
+      title: "Child",
+      provider: `${provider}/gpt-5.4`,
+      initialPrompt: "Do work",
+    });
+
+    expect(spies.agentManager.createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider,
+        modeId: "paseo-custom",
+        featureValues: { auto_accept: true },
+      }),
       undefined,
       expect.any(Object),
     );

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -13,8 +13,6 @@ import { createAgentMcpServer } from "./mcp-server.js";
 import type { AgentManager, ManagedAgent } from "./agent-manager.js";
 import type { AgentStorage, StoredAgentRecord } from "./agent-storage.js";
 import type { AgentMode, AgentProvider, ProviderSnapshotEntry } from "./agent-sdk-types.js";
-import { resolveDefaultAgentCreateConfig } from "./create-agent-mode.js";
-import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
 import { createProviderSnapshotManagerStub } from "../test-utils/session-stubs.js";
 import {
   AgentListItemPayloadSchema,
@@ -218,7 +216,6 @@ function createTerminalManagerStub(overrides: Partial<TerminalManager> = {}): Te
 }
 
 type ProviderSnapshotManagerStub = ReturnType<typeof createProviderSnapshotManagerStub>;
-const OPEN_CODE_CREATE_CONFIG_RESOLVER = new OpenCodeAgentClient(createTestLogger());
 
 interface ConfigureProviderEntry {
   provider: AgentProvider;
@@ -227,27 +224,6 @@ interface ConfigureProviderEntry {
   enabled?: boolean;
   defaultModeId?: string;
   modes?: AgentMode[];
-}
-
-function isStubParentUnattended(
-  parent: ManagedAgent | null,
-  modesByProvider: Record<string, AgentMode[]>,
-  openCodeProviderIds: Set<AgentProvider>,
-): boolean {
-  const parentModes = parent ? (modesByProvider[parent.provider] ?? []) : [];
-  const parentMode = parentModes.find((mode) => mode.id === parent?.currentModeId);
-  if (!parent || !openCodeProviderIds.has(parent.provider)) {
-    return parentMode?.isUnattended === true;
-  }
-  return (
-    parentMode?.isUnattended === true ||
-    OPEN_CODE_CREATE_CONFIG_RESOLVER.isCreateConfigUnattended({
-      modeId: parent?.currentModeId ?? null,
-      config: parent?.config ?? {},
-      features: parent?.features ?? [],
-      availableModes: parentModes,
-    })
-  );
 }
 
 // Builds a ProviderSnapshotEntry for tests that need to configure listProviders /
@@ -292,7 +268,6 @@ function configureOpenCodeProviderStub(
   stub: ProviderSnapshotManagerStub,
   options: ConfigureOpenCodeProviderStubOptions = {},
 ): void {
-  const openCodeCreateConfigResolver = new OpenCodeAgentClient(createTestLogger());
   const claudeModes: AgentMode[] = [
     { id: "default", label: "Default", description: "Ask first" },
     { id: "bypassPermissions", label: "Bypass", description: "No prompts", isUnattended: true },
@@ -350,10 +325,8 @@ function configureOpenCodeProviderStub(
     codex: codexModes,
     opencode: opencodeModes,
   };
-  const openCodeProviderIds = new Set<AgentProvider>(["opencode"]);
   if (options.customOpenCodeProvider) {
     modesByProvider[options.customOpenCodeProvider] = customOpenCodeModes;
-    openCodeProviderIds.add(options.customOpenCodeProvider);
   }
 
   stub.listRegisteredProviderIds.mockReturnValue(entries.map((entry) => entry.provider));
@@ -386,44 +359,8 @@ function configureOpenCodeProviderStub(
       provider: AgentProvider;
       requestedMode: string | undefined;
       featureValues: Record<string, unknown> | undefined;
-      parent: ManagedAgent | null;
     };
-    const parentIsUnattended = isStubParentUnattended(
-      opts.parent,
-      modesByProvider,
-      openCodeProviderIds,
-    );
-    const availableModes = modesByProvider[opts.provider] ?? [];
-    if (openCodeProviderIds.has(opts.provider)) {
-      return openCodeCreateConfigResolver.resolveCreateConfig({
-        provider: opts.provider,
-        requestedMode: opts.requestedMode,
-        featureValues: opts.featureValues,
-        parent: opts.parent
-          ? {
-              kind: "agent",
-              provider: opts.parent.provider,
-              modeId: opts.parent.currentModeId,
-              isUnattended: parentIsUnattended,
-            }
-          : null,
-        availableModes,
-      });
-    }
-    return resolveDefaultAgentCreateConfig({
-      provider: opts.provider,
-      requestedMode: opts.requestedMode,
-      featureValues: opts.featureValues,
-      parent: opts.parent
-        ? {
-            kind: "agent",
-            provider: opts.parent.provider,
-            modeId: opts.parent.currentModeId,
-            isUnattended: parentIsUnattended,
-          }
-        : null,
-      availableModes,
-    });
+    return { modeId: opts.requestedMode, featureValues: opts.featureValues };
   });
 }
 
@@ -1893,12 +1830,17 @@ describe("create_agent MCP tool", () => {
       availableModes: [],
       config: { title: "Child", featureValues: { fast_mode: true } },
     } as ManagedAgent);
+    const providerSnapshot = createOpenCodeManager();
+    providerSnapshot.stub.resolveCreateConfig.mockImplementation(async (input) => {
+      const opts = input as { featureValues: Record<string, unknown> | undefined };
+      return { modeId: undefined, featureValues: opts.featureValues };
+    });
 
     const server = await createAgentMcpServer({
       agentManager,
       agentStorage,
       callerAgentId: "parent-agent",
-      providerSnapshotManager: createOpenCodeManager().manager,
+      providerSnapshotManager: providerSnapshot.manager,
       logger,
     });
     const tool = registeredTool(server, "create_agent");
@@ -1967,10 +1909,14 @@ describe("create_agent MCP tool", () => {
 
   it("rejects an explicit mode that is not valid for the target provider", async () => {
     const { agentManager, agentStorage, spies } = createTestDeps();
+    const providerSnapshot = createOpenCodeManager();
+    providerSnapshot.stub.resolveCreateConfig.mockImplementation(async () => {
+      throw new Error("resolver rejected mode");
+    });
     const server = await createAgentMcpServer({
       agentManager,
       agentStorage,
-      providerSnapshotManager: createOpenCodeManager().manager,
+      providerSnapshotManager: providerSnapshot.manager,
       logger,
     });
     const tool = registeredTool(server, "create_agent");
@@ -1983,9 +1929,7 @@ describe("create_agent MCP tool", () => {
         settings: { modeId: "bypassPermissions" },
         initialPrompt: "Do work",
       }),
-    ).rejects.toThrow(
-      "Invalid mode 'bypassPermissions' for provider 'opencode'. Available modes: build, plan",
-    );
+    ).rejects.toThrow("resolver rejected mode");
     expect(spies.agentManager.createAgent).not.toHaveBeenCalled();
   });
 
@@ -2013,13 +1957,8 @@ describe("create_agent MCP tool", () => {
     provStub.listModes.mockResolvedValue(dynamicModes);
     provStub.resolveCreateConfig.mockImplementation(async (input) => {
       const opts = input as { requestedMode: string | undefined };
-      return resolveDefaultAgentCreateConfig({
-        provider: "codex",
-        requestedMode: opts.requestedMode,
-        featureValues: undefined,
-        parent: null,
-        availableModes: dynamicModes,
-      });
+      expect(opts.requestedMode).toBe("dynamic");
+      return { modeId: "dynamic", featureValues: undefined };
     });
     const server = await createAgentMcpServer({
       agentManager,
@@ -2044,7 +1983,7 @@ describe("create_agent MCP tool", () => {
     );
   });
 
-  it("accepts legacy OpenCode full-access as build plus auto accept", async () => {
+  it("passes resolver-returned mode and features into createAgent", async () => {
     const { agentManager, agentStorage, spies } = createTestDeps();
     spies.agentManager.createAgent.mockResolvedValue({
       id: "child-agent",
@@ -2054,10 +1993,15 @@ describe("create_agent MCP tool", () => {
       availableModes: [],
       config: { title: "Child", featureValues: { auto_accept: true } },
     } as ManagedAgent);
+    const providerSnapshot = createOpenCodeManager();
+    providerSnapshot.stub.resolveCreateConfig.mockResolvedValue({
+      modeId: "build",
+      featureValues: { auto_accept: true },
+    });
     const server = await createAgentMcpServer({
       agentManager,
       agentStorage,
-      providerSnapshotManager: createOpenCodeManager().manager,
+      providerSnapshotManager: providerSnapshot.manager,
       logger,
     });
     const tool = registeredTool(server, "create_agent");
@@ -2077,28 +2021,34 @@ describe("create_agent MCP tool", () => {
     );
   });
 
-  it("inherits the caller mode when the new agent uses the same provider", async () => {
+  it("passes the real parent agent and explicit unattended intent to the resolver", async () => {
     const { agentManager, agentStorage, spies } = createTestDeps();
-    spies.agentManager.getAgent.mockReturnValue({
+    const parentAgent = {
       id: "parent-agent",
       cwd: existingCwd,
       provider: "claude",
       currentModeId: "bypassPermissions",
-    } as ManagedAgent);
+    } as ManagedAgent;
+    spies.agentManager.getAgent.mockReturnValue(parentAgent);
     spies.agentManager.createAgent.mockResolvedValue({
       id: "child-agent",
       cwd: existingCwd,
       lifecycle: "idle",
-      currentModeId: "bypassPermissions",
+      currentModeId: "resolver-mode",
       availableModes: [],
       config: { title: "Child" },
     } as ManagedAgent);
+    const providerSnapshot = createOpenCodeManager();
+    providerSnapshot.stub.resolveCreateConfig.mockResolvedValue({
+      modeId: "resolver-mode",
+      featureValues: { resolver_feature: true },
+    });
 
     const server = await createAgentMcpServer({
       agentManager,
       agentStorage,
       callerAgentId: "parent-agent",
-      providerSnapshotManager: createOpenCodeManager().manager,
+      providerSnapshotManager: providerSnapshot.manager,
       logger,
     });
     const tool = registeredTool(server, "create_agent");
@@ -2108,235 +2058,13 @@ describe("create_agent MCP tool", () => {
       initialPrompt: "Do work",
     });
 
-    expect(spies.agentManager.createAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ modeId: "bypassPermissions" }),
-      undefined,
-      expect.any(Object),
+    expect(providerSnapshot.stub.resolveCreateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ parent: parentAgent, unattended: false }),
     );
-  });
-
-  it("refuses cross-provider mode inheritance when caller is not in an unattended mode", async () => {
-    const { agentManager, agentStorage, spies } = createTestDeps();
-    spies.agentManager.getAgent.mockReturnValue({
-      id: "parent-agent",
-      cwd: existingCwd,
-      provider: "claude",
-      currentModeId: "default",
-    } as ManagedAgent);
-
-    const server = await createAgentMcpServer({
-      agentManager,
-      agentStorage,
-      callerAgentId: "parent-agent",
-      providerSnapshotManager: createOpenCodeManager().manager,
-      logger,
-    });
-    const tool = registeredTool(server, "create_agent");
-
-    await expect(
-      tool.handler({
-        title: "Child",
-        provider: "opencode/gpt-5.4",
-        initialPrompt: "Do work",
-      }),
-    ).rejects.toThrow(
-      "cannot inherit mode 'default' from caller (provider 'claude') for new agent (provider 'opencode'). Pass an explicit mode. Available modes for 'opencode': build, plan",
-    );
-    expect(spies.agentManager.createAgent).not.toHaveBeenCalled();
-  });
-
-  it("maps unattended callers to OpenCode auto accept", async () => {
-    const { agentManager, agentStorage, spies } = createTestDeps();
-    spies.agentManager.getAgent.mockReturnValue({
-      id: "parent-agent",
-      cwd: existingCwd,
-      provider: "claude",
-      currentModeId: "bypassPermissions",
-    } as ManagedAgent);
-    spies.agentManager.createAgent.mockResolvedValue({
-      id: "child-agent",
-      cwd: existingCwd,
-      lifecycle: "idle",
-      currentModeId: "build",
-      availableModes: [],
-      config: { title: "Child", featureValues: { auto_accept: true } },
-    } as ManagedAgent);
-
-    const server = await createAgentMcpServer({
-      agentManager,
-      agentStorage,
-      callerAgentId: "parent-agent",
-      providerSnapshotManager: createOpenCodeManager().manager,
-      logger,
-    });
-    const tool = registeredTool(server, "create_agent");
-    await tool.handler({
-      title: "Child",
-      provider: "opencode/gpt-5.4",
-      initialPrompt: "Do work",
-    });
-
-    expect(spies.agentManager.createAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ modeId: "build", featureValues: { auto_accept: true } }),
-      undefined,
-      expect.any(Object),
-    );
-  });
-
-  it("maps unattended Claude callers to Codex full access", async () => {
-    const { agentManager, agentStorage, spies } = createTestDeps();
-    spies.agentManager.getAgent.mockReturnValue({
-      id: "parent-agent",
-      cwd: existingCwd,
-      provider: "claude",
-      currentModeId: "bypassPermissions",
-    } as ManagedAgent);
-    spies.agentManager.createAgent.mockResolvedValue({
-      id: "child-agent",
-      cwd: existingCwd,
-      lifecycle: "idle",
-      currentModeId: "full-access",
-      availableModes: [],
-      config: { title: "Child", modeId: "full-access" },
-    } as ManagedAgent);
-
-    const server = await createAgentMcpServer({
-      agentManager,
-      agentStorage,
-      callerAgentId: "parent-agent",
-      providerSnapshotManager: createOpenCodeManager().manager,
-      logger,
-    });
-    const tool = registeredTool(server, "create_agent");
-    await tool.handler({
-      title: "Child",
-      provider: "codex/gpt-5.4",
-      initialPrompt: "Do work",
-    });
-
-    expect(spies.agentManager.createAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ modeId: "full-access" }),
-      undefined,
-      expect.any(Object),
-    );
-  });
-
-  it("preserves an OpenCode custom parent agent while inheriting auto accept", async () => {
-    const { agentManager, agentStorage, spies } = createTestDeps();
-    spies.agentManager.getAgent.mockReturnValue({
-      id: "parent-agent",
-      cwd: existingCwd,
-      provider: "opencode",
-      currentModeId: "paseo-custom",
-      config: {
-        provider: "opencode",
-        cwd: existingCwd,
-        modeId: "paseo-custom",
-        featureValues: { auto_accept: true },
-      },
-      features: [
-        {
-          type: "toggle",
-          id: "auto_accept",
-          label: "Auto Accept",
-          value: true,
-        },
-      ],
-      availableModes: [
-        { id: "build", label: "Build" },
-        { id: "plan", label: "Plan" },
-        { id: "paseo-custom", label: "Paseo Custom" },
-      ],
-    } as ManagedAgent);
-    spies.agentManager.createAgent.mockResolvedValue({
-      id: "child-agent",
-      cwd: existingCwd,
-      lifecycle: "idle",
-      currentModeId: "paseo-custom",
-      availableModes: [],
-      config: { title: "Child", featureValues: { auto_accept: true } },
-    } as ManagedAgent);
-
-    const server = await createAgentMcpServer({
-      agentManager,
-      agentStorage,
-      callerAgentId: "parent-agent",
-      providerSnapshotManager: createOpenCodeManager().manager,
-      logger,
-    });
-    const tool = registeredTool(server, "create_agent");
-    await tool.handler({
-      title: "Child",
-      provider: "opencode/gpt-5.4",
-      initialPrompt: "Do work",
-    });
-
     expect(spies.agentManager.createAgent).toHaveBeenCalledWith(
       expect.objectContaining({
-        modeId: "paseo-custom",
-        featureValues: { auto_accept: true },
-      }),
-      undefined,
-      expect.any(Object),
-    );
-  });
-
-  it("preserves a custom OpenCode provider parent agent while inheriting auto accept", async () => {
-    const { agentManager, agentStorage, spies } = createTestDeps();
-    const provider = "opencode-custom";
-    spies.agentManager.getAgent.mockReturnValue({
-      id: "parent-agent",
-      cwd: existingCwd,
-      provider,
-      currentModeId: "paseo-custom",
-      config: {
-        provider,
-        cwd: existingCwd,
-        modeId: "paseo-custom",
-        featureValues: { auto_accept: true },
-      },
-      features: [
-        {
-          type: "toggle",
-          id: "auto_accept",
-          label: "Auto Accept",
-          value: true,
-        },
-      ],
-      availableModes: [
-        { id: "build", label: "Build" },
-        { id: "plan", label: "Plan" },
-        { id: "paseo-custom", label: "Paseo Custom" },
-      ],
-    } as ManagedAgent);
-    spies.agentManager.createAgent.mockResolvedValue({
-      id: "child-agent",
-      cwd: existingCwd,
-      lifecycle: "idle",
-      currentModeId: "paseo-custom",
-      availableModes: [],
-      config: { title: "Child", featureValues: { auto_accept: true } },
-    } as ManagedAgent);
-
-    const server = await createAgentMcpServer({
-      agentManager,
-      agentStorage,
-      callerAgentId: "parent-agent",
-      providerSnapshotManager: createOpenCodeManager({ customOpenCodeProvider: provider }).manager,
-      logger,
-    });
-    const tool = registeredTool(server, "create_agent");
-    await tool.handler({
-      title: "Child",
-      provider: `${provider}/gpt-5.4`,
-      initialPrompt: "Do work",
-    });
-
-    expect(spies.agentManager.createAgent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider,
-        modeId: "paseo-custom",
-        featureValues: { auto_accept: true },
+        modeId: "resolver-mode",
+        featureValues: { resolver_feature: true },
       }),
       undefined,
       expect.any(Object),

--- a/packages/server/src/server/agent/model-catalog.e2e.test.ts
+++ b/packages/server/src/server/agent/model-catalog.e2e.test.ts
@@ -40,15 +40,23 @@ describe("provider model catalogs (e2e)", () => {
   }, 180_000);
 
   test.runIf(hasCodex)(
-    "Codex catalog exposes gpt-5.1-codex",
+    "Codex catalog exposes normalized models",
     async () => {
       const ctx = await createDaemonTestContext();
       try {
         const result = await ctx.client.listProviderModels("codex");
 
         expect(result.error).toBeNull();
-        const ids = result.models.map((model) => model.id);
-        expect(ids.some((id) => id.includes("codex"))).toBe(true);
+        expect(result.models.length).toBeGreaterThan(0);
+        expect(result.models).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              provider: "codex",
+              id: expect.any(String),
+              label: expect.any(String),
+            }),
+          ]),
+        );
       } finally {
         await ctx.cleanup();
       }
@@ -66,17 +74,15 @@ describe("provider model catalogs (e2e)", () => {
         expect(result.error).toBeNull();
         expect(result.models.length).toBeGreaterThan(0);
 
-        for (const model of result.models) {
-          expect(model.provider).toBe("opencode");
-          expect(model.id).toContain("/");
-          expect(model.label).toBeTruthy();
-          expect(model.metadata).toBeDefined();
-          expect(model.metadata?.providerId).toBeTruthy();
-          expect(model.metadata?.modelId).toBeTruthy();
-        }
-
-        const providerIds = new Set(result.models.map((m) => m.metadata?.providerId));
-        expect(providerIds.size).toBeGreaterThan(0);
+        expect(result.models).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              provider: "opencode",
+              id: expect.any(String),
+              label: expect.any(String),
+            }),
+          ]),
+        );
       } finally {
         await ctx.cleanup();
       }

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -4,10 +4,13 @@ import { describe, expect, test, vi } from "vitest";
 import { createTestLogger } from "../../test-utils/test-logger.js";
 import type {
   AgentClient,
+  AgentMode,
   AgentModelDefinition,
   AgentProvider,
   ListModelsOptions,
+  ResolveAgentCreateConfigInput,
 } from "./agent-sdk-types.js";
+import type { ManagedAgent } from "./agent-manager.js";
 import { ProviderSnapshotManager } from "./provider-snapshot-manager.js";
 
 const TEST_CAPABILITIES = {
@@ -305,6 +308,143 @@ describe("ProviderSnapshotManager public surface", () => {
       expect(state.clients.claude).toBe(claudeClient);
       expect(state.providerDefinitions.opencode).toMatchObject({ enabled: false });
       expect(state.providerDefinitions.codex).toMatchObject({ enabled: true });
+    } finally {
+      manager.destroy();
+    }
+  });
+
+  test("resolveCreateConfig reduces a managed parent to provider mode and unattended data", async () => {
+    const resolverInputs: ResolveAgentCreateConfigInput[] = [];
+    const childModes: AgentMode[] = [
+      { id: "child-unattended", label: "Child", isUnattended: true },
+    ];
+    const parentModes: AgentMode[] = [
+      { id: "parent-unattended", label: "Parent", isUnattended: true },
+    ];
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      providerOverrides: {
+        copilot: { enabled: false },
+        opencode: { enabled: false },
+        pi: { enabled: false },
+      },
+      extraClients: {
+        codex: createExtraClient("codex", {
+          async isAvailable() {
+            return true;
+          },
+          async listModes() {
+            return childModes;
+          },
+          async resolveCreateConfig(input) {
+            resolverInputs.push(input);
+            return {
+              modeId: input.parent?.isUnattended ? "child-unattended" : undefined,
+              featureValues: undefined,
+            };
+          },
+        }),
+        claude: createExtraClient("claude", {
+          async isAvailable() {
+            return true;
+          },
+          async listModes() {
+            return parentModes;
+          },
+          isCreateConfigUnattended(input) {
+            return input.modeId === "parent-unattended";
+          },
+        }),
+      },
+    });
+    try {
+      const parent = {
+        id: "parent-agent",
+        provider: "claude",
+        currentModeId: "parent-unattended",
+        availableModes: parentModes,
+        config: { provider: "claude", cwd: "/tmp/project" },
+      } as ManagedAgent;
+
+      const resolved = await manager.resolveCreateConfig({
+        cwd: "/tmp/project",
+        provider: "codex",
+        requestedMode: undefined,
+        featureValues: undefined,
+        parent,
+        unattended: false,
+      });
+
+      expect(resolved).toEqual({ modeId: "child-unattended", featureValues: undefined });
+      expect(resolverInputs).toEqual([
+        {
+          provider: "codex",
+          requestedMode: undefined,
+          featureValues: undefined,
+          parent: {
+            provider: "claude",
+            modeId: "parent-unattended",
+            isUnattended: true,
+          },
+          unattended: true,
+          availableModes: childModes,
+        },
+      ]);
+    } finally {
+      manager.destroy();
+    }
+  });
+
+  test("resolveCreateConfig passes explicit unattended intent to provider policy", async () => {
+    const resolverInputs: ResolveAgentCreateConfigInput[] = [];
+    const modes: AgentMode[] = [{ id: "worker", label: "Worker", isUnattended: true }];
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      providerOverrides: {
+        claude: { enabled: false },
+        copilot: { enabled: false },
+        opencode: { enabled: false },
+        pi: { enabled: false },
+      },
+      extraClients: {
+        codex: createExtraClient("codex", {
+          async isAvailable() {
+            return true;
+          },
+          async listModes() {
+            return modes;
+          },
+          async resolveCreateConfig(input) {
+            resolverInputs.push(input);
+            return {
+              modeId: input.unattended ? "worker" : undefined,
+              featureValues: undefined,
+            };
+          },
+        }),
+      },
+    });
+    try {
+      const resolved = await manager.resolveCreateConfig({
+        cwd: "/tmp/project",
+        provider: "codex",
+        requestedMode: undefined,
+        featureValues: { fast_mode: true },
+        parent: null,
+        unattended: true,
+      });
+
+      expect(resolved).toEqual({ modeId: "worker", featureValues: undefined });
+      expect(resolverInputs).toEqual([
+        {
+          provider: "codex",
+          requestedMode: undefined,
+          featureValues: { fast_mode: true },
+          parent: null,
+          unattended: true,
+          availableModes: modes,
+        },
+      ]);
     } finally {
       manager.destroy();
     }

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -8,6 +8,7 @@ import { expandTilde } from "../../utils/path.js";
 import { withTimeout } from "../../utils/promise-timeout.js";
 import type {
   AgentClient,
+  AgentCreateConfigParent,
   AgentMode,
   AgentModelDefinition,
   AgentProvider,
@@ -64,6 +65,12 @@ interface ResolveProviderCreateConfigOptions {
   requestedMode: string | undefined;
   featureValues: Record<string, unknown> | undefined;
   parent: ManagedAgent | null;
+}
+
+export interface ResolveUnattendedProviderCreateConfigOptions {
+  cwd?: string | null;
+  provider: AgentProvider;
+  featureValues: Record<string, unknown> | undefined;
 }
 
 export interface ResolvedProviderCreateConfig {
@@ -310,6 +317,26 @@ export class ProviderSnapshotManager {
     });
   }
 
+  async resolveUnattendedCreateConfig(
+    input: ResolveUnattendedProviderCreateConfigOptions,
+  ): Promise<ResolvedProviderCreateConfig> {
+    const entry = await this.getReadyProvider({
+      cwd: input.cwd,
+      provider: input.provider,
+      wait: true,
+    });
+    const definition = this.requireProvider(input.provider);
+    return definition.resolveCreateConfig({
+      provider: input.provider,
+      requestedMode: undefined,
+      featureValues: input.featureValues,
+      parent: {
+        kind: "system-unattended",
+      },
+      availableModes: entry.modes ?? [],
+    });
+  }
+
   async getProviderDiagnostic(provider: AgentProvider): Promise<ProviderDiagnosticResult> {
     const client = this.providerClients[provider];
     if (!client) {
@@ -377,9 +404,10 @@ export class ProviderSnapshotManager {
     });
   }
 
-  private resolveParent(parent: ManagedAgent) {
+  private resolveParent(parent: ManagedAgent): AgentCreateConfigParent {
     const definition = this.requireProvider(parent.provider);
     return {
+      kind: "agent",
       provider: parent.provider,
       modeId: parent.currentModeId,
       isUnattended: definition.isCreateConfigUnattended({

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -59,18 +59,13 @@ interface ProviderSnapshotProviderOptions {
   wait?: boolean;
 }
 
-interface ResolveProviderCreateConfigOptions {
+export interface ResolveProviderCreateConfigOptions {
   cwd?: string | null;
   provider: AgentProvider;
   requestedMode: string | undefined;
   featureValues: Record<string, unknown> | undefined;
   parent: ManagedAgent | null;
-}
-
-export interface ResolveUnattendedProviderCreateConfigOptions {
-  cwd?: string | null;
-  provider: AgentProvider;
-  featureValues: Record<string, unknown> | undefined;
+  unattended: boolean;
 }
 
 export interface ResolvedProviderCreateConfig {
@@ -308,31 +303,13 @@ export class ProviderSnapshotManager {
       wait: true,
     });
     const definition = this.requireProvider(input.provider);
+    const parent = input.parent ? this.resolveParent(input.parent) : null;
     return definition.resolveCreateConfig({
       provider: input.provider,
       requestedMode: input.requestedMode,
       featureValues: input.featureValues,
-      parent: input.parent ? this.resolveParent(input.parent) : null,
-      availableModes: entry.modes ?? [],
-    });
-  }
-
-  async resolveUnattendedCreateConfig(
-    input: ResolveUnattendedProviderCreateConfigOptions,
-  ): Promise<ResolvedProviderCreateConfig> {
-    const entry = await this.getReadyProvider({
-      cwd: input.cwd,
-      provider: input.provider,
-      wait: true,
-    });
-    const definition = this.requireProvider(input.provider);
-    return definition.resolveCreateConfig({
-      provider: input.provider,
-      requestedMode: undefined,
-      featureValues: input.featureValues,
-      parent: {
-        kind: "system-unattended",
-      },
+      parent,
+      unattended: input.unattended || parent?.isUnattended === true,
       availableModes: entry.modes ?? [],
     });
   }
@@ -396,18 +373,36 @@ export class ProviderSnapshotManager {
   }
 
   private buildRegistry(): Record<AgentProvider, ProviderDefinition> {
-    return buildProviderRegistry(this.logger, {
+    const registry = buildProviderRegistry(this.logger, {
       runtimeSettings: this.runtimeSettings,
       providerOverrides: this.providerOverrides,
       workspaceGitService: this.workspaceGitService,
       isDev: this.isDev,
     });
+
+    for (const [provider, client] of Object.entries(this.extraClients) as Array<
+      [AgentProvider, AgentClient]
+    >) {
+      const definition = registry[provider];
+      if (!definition) continue;
+      registry[provider] = {
+        ...definition,
+        createClient: () => client,
+        resolveCreateConfig:
+          client.resolveCreateConfig?.bind(client) ?? definition.resolveCreateConfig,
+        isCreateConfigUnattended:
+          client.isCreateConfigUnattended?.bind(client) ?? definition.isCreateConfigUnattended,
+        fetchModels: client.listModels.bind(client),
+        fetchModes: client.listModes?.bind(client) ?? definition.fetchModes,
+      };
+    }
+
+    return registry;
   }
 
   private resolveParent(parent: ManagedAgent): AgentCreateConfigParent {
     const definition = this.requireProvider(parent.provider);
     return {
-      kind: "agent",
       provider: parent.provider,
       modeId: parent.currentModeId,
       isUnattended: definition.isCreateConfigUnattended({

--- a/packages/server/src/server/agent/providers/opencode-agent.full-access.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.full-access.test.ts
@@ -134,6 +134,7 @@ describe("OpenCode auto_accept feature", () => {
         requestedMode: "full-access",
         featureValues: undefined,
         parent: null,
+        unattended: false,
         availableModes: [
           { id: "build", label: "Build" },
           { id: "plan", label: "Plan" },
@@ -151,11 +152,11 @@ describe("OpenCode auto_accept feature", () => {
         requestedMode: undefined,
         featureValues: undefined,
         parent: {
-          kind: "agent",
           provider: "claude",
           modeId: "bypassPermissions",
           isUnattended: true,
         },
+        unattended: true,
         availableModes: [
           { id: "build", label: "Build" },
           { id: "plan", label: "Plan" },
@@ -164,7 +165,7 @@ describe("OpenCode auto_accept feature", () => {
     ).toEqual({ modeId: "build", featureValues: { auto_accept: true } });
   });
 
-  test("defaults system unattended creation to build plus auto accept", () => {
+  test("defaults unattended creation without a parent to build plus auto accept", () => {
     const client = new OpenCodeAgentClient(createTestLogger());
 
     expect(
@@ -172,7 +173,8 @@ describe("OpenCode auto_accept feature", () => {
         provider: "opencode",
         requestedMode: undefined,
         featureValues: undefined,
-        parent: { kind: "system-unattended" },
+        parent: null,
+        unattended: true,
         availableModes: [
           { id: "build", label: "Build" },
           { id: "plan", label: "Plan" },
@@ -190,11 +192,11 @@ describe("OpenCode auto_accept feature", () => {
         requestedMode: undefined,
         featureValues: undefined,
         parent: {
-          kind: "agent",
           provider: "opencode",
           modeId: "paseo-custom",
           isUnattended: true,
         },
+        unattended: true,
         availableModes: [
           { id: "build", label: "Build" },
           { id: "plan", label: "Plan" },

--- a/packages/server/src/server/agent/providers/opencode-agent.full-access.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.full-access.test.ts
@@ -151,6 +151,7 @@ describe("OpenCode auto_accept feature", () => {
         requestedMode: undefined,
         featureValues: undefined,
         parent: {
+          kind: "agent",
           provider: "claude",
           modeId: "bypassPermissions",
           isUnattended: true,
@@ -161,6 +162,46 @@ describe("OpenCode auto_accept feature", () => {
         ],
       }),
     ).toEqual({ modeId: "build", featureValues: { auto_accept: true } });
+  });
+
+  test("defaults system unattended creation to build plus auto accept", () => {
+    const client = new OpenCodeAgentClient(createTestLogger());
+
+    expect(
+      client.resolveCreateConfig({
+        provider: "opencode",
+        requestedMode: undefined,
+        featureValues: undefined,
+        parent: { kind: "system-unattended" },
+        availableModes: [
+          { id: "build", label: "Build" },
+          { id: "plan", label: "Plan" },
+        ],
+      }),
+    ).toEqual({ modeId: "build", featureValues: { auto_accept: true } });
+  });
+
+  test("preserves the selected OpenCode agent when inheriting auto accept from an OpenCode parent", () => {
+    const client = new OpenCodeAgentClient(createTestLogger());
+
+    expect(
+      client.resolveCreateConfig({
+        provider: "opencode",
+        requestedMode: undefined,
+        featureValues: undefined,
+        parent: {
+          kind: "agent",
+          provider: "opencode",
+          modeId: "paseo-custom",
+          isUnattended: true,
+        },
+        availableModes: [
+          { id: "build", label: "Build" },
+          { id: "plan", label: "Plan" },
+          { id: "paseo-custom", label: "Paseo Custom" },
+        ],
+      }),
+    ).toEqual({ modeId: "paseo-custom", featureValues: { auto_accept: true } });
   });
 
   test("auto-approves tool permissions when auto accept is enabled", async () => {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -133,11 +133,9 @@ function resolveOpenCodeCreateConfig(
   const legacyFullAccess = input.requestedMode === OPENCODE_LEGACY_FULL_ACCESS_MODE_ID;
   const parent = input.parent;
   const inheritsUnattended =
-    input.requestedMode === undefined &&
-    parent !== null &&
-    (parent.kind === "system-unattended" || parent.isUnattended === true);
+    input.requestedMode === undefined && (input.unattended || parent?.isUnattended === true);
   const inheritedOpenCodeMode =
-    inheritsUnattended && parent?.kind === "agent" && parent.provider === input.provider
+    inheritsUnattended && parent?.provider === input.provider
       ? (parent.modeId ?? undefined)
       : undefined;
   const requestedMode = legacyFullAccess

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -131,9 +131,18 @@ function resolveOpenCodeCreateConfig(
   input: ResolveAgentCreateConfigInput,
 ): ResolveAgentCreateConfigResult {
   const legacyFullAccess = input.requestedMode === OPENCODE_LEGACY_FULL_ACCESS_MODE_ID;
+  const parent = input.parent;
   const inheritsUnattended =
-    input.requestedMode === undefined && input.parent?.isUnattended === true;
-  const requestedMode = legacyFullAccess ? OPENCODE_BUILD_MODE_ID : input.requestedMode;
+    input.requestedMode === undefined &&
+    parent !== null &&
+    (parent.kind === "system-unattended" || parent.isUnattended === true);
+  const inheritedOpenCodeMode =
+    inheritsUnattended && parent?.kind === "agent" && parent.provider === input.provider
+      ? (parent.modeId ?? undefined)
+      : undefined;
+  const requestedMode = legacyFullAccess
+    ? OPENCODE_BUILD_MODE_ID
+    : (input.requestedMode ?? inheritedOpenCodeMode);
   const featureValues =
     legacyFullAccess ||
     (inheritsUnattended && input.featureValues?.[OPENCODE_AUTO_ACCEPT_FEATURE_ID] === undefined)

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -597,6 +597,7 @@ export async function createPaseoDaemon(
     paseoHome: config.paseoHome,
     logger,
     agentManager,
+    providerSnapshotManager,
   });
   await loopService.initialize();
   logger.info({ elapsed: elapsed() }, "Loop service initialized");
@@ -605,6 +606,7 @@ export async function createPaseoDaemon(
     logger,
     agentManager,
     agentStorage,
+    providerSnapshotManager,
   });
   await scheduleService.start();
   agentManager.setAgentArchivedCallback(async (agentId) => {

--- a/packages/server/src/server/daemon-e2e/live-preferences.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/live-preferences.e2e.test.ts
@@ -39,12 +39,39 @@ function waitForAgentUpdate(
   });
 }
 
-function pickTwoDistinctModels(models: Array<{ id: string }>): [string, string] {
+function pickModelSwitchPair(provider: string, models: Array<{ id: string }>): [string, string] {
   const ids = Array.from(new Set(models.map((m) => m.id))).filter(Boolean);
-  if (ids.length < 2) {
-    throw new Error(`Need at least 2 models to test switching; got ${ids.length}`);
+  const first = ids[0];
+  if (!first) {
+    throw new Error(`No models returned for provider ${provider}`);
   }
-  return [ids[0], ids[1]];
+  return [first, ids[1] ?? `${first}-switch-target`];
+}
+
+function pickThinkingSwitchOption(
+  provider: string,
+  models: Array<{
+    thinkingOptions?: Array<{ id: string }>;
+    defaultThinkingOptionId?: string;
+  }>,
+): { model: (typeof models)[number]; thinkingOptionId: string } {
+  const modelWithOptions = models.find((m) => (m.thinkingOptions?.length ?? 0) > 0);
+  if (!modelWithOptions) {
+    const first = models[0];
+    if (!first) {
+      throw new Error(`No ${provider} models returned`);
+    }
+    return { model: first, thinkingOptionId: "test-thinking-option" };
+  }
+
+  const defaultThinkingId = modelWithOptions.defaultThinkingOptionId ?? "default";
+  const thinkingOptionId =
+    modelWithOptions.thinkingOptions?.find((o) => o.id !== defaultThinkingId)?.id ??
+    modelWithOptions.thinkingOptions?.[0]?.id;
+  if (!thinkingOptionId) {
+    throw new Error(`No ${provider} thinking option found`);
+  }
+  return { model: modelWithOptions, thinkingOptionId };
 }
 
 function isBinaryInstalled(binary: string): boolean {
@@ -92,7 +119,7 @@ describe.each(["claude", "codex", "opencode"] as const)("live model switching (%
         if (!modelList.models || modelList.models.length === 0) {
           throw new Error(`No models returned for provider ${provider}`);
         }
-        const [modelA, modelB] = pickTwoDistinctModels(modelList.models);
+        const [modelA, modelB] = pickModelSwitchPair(provider, modelList.models);
 
         const agent = await ctx.client.createAgent({
           provider,
@@ -162,18 +189,10 @@ test.runIf(hasCodex)(
         throw new Error("No Codex models returned");
       }
 
-      const modelWithOptions = modelList.models.find((m) => (m.thinkingOptions?.length ?? 0) > 1);
-      if (!modelWithOptions) {
-        throw new Error("No Codex model with thinkingOptions returned");
-      }
-      const defaultThinkingId = modelWithOptions.defaultThinkingOptionId ?? "default";
-      const nonDefault =
-        modelWithOptions.thinkingOptions?.find((o) => o.id !== defaultThinkingId)?.id ??
-        modelWithOptions.thinkingOptions?.[0]?.id ??
-        null;
-      if (!nonDefault) {
-        throw new Error("No non-default Codex thinking option found");
-      }
+      const { model: modelWithOptions, thinkingOptionId } = pickThinkingSwitchOption(
+        "Codex",
+        modelList.models,
+      );
 
       const agent = await ctx.client.createAgent({
         provider: "codex",
@@ -183,16 +202,16 @@ test.runIf(hasCodex)(
       });
 
       const startIndex = messages.length;
-      await ctx.client.setAgentThinkingOption(agent.id, nonDefault);
+      await ctx.client.setAgentThinkingOption(agent.id, thinkingOptionId);
 
       const updated = await waitForAgentUpdate(
         messages,
         startIndex,
-        (a) => a.id === agent.id && a.thinkingOptionId === nonDefault,
+        (a) => a.id === agent.id && a.thinkingOptionId === thinkingOptionId,
         { timeoutMs: 20000 },
       );
 
-      expect(updated.thinkingOptionId).toBe(nonDefault);
+      expect(updated.thinkingOptionId).toBe(thinkingOptionId);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
@@ -210,12 +229,10 @@ test.runIf(hasOpenCode)(
         throw new Error("No OpenCode models returned");
       }
 
-      const modelWithThinkingOptions = modelList.models.find(
-        (m) => (m.thinkingOptions?.length ?? 0) > 1,
+      const { model: modelWithThinkingOptions, thinkingOptionId } = pickThinkingSwitchOption(
+        "OpenCode",
+        modelList.models,
       );
-      if (!modelWithThinkingOptions) {
-        throw new Error("No OpenCode model with thinkingOptions returned");
-      }
 
       const agent = await ctx.client.createAgent({
         provider: "opencode",
@@ -224,23 +241,15 @@ test.runIf(hasOpenCode)(
         model: modelWithThinkingOptions.id,
       });
 
-      const defaultThinkingId = modelWithThinkingOptions.defaultThinkingOptionId ?? "default";
-      const thinkingId =
-        modelWithThinkingOptions.thinkingOptions?.find((o) => o.id !== defaultThinkingId)?.id ??
-        modelWithThinkingOptions.thinkingOptions?.[0]?.id ??
-        null;
-      if (!thinkingId) {
-        throw new Error("No non-default OpenCode thinking option found");
-      }
       const startIndex = messages.length;
-      await ctx.client.setAgentThinkingOption(agent.id, thinkingId);
+      await ctx.client.setAgentThinkingOption(agent.id, thinkingOptionId);
       const updatedThinking = await waitForAgentUpdate(
         messages,
         startIndex,
-        (a) => a.id === agent.id && a.thinkingOptionId === thinkingId,
+        (a) => a.id === agent.id && a.thinkingOptionId === thinkingOptionId,
         { timeoutMs: 20000 },
       );
-      expect(updatedThinking.thinkingOptionId).toBe(thinkingId);
+      expect(updatedThinking.thinkingOptionId).toBe(thinkingOptionId);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/packages/server/src/server/loop-service.test.ts
+++ b/packages/server/src/server/loop-service.test.ts
@@ -45,8 +45,9 @@ const TEST_CAPABILITIES: AgentCapabilityFlags = {
   supportsToolInvocations: false,
 };
 
-const NO_UNATTENDED_LOOP_POLICY: Pick<ProviderSnapshotManager, "resolveUnattendedCreateConfig"> = {
-  async resolveUnattendedCreateConfig(input) {
+const NO_UNATTENDED_LOOP_POLICY: Pick<ProviderSnapshotManager, "resolveCreateConfig"> = {
+  async resolveCreateConfig(input) {
+    expect(input).toMatchObject({ parent: null, unattended: true, requestedMode: undefined });
     return { modeId: undefined, featureValues: input.featureValues };
   },
 };
@@ -504,7 +505,8 @@ describe("LoopService", () => {
       agentManager: manager,
       logger,
       providerSnapshotManager: {
-        async resolveUnattendedCreateConfig(input) {
+        async resolveCreateConfig(input) {
+          expect(input).toMatchObject({ parent: null, unattended: true, requestedMode: undefined });
           return { modeId: "bypassPermissions", featureValues: input.featureValues };
         },
       },
@@ -558,7 +560,8 @@ describe("LoopService", () => {
       agentManager: manager,
       logger,
       providerSnapshotManager: {
-        async resolveUnattendedCreateConfig(input) {
+        async resolveCreateConfig(input) {
+          expect(input).toMatchObject({ parent: null, unattended: true, requestedMode: undefined });
           return {
             modeId: "build",
             featureValues: { ...input.featureValues, auto_accept: true },

--- a/packages/server/src/server/loop-service.test.ts
+++ b/packages/server/src/server/loop-service.test.ts
@@ -31,6 +31,7 @@ import type {
 } from "./agent/agent-sdk-types.js";
 import { AgentStorage } from "./agent/agent-storage.js";
 import { AgentManager } from "./agent/agent-manager.js";
+import type { ProviderSnapshotManager } from "./agent/provider-snapshot-manager.js";
 import { LoopService } from "./loop-service.js";
 import { isPlatform } from "../test-utils/platform.js";
 import { createTestLogger } from "../test-utils/test-logger.js";
@@ -42,6 +43,12 @@ const TEST_CAPABILITIES: AgentCapabilityFlags = {
   supportsMcpServers: false,
   supportsReasoningStream: false,
   supportsToolInvocations: false,
+};
+
+const NO_UNATTENDED_LOOP_POLICY: Pick<ProviderSnapshotManager, "resolveUnattendedCreateConfig"> = {
+  async resolveUnattendedCreateConfig(input) {
+    return { modeId: undefined, featureValues: input.featureValues };
+  },
 };
 
 interface ScriptedAgentBehavior {
@@ -266,7 +273,12 @@ describe("LoopService", () => {
         registry: storage,
         logger,
       });
-      const service = new LoopService({ paseoHome, agentManager: manager, logger });
+      const service = new LoopService({
+        paseoHome,
+        agentManager: manager,
+        logger,
+        providerSnapshotManager: NO_UNATTENDED_LOOP_POLICY,
+      });
       await service.initialize();
 
       const loop = await service.runLoop({
@@ -317,7 +329,12 @@ describe("LoopService", () => {
       registry: storage,
       logger,
     });
-    const service = new LoopService({ paseoHome, agentManager: manager, logger });
+    const service = new LoopService({
+      paseoHome,
+      agentManager: manager,
+      logger,
+      providerSnapshotManager: NO_UNATTENDED_LOOP_POLICY,
+    });
     await service.initialize();
 
     const loop = await service.runLoop({
@@ -378,7 +395,12 @@ describe("LoopService", () => {
       archivedAgentIds.push(agentId);
       await archiveAgent(agentId);
     };
-    const service = new LoopService({ paseoHome, agentManager: manager, logger });
+    const service = new LoopService({
+      paseoHome,
+      agentManager: manager,
+      logger,
+      providerSnapshotManager: NO_UNATTENDED_LOOP_POLICY,
+    });
     await service.initialize();
 
     const loop = await service.runLoop({
@@ -430,7 +452,12 @@ describe("LoopService", () => {
       registry: storage,
       logger,
     });
-    const service = new LoopService({ paseoHome, agentManager: manager, logger });
+    const service = new LoopService({
+      paseoHome,
+      agentManager: manager,
+      logger,
+      providerSnapshotManager: NO_UNATTENDED_LOOP_POLICY,
+    });
     await service.initialize();
 
     const loop = await service.runLoop({
@@ -472,7 +499,16 @@ describe("LoopService", () => {
       registry: storage,
       logger,
     });
-    const service = new LoopService({ paseoHome, agentManager: manager, logger });
+    const service = new LoopService({
+      paseoHome,
+      agentManager: manager,
+      logger,
+      providerSnapshotManager: {
+        async resolveUnattendedCreateConfig(input) {
+          return { modeId: "bypassPermissions", featureValues: input.featureValues };
+        },
+      },
+    });
     await service.initialize();
 
     const loop = await service.runLoop({
@@ -486,6 +522,70 @@ describe("LoopService", () => {
 
     expect(workerConfigs[0]?.modeId).toBe("bypassPermissions");
     expect(verifierConfigs[0]?.modeId).toBe("bypassPermissions");
+  });
+
+  test("defaults OpenCode workers and verifiers to build plus auto accept", async () => {
+    class CapturingScriptedAgentClient extends ScriptedAgentClient {
+      readonly createdConfigs: AgentSessionConfig[] = [];
+
+      override async createSession(
+        config: AgentSessionConfig,
+        launchContext?: AgentLaunchContext,
+      ): Promise<AgentSession> {
+        this.createdConfigs.push(config);
+        return super.createSession(config, launchContext);
+      }
+    }
+
+    const opencodeClient = new CapturingScriptedAgentClient("opencode", {
+      async onRun({ config }) {
+        if (config.title?.includes("worker")) {
+          writeFileSync(path.join(workspaceDir, "done.txt"), "ok");
+          return "created done.txt";
+        }
+        return '{"passed":true,"reason":"ok"}';
+      },
+    });
+    const manager = new AgentManager({
+      clients: {
+        opencode: opencodeClient,
+      },
+      registry: storage,
+      logger,
+    });
+    const service = new LoopService({
+      paseoHome,
+      agentManager: manager,
+      logger,
+      providerSnapshotManager: {
+        async resolveUnattendedCreateConfig(input) {
+          return {
+            modeId: "build",
+            featureValues: { ...input.featureValues, auto_accept: true },
+          };
+        },
+      },
+    });
+    await service.initialize();
+
+    const loop = await service.runLoop({
+      prompt: "Create done.txt",
+      cwd: workspaceDir,
+      provider: "opencode",
+      verifyPrompt: "Confirm that done.txt exists in the workspace.",
+      maxIterations: 1,
+    });
+
+    await waitForLoopCompletion(service, loop.id);
+
+    expect(opencodeClient.createdConfigs[0]).toMatchObject({
+      modeId: "build",
+      featureValues: { auto_accept: true },
+    });
+    expect(opencodeClient.createdConfigs[1]).toMatchObject({
+      modeId: "build",
+      featureValues: { auto_accept: true },
+    });
   });
 
   test("explicit modeId wins over unattended default", async () => {
@@ -508,7 +608,12 @@ describe("LoopService", () => {
       registry: storage,
       logger,
     });
-    const service = new LoopService({ paseoHome, agentManager: manager, logger });
+    const service = new LoopService({
+      paseoHome,
+      agentManager: manager,
+      logger,
+      providerSnapshotManager: NO_UNATTENDED_LOOP_POLICY,
+    });
     await service.initialize();
 
     const loop = await service.runLoop({
@@ -546,7 +651,12 @@ describe("LoopService", () => {
       registry: storage,
       logger,
     });
-    const service = new LoopService({ paseoHome, agentManager: manager, logger });
+    const service = new LoopService({
+      paseoHome,
+      agentManager: manager,
+      logger,
+      providerSnapshotManager: NO_UNATTENDED_LOOP_POLICY,
+    });
     await service.initialize();
 
     const loop = await service.runLoop({

--- a/packages/server/src/server/loop-service.ts
+++ b/packages/server/src/server/loop-service.ts
@@ -14,7 +14,11 @@ import type {
   AgentProvider,
 } from "./agent/agent-sdk-types.js";
 import { execCommand, platformShell } from "../utils/spawn.js";
-import { getUnattendedModeId } from "@getpaseo/protocol/provider-manifest";
+import type {
+  ProviderSnapshotManager,
+  ResolvedProviderCreateConfig,
+  ResolveUnattendedProviderCreateConfigOptions,
+} from "./agent/provider-snapshot-manager.js";
 
 const LOOP_ID_LENGTH = 8;
 const DEFAULT_LOOP_PROVIDER: AgentProvider = "claude";
@@ -206,6 +210,11 @@ function buildVerifierTitle(loop: LoopRecord, iterationIndex: number): string {
   return `${prefix} [loop ${iterationIndex} verifier]`;
 }
 
+type UnattendedCreateConfigResolver = Pick<
+  ProviderSnapshotManager,
+  "resolveUnattendedCreateConfig"
+>;
+
 function formatStreamLog(event: AgentStreamEvent): string | null {
   switch (event.type) {
     case "timeline": {
@@ -304,6 +313,7 @@ export class LoopService {
       paseoHome: string;
       agentManager: AgentManager;
       logger: Logger;
+      providerSnapshotManager: UnattendedCreateConfigResolver;
     },
   ) {
     this.storePath = path.join(options.paseoHome, "loops", "loops.json");
@@ -613,7 +623,7 @@ export class LoopService {
     signal: AbortSignal,
   ): Promise<boolean> {
     const agent = await this.options.agentManager.createAgent(
-      this.buildWorkerConfig(loop, iteration),
+      await this.buildWorkerConfig(loop, iteration),
     );
     iteration.workerAgentId = agent.id;
     loop.activeWorkerAgentId = agent.id;
@@ -720,7 +730,7 @@ export class LoopService {
 
     const startedAt = nowIso();
     const verifierAgent = await this.options.agentManager.createAgent(
-      this.buildVerifierConfig(loop, iteration),
+      await this.buildVerifierConfig(loop, iteration),
     );
     iteration.verifierAgentId = verifierAgent.id;
     loop.activeVerifierAgentId = verifierAgent.id;
@@ -795,31 +805,53 @@ export class LoopService {
     }
   }
 
-  private buildWorkerConfig(loop: LoopRecord, iteration: LoopIterationRecord): AgentSessionConfig {
+  private async buildWorkerConfig(
+    loop: LoopRecord,
+    iteration: LoopIterationRecord,
+  ): Promise<AgentSessionConfig> {
     const provider = loop.workerProvider ?? loop.provider;
+    const resolvedUnattendedConfig = loop.modeId
+      ? { modeId: loop.modeId, featureValues: undefined }
+      : await this.resolveUnattendedCreateConfig({ provider, cwd: loop.cwd });
     return {
       provider,
       cwd: loop.cwd,
       model: loop.workerModel ?? loop.model ?? undefined,
-      modeId: loop.modeId ?? getUnattendedModeId(provider),
+      modeId: resolvedUnattendedConfig.modeId,
+      featureValues: resolvedUnattendedConfig.featureValues,
       title: buildWorkerTitle(loop, iteration.index),
       internal: true,
     };
   }
 
-  private buildVerifierConfig(
+  private async buildVerifierConfig(
     loop: LoopRecord,
     iteration: LoopIterationRecord,
-  ): AgentSessionConfig {
+  ): Promise<AgentSessionConfig> {
     const provider = loop.verifierProvider ?? loop.provider;
+    const explicitModeId = loop.verifierModeId ?? loop.modeId;
+    const resolvedUnattendedConfig = explicitModeId
+      ? { modeId: explicitModeId, featureValues: undefined }
+      : await this.resolveUnattendedCreateConfig({ provider, cwd: loop.cwd });
     return {
       provider,
       cwd: loop.cwd,
       model: loop.verifierModel ?? loop.model ?? undefined,
-      modeId: loop.verifierModeId ?? loop.modeId ?? getUnattendedModeId(provider),
+      modeId: resolvedUnattendedConfig.modeId,
+      featureValues: resolvedUnattendedConfig.featureValues,
       title: buildVerifierTitle(loop, iteration.index),
       internal: true,
     };
+  }
+
+  private resolveUnattendedCreateConfig(
+    input: Pick<ResolveUnattendedProviderCreateConfigOptions, "provider" | "cwd">,
+  ): Promise<ResolvedProviderCreateConfig> {
+    return this.options.providerSnapshotManager.resolveUnattendedCreateConfig({
+      provider: input.provider,
+      cwd: input.cwd,
+      featureValues: undefined,
+    });
   }
 
   private resolveFinalText(timeline: AgentTimelineItem[], finalText: string): string {

--- a/packages/server/src/server/loop-service.ts
+++ b/packages/server/src/server/loop-service.ts
@@ -17,7 +17,7 @@ import { execCommand, platformShell } from "../utils/spawn.js";
 import type {
   ProviderSnapshotManager,
   ResolvedProviderCreateConfig,
-  ResolveUnattendedProviderCreateConfigOptions,
+  ResolveProviderCreateConfigOptions,
 } from "./agent/provider-snapshot-manager.js";
 
 const LOOP_ID_LENGTH = 8;
@@ -210,10 +210,7 @@ function buildVerifierTitle(loop: LoopRecord, iterationIndex: number): string {
   return `${prefix} [loop ${iterationIndex} verifier]`;
 }
 
-type UnattendedCreateConfigResolver = Pick<
-  ProviderSnapshotManager,
-  "resolveUnattendedCreateConfig"
->;
+type CreateConfigResolver = Pick<ProviderSnapshotManager, "resolveCreateConfig">;
 
 function formatStreamLog(event: AgentStreamEvent): string | null {
   switch (event.type) {
@@ -313,7 +310,7 @@ export class LoopService {
       paseoHome: string;
       agentManager: AgentManager;
       logger: Logger;
-      providerSnapshotManager: UnattendedCreateConfigResolver;
+      providerSnapshotManager: CreateConfigResolver;
     },
   ) {
     this.storePath = path.join(options.paseoHome, "loops", "loops.json");
@@ -812,7 +809,7 @@ export class LoopService {
     const provider = loop.workerProvider ?? loop.provider;
     const resolvedUnattendedConfig = loop.modeId
       ? { modeId: loop.modeId, featureValues: undefined }
-      : await this.resolveUnattendedCreateConfig({ provider, cwd: loop.cwd });
+      : await this.resolveProviderCreateConfig({ provider, cwd: loop.cwd });
     return {
       provider,
       cwd: loop.cwd,
@@ -832,7 +829,7 @@ export class LoopService {
     const explicitModeId = loop.verifierModeId ?? loop.modeId;
     const resolvedUnattendedConfig = explicitModeId
       ? { modeId: explicitModeId, featureValues: undefined }
-      : await this.resolveUnattendedCreateConfig({ provider, cwd: loop.cwd });
+      : await this.resolveProviderCreateConfig({ provider, cwd: loop.cwd });
     return {
       provider,
       cwd: loop.cwd,
@@ -844,13 +841,16 @@ export class LoopService {
     };
   }
 
-  private resolveUnattendedCreateConfig(
-    input: Pick<ResolveUnattendedProviderCreateConfigOptions, "provider" | "cwd">,
+  private resolveProviderCreateConfig(
+    input: Pick<ResolveProviderCreateConfigOptions, "provider" | "cwd">,
   ): Promise<ResolvedProviderCreateConfig> {
-    return this.options.providerSnapshotManager.resolveUnattendedCreateConfig({
+    return this.options.providerSnapshotManager.resolveCreateConfig({
       provider: input.provider,
       cwd: input.cwd,
+      requestedMode: undefined,
       featureValues: undefined,
+      parent: null,
+      unattended: true,
     });
   }
 

--- a/packages/server/src/server/schedule/service.test.ts
+++ b/packages/server/src/server/schedule/service.test.ts
@@ -39,11 +39,9 @@ const SCHEDULE_TEST_CAPABILITIES: AgentCapabilityFlags = {
   supportsToolInvocations: true,
 };
 
-const NO_UNATTENDED_SCHEDULE_POLICY: Pick<
-  ProviderSnapshotManager,
-  "resolveUnattendedCreateConfig"
-> = {
-  async resolveUnattendedCreateConfig(input) {
+const NO_UNATTENDED_SCHEDULE_POLICY: Pick<ProviderSnapshotManager, "resolveCreateConfig"> = {
+  async resolveCreateConfig(input) {
+    expect(input).toMatchObject({ parent: null, unattended: true, requestedMode: undefined });
     return { modeId: undefined, featureValues: input.featureValues };
   },
 };
@@ -407,7 +405,8 @@ describe("ScheduleService", () => {
       agentManager: manager,
       agentStorage,
       providerSnapshotManager: {
-        async resolveUnattendedCreateConfig(input) {
+        async resolveCreateConfig(input) {
+          expect(input).toMatchObject({ parent: null, unattended: true, requestedMode: undefined });
           return { modeId: "bypassPermissions", featureValues: input.featureValues };
         },
       },
@@ -468,7 +467,8 @@ describe("ScheduleService", () => {
       agentManager: manager,
       agentStorage,
       providerSnapshotManager: {
-        async resolveUnattendedCreateConfig(input) {
+        async resolveCreateConfig(input) {
+          expect(input).toMatchObject({ parent: null, unattended: true, requestedMode: undefined });
           return {
             modeId: "build",
             featureValues: { ...input.featureValues, auto_accept: true },

--- a/packages/server/src/server/schedule/service.test.ts
+++ b/packages/server/src/server/schedule/service.test.ts
@@ -22,6 +22,7 @@ import type {
 } from "../agent/agent-sdk-types.js";
 import { createTestAgentClients } from "../test-utils/fake-agent-client.js";
 import { createTestLogger } from "../../test-utils/test-logger.js";
+import type { ProviderSnapshotManager } from "../agent/provider-snapshot-manager.js";
 import { ScheduleService } from "./service.js";
 import type { ScheduleExecutionResult, StoredSchedule } from "@getpaseo/protocol/schedule/types";
 
@@ -36,6 +37,15 @@ const SCHEDULE_TEST_CAPABILITIES: AgentCapabilityFlags = {
   supportsMcpServers: false,
   supportsReasoningStream: false,
   supportsToolInvocations: true,
+};
+
+const NO_UNATTENDED_SCHEDULE_POLICY: Pick<
+  ProviderSnapshotManager,
+  "resolveUnattendedCreateConfig"
+> = {
+  async resolveUnattendedCreateConfig(input) {
+    return { modeId: undefined, featureValues: input.featureValues };
+  },
 };
 
 describe("ScheduleService", () => {
@@ -64,6 +74,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async (schedule) => ({
         agentId: "00000000-0000-0000-0000-000000000001",
@@ -102,6 +113,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({
         agentId: null,
@@ -137,6 +149,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({
         agentId: null,
@@ -176,6 +189,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: manager,
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
     });
 
@@ -350,6 +364,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: manager,
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
     });
 
@@ -391,6 +406,11 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: manager,
       agentStorage,
+      providerSnapshotManager: {
+        async resolveUnattendedCreateConfig(input) {
+          return { modeId: "bypassPermissions", featureValues: input.featureValues };
+        },
+      },
       now: () => now,
     });
 
@@ -419,12 +439,76 @@ describe("ScheduleService", () => {
     expect(agent?.archivedAt).toBeTruthy();
   });
 
+  test("defaults OpenCode new-agent schedules to build plus auto accept", async () => {
+    const createdConfigs: AgentSessionConfig[] = [];
+    const clients = createTestAgentClients();
+    const opencodeClient = clients.opencode;
+    if (!opencodeClient) {
+      throw new Error("Expected OpenCode test client");
+    }
+    clients.opencode = {
+      provider: opencodeClient.provider,
+      capabilities: opencodeClient.capabilities,
+      createSession: async (...args) => {
+        createdConfigs.push(args[0]);
+        return opencodeClient.createSession(...args);
+      },
+      resumeSession: (...args) => opencodeClient.resumeSession(...args),
+      listModels: (...args) => opencodeClient.listModels(...args),
+      isAvailable: () => opencodeClient.isAvailable(),
+    } satisfies AgentClient;
+    const manager = new AgentManager({
+      logger: createTestLogger(),
+      clients,
+      registry: agentStorage,
+    });
+    const service = new ScheduleService({
+      paseoHome: tempDir,
+      logger: createTestLogger(),
+      agentManager: manager,
+      agentStorage,
+      providerSnapshotManager: {
+        async resolveUnattendedCreateConfig(input) {
+          return {
+            modeId: "build",
+            featureValues: { ...input.featureValues, auto_accept: true },
+          };
+        },
+      },
+      now: () => now,
+    });
+
+    const created = await service.create({
+      prompt: "Respond with exactly hello",
+      cadence: { type: "every", everyMs: 60_000 },
+      target: {
+        type: "new-agent",
+        config: {
+          provider: "opencode",
+          cwd: tempDir,
+        },
+      },
+      maxRuns: 1,
+    });
+
+    now = new Date("2026-01-01T00:01:00.000Z");
+    await service.tick();
+
+    const inspected = await service.inspect(created.id);
+    expect(inspected.runs[0]?.error).toBeNull();
+    expect(createdConfigs[0]).toMatchObject({
+      modeId: "build",
+      featureValues: { auto_accept: true },
+    });
+  });
+
   test("advances stale nextRunAt on daemon restart", async () => {
     const service1 = new ScheduleService({
       paseoHome: tempDir,
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -449,6 +533,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -474,6 +559,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => {
         releaseRun?.();
@@ -522,6 +608,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: manager,
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
     });
 
@@ -579,6 +666,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -601,6 +689,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -624,6 +713,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -646,6 +736,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -669,6 +760,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async (schedule) => ({
         agentId: "00000000-0000-0000-0000-000000000099",
@@ -704,6 +796,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -756,6 +849,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -788,6 +882,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ran" }),
     });
@@ -819,6 +914,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -844,6 +940,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -868,6 +965,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -912,6 +1010,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -942,6 +1041,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });
@@ -967,6 +1067,7 @@ describe("ScheduleService", () => {
       logger: createTestLogger(),
       agentManager: new AgentManager({ logger: createTestLogger() }),
       agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
       now: () => now,
       runner: async () => ({ agentId: null, output: "ok" }),
     });

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -7,9 +7,13 @@ import type { AgentSessionConfig } from "../agent/agent-sdk-types.js";
 import { curateAgentActivity } from "../agent/activity-curator.js";
 import { ensureAgentLoaded } from "../agent/agent-loading.js";
 import { formatSystemNotificationPrompt } from "../agent/agent-prompt.js";
-import { getUnattendedModeId } from "@getpaseo/protocol/provider-manifest";
 import { ScheduleStore } from "./store.js";
 import { computeNextRunAt, validateScheduleCadence } from "./cron.js";
+import type {
+  ProviderSnapshotManager,
+  ResolvedProviderCreateConfig,
+  ResolveUnattendedProviderCreateConfigOptions,
+} from "../agent/provider-snapshot-manager.js";
 import type {
   CreateScheduleInput,
   ScheduleExecutionResult,
@@ -134,11 +138,17 @@ function buildRunOutput(params: {
   return null;
 }
 
+type UnattendedCreateConfigResolver = Pick<
+  ProviderSnapshotManager,
+  "resolveUnattendedCreateConfig"
+>;
+
 export interface ScheduleServiceOptions {
   paseoHome: string;
   logger: Logger;
   agentManager: AgentManager;
   agentStorage: AgentStorage;
+  providerSnapshotManager: UnattendedCreateConfigResolver;
   now?: () => Date;
   runner?: (schedule: StoredSchedule, runId: string) => Promise<ScheduleExecutionResult>;
 }
@@ -148,6 +158,7 @@ export class ScheduleService {
   private readonly logger: Logger;
   private readonly agentManager: AgentManager;
   private readonly agentStorage: AgentStorage;
+  private readonly unattendedCreateConfigResolver: UnattendedCreateConfigResolver;
   private readonly now: () => Date;
   private readonly runner: (
     schedule: StoredSchedule,
@@ -161,6 +172,7 @@ export class ScheduleService {
     this.logger = options.logger.child({ module: "schedule-service" });
     this.agentManager = options.agentManager;
     this.agentStorage = options.agentStorage;
+    this.unattendedCreateConfigResolver = options.providerSnapshotManager;
     this.now = options.now ?? (() => new Date());
     this.runner = options.runner ?? ((schedule, runId) => this.executeSchedule(schedule, runId));
   }
@@ -547,21 +559,29 @@ export class ScheduleService {
       };
     }
 
+    const targetConfig = schedule.target.config;
+    const resolvedUnattendedConfig = targetConfig.modeId
+      ? { modeId: targetConfig.modeId, featureValues: targetConfig.featureValues }
+      : await this.resolveUnattendedCreateConfig({
+          provider: targetConfig.provider,
+          cwd: targetConfig.cwd,
+          featureValues: targetConfig.featureValues,
+        });
     const config: AgentSessionConfig = {
-      provider: schedule.target.config.provider,
-      cwd: schedule.target.config.cwd,
-      modeId: schedule.target.config.modeId ?? getUnattendedModeId(schedule.target.config.provider),
-      model: schedule.target.config.model,
-      thinkingOptionId: schedule.target.config.thinkingOptionId,
-      title: schedule.target.config.title,
-      approvalPolicy: schedule.target.config.approvalPolicy,
-      sandboxMode: schedule.target.config.sandboxMode,
-      networkAccess: schedule.target.config.networkAccess,
-      webSearch: schedule.target.config.webSearch,
-      featureValues: schedule.target.config.featureValues,
-      extra: schedule.target.config.extra,
-      systemPrompt: schedule.target.config.systemPrompt,
-      mcpServers: schedule.target.config.mcpServers as AgentSessionConfig["mcpServers"],
+      provider: targetConfig.provider,
+      cwd: targetConfig.cwd,
+      modeId: resolvedUnattendedConfig.modeId,
+      model: targetConfig.model,
+      thinkingOptionId: targetConfig.thinkingOptionId,
+      title: targetConfig.title,
+      approvalPolicy: targetConfig.approvalPolicy,
+      sandboxMode: targetConfig.sandboxMode,
+      networkAccess: targetConfig.networkAccess,
+      webSearch: targetConfig.webSearch,
+      featureValues: resolvedUnattendedConfig.featureValues,
+      extra: targetConfig.extra,
+      systemPrompt: targetConfig.systemPrompt,
+      mcpServers: targetConfig.mcpServers as AgentSessionConfig["mcpServers"],
     };
     const labels = {
       "paseo.schedule-id": schedule.id,
@@ -593,5 +613,11 @@ export class ScheduleService {
         finalText: result.finalText,
       }),
     };
+  }
+
+  private async resolveUnattendedCreateConfig(
+    input: ResolveUnattendedProviderCreateConfigOptions,
+  ): Promise<ResolvedProviderCreateConfig> {
+    return this.unattendedCreateConfigResolver.resolveUnattendedCreateConfig(input);
   }
 }

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -12,7 +12,7 @@ import { computeNextRunAt, validateScheduleCadence } from "./cron.js";
 import type {
   ProviderSnapshotManager,
   ResolvedProviderCreateConfig,
-  ResolveUnattendedProviderCreateConfigOptions,
+  ResolveProviderCreateConfigOptions,
 } from "../agent/provider-snapshot-manager.js";
 import type {
   CreateScheduleInput,
@@ -138,17 +138,14 @@ function buildRunOutput(params: {
   return null;
 }
 
-type UnattendedCreateConfigResolver = Pick<
-  ProviderSnapshotManager,
-  "resolveUnattendedCreateConfig"
->;
+type CreateConfigResolver = Pick<ProviderSnapshotManager, "resolveCreateConfig">;
 
 export interface ScheduleServiceOptions {
   paseoHome: string;
   logger: Logger;
   agentManager: AgentManager;
   agentStorage: AgentStorage;
-  providerSnapshotManager: UnattendedCreateConfigResolver;
+  providerSnapshotManager: CreateConfigResolver;
   now?: () => Date;
   runner?: (schedule: StoredSchedule, runId: string) => Promise<ScheduleExecutionResult>;
 }
@@ -158,7 +155,7 @@ export class ScheduleService {
   private readonly logger: Logger;
   private readonly agentManager: AgentManager;
   private readonly agentStorage: AgentStorage;
-  private readonly unattendedCreateConfigResolver: UnattendedCreateConfigResolver;
+  private readonly createConfigResolver: CreateConfigResolver;
   private readonly now: () => Date;
   private readonly runner: (
     schedule: StoredSchedule,
@@ -172,7 +169,7 @@ export class ScheduleService {
     this.logger = options.logger.child({ module: "schedule-service" });
     this.agentManager = options.agentManager;
     this.agentStorage = options.agentStorage;
-    this.unattendedCreateConfigResolver = options.providerSnapshotManager;
+    this.createConfigResolver = options.providerSnapshotManager;
     this.now = options.now ?? (() => new Date());
     this.runner = options.runner ?? ((schedule, runId) => this.executeSchedule(schedule, runId));
   }
@@ -562,10 +559,13 @@ export class ScheduleService {
     const targetConfig = schedule.target.config;
     const resolvedUnattendedConfig = targetConfig.modeId
       ? { modeId: targetConfig.modeId, featureValues: targetConfig.featureValues }
-      : await this.resolveUnattendedCreateConfig({
+      : await this.resolveProviderCreateConfig({
           provider: targetConfig.provider,
           cwd: targetConfig.cwd,
+          requestedMode: undefined,
           featureValues: targetConfig.featureValues,
+          parent: null,
+          unattended: true,
         });
     const config: AgentSessionConfig = {
       provider: targetConfig.provider,
@@ -615,9 +615,9 @@ export class ScheduleService {
     };
   }
 
-  private async resolveUnattendedCreateConfig(
-    input: ResolveUnattendedProviderCreateConfigOptions,
+  private async resolveProviderCreateConfig(
+    input: ResolveProviderCreateConfigOptions,
   ): Promise<ResolvedProviderCreateConfig> {
-    return this.unattendedCreateConfigResolver.resolveUnattendedCreateConfig(input);
+    return this.createConfigResolver.resolveCreateConfig(input);
   }
 }

--- a/packages/server/src/server/test-utils/session-stubs.ts
+++ b/packages/server/src/server/test-utils/session-stubs.ts
@@ -155,9 +155,6 @@ export interface ProviderSnapshotManagerSpies {
   listModels: ReturnType<typeof vi.fn<[unknown], Promise<AgentModelDefinition[]>>>;
   listModes: ReturnType<typeof vi.fn<[unknown], Promise<AgentMode[]>>>;
   resolveCreateConfig: ReturnType<typeof vi.fn<[unknown], Promise<ResolvedProviderCreateConfig>>>;
-  resolveUnattendedCreateConfig: ReturnType<
-    typeof vi.fn<[unknown], Promise<ResolvedProviderCreateConfig>>
-  >;
   resolveDefaultModel: ReturnType<typeof vi.fn<[unknown], Promise<string | undefined>>>;
   getProviderDiagnostic: ReturnType<
     typeof vi.fn<[AgentProvider], Promise<ProviderDiagnosticResult>>
@@ -196,12 +193,6 @@ export function createProviderSnapshotManagerStub(): {
     modeId: undefined,
     featureValues: undefined,
   }));
-  const resolveUnattendedCreateConfig = vi.fn<[unknown], Promise<ResolvedProviderCreateConfig>>(
-    async () => ({
-      modeId: undefined,
-      featureValues: undefined,
-    }),
-  );
   const resolveDefaultModel = vi.fn<[unknown], Promise<string | undefined>>(async () => undefined);
   const getProviderDiagnostic = vi.fn<[AgentProvider], Promise<ProviderDiagnosticResult>>(
     async (provider) => ({ provider, diagnostic: "No diagnostic available for this provider." }),
@@ -227,7 +218,6 @@ export function createProviderSnapshotManagerStub(): {
     listModels,
     listModes,
     resolveCreateConfig,
-    resolveUnattendedCreateConfig,
     resolveDefaultModel,
     getProviderDiagnostic,
     applyMutableProviderConfig,
@@ -253,7 +243,6 @@ export function createProviderSnapshotManagerStub(): {
     listModels,
     listModes,
     resolveCreateConfig,
-    resolveUnattendedCreateConfig,
     resolveDefaultModel,
     getProviderDiagnostic,
     applyMutableProviderConfig,

--- a/packages/server/src/server/test-utils/session-stubs.ts
+++ b/packages/server/src/server/test-utils/session-stubs.ts
@@ -155,6 +155,9 @@ export interface ProviderSnapshotManagerSpies {
   listModels: ReturnType<typeof vi.fn<[unknown], Promise<AgentModelDefinition[]>>>;
   listModes: ReturnType<typeof vi.fn<[unknown], Promise<AgentMode[]>>>;
   resolveCreateConfig: ReturnType<typeof vi.fn<[unknown], Promise<ResolvedProviderCreateConfig>>>;
+  resolveUnattendedCreateConfig: ReturnType<
+    typeof vi.fn<[unknown], Promise<ResolvedProviderCreateConfig>>
+  >;
   resolveDefaultModel: ReturnType<typeof vi.fn<[unknown], Promise<string | undefined>>>;
   getProviderDiagnostic: ReturnType<
     typeof vi.fn<[AgentProvider], Promise<ProviderDiagnosticResult>>
@@ -193,6 +196,12 @@ export function createProviderSnapshotManagerStub(): {
     modeId: undefined,
     featureValues: undefined,
   }));
+  const resolveUnattendedCreateConfig = vi.fn<[unknown], Promise<ResolvedProviderCreateConfig>>(
+    async () => ({
+      modeId: undefined,
+      featureValues: undefined,
+    }),
+  );
   const resolveDefaultModel = vi.fn<[unknown], Promise<string | undefined>>(async () => undefined);
   const getProviderDiagnostic = vi.fn<[AgentProvider], Promise<ProviderDiagnosticResult>>(
     async (provider) => ({ provider, diagnostic: "No diagnostic available for this provider." }),
@@ -218,6 +227,7 @@ export function createProviderSnapshotManagerStub(): {
     listModels,
     listModes,
     resolveCreateConfig,
+    resolveUnattendedCreateConfig,
     resolveDefaultModel,
     getProviderDiagnostic,
     applyMutableProviderConfig,
@@ -243,6 +253,7 @@ export function createProviderSnapshotManagerStub(): {
     listModels,
     listModes,
     resolveCreateConfig,
+    resolveUnattendedCreateConfig,
     resolveDefaultModel,
     getProviderDiagnostic,
     applyMutableProviderConfig,


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

This fixes child agent creation when a broad-permission parent starts a child through a provider that expresses unattended access differently.

Broad-permission parent agents can now create child agents across providers without failing on mismatched mode IDs. Provider-specific unattended settings are translated through one server policy path, and feature-valued unattended settings are preserved where the target provider supports them. Scheduled and loop-created unattended agents use the same policy path.

Scope is server-only: no app, CLI, or protocol changes.

### How did you verify it

- `npm run format` passed.
- `npm run format:check` passed.
- `npm run typecheck` passed.
- `npm run lint` passed.
- Targeted server Vitest passed: `npx vitest run src/server/agent/mcp-server.test.ts src/server/agent/create-agent-mode.test.ts src/server/agent/provider-snapshot-manager.test.ts src/server/agent/providers/opencode-agent.full-access.test.ts src/server/schedule/service.test.ts src/server/loop-service.test.ts --bail=1` — 6 files / 166 tests.
- Stale-shape search over server production/tests found no old resolver unions, sentinels, or removed resolver names.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

### Risk surface

Server-only behavior change. The main review surface is unattended child creation across different provider catalogs and explicit-mode requests continuing to win over inferred unattended defaults.