### PR TITLE
Highlight Dart code blocks and diffs

### DIFF
--- a/packages/highlight/src/__tests__/highlighter.test.ts
+++ b/packages/highlight/src/__tests__/highlighter.test.ts
@@ -46,6 +46,22 @@ describe("highlightCode", () => {
     expect(stringToken?.style).toBe("string");
   });
 
+  it("highlights Dart code", () => {
+    const code = 'class Greeter {\n  final String message = "hello";\n}';
+    const result = highlightCode(code, "test.dart");
+
+    expect(result).toHaveLength(3);
+
+    const classToken = result[0].find((t) => t.text === "class");
+    expect(classToken?.style).toBe("keyword");
+
+    const finalToken = result[1].find((t) => t.text === "final");
+    expect(finalToken?.style).toBe("keyword");
+
+    const stringToken = result[1].find((t) => t.text.includes("hello"));
+    expect(stringToken?.style).toBe("string");
+  });
+
   it("highlights TSX code with correct dialect", () => {
     const code = 'const el = <div className="test">hello</div>;';
     const result = highlightCode(code, "test.tsx");

--- a/packages/highlight/src/__tests__/parsers.test.ts
+++ b/packages/highlight/src/__tests__/parsers.test.ts
@@ -14,6 +14,7 @@ describe("isLanguageSupported", () => {
     expect(isLanguageSupported("test.html")).toBe(true);
     expect(isLanguageSupported("test.java")).toBe(true);
     expect(isLanguageSupported("test.swift")).toBe(true);
+    expect(isLanguageSupported("test.dart")).toBe(true);
     expect(isLanguageSupported("test.ex")).toBe(true);
   });
 
@@ -51,6 +52,7 @@ describe("getSupportedExtensions", () => {
     expect(extensions).toContain("go");
     expect(extensions).toContain("rs");
     expect(extensions).toContain("swift");
+    expect(extensions).toContain("dart");
     expect(extensions).toContain("json");
   });
 });

--- a/packages/highlight/src/parsers.ts
+++ b/packages/highlight/src/parsers.ts
@@ -1,4 +1,5 @@
 import { StreamLanguage } from "@codemirror/language";
+import { dart } from "@codemirror/legacy-modes/mode/clike";
 import { swift } from "@codemirror/legacy-modes/mode/swift";
 import { parser as jsParser } from "@lezer/javascript";
 import { parser as jsonParser } from "@lezer/json";
@@ -59,6 +60,8 @@ const parsersByExtension: Record<string, Parser> = {
   rs: rustParser,
   // Swift
   swift: StreamLanguage.define(swift).parser,
+  // Dart
+  dart: StreamLanguage.define(dart).parser,
   // Elixir
   ex: elixirParser,
   exs: elixirParser,


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds Dart as a supported syntax-highlighted language. Dart files and Dart-labeled code paths now get highlighted instead of falling back to plain, unstyled text.

### How did you verify it

- `npx vitest run packages/highlight/src/__tests__/parsers.test.ts packages/highlight/src/__tests__/highlighter.test.ts --bail=1`
- `npm run format`
- `npm run build:highlight`
- `npm run typecheck`
- `npm run lint`

### Risk surface

This touches the shared highlighting package used by app and daemon diff rendering. The risk is limited to Dart token classification quality; unsupported or imperfect Dart syntax still renders as text rather than affecting agent/session behavior.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense