### PR TITLE
fix: prevent file mention autocomplete from triggering on email addresses

### DIFF
--- a/packages/app/src/utils/file-mention-autocomplete.test.ts
+++ b/packages/app/src/utils/file-mention-autocomplete.test.ts
@@ -44,6 +44,24 @@ describe("findActiveFileMention", () => {
     });
     expect(mention).toBeNull();
   });
+
+  it("returns null for email addresses (word char before @)", () => {
+    const text = "thedavidweng <95214375+thedavidweng@users.noreply.github.com>";
+    const mention = findActiveFileMention({
+      text,
+      cursorIndex: text.length,
+    });
+    expect(mention).toBeNull();
+  });
+
+  it("returns null when query contains angle brackets", () => {
+    const text = "check @foo<bar> end";
+    const mention = findActiveFileMention({
+      text,
+      cursorIndex: text.indexOf(" end"),
+    });
+    expect(mention).toBeNull();
+  });
 });
 
 describe("applyFileMentionReplacement", () => {

--- a/packages/app/src/utils/file-mention-autocomplete.test.ts
+++ b/packages/app/src/utils/file-mention-autocomplete.test.ts
@@ -46,7 +46,16 @@ describe("findActiveFileMention", () => {
   });
 
   it("returns null for email addresses (word char before @)", () => {
-    const text = "thedavidweng <95214375+thedavidweng@users.noreply.github.com>";
+    const text = "send to alice@example.com please";
+    const mention = findActiveFileMention({
+      text,
+      cursorIndex: text.length,
+    });
+    expect(mention).toBeNull();
+  });
+
+  it("returns null for email addresses (+ before @)", () => {
+    const text = "send to noreply+tag@example.com please";
     const mention = findActiveFileMention({
       text,
       cursorIndex: text.length,

--- a/packages/app/src/utils/file-mention-autocomplete.ts
+++ b/packages/app/src/utils/file-mention-autocomplete.ts
@@ -15,7 +15,7 @@ interface ApplyFileMentionReplacementInput {
   relativePath: string;
 }
 
-const INVALID_MENTION_QUERY_CHARS = /[\s\n\r\t"']/;
+const INVALID_MENTION_QUERY_CHARS = /[\s\n\r\t"'><]/;
 
 export function findActiveFileMention(input: FindActiveFileMentionInput): FileMentionRange | null {
   const clampedCursor = Math.max(0, Math.min(input.cursorIndex, input.text.length));
@@ -26,6 +26,10 @@ export function findActiveFileMention(input: FindActiveFileMentionInput): FileMe
     atIndex >= 0;
     atIndex = atIndex === 0 ? -1 : beforeCursor.lastIndexOf("@", atIndex - 1)
   ) {
+    // Skip @ that looks like part of an email address (preceded by a word character)
+    if (atIndex > 0 && /\w/.test(beforeCursor[atIndex - 1])) {
+      continue;
+    }
     const query = beforeCursor.slice(atIndex + 1);
     if (INVALID_MENTION_QUERY_CHARS.test(query)) {
       continue;

--- a/packages/app/src/utils/file-mention-autocomplete.ts
+++ b/packages/app/src/utils/file-mention-autocomplete.ts
@@ -26,8 +26,8 @@ export function findActiveFileMention(input: FindActiveFileMentionInput): FileMe
     atIndex >= 0;
     atIndex = atIndex === 0 ? -1 : beforeCursor.lastIndexOf("@", atIndex - 1)
   ) {
-    // Skip @ that looks like part of an email address (preceded by a word character)
-    if (atIndex > 0 && /\w/.test(beforeCursor[atIndex - 1])) {
+    // Skip @ that looks like part of an email address (preceded by a word character or +)
+    if (atIndex > 0 && /[\w+]/.test(beforeCursor[atIndex - 1])) {
       continue;
     }
     const query = beforeCursor.slice(atIndex + 1);


### PR DESCRIPTION
## Problem

File mention autocomplete (`@` trigger) falsely activates on email addresses in message input. When a user types text containing an email like `user <12345+user@noreply.example.com>` and presses Enter, the `@` is detected as a file mention, the autocomplete popover appears, and Enter selects the first suggestion — replacing part of the email with a quoted file path.

## Root Cause

`findActiveFileMention` in `file-mention-autocomplete.ts`:

1. Scans backwards for `@` but doesn't check if it's part of an email (preceded by a word character)
2. `INVALID_MENTION_QUERY_CHARS` regex doesn't include `<` or `>`, so `noreply.example.com>` passes validation

## Fix

1. Add `<` and `>` to `INVALID_MENTION_QUERY_CHARS`
2. Skip `@` preceded by a word character (`\w`) — indicates email, not file mention

Closes #1364
