### PR TITLE
fix(app): keep desktop file attachment extensions dotted

### DIFF
--- a/packages/app/src/hooks/use-file-picker.test.ts
+++ b/packages/app/src/hooks/use-file-picker.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  pickFilesWithDesktopDialog,
+  readDesktopFileBytes,
+  type DesktopFilePickerDependencies,
+  type DesktopFileReaderDependencies,
+} from "./use-file-picker";
+import type { DesktopDialogOpenOptions } from "@/desktop/host";
+
+interface CopiedAttachmentFile {
+  attachmentId: string;
+  sourcePath: string;
+  extension?: string | null;
+}
+
+class FakeDesktopFileReaderDependencies implements DesktopFileReaderDependencies {
+  readonly copiedFiles: CopiedAttachmentFile[] = [];
+  readonly reads: string[] = [];
+  private nextId = 1;
+  private readonly files = new Map<string, string>();
+
+  async copyAttachmentFile(input: CopiedAttachmentFile): Promise<{ path: string; byteSize: number }> {
+    this.copiedFiles.push(input);
+    const managedPath = `/managed/${input.attachmentId}${input.extension ?? ".bin"}`;
+    return { path: managedPath, byteSize: this.files.get(managedPath)?.length ?? 0 };
+  }
+
+  async readFileBase64(path: string): Promise<string> {
+    this.reads.push(path);
+    const base64 = this.files.get(path);
+    if (base64 === undefined) {
+      throw new Error(`FakeDesktopFileReaderDependencies: no file registered for ${path}`);
+    }
+    return base64;
+  }
+
+  createAttachmentId(): string {
+    return `attachment-${this.nextId++}`;
+  }
+
+  registerManagedFile(path: string, base64: string): void {
+    this.files.set(path, base64);
+  }
+}
+
+class FakeDesktopFilePickerDependencies
+  extends FakeDesktopFileReaderDependencies
+  implements DesktopFilePickerDependencies
+{
+  readonly dialogOpenOptions: DesktopDialogOpenOptions[] = [];
+  dialogSelection: string | string[] | null = null;
+
+  async openDialog(options: DesktopDialogOpenOptions): Promise<string | string[] | null> {
+    this.dialogOpenOptions.push(options);
+    return this.dialogSelection;
+  }
+}
+
+describe("use-file-picker", () => {
+  it.each([
+    ["/tmp/archive.zip", ".zip"],
+    ["/tmp/report.pdf", ".pdf"],
+    ["/tmp/data.csv", ".csv"],
+  ])("passes dotted file extension %s to desktop managed storage", async (sourcePath, extension) => {
+    const desktop = new FakeDesktopFileReaderDependencies();
+    desktop.registerManagedFile(`/managed/attachment-1${extension}`, "AQID");
+
+    const bytes = await readDesktopFileBytes(sourcePath, desktop);
+
+    expect(desktop.copiedFiles).toEqual([
+      {
+        attachmentId: "attachment-1",
+        sourcePath,
+        extension,
+      },
+    ]);
+    expect(desktop.reads).toEqual([`/managed/attachment-1${extension}`]);
+    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+  });
+
+  it("passes dotted file extensions for files selected with the desktop dialog", async () => {
+    const desktop = new FakeDesktopFilePickerDependencies();
+    desktop.dialogSelection = ["/tmp/archive.zip", "/tmp/report.pdf"];
+    desktop.registerManagedFile("/managed/attachment-1.zip", "AQID");
+    desktop.registerManagedFile("/managed/attachment-2.pdf", "BAUG");
+
+    const files = await pickFilesWithDesktopDialog(desktop);
+
+    expect(desktop.dialogOpenOptions).toEqual([{ directory: false, multiple: true }]);
+    expect(desktop.copiedFiles).toEqual([
+      {
+        attachmentId: "attachment-1",
+        sourcePath: "/tmp/archive.zip",
+        extension: ".zip",
+      },
+      {
+        attachmentId: "attachment-2",
+        sourcePath: "/tmp/report.pdf",
+        extension: ".pdf",
+      },
+    ]);
+    expect(desktop.reads).toEqual(["/managed/attachment-1.zip", "/managed/attachment-2.pdf"]);
+    expect(files).toEqual([
+      {
+        fileName: "archive.zip",
+        mimeType: "application/zip",
+        bytes: new Uint8Array([1, 2, 3]),
+      },
+      {
+        fileName: "report.pdf",
+        mimeType: "application/pdf",
+        bytes: new Uint8Array([4, 5, 6]),
+      },
+    ]);
+  });
+});

--- a/packages/app/src/hooks/use-file-picker.ts
+++ b/packages/app/src/hooks/use-file-picker.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from "react";
 import * as DocumentPicker from "expo-document-picker";
 import { File } from "expo-file-system";
-import { getDesktopHost, isElectronRuntime } from "@/desktop/host";
+import { getDesktopHost, isElectronRuntime, type DesktopDialogOpenOptions } from "@/desktop/host";
 import { copyDesktopAttachmentFile } from "@/desktop/attachments/desktop-file-commands";
 import { readDesktopFileBase64 } from "@/desktop/attachments/desktop-preview-url";
 import { isWeb } from "@/constants/platform";
@@ -13,6 +13,34 @@ export interface PickedFile {
   bytes: Uint8Array;
 }
 
