### PR TITLE
Fix markdown rendering hang on unmatched backticks

### DIFF
--- a/packages/app/src/components/markdown/html-ish.test.ts
+++ b/packages/app/src/components/markdown/html-ish.test.ts
@@ -256,6 +256,12 @@ describe("splitHtmlishMarkdown", () => {
     expect(splitHtmlishMarkdown(source)).toEqual([{ kind: "markdown", text: source }]);
   });
 
+  it("terminates when an unmatched backtick follows a closed inline code span", () => {
+    const source = "Use `<details><summary>Example</summary>Body</details>` before `dangling";
+
+    expect(splitHtmlishMarkdown(source)).toEqual([{ kind: "markdown", text: source }]);
+  });
+
   it("still parses normal details outside code", () => {
     expect(splitHtmlishMarkdown("`code`\n<details><summary>Real</summary>Body</details>")).toEqual([
       { kind: "markdown", text: "`code`\n" },

--- a/packages/app/src/components/markdown/html-ish.ts
+++ b/packages/app/src/components/markdown/html-ish.ts
@@ -651,8 +651,13 @@ function getInlineCodeRanges(
     }
 
     const marker = open[0];
-    const close = findClosingBacktickRun(source, BACKTICK_RUN_RE.lastIndex, marker, fencedRanges);
+    const afterOpen = BACKTICK_RUN_RE.lastIndex;
+    const close = findClosingBacktickRun(source, afterOpen, marker, fencedRanges);
     if (!close) {
+      // Unmatched backtick run — skip past it so the loop doesn't restart from 0.
+      // findClosingBacktickRun exhausts the global regex, which resets lastIndex
+      // to 0 when exec() returns null (ECMAScript §22.2.7.2).
+      BACKTICK_RUN_RE.lastIndex = open.index + marker.length;
       continue;
     }
 

--- a/packages/app/src/components/markdown/html-ish.ts
+++ b/packages/app/src/components/markdown/html-ish.ts
@@ -657,7 +657,7 @@ function getInlineCodeRanges(
       // Unmatched backtick run — skip past it so the loop doesn't restart from 0.
       // findClosingBacktickRun exhausts the global regex, which resets lastIndex
       // to 0 when exec() returns null (ECMAScript §22.2.7.2).
-      BACKTICK_RUN_RE.lastIndex = open.index + marker.length;
+      BACKTICK_RUN_RE.lastIndex = afterOpen;
       continue;
     }
 


### PR DESCRIPTION
### Linked issue

Closes #1584

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fixes a markdown parser hang when a message contains a normal inline code span followed later by a dangling backtick run.

The parser now advances past the unmatched backtick opener after a failed close search, instead of letting the shared global regex reset scanning back to the beginning. The follow-up commit also adds regression coverage for that exact shape.

### How did you verify it

- Added a regression test in `packages/app/src/components/markdown/html-ish.test.ts` for a closed inline code span followed by an unmatched trailing backtick.
- `npx vitest run packages/app/src/components/markdown/html-ish.test.ts --bail=1` passed: 1 file, 27 tests.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run format` ran.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A: parser-only change)
- [x] Tests added or updated where it made sense
