### PR TITLE
Honor known Claude model context windows

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -750,11 +750,19 @@ describe("normalizeClaudeAskUserQuestionUpdatedInput", () => {
 describe("ClaudeAgentSession context window usage", () => {
   const logger = createTestLogger();
 
-  async function createSessionForTest(): Promise<TestClaudeSession> {
-    const client = new ClaudeAgentClient({ logger, resolveBinary: async () => "/test/claude/bin" });
+  async function createSessionForTest(options?: {
+    model?: string;
+    runtimeEnv?: Record<string, string>;
+  }): Promise<TestClaudeSession> {
+    const client = new ClaudeAgentClient({
+      logger,
+      resolveBinary: async () => "/test/claude/bin",
+      runtimeSettings: options?.runtimeEnv ? { env: options.runtimeEnv } : undefined,
+    });
     const session = await client.createSession({
       provider: "claude",
       cwd: process.cwd(),
+      model: options?.model,
     });
     return session as unknown as TestClaudeSession;
   }
@@ -1030,6 +1038,68 @@ describe("ClaudeAgentSession context window usage", () => {
       {
         "claude-sonnet-4-6": { contextWindow: 200_000 },
         "claude-opus-4-6": { contextWindow: 1_000_000 },
+      },
+    );
+
+    expect(usage).toEqual({
+      inputTokens: 10,
+      cachedInputTokens: 5,
+      outputTokens: 7,
+      totalCostUsd: 0.12,
+      contextWindowMaxTokens: 1_000_000,
+      contextWindowUsedTokens: 22,
+    });
+  });
+
+  test("convertUsage prefers known selected-model context over SDK default context", async () => {
+    const session = await createSessionForTest({ model: "MiniMax-M3" });
+
+    const usage = session.convertUsage(
+      {
+        type: "result",
+        subtype: "success",
+        usage: {
+          input_tokens: 10,
+          cache_read_input_tokens: 5,
+          output_tokens: 7,
+        },
+        total_cost_usd: 0.12,
+      },
+      {
+        "MiniMax-M3": { contextWindow: 200_000 },
+      },
+    );
+
+    expect(usage).toEqual({
+      inputTokens: 10,
+      cachedInputTokens: 5,
+      outputTokens: 7,
+      totalCostUsd: 0.12,
+      contextWindowMaxTokens: 1_000_000,
+      contextWindowUsedTokens: 22,
+    });
+  });
+
+  test("convertUsage uses configured Anthropic model env context when no session model is selected", async () => {
+    const session = await createSessionForTest({
+      runtimeEnv: {
+        ANTHROPIC_MODEL: "MiniMax-M3",
+      },
+    });
+
+    const usage = session.convertUsage(
+      {
+        type: "result",
+        subtype: "success",
+        usage: {
+          input_tokens: 10,
+          cache_read_input_tokens: 5,
+          output_tokens: 7,
+        },
+        total_cost_usd: 0.12,
+      },
+      {
+        "MiniMax-M3": { contextWindow: 200_000 },
       },
     );
 

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -29,7 +29,11 @@ import {
   mapTaskNotificationSystemRecordToToolCall,
   mapTaskNotificationUserContentToToolCall,
 } from "./task-notification-tool-call.js";
-import { getClaudeModelsWithSettings, normalizeClaudeRuntimeModelId } from "./models.js";
+import {
+  getClaudeModelsWithSettings,
+  normalizeClaudeRuntimeModelId,
+  resolveClaudeModelContextWindowOverride,
+} from "./models.js";
 import { parsePartialJsonObject } from "./partial-json.js";
 import { ClaudeSidechainTracker } from "./sidechain-tracker.js";
 import { buildClaudeFeatures, claudeModelSupportsFastMode } from "./feature-definitions.js";
@@ -1517,6 +1521,17 @@ function readUsageTotalTokens(usage: unknown): number | undefined {
     return undefined;
   }
   return totalTokens;
+}
+
+function maxPositiveFiniteNumber(...values: Array<number | undefined>): number | undefined {
+  let max: number | undefined;
+  for (const value of values) {
+    if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+      continue;
+    }
+    max = Math.max(max ?? 0, value);
+  }
+  return max;
 }
 
 function readContextWindowUsedTokensFromTaskProgress(
@@ -3654,7 +3669,12 @@ class ClaudeAgentSession implements AgentSession {
       outputTokens: message.usage.output_tokens,
       totalCostUsd: message.total_cost_usd,
     };
-    const contextWindowMaxTokens = extractContextWindowSize(modelUsage ?? message.modelUsage);
+    const sdkContextWindowMaxTokens = extractContextWindowSize(modelUsage ?? message.modelUsage);
+    const selectedModelContextWindowMaxTokens = this.resolveSelectedModelContextWindowMaxTokens();
+    const contextWindowMaxTokens = maxPositiveFiniteNumber(
+      sdkContextWindowMaxTokens,
+      selectedModelContextWindowMaxTokens,
+    );
     if (contextWindowMaxTokens !== undefined) {
       this.lastContextWindowMaxTokens = contextWindowMaxTokens;
       usage.contextWindowMaxTokens = contextWindowMaxTokens;
@@ -3689,6 +3709,16 @@ class ClaudeAgentSession implements AgentSession {
       }
     }
     return usage;
+  }
+
+  private resolveSelectedModelContextWindowMaxTokens(): number | undefined {
+    const modelId =
+      this.config.model ??
+      this.lastOptionsModel ??
+      this.launchEnv?.ANTHROPIC_MODEL ??
+      this.runtimeSettings?.env?.ANTHROPIC_MODEL ??
+      this.lastRuntimeModel;
+    return resolveClaudeModelContextWindowOverride(modelId);
   }
 
   private createUsageUpdatedEvent(contextWindowUsedTokens: number): AgentStreamEvent {

--- a/packages/server/src/server/agent/providers/claude/models.ts
+++ b/packages/server/src/server/agent/providers/claude/models.ts
@@ -94,6 +94,8 @@ const CLAUDE_SETTINGS_MODEL_ENV_KEYS = [
   "ANTHROPIC_DEFAULT_HAIKU_MODEL",
 ] as const;
 
+const MODEL_CONTEXT_WINDOW_OVERRIDES = new Map<string, number>([["minimax-m3", 1_000_000]]);
+
 export function getClaudeModels(): AgentModelDefinition[] {
   return CLAUDE_MODELS.map((model) => ({ ...model }));
 }
@@ -219,4 +221,19 @@ export function normalizeClaudeRuntimeModelId(value: string | null | undefined):
   const minor = runtimeMatch[3];
   const suffix = runtimeMatch[4] ?? "";
   return `claude-${family}-${major}-${minor}${suffix}`;
+}
+
+export function resolveClaudeModelContextWindowOverride(
+  modelId: string | null | undefined,
+): number | undefined {
+  const trimmed = typeof modelId === "string" ? modelId.trim() : "";
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (/\[1m\]$/i.test(trimmed)) {
+    return 1_000_000;
+  }
+
+  return MODEL_CONTEXT_WINDOW_OVERRIDES.get(trimmed.toLowerCase());
 }


### PR DESCRIPTION
## Summary
- Add a Claude model context-window override for MiniMax-M3 and explicit `[1m]` model IDs.
- Combine SDK-reported `modelUsage` with the selected/configured model override, taking the larger positive context value.
- Fall back to `ANTHROPIC_MODEL` from launch/runtime env when no session model is selected.
- Add regressions for MiniMax-M3 when selected explicitly and when configured through provider env.

Closes #1392

## Verification
- `node ../../node_modules/vitest/vitest.mjs run src/server/agent/providers/claude/agent.test.ts src/server/agent/providers/claude/models.test.ts --config vitest.config.ts --bail=1`
- `npm run lint -- packages/server/src/server/agent/providers/claude/agent.ts packages/server/src/server/agent/providers/claude/agent.test.ts packages/server/src/server/agent/providers/claude/models.ts`
- `npm run typecheck --workspace=@getpaseo/server`
- pre-commit hook: targeted `lint`, `format:check:files`, full workspace `typecheck`