### PR TITLE
Bound retained workspace screens

### DIFF
--- a/packages/app/e2e/helpers/startup-dsl.ts
+++ b/packages/app/e2e/helpers/startup-dsl.ts
@@ -139,17 +139,18 @@ class StartupAssertions {
     this.page = page;
   }
 
-  async expectsReconnectWelcome(): Promise<this> {
-    await expect(this.page.getByTestId("welcome-screen")).toBeVisible({ timeout: 15_000 });
-    await expect(this.page.getByTestId("welcome-open-settings")).toBeVisible();
-    await expect(this.page.getByTestId("welcome-direct-connection")).toBeVisible();
-    await expect(this.page.getByTestId("welcome-paste-pairing-link")).toBeVisible();
-    await expect(this.page.getByTestId("welcome-scan-qr")).toHaveCount(0);
+  async expectsSavedHostShell(input: { label: string }): Promise<this> {
+    await expect(this.page.getByText(input.label, { exact: true })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(this.page.getByRole("button", { name: "Add project" })).toBeVisible();
+    await expect(this.page.getByRole("button", { name: "Home" })).toBeVisible();
+    await expect(this.page.getByRole("button", { name: "Settings" })).toBeVisible();
+    await expect(this.page.getByTestId("welcome-screen")).toHaveCount(0);
     return this;
   }
 
-  async expectsNoSavedHostStatus(input: { label: string }): Promise<this> {
-    await expect(this.page.getByText(input.label, { exact: true })).toHaveCount(0);
+  async expectsNoSavedHostErrorStatus(): Promise<this> {
     await expect(this.page.getByText("Connection error", { exact: true })).toHaveCount(0);
     await expect(this.page.getByText("Offline", { exact: true })).toHaveCount(0);
     return this;

--- a/packages/app/e2e/startup-loading.spec.ts
+++ b/packages/app/e2e/startup-loading.spec.ts
@@ -4,7 +4,7 @@ import { getServerId } from "./helpers/server-id";
 import { startupScenario } from "./helpers/startup-dsl";
 
 test.describe("Startup loading presentation", () => {
-  test("mobile reconnect keeps connection recovery actions visible", async ({ page }) => {
+  test("mobile reconnect preserves the saved host shell", async ({ page }) => {
     const startup = await startupScenario(page)
       .withMobileViewport()
       .withSavedHost({
@@ -14,8 +14,8 @@ test.describe("Startup loading presentation", () => {
       })
       .openRoot();
 
-    await startup.expectsReconnectWelcome();
-    await startup.expectsNoSavedHostStatus({ label: "Dev" });
+    await startup.expectsSavedHostShell({ label: "Dev" });
+    await startup.expectsNoSavedHostErrorStatus();
     await startup.expectsNoLocalServerStartupCopy();
   });
 

--- a/packages/app/src/app/h/[serverId]/workspace/[workspaceId]/index.tsx
+++ b/packages/app/src/app/h/[serverId]/workspace/[workspaceId]/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { StyleSheet, View } from "react-native";
 import { useGlobalSearchParams, useLocalSearchParams, useRootNavigationState } from "expo-router";
@@ -7,7 +7,7 @@ import {
   type ActiveWorkspaceSelection,
   useActiveWorkspaceSelection,
 } from "@/stores/navigation-active-workspace-store";
-import { useSessionStore } from "@/stores/session-store";
+import { useHasHydratedWorkspaces, useWorkspaceExists } from "@/stores/session-store-hooks";
 import type { WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
 import { WorkspaceScreen } from "@/screens/workspace/workspace-screen";
 import { useWorkspaceLayoutStoreHydrated } from "@/stores/workspace-layout-store";
@@ -16,6 +16,7 @@ import {
   areWorkspaceSelectionsEqual,
   getWorkspaceSelectionKey,
   pruneMountedWorkspaceSelections,
+  shouldKeepWorkspaceDeckEntryMounted,
   WORKSPACE_DECK_MAX_MOUNTED_WORKSPACES,
 } from "@/screens/workspace/workspace-deck-retention";
 import {
@@ -24,7 +25,6 @@ import {
   type WorkspaceOpenIntent,
 } from "@/utils/host-routes";
 import { prepareWorkspaceTab } from "@/utils/workspace-navigation";
-import { resolveWorkspaceMapKeyByIdentity } from "@/utils/workspace-execution";
 import { isWeb } from "@/constants/platform";
 
 function getParamValue(value: string | string[] | undefined): string {
@@ -163,16 +163,16 @@ function HostWorkspaceRouteContent() {
 
 function WorkspaceDeck() {
   const activeSelection = useActiveWorkspaceSelection();
-  const activeServerId = activeSelection?.serverId ?? null;
-  const workspaces = useSessionStore((state) =>
-    activeServerId ? state.sessions[activeServerId]?.workspaces : undefined,
-  );
-  const hasHydratedWorkspaces = useSessionStore((state) =>
-    activeServerId ? (state.sessions[activeServerId]?.hasHydratedWorkspaces ?? false) : false,
-  );
   const [mountedSelections, setMountedSelections] = useState<ActiveWorkspaceSelection[]>(() =>
     activeSelection ? [activeSelection] : [],
   );
+  const unmountWorkspaceSelection = useCallback((selection: ActiveWorkspaceSelection) => {
+    setMountedSelections((current) =>
+      current.filter(
+        (mountedSelection) => !areWorkspaceSelectionsEqual(mountedSelection, selection),
+      ),
+    );
+  }, []);
 
   useEffect(() => {
     setMountedSelections((current) => {
@@ -180,25 +180,13 @@ function WorkspaceDeck() {
         currentSelections: current,
         activeSelection,
         maxMountedWorkspaces: WORKSPACE_DECK_MAX_MOUNTED_WORKSPACES,
-        shouldPruneInactiveSelections: hasHydratedWorkspaces,
-        canRetainInactiveSelection: (selection) => {
-          if (selection.serverId !== activeServerId) {
-            return false;
-          }
-          return Boolean(
-            resolveWorkspaceMapKeyByIdentity({
-              workspaces,
-              workspaceId: selection.workspaceId,
-            }),
-          );
-        },
       });
       if (areWorkspaceSelectionListsEqual(current, next)) {
         return current;
       }
       return next;
     });
-  }, [activeSelection, activeServerId, hasHydratedWorkspaces, workspaces]);
+  }, [activeSelection]);
 
   if (!activeSelection) {
     return null;
@@ -207,21 +195,57 @@ function WorkspaceDeck() {
   return (
     <View style={styles.deck}>
       {mountedSelections.map((selection) => {
-        const isActive = areWorkspaceSelectionsEqual(selection, activeSelection);
         return (
-          <View
+          <WorkspaceDeckEntry
             key={getWorkspaceSelectionKey(selection)}
-            style={isActive ? styles.activeDeckEntry : styles.inactiveDeckEntry}
-            testID={`workspace-deck-entry-${selection.serverId}:${selection.workspaceId}`}
-          >
-            <WorkspaceScreen
-              serverId={selection.serverId}
-              workspaceId={selection.workspaceId}
-              isRouteFocused={isActive}
-            />
-          </View>
+            selection={selection}
+            activeSelection={activeSelection}
+            onUnmountInactive={unmountWorkspaceSelection}
+          />
         );
       })}
+    </View>
+  );
+}
+
+function WorkspaceDeckEntry({
+  selection,
+  activeSelection,
+  onUnmountInactive,
+}: {
+  selection: ActiveWorkspaceSelection;
+  activeSelection: ActiveWorkspaceSelection;
+  onUnmountInactive: (selection: ActiveWorkspaceSelection) => void;
+}) {
+  const isActive = areWorkspaceSelectionsEqual(selection, activeSelection);
+  const hasHydratedWorkspaces = useHasHydratedWorkspaces(selection.serverId);
+  const workspaceExists = useWorkspaceExists(selection.serverId, selection.workspaceId);
+  const shouldKeepMounted = shouldKeepWorkspaceDeckEntryMounted({
+    isActive,
+    hasHydratedWorkspaces,
+    workspaceExists,
+  });
+
+  useEffect(() => {
+    if (!shouldKeepMounted) {
+      onUnmountInactive(selection);
+    }
+  }, [onUnmountInactive, selection, shouldKeepMounted]);
+
+  if (!shouldKeepMounted) {
+    return null;
+  }
+
+  return (
+    <View
+      style={isActive ? styles.activeDeckEntry : styles.inactiveDeckEntry}
+      testID={`workspace-deck-entry-${selection.serverId}:${selection.workspaceId}`}
+    >
+      <WorkspaceScreen
+        serverId={selection.serverId}
+        workspaceId={selection.workspaceId}
+        isRouteFocused={isActive}
+      />
     </View>
   );
 }

--- a/packages/app/src/app/h/[serverId]/workspace/[workspaceId]/index.tsx
+++ b/packages/app/src/app/h/[serverId]/workspace/[workspaceId]/index.tsx
@@ -7,15 +7,24 @@ import {
   type ActiveWorkspaceSelection,
   useActiveWorkspaceSelection,
 } from "@/stores/navigation-active-workspace-store";
+import { useSessionStore } from "@/stores/session-store";
 import type { WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
 import { WorkspaceScreen } from "@/screens/workspace/workspace-screen";
 import { useWorkspaceLayoutStoreHydrated } from "@/stores/workspace-layout-store";
+import {
+  areWorkspaceSelectionListsEqual,
+  areWorkspaceSelectionsEqual,
+  getWorkspaceSelectionKey,
+  pruneMountedWorkspaceSelections,
+  WORKSPACE_DECK_MAX_MOUNTED_WORKSPACES,
+} from "@/screens/workspace/workspace-deck-retention";
 import {
   decodeWorkspaceIdFromPathSegment,
   parseWorkspaceOpenIntent,
   type WorkspaceOpenIntent,
 } from "@/utils/host-routes";
 import { prepareWorkspaceTab } from "@/utils/workspace-navigation";
+import { resolveWorkspaceMapKeyByIdentity } from "@/utils/workspace-execution";
 import { isWeb } from "@/constants/platform";
 
 function getParamValue(value: string | string[] | undefined): string {
@@ -152,30 +161,44 @@ function HostWorkspaceRouteContent() {
   return <WorkspaceDeck />;
 }
 
-function areWorkspaceSelectionsEqual(
-  left: ActiveWorkspaceSelection | null,
-  right: ActiveWorkspaceSelection | null,
-): boolean {
-  return left?.serverId === right?.serverId && left?.workspaceId === right?.workspaceId;
-}
-
 function WorkspaceDeck() {
   const activeSelection = useActiveWorkspaceSelection();
+  const activeServerId = activeSelection?.serverId ?? null;
+  const workspaces = useSessionStore((state) =>
+    activeServerId ? state.sessions[activeServerId]?.workspaces : undefined,
+  );
+  const hasHydratedWorkspaces = useSessionStore((state) =>
+    activeServerId ? (state.sessions[activeServerId]?.hasHydratedWorkspaces ?? false) : false,
+  );
   const [mountedSelections, setMountedSelections] = useState<ActiveWorkspaceSelection[]>(() =>
     activeSelection ? [activeSelection] : [],
   );
 
   useEffect(() => {
-    if (!activeSelection) {
-      return;
-    }
     setMountedSelections((current) => {
-      if (current.some((selection) => areWorkspaceSelectionsEqual(selection, activeSelection))) {
+      const next = pruneMountedWorkspaceSelections({
+        currentSelections: current,
+        activeSelection,
+        maxMountedWorkspaces: WORKSPACE_DECK_MAX_MOUNTED_WORKSPACES,
+        shouldPruneInactiveSelections: hasHydratedWorkspaces,
+        canRetainInactiveSelection: (selection) => {
+          if (selection.serverId !== activeServerId) {
+            return false;
+          }
+          return Boolean(
+            resolveWorkspaceMapKeyByIdentity({
+              workspaces,
+              workspaceId: selection.workspaceId,
+            }),
+          );
+        },
+      });
+      if (areWorkspaceSelectionListsEqual(current, next)) {
         return current;
       }
-      return [...current, activeSelection];
+      return next;
     });
-  }, [activeSelection]);
+  }, [activeSelection, activeServerId, hasHydratedWorkspaces, workspaces]);
 
   if (!activeSelection) {
     return null;
@@ -187,7 +210,7 @@ function WorkspaceDeck() {
         const isActive = areWorkspaceSelectionsEqual(selection, activeSelection);
         return (
           <View
-            key={`${selection.serverId}:${selection.workspaceId}`}
+            key={getWorkspaceSelectionKey(selection)}
             style={isActive ? styles.activeDeckEntry : styles.inactiveDeckEntry}
             testID={`workspace-deck-entry-${selection.serverId}:${selection.workspaceId}`}
           >

--- a/packages/app/src/app/h/[serverId]/workspace/[workspaceId]/index.tsx
+++ b/packages/app/src/app/h/[serverId]/workspace/[workspaceId]/index.tsx
@@ -175,6 +175,9 @@ function WorkspaceDeck() {
   }, []);
 
   useEffect(() => {
+    if (!activeSelection) {
+      return;
+    }
     setMountedSelections((current) => {
       const next = pruneMountedWorkspaceSelections({
         currentSelections: current,

--- a/packages/app/src/screens/workspace/workspace-deck-retention.test.ts
+++ b/packages/app/src/screens/workspace/workspace-deck-retention.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { ActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
+import { pruneMountedWorkspaceSelections } from "@/screens/workspace/workspace-deck-retention";
+
+function workspace(workspaceId: string, serverId = "server"): ActiveWorkspaceSelection {
+  return { serverId, workspaceId };
+}
+
+function mountedWorkspaceIds(selections: ActiveWorkspaceSelection[]): string[] {
+  return selections.map((selection) => selection.workspaceId);
+}
+
+describe("pruneMountedWorkspaceSelections", () => {
+  it("keeps the active workspace and the two most recent inactive workspaces", () => {
+    const mountedAfterA = pruneMountedWorkspaceSelections({
+      currentSelections: [],
+      activeSelection: workspace("A"),
+      shouldPruneInactiveSelections: true,
+      canRetainInactiveSelection: () => true,
+    });
+    const mountedAfterB = pruneMountedWorkspaceSelections({
+      currentSelections: mountedAfterA,
+      activeSelection: workspace("B"),
+      shouldPruneInactiveSelections: true,
+      canRetainInactiveSelection: () => true,
+    });
+    const mountedAfterC = pruneMountedWorkspaceSelections({
+      currentSelections: mountedAfterB,
+      activeSelection: workspace("C"),
+      shouldPruneInactiveSelections: true,
+      canRetainInactiveSelection: () => true,
+    });
+    const mountedAfterD = pruneMountedWorkspaceSelections({
+      currentSelections: mountedAfterC,
+      activeSelection: workspace("D"),
+      shouldPruneInactiveSelections: true,
+      canRetainInactiveSelection: () => true,
+    });
+
+    expect(mountedWorkspaceIds(mountedAfterD)).toEqual(["D", "C", "B"]);
+  });
+
+  it("retains the active workspace even when inactive pruning would reject it", () => {
+    const mountedSelections = pruneMountedWorkspaceSelections({
+      currentSelections: [workspace("A")],
+      activeSelection: workspace("A"),
+      shouldPruneInactiveSelections: true,
+      canRetainInactiveSelection: () => false,
+    });
+
+    expect(mountedWorkspaceIds(mountedSelections)).toEqual(["A"]);
+  });
+
+  it("prunes inactive workspaces that no longer exist", () => {
+    const mountedSelections = pruneMountedWorkspaceSelections({
+      currentSelections: [workspace("A"), workspace("B"), workspace("C")],
+      activeSelection: workspace("A"),
+      shouldPruneInactiveSelections: true,
+      canRetainInactiveSelection: (selection) => selection.workspaceId !== "B",
+    });
+
+    expect(mountedWorkspaceIds(mountedSelections)).toEqual(["A", "C"]);
+  });
+
+  it("waits to prune inactive workspaces until workspace hydration is ready", () => {
+    const mountedSelections = pruneMountedWorkspaceSelections({
+      currentSelections: [workspace("A"), workspace("B")],
+      activeSelection: workspace("A"),
+      shouldPruneInactiveSelections: false,
+      canRetainInactiveSelection: () => false,
+    });
+
+    expect(mountedWorkspaceIds(mountedSelections)).toEqual(["A", "B"]);
+  });
+
+  it("always allows at least the active workspace", () => {
+    const mountedSelections = pruneMountedWorkspaceSelections({
+      currentSelections: [workspace("A"), workspace("B")],
+      activeSelection: workspace("C"),
+      maxMountedWorkspaces: 0,
+      shouldPruneInactiveSelections: true,
+      canRetainInactiveSelection: () => true,
+    });
+
+    expect(mountedWorkspaceIds(mountedSelections)).toEqual(["C"]);
+  });
+});

--- a/packages/app/src/screens/workspace/workspace-deck-retention.test.ts
+++ b/packages/app/src/screens/workspace/workspace-deck-retention.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
-import { pruneMountedWorkspaceSelections } from "@/screens/workspace/workspace-deck-retention";
+import {
+  pruneMountedWorkspaceSelections,
+  shouldKeepWorkspaceDeckEntryMounted,
+} from "@/screens/workspace/workspace-deck-retention";
 
 function workspace(workspaceId: string, serverId = "server"): ActiveWorkspaceSelection {
   return { serverId, workspaceId };
@@ -15,59 +18,36 @@ describe("pruneMountedWorkspaceSelections", () => {
     const mountedAfterA = pruneMountedWorkspaceSelections({
       currentSelections: [],
       activeSelection: workspace("A"),
-      shouldPruneInactiveSelections: true,
-      canRetainInactiveSelection: () => true,
     });
     const mountedAfterB = pruneMountedWorkspaceSelections({
       currentSelections: mountedAfterA,
       activeSelection: workspace("B"),
-      shouldPruneInactiveSelections: true,
-      canRetainInactiveSelection: () => true,
     });
     const mountedAfterC = pruneMountedWorkspaceSelections({
       currentSelections: mountedAfterB,
       activeSelection: workspace("C"),
-      shouldPruneInactiveSelections: true,
-      canRetainInactiveSelection: () => true,
     });
     const mountedAfterD = pruneMountedWorkspaceSelections({
       currentSelections: mountedAfterC,
       activeSelection: workspace("D"),
-      shouldPruneInactiveSelections: true,
-      canRetainInactiveSelection: () => true,
     });
 
     expect(mountedWorkspaceIds(mountedAfterD)).toEqual(["D", "C", "B"]);
   });
 
-  it("retains the active workspace even when inactive pruning would reject it", () => {
+  it("retains the active workspace", () => {
     const mountedSelections = pruneMountedWorkspaceSelections({
       currentSelections: [workspace("A")],
       activeSelection: workspace("A"),
-      shouldPruneInactiveSelections: true,
-      canRetainInactiveSelection: () => false,
     });
 
     expect(mountedWorkspaceIds(mountedSelections)).toEqual(["A"]);
   });
 
-  it("prunes inactive workspaces that no longer exist", () => {
+  it("deduplicates retained workspace selections", () => {
     const mountedSelections = pruneMountedWorkspaceSelections({
-      currentSelections: [workspace("A"), workspace("B"), workspace("C")],
+      currentSelections: [workspace("B"), workspace("A"), workspace("B")],
       activeSelection: workspace("A"),
-      shouldPruneInactiveSelections: true,
-      canRetainInactiveSelection: (selection) => selection.workspaceId !== "B",
-    });
-
-    expect(mountedWorkspaceIds(mountedSelections)).toEqual(["A", "C"]);
-  });
-
-  it("waits to prune inactive workspaces until workspace hydration is ready", () => {
-    const mountedSelections = pruneMountedWorkspaceSelections({
-      currentSelections: [workspace("A"), workspace("B")],
-      activeSelection: workspace("A"),
-      shouldPruneInactiveSelections: false,
-      canRetainInactiveSelection: () => false,
     });
 
     expect(mountedWorkspaceIds(mountedSelections)).toEqual(["A", "B"]);
@@ -78,10 +58,50 @@ describe("pruneMountedWorkspaceSelections", () => {
       currentSelections: [workspace("A"), workspace("B")],
       activeSelection: workspace("C"),
       maxMountedWorkspaces: 0,
-      shouldPruneInactiveSelections: true,
-      canRetainInactiveSelection: () => true,
     });
 
     expect(mountedWorkspaceIds(mountedSelections)).toEqual(["C"]);
+  });
+});
+
+describe("shouldKeepWorkspaceDeckEntryMounted", () => {
+  it("keeps the active workspace mounted even when it is missing from hydrated workspaces", () => {
+    expect(
+      shouldKeepWorkspaceDeckEntryMounted({
+        isActive: true,
+        hasHydratedWorkspaces: true,
+        workspaceExists: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps inactive workspaces mounted until workspace hydration finishes", () => {
+    expect(
+      shouldKeepWorkspaceDeckEntryMounted({
+        isActive: false,
+        hasHydratedWorkspaces: false,
+        workspaceExists: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("unmounts inactive workspaces that are gone after hydration", () => {
+    expect(
+      shouldKeepWorkspaceDeckEntryMounted({
+        isActive: false,
+        hasHydratedWorkspaces: true,
+        workspaceExists: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps inactive workspaces that still exist after hydration", () => {
+    expect(
+      shouldKeepWorkspaceDeckEntryMounted({
+        isActive: false,
+        hasHydratedWorkspaces: true,
+        workspaceExists: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/app/src/screens/workspace/workspace-deck-retention.ts
+++ b/packages/app/src/screens/workspace/workspace-deck-retention.ts
@@ -6,8 +6,12 @@ interface PruneMountedWorkspaceSelectionsInput {
   currentSelections: ActiveWorkspaceSelection[];
   activeSelection: ActiveWorkspaceSelection | null;
   maxMountedWorkspaces?: number;
-  shouldPruneInactiveSelections: boolean;
-  canRetainInactiveSelection: (selection: ActiveWorkspaceSelection) => boolean;
+}
+
+interface WorkspaceDeckEntryMountInput {
+  isActive: boolean;
+  hasHydratedWorkspaces: boolean;
+  workspaceExists: boolean;
 }
 
 export function getWorkspaceSelectionKey(selection: ActiveWorkspaceSelection): string {
@@ -37,8 +41,6 @@ export function pruneMountedWorkspaceSelections({
   currentSelections,
   activeSelection,
   maxMountedWorkspaces = WORKSPACE_DECK_MAX_MOUNTED_WORKSPACES,
-  shouldPruneInactiveSelections,
-  canRetainInactiveSelection,
 }: PruneMountedWorkspaceSelectionsInput): ActiveWorkspaceSelection[] {
   if (!activeSelection) {
     return [];
@@ -66,11 +68,22 @@ export function pruneMountedWorkspaceSelections({
     if (areWorkspaceSelectionsEqual(selection, activeSelection)) {
       continue;
     }
-    if (shouldPruneInactiveSelections && !canRetainInactiveSelection(selection)) {
-      continue;
-    }
     appendSelection(selection);
   }
 
   return nextSelections;
+}
+
+export function shouldKeepWorkspaceDeckEntryMounted({
+  isActive,
+  hasHydratedWorkspaces,
+  workspaceExists,
+}: WorkspaceDeckEntryMountInput): boolean {
+  if (isActive) {
+    return true;
+  }
+  if (!hasHydratedWorkspaces) {
+    return true;
+  }
+  return workspaceExists;
 }

--- a/packages/app/src/screens/workspace/workspace-deck-retention.ts
+++ b/packages/app/src/screens/workspace/workspace-deck-retention.ts
@@ -1,0 +1,76 @@
+import type { ActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
+
+export const WORKSPACE_DECK_MAX_MOUNTED_WORKSPACES = 3;
+
+interface PruneMountedWorkspaceSelectionsInput {
+  currentSelections: ActiveWorkspaceSelection[];
+  activeSelection: ActiveWorkspaceSelection | null;
+  maxMountedWorkspaces?: number;
+  shouldPruneInactiveSelections: boolean;
+  canRetainInactiveSelection: (selection: ActiveWorkspaceSelection) => boolean;
+}
+
+export function getWorkspaceSelectionKey(selection: ActiveWorkspaceSelection): string {
+  return `${selection.serverId}:${selection.workspaceId}`;
+}
+
+export function areWorkspaceSelectionsEqual(
+  left: ActiveWorkspaceSelection | null,
+  right: ActiveWorkspaceSelection | null,
+): boolean {
+  return left?.serverId === right?.serverId && left?.workspaceId === right?.workspaceId;
+}
+
+export function areWorkspaceSelectionListsEqual(
+  left: ActiveWorkspaceSelection[],
+  right: ActiveWorkspaceSelection[],
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((selection, index) =>
+    areWorkspaceSelectionsEqual(selection, right[index] ?? null),
+  );
+}
+
+export function pruneMountedWorkspaceSelections({
+  currentSelections,
+  activeSelection,
+  maxMountedWorkspaces = WORKSPACE_DECK_MAX_MOUNTED_WORKSPACES,
+  shouldPruneInactiveSelections,
+  canRetainInactiveSelection,
+}: PruneMountedWorkspaceSelectionsInput): ActiveWorkspaceSelection[] {
+  if (!activeSelection) {
+    return [];
+  }
+
+  const maxSelections = Math.max(1, maxMountedWorkspaces);
+  const nextSelections: ActiveWorkspaceSelection[] = [];
+  const seenSelectionKeys = new Set<string>();
+
+  function appendSelection(selection: ActiveWorkspaceSelection): void {
+    if (nextSelections.length >= maxSelections) {
+      return;
+    }
+    const selectionKey = getWorkspaceSelectionKey(selection);
+    if (seenSelectionKeys.has(selectionKey)) {
+      return;
+    }
+    seenSelectionKeys.add(selectionKey);
+    nextSelections.push(selection);
+  }
+
+  appendSelection(activeSelection);
+
+  for (const selection of currentSelections) {
+    if (areWorkspaceSelectionsEqual(selection, activeSelection)) {
+      continue;
+    }
+    if (shouldPruneInactiveSelections && !canRetainInactiveSelection(selection)) {
+      continue;
+    }
+    appendSelection(selection);
+  }
+
+  return nextSelections;
+}

--- a/packages/app/src/stores/session-store-hooks/index.ts
+++ b/packages/app/src/stores/session-store-hooks/index.ts
@@ -3,11 +3,13 @@ import { useStoreWithEqualityFn } from "zustand/traditional";
 import { useSidebarOrderStore } from "@/stores/sidebar-order-store";
 import {
   composeWorkspaceStructure,
+  selectHasHydratedWorkspaces,
   selectHasWorkspaces,
   selectProjectOrder,
   selectRecommendedProjectPaths,
   selectResolveWorkspaceIdByCwd,
   selectWorkspace,
+  selectWorkspaceExists,
   selectWorkspaceExecutionAuthority,
   selectWorkspaceFields,
   selectWorkspaceKeys,
@@ -51,6 +53,22 @@ export function useWorkspaceFields<T>(
     useSessionStore,
     (state) => selectWorkspaceFields(state, serverId, workspaceId, project),
     workspaceEqualityFns.deep,
+  );
+}
+
+export function useWorkspaceExists(serverId: string | null, workspaceId: string | null): boolean {
+  return useStoreWithEqualityFn(
+    useSessionStore,
+    (state) => selectWorkspaceExists(state, serverId, workspaceId),
+    workspaceEqualityFns.identity,
+  );
+}
+
+export function useHasHydratedWorkspaces(serverId: string | null): boolean {
+  return useStoreWithEqualityFn(
+    useSessionStore,
+    (state) => selectHasHydratedWorkspaces(state, serverId),
+    workspaceEqualityFns.identity,
   );
 }
 

--- a/packages/app/src/stores/session-store-hooks/selectors.ts
+++ b/packages/app/src/stores/session-store-hooks/selectors.ts
@@ -17,7 +17,10 @@ export type { DesktopBadgeWorkspaceStatus } from "@/utils/desktop-badge-state";
 export type { WorkspaceStructure, WorkspaceStructureProject } from "@/projects/workspace-structure";
 
 export interface SessionsSnapshot {
-  sessions: Record<string, { workspaces: Map<string, WorkspaceDescriptor> }>;
+  sessions: Record<
+    string,
+    { hasHydratedWorkspaces?: boolean; workspaces: Map<string, WorkspaceDescriptor> }
+  >;
 }
 
 export interface SidebarOrderSnapshot {
@@ -108,6 +111,21 @@ export function selectWorkspaceFields<T>(
 ): T | null {
   const workspace = selectWorkspace(state, serverId, workspaceId);
   return workspace ? project(workspace) : null;
+}
+
+export function selectWorkspaceExists(
+  state: SessionsSnapshot,
+  serverId: string | null,
+  workspaceId: string | null,
+): boolean {
+  return selectWorkspace(state, serverId, workspaceId) !== null;
+}
+
+export function selectHasHydratedWorkspaces(
+  state: SessionsSnapshot,
+  serverId: string | null,
+): boolean {
+  return serverId ? (state.sessions[serverId]?.hasHydratedWorkspaces ?? false) : false;
 }
 
 export function selectWorkspaceExecutionAuthority(


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Retained workspace screens are now bounded instead of growing for every visited workspace. The active workspace stays mounted, the two most recent inactive workspaces stay mounted for quick switching, and inactive workspaces that disappear from the workspace list are unmounted so archived/hidden workspaces do not keep their panels and agent streams alive.

The deck no longer subscribes to the whole workspace map. LRU state stays local to the deck, while each retained deck entry subscribes only to primitive workspace hydration/existence selectors through the workspace store hook layer.

### How did you verify it

- `npx vitest run packages/app/src/screens/workspace/workspace-deck-retention.test.ts --bail=1`
- `npm run format`
- `npm run typecheck`
- `npm run lint`

Risk surface: this touches workspace route retention, so the thing to smoke before merge is quick switching among three workspaces and archiving/hiding one of the inactive workspaces. There is no visual UI change to screenshot.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform — N/A, no visual UI change
- [x] Tests added or updated where it made sense