### PR TITLE
Fix new workspace keyboard overlap

### DIFF
--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, Text, View } from "react-native";
 import type { PressableStateCallbackType } from "react-native";
+import ReanimatedAnimated from "react-native-reanimated";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { createNameId } from "mnemonic-id";
@@ -33,6 +34,7 @@ import { generateDraftId } from "@/stores/draft-keys";
 import { useDraftStore } from "@/stores/draft-store";
 import { useCreateFlowStore } from "@/stores/create-flow-store";
 import { useWorkspaceDraftSubmissionStore } from "@/stores/workspace-draft-submission-store";
+import { useKeyboardShiftStyle } from "@/hooks/use-keyboard-shift-style";
 import { generateMessageId } from "@/types/stream";
 import { toErrorMessage } from "@/utils/error-messages";
 import { projectIconPlaceholderLabelFromDisplayName } from "@/utils/project-display-name";
@@ -1184,6 +1186,15 @@ export function NewWorkspaceScreen({
     [isCompact, insets.bottom],
   );
 
+  const { style: composerKeyboardStyle } = useKeyboardShiftStyle({
+    mode: "translate",
+  });
+
+  const centeredStyle = useMemo(
+    () => [styles.centered, composerKeyboardStyle],
+    [composerKeyboardStyle],
+  );
+
   const agentControlsWithDisabled = useMemo(
     () =>
       composerState
@@ -1327,7 +1338,7 @@ export function NewWorkspaceScreen({
         <ScreenHeader left={screenHeaderLeft} borderless />
         <View style={contentStyle}>
           <TitlebarDragRegion />
-          <View style={styles.centered}>
+          <ReanimatedAnimated.View style={centeredStyle}>
             <View style={styles.composerTitleContainer}>
               <Text style={styles.composerTitle}>{t("newWorkspace.title")}</Text>
             </View>
@@ -1355,7 +1366,7 @@ export function NewWorkspaceScreen({
               footer={composerFooter}
             />
             {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
-          </View>
+          </ReanimatedAnimated.View>
         </View>
       </View>
     </FileDropZone>


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fixes the new workspace screen so the title moves up with the composer when the keyboard opens. The title and composer now shift together, avoiding the awkward overlap behind the keyboard.

### How did you verify it

- `npm run typecheck`
- `npm run lint -- packages/app/src/screens/new-workspace-screen.tsx`
- `npm run format:check -- packages/app/src/screens/new-workspace-screen.tsx`
- Pre-commit hook reran lint, format check, and typecheck successfully.

Risk surface: this touches mobile keyboard layout on the new workspace screen. Before merge, smoke the new workspace composer on iOS or Android with the keyboard open; I did not capture visual proof in this environment.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [ ] Tests added or updated where it made sense