### PR TITLE
[codex] Add prompt scroll indicators

### DIFF
--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -550,7 +550,7 @@ describe("createWebStreamStrategy", () => {
     });
 
     expect(HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
-      top: 302,
+      top: 305,
       behavior: "auto",
     });
   });
@@ -575,7 +575,7 @@ describe("createWebStreamStrategy", () => {
     });
 
     expect(HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
-      top: 270,
+      top: 273,
       behavior: "auto",
     });
   });

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -36,6 +36,15 @@ function userMessage(index: number): StreamItem {
   };
 }
 
+function assistantMessage(index: number): StreamItem {
+  return {
+    kind: "assistant_message",
+    id: `assistant-${index}`,
+    text: `Assistant ${index}`,
+    timestamp: new Date(`2026-04-20T00:01:${String(index % 60).padStart(2, "0")}.000Z`),
+  };
+}
+
 const VIRTUAL_ROW_STYLE = { height: 24 };
 
 function createRenderers(onRowRender: () => void): StreamSegmentRenderers {
@@ -48,6 +57,99 @@ function createRenderers(onRowRender: () => void): StreamSegmentRenderers {
     renderLiveHeadRow: (item) => <div>{item.id}</div>,
     renderLiveAuxiliary: () => null,
   };
+}
+
+function renderViewport(input: {
+  root: Root;
+  isMobileBreakpoint?: boolean;
+  historyVirtualized?: StreamItem[];
+  historyMounted?: StreamItem[];
+  liveHead?: StreamItem[];
+  onNearHistoryStart?: () => void;
+}) {
+  const strategy = createWebStreamStrategy({
+    isMobileBreakpoint: input.isMobileBreakpoint ?? false,
+  });
+  const viewportRef = React.createRef<StreamViewportHandle>();
+  const historyVirtualized = input.historyVirtualized ?? [];
+  const historyMounted = input.historyMounted ?? [];
+  const liveHead = input.liveHead ?? [];
+
+  act(() => {
+    input.root.render(
+      <>
+        {strategy.render({
+          agentId: "agent",
+          segments: {
+            historyVirtualized,
+            historyMounted,
+            liveHead,
+          },
+          boundary: {
+            hasVirtualizedHistory: historyVirtualized.length > 0,
+            hasMountedHistory: historyMounted.length > 0,
+            hasLiveHead: liveHead.length > 0,
+          },
+          renderers: createRenderers(vi.fn()),
+          listEmptyComponent: null,
+          viewportRef,
+          routeBottomAnchorRequest: null,
+          isAuthoritativeHistoryReady: true,
+          onNearBottomChange: vi.fn(),
+          onNearHistoryStart: input.onNearHistoryStart ?? vi.fn(),
+          isLoadingOlderHistory: false,
+          hasOlderHistory: Boolean(input.onNearHistoryStart),
+          scrollEnabled: true,
+          listStyle: null,
+          baseListContentContainerStyle: null,
+          forwardListContentContainerStyle: null,
+        })}
+      </>,
+    );
+  });
+
+  return viewportRef;
+}
+
+function setScrollableMetrics(input: {
+  scrollContainer: Element;
+  viewportHeight: number;
+  contentHeight: number;
+  scrollTop?: number;
+}) {
+  Object.defineProperty(input.scrollContainer, "clientHeight", {
+    configurable: true,
+    value: input.viewportHeight,
+  });
+  Object.defineProperty(input.scrollContainer, "scrollHeight", {
+    configurable: true,
+    value: input.contentHeight,
+  });
+  Object.defineProperty(input.scrollContainer, "scrollTop", {
+    configurable: true,
+    value: input.scrollTop ?? 0,
+  });
+}
+
+function setElementOffsetTop(element: Element, offsetTop: number) {
+  Object.defineProperty(element, "offsetTop", {
+    configurable: true,
+    value: offsetTop,
+  });
+}
+
+function refreshScrollMetrics(scrollContainer: Element) {
+  act(() => {
+    scrollContainer.dispatchEvent(new Event("scroll"));
+  });
+}
+
+function getRequiredElement(parent: ParentNode, selector: string): HTMLElement {
+  const element = parent.querySelector(selector);
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Expected ${selector} to match an HTMLElement`);
+  }
+  return element;
 }
 
 describe("createWebStreamStrategy", () => {
@@ -204,5 +306,126 @@ describe("createWebStreamStrategy", () => {
     });
 
     expect(onNearHistoryStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders one desktop marker for each loaded user prompt", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    renderViewport({
+      root,
+      historyMounted: [userMessage(1), assistantMessage(1), userMessage(2)],
+      liveHead: [userMessage(3)],
+    });
+
+    const scrollContainer = getRequiredElement(container, '[data-testid="agent-chat-scroll"]');
+    setScrollableMetrics({ scrollContainer, viewportHeight: 400, contentHeight: 1200 });
+    for (const [index, anchor] of Array.from(
+      container.querySelectorAll("[data-stream-item-id]"),
+    ).entries()) {
+      setElementOffsetTop(anchor, index * 160);
+    }
+    refreshScrollMetrics(scrollContainer);
+
+    expect(container.querySelectorAll("[data-testid^='prompt-scroll-marker-']")).toHaveLength(3);
+  });
+
+  it("does not render prompt markers on compact web", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    renderViewport({
+      root,
+      isMobileBreakpoint: true,
+      historyMounted: [userMessage(1), userMessage(2)],
+    });
+
+    const scrollContainer = getRequiredElement(container, '[data-testid="agent-chat-scroll"]');
+    setScrollableMetrics({ scrollContainer, viewportHeight: 400, contentHeight: 1200 });
+    refreshScrollMetrics(scrollContainer);
+
+    expect(container.querySelector("[data-testid='prompt-marker-rail']")).toBeNull();
+  });
+
+  it("reveals a user prompt preview while hovering a marker", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    renderViewport({
+      root,
+      historyMounted: [userMessage(1)],
+    });
+
+    const scrollContainer = getRequiredElement(container, '[data-testid="agent-chat-scroll"]');
+    setScrollableMetrics({ scrollContainer, viewportHeight: 400, contentHeight: 1200 });
+    const anchor = getRequiredElement(container, "[data-stream-item-id='message-1']");
+    setElementOffsetTop(anchor, 240);
+    refreshScrollMetrics(scrollContainer);
+
+    const marker = getRequiredElement(container, "[data-testid='prompt-scroll-marker-message-1']");
+    const preview = getRequiredElement(
+      container,
+      "[data-testid='prompt-scroll-preview-message-1']",
+    );
+    expect(preview.style.opacity).toBe("0");
+
+    act(() => {
+      marker.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+
+    expect(preview.style.opacity).toBe("1");
+    expect(preview.textContent).toBe("Message 1");
+  });
+
+  it("scrolls a mounted prompt to the top when its marker is clicked", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    renderViewport({
+      root,
+      historyMounted: [userMessage(1), userMessage(2)],
+    });
+
+    const scrollContainer = getRequiredElement(container, '[data-testid="agent-chat-scroll"]');
+    setScrollableMetrics({ scrollContainer, viewportHeight: 400, contentHeight: 1200 });
+    const anchor = getRequiredElement(container, "[data-stream-item-id='message-2']");
+    setElementOffsetTop(anchor, 320);
+    refreshScrollMetrics(scrollContainer);
+    vi.mocked(HTMLElement.prototype.scrollTo).mockClear();
+
+    const marker = getRequiredElement(container, "[data-testid='prompt-scroll-marker-message-2']");
+    act(() => {
+      marker.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
+      top: 320,
+      behavior: "auto",
+    });
+  });
+
+  it("scrolls a virtualized prompt using the virtualizer offset", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    renderViewport({
+      root,
+      historyVirtualized: Array.from({ length: 8 }, (_, index) => userMessage(index)),
+    });
+
+    const scrollContainer = getRequiredElement(container, '[data-testid="agent-chat-scroll"]');
+    setScrollableMetrics({ scrollContainer, viewportHeight: 400, contentHeight: 1600 });
+    refreshScrollMetrics(scrollContainer);
+    vi.mocked(HTMLElement.prototype.scrollTo).mockClear();
+
+    const marker = getRequiredElement(container, "[data-testid='prompt-scroll-marker-message-3']");
+    act(() => {
+      marker.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
+      top: 288,
+      behavior: "auto",
+    });
   });
 });

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -9,6 +9,10 @@ import type { StreamItem } from "@/types/stream";
 import type { StreamSegmentRenderers, StreamViewportHandle } from "./strategy";
 import { createWebStreamStrategy } from "./strategy-web";
 
+const mockSettingsState = vi.hoisted(() => ({
+  promptScrollMarkers: true,
+}));
+
 vi.hoisted(() => {
   Object.defineProperty(window, "matchMedia", {
     configurable: true,
@@ -24,6 +28,14 @@ vi.hoisted(() => {
     }),
   });
 });
+
+vi.mock("@/hooks/use-settings", () => ({
+  useAppSettings: () => ({
+    settings: {
+      promptScrollMarkers: mockSettingsState.promptScrollMarkers,
+    },
+  }),
+}));
 
 vi.mock("@/components/use-web-scrollbar", () => ({ useWebElementScrollbar: () => null }));
 
@@ -62,6 +74,7 @@ function createRenderers(onRowRender: () => void): StreamSegmentRenderers {
 function renderViewport(input: {
   root: Root;
   isMobileBreakpoint?: boolean;
+  promptScrollMarkers?: boolean;
   historyVirtualized?: StreamItem[];
   historyMounted?: StreamItem[];
   liveHead?: StreamItem[];
@@ -74,6 +87,7 @@ function renderViewport(input: {
   const historyVirtualized = input.historyVirtualized ?? [];
   const historyMounted = input.historyMounted ?? [];
   const liveHead = input.liveHead ?? [];
+  mockSettingsState.promptScrollMarkers = input.promptScrollMarkers ?? true;
 
   act(() => {
     input.root.render(
@@ -337,6 +351,23 @@ describe("createWebStreamStrategy", () => {
     renderViewport({
       root,
       isMobileBreakpoint: true,
+      historyMounted: [userMessage(1), userMessage(2)],
+    });
+
+    const scrollContainer = getRequiredElement(container, '[data-testid="agent-chat-scroll"]');
+    setScrollableMetrics({ scrollContainer, viewportHeight: 400, contentHeight: 1200 });
+    refreshScrollMetrics(scrollContainer);
+
+    expect(container.querySelector("[data-testid='prompt-marker-rail']")).toBeNull();
+  });
+
+  it("does not render prompt markers when the appearance setting is disabled", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    renderViewport({
+      root,
+      promptScrollMarkers: false,
       historyMounted: [userMessage(1), userMessage(2)],
     });
 

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -39,11 +39,11 @@ vi.mock("@/hooks/use-settings", () => ({
 
 vi.mock("@/components/use-web-scrollbar", () => ({ useWebElementScrollbar: () => null }));
 
-function userMessage(index: number): StreamItem {
+function userMessage(index: number, text = `Message ${index}`): StreamItem {
   return {
     kind: "user_message",
     id: `message-${index}`,
-    text: `Message ${index}`,
+    text,
     timestamp: new Date(`2026-04-20T00:00:${String(index % 60).padStart(2, "0")}.000Z`),
   };
 }
@@ -406,6 +406,79 @@ describe("createWebStreamStrategy", () => {
 
     expect(preview.style.opacity).toBe("1");
     expect(preview.textContent).toBe("Message 1");
+  });
+
+  it("truncates long prompt previews with three periods", () => {
+    const longPrompt = `${"Outline the generation process in a diagram. ".repeat(8)}Finish here`;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    renderViewport({
+      root,
+      historyMounted: [userMessage(1, longPrompt)],
+    });
+
+    const scrollContainer = getRequiredElement(container, '[data-testid="agent-chat-scroll"]');
+    setScrollableMetrics({ scrollContainer, viewportHeight: 400, contentHeight: 1200 });
+    const anchor = getRequiredElement(container, "[data-stream-item-id='message-1']");
+    setElementOffsetTop(anchor, 240);
+    refreshScrollMetrics(scrollContainer);
+
+    const preview = getRequiredElement(
+      container,
+      "[data-testid='prompt-scroll-preview-message-1']",
+    );
+
+    expect(preview.textContent?.endsWith("...")).toBe(true);
+    expect(preview.textContent).not.toContain("Finish here");
+  });
+
+  it("keeps prompt previews padded inside the viewport edges", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    renderViewport({
+      root,
+      historyMounted: [userMessage(1)],
+    });
+
+    const scrollContainer = getRequiredElement(container, '[data-testid="agent-chat-scroll"]');
+    setScrollableMetrics({ scrollContainer, viewportHeight: 400, contentHeight: 1200 });
+    const anchor = getRequiredElement(container, "[data-stream-item-id='message-1']");
+    setElementOffsetTop(anchor, 0);
+    refreshScrollMetrics(scrollContainer);
+
+    const marker = getRequiredElement(container, "[data-testid='prompt-scroll-marker-message-1']");
+    const preview = getRequiredElement(
+      container,
+      "[data-testid='prompt-scroll-preview-message-1']",
+    );
+    const markerTop = Number.parseFloat(marker.style.top);
+    const previewTop = markerTop + Number.parseFloat(preview.style.top);
+
+    expect(previewTop).toBeGreaterThanOrEqual(16);
+    expect(previewTop + 120).toBeLessThanOrEqual(384);
+  });
+
+  it("positions prompt markers from the top of the user message in the content", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    renderViewport({
+      root,
+      historyMounted: [userMessage(1)],
+    });
+
+    const scrollContainer = getRequiredElement(container, '[data-testid="agent-chat-scroll"]');
+    setScrollableMetrics({ scrollContainer, viewportHeight: 400, contentHeight: 432 });
+    const anchor = getRequiredElement(container, "[data-stream-item-id='message-1']");
+    setElementOffsetTop(anchor, 16);
+    refreshScrollMetrics(scrollContainer);
+
+    const marker = getRequiredElement(container, "[data-testid='prompt-scroll-marker-message-1']");
+    const markerTop = Number.parseFloat(marker.style.top);
+
+    expect(markerTop).toBeLessThan(20);
   });
 
   it("scrolls a mounted prompt to the top when its marker is clicked", () => {

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -408,6 +408,27 @@ describe("createWebStreamStrategy", () => {
     expect(preview.textContent).toBe("Message 1");
   });
 
+  it("keeps mounted stream item anchors from breaking centered row layout", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    renderViewport({
+      root,
+      historyMounted: [userMessage(1)],
+      liveHead: [userMessage(2)],
+    });
+
+    const mountedAnchor = getRequiredElement(container, "[data-stream-item-id='message-1']");
+    const liveAnchor = getRequiredElement(container, "[data-stream-item-id='message-2']");
+
+    expect(mountedAnchor.style.display).toBe("flex");
+    expect(mountedAnchor.style.flexDirection).toBe("column");
+    expect(mountedAnchor.style.width).toBe("100%");
+    expect(liveAnchor.style.display).toBe("flex");
+    expect(liveAnchor.style.flexDirection).toBe("column");
+    expect(liveAnchor.style.width).toBe("100%");
+  });
+
   it("truncates long prompt previews with three periods", () => {
     const longPrompt = `${"Outline the generation process in a diagram. ".repeat(8)}Finish here`;
     container = document.createElement("div");

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -528,7 +528,7 @@ describe("createWebStreamStrategy", () => {
     expect(markerTop).toBeLessThan(20);
   });
 
-  it("scrolls a mounted prompt to the top when its marker is clicked", () => {
+  it("scrolls a mounted prompt near the top with padding when its marker is clicked", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -550,12 +550,12 @@ describe("createWebStreamStrategy", () => {
     });
 
     expect(HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
-      top: 320,
+      top: 302,
       behavior: "auto",
     });
   });
 
-  it("scrolls a virtualized prompt using the virtualizer offset", () => {
+  it("scrolls a virtualized prompt using the virtualizer offset with top padding", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -575,7 +575,7 @@ describe("createWebStreamStrategy", () => {
     });
 
     expect(HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
-      top: 288,
+      top: 270,
       behavior: "auto",
     });
   });

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -481,6 +481,32 @@ describe("createWebStreamStrategy", () => {
     expect(previewTop + 120).toBeLessThanOrEqual(384);
   });
 
+  it("aligns prompt preview top with the visible dot top when unclamped", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    renderViewport({
+      root,
+      historyMounted: [userMessage(1)],
+    });
+
+    const scrollContainer = getRequiredElement(container, '[data-testid="agent-chat-scroll"]');
+    setScrollableMetrics({ scrollContainer, viewportHeight: 400, contentHeight: 1200 });
+    const anchor = getRequiredElement(container, "[data-stream-item-id='message-1']");
+    setElementOffsetTop(anchor, 600);
+    refreshScrollMetrics(scrollContainer);
+
+    const marker = getRequiredElement(container, "[data-testid='prompt-scroll-marker-message-1']");
+    const preview = getRequiredElement(
+      container,
+      "[data-testid='prompt-scroll-preview-message-1']",
+    );
+    const markerTop = Number.parseFloat(marker.style.top);
+    const previewTop = markerTop + Number.parseFloat(preview.style.top);
+
+    expect(previewTop - markerTop).toBe(11);
+  });
+
   it("positions prompt markers from the top of the user message in the content", () => {
     container = document.createElement("div");
     document.body.appendChild(container);

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -1,5 +1,4 @@
 import React, {
-  Fragment,
   type CSSProperties,
   useCallback,
   useEffect,
@@ -10,9 +9,11 @@ import React, {
 } from "react";
 import { ActivityIndicator } from "react-native";
 import { measureElement as measureVirtualElement, useVirtualizer } from "@tanstack/react-virtual";
+import { useWebElementScrollbar } from "@/components/use-web-scrollbar";
 import { estimateStreamItemHeight } from "./web-virtualization";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./strategy";
 import { createStreamStrategy } from "./strategy";
+import type { StreamItem } from "@/types/stream";
 
 interface CreateWebStreamStrategyInput {
   isMobileBreakpoint: boolean;
@@ -25,7 +26,30 @@ const USER_SCROLL_DELTA_EPSILON = 1;
 const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 64;
 const AUTO_SCROLL_RESUME_THRESHOLD_PX = 1;
 const HISTORY_START_THRESHOLD_PX = 96;
-import { useWebElementScrollbar } from "@/components/use-web-scrollbar";
+const PROMPT_MARKER_SIZE = 6;
+const PROMPT_MARKER_HIT_SIZE = 28;
+const PROMPT_MARKER_RAIL_RIGHT = 10;
+const PROMPT_PREVIEW_WIDTH = 280;
+const PROMPT_PREVIEW_MAX_HEIGHT = 132;
+
+type PromptMarkerSegment = "virtualizedHistory" | "mountedHistory" | "liveHead";
+
+interface PromptMarkerDescriptor {
+  id: string;
+  text: string;
+  index: number;
+  segment: PromptMarkerSegment;
+}
+
+interface PromptMarker extends PromptMarkerDescriptor {
+  targetOffset: number;
+}
+
+interface PromptRailMetrics {
+  viewportSize: number;
+  contentSize: number;
+  offsetsById: Map<string, number>;
+}
 
 const historyStartSlotStyle: CSSProperties = {
   display: "flex",
@@ -35,6 +59,75 @@ const historyStartSlotStyle: CSSProperties = {
   paddingTop: 4,
   paddingBottom: 8,
 };
+
+const promptMarkerOverlayStyle: CSSProperties = {
+  position: "absolute",
+  top: 0,
+  right: PROMPT_MARKER_RAIL_RIGHT,
+  bottom: 0,
+  width: PROMPT_MARKER_HIT_SIZE,
+  pointerEvents: "none",
+  zIndex: 11,
+};
+
+const promptMarkerTargetBaseStyle: CSSProperties = {
+  position: "absolute",
+  right: 0,
+  width: PROMPT_MARKER_HIT_SIZE,
+  height: PROMPT_MARKER_HIT_SIZE,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  pointerEvents: "auto",
+  cursor: "pointer",
+};
+
+const promptMarkerDotBaseStyle: CSSProperties = {
+  width: PROMPT_MARKER_SIZE,
+  height: PROMPT_MARKER_SIZE,
+  borderRadius: 999,
+  backgroundColor: "#ffffff",
+  border: "1px solid rgba(0, 0, 0, 0.22)",
+  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.32)",
+};
+
+const promptPreviewBaseStyle: CSSProperties = {
+  position: "absolute",
+  right: PROMPT_MARKER_HIT_SIZE,
+  top: "50%",
+  width: PROMPT_PREVIEW_WIDTH,
+  maxHeight: PROMPT_PREVIEW_MAX_HEIGHT,
+  transform: "translateY(-50%)",
+  overflow: "hidden",
+  padding: "12px 14px",
+  borderRadius: 18,
+  borderTopRightRadius: 6,
+  backgroundColor: "var(--colors-surface3, #e4e4e7)",
+  color: "var(--colors-foreground, #1a1a1e)",
+  boxShadow: "0 12px 32px rgba(0, 0, 0, 0.24)",
+  fontSize: 14,
+  lineHeight: "20px",
+  whiteSpace: "pre-wrap",
+  overflowWrap: "anywhere",
+  textAlign: "left",
+  transition: "opacity 120ms ease-out, transform 120ms ease-out",
+};
+
+const promptPreviewHiddenStyle: CSSProperties = {
+  opacity: 0,
+  pointerEvents: "none",
+  transform: "translateY(-50%) translateX(4px)",
+};
+
+const promptPreviewVisibleStyle: CSSProperties = {
+  opacity: 1,
+  pointerEvents: "auto",
+  transform: "translateY(-50%) translateX(0)",
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
 
 function isScrollContainerNearBottom(
   scrollContainer: Pick<HTMLElement, "scrollTop" | "clientHeight" | "scrollHeight">,
@@ -92,6 +185,183 @@ function isScrollContainerOverscrolledPastBottom(
   return getScrollContainerDistanceFromBottom(scrollContainer) < 0;
 }
 
+function arePromptRailMetricsEqual(left: PromptRailMetrics, right: PromptRailMetrics): boolean {
+  if (
+    left.viewportSize !== right.viewportSize ||
+    left.contentSize !== right.contentSize ||
+    left.offsetsById.size !== right.offsetsById.size
+  ) {
+    return false;
+  }
+
+  for (const [id, offset] of left.offsetsById) {
+    if (right.offsetsById.get(id) !== offset) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function collectPromptMarkerDescriptors(
+  segments: StreamRenderInput["segments"],
+): PromptMarkerDescriptor[] {
+  const markers: PromptMarkerDescriptor[] = [];
+  const visit = (items: StreamItem[], segment: PromptMarkerSegment) => {
+    items.forEach((item, index) => {
+      if (item.kind !== "user_message") {
+        return;
+      }
+      markers.push({
+        id: item.id,
+        text: item.text,
+        index,
+        segment,
+      });
+    });
+  };
+
+  visit(segments.historyVirtualized, "virtualizedHistory");
+  visit(segments.historyMounted, "mountedHistory");
+  visit(segments.liveHead, "liveHead");
+  return markers;
+}
+
+function findStreamItemAnchor(
+  contentElement: HTMLElement | null,
+  itemId: string,
+): HTMLElement | null {
+  if (!contentElement) {
+    return null;
+  }
+  const anchors = contentElement.querySelectorAll<HTMLElement>("[data-stream-item-id]");
+  for (const anchor of anchors) {
+    if (anchor.dataset.streamItemId === itemId) {
+      return anchor;
+    }
+  }
+  return null;
+}
+
+function getPromptMarkerTop(input: {
+  targetOffset: number;
+  viewportSize: number;
+  contentSize: number;
+}): number {
+  const maxScrollOffset = Math.max(0, input.contentSize - input.viewportSize);
+  const maxMarkerTop = Math.max(0, input.viewportSize - PROMPT_MARKER_HIT_SIZE);
+  if (maxScrollOffset <= 0) {
+    return 0;
+  }
+  const clampedTarget = clamp(input.targetOffset, 0, maxScrollOffset);
+  return (clampedTarget / maxScrollOffset) * maxMarkerTop;
+}
+
+interface PromptMarkerRailProps {
+  markers: PromptMarker[];
+  viewportSize: number;
+  contentSize: number;
+  onMarkerPress: (marker: PromptMarker) => void;
+}
+
+interface PromptMarkerRailItemProps {
+  marker: PromptMarker;
+  markerTop: number;
+  isHovered: boolean;
+  onMarkerPress: (marker: PromptMarker) => void;
+  onHoveredPromptChange: (promptId: string | null) => void;
+}
+
+function PromptMarkerRailItem({
+  marker,
+  markerTop,
+  isHovered,
+  onMarkerPress,
+  onHoveredPromptChange,
+}: PromptMarkerRailItemProps) {
+  const targetStyle = useMemo(
+    (): CSSProperties => ({
+      ...promptMarkerTargetBaseStyle,
+      top: markerTop,
+      border: 0,
+      padding: 0,
+      background: "transparent",
+    }),
+    [markerTop],
+  );
+  const previewStyle = useMemo(
+    (): CSSProperties => ({
+      ...promptPreviewBaseStyle,
+      ...(isHovered ? promptPreviewVisibleStyle : promptPreviewHiddenStyle),
+    }),
+    [isHovered],
+  );
+  const handleClick = useCallback(() => {
+    onMarkerPress(marker);
+  }, [marker, onMarkerPress]);
+  const handleMouseEnter = useCallback(() => {
+    onHoveredPromptChange(marker.id);
+  }, [marker.id, onHoveredPromptChange]);
+  const handleMouseLeave = useCallback(() => {
+    onHoveredPromptChange(null);
+  }, [onHoveredPromptChange]);
+
+  return (
+    <button
+      type="button"
+      data-testid={`prompt-scroll-marker-${marker.id}`}
+      aria-label="Jump to prompt"
+      style={targetStyle}
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <span style={promptMarkerDotBaseStyle} />
+      <span data-testid={`prompt-scroll-preview-${marker.id}`} style={previewStyle}>
+        {marker.text}
+      </span>
+    </button>
+  );
+}
+
+function PromptMarkerRail({
+  markers,
+  viewportSize,
+  contentSize,
+  onMarkerPress,
+}: PromptMarkerRailProps) {
+  const [hoveredPromptId, setHoveredPromptId] = useState<string | null>(null);
+  const handleHoveredPromptChange = useCallback((promptId: string | null) => {
+    setHoveredPromptId(promptId);
+  }, []);
+
+  if (markers.length === 0 || contentSize <= viewportSize || viewportSize <= 0) {
+    return null;
+  }
+
+  return (
+    <div style={promptMarkerOverlayStyle} data-testid="prompt-marker-rail">
+      {markers.map((marker) => {
+        const markerTop = getPromptMarkerTop({
+          targetOffset: marker.targetOffset,
+          viewportSize,
+          contentSize,
+        });
+        const isHovered = hoveredPromptId === marker.id;
+        return (
+          <PromptMarkerRailItem
+            key={marker.id}
+            marker={marker}
+            markerTop={markerTop}
+            isHovered={isHovered}
+            onMarkerPress={onMarkerPress}
+            onHoveredPromptChange={handleHoveredPromptChange}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
 function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: boolean }) {
   const {
     segments,
@@ -110,6 +380,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   } = props;
   const scrollContainerRef = useRef<HTMLElement | null>(null);
   const contentRef = useRef<HTMLElement | null>(null);
+  const virtualRowsContainerRef = useRef<HTMLDivElement | null>(null);
   const handleScrollContainerRef = useCallback((node: HTMLElement | null) => {
     scrollContainerRef.current = node;
   }, []);
@@ -130,6 +401,11 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   const pendingAutoScrollTimeoutRef = useRef<number | null>(null);
   const pendingVirtualRowMeasureFramesRef = useRef(new Map<Element, number>());
   const historyStartReadyRef = useRef(false);
+  const [promptRailMetrics, setPromptRailMetrics] = useState<PromptRailMetrics>({
+    viewportSize: 0,
+    contentSize: 0,
+    offsetsById: new Map(),
+  });
   const showDesktopWebScrollbar = !isMobileBreakpoint;
   const scrollbarOverlay = useWebElementScrollbar(scrollContainerRef, {
     enabled: showDesktopWebScrollbar,
@@ -173,6 +449,61 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   }, [rowVirtualizer]);
   const virtualRows = rowVirtualizer.getVirtualItems();
   const virtualTotalSize = rowVirtualizer.getTotalSize();
+
+  const getVirtualPromptOffset = useCallback(
+    (index: number): number | null => {
+      const offsetInfo = rowVirtualizer.getOffsetForIndex(index, "start");
+      if (!offsetInfo) {
+        return null;
+      }
+      const virtualRowsContainerOffset = virtualRowsContainerRef.current?.offsetTop ?? 0;
+      return virtualRowsContainerOffset + offsetInfo[0];
+    },
+    [rowVirtualizer],
+  );
+
+  const resolvePromptOffset = useCallback(
+    (marker: PromptMarkerDescriptor): number | null => {
+      if (marker.segment === "virtualizedHistory") {
+        return getVirtualPromptOffset(marker.index);
+      }
+      const anchor = findStreamItemAnchor(contentRef.current, marker.id);
+      return anchor?.offsetTop ?? null;
+    },
+    [getVirtualPromptOffset],
+  );
+
+  const updatePromptRailMetrics = useCallback(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer || isMobileBreakpoint) {
+      setPromptRailMetrics((previous) => {
+        const next: PromptRailMetrics = {
+          viewportSize: 0,
+          contentSize: 0,
+          offsetsById: new Map(),
+        };
+        return arePromptRailMetricsEqual(previous, next) ? previous : next;
+      });
+      return;
+    }
+
+    const offsetsById = new Map<string, number>();
+    for (const marker of collectPromptMarkerDescriptors(segments)) {
+      const offset = resolvePromptOffset(marker);
+      if (offset !== null) {
+        offsetsById.set(marker.id, offset);
+      }
+    }
+
+    const next: PromptRailMetrics = {
+      viewportSize: scrollContainer.clientHeight,
+      contentSize: scrollContainer.scrollHeight,
+      offsetsById,
+    };
+    setPromptRailMetrics((previous) =>
+      arePromptRailMetricsEqual(previous, next) ? previous : next,
+    );
+  }, [isMobileBreakpoint, resolvePromptOffset, segments]);
 
   const measureVirtualizedRowElement = useCallback(
     (node: HTMLDivElement | null) => {
@@ -262,10 +593,12 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer) {
       onNearBottomChange(true);
+      updatePromptRailMetrics();
       return;
     }
     syncNearBottom(scrollContainer, onNearBottomChange);
-  }, [onNearBottomChange]);
+    updatePromptRailMetrics();
+  }, [onNearBottomChange, updatePromptRailMetrics]);
 
   const handleDomScroll = useCallback(() => {
     const scrollContainer = scrollContainerRef.current;
@@ -364,6 +697,16 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     segments.historyVirtualized.length,
     segments.liveHead.length,
     updateScrollMetrics,
+    virtualTotalSize,
+  ]);
+
+  useLayoutEffect(() => {
+    updatePromptRailMetrics();
+  }, [
+    segments.historyMounted,
+    segments.historyVirtualized,
+    segments.liveHead,
+    updatePromptRailMetrics,
     virtualTotalSize,
   ]);
 
@@ -520,14 +863,16 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   );
   const mountedHistoryRows = useMemo(() => {
     return segments.historyMounted.map((item, index) => (
-      <Fragment key={item.id}>
+      <div key={item.id} data-stream-item-id={item.id} data-stream-item-kind={item.kind}>
         {renderHistoryMountedRow(item, index, segments.historyMounted)}
-      </Fragment>
+      </div>
     ));
   }, [renderHistoryMountedRow, segments.historyMounted]);
   const liveHeadRows = useMemo(() => {
     return segments.liveHead.map((item, index) => (
-      <Fragment key={item.id}>{renderLiveHeadRow(item, index, segments.liveHead)}</Fragment>
+      <div key={item.id} data-stream-item-id={item.id} data-stream-item-kind={item.kind}>
+        {renderLiveHeadRow(item, index, segments.liveHead)}
+      </div>
     ));
   }, [renderLiveHeadRow, segments.liveHead]);
   const liveAuxiliary = useMemo(() => {
@@ -548,6 +893,30 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     !boundary.hasVirtualizedHistory &&
     !boundary.hasLiveHead &&
     !liveAuxiliary;
+  const promptMarkers = useMemo((): PromptMarker[] => {
+    return collectPromptMarkerDescriptors(segments).flatMap((marker) => {
+      const targetOffset = promptRailMetrics.offsetsById.get(marker.id);
+      return targetOffset === undefined ? [] : [{ ...marker, targetOffset }];
+    });
+  }, [promptRailMetrics.offsetsById, segments]);
+  const handlePromptMarkerPress = useCallback(
+    (marker: PromptMarker) => {
+      const scrollContainer = scrollContainerRef.current;
+      if (!scrollContainer) {
+        return;
+      }
+      const resolvedOffset = resolvePromptOffset(marker) ?? marker.targetOffset;
+      const maxScrollOffset = Math.max(
+        0,
+        scrollContainer.scrollHeight - scrollContainer.clientHeight,
+      );
+      scrollContainer.scrollTo({
+        top: clamp(resolvedOffset, 0, maxScrollOffset),
+        behavior: "auto",
+      });
+    },
+    [resolvePromptOffset],
+  );
 
   return (
     <>
@@ -560,7 +929,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         <div ref={handleContentRef} style={contentContainerStyle}>
           {historyStartSlot}
           {shouldUseVirtualizer ? (
-            <div style={virtualRowsContainerStyle}>
+            <div ref={virtualRowsContainerRef} style={virtualRowsContainerStyle}>
               {virtualRows.map((virtualRow) => {
                 const item = segments.historyVirtualized[virtualRow.index];
                 if (!item) {
@@ -570,6 +939,8 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
                   <div
                     key={virtualRow.key}
                     data-index={virtualRow.index}
+                    data-stream-item-id={item.id}
+                    data-stream-item-kind={item.kind}
                     ref={measureVirtualizedRowElement}
                     style={renderVirtualRowStyle(virtualRow.start)}
                   >
@@ -589,6 +960,12 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
           {shouldRenderEmpty ? listEmptyComponent : null}
         </div>
       </div>
+      <PromptMarkerRail
+        markers={promptMarkers}
+        viewportSize={promptRailMetrics.viewportSize}
+        contentSize={promptRailMetrics.contentSize}
+        onMarkerPress={handlePromptMarkerPress}
+      />
       {scrollbarOverlay}
     </>
   );

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -10,6 +10,7 @@ import React, {
 import { ActivityIndicator } from "react-native";
 import { measureElement as measureVirtualElement, useVirtualizer } from "@tanstack/react-virtual";
 import { useWebElementScrollbar } from "@/components/use-web-scrollbar";
+import { useAppSettings } from "@/hooks/use-settings";
 import { estimateStreamItemHeight } from "./web-virtualization";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./strategy";
 import { createStreamStrategy } from "./strategy";
@@ -401,12 +402,14 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   const pendingAutoScrollTimeoutRef = useRef<number | null>(null);
   const pendingVirtualRowMeasureFramesRef = useRef(new Map<Element, number>());
   const historyStartReadyRef = useRef(false);
+  const { settings: appSettings } = useAppSettings();
   const [promptRailMetrics, setPromptRailMetrics] = useState<PromptRailMetrics>({
     viewportSize: 0,
     contentSize: 0,
     offsetsById: new Map(),
   });
   const showDesktopWebScrollbar = !isMobileBreakpoint;
+  const showPromptMarkers = showDesktopWebScrollbar && appSettings.promptScrollMarkers;
   const scrollbarOverlay = useWebElementScrollbar(scrollContainerRef, {
     enabled: showDesktopWebScrollbar,
     contentRef,
@@ -475,7 +478,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
 
   const updatePromptRailMetrics = useCallback(() => {
     const scrollContainer = scrollContainerRef.current;
-    if (!scrollContainer || isMobileBreakpoint) {
+    if (!scrollContainer || !showPromptMarkers) {
       setPromptRailMetrics((previous) => {
         const next: PromptRailMetrics = {
           viewportSize: 0,
@@ -503,7 +506,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     setPromptRailMetrics((previous) =>
       arePromptRailMetricsEqual(previous, next) ? previous : next,
     );
-  }, [isMobileBreakpoint, resolvePromptOffset, segments]);
+  }, [resolvePromptOffset, segments, showPromptMarkers]);
 
   const measureVirtualizedRowElement = useCallback(
     (node: HTMLDivElement | null) => {

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -63,6 +63,12 @@ const historyStartSlotStyle: CSSProperties = {
   paddingBottom: 8,
 };
 
+const streamItemAnchorStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
+};
+
 const promptMarkerOverlayStyle: CSSProperties = {
   position: "absolute",
   top: 0,
@@ -888,14 +894,24 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   );
   const mountedHistoryRows = useMemo(() => {
     return segments.historyMounted.map((item, index) => (
-      <div key={item.id} data-stream-item-id={item.id} data-stream-item-kind={item.kind}>
+      <div
+        key={item.id}
+        data-stream-item-id={item.id}
+        data-stream-item-kind={item.kind}
+        style={streamItemAnchorStyle}
+      >
         {renderHistoryMountedRow(item, index, segments.historyMounted)}
       </div>
     ));
   }, [renderHistoryMountedRow, segments.historyMounted]);
   const liveHeadRows = useMemo(() => {
     return segments.liveHead.map((item, index) => (
-      <div key={item.id} data-stream-item-id={item.id} data-stream-item-kind={item.kind}>
+      <div
+        key={item.id}
+        data-stream-item-id={item.id}
+        data-stream-item-kind={item.kind}
+        style={streamItemAnchorStyle}
+      >
         {renderLiveHeadRow(item, index, segments.liveHead)}
       </div>
     ));

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -34,7 +34,7 @@ const PROMPT_PREVIEW_WIDTH = 280;
 const PROMPT_PREVIEW_MAX_HEIGHT = 120;
 const PROMPT_PREVIEW_EDGE_PADDING = 16;
 const PROMPT_PREVIEW_TEXT_MAX_LENGTH = 140;
-const PROMPT_SCROLL_TARGET_TOP_PADDING = 18;
+const PROMPT_SCROLL_TARGET_TOP_PADDING = 15;
 
 type PromptMarkerSegment = "virtualizedHistory" | "mountedHistory" | "liveHead";
 

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -439,6 +439,10 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   });
   const showDesktopWebScrollbar = !isMobileBreakpoint;
   const showPromptMarkers = showDesktopWebScrollbar && appSettings.promptScrollMarkers;
+  const promptMarkerDescriptors = useMemo(
+    () => collectPromptMarkerDescriptors(segments),
+    [segments],
+  );
   const scrollbarOverlay = useWebElementScrollbar(scrollContainerRef, {
     enabled: showDesktopWebScrollbar,
     contentRef,
@@ -520,7 +524,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     }
 
     const offsetsById = new Map<string, number>();
-    for (const marker of collectPromptMarkerDescriptors(segments)) {
+    for (const marker of promptMarkerDescriptors) {
       const offset = resolvePromptOffset(marker);
       if (offset !== null) {
         offsetsById.set(marker.id, offset);
@@ -535,7 +539,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     setPromptRailMetrics((previous) =>
       arePromptRailMetricsEqual(previous, next) ? previous : next,
     );
-  }, [resolvePromptOffset, segments, showPromptMarkers]);
+  }, [promptMarkerDescriptors, resolvePromptOffset, showPromptMarkers]);
 
   const measureVirtualizedRowElement = useCallback(
     (node: HTMLDivElement | null) => {
@@ -625,12 +629,10 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer) {
       onNearBottomChange(true);
-      updatePromptRailMetrics();
       return;
     }
     syncNearBottom(scrollContainer, onNearBottomChange);
-    updatePromptRailMetrics();
-  }, [onNearBottomChange, updatePromptRailMetrics]);
+  }, [onNearBottomChange]);
 
   const handleDomScroll = useCallback(() => {
     const scrollContainer = scrollContainerRef.current;
@@ -661,13 +663,29 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     lastKnownScrollTopRef.current = currentScrollTop;
     updateScrollMetrics();
     if (
+      showPromptMarkers &&
+      (scrollContainer.clientHeight !== promptRailMetrics.viewportSize ||
+        scrollContainer.scrollHeight !== promptRailMetrics.contentSize)
+    ) {
+      updatePromptRailMetrics();
+    }
+    if (
       historyStartReadyRef.current &&
       hasOlderHistory &&
       currentScrollTop <= HISTORY_START_THRESHOLD_PX
     ) {
       onNearHistoryStart();
     }
-  }, [cancelPendingStickToBottom, hasOlderHistory, onNearHistoryStart, updateScrollMetrics]);
+  }, [
+    cancelPendingStickToBottom,
+    hasOlderHistory,
+    onNearHistoryStart,
+    promptRailMetrics.contentSize,
+    promptRailMetrics.viewportSize,
+    showPromptMarkers,
+    updatePromptRailMetrics,
+    updateScrollMetrics,
+  ]);
 
   useEffect(() => {
     const frame = window.requestAnimationFrame(() => {
@@ -750,8 +768,10 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     }
 
     updateScrollMetrics();
+    updatePromptRailMetrics();
     const observer = new ResizeObserver(() => {
       updateScrollMetrics();
+      updatePromptRailMetrics();
       if (!followOutputRef.current) {
         return;
       }
@@ -764,7 +784,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     return () => {
       observer.disconnect();
     };
-  }, [scheduleStickToBottom, updateScrollMetrics]);
+  }, [scheduleStickToBottom, updatePromptRailMetrics, updateScrollMetrics]);
 
   useEffect(() => {
     const scrollContainer = scrollContainerRef.current;
@@ -874,6 +894,15 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       overscrollBehaviorY: "contain",
     };
   }, [scrollEnabled]);
+  const viewportChromeStyle = useMemo(
+    (): CSSProperties => ({
+      position: "relative",
+      display: "flex",
+      flex: 1,
+      minHeight: 0,
+    }),
+    [],
+  );
   const virtualRowsContainerStyle = useMemo((): CSSProperties => {
     return {
       position: "relative",
@@ -936,11 +965,11 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     !boundary.hasLiveHead &&
     !liveAuxiliary;
   const promptMarkers = useMemo((): PromptMarker[] => {
-    return collectPromptMarkerDescriptors(segments).flatMap((marker) => {
+    return promptMarkerDescriptors.flatMap((marker) => {
       const targetOffset = promptRailMetrics.offsetsById.get(marker.id);
       return targetOffset === undefined ? [] : [{ ...marker, targetOffset }];
     });
-  }, [promptRailMetrics.offsetsById, segments]);
+  }, [promptMarkerDescriptors, promptRailMetrics.offsetsById]);
   const handlePromptMarkerPress = useCallback(
     (marker: PromptMarker) => {
       const scrollContainer = scrollContainerRef.current;
@@ -961,7 +990,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   );
 
   return (
-    <>
+    <div style={viewportChromeStyle}>
       <div
         ref={handleScrollContainerRef}
         data-testid="agent-chat-scroll"
@@ -1009,7 +1038,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         onMarkerPress={handlePromptMarkerPress}
       />
       {scrollbarOverlay}
-    </>
+    </div>
   );
 }
 

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -263,12 +263,12 @@ function getPromptMarkerTop(input: {
 }
 
 function getPromptPreviewTop(input: { markerTop: number; viewportSize: number }): number {
-  const centeredTop = input.markerTop + PROMPT_MARKER_HIT_SIZE / 2 - PROMPT_PREVIEW_MAX_HEIGHT / 2;
+  const dotTop = input.markerTop + (PROMPT_MARKER_HIT_SIZE - PROMPT_MARKER_SIZE) / 2;
   const maxTop = Math.max(
     PROMPT_PREVIEW_EDGE_PADDING,
     input.viewportSize - PROMPT_PREVIEW_EDGE_PADDING - PROMPT_PREVIEW_MAX_HEIGHT,
   );
-  return clamp(centeredTop, PROMPT_PREVIEW_EDGE_PADDING, maxTop);
+  return clamp(dotTop, PROMPT_PREVIEW_EDGE_PADDING, maxTop);
 }
 
 function getPromptPreviewText(text: string): string {

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -31,7 +31,9 @@ const PROMPT_MARKER_SIZE = 6;
 const PROMPT_MARKER_HIT_SIZE = 28;
 const PROMPT_MARKER_RAIL_RIGHT = 10;
 const PROMPT_PREVIEW_WIDTH = 280;
-const PROMPT_PREVIEW_MAX_HEIGHT = 132;
+const PROMPT_PREVIEW_MAX_HEIGHT = 120;
+const PROMPT_PREVIEW_EDGE_PADDING = 16;
+const PROMPT_PREVIEW_TEXT_MAX_LENGTH = 140;
 
 type PromptMarkerSegment = "virtualizedHistory" | "mountedHistory" | "liveHead";
 
@@ -87,27 +89,25 @@ const promptMarkerDotBaseStyle: CSSProperties = {
   width: PROMPT_MARKER_SIZE,
   height: PROMPT_MARKER_SIZE,
   borderRadius: 999,
-  backgroundColor: "#ffffff",
-  border: "1px solid rgba(0, 0, 0, 0.22)",
-  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.32)",
+  backgroundColor: "var(--colors-surface3, #e4e4e7)",
+  border: "1px solid rgba(0, 0, 0, 0.16)",
+  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.28)",
 };
 
 const promptPreviewBaseStyle: CSSProperties = {
   position: "absolute",
   right: PROMPT_MARKER_HIT_SIZE,
-  top: "50%",
   width: PROMPT_PREVIEW_WIDTH,
   maxHeight: PROMPT_PREVIEW_MAX_HEIGHT,
-  transform: "translateY(-50%)",
   overflow: "hidden",
-  padding: "12px 14px",
-  borderRadius: 18,
-  borderTopRightRadius: 6,
+  padding: 16,
+  borderRadius: 16,
+  borderTopRightRadius: 2,
   backgroundColor: "var(--colors-surface3, #e4e4e7)",
   color: "var(--colors-foreground, #1a1a1e)",
   boxShadow: "0 12px 32px rgba(0, 0, 0, 0.24)",
-  fontSize: 14,
-  lineHeight: "20px",
+  fontSize: 16,
+  lineHeight: "22px",
   whiteSpace: "pre-wrap",
   overflowWrap: "anywhere",
   textAlign: "left",
@@ -117,13 +117,13 @@ const promptPreviewBaseStyle: CSSProperties = {
 const promptPreviewHiddenStyle: CSSProperties = {
   opacity: 0,
   pointerEvents: "none",
-  transform: "translateY(-50%) translateX(4px)",
+  transform: "translateX(4px)",
 };
 
 const promptPreviewVisibleStyle: CSSProperties = {
   opacity: 1,
   pointerEvents: "auto",
-  transform: "translateY(-50%) translateX(0)",
+  transform: "translateX(0)",
 };
 
 function clamp(value: number, min: number, max: number): number {
@@ -248,13 +248,29 @@ function getPromptMarkerTop(input: {
   viewportSize: number;
   contentSize: number;
 }): number {
-  const maxScrollOffset = Math.max(0, input.contentSize - input.viewportSize);
   const maxMarkerTop = Math.max(0, input.viewportSize - PROMPT_MARKER_HIT_SIZE);
-  if (maxScrollOffset <= 0) {
+  if (input.contentSize <= 0) {
     return 0;
   }
-  const clampedTarget = clamp(input.targetOffset, 0, maxScrollOffset);
-  return (clampedTarget / maxScrollOffset) * maxMarkerTop;
+  const clampedTarget = clamp(input.targetOffset, 0, input.contentSize);
+  return (clampedTarget / input.contentSize) * maxMarkerTop;
+}
+
+function getPromptPreviewTop(input: { markerTop: number; viewportSize: number }): number {
+  const centeredTop = input.markerTop + PROMPT_MARKER_HIT_SIZE / 2 - PROMPT_PREVIEW_MAX_HEIGHT / 2;
+  const maxTop = Math.max(
+    PROMPT_PREVIEW_EDGE_PADDING,
+    input.viewportSize - PROMPT_PREVIEW_EDGE_PADDING - PROMPT_PREVIEW_MAX_HEIGHT,
+  );
+  return clamp(centeredTop, PROMPT_PREVIEW_EDGE_PADDING, maxTop);
+}
+
+function getPromptPreviewText(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= PROMPT_PREVIEW_TEXT_MAX_LENGTH) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, PROMPT_PREVIEW_TEXT_MAX_LENGTH - 3).trimEnd()}...`;
 }
 
 interface PromptMarkerRailProps {
@@ -267,6 +283,7 @@ interface PromptMarkerRailProps {
 interface PromptMarkerRailItemProps {
   marker: PromptMarker;
   markerTop: number;
+  previewTop: number;
   isHovered: boolean;
   onMarkerPress: (marker: PromptMarker) => void;
   onHoveredPromptChange: (promptId: string | null) => void;
@@ -275,10 +292,12 @@ interface PromptMarkerRailItemProps {
 function PromptMarkerRailItem({
   marker,
   markerTop,
+  previewTop,
   isHovered,
   onMarkerPress,
   onHoveredPromptChange,
 }: PromptMarkerRailItemProps) {
+  const previewText = useMemo(() => getPromptPreviewText(marker.text), [marker.text]);
   const targetStyle = useMemo(
     (): CSSProperties => ({
       ...promptMarkerTargetBaseStyle,
@@ -292,9 +311,10 @@ function PromptMarkerRailItem({
   const previewStyle = useMemo(
     (): CSSProperties => ({
       ...promptPreviewBaseStyle,
+      top: previewTop - markerTop,
       ...(isHovered ? promptPreviewVisibleStyle : promptPreviewHiddenStyle),
     }),
-    [isHovered],
+    [isHovered, markerTop, previewTop],
   );
   const handleClick = useCallback(() => {
     onMarkerPress(marker);
@@ -318,7 +338,7 @@ function PromptMarkerRailItem({
     >
       <span style={promptMarkerDotBaseStyle} />
       <span data-testid={`prompt-scroll-preview-${marker.id}`} style={previewStyle}>
-        {marker.text}
+        {previewText}
       </span>
     </button>
   );
@@ -347,12 +367,14 @@ function PromptMarkerRail({
           viewportSize,
           contentSize,
         });
+        const previewTop = getPromptPreviewTop({ markerTop, viewportSize });
         const isHovered = hoveredPromptId === marker.id;
         return (
           <PromptMarkerRailItem
             key={marker.id}
             marker={marker}
             markerTop={markerTop}
+            previewTop={previewTop}
             isHovered={isHovered}
             onMarkerPress={onMarkerPress}
             onHoveredPromptChange={handleHoveredPromptChange}

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -34,6 +34,7 @@ const PROMPT_PREVIEW_WIDTH = 280;
 const PROMPT_PREVIEW_MAX_HEIGHT = 120;
 const PROMPT_PREVIEW_EDGE_PADDING = 16;
 const PROMPT_PREVIEW_TEXT_MAX_LENGTH = 140;
+const PROMPT_SCROLL_TARGET_TOP_PADDING = 18;
 
 type PromptMarkerSegment = "virtualizedHistory" | "mountedHistory" | "liveHead";
 
@@ -952,7 +953,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         scrollContainer.scrollHeight - scrollContainer.clientHeight,
       );
       scrollContainer.scrollTo({
-        top: clamp(resolvedOffset, 0, maxScrollOffset),
+        top: clamp(resolvedOffset - PROMPT_SCROLL_TARGET_TOP_PADDING, 0, maxScrollOffset),
         behavior: "auto",
       });
     },

--- a/packages/app/src/hooks/use-settings/index.ts
+++ b/packages/app/src/hooks/use-settings/index.ts
@@ -172,6 +172,9 @@ export function useSettings(): UseSettingsReturn {
       if (updates.syntaxTheme !== undefined) {
         appUpdates.syntaxTheme = updates.syntaxTheme;
       }
+      if (updates.promptScrollMarkers !== undefined) {
+        appUpdates.promptScrollMarkers = updates.promptScrollMarkers;
+      }
       const promises: Promise<void>[] = [];
       if (Object.keys(appUpdates).length > 0) {
         promises.push(appSettings.updateSettings(appUpdates));

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -274,6 +274,7 @@ describe("appearance settings", () => {
     expect(result.uiFontSize).toBe(DEFAULT_UI_FONT_SIZE);
     expect(result.codeFontSize).toBe(DEFAULT_CODE_FONT_SIZE);
     expect(result.syntaxTheme).toBe("one");
+    expect(result.promptScrollMarkers).toBe(true);
   });
 
   it("clamps the UI font size into range and rejects non-numeric values", async () => {
@@ -390,6 +391,26 @@ describe("appearance settings", () => {
     });
 
     expect((await loadAppSettingsFromStorage(deps)).syntaxTheme).toBe("one");
+  });
+
+  it("loads the prompt scroll marker preference", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ promptScrollMarkers: false }),
+      }),
+    });
+
+    expect((await loadAppSettingsFromStorage(deps)).promptScrollMarkers).toBe(false);
+  });
+
+  it("drops non-boolean prompt scroll marker values back to the default", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ promptScrollMarkers: "false" }),
+      }),
+    });
+
+    expect((await loadAppSettingsFromStorage(deps)).promptScrollMarkers).toBe(true);
   });
 });
 

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -36,6 +36,7 @@ export interface AppSettings {
   uiFontSize: number; // clamped px, default 16
   codeFontSize: number; // clamped px, default 12
   syntaxTheme: SyntaxThemeId; // default "one"
+  promptScrollMarkers: boolean;
 }
 
 export interface Settings extends AppSettings {
@@ -54,6 +55,7 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   uiFontSize: DEFAULT_UI_FONT_SIZE,
   codeFontSize: DEFAULT_CODE_FONT_SIZE,
   syntaxTheme: "one",
+  promptScrollMarkers: true,
 };
 
 export const DEFAULT_APP_SETTINGS: Settings = {
@@ -193,6 +195,9 @@ function pickAppSettings(stored: Partial<AppSettings>): Partial<AppSettings> {
   }
   if (typeof stored.syntaxTheme === "string" && isSyntaxThemeId(stored.syntaxTheme)) {
     result.syntaxTheme = stored.syntaxTheme;
+  }
+  if (typeof stored.promptScrollMarkers === "boolean") {
+    result.promptScrollMarkers = stored.promptScrollMarkers;
   }
   return result;
 }

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1501,6 +1501,12 @@ export const ar: TranslationResources = {
         codeSize: "حجم الكود",
         codeSizeAccessibility: "حجم خط الكود",
       },
+      display: {
+        title: "العرض",
+        promptMarkers: "علامات المطالبات",
+        promptMarkersHint: "إظهار نقاط بجانب شريط تمرير دردشة سطح المكتب لكل مطالبة من المستخدم",
+        promptMarkersAccessibility: "إظهار علامات المطالبات بجانب شريط تمرير الدردشة",
+      },
       syntax: {
         title: "بناء الجملة",
         highlightTheme: "تسليط الضوء على الموضوع",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1507,6 +1507,12 @@ export const en = {
         codeSize: "Code size",
         codeSizeAccessibility: "Code font size",
       },
+      display: {
+        title: "Display",
+        promptMarkers: "Prompt markers",
+        promptMarkersHint: "Show dots beside the desktop chat scrollbar for each user prompt",
+        promptMarkersAccessibility: "Show prompt markers beside the chat scrollbar",
+      },
       syntax: {
         title: "Syntax",
         highlightTheme: "Highlight theme",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1539,6 +1539,14 @@ export const es: TranslationResources = {
         codeSize: "Tamaño del código",
         codeSizeAccessibility: "Tamaño de fuente del código",
       },
+      display: {
+        title: "Pantalla",
+        promptMarkers: "Marcadores de indicaciones",
+        promptMarkersHint:
+          "Muestra puntos junto a la barra de desplazamiento del chat de escritorio para cada indicación del usuario.",
+        promptMarkersAccessibility:
+          "Mostrar marcadores de indicaciones junto a la barra de desplazamiento del chat",
+      },
       syntax: {
         title: "Sintaxis",
         highlightTheme: "Tema destacado",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1543,6 +1543,14 @@ export const fr: TranslationResources = {
         codeSize: "Taille du code",
         codeSizeAccessibility: "Taille de la police du code",
       },
+      display: {
+        title: "Affichage",
+        promptMarkers: "Repères de prompts",
+        promptMarkersHint:
+          "Afficher des points près de la barre de défilement du chat sur ordinateur pour chaque prompt utilisateur",
+        promptMarkersAccessibility:
+          "Afficher les repères de prompts près de la barre de défilement du chat",
+      },
       syntax: {
         title: "Syntaxe",
         highlightTheme: "Thème de surbrillance",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1530,6 +1530,13 @@ export const ru: TranslationResources = {
         codeSize: "Размер кода",
         codeSizeAccessibility: "Размер шрифта кода",
       },
+      display: {
+        title: "Отображение",
+        promptMarkers: "Маркеры запросов",
+        promptMarkersHint:
+          "Показывать точки рядом с полосой прокрутки чата на рабочем столе для каждого запроса пользователя.",
+        promptMarkersAccessibility: "Показывать маркеры запросов рядом с полосой прокрутки чата",
+      },
       syntax: {
         title: "Синтаксис",
         highlightTheme: "Выделить тему",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1482,6 +1482,12 @@ export const zhCN: TranslationResources = {
         codeSize: "代码字号",
         codeSizeAccessibility: "代码字号",
       },
+      display: {
+        title: "显示",
+        promptMarkers: "提示标记",
+        promptMarkersHint: "在桌面聊天滚动条旁为每条用户提示显示圆点",
+        promptMarkersAccessibility: "在聊天滚动条旁显示提示标记",
+      },
       syntax: {
         title: "语法",
         highlightTheme: "高亮主题",

--- a/packages/app/src/screens/settings/appearance/appearance-section.tsx
+++ b/packages/app/src/screens/settings/appearance/appearance-section.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Switch } from "@/components/ui/switch";
 import { SettingsSection } from "@/screens/settings/settings-section";
 import {
   MAX_CODE_FONT_SIZE,
@@ -359,6 +360,32 @@ function SyntaxRow({ value, onChange }: SyntaxRowProps) {
   );
 }
 
+interface PromptScrollMarkersRowProps {
+  value: boolean;
+  onChange: (value: boolean) => void;
+}
+
+function PromptScrollMarkersRow({ value, onChange }: PromptScrollMarkersRowProps) {
+  const { t } = useTranslation();
+  return (
+    <View style={settingsStyles.row}>
+      <View style={settingsStyles.rowContent}>
+        <Text style={settingsStyles.rowTitle}>
+          {t("settings.appearance.display.promptMarkers")}
+        </Text>
+        <Text style={settingsStyles.rowHint}>
+          {t("settings.appearance.display.promptMarkersHint")}
+        </Text>
+      </View>
+      <Switch
+        value={value}
+        onValueChange={onChange}
+        accessibilityLabel={t("settings.appearance.display.promptMarkersAccessibility")}
+      />
+    </View>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
@@ -367,6 +394,7 @@ export function AppearanceSection() {
   const { t } = useTranslation();
   const { settings, updateSettings } = useAppSettings();
   const showFontFamilyRows = !isNative;
+  const showPromptMarkerRows = !isNative;
   const uiFontPlaceholder = resolveDefaultStackPlaceholder(t, DEFAULT_UI_FONT_STACK);
   const monoFontPlaceholder = resolveDefaultStackPlaceholder(t, DEFAULT_MONO_FONT_STACK);
 
@@ -393,6 +421,13 @@ export function AppearanceSection() {
   const handleSyntaxThemeChange = useCallback(
     (syntaxTheme: SyntaxThemeId) => {
       void updateSettings({ syntaxTheme });
+    },
+    [updateSettings],
+  );
+
+  const handlePromptScrollMarkersChange = useCallback(
+    (promptScrollMarkers: boolean) => {
+      void updateSettings({ promptScrollMarkers });
     },
     [updateSettings],
   );
@@ -477,6 +512,16 @@ export function AppearanceSection() {
           <ThemeRow value={settings.theme} onChange={handleThemeChange} />
         </View>
       </SettingsSection>
+      {showPromptMarkerRows ? (
+        <SettingsSection title={t("settings.appearance.display.title")}>
+          <View style={settingsStyles.card}>
+            <PromptScrollMarkersRow
+              value={settings.promptScrollMarkers}
+              onChange={handlePromptScrollMarkersChange}
+            />
+          </View>
+        </SettingsSection>
+      ) : null}
       <SettingsSection title={t("settings.appearance.fonts.title")}>
         <View style={settingsStyles.card}>
           {showFontFamilyRows ? (


### PR DESCRIPTION
## Summary
- Adds web prompt scroll markers with preview positioning and scroll targeting refinements
- Adds an appearance setting with persisted storage and translations
- Tidies marker naming and clamps preview behavior after review

## Validation
- Branch review agent ran focused tests plus repo typecheck/lint/format before the rebase
- Rebased onto origin/main and verified the final diff scope
