### PR TITLE
Include agent plan files in workspace suggestions

### DIFF
--- a/packages/server/src/utils/directory-suggestions.test.ts
+++ b/packages/server/src/utils/directory-suggestions.test.ts
@@ -277,6 +277,24 @@ describe("searchWorkspaceEntries", () => {
     ]);
   });
 
+  it("includes plan files under known hidden agent directories", async () => {
+    mkdirSync(path.join(workspaceDir, ".cursor", "plans"), { recursive: true });
+    writeFileSync(path.join(workspaceDir, ".cursor", "plans", "implementation-plan.md"), "");
+
+    const results = await searchWorkspaceEntries({
+      cwd: workspaceDir,
+      query: "implementation",
+      limit: 20,
+      includeFiles: true,
+      includeDirectories: false,
+    });
+
+    expect(results).toContainEqual({
+      path: ".cursor/plans/implementation-plan.md",
+      kind: "file",
+    });
+  });
+
   it("ranks fuzzy basename matches after exact, prefix, and substring matches", async () => {
     writeFileSync(path.join(workspaceDir, "src", "components", "msgrndr"), "");
     writeFileSync(path.join(workspaceDir, "src", "components", "msgrndr-panel.tsx"), "");

--- a/packages/server/src/utils/directory-suggestions.ts
+++ b/packages/server/src/utils/directory-suggestions.ts
@@ -91,6 +91,7 @@ const IGNORED_SUGGESTION_DIRECTORY_NAMES = new Set([
   "vendor",
   "__pycache__",
 ]);
+const ALLOWED_HIDDEN_WORKSPACE_DIRECTORY_NAMES = new Set([".claude", ".codex", ".cursor"]);
 
 export async function searchHomeDirectories(
   options: SearchHomeDirectoriesOptions,
@@ -869,7 +870,8 @@ async function listWorkspaceChildEntries(input: {
   );
   const candidates = dirents.filter(
     (dirent) =>
-      !isHiddenDirectoryName(dirent.name) && !isIgnoredSuggestionDirectoryName(dirent.name),
+      (!isHiddenDirectoryName(dirent.name) || isAllowedHiddenWorkspaceDirectoryName(dirent.name)) &&
+      !isIgnoredSuggestionDirectoryName(dirent.name),
   );
   const resolved = await Promise.all(
     candidates.map(async (dirent) => {
@@ -958,6 +960,10 @@ async function resolveWorkspaceCandidate(input: {
 
 function isHiddenDirectoryName(name: string): boolean {
   return name.startsWith(".");
+}
+
+function isAllowedHiddenWorkspaceDirectoryName(name: string): boolean {
+  return ALLOWED_HIDDEN_WORKSPACE_DIRECTORY_NAMES.has(name);
 }
 
 function isIgnoredSuggestionDirectoryName(name: string): boolean {


### PR DESCRIPTION
## Summary
- Allow workspace file suggestions to traverse known hidden agent directories: `.cursor`, `.codex`, and `.claude`.
- Keep the existing ignore list for heavy generated directories such as `node_modules`, `dist`, and `coverage`.
- Add a regression for `@` file suggestions finding `.cursor/plans/implementation-plan.md`.

Closes #1380

## Verification
- `node ../../node_modules/vitest/vitest.mjs run src/utils/directory-suggestions.test.ts --config vitest.config.ts --bail=1`
- `npm run lint -- packages/server/src/utils/directory-suggestions.ts packages/server/src/utils/directory-suggestions.test.ts`
- `npm run typecheck --workspace=@getpaseo/server`
- pre-commit hook: `format:check:files`, targeted `lint`, full workspace `typecheck`