### PR TITLE
fix(server): show Other input for Claude questions

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -848,7 +848,6 @@ describe("normalizeClaudeAskUserQuestionUpdatedInput", () => {
                 { label: "Codex", description: "Use Codex" },
               ],
               multiSelect: false,
-              allowOther: true,
             },
           ],
           answers: { "Which provider should I use?": "Use both" },

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -9,6 +9,7 @@ import * as executableUtils from "../../../../utils/executable.js";
 import {
   ClaudeAgentClient,
   convertClaudeHistoryEntry,
+  normalizeClaudeAskUserQuestionRequestInput,
   normalizeClaudeAskUserQuestionUpdatedInput,
   toClaudeSdkMcpConfig,
 } from "./agent.js";
@@ -614,6 +615,37 @@ describe("ClaudeAgentSession features", () => {
 });
 
 describe("normalizeClaudeAskUserQuestionUpdatedInput", () => {
+  test("marks Claude AskUserQuestion options as allowing other answers", () => {
+    expect(
+      normalizeClaudeAskUserQuestionRequestInput("AskUserQuestion", {
+        questions: [
+          {
+            question: "Which provider should I use?",
+            header: "Provider",
+            options: [
+              { label: "Claude", description: "Use Claude Code" },
+              { label: "Codex", description: "Use Codex" },
+            ],
+            multiSelect: false,
+          },
+        ],
+      }),
+    ).toEqual({
+      questions: [
+        {
+          question: "Which provider should I use?",
+          header: "Provider",
+          options: [
+            { label: "Claude", description: "Use Claude Code" },
+            { label: "Codex", description: "Use Codex" },
+          ],
+          multiSelect: false,
+          allowOther: true,
+        },
+      ],
+    });
+  });
+
   test("maps frontend header-keyed answers to Claude question text keys", () => {
     expect(
       normalizeClaudeAskUserQuestionUpdatedInput(
@@ -739,6 +771,87 @@ describe("normalizeClaudeAskUserQuestionUpdatedInput", () => {
             },
           ],
           answers: { "Which provider should I use?": "Claude" },
+        },
+        updatedPermissions: undefined,
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("respondToPermission maps other answer text back to Claude question keys", async () => {
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    const session = await client.createSession({
+      provider: "claude",
+      cwd: process.cwd(),
+    });
+
+    const request = {
+      id: "permission-question-2",
+      provider: "claude",
+      name: "AskUserQuestion",
+      kind: "question",
+      input: normalizeClaudeAskUserQuestionRequestInput("AskUserQuestion", {
+        questions: [
+          {
+            question: "Which provider should I use?",
+            header: "Provider",
+            options: [
+              { label: "Claude", description: "Use Claude Code" },
+              { label: "Codex", description: "Use Codex" },
+            ],
+            multiSelect: false,
+          },
+        ],
+      }),
+    };
+
+    const resultPromise = new Promise<unknown>((resolve, reject) => {
+      (
+        session as unknown as {
+          pendingPermissions: Map<
+            string,
+            {
+              request: typeof request;
+              resolve: (value: unknown) => void;
+              reject: (error: Error) => void;
+            }
+          >;
+        }
+      ).pendingPermissions.set(request.id, {
+        request,
+        resolve,
+        reject,
+      });
+    });
+
+    try {
+      await session.respondToPermission(request.id, {
+        behavior: "allow",
+        updatedInput: {
+          answers: { Provider: "Use both" },
+        },
+      });
+
+      await expect(resultPromise).resolves.toEqual({
+        behavior: "allow",
+        updatedInput: {
+          questions: [
+            {
+              question: "Which provider should I use?",
+              header: "Provider",
+              options: [
+                { label: "Claude", description: "Use Claude Code" },
+                { label: "Codex", description: "Use Codex" },
+              ],
+              multiSelect: false,
+              allowOther: true,
+            },
+          ],
+          answers: { "Which provider should I use?": "Use both" },
         },
         updatedPermissions: undefined,
       });

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -129,6 +129,24 @@ export function normalizeClaudeAskUserQuestionRequestInput(
   };
 }
 
+function stripClaudeAskUserQuestionUiMetadata(input: AgentMetadata): AgentMetadata {
+  if (!Array.isArray(input.questions)) {
+    return input;
+  }
+
+  return {
+    ...input,
+    questions: input.questions.map((item) => {
+      if (!isMetadata(item) || !("allowOther" in item)) {
+        return item;
+      }
+      const itemForClaude: AgentMetadata = { ...item };
+      delete itemForClaude.allowOther;
+      return itemForClaude;
+    }),
+  };
+}
+
 export function normalizeClaudeAskUserQuestionUpdatedInput(
   updatedInput: AgentMetadata | undefined,
   fallbackInput: AgentMetadata | undefined,
@@ -139,7 +157,7 @@ export function normalizeClaudeAskUserQuestionUpdatedInput(
   // AskUserQuestion tool expects answer keys to match the full question text. Merge
   // the original request payload back in so provider callbacks that only return
   // `{ answers }` still satisfy Claude's full tool input schema.
-  const merged = { ...fallback, ...base };
+  const merged = stripClaudeAskUserQuestionUiMetadata({ ...fallback, ...base });
   const questions =
     (Array.isArray(base.questions) ? base.questions : null) ??
     (Array.isArray(fallback.questions) ? fallback.questions : null);

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -104,6 +104,31 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
+export function normalizeClaudeAskUserQuestionRequestInput(
+  toolName: string,
+  input: AgentMetadata,
+): AgentMetadata {
+  if (toolName !== "AskUserQuestion" || !Array.isArray(input.questions)) {
+    return input;
+  }
+
+  // Claude Code's AskUserQuestion schema says "Other" is host-provided, not a
+  // model-supplied option. Paseo's shared question UI uses allowOther for that
+  // freeform answer path.
+  return {
+    ...input,
+    questions: input.questions.map((item) => {
+      if (!isMetadata(item)) {
+        return item;
+      }
+      return {
+        ...item,
+        allowOther: true,
+      };
+    }),
+  };
+}
+
 export function normalizeClaudeAskUserQuestionUpdatedInput(
   updatedInput: AgentMetadata | undefined,
   fallbackInput: AgentMetadata | undefined,
@@ -3760,6 +3785,7 @@ class ClaudeAgentSession implements AgentSession {
   ): Promise<PermissionResult> => {
     const requestId = `permission-${randomUUID()}`;
     const kind = resolvePermissionKind(toolName, input);
+    const requestInput = normalizeClaudeAskUserQuestionRequestInput(toolName, input);
     const metadata: AgentMetadata = {};
     if (options.toolUseID) {
       metadata.toolUseId = options.toolUseID;
@@ -3782,7 +3808,7 @@ class ClaudeAgentSession implements AgentSession {
       provider: "claude",
       name: toolName,
       kind,
-      input,
+      input: requestInput,
       detail: toolDetail,
       suggestions: options.suggestions?.map((suggestion) => ({
         ...suggestion,


### PR DESCRIPTION
### Linked issue

Closes #1421

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Claude Code's `AskUserQuestion` tool supports a host-provided "Other" free-text answer path. The SDK schema says the model should not include an `"Other"` option itself because the host provides that UI affordance.

Paseo already has shared question UI support for this through `allowOther`, but the Claude provider forwarded `AskUserQuestion` metadata unchanged. As a result, Claude questions with predefined options rendered only those options in Paseo, with no way to type a custom answer.

This PR maps Claude `AskUserQuestion` question metadata to `allowOther: true` before creating the permission request. It does not add `"Other"` to Claude's `options` array. When the user chooses the free-text path, the existing response normalization maps the answer back to Claude's expected question-text keys.

Scope is one provider file plus focused tests.

### How did you verify it

Confirmed the intended Claude behavior from the installed Claude SDK types:

- `@anthropic-ai/claude-agent-sdk@0.2.133`
- `@anthropic-ai/claude-code@2.1.154`

Both document `AskUserQuestionInput.options` as model-provided choices where `"Other"` should not be included because the host provides it automatically.

Checks run in the repo devcontainer with Node 22:

- `npm run build:server` — passes
- `npx vitest run packages/server/src/server/agent/providers/claude/agent.test.ts --bail=1` — passes
- `npm run lint -- packages/server/src/server/agent/providers/claude/agent.ts packages/server/src/server/agent/providers/claude/agent.test.ts` — passes
- `npm run typecheck` — passes
- `npm run format:check:files -- packages/server/src/server/agent/providers/claude/agent.ts packages/server/src/server/agent/providers/claude/agent.test.ts` — passes

Automated coverage added:

- Claude `AskUserQuestion` request metadata is marked with `allowOther: true`.
- Free-text "Other" answers are mapped back to Claude's expected question-text keys.

Platforms tested: provider/server behavior was verified in the Linux devcontainer. I did not attach UI screenshots because this change only enables the already-existing shared question UI free-text path; no client UI code changed.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
