### PR TITLE
fix(desktop): stop AppImage updates hanging on quit and deleting the app

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -52,6 +52,13 @@ linux:
     - deb
     - rpm
     - tar.gz
+appImage:
+  # Keep the AppImage filename stable across versions (no ${version}) so
+  # electron-updater overwrites the file in place instead of renaming it to a new
+  # versioned path. A rename orphans the old binary, breaks desktop shortcuts, and
+  # dangles the ~/.local/bin/paseo CLI symlink, which points at $APPIMAGE. The
+  # version stays discoverable via the release tag and the in-app version.
+  artifactName: "Paseo-${arch}.${ext}"
 win:
   artifactName: "Paseo-Setup-${version}-${arch}.${ext}"
   icon: assets/icon.ico

--- a/packages/desktop/src/features/auto-updater.test.ts
+++ b/packages/desktop/src/features/auto-updater.test.ts
@@ -19,7 +19,17 @@ import {
   resolveStagingUserId,
   rolloutManifestSchema,
   shouldAdmitToRollout,
+  shouldAutoInstallOnQuit,
 } from "./auto-updater";
+
+describe("shouldAutoInstallOnQuit", () => {
+  it("auto-installs on quit everywhere except Linux AppImage", () => {
+    expect(shouldAutoInstallOnQuit({ platform: "linux", isAppImage: true })).toBe(false);
+    expect(shouldAutoInstallOnQuit({ platform: "linux", isAppImage: false })).toBe(true);
+    expect(shouldAutoInstallOnQuit({ platform: "darwin", isAppImage: false })).toBe(true);
+    expect(shouldAutoInstallOnQuit({ platform: "win32", isAppImage: false })).toBe(true);
+  });
+});
 
 describe("shouldAdmitToRollout", () => {
   it("admits beta, missing rollout hours, zero-hour rollout, and missing release date", () => {

--- a/packages/desktop/src/features/auto-updater.ts
+++ b/packages/desktop/src/features/auto-updater.ts
@@ -76,13 +76,31 @@ export function getStagingUserId(): Promise<string> {
   return cachedStagingUserIdPromise;
 }
 
+// AppImages have no install step. electron-updater "installs" by unlinking the
+// running file and mv-ing the downloaded one into place; on app quit it does this
+// via a *blocking* execFileSync(newAppImage, { APPIMAGE_EXIT_AFTER_INSTALL: "true" }).
+// That env var is only honored by AppImageLauncher, so without it the freshly
+// launched process boots the full app and never exits — the quit hangs forever,
+// with the old binary already deleted. We therefore install AppImages only on
+// explicit quitAndInstall (the "Update now" button), which takes the non-blocking
+// spawn path. Every other target keeps auto-install-on-quit, which works there.
+export function shouldAutoInstallOnQuit(input: {
+  platform: NodeJS.Platform;
+  isAppImage: boolean;
+}): boolean {
+  return !(input.platform === "linux" && input.isAppImage);
+}
+
 class ElectronAppUpdateRuntime implements AppUpdateRuntime {
   private configured = false;
 
   configure(input: AppUpdateRuntimeConfiguration): void {
     autoUpdater.autoDownload = true;
     autoUpdater.autoRunAppAfterInstall = true;
-    autoUpdater.autoInstallOnAppQuit = !(process.platform === "linux" && process.env.APPIMAGE);
+    autoUpdater.autoInstallOnAppQuit = shouldAutoInstallOnQuit({
+      platform: process.platform,
+      isAppImage: Boolean(process.env.APPIMAGE),
+    });
     autoUpdater.allowPrerelease = input.releaseChannel === "beta";
     autoUpdater.channel = input.releaseChannel === "beta" ? "beta" : "latest";
     autoUpdater.allowDowngrade = false;

--- a/packages/desktop/src/features/auto-updater.ts
+++ b/packages/desktop/src/features/auto-updater.ts
@@ -81,8 +81,8 @@ class ElectronAppUpdateRuntime implements AppUpdateRuntime {
 
   configure(input: AppUpdateRuntimeConfiguration): void {
     autoUpdater.autoDownload = true;
-    autoUpdater.autoInstallOnAppQuit = true;
     autoUpdater.autoRunAppAfterInstall = true;
+    autoUpdater.autoInstallOnAppQuit = !(process.platform === "linux" && process.env.APPIMAGE);
     autoUpdater.allowPrerelease = input.releaseChannel === "beta";
     autoUpdater.channel = input.releaseChannel === "beta" ? "beta" : "latest";
     autoUpdater.allowDowngrade = false;


### PR DESCRIPTION
AppImage auto-updates were unreliable on Linux: the update hung the app on quit and deleted the running binary. This PR fixes both — the hang, and the orphaned/renamed file that broke desktop shortcuts and the `paseo` CLI symlink.

### Linked issue

Closes # n/a

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

**Disable auto-install-on-quit for AppImage (original change).** electron-updater downloads a new AppImage in the background, then on quit tries to "install" it via a blocking `execFileSync(newAppImage, { APPIMAGE_EXIT_AFTER_INSTALL })`. That env var is only honored by AppImageLauncher, so without it the new process never exits and the quit hangs — with the old binary already unlinked. Scoped to AppImage only (`process.platform === 'linux' && process.env.APPIMAGE`); `.deb`/`.rpm`/Windows/macOS keep auto-install-on-quit.

**Keep the AppImage filename stable (maintainer follow-up).** With a versioned `artifactName`, electron-updater renames the AppImage to a new path on every update and unlinks the old one — orphaning the previous binary, breaking desktop shortcuts, and dangling the `~/.local/bin/paseo` CLI symlink (which points at `$APPIMAGE`). Dropping `${version}` from the AppImage `artifactName` makes the updater overwrite the file in place. `.deb`/`.rpm` keep their versioned names. **Trade-off:** the AppImage release asset is now `Paseo-${arch}.AppImage` (no version in the filename), and existing versioned installs do one final rename on their next update, then stay stable.

**Docs + test.** The auto-install-on-quit gate is now a documented, unit-tested `shouldAutoInstallOnQuit()` helper that explains the hang in-code instead of only in the commit message.

### How did you verify it

- *(original)* Built a patch against the previous release to ensure the update fires, then applied it to latest head.
- *(maintainer)* `npm run typecheck`, `npm run lint`, and the desktop `auto-updater` test file pass locally; added a unit test covering the gate across linux-AppImage / linux-deb·rpm / macOS / Windows.

### Beyond CI

CI does not exercise the Linux desktop auto-updater end-to-end. Before merge, worth one real AppImage update check: (1) an update applied via "Update now" relaunches without hanging, and (2) the post-update file keeps the same path so a pinned shortcut and the `paseo` symlink still resolve. `.deb`/`.rpm` install-on-quit is intentionally unchanged.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense