### PR TITLE
fix(catalog): point Kimi entry at Kimi Code CLI

### DIFF
--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -279,11 +279,11 @@ const CATALOG_DATA = [
   },
   {
     id: "kimi",
-    title: "Kimi CLI",
-    description: "Moonshot AI's coding assistant",
-    version: "1.41.0",
+    title: "Kimi Code CLI",
+    description: "Moonshot AI's open-source terminal coding agent",
+    version: "0.11.0",
     iconId: "kimi",
-    installLink: "https://github.com/MoonshotAI/kimi-cli",
+    installLink: "https://github.com/MoonshotAI/kimi-code",
     command: ["kimi", "acp"],
   },
   {

--- a/public-docs/supported-providers.md
+++ b/public-docs/supported-providers.md
@@ -45,7 +45,7 @@ Pick any of these from the in-app provider catalog. Each entry is a one-click in
 - [Hermes Agent](https://hermes-agent.nousresearch.com/docs/user-guide/features/acp), Nous Research's self-improving agent.
 - [Junie](https://junie.jetbrains.com/docs/junie-cli-acp.html), JetBrains' coding agent.
 - [Kilo Code](https://kilo.ai/docs/code-with-ai/platforms/cli), open-source coding agent.
-- [Kimi Code CLI](https://github.com/MoonshotAI/kimi-cli), Moonshot AI's coding assistant.
+- [Kimi Code CLI](https://github.com/MoonshotAI/kimi-code), Moonshot AI's coding assistant.
 - [Minion Code](https://github.com/femto/minion-code), Minion-framework coding agent.
 - [Mistral Vibe](https://github.com/mistralai/mistral-vibe), Mistral's open-source CLI assistant.
 - [Nova](https://www.compassap.ai/portfolio/nova.html), Compass AI's software engineer.


### PR DESCRIPTION
### Linked issue

N/A — small catalog metadata correction. Per the template, pure docs/refactors can skip a linked issue; happy to open one if you'd prefer.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

The ACP catalog `kimi` entry still pointed at the legacy Python `kimi-cli`. Moonshot AI's actively maintained agent is now the TypeScript **Kimi Code CLI** (`@moonshot-ai/kimi-code`, repo [`MoonshotAI/kimi-code`](https://github.com/MoonshotAI/kimi-code)), which exposes the same `kimi acp` ACP server. This points the entry at the right tool.

- `packages/app/src/data/acp-provider-catalog.ts`: `title` `Kimi CLI`→`Kimi Code CLI`, `version` `1.41.0`→`0.11.0`, `installLink` `…/kimi-cli`→`…/kimi-code`, `description` updated.
- `public-docs/supported-providers.md`: fix the link target (`kimi-cli`→`kimi-code`).

The launch command (`kimi acp`) is **unchanged** — only metadata.

### How did you verify it

Local environment: macOS, dev daemon (`npm run dev:server`) + web app (`npm run dev:app`).

- `npm run test --workspace=@getpaseo/app -- use-acp-provider-catalog` → 5/5 pass.
- `npm run typecheck --workspace=@getpaseo/app` → clean (after building workspace deps).
- `node scripts/check-acp-catalog-version-drift.mjs` → entry is correctly listed under "Skipped non-package-runner commands", so the `version` field is display-only and introduces no drift.
- In the app: **Add provider → ACP catalog** shows **Kimi Code CLI** with the updated description and the `MoonshotAI/kimi-code` link; adding it launches `kimi acp`, the `initialize` handshake completes, and the model picker populates. (Verified on web; `kimi login` completed first since Paseo's generic ACP adapter doesn't drive login.)

Only platform tested: web (macOS). The change is a string/metadata edit rendered by the existing catalog row component; no layout change.

<img width="1448" height="753" alt="image" src="https://github.com/user-attachments/assets/e3c31a18-eaa8-4bf1-be98-15f006b36ccc" />
<img width="1495" height="786" alt="image" src="https://github.com/user-attachments/assets/18830837-7aa9-400b-b8b1-8bc1ccb4367b" />


### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [ ] UI changes include screenshots or video for every affected platform — metadata-only string change; can attach a web catalog screenshot on request.
- [x] Tests added or updated where it made sense — existing `use-acp-provider-catalog` test already covers entry invariants (non-empty title/description, `https` install link, concrete command); no new test needed.
