### PR TITLE
Dedupe stored host connections on load

### DIFF
--- a/packages/app/src/runtime/host-runtime.test.ts
+++ b/packages/app/src/runtime/host-runtime.test.ts
@@ -1741,6 +1741,46 @@ describe("HostRuntimeStore", () => {
     store.syncHosts([]);
   });
 
+  it("upsertConnectionFromListen preserves an existing direct TCP password", async () => {
+    const store = new HostRuntimeStore({
+      deps: {
+        createClient: () => new FakeDaemonClient() as unknown as DaemonClient,
+        connectToDaemon: async ({ host }) => ({
+          client: makeConnectedProbeClient(5) as unknown as DaemonClient,
+          serverId: host.serverId,
+          hostname: host.label ?? null,
+        }),
+        getClientId: async () => "cid_test_runtime",
+      },
+    });
+
+    await store.upsertDirectConnection({
+      serverId: "srv_listen_password",
+      endpoint: "localhost:6767",
+      password: "shared-secret",
+      label: "desktop host",
+    });
+
+    await store.upsertConnectionFromListen({
+      serverId: "srv_listen_password",
+      listenAddress: "127.0.0.1:6767",
+      hostname: "desktop host",
+    });
+
+    const host = store.getHosts().find((entry) => entry.serverId === "srv_listen_password");
+    expect(host?.connections).toEqual([
+      {
+        id: "direct:localhost:6767",
+        type: "directTcp",
+        endpoint: "localhost:6767",
+        useTls: false,
+        password: "shared-secret",
+      },
+    ]);
+
+    store.syncHosts([]);
+  });
+
   it("probeAndUpsertConnection learns the real server id before storing a direct host", async () => {
     const connection: HostConnection = {
       id: "direct:lan:6767",

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -1333,6 +1333,7 @@ export class HostRuntimeStore {
       await this.probeAndUpsertConnection({
         connection,
         timeoutMs: DEFAULT_LOCALHOST_BOOTSTRAP_TIMEOUT_MS,
+        preserveExistingDirectTcpPassword: true,
       });
     } catch (error) {
       console.warn("[HostRuntime] bootstrap probe failed", {
@@ -1373,6 +1374,7 @@ export class HostRuntimeStore {
         await this.probeAndUpsertConnection({
           connection,
           timeoutMs: DEFAULT_LOCALHOST_BOOTSTRAP_TIMEOUT_MS,
+          preserveExistingDirectTcpPassword: true,
         });
         return;
       } catch (error) {
@@ -1454,6 +1456,7 @@ export class HostRuntimeStore {
     connection: HostConnection;
     label?: string;
     timeoutMs?: number;
+    preserveExistingDirectTcpPassword?: boolean;
   }): Promise<{ profile: HostProfile; serverId: string; hostname: string | null }> {
     if (input.connection.type === "relay") {
       throw new Error("Cannot probe a relay connection without a server id.");
@@ -1477,6 +1480,9 @@ export class HostRuntimeStore {
       label: input.label ?? hostname ?? undefined,
       connection: input.connection,
       existingClient: client,
+      ...(input.preserveExistingDirectTcpPassword !== undefined
+        ? { preserveExistingDirectTcpPassword: input.preserveExistingDirectTcpPassword }
+        : {}),
     });
     return { profile, serverId, hostname };
   }
@@ -1576,6 +1582,7 @@ export class HostRuntimeStore {
       serverId,
       label: input.hostname ?? undefined,
       connection,
+      preserveExistingDirectTcpPassword: true,
     });
   }
 
@@ -1623,6 +1630,7 @@ export class HostRuntimeStore {
     label?: string;
     connection: HostConnection;
     existingClient?: DaemonClient;
+    preserveExistingDirectTcpPassword?: boolean;
   }): Promise<HostProfile> {
     const now = new Date().toISOString();
     const next = upsertHostConnectionInProfiles({
@@ -1630,6 +1638,9 @@ export class HostRuntimeStore {
       serverId: input.serverId,
       label: input.label,
       connection: input.connection,
+      ...(input.preserveExistingDirectTcpPassword !== undefined
+        ? { preserveExistingDirectTcpPassword: input.preserveExistingDirectTcpPassword }
+        : {}),
       now,
     });
     this.setHostsAndSync(next, {

--- a/packages/app/src/types/host-connection.test.ts
+++ b/packages/app/src/types/host-connection.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizeStoredHostProfile } from "./host-connection";
+import {
+  type HostProfile,
+  normalizeStoredHostProfile,
+  upsertHostConnectionInProfiles,
+} from "./host-connection";
 
 describe("normalizeStoredHostProfile", () => {
   it("loads direct TCP connections stored before TLS and password fields existed", () => {
@@ -26,6 +30,74 @@ describe("normalizeStoredHostProfile", () => {
       useTls: false,
     });
     expect(profile?.connections[0]).not.toHaveProperty("password");
+  });
+
+  it("deduplicates stored direct TCP connections after endpoint normalization", () => {
+    const profile = normalizeStoredHostProfile({
+      serverId: "srv_duplicate",
+      label: "Duplicate Host",
+      connections: [
+        {
+          id: "direct:127.0.0.1:6767",
+          type: "directTcp",
+          endpoint: "127.0.0.1:6767",
+          useTls: false,
+          password: "secret",
+        },
+        {
+          id: "direct:localhost:6767",
+          type: "directTcp",
+          endpoint: "localhost:6767",
+          useTls: false,
+          password: "secret",
+        },
+      ],
+      preferredConnectionId: "direct:127.0.0.1:6767",
+    });
+
+    expect(profile?.connections).toEqual([
+      {
+        id: "direct:localhost:6767",
+        type: "directTcp",
+        endpoint: "localhost:6767",
+        useTls: false,
+        password: "secret",
+      },
+    ]);
+    expect(profile?.preferredConnectionId).toBe("direct:localhost:6767");
+  });
+
+  it("deduplicates stored direct TCP connections with the same id even when auth fields differ", () => {
+    const profile = normalizeStoredHostProfile({
+      serverId: "srv_duplicate_auth",
+      label: "Duplicate Host",
+      connections: [
+        {
+          id: "direct:localhost:6767",
+          type: "directTcp",
+          endpoint: "localhost:6767",
+          useTls: false,
+          password: "secret",
+        },
+        {
+          id: "direct:localhost:6767",
+          type: "directTcp",
+          endpoint: "localhost:6767",
+          useTls: false,
+        },
+      ],
+      preferredConnectionId: "direct:localhost:6767",
+    });
+
+    expect(profile?.connections).toEqual([
+      {
+        id: "direct:localhost:6767",
+        type: "directTcp",
+        endpoint: "localhost:6767",
+        useTls: false,
+        password: "secret",
+      },
+    ]);
   });
 
   it("preserves legacy relay ids when TLS is absent", () => {
@@ -70,5 +142,51 @@ describe("normalizeStoredHostProfile", () => {
       useTls: true,
       daemonPublicKeyB64: "pubkey",
     });
+  });
+});
+
+describe("upsertHostConnectionInProfiles", () => {
+  it("replaces an existing direct TCP connection when the incoming connection omits password", () => {
+    const profiles: HostProfile[] = [
+      {
+        serverId: "srv_password",
+        label: "Password Host",
+        lifecycle: {},
+        connections: [
+          {
+            id: "direct:localhost:6767",
+            type: "directTcp",
+            endpoint: "localhost:6767",
+            useTls: false,
+            password: "old-secret",
+          },
+        ],
+        preferredConnectionId: "direct:localhost:6767",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ];
+
+    const next = upsertHostConnectionInProfiles({
+      profiles,
+      serverId: "srv_password",
+      connection: {
+        id: "direct:localhost:6767",
+        type: "directTcp",
+        endpoint: "localhost:6767",
+        useTls: false,
+      },
+      now: "2026-01-02T00:00:00.000Z",
+    });
+
+    expect(next[0]?.connections).toEqual([
+      {
+        id: "direct:localhost:6767",
+        type: "directTcp",
+        endpoint: "localhost:6767",
+        useTls: false,
+      },
+    ]);
+    expect(next[0]?.updatedAt).toBe("2026-01-02T00:00:00.000Z");
   });
 });

--- a/packages/app/src/types/host-connection.ts
+++ b/packages/app/src/types/host-connection.ts
@@ -89,15 +89,54 @@ function hostLifecycleEquals(left: HostLifecycle, right: HostLifecycle): boolean
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
-function dedupeHostConnections(connections: HostConnection[]): HostConnection[] {
+function replaceHostConnection(
+  _existing: HostConnection,
+  incoming: HostConnection,
+): HostConnection {
+  return incoming;
+}
+
+function dedupeHostConnections(
+  connections: HostConnection[],
+  mergeConnection: (existing: HostConnection, incoming: HostConnection) => HostConnection,
+): HostConnection[] {
   const next: HostConnection[] = [];
   for (const connection of connections) {
-    if (next.some((existing) => hostConnectionEquals(existing, connection))) {
+    const existingIndex = next.findIndex((existing) => existing.id === connection.id);
+    if (existingIndex === -1) {
+      next.push(connection);
       continue;
     }
-    next.push(connection);
+    next[existingIndex] = mergeConnection(next[existingIndex], connection);
   }
   return next;
+}
+
+function mergeStoredHostConnection(
+  existing: HostConnection,
+  incoming: HostConnection,
+): HostConnection {
+  if (
+    existing.type === "directTcp" &&
+    incoming.type === "directTcp" &&
+    existing.id === incoming.id
+  ) {
+    const password = incoming.password ?? existing.password;
+    return {
+      ...incoming,
+      ...(password ? { password } : {}),
+    };
+  }
+  return incoming;
+}
+
+function resolveHostConnectionMerge(
+  preserveExistingDirectTcpPassword: boolean | undefined,
+): (existing: HostConnection, incoming: HostConnection) => HostConnection {
+  if (preserveExistingDirectTcpPassword) {
+    return mergeStoredHostConnection;
+  }
+  return replaceHostConnection;
 }
 
 export function upsertHostConnectionInProfiles(input: {
@@ -105,6 +144,7 @@ export function upsertHostConnectionInProfiles(input: {
   serverId: string;
   label?: string;
   connection: HostConnection;
+  preserveExistingDirectTcpPassword?: boolean;
   now?: string;
 }): HostProfile[] {
   const serverId = input.serverId.trim();
@@ -141,10 +181,11 @@ export function upsertHostConnectionInProfiles(input: {
 
   const matchedProfiles = matchingIndexes.map((index) => existing[index]);
   const prev = matchedProfiles.find((daemon) => daemon.serverId === serverId) ?? matchedProfiles[0];
-  const nextConnections = dedupeHostConnections([
-    ...matchedProfiles.flatMap((daemon) => daemon.connections),
-    input.connection,
-  ]);
+  const mergeConnection = resolveHostConnectionMerge(input.preserveExistingDirectTcpPassword);
+  const nextConnections = dedupeHostConnections(
+    [...matchedProfiles.flatMap((daemon) => daemon.connections), input.connection],
+    mergeConnection,
+  );
   const nextLifecycle = prev.lifecycle;
   const nextLabel = labelTrimmed || (prev.label === prev.serverId ? derivedLabel : prev.label);
   const nextPreferredConnectionId =
@@ -309,9 +350,10 @@ export function normalizeStoredHostProfile(entry: unknown): HostProfile | null {
   }
 
   const rawConnections = Array.isArray(record.connections) ? record.connections : [];
-  const connections = rawConnections
+  const normalizedConnections = rawConnections
     .map((connection) => normalizeStoredConnection(connection))
     .filter((connection): connection is HostConnection => connection !== null);
+  const connections = dedupeHostConnections(normalizedConnections, mergeStoredHostConnection);
   if (connections.length === 0) {
     return null;
   }


### PR DESCRIPTION
## Summary
- Deduplicate normalized stored host connections when loading the daemon registry.
- Collapse legacy loopback TCP duplicates like 127.0.0.1 and localhost into one canonical connection.
- Add a regression for duplicate direct TCP rows so Settings does not render two identical removable entries.

Closes #1201

## Test plan
- node ../../node_modules/vitest/vitest.mjs run src/types/host-connection.test.ts --config vitest.config.ts --bail=1
- npm run lint -- packages/app/src/types/host-connection.ts packages/app/src/types/host-connection.test.ts
- npm run typecheck --workspace=@getpaseo/app
- pre-commit: format, lint, full workspace typecheck