### PR TITLE
Add Claude Fable 5 to the model catalog

### DIFF
--- a/packages/cli/tests/15-provider.test.ts
+++ b/packages/cli/tests/15-provider.test.ts
@@ -46,6 +46,11 @@ interface ProviderListRow {
 
 const EXPECTED_CLAUDE_MODELS = [
   {
+    id: "claude-fable-5",
+    model: "Fable 5",
+    descriptionFragment: "Most powerful",
+  },
+  {
     id: "claude-opus-4-8[1m]",
     model: "Opus 4.8 1M",
     descriptionFragment: "1M context window",

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -408,6 +408,7 @@ describe("ClaudeAgentClient.listModels", () => {
       const models = await client.listModels({ cwd: "/tmp/claude-models", force: false });
 
       expect(models.map((m) => m.id)).toEqual([
+        "claude-fable-5",
         "claude-opus-4-8[1m]",
         "claude-opus-4-8",
         "claude-opus-4-7[1m]",

--- a/packages/server/src/server/agent/providers/claude/models.test.ts
+++ b/packages/server/src/server/agent/providers/claude/models.test.ts
@@ -35,6 +35,7 @@ describe("getClaudeModels", () => {
   it("returns all claude models", () => {
     const models = getClaudeModels();
     expect(models.map((m) => m.id)).toEqual([
+      "claude-fable-5",
       "claude-opus-4-8[1m]",
       "claude-opus-4-8",
       "claude-opus-4-7[1m]",
@@ -179,6 +180,7 @@ describe("ClaudeAgentClient.listModels", () => {
 
 describe("normalizeClaudeRuntimeModelId", () => {
   it("returns exact match for known model IDs", () => {
+    expect(normalizeClaudeRuntimeModelId("claude-fable-5")).toBe("claude-fable-5");
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6")).toBe("claude-opus-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6[1m]")).toBe("claude-opus-4-6[1m]");
     expect(normalizeClaudeRuntimeModelId("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
@@ -186,6 +188,7 @@ describe("normalizeClaudeRuntimeModelId", () => {
   });
 
   it("normalizes dated model IDs to base model", () => {
+    expect(normalizeClaudeRuntimeModelId("claude-fable-5-20260301")).toBe("claude-fable-5");
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6-20260101")).toBe("claude-opus-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-sonnet-4-6-20260101")).toBe("claude-sonnet-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-haiku-4-5-20251001")).toBe("claude-haiku-4-5");

--- a/packages/server/src/server/agent/providers/claude/models.ts
+++ b/packages/server/src/server/agent/providers/claude/models.ts
@@ -215,11 +215,11 @@ export function normalizeClaudeRuntimeModelId(value: string | null | undefined):
 
   // Fable uses a single-segment version (claude-fable-5), not the {major}-{minor}
   // scheme of opus/sonnet/haiku, so match it separately. This maps dated runtime
-  // strings (e.g. claude-fable-5-20260301) back to the catalog ID.
-  const fableMatch = trimmed.match(/(?:claude-)?fable[-_ ]+(\d+)(\[1m\])?/i);
+  // strings (e.g. claude-fable-5-20260301) back to the catalog ID. No [1m] variant:
+  // Fable 5 is natively 1M, so there is no 200K-default model to opt into 1M.
+  const fableMatch = trimmed.match(/(?:claude-)?fable[-_ ]+(\d+)/i);
   if (fableMatch) {
-    const suffix = fableMatch[2] ?? "";
-    return `claude-fable-${fableMatch[1]}${suffix}`;
+    return `claude-fable-${fableMatch[1]}`;
   }
 
   // Match: claude-{family}-{major}-{minor}[1m]? possibly followed by a date suffix

--- a/packages/server/src/server/agent/providers/claude/models.ts
+++ b/packages/server/src/server/agent/providers/claude/models.ts
@@ -23,6 +23,13 @@ const CLAUDE_OPUS_EXTENDED_THINKING_OPTIONS = [
 const CLAUDE_MODELS: AgentModelDefinition[] = [
   {
     provider: "claude",
+    id: "claude-fable-5",
+    label: "Fable 5",
+    description: "Fable 5 · Most powerful model",
+    thinkingOptions: [...CLAUDE_OPUS_EXTENDED_THINKING_OPTIONS],
+  },
+  {
+    provider: "claude",
     id: "claude-opus-4-8[1m]",
     label: "Opus 4.8 1M",
     description: "Opus 4.8 with 1M context window",
@@ -204,6 +211,15 @@ export function normalizeClaudeRuntimeModelId(value: string | null | undefined):
   // Check for exact match first (handles claude-opus-4-6[1m] directly)
   if (CLAUDE_MODELS.some((model) => model.id === trimmed)) {
     return trimmed;
+  }
+
+  // Fable uses a single-segment version (claude-fable-5), not the {major}-{minor}
+  // scheme of opus/sonnet/haiku, so match it separately. This maps dated runtime
+  // strings (e.g. claude-fable-5-20260301) back to the catalog ID.
+  const fableMatch = trimmed.match(/(?:claude-)?fable[-_ ]+(\d+)(\[1m\])?/i);
+  if (fableMatch) {
+    const suffix = fableMatch[2] ?? "";
+    return `claude-fable-${fableMatch[1]}${suffix}`;
   }
 
   // Match: claude-{family}-{major}-{minor}[1m]? possibly followed by a date suffix


### PR DESCRIPTION
## What

Adds **Claude Fable 5** (`claude-fable-5`) to the Claude provider's model catalog so it shows up in the model selector.

## Why

The Claude model list is hardcoded in `CLAUDE_MODELS` (`packages/server/src/server/agent/providers/claude/models.ts`) and is **not** fetched dynamically from the Anthropic API — it's only supplemented by whatever is in `~/.claude/settings.json`. So any model released after the last edit of that file (Fable 5, the new tier above Opus) never appears unless the user adds it to their settings manually.

## Changes

- **`models.ts`** — add a `claude-fable-5` entry to `CLAUDE_MODELS`.
  - Kept **non-default** on purpose — Opus 4.8 remains `isDefault` (Fable 5 is the pricier top tier; changing the default for everyone is a separate product call).
  - Uses the Opus extended-thinking effort levels (`low`/`medium`/`high`/`xhigh`/`max`).
  - **No `[1m]` variant.** The `[1m]` entries elsewhere opt a 200K-default model into the 1M-context beta; Fable 5 is natively 1M, so a `[1m]` variant would be redundant (and possibly an invalid selector). Happy to add one if Claude Code actually exposes `claude-fable-5[1m]`.
- **`models.ts` → `normalizeClaudeRuntimeModelId`** — teach it the Fable family. Fable's version is a single segment (`fable-5`) rather than the `{major}-{minor}` scheme of opus/sonnet/haiku, so it needs its own match. This maps dated runtime IDs (e.g. `claude-fable-5-20260301`) back to the catalog ID for selector highlighting.
- **Tests** — update the model-list and normalization expectations in `models.test.ts` and `agent.test.ts`, and add Fable 5 to the CLI provider e2e catalog fixture in `15-provider.test.ts`.

Fast Mode is intentionally **not** offered for Fable 5 — its allowlist (`feature-definitions.ts`) is Opus 4.6/4.7/4.8 only, so `claude-fable-5` correctly gets no Fast toggle.

## Testing

Local dev deps weren't installed in my environment, so I couldn't run `typecheck`/`lint`/`vitest` locally — relying on CI for those. The changes are mechanical (one catalog entry, one regex branch, matching list-assertion updates). Please let CI run; happy to fix anything it flags.