### PR TITLE
chore: improve paseo maintenance path

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolveHostnamesOption } from "./cli.js";
+
+describe("resolveHostnamesOption", () => {
+  it("returns hostnames when it is a string", () => {
+    expect(resolveHostnamesOption("example.com", undefined)).toBe("example.com");
+  });
+
+  it("falls back to allowedHosts when hostnames is not a string", () => {
+    expect(resolveHostnamesOption(undefined, "fallback.com")).toBe("fallback.com");
+  });
+
+  it("prefers hostnames over allowedHosts when both are strings", () => {
+    expect(resolveHostnamesOption("primary.com", "fallback.com")).toBe("primary.com");
+  });
+
+  it("returns undefined when neither value is a string", () => {
+    expect(resolveHostnamesOption(undefined, undefined)).toBeUndefined();
+    expect(resolveHostnamesOption(123, true)).toBeUndefined();
+    expect(resolveHostnamesOption({}, [])).toBeUndefined();
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -23,7 +23,7 @@ import { addWaitOptions, runWaitCommand } from "./commands/agent/wait.js";
 import { addArchiveOptions, runArchiveCommand } from "./commands/agent/archive.js";
 import { addAttachOptions, runAttachCommand } from "./commands/agent/attach.js";
 import { addImportOptions, runImportCommand } from "./commands/agent/import.js";
-import { withOutput } from "./output/index.js";
+import { withOutput, type CommandOptions } from "./output/index.js";
 import { onboardCommand } from "./commands/onboard.js";
 import {
   addDaemonHostOption,
@@ -34,7 +34,7 @@ import { resolveCliVersion } from "./version.js";
 
 const VERSION = resolveCliVersion();
 
-function resolveHostnamesOption(hostnames: unknown, allowedHosts: unknown): string | undefined {
+export function resolveHostnamesOption(hostnames: unknown, allowedHosts: unknown): string | undefined {
   if (typeof hostnames === "string") return hostnames;
   if (typeof allowedHosts === "string") return allowedHosts;
   return undefined;
@@ -127,7 +127,7 @@ export function createCli(): Command {
     .addOption(new Option("--allowed-hosts <hosts>").hideHelp())
     .action(
       withOutput((...args) => {
-        const [options, command] = args.slice(-2) as [(typeof args)[number], Command];
+        const [options, command] = args.slice(-2) as [CommandOptions, Command];
         return runDaemonRestartCommand(
           {
             ...options,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ import { configDefaults, defineConfig } from "vitest/config";
 const appDir = path.resolve(__dirname, "packages/app");
 const appNodeModules = path.resolve(appDir, "node_modules");
 const rootNodeModules = path.resolve(__dirname, "node_modules");
-const resolvePackageEntry = (packageName: string) => {
+const resolvePackageEntry = (packageName: string): string => {
   const appPackagePath = path.resolve(appNodeModules, packageName);
   return fs.existsSync(appPackagePath)
     ? appPackagePath


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in vitest.config.ts, packages/cli/src/cli.ts related to TypeScript, frontend tooling, test stability, build fixes; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.