### PR TITLE
Confirm before archiving clean worktrees

### DIFF
--- a/packages/app/src/git/worktree-archive-warning.test.ts
+++ b/packages/app/src/git/worktree-archive-warning.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@/git/worktree-archive-warning";
 
 describe("worktree archive warning", () => {
-  it("does not require a confirmation for clean and pushed worktrees", () => {
+  it("requires a confirmation for clean and pushed worktrees", () => {
     expect(
       buildWorktreeArchiveConfirmationMessage({
         worktreeName: "feature",
@@ -14,7 +14,7 @@ describe("worktree archive warning", () => {
         aheadOfOrigin: 0,
         diffStat: null,
       }),
-    ).toBeNull();
+    ).toBe("This clean worktree will be removed from disk.");
   });
 
   it("explains uncommitted line changes", () => {

--- a/packages/app/src/git/worktree-archive-warning.ts
+++ b/packages/app/src/git/worktree-archive-warning.ts
@@ -55,7 +55,7 @@ export function buildWorktreeArchiveConfirmationMessage(
 ): string | null {
   const reasons = buildWorktreeArchiveRiskReasons(input);
   if (reasons.length === 0) {
-    return null;
+    return "This clean worktree will be removed from disk.";
   }
 
   return reasons.join("\n");


### PR DESCRIPTION
## Summary
- require the worktree archive confirmation dialog even when the worktree is clean and fully pushed
- update the archive warning regression test to cover the clean-worktree deletion path

Closes #1335

## Verification
- node ../../node_modules/vitest/vitest.mjs run src/git/worktree-archive-warning.test.ts --config vitest.config.ts --bail=1
- npm run format:files -- packages/app/src/git/worktree-archive-warning.ts packages/app/src/git/worktree-archive-warning.test.ts
- npm run lint -- packages/app/src/git/worktree-archive-warning.ts packages/app/src/git/worktree-archive-warning.test.ts
- npm run typecheck --workspace=@getpaseo/app
- npm run build:server
- pre-commit hook: lint, format:check:files, npm run typecheck
