### PR TITLE
feat(app,desktop): add notification sound when agent tasks complete

### DIFF
--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -48,6 +48,8 @@ import { useDraftStore } from "@/stores/draft-store";
 import { useWorkspaceSetupStore } from "@/stores/workspace-setup-store";
 import { sendOsNotification } from "@/utils/os-notifications";
 import { getIsAppActivelyVisible } from "@/utils/app-visibility";
+import { playNotificationSound } from "@/utils/notification-sound";
+import { useAppSettings } from "@/hooks/use-settings";
 import {
   getInitKey,
   getInitDeferred,
@@ -821,6 +823,8 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
   useClientActivity({ client, focusedAgentId, focusedTerminalId, onAppResumed: handleAppResumed });
   usePushTokenRegistration({ client, serverId });
 
+  const { settings } = useAppSettings();
+
   const notifyAgentAttention = useCallback(
     (params: {
       agentId: string;
@@ -868,8 +872,12 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
         body: notification.body,
         data: notification.data,
       });
+
+      if (settings.notificationSound) {
+        playNotificationSound();
+      }
     },
-    [serverId],
+    [serverId, settings.notificationSound],
   );
 
   // Initialize session in store
@@ -1670,6 +1678,10 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
           ...(message.payload.workspaceId ? { workspaceId: message.payload.workspaceId } : {}),
         },
       });
+
+      if (settings.notificationSound) {
+        playNotificationSound();
+      }
     });
 
     return () => {

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -36,6 +36,7 @@ export interface AppSettings {
   uiFontSize: number; // clamped px, default 16
   codeFontSize: number; // clamped px, default 12
   syntaxTheme: SyntaxThemeId; // default "one"
+  notificationSound: boolean;
 }
 
 export interface Settings extends AppSettings {
@@ -54,6 +55,7 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   uiFontSize: DEFAULT_UI_FONT_SIZE,
   codeFontSize: DEFAULT_CODE_FONT_SIZE,
   syntaxTheme: "one",
+  notificationSound: true,
 };
 
 export const DEFAULT_APP_SETTINGS: Settings = {
@@ -193,6 +195,9 @@ function pickAppSettings(stored: Partial<AppSettings>): Partial<AppSettings> {
   }
   if (typeof stored.syntaxTheme === "string" && isSyntaxThemeId(stored.syntaxTheme)) {
     result.syntaxTheme = stored.syntaxTheme;
+  }
+  if (typeof stored.notificationSound === "boolean") {
+    result.notificationSound = stored.notificationSound;
   }
   return result;
 }

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1412,6 +1412,10 @@ export const ar: TranslationResources = {
           zhCN: "中文",
         },
       },
+      notificationSound: {
+        label: "صوت الإشعار",
+        description: "تشغيل نغمة عند انتهاء الوكيل أثناء تشغيل Paseo في الخلفية",
+      },
     },
     diagnostics: {
       title: "التشخيص",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1417,6 +1417,10 @@ export const en = {
           zhCN: "Simplified Chinese",
         },
       },
+      notificationSound: {
+        label: "Notification sound",
+        description: "Play a chime when an agent finishes while Paseo is in the background",
+      },
     },
     diagnostics: {
       title: "Diagnostics",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1448,6 +1448,10 @@ export const es: TranslationResources = {
           zhCN: "中文",
         },
       },
+      notificationSound: {
+        label: "Sonido de notificación",
+        description: "Reproducir un sonido cuando un agente termine mientras Paseo está en segundo plano",
+      },
     },
     diagnostics: {
       title: "Diagnóstico",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1451,6 +1451,10 @@ export const fr: TranslationResources = {
           zhCN: "中文",
         },
       },
+      notificationSound: {
+        label: "Son de notification",
+        description: "Émettre un son lorsqu'un agent termine alors que Paseo est en arrière-plan",
+      },
     },
     diagnostics: {
       title: "Diagnostic",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1438,6 +1438,10 @@ export const ru: TranslationResources = {
           zhCN: "中文",
         },
       },
+      notificationSound: {
+        label: "Звук уведомления",
+        description: "Воспроизводить звуковой сигнал при завершении агента, когда Paseo работает в фоновом режиме",
+      },
     },
     diagnostics: {
       title: "Диагностика",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1394,6 +1394,10 @@ export const zhCN: TranslationResources = {
           zhCN: "简体中文",
         },
       },
