### PR TITLE
feat(app): browse host folders in project picker

### DIFF
--- a/packages/app/src/components/project-picker-modal.tsx
+++ b/packages/app/src/components/project-picker-modal.tsx
@@ -8,7 +8,7 @@ import {
   View,
   type PressableStateCallbackType,
 } from "react-native";
-import { Folder, FolderPlus } from "lucide-react-native";
+import { Check, Folder, FolderOpen, FolderPlus, Home, Undo2 } from "lucide-react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
@@ -21,16 +21,21 @@ import type { OpenProjectFailure, OpenProjectResult } from "@/hooks/open-project
 import { isNative } from "@/constants/platform";
 import { useActiveServerId } from "@/hooks/use-active-server-id";
 import {
+  buildProjectPickerBrowseOptions,
   buildProjectPickerOptions,
+  PROJECT_PICKER_HOME_CWD,
   isOpenableProjectPath,
-  type ProjectPickerOption,
+  type ProjectPickerListOption,
 } from "./project-picker-options";
 
 interface PathRowProps {
-  option: ProjectPickerOption;
+  option: ProjectPickerListOption;
   active: boolean;
+  browseHostFoldersLabel: string;
   openPathLabel: string;
-  onSelect: (path: string) => void;
+  selectCurrentFolderLabel: string;
+  parentFolderLabel: string;
+  onSelect: (option: ProjectPickerListOption) => void;
 }
 
 type ProjectPickerErrorCode = NonNullable<OpenProjectFailure["errorCode"]>;
@@ -53,15 +58,29 @@ function getProjectPickerErrorMessage(
   return null;
 }
 
