### PR TITLE
Authenticate file downloads with their capability token alone

### DIFF
--- a/packages/server/src/server/auth.test.ts
+++ b/packages/server/src/server/auth.test.ts
@@ -7,6 +7,7 @@ import {
   hashDaemonPassword,
   isBearerTokenValidAsync,
   isBearerTokenValid,
+  shouldBypassBearerAuth,
 } from "./auth.js";
 
 const CORRECT_PASSWORD_HASH = "$2b$12$OLxyuuP9uLK30Uzc4wQX0O6liuU/Q1t5P2b0Ebf36mULvpVK3DRZW";
@@ -51,5 +52,17 @@ describe("daemon bearer validator", () => {
     expect(protocol).toBe("paseo.bearer.secret.with.dots");
     expect(extractWsBearerToken(protocol)).toBe("secret.with.dots");
     expect(extractWsBearerToken("paseo.other.secret")).toBeNull();
+  });
+
+  test("bypasses bearer auth for preflight, liveness, and capability-token routes", () => {
+    // Preflight is always bypassed regardless of path.
+    expect(shouldBypassBearerAuth("OPTIONS", "/api/status")).toBe(true);
+    // Unauthenticated liveness probe.
+    expect(shouldBypassBearerAuth("GET", "/api/health")).toBe(true);
+    // Guarded by its own single-use download token, not the daemon password.
+    expect(shouldBypassBearerAuth("GET", "/api/files/download")).toBe(true);
+    // Everything else stays behind the daemon password.
+    expect(shouldBypassBearerAuth("GET", "/api/status")).toBe(false);
+    expect(shouldBypassBearerAuth("POST", "/api/files/upload")).toBe(false);
   });
 });

--- a/packages/server/src/server/auth.ts
+++ b/packages/server/src/server/auth.ts
@@ -118,9 +118,25 @@ export function createRequireBearerMiddleware(
   };
 }
 
+// Routes that authenticate via their own capability and therefore must not be
+// gated a second time behind the daemon password.
+const BEARER_AUTH_BYPASS_PATHS = new Set([
+  // Unauthenticated liveness probe.
+  "/api/health",
+  // Guarded by a single-use download token (crypto-random UUID, 60s TTL,
+  // consumed on first use) that is only ever issued over the
+  // already-authenticated WebSocket. The token IS the capability for this
+  // route. Requiring the daemon password on top of it breaks browser and
+  // Electron downloads: those trigger the download via an anchor navigation,
+  // which cannot attach an `Authorization` header. The download endpoint still
+  // rejects requests without a valid token (400/403), so dropping the bearer
+  // here does not make the route unauthenticated.
+  "/api/files/download",
+]);
+
 export function shouldBypassBearerAuth(method: string, path: string): boolean {
   if (method === "OPTIONS") {
     return true;
   }
-  return path === "/api/health";
+  return BEARER_AUTH_BYPASS_PATHS.has(path);
 }

--- a/packages/server/src/server/bootstrap-auth.test.ts
+++ b/packages/server/src/server/bootstrap-auth.test.ts
@@ -65,18 +65,39 @@ describe("daemon bearer auth", () => {
       auth: { password: CORRECT_PASSWORD_HASH },
     });
     try {
-      const missing = await fetch(`http://127.0.0.1:${daemonHandle.port}/api/files/download`);
+      const missing = await fetch(`http://127.0.0.1:${daemonHandle.port}/api/status`);
       expect(missing.status).toBe(401);
 
-      const wrong = await fetch(`http://127.0.0.1:${daemonHandle.port}/api/files/download`, {
+      const wrong = await fetch(`http://127.0.0.1:${daemonHandle.port}/api/status`, {
         headers: { Authorization: "Bearer wrong-password" },
       });
       expect(wrong.status).toBe(401);
 
-      const correct = await fetch(`http://127.0.0.1:${daemonHandle.port}/api/files/download`, {
+      const correct = await fetch(`http://127.0.0.1:${daemonHandle.port}/api/status`, {
         headers: { Authorization: "Bearer correct-password" },
       });
-      expect(correct.status).toBe(400);
+      expect(correct.status).toBe(200);
+    } finally {
+      await daemonHandle.close();
+    }
+  });
+
+  test("allows file downloads with only a capability token when password is configured", async () => {
+    const daemonHandle = await createTestPaseoDaemon({
+      auth: { password: CORRECT_PASSWORD_HASH },
+    });
+    try {
+      // No bearer at all: the route is reachable, but the download token store
+      // rejects the request because no token was supplied (400, not 401).
+      const missingToken = await fetch(`http://127.0.0.1:${daemonHandle.port}/api/files/download`);
+      expect(missingToken.status).toBe(400);
+
+      // An invalid token is rejected by the token store (403, not 401) — proving
+      // the token, not the daemon password, is what guards this route.
+      const invalidToken = await fetch(
+        `http://127.0.0.1:${daemonHandle.port}/api/files/download?token=invalid-token`,
+      );
+      expect(invalidToken.status).toBe(403);
     } finally {
       await daemonHandle.close();
     }


### PR DESCRIPTION
Fixes #1350.

## What

Add `/api/files/download` to the daemon's bearer-auth bypass list so the route
authenticates with its single-use download token alone, instead of *also*
requiring the daemon password.

## Why

`createRequireBearerMiddleware` gates every route except `/api/health` behind
`PASEO_PASSWORD`, including `/api/files/download`. But that route already
carries a single-use, 60s-TTL, `crypto.randomUUID()` token that is only ever
issued over the authenticated WebSocket — the token *is* the capability for the
route.

Requiring the password on top of the token breaks browser and Electron
downloads, which trigger the download via an anchor navigation that cannot
attach an `Authorization` header. The cross-platform download store
(`packages/app/src/stores/download-store.ts`) therefore sends no bearer, and the
daemon returns `401` whenever a password is configured. See #1350 for the full
root-cause analysis, including why a client-side bearer fix only works on
native and not on web/Electron.

## How

`shouldBypassBearerAuth` now also bypasses `/api/files/download`. The download
handler still validates the token (`400` missing / `403` invalid/expired), so
the route stays authenticated — it just no longer demands the daemon password a
second time.

Because this only relaxes a redundant second factor on the daemon side, it also
fixes every already-released client without an app update.

## Security note

The download token retains all of its properties: 122 bits of entropy,
single-use (consumed before the file is served), 60s TTL, and issued only over
the authenticated WebSocket. The only change is that a leaked, not-yet-consumed
token within its 60s window no longer additionally requires the password —
a single-use, TLS-protected window.

## Tests

- `auth.test.ts`: unit coverage for `shouldBypassBearerAuth` (preflight,
  liveness, and the download capability route bypass; everything else stays
  gated).
- `bootstrap-auth.test.ts`: repointed the "protected route requires bearer"
  case to `/api/status`, and added a case asserting `/api/files/download` is
  reachable without a bearer but still token-gated (`400` without a token,
  `403` with an invalid one) when a password is configured.
