### PR TITLE
Make login-shell env probe resilient on slow shells

### DIFF
--- a/packages/desktop/src/login-shell-env.test.ts
+++ b/packages/desktop/src/login-shell-env.test.ts
@@ -27,6 +27,11 @@ describe("getResolveTimeoutMs", () => {
     expect(getResolveTimeoutMs()).toBe(45_000);
   });
 
+  it("parses scientific notation rather than truncating it", () => {
+    process.env[KEY] = "60e3";
+    expect(getResolveTimeoutMs()).toBe(60_000);
+  });
+
   it("falls back on non-numeric values", () => {
     process.env[KEY] = "soon";
     expect(getResolveTimeoutMs()).toBe(DEFAULT_RESOLVE_TIMEOUT_MS);

--- a/packages/desktop/src/login-shell-env.test.ts
+++ b/packages/desktop/src/login-shell-env.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_RESOLVE_TIMEOUT_MS, getResolveTimeoutMs } from "./login-shell-env";
+
+vi.mock("electron-log/main", () => ({
+  default: { info: vi.fn(), warn: vi.fn() },
+}));
+
+describe("getResolveTimeoutMs", () => {
+  const KEY = "PASEO_SHELL_ENV_TIMEOUT_MS";
+  const original = process.env[KEY];
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[KEY];
+    } else {
+      process.env[KEY] = original;
+    }
+  });
+
+  it("defaults when the override is unset", () => {
+    delete process.env[KEY];
+    expect(getResolveTimeoutMs()).toBe(DEFAULT_RESOLVE_TIMEOUT_MS);
+  });
+
+  it("honors a positive override", () => {
+    process.env[KEY] = "45000";
+    expect(getResolveTimeoutMs()).toBe(45_000);
+  });
+
+  it("falls back on non-numeric values", () => {
+    process.env[KEY] = "soon";
+    expect(getResolveTimeoutMs()).toBe(DEFAULT_RESOLVE_TIMEOUT_MS);
+  });
+
+  it("falls back on non-positive values", () => {
+    process.env[KEY] = "0";
+    expect(getResolveTimeoutMs()).toBe(DEFAULT_RESOLVE_TIMEOUT_MS);
+  });
+});

--- a/packages/desktop/src/login-shell-env.ts
+++ b/packages/desktop/src/login-shell-env.ts
@@ -6,8 +6,33 @@ import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { userInfo } from "node:os";
 import { basename } from "node:path";
+import log from "electron-log/main";
 
-const RESOLVE_TIMEOUT_MS = 10_000;
+/**
+ * Default timeout for the login-shell environment probe.
+ *
+ * The probe spawns an interactive login shell, which sources the user's full
+ * shell init (e.g. oh-my-zsh, eager nvm, compinit). On a cold start that can
+ * take well over 10s, so the previous fixed 10s budget was routinely exceeded,
+ * silently falling back to the minimal launchd environment and making CLIs that
+ * live only on the shell PATH (e.g. nvm-installed Claude/Codex) look like they
+ * are "not installed".
+ */
+export const DEFAULT_RESOLVE_TIMEOUT_MS = 30_000;
+
+/**
+ * Timeout (ms) for the login-shell environment probe. Override with the
+ * `PASEO_SHELL_ENV_TIMEOUT_MS` environment variable; invalid or non-positive
+ * values fall back to {@link DEFAULT_RESOLVE_TIMEOUT_MS}.
+ */
+export function getResolveTimeoutMs(): number {
+  const raw = process.env.PASEO_SHELL_ENV_TIMEOUT_MS;
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_RESOLVE_TIMEOUT_MS;
+}
 
 function getSystemShell(): string {
   const shell = process.env.SHELL;
@@ -59,9 +84,10 @@ function resolveShellEnv(): Record<string, string> | undefined {
   delete shellEnv.PASEO_DESKTOP_MANAGED;
   delete shellEnv.PASEO_SUPERVISED;
 
+  const timeoutMs = getResolveTimeoutMs();
   const result = spawnSync(shell, [...shellArgs, command], {
     encoding: "utf8",
-    timeout: RESOLVE_TIMEOUT_MS,
+    timeout: timeoutMs,
     windowsHide: true,
     env: {
       ...shellEnv,
@@ -70,11 +96,28 @@ function resolveShellEnv(): Record<string, string> | undefined {
     },
   });
 
-  if (result.status !== 0 && result.status !== null) return undefined;
-  if (!result.stdout) return undefined;
+  if (result.error) {
+    const timedOut = (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT";
+    const detail = timedOut
+      ? `timed out after ${timeoutMs}ms (set PASEO_SHELL_ENV_TIMEOUT_MS to raise it)`
+      : result.error.message;
+    log.warn(`[login-shell-env] could not resolve ${shell} environment: ${detail}`);
+    return undefined;
+  }
+  if (result.status !== 0 && result.status !== null) {
+    log.warn(`[login-shell-env] ${shell} exited with status ${result.status}`);
+    return undefined;
+  }
+  if (!result.stdout) {
+    log.warn(`[login-shell-env] ${shell} produced no output`);
+    return undefined;
+  }
 
   const match = regex.exec(result.stdout);
-  if (!match?.[1]) return undefined;
+  if (!match?.[1]) {
+    log.warn(`[login-shell-env] could not parse environment marker from ${shell} output`);
+    return undefined;
+  }
 
   try {
     const env = JSON.parse(match[1]) as Record<string, string>;
@@ -94,7 +137,8 @@ function resolveShellEnv(): Record<string, string> | undefined {
     delete env.XDG_RUNTIME_DIR;
 
     return env;
-  } catch {
+  } catch (error) {
+    log.warn(`[login-shell-env] failed to parse ${shell} environment output: ${String(error)}`);
     return undefined;
   }
 }
@@ -112,8 +156,11 @@ export function inheritLoginShellEnv(): void {
     const env = resolveShellEnv();
     if (env) {
       Object.assign(process.env, env);
+      log.info(`[login-shell-env] inherited ${Object.keys(env).length} vars from login shell`);
+    } else {
+      log.warn("[login-shell-env] login shell env unresolved; nvm CLIs may appear unavailable");
     }
-  } catch {
-    // Keep inherited environment if shell lookup fails.
+  } catch (error) {
+    log.warn(`[login-shell-env] unexpected error resolving login shell env: ${String(error)}`);
   }
 }

--- a/packages/desktop/src/login-shell-env.ts
+++ b/packages/desktop/src/login-shell-env.ts
@@ -28,7 +28,9 @@ export const DEFAULT_RESOLVE_TIMEOUT_MS = 30_000;
 export function getResolveTimeoutMs(): number {
   const raw = process.env.PASEO_SHELL_ENV_TIMEOUT_MS;
   if (raw) {
-    const parsed = Number.parseInt(raw, 10);
+    // Number() (not parseInt) so "60e3" parses as 60000 rather than being
+    // truncated to 60ms, which would nearly disable the probe.
+    const parsed = Number(raw.trim());
     if (Number.isFinite(parsed) && parsed > 0) return parsed;
   }
   return DEFAULT_RESOLVE_TIMEOUT_MS;


### PR DESCRIPTION
## What

Make the desktop login-shell environment probe resilient on slow shells, and
stop it from failing silently.

Fixes #1492.

## Why

`packages/desktop/src/login-shell-env.ts` imports the user's PATH by spawning an
interactive login shell. It used a fixed 10s timeout and swallowed every failure
with `return undefined` and no logging. On a heavy cold-start shell (oh-my-zsh +
eager nvm + double `compinit`, measured at ~31s cold on my machine) the probe
blows the budget, falls back to the minimal launchd environment, and
nvm-installed CLIs (Claude, Codex) show up as "not available" — with nothing in
`daemon.log` to explain it. Because the probe runs once at startup, a single slow
launch pins the daemon to a broken PATH until it is restarted.

## Changes

- Raise the default timeout to 30s and make it configurable via
  `PASEO_SHELL_ENV_TIMEOUT_MS` (`getResolveTimeoutMs`).
- Detect spawn errors / timeouts explicitly (`result.error` + `ETIMEDOUT`) and
  log every failure path (timeout, non-zero exit, empty output, parse failure)
  plus a one-line success message, so `daemon.log` shows whether the probe
  worked and why it didn't.
- Add unit tests for the timeout resolution.

## Follow-ups (not in this PR)

- The provider "not available — ensure the CLI is installed" message could
  distinguish "not on PATH" from "not installed" and hint about the macOS GUI
  launchd PATH.
- Could additionally retry the probe and/or cache a resolved env to disk.

## Testing

- `packages/desktop/src/login-shell-env.test.ts` covers `getResolveTimeoutMs`
  (default / override / non-numeric / non-positive).
- Heads up: I could not run the repo toolchain locally (mise + `node_modules`
  not installed in my checkout, and the configured npm registry was
  unreachable), so typecheck / lint / format / test rely on CI here. The change
  is small and self-contained; please confirm CI is green before merge.