-function PathRow({ option, active, openPathLabel, onSelect }: PathRowProps) {
+function PathRow({
+  option,
+  active,
+  browseHostFoldersLabel,
+  openPathLabel,
+  selectCurrentFolderLabel,
+  parentFolderLabel,
+  onSelect,
+}: PathRowProps) {
   const { theme } = useUnistyles();
-  const Icon = option.kind === "path" ? FolderPlus : Folder;
-  const path = option.path;
-  const displayPath = shortenPath(path);
-  const label = option.kind === "path" ? `${openPathLabel}: ${displayPath}` : displayPath;
+  const Icon = getPathRowIcon(option.kind);
+  const displayPath = shortenPath(option.path);
+  const label = getPathRowLabel({
+    option,
+    displayPath,
+    browseHostFoldersLabel,
+    openPathLabel,
+    selectCurrentFolderLabel,
+    parentFolderLabel,
+  });
   const handlePress = useCallback(() => {
-    onSelect(path);
-  }, [onSelect, path]);
+    onSelect(option);
+  }, [onSelect, option]);
   const pressableStyle = useCallback(
     ({ hovered = false, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
       styles.row,
@@ -89,6 +108,45 @@ function PathRow({ option, active, openPathLabel, onSelect }: PathRowProps) {
   );
 }
 
+function getPathRowIcon(kind: ProjectPickerListOption["kind"]) {
+  switch (kind) {
+    case "path":
+      return FolderPlus;
+    case "browse-root":
+      return Home;
+    case "browse-current":
+      return Check;
+    case "browse-parent":
+      return Undo2;
+    case "browse-directory":
+      return FolderOpen;
+    case "suggestion":
+      return Folder;
+  }
+}
+
+function getPathRowLabel(input: {
+  option: ProjectPickerListOption;
+  displayPath: string;
+  browseHostFoldersLabel: string;
+  openPathLabel: string;
+  selectCurrentFolderLabel: string;
+  parentFolderLabel: string;
+}): string {
+  switch (input.option.kind) {
+    case "path":
+      return `${input.openPathLabel}: ${input.displayPath}`;
+    case "browse-root":
+      return input.browseHostFoldersLabel;
+    case "browse-current":
+      return `${input.selectCurrentFolderLabel}: ${input.displayPath}`;
+    case "browse-parent":
+      return `${input.parentFolderLabel}: ${input.displayPath}`;
+    case "browse-directory":
+    case "suggestion":
+      return input.displayPath;
+  }
+}
 export function ProjectPickerModal() {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
@@ -104,6 +162,7 @@ export function ProjectPickerModal() {
   const inputRef = useRef<TextInput>(null);
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
+  const [browseCwd, setBrowseCwd] = useState<string | null>(null);
   const openProject = useOpenProject(serverId);
 
   const openProjectMutation = useMutation({
@@ -123,12 +182,15 @@ export function ProjectPickerModal() {
     () => t("projectPicker.errors.open_failed"),
   );
 
+  const isBrowsing = browseCwd !== null;
+
   const directorySuggestionsQuery = useQuery({
-    queryKey: ["project-picker-directory-suggestions", serverId, query],
+    queryKey: ["project-picker-directory-suggestions", serverId, query, browseCwd],
     queryFn: async () => {
       if (!client) return [];
       const result = await client.getDirectorySuggestions({
-        query,
+        query: isBrowsing ? "" : query,
+        ...(browseCwd ? { cwd: browseCwd } : {}),
         includeDirectories: true,
         includeFiles: false,
         limit: 30,
@@ -142,13 +204,22 @@ export function ProjectPickerModal() {
     retry: false,
   });
 
-  const options = useMemo(() => {
-    return buildProjectPickerOptions({
+  const options = useMemo<ProjectPickerListOption[]>(() => {
+    if (browseCwd) {
+      return buildProjectPickerBrowseOptions({
+        cwd: browseCwd,
+        childPaths: directorySuggestionsQuery.data ?? [],
+      });
+    }
+
+    const searchOptions = buildProjectPickerOptions({
       recommendedPaths,
       serverPaths: directorySuggestionsQuery.data ?? [],
       query,
     });
-  }, [query, directorySuggestionsQuery.data, recommendedPaths]);
+
+    return [{ kind: "browse-root", path: PROJECT_PICKER_HOME_CWD }, ...searchOptions];
+  }, [browseCwd, query, directorySuggestionsQuery.data, recommendedPaths]);
 
   const handleClose = useCallback(() => {
     setOpen(false);
@@ -163,6 +234,34 @@ export function ProjectPickerModal() {
     [client, serverId, submitPath],
   );
 
+  const handleBrowse = useCallback(
+    (path: string) => {
+      setBrowseCwd(path);
+      setQuery("");
+      setActiveIndex(0);
+      resetSubmit();
+    },
+    [resetSubmit],
+  );
+
+  const handleSelectOption = useCallback(
+    (option: ProjectPickerListOption) => {
+      switch (option.kind) {
+        case "browse-root":
+        case "browse-parent":
+        case "browse-directory":
+          handleBrowse(option.path);
+          return;
+        case "browse-current":
+        case "path":
+        case "suggestion":
+          handleSelectPath(option.path);
+          return;
+      }
+    },
+    [handleBrowse, handleSelectPath],
+  );
+
   const handleSubmitCustom = useCallback(() => {
     const trimmed = query.trim();
     if (!isOpenableProjectPath(trimmed)) return;
@@ -172,6 +271,7 @@ export function ProjectPickerModal() {
   const handleChangeQuery = useCallback(
     (text: string) => {
       setQuery(text);
+      setBrowseCwd(null);
       setActiveIndex(0);
       resetSubmit();
     },
@@ -186,6 +286,7 @@ export function ProjectPickerModal() {
     }
 
     setQuery("");
+    setBrowseCwd(null);
     setActiveIndex(0);
     const id = setTimeout(() => inputRef.current?.focus(), 0);
     return () => clearTimeout(id);
@@ -216,7 +317,7 @@ export function ProjectPickerModal() {
       if (key === "Enter") {
         event.preventDefault();
         if (options.length > 0 && activeIndex < options.length) {
-          handleSelectPath(options[activeIndex].path);
+          handleSelectOption(options[activeIndex]);
         } else if (query.trim()) {
           handleSubmitCustom();
         }
@@ -238,7 +339,7 @@ export function ProjectPickerModal() {
 
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [activeIndex, handleClose, handleSelectPath, handleSubmitCustom, open, options, query]);
+  }, [activeIndex, handleClose, handleSelectOption, handleSubmitCustom, open, options, query]);
 
   const panelStyle = useMemo(
     () => [
@@ -280,7 +381,11 @@ export function ProjectPickerModal() {
               ref={inputRef}
               value={query}
               onChangeText={handleChangeQuery}
-              placeholder={t("projectPicker.placeholder")}
+              placeholder={
+                isBrowsing
+                  ? t("projectPicker.browsing", { path: shortenPath(browseCwd) })
+                  : t("projectPicker.placeholder")
+              }
               placeholderTextColor={theme.colors.foregroundMuted}
               style={inputStyle}
               autoCapitalize="none"
@@ -310,8 +415,11 @@ export function ProjectPickerModal() {
                     key={`${option.kind}:${option.path}`}
                     option={option}
                     active={index === activeIndex}
+                    browseHostFoldersLabel={t("projectPicker.browseHostFolders")}
                     openPathLabel={t("projectPicker.openPath")}
-                    onSelect={handleSelectPath}
+                    selectCurrentFolderLabel={t("projectPicker.selectCurrentFolder")}
+                    parentFolderLabel={t("projectPicker.parentFolder")}
+                    onSelect={handleSelectOption}
                   />
                 ))}
               </>

--- a/packages/app/src/components/project-picker-options.test.ts
+++ b/packages/app/src/components/project-picker-options.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildProjectPickerOptions, isOpenableProjectPath } from "./project-picker-options";
+import {
+  buildProjectPickerBrowseOptions,
+  buildProjectPickerOptions,
+  getProjectPickerBrowseParentPath,
+  isOpenableProjectPath,
+  joinProjectPickerBrowsePath,
+} from "./project-picker-options";
 
 describe("isOpenableProjectPath", () => {
   it("accepts POSIX, tilde, Windows drive-letter, and UNC paths", () => {
@@ -76,5 +82,63 @@ describe("buildProjectPickerOptions", () => {
     });
 
     expect(options).toEqual([{ kind: "suggestion", path: "/repo/app" }]);
+  });
+});
+
+describe("project picker browse options", () => {
+  it("starts home browsing with the current directory and child directories", () => {
+    const options = buildProjectPickerBrowseOptions({
+      cwd: "~",
+      childPaths: ["src", "Downloads"],
+    });
+
+    expect(options).toEqual([
+      { kind: "browse-current", path: "~" },
+      { kind: "browse-directory", path: "~/src" },
+      { kind: "browse-directory", path: "~/Downloads" },
+    ]);
+  });
+
+  it("adds a parent row outside the home root", () => {
+    const options = buildProjectPickerBrowseOptions({
+      cwd: "~/src/paseo",
+      childPaths: ["packages"],
+    });
+
+    expect(options).toEqual([
+      { kind: "browse-current", path: "~/src/paseo" },
+      { kind: "browse-parent", path: "~/src" },
+      { kind: "browse-directory", path: "~/src/paseo/packages" },
+    ]);
+  });
+
+  it("dedupes child paths that point at existing browse actions", () => {
+    const options = buildProjectPickerBrowseOptions({
+      cwd: "/workspace",
+      childPaths: [".", "/workspace/src", "workspace/src", "src"],
+    });
+
+    expect(options).toEqual([
+      { kind: "browse-current", path: "/workspace" },
+      { kind: "browse-parent", path: "/" },
+      { kind: "browse-directory", path: "/workspace/src" },
+    ]);
+  });
+
+  it("resolves parent paths for tilde, POSIX, and Windows-style directories", () => {
+    expect(getProjectPickerBrowseParentPath("~")).toBeNull();
+    expect(getProjectPickerBrowseParentPath("~/src/paseo")).toBe("~/src");
+    expect(getProjectPickerBrowseParentPath("/Users/mo/src")).toBe("/Users/mo");
+    expect(getProjectPickerBrowseParentPath("/")).toBeNull();
+    expect(getProjectPickerBrowseParentPath("C:\\Users\\mo")).toBe("C:\\Users");
+    expect(getProjectPickerBrowseParentPath("C:\\Users\\mo\\")).toBe("C:\\Users");
+  });
+
+  it("joins relative server child paths under the current browsed directory", () => {
+    expect(joinProjectPickerBrowsePath("~/src", "paseo")).toBe("~/src/paseo");
+    expect(joinProjectPickerBrowsePath("/workspace", "./packages/app")).toBe(
+      "/workspace/packages/app",
+    );
+    expect(joinProjectPickerBrowsePath("~/src", "/tmp/project")).toBe("/tmp/project");
   });
 });

--- a/packages/app/src/components/project-picker-options.ts
+++ b/packages/app/src/components/project-picker-options.ts
@@ -6,6 +6,11 @@ export interface BuildProjectPickerOptionsInput {
   query: string;
 }
 
+export interface BuildProjectPickerBrowseOptionsInput {
+  cwd: string;
+  childPaths: string[];
+}
+
 export interface ProjectPickerPathOption {
   kind: "path";
   path: string;
@@ -16,7 +21,37 @@ export interface ProjectPickerSuggestionOption {
   path: string;
 }
 
+export interface ProjectPickerBrowseRootOption {
+  kind: "browse-root";
+  path: string;
+}
+
+export interface ProjectPickerBrowseCurrentOption {
+  kind: "browse-current";
+  path: string;
+}
+
+export interface ProjectPickerBrowseParentOption {
+  kind: "browse-parent";
+  path: string;
+}
+
+export interface ProjectPickerBrowseDirectoryOption {
+  kind: "browse-directory";
+  path: string;
+}
+
 export type ProjectPickerOption = ProjectPickerPathOption | ProjectPickerSuggestionOption;
+export type ProjectPickerBrowseOption =
+  | ProjectPickerBrowseCurrentOption
+  | ProjectPickerBrowseParentOption
+  | ProjectPickerBrowseDirectoryOption;
+export type ProjectPickerListOption =
+  | ProjectPickerOption
+  | ProjectPickerBrowseRootOption
+  | ProjectPickerBrowseOption;
+
+export const PROJECT_PICKER_HOME_CWD = "~";
 
 // Matches the daemon's filesystem semantics, not the client's: POSIX absolute,
 // tilde, Windows drive letter (C:\ or C:/), or UNC (\\server\share).
@@ -45,4 +80,95 @@ export function buildProjectPickerOptions(
   }
 
   return [{ kind: "path", path: trimmedQuery }, ...suggestions];
+}
+
+export function buildProjectPickerBrowseOptions(
+  input: BuildProjectPickerBrowseOptionsInput,
+): ProjectPickerBrowseOption[] {
+  const cwd = normalizeBrowsePath(input.cwd);
+  const options: ProjectPickerBrowseOption[] = [{ kind: "browse-current", path: cwd }];
+  const parentPath = getProjectPickerBrowseParentPath(cwd);
+  if (parentPath) {
+    options.push({ kind: "browse-parent", path: parentPath });
+  }
+
+  const seen = new Set<string>(options.map((option) => option.path));
+  for (const childPath of input.childPaths) {
+    const path = joinProjectPickerBrowsePath(cwd, childPath);
+    if (!path || seen.has(path)) {
+      continue;
+    }
+    options.push({ kind: "browse-directory", path });
+    seen.add(path);
+  }
+
+  return options;
+}
+
+export function getProjectPickerBrowseParentPath(cwd: string): string | null {
+  const normalized = normalizeBrowsePath(cwd);
+  if (normalized === PROJECT_PICKER_HOME_CWD || normalized === "/") {
+    return null;
+  }
+
+  if (normalized.startsWith(`${PROJECT_PICKER_HOME_CWD}/`)) {
+    const parent = normalized.slice(0, normalized.lastIndexOf("/"));
+    return parent || PROJECT_PICKER_HOME_CWD;
+  }
+
+  const withoutTrailingSlash = normalized.replace(/[\\/]+$/, "");
+  const slashIndex = Math.max(
+    withoutTrailingSlash.lastIndexOf("/"),
+    withoutTrailingSlash.lastIndexOf("\\"),
+  );
+  if (slashIndex <= 0) {
+    return withoutTrailingSlash.startsWith("/") ? "/" : null;
+  }
+
+  if (/^[a-zA-Z]:[\\/]/.test(withoutTrailingSlash) && slashIndex <= 2) {
+    return withoutTrailingSlash.slice(0, 3);
+  }
+
+  return withoutTrailingSlash.slice(0, slashIndex);
+}
+
+export function joinProjectPickerBrowsePath(cwd: string, childPath: string): string {
+  const normalizedCwd = normalizeBrowsePath(cwd);
+  const trimmedChild = childPath.trim();
+  if (isOpenableProjectPath(trimmedChild)) {
+    return normalizeBrowsePath(trimmedChild);
+  }
+
+  const normalizedChild = trimmedChild.replace(/^\.\/+/, "");
+  if (!normalizedChild || normalizedChild === ".") {
+    return normalizedCwd;
+  }
+
+  const cwdTail = getBrowsePathTail(normalizedCwd);
+  if (cwdTail && normalizedChild === cwdTail) {
+    return normalizedCwd;
+  }
+  if (cwdTail && normalizedChild.startsWith(`${cwdTail}/`)) {
+    const parentPath = getProjectPickerBrowseParentPath(normalizedCwd);
+    const basePath = parentPath ?? normalizedCwd;
+    const separator = basePath.endsWith("/") || basePath.endsWith("\\") ? "" : "/";
+    return `${basePath}${separator}${normalizedChild}`;
+  }
+
+  const separator = normalizedCwd.endsWith("/") || normalizedCwd.endsWith("\\") ? "" : "/";
+  return `${normalizedCwd}${separator}${normalizedChild}`;
+}
+
+function getBrowsePathTail(path: string): string | null {
+  const normalized = normalizeBrowsePath(path);
+  if (normalized === PROJECT_PICKER_HOME_CWD || normalized === "/") {
+    return null;
+  }
+  const slashIndex = Math.max(normalized.lastIndexOf("/"), normalized.lastIndexOf("\\"));
+  return slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+}
+
+function normalizeBrowsePath(path: string): string {
+  const trimmed = path.trim().replace(/[\\/]+$/, "");
+  return trimmed || PROJECT_PICKER_HOME_CWD;
 }

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1049,6 +1049,10 @@ export const ar: TranslationResources = {
   },
   projectPicker: {
     placeholder: "اكتب مسار الدليل...",
+    browsing: "تصفح {{path}}",
+    browseHostFolders: "تصفح مجلدات المضيف",
+    selectCurrentFolder: "اختيار المجلد الحالي",
+    parentFolder: "المجلد الأصل",
     opening: "افتتاح المشروع...",
     empty: "ابدأ بكتابة المسار",
     errors: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1055,6 +1055,10 @@ export const en = {
   },
   projectPicker: {
     placeholder: "Type a directory path...",
+    browsing: "Browsing {{path}}",
+    browseHostFolders: "Browse host folders",
+    selectCurrentFolder: "Select current folder",
+    parentFolder: "Parent folder",
     opening: "Opening project...",
     empty: "Start typing a path",
     errors: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1082,6 +1082,10 @@ export const es: TranslationResources = {
   },
   projectPicker: {
     placeholder: "Escriba una ruta de directorio...",
+    browsing: "Explorando {{path}}",
+    browseHostFolders: "Explorar carpetas del host",
+    selectCurrentFolder: "Seleccionar carpeta actual",
+    parentFolder: "Carpeta superior",
     opening: "Proyecto de apertura...",
     empty: "Comience a escribir una ruta",
     errors: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1084,6 +1084,10 @@ export const fr: TranslationResources = {
   },
   projectPicker: {
     placeholder: "Tapez un chemin de répertoire...",
+    browsing: "Parcours de {{path}}",
+    browseHostFolders: "Parcourir les dossiers de l’hôte",
+    selectCurrentFolder: "Sélectionner le dossier actuel",
+    parentFolder: "Dossier parent",
     opening: "Projet d'ouverture...",
     empty: "Commencez à taper un chemin",
     errors: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1072,6 +1072,10 @@ export const ru: TranslationResources = {
   },
   projectPicker: {
     placeholder: "Введите путь к каталогу...",
+    browsing: "Просмотр {{path}}",
+    browseHostFolders: "Просмотреть папки хоста",
+    selectCurrentFolder: "Выбрать текущую папку",
+    parentFolder: "Родительская папка",
     opening: "Открытие проекта...",
     empty: "Начните вводить путь",
     errors: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1034,6 +1034,10 @@ export const zhCN: TranslationResources = {
   },
   projectPicker: {
     placeholder: "输入目录路径...",
+    browsing: "正在浏览 {{path}}",
+    browseHostFolders: "浏览主机文件夹",
+    selectCurrentFolder: "选择当前文件夹",
+    parentFolder: "上级文件夹",
     opening: "正在打开 project...",
     empty: "开始输入路径",
     errors: {


### PR DESCRIPTION
## Summary
- Add a host-folder browsing entry to the project picker so mobile/remote users can navigate from the host home directory.
- Reuse the existing directory suggestions RPC with cwd + empty query for child folders; no protocol or daemon changes.
- Add browse option helpers for current folder, parent folder, child folder navigation, and path dedupe across relative/absolute suggestion forms.
- Localize the new project picker labels.

Closes #1508

## Test plan
- npm run test --workspace=@getpaseo/app -- src/components/project-picker-options.test.ts src/i18n/resources.test.ts --bail=1
- npm run lint
- npm run typecheck
- npm run format