### PR TITLE
Archive merged PR worktrees after branch deletion

### DIFF
--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
@@ -233,15 +233,15 @@ describe("archiveIfSafe", () => {
     expect(harness.deps.archivePaseoWorktree).not.toHaveBeenCalled();
   });
 
-  test("does nothing when the upstream status is unknown", async () => {
+  test("archives when the PR is merged and the upstream branch was deleted", async () => {
     const harness = createHarness({
-      getSnapshot: async () => createSnapshot({ git: { aheadOfOrigin: null } }),
+      getSnapshot: async () =>
+        createSnapshot({ git: { aheadOfOrigin: null, behindOfOrigin: null } }),
     });
 
     await runArchiveIfSafe(harness);
 
-    expect(harness.deps.isPaseoOwnedWorktreeCwd).not.toHaveBeenCalled();
-    expect(harness.deps.archivePaseoWorktree).not.toHaveBeenCalled();
+    expect(harness.deps.archivePaseoWorktree).toHaveBeenCalledTimes(1);
   });
 
   test("does nothing when the cwd is not a Paseo-owned worktree", async () => {

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
@@ -78,10 +78,10 @@ export async function archiveIfSafe(input: {
       return;
     }
 
-    if (snapshot.git.isDirty === true || snapshot.git.aheadOfOrigin === null) {
+    if (snapshot.git.isDirty === true) {
       return;
     }
-    if (snapshot.git.aheadOfOrigin > 0) {
+    if (typeof snapshot.git.aheadOfOrigin === "number" && snapshot.git.aheadOfOrigin > 0) {
       return;
     }
 


### PR DESCRIPTION
### Linked issue

Not filed.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fixes auto-archive for merged PR worktrees when the pull request branch has already been deleted. A clean Paseo-owned worktree with a merged PR will still archive even when its upstream tracking branch is gone; dirty worktrees and worktrees with known unpushed commits still stay active.

### How did you verify it

Reproduced the failing shape in a regression test by setting the merged PR state with `aheadOfOrigin: null`, matching the deleted-upstream case.

Ran:

- `npx vitest run packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts --bail=1`
- `npm run lint`
- `npm run typecheck`
- `npm run format`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense