### PR TITLE
Fix Tab indentation in composer input

### DIFF
--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -58,6 +58,7 @@ import { getShortcutOs } from "@/utils/shortcut-platform";
 import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
 import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
 import { isWeb } from "@/constants/platform";
+import { insertComposerTabIndent } from "./tab-indent";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useComposerHeightMirror } from "./height-mirror";
 import { computeCanStartDictation } from "./state";
@@ -161,8 +162,10 @@ interface TextAreaHandle {
   clientHeight?: number;
   offsetHeight?: number;
   scrollTop?: number;
+  value?: string;
   selectionStart?: number | null;
   selectionEnd?: number | null;
+  setSelectionRange?: (selectionStart: number, selectionEnd: number) => void;
   style?: {
     height?: string;
     overflowY?: string;
@@ -653,6 +656,100 @@ function usePasteImagesEffect(args: PasteImagesEffectArgs): void {
     isRealtimeVoiceForCurrentAgent,
     onAddImages,
   ]);
+}
+
+interface WebTabIndentEffectArgs {
+  getWebTextArea: () => TextAreaHandle | null;
+  valueRef: React.MutableRefObject<string>;
+  onChangeText: (nextValue: string) => void;
+  onKeyPressCallback: ((event: { key: string; preventDefault: () => void }) => boolean) | undefined;
+  disabled: boolean;
+  isDictating: boolean;
+  isRealtimeVoiceForCurrentAgent: boolean;
+}
+
+function useWebTabIndentEffect(args: WebTabIndentEffectArgs): void {
+  const {
+    getWebTextArea,
+    valueRef,
+    onChangeText,
+    onKeyPressCallback,
+    disabled,
+    isDictating,
+    isRealtimeVoiceForCurrentAgent,
+  } = args;
+
+  useEffect(() => {
+    if (!isWeb) return;
+
+    const textarea = getWebTextArea() as
+      | (TextAreaHandle & {
+          addEventListener?: (type: string, listener: (event: KeyboardEvent) => void) => void;
+          removeEventListener?: (type: string, listener: (event: KeyboardEvent) => void) => void;
+        })
+      | null;
+    if (
+      !textarea ||
+      typeof textarea.addEventListener !== "function" ||
+      typeof textarea.removeEventListener !== "function"
+    ) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isPlainTabKey(event)) return;
+      if (disabled || isDictating || isRealtimeVoiceForCurrentAgent) return;
+
+      if (onKeyPressCallback) {
+        const handled = onKeyPressCallback({
+          key: event.key,
+          preventDefault: () => event.preventDefault(),
+        });
+        if (handled) return;
+      }
+
+      event.preventDefault();
+      const next = insertComposerTabIndent({
+        value: valueRef.current,
+        selectionStart: textarea.selectionStart,
+        selectionEnd: textarea.selectionEnd,
+      });
+      valueRef.current = next.value;
+      textarea.value = next.value;
+      onChangeText(next.value);
+      restoreTextAreaSelection(textarea, next.selectionStart, next.selectionEnd);
+    };
+
+    textarea.addEventListener("keydown", handleKeyDown);
+    return () => {
+      textarea.removeEventListener?.("keydown", handleKeyDown);
+    };
+  }, [
+    disabled,
+    getWebTextArea,
+    isDictating,
+    isRealtimeVoiceForCurrentAgent,
+    onChangeText,
+    onKeyPressCallback,
+    valueRef,
+  ]);
+}
+
+function isPlainTabKey(event: KeyboardEvent): boolean {
+  return (
+    event.key === "Tab" && !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey
+  );
+}
+
+function restoreTextAreaSelection(
+  textarea: TextAreaHandle,
+  selectionStart: number,
+  selectionEnd: number,
+): void {
+  textarea.setSelectionRange?.(selectionStart, selectionEnd);
+  requestAnimationFrame(() => {
+    textarea.setSelectionRange?.(selectionStart, selectionEnd);
+  });
 }
 
 function useAutoFocusOnWebEffect(
@@ -1767,6 +1864,16 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       },
       [onChangeText],
     );
+
+    useWebTabIndentEffect({
+      getWebTextArea,
+      valueRef,
+      onChangeText: handleInputChange,
+      onKeyPressCallback,
+      disabled,
+      isDictating,
+      isRealtimeVoiceForCurrentAgent,
+    });
 
     const handleInputFocus = useCallback(() => {
       isInputFocusedRef.current = true;

--- a/packages/app/src/composer/input/tab-indent.test.ts
+++ b/packages/app/src/composer/input/tab-indent.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { insertComposerTabIndent } from "./tab-indent";
+
+describe("insertComposerTabIndent", () => {
+  it("inserts a tab at the cursor and moves selection after it", () => {
+    expect(
+      insertComposerTabIndent({
+        value: "foo\nbar",
+        selectionStart: 4,
+        selectionEnd: 4,
+      }),
+    ).toEqual({
+      value: "foo\n\tbar",
+      selectionStart: 5,
+      selectionEnd: 5,
+    });
+  });
+});

--- a/packages/app/src/composer/input/tab-indent.ts
+++ b/packages/app/src/composer/input/tab-indent.ts
@@ -1,0 +1,31 @@
+export interface ComposerTabIndentInput {
+  value: string;
+  selectionStart: number | null | undefined;
+  selectionEnd: number | null | undefined;
+}
+
+export interface ComposerTabIndentResult {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+export function insertComposerTabIndent(input: ComposerTabIndentInput): ComposerTabIndentResult {
+  const start = clampSelectionIndex(input.selectionStart, input.value.length);
+  const end = clampSelectionIndex(input.selectionEnd, input.value.length);
+  const selectionStart = Math.min(start, end);
+  const selectionEnd = Math.max(start, end);
+  const cursor = selectionStart + 1;
+  return {
+    value: `${input.value.slice(0, selectionStart)}\t${input.value.slice(selectionEnd)}`,
+    selectionStart: cursor,
+    selectionEnd: cursor,
+  };
+}
+
+function clampSelectionIndex(index: number | null | undefined, valueLength: number): number {
+  if (typeof index !== "number") {
+    return valueLength;
+  }
+  return Math.max(0, Math.min(index, valueLength));
+}


### PR DESCRIPTION
## Summary
- Handle plain Tab on the web composer textarea with a keydown listener so browser focus navigation is prevented.
- Insert a tab at the current textarea selection and restore the cursor after the inserted tab.
- Let command autocomplete consume Tab first when suggestions are visible.

Closes #1347

## Test plan
- node ../../node_modules/vitest/vitest.mjs run src/composer/input/tab-indent.test.ts --config vitest.config.ts --bail=1
- npm run lint -- packages/app/src/composer/input/input.tsx packages/app/src/composer/input/tab-indent.ts packages/app/src/composer/input/tab-indent.test.ts
- npm run typecheck --workspace=@getpaseo/app
- pre-commit: format, lint, full workspace typecheck