### PR TITLE
Restore global agent listing

### DIFF
--- a/packages/cli/src/commands/agent/ls.test.ts
+++ b/packages/cli/src/commands/agent/ls.test.ts
@@ -23,10 +23,38 @@ describe("buildAgentLsFetchOptions", () => {
     });
   });
 
-  it("uses the unscoped archived query for -a", () => {
+  it("fetches global non-archived agents for -g", () => {
+    expect(buildAgentLsFetchOptions({ global: true })).toEqual({});
+  });
+
+  it("keeps -a within the active scope", () => {
     expect(buildAgentLsFetchOptions({ all: true })).toEqual({
+      scope: "active",
       filter: {
         includeArchived: true,
+      },
+    });
+  });
+
+  it("fetches all global agents for -a -g", () => {
+    expect(buildAgentLsFetchOptions({ all: true, global: true })).toEqual({
+      filter: {
+        includeArchived: true,
+      },
+    });
+  });
+
+  it("applies filters to global queries", () => {
+    expect(
+      buildAgentLsFetchOptions({
+        global: true,
+        label: ["surface=workspace"],
+        thinking: " medium ",
+      }),
+    ).toEqual({
+      filter: {
+        labels: { surface: "workspace" },
+        thinkingOptionId: "medium",
       },
     });
   });

--- a/packages/cli/src/commands/agent/ls.ts
+++ b/packages/cli/src/commands/agent/ls.ts
@@ -13,7 +13,7 @@ export function addLsOptions(cmd: Command): Command {
   return cmd
     .description("List agents. By default excludes archived agents.")
     .option("-a, --all", "Include archived agents")
-    .option("-g, --global", "Legacy no-op (kept for compatibility)")
+    .option("-g, --global", "List agents across all directories")
     .option(
       "--label <key=value>",
       "Filter by label (can be used multiple times)",
@@ -107,7 +107,7 @@ export type AgentLsResult = ListResult<AgentListItem>;
 export interface AgentLsOptions extends CommandOptions {
   /** -a: Include archived agents */
   all?: boolean;
-  /** Legacy flag retained for CLI compatibility */
+  /** -g: List agents across all directories */
   global?: boolean;
   /** Filter by specific status */
   status?: string;
@@ -133,7 +133,7 @@ function parseLabelFilters(labels: string[] | undefined): Record<string, string>
 }
 
 export function buildAgentLsFetchOptions(
-  options: Pick<AgentLsOptions, "all" | "label" | "thinking">,
+  options: Pick<AgentLsOptions, "all" | "global" | "label" | "thinking">,
 ): FetchAgentsOptions {
   const labelFilters = parseLabelFilters(options.label);
   const normalizedThinkingOptionId = options.thinking?.trim();
@@ -150,7 +150,7 @@ export function buildAgentLsFetchOptions(
   }
 
   const fetchOptions: FetchAgentsOptions = {};
-  if (!options.all) {
+  if (!options.global) {
     fetchOptions.scope = "active";
   }
   if (Object.keys(daemonFilter).length > 0) {
@@ -162,7 +162,9 @@ export function buildAgentLsFetchOptions(
 /**
  * Agent ls command semantics:
  * - `paseo agent ls`    → active non-archived agents
- * - `paseo agent ls -a` → include archived agents
+ * - `paseo agent ls -g` → global non-archived agents
+ * - `paseo agent ls -a` → active agents, including archived
+ * - `paseo agent ls -ag` → global agents, including archived
  */
 export async function runLsCommand(
   options: AgentLsOptions,

--- a/packages/cli/tests/04-agent-ls.test.ts
+++ b/packages/cli/tests/04-agent-ls.test.ts
@@ -50,6 +50,8 @@ try {
     assert(result.stdout.includes("--all"), "help should mention --all flag");
     assert(result.stdout.includes("-g"), "help should mention -g flag");
     assert(result.stdout.includes("--global"), "help should mention --global flag");
+    assert(result.stdout.includes("across all directories"), "help should describe global scope");
+    assert(!result.stdout.includes("Legacy no-op"), "help should not describe -g as a no-op");
     assert(result.stdout.includes("--host"), "help should mention --host option");
     assert(!result.stdout.includes("--ui"), "help should not mention --ui");
     console.log("✓ paseo ls --help shows options\n");


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Restores `paseo ls -g` / `paseo agent ls -g` as the global listing switch.

Default `ls` remains active-scoped. `-a` now only means include archived agents, and `-a -g` means include archived agents globally.

### How did you verify it

- `npx vitest run packages/cli/src/commands/agent/ls.test.ts --bail=1`
- `npm run build --workspace=@getpaseo/cli`
- `npx tsx packages/cli/tests/04-agent-ls.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense