### PR TITLE
feat: hide dotfiles in file explorer

### DIFF
--- a/packages/app/src/components/file-explorer-pane.tsx
+++ b/packages/app/src/components/file-explorer-pane.tsx
@@ -270,9 +270,11 @@ export function FileExplorerPane({
       workspaceRoot: normalizedWorkspaceRoot,
     });
   const sortOption = usePanelStore((state) => state.explorerSortOption);
-  const hideDotFiles = usePanelStore((state) => state.explorerHideDotFiles);
+  const showHiddenFiles = usePanelStore((state) => state.explorerShowHiddenFiles);
   const setSortOption = usePanelStore((state) => state.setExplorerSortOption);
-  const toggleExplorerHideDotFiles = usePanelStore((state) => state.toggleExplorerHideDotFiles);
+  const toggleExplorerShowHiddenFiles = usePanelStore(
+    (state) => state.toggleExplorerShowHiddenFiles,
+  );
   const expandedPathsArray = usePanelStore((state) =>
     workspaceStateKey ? state.expandedPathsByWorkspace[workspaceStateKey] : undefined,
   );
@@ -308,9 +310,8 @@ export function FileExplorerPane({
       hasInitializedRef,
       workspaceStateKey,
       requestDirectoryListing,
-      hideDotFiles,
     });
-  }, [hasWorkspaceScope, hideDotFiles, requestDirectoryListing, workspaceStateKey]);
+  }, [hasWorkspaceScope, requestDirectoryListing, workspaceStateKey]);
 
   const handleToggleDirectory = useCallback(
     (entry: ExplorerEntry) =>
@@ -385,26 +386,22 @@ export function FileExplorerPane({
     setSortOption(SORT_OPTIONS[nextIndex].value);
   }, [sortOption, setSortOption]);
 
-  const handleToggleDotFiles = useCallback(() => {
-    toggleExplorerHideDotFiles();
-    if (hideDotFiles) {
-      requestPersistedExpandedPaths({
-        workspaceStateKey,
-        requestDirectoryListing,
-        hideDotFiles: false,
-      });
+  const handleToggleHiddenFiles = useCallback(() => {
+    const willShow = !usePanelStore.getState().explorerShowHiddenFiles;
+    toggleExplorerShowHiddenFiles();
+    if (willShow) {
+      requestPersistedExpandedPaths({ workspaceStateKey, requestDirectoryListing });
     }
-  }, [hideDotFiles, requestDirectoryListing, toggleExplorerHideDotFiles, workspaceStateKey]);
+  }, [requestDirectoryListing, toggleExplorerShowHiddenFiles, workspaceStateKey]);
 
   const refreshExplorer = useCallback(
     () =>
       refreshExplorerDirectories({
         hasWorkspaceScope,
         expandedPaths,
-        hideDotFiles,
         requestDirectoryListing,
       }),
-    [expandedPaths, hasWorkspaceScope, hideDotFiles, requestDirectoryListing],
+    [expandedPaths, hasWorkspaceScope, requestDirectoryListing],
   );
   const { refetch: refetchExplorer, isFetching: isRefreshFetching } = useQuery({
     queryKey: ["fileExplorerRefresh", serverId, workspaceStateKey],
@@ -427,8 +424,8 @@ export function FileExplorerPane({
   const currentSortLabel = resolveCurrentSortLabel(sortOption, sortLabels);
 
   const treeRows = useMemo(
-    () => resolveTreeRows({ directories, expandedPaths, sortOption, hideDotFiles }),
-    [directories, expandedPaths, hideDotFiles, sortOption],
+    () => resolveTreeRows({ directories, expandedPaths, sortOption, showHiddenFiles }),
+    [directories, expandedPaths, showHiddenFiles, sortOption],
   );
 
   const showInitialLoading = resolveShowInitialLoading({
@@ -495,14 +492,13 @@ export function FileExplorerPane({
         showBackFromError={showBackFromError}
         treeRows={treeRows}
         currentSortLabel={currentSortLabel}
-        hideDotFiles={hideDotFiles}
         isRefreshFetching={isRefreshFetching}
         showDesktopWebScrollbar={showDesktopWebScrollbar}
         treeListRef={treeListRef}
         scrollbar={scrollbar}
         renderTreeRow={renderTreeRow}
         handleSortCycle={handleSortCycle}
-        handleToggleDotFiles={handleToggleDotFiles}
+        handleToggleHiddenFiles={handleToggleHiddenFiles}
         handleRefresh={handleRefresh}
         handleBackFromError={handleBackFromError}
         handleRetry={handleRetry}
@@ -519,14 +515,13 @@ interface FileExplorerPaneContentProps {
   showBackFromError: boolean;
   treeRows: TreeRow[];
   currentSortLabel: string;
-  hideDotFiles: boolean;
   isRefreshFetching: boolean;
   showDesktopWebScrollbar: boolean;
   treeListRef: RefObject<FlatList<TreeRow> | null>;
   scrollbar: ReturnType<typeof useWebScrollViewScrollbar>;
   renderTreeRow: (info: ListRenderItemInfo<TreeRow>) => ReactElement;
   handleSortCycle: () => void;
-  handleToggleDotFiles: () => void;
+  handleToggleHiddenFiles: () => void;
   handleRefresh: () => void;
   handleBackFromError: () => void;
   handleRetry: () => void;
@@ -543,14 +538,13 @@ function FileExplorerPaneContent(props: FileExplorerPaneContentProps) {
     showBackFromError,
     treeRows,
     currentSortLabel,
-    hideDotFiles,
     isRefreshFetching,
     showDesktopWebScrollbar,
     treeListRef,
     scrollbar,
     renderTreeRow,
     handleSortCycle,
-    handleToggleDotFiles,
+    handleToggleHiddenFiles,
     handleRefresh,
     handleBackFromError,
     handleRetry,
@@ -558,22 +552,24 @@ function FileExplorerPaneContent(props: FileExplorerPaneContentProps) {
     iconButtonStyle: iconButtonStyleProp,
   } = props;
 
-  const dotfileToggleAccessibilityLabel = hideDotFiles
-    ? t("workspace.fileExplorer.actions.showDotFiles")
-    : t("workspace.fileExplorer.actions.hideDotFiles");
-  const emptyLabel = hideDotFiles
-    ? t("workspace.fileExplorer.empty.noVisibleFiles")
-    : t("workspace.fileExplorer.empty.noFiles");
-  const dotfileToggleStyle = useCallback(
+  const showHiddenFiles = usePanelStore((state) => state.explorerShowHiddenFiles);
+
+  const hiddenFilesToggleAccessibilityLabel = showHiddenFiles
+    ? t("workspace.fileExplorer.actions.hideHiddenFiles")
+    : t("workspace.fileExplorer.actions.showHiddenFiles");
+  const emptyLabel = showHiddenFiles
+    ? t("workspace.fileExplorer.empty.noFiles")
+    : t("workspace.fileExplorer.empty.noVisibleFiles");
+  const hiddenFilesToggleStyle = useCallback(
     (state: PressableStateCallbackType) => [
       iconButtonStyleProp(state),
-      hideDotFiles && styles.iconButtonActive,
+      !showHiddenFiles && styles.iconButtonActive,
     ],
-    [hideDotFiles, iconButtonStyleProp],
+    [showHiddenFiles, iconButtonStyleProp],
   );
-  const dotfileToggleAccessibilityState = useMemo(
-    () => ({ selected: hideDotFiles }),
-    [hideDotFiles],
+  const hiddenFilesToggleAccessibilityState = useMemo(
+    () => ({ selected: !showHiddenFiles }),
+    [showHiddenFiles],
   );
 
   if (error) {
@@ -612,17 +608,17 @@ function FileExplorerPaneContent(props: FileExplorerPaneContentProps) {
         </Pressable>
         <View style={styles.headerActions}>
           <Pressable
-            onPress={handleToggleDotFiles}
+            onPress={handleToggleHiddenFiles}
             hitSlop={8}
-            style={dotfileToggleStyle}
+            style={hiddenFilesToggleStyle}
             accessibilityRole="button"
-            accessibilityLabel={dotfileToggleAccessibilityLabel}
-            accessibilityState={dotfileToggleAccessibilityState}
+            accessibilityLabel={hiddenFilesToggleAccessibilityLabel}
+            accessibilityState={hiddenFilesToggleAccessibilityState}
           >
-            {hideDotFiles ? (
-              <EyeOff size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
-            ) : (
+            {showHiddenFiles ? (
               <Eye size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+            ) : (
+              <EyeOff size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
             )}
           </Pressable>
           <Pressable
@@ -699,14 +695,14 @@ function buildTreeRows({
   directories,
   expandedPaths,
   sortOption,
-  hideDotFiles,
+  showHiddenFiles,
   path,
   depth,
 }: {
   directories: Map<string, { path: string; entries: ExplorerEntry[] }>;
   expandedPaths: Set<string>;
   sortOption: SortOption;
-  hideDotFiles: boolean;
+  showHiddenFiles: boolean;
   path: string;
   depth: number;
 }): TreeRow[] {
@@ -717,7 +713,7 @@ function buildTreeRows({
 
   const rows: TreeRow[] = [];
   const entries = sortEntries(
-    filterVisibleExplorerEntries(directory.entries, hideDotFiles),
+    filterVisibleExplorerEntries(directory.entries, showHiddenFiles),
     sortOption,
   );
 
@@ -729,7 +725,7 @@ function buildTreeRows({
           directories,
           expandedPaths,
           sortOption,
-          hideDotFiles,
+          showHiddenFiles,
           path: entry.path,
           depth: depth + 1,
         }),
@@ -793,12 +789,12 @@ function resolveTreeRows({
   directories,
   expandedPaths,
   sortOption,
-  hideDotFiles,
+  showHiddenFiles,
 }: {
   directories: Map<string, { path: string; entries: ExplorerEntry[] }>;
   expandedPaths: Set<string>;
   sortOption: SortOption;
-  hideDotFiles: boolean;
+  showHiddenFiles: boolean;
 }): TreeRow[] {
   if (!directories.get(".")) {
     return [];
@@ -807,7 +803,7 @@ function resolveTreeRows({
     directories,
     expandedPaths,
     sortOption,
-    hideDotFiles,
+    showHiddenFiles,
     path: ".",
     depth: 0,
   });
@@ -927,7 +923,6 @@ async function initializeExplorer({
   hasInitializedRef,
   workspaceStateKey,
   requestDirectoryListing,
-  hideDotFiles,
 }: {
   hasWorkspaceScope: boolean;
   hasInitializedRef: RefObject<boolean>;
@@ -936,7 +931,6 @@ async function initializeExplorer({
     path: string,
     opts?: { recordHistory?: boolean; setCurrentPath?: boolean },
   ) => Promise<boolean>;
-  hideDotFiles: boolean;
 }): Promise<void> {
   if (!hasWorkspaceScope || hasInitializedRef.current) {
     return;
@@ -950,27 +944,26 @@ async function initializeExplorer({
     hasInitializedRef.current = false;
     return;
   }
-  requestPersistedExpandedPaths({ workspaceStateKey, requestDirectoryListing, hideDotFiles });
+  requestPersistedExpandedPaths({ workspaceStateKey, requestDirectoryListing });
 }
 
 function requestPersistedExpandedPaths({
   workspaceStateKey,
   requestDirectoryListing,
-  hideDotFiles,
 }: {
   workspaceStateKey: string | null;
   requestDirectoryListing: (
     path: string,
     opts?: { recordHistory?: boolean; setCurrentPath?: boolean },
   ) => Promise<boolean>;
-  hideDotFiles: boolean;
 }): void {
+  const showHiddenFiles = usePanelStore.getState().explorerShowHiddenFiles;
   const persistedPaths = usePanelStore.getState().expandedPathsByWorkspace[workspaceStateKey ?? ""];
   if (!persistedPaths) {
     return;
   }
   for (const path of persistedPaths) {
-    if (path !== "." && (!hideDotFiles || !isHiddenExplorerPath(path))) {
+    if (path !== "." && (showHiddenFiles || !isHiddenExplorerPath(path))) {
       void requestDirectoryListing(path, {
         recordHistory: false,
         setCurrentPath: false,
@@ -982,12 +975,10 @@ function requestPersistedExpandedPaths({
 async function refreshExplorerDirectories({
   hasWorkspaceScope,
   expandedPaths,
-  hideDotFiles,
   requestDirectoryListing,
 }: {
   hasWorkspaceScope: boolean;
   expandedPaths: Set<string>;
-  hideDotFiles: boolean;
   requestDirectoryListing: (
     path: string,
     opts?: { recordHistory?: boolean; setCurrentPath?: boolean },
@@ -996,8 +987,9 @@ async function refreshExplorerDirectories({
   if (!hasWorkspaceScope) {
     return null;
   }
+  const showHiddenFiles = usePanelStore.getState().explorerShowHiddenFiles;
   const directoryPaths = Array.from(expandedPaths).filter(
-    (path) => !hideDotFiles || !isHiddenExplorerPath(path),
+    (path) => showHiddenFiles || !isHiddenExplorerPath(path),
   );
   if (!directoryPaths.includes(".")) {
     directoryPaths.unshift(".");

--- a/packages/app/src/components/file-explorer-pane.tsx
+++ b/packages/app/src/components/file-explorer-pane.tsx
@@ -22,6 +22,8 @@ import {
   ChevronRight,
   Copy,
   Download,
+  Eye,
+  EyeOff,
   MoreVertical,
   RotateCw,
 } from "lucide-react-native";
@@ -43,6 +45,7 @@ import { buildWorkspaceExplorerStateKey } from "@/hooks/use-file-explorer-action
 import { usePanelStore, type SortOption } from "@/stores/panel-store";
 import { formatTimeAgo } from "@/utils/time";
 import { buildAbsoluteExplorerPath } from "@/utils/explorer-paths";
+import { filterVisibleExplorerEntries, isHiddenExplorerPath } from "@/file-explorer/visibility";
 import { useWebScrollViewScrollbar } from "@/components/use-web-scrollbar";
 import { isWeb } from "@/constants/platform";
 
@@ -267,7 +270,9 @@ export function FileExplorerPane({
       workspaceRoot: normalizedWorkspaceRoot,
     });
   const sortOption = usePanelStore((state) => state.explorerSortOption);
+  const hideDotFiles = usePanelStore((state) => state.explorerHideDotFiles);
   const setSortOption = usePanelStore((state) => state.setExplorerSortOption);
+  const toggleExplorerHideDotFiles = usePanelStore((state) => state.toggleExplorerHideDotFiles);
   const expandedPathsArray = usePanelStore((state) =>
     workspaceStateKey ? state.expandedPathsByWorkspace[workspaceStateKey] : undefined,
   );
@@ -303,8 +308,9 @@ export function FileExplorerPane({
       hasInitializedRef,
       workspaceStateKey,
       requestDirectoryListing,
+      hideDotFiles,
     });
-  }, [hasWorkspaceScope, requestDirectoryListing, workspaceStateKey]);
+  }, [hasWorkspaceScope, hideDotFiles, requestDirectoryListing, workspaceStateKey]);
 
   const handleToggleDirectory = useCallback(
     (entry: ExplorerEntry) =>
@@ -379,14 +385,26 @@ export function FileExplorerPane({
     setSortOption(SORT_OPTIONS[nextIndex].value);
   }, [sortOption, setSortOption]);
 
+  const handleToggleDotFiles = useCallback(() => {
+    toggleExplorerHideDotFiles();
+    if (hideDotFiles) {
+      requestPersistedExpandedPaths({
+        workspaceStateKey,
+        requestDirectoryListing,
+        hideDotFiles: false,
+      });
+    }
+  }, [hideDotFiles, requestDirectoryListing, toggleExplorerHideDotFiles, workspaceStateKey]);
+
   const refreshExplorer = useCallback(
     () =>
       refreshExplorerDirectories({
         hasWorkspaceScope,
         expandedPaths,
+        hideDotFiles,
         requestDirectoryListing,
       }),
-    [expandedPaths, hasWorkspaceScope, requestDirectoryListing],
+    [expandedPaths, hasWorkspaceScope, hideDotFiles, requestDirectoryListing],
   );
   const { refetch: refetchExplorer, isFetching: isRefreshFetching } = useQuery({
     queryKey: ["fileExplorerRefresh", serverId, workspaceStateKey],
@@ -409,8 +427,8 @@ export function FileExplorerPane({
   const currentSortLabel = resolveCurrentSortLabel(sortOption, sortLabels);
 
   const treeRows = useMemo(
-    () => resolveTreeRows({ directories, expandedPaths, sortOption }),
-    [directories, expandedPaths, sortOption],
+    () => resolveTreeRows({ directories, expandedPaths, sortOption, hideDotFiles }),
+    [directories, expandedPaths, hideDotFiles, sortOption],
   );
 
   const showInitialLoading = resolveShowInitialLoading({
@@ -477,12 +495,14 @@ export function FileExplorerPane({
         showBackFromError={showBackFromError}
         treeRows={treeRows}
         currentSortLabel={currentSortLabel}
+        hideDotFiles={hideDotFiles}
         isRefreshFetching={isRefreshFetching}
         showDesktopWebScrollbar={showDesktopWebScrollbar}
         treeListRef={treeListRef}
         scrollbar={scrollbar}
         renderTreeRow={renderTreeRow}
         handleSortCycle={handleSortCycle}
+        handleToggleDotFiles={handleToggleDotFiles}
         handleRefresh={handleRefresh}
         handleBackFromError={handleBackFromError}
         handleRetry={handleRetry}
@@ -499,12 +519,14 @@ interface FileExplorerPaneContentProps {
   showBackFromError: boolean;
   treeRows: TreeRow[];
   currentSortLabel: string;
+  hideDotFiles: boolean;
   isRefreshFetching: boolean;
   showDesktopWebScrollbar: boolean;
   treeListRef: RefObject<FlatList<TreeRow> | null>;
   scrollbar: ReturnType<typeof useWebScrollViewScrollbar>;
   renderTreeRow: (info: ListRenderItemInfo<TreeRow>) => ReactElement;
   handleSortCycle: () => void;
+  handleToggleDotFiles: () => void;
   handleRefresh: () => void;
   handleBackFromError: () => void;
   handleRetry: () => void;
@@ -521,18 +543,38 @@ function FileExplorerPaneContent(props: FileExplorerPaneContentProps) {
     showBackFromError,
     treeRows,
     currentSortLabel,
+    hideDotFiles,
     isRefreshFetching,
     showDesktopWebScrollbar,
     treeListRef,
     scrollbar,
     renderTreeRow,
     handleSortCycle,
+    handleToggleDotFiles,
     handleRefresh,
     handleBackFromError,
     handleRetry,
     sortTriggerStyle: sortTriggerStyleProp,
     iconButtonStyle: iconButtonStyleProp,
   } = props;
+
+  const dotfileToggleAccessibilityLabel = hideDotFiles
+    ? t("workspace.fileExplorer.actions.showDotFiles")
+    : t("workspace.fileExplorer.actions.hideDotFiles");
+  const emptyLabel = hideDotFiles
+    ? t("workspace.fileExplorer.empty.noVisibleFiles")
+    : t("workspace.fileExplorer.empty.noFiles");
+  const dotfileToggleStyle = useCallback(
+    (state: PressableStateCallbackType) => [
+      iconButtonStyleProp(state),
+      hideDotFiles && styles.iconButtonActive,
+    ],
+    [hideDotFiles, iconButtonStyleProp],
+  );
+  const dotfileToggleAccessibilityState = useMemo(
+    () => ({ selected: hideDotFiles }),
+    [hideDotFiles],
+  );
 
   if (error) {
     return (
@@ -561,14 +603,6 @@ function FileExplorerPaneContent(props: FileExplorerPaneContentProps) {
     );
   }
 
-  if (treeRows.length === 0) {
-    return (
-      <View style={styles.centerState}>
-        <Text style={styles.emptyText}>{t("workspace.fileExplorer.empty.noFiles")}</Text>
-      </View>
-    );
-  }
-
   return (
     <View style={TREE_PANE_CONTAINER_STYLE}>
       <View style={styles.paneHeader} testID="files-pane-header">
@@ -576,45 +610,67 @@ function FileExplorerPaneContent(props: FileExplorerPaneContentProps) {
           <Text style={styles.sortTriggerText}>{currentSortLabel}</Text>
           <ChevronDown size={12} color={theme.colors.foregroundMuted} />
         </Pressable>
-        <Pressable
-          onPress={handleRefresh}
-          disabled={isRefreshFetching}
-          hitSlop={8}
-          style={iconButtonStyleProp}
-          accessibilityRole="button"
-          accessibilityLabel={
-            isRefreshFetching
-              ? t("workspace.fileExplorer.actions.refreshing")
-              : t("workspace.fileExplorer.actions.refresh")
-          }
-        >
-          <View style={styles.refreshIcon}>
-            {isRefreshFetching ? (
-              <LoadingSpinner size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+        <View style={styles.headerActions}>
+          <Pressable
+            onPress={handleToggleDotFiles}
+            hitSlop={8}
+            style={dotfileToggleStyle}
+            accessibilityRole="button"
+            accessibilityLabel={dotfileToggleAccessibilityLabel}
+            accessibilityState={dotfileToggleAccessibilityState}
+          >
+            {hideDotFiles ? (
+              <EyeOff size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
             ) : (
-              <RotateCw size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+              <Eye size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
             )}
-          </View>
-        </Pressable>
+          </Pressable>
+          <Pressable
+            onPress={handleRefresh}
+            disabled={isRefreshFetching}
+            hitSlop={8}
+            style={iconButtonStyleProp}
+            accessibilityRole="button"
+            accessibilityLabel={
+              isRefreshFetching
+                ? t("workspace.fileExplorer.actions.refreshing")
+                : t("workspace.fileExplorer.actions.refresh")
+            }
+          >
+            <View style={styles.refreshIcon}>
+              {isRefreshFetching ? (
+                <LoadingSpinner size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+              ) : (
+                <RotateCw size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+              )}
+            </View>
+          </Pressable>
+        </View>
       </View>
-      <FlatList
-        ref={treeListRef}
-        style={styles.treeList}
-        data={treeRows}
-        renderItem={renderTreeRow}
-        keyExtractor={treeRowKeyExtractor}
-        testID="file-explorer-tree-scroll"
-        contentContainerStyle={styles.entriesContent}
-        onLayout={scrollbar.onLayout}
-        onScroll={scrollbar.onScroll}
-        onContentSizeChange={scrollbar.onContentSizeChange}
-        scrollEventThrottle={16}
-        showsVerticalScrollIndicator={!showDesktopWebScrollbar}
-        initialNumToRender={24}
-        maxToRenderPerBatch={40}
-        windowSize={12}
-      />
-      {scrollbar.overlay}
+      {treeRows.length === 0 ? (
+        <View style={styles.centerState}>
+          <Text style={styles.emptyText}>{emptyLabel}</Text>
+        </View>
+      ) : (
+        <FlatList
+          ref={treeListRef}
+          style={styles.treeList}
+          data={treeRows}
+          renderItem={renderTreeRow}
+          keyExtractor={treeRowKeyExtractor}
+          testID="file-explorer-tree-scroll"
+          contentContainerStyle={styles.entriesContent}
+          onLayout={scrollbar.onLayout}
+          onScroll={scrollbar.onScroll}
+          onContentSizeChange={scrollbar.onContentSizeChange}
+          scrollEventThrottle={16}
+          showsVerticalScrollIndicator={!showDesktopWebScrollbar}
+          initialNumToRender={24}
+          maxToRenderPerBatch={40}
+          windowSize={12}
+        />
+      )}
+      {treeRows.length > 0 ? scrollbar.overlay : null}
     </View>
   );
 }
@@ -643,12 +699,14 @@ function buildTreeRows({
   directories,
   expandedPaths,
   sortOption,
+  hideDotFiles,
   path,
   depth,
 }: {
   directories: Map<string, { path: string; entries: ExplorerEntry[] }>;
   expandedPaths: Set<string>;
   sortOption: SortOption;
+  hideDotFiles: boolean;
   path: string;
   depth: number;
 }): TreeRow[] {
@@ -658,7 +716,10 @@ function buildTreeRows({
   }
 
   const rows: TreeRow[] = [];
-  const entries = sortEntries(directory.entries, sortOption);
+  const entries = sortEntries(
+    filterVisibleExplorerEntries(directory.entries, hideDotFiles),
+    sortOption,
+  );
 
   for (const entry of entries) {
     rows.push({ entry, depth });
@@ -668,6 +729,7 @@ function buildTreeRows({
           directories,
           expandedPaths,
           sortOption,
+          hideDotFiles,
           path: entry.path,
           depth: depth + 1,
         }),
@@ -731,15 +793,24 @@ function resolveTreeRows({
   directories,
   expandedPaths,
   sortOption,
+  hideDotFiles,
 }: {
   directories: Map<string, { path: string; entries: ExplorerEntry[] }>;
   expandedPaths: Set<string>;
   sortOption: SortOption;
+  hideDotFiles: boolean;
 }): TreeRow[] {
   if (!directories.get(".")) {
     return [];
   }
-  return buildTreeRows({ directories, expandedPaths, sortOption, path: ".", depth: 0 });
+  return buildTreeRows({
+    directories,
+    expandedPaths,
+    sortOption,
+    hideDotFiles,
+    path: ".",
+    depth: 0,
+  });
 }
 
 type StartDownloadFn = ReturnType<typeof useDownloadStore.getState>["startDownload"];
@@ -856,6 +927,7 @@ async function initializeExplorer({
   hasInitializedRef,
   workspaceStateKey,
   requestDirectoryListing,
+  hideDotFiles,
 }: {
   hasWorkspaceScope: boolean;
   hasInitializedRef: RefObject<boolean>;
@@ -864,6 +936,7 @@ async function initializeExplorer({
     path: string,
     opts?: { recordHistory?: boolean; setCurrentPath?: boolean },
   ) => Promise<boolean>;
+  hideDotFiles: boolean;
 }): Promise<void> {
   if (!hasWorkspaceScope || hasInitializedRef.current) {
     return;
@@ -877,25 +950,27 @@ async function initializeExplorer({
     hasInitializedRef.current = false;
     return;
   }
-  requestPersistedExpandedPaths({ workspaceStateKey, requestDirectoryListing });
+  requestPersistedExpandedPaths({ workspaceStateKey, requestDirectoryListing, hideDotFiles });
 }
 
 function requestPersistedExpandedPaths({
   workspaceStateKey,
   requestDirectoryListing,
+  hideDotFiles,
 }: {
   workspaceStateKey: string | null;
   requestDirectoryListing: (
     path: string,
     opts?: { recordHistory?: boolean; setCurrentPath?: boolean },
   ) => Promise<boolean>;
+  hideDotFiles: boolean;
 }): void {
   const persistedPaths = usePanelStore.getState().expandedPathsByWorkspace[workspaceStateKey ?? ""];
   if (!persistedPaths) {
     return;
   }
   for (const path of persistedPaths) {
-    if (path !== ".") {
+    if (path !== "." && (!hideDotFiles || !isHiddenExplorerPath(path))) {
       void requestDirectoryListing(path, {
         recordHistory: false,
         setCurrentPath: false,
@@ -907,10 +982,12 @@ function requestPersistedExpandedPaths({
 async function refreshExplorerDirectories({
   hasWorkspaceScope,
   expandedPaths,
+  hideDotFiles,
   requestDirectoryListing,
 }: {
   hasWorkspaceScope: boolean;
   expandedPaths: Set<string>;
+  hideDotFiles: boolean;
   requestDirectoryListing: (
     path: string,
     opts?: { recordHistory?: boolean; setCurrentPath?: boolean },
@@ -919,7 +996,9 @@ async function refreshExplorerDirectories({
   if (!hasWorkspaceScope) {
     return null;
   }
-  const directoryPaths = Array.from(expandedPaths);
+  const directoryPaths = Array.from(expandedPaths).filter(
+    (path) => !hideDotFiles || !isHiddenExplorerPath(path),
+  );
   if (!directoryPaths.includes(".")) {
     directoryPaths.unshift(".");
   }
@@ -1010,6 +1089,11 @@ const styles = StyleSheet.create((theme) => ({
   sortTriggerText: {
     fontSize: theme.fontSize.xs,
     color: theme.colors.foregroundMuted,
+  },
+  headerActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
   },
   treeList: {
     flex: 1,
@@ -1152,6 +1236,9 @@ const styles = StyleSheet.create((theme) => ({
     justifyContent: "center",
   },
   iconButtonHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+  iconButtonActive: {
     backgroundColor: theme.colors.surface2,
   },
   refreshIcon: {

--- a/packages/app/src/file-explorer/visibility.test.ts
+++ b/packages/app/src/file-explorer/visibility.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { ExplorerEntry } from "@/stores/session-store";
+import { filterVisibleExplorerEntries, isHiddenExplorerPath } from "./visibility";
+
+function makeEntry(name: string, kind: ExplorerEntry["kind"]): ExplorerEntry {
+  return {
+    name,
+    path: name,
+    kind,
+    size: 0,
+    modifiedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("file explorer visibility", () => {
+  it("keeps dot-prefixed entries when dotfile hiding is disabled", () => {
+    const entries = [makeEntry(".env", "file"), makeEntry("src", "directory")];
+
+    expect(filterVisibleExplorerEntries(entries, false)).toEqual(entries);
+  });
+
+  it("hides dot-prefixed files and directories", () => {
+    const entries = [
+      makeEntry(".env", "file"),
+      makeEntry(".git", "directory"),
+      makeEntry("README.md", "file"),
+      makeEntry("src", "directory"),
+    ];
+
+    expect(filterVisibleExplorerEntries(entries, true).map((entry) => entry.name)).toEqual([
+      "README.md",
+      "src",
+    ]);
+  });
+
+  it("detects paths nested under dot-prefixed directories", () => {
+    expect(isHiddenExplorerPath(".")).toBe(false);
+    expect(isHiddenExplorerPath("src/components")).toBe(false);
+    expect(isHiddenExplorerPath(".git")).toBe(true);
+    expect(isHiddenExplorerPath("src/.cache/output.json")).toBe(true);
+  });
+});

--- a/packages/app/src/file-explorer/visibility.test.ts
+++ b/packages/app/src/file-explorer/visibility.test.ts
@@ -35,6 +35,8 @@ describe("file explorer visibility", () => {
 
   it("detects paths nested under dot-prefixed directories", () => {
     expect(isHiddenExplorerPath(".")).toBe(false);
+    expect(isHiddenExplorerPath("..")).toBe(false);
+    expect(isHiddenExplorerPath("../sibling")).toBe(false);
     expect(isHiddenExplorerPath("src/components")).toBe(false);
     expect(isHiddenExplorerPath(".git")).toBe(true);
     expect(isHiddenExplorerPath("src/.cache/output.json")).toBe(true);

--- a/packages/app/src/file-explorer/visibility.test.ts
+++ b/packages/app/src/file-explorer/visibility.test.ts
@@ -13,13 +13,13 @@ function makeEntry(name: string, kind: ExplorerEntry["kind"]): ExplorerEntry {
 }
 
 describe("file explorer visibility", () => {
-  it("keeps dot-prefixed entries when dotfile hiding is disabled", () => {
+  it("keeps dot-prefixed entries when hidden files are shown", () => {
     const entries = [makeEntry(".env", "file"), makeEntry("src", "directory")];
 
-    expect(filterVisibleExplorerEntries(entries, false)).toEqual(entries);
+    expect(filterVisibleExplorerEntries(entries, true)).toEqual(entries);
   });
 
-  it("hides dot-prefixed files and directories", () => {
+  it("hides dot-prefixed files and directories when hidden files are not shown", () => {
     const entries = [
       makeEntry(".env", "file"),
       makeEntry(".git", "directory"),
@@ -27,7 +27,7 @@ describe("file explorer visibility", () => {
       makeEntry("src", "directory"),
     ];
 
-    expect(filterVisibleExplorerEntries(entries, true).map((entry) => entry.name)).toEqual([
+    expect(filterVisibleExplorerEntries(entries, false).map((entry) => entry.name)).toEqual([
       "README.md",
       "src",
     ]);

--- a/packages/app/src/file-explorer/visibility.ts
+++ b/packages/app/src/file-explorer/visibility.ts
@@ -1,0 +1,15 @@
+import type { ExplorerEntry } from "@/stores/session-store";
+
+export function isHiddenExplorerPath(path: string): boolean {
+  return path.split("/").some((segment) => segment !== "." && segment.startsWith("."));
+}
+
+export function filterVisibleExplorerEntries(
+  entries: ExplorerEntry[],
+  hideDotFiles: boolean,
+): ExplorerEntry[] {
+  if (!hideDotFiles) {
+    return entries;
+  }
+  return entries.filter((entry) => !entry.name.startsWith("."));
+}

--- a/packages/app/src/file-explorer/visibility.ts
+++ b/packages/app/src/file-explorer/visibility.ts
@@ -1,7 +1,9 @@
 import type { ExplorerEntry } from "@/stores/session-store";
 
 export function isHiddenExplorerPath(path: string): boolean {
-  return path.split("/").some((segment) => segment !== "." && segment.startsWith("."));
+  return path
+    .split("/")
+    .some((segment) => segment !== "." && segment !== ".." && segment.startsWith("."));
 }
 
 export function filterVisibleExplorerEntries(

--- a/packages/app/src/file-explorer/visibility.ts
+++ b/packages/app/src/file-explorer/visibility.ts
@@ -6,9 +6,9 @@ export function isHiddenExplorerPath(path: string): boolean {
 
 export function filterVisibleExplorerEntries(
   entries: ExplorerEntry[],
-  hideDotFiles: boolean,
+  showHiddenFiles: boolean,
 ): ExplorerEntry[] {
-  if (!hideDotFiles) {
+  if (showHiddenFiles) {
     return entries;
   }
   return entries.filter((entry) => !entry.name.startsWith("."));

--- a/packages/app/src/i18n/resources.test.ts
+++ b/packages/app/src/i18n/resources.test.ts
@@ -224,7 +224,7 @@ describe("translation resources", () => {
     expect(en.importSession.status.connectHost).toBe("Connect to a host to import sessions");
     expect(en.importSession.actions.refresh).toBe("Refresh sessions");
     expect(en.workspace.fileExplorer.sort.name).toBe("Name");
-    expect(en.workspace.fileExplorer.actions.hideDotFiles).toBe("Hide dotfiles");
+    expect(en.workspace.fileExplorer.actions.hideHiddenFiles).toBe("Hide hidden files");
     expect(en.workspace.fileExplorer.empty.noFiles).toBe("No files");
     expect(en.workspace.fileExplorer.empty.noVisibleFiles).toBe("No visible files");
     expect(en.workspace.setup.status.running).toBe("Running");

--- a/packages/app/src/i18n/resources.test.ts
+++ b/packages/app/src/i18n/resources.test.ts
@@ -225,6 +225,7 @@ describe("translation resources", () => {
     expect(en.importSession.actions.refresh).toBe("Refresh sessions");
     expect(en.workspace.fileExplorer.sort.name).toBe("Name");
     expect(en.workspace.fileExplorer.actions.hideHiddenFiles).toBe("Hide hidden files");
+    expect(en.workspace.fileExplorer.actions.showHiddenFiles).toBe("Show hidden files");
     expect(en.workspace.fileExplorer.empty.noFiles).toBe("No files");
     expect(en.workspace.fileExplorer.empty.noVisibleFiles).toBe("No visible files");
     expect(en.workspace.setup.status.running).toBe("Running");

--- a/packages/app/src/i18n/resources.test.ts
+++ b/packages/app/src/i18n/resources.test.ts
@@ -224,7 +224,9 @@ describe("translation resources", () => {
     expect(en.importSession.status.connectHost).toBe("Connect to a host to import sessions");
     expect(en.importSession.actions.refresh).toBe("Refresh sessions");
     expect(en.workspace.fileExplorer.sort.name).toBe("Name");
+    expect(en.workspace.fileExplorer.actions.hideDotFiles).toBe("Hide dotfiles");
     expect(en.workspace.fileExplorer.empty.noFiles).toBe("No files");
+    expect(en.workspace.fileExplorer.empty.noVisibleFiles).toBe("No visible files");
     expect(en.workspace.setup.status.running).toBe("Running");
     expect(en.workspace.setup.empty.noCommands).toBe("No setup commands ran for this workspace.");
     expect(en.workspace.browser.unavailable.title).toBe("Browser is desktop-only");

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -355,8 +355,8 @@ export const ar: TranslationResources = {
         retry: "أعد المحاولة",
         refresh: "تحديث الملفات",
         refreshing: "تحديث الملفات",
-        hideDotFiles: "إخفاء ملفات النقطة",
-        showDotFiles: "إظهار ملفات النقطة",
+        hideHiddenFiles: "إخفاء الملفات المخفية",
+        showHiddenFiles: "إظهار الملفات المخفية",
       },
       empty: {
         noFiles: "لا توجد ملفات",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -355,9 +355,12 @@ export const ar: TranslationResources = {
         retry: "أعد المحاولة",
         refresh: "تحديث الملفات",
         refreshing: "تحديث الملفات",
+        hideDotFiles: "إخفاء ملفات النقطة",
+        showDotFiles: "إظهار ملفات النقطة",
       },
       empty: {
         noFiles: "لا توجد ملفات",
+        noVisibleFiles: "لا توجد ملفات مرئية",
       },
       states: {
         unavailable: "Workspace غير متوفر",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -354,8 +354,8 @@ export const en = {
         retry: "Retry",
         refresh: "Refresh files",
         refreshing: "Refreshing files",
-        hideDotFiles: "Hide dotfiles",
-        showDotFiles: "Show dotfiles",
+        hideHiddenFiles: "Hide hidden files",
+        showHiddenFiles: "Show hidden files",
       },
       empty: {
         noFiles: "No files",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -354,9 +354,12 @@ export const en = {
         retry: "Retry",
         refresh: "Refresh files",
         refreshing: "Refreshing files",
+        hideDotFiles: "Hide dotfiles",
+        showDotFiles: "Show dotfiles",
       },
       empty: {
         noFiles: "No files",
+        noVisibleFiles: "No visible files",
       },
       states: {
         unavailable: "Workspace is unavailable",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -358,9 +358,12 @@ export const es: TranslationResources = {
         retry: "Rever",
         refresh: "Actualizar archivos",
         refreshing: "Actualizar archivos",
+        hideDotFiles: "Ocultar archivos con punto",
+        showDotFiles: "Mostrar archivos con punto",
       },
       empty: {
         noFiles: "Sin archivos",
+        noVisibleFiles: "No hay archivos visibles",
       },
       states: {
         unavailable: "Workspaceno está disponible",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -358,8 +358,8 @@ export const es: TranslationResources = {
         retry: "Rever",
         refresh: "Actualizar archivos",
         refreshing: "Actualizar archivos",
-        hideDotFiles: "Ocultar archivos con punto",
-        showDotFiles: "Mostrar archivos con punto",
+        hideHiddenFiles: "Ocultar archivos ocultos",
+        showHiddenFiles: "Mostrar archivos ocultos",
       },
       empty: {
         noFiles: "Sin archivos",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -358,8 +358,8 @@ export const fr: TranslationResources = {
         retry: "Réessayer",
         refresh: "Actualiser les fichiers",
         refreshing: "Actualisation des fichiers",
-        hideDotFiles: "Masquer les fichiers point",
-        showDotFiles: "Afficher les fichiers point",
+        hideHiddenFiles: "Masquer les fichiers cachés",
+        showHiddenFiles: "Afficher les fichiers cachés",
       },
       empty: {
         noFiles: "Aucun fichier",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -358,9 +358,12 @@ export const fr: TranslationResources = {
         retry: "Réessayer",
         refresh: "Actualiser les fichiers",
         refreshing: "Actualisation des fichiers",
+        hideDotFiles: "Masquer les fichiers point",
+        showDotFiles: "Afficher les fichiers point",
       },
       empty: {
         noFiles: "Aucun fichier",
+        noVisibleFiles: "Aucun fichier visible",
       },
       states: {
         unavailable: "Workspacen'est pas disponible",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -357,9 +357,12 @@ export const ru: TranslationResources = {
         retry: "Повторить попытку",
         refresh: "Обновить файлы",
         refreshing: "Обновление файлов",
+        hideDotFiles: "Скрыть dot-файлы",
+        showDotFiles: "Показать dot-файлы",
       },
       empty: {
         noFiles: "Нет файлов",
+        noVisibleFiles: "Нет видимых файлов",
       },
       states: {
         unavailable: "Workspace недоступен",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -357,8 +357,8 @@ export const ru: TranslationResources = {
         retry: "Повторить попытку",
         refresh: "Обновить файлы",
         refreshing: "Обновление файлов",
-        hideDotFiles: "Скрыть dot-файлы",
-        showDotFiles: "Показать dot-файлы",
+        hideHiddenFiles: "Скрыть скрытые файлы",
+        showHiddenFiles: "Показать скрытые файлы",
       },
       empty: {
         noFiles: "Нет файлов",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -355,9 +355,12 @@ export const zhCN: TranslationResources = {
         retry: "重试",
         refresh: "刷新文件",
         refreshing: "正在刷新文件",
+        hideDotFiles: "隐藏点文件",
+        showDotFiles: "显示点文件",
       },
       empty: {
         noFiles: "没有文件",
+        noVisibleFiles: "没有可见文件",
       },
       states: {
         unavailable: "Workspace 不可用",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -355,8 +355,8 @@ export const zhCN: TranslationResources = {
         retry: "重试",
         refresh: "刷新文件",
         refreshing: "正在刷新文件",
-        hideDotFiles: "隐藏点文件",
-        showDotFiles: "显示点文件",
+        hideHiddenFiles: "隐藏隐藏文件",
+        showHiddenFiles: "显示隐藏文件",
       },
       empty: {
         noFiles: "没有文件",

--- a/packages/app/src/stores/panel-store/index.ts
+++ b/packages/app/src/stores/panel-store/index.ts
@@ -75,7 +75,7 @@ export interface PanelState {
   sidebarWidth: number;
   explorerWidth: number;
   explorerSortOption: SortOption;
-  explorerHideDotFiles: boolean;
+  explorerShowHiddenFiles: boolean;
   explorerFilesSplitRatio: number;
 
   // Actions
@@ -102,7 +102,7 @@ export interface PanelState {
   setSidebarWidth: (width: number) => void;
   setExplorerWidth: (width: number) => void;
   setExplorerSortOption: (option: SortOption) => void;
-  toggleExplorerHideDotFiles: () => void;
+  toggleExplorerShowHiddenFiles: () => void;
   setExplorerFilesSplitRatio: (ratio: number) => void;
 }
 
@@ -129,7 +129,7 @@ export const usePanelStore = create<PanelState>()(
       sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
       explorerWidth: DEFAULT_EXPLORER_SIDEBAR_WIDTH,
       explorerSortOption: "name",
-      explorerHideDotFiles: false,
+      explorerShowHiddenFiles: true,
       explorerFilesSplitRatio: DEFAULT_EXPLORER_FILES_SPLIT_RATIO,
 
       toggleFocusMode: () =>
@@ -265,8 +265,8 @@ export const usePanelStore = create<PanelState>()(
       setSidebarWidth: (width) => set({ sidebarWidth: clampSidebarWidth(width) }),
       setExplorerWidth: (width) => set({ explorerWidth: clampExplorerWidth(width) }),
       setExplorerSortOption: (option) => set({ explorerSortOption: option }),
-      toggleExplorerHideDotFiles: () =>
-        set((state) => ({ explorerHideDotFiles: !state.explorerHideDotFiles })),
+      toggleExplorerShowHiddenFiles: () =>
+        set((state) => ({ explorerShowHiddenFiles: !state.explorerShowHiddenFiles })),
       setExplorerFilesSplitRatio: (ratio) =>
         set({
           explorerFilesSplitRatio: Number.isFinite(ratio)
@@ -290,7 +290,7 @@ export const usePanelStore = create<PanelState>()(
         sidebarWidth: state.sidebarWidth,
         explorerWidth: state.explorerWidth,
         explorerSortOption: state.explorerSortOption,
-        explorerHideDotFiles: state.explorerHideDotFiles,
+        explorerShowHiddenFiles: state.explorerShowHiddenFiles,
         explorerFilesSplitRatio: state.explorerFilesSplitRatio,
       }),
     },
@@ -321,7 +321,6 @@ export function usePanelState(isMobile: boolean) {
   const explorerTabByCheckout = usePanelStore((state) => state.explorerTabByCheckout);
   const explorerWidth = usePanelStore((state) => state.explorerWidth);
   const explorerSortOption = usePanelStore((state) => state.explorerSortOption);
-  const explorerHideDotFiles = usePanelStore((state) => state.explorerHideDotFiles);
   const explorerFilesSplitRatio = usePanelStore((state) => state.explorerFilesSplitRatio);
   const setExplorerTab = usePanelStore((state) => state.setExplorerTab);
   const setExplorerTabForCheckout = usePanelStore((state) => state.setExplorerTabForCheckout);
@@ -330,7 +329,6 @@ export function usePanelState(isMobile: boolean) {
   );
   const setExplorerWidth = usePanelStore((state) => state.setExplorerWidth);
   const setExplorerSortOption = usePanelStore((state) => state.setExplorerSortOption);
-  const toggleExplorerHideDotFiles = usePanelStore((state) => state.toggleExplorerHideDotFiles);
   const setExplorerFilesSplitRatio = usePanelStore((state) => state.setExplorerFilesSplitRatio);
 
   return {
@@ -344,14 +342,12 @@ export function usePanelState(isMobile: boolean) {
     explorerTabByCheckout,
     explorerWidth,
     explorerSortOption,
-    explorerHideDotFiles,
     explorerFilesSplitRatio,
     setExplorerTab,
     setExplorerTabForCheckout,
     activateExplorerTabForCheckout,
     setExplorerWidth,
     setExplorerSortOption,
-    toggleExplorerHideDotFiles,
     setExplorerFilesSplitRatio,
   };
 }

--- a/packages/app/src/stores/panel-store/index.ts
+++ b/packages/app/src/stores/panel-store/index.ts
@@ -75,6 +75,7 @@ export interface PanelState {
   sidebarWidth: number;
   explorerWidth: number;
   explorerSortOption: SortOption;
+  explorerHideDotFiles: boolean;
   explorerFilesSplitRatio: number;
 
   // Actions
@@ -101,6 +102,7 @@ export interface PanelState {
   setSidebarWidth: (width: number) => void;
   setExplorerWidth: (width: number) => void;
   setExplorerSortOption: (option: SortOption) => void;
+  toggleExplorerHideDotFiles: () => void;
   setExplorerFilesSplitRatio: (ratio: number) => void;
 }
 
@@ -127,6 +129,7 @@ export const usePanelStore = create<PanelState>()(
       sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
       explorerWidth: DEFAULT_EXPLORER_SIDEBAR_WIDTH,
       explorerSortOption: "name",
+      explorerHideDotFiles: false,
       explorerFilesSplitRatio: DEFAULT_EXPLORER_FILES_SPLIT_RATIO,
 
       toggleFocusMode: () =>
@@ -262,6 +265,8 @@ export const usePanelStore = create<PanelState>()(
       setSidebarWidth: (width) => set({ sidebarWidth: clampSidebarWidth(width) }),
       setExplorerWidth: (width) => set({ explorerWidth: clampExplorerWidth(width) }),
       setExplorerSortOption: (option) => set({ explorerSortOption: option }),
+      toggleExplorerHideDotFiles: () =>
+        set((state) => ({ explorerHideDotFiles: !state.explorerHideDotFiles })),
       setExplorerFilesSplitRatio: (ratio) =>
         set({
           explorerFilesSplitRatio: Number.isFinite(ratio)
@@ -271,7 +276,7 @@ export const usePanelStore = create<PanelState>()(
     }),
     {
       name: "panel-state",
-      version: 10,
+      version: 11,
       storage: createJSONStorage(() => AsyncStorage),
       migrate: (persistedState, version) =>
         migratePanelState(persistedState, version, { isWeb }) as unknown as PanelState,
@@ -285,6 +290,7 @@ export const usePanelStore = create<PanelState>()(
         sidebarWidth: state.sidebarWidth,
         explorerWidth: state.explorerWidth,
         explorerSortOption: state.explorerSortOption,
+        explorerHideDotFiles: state.explorerHideDotFiles,
         explorerFilesSplitRatio: state.explorerFilesSplitRatio,
       }),
     },
@@ -315,6 +321,7 @@ export function usePanelState(isMobile: boolean) {
   const explorerTabByCheckout = usePanelStore((state) => state.explorerTabByCheckout);
   const explorerWidth = usePanelStore((state) => state.explorerWidth);
   const explorerSortOption = usePanelStore((state) => state.explorerSortOption);
+  const explorerHideDotFiles = usePanelStore((state) => state.explorerHideDotFiles);
   const explorerFilesSplitRatio = usePanelStore((state) => state.explorerFilesSplitRatio);
   const setExplorerTab = usePanelStore((state) => state.setExplorerTab);
   const setExplorerTabForCheckout = usePanelStore((state) => state.setExplorerTabForCheckout);
@@ -323,6 +330,7 @@ export function usePanelState(isMobile: boolean) {
   );
   const setExplorerWidth = usePanelStore((state) => state.setExplorerWidth);
   const setExplorerSortOption = usePanelStore((state) => state.setExplorerSortOption);
+  const toggleExplorerHideDotFiles = usePanelStore((state) => state.toggleExplorerHideDotFiles);
   const setExplorerFilesSplitRatio = usePanelStore((state) => state.setExplorerFilesSplitRatio);
 
   return {
@@ -336,12 +344,14 @@ export function usePanelState(isMobile: boolean) {
     explorerTabByCheckout,
     explorerWidth,
     explorerSortOption,
+    explorerHideDotFiles,
     explorerFilesSplitRatio,
     setExplorerTab,
     setExplorerTabForCheckout,
     activateExplorerTabForCheckout,
     setExplorerWidth,
     setExplorerSortOption,
+    toggleExplorerHideDotFiles,
     setExplorerFilesSplitRatio,
   };
 }

--- a/packages/app/src/stores/panel-store/state.test.ts
+++ b/packages/app/src/stores/panel-store/state.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   buildOpenFileExplorerPatch,
   buildToggleFileExplorerPatch,
+  migratePanelState,
   selectIsAgentListOpen,
   selectIsFileExplorerOpen,
   selectPanelVisibility,
@@ -93,6 +94,14 @@ describe("panel-store explorer tab resolution", () => {
         },
       }),
     ).toBe("files");
+  });
+});
+
+describe("panel-store migration", () => {
+  it("defaults dotfile visibility to showing dotfiles", () => {
+    const state = migratePanelState({}, 10, { isWeb: false });
+
+    expect(state.explorerHideDotFiles).toBe(false);
   });
 });
 

--- a/packages/app/src/stores/panel-store/state.test.ts
+++ b/packages/app/src/stores/panel-store/state.test.ts
@@ -98,10 +98,10 @@ describe("panel-store explorer tab resolution", () => {
 });
 
 describe("panel-store migration", () => {
-  it("defaults dotfile visibility to showing dotfiles", () => {
+  it("defaults hidden-file visibility to showing hidden files", () => {
     const state = migratePanelState({}, 10, { isWeb: false });
 
-    expect(state.explorerHideDotFiles).toBe(false);
+    expect(state.explorerShowHiddenFiles).toBe(true);
   });
 });
 

--- a/packages/app/src/stores/panel-store/state.ts
+++ b/packages/app/src/stores/panel-store/state.ts
@@ -207,6 +207,12 @@ function migratePanelDesktopFocusMode(state: MigratablePanelState): void {
   }
 }
 
+function migratePanelExplorerDotfileVisibility(state: MigratablePanelState): void {
+  if (typeof state.explorerHideDotFiles !== "boolean") {
+    state.explorerHideDotFiles = false;
+  }
+}
+
 export function migratePanelState(
   persistedState: unknown,
   version: number,
@@ -244,6 +250,9 @@ export function migratePanelState(
     !state.diffExpandedPathsByWorkspace
   ) {
     state.diffExpandedPathsByWorkspace = {};
+  }
+  if (version < 11 || typeof state.explorerHideDotFiles !== "boolean") {
+    migratePanelExplorerDotfileVisibility(state);
   }
 
   return state;

--- a/packages/app/src/stores/panel-store/state.ts
+++ b/packages/app/src/stores/panel-store/state.ts
@@ -207,12 +207,6 @@ function migratePanelDesktopFocusMode(state: MigratablePanelState): void {
   }
 }
 
-function migratePanelExplorerDotfileVisibility(state: MigratablePanelState): void {
-  if (typeof state.explorerHideDotFiles !== "boolean") {
-    state.explorerHideDotFiles = false;
-  }
-}
-
 export function migratePanelState(
   persistedState: unknown,
   version: number,
@@ -251,8 +245,8 @@ export function migratePanelState(
   ) {
     state.diffExpandedPathsByWorkspace = {};
   }
-  if (version < 11 || typeof state.explorerHideDotFiles !== "boolean") {
-    migratePanelExplorerDotfileVisibility(state);
+  if (typeof state.explorerShowHiddenFiles !== "boolean") {
+    state.explorerShowHiddenFiles = true;
   }
 
   return state;


### PR DESCRIPTION
### Linked issue

Closes #1515

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds a File Explorer toggle for dot-prefixed files and directories.

The change is intentionally scoped to the existing File Explorer pane:

- Adds a persisted `explorerHideDotFiles` setting to the panel store, with a v11 migration that preserves the existing default behavior: dotfiles remain visible until the user turns hiding on.
- Adds an Eye/EyeOff button to the Files pane header. When enabled, rows whose entry name starts with `.` are hidden from the tree.
- Filters dotfile entries client-side so the daemon file explorer protocol stays unchanged.
- Avoids refreshing or restoring persisted expanded paths inside hidden dot-directories while hiding is enabled. When hiding is turned off again, persisted expanded paths are requested again so previously-expanded dot-directories can repopulate.
- Adds `workspace.fileExplorer.actions.hideDotFiles`, `showDotFiles`, and `empty.noVisibleFiles` translations for all app locales.
- Adds focused tests for the visibility helper, panel-store migration default, and the new i18n keys.

### How did you verify it

Automated checks run locally:

```bash
npm run format
npx vitest run packages/app/src/file-explorer/visibility.test.ts packages/app/src/stores/panel-store/state.test.ts packages/app/src/i18n/resources.test.ts --bail=1
npm run build:server
npm run lint
npm run typecheck
```

The pre-commit hook also reran lint, formatting check, and typecheck for the committed files and passed.

Manual QA:

- Ran the local dev daemon and web app with the documented workflow:

  ```bash
  npm run dev:server
  npm run dev:app
  ```

- Opened the app in a browser at `http://localhost:8081` with the dev daemon on `127.0.0.1:6768`.
- Verified the File Explorer UI in browser web: toggling the new dotfile control hides dot-prefixed files/directories and toggling it back shows them again.

Platform coverage: browser web only. iOS, Android, and desktop were not manually tested for this PR. Screenshot/video is not attached from this CLI-submitted flow.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
