### PR TITLE
Fix worktree checkout validation for existing git branch refs

### DIFF
--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -509,6 +509,24 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       expect((caughtError as InvalidGitBranchNameError).branchName).toBe("bad..name");
     });
 
+    it("throws a typed error when checking out a ref that is valid but not a branch name", async () => {
+      let caughtError: unknown;
+      try {
+        await createLegacyWorktreeForTest({
+          cwd: repoDir,
+          worktreeSlug: "invalid-option-like-branch",
+          source: { kind: "checkout-branch", branchName: "-bad" },
+          runSetup: true,
+          paseoHome,
+        });
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError).toBeInstanceOf(InvalidGitBranchNameError);
+      expect((caughtError as InvalidGitBranchNameError).branchName).toBe("-bad");
+    });
+
     it("handles branch name collision by adding suffix", async () => {
       const projectHash = await deriveWorktreeProjectHash(repoDir);
       // Create a branch named "hello" first

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -6,6 +6,7 @@ import {
   createWorktree as createWorktreePrimitive,
   deriveWorktreeProjectHash,
   deletePaseoWorktree,
+  InvalidGitBranchNameError,
   getScriptConfigs,
   getWorktreeSetupCommands,
   getWorktreeTerminalSpecs,
@@ -270,6 +271,26 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       expect(metadata).toMatchObject({ version: 1, baseRefName: "dev" });
     });
 
+    it("checks out an existing local branch whose name contains uppercase letters and dots", async () => {
+      execFileSync("git", ["branch", "release/1.1.15"], { cwd: repoDir });
+
+      const result = await createLegacyWorktreeForTest({
+        cwd: repoDir,
+        worktreeSlug: "release-worktree",
+        source: { kind: "checkout-branch", branchName: "release/1.1.15" },
+        runSetup: true,
+        paseoHome,
+      });
+
+      expect(existsSync(result.worktreePath)).toBe(true);
+      const currentBranch = execFileSync("git", ["branch", "--show-current"], {
+        cwd: result.worktreePath,
+      })
+        .toString()
+        .trim();
+      expect(currentBranch).toBe("release/1.1.15");
+    });
+
     it("throws a typed error when checking out a branch already checked out in the main repo", async () => {
       let caughtError: unknown;
       try {
@@ -338,6 +359,51 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       const metadataPath = getPaseoWorktreeMetadataPath(result.worktreePath);
       const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
       expect(metadata).toMatchObject({ baseRefName: "main" });
+    });
+
+    it("fetches a GitHub PR branch when the head ref contains uppercase letters and dots", async () => {
+      const remoteDir = join(tempDir, "remote.git");
+      const remoteCloneDir = join(tempDir, "remote-clone");
+      execFileSync("git", ["clone", "--bare", repoDir, remoteDir]);
+      execFileSync("git", ["remote", "add", "origin", remoteDir], { cwd: repoDir });
+
+      execFileSync("git", ["clone", remoteDir, remoteCloneDir]);
+      execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: remoteCloneDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: remoteCloneDir });
+      execFileSync("git", ["checkout", "-b", "Feature.X"], { cwd: remoteCloneDir });
+      writeFileSync(join(remoteCloneDir, "file.txt"), "from-uppercase-pr\n");
+      execFileSync("git", ["add", "file.txt"], { cwd: remoteCloneDir });
+      execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "uppercase pr branch"], {
+        cwd: remoteCloneDir,
+      });
+      const prHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd: remoteCloneDir })
+        .toString()
+        .trim();
+      execFileSync("git", ["push", "origin", "Feature.X"], { cwd: remoteCloneDir });
+      execFileSync("git", [`--git-dir=${remoteDir}`, "update-ref", "refs/pull/43/head", prHead]);
+
+      const result = await createLegacyWorktreeForTest({
+        cwd: repoDir,
+        worktreeSlug: "pr-43",
+        source: {
+          kind: "checkout-github-pr",
+          githubPrNumber: 43,
+          headRef: "Feature.X",
+          baseRefName: "main",
+        },
+        runSetup: true,
+        paseoHome,
+      });
+
+      expect(readFileSync(join(result.worktreePath, "file.txt"), "utf8")).toBe(
+        "from-uppercase-pr\n",
+      );
+      const currentBranch = execFileSync("git", ["branch", "--show-current"], {
+        cwd: result.worktreePath,
+      })
+        .toString()
+        .trim();
+      expect(currentBranch).toBe("Feature.X");
     });
 
     it("prefers origin/{branch} over local {branch} when both exist", async () => {
@@ -423,6 +489,24 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
           worktreeSlug: "test",
         }),
       ).rejects.toThrow("Invalid branch name");
