### PR TITLE
feat(server): make provider refresh timeout configurable via PASEO_PROVIDER_REFRESH_TIMEOUT_MS

### DIFF
--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -156,6 +156,100 @@ describe("ProviderSnapshotManager public surface", () => {
     }
   });
 
+  test("refreshTimeoutMs option overrides the default and yields a timeout error", async () => {
+    // never-resolving isAvailable forces the timeout path
+    const isAvailable = vi.fn(() => new Promise<boolean>(() => {}));
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      refreshTimeoutMs: 1,
+      providerOverrides: {
+        claude: { enabled: false },
+        copilot: { enabled: false },
+        opencode: { enabled: false },
+        pi: { enabled: false },
+      },
+      extraClients: { codex: createExtraClient("codex", { isAvailable }) },
+    });
+    try {
+      const entry = await manager.getProvider({
+        cwd: "/tmp/project",
+        provider: "codex",
+        wait: true,
+      });
+      expect(entry.provider).toBe("codex");
+      expect(entry.status).toBe("error");
+      expect(entry.error).toMatch(/after 1ms/);
+    } finally {
+      manager.destroy();
+    }
+  });
+
+  test("PASEO_PROVIDER_REFRESH_TIMEOUT_MS env var is honored when no option is given", async () => {
+    const previous = process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS;
+    process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS = "1";
+    const isAvailable = vi.fn(() => new Promise<boolean>(() => {}));
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      providerOverrides: {
+        claude: { enabled: false },
+        copilot: { enabled: false },
+        opencode: { enabled: false },
+        pi: { enabled: false },
+      },
+      extraClients: { codex: createExtraClient("codex", { isAvailable }) },
+    });
+    try {
+      const entry = await manager.getProvider({
+        cwd: "/tmp/project",
+        provider: "codex",
+        wait: true,
+      });
+      expect(entry.status).toBe("error");
+      expect(entry.error).toMatch(/after 1ms/);
+    } finally {
+      manager.destroy();
+      if (previous === undefined) {
+        delete process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS;
+      } else {
+        process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS = previous;
+      }
+    }
+  });
+
+  test("PASEO_PROVIDER_REFRESH_TIMEOUT_MS env var is ignored when option is provided", async () => {
+    const previous = process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS;
+    process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS = "1";
+    const isAvailable = vi.fn(() => new Promise<boolean>(() => {}));
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      refreshTimeoutMs: 5,
+      providerOverrides: {
+        claude: { enabled: false },
+        copilot: { enabled: false },
+        opencode: { enabled: false },
+        pi: { enabled: false },
+      },
+      extraClients: { codex: createExtraClient("codex", { isAvailable }) },
+    });
+    try {
+      const entry = await manager.getProvider({
+        cwd: "/tmp/project",
+        provider: "codex",
+        wait: true,
+      });
+      expect(entry.status).toBe("error");
+      // explicit option (5) wins over env var (1)
+      expect(entry.error).toMatch(/after 5ms/);
+    } finally {
+      manager.destroy();
+      if (previous === undefined) {
+        delete process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS;
+      } else {
+        process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS = previous;
+      }
+    }
+  });
+
   test("listProviders returns an entry per registered provider", async () => {
     const manager = new ProviderSnapshotManager({
       logger: createTestLogger(),

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -185,8 +185,7 @@ describe("ProviderSnapshotManager public surface", () => {
   });
 
   test("PASEO_PROVIDER_REFRESH_TIMEOUT_MS env var is honored when no option is given", async () => {
-    const previous = process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS;
-    process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS = "1";
+    vi.stubEnv("PASEO_PROVIDER_REFRESH_TIMEOUT_MS", "1");
     const isAvailable = vi.fn(() => new Promise<boolean>(() => {}));
     const manager = new ProviderSnapshotManager({
       logger: createTestLogger(),
@@ -208,17 +207,12 @@ describe("ProviderSnapshotManager public surface", () => {
       expect(entry.error).toMatch(/after 1ms/);
     } finally {
       manager.destroy();
-      if (previous === undefined) {
-        delete process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS;
-      } else {
-        process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS = previous;
-      }
+      vi.unstubAllEnvs();
     }
   });
 
   test("PASEO_PROVIDER_REFRESH_TIMEOUT_MS env var is ignored when option is provided", async () => {
-    const previous = process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS;
-    process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS = "1";
+    vi.stubEnv("PASEO_PROVIDER_REFRESH_TIMEOUT_MS", "1");
     const isAvailable = vi.fn(() => new Promise<boolean>(() => {}));
     const manager = new ProviderSnapshotManager({
       logger: createTestLogger(),
@@ -242,11 +236,7 @@ describe("ProviderSnapshotManager public surface", () => {
       expect(entry.error).toMatch(/after 5ms/);
     } finally {
       manager.destroy();
-      if (previous === undefined) {
-        delete process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS;
-      } else {
-        process.env.PASEO_PROVIDER_REFRESH_TIMEOUT_MS = previous;
-      }
+      vi.unstubAllEnvs();
     }
   });
 

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -29,6 +29,24 @@ import { applyMutableProviderConfigToOverrides } from "../daemon-config-store.js
 import type { MutableDaemonConfig } from "../daemon-config-store.js";
 
 const DEFAULT_REFRESH_TIMEOUT_MS = 30_000;
+const REFRESH_TIMEOUT_ENV_VAR = "PASEO_PROVIDER_REFRESH_TIMEOUT_MS";
+
+// Provider refresh probes can be slow on cold starts (e.g. Copilot's first
+// `copilot --acp` invocation, OpenCode workspace probes with many MCP servers).
+// Allow operators to bump the ceiling via env var without rebuilding.
+function resolveRefreshTimeoutMs(option: number | undefined): number {
+  if (typeof option === "number" && Number.isFinite(option) && option > 0) {
+    return option;
+  }
+  const fromEnv = process.env[REFRESH_TIMEOUT_ENV_VAR];
+  if (fromEnv) {
+    const parsed = Number.parseInt(fromEnv, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_REFRESH_TIMEOUT_MS;
+}
 
 type ProviderSnapshotChangeListener = (entries: ProviderSnapshotEntry[], cwd: string) => void;
 
@@ -124,7 +142,7 @@ export class ProviderSnapshotManager {
     this.runtimeSettings = options.runtimeSettings;
     this.providerOverrides = options.providerOverrides;
     this.baseProviderOverrides = options.providerOverrides;
-    this.refreshTimeoutMs = options.refreshTimeoutMs ?? DEFAULT_REFRESH_TIMEOUT_MS;
+    this.refreshTimeoutMs = resolveRefreshTimeoutMs(options.refreshTimeoutMs);
     this.providerRegistry = this.buildRegistry();
     this.providerClients = { ...this.extraClients } as Record<AgentProvider, AgentClient>;
   }

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -40,7 +40,8 @@ function resolveRefreshTimeoutMs(option: number | undefined): number {
   }
   const fromEnv = process.env[REFRESH_TIMEOUT_ENV_VAR];
   if (fromEnv) {
-    const parsed = Number.parseInt(fromEnv, 10);
+    // Number() handles scientific notation (e.g. "6e4") which parseInt would silently truncate.
+    const parsed = Number(fromEnv);
     if (Number.isFinite(parsed) && parsed > 0) {
       return parsed;
     }


### PR DESCRIPTION
Closes #1345

## Problem

Provider snapshot refresh has a hardcoded 30s timeout for the `isAvailable()` and `listModels`/`listModes` probes:

```
Timed out refreshing Copilot after 30000ms
```

With many providers and MCP servers configured, cold starts (first `copilot --acp` invocation since boot, etc.) can exceed this. A manual retry always succeeds because the second probe hits warm caches.

`ProviderSnapshotManager` already accepts a `refreshTimeoutMs` option, but `bootstrap.ts` never passes it — so there's no way to bump it short of rebuilding the daemon.

## Change

Add `PASEO_PROVIDER_REFRESH_TIMEOUT_MS` env var support inside `ProviderSnapshotManager` itself. Precedence:

1. explicit constructor `refreshTimeoutMs` option (used in tests)
2. `PASEO_PROVIDER_REFRESH_TIMEOUT_MS` env var (new)
3. `DEFAULT_REFRESH_TIMEOUT_MS` = 30_000 (unchanged default)

Invalid values (non-numeric, ≤ 0, NaN) silently fall back to the default.

```bash
PASEO_PROVIDER_REFRESH_TIMEOUT_MS=60000 paseo daemon start
```

## Tests

Three new tests in `provider-snapshot-manager.test.ts` exercise the timeout path with a never-resolving `isAvailable` mock and a tiny budget, asserting the resulting error status carries the expected `after Nms` message:

- explicit option wins
- env var honored when no option given
- explicit option still wins over env var

## Notes

- No protocol changes, no new RPC, no config schema changes
- Default behavior unchanged for everyone not setting the env var
- Local `npm run lint` / `npm run format:check` couldn't run (broken oxfmt/oxlint native bindings on my machine), but CI will catch any formatting issues. Server `typecheck` passed clean.
