### PR TITLE
Scope assistant image previews to the workspace

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,8 @@ The daemon also supports an optional shared-secret password (set via `auth.passw
 
 Connected clients are trusted operators of the daemon user. File previews follow that authority: a preview request may read any regular file the daemon process can read, while keeping path normalization and symlink checks in the daemon file service. Workspace-relative paths remain a UI convenience, not a security boundary.
 
+Assistant-rendered markdown image previews are stricter than manual file previews: local image paths are auto-loaded only when they resolve inside the active workspace, so assistant output cannot trigger background reads from arbitrary filesystem roots.
+
 If you expose the daemon beyond loopback, such as by binding to `0.0.0.0`, forwarding it through a tunnel or reverse proxy, or publishing it from a Docker container, you are responsible for restricting and securing that access. Setting a password is strongly recommended in that case.
 
 For remote access, use the relay connection. It is the supported path for reaching the daemon off-machine, and it adds end-to-end encryption plus a pairing handshake before commands are accepted.

--- a/packages/app/src/utils/assistant-image-source.test.ts
+++ b/packages/app/src/utils/assistant-image-source.test.ts
@@ -40,55 +40,52 @@ describe("resolveAssistantImageSource", () => {
     });
   });
 
-  it("falls back to filesystem root for absolute paths outside the workspace", () => {
+  it("rejects absolute paths outside the workspace", () => {
     expect(
       resolveAssistantImageSource({
         source: "/tmp/paseo-codex-screenshot.png",
         workspaceRoot: "/Users/test/project",
       }),
-    ).toEqual({
-      kind: "file_rpc",
-      cwd: "/",
-      path: "/tmp/paseo-codex-screenshot.png",
-    });
+    ).toBeNull();
   });
 
-  it("uses the same home-root target as file previews for tilde paths", () => {
+  it("rejects home-relative paths", () => {
     expect(
       resolveAssistantImageSource({
         source: "~/.paseo/screenshots/output.png",
         workspaceRoot: "/Users/test/project",
       }),
+    ).toBeNull();
+  });
+
+  it("normalizes file URIs inside the workspace into file RPC requests", () => {
+    expect(
+      resolveAssistantImageSource({
+        source: "file:///Users/test/project/screenshots/output.png",
+        workspaceRoot: "/Users/test/project",
+      }),
     ).toEqual({
       kind: "file_rpc",
-      cwd: "~",
-      path: "~/.paseo/screenshots/output.png",
+      cwd: "/Users/test/project",
+      path: "/Users/test/project/screenshots/output.png",
     });
   });
 
-  it("normalizes file URIs into file RPC requests", () => {
+  it("rejects file URIs outside the workspace", () => {
     expect(
       resolveAssistantImageSource({
         source: "file:///tmp/paseo-codex-screenshot.png",
         workspaceRoot: "/Users/test/project",
       }),
-    ).toEqual({
-      kind: "file_rpc",
-      cwd: "/",
-      path: "/tmp/paseo-codex-screenshot.png",
-    });
+    ).toBeNull();
   });
 
-  it("falls back to the drive root for Windows absolute paths", () => {
+  it("rejects Windows absolute paths outside the workspace", () => {
     expect(
       resolveAssistantImageSource({
         source: "C:/Users/test/Desktop/screenshot.png",
         workspaceRoot: "D:/repo",
       }),
-    ).toEqual({
-      kind: "file_rpc",
-      cwd: "C:/",
-      path: "C:/Users/test/Desktop/screenshot.png",
-    });
+    ).toBeNull();
   });
 });

--- a/packages/app/src/utils/assistant-image-source.ts
+++ b/packages/app/src/utils/assistant-image-source.ts
@@ -23,11 +23,12 @@ export function resolveAssistantImageSource(input: {
     return null;
   }
 
+  const workspaceRoot = input.workspaceRoot?.trim();
   const readTarget = resolveFilePreviewReadTarget({
     path: sourcePath,
-    workspaceRoot: input.workspaceRoot,
+    workspaceRoot,
   });
-  if (!readTarget) {
+  if (!readTarget || readTarget.cwd !== workspaceRoot) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Restrict assistant-rendered local markdown image previews to paths that resolve under the active workspace root.
- Reject assistant image sources that would otherwise fall back to `/`, `~`, or a Windows drive root while keeping direct remote/data/blob image URIs unchanged.
- Preserve the broader manual file preview behavior and document that assistant auto-previews are intentionally stricter.
- Update assistant image source tests for workspace-scoped local paths and outside-workspace rejection.

Closes #448

## Verification
- `node ../../node_modules/vitest/vitest.mjs run src/utils/assistant-image-source.test.ts src/utils/assistant-image-metadata.test.ts --config vitest.config.ts --bail=1`
- `npm run lint -- SECURITY.md packages/app/src/utils/assistant-image-source.ts packages/app/src/utils/assistant-image-source.test.ts`
- `npm run typecheck --workspace=@getpaseo/app`
- pre-commit hook: targeted `lint`, `format:check:files`, full workspace `typecheck`