+export interface DesktopFileReaderDependencies {
+  copyAttachmentFile(input: {
+    attachmentId: string;
+    sourcePath: string;
+    extension?: string | null;
+  }): Promise<{ path: string; byteSize: number }>;
+  readFileBase64(path: string): Promise<string>;
+  createAttachmentId(): string;
+}
+
+export interface DesktopFilePickerDependencies extends DesktopFileReaderDependencies {
+  openDialog(options: DesktopDialogOpenOptions): Promise<string | string[] | null>;
+}
+
+const defaultDesktopFilePickerDependencies: DesktopFilePickerDependencies = {
+  copyAttachmentFile: copyDesktopAttachmentFile,
+  readFileBase64: readDesktopFileBase64,
+  createAttachmentId: () => crypto.randomUUID(),
+  async openDialog(options) {
+    const dialogOpen = getDesktopHost()?.dialog?.open;
+    if (typeof dialogOpen !== "function") {
+      throw new Error("Desktop dialog API is not available.");
+    }
+
+    return await dialogOpen(options);
+  },
+};
+
 function base64ToUint8Array(base64: string): Uint8Array {
   const binaryString = atob(base64);
   const bytes = new Uint8Array(binaryString.length);
@@ -22,24 +50,23 @@ function base64ToUint8Array(base64: string): Uint8Array {
   return bytes;
 }
 
-export async function readDesktopFileBytes(path: string): Promise<Uint8Array> {
-  const { path: managedPath } = await copyDesktopAttachmentFile({
-    attachmentId: crypto.randomUUID(),
+export async function readDesktopFileBytes(
+  path: string,
+  dependencies: DesktopFileReaderDependencies = defaultDesktopFilePickerDependencies,
+): Promise<Uint8Array> {
+  const { path: managedPath } = await dependencies.copyAttachmentFile({
+    attachmentId: dependencies.createAttachmentId(),
     sourcePath: path,
-    extension: getFileExtension(path).slice(1) || null,
+    extension: getFileExtension(path) || null,
   });
-  const base64 = await readDesktopFileBase64(managedPath);
+  const base64 = await dependencies.readFileBase64(managedPath);
   return base64ToUint8Array(base64);
 }
 
-async function pickFilesWithDesktopDialog(): Promise<PickedFile[] | null> {
-  const dialog = getDesktopHost()?.dialog;
-  const dialogOpen = dialog?.open;
-  if (typeof dialogOpen !== "function") {
-    throw new Error("Desktop dialog API is not available.");
-  }
-
-  const selection = await dialogOpen({
+export async function pickFilesWithDesktopDialog(
+  dependencies: DesktopFilePickerDependencies = defaultDesktopFilePickerDependencies,
+): Promise<PickedFile[] | null> {
+  const selection = await dependencies.openDialog({
     directory: false,
     multiple: true,
   });
@@ -60,13 +87,13 @@ async function pickFilesWithDesktopDialog(): Promise<PickedFile[] | null> {
     const mimeType = getMimeTypeFromPath(filePath);
 
     // Copy into managed storage so we can read it through the existing secure IPC.
-    const { path: managedPath } = await copyDesktopAttachmentFile({
-      attachmentId: crypto.randomUUID(),
+    const { path: managedPath } = await dependencies.copyAttachmentFile({
+      attachmentId: dependencies.createAttachmentId(),
       sourcePath: filePath,
-      extension: getFileExtension(filePath).slice(1) || null,
+      extension: getFileExtension(filePath) || null,
     });
 
-    const base64 = await readDesktopFileBase64(managedPath);
+    const base64 = await dependencies.readFileBase64(managedPath);
     const bytes = base64ToUint8Array(base64);
 
     result.push({ fileName, mimeType, bytes });


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
-->

### Linked issue

Closes #1547

<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

<!-- A short description of the change in your own words. What was wrong, what you changed, why it works. If you can't explain this briefly, the PR is probably too big. -->

Desktop generic file uploads were stripping the leading dot from file extensions before copying files into Electron-managed attachment storage.

The desktop IPC validation expects dotted extensions such as `.zip`, `.pdf`, or `.csv`, but the app was passing values such as `zip`, `pdf`, or `csv`. That caused uploads for files with extensions to fail with errors like:

`Invalid attachment extension: zip`

This change preserves the dotted extension returned by `getFileExtension()` before calling `copyDesktopAttachmentFile()`. It applies to both direct desktop file reads and the desktop file picker path, including drag/drop flows that reuse `readDesktopFileBytes()`.

`getFileExtension()` already returns the final filename suffix with the leading dot, for example `.zip` or `.gz`. The desktop managed-storage IPC expects that same dotted form, so this change passes the value through directly instead of stripping the dot with `.slice(1)`.

### How did you verify it

<!--
This is the section I read most carefully. I need to see that *you* tested this, not that the diff looks plausible.

- For UI changes: a screenshot or short video on every affected platform (mobile, web, desktop). UI claims without visual proof are not enough.
- For behavior changes: the actual steps you ran, and what you observed.
- For bug fixes: how you reproduced the bug before, and confirmed it's fixed after.

AI-generated PR descriptions are fine in principle. AI-generated *verification claims* with no actual testing behind them are not, and they're easy to spot.
-->


- [Built an app package from this patched branch.](https://github.com/ovlerfork/paseo/actions/runs/27524869831)
- Installed that build locally.
- Reproduced the affected desktop file-upload flow with a `.zip` file.
- Confirmed the upload now succeeds; the previous `Invalid attachment extension: zip` failure no longer occurs.
- Added automated coverage for preserving dotted extensions across `.zip`, `.pdf`, and `.csv`.


### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
