### PR TITLE
Fix Windows Explorer opening Documents instead of the workspace

### DIFF
--- a/packages/desktop/src/features/editor-targets.test.ts
+++ b/packages/desktop/src/features/editor-targets.test.ts
@@ -162,7 +162,45 @@ describe("desktop editor targets", () => {
     expect(recorder.calls[0]?.args).toEqual(["-R", "/tmp/repo/src/index.ts"]);
   });
 
-  it("reveals files in Explorer on Windows", async () => {
+  it("opens the workspace directory in Explorer using Windows path separators", async () => {
+    const recorder = createSpawnRecorder();
+
+    await openEditorTarget(
+      { editorId: "explorer", path: "C:/Users/me/project" },
+      {
+        platform: "win32",
+        env: { PATH: "C:/Windows" },
+        existsSync: createExistsSync(["C:/Users/me/project", "C:/Windows/explorer.exe"]),
+        spawn: recorder.spawn,
+      },
+    );
+
+    // explorer.exe reads each "/segment" of a forward-slash arg as a switch and
+    // falls back to the Documents folder. The path must use backslashes.
+    expect(recorder.calls[0]?.command).toBe("C:/Windows/explorer.exe");
+    expect(recorder.calls[0]?.args).toEqual(["C:\\Users\\me\\project"]);
+    expect(recorder.calls[0]?.options.shell).toBe(false);
+  });
+
+  it("opens UNC workspace directories in Explorer using Windows path separators", async () => {
+    const recorder = createSpawnRecorder();
+
+    await openEditorTarget(
+      { editorId: "explorer", path: "//server/share/project" },
+      {
+        platform: "win32",
+        env: { PATH: "C:/Windows" },
+        existsSync: createExistsSync(["//server/share/project", "C:/Windows/explorer.exe"]),
+        spawn: recorder.spawn,
+      },
+    );
+
+    // UNC paths must become \\server\share\... — the leading // is preserved by
+    // the app's path normalization and explorer accepts the backslash form.
+    expect(recorder.calls[0]?.args).toEqual(["\\\\server\\share\\project"]);
+  });
+
+  it("reveals files in Explorer on Windows using Windows path separators", async () => {
     const recorder = createSpawnRecorder();
 
     await openEditorTarget(
@@ -176,7 +214,7 @@ describe("desktop editor targets", () => {
     );
 
     expect(recorder.calls[0]?.command).toBe("C:/Windows/explorer.exe");
-    expect(recorder.calls[0]?.args).toEqual(["/select,", "C:/repo/src/index.ts"]);
+    expect(recorder.calls[0]?.args).toEqual(["/select,", "C:\\repo\\src\\index.ts"]);
     expect(recorder.calls[0]?.options.shell).toBe(false);
   });
 
@@ -196,11 +234,34 @@ describe("desktop editor targets", () => {
       },
     );
 
+    // Separators flip to backslashes; "&" stays literal and the path stays a
+    // separate arg token (Node only quotes the path, not the "/select," switch).
     expect(recorder.calls[0]).toMatchObject({
       command: "C:/Windows/explorer.exe",
-      args: ["/select,", "C:/repo/src/file & calculator.ts"],
+      args: ["/select,", "C:\\repo\\src\\file & calculator.ts"],
       options: { shell: false },
     });
+  });
+
+  it("does not convert separators for editor targets on Windows", async () => {
+    const recorder = createSpawnRecorder();
+
+    await openEditorTarget(
+      { editorId: "vscode", path: "C:/repo/src/index.ts", cwd: "C:/repo" },
+      {
+        platform: "win32",
+        env: { PATH: "C:/Program Files/Microsoft VS Code/bin" },
+        existsSync: createExistsSync([
+          "C:/repo/src/index.ts",
+          "C:/repo",
+          "C:/Program Files/Microsoft VS Code/bin/code.exe",
+        ]),
+        spawn: recorder.spawn,
+      },
+    );
+
+    // Editors accept forward slashes; the backslash conversion is Explorer-scoped.
+    expect(recorder.calls[0]?.args).toEqual(["C:/repo", "C:/repo/src/index.ts"]);
   });
 
   it("prefers Windows command shims over extensionless shell launchers", async () => {

--- a/packages/desktop/src/features/editor-targets.ts
+++ b/packages/desktop/src/features/editor-targets.ts
@@ -190,6 +190,16 @@ function dirnameForPlatform(value: string, platform: NodeJS.Platform): string {
   return platform === "win32" ? win32.dirname(value) : posix.dirname(value);
 }
 
+// App paths are normalized to forward slashes everywhere (see file-open), but
+// explorer.exe parses each "/segment" of an argument as a command-line switch.
+// Given a POSIX-style path it finds no path token and silently falls back to
+// the default shell folder (the user's Documents). Hand it native backslashes.
+// Only the argument needs converting — CreateProcess resolves the command path
+// fine with forward slashes.
+function toWindowsPathSeparators(value: string): string {
+  return value.replace(/\//g, "\\");
+}
+
 function isWindowsCommandScript(executable: string, platform: NodeJS.Platform): boolean {
   if (platform !== "win32") {
     return false;
@@ -237,7 +247,7 @@ function buildLaunch(input: {
       return { command: input.executable, args: ["-R", input.path] };
     }
     if (input.target.id === "explorer" && input.platform === "win32") {
-      return { command: input.executable, args: ["/select,", input.path] };
+      return { command: input.executable, args: ["/select,", toWindowsPathSeparators(input.path)] };
     }
     if (input.target.id === "file-manager") {
       return { command: input.executable, args: [dirnameForPlatform(input.path, input.platform)] };
@@ -246,6 +256,9 @@ function buildLaunch(input: {
 
   if (input.target.kind === "editor" && input.cwd && input.cwd !== input.path) {
     return { command: input.executable, args: [input.cwd, input.path] };
+  }
+  if (input.target.id === "explorer" && input.platform === "win32") {
+    return { command: input.executable, args: [toWindowsPathSeparators(input.path)] };
   }
   return { command: input.executable, args: [input.path] };
 }


### PR DESCRIPTION
### Linked issue

Closes #476

### Type of change

- [x] Bug fix

### What does this PR do

On Windows, the top-bar **Open → Explorer** action (the split button next to the GitHub +/- line info) opened the user's **Documents** folder instead of the workspace directory.

Root cause is a separator/boundary mismatch, not "Explorer being weird":

- Paseo normalizes **all** app paths to forward slashes (e.g. `C:/Users/me/project`) — see `packages/app/src/workspace/file-open` (`.replace(/\\/g, "/")`). The workspace root itself is git-derived (`git rev-parse` emits forward slashes on Windows).
- The desktop layer passed that string **verbatim** to `explorer.exe` via `spawn(..., { shell: false })` in `packages/desktop/src/features/editor-targets.ts` (`buildLaunch`).
- `explorer.exe` parses each `/segment` of an argument as a **command-line switch** (`/e`, `/select`, `/root`, …). Given `C:/Users/me/project` it sees `/Users`, `/me`, `/project` as unknown switches, finds **no path token left**, and silently falls back to its default shell folder — the user's Documents. "Documents" is the symptom; the forward-slash argument is the cause.

This is Windows-only: macOS `open` and Linux `xdg-open` accept forward slashes natively, and Windows editors (`code`, `cursor`, …) accept them too — only `explorer.exe` has the switch-parsing quirk.

**The fix:** convert the Explorer **argument** to native backslashes on `win32`, for both the plain `open` and the `/select,` reveal paths. Only the argument is converted — the command path (`C:/Windows/explorer.exe`) resolves fine with forward slashes via CreateProcess. Editors and macOS/Linux are untouched. The change is gated to `target.id === "explorer" && platform === "win32"`, consistent with the existing reveal gate.

```ts
function toWindowsPathSeparators(value: string): string {
  return value.replace(/\//g, "\\");
}
```

It's a 15-line change in one file plus tests. The previous Windows reveal tests actually **encoded the bug** (they asserted forward-slash `/select,` args as if correct); they're corrected here.

### How did you verify it

**Tested on Windows 11 only** (PowerShell / Windows Terminal). I don't have macOS/Linux to test those paths — but they're untouched by this change (the conversion is win32+Explorer-gated), and their existing unit tests stay green.

**1) Reproduced the bug and confirmed the fix at the OS level** — same folder, only the slash direction differs:

```powershell
# BUG (forward slashes) -> Explorer can't parse the arg, opens "Documents"
explorer.exe "D:/Projects/Forks/paseo"

# FIX (backslashes) -> Explorer opens the actual folder
explorer.exe "D:\Projects\Forks\paseo"
```

- Command 1 opened my **Documents** folder → exactly issue #476.
- Command 2 opened the real `paseo` folder. ✅

**2) Verified the `/select,` reveal path through the *real* spawn the app uses** (`shell: false`, which bypasses the shell). Run in Windows Terminal with `node`:

```powershell
# Reveal / file-selection — reproduces exactly what Paseo's spawn does
node -e "require('child_process').spawn('explorer.exe',['/select,','D:\\Projects\\Forks\\paseo\\package.json'],{detached:true,stdio:'ignore'}).unref()"
```

→ Explorer opened the folder and **selected `package.json`**. ✅ Reveal works with the backslash arg.

> Note: a direct PowerShell `explorer.exe /select,"D:\..."` looked broken, but that's a PowerShell comma/quoting artifact — the app uses `child_process.spawn(..., { shell: false })`, which goes straight to `CreateProcess` and is unaffected. The Node repro above is the faithful test.

**3) Unit tests** (`packages/desktop/src/features/editor-targets.test.ts`): added a Windows plain-open test (asserts `["C:\\Users\\me\\project"]`), a UNC regression test (`//server/share/project` → `\\server\share\project`), and an "editors are not converted" guard (VS Code keeps forward slashes). Updated the Windows reveal + metacharacter tests to assert the corrected backslash argv. macOS/Linux tests unchanged. `npm run lint` and `npm run format:check:files` pass on the changed files.

<details>
<summary>Root-cause analysis (cross-checked independently by two reasoning models — Claude Opus 4.8 and GPT-5.4)</summary>

I had the fix reviewed from scratch by two independent models to avoid tunnel vision. Both converged on the same root cause and confirmed the chosen fix; the substance is what matters and is summarized below.

- **Why "Documents"?** Explorer received an argument with no parseable path token, so it opened its default window location (Documents). No code path in Paseo selects Documents — it's Explorer's fallback.
- **Why no path token?** `explorer.exe` treats `/` as a switch sigil; a POSIX-style path becomes a list of unknown switches.
- **Why forward slashes at all?** Paseo canonicalizes paths to POSIX form for cross-platform string handling and hands that form to a native Windows tool without converting back to `\`.
- **Open vs. reveal:** both were affected. Plain open became `explorer.exe C:/...`; reveal passed a forward-slash path to `/select,`. Both are fixed by the backslash conversion.
- **Alternative considered — Electron `shell.openPath` / `shell.showItemInFolder`:** the bulletproof long-term option for reveal-with-spaces, but it splits the unified spawn architecture (editors via spawn / file-manager via Electron), is harder to unit-test, and is a larger change than this focused bug warrants. The empirical Windows test above confirmed the spawn `+` backslash form works for both open and reveal, so the minimal fix was chosen. `shell.showItemInFolder` remains the documented escape hatch if a real-world reveal-with-spaces issue ever surfaces.
- Keeping `/select,` and the path as **separate argv tokens** is deliberate: Node then quotes only the path token (`explorer.exe /select, "C:\dir\file name.ts"`) rather than wrapping the whole switch in quotes (the historically broken single-token form).

</details>

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run lint` passes (on the changed files)
- [x] `npm run format` ran (Biome/oxfmt)
- [x] `npm run typecheck` — change is a pure `string -> string` helper with no new imports/types; not run as a full local suite (see repo guidance on heavy local suites)
- [x] No UI changes (button behavior only); no screenshots needed
- [x] Tests added/updated
