### PR TITLE
Show an error for missing project paths

### DIFF
--- a/packages/app/e2e/helpers/new-workspace.ts
+++ b/packages/app/e2e/helpers/new-workspace.ts
@@ -16,6 +16,7 @@ type NewWorkspaceDaemonClient = Pick<
 >;
 
 type OpenProjectPayload = Awaited<ReturnType<NewWorkspaceDaemonClient["openProject"]>>;
+type WorkspacePayload = Pick<OpenProjectPayload, "error" | "workspace">;
 
 export interface OpenedProject {
   workspaceId: string;
@@ -24,7 +25,7 @@ export interface OpenedProject {
   workspaceName: string;
 }
 
-function requireWorkspace(payload: OpenProjectPayload) {
+function requireWorkspace(payload: WorkspacePayload) {
   if (payload.error) {
     throw new Error(payload.error);
   }

--- a/packages/app/src/components/project-picker-modal.tsx
+++ b/packages/app/src/components/project-picker-modal.tsx
@@ -8,27 +8,36 @@ import {
   View,
   type PressableStateCallbackType,
 } from "react-native";
-import { Folder } from "lucide-react-native";
+import { Folder, FolderPlus } from "lucide-react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useKeyboardShortcutsStore } from "@/stores/keyboard-shortcuts-store";
 import { shortenPath } from "@/utils/shorten-path";
 import { useRecommendedProjectPaths } from "@/stores/session-store-hooks";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { useOpenProject } from "@/hooks/use-open-project";
-import { buildWorkingDirectorySuggestions } from "@/utils/working-directory-suggestions";
 import { isNative } from "@/constants/platform";
 import { useActiveServerId } from "@/hooks/use-active-server-id";
+import {
+  buildProjectPickerOptions,
+  isOpenableProjectPath,
+  type ProjectPickerOption,
+} from "./project-picker-options";
 
 interface PathRowProps {
-  path: string;
+  option: ProjectPickerOption;
   active: boolean;
+  openPathLabel: string;
   onSelect: (path: string) => void;
 }
 
-function PathRow({ path, active, onSelect }: PathRowProps) {
+function PathRow({ option, active, openPathLabel, onSelect }: PathRowProps) {
   const { theme } = useUnistyles();
+  const Icon = option.kind === "path" ? FolderPlus : Folder;
+  const path = option.path;
+  const displayPath = shortenPath(path);
+  const label = option.kind === "path" ? `${openPathLabel}: ${displayPath}` : displayPath;
   const handlePress = useCallback(() => {
     onSelect(path);
   }, [onSelect, path]);
@@ -49,10 +58,10 @@ function PathRow({ path, active, onSelect }: PathRowProps) {
     <Pressable style={pressableStyle} onPress={handlePress}>
       <View style={styles.rowContent}>
         <View style={styles.iconSlot}>
-          <Folder size={16} strokeWidth={2.2} color={theme.colors.foregroundMuted} />
+          <Icon size={16} strokeWidth={2.2} color={theme.colors.foregroundMuted} />
         </View>
         <Text style={rowTextStyle} numberOfLines={1}>
-          {shortenPath(path)}
+          {label}
         </Text>
       </View>
     </Pressable>
@@ -74,8 +83,26 @@ export function ProjectPickerModal() {
   const inputRef = useRef<TextInput>(null);
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const openProject = useOpenProject(serverId);
+
+  const openProjectMutation = useMutation({
+    mutationFn: (path: string) => openProject(path),
+    onSuccess: (result) => {
+      if (result.ok) {
+        setOpen(false);
+      }
+    },
+  });
+  const { mutate: submitPath, reset: resetSubmit, isPending: isSubmitting } = openProjectMutation;
+  const submitResult = openProjectMutation.data;
+  let errorMessage: string | null = null;
+  if (submitResult?.ok === false) {
+    if (submitResult.errorCode) {
+      errorMessage = t(`projectPicker.errors.${submitResult.errorCode}`);
+    } else {
+      errorMessage = submitResult.error;
+    }
+  }
 
   const directorySuggestionsQuery = useQuery({
     queryKey: ["project-picker-directory-suggestions", serverId, query],
@@ -97,16 +124,11 @@ export function ProjectPickerModal() {
   });
 
   const options = useMemo(() => {
-    const suggestedPaths = buildWorkingDirectorySuggestions({
+    return buildProjectPickerOptions({
       recommendedPaths,
       serverPaths: directorySuggestionsQuery.data ?? [],
       query,
     });
-    const trimmedQuery = query.trim();
-    if (!trimmedQuery || suggestedPaths.includes(trimmedQuery)) {
-      return suggestedPaths;
-    }
-    return [trimmedQuery, ...suggestedPaths];
   }, [query, directorySuggestionsQuery.data, recommendedPaths]);
 
   const handleClose = useCallback(() => {
@@ -114,43 +136,41 @@ export function ProjectPickerModal() {
   }, [setOpen]);
 
   const handleSelectPath = useCallback(
-    async (path: string) => {
+    (path: string) => {
       const trimmed = path.trim();
       if (!trimmed || !client || !serverId) return;
-
-      setIsSubmitting(true);
-      try {
-        const didOpenProject = await openProject(trimmed);
-        if (didOpenProject) {
-          setOpen(false);
-        }
-      } finally {
-        setIsSubmitting(false);
-      }
+      submitPath(trimmed);
     },
-    [client, openProject, serverId, setOpen],
+    [client, serverId, submitPath],
   );
 
   const handleSubmitCustom = useCallback(() => {
     const trimmed = query.trim();
-    if (!trimmed) return;
-    void handleSelectPath(trimmed);
+    if (!isOpenableProjectPath(trimmed)) return;
+    handleSelectPath(trimmed);
   }, [handleSelectPath, query]);
 
-  const handleChangeQuery = useCallback((text: string) => {
-    setQuery(text);
-    setActiveIndex(0);
-  }, []);
+  const handleChangeQuery = useCallback(
+    (text: string) => {
+      setQuery(text);
+      setActiveIndex(0);
+      resetSubmit();
+    },
+    [resetSubmit],
+  );
 
   // Reset state when opening/closing
   useEffect(() => {
-    if (open) {
-      setQuery("");
-      setActiveIndex(0);
-      const id = setTimeout(() => inputRef.current?.focus(), 0);
-      return () => clearTimeout(id);
+    resetSubmit();
+    if (!open) {
+      return;
     }
-  }, [open]);
+
+    setQuery("");
+    setActiveIndex(0);
+    const id = setTimeout(() => inputRef.current?.focus(), 0);
+    return () => clearTimeout(id);
+  }, [open, resetSubmit]);
 
   // Clamp active index
   useEffect(() => {
@@ -170,14 +190,14 @@ export function ProjectPickerModal() {
 
       if (key === "Escape") {
         event.preventDefault();
-        setOpen(false);
+        handleClose();
         return;
       }
 
       if (key === "Enter") {
         event.preventDefault();
         if (options.length > 0 && activeIndex < options.length) {
-          void handleSelectPath(options[activeIndex]);
+          handleSelectPath(options[activeIndex].path);
         } else if (query.trim()) {
           handleSubmitCustom();
         }
@@ -199,7 +219,7 @@ export function ProjectPickerModal() {
 
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [activeIndex, handleSelectPath, handleSubmitCustom, open, options, query, setOpen]);
+  }, [activeIndex, handleClose, handleSelectPath, handleSubmitCustom, open, options, query]);
 
   const panelStyle = useMemo(
     () => [
@@ -218,6 +238,10 @@ export function ProjectPickerModal() {
   const inputStyle = useMemo(
     () => [styles.input, { color: theme.colors.foreground }],
     [theme.colors.foreground],
+  );
+  const errorTextStyle = useMemo(
+    () => [styles.errorText, { color: theme.colors.destructive }],
+    [theme.colors.destructive],
   );
   const emptyTextStyle = useMemo(
     () => [styles.emptyText, { color: theme.colors.foregroundMuted }],
@@ -247,6 +271,7 @@ export function ProjectPickerModal() {
               returnKeyType="go"
               onSubmitEditing={handleSubmitCustom}
             />
+            {errorMessage ? <Text style={errorTextStyle}>{errorMessage}</Text> : null}
           </View>
 
           <ScrollView
@@ -256,16 +281,17 @@ export function ProjectPickerModal() {
             showsVerticalScrollIndicator={false}
           >
             {isSubmitting ? <Text style={emptyTextStyle}>{t("projectPicker.opening")}</Text> : null}
-            {!isSubmitting && options.length === 0 && !query.trim() ? (
+            {!isSubmitting && options.length === 0 ? (
               <Text style={emptyTextStyle}>{t("projectPicker.empty")}</Text>
             ) : null}
-            {!isSubmitting && !(options.length === 0 && !query.trim()) ? (
+            {!isSubmitting && options.length > 0 ? (
               <>
-                {options.map((path, index) => (
+                {options.map((option, index) => (
                   <PathRow
-                    key={path}
-                    path={path}
+                    key={`${option.kind}:${option.path}`}
+                    option={option}
                     active={index === activeIndex}
+                    openPathLabel={t("projectPicker.openPath")}
                     onSelect={handleSelectPath}
                   />
                 ))}
@@ -308,6 +334,11 @@ const styles = StyleSheet.create((theme) => ({
     paddingVertical: theme.spacing[1],
     outlineStyle: "none",
   } as object,
+  errorText: {
+    marginTop: theme.spacing[2],
+    fontSize: theme.fontSize.sm,
+    lineHeight: 18,
+  },
   results: {
     flexGrow: 0,
   },

--- a/packages/app/src/components/project-picker-modal.tsx
+++ b/packages/app/src/components/project-picker-modal.tsx
@@ -37,15 +37,20 @@ type ProjectPickerErrorCode = NonNullable<OpenProjectFailure["errorCode"]>;
 
 function getProjectPickerErrorMessage(
   result: OpenProjectResult | undefined,
+  thrownError: Error | null,
   translateErrorCode: (errorCode: ProjectPickerErrorCode) => string,
+  translateOpenFailed: () => string,
 ): string | null {
-  if (result?.ok !== false) {
-    return null;
+  if (result?.ok === false) {
+    if (result.errorCode) {
+      return translateErrorCode(result.errorCode);
+    }
+    return result.error;
   }
-  if (result.errorCode) {
-    return translateErrorCode(result.errorCode);
+  if (thrownError) {
+    return thrownError.message || translateOpenFailed();
   }
-  return result.error;
+  return null;
 }
 
 function PathRow({ option, active, openPathLabel, onSelect }: PathRowProps) {
@@ -111,8 +116,11 @@ export function ProjectPickerModal() {
   });
   const { mutate: submitPath, reset: resetSubmit, isPending: isSubmitting } = openProjectMutation;
   const submitResult = openProjectMutation.data;
-  const errorMessage = getProjectPickerErrorMessage(submitResult, (errorCode) =>
-    t(`projectPicker.errors.${errorCode}`),
+  const errorMessage = getProjectPickerErrorMessage(
+    submitResult,
+    openProjectMutation.error,
+    (errorCode) => t(`projectPicker.errors.${errorCode}`),
+    () => t("projectPicker.errors.open_failed"),
   );
 
   const directorySuggestionsQuery = useQuery({

--- a/packages/app/src/components/project-picker-modal.tsx
+++ b/packages/app/src/components/project-picker-modal.tsx
@@ -17,6 +17,7 @@ import { shortenPath } from "@/utils/shorten-path";
 import { useRecommendedProjectPaths } from "@/stores/session-store-hooks";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { useOpenProject } from "@/hooks/use-open-project";
+import type { OpenProjectFailure, OpenProjectResult } from "@/hooks/open-project";
 import { isNative } from "@/constants/platform";
 import { useActiveServerId } from "@/hooks/use-active-server-id";
 import {
@@ -30,6 +31,21 @@ interface PathRowProps {
   active: boolean;
   openPathLabel: string;
   onSelect: (path: string) => void;
+}
+
+type ProjectPickerErrorCode = NonNullable<OpenProjectFailure["errorCode"]>;
+
+function getProjectPickerErrorMessage(
+  result: OpenProjectResult | undefined,
+  translateErrorCode: (errorCode: ProjectPickerErrorCode) => string,
+): string | null {
+  if (result?.ok !== false) {
+    return null;
+  }
+  if (result.errorCode) {
+    return translateErrorCode(result.errorCode);
+  }
+  return result.error;
 }
 
 function PathRow({ option, active, openPathLabel, onSelect }: PathRowProps) {
@@ -95,14 +111,9 @@ export function ProjectPickerModal() {
   });
   const { mutate: submitPath, reset: resetSubmit, isPending: isSubmitting } = openProjectMutation;
   const submitResult = openProjectMutation.data;
-  let errorMessage: string | null = null;
-  if (submitResult?.ok === false) {
-    if (submitResult.errorCode) {
-      errorMessage = t(`projectPicker.errors.${submitResult.errorCode}`);
-    } else {
-      errorMessage = submitResult.error;
-    }
-  }
+  const errorMessage = getProjectPickerErrorMessage(submitResult, (errorCode) =>
+    t(`projectPicker.errors.${errorCode}`),
+  );
 
   const directorySuggestionsQuery = useQuery({
     queryKey: ["project-picker-directory-suggestions", serverId, query],

--- a/packages/app/src/components/project-picker-options.test.ts
+++ b/packages/app/src/components/project-picker-options.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { buildProjectPickerOptions, isOpenableProjectPath } from "./project-picker-options";
+
+describe("isOpenableProjectPath", () => {
+  it("accepts POSIX, tilde, Windows drive-letter, and UNC paths", () => {
+    expect(isOpenableProjectPath("/repo")).toBe(true);
+    expect(isOpenableProjectPath("~/src")).toBe(true);
+    expect(isOpenableProjectPath("C:\\Users\\mo")).toBe(true);
+    expect(isOpenableProjectPath("c:/users/mo")).toBe(true);
+    expect(isOpenableProjectPath("\\\\server\\share")).toBe(true);
+  });
+
+  it("rejects relative input", () => {
+    expect(isOpenableProjectPath("repo")).toBe(false);
+    expect(isOpenableProjectPath("repo/sub")).toBe(false);
+    expect(isOpenableProjectPath("c:repo")).toBe(false);
+    expect(isOpenableProjectPath("")).toBe(false);
+  });
+});
+
+describe("buildProjectPickerOptions", () => {
+  it("does not create an open-path row for word queries", () => {
+    const options = buildProjectPickerOptions({
+      recommendedPaths: ["/repo/api"],
+      serverPaths: ["/repo/app"],
+      query: "repo",
+    });
+
+    expect(options).toEqual([
+      { kind: "suggestion", path: "/repo/api" },
+      { kind: "suggestion", path: "/repo/app" },
+    ]);
+  });
+
+  it("puts an absolute path row first", () => {
+    const options = buildProjectPickerOptions({
+      recommendedPaths: ["/repo/api"],
+      serverPaths: [],
+      query: "/repo",
+    });
+
+    expect(options).toEqual([
+      { kind: "path", path: "/repo" },
+      { kind: "suggestion", path: "/repo/api" },
+    ]);
+  });
+
+  it("puts a home-relative path row first", () => {
+    const options = buildProjectPickerOptions({
+      recommendedPaths: ["/Users/mo/src/api"],
+      serverPaths: [],
+      query: "~/src",
+    });
+
+    expect(options).toEqual([
+      { kind: "path", path: "~/src" },
+      { kind: "suggestion", path: "/Users/mo/src/api" },
+    ]);
+  });
+
+  it("creates an open-path row for Windows paths", () => {
+    const options = buildProjectPickerOptions({
+      recommendedPaths: [],
+      serverPaths: [],
+      query: "C:\\Users\\mo\\src",
+    });
+
+    expect(options).toEqual([{ kind: "path", path: "C:\\Users\\mo\\src" }]);
+  });
+
+  it("does not duplicate an existing suggestion", () => {
+    const options = buildProjectPickerOptions({
+      recommendedPaths: ["/repo/api"],
+      serverPaths: ["/repo/app"],
+      query: "/repo/app",
+    });
+
+    expect(options).toEqual([{ kind: "suggestion", path: "/repo/app" }]);
+  });
+});

--- a/packages/app/src/components/project-picker-options.ts
+++ b/packages/app/src/components/project-picker-options.ts
@@ -1,0 +1,48 @@
+import { buildWorkingDirectorySuggestions } from "@/utils/working-directory-suggestions";
+
+export interface BuildProjectPickerOptionsInput {
+  recommendedPaths: string[];
+  serverPaths: string[];
+  query: string;
+}
+
+export interface ProjectPickerPathOption {
+  kind: "path";
+  path: string;
+}
+
+export interface ProjectPickerSuggestionOption {
+  kind: "suggestion";
+  path: string;
+}
+
+export type ProjectPickerOption = ProjectPickerPathOption | ProjectPickerSuggestionOption;
+
+// Matches the daemon's filesystem semantics, not the client's: POSIX absolute,
+// tilde, Windows drive letter (C:\ or C:/), or UNC (\\server\share).
+export function isOpenableProjectPath(query: string): boolean {
+  const trimmedQuery = query.trim();
+  return (
+    trimmedQuery.startsWith("/") ||
+    trimmedQuery.startsWith("~") ||
+    trimmedQuery.startsWith("\\\\") ||
+    /^[a-zA-Z]:[\\/]/.test(trimmedQuery)
+  );
+}
+
+export function buildProjectPickerOptions(
+  input: BuildProjectPickerOptionsInput,
+): ProjectPickerOption[] {
+  const suggestedPaths = buildWorkingDirectorySuggestions(input);
+  const suggestions = suggestedPaths.map<ProjectPickerSuggestionOption>((path) => ({
+    kind: "suggestion",
+    path,
+  }));
+  const trimmedQuery = input.query.trim();
+
+  if (!isOpenableProjectPath(trimmedQuery) || suggestedPaths.includes(trimmedQuery)) {
+    return suggestions;
+  }
+
+  return [{ kind: "path", path: trimmedQuery }, ...suggestions];
+}

--- a/packages/app/src/hooks/open-project.ts
+++ b/packages/app/src/hooks/open-project.ts
@@ -1,6 +1,22 @@
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import type { OpenProjectResponseMessage } from "@getpaseo/protocol/messages";
 import { normalizeWorkspaceDescriptor, type WorkspaceDescriptor } from "@/stores/session-store";
 import { buildWorkspaceTabPersistenceKey } from "@/stores/workspace-tabs-store";
+
+type OpenProjectPayload = OpenProjectResponseMessage["payload"];
+type OpenProjectErrorCode = NonNullable<OpenProjectPayload["errorCode"]>;
+
+export interface OpenProjectSuccess {
+  ok: true;
+}
+
+export interface OpenProjectFailure {
+  ok: false;
+  errorCode: OpenProjectErrorCode | null;
+  error: string | null;
+}
+
+export type OpenProjectResult = OpenProjectSuccess | OpenProjectFailure;
 
 export interface OpenProjectDirectlyInput {
   serverId: string;
@@ -13,16 +29,22 @@ export interface OpenProjectDirectlyInput {
   navigateToWorkspace: (serverId: string, workspaceId: string) => void;
 }
 
-export async function openProjectDirectly(input: OpenProjectDirectlyInput): Promise<boolean> {
+export async function openProjectDirectly(
+  input: OpenProjectDirectlyInput,
+): Promise<OpenProjectResult> {
   const normalizedServerId = input.serverId.trim();
   const trimmedPath = input.projectPath.trim();
   if (!normalizedServerId || !trimmedPath || !input.client || !input.isConnected) {
-    return false;
+    return { ok: false, errorCode: null, error: null };
   }
 
   const payload = await input.client.openProject(trimmedPath);
   if (payload.error || !payload.workspace) {
-    return false;
+    return {
+      ok: false,
+      errorCode: payload.errorCode ?? null,
+      error: payload.error,
+    };
   }
 
   const workspace = normalizeWorkspaceDescriptor(payload.workspace);
@@ -34,10 +56,10 @@ export async function openProjectDirectly(input: OpenProjectDirectlyInput): Prom
     workspaceId: workspace.id,
   });
   if (!workspaceKey) {
-    return false;
+    return { ok: false, errorCode: null, error: null };
   }
 
   input.openDraftTab(workspaceKey);
   input.navigateToWorkspace(normalizedServerId, workspace.id);
-  return true;
+  return { ok: true };
 }

--- a/packages/app/src/hooks/use-open-project.test.ts
+++ b/packages/app/src/hooks/use-open-project.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { openProjectDirectly } from "@/hooks/open-project";
 import type { WorkspaceDescriptor } from "@/stores/session-store";
 
@@ -91,11 +91,11 @@ describe("openProjectDirectly", () => {
       projectPath: PROJECT_PATH,
       isConnected: true,
       client: {
-        openProject: vi.fn(async () => ({
+        openProject: async () => ({
           requestId: "request-1",
           error: null,
           workspace: workspacePayload,
-        })),
+        }),
       },
       mergeWorkspaces: session.mergeWorkspaces,
       setHasHydratedWorkspaces: session.setHasHydratedWorkspaces,
@@ -103,7 +103,7 @@ describe("openProjectDirectly", () => {
       navigateToWorkspace: navigator.navigateToWorkspace,
     });
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ ok: true });
     expect(session.merges).toHaveLength(1);
     expect(session.merges[0]?.serverId).toBe(SERVER_ID);
     expect(session.merges[0]?.workspaces[0]).toMatchObject({
@@ -127,11 +127,12 @@ describe("openProjectDirectly", () => {
       projectPath: PROJECT_PATH,
       isConnected: true,
       client: {
-        openProject: vi.fn(async () => ({
+        openProject: async () => ({
           requestId: "request-2",
-          error: "Failed to open project",
+          error: "Directory not found: /repo/project",
+          errorCode: "directory_not_found" as const,
           workspace: null,
-        })),
+        }),
       },
       mergeWorkspaces: session.mergeWorkspaces,
       setHasHydratedWorkspaces: session.setHasHydratedWorkspaces,
@@ -139,7 +140,11 @@ describe("openProjectDirectly", () => {
       navigateToWorkspace: navigator.navigateToWorkspace,
     });
 
-    expect(result).toBe(false);
+    expect(result).toEqual({
+      ok: false,
+      errorCode: "directory_not_found",
+      error: "Directory not found: /repo/project",
+    });
     expect(session.merges).toEqual([]);
     expect(session.hydrated).toEqual([]);
     expect(layout.openedTabs).toEqual([]);

--- a/packages/app/src/hooks/use-open-project.ts
+++ b/packages/app/src/hooks/use-open-project.ts
@@ -4,9 +4,11 @@ import { useSessionStore } from "@/stores/session-store";
 import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
 import { generateDraftId } from "@/stores/draft-keys";
 import { navigateToWorkspace } from "@/stores/navigation-active-workspace-store";
-import { openProjectDirectly } from "@/hooks/open-project";
+import { openProjectDirectly, type OpenProjectResult } from "@/hooks/open-project";
 
-export function useOpenProject(serverId: string | null): (path: string) => Promise<boolean> {
+export function useOpenProject(
+  serverId: string | null,
+): (path: string) => Promise<OpenProjectResult> {
   const normalizedServerId = serverId?.trim() ?? "";
   const client = useHostRuntimeClient(normalizedServerId);
   const isConnected = useHostRuntimeIsConnected(normalizedServerId);

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1020,6 +1020,10 @@ export const ar: TranslationResources = {
     placeholder: "اكتب مسار الدليل...",
     opening: "افتتاح المشروع...",
     empty: "ابدأ بكتابة المسار",
+    errors: {
+      directory_not_found: "لم يتم العثور على الدليل.",
+    },
+    openPath: "فتح المسار",
   },
   branchSwitcher: {
     currentBranch: "الفرع الحالي:{{branchName}}. اضغط لتبديل الفرع.",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1022,6 +1022,7 @@ export const ar: TranslationResources = {
     empty: "ابدأ بكتابة المسار",
     errors: {
       directory_not_found: "لم يتم العثور على الدليل.",
+      open_failed: "تعذر فتح المشروع.",
     },
     openPath: "فتح المسار",
   },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1027,6 +1027,7 @@ export const en = {
     empty: "Start typing a path",
     errors: {
       directory_not_found: "Directory not found.",
+      open_failed: "Could not open project.",
     },
     openPath: "Open path",
   },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1025,6 +1025,10 @@ export const en = {
     placeholder: "Type a directory path...",
     opening: "Opening project...",
     empty: "Start typing a path",
+    errors: {
+      directory_not_found: "Directory not found.",
+    },
+    openPath: "Open path",
   },
   branchSwitcher: {
     currentBranch: "Current branch: {{branchName}}. Press to switch branch.",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1052,6 +1052,10 @@ export const es: TranslationResources = {
     placeholder: "Escriba una ruta de directorio...",
     opening: "Proyecto de apertura...",
     empty: "Comience a escribir una ruta",
+    errors: {
+      directory_not_found: "No se encontró el directorio.",
+    },
+    openPath: "Abrir ruta",
   },
   branchSwitcher: {
     currentBranch: "Sucursal actual:{{branchName}}. Presione para cambiar de rama.",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1054,6 +1054,7 @@ export const es: TranslationResources = {
     empty: "Comience a escribir una ruta",
     errors: {
       directory_not_found: "No se encontró el directorio.",
+      open_failed: "No se pudo abrir el proyecto.",
     },
     openPath: "Abrir ruta",
   },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1056,6 +1056,7 @@ export const fr: TranslationResources = {
     empty: "Commencez à taper un chemin",
     errors: {
       directory_not_found: "Répertoire introuvable.",
+      open_failed: "Impossible d’ouvrir le projet.",
     },
     openPath: "Ouvrir le chemin",
   },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1054,6 +1054,10 @@ export const fr: TranslationResources = {
     placeholder: "Tapez un chemin de répertoire...",
     opening: "Projet d'ouverture...",
     empty: "Commencez à taper un chemin",
+    errors: {
+      directory_not_found: "Répertoire introuvable.",
+    },
+    openPath: "Ouvrir le chemin",
   },
   branchSwitcher: {
     currentBranch: "Branche actuelle:{{branchName}}. Appuyez pour changer de branche.",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1044,6 +1044,7 @@ export const ru: TranslationResources = {
     empty: "Начните вводить путь",
     errors: {
       directory_not_found: "Каталог не найден.",
+      open_failed: "Не удалось открыть проект.",
     },
     openPath: "Открыть путь",
   },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1042,6 +1042,10 @@ export const ru: TranslationResources = {
     placeholder: "Введите путь к каталогу...",
     opening: "Открытие проекта...",
     empty: "Начните вводить путь",
+    errors: {
+      directory_not_found: "Каталог не найден.",
+    },
+    openPath: "Открыть путь",
   },
   branchSwitcher: {
     currentBranch: "Текущая ветка:{{branchName}}. Нажмите, чтобы переключить ветку.",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1007,6 +1007,7 @@ export const zhCN: TranslationResources = {
     empty: "开始输入路径",
     errors: {
       directory_not_found: "找不到目录。",
+      open_failed: "无法打开项目。",
     },
     openPath: "打开路径",
   },

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1005,6 +1005,10 @@ export const zhCN: TranslationResources = {
     placeholder: "输入目录路径...",
     opening: "正在打开 project...",
     empty: "开始输入路径",
+    errors: {
+      directory_not_found: "找不到目录。",
+    },
+    openPath: "打开路径",
   },
   branchSwitcher: {
     currentBranch: "当前分支：{{branchName}}。按下以切换分支。",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2622,6 +2622,8 @@ export const OpenProjectResponseMessageSchema = z.object({
     requestId: z.string(),
     workspace: WorkspaceDescriptorPayloadSchema.nullable(),
     error: z.string().nullable(),
+    // Unknown codes from newer daemons degrade to null; clients fall back to `error`.
+    errorCode: z.enum(["directory_not_found"]).nullish().catch(null),
   }),
 });
 

--- a/packages/server/src/server/daemon-e2e/open-project-missing-directory.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/open-project-missing-directory.e2e.test.ts
@@ -1,0 +1,97 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { afterEach, expect, test } from "vitest";
+
+import { DaemonClient, type DaemonEvent } from "../test-utils/daemon-client.js";
+import { createTestPaseoDaemon, type TestPaseoDaemon } from "../test-utils/paseo-daemon.js";
+
+const cleanupPaths = new Set<string>();
+const cleanupDaemons = new Set<TestPaseoDaemon>();
+const cleanupClients = new Set<DaemonClient>();
+
+afterEach(async () => {
+  await Promise.all(Array.from(cleanupClients, (client) => client.close().catch(() => undefined)));
+  cleanupClients.clear();
+  await Promise.all(Array.from(cleanupDaemons, (daemon) => daemon.close().catch(() => undefined)));
+  cleanupDaemons.clear();
+  await Promise.all(
+    Array.from(cleanupPaths, (target) => rm(target, { recursive: true, force: true })),
+  );
+  cleanupPaths.clear();
+});
+
+// Repro for the "project flashes in the sidebar then disappears" report.
+// The project picker submits the typed query verbatim, so open_project can
+// receive a path that does not exist on the daemon's disk. The daemon must not
+// answer with a success + workspace upsert that it immediately retracts.
+test("openProject on a nonexistent directory does not broadcast an upsert that is immediately removed", async () => {
+  const previousSupervised = process.env.PASEO_SUPERVISED;
+  process.env.PASEO_SUPERVISED = "0";
+  try {
+    const daemon = await createTestPaseoDaemon();
+    cleanupDaemons.add(daemon);
+
+    const client = new DaemonClient({ url: `ws://127.0.0.1:${daemon.port}/ws` });
+    cleanupClients.add(client);
+    await client.connect();
+    await client.fetchAgents({ subscribe: { subscriptionId: "missing-dir-agents" } });
+
+    const workspaceEvents: Array<{ kind: "upsert" | "remove"; workspaceId: string }> = [];
+    client.subscribe((event: DaemonEvent) => {
+      if (event.type !== "workspace_update") {
+        return;
+      }
+      workspaceEvents.push({ kind: event.payload.kind, workspaceId: event.workspaceId });
+    });
+    await client.fetchWorkspaces({ subscribe: { subscriptionId: "missing-dir-workspaces" } });
+
+    const tempParent = await mkdtemp(path.join(os.tmpdir(), "paseo-open-project-"));
+    cleanupPaths.add(tempParent);
+    const missingPath = path.join(tempParent, "this-directory-does-not-exist");
+    const response = await client.openProject(missingPath);
+
+    expect(response.workspace).toBeNull();
+    expect(response.error).toBe(`Directory not found: ${missingPath}`);
+    expect(response.errorCode).toBe("directory_not_found");
+    expect(workspaceEvents).toEqual([]);
+  } finally {
+    if (previousSupervised === undefined) {
+      delete process.env.PASEO_SUPERVISED;
+    } else {
+      process.env.PASEO_SUPERVISED = previousSupervised;
+    }
+  }
+}, 30000);
+
+test("openProject expands tilde before creating the workspace", async () => {
+  const previousSupervised = process.env.PASEO_SUPERVISED;
+  process.env.PASEO_SUPERVISED = "0";
+  try {
+    const daemon = await createTestPaseoDaemon();
+    cleanupDaemons.add(daemon);
+
+    const client = new DaemonClient({ url: `ws://127.0.0.1:${daemon.port}/ws` });
+    cleanupClients.add(client);
+    await client.connect();
+    await client.fetchAgents({ subscribe: { subscriptionId: "tilde-project-agents" } });
+    await client.fetchWorkspaces({ subscribe: { subscriptionId: "tilde-project-workspaces" } });
+
+    const home = process.env.HOME || os.homedir();
+    const workspacePath = await mkdtemp(path.join(home, ".paseo-open-project-"));
+    cleanupPaths.add(workspacePath);
+    const queryPath = `~/${path.relative(home, workspacePath)}`;
+
+    const response = await client.openProject(queryPath);
+
+    expect(response.error).toBeNull();
+    expect(response.errorCode).toBeUndefined();
+    expect(response.workspace?.workspaceDirectory).toBe(workspacePath);
+  } finally {
+    if (previousSupervised === undefined) {
+      delete process.env.PASEO_SUPERVISED;
+    } else {
+      process.env.PASEO_SUPERVISED = previousSupervised;
+    }
+  }
+}, 30000);

--- a/packages/server/src/server/daemon-e2e/open-project-missing-directory.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/open-project-missing-directory.e2e.test.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";
-import { afterEach, expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test } from "vitest";
 
 import { DaemonClient, type DaemonEvent } from "../test-utils/daemon-client.js";
 import { createTestPaseoDaemon, type TestPaseoDaemon } from "../test-utils/paseo-daemon.js";
@@ -9,8 +9,15 @@ import { createTestPaseoDaemon, type TestPaseoDaemon } from "../test-utils/paseo
 const cleanupPaths = new Set<string>();
 const cleanupDaemons = new Set<TestPaseoDaemon>();
 const cleanupClients = new Set<DaemonClient>();
+let previousSupervised: string | undefined;
+
+beforeEach(() => {
+  previousSupervised = process.env.PASEO_SUPERVISED;
+  process.env.PASEO_SUPERVISED = "0";
+});
 
 afterEach(async () => {
+  restoreSupervisedEnv();
   await Promise.all(Array.from(cleanupClients, (client) => client.close().catch(() => undefined)));
   cleanupClients.clear();
   await Promise.all(Array.from(cleanupDaemons, (daemon) => daemon.close().catch(() => undefined)));
@@ -21,77 +28,66 @@ afterEach(async () => {
   cleanupPaths.clear();
 });
 
+function restoreSupervisedEnv(): void {
+  if (previousSupervised === undefined) {
+    delete process.env.PASEO_SUPERVISED;
+    return;
+  }
+
+  process.env.PASEO_SUPERVISED = previousSupervised;
+}
+
 // Repro for the "project flashes in the sidebar then disappears" report.
 // The project picker submits the typed query verbatim, so open_project can
 // receive a path that does not exist on the daemon's disk. The daemon must not
 // answer with a success + workspace upsert that it immediately retracts.
 test("openProject on a nonexistent directory does not broadcast an upsert that is immediately removed", async () => {
-  const previousSupervised = process.env.PASEO_SUPERVISED;
-  process.env.PASEO_SUPERVISED = "0";
-  try {
-    const daemon = await createTestPaseoDaemon();
-    cleanupDaemons.add(daemon);
+  const daemon = await createTestPaseoDaemon();
+  cleanupDaemons.add(daemon);
 
-    const client = new DaemonClient({ url: `ws://127.0.0.1:${daemon.port}/ws` });
-    cleanupClients.add(client);
-    await client.connect();
-    await client.fetchAgents({ subscribe: { subscriptionId: "missing-dir-agents" } });
+  const client = new DaemonClient({ url: `ws://127.0.0.1:${daemon.port}/ws` });
+  cleanupClients.add(client);
+  await client.connect();
+  await client.fetchAgents({ subscribe: { subscriptionId: "missing-dir-agents" } });
 
-    const workspaceEvents: Array<{ kind: "upsert" | "remove"; workspaceId: string }> = [];
-    client.subscribe((event: DaemonEvent) => {
-      if (event.type !== "workspace_update") {
-        return;
-      }
-      workspaceEvents.push({ kind: event.payload.kind, workspaceId: event.workspaceId });
-    });
-    await client.fetchWorkspaces({ subscribe: { subscriptionId: "missing-dir-workspaces" } });
-
-    const tempParent = await mkdtemp(path.join(os.tmpdir(), "paseo-open-project-"));
-    cleanupPaths.add(tempParent);
-    const missingPath = path.join(tempParent, "this-directory-does-not-exist");
-    const response = await client.openProject(missingPath);
-
-    expect(response.workspace).toBeNull();
-    expect(response.error).toBe(`Directory not found: ${missingPath}`);
-    expect(response.errorCode).toBe("directory_not_found");
-    expect(workspaceEvents).toEqual([]);
-  } finally {
-    if (previousSupervised === undefined) {
-      delete process.env.PASEO_SUPERVISED;
-    } else {
-      process.env.PASEO_SUPERVISED = previousSupervised;
+  const workspaceEvents: Array<{ kind: "upsert" | "remove"; workspaceId: string }> = [];
+  client.subscribe((event: DaemonEvent) => {
+    if (event.type !== "workspace_update") {
+      return;
     }
-  }
+    workspaceEvents.push({ kind: event.payload.kind, workspaceId: event.workspaceId });
+  });
+  await client.fetchWorkspaces({ subscribe: { subscriptionId: "missing-dir-workspaces" } });
+
+  const tempParent = await mkdtemp(path.join(os.tmpdir(), "paseo-open-project-"));
+  cleanupPaths.add(tempParent);
+  const missingPath = path.join(tempParent, "this-directory-does-not-exist");
+  const response = await client.openProject(missingPath);
+
+  expect(response.workspace).toBeNull();
+  expect(response.error).toBe(`Directory not found: ${missingPath}`);
+  expect(response.errorCode).toBe("directory_not_found");
+  expect(workspaceEvents).toEqual([]);
 }, 30000);
 
 test("openProject expands tilde before creating the workspace", async () => {
-  const previousSupervised = process.env.PASEO_SUPERVISED;
-  process.env.PASEO_SUPERVISED = "0";
-  try {
-    const daemon = await createTestPaseoDaemon();
-    cleanupDaemons.add(daemon);
+  const daemon = await createTestPaseoDaemon();
+  cleanupDaemons.add(daemon);
 
-    const client = new DaemonClient({ url: `ws://127.0.0.1:${daemon.port}/ws` });
-    cleanupClients.add(client);
-    await client.connect();
-    await client.fetchAgents({ subscribe: { subscriptionId: "tilde-project-agents" } });
-    await client.fetchWorkspaces({ subscribe: { subscriptionId: "tilde-project-workspaces" } });
+  const client = new DaemonClient({ url: `ws://127.0.0.1:${daemon.port}/ws` });
+  cleanupClients.add(client);
+  await client.connect();
+  await client.fetchAgents({ subscribe: { subscriptionId: "tilde-project-agents" } });
+  await client.fetchWorkspaces({ subscribe: { subscriptionId: "tilde-project-workspaces" } });
 
-    const home = process.env.HOME || os.homedir();
-    const workspacePath = await mkdtemp(path.join(home, ".paseo-open-project-"));
-    cleanupPaths.add(workspacePath);
-    const queryPath = `~/${path.relative(home, workspacePath)}`;
+  const home = process.env.HOME || os.homedir();
+  const workspacePath = await mkdtemp(path.join(home, ".paseo-open-project-"));
+  cleanupPaths.add(workspacePath);
+  const queryPath = `~/${path.relative(home, workspacePath)}`;
 
-    const response = await client.openProject(queryPath);
+  const response = await client.openProject(queryPath);
 
-    expect(response.error).toBeNull();
-    expect(response.errorCode).toBeUndefined();
-    expect(response.workspace?.workspaceDirectory).toBe(workspacePath);
-  } finally {
-    if (previousSupervised === undefined) {
-      delete process.env.PASEO_SUPERVISED;
-    } else {
-      process.env.PASEO_SUPERVISED = previousSupervised;
-    }
-  }
+  expect(response.error).toBeNull();
+  expect(response.errorCode).toBeUndefined();
+  expect(response.workspace?.workspaceDirectory).toBe(workspacePath);
 }, 30000);

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -720,6 +720,19 @@ interface AgentTimelineProjectionSelection {
   hasNewer: boolean;
 }
 
+type RegistryTransition = "created" | "unarchived" | "existing";
+
+interface ArchivedRecordSnapshot {
+  archivedAt?: string | null;
+}
+
+function describeRegistryTransition(record: ArchivedRecordSnapshot | null): RegistryTransition {
+  if (!record) {
+    return "created";
+  }
+  return record.archivedAt ? "unarchived" : "existing";
+}
+
 /**
  * Session represents a single connected client session.
  * It owns all state management, orchestration logic, and message processing.
@@ -6756,15 +6769,32 @@ export class Session {
   }
 
   private async archiveWorkspaceRecord(workspaceId: string, archivedAt?: string): Promise<void> {
+    const archiveTimestamp = archivedAt ?? new Date().toISOString();
     const existingWorkspace = await archivePersistedWorkspaceRecord({
       workspaceId,
-      archivedAt,
+      archivedAt: archiveTimestamp,
       workspaceRegistry: this.workspaceRegistry,
       projectRegistry: this.projectRegistry,
     });
     if (!existingWorkspace) {
       this.removeWorkspaceGitSubscription(workspaceId);
       return;
+    }
+
+    if (!existingWorkspace.archivedAt) {
+      const activeSiblings = (await this.workspaceRegistry.list()).filter(
+        (workspace) => workspace.projectId === existingWorkspace.projectId && !workspace.archivedAt,
+      );
+      this.sessionLogger.info(
+        {
+          workspaceId,
+          workspaceCwd: existingWorkspace.cwd,
+          projectId: existingWorkspace.projectId,
+          projectArchived: activeSiblings.length === 0,
+          archivedAt: archiveTimestamp,
+        },
+        "Workspace archived",
+      );
     }
 
     await this.removeWorkspaceGitWatchTarget(existingWorkspace.cwd);
@@ -7157,9 +7187,14 @@ export class Session {
   private async handleOpenProjectRequest(
     request: Extract<SessionInboundMessage, { type: "open_project_request" }>,
   ): Promise<void> {
-    const cwd = expandTilde(request.cwd);
+    const requestedCwd = request.cwd;
+    const cwd = expandTilde(requestedCwd);
     const cwdStats = await stat(cwd).catch(() => null);
     if (!cwdStats?.isDirectory()) {
+      this.sessionLogger.info(
+        { requestedCwd, resolvedCwd: cwd, reason: "directory_not_found" },
+        "Open project rejected",
+      );
       this.emit({
         type: "open_project_response",
         payload: {
@@ -7173,10 +7208,37 @@ export class Session {
     }
 
     try {
+      const projectsBefore = new Map<string, PersistedProjectRecord>();
+      for (const project of await this.projectRegistry.list()) {
+        projectsBefore.set(project.projectId, project);
+      }
+      const workspacesBefore = new Map<string, PersistedWorkspaceRecord>();
+      for (const workspaceRecord of await this.workspaceRegistry.list()) {
+        workspacesBefore.set(workspaceRecord.workspaceId, workspaceRecord);
+      }
       const workspace = await this.findOrCreateWorkspaceForDirectory(cwd);
+      const project = await this.projectRegistry.get(workspace.projectId);
       await this.syncWorkspaceGitObserverForWorkspace(workspace);
       const descriptor = await this.describeWorkspaceRecord(workspace);
       await this.emitWorkspaceUpdateForCwd(workspace.cwd);
+      this.sessionLogger.info(
+        {
+          requestedCwd,
+          resolvedCwd: cwd,
+          workspaceCwd: workspace.cwd,
+          workspaceId: workspace.workspaceId,
+          workspaceKind: workspace.kind,
+          workspaceTransition: describeRegistryTransition(
+            workspacesBefore.get(workspace.workspaceId) ?? null,
+          ),
+          projectId: workspace.projectId,
+          projectKind: project?.kind ?? null,
+          projectTransition: describeRegistryTransition(
+            projectsBefore.get(workspace.projectId) ?? null,
+          ),
+        },
+        "Project opened",
+      );
       this.emit({
         type: "open_project_response",
         payload: {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2,6 +2,7 @@ import equal from "fast-deep-equal";
 import { v4 as uuidv4 } from "uuid";
 import { realpathSync } from "node:fs";
 import type { FSWatcher } from "node:fs";
+import { stat } from "node:fs/promises";
 import { basename, resolve, sep } from "path";
 import { homedir } from "node:os";
 import { z } from "zod";
@@ -7156,8 +7157,23 @@ export class Session {
   private async handleOpenProjectRequest(
     request: Extract<SessionInboundMessage, { type: "open_project_request" }>,
   ): Promise<void> {
+    const cwd = expandTilde(request.cwd);
+    const cwdStats = await stat(cwd).catch(() => null);
+    if (!cwdStats?.isDirectory()) {
+      this.emit({
+        type: "open_project_response",
+        payload: {
+          requestId: request.requestId,
+          workspace: null,
+          error: `Directory not found: ${cwd}`,
+          errorCode: "directory_not_found",
+        },
+      });
+      return;
+    }
+
     try {
-      const workspace = await this.findOrCreateWorkspaceForDirectory(request.cwd);
+      const workspace = await this.findOrCreateWorkspaceForDirectory(cwd);
       await this.syncWorkspaceGitObserverForWorkspace(workspace);
       const descriptor = await this.describeWorkspaceRecord(workspace);
       await this.emitWorkspaceUpdateForCwd(workspace.cwd);
@@ -7183,7 +7199,7 @@ export class Session {
         });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to open project";
-      this.sessionLogger.error({ err: error, cwd: request.cwd }, "Failed to open project");
+      this.sessionLogger.error({ err: error, cwd }, "Failed to open project");
       this.emit({
         type: "open_project_response",
         payload: {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -534,6 +534,17 @@ interface AudioBufferState {
   totalPCMBytes: number;
 }
 
+export interface SessionFileSystem {
+  isDirectory(path: string): Promise<boolean>;
+}
+
+const nodeSessionFileSystem: SessionFileSystem = {
+  async isDirectory(path) {
+    const stats = await stat(path).catch(() => null);
+    return stats?.isDirectory() ?? false;
+  },
+};
+
 // Stub types for features under development (modules not yet available)
 type AgentMcpTransportFactory = () => Promise<unknown>;
 
@@ -565,6 +576,7 @@ export interface SessionOptions {
   agentStorage: AgentStorage;
   projectRegistry: ProjectRegistry;
   workspaceRegistry: WorkspaceRegistry;
+  filesystem?: SessionFileSystem;
   chatService: FileBackedChatService;
   scheduleService: ScheduleService;
   loopService: LoopService;
@@ -784,6 +796,7 @@ export class Session {
   private readonly agentStorage: AgentStorage;
   private readonly projectRegistry: ProjectRegistry;
   private readonly workspaceRegistry: WorkspaceRegistry;
+  private readonly filesystem: SessionFileSystem;
   private readonly chatService: FileBackedChatService;
   private readonly scheduleService: ScheduleService;
   private readonly loopService: LoopService;
@@ -858,6 +871,7 @@ export class Session {
       agentStorage,
       projectRegistry,
       workspaceRegistry,
+      filesystem,
       chatService,
       scheduleService,
       loopService,
@@ -907,6 +921,7 @@ export class Session {
     this.agentStorage = agentStorage;
     this.projectRegistry = projectRegistry;
     this.workspaceRegistry = workspaceRegistry;
+    this.filesystem = filesystem ?? nodeSessionFileSystem;
     this.chatService = chatService;
     this.scheduleService = scheduleService;
     this.loopService = loopService;
@@ -7189,8 +7204,8 @@ export class Session {
   ): Promise<void> {
     const requestedCwd = request.cwd;
     const cwd = expandTilde(requestedCwd);
-    const cwdStats = await stat(cwd).catch(() => null);
-    if (!cwdStats?.isDirectory()) {
+    const directoryExists = await this.filesystem.isDirectory(cwd).catch(() => false);
+    if (!directoryExists) {
       this.sessionLogger.info(
         { requestedCwd, resolvedCwd: cwd, reason: "directory_not_found" },
         "Open project rejected",

--- a/packages/server/src/server/session.workspace-resolution-invariants.test.ts
+++ b/packages/server/src/server/session.workspace-resolution-invariants.test.ts
@@ -138,6 +138,7 @@ function createHarness(input: {
         workspaces.delete(id);
       },
     }),
+    filesystem: { isDirectory: async () => true },
     chatService: createStub<SessionOptions["chatService"]>({}),
     scheduleService: createStub<SessionOptions["scheduleService"]>({}),
     loopService: createStub<SessionOptions["loopService"]>({}),

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -512,6 +512,7 @@ function createSessionForWorkspaceTests(
         archive: async () => {},
         remove: async () => {},
       },
+      filesystem: { isDirectory: async () => true },
       chatService: asChatService(),
       scheduleService: asScheduleService(),
       loopService: asLoopService(),

--- a/packages/server/src/server/workspace-reconciliation-service.test.ts
+++ b/packages/server/src/server/workspace-reconciliation-service.test.ts
@@ -73,6 +73,26 @@ function createTestLogger() {
   return logger as unknown as pino.Logger;
 }
 
+interface CapturedLogRecord {
+  message: string;
+  payload: unknown;
+}
+
+function createCapturingLogger() {
+  const infoRecords: CapturedLogRecord[] = [];
+  const logger = {
+    child: () => logger,
+    trace: () => undefined,
+    debug: () => undefined,
+    info: (payload: unknown, message?: string) => {
+      infoRecords.push({ payload, message: message ?? "" });
+    },
+    warn: () => undefined,
+    error: () => undefined,
+  };
+  return { logger: logger as unknown as pino.Logger, infoRecords };
+}
+
 function createWorkspaceGitServiceStub(
   metadataByCwd: Record<
     string,
@@ -691,5 +711,81 @@ describe("WorkspaceReconciliationService", () => {
 
     expect(onChanges).toHaveBeenCalledTimes(1);
     expect(onChanges.mock.calls[0][0].length).toBeGreaterThan(0);
+  });
+
+  test("logs reconciliation changes with affected paths and reasons", async () => {
+    const { projects, workspaces, projectRegistry, workspaceRegistry } = createTestRegistries();
+    const { logger, infoRecords } = createCapturingLogger();
+
+    projects.set(
+      "p1",
+      createPersistedProjectRecord({
+        projectId: "p1",
+        rootPath: "/tmp/does-not-exist-log-test",
+        kind: "non_git",
+        displayName: "ghost",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      }),
+    );
+    workspaces.set(
+      "w1",
+      createPersistedWorkspaceRecord({
+        workspaceId: "w1",
+        projectId: "p1",
+        cwd: "/tmp/does-not-exist-log-test",
+        kind: "directory",
+        displayName: "ghost",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      }),
+    );
+
+    const service = new WorkspaceReconciliationService({
+      projectRegistry,
+      workspaceRegistry,
+      logger,
+    });
+
+    await service.runOnce();
+
+    expect(infoRecords).toEqual([
+      {
+        message: "Workspace reconciliation applied changes",
+        payload: expect.objectContaining({
+          changeCount: 2,
+          changes: expect.arrayContaining([
+            {
+              kind: "workspace_archived",
+              workspaceId: "w1",
+              directory: "/tmp/does-not-exist-log-test",
+              reason: "directory_missing",
+            },
+            {
+              kind: "project_archived",
+              projectId: "p1",
+              directory: "/tmp/does-not-exist-log-test",
+              reason: "no_active_workspaces",
+            },
+          ]),
+          durationMs: expect.any(Number),
+        }),
+      },
+    ]);
+  });
+
+  test("does not log reconciliation when no changes are applied", async () => {
+    const { projectRegistry, workspaceRegistry } = createTestRegistries();
+    const { logger, infoRecords } = createCapturingLogger();
+
+    const service = new WorkspaceReconciliationService({
+      projectRegistry,
+      workspaceRegistry,
+      logger,
+    });
+
+    await service.runOnce();
+
+    expect(infoRecords).toEqual([]);
   });
 });

--- a/packages/server/src/server/workspace-reconciliation-service.ts
+++ b/packages/server/src/server/workspace-reconciliation-service.ts
@@ -109,13 +109,7 @@ export class WorkspaceReconciliationService {
     if (this.running) return;
     this.running = true;
     try {
-      const result = await this.reconcile();
-      if (result.changesApplied.length > 0) {
-        this.logger.info(
-          { changeCount: result.changesApplied.length, durationMs: result.durationMs },
-          "Reconciliation pass completed with changes",
-        );
-      }
+      await this.reconcile();
     } catch (error) {
       this.logger.error({ err: error }, "Reconciliation pass failed");
     } finally {
@@ -201,7 +195,19 @@ export class WorkspaceReconciliationService {
       this.onChanges(changes);
     }
 
-    return { changesApplied: changes, durationMs: Date.now() - start };
+    const result = { changesApplied: changes, durationMs: Date.now() - start };
+    if (changes.length > 0) {
+      this.logger.info(
+        {
+          changeCount: changes.length,
+          durationMs: result.durationMs,
+          changes,
+        },
+        "Workspace reconciliation applied changes",
+      );
+    }
+
+    return result;
   }
 
   private async mergeDuplicateProjectsByRoot(


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The project picker no longer turns arbitrary typed words into openable project paths. Pasted path-like input is shown as an explicit “Open path” row, and missing directories keep the picker open with an inline error instead of briefly adding a workspace that disappears from the sidebar.

The picker also surfaces thrown project-open failures, such as connection or transport errors, instead of returning to an idle state with no feedback.

The daemon validates the requested directory before creating or broadcasting a workspace, including expanding `~` first. It also logs project lifecycle changes at info level — project opens, rejected paths, workspace archives, and reconciliation changes — with the affected paths and reasons so support logs explain why a project appeared or disappeared.

### How did you verify it

- `npx vitest run src/server/daemon-e2e/open-project-missing-directory.e2e.test.ts --bail=1` in `packages/server`
- `npx vitest run src/server/workspace-reconciliation-service.test.ts src/server/daemon-e2e/open-project-missing-directory.e2e.test.ts --bail=1` in `packages/server`
- `npx vitest run src/hooks/use-open-project.test.ts src/components/project-picker-options.test.ts src/i18n/resources.test.ts --bail=1` in `packages/app`
- `npm run build:server`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- Web smoke via worktree Expo + agent-browser snapshot: word query had no openable custom row; path-like query showed `Open path: /tmp/paseo-browser-smoke-missing`.

### Risk surface

- The protocol adds an optional project-open error code. Old clients still get the existing raw error string; newer clients treat unknown future codes as `null` and fall back to the raw error.
- The picker UI was manually smoked on web only. Native uses the same React Native component, but iOS/Android rendering was not manually checked.
- Windows-style path detection is unit-covered, but no Windows daemon smoke was run.
- Project lifecycle logs intentionally include local project paths in the daemon log so disappearance reports can be diagnosed from user-provided logs.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense