### PR TITLE
fix(app): add paste button to mobile terminal virtual keyboard

### DIFF
--- a/packages/app/src/components/terminal-emulator.native.tsx
+++ b/packages/app/src/components/terminal-emulator.native.tsx
@@ -559,11 +559,15 @@ export default function TerminalEmulator({
           callbacksRef.current.onSwipeRight?.();
           break;
         case "clipboardRead":
-          void Clipboard.getStringAsync().then((text) => {
-            if (text) {
-              sendToWebView({ type: "clipboardText", streamKey: message.streamKey, text });
-            }
-          });
+          void Clipboard.getStringAsync()
+            .then((text) => {
+              if (text) {
+                sendToWebView({ type: "clipboardText", streamKey: message.streamKey, text });
+              }
+            })
+            .catch(() => {
+              // Clipboard permission denied or unavailable — silently ignore.
+            });
           break;
         case "debug":
           break;

--- a/packages/app/src/components/terminal-emulator.native.tsx
+++ b/packages/app/src/components/terminal-emulator.native.tsx
@@ -29,6 +29,7 @@ import { terminalEmulatorWebViewHtml } from "../terminal/webview/terminal-emulat
 import type { PendingTerminalModifiers } from "../utils/terminal-keys";
 import type { TerminalRendererReadyChange } from "../utils/terminal-renderer-readiness";
 import { openExternalUrl } from "../utils/open-external-url";
+import * as Clipboard from "expo-clipboard";
 
 export interface TerminalEmulatorHandle {
   writeOutput: (data: TerminalOutputData) => void;
@@ -36,6 +37,7 @@ export interface TerminalEmulatorHandle {
   renderSnapshot: (state: TerminalState | null) => void;
   clear: () => void;
   blur: () => void;
+  requestClipboardRead: () => void;
 }
 
 interface TerminalEmulatorProps {
@@ -105,7 +107,8 @@ type BridgeInboundMessage =
       streamKey: string;
       requestId: number;
       target: TerminalLocalFileLinkTarget | null;
-    };
+    }
+  | { type: "clipboardText"; streamKey: string; text: string };
 
 type BridgeOutboundMessage =
   | { type: "bridgeReady" }
@@ -138,6 +141,7 @@ type BridgeOutboundMessage =
     }
   | { type: "swipeLeft"; streamKey: string }
   | { type: "swipeRight"; streamKey: string }
+  | { type: "clipboardRead"; streamKey: string }
   | { type: "debug"; message: string; details?: unknown };
 
 const TERMINAL_WEBVIEW_SOURCE = { html: terminalEmulatorWebViewHtml };
@@ -374,6 +378,11 @@ export default function TerminalEmulator({
         );
         Keyboard.dismiss();
       },
+      requestClipboardRead: () => {
+        webViewRef.current?.injectJavaScript(
+          "window.__PASEO_TERMINAL_WEBVIEW_REQUEST_CLIPBOARD_READ__ && window.__PASEO_TERMINAL_WEBVIEW_REQUEST_CLIPBOARD_READ__(); true;",
+        );
+      },
     }),
     [sendToWebView, streamKey],
   );
@@ -549,11 +558,18 @@ export default function TerminalEmulator({
         case "swipeRight":
           callbacksRef.current.onSwipeRight?.();
           break;
+        case "clipboardRead":
+          void Clipboard.getStringAsync().then((text) => {
+            if (text) {
+              sendToWebView({ type: "clipboardText", streamKey: message.streamKey, text });
+            }
+          });
+          break;
         case "debug":
           break;
       }
     },
-    [resolveLocalFileLink],
+    [resolveLocalFileLink, sendToWebView],
   );
 
   const handleMessage = useCallback(

--- a/packages/app/src/components/terminal-emulator.tsx
+++ b/packages/app/src/components/terminal-emulator.tsx
@@ -340,11 +340,16 @@ export default function TerminalEmulator({
         runtimeRef.current?.blur();
       },
       requestClipboardRead: () => {
-        void navigator.clipboard.readText().then((text) => {
-          if (text) {
-            runtimeRef.current?.paste(text);
-          }
-        });
+        void navigator.clipboard
+          .readText()
+          .then((text) => {
+            if (text) {
+              runtimeRef.current?.paste(text);
+            }
+          })
+          .catch(() => {
+            // Clipboard permission denied or unavailable — silently ignore.
+          });
       },
     }),
     [],

--- a/packages/app/src/components/terminal-emulator.tsx
+++ b/packages/app/src/components/terminal-emulator.tsx
@@ -49,6 +49,7 @@ export interface TerminalEmulatorHandle {
   renderSnapshot: (state: TerminalState | null) => void;
   clear: () => void;
   blur: () => void;
+  requestClipboardRead: () => void;
 }
 
 const SCROLLBAR_HANDLE_WIDTH_IDLE = 6;
