### PR TITLE
fix(server): prepend node_modules/.bin to PATH for paseo.json commands

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -166,7 +166,12 @@ defaults. The default rotation is `10m` x `3` files everywhere.
 ## paseo.json service scripts
 
 `worktree.setup` and `worktree.teardown` accept either a multiline shell script or an array
-of commands. Both run sequentially.
+of commands. Both run sequentially. All repo-configured commands — setup, teardown, `scripts`
+entries, and `worktree.terminals` — run with `<cwd>/node_modules/.bin` prepended to `PATH`
+(matching the local-bin lookup behavior of `npm run`; ancestor directories are not walked), so
+locally installed CLI tools like `cross-env` resolve no matter how the daemon was started.
+Resolution is guaranteed; shadowing priority is not — a login-shell profile or macOS
+`path_helper` may reorder entries.
 
 ```json
 {

--- a/packages/server/src/server/speech/providers/local/sherpa/sherpa-runtime-env.ts
+++ b/packages/server/src/server/speech/providers/local/sherpa/sherpa-runtime-env.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import path from "node:path";
+import { findEnvKey, prependEnvPath } from "../../../../../utils/env-path.js";
 
 export type SherpaLoaderEnvKey = "LD_LIBRARY_PATH" | "DYLD_LIBRARY_PATH" | "PATH";
 
@@ -39,14 +40,6 @@ export function sherpaLoaderEnvKey(
   return null;
 }
 
-export function prependEnvPath(existing: string | undefined, value: string): string {
-  const parts = (existing ?? "").split(path.delimiter).filter(Boolean);
-  if (parts.includes(value)) {
-    return parts.join(path.delimiter);
-  }
-  return [value, ...parts].join(path.delimiter);
-}
-
 export function resolveSherpaLoaderEnv(
   platform: NodeJS.Platform = process.platform,
   arch: string = process.arch,
@@ -68,21 +61,6 @@ export function resolveSherpaLoaderEnv(
   } catch {
     return null;
   }
-}
-
-/**
- * Find the actual case-sensitive key in a plain object that matches the given
- * key case-insensitively. On Windows, `{...process.env}` produces a plain
- * (case-sensitive) object where PATH is typically stored as `Path`. Using a
- * hardcoded `"PATH"` would miss the existing key and create a duplicate,
- * breaking the child process's PATH.
- */
-function findEnvKey(env: NodeJS.ProcessEnv, key: string): string {
-  const lower = key.toLowerCase();
-  for (const k of Object.keys(env)) {
-    if (k.toLowerCase() === lower) return k;
-  }
-  return key;
 }
 
 export function applySherpaLoaderEnv(

--- a/packages/server/src/server/worktree-bootstrap.test.ts
+++ b/packages/server/src/server/worktree-bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "child_process";
 import { mkdtempSync, realpathSync, rmSync, writeFileSync, mkdirSync } from "fs";
-import { join } from "path";
+import { delimiter, join } from "path";
 import { tmpdir } from "os";
 
 import type { AgentTimelineItem } from "./agent/agent-sdk-types.js";
@@ -236,6 +236,7 @@ describe("runAsyncWorktreeBootstrap", () => {
 
     let readyAt = 0;
     let sendAt = 0;
+    let terminalEnv: Record<string, string> | undefined;
     let outputListener: ((chunk: { data: string }) => void) | null = null;
 
     await runAsyncWorktreeBootstrap({
@@ -248,6 +249,7 @@ describe("runAsyncWorktreeBootstrap", () => {
           return [];
         },
         async createTerminal(options) {
+          terminalEnv = options.env;
           setTimeout(() => {
             readyAt = Date.now();
             outputListener?.({ data: "$ " });
@@ -303,6 +305,15 @@ describe("runAsyncWorktreeBootstrap", () => {
     expect(readyAt).toBeGreaterThan(0);
     expect(sendAt).toBeGreaterThan(0);
     expect(sendAt).toBeGreaterThanOrEqual(readyAt);
+
+    const terminalPathKeys = Object.keys(terminalEnv ?? {}).filter(
+      (key) => key.toUpperCase() === "PATH",
+    );
+    expect(terminalPathKeys).toHaveLength(1);
+    expect(terminalEnv?.[terminalPathKeys[0] ?? ""]?.split(delimiter)[0]).toBe(
+      join(worktreeBootstrap.worktree.worktreePath, "node_modules", ".bin"),
+    );
+    expect(terminalEnv?.PASEO_WORKTREE_PATH).toBe(worktreeBootstrap.worktree.worktreePath);
   });
 
   interface CreateTerminalCall {
@@ -502,7 +513,7 @@ describe("runAsyncWorktreeBootstrap", () => {
     });
   }
 
-  it("spawns plain scripts in persistent shell terminals without env injection or routes", async () => {
+  it("spawns plain scripts in persistent shell terminals without service env or routes", async () => {
     commitPaseoScripts({
       web: {
         command: "npm run dev",
@@ -532,7 +543,13 @@ describe("runAsyncWorktreeBootstrap", () => {
     expect(createTerminalCalls[0]?.cwd).toBe(repoDir);
     expect(createTerminalCalls[0]?.name).toBe("web");
     expect(createTerminalCalls[0]?.title).toBe("web");
-    expect(createTerminalCalls[0]?.env).toBeUndefined();
+    const scriptEnv = createTerminalCalls[0]?.env ?? {};
+    const scriptEnvKeys = Object.keys(scriptEnv);
+    expect(scriptEnvKeys).toHaveLength(1);
+    expect(scriptEnvKeys[0]?.toUpperCase()).toBe("PATH");
+    expect(scriptEnv[scriptEnvKeys[0] ?? ""]?.split(delimiter)[0]).toBe(
+      join(repoDir, "node_modules", ".bin"),
+    );
     expect(terminalRecords[0]?.sentInputs).toEqual(["npm run dev\r"]);
     expect(runtimeStore.get({ workspaceId: repoDir, scriptName: "web" })).toMatchObject({
       type: "script",

--- a/packages/server/src/server/worktree-bootstrap.ts
+++ b/packages/server/src/server/worktree-bootstrap.ts
@@ -17,6 +17,7 @@ import {
   type WorktreeRuntimeEnv,
 } from "../utils/worktree.js";
 import { findFreePort, type ServiceProxySubsystem } from "./service-proxy.js";
+import { repoCommandBinPathOverlay } from "../utils/env-path.js";
 import type { WorkspaceScriptRuntimeStore } from "./workspace-script-runtime-store.js";
 import type { AgentTimelineItem, ToolCallDetail } from "./agent/agent-sdk-types.js";
 import {
@@ -542,7 +543,7 @@ async function runWorktreeTerminalBootstrap(
         const terminal = await terminalManager.createTerminal({
           cwd: options.worktree.worktreePath,
           name: spec.name,
-          env: runtimeEnv,
+          env: { ...runtimeEnv, ...repoCommandBinPathOverlay(options.worktree.worktreePath) },
           workspaceId: options.workspaceId,
         });
         await waitForTerminalBootstrapReadiness(terminal);
@@ -903,7 +904,7 @@ export async function spawnWorkspaceScript(
       repoRoot,
       workspaceId,
       scriptName,
-      env,
+      env: { ...env, ...repoCommandBinPathOverlay(repoRoot) },
     });
 
     runtimeStore.set({

--- a/packages/server/src/utils/env-path.test.ts
+++ b/packages/server/src/utils/env-path.test.ts
@@ -1,0 +1,59 @@
+import { delimiter, join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { findEnvKey, prependEnvPath, repoCommandBinPathOverlay } from "./env-path.js";
+
+describe("prependEnvPath", () => {
+  test("prepends a new entry", () => {
+    expect(prependEnvPath(["/usr/bin", "/bin"].join(delimiter), "/opt/x")).toBe(
+      ["/opt/x", "/usr/bin", "/bin"].join(delimiter),
+    );
+  });
+
+  test("keeps existing order when the entry is already present", () => {
+    const existing = ["/opt/x", "/usr/bin"].join(delimiter);
+    expect(prependEnvPath(existing, "/opt/x")).toBe(existing);
+  });
+
+  test("handles an empty existing value", () => {
+    expect(prependEnvPath(undefined, "/opt/x")).toBe("/opt/x");
+    expect(prependEnvPath("", "/opt/x")).toBe("/opt/x");
+  });
+});
+
+describe("findEnvKey", () => {
+  test("finds the Windows-cased Path key", () => {
+    expect(findEnvKey({ Path: "C:\\Windows" }, "PATH")).toBe("Path");
+  });
+
+  test("falls back to the requested key when absent", () => {
+    expect(findEnvKey({ HOME: "/home/user" }, "PATH")).toBe("PATH");
+  });
+
+  test("prefers an exact key match when multiple casings exist", () => {
+    expect(findEnvKey({ Path: "/b", PATH: "/a" }, "PATH")).toBe("PATH");
+  });
+});
+
+describe("repoCommandBinPathOverlay", () => {
+  const binDir = join("/repo", "node_modules", ".bin");
+
+  test("prepends <cwd>/node_modules/.bin to PATH", () => {
+    const overlay = repoCommandBinPathOverlay("/repo", { PATH: "/usr/bin" });
+    expect(overlay).toEqual({ PATH: [binDir, "/usr/bin"].join(delimiter) });
+  });
+
+  test("reuses the base env's Windows-cased Path key instead of adding a duplicate", () => {
+    const overlay = repoCommandBinPathOverlay("/repo", { Path: "/usr/bin" });
+    expect(overlay).toEqual({ Path: [binDir, "/usr/bin"].join(delimiter) });
+  });
+
+  test("sets PATH when the base env has none", () => {
+    expect(repoCommandBinPathOverlay("/repo", {})).toEqual({ PATH: binDir });
+  });
+
+  test("is idempotent", () => {
+    const once = repoCommandBinPathOverlay("/repo", { PATH: "/usr/bin" });
+    const twice = repoCommandBinPathOverlay("/repo", { PATH: once.PATH });
+    expect(twice).toEqual(once);
+  });
+});

--- a/packages/server/src/utils/env-path.ts
+++ b/packages/server/src/utils/env-path.ts
@@ -1,0 +1,57 @@
+import { delimiter, join } from "node:path";
+
+/**
+ * Prepend a directory to a PATH-style value, deduplicating if already present.
+ */
+export function prependEnvPath(existing: string | undefined, value: string): string {
+  const parts = (existing ?? "").split(delimiter).filter(Boolean);
+  if (parts.includes(value)) {
+    return parts.join(delimiter);
+  }
+  return [value, ...parts].join(delimiter);
+}
+
+/**
+ * Find the actual case-sensitive key in a plain object that matches the given
+ * key case-insensitively. On Windows, `{...process.env}` produces a plain
+ * (case-sensitive) object where PATH is typically stored as `Path`. Using a
+ * hardcoded `"PATH"` would miss the existing key and create a duplicate,
+ * breaking the child process's PATH.
+ *
+ * Exact matches win. The exact check scans `Object.keys` rather than using
+ * the `in` operator, which is itself case-insensitive on Windows's
+ * `process.env` and would defeat the purpose.
+ */
+export function findEnvKey(env: NodeJS.ProcessEnv, key: string): string {
+  const keys = Object.keys(env);
+  if (keys.includes(key)) {
+    return key;
+  }
+  const lower = key.toLowerCase();
+  for (const k of keys) {
+    if (k.toLowerCase() === lower) return k;
+  }
+  return key;
+}
+
+/**
+ * Env overlay that lets commands configured in a repo's paseo.json (worktree
+ * setup/teardown, scripts, worktree terminals) resolve locally installed CLI
+ * tools the way `npm run` does, by prepending `<cwd>/node_modules/.bin` to
+ * PATH. Without this, bare devDependency binaries like `cross-env` only
+ * resolve when the daemon itself happened to be started from an npm script.
+ *
+ * The overlay key mirrors the base env's existing PATH key so merging never
+ * creates a `Path`/`PATH` duplicate on Windows. The bin directory is added
+ * without an existence check: setup envs are built before `npm ci` runs, and
+ * a nonexistent PATH entry is harmless. Deliberately cwd-only — npm-style
+ * ancestor directory collection could pull unrelated outer projects into the
+ * env of a worktree.
+ */
+export function repoCommandBinPathOverlay(
+  cwd: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const key = findEnvKey(baseEnv, "PATH");
+  return { [key]: prependEnvPath(baseEnv[key], join(cwd, "node_modules", ".bin")) };
+}

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -18,6 +18,7 @@ import {
   resolveWorktreeRuntimeEnv,
   type WorktreeSetupCommandProgressEvent,
   runWorktreeSetupCommands,
+  runWorktreeTeardownCommands,
   type CreateWorktreeOptions,
   type WorktreeConfig,
 } from "./worktree";
@@ -34,7 +35,7 @@ import {
   writeFileSync,
   readFileSync,
 } from "fs";
-import { dirname, join } from "path";
+import { delimiter, dirname, join } from "path";
 import { tmpdir } from "os";
 import net from "node:net";
 
@@ -734,6 +735,51 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       expect(progressEvents.some((event) => event.type === "command_started")).toBe(true);
       expect(progressEvents.some((event) => event.type === "output")).toBe(true);
       expect(progressEvents.some((event) => event.type === "command_completed")).toBe(true);
+    });
+
+    it("prepends the worktree's node_modules/.bin to PATH for setup commands", async () => {
+      const paseoConfig = {
+        worktree: {
+          setup: ['printf "%s" "$PATH"'],
+        },
+      };
+      writeFileSync(join(repoDir, "paseo.json"), JSON.stringify(paseoConfig));
+      execFileSync("git", ["add", "paseo.json"], { cwd: repoDir });
+      execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "add path setup"], {
+        cwd: repoDir,
+      });
+
+      const results = await runWorktreeSetupCommands({
+        worktreePath: repoDir,
+        branchName: "main",
+        cleanupOnFailure: false,
+      });
+
+      expect(results).toHaveLength(1);
+      const pathEntries = (results[0]?.stdout ?? "").trim().split(delimiter);
+      expect(pathEntries).toContain(join(repoDir, "node_modules", ".bin"));
+    });
+
+    it("prepends the worktree's node_modules/.bin to PATH for teardown commands", async () => {
+      const paseoConfig = {
+        worktree: {
+          teardown: ['printf "%s" "$PATH"'],
+        },
+      };
+      writeFileSync(join(repoDir, "paseo.json"), JSON.stringify(paseoConfig));
+      execFileSync("git", ["add", "paseo.json"], { cwd: repoDir });
+      execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "add path teardown"], {
+        cwd: repoDir,
+      });
+
+      const results = await runWorktreeTeardownCommands({
+        worktreePath: repoDir,
+        branchName: "main",
+      });
+
+      expect(results).toHaveLength(1);
+      const pathEntries = (results[0]?.stdout ?? "").trim().split(delimiter);
+      expect(pathEntries).toContain(join(repoDir, "node_modules", ".bin"));
     });
 
     it("reuses persisted worktree runtime port across resolutions", async () => {

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -29,6 +29,7 @@ import { runGitCommand } from "./run-git-command.js";
 import { spawnProcess } from "./spawn.js";
 import { resolvePaseoHome } from "../server/paseo-home.js";
 import { createExternalProcessEnv } from "../server/paseo-env.js";
+import { repoCommandBinPathOverlay } from "./env-path.js";
 import { parseGitRevParsePath, resolveGitRevParsePath } from "./git-rev-parse-path.js";
 import { validateBranchSlug } from "@getpaseo/protocol/branch-slug";
 import { expandTilde } from "./path.js";
@@ -606,7 +607,11 @@ export async function runWorktreeSetupCommands(options: {
       branchName: options.branchName,
       ...(options.repoRootPath ? { repoRootPath: options.repoRootPath } : {}),
     }));
-  const setupEnv = createExternalProcessEnv(process.env, runtimeEnv);
+  const setupEnv = createExternalProcessEnv(
+    process.env,
+    runtimeEnv,
+    repoCommandBinPathOverlay(options.worktreePath),
+  );
 
   const results: WorktreeSetupCommandResult[] = [];
   for (const [index, cmd] of setupCommands.entries()) {
@@ -714,17 +719,21 @@ export async function runWorktreeTeardownCommands(options: {
     options.branchName ?? (await resolveBranchNameForWorktreePath(options.worktreePath));
   const worktreePort = readPaseoWorktreeRuntimePort(options.worktreePath);
 
-  const teardownEnv: NodeJS.ProcessEnv = createExternalProcessEnv(process.env, {
-    // Source checkout path is the original git repo root (shared across worktrees), not the
-    // worktree itself. This allows lifecycle scripts to copy or clean resources using paths
-    // from the source checkout.
-    PASEO_SOURCE_CHECKOUT_PATH: repoRootPath,
-    // Backward-compatible alias.
-    PASEO_ROOT_PATH: repoRootPath,
-    PASEO_WORKTREE_PATH: options.worktreePath,
-    PASEO_BRANCH_NAME: branchName,
-    ...(worktreePort !== null ? { PASEO_WORKTREE_PORT: String(worktreePort) } : {}),
-  });
+  const teardownEnv: NodeJS.ProcessEnv = createExternalProcessEnv(
+    process.env,
+    {
+      // Source checkout path is the original git repo root (shared across worktrees), not the
+      // worktree itself. This allows lifecycle scripts to copy or clean resources using paths
+      // from the source checkout.
+      PASEO_SOURCE_CHECKOUT_PATH: repoRootPath,
+      // Backward-compatible alias.
+      PASEO_ROOT_PATH: repoRootPath,
+      PASEO_WORKTREE_PATH: options.worktreePath,
+      PASEO_BRANCH_NAME: branchName,
+      ...(worktreePort !== null ? { PASEO_WORKTREE_PORT: String(worktreePort) } : {}),
+    },
+    repoCommandBinPathOverlay(options.worktreePath),
+  );
 
   const results: WorktreeTeardownCommandResult[] = [];
   for (const cmd of teardownCommands) {

--- a/paseo.json
+++ b/paseo.json
@@ -3,7 +3,7 @@
     "setup": [
       "npm ci",
       "node ./scripts/seed-ios-native-cache.mjs",
-      "cross-env PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_SEED_HOME=\"$PASEO_SOURCE_CHECKOUT_PATH/.dev/paseo-home\" PASEO_HOME=\"$PWD/.dev/paseo-home\" ./scripts/dev-home.sh",
+      "npx cross-env PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_SEED_HOME=\"$PASEO_SOURCE_CHECKOUT_PATH/.dev/paseo-home\" PASEO_HOME=\"$PWD/.dev/paseo-home\" ./scripts/dev-home.sh",
       "npm run build:server",
       "npm run build --workspace=@getpaseo/expo-two-way-audio",
       "cp \"$PASEO_SOURCE_CHECKOUT_PATH/packages/server/.env\" \"$PWD/packages/server/.env\""
@@ -12,19 +12,19 @@
   "scripts": {
     "daemon": {
       "type": "service",
-      "command": "cross-env PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_ROOT=\"$PWD\" PASEO_HOME=\"$PWD/.dev/paseo-home\" PASEO_SKIP_DEV_SERVER_BUILD=1 PASEO_LISTEN=0.0.0.0:$PASEO_PORT ./scripts/dev-daemon.sh"
+      "command": "npx cross-env PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_ROOT=\"$PWD\" PASEO_HOME=\"$PWD/.dev/paseo-home\" PASEO_SKIP_DEV_SERVER_BUILD=1 PASEO_LISTEN=0.0.0.0:$PASEO_PORT ./scripts/dev-daemon.sh"
     },
     "app": {
       "type": "service",
-      "command": "cross-env PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_ROOT=\"$PWD\" PASEO_HOME=\"$PWD/.dev/paseo-home\" PASEO_LISTEN=0.0.0.0:${PASEO_SERVICE_DAEMON_PORT} PASEO_DEV_DAEMON_ENDPOINT=localhost:${PASEO_SERVICE_DAEMON_PORT} EXPO_PORT=$PASEO_PORT ./scripts/dev-app.sh"
+      "command": "npx cross-env PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_ROOT=\"$PWD\" PASEO_HOME=\"$PWD/.dev/paseo-home\" PASEO_LISTEN=0.0.0.0:${PASEO_SERVICE_DAEMON_PORT} PASEO_DEV_DAEMON_ENDPOINT=localhost:${PASEO_SERVICE_DAEMON_PORT} EXPO_PORT=$PASEO_PORT ./scripts/dev-app.sh"
     },
     "desktop": {
       "type": "service",
-      "command": "cross-env PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_ROOT=\"$PWD\" PASEO_HOME=\"$PWD/.dev/paseo-home\" PASEO_LISTEN=0.0.0.0:${PASEO_SERVICE_DAEMON_PORT} PASEO_DEV_DAEMON_ENDPOINT=localhost:${PASEO_SERVICE_DAEMON_PORT} EXPO_PORT=$PASEO_PORT npm run dev --workspace=@getpaseo/desktop"
+      "command": "npx cross-env PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_ROOT=\"$PWD\" PASEO_HOME=\"$PWD/.dev/paseo-home\" PASEO_LISTEN=0.0.0.0:${PASEO_SERVICE_DAEMON_PORT} PASEO_DEV_DAEMON_ENDPOINT=localhost:${PASEO_SERVICE_DAEMON_PORT} EXPO_PORT=$PASEO_PORT npm run dev --workspace=@getpaseo/desktop"
     },
     "ios-simulator": {
       "type": "service",
-      "command": "cross-env PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_ROOT=\"$PWD\" PASEO_HOME=\"$PWD/.dev/paseo-home\" PASEO_LISTEN=0.0.0.0:${PASEO_SERVICE_DAEMON_PORT} PASEO_DEV_DAEMON_ENDPOINT=localhost:${PASEO_SERVICE_DAEMON_PORT} ./scripts/paseo-ios-simulator-service.sh"
+      "command": "npx cross-env PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_ROOT=\"$PWD\" PASEO_HOME=\"$PWD/.dev/paseo-home\" PASEO_LISTEN=0.0.0.0:${PASEO_SERVICE_DAEMON_PORT} PASEO_DEV_DAEMON_ENDPOINT=localhost:${PASEO_SERVICE_DAEMON_PORT} ./scripts/paseo-ios-simulator-service.sh"
     }
   }
 }


### PR DESCRIPTION
Fixes #1577

## Problem

Worktree setup/teardown commands, workspace scripts, and worktree terminals run with the daemon's own environment. Unless the daemon was started from an npm script, PATH has no `node_modules/.bin`, so bare devDependency CLIs like `cross-env` exit 127 on every packaged daemon (desktop app, global npm install, `dist`). Dogfood repro in #1577.

## Fix

`repoCommandBinPathOverlay` prepends `<cwd>/node_modules/.bin` to PATH for commands that originate from a repo's `paseo.json`, matching `npm run` semantics: resolution is guaranteed, shadowing priority is not (login-shell profiles / macOS `path_helper` may reorder entries).

**Contract note:** the overlay covers all four repo-configured command sources — `worktree.setup`, `worktree.teardown`, workspace `scripts` (plain service scripts), and `worktree.terminals`. Folding plain service scripts and worktree terminals into the same overlay is a deliberate, small contract extension so *every* paseo.json-sourced command resolves local bins consistently — not just the lifecycle hooks. Manual terminals and agent processes are deliberately left untouched.

Design decisions:
- **cwd-only** — no npm-style ancestor-directory walk, so an outer project can't leak its bins into a worktree's env.
- **No `existsSync` gate** — setup envs are built before `npm ci` runs; a nonexistent PATH entry is harmless.
- **Windows-safe** — reuses case-insensitive PATH-key handling (extracted from `sherpa-runtime-env`) so `{...process.env}`'s `Path` key never gets a duplicate `PATH`.

Also switches `paseo.json`'s own `cross-env` calls to `npx cross-env` so they keep working on daemons that don't yet have this fix.

## Prior art

#737 does the same `node_modules/.bin` → PATH prepend for the CLI test runner; this is the runtime-side counterpart.

## Testing

- **End-to-end repro** (PATH the only variable): no `node_modules/.bin` → exit 127; prepend `<cwd>/node_modules/.bin` → exit 0.
- **Unit tests** — `env-path.test.ts`, `worktree.posix.test.ts`, `worktree-bootstrap.test.ts`: 69 passed / 1 skipped. Cover overlay logic (dedup, Windows `Path`/`PATH` key) and its wiring into setup/teardown/terminals.
- Changed files typecheck clean; `lint` and `format:check` clean. Full-repo typecheck via CI.
- **Platforms:** verified on Linux. Windows `Path`/`PATH` case handling covered by unit tests, not run on a real Windows host. Not a UI change — no screenshots.
