### PR TITLE
Fix Android notification deeplinks to target agent chat

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -201,16 +201,15 @@ function PushNotificationRouter() {
         | Record<string, unknown>
         | undefined;
       openNotification(data);
+      Notifications.clearLastNotificationResponse();
     };
 
     const subscription = Notifications.addNotificationResponseReceivedListener(openFromResponse);
 
-    void Notifications.getLastNotificationResponseAsync().then((response) => {
-      if (response) {
-        openFromResponse(response);
-      }
-      return;
-    });
+    const response = Notifications.getLastNotificationResponse();
+    if (response) {
+      openFromResponse(response);
+    }
 
     return () => {
       subscription.remove();

--- a/packages/app/src/app/h/[serverId]/agent/[agentId].tsx
+++ b/packages/app/src/app/h/[serverId]/agent/[agentId].tsx
@@ -1,12 +1,16 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocalSearchParams, usePathname, useRouter, type Href } from "expo-router";
 import { HostRouteBootstrapBoundary } from "@/components/host-route-bootstrap-boundary";
 import { useSessionStore } from "@/stores/session-store";
 import { useResolveWorkspaceIdByCwd } from "@/stores/session-store-hooks";
-import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+import { useHostRuntimeClient, useHostRuntimeConnectionStatus } from "@/runtime/host-runtime";
 import { buildHostRootRoute } from "@/utils/host-routes";
 import { resolveWorkspaceIdByExecutionDirectory } from "@/utils/workspace-execution";
 import { navigateToPreparedWorkspaceTab } from "@/utils/workspace-navigation";
