### PR TITLE
Prioritize ready actions and scheduled agent prompts

### DIFF
--- a/packages/app/src/git/policy.test.ts
+++ b/packages/app/src/git/policy.test.ts
@@ -366,45 +366,62 @@ describe("git-actions-policy", () => {
     );
   });
 
-  it("respects the ship preference when choosing between PR merge and local merge", () => {
-    const prPreferredActions = buildGitActions(
+  it("promotes ready PR merge over update-from-base", () => {
+    const actions = buildGitActions(
       createInput({
         hasRemote: true,
         isOnBaseBranch: false,
         aheadCount: 2,
+        behindBaseCount: 3,
         hasPullRequest: true,
         pullRequestUrl: "https://example.com/pr/456",
         pullRequestState: "open",
         pullRequestMergeable: "MERGEABLE",
-        pullRequestGithub: githubStatus(),
-        shipDefault: "pr",
-      }),
-    );
-    const localMergePreferredActions = buildGitActions(
-      createInput({
-        hasRemote: true,
-        isOnBaseBranch: false,
-        aheadCount: 2,
-        hasPullRequest: true,
-        pullRequestUrl: "https://example.com/pr/456",
-        pullRequestState: "open",
-        pullRequestMergeable: "MERGEABLE",
-        pullRequestGithub: githubStatus(),
-        shipDefault: "merge",
+        pullRequestGithub: githubStatus({ mergeStateStatus: "CLEAN" }),
       }),
     );
 
-    expect(prPreferredActions.primary).toMatchObject({
+    expect(actions.primary).toMatchObject({
       id: "merge-pr-squash",
       label: "Squash and merge",
     });
-    expect(localMergePreferredActions.primary).toMatchObject({
+  });
+
+  it("promotes local merge over update-from-base", () => {
+    const actions = buildGitActions(
+      createInput({
+        hasRemote: true,
+        isOnBaseBranch: false,
+        aheadCount: 2,
+        behindBaseCount: 3,
+      }),
+    );
+
+    expect(actions.primary).toMatchObject({
       id: "merge-branch",
       label: "Merge locally",
     });
-    expect(
-      localMergePreferredActions.secondary.some((action) => action.id === "merge-pr-squash"),
-    ).toBe(true);
+  });
+
+  it("promotes ready PR merge over local merge", () => {
+    const actions = buildGitActions(
+      createInput({
+        hasRemote: true,
+        isOnBaseBranch: false,
+        aheadCount: 2,
+        hasPullRequest: true,
+        pullRequestUrl: "https://example.com/pr/456",
+        pullRequestState: "open",
+        pullRequestMergeable: "MERGEABLE",
+        pullRequestGithub: githubStatus(),
+      }),
+    );
+
+    expect(actions.primary).toMatchObject({
+      id: "merge-pr-squash",
+      label: "Squash and merge",
+    });
+    expect(actions.secondary.some((action) => action.id === "merge-branch")).toBe(true);
   });
 
   it("keeps the merge-pr actions in the feature branch menu", () => {
@@ -648,7 +665,7 @@ describe("git-actions-policy", () => {
       }),
     );
 
-    expect(actions.primary).toMatchObject({ id: "pr", label: "View PR" });
+    expect(actions.primary).toMatchObject({ id: "merge-branch", label: "Merge locally" });
     expect(actions.secondary.some((action) => action.id.startsWith("enable-pr-auto-merge"))).toBe(
       false,
     );
@@ -748,7 +765,7 @@ describe("git-actions-policy", () => {
       }),
     );
 
-    expect(actions.primary).toMatchObject({ id: "pr", label: "View PR" });
+    expect(actions.primary).toMatchObject({ id: "merge-branch", label: "Merge locally" });
     expect(
       actions.secondary.some((action) =>
         ["merge-pr-squash", "merge-pr-merge", "merge-pr-rebase"].includes(action.id),

--- a/packages/app/src/git/policy.ts
+++ b/packages/app/src/git/policy.ts
@@ -336,22 +336,19 @@ function getPrimaryActionId(input: BuildGitActionsInput): GitActionId | null {
   if (canPush(input)) {
     return "push";
   }
+  if (canMergePr(input)) {
+    return getDefaultDirectPullRequestMergeActionId(input);
+  }
+  if (canEnablePrAutoMerge(input)) {
+    return getDefaultEnablePullRequestAutoMergeActionId(input);
+  }
+  if (!input.isOnBaseBranch && input.aheadCount > 0) {
+    return "merge-branch";
+  }
   if (!input.isOnBaseBranch && canMergeFromBase(input)) {
     return "merge-from-base";
   }
-  if (canMergePr(input) && input.shipDefault === "pr") {
-    return getDefaultDirectPullRequestMergeActionId(input);
-  }
-  if (canEnablePrAutoMerge(input) && input.shipDefault === "pr") {
-    return getDefaultEnablePullRequestAutoMergeActionId(input);
-  }
-  if (!input.isOnBaseBranch && input.aheadCount > 0 && input.shipDefault === "merge") {
-    return "merge-branch";
-  }
   if (input.githubFeaturesEnabled && input.hasPullRequest && input.pullRequestUrl) {
-    return "pr";
-  }
-  if (!input.isOnBaseBranch && input.aheadCount > 0) {
     return "pr";
   }
   return null;

--- a/packages/app/src/screens/sessions-screen.tsx
+++ b/packages/app/src/screens/sessions-screen.tsx
@@ -44,7 +44,7 @@ function SessionsScreenContent({ serverId }: { serverId: string }) {
   }, [isRevalidating, isManualRefresh]);
 
   const sortedAgents = useMemo(() => {
-    return [...agents].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    return [...agents].sort((a, b) => b.lastActivityAt.getTime() - a.lastActivityAt.getTime());
   }, [agents]);
 
   const handleBack = useCallback(() => {

--- a/packages/server/src/server/schedule/service.test.ts
+++ b/packages/server/src/server/schedule/service.test.ts
@@ -216,6 +216,212 @@ describe("ScheduleService", () => {
     );
   });
 
+  test("titles scheduled new agents from the schedule prompt", async () => {
+    const manager = new AgentManager({
+      logger: createTestLogger(),
+      clients: createTestAgentClients(),
+      registry: agentStorage,
+    });
+    const service = new ScheduleService({
+      paseoHome: tempDir,
+      logger: createTestLogger(),
+      agentManager: manager,
+      agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
+      now: () => now,
+    });
+
+    const created = await service.create({
+      prompt: "Audit flaky checkout flow\n\nReport only blockers.",
+      cadence: { type: "every", everyMs: 60_000 },
+      target: {
+        type: "new-agent",
+        config: {
+          provider: "claude",
+          cwd: tempDir,
+          approvalPolicy: "never",
+        },
+      },
+      maxRuns: 1,
+    });
+
+    now = new Date("2026-01-01T00:01:00.000Z");
+    await service.tick();
+
+    const inspected = await service.inspect(created.id);
+    const agentId = inspected.runs[0]?.agentId;
+    expect(agentId).toMatch(/^[0-9a-f-]{36}$/);
+    const storedAgent = await agentStorage.get(agentId!);
+    expect(storedAgent?.title).toBe("Audit flaky checkout flow");
+  });
+
+  test("shows scheduled new-agent prompts as normal user turns", async () => {
+    class PromptEchoScheduleSession implements AgentSession {
+      readonly provider = "claude";
+      readonly capabilities = SCHEDULE_TEST_CAPABILITIES;
+      readonly id = "scheduled-prompt-echo-session";
+      private turnCount = 0;
+      private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
+
+      async run(_prompt: AgentPromptInput, _options?: AgentRunOptions): Promise<AgentRunResult> {
+        return {
+          sessionId: this.id,
+          finalText: "done",
+          timeline: [{ type: "assistant_message", text: "done" }],
+        };
+      }
+
+      async startTurn(prompt: AgentPromptInput): Promise<{ turnId: string }> {
+        const turnId = `turn-${++this.turnCount}`;
+        const textPrompt = typeof prompt === "string" ? prompt : JSON.stringify(prompt);
+        setImmediate(() => {
+          this.emit({ type: "turn_started", provider: this.provider, turnId });
+          this.emit({
+            type: "timeline",
+            provider: this.provider,
+            turnId,
+            item: { type: "user_message", text: textPrompt },
+          });
+          this.emit({
+            type: "timeline",
+            provider: this.provider,
+            turnId,
+            item: { type: "assistant_message", text: "done" },
+          });
+          this.emit({
+            type: "turn_completed",
+            provider: this.provider,
+            turnId,
+            usage: { inputTokens: 1, outputTokens: 1 },
+          });
+        });
+        return { turnId };
+      }
+
+      subscribe(callback: (event: AgentStreamEvent) => void): () => void {
+        this.subscribers.add(callback);
+        return () => {
+          this.subscribers.delete(callback);
+        };
+      }
+
+      async *streamHistory(): AsyncGenerator<AgentStreamEvent> {}
+
+      async getRuntimeInfo() {
+        return {
+          provider: this.provider,
+          sessionId: this.id,
+          model: null,
+          modeId: null,
+        };
+      }
+
+      async getAvailableModes(): Promise<AgentMode[]> {
+        return [];
+      }
+
+      async getCurrentMode(): Promise<string | null> {
+        return null;
+      }
+
+      async setMode(_modeId: string): Promise<void> {}
+
+      getPendingPermissions(): AgentPermissionRequest[] {
+        return [];
+      }
+
+      async respondToPermission(
+        _requestId: string,
+        _response: AgentPermissionResponse,
+      ): Promise<void> {}
+
+      describePersistence(): AgentPersistenceHandle {
+        return {
+          provider: this.provider,
+          sessionId: this.id,
+        };
+      }
+
+      async interrupt(): Promise<void> {}
+
+      async close(): Promise<void> {}
+
+      private emit(event: AgentStreamEvent): void {
+        for (const subscriber of this.subscribers) {
+          subscriber(event);
+        }
+      }
+    }
+
+    class PromptEchoScheduleClient implements AgentClient {
+      readonly provider = "claude";
+      readonly capabilities = SCHEDULE_TEST_CAPABILITIES;
+
+      async createSession(_config: AgentSessionConfig): Promise<AgentSession> {
+        return new PromptEchoScheduleSession();
+      }
+
+      async resumeSession(_handle: AgentPersistenceHandle): Promise<AgentSession> {
+        return new PromptEchoScheduleSession();
+      }
+
+      async listModels(_options: ListModelsOptions): Promise<AgentModelDefinition[]> {
+        return [];
+      }
+
+      async isAvailable(): Promise<boolean> {
+        return true;
+      }
+    }
+
+    const manager = new AgentManager({
+      logger: createTestLogger(),
+      clients: { claude: new PromptEchoScheduleClient() },
+      registry: agentStorage,
+    });
+    const service = new ScheduleService({
+      paseoHome: tempDir,
+      logger: createTestLogger(),
+      agentManager: manager,
+      agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
+      now: () => now,
+    });
+    const observedUserMessages: string[] = [];
+    const unsubscribe = manager.subscribe((event) => {
+      if (event.type !== "agent_stream" || event.event.type !== "timeline") {
+        return;
+      }
+      if (event.event.item.type === "user_message") {
+        observedUserMessages.push(event.event.item.text);
+      }
+    });
+
+    const created = await service.create({
+      prompt: "Audit nightly run",
+      cadence: { type: "every", everyMs: 60_000 },
+      target: {
+        type: "new-agent",
+        config: {
+          provider: "claude",
+          cwd: tempDir,
+          approvalPolicy: "never",
+        },
+      },
+      maxRuns: 1,
+    });
+
+    now = new Date("2026-01-01T00:01:00.000Z");
+    try {
+      await service.tick();
+    } finally {
+      unsubscribe();
+    }
+
+    expect(observedUserMessages).toEqual(["Audit nightly run"]);
+    expect((await service.inspect(created.id)).runs[0]?.status).toBe("succeeded");
+  });
+
   test("archives new-agent schedule sessions after the run finishes", async () => {
     class CountingScheduleSession implements AgentSession {
       readonly provider = "claude";

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -7,6 +7,7 @@ import type { AgentSessionConfig } from "../agent/agent-sdk-types.js";
 import { curateAgentActivity } from "../agent/activity-curator.js";
 import { ensureAgentLoaded } from "../agent/agent-loading.js";
 import { formatSystemNotificationPrompt } from "../agent/agent-prompt.js";
+import { resolveCreateAgentTitles } from "../agent/create-agent-title.js";
 import { ScheduleStore } from "./store.js";
 import { computeNextRunAt, validateScheduleCadence } from "./cron.js";
 import type {
@@ -528,9 +529,8 @@ export class ScheduleService {
     schedule: StoredSchedule,
     runId: string,
   ): Promise<ScheduleExecutionResult> {
-    const wrappedPrompt = formatSystemNotificationPrompt(buildScheduleFireBody(schedule, runId));
-
     if (schedule.target.type === "agent") {
+      const wrappedPrompt = formatSystemNotificationPrompt(buildScheduleFireBody(schedule, runId));
       const record = await this.agentStorage.get(schedule.target.agentId);
       if (record?.archivedAt) {
         throw new Error(`Agent ${schedule.target.agentId} is archived`);
@@ -583,14 +583,22 @@ export class ScheduleService {
       systemPrompt: targetConfig.systemPrompt,
       mcpServers: targetConfig.mcpServers as AgentSessionConfig["mcpServers"],
     };
+    const { provisionalTitle } = resolveCreateAgentTitles({
+      configTitle: config.title,
+      initialPrompt: schedule.prompt,
+    });
     const labels = {
       "paseo.schedule-id": schedule.id,
       "paseo.schedule-run": runId,
     };
-    const agent = await this.agentManager.createAgent(config, undefined, { labels });
+    const agent = await this.agentManager.createAgent(config, undefined, {
+      labels,
+      initialPrompt: schedule.prompt,
+      initialTitle: provisionalTitle,
+    });
     let result;
     try {
-      result = await this.agentManager.runAgent(agent.id, wrappedPrompt);
+      result = await this.agentManager.runAgent(agent.id, schedule.prompt);
     } catch (error) {
       try {
         await this.agentManager.archiveAgent(agent.id);


### PR DESCRIPTION
### Linked issue

Not linked.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

This PR makes ready shipping actions take priority in the git controls, sorts the sessions screen by latest activity, and fixes scheduled new-agent runs so they open with a real title and visible user prompt instead of a loading-looking tab.

Schedules that target an existing agent still use hidden system context; only schedules that create a fresh agent behave like a normal first prompt.

### How did you verify it

- `npx vitest run src/server/schedule/service.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint -- packages/server/src/server/schedule/service.ts packages/server/src/server/schedule/service.test.ts`
- `npm run format` ran before commit; pre-commit also re-ran format check, lint, and typecheck.

### Risk surface

- Git action priority changes affect which button is primary when a branch is both behind base and ready to merge; reviewers should sanity-check the intended primary action ordering in the git panel.
- Scheduled new-agent behavior now sends the schedule prompt as a normal first prompt, while existing-agent schedules remain hidden system injections.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense