### PR TITLE
fix(app): prevent Android crash when opening Providers settings

### DIFF
--- a/packages/app/src/components/provider-catalog-list.tsx
+++ b/packages/app/src/components/provider-catalog-list.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Pressable, Text, View } from "react-native";
+import { Pressable, Text, TextInput, View } from "react-native";
 import { SvgXml } from "react-native-svg";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { ExternalLink, PackagePlus, Search } from "lucide-react-native";
-import { AdaptiveTextInput } from "@/components/adaptive-modal-sheet";
 import { Button } from "@/components/ui/button";
+import { isWeb } from "@/constants/platform";
 import {
   useAcpProviderCatalog,
   type AcpProviderCatalogItem,
@@ -145,13 +145,15 @@ export function ProviderCatalogList({
         <View style={styles.searchIcon}>
           <ThemedSearch size={SEARCH_ICON_SIZE} uniProps={foregroundMutedColorMapping} />
         </View>
-        <AdaptiveTextInput
+        <TextInput
           testID="provider-catalog-search"
           value={search}
           onChangeText={setSearch}
           accessibilityLabel={t("providerCatalog.search")}
           placeholder={t("providerCatalog.search")}
-          style={styles.searchInput}
+          placeholderTextColor={styles.placeholderColor.color}
+          // @ts-expect-error - outlineStyle is web-only
+          style={SEARCH_INPUT_STYLE}
           autoCapitalize="none"
           autoCorrect={false}
         />
@@ -279,4 +281,9 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foregroundMuted,
     fontSize: theme.fontSize.sm,
   },
+  placeholderColor: {
+    color: theme.colors.foregroundMuted,
+  },
 }));
+
+const SEARCH_INPUT_STYLE = [styles.searchInput, isWeb && { outlineStyle: "none" }];

--- a/packages/app/src/components/provider-catalog-list.tsx
+++ b/packages/app/src/components/provider-catalog-list.tsx
@@ -28,6 +28,9 @@ const ThemedPackagePlus = withUnistyles(PackagePlus);
 const ThemedSvgXml = withUnistyles(SvgXml);
 const ThemedSearch = withUnistyles(Search);
 const ThemedExternalLink = withUnistyles(ExternalLink);
+const ThemedTextInput = withUnistyles(TextInput, (theme) => ({
+  placeholderTextColor: theme.colors.foregroundMuted,
+}));
 
 const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
 const foregroundMutedColorMapping = (theme: Theme) => ({
@@ -145,13 +148,12 @@ export function ProviderCatalogList({
         <View style={styles.searchIcon}>
           <ThemedSearch size={SEARCH_ICON_SIZE} uniProps={foregroundMutedColorMapping} />
         </View>
-        <TextInput
+        <ThemedTextInput
           testID="provider-catalog-search"
           value={search}
           onChangeText={setSearch}
           accessibilityLabel={t("providerCatalog.search")}
           placeholder={t("providerCatalog.search")}
-          placeholderTextColor={styles.placeholderColor.color}
           // @ts-expect-error - outlineStyle is web-only
           style={SEARCH_INPUT_STYLE}
           autoCapitalize="none"
@@ -280,9 +282,6 @@ const styles = StyleSheet.create((theme) => ({
   stateText: {
     color: theme.colors.foregroundMuted,
     fontSize: theme.fontSize.sm,
-  },
-  placeholderColor: {
-    color: theme.colors.foregroundMuted,
   },
 }));
 


### PR DESCRIPTION
opening settings -> providers on android showed a white screen and hard crashed the app, unrecoverable without a force quit. regression in v0.1.96, multiple reporters (#1504).

### what's happening

`ProviderCatalogList` renders `AdaptiveTextInput`. on native compact that resolves to a `BottomSheetTextInput`, which calls `useBottomSheetInternal()`. that hook throws when the component isn't mounted inside a `<BottomSheet>`:

```
'useBottomSheetInternal' cannot be used out of the BottomSheet!
```

the provider catalog is an ordinary settings section, not a sheet. `AdaptiveTextInput` is the adaptive-modal-sheet header input; #1423 inlined the catalog into the settings page but kept that sheet-only input, so it throws on render on android.

### the fix

swap it for a plain `TextInput`, themed the way every other non-sheet input in the app already is:

- text color via the tracked `style`
- `placeholderTextColor` via `styles.placeholderColor.color`, the same pattern as appearance-section, project-settings, and the review surface
- `outlineStyle: "none"` on web

no bottom-sheet context, no `useUnistyles`.

### supersedes #1536

#1536 diagnosed this crash correctly and also moved to a plain `TextInput`, but pulled placeholder color through `useUnistyles()`, which is banned in this codebase (see docs/unistyles.md). this PR uses the existing `StyleSheet.create((theme) => ...)` placeholder pattern instead, so it stays off the hook and matches how non-sheet inputs are already themed.

thanks to @chyendongnhanh338 for the report and the correct diagnosis in #1536, and to the others who confirmed it.

### verification

- full-workspace `npm run typecheck` clean (pre-commit hook)
- `npm run lint` clean, `npm run format` (oxfmt)
- existing `providers-section.test.tsx` green

i can't run on-device android QA from here. the crash is a deterministic react context error, so removing the `useBottomSheetInternal()` dependency removes the throw by construction; types and the reasoning above cover the rest.

Closes #1504