### PR TITLE
Clean up lingering OpenCode serve processes

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-server-manager.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-server-manager.test.ts
@@ -5,8 +5,10 @@ import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { OpenCodeServerManager, type OpenCodeServerGeneration } from "./opencode/server-manager.js";
 
 type FakeServerProcess = EventEmitter & {
+  exitCode: number | null;
   killed: boolean;
   kill: ReturnType<typeof vi.fn>;
+  signalCode: NodeJS.Signals | null;
 };
 
 type FakeGeneration = OpenCodeServerGeneration & { process: FakeServerProcess };
@@ -119,6 +121,38 @@ describe("OpenCodeServerManager generations", () => {
     expect(first.process.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
+  test("release cleans lingering OpenCode serve processes by port after dedicated server teardown", async () => {
+    const cleanupServeProcessesByPort = vi.fn(async () => {});
+    const manager = createTestManager({ cleanupServeProcessesByPort });
+    const dedicated = createGeneration(4471);
+    stubGenerations(manager, [dedicated]);
+
+    const acquisition = await manager.acquire({
+      force: false,
+      env: { OPENCODE_AUTH_TOKEN: "test-token" },
+    });
+    acquisition.release();
+
+    await vi.waitFor(() => {
+      expect(cleanupServeProcessesByPort).toHaveBeenCalledWith(4471);
+    });
+  });
+
+  test("shutdown cleans lingering OpenCode serve processes when the owner process already exited", async () => {
+    const cleanupServeProcessesByPort = vi.fn(async () => {});
+    const manager = createTestManager({ cleanupServeProcessesByPort });
+    const first = createGeneration(4481);
+    stubGenerations(manager, [first]);
+
+    await manager.acquire({ force: false });
+    first.process.exitCode = 0;
+
+    await manager.shutdown();
+
+    expect(first.process.kill).not.toHaveBeenCalled();
+    expect(cleanupServeProcessesByPort).toHaveBeenCalledWith(4481);
+  });
+
   test("repeated rotations leave zero unreferenced retired servers", async () => {
     const manager = createTestManager();
     const first = createGeneration(4501);
@@ -141,11 +175,19 @@ describe("OpenCodeServerManager generations", () => {
   });
 });
 
-function createTestManager(): OpenCodeServerManager {
+function createTestManager(options?: {
+  cleanupServeProcessesByPort?: (port: number) => Promise<void>;
+}): OpenCodeServerManager {
   const ManagerConstructor = OpenCodeServerManager as unknown as {
-    new (logger: ReturnType<typeof createTestLogger>): OpenCodeServerManager;
+    new (
+      logger: ReturnType<typeof createTestLogger>,
+      runtimeSettings: undefined,
+      options?: {
+        cleanupServeProcessesByPort?: (port: number) => Promise<void>;
+      },
+    ): OpenCodeServerManager;
   };
-  return new ManagerConstructor(createTestLogger());
+  return new ManagerConstructor(createTestLogger(), undefined, options);
 }
 
 function stubGenerations(
@@ -165,12 +207,15 @@ function stubGenerations(
 
 function createGeneration(port: number): FakeGeneration {
   const process = new EventEmitter() as FakeServerProcess;
+  process.exitCode = null;
   process.killed = false;
   process.kill = vi.fn((signal?: NodeJS.Signals) => {
     process.killed = true;
+    process.signalCode = signal ?? "SIGTERM";
     process.emit("exit", signal ?? "SIGTERM");
     return true;
   });
+  process.signalCode = null;
   return {
     process,
     port,

--- a/packages/server/src/server/agent/providers/opencode/server-manager.ts
+++ b/packages/server/src/server/agent/providers/opencode/server-manager.ts
@@ -10,6 +10,7 @@ import {
   resolveProviderCommandPrefix,
   type ProviderRuntimeSettings,
 } from "../../provider-launch-config.js";
+import { cleanupWindowsOpenCodeServeProcessesByPort } from "./windows-serve-cleanup.js";
 
 const OPENCODE_SERVER_GRACEFUL_SHUTDOWN_TIMEOUT_MS = 5_000;
 const OPENCODE_SERVER_FORCE_SHUTDOWN_TIMEOUT_MS = 1_000;
@@ -35,6 +36,10 @@ export interface OpenCodeServerGeneration {
   retired: boolean;
 }
 
+interface OpenCodeServerManagerOptions {
+  cleanupServeProcessesByPort?: (port: number) => Promise<void>;
+}
+
 export class OpenCodeServerManager implements OpenCodeServerManagerLike {
   private static instance: OpenCodeServerManager | null = null;
   private static exitHandlerRegistered = false;
@@ -45,11 +50,19 @@ export class OpenCodeServerManager implements OpenCodeServerManagerLike {
   private readonly logger: Logger;
   private readonly runtimeSettings?: ProviderRuntimeSettings;
   private readonly runtimeSettingsKey: string;
+  private readonly cleanupServeProcessesByPort: (port: number) => Promise<void>;
 
-  private constructor(logger: Logger, runtimeSettings?: ProviderRuntimeSettings) {
+  private constructor(
+    logger: Logger,
+    runtimeSettings?: ProviderRuntimeSettings,
+    options?: OpenCodeServerManagerOptions,
+  ) {
     this.logger = logger;
     this.runtimeSettings = runtimeSettings;
     this.runtimeSettingsKey = JSON.stringify(runtimeSettings ?? {});
+    this.cleanupServeProcessesByPort =
+      options?.cleanupServeProcessesByPort ??
+      ((port) => cleanupWindowsOpenCodeServeProcessesByPort(port, logger));
   }
 
   static getInstance(
@@ -308,6 +321,7 @@ export class OpenCodeServerManager implements OpenCodeServerManagerLike {
       (server.process.exitCode !== null && server.process.exitCode !== undefined) ||
       (server.process.signalCode !== null && server.process.signalCode !== undefined)
     ) {
+      await this.cleanupLingeringServeProcesses(server.port);
       return;
     }
     const result = await terminateWithTreeKill(server.process, {
@@ -324,6 +338,18 @@ export class OpenCodeServerManager implements OpenCodeServerManagerLike {
       this.logger.warn(
         { timeoutMs: OPENCODE_SERVER_FORCE_SHUTDOWN_TIMEOUT_MS },
         "OpenCode server did not report exit after SIGKILL",
+      );
+    }
+    await this.cleanupLingeringServeProcesses(server.port);
+  }
+
+  private async cleanupLingeringServeProcesses(port: number): Promise<void> {
+    try {
+      await this.cleanupServeProcessesByPort(port);
+    } catch (error) {
+      this.logger.warn(
+        { err: error, port },
+        "Failed to clean up lingering OpenCode serve processes",
       );
     }
   }

--- a/packages/server/src/server/agent/providers/opencode/windows-serve-cleanup.ts
+++ b/packages/server/src/server/agent/providers/opencode/windows-serve-cleanup.ts
@@ -1,0 +1,62 @@
+import { execFile } from "node:child_process";
+import type { Logger } from "pino";
+
+const WINDOWS_PROCESS_CLEANUP_TIMEOUT_MS = 5_000;
+
+export async function cleanupWindowsOpenCodeServeProcessesByPort(
+  port: number,
+  logger: Logger,
+): Promise<void> {
+  if (process.platform !== "win32") {
+    return;
+  }
+
+  const stdout = await runPowerShell(buildCleanupScript(port));
+  const killedProcesses = stdout.trim();
+  if (killedProcesses) {
+    logger.warn({ port, killedProcesses }, "Cleaned up lingering OpenCode serve processes");
+  }
+}
+
+function buildCleanupScript(port: number): string {
+  return `
+$ErrorActionPreference = "SilentlyContinue"
+$port = ${port}
+$portPattern = "(^|\\s)--port(\\s+|=)$port(\\s|$)"
+$processes = Get-CimInstance Win32_Process | Where-Object {
+  $_.CommandLine -and
+  $_.CommandLine -match "(?i)opencode(\\.cmd|\\.exe)?" -and
+  $_.CommandLine -match "(^|\\s)serve(\\s|$)" -and
+  $_.CommandLine -match $portPattern
+}
+$processes | ForEach-Object {
+  Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+  [PSCustomObject]@{
+    ProcessId = $_.ProcessId
+    Name = $_.Name
+    CommandLine = $_.CommandLine
+  }
+} | ConvertTo-Json -Compress
+`;
+}
+
+function runPowerShell(script: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "powershell",
+      ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
+      {
+        encoding: "utf8",
+        timeout: WINDOWS_PROCESS_CLEANUP_TIMEOUT_MS,
+        windowsHide: true,
+      },
+      (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Run an OpenCode serve cleanup step after server teardown, keyed by the server port.
- On Windows, query `Win32_Process` and force-stop lingering `opencode.CMD serve --port <port>` / `opencode.exe serve --port <port>` processes that survive the normal tree-kill path.
- Still run the port cleanup when the owner process has already exited, which covers wrapper processes that disappear while the child server remains.
- Add OpenCode server manager regressions for dedicated-server release and already-exited owner cleanup.

Closes #1396

## Verification
- `node ../../node_modules/vitest/vitest.mjs run src/server/agent/providers/opencode-server-manager.test.ts --config vitest.config.ts --bail=1`
- `npm run lint -- packages/server/src/server/agent/providers/opencode-server-manager.test.ts packages/server/src/server/agent/providers/opencode/server-manager.ts packages/server/src/server/agent/providers/opencode/windows-serve-cleanup.ts`
- `npm run typecheck --workspace=@getpaseo/server`
- pre-commit hook: targeted `lint`, `format:check:files`, full workspace `typecheck`

Note: I verified the teardown path with injected unit coverage in this Linux dev environment; I did not have a Windows host available for manual process-list verification.