### PR TITLE
Include child results in finish notifications

### DIFF
--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -156,7 +156,7 @@ test("finish notifications tell the parent the child's last assistant message", 
 
   expect(parentPrompt).toEqual(
     formatSystemNotificationPrompt(
-      "Agent child-agent (Child Agent) finished.\n\nLast assistant message:\nImplemented the cleanup and all checks pass.",
+      "Agent child-agent (Child Agent) finished.\n\n<agent-response>\nImplemented the cleanup and all checks pass.\n</agent-response>",
     ),
   );
 });

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -11,6 +11,97 @@ import {
 } from "./agent-prompt.js";
 import type { AgentManagerEvent, ManagedAgent } from "./agent-manager.js";
 
+interface FinishNotificationScenarioOptions {
+  childLastAssistantMessage?: string | null;
+}
+
+interface FinishNotificationScenario {
+  startWatchingChild(): void;
+  finishChildAndReadParentPrompt(): Promise<string>;
+}
+
+function createFinishNotificationScenario(
+  options?: FinishNotificationScenarioOptions,
+): FinishNotificationScenario {
+  let subscriber: ((event: AgentManagerEvent) => void) | null = null;
+  let resolveParentPrompt: ((prompt: string) => void) | null = null;
+
+  const childAgent: ManagedAgent = Object.create(null);
+  Reflect.set(childAgent, "id", "child-agent");
+  Reflect.set(childAgent, "lifecycle", "idle");
+  Reflect.set(childAgent, "config", { title: "Child Agent" });
+
+  const callerAgent: ManagedAgent = Object.create(null);
+  Reflect.set(callerAgent, "id", "caller-agent");
+  Reflect.set(callerAgent, "lifecycle", "idle");
+  Reflect.set(callerAgent, "config", { title: "Caller Agent" });
+
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(agentManager, "getAgent", (agentId: string) => {
+    if (agentId === "child-agent") {
+      return childAgent;
+    }
+    if (agentId === "caller-agent") {
+      return callerAgent;
+    }
+    return null;
+  });
+  Reflect.set(agentManager, "subscribe", (callback: (event: AgentManagerEvent) => void) => {
+    subscriber = callback;
+    return () => {
+      subscriber = null;
+    };
+  });
+  Reflect.set(agentManager, "getLastAssistantMessage", async () => {
+    return options?.childLastAssistantMessage ?? null;
+  });
+  Reflect.set(agentManager, "tryRunOutOfBand", () => false);
+  Reflect.set(agentManager, "hasInFlightRun", () => false);
+  Reflect.set(agentManager, "streamAgent", (_agentId: string, prompt: string) => {
+    resolveParentPrompt?.(prompt);
+    return (async function* noop() {})();
+  });
+
+  const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
+  Reflect.set(agentStorage, "get", async (agentId: string) => {
+    if (agentId === "child-agent") {
+      return { title: "Child Agent" };
+    }
+    return null;
+  });
+
+  return {
+    startWatchingChild() {
+      setupFinishNotification({
+        agentManager,
+        agentStorage,
+        childAgentId: "child-agent",
+        callerAgentId: "caller-agent",
+        logger: createTestLogger(),
+      });
+    },
+    async finishChildAndReadParentPrompt() {
+      const parentPrompt = new Promise<string>((resolve) => {
+        resolveParentPrompt = resolve;
+      });
+
+      childAgent.lifecycle = "running";
+      subscriber?.({
+        type: "agent_state",
+        agent: childAgent,
+      });
+
+      childAgent.lifecycle = "idle";
+      subscriber?.({
+        type: "agent_state",
+        agent: childAgent,
+      });
+
+      return parentPrompt;
+    },
+  };
+}
+
 test("isSystemInjectedEnvelope matches the envelope formatSystemNotificationPrompt produces", () => {
   expect(isSystemInjectedEnvelope(formatSystemNotificationPrompt("child finished"))).toBe(true);
   expect(isSystemInjectedEnvelope("hello world")).toBe(false);
@@ -53,6 +144,21 @@ test("sendPromptToAgent forwards the client message id as run options", async ()
     outputSchema: { type: "object" },
     messageId: "msg-client-1",
   });
+});
+
+test("finish notifications tell the parent the child's last assistant message", async () => {
+  const scenario = createFinishNotificationScenario({
+    childLastAssistantMessage: "Implemented the cleanup and all checks pass.",
+  });
+
+  scenario.startWatchingChild();
+  const parentPrompt = await scenario.finishChildAndReadParentPrompt();
+
+  expect(parentPrompt).toEqual(
+    formatSystemNotificationPrompt(
+      "Agent child-agent (Child Agent) finished.\n\nLast assistant message:\nImplemented the cleanup and all checks pass.",
+    ),
+  );
 });
 
 it("does not notify archived callers", async () => {

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -252,6 +252,22 @@ export interface SetupFinishNotificationParams {
   logger: Logger;
 }
 
+interface FinishNotificationBodyInput {
+  childAgentId: string;
+  title: string;
+  reason: "finished" | "errored" | "needs permission";
+  lastAssistantMessage: string | null;
+}
+
+function formatFinishNotificationBody(params: FinishNotificationBodyInput): string {
+  const statusLine = `Agent ${params.childAgentId} (${params.title}) ${params.reason}.`;
+  const lastAssistantMessage = params.lastAssistantMessage?.trim();
+  if (!lastAssistantMessage) {
+    return statusLine;
+  }
+  return `${statusLine}\n\nLast assistant message:\n${lastAssistantMessage}`;
+}
+
 export function setupFinishNotification(params: SetupFinishNotificationParams): void {
   const { agentManager, agentStorage, childAgentId, callerAgentId, logger } = params;
   let hasSeenRunning = false;
@@ -265,9 +281,20 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
     fired = true;
     unsubscribe?.();
 
+    const callerRecord = await agentStorage.get(callerAgentId);
+    if (callerRecord?.archivedAt) {
+      return;
+    }
+
     const record = await agentStorage.get(childAgentId);
     const title = record?.title ?? childAgentId;
-    const body = `Agent ${childAgentId} (${title}) ${reason}.`;
+    const lastAssistantMessage = await agentManager.getLastAssistantMessage(childAgentId);
+    const body = formatFinishNotificationBody({
+      childAgentId,
+      title,
+      reason,
+      lastAssistantMessage,
+    });
 
     await sendPromptToAgent({
       agentManager,

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -265,7 +265,7 @@ function formatFinishNotificationBody(params: FinishNotificationBodyInput): stri
   if (!lastAssistantMessage) {
     return statusLine;
   }
-  return `${statusLine}\n\nLast assistant message:\n${lastAssistantMessage}`;
+  return `${statusLine}\n\n<agent-response>\n${lastAssistantMessage}\n</agent-response>`;
 }
 
 export function setupFinishNotification(params: SetupFinishNotificationParams): void {


### PR DESCRIPTION
### Linked issue

Not linked.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Parent agents now receive the child agent's latest assistant message in notify-on-finish prompts. The whole notification remains wrapped as `<paseo-system>`, and the child result is nested in `<agent-response>` so the parent can treat it as delegated-agent output rather than a user prompt.

Archived parent agents still stay silent.

### How did you verify it

- Added a red unit test showing a child finish notification omitted the last assistant message.
- Confirmed the test failed for that reason before the fix.
- Ran `npx vitest run packages/server/src/server/agent/agent-prompt.test.ts --bail=1` — 4 tests passed.
- Ran `npm run typecheck` — passed.
- Ran `npm run lint` — passed.
- Ran `npm run format` — passed.

Risk surface: daemon-only MCP notification text. No WebSocket protocol, client UI, or persisted data shape changes.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform — N/A, no UI changes
- [x] Tests added or updated where it made sense
