### PR TITLE
feat(app): enhance workspace tab selection display with accent indicator

### DIFF
--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -1343,6 +1343,7 @@ function ProjectHeaderRow({
           <SidebarWorkspaceShortcutBadge number={shortcutNumber} />
         </View>
       ) : null}
+      {selected && <View style={styles.sidebarSelectedAccent} />}
     </>
   );
 
@@ -1501,6 +1502,7 @@ function WorkspaceRowInner({
                   onRename={onRename}
                 />
               </SidebarWorkspaceRowContent>
+              {selected && <View style={styles.sidebarSelectedAccent} />}
             </Pressable>
           </View>
         );
@@ -3056,6 +3058,15 @@ const styles = StyleSheet.create((theme) => ({
   },
   sidebarRowSelected: {
     backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  sidebarSelectedAccent: {
+    position: "absolute",
+    right: 0,
+    top: theme.spacing[1],
+    bottom: theme.spacing[1],
+    width: 3,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.accent,
   },
   workspaceRowContainer: {
     position: "relative",

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -656,6 +656,7 @@ function StatusWorkspaceRowInner({
                   />
                 ) : null}
               </SidebarWorkspaceRowContent>
+              {selected && <View style={styles.sidebarSelectedAccent} />}
             </Pressable>
           </View>
         );
@@ -921,6 +922,15 @@ const styles = StyleSheet.create((theme) => ({
   },
   sidebarRowSelected: {
     backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  sidebarSelectedAccent: {
+    position: "absolute",
+    right: 0,
+    top: theme.spacing[1],
+    bottom: theme.spacing[1],
+    width: 3,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.accent,
   },
   kebabButton: {
     padding: 2,


### PR DESCRIPTION
## Summary

Enhance the visual display of selected workspace/session tabs in the sidebar by adding a 3px accent-colored vertical indicator bar on the right side of the selected row.

## Problem

Currently, the selected state (`sidebarRowSelected`) and hover state (`workspaceRowHovered`) use the **same** background color (`surfaceSidebarHover`), making it impossible for users to visually distinguish between hovering over a workspace and having it selected.

## Solution

Add a right-side accent indicator bar (matching the `tabFocusIndicator` pattern from desktop workspace tabs) that appears only when a workspace row is **selected**:

| State | Before | After |
|-------|--------|-------|
| Default | Transparent | No change |
| Hover | Gray background | No change |
| **Selected** | Gray background (same as hover) | Gray background + **right-side accent bar** |

The accent color uses `theme.colors.accent`, which adapts to the user's appearance theme configuration.

## Changes

- **`sidebar-workspace-list.tsx`**: Add accent indicator to `WorkspaceRowInner` and `ProjectHeaderRow` components
- **`sidebar-status-list.tsx`**: Add accent indicator to `StatusWorkspaceRowInner` component

🤖 Generated with [Claude Code](https://claude.com/claude-code)