### PR TITLE
fix(app): return to correct host when closing settings

### DIFF
--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -648,6 +648,22 @@ function useAnyOnlineHostServerId(serverIds: string[]): string | null {
   );
 }
 
+function useLocalDaemonIfOnline(localServerId: string | null): string | null {
+  const runtime = getHostRuntimeStore();
+  return useSyncExternalStore(
+    (onStoreChange) => {
+      if (!localServerId) return () => {};
+      return runtime.subscribe(localServerId, onStoreChange);
+    },
+    () => {
+      if (!localServerId) return null;
+      const snapshot = runtime.getSnapshot(localServerId);
+      return isHostRuntimeConnected(snapshot) ? localServerId : null;
+    },
+    () => null,
+  );
+}
+
 /**
  * Local daemon first, then remaining hosts in their existing order. Lets the
  * picker and the active-host resolver agree on a stable "first" host.
@@ -1114,6 +1130,7 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
   );
   const hosts = useHosts();
   const localServerId = useLocalDaemonServerId();
+  const localDaemonIfOnline = useLocalDaemonIfOnline(localServerId);
   const sortedHosts = useSortedHosts(hosts, localServerId);
   const hostServerIds = useMemo(() => hosts.map((host) => host.serverId), [hosts]);
   const anyOnlineServerId = useAnyOnlineHostServerId(hostServerIds);
@@ -1315,17 +1332,17 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
     if (navigateToLastWorkspace()) {
       return;
     }
-    // Prefer the local daemon host — it's the most likely origin when the user
-    // entered settings from a workspace.  `anyOnlineServerId` can point to a
-    // different host if the user navigated to another host's settings page
-    // before closing, which would drop them on the wrong host.
-    const fallbackServerId = localServerId ?? anyOnlineServerId;
+    // Prefer the local daemon host when it's online — it's the most likely
+    // origin when the user entered settings from a workspace.  Fall back to
+    // anyOnlineServerId only when the local daemon is unreachable, so we
+    // never strand the user on an offline host.
+    const fallbackServerId = localDaemonIfOnline ?? anyOnlineServerId;
     if (fallbackServerId) {
       router.replace(buildHostOpenProjectRoute(fallbackServerId));
       return;
     }
     router.replace("/");
-  }, [localServerId, anyOnlineServerId, router]);
+  }, [localDaemonIfOnline, anyOnlineServerId, router]);
 
   const detailHeader = ((): {
     title: string;

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -1474,14 +1474,11 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
     );
   }
 
-  // Mobile detail: full-screen content with a back header. Project and host
-  // detail views use an app-level back (out of settings, to the workspace).
-  // Host views use the same handler so that navigating between hosts in
-  // settings and then pressing back always returns to the original workspace,
-  // not to the previous host's settings page.  Section views step back to the
-  // settings root since they're always reachable from there.
-  const detailBackHandler =
-    view.kind === "project" || view.kind === "host" ? handleBackToWorkspace : handleBackToRoot;
+  // Mobile detail: full-screen content with a back header. Project detail uses
+  // an app-level back (out of settings, to the workspace) since the in-body
+  // "Back to projects" ghost button handles list-level back; other detail views
+  // step back to the settings root.
+  const detailBackHandler = view.kind === "project" ? handleBackToWorkspace : handleBackToRoot;
   if (isCompactLayout) {
     return (
       <View style={styles.container}>

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -1315,12 +1315,17 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
     if (navigateToLastWorkspace()) {
       return;
     }
-    if (anyOnlineServerId) {
-      router.replace(buildHostOpenProjectRoute(anyOnlineServerId));
+    // Prefer the local daemon host — it's the most likely origin when the user
+    // entered settings from a workspace.  `anyOnlineServerId` can point to a
+    // different host if the user navigated to another host's settings page
+    // before closing, which would drop them on the wrong host.
+    const fallbackServerId = localServerId ?? anyOnlineServerId;
+    if (fallbackServerId) {
+      router.replace(buildHostOpenProjectRoute(fallbackServerId));
       return;
     }
     router.replace("/");
-  }, [anyOnlineServerId, router]);
+  }, [localServerId, anyOnlineServerId, router]);
 
   const detailHeader = ((): {
     title: string;
@@ -1452,11 +1457,14 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
     );
   }
 
-  // Mobile detail: full-screen content with a back header. Project detail uses
-  // an app-level back (out of settings, to the workspace) since the in-body
-  // "Back to projects" ghost button handles list-level back; other detail views
-  // step back to the settings root.
-  const detailBackHandler = view.kind === "project" ? handleBackToWorkspace : handleBackToRoot;
+  // Mobile detail: full-screen content with a back header. Project and host
+  // detail views use an app-level back (out of settings, to the workspace).
+  // Host views use the same handler so that navigating between hosts in
+  // settings and then pressing back always returns to the original workspace,
+  // not to the previous host's settings page.  Section views step back to the
+  // settings root since they're always reachable from there.
+  const detailBackHandler =
+    view.kind === "project" || view.kind === "host" ? handleBackToWorkspace : handleBackToRoot;
   if (isCompactLayout) {
     return (
       <View style={styles.container}>


### PR DESCRIPTION
## What

When navigating between hosts in settings and then closing, the fallback in  used  which could point to a different host than the one the user was originally viewing.

## Changes

- Prefer  over  as the fallback host when the last workspace selection is unavailable
- Use  for host detail views so pressing back from host settings exits to the workspace instead of navigating within the settings stack

Fixes #1320