### PR TITLE
fix(app): open settings for the current host and return to the originating page

### DIFF
--- a/packages/app/e2e/diff-row-alignment.spec.ts
+++ b/packages/app/e2e/diff-row-alignment.spec.ts
@@ -1,7 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { type Page } from "@playwright/test";
-import { buildHostWorkspaceRoute, buildSettingsSectionRoute } from "../src/utils/host-routes";
+import { buildHostWorkspaceRoute } from "../src/utils/host-routes";
 import { test, expect } from "./fixtures";
 import { getServerId } from "./helpers/server-id";
 import { connectSeedClient } from "./helpers/seed-client";
@@ -393,7 +393,7 @@ async function expectExpandedMountedTabDiff(page: Page): Promise<void> {
 
 async function changeCodeFontSizeFromSettings(page: Page, codeFontSize: number): Promise<void> {
   await page.getByTestId("sidebar-settings").click();
-  await expect(page).toHaveURL(new RegExp(`${buildSettingsSectionRoute("general")}|/settings$`));
+  await expect(page).toHaveURL(/\/settings(?:\/|$)/);
   await page.getByRole("button", { name: "Appearance" }).click();
   await page.getByLabel("Code font size").fill(String(codeFontSize));
   await page.getByLabel("Code font size").press("Enter");

--- a/packages/app/e2e/helpers/app.ts
+++ b/packages/app/e2e/helpers/app.ts
@@ -35,7 +35,7 @@ export const openSettings = async (page: Page) => {
   const settingsButton = page.locator('[data-testid="sidebar-settings"]:visible').first();
   await expect(settingsButton).toBeVisible();
   await settingsButton.click();
-  await expect(page).toHaveURL(/\/settings\/general$/);
+  await expect(page).toHaveURL(/\/settings(?:\/|$)/);
 };
 
 export const setWorkingDirectory = async (page: Page, directory: string) => {

--- a/packages/app/e2e/helpers/settings.ts
+++ b/packages/app/e2e/helpers/settings.ts
@@ -27,8 +27,12 @@ export type SettingsSection = keyof typeof SECTION_LABELS | "projects";
 
 type HostSection = "connections" | "agents" | "workspaces" | "providers" | "host";
 
+function visibleSettingsSidebar(page: Page) {
+  return page.locator('[data-testid="settings-sidebar"]:visible').first();
+}
+
 export async function openSettingsSection(page: Page, section: SettingsSection): Promise<void> {
-  const sidebar = page.getByTestId("settings-sidebar");
+  const sidebar = visibleSettingsSidebar(page);
   await expect(sidebar).toBeVisible();
 
   if (section === "projects") {
@@ -39,6 +43,11 @@ export async function openSettingsSection(page: Page, section: SettingsSection):
 
   await sidebar.getByRole("button", { name: SECTION_LABELS[section], exact: true }).click();
   await expect(page).toHaveURL(new RegExp(`/settings/${section}$`));
+}
+
+export async function openGeneralSettingsSection(page: Page): Promise<void> {
+  await openSettingsSection(page, "general");
+  await expectGeneralContent(page);
 }
 
 export async function openSettingsHost(page: Page, serverId: string): Promise<void> {
@@ -90,8 +99,20 @@ export async function openCompactSettings(page: Page): Promise<void> {
   const settingsButton = page.locator('[data-testid="sidebar-settings"]:visible').first();
   await expect(settingsButton).toBeVisible();
   await settingsButton.click();
+  await expect(page).toHaveURL(/\/settings(?:\/|$)/);
+
+  if (
+    !(await page
+      .locator('[data-testid="settings-sidebar"]:visible')
+      .first()
+      .isVisible()
+      .catch(() => false))
+  ) {
+    await goBackInSettings(page);
+  }
+
   await expect(page).toHaveURL(/\/settings$/);
-  await expect(page.getByTestId("settings-sidebar")).toBeVisible();
+  await expect(visibleSettingsSidebar(page)).toBeVisible();
 }
 
 export async function seedSavedSettingsHosts(
@@ -150,14 +171,14 @@ export async function expectSettingsHostPickerLabel(page: Page, label: string): 
 
 export async function expectCompactSettingsList(page: Page): Promise<void> {
   await expect(page).toHaveURL(/\/settings$/);
-  await expect(page.getByTestId("settings-sidebar")).toBeVisible();
+  await expect(visibleSettingsSidebar(page)).toBeVisible();
   await expect(page.getByText("Theme", { exact: true })).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Play test" })).toHaveCount(0);
   await expect(page.getByTestId("host-page-connections-card")).toHaveCount(0);
 }
 
 export async function expectSettingsSidebarVisible(page: Page): Promise<void> {
-  await expect(page.getByTestId("settings-sidebar")).toBeVisible();
+  await expect(visibleSettingsSidebar(page)).toBeVisible();
 }
 
 export async function expectSettingsSidebarHidden(page: Page): Promise<void> {
@@ -168,7 +189,7 @@ export async function expectSettingsSidebarSections(
   page: Page,
   sections: Array<Exclude<SettingsSection, "projects">>,
 ): Promise<void> {
-  const sidebar = page.getByTestId("settings-sidebar");
+  const sidebar = visibleSettingsSidebar(page);
   for (const section of sections) {
     await expect(
       sidebar.getByRole("button", { name: SECTION_LABELS[section], exact: true }),
@@ -350,7 +371,7 @@ export async function expectHostNoLocalOnlyRows(page: Page): Promise<void> {
 }
 
 export async function expectRetiredSidebarSectionsAbsent(page: Page): Promise<void> {
-  const sidebar = page.getByTestId("settings-sidebar");
+  const sidebar = visibleSettingsSidebar(page);
   await expect(sidebar).toBeVisible();
 
   // App group rows remain top-level.
@@ -374,7 +395,7 @@ export async function expectHostPageVisible(page: Page, _serverId: string): Prom
 }
 
 export async function expectLocalHostEntryFirst(page: Page, _serverId: string): Promise<void> {
-  const sidebar = page.getByTestId("settings-sidebar");
+  const sidebar = visibleSettingsSidebar(page);
   await expect(sidebar).toBeVisible({ timeout: 15_000 });
 
   // Single-host fixture: the picker is a non-interactive chip (no dropdown to

--- a/packages/app/e2e/settings-toggle-tab-regression.spec.ts
+++ b/packages/app/e2e/settings-toggle-tab-regression.spec.ts
@@ -4,6 +4,7 @@ import { createIdleAgent, openWorkspaceWithAgents } from "./helpers/archive-tab"
 import { waitForTabBar, expectAgentTabActive } from "./helpers/launcher";
 import { seedWorkspace } from "./helpers/seed-client";
 import { getServerId } from "./helpers/server-id";
+import { openGeneralSettingsSection } from "./helpers/settings";
 
 async function pressSettingsToggleShortcut(page: import("@playwright/test").Page) {
   const modifier = process.platform === "darwin" ? "Meta" : "Control";
@@ -66,7 +67,8 @@ test.describe("Settings toggle tab regression", () => {
       await expectAgentTabActive(page, secondAgent.id);
 
       await pressSettingsToggleShortcut(page);
-      await expect(page).toHaveURL(/\/settings\/general$/);
+      await expect(page).toHaveURL(/\/settings(?:\/|$)/);
+      await openGeneralSettingsSection(page);
 
       await page.getByRole("button", { name: "Queue", exact: true }).click();
       await expectSendBehavior(page, "queue");

--- a/packages/app/e2e/workspace-navigation-regression.spec.ts
+++ b/packages/app/e2e/workspace-navigation-regression.spec.ts
@@ -30,7 +30,7 @@ import {
   workspaceDeckEntryLocator,
   expectWorkspaceDeckEntryCount,
 } from "./helpers/workspace-ui";
-import { clickSettingsBackToWorkspace } from "./helpers/settings";
+import { clickSettingsBackToWorkspace, expectHostSettingsUrl } from "./helpers/settings";
 import { getServerId } from "./helpers/server-id";
 
 const LOADING_WORKSPACE_TEXT_PATTERN = /Loading workspace/i;
@@ -229,7 +229,7 @@ test.describe("Workspace navigation regression", () => {
     await expectWorkspaceHeaderAbsent(page);
     await expectWorkspaceTabsAbsent(page);
     await openSettings(page);
-    await expect(page).toHaveURL(/\/settings\/general$/);
+    await expectHostSettingsUrl(page, serverId);
   });
 
   test("cold workspace URL keeps sidebar workspace navigation functional", async ({ page }) => {

--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -1,4 +1,4 @@
-import { router, usePathname } from "expo-router";
+import { router, usePathname, type Href } from "expo-router";
 import { FolderPlus, Home, MessagesSquare, Plus, Search, Settings, X } from "lucide-react-native";
 import {
   type Dispatch,
@@ -68,9 +68,9 @@ import {
   buildHostOpenProjectRoute,
   buildHostNewWorkspaceRoute,
   buildHostSessionsRoute,
-  buildSettingsRoute,
   mapPathnameToServer,
 } from "@/utils/host-routes";
+import { prepareSettingsEntryNavigation } from "@/stores/settings-entry-context";
 import { SidebarAgentListSkeleton } from "./sidebar-agent-list-skeleton";
 import { SidebarCalloutSlot } from "./sidebar-callout-slot";
 import { SidebarWorkspaceList } from "./sidebar-workspace-list";
@@ -231,12 +231,12 @@ export const LeftSidebar = memo(function LeftSidebar({
 
   const handleSettingsMobile = useCallback(() => {
     showMobileAgent();
-    router.push(buildSettingsRoute());
-  }, [showMobileAgent]);
+    router.push(prepareSettingsEntryNavigation(pathname) as Href);
+  }, [pathname, showMobileAgent]);
 
   const handleSettingsDesktop = useCallback(() => {
-    router.push(buildSettingsRoute());
-  }, []);
+    router.push(prepareSettingsEntryNavigation(pathname) as Href);
+  }, [pathname]);
 
   const handleHomeMobile = useCallback(() => {
     if (!activeServerId) return;

--- a/packages/app/src/hooks/use-any-online-host-server-id.ts
+++ b/packages/app/src/hooks/use-any-online-host-server-id.ts
@@ -1,0 +1,26 @@
+import { useSyncExternalStore } from "react";
+import { getHostRuntimeStore, isHostRuntimeConnected } from "@/runtime/host-runtime";
+
+export function useAnyOnlineHostServerId(serverIds: string[]): string | null {
+  const runtime = getHostRuntimeStore();
+  return useSyncExternalStore(
+    (onStoreChange) => runtime.subscribeAll(onStoreChange),
+    () => {
+      let firstOnlineServerId: string | null = null;
+      let firstOnlineAt: string | null = null;
+      for (const serverId of serverIds) {
+        const snapshot = runtime.getSnapshot(serverId);
+        const lastOnlineAt = snapshot?.lastOnlineAt ?? null;
+        if (!isHostRuntimeConnected(snapshot) || !lastOnlineAt) {
+          continue;
+        }
+        if (!firstOnlineAt || lastOnlineAt < firstOnlineAt) {
+          firstOnlineAt = lastOnlineAt;
+          firstOnlineServerId = serverId;
+        }
+      }
+      return firstOnlineServerId;
+    },
+    () => null,
+  );
+}

--- a/packages/app/src/hooks/use-command-center.ts
+++ b/packages/app/src/hooks/use-command-center.ts
@@ -10,7 +10,11 @@ import {
   clearCommandCenterFocusRestoreElement,
   takeCommandCenterFocusRestoreElement,
 } from "@/utils/command-center-focus-restore";
-import { buildHostOpenProjectRoute, buildSettingsRoute } from "@/utils/host-routes";
+import { buildHostOpenProjectRoute } from "@/utils/host-routes";
+import {
+  buildSettingsEntryRoute,
+  prepareSettingsEntryNavigation,
+} from "@/stores/settings-entry-context";
 import type { ShortcutKey } from "@/utils/format-shortcut";
 import { chordStringToShortcutKeys } from "@/keyboard/shortcut-string";
 import { getBindingIdForAction, getDefaultKeysForAction } from "@/keyboard/keyboard-shortcuts";
@@ -159,8 +163,8 @@ export function useCommandCenter() {
   }, [agents, open, query]);
 
   const settingsRoute = useMemo<Href>(() => {
-    return buildSettingsRoute();
-  }, []);
+    return buildSettingsEntryRoute(pathname) as Href;
+  }, [pathname]);
 
   const homeRoute = useMemo<Href | undefined>(() => {
     if (!routeActiveServerId) return undefined;
@@ -243,9 +247,13 @@ export function useCommandCenter() {
         return;
       }
       didNavigateRef.current = true;
+      if (action.id === "settings") {
+        router.push(prepareSettingsEntryNavigation(pathname) as Href);
+        return;
+      }
       router.push(action.route);
     },
-    [openProjectPicker, setOpen],
+    [openProjectPicker, pathname, setOpen],
   );
 
   const handleSelectItem = useCallback(

--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -23,11 +23,18 @@ import { isNative } from "@/constants/platform";
 import { getDesktopHost, isElectronRuntime } from "@/desktop/host";
 import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
 import { useActiveServerId } from "@/hooks/use-active-server-id";
+import { useAnyOnlineHostServerId } from "@/hooks/use-any-online-host-server-id";
 import {
   type ActiveWorkspaceSelection,
   navigateToLastWorkspace,
   useActiveWorkspaceSelection,
 } from "@/stores/navigation-active-workspace-store";
+import {
+  consumeSettingsEntryReturnPath,
+  prepareSettingsEntryNavigation,
+} from "@/stores/settings-entry-context";
+import { useHosts } from "@/runtime/host-runtime";
+import { resolveSettingsBackDestination } from "@/screens/settings-navigation";
 
 export function useKeyboardShortcuts({
   enabled,
@@ -55,6 +62,9 @@ export function useKeyboardShortcuts({
     timeoutId: null,
   });
   const activeServerId = useActiveServerId();
+  const hosts = useHosts();
+  const hostServerIds = useMemo(() => hosts.map((host) => host.serverId), [hosts]);
+  const anyOnlineServerId = useAnyOnlineHostServerId(hostServerIds);
   const openProjectPickerAction = useOpenProjectPicker(activeServerId);
   const activeWorkspaceSelection = useActiveWorkspaceSelection();
   const keyboardWorkspaceSelectionRef = useRef<ActiveWorkspaceSelection | null>(null);
@@ -111,6 +121,27 @@ export function useKeyboardShortcuts({
           return true;
         case "navigate-last-workspace":
           return navigateToLastWorkspace();
+        case "navigate-settings-entry":
+          router.push(
+            prepareSettingsEntryNavigation(pathname) as Parameters<typeof router.push>[0],
+          );
+          return true;
+        case "navigate-settings-return": {
+          const returnPath = consumeSettingsEntryReturnPath();
+          if (returnPath) {
+            router.dismissTo(returnPath as Parameters<typeof router.dismissTo>[0]);
+            return true;
+          }
+          if (navigateToLastWorkspace()) {
+            return true;
+          }
+          const fallbackDestination = resolveSettingsBackDestination({
+            entryReturnPath: null,
+            anyOnlineServerId,
+          });
+          router.replace(fallbackDestination.route as Parameters<typeof router.replace>[0]);
+          return true;
+        }
         case "router-replace":
           router.replace(action.route as Parameters<typeof router.replace>[0]);
           return true;
@@ -291,6 +322,7 @@ export function useKeyboardShortcuts({
     cycleTheme,
     enabled,
     activeWorkspaceSelection,
+    anyOnlineServerId,
     isMobile,
     openProjectPickerAction,
     pathname,

--- a/packages/app/src/keyboard/route-shortcut.test.ts
+++ b/packages/app/src/keyboard/route-shortcut.test.ts
@@ -301,16 +301,16 @@ describe("routeKeyboardShortcut — message-input.action", () => {
 });
 
 describe("routeKeyboardShortcut — settings.toggle", () => {
-  it("pushes to the settings root when not currently in settings", () => {
+  it("opens settings through the entry navigation helper when not currently in settings", () => {
     expect(
       routeKeyboardShortcut(
         { action: "settings.toggle", payload: null },
         makeCtx({ pathname: "/h/srv/workspace/ws-2" }),
       ),
-    ).toEqual<ShortcutAction>({ kind: "router-push", route: "/settings" });
+    ).toEqual<ShortcutAction>({ kind: "navigate-settings-entry" });
   });
 
-  it("navigates to the last workspace when leaving settings on desktop", () => {
+  it("returns through the settings entry context when leaving settings on desktop", () => {
     expect(
       routeKeyboardShortcut(
         { action: "settings.toggle", payload: null },
@@ -319,7 +319,7 @@ describe("routeKeyboardShortcut — settings.toggle", () => {
           isMobile: false,
         }),
       ),
-    ).toEqual<ShortcutAction>({ kind: "navigate-last-workspace" });
+    ).toEqual<ShortcutAction>({ kind: "navigate-settings-return" });
   });
 
   it("falls back to router.back() on mobile", () => {

--- a/packages/app/src/keyboard/route-shortcut.ts
+++ b/packages/app/src/keyboard/route-shortcut.ts
@@ -1,6 +1,7 @@
 import type { KeyboardShortcutPayload, MessageInputKeyboardActionKind } from "@/keyboard/actions";
 import type { KeyboardActionDefinition } from "@/keyboard/keyboard-action-dispatcher";
-import { buildSettingsRoute, parseHostWorkspaceRouteFromPathname } from "@/utils/host-routes";
+import { parseHostWorkspaceRouteFromPathname } from "@/utils/host-routes";
+import { isSettingsPathname } from "@/stores/settings-entry-context";
 import {
   getRelativeSidebarShortcutTarget,
   type SidebarShortcutWorkspaceTarget,
@@ -31,6 +32,8 @@ export type ShortcutAction =
   | { kind: "dispatch"; action: KeyboardActionDefinition }
   | { kind: "navigate-workspace"; serverId: string; workspaceId: string }
   | { kind: "navigate-last-workspace" }
+  | { kind: "navigate-settings-entry" }
+  | { kind: "navigate-settings-return" }
   | { kind: "router-replace"; route: string }
   | { kind: "router-back" }
   | { kind: "router-push"; route: string }
@@ -159,11 +162,11 @@ function routeMessageInputAction(payload: KeyboardShortcutPayload): ShortcutActi
 }
 
 function routeSettingsToggle(ctx: ShortcutRoutingContext): ShortcutAction {
-  if (!ctx.pathname.startsWith("/settings")) {
-    return { kind: "router-push", route: buildSettingsRoute() };
+  if (!isSettingsPathname(ctx.pathname)) {
+    return { kind: "navigate-settings-entry" };
   }
   if (!ctx.isMobile) {
-    return { kind: "navigate-last-workspace" };
+    return { kind: "navigate-settings-return" };
   }
   return { kind: "router-back" };
 }

--- a/packages/app/src/screens/settings-navigation.test.ts
+++ b/packages/app/src/screens/settings-navigation.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveCompactSettingsDetailBackDestination,
+  resolveSettingsBackDestination,
+} from "./settings-navigation";
+
+describe("resolveSettingsBackDestination", () => {
+  it("prefers the entry return route", () => {
+    expect(
+      resolveSettingsBackDestination({
+        entryReturnPath: "/h/srv-1/workspace/repo",
+        anyOnlineServerId: "srv-2",
+      }),
+    ).toEqual({
+      kind: "entry-route",
+      route: "/h/srv-1/workspace/repo",
+    });
+  });
+
+  it("falls back to an online host open-project route", () => {
+    expect(
+      resolveSettingsBackDestination({
+        entryReturnPath: null,
+        anyOnlineServerId: "srv-2",
+      }),
+    ).toEqual({
+      kind: "fallback-route",
+      route: "/h/srv-2/open-project",
+    });
+  });
+
+  it("gives keyboard settings-return the same online-host fallback as the UI back button", () => {
+    expect(
+      resolveSettingsBackDestination({
+        entryReturnPath: null,
+        anyOnlineServerId: "srv-keyboard",
+      }),
+    ).toEqual({
+      kind: "fallback-route",
+      route: "/h/srv-keyboard/open-project",
+    });
+  });
+
+  it("falls back to the app root without an entry route or online host", () => {
+    expect(
+      resolveSettingsBackDestination({
+        entryReturnPath: null,
+        anyOnlineServerId: null,
+      }),
+    ).toEqual({
+      kind: "fallback-route",
+      route: "/",
+    });
+  });
+});
+
+describe("resolveCompactSettingsDetailBackDestination", () => {
+  it("returns to the settings root when the current settings session has an entry context", () => {
+    expect(
+      resolveCompactSettingsDetailBackDestination({
+        hasEntryContext: true,
+        canGoBack: true,
+      }),
+    ).toEqual({
+      kind: "settings-root",
+    });
+  });
+
+  it("uses router back for direct compact detail routes with navigation history", () => {
+    expect(
+      resolveCompactSettingsDetailBackDestination({
+        hasEntryContext: false,
+        canGoBack: true,
+      }),
+    ).toEqual({
+      kind: "router-back",
+    });
+  });
+
+  it("falls back to the settings root when router history is empty", () => {
+    expect(
+      resolveCompactSettingsDetailBackDestination({
+        hasEntryContext: false,
+        canGoBack: false,
+      }),
+    ).toEqual({
+      kind: "settings-root",
+    });
+  });
+});

--- a/packages/app/src/screens/settings-navigation.ts
+++ b/packages/app/src/screens/settings-navigation.ts
@@ -1,0 +1,38 @@
+import { buildHostOpenProjectRoute } from "@/utils/host-routes";
+
+export type SettingsBackDestination =
+  | { kind: "entry-route"; route: string }
+  | { kind: "fallback-route"; route: string };
+
+export type CompactSettingsDetailBackDestination =
+  | { kind: "settings-root" }
+  | { kind: "router-back" };
+
+export function resolveSettingsBackDestination({
+  entryReturnPath,
+  anyOnlineServerId,
+}: {
+  entryReturnPath: string | null;
+  anyOnlineServerId: string | null;
+}): SettingsBackDestination {
+  if (entryReturnPath) {
+    return { kind: "entry-route", route: entryReturnPath };
+  }
+  if (anyOnlineServerId) {
+    return { kind: "fallback-route", route: buildHostOpenProjectRoute(anyOnlineServerId) };
+  }
+  return { kind: "fallback-route", route: "/" };
+}
+
+export function resolveCompactSettingsDetailBackDestination({
+  hasEntryContext,
+  canGoBack,
+}: {
+  hasEntryContext: boolean;
+  canGoBack: boolean;
+}): CompactSettingsDetailBackDestination {
+  if (hasEntryContext || !canGoBack) {
+    return { kind: "settings-root" };
+  }
+  return { kind: "router-back" };
+}

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -1,12 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ComponentType, ReactElement, ReactNode } from "react";
 import {
   Alert,
@@ -17,7 +9,7 @@ import {
   View,
   type PressableStateCallbackType,
 } from "react-native";
-import { useRouter } from "expo-router";
+import { useRouter, type Href } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
@@ -55,12 +47,7 @@ import {
   type ServiceUrlBehavior,
   type Settings as EffectiveSettings,
 } from "@/hooks/use-settings";
-import {
-  getHostRuntimeStore,
-  isHostRuntimeConnected,
-  useHostRuntimeIsConnected,
-  useHosts,
-} from "@/runtime/host-runtime";
+import { useHostRuntimeIsConnected, useHosts } from "@/runtime/host-runtime";
 import { useSessionStore } from "@/stores/session-store";
 import type { HostProfile } from "@/types/host-connection";
 import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
@@ -103,8 +90,8 @@ import ProjectSettingsScreen from "@/screens/project-settings-screen";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useLocalDaemonServerId } from "@/hooks/use-is-local-daemon";
 import { useWebScrollbarStyle } from "@/hooks/use-web-scrollbar-style";
+import { useAnyOnlineHostServerId } from "@/hooks/use-any-online-host-server-id";
 import {
-  buildHostOpenProjectRoute,
   buildProjectsSettingsRoute,
   buildSettingsHostSectionRoute,
   buildSettingsSectionRoute,
@@ -112,6 +99,14 @@ import {
   type SettingsSectionSlug,
 } from "@/utils/host-routes";
 import { navigateToLastWorkspace } from "@/stores/navigation-active-workspace-store";
+import {
+  consumeSettingsEntryReturnPath,
+  peekSettingsEntryContext,
+} from "@/stores/settings-entry-context";
+import {
+  resolveCompactSettingsDetailBackDestination,
+  resolveSettingsBackDestination,
+} from "@/screens/settings-navigation";
 
 // ---------------------------------------------------------------------------
 // View model
@@ -603,30 +598,6 @@ function DesktopAppUpdateRow() {
 // ---------------------------------------------------------------------------
 // Sidebar
 // ---------------------------------------------------------------------------
-
-function useAnyOnlineHostServerId(serverIds: string[]): string | null {
-  const runtime = getHostRuntimeStore();
-  return useSyncExternalStore(
-    (onStoreChange) => runtime.subscribeAll(onStoreChange),
-    () => {
-      let firstOnlineServerId: string | null = null;
-      let firstOnlineAt: string | null = null;
-      for (const serverId of serverIds) {
-        const snapshot = runtime.getSnapshot(serverId);
-        const lastOnlineAt = snapshot?.lastOnlineAt ?? null;
-        if (!isHostRuntimeConnected(snapshot) || !lastOnlineAt) {
-          continue;
-        }
-        if (!firstOnlineAt || lastOnlineAt < firstOnlineAt) {
-          firstOnlineAt = lastOnlineAt;
-          firstOnlineServerId = serverId;
-        }
-      }
-      return firstOnlineServerId;
-    },
-    () => null,
-  );
-}
 
 /**
  * Local daemon first, then remaining hosts in their existing order. Lets the
@@ -1284,7 +1255,11 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
   }, [isCompactLayout, router]);
 
   const handleBackToRoot = useCallback(() => {
-    if (router.canGoBack()) {
+    const destination = resolveCompactSettingsDetailBackDestination({
+      hasEntryContext: peekSettingsEntryContext() !== null,
+      canGoBack: router.canGoBack(),
+    });
+    if (destination.kind === "router-back") {
       router.back();
     } else {
       router.replace("/settings");
@@ -1292,14 +1267,19 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
   }, [router]);
 
   const handleBackToWorkspace = useCallback(() => {
+    const returnPath = consumeSettingsEntryReturnPath();
+    if (returnPath) {
+      router.dismissTo(returnPath as Href);
+      return;
+    }
     if (navigateToLastWorkspace()) {
       return;
     }
-    if (anyOnlineServerId) {
-      router.replace(buildHostOpenProjectRoute(anyOnlineServerId));
-      return;
-    }
-    router.replace("/");
+    const fallbackDestination = resolveSettingsBackDestination({
+      entryReturnPath: null,
+      anyOnlineServerId,
+    });
+    router.replace(fallbackDestination.route as Href);
   }, [anyOnlineServerId, router]);
 
   const detailHeader = ((): {

--- a/packages/app/src/stores/settings-entry-context.test.ts
+++ b/packages/app/src/stores/settings-entry-context.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildSettingsEntryRoute,
+  consumeSettingsEntryReturnPath,
+  isSettingsPathname,
+  peekSettingsEntryContext,
+  prepareSettingsEntryNavigation,
+} from "./settings-entry-context";
+
+describe("settings-entry-context", () => {
+  afterEach(() => {
+    prepareSettingsEntryNavigation("/welcome");
+  });
+
+  it("builds a host-scoped settings route from host routes", () => {
+    expect(buildSettingsEntryRoute("/h/srv-1/workspace/repo")).toBe(
+      "/settings/hosts/srv-1/connections",
+    );
+    expect(buildSettingsEntryRoute("/h/srv-1/open-project")).toBe(
+      "/settings/hosts/srv-1/connections",
+    );
+  });
+
+  it("falls back to the settings root when there is no host route", () => {
+    expect(buildSettingsEntryRoute("/")).toBe("/settings");
+    expect(buildSettingsEntryRoute("/welcome")).toBe("/settings");
+  });
+
+  it("recognizes both current and legacy settings pathnames", () => {
+    expect(isSettingsPathname("/settings")).toBe(true);
+    expect(isSettingsPathname("/settings/hosts/srv-1/connections")).toBe(true);
+    expect(isSettingsPathname("/h/srv-1/settings")).toBe(true);
+    expect(isSettingsPathname("/h/srv-1/open-project")).toBe(false);
+  });
+
+  it("prepares navigation and consumes the return path once", () => {
+    expect(prepareSettingsEntryNavigation("/h/srv-1/open-project")).toBe(
+      "/settings/hosts/srv-1/connections",
+    );
+    expect(peekSettingsEntryContext()?.returnPathname).toBe("/h/srv-1/open-project");
+    expect(consumeSettingsEntryReturnPath()).toBe("/h/srv-1/open-project");
+    expect(consumeSettingsEntryReturnPath()).toBeNull();
+  });
+
+  it("records host and workspace metadata for the current settings entry", () => {
+    prepareSettingsEntryNavigation("/h/srv-1/workspace/repo");
+    expect(peekSettingsEntryContext()).toEqual({
+      returnPathname: "/h/srv-1/workspace/repo",
+      serverId: "srv-1",
+      workspaceId: "repo",
+    });
+  });
+
+  it("keeps the current entry context when settings is opened again from inside settings", () => {
+    expect(prepareSettingsEntryNavigation("/h/srv-1/open-project")).toBe(
+      "/settings/hosts/srv-1/connections",
+    );
+    expect(prepareSettingsEntryNavigation("/settings/general")).toBe("/settings");
+    expect(consumeSettingsEntryReturnPath()).toBe("/h/srv-1/open-project");
+  });
+
+  it("clears stale entry context when settings is opened from a non-host route", () => {
+    prepareSettingsEntryNavigation("/h/srv-1/open-project");
+    expect(prepareSettingsEntryNavigation("/welcome")).toBe("/settings");
+    expect(peekSettingsEntryContext()).toBeNull();
+  });
+
+  it("does not record settings routes as return targets", () => {
+    expect(prepareSettingsEntryNavigation("/settings/general")).toBe("/settings");
+    expect(consumeSettingsEntryReturnPath()).toBeNull();
+  });
+});

--- a/packages/app/src/stores/settings-entry-context.ts
+++ b/packages/app/src/stores/settings-entry-context.ts
@@ -1,0 +1,97 @@
+import {
+  buildSettingsHostSectionRoute,
+  buildSettingsRoute,
+  parseHostWorkspaceRouteFromPathname,
+  parseServerIdFromPathname,
+} from "@/utils/host-routes";
+
+export interface SettingsEntryContext {
+  returnPathname: string;
+  serverId: string | null;
+  workspaceId: string | null;
+}
+
+let entryContext: SettingsEntryContext | null = null;
+
+function normalizePathname(pathname: string): string | null {
+  const trimmed = pathname.trim();
+  if (!trimmed.startsWith("/")) {
+    return null;
+  }
+  const [withoutHash] = trimmed.split("#");
+  const [pathOnly] = (withoutHash ?? "").split("?");
+  const normalized = pathOnly?.trim() ?? "";
+  return normalized.startsWith("/") ? normalized : null;
+}
+
+export function isSettingsPathname(pathname: string): boolean {
+  const normalized = normalizePathname(pathname);
+  if (!normalized) {
+    return false;
+  }
+  if (normalized === "/settings" || normalized.startsWith("/settings/")) {
+    return true;
+  }
+  return /^\/h\/[^/]+\/settings\/?$/.test(normalized);
+}
+
+function isSafeSettingsReturnPath(pathname: string): boolean {
+  const normalized = normalizePathname(pathname);
+  if (!normalized || isSettingsPathname(normalized)) {
+    return false;
+  }
+  if (normalized === "/") {
+    return true;
+  }
+  return /^\/h\/[^/]+(?:\/|$)/.test(normalized);
+}
+
+export function buildSettingsEntryRoute(pathname: string): string {
+  const serverId = parseServerIdFromPathname(pathname);
+  if (!serverId) {
+    return buildSettingsRoute();
+  }
+  return buildSettingsHostSectionRoute(serverId, "connections");
+}
+
+function createSettingsEntryContext(pathname: string): SettingsEntryContext | null {
+  const returnPathname = normalizePathname(pathname);
+  if (!returnPathname || !isSafeSettingsReturnPath(returnPathname)) {
+    return null;
+  }
+
+  const workspaceRoute = parseHostWorkspaceRouteFromPathname(returnPathname);
+  const serverId = workspaceRoute?.serverId ?? parseServerIdFromPathname(returnPathname);
+  return {
+    returnPathname,
+    serverId: serverId ?? null,
+    workspaceId: workspaceRoute?.workspaceId ?? null,
+  };
+}
+
+function rememberSettingsEntryContext(context: SettingsEntryContext | null): void {
+  entryContext = context;
+}
+
+export function peekSettingsEntryContext(): SettingsEntryContext | null {
+  return entryContext;
+}
+
+export function consumeSettingsEntryReturnPath(): string | null {
+  const context = entryContext;
+  entryContext = null;
+  if (!context || !isSafeSettingsReturnPath(context.returnPathname)) {
+    return null;
+  }
+  return context.returnPathname;
+}
+
+export function prepareSettingsEntryNavigation(pathname: string): string {
+  const context = createSettingsEntryContext(pathname);
+  if (context) {
+    rememberSettingsEntryContext(context);
+  } else if (!isSettingsPathname(pathname)) {
+    entryContext = null;
+  }
+  return buildSettingsEntryRoute(pathname);
+}


### PR DESCRIPTION
## Summary

Fix Settings navigation so opening Settings from a host or workspace keeps the current host context, and Back returns to the page that opened Settings.

Previously Settings relied on fallback / last-workspace behavior. In multi-host usage, that could show a different host in Settings or return to a different page after closing Settings.

## Changes

- Open Settings entry points with a host-aware route when the current route has a host.
- Store the originating app route in transient in-memory navigation context.
- Make Settings Back prefer that entry context, then fall back to the existing last-workspace / online-host behavior.
- Keep Settings as a route; no overlay and no `returnTo` URL parameter.

## Test Plan

- `npx vitest run packages/app/src/stores/settings-entry-context.test.ts packages/app/src/keyboard/route-shortcut.test.ts packages/app/src/screens/settings-navigation.test.ts --bail=1`
- `npm run lint -- packages/app/src/components/left-sidebar.tsx packages/app/src/hooks/use-command-center.ts packages/app/src/hooks/use-keyboard-shortcuts.ts packages/app/src/keyboard/route-shortcut.test.ts packages/app/src/keyboard/route-shortcut.ts packages/app/src/screens/settings-navigation.test.ts packages/app/src/screens/settings-navigation.ts packages/app/src/screens/settings-screen.tsx packages/app/src/stores/settings-entry-context.test.ts packages/app/src/stores/settings-entry-context.ts`
- `npm run format:check:files -- packages/app/src/components/left-sidebar.tsx packages/app/src/hooks/use-command-center.ts packages/app/src/hooks/use-keyboard-shortcuts.ts packages/app/src/keyboard/route-shortcut.test.ts packages/app/src/keyboard/route-shortcut.ts packages/app/src/screens/settings-navigation.test.ts packages/app/src/screens/settings-navigation.ts packages/app/src/screens/settings-screen.tsx packages/app/src/stores/settings-entry-context.test.ts packages/app/src/stores/settings-entry-context.ts`
- `npm run typecheck`
- Manual real-device check on iPad: open Settings from a remote host/workspace, confirm the host Settings page opens for that host, then Back returns to the originating page.