### PR TITLE
fix: prevent IME Enter key from sending message on macOS

### DIFF
--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -1657,8 +1657,10 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     function handleDesktopKeyPress(event: WebTextInputKeyPressEvent) {
       if (!shouldHandleWebKeyPress) return;
       // On macOS, compositionend fires before keydown so isComposing is already
-      // false when Enter is pressed. Check the native ref as a fallback.
-      if (isNativeComposingRef.current) return;
+      // false when Enter is pressed. Check the native ref as a fallback, but
+      // only for Enter — the deferred window is one tick so non-Enter keys
+      // should not be affected.
+      if (event.nativeEvent.key === "Enter" && isNativeComposingRef.current) return;
       handleDesktopKeyPressImpl(event, {
         onKeyPressCallback,
         submitOnEnter: shouldSubmitOnEnter,

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -57,7 +57,7 @@ import { useIosHardwareKeyboardSubmit } from "@/hooks/use-ios-hardware-keyboard-
 import { formatShortcut, type ShortcutKey } from "@/utils/format-shortcut";
 import { getShortcutOs } from "@/utils/shortcut-platform";
 import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
-import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
+import { isImeComposingKeyboardEvent, useNativeImeComposingRef } from "@/utils/keyboard-ime";
 import { isWeb } from "@/constants/platform";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useComposerHeightMirror } from "./height-mirror";
@@ -1596,6 +1596,8 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       }
     }, [getWebTextArea]);
 
+    const isNativeComposingRef = useNativeImeComposingRef(() => webTextareaRef.current);
+
     const inputScrollbar = useWebElementScrollbar(webTextareaRef, {
       enabled: isWeb,
     });
@@ -1654,6 +1656,9 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
 
     function handleDesktopKeyPress(event: WebTextInputKeyPressEvent) {
       if (!shouldHandleWebKeyPress) return;
+      // On macOS, compositionend fires before keydown so isComposing is already
+      // false when Enter is pressed. Check the native ref as a fallback.
+      if (isNativeComposingRef.current) return;
       handleDesktopKeyPressImpl(event, {
         onKeyPressCallback,
         submitOnEnter: shouldSubmitOnEnter,

--- a/packages/app/src/utils/keyboard-ime.ts
+++ b/packages/app/src/utils/keyboard-ime.ts
@@ -1,6 +1,45 @@
+import { useEffect, useRef } from "react";
+
 export function isImeComposingKeyboardEvent(event: {
   isComposing?: boolean;
   keyCode?: number;
 }): boolean {
   return Boolean(event.isComposing) || event.keyCode === 229;
+}
+
+/**
+ * On macOS (Chromium/Electron), `compositionend` fires *before* the Enter
+ * `keydown` event, so `event.nativeEvent.isComposing` is already false by the
+ * time the keypress handler runs. This hook attaches native DOM listeners and
+ * defers the flag clear by one tick so the Enter handler can still see that
+ * IME composition just ended.
+ */
+export function useNativeImeComposingRef(
+  getElement: () => HTMLElement | null,
+): React.MutableRefObject<boolean> {
+  const isComposingRef = useRef(false);
+
+  useEffect(() => {
+    const el = getElement();
+    if (!el) return;
+
+    const onStart = () => {
+      isComposingRef.current = true;
+    };
+    const onEnd = () => {
+      // Defer so the Enter keydown handler still sees isComposing=true
+      setTimeout(() => {
+        isComposingRef.current = false;
+      }, 0);
+    };
+
+    el.addEventListener("compositionstart", onStart);
+    el.addEventListener("compositionend", onEnd);
+    return () => {
+      el.removeEventListener("compositionstart", onStart);
+      el.removeEventListener("compositionend", onEnd);
+    };
+  });
+
+  return isComposingRef;
 }

--- a/packages/app/src/utils/keyboard-ime.ts
+++ b/packages/app/src/utils/keyboard-ime.ts
@@ -39,7 +39,10 @@ export function useNativeImeComposingRef(
       el.removeEventListener("compositionstart", onStart);
       el.removeEventListener("compositionend", onEnd);
     };
-  });
+    // Empty deps: the element ref is stable after mount (set by useLayoutEffect
+    // before this useEffect runs), so we only need to attach listeners once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return isComposingRef;
 }


### PR DESCRIPTION
## Problem

On macOS (Chromium/Electron), the `compositionend` event fires **before** the `keydown` event for the Enter key. This means `event.nativeEvent.isComposing` is already `false` by the time `handleDesktopKeyPressImpl` runs, so the existing IME guard doesn't fire and the message is sent when the user intended only to confirm the composition.

This affects **Korean, Japanese, and Chinese** (CJK) input on macOS. The behavior is intermittent because it depends on exact event ordering, which varies by input method and OS version.

Closes #309, related to #264, #241.

## Fix

Add a `useNativeImeComposingRef` hook in `keyboard-ime.ts` that:
- Attaches native DOM `compositionstart` / `compositionend` listeners directly to the textarea element
- Defers the flag clear in `compositionend` by one tick (`setTimeout(0)`) so the Enter `keydown` handler still sees that composition just ended

In `input.tsx`, call this hook and check `isNativeComposingRef.current` as an early return in `handleDesktopKeyPress` before delegating to `handleDesktopKeyPressImpl`.

## Testing

1. Open Paseo on macOS
2. Switch input method to Korean (or Japanese/Chinese)
3. Type a word using IME (e.g. `안녕`)
4. Press Enter to confirm the composition
5. **Before fix**: message sends immediately
6. **After fix**: composition is confirmed, Enter sends only on a second press

🤖 Generated with [Claude Code](https://claude.ai/claude-code)