### PR TITLE
fix: handle fragmented DeepSeek thinking stream with interleaved reasoning + text

### DIFF
--- a/packages/app/src/types/stream-event.test.ts
+++ b/packages/app/src/types/stream-event.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentStreamEventPayload } from "@getpaseo/protocol/messages";
-import type { ThoughtItem } from "@/types/stream";
+import type { AssistantMessageItem, ThoughtItem } from "@/types/stream";
 import { applyStreamEvent } from "@/types/stream";
 
 const baseTimestamp = new Date(0);
@@ -181,6 +181,64 @@ describe("applyStreamEvent", () => {
     expect(result.head[0].kind).toBe("thought");
     expect((result.head[0] as ThoughtItem).status).toBe("ready");
     expect(result.head[1].kind).toBe("assistant_message");
+  });
+
+  it("accumulates interleaved reasoning and assistant chunks across multiple cycles (DeepSeek)", () => {
+    // R → A → R → A → turn_completed
+    let result = applyStreamEvent({
+      tail: [],
+      head: [],
+      event: reasoningChunk("Thinking phase one. "),
+      timestamp: baseTimestamp,
+    });
+    result = applyStreamEvent({
+      tail: result.tail,
+      head: result.head,
+      event: assistantChunk("Answer part one. "),
+      timestamp: baseTimestamp,
+    });
+    // Head now contains [thought, assistant_message]
+    expect(result.head).toHaveLength(2);
+
+    result = applyStreamEvent({
+      tail: result.tail,
+      head: result.head,
+      event: reasoningChunk("Thinking phase two."),
+      timestamp: baseTimestamp,
+    });
+    // Should append to existing thought via backward scan past assistant_message
+    expect(result.head).toHaveLength(2);
+    expect(result.head[0].kind).toBe("thought");
+    expect((result.head[0] as ThoughtItem).text).toBe("Thinking phase one. Thinking phase two.");
+    expect((result.head[0] as ThoughtItem).status).toBe("loading");
+
+    result = applyStreamEvent({
+      tail: result.tail,
+      head: result.head,
+      event: assistantChunk("Answer part two."),
+      timestamp: baseTimestamp,
+    });
+    // Should append to existing assistant_message via backward scan past thought
+    expect(result.head).toHaveLength(2);
+    expect(result.head[0].kind).toBe("thought");
+    expect((result.head[0] as ThoughtItem).status).toBe("ready");
+    expect(result.head[1].kind).toBe("assistant_message");
+    expect((result.head[1] as AssistantMessageItem).text).toBe(
+      "Answer part one. Answer part two.",
+    );
+
+    // Turn completion flushes head to tail
+    result = applyStreamEvent({
+      tail: result.tail,
+      head: result.head,
+      event: completionEvent(),
+      timestamp: baseTimestamp,
+    });
+    expect(result.head).toHaveLength(0);
+    expect(result.tail).toHaveLength(2);
+    expect(result.tail[0].kind).toBe("thought");
+    expect((result.tail[0] as ThoughtItem).status).toBe("ready");
+    expect(result.tail[1].kind).toBe("assistant_message");
   });
 
   it("keeps references stable for no-op events", () => {

--- a/packages/app/src/types/stream-event.test.ts
+++ b/packages/app/src/types/stream-event.test.ts
@@ -162,7 +162,7 @@ describe("applyStreamEvent", () => {
     }
   });
 
-  it("flushes reasoning when assistant message starts", () => {
+  it("keeps reasoning and assistant interleaved in head for interleaving providers (DeepSeek)", () => {
     let result = applyStreamEvent({
       tail: [],
       head: [],
@@ -176,11 +176,11 @@ describe("applyStreamEvent", () => {
       timestamp: baseTimestamp,
     });
 
-    expect(result.tail).toHaveLength(1);
-    expect(result.tail[0].kind).toBe("thought");
-    expect((result.tail[0] as ThoughtItem).status).toBe("ready");
-    expect(result.head).toHaveLength(1);
-    expect(result.head[0].kind).toBe("assistant_message");
+    expect(result.tail).toHaveLength(0);
+    expect(result.head).toHaveLength(2);
+    expect(result.head[0].kind).toBe("thought");
+    expect((result.head[0] as ThoughtItem).status).toBe("ready");
+    expect(result.head[1].kind).toBe("assistant_message");
   });
 
   it("keeps references stable for no-op events", () => {

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -320,12 +320,13 @@ function tryAppendToLastAssistantPastThoughts(
   timestamp: Date,
   messageId?: string,
 ): StreamItem[] | null {
-  if (messageId !== undefined) {
-    return null;
-  }
   for (let i = state.length - 1; i >= 0; i--) {
     const candidate = state[i];
-    if (candidate && candidate.kind === "assistant_message") {
+    if (
+      candidate &&
+      candidate.kind === "assistant_message" &&
+      (messageId === undefined || candidate.messageId === messageId)
+    ) {
       const updated: AssistantMessageItem = {
         ...candidate,
         text: `${candidate.text}${chunk}`,

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -314,6 +314,32 @@ export function clearOptimisticUserMessages(state: StreamItem[]): StreamItem[] {
   return next.length === state.length ? state : next;
 }
 
+function tryAppendToLastAssistantPastThoughts(
+  state: StreamItem[],
+  chunk: string,
+  timestamp: Date,
+  messageId?: string,
+): StreamItem[] | null {
+  if (messageId !== undefined) {
+    return null;
+  }
+  for (let i = state.length - 1; i >= 0; i--) {
+    const candidate = state[i];
+    if (candidate && candidate.kind === "assistant_message") {
+      const updated: AssistantMessageItem = {
+        ...candidate,
+        text: `${candidate.text}${chunk}`,
+        timestamp,
+      };
+      return [...state.slice(0, i), updated, ...state.slice(i + 1)];
+    }
+    if (candidate && candidate.kind !== "thought") {
+      break;
+    }
+  }
+  return null;
+}
+
 function appendAssistantMessage(
   state: StreamItem[],
   text: string,
@@ -357,6 +383,16 @@ function appendAssistantMessage(
     return [...state.slice(0, -2), updated, last];
   }
 
+  const appendedToExisting = tryAppendToLastAssistantPastThoughts(
+    state,
+    chunk,
+    timestamp,
+    messageId,
+  );
+  if (appendedToExisting) {
+    return appendedToExisting;
+  }
+
   if (!hasContent) {
     return state;
   }
@@ -388,6 +424,25 @@ function appendThought(state: StreamItem[], text: string, timestamp: Date): Stre
       status: "loading",
     };
     return [...state.slice(0, -1), updated];
+  }
+
+  // Look backward past interleaved assistant_message items for the
+  // last thought (DeepSeek interleaves reasoning + text at fine
+  // granularity during thinking mode).
+  for (let i = state.length - 1; i >= 0; i--) {
+    const candidate = state[i];
+    if (candidate && candidate.kind === "thought") {
+      const updated: ThoughtItem = {
+        ...candidate,
+        text: `${candidate.text}${chunk}`,
+        timestamp,
+        status: "loading",
+      };
+      return [...state.slice(0, i), updated, ...state.slice(i + 1)];
+    }
+    if (candidate && candidate.kind !== "assistant_message") {
+      break;
+    }
   }
 
   if (!hasContent) {
@@ -1067,8 +1122,15 @@ function shouldFlushHead(head: StreamItem[], incomingKind: StreamItem["kind"] | 
   }
 
   // If incoming kind is different from current head's streamable kind, flush
+  // EXCEPT: allow thought and assistant_message to coexist (DeepSeek interleaves
+  // reasoning and text at fine granularity during thinking mode)
   if (lastStreamable.kind !== incomingKind) {
-    return true;
+    const bothAreThinkingOrText =
+      (lastStreamable.kind === "thought" || lastStreamable.kind === "assistant_message") &&
+      (incomingKind === "thought" || incomingKind === "assistant_message");
+    if (!bothAreThinkingOrText) {
+      return true;
+    }
   }
 
   return false;


### PR DESCRIPTION
### Linked issue

Closes #1445

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

**This PR fixes fragmented DeepSeek thinking output, so that interleaved reasoning and text chunks render as contiguous blocks instead of many small fragments.**

- DeepSeek interleaves `reasoning` and `assistant_message` at fine granularity during high-thinking mode. The stream renderer assumed reasoning completes before text begins, causing each kind-switch to flush head to tail — splitting output into many small blocks.
- Three changes in `stream.ts` fix this: `shouldFlushHead` exempts `thought`↔`assistant_message` transitions from flushing; `appendThought` scans backward past interleaved `assistant_message` items to find and extend the last thought; `tryAppendToLastAssistantPastThoughts` symmetrically scans backward past interleaved `thought` items to find the last assistant message, with messageId-aware matching so future providers that interleave AND supply messageId are handled correctly.
- The existing test was updated to expect the new single-head-buffer behavior. A new multi-cycle test (R→A→R→A→turn_completed) exercises both backward-scan paths.

### How did you verify it

- ✅ All 48 stream tests pass — the updated test validates a single R→A cycle; the new multi-cycle test exercises both backward-scan paths through R→A→R→A→turn_completed.
- ✅ `npm run typecheck` passes (full workspace check).
- ✅ Tested with DeepSeek on high thinking during a long agentic session — reasoning and text now render as one contiguous thought block followed by one contiguous response, instead of many small fragments.
- ⚠️ Exact repro is non-deterministic (manifests naturally during extended agentic runs). The unit tests simulate the interleaving pattern directly.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

### What to look at first

- The backward-scan loops in `tryAppendToLastAssistantPastThoughts` and `appendThought` are the core mechanism. The break conditions halt scanning at the first item that is not the "other" interleaving kind — verify this boundary is correct.
- The messageId match condition `(messageId === undefined || candidate.messageId === messageId)` mirrors the pattern used by the existing `shouldAppendToLast` logic, so the backward scan is consistent with the direct-append path.

### Files of interest

- `packages/app/src/types/stream.ts` — the three-part fix: backward-scan helpers and relaxed `shouldFlushHead`
- `packages/app/src/types/stream-event.test.ts` — updated single-cycle test + new multi-cycle test covering backward scans