### PR TITLE
Default running-agent sends to queue

### DIFF
--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -41,6 +41,14 @@ describe("loadAppSettingsFromStorage", () => {
     expect(result.theme).toBe("auto");
   });
 
+  it("defaults running-agent Enter behavior to queue", async () => {
+    const deps = makeDeps();
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.sendBehavior).toBe("queue");
+  });
+
   it("seeds storage with the client defaults when nothing is persisted", async () => {
     const deps = makeDeps();
 

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -43,7 +43,7 @@ export interface Settings extends AppSettings {
 
 export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   theme: "auto",
-  sendBehavior: "interrupt",
+  sendBehavior: "queue",
   serviceUrlBehavior: "ask",
   terminalScrollbackLines: DEFAULT_TERMINAL_SCROLLBACK_LINES,
   uiFontFamily: "",


### PR DESCRIPTION
## Summary
- Change the default running-agent send behavior from interrupt to queue
- Preserve explicitly persisted send behavior settings for existing users
- Add unit coverage for the default app settings value

## Test plan
- npx vitest run packages/app/src/hooks/use-settings/storage.test.ts --bail=1
- npm run lint
- npm run format:check
- npm run typecheck