### PR TITLE
Open browser links in workspace tabs

### DIFF
--- a/packages/app/src/browser/new-tab-requests/index.test.ts
+++ b/packages/app/src/browser/new-tab-requests/index.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { SplitNode, WorkspaceLayout } from "@/stores/workspace-layout-store";
+import { resolveBrowserNewTabRequest, type BrowserNewTabRequest } from ".";
+
+function createLayoutWithBrowser(browserId: string): WorkspaceLayout {
+  return {
+    focusedPaneId: "pane-main",
+    root: {
+      kind: "pane",
+      pane: {
+        id: "pane-main",
+        tabIds: ["browser-tab"],
+        tabs: [
+          {
+            tabId: "browser-tab",
+            target: { kind: "browser", browserId },
+            createdAt: 1,
+          },
+        ],
+        focusedTabId: "browser-tab",
+      },
+    } as unknown as SplitNode,
+  };
+}
+
+describe("browser new-tab requests", () => {
+  it("accepts desktop requests from browser tabs in the current workspace", () => {
+    const request = resolveBrowserNewTabRequest({
+      payload: {
+        sourceBrowserId: "browser-1",
+        url: "https://example.com/target",
+      },
+      workspaceLayout: createLayoutWithBrowser("browser-1"),
+    });
+
+    expect(request).toEqual<BrowserNewTabRequest>({
+      sourceBrowserId: "browser-1",
+      url: "https://example.com/target",
+    });
+  });
+
+  it("ignores desktop requests from another workspace", () => {
+    const request = resolveBrowserNewTabRequest({
+      payload: {
+        sourceBrowserId: "browser-from-other-workspace",
+        url: "https://example.com/target",
+      },
+      workspaceLayout: createLayoutWithBrowser("browser-1"),
+    });
+
+    expect(request).toBeNull();
+  });
+
+  it("rejects unsupported desktop request URLs", () => {
+    const request = resolveBrowserNewTabRequest({
+      payload: {
+        sourceBrowserId: "browser-1",
+        url: "file:///etc/passwd",
+      },
+      workspaceLayout: createLayoutWithBrowser("browser-1"),
+    });
+
+    expect(request).toBeNull();
+  });
+});

--- a/packages/app/src/browser/new-tab-requests/index.test.ts
+++ b/packages/app/src/browser/new-tab-requests/index.test.ts
@@ -1,26 +1,15 @@
 import { describe, expect, it } from "vitest";
