### PR TITLE
fix(server): skip live git in fetch_agent_history placement

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -6128,6 +6128,14 @@ export class Session {
         ? { ...request.filter, includeArchived: true }
         : request.filter;
     const scope = request.type === "fetch_agents_request" ? request.scope : undefined;
+    // The history list never renders checkout info (the client requests it with
+    // showCheckoutInfo=false and does not read the `project` payload), so resolving
+    // each agent's placement via live git is pure overhead. On slow filesystems
+    // (network mounts) a per-cwd `git status` can take seconds, and summed across
+    // many sessions it blows past the client's 10s RPC timeout, leaving the list
+    // blank. Resolve placement from cached snapshots + the workspace registry
+    // (refreshGit: false) instead — no git spawns on the history path.
+    const skipGitPlacement = request.type === "fetch_agent_history_request";
     const sort = this.agentsPager.normalizeSort(request.sort);
 
     let agents = await this.listAgentPayloads({
@@ -6154,7 +6162,10 @@ export class Session {
       if (existing) {
         return existing;
       }
-      const placementPromise = this.buildProjectPlacementForCwd(cwd);
+      const placementPromise = this.buildProjectPlacementForCwd(
+        cwd,
+        skipGitPlacement ? { refreshGit: false } : undefined,
+      );
       placementByCwd.set(cwd, placementPromise);
       return placementPromise;
     };

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -20,7 +20,10 @@ import type {
   PersistedAgentDescriptor,
 } from "./agent/agent-sdk-types.js";
 import type { WorkspaceGitRuntimeSnapshot } from "./workspace-git-service.js";
-import { createNoopWorkspaceGitService } from "./test-utils/workspace-git-service-stub.js";
+import {
+  createNoGitWorkspaceRuntimeSnapshot,
+  createNoopWorkspaceGitService,
+} from "./test-utils/workspace-git-service-stub.js";
 import {
   asSessionLogger,
   asAgentManager,
@@ -2110,6 +2113,78 @@ test("fetch_agent_history_request pages archived historical rows separately", as
     },
   ]);
   expect(session.agentUpdatesSubscription).toBeNull();
+});
+
+test("fetch_agent_history_request resolves placement without spawning git", async () => {
+  // Regression: the history list never renders checkout info, so it must not pay
+  // the per-cwd `git status` cost. On slow filesystems that cost summed across
+  // sessions blew past the client's 10s RPC timeout and left the list blank.
+  // Here `getCheckout` (the git-spawning path) throws to assert it is never hit;
+  // placement must come from the cached snapshot + workspace registry instead.
+  const emitted: SessionOutboundMessage[] = [];
+  const repoCwd = path.resolve("/tmp/history-git-repo");
+  const getCheckout = vi.fn(async () => {
+    throw new Error("getCheckout must not be called on the history path");
+  });
+  const peekSnapshot = vi.fn(() => createNoGitWorkspaceRuntimeSnapshot(repoCwd));
+  const session = createSessionForWorkspaceTests({
+    workspaceGitService: createNoopWorkspaceGitService({ getCheckout, peekSnapshot }),
+  });
+
+  const project = createPersistedProjectRecord({
+    projectId: "proj-history-git",
+    rootPath: repoCwd,
+    kind: "git",
+    displayName: "history-git",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-history-git",
+    projectId: project.projectId,
+    cwd: repoCwd,
+    kind: "local_checkout",
+    displayName: "history-git",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+
+  session.emit = (message) => {
+    if (isSessionOutboundMessage(message)) emitted.push(message);
+  };
+  session.projectRegistry.get = async () => project;
+  session.projectRegistry.list = async () => [project];
+  session.workspaceRegistry.list = async () => [workspace];
+  session.listAgentPayloads = async () => [
+    makeAgent({
+      id: "history-git-agent",
+      cwd: repoCwd,
+      status: "idle",
+      updatedAt: "2026-03-01T12:00:00.000Z",
+    }),
+  ];
+
+  await session.handleMessage({
+    type: "fetch_agent_history_request",
+    requestId: "req-history-git",
+    page: { limit: 25 },
+  });
+
+  expect(getCheckout).not.toHaveBeenCalled();
+  expect(emitted).toEqual([
+    {
+      type: "fetch_agent_history_response",
+      payload: expect.objectContaining({
+        requestId: "req-history-git",
+        entries: [
+          expect.objectContaining({
+            agent: expect.objectContaining({ id: "history-git-agent" }),
+            project: expect.objectContaining({ projectKey: "proj-history-git" }),
+          }),
+        ],
+      }),
+    },
+  ]);
 });
 
 test("fetch_recent_provider_sessions_request lists importable provider sessions by handle", async () => {


### PR DESCRIPTION
### Linked issue

Closes #1382

### Type of change

- [x] Bug fix

### What does this PR do

The Sessions (history) list resolves every agent's placement through `getCheckoutStatus(cwd)`, which spawns git subprocesses per cwd. On slow / network filesystems each `git status` takes seconds, and the sum across all distinct cwds blows past the client's 10s `fetch_agent_history` RPC timeout — so the list hangs and renders empty.

The history path doesn't use that git data at all: the client requests it with `showCheckoutInfo={false}`, never reads the `project`/checkout payload, and applies no project filter here. So the git work is pure overhead.

This PR makes `fetch_agent_history` resolve placement with `refreshGit: false` (cached snapshot + workspace registry lookup) instead of live git. The `fetch_agents` (active list) path is unchanged, the wire protocol is unchanged, and no client/CLI changes are needed.

### How did you verify it

Tested on a real machine with ~180 sessions across 15 distinct cwds, several on network mounts.

**Before (current code), from daemon.log:**
- `fetch_agent_history_request` latency: 10.7s – 11.9s — over the 10s client timeout, list came back empty.

**Micro-benchmark of the placement step** (real `getCheckoutStatus` against the real cwds, vs the registry lookup the fix uses):
- Before (per-cwd git): **~21,000 ms** total for 15 cwds (cold cache — the worst case the slow-FS user hits). Top offenders: one repo 4.6s, four network-mount repos ~3s each.
- After (registry lookup): **~0.03 ms**.

**End-to-end after the fix:** built the server, swapped it into my daemon, restarted, and opened the Sessions list from the app — it now loads sub-second instead of timing out.

**Automated test:** added a test that mocks `getCheckoutStatus` to throw and asserts the history path still returns entries without ever calling it (proves no git is spawned). Full `session.workspaces.test.ts` passes (53 passed, 4 pre-existing skips).

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes (0 errors, all workspaces)
- [x] `npm run lint` passes (oxlint: 0 warnings, 0 errors)
- [x] `npm run format` ran
- [ ] UI changes include screenshots — N/A, server-only change
- [x] Tests added or updated where it made sense