@@ -337,6 +338,13 @@ export default function TerminalEmulator({
       },
       blur: () => {
         runtimeRef.current?.blur();
+      },
+      requestClipboardRead: () => {
+        void navigator.clipboard.readText().then((text) => {
+          if (text) {
+            runtimeRef.current?.paste(text);
+          }
+        });
       },
     }),
     [],

--- a/packages/app/src/components/terminal-pane.tsx
+++ b/packages/app/src/components/terminal-pane.tsx
@@ -728,6 +728,11 @@ export function TerminalPane({
     [keyboardPaddingStyle],
   );
 
+  const handlePaste = useCallback(() => {
+    emulatorRef.current?.requestClipboardRead();
+    requestTerminalFocus();
+  }, [requestTerminalFocus]);
+
   const handleSwipeRight = useCallback(() => {
     if (!swipeGesturesEnabled) return;
     emulatorRef.current?.blur();
@@ -857,6 +862,17 @@ export function TerminalPane({
                   onSend={sendVirtualKey}
                 />
               ))}
+
+              <Pressable
+                testID="terminal-key-paste"
+                onPress={handlePaste}
+                style={({ hovered, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+                  styles.keyButton,
+                  (Boolean(hovered) || pressed) && styles.keyButtonHovered,
+                ]}
+              >
+                <Text style={styles.keyButtonText}>Paste</Text>
+              </Pressable>
             </View>
           </View>
         </View>

--- a/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
+++ b/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
@@ -715,6 +715,10 @@ export class TerminalEmulatorRuntime {
     this.terminal?.blur();
   }
 
+  paste(text: string): void {
+    this.terminal?.paste(text);
+  }
+
   private refreshVisibleRows(): void {
     const terminal = this.terminal;
     if (!terminal || terminal.rows <= 0) {

--- a/packages/app/src/terminal/webview/terminal-emulator-webview-entry.ts
+++ b/packages/app/src/terminal/webview/terminal-emulator-webview-entry.ts
@@ -43,7 +43,8 @@ type InboundMessage =
       streamKey: string;
       requestId: number;
       target: TerminalLocalFileLinkTarget | null;
-    };
+    }
+  | { type: "clipboardText"; streamKey: string; text: string };
 
 type OutboundMessage =
   | { type: "bridgeReady" }
@@ -76,6 +77,7 @@ type OutboundMessage =
     }
   | { type: "swipeLeft"; streamKey: string }
   | { type: "swipeRight"; streamKey: string }
+  | { type: "clipboardRead"; streamKey: string }
   | { type: "debug"; message: string; details?: unknown };
 
 declare global {
@@ -85,6 +87,7 @@ declare global {
     };
     __PASEO_TERMINAL_WEBVIEW_RECEIVE__?: (message: InboundMessage) => void;
     __PASEO_TERMINAL_WEBVIEW_BLUR__?: () => void;
+    __PASEO_TERMINAL_WEBVIEW_REQUEST_CLIPBOARD_READ__?: () => void;
   }
 }
 
@@ -251,6 +254,11 @@ class TerminalWebViewBridge {
       case "resize":
         this.runtime?.resize({ force: true, shouldClaim: message.shouldClaim !== false });
         break;
+      case "clipboardText":
+        if (message.text) {
+          this.runtime?.paste(message.text);
+        }
+        break;
     }
   }
 
@@ -336,6 +344,12 @@ class TerminalWebViewBridge {
 
   blur = (): void => {
     this.runtime?.blur();
+  };
+
+  requestClipboardRead = (): void => {
+    if (this.streamKey) {
+      sendToNative({ type: "clipboardRead", streamKey: this.streamKey });
+    }
   };
 
   private unmount(streamKey: string | null): void {
@@ -523,4 +537,5 @@ document.body.appendChild(root);
 const bridge = new TerminalWebViewBridge(root, host);
 window.__PASEO_TERMINAL_WEBVIEW_RECEIVE__ = bridge.receive;
 window.__PASEO_TERMINAL_WEBVIEW_BLUR__ = bridge.blur;
+window.__PASEO_TERMINAL_WEBVIEW_REQUEST_CLIPBOARD_READ__ = bridge.requestClipboardRead;
 sendToNative({ type: "bridgeReady" });


### PR DESCRIPTION
## What

On iOS, there was no way to paste clipboard content into the terminal. The Clipboard API (navigator.clipboard.readText()) is unreliable in iOS WebViews, and there was no fallback.

## Changes

- Add a Paste button to the mobile virtual keyboard
- Implement a native bridge: WebView sends clipboardRead, native reads clipboard via expo-clipboard, sends clipboardText back, WebView pastes into xterm.js
- Add requestClipboardRead to TerminalEmulatorHandle for both native and web implementations
- Add paste() method to TerminalEmulatorRuntime

Fixes #1336