### PR TITLE
fix(claude): use generic model aliases on Bedrock transport

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -420,6 +420,26 @@ describe("ClaudeAgentClient.listModels", () => {
     const defaultModel = models.find((m) => m.isDefault);
     expect(defaultModel?.id).toBe("claude-opus-4-8");
   });
+
+  test("returns bedrock-compatible models when CLAUDE_CODE_USE_BEDROCK is set", async () => {
+    const prev = process.env.CLAUDE_CODE_USE_BEDROCK;
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    try {
+      const client = new ClaudeAgentClient({ logger, resolveBinary: async () => "/test/claude/bin" });
+      const models = await client.listModels({ cwd: "/tmp/claude-models", force: false });
+
+      expect(models.map((m) => m.id)).toEqual(["opus", "sonnet", "haiku"]);
+
+      const defaultModel = models.find((m) => m.isDefault);
+      expect(defaultModel?.id).toBe("opus");
+    } finally {
+      if (prev === undefined) {
+        delete process.env.CLAUDE_CODE_USE_BEDROCK;
+      } else {
+        process.env.CLAUDE_CODE_USE_BEDROCK = prev;
+      }
+    }
+  });
 });
 
 describe("ClaudeAgentClient binary resolution", () => {

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -422,23 +422,14 @@ describe("ClaudeAgentClient.listModels", () => {
   });
 
   test("returns bedrock-compatible models when CLAUDE_CODE_USE_BEDROCK is set", async () => {
-    const prev = process.env.CLAUDE_CODE_USE_BEDROCK;
-    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
-    try {
-      const client = new ClaudeAgentClient({ logger, resolveBinary: async () => "/test/claude/bin" });
-      const models = await client.listModels({ cwd: "/tmp/claude-models", force: false });
+    vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "1");
+    const client = new ClaudeAgentClient({ logger, resolveBinary: async () => "/test/claude/bin" });
+    const models = await client.listModels({ cwd: "/tmp/claude-models", force: false });
 
-      expect(models.map((m) => m.id)).toEqual(["opus", "sonnet", "haiku"]);
+    expect(models.map((m) => m.id)).toEqual(["opus", "sonnet", "haiku"]);
 
-      const defaultModel = models.find((m) => m.isDefault);
-      expect(defaultModel?.id).toBe("opus");
-    } finally {
-      if (prev === undefined) {
-        delete process.env.CLAUDE_CODE_USE_BEDROCK;
-      } else {
-        process.env.CLAUDE_CODE_USE_BEDROCK = prev;
-      }
-    }
+    const defaultModel = models.find((m) => m.isDefault);
+    expect(defaultModel?.id).toBe("opus");
   });
 });
 

--- a/packages/server/src/server/agent/providers/claude/models.test.ts
+++ b/packages/server/src/server/agent/providers/claude/models.test.ts
@@ -60,6 +60,15 @@ describe("getClaudeModels", () => {
     expect(a).not.toBe(b);
     expect(a[0]).not.toBe(b[0]);
   });
+
+  it("returns bedrock-compatible aliases when CLAUDE_CODE_USE_BEDROCK=1", () => {
+    vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "1");
+    const models = getClaudeModels();
+    expect(models.map((m) => m.id)).toEqual(["opus", "sonnet", "haiku"]);
+    const defaults = models.filter((m) => m.isDefault);
+    expect(defaults).toHaveLength(1);
+    expect(defaults[0].id).toBe("opus");
+  });
 });
 
 describe("ClaudeAgentClient.listModels", () => {

--- a/packages/server/src/server/agent/providers/claude/models.test.ts
+++ b/packages/server/src/server/agent/providers/claude/models.test.ts
@@ -215,4 +215,27 @@ describe("normalizeClaudeRuntimeModelId", () => {
     expect(normalizeClaudeRuntimeModelId("gpt-5")).toBeNull();
     expect(normalizeClaudeRuntimeModelId("random")).toBeNull();
   });
+
+  describe("on Bedrock transport", () => {
+    it("returns exact match for bedrock aliases", () => {
+      vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "1");
+      expect(normalizeClaudeRuntimeModelId("opus")).toBe("opus");
+      expect(normalizeClaudeRuntimeModelId("sonnet")).toBe("sonnet");
+      expect(normalizeClaudeRuntimeModelId("haiku")).toBe("haiku");
+    });
+
+    it("normalizes Bedrock ARNs to family alias", () => {
+      vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "1");
+      expect(normalizeClaudeRuntimeModelId("us.anthropic.claude-opus-4-6-v1:0")).toBe("opus");
+      expect(normalizeClaudeRuntimeModelId("eu.anthropic.claude-sonnet-4-6-20260101-v1:0")).toBe("sonnet");
+      expect(normalizeClaudeRuntimeModelId("anthropic.claude-haiku-4-5-20251001-v1:0")).toBe("haiku");
+    });
+
+    it("normalizes versioned IDs to family alias", () => {
+      vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "1");
+      expect(normalizeClaudeRuntimeModelId("claude-opus-4-8")).toBe("opus");
+      expect(normalizeClaudeRuntimeModelId("claude-sonnet-4-6")).toBe("sonnet");
+      expect(normalizeClaudeRuntimeModelId("claude-haiku-4-5")).toBe("haiku");
+    });
+  });
 });

--- a/packages/server/src/server/agent/providers/claude/models.ts
+++ b/packages/server/src/server/agent/providers/claude/models.ts
@@ -20,6 +20,11 @@ const CLAUDE_OPUS_EXTENDED_THINKING_OPTIONS = [
   { id: "max", label: "Max" },
 ] as const;
 
+/**
+ * Standard model catalog for the Anthropic API.
+ * These versioned IDs (claude-opus-4-8, etc.) are resolved by the Claude SDK
+ * when connected directly to the Anthropic API.
+ */
 const CLAUDE_MODELS: AgentModelDefinition[] = [
   {
     provider: "claude",
@@ -86,6 +91,36 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
   },
 ];
 
+/**
+ * Bedrock-compatible model catalog.
+ * When Claude Code runs via Bedrock (CLAUDE_CODE_USE_BEDROCK=1), the CLI only
+ * recognizes generic family aliases (opus, sonnet, haiku) — not the versioned
+ * IDs like claude-opus-4-8 that work on the Anthropic API directly.
+ */
+const CLAUDE_BEDROCK_MODELS: AgentModelDefinition[] = [
+  {
+    provider: "claude",
+    id: "opus",
+    label: "Opus",
+    description: "Latest Opus · Most capable",
+    isDefault: true,
+    thinkingOptions: [...CLAUDE_OPUS_EXTENDED_THINKING_OPTIONS],
+  },
+  {
+    provider: "claude",
+    id: "sonnet",
+    label: "Sonnet",
+    description: "Latest Sonnet · Best for everyday tasks",
+    thinkingOptions: [...CLAUDE_THINKING_OPTIONS],
+  },
+  {
+    provider: "claude",
+    id: "haiku",
+    label: "Haiku",
+    description: "Latest Haiku · Fastest for quick answers",
+  },
+];
+
 const CLAUDE_SETTINGS_MODEL_ENV_KEYS = [
   "ANTHROPIC_MODEL",
   "ANTHROPIC_SMALL_FAST_MODEL",
@@ -94,8 +129,13 @@ const CLAUDE_SETTINGS_MODEL_ENV_KEYS = [
   "ANTHROPIC_DEFAULT_HAIKU_MODEL",
 ] as const;
 
+function isBedrockTransport(): boolean {
+  return process.env.CLAUDE_CODE_USE_BEDROCK === "1";
+}
+
 export function getClaudeModels(): AgentModelDefinition[] {
-  return CLAUDE_MODELS.map((model) => ({ ...model }));
+  const models = isBedrockTransport() ? CLAUDE_BEDROCK_MODELS : CLAUDE_MODELS;
+  return models.map((model) => ({ ...model }));
 }
 
 export async function getClaudeModelsWithSettings(logger: Logger): Promise<AgentModelDefinition[]> {

--- a/packages/server/src/server/agent/providers/claude/models.ts
+++ b/packages/server/src/server/agent/providers/claude/models.ts
@@ -228,6 +228,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /**
  * Normalize a runtime model string (from SDK init message) to a known model ID.
  * Handles the `[1m]` suffix that the SDK appends for 1M context sessions.
+ *
+ * On Bedrock, the SDK init message includes versioned ARNs or region-prefixed IDs
+ * (e.g. `us.anthropic.claude-opus-4-6-v1:0`). We normalize these to the generic
+ * family alias (opus, sonnet, haiku) so the next turn doesn't send an invalid ID.
  */
 export function normalizeClaudeRuntimeModelId(value: string | null | undefined): string | null {
   const trimmed = typeof value === "string" ? value.trim() : "";
@@ -235,22 +239,35 @@ export function normalizeClaudeRuntimeModelId(value: string | null | undefined):
     return null;
   }
 
-  // Check for exact match first (handles claude-opus-4-6[1m] directly)
-  if (CLAUDE_MODELS.some((model) => model.id === trimmed)) {
+  // Check for exact match in the active catalog (Bedrock or Anthropic)
+  const activeCatalog = isBedrockTransport() ? CLAUDE_BEDROCK_MODELS : CLAUDE_MODELS;
+  if (activeCatalog.some((model) => model.id === trimmed)) {
     return trimmed;
   }
 
   // Match: claude-{family}-{major}-{minor}[1m]? possibly followed by a date suffix
+  // Also matches Bedrock ARN patterns like: us.anthropic.claude-opus-4-6-v1:0
   const runtimeMatch = trimmed.match(
-    /(?:claude-)?(opus|sonnet|haiku)[-_ ]+(\d+)[-.](\d+)(\[1m\])?/i,
+    /(?:claude-)?(opus|sonnet|haiku)[-_ ]+(?:\d+)[-.](?:\d+)(\[1m\])?/i,
   );
   if (!runtimeMatch) {
     return null;
   }
 
   const family = runtimeMatch[1].toLowerCase();
-  const major = runtimeMatch[2];
-  const minor = runtimeMatch[3];
-  const suffix = runtimeMatch[4] ?? "";
-  return `claude-${family}-${major}-${minor}${suffix}`;
+  const suffix = runtimeMatch[2] ?? "";
+
+  // On Bedrock, return the generic family alias
+  if (isBedrockTransport()) {
+    return family;
+  }
+
+  // On Anthropic API, return the versioned ID
+  const fullMatch = trimmed.match(
+    /(?:claude-)?(opus|sonnet|haiku)[-_ ]+(\d+)[-. ](\d+)(\[1m\])?/i,
+  );
+  if (!fullMatch) {
+    return null;
+  }
+  return `claude-${fullMatch[1].toLowerCase()}-${fullMatch[2]}-${fullMatch[3]}${fullMatch[4] ?? ""}${suffix}`;
 }


### PR DESCRIPTION
## Problem

When Paseo runs Claude Code via Bedrock (`CLAUDE_CODE_USE_BEDROCK=1`), every model in the UI fails with:

```
API Error (claude-opus-4-8): 400 The provided model identifier is invalid...
Try --model to switch to eu.anthropic.claude-opus-4-1-20250805-v1:0.
```

## Root Cause

Paseo's hardcoded model catalog uses versioned IDs (`claude-opus-4-8`, `claude-opus-4-6`, etc.) that the Claude SDK resolves against the **Anthropic API**. On **Bedrock**, the Claude CLI only recognizes generic family aliases: `opus`, `sonnet`, `haiku`, `default`.

When Paseo passes `--model claude-opus-4-8` to the CLI on Bedrock, the CLI doesn't recognize it as an alias and passes it verbatim to the Bedrock API, which rejects it.

## Fix

Detect the Bedrock transport via `CLAUDE_CODE_USE_BEDROCK` env var in `getClaudeModels()` and return the generic aliases instead of versioned IDs:

| Anthropic API (default) | Bedrock |
|---|---|
| claude-opus-4-8, claude-opus-4-7, claude-opus-4-6, ... | opus |
| claude-sonnet-4-6 | sonnet |
| claude-haiku-4-5 | haiku |

## Testing

- Added unit tests for both paths (Anthropic and Bedrock)
- Manually verified on EC2 with instance role + Bedrock:
  - `claude --print --model opus 'say hi'` ✅
  - `claude --print --model claude-opus-4-6 'say hi'` ❌ (before fix)