### PR TITLE
Accept inline skill autocomplete in the composer

### DIFF
--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -440,9 +440,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
           command: activeSlashCommand,
           commandName: selected.id,
         });
-        const shouldAppendSpace =
-          activeSlashCommand.position === "start" && activeSlashCommand.end === userInput.length;
-        setUserInput(shouldAppendSpace ? `${nextInput} ` : nextInput);
+        setUserInput(nextInput);
         onAutocompleteApplied?.();
         return;
       }

--- a/packages/app/src/utils/agent-command-autocomplete.test.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.test.ts
@@ -95,6 +95,30 @@ describe("applySlashCommandReplacement", () => {
       }),
     ).toBe("use /taste before implementation");
   });
+
+  it("commits an inline slash token at the prompt tail", () => {
+    const text = "use /tas";
+
+    expect(
+      applySlashCommandReplacement({
+        text,
+        command: { start: 4, end: text.length, query: "tas", position: "inline" },
+        commandName: "taste",
+      }),
+    ).toBe("use /taste ");
+  });
+
+  it("commits a start slash token at the prompt tail", () => {
+    const text = "/tas";
+
+    expect(
+      applySlashCommandReplacement({
+        text,
+        command: { start: 0, end: text.length, query: "tas", position: "start" },
+        commandName: "taste",
+      }),
+    ).toBe("/taste ");
+  });
 });
 
 describe("filterInlineSkillCommandEntries", () => {

--- a/packages/app/src/utils/agent-command-autocomplete.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.ts
@@ -115,5 +115,6 @@ export function findActiveSlashCommand(
 export function applySlashCommandReplacement(input: ApplySlashCommandReplacementInput): string {
   const before = input.text.slice(0, input.command.start);
   const after = input.text.slice(input.command.end);
-  return `${before}/${input.commandName}${after}`;
+  const replacement = `${before}/${input.commandName}${after}`;
+  return input.command.end === input.text.length ? `${replacement} ` : replacement;
 }


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Skill autocomplete now accepts slash commands when the slash token is in the middle of a prompt. Pressing Enter on an inline skill suggestion replaces the partial token, adds the same trailing space as start-of-prompt autocomplete, hides the popover, and leaves the draft ready for more typing.

### How did you verify it

- Added a red regression test for committing an inline `/tas` token at the prompt tail, then confirmed it passes.
- Ran `npx vitest run packages/app/src/utils/agent-command-autocomplete.test.ts --bail=1`.
- Ran `npm run format`.
- Ran `npm run typecheck`.
- Ran `npm run lint -- packages/app/src/hooks/use-agent-autocomplete.ts packages/app/src/utils/agent-command-autocomplete.ts packages/app/src/utils/agent-command-autocomplete.test.ts`.
- Smoked the web composer: typed `please /ta`, pressed Enter, and observed the draft become `please /taste ` without submitting.

### Risk surface

Composer autocomplete is shared app UI. Local smoke covered web; native selection should be quick to spot-check if this path is release-blocking on mobile.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense