### PR TITLE
fix(app): reveal workspace-jump numbers only for the active modifier

### DIFF
--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -9,6 +9,7 @@ import {
   type ChordState,
   resolveKeyboardShortcut,
   buildEffectiveBindings,
+  getWorkspaceIndexJumpModifierKey,
 } from "@/keyboard/keyboard-shortcuts";
 import { resolveKeyboardFocusScope } from "@/keyboard/focus-scope";
 import {
@@ -72,6 +73,20 @@ export function useKeyboardShortcuts({
 
     const isDesktopApp = getIsElectronRuntime();
     const isMac = getShortcutOs() === "mac";
+
+    // Only the modifier that actually performs the workspace-index jump on this
+    // runtime should reveal the sidebar number badges (Alt on web, Cmd on
+    // desktop Mac, Ctrl on desktop non-Mac). The store ORs altDown/cmdOrCtrlDown
+    // to drive badge visibility, so we set the flag matching this runtime.
+    const badgeModifierKey = getWorkspaceIndexJumpModifierKey({ isMac, isDesktop: isDesktopApp });
+    const setBadgeModifierDown = (down: boolean) => {
+      const state = useKeyboardShortcutsStore.getState();
+      if (isDesktopApp) {
+        state.setCmdOrCtrlDown(down);
+      } else {
+        state.setAltDown(down);
+      }
+    };
 
     const shouldHandle = () => {
       if (typeof document === "undefined") return false;
@@ -156,11 +171,8 @@ export function useKeyboardShortcuts({
       }
 
       const key = event.key ?? "";
-      if (key === "Alt" && !event.shiftKey) {
-        useKeyboardShortcutsStore.getState().setAltDown(true);
-      }
-      if (isDesktopApp && (key === "Meta" || key === "Control") && !event.shiftKey) {
-        useKeyboardShortcutsStore.getState().setCmdOrCtrlDown(true);
+      if (key === badgeModifierKey && !event.shiftKey) {
+        setBadgeModifierDown(true);
       }
       if (key === "Shift") {
         const state = useKeyboardShortcutsStore.getState();
@@ -231,11 +243,8 @@ export function useKeyboardShortcuts({
 
     const handleKeyUp = (event: KeyboardEvent) => {
       const key = event.key ?? "";
-      if (key === "Alt") {
-        useKeyboardShortcutsStore.getState().setAltDown(false);
-      }
-      if (isDesktopApp && (key === "Meta" || key === "Control")) {
-        useKeyboardShortcutsStore.getState().setCmdOrCtrlDown(false);
+      if (key === badgeModifierKey) {
+        setBadgeModifierDown(false);
       }
     };
 

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -3,6 +3,7 @@ import {
   buildKeyboardShortcutHelpSections,
   buildEffectiveBindings,
   getBindingIdForAction,
+  getWorkspaceIndexJumpModifierKey,
   resolveKeyboardShortcut,
   type ChordState,
   type KeyboardShortcutContext,
@@ -636,5 +637,20 @@ describe("keyboard-shortcut help sections", () => {
     expect(
       getBindingIdForAction("message-input-queue", { isMac: true, isDesktop: true }),
     ).toBeNull();
+  });
+});
+
+describe("getWorkspaceIndexJumpModifierKey", () => {
+  it("uses Alt on web, regardless of OS", () => {
+    expect(getWorkspaceIndexJumpModifierKey({ isMac: true, isDesktop: false })).toBe("Alt");
+    expect(getWorkspaceIndexJumpModifierKey({ isMac: false, isDesktop: false })).toBe("Alt");
+  });
+
+  it("uses Cmd (Meta) on desktop Mac, not Control or Alt", () => {
+    expect(getWorkspaceIndexJumpModifierKey({ isMac: true, isDesktop: true })).toBe("Meta");
+  });
+
+  it("uses Ctrl on desktop non-Mac, not Meta or Alt", () => {
+    expect(getWorkspaceIndexJumpModifierKey({ isMac: false, isDesktop: true })).toBe("Control");
   });
 });

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -1344,6 +1344,21 @@ export function getDefaultKeysForAction(
   return null;
 }
 
+/**
+ * The `KeyboardEvent.key` whose hold reveals the sidebar workspace-jump number
+ * badges. It must match the modifier of the active `workspace.navigate.index`
+ * binding for this runtime, otherwise the badges appear for a modifier that
+ * does not actually jump: Alt on web, Cmd (Meta) on desktop Mac, Ctrl on
+ * desktop non-Mac.
+ */
+export function getWorkspaceIndexJumpModifierKey(platform: {
+  isMac: boolean;
+  isDesktop: boolean;
+}): "Alt" | "Meta" | "Control" {
+  if (!platform.isDesktop) return "Alt";
+  return platform.isMac ? "Meta" : "Control";
+}
+
 export function buildKeyboardShortcutHelpSections(
   input: KeyboardShortcutPlatformContext,
   bindings: readonly ParsedShortcutBinding[] = DEFAULT_BINDINGS,


### PR DESCRIPTION
### Linked issue

Closes #1579

### Type of change

- [x] Bug fix

### What does this PR do

Holding the workspace-jump modifier reveals the numbered jump badges in the sidebar (⌘1–⌘9). On the desktop app those badges also appeared while holding **Option** or **Control**, even though neither performs the jump — only ⌘ does on macOS desktop (Ctrl on non-Mac desktop, Alt on web). So the sidebar advertised a shortcut on modifiers that do nothing.

**Root cause:** the keydown/keyup handler in `use-keyboard-shortcuts.ts` flagged badge visibility for `Alt` on *every* runtime and for *both* `Meta` and `Control` on desktop — broader than the active `workspace.navigate.index` binding (`Cmd+Digit` on Mac desktop, `Ctrl+Digit` on non-Mac desktop, `Alt+Digit` on web). The badge state (`altDown || cmdOrCtrlDown`) therefore lit up for modifiers that don't jump.

**Fix:** gate the badge reveal to the single modifier that performs the jump on the current runtime, via a new pure helper `getWorkspaceIndexJumpModifierKey({ isMac, isDesktop })` — `Alt` on web, `Meta` on desktop Mac, `Control` on desktop non-Mac — co-located with the `workspace.navigate.index` binding table it mirrors. The keydown/keyup handlers now set the badge flag only for that key. No store or rendering changes.

### How did you verify it

**Tested manually on the macOS desktop (Electron) dev build** (isolated dev daemon, not the production one), with an on-screen keyboard overlay so the held modifier is visible:

- Hold **⌘ Cmd** → numbers appear; ⌘+2 switches workspace. ✅
- Hold **⌥ Option** → no numbers (previously appeared). ✅
- Hold **⌃ Control** → no numbers (previously appeared). ✅

<!-- ⬇️ drag the screen recording in right here ⬇️ -->


Web behavior is unchanged (Alt still reveals the numbers and Alt+N jumps); I did not separately record web. iOS/Android are unaffected — the handler early-returns on native (`if (isNative) return`) and on mobile, so there are no badges to misfire there.

- `npm run typecheck` — passes
- `npm run lint` — passes
- `npm run format` — ran (oxfmt/Biome)
- Unit tests added: 3 cases for `getWorkspaceIndexJumpModifierKey` in `keyboard-shortcuts.test.ts` (web / desktop-mac / desktop-non-mac). The file passes (66 tests).

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] Recording on the affected platform (desktop). Web behavior unchanged (not separately recorded); native unaffected.
- [x] Tests added or updated where it made sense
