### PR TITLE
fix(server): surface ACP context-window usage in the composer meter

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -37,7 +37,7 @@ import {
   writeCopilotProviderMode,
 } from "./copilot-acp-agent.js";
 import { transformPiModels } from "./pi/agent.js";
-import type { AgentStreamEvent } from "../agent-sdk-types.js";
+import type { AgentStreamEvent, AgentUsage } from "../agent-sdk-types.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { asInternals } from "../../test-utils/class-mocks.js";
 import * as spawnUtils from "../../../utils/spawn.js";
@@ -47,6 +47,7 @@ interface ACPSessionInternals {
   connection: { prompt: (...args: unknown[]) => Promise<PromptResponse> };
   activeForegroundTurnId: string | null;
   configOptions: SessionConfigOption[];
+  currentTurnUsage: AgentUsage | undefined;
   translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[];
 }
 
@@ -509,6 +510,108 @@ describe("mapACPUsage", () => {
       outputTokens: 7,
       cachedInputTokens: 5,
     });
+  });
+});
+
+describe("translateSessionUpdate usage_update", () => {
+  test("emits usage_updated carrying context window size/used", () => {
+    const session = createSession();
+    const internals = asInternals<ACPSessionInternals>(session);
+
+    const events = internals.translateSessionUpdate({
+      sessionUpdate: "usage_update",
+      size: 1_000_000,
+      used: 40_002,
+    });
+
+    expect(events).toEqual([
+      {
+        type: "usage_updated",
+        provider: "claude-acp",
+        usage: {
+          contextWindowMaxTokens: 1_000_000,
+          contextWindowUsedTokens: 40_002,
+        },
+      },
+    ]);
+    expect(internals.currentTurnUsage).toEqual({
+      contextWindowMaxTokens: 1_000_000,
+      contextWindowUsedTokens: 40_002,
+    });
+  });
+
+  test("merges context window fields onto existing turn token usage", () => {
+    const session = createSession();
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.currentTurnUsage = { inputTokens: 11, outputTokens: 7 };
+
+    const events = internals.translateSessionUpdate({
+      sessionUpdate: "usage_update",
+      size: 1_000_000,
+      used: 50_000,
+    });
+
+    expect(events).toEqual([
+      {
+        type: "usage_updated",
+        provider: "claude-acp",
+        usage: {
+          inputTokens: 11,
+          outputTokens: 7,
+          contextWindowMaxTokens: 1_000_000,
+          contextWindowUsedTokens: 50_000,
+        },
+      },
+    ]);
+  });
+
+  test("ignores non-positive or non-finite size and used, keeping prior values", () => {
+    const session = createSession();
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.currentTurnUsage = {
+      contextWindowMaxTokens: 1_000_000,
+      contextWindowUsedTokens: 12_345,
+    };
+
+    const events = internals.translateSessionUpdate({
+      sessionUpdate: "usage_update",
+      size: 0,
+      used: Number.NaN,
+    });
+
+    // size=0 (divide-by-zero) and used=NaN must not overwrite the good values.
+    expect(events).toEqual([
+      {
+        type: "usage_updated",
+        provider: "claude-acp",
+        usage: {
+          contextWindowMaxTokens: 1_000_000,
+          contextWindowUsedTokens: 12_345,
+        },
+      },
+    ]);
+  });
+
+  test("accepts used=0 as a valid reading", () => {
+    const session = createSession();
+    const internals = asInternals<ACPSessionInternals>(session);
+
+    const events = internals.translateSessionUpdate({
+      sessionUpdate: "usage_update",
+      size: 1_000_000,
+      used: 0,
+    });
+
+    expect(events).toEqual([
+      {
+        type: "usage_updated",
+        provider: "claude-acp",
+        usage: {
+          contextWindowMaxTokens: 1_000_000,
+          contextWindowUsedTokens: 0,
+        },
+      },
+    ]);
   });
 });
 

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1982,8 +1982,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         this.handleSessionInfoUpdate(update);
         return [];
       case "usage_update":
-        this.handleUsageUpdate(update);
-        return [];
+        return [
+          {
+            type: "usage_updated",
+            provider: this.provider,
+            usage: this.handleUsageUpdate(update),
+          },
+        ];
       case "available_commands_update":
         this.cachedCommands = update.availableCommands.map((command) => ({
           name: command.name,
@@ -2090,8 +2095,26 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
-  private handleUsageUpdate(update: UsageUpdate): void {
-    void update;
+  private handleUsageUpdate(update: UsageUpdate): AgentUsage {
+    // ACP UsageUpdate carries the context-window figures (experimental in the
+    // spec): `size` is the total window, `used` is what's currently in context.
+    // Merge them into currentTurnUsage so they ride along with turn_completed
+    // and surface in the composer's context meter, mirroring Claude/Codex.
+    //
+    // The ACP SDK validates shape (size/used are required numbers) before this
+    // runs, but zod still admits NaN / negative / zero values that a loosely
+    // conforming agent might emit. Guard against those so a bad reading never
+    // leaks a NaN percentage or a divide-by-zero into the UI; we keep the prior
+    // valid value instead, matching the Claude provider's contextWindow checks.
+    const usage: AgentUsage = { ...this.currentTurnUsage };
+    if (Number.isFinite(update.size) && update.size > 0) {
+      usage.contextWindowMaxTokens = update.size;
+    }
+    if (Number.isFinite(update.used) && update.used >= 0) {
+      usage.contextWindowUsedTokens = update.used;
+    }
+    this.currentTurnUsage = usage;
+    return usage;
   }
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {


### PR DESCRIPTION
### Linked issue

Closes #1390

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The composer context-window meter shows for Claude Code and Codex but never for ACP-based providers. The ACP `usage_update` handler in `acp-agent.ts` was a no-op:

```ts
private handleUsageUpdate(update: UsageUpdate): void {
  void update;   // size / used dropped here
}
```

ACP `UsageUpdate` carries `size` (total context window) and `used` (tokens in context), but they were discarded, so `contextWindowMaxTokens` / `contextWindowUsedTokens` stayed undefined and the meter's render guard (`if (max === null || used === null) return null`) hid it permanently.

This PR maps `size`/`used` onto those fields, merges them into `currentTurnUsage`, and emits a `usage_updated` event from `translateSessionUpdate` — the same event Claude/Codex already emit, which `AgentManager` writes to `lastUsage` and pushes to clients. No protocol or client changes are needed.

It also guards against bad readings: the ACP SDK validates shape (`size`/`used` are required numbers) before the handler runs, but zod still admits `NaN` / negative / zero. Those are ignored so a divide-by-zero or `NaN` percentage never reaches the meter — matching the Claude provider's existing `contextWindow` checks. Since `size` arrives at session start, ACP agents show the meter slightly earlier than Claude (which waits for a result message).

Scope is one file plus its test.

### How did you verify it

**Confirmed the agent actually sends the data (not inferred).** I wrote a minimal ACP client probe speaking raw NDJSON JSON-RPC to a live ACP agent (`--acp`) and logged every `session/update` during one real turn. The agent emits `usage_update` with full `size`/`used` every turn:

```json
{"sessionUpdate":"usage_update","used":0,"size":1000000}
{"sessionUpdate":"usage_update","used":40002,"size":1000000,"cost":{"amount":13.21}}
```

`usage_update` was delivered 3× during that turn, always with `size`+`used`. So the data was always arriving; Paseo was dropping it.

**Before / after:**

Before — ACP agent, no context meter in the composer:

<img width="1866" height="422" alt="1780821409888" src="https://github.com/user-attachments/assets/9608d155-1792-4e27-80e3-ec5b28ec4adb" />

After — meter renders and updates per turn:

<img width="1760" height="342" alt="1780820718965_副本" src="https://github.com/user-attachments/assets/1dc445ea-e13d-420e-a688-1bea6c1ca9f1" />

**Checks (run in the repo devcontainer, Node 22):**

- `npm run typecheck` — passes (full monorepo)
- `npm run lint` — passes (oxlint, 0 errors)
- `npm run format` — ran (oxfmt)
- Unit tests: `acp-agent.test.ts` 47 passed, including 4 new `usage_update` cases (maps size/used, merges onto token usage, ignores NaN/zero/negative, accepts used=0)

**Platforms tested:** verified on one ACP agent on Linux (the meter is shared composer UI across desktop/web). I have not tested every ACP provider — `UsageUpdate` is an experimental ACP capability and not all agents emit it; this change is a no-op for those (the meter stays hidden as before). Stating clearly per CONTRIBUTING.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [x] UI changes include screenshots (before/after of the ACP context meter)
- [x] Tests added or updated where it made sense

