### PR TITLE
feat: multi-repo projects — add a parent folder containing multiple git repos as one project

### DIFF
--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -1274,6 +1274,11 @@ function ProjectHeaderRow({
           <Text style={styles.projectTitle} numberOfLines={1}>
             {displayName}
           </Text>
+          {project.projectKind === "multi_git" && project.subRepos.length > 0 ? (
+            <Text style={styles.projectSubtitle} numberOfLines={1}>
+              {project.subRepos.map((r) => r.split("/").pop() ?? r).join(" · ")}
+            </Text>
+          ) : null}
         </View>
       </View>
       <ProjectRowTrailingActions
@@ -2815,9 +2820,10 @@ const styles = StyleSheet.create((theme) => ({
     minWidth: 0,
   },
   projectTitleGroup: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[1],
+    flexDirection: "column",
+    alignItems: "flex-start",
+    justifyContent: "center",
+    gap: theme.spacing[0],
     flex: 1,
     minWidth: 0,
   },
@@ -2848,6 +2854,12 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foreground,
     fontSize: theme.fontSize.sm,
     fontWeight: "400",
+    minWidth: 0,
+    flexShrink: 1,
+  },
+  projectSubtitle: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
     minWidth: 0,
     flexShrink: 1,
   },

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -1246,6 +1246,16 @@ function ProjectHeaderRow({
   const handlePointerEnter = useCallback(() => setIsHovered(true), []);
   const handlePointerLeave = useCallback(() => setIsHovered(false), []);
 
+  const isMultiGit = project.projectKind === "multi_git" && project.subRepos.length > 0;
+
+  const projectTitleGroupStyle = useMemo(
+    () =>
+      isMultiGit
+        ? [styles.projectTitleGroup, styles.projectTitleGroupColumn]
+        : styles.projectTitleGroup,
+    [isMultiGit],
+  );
+
   const projectRowStyle = useCallback(
     ({ pressed }: PressableStateCallbackType) => [
       styles.projectRow,
@@ -1270,11 +1280,11 @@ function ProjectHeaderRow({
           isArchiving={isArchiving}
         />
 
-        <View style={styles.projectTitleGroup}>
+        <View style={projectTitleGroupStyle}>
           <Text style={styles.projectTitle} numberOfLines={1}>
             {displayName}
           </Text>
-          {project.projectKind === "multi_git" && project.subRepos.length > 0 ? (
+          {isMultiGit ? (
             <Text style={styles.projectSubtitle} numberOfLines={1}>
               {project.subRepos.map((r) => r.split("/").pop() ?? r).join(" · ")}
             </Text>
@@ -2820,12 +2830,18 @@ const styles = StyleSheet.create((theme) => ({
     minWidth: 0,
   },
   projectTitleGroup: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: theme.spacing[1],
+    flex: 1,
+    minWidth: 0,
+  },
+  projectTitleGroupColumn: {
     flexDirection: "column",
     alignItems: "flex-start",
     justifyContent: "center",
     gap: theme.spacing[0],
-    flex: 1,
-    minWidth: 0,
   },
   projectIcon: {
     width: "100%",

--- a/packages/app/src/components/workspace-setup-dialog.tsx
+++ b/packages/app/src/components/workspace-setup-dialog.tsx
@@ -170,6 +170,7 @@ function MultiGitConfirmationStep({
       <View style={styles.multiGitActions}>
         <Pressable
           accessibilityRole="button"
+          accessibilityLabel="Continue setup"
           onPress={onConfirm}
           style={styles.multiGitContinueButton}
           testID="multi-git-confirm-continue"
@@ -178,6 +179,7 @@ function MultiGitConfirmationStep({
         </Pressable>
         <Pressable
           accessibilityRole="button"
+          accessibilityLabel="Cancel"
           onPress={onCancel}
           style={styles.multiGitCancelButton}
           testID="multi-git-confirm-cancel"
@@ -262,7 +264,10 @@ export function WorkspaceSetupDialog() {
     void (async () => {
       const payload = await client.openProject(sourceDirectory);
       if (cancelled) return;
-      if (!payload.workspace || payload.error) return;
+      if (!payload.workspace || payload.error) {
+        setErrorMessage(payload.error ?? "Failed to probe project");
+        return;
+      }
       const normalized = normalizeWorkspaceDescriptor(payload.workspace);
       if (normalized.projectKind !== "multi_git") return;
       const subRepos = payload.workspace.project?.subRepos ?? [];

--- a/packages/app/src/components/workspace-setup-dialog.tsx
+++ b/packages/app/src/components/workspace-setup-dialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Image, Text, View } from "react-native";
+import { Image, Pressable, Text, View } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { createNameId } from "mnemonic-id";
 import { AdaptiveModalSheet, type SheetHeader } from "@/components/adaptive-modal-sheet";
@@ -139,6 +139,56 @@ function buildCreateAgentOptions({
   };
 }
 
+function MultiGitConfirmationStep({
+  subRepos,
+  onConfirm,
+  onCancel,
+}: {
+  subRepos: string[];
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <View style={styles.multiGitConfirmation}>
+      <Text style={styles.multiGitHeading}>
+        Found {subRepos.length} git repo{subRepos.length === 1 ? "" : "s"} inside this folder:
+      </Text>
+      <View style={styles.multiGitRepoList}>
+        {subRepos.map((repoPath) => {
+          const repoName = repoPath.split(/[\\/]/).findLast(Boolean) ?? repoPath;
+          return (
+            <Text key={repoPath} style={styles.multiGitRepoItem}>
+              {"•"} {repoName}
+            </Text>
+          );
+        })}
+      </View>
+      <Text style={styles.multiGitDescription}>
+        This will be added as a multi-repo project. Creating a workspace will set up worktrees for
+        all repos, and your setup script will run from a shared workspace directory.
+      </Text>
+      <View style={styles.multiGitActions}>
+        <Pressable
+          accessibilityRole="button"
+          onPress={onConfirm}
+          style={styles.multiGitContinueButton}
+          testID="multi-git-confirm-continue"
+        >
+          <Text style={styles.multiGitContinueButtonText}>Continue</Text>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          onPress={onCancel}
+          style={styles.multiGitCancelButton}
+          testID="multi-git-confirm-cancel"
+        >
+          <Text style={styles.multiGitCancelButtonText}>Cancel</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
 export function WorkspaceSetupDialog() {
   const toast = useToast();
   const pendingWorkspaceSetup = useWorkspaceSetupStore((state) => state.pendingWorkspaceSetup);
@@ -151,6 +201,10 @@ export function WorkspaceSetupDialog() {
     typeof normalizeWorkspaceDescriptor
   > | null>(null);
   const [pendingAction, setPendingAction] = useState<"chat" | null>(null);
+  const [multiGitConfirmation, setMultiGitConfirmation] = useState<{
+    subRepos: string[];
+  } | null>(null);
+  const [multiGitConfirmed, setMultiGitConfirmed] = useState(false);
 
   const serverId = pendingWorkspaceSetup?.serverId ?? "";
   const sourceDirectory = pendingWorkspaceSetup?.sourceDirectory ?? "";
@@ -183,9 +237,61 @@ export function WorkspaceSetupDialog() {
     setErrorMessage(null);
     setCreatedWorkspace(null);
     setPendingAction(null);
+    setMultiGitConfirmation(null);
+    setMultiGitConfirmed(false);
   }, [pendingWorkspaceSetup?.creationMethod, serverId, sourceDirectory]);
 
   const handleClose = useCallback(() => {
+    clearWorkspaceSetup();
+  }, [clearWorkspaceSetup]);
+
+  // For open_project flows, probe the project kind before showing the composer.
+  // If the project is multi_git, we show a confirmation step first.
+  useEffect(() => {
+    if (
+      !pendingWorkspaceSetup ||
+      pendingWorkspaceSetup.creationMethod !== "open_project" ||
+      !client ||
+      !isConnected ||
+      multiGitConfirmed
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      const payload = await client.openProject(sourceDirectory);
+      if (cancelled) return;
+      if (!payload.workspace || payload.error) return;
+      const normalized = normalizeWorkspaceDescriptor(payload.workspace);
+      if (normalized.projectKind !== "multi_git") return;
+      const subRepos = payload.workspace.project?.subRepos ?? [];
+      setMultiGitConfirmation({ subRepos });
+      // Cache the already-created workspace so ensureWorkspace reuses it.
+      mergeWorkspaces(pendingWorkspaceSetup.serverId, [normalized]);
+      setHasHydratedWorkspaces(pendingWorkspaceSetup.serverId, true);
+      setCreatedWorkspace(normalized);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    client,
+    isConnected,
+    mergeWorkspaces,
+    multiGitConfirmed,
+    pendingWorkspaceSetup,
+    setHasHydratedWorkspaces,
+    sourceDirectory,
+  ]);
+
+  const handleMultiGitConfirm = useCallback(() => {
+    setMultiGitConfirmation(null);
+    setMultiGitConfirmed(true);
+  }, []);
+
+  const handleMultiGitCancel = useCallback(() => {
     clearWorkspaceSetup();
   }, [clearWorkspaceSetup]);
 
@@ -410,28 +516,36 @@ export function WorkspaceSetupDialog() {
       desktopMaxWidth={640}
       onFilesDropped={handleFilesDropped}
     >
-      <View style={styles.section}>
-        <Composer
-          agentId={`workspace-setup:${serverId}:${sourceDirectory}`}
-          serverId={serverId}
-          isPaneFocused={true}
-          onSubmitMessage={handleCreateChatAgent}
-          isSubmitLoading={pendingAction === "chat"}
-          blurOnSubmit={true}
-          value={chatDraft.text}
-          onChangeText={chatDraft.setText}
-          attachments={chatDraft.attachments}
-          onChangeAttachments={chatDraft.setAttachments}
-          cwd={sourceDirectory}
-          clearDraft={chatDraft.clear}
-          autoFocus
-          commandDraftConfig={composerState?.commandDraftConfig}
-          agentControls={agentControlsWithDisabled}
-          inputWrapperStyle={styles.composerInputWrapper}
-          onAddImages={handleAddImagesCallback}
-          footer={composerFooter}
+      {multiGitConfirmation ? (
+        <MultiGitConfirmationStep
+          subRepos={multiGitConfirmation.subRepos}
+          onConfirm={handleMultiGitConfirm}
+          onCancel={handleMultiGitCancel}
         />
-      </View>
+      ) : (
+        <View style={styles.section}>
+          <Composer
+            agentId={`workspace-setup:${serverId}:${sourceDirectory}`}
+            serverId={serverId}
+            isPaneFocused={true}
+            onSubmitMessage={handleCreateChatAgent}
+            isSubmitLoading={pendingAction === "chat"}
+            blurOnSubmit={true}
+            value={chatDraft.text}
+            onChangeText={chatDraft.setText}
+            attachments={chatDraft.attachments}
+            onChangeAttachments={chatDraft.setAttachments}
+            cwd={sourceDirectory}
+            clearDraft={chatDraft.clear}
+            autoFocus
+            commandDraftConfig={composerState?.commandDraftConfig}
+            agentControls={agentControlsWithDisabled}
+            inputWrapperStyle={styles.composerInputWrapper}
+            onAddImages={handleAddImagesCallback}
+            footer={composerFooter}
+          />
+        </View>
+      )}
 
       {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
     </AdaptiveModalSheet>
@@ -478,5 +592,61 @@ const styles = StyleSheet.create((theme) => ({
   },
   composerInputWrapper: {
     backgroundColor: theme.colors.surface2,
+  },
+  multiGitConfirmation: {
+    gap: theme.spacing[4],
+    paddingVertical: theme.spacing[2],
+  },
+  multiGitHeading: {
+    fontSize: theme.fontSize.base,
+    fontWeight: "600",
+    color: theme.colors.foreground,
+    lineHeight: 22,
+  },
+  multiGitRepoList: {
+    gap: theme.spacing[1],
+  },
+  multiGitRepoItem: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foreground,
+    lineHeight: 20,
+  },
+  multiGitDescription: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foregroundMuted,
+    lineHeight: 20,
+  },
+  multiGitActions: {
+    flexDirection: "row",
+    gap: theme.spacing[3],
+    marginTop: theme.spacing[2],
+  },
+  multiGitContinueButton: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: theme.spacing[3],
+    borderRadius: theme.borderRadius.md,
+    backgroundColor: theme.colors.primary,
+  },
+  multiGitContinueButtonText: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: "600",
+    color: theme.colors.primaryForeground,
+  },
+  multiGitCancelButton: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: theme.spacing[3],
+    borderRadius: theme.borderRadius.md,
+    backgroundColor: theme.colors.surface2,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  multiGitCancelButtonText: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: "500",
+    color: theme.colors.foreground,
   },
 }));

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
@@ -30,6 +30,7 @@ function project(input: {
     projectKind: input.projectKind ?? "git",
     iconWorkingDir: input.iconWorkingDir ?? input.projectKey,
     workspaceKeys: input.workspaceKeys,
+    subRepos: [],
   };
 }
 

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -38,6 +38,7 @@ export interface SidebarProjectEntry {
   iconWorkingDir: string;
   canCreateWorktree: boolean;
   workspaces: SidebarWorkspaceEntry[];
+  subRepos: string[];
 }
 
 function createStructuralWorkspaceEntry(input: {
@@ -80,6 +81,7 @@ export function buildSidebarProjectsFromStructure(input: {
       iconWorkingDir: project.iconWorkingDir,
       workspaceKeys: project.workspaceKeys,
       canCreateWorktree: canCreateWorktreeForProjectKind(project.projectKind),
+      subRepos: project.subRepos,
     })),
   });
 }
@@ -97,6 +99,7 @@ export function buildSidebarProjectsFromHostProjects(input: {
     projectKind: project.projectKind,
     iconWorkingDir: project.iconWorkingDir,
     canCreateWorktree: project.canCreateWorktree,
+    subRepos: project.subRepos,
     workspaces: project.workspaceKeys.map((workspaceId) =>
       createStructuralWorkspaceEntry({
         serverId: project.serverId,

--- a/packages/app/src/hooks/use-agent-history.test.ts
+++ b/packages/app/src/hooks/use-agent-history.test.ts
@@ -99,6 +99,8 @@ function historyEntry(input: {
         worktreeRoot: null,
         isPaseoOwnedWorktree: false,
         mainRepoRoot: null,
+        isMultiGit: undefined,
+        subRepos: undefined,
       },
     },
   };

--- a/packages/app/src/projects/host-project-model.ts
+++ b/packages/app/src/projects/host-project-model.ts
@@ -9,6 +9,7 @@ export interface HostProjectListItem {
   iconWorkingDir: string;
   workspaceKeys: string[];
   canCreateWorktree: boolean;
+  subRepos: string[];
 }
 
 export interface HostProjectRouteContext {
@@ -41,6 +42,7 @@ export function buildHostProjectList(input: {
     iconWorkingDir: project.iconWorkingDir,
     workspaceKeys: project.workspaceKeys,
     canCreateWorktree: canCreateWorktreeForProjectKind(project.projectKind),
+    subRepos: project.subRepos,
   }));
 }
 
@@ -58,6 +60,7 @@ export function hostProjectFromRoute(route: HostProjectRouteContext): HostProjec
     iconWorkingDir,
     workspaceKeys: [],
     canCreateWorktree: true,
+    subRepos: [],
   };
 }
 
@@ -81,6 +84,7 @@ export function hostProjectFromWorkspace(input: {
     iconWorkingDir,
     workspaceKeys: [input.workspace.id],
     canCreateWorktree: canCreateWorktreeForProjectKind(input.workspace.projectKind),
+    subRepos: input.workspace.project?.subRepos ?? [],
   };
 }
 

--- a/packages/app/src/projects/host-projects.test.ts
+++ b/packages/app/src/projects/host-projects.test.ts
@@ -18,6 +18,7 @@ function structureProject(input: Partial<WorkspaceStructureProject>): WorkspaceS
     projectKind: input.projectKind ?? "git",
     iconWorkingDir: input.iconWorkingDir ?? "/repo/a",
     workspaceKeys: input.workspaceKeys ?? ["workspace-a"],
+    subRepos: input.subRepos ?? [],
   };
 }
 
@@ -30,6 +31,7 @@ function hostProject(input: Partial<HostProjectListItem>): HostProjectListItem {
     iconWorkingDir: input.iconWorkingDir ?? "/repo/a",
     workspaceKeys: input.workspaceKeys ?? ["workspace-a"],
     canCreateWorktree: input.canCreateWorktree ?? true,
+    subRepos: input.subRepos ?? [],
   };
 }
 

--- a/packages/app/src/projects/workspace-structure.ts
+++ b/packages/app/src/projects/workspace-structure.ts
@@ -7,6 +7,7 @@ export interface WorkspaceStructureProject {
   projectKind: WorkspaceDescriptor["projectKind"];
   iconWorkingDir: string;
   workspaceKeys: string[];
+  subRepos: string[];
 }
 
 export interface WorkspaceStructure {
@@ -68,6 +69,7 @@ export function buildWorkspaceStructureProjects(input: {
         projectKind: workspace.projectKind,
         iconWorkingDir: workspace.projectRootPath,
         workspaceKeys: [],
+        subRepos: workspace.project?.subRepos ?? [],
         workspaces: [],
       } satisfies WorkspaceStructureProject & {
         workspaces: Array<{ workspaceId: string; workspaceName: string; workspaceKey: string }>;

--- a/packages/app/src/runtime/host-runtime.test.ts
+++ b/packages/app/src/runtime/host-runtime.test.ts
@@ -166,6 +166,8 @@ function makeFetchAgentsEntry(input: {
         worktreeRoot: null,
         isPaseoOwnedWorktree: false,
         mainRepoRoot: null,
+        isMultiGit: undefined,
+        subRepos: undefined,
       },
     },
   };

--- a/packages/app/src/screens/project-settings-screen.tsx
+++ b/packages/app/src/screens/project-settings-screen.tsx
@@ -1266,7 +1266,7 @@ function ScriptEditModal({ script, onChange, onCancel, onSave }: ScriptEditModal
 }
 
 function RepoRow({ repoPath, isFirst }: { repoPath: string; isFirst: boolean }) {
-  const parts = repoPath.split("/");
+  const parts = repoPath.split(/[\\/]/).filter(Boolean);
   const folderName = parts[parts.length - 1] || repoPath;
   const rowStyle = isFirst ? settingsStyles.row : styles.repoRowWithBorder;
   return (

--- a/packages/app/src/screens/project-settings-screen.tsx
+++ b/packages/app/src/screens/project-settings-screen.tsx
@@ -3,7 +3,16 @@ import { Pressable, Text, TextInput, View } from "react-native";
 import { router } from "expo-router";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Check, ChevronDown, MoreVertical, Pencil, Plus, X } from "lucide-react-native";
+import {
+  ArrowLeft,
+  Check,
+  ChevronDown,
+  FolderGit2,
+  MoreVertical,
+  Pencil,
+  Plus,
+  X,
+} from "lucide-react-native";
 import { ProjectIconView } from "@/components/project-icon-view";
 import type {
   PaseoConfigRaw,
@@ -271,6 +280,8 @@ function ProjectSettingsBody({
         onReload: handleReload,
         hasMultipleHosts,
         isHostGone,
+        projectKind: selectedHost.projectKind,
+        subRepos: selectedHost.subRepos,
       })}
     </View>
   );
@@ -287,6 +298,8 @@ interface RenderContentInput {
   onReload: () => void;
   hasMultipleHosts: boolean;
   isHostGone: boolean;
+  projectKind: ProjectHostEntry["projectKind"];
+  subRepos: string[];
 }
 
 function renderContent({
@@ -300,6 +313,8 @@ function renderContent({
   onReload,
   hasMultipleHosts,
   isHostGone,
+  projectKind,
+  subRepos,
 }: RenderContentInput) {
   if (readQuery.isLoading) {
     return (
@@ -353,6 +368,8 @@ function renderContent({
       queryKey={queryKey}
       client={client}
       onReload={onReload}
+      projectKind={projectKind}
+      subRepos={subRepos}
     />
   );
 }
@@ -431,6 +448,8 @@ interface ProjectConfigFormProps {
   queryKey: readonly [string, string, string];
   client: DaemonClient;
   onReload: () => void;
+  projectKind: ProjectHostEntry["projectKind"];
+  subRepos: string[];
 }
 
 function ProjectConfigForm({
@@ -440,6 +459,8 @@ function ProjectConfigForm({
   queryKey,
   client,
   onReload,
+  projectKind,
+  subRepos,
 }: ProjectConfigFormProps) {
   const queryClient = useQueryClient();
   const toast = useToast();
@@ -636,6 +657,10 @@ function ProjectConfigForm({
 
   return (
     <View>
+      {projectKind === "multi_git" ? (
+        <RepositoriesGroup repoRoot={repoRoot} subRepos={subRepos} client={client} />
+      ) : null}
+
       <SettingsGroup
         title="Worktree lifecycle hooks"
         info={WORKTREE_GROUP_INFO}
@@ -1240,6 +1265,79 @@ function ScriptEditModal({ script, onChange, onCancel, onSave }: ScriptEditModal
   );
 }
 
+function RepoRow({ repoPath, isFirst }: { repoPath: string; isFirst: boolean }) {
+  const parts = repoPath.split("/");
+  const folderName = parts[parts.length - 1] || repoPath;
+  const rowStyle = isFirst ? settingsStyles.row : styles.repoRowWithBorder;
+  return (
+    <View style={rowStyle}>
+      <FolderGit2 size={ICON_SIZE} color={styles.iconColor.color} style={styles.repoIcon} />
+      <View style={styles.repoRowContent}>
+        <Text style={settingsStyles.rowTitle} numberOfLines={1}>
+          {folderName}
+        </Text>
+        <Text style={settingsStyles.rowHint} numberOfLines={1}>
+          {repoPath}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+interface RepositoriesGroupProps {
+  repoRoot: string;
+  subRepos: string[];
+  client: DaemonClient;
+}
+
+function RepositoriesGroup({ repoRoot, subRepos, client }: RepositoriesGroupProps) {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  const rescanMutation = useMutation({
+    mutationFn: () => client.openProject(repoRoot),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+      toast.show("Repositories refreshed", { variant: "success" });
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : "Re-scan failed";
+      toast.show(message, { variant: "error" });
+    },
+  });
+
+  const handleRescan = useCallback(() => {
+    rescanMutation.mutate();
+  }, [rescanMutation]);
+
+  return (
+    <SettingsGroup title="Repositories" testID="repositories-group">
+      <View style={settingsStyles.card} testID="repositories-list">
+        {subRepos.length === 0 ? (
+          <View style={settingsStyles.row}>
+            <Text style={styles.emptyScripts}>No sub-repositories found.</Text>
+          </View>
+        ) : (
+          subRepos.map((repoPath, index) => (
+            <RepoRow key={repoPath} repoPath={repoPath} isFirst={index === 0} />
+          ))
+        )}
+      </View>
+      <View style={styles.rescanButtonRow}>
+        <Button
+          testID="repositories-rescan-button"
+          variant="secondary"
+          size="sm"
+          loading={rescanMutation.isPending}
+          onPress={handleRescan}
+        >
+          Re-scan repos
+        </Button>
+      </View>
+    </SettingsGroup>
+  );
+}
+
 const styles = StyleSheet.create((theme) => ({
   noTargetContainer: {
     padding: theme.spacing[4],
@@ -1456,5 +1554,27 @@ const styles = StyleSheet.create((theme) => ({
   },
   spinnerColor: {
     color: theme.colors.foregroundMuted,
+  },
+  repoIcon: {
+    marginRight: theme.spacing[3],
+    flexShrink: 0,
+  },
+  repoRowWithBorder: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: theme.spacing[4],
+    paddingHorizontal: theme.spacing[4],
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+  },
+  repoRowContent: {
+    flex: 1,
+    minWidth: 0,
+    gap: theme.spacing[1],
+  },
+  rescanButtonRow: {
+    marginTop: theme.spacing[2],
+    flexDirection: "row",
   },
 }));

--- a/packages/app/src/screens/projects-screen.test.tsx
+++ b/packages/app/src/screens/projects-screen.test.tsx
@@ -213,6 +213,8 @@ function hostEntry(overrides: Partial<ProjectHostEntry> = {}): ProjectHostEntry 
     repoRoot: "/home/me/proj",
     workspaceCount: 1,
     workspaces: [workspaceSummary()],
+    projectKind: "git",
+    subRepos: [],
     ...overrides,
   };
 }

--- a/packages/app/src/utils/agent-directory-sync.test.ts
+++ b/packages/app/src/utils/agent-directory-sync.test.ts
@@ -51,6 +51,8 @@ function createEntry(agent: AgentSnapshotPayload): FetchAgentsEntry {
         worktreeRoot: null,
         isPaseoOwnedWorktree: false,
         mainRepoRoot: null,
+        isMultiGit: undefined,
+        subRepos: undefined,
       },
     },
   };

--- a/packages/app/src/utils/project-placement.ts
+++ b/packages/app/src/utils/project-placement.ts
@@ -21,6 +21,8 @@ export function deriveProjectPlacementFromCwd(cwd: string): ProjectPlacementPayl
       worktreeRoot: null,
       isPaseoOwnedWorktree: false,
       mainRepoRoot: null,
+      isMultiGit: undefined,
+      subRepos: undefined,
     },
   };
 }

--- a/packages/app/src/utils/projects.ts
+++ b/packages/app/src/utils/projects.ts
@@ -17,6 +17,8 @@ export interface ProjectHostEntry {
   repoRoot: string;
   workspaceCount: number;
   workspaces: WorkspaceSummary[];
+  projectKind: WorkspaceDescriptor["projectKind"];
+  subRepos: string[];
   gitRuntime?: WorkspaceDescriptor["gitRuntime"];
   githubRuntime?: WorkspaceDescriptor["githubRuntime"];
 }
@@ -128,6 +130,8 @@ function toHostEntry(group: HostGroup): ProjectHostEntry {
     repoRoot,
     workspaceCount: group.workspaces.length,
     workspaces: group.workspaces.map(toWorkspaceSummary),
+    projectKind: canonical?.projectKind ?? "git",
+    subRepos: canonical?.project?.subRepos ?? [],
     gitRuntime: canonical?.gitRuntime,
     githubRuntime: canonical?.githubRuntime,
   };

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -40,6 +40,7 @@ function project(overrides: Partial<SidebarProjectEntry> = {}): SidebarProjectEn
     iconWorkingDir: "/repo",
     canCreateWorktree: overrides.canCreateWorktree ?? projectKind === "git",
     workspaces: [workspace()],
+    subRepos: [],
     ...overrides,
   };
 }

--- a/packages/app/src/utils/sidebar-shortcuts.test.ts
+++ b/packages/app/src/utils/sidebar-shortcuts.test.ts
@@ -48,6 +48,7 @@ function project(projectKey: string, workspaces: SidebarWorkspaceEntry[]): Sideb
     iconWorkingDir: workspaces[0]?.workspaceDirectory ?? "",
     canCreateWorktree: true,
     workspaces,
+    subRepos: [],
   };
 }
 

--- a/packages/cli/src/commands/agent/ls.ts
+++ b/packages/cli/src/commands/agent/ls.ts
@@ -198,26 +198,28 @@ export async function runLsCommand(
 
     const labelFilters = parseLabelFilters(options.label);
     const fetchPayload = await client.fetchAgents(buildAgentLsFetchOptions(options));
-    let agents = fetchPayload.entries.map((entry) => entry.agent);
+    let agents = fetchPayload.entries.map((entry: { agent: AgentSnapshotPayload }) => entry.agent);
 
     // By default, exclude archived agents. `-a` includes them.
     if (!options.all) {
-      agents = agents.filter((a) => !a.archivedAt);
+      agents = agents.filter((a: AgentSnapshotPayload) => !a.archivedAt);
     }
 
     // If explicit status filter is provided, apply it.
     if (options.status) {
-      agents = agents.filter((a) => a.status === options.status);
+      agents = agents.filter((a: AgentSnapshotPayload) => a.status === options.status);
     }
 
     // Optional cwd filter.
     if (options.cwd) {
-      agents = agents.filter((a) => isSameOrDescendantPath(options.cwd!, a.cwd));
+      agents = agents.filter((a: AgentSnapshotPayload) =>
+        isSameOrDescendantPath(options.cwd!, a.cwd),
+      );
     }
 
     // Apply label filtering only when explicitly requested.
     if (Object.keys(labelFilters).length > 0) {
-      agents = agents.filter((a) => {
+      agents = agents.filter((a: AgentSnapshotPayload) => {
         const agentLabels = a.labels;
         for (const [key, value] of Object.entries(labelFilters)) {
           if (agentLabels[key] !== value) {
@@ -232,7 +234,7 @@ export async function runLsCommand(
 
     // Sort agents: running first, then idle, then others; within each group, most recent first
     const statusOrder = { running: 0, idle: 1 } as Record<string, number>;
-    agents.sort((a, b) => {
+    agents.sort((a: AgentSnapshotPayload, b: AgentSnapshotPayload) => {
       // Primary sort: by status
       const aOrder = statusOrder[a.status] ?? 999;
       const bOrder = statusOrder[b.status] ?? 999;

--- a/packages/cli/src/commands/agent/mode.ts
+++ b/packages/cli/src/commands/agent/mode.ts
@@ -81,7 +81,7 @@ export async function runModeCommand(
       // List available modes for this agent
       const availableModes = agent.availableModes ?? [];
 
-      const items: AgentMode[] = availableModes.map((m) => ({
+      const items: AgentMode[] = availableModes.map((m: AgentMode) => ({
         id: m.id,
         label: m.label,
         description: m.description,

--- a/packages/cli/src/commands/permit/allow.ts
+++ b/packages/cli/src/commands/permit/allow.ts
@@ -111,13 +111,15 @@ export async function runAllowCommand(
       permissionsToAllow = pendingPermissions;
     } else {
       // Find permission by ID prefix
-      const permission = pendingPermissions.find((p) => p.id === reqId || p.id.startsWith(reqId));
+      const permission = pendingPermissions.find(
+        (p: AgentPermissionRequest) => p.id === reqId || p.id.startsWith(reqId),
+      );
       if (!permission) {
         await client.close();
         const error: CommandError = {
           code: "PERMISSION_NOT_FOUND",
           message: `Permission request not found: ${reqId}`,
-          details: `Available requests: ${pendingPermissions.map((p) => p.id.slice(0, 8)).join(", ")}`,
+          details: `Available requests: ${pendingPermissions.map((p: AgentPermissionRequest) => p.id.slice(0, 8)).join(", ")}`,
         };
         throw error;
       }

--- a/packages/cli/src/commands/permit/deny.ts
+++ b/packages/cli/src/commands/permit/deny.ts
@@ -75,13 +75,15 @@ export async function runDenyCommand(
       permissionsToDeny = pendingPermissions;
     } else {
       // Find permission by ID prefix
-      const permission = pendingPermissions.find((p) => p.id === reqId || p.id.startsWith(reqId!));
+      const permission = pendingPermissions.find(
+        (p: AgentPermissionRequest) => p.id === reqId || p.id.startsWith(reqId!),
+      );
       if (!permission) {
         await client.close();
         const error: CommandError = {
           code: "PERMISSION_NOT_FOUND",
           message: `Permission request not found: ${reqId}`,
-          details: `Available requests: ${pendingPermissions.map((p) => p.id.slice(0, 8)).join(", ")}`,
+          details: `Available requests: ${pendingPermissions.map((p: AgentPermissionRequest) => p.id.slice(0, 8)).join(", ")}`,
         };
         throw error;
       }

--- a/packages/cli/src/commands/permit/ls.ts
+++ b/packages/cli/src/commands/permit/ls.ts
@@ -65,7 +65,9 @@ export async function runLsCommand(
 
   try {
     const agentsPayload = await client.fetchAgents({ filter: { includeArchived: true } });
-    const agents = agentsPayload.entries.map((entry) => entry.agent);
+    const agents = agentsPayload.entries.map(
+      (entry: { agent: AgentSnapshotPayload }) => entry.agent,
+    );
     await client.close();
 
     // Collect all pending permissions from all agents

--- a/packages/cli/src/commands/provider/ls.ts
+++ b/packages/cli/src/commands/provider/ls.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import type { CommandOptions, ListResult, OutputSchema } from "../../output/index.js";
-import type { ProviderSnapshotEntry } from "@getpaseo/protocol/agent-types";
+import type { ProviderSnapshotEntry, AgentMode } from "@getpaseo/protocol/agent-types";
 import { AGENT_PROVIDER_DEFINITIONS } from "@getpaseo/protocol/provider-manifest";
 import { tryConnectToDaemon } from "../../utils/client.js";
 
@@ -73,13 +73,13 @@ export async function runLsCommand(
     const snapshot = await client.getProvidersSnapshot();
     return {
       type: "list",
-      data: snapshot.entries.map((entry) => ({
+      data: snapshot.entries.map((entry: ProviderSnapshotEntry) => ({
         provider: entry.provider,
         label: entry.label ?? entry.provider,
         status: entry.status === "ready" ? "available" : entry.status,
         enabled: !entry.enabled ? "Disabled" : "Enabled",
         defaultMode: entry.defaultModeId ?? "default",
-        modes: (entry.modes ?? []).map((mode) => mode.label).join(", "),
+        modes: (entry.modes ?? []).map((mode: AgentMode) => mode.label).join(", "),
       })),
       schema: providerLsSchema,
     };

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2315,6 +2315,7 @@ export const ProjectPlacementPayloadSchema = z.object({
   projectKey: z.string(),
   projectName: z.string(),
   checkout: ProjectCheckoutLitePayloadSchema,
+  subRepos: z.array(z.string()).optional(),
 });
 
 export const WorkspaceScriptLifecycleSchema = z.enum(["running", "stopped"]);
@@ -2409,7 +2410,7 @@ export const WorkspaceDescriptorPayloadSchema = z
     projectCustomName: z.string().nullable().optional(),
     projectRootPath: z.string(),
     workspaceDirectory: z.string().optional(),
-    projectKind: z.enum(["git", "non_git", "directory"]),
+    projectKind: z.enum(["git", "non_git", "multi_git", "directory"]),
     // COMPAT(workspaces): keep legacy directory workspace kind parseable.
     workspaceKind: z.enum(["directory", "local_checkout", "checkout", "worktree"]),
     name: z.string(),

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2269,10 +2269,14 @@ export const ProjectCheckoutLiteNotGitPayloadSchema = z
     worktreeRoot: z.null().optional(),
     isPaseoOwnedWorktree: z.literal(false),
     mainRepoRoot: z.null(),
+    isMultiGit: z.boolean().optional(),
+    subRepos: z.array(z.string()).optional(),
   })
   .transform((value) => ({
     ...value,
-    worktreeRoot: null,
+    worktreeRoot: null as null,
+    isMultiGit: value.isMultiGit,
+    subRepos: value.subRepos,
   }));
 
 export const ProjectCheckoutLiteGitNonPaseoPayloadSchema = z

--- a/packages/protocol/src/paseo-config-schema.ts
+++ b/packages/protocol/src/paseo-config-schema.ts
@@ -22,9 +22,27 @@ export const PaseoScriptEntryRawSchema = z
   })
   .passthrough();
 
+/**
+ * Per-project worktree lifecycle configuration.
+ *
+ * For single-repo projects, setup/teardown commands run from the worktree root.
+ *
+ * For multi-repo projects (multi_git), a workspace root directory is created that
+ * contains each sub-repo's worktree as a named subdirectory matching the original
+ * folder name. setup/teardown commands run from that workspace root, so you can
+ * install dependencies across multiple repos in a single script, e.g.:
+ *   "cd frontend && npm install"
+ *   "cd backend && pip install -r requirements.txt"
+ */
 export const PaseoWorktreeConfigRawSchema = z
   .object({
+    /** Shell command(s) to run after a worktree is created. For multi-repo projects,
+     *  runs from the workspace root which contains all sub-repo worktrees as named
+     *  subdirectories (e.g. `cd frontend && npm install`). */
     setup: PaseoLifecycleCommandRawSchema.optional(),
+    /** Shell command(s) to run before a worktree is deleted. For multi-repo projects,
+     *  runs from the workspace root which contains all sub-repo worktrees as named
+     *  subdirectories. */
     teardown: PaseoLifecycleCommandRawSchema.optional(),
     terminals: z.unknown().optional(),
   })

--- a/packages/server/src/server/agent/mcp-server.ts
+++ b/packages/server/src/server/agent/mcp-server.ts
@@ -72,6 +72,7 @@ import {
 } from "./lifecycle-command.js";
 import type { GitHubService } from "../../services/github-service.js";
 import type { WorkspaceGitService } from "../workspace-git-service.js";
+import type { WorkspaceRegistry } from "../workspace-registry.js";
 import { WorktreeRequestError } from "../worktree-errors.js";
 import {
   archivePaseoWorktreeCommand,
@@ -98,6 +99,7 @@ export interface AgentMcpServerOptions {
   markWorkspaceArchiving?: ArchivePaseoWorktreeDependencies["markWorkspaceArchiving"];
   clearWorkspaceArchiving?: ArchivePaseoWorktreeDependencies["clearWorkspaceArchiving"];
   createPaseoWorktree?: CreatePaseoWorktreeWorkflowFn;
+  workspaceRegistry?: Pick<WorkspaceRegistry, "get">;
   paseoHome?: string;
   worktreesRoot?: string;
   /**
@@ -2426,6 +2428,7 @@ function archiveWorktreeDependencies(
     emitWorkspaceUpdatesForWorkspaceIds: options.emitWorkspaceUpdatesForWorkspaceIds,
     markWorkspaceArchiving: options.markWorkspaceArchiving,
     clearWorkspaceArchiving: options.clearWorkspaceArchiving,
+    workspaceRegistry: options.workspaceRegistry,
     isPathWithinRoot: isSameOrDescendantPath,
     killTerminalsUnderPath: (rootPath: string) =>
       killTerminalsUnderPath(

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
@@ -12,6 +12,8 @@ import type {
 import type { GitHubService } from "../../services/github-service.js";
 import type { TerminalManager } from "../../terminal/terminal-manager.js";
 import { isPaseoOwnedWorktreeCwd } from "../../utils/worktree.js";
+import type { WorkspaceRegistry } from "../workspace-registry.js";
+import { normalizeWorkspaceId } from "../workspace-registry-model.js";
 
 export interface AutoArchiveArchiveOptions {
   paseoHome: string;
@@ -22,6 +24,7 @@ export interface AutoArchiveArchiveOptions {
   agentManager: AgentManager;
   agentStorage: AgentStorage;
   terminalManager: TerminalManager;
+  workspaceRegistry?: Pick<WorkspaceRegistry, "get">;
   archiveWorkspaceRecord: (workspaceId: string) => Promise<void>;
   markWorkspaceArchiving: (workspaceIds: Iterable<string>, archivingAt: string) => void;
   clearWorkspaceArchiving: (workspaceIds: Iterable<string>) => void;
@@ -85,11 +88,31 @@ export async function archiveIfSafe(input: {
       return;
     }
 
+    // For multi_git workspaces the workspace record carries subRepoWorktrees.
+    // Look it up so the archive step can clean up all sub-repo worktrees, and so
+    // we can bypass the Paseo-ownership check (workspaceRoot is not under the
+    // Paseo worktrees base root — it lives next to the project directory).
+    let subRepoWorktrees:
+      | Array<{ name: string; repoPath: string; worktreePath: string }>
+      | undefined;
+    if (options.workspaceRegistry) {
+      try {
+        const workspaceId = normalizeWorkspaceId(cwd);
+        const workspace = await options.workspaceRegistry.get(workspaceId);
+        if (workspace?.subRepoWorktrees?.length) {
+          subRepoWorktrees = workspace.subRepoWorktrees;
+        }
+      } catch {
+        // best-effort: if lookup fails, proceed without subRepoWorktrees
+      }
+    }
+    const isMultiGit = subRepoWorktrees !== undefined;
+
     const ownership = await deps.isPaseoOwnedWorktreeCwd(cwd, {
       paseoHome: options.paseoHome,
       worktreesRoot: options.worktreesRoot,
     });
-    if (!ownership.allowed) {
+    if (!ownership.allowed && !isMultiGit) {
       return;
     }
 
@@ -125,6 +148,7 @@ export async function archiveIfSafe(input: {
           worktreesRoot: ownership.worktreeRoot,
           worktreesBaseRoot: options.worktreesRoot,
           requestId: "auto-archive-on-merge",
+          subRepoWorktrees,
         },
       );
       log.info({ cwd }, "Auto-archived worktree after PR merge");

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -676,6 +676,7 @@ export async function createPaseoDaemon(
     agentManager,
     agentStorage,
     terminalManager,
+    workspaceRegistry: workspaceRegistry ?? undefined,
     logger,
     archiveWorkspaceRecord: archiveWorkspaceRecordExternal,
     markWorkspaceArchiving: markWorkspaceArchivingExternal,
@@ -703,6 +704,7 @@ export async function createPaseoDaemon(
         emitWorkspaceUpdatesForWorkspaceIds: emitWorkspaceUpdatesExternal,
         markWorkspaceArchiving: markWorkspaceArchivingExternal,
         clearWorkspaceArchiving: clearWorkspaceArchivingExternal,
+        workspaceRegistry: workspaceRegistry ?? undefined,
         createPaseoWorktree: async (input, serviceOptions) => {
           return createPaseoWorktreeWorkflow(
             {

--- a/packages/server/src/server/paseo-worktree-archive-service.ts
+++ b/packages/server/src/server/paseo-worktree-archive-service.ts
@@ -1,3 +1,5 @@
+import { promises as fs } from "node:fs";
+
 import type { Logger } from "pino";
 
 import type { AgentManager } from "./agent/agent-manager.js";
@@ -8,8 +10,10 @@ import type { GitHubService } from "../services/github-service.js";
 import {
   deletePaseoWorktree,
   resolvePaseoWorktreeRootForCwd,
+  runWorktreeTeardownCommands,
   WorktreeTeardownError,
 } from "../utils/worktree.js";
+import { runGitCommand } from "../utils/run-git-command.js";
 import type { TerminalManager } from "../terminal/terminal-manager.js";
 
 export interface ArchivePaseoWorktreeDependencies {
@@ -44,6 +48,8 @@ export async function archivePaseoWorktree(
     worktreesRoot?: string;
     worktreesBaseRoot?: string;
     requestId: string;
+    /** Present for multi_git workspaces: the list of sub-repo worktrees to clean up. */
+    subRepoWorktrees?: Array<{ name: string; repoPath: string; worktreePath: string }>;
   },
 ): Promise<string[]> {
   let targetPath = options.targetPath;
@@ -111,26 +117,7 @@ export async function archivePaseoWorktree(
       }
     }
 
-    let teardownError: WorktreeTeardownError | null = null;
-    try {
-      await deletePaseoWorktree({
-        cwd: options.repoRoot,
-        worktreePath: targetPath,
-        worktreesRoot: options.worktreesRoot,
-        paseoHome: dependencies.paseoHome,
-        worktreesBaseRoot: options.worktreesBaseRoot ?? dependencies.worktreesRoot,
-      });
-    } catch (error) {
-      if (error instanceof WorktreeTeardownError) {
-        teardownError = error;
-        dependencies.sessionLogger?.warn(
-          { err: error, targetPath },
-          "Worktree teardown failed during archive; archiving workspace record anyway",
-        );
-      } else {
-        throw error;
-      }
-    }
+    const teardownError = await teardownWorktreeFilesystem(targetPath, options, dependencies);
 
     if (!teardownError && options.repoRoot) {
       try {
@@ -174,6 +161,94 @@ export async function archivePaseoWorktree(
   }
 
   return Array.from(archivedAgents);
+}
+
+/**
+ * Dispatch to either the multi_git or single-repo teardown path.
+ * Returns any WorktreeTeardownError that should be re-thrown after the
+ * workspace record has been archived (best-effort semantics).
+ */
+async function teardownWorktreeFilesystem(
+  targetPath: string,
+  options: {
+    repoRoot: string | null;
+    worktreesRoot?: string;
+    worktreesBaseRoot?: string;
+    subRepoWorktrees?: Array<{ name: string; repoPath: string; worktreePath: string }>;
+  },
+  dependencies: Pick<ArchivePaseoWorktreeDependencies, "paseoHome" | "sessionLogger">,
+): Promise<WorktreeTeardownError | null> {
+  const subRepoWorktrees = options.subRepoWorktrees;
+  if (subRepoWorktrees && subRepoWorktrees.length > 0) {
+    await teardownMultiGitWorkspace(targetPath, subRepoWorktrees, dependencies.sessionLogger);
+    return null;
+  }
+
+  try {
+    await deletePaseoWorktree({
+      cwd: options.repoRoot,
+      worktreePath: targetPath,
+      worktreesRoot: options.worktreesRoot,
+      paseoHome: dependencies.paseoHome,
+      worktreesBaseRoot: options.worktreesBaseRoot,
+    });
+    return null;
+  } catch (error) {
+    if (error instanceof WorktreeTeardownError) {
+      dependencies.sessionLogger?.warn(
+        { err: error, targetPath },
+        "Worktree teardown failed during archive; archiving workspace record anyway",
+      );
+      return error;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Tear down a multi_git workspace: run paseo.json teardown commands from
+ * workspaceRoot, remove each sub-repo worktree from its parent git repo,
+ * then delete the workspaceRoot directory. All steps are best-effort.
+ */
+async function teardownMultiGitWorkspace(
+  workspaceRoot: string,
+  subRepoWorktrees: Array<{ name: string; repoPath: string; worktreePath: string }>,
+  logger: Logger | undefined,
+): Promise<void> {
+  // Step 1: Run worktree.teardown commands from workspaceRoot (best-effort).
+  try {
+    await runWorktreeTeardownCommands({ worktreePath: workspaceRoot });
+  } catch (error) {
+    logger?.warn(
+      { err: error, workspaceRoot },
+      "Multi-git worktree teardown commands failed; continuing with cleanup",
+    );
+  }
+
+  // Step 2: Remove each sub-repo worktree from its parent git repo (best-effort).
+  for (const subRepo of subRepoWorktrees) {
+    try {
+      await runGitCommand(["worktree", "remove", "--force", subRepo.worktreePath], {
+        cwd: subRepo.repoPath,
+        timeout: 120_000,
+      });
+    } catch (error) {
+      logger?.warn(
+        { err: error, worktreePath: subRepo.worktreePath, repoPath: subRepo.repoPath },
+        "git worktree remove failed for sub-repo during multi-git archive; continuing",
+      );
+    }
+  }
+
+  // Step 3: Remove the workspaceRoot directory (best-effort).
+  try {
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+  } catch (error) {
+    logger?.warn(
+      { err: error, workspaceRoot },
+      "Failed to remove workspaceRoot directory during multi-git archive; continuing",
+    );
+  }
 }
 
 export async function killTerminalsUnderPath(

--- a/packages/server/src/server/paseo-worktree-service.ts
+++ b/packages/server/src/server/paseo-worktree-service.ts
@@ -33,6 +33,10 @@ export interface CreatePaseoWorktreeResult {
   workspace: PersistedWorkspaceRecord;
   repoRoot: string;
   created: boolean;
+  /** Root path of the project that owns this worktree.  For multi_git projects
+   *  this is the parent folder that contains paseo.json; for standard git
+   *  projects it equals repoRoot. */
+  projectRootPath: string;
 }
 
 export type CreatePaseoWorktreeFn = (
@@ -60,7 +64,7 @@ export async function createPaseoWorktree(
 ): Promise<CreatePaseoWorktreeResult> {
   const createdWorktree = await createWorktreeCore(input, deps);
   maybeMarkFirstAgentBranchAutoNameEligible({ createdWorktree });
-  const workspace = await upsertWorkspaceForWorktree({
+  const { workspace, projectRootPath } = await upsertWorkspaceForWorktree({
     inputCwd: input.cwd,
     projectId: input.projectId,
     repoRoot: createdWorktree.repoRoot,
@@ -76,6 +80,7 @@ export async function createPaseoWorktree(
     workspace,
     repoRoot: createdWorktree.repoRoot,
     created: createdWorktree.created,
+    projectRootPath,
   };
 }
 
@@ -196,7 +201,7 @@ async function upsertWorkspaceForWorktree(options: {
   repoRoot: string;
   worktree: WorktreeConfig;
   deps: Pick<CreatePaseoWorktreeDeps, "projectRegistry" | "workspaceRegistry">;
-}): Promise<PersistedWorkspaceRecord> {
+}): Promise<{ workspace: PersistedWorkspaceRecord; projectRootPath: string }> {
   const normalizedCwd = normalizeWorkspaceId(options.worktree.worktreePath);
   const normalizedInputCwd = normalizeWorkspaceId(options.inputCwd);
   const normalizedRepoRoot = normalizeWorkspaceId(options.repoRoot);
@@ -239,7 +244,9 @@ async function upsertWorkspaceForWorktree(options: {
   });
 
   await options.deps.workspaceRegistry.upsert(workspace);
-  return (await options.deps.workspaceRegistry.get(workspace.workspaceId)) ?? workspace;
+  const persistedWorkspace =
+    (await options.deps.workspaceRegistry.get(workspace.workspaceId)) ?? workspace;
+  return { workspace: persistedWorkspace, projectRootPath: sourceProject.rootPath };
 }
 
 interface SourceProjectForWorktree {

--- a/packages/server/src/server/paseo-worktree-service.ts
+++ b/packages/server/src/server/paseo-worktree-service.ts
@@ -1,5 +1,9 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
 import type { WorkspaceGitService } from "./workspace-git-service.js";
 import {
+  type PersistedProjectRecord,
   type PersistedWorkspaceRecord,
   type ProjectRegistry,
   type WorkspaceRegistry,
@@ -12,7 +16,7 @@ import {
   type CreateWorktreeCoreDeps,
   type CreateWorktreeCoreInput,
 } from "./worktree-core.js";
-import { validateBranchSlug, type WorktreeConfig } from "../utils/worktree.js";
+import { slugify, validateBranchSlug, type WorktreeConfig } from "../utils/worktree.js";
 import { getCurrentBranch, localBranchExists, renameCurrentBranch } from "../utils/checkout-git.js";
 import {
   markPaseoWorktreeFirstAgentBranchAutoNameAttempted,
@@ -62,6 +66,19 @@ export async function createPaseoWorktree(
   input: CreatePaseoWorktreeInput,
   deps: CreatePaseoWorktreeDeps,
 ): Promise<CreatePaseoWorktreeResult> {
+  // Route multi_git projects to dedicated handler
+  if (input.projectId) {
+    const project = await deps.projectRegistry.get(input.projectId);
+    if (
+      project &&
+      !project.archivedAt &&
+      project.kind === "multi_git" &&
+      project.subRepos?.length
+    ) {
+      return createMultiGitWorktree(input, project, deps);
+    }
+  }
+
   const createdWorktree = await createWorktreeCore(input, deps);
   maybeMarkFirstAgentBranchAutoNameEligible({ createdWorktree });
   const { workspace, projectRootPath } = await upsertWorkspaceForWorktree({
@@ -81,6 +98,112 @@ export async function createPaseoWorktree(
     repoRoot: createdWorktree.repoRoot,
     created: createdWorktree.created,
     projectRootPath,
+  };
+}
+
+async function createMultiGitWorktree(
+  input: CreatePaseoWorktreeInput,
+  project: PersistedProjectRecord,
+  deps: CreatePaseoWorktreeDeps,
+): Promise<CreatePaseoWorktreeResult> {
+  const subRepos = project.subRepos!;
+
+  // Step 1: Create a worktree for each sub-repo sequentially, using the same
+  // branchSlug across all repos.  For the first sub-repo we let createWorktreeCore
+  // generate/resolve the slug; for subsequent ones we re-use that slug so all
+  // worktrees land on the same branch name.
+  const subRepoWorktrees: Array<{ name: string; repoPath: string; worktreePath: string }> = [];
+  let firstCreatedWorktree: Awaited<ReturnType<typeof createWorktreeCore>> | null = null;
+  let resolvedBranchSlug: string | undefined;
+
+  for (const subRepoPath of subRepos) {
+    const folderName = path.basename(subRepoPath);
+
+    const createdWorktree = await createWorktreeCore(
+      {
+        ...input,
+        cwd: subRepoPath,
+        // After the first sub-repo we lock in the slug so all repos use the same branch.
+        worktreeSlug: resolvedBranchSlug ?? input.worktreeSlug,
+      },
+      deps,
+    );
+
+    if (!firstCreatedWorktree) {
+      firstCreatedWorktree = createdWorktree;
+      // Derive the slug from the actual branch name of the first worktree
+      resolvedBranchSlug = createdWorktree.worktree.branchName;
+      maybeMarkFirstAgentBranchAutoNameEligible({ createdWorktree });
+    }
+
+    subRepoWorktrees.push({
+      name: folderName,
+      repoPath: subRepoPath,
+      worktreePath: createdWorktree.worktree.worktreePath,
+    });
+
+    deps.github.invalidate({ cwd: createdWorktree.worktree.worktreePath });
+  }
+
+  if (!firstCreatedWorktree || !resolvedBranchSlug) {
+    throw new Error("No sub-repos produced a worktree");
+  }
+
+  // Step 2: Compute workspace root using the resolved slug and create the directory.
+  // workspaceRoot acts as the cwd for the setup script — it is a plain directory,
+  // not a git repo itself.
+  const branchSlug = slugify(resolvedBranchSlug);
+  const workspaceRoot = path.join(
+    path.dirname(project.rootPath),
+    path.basename(project.rootPath) + "-workspaces",
+    branchSlug,
+  );
+  await fs.mkdir(workspaceRoot, { recursive: true });
+
+  // Step 3: Upsert the project record (refresh timestamps).
+  const now = new Date().toISOString();
+  await deps.projectRegistry.upsert(
+    createPersistedProjectRecord({
+      projectId: project.projectId,
+      rootPath: project.rootPath,
+      kind: project.kind,
+      displayName: project.displayName,
+      customName: project.customName,
+      subRepos: project.subRepos,
+      createdAt: project.createdAt ?? now,
+      updatedAt: now,
+      archivedAt: null,
+    }),
+  );
+
+  // Step 4: Create workspace record with cwd = workspaceRoot and kind = "directory".
+  const normalizedWorkspaceRoot = normalizeWorkspaceId(workspaceRoot);
+  const existingWorkspace = await deps.workspaceRegistry
+    .list()
+    .then((ws) => ws.find((w) => w.cwd === normalizedWorkspaceRoot) ?? null);
+
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: normalizedWorkspaceRoot,
+    projectId: project.projectId,
+    cwd: normalizedWorkspaceRoot,
+    kind: "directory",
+    displayName: firstCreatedWorktree.worktree.branchName || normalizedWorkspaceRoot,
+    subRepoWorktrees,
+    createdAt: existingWorkspace?.createdAt ?? now,
+    updatedAt: now,
+    archivedAt: null,
+  });
+
+  await deps.workspaceRegistry.upsert(workspace);
+  const persistedWorkspace = (await deps.workspaceRegistry.get(workspace.workspaceId)) ?? workspace;
+
+  return {
+    worktree: firstCreatedWorktree.worktree,
+    intent: firstCreatedWorktree.intent,
+    workspace: persistedWorkspace,
+    repoRoot: firstCreatedWorktree.repoRoot,
+    created: firstCreatedWorktree.created,
+    projectRootPath: workspaceRoot,
   };
 }
 

--- a/packages/server/src/server/paseo-worktree-service.ts
+++ b/packages/server/src/server/paseo-worktree-service.ts
@@ -1,6 +1,8 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
+import { createNameId } from "mnemonic-id";
+
 import type { WorkspaceGitService } from "./workspace-git-service.js";
 import {
   type PersistedProjectRecord,
@@ -108,13 +110,23 @@ async function createMultiGitWorktree(
 ): Promise<CreatePaseoWorktreeResult> {
   const subRepos = project.subRepos!;
 
-  // Step 1: Create a worktree for each sub-repo sequentially, using the same
-  // branchSlug across all repos.  For the first sub-repo we let createWorktreeCore
-  // generate/resolve the slug; for subsequent ones we re-use that slug so all
-  // worktrees land on the same branch name.
+  // Step 1: Pre-resolve the branch slug so we can compute workspaceRoot before
+  // creating any worktrees and place each sub-repo worktree at the correct path
+  // (workspaceRoot/<folderName>) from the very first call.
+  const branchSlug = slugify(input.worktreeSlug ?? createNameId());
+  const workspaceRoot = path.join(
+    path.dirname(project.rootPath),
+    path.basename(project.rootPath) + "-workspaces",
+    branchSlug,
+  );
+  await fs.mkdir(workspaceRoot, { recursive: true });
+
+  // Step 2: Create a worktree for each sub-repo sequentially, using the same
+  // branchSlug across all repos.  We pin worktreeSlug for all repos so they
+  // all land on the same branch name, and pass explicitWorktreePath so each
+  // worktree is placed inside workspaceRoot instead of the default paseo location.
   const subRepoWorktrees: Array<{ name: string; repoPath: string; worktreePath: string }> = [];
   let firstCreatedWorktree: Awaited<ReturnType<typeof createWorktreeCore>> | null = null;
-  let resolvedBranchSlug: string | undefined;
 
   for (const subRepoPath of subRepos) {
     const folderName = path.basename(subRepoPath);
@@ -123,16 +135,14 @@ async function createMultiGitWorktree(
       {
         ...input,
         cwd: subRepoPath,
-        // After the first sub-repo we lock in the slug so all repos use the same branch.
-        worktreeSlug: resolvedBranchSlug ?? input.worktreeSlug,
+        worktreeSlug: branchSlug,
+        explicitWorktreePath: path.join(workspaceRoot, folderName),
       },
       deps,
     );
 
     if (!firstCreatedWorktree) {
       firstCreatedWorktree = createdWorktree;
-      // Derive the slug from the actual branch name of the first worktree
-      resolvedBranchSlug = createdWorktree.worktree.branchName;
       maybeMarkFirstAgentBranchAutoNameEligible({ createdWorktree });
     }
 
@@ -145,20 +155,9 @@ async function createMultiGitWorktree(
     deps.github.invalidate({ cwd: createdWorktree.worktree.worktreePath });
   }
 
-  if (!firstCreatedWorktree || !resolvedBranchSlug) {
+  if (!firstCreatedWorktree) {
     throw new Error("No sub-repos produced a worktree");
   }
-
-  // Step 2: Compute workspace root using the resolved slug and create the directory.
-  // workspaceRoot acts as the cwd for the setup script — it is a plain directory,
-  // not a git repo itself.
-  const branchSlug = slugify(resolvedBranchSlug);
-  const workspaceRoot = path.join(
-    path.dirname(project.rootPath),
-    path.basename(project.rootPath) + "-workspaces",
-    branchSlug,
-  );
-  await fs.mkdir(workspaceRoot, { recursive: true });
 
   // Step 3: Upsert the project record (refresh timestamps).
   const now = new Date().toISOString();

--- a/packages/server/src/server/paseo-worktree-service.ts
+++ b/packages/server/src/server/paseo-worktree-service.ts
@@ -108,7 +108,7 @@ async function createMultiGitWorktree(
   project: PersistedProjectRecord,
   deps: CreatePaseoWorktreeDeps,
 ): Promise<CreatePaseoWorktreeResult> {
-  const subRepos = project.subRepos!;
+  const subRepos = project.subRepos ?? [];
 
   // Step 1: Pre-resolve the branch slug so we can compute workspaceRoot before
   // creating any worktrees and place each sub-repo worktree at the correct path
@@ -128,31 +128,40 @@ async function createMultiGitWorktree(
   const subRepoWorktrees: Array<{ name: string; repoPath: string; worktreePath: string }> = [];
   let firstCreatedWorktree: Awaited<ReturnType<typeof createWorktreeCore>> | null = null;
 
-  for (const subRepoPath of subRepos) {
-    const folderName = path.basename(subRepoPath);
+  try {
+    for (const subRepoPath of subRepos) {
+      const folderName = path.basename(subRepoPath);
 
-    const createdWorktree = await createWorktreeCore(
-      {
-        ...input,
-        cwd: subRepoPath,
-        worktreeSlug: branchSlug,
-        explicitWorktreePath: path.join(workspaceRoot, folderName),
-      },
-      deps,
-    );
+      const createdWorktree = await createWorktreeCore(
+        {
+          ...input,
+          cwd: subRepoPath,
+          worktreeSlug: branchSlug,
+          explicitWorktreePath: path.join(workspaceRoot, folderName),
+        },
+        deps,
+      );
 
-    if (!firstCreatedWorktree) {
-      firstCreatedWorktree = createdWorktree;
-      maybeMarkFirstAgentBranchAutoNameEligible({ createdWorktree });
+      if (!firstCreatedWorktree) {
+        firstCreatedWorktree = createdWorktree;
+        maybeMarkFirstAgentBranchAutoNameEligible({ createdWorktree });
+      }
+
+      subRepoWorktrees.push({
+        name: folderName,
+        repoPath: subRepoPath,
+        worktreePath: createdWorktree.worktree.worktreePath,
+      });
+
+      deps.github.invalidate({ cwd: createdWorktree.worktree.worktreePath });
     }
-
-    subRepoWorktrees.push({
-      name: folderName,
-      repoPath: subRepoPath,
-      worktreePath: createdWorktree.worktree.worktreePath,
-    });
-
-    deps.github.invalidate({ cwd: createdWorktree.worktree.worktreePath });
+  } catch (err) {
+    try {
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors, throw original
+    }
+    throw err;
   }
 
   if (!firstCreatedWorktree) {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -5721,6 +5721,7 @@ export class Session {
         killTerminalsUnderPath: (rootPath) =>
           this.terminalController.killTerminalsUnderPath(rootPath),
         sessionLogger: this.sessionLogger,
+        workspaceRegistry: this.workspaceRegistry,
       },
       msg,
     );

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -372,6 +372,8 @@ function buildWorkspaceCheckout(
       worktreeRoot: null,
       isPaseoOwnedWorktree: false,
       mainRepoRoot: null,
+      isMultiGit: undefined,
+      subRepos: undefined,
     };
   }
   if (workspace.kind === "worktree") {
@@ -1627,6 +1629,8 @@ export class Session {
           worktreeRoot: null,
           isPaseoOwnedWorktree: false,
           mainRepoRoot: null,
+          isMultiGit: undefined,
+          subRepos: undefined,
         },
       };
     }
@@ -6268,6 +6272,16 @@ export class Session {
       diffStat = snapshot.git.diffStat;
     }
 
+    const resolvedKind = resolvedProjectRecord?.kind ?? "directory";
+    let projectKind: WorkspaceDescriptorPayload["projectKind"];
+    if (resolvedKind === "git") {
+      projectKind = "git";
+    } else if (resolvedKind === "multi_git") {
+      projectKind = "multi_git";
+    } else {
+      projectKind = "non_git";
+    }
+
     return {
       id: workspace.workspaceId,
       projectId: workspace.projectId,
@@ -6277,7 +6291,7 @@ export class Session {
       projectCustomName: resolvedProjectRecord?.customName ?? null,
       projectRootPath: resolvedProjectRecord?.rootPath ?? workspace.cwd,
       workspaceDirectory: workspace.cwd,
-      projectKind: (resolvedProjectRecord?.kind ?? "directory") === "git" ? "git" : (resolvedProjectRecord?.kind ?? "directory") === "multi_git" ? "multi_git" : "non_git",
+      projectKind,
       workspaceKind: workspace.kind,
       name: workspace.displayName,
       archivingAt: null,
@@ -6629,12 +6643,15 @@ export class Session {
       projects.find((project) => project.rootPath === rootPath) ??
       null;
 
+    const subRepos = kind === "multi_git" ? input.membership.subRepos : undefined;
+
     if (!existingProject) {
       return createPersistedProjectRecord({
         projectId: input.membership.projectKey,
         rootPath,
         kind,
         displayName: input.membership.projectName,
+        subRepos,
         createdAt: input.timestamp,
         updatedAt: input.timestamp,
       });
@@ -6644,6 +6661,7 @@ export class Session {
       ...existingProject,
       rootPath,
       kind,
+      ...(subRepos !== undefined ? { subRepos } : {}),
       archivedAt: null,
       updatedAt: input.timestamp,
     };

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -4875,7 +4875,7 @@ export class Session {
   private syncWorkspaceGitObservers(workspaces: Iterable<WorkspaceDescriptorPayload>): void {
     for (const workspace of workspaces) {
       this.syncWorkspaceGitObserver(workspace.workspaceDirectory, {
-        isGit: workspace.projectKind === "git",
+        isGit: workspace.projectKind === "git" || workspace.projectKind === "multi_git",
         workspaceId: workspace.id,
       });
       this.rememberWorkspaceGitDescriptorState(workspace.workspaceDirectory, workspace);
@@ -6277,7 +6277,7 @@ export class Session {
       projectCustomName: resolvedProjectRecord?.customName ?? null,
       projectRootPath: resolvedProjectRecord?.rootPath ?? workspace.cwd,
       workspaceDirectory: workspace.cwd,
-      projectKind: (resolvedProjectRecord?.kind ?? "directory") === "git" ? "git" : "non_git",
+      projectKind: (resolvedProjectRecord?.kind ?? "directory") === "git" ? "git" : (resolvedProjectRecord?.kind ?? "directory") === "multi_git" ? "multi_git" : "non_git",
       workspaceKind: workspace.kind,
       name: workspace.displayName,
       archivingAt: null,

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1602,6 +1602,7 @@ export class Session {
       projectKey: project.projectId,
       projectName: resolveProjectDisplayName(project),
       checkout,
+      subRepos: project.subRepos,
     };
   }
 

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -118,6 +118,8 @@ function createFallbackWorkspaceGitService(): WorkspaceGitService {
       worktreeRoot: null,
       isPaseoOwnedWorktree: false,
       mainRepoRoot: null,
+      isMultiGit: undefined,
+      subRepos: undefined,
     }),
     getSnapshot: async (cwd: string) => createFallbackWorkspaceGitSnapshot(cwd),
     getCheckoutDiff: async () => ({ diff: "" }),

--- a/packages/server/src/server/workspace-git-metadata.ts
+++ b/packages/server/src/server/workspace-git-metadata.ts
@@ -42,8 +42,23 @@ export function buildWorkspaceGitMetadataFromSnapshot(input: {
   mainRepoRoot: string | null;
   currentBranch: string | null;
   remoteUrl: string | null;
+  isMultiGit?: boolean;
+  subRepos?: string[];
 }): WorkspaceGitMetadata {
   if (!input.isGit) {
+    if (input.isMultiGit) {
+      return {
+        projectKind: "multi_git",
+        projectDisplayName: input.directoryName,
+        workspaceDisplayName: input.directoryName,
+        gitRemote: null,
+        isWorktree: false,
+        projectSlug: deriveProjectSlug(input.cwd),
+        repoRoot: null,
+        currentBranch: null,
+        remoteUrl: null,
+      };
+    }
     return {
       projectKind: "directory",
       projectDisplayName: input.directoryName,

--- a/packages/server/src/server/workspace-git-metadata.ts
+++ b/packages/server/src/server/workspace-git-metadata.ts
@@ -4,7 +4,7 @@ import { slugify } from "../utils/worktree.js";
 import { deriveProjectGroupingKey, deriveProjectGroupingName } from "./workspace-registry-model.js";
 
 export interface WorkspaceGitMetadata {
-  projectKind: "git" | "directory";
+  projectKind: "git" | "directory" | "multi_git";
   projectDisplayName: string;
   workspaceDisplayName: string;
   gitRemote: string | null;

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -77,6 +77,8 @@ export interface WorkspaceGitRuntimeSnapshot {
     behindOfOrigin: number | null;
     hasRemote: boolean;
     diffStat: { additions: number; deletions: number } | null;
+    isMultiGit?: boolean;
+    subRepos?: string[];
   };
   github: {
     featuresEnabled: boolean;
@@ -643,6 +645,8 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
       mainRepoRoot: snapshot.git.mainRepoRoot,
       currentBranch: snapshot.git.currentBranch,
       remoteUrl: snapshot.git.remoteUrl,
+      isMultiGit: snapshot.git.isMultiGit,
+      subRepos: snapshot.git.subRepos,
     });
   }
 
@@ -1623,7 +1627,12 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
     const context: CheckoutContext = { ...baseContext, facts };
     const checkoutStatus = await this.deps.getCheckoutStatus(cwd, context);
     if (!checkoutStatus.isGit) {
-      target.latestGit = buildNotGitSnapshot(cwd).git;
+      target.latestGit = {
+        ...buildNotGitSnapshot(cwd).git,
+        ...(checkoutStatus.isMultiGit
+          ? { isMultiGit: true, subRepos: checkoutStatus.subRepos }
+          : {}),
+      };
       target.latestGitLoadedAtMs = this.deps.now().getTime();
       target.cachedGitHubRemote = null;
       target.latestGithub = buildGitHubUnavailableSnapshot();

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -450,7 +450,7 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
         logger: this.logger,
       });
       if (!status.isGit) {
-        return checkoutLiteFromGitSnapshot(normalizedCwd, {
+        const base = checkoutLiteFromGitSnapshot(normalizedCwd, {
           isGit: false,
           currentBranch: null,
           remoteUrl: null,
@@ -458,6 +458,10 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
           isPaseoOwnedWorktree: false,
           mainRepoRoot: null,
         });
+        return {
+          ...base,
+          ...(status.isMultiGit ? { isMultiGit: true, subRepos: status.subRepos } : {}),
+        };
       }
       return checkoutLiteFromGitSnapshot(normalizedCwd, {
         isGit: true,

--- a/packages/server/src/server/workspace-reconciliation-service.ts
+++ b/packages/server/src/server/workspace-reconciliation-service.ts
@@ -12,7 +12,7 @@ import { normalizeWorkspaceId } from "./workspace-registry-model.js";
 const DEFAULT_RECONCILE_INTERVAL_MS = 60_000;
 
 function deriveWorkspaceKindFromMetadata(metadata: {
-  projectKind: "git" | "directory";
+  projectKind: "git" | "directory" | "multi_git";
   isWorktree: boolean;
 }): PersistedWorkspaceRecord["kind"] {
   if (metadata.projectKind !== "git") return "directory";
@@ -301,7 +301,14 @@ export class WorkspaceReconciliationService {
       Pick<PersistedProjectRecord, "kind" | "displayName" | "rootPath">
     > = {};
 
-    const mappedKind = currentGit.projectKind === "git" ? "git" : currentGit.projectKind === "multi_git" ? "multi_git" : "non_git";
+    let mappedKind: PersistedProjectRecord["kind"];
+    if (currentGit.projectKind === "git") {
+      mappedKind = "git";
+    } else if (currentGit.projectKind === "multi_git") {
+      mappedKind = "multi_git";
+    } else {
+      mappedKind = "non_git";
+    }
 
     if (project.kind !== mappedKind) {
       projectUpdates.kind = mappedKind;

--- a/packages/server/src/server/workspace-reconciliation-service.ts
+++ b/packages/server/src/server/workspace-reconciliation-service.ts
@@ -301,7 +301,7 @@ export class WorkspaceReconciliationService {
       Pick<PersistedProjectRecord, "kind" | "displayName" | "rootPath">
     > = {};
 
-    const mappedKind = currentGit.projectKind === "git" ? "git" : "non_git";
+    const mappedKind = currentGit.projectKind === "git" ? "git" : currentGit.projectKind === "multi_git" ? "multi_git" : "non_git";
 
     if (project.kind !== mappedKind) {
       projectUpdates.kind = mappedKind;

--- a/packages/server/src/server/workspace-registry-model.ts
+++ b/packages/server/src/server/workspace-registry-model.ts
@@ -20,6 +20,7 @@ export interface DirectoryProjectMembership {
   projectName: string;
   projectRootPath: string;
   projectKind: PersistedProjectKind;
+  subRepos?: string[];
 }
 
 export interface DetectStaleWorkspacesInput {
@@ -150,7 +151,9 @@ export function deriveProjectRootPath(input: {
 }
 
 export function deriveProjectKind(checkout: ProjectCheckoutLitePayload): PersistedProjectKind {
-  return checkout.isGit ? "git" : "non_git";
+  if (checkout.isGit) return "git";
+  if (!checkout.isGit && checkout.isMultiGit) return "multi_git";
+  return "non_git";
 }
 
 export function deriveWorkspaceKind(checkout: ProjectCheckoutLitePayload): PersistedWorkspaceKind {
@@ -180,6 +183,8 @@ export function checkoutLiteFromGitSnapshot(
       worktreeRoot: null,
       isPaseoOwnedWorktree: false,
       mainRepoRoot: null,
+      isMultiGit: undefined,
+      subRepos: undefined,
     };
   }
   if (git.isPaseoOwnedWorktree && git.mainRepoRoot) {
@@ -268,5 +273,6 @@ export function classifyDirectoryForProjectMembership(input: {
       checkout,
     }),
     projectKind: deriveProjectKind(checkout),
+    subRepos: !checkout.isGit && checkout.isMultiGit ? checkout.subRepos : undefined,
   };
 }

--- a/packages/server/src/server/workspace-registry-model.ts
+++ b/packages/server/src/server/workspace-registry-model.ts
@@ -7,7 +7,7 @@ import type {
 import { parseGitRevParsePath } from "../utils/git-rev-parse-path.js";
 import type { PersistedWorkspaceRecord } from "./workspace-registry.js";
 
-export type PersistedProjectKind = "git" | "non_git";
+export type PersistedProjectKind = "git" | "non_git" | "multi_git";
 export type PersistedWorkspaceKind = "local_checkout" | "worktree" | "directory";
 
 export interface DirectoryProjectMembership {

--- a/packages/server/src/server/workspace-registry.ts
+++ b/packages/server/src/server/workspace-registry.ts
@@ -216,6 +216,7 @@ export function createPersistedProjectRecord(input: {
   kind: PersistedProjectKind;
   displayName: string;
   customName?: string | null;
+  subRepos?: string[];
   createdAt: string;
   updatedAt: string;
   archivedAt?: string | null;

--- a/packages/server/src/server/workspace-registry.ts
+++ b/packages/server/src/server/workspace-registry.ts
@@ -238,6 +238,7 @@ export function createPersistedWorkspaceRecord(input: {
   cwd: string;
   kind: PersistedWorkspaceKind;
   displayName: string;
+  subRepoWorktrees?: Array<{ name: string; repoPath: string; worktreePath: string }>;
   createdAt: string;
   updatedAt: string;
   archivedAt?: string | null;

--- a/packages/server/src/server/workspace-registry.ts
+++ b/packages/server/src/server/workspace-registry.ts
@@ -9,7 +9,7 @@ import type { PersistedProjectKind, PersistedWorkspaceKind } from "./workspace-r
 const PersistedProjectRecordSchema = z.object({
   projectId: z.string(),
   rootPath: z.string(),
-  kind: z.enum(["git", "non_git"]),
+  kind: z.enum(["git", "non_git", "multi_git"]),
   displayName: z.string(),
   // User-set override layered over the derived displayName. Reconciliation
   // never touches this. Null means "use the derived name". Added for #987.
@@ -18,6 +18,7 @@ const PersistedProjectRecordSchema = z.object({
     .nullable()
     .optional()
     .transform((value) => value ?? null),
+  subRepos: z.array(z.string()).optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
   archivedAt: z.string().nullable(),
@@ -29,6 +30,15 @@ const PersistedWorkspaceRecordSchema = z.object({
   cwd: z.string(),
   kind: z.enum(["local_checkout", "worktree", "directory"]),
   displayName: z.string(),
+  subRepoWorktrees: z
+    .array(
+      z.object({
+        name: z.string(),
+        repoPath: z.string(),
+        worktreePath: z.string(),
+      }),
+    )
+    .optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
   archivedAt: z.string().nullable(),

--- a/packages/server/src/server/worktree-bootstrap.ts
+++ b/packages/server/src/server/worktree-bootstrap.ts
@@ -46,6 +46,9 @@ export interface RunAsyncWorktreeBootstrapOptions {
   appendTimelineItem: (item: AgentTimelineItem) => Promise<boolean>;
   emitLiveTimelineItem?: (item: AgentTimelineItem) => Promise<boolean>;
   logger?: Logger;
+  /** For multi_git projects: the parent folder that contains paseo.json.
+   *  When set, config is read from this path instead of worktree.worktreePath. */
+  projectRootPath?: string;
 }
 
 const MAX_WORKTREE_SETUP_COMMAND_OUTPUT_BYTES = 64 * 1024;
@@ -500,7 +503,8 @@ async function runWorktreeTerminalBootstrap(
   options: RunAsyncWorktreeBootstrapOptions,
   runtimeEnv: WorktreeRuntimeEnv,
 ): Promise<void> {
-  const terminalSpecs = getWorktreeTerminalSpecs(options.worktree.worktreePath);
+  const configRoot = options.projectRootPath ?? options.worktree.worktreePath;
+  const terminalSpecs = getWorktreeTerminalSpecs(configRoot);
   if (terminalSpecs.length === 0) {
     return;
   }
@@ -637,6 +641,7 @@ export async function runAsyncWorktreeBootstrap(
       branchName: options.worktree.branchName,
       cleanupOnFailure: false,
       runtimeEnv,
+      ...(options.projectRootPath ? { configRootPath: options.projectRootPath } : {}),
       onEvent: (event) => {
         applyWorktreeSetupProgressEvent(progressAccumulator, event);
         queueLiveRunningEmit();

--- a/packages/server/src/server/worktree-bootstrap.ts
+++ b/packages/server/src/server/worktree-bootstrap.ts
@@ -690,29 +690,39 @@ export async function runAsyncWorktreeBootstrap(
   // multi_git: register per-repo env vars and append a workspace summary.
   const subRepoWorktrees = options.subRepoWorktrees;
   if (subRepoWorktrees && subRepoWorktrees.length > 0) {
-    const repoEnv: Record<string, string> = {};
-    for (const [index, repo] of subRepoWorktrees.entries()) {
-      repoEnv[`PASEO_REPO_${index}_NAME`] = repo.name;
-      repoEnv[`PASEO_REPO_${index}_PATH`] = repo.repoPath;
-      repoEnv[`PASEO_REPO_${index}_WORKTREE_PATH`] = repo.worktreePath;
+    try {
+      const repoEnv: Record<string, string> = {};
+      for (const [index, repo] of subRepoWorktrees.entries()) {
+        repoEnv[`PASEO_REPO_${index}_NAME`] = repo.name;
+        repoEnv[`PASEO_REPO_${index}_PATH`] = repo.repoPath;
+        repoEnv[`PASEO_REPO_${index}_WORKTREE_PATH`] = repo.worktreePath;
+      }
+
+      // Register the env vars for the workspace root CWD so all terminals
+      // spawned from there pick them up.
+      options.terminalManager?.registerCwdEnv({
+        cwd: options.projectRootPath ?? options.worktree.worktreePath,
+        env: repoEnv,
+      });
+
+      // Append a system timeline item so the agent sees the sub-repo paths.
+      const repoLines = subRepoWorktrees
+        .map((repo) => `- ${repo.name}: ${repo.worktreePath}`)
+        .join("\n");
+      const summaryText = `Multi-repo workspace initialized with ${subRepoWorktrees.length} repo${subRepoWorktrees.length === 1 ? "" : "s"}:\n${repoLines}`;
+      await options.appendTimelineItem({
+        type: "user_message",
+        text: formatSystemNotificationPrompt(summaryText),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await options.appendTimelineItem({
+        type: "user_message",
+        text: formatSystemNotificationPrompt(
+          `Failed to initialize multi-repo workspace: ${message}`,
+        ),
+      });
     }
-
-    // Register the env vars for the workspace root CWD so all terminals
-    // spawned from there pick them up.
-    options.terminalManager?.registerCwdEnv({
-      cwd: options.projectRootPath ?? options.worktree.worktreePath,
-      env: repoEnv,
-    });
-
-    // Append a system timeline item so the agent sees the sub-repo paths.
-    const repoLines = subRepoWorktrees
-      .map((repo) => `- ${repo.name}: ${repo.worktreePath}`)
-      .join("\n");
-    const summaryText = `Multi-repo workspace initialized with ${subRepoWorktrees.length} repo${subRepoWorktrees.length === 1 ? "" : "s"}:\n${repoLines}`;
-    await options.appendTimelineItem({
-      type: "user_message",
-      text: formatSystemNotificationPrompt(summaryText),
-    });
   }
 }
 

--- a/packages/server/src/server/worktree-bootstrap.ts
+++ b/packages/server/src/server/worktree-bootstrap.ts
@@ -29,6 +29,7 @@ import {
   requirePlannedWorkspaceServicePort,
   refreshWorkspaceServicePort,
 } from "./workspace-service-port-registry.js";
+import { formatSystemNotificationPrompt } from "./agent/agent-prompt.js";
 
 export interface WorktreeBootstrapTerminalResult {
   name: string | null;
@@ -49,6 +50,9 @@ export interface RunAsyncWorktreeBootstrapOptions {
   /** For multi_git projects: the parent folder that contains paseo.json.
    *  When set, config is read from this path instead of worktree.worktreePath. */
   projectRootPath?: string;
+  /** For multi_git workspaces: the list of sub-repo worktrees. When present,
+   *  env vars and a timeline summary item are injected for the workspace. */
+  subRepoWorktrees?: Array<{ name: string; repoPath: string; worktreePath: string }>;
 }
 
 const MAX_WORKTREE_SETUP_COMMAND_OUTPUT_BYTES = 64 * 1024;
@@ -682,6 +686,34 @@ export async function runAsyncWorktreeBootstrap(
   }
 
   await runWorktreeTerminalBootstrap(options, runtimeEnv);
+
+  // multi_git: register per-repo env vars and append a workspace summary.
+  const subRepoWorktrees = options.subRepoWorktrees;
+  if (subRepoWorktrees && subRepoWorktrees.length > 0) {
+    const repoEnv: Record<string, string> = {};
+    for (const [index, repo] of subRepoWorktrees.entries()) {
+      repoEnv[`PASEO_REPO_${index}_NAME`] = repo.name;
+      repoEnv[`PASEO_REPO_${index}_PATH`] = repo.repoPath;
+      repoEnv[`PASEO_REPO_${index}_WORKTREE_PATH`] = repo.worktreePath;
+    }
+
+    // Register the env vars for the workspace root CWD so all terminals
+    // spawned from there pick them up.
+    options.terminalManager?.registerCwdEnv({
+      cwd: options.worktree.worktreePath,
+      env: repoEnv,
+    });
+
+    // Append a system timeline item so the agent sees the sub-repo paths.
+    const repoLines = subRepoWorktrees
+      .map((repo) => `- ${repo.name}: ${repo.worktreePath}`)
+      .join("\n");
+    const summaryText = `Multi-repo workspace initialized with ${subRepoWorktrees.length} repo${subRepoWorktrees.length === 1 ? "" : "s"}:\n${repoLines}`;
+    await options.appendTimelineItem({
+      type: "user_message",
+      text: formatSystemNotificationPrompt(summaryText),
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/server/worktree-bootstrap.ts
+++ b/packages/server/src/server/worktree-bootstrap.ts
@@ -641,7 +641,7 @@ export async function runAsyncWorktreeBootstrap(
     });
 
     setupResults = await runWorktreeSetupCommands({
-      worktreePath: options.worktree.worktreePath,
+      worktreePath: options.projectRootPath ?? options.worktree.worktreePath,
       branchName: options.worktree.branchName,
       cleanupOnFailure: false,
       runtimeEnv,
@@ -700,7 +700,7 @@ export async function runAsyncWorktreeBootstrap(
     // Register the env vars for the workspace root CWD so all terminals
     // spawned from there pick them up.
     options.terminalManager?.registerCwdEnv({
-      cwd: options.worktree.worktreePath,
+      cwd: options.projectRootPath ?? options.worktree.worktreePath,
       env: repoEnv,
     });
 

--- a/packages/server/src/server/worktree-core.ts
+++ b/packages/server/src/server/worktree-core.ts
@@ -26,6 +26,8 @@ export interface CreateWorktreeCoreInput {
   paseoHome?: string;
   worktreesRoot?: string;
   runSetup?: boolean;
+  /** If provided, create the worktree at this exact path instead of the computed paseo path. */
+  explicitWorktreePath?: string;
 }
 
 export interface CreateWorktreeCoreDeps {
@@ -113,6 +115,7 @@ export async function createWorktreeCore(
       runSetup: input.runSetup ?? true,
       paseoHome: input.paseoHome,
       worktreesRoot: input.worktreesRoot,
+      explicitWorktreePath: input.explicitWorktreePath,
     }),
     intent,
     repoRoot,

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -10,7 +10,7 @@ import {
   type WorkspaceSetupSnapshot,
   type WorkspaceDescriptorPayload,
 } from "./messages.js";
-import type { PersistedWorkspaceRecord } from "./workspace-registry.js";
+import type { PersistedWorkspaceRecord, WorkspaceRegistry } from "./workspace-registry.js";
 import type { WorkspaceGitService } from "./workspace-git-service.js";
 import {
   runAsyncWorktreeBootstrap,
@@ -438,6 +438,8 @@ export async function handlePaseoWorktreeArchiveRequest(
     emit: EmitSessionMessage;
     workspaceGitService: Pick<WorkspaceGitService, "getSnapshot" | "listWorktrees">;
     emitWorkspaceUpdatesForWorkspaceIds: (workspaceIds: Iterable<string>) => Promise<void>;
+    /** Optional registry used to look up subRepoWorktrees for multi_git workspace teardown. */
+    workspaceRegistry?: Pick<WorkspaceRegistry, "get">;
   },
   msg: Extract<SessionInboundMessage, { type: "paseo_worktree_archive_request" }>,
 ): Promise<void> {

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -610,6 +610,7 @@ export async function createPaseoWorktreeWorkflow(
         shouldBootstrap: createdWorktree.created,
         slug,
         worktreePath: createdWorktree.worktree.worktreePath,
+        projectRootPath: createdWorktree.projectRootPath,
       });
     }
   }, 0);
@@ -629,6 +630,7 @@ export async function createPaseoWorktreeWorkflow(
             emitLiveTimelineItem: (item) =>
               setupContinuation.emitLiveTimelineItem({ agentId, item }),
             logger: setupContinuation.logger,
+            projectRootPath: createdWorktree.projectRootPath,
           });
         },
       },
@@ -665,6 +667,9 @@ export async function runWorktreeSetupInBackground(
     shouldBootstrap: boolean;
     slug: string;
     worktreePath: string;
+    /** For multi_git projects: the parent folder that contains paseo.json.
+     *  When set, config is read from this path instead of worktreePath. */
+    projectRootPath?: string;
   },
 ): Promise<void> {
   let worktree: WorktreeConfig = options.worktree;
@@ -703,7 +708,8 @@ export async function runWorktreeSetupInBackground(
       if (!options.shouldBootstrap) {
         emitSetupProgress("completed", null);
       } else {
-        const setupCommands = getWorktreeSetupCommands(worktree.worktreePath);
+        const configRoot = options.projectRootPath ?? worktree.worktreePath;
+        const setupCommands = getWorktreeSetupCommands(configRoot);
         if (setupCommands.length === 0) {
           setupStarted = true;
           emitSetupProgress("completed", null);
@@ -724,6 +730,7 @@ export async function runWorktreeSetupInBackground(
             cleanupOnFailure: false,
             repoRootPath: options.repoRoot,
             runtimeEnv,
+            ...(options.projectRootPath ? { configRootPath: options.projectRootPath } : {}),
             onEvent: (event) => {
               applyWorktreeSetupProgressEvent(progressAccumulator, event);
               emitSetupProgress("running", null);

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -631,6 +631,7 @@ export async function createPaseoWorktreeWorkflow(
               setupContinuation.emitLiveTimelineItem({ agentId, item }),
             logger: setupContinuation.logger,
             projectRootPath: createdWorktree.projectRootPath,
+            subRepoWorktrees: workspace.subRepoWorktrees,
           });
         },
       },

--- a/packages/server/src/server/worktree/commands.ts
+++ b/packages/server/src/server/worktree/commands.ts
@@ -11,6 +11,8 @@ import type {
 } from "../paseo-worktree-service.js";
 import { toWorktreeWireError, type WorktreeWireError } from "../worktree-errors.js";
 import type { WorkspaceGitService, WorkspaceGitWorktreeInfo } from "../workspace-git-service.js";
+import type { WorkspaceRegistry } from "../workspace-registry.js";
+import { normalizeWorkspaceId } from "../workspace-registry-model.js";
 
 export interface ListPaseoWorktreesCommandDependencies {
   workspaceGitService: Pick<WorkspaceGitService, "listWorktrees">;
@@ -92,6 +94,8 @@ export interface ArchivePaseoWorktreeCommandDependencies extends Omit<
   "workspaceGitService"
 > {
   workspaceGitService: Pick<WorkspaceGitService, "getSnapshot" | "listWorktrees">;
+  /** Optional registry used to look up subRepoWorktrees for multi_git workspaces. */
+  workspaceRegistry?: Pick<WorkspaceRegistry, "get">;
 }
 
 export interface ArchivePaseoWorktreeCommandInput {
@@ -119,12 +123,35 @@ export async function archivePaseoWorktreeCommand(
   input: ArchivePaseoWorktreeCommandInput,
 ): Promise<ArchivePaseoWorktreeCommandResult> {
   const resolvedTarget = await resolveArchiveTarget(dependencies, input);
+
+  // For multi_git workspaces the workspace record carries subRepoWorktrees.
+  // Look it up so the archive step can clean up all sub-repo worktrees, and so
+  // we can bypass the Paseo-ownership check (workspaceRoot is not under the
+  // Paseo worktrees base root — it lives next to the project directory).
+  let subRepoWorktrees: Array<{ name: string; repoPath: string; worktreePath: string }> | undefined;
+  if (dependencies.workspaceRegistry) {
+    try {
+      const workspaceId = normalizeWorkspaceId(resolvedTarget.targetPath);
+      const workspace = await dependencies.workspaceRegistry.get(workspaceId);
+      if (workspace?.subRepoWorktrees?.length) {
+        subRepoWorktrees = workspace.subRepoWorktrees;
+      }
+    } catch {
+      // best-effort: if lookup fails, proceed without subRepoWorktrees
+    }
+  }
+
+  const isMultiGit = subRepoWorktrees !== undefined;
+
   const ownership = await isPaseoOwnedWorktreeCwd(resolvedTarget.targetPath, {
     paseoHome: dependencies.paseoHome,
     worktreesRoot: dependencies.worktreesRoot,
   });
 
-  if (!ownership.allowed) {
+  // Multi-git workspaces live outside the Paseo worktrees base root (the
+  // workspaceRoot is placed next to the project dir), so they never pass the
+  // ownership check. Allow archive if we confirmed this is a multi_git workspace.
+  if (!ownership.allowed && !isMultiGit) {
     return {
       ok: false,
       code: "NOT_ALLOWED",
@@ -134,12 +161,14 @@ export async function archivePaseoWorktreeCommand(
   }
 
   const repoRoot = ownership.repoRoot ?? resolvedTarget.repoRoot ?? null;
+
   const removedAgents = await archivePaseoWorktree(dependencies, {
     targetPath: resolvedTarget.targetPath,
     repoRoot,
     worktreesRoot: ownership.worktreeRoot,
     worktreesBaseRoot: dependencies.worktreesRoot,
     requestId: input.requestId,
+    subRepoWorktrees,
   });
 
   return {

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -2487,4 +2487,81 @@ const x = 1;
       expect(isDescendantPath("c:\\repo\\child", "C:\\repo")).toBe(true);
     });
   });
+
+  describe("multi-git sub-repo detection", () => {
+    function nativePath(p: string): string {
+      return realpathSync.native(p);
+    }
+
+    function initSubRepo(parentDir: string, name: string): string {
+      const subDir = join(parentDir, name);
+      mkdirSync(subDir, { recursive: true });
+      execFileSync("git", ["init", "-b", "main"], { cwd: subDir });
+      execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: subDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: subDir });
+      writeFileSync(join(subDir, "file.txt"), "hello\n");
+      execFileSync("git", ["add", "."], { cwd: subDir });
+      execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], {
+        cwd: subDir,
+      });
+      return subDir;
+    }
+
+    it("detects multi_git when 2 or more immediate subdirs are git repos", async () => {
+      const multiDir = join(tempDir, "multi-parent");
+      mkdirSync(multiDir, { recursive: true });
+      const sub1 = initSubRepo(multiDir, "repo-one");
+      const sub2 = initSubRepo(multiDir, "repo-two");
+
+      const status = await getCheckoutStatus(multiDir);
+
+      expect(status.isGit).toBe(false);
+      expect(status.isMultiGit).toBe(true);
+      expect(status.subRepos).toBeDefined();
+      const actualSubRepos = (status.subRepos ?? []).map(nativePath).sort();
+      const expectedSubRepos = [nativePath(sub1), nativePath(sub2)].sort();
+      expect(actualSubRepos).toEqual(expectedSubRepos);
+    });
+
+    it("does NOT detect multi_git when only 1 subdir is a git repo", async () => {
+      const singleDir = join(tempDir, "single-parent");
+      mkdirSync(singleDir, { recursive: true });
+      initSubRepo(singleDir, "only-repo");
+      mkdirSync(join(singleDir, "plain-dir"), { recursive: true });
+
+      const status = await getCheckoutStatus(singleDir);
+
+      expect(status.isGit).toBe(false);
+      expect(status.isMultiGit).toBeUndefined();
+      expect(status.subRepos).toBeUndefined();
+    });
+
+    it("does NOT detect multi_git when no subdirs are git repos", async () => {
+      const emptyParent = join(tempDir, "empty-parent");
+      mkdirSync(emptyParent, { recursive: true });
+      mkdirSync(join(emptyParent, "dir-a"), { recursive: true });
+      mkdirSync(join(emptyParent, "dir-b"), { recursive: true });
+
+      const status = await getCheckoutStatus(emptyParent);
+
+      expect(status.isGit).toBe(false);
+      expect(status.isMultiGit).toBeUndefined();
+      expect(status.subRepos).toBeUndefined();
+    });
+
+    it("skips hidden directories and node_modules when scanning for sub-repos", async () => {
+      const multiDir = join(tempDir, "multi-skip-parent");
+      mkdirSync(multiDir, { recursive: true });
+      // These should be skipped
+      initSubRepo(multiDir, ".hidden-repo");
+      initSubRepo(multiDir, "node_modules");
+      // Only one visible repo — should NOT trigger multi_git
+      initSubRepo(multiDir, "visible-repo");
+
+      const status = await getCheckoutStatus(multiDir);
+
+      expect(status.isGit).toBe(false);
+      expect(status.isMultiGit).toBeUndefined();
+    });
+  });
 });

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1,6 +1,6 @@
 import { resolve, dirname, basename } from "path";
 import { existsSync, realpathSync } from "fs";
-import { open as openFile, readFile, stat as statFile } from "fs/promises";
+import { open as openFile, readFile, stat as statFile, readdir } from "fs/promises";
 import { TTLCache } from "@isaacs/ttlcache";
 import type { Logger } from "pino";
 import type { ParsedDiffFile } from "../server/utils/diff-highlighter.js";
@@ -718,6 +718,8 @@ export interface AheadBehind {
 
 export interface CheckoutStatus {
   isGit: false;
+  isMultiGit?: boolean;
+  subRepos?: string[];
 }
 
 export interface CheckoutStatusGitNonPaseo {
@@ -1731,12 +1733,54 @@ async function getUntrackedDiffText(
   };
 }
 
+async function discoverSubRepos(dir: string): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const subdirs: string[] = [];
+  for (const name of entries) {
+    if (name.startsWith(".") || name === "node_modules") {
+      continue;
+    }
+    const full = resolve(dir, name);
+    try {
+      const s = await statFile(full);
+      if (s.isDirectory()) {
+        subdirs.push(full);
+      }
+    } catch {
+      // skip unreadable entries
+    }
+  }
+
+  const results = await Promise.all(
+    subdirs.map(async (subdir): Promise<string | null> => {
+      try {
+        await statFile(resolve(subdir, ".git"));
+        return subdir;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return results.filter((p): p is string => p !== null);
+}
+
 export async function getCheckoutStatus(
   cwd: string,
   context?: CheckoutContext,
 ): Promise<CheckoutStatusResult> {
   const facts = await getCheckoutSnapshotFacts(cwd, context);
   if (!facts.isGit) {
+    const subRepos = await discoverSubRepos(cwd);
+    if (subRepos.length >= 2) {
+      return { isGit: false, isMultiGit: true, subRepos };
+    }
     return { isGit: false };
   }
 

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1768,7 +1768,7 @@ async function discoverSubRepos(dir: string): Promise<string[]> {
     }),
   );
 
-  return results.filter((p): p is string => p !== null);
+  return results.filter((p): p is string => p !== null).sort();
 }
 
 export async function getCheckoutStatus(

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -590,11 +590,17 @@ export async function runWorktreeSetupCommands(options: {
   branchName: string;
   cleanupOnFailure: boolean;
   repoRootPath?: string;
+  /** For multi_git projects, the parent folder containing all sub-repos. When
+   *  provided, paseo.json is read from this path instead of worktreePath. */
+  configRootPath?: string;
   runtimeEnv?: WorktreeRuntimeEnv;
   onEvent?: (event: WorktreeSetupCommandProgressEvent) => void;
 }): Promise<WorktreeSetupCommandResult[]> {
-  // Read paseo.json from the worktree (it will have the same content as the source repo)
-  const setupCommands = getWorktreeSetupCommands(options.worktreePath);
+  // For multi_git projects paseo.json lives in the project root (parent folder),
+  // not in the individual sub-repo worktree. Fall back to worktreePath for
+  // standard git projects.
+  const configRoot = options.configRootPath ?? options.worktreePath;
+  const setupCommands = getWorktreeSetupCommands(configRoot);
   if (setupCommands.length === 0) {
     return [];
   }

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -175,6 +175,8 @@ export interface CreateWorktreeOptions {
   runSetup: boolean;
   paseoHome?: string;
   worktreesRoot?: string;
+  /** If provided, use this exact path for the worktree instead of the computed paseo path. */
+  explicitWorktreePath?: string;
 }
 
 interface ResolveExistingWorktreeForSlugOptions {
@@ -1180,9 +1182,12 @@ export const createWorktree = async ({
   runSetup,
   paseoHome,
   worktreesRoot,
+  explicitWorktreePath,
 }: CreateWorktreeOptions): Promise<WorktreeConfig> => {
   const sourcePlan = await resolveWorktreeSourcePlan({ cwd, source, desiredSlug: worktreeSlug });
-  let worktreePath = join(await getPaseoWorktreesRoot(cwd, paseoHome, worktreesRoot), worktreeSlug);
+  let worktreePath = explicitWorktreePath
+    ? explicitWorktreePath
+    : join(await getPaseoWorktreesRoot(cwd, paseoHome, worktreesRoot), worktreeSlug);
   mkdirSync(dirname(worktreePath), { recursive: true });
 
   // Also handle worktree path collision

--- a/packages/website/public/schemas/paseo.config.v1.json
+++ b/packages/website/public/schemas/paseo.config.v1.json
@@ -147,6 +147,51 @@
           },
           "additionalProperties": false
         },
+        "worktree": {
+          "description": "Per-project worktree lifecycle hooks, defined in each project's paseo.json. For multi-repo projects (multi_git), the workspace root contains all sub-repo worktrees as named subdirectories matching their original folder names.",
+          "type": "object",
+          "properties": {
+            "setup": {
+              "description": "Shell command(s) to run after a worktree is created. For single-repo projects, runs from the worktree root. For multi-repo projects, runs from the workspace root that contains each sub-repo as a named subdirectory — e.g. \"cd frontend && npm install\" or \"cd backend && pip install -r requirements.txt\".",
+              "examples": [
+                "npm ci",
+                "cd frontend && npm install",
+                "cd backend && pip install -r requirements.txt"
+              ],
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "teardown": {
+              "description": "Shell command(s) to run before a worktree is deleted. For single-repo projects, runs from the worktree root. For multi-repo projects, runs from the workspace root that contains each sub-repo as a named subdirectory.",
+              "examples": [
+                "docker compose down",
+                "cd frontend && rm -rf node_modules",
+                "cd backend && deactivate"
+              ],
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            }
+          },
+          "additionalProperties": true
+        },
         "providers": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
## Summary

- Adds a new `multi_git` project kind: when a parent folder containing 2+ git repos is added to Paseo, it is detected and stored as a multi-repo project
- On workspace creation, git worktrees for **all sub-repos** are created as named subdirectories inside a shared workspace root (`<project>-workspaces/<branch>/frontend/`, `.../backend/`, etc.)
- `worktree.setup` / `teardown` in `paseo.json` run **once from the workspace root**, so scripts like `cd frontend && npm install` and `cd backend && pip install -r requirements.txt` work naturally
- Agent gets `PASEO_REPO_N_NAME` / `PASEO_REPO_N_PATH` / `PASEO_REPO_N_WORKTREE_PATH` env vars and a timeline item listing all repo paths at session start
- Full teardown on archive: runs teardown script, `git worktree remove` for each sub-repo, removes workspace root directory

## UI Changes

- **Project add**: confirmation step when a multi-repo folder is detected ("Found 2 git repos: frontend · backend — add as multi-repo project?")
- **Project settings**: new "Repositories" section showing each sub-repo with a Re-scan button
- **Sidebar**: sub-repo names displayed as a subtitle under the project name ("frontend · backend")

## How it works

```
~/my-app/           ← add this folder as a project
  frontend/         ← git repo
  backend/          ← git repo

# On workspace create:
~/my-app-workspaces/
  feature-auth/     ← workspaceRoot (cwd for setup script)
    frontend/       ← worktree
    backend/        ← worktree
```

```json
// paseo.json at ~/my-app/
{
  "worktree": {
    "setup": [
      "cd frontend && npm install",
      "cd backend && pip install -r requirements.txt"
    ]
  }
}
```

## Test Plan

- [ ] Add a folder with 2 git sub-repos → confirmation dialog appears with both repo names
- [ ] Confirm → workspace created, both worktrees exist at `<project>-workspaces/<branch>/frontend/` and `.../backend/`
- [ ] Terminal in workspace has `PASEO_REPO_0_*` and `PASEO_REPO_1_*` env vars
- [ ] Agent session timeline lists both worktree paths
- [ ] `worktree.setup` with `cd frontend && ...` runs successfully from workspace root
- [ ] Archive workspace → both worktrees pruned, workspace root removed
- [ ] Project settings → Repositories section shows both repos, Re-scan refreshes list
- [ ] Existing single-repo projects — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)