### PR TITLE
Fix project rename input prefill

### DIFF
--- a/packages/app/src/screens/project-settings-name-editor.test.ts
+++ b/packages/app/src/screens/project-settings-name-editor.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { getProjectNameEditValue, resolveProjectNameSave } from "./project-settings-name-editor";
+
+describe("project settings name editor", () => {
+  it("prefills the original project name when there is no custom name", () => {
+    expect(
+      getProjectNameEditValue({
+        projectName: "acme/repo",
+        projectCustomName: null,
+      }),
+    ).toBe("acme/repo");
+  });
+
+  it("does not persist the original name as a custom name when saved unchanged", () => {
+    expect(
+      resolveProjectNameSave({
+        projectName: "acme/repo",
+        projectCustomName: null,
+        value: "acme/repo",
+      }),
+    ).toEqual({
+      hasChange: false,
+      customName: null,
+    });
+  });
+});

--- a/packages/app/src/screens/project-settings-name-editor.ts
+++ b/packages/app/src/screens/project-settings-name-editor.ts
@@ -1,0 +1,32 @@
+interface ProjectNameEditInput {
+  projectName: string;
+  projectCustomName?: string | null;
+}
+
+interface ProjectNameSaveInput {
+  projectName: string;
+  projectCustomName?: string | null;
+  value: string;
+}
+
+export interface ProjectNameSaveResolution {
+  hasChange: boolean;
+  customName: string | null;
+}
+
+export function getProjectNameEditValue(project: ProjectNameEditInput): string {
+  return project.projectCustomName ?? project.projectName;
+}
+
+export function resolveProjectNameSave(input: ProjectNameSaveInput): ProjectNameSaveResolution {
+  const currentCustomName = input.projectCustomName ?? null;
+  const trimmed = input.value.trim();
+  let customName = trimmed.length === 0 ? null : trimmed;
+  if (currentCustomName === null && customName === input.projectName) {
+    customName = null;
+  }
+  return {
+    hasChange: customName !== currentCustomName,
+    customName,
+  };
+}

--- a/packages/app/src/screens/project-settings-screen.tsx
+++ b/packages/app/src/screens/project-settings-screen.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/utils/project-config-form";
 import { buildProjectsSettingsRoute } from "@/utils/host-routes";
 import type { ProjectHostEntry, ProjectSummary } from "@/utils/projects";
+import { getProjectNameEditValue, resolveProjectNameSave } from "./project-settings-name-editor";
 
 const SCRIPT_SERVICE_TYPE = "service";
 
@@ -791,7 +792,7 @@ function ProjectNameEditor({ project, client }: ProjectNameEditorProps) {
   const queryClient = useQueryClient();
   const toast = useToast();
   const [isEditing, setIsEditing] = useState(false);
-  const [value, setValue] = useState(project.projectCustomName ?? "");
+  const [value, setValue] = useState(() => getProjectNameEditValue(project));
 
   const renameMutation = useMutation({
     mutationFn: (customName: string | null) => client.renameProject(project.projectKey, customName),
@@ -807,24 +808,27 @@ function ProjectNameEditor({ project, client }: ProjectNameEditorProps) {
   });
 
   const handleStartEdit = useCallback(() => {
-    setValue(project.projectCustomName ?? "");
+    setValue(getProjectNameEditValue(project));
     setIsEditing(true);
-  }, [project.projectCustomName]);
+  }, [project]);
 
   const handleCancel = useCallback(() => {
     setIsEditing(false);
-    setValue(project.projectCustomName ?? "");
-  }, [project.projectCustomName]);
+    setValue(getProjectNameEditValue(project));
+  }, [project]);
 
   const handleSave = useCallback(() => {
-    const trimmed = value.trim();
-    const next = trimmed.length === 0 ? null : trimmed;
-    if (next === (project.projectCustomName ?? null)) {
+    const result = resolveProjectNameSave({
+      projectName: project.projectName,
+      projectCustomName: project.projectCustomName,
+      value,
+    });
+    if (!result.hasChange) {
       setIsEditing(false);
       return;
     }
-    renameMutation.mutate(next);
-  }, [value, project.projectCustomName, renameMutation]);
+    renameMutation.mutate(result.customName);
+  }, [value, project.projectName, project.projectCustomName, renameMutation]);
 
   const handleReset = useCallback(() => {
     renameMutation.mutate(null);


### PR DESCRIPTION
## Summary
- Prefill the project settings rename input with the current project name when no custom name exists.
- Keep unchanged default-name saves as a no-op so the default name is not persisted as a custom override.

Closes #1381

## Test plan
- node ../../node_modules/vitest/vitest.mjs run src/screens/project-settings-name-editor.test.ts --config vitest.config.ts --bail=1
- npm run lint -- packages/app/src/screens/project-settings-screen.tsx packages/app/src/screens/project-settings-name-editor.ts packages/app/src/screens/project-settings-name-editor.test.ts
- npm run typecheck --workspace=@getpaseo/app
- pre-commit: format, lint, full workspace typecheck