### PR TITLE
fix: daemon warns instead of crashing on missing OpenAI speech credentials

### DIFF
--- a/packages/server/src/server/bootstrap.smoke.test.ts
+++ b/packages/server/src/server/bootstrap.smoke.test.ts
@@ -338,7 +338,7 @@ describe("paseo daemon bootstrap", () => {
     }
   });
 
-  test("fails fast when OpenAI speech provider is configured without credentials", async () => {
+  test("starts when OpenAI speech provider is configured without credentials", async () => {
     const paseoHomeRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-openai-config-"));
     const paseoHome = path.join(paseoHomeRoot, ".paseo");
     const staticDir = await mkdtemp(path.join(os.tmpdir(), "paseo-static-"));
@@ -367,9 +367,11 @@ describe("paseo daemon bootstrap", () => {
     };
 
     try {
-      await expect(createPaseoDaemon(config, pino({ level: "silent" }))).rejects.toThrow(
-        "Missing OpenAI credentials",
-      );
+      const daemon = await createPaseoDaemon(config, pino({ level: "silent" }));
+      expect(daemon).toBeDefined();
+      // Must also start without throwing
+      await daemon.start();
+      await daemon.stop();
     } finally {
       await rm(paseoHomeRoot, { recursive: true, force: true });
       await rm(staticDir, { recursive: true, force: true });

--- a/packages/server/src/server/bootstrap.smoke.test.ts
+++ b/packages/server/src/server/bootstrap.smoke.test.ts
@@ -368,10 +368,13 @@ describe("paseo daemon bootstrap", () => {
 
     try {
       const daemon = await createPaseoDaemon(config, pino({ level: "silent" }));
-      expect(daemon).toBeDefined();
-      // Must also start without throwing
-      await daemon.start();
-      await daemon.stop();
+      try {
+        await daemon.start();
+        expect(daemon.getListenTarget()).toBeDefined();
+        // Must also stop without throwing
+      } finally {
+        await daemon.stop();
+      }
     } finally {
       await rm(paseoHomeRoot, { recursive: true, force: true });
       await rm(staticDir, { recursive: true, force: true });

--- a/packages/server/src/server/speech/providers/openai/runtime.ts
+++ b/packages/server/src/server/speech/providers/openai/runtime.ts
@@ -85,7 +85,7 @@ export function validateOpenAiCredentialRequirements(params: {
   }
 
   if (missingOpenAiCredentialsFor.length > 0) {
-    logger.error(
+    logger.warn(
       {
         requestedProviders: {
           dictationStt: providers.dictationStt.provider,
@@ -94,10 +94,7 @@ export function validateOpenAiCredentialRequirements(params: {
         },
         missingOpenAiCredentialsFor,
       },
-      "Invalid speech configuration: OpenAI provider selected but credentials are missing",
-    );
-    throw new Error(
-      `Missing OpenAI credentials for configured speech features: ${missingOpenAiCredentialsFor.join(", ")}`,
+      "Invalid speech configuration: OpenAI provider selected but credentials are missing — speech features will be unavailable",
     );
   }
 }

--- a/packages/server/src/server/speech/providers/openai/runtime.ts
+++ b/packages/server/src/server/speech/providers/openai/runtime.ts
@@ -192,7 +192,7 @@ export function initializeOpenAiSpeechServices(params: {
       );
     }
   } else if (needsAnyOpenAi) {
-    logger.warn("OpenAI speech providers are configured but credentials are missing");
+    // validateOpenAiCredentialRequirements already warned about missing credentials
   }
 
   return {


### PR DESCRIPTION
Fixes #1367

## Problem
The daemon crashed on startup when dictation (or other speech features) was configured with the OpenAI provider but no API key was set. `validateOpenAiCredentialRequirements` was throwing an Error synchronously during daemon construction, preventing it from ever reaching a state where it could serve health checks — resulting in a crash loop.

## Fix
Changed `validateOpenAiCredentialRequirements` to log a warning instead of throwing. The daemon now starts successfully, and speech features requiring missing credentials are reported as unavailable. This matches the existing graceful degradation path in `initializeOpenAiSpeechServices`.

## Changes
- `packages/server/src/server/speech/providers/openai/runtime.ts`: Replaced `logger.error` + `throw` with `logger.warn` only  
- `packages/server/src/server/bootstrap.smoke.test.ts`: Updated the test to verify the daemon **starts** successfully when credentials are missing (rather than crashing as before)