### PR TITLE
Fix pending permission MCP listing

### DIFF
--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -17,6 +17,7 @@ import type { AgentMode, AgentProvider, ProviderSnapshotEntry } from "./agent-sd
 import { createProviderSnapshotManagerStub } from "../test-utils/session-stubs.js";
 import {
   AgentListItemPayloadSchema,
+  AgentPermissionRequestPayloadSchema,
   AgentSnapshotPayloadSchema,
 } from "@getpaseo/protocol/messages";
 import type { PersistedProjectRecord, PersistedWorkspaceRecord } from "../workspace-registry.js";
@@ -3737,6 +3738,66 @@ describe("agent snapshot MCP serialization", () => {
         `list_agents response failed AgentListItemPayloadSchema: ${JSON.stringify(parsed.error.issues, null, 2)}`,
       );
     }
+  });
+
+  it("emits list_pending_permissions payloads that satisfy the declared output schema", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    spies.agentManager.listAgents.mockReturnValue([
+      createManagedAgent({
+        id: "agent-with-permission",
+        provider: "codex",
+        pendingPermissions: new Map([
+          [
+            "perm-minimal",
+            {
+              id: "perm-minimal",
+              provider: "codex",
+              name: "request_user_input",
+              kind: "question",
+              title: "Need input",
+              input: { prompt: "Pick one" },
+              detail: undefined,
+              metadata: { source: "test" },
+            },
+          ],
+        ]),
+      }),
+    ]);
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      logger,
+      providerSnapshotManager: createClaudeOnlyManager(),
+    });
+    const tool = registeredTool(server, "list_pending_permissions");
+    const response = await tool.handler({});
+
+    const permissions = z
+      .array(
+        z.object({
+          agentId: z.string(),
+          status: z.string(),
+          request: AgentPermissionRequestPayloadSchema,
+        }),
+      )
+      .parse(response.structuredContent.permissions);
+    expect(permissions).toEqual([
+      {
+        agentId: "agent-with-permission",
+        status: "idle",
+        request: {
+          id: "perm-minimal",
+          provider: "codex",
+          name: "request_user_input",
+          kind: "question",
+          title: "Need input",
+          input: { prompt: "Pick one" },
+          metadata: { source: "test" },
+        },
+      },
+    ]);
+    expectOutputSchemaAccepts(tool, response.structuredContent);
   });
 
   it("loads archived agents before reading get_agent_activity", async () => {

--- a/packages/server/src/server/agent/mcp-server.ts
+++ b/packages/server/src/server/agent/mcp-server.ts
@@ -2371,7 +2371,7 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
         return payload.pendingPermissions.map((request) => ({
           agentId: agent.id,
           status: payload.status,
-          request: sanitizePermissionRequest(request) ?? request,
+          request: sanitizePermissionRequest(request),
         }));
       });
 

--- a/packages/server/src/server/agent/mcp-server.ts
+++ b/packages/server/src/server/agent/mcp-server.ts
@@ -2371,7 +2371,7 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
         return payload.pendingPermissions.map((request) => ({
           agentId: agent.id,
           status: payload.status,
-          request,
+          request: sanitizePermissionRequest(request) ?? request,
         }));
       });
 

--- a/packages/server/src/server/agent/mcp-shared.ts
+++ b/packages/server/src/server/agent/mcp-shared.ts
@@ -174,6 +174,9 @@ export function sanitizePermissionRequest(
   if (sanitized.input === undefined) {
     delete sanitized.input;
   }
+  if (sanitized.detail === undefined) {
+    delete sanitized.detail;
+  }
   if (sanitized.suggestions === undefined) {
     delete sanitized.suggestions;
   }

--- a/packages/server/src/server/agent/mcp-shared.ts
+++ b/packages/server/src/server/agent/mcp-shared.ts
@@ -159,6 +159,13 @@ export async function waitForAgentWithTimeout(
 }
 
 export function sanitizePermissionRequest(
+  permission: AgentPermissionRequest,
+): AgentPermissionRequest;
+export function sanitizePermissionRequest(permission: null | undefined): null;
+export function sanitizePermissionRequest(
+  permission: AgentPermissionRequest | null | undefined,
+): AgentPermissionRequest | null;
+export function sanitizePermissionRequest(
   permission: AgentPermissionRequest | null | undefined,
 ): AgentPermissionRequest | null {
   if (!permission) {


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fixes MCP pending-permission responses so absent optional fields are omitted instead of serialized as `null`. This lets `list_pending_permissions` return schema-valid structured content when a permission has no `detail`, `suggestions`, or `actions`.

The fix reuses the existing MCP permission sanitizer and extends it to cover `detail`, then adds a regression test for the listed-permissions tool output.

### How did you verify it

- Reproduced the bug with the new regression test before the fix: `list_pending_permissions` failed schema parsing because optional fields were emitted as `null`.
- `npm run test:unit --workspace=@getpaseo/server -- src/server/agent/mcp-server.test.ts -t "emits list_pending_permissions payloads" --bail=1`
- `npm run test:unit --workspace=@getpaseo/server -- src/server/agent/mcp-server.test.ts --bail=1`
- `npm run format`
- `npm run lint`
- `npm run typecheck --workspace=@getpaseo/server`
- Pre-commit hook also ran targeted lint/format checks and the full workspace `npm run typecheck`.

### Risk surface

MCP structured output shape only. No protocol schema changes, persistence changes, or UI changes.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] No UI changes
- [x] Tests added or updated where it made sense