### PR TITLE
Keep Codex usage logs on Codex identity

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -534,6 +534,37 @@ describe("Codex app-server provider", () => {
     await session.close();
   });
 
+  test("initializes Codex app-server without making Paseo the request originator", async () => {
+    let initializeParams: unknown;
+    const appServer = createFakeCodexAppServer({
+      initialize: (params) => {
+        initializeParams = params;
+        return {};
+      },
+      "collaborationMode/list": () => ({ data: [] }),
+      "skills/list": () => ({ data: [] }),
+    });
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+
+    await session.connect();
+
+    expect(initializeParams).toEqual({
+      clientInfo: {
+        name: "codex_app_server_daemon",
+        title: "Codex App Server Daemon",
+        version: "0.0.0",
+      },
+      capabilities: { experimentalApi: true },
+    });
+    appServer.assertNoErrors();
+    await session.close();
+  });
+
   test("rewinds the conversation to a freshly emitted Codex user message id", async () => {
     const appServer = createFakeCodexAppServer();
     const session = new CodexAppServerAgentSession(
@@ -2703,7 +2734,17 @@ describe("Codex persisted sessions", () => {
       }),
     );
     expect(calls).toEqual([
-      { method: "initialize", params: expect.any(Object) },
+      {
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "codex_app_server_daemon",
+            title: "Codex App Server Daemon",
+            version: "0.0.0",
+          },
+          capabilities: { experimentalApi: true },
+        },
+      },
       { method: "thread/list", params: { limit: 50, cwd: "/workspace/project-a" } },
     ]);
   });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -103,6 +103,14 @@ const TURN_START_TIMEOUT_MS = 90 * 1000;
 const INTERRUPT_TIMEOUT_MS = 2_000;
 const CODEX_PROVIDER = "codex" as const;
 const CODEX_IMAGE_ATTACHMENT_DIR = "paseo-attachments";
+// Codex treats most app-server client names as the model-request originator.
+// This reserved Codex name is non-originating, so requests keep Codex's default
+// CLI identity instead of showing up as Paseo in provider usage logs.
+const CODEX_NON_ORIGINATING_APP_SERVER_CLIENT_INFO = {
+  name: "codex_app_server_daemon",
+  title: "Codex App Server Daemon",
+  version: "0.0.0",
+} as const;
 const ASSISTANT_MESSAGE_BOUNDARY_MARKDOWN = "\n\n---\n\n";
 const CODEX_TOOL_THREAD_ITEM_TYPES = new Set([
   "commandExecution",
@@ -2818,11 +2826,7 @@ function buildCodexAppServerInitializeParams(): {
   capabilities: { experimentalApi: true };
 } {
   return {
-    clientInfo: {
-      name: "paseo",
-      title: "Paseo",
-      version: "0.0.0",
-    },
+    clientInfo: CODEX_NON_ORIGINATING_APP_SERVER_CLIENT_INFO,
     capabilities: {
       experimentalApi: true,
     },


### PR DESCRIPTION
### Linked issue

Not linked.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Paseo now initializes Codex app-server with Codex's non-originating app-server client identity. This keeps model API usage logs attributed to Codex's normal request identity instead of rewriting them to Paseo.

The PR also adds regression coverage for normal session startup and persisted-session listing so the app-server initialize payload does not drift back to a Paseo-originating client.

### How did you verify it

- `npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

Risk surface: this depends on Codex preserving `codex_app_server_daemon` as a non-originating app-server client name. CI covers Paseo's emitted initialize payload, but a future Codex protocol behavior change would need a manual smoke test against a real Codex binary.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A, no UI changes)
- [x] Tests added or updated where it made sense
