### PR TITLE
[codex] Reduce Pi provider startup probes

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -671,6 +671,44 @@ describe("PiRpcAgentSession", () => {
 });
 
 describe("PiRpcAgentClient", () => {
+  test("reuses the availability model probe when listing models", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+    pi.queueModels([
+      { provider: "openrouter", id: "anthropic/claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
+    ]);
+
+    await expect(client.isAvailable()).resolves.toBe(true);
+    await expect(
+      client.listModels({ cwd: "/tmp/paseo-pi-workspace", force: false }),
+    ).resolves.toEqual([
+      {
+        provider: "pi",
+        id: "openrouter/anthropic/claude-sonnet-4.5",
+        label: "Claude Sonnet 4.5",
+        description: "openrouter/anthropic/claude-sonnet-4.5",
+        metadata: {
+          provider: "openrouter",
+          modelId: "anthropic/claude-sonnet-4.5",
+        },
+        thinkingOptions: undefined,
+        defaultThinkingOptionId: undefined,
+      },
+    ]);
+
+    expect(pi.recordedLaunches).toHaveLength(1);
+    expect(pi.latestSession().closed).toBe(true);
+  });
+
+  test("lists no draft features without starting a Pi session", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+
+    await expect(client.listFeatures(createConfig())).resolves.toEqual([]);
+
+    expect(pi.recordedLaunches).toHaveLength(0);
+  });
+
   test("lists JSONL persisted sessions from configured provider params", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "paseo-pi-sessions-"));
     const cwd = path.join(root, "workspace");

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import {
   type AgentCapabilityFlags,
   type AgentClient,
+  type AgentFeature,
   type AgentLaunchContext,
   type AgentMetadata,
   type AgentMode,
@@ -1860,6 +1861,7 @@ export class PiRpcAgentClient implements AgentClient {
   private readonly runtimeSettings?: ProviderRuntimeSettings;
   private readonly providerParams: PiProviderParams;
   private readonly runtime: PiRuntime;
+  private availableModelsCache: Promise<AgentModelDefinition[]> | null = null;
 
   constructor(options: PiRpcAgentClientOptions) {
     this.logger = options.logger;
@@ -1961,15 +1963,14 @@ export class PiRpcAgentClient implements AgentClient {
   }
 
   async listModels(options: ListModelsOptions): Promise<AgentModelDefinition[]> {
-    const runtimeSession = await this.runtime.startSession({ cwd: options.cwd });
-    try {
-      return transformPiModels((await runtimeSession.getAvailableModels()).map(mapPiModel));
-    } finally {
-      await runtimeSession.close();
-    }
+    return await this.getAvailableModels(options.cwd, { force: options.force });
   }
 
   async listModes(_options: ListModesOptions): Promise<AgentMode[]> {
+    return [];
+  }
+
+  async listFeatures(_config: AgentSessionConfig): Promise<AgentFeature[]> {
     return [];
   }
 
@@ -2000,16 +2001,35 @@ export class PiRpcAgentClient implements AgentClient {
     if (!availability.available) {
       return false;
     }
-    const runtimeSession = await this.runtime.startSession({ cwd: homedir() }).catch(() => null);
-    if (!runtimeSession) {
-      return false;
-    }
     try {
-      return (await runtimeSession.getAvailableModels()).length > 0;
+      return (await this.getAvailableModels(homedir(), { force: false })).length > 0;
     } catch {
       return false;
+    }
+  }
+
+  private async getAvailableModels(
+    cwd: string,
+    options: { force: boolean },
+  ): Promise<AgentModelDefinition[]> {
+    if (!this.availableModelsCache || options.force) {
+      const cache = this.fetchAvailableModels(cwd).catch((error) => {
+        if (this.availableModelsCache === cache) {
+          this.availableModelsCache = null;
+        }
+        throw error;
+      });
+      this.availableModelsCache = cache;
+    }
+    return await this.availableModelsCache;
+  }
+
+  private async fetchAvailableModels(cwd: string): Promise<AgentModelDefinition[]> {
+    const runtimeSession = await this.runtime.startSession({ cwd });
+    try {
+      return transformPiModels((await runtimeSession.getAvailableModels()).map(mapPiModel));
     } finally {
-      await runtimeSession.close().catch(() => undefined);
+      await runtimeSession.close();
     }
   }
 

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -19,6 +19,7 @@ export class FakePi implements PiRuntime {
   private readonly sessions: FakePiSession[] = [];
   private readonly command: [string, ...string[]];
   private readonly queuedCommands: PiRpcSlashCommand[][] = [];
+  private readonly queuedModels: PiModel[][] = [];
 
   constructor(command: [string, ...string[]] = ["pi"]) {
     this.command = command;
@@ -32,12 +33,17 @@ export class FakePi implements PiRuntime {
     this.recordedLaunches.push(launch);
     const session = new FakePiSession(launch);
     session.commands = this.queuedCommands.shift() ?? [];
+    session.models = this.queuedModels.shift() ?? [];
     this.sessions.push(session);
     return session;
   }
 
   queueCommands(commands: PiRpcSlashCommand[]): void {
     this.queuedCommands.push(commands);
+  }
+
+  queueModels(models: PiModel[]): void {
+    this.queuedModels.push(models);
   }
 
   latestSession(): FakePiSession {
@@ -73,6 +79,7 @@ export class FakePiSession implements PiRuntimeSession {
   commands: PiRpcSlashCommand[] = [];
   compactError: Error | null = null;
   emitCompactEnd = true;
+  closed = false;
   state: PiSessionState;
 
   private readonly subscribers = new Set<(event: PiRuntimeEvent) => void>();
@@ -174,7 +181,9 @@ export class FakePiSession implements PiRuntimeSession {
     this.respondToExtensionUiRequest(id, { cancelled: true });
   }
 
-  async close(): Promise<void> {}
+  async close(): Promise<void> {
+    this.closed = true;
+  }
 
   emit(event: PiRuntimeEvent): void {
     for (const subscriber of this.subscribers) {

--- a/packages/server/src/server/agent/structured-generation-providers.test.ts
+++ b/packages/server/src/server/agent/structured-generation-providers.test.ts
@@ -106,6 +106,47 @@ describe("resolveStructuredGenerationProviders", () => {
     ]);
   });
 
+  test("skips disabled providers when resolving dynamic defaults", async () => {
+    const providers = await resolveStructuredGenerationProviders({
+      cwd: "/tmp/repo",
+      providerSnapshotManager: {
+        listProviders: vi.fn(async () => [
+          {
+            provider: "opencode",
+            status: READY,
+            enabled: false,
+            models: [
+              {
+                provider: "opencode",
+                id: "anthropic/claude-haiku-4-5",
+                label: "Claude Haiku 4.5",
+              },
+              {
+                provider: "opencode",
+                id: "openai/gpt-5.4-mini",
+                label: "GPT 5.4 Mini",
+              },
+            ],
+          },
+          {
+            provider: "nvidia",
+            status: READY,
+            enabled: true,
+            models: [
+              {
+                provider: "nvidia",
+                id: "nvidia/nemotron-3-super-120b-a12b",
+                label: "Nemotron 3 Super",
+              },
+            ],
+          },
+        ]),
+      },
+    });
+
+    expect(providers).toEqual([{ provider: "nvidia", model: "nvidia/nemotron-3-super-120b-a12b" }]);
+  });
+
   test("resolves a provider-only current selection to that provider's default model", async () => {
     const providers = await resolveStructuredGenerationProviders({
       cwd: "/tmp/repo",


### PR DESCRIPTION
## Summary
- cache Pi available-model probes so availability checks and model listing can share one short-lived Pi session
- add Pi listFeatures() so draft feature listing no longer creates a throwaway agent session
- cover disabled structured-generation providers so default metadata generation candidates skip disabled provider snapshots

## Root cause
Opening a new Pi agent could start Pi repeatedly while resolving provider availability, draft features, and then the actual agent session. Pi did not implement listFeatures(), so AgentManager fell back to creating a full session just to read session.features. The Pi availability probe also fetched models without sharing that result with listModels().

## Validation
- npx vitest run packages/server/src/server/agent/providers/pi/agent.test.ts --bail=1
- npx vitest run packages/server/src/server/agent/structured-generation-providers.test.ts --bail=1
- npm run format
- npm run lint
- npm run typecheck

Fixes #1541