### PR TITLE
Harden wildcard CORS origins

### DIFF
--- a/packages/server/src/server/bootstrap.smoke.test.ts
+++ b/packages/server/src/server/bootstrap.smoke.test.ts
@@ -45,6 +45,22 @@ describe("paseo daemon bootstrap", () => {
     }
   });
 
+  test("serves wildcard CORS without reflecting credentialed origins", async () => {
+    const daemonHandle = await createTestPaseoDaemon({
+      corsAllowedOrigins: ["*"],
+    });
+    try {
+      const response = await fetch(`http://127.0.0.1:${daemonHandle.port}/api/status`, {
+        headers: { Origin: "https://evil.example" },
+      });
+
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
+      expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+    } finally {
+      await daemonHandle.close();
+    }
+  });
+
   function httpGetWithHost(port: number, host: string, requestPath: string): Promise<Response> {
     return new Promise((resolve, reject) => {
       const req = http.get(
@@ -200,6 +216,32 @@ describe("paseo daemon bootstrap", () => {
         ws.once("error", reject);
       });
       expect(ws.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      ws.close();
+      await daemonHandle.close();
+    }
+  });
+
+  test("rejects wildcard CORS for cross-origin websocket upgrades", async () => {
+    const daemonHandle = await createTestPaseoDaemon({
+      corsAllowedOrigins: ["*"],
+    });
+    const ws = new WebSocket(`ws://127.0.0.1:${daemonHandle.port}/ws`, {
+      headers: { Origin: "https://evil.example" },
+    });
+    try {
+      await expect(
+        new Promise<void>((resolve, reject) => {
+          ws.once("open", () => {
+            ws.close();
+            reject(new Error("Expected websocket upgrade to be rejected"));
+          });
+          ws.once("error", (error) => {
+            expect(error.message).toContain("Unexpected server response: 403");
+            resolve();
+          });
+        }),
+      ).resolves.toBeUndefined();
     } finally {
       ws.close();
       await daemonHandle.close();

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -401,11 +401,15 @@ export async function createPaseoDaemon(
 
   app.use((req, res, next) => {
     const origin = req.headers.origin;
-    if (origin && (allowedOrigins.has("*") || allowedOrigins.has(origin))) {
+    if (origin && allowedOrigins.has(origin)) {
       res.setHeader("Access-Control-Allow-Origin", origin);
       res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
       res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
       res.setHeader("Access-Control-Allow-Credentials", "true");
+    } else if (origin && allowedOrigins.has("*")) {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+      res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
     }
     if (req.method === "OPTIONS") {
       res.status(204).end();

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -590,7 +590,7 @@ export class VoiceAssistantWebSocketServer {
       !!requestHost &&
       (origin === `http://${requestHost}` || origin === `https://${requestHost}`);
 
-    if (!origin || allowedOrigins.has("*") || allowedOrigins.has(origin) || sameOrigin) {
+    if (!origin || allowedOrigins.has(origin) || sameOrigin) {
       callback(true);
     } else {
       this.incrementRuntimeCounter("originRejected");


### PR DESCRIPTION
## Summary
- Stop reflecting arbitrary origins with credentials when `corsAllowedOrigins` contains `*`.
- Send literal `Access-Control-Allow-Origin: *` without credentials for wildcard HTTP CORS.
- Treat wildcard as non-authorizing for browser WebSocket upgrades while preserving explicit origins, same-origin requests, and clients without an Origin header.
- Add daemon smoke regressions for HTTP and WebSocket wildcard origin handling.

Closes #449

## Verification
- `node ../../node_modules/vitest/vitest.mjs run src/server/bootstrap.smoke.test.ts --config vitest.config.ts --bail=1`
- `npm run lint -- packages/server/src/server/bootstrap.ts packages/server/src/server/websocket-server.ts packages/server/src/server/bootstrap.smoke.test.ts`
- `npm run typecheck --workspace=@getpaseo/server`
- pre-commit hook: `format:check:files`, targeted `lint`, full workspace `typecheck`