### PR TITLE
feat(cli): add agent unarchive command (fixes #957)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -22,6 +22,7 @@ import { addSendOptions, runSendCommand } from "./commands/agent/send.js";
 import { addInspectOptions, runInspectCommand } from "./commands/agent/inspect.js";
 import { addWaitOptions, runWaitCommand } from "./commands/agent/wait.js";
 import { addArchiveOptions, runArchiveCommand } from "./commands/agent/archive.js";
+import { addUnarchiveOptions, runUnarchiveCommand } from "./commands/agent/unarchive.js";
 import { addAttachOptions, runAttachCommand } from "./commands/agent/attach.js";
 import { addImportOptions, runImportCommand } from "./commands/agent/import.js";
 import { withOutput } from "./output/index.js";
@@ -92,6 +93,10 @@ export function createCli(): Command {
 
   addJsonAndDaemonHostOptions(addArchiveOptions(program.command("archive"))).action(
     withOutput(runArchiveCommand),
+  );
+
+  addJsonAndDaemonHostOptions(addUnarchiveOptions(program.command("unarchive"))).action(
+    withOutput(runUnarchiveCommand),
   );
 
   // Top-level local daemon shortcuts

--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { runModeCommand } from "./mode.js";
 import { addArchiveOptions, runArchiveCommand } from "./archive.js";
+import { addUnarchiveOptions, runUnarchiveCommand } from "./unarchive.js";
 import { addDeleteOptions, runDeleteCommand } from "./delete.js";
 import { addLsOptions, runLsCommand } from "./ls.js";
 import { addRunOptions, runRunCommand } from "./run.js";
@@ -70,6 +71,10 @@ export function createAgentCommand(): Command {
 
   addJsonAndDaemonHostOptions(addArchiveOptions(agent.command("archive"))).action(
     withOutput(runArchiveCommand),
+  );
+
+  addJsonAndDaemonHostOptions(addUnarchiveOptions(agent.command("unarchive"))).action(
+    withOutput(runUnarchiveCommand),
   );
 
   addJsonAndDaemonHostOptions(addReloadOptions(agent.command("reload"))).action(

--- a/packages/cli/src/commands/agent/unarchive.ts
+++ b/packages/cli/src/commands/agent/unarchive.ts
@@ -1,0 +1,129 @@
+import { Command } from "commander";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import { connectToDaemon, getDaemonHost, resolveAgentId } from "../../utils/client.js";
+import type {
+  CommandOptions,
+  SingleResult,
+  OutputSchema,
+  CommandError,
+} from "../../output/index.js";
+
+/** Result type for agent unarchive command */
+export interface AgentUnarchiveResult {
+  agentId: string;
+  status: "unarchived";
+  unarchivedAt: string;
+}
+
+/** Schema for unarchive command output */
+export const unarchiveSchema: OutputSchema<AgentUnarchiveResult> = {
+  idField: "agentId",
+  columns: [
+    { header: "AGENT ID", field: "agentId" },
+    { header: "STATUS", field: "status" },
+    { header: "UNARCHIVED AT", field: "unarchivedAt" },
+  ],
+};
+
+export function addUnarchiveOptions(cmd: Command): Command {
+  return cmd
+    .description("Unarchive an agent (reverse soft-delete)")
+    .argument("<id>", "Agent ID, prefix, or name");
+}
+
+export interface AgentUnarchiveOptions extends CommandOptions {
+  host?: string;
+}
+
+export type AgentUnarchiveCommandResult = SingleResult<AgentUnarchiveResult>;
+
+export async function runUnarchiveCommand(
+  agentIdArg: string,
+  options: AgentUnarchiveOptions,
+  _command: Command,
+): Promise<AgentUnarchiveCommandResult> {
+  const host = getDaemonHost({ host: options.host });
+
+  // Validate arguments
+  if (!agentIdArg || agentIdArg.trim().length === 0) {
+    const error: CommandError = {
+      code: "MISSING_AGENT_ID",
+      message: "Agent ID is required",
+      details: "Usage: paseo agent unarchive <id-or-name>",
+    };
+    throw error;
+  }
+
+  let client: DaemonClient;
+  try {
+    client = await connectToDaemon({ host: options.host });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const error: CommandError = {
+      code: "DAEMON_NOT_RUNNING",
+      message: `Cannot connect to daemon at ${host}: ${message}`,
+      details: "Start the daemon with: paseo daemon start",
+    };
+    throw error;
+  }
+
+  try {
+    const agentsPayload = await client.fetchAgents({ filter: { includeArchived: true } });
+    const agents = agentsPayload.entries.map((entry) => entry.agent);
+    const agentId = resolveAgentId(agentIdArg, agents);
+    if (!agentId) {
+      const error: CommandError = {
+        code: "AGENT_NOT_FOUND",
+        message: `Agent not found: ${agentIdArg}`,
+        details: 'Use "paseo ls" to list available agents',
+      };
+      throw error;
+    }
+    const agent = agents.find((entry) => entry.id === agentId);
+    if (!agent) {
+      throw new Error(`Resolved agent missing from fetched agents: ${agentId}`);
+    }
+
+    // Check if agent is not archived
+    if (!agent.archivedAt) {
+      const error: CommandError = {
+        code: "AGENT_NOT_ARCHIVED",
+        message: `Agent ${agentId.slice(0, 7)} is not archived`,
+        details:
+          "Archived agents can be listed with: paseo ls --archived. Use paseo agent archive to archive an agent first.",
+      };
+      throw error;
+    }
+
+    // Unarchive the agent via refresh (which clears the archived flag)
+    await client.refreshAgent(agentId);
+
+    const unarchivedAt = new Date().toISOString();
+
+    await client.close();
+
+    return {
+      type: "single",
+      data: {
+        agentId,
+        status: "unarchived",
+        unarchivedAt,
+      },
+      schema: unarchiveSchema,
+    };
+  } catch (err) {
+    await client.close().catch(() => {});
+
+    // Re-throw CommandError as-is
+    if (err && typeof err === "object" && "code" in err) {
+      throw err;
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    const error: CommandError = {
+      code: "UNARCHIVE_FAILED",
+      message: `Failed to unarchive agent: ${message}`,
+    };
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Add `paseo agent unarchive <id>` and `paseo unarchive <id>` as the inverse of the existing `archive` command. Today the only way to unarchive an agent is from the app — this adds CLI symmetry.

## What changed

- **New file**: `packages/cli/src/commands/agent/unarchive.ts` — unarchive command implementation
- **Registered** as `agent unarchive` subcommand in `agent/index.ts`
- **Registered** as top-level `unarchive` command in `cli.ts`

## Implementation

- Uses the same `refresh_agent_request` RPC that the app&apos;s Unarchive button calls
- Follows the same pattern as the existing `archive` command (error handling, daemon connection, agent resolution)
- Reports a clear `AGENT_NOT_ARCHIVED` error when the agent is not archived
- Includes archived agents in the lookup (via `includeArchived: true`) so archived agents can be found

## Testing

- [x] Format check passes (`npm run format`)
- [x] Lint passes with 0 warnings/errors (`npm run lint`)
- [x] All type errors are pre-existing (unrelated to this change)

## Related

Closes #957