+import {
+  AGENT_READY_ROUTE_CONNECTION_FALLBACK_TIMEOUT_MS,
+  shouldFallbackHostAgentReadyRoute,
+} from "./agent-ready-route-state";
 
 export default function HostAgentReadyRoute() {
   return (
@@ -24,10 +28,12 @@ function HostAgentReadyRouteContent() {
     agentId?: string;
   }>();
   const redirectedRef = useRef(false);
+  const [connectionFallbackReady, setConnectionFallbackReady] = useState(false);
   const serverId = typeof params.serverId === "string" ? params.serverId : "";
   const agentId = typeof params.agentId === "string" ? params.agentId : "";
   const client = useHostRuntimeClient(serverId);
-  const isConnected = useHostRuntimeIsConnected(serverId);
+  const connectionStatus = useHostRuntimeConnectionStatus(serverId);
+  const isConnected = connectionStatus === "online";
   const agentCwd = useSessionStore((state) => {
     if (!serverId || !agentId) {
       return null;
@@ -38,6 +44,28 @@ function HostAgentReadyRouteContent() {
     serverId ? (state.sessions[serverId]?.hasHydratedWorkspaces ?? false) : false,
   );
   const resolvedWorkspaceId = useResolveWorkspaceIdByCwd(serverId, agentCwd);
+
+  useEffect(() => {
+    setConnectionFallbackReady(false);
+  }, [agentId, serverId]);
+
+  useEffect(() => {
+    if (!serverId || !agentId || redirectedRef.current) {
+      return;
+    }
+    if (client && isConnected) {
+      setConnectionFallbackReady(false);
+      return;
+    }
+
+    setConnectionFallbackReady(false);
+    const handle = setTimeout(() => {
+      setConnectionFallbackReady(true);
+    }, AGENT_READY_ROUTE_CONNECTION_FALLBACK_TIMEOUT_MS);
+    return () => {
+      clearTimeout(handle);
+    };
+  }, [agentId, client, isConnected, serverId]);
 
   useEffect(() => {
     if (redirectedRef.current) {
@@ -67,14 +95,28 @@ function HostAgentReadyRouteContent() {
     if (!serverId || !agentId) {
       return;
     }
-    if (agentCwd?.trim() && !hasHydratedWorkspaces) {
-      return;
-    }
-    if (!client || !isConnected) {
+    if (
+      shouldFallbackHostAgentReadyRoute({
+        agentCwd,
+        hasHydratedWorkspaces,
+        hasClient: Boolean(client),
+        isConnected,
+        connectionFallbackReady,
+      })
+    ) {
       redirectedRef.current = true;
       router.replace(buildHostRootRoute(serverId));
     }
-  }, [agentCwd, agentId, client, hasHydratedWorkspaces, isConnected, router, serverId]);
+  }, [
+    agentCwd,
+    agentId,
+    client,
+    connectionFallbackReady,
+    hasHydratedWorkspaces,
+    isConnected,
+    router,
+    serverId,
+  ]);
 
   useEffect(() => {
     if (redirectedRef.current) {

--- a/packages/app/src/app/h/[serverId]/agent/agent-ready-route-state.test.ts
+++ b/packages/app/src/app/h/[serverId]/agent/agent-ready-route-state.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldFallbackHostAgentReadyRoute } from "./agent-ready-route-state";
+
+describe("shouldFallbackHostAgentReadyRoute", () => {
+  it("waits for the host connection before abandoning an agent deeplink", () => {
+    expect(
+      shouldFallbackHostAgentReadyRoute({
+        agentCwd: null,
+        hasHydratedWorkspaces: false,
+        hasClient: false,
+        isConnected: false,
+        connectionFallbackReady: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back only after the connection grace period is ready", () => {
+    expect(
+      shouldFallbackHostAgentReadyRoute({
+        agentCwd: null,
+        hasHydratedWorkspaces: false,
+        hasClient: false,
+        isConnected: false,
+        connectionFallbackReady: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not fall back while a known agent cwd waits for workspace hydration", () => {
+    expect(
+      shouldFallbackHostAgentReadyRoute({
+        agentCwd: "/repo/project",
+        hasHydratedWorkspaces: false,
+        hasClient: false,
+        isConnected: false,
+        connectionFallbackReady: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not fall back once the host connection is online", () => {
+    expect(
+      shouldFallbackHostAgentReadyRoute({
+        agentCwd: null,
+        hasHydratedWorkspaces: true,
+        hasClient: true,
+        isConnected: true,
+        connectionFallbackReady: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/app/h/[serverId]/agent/agent-ready-route-state.ts
+++ b/packages/app/src/app/h/[serverId]/agent/agent-ready-route-state.ts
@@ -1,0 +1,17 @@
+export const AGENT_READY_ROUTE_CONNECTION_FALLBACK_TIMEOUT_MS = 5_000;
+
+export function shouldFallbackHostAgentReadyRoute(input: {
+  agentCwd: string | null;
+  hasHydratedWorkspaces: boolean;
+  hasClient: boolean;
+  isConnected: boolean;
+  connectionFallbackReady: boolean;
+}): boolean {
+  if (input.agentCwd?.trim() && !input.hasHydratedWorkspaces) {
+    return false;
+  }
+  if (input.hasClient && input.isConnected) {
+    return false;
+  }
+  return input.connectionFallbackReady;
+}


### PR DESCRIPTION
## Summary

Fix Android notification taps so they reliably land in the intended agent chat instead of falling back to the host start page or replaying an older chat target.

- keep `/h/:serverId/agent/:agentId` deeplinks alive while the host connection is still coming online
- clear handled Expo notification responses so stale Android launches do not replay an already-consumed notification target
- add focused unit coverage for the agent-route fallback decision

## Root Cause Analysis

There are two related failure modes in the native notification launch path.

### 1. Cold-start notification taps could be abandoned before the host socket came online

`PushNotificationRouter` reads the notification response and calls `navigateToAgent({ serverId, agentId, ... })`. On a cold Android start, session/workspace state often is not hydrated yet, so `navigateToAgent` falls back to the intermediate route `/h/:serverId/agent/:agentId`.

That route previously treated `!client || !isConnected` as a terminal failure. On its first effect pass it immediately did `router.replace(buildHostRootRoute(serverId))` and set `redirectedRef.current = true`. If Android launched from a notification before the host runtime reached `online`, the original agent-chat intent was discarded and never retried. The visible result was a notification tap landing on the host start page instead of the target chat.

### 2. Handled notification responses could be replayed on later native mounts

The native notification effect read `Notifications.getLastNotificationResponseAsync()` on mount and routed from it, but never cleared the response after handling it. Expo documents `clearLastNotificationResponse()` for the exact case where an app selects a route from a notification response and should not continue selecting that route after it has already been handled:

https://docs.expo.dev/versions/v54.0.0/sdk/notifications/#notificationsclearlastnotificationresponse

On Android, this can present as a later launch replaying an older notification response, sending the user to the wrong previous chat instead of their current/expected position.

## Fix Details

- `HostAgentReadyRoute` now tracks a short connection grace period before falling back to host root.
- The fallback decision is extracted to `shouldFallbackHostAgentReadyRoute()` and covered with focused tests.
- When the route has a known `agentCwd` but workspace hydration is still pending, it continues to wait instead of abandoning the deeplink.
- Once the host is connected, the existing `fetchAgent()` resolution path can run and route to the prepared workspace tab for the target agent.
- The native notification handler now uses Expo's synchronous `getLastNotificationResponse()` API and calls `clearLastNotificationResponse()` immediately after consuming a response.

## Testing

- `npm ci`
- `npm run build:app-deps`
- `npm run test --workspace=@getpaseo/app -- agent-ready-route-state.test.ts`
- `npm run typecheck --workspace=@getpaseo/app`
- `npm run lint -- "packages/app/src/app/_layout.tsx" "packages/app/src/app/h/[serverId]/agent/[agentId].tsx" "packages/app/src/app/h/[serverId]/agent/agent-ready-route-state.ts" "packages/app/src/app/h/[serverId]/agent/agent-ready-route-state.test.ts"`
- `npm run format:check:files -- "packages/app/src/app/_layout.tsx" "packages/app/src/app/h/[serverId]/agent/[agentId].tsx" "packages/app/src/app/h/[serverId]/agent/agent-ready-route-state.ts" "packages/app/src/app/h/[serverId]/agent/agent-ready-route-state.test.ts"`

## Manual Android Repro To Validate

1. Force-stop the Android app.
2. Trigger a push notification for a specific agent while the host connection will take a moment to come online.
3. Tap the notification.
4. Expected: the app waits for host/session resolution and opens the workspace with that exact agent chat focused, rather than landing on host root.
5. After handling a notification, relaunch the app normally from the launcher.
6. Expected: the old notification target is not replayed into a previous chat.
