### PR TITLE
[codex] Add pinned user input overlay

### DIFF
--- a/packages/app/src/agent-stream/pinned-user-input.test.ts
+++ b/packages/app/src/agent-stream/pinned-user-input.test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, it } from "vitest";
 import type { StreamItem } from "@/types/stream";
-import { selectPinnedUserInput, type PinnedUserInputCandidate } from "./pinned-user-input";
+import {
+  collectEstimatedPinnedUserInputCandidates,
+  findEstimatedStreamItemTop,
+  selectPinnedUserInput,
+  type PinnedUserInputCandidate,
+} from "./pinned-user-input";
 
 function userMessage(id: string): Extract<StreamItem, { kind: "user_message" }> {
   return {
     kind: "user_message",
+    id,
+    text: id,
+    timestamp: new Date("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+function assistantMessage(id: string): Extract<StreamItem, { kind: "assistant_message" }> {
+  return {
+    kind: "assistant_message",
     id,
     text: id,
     timestamp: new Date("2026-01-01T00:00:00.000Z"),
@@ -31,7 +45,7 @@ describe("selectPinnedUserInput", () => {
     ).toBeNull();
   });
 
-  it("selects the latest user input at or above the viewport bottom", () => {
+  it("selects the latest user input at or above the viewport midpoint", () => {
     expect(
       selectPinnedUserInput({
         enabled: true,
@@ -53,18 +67,40 @@ describe("selectPinnedUserInput", () => {
     ).toBeNull();
   });
 
-  it("switches to the next user input when the viewport bottom enters the next turn", () => {
+  it("keeps the previous user input until the next input top crosses the viewport midpoint", () => {
     expect(
       selectPinnedUserInput({
         enabled: true,
         candidates: [candidate("u1", 0, 80), candidate("u2", 700, 780)],
-        viewportTop: 820,
+        viewportTop: 300,
+        viewportBottom: 900,
+      })?.item.id,
+    ).toBe("u1");
+  });
+
+  it("hides the previous pinned input when the next input top crosses the viewport midpoint", () => {
+    expect(
+      selectPinnedUserInput({
+        enabled: true,
+        candidates: [candidate("u1", 0, 80), candidate("u2", 700, 780)],
+        viewportTop: 500,
+        viewportBottom: 1000,
+      }),
+    ).toBeNull();
+  });
+
+  it("switches to the next user input after it scrolls off the top", () => {
+    expect(
+      selectPinnedUserInput({
+        enabled: true,
+        candidates: [candidate("u1", 0, 80), candidate("u2", 700, 780)],
+        viewportTop: 800,
         viewportBottom: 1100,
       })?.item.id,
     ).toBe("u2");
   });
 
-  it("returns null when no user inputs are above the viewport bottom", () => {
+  it("returns null when no user inputs are above the viewport midpoint", () => {
     expect(
       selectPinnedUserInput({
         enabled: true,
@@ -73,5 +109,45 @@ describe("selectPinnedUserInput", () => {
         viewportBottom: 300,
       }),
     ).toBeNull();
+  });
+});
+
+describe("collectEstimatedPinnedUserInputCandidates", () => {
+  it("keeps estimated coordinates in stream order", () => {
+    const items: StreamItem[] = [userMessage("u1"), assistantMessage("a1"), userMessage("u2")];
+    const heightById = new Map<string, number>([
+      ["u1", 80],
+      ["a1", 320],
+      ["u2", 90],
+    ]);
+
+    expect(
+      collectEstimatedPinnedUserInputCandidates({
+        items,
+        estimateHeight: (item) => heightById.get(item.id) ?? 0,
+      }),
+    ).toEqual([
+      { item: expect.objectContaining({ id: "u1" }), top: 0, bottom: 80 },
+      { item: expect.objectContaining({ id: "u2" }), top: 400, bottom: 490 },
+    ]);
+  });
+});
+
+describe("findEstimatedStreamItemTop", () => {
+  it("returns the estimated top in stream order", () => {
+    const items: StreamItem[] = [userMessage("u1"), assistantMessage("a1"), userMessage("u2")];
+    const heightById = new Map<string, number>([
+      ["u1", 80],
+      ["a1", 320],
+      ["u2", 90],
+    ]);
+
+    expect(
+      findEstimatedStreamItemTop({
+        items,
+        itemId: "u2",
+        estimateHeight: (item) => heightById.get(item.id) ?? 0,
+      }),
+    ).toBe(400);
   });
 });

--- a/packages/app/src/agent-stream/pinned-user-input.test.ts
+++ b/packages/app/src/agent-stream/pinned-user-input.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { StreamItem } from "@/types/stream";
+import { selectPinnedUserInput, type PinnedUserInputCandidate } from "./pinned-user-input";
+
+function userMessage(id: string): Extract<StreamItem, { kind: "user_message" }> {
+  return {
+    kind: "user_message",
+    id,
+    text: id,
+    timestamp: new Date("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+function candidate(id: string, top: number, bottom: number): PinnedUserInputCandidate {
+  return {
+    item: userMessage(id),
+    top,
+    bottom,
+  };
+}
+
+describe("selectPinnedUserInput", () => {
+  it("returns null when disabled", () => {
+    expect(
+      selectPinnedUserInput({
+        enabled: false,
+        candidates: [candidate("u1", 0, 80)],
+        viewportTop: 120,
+        viewportBottom: 520,
+      }),
+    ).toBeNull();
+  });
+
+  it("selects the latest user input at or above the viewport bottom", () => {
+    expect(
+      selectPinnedUserInput({
+        enabled: true,
+        candidates: [candidate("u1", 0, 80), candidate("u2", 500, 580)],
+        viewportTop: 620,
+        viewportBottom: 1000,
+      })?.item.id,
+    ).toBe("u2");
+  });
+
+  it("hides the relevant user input while it is visible in the viewport", () => {
+    expect(
+      selectPinnedUserInput({
+        enabled: true,
+        candidates: [candidate("u1", 0, 80), candidate("u2", 500, 580)],
+        viewportTop: 520,
+        viewportBottom: 920,
+      }),
+    ).toBeNull();
+  });
+
+  it("switches to the next user input when the viewport bottom enters the next turn", () => {
+    expect(
+      selectPinnedUserInput({
+        enabled: true,
+        candidates: [candidate("u1", 0, 80), candidate("u2", 700, 780)],
+        viewportTop: 820,
+        viewportBottom: 1100,
+      })?.item.id,
+    ).toBe("u2");
+  });
+
+  it("returns null when no user inputs are above the viewport bottom", () => {
+    expect(
+      selectPinnedUserInput({
+        enabled: true,
+        candidates: [candidate("u1", 500, 580)],
+        viewportTop: 0,
+        viewportBottom: 300,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/app/src/agent-stream/pinned-user-input.ts
+++ b/packages/app/src/agent-stream/pinned-user-input.ts
@@ -17,12 +17,53 @@ export interface SelectPinnedUserInputInput {
   viewportBottom: number;
 }
 
+export interface CollectEstimatedPinnedUserInputCandidatesInput {
+  items: StreamItem[];
+  estimateHeight: (item: StreamItem) => number;
+  initialTop?: number;
+}
+
 function isCandidateVisible(input: {
   candidate: PinnedUserInputCandidate;
   viewportTop: number;
   viewportBottom: number;
 }): boolean {
   return input.candidate.bottom > input.viewportTop && input.candidate.top < input.viewportBottom;
+}
+
+export function collectEstimatedPinnedUserInputCandidates(
+  input: CollectEstimatedPinnedUserInputCandidatesInput,
+): PinnedUserInputCandidate[] {
+  const candidates: PinnedUserInputCandidate[] = [];
+  let top = input.initialTop ?? 0;
+  for (const item of input.items) {
+    const height = input.estimateHeight(item);
+    if (item.kind === "user_message") {
+      candidates.push({
+        item,
+        top,
+        bottom: top + height,
+      });
+    }
+    top += height;
+  }
+  return candidates;
+}
+
+export function findEstimatedStreamItemTop(input: {
+  items: StreamItem[];
+  itemId: string;
+  estimateHeight: (item: StreamItem) => number;
+  initialTop?: number;
+}): number | null {
+  let top = input.initialTop ?? 0;
+  for (const item of input.items) {
+    if (item.id === input.itemId) {
+      return top;
+    }
+    top += input.estimateHeight(item);
+  }
+  return null;
 }
 
 export function selectPinnedUserInput(
@@ -35,9 +76,10 @@ export function selectPinnedUserInput(
     return null;
   }
 
+  const viewportMidpoint = input.viewportTop + (input.viewportBottom - input.viewportTop) / 2;
   let relevant: PinnedUserInputCandidate | null = null;
   for (const candidate of input.candidates) {
-    if (candidate.top <= input.viewportBottom) {
+    if (candidate.top <= viewportMidpoint) {
       relevant = candidate;
     } else {
       break;

--- a/packages/app/src/agent-stream/pinned-user-input.ts
+++ b/packages/app/src/agent-stream/pinned-user-input.ts
@@ -1,0 +1,61 @@
+import type { StreamItem } from "@/types/stream";
+
+export interface PinnedUserInputCandidate {
+  item: Extract<StreamItem, { kind: "user_message" }>;
+  top: number;
+  bottom: number;
+}
+
+export interface PinnedUserInputState {
+  item: Extract<StreamItem, { kind: "user_message" }>;
+}
+
+export interface SelectPinnedUserInputInput {
+  enabled: boolean;
+  candidates: PinnedUserInputCandidate[];
+  viewportTop: number;
+  viewportBottom: number;
+}
+
+function isCandidateVisible(input: {
+  candidate: PinnedUserInputCandidate;
+  viewportTop: number;
+  viewportBottom: number;
+}): boolean {
+  return input.candidate.bottom > input.viewportTop && input.candidate.top < input.viewportBottom;
+}
+
+export function selectPinnedUserInput(
+  input: SelectPinnedUserInputInput,
+): PinnedUserInputState | null {
+  if (!input.enabled) {
+    return null;
+  }
+  if (input.viewportBottom <= input.viewportTop) {
+    return null;
+  }
+
+  let relevant: PinnedUserInputCandidate | null = null;
+  for (const candidate of input.candidates) {
+    if (candidate.top <= input.viewportBottom) {
+      relevant = candidate;
+    } else {
+      break;
+    }
+  }
+
+  if (!relevant) {
+    return null;
+  }
+  if (
+    isCandidateVisible({
+      candidate: relevant,
+      viewportTop: input.viewportTop,
+      viewportBottom: input.viewportBottom,
+    })
+  ) {
+    return null;
+  }
+
+  return { item: relevant.item };
+}

--- a/packages/app/src/agent-stream/strategy-native.tsx
+++ b/packages/app/src/agent-stream/strategy-native.tsx
@@ -20,12 +20,14 @@ import {
 import type { StreamItem } from "@/types/stream";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import { useBottomAnchorController } from "./bottom-anchor-controller";
+import { estimateStreamItemHeight } from "./web-virtualization";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./strategy";
 import {
   createStreamStrategy,
   isNearBottomForStreamRenderStrategy,
   resolveBottomAnchorTransportBehavior,
 } from "./strategy";
+import { selectPinnedUserInput, type PinnedUserInputCandidate } from "./pinned-user-input";
 
 const DEFAULT_MAINTAIN_VISIBLE_CONTENT_POSITION = Object.freeze({
   minIndexForVisible: 0,
@@ -49,6 +51,8 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
     isAuthoritativeHistoryReady,
     onNearBottomChange,
     onNearHistoryStart,
+    pinUserInputsEnabled,
+    onPinnedUserInputChange,
     isLoadingOlderHistory,
     hasOlderHistory,
     scrollEnabled,
@@ -79,6 +83,58 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
     }
     return [...segments.historyVirtualized, ...segments.historyMounted];
   }, [segments.historyMounted, segments.historyVirtualized]);
+
+  const collectPinnedUserInputCandidates = useCallback((): PinnedUserInputCandidate[] => {
+    const candidates: PinnedUserInputCandidate[] = [];
+    let top = 0;
+    for (const item of historyRows.toReversed()) {
+      const height = estimateStreamItemHeight(item);
+      if (item.kind === "user_message") {
+        candidates.push({
+          item,
+          top,
+          bottom: top + height,
+        });
+      }
+      top += height;
+    }
+    return candidates;
+  }, [historyRows]);
+
+  const findEstimatedNormalTop = useCallback(
+    (itemId: string): number | null => {
+      let top = 0;
+      for (const item of historyRows.toReversed()) {
+        if (item.id === itemId) {
+          return top;
+        }
+        top += estimateStreamItemHeight(item);
+      }
+      return null;
+    },
+    [historyRows],
+  );
+
+  const updatePinnedUserInput = useCallback(() => {
+    const metrics = streamViewportMetricsRef.current;
+    if (metrics.viewportHeight <= 0 || metrics.contentHeight <= 0) {
+      onPinnedUserInputChange(null);
+      return;
+    }
+    const viewportTop = Math.max(
+      0,
+      metrics.contentHeight - metrics.offsetY - metrics.viewportHeight,
+    );
+    const viewportBottom = Math.max(viewportTop, metrics.contentHeight - metrics.offsetY);
+    onPinnedUserInputChange(
+      selectPinnedUserInput({
+        enabled: pinUserInputsEnabled,
+        candidates: collectPinnedUserInputCandidates(),
+        viewportTop,
+        viewportBottom,
+      }),
+    );
+  }, [collectPinnedUserInputCandidates, onPinnedUserInputChange, pinUserInputsEnabled]);
 
   const clearNativeViewportSettling = useCallback(() => {
     if (nativeViewportSettlingFrameIdRef.current !== null) {
@@ -205,6 +261,19 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
           reason,
         });
       },
+      scrollToStreamItemTop: (itemId: string) => {
+        const metrics = streamViewportMetricsRef.current;
+        const itemTop = findEstimatedNormalTop(itemId);
+        if (itemTop === null || metrics.viewportHeight <= 0 || metrics.contentHeight <= 0) {
+          return;
+        }
+        const offset = Math.max(0, metrics.contentHeight - itemTop - metrics.viewportHeight);
+        programmaticScrollEventBudgetRef.current = 3;
+        flatListRef.current?.scrollToOffset({
+          offset,
+          animated: true,
+        });
+      },
       prepareForViewportChange: () => {
         bottomAnchorController.prepareForStickyViewportChange();
         markNativeViewportSettling();
@@ -216,7 +285,13 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
         viewportRef.current = null;
       }
     };
-  }, [agentId, bottomAnchorController, markNativeViewportSettling, viewportRef]);
+  }, [
+    agentId,
+    bottomAnchorController,
+    findEstimatedNormalTop,
+    markNativeViewportSettling,
+    viewportRef,
+  ]);
 
   const handleScroll = useStableEvent((event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
@@ -240,6 +315,7 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
       viewportHeight: streamViewportMetricsRef.current.viewportHeight,
     });
     onNearBottomChange(nearBottom);
+    updatePinnedUserInput();
 
     const distanceFromOldestEdge =
       streamViewportMetricsRef.current.contentHeight -
@@ -288,6 +364,7 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
       previousViewportHeight,
       viewportHeight,
     });
+    updatePinnedUserInput();
   });
 
   const handleContentSizeChange = useStableEvent((_width: number, height: number) => {
@@ -303,7 +380,12 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
       previousContentHeight,
       contentHeight: nextContentHeight,
     });
+    updatePinnedUserInput();
   });
+
+  useEffect(() => {
+    updatePinnedUserInput();
+  }, [historyRows, pinUserInputsEnabled, updatePinnedUserInput]);
 
   const renderItem = useStableEvent(
     ({ item, index }: ListRenderItemInfo<StreamItem>): ReactElement | null => {

--- a/packages/app/src/agent-stream/strategy-native.tsx
+++ b/packages/app/src/agent-stream/strategy-native.tsx
@@ -12,6 +12,7 @@ import {
   ActivityIndicator,
   Keyboard,
   View,
+  StyleSheet,
   type LayoutChangeEvent,
   type ListRenderItemInfo,
   type NativeScrollEvent,
@@ -21,19 +22,34 @@ import type { StreamItem } from "@/types/stream";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import { useBottomAnchorController } from "./bottom-anchor-controller";
 import { estimateStreamItemHeight } from "./web-virtualization";
+import {
+  collectEstimatedPinnedUserInputCandidates,
+  findEstimatedStreamItemTop,
+  selectPinnedUserInput,
+} from "./pinned-user-input";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./strategy";
 import {
   createStreamStrategy,
   isNearBottomForStreamRenderStrategy,
+  PINNED_USER_INPUT_SCROLL_TOP_OFFSET,
   resolveBottomAnchorTransportBehavior,
 } from "./strategy";
-import { selectPinnedUserInput, type PinnedUserInputCandidate } from "./pinned-user-input";
 
 const DEFAULT_MAINTAIN_VISIBLE_CONTENT_POSITION = Object.freeze({
   minIndexForVisible: 0,
   autoscrollToTopThreshold: 0,
 });
 const HISTORY_START_THRESHOLD_PX = 96;
+
+const nativeStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
+  list: {
+    flex: 1,
+  },
+});
 
 function keyExtractor(item: { id: string }): string {
   return item.id;
@@ -53,6 +69,7 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
     onNearHistoryStart,
     pinUserInputsEnabled,
     onPinnedUserInputChange,
+    pinnedUserInputOverlay,
     isLoadingOlderHistory,
     hasOlderHistory,
     scrollEnabled,
@@ -84,33 +101,20 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
     return [...segments.historyVirtualized, ...segments.historyMounted];
   }, [segments.historyMounted, segments.historyVirtualized]);
 
-  const collectPinnedUserInputCandidates = useCallback((): PinnedUserInputCandidate[] => {
-    const candidates: PinnedUserInputCandidate[] = [];
-    let top = 0;
-    for (const item of historyRows.toReversed()) {
-      const height = estimateStreamItemHeight(item);
-      if (item.kind === "user_message") {
-        candidates.push({
-          item,
-          top,
-          bottom: top + height,
-        });
-      }
-      top += height;
-    }
-    return candidates;
+  const collectPinnedUserInputCandidates = useCallback(() => {
+    return collectEstimatedPinnedUserInputCandidates({
+      items: historyRows,
+      estimateHeight: estimateStreamItemHeight,
+    });
   }, [historyRows]);
 
   const findEstimatedNormalTop = useCallback(
     (itemId: string): number | null => {
-      let top = 0;
-      for (const item of historyRows.toReversed()) {
-        if (item.id === itemId) {
-          return top;
-        }
-        top += estimateStreamItemHeight(item);
-      }
-      return null;
+      return findEstimatedStreamItemTop({
+        items: historyRows,
+        itemId,
+        estimateHeight: estimateStreamItemHeight,
+      });
     },
     [historyRows],
   );
@@ -267,7 +271,13 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
         if (itemTop === null || metrics.viewportHeight <= 0 || metrics.contentHeight <= 0) {
           return;
         }
-        const offset = Math.max(0, metrics.contentHeight - itemTop - metrics.viewportHeight);
+        const offset = Math.max(
+          0,
+          metrics.contentHeight -
+            itemTop -
+            metrics.viewportHeight +
+            PINNED_USER_INPUT_SCROLL_TOP_OFFSET,
+        );
         programmaticScrollEventBudgetRef.current = 3;
         flatListRef.current?.scrollToOffset({
           offset,
@@ -387,6 +397,8 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
     updatePinnedUserInput();
   }, [historyRows, pinUserInputsEnabled, updatePinnedUserInput]);
 
+  const containerStyle = useMemo(() => [nativeStyles.container, listStyle], [listStyle]);
+
   const renderItem = useStableEvent(
     ({ item, index }: ListRenderItemInfo<StreamItem>): ReactElement | null => {
       const rendered = renderHistoryMountedRow(item, index, historyRows);
@@ -427,31 +439,34 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
   }, [isLoadingOlderHistory]);
 
   return (
-    <FlatList
-      ref={flatListRef}
-      data={historyRows}
-      renderItem={renderItem}
-      keyExtractor={keyExtractor}
-      testID="agent-chat-scroll"
-      nativeID="agent-chat-scroll-native-virtualized"
-      ListHeaderComponent={liveHeaderContent ?? undefined}
-      ListFooterComponent={historyFooterContent ?? undefined}
-      contentContainerStyle={baseListContentContainerStyle}
-      style={listStyle}
-      onLayout={handleListLayout}
-      onScroll={handleScroll}
-      scrollEventThrottle={16}
-      onContentSizeChange={handleContentSizeChange}
-      maintainVisibleContentPosition={DEFAULT_MAINTAIN_VISIBLE_CONTENT_POSITION}
-      initialNumToRender={40}
-      maxToRenderPerBatch={40}
-      updateCellsBatchingPeriod={0}
-      windowSize={21}
-      removeClippedSubviews={false}
-      scrollEnabled={scrollEnabled}
-      showsVerticalScrollIndicator
-      inverted
-    />
+    <View style={containerStyle}>
+      <FlatList
+        ref={flatListRef}
+        data={historyRows}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        testID="agent-chat-scroll"
+        nativeID="agent-chat-scroll-native-virtualized"
+        ListHeaderComponent={liveHeaderContent ?? undefined}
+        ListFooterComponent={historyFooterContent ?? undefined}
+        contentContainerStyle={baseListContentContainerStyle}
+        style={nativeStyles.list}
+        onLayout={handleListLayout}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        onContentSizeChange={handleContentSizeChange}
+        maintainVisibleContentPosition={DEFAULT_MAINTAIN_VISIBLE_CONTENT_POSITION}
+        initialNumToRender={40}
+        maxToRenderPerBatch={40}
+        updateCellsBatchingPeriod={0}
+        windowSize={21}
+        removeClippedSubviews={false}
+        scrollEnabled={scrollEnabled}
+        showsVerticalScrollIndicator
+        inverted
+      />
+      {pinnedUserInputOverlay}
+    </View>
   );
 }
 

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -1,8 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import React from "react";
-import { act } from "react";
+import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { StreamItem } from "@/types/stream";
@@ -33,6 +32,15 @@ function userMessage(index: number): StreamItem {
     id: `message-${index}`,
     text: `Message ${index}`,
     timestamp: new Date(`2026-04-20T00:00:${String(index % 60).padStart(2, "0")}.000Z`),
+  };
+}
+
+function assistantMessage(index: number): StreamItem {
+  return {
+    kind: "assistant_message",
+    id: `assistant-${index}`,
+    text: `Assistant ${index}`,
+    timestamp: new Date(`2026-04-20T00:01:${String(index % 60).padStart(2, "0")}.000Z`),
   };
 }
 
@@ -133,6 +141,8 @@ describe("createWebStreamStrategy", () => {
             isAuthoritativeHistoryReady: true,
             onNearBottomChange: vi.fn(),
             onNearHistoryStart: vi.fn(),
+            pinUserInputsEnabled: false,
+            onPinnedUserInputChange: vi.fn(),
             isLoadingOlderHistory: false,
             hasOlderHistory: false,
             scrollEnabled: true,
@@ -178,6 +188,8 @@ describe("createWebStreamStrategy", () => {
             isAuthoritativeHistoryReady: true,
             onNearBottomChange: vi.fn(),
             onNearHistoryStart,
+            pinUserInputsEnabled: false,
+            onPinnedUserInputChange: vi.fn(),
             isLoadingOlderHistory: false,
             hasOlderHistory: true,
             scrollEnabled: true,
@@ -204,5 +216,95 @@ describe("createWebStreamStrategy", () => {
     });
 
     expect(onNearHistoryStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a pinned user input and scrolls to its source row", () => {
+    const strategy = createWebStreamStrategy({ isMobileBreakpoint: true });
+    const viewportRef = React.createRef<StreamViewportHandle>();
+    const onPinnedUserInputChange = vi.fn();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(
+        <>
+          {strategy.render({
+            agentId: "agent",
+            segments: {
+              historyVirtualized: [],
+              historyMounted: [
+                userMessage(1),
+                assistantMessage(1),
+                userMessage(2),
+                assistantMessage(2),
+              ],
+              liveHead: [],
+            },
+            boundary: {
+              hasVirtualizedHistory: false,
+              hasMountedHistory: true,
+              hasLiveHead: false,
+            },
+            renderers: createRenderers(vi.fn()),
+            listEmptyComponent: null,
+            viewportRef,
+            routeBottomAnchorRequest: null,
+            isAuthoritativeHistoryReady: true,
+            onNearBottomChange: vi.fn(),
+            onNearHistoryStart: vi.fn(),
+            pinUserInputsEnabled: true,
+            onPinnedUserInputChange,
+            isLoadingOlderHistory: false,
+            hasOlderHistory: false,
+            scrollEnabled: true,
+            listStyle: null,
+            baseListContentContainerStyle: null,
+            forwardListContentContainerStyle: null,
+          })}
+        </>,
+      );
+    });
+
+    const scrollContainer = container.querySelector('[data-testid="agent-chat-scroll"]');
+    const firstUserRow = container.querySelector('[data-stream-item-id="message-1"]');
+    const firstAssistantRow = container.querySelector('[data-stream-item-id="assistant-1"]');
+    const secondUserRow = container.querySelector('[data-stream-item-id="message-2"]');
+    const secondAssistantRow = container.querySelector('[data-stream-item-id="assistant-2"]');
+
+    expect(scrollContainer).toBeInstanceOf(HTMLElement);
+    expect(firstUserRow).toBeInstanceOf(HTMLElement);
+    expect(firstAssistantRow).toBeInstanceOf(HTMLElement);
+    expect(secondUserRow).toBeInstanceOf(HTMLElement);
+    expect(secondAssistantRow).toBeInstanceOf(HTMLElement);
+
+    Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 300 });
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1000 });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 120 });
+    Object.defineProperty(firstUserRow, "offsetTop", { configurable: true, value: 16 });
+    Object.defineProperty(firstUserRow, "offsetHeight", { configurable: true, value: 80 });
+    Object.defineProperty(firstAssistantRow, "offsetTop", { configurable: true, value: 120 });
+    Object.defineProperty(firstAssistantRow, "offsetHeight", { configurable: true, value: 320 });
+    Object.defineProperty(secondUserRow, "offsetTop", { configurable: true, value: 500 });
+    Object.defineProperty(secondUserRow, "offsetHeight", { configurable: true, value: 80 });
+    Object.defineProperty(secondAssistantRow, "offsetTop", { configurable: true, value: 610 });
+    Object.defineProperty(secondAssistantRow, "offsetHeight", { configurable: true, value: 320 });
+
+    act(() => {
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(onPinnedUserInputChange).toHaveBeenLastCalledWith({
+      item: expect.objectContaining({ id: "message-1" }),
+    });
+
+    act(() => {
+      viewportRef.current?.scrollToStreamItemTop("message-1");
+    });
+
+    expect(HTMLElement.prototype.scrollTo).toHaveBeenLastCalledWith({
+      top: 16,
+      behavior: "smooth",
+    });
   });
 });

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -143,6 +143,7 @@ describe("createWebStreamStrategy", () => {
             onNearHistoryStart: vi.fn(),
             pinUserInputsEnabled: false,
             onPinnedUserInputChange: vi.fn(),
+            pinnedUserInputOverlay: null,
             isLoadingOlderHistory: false,
             hasOlderHistory: false,
             scrollEnabled: true,
@@ -190,6 +191,7 @@ describe("createWebStreamStrategy", () => {
             onNearHistoryStart,
             pinUserInputsEnabled: false,
             onPinnedUserInputChange: vi.fn(),
+            pinnedUserInputOverlay: null,
             isLoadingOlderHistory: false,
             hasOlderHistory: true,
             scrollEnabled: true,
@@ -255,6 +257,7 @@ describe("createWebStreamStrategy", () => {
             onNearHistoryStart: vi.fn(),
             pinUserInputsEnabled: true,
             onPinnedUserInputChange,
+            pinnedUserInputOverlay: <div data-testid="pinned-user-input-overlay" />,
             isLoadingOlderHistory: false,
             hasOlderHistory: false,
             scrollEnabled: true,
@@ -277,6 +280,9 @@ describe("createWebStreamStrategy", () => {
     expect(firstAssistantRow).toBeInstanceOf(HTMLElement);
     expect(secondUserRow).toBeInstanceOf(HTMLElement);
     expect(secondAssistantRow).toBeInstanceOf(HTMLElement);
+    expect(
+      scrollContainer?.querySelector('[data-testid="pinned-user-input-overlay"]'),
+    ).toBeInstanceOf(HTMLElement);
 
     Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 300 });
     Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1000 });
@@ -303,7 +309,7 @@ describe("createWebStreamStrategy", () => {
     });
 
     expect(HTMLElement.prototype.scrollTo).toHaveBeenLastCalledWith({
-      top: 16,
+      top: 1,
       behavior: "smooth",
     });
   });

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -1,6 +1,6 @@
 import React, {
-  Fragment,
   type CSSProperties,
+  type ReactNode,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -10,9 +10,11 @@ import React, {
 } from "react";
 import { ActivityIndicator } from "react-native";
 import { measureElement as measureVirtualElement, useVirtualizer } from "@tanstack/react-virtual";
+import { useWebElementScrollbar } from "@/components/use-web-scrollbar";
 import { estimateStreamItemHeight } from "./web-virtualization";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./strategy";
 import { createStreamStrategy } from "./strategy";
+import { selectPinnedUserInput, type PinnedUserInputCandidate } from "./pinned-user-input";
 
 interface CreateWebStreamStrategyInput {
   isMobileBreakpoint: boolean;
@@ -25,7 +27,56 @@ const USER_SCROLL_DELTA_EPSILON = 1;
 const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 64;
 const AUTO_SCROLL_RESUME_THRESHOLD_PX = 1;
 const HISTORY_START_THRESHOLD_PX = 96;
-import { useWebElementScrollbar } from "@/components/use-web-scrollbar";
+
+interface StreamItemElementProps {
+  children: ReactNode;
+  itemId: string;
+  setStreamItemElement: (itemId: string, node: HTMLDivElement | null) => void;
+}
+
+function StreamItemElement({ children, itemId, setStreamItemElement }: StreamItemElementProps) {
+  const handleRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      setStreamItemElement(itemId, node);
+    },
+    [itemId, setStreamItemElement],
+  );
+
+  return (
+    <div key={itemId} data-stream-item-id={itemId} ref={handleRef}>
+      {children}
+    </div>
+  );
+}
+
+interface VirtualStreamItemElementProps extends StreamItemElementProps {
+  index: number;
+  measureElement: (node: HTMLDivElement | null) => void;
+  style: CSSProperties;
+}
+
+function VirtualStreamItemElement({
+  children,
+  index,
+  itemId,
+  measureElement,
+  setStreamItemElement,
+  style,
+}: VirtualStreamItemElementProps) {
+  const handleRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      measureElement(node);
+      setStreamItemElement(itemId, node);
+    },
+    [itemId, measureElement, setStreamItemElement],
+  );
+
+  return (
+    <div data-index={index} data-stream-item-id={itemId} ref={handleRef} style={style}>
+      {children}
+    </div>
+  );
+}
 
 const historyStartSlotStyle: CSSProperties = {
   display: "flex",
@@ -103,6 +154,8 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     isAuthoritativeHistoryReady,
     onNearBottomChange,
     onNearHistoryStart,
+    pinUserInputsEnabled,
+    onPinnedUserInputChange,
     isLoadingOlderHistory,
     hasOlderHistory,
     scrollEnabled,
@@ -110,11 +163,24 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   } = props;
   const scrollContainerRef = useRef<HTMLElement | null>(null);
   const contentRef = useRef<HTMLElement | null>(null);
+  const virtualRowsContainerRef = useRef<HTMLDivElement | null>(null);
+  const streamItemElementByIdRef = useRef(new Map<string, HTMLElement>());
   const handleScrollContainerRef = useCallback((node: HTMLElement | null) => {
     scrollContainerRef.current = node;
   }, []);
   const handleContentRef = useCallback((node: HTMLElement | null) => {
     contentRef.current = node;
+  }, []);
+  const handleVirtualRowsContainerRef = useCallback((node: HTMLDivElement | null) => {
+    virtualRowsContainerRef.current = node;
+  }, []);
+  const setStreamItemElement = useCallback((itemId: string, node: HTMLElement | null) => {
+    const elements = streamItemElementByIdRef.current;
+    if (node) {
+      elements.set(itemId, node);
+      return;
+    }
+    elements.delete(itemId);
   }, []);
   const [followOutput, setFollowOutputr] = useState(true);
   const setFollowOutput = (value: boolean) => {
@@ -267,6 +333,56 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     syncNearBottom(scrollContainer, onNearBottomChange);
   }, [onNearBottomChange]);
 
+  const collectPinnedUserInputCandidates = useCallback((): PinnedUserInputCandidate[] => {
+    const candidates: PinnedUserInputCandidate[] = [];
+    const virtualContainerTop = virtualRowsContainerRef.current?.offsetTop ?? 0;
+    let virtualTop = virtualContainerTop;
+    for (const item of segments.historyVirtualized) {
+      const height = estimateStreamItemHeight(item);
+      if (item.kind === "user_message") {
+        candidates.push({
+          item,
+          top: virtualTop,
+          bottom: virtualTop + height,
+        });
+      }
+      virtualTop += height;
+    }
+
+    const mountedItems = [...segments.historyMounted, ...segments.liveHead];
+    for (const item of mountedItems) {
+      if (item.kind !== "user_message") {
+        continue;
+      }
+      const element = streamItemElementByIdRef.current.get(item.id);
+      if (!element) {
+        continue;
+      }
+      candidates.push({
+        item,
+        top: element.offsetTop,
+        bottom: element.offsetTop + element.offsetHeight,
+      });
+    }
+    return candidates.toSorted((left, right) => left.top - right.top);
+  }, [segments.historyMounted, segments.historyVirtualized, segments.liveHead]);
+
+  const updatePinnedUserInput = useCallback(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) {
+      onPinnedUserInputChange(null);
+      return;
+    }
+    onPinnedUserInputChange(
+      selectPinnedUserInput({
+        enabled: pinUserInputsEnabled,
+        candidates: collectPinnedUserInputCandidates(),
+        viewportTop: scrollContainer.scrollTop,
+        viewportBottom: scrollContainer.scrollTop + scrollContainer.clientHeight,
+      }),
+    );
+  }, [collectPinnedUserInputCandidates, onPinnedUserInputChange, pinUserInputsEnabled]);
+
   const handleDomScroll = useCallback(() => {
     const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer) {
@@ -295,6 +411,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
 
     lastKnownScrollTopRef.current = currentScrollTop;
     updateScrollMetrics();
+    updatePinnedUserInput();
     if (
       historyStartReadyRef.current &&
       hasOlderHistory &&
@@ -302,7 +419,13 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     ) {
       onNearHistoryStart();
     }
-  }, [cancelPendingStickToBottom, hasOlderHistory, onNearHistoryStart, updateScrollMetrics]);
+  }, [
+    cancelPendingStickToBottom,
+    hasOlderHistory,
+    onNearHistoryStart,
+    updatePinnedUserInput,
+    updateScrollMetrics,
+  ]);
 
   useEffect(() => {
     const frame = window.requestAnimationFrame(() => {
@@ -359,11 +482,13 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
 
   useEffect(() => {
     updateScrollMetrics();
+    updatePinnedUserInput();
   }, [
     segments.historyMounted.length,
     segments.historyVirtualized.length,
     segments.liveHead.length,
     updateScrollMetrics,
+    updatePinnedUserInput,
     virtualTotalSize,
   ]);
 
@@ -377,6 +502,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     updateScrollMetrics();
     const observer = new ResizeObserver(() => {
       updateScrollMetrics();
+      updatePinnedUserInput();
       if (!followOutputRef.current) {
         return;
       }
@@ -389,7 +515,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     return () => {
       observer.disconnect();
     };
-  }, [scheduleStickToBottom, updateScrollMetrics]);
+  }, [scheduleStickToBottom, updatePinnedUserInput, updateScrollMetrics]);
 
   useEffect(() => {
     const scrollContainer = scrollContainerRef.current;
@@ -462,6 +588,27 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         cancelPendingStickToBottom();
         forceStickToBottom();
       },
+      scrollToStreamItemTop: (itemId: string) => {
+        const scrollContainer = scrollContainerRef.current;
+        if (!scrollContainer) {
+          return;
+        }
+        const element = streamItemElementByIdRef.current.get(itemId);
+        if (element) {
+          setFollowOutput(false);
+          scrollContainer.scrollTo({ top: element.offsetTop, behavior: "smooth" });
+          return;
+        }
+        let estimatedTop = virtualRowsContainerRef.current?.offsetTop ?? 0;
+        for (const item of segments.historyVirtualized) {
+          if (item.id === itemId) {
+            setFollowOutput(false);
+            scrollContainer.scrollTo({ top: estimatedTop, behavior: "smooth" });
+            return;
+          }
+          estimatedTop += estimateStreamItemHeight(item);
+        }
+      },
       prepareForViewportChange: () => {
         if (!followOutputRef.current) {
           return;
@@ -476,7 +623,13 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       }
       cancelPendingStickToBottom();
     };
-  }, [cancelPendingStickToBottom, forceStickToBottom, scheduleStickToBottom, viewportRef]);
+  }, [
+    cancelPendingStickToBottom,
+    forceStickToBottom,
+    scheduleStickToBottom,
+    segments.historyVirtualized,
+    viewportRef,
+  ]);
 
   const contentContainerStyle = useMemo((): CSSProperties => {
     return {
@@ -520,16 +673,18 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   );
   const mountedHistoryRows = useMemo(() => {
     return segments.historyMounted.map((item, index) => (
-      <Fragment key={item.id}>
+      <StreamItemElement key={item.id} itemId={item.id} setStreamItemElement={setStreamItemElement}>
         {renderHistoryMountedRow(item, index, segments.historyMounted)}
-      </Fragment>
+      </StreamItemElement>
     ));
-  }, [renderHistoryMountedRow, segments.historyMounted]);
+  }, [renderHistoryMountedRow, segments.historyMounted, setStreamItemElement]);
   const liveHeadRows = useMemo(() => {
     return segments.liveHead.map((item, index) => (
-      <Fragment key={item.id}>{renderLiveHeadRow(item, index, segments.liveHead)}</Fragment>
+      <StreamItemElement key={item.id} itemId={item.id} setStreamItemElement={setStreamItemElement}>
+        {renderLiveHeadRow(item, index, segments.liveHead)}
+      </StreamItemElement>
     ));
-  }, [renderLiveHeadRow, segments.liveHead]);
+  }, [renderLiveHeadRow, segments.liveHead, setStreamItemElement]);
   const liveAuxiliary = useMemo(() => {
     return renderLiveAuxiliary();
   }, [renderLiveAuxiliary]);
@@ -560,17 +715,19 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         <div ref={handleContentRef} style={contentContainerStyle}>
           {historyStartSlot}
           {shouldUseVirtualizer ? (
-            <div style={virtualRowsContainerStyle}>
+            <div ref={handleVirtualRowsContainerRef} style={virtualRowsContainerStyle}>
               {virtualRows.map((virtualRow) => {
                 const item = segments.historyVirtualized[virtualRow.index];
                 if (!item) {
                   return null;
                 }
                 return (
-                  <div
+                  <VirtualStreamItemElement
                     key={virtualRow.key}
-                    data-index={virtualRow.index}
-                    ref={measureVirtualizedRowElement}
+                    index={virtualRow.index}
+                    itemId={item.id}
+                    measureElement={measureVirtualizedRowElement}
+                    setStreamItemElement={setStreamItemElement}
                     style={renderVirtualRowStyle(virtualRow.start)}
                   >
                     {renderHistoryVirtualizedRow(
@@ -578,7 +735,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
                       virtualRow.index,
                       segments.historyVirtualized,
                     )}
-                  </div>
+                  </VirtualStreamItemElement>
                 );
               })}
             </div>

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -13,8 +13,13 @@ import { measureElement as measureVirtualElement, useVirtualizer } from "@tansta
 import { useWebElementScrollbar } from "@/components/use-web-scrollbar";
 import { estimateStreamItemHeight } from "./web-virtualization";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./strategy";
-import { createStreamStrategy } from "./strategy";
-import { selectPinnedUserInput, type PinnedUserInputCandidate } from "./pinned-user-input";
+import { createStreamStrategy, PINNED_USER_INPUT_SCROLL_TOP_OFFSET } from "./strategy";
+import {
+  collectEstimatedPinnedUserInputCandidates,
+  findEstimatedStreamItemTop,
+  selectPinnedUserInput,
+  type PinnedUserInputCandidate,
+} from "./pinned-user-input";
 
 interface CreateWebStreamStrategyInput {
   isMobileBreakpoint: boolean;
@@ -43,7 +48,7 @@ function StreamItemElement({ children, itemId, setStreamItemElement }: StreamIte
   );
 
   return (
-    <div key={itemId} data-stream-item-id={itemId} ref={handleRef}>
+    <div key={itemId} data-stream-item-id={itemId} ref={handleRef} style={streamItemElementStyle}>
       {children}
     </div>
   );
@@ -85,6 +90,26 @@ const historyStartSlotStyle: CSSProperties = {
   minHeight: 32,
   paddingTop: 4,
   paddingBottom: 8,
+};
+
+const pinnedUserInputStickySlotStyle: CSSProperties = {
+  position: "sticky",
+  top: 0,
+  zIndex: 4,
+  height: 0,
+  pointerEvents: "none",
+};
+
+const pinnedUserInputStickyLayerStyle: CSSProperties = {
+  position: "relative",
+  height: 0,
+  pointerEvents: "auto",
+};
+
+const streamItemElementStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
 };
 
 function isScrollContainerNearBottom(
@@ -156,6 +181,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     onNearHistoryStart,
     pinUserInputsEnabled,
     onPinnedUserInputChange,
+    pinnedUserInputOverlay,
     isLoadingOlderHistory,
     hasOlderHistory,
     scrollEnabled,
@@ -334,20 +360,12 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   }, [onNearBottomChange]);
 
   const collectPinnedUserInputCandidates = useCallback((): PinnedUserInputCandidate[] => {
-    const candidates: PinnedUserInputCandidate[] = [];
     const virtualContainerTop = virtualRowsContainerRef.current?.offsetTop ?? 0;
-    let virtualTop = virtualContainerTop;
-    for (const item of segments.historyVirtualized) {
-      const height = estimateStreamItemHeight(item);
-      if (item.kind === "user_message") {
-        candidates.push({
-          item,
-          top: virtualTop,
-          bottom: virtualTop + height,
-        });
-      }
-      virtualTop += height;
-    }
+    const candidates = collectEstimatedPinnedUserInputCandidates({
+      items: segments.historyVirtualized,
+      estimateHeight: estimateStreamItemHeight,
+      initialTop: virtualContainerTop,
+    });
 
     const mountedItems = [...segments.historyMounted, ...segments.liveHead];
     for (const item of mountedItems) {
@@ -596,18 +614,26 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         const element = streamItemElementByIdRef.current.get(itemId);
         if (element) {
           setFollowOutput(false);
-          scrollContainer.scrollTo({ top: element.offsetTop, behavior: "smooth" });
+          scrollContainer.scrollTo({
+            top: Math.max(0, element.offsetTop - PINNED_USER_INPUT_SCROLL_TOP_OFFSET),
+            behavior: "smooth",
+          });
           return;
         }
-        let estimatedTop = virtualRowsContainerRef.current?.offsetTop ?? 0;
-        for (const item of segments.historyVirtualized) {
-          if (item.id === itemId) {
-            setFollowOutput(false);
-            scrollContainer.scrollTo({ top: estimatedTop, behavior: "smooth" });
-            return;
-          }
-          estimatedTop += estimateStreamItemHeight(item);
+        const estimatedTop = findEstimatedStreamItemTop({
+          items: segments.historyVirtualized,
+          itemId,
+          estimateHeight: estimateStreamItemHeight,
+          initialTop: virtualRowsContainerRef.current?.offsetTop ?? 0,
+        });
+        if (estimatedTop === null) {
+          return;
         }
+        setFollowOutput(false);
+        scrollContainer.scrollTo({
+          top: Math.max(0, estimatedTop - PINNED_USER_INPUT_SCROLL_TOP_OFFSET),
+          behavior: "smooth",
+        });
       },
       prepareForViewportChange: () => {
         if (!followOutputRef.current) {
@@ -712,6 +738,11 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         id={`agent-chat-scroll-${shouldUseVirtualizer ? "web-dom-virtualized" : "web-dom-scroll"}`}
         style={scrollContainerStyle}
       >
+        {pinnedUserInputOverlay ? (
+          <div style={pinnedUserInputStickySlotStyle}>
+            <div style={pinnedUserInputStickyLayerStyle}>{pinnedUserInputOverlay}</div>
+          </div>
+        ) : null}
         <div ref={handleContentRef} style={contentContainerStyle}>
           {historyStartSlot}
           {shouldUseVirtualizer ? (

--- a/packages/app/src/agent-stream/strategy.ts
+++ b/packages/app/src/agent-stream/strategy.ts
@@ -6,6 +6,7 @@ import type {
   BottomAnchorLocalRequest,
   BottomAnchorRouteRequest,
 } from "./bottom-anchor-controller";
+import type { PinnedUserInputState } from "./pinned-user-input";
 
 type EdgeSlot = "header" | "footer";
 type NeighborRelation = "above" | "below";
@@ -41,6 +42,7 @@ export interface StreamEdgeSlotProps {
 
 export interface StreamViewportHandle {
   scrollToBottom: (reason?: BottomAnchorLocalRequest["reason"]) => void;
+  scrollToStreamItemTop: (itemId: string) => void;
   prepareForViewportChange: () => void;
 }
 
@@ -62,6 +64,8 @@ export interface StreamRenderInput {
   isAuthoritativeHistoryReady: boolean;
   onNearBottomChange: (value: boolean) => void;
   onNearHistoryStart: () => void;
+  pinUserInputsEnabled: boolean;
+  onPinnedUserInputChange: (state: PinnedUserInputState | null) => void;
   isLoadingOlderHistory: boolean;
   hasOlderHistory: boolean;
   scrollEnabled: boolean;

--- a/packages/app/src/agent-stream/strategy.ts
+++ b/packages/app/src/agent-stream/strategy.ts
@@ -12,6 +12,7 @@ type EdgeSlot = "header" | "footer";
 type NeighborRelation = "above" | "below";
 type AssistantTurnTraversalStep = -1 | 1;
 export type StreamFrameChildOrder = "content-then-footer" | "footer-then-content";
+export const PINNED_USER_INPUT_SCROLL_TOP_OFFSET = 15;
 
 export type MaintainVisibleContentPositionConfig = Readonly<{
   minIndexForVisible: number;
@@ -66,6 +67,7 @@ export interface StreamRenderInput {
   onNearHistoryStart: () => void;
   pinUserInputsEnabled: boolean;
   onPinnedUserInputChange: (state: PinnedUserInputState | null) => void;
+  pinnedUserInputOverlay: ReactNode;
   isLoadingOlderHistory: boolean;
   hasOlderHistory: boolean;
   scrollEnabled: boolean;

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -18,6 +18,7 @@ import {
   Pressable,
   Platform,
   ActivityIndicator,
+  type LayoutChangeEvent,
   type PressableStateCallbackType,
   type StyleProp,
   type ViewStyle,
@@ -25,7 +26,7 @@ import {
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { MAX_CONTENT_WIDTH, useIsCompactFormFactor } from "@/constants/layout";
 import { useMutation } from "@tanstack/react-query";
-import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
+import Animated, { FadeIn, FadeOut, SlideInUp, SlideOutUp } from "react-native-reanimated";
 import MaskedView from "@react-native-masked-view/masked-view";
 import Svg, { Defs, LinearGradient as SvgLinearGradient, Rect, Stop } from "react-native-svg";
 import { Check, ChevronDown, X } from "lucide-react-native";
@@ -34,7 +35,7 @@ import {
   AssistantMessage,
   SpeakMessage,
   UserMessage,
-  PinnedUserMessagePreview,
+  PinnedUserMessage,
   ActivityLog,
   ToolCall,
   TodoListCard,
@@ -82,20 +83,30 @@ import { navigateToPreparedWorkspaceTab } from "@/utils/workspace-navigation";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import { isWeb } from "@/constants/platform";
 import type { Theme } from "@/styles/theme";
+import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { recordRenderProfileReasons } from "@/utils/render-profiler";
 import { MountedTabActiveContext } from "@/components/split-container";
 import { useAppSettings } from "@/hooks/use-settings";
 import type { PinnedUserInputState } from "./pinned-user-input";
 
-const PINNED_USER_INPUT_MASK_ELEMENT = (
+const PINNED_USER_INPUT_TOP_PADDING = 15;
+const PINNED_USER_INPUT_MAX_HEIGHT = 118;
+const PINNED_USER_INPUT_GRADIENT_HEIGHT = 48;
+const PINNED_USER_INPUT_SOLID_BACKGROUND_HEIGHT =
+  PINNED_USER_INPUT_TOP_PADDING + PINNED_USER_INPUT_MAX_HEIGHT;
+const PINNED_USER_INPUT_OVERLAY_HEIGHT =
+  PINNED_USER_INPUT_SOLID_BACKGROUND_HEIGHT + PINNED_USER_INPUT_GRADIENT_HEIGHT;
+const pinnedUserInputEntering = SlideInUp.duration(320);
+const pinnedUserInputExiting = SlideOutUp.duration(280);
+const pinnedUserInputGradientMask = (
   <Svg width="100%" height="100%" preserveAspectRatio="none">
     <Defs>
-      <SvgLinearGradient id="pinnedUserInputFade" x1="0" y1="0" x2="0" y2="1">
-        <Stop offset="0" stopColor="#000000" stopOpacity={1} />
-        <Stop offset="1" stopColor="#000000" stopOpacity={0} />
+      <SvgLinearGradient id="pinnedUserInputFadeMask" x1="0" y1="0" x2="0" y2="1">
+        <Stop offset="0%" stopColor="#000000" stopOpacity="1" />
+        <Stop offset="100%" stopColor="#000000" stopOpacity="0" />
       </SvgLinearGradient>
     </Defs>
-    <Rect x="0" y="0" width="100%" height="100%" fill="url(#pinnedUserInputFade)" />
+    <Rect x="0" y="0" width="100%" height="100%" fill="url(#pinnedUserInputFadeMask)" />
   </Svg>
 );
 
@@ -118,46 +129,80 @@ function renderLiveAuxiliaryNode(input: {
   );
 }
 
-function PinnedUserInputGradient() {
+function PinnedUserInputGradient({ style }: { style: StyleProp<ViewStyle> }) {
   return (
-    <MaskedView
-      pointerEvents="none"
-      style={stylesheet.pinnedUserInputGradient}
-      maskElement={PINNED_USER_INPUT_MASK_ELEMENT}
-    >
+    <MaskedView pointerEvents="none" style={style} maskElement={pinnedUserInputGradientMask}>
       <View pointerEvents="none" style={stylesheet.pinnedUserInputGradientFill} />
     </MaskedView>
   );
 }
 
 function PinnedUserInputOverlay({
-  pinnedUserInput,
   accessibilityLabel,
+  children,
+  entering,
+  exiting,
   onPress,
 }: {
-  pinnedUserInput: PinnedUserInputState;
   accessibilityLabel: string;
+  children: ReactNode;
+  entering?: ComponentProps<typeof Animated.View>["entering"];
+  exiting?: ComponentProps<typeof Animated.View>["exiting"];
   onPress: () => void;
 }) {
-  const item = pinnedUserInput.item;
+  const [solidBackgroundHeight, setSolidBackgroundHeight] = useState(
+    PINNED_USER_INPUT_SOLID_BACKGROUND_HEIGHT,
+  );
+  const handlePinnedContentLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextHeight = Math.max(PINNED_USER_INPUT_TOP_PADDING, event.nativeEvent.layout.height);
+    setSolidBackgroundHeight((previousHeight) =>
+      previousHeight === nextHeight ? previousHeight : nextHeight,
+    );
+  }, []);
+  const overlayStyle = useMemo(
+    () => [
+      stylesheet.pinnedUserInputOverlay,
+      inlineUnistylesStyle({
+        height: solidBackgroundHeight + PINNED_USER_INPUT_GRADIENT_HEIGHT,
+      }),
+    ],
+    [solidBackgroundHeight],
+  );
+  const backgroundBlockStyle = useMemo(
+    () => [
+      stylesheet.pinnedUserInputBackgroundBlock,
+      inlineUnistylesStyle({ height: solidBackgroundHeight }),
+    ],
+    [solidBackgroundHeight],
+  );
+  const gradientStyle = useMemo(
+    () => [
+      stylesheet.pinnedUserInputGradient,
+      inlineUnistylesStyle({ top: solidBackgroundHeight }),
+    ],
+    [solidBackgroundHeight],
+  );
+
   return (
-    <View pointerEvents="box-none" style={stylesheet.pinnedUserInputOverlay}>
-      <PinnedUserInputGradient />
-      <View pointerEvents="box-none" style={stylesheet.pinnedUserInputContentWrapper}>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={accessibilityLabel}
-          onPress={onPress}
-          testID="pinned-user-input-button"
-        >
-          <PinnedUserMessagePreview
-            message={item.text}
-            images={item.images}
-            attachments={item.attachments}
-          />
-        </Pressable>
-      </View>
-    </View>
+    <Animated.View
+      pointerEvents="box-none"
+      entering={entering}
+      exiting={exiting}
+      style={overlayStyle}
+    >
+      <View pointerEvents="none" style={backgroundBlockStyle} />
+      <PinnedUserInputGradient style={gradientStyle} />
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        onPress={onPress}
+        onLayout={handlePinnedContentLayout}
+        testID="pinned-user-input-button"
+        style={stylesheet.pinnedUserInputPressable}
+      >
+        {children}
+      </Pressable>
+    </Animated.View>
   );
 }
 
@@ -527,6 +572,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
 
     const renderUserMessageItem = useCallback(
       (layoutItem: StreamLayoutItem, item: Extract<StreamItem, { kind: "user_message" }>) => {
+        const presentation = pinnedUserInput?.item.id === item.id ? "placeholder" : "inline";
         return (
           <UserMessage
             serverId={resolvedServerId}
@@ -540,10 +586,11 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             client={client}
             isFirstInGroup={layoutItem.isFirstInUserGroup}
             isLastInGroup={layoutItem.isLastInUserGroup}
+            presentation={presentation}
           />
         );
       },
-      [agent.capabilities, agentId, client, resolvedServerId],
+      [agent.capabilities, agentId, client, pinnedUserInput?.item.id, resolvedServerId],
     );
 
     const renderAssistantMessageItem = useCallback(
@@ -822,6 +869,30 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       !streamRenderStrategy.shouldDisableParentScrollOnInlineDetailsExpansion() ||
       expandedInlineToolCallIds.size === 0;
 
+    const pinnedUserInputOverlay = useMemo(() => {
+      const item = pinnedUserInput?.item;
+      if (!item) {
+        return null;
+      }
+
+      return (
+        <PinnedUserInputOverlay
+          accessibilityLabel={t("agentStream.scrollToPinnedUserInput")}
+          entering={shouldDisableEntryExitAnimations ? undefined : pinnedUserInputEntering}
+          exiting={shouldDisableEntryExitAnimations ? undefined : pinnedUserInputExiting}
+          onPress={scrollToPinnedUserInput}
+        >
+          <StreamItemWrapper gapBelow={0}>
+            <PinnedUserMessage
+              message={item.text}
+              images={item.images}
+              attachments={item.attachments}
+            />
+          </StreamItemWrapper>
+        </PinnedUserInputOverlay>
+      );
+    }, [pinnedUserInput?.item, scrollToPinnedUserInput, shouldDisableEntryExitAnimations, t]);
+
     return (
       <ToolCallSheetProvider>
         <View style={stylesheet.container}>
@@ -839,6 +910,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
               onNearHistoryStart: loadOlder,
               pinUserInputsEnabled: appSettings.pinUserInputs,
               onPinnedUserInputChange: handlePinnedUserInputChange,
+              pinnedUserInputOverlay,
               isLoadingOlderHistory: isLoadingOlder,
               hasOlderHistory: hasOlder,
               scrollEnabled: streamScrollEnabled,
@@ -847,13 +919,6 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
               forwardListContentContainerStyle: stylesheet.forwardListContentContainer,
             })}
           </MessageOuterSpacingProvider>
-          {pinnedUserInput ? (
-            <PinnedUserInputOverlay
-              pinnedUserInput={pinnedUserInput}
-              accessibilityLabel={t("agentStream.scrollToPinnedUserInput")}
-              onPress={scrollToPinnedUserInput}
-            />
-          ) : null}
           {!isNearBottom && (
             <Animated.View
               style={stylesheet.scrollToBottomContainer}
@@ -1331,29 +1396,31 @@ const stylesheet = StyleSheet.create((theme) => ({
     top: 0,
     left: 0,
     right: 0,
-    height: 154,
+    height: PINNED_USER_INPUT_OVERLAY_HEIGHT,
     pointerEvents: "box-none",
   },
-  pinnedUserInputGradient: {
+  pinnedUserInputBackgroundBlock: {
     position: "absolute",
     top: 0,
     left: 0,
     right: 0,
-    height: 154,
+    height: PINNED_USER_INPUT_SOLID_BACKGROUND_HEIGHT,
+    backgroundColor: theme.colors.surface0,
+  },
+  pinnedUserInputGradient: {
+    position: "absolute",
+    top: PINNED_USER_INPUT_SOLID_BACKGROUND_HEIGHT,
+    left: 0,
+    right: 0,
+    height: PINNED_USER_INPUT_GRADIENT_HEIGHT,
   },
   pinnedUserInputGradientFill: {
     flex: 1,
     backgroundColor: theme.colors.surface0,
   },
-  pinnedUserInputContentWrapper: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
+  pinnedUserInputPressable: {
     width: "100%",
-    maxWidth: MAX_CONTENT_WIDTH,
-    alignSelf: "center",
-    paddingHorizontal: theme.spacing[4],
+    paddingTop: PINNED_USER_INPUT_TOP_PADDING,
   },
 }));
 

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -1239,6 +1239,7 @@ const stylesheet = StyleSheet.create((theme) => ({
   container: {
     flex: 1,
     backgroundColor: theme.colors.surface0,
+    position: "relative",
   },
   contentWrapper: {
     width: "100%",
@@ -1342,13 +1343,16 @@ const stylesheet = StyleSheet.create((theme) => ({
   },
   pinnedUserInputGradientFill: {
     flex: 1,
-    backgroundColor: theme.colors.surface2,
+    backgroundColor: theme.colors.surface0,
   },
   pinnedUserInputContentWrapper: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
     width: "100%",
     maxWidth: MAX_CONTENT_WIDTH,
     alignSelf: "center",
-    paddingTop: theme.spacing[4],
     paddingHorizontal: theme.spacing[4],
   },
 }));

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -26,12 +26,15 @@ import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { MAX_CONTENT_WIDTH, useIsCompactFormFactor } from "@/constants/layout";
 import { useMutation } from "@tanstack/react-query";
 import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
+import MaskedView from "@react-native-masked-view/masked-view";
+import Svg, { Defs, LinearGradient as SvgLinearGradient, Rect, Stop } from "react-native-svg";
 import { Check, ChevronDown, X } from "lucide-react-native";
 import { usePanelStore } from "@/stores/panel-store";
 import {
   AssistantMessage,
   SpeakMessage,
   UserMessage,
+  PinnedUserMessagePreview,
   ActivityLog,
   ToolCall,
   TodoListCard,
@@ -81,6 +84,20 @@ import { isWeb } from "@/constants/platform";
 import type { Theme } from "@/styles/theme";
 import { recordRenderProfileReasons } from "@/utils/render-profiler";
 import { MountedTabActiveContext } from "@/components/split-container";
+import { useAppSettings } from "@/hooks/use-settings";
+import type { PinnedUserInputState } from "./pinned-user-input";
+
+const PINNED_USER_INPUT_MASK_ELEMENT = (
+  <Svg width="100%" height="100%" preserveAspectRatio="none">
+    <Defs>
+      <SvgLinearGradient id="pinnedUserInputFade" x1="0" y1="0" x2="0" y2="1">
+        <Stop offset="0" stopColor="#000000" stopOpacity={1} />
+        <Stop offset="1" stopColor="#000000" stopOpacity={0} />
+      </SvgLinearGradient>
+    </Defs>
+    <Rect x="0" y="0" width="100%" height="100%" fill="url(#pinnedUserInputFade)" />
+  </Svg>
+);
 
 function renderLiveAuxiliaryNode(input: {
   pendingPermissions: ReactNode;
@@ -98,6 +115,49 @@ function renderLiveAuxiliaryNode(input: {
         </View>
       ) : null}
     </>
+  );
+}
+
+function PinnedUserInputGradient() {
+  return (
+    <MaskedView
+      pointerEvents="none"
+      style={stylesheet.pinnedUserInputGradient}
+      maskElement={PINNED_USER_INPUT_MASK_ELEMENT}
+    >
+      <View pointerEvents="none" style={stylesheet.pinnedUserInputGradientFill} />
+    </MaskedView>
+  );
+}
+
+function PinnedUserInputOverlay({
+  pinnedUserInput,
+  accessibilityLabel,
+  onPress,
+}: {
+  pinnedUserInput: PinnedUserInputState;
+  accessibilityLabel: string;
+  onPress: () => void;
+}) {
+  const item = pinnedUserInput.item;
+  return (
+    <View pointerEvents="box-none" style={stylesheet.pinnedUserInputOverlay}>
+      <PinnedUserInputGradient />
+      <View pointerEvents="box-none" style={stylesheet.pinnedUserInputContentWrapper}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={accessibilityLabel}
+          onPress={onPress}
+          testID="pinned-user-input-button"
+        >
+          <PinnedUserMessagePreview
+            message={item.text}
+            images={item.images}
+            attachments={item.attachments}
+          />
+        </Pressable>
+      </View>
+    </View>
   );
 }
 
@@ -249,6 +309,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     ref,
   ) {
     const { t } = useTranslation();
+    const { settings: appSettings } = useAppSettings();
     const viewportRef = useRef<StreamViewportHandle | null>(null);
     const isMobile = useIsCompactFormFactor();
     const streamRenderStrategy = useMemo(
@@ -260,6 +321,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       [isMobile],
     );
     const [isNearBottom, setIsNearBottom] = useState(true);
+    const [pinnedUserInput, setPinnedUserInput] = useState<PinnedUserInputState | null>(null);
     const [expandedInlineToolCallIds, setExpandedInlineToolCallIds] = useState<Set<string>>(
       new Set(),
     );
@@ -297,8 +359,15 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
 
     useEffect(() => {
       setIsNearBottom(true);
+      setPinnedUserInput(null);
       setExpandedInlineToolCallIds(new Set());
     }, [agentId]);
+
+    useEffect(() => {
+      if (!appSettings.pinUserInputs) {
+        setPinnedUserInput(null);
+      }
+    }, [appSettings.pinUserInputs]);
 
     const handleInlinePathPress = useStableEvent(
       (target: InlinePathTarget, disposition: OpenFileDisposition) => {
@@ -416,6 +485,26 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
 
     const scrollToBottom = useCallback(() => {
       viewportRef.current?.scrollToBottom("jump-to-bottom");
+    }, []);
+
+    const scrollToPinnedUserInput = useCallback(() => {
+      const itemId = pinnedUserInput?.item.id;
+      if (!itemId) {
+        return;
+      }
+      viewportRef.current?.scrollToStreamItemTop(itemId);
+    }, [pinnedUserInput?.item.id]);
+
+    const handlePinnedUserInputChange = useCallback((next: PinnedUserInputState | null) => {
+      setPinnedUserInput((previous) => {
+        if (previous?.item === next?.item) {
+          return previous;
+        }
+        if (previous?.item.id === next?.item.id && previous?.item.text === next?.item.text) {
+          return previous;
+        }
+        return next;
+      });
     }, []);
 
     const setInlineDetailsExpanded = useCallback(
@@ -748,6 +837,8 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
               isAuthoritativeHistoryReady,
               onNearBottomChange: setIsNearBottom,
               onNearHistoryStart: loadOlder,
+              pinUserInputsEnabled: appSettings.pinUserInputs,
+              onPinnedUserInputChange: handlePinnedUserInputChange,
               isLoadingOlderHistory: isLoadingOlder,
               hasOlderHistory: hasOlder,
               scrollEnabled: streamScrollEnabled,
@@ -756,6 +847,13 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
               forwardListContentContainerStyle: stylesheet.forwardListContentContainer,
             })}
           </MessageOuterSpacingProvider>
+          {pinnedUserInput ? (
+            <PinnedUserInputOverlay
+              pinnedUserInput={pinnedUserInput}
+              accessibilityLabel={t("agentStream.scrollToPinnedUserInput")}
+              onPress={scrollToPinnedUserInput}
+            />
+          ) : null}
           {!isNearBottom && (
             <Animated.View
               style={stylesheet.scrollToBottomContainer}
@@ -1226,6 +1324,32 @@ const stylesheet = StyleSheet.create((theme) => ({
   },
   scrollToBottomIcon: {
     color: theme.colors.foreground,
+  },
+  pinnedUserInputOverlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 154,
+    pointerEvents: "box-none",
+  },
+  pinnedUserInputGradient: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 154,
+  },
+  pinnedUserInputGradientFill: {
+    flex: 1,
+    backgroundColor: theme.colors.surface2,
+  },
+  pinnedUserInputContentWrapper: {
+    width: "100%",
+    maxWidth: MAX_CONTENT_WIDTH,
+    alignSelf: "center",
+    paddingTop: theme.spacing[4],
+    paddingHorizontal: theme.spacing[4],
   },
 }));
 

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -129,7 +129,10 @@ interface UserMessageProps {
   isFirstInGroup?: boolean;
   isLastInGroup?: boolean;
   disableOuterSpacing?: boolean;
+  presentation?: UserMessagePresentation;
 }
+
+type UserMessagePresentation = "inline" | "placeholder";
 
 interface UserMessageBubbleContentProps {
   message: string;
@@ -372,6 +375,9 @@ const userMessageStylesheet = StyleSheet.create((theme) => ({
     maxHeight: 118,
     overflow: "hidden",
   },
+  placeholder: {
+    opacity: 0,
+  },
   text: {
     color: theme.colors.foreground,
     fontSize: theme.fontSize.base,
@@ -590,6 +596,7 @@ export const UserMessage = memo(function UserMessage({
   isFirstInGroup = true,
   isLastInGroup = true,
   disableOuterSpacing,
+  presentation = "inline",
 }: UserMessageProps) {
   const isCompact = useIsCompactFormFactor();
   const { t } = useTranslation();
@@ -597,6 +604,7 @@ export const UserMessage = memo(function UserMessage({
   const [lightboxMetadata, setLightboxMetadata] = useState<UserMessageImageAttachment | null>(null);
   const handleLightboxClose = useCallback(() => setLightboxMetadata(null), []);
   const resolvedDisableOuterSpacing = useDisableOuterSpacing(disableOuterSpacing);
+  const isPlaceholder = presentation === "placeholder";
   const hasText = message.trim().length > 0;
   const showTrailingRow = hasText && (isCompact || isNative || isHovered);
   const formattedTimestamp = useMemo(
@@ -623,9 +631,11 @@ export const UserMessage = memo(function UserMessage({
         isLastInGroup ? userMessageStylesheet.containerLastInGroup : null,
         !isFirstInGroup || !isLastInGroup ? userMessageStylesheet.containerSpacing : null,
       ],
+      isPlaceholder ? userMessageStylesheet.placeholder : null,
     ],
-    [resolvedDisableOuterSpacing, isFirstInGroup, isLastInGroup],
+    [resolvedDisableOuterSpacing, isFirstInGroup, isLastInGroup, isPlaceholder],
   );
+  const bubbleStyle = userMessageStylesheet.bubble;
   const trailingRowStyle = useMemo(
     () => [
       userMessageStylesheet.trailingRow,
@@ -637,18 +647,24 @@ export const UserMessage = memo(function UserMessage({
   );
 
   return (
-    <View style={containerStyle} testID="user-message">
+    <View
+      style={containerStyle}
+      testID="user-message"
+      pointerEvents={isPlaceholder ? "none" : "auto"}
+      accessibilityElementsHidden={isPlaceholder}
+      importantForAccessibility={isPlaceholder ? "no-hide-descendants" : "auto"}
+    >
       <View
         style={userMessageStylesheet.content}
         onPointerEnter={handlePointerEnter}
         onPointerLeave={handlePointerLeave}
       >
-        <View style={userMessageStylesheet.bubble}>
+        <View style={bubbleStyle}>
           <UserMessageBubbleContent
             message={message}
             images={images}
             attachments={attachments}
-            onOpenImage={setLightboxMetadata}
+            onOpenImage={isPlaceholder ? undefined : setLightboxMetadata}
           />
         </View>
         {hasText ? (
@@ -670,30 +686,32 @@ export const UserMessage = memo(function UserMessage({
           </View>
         ) : null}
       </View>
-      <AttachmentLightbox metadata={lightboxMetadata} onClose={handleLightboxClose} />
+      {!isPlaceholder ? (
+        <AttachmentLightbox metadata={lightboxMetadata} onClose={handleLightboxClose} />
+      ) : null}
     </View>
   );
 });
 
-interface PinnedUserMessagePreviewProps {
+interface PinnedUserMessageProps {
   message: string;
   images?: UserMessageImageAttachment[];
   attachments?: AgentAttachment[];
 }
 
-export const PinnedUserMessagePreview = memo(function PinnedUserMessagePreview({
+export const PinnedUserMessage = memo(function PinnedUserMessage({
   message,
   images = EMPTY_USER_MESSAGE_IMAGES,
   attachments = EMPTY_USER_MESSAGE_ATTACHMENTS,
-}: PinnedUserMessagePreviewProps) {
+}: PinnedUserMessageProps) {
   const bubbleStyle = useMemo(
     () => [userMessageStylesheet.bubble, userMessageStylesheet.pinnedBubble],
     [],
   );
 
   return (
-    <View style={userMessageStylesheet.container} testID="pinned-user-message-preview">
-      <View style={userMessageStylesheet.content} pointerEvents="none">
+    <View style={userMessageStylesheet.container} testID="pinned-user-message" pointerEvents="none">
+      <View style={userMessageStylesheet.content}>
         <View style={bubbleStyle}>
           <UserMessageBubbleContent
             message={message}

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -65,7 +65,7 @@ import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
 import { MarkdownRenderer, type MarkdownStyles } from "@/components/markdown/renderer";
 import type { TodoEntry, UserMessageImageAttachment } from "@/types/stream";
 import type { AgentAttachment } from "@getpaseo/protocol/messages";
-import type { ToolCallDetail } from "@getpaseo/protocol/agent-types";
+import type { AgentCapabilityFlags, ToolCallDetail } from "@getpaseo/protocol/agent-types";
 import { buildToolCallPresentation } from "@/tool-calls/presentation";
 import { resolveToolCallIcon } from "@/utils/tool-call-icon";
 import { getMarkdownListMarker, getMarkdownListSpacing } from "@/utils/markdown-list";
@@ -97,7 +97,6 @@ import {
   type AssistantFileLinkSource,
   AssistantMarkdownCodeLink,
   AssistantMarkdownLink,
-  type InlinePathTarget,
   useAssistantFileLinkActions,
   useAssistantLinkPress,
 } from "@/assistant-file-links";
@@ -113,7 +112,6 @@ import {
 import { AttachmentLightbox } from "@/components/attachment-lightbox";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { isWeb, isNative } from "@/constants/platform";
-import type { AgentCapabilityFlags } from "@getpaseo/protocol/agent-types";
 import { RewindMenu, type RewindMode } from "@/components/rewind/rewind-menu";
 import { useRewindAgentMutation } from "@/components/rewind/use-rewind-agent-mutation";
 export type { InlinePathTarget } from "@/assistant-file-links";
@@ -132,6 +130,18 @@ interface UserMessageProps {
   isLastInGroup?: boolean;
   disableOuterSpacing?: boolean;
 }
+
+interface UserMessageBubbleContentProps {
+  message: string;
+  images: UserMessageImageAttachment[];
+  attachments: AgentAttachment[];
+  onOpenImage?: (image: UserMessageImageAttachment) => void;
+  textNumberOfLines?: number;
+  selectable?: boolean;
+}
+
+const EMPTY_USER_MESSAGE_IMAGES: UserMessageImageAttachment[] = [];
+const EMPTY_USER_MESSAGE_ATTACHMENTS: AgentAttachment[] = [];
 
 const MessageOuterSpacingContext = createContext(false);
 
@@ -358,6 +368,10 @@ const userMessageStylesheet = StyleSheet.create((theme) => ({
     minWidth: 0,
     flexShrink: 1,
   },
+  pinnedBubble: {
+    maxHeight: 118,
+    overflow: "hidden",
+  },
   text: {
     color: theme.colors.foreground,
     fontSize: theme.fontSize.base,
@@ -433,6 +447,85 @@ function UserMessageImagePill({ image, onOpen, accessibilityLabel }: UserMessage
   );
 }
 
+function UserMessageBubbleContent({
+  message,
+  images,
+  attachments,
+  onOpenImage,
+  textNumberOfLines,
+  selectable = true,
+}: UserMessageBubbleContentProps) {
+  const { t } = useTranslation();
+  const hasText = message.trim().length > 0;
+  const hasImages = images.length > 0;
+  const hasAttachments = attachments.length > 0;
+  const imagePreviewContainerStyle = useMemo(
+    () => [
+      userMessageStylesheet.imagePreviewContainer,
+      hasText || hasAttachments ? userMessageStylesheet.imagePreviewSpacing : undefined,
+    ],
+    [hasAttachments, hasText],
+  );
+  const attachmentPreviewContainerStyle = useMemo(
+    () => [
+      userMessageStylesheet.attachmentPreviewContainer,
+      hasText ? userMessageStylesheet.imagePreviewSpacing : undefined,
+    ],
+    [hasText],
+  );
+
+  return (
+    <>
+      {hasImages ? (
+        <View style={imagePreviewContainerStyle}>
+          {images.map((image) =>
+            onOpenImage ? (
+              <UserMessageImagePill
+                key={image.id}
+                image={image}
+                onOpen={onOpenImage}
+                accessibilityLabel={t("composer.attachments.openImage")}
+              />
+            ) : (
+              <AttachmentFrame key={image.id}>
+                <AttachmentThumbnail metadata={image} />
+              </AttachmentFrame>
+            ),
+          )}
+        </View>
+      ) : null}
+      {hasAttachments ? (
+        <View style={attachmentPreviewContainerStyle}>
+          {attachments.map((attachment, index) => {
+            const content = getUserMessageAttachmentContent(attachment, t);
+            return (
+              <AttachmentFrame
+                key={`${attachment.type}:${"number" in attachment ? attachment.number : index}`}
+              >
+                <AttachmentLabel
+                  icon={content.icon}
+                  title={content.title}
+                  subtitle={content.subtitle}
+                />
+              </AttachmentFrame>
+            );
+          })}
+        </View>
+      ) : null}
+      {hasText ? (
+        <Text
+          selectable={selectable}
+          style={userMessageStylesheet.text}
+          numberOfLines={textNumberOfLines}
+          ellipsizeMode="tail"
+        >
+          {message}
+        </Text>
+      ) : null}
+    </>
+  );
+}
+
 interface UserMessageAttachmentContent {
   icon: ReactNode;
   title: string;
@@ -480,6 +573,8 @@ function getUserMessageAttachmentContent(
         subtitle: getFileTypeLabel(attachment.fileName) ?? t("message.attachments.file"),
       };
   }
+  const exhaustive: never = attachment;
+  return exhaustive;
 }
 
 export const UserMessage = memo(function UserMessage({
@@ -487,8 +582,8 @@ export const UserMessage = memo(function UserMessage({
   agentId,
   messageId,
   message,
-  images = [],
-  attachments = [],
+  images = EMPTY_USER_MESSAGE_IMAGES,
+  attachments = EMPTY_USER_MESSAGE_ATTACHMENTS,
   timestamp,
   capabilities,
   client,
@@ -503,8 +598,6 @@ export const UserMessage = memo(function UserMessage({
   const handleLightboxClose = useCallback(() => setLightboxMetadata(null), []);
   const resolvedDisableOuterSpacing = useDisableOuterSpacing(disableOuterSpacing);
   const hasText = message.trim().length > 0;
-  const hasImages = images.length > 0;
-  const hasAttachments = attachments.length > 0;
   const showTrailingRow = hasText && (isCompact || isNative || isHovered);
   const formattedTimestamp = useMemo(
     () => formatMessageTimestamp(new Date(timestamp)),
@@ -533,20 +626,6 @@ export const UserMessage = memo(function UserMessage({
     ],
     [resolvedDisableOuterSpacing, isFirstInGroup, isLastInGroup],
   );
-  const imagePreviewContainerStyle = useMemo(
-    () => [
-      userMessageStylesheet.imagePreviewContainer,
-      hasText || hasAttachments ? userMessageStylesheet.imagePreviewSpacing : undefined,
-    ],
-    [hasAttachments, hasText],
-  );
-  const attachmentPreviewContainerStyle = useMemo(
-    () => [
-      userMessageStylesheet.attachmentPreviewContainer,
-      hasText ? userMessageStylesheet.imagePreviewSpacing : undefined,
-    ],
-    [hasText],
-  );
   const trailingRowStyle = useMemo(
     () => [
       userMessageStylesheet.trailingRow,
@@ -565,41 +644,12 @@ export const UserMessage = memo(function UserMessage({
         onPointerLeave={handlePointerLeave}
       >
         <View style={userMessageStylesheet.bubble}>
-          {hasImages ? (
-            <View style={imagePreviewContainerStyle}>
-              {images.map((image) => (
-                <UserMessageImagePill
-                  key={image.id}
-                  image={image}
-                  onOpen={setLightboxMetadata}
-                  accessibilityLabel={t("composer.attachments.openImage")}
-                />
-              ))}
-            </View>
-          ) : null}
-          {hasAttachments ? (
-            <View style={attachmentPreviewContainerStyle}>
-              {attachments.map((attachment, index) => {
-                const content = getUserMessageAttachmentContent(attachment, t);
-                return (
-                  <AttachmentFrame
-                    key={`${attachment.type}:${"number" in attachment ? attachment.number : index}`}
-                  >
-                    <AttachmentLabel
-                      icon={content.icon}
-                      title={content.title}
-                      subtitle={content.subtitle}
-                    />
-                  </AttachmentFrame>
-                );
-              })}
-            </View>
-          ) : null}
-          {hasText ? (
-            <Text selectable style={userMessageStylesheet.text}>
-              {message}
-            </Text>
-          ) : null}
+          <UserMessageBubbleContent
+            message={message}
+            images={images}
+            attachments={attachments}
+            onOpenImage={setLightboxMetadata}
+          />
         </View>
         {hasText ? (
           <View style={trailingRowStyle} pointerEvents={showTrailingRow ? "auto" : "none"}>
@@ -621,6 +671,39 @@ export const UserMessage = memo(function UserMessage({
         ) : null}
       </View>
       <AttachmentLightbox metadata={lightboxMetadata} onClose={handleLightboxClose} />
+    </View>
+  );
+});
+
+interface PinnedUserMessagePreviewProps {
+  message: string;
+  images?: UserMessageImageAttachment[];
+  attachments?: AgentAttachment[];
+}
+
+export const PinnedUserMessagePreview = memo(function PinnedUserMessagePreview({
+  message,
+  images = EMPTY_USER_MESSAGE_IMAGES,
+  attachments = EMPTY_USER_MESSAGE_ATTACHMENTS,
+}: PinnedUserMessagePreviewProps) {
+  const bubbleStyle = useMemo(
+    () => [userMessageStylesheet.bubble, userMessageStylesheet.pinnedBubble],
+    [],
+  );
+
+  return (
+    <View style={userMessageStylesheet.container} testID="pinned-user-message-preview">
+      <View style={userMessageStylesheet.content} pointerEvents="none">
+        <View style={bubbleStyle}>
+          <UserMessageBubbleContent
+            message={message}
+            images={images}
+            attachments={attachments}
+            textNumberOfLines={4}
+            selectable={false}
+          />
+        </View>
+      </View>
     </View>
   );
 });

--- a/packages/app/src/hooks/use-settings/index.ts
+++ b/packages/app/src/hooks/use-settings/index.ts
@@ -151,6 +151,9 @@ export function useSettings(): UseSettingsReturn {
       if (updates.sendBehavior !== undefined) {
         appUpdates.sendBehavior = updates.sendBehavior;
       }
+      if (updates.pinUserInputs !== undefined) {
+        appUpdates.pinUserInputs = updates.pinUserInputs;
+      }
       if (updates.serviceUrlBehavior !== undefined) {
         appUpdates.serviceUrlBehavior = updates.serviceUrlBehavior;
       }

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -61,6 +61,38 @@ describe("loadAppSettingsFromStorage", () => {
     expect(result.language).toBe("system");
   });
 
+  it("defaults pinned user inputs to disabled when storage is empty", async () => {
+    const deps = makeDeps();
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.pinUserInputs).toBe(false);
+  });
+
+  it("loads persisted pinned user input preference", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ pinUserInputs: true }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.pinUserInputs).toBe(true);
+  });
+
+  it("ignores invalid pinned user input preference values", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ pinUserInputs: "true" }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.pinUserInputs).toBe(false);
+  });
+
   it("loads configured terminal scrollback lines from app settings", async () => {
     const deps = makeDeps({
       storage: createInMemoryKeyValueStorage({

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -29,6 +29,7 @@ export interface AppSettings {
   theme: ThemeName | "auto";
   language: AppLanguage;
   sendBehavior: SendBehavior;
+  pinUserInputs: boolean;
   serviceUrlBehavior: ServiceUrlBehavior;
   terminalScrollbackLines: number;
   uiFontFamily: string; // "" = platform default UI stack
@@ -47,6 +48,7 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   theme: "auto",
   language: "system",
   sendBehavior: "interrupt",
+  pinUserInputs: false,
   serviceUrlBehavior: "ask",
   terminalScrollbackLines: DEFAULT_TERMINAL_SCROLLBACK_LINES,
   uiFontFamily: "",
@@ -158,6 +160,9 @@ function pickAppSettings(stored: Partial<AppSettings>): Partial<AppSettings> {
   }
   if (stored.sendBehavior === "interrupt" || stored.sendBehavior === "queue") {
     result.sendBehavior = stored.sendBehavior;
+  }
+  if (typeof stored.pinUserInputs === "boolean") {
+    result.pinUserInputs = stored.pinUserInputs;
   }
   if (
     typeof stored.serviceUrlBehavior === "string" &&

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1424,10 +1424,6 @@ export const ar: TranslationResources = {
         description: "يتم الاحتفاظ بالخطوط في المخزن المؤقت الطرفي المدمج",
         accessibilityLabel: "خطوط التمرير Terminal",
       },
-      pinUserInputs: {
-        label: "تثبيت إدخالات المستخدم",
-        description: "يبقي مطالبة المستخدم ذات الصلة مرئية أثناء التمرير عبر الردود",
-      },
       language: {
         label: "لغة",
         description: "لغة التطبيق",
@@ -1490,6 +1486,13 @@ export const ar: TranslationResources = {
           ghostty: "شبحي",
           auto: "نظام",
         },
+      },
+      messages: {
+        title: "الرسائل",
+      },
+      pinUserInputs: {
+        label: "تثبيت إدخالات المستخدم",
+        description: "يبقي مطالبة المستخدم ذات الصلة مرئية أثناء التمرير عبر الردود",
       },
       fonts: {
         title: "الخطوط",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -171,6 +171,7 @@ export const ar: TranslationResources = {
   agentStream: {
     empty: "ابدأ الدردشة مع هذا الوكيل...",
     scrollToBottom: "قم بالتمرير إلى الأسفل",
+    scrollToPinnedUserInput: "انتقل إلى إدخال المستخدم المثبت",
     permission: {
       plan: "يخطط",
       required: "الإذن مطلوب",
@@ -1422,6 +1423,10 @@ export const ar: TranslationResources = {
         label: "التمرير Terminal",
         description: "يتم الاحتفاظ بالخطوط في المخزن المؤقت الطرفي المدمج",
         accessibilityLabel: "خطوط التمرير Terminal",
+      },
+      pinUserInputs: {
+        label: "تثبيت إدخالات المستخدم",
+        description: "يبقي مطالبة المستخدم ذات الصلة مرئية أثناء التمرير عبر الردود",
       },
       language: {
         label: "لغة",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1430,10 +1430,6 @@ export const en = {
         description: "Lines kept in the built-in terminal buffer",
         accessibilityLabel: "Terminal scrollback lines",
       },
-      pinUserInputs: {
-        label: "Pin user inputs",
-        description: "Keep the relevant user prompt visible while scrolling through responses",
-      },
       language: {
         label: "Language",
         description: "App language",
@@ -1496,6 +1492,13 @@ export const en = {
           ghostty: "Ghostty",
           auto: "System",
         },
+      },
+      messages: {
+        title: "Messages",
+      },
+      pinUserInputs: {
+        label: "Pin user inputs",
+        description: "Keep the relevant user prompt visible while scrolling through responses",
       },
       fonts: {
         title: "Fonts",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -169,6 +169,7 @@ export const en = {
   agentStream: {
     empty: "Start chatting with this agent...",
     scrollToBottom: "Scroll to bottom",
+    scrollToPinnedUserInput: "Scroll to pinned user input",
     permission: {
       plan: "Plan",
       required: "Permission Required",
@@ -1428,6 +1429,10 @@ export const en = {
         label: "Terminal scrollback",
         description: "Lines kept in the built-in terminal buffer",
         accessibilityLabel: "Terminal scrollback lines",
+      },
+      pinUserInputs: {
+        label: "Pin user inputs",
+        description: "Keep the relevant user prompt visible while scrolling through responses",
       },
       language: {
         label: "Language",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1461,11 +1461,6 @@ export const es: TranslationResources = {
         description: "Líneas mantenidas en el búfer de terminal incorporado",
         accessibilityLabel: "Líneas del historial de terminal",
       },
-      pinUserInputs: {
-        label: "Fijar entradas del usuario",
-        description:
-          "Mantiene visible el prompt relevante del usuario al desplazarte por las respuestas",
-      },
       language: {
         label: "Idioma",
         description: "Idioma de la aplicación",
@@ -1528,6 +1523,14 @@ export const es: TranslationResources = {
           ghostty: "fantasmal",
           auto: "Sistema",
         },
+      },
+      messages: {
+        title: "Mensajes",
+      },
+      pinUserInputs: {
+        label: "Fijar entradas del usuario",
+        description:
+          "Mantiene visible el prompt relevante del usuario al desplazarte por las respuestas",
       },
       fonts: {
         title: "Fuentes",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -171,6 +171,7 @@ export const es: TranslationResources = {
   agentStream: {
     empty: "Comience a chatear con este agente...",
     scrollToBottom: "Desplazarse hacia abajo",
+    scrollToPinnedUserInput: "Ir a la entrada de usuario fijada",
     permission: {
       plan: "Plan",
       required: "Permiso requerido",
@@ -1459,6 +1460,11 @@ export const es: TranslationResources = {
         label: "Historial de terminal",
         description: "Líneas mantenidas en el búfer de terminal incorporado",
         accessibilityLabel: "Líneas del historial de terminal",
+      },
+      pinUserInputs: {
+        label: "Fijar entradas del usuario",
+        description:
+          "Mantiene visible el prompt relevante del usuario al desplazarte por las respuestas",
       },
       language: {
         label: "Idioma",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -172,6 +172,7 @@ export const fr: TranslationResources = {
   agentStream: {
     empty: "Commencez à discuter avec cet agent...",
     scrollToBottom: "Faire défiler vers le bas",
+    scrollToPinnedUserInput: "Aller à la saisie utilisateur épinglée",
     permission: {
       plan: "Plan",
       required: "Autorisation requise",
@@ -1462,6 +1463,11 @@ export const fr: TranslationResources = {
         label: "DéfilementTerminal",
         description: "Lignes conservées dans le tampon du terminal intégré",
         accessibilityLabel: "Lignes de défilementTerminal",
+      },
+      pinUserInputs: {
+        label: "Épingler les saisies utilisateur",
+        description:
+          "Garde visible le prompt utilisateur pertinent pendant le défilement des réponses",
       },
       language: {
         label: "Langue",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1464,11 +1464,6 @@ export const fr: TranslationResources = {
         description: "Lignes conservées dans le tampon du terminal intégré",
         accessibilityLabel: "Lignes de défilementTerminal",
       },
-      pinUserInputs: {
-        label: "Épingler les saisies utilisateur",
-        description:
-          "Garde visible le prompt utilisateur pertinent pendant le défilement des réponses",
-      },
       language: {
         label: "Langue",
         description: "Langue de l'application",
@@ -1532,6 +1527,14 @@ export const fr: TranslationResources = {
           ghostty: "Fantôme",
           auto: "Système",
         },
+      },
+      messages: {
+        title: "Messages",
+      },
+      pinUserInputs: {
+        label: "Épingler les saisies utilisateur",
+        description:
+          "Garde visible le prompt utilisateur pertinent pendant le défilement des réponses",
       },
       fonts: {
         title: "Polices",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1451,10 +1451,6 @@ export const ru: TranslationResources = {
         description: "Строки, хранящиеся во встроенном буфере терминала.",
         accessibilityLabel: "Линии прокрутки Terminal",
       },
-      pinUserInputs: {
-        label: "Закреплять ввод пользователя",
-        description: "Показывает связанный запрос пользователя при прокрутке ответов",
-      },
       language: {
         label: "Язык",
         description: "Язык приложения",
@@ -1518,6 +1514,13 @@ export const ru: TranslationResources = {
           ghostty: "Призрачный",
           auto: "Система",
         },
+      },
+      messages: {
+        title: "Сообщения",
+      },
+      pinUserInputs: {
+        label: "Закреплять ввод пользователя",
+        description: "Показывает связанный запрос пользователя при прокрутке ответов",
       },
       fonts: {
         title: "Шрифты",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -171,6 +171,7 @@ export const ru: TranslationResources = {
   agentStream: {
     empty: "Начните общаться с этим агентом...",
     scrollToBottom: "Прокрутить вниз",
+    scrollToPinnedUserInput: "Перейти к закрепленному вводу пользователя",
     permission: {
       plan: "План",
       required: "Требуется разрешение",
@@ -1449,6 +1450,10 @@ export const ru: TranslationResources = {
         label: "Terminal прокрутка назад",
         description: "Строки, хранящиеся во встроенном буфере терминала.",
         accessibilityLabel: "Линии прокрутки Terminal",
+      },
+      pinUserInputs: {
+        label: "Закреплять ввод пользователя",
+        description: "Показывает связанный запрос пользователя при прокрутке ответов",
       },
       language: {
         label: "Язык",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -171,6 +171,7 @@ export const zhCN: TranslationResources = {
   agentStream: {
     empty: "开始和这个 Agent 对话...",
     scrollToBottom: "滚动到底部",
+    scrollToPinnedUserInput: "滚动到固定的用户输入",
     permission: {
       plan: "Plan",
       required: "需要权限",
@@ -1404,6 +1405,10 @@ export const zhCN: TranslationResources = {
         label: "终端回滚",
         description: "内置终端缓冲区保留的行数",
         accessibilityLabel: "终端回滚行数",
+      },
+      pinUserInputs: {
+        label: "固定用户输入",
+        description: "滚动查看回复时保持相关用户提示可见",
       },
       language: {
         label: "语言",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1406,10 +1406,6 @@ export const zhCN: TranslationResources = {
         description: "内置终端缓冲区保留的行数",
         accessibilityLabel: "终端回滚行数",
       },
-      pinUserInputs: {
-        label: "固定用户输入",
-        description: "滚动查看回复时保持相关用户提示可见",
-      },
       language: {
         label: "语言",
         description: "应用语言",
@@ -1472,6 +1468,13 @@ export const zhCN: TranslationResources = {
           ghostty: "Ghostty",
           auto: "系统",
         },
+      },
+      messages: {
+        title: "消息",
+      },
+      pinUserInputs: {
+        label: "固定用户输入",
+        description: "滚动查看回复时保持相关用户提示可见",
       },
       fonts: {
         title: "字体",

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -77,7 +77,6 @@ import { AddHostModal } from "@/components/add-host-modal";
 import { PairLinkModal } from "@/components/pair-link-modal";
 import { KeyboardShortcutsSection } from "@/screens/settings/keyboard-shortcuts-section";
 import { Button } from "@/components/ui/button";
-import { Switch } from "@/components/ui/switch";
 import { CommunityLinks } from "@/components/community-links";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
@@ -251,7 +250,6 @@ interface GeneralSectionProps {
   handleSendBehaviorChange: (behavior: SendBehavior) => void;
   handleServiceUrlBehaviorChange: (behavior: ServiceUrlBehavior) => void;
   handleLanguageChange: (language: AppLanguage) => void;
-  handlePinUserInputsChange: (enabled: boolean) => void;
   handleTerminalScrollbackLinesChange: (lines: number) => void;
 }
 
@@ -308,7 +306,6 @@ function GeneralSection({
   handleSendBehaviorChange,
   handleServiceUrlBehaviorChange,
   handleLanguageChange,
-  handlePinUserInputsChange,
   handleTerminalScrollbackLinesChange,
 }: GeneralSectionProps) {
   const { t, i18n } = useTranslation();
@@ -422,20 +419,6 @@ function GeneralSection({
             </DropdownMenu>
           </View>
         ) : null}
-        <View style={ROW_WITH_BORDER_STYLE}>
-          <View style={settingsStyles.rowContent}>
-            <Text style={settingsStyles.rowTitle}>{t("settings.general.pinUserInputs.label")}</Text>
-            <Text style={settingsStyles.rowHint}>
-              {t("settings.general.pinUserInputs.description")}
-            </Text>
-          </View>
-          <Switch
-            value={settings.pinUserInputs}
-            onValueChange={handlePinUserInputsChange}
-            accessibilityLabel={t("settings.general.pinUserInputs.label")}
-            testID="settings-pin-user-inputs-switch"
-          />
-        </View>
         <View style={ROW_WITH_BORDER_STYLE}>
           <View style={settingsStyles.rowContent}>
             <Text style={settingsStyles.rowTitle}>
@@ -1318,13 +1301,6 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
     [updateSettings],
   );
 
-  const handlePinUserInputsChange = useCallback(
-    (pinUserInputs: boolean) => {
-      void updateSettings({ pinUserInputs });
-    },
-    [updateSettings],
-  );
-
   const handleTerminalScrollbackLinesChange = useCallback(
     (terminalScrollbackLines: number) => {
       void updateSettings({ terminalScrollbackLines });
@@ -1532,7 +1508,6 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
               handleSendBehaviorChange={handleSendBehaviorChange}
               handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
               handleLanguageChange={handleLanguageChange}
-              handlePinUserInputsChange={handlePinUserInputsChange}
               handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
             />
           );

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -77,6 +77,7 @@ import { AddHostModal } from "@/components/add-host-modal";
 import { PairLinkModal } from "@/components/pair-link-modal";
 import { KeyboardShortcutsSection } from "@/screens/settings/keyboard-shortcuts-section";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { CommunityLinks } from "@/components/community-links";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
@@ -250,6 +251,7 @@ interface GeneralSectionProps {
   handleSendBehaviorChange: (behavior: SendBehavior) => void;
   handleServiceUrlBehaviorChange: (behavior: ServiceUrlBehavior) => void;
   handleLanguageChange: (language: AppLanguage) => void;
+  handlePinUserInputsChange: (enabled: boolean) => void;
   handleTerminalScrollbackLinesChange: (lines: number) => void;
 }
 
@@ -306,6 +308,7 @@ function GeneralSection({
   handleSendBehaviorChange,
   handleServiceUrlBehaviorChange,
   handleLanguageChange,
+  handlePinUserInputsChange,
   handleTerminalScrollbackLinesChange,
 }: GeneralSectionProps) {
   const { t, i18n } = useTranslation();
@@ -419,6 +422,20 @@ function GeneralSection({
             </DropdownMenu>
           </View>
         ) : null}
+        <View style={ROW_WITH_BORDER_STYLE}>
+          <View style={settingsStyles.rowContent}>
+            <Text style={settingsStyles.rowTitle}>{t("settings.general.pinUserInputs.label")}</Text>
+            <Text style={settingsStyles.rowHint}>
+              {t("settings.general.pinUserInputs.description")}
+            </Text>
+          </View>
+          <Switch
+            value={settings.pinUserInputs}
+            onValueChange={handlePinUserInputsChange}
+            accessibilityLabel={t("settings.general.pinUserInputs.label")}
+            testID="settings-pin-user-inputs-switch"
+          />
+        </View>
         <View style={ROW_WITH_BORDER_STYLE}>
           <View style={settingsStyles.rowContent}>
             <Text style={settingsStyles.rowTitle}>
@@ -1301,6 +1318,13 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
     [updateSettings],
   );
 
+  const handlePinUserInputsChange = useCallback(
+    (pinUserInputs: boolean) => {
+      void updateSettings({ pinUserInputs });
+    },
+    [updateSettings],
+  );
+
   const handleTerminalScrollbackLinesChange = useCallback(
     (terminalScrollbackLines: number) => {
       void updateSettings({ terminalScrollbackLines });
@@ -1508,6 +1532,7 @@ export default function SettingsScreen({ view }: SettingsScreenProps) {
               handleSendBehaviorChange={handleSendBehaviorChange}
               handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
               handleLanguageChange={handleLanguageChange}
+              handlePinUserInputsChange={handlePinUserInputsChange}
               handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
             />
           );

--- a/packages/app/src/screens/settings/appearance/appearance-section.tsx
+++ b/packages/app/src/screens/settings/appearance/appearance-section.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/styles/theme";
 import { isNative } from "@/constants/platform";
 import { settingsStyles } from "@/styles/settings";
+import { Switch } from "@/components/ui/switch";
 import { AppearancePreview } from "./appearance-preview";
 
 // ---------------------------------------------------------------------------
@@ -360,6 +361,35 @@ function SyntaxRow({ value, onChange }: SyntaxRowProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+interface PinUserInputsRowProps {
+  value: boolean;
+  onChange: (value: boolean) => void;
+}
+
+function PinUserInputsRow({ value, onChange }: PinUserInputsRowProps) {
+  const { t } = useTranslation();
+  return (
+    <View style={settingsStyles.row}>
+      <View style={settingsStyles.rowContent}>
+        <Text style={settingsStyles.rowTitle}>{t("settings.appearance.pinUserInputs.label")}</Text>
+        <Text style={settingsStyles.rowHint}>
+          {t("settings.appearance.pinUserInputs.description")}
+        </Text>
+      </View>
+      <Switch
+        value={value}
+        onValueChange={onChange}
+        accessibilityLabel={t("settings.appearance.pinUserInputs.label")}
+        testID="settings-pin-user-inputs-switch"
+      />
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
@@ -393,6 +423,13 @@ export function AppearanceSection() {
   const handleSyntaxThemeChange = useCallback(
     (syntaxTheme: SyntaxThemeId) => {
       void updateSettings({ syntaxTheme });
+    },
+    [updateSettings],
+  );
+
+  const handlePinUserInputsChange = useCallback(
+    (pinUserInputs: boolean) => {
+      void updateSettings({ pinUserInputs });
     },
     [updateSettings],
   );
@@ -475,6 +512,11 @@ export function AppearanceSection() {
       <SettingsSection title={t("settings.appearance.theme.title")}>
         <View style={settingsStyles.card}>
           <ThemeRow value={settings.theme} onChange={handleThemeChange} />
+        </View>
+      </SettingsSection>
+      <SettingsSection title={t("settings.appearance.messages.title")}>
+        <View style={settingsStyles.card}>
+          <PinUserInputsRow value={settings.pinUserInputs} onChange={handlePinUserInputsChange} />
         </View>
       </SettingsSection>
       <SettingsSection title={t("settings.appearance.fonts.title")}>


### PR DESCRIPTION
## Summary
- Adds a pinned user input overlay for agent streams across web and native strategies
- Adds persistence, appearance controls, translations, and focused stream tests
- Tidies overlay ownership and message rendering after review

## Validation
- Branch review agent ran focused tests plus repo typecheck/lint/format before the rebase
- Rebased onto origin/main and verified the final diff scope
