### PR TITLE
Fix stale service port plans

### DIFF
--- a/packages/server/src/server/workspace-service-port-registry.test.ts
+++ b/packages/server/src/server/workspace-service-port-registry.test.ts
@@ -29,7 +29,7 @@ describe("ensureWorkspaceServicePortPlan", () => {
     expect(allocationCount).toBe(3);
   });
 
-  it("returns the existing plan without calling the allocator on later calls", async () => {
+  it("extends the existing plan for later service declarations without reallocating known services", async () => {
     let allocationCount = 0;
 
     const firstPlan = await ensureWorkspaceServicePortPlan({
@@ -43,16 +43,23 @@ describe("ensureWorkspaceServicePortPlan", () => {
 
     const secondPlan = await ensureWorkspaceServicePortPlan({
       workspaceId: "registry-first-wins-workspace",
-      services: [{ scriptName: "new-service" }],
+      services: [{ scriptName: "api" }, { scriptName: "web" }, { scriptName: "new-service" }],
       allocatePort: async () => {
         allocationCount += 1;
         return 4300;
       },
     });
 
-    expect(Array.from(secondPlan.entries())).toEqual(Array.from(firstPlan.entries()));
-    expect(secondPlan.has("new-service")).toBe(false);
-    expect(allocationCount).toBe(2);
+    expect(Array.from(firstPlan.entries())).toEqual([
+      ["api", 4201],
+      ["web", 4202],
+    ]);
+    expect(Array.from(secondPlan.entries())).toEqual([
+      ["api", 4201],
+      ["web", 4202],
+      ["new-service", 4300],
+    ]);
+    expect(allocationCount).toBe(3);
   });
 
   it("shares one first-plan build across concurrent callers", async () => {
@@ -119,6 +126,54 @@ describe("ensureWorkspaceServicePortPlan", () => {
     expect(allocationCount).toBe(0);
   });
 
+  it("updates an existing plan when a later declaration sets an explicit port", async () => {
+    let allocationCount = 0;
+
+    const firstPlan = await ensureWorkspaceServicePortPlan({
+      workspaceId: "registry-later-explicit-port-workspace",
+      services: [{ scriptName: "api" }, { scriptName: "web" }],
+      allocatePort: async () => {
+        allocationCount += 1;
+        return 4450 + allocationCount;
+      },
+    });
+
+    const secondPlan = await ensureWorkspaceServicePortPlan({
+      workspaceId: "registry-later-explicit-port-workspace",
+      services: [{ scriptName: "api" }, { scriptName: "web", port: 5173 }],
+      allocatePort: async () => {
+        allocationCount += 1;
+        return 4499;
+      },
+    });
+
+    expect(Array.from(firstPlan.entries())).toEqual([
+      ["api", 4451],
+      ["web", 4452],
+    ]);
+    expect(Array.from(secondPlan.entries())).toEqual([
+      ["api", 4451],
+      ["web", 5173],
+    ]);
+    expect(allocationCount).toBe(2);
+  });
+
+  it("drops services that are no longer declared", async () => {
+    await ensureWorkspaceServicePortPlan({
+      workspaceId: "registry-removed-service-workspace",
+      services: [{ scriptName: "api" }, { scriptName: "web" }],
+      allocatePort: createSequentialPortAllocator(4460),
+    });
+
+    const nextPlan = await ensureWorkspaceServicePortPlan({
+      workspaceId: "registry-removed-service-workspace",
+      services: [{ scriptName: "api" }],
+      allocatePort: async () => 4469,
+    });
+
+    expect(Array.from(nextPlan.entries())).toEqual([["api", 4460]]);
+  });
+
   it("keeps workspace plans independent", async () => {
     const firstPlan = await ensureWorkspaceServicePortPlan({
       workspaceId: "registry-independent-workspace-a",
@@ -145,7 +200,7 @@ describe("ensureWorkspaceServicePortPlan", () => {
 
     const second = await ensureWorkspaceServicePortPlan({
       workspaceId: "registry-defensive-snapshot-workspace",
-      services: [],
+      services: [{ scriptName: "api" }],
       allocatePort: async () => 4701,
     });
 
@@ -171,7 +226,7 @@ describe("refreshWorkspaceServicePort", () => {
 
     const snapshot = await ensureWorkspaceServicePortPlan({
       workspaceId: "registry-refresh-workspace",
-      services: [],
+      services: [{ scriptName: "api" }, { scriptName: "web" }],
       allocatePort: async () => 4901,
     });
 

--- a/packages/server/src/server/workspace-service-port-registry.ts
+++ b/packages/server/src/server/workspace-service-port-registry.ts
@@ -21,22 +21,26 @@ const pendingWorkspaceServicePortPlans = new Map<string, Promise<Map<string, num
 export async function ensureWorkspaceServicePortPlan(
   options: EnsureWorkspaceServicePortPlanOptions,
 ): Promise<ReadonlyMap<string, number>> {
-  const existingPlan = workspaceServicePortPlans.get(options.workspaceId);
-  if (existingPlan) {
-    return new Map(existingPlan);
-  }
+  while (true) {
+    const existingPlan = workspaceServicePortPlans.get(options.workspaceId);
+    if (existingPlan && planMatchesServiceDeclarations(existingPlan, options.services)) {
+      return new Map(existingPlan);
+    }
 
-  let pendingPlan = pendingWorkspaceServicePortPlans.get(options.workspaceId);
-  if (!pendingPlan) {
-    pendingPlan = createPendingWorkspaceServicePortPlan({
-      workspaceId: options.workspaceId,
-      services: options.services,
-      allocatePort: options.allocatePort,
-    });
-    pendingWorkspaceServicePortPlans.set(options.workspaceId, pendingPlan);
-  }
+    let pendingPlan = pendingWorkspaceServicePortPlans.get(options.workspaceId);
+    if (!pendingPlan) {
+      pendingPlan = createPendingWorkspaceServicePortPlan({
+        workspaceId: options.workspaceId,
+        existingPlan,
+        services: options.services,
+        allocatePort: options.allocatePort,
+      });
+      pendingWorkspaceServicePortPlans.set(options.workspaceId, pendingPlan);
+      return new Map(await pendingPlan);
+    }
 
-  return new Map(await pendingPlan);
+    await pendingPlan;
+  }
 }
 
 export function requirePlannedWorkspaceServicePort(
@@ -52,11 +56,13 @@ export function requirePlannedWorkspaceServicePort(
 
 async function createPendingWorkspaceServicePortPlan(options: {
   workspaceId: string;
+  existingPlan: ReadonlyMap<string, number> | undefined;
   services: readonly WorkspaceServicePortDeclaration[];
   allocatePort: () => Promise<number>;
 }): Promise<Map<string, number>> {
   try {
     const plan = await buildWorkspaceServicePortPlan({
+      existingPlan: options.existingPlan,
       services: options.services,
       allocatePort: options.allocatePort,
     });
@@ -68,15 +74,38 @@ async function createPendingWorkspaceServicePortPlan(options: {
 }
 
 async function buildWorkspaceServicePortPlan(options: {
+  existingPlan: ReadonlyMap<string, number> | undefined;
   services: readonly WorkspaceServicePortDeclaration[];
   allocatePort: () => Promise<number>;
 }): Promise<Map<string, number>> {
   const plan = new Map<string, number>();
   for (const service of options.services) {
-    plan.set(service.scriptName, await resolveServicePort(service, options.allocatePort));
+    const port = await resolvePlannedServicePort({
+      service,
+      existingPlan: options.existingPlan,
+      allocatePort: options.allocatePort,
+    });
+    plan.set(service.scriptName, port);
   }
 
   return plan;
+}
+
+function planMatchesServiceDeclarations(
+  plan: ReadonlyMap<string, number>,
+  services: readonly WorkspaceServicePortDeclaration[],
+): boolean {
+  const serviceNames = new Set(services.map((service) => service.scriptName));
+  if (plan.size !== serviceNames.size) {
+    return false;
+  }
+  return services.every((service) => {
+    const plannedPort = plan.get(service.scriptName);
+    if (plannedPort === undefined) {
+      return false;
+    }
+    return service.port === undefined || service.port === plannedPort;
+  });
 }
 
 export async function refreshWorkspaceServicePort(
@@ -88,6 +117,23 @@ export async function refreshWorkspaceServicePort(
   plan.set(options.service.scriptName, port);
   workspaceServicePortPlans.set(options.workspaceId, plan);
   return port;
+}
+
+async function resolvePlannedServicePort(options: {
+  service: WorkspaceServicePortDeclaration;
+  existingPlan: ReadonlyMap<string, number> | undefined;
+  allocatePort: () => Promise<number>;
+}): Promise<number> {
+  if (options.service.port !== undefined) {
+    return options.service.port;
+  }
+
+  const existingPort = options.existingPlan?.get(options.service.scriptName);
+  if (existingPort !== undefined) {
+    return existingPort;
+  }
+
+  return await options.allocatePort();
 }
 
 async function resolveServicePort(

--- a/packages/server/src/server/worktree-bootstrap.test.ts
+++ b/packages/server/src/server/worktree-bootstrap.test.ts
@@ -813,6 +813,75 @@ describe("runAsyncWorktreeBootstrap", () => {
     });
   });
 
+  it("extends a cached service port plan when paseo.json gains another service", async () => {
+    commitPaseoScripts(
+      {
+        "backend-dev": {
+          type: "service",
+          command: "npm run backend",
+        },
+      },
+      "add backend service script config",
+    );
+
+    const routeStore = new ScriptRouteStore();
+    const runtimeStore = new WorkspaceScriptRuntimeStore();
+    const createTerminalCalls: CreateTerminalCall[] = [];
+    const terminalRecords: StubTerminalRecord[] = [];
+    const terminalManager = createStubTerminalManager(createTerminalCalls, terminalRecords);
+
+    await spawnWorkspaceScript({
+      repoRoot: repoDir,
+      workspaceId: repoDir,
+      projectSlug: "repo",
+      branchName: "feature-service-plan-update",
+      scriptName: "backend-dev",
+      daemonPort: 6767,
+      serviceProxy: routeStore,
+      runtimeStore,
+      terminalManager,
+    });
+
+    commitPaseoScripts(
+      {
+        "backend-dev": {
+          type: "service",
+          command: "npm run backend",
+        },
+        web: {
+          type: "service",
+          command: "npm run web",
+        },
+      },
+      "add web service script config",
+    );
+
+    const webResult = await spawnWorkspaceScript({
+      repoRoot: repoDir,
+      workspaceId: repoDir,
+      projectSlug: "repo",
+      branchName: "feature-service-plan-update",
+      scriptName: "web",
+      daemonPort: 6767,
+      serviceProxy: routeStore,
+      runtimeStore,
+      terminalManager,
+    });
+
+    expect(webResult.scriptName).toBe("web");
+    expect(createTerminalCalls).toHaveLength(2);
+    const backendPort = createTerminalCalls[0]?.env?.PASEO_SERVICE_BACKEND_DEV_PORT;
+    const webPort = createTerminalCalls[1]?.env?.PASEO_SERVICE_WEB_PORT;
+    expect(backendPort).toEqual(expect.stringMatching(/^\d+$/));
+    expect(webPort).toEqual(expect.stringMatching(/^\d+$/));
+    expect(webPort).not.toBe(backendPort);
+    expect(createTerminalCalls[1]?.env?.PASEO_SERVICE_BACKEND_DEV_PORT).toBe(backendPort);
+    expect(createTerminalCalls[1]?.env?.PASEO_PORT).toBe(webPort);
+    expect(createTerminalCalls[1]?.env?.PASEO_SERVICE_WEB_URL).toBe(
+      "http://web--feature-service-plan-update--repo.localhost:6767",
+    );
+  });
+
   it("spawns services with public aliases and public service URLs", async () => {
     commitPaseoScripts(
       {


### PR DESCRIPTION
## Summary
- Extend cached workspace service port plans when `paseo.json` gains additional service scripts.
- Preserve existing service ports while allocating ports for newly declared services.
- Add a bootstrap regression for adding `web` after a backend service plan already exists.

Closes #1374

## Test plan
- node ../../node_modules/vitest/vitest.mjs run src/server/workspace-service-port-registry.test.ts src/server/worktree-bootstrap.test.ts --config vitest.config.ts --bail=1
- npm run lint -- packages/server/src/server/workspace-service-port-registry.ts packages/server/src/server/workspace-service-port-registry.test.ts packages/server/src/server/worktree-bootstrap.test.ts
- npm run typecheck --workspace=@getpaseo/server
- pre-commit: format, lint, full workspace typecheck