### PR TITLE
Fix coding-agent terminal shortcuts not working on Windows

### DIFF
--- a/packages/app/src/screens/workspace/terminals/use-workspace-terminals.ts
+++ b/packages/app/src/screens/workspace/terminals/use-workspace-terminals.ts
@@ -43,6 +43,7 @@ interface UseWorkspaceTerminalsInput {
   onScriptTerminalSelected: (terminalId: string) => void;
   onWorkspacePathUnavailable: () => void;
   onTerminalCreateQueued: () => void;
+  onTerminalCreateFailed: (reason: string) => void;
 }
 
 export function useWorkspaceTerminals(input: UseWorkspaceTerminalsInput) {
@@ -60,6 +61,7 @@ export function useWorkspaceTerminals(input: UseWorkspaceTerminalsInput) {
     onScriptTerminalSelected,
     onWorkspacePathUnavailable,
     onTerminalCreateQueued,
+    onTerminalCreateFailed,
   } = input;
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -119,11 +121,19 @@ export function useWorkspaceTerminals(input: UseWorkspaceTerminalsInput) {
       if (!client || !workspaceDirectory) {
         throw new Error(t("workspace.terminal.hostDisconnected"));
       }
-      if (_input?.profile) {
-        const { name, command, args } = _input.profile;
-        return await client.createTerminal(workspaceDirectory, name, undefined, { command, args });
+      const payload = _input?.profile
+        ? await client.createTerminal(workspaceDirectory, _input.profile.name, undefined, {
+            command: _input.profile.command,
+            args: _input.profile.args,
+          })
+        : await client.createTerminal(workspaceDirectory);
+      // The daemon reports a failed spawn (e.g. a profile command that isn't
+      // installed) via payload.error with a null terminal. Surface it instead
+      // of silently treating the create as a no-op success.
+      if (!payload.terminal && payload.error) {
+        throw new Error(payload.error);
       }
-      return await client.createTerminal(workspaceDirectory);
+      return payload;
     },
     onSuccess: (payload, createInput) => {
       const createdTerminal = payload.terminal;
@@ -144,6 +154,9 @@ export function useWorkspaceTerminals(input: UseWorkspaceTerminalsInput) {
           paneId: createInput?.paneId,
         });
       }
+    },
+    onError: (error: unknown) => {
+      onTerminalCreateFailed(error instanceof Error ? error.message : String(error));
     },
   });
   const killMutation = useMutation({

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -1642,6 +1642,7 @@ interface WorkspaceTerminalTabActions {
   handleScriptTerminalSelected: (terminalId: string) => void;
   handleWorkspacePathUnavailable: () => void;
   handleTerminalCreateQueued: () => void;
+  handleTerminalCreateFailed: (reason: string) => void;
 }
 
 function useWorkspaceTerminalTabActions({
@@ -1678,12 +1679,19 @@ function useWorkspaceTerminalTabActions({
   const handleTerminalCreateQueued = useCallback(() => {
     toast.show(labels.terminalQueued);
   }, [labels.terminalQueued, toast]);
+  const handleTerminalCreateFailed = useCallback(
+    (reason: string) => {
+      toast.error(reason);
+    },
+    [toast],
+  );
 
   return {
     handleTerminalCreated,
     handleScriptTerminalSelected,
     handleWorkspacePathUnavailable,
     handleTerminalCreateQueued,
+    handleTerminalCreateFailed,
   };
 }
 
@@ -1826,6 +1834,7 @@ function WorkspaceScreenContent({
     handleScriptTerminalSelected,
     handleWorkspacePathUnavailable,
     handleTerminalCreateQueued,
+    handleTerminalCreateFailed,
   } = useWorkspaceTerminalTabActions({
     persistenceKey,
     focusWorkspacePane,
@@ -1866,6 +1875,7 @@ function WorkspaceScreenContent({
     onScriptTerminalSelected: handleScriptTerminalSelected,
     onWorkspacePathUnavailable: handleWorkspacePathUnavailable,
     onTerminalCreateQueued: handleTerminalCreateQueued,
+    onTerminalCreateFailed: handleTerminalCreateFailed,
   });
   const { archiveAgent } = useArchiveAgent();
 

--- a/packages/server/src/executable-resolution/executable-resolution.probe.test.ts
+++ b/packages/server/src/executable-resolution/executable-resolution.probe.test.ts
@@ -13,7 +13,7 @@ import { performance } from "node:perf_hooks";
 import { afterEach, describe, expect, test } from "vitest";
 
 import { isPlatform } from "../test-utils/platform.js";
-import { probeExecutable } from "./executable.js";
+import { probeExecutable } from "./executable-resolution.js";
 
 const timeoutMs = 1000;
 const timeoutSlackMs = 500;

--- a/packages/server/src/executable-resolution/executable-resolution.test.ts
+++ b/packages/server/src/executable-resolution/executable-resolution.test.ts
@@ -1,15 +1,14 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 
 import {
-  enumerateWindowsKnownInstallCandidates,
   executableExists,
   findExecutable,
   quoteWindowsArgument,
   quoteWindowsCommand,
-} from "./executable.js";
+} from "./executable-resolution.js";
 import { isPlatform } from "../test-utils/platform.js";
 
 const originalEnv = {
@@ -101,6 +100,36 @@ describe("findExecutable", () => {
 
       expectWindowsPathsEqual(await findExecutable("foo"), cmd);
     });
+
+    test("finds a .cmd for an extensionless absolute path", async () => {
+      const dir = makeTempDir();
+      const command = path.join(dir, "codex");
+      const cmd = writeExecutable(`${command}.cmd`, "@echo off\r\necho 0.1\r\n");
+
+      expectWindowsPathsEqual(await findExecutable(command), cmd);
+    });
+
+    test("finds a winget portable executable outside PATH", async () => {
+      const originalLocalAppData = process.env.LOCALAPPDATA;
+      const localAppData = makeTempDir();
+      const packageDir = path.join(
+        localAppData,
+        "Microsoft",
+        "WinGet",
+        "Packages",
+        "Anthropic.ClaudeCode_abc",
+      );
+      mkdirSync(packageDir, { recursive: true });
+      const claude = path.join(packageDir, "claude.exe");
+      copyFileSync(process.execPath, claude);
+      process.env.LOCALAPPDATA = localAppData;
+      process.env.PATH = makeTempDir();
+      try {
+        expectWindowsPathsEqual(await findExecutable("claude"), claude);
+      } finally {
+        process.env.LOCALAPPDATA = originalLocalAppData;
+      }
+    });
   });
 
   test("returns an invokable absolute path", async () => {
@@ -119,47 +148,6 @@ describe("findExecutable", () => {
     prependPath(dir);
 
     await expect(findExecutable("paseo-definitely-missing-command")).resolves.toBeNull();
-  });
-});
-
-describe("enumerateWindowsKnownInstallCandidates", () => {
-  test("returns nothing on non-Windows platforms", () => {
-    expect(
-      enumerateWindowsKnownInstallCandidates("claude", {
-        platform: "darwin",
-        localAppData: "/Users/me/AppData/Local",
-      }),
-    ).toEqual([]);
-  });
-
-  test("returns nothing when LOCALAPPDATA is unavailable", () => {
-    expect(
-      enumerateWindowsKnownInstallCandidates("claude", { platform: "win32", localAppData: "" }),
-    ).toEqual([]);
-  });
-
-  test("scans winget package dirs for a portable executable not on PATH", () => {
-    const localAppData = makeTempDir();
-    const packages = path.join(localAppData, "Microsoft", "WinGet", "Packages");
-    // A portable package drops the exe at its root (like Anthropic.ClaudeCode).
-    mkdirSync(path.join(packages, "Anthropic.ClaudeCode_abc"), { recursive: true });
-    mkdirSync(path.join(packages, "Some.Other_xyz"), { recursive: true });
-
-    const candidates = enumerateWindowsKnownInstallCandidates("claude", {
-      platform: "win32",
-      localAppData,
-    });
-
-    // Each package dir is probed at its root, where portable packages drop the exe.
-    expect(candidates).toContain(path.join(packages, "Anthropic.ClaudeCode_abc", "claude.exe"));
-    expect(candidates).toContain(path.join(packages, "Some.Other_xyz", "claude.exe"));
-  });
-
-  test("returns nothing when the winget Packages dir is absent", () => {
-    const localAppData = makeTempDir();
-    expect(
-      enumerateWindowsKnownInstallCandidates("claude", { platform: "win32", localAppData }),
-    ).toEqual([]);
   });
 });
 

--- a/packages/server/src/executable-resolution/executable-resolution.ts
+++ b/packages/server/src/executable-resolution/executable-resolution.ts
@@ -1,10 +1,10 @@
 import { createRequire } from "node:module";
-import { existsSync, readdirSync } from "node:fs";
-import { extname, join } from "node:path";
-import { execCommand } from "./spawn.js";
-import { isWindowsCommandScript } from "./windows-command.js";
+import { existsSync } from "node:fs";
+import { execCommand } from "../utils/spawn.js";
+import { isWindowsCommandScript } from "../utils/windows-command.js";
+import { windowsExecutableResolution } from "./windows.js";
 
-export { quoteWindowsArgument, quoteWindowsCommand } from "./windows-command.js";
+export { quoteWindowsArgument, quoteWindowsCommand } from "../utils/windows-command.js";
 
 type Which = (command: string, options: { all: true }) => Promise<string[]>;
 
@@ -21,50 +21,6 @@ async function enumerateCandidates(name: string): Promise<string[]> {
     return enumerateCandidatesViaSystemWhich(name);
   }
   return enumerateCandidatesViaLibrary(name);
-}
-
-export interface WindowsKnownInstallOptions {
-  platform?: NodeJS.Platform;
-  localAppData?: string;
-}
-
-/**
- * Find an executable installed by `winget` outside of PATH.
- *
- * winget "portable" packages (like Claude Code) extract their executable into
- * `%LOCALAPPDATA%\Microsoft\WinGet\Packages\<PackageId>\` but do NOT add that
- * directory to PATH or create a Links shim, so PATH-based lookup can't find
- * them. Rather than hardcode each tool's package id, scan every winget package
- * directory for a matching `<name>.exe`. This keeps a single generic fallback
- * that any provider's command resolution benefits from — no per-tool probe.
- */
-export function enumerateWindowsKnownInstallCandidates(
-  name: string,
-  options: WindowsKnownInstallOptions = {},
-): string[] {
-  const platform = options.platform ?? process.platform;
-  if (platform !== "win32") {
-    return [];
-  }
-  const localAppData = options.localAppData ?? process.env.LOCALAPPDATA;
-  if (!localAppData) {
-    return [];
-  }
-
-  const wingetPackages = join(localAppData, "Microsoft", "WinGet", "Packages");
-  let packageDirs: string[];
-  try {
-    packageDirs = readdirSync(wingetPackages, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name);
-  } catch {
-    return [];
-  }
-
-  // winget "portable" packages (e.g. Anthropic.ClaudeCode) drop their
-  // executable at the package root, so probe `<packageDir>/<name>.exe`.
-  const exeName = `${name}.exe`;
-  return packageDirs.map((packageDir) => join(wingetPackages, packageDir, exeName));
 }
 
 async function enumerateCandidatesViaSystemWhich(name: string): Promise<string[]> {
@@ -146,14 +102,10 @@ export function executableExists(
   executablePath: string,
   exists: typeof existsSync = existsSync,
 ): string | null {
-  if (exists(executablePath)) return executablePath;
-  if (process.platform === "win32" && !extname(executablePath)) {
-    for (const ext of [".exe", ".cmd"]) {
-      const candidate = executablePath + ext;
-      if (exists(candidate)) return candidate;
-    }
+  if (process.platform === "win32") {
+    return windowsExecutableResolution.exists(executablePath, { exists });
   }
-  return null;
+  return exists(executablePath) ? executablePath : null;
 }
 
 export async function findExecutable(
@@ -165,6 +117,15 @@ export async function findExecutable(
     return null;
   }
 
+  if (process.platform === "win32") {
+    return windowsExecutableResolution.find(trimmed, {
+      enumeratePathCandidates: enumerateCandidates,
+      probeExecutable,
+      exists: existsSync,
+      probeTimeoutMs,
+    });
+  }
+
   if (hasPathSeparator(trimmed)) {
     return (await probeExecutable(trimmed, probeTimeoutMs)) ? trimmed : null;
   }
@@ -172,15 +133,6 @@ export async function findExecutable(
   const candidates = await enumerateCandidates(trimmed);
   for (const candidate of candidates) {
     if (await probeExecutable(candidate, probeTimeoutMs)) {
-      return candidate;
-    }
-  }
-
-  // PATH didn't resolve it. Fall back to well-known Windows install locations
-  // (e.g. winget portable packages) that don't register themselves on PATH.
-  // Only the existing executables are probed, so the cost is bounded.
-  for (const candidate of enumerateWindowsKnownInstallCandidates(trimmed)) {
-    if (existsSync(candidate) && (await probeExecutable(candidate, probeTimeoutMs))) {
       return candidate;
     }
   }

--- a/packages/server/src/executable-resolution/windows.ts
+++ b/packages/server/src/executable-resolution/windows.ts
@@ -1,0 +1,92 @@
+import { readdirSync } from "node:fs";
+import { extname, join } from "node:path";
+
+interface WindowsFindExecutableOptions {
+  enumeratePathCandidates: (name: string) => Promise<string[]>;
+  probeExecutable: (executablePath: string, timeoutMs: number) => Promise<boolean>;
+  exists: (path: string) => boolean;
+  localAppData?: string;
+  probeTimeoutMs: number;
+}
+
+interface WindowsExecutableExistsOptions {
+  exists: (path: string) => boolean;
+}
+
+function hasPathSeparator(value: string): boolean {
+  return value.includes("/") || value.includes("\\");
+}
+
+function enumerateLiteralPathCandidates(executablePath: string): string[] {
+  if (extname(executablePath)) {
+    return [executablePath];
+  }
+  return [executablePath, `${executablePath}.exe`, `${executablePath}.cmd`];
+}
+
+function enumerateWingetPackageCandidates(
+  name: string,
+  localAppData: string | undefined,
+): string[] {
+  if (!localAppData) {
+    return [];
+  }
+
+  const wingetPackages = join(localAppData, "Microsoft", "WinGet", "Packages");
+  let packageDirs: string[];
+  try {
+    packageDirs = readdirSync(wingetPackages, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+
+  const exeName = `${name}.exe`;
+  return packageDirs.map((packageDir) => join(wingetPackages, packageDir, exeName));
+}
+
+async function find(input: string, options: WindowsFindExecutableOptions): Promise<string | null> {
+  if (hasPathSeparator(input)) {
+    return findFirstProbeable(enumerateLiteralPathCandidates(input), options);
+  }
+
+  const pathCandidates = await options.enumeratePathCandidates(input);
+  const wingetCandidates = enumerateWingetPackageCandidates(
+    input,
+    options.localAppData ?? process.env.LOCALAPPDATA,
+  ).filter(options.exists);
+
+  return findFirstProbeable([...pathCandidates, ...wingetCandidates], options);
+}
+
+async function findFirstProbeable(
+  candidates: string[],
+  options: WindowsFindExecutableOptions,
+): Promise<string | null> {
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    if (await options.probeExecutable(candidate, options.probeTimeoutMs)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function exists(executablePath: string, options: WindowsExecutableExistsOptions): string | null {
+  for (const candidate of enumerateLiteralPathCandidates(executablePath)) {
+    if (options.exists(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export const windowsExecutableResolution = {
+  exists,
+  find,
+};

--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -1,5 +1,8 @@
 import { isAbsolute } from "node:path";
-import { executableExists, findExecutable } from "../../utils/executable.js";
+import {
+  executableExists,
+  findExecutable,
+} from "../../executable-resolution/executable-resolution.js";
 import { createExternalProcessEnv, type ProcessEnvRecord } from "../paseo-env.js";
 export {
   AgentProviderRuntimeSettingsMapSchema,

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -44,7 +44,7 @@ const mockState = vi.hoisted(() => {
   };
 });
 
-vi.mock("../../utils/executable.js", () => ({
+vi.mock("../../executable-resolution/executable-resolution.js", () => ({
   isCommandAvailable: mockState.isCommandAvailable,
 }));
 
@@ -90,7 +90,8 @@ vi.mock("./providers/claude/agent.js", () => ({
           ? Reflect.get(this.runtimeSettings, "command")
           : undefined;
       if (command?.mode === "replace") {
-        const { isCommandAvailable } = await import("../../utils/executable.js");
+        const { isCommandAvailable } =
+          await import("../../executable-resolution/executable-resolution.js");
         return await isCommandAvailable(command.argv?.[0] ?? "");
       }
       return true;
@@ -138,7 +139,8 @@ vi.mock("./providers/codex-app-server-agent.js", () => ({
           ? Reflect.get(this.runtimeSettings, "command")
           : undefined;
       if (command?.mode === "replace") {
-        const { isCommandAvailable } = await import("../../utils/executable.js");
+        const { isCommandAvailable } =
+          await import("../../executable-resolution/executable-resolution.js");
         return await isCommandAvailable(command.argv?.[0] ?? "");
       }
       return true;
@@ -188,7 +190,8 @@ vi.mock("./providers/copilot-acp-agent.js", () => ({
           ? Reflect.get(this.runtimeSettings, "command")
           : undefined;
       if (command?.mode === "replace") {
-        const { isCommandAvailable } = await import("../../utils/executable.js");
+        const { isCommandAvailable } =
+          await import("../../executable-resolution/executable-resolution.js");
         return await isCommandAvailable(command.argv?.[0] ?? "");
       }
       return true;

--- a/packages/server/src/server/agent/providers/claude/agent.real.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.real.e2e.test.ts
@@ -16,7 +16,7 @@ import {
   getRealProviderConfig,
   getRealProviderRuntimeSettings,
 } from "../../../daemon-e2e/real-provider-test-config.js";
-import { findExecutable } from "../../../../utils/executable.js";
+import { findExecutable } from "../../../../executable-resolution/executable-resolution.js";
 import { withTimeout } from "../../../../utils/promise-timeout.js";
 import { claudeQuery } from "./query.js";
 import { streamSession } from "../test-utils/session-stream-adapter.js";

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 
 import { createTestLogger } from "../../../../test-utils/test-logger.js";
-import * as executableUtils from "../../../../utils/executable.js";
+import * as executableUtils from "../../../../executable-resolution/executable-resolution.js";
 import {
   ClaudeAgentClient,
   convertClaudeHistoryEntry,

--- a/packages/server/src/server/agent/providers/claude/sdk-behavior.real.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/claude/sdk-behavior.real.e2e.test.ts
@@ -10,7 +10,7 @@ import {
   canRunRealProvider,
   getRealProviderRuntimeSettings,
 } from "../../../daemon-e2e/real-provider-test-config.js";
-import { findExecutable } from "../../../../utils/executable.js";
+import { findExecutable } from "../../../../executable-resolution/executable-resolution.js";
 import { claudeQuery } from "./query.js";
 
 class Pushable<T> implements AsyncIterable<T> {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -58,7 +58,10 @@ import {
   type ProviderRuntimeSettings,
   type ResolvedProviderLaunch,
 } from "../provider-launch-config.js";
-import { findExecutable, probeExecutable } from "../../../utils/executable.js";
+import {
+  findExecutable,
+  probeExecutable,
+} from "../../../executable-resolution/executable-resolution.js";
 import { createPathEquivalenceMatcher } from "../../../utils/path.js";
 import { spawnProcess } from "../../../utils/spawn.js";
 import { extractCodexTerminalSessionId, nonEmptyString } from "./tool-call-mapper-utils.js";

--- a/packages/server/src/server/agent/providers/opencode/server-manager.ts
+++ b/packages/server/src/server/agent/providers/opencode/server-manager.ts
@@ -2,7 +2,7 @@ import type { ChildProcess } from "node:child_process";
 import net from "node:net";
 import type { Logger } from "pino";
 
-import { findExecutable } from "../../../../utils/executable.js";
+import { findExecutable } from "../../../../executable-resolution/executable-resolution.js";
 import { spawnProcess } from "../../../../utils/spawn.js";
 import { terminateWithTreeKill } from "../../../../utils/tree-kill.js";
 import {

--- a/packages/server/src/server/agent/providers/provider-windows-launch.test.ts
+++ b/packages/server/src/server/agent/providers/provider-windows-launch.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import pino from "pino";
 import { afterEach, describe, expect, test } from "vitest";
 
-import { findExecutable } from "../../../utils/executable.js";
+import { findExecutable } from "../../../executable-resolution/executable-resolution.js";
 import { spawnProcess } from "../../../utils/spawn.js";
 import { PiCliRuntime } from "./pi/cli-runtime.js";
 

--- a/packages/server/src/server/daemon-e2e/real-provider-test-config.ts
+++ b/packages/server/src/server/daemon-e2e/real-provider-test-config.ts
@@ -10,7 +10,7 @@ import { ClaudeAgentClient } from "../agent/providers/claude/agent.js";
 import { CodexAppServerAgentClient } from "../agent/providers/codex-app-server-agent.js";
 import { OpenCodeAgentClient } from "../agent/providers/opencode-agent.js";
 import { PiRpcAgentClient } from "../agent/providers/pi/agent.js";
-import { isCommandAvailable } from "../../utils/executable.js";
+import { isCommandAvailable } from "../../executable-resolution/executable-resolution.js";
 
 export const realProviders = ["claude", "codex", "opencode", "pi"] as const;
 export type RealProvider = (typeof realProviders)[number];

--- a/packages/server/src/server/exports.ts
+++ b/packages/server/src/server/exports.ts
@@ -53,7 +53,7 @@ export {
   type ProviderOverride,
   type ProviderProfileModel,
 } from "./agent/provider-launch-config.js";
-export { findExecutable } from "../utils/executable.js";
+export { findExecutable } from "../executable-resolution/executable-resolution.js";
 export { execCommand, spawnProcess } from "../utils/spawn.js";
 
 // Provider manifest (source of truth for provider definitions)

--- a/packages/server/src/services/github-service.ts
+++ b/packages/server/src/services/github-service.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { GitHubSearchKind } from "@getpaseo/protocol/messages";
-import { findExecutable } from "../utils/executable.js";
+import { findExecutable } from "../executable-resolution/executable-resolution.js";
 import { resolveGitHubRemote } from "../utils/github-remote.js";
 import { runGitCommand } from "../utils/run-git-command.js";
 import { execCommand } from "../utils/spawn.js";

--- a/packages/server/src/terminal/terminal-worker-process.ts
+++ b/packages/server/src/terminal/terminal-worker-process.ts
@@ -7,22 +7,26 @@ import type {
   WorkerTerminalInfo,
 } from "./terminal-worker-protocol.js";
 
+type TerminalCreateRequest = Extract<TerminalWorkerRequest, { type: "createTerminal" }>;
+
 const manager = createTerminalManager();
 const unsubscribeByTerminalId = new Map<string, Array<() => void>>();
 let ipcClosing = false;
 
+interface InFlightTerminalCreateRequest {
+  requestId: string;
+  errorReported: boolean;
+}
+
+let inFlightTerminalCreateRequest: InFlightTerminalCreateRequest | null = null;
+
 // node-pty completes its Windows conpty spawn asynchronously on a separate
 // conout worker thread. When that spawn fails (bad cwd, missing command, etc.)
 // it throws an exception there that cannot be caught at the call site and would
-// otherwise crash this entire worker process — taking every existing terminal
-// down with it ("Terminal worker is not running"), with no restart path in the
-// parent (see worker-terminal-manager's `worker.on("exit")`, which only rejects
-// pending requests). Keeping the worker alive on an uncaught exception is a
-// deliberate trade-off: a single bad terminal must not sever the rest, and the
-// failed terminal still surfaces its own exit/error to the client. Scoped to
-// `uncaughtException` only — that is the path conpty failures actually take.
+// otherwise crash this worker process and sever every existing terminal.
 process.on("uncaughtException", (error) => {
   console.error("Terminal worker uncaught exception (kept alive):", error);
+  reportInFlightTerminalCreateFailure(error);
 });
 
 function sendToParent(message: TerminalWorkerToParentMessage): void {
@@ -47,6 +51,23 @@ function toTerminalInfo(session: TerminalSession): WorkerTerminalInfo {
     cwd: session.cwd,
     ...(session.getTitle() ? { title: session.getTitle() } : {}),
   };
+}
+
+function terminalWorkerErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Terminal worker request failed";
+}
+
+function reportInFlightTerminalCreateFailure(error: unknown): void {
+  if (!inFlightTerminalCreateRequest || inFlightTerminalCreateRequest.errorReported) {
+    return;
+  }
+  inFlightTerminalCreateRequest.errorReported = true;
+  sendToParent({
+    type: "response",
+    requestId: inFlightTerminalCreateRequest.requestId,
+    ok: false,
+    error: terminalWorkerErrorMessage(error),
+  });
 }
 
 function clearTerminalSubscriptions(terminalId: string): void {
@@ -112,6 +133,43 @@ manager.subscribeTerminalsChanged((event) => {
   });
 });
 
+async function handleCreateTerminalRequest(message: TerminalCreateRequest): Promise<void> {
+  const request: InFlightTerminalCreateRequest = {
+    requestId: message.requestId,
+    errorReported: false,
+  };
+  inFlightTerminalCreateRequest = request;
+  try {
+    const session = await manager.createTerminal(message.options);
+    if (request.errorReported) {
+      session.kill();
+      return;
+    }
+    watchTerminal(session);
+    const initialSnapshot = session.getStateSnapshot();
+    sendToParent({
+      type: "terminalCreated",
+      terminal: toTerminalInfo(session),
+      state: initialSnapshot.state,
+    });
+    sendToParent({
+      type: "response",
+      requestId: message.requestId,
+      ok: true,
+      result: {
+        terminal: toTerminalInfo(session),
+        state: initialSnapshot.state,
+      },
+    });
+  } catch (error) {
+    reportInFlightTerminalCreateFailure(error);
+  } finally {
+    if (inFlightTerminalCreateRequest === request) {
+      inFlightTerminalCreateRequest = null;
+    }
+  }
+}
+
 async function handleRequest(message: TerminalWorkerRequest): Promise<void> {
   switch (message.type) {
     case "getTerminals": {
@@ -126,23 +184,7 @@ async function handleRequest(message: TerminalWorkerRequest): Promise<void> {
     }
 
     case "createTerminal": {
-      const session = await manager.createTerminal(message.options);
-      watchTerminal(session);
-      const initialSnapshot = session.getStateSnapshot();
-      sendToParent({
-        type: "terminalCreated",
-        terminal: toTerminalInfo(session),
-        state: initialSnapshot.state,
-      });
-      sendToParent({
-        type: "response",
-        requestId: message.requestId,
-        ok: true,
-        result: {
-          terminal: toTerminalInfo(session),
-          state: initialSnapshot.state,
-        },
-      });
+      await handleCreateTerminalRequest(message);
       return;
     }
 
@@ -247,7 +289,7 @@ process.on("message", (message: TerminalWorkerRequest) => {
       type: "response",
       requestId: message.requestId,
       ok: false,
-      error: error instanceof Error ? error.message : "Terminal worker request failed",
+      error: terminalWorkerErrorMessage(error),
     });
   });
 });

--- a/packages/server/src/terminal/terminal-worker-process.ts
+++ b/packages/server/src/terminal/terminal-worker-process.ts
@@ -11,6 +11,20 @@ const manager = createTerminalManager();
 const unsubscribeByTerminalId = new Map<string, Array<() => void>>();
 let ipcClosing = false;
 
+// node-pty completes its Windows conpty spawn asynchronously on a separate
+// conout worker thread. When that spawn fails (bad cwd, missing command, etc.)
+// it throws an exception that escapes our per-request try/catch and would
+// otherwise crash this entire worker process — taking every existing terminal
+// down with it ("Terminal worker is not running"). Keep the worker alive so a
+// single bad terminal can't sever the rest; the failed terminal still surfaces
+// its own exit/error to the client.
+process.on("uncaughtException", (error) => {
+  console.error("Terminal worker uncaught exception (kept alive):", error);
+});
+process.on("unhandledRejection", (reason) => {
+  console.error("Terminal worker unhandled rejection (kept alive):", reason);
+});
+
 function sendToParent(message: TerminalWorkerToParentMessage): void {
   if (ipcClosing || !process.connected || !process.send) {
     return;

--- a/packages/server/src/terminal/terminal-worker-process.ts
+++ b/packages/server/src/terminal/terminal-worker-process.ts
@@ -20,6 +20,10 @@ interface InFlightTerminalCreateRequest {
 
 let inFlightTerminalCreateRequest: InFlightTerminalCreateRequest | null = null;
 
+// The conpty failure signal is process-scoped, not request-scoped. Serializing
+// creates keeps an async spawn failure attributable to exactly one request.
+let createTerminalQueue: Promise<void> = Promise.resolve();
+
 // node-pty completes its Windows conpty spawn asynchronously on a separate
 // conout worker thread. When that spawn fails (bad cwd, missing command, etc.)
 // it throws an exception there that cannot be caught at the call site and would
@@ -133,6 +137,12 @@ manager.subscribeTerminalsChanged((event) => {
   });
 });
 
+function enqueueCreateTerminalRequest(message: TerminalCreateRequest): Promise<void> {
+  const nextRequest = createTerminalQueue.then(() => handleCreateTerminalRequest(message));
+  createTerminalQueue = nextRequest.catch(() => {});
+  return nextRequest;
+}
+
 async function handleCreateTerminalRequest(message: TerminalCreateRequest): Promise<void> {
   const request: InFlightTerminalCreateRequest = {
     requestId: message.requestId,
@@ -184,7 +194,7 @@ async function handleRequest(message: TerminalWorkerRequest): Promise<void> {
     }
 
     case "createTerminal": {
-      await handleCreateTerminalRequest(message);
+      await enqueueCreateTerminalRequest(message);
       return;
     }
 

--- a/packages/server/src/terminal/terminal-worker-process.ts
+++ b/packages/server/src/terminal/terminal-worker-process.ts
@@ -13,16 +13,16 @@ let ipcClosing = false;
 
 // node-pty completes its Windows conpty spawn asynchronously on a separate
 // conout worker thread. When that spawn fails (bad cwd, missing command, etc.)
-// it throws an exception that escapes our per-request try/catch and would
+// it throws an exception there that cannot be caught at the call site and would
 // otherwise crash this entire worker process — taking every existing terminal
-// down with it ("Terminal worker is not running"). Keep the worker alive so a
-// single bad terminal can't sever the rest; the failed terminal still surfaces
-// its own exit/error to the client.
+// down with it ("Terminal worker is not running"), with no restart path in the
+// parent (see worker-terminal-manager's `worker.on("exit")`, which only rejects
+// pending requests). Keeping the worker alive on an uncaught exception is a
+// deliberate trade-off: a single bad terminal must not sever the rest, and the
+// failed terminal still surfaces its own exit/error to the client. Scoped to
+// `uncaughtException` only — that is the path conpty failures actually take.
 process.on("uncaughtException", (error) => {
   console.error("Terminal worker uncaught exception (kept alive):", error);
-});
-process.on("unhandledRejection", (reason) => {
-  console.error("Terminal worker unhandled rejection (kept alive):", reason);
 });
 
 function sendToParent(message: TerminalWorkerToParentMessage): void {

--- a/packages/server/src/terminal/terminal.test.ts
+++ b/packages/server/src/terminal/terminal.test.ts
@@ -5,6 +5,7 @@ import {
   createTerminal,
   ensureNodePtySpawnHelperExecutableForCurrentPlatform,
   resolveDefaultTerminalShell,
+  resolveTerminalSpawnCommand,
   humanizeProcessTitle,
   normalizeProcessTitle,
   resolveZshShellIntegrationDir,
@@ -201,6 +202,50 @@ describe("createTerminal", () => {
         env: { ComSpec: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" },
       }),
     ).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe");
+  });
+
+  it("passes profile commands through untouched on non-Windows", async () => {
+    const resolveExecutable = vi.fn(async () => "/usr/local/bin/claude");
+    const resolved = await resolveTerminalSpawnCommand("claude", ["--foo"], {
+      platform: "linux",
+      resolveExecutable,
+    });
+
+    expect(resolved).toEqual({ command: "claude", args: ["--foo"] });
+    // Non-Windows must not pay the executable-resolution cost.
+    expect(resolveExecutable).not.toHaveBeenCalled();
+  });
+
+  it("keeps the original command when it cannot be resolved on Windows", async () => {
+    const resolved = await resolveTerminalSpawnCommand("claude", [], {
+      platform: "win32",
+      resolveExecutable: async () => null,
+    });
+
+    // Falls back to the bare command so the terminal surfaces the error itself.
+    expect(resolved).toEqual({ command: "claude", args: [] });
+  });
+
+  it("routes resolved .cmd shims through cmd.exe on Windows", async () => {
+    const resolved = await resolveTerminalSpawnCommand("claude", ["--foo"], {
+      platform: "win32",
+      env: { ComSpec: "C:\\Windows\\System32\\cmd.exe" },
+      resolveExecutable: async () => "C:\\npm\\claude.cmd",
+    });
+
+    expect(resolved).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/c", "C:\\npm\\claude.cmd", "--foo"],
+    });
+  });
+
+  it("uses the resolved .exe path directly on Windows", async () => {
+    const resolved = await resolveTerminalSpawnCommand("claude", ["--foo"], {
+      platform: "win32",
+      resolveExecutable: async () => "C:\\tools\\claude.exe",
+    });
+
+    expect(resolved).toEqual({ command: "C:\\tools\\claude.exe", args: ["--foo"] });
   });
 
   it("creates a terminal session with an id, name, and cwd", async () => {

--- a/packages/server/src/terminal/terminal.ts
+++ b/packages/server/src/terminal/terminal.ts
@@ -8,7 +8,7 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { createExternalProcessEnv } from "../server/paseo-env.js";
 import { writePrivateFileAtomicSync } from "../server/private-files.js";
-import { findExecutable } from "../utils/executable.js";
+import { findExecutable } from "../executable-resolution/executable-resolution.js";
 import type { TerminalCell, TerminalState } from "@getpaseo/protocol/messages";
 import { TerminalInputModeTracker } from "@getpaseo/protocol/terminal-input-mode";
 

--- a/packages/server/src/terminal/terminal.ts
+++ b/packages/server/src/terminal/terminal.ts
@@ -3,11 +3,12 @@ import xterm, { type Terminal as TerminalType } from "@xterm/headless";
 import { randomUUID } from "crypto";
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { tmpdir, userInfo } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, extname, join } from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { createExternalProcessEnv } from "../server/paseo-env.js";
 import { writePrivateFileAtomicSync } from "../server/private-files.js";
+import { findExecutable } from "../utils/executable.js";
 import type { TerminalCell, TerminalState } from "@getpaseo/protocol/messages";
 import { TerminalInputModeTracker } from "@getpaseo/protocol/terminal-input-mode";
 
@@ -199,6 +200,64 @@ export function resolveDefaultTerminalShell(
   }
 
   return env.SHELL || "/bin/sh";
+}
+
+export interface ResolvedTerminalCommand {
+  command: string;
+  args: string[];
+}
+
+export interface ResolveTerminalSpawnCommandOptions {
+  platform?: NodeJS.Platform;
+  env?: Record<string, string | undefined>;
+  resolveExecutable?: (name: string) => Promise<string | null>;
+}
+
+/**
+ * Resolve a terminal profile command (e.g. `claude`) into something node-pty's
+ * conpty backend can actually launch on Windows.
+ *
+ * On Windows, conpty's underlying `CreateProcess` does not apply `PATHEXT`, so a
+ * bare `claude` (installed by npm as `claude.cmd`) fails with `error code: 2`
+ * (`ERROR_FILE_NOT_FOUND`). Worse, conpty completes the spawn asynchronously on
+ * its own conout worker thread, so that failure surfaces as an uncaught
+ * exception that takes down the whole terminal worker process. Resolving the
+ * real path up front — and routing `.cmd`/`.bat` shims through `cmd.exe /c`
+ * (node-pty has no `shell` option) — keeps the profile launchable.
+ *
+ * Non-Windows and the default-shell path (no explicit command) are unchanged.
+ */
+export async function resolveTerminalSpawnCommand(
+  command: string,
+  args: string[],
+  options: ResolveTerminalSpawnCommandOptions = {},
+): Promise<ResolvedTerminalCommand> {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") {
+    return { command, args };
+  }
+
+  const resolveExecutable = options.resolveExecutable ?? findExecutable;
+  const resolved = await resolveExecutable(command);
+  if (!resolved) {
+    // Leave the command as-is so the terminal itself surfaces the "not found"
+    // error to the user instead of silently doing nothing.
+    return { command, args };
+  }
+
+  // `.cmd`/`.bat` shims are batch scripts that conpty's CreateProcess cannot
+  // launch directly; they must run through cmd.exe (node-pty has no `shell`
+  // option, so build the `cmd /c` invocation ourselves). Checked by extension
+  // rather than isWindowsCommandScript() because that helper gates on the live
+  // process.platform, which is wrong once we're already on the win32 branch.
+  const extension = extname(resolved).toLowerCase();
+  if (extension === ".cmd" || extension === ".bat") {
+    const env = options.env ?? process.env;
+    const comSpec = env.ComSpec || env.COMSPEC || "C:\\Windows\\System32\\cmd.exe";
+    return { command: comSpec, args: ["/c", resolved, ...args] };
+  }
+
+  return { command: resolved, args };
 }
 
 export function resolveZshShellIntegrationDir(): string {
@@ -628,8 +687,9 @@ export async function createTerminal(options: CreateTerminalOptions): Promise<Te
   ensureNodePtySpawnHelperExecutableForCurrentPlatform();
 
   // Create PTY
-  const spawnCommand = command ?? resolvedShell;
-  const spawnArgs = command ? args : [];
+  const { command: spawnCommand, args: spawnArgs } = command
+    ? await resolveTerminalSpawnCommand(command, args)
+    : { command: resolvedShell, args: [] as string[] };
   const ptyProcess = pty.spawn(spawnCommand, spawnArgs, {
     name: "xterm-256color",
     cols,

--- a/packages/server/src/utils/executable.test.ts
+++ b/packages/server/src/utils/executable.test.ts
@@ -1,9 +1,10 @@
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 
 import {
+  enumerateWindowsKnownInstallCandidates,
   executableExists,
   findExecutable,
   quoteWindowsArgument,
@@ -118,6 +119,47 @@ describe("findExecutable", () => {
     prependPath(dir);
 
     await expect(findExecutable("paseo-definitely-missing-command")).resolves.toBeNull();
+  });
+});
+
+describe("enumerateWindowsKnownInstallCandidates", () => {
+  test("returns nothing on non-Windows platforms", () => {
+    expect(
+      enumerateWindowsKnownInstallCandidates("claude", {
+        platform: "darwin",
+        localAppData: "/Users/me/AppData/Local",
+      }),
+    ).toEqual([]);
+  });
+
+  test("returns nothing when LOCALAPPDATA is unavailable", () => {
+    expect(
+      enumerateWindowsKnownInstallCandidates("claude", { platform: "win32", localAppData: "" }),
+    ).toEqual([]);
+  });
+
+  test("scans winget package dirs for a portable executable not on PATH", () => {
+    const localAppData = makeTempDir();
+    const packages = path.join(localAppData, "Microsoft", "WinGet", "Packages");
+    // A portable package drops the exe at its root (like Anthropic.ClaudeCode).
+    mkdirSync(path.join(packages, "Anthropic.ClaudeCode_abc"), { recursive: true });
+    mkdirSync(path.join(packages, "Some.Other_xyz"), { recursive: true });
+
+    const candidates = enumerateWindowsKnownInstallCandidates("claude", {
+      platform: "win32",
+      localAppData,
+    });
+
+    // Each package dir is probed at its root, where portable packages drop the exe.
+    expect(candidates).toContain(path.join(packages, "Anthropic.ClaudeCode_abc", "claude.exe"));
+    expect(candidates).toContain(path.join(packages, "Some.Other_xyz", "claude.exe"));
+  });
+
+  test("returns nothing when the winget Packages dir is absent", () => {
+    const localAppData = makeTempDir();
+    expect(
+      enumerateWindowsKnownInstallCandidates("claude", { platform: "win32", localAppData }),
+    ).toEqual([]);
   });
 });
 

--- a/packages/server/src/utils/executable.ts
+++ b/packages/server/src/utils/executable.ts
@@ -28,11 +28,6 @@ export interface WindowsKnownInstallOptions {
   localAppData?: string;
 }
 
-// winget "portable" packages drop their executable at the package root
-// (e.g. Anthropic.ClaudeCode → claude.exe). Keep the scan to the verified
-// root layout; widen this list only when a real package needs a subdir.
-const WINGET_PACKAGE_BIN_SUBDIRS = [""];
-
 /**
  * Find an executable installed by `winget` outside of PATH.
  *
@@ -66,14 +61,10 @@ export function enumerateWindowsKnownInstallCandidates(
     return [];
   }
 
+  // winget "portable" packages (e.g. Anthropic.ClaudeCode) drop their
+  // executable at the package root, so probe `<packageDir>/<name>.exe`.
   const exeName = `${name}.exe`;
-  const candidates: string[] = [];
-  for (const packageDir of packageDirs) {
-    for (const subdir of WINGET_PACKAGE_BIN_SUBDIRS) {
-      candidates.push(join(wingetPackages, packageDir, subdir, exeName));
-    }
-  }
-  return candidates;
+  return packageDirs.map((packageDir) => join(wingetPackages, packageDir, exeName));
 }
 
 async function enumerateCandidatesViaSystemWhich(name: string): Promise<string[]> {

--- a/packages/server/src/utils/executable.ts
+++ b/packages/server/src/utils/executable.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
-import { existsSync } from "node:fs";
-import { extname } from "node:path";
+import { existsSync, readdirSync } from "node:fs";
+import { extname, join } from "node:path";
 import { execCommand } from "./spawn.js";
 import { isWindowsCommandScript } from "./windows-command.js";
 
@@ -21,6 +21,59 @@ async function enumerateCandidates(name: string): Promise<string[]> {
     return enumerateCandidatesViaSystemWhich(name);
   }
   return enumerateCandidatesViaLibrary(name);
+}
+
+export interface WindowsKnownInstallOptions {
+  platform?: NodeJS.Platform;
+  localAppData?: string;
+}
+
+// winget "portable" packages drop their executable at the package root
+// (e.g. Anthropic.ClaudeCode → claude.exe). Keep the scan to the verified
+// root layout; widen this list only when a real package needs a subdir.
+const WINGET_PACKAGE_BIN_SUBDIRS = [""];
+
+/**
+ * Find an executable installed by `winget` outside of PATH.
+ *
+ * winget "portable" packages (like Claude Code) extract their executable into
+ * `%LOCALAPPDATA%\Microsoft\WinGet\Packages\<PackageId>\` but do NOT add that
+ * directory to PATH or create a Links shim, so PATH-based lookup can't find
+ * them. Rather than hardcode each tool's package id, scan every winget package
+ * directory for a matching `<name>.exe`. This keeps a single generic fallback
+ * that any provider's command resolution benefits from — no per-tool probe.
+ */
+export function enumerateWindowsKnownInstallCandidates(
+  name: string,
+  options: WindowsKnownInstallOptions = {},
+): string[] {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") {
+    return [];
+  }
+  const localAppData = options.localAppData ?? process.env.LOCALAPPDATA;
+  if (!localAppData) {
+    return [];
+  }
+
+  const wingetPackages = join(localAppData, "Microsoft", "WinGet", "Packages");
+  let packageDirs: string[];
+  try {
+    packageDirs = readdirSync(wingetPackages, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+
+  const exeName = `${name}.exe`;
+  const candidates: string[] = [];
+  for (const packageDir of packageDirs) {
+    for (const subdir of WINGET_PACKAGE_BIN_SUBDIRS) {
+      candidates.push(join(wingetPackages, packageDir, subdir, exeName));
+    }
+  }
+  return candidates;
 }
 
 async function enumerateCandidatesViaSystemWhich(name: string): Promise<string[]> {
@@ -128,6 +181,15 @@ export async function findExecutable(
   const candidates = await enumerateCandidates(trimmed);
   for (const candidate of candidates) {
     if (await probeExecutable(candidate, probeTimeoutMs)) {
+      return candidate;
+    }
+  }
+
+  // PATH didn't resolve it. Fall back to well-known Windows install locations
+  // (e.g. winget portable packages) that don't register themselves on PATH.
+  // Only the existing executables are probed, so the cost is bounded.
+  for (const candidate of enumerateWindowsKnownInstallCandidates(trimmed)) {
+    if (existsSync(candidate) && (await probeExecutable(candidate, probeTimeoutMs))) {
       return candidate;
     }
   }

--- a/packages/server/src/utils/github-remote.ts
+++ b/packages/server/src/utils/github-remote.ts
@@ -5,7 +5,7 @@ import {
   parseGitRemoteLocation,
   type GitHubRemoteIdentity as ResolvedGitHubRemoteIdentity,
 } from "@getpaseo/protocol/git-remote";
-import { findExecutable } from "./executable.js";
+import { findExecutable } from "../executable-resolution/executable-resolution.js";
 import { execCommand } from "./spawn.js";
 
 let sshExecutableLookup: Promise<string | null> | null = null;

--- a/packages/server/src/utils/spawn.launch-regression.test.ts
+++ b/packages/server/src/utils/spawn.launch-regression.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import type { ChildProcess } from "node:child_process";
 import { afterEach, describe, expect, test } from "vitest";
 
-import { findExecutable } from "./executable.js";
+import { findExecutable } from "../executable-resolution/executable-resolution.js";
 import { spawnProcess } from "./spawn.js";
 import { isPlatform } from "../test-utils/platform.js";
 


### PR DESCRIPTION
## Description

### Background

The coding-agent terminal shortcut (the **New ▸ Terminal profiles** menu — Claude Code / Codex / OpenCode) is a feature I originally proposed together with the maintainer on Discord. After updating to the latest release and using it on **Windows 11**, I found the shortcut was broken.

Symptoms:

- A plain **New Terminal** opens fine;
- but clicking a coding-agent shortcut (Terminal profiles) does nothing;
- and once a shortcut has been clicked, even the previously working **New Terminal** stops opening too, until the app is restarted.

The same actions work fine on macOS.

I wanted to help fix it and contribute back, so I dug into the root cause on Windows 11.

### Problem

Three Windows-specific problems combine into "nothing happens":

1. **A failed node-pty conpty spawn takes down the whole terminal worker.**
   On Windows, node-pty completes its conpty spawn **asynchronously** on its own conout worker thread. When a spawn fails (command not found, bad cwd, etc.), the resulting **uncaught exception** escapes the per-request `try/catch` in `terminal-worker-process.ts` and kills the entire terminal worker process. Every existing terminal then fails with `Terminal worker is not running` — which is exactly why clicking one bad profile also breaks plain terminals.

2. **Profile commands aren't resolved for Windows.**
   A profile launches a bare command like `claude` / `codex`. conpty's underlying `CreateProcess` does **not** apply `PATHEXT`, so a bare `codex` (installed by npm as `codex.cmd`) isn't found, and `.cmd`/`.bat` shims can't be executed directly at all (they must go through `cmd.exe`).

3. **winget-installed CLIs aren't on PATH.**
   Claude Code installed via winget lives at `%LOCALAPPDATA%\Microsoft\WinGet\Packages\<id>\claude.exe`, but winget does **not** add that directory to PATH or create a shim, so PATH-based lookup never finds it.

On top of that, when a spawn failed the client received the error but **silently dropped it**, leaving the user with no feedback at all.

### Solution

**Server**

- **`terminal-worker-process.ts`** — add `uncaughtException` / `unhandledRejection` handlers so a single failed conpty spawn can no longer crash the terminal worker and sever every other terminal. The failed terminal still surfaces its own error to the client.
- **`terminal.ts`** — add `resolveTerminalSpawnCommand()`: on Windows, resolve a profile command to its real path via the existing `findExecutable()`; route `.cmd`/`.bat` shims through `cmd.exe /c` (node-pty has no `shell` option); pass `.exe` through directly. Non-Windows and the default-shell path are unchanged.
- **`executable.ts`** — `findExecutable()` now falls back to well-known Windows install locations (winget `Packages` dirs) when a PATH lookup misses. This is a **single generic fallback in the shared resolver**, so terminal profiles, the Claude/Codex/etc. providers, and any future tool all benefit — no per-tool probe. Only paths that actually exist are probed, so the cost is bounded.

**App**

- **`use-workspace-terminals.ts` / `workspace-screen.tsx`** — surface a failed terminal create (`payload.error`) via `toast.error(...)` instead of treating it as a silent no-op, reusing the existing toast pattern.

**Tests**

- `terminal.test.ts` — 4 cases for `resolveTerminalSpawnCommand` (non-Windows passthrough, unresolved fallback, `.cmd` → `cmd.exe`, `.exe` direct).
- `executable.test.ts` — 4 cases for the winget fallback (non-Windows, missing LOCALAPPDATA, package-scan hit, missing Packages dir).

### Notes / scope

- **Protocol unchanged** — no WebSocket schema changes; fully backward compatible.
- The winget fallback intentionally **widens the responsibility of `findExecutable`** to know about `%LOCALAPPDATA%\Microsoft\WinGet`; this is a deliberate "handle it in one generic place" choice rather than a per-provider probe (it follows and generalises the existing `findCodexMicrosoftStoreBinary` precedent).
- The worker `uncaughtException` guard deliberately keeps the worker alive and logs rather than crashing — a reasonable trade-off for a single-purpose isolated worker.
- Worker survival and the toast feedback are verified end-to-end (local dev build on Windows) rather than by unit test.

### Testing

Verified on a Windows machine via a local dev build (using an isolated dev daemon, not the production one):

- **Codex** (npm `codex.cmd`) profile — launches correctly (previously no response).
- **Claude Code** (winget `claude.exe`, not on PATH) profile — launches correctly via the winget fallback.
- **Plain New Terminal** — still opens; clicking a failing profile first no longer breaks it (the worker stays alive).
- macOS behavior unchanged (non-Windows code paths untouched).
- `npm run typecheck`, `npm run lint`, and the two changed test files all pass.

## Checklist

### Root cause & fix
- [x] Guard the terminal worker against async conpty spawn failures (`uncaughtException`)
- [x] Resolve profile commands on Windows via `resolveTerminalSpawnCommand()` (PATHEXT / `.cmd`/`.bat` → `cmd.exe /c`, `.exe` direct)
- [x] Add winget `Packages` fallback to the shared `findExecutable()` resolver
- [x] Surface failed terminal creates to the user via `toast.error(...)`

### Quality
- [x] Unit tests for `resolveTerminalSpawnCommand` (4 cases)
- [x] Unit tests for the winget fallback (4 cases)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Protocol unchanged — backward compatible (no WebSocket schema changes)

### Verification
- [x] Codex (npm `codex.cmd`) profile launches on Windows 11
- [x] Claude Code (winget `claude.exe`, not on PATH) profile launches
- [x] Plain New Terminal still works after a failing profile (worker stays alive)
- [x] macOS behavior unchanged
- [ ] Maintainer review
- [ ] CI green
