### PR TITLE
Fix Windows workspace provider loading

### DIFF
--- a/packages/app/src/hooks/providers-snapshot-query.test.ts
+++ b/packages/app/src/hooks/providers-snapshot-query.test.ts
@@ -39,4 +39,13 @@ describe("providers snapshot query scope", () => {
       providers: ["codex"],
     });
   });
+
+  it("uses one query scope for Windows cwd values with either separator", () => {
+    expect(normalizeProvidersSnapshotCwd("C:\\Users\\Ezekiel Bulver\\project")).toBe(
+      "C:/Users/Ezekiel Bulver/project",
+    );
+    expect(providersSnapshotQueryKey("server-1", "C:\\Users\\Ezekiel Bulver\\project")).toEqual(
+      providersSnapshotQueryKey("server-1", "C:/Users/Ezekiel Bulver/project"),
+    );
+  });
 });

--- a/packages/app/src/hooks/providers-snapshot-query.ts
+++ b/packages/app/src/hooks/providers-snapshot-query.ts
@@ -1,10 +1,10 @@
 import type { AgentProvider } from "@getpaseo/protocol/agent-types";
+import { normalizeWorkspacePath } from "@/utils/workspace-identity";
 
 export const PROVIDERS_SNAPSHOT_QUERY_ROOT = "providersSnapshot";
 
 export function normalizeProvidersSnapshotCwd(cwd?: string | null): string | null {
-  const trimmed = cwd?.trim();
-  return trimmed ? trimmed : null;
+  return normalizeWorkspacePath(cwd);
 }
 
 export function providersSnapshotQueryRoot(serverId: string | null) {

--- a/packages/app/src/hooks/use-providers-snapshot.test.ts
+++ b/packages/app/src/hooks/use-providers-snapshot.test.ts
@@ -250,6 +250,27 @@ describe("applyProvidersSnapshotUpdate", () => {
       providersSnapshot([]),
     );
   });
+
+  it("applies Windows daemon updates to app-normalized workspace paths", () => {
+    const workspaceCwd = "C:/Users/Ezekiel Bulver/project";
+    const daemonCwd = "C:\\Users\\Ezekiel Bulver\\project";
+    queryClient.setQueryData(
+      providersSnapshotQueryKey(serverId, workspaceCwd),
+      providersSnapshot([codexEntry("loading")]),
+    );
+
+    applyProvidersSnapshotUpdate({
+      serverId,
+      queryClient,
+      message: updateMessage([codexEntry("ready", [readyCodexModel])], daemonCwd),
+    });
+
+    expect(queryClient.getQueryData(providersSnapshotQueryKey(serverId, workspaceCwd))).toEqual({
+      entries: [codexEntry("ready", [readyCodexModel])],
+      generatedAt: "2026-01-01T00:00:01.000Z",
+      requestId: "providers_snapshot_update",
+    });
+  });
 });
 
 describe("selectorOpenRefetchDecision", () => {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -45,6 +45,7 @@ import { renderPromptAttachmentAsText } from "../../prompt-attachments.js";
 import { claudeQuery, type ClaudeOptions, type ClaudeQueryFactory } from "./query.js";
 import { realClaudeRewindSdk, revertClaudeConversation, revertClaudeFiles } from "./rewind.js";
 import { normalizeProviderReplayTimestamp } from "../../provider-history-timestamps.js";
+import { claudeProjectDirSync } from "./project-dir.js";
 
 import {
   getAgentStreamEventTurnId,
@@ -337,10 +338,6 @@ function isClaudeThinkingEffort(value: string | null | undefined): value is Clau
     value === "xhigh" ||
     value === "max"
   );
-}
-
-function sanitizeClaudeProjectPath(cwd: string): string {
-  return cwd.replace(/[\\/._:]/g, "-");
 }
 
 interface ClaudeOptionsLogSummary {
@@ -3985,14 +3982,15 @@ class ClaudeAgentSession implements AgentSession {
       // Fall back to the configured cwd when the path has already disappeared.
     }
     for (const candidate of candidates) {
-      const sanitized = sanitizeClaudeProjectPath(candidate);
-      const historyPath = path.join(configDir, "projects", sanitized, `${sessionId}.jsonl`);
+      const historyPath = path.join(
+        claudeProjectDirSync(candidate, { configDir }),
+        `${sessionId}.jsonl`,
+      );
       if (fs.existsSync(historyPath)) {
         return historyPath;
       }
     }
-    const sanitized = sanitizeClaudeProjectPath(cwd);
-    return path.join(configDir, "projects", sanitized, `${sessionId}.jsonl`);
+    return path.join(claudeProjectDirSync(cwd, { configDir }), `${sessionId}.jsonl`);
   }
 
   private convertHistoryEntry(entry: ClaudeHistoryEntry): AgentTimelineItem[] {

--- a/packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { createTestLogger } from "../../../../test-utils/test-logger.js";
 import { ClaudeAgentClient } from "./agent.js";
+import { claudeProjectDirSync } from "./project-dir.js";
 import { streamSession } from "../test-utils/session-stream-adapter.js";
 import type { AgentPersistenceHandle, AgentStreamEvent } from "../../agent-sdk-types.js";
 
@@ -14,10 +15,6 @@ let lastQuery: ReturnType<typeof buildSdkQueryMock> | null = null;
 const LIVE_REPLY_MARKER = "LIVE_ONLY_REPLY_MARKER";
 const HISTORY_USER_MARKER = "HISTORY_ONLY_USER_MARKER";
 const HISTORY_ASSISTANT_MARKER = "HISTORY_ONLY_ASSISTANT_MARKER";
-
-function sanitizeClaudeProjectPath(cwd: string): string {
-  return cwd.replace(/[\\/._:]/g, "-");
-}
 
 function buildSdkQueryMock() {
   const events = [
@@ -100,12 +97,11 @@ describe("ClaudeAgentSession history replay regression", () => {
     });
 
     tempRoot = mkdtempSync(path.join(os.tmpdir(), "claude-history-regression-"));
-    cwd = path.join(tempRoot, "repo");
+    cwd = path.join(tempRoot, "Michael Depies", "repo");
     configDir = path.join(tempRoot, "claude-config");
     mkdirSync(cwd, { recursive: true });
 
-    const sanitized = sanitizeClaudeProjectPath(cwd);
-    const historyDir = path.join(configDir, "projects", sanitized);
+    const historyDir = claudeProjectDirSync(cwd, { configDir });
     mkdirSync(historyDir, { recursive: true });
     const historyPath = path.join(historyDir, "history-session.jsonl");
     writeFileSync(

--- a/packages/server/src/server/agent/providers/claude/project-dir.test.ts
+++ b/packages/server/src/server/agent/providers/claude/project-dir.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { getSessionInfo } from "@anthropic-ai/claude-agent-sdk";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 
-import { claudeProjectDir } from "./project-dir.js";
+import { claudeProjectDir, claudeProjectDirSync } from "./project-dir.js";
 
 // Parity oracle: the Claude SDK's getSessionInfo({ dir }) canonicalizes the
 // given dir with the SDK's own encoder and looks for `<sessionId>.jsonl` under
@@ -101,6 +101,12 @@ describe("claudeProjectDir parity with Claude Agent SDK", () => {
       expect(info?.sessionId).toBe(sessionId);
     });
   }
+
+  test("sync helper uses the same directory as the SDK-parity helper", async () => {
+    const cwd = await ensureDir(join(workspaceRoot, "sync path with spaces"));
+
+    await expect(claudeProjectDir(cwd)).resolves.toBe(claudeProjectDirSync(cwd));
+  });
 });
 
 async function ensureDir(path: string): Promise<string> {

--- a/packages/server/src/server/agent/providers/claude/project-dir.ts
+++ b/packages/server/src/server/agent/providers/claude/project-dir.ts
@@ -1,4 +1,3 @@
-import { realpathSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -25,7 +24,7 @@ export async function claudeProjectDir(
 }
 
 export function claudeProjectDirSync(cwd: string, options?: ClaudeProjectDirOptions): string {
-  const canonical = canonicalizeSync(cwd);
+  const canonical = cwd.normalize("NFC");
   const projectsRoot = join(resolveConfigDir(options), "projects");
   return join(projectsRoot, encode(canonical));
 }
@@ -33,14 +32,6 @@ export function claudeProjectDirSync(cwd: string, options?: ClaudeProjectDirOpti
 async function canonicalize(input: string): Promise<string> {
   try {
     return (await realpath(input)).normalize("NFC");
-  } catch {
-    return input.normalize("NFC");
-  }
-}
-
-function canonicalizeSync(input: string): string {
-  try {
-    return realpathSync(input).normalize("NFC");
   } catch {
     return input.normalize("NFC");
   }

--- a/packages/server/src/server/agent/providers/claude/project-dir.ts
+++ b/packages/server/src/server/agent/providers/claude/project-dir.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -23,9 +24,23 @@ export async function claudeProjectDir(
   return join(projectsRoot, encode(canonical));
 }
 
+export function claudeProjectDirSync(cwd: string, options?: ClaudeProjectDirOptions): string {
+  const canonical = canonicalizeSync(cwd);
+  const projectsRoot = join(resolveConfigDir(options), "projects");
+  return join(projectsRoot, encode(canonical));
+}
+
 async function canonicalize(input: string): Promise<string> {
   try {
     return (await realpath(input)).normalize("NFC");
+  } catch {
+    return input.normalize("NFC");
+  }
+}
+
+function canonicalizeSync(input: string): string {
+  try {
+    return realpathSync(input).normalize("NFC");
   } catch {
     return input.normalize("NFC");
   }

--- a/packages/server/src/server/agent/providers/claude/project-dir.ts
+++ b/packages/server/src/server/agent/providers/claude/project-dir.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -24,7 +25,7 @@ export async function claudeProjectDir(
 }
 
 export function claudeProjectDirSync(cwd: string, options?: ClaudeProjectDirOptions): string {
-  const canonical = cwd.normalize("NFC");
+  const canonical = canonicalizeSync(cwd);
   const projectsRoot = join(resolveConfigDir(options), "projects");
   return join(projectsRoot, encode(canonical));
 }
@@ -32,6 +33,14 @@ export function claudeProjectDirSync(cwd: string, options?: ClaudeProjectDirOpti
 async function canonicalize(input: string): Promise<string> {
   try {
     return (await realpath(input)).normalize("NFC");
+  } catch {
+    return input.normalize("NFC");
+  }
+}
+
+function canonicalizeSync(input: string): string {
+  try {
+    return realpathSync.native(input).normalize("NFC");
   } catch {
     return input.normalize("NFC");
   }


### PR DESCRIPTION
### Linked issue

Closes #63

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Provider models now finish loading for Windows workspaces even when the app and daemon see the same cwd with different path separators.

The app already normalizes workspace paths to forward slashes, while the daemon reports resolved Windows paths with backslashes. Provider snapshot query keys now use the same workspace path normalization, so a loading workspace snapshot is updated by the daemon's ready snapshot instead of staying stuck under a different cache key.

This also fixes imported Claude session history lookup for Windows user/profile paths with spaces by using the same Claude project-directory encoder that the SDK uses, rather than a stale sanitizer that preserved spaces.

### How did you verify it

- Windows probe box red/green for provider loading:
  - Checked out `8bf855c57` (test-only red commit), ran `npm run build:client`, then `npm run test --workspace=@getpaseo/app -- src/hooks/use-providers-snapshot.test.ts --bail=1`; result: `RED_BUILD_EXIT=0`, `RED_EXIT=1`.
  - Checked out fixed HEAD `d59968c14`, ran `npm run build:client`, then `npm run test --workspace=@getpaseo/app -- src/hooks/providers-snapshot-query.test.ts src/hooks/use-providers-snapshot.test.ts --bail=1`; result: `FINAL_BUILD_EXIT=0`, `FINAL_APP_EXIT=0`.
- Windows probe box for Claude history/project-dir coverage:
  - At fixed HEAD `d59968c14`, ran `cd packages/server && npx vitest run src/server/agent/providers/claude/project-dir.test.ts src/server/agent/providers/claude/agent.voice-history-regression.test.ts --bail=1`; result: `FINAL_SERVER_EXIT=0`.
- Local targeted tests:
  - `npm run test --workspace=@getpaseo/app -- src/hooks/providers-snapshot-query.test.ts src/hooks/use-providers-snapshot.test.ts --bail=1`
  - `cd packages/server && npx vitest run src/server/agent/providers/claude/project-dir.test.ts src/server/agent/providers/claude/agent.voice-history-regression.test.ts --bail=1`
- Local gates:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run format:files -- packages/app/src/hooks/providers-snapshot-query.test.ts packages/app/src/hooks/providers-snapshot-query.ts packages/app/src/hooks/use-providers-snapshot.test.ts packages/server/src/server/agent/providers/claude/agent.ts packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts packages/server/src/server/agent/providers/claude/project-dir.test.ts packages/server/src/server/agent/providers/claude/project-dir.ts`

The Windows GitHub Actions matrix is also running for the pushed branch.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
