### PR TITLE
Keep virtualenvs out of project picker results

### DIFF
--- a/packages/server/src/utils/directory-suggestions.test.ts
+++ b/packages/server/src/utils/directory-suggestions.test.ts
@@ -93,6 +93,32 @@ describe("searchHomeDirectories", () => {
     expect(exactIndex).toBeLessThan(prefixIndex);
   });
 
+  it("does not let Python virtual environments crowd out top-level project matches", async () => {
+    const projectPath = path.join(homeDir, "django-po-merge");
+    const dependencyPath = path.join(
+      homeDir,
+      "other-project",
+      "venv",
+      "Lib",
+      "site-packages",
+      "django",
+    );
+    mkdirSync(projectPath, { recursive: true });
+    mkdirSync(dependencyPath, { recursive: true });
+
+    const results = await searchHomeDirectories({
+      homeDir,
+      query: "~/django",
+      limit: 30,
+    });
+
+    const resolvedResults = results.map((result) => realpathSync.native(result));
+    const projectIndex = resolvedResults.indexOf(realpathSync.native(projectPath));
+    const dependencyIndex = resolvedResults.indexOf(realpathSync.native(dependencyPath));
+    expect(projectIndex).toBeGreaterThanOrEqual(0);
+    expect(dependencyIndex).toBe(-1);
+  });
+
   it("prioritizes partial matches that appear earlier in the path", async () => {
     const earlierPath = path.join(homeDir, "farofoo");
     const laterPath = path.join(homeDir, "x", "y", "farofoo");

--- a/packages/server/src/utils/directory-suggestions.test.ts
+++ b/packages/server/src/utils/directory-suggestions.test.ts
@@ -95,16 +95,20 @@ describe("searchHomeDirectories", () => {
 
   it("does not let Python virtual environments crowd out top-level project matches", async () => {
     const projectPath = path.join(homeDir, "django-po-merge");
-    const dependencyPath = path.join(
-      homeDir,
-      "other-project",
-      "venv",
-      "Lib",
-      "site-packages",
-      "django",
-    );
     mkdirSync(projectPath, { recursive: true });
-    mkdirSync(dependencyPath, { recursive: true });
+    const dependencyPaths = ["venv", "env", "virtualenv"].map((environmentDirectoryName) =>
+      path.join(
+        homeDir,
+        `${environmentDirectoryName}-project`,
+        environmentDirectoryName,
+        "Lib",
+        "site-packages",
+        "django",
+      ),
+    );
+    for (const dependencyPath of dependencyPaths) {
+      mkdirSync(dependencyPath, { recursive: true });
+    }
 
     const results = await searchHomeDirectories({
       homeDir,
@@ -114,9 +118,10 @@ describe("searchHomeDirectories", () => {
 
     const resolvedResults = results.map((result) => realpathSync.native(result));
     const projectIndex = resolvedResults.indexOf(realpathSync.native(projectPath));
-    const dependencyIndex = resolvedResults.indexOf(realpathSync.native(dependencyPath));
     expect(projectIndex).toBeGreaterThanOrEqual(0);
-    expect(dependencyIndex).toBe(-1);
+    for (const dependencyPath of dependencyPaths) {
+      expect(resolvedResults).not.toContain(realpathSync.native(dependencyPath));
+    }
   });
 
   it("prioritizes partial matches that appear earlier in the path", async () => {

--- a/packages/server/src/utils/directory-suggestions.ts
+++ b/packages/server/src/utils/directory-suggestions.ts
@@ -78,8 +78,9 @@ const NO_SEGMENT_INDEX = Number.MAX_SAFE_INTEGER;
 const NO_MATCH_OFFSET = Number.MAX_SAFE_INTEGER;
 const NO_FUZZY_SCORE = Number.MAX_SAFE_INTEGER;
 const NO_WORKSPACE_MATCH_TIER = 5;
-const WORKSPACE_IGNORED_DIRECTORY_NAMES = new Set([
+const IGNORED_SUGGESTION_DIRECTORY_NAMES = new Set([
   "node_modules",
+  "venv",
   "dist",
   "build",
   "target",
@@ -824,7 +825,9 @@ async function listChildDirectories(input: {
   );
   const candidates = dirents.filter(
     (dirent) =>
-      !isHiddenDirectoryName(dirent.name) && (dirent.isDirectory() || dirent.isSymbolicLink()),
+      !isHiddenDirectoryName(dirent.name) &&
+      !isIgnoredSuggestionDirectoryName(dirent.name) &&
+      (dirent.isDirectory() || dirent.isSymbolicLink()),
   );
   const resolved = await Promise.all(
     candidates.map(async (dirent) => {
@@ -864,7 +867,7 @@ async function listWorkspaceChildEntries(input: {
   );
   const candidates = dirents.filter(
     (dirent) =>
-      !isHiddenDirectoryName(dirent.name) && !isIgnoredWorkspaceDirectoryName(dirent.name),
+      !isHiddenDirectoryName(dirent.name) && !isIgnoredSuggestionDirectoryName(dirent.name),
   );
   const resolved = await Promise.all(
     candidates.map(async (dirent) => {
@@ -955,8 +958,8 @@ function isHiddenDirectoryName(name: string): boolean {
   return name.startsWith(".");
 }
 
-function isIgnoredWorkspaceDirectoryName(name: string): boolean {
-  return WORKSPACE_IGNORED_DIRECTORY_NAMES.has(name);
+function isIgnoredSuggestionDirectoryName(name: string): boolean {
+  return IGNORED_SUGGESTION_DIRECTORY_NAMES.has(name);
 }
 
 function setDirectoryListCache(cacheKey: string, entry: DirectoryListCacheEntry): void {

--- a/packages/server/src/utils/directory-suggestions.ts
+++ b/packages/server/src/utils/directory-suggestions.ts
@@ -81,6 +81,8 @@ const NO_WORKSPACE_MATCH_TIER = 5;
 const IGNORED_SUGGESTION_DIRECTORY_NAMES = new Set([
   "node_modules",
   "venv",
+  "env",
+  "virtualenv",
   "dist",
   "build",
   "target",


### PR DESCRIPTION
### Linked issue

Closes #1352

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The new project picker no longer surfaces Python virtual environment dependency folders while searching home directories. Searching for a project like `~/django` now keeps the top-level project result visible instead of letting `venv/Lib/site-packages/django` crowd the results.

The same generated/dependency directory ignore policy now applies to both home-directory project search and workspace-entry search, with `venv` added to that policy.

### How did you verify it

Reproduced the bug with a failing regression test before the fix: `venv/Lib/site-packages/django` appeared ahead of `django-po-merge` for `~/django`.

After the fix:

- `npx vitest run src/utils/directory-suggestions.test.ts --bail=1` in `packages/server`
- `npm run typecheck`
- `npm run lint`
- `npm run format:files -- packages/server/src/utils/directory-suggestions.ts packages/server/src/utils/directory-suggestions.test.ts`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense