### PR TITLE
fix: upgrade @opencode-ai/sdk to 1.16.2 for OpenCode >= 1.15.0 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38220,7 +38220,7 @@
         "@getpaseo/relay": "0.1.91-beta.2",
         "@isaacs/ttlcache": "^2.1.4",
         "@modelcontextprotocol/sdk": "^1.20.1",
-        "@opencode-ai/sdk": "1.14.46",
+        "@opencode-ai/sdk": "1.16.2",
         "@xterm/headless": "^6.0.0",
         "ai": "5.0.78",
         "ajv": "^8.20.0",
@@ -38400,9 +38400,9 @@
       }
     },
     "packages/server/node_modules/@opencode-ai/sdk": {
-      "version": "1.14.46",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.46.tgz",
-      "integrity": "sha512-7KOMuoCkNI+bLOw3GCg0nWZ5m7A/MzNsyLfTbZYmE/DIaUqkV2LNRULtrW6PHL1WtYVmJEFPws4dbw/4dVxjzA==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.16.2.tgz",
+      "integrity": "sha512-Z/xZ7q79dYeE0afqIk/yFEcRNGEQFcE+H8ssYivUiy+xGZ1mGwT72jpaQZKBwPn3JH4sRCu4KA2lcktBQfcOjg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -65,7 +65,7 @@
     "@getpaseo/relay": "0.1.91-beta.2",
     "@isaacs/ttlcache": "^2.1.4",
     "@modelcontextprotocol/sdk": "^1.20.1",
-    "@opencode-ai/sdk": "1.14.46",
+    "@opencode-ai/sdk": "1.16.2",
     "@xterm/headless": "^6.0.0",
     "ai": "5.0.78",
     "ajv": "^8.20.0",

--- a/packages/server/src/server/agent/providers/opencode/runtime.ts
+++ b/packages/server/src/server/agent/providers/opencode/runtime.ts
@@ -23,5 +23,14 @@ export function createSdkOpenCodeClient(options: {
   baseUrl: string;
   directory: string;
 }): OpencodeClient {
+  // COMPAT(opencode-auth): OpenCode >= 1.15.0 requires HTTP Basic auth on the
+  // server. The auth credentials are not exposed via stdout, stderr, or any
+  // known environment variable. The `@opencode-ai/sdk` >= 1.15.0 supports auth
+  // via `Config.auth` (basic / bearer), but the mechanism to obtain server
+  // credentials from `opencode serve` needs to be determined in coordination
+  // with the OpenCode team.
+  //
+  // Once the auth mechanism is understood, pass credentials like:
+  //   auth: () => `${username}:${password}`,
   return createOpencodeClient(options satisfies OpencodeClientConfig & { directory: string });
 }


### PR DESCRIPTION
## Problem

OpenCode >= 1.15.0 introduced HTTP Basic authentication on `opencode serve`. The bundled SDK version 1.14.46 does not support this auth mechanism, causing all OpenCode provider operations to fail with:

```
Failed to fetch OpenCode providers: {}
```

## Changes

- Bump `@opencode-ai/sdk` from `1.14.46` to `1.16.2` in `packages/server/package.json`
- Add `COMPAT(opencode-auth)` comment in `runtime.ts` documenting the remaining auth gap
- Lock file updated against `registry.npmjs.org` with minimal diff

## Auth Gap

The SDK >= 1.15.0 supports HTTP auth via `Config.auth` (basic / bearer schemes), but the credentials that `opencode serve` expects are not discoverable:

- Server returns `401` with `www-authenticate: Basic realm="Secure Area"`
- No auth credentials appear in stdout, stderr, or debug logs
- No auth-related tables exist in `~/.local/share/opencode/opencode.db`
- No known environment variable disables the auth requirement
- The OpenCode SDK does not auto-authenticate

**Next step**: The OpenCode team needs to either:
1. Document how external SDK clients should authenticate
2. Provide a `--no-auth` flag for the server
3. Expose credentials via a known mechanism (env var, stdout, db)

## Testing

- Lock file diff verified: only 2 changes (version bump + integrity hash)
- No unrelated rollup/website mutations
- Clean build with `npm run build:server`