+    });
+
+    it("throws a typed error when checking out an invalid existing branch name", async () => {
+      let caughtError: unknown;
+      try {
+        await createLegacyWorktreeForTest({
+          cwd: repoDir,
+          worktreeSlug: "invalid-existing-branch",
+          source: { kind: "checkout-branch", branchName: "bad..name" },
+          runSetup: true,
+          paseoHome,
+        });
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError).toBeInstanceOf(InvalidGitBranchNameError);
+      expect((caughtError as InvalidGitBranchNameError).branchName).toBe("bad..name");
     });
 
     it("handles branch name collision by adding suffix", async () => {

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -206,6 +206,16 @@ export class UnknownBranchError extends Error {
   }
 }
 
+export class InvalidGitBranchNameError extends Error {
+  readonly branchName: string;
+
+  constructor(branchName: string) {
+    super(`Invalid branch name: Git rejected ref name '${branchName}'`);
+    this.name = "InvalidGitBranchNameError";
+    this.branchName = branchName;
+  }
+}
+
 export type ReadPaseoConfigResult =
   | { ok: true; config: PaseoConfig | null }
   | { ok: false; configPath: string; error: unknown };
@@ -1261,7 +1271,7 @@ async function resolveWorktreeSourcePlan({
       };
     }
     case "checkout-branch": {
-      validateWorktreeBranchName(source.branchName);
+      await validateExistingWorktreeBranchName(cwd, source.branchName);
       if (!(await localBranchExists(cwd, source.branchName))) {
         try {
           await runGitCommand(["fetch", "origin", `${source.branchName}:${source.branchName}`], {
@@ -1284,7 +1294,7 @@ async function resolveWorktreeSourcePlan({
     }
     case "checkout-github-pr": {
       const localBranchCandidate = source.localBranchName ?? source.headRef;
-      validateWorktreeBranchName(localBranchCandidate);
+      await validateExistingWorktreeBranchName(cwd, localBranchCandidate);
       const localBranchName = await resolveUniqueLocalBranchName(cwd, localBranchCandidate);
       const normalizedBaseRefName = normalizeRequiredBaseBranch(source.baseRefName);
       await runGitCommand(
@@ -1347,6 +1357,17 @@ function validateWorktreeBranchName(branchName: string): void {
   const validation = validateBranchSlug(branchName);
   if (!validation.valid) {
     throw new Error(`Invalid branch name: ${validation.error}`);
+  }
+}
+
+async function validateExistingWorktreeBranchName(cwd: string, branchName: string): Promise<void> {
+  try {
+    await runGitCommand(["check-ref-format", `refs/heads/${branchName}`], {
+      cwd,
+      timeout: 30_000,
+    });
+  } catch {
+    throw new InvalidGitBranchNameError(branchName);
   }
 }
 

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1361,12 +1361,12 @@ function validateWorktreeBranchName(branchName: string): void {
 }
 
 async function validateExistingWorktreeBranchName(cwd: string, branchName: string): Promise<void> {
-  try {
-    await runGitCommand(["check-ref-format", `refs/heads/${branchName}`], {
-      cwd,
-      timeout: 30_000,
-    });
-  } catch {
+  const result = await runGitCommand(["check-ref-format", "--branch", branchName], {
+    cwd,
+    timeout: 30_000,
+    acceptExitCodes: [0, 1, 128],
+  });
+  if (result.exitCode !== 0) {
     throw new InvalidGitBranchNameError(branchName);
   }
 }


### PR DESCRIPTION
### Linked issue

Closes #1357

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Paseo was applying its lowercase branch slug rule to checkout paths that target existing or external refs. That blocked valid git branch names like `release/1.1.15` or `Feature.X` before git ever ran.

This keeps the existing slug validation for `branch-off` (new branch creation), but switches `checkout-branch` and `checkout-github-pr` to `git check-ref-format refs/heads/<name>`. If git rejects the ref name, the server now throws a typed `InvalidGitBranchNameError`.

### How did you verify it

This is a server-side logic change only; no UI changed, so no screenshots apply. I tested locally on macOS.

Repro before the fix:
- Existing branch checkout paths rejected valid refs with uppercase letters or dots via the `Invalid branch name` slug check.

Confirmed after the fix:
- `checkout-branch` accepts an existing branch named `release/1.1.15`.
- `checkout-github-pr` accepts a PR head ref named `Feature.X`.
- The existing `branch-off` invalid-name test still passes, so new branch creation still enforces the slug rule.

Commands run:
- `npm install`
- `npm run build:server`
- `cd packages/server && npx vitest run src/utils/worktree.posix.test.ts --bail=1`
  - Result: `Test Files 1 passed (1)` and `Tests 41 passed | 1 skipped (42)`
- `npm run typecheck`
  - Result: passed across all workspaces
- `npm run lint`
  - Result: `Found 0 warnings and 0 errors.`
- `npm run format`
  - Result: completed successfully
- `npm run format:check`
  - Result: `All matched files use the correct format.`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
