### PR TITLE
[codex] Restore closed workspace tabs

### DIFF
--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -65,6 +65,7 @@ import {
 import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
 import {
   useWorkspaceLayoutStore,
+  type RecentlyClosedWorkspaceTab,
   type SplitNode,
   type SplitPane,
   type WorkspaceLayout,
@@ -85,6 +86,7 @@ interface SplitContainerProps {
   normalizedWorkspaceId: string;
   isWorkspaceFocused: boolean;
   uiTabs: WorkspaceTab[];
+  recentlyClosedTabs: RecentlyClosedWorkspaceTab[];
   hoveredCloseTabKey: string | null;
   setHoveredCloseTabKey: Dispatch<SetStateAction<string | null>>;
   closingTabIds: Set<string>;
@@ -98,6 +100,7 @@ interface SplitContainerProps {
   onCloseTabsToLeft: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
+  onRestoreClosedTab: (entryKey: string) => void;
   onCreateDraftTab: (input: { paneId?: string }) => void;
   onCreateTerminalTab: (input: { paneId?: string; profile?: TerminalProfileInput }) => void;
   onCreateBrowserTab: (input: { paneId?: string }) => void;
@@ -366,6 +369,7 @@ export function SplitContainer({
   normalizedWorkspaceId,
   isWorkspaceFocused,
   uiTabs,
+  recentlyClosedTabs,
   hoveredCloseTabKey,
   setHoveredCloseTabKey,
   closingTabIds,
@@ -379,6 +383,7 @@ export function SplitContainer({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  onRestoreClosedTab,
   onCreateDraftTab,
   onCreateTerminalTab,
   onCreateBrowserTab,
@@ -583,6 +588,7 @@ export function SplitContainer({
           normalizedServerId={normalizedServerId}
           normalizedWorkspaceId={normalizedWorkspaceId}
           isWorkspaceFocused={isWorkspaceFocused}
+          recentlyClosedTabs={recentlyClosedTabs}
           hoveredCloseTabKey={hoveredCloseTabKey}
           setHoveredCloseTabKey={setHoveredCloseTabKey}
           closingTabIds={closingTabIds}
@@ -596,6 +602,7 @@ export function SplitContainer({
           onCloseTabsToLeft={onCloseTabsToLeft}
           onCloseTabsToRight={onCloseTabsToRight}
           onCloseOtherTabs={onCloseOtherTabs}
+          onRestoreClosedTab={onRestoreClosedTab}
           onCreateDraftTab={onCreateDraftTab}
           onCreateTerminalTab={onCreateTerminalTab}
           onCreateBrowserTab={onCreateBrowserTab}
@@ -726,6 +733,7 @@ function SplitNodeView({
   normalizedServerId,
   normalizedWorkspaceId,
   isWorkspaceFocused,
+  recentlyClosedTabs,
   hoveredCloseTabKey,
   setHoveredCloseTabKey,
   closingTabIds,
@@ -739,6 +747,7 @@ function SplitNodeView({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  onRestoreClosedTab,
   onCreateDraftTab,
   onCreateTerminalTab,
   onCreateBrowserTab,
@@ -779,6 +788,7 @@ function SplitNodeView({
         normalizedServerId={normalizedServerId}
         normalizedWorkspaceId={normalizedWorkspaceId}
         isWorkspaceFocused={isWorkspaceFocused}
+        recentlyClosedTabs={recentlyClosedTabs}
         hoveredCloseTabKey={hoveredCloseTabKey}
         setHoveredCloseTabKey={setHoveredCloseTabKey}
         closingTabIds={closingTabIds}
@@ -792,6 +802,7 @@ function SplitNodeView({
         onCloseTabsToLeft={onCloseTabsToLeft}
         onCloseTabsToRight={onCloseTabsToRight}
         onCloseOtherTabs={onCloseOtherTabs}
+        onRestoreClosedTab={onRestoreClosedTab}
         onCreateDraftTab={onCreateDraftTab}
         onCreateTerminalTab={onCreateTerminalTab}
         onCreateBrowserTab={onCreateBrowserTab}
@@ -825,6 +836,7 @@ function SplitNodeView({
               normalizedServerId={normalizedServerId}
               normalizedWorkspaceId={normalizedWorkspaceId}
               isWorkspaceFocused={isWorkspaceFocused}
+              recentlyClosedTabs={recentlyClosedTabs}
               hoveredCloseTabKey={hoveredCloseTabKey}
               setHoveredCloseTabKey={setHoveredCloseTabKey}
               closingTabIds={closingTabIds}
@@ -838,6 +850,7 @@ function SplitNodeView({
               onCloseTabsToLeft={onCloseTabsToLeft}
               onCloseTabsToRight={onCloseTabsToRight}
               onCloseOtherTabs={onCloseOtherTabs}
+              onRestoreClosedTab={onRestoreClosedTab}
               onCreateDraftTab={onCreateDraftTab}
               onCreateTerminalTab={onCreateTerminalTab}
               onCreateBrowserTab={onCreateBrowserTab}
@@ -877,6 +890,7 @@ function SplitPaneView({
   normalizedServerId,
   normalizedWorkspaceId,
   isWorkspaceFocused,
+  recentlyClosedTabs,
   hoveredCloseTabKey,
   setHoveredCloseTabKey,
   closingTabIds,
@@ -890,6 +904,7 @@ function SplitPaneView({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  onRestoreClosedTab,
   onCreateDraftTab,
   onCreateTerminalTab,
   onCreateBrowserTab,
@@ -1019,6 +1034,7 @@ function SplitPaneView({
             paneId={pane.id}
             isFocused={isFocused}
             tabs={desktopTabRowItems}
+            recentlyClosedTabs={recentlyClosedTabs}
             normalizedServerId={normalizedServerId}
             normalizedWorkspaceId={normalizedWorkspaceId}
             setHoveredCloseTabKey={setHoveredCloseTabKey}
@@ -1032,6 +1048,7 @@ function SplitPaneView({
             onCloseTabsToLeft={handleCloseTabsToLeft}
             onCloseTabsToRight={handleCloseTabsToRight}
             onCloseOtherTabs={handleCloseOtherTabs}
+            onRestoreClosedTab={onRestoreClosedTab}
             onCreateDraftTab={onCreateDraftTab}
             onCreateTerminalTab={onCreateTerminalTab}
             onCreateBrowserTab={onCreateBrowserTab}

--- a/packages/app/src/i18n/resources.test.ts
+++ b/packages/app/src/i18n/resources.test.ts
@@ -345,6 +345,9 @@ describe("translation resources", () => {
     expect(en.workspace.tabs.toasts.reloadingAgent).toBe("Reloading agent...");
     expect(en.workspace.tabs.toasts.reloadedAgent).toBe("Reloaded agent");
     expect(en.workspace.tabs.toasts.failedToReloadAgent).toBe("Failed to reload agent");
+    expect(en.workspace.tabs.recentlyClosed.title).toBe("Recently closed tabs");
+    expect(en.workspace.tabs.recentlyClosed.empty).toBe("No recently closed tabs");
+    expect(en.settings.shortcuts.help.restoreLastClosedTab).toBe("Restore last closed tab");
     expect(en.workspace.header.toasts.workspacePathCopiedLabel).toBe("Workspace path");
     expect(en.workspace.header.toasts.branchNameCopiedLabel).toBe("Branch name");
   });

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -476,6 +476,10 @@ export const ar: TranslationResources = {
         pinTarget: "تثبيت",
         unpinTarget: "إلغاء التثبيت",
       },
+      recentlyClosed: {
+        title: "علامات التبويب المغلقة حديثًا",
+        empty: "لا توجد علامات تبويب مغلقة حديثًا",
+      },
       explorer: {
         open: "افتح المستكشف",
         close: "إغلاق المستكشف",
@@ -1534,6 +1538,7 @@ export const ar: TranslationResources = {
         archiveWorktree: "أرشفة شجرة العمل",
         newTab: "علامة تبويب جديدة",
         closeCurrentTab: "إغلاق علامة التبويب الحالية",
+        restoreLastClosedTab: "استعادة آخر علامة تبويب مغلقة",
         jumpToWorkspace: "انتقل إلى مساحة العمل",
         jumpToTab: "انتقل إلى علامة التبويب",
         previousWorkspace: "مساحة العمل السابقة",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -476,6 +476,10 @@ export const en = {
         pinTarget: "Pin",
         unpinTarget: "Unpin",
       },
+      recentlyClosed: {
+        title: "Recently closed tabs",
+        empty: "No recently closed tabs",
+      },
       explorer: {
         open: "Open explorer",
         close: "Close explorer",
@@ -1540,6 +1544,7 @@ export const en = {
         archiveWorktree: "Archive worktree",
         newTab: "New tab",
         closeCurrentTab: "Close current tab",
+        restoreLastClosedTab: "Restore last closed tab",
         jumpToWorkspace: "Jump to workspace",
         jumpToTab: "Jump to tab",
         previousWorkspace: "Previous workspace",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -481,6 +481,10 @@ export const es: TranslationResources = {
         pinTarget: "Fijar",
         unpinTarget: "Desfijar",
       },
+      recentlyClosed: {
+        title: "Pestañas cerradas recientemente",
+        empty: "No hay pestañas cerradas recientemente",
+      },
       explorer: {
         open: "Explorador abierto",
         close: "Cerrar explorador",
@@ -1572,6 +1576,7 @@ export const es: TranslationResources = {
         archiveWorktree: "Árbol de trabajo de archivo",
         newTab: "Nueva pestaña",
         closeCurrentTab: "Cerrar pestaña actual",
+        restoreLastClosedTab: "Restaurar la última pestaña cerrada",
         jumpToWorkspace: "Saltar al espacio de trabajo",
         jumpToTab: "Saltar a la pestaña",
         previousWorkspace: "Espacio de trabajo anterior",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -481,6 +481,10 @@ export const fr: TranslationResources = {
         pinTarget: "Épingler",
         unpinTarget: "Détacher",
       },
+      recentlyClosed: {
+        title: "Onglets récemment fermés",
+        empty: "Aucun onglet récemment fermé",
+      },
       explorer: {
         open: "Ouvrir l'explorateur",
         close: "Fermer l'explorateur",
@@ -1576,6 +1580,7 @@ export const fr: TranslationResources = {
         archiveWorktree: "Arbre de travail d'archivage",
         newTab: "Nouvel onglet",
         closeCurrentTab: "Fermer l'onglet actuel",
+        restoreLastClosedTab: "Restaurer le dernier onglet fermé",
         jumpToWorkspace: "Accéder à l'espace de travail",
         jumpToTab: "Aller à l'onglet",
         previousWorkspace: "Espace de travail précédent",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -480,6 +480,10 @@ export const ru: TranslationResources = {
         pinTarget: "Закрепить",
         unpinTarget: "Открепить",
       },
+      recentlyClosed: {
+        title: "Недавно закрытые вкладки",
+        empty: "Нет недавно закрытых вкладок",
+      },
       explorer: {
         open: "Открыть проводник",
         close: "Закрыть проводник",
@@ -1564,6 +1568,7 @@ export const ru: TranslationResources = {
         archiveWorktree: "Архив рабочего дерева",
         newTab: "Новая вкладка",
         closeCurrentTab: "Закрыть текущую вкладку",
+        restoreLastClosedTab: "Восстановить последнюю закрытую вкладку",
         jumpToWorkspace: "Перейти в рабочую область",
         jumpToTab: "Перейти на вкладку",
         previousWorkspace: "Предыдущая рабочая область",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -476,6 +476,10 @@ export const zhCN: TranslationResources = {
         pinTarget: "固定",
         unpinTarget: "取消固定",
       },
+      recentlyClosed: {
+        title: "最近关闭的标签",
+        empty: "没有最近关闭的标签",
+      },
       explorer: {
         open: "打开 explorer",
         close: "关闭 explorer",
@@ -1533,6 +1537,7 @@ export const zhCN: TranslationResources = {
         moveTabDown: "向下移动标签",
         closePane: "关闭窗格",
         newTerminal: "新建终端",
+        restoreLastClosedTab: "恢复最后关闭的标签",
         toggleCommandCenter: "切换命令中心",
         showKeyboardShortcuts: "显示键盘快捷键",
         toggleLeftSidebar: "切换左侧边栏",

--- a/packages/app/src/keyboard/actions.ts
+++ b/packages/app/src/keyboard/actions.ts
@@ -19,6 +19,7 @@ export type KeyboardActionId =
   | "agent.new"
   | "workspace.tab.new"
   | "workspace.tab.close.current"
+  | "workspace.tab.restore.lastClosed"
   | "workspace.tab.navigate.index"
   | "workspace.tab.navigate.relative"
   | "workspace.pane.split.right"

--- a/packages/app/src/keyboard/keyboard-action-dispatcher.test.ts
+++ b/packages/app/src/keyboard/keyboard-action-dispatcher.test.ts
@@ -186,4 +186,23 @@ describe("keyboard-action-dispatcher", () => {
     expect(handled).toBe(false);
     expect(handle).not.toHaveBeenCalled();
   });
+
+  it("dispatches restore-last-closed tab actions", () => {
+    const handle = vi.fn(() => true);
+    const action: KeyboardActionDefinition = {
+      id: "workspace.tab.restore-last-closed",
+      scope: "workspace",
+    };
+
+    dispatcher.registerHandler({
+      handlerId: "workspace",
+      actions: [action.id],
+      enabled: true,
+      priority: 100,
+      handle,
+    });
+
+    expect(dispatcher.dispatch(action)).toBe(true);
+    expect(handle).toHaveBeenCalledWith(action);
+  });
 });

--- a/packages/app/src/keyboard/keyboard-action-dispatcher.ts
+++ b/packages/app/src/keyboard/keyboard-action-dispatcher.ts
@@ -11,6 +11,7 @@ export type KeyboardActionId =
   | "message-input.voice-mute-toggle"
   | "workspace.tab.new"
   | "workspace.tab.close-current"
+  | "workspace.tab.restore-last-closed"
   | "workspace.tab.navigate-index"
   | "workspace.tab.navigate-relative"
   | "workspace.pane.split.right"
@@ -41,6 +42,7 @@ export type KeyboardActionDefinition =
   | { id: "message-input.voice-mute-toggle"; scope: KeyboardActionScope }
   | { id: "workspace.tab.new"; scope: KeyboardActionScope }
   | { id: "workspace.tab.close-current"; scope: KeyboardActionScope }
+  | { id: "workspace.tab.restore-last-closed"; scope: KeyboardActionScope }
   | { id: "workspace.tab.navigate-index"; scope: KeyboardActionScope; index: number }
   | { id: "workspace.tab.navigate-relative"; scope: KeyboardActionScope; delta: 1 | -1 }
   | { id: "workspace.pane.split.right"; scope: KeyboardActionScope }

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -209,6 +209,18 @@ describe("keyboard-shortcuts", () => {
       action: "workspace.tab.new",
     },
     {
+      name: "matches Mod+Shift+T to restore the last closed tab",
+      event: { key: "T", code: "KeyT", metaKey: true, shiftKey: true },
+      context: { isMac: true },
+      action: "workspace.tab.restore.lastClosed",
+    },
+    {
+      name: "matches Ctrl+Alt+Shift+T to create a new terminal on non-mac",
+      event: { key: "T", code: "KeyT", ctrlKey: true, altKey: true, shiftKey: true },
+      context: { isMac: false },
+      action: "workspace.terminal.new",
+    },
+    {
       name: "matches Alt+Shift+W to close current tab on web",
       event: { key: "W", code: "KeyW", altKey: true, shiftKey: true },
       context: { isDesktop: false },
@@ -488,10 +500,10 @@ describe("keyboard-shortcuts", () => {
 
   it("prefers advancing chord candidates over single-combo matches on the same prefix", () => {
     const bindings = buildEffectiveBindings({
-      "workspace-terminal-new-ctrl-shift-t-non-mac": "Ctrl+W S",
+      "workspace-terminal-new-ctrl-alt-shift-t-non-mac": "Ctrl+W S",
     });
     const chordBindingIndex = bindings.findIndex(
-      (binding) => binding.id === "workspace-terminal-new-ctrl-shift-t-non-mac",
+      (binding) => binding.id === "workspace-terminal-new-ctrl-alt-shift-t-non-mac",
     );
     expect(chordBindingIndex).toBeGreaterThan(-1);
 
@@ -525,7 +537,7 @@ describe("keyboard-shortcuts", () => {
     vi.useFakeTimers();
 
     const bindings = buildEffectiveBindings({
-      "workspace-terminal-new-ctrl-shift-t-non-mac": "Ctrl+W S",
+      "workspace-terminal-new-ctrl-alt-shift-t-non-mac": "Ctrl+W S",
     });
     const onChordReset = vi.fn();
 

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -125,6 +125,7 @@ const SHORTCUT_HELP_LABEL_KEYS: Record<string, string> = {
   "archive-worktree": "settings.shortcuts.help.archiveWorktree",
   "workspace-tab-new": "settings.shortcuts.help.newTab",
   "workspace-tab-close-current": "settings.shortcuts.help.closeCurrentTab",
+  "workspace-tab-restore-last-closed": "settings.shortcuts.help.restoreLastClosedTab",
   "workspace-jump-index": "settings.shortcuts.help.jumpToWorkspace",
   "workspace-tab-jump-index": "settings.shortcuts.help.jumpToTab",
   "workspace-prev": "settings.shortcuts.help.previousWorkspace",
@@ -328,6 +329,30 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
       section: "tabs-panes",
       label: "Close current tab",
       keys: ["alt", "shift", "W"],
+    },
+  },
+  {
+    id: "workspace-tab-restore-last-closed-cmd-shift-t-mac",
+    action: "workspace.tab.restore.lastClosed",
+    combo: "Cmd+Shift+T",
+    when: { mac: true, commandCenter: false },
+    help: {
+      id: "workspace-tab-restore-last-closed",
+      section: "tabs-panes",
+      label: "Restore last closed tab",
+      keys: ["mod", "shift", "T"],
+    },
+  },
+  {
+    id: "workspace-tab-restore-last-closed-ctrl-shift-t-non-mac",
+    action: "workspace.tab.restore.lastClosed",
+    combo: "Ctrl+Shift+T",
+    when: { mac: false, commandCenter: false, terminal: false },
+    help: {
+      id: "workspace-tab-restore-last-closed",
+      section: "tabs-panes",
+      label: "Restore last closed tab",
+      keys: ["mod", "shift", "T"],
     },
   },
 
@@ -657,27 +682,27 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
 
   // --- New terminal ---
   {
-    id: "workspace-terminal-new-cmd-shift-t-mac",
+    id: "workspace-terminal-new-cmd-alt-shift-t-mac",
     action: "workspace.terminal.new",
-    combo: "Cmd+Shift+T",
+    combo: "Cmd+Alt+Shift+T",
     when: { mac: true, commandCenter: false },
     help: {
       id: "workspace-terminal-new",
       section: "panels",
       label: "New terminal",
-      keys: ["mod", "shift", "T"],
+      keys: ["mod", "alt", "shift", "T"],
     },
   },
   {
-    id: "workspace-terminal-new-ctrl-shift-t-non-mac",
+    id: "workspace-terminal-new-ctrl-alt-shift-t-non-mac",
     action: "workspace.terminal.new",
-    combo: "Ctrl+Shift+T",
+    combo: "Ctrl+Alt+Shift+T",
     when: { mac: false, commandCenter: false, terminal: false },
     help: {
       id: "workspace-terminal-new",
       section: "panels",
       label: "New terminal",
-      keys: ["mod", "shift", "T"],
+      keys: ["mod", "alt", "shift", "T"],
     },
   },
 

--- a/packages/app/src/keyboard/route-shortcut.test.ts
+++ b/packages/app/src/keyboard/route-shortcut.test.ts
@@ -34,6 +34,10 @@ describe("routeKeyboardShortcut — dispatch passthroughs", () => {
     ["worktree.new", { id: "worktree.new", scope: "sidebar" }],
     ["workspace.terminal.new", { id: "workspace.terminal.new", scope: "workspace" }],
     ["workspace.tab.close.current", { id: "workspace.tab.close-current", scope: "workspace" }],
+    [
+      "workspace.tab.restore.lastClosed",
+      { id: "workspace.tab.restore-last-closed", scope: "workspace" },
+    ],
     ["sidebar.toggle.right", { id: "sidebar.toggle.right", scope: "sidebar" }],
     ["workspace.pane.split.right", { id: "workspace.pane.split.right", scope: "workspace" }],
     ["workspace.pane.split.down", { id: "workspace.pane.split.down", scope: "workspace" }],

--- a/packages/app/src/keyboard/route-shortcut.ts
+++ b/packages/app/src/keyboard/route-shortcut.ts
@@ -50,6 +50,10 @@ const PASSTHROUGH_DISPATCH: Record<string, KeyboardActionDefinition> = {
   "worktree.new": { id: "worktree.new", scope: "sidebar" },
   "workspace.terminal.new": { id: "workspace.terminal.new", scope: "workspace" },
   "workspace.tab.close.current": { id: "workspace.tab.close-current", scope: "workspace" },
+  "workspace.tab.restore.lastClosed": {
+    id: "workspace.tab.restore-last-closed",
+    scope: "workspace",
+  },
   "sidebar.toggle.right": { id: "sidebar.toggle.right", scope: "sidebar" },
   "workspace.pane.split.right": { id: "workspace.pane.split.right", scope: "workspace" },
   "workspace.pane.split.down": { id: "workspace.pane.split.down", scope: "workspace" },

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -45,6 +45,7 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuLabel,
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
@@ -75,6 +76,7 @@ import {
   type WorkspaceTabMenuLabels,
 } from "@/screens/workspace/workspace-tab-menu";
 import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
+import type { RecentlyClosedWorkspaceTab } from "@/stores/workspace-layout-store";
 import type { Theme } from "@/styles/theme";
 import { RenderProfile } from "@/utils/render-profiler";
 import { useDaemonConfig } from "@/hooks/use-daemon-config";
@@ -171,40 +173,161 @@ function PinnableProfileMenuItem({ profile, disabled, onLaunch }: PinnableProfil
 
 interface WorkspaceInlineAddTabButtonProps {
   shortcutKeys: ShortcutKey[][] | null;
+  recentlyClosedTabs: RecentlyClosedWorkspaceTab[];
+  normalizedServerId: string;
+  normalizedWorkspaceId: string;
   onCreateAgentTab: () => void;
+  onRestoreClosedTab: (entryKey: string) => void;
   onLayout: (event: LayoutChangeEvent) => void;
 }
 
 function WorkspaceInlineAddTabButton({
   shortcutKeys,
+  recentlyClosedTabs,
+  normalizedServerId,
+  normalizedWorkspaceId,
   onCreateAgentTab,
+  onRestoreClosedTab,
   onLayout,
 }: WorkspaceInlineAddTabButtonProps) {
   const { t } = useTranslation();
   const tooltipText = t("workspace.tabs.actions.newAgent");
+  const fallbackTabLabels = useMemo(
+    () => ({
+      newAgent: t("workspace.tabs.fallback.newAgent"),
+      setup: t("workspace.tabs.fallback.setup"),
+      terminal: t("workspace.tabs.fallback.terminal"),
+      agent: t("workspace.tabs.fallback.agent"),
+    }),
+    [t],
+  );
 
   return (
     <View style={styles.inlineAddButton} onLayout={onLayout}>
-      <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
-        <TooltipTrigger
-          testID="workspace-new-agent-tab-inline"
-          onPress={onCreateAgentTab}
-          accessibilityRole="button"
-          accessibilityLabel={tooltipText}
-          style={inlineAddActionButtonStyle}
+      <ContextMenu>
+        <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
+          <TooltipTrigger asChild triggerRefProp="triggerRef">
+            <ContextMenuTrigger
+              testID="workspace-new-agent-tab-inline"
+              onPress={onCreateAgentTab}
+              accessibilityRole="button"
+              accessibilityLabel={tooltipText}
+              enabledOnMobile={false}
+              style={inlineAddActionButtonStyle}
+            >
+              <ThemedPlus size={14} uniProps={mutedColorMapping} />
+            </ContextMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" align="center" offset={8}>
+            <View style={styles.newTabTooltipRow}>
+              <Text style={styles.newTabTooltipText}>{tooltipText}</Text>
+              {shortcutKeys ? (
+                <Shortcut chord={shortcutKeys} style={styles.newTabTooltipShortcut} />
+              ) : null}
+            </View>
+          </TooltipContent>
+        </Tooltip>
+        <ContextMenuContent
+          align="start"
+          minWidth={220}
+          testID="workspace-recently-closed-tabs-menu"
         >
-          <ThemedPlus size={14} uniProps={mutedColorMapping} />
-        </TooltipTrigger>
-        <TooltipContent side="bottom" align="center" offset={8}>
-          <View style={styles.newTabTooltipRow}>
-            <Text style={styles.newTabTooltipText}>{tooltipText}</Text>
-            {shortcutKeys ? (
-              <Shortcut chord={shortcutKeys} style={styles.newTabTooltipShortcut} />
-            ) : null}
-          </View>
-        </TooltipContent>
-      </Tooltip>
+          <ContextMenuLabel>{t("workspace.tabs.recentlyClosed.title")}</ContextMenuLabel>
+          {recentlyClosedTabs.length === 0 ? (
+            <ContextMenuItem testID="workspace-recently-closed-tabs-empty" disabled>
+              {t("workspace.tabs.recentlyClosed.empty")}
+            </ContextMenuItem>
+          ) : (
+            recentlyClosedTabs.map((entry) => (
+              <RecentlyClosedTabMenuItem
+                key={entry.key}
+                entry={entry}
+                normalizedServerId={normalizedServerId}
+                normalizedWorkspaceId={normalizedWorkspaceId}
+                fallbackLabels={fallbackTabLabels}
+                onRestoreClosedTab={onRestoreClosedTab}
+              />
+            ))
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
     </View>
+  );
+}
+
+function RecentlyClosedTabMenuItemResolved({
+  entryKey,
+  label,
+  presentation,
+  onSelect,
+}: {
+  entryKey: string;
+  label: string;
+  presentation: WorkspaceTabPresentation;
+  onSelect: () => void;
+}) {
+  const leading = useMemo(
+    () => <WorkspaceTabIcon presentation={presentation} active={false} />,
+    [presentation],
+  );
+  return (
+    <ContextMenuItem
+      testID={`workspace-recently-closed-tab-${entryKey}`}
+      leading={leading}
+      onSelect={onSelect}
+    >
+      {label}
+    </ContextMenuItem>
+  );
+}
+
+function RecentlyClosedTabMenuItem({
+  entry,
+  normalizedServerId,
+  normalizedWorkspaceId,
+  fallbackLabels,
+  onRestoreClosedTab,
+}: {
+  entry: RecentlyClosedWorkspaceTab;
+  normalizedServerId: string;
+  normalizedWorkspaceId: string;
+  fallbackLabels: { newAgent: string; setup: string; terminal: string; agent: string };
+  onRestoreClosedTab: (entryKey: string) => void;
+}) {
+  const tab = useMemo<WorkspaceTabDescriptor>(
+    () => ({
+      key: entry.tab.tabId,
+      tabId: entry.tab.tabId,
+      kind: entry.tab.target.kind,
+      target: entry.tab.target,
+    }),
+    [entry.tab],
+  );
+  const handleSelect = useCallback(() => {
+    onRestoreClosedTab(entry.key);
+  }, [entry.key, onRestoreClosedTab]);
+
+  return (
+    <WorkspaceTabPresentationResolver
+      tab={tab}
+      serverId={normalizedServerId}
+      workspaceId={normalizedWorkspaceId}
+    >
+      {(presentation) => {
+        const label =
+          presentation.titleState === "loading"
+            ? getFallbackTabLabel(tab, fallbackLabels)
+            : presentation.label;
+        return (
+          <RecentlyClosedTabMenuItemResolved
+            entryKey={entry.key}
+            label={label}
+            presentation={presentation}
+            onSelect={handleSelect}
+          />
+        );
+      }}
+    </WorkspaceTabPresentationResolver>
   );
 }
 
@@ -412,6 +535,7 @@ interface WorkspaceDesktopTabsRowProps {
   paneId?: string;
   isFocused?: boolean;
   tabs: WorkspaceDesktopTabRowItem[];
+  recentlyClosedTabs: RecentlyClosedWorkspaceTab[];
   normalizedServerId: string;
   normalizedWorkspaceId: string;
   setHoveredCloseTabKey: Dispatch<SetStateAction<string | null>>;
@@ -425,6 +549,7 @@ interface WorkspaceDesktopTabsRowProps {
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  onRestoreClosedTab: (entryKey: string) => void;
   onCreateDraftTab: (input: { paneId?: string }) => void;
   onCreateTerminalTab: (input: { paneId?: string; profile?: TerminalProfileInput }) => void;
   onCreateBrowserTab: (input: { paneId?: string }) => void;
@@ -732,6 +857,7 @@ export function WorkspaceDesktopTabsRow({
   paneId,
   isFocused = false,
   tabs,
+  recentlyClosedTabs,
   normalizedServerId,
   normalizedWorkspaceId,
   setHoveredCloseTabKey,
@@ -745,6 +871,7 @@ export function WorkspaceDesktopTabsRow({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  onRestoreClosedTab,
   onCreateDraftTab,
   onCreateTerminalTab,
   onCreateBrowserTab,
@@ -989,7 +1116,11 @@ export function WorkspaceDesktopTabsRow({
         />
         <WorkspaceInlineAddTabButton
           shortcutKeys={newTabKeys}
+          recentlyClosedTabs={recentlyClosedTabs}
+          normalizedServerId={normalizedServerId}
+          normalizedWorkspaceId={normalizedWorkspaceId}
           onCreateAgentTab={handleCreateAgentTab}
+          onRestoreClosedTab={onRestoreClosedTab}
           onLayout={handleInlineAddButtonLayout}
         />
       </ScrollView>

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -80,6 +80,7 @@ import {
   buildWorkspaceTabPersistenceKey,
   collectAllTabs,
   getFocusedBrowserId,
+  type RecentlyClosedWorkspaceTab,
   type WorkspaceLayout,
   useWorkspaceLayoutStore,
   useWorkspaceLayoutStoreHydrated,
@@ -200,6 +201,7 @@ import { RenderProfile } from "@/utils/render-profiler";
 const WORKSPACE_SETUP_AUTO_OPEN_WINDOW_MS = 30_000;
 const WORKSPACE_FLOATING_PANEL_PORTAL_HOST_PREFIX = "workspace-floating-panels";
 const EMPTY_UI_TABS: WorkspaceTab[] = [];
+const EMPTY_RECENTLY_CLOSED_TABS: RecentlyClosedWorkspaceTab[] = [];
 const EMPTY_WORKSPACE_SCRIPTS: WorkspaceDescriptor["scripts"] = [];
 const EMPTY_PINNED_AGENT_IDS = new Set<string>();
 const EMPTY_SET = new Set<string>();
@@ -1976,6 +1978,10 @@ function WorkspaceScreenContent({
   );
   const focusWorkspaceTab = useWorkspaceLayoutStore((state) => state.focusTab);
   const closeWorkspaceTab = useWorkspaceLayoutStore((state) => state.closeTab);
+  const restoreClosedWorkspaceTab = useWorkspaceLayoutStore((state) => state.restoreClosedTab);
+  const restoreLastClosedWorkspaceTab = useWorkspaceLayoutStore(
+    (state) => state.restoreLastClosedTab,
+  );
   const unpinWorkspaceAgent = useWorkspaceLayoutStore((state) => state.unpinAgent);
   const hideWorkspaceAgent = useWorkspaceLayoutStore((state) => state.hideAgent);
   const retargetWorkspaceTab = useWorkspaceLayoutStore((state) => state.retargetTab);
@@ -1993,6 +1999,11 @@ function WorkspaceScreenContent({
   );
   const _hiddenAgentIds = useWorkspaceLayoutStore((state) =>
     persistenceKey ? (state.hiddenAgentIdsByWorkspace[persistenceKey] ?? EMPTY_SET) : EMPTY_SET,
+  );
+  const recentlyClosedTabs = useWorkspaceLayoutStore((state) =>
+    persistenceKey
+      ? (state.recentlyClosedTabsByWorkspace[persistenceKey] ?? EMPTY_RECENTLY_CLOSED_TABS)
+      : EMPTY_RECENTLY_CLOSED_TABS,
   );
   const pendingByDraftId = useCreateFlowStore((state) => state.pendingByDraftId);
   const { closingTabIds, closeTab } = useCloseTabs();
@@ -2561,6 +2572,16 @@ function WorkspaceScreenContent({
     [focusWorkspacePane, openWorkspaceTabFocused, persistenceKey],
   );
 
+  const handleRestoreClosedTab = useCallback(
+    (entryKey: string) => {
+      if (!persistenceKey) {
+        return;
+      }
+      restoreClosedWorkspaceTab(persistenceKey, entryKey);
+    },
+    [persistenceKey, restoreClosedWorkspaceTab],
+  );
+
   const handleOpenUrlInBrowserTab = useCallback(
     (url: string) => {
       if (!persistenceKey || !getIsElectron()) {
@@ -2976,6 +2997,11 @@ function WorkspaceScreenContent({
             void handleCloseTabById(activeTabId);
           }
           return true;
+        case "workspace.tab.restore-last-closed":
+          if (persistenceKey) {
+            restoreLastClosedWorkspaceTab(persistenceKey);
+          }
+          return true;
         case "workspace.tab.navigate-index": {
           const next = tabs[action.index - 1] ?? null;
           if (next?.tabId) {
@@ -3005,6 +3031,8 @@ function WorkspaceScreenContent({
       handleCreateDraftTab,
       handleCreateTerminal,
       navigateToTabId,
+      persistenceKey,
+      restoreLastClosedWorkspaceTab,
       tabs,
     ],
   );
@@ -3104,6 +3132,7 @@ function WorkspaceScreenContent({
     actions: [
       "workspace.tab.new",
       "workspace.tab.close-current",
+      "workspace.tab.restore-last-closed",
       "workspace.tab.navigate-index",
       "workspace.tab.navigate-relative",
       "workspace.terminal.new",
@@ -3561,6 +3590,7 @@ function WorkspaceScreenContent({
         normalizedWorkspaceId={normalizedWorkspaceId}
         isWorkspaceFocused={isRouteFocused}
         uiTabs={uiTabs}
+        recentlyClosedTabs={recentlyClosedTabs}
         hoveredCloseTabKey={hoveredCloseTabKey}
         setHoveredCloseTabKey={setHoveredCloseTabKey}
         closingTabIds={closingTabIds}
@@ -3574,6 +3604,7 @@ function WorkspaceScreenContent({
         onCloseTabsToLeft={handleCloseTabsToLeftInPane}
         onCloseTabsToRight={handleCloseTabsToRightInPane}
         onCloseOtherTabs={handleCloseOtherTabsInPane}
+        onRestoreClosedTab={handleRestoreClosedTab}
         onCreateDraftTab={handleCreateDraftTab}
         onCreateTerminalTab={handleCreateTerminal}
         onCreateBrowserTab={handleCreateBrowserTab}
@@ -3597,6 +3628,7 @@ function WorkspaceScreenContent({
     normalizedWorkspaceId,
     isRouteFocused,
     uiTabs,
+    recentlyClosedTabs,
     hoveredCloseTabKey,
     closingTabIds,
     navigateToTabId,
@@ -3609,6 +3641,7 @@ function WorkspaceScreenContent({
     handleCloseTabsToLeftInPane,
     handleCloseTabsToRightInPane,
     handleCloseOtherTabsInPane,
+    handleRestoreClosedTab,
     handleCreateDraftTab,
     handleCreateTerminal,
     handleCreateBrowserTab,
@@ -3699,6 +3732,7 @@ function WorkspaceScreenContent({
           paneId={focusedPaneIdOrUndefined}
           isFocused={isRouteFocused}
           tabs={desktopTabRowItems}
+          recentlyClosedTabs={recentlyClosedTabs}
           normalizedServerId={normalizedServerId}
           normalizedWorkspaceId={normalizedWorkspaceId}
           setHoveredCloseTabKey={setHoveredCloseTabKey}
@@ -3712,6 +3746,7 @@ function WorkspaceScreenContent({
           onCloseTabsToLeft={handleCloseTabsToLeft}
           onCloseTabsToRight={handleCloseTabsToRight}
           onCloseOtherTabs={handleCloseOtherTabs}
+          onRestoreClosedTab={handleRestoreClosedTab}
           onCreateDraftTab={handleCreateDraftTab}
           onCreateTerminalTab={handleCreateTerminal}
           onCreateBrowserTab={handleCreateBrowserTab}

--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -109,6 +109,18 @@ interface OpenTabInLayoutResult {
   tabId: string;
 }
 
+interface RestoreTabInLayoutInput {
+  layout: WorkspaceLayout;
+  tab: WorkspaceTab;
+  paneId: string | null;
+  parentTabId?: string | null;
+}
+
+interface RestoreTabInLayoutResult {
+  layout: WorkspaceLayout;
+  tabId: string;
+}
+
 interface RetargetTabInLayoutInput {
   layout: WorkspaceLayout;
   tabId: string;
@@ -277,7 +289,7 @@ function createGroupNode(input: {
   };
 }
 
-function normalizeWorkspaceTab(value: unknown): WorkspaceTab | null {
+export function normalizeWorkspaceTab(value: unknown): WorkspaceTab | null {
   if (!value || typeof value !== "object") {
     return null;
   }
@@ -1115,6 +1127,60 @@ export function openTabInLayoutBackground(input: OpenTabInLayoutInput): OpenTabI
   }
 
   return insertNewTabIntoFocusedPane({ ...input, focus: false });
+}
+
+export function restoreTabInLayout(
+  input: RestoreTabInLayoutInput,
+): RestoreTabInLayoutResult | null {
+  const restoredTab = normalizeWorkspaceTab(input.tab);
+  if (!restoredTab) {
+    return null;
+  }
+
+  const layout = asInternalLayout(input.layout);
+  const existingTab = findExistingTabForTarget(layout.root, restoredTab.target);
+  if (existingTab) {
+    const nextLayout = updateExistingTabTarget(input.layout, existingTab, restoredTab.target);
+    return {
+      tabId: existingTab.tabId,
+      layout:
+        focusTabInLayout({
+          layout: nextLayout,
+          tabId: existingTab.tabId,
+        }) ?? nextLayout,
+    };
+  }
+
+  const requestedPaneId = trimNonEmpty(input.paneId);
+  const targetPane =
+    (requestedPaneId ? findPaneById(layout.root, requestedPaneId) : null) ??
+    findPaneById(layout.root, layout.focusedPaneId) ??
+    collectAllPanes(layout.root)[0] ??
+    findPaneById(createDefaultLayout().root, DEFAULT_PANE_ID);
+  invariant(targetPane, "Workspace layout must always have a pane");
+
+  return {
+    tabId: restoredTab.tabId,
+    layout: withNormalizedParentTabMap({
+      root: insertTabIntoPane(layout.root, {
+        paneId: targetPane.id,
+        tab: restoredTab,
+        focusTabId: restoredTab.tabId,
+      }),
+      focusedPaneId: targetPane.id,
+      parentTabIdByTabId: (() => {
+        const parentTabId = trimNonEmpty(input.parentTabId);
+        const openTabIds = new Set(collectAllTabs(layout.root).map((tab) => tab.tabId));
+        if (!parentTabId || !openTabIds.has(parentTabId)) {
+          return input.layout.parentTabIdByTabId;
+        }
+        return {
+          ...input.layout.parentTabIdByTabId,
+          [restoredTab.tabId]: parentTabId,
+        };
+      })(),
+    }),
+  };
 }
 
 export function closeTabInLayout(input: CloseTabInLayoutInput): WorkspaceLayout | null {

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -309,6 +309,7 @@ describe("workspace-layout-store actions", () => {
     workspaceLayoutStore.setState({
       layoutByWorkspace: {},
       splitSizesByWorkspace: {},
+      recentlyClosedTabsByWorkspace: {},
       pinnedAgentIdsByWorkspace: {},
       hiddenAgentIdsByWorkspace: {},
       focusRestorationByWorkspace: {},
@@ -511,6 +512,153 @@ describe("workspace-layout-store actions", () => {
 
     expect(pane.tabIds).toEqual([leftTabId]);
     expect(pane.focusedTabId).toBe(leftTabId);
+  });
+
+  it("records recently closed restorable tabs newest-first and caps them at ten", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    for (let index = 0; index < 11; index += 1) {
+      const tabId = store.openTabFocused(workspaceKey, {
+        kind: "file",
+        path: `/repo/worktree/${index}.ts`,
+      });
+      expect(tabId).toBeTruthy();
+      workspaceLayoutStore.getState().closeTab(workspaceKey, tabId!);
+    }
+
+    const entries = workspaceLayoutStore.getState().recentlyClosedTabsByWorkspace[workspaceKey];
+    expect(entries).toHaveLength(10);
+    expect(entries?.map((entry) => entry.tab.target)).toEqual(
+      Array.from({ length: 10 }, (_, index) => ({
+        kind: "file",
+        path: `/repo/worktree/${10 - index}.ts`,
+      })),
+    );
+  });
+
+  it("restores a closed tab, focuses it, and removes it from recently closed tabs", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    const tabId = store.openTabFocused(workspaceKey, {
+      kind: "draft",
+      draftId: "draft-to-restore",
+    });
+    expect(tabId).toBeTruthy();
+
+    workspaceLayoutStore.getState().closeTab(workspaceKey, tabId!);
+    const entry = workspaceLayoutStore.getState().recentlyClosedTabsByWorkspace[workspaceKey]?.[0];
+    expect(entry).toBeTruthy();
+
+    const restoredTabId = workspaceLayoutStore
+      .getState()
+      .restoreClosedTab(workspaceKey, entry!.key);
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+    const pane = findPaneContainingTab(layout.root, tabId!);
+
+    expect(restoredTabId).toBe(tabId);
+    expect(pane?.focusedTabId).toBe(tabId);
+    expect(
+      workspaceLayoutStore.getState().recentlyClosedTabsByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("restoring a closed agent tab clears its hidden state", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    const tabId = store.openTabFocused(workspaceKey, {
+      kind: "agent",
+      agentId: "agent-to-restore",
+    });
+
+    expect(tabId).not.toBeNull();
+    store.hideAgent(workspaceKey, "agent-to-restore");
+    store.closeTab(workspaceKey, tabId!);
+
+    const entry = workspaceLayoutStore.getState().recentlyClosedTabsByWorkspace[workspaceKey]?.[0];
+    expect(entry).toBeDefined();
+
+    workspaceLayoutStore.getState().restoreClosedTab(workspaceKey, entry!.key);
+
+    expect(workspaceLayoutStore.getState().hiddenAgentIdsByWorkspace[workspaceKey]).toBeUndefined();
+  });
+
+  it("restores into the focused pane when the original pane is gone", () => {
+    useWorkspaceLayoutIds(
+      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    );
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+    const leftTabId = store.openTabFocused(workspaceKey, {
+      kind: "draft",
+      draftId: "left",
+    });
+    const rightPaneId = store.splitPaneEmpty(workspaceKey, {
+      targetPaneId: "main",
+      position: "right",
+    });
+    expect(rightPaneId).toBeTruthy();
+    const rightTabId = store.openTabFocused(workspaceKey, {
+      kind: "draft",
+      draftId: "right",
+    });
+    expect(rightTabId).toBeTruthy();
+
+    workspaceLayoutStore.getState().closeTab(workspaceKey, rightTabId!);
+    workspaceLayoutStore.getState().focusTab(workspaceKey, leftTabId!);
+    const entry = workspaceLayoutStore.getState().recentlyClosedTabsByWorkspace[workspaceKey]?.[0];
+    expect(entry?.paneId).toBe(rightPaneId);
+
+    workspaceLayoutStore.getState().restoreLastClosedTab(workspaceKey);
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+    const restoredPane = findPaneContainingTab(layout.root, rightTabId!);
+
+    expect(restoredPane?.id).toBe("main");
+    expect(restoredPane?.focusedTabId).toBe(rightTabId);
+  });
+
+  it("focuses an already-open matching target and removes it from recently closed tabs", () => {
+    const workspaceKey = createWorkspaceKey();
+    const target = {
+      kind: "file" as const,
+      path: "/repo/worktree/reopened.ts",
+      serverId: SERVER_ID,
+      workspaceId: WORKSPACE_ID,
+    };
+    const store = workspaceLayoutStore.getState();
+    const tabId = store.openTabFocused(workspaceKey, target);
+    workspaceLayoutStore.getState().closeTab(workspaceKey, tabId!);
+    const entry = workspaceLayoutStore.getState().recentlyClosedTabsByWorkspace[workspaceKey]?.[0];
+    expect(entry).toBeTruthy();
+
+    const reopenedTabId = workspaceLayoutStore.getState().openTabFocused(workspaceKey, target);
+    const restoredTabId = workspaceLayoutStore
+      .getState()
+      .restoreClosedTab(workspaceKey, entry!.key);
+    const tabs = collectAllTabs(
+      workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey].root,
+    );
+
+    expect(restoredTabId).toBe(reopenedTabId);
+    expect(tabs.filter((tab) => tab.tabId === reopenedTabId)).toHaveLength(1);
+    expect(
+      workspaceLayoutStore.getState().recentlyClosedTabsByWorkspace[workspaceKey],
+    ).toBeUndefined();
+  });
+
+  it("does not record terminal tabs as recently closed", () => {
+    const workspaceKey = createWorkspaceKey();
+    const tabId = workspaceLayoutStore.getState().openTabFocused(workspaceKey, {
+      kind: "terminal",
+      terminalId: "term-1",
+    });
+
+    workspaceLayoutStore.getState().closeTab(workspaceKey, tabId!);
+
+    expect(
+      workspaceLayoutStore.getState().recentlyClosedTabsByWorkspace[workspaceKey],
+    ).toBeUndefined();
   });
 
   it("unfocuses and restores the previous focused pane", () => {
@@ -1215,6 +1363,74 @@ describe("workspace-layout-store actions", () => {
     expect(partialize?.(state)).toEqual({
       layoutByWorkspace: {},
       splitSizesByWorkspace: {},
+      recentlyClosedTabsByWorkspace: {},
+    });
+  });
+
+  it("partialize keeps only normalized restorable recently closed tabs", () => {
+    const workspaceKey = createWorkspaceKey();
+    const partialize = workspaceLayoutStore.persist.getOptions().partialize;
+
+    expect(partialize).toBeTypeOf("function");
+    workspaceLayoutStore.setState((state) => ({
+      ...state,
+      recentlyClosedTabsByWorkspace: {
+        [workspaceKey]: [
+          {
+            key: "valid",
+            tab: {
+              tabId: "",
+              target: { kind: "file", path: "/repo/worktree/restorable.ts" },
+              createdAt: 1,
+            },
+            paneId: "main",
+            parentTabId: null,
+            closedAt: 10,
+          },
+          {
+            key: "terminal",
+            tab: {
+              tabId: "term-1",
+              target: { kind: "terminal", terminalId: "term-1" },
+              createdAt: 1,
+            },
+            paneId: "main",
+            parentTabId: null,
+            closedAt: 20,
+          },
+          {
+            key: "invalid",
+            tab: {
+              tabId: "broken",
+              target: { kind: "file", path: "" },
+              createdAt: 1,
+            },
+            paneId: "main",
+            parentTabId: null,
+            closedAt: 30,
+          },
+        ],
+      },
+    }));
+
+    expect(partialize?.(workspaceLayoutStore.getState())).toEqual({
+      layoutByWorkspace: {},
+      splitSizesByWorkspace: {},
+      recentlyClosedTabsByWorkspace: {
+        [workspaceKey]: [
+          {
+            key: "valid",
+            tab: {
+              tabId: "file_/repo/worktree/restorable.ts",
+              target: { kind: "file", path: "/repo/worktree/restorable.ts" },
+              createdAt: 1,
+            },
+            paneId: "main",
+            parentTabId: null,
+            closedAt: 10,
+          },
+        ],
+      },
     });
   });
 
@@ -1251,6 +1467,7 @@ describe("workspace-layout-store actions", () => {
     expect(partialize?.(state)).toEqual({
       layoutByWorkspace: {},
       splitSizesByWorkspace: {},
+      recentlyClosedTabsByWorkspace: {},
     });
   });
 

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -27,6 +27,7 @@ import {
   insertSplit,
   moveTabToPaneInLayout,
   normalizeLayout,
+  normalizeWorkspaceTab,
   openTabInLayoutBackground,
   openTabInLayoutFocused,
   reconcileWorkspaceTabs,
@@ -34,6 +35,7 @@ import {
   removeTabFromTree,
   reorderFocusedPaneTabsInLayout,
   reorderPaneTabsInLayout,
+  restoreTabInLayout,
   retargetTabInLayout,
   splitPaneEmptyInLayout,
   splitPaneInLayout,
@@ -72,6 +74,7 @@ export type {
 interface WorkspaceLayoutStore {
   layoutByWorkspace: Record<string, WorkspaceLayout>;
   splitSizesByWorkspace: Record<string, Record<string, number[]>>;
+  recentlyClosedTabsByWorkspace: Record<string, RecentlyClosedWorkspaceTab[]>;
   pinnedAgentIdsByWorkspace: Record<string, Set<string>>;
   hiddenAgentIdsByWorkspace: Record<string, Set<string>>;
   focusRestorationByWorkspace: Record<string, WorkspaceFocusRestorationState>;
@@ -83,6 +86,8 @@ interface WorkspaceLayoutStore {
   ) => string | null;
   openTabInBackground: (workspaceKey: string, target: WorkspaceTabTarget) => string | null;
   closeTab: (workspaceKey: string, tabId: string) => void;
+  restoreClosedTab: (workspaceKey: string, entryKey: string) => string | null;
+  restoreLastClosedTab: (workspaceKey: string) => string | null;
   focusTab: (workspaceKey: string, tabId: string) => void;
   retargetTab: (workspaceKey: string, tabId: string, target: WorkspaceTabTarget) => string | null;
   convertDraftToAgent: (workspaceKey: string, tabId: string, agentId: string) => string | null;
@@ -122,7 +127,16 @@ interface WorkspaceFocusRestorationState {
   tokens: string[];
 }
 
+export interface RecentlyClosedWorkspaceTab {
+  key: string;
+  tab: WorkspaceTab;
+  paneId: string | null;
+  parentTabId: string | null;
+  closedAt: number;
+}
+
 const MAX_TREE_DEPTH = 4;
+const MAX_RECENTLY_CLOSED_TABS = 10;
 
 function trimNonEmpty(value: string | null | undefined): string | null {
   if (typeof value !== "string") {
@@ -193,6 +207,104 @@ function withoutFocusRestoration(
   return { focusRestorationByWorkspace };
 }
 
+function isRestorableClosedTab(tab: WorkspaceTab): boolean {
+  switch (tab.target.kind) {
+    case "draft":
+    case "agent":
+    case "file":
+    case "setup":
+      return true;
+    case "terminal":
+    case "browser":
+      return false;
+  }
+}
+
+function normalizeRecentlyClosedTab(value: unknown): RecentlyClosedWorkspaceTab | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as Partial<RecentlyClosedWorkspaceTab>;
+  const tab = normalizeWorkspaceTab(record.tab);
+  if (!tab || !isRestorableClosedTab(tab)) {
+    return null;
+  }
+  const closedAt = typeof record.closedAt === "number" ? record.closedAt : Date.now();
+  const key = trimNonEmpty(record.key) ?? `${closedAt}:${tab.tabId}`;
+  return {
+    key,
+    tab,
+    paneId: trimNonEmpty(record.paneId) ?? null,
+    parentTabId: trimNonEmpty(record.parentTabId) ?? null,
+    closedAt,
+  };
+}
+
+function normalizeRecentlyClosedTabs(value: unknown): RecentlyClosedWorkspaceTab[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const next: RecentlyClosedWorkspaceTab[] = [];
+  const seen = new Set<string>();
+  for (const entryValue of value) {
+    const entry = normalizeRecentlyClosedTab(entryValue);
+    if (!entry || seen.has(entry.key)) {
+      continue;
+    }
+    seen.add(entry.key);
+    next.push(entry);
+  }
+  return next
+    .sort((left, right) => right.closedAt - left.closedAt)
+    .slice(0, MAX_RECENTLY_CLOSED_TABS);
+}
+
+function enqueueRecentlyClosedTab(input: {
+  current: RecentlyClosedWorkspaceTab[];
+  tab: WorkspaceTab;
+  paneId: string | null;
+  parentTabId: string | null;
+  closedAt: number;
+}): RecentlyClosedWorkspaceTab[] {
+  if (!isRestorableClosedTab(input.tab)) {
+    return input.current;
+  }
+  const key = `${input.closedAt}:${input.tab.tabId}`;
+  const entry: RecentlyClosedWorkspaceTab = {
+    key,
+    tab: input.tab,
+    paneId: input.paneId,
+    parentTabId: input.parentTabId,
+    closedAt: input.closedAt,
+  };
+  return [entry, ...input.current.filter((current) => current.tab.tabId !== input.tab.tabId)].slice(
+    0,
+    MAX_RECENTLY_CLOSED_TABS,
+  );
+}
+
+function removeRecentlyClosedEntry(
+  entries: RecentlyClosedWorkspaceTab[],
+  entryKey: string,
+): RecentlyClosedWorkspaceTab[] {
+  return entries.filter((entry) => entry.key !== entryKey);
+}
+
+function resolveRestoredHiddenAgentIds(input: {
+  hiddenAgentIdsByWorkspace: Record<string, Set<string>>;
+  workspaceKey: string;
+  tab: WorkspaceTab;
+}): Record<string, Set<string>> {
+  if (input.tab.target.kind !== "agent") {
+    return input.hiddenAgentIdsByWorkspace;
+  }
+  return removeAgentIdFromWorkspaceSet(
+    input.hiddenAgentIdsByWorkspace,
+    input.workspaceKey,
+    input.tab.target.agentId,
+  );
+}
+
 function attachParentTab(input: {
   layout: WorkspaceLayout;
   childTabId: string | null;
@@ -226,6 +338,7 @@ export function createWorkspaceLayoutStore(
       (set, get) => ({
         layoutByWorkspace: {},
         splitSizesByWorkspace: {},
+        recentlyClosedTabsByWorkspace: {},
         pinnedAgentIdsByWorkspace: {},
         hiddenAgentIdsByWorkspace: {},
         focusRestorationByWorkspace: {},
@@ -337,22 +450,120 @@ export function createWorkspaceLayoutStore(
           }
 
           set((state) => {
+            const layout = getWorkspaceLayout(state.layoutByWorkspace, normalizedWorkspaceKey);
+            const sourcePane = findPaneContainingTab(layout.root, normalizedTabId);
+            const closedTab =
+              collectAllTabs(layout.root).find((tab) => tab.tabId === normalizedTabId) ?? null;
             const nextLayout = closeTabInLayout({
-              layout: getWorkspaceLayout(state.layoutByWorkspace, normalizedWorkspaceKey),
+              layout,
               tabId: normalizedTabId,
             });
             if (!nextLayout) {
               return state;
             }
 
+            const parentTabId = trimNonEmpty(layout.parentTabIdByTabId?.[normalizedTabId]);
+            const currentRecentlyClosed =
+              state.recentlyClosedTabsByWorkspace[normalizedWorkspaceKey] ?? [];
+            const nextRecentlyClosed =
+              closedTab && sourcePane
+                ? enqueueRecentlyClosedTab({
+                    current: currentRecentlyClosed,
+                    tab: closedTab,
+                    paneId: sourcePane.id,
+                    parentTabId,
+                    closedAt: Date.now(),
+                  })
+                : currentRecentlyClosed;
+            const recentlyClosedTabsByWorkspace =
+              nextRecentlyClosed === currentRecentlyClosed
+                ? state.recentlyClosedTabsByWorkspace
+                : {
+                    ...state.recentlyClosedTabsByWorkspace,
+                    [normalizedWorkspaceKey]: nextRecentlyClosed,
+                  };
+
             return {
               ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+              recentlyClosedTabsByWorkspace,
               layoutByWorkspace: {
                 ...state.layoutByWorkspace,
                 [normalizedWorkspaceKey]: nextLayout,
               },
             };
           });
+        },
+        restoreClosedTab: (workspaceKey, entryKey) => {
+          const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
+          const normalizedEntryKey = trimNonEmpty(entryKey);
+          if (!normalizedWorkspaceKey || !normalizedEntryKey) {
+            return null;
+          }
+
+          let restoredTabId: string | null = null;
+          set((state) => {
+            const entries = normalizeRecentlyClosedTabs(
+              state.recentlyClosedTabsByWorkspace[normalizedWorkspaceKey],
+            );
+            const entry = entries.find((candidate) => candidate.key === normalizedEntryKey) ?? null;
+            if (!entry) {
+              return state;
+            }
+
+            const layout = getWorkspaceLayout(state.layoutByWorkspace, normalizedWorkspaceKey);
+            const result = restoreTabInLayout({
+              layout,
+              tab: entry.tab,
+              paneId: entry.paneId,
+              parentTabId: entry.parentTabId,
+            });
+            if (!result) {
+              return state;
+            }
+
+            restoredTabId = result.tabId;
+            const nextEntries = removeRecentlyClosedEntry(entries, normalizedEntryKey);
+            const recentlyClosedTabsByWorkspace =
+              nextEntries.length === 0
+                ? (() => {
+                    const { [normalizedWorkspaceKey]: _removed, ...rest } =
+                      state.recentlyClosedTabsByWorkspace;
+                    return rest;
+                  })()
+                : {
+                    ...state.recentlyClosedTabsByWorkspace,
+                    [normalizedWorkspaceKey]: nextEntries,
+                  };
+
+            return {
+              ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+              hiddenAgentIdsByWorkspace: resolveRestoredHiddenAgentIds({
+                hiddenAgentIdsByWorkspace: state.hiddenAgentIdsByWorkspace,
+                workspaceKey: normalizedWorkspaceKey,
+                tab: entry.tab,
+              }),
+              recentlyClosedTabsByWorkspace,
+              layoutByWorkspace: {
+                ...state.layoutByWorkspace,
+                [normalizedWorkspaceKey]: result.layout,
+              },
+            };
+          });
+          return restoredTabId;
+        },
+        restoreLastClosedTab: (workspaceKey) => {
+          const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
+          if (!normalizedWorkspaceKey) {
+            return null;
+          }
+          const entries = normalizeRecentlyClosedTabs(
+            get().recentlyClosedTabsByWorkspace[normalizedWorkspaceKey],
+          );
+          const entry = entries[0] ?? null;
+          if (!entry) {
+            return null;
+          }
+          return get().restoreClosedTab(normalizedWorkspaceKey, entry.key);
         },
         focusTab: (workspaceKey, tabId) => {
           const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
@@ -869,6 +1080,7 @@ export function createWorkspaceLayoutStore(
             const hasAny =
               normalizedWorkspaceKey in state.layoutByWorkspace ||
               normalizedWorkspaceKey in state.splitSizesByWorkspace ||
+              normalizedWorkspaceKey in state.recentlyClosedTabsByWorkspace ||
               normalizedWorkspaceKey in state.pinnedAgentIdsByWorkspace ||
               normalizedWorkspaceKey in state.hiddenAgentIdsByWorkspace ||
               normalizedWorkspaceKey in state.focusRestorationByWorkspace;
@@ -879,6 +1091,8 @@ export function createWorkspaceLayoutStore(
               state.layoutByWorkspace;
             const { [normalizedWorkspaceKey]: _splits, ...splitSizesByWorkspace } =
               state.splitSizesByWorkspace;
+            const { [normalizedWorkspaceKey]: _recentlyClosed, ...recentlyClosedTabsByWorkspace } =
+              state.recentlyClosedTabsByWorkspace;
             const { [normalizedWorkspaceKey]: _pinned, ...pinnedAgentIdsByWorkspace } =
               state.pinnedAgentIdsByWorkspace;
             const { [normalizedWorkspaceKey]: _hidden, ...hiddenAgentIdsByWorkspace } =
@@ -888,6 +1102,7 @@ export function createWorkspaceLayoutStore(
             return {
               layoutByWorkspace,
               splitSizesByWorkspace,
+              recentlyClosedTabsByWorkspace,
               pinnedAgentIdsByWorkspace,
               hiddenAgentIdsByWorkspace,
               focusRestorationByWorkspace,
@@ -907,6 +1122,12 @@ export function createWorkspaceLayoutStore(
           return {
             layoutByWorkspace,
             splitSizesByWorkspace: state.splitSizesByWorkspace,
+            recentlyClosedTabsByWorkspace: Object.fromEntries(
+              Object.entries(state.recentlyClosedTabsByWorkspace).map(([key, entries]) => [
+                key,
+                normalizeRecentlyClosedTabs(entries),
+              ]),
+            ),
           };
         },
       },


### PR DESCRIPTION
## Summary
- Adds restore-closed-tab behavior for workspace panes and tab rows
- Adds keyboard actions, route shortcuts, translations, and layout-store tests
- Rebases the branch to remove unrelated old-main changes from the PR scope

## Validation
- Branch review agent ran focused tests plus repo typecheck/lint/format before the rebase
- Rebased onto origin/main and verified the final diff scope