+      notificationSound: {
+        label: "通知提示音",
+        description: "当 Paseo 在后台运行且 Agent 完成任务时播放提示音",
+      },
     },
     diagnostics: {
       title: "诊断",

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -78,6 +78,7 @@ import { KeyboardShortcutsSection } from "@/screens/settings/keyboard-shortcuts-
 import { Button } from "@/components/ui/button";
 import { CommunityLinks } from "@/components/community-links";
 import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Switch } from "@/components/ui/switch";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -255,6 +256,7 @@ interface GeneralSectionProps {
   handleServiceUrlBehaviorChange: (behavior: ServiceUrlBehavior) => void;
   handleLanguageChange: (language: AppLanguage) => void;
   handleTerminalScrollbackLinesChange: (lines: number) => void;
+  handleNotificationSoundChange: (value: boolean) => void;
 }
 
 interface ServiceUrlBehaviorMenuItemProps {
@@ -311,6 +313,7 @@ function GeneralSection({
   handleServiceUrlBehaviorChange,
   handleLanguageChange,
   handleTerminalScrollbackLinesChange,
+  handleNotificationSoundChange,
 }: GeneralSectionProps) {
   const { theme } = useUnistyles();
   const { t, i18n } = useTranslation();
@@ -446,6 +449,21 @@ function GeneralSection({
             selectTextOnFocus
             style={styles.terminalScrollbackInput}
             accessibilityLabel={t("settings.general.terminalScrollback.accessibilityLabel")}
+          />
+        </View>
+        <View style={ROW_WITH_BORDER_STYLE}>
+          <View style={settingsStyles.rowContent}>
+            <Text style={settingsStyles.rowTitle}>
+              {t("settings.general.notificationSound.label")}
+            </Text>
+            <Text style={settingsStyles.rowHint}>
+              {t("settings.general.notificationSound.description")}
+            </Text>
+          </View>
+          <Switch
+            value={settings.notificationSound}
+            onValueChange={handleNotificationSoundChange}
+            accessibilityLabel={t("settings.general.notificationSound.label")}
           />
         </View>
       </View>
@@ -1317,6 +1335,13 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
     [updateSettings],
   );
 
+  const handleNotificationSoundChange = useCallback(
+    (notificationSound: boolean) => {
+      void updateSettings({ notificationSound });
+    },
+    [updateSettings],
+  );
+
   const handlePlaybackTest = useCallback(async () => {
     if (!voiceAudioEngine || isPlaybackTestRunning) {
       return;
@@ -1518,6 +1543,7 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
               handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
               handleLanguageChange={handleLanguageChange}
               handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
+              handleNotificationSoundChange={handleNotificationSoundChange}
             />
           );
         case "daemon":

--- a/packages/app/src/utils/notification-sound.ts
+++ b/packages/app/src/utils/notification-sound.ts
@@ -1,0 +1,75 @@
+/**
+ * Plays a short notification chime using the Web Audio API.
+ *
+ * Generates a 3-note ascending arpeggio (C5 → E5 → G5) over ~500ms.
+ * Gracefully no-ops in environments without `window.AudioContext` (SSR, native mobile).
+ * Uses a lazily-initialized singleton AudioContext to avoid hitting browser
+ * concurrent-context limits and to inherit the "allowed to play" state from
+ * prior user interaction.
+ */
+
+let cachedContext: AudioContext | null = null;
+let contextFailed = false;
+
+function getAudioContext(): AudioContext | null {
+  if (contextFailed) return null;
+  if (cachedContext) return cachedContext;
+
+  if (typeof window === "undefined") return null;
+  const AudioContextCtor =
+    window.AudioContext ??
+    ((window as Record<string, unknown>).webkitAudioContext as typeof AudioContext | undefined);
+  if (!AudioContextCtor) return null;
+
+  try {
+    cachedContext = new AudioContextCtor();
+  } catch {
+    contextFailed = true;
+    return null;
+  }
+
+  return cachedContext;
+}
+
+export function playNotificationSound(): void {
+  const ctx = getAudioContext();
+  if (!ctx) return;
+
+  // Ensure the context is running (handle autoplay policy). Fire-and-forget:
+  // if resume fails the scheduled notes simply won't be audible.
+  const scheduleChime = (): void => {
+    try {
+      const notes = [523.25, 659.25, 783.99]; // C5, E5, G5
+      const noteDuration = 0.15;
+      const gap = 0.02;
+      const now = ctx.currentTime;
+      const masterGain = ctx.createGain();
+      masterGain.gain.value = 0.3;
+      masterGain.connect(ctx.destination);
+
+      for (let i = 0; i < notes.length; i++) {
+        const osc = ctx.createOscillator();
+        const noteGain = ctx.createGain();
+        osc.type = "sine";
+        osc.frequency.value = notes[i];
+        const startTime = now + i * (noteDuration + gap);
+        noteGain.gain.setValueAtTime(0, startTime);
+        noteGain.gain.linearRampToValueAtTime(0.3, startTime + 0.01);
+        noteGain.gain.setValueAtTime(0.3, startTime + noteDuration - 0.03);
+        noteGain.gain.linearRampToValueAtTime(0, startTime + noteDuration);
+        osc.connect(noteGain);
+        noteGain.connect(masterGain);
+        osc.start(startTime);
+        osc.stop(startTime + noteDuration);
+      }
+    } catch {
+      // Best-effort: silently ignore failures
+    }
+  };
+
+  if (ctx.state === "suspended") {
+    ctx.resume().then(scheduleChime).catch(() => {});
+  } else {
+    scheduleChime();
+  }
+}


### PR DESCRIPTION
## Summary

Adds an audio notification (chime) when agent tasks complete, so you can hear when your AI agent finishes working — especially useful when Paseo is in a background tab.

The sound is a pleasant 3-note ascending chime (C5→E5→G5) played via the Web Audio API. A singleton `AudioContext` is lazily initialized on first use and reused — avoiding browser concurrent-context limits and inheriting the "allowed to play" state from prior user interaction. Browser autoplay policy is handled by awaiting `ctx.resume()` when the context is suspended.

## Changes

- **New `packages/app/src/utils/notification-sound.ts`** — Web Audio API chime generator with lazy singleton `AudioContext`, proper `resume()` handling, and concurrent-call safety
- **`packages/app/src/hooks/use-settings/storage.ts`** — Add `notificationSound` boolean field (default `true`) + validation
- **`packages/app/src/contexts/session-context.tsx`** — Wire `playNotificationSound()` into **both** attention paths:
  1. `notifyAgentAttention()` — for agent-window agents (`agent_stream/attention_required`)
  2. `terminal_attention_required` handler — for terminal-based agents (Claude Code in terminal)
- **`packages/app/src/screens/settings-screen.tsx`** — Add `Switch` toggle in Settings > General
- **`packages/app/src/i18n/resources/*.ts`** (6 files) — Translations for en, zh-CN, ar, es, fr, ru

## How it works

```
Agent/terminal finishes or needs input
  → Server sends attention_required / terminal_attention_required WebSocket event
  → Client receives it, checks: is user away? is sound enabled?
  → Plays ascending chime + sends OS notification
```

Sound is **automatically suppressed** when the user is actively watching the agent. The "Notification sound" toggle in Settings > General provides a global opt-out.

## Visual indicator on workspace node

For terminal-based Claude Code agents, the workspace node in the sidebar already shows the appropriate visual indicator (amber `CircleAlert` for needs-input, green dot for attention, blue dot for running) — this flows through the existing `deriveAgentStateBucket` → workspace row rendering pipeline and works for all agent types.

## Review addressals

- **P1 (desktop `silent` bypasses toggle)**: Fixed — reverted `silent: false` back to `silent: true`. The Web Audio chime is now the sole notification sound, uniformly controlled by the `notificationSound` setting across all platforms.
- **P2 (AudioContext not awaited)**: Fixed — singleton `AudioContext` is lazily initialized once and reused. When suspended, `resume()` is properly awaited before scheduling notes.
- **P2 (no guard against concurrent calls)**: Fixed — singleton context eliminates the issue.

## Test plan

1. Open Paseo in browser → start an agent → switch to another tab → hear ascending chime on completion
2. Terminal-based Claude Code → `terminal_attention_required` → hear ascending chime
3. Disable "Notification sound" in Settings → no chime (both paths)
4. Keep Paseo tab focused → agent finishes → no chime (user is watching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)