### PR TITLE
[codex] Add vertical pane tab orientation

### DIFF
--- a/packages/app/src/components/sortable-inline-list.native.tsx
+++ b/packages/app/src/components/sortable-inline-list.native.tsx
@@ -15,6 +15,7 @@ export function SortableInlineList<T>({
   externalDndContext?: boolean;
   activeId?: string | null;
   getItemData?: (item: T, index: number) => Record<string, unknown>;
+  orientation?: "horizontal" | "vertical";
 }): ReactElement {
   return (
     <>

--- a/packages/app/src/components/sortable-inline-list.web.tsx
+++ b/packages/app/src/components/sortable-inline-list.web.tsx
@@ -12,6 +12,7 @@ import {
   SortableContext,
   sortableKeyboardCoordinates,
   horizontalListSortingStrategy,
+  verticalListSortingStrategy,
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -23,7 +24,13 @@ const restrictToHorizontalAxis: Modifier = ({ transform }) => ({
   y: 0,
 });
 
-const DND_MODIFIERS: Modifier[] = [restrictToHorizontalAxis];
+const restrictToVerticalAxis: Modifier = ({ transform }) => ({
+  ...transform,
+  x: 0,
+});
+
+const HORIZONTAL_DND_MODIFIERS: Modifier[] = [restrictToHorizontalAxis];
+const VERTICAL_DND_MODIFIERS: Modifier[] = [restrictToVerticalAxis];
 
 function computeDragOpacity(hasExternalContext: boolean, isDragging: boolean): number {
   if (!isDragging) return 1;
@@ -123,6 +130,7 @@ export function SortableInlineList<T>({
   externalDndContext = false,
   activeId: externalActiveId = null,
   getItemData,
+  orientation = "horizontal",
 }: {
   data: T[];
   keyExtractor: (item: T, index: number) => string;
@@ -135,6 +143,7 @@ export function SortableInlineList<T>({
   externalDndContext?: boolean;
   activeId?: string | null;
   getItemData?: (item: T, index: number) => Record<string, unknown>;
+  orientation?: "horizontal" | "vertical";
 }): ReactElement {
   const {
     activeId: internalActiveId,
@@ -166,8 +175,13 @@ export function SortableInlineList<T>({
     [items, keyExtractor],
   );
 
+  const sortingStrategy =
+    orientation === "vertical" ? verticalListSortingStrategy : horizontalListSortingStrategy;
+  const dndModifiers =
+    orientation === "vertical" ? VERTICAL_DND_MODIFIERS : HORIZONTAL_DND_MODIFIERS;
+
   const renderedItems = (
-    <SortableContext items={ids} strategy={horizontalListSortingStrategy}>
+    <SortableContext items={ids} strategy={sortingStrategy}>
       {items.map((item, index) => {
         const id = keyExtractor(item, index);
         return (
@@ -196,7 +210,7 @@ export function SortableInlineList<T>({
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
-      modifiers={DND_MODIFIERS}
+      modifiers={dndModifiers}
       onDragStart={handlers.onDragStart}
       onDragCancel={handlers.onDragCancel}
       onDragEnd={handlers.onDragEnd}

--- a/packages/app/src/components/split-container-tab-drop-preview.test.ts
+++ b/packages/app/src/components/split-container-tab-drop-preview.test.ts
@@ -25,8 +25,8 @@ describe("computeTabDropPreview", () => {
         overPaneId: "target",
         overTabId: "c",
         targetTabs,
-        activeRect: { left: 180, width: 40 },
-        overRect: { left: 200, width: 100 },
+        activeRect: { left: 180, top: 0, width: 40, height: 30 },
+        overRect: { left: 200, top: 0, width: 100, height: 30 },
       }),
     ).toEqual({
       paneId: "target",
@@ -43,8 +43,8 @@ describe("computeTabDropPreview", () => {
         overPaneId: "target",
         overTabId: "c",
         targetTabs,
-        activeRect: { left: 280, width: 40 },
-        overRect: { left: 200, width: 100 },
+        activeRect: { left: 280, top: 0, width: 40, height: 30 },
+        overRect: { left: 200, top: 0, width: 100, height: 30 },
       }),
     ).toEqual({
       paneId: "target",
@@ -61,13 +61,51 @@ describe("computeTabDropPreview", () => {
         overPaneId: "pane",
         overTabId: "d",
         targetTabs,
-        activeRect: { left: 460, width: 40 },
-        overRect: { left: 400, width: 100 },
+        activeRect: { left: 460, top: 0, width: 40, height: 30 },
+        overRect: { left: 400, top: 0, width: 100, height: 30 },
       }),
     ).toEqual({
       paneId: "pane",
       insertionIndex: 3,
       indicatorIndex: 4,
+    });
+  });
+
+  it("returns a before-target insertion index for vertical drops on the top half", () => {
+    expect(
+      computeTabDropPreview({
+        orientation: "vertical",
+        activePaneId: "source",
+        activeTabId: "x",
+        overPaneId: "target",
+        overTabId: "c",
+        targetTabs,
+        activeRect: { left: 0, top: 180, width: 180, height: 40 },
+        overRect: { left: 0, top: 200, width: 180, height: 100 },
+      }),
+    ).toEqual({
+      paneId: "target",
+      insertionIndex: 2,
+      indicatorIndex: 2,
+    });
+  });
+
+  it("returns an after-target insertion index for vertical drops on the bottom half", () => {
+    expect(
+      computeTabDropPreview({
+        orientation: "vertical",
+        activePaneId: "source",
+        activeTabId: "x",
+        overPaneId: "target",
+        overTabId: "c",
+        targetTabs,
+        activeRect: { left: 0, top: 280, width: 180, height: 40 },
+        overRect: { left: 0, top: 200, width: 180, height: 100 },
+      }),
+    ).toEqual({
+      paneId: "target",
+      insertionIndex: 3,
+      indicatorIndex: 3,
     });
   });
 });

--- a/packages/app/src/components/split-container-tab-drop-preview.ts
+++ b/packages/app/src/components/split-container-tab-drop-preview.ts
@@ -7,6 +7,7 @@ export interface TabDropPreview {
 }
 
 interface ComputeTabDropPreviewInput {
+  orientation?: "horizontal" | "vertical";
   activePaneId: string;
   activeTabId: string;
   overPaneId: string;
@@ -14,23 +15,35 @@ interface ComputeTabDropPreviewInput {
   targetTabs: WorkspaceTabDescriptor[];
   activeRect: {
     left: number;
+    top: number;
     width: number;
+    height: number;
   };
   overRect: {
     left: number;
+    top: number;
     width: number;
+    height: number;
   };
 }
 
 export function computeTabDropPreview(input: ComputeTabDropPreviewInput): TabDropPreview | null {
   const targetIndex = input.targetTabs.findIndex((tab) => tab.tabId === input.overTabId);
-  if (targetIndex < 0 || input.overRect.width <= 0) {
+  const orientation = input.orientation ?? "horizontal";
+  const overSize = orientation === "vertical" ? input.overRect.height : input.overRect.width;
+  if (targetIndex < 0 || overSize <= 0) {
     return null;
   }
 
-  const activeCenterX = input.activeRect.left + input.activeRect.width / 2;
-  const overCenterX = input.overRect.left + input.overRect.width / 2;
-  const insertAfterTarget = activeCenterX >= overCenterX;
+  const activeCenter =
+    orientation === "vertical"
+      ? input.activeRect.top + input.activeRect.height / 2
+      : input.activeRect.left + input.activeRect.width / 2;
+  const overCenter =
+    orientation === "vertical"
+      ? input.overRect.top + input.overRect.height / 2
+      : input.overRect.left + input.overRect.width / 2;
+  const insertAfterTarget = activeCenter >= overCenter;
 
   const indicatorIndex = targetIndex + (insertAfterTarget ? 1 : 0);
   let insertionIndex = indicatorIndex;

--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -67,7 +67,9 @@ import {
   useWorkspaceLayoutStore,
   type SplitNode,
   type SplitPane,
+  type WorkspaceTabBarOrientation,
   type WorkspaceLayout,
+  findTopLeftPaneId,
 } from "@/stores/workspace-layout-store";
 import type { WorkspaceTab } from "@/stores/workspace-tabs-store";
 import { RenderProfile } from "@/utils/render-profiler";
@@ -162,21 +164,23 @@ interface SplitNodeViewProps extends Omit<SplitContainerProps, "layout" | "onMov
   showDropZones: boolean;
   dropPreview: SplitDropZoneHover | null;
   tabDropPreview: TabDropPreview | null;
+  topLeftPaneId: string | null;
 }
 
 interface SplitPaneViewProps extends Omit<
   SplitNodeViewProps,
   | "node"
-  | "workspaceKey"
   | "focusedPaneId"
   | "activeDragTabId"
   | "showDropZones"
   | "dropPreview"
   | "onResizeSplit"
+  | "topLeftPaneId"
 > {
   pane: SplitPane;
   uiTabs: WorkspaceTab[];
   isFocused: boolean;
+  topLeftPaneId: string | null;
   activeDragTabId: string | null;
   showDropZones: boolean;
   dropPreview: SplitDropZoneHover | null;
@@ -285,15 +289,18 @@ function computeTabOverDropPreview(input: {
   overData: WorkspaceTabDragData;
   rects: DragMoveRects;
   panesById: Map<string, SplitPane>;
+  tabBarOrientationByPaneId: Map<string, WorkspaceTabBarOrientation>;
   uiTabs: WorkspaceTab[];
 }): TabDropPreview | null {
-  const { activeData, overData, rects, panesById, uiTabs } = input;
+  const { activeData, overData, rects, panesById, tabBarOrientationByPaneId, uiTabs } = input;
   const targetPane = panesById.get(overData.paneId) ?? null;
   if (!targetPane) {
     return null;
   }
   const targetTabs = getWorkspacePaneDescriptors({ pane: targetPane, tabs: uiTabs });
+  const orientation = tabBarOrientationByPaneId.get(overData.paneId) ?? "horizontal";
   return computeTabDropPreview({
+    orientation,
     activePaneId: activeData.paneId,
     activeTabId: activeData.tabId,
     overPaneId: overData.paneId,
@@ -301,11 +308,15 @@ function computeTabOverDropPreview(input: {
     targetTabs,
     activeRect: {
       left: rects.translatedRect.left,
+      top: rects.translatedRect.top,
       width: rects.translatedRect.width,
+      height: rects.translatedRect.height,
     },
     overRect: {
       left: rects.overRect.left,
+      top: rects.overRect.top,
       width: rects.overRect.width,
+      height: rects.overRect.height,
     },
   });
 }
@@ -396,6 +407,9 @@ export function SplitContainer({
   const [activeDragTabId, setActiveDragTabId] = useState<string | null>(null);
   const [dropPreview, setDropPreview] = useState<SplitDropZoneHover | null>(null);
   const [tabDropPreview, setTabDropPreview] = useState<TabDropPreview | null>(null);
+  const topLeftPaneTabBarOrientation = useWorkspaceLayoutStore(
+    (state) => state.topLeftPaneTabBarOrientation,
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -409,6 +423,17 @@ export function SplitContainer({
   );
 
   const panesById = useMemo(() => collectPanesById(layout.root), [layout.root]);
+  const topLeftPaneId = useMemo(() => findTopLeftPaneId(layout.root), [layout.root]);
+  const tabBarOrientationByPaneId = useMemo(() => {
+    const next = new Map<string, WorkspaceTabBarOrientation>();
+    for (const [paneId, pane] of panesById) {
+      next.set(
+        paneId,
+        paneId === topLeftPaneId ? topLeftPaneTabBarOrientation : pane.tabBarOrientation,
+      );
+    }
+    return next;
+  }, [panesById, topLeftPaneId, topLeftPaneTabBarOrientation]);
 
   const effectiveRoot = useMemo(() => {
     if (!focusModeEnabled) {
@@ -463,6 +488,7 @@ export function SplitContainer({
           overData,
           rects,
           panesById,
+          tabBarOrientationByPaneId,
           uiTabs,
         });
         setDropPreview(null);
@@ -478,7 +504,7 @@ export function SplitContainer({
 
       setDropPreview(computePaneOverDropPreview({ overData, rects }));
     },
-    [panesById, uiTabs],
+    [panesById, tabBarOrientationByPaneId, uiTabs],
   );
 
   const applyTabDropEnd = useCallback(
@@ -611,6 +637,7 @@ export function SplitContainer({
           showDropZones={activeDragTabId !== null}
           dropPreview={dropPreview}
           tabDropPreview={tabDropPreview}
+          topLeftPaneId={topLeftPaneId}
         />
         <DragOverlay dropAnimation={null}>
           {activeDragTabId ? (
@@ -754,6 +781,7 @@ function SplitNodeView({
   showDropZones,
   dropPreview,
   tabDropPreview,
+  topLeftPaneId,
 }: SplitNodeViewProps) {
   const groupId = node.kind === "group" ? node.group.id : null;
   const groupDirection = node.kind === "group" ? node.group.direction : null;
@@ -776,6 +804,8 @@ function SplitNodeView({
         pane={node.pane}
         uiTabs={uiTabs}
         isFocused={node.pane.id === focusedPaneId}
+        workspaceKey={workspaceKey}
+        topLeftPaneId={topLeftPaneId}
         normalizedServerId={normalizedServerId}
         normalizedWorkspaceId={normalizedWorkspaceId}
         isWorkspaceFocused={isWorkspaceFocused}
@@ -853,6 +883,7 @@ function SplitNodeView({
               showDropZones={showDropZones}
               dropPreview={dropPreview}
               tabDropPreview={tabDropPreview}
+              topLeftPaneId={topLeftPaneId}
             />
           </SplitGroupChild>
           {index < node.group.children.length - 1 ? (
@@ -874,6 +905,8 @@ function SplitPaneView({
   pane,
   uiTabs,
   isFocused,
+  workspaceKey,
+  topLeftPaneId,
   normalizedServerId,
   normalizedWorkspaceId,
   isWorkspaceFocused,
@@ -909,6 +942,15 @@ function SplitPaneView({
   const paneRef = useRef<View | null>(null);
   const stableOnFocusPane = useStableEvent(onFocusPane);
   const padding = useWindowControlsPadding("tabRow");
+  const topLeftPaneTabBarOrientation = useWorkspaceLayoutStore(
+    (state) => state.topLeftPaneTabBarOrientation,
+  );
+  const setPaneTabBarOrientation = useWorkspaceLayoutStore(
+    (state) => state.setPaneTabBarOrientation,
+  );
+  const isTopLeftPane = pane.id === topLeftPaneId;
+  const tabBarOrientation = isTopLeftPane ? topLeftPaneTabBarOrientation : pane.tabBarOrientation;
+  const isVerticalTabBar = tabBarOrientation === "vertical";
   const paneState = useMemo(
     () =>
       deriveWorkspacePaneState({
@@ -1005,71 +1047,91 @@ function SplitPaneView({
     () => onSplitPaneEmpty({ targetPaneId: paneId, position: "bottom" }),
     [onSplitPaneEmpty, paneId],
   );
+  const handleVerticalTabsChange = useCallback(
+    (selected: boolean) => {
+      setPaneTabBarOrientation(workspaceKey, paneId, selected ? "vertical" : "horizontal");
+    },
+    [paneId, setPaneTabBarOrientation, workspaceKey],
+  );
   const paneTabsStyle = useMemo(
-    () => [styles.paneTabs, { paddingLeft: padding.left, paddingRight: padding.right }],
-    [padding.left, padding.right],
+    () => [
+      styles.paneTabs,
+      !isVerticalTabBar && { paddingLeft: padding.left, paddingRight: padding.right },
+    ],
+    [isVerticalTabBar, padding.left, padding.right],
+  );
+  const paneBodyStyle = useMemo(
+    () => [styles.paneBody, isVerticalTabBar && styles.paneBodyVertical],
+    [isVerticalTabBar],
+  );
+  const tabRow = (
+    <View style={paneTabsStyle}>
+      <TitlebarDragRegion />
+      <WorkspaceDesktopTabsRow
+        paneId={pane.id}
+        isFocused={isFocused}
+        tabs={desktopTabRowItems}
+        normalizedServerId={normalizedServerId}
+        normalizedWorkspaceId={normalizedWorkspaceId}
+        setHoveredCloseTabKey={setHoveredCloseTabKey}
+        onNavigateTab={onNavigateTab}
+        onCloseTab={onCloseTab}
+        onCopyResumeCommand={onCopyResumeCommand}
+        onCopyAgentId={onCopyAgentId}
+        onCopyFilePath={onCopyFilePath}
+        onReloadAgent={onReloadAgent}
+        onRenameTab={onRenameTab}
+        onCloseTabsToLeft={handleCloseTabsToLeft}
+        onCloseTabsToRight={handleCloseTabsToRight}
+        onCloseOtherTabs={handleCloseOtherTabs}
+        onCreateDraftTab={onCreateDraftTab}
+        onCreateTerminalTab={onCreateTerminalTab}
+        onCreateBrowserTab={onCreateBrowserTab}
+        showCreateBrowserTab={showCreateBrowserTab}
+        onReorderTabs={handleReorderTabs}
+        onSplitRight={handleSplitRight}
+        onSplitDown={handleSplitDown}
+        tabBarOrientation={tabBarOrientation}
+        verticalTabsSelected={isVerticalTabBar}
+        onVerticalTabsChange={handleVerticalTabsChange}
+        externalDndContext
+        activeDragTabId={activeDragTabId}
+        tabDropPreviewIndex={
+          tabDropPreview?.paneId === pane.id ? tabDropPreview.indicatorIndex : null
+        }
+      />
+    </View>
   );
 
   return (
     <RenderProfile id={`SplitPaneView:${pane.id}`}>
       <View ref={paneRef} collapsable={false} style={styles.pane}>
-        <View style={paneTabsStyle}>
-          <TitlebarDragRegion />
-          <WorkspaceDesktopTabsRow
-            paneId={pane.id}
-            isFocused={isFocused}
-            tabs={desktopTabRowItems}
-            normalizedServerId={normalizedServerId}
-            normalizedWorkspaceId={normalizedWorkspaceId}
-            setHoveredCloseTabKey={setHoveredCloseTabKey}
-            onNavigateTab={onNavigateTab}
-            onCloseTab={onCloseTab}
-            onCopyResumeCommand={onCopyResumeCommand}
-            onCopyAgentId={onCopyAgentId}
-            onCopyFilePath={onCopyFilePath}
-            onReloadAgent={onReloadAgent}
-            onRenameTab={onRenameTab}
-            onCloseTabsToLeft={handleCloseTabsToLeft}
-            onCloseTabsToRight={handleCloseTabsToRight}
-            onCloseOtherTabs={handleCloseOtherTabs}
-            onCreateDraftTab={onCreateDraftTab}
-            onCreateTerminalTab={onCreateTerminalTab}
-            onCreateBrowserTab={onCreateBrowserTab}
-            showCreateBrowserTab={showCreateBrowserTab}
-            onReorderTabs={handleReorderTabs}
-            onSplitRight={handleSplitRight}
-            onSplitDown={handleSplitDown}
-            externalDndContext
-            activeDragTabId={activeDragTabId}
-            tabDropPreviewIndex={
-              tabDropPreview?.paneId === pane.id ? tabDropPreview.indicatorIndex : null
-            }
-          />
-        </View>
+        <View style={paneBodyStyle}>
+          {tabRow}
+          <View style={styles.paneContent}>
+            {mountedPaneTabIds.length > 0
+              ? mountedPaneTabIds.map((tabId) => {
+                  const tabDescriptor = tabDescriptorMap.get(tabId);
+                  if (!tabDescriptor) {
+                    return null;
+                  }
 
-        <View style={styles.paneContent}>
-          {mountedPaneTabIds.length > 0
-            ? mountedPaneTabIds.map((tabId) => {
-                const tabDescriptor = tabDescriptorMap.get(tabId);
-                if (!tabDescriptor) {
-                  return null;
-                }
-
-                return (
-                  <MountedTabSlot
-                    key={tabId}
-                    tabDescriptor={tabDescriptor}
-                    isVisible={tabId === activeTabDescriptor?.tabId}
-                    isWorkspaceFocused={isWorkspaceFocused}
-                    isPaneFocused={isFocused && tabId === activeTabDescriptor?.tabId}
-                    paneId={pane.id}
-                    onFocusPane={stableOnFocusPane}
-                    buildPaneContentModel={buildPaneContentModel}
-                  />
-                );
-              })
-            : (renderPaneEmptyState?.() ?? null)}
-          <SplitDropZone paneId={pane.id} active={showDropZones} preview={dropPreview} />
+                  return (
+                    <MountedTabSlot
+                      key={tabId}
+                      tabDescriptor={tabDescriptor}
+                      isVisible={tabId === activeTabDescriptor?.tabId}
+                      isWorkspaceFocused={isWorkspaceFocused}
+                      isPaneFocused={isFocused && tabId === activeTabDescriptor?.tabId}
+                      paneId={pane.id}
+                      onFocusPane={stableOnFocusPane}
+                      buildPaneContentModel={buildPaneContentModel}
+                    />
+                  );
+                })
+              : (renderPaneEmptyState?.() ?? null)}
+            <SplitDropZone paneId={pane.id} active={showDropZones} preview={dropPreview} />
+          </View>
         </View>
       </View>
     </RenderProfile>
@@ -1142,6 +1204,14 @@ const styles = StyleSheet.create((theme) => ({
   paneTabs: {
     position: "relative",
     minWidth: 0,
+  },
+  paneBody: {
+    flex: 1,
+    minWidth: 0,
+    minHeight: 0,
+  },
+  paneBodyVertical: {
+    flexDirection: "row",
   },
   paneContent: {
     position: "relative",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -473,6 +473,7 @@ export const ar: TranslationResources = {
         splitDown: "تقسيم الجزء لأسفل",
         terminalProfilesMenu: "Terminal profiles",
         editTerminalProfiles: "Edit profiles…",
+        verticalTabs: "Vertical tabs",
         pinTarget: "تثبيت",
         unpinTarget: "إلغاء التثبيت",
       },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -473,6 +473,7 @@ export const en = {
         splitDown: "Split pane down",
         terminalProfilesMenu: "Terminal profiles",
         editTerminalProfiles: "Edit profiles…",
+        verticalTabs: "Vertical tabs",
         pinTarget: "Pin",
         unpinTarget: "Unpin",
       },

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -478,6 +478,7 @@ export const es: TranslationResources = {
         splitDown: "Dividir panel hacia abajo",
         terminalProfilesMenu: "Terminal profiles",
         editTerminalProfiles: "Edit profiles…",
+        verticalTabs: "Vertical tabs",
         pinTarget: "Fijar",
         unpinTarget: "Desfijar",
       },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -478,6 +478,7 @@ export const fr: TranslationResources = {
         splitDown: "Diviser le volet vers le bas",
         terminalProfilesMenu: "Terminal profiles",
         editTerminalProfiles: "Edit profiles…",
+        verticalTabs: "Vertical tabs",
         pinTarget: "Épingler",
         unpinTarget: "Détacher",
       },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -477,6 +477,7 @@ export const ru: TranslationResources = {
         splitDown: "Разделить панель вниз",
         terminalProfilesMenu: "Terminal profiles",
         editTerminalProfiles: "Edit profiles…",
+        verticalTabs: "Vertical tabs",
         pinTarget: "Закрепить",
         unpinTarget: "Открепить",
       },

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -473,6 +473,7 @@ export const zhCN: TranslationResources = {
         splitDown: "向下拆分窗格",
         terminalProfilesMenu: "Terminal profiles",
         editTerminalProfiles: "Edit profiles…",
+        verticalTabs: "Vertical tabs",
         pinTarget: "固定",
         unpinTarget: "取消固定",
       },

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -28,8 +28,6 @@ import {
   Rows2,
   Globe,
   Plus,
-  Square,
-  SquareCheckBig,
   SquarePen,
   SquareTerminal,
   X,
@@ -111,8 +109,6 @@ const ThemedGlobe = withUnistyles(Globe);
 const ThemedColumns2 = withUnistyles(Columns2);
 const ThemedRows2 = withUnistyles(Rows2);
 const ThemedPlus = withUnistyles(Plus);
-const ThemedSquare = withUnistyles(Square);
-const ThemedSquareCheckBig = withUnistyles(SquareCheckBig);
 const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
 const mutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
 
@@ -265,15 +261,6 @@ function WorkspaceTabRowExtras({
   const handleToggleVerticalTabs = useCallback(() => {
     onVerticalTabsChange(!verticalTabsSelected);
   }, [onVerticalTabsChange, verticalTabsSelected]);
-  const verticalTabsLeading = useMemo(
-    () =>
-      verticalTabsSelected ? (
-        <ThemedSquareCheckBig size={14} uniProps={mutedColorMapping} />
-      ) : (
-        <ThemedSquare size={14} uniProps={mutedColorMapping} />
-      ),
-    [verticalTabsSelected],
-  );
 
   return (
     <>
@@ -321,7 +308,8 @@ function WorkspaceTabRowExtras({
           <DropdownMenuSeparator />
           <DropdownMenuItem
             testID="workspace-new-tab-menu-vertical-tabs"
-            leading={verticalTabsLeading}
+            selected={verticalTabsSelected}
+            showSelectedCheck
             onSelect={handleToggleVerticalTabs}
           >
             {t("workspace.tabs.actions.verticalTabs")}

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -28,6 +28,8 @@ import {
   Rows2,
   Globe,
   Plus,
+  Square,
+  SquareCheckBig,
   SquarePen,
   SquareTerminal,
   X,
@@ -109,6 +111,8 @@ const ThemedGlobe = withUnistyles(Globe);
 const ThemedColumns2 = withUnistyles(Columns2);
 const ThemedRows2 = withUnistyles(Rows2);
 const ThemedPlus = withUnistyles(Plus);
+const ThemedSquare = withUnistyles(Square);
+const ThemedSquareCheckBig = withUnistyles(SquareCheckBig);
 const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
 const mutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
 
@@ -217,6 +221,8 @@ interface WorkspaceTabRowExtrasProps {
   normalizedServerId: string;
   showCreateBrowserTab: boolean;
   terminalDisabled: boolean;
+  verticalTabsSelected: boolean;
+  onVerticalTabsChange: (selected: boolean) => void;
 }
 
 function WorkspaceTabRowExtras({
@@ -228,6 +234,8 @@ function WorkspaceTabRowExtras({
   normalizedServerId,
   showCreateBrowserTab,
   terminalDisabled,
+  verticalTabsSelected,
+  onVerticalTabsChange,
 }: WorkspaceTabRowExtrasProps) {
   const { t } = useTranslation();
   const { config } = useDaemonConfig(normalizedServerId);
@@ -254,6 +262,18 @@ function WorkspaceTabRowExtras({
   );
 
   const launchers = usePinnedLaunchers({ serverId: normalizedServerId, onLaunch });
+  const handleToggleVerticalTabs = useCallback(() => {
+    onVerticalTabsChange(!verticalTabsSelected);
+  }, [onVerticalTabsChange, verticalTabsSelected]);
+  const verticalTabsLeading = useMemo(
+    () =>
+      verticalTabsSelected ? (
+        <ThemedSquareCheckBig size={14} uniProps={mutedColorMapping} />
+      ) : (
+        <ThemedSquare size={14} uniProps={mutedColorMapping} />
+      ),
+    [verticalTabsSelected],
+  );
 
   return (
     <>
@@ -298,6 +318,14 @@ function WorkspaceTabRowExtras({
               onSelect={onCreateBrowser}
             />
           ) : null}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            testID="workspace-new-tab-menu-vertical-tabs"
+            leading={verticalTabsLeading}
+            onSelect={handleToggleVerticalTabs}
+          >
+            {t("workspace.tabs.actions.verticalTabs")}
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel>{t("workspace.tabs.actions.terminalProfilesMenu")}</DropdownMenuLabel>
           {profiles.map((profile) => (
@@ -434,6 +462,9 @@ interface WorkspaceDesktopTabsRowProps {
   onReorderTabs: (nextTabs: WorkspaceTabDescriptor[]) => void;
   onSplitRight: () => void;
   onSplitDown: () => void;
+  tabBarOrientation?: "horizontal" | "vertical";
+  verticalTabsSelected?: boolean;
+  onVerticalTabsChange?: (selected: boolean) => void;
   externalDndContext?: boolean;
   activeDragTabId?: string | null;
   tabDropPreviewIndex?: number | null;
@@ -529,6 +560,7 @@ function TabChip({
   presentation,
   tooltipLabel,
   resolvedTab,
+  orientation,
   setHoveredCloseTabKey,
   onNavigateTab,
   onCloseTab,
@@ -546,6 +578,7 @@ function TabChip({
   presentation: WorkspaceTabPresentation;
   tooltipLabel: string;
   resolvedTab: WorkspaceDesktopTabActions;
+  orientation: "horizontal" | "vertical";
   setHoveredCloseTabKey: Dispatch<SetStateAction<string | null>>;
   onNavigateTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
@@ -571,6 +604,7 @@ function TabChip({
   const tabChipStyle = useCallback(
     () => [
       styles.tab,
+      orientation === "vertical" && styles.tabVertical,
       isWeb && isDragging && ({ cursor: "grabbing" } as object),
       {
         minWidth: resolvedTabWidth,
@@ -578,7 +612,7 @@ function TabChip({
         maxWidth: resolvedTabWidth,
       },
     ],
-    [isDragging, resolvedTabWidth],
+    [isDragging, orientation, resolvedTabWidth],
   );
 
   const handleTabHoverIn = useCallback(() => {
@@ -624,8 +658,12 @@ function TabChip({
 
   const tabAccessibilityState = useMemo(() => ({ selected: isActive }), [isActive]);
   const tabFocusIndicatorStyle = useMemo(
-    () => [styles.tabFocusIndicator, !isFocused && styles.tabFocusIndicatorUnfocused],
-    [isFocused],
+    () => [
+      styles.tabFocusIndicator,
+      orientation === "vertical" && styles.tabFocusIndicatorVertical,
+      !isFocused && styles.tabFocusIndicatorUnfocused,
+    ],
+    [isFocused, orientation],
   );
   const tabLabelSkeletonStyle = useMemo(
     () => [styles.tabLabelSkeleton, showCloseButton && styles.tabLabelSkeletonWithCloseButton],
@@ -702,7 +740,11 @@ function TabChip({
               ) : null}
             </ContextMenuTrigger>
           </TooltipTrigger>
-          <TooltipContent side="bottom" align="center" offset={8}>
+          <TooltipContent
+            side={orientation === "vertical" ? "right" : "bottom"}
+            align="center"
+            offset={8}
+          >
             {tab.target.kind === "agent" ? (
               <View style={styles.tooltipAgentRow}>
                 <Text style={styles.newTabTooltipText}>{tooltipLabel}</Text>
@@ -754,6 +796,9 @@ export function WorkspaceDesktopTabsRow({
   onReorderTabs,
   onSplitRight,
   onSplitDown,
+  tabBarOrientation = "horizontal",
+  verticalTabsSelected = false,
+  onVerticalTabsChange,
   externalDndContext = false,
   activeDragTabId = null,
   tabDropPreviewIndex = null,
@@ -767,6 +812,7 @@ export function WorkspaceDesktopTabsRow({
   const [tabsContainerWidth, setTabsContainerWidth] = useState<number>(0);
   const [tabsActionsWidth, setTabsActionsWidth] = useState<number>(0);
   const [inlineAddButtonWidth, setInlineAddButtonWidth] = useState<number>(0);
+  const isVertical = tabBarOrientation === "vertical";
 
   const handleTabsContainerLayout = useCallback((event: LayoutChangeEvent) => {
     updateMeasuredWidth(setTabsContainerWidth, event);
@@ -833,11 +879,24 @@ export function WorkspaceDesktopTabsRow({
     [fallbackTabLabels, tabs],
   );
 
-  const { layout } = useWorkspaceTabLayout({
+  const { layout: horizontalLayout } = useWorkspaceTabLayout({
     tabLabelLengths,
     viewportWidthOverride: tabsContainerWidth > 0 ? tabsContainerWidth : null,
     metrics: layoutMetrics,
   });
+  const verticalLayout = useMemo(
+    () => ({
+      items: tabLabelLengths.map(() => ({
+        width: Math.max(60, Math.min(200, tabsContainerWidth || 200)),
+        showLabel: true,
+        labelCharCap: Number.POSITIVE_INFINITY,
+      })),
+      closeButtonPolicy: "all" as const,
+      requiresHorizontalScrollFallback: false,
+    }),
+    [tabLabelLengths, tabsContainerWidth],
+  );
+  const layout = isVertical ? verticalLayout : horizontalLayout;
 
   const handleDragEnd = useCallback(
     (nextTabs: WorkspaceDesktopTabRowItem[]) => {
@@ -879,6 +938,12 @@ export function WorkspaceDesktopTabsRow({
   }, [onCreateBrowserTab, paneId]);
 
   const terminalDisabled = disableCreateTerminal || isWaitingOnTerminalReadiness;
+  const handleVerticalTabsChange = useCallback(
+    (selected: boolean) => {
+      onVerticalTabsChange?.(selected);
+    },
+    [onVerticalTabsChange],
+  );
 
   const renderTab = useCallback(
     ({
@@ -923,6 +988,7 @@ export function WorkspaceDesktopTabsRow({
           onCloseTab={onCloseTab}
           labels={tabMenuLabels}
           dragHandleProps={dragHandleProps}
+          orientation={tabBarOrientation}
           showDropIndicatorBefore={showDropIndicatorBefore}
           showDropIndicatorAfter={showDropIndicatorAfter}
         />
@@ -946,6 +1012,7 @@ export function WorkspaceDesktopTabsRow({
       onReloadAgent,
       onRenameTab,
       setHoveredCloseTabKey,
+      tabBarOrientation,
       tabMenuLabels,
       tabDropPreviewIndex,
       tabs.length,
@@ -955,26 +1022,40 @@ export function WorkspaceDesktopTabsRow({
   const tabsScrollStyle = useMemo(
     () => [
       styles.tabsScroll,
+      isVertical && styles.tabsScrollVertical,
       layout.requiresHorizontalScrollFallback
         ? styles.tabsScrollOverflow
         : styles.tabsScrollFitContent,
     ],
-    [layout.requiresHorizontalScrollFallback],
+    [isVertical, layout.requiresHorizontalScrollFallback],
+  );
+  const tabsContainerStyle = useMemo(
+    () => [styles.tabsContainer, isVertical && styles.tabsContainerVertical],
+    [isVertical],
+  );
+  const tabsContentStyle = useMemo(
+    () => [styles.tabsContent, isVertical && styles.tabsContentVertical],
+    [isVertical],
+  );
+  const tabsActionsStyle = useMemo(
+    () => [styles.tabsActions, isVertical && styles.tabsActionsVertical],
+    [isVertical],
   );
 
   const row = (
     <View
-      style={styles.tabsContainer}
+      style={tabsContainerStyle}
       testID="workspace-tabs-row"
       onLayout={handleTabsContainerLayout}
     >
       <ScrollView
-        horizontal
-        scrollEnabled={layout.requiresHorizontalScrollFallback}
+        horizontal={!isVertical}
+        scrollEnabled={isVertical || layout.requiresHorizontalScrollFallback}
         testID="workspace-tabs-scroll"
         style={tabsScrollStyle}
-        contentContainerStyle={styles.tabsContent}
+        contentContainerStyle={tabsContentStyle}
         showsHorizontalScrollIndicator={false}
+        showsVerticalScrollIndicator={false}
       >
         <SortableInlineList
           data={tabs}
@@ -985,15 +1066,25 @@ export function WorkspaceDesktopTabsRow({
           externalDndContext={externalDndContext}
           activeId={activeDragTabId}
           getItemData={getTabDragData}
+          orientation={tabBarOrientation}
           renderItem={renderTab}
         />
-        <WorkspaceInlineAddTabButton
-          shortcutKeys={newTabKeys}
-          onCreateAgentTab={handleCreateAgentTab}
-          onLayout={handleInlineAddButtonLayout}
-        />
+        {isVertical ? null : (
+          <WorkspaceInlineAddTabButton
+            shortcutKeys={newTabKeys}
+            onCreateAgentTab={handleCreateAgentTab}
+            onLayout={handleInlineAddButtonLayout}
+          />
+        )}
       </ScrollView>
-      <View style={styles.tabsActions} onLayout={handleTabsActionsLayout}>
+      <View style={tabsActionsStyle} onLayout={handleTabsActionsLayout}>
+        {isVertical ? (
+          <WorkspaceInlineAddTabButton
+            shortcutKeys={newTabKeys}
+            onCreateAgentTab={handleCreateAgentTab}
+            onLayout={handleInlineAddButtonLayout}
+          />
+        ) : null}
         <WorkspaceTabRowExtras
           onCreateAgentTab={handleCreateAgentTab}
           onCreateTerminal={handleCreateTerminal}
@@ -1003,6 +1094,8 @@ export function WorkspaceDesktopTabsRow({
           normalizedServerId={normalizedServerId}
           showCreateBrowserTab={showCreateBrowserTab}
           terminalDisabled={terminalDisabled}
+          verticalTabsSelected={verticalTabsSelected}
+          onVerticalTabsChange={handleVerticalTabsChange}
         />
         {showPaneSplitActions ? (
           <>
@@ -1050,6 +1143,7 @@ function ResolvedDesktopTabChip({
   onCloseTab,
   labels,
   dragHandleProps,
+  orientation,
   showDropIndicatorBefore,
   showDropIndicatorAfter,
 }: {
@@ -1076,6 +1170,7 @@ function ResolvedDesktopTabChip({
   onCloseTab: (tabId: string) => Promise<void> | void;
   labels: WorkspaceTabMenuLabels;
   dragHandleProps: DraggableListDragHandleProps | undefined;
+  orientation: "horizontal" | "vertical";
   showDropIndicatorBefore: boolean;
   showDropIndicatorAfter: boolean;
 }) {
@@ -1128,7 +1223,15 @@ function ResolvedDesktopTabChip({
 
         return (
           <View style={styles.tabSlot}>
-            {showDropIndicatorBefore ? <View style={TAB_DROP_INDICATOR_BEFORE_STYLE} /> : null}
+            {showDropIndicatorBefore ? (
+              <View
+                style={
+                  orientation === "vertical"
+                    ? TAB_DROP_INDICATOR_VERTICAL_BEFORE_STYLE
+                    : TAB_DROP_INDICATOR_BEFORE_STYLE
+                }
+              />
+            ) : null}
             <TabChip
               tab={item.tab}
               isActive={item.isActive}
@@ -1142,12 +1245,21 @@ function ResolvedDesktopTabChip({
               presentation={presentation}
               tooltipLabel={tooltipLabel}
               resolvedTab={resolvedTab}
+              orientation={orientation}
               setHoveredCloseTabKey={setHoveredCloseTabKey}
               onNavigateTab={onNavigateTab}
               onCloseTab={onCloseTab}
               dragHandleProps={dragHandleProps}
             />
-            {showDropIndicatorAfter ? <View style={TAB_DROP_INDICATOR_AFTER_STYLE} /> : null}
+            {showDropIndicatorAfter ? (
+              <View
+                style={
+                  orientation === "vertical"
+                    ? TAB_DROP_INDICATOR_VERTICAL_AFTER_STYLE
+                    : TAB_DROP_INDICATOR_AFTER_STYLE
+                }
+              />
+            ) : null}
           </View>
         );
       }}
@@ -1166,8 +1278,22 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     overflow: "visible",
   },
+  tabsContainerVertical: {
+    width: 220,
+    height: "100%",
+    minHeight: 0,
+    borderBottomWidth: 0,
+    borderRightWidth: 1,
+    borderRightColor: theme.colors.border,
+    flexDirection: "column",
+    alignItems: "stretch",
+  },
   tabsScroll: {
     minWidth: 0,
+  },
+  tabsScrollVertical: {
+    flex: 1,
+    minHeight: 0,
   },
   tabsScrollFitContent: {
     flex: 1,
@@ -1179,10 +1305,22 @@ const styles = StyleSheet.create((theme) => ({
     flexDirection: "row",
     alignItems: "stretch",
   },
+  tabsContentVertical: {
+    flexDirection: "column",
+    alignItems: "stretch",
+  },
   tabsActions: {
     flexDirection: "row",
     alignItems: "center",
     paddingHorizontal: theme.spacing[2],
+  },
+  tabsActionsVertical: {
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+    paddingHorizontal: theme.spacing[1],
+    paddingVertical: theme.spacing[1],
+    justifyContent: "flex-start",
+    flexWrap: "wrap",
   },
   inlineAddButton: {
     flexDirection: "row",
@@ -1198,6 +1336,11 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     gap: theme.spacing[1],
     userSelect: "none",
+  },
+  tabVertical: {
+    borderRightWidth: 0,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
   },
   tabSlot: {
     position: "relative",
@@ -1222,6 +1365,13 @@ const styles = StyleSheet.create((theme) => ({
     height: 2,
     backgroundColor: theme.colors.accent,
   },
+  tabFocusIndicatorVertical: {
+    top: 0,
+    bottom: 0,
+    right: undefined,
+    width: 2,
+    height: undefined,
+  },
   tabFocusIndicatorUnfocused: {
     backgroundColor: theme.colors.borderAccent,
   },
@@ -1240,6 +1390,20 @@ const styles = StyleSheet.create((theme) => ({
   },
   tabDropIndicatorAfter: {
     right: -3,
+  },
+  tabDropIndicatorVertical: {
+    left: theme.spacing[2],
+    right: theme.spacing[2],
+    height: 5,
+    width: "auto",
+  },
+  tabDropIndicatorVerticalBefore: {
+    top: -3,
+    bottom: undefined,
+  },
+  tabDropIndicatorVerticalAfter: {
+    top: undefined,
+    bottom: -3,
   },
   tabLabel: {
     flexShrink: 1,
@@ -1333,3 +1497,13 @@ const styles = StyleSheet.create((theme) => ({
 
 const TAB_DROP_INDICATOR_BEFORE_STYLE = [styles.tabDropIndicator, styles.tabDropIndicatorBefore];
 const TAB_DROP_INDICATOR_AFTER_STYLE = [styles.tabDropIndicator, styles.tabDropIndicatorAfter];
+const TAB_DROP_INDICATOR_VERTICAL_BEFORE_STYLE = [
+  styles.tabDropIndicator,
+  styles.tabDropIndicatorVertical,
+  styles.tabDropIndicatorVerticalBefore,
+];
+const TAB_DROP_INDICATOR_VERTICAL_AFTER_STYLE = [
+  styles.tabDropIndicator,
+  styles.tabDropIndicatorVertical,
+  styles.tabDropIndicatorVerticalAfter,
+];

--- a/packages/app/src/screens/workspace/workspace-pane-state.test.ts
+++ b/packages/app/src/screens/workspace/workspace-pane-state.test.ts
@@ -36,6 +36,7 @@ describe("workspace-pane-state", () => {
                 id: "left",
                 tabIds: ["file_/repo/README.md", "agent_agent-a"],
                 focusedTabId: "agent_agent-a",
+                tabBarOrientation: "horizontal",
               },
             },
             {
@@ -44,6 +45,7 @@ describe("workspace-pane-state", () => {
                 id: "right",
                 tabIds: ["terminal_term-1"],
                 focusedTabId: "terminal_term-1",
+                tabBarOrientation: "horizontal",
               },
             },
           ],
@@ -67,6 +69,7 @@ describe("workspace-pane-state", () => {
       id: "main",
       tabIds: ["draft_1", "draft_2"],
       focusedTabId: " ",
+      tabBarOrientation: "horizontal" as const,
     };
     const tabs: WorkspaceTab[] = [
       createTab("draft_2", { kind: "draft", draftId: "draft_2" }),
@@ -87,6 +90,7 @@ describe("workspace-pane-state", () => {
       id: "main",
       tabIds: ["agent_agent-a", "file_/repo/README.md"],
       focusedTabId: "agent_agent-a",
+      tabBarOrientation: "horizontal" as const,
     };
     const tabs: WorkspaceTab[] = [
       createTab("agent_agent-a", { kind: "agent", agentId: "agent-a" }),
@@ -114,6 +118,7 @@ describe("workspace-pane-state", () => {
           id: "main",
           tabIds: ["file_/repo/README.md"],
           focusedTabId: "file_/repo/README.md",
+          tabBarOrientation: "horizontal",
         },
       },
       focusedPaneId: "main",
@@ -138,6 +143,7 @@ describe("workspace-pane-state", () => {
           id: "main",
           tabIds: ["file_/repo/README.md"],
           focusedTabId: "file_/repo/README.md",
+          tabBarOrientation: "horizontal",
         },
       },
       focusedPaneId: "main",
@@ -165,11 +171,21 @@ describe("workspace-pane-state", () => {
           children: [
             {
               kind: "pane",
-              pane: { id: "left", tabIds: ["agent_agent-a"], focusedTabId: "agent_agent-a" },
+              pane: {
+                id: "left",
+                tabIds: ["agent_agent-a"],
+                focusedTabId: "agent_agent-a",
+                tabBarOrientation: "horizontal",
+              },
             },
             {
               kind: "pane",
-              pane: { id: "right", tabIds: [], focusedTabId: null },
+              pane: {
+                id: "right",
+                tabIds: [],
+                focusedTabId: null,
+                tabBarOrientation: "horizontal",
+              },
             },
           ],
         },
@@ -191,7 +207,12 @@ describe("workspace-pane-state", () => {
     const layout: WorkspaceLayout = {
       root: {
         kind: "pane",
-        pane: { id: "main", tabIds: ["agent_agent-a"], focusedTabId: "agent_agent-a" },
+        pane: {
+          id: "main",
+          tabIds: ["agent_agent-a"],
+          focusedTabId: "agent_agent-a",
+          tabBarOrientation: "horizontal",
+        },
       },
       focusedPaneId: "main",
     };

--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -13,7 +13,10 @@ export interface SplitPane {
   id: string;
   tabIds: string[];
   focusedTabId: string | null;
+  tabBarOrientation: WorkspaceTabBarOrientation;
 }
+
+export type WorkspaceTabBarOrientation = "horizontal" | "vertical";
 
 export interface SplitGroup {
   id: string;
@@ -191,6 +194,12 @@ interface ReorderPaneTabsInLayoutInput {
   tabIds: string[];
 }
 
+interface SetPaneTabBarOrientationInLayoutInput {
+  layout: WorkspaceLayout;
+  paneId: string;
+  orientation: WorkspaceTabBarOrientation;
+}
+
 export interface WorkspaceTabReconcileState {
   layout: WorkspaceLayout;
   pinnedAgentIds?: ReadonlySet<string> | null;
@@ -239,6 +248,7 @@ function createPaneNode(input: {
   id: string;
   tabs?: WorkspaceTab[];
   focusedTabId?: string | null;
+  tabBarOrientation?: WorkspaceTabBarOrientation;
 }): SplitNodeInternal {
   const normalizedTabs = normalizeWorkspaceTabs(input.tabs ?? []);
   const tabIds = normalizedTabs.map((tab) => tab.tabId);
@@ -253,8 +263,13 @@ function createPaneNode(input: {
       tabs: normalizedTabs,
       tabIds,
       focusedTabId,
+      tabBarOrientation: input.tabBarOrientation ?? "horizontal",
     },
   };
+}
+
+function normalizeTabBarOrientation(value: unknown): WorkspaceTabBarOrientation {
+  return value === "vertical" ? "vertical" : "horizontal";
 }
 
 function createGroupNode(input: {
@@ -556,6 +571,7 @@ function normalizePaneAfterTabChange(pane: SplitPaneInternal): SplitPaneInternal
     tabs,
     tabIds,
     focusedTabId,
+    tabBarOrientation: pane.tabBarOrientation,
   };
 }
 
@@ -578,6 +594,7 @@ function normalizePaneNode(rawPane: SplitPaneInternal | undefined): SplitNodeInt
     id: paneId,
     tabs: mergedTabs,
     focusedTabId: trimNonEmpty(rawPane?.focusedTabId) ?? null,
+    tabBarOrientation: normalizeTabBarOrientation(rawPane?.tabBarOrientation),
   });
 }
 
@@ -969,6 +986,20 @@ export function collectAllPanes(root: SplitNode): SplitPane[] {
     return [internalRoot.pane];
   }
   return internalRoot.group.children.flatMap((child) => collectAllPanes(child));
+}
+
+export function findTopLeftPaneId(root: SplitNode): string | null {
+  const internalRoot = asInternalNode(root);
+  if (internalRoot.kind === "pane") {
+    return internalRoot.pane.id;
+  }
+  for (const child of internalRoot.group.children) {
+    const paneId = findTopLeftPaneId(child);
+    if (paneId) {
+      return paneId;
+    }
+  }
+  return null;
 }
 
 export function getFocusedBrowserId(layout: WorkspaceLayout | null | undefined): string | null {
@@ -1457,6 +1488,31 @@ export function reorderPaneTabsInLayout(
     root: updatePaneInTree(layout.root, {
       paneId: input.paneId,
       updater: (pane) => reorderTabsForPane({ pane, tabIds: input.tabIds }),
+    }),
+    focusedPaneId: layout.focusedPaneId,
+    parentTabIdByTabId: input.layout.parentTabIdByTabId,
+  });
+}
+
+export function setPaneTabBarOrientationInLayout(
+  input: SetPaneTabBarOrientationInLayoutInput,
+): WorkspaceLayout | null {
+  const layout = asInternalLayout(input.layout);
+  const pane = findPaneById(layout.root, input.paneId);
+  if (!pane) {
+    return null;
+  }
+  if (pane.tabBarOrientation === input.orientation) {
+    return null;
+  }
+
+  return withNormalizedParentTabMap({
+    root: updatePaneInTree(layout.root, {
+      paneId: input.paneId,
+      updater: (currentPane) => ({
+        ...currentPane,
+        tabBarOrientation: input.orientation,
+      }),
     }),
     focusedPaneId: layout.focusedPaneId,
     parentTabIdByTabId: input.layout.parentTabIdByTabId,

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -24,13 +24,16 @@ import {
   createDefaultLayout,
   findPaneById,
   findPaneContainingTab,
+  findTopLeftPaneId,
   getFocusedBrowserId,
   getTreeDepth,
   insertSplit,
+  normalizeLayout,
   removePaneFromTree,
   removeTabFromTree,
   type SplitNode,
   type SplitPane,
+  type WorkspaceTabBarOrientation,
 } from "@/stores/workspace-layout-store";
 
 const SERVER_ID = "server-1";
@@ -82,6 +85,7 @@ function createPane(input: {
   id: string;
   tabIds: string[];
   focusedTabId?: string | null;
+  tabBarOrientation?: WorkspaceTabBarOrientation;
   targetsByTabId?: Record<string, WorkspaceTab["target"]>;
 }): SplitNode {
   const tabs = input.tabIds.map((tabId) => createTab(tabId, input.targetsByTabId?.[tabId]));
@@ -91,6 +95,7 @@ function createPane(input: {
       id: input.id,
       tabIds: input.tabIds,
       focusedTabId: input.focusedTabId ?? input.tabIds[input.tabIds.length - 1] ?? null,
+      tabBarOrientation: input.tabBarOrientation ?? "horizontal",
       tabs,
     } as SplitPane,
   };
@@ -150,6 +155,35 @@ describe("workspace-layout-store helpers", () => {
       "tab-c",
       "tab-d",
     ]);
+    expect(findTopLeftPaneId(root)).toBe("left");
+  });
+
+  it("finds the top-left pane through nested split groups", () => {
+    const root: SplitNode = {
+      kind: "group",
+      group: {
+        id: "group-root",
+        direction: "vertical",
+        sizes: [0.5, 0.5],
+        children: [
+          {
+            kind: "group",
+            group: {
+              id: "group-top",
+              direction: "horizontal",
+              sizes: [0.4, 0.6],
+              children: [
+                createPane({ id: "top-left", tabIds: ["tab-a"] }),
+                createPane({ id: "top-right", tabIds: ["tab-b"] }),
+              ],
+            },
+          },
+          createPane({ id: "bottom", tabIds: ["tab-c"] }),
+        ],
+      },
+    };
+
+    expect(findTopLeftPaneId(root)).toBe("top-left");
   });
 
   it("derives the focused browser id from the focused pane active tab", () => {
@@ -309,6 +343,7 @@ describe("workspace-layout-store actions", () => {
     workspaceLayoutStore.setState({
       layoutByWorkspace: {},
       splitSizesByWorkspace: {},
+      topLeftPaneTabBarOrientation: "horizontal",
       pinnedAgentIdsByWorkspace: {},
       hiddenAgentIdsByWorkspace: {},
       focusRestorationByWorkspace: {},
@@ -829,6 +864,7 @@ describe("workspace-layout-store actions", () => {
       id: "main",
       tabIds: [thirdTabId!, firstTabId!, secondTabId!],
       focusedTabId: thirdTabId,
+      tabBarOrientation: "horizontal",
       tabs: [
         {
           tabId: thirdTabId,
@@ -884,6 +920,7 @@ describe("workspace-layout-store actions", () => {
       id: splitPaneId,
       tabIds: [fourthTabId!, thirdTabId!],
       focusedTabId: fourthTabId,
+      tabBarOrientation: "horizontal",
       tabs: [
         {
           tabId: fourthTabId,
@@ -1182,6 +1219,79 @@ describe("workspace-layout-store actions", () => {
     expect(layout).toEqual(createDefaultLayout());
   });
 
+  it("defaults legacy persisted panes to horizontal tabs", () => {
+    const legacyLayout = {
+      root: {
+        kind: "pane",
+        pane: {
+          id: "legacy-pane",
+          tabIds: [],
+          focusedTabId: null,
+        },
+      },
+      focusedPaneId: "legacy-pane",
+    } as unknown as Parameters<typeof normalizeLayout>[0];
+
+    const layout = normalizeLayout(legacyLayout);
+
+    expect(findPaneById(layout.root, "legacy-pane")?.tabBarOrientation).toBe("horizontal");
+  });
+
+  it("persists vertical tabs per non-top-left pane", () => {
+    useWorkspaceLayoutIds("12121212-1212-1212-1212-121212121212");
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    const tabId = store.openTabFocused(workspaceKey, { kind: "draft", draftId: "draft-1" });
+    const rightPaneId = store.splitPane(workspaceKey, {
+      tabId: tabId!,
+      targetPaneId: "main",
+      position: "right",
+    });
+
+    store.setPaneTabBarOrientation(workspaceKey, rightPaneId!, "vertical");
+
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+    expect(findPaneById(layout.root, "main")?.tabBarOrientation).toBe("horizontal");
+    expect(findPaneById(layout.root, rightPaneId!)?.tabBarOrientation).toBe("vertical");
+    expect(workspaceLayoutStore.getState().topLeftPaneTabBarOrientation).toBe("horizontal");
+  });
+
+  it("shares vertical tabs for the top-left pane across workspaces", () => {
+    const workspaceKey = createWorkspaceKey();
+    const otherWorkspaceKey = buildWorkspaceTabPersistenceKey({
+      serverId: SERVER_ID,
+      workspaceId: "ws-other-worktree",
+    });
+
+    expect(otherWorkspaceKey).toBeTruthy();
+
+    const store = workspaceLayoutStore.getState();
+    store.setPaneTabBarOrientation(workspaceKey, "main", "vertical");
+
+    expect(workspaceLayoutStore.getState().topLeftPaneTabBarOrientation).toBe("vertical");
+    expect(workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey]).toBeUndefined();
+
+    store.openTabFocused(otherWorkspaceKey as string, { kind: "draft", draftId: "other-draft" });
+    const otherLayout =
+      workspaceLayoutStore.getState().layoutByWorkspace[otherWorkspaceKey as string];
+
+    expect(findTopLeftPaneId(otherLayout.root)).toBe("main");
+    expect(workspaceLayoutStore.getState().topLeftPaneTabBarOrientation).toBe("vertical");
+  });
+
+  it("does not clear the shared top-left tab orientation when purging a workspace", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    store.setPaneTabBarOrientation(workspaceKey, "main", "vertical");
+    store.openTabFocused(workspaceKey, { kind: "draft", draftId: "draft-1" });
+    store.purgeWorkspace(workspaceKey);
+
+    expect(workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey]).toBeUndefined();
+    expect(workspaceLayoutStore.getState().topLeftPaneTabBarOrientation).toBe("vertical");
+  });
+
   it("keeps pinned archived agents in memory per workspace without persisting them", () => {
     const workspaceKey = createWorkspaceKey();
     const otherWorkspaceKey = buildWorkspaceTabPersistenceKey({
@@ -1215,6 +1325,7 @@ describe("workspace-layout-store actions", () => {
     expect(partialize?.(state)).toEqual({
       layoutByWorkspace: {},
       splitSizesByWorkspace: {},
+      topLeftPaneTabBarOrientation: "horizontal",
     });
   });
 
@@ -1251,6 +1362,7 @@ describe("workspace-layout-store actions", () => {
     expect(partialize?.(state)).toEqual({
       layoutByWorkspace: {},
       splitSizesByWorkspace: {},
+      topLeftPaneTabBarOrientation: "horizontal",
     });
   });
 
@@ -1294,6 +1406,7 @@ describe("workspace-layout-store actions", () => {
               id: "main",
               tabIds: ["draft_agent", "agent_agent-1", "terminal_orphan", "draft-1"],
               focusedTabId: "draft_agent",
+              tabBarOrientation: "horizontal",
               tabs: [
                 {
                   tabId: "draft_agent",
@@ -1368,6 +1481,7 @@ describe("workspace-layout-store actions", () => {
               id: "main",
               tabIds: ["draft-agent"],
               focusedTabId: "draft-agent",
+              tabBarOrientation: "horizontal",
               tabs: [
                 {
                   tabId: "draft-agent",

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -20,6 +20,7 @@ import {
   createDefaultLayout,
   findPaneById,
   findPaneContainingTab,
+  findTopLeftPaneId,
   focusPaneInLayout,
   focusTabInLayout,
   getFocusedBrowserId,
@@ -35,11 +36,13 @@ import {
   reorderFocusedPaneTabsInLayout,
   reorderPaneTabsInLayout,
   retargetTabInLayout,
+  setPaneTabBarOrientationInLayout,
   splitPaneEmptyInLayout,
   splitPaneInLayout,
   type SplitGroup,
   type SplitNode,
   type SplitPane,
+  type WorkspaceTabBarOrientation,
   type WorkspaceTabReconcileState,
   type WorkspaceTabSnapshot,
   type WorkspaceLayout,
@@ -53,6 +56,7 @@ export {
   createDefaultLayout,
   findPaneById,
   findPaneContainingTab,
+  findTopLeftPaneId,
   getFocusedBrowserId,
   getTreeDepth,
   insertSplit,
@@ -64,6 +68,7 @@ export type {
   SplitGroup,
   SplitNode,
   SplitPane,
+  WorkspaceTabBarOrientation,
   WorkspaceLayout,
   WorkspaceTabReconcileState,
   WorkspaceTabSnapshot,
@@ -72,6 +77,7 @@ export type {
 interface WorkspaceLayoutStore {
   layoutByWorkspace: Record<string, WorkspaceLayout>;
   splitSizesByWorkspace: Record<string, Record<string, number[]>>;
+  topLeftPaneTabBarOrientation: WorkspaceTabBarOrientation;
   pinnedAgentIdsByWorkspace: Record<string, Set<string>>;
   hiddenAgentIdsByWorkspace: Record<string, Set<string>>;
   focusRestorationByWorkspace: Record<string, WorkspaceFocusRestorationState>;
@@ -109,6 +115,11 @@ interface WorkspaceLayoutStore {
   unfocusPane: (workspaceKey: string) => string | null;
   restorePaneFocus: (workspaceKey: string, token: string) => void;
   resizeSplit: (workspaceKey: string, groupId: string, sizes: number[]) => void;
+  setPaneTabBarOrientation: (
+    workspaceKey: string,
+    paneId: string,
+    orientation: WorkspaceTabBarOrientation,
+  ) => void;
   reorderTabsInPane: (workspaceKey: string, paneId: string, tabIds: string[]) => void;
   pinAgent: (workspaceKey: string, agentId: string) => void;
   unpinAgent: (workspaceKey: string, agentId: string) => void;
@@ -226,6 +237,7 @@ export function createWorkspaceLayoutStore(
       (set, get) => ({
         layoutByWorkspace: {},
         splitSizesByWorkspace: {},
+        topLeftPaneTabBarOrientation: "horizontal",
         pinnedAgentIdsByWorkspace: {},
         hiddenAgentIdsByWorkspace: {},
         focusRestorationByWorkspace: {},
@@ -724,6 +736,45 @@ export function createWorkspaceLayoutStore(
             },
           }));
         },
+        setPaneTabBarOrientation: (workspaceKey, paneId, orientation) => {
+          const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
+          const normalizedPaneId = trimNonEmpty(paneId);
+          if (!normalizedWorkspaceKey || !normalizedPaneId) {
+            return;
+          }
+
+          set((state) => {
+            const layout = getWorkspaceLayout(state.layoutByWorkspace, normalizedWorkspaceKey);
+            if (!findPaneById(layout.root, normalizedPaneId)) {
+              return state;
+            }
+
+            if (findTopLeftPaneId(layout.root) === normalizedPaneId) {
+              if (state.topLeftPaneTabBarOrientation === orientation) {
+                return state;
+              }
+              return {
+                topLeftPaneTabBarOrientation: orientation,
+              };
+            }
+
+            const nextLayout = setPaneTabBarOrientationInLayout({
+              layout,
+              paneId: normalizedPaneId,
+              orientation,
+            });
+            if (!nextLayout) {
+              return state;
+            }
+
+            return {
+              layoutByWorkspace: {
+                ...state.layoutByWorkspace,
+                [normalizedWorkspaceKey]: nextLayout,
+              },
+            };
+          });
+        },
         reorderTabsInPane: (workspaceKey, paneId, tabIds) => {
           const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
           const normalizedPaneId = trimNonEmpty(paneId);
@@ -907,6 +958,7 @@ export function createWorkspaceLayoutStore(
           return {
             layoutByWorkspace,
             splitSizesByWorkspace: state.splitSizesByWorkspace,
+            topLeftPaneTabBarOrientation: state.topLeftPaneTabBarOrientation,
           };
         },
       },

--- a/packages/app/src/utils/split-navigation.test.ts
+++ b/packages/app/src/utils/split-navigation.test.ts
@@ -9,6 +9,7 @@ function createPaneNode(id: string): SplitNode {
       id,
       tabIds: [],
       focusedTabId: null,
+      tabBarOrientation: "horizontal",
     },
   };
 }


### PR DESCRIPTION
## Summary
- Adds per-pane vertical tab bar orientation support for workspace panes
- Updates split-container drag/drop behavior, pane state, translations, and layout tests
- Tidies the tab menu item alignment after review

## Validation
- Branch review agent ran focused tests plus repo typecheck/lint/format before the rebase
- Rebased onto origin/main and verified the final diff scope