-import type { SplitNode, WorkspaceLayout } from "@/stores/workspace-layout-store";
+import type { WorkspaceLayout } from "@/stores/workspace-layout-store";
+import { createDefaultLayout } from "@/stores/workspace-layout-store";
+import { openTabInLayoutFocused } from "@/stores/workspace-layout-actions";
 import { resolveBrowserNewTabRequest, type BrowserNewTabRequest } from ".";
 
 function createLayoutWithBrowser(browserId: string): WorkspaceLayout {
-  return {
-    focusedPaneId: "pane-main",
-    root: {
-      kind: "pane",
-      pane: {
-        id: "pane-main",
-        tabIds: ["browser-tab"],
-        tabs: [
-          {
-            tabId: "browser-tab",
-            target: { kind: "browser", browserId },
-            createdAt: 1,
-          },
-        ],
-        focusedTabId: "browser-tab",
-      },
-    } as unknown as SplitNode,
-  };
+  return openTabInLayoutFocused({
+    layout: createDefaultLayout(),
+    target: { kind: "browser", browserId },
+    now: 1,
+  }).layout;
 }
 
 describe("browser new-tab requests", () => {

--- a/packages/app/src/browser/new-tab-requests/index.ts
+++ b/packages/app/src/browser/new-tab-requests/index.ts
@@ -1,0 +1,99 @@
+import { useEffect } from "react";
+import { getDesktopHost, type DesktopBrowserNewTabRequestEvent } from "@/desktop/host";
+import { collectAllTabs, type WorkspaceLayout } from "@/stores/workspace-layout-store";
+import { getIsElectron } from "@/constants/platform";
+import { useStableEvent } from "@/hooks/use-stable-event";
+
+export type BrowserNewTabRequest = DesktopBrowserNewTabRequestEvent;
+
+function isAllowedBrowserNewTabUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.protocol === "http:" || parsed.protocol === "https:" || parsed.href === "about:blank"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readDesktopBrowserNewTabRequest(payload: unknown): BrowserNewTabRequest | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const candidate = payload as Partial<BrowserNewTabRequest>;
+  if (typeof candidate.sourceBrowserId !== "string" || !candidate.sourceBrowserId.trim()) {
+    return null;
+  }
+  if (typeof candidate.url !== "string" || !isAllowedBrowserNewTabUrl(candidate.url)) {
+    return null;
+  }
+  return {
+    sourceBrowserId: candidate.sourceBrowserId,
+    url: candidate.url,
+  };
+}
+
+function workspaceContainsBrowser(input: {
+  workspaceLayout: WorkspaceLayout | null | undefined;
+  browserId: string;
+}): boolean {
+  if (!input.workspaceLayout) {
+    return false;
+  }
+  return collectAllTabs(input.workspaceLayout.root).some((tab) => {
+    return tab.target.kind === "browser" && tab.target.browserId === input.browserId;
+  });
+}
+
+export function resolveBrowserNewTabRequest(input: {
+  payload: unknown;
+  workspaceLayout: WorkspaceLayout | null | undefined;
+}): BrowserNewTabRequest | null {
+  const request = readDesktopBrowserNewTabRequest(input.payload);
+  if (!request) {
+    return null;
+  }
+  if (
+    !workspaceContainsBrowser({
+      workspaceLayout: input.workspaceLayout,
+      browserId: request.sourceBrowserId,
+    })
+  ) {
+    return null;
+  }
+  return request;
+}
+
+export function useDesktopBrowserNewTabRequests(input: {
+  enabled: boolean;
+  workspaceLayout: WorkspaceLayout | null | undefined;
+  openUrl: (url: string) => void;
+}): void {
+  const handleNewTabRequest = useStableEvent((payload: unknown) => {
+    const request = resolveBrowserNewTabRequest({
+      payload,
+      workspaceLayout: input.workspaceLayout,
+    });
+    if (!request) {
+      return;
+    }
+    input.openUrl(request.url);
+  });
+
+  useEffect(() => {
+    if (!input.enabled || !getIsElectron()) {
+      return;
+    }
+    const unsubscribe = getDesktopHost()?.events?.on?.(
+      "browser-new-tab-request",
+      handleNewTabRequest,
+    );
+    if (typeof unsubscribe === "function") {
+      return unsubscribe;
+    }
+    return () => {
+      void unsubscribe?.then((dispose) => dispose());
+    };
+  }, [handleNewTabRequest, input.enabled]);
+}

--- a/packages/app/src/desktop/host.ts
+++ b/packages/app/src/desktop/host.ts
@@ -111,6 +111,11 @@ export interface DesktopBrowserShortcutEvent {
   action: "focus-url";
 }
 
+export interface DesktopBrowserNewTabRequestEvent {
+  sourceBrowserId: string;
+  url: string;
+}
+
 export interface DesktopBrowserBridge {
   setWorkspaceActiveBrowser?: (browserId: string | null) => Promise<void>;
   openDevTools?: (browserId: string) => Promise<unknown>;

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -130,6 +130,7 @@ import {
   buildWorkspaceTabMenuEntries,
   type WorkspaceTabMenuEntry,
 } from "@/screens/workspace/workspace-tab-menu";
+import { useDesktopBrowserNewTabRequests } from "@/browser/new-tab-requests";
 import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
 import {
   resolveWorkspaceHeaderRenderState,
@@ -2328,6 +2329,12 @@ function WorkspaceScreenContent({
     },
     [openWorkspaceTabFocused, persistenceKey],
   );
+
+  useDesktopBrowserNewTabRequests({
+    enabled: Boolean(persistenceKey),
+    workspaceLayout,
+    openUrl: handleOpenUrlInBrowserTab,
+  });
 
   const handleSelectSwitcherTab = useCallback(
     (key: string) => {

--- a/packages/desktop/src/features/browser-webviews/index.ts
+++ b/packages/desktop/src/features/browser-webviews/index.ts
@@ -5,14 +5,29 @@ import {
   isAllowedBrowserWebviewUrl,
 } from "./window-open.js";
 
-export {
-  BROWSER_NEW_TAB_REQUEST_EVENT,
-  handleBrowserWindowOpenRequest,
-  isAllowedBrowserWebviewUrl,
-};
+export { BROWSER_NEW_TAB_REQUEST_EVENT, handleBrowserWindowOpenRequest };
 
 const browserIdsByWebContentsId = new Map<number, string>();
 let workspaceActiveBrowserId: string | null = null;
+
+function getBrowserIdFromWebviewPartition(partition: string | undefined): string | null {
+  const prefix = "persist:paseo-browser-";
+  if (!partition?.startsWith(prefix)) {
+    return null;
+  }
+  const browserId = partition.slice(prefix.length).trim();
+  return browserId.length > 0 ? browserId : null;
+}
+
+export function readBrowserIdFromWebviewAttach(input: {
+  src?: string;
+  partition?: string;
+}): string | null {
+  if (!isAllowedBrowserWebviewUrl(input.src)) {
+    return null;
+  }
+  return getBrowserIdFromWebviewPartition(input.partition);
+}
 
 export function listRegisteredPaseoBrowserIds(): string[] {
   return Array.from(new Set(browserIdsByWebContentsId.values())).sort();
@@ -55,4 +70,25 @@ export function getWorkspaceActivePaseoBrowserWebContents(): WebContents | null 
     return null;
   }
   return getPaseoBrowserWebContents(workspaceActiveBrowserId);
+}
+
+function preventUnsafeBrowserWebviewNavigation(
+  event: { preventDefault: () => void },
+  url: string | undefined,
+): void {
+  if (!isAllowedBrowserWebviewUrl(url)) {
+    event.preventDefault();
+  }
+}
+
+export function registerBrowserWebviewNavigationGuards(contents: WebContents): void {
+  contents.on("will-navigate", (event) => {
+    preventUnsafeBrowserWebviewNavigation(event, event.url);
+  });
+  contents.on("will-frame-navigate", (event) => {
+    preventUnsafeBrowserWebviewNavigation(event, event.url);
+  });
+  contents.on("will-redirect", (event) => {
+    preventUnsafeBrowserWebviewNavigation(event, event.url);
+  });
 }

--- a/packages/desktop/src/features/browser-webviews/index.ts
+++ b/packages/desktop/src/features/browser-webviews/index.ts
@@ -1,4 +1,15 @@
 import { webContents as allWebContents, type WebContents } from "electron";
+import {
+  BROWSER_NEW_TAB_REQUEST_EVENT,
+  handleBrowserWindowOpenRequest,
+  isAllowedBrowserWebviewUrl,
+} from "./window-open.js";
+
+export {
+  BROWSER_NEW_TAB_REQUEST_EVENT,
+  handleBrowserWindowOpenRequest,
+  isAllowedBrowserWebviewUrl,
+};
 
 const browserIdsByWebContentsId = new Map<number, string>();
 let workspaceActiveBrowserId: string | null = null;

--- a/packages/desktop/src/features/browser-webviews/window-open.test.ts
+++ b/packages/desktop/src/features/browser-webviews/window-open.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { handleBrowserWindowOpenRequest } from "./window-open";
+
+describe("browser webview window-open requests", () => {
+  it("denies Electron window creation and requests a Paseo browser tab", () => {
+    const requestNewTab = vi.fn();
+
+    const result = handleBrowserWindowOpenRequest({
+      url: "https://example.com/target",
+      sourceBrowserId: "browser-1",
+      requestNewTab,
+    });
+
+    expect(result).toEqual({ action: "deny" });
+    expect(requestNewTab).toHaveBeenCalledWith({
+      sourceBrowserId: "browser-1",
+      url: "https://example.com/target",
+    });
+  });
+
+  it("denies unsupported window-open requests before asking for a Paseo browser tab", () => {
+    const requestNewTab = vi.fn();
+
+    const result = handleBrowserWindowOpenRequest({
+      url: "file:///etc/passwd",
+      sourceBrowserId: "browser-1",
+      requestNewTab,
+    });
+
+    expect(result).toEqual({ action: "deny" });
+    expect(requestNewTab).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/src/features/browser-webviews/window-open.test.ts
+++ b/packages/desktop/src/features/browser-webviews/window-open.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { handleBrowserWindowOpenRequest } from "./window-open";
+import { handleBrowserWindowOpenRequest } from ".";
 
 describe("browser webview window-open requests", () => {
   it("denies Electron window creation and requests a Paseo browser tab", () => {

--- a/packages/desktop/src/features/browser-webviews/window-open.ts
+++ b/packages/desktop/src/features/browser-webviews/window-open.ts
@@ -1,0 +1,36 @@
+export const BROWSER_NEW_TAB_REQUEST_EVENT = "paseo:event:browser-new-tab-request";
+
+export interface BrowserNewTabRequestPayload {
+  sourceBrowserId: string;
+  url: string;
+}
+
+export function isAllowedBrowserWebviewUrl(value: string | undefined): boolean {
+  if (!value) {
+    return true;
+  }
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.protocol === "http:" || parsed.protocol === "https:" || parsed.href === "about:blank"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function handleBrowserWindowOpenRequest(input: {
+  url: string;
+  sourceBrowserId: string | null;
+  requestNewTab: (payload: BrowserNewTabRequestPayload) => void;
+}): { action: "deny" } {
+  if (!isAllowedBrowserWebviewUrl(input.url) || !input.sourceBrowserId) {
+    return { action: "deny" };
+  }
+
+  input.requestNewTab({
+    sourceBrowserId: input.sourceBrowserId,
+    url: input.url,
+  });
+  return { action: "deny" };
+}

--- a/packages/desktop/src/features/menu.ts
+++ b/packages/desktop/src/features/menu.ts
@@ -1,5 +1,5 @@
 import { app, Menu, BrowserWindow, ipcMain } from "electron";
-import { getWorkspaceActivePaseoBrowserWebContents } from "./browser-webviews.js";
+import { getWorkspaceActivePaseoBrowserWebContents } from "./browser-webviews/index.js";
 
 interface ShowContextMenuInput {
   kind?: "terminal";

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -50,8 +50,9 @@ import {
   getPaseoBrowserIdForWebContents,
   getPaseoBrowserWebContents,
   handleBrowserWindowOpenRequest,
-  isAllowedBrowserWebviewUrl,
   listRegisteredPaseoBrowserIds,
+  readBrowserIdFromWebviewAttach,
+  registerBrowserWebviewNavigationGuards,
   registerPaseoBrowserWebContents,
   setWorkspaceActivePaseoBrowserId,
 } from "./features/browser-webviews/index.js";
@@ -76,14 +77,6 @@ const PASEO_DEBUG = process.env.PASEO_DEBUG === "1";
 const DISABLE_SINGLE_INSTANCE_LOCK = process.env.PASEO_DISABLE_SINGLE_INSTANCE_LOCK === "1";
 const APP_NAME = process.env.PASEO_TEST_APP_NAME?.trim() || "Paseo";
 
-function preventUnsafeBrowserWebviewNavigation(
-  event: Electron.Event,
-  url: string | undefined,
-): void {
-  if (!isAllowedBrowserWebviewUrl(url)) {
-    event.preventDefault();
-  }
-}
 const BROWSER_SHORTCUT_EVENT = "paseo:event:browser-shortcut";
 const BROWSER_FORWARDED_KEY_EVENT = "paseo:event:browser-forwarded-key";
 
@@ -115,15 +108,6 @@ const FORWARDED_PASEO_SHORTCUT_KEYS = new Set([
 const DESKTOP_SMOKE_ENV = "PASEO_DESKTOP_SMOKE";
 const DESKTOP_SMOKE_STOP_REQUEST = "paseo-smoke-stop";
 app.setName(APP_NAME);
-
-function getBrowserIdFromWebviewPartition(partition: string | undefined): string | null {
-  const prefix = "persist:paseo-browser-";
-  if (!partition?.startsWith(prefix)) {
-    return null;
-  }
-  const browserId = partition.slice(prefix.length).trim();
-  return browserId.length > 0 ? browserId : null;
-}
 
 const pendingBrowserWebviewIds: string[] = [];
 
@@ -459,11 +443,7 @@ async function createWindow(
   setupDefaultContextMenu(mainWindow);
   setupDragDropPrevention(mainWindow);
   mainWindow.webContents.on("will-attach-webview", (event, webPreferences, params) => {
-    if (!isAllowedBrowserWebviewUrl(params.src)) {
-      event.preventDefault();
-      return;
-    }
-    const browserId = getBrowserIdFromWebviewPartition(params.partition);
+    const browserId = readBrowserIdFromWebviewAttach(params);
     if (!browserId) {
       event.preventDefault();
       return;
@@ -535,15 +515,7 @@ async function createWindow(
     contents.on("context-menu", (_contextMenuEvent, params) => {
       showBrowserWebviewContextMenu(mainWindow, contents, params);
     });
-    contents.on("will-navigate", (event) => {
-      preventUnsafeBrowserWebviewNavigation(event, event.url);
-    });
-    contents.on("will-frame-navigate", (event) => {
-      preventUnsafeBrowserWebviewNavigation(event, event.url);
-    });
-    contents.on("will-redirect", (event) => {
-      preventUnsafeBrowserWebviewNavigation(event, event.url);
-    });
+    registerBrowserWebviewNavigationGuards(contents);
   });
 
   mainWindow.once("ready-to-show", () => {

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -46,12 +46,15 @@ import { registerOpenerHandlers } from "./features/opener.js";
 import { registerEditorTargetHandlers } from "./features/editor-targets.js";
 import { setupApplicationMenu } from "./features/menu.js";
 import {
+  BROWSER_NEW_TAB_REQUEST_EVENT,
   getPaseoBrowserIdForWebContents,
   getPaseoBrowserWebContents,
+  handleBrowserWindowOpenRequest,
+  isAllowedBrowserWebviewUrl,
   listRegisteredPaseoBrowserIds,
   registerPaseoBrowserWebContents,
   setWorkspaceActivePaseoBrowserId,
-} from "./features/browser-webviews.js";
+} from "./features/browser-webviews/index.js";
 import { parseOpenProjectPathFromArgv } from "./open-project-routing.js";
 import { PendingOpenProjectStore } from "./pending-open-project-store.js";
 import { getDesktopSettingsStore } from "./settings/desktop-settings-electron.js";
@@ -72,20 +75,6 @@ const APP_SCHEME = "paseo";
 const PASEO_DEBUG = process.env.PASEO_DEBUG === "1";
 const DISABLE_SINGLE_INSTANCE_LOCK = process.env.PASEO_DISABLE_SINGLE_INSTANCE_LOCK === "1";
 const APP_NAME = process.env.PASEO_TEST_APP_NAME?.trim() || "Paseo";
-
-function isAllowedBrowserWebviewUrl(value: string | undefined): boolean {
-  if (!value) {
-    return true;
-  }
-  try {
-    const parsed = new URL(value);
-    return (
-      parsed.protocol === "http:" || parsed.protocol === "https:" || parsed.href === "about:blank"
-    );
-  } catch {
-    return false;
-  }
-}
 
 function preventUnsafeBrowserWebviewNavigation(
   event: Electron.Event,
@@ -534,13 +523,15 @@ async function createWindow(
         });
       }
     });
-    contents.setWindowOpenHandler(({ url }) => {
-      if (!isAllowedBrowserWebviewUrl(url)) {
-        return { action: "deny" };
-      }
-      contents.loadURL(url).catch(() => undefined);
-      return { action: "deny" };
-    });
+    contents.setWindowOpenHandler(({ url }) =>
+      handleBrowserWindowOpenRequest({
+        url,
+        sourceBrowserId: getPaseoBrowserIdForWebContents(contents),
+        requestNewTab: (payload) => {
+          mainWindow.webContents.send(BROWSER_NEW_TAB_REQUEST_EVENT, payload);
+        },
+      }),
+    );
     contents.on("context-menu", (_contextMenuEvent, params) => {
       showBrowserWebviewContextMenu(mainWindow, contents, params);
     });


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Desktop browser links that ask for a new window now open as normal Paseo browser tabs in the same workspace. Electron still denies native window creation, so the app stays inside the workspace tab model instead of navigating the current browser pane or spawning a separate window.

The new-tab request handling lives in dedicated browser modules on both the desktop and app sides, with the workspace screen reduced to a single hook integration.

### How did you verify it

- Reproduced the old Electron webview behavior with a throwaway harness during diagnosis: window-open requests were being caught and loaded into the current webview.
- Added targeted tests for desktop window-open handling and app-side workspace filtering.
- Ran `npx vitest run packages/desktop/src/features/browser-webviews/window-open.test.ts --bail=1`.
- Ran `npx vitest run packages/app/src/browser/new-tab-requests/index.test.ts --bail=1`.
- Ran `npm run typecheck --workspace=@getpaseo/desktop`.
- Ran `npm run typecheck --workspace=@getpaseo/app`.
- Ran `npm run lint`.
- Ran `npm run format`.
- Pre-commit hook also ran format check, lint, and full workspace typecheck.

Risk surface: this touches Electron-only browser behavior. I did not manually launch the desktop app after the final reshape, so reviewer smoke should click a `target=\"_blank\"` link in the desktop browser and confirm a new workspace browser tab opens while the original tab stays put.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense