### PR TITLE
Use terminateWithTreeKill for ACP agent child process cleanup

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -28,6 +28,7 @@ import {
   resolveACPModelSelection,
   summarizeACPRequestError,
 } from "./acp-agent.js";
+import * as treeKillModule from "../../../utils/tree-kill.js";
 import {
   COPILOT_ALLOW_ALL_MODE_ID,
   COPILOT_MODES,
@@ -1865,5 +1866,83 @@ describe("ACPAgentSession", () => {
     await expect(turnFailed).resolves.toMatchObject({
       error: expect.not.stringContaining("[object Object]"),
     });
+  });
+});
+
+interface ACPCloseInternals {
+  child: ChildProcess | null;
+  closed: boolean;
+  connection: unknown;
+  sessionId: string | null;
+  terminalEntries: Map<string, { child: ChildProcess; exit: unknown }>;
+  subscribers: Map<unknown, unknown>;
+  activeForegroundTurnId: string | null;
+}
+
+describe("ACPAgentSession close() tree-kill", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("close() uses terminateWithTreeKill for the main child process", async () => {
+    const terminateWithTreeKill = vi
+      .spyOn(treeKillModule, "terminateWithTreeKill")
+      .mockResolvedValue("terminated");
+    const session = createSession();
+    const internals = asInternals<ACPCloseInternals>(session);
+
+    const child = createTerminalChildStub();
+    internals.child = child;
+    internals.connection = null;
+    internals.sessionId = null;
+
+    await session.close();
+
+    expect(terminateWithTreeKill).toHaveBeenCalledWith(child, {
+      gracefulTimeoutMs: 2_000,
+      forceTimeoutMs: 2_000,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  test("close() uses terminateWithTreeKill for terminal child processes", async () => {
+    const terminateWithTreeKill = vi
+      .spyOn(treeKillModule, "terminateWithTreeKill")
+      .mockResolvedValue("terminated");
+    const session = createSession();
+    const internals = asInternals<ACPCloseInternals>(session);
+
+    const terminalChild = createTerminalChildStub();
+    internals.terminalEntries = new Map([["terminal-1", { child: terminalChild, exit: null }]]);
+    internals.child = null;
+    internals.connection = null;
+    internals.sessionId = null;
+
+    await session.close();
+
+    expect(terminateWithTreeKill).toHaveBeenCalledWith(terminalChild, {
+      gracefulTimeoutMs: 2_000,
+      forceTimeoutMs: 2_000,
+    });
+    expect(terminalChild.kill).not.toHaveBeenCalled();
+  });
+
+  test("killTerminal uses terminateWithTreeKill instead of direct SIGTERM", async () => {
+    const terminateWithTreeKill = vi
+      .spyOn(treeKillModule, "terminateWithTreeKill")
+      .mockResolvedValue("terminated");
+    const session = createSession();
+    const internals = asInternals<ACPCloseInternals>(session);
+
+    const child = createTerminalChildStub();
+    internals.terminalEntries = new Map([["terminal-1", { child, exit: null }]]);
+
+    await session.killTerminal({ sessionId: "session-1", terminalId: "terminal-1" });
+
+    expect(terminateWithTreeKill).toHaveBeenCalledWith(child, {
+      gracefulTimeoutMs: 2_000,
+      forceTimeoutMs: 2_000,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess } from "node:child_process";
+import { type ChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
@@ -141,6 +141,35 @@ function createTerminalChildStub(): ChildProcess {
   child.stderr = new EventEmitter() as ChildProcess["stderr"];
   child.kill = vi.fn(() => true) as ChildProcess["kill"];
   return child;
+}
+
+function createProbeChildStub(order: string[]): ChildProcessWithoutNullStreams {
+  const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+  child.stdin = {
+    destroy: vi.fn(() => {
+      order.push("stdin.destroy");
+    }),
+  } as ChildProcessWithoutNullStreams["stdin"];
+  child.stdout = {
+    destroy: vi.fn(() => {
+      order.push("stdout.destroy");
+    }),
+  } as ChildProcessWithoutNullStreams["stdout"];
+  child.stderr = {
+    destroy: vi.fn(() => {
+      order.push("stderr.destroy");
+    }),
+  } as ChildProcessWithoutNullStreams["stderr"];
+  child.kill = vi.fn(() => true) as ChildProcessWithoutNullStreams["kill"];
+  return child;
+}
+
+function createDeferredTermination(): { promise: Promise<"terminated">; resolve: () => void } {
+  let resolveTermination: () => void = () => {};
+  const promise = new Promise<"terminated">((resolve) => {
+    resolveTermination = () => resolve("terminated");
+  });
+  return { promise, resolve: resolveTermination };
 }
 
 function selectConfigOption(
@@ -1927,6 +1956,39 @@ describe("ACPAgentSession close() tree-kill", () => {
     expect(terminalChild.kill).not.toHaveBeenCalled();
   });
 
+  test("close() terminates terminal child processes in parallel", async () => {
+    const resolvers: Array<() => void> = [];
+    const terminateWithTreeKill = vi
+      .spyOn(treeKillModule, "terminateWithTreeKill")
+      .mockImplementation(() => {
+        const termination = createDeferredTermination();
+        resolvers.push(termination.resolve);
+        return termination.promise;
+      });
+    const session = createSession();
+    const internals = asInternals<ACPCloseInternals>(session);
+
+    const firstTerminalChild = createTerminalChildStub();
+    const secondTerminalChild = createTerminalChildStub();
+    internals.terminalEntries = new Map([
+      ["terminal-1", { child: firstTerminalChild, exit: null }],
+      ["terminal-2", { child: secondTerminalChild, exit: null }],
+    ]);
+    internals.child = null;
+    internals.connection = null;
+    internals.sessionId = null;
+
+    const close = session.close();
+    await Promise.resolve();
+
+    expect(terminateWithTreeKill).toHaveBeenCalledTimes(2);
+
+    for (const resolve of resolvers) {
+      resolve();
+    }
+    await close;
+  });
+
   test("killTerminal uses terminateWithTreeKill instead of direct SIGTERM", async () => {
     const terminateWithTreeKill = vi
       .spyOn(treeKillModule, "terminateWithTreeKill")
@@ -1944,5 +2006,47 @@ describe("ACPAgentSession close() tree-kill", () => {
       forceTimeoutMs: 2_000,
     });
     expect(child.kill).not.toHaveBeenCalled();
+  });
+});
+
+describe("ACPAgentClient probe cleanup", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("signals the probe process tree before destroying stdio", async () => {
+    const order: string[] = [];
+    const terminateWithTreeKill = vi
+      .spyOn(treeKillModule, "terminateWithTreeKill")
+      .mockImplementation(async () => {
+        order.push("tree-kill");
+        return "terminated";
+      });
+
+    class TestACPAgentClient extends ACPAgentClient {
+      async closeSpawnedProbe(probe: SpawnedACPProcess): Promise<void> {
+        await this.closeProbe(probe);
+      }
+    }
+
+    const client = new TestACPAgentClient({
+      provider: "claude-acp",
+      logger: createTestLogger(),
+      defaultCommand: ["claude", "--acp"],
+      defaultModes: [],
+    });
+    const child = createProbeChildStub(order);
+
+    await client.closeSpawnedProbe({
+      child,
+      connection: {},
+      initialize: { agentCapabilities: {} },
+    } as SpawnedACPProcess);
+
+    expect(terminateWithTreeKill).toHaveBeenCalledWith(child, {
+      gracefulTimeoutMs: 2_000,
+      forceTimeoutMs: 2_000,
+    });
+    expect(order).toEqual(["tree-kill", "stdin.destroy", "stdout.destroy", "stderr.destroy"]);
   });
 });

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2007,6 +2007,35 @@ describe("ACPAgentSession close() tree-kill", () => {
     });
     expect(child.kill).not.toHaveBeenCalled();
   });
+
+  test("releaseTerminal uses terminateWithTreeKill before removing a running terminal", async () => {
+    const terminateWithTreeKill = vi
+      .spyOn(treeKillModule, "terminateWithTreeKill")
+      .mockResolvedValue("terminated");
+    const child = createTerminalChildStub();
+    vi.spyOn(spawnUtils, "spawnProcess").mockReturnValue(child);
+    const session = createSession();
+
+    const terminal = await session.createTerminal({
+      sessionId: "session-1",
+      command: "sleep",
+      args: ["60"],
+    });
+
+    await session.releaseTerminal({
+      sessionId: "session-1",
+      terminalId: terminal.terminalId,
+    });
+
+    expect(terminateWithTreeKill).toHaveBeenCalledWith(child, {
+      gracefulTimeoutMs: 2_000,
+      forceTimeoutMs: 2_000,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
+    await expect(
+      session.terminalOutput({ sessionId: "session-1", terminalId: terminal.terminalId }),
+    ).rejects.toThrow(`Unknown terminal '${terminal.terminalId}'`);
+  });
 });
 
 describe("ACPAgentClient probe cleanup", () => {
@@ -2022,10 +2051,21 @@ describe("ACPAgentClient probe cleanup", () => {
         order.push("tree-kill");
         return "terminated";
       });
+    const child = createProbeChildStub(order);
 
     class TestACPAgentClient extends ACPAgentClient {
-      async closeSpawnedProbe(probe: SpawnedACPProcess): Promise<void> {
-        await this.closeProbe(probe);
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child,
+          connection: {
+            newSession: vi.fn().mockResolvedValue({
+              modes: null,
+              models: null,
+              configOptions: [],
+            }),
+          },
+          initialize: { agentCapabilities: {} },
+        } as SpawnedACPProcess;
       }
     }
 
@@ -2035,13 +2075,8 @@ describe("ACPAgentClient probe cleanup", () => {
       defaultCommand: ["claude", "--acp"],
       defaultModes: [],
     });
-    const child = createProbeChildStub(order);
 
-    await client.closeSpawnedProbe({
-      child,
-      connection: {},
-      initialize: { agentCapabilities: {} },
-    } as SpawnedACPProcess);
+    await client.listModels({ cwd: "/tmp/acp-models", force: false });
 
     expect(terminateWithTreeKill).toHaveBeenCalledWith(child, {
       gracefulTimeoutMs: 2_000,

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -3,6 +3,8 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
+
+import { terminateWithTreeKill } from "../../../utils/tree-kill.js";
 import type {
   ReadableStream as NodeReadableStream,
   WritableStream as NodeWritableStream,
@@ -1655,13 +1657,15 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
 
     for (const terminal of this.terminalEntries.values()) {
-      terminal.child.kill("SIGTERM");
+      await terminateWithTreeKill(terminal.child, {
+        gracefulTimeoutMs: 2_000,
+        forceTimeoutMs: 2_000,
+      });
     }
     this.terminalEntries.clear();
 
     if (this.child) {
-      this.child.kill("SIGTERM");
-      await waitForChildExit(this.child, 2_000);
+      await terminateWithTreeKill(this.child, { gracefulTimeoutMs: 2_000, forceTimeoutMs: 2_000 });
     }
 
     this.subscribers.clear();
@@ -1843,7 +1847,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   async releaseTerminal(params: { sessionId: string; terminalId: string }): Promise<void> {
     const entry = this.getTerminalEntry(params.terminalId);
     if (!entry.exit) {
-      entry.child.kill("SIGTERM");
+      await terminateWithTreeKill(entry.child, { gracefulTimeoutMs: 2_000, forceTimeoutMs: 2_000 });
     }
     this.terminalEntries.delete(params.terminalId);
   }
@@ -1851,7 +1855,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   async killTerminal(params: KillTerminalRequest): Promise<Record<string, never>> {
     const entry = this.getTerminalEntry(params.terminalId);
     if (!entry.exit) {
-      entry.child.kill("SIGTERM");
+      await terminateWithTreeKill(entry.child, { gracefulTimeoutMs: 2_000, forceTimeoutMs: 2_000 });
     }
     return {};
   }
@@ -2874,29 +2878,12 @@ function coerceSessionConfigMetadata(
   return metadata as Partial<AgentSessionConfig>;
 }
 
-async function waitForChildExit(
-  child: ChildProcessWithoutNullStreams,
-  timeoutMs: number,
-): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return;
-  }
-  await Promise.race([
-    new Promise<void>((resolve) => child.once("exit", () => resolve())),
-    new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
-  ]);
-  if (child.exitCode === null && child.signalCode === null) {
-    child.kill("SIGKILL");
-  }
-}
-
 async function terminateChildProcess(
   child: ChildProcessWithoutNullStreams,
   timeoutMs: number,
 ): Promise<void> {
-  child.kill("SIGTERM");
   child.stdin.destroy();
   child.stdout.destroy();
   child.stderr.destroy();
-  await waitForChildExit(child, timeoutMs);
+  await terminateWithTreeKill(child, { gracefulTimeoutMs: timeoutMs, forceTimeoutMs: timeoutMs });
 }

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1656,12 +1656,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       }
     }
 
-    for (const terminal of this.terminalEntries.values()) {
-      await terminateWithTreeKill(terminal.child, {
+    const terminalTerminations = Array.from(this.terminalEntries.values(), (terminal) =>
+      terminateWithTreeKill(terminal.child, {
         gracefulTimeoutMs: 2_000,
         forceTimeoutMs: 2_000,
-      });
-    }
+      }),
+    );
+    await Promise.all(terminalTerminations);
     this.terminalEntries.clear();
 
     if (this.child) {
@@ -2882,8 +2883,11 @@ async function terminateChildProcess(
   child: ChildProcessWithoutNullStreams,
   timeoutMs: number,
 ): Promise<void> {
-  child.stdin.destroy();
-  child.stdout.destroy();
-  child.stderr.destroy();
-  await terminateWithTreeKill(child, { gracefulTimeoutMs: timeoutMs, forceTimeoutMs: timeoutMs });
+  try {
+    await terminateWithTreeKill(child, { gracefulTimeoutMs: timeoutMs, forceTimeoutMs: timeoutMs });
+  } finally {
+    child.stdin.destroy();
+    child.stdout.destroy();
+    child.stderr.destroy();
+  }
 }


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
-->

### Linked issue

Closes #1459

<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

<!-- A short description of the change in your own words. What was wrong, what you changed, why it works. If you can't explain this briefly, the PR is probably too big. -->

ACPAgentSession.close() used child.kill("SIGTERM"), which only signals the direct child process (for example, npx). When an ACP provider like qoder spawns a process tree (npx -> sh -c -> node qodercli), grandchild processes can survive as orphans. Over 3 days with scheduled agents, 24 orphan qodercli processes accumulated consuming ~8GB RAM.

The fix replaces direct child.kill("SIGTERM") cleanup in the ACP agent lifecycle with terminateWithTreeKill(), which recursively walks /proc on Linux and uses taskkill /T on Windows to terminate the whole process tree. This aligns ACP with OpenCode, Pi, and Codex providers that already use terminateWithTreeKill().

Affected code paths: close(), killTerminal(), releaseTerminal(), terminateChildProcess(). The PR also removes the now-unused waitForChildExit(), terminates multiple terminal children in parallel during close(), and ensures probe cleanup signals the process tree before destroying stdio so descendants are not missed if the direct child exits on stdin EOF.

### How did you verify it

<!--
This is the section I read most carefully. I need to see that *you* tested this, not that the diff looks plausible.

- For UI changes: a screenshot or short video on every affected platform (mobile, web, desktop). UI claims without visual proof are not enough.
- For behavior changes: the actual steps you ran, and what you observed.
- For bug fixes: how you reproduced the bug before, and confirmed it's fixed after.

AI-generated PR descriptions are fine in principle. AI-generated *verification claims* with no actual testing behind them are not, and they're easy to spot.
-->

1. Observed the bug in production: ran 3 scheduled qoder agents per day for 3 days. ps aux | grep qodercli showed 24 orphan processes after paseo agent ls returned empty.
2. Integration tests with real process trees (Linux, non-Windows):
  - Spawned a parent -> grandchild tree where grandchild traps SIGTERM
  - Verified child.kill("SIGTERM") kills only the parent, grandchild stays alive (bug reproduced)
  - Verified terminateWithTreeKill() kills both parent and grandchild (fix confirmed)
3. Unit tests now cover close(), killTerminal(), terminal close parallelism, and probe cleanup ordering around stdio destruction.
4. Local checks run after the review fixes:
  - npm run format
  - npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1 — 50/50 passed
  - npm run lint
  - npm run typecheck

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
