### PR TITLE
fix: disambiguate merge PR action labels (squash/merge/rebase)

### DIFF
--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -601,9 +601,9 @@ export const ar: TranslationResources = {
           success: "مؤرشف",
         },
         mergePr: {
-          squash: "دمج",
-          merge: "دمج",
-          rebase: "دمج",
+          squash: "دمج PR (squash)",
+          merge: "دمج PR (merge)",
+          rebase: "دمج PR (rebase)",
           pending: "دمج PR...",
           success: "تم دمج PR",
         },

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -608,9 +608,9 @@ export const ar: TranslationResources = {
           success: "تم دمج PR",
         },
         autoMerge: {
-          enableSquash: "دمج تلقائي",
-          enableMerge: "دمج تلقائي",
-          enableRebase: "دمج تلقائي",
+          enableSquash: "دمج تلقائي (squash)",
+          enableMerge: "دمج تلقائي (merge)",
+          enableRebase: "دمج تلقائي (rebase)",
           enabled: "تم تمكين الدمج التلقائي",
           enabling: "تمكين الدمج التلقائي...",
           disabling: "تعطيل الدمج التلقائي...",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -599,9 +599,9 @@ export const en = {
           success: "Archived",
         },
         mergePr: {
-          squash: "Merge",
-          merge: "Merge",
-          rebase: "Merge",
+          squash: "Merge PR (squash)",
+          merge: "Merge PR (merge)",
+          rebase: "Merge PR (rebase)",
           pending: "Merging PR...",
           success: "PR merged",
         },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -606,9 +606,9 @@ export const en = {
           success: "PR merged",
         },
         autoMerge: {
-          enableSquash: "Auto merge",
-          enableMerge: "Auto merge",
-          enableRebase: "Auto merge",
+          enableSquash: "Auto merge (squash)",
+          enableMerge: "Auto merge (merge)",
+          enableRebase: "Auto merge (rebase)",
           enabled: "Auto-merge enabled",
           enabling: "Enabling auto-merge...",
           disabling: "Disabling auto-merge...",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -613,9 +613,9 @@ export const es: TranslationResources = {
           success: "PRfusionado",
         },
         autoMerge: {
-          enableSquash: "Fusión automática",
-          enableMerge: "Fusión automática",
-          enableRebase: "Fusión automática",
+          enableSquash: "Fusión automática (squash)",
+          enableMerge: "Fusión automática (merge)",
+          enableRebase: "Fusión automática (rebase)",
           enabled: "Combinación automática habilitada",
           enabling: "Habilitando la fusión automática...",
           disabling: "Desactivando la fusión automática...",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -606,9 +606,9 @@ export const es: TranslationResources = {
           success: "Archivado",
         },
         mergePr: {
-          squash: "Fusionar",
-          merge: "Fusionar",
-          rebase: "Fusionar",
+          squash: "Fusionar PR (squash)",
+          merge: "Fusionar PR (merge)",
+          rebase: "Fusionar PR (rebase)",
           pending: "FusionandoPR...",
           success: "PRfusionado",
         },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -613,9 +613,9 @@ export const fr: TranslationResources = {
           success: "PRfusionné",
         },
         autoMerge: {
-          enableSquash: "Fusion automatique",
-          enableMerge: "Fusion automatique",
-          enableRebase: "Fusion automatique",
+          enableSquash: "Fusion automatique (squash)",
+          enableMerge: "Fusion automatique (merge)",
+          enableRebase: "Fusion automatique (rebase)",
           enabled: "Fusion automatique activée",
           enabling: "Activation de la fusion automatique...",
           disabling: "Désactivation de la fusion automatique...",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -606,9 +606,9 @@ export const fr: TranslationResources = {
           success: "Archivé",
         },
         mergePr: {
-          squash: "Fusionner",
-          merge: "Fusionner",
-          rebase: "Fusionner",
+          squash: "Fusionner PR (squash)",
+          merge: "Fusionner PR (merge)",
+          rebase: "Fusionner PR (rebase)",
           pending: "Fusion dePR...",
           success: "PRfusionné",
         },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -605,9 +605,9 @@ export const ru: TranslationResources = {
           success: "В архиве",
         },
         mergePr: {
-          squash: "Объединить",
-          merge: "Объединить",
-          rebase: "Объединить",
+          squash: "Объединить PR (squash)",
+          merge: "Объединить PR (merge)",
+          rebase: "Объединить PR (rebase)",
           pending: "Объединение PR...",
           success: "PR объединен",
         },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -612,9 +612,9 @@ export const ru: TranslationResources = {
           success: "PR объединен",
         },
         autoMerge: {
-          enableSquash: "Автообъединение",
-          enableMerge: "Автообъединение",
-          enableRebase: "Автообъединение",
+          enableSquash: "Автообъединение (squash)",
+          enableMerge: "Автообъединение (merge)",
+          enableRebase: "Автообъединение (rebase)",
           enabled: "Автоматическое объединение включено",
           enabling: "Включение автоматического объединения...",
           disabling: "Отключение автоматического объединения...",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -606,9 +606,9 @@ export const zhCN: TranslationResources = {
           success: "PR 已 merge",
         },
         autoMerge: {
-          enableSquash: "Auto merge",
-          enableMerge: "Auto merge",
-          enableRebase: "Auto merge",
+          enableSquash: "Auto merge (squash)",
+          enableMerge: "Auto merge (merge)",
+          enableRebase: "Auto merge (rebase)",
           enabled: "Auto-merge 已启用",
           enabling: "正在启用 auto-merge...",
           disabling: "正在禁用 auto-merge...",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -599,9 +599,9 @@ export const zhCN: TranslationResources = {
           success: "已归档",
         },
         mergePr: {
-          squash: "Merge",
-          merge: "Merge",
-          rebase: "Merge",
+          squash: "Merge PR (squash)",
+          merge: "Merge PR (merge)",
+          rebase: "Merge PR (rebase)",
           pending: "正在 merge PR...",
           success: "PR 已 merge",
         },


### PR DESCRIPTION
## Problem

All three PR merge methods had the identical label `"Merge"` in every locale. Combined with the local git `merge-branch` action (labeled "Merge locally"), users could see multiple near-identical "Merge" entries in the actions menu with no way to distinguish them.

## Fix

Differentiate the three GitHub PR merge method labels to include the method name in parentheses:

- `"Merge PR (squash)"`
- `"Merge PR (merge)"`
- `"Merge PR (rebase)"`

Applied across all 6 supported locales: `en`, `ar`, `fr`, `es`, `ru`, `zh-CN`.