### PR TITLE
fix(server): encode non-ASCII filenames in Content-Disposition header with RFC 5987

### DIFF
--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -447,10 +447,18 @@ export async function createPaseoDaemon(
    * to prevent ERR_INVALID_CHAR from Node.js HTTP parser.
    */
   function formatContentDisposition(fileName: string): string {
-    // Strip characters that are unsafe in header values
-    const sanitized = fileName.replace(/["\r\n]/g, "_");
+    // Strip characters that are unsafe in header values.
+    // Backslash is an escape character in HTTP quoted-strings (RFC 7230 §3.2.6).
+    const sanitized = fileName.replace(/["\\\r\n]/g, "_");
     // ASCII-only filenames can use the simple form
-    if (encodeURIComponent(sanitized) === sanitized) {
+    let hasNonAscii = false;
+    for (let i = 0; i < sanitized.length; i++) {
+      if (sanitized.charCodeAt(i) > 127) {
+        hasNonAscii = true;
+        break;
+      }
+    }
+    if (!hasNonAscii) {
       return `attachment; filename="${sanitized}"`;
     }
     // Non-ASCII: RFC 5987 encoding with ASCII fallback

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -441,6 +441,27 @@ export async function createPaseoDaemon(
     });
   });
 
+  /**
+   * Build a RFC 5987 compliant Content-Disposition header value for file downloads.
+   * Non-ASCII characters (e.g. Chinese) are percent-encoded in the filename* parameter
+   * to prevent ERR_INVALID_CHAR from Node.js HTTP parser.
+   */
+  function formatContentDisposition(fileName: string): string {
+    // Strip characters that are unsafe in header values
+    const sanitized = fileName.replace(/["\r\n]/g, "_");
+    // ASCII-only filenames can use the simple form
+    if (encodeURIComponent(sanitized) === sanitized) {
+      return `attachment; filename="${sanitized}"`;
+    }
+    // Non-ASCII: RFC 5987 encoding with ASCII fallback
+    let asciiFallback = "";
+    for (let i = 0; i < sanitized.length; i++) {
+      asciiFallback += sanitized.charCodeAt(i) <= 127 ? sanitized[i] : "_";
+    }
+    const encoded = encodeURIComponent(sanitized);
+    return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encoded}`;
+  }
+
   const handleFileDownload = async (req: express.Request, res: express.Response): Promise<void> => {
     const token =
       typeof req.query.token === "string" && req.query.token.trim().length > 0
@@ -467,9 +488,8 @@ export async function createPaseoDaemon(
         return;
       }
 
-      const safeFileName = entry.fileName.replace(/["\r\n]/g, "_");
       res.setHeader("Content-Type", entry.mimeType);
-      res.setHeader("Content-Disposition", `attachment; filename="${safeFileName}"`);
+      res.setHeader("Content-Disposition", formatContentDisposition(entry.fileName));
       res.setHeader("Content-Length", fileStats.size.toString());
 
       const stream = fileHandle.createReadStream();

--- a/packages/server/src/server/daemon-e2e/file-download.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/file-download.e2e.test.ts
@@ -118,5 +118,46 @@ describe("daemon E2E", () => {
 
       rmSync(cwd, { recursive: true, force: true });
     }, 60000);
+
+    test("downloads files with Chinese filename via RFC 5987 encoding", async () => {
+      const cwd = tmpCwd();
+      const chineseName = "语言赏析能力分享_Marp.pdf";
+      const filePath = path.join(cwd, chineseName);
+      const fileContents = "chinese filename download test payload";
+      writeFileSync(filePath, fileContents, "utf-8");
+
+      const agent = await ctx.client.createAgent({
+        provider: "codex",
+        model: CODEX_TEST_MODEL,
+        thinkingOptionId: CODEX_TEST_THINKING_OPTION_ID,
+        cwd,
+        title: "Chinese Filename Download Test Agent",
+      });
+
+      expect(agent.id).toBeTruthy();
+
+      const tokenResponse = await ctx.client.requestDownloadToken(cwd, chineseName);
+
+      expect(tokenResponse.error).toBeNull();
+      expect(tokenResponse.token).toBeTruthy();
+      expect(tokenResponse.fileName).toBe(chineseName);
+
+      const response = await fetch(
+        `http://127.0.0.1:${ctx.daemon.port}/api/files/download?token=${tokenResponse.token}`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe(tokenResponse.mimeType);
+      const disposition = response.headers.get("content-disposition") ?? "";
+      // Must use RFC 5987 filename* parameter for non-ASCII characters
+      expect(disposition).toContain("filename*=UTF-8''");
+      // Header must not contain raw non-ASCII bytes (would crash Node.js HTTP parser)
+      expect(disposition).not.toContain(chineseName);
+
+      const body = await response.text();
+      expect(body).toBe(fileContents);
+
+      rmSync(cwd, { recursive: true, force: true });
+    }, 60000);
   });
 });


### PR DESCRIPTION
## Summary

Fix a crash when downloading files with Chinese (or other non-ASCII) filenames.

## Root Cause

HTTP headers can only contain ASCII characters (RFC 7230 §3.2.6). When a file with a Chinese name like `语言赏析能力分享_Marp.pdf` was downloaded, the filename was written directly into the `Content-Disposition` header:

```
Content-Disposition: attachment; filename=语言赏析能力分享_Marp.pdf
```

Node.js HTTP parser throws `ERR_INVALID_CHAR` because the header contains non-ASCII bytes. This also invalidates the download token, breaking subsequent requests.

## Fix

Add a `formatContentDisposition()` helper that implements RFC 5987 encoding:

- **ASCII-only filenames**: preserved as-is → `filename=report.pdf`
- **Non-ASCII filenames**: percent-encoded in `filename*=` parameter with an ASCII fallback → `filename=__Marp.pdf; filename*=UTF-8''%E8%AF%AD%E8%A8%80...`

## Changes

| File | Change |
|------|--------|
| `bootstrap.ts` | Add `formatContentDisposition()` helper, use it in `handleFileDownload` |
| `file-download.e2e.test.ts` | Add test for Chinese filename download |

## Verification

- ✅ `oxfmt` formatting pass
- ✅ `oxlint` no new warnings
- ✅ `tsc --noEmit` no new errors
- ✅ E2E test added covering Chinese filename (`语言赏析能力分享_Marp.pdf`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)