### PR TITLE
feat(openchamber): OpenChamber-parity feature set + capability gating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ packages/server/src/server/fixtures/dictation/dictation-debug-largest.transcript
 packages/desktop/.cache/
 packages/desktop/src-tauri/resources/managed-runtime/
 app.json
+.omc/
+scratch/

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dev:server:watch": "concurrently --kill-others --names protocol,client,server --prefix-colors yellow,blue,cyan \"npm run watch:protocol\" \"npm run watch:client\" \"npm run dev:server:raw\"",
     "dev:server:raw": "npm run dev --workspace=@getpaseo/server",
     "dev:app": "cross-env PASEO_LISTEN=127.0.0.1:6768 EXPO_PORT=8081 ./scripts/dev-app.sh",
+    "dev:web": "./scripts/dev-web.sh",
     "dev:website": "npm run dev --workspace=@getpaseo/website",
     "postinstall": "node scripts/postinstall-patches.mjs",
     "prepare": "lefthook install --force",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -86,6 +86,7 @@
     "i18next": "^26.3.0",
     "lucide-react-native": "^0.546.0",
     "markdown-it": "^10.0.0",
+    "mermaid": "^11.16.0",
     "mnemonic-id": "^3.2.7",
     "qrcode": "^1.5.4",
     "react": "19.1.0",

--- a/packages/app/src/components/explorer-sidebar.tsx
+++ b/packages/app/src/components/explorer-sidebar.tsx
@@ -36,6 +36,7 @@ import { canCloseRightSidebarGesture } from "@/utils/sidebar-animation-state";
 import { HEADER_INNER_HEIGHT } from "@/constants/layout";
 import { GitDiffPane } from "@/git/diff-pane";
 import { FileExplorerPane } from "./file-explorer-pane";
+import { ProjectNotesPanel } from "@/components/project-notes-panel";
 import { useKeyboardShiftStyle } from "@/hooks/use-keyboard-shift-style";
 import { useWindowControlsPadding } from "@/utils/desktop-window";
 import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
@@ -510,6 +511,13 @@ function ExplorerSidebarContent({
             onTabPress={onTabPress}
             testID="explorer-tab-files"
           />
+          <ExplorerTabButton
+            tab="notes"
+            active={resolvedTab === "notes"}
+            label="Notes"
+            onTabPress={onTabPress}
+            testID="explorer-tab-notes"
+          />
           {isGit && showPrTab && (
             <ExplorerTabButton
               tab="pr"
@@ -554,6 +562,11 @@ function ExplorerSidebarContent({
             onOpenFile={onOpenFile}
           />
         )}
+        <ProjectNotesPanel
+          active={resolvedTab === "notes"}
+          serverId={serverId}
+          cwd={workspaceRoot}
+        />
         {resolvedTab === "pr" && (
           <PrTabContent
             serverId={serverId}

--- a/packages/app/src/components/markdown/renderer.tsx
+++ b/packages/app/src/components/markdown/renderer.tsx
@@ -24,6 +24,7 @@ import Markdown, {
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { AppearanceStyleBoundary } from "@/components/appearance-style-boundary";
 import { HighlightedCodeBlock } from "@/components/highlighted-code-block";
+import { MermaidBlock } from "@/components/mermaid-block";
 import { MarkdownParagraphView, MarkdownTextSpan } from "@/components/markdown-text";
 import { getMarkdownListMarker, getMarkdownListSpacing } from "@/utils/markdown-list";
 import { markdownNodeContainsType } from "@/utils/markdown-ast";
@@ -591,15 +592,21 @@ export function createSharedMarkdownRules(): RenderRules {
       _parent: ASTNode[],
       styles: MarkdownStyles,
       inheritedStyles: TextStyle = {},
-    ) => (
-      <HighlightedCodeBlock
-        key={node.key}
-        code={node.content}
-        language={node.sourceInfo}
-        inheritedStyles={inheritedStyles}
-        textStyle={styles.fence}
-      />
-    ),
+    ) => {
+      const fenceLanguage = (node.sourceInfo ?? "").trim().split(/\s+/)[0]?.toLowerCase();
+      if (fenceLanguage === "mermaid") {
+        return <MermaidBlock key={node.key} code={node.content} />;
+      }
+      return (
+        <HighlightedCodeBlock
+          key={node.key}
+          code={node.content}
+          language={node.sourceInfo}
+          inheritedStyles={inheritedStyles}
+          textStyle={styles.fence}
+        />
+      );
+    },
     code_inline: (
       node: ASTNode,
       _children: ReactNode[],

--- a/packages/app/src/components/mermaid-block.tsx
+++ b/packages/app/src/components/mermaid-block.tsx
@@ -1,0 +1,44 @@
+import { View } from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import MermaidDiagram, { type MermaidThemeColors } from "@/components/mermaid-diagram";
+
+// matchContents sizes the native WebView to the diagram; ignored on web.
+const DOM_PROPS = { matchContents: true, scrollEnabled: false } as const;
+
+// Plain RN wrapper so withUnistyles can inject theme colors here (it cannot wrap
+// the "use dom" component directly without dropping its `dom` prop). This passes
+// `dom` through to the DOM component, whose type accepts it.
+function MermaidInner({ code, themeColors }: { code: string; themeColors: MermaidThemeColors }) {
+  return <MermaidDiagram code={code} themeColors={themeColors} dom={DOM_PROPS} />;
+}
+
+// useUnistyles() is forbidden in this repo (docs/unistyles.md); withUnistyles is
+// the sanctioned reactive path for feeding theme values into a component.
+const ThemedMermaidInner = withUnistyles(MermaidInner, (theme) => ({
+  themeColors: {
+    background: theme.colors.background,
+    foreground: theme.colors.foreground,
+    muted: theme.colors.foregroundMuted,
+    border: theme.colors.border,
+    accent: theme.colors.accent,
+  },
+}));
+
+export function MermaidBlock({ code }: { code: string }) {
+  const trimmed = code.replace(/\n+$/, "");
+  if (!trimmed.trim()) {
+    return null;
+  }
+  return (
+    <View style={styles.container}>
+      <ThemedMermaidInner code={trimmed} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: "100%",
+    marginVertical: 8,
+  },
+});

--- a/packages/app/src/components/mermaid-diagram.tsx
+++ b/packages/app/src/components/mermaid-diagram.tsx
@@ -1,0 +1,124 @@
+"use dom";
+
+// Expo DOM component: renders a Mermaid diagram. On web this runs directly in
+// the DOM; on native Expo hosts it inside a WebView automatically. Mermaid is a
+// browser library (needs a DOM to render SVG), so this is the cross-platform
+// seam. Theme colors are injected from the RN side (see mermaid-block.tsx) so
+// the diagram matches the active Paseo theme.
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import type { DOMProps } from "expo/dom";
+import mermaid from "mermaid";
+
+export interface MermaidThemeColors {
+  background: string;
+  foreground: string;
+  muted: string;
+  border: string;
+  accent: string;
+}
+
+const DIAGRAM_CONTAINER_STYLE: CSSProperties = {
+  display: "flex",
+  justifyContent: "center",
+  width: "100%",
+  overflowX: "auto",
+};
+
+let renderSeq = 0;
+
+export default function MermaidDiagram({
+  code,
+  themeColors,
+}: {
+  code: string;
+  themeColors: MermaidThemeColors;
+  dom?: DOMProps;
+}) {
+  const [svg, setSvg] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const idRef = useRef<string>(`mmd-${(renderSeq += 1)}`);
+
+  useEffect(() => {
+    let cancelled = false;
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: "strict",
+      theme: "base",
+      themeVariables: {
+        background: themeColors.background,
+        primaryColor: themeColors.background,
+        primaryBorderColor: themeColors.border,
+        primaryTextColor: themeColors.foreground,
+        secondaryColor: themeColors.border,
+        tertiaryColor: themeColors.background,
+        lineColor: themeColors.muted,
+        textColor: themeColors.foreground,
+        mainBkg: themeColors.background,
+        nodeBorder: themeColors.border,
+        clusterBkg: themeColors.background,
+        clusterBorder: themeColors.border,
+        fontSize: "14px",
+      },
+    });
+    const run = async () => {
+      try {
+        const result = await mermaid.render(idRef.current, code);
+        if (!cancelled) {
+          setSvg(result.svg);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setSvg(null);
+        }
+      }
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    code,
+    themeColors.background,
+    themeColors.foreground,
+    themeColors.muted,
+    themeColors.border,
+    themeColors.accent,
+  ]);
+
+  const errorStyle = useMemo<CSSProperties>(
+    () => ({
+      margin: 0,
+      padding: 12,
+      whiteSpace: "pre-wrap",
+      wordBreak: "break-word",
+      color: themeColors.foreground,
+      background: themeColors.background,
+      border: `1px solid ${themeColors.border}`,
+      borderRadius: 8,
+      fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+      fontSize: 12,
+    }),
+    [themeColors.foreground, themeColors.background, themeColors.border],
+  );
+
+  const loadingStyle = useMemo<CSSProperties>(
+    () => ({ color: themeColors.muted, fontSize: 12, padding: 8 }),
+    [themeColors.muted],
+  );
+
+  const innerHtml = useMemo(() => ({ __html: svg ?? "" }), [svg]);
+
+  if (error) {
+    // Fall back to the raw source so a malformed diagram still shows its text.
+    return <pre style={errorStyle}>{code}</pre>;
+  }
+
+  if (!svg) {
+    return <div style={loadingStyle}>Rendering diagram…</div>;
+  }
+
+  // Mermaid output is sanitized by securityLevel: "strict".
+  return <div style={DIAGRAM_CONTAINER_STYLE} dangerouslySetInnerHTML={innerHtml} />;
+}

--- a/packages/app/src/components/model-multi-select.tsx
+++ b/packages/app/src/components/model-multi-select.tsx
@@ -1,0 +1,112 @@
+// Ported concept from openchamber/openchamber (MIT): ModelMultiSelect.
+// Presentational toggle-chip picker over available (provider, model) pairs for multi-run.
+import { useCallback, useMemo } from "react";
+import { Pressable, Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+
+export interface ModelOption {
+  provider: string;
+  model: string;
+  label: string;
+}
+
+export function modelOptionKey(provider: string, model: string): string {
+  return `${provider}::${model}`;
+}
+
+interface ModelMultiSelectProps {
+  options: ModelOption[];
+  selectedKeys: Set<string>;
+  onToggle: (option: ModelOption) => void;
+}
+
+function ModelChip({
+  option,
+  selected,
+  onToggle,
+}: {
+  option: ModelOption;
+  selected: boolean;
+  onToggle: (option: ModelOption) => void;
+}) {
+  const handlePress = useCallback(() => onToggle(option), [onToggle, option]);
+  const a11yState = useMemo(() => ({ selected }), [selected]);
+  return (
+    <Pressable
+      onPress={handlePress}
+      style={selected ? selectedChipStyle : chipStyle}
+      accessibilityRole="button"
+      accessibilityState={a11yState}
+      testID={`multi-run-model-${option.provider}-${option.model}`}
+    >
+      <Text style={selected ? styles.chipTextSelected : styles.chipText} numberOfLines={1}>
+        {option.label}
+      </Text>
+    </Pressable>
+  );
+}
+
+export function ModelMultiSelect({ options, selectedKeys, onToggle }: ModelMultiSelectProps) {
+  if (options.length === 0) {
+    return <Text style={styles.empty}>No models available for this host.</Text>;
+  }
+  return (
+    <View style={styles.container}>
+      {options.map((option) => (
+        <ModelChip
+          key={modelOptionKey(option.provider, option.model)}
+          option={option}
+          selected={selectedKeys.has(modelOptionKey(option.provider, option.model))}
+          onToggle={onToggle}
+        />
+      ))}
+    </View>
+  );
+}
+
+function chipStyle({ hovered = false }: { hovered?: boolean }) {
+  return [styles.chip, hovered && styles.chipHovered];
+}
+
+function selectedChipStyle({ hovered = false }: { hovered?: boolean }) {
+  return [styles.chip, styles.chipSelected, hovered && styles.chipSelectedHovered];
+}
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: theme.spacing[2],
+  },
+  empty: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  chip: {
+    paddingVertical: theme.spacing[1],
+    paddingHorizontal: theme.spacing[3],
+    borderRadius: theme.borderRadius.full,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface1,
+  },
+  chipHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+  chipSelected: {
+    borderColor: theme.colors.accent,
+    backgroundColor: theme.colors.accent,
+  },
+  chipSelectedHovered: {
+    opacity: 0.9,
+  },
+  chipText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  chipTextSelected: {
+    color: theme.colors.accentForeground,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+  },
+}));

--- a/packages/app/src/components/multi-run-launcher.tsx
+++ b/packages/app/src/components/multi-run-launcher.tsx
@@ -1,0 +1,207 @@
+// Ported concept from openchamber/openchamber (MIT): MultiRunLauncher.
+// Launches one prompt across multiple selected models in parallel (one agent per model).
+import { useCallback, useMemo, useState } from "react";
+import { Text, TextInput, View } from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { AdaptiveModalSheet } from "@/components/adaptive-modal-sheet";
+import { Button } from "@/components/ui/button";
+import {
+  ModelMultiSelect,
+  modelOptionKey,
+  type ModelOption,
+} from "@/components/model-multi-select";
+import { useProvidersSnapshot } from "@/hooks/use-providers-snapshot";
+import { useMultiRunStore, type MultiRunModelSelection } from "@/stores/multi-run-store";
+import { useI18n } from "@/lib/i18n";
+
+const ThemedTextInput = withUnistyles(TextInput, (theme) => ({
+  placeholderTextColor: theme.colors.foregroundMuted,
+}));
+
+interface MultiRunLauncherProps {
+  serverId: string;
+  cwd: string;
+  workspaceId: string;
+  visible: boolean;
+  onClose: () => void;
+}
+
+export function MultiRunLauncher({
+  serverId,
+  cwd,
+  workspaceId,
+  visible,
+  onClose,
+}: MultiRunLauncherProps) {
+  const { entries } = useProvidersSnapshot(serverId, { cwd, enabled: visible });
+  const { t } = useI18n();
+  const header = useMemo(() => ({ title: t("multiRun.title") }), [t]);
+  const launch = useMultiRunStore((state) => state.launch);
+  const [prompt, setPrompt] = useState("");
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const [launching, setLaunching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const options = useMemo<ModelOption[]>(() => {
+    const result: ModelOption[] = [];
+    for (const entry of entries ?? []) {
+      if (!entry.enabled || !entry.models) {
+        continue;
+      }
+      for (const model of entry.models) {
+        result.push({ provider: entry.provider, model: model.id, label: model.label });
+      }
+    }
+    return result;
+  }, [entries]);
+
+  const handleToggle = useCallback((option: ModelOption) => {
+    const key = modelOptionKey(option.provider, option.model);
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectedModels = useMemo<MultiRunModelSelection[]>(
+    () =>
+      options
+        .filter((option) => selectedKeys.has(modelOptionKey(option.provider, option.model)))
+        .map((option) => ({ provider: option.provider, model: option.model })),
+    [options, selectedKeys],
+  );
+
+  const handleLaunch = useCallback(() => {
+    void (async () => {
+      setLaunching(true);
+      setError(null);
+      try {
+        await launch({ serverId, cwd, workspaceId, prompt, models: selectedModels });
+        setPrompt("");
+        setSelectedKeys(new Set());
+        onClose();
+      } catch (launchError) {
+        setError(launchError instanceof Error ? launchError.message : "Failed to launch");
+      } finally {
+        setLaunching(false);
+      }
+    })();
+  }, [launch, serverId, cwd, workspaceId, prompt, selectedModels, onClose]);
+
+  const canLaunch = prompt.trim().length > 0 && selectedModels.length > 0 && !launching;
+
+  return (
+    <AdaptiveModalSheet
+      header={header}
+      visible={visible}
+      onClose={onClose}
+      testID="multi-run-launcher"
+    >
+      <View style={styles.body}>
+        <Text style={styles.label}>Prompt</Text>
+        <ThemedTextInput
+          style={styles.promptInput}
+          value={prompt}
+          onChangeText={setPrompt}
+          placeholder="What should every model do?"
+          multiline
+          editable={!launching}
+        />
+        <Text style={styles.label}>{`Models (${selectedModels.length} selected)`}</Text>
+        <ModelMultiSelect options={options} selectedKeys={selectedKeys} onToggle={handleToggle} />
+        {error ? <Text style={styles.errorText}>{error}</Text> : null}
+        <View style={styles.actions}>
+          <Button
+            variant="default"
+            onPress={handleLaunch}
+            loading={launching}
+            disabled={!canLaunch}
+          >
+            {`Launch ${selectedModels.length || ""}`.trim()}
+          </Button>
+          <Button variant="ghost" onPress={onClose} disabled={launching}>
+            Cancel
+          </Button>
+        </View>
+      </View>
+    </AdaptiveModalSheet>
+  );
+}
+
+/**
+ * Self-contained multi-run entry point for the workspace draft tab: a trigger button plus the
+ * launcher modal. Renders nothing until a workspace directory and id are available.
+ */
+export function WorkspaceDraftMultiRun({
+  serverId,
+  cwd,
+  authority,
+}: {
+  serverId: string;
+  cwd: string | null;
+  authority: { workspaceId: string } | null;
+}) {
+  const [visible, setVisible] = useState(false);
+  const open = useCallback(() => setVisible(true), []);
+  const close = useCallback(() => setVisible(false), []);
+  const workspaceId = authority?.workspaceId ?? null;
+  if (!cwd || !workspaceId) {
+    return null;
+  }
+  return (
+    <View style={styles.draftEntryRow}>
+      <Button variant="outline" size="sm" onPress={open}>
+        Run across multiple models…
+      </Button>
+      <MultiRunLauncher
+        serverId={serverId}
+        cwd={cwd}
+        workspaceId={workspaceId}
+        visible={visible}
+        onClose={close}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  body: {
+    gap: theme.spacing[3],
+    padding: theme.spacing[2],
+  },
+  draftEntryRow: {
+    flexDirection: "row",
+    paddingHorizontal: theme.spacing[3],
+  },
+  label: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.medium,
+  },
+  promptInput: {
+    minHeight: 72,
+    backgroundColor: theme.colors.surface1,
+    borderRadius: theme.borderRadius.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    textAlignVertical: "top",
+  },
+  errorText: {
+    color: theme.colors.destructive,
+    fontSize: theme.fontSize.xs,
+  },
+  actions: {
+    flexDirection: "row",
+    gap: theme.spacing[2],
+    marginTop: theme.spacing[2],
+  },
+}));

--- a/packages/app/src/components/project-notes-panel.tsx
+++ b/packages/app/src/components/project-notes-panel.tsx
@@ -1,0 +1,247 @@
+// Ported concept from openchamber/openchamber (MIT): ProjectNotesTodoPanel.
+// Per-project scratchpad: free-form notes + a todo checklist. Backed by project-notes-store.
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { Check, Plus, Square, Trash2 } from "lucide-react-native";
+import type { Theme } from "@/styles/theme";
+import {
+  buildProjectNotesKey,
+  useProjectNotesStore,
+  type ProjectTodo,
+} from "@/stores/project-notes-store";
+import { useI18n } from "@/lib/i18n";
+
+const ThemedTextInput = withUnistyles(TextInput, (theme) => ({
+  placeholderTextColor: theme.colors.foregroundMuted,
+}));
+const ThemedCheck = withUnistyles(Check);
+const ThemedSquare = withUnistyles(Square);
+const ThemedTrash = withUnistyles(Trash2);
+const ThemedPlus = withUnistyles(Plus);
+
+const mutedColor = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+const accentColor = (theme: Theme) => ({ color: theme.colors.accent });
+
+interface ProjectNotesPanelProps {
+  serverId: string;
+  cwd: string;
+  active?: boolean;
+}
+
+function TodoRow({
+  todo,
+  onToggle,
+  onRemove,
+}: {
+  todo: ProjectTodo;
+  onToggle: (id: string) => void;
+  onRemove: (id: string) => void;
+}) {
+  const handleToggle = useCallback(() => onToggle(todo.id), [onToggle, todo.id]);
+  const handleRemove = useCallback(() => onRemove(todo.id), [onRemove, todo.id]);
+  const checkedState = useMemo(() => ({ checked: todo.done }), [todo.done]);
+  return (
+    <View style={styles.todoRow}>
+      <Pressable
+        onPress={handleToggle}
+        hitSlop={8}
+        style={styles.todoCheck}
+        accessibilityRole="checkbox"
+        accessibilityState={checkedState}
+        testID={`project-todo-toggle-${todo.id}`}
+      >
+        {todo.done ? (
+          <ThemedCheck size={16} uniProps={accentColor} />
+        ) : (
+          <ThemedSquare size={16} uniProps={mutedColor} />
+        )}
+      </Pressable>
+      <Text style={todo.done ? styles.todoTextDone : styles.todoText}>{todo.text}</Text>
+      <Pressable
+        onPress={handleRemove}
+        hitSlop={8}
+        style={styles.todoDelete}
+        accessibilityLabel="Delete todo"
+        testID={`project-todo-delete-${todo.id}`}
+      >
+        <ThemedTrash size={14} uniProps={mutedColor} />
+      </Pressable>
+    </View>
+  );
+}
+
+export function ProjectNotesPanel({ serverId, cwd, active = true }: ProjectNotesPanelProps) {
+  const { t } = useI18n();
+  const key = buildProjectNotesKey(serverId, cwd);
+  const selectData = useCallback(
+    (state: { byKey: Record<string, { notes: string; todos: ProjectTodo[] }> }) => state.byKey[key],
+    [key],
+  );
+  const data = useProjectNotesStore(selectData);
+  const setNotes = useProjectNotesStore((state) => state.setNotes);
+  const addTodo = useProjectNotesStore((state) => state.addTodo);
+  const toggleTodo = useProjectNotesStore((state) => state.toggleTodo);
+  const removeTodo = useProjectNotesStore((state) => state.removeTodo);
+
+  const notes = data?.notes ?? "";
+  const todos = data?.todos ?? EMPTY_TODOS;
+
+  const [notesDraft, setNotesDraft] = useState(notes);
+  const [todoDraft, setTodoDraft] = useState("");
+
+  useEffect(() => {
+    setNotesDraft(notes);
+  }, [notes]);
+
+  const handleNotesBlur = useCallback(() => {
+    if (notesDraft !== notes) {
+      setNotes(key, notesDraft);
+    }
+  }, [notesDraft, notes, setNotes, key]);
+
+  const handleAddTodo = useCallback(() => {
+    const trimmed = todoDraft.trim();
+    if (!trimmed) {
+      return;
+    }
+    addTodo(key, trimmed);
+    setTodoDraft("");
+  }, [addTodo, key, todoDraft]);
+
+  const handleToggle = useCallback((id: string) => toggleTodo(key, id), [toggleTodo, key]);
+  const handleRemove = useCallback((id: string) => removeTodo(key, id), [removeTodo, key]);
+
+  if (!active) {
+    return null;
+  }
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.sectionLabel}>{t("projectNotes.notes")}</Text>
+      <ThemedTextInput
+        style={styles.notesInput}
+        value={notesDraft}
+        onChangeText={setNotesDraft}
+        onBlur={handleNotesBlur}
+        placeholder={t("projectNotes.notesPlaceholder")}
+        multiline
+        textAlignVertical="top"
+      />
+
+      <Text style={styles.sectionLabel}>{t("projectNotes.todos")}</Text>
+      <View style={styles.addRow}>
+        <ThemedTextInput
+          style={styles.todoInput}
+          value={todoDraft}
+          onChangeText={setTodoDraft}
+          onSubmitEditing={handleAddTodo}
+          placeholder={t("projectNotes.todoPlaceholder")}
+          returnKeyType="done"
+        />
+        <Pressable
+          onPress={handleAddTodo}
+          style={styles.addButton}
+          accessibilityLabel="Add todo"
+          testID="project-todo-add"
+        >
+          <ThemedPlus size={16} uniProps={mutedColor} />
+        </Pressable>
+      </View>
+
+      {todos.length === 0 ? (
+        <Text style={styles.emptyText}>{t("projectNotes.empty")}</Text>
+      ) : (
+        todos.map((todo) => (
+          <TodoRow key={todo.id} todo={todo} onToggle={handleToggle} onRemove={handleRemove} />
+        ))
+      )}
+    </ScrollView>
+  );
+}
+
+const EMPTY_TODOS: ProjectTodo[] = [];
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.surface0,
+  },
+  content: {
+    padding: theme.spacing[3],
+    gap: theme.spacing[2],
+  },
+  sectionLabel: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.semibold,
+    marginTop: theme.spacing[2],
+  },
+  notesInput: {
+    minHeight: 120,
+    backgroundColor: theme.colors.surface1,
+    borderRadius: theme.borderRadius.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    padding: theme.spacing[3],
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  addRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  todoInput: {
+    flex: 1,
+    backgroundColor: theme.colors.surface1,
+    borderRadius: theme.borderRadius.base,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  addButton: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: theme.borderRadius.base,
+    backgroundColor: theme.colors.surface2,
+  },
+  todoRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    paddingVertical: theme.spacing[1],
+  },
+  todoCheck: {
+    width: 24,
+    height: 24,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  todoText: {
+    flex: 1,
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  todoTextDone: {
+    flex: 1,
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    textDecorationLine: "line-through",
+  },
+  todoDelete: {
+    width: 24,
+    height: 24,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  emptyText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+}));

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -18,6 +18,7 @@ import type { CreateAgentInitialValues } from "@/hooks/use-agent-form-state";
 import { useDraftAgentCreateFlow, type DraftCreateAttempt } from "@/composer/draft/create-flow";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { buildWorkspaceDraftAgentConfig } from "@/screens/workspace/workspace-draft-agent-config";
+import { WorkspaceDraftMultiRun } from "@/components/multi-run-launcher";
 import { buildDraftStoreKey } from "@/stores/draft-keys";
 import { usePanelStore } from "@/stores/panel-store";
 import { useCreateFlowStore } from "@/stores/create-flow-store";
@@ -327,6 +328,7 @@ export function WorkspaceDraftAgentTab({
     id: w.id,
   }));
   const workspaceDirectory = workspaceFields?.workspaceDirectory || null;
+  const draftMultiRunAuthority = useMemo(() => ({ workspaceId }), [workspaceId]);
   const draftSetup = initialSetup ?? null;
   const draftWorkingDirectory = resolveDraftWorkingDirectory({
     workspaceDirectory,
@@ -687,6 +689,11 @@ export function WorkspaceDraftAgentTab({
                   <Text style={styles.errorText}>{formErrorMessage}</Text>
                 </View>
               ) : null}
+              <WorkspaceDraftMultiRun
+                serverId={serverId}
+                cwd={workspaceDirectory}
+                authority={draftMultiRunAuthority}
+              />
             </View>
           </ScrollView>
         )}

--- a/packages/app/src/git/actions-store.ts
+++ b/packages/app/src/git/actions-store.ts
@@ -228,7 +228,7 @@ interface CheckoutGitActionsStoreState {
     actionId: CheckoutGitAsyncActionId;
   }) => CheckoutGitActionStatus;
 
-  commit: (params: { serverId: string; cwd: string }) => Promise<void>;
+  commit: (params: { serverId: string; cwd: string; gitmoji?: boolean }) => Promise<void>;
   pull: (params: { serverId: string; cwd: string }) => Promise<void>;
   push: (params: { serverId: string; cwd: string }) => Promise<void>;
   pullAndPush: (params: { serverId: string; cwd: string }) => Promise<void>;
@@ -313,14 +313,14 @@ export const useCheckoutGitActionsStore = create<CheckoutGitActionsStoreState>()
     return get().statusByCheckout[key]?.[actionId] ?? "idle";
   },
 
-  commit: async ({ serverId, cwd }) => {
+  commit: async ({ serverId, cwd, gitmoji }) => {
     await runCheckoutAction({
       serverId,
       cwd,
       actionId: "commit",
       run: async () => {
         const client = resolveClient(serverId);
-        const payload = await client.checkoutCommit(cwd, { addAll: true });
+        const payload = await client.checkoutCommit(cwd, { addAll: true, gitmoji });
         if (payload.error) {
           throw new Error(payload.error.message);
         }

--- a/packages/app/src/git/use-actions.tsx
+++ b/packages/app/src/git/use-actions.tsx
@@ -3,6 +3,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useTranslation } from "react-i18next";
 import { type CheckoutGitActionStatus, useCheckoutGitActionsStore } from "@/git/actions-store";
 import { type CheckoutStatusPayload, useCheckoutStatusQuery } from "@/git/use-status-query";
+import { useAppSettings } from "@/hooks/use-settings";
 import { type CheckoutPrStatusPayload, useCheckoutPrStatusQuery } from "@/git/use-pr-status-query";
 import {
   buildGitActions,
@@ -221,6 +222,8 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
   const { t } = useTranslation();
   const toast = useToast();
   const activeWorkspaceSelection = useActiveWorkspaceSelection();
+  const { settings: appSettings } = useAppSettings();
+  const commitGitmoji = appSettings.commitGitmoji;
   const [postShipArchiveSuggested, setPostShipArchiveSuggested] = useState(false);
   const [shipDefault, setShipDefault] = useState<"merge" | "pr">("pr");
 
@@ -377,7 +380,7 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
 
   // Handlers
   const handleCommit = useCallback(() => {
-    void runCommit({ serverId, cwd })
+    void runCommit({ serverId, cwd, gitmoji: commitGitmoji })
       .then(() => {
         toastActionSuccess(t("workspace.git.actions.commit.success"));
         return;
@@ -385,7 +388,7 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
       .catch((err) => {
         toastActionError(err, t("workspace.git.actions.toasts.failedCommit"));
       });
-  }, [cwd, runCommit, serverId, t, toastActionError, toastActionSuccess]);
+  }, [commitGitmoji, cwd, runCommit, serverId, t, toastActionError, toastActionSuccess]);
 
   const handlePull = useCallback(() => {
     void runPull({ serverId, cwd })

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -25,6 +25,17 @@ import {
   findActiveFileMention,
   type FileMentionRange,
 } from "@/utils/file-mention-autocomplete";
+import {
+  applySnippetReplacement,
+  findActiveSnippetMention,
+  type SnippetMentionRange,
+} from "@/utils/snippet-mention-autocomplete";
+import {
+  EMPTY_SNIPPETS,
+  GLOBAL_SNIPPET_SCOPE,
+  useSnippetsStore,
+  type Snippet,
+} from "@/stores/snippets-store";
 
 interface UseAgentAutocompleteInput {
   userInput: string;
@@ -45,6 +56,11 @@ type AgentAutocompleteOption =
       type: "workspace_entry";
       entryPath: string;
       mention: FileMentionRange;
+    })
+  | (AutocompleteOption & {
+      type: "snippet";
+      body: string;
+      mention: SnippetMentionRange;
     });
 
 interface AgentAutocompleteResult {
@@ -140,7 +156,26 @@ function mapCommandToOption(entry: AvailableCommand, t: TFunction): AgentAutocom
   };
 }
 
-type AutocompleteMode = "command" | "file" | null;
+function buildSnippetAutocompleteOptions(
+  snippets: Snippet[],
+  query: string,
+  mention: SnippetMentionRange,
+): AgentAutocompleteOption[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  const matches = normalizedQuery
+    ? snippets.filter((snippet) => snippet.name.toLowerCase().includes(normalizedQuery))
+    : snippets;
+  return matches.map((snippet) => ({
+    type: "snippet" as const,
+    id: snippet.id,
+    label: snippet.name,
+    description: snippet.body,
+    body: snippet.body,
+    mention,
+  }));
+}
+
+type AutocompleteMode = "command" | "file" | "snippet" | null;
 
 interface BuildAutocompleteOptionsInput {
   isVisible: boolean;
@@ -201,9 +236,13 @@ function buildCommandAutocompleteOptions(input: BuildAutocompleteOptionsInput) {
 }
 
 function resolveAutocompleteMode(args: {
+  showSnippetAutocomplete: boolean;
   showFileAutocomplete: boolean;
   showCommandAutocomplete: boolean;
 }): AutocompleteMode {
+  if (args.showSnippetAutocomplete) {
+    return "snippet";
+  }
   if (args.showFileAutocomplete) {
     return "file";
   }
@@ -219,6 +258,9 @@ function resolveAutocompleteIsVisible(args: {
   serverId: string;
   autocompleteCwd: string;
 }): boolean {
+  if (args.mode === "snippet") {
+    return true;
+  }
   if (args.mode === "command") {
     return args.canLoadCommands;
   }
@@ -277,6 +319,31 @@ function resolveAutocompleteErrorMessage(args: {
   return undefined;
 }
 
+function resolveAutocompleteFilterQuery(args: {
+  mode: AutocompleteMode;
+  commandFilterQuery: string;
+  snippetFilterQuery: string;
+  fileFilterQuery: string;
+}): string {
+  if (args.mode === "command") {
+    return args.commandFilterQuery;
+  }
+  if (args.mode === "snippet") {
+    return args.snippetFilterQuery;
+  }
+  return args.fileFilterQuery;
+}
+
+function resolveAutocompleteEmptyText(args: { mode: AutocompleteMode; t: TFunction }): string {
+  if (args.mode === "snippet") {
+    return "No snippets";
+  }
+  if (args.mode === "file") {
+    return args.t("agentAutocomplete.noFiles");
+  }
+  return args.t("agentAutocomplete.noCommands");
+}
+
 export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAutocompleteResult {
   const { t } = useTranslation();
   const {
@@ -312,6 +379,16 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
   );
   const showFileAutocomplete = activeFileMention !== null;
   const fileFilterQuery = activeFileMention?.query ?? "";
+
+  const activeSnippetMention = useMemo(
+    () => findActiveSnippetMention({ text: userInput, cursorIndex }),
+    [cursorIndex, userInput],
+  );
+  const snippets = useSnippetsStore(
+    (state) => state.byScope[GLOBAL_SNIPPET_SCOPE] ?? EMPTY_SNIPPETS,
+  );
+  const showSnippetAutocomplete = activeSnippetMention !== null && snippets.length > 0;
+  const snippetFilterQuery = activeSnippetMention?.query ?? "";
   const [debouncedFileFilterQuery, setDebouncedFileFilterQuery] = useState(fileFilterQuery);
 
   useEffect(() => {
@@ -341,7 +418,11 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
   const client = useHostRuntimeClient(serverId);
   const isConnected = useHostRuntimeIsConnected(serverId);
 
-  const mode = resolveAutocompleteMode({ showFileAutocomplete, showCommandAutocomplete });
+  const mode = resolveAutocompleteMode({
+    showSnippetAutocomplete,
+    showFileAutocomplete,
+    showCommandAutocomplete,
+  });
   const canShowAutocomplete = resolveAutocompleteIsVisible({
     mode,
     canLoadCommands,
@@ -399,31 +480,35 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     placeholderData: keepPreviousData,
   });
 
-  const options = useMemo<AgentAutocompleteOption[]>(
-    () =>
-      buildCommandAutocompleteOptions({
-        activeFileMention,
-        commandFilterQuery,
-        commands,
-        activeSlashCommand,
-        fileSuggestions: fileSuggestionsQuery.data ?? [],
-        isDraftContext,
-        isVisible,
-        mode,
-        t,
-      }),
-    [
+  const options = useMemo<AgentAutocompleteOption[]>(() => {
+    if (mode === "snippet" && activeSnippetMention) {
+      return buildSnippetAutocompleteOptions(snippets, snippetFilterQuery, activeSnippetMention);
+    }
+    return buildCommandAutocompleteOptions({
       activeFileMention,
-      activeSlashCommand,
       commandFilterQuery,
       commands,
-      fileSuggestionsQuery.data,
+      activeSlashCommand,
+      fileSuggestions: fileSuggestionsQuery.data ?? [],
       isDraftContext,
       isVisible,
       mode,
       t,
-    ],
-  );
+    });
+  }, [
+    activeFileMention,
+    activeSlashCommand,
+    activeSnippetMention,
+    commandFilterQuery,
+    commands,
+    fileSuggestionsQuery.data,
+    isDraftContext,
+    isVisible,
+    mode,
+    snippetFilterQuery,
+    snippets,
+    t,
+  ]);
 
   const onSelectOption = useCallback(
     (option: AutocompleteOption) => {
@@ -455,6 +540,17 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
         return;
       }
 
+      if (selected.type === "snippet") {
+        const snippetInput = applySnippetReplacement({
+          text: userInput,
+          mention: selected.mention,
+          body: selected.body,
+        });
+        setUserInput(snippetInput);
+        onAutocompleteApplied?.();
+        return;
+      }
+
       const nextInput = applyFileMentionReplacement({
         text: userInput,
         mention: selected.mention,
@@ -476,7 +572,12 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
   const { selectedIndex, onKeyPress } = useAutocomplete({
     isVisible,
     options,
-    query: mode === "command" ? commandFilterQuery : fileFilterQuery,
+    query: resolveAutocompleteFilterQuery({
+      mode,
+      commandFilterQuery,
+      snippetFilterQuery,
+      fileFilterQuery,
+    }),
     onSelectOption,
     onEscape:
       mode === "command" && activeSlashCommand?.position === "start"
@@ -503,8 +604,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     mode === "file"
       ? t("agentAutocomplete.searchingWorkspace")
       : t("agentAutocomplete.loadingCommands");
-  const emptyText =
-    mode === "file" ? t("agentAutocomplete.noFiles") : t("agentAutocomplete.noCommands");
+  const emptyText = resolveAutocompleteEmptyText({ mode, t });
 
   return {
     isVisible,

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -39,6 +39,7 @@ export interface AppSettings {
   codeFontSize: number; // clamped px, default 12
   syntaxTheme: SyntaxThemeId; // default "one"
   workspaceTitleSource: WorkspaceTitleSource;
+  commitGitmoji: boolean; // prefix generated commit messages with a gitmoji
 }
 
 export interface Settings extends AppSettings {
@@ -58,6 +59,7 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   codeFontSize: DEFAULT_CODE_FONT_SIZE,
   syntaxTheme: "one",
   workspaceTitleSource: "title",
+  commitGitmoji: false,
 };
 
 export const DEFAULT_APP_SETTINGS: Settings = {
@@ -203,6 +205,9 @@ function pickAppSettings(stored: Partial<AppSettings>): Partial<AppSettings> {
     VALID_WORKSPACE_TITLE_SOURCES.has(stored.workspaceTitleSource)
   ) {
     result.workspaceTitleSource = stored.workspaceTitleSource;
+  }
+  if (typeof stored.commitGitmoji === "boolean") {
+    result.commitGitmoji = stored.commitGitmoji;
   }
   return result;
 }

--- a/packages/app/src/hooks/use-skills.ts
+++ b/packages/app/src/hooks/use-skills.ts
@@ -1,0 +1,93 @@
+import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
+import type { InstalledSkill } from "@getpaseo/protocol/skills-catalog/types";
+import type { ScannedSkill, SkillsCatalogError } from "@getpaseo/protocol/skills-catalog/types";
+import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+
+export type { InstalledSkill, ScannedSkill, SkillsCatalogError };
+
+export interface SkillsScanOutcome {
+  skills: ScannedSkill[];
+  error: SkillsCatalogError | null;
+}
+
+export interface SkillsInstallOutcome {
+  installed: string[];
+  skipped: { skillName: string; reason: string }[];
+  error: SkillsCatalogError | null;
+}
+
+export function skillsQueryKey(serverId: string | null): (string | null)[] {
+  return ["skills", serverId];
+}
+
+interface UseSkillsResult {
+  installed: InstalledSkill[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+  scan: (source: string, subpath?: string) => Promise<SkillsScanOutcome>;
+  install: (input: {
+    source: string;
+    subpath?: string;
+    skillDirs: string[];
+    overwrite?: boolean;
+  }) => Promise<SkillsInstallOutcome>;
+}
+
+export function useSkills(serverId: string | null): UseSkillsResult {
+  const client = useHostRuntimeClient(serverId ?? "");
+  const isConnected = useHostRuntimeIsConnected(serverId ?? "");
+
+  const query = useQuery<InstalledSkill[]>({
+    queryKey: skillsQueryKey(serverId),
+    enabled: Boolean(serverId) && isConnected && Boolean(client),
+    staleTime: 15_000,
+    queryFn: async () => {
+      if (!client) {
+        return [];
+      }
+      const payload = await client.skillsList();
+      if (payload.error) {
+        throw new Error(payload.error);
+      }
+      return payload.skills;
+    },
+  });
+
+  const scan = useCallback<UseSkillsResult["scan"]>(
+    async (source, subpath) => {
+      if (!client) {
+        return { skills: [], error: { kind: "unknown", message: "Not connected" } };
+      }
+      const payload = await client.skillsScan({ source, subpath });
+      return { skills: payload.skills, error: payload.error };
+    },
+    [client],
+  );
+
+  const install = useCallback<UseSkillsResult["install"]>(
+    async (input) => {
+      if (!client) {
+        return { installed: [], skipped: [], error: { kind: "unknown", message: "Not connected" } };
+      }
+      const payload = await client.skillsInstall(input);
+      if (!payload.error) {
+        void query.refetch();
+      }
+      return { installed: payload.installed, skipped: payload.skipped, error: payload.error };
+    },
+    [client, query],
+  );
+
+  return {
+    installed: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error instanceof Error ? query.error.message : null,
+    refetch: () => {
+      void query.refetch();
+    },
+    scan,
+    install,
+  };
+}

--- a/packages/app/src/lib/i18n/en.ts
+++ b/packages/app/src/lib/i18n/en.ts
@@ -1,0 +1,36 @@
+// Ported concept from openchamber/openchamber (MIT): lib/i18n message catalogs.
+// English is the source-of-truth catalog; keys are dot-namespaced by surface. Templates use
+// {name}-style placeholders interpolated at render time.
+export const en = {
+  // Project notes / todos panel
+  "projectNotes.notes": "Notes",
+  "projectNotes.todos": "Todos",
+  "projectNotes.notesPlaceholder": "Project notes, reminders, links…",
+  "projectNotes.todoPlaceholder": "Add a todo…",
+  "projectNotes.empty": "No todos yet.",
+
+  // Skills catalog section
+  "skills.title": "Skills",
+  "skills.loading": "Loading skills…",
+  "skills.none": "No skills installed.",
+  "skills.installFrom": "Install from GitHub",
+  "skills.scan": "Scan",
+  "skills.sourcePlaceholder": "owner/repo or owner/repo/subpath",
+
+  // Git identity section
+  "gitIdentity.title": "Git identity",
+  "gitIdentity.current": "Current",
+  "gitIdentity.add": "Add identity",
+  "gitIdentity.apply": "Apply",
+  "gitIdentity.remove": "Remove",
+  "gitIdentity.applied": 'Applied "{label}" to this repository.',
+
+  // Multi-run launcher
+  "multiRun.title": "Multi-run",
+  "multiRun.prompt": "Prompt",
+  "multiRun.promptPlaceholder": "What should every model do?",
+  "multiRun.modelsSelected": "Models ({count} selected)",
+  "multiRun.cancel": "Cancel",
+} as const;
+
+export type MessageKey = keyof typeof en;

--- a/packages/app/src/lib/i18n/en.ts
+++ b/packages/app/src/lib/i18n/en.ts
@@ -31,6 +31,16 @@ export const en = {
   "multiRun.promptPlaceholder": "What should every model do?",
   "multiRun.modelsSelected": "Models ({count} selected)",
   "multiRun.cancel": "Cancel",
+
+  // Snippets settings + composer (# autocomplete)
+  "snippets.title": "Snippets",
+  "snippets.hint": "Reusable text inserted in the composer by typing # then the snippet name.",
+  "snippets.empty": "No snippets yet.",
+  "snippets.namePlaceholder": "Name (e.g. review)",
+  "snippets.bodyPlaceholder": "Snippet text…",
+  "snippets.add": "Add snippet",
+  "snippets.save": "Save",
+  "snippets.cancel": "Cancel",
 } as const;
 
 export type MessageKey = keyof typeof en;

--- a/packages/app/src/lib/i18n/i18n.test.ts
+++ b/packages/app/src/lib/i18n/i18n.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: { getItem: vi.fn(async () => null), setItem: vi.fn(), removeItem: vi.fn() },
+}));
+
+import { translate, useI18nStore } from "@/lib/i18n";
+
+describe("i18n", () => {
+  beforeEach(() => {
+    useI18nStore.setState({ locale: "en" });
+  });
+
+  it("resolves a known key", () => {
+    expect(translate("en", "skills.title")).toBe("Skills");
+  });
+
+  it("interpolates placeholders", () => {
+    expect(translate("en", "multiRun.modelsSelected", { count: 3 })).toBe("Models (3 selected)");
+    expect(translate("en", "gitIdentity.applied", { label: "Work" })).toBe(
+      'Applied "Work" to this repository.',
+    );
+  });
+
+  it("leaves missing placeholders empty when params are provided", () => {
+    expect(translate("en", "multiRun.modelsSelected", {})).toBe("Models ( selected)");
+  });
+
+  it("returns the template verbatim when no params are passed", () => {
+    expect(translate("en", "multiRun.modelsSelected")).toBe("Models ({count} selected)");
+  });
+
+  it("exposes a settable locale", () => {
+    useI18nStore.getState().setLocale("en");
+    expect(useI18nStore.getState().locale).toBe("en");
+  });
+
+  it("falls back to en on unsupported persisted locale", () => {
+    const options = useI18nStore.persist.getOptions();
+    const restored = options.merge?.({ locale: "zz" }, useI18nStore.getState());
+    expect(restored?.locale).toBe("en");
+  });
+});

--- a/packages/app/src/lib/i18n/index.ts
+++ b/packages/app/src/lib/i18n/index.ts
@@ -1,0 +1,81 @@
+// Ported concept from openchamber/openchamber (MIT): lib/i18n runtime.
+// Minimal, typed i18n: a locale store (AsyncStorage-persisted) + a translate() with {placeholder}
+// interpolation, exposed through the useI18n() hook. English is the fallback catalog.
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useCallback } from "react";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { en, type MessageKey } from "./en";
+
+export type { MessageKey };
+
+export type Locale = "en";
+
+export const SUPPORTED_LOCALES: Locale[] = ["en"];
+
+const CATALOGS: Record<Locale, Partial<Record<MessageKey, string>>> = {
+  en,
+};
+
+export type TranslateParams = Record<string, string | number>;
+
+function interpolate(template: string, params?: TranslateParams): string {
+  if (!params) {
+    return template;
+  }
+  return template.replace(/\{\s*([a-zA-Z0-9_]+)\s*\}/g, (_match, key: string) => {
+    const value = params[key];
+    return value === undefined ? "" : String(value);
+  });
+}
+
+/** Resolves a message for a locale, falling back to English then the raw key. */
+export function translate(locale: Locale, key: MessageKey, params?: TranslateParams): string {
+  const template = CATALOGS[locale]?.[key] ?? en[key] ?? key;
+  return interpolate(template, params);
+}
+
+interface I18nState {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+}
+
+function isLocale(value: unknown): value is Locale {
+  return typeof value === "string" && (SUPPORTED_LOCALES as string[]).includes(value);
+}
+
+export const useI18nStore = create<I18nState>()(
+  persist(
+    (set) => ({
+      locale: "en",
+      setLocale: (locale) => set({ locale }),
+    }),
+    {
+      name: "i18n",
+      storage: createJSONStorage(() => AsyncStorage),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as { locale?: unknown } | undefined;
+        return {
+          ...currentState,
+          locale: isLocale(persisted?.locale) ? persisted.locale : "en",
+        };
+      },
+    },
+  ),
+);
+
+export interface UseI18nResult {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: MessageKey, params?: TranslateParams) => string;
+}
+
+export function useI18n(): UseI18nResult {
+  const locale = useI18nStore((state) => state.locale);
+  const setLocale = useI18nStore((state) => state.setLocale);
+  const t = useCallback(
+    (key: MessageKey, params?: TranslateParams) => translate(locale, key, params),
+    [locale],
+  );
+  return { locale, setLocale, t };
+}

--- a/packages/app/src/screens/project-settings-screen.tsx
+++ b/packages/app/src/screens/project-settings-screen.tsx
@@ -29,6 +29,8 @@ import { AdaptiveModalSheet, type SheetHeader } from "@/components/adaptive-moda
 import { SettingsTextAreaCard } from "@/components/settings-textarea";
 import { SettingsGroup } from "@/screens/settings/settings-group";
 import { SettingsSection } from "@/screens/settings/settings-section";
+import { GitIdentitySection } from "@/screens/settings/git-identity-section";
+import { useSessionStore } from "@/stores/session-store";
 import { settingsStyles } from "@/styles/settings";
 import { useProjects } from "@/hooks/use-projects";
 import { useProjectIconDataByProjectKey } from "@/projects/project-icons";
@@ -229,6 +231,9 @@ function ProjectSettingsBody({
   }, [readQuery]);
 
   const hasMultipleHosts = hosts.length > 1;
+  const gitIdentityEnabled = useSessionStore(
+    (s) => s.sessions[selectedHost.serverId]?.serverInfo?.features?.gitIdentity === true,
+  );
 
   return (
     <View style={styles.body}>
@@ -245,6 +250,10 @@ function ProjectSettingsBody({
         </View>
         <HostContext hosts={hosts} selectedHost={selectedHost} onSelectHost={onSelectHost} />
       </View>
+
+      {gitIdentityEnabled ? (
+        <GitIdentitySection client={client} cwd={selectedHost.repoRoot} />
+      ) : null}
 
       {renderContent({
         readQuery,

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -69,6 +69,7 @@ import { KeyboardShortcutsSection } from "@/screens/settings/keyboard-shortcuts-
 import { Button } from "@/components/ui/button";
 import { CommunityLinks } from "@/components/community-links";
 import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Switch } from "@/components/ui/switch";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { DesktopPermissionsSection } from "@/desktop/components/desktop-permissions-section";
 import { IntegrationsSection } from "@/desktop/components/integrations-section";
@@ -244,6 +245,7 @@ interface GeneralSectionProps {
   handleServiceUrlBehaviorChange: (behavior: ServiceUrlBehavior) => void;
   handleLanguageChange: (language: AppLanguage) => void;
   handleTerminalScrollbackLinesChange: (lines: number) => void;
+  handleCommitGitmojiChange: (enabled: boolean) => void;
 }
 
 interface ServiceUrlBehaviorMenuItemProps {
@@ -300,6 +302,7 @@ function GeneralSection({
   handleServiceUrlBehaviorChange,
   handleLanguageChange,
   handleTerminalScrollbackLinesChange,
+  handleCommitGitmojiChange,
 }: GeneralSectionProps) {
   const { t, i18n } = useTranslation();
   const activeLocale = getActiveLocale(i18n.language);
@@ -357,6 +360,15 @@ function GeneralSection({
             onValueChange={handleSendBehaviorChange}
             options={sendBehaviorOptions}
           />
+        </View>
+        <View style={ROW_WITH_BORDER_STYLE}>
+          <View style={settingsStyles.rowContent}>
+            <Text style={settingsStyles.rowTitle}>Gitmoji commits</Text>
+            <Text style={settingsStyles.rowHint}>
+              Prefix generated commit messages with a gitmoji for their type
+            </Text>
+          </View>
+          <Switch value={settings.commitGitmoji} onValueChange={handleCommitGitmojiChange} />
         </View>
         <View style={ROW_WITH_BORDER_STYLE}>
           <View style={settingsStyles.rowContent}>
@@ -1159,6 +1171,13 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     [updateSettings],
   );
 
+  const handleCommitGitmojiChange = useCallback(
+    (enabled: boolean) => {
+      void updateSettings({ commitGitmoji: enabled });
+    },
+    [updateSettings],
+  );
+
   const handleServiceUrlBehaviorChange = useCallback(
     (behavior: ServiceUrlBehavior) => {
       void updateSettings({ serviceUrlBehavior: behavior });
@@ -1385,6 +1404,7 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
               handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
               handleLanguageChange={handleLanguageChange}
               handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
+              handleCommitGitmojiChange={handleCommitGitmojiChange}
             />
           );
         case "daemon":

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -44,6 +44,7 @@ import { HostStatusDot } from "@/components/host-status-dot";
 import { ScreenTitle } from "@/components/headers/screen-title";
 import { HeaderIconBadge } from "@/components/headers/header-icon-badge";
 import { SettingsSection } from "@/screens/settings/settings-section";
+import { SnippetsSection } from "@/screens/settings/snippets-section";
 import { AppearanceSection } from "@/screens/settings/appearance/appearance-section";
 import {
   useAppSettings,
@@ -1397,15 +1398,18 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
       switch (view.section) {
         case "general":
           return (
-            <GeneralSection
-              settings={settings}
-              isDesktopApp={isDesktopApp}
-              handleSendBehaviorChange={handleSendBehaviorChange}
-              handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
-              handleLanguageChange={handleLanguageChange}
-              handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
-              handleCommitGitmojiChange={handleCommitGitmojiChange}
-            />
+            <>
+              <GeneralSection
+                settings={settings}
+                isDesktopApp={isDesktopApp}
+                handleSendBehaviorChange={handleSendBehaviorChange}
+                handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
+                handleLanguageChange={handleLanguageChange}
+                handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
+                handleCommitGitmojiChange={handleCommitGitmojiChange}
+              />
+              <SnippetsSection />
+            </>
           );
         case "daemon":
           return <LocalDaemonSection />;

--- a/packages/app/src/screens/settings/git-identity-section.tsx
+++ b/packages/app/src/screens/settings/git-identity-section.tsx
@@ -1,0 +1,277 @@
+// Ported concept from openchamber/openchamber (MIT): GitPage + GitIdentityEditorDialog.
+// Lists named git identity profiles and applies one to a repository (writes repo-local
+// user.name/user.email via the daemon git-identity RPC).
+import { useCallback, useEffect, useState } from "react";
+import { Text, TextInput, View } from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import type { RepoGitIdentity } from "@getpaseo/protocol/git-identity/types";
+import { Button } from "@/components/ui/button";
+import { SettingsSection } from "@/screens/settings/settings-section";
+import { settingsStyles } from "@/styles/settings";
+import { useI18n } from "@/lib/i18n";
+import { useGitIdentitiesStore, type GitIdentityProfile } from "@/stores/git-identities-store";
+
+const ThemedTextInput = withUnistyles(TextInput, (theme) => ({
+  placeholderTextColor: theme.colors.foregroundMuted,
+}));
+
+interface GitIdentitySectionProps {
+  client: DaemonClient;
+  cwd: string;
+}
+
+function formatCurrentIdentity(current: RepoGitIdentity | null): string {
+  if (!current) {
+    return "…";
+  }
+  if (!current.name && !current.email) {
+    return "Not configured";
+  }
+  const name = current.name ?? "(no name)";
+  const email = current.email ?? "(no email)";
+  const suffix = current.local ? "" : " (inherited)";
+  return `${name} <${email}>${suffix}`;
+}
+
+function ProfileRow({
+  profile,
+  applying,
+  onApply,
+  onRemove,
+}: {
+  profile: GitIdentityProfile;
+  applying: boolean;
+  onApply: (profile: GitIdentityProfile) => void;
+  onRemove: (id: string) => void;
+}) {
+  const handleApply = useCallback(() => onApply(profile), [onApply, profile]);
+  const handleRemove = useCallback(() => onRemove(profile.id), [onRemove, profile.id]);
+  return (
+    <View style={styles.profileRow}>
+      <View style={styles.profileText}>
+        <Text style={styles.profileLabel}>{profile.label}</Text>
+        <Text style={styles.profileMeta} numberOfLines={1}>
+          {profile.name} {"<"}
+          {profile.email}
+          {">"}
+        </Text>
+      </View>
+      <View style={styles.profileActions}>
+        <Button
+          variant="secondary"
+          size="sm"
+          onPress={handleApply}
+          loading={applying}
+          disabled={applying}
+        >
+          Apply
+        </Button>
+        <Button variant="ghost" size="sm" onPress={handleRemove} disabled={applying}>
+          Remove
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+export function GitIdentitySection({ client, cwd }: GitIdentitySectionProps) {
+  const { t } = useI18n();
+  const profiles = useGitIdentitiesStore((state) => state.profiles);
+  const addProfile = useGitIdentitiesStore((state) => state.addProfile);
+  const removeProfile = useGitIdentitiesStore((state) => state.removeProfile);
+
+  const [current, setCurrent] = useState<RepoGitIdentity | null>(null);
+  const [applyingId, setApplyingId] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [label, setLabel] = useState("");
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+
+  const refresh = useCallback(async () => {
+    try {
+      const payload = await client.gitIdentityGet(cwd);
+      setCurrent(payload.identity);
+    } catch {
+      setCurrent(null);
+    }
+  }, [client, cwd]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleApply = useCallback(
+    (profile: GitIdentityProfile) => {
+      void (async () => {
+        setApplyingId(profile.id);
+        setStatus(null);
+        try {
+          const payload = await client.gitIdentitySet({
+            cwd,
+            name: profile.name,
+            email: profile.email,
+          });
+          if (payload.error) {
+            setStatus(payload.error);
+          } else {
+            setCurrent(payload.identity);
+            setStatus(`Applied "${profile.label}" to this repository.`);
+          }
+        } catch (error) {
+          setStatus(error instanceof Error ? error.message : "Failed to apply identity");
+        } finally {
+          setApplyingId(null);
+        }
+      })();
+    },
+    [client, cwd],
+  );
+
+  const handleStartAdd = useCallback(() => setAdding(true), []);
+  const handleCancelAdd = useCallback(() => {
+    setAdding(false);
+    setLabel("");
+    setName("");
+    setEmail("");
+  }, []);
+
+  const handleSaveAdd = useCallback(() => {
+    if (!name.trim() || !email.trim()) {
+      setStatus("Name and email are required");
+      return;
+    }
+    addProfile({ label, name, email });
+    handleCancelAdd();
+  }, [addProfile, label, name, email, handleCancelAdd]);
+
+  const currentLabel = formatCurrentIdentity(current);
+
+  return (
+    <SettingsSection title={t("gitIdentity.title")} testID="project-git-identity">
+      <View style={settingsStyles.card}>
+        <View style={settingsStyles.row}>
+          <View style={settingsStyles.rowContent}>
+            <Text style={settingsStyles.rowTitle}>Current</Text>
+            <Text style={settingsStyles.rowHint}>{currentLabel}</Text>
+          </View>
+        </View>
+        {profiles.map((profile) => (
+          <View key={profile.id} style={styles.borderedRow}>
+            <ProfileRow
+              profile={profile}
+              applying={applyingId === profile.id}
+              onApply={handleApply}
+              onRemove={removeProfile}
+            />
+          </View>
+        ))}
+      </View>
+
+      {adding ? (
+        <View style={styles.addCard}>
+          <ThemedTextInput
+            style={styles.input}
+            value={label}
+            onChangeText={setLabel}
+            placeholder="Label (e.g. Work)"
+            autoCapitalize="none"
+          />
+          <ThemedTextInput
+            style={styles.input}
+            value={name}
+            onChangeText={setName}
+            placeholder="Name (user.name)"
+            autoCapitalize="none"
+          />
+          <ThemedTextInput
+            style={styles.input}
+            value={email}
+            onChangeText={setEmail}
+            placeholder="Email (user.email)"
+            autoCapitalize="none"
+            keyboardType="email-address"
+          />
+          <View style={styles.addActions}>
+            <Button variant="default" size="sm" onPress={handleSaveAdd}>
+              Save
+            </Button>
+            <Button variant="ghost" size="sm" onPress={handleCancelAdd}>
+              Cancel
+            </Button>
+          </View>
+        </View>
+      ) : (
+        <View style={styles.addButtonRow}>
+          <Button variant="secondary" size="sm" onPress={handleStartAdd}>
+            Add identity
+          </Button>
+        </View>
+      )}
+
+      {status ? <Text style={styles.statusText}>{status}</Text> : null}
+    </SettingsSection>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  borderedRow: {
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+  },
+  profileRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: theme.spacing[3],
+    paddingHorizontal: theme.spacing[4],
+    gap: theme.spacing[3],
+  },
+  profileText: {
+    flex: 1,
+    gap: theme.spacing[1],
+  },
+  profileLabel: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+    fontWeight: theme.fontWeight.medium,
+  },
+  profileMeta: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  profileActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+  },
+  addCard: {
+    marginTop: theme.spacing[3],
+    gap: theme.spacing[2],
+  },
+  input: {
+    backgroundColor: theme.colors.surface1,
+    borderRadius: theme.borderRadius.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  addActions: {
+    flexDirection: "row",
+    gap: theme.spacing[2],
+  },
+  addButtonRow: {
+    marginTop: theme.spacing[3],
+    flexDirection: "row",
+  },
+  statusText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    marginTop: theme.spacing[2],
+    marginLeft: theme.spacing[1],
+  },
+}));

--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -50,6 +50,8 @@ import { ProvidersSection } from "@/screens/settings/providers-section";
 import { ProviderUsageSettingsSection } from "@/provider-usage/settings-section";
 import { useProviderUsage } from "@/provider-usage/use-provider-usage";
 import { SettingsSection } from "@/screens/settings/settings-section";
+import { SkillsSection } from "@/screens/settings/skills-section";
+import { TunnelSection } from "@/screens/settings/tunnel-section";
 import { useSessionStore } from "@/stores/session-store";
 import { settingsStyles } from "@/styles/settings";
 import type { HostConnection, HostProfile } from "@/types/host-connection";
@@ -252,6 +254,9 @@ export function HostAgentsPage({ serverId }: { serverId: string }) {
   const { t } = useTranslation();
   const host = useHostProfile(serverId);
   const isConnected = useHostRuntimeIsConnected(serverId);
+  const skillsEnabled = useSessionStore(
+    (s) => s.sessions[serverId]?.serverInfo?.features?.skillsCatalog === true,
+  );
 
   if (!host) {
     return <HostNotFound />;
@@ -269,6 +274,7 @@ export function HostAgentsPage({ serverId }: { serverId: string }) {
           <Text style={styles.emptyText}>{t("settings.host.agents.unavailable")}</Text>
         </View>
       )}
+      {skillsEnabled ? <SkillsSection serverId={serverId} /> : null}
     </View>
   );
 }
@@ -338,6 +344,9 @@ export function HostSettingsPage({
 }) {
   const host = useHostProfile(serverId);
   const isLocalDaemon = useIsLocalDaemon(serverId);
+  const tunnelEnabled = useSessionStore(
+    (s) => s.sessions[serverId]?.serverInfo?.features?.tunnel === true,
+  );
 
   if (!host) {
     return <HostNotFound />;
@@ -357,6 +366,7 @@ export function HostSettingsPage({
       {isLocalDaemon ? <LocalDaemonSection /> : null}
 
       {!isLocalDaemon ? <UpdateDaemonCard host={host} /> : null}
+      {tunnelEnabled ? <TunnelSection serverId={serverId} /> : null}
 
       <RemoveHostSection host={host} isLocalDaemon={isLocalDaemon} onRemoved={onHostRemoved} />
     </View>

--- a/packages/app/src/screens/settings/skills-section.tsx
+++ b/packages/app/src/screens/settings/skills-section.tsx
@@ -1,0 +1,343 @@
+// Ported concept from openchamber/openchamber (MIT): packages/ui/src/components/sections/skills/catalog/SkillsCatalogPage.tsx
+// Installs skills (SKILL.md directories) from a GitHub repo into the OMP/pi user skills dir, and
+// lists what's installed. Data via the daemon skills RPC.
+import { useCallback, useMemo, useState } from "react";
+import { Text, TextInput, View } from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import {
+  useSkills,
+  type InstalledSkill,
+  type ScannedSkill,
+  type SkillsCatalogError,
+} from "@/hooks/use-skills";
+import { SettingsSection } from "@/screens/settings/settings-section";
+import { settingsStyles } from "@/styles/settings";
+import { useI18n } from "@/lib/i18n";
+
+const ThemedTextInput = withUnistyles(TextInput, (theme) => ({
+  placeholderTextColor: theme.colors.foregroundMuted,
+}));
+
+interface SkillsSectionProps {
+  serverId: string;
+}
+
+function describeError(error: SkillsCatalogError): string {
+  if (error.kind === "conflicts" && error.conflicts && error.conflicts.length > 0) {
+    return `Already installed: ${error.conflicts.join(", ")}. Use Overwrite to replace.`;
+  }
+  if (error.kind === "authRequired") {
+    return "Authentication required for this repository (private repos need SSH).";
+  }
+  if (error.kind === "gitUnavailable") {
+    return "git is not available on this host.";
+  }
+  return error.message;
+}
+
+function ScannedSkillRow({
+  skill,
+  selected,
+  onToggle,
+}: {
+  skill: ScannedSkill;
+  selected: boolean;
+  onToggle: (skillDir: string, next: boolean) => void;
+}) {
+  const handleChange = useCallback(
+    (next: boolean) => onToggle(skill.skillDir, next),
+    [onToggle, skill.skillDir],
+  );
+  return (
+    <View style={styles.scanRow}>
+      <View style={styles.scanRowText}>
+        <Text style={styles.skillName}>{skill.name}</Text>
+        {skill.description ? (
+          <Text style={styles.skillDescription} numberOfLines={2}>
+            {skill.description}
+          </Text>
+        ) : null}
+      </View>
+      <Switch value={selected} onValueChange={handleChange} />
+    </View>
+  );
+}
+
+function InstalledSkillsList({
+  installed,
+  isLoading,
+}: {
+  installed: InstalledSkill[];
+  isLoading: boolean;
+}) {
+  if (isLoading) {
+    return (
+      <View style={settingsStyles.card}>
+        <Text style={styles.emptyHint}>Loading skills…</Text>
+      </View>
+    );
+  }
+  if (installed.length === 0) {
+    return (
+      <View style={settingsStyles.card}>
+        <Text style={styles.emptyHint}>No skills installed.</Text>
+      </View>
+    );
+  }
+  return (
+    <View style={settingsStyles.card}>
+      {installed.map((skill) => (
+        <View key={skill.path} style={styles.installedRow}>
+          <Text style={styles.skillName}>{skill.name}</Text>
+          {skill.description ? (
+            <Text style={styles.skillDescription} numberOfLines={2}>
+              {skill.description}
+            </Text>
+          ) : null}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+export function SkillsSection({ serverId }: SkillsSectionProps) {
+  const { t } = useI18n();
+  const { installed, isLoading, scan, install } = useSkills(serverId);
+  const [source, setSource] = useState("");
+  const [scanned, setScanned] = useState<ScannedSkill[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const [hadConflict, setHadConflict] = useState(false);
+
+  const handleToggle = useCallback((skillDir: string, next: boolean) => {
+    setSelected((prev) => {
+      const updated = new Set(prev);
+      if (next) {
+        updated.add(skillDir);
+      } else {
+        updated.delete(skillDir);
+      }
+      return updated;
+    });
+  }, []);
+
+  const handleScan = useCallback(async () => {
+    const trimmed = source.trim();
+    if (!trimmed) {
+      return;
+    }
+    setBusy(true);
+    setStatus(null);
+    setHadConflict(false);
+    setScanned([]);
+    setSelected(new Set());
+    try {
+      const outcome = await scan(trimmed);
+      if (outcome.error) {
+        setStatus(describeError(outcome.error));
+        return;
+      }
+      if (outcome.skills.length === 0) {
+        setStatus("No SKILL.md directories found in that repository.");
+        return;
+      }
+      setScanned(outcome.skills);
+      setSelected(new Set(outcome.skills.map((skill) => skill.skillDir)));
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : "Scan failed");
+    } finally {
+      setBusy(false);
+    }
+  }, [scan, source]);
+
+  const runInstall = useCallback(
+    async (overwrite: boolean) => {
+      const skillDirs = scanned
+        .filter((skill) => selected.has(skill.skillDir))
+        .map((skill) => skill.skillDir);
+      if (skillDirs.length === 0) {
+        return;
+      }
+      setBusy(true);
+      setStatus(null);
+      try {
+        const outcome = await install({ source: source.trim(), skillDirs, overwrite });
+        if (outcome.error) {
+          setHadConflict(outcome.error.kind === "conflicts");
+          setStatus(describeError(outcome.error));
+          return;
+        }
+        setHadConflict(false);
+        const installedCount = outcome.installed.length;
+        const skippedCount = outcome.skipped.length;
+        setStatus(
+          `Installed ${installedCount} skill${installedCount === 1 ? "" : "s"}` +
+            (skippedCount > 0 ? `, skipped ${skippedCount}.` : "."),
+        );
+        setScanned([]);
+        setSelected(new Set());
+        setSource("");
+      } catch (error) {
+        setStatus(error instanceof Error ? error.message : "Install failed");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [install, scanned, selected, source],
+  );
+
+  const handleInstall = useCallback(() => {
+    void runInstall(false);
+  }, [runInstall]);
+
+  const handleOverwrite = useCallback(() => {
+    void runInstall(true);
+  }, [runInstall]);
+
+  const selectedCount = useMemo(
+    () => scanned.filter((skill) => selected.has(skill.skillDir)).length,
+    [scanned, selected],
+  );
+
+  return (
+    <SettingsSection title={t("skills.title")} testID="host-page-skills">
+      <InstalledSkillsList installed={installed} isLoading={isLoading} />
+
+      <View style={styles.installCard}>
+        <Text style={styles.installLabel}>Install from GitHub</Text>
+        <View style={styles.inputRow}>
+          <ThemedTextInput
+            style={styles.input}
+            value={source}
+            onChangeText={setSource}
+            placeholder="owner/repo or owner/repo/subpath"
+            autoCapitalize="none"
+            autoCorrect={false}
+            editable={!busy}
+          />
+          <Button
+            variant="secondary"
+            onPress={handleScan}
+            loading={busy && scanned.length === 0}
+            disabled={busy}
+          >
+            Scan
+          </Button>
+        </View>
+
+        {scanned.length > 0 ? (
+          <View style={styles.scanList}>
+            {scanned.map((skill) => (
+              <ScannedSkillRow
+                key={skill.skillDir}
+                skill={skill}
+                selected={selected.has(skill.skillDir)}
+                onToggle={handleToggle}
+              />
+            ))}
+            <View style={styles.installActions}>
+              <Button
+                variant="default"
+                onPress={handleInstall}
+                disabled={busy || selectedCount === 0}
+              >
+                {`Install ${selectedCount}`}
+              </Button>
+              {hadConflict ? (
+                <Button variant="outline" onPress={handleOverwrite} disabled={busy}>
+                  Overwrite
+                </Button>
+              ) : null}
+            </View>
+          </View>
+        ) : null}
+
+        {status ? <Text style={styles.statusText}>{status}</Text> : null}
+      </View>
+    </SettingsSection>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  emptyHint: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    paddingVertical: theme.spacing[4],
+    paddingHorizontal: theme.spacing[4],
+  },
+  installedRow: {
+    paddingVertical: theme.spacing[3],
+    paddingHorizontal: theme.spacing[4],
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+    gap: theme.spacing[1],
+  },
+  skillName: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+    fontWeight: theme.fontWeight.medium,
+  },
+  skillDescription: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  installCard: {
+    marginTop: theme.spacing[3],
+    gap: theme.spacing[3],
+  },
+  installLabel: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    marginLeft: theme.spacing[1],
+  },
+  inputRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  input: {
+    flex: 1,
+    backgroundColor: theme.colors.surface1,
+    borderRadius: theme.borderRadius.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  scanList: {
+    backgroundColor: theme.colors.surface1,
+    borderRadius: theme.borderRadius.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    overflow: "hidden",
+  },
+  scanRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: theme.spacing[3],
+    paddingHorizontal: theme.spacing[4],
+    gap: theme.spacing[3],
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+  },
+  scanRowText: {
+    flex: 1,
+    gap: theme.spacing[1],
+  },
+  installActions: {
+    flexDirection: "row",
+    gap: theme.spacing[2],
+    padding: theme.spacing[3],
+  },
+  statusText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    marginLeft: theme.spacing[1],
+  },
+}));

--- a/packages/app/src/screens/settings/snippets-section.tsx
+++ b/packages/app/src/screens/settings/snippets-section.tsx
@@ -1,0 +1,212 @@
+// Ported concept from openchamber/openchamber (MIT): reusable composer snippets.
+// Manages the global snippet list (insert via `#` in the composer). Persisted
+// client-side via snippets-store.
+import { useCallback, useMemo, useState } from "react";
+import { Pressable, Text, TextInput, View } from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { Button } from "@/components/ui/button";
+import { SettingsSection } from "@/screens/settings/settings-section";
+import { settingsStyles } from "@/styles/settings";
+import { useI18n } from "@/lib/i18n";
+import { GLOBAL_SNIPPET_SCOPE, useSnippetsStore, type Snippet } from "@/stores/snippets-store";
+
+const ThemedTextInput = withUnistyles(TextInput, (theme) => ({
+  placeholderTextColor: theme.colors.foregroundMuted,
+}));
+
+function SnippetRow({
+  snippet,
+  onEdit,
+  onRemove,
+}: {
+  snippet: Snippet;
+  onEdit: (snippet: Snippet) => void;
+  onRemove: (id: string) => void;
+}) {
+  const handleEdit = useCallback(() => onEdit(snippet), [onEdit, snippet]);
+  const handleRemove = useCallback(() => onRemove(snippet.id), [onRemove, snippet.id]);
+  return (
+    <View style={styles.row}>
+      <Pressable style={styles.rowMain} onPress={handleEdit} testID={`snippet-edit-${snippet.id}`}>
+        <Text style={styles.rowName}>{`#${snippet.name}`}</Text>
+        <Text style={styles.rowBody} numberOfLines={1}>
+          {snippet.body}
+        </Text>
+      </Pressable>
+      <Pressable
+        style={styles.removeButton}
+        onPress={handleRemove}
+        testID={`snippet-remove-${snippet.id}`}
+      >
+        <Text style={styles.removeText}>×</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export function SnippetsSection() {
+  const { t } = useI18n();
+  const selectSnippets = useCallback(
+    (state: { byScope: Record<string, Snippet[]> }) => state.byScope[GLOBAL_SNIPPET_SCOPE],
+    [],
+  );
+  const stored = useSnippetsStore(selectSnippets);
+  const addSnippet = useSnippetsStore((state) => state.addSnippet);
+  const updateSnippet = useSnippetsStore((state) => state.updateSnippet);
+  const removeSnippet = useSnippetsStore((state) => state.removeSnippet);
+  const snippets = useMemo(() => stored ?? EMPTY, [stored]);
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [nameDraft, setNameDraft] = useState("");
+  const [bodyDraft, setBodyDraft] = useState("");
+
+  const resetForm = useCallback(() => {
+    setEditingId(null);
+    setNameDraft("");
+    setBodyDraft("");
+  }, []);
+
+  const handleEdit = useCallback((snippet: Snippet) => {
+    setEditingId(snippet.id);
+    setNameDraft(snippet.name);
+    setBodyDraft(snippet.body);
+  }, []);
+
+  const handleSave = useCallback(() => {
+    const name = nameDraft.trim();
+    if (!name) {
+      return;
+    }
+    if (editingId) {
+      updateSnippet(GLOBAL_SNIPPET_SCOPE, editingId, { name, body: bodyDraft });
+    } else {
+      addSnippet(GLOBAL_SNIPPET_SCOPE, name, bodyDraft);
+    }
+    resetForm();
+  }, [addSnippet, bodyDraft, editingId, nameDraft, resetForm, updateSnippet]);
+
+  const handleRemove = useCallback(
+    (id: string) => {
+      removeSnippet(GLOBAL_SNIPPET_SCOPE, id);
+      if (editingId === id) {
+        resetForm();
+      }
+    },
+    [editingId, removeSnippet, resetForm],
+  );
+
+  return (
+    <SettingsSection title={t("snippets.title")}>
+      <View style={settingsStyles.card}>
+        <Text style={styles.hint}>{t("snippets.hint")}</Text>
+        {snippets.length === 0 ? (
+          <Text style={styles.empty}>{t("snippets.empty")}</Text>
+        ) : (
+          snippets.map((snippet) => (
+            <SnippetRow
+              key={snippet.id}
+              snippet={snippet}
+              onEdit={handleEdit}
+              onRemove={handleRemove}
+            />
+          ))
+        )}
+        <ThemedTextInput
+          style={styles.nameInput}
+          value={nameDraft}
+          onChangeText={setNameDraft}
+          placeholder={t("snippets.namePlaceholder")}
+          autoCapitalize="none"
+          testID="snippet-name-input"
+        />
+        <ThemedTextInput
+          style={styles.bodyInput}
+          value={bodyDraft}
+          onChangeText={setBodyDraft}
+          placeholder={t("snippets.bodyPlaceholder")}
+          multiline
+          textAlignVertical="top"
+          testID="snippet-body-input"
+        />
+        <View style={styles.actions}>
+          {editingId ? (
+            <Button variant="ghost" onPress={resetForm}>
+              {t("snippets.cancel")}
+            </Button>
+          ) : null}
+          <Button onPress={handleSave} testID="snippet-save">
+            {editingId ? t("snippets.save") : t("snippets.add")}
+          </Button>
+        </View>
+      </View>
+    </SettingsSection>
+  );
+}
+
+const EMPTY: Snippet[] = [];
+
+const styles = StyleSheet.create((theme) => ({
+  hint: {
+    color: theme.colors.foregroundMuted,
+    fontSize: 13,
+    marginBottom: 8,
+  },
+  empty: {
+    color: theme.colors.foregroundMuted,
+    fontSize: 13,
+    paddingVertical: 8,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: theme.colors.border,
+  },
+  rowMain: {
+    flex: 1,
+    minWidth: 0,
+  },
+  rowName: {
+    color: theme.colors.foreground,
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  rowBody: {
+    color: theme.colors.foregroundMuted,
+    fontSize: 12,
+  },
+  removeButton: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  removeText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: 20,
+  },
+  nameInput: {
+    marginTop: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: theme.colors.border,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    color: theme.colors.foreground,
+  },
+  bodyInput: {
+    marginTop: 8,
+    minHeight: 72,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: theme.colors.border,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    color: theme.colors.foreground,
+  },
+  actions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 8,
+    marginTop: 12,
+  },
+}));

--- a/packages/app/src/screens/settings/tunnel-section.tsx
+++ b/packages/app/src/screens/settings/tunnel-section.tsx
@@ -1,0 +1,137 @@
+// Ported concept from openchamber/openchamber (MIT): TunnelSettings.
+// Starts/stops a Cloudflare quick tunnel exposing this host's local daemon port, surfacing the
+// public URL. An optional alternative to Paseo's native relay + device pairing.
+import { useCallback, useEffect, useState } from "react";
+import { Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import type { TunnelStatus } from "@getpaseo/protocol/tunnel/types";
+import { Button } from "@/components/ui/button";
+import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+import { SettingsSection } from "@/screens/settings/settings-section";
+import { settingsStyles } from "@/styles/settings";
+
+interface TunnelSectionProps {
+  serverId: string;
+}
+
+function describeState(status: TunnelStatus | null): string {
+  if (!status) {
+    return "…";
+  }
+  switch (status.state) {
+    case "running":
+      return status.url ?? "Running";
+    case "starting":
+      return "Starting…";
+    case "error":
+      return status.error ?? "Error";
+    default:
+      return "Not running";
+  }
+}
+
+export function TunnelSection({ serverId }: TunnelSectionProps) {
+  const client = useHostRuntimeClient(serverId);
+  const isConnected = useHostRuntimeIsConnected(serverId);
+  const [status, setStatus] = useState<TunnelStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!client) {
+      return;
+    }
+    try {
+      const payload = await client.tunnelStatus();
+      setStatus(payload.status);
+    } catch {
+      setStatus(null);
+    }
+  }, [client]);
+
+  useEffect(() => {
+    if (isConnected) {
+      void refresh();
+    }
+  }, [isConnected, refresh]);
+
+  const handleStart = useCallback(() => {
+    void (async () => {
+      if (!client) {
+        return;
+      }
+      setBusy(true);
+      try {
+        const payload = await client.tunnelStart();
+        setStatus(payload.status);
+      } finally {
+        setBusy(false);
+      }
+    })();
+  }, [client]);
+
+  const handleStop = useCallback(() => {
+    void (async () => {
+      if (!client) {
+        return;
+      }
+      setBusy(true);
+      try {
+        const payload = await client.tunnelStop();
+        setStatus(payload.status);
+      } finally {
+        setBusy(false);
+      }
+    })();
+  }, [client]);
+
+  const running = status?.state === "running" || status?.state === "starting";
+
+  return (
+    <SettingsSection title="Remote tunnel" testID="host-page-tunnel">
+      <View style={settingsStyles.card}>
+        <View style={settingsStyles.row}>
+          <View style={settingsStyles.rowContent}>
+            <Text style={settingsStyles.rowTitle}>Cloudflare quick tunnel</Text>
+            <Text style={settingsStyles.rowHint} numberOfLines={2}>
+              {describeState(status)}
+            </Text>
+          </View>
+          {running ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              onPress={handleStop}
+              loading={busy}
+              disabled={busy}
+            >
+              Stop
+            </Button>
+          ) : (
+            <Button
+              variant="secondary"
+              size="sm"
+              onPress={handleStart}
+              loading={busy}
+              disabled={busy}
+            >
+              Start
+            </Button>
+          )}
+        </View>
+      </View>
+      <Text style={styles.note}>
+        Exposes this host&apos;s local port publicly via cloudflared. Paseo&apos;s relay + device
+        pairing remains the recommended remote-access path.
+      </Text>
+    </SettingsSection>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  note: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    marginTop: theme.spacing[2],
+    marginLeft: theme.spacing[1],
+  },
+}));

--- a/packages/app/src/stores/explorer-tab-memory.ts
+++ b/packages/app/src/stores/explorer-tab-memory.ts
@@ -1,7 +1,7 @@
-export type ExplorerTab = "changes" | "files" | "pr";
+export type ExplorerTab = "changes" | "files" | "pr" | "notes";
 
 export function isExplorerTab(value: unknown): value is ExplorerTab {
-  return value === "changes" || value === "files" || value === "pr";
+  return value === "changes" || value === "files" || value === "pr" || value === "notes";
 }
 
 export function buildExplorerCheckoutKey(serverId: string, cwd: string): string | null {

--- a/packages/app/src/stores/git-identities-store.test.ts
+++ b/packages/app/src/stores/git-identities-store.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: { getItem: vi.fn(async () => null), setItem: vi.fn(), removeItem: vi.fn() },
+}));
+
+import { useGitIdentitiesStore } from "@/stores/git-identities-store";
+
+describe("git-identities-store", () => {
+  beforeEach(() => {
+    useGitIdentitiesStore.setState({ profiles: [] });
+  });
+
+  it("adds a profile, defaulting label to name", () => {
+    const store = useGitIdentitiesStore.getState();
+    const created = store.addProfile({ label: "", name: "Ada", email: "ada@x.dev" });
+    expect(created.label).toBe("Ada");
+    expect(useGitIdentitiesStore.getState().profiles).toHaveLength(1);
+  });
+
+  it("trims fields on add", () => {
+    const store = useGitIdentitiesStore.getState();
+    const created = store.addProfile({ label: " Work ", name: " Grace ", email: " grace@x.dev " });
+    expect(created.label).toBe("Work");
+    expect(created.name).toBe("Grace");
+    expect(created.email).toBe("grace@x.dev");
+  });
+
+  it("updates a profile", () => {
+    const store = useGitIdentitiesStore.getState();
+    const created = store.addProfile({ label: "Work", name: "Grace", email: "grace@x.dev" });
+    store.updateProfile(created.id, { label: "Home", name: "Grace H", email: "grace@home.dev" });
+    const updated = useGitIdentitiesStore.getState().profiles[0];
+    expect(updated.label).toBe("Home");
+    expect(updated.email).toBe("grace@home.dev");
+  });
+
+  it("removes a profile", () => {
+    const store = useGitIdentitiesStore.getState();
+    const created = store.addProfile({ label: "Work", name: "Grace", email: "grace@x.dev" });
+    store.removeProfile(created.id);
+    expect(useGitIdentitiesStore.getState().profiles).toEqual([]);
+  });
+
+  it("drops invalid entries during persistence merge", () => {
+    const options = useGitIdentitiesStore.persist.getOptions();
+    const restored = options.merge?.(
+      {
+        profiles: [
+          { id: "1", label: "Ok", name: "A", email: "a@x.dev" },
+          { id: "2", name: "", email: "b@x.dev" },
+          { label: "no id", name: "C", email: "c@x.dev" },
+        ],
+      },
+      useGitIdentitiesStore.getState(),
+    );
+    expect(restored?.profiles).toHaveLength(1);
+    expect(restored?.profiles[0]?.id).toBe("1");
+  });
+});

--- a/packages/app/src/stores/git-identities-store.ts
+++ b/packages/app/src/stores/git-identities-store.ts
@@ -1,0 +1,105 @@
+// Ported concept from openchamber/openchamber (MIT): packages/ui/src/stores/useGitIdentitiesStore.ts
+// Named git identity profiles (name + email) the user can apply to a repository. Client-only,
+// AsyncStorage-persisted (matches sidebar/workspace-folders convention). Applying a profile writes
+// the repo-local git config via the daemon git-identity RPC.
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+export interface GitIdentityProfile {
+  id: string;
+  label: string;
+  name: string;
+  email: string;
+}
+
+interface GitIdentitiesState {
+  profiles: GitIdentityProfile[];
+}
+
+interface GitIdentitiesActions {
+  addProfile: (input: { label: string; name: string; email: string }) => GitIdentityProfile;
+  updateProfile: (id: string, input: { label: string; name: string; email: string }) => void;
+  removeProfile: (id: string) => void;
+}
+
+type GitIdentitiesStore = GitIdentitiesState & GitIdentitiesActions;
+
+function createProfileId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `identity_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sanitizeProfiles(value: unknown): GitIdentityProfile[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const profiles: GitIdentityProfile[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const candidate = entry as Record<string, unknown>;
+    const id = typeof candidate.id === "string" ? candidate.id : "";
+    const name = typeof candidate.name === "string" ? candidate.name.trim() : "";
+    const email = typeof candidate.email === "string" ? candidate.email.trim() : "";
+    if (!id || !name || !email) {
+      continue;
+    }
+    const label =
+      typeof candidate.label === "string" && candidate.label.trim() ? candidate.label.trim() : name;
+    profiles.push({ id, label, name, email });
+  }
+  return profiles;
+}
+
+export const useGitIdentitiesStore = create<GitIdentitiesStore>()(
+  persist(
+    (set) => ({
+      profiles: [],
+
+      addProfile: ({ label, name, email }) => {
+        const profile: GitIdentityProfile = {
+          id: createProfileId(),
+          label: label.trim() || name.trim(),
+          name: name.trim(),
+          email: email.trim(),
+        };
+        set((state) => ({ profiles: state.profiles.concat(profile) }));
+        return profile;
+      },
+
+      updateProfile: (id, { label, name, email }) => {
+        set((state) => ({
+          profiles: state.profiles.map((profile) =>
+            profile.id === id
+              ? Object.assign({}, profile, {
+                  label: label.trim() || name.trim(),
+                  name: name.trim(),
+                  email: email.trim(),
+                })
+              : profile,
+          ),
+        }));
+      },
+
+      removeProfile: (id) => {
+        set((state) => ({ profiles: state.profiles.filter((profile) => profile.id !== id) }));
+      },
+    }),
+    {
+      name: "git-identities",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({ profiles: state.profiles }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as { profiles?: unknown } | undefined;
+        return {
+          ...currentState,
+          profiles: sanitizeProfiles(persisted?.profiles),
+        };
+      },
+    },
+  ),
+);

--- a/packages/app/src/stores/multi-run-store.test.ts
+++ b/packages/app/src/stores/multi-run-store.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createAgentMock = vi.fn();
+
+vi.mock("@/stores/session-store", () => ({
+  useSessionStore: {
+    getState: () => ({ sessions: { srv: { client: { createAgent: createAgentMock } } } }),
+  },
+}));
+
+vi.mock("@/screens/workspace/workspace-draft-agent-config", () => ({
+  buildWorkspaceDraftAgentConfig: (input: Record<string, unknown>) => ({ ...input }),
+}));
+
+import { useMultiRunStore } from "@/stores/multi-run-store";
+
+describe("multi-run-store", () => {
+  beforeEach(() => {
+    useMultiRunStore.setState({ groups: [] });
+    createAgentMock.mockReset();
+  });
+
+  it("rejects empty prompt and empty model list", async () => {
+    await expect(
+      useMultiRunStore.getState().launch({
+        serverId: "srv",
+        cwd: "/r",
+        workspaceId: "w",
+        prompt: "  ",
+        models: [{ provider: "claude", model: "sonnet" }],
+      }),
+    ).rejects.toThrow("prompt");
+
+    await expect(
+      useMultiRunStore.getState().launch({
+        serverId: "srv",
+        cwd: "/r",
+        workspaceId: "w",
+        prompt: "hi",
+        models: [],
+      }),
+    ).rejects.toThrow("at least one model");
+  });
+
+  it("fires one createAgent per model and records agent ids", async () => {
+    createAgentMock.mockImplementation(async (opts: { config: { model: string } }) => ({
+      id: `agent-${opts.config.model}`,
+    }));
+
+    const group = await useMultiRunStore.getState().launch({
+      serverId: "srv",
+      cwd: "/r",
+      workspaceId: "w",
+      prompt: "do it",
+      models: [
+        { provider: "claude", model: "sonnet" },
+        { provider: "codex", model: "gpt-5" },
+      ],
+    });
+
+    expect(createAgentMock).toHaveBeenCalledTimes(2);
+    expect(group.entries).toHaveLength(2);
+    expect(group.entries.every((entry) => entry.status === "running")).toBe(true);
+    expect(group.entries.map((entry) => entry.agentId).sort()).toEqual([
+      "agent-gpt-5",
+      "agent-sonnet",
+    ]);
+    expect(group.prompt).toBe("do it");
+  });
+
+  it("marks an entry failed when createAgent rejects", async () => {
+    createAgentMock.mockRejectedValue(new Error("boom"));
+
+    const group = await useMultiRunStore.getState().launch({
+      serverId: "srv",
+      cwd: "/r",
+      workspaceId: "w",
+      prompt: "do it",
+      models: [{ provider: "claude", model: "sonnet" }],
+    });
+
+    expect(group.entries[0].status).toBe("failed");
+    expect(group.entries[0].error).toBe("boom");
+  });
+
+  it("clears groups", async () => {
+    createAgentMock.mockResolvedValue({ id: "a" });
+    const group = await useMultiRunStore.getState().launch({
+      serverId: "srv",
+      cwd: "/r",
+      workspaceId: "w",
+      prompt: "x",
+      models: [{ provider: "claude", model: "sonnet" }],
+    });
+    useMultiRunStore.getState().clearGroup(group.id);
+    expect(useMultiRunStore.getState().groups).toEqual([]);
+  });
+});

--- a/packages/app/src/stores/multi-run-store.ts
+++ b/packages/app/src/stores/multi-run-store.ts
@@ -1,0 +1,155 @@
+// Ported concept from openchamber/openchamber (MIT): useMultiRunStore.
+// Launches the same prompt across multiple (provider, model) pairs in parallel by firing one
+// createAgent per pair into a workspace, tracking each as a run entry. Ephemeral (not persisted).
+import { create } from "zustand";
+import type { AgentProvider } from "@getpaseo/protocol/agent-types";
+import { useSessionStore } from "@/stores/session-store";
+import { buildWorkspaceDraftAgentConfig } from "@/screens/workspace/workspace-draft-agent-config";
+
+export interface MultiRunModelSelection {
+  provider: AgentProvider;
+  model: string;
+}
+
+export type MultiRunEntryStatus = "pending" | "running" | "failed";
+
+export interface MultiRunEntry {
+  id: string;
+  provider: AgentProvider;
+  model: string;
+  status: MultiRunEntryStatus;
+  agentId: string | null;
+  error: string | null;
+}
+
+export interface MultiRunGroup {
+  id: string;
+  prompt: string;
+  cwd: string;
+  serverId: string;
+  workspaceId: string;
+  entries: MultiRunEntry[];
+  createdAt: number;
+}
+
+export interface LaunchMultiRunInput {
+  serverId: string;
+  cwd: string;
+  workspaceId: string;
+  prompt: string;
+  models: MultiRunModelSelection[];
+}
+
+interface MultiRunState {
+  groups: MultiRunGroup[];
+}
+
+interface MultiRunActions {
+  launch: (input: LaunchMultiRunInput) => Promise<MultiRunGroup>;
+  clearGroup: (groupId: string) => void;
+  clearAll: () => void;
+}
+
+type MultiRunStore = MultiRunState & MultiRunActions;
+
+function createId(prefix: string): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `${prefix}_${crypto.randomUUID()}`;
+  }
+  return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+function patchGroupEntry(
+  group: MultiRunGroup,
+  entryId: string,
+  patch: Partial<MultiRunEntry>,
+): MultiRunGroup {
+  return Object.assign({}, group, {
+    entries: group.entries.map((entry) =>
+      entry.id === entryId ? Object.assign({}, entry, patch) : entry,
+    ),
+  });
+}
+
+function resolveClient(serverId: string) {
+  const client = useSessionStore.getState().sessions[serverId]?.client ?? null;
+  if (!client) {
+    throw new Error("Daemon client unavailable");
+  }
+  return client;
+}
+
+export const useMultiRunStore = create<MultiRunStore>()((set, get) => ({
+  groups: [],
+
+  launch: async (input) => {
+    const prompt = input.prompt.trim();
+    if (!prompt) {
+      throw new Error("A prompt is required");
+    }
+    if (input.models.length === 0) {
+      throw new Error("Select at least one model");
+    }
+
+    const groupId = createId("multirun");
+    const entries: MultiRunEntry[] = input.models.map((selection) => ({
+      id: createId("entry"),
+      provider: selection.provider,
+      model: selection.model,
+      status: "pending",
+      agentId: null,
+      error: null,
+    }));
+    const group: MultiRunGroup = {
+      id: groupId,
+      prompt,
+      cwd: input.cwd,
+      serverId: input.serverId,
+      workspaceId: input.workspaceId,
+      entries,
+      createdAt: Date.now(),
+    };
+    set((state) => ({ groups: state.groups.concat(group) }));
+
+    const updateEntry = (entryId: string, patch: Partial<MultiRunEntry>) => {
+      set((state) => ({
+        groups: state.groups.map((existing) =>
+          existing.id === groupId ? patchGroupEntry(existing, entryId, patch) : existing,
+        ),
+      }));
+    };
+
+    const client = resolveClient(input.serverId);
+    await Promise.all(
+      entries.map(async (entry) => {
+        try {
+          const config = buildWorkspaceDraftAgentConfig({
+            provider: entry.provider,
+            cwd: input.cwd,
+            model: entry.model,
+          });
+          const result = await client.createAgent({
+            config,
+            workspaceId: input.workspaceId,
+            initialPrompt: prompt,
+          });
+          updateEntry(entry.id, { status: "running", agentId: result.id });
+        } catch (error) {
+          updateEntry(entry.id, {
+            status: "failed",
+            error: error instanceof Error ? error.message : "Failed to launch",
+          });
+        }
+      }),
+    );
+
+    return get().groups.find((existing) => existing.id === groupId) ?? group;
+  },
+
+  clearGroup: (groupId) => {
+    set((state) => ({ groups: state.groups.filter((group) => group.id !== groupId) }));
+  },
+
+  clearAll: () => {
+    set({ groups: [] });
+  },
+}));

--- a/packages/app/src/stores/project-notes-store.test.ts
+++ b/packages/app/src/stores/project-notes-store.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: { getItem: vi.fn(async () => null), setItem: vi.fn(), removeItem: vi.fn() },
+}));
+
+import { buildProjectNotesKey, useProjectNotesStore } from "@/stores/project-notes-store";
+
+const KEY = buildProjectNotesKey("srv", "/home/me/project");
+
+describe("project-notes-store", () => {
+  beforeEach(() => {
+    useProjectNotesStore.setState({ byKey: {} });
+  });
+
+  it("builds a key from server id and cwd", () => {
+    expect(buildProjectNotesKey("srv", "/r")).toBe("srv::/r");
+  });
+
+  it("returns empty data for an unknown key", () => {
+    expect(useProjectNotesStore.getState().getData("missing")).toEqual({ notes: "", todos: [] });
+  });
+
+  it("sets notes scoped to a key", () => {
+    useProjectNotesStore.getState().setNotes(KEY, "remember this");
+    expect(useProjectNotesStore.getState().getData(KEY).notes).toBe("remember this");
+    expect(useProjectNotesStore.getState().getData("other").notes).toBe("");
+  });
+
+  it("adds, toggles, and removes todos", () => {
+    const store = useProjectNotesStore.getState();
+    store.addTodo(KEY, "  ship it  ");
+    let todos = useProjectNotesStore.getState().getData(KEY).todos;
+    expect(todos).toHaveLength(1);
+    expect(todos[0].text).toBe("ship it");
+    expect(todos[0].done).toBe(false);
+
+    const id = todos[0].id;
+    store.toggleTodo(KEY, id);
+    expect(useProjectNotesStore.getState().getData(KEY).todos[0].done).toBe(true);
+
+    store.removeTodo(KEY, id);
+    expect(useProjectNotesStore.getState().getData(KEY).todos).toEqual([]);
+  });
+
+  it("ignores blank todos", () => {
+    useProjectNotesStore.getState().addTodo(KEY, "   ");
+    expect(useProjectNotesStore.getState().getData(KEY).todos).toEqual([]);
+  });
+
+  it("drops malformed entries during persistence merge", () => {
+    const options = useProjectNotesStore.persist.getOptions();
+    const restored = options.merge?.(
+      {
+        byKey: {
+          good: { notes: "n", todos: [{ id: "1", text: "t", done: true, createdAt: 1 }] },
+          bad: { notes: 42, todos: "nope" },
+        },
+      },
+      useProjectNotesStore.getState(),
+    );
+    expect(restored?.byKey.good?.todos).toHaveLength(1);
+    expect(restored?.byKey.bad).toBeUndefined();
+  });
+});

--- a/packages/app/src/stores/project-notes-store.ts
+++ b/packages/app/src/stores/project-notes-store.ts
@@ -1,0 +1,148 @@
+// Ported concept from openchamber/openchamber (MIT): openchamberConfig project notes/todos +
+// ProjectNotesTodoPanel. Per-project scratchpad (free-form notes + a todo checklist), persisted
+// client-side (AsyncStorage), keyed by `${serverId}::${cwd}` (matches sidebar store conventions).
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+export interface ProjectTodo {
+  id: string;
+  text: string;
+  done: boolean;
+  createdAt: number;
+}
+
+export interface ProjectNotesData {
+  notes: string;
+  todos: ProjectTodo[];
+}
+
+type ProjectNotesMap = Record<string, ProjectNotesData>;
+
+interface ProjectNotesState {
+  byKey: ProjectNotesMap;
+}
+
+interface ProjectNotesActions {
+  getData: (key: string) => ProjectNotesData;
+  setNotes: (key: string, notes: string) => void;
+  addTodo: (key: string, text: string) => void;
+  toggleTodo: (key: string, todoId: string) => void;
+  removeTodo: (key: string, todoId: string) => void;
+}
+
+type ProjectNotesStore = ProjectNotesState & ProjectNotesActions;
+
+const EMPTY_DATA: ProjectNotesData = { notes: "", todos: [] };
+
+export function buildProjectNotesKey(serverId: string, cwd: string): string {
+  return `${serverId.trim()}::${cwd.trim()}`;
+}
+
+function createTodoId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `todo_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function dataFor(map: ProjectNotesMap, key: string): ProjectNotesData {
+  return map[key] ?? EMPTY_DATA;
+}
+
+function sanitizeMap(value: unknown): ProjectNotesMap {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  const result: ProjectNotesMap = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const candidate = entry as Record<string, unknown>;
+    const notes = typeof candidate.notes === "string" ? candidate.notes : "";
+    const todos = Array.isArray(candidate.todos)
+      ? (candidate.todos as unknown[]).flatMap((todo) => {
+          if (!todo || typeof todo !== "object") {
+            return [];
+          }
+          const item = todo as Record<string, unknown>;
+          const id = typeof item.id === "string" ? item.id : "";
+          const text = typeof item.text === "string" ? item.text : "";
+          if (!id || !text) {
+            return [];
+          }
+          return [
+            {
+              id,
+              text,
+              done: item.done === true,
+              createdAt: typeof item.createdAt === "number" ? item.createdAt : 0,
+            } satisfies ProjectTodo,
+          ];
+        })
+      : [];
+    if (notes || todos.length > 0) {
+      result[key] = { notes, todos };
+    }
+  }
+  return result;
+}
+
+export const useProjectNotesStore = create<ProjectNotesStore>()(
+  persist(
+    (set, get) => ({
+      byKey: {},
+
+      getData: (key) => dataFor(get().byKey, key),
+
+      setNotes: (key, notes) => {
+        if (!key) {
+          return;
+        }
+        const current = dataFor(get().byKey, key);
+        set((state) => ({ byKey: { ...state.byKey, [key]: { ...current, notes } } }));
+      },
+
+      addTodo: (key, text) => {
+        const trimmed = text.trim();
+        if (!key || !trimmed) {
+          return;
+        }
+        const current = dataFor(get().byKey, key);
+        const todo: ProjectTodo = {
+          id: createTodoId(),
+          text: trimmed,
+          done: false,
+          createdAt: Date.now(),
+        };
+        set((state) => ({
+          byKey: { ...state.byKey, [key]: { ...current, todos: current.todos.concat(todo) } },
+        }));
+      },
+
+      toggleTodo: (key, todoId) => {
+        const current = dataFor(get().byKey, key);
+        const todos = current.todos.map((todo) =>
+          todo.id === todoId ? Object.assign({}, todo, { done: !todo.done }) : todo,
+        );
+        set((state) => ({ byKey: { ...state.byKey, [key]: { ...current, todos } } }));
+      },
+
+      removeTodo: (key, todoId) => {
+        const current = dataFor(get().byKey, key);
+        const todos = current.todos.filter((todo) => todo.id !== todoId);
+        set((state) => ({ byKey: { ...state.byKey, [key]: { ...current, todos } } }));
+      },
+    }),
+    {
+      name: "project-notes",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({ byKey: state.byKey }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as { byKey?: unknown } | undefined;
+        return { ...currentState, byKey: sanitizeMap(persisted?.byKey) };
+      },
+    },
+  ),
+);

--- a/packages/app/src/stores/snippets-store.ts
+++ b/packages/app/src/stores/snippets-store.ts
@@ -1,0 +1,121 @@
+// Ported concept from openchamber/openchamber (MIT): reusable snippets inserted in the
+// composer via `#` autocomplete. Persisted client-side (AsyncStorage). v1 is a single
+// "global" scope; the scope-keyed map leaves room for per-project snippets later.
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+export interface Snippet {
+  id: string;
+  name: string;
+  body: string;
+}
+
+type SnippetsMap = Record<string, Snippet[]>;
+
+interface SnippetsState {
+  byScope: SnippetsMap;
+}
+
+interface SnippetsActions {
+  getSnippets: (scope: string) => Snippet[];
+  addSnippet: (scope: string, name: string, body: string) => void;
+  updateSnippet: (scope: string, id: string, patch: { name?: string; body?: string }) => void;
+  removeSnippet: (scope: string, id: string) => void;
+}
+
+type SnippetsStore = SnippetsState & SnippetsActions;
+
+export const GLOBAL_SNIPPET_SCOPE = "global";
+export const EMPTY_SNIPPETS: Snippet[] = [];
+
+function createSnippetId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `snippet_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function snippetsFor(map: SnippetsMap, scope: string): Snippet[] {
+  return map[scope] ?? EMPTY_SNIPPETS;
+}
+
+function sanitizeMap(value: unknown): SnippetsMap {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  const result: SnippetsMap = {};
+  for (const [scope, entries] of Object.entries(value as Record<string, unknown>)) {
+    if (!Array.isArray(entries)) {
+      continue;
+    }
+    const snippets = entries.flatMap((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return [];
+      }
+      const item = entry as Record<string, unknown>;
+      const id = typeof item.id === "string" ? item.id : "";
+      const name = typeof item.name === "string" ? item.name : "";
+      const body = typeof item.body === "string" ? item.body : "";
+      if (!id || !name) {
+        return [];
+      }
+      return [{ id, name, body } satisfies Snippet];
+    });
+    if (snippets.length > 0) {
+      result[scope] = snippets;
+    }
+  }
+  return result;
+}
+
+export const useSnippetsStore = create<SnippetsStore>()(
+  persist(
+    (set, get) => ({
+      byScope: {},
+
+      getSnippets: (scope) => snippetsFor(get().byScope, scope),
+
+      addSnippet: (scope, name, body) => {
+        const trimmedName = name.trim();
+        if (!scope || !trimmedName) {
+          return;
+        }
+        const current = snippetsFor(get().byScope, scope);
+        const snippet: Snippet = { id: createSnippetId(), name: trimmedName, body };
+        set((state) => ({
+          byScope: { ...state.byScope, [scope]: current.concat(snippet) },
+        }));
+      },
+
+      updateSnippet: (scope, id, patch) => {
+        const current = snippetsFor(get().byScope, scope);
+        const next = current.map((snippet) => {
+          if (snippet.id !== id) {
+            return snippet;
+          }
+          const trimmedName = patch.name === undefined ? snippet.name : patch.name.trim();
+          const body = patch.body === undefined ? snippet.body : patch.body;
+          return { id: snippet.id, name: trimmedName || snippet.name, body };
+        });
+        set((state) => ({ byScope: { ...state.byScope, [scope]: next } }));
+      },
+
+      removeSnippet: (scope, id) => {
+        const current = snippetsFor(get().byScope, scope);
+        set((state) => ({
+          byScope: { ...state.byScope, [scope]: current.filter((snippet) => snippet.id !== id) },
+        }));
+      },
+    }),
+    {
+      name: "snippets",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({ byScope: state.byScope }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as { byScope?: unknown } | undefined;
+        return { ...currentState, byScope: sanitizeMap(persisted?.byScope) };
+      },
+    },
+  ),
+);

--- a/packages/app/src/utils/snippet-mention-autocomplete.ts
+++ b/packages/app/src/utils/snippet-mention-autocomplete.ts
@@ -1,0 +1,51 @@
+// Detects a `#snippet` mention being typed in the composer and replaces it with the
+// snippet body. Mirrors file-mention-autocomplete.ts (the `@` trigger).
+export interface SnippetMentionRange {
+  start: number;
+  end: number;
+  query: string;
+}
+
+interface FindActiveSnippetMentionInput {
+  text: string;
+  cursorIndex: number;
+}
+
+interface ApplySnippetReplacementInput {
+  text: string;
+  mention: SnippetMentionRange;
+  body: string;
+}
+
+const INVALID_SNIPPET_QUERY_CHARS = /[\s\n\r\t]/;
+
+export function findActiveSnippetMention(
+  input: FindActiveSnippetMentionInput,
+): SnippetMentionRange | null {
+  const clampedCursor = Math.max(0, Math.min(input.cursorIndex, input.text.length));
+  const beforeCursor = input.text.slice(0, clampedCursor);
+
+  for (
+    let hashIndex = beforeCursor.lastIndexOf("#");
+    hashIndex >= 0;
+    hashIndex = hashIndex === 0 ? -1 : beforeCursor.lastIndexOf("#", hashIndex - 1)
+  ) {
+    const query = beforeCursor.slice(hashIndex + 1);
+    if (INVALID_SNIPPET_QUERY_CHARS.test(query)) {
+      continue;
+    }
+    return {
+      start: hashIndex,
+      end: clampedCursor,
+      query,
+    };
+  }
+
+  return null;
+}
+
+export function applySnippetReplacement(input: ApplySnippetReplacementInput): string {
+  const before = input.text.slice(0, input.mention.start);
+  const after = input.text.slice(input.mention.end);
+  return `${before}${input.body}${after}`;
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,7 +11,10 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true
+    "noImplicitReturns": true,
+    "paths": {
+      "@getpaseo/server": ["../server/src/server/exports.ts"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "src/**/*.test.ts"]

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -420,6 +420,38 @@ type LoopInspectPayload = Extract<
 >["payload"];
 type LoopLogsPayload = Extract<SessionOutboundMessage, { type: "loop/logs/response" }>["payload"];
 type LoopStopPayload = Extract<SessionOutboundMessage, { type: "loop/stop/response" }>["payload"];
+type SkillsListPayload = Extract<
+  SessionOutboundMessage,
+  { type: "skills/list/response" }
+>["payload"];
+type SkillsScanPayload = Extract<
+  SessionOutboundMessage,
+  { type: "skills/scan/response" }
+>["payload"];
+type SkillsInstallPayload = Extract<
+  SessionOutboundMessage,
+  { type: "skills/install/response" }
+>["payload"];
+type GitIdentityGetPayload = Extract<
+  SessionOutboundMessage,
+  { type: "git-identity/get/response" }
+>["payload"];
+type GitIdentitySetPayload = Extract<
+  SessionOutboundMessage,
+  { type: "git-identity/set/response" }
+>["payload"];
+type TunnelStatusPayload = Extract<
+  SessionOutboundMessage,
+  { type: "tunnel/status/response" }
+>["payload"];
+type TunnelStartPayload = Extract<
+  SessionOutboundMessage,
+  { type: "tunnel/start/response" }
+>["payload"];
+type TunnelStopPayload = Extract<
+  SessionOutboundMessage,
+  { type: "tunnel/stop/response" }
+>["payload"];
 type ScheduleCreatePayload = Extract<
   SessionOutboundMessage,
   { type: "schedule/create/response" }
@@ -3148,7 +3180,7 @@ export class DaemonClient {
 
   async checkoutCommit(
     cwd: string,
-    input: { message?: string; addAll?: boolean },
+    input: { message?: string; addAll?: boolean; gitmoji?: boolean },
     requestId?: string,
   ): Promise<CheckoutCommitPayload> {
     return this.sendCorrelatedSessionRequest({
@@ -3158,6 +3190,7 @@ export class DaemonClient {
         cwd,
         message: input.message,
         addAll: input.addAll,
+        ...(input.gitmoji !== undefined ? { gitmoji: input.gitmoji } : {}),
       },
       responseType: "checkout_commit_response",
     });
@@ -4583,6 +4616,113 @@ export class DaemonClient {
         id: normalized.id,
       },
       responseType: "loop/stop/response",
+    });
+  }
+
+  async skillsList(requestId?: string): Promise<SkillsListPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "skills/list",
+      },
+      responseType: "skills/list/response",
+      timeout: 10000,
+    });
+  }
+
+  async skillsScan(input: {
+    source: string;
+    subpath?: string;
+    requestId?: string;
+  }): Promise<SkillsScanPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId: input.requestId,
+      message: {
+        type: "skills/scan",
+        source: input.source,
+        ...(input.subpath ? { subpath: input.subpath } : {}),
+      },
+      responseType: "skills/scan/response",
+      timeout: 120000,
+    });
+  }
+
+  async skillsInstall(input: {
+    source: string;
+    subpath?: string;
+    skillDirs: string[];
+    overwrite?: boolean;
+    requestId?: string;
+  }): Promise<SkillsInstallPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId: input.requestId,
+      message: {
+        type: "skills/install",
+        source: input.source,
+        skillDirs: input.skillDirs,
+        ...(input.subpath ? { subpath: input.subpath } : {}),
+        ...(input.overwrite !== undefined ? { overwrite: input.overwrite } : {}),
+      },
+      responseType: "skills/install/response",
+      timeout: 120000,
+    });
+  }
+
+  async gitIdentityGet(cwd: string, requestId?: string): Promise<GitIdentityGetPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "git-identity/get",
+        cwd,
+      },
+      responseType: "git-identity/get/response",
+      timeout: 10000,
+    });
+  }
+
+  async gitIdentitySet(input: {
+    cwd: string;
+    name: string;
+    email: string;
+    requestId?: string;
+  }): Promise<GitIdentitySetPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId: input.requestId,
+      message: {
+        type: "git-identity/set",
+        cwd: input.cwd,
+        name: input.name,
+        email: input.email,
+      },
+      responseType: "git-identity/set/response",
+      timeout: 15000,
+    });
+  }
+
+  async tunnelStatus(requestId?: string): Promise<TunnelStatusPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: { type: "tunnel/status" },
+      responseType: "tunnel/status/response",
+      timeout: 10000,
+    });
+  }
+
+  async tunnelStart(requestId?: string): Promise<TunnelStartPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: { type: "tunnel/start" },
+      responseType: "tunnel/start/response",
+      timeout: 45000,
+    });
+  }
+
+  async tunnelStop(requestId?: string): Promise<TunnelStopPayload> {
+    return this.sendCorrelatedSessionRequest({
+      requestId,
+      message: { type: "tunnel/stop" },
+      responseType: "tunnel/stop/response",
+      timeout: 10000,
     });
   }
 

--- a/packages/protocol/src/git-identity/rpc-schemas.ts
+++ b/packages/protocol/src/git-identity/rpc-schemas.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+const RepoGitIdentitySchema = z.object({
+  name: z.string().nullable(),
+  email: z.string().nullable(),
+  local: z.boolean(),
+});
+
+export const GitIdentityGetRequestSchema = z.object({
+  type: z.literal("git-identity/get"),
+  requestId: z.string(),
+  cwd: z.string(),
+});
+
+export const GitIdentitySetRequestSchema = z.object({
+  type: z.literal("git-identity/set"),
+  requestId: z.string(),
+  cwd: z.string(),
+  name: z.string(),
+  email: z.string(),
+});
+
+export const GitIdentityGetResponseSchema = z.object({
+  type: z.literal("git-identity/get/response"),
+  payload: z.object({
+    requestId: z.string(),
+    identity: RepoGitIdentitySchema.nullable(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const GitIdentitySetResponseSchema = z.object({
+  type: z.literal("git-identity/set/response"),
+  payload: z.object({
+    requestId: z.string(),
+    identity: RepoGitIdentitySchema.nullable(),
+    error: z.string().nullable(),
+  }),
+});

--- a/packages/protocol/src/git-identity/types.ts
+++ b/packages/protocol/src/git-identity/types.ts
@@ -1,0 +1,9 @@
+// Shared git-identity types. Single source of truth consumed by the server
+// (git-identity/service) and the app (git-identity-section).
+
+export interface RepoGitIdentity {
+  name: string | null;
+  email: string | null;
+  /** True when the values come from the repo-local config rather than global/inherited. */
+  local: boolean;
+}

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -54,6 +54,28 @@ import {
   LoopStopResponseSchema,
 } from "@getpaseo/protocol/loop/rpc-schemas";
 import {
+  SkillsListRequestSchema,
+  SkillsScanRequestSchema,
+  SkillsInstallRequestSchema,
+  SkillsListResponseSchema,
+  SkillsScanResponseSchema,
+  SkillsInstallResponseSchema,
+} from "@getpaseo/protocol/skills-catalog/rpc-schemas";
+import {
+  GitIdentityGetRequestSchema,
+  GitIdentitySetRequestSchema,
+  GitIdentityGetResponseSchema,
+  GitIdentitySetResponseSchema,
+} from "@getpaseo/protocol/git-identity/rpc-schemas";
+import {
+  TunnelStatusRequestSchema,
+  TunnelStartRequestSchema,
+  TunnelStopRequestSchema,
+  TunnelStatusResponseSchema,
+  TunnelStartResponseSchema,
+  TunnelStopResponseSchema,
+} from "@getpaseo/protocol/tunnel/rpc-schemas";
+import {
   PaseoConfigRawSchema,
   PaseoLifecycleCommandRawSchema,
   PaseoMetadataGenerationEntrySchema,
@@ -1482,6 +1504,7 @@ export const CheckoutCommitRequestSchema = z.object({
   cwd: z.string(),
   message: z.string().optional(),
   addAll: z.boolean().optional(),
+  gitmoji: z.boolean().optional(),
   requestId: z.string(),
 });
 
@@ -2152,6 +2175,14 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   ScheduleDeleteRequestSchema,
   ScheduleRunOnceRequestSchema,
   ScheduleUpdateRequestSchema,
+  SkillsListRequestSchema,
+  SkillsScanRequestSchema,
+  SkillsInstallRequestSchema,
+  GitIdentityGetRequestSchema,
+  GitIdentitySetRequestSchema,
+  TunnelStatusRequestSchema,
+  TunnelStartRequestSchema,
+  TunnelStopRequestSchema,
   LoopRunRequestSchema,
   LoopListRequestSchema,
   LoopInspectRequestSchema,
@@ -2351,6 +2382,12 @@ export const ServerInfoStatusPayloadSchema = z
         daemonSelfUpdate: z.boolean().optional(),
         // COMPAT(agentForkContext): added in v0.1.102, remove gate after 2026-12-28.
         agentForkContext: z.boolean().optional(),
+        // COMPAT(skillsCatalog): OpenChamber skills RPCs (skills/list,scan,install); fork feature.
+        skillsCatalog: z.boolean().optional(),
+        // COMPAT(gitIdentity): OpenChamber per-repo git-identity RPCs (git-identity/get,set); fork feature.
+        gitIdentity: z.boolean().optional(),
+        // COMPAT(tunnel): OpenChamber Cloudflare-tunnel RPCs (tunnel/status,start,stop); fork feature.
+        tunnel: z.boolean().optional(),
       })
       .optional(),
   })
@@ -4283,6 +4320,14 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   ScheduleDeleteResponseSchema,
   ScheduleRunOnceResponseSchema,
   ScheduleUpdateResponseSchema,
+  SkillsListResponseSchema,
+  SkillsScanResponseSchema,
+  SkillsInstallResponseSchema,
+  GitIdentityGetResponseSchema,
+  GitIdentitySetResponseSchema,
+  TunnelStatusResponseSchema,
+  TunnelStartResponseSchema,
+  TunnelStopResponseSchema,
   LoopRunResponseSchema,
   LoopListResponseSchema,
   LoopInspectResponseSchema,

--- a/packages/protocol/src/skills-catalog/rpc-schemas.ts
+++ b/packages/protocol/src/skills-catalog/rpc-schemas.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+const InstalledSkillSchema = z.object({
+  name: z.string(),
+  description: z.string().nullable(),
+  path: z.string(),
+});
+
+const ScannedSkillSchema = z.object({
+  skillDir: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+});
+
+const SkillsCatalogErrorSchema = z.object({
+  kind: z.enum([
+    "invalidSource",
+    "gitUnavailable",
+    "authRequired",
+    "networkError",
+    "conflicts",
+    "unknown",
+  ]),
+  message: z.string(),
+  conflicts: z.array(z.string()).optional(),
+});
+
+const SkippedSkillSchema = z.object({ skillName: z.string(), reason: z.string() });
+
+// --- Requests ---
+
+export const SkillsListRequestSchema = z.object({
+  type: z.literal("skills/list"),
+  requestId: z.string(),
+});
+
+export const SkillsScanRequestSchema = z.object({
+  type: z.literal("skills/scan"),
+  requestId: z.string(),
+  source: z.string(),
+  subpath: z.string().optional(),
+});
+
+export const SkillsInstallRequestSchema = z.object({
+  type: z.literal("skills/install"),
+  requestId: z.string(),
+  source: z.string(),
+  subpath: z.string().optional(),
+  skillDirs: z.array(z.string()),
+  overwrite: z.boolean().optional(),
+});
+
+// --- Responses ---
+
+export const SkillsListResponseSchema = z.object({
+  type: z.literal("skills/list/response"),
+  payload: z.object({
+    requestId: z.string(),
+    skills: z.array(InstalledSkillSchema),
+    error: z.string().nullable(),
+  }),
+});
+
+export const SkillsScanResponseSchema = z.object({
+  type: z.literal("skills/scan/response"),
+  payload: z.object({
+    requestId: z.string(),
+    skills: z.array(ScannedSkillSchema),
+    error: SkillsCatalogErrorSchema.nullable(),
+  }),
+});
+
+export const SkillsInstallResponseSchema = z.object({
+  type: z.literal("skills/install/response"),
+  payload: z.object({
+    requestId: z.string(),
+    installed: z.array(z.string()),
+    skipped: z.array(SkippedSkillSchema),
+    error: SkillsCatalogErrorSchema.nullable(),
+  }),
+});

--- a/packages/protocol/src/skills-catalog/types.ts
+++ b/packages/protocol/src/skills-catalog/types.ts
@@ -1,0 +1,29 @@
+// Shared skills-catalog types. Single source of truth consumed by the server
+// (skills-dir/repo) and the app (use-skills). Kept in the protocol package so the
+// app does not deep-import server internals.
+
+export interface InstalledSkill {
+  name: string;
+  description: string | null;
+  path: string;
+}
+
+export interface ScannedSkill {
+  skillDir: string;
+  name: string;
+  description: string | null;
+}
+
+export type SkillsCatalogErrorKind =
+  | "invalidSource"
+  | "gitUnavailable"
+  | "authRequired"
+  | "networkError"
+  | "conflicts"
+  | "unknown";
+
+export interface SkillsCatalogError {
+  kind: SkillsCatalogErrorKind;
+  message: string;
+  conflicts?: string[];
+}

--- a/packages/protocol/src/tunnel/rpc-schemas.ts
+++ b/packages/protocol/src/tunnel/rpc-schemas.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+const TunnelStatusSchema = z.object({
+  state: z.enum(["stopped", "starting", "running", "error"]),
+  url: z.string().nullable(),
+  error: z.string().nullable(),
+  port: z.number().nullable(),
+});
+
+export const TunnelStatusRequestSchema = z.object({
+  type: z.literal("tunnel/status"),
+  requestId: z.string(),
+});
+
+export const TunnelStartRequestSchema = z.object({
+  type: z.literal("tunnel/start"),
+  requestId: z.string(),
+});
+
+export const TunnelStopRequestSchema = z.object({
+  type: z.literal("tunnel/stop"),
+  requestId: z.string(),
+});
+
+export const TunnelStatusResponseSchema = z.object({
+  type: z.literal("tunnel/status/response"),
+  payload: z.object({
+    requestId: z.string(),
+    status: TunnelStatusSchema.nullable(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const TunnelStartResponseSchema = z.object({
+  type: z.literal("tunnel/start/response"),
+  payload: z.object({
+    requestId: z.string(),
+    status: TunnelStatusSchema.nullable(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const TunnelStopResponseSchema = z.object({
+  type: z.literal("tunnel/stop/response"),
+  payload: z.object({
+    requestId: z.string(),
+    status: TunnelStatusSchema.nullable(),
+    error: z.string().nullable(),
+  }),
+});

--- a/packages/protocol/src/tunnel/types.ts
+++ b/packages/protocol/src/tunnel/types.ts
@@ -1,0 +1,11 @@
+// Shared tunnel types. Single source of truth consumed by the server
+// (tunnel/cloudflare-tunnel) and the app (tunnel-section).
+
+export type TunnelState = "stopped" | "starting" | "running" | "error";
+
+export interface TunnelStatus {
+  state: TunnelState;
+  url: string | null;
+  error: string | null;
+  port: number | null;
+}

--- a/packages/server/src/server/git-identity/service.ts
+++ b/packages/server/src/server/git-identity/service.ts
@@ -1,0 +1,56 @@
+// Per-repository git identity (user.name / user.email). Ported concept from
+// openchamber/openchamber (MIT): packages/web/server/lib/git/identity-storage.js.
+// Paseo stores named profiles client-side; the server only reads/writes the repo-local git config.
+import { execCommand } from "../../utils/spawn.js";
+
+import type { RepoGitIdentity } from "@getpaseo/protocol/git-identity/types";
+
+export type { RepoGitIdentity };
+
+async function readGitConfig(
+  cwd: string,
+  key: string,
+  scope: "local" | null,
+): Promise<string | null> {
+  const args = scope === "local" ? ["config", "--local", key] : ["config", key];
+  try {
+    const { stdout } = await execCommand("git", args, { cwd, timeout: 10_000 });
+    const value = stdout.trim();
+    return value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export class GitIdentityService {
+  async get(cwd: string): Promise<RepoGitIdentity> {
+    const [localName, localEmail] = await Promise.all([
+      readGitConfig(cwd, "user.name", "local"),
+      readGitConfig(cwd, "user.email", "local"),
+    ]);
+    if (localName || localEmail) {
+      return { name: localName, email: localEmail, local: true };
+    }
+    const [name, email] = await Promise.all([
+      readGitConfig(cwd, "user.name", null),
+      readGitConfig(cwd, "user.email", null),
+    ]);
+    return { name, email, local: false };
+  }
+
+  async set(cwd: string, name: string, email: string): Promise<void> {
+    const trimmedName = name.trim();
+    const trimmedEmail = email.trim();
+    if (!trimmedName || !trimmedEmail) {
+      throw new Error("Both name and email are required");
+    }
+    await execCommand("git", ["config", "--local", "user.name", trimmedName], {
+      cwd,
+      timeout: 10_000,
+    });
+    await execCommand("git", ["config", "--local", "user.email", trimmedEmail], {
+      cwd,
+      timeout: 10_000,
+    });
+  }
+}

--- a/packages/server/src/server/git/gitmoji.test.ts
+++ b/packages/server/src/server/git/gitmoji.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { applyGitmoji, gitmojiForType } from "./gitmoji.js";
+
+describe("gitmojiForType", () => {
+  it("maps known conventional types", () => {
+    expect(gitmojiForType("feat")).toBe("✨");
+    expect(gitmojiForType("fix")).toBe("🐛");
+    expect(gitmojiForType("FEAT")).toBe("✨");
+  });
+
+  it("returns null for unknown types", () => {
+    expect(gitmojiForType("bogus")).toBeNull();
+  });
+});
+
+describe("applyGitmoji", () => {
+  it("prefixes a conventional commit subject", () => {
+    expect(applyGitmoji("feat: add thing")).toBe("✨ feat: add thing");
+    expect(applyGitmoji("fix(parser): handle eof")).toBe("🐛 fix(parser): handle eof");
+  });
+
+  it("handles breaking-change marker", () => {
+    expect(applyGitmoji("feat!: drop v1")).toBe("✨ feat!: drop v1");
+  });
+
+  it("preserves the body across newlines", () => {
+    expect(applyGitmoji("feat: x\n\nbody line")).toBe("✨ feat: x\n\nbody line");
+  });
+
+  it("does not double-prefix when an emoji is already present", () => {
+    expect(applyGitmoji("✨ feat: add thing")).toBe("✨ feat: add thing");
+  });
+
+  it("leaves non-conventional messages unchanged", () => {
+    expect(applyGitmoji("update files")).toBe("update files");
+    expect(applyGitmoji("")).toBe("");
+  });
+
+  it("leaves unmapped types unchanged", () => {
+    expect(applyGitmoji("frobnicate: stuff")).toBe("frobnicate: stuff");
+  });
+});

--- a/packages/server/src/server/git/gitmoji.ts
+++ b/packages/server/src/server/git/gitmoji.ts
@@ -1,0 +1,65 @@
+// Ported concept from openchamber/openchamber (MIT): GitView KEYWORD_MAP.
+// Maps a Conventional Commit type to its gitmoji (https://gitmoji.dev) and prefixes a generated
+// commit message's subject line with the matching emoji.
+const KEYWORD_MAP: Record<string, string> = {
+  feat: "✨",
+  feature: "✨",
+  fix: "🐛",
+  hotfix: "🚑️",
+  docs: "📝",
+  doc: "📝",
+  style: "🎨",
+  refactor: "♻️",
+  perf: "⚡️",
+  test: "✅",
+  tests: "✅",
+  build: "📦️",
+  ci: "👷",
+  chore: "🔧",
+  revert: "⏪️",
+  init: "🎉",
+  security: "🔒️",
+  deps: "⬆️",
+  wip: "🚧",
+  remove: "🔥",
+  config: "🔧",
+};
+
+// type or type(scope), optional `!` for breaking changes, then `: subject`.
+const CONVENTIONAL_PREFIX = /^([a-z]+)(?:\([^)]*\))?(!)?:\s/i;
+
+// Detects a leading emoji (so we never double-prefix). Covers the gitmoji ranges plus VS-16.
+const LEADING_EMOJI = /^(?:\p{Extended_Pictographic}|\p{Emoji_Presentation})/u;
+
+/**
+ * Returns the gitmoji for a Conventional Commit `type`, or null when unmapped.
+ */
+export function gitmojiForType(type: string): string | null {
+  return KEYWORD_MAP[type.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * Prefixes a commit message's first line with the gitmoji matching its Conventional Commit type.
+ * Returns the message unchanged when there is no recognized type or it already starts with an emoji.
+ */
+export function applyGitmoji(message: string): string {
+  if (!message) {
+    return message;
+  }
+  const newlineIndex = message.indexOf("\n");
+  const subject = newlineIndex === -1 ? message : message.slice(0, newlineIndex);
+  const rest = newlineIndex === -1 ? "" : message.slice(newlineIndex);
+
+  if (LEADING_EMOJI.test(subject.trimStart())) {
+    return message;
+  }
+  const match = subject.match(CONVENTIONAL_PREFIX);
+  if (!match) {
+    return message;
+  }
+  const emoji = gitmojiForType(match[1]);
+  if (!emoji) {
+    return message;
+  }
+  return `${emoji} ${subject}${rest}`;
+}

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -184,6 +184,9 @@ import { LoopService } from "./loop-service.js";
 import { ScheduleService } from "./schedule/service.js";
 import { createGitHubService, type GitHubService } from "../services/github-service.js";
 import type { ProviderUsageService } from "../services/quota-fetcher/service.js";
+import { SkillsCatalogService } from "./skills-catalog/service.js";
+import { GitIdentityService } from "./git-identity/service.js";
+import { TunnelService } from "./tunnel/service.js";
 import {
   summarizeFetchWorkspacesEntries,
   workspaceIdsOnCheckout,
@@ -439,6 +442,9 @@ export interface SessionOptions {
   terminalManager: TerminalManager | null;
   providerSnapshotManager: ProviderSnapshotManager;
   providerUsageService: ProviderUsageService;
+  skillsCatalogService: SkillsCatalogService;
+  gitIdentityService: GitIdentityService;
+  tunnelService: TunnelService;
   serviceProxy?: ServiceProxySubsystem;
   scriptRuntimeStore?: WorkspaceScriptRuntimeStore;
   workspaceSetupSnapshots?: Map<string, WorkspaceSetupSnapshot>;
@@ -547,6 +553,9 @@ export class Session {
   private readonly projectRegistry: ProjectRegistry;
   private readonly workspaceRegistry: WorkspaceRegistry;
   private readonly filesystem: SessionFileSystem;
+  private readonly skillsCatalogService: SkillsCatalogService;
+  private readonly gitIdentityService: GitIdentityService;
+  private readonly tunnelService: TunnelService;
   private readonly github: GitHubService;
   private readonly renameCurrentBranch: typeof renameCurrentBranchDefault;
   private readonly generateWorkspaceName: typeof generateBranchNameFromFirstAgentContext;
@@ -626,6 +635,9 @@ export class Session {
       terminalManager,
       providerSnapshotManager,
       providerUsageService,
+      skillsCatalogService,
+      gitIdentityService,
+      tunnelService,
       serviceProxy,
       scriptRuntimeStore,
       workspaceSetupSnapshots,
@@ -673,6 +685,9 @@ export class Session {
     this.projectRegistry = projectRegistry;
     this.workspaceRegistry = workspaceRegistry;
     this.filesystem = filesystem ?? nodeSessionFileSystem;
+    this.skillsCatalogService = skillsCatalogService;
+    this.gitIdentityService = gitIdentityService;
+    this.tunnelService = tunnelService;
     this.github = github ?? createGitHubService();
     this.renameCurrentBranch = renameCurrentBranch ?? renameCurrentBranchDefault;
     this.generateWorkspaceName = generateWorkspaceName ?? generateBranchNameFromFirstAgentContext;
@@ -1372,6 +1387,9 @@ export class Session {
       this.dispatchProviderMessage(msg) ??
       this.dispatchTerminalMessage(msg) ??
       this.dispatchChatScheduleLoopMessage(msg) ??
+      this.dispatchSkillsMessage(msg) ??
+      this.dispatchGitIdentityMessage(msg) ??
+      this.dispatchTunnelMessage(msg) ??
       this.dispatchMiscMessage(msg);
     if (promise) await promise;
   }
@@ -1722,6 +1740,223 @@ export class Session {
       default:
         return undefined;
     }
+  }
+
+  private dispatchSkillsMessage(msg: SessionInboundMessage): Promise<void> | undefined {
+    switch (msg.type) {
+      case "skills/list":
+        return this.handleSkillsListRequest(msg);
+      case "skills/scan":
+        return this.handleSkillsScanRequest(msg);
+      case "skills/install":
+        return this.handleSkillsInstallRequest(msg);
+      default:
+        return undefined;
+    }
+  }
+
+  private dispatchGitIdentityMessage(msg: SessionInboundMessage): Promise<void> | undefined {
+    switch (msg.type) {
+      case "git-identity/get":
+        return this.handleGitIdentityGetRequest(msg);
+      case "git-identity/set":
+        return this.handleGitIdentitySetRequest(msg);
+      default:
+        return undefined;
+    }
+  }
+
+  private dispatchTunnelMessage(msg: SessionInboundMessage): Promise<void> | undefined {
+    switch (msg.type) {
+      case "tunnel/status":
+        return this.handleTunnelStatusRequest(msg);
+      case "tunnel/start":
+        return this.handleTunnelStartRequest(msg);
+      case "tunnel/stop":
+        return this.handleTunnelStopRequest(msg);
+      default:
+        return undefined;
+    }
+  }
+
+  private async handleSkillsListRequest(
+    request: Extract<SessionInboundMessage, { type: "skills/list" }>,
+  ): Promise<void> {
+    try {
+      const skills = await this.skillsCatalogService.listInstalled();
+      this.emit({
+        type: "skills/list/response",
+        payload: { requestId: request.requestId, skills, error: null },
+      });
+    } catch (error) {
+      this.emit({
+        type: "skills/list/response",
+        payload: {
+          requestId: request.requestId,
+          skills: [],
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+
+  private async handleSkillsScanRequest(
+    request: Extract<SessionInboundMessage, { type: "skills/scan" }>,
+  ): Promise<void> {
+    try {
+      const result = await this.skillsCatalogService.scan(request.source, request.subpath);
+      this.emit({
+        type: "skills/scan/response",
+        payload: {
+          requestId: request.requestId,
+          skills: result.ok ? result.skills : [],
+          error: result.ok ? null : result.error,
+        },
+      });
+    } catch (error) {
+      this.emit({
+        type: "skills/scan/response",
+        payload: {
+          requestId: request.requestId,
+          skills: [],
+          error: {
+            kind: "unknown",
+            message: error instanceof Error ? error.message : String(error),
+          },
+        },
+      });
+    }
+  }
+
+  private async handleSkillsInstallRequest(
+    request: Extract<SessionInboundMessage, { type: "skills/install" }>,
+  ): Promise<void> {
+    try {
+      const result = await this.skillsCatalogService.install({
+        source: request.source,
+        subpath: request.subpath,
+        skillDirs: request.skillDirs,
+        overwrite: request.overwrite,
+      });
+      this.emit({
+        type: "skills/install/response",
+        payload: {
+          requestId: request.requestId,
+          installed: result.ok ? result.installed : [],
+          skipped: result.ok ? result.skipped : [],
+          error: result.ok ? null : result.error,
+        },
+      });
+    } catch (error) {
+      this.emit({
+        type: "skills/install/response",
+        payload: {
+          requestId: request.requestId,
+          installed: [],
+          skipped: [],
+          error: {
+            kind: "unknown",
+            message: error instanceof Error ? error.message : String(error),
+          },
+        },
+      });
+    }
+  }
+
+  private async handleGitIdentityGetRequest(
+    request: Extract<SessionInboundMessage, { type: "git-identity/get" }>,
+  ): Promise<void> {
+    try {
+      const identity = await this.gitIdentityService.get(request.cwd);
+      this.emit({
+        type: "git-identity/get/response",
+        payload: { requestId: request.requestId, identity, error: null },
+      });
+    } catch (error) {
+      this.emit({
+        type: "git-identity/get/response",
+        payload: {
+          requestId: request.requestId,
+          identity: null,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+
+  private async handleGitIdentitySetRequest(
+    request: Extract<SessionInboundMessage, { type: "git-identity/set" }>,
+  ): Promise<void> {
+    try {
+      await this.gitIdentityService.set(request.cwd, request.name, request.email);
+      const identity = await this.gitIdentityService.get(request.cwd);
+      this.emit({
+        type: "git-identity/set/response",
+        payload: { requestId: request.requestId, identity, error: null },
+      });
+    } catch (error) {
+      this.emit({
+        type: "git-identity/set/response",
+        payload: {
+          requestId: request.requestId,
+          identity: null,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+
+  private handleTunnelStatusRequest(
+    request: Extract<SessionInboundMessage, { type: "tunnel/status" }>,
+  ): Promise<void> {
+    this.emit({
+      type: "tunnel/status/response",
+      payload: { requestId: request.requestId, status: this.tunnelService.status(), error: null },
+    });
+    return Promise.resolve();
+  }
+
+  private async handleTunnelStartRequest(
+    request: Extract<SessionInboundMessage, { type: "tunnel/start" }>,
+  ): Promise<void> {
+    try {
+      const port = this.getDaemonTcpPort?.() ?? null;
+      if (port === null) {
+        this.emit({
+          type: "tunnel/start/response",
+          payload: {
+            requestId: request.requestId,
+            status: this.tunnelService.status(),
+            error: "This host has no local TCP port to expose.",
+          },
+        });
+        return;
+      }
+      const status = await this.tunnelService.start(port);
+      this.emit({
+        type: "tunnel/start/response",
+        payload: { requestId: request.requestId, status, error: null },
+      });
+    } catch (error) {
+      this.emit({
+        type: "tunnel/start/response",
+        payload: {
+          requestId: request.requestId,
+          status: this.tunnelService.status(),
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+
+  private handleTunnelStopRequest(
+    request: Extract<SessionInboundMessage, { type: "tunnel/stop" }>,
+  ): Promise<void> {
+    this.emit({
+      type: "tunnel/stop/response",
+      payload: { requestId: request.requestId, status: this.tunnelService.stop(), error: null },
+    });
+    return Promise.resolve();
   }
 
   private async dispatchMiscMessage(msg: SessionInboundMessage): Promise<void> {

--- a/packages/server/src/server/skills-catalog/frontmatter.ts
+++ b/packages/server/src/server/skills-catalog/frontmatter.ts
@@ -1,0 +1,44 @@
+// Minimal SKILL.md frontmatter reader. Skills use a leading `---` YAML block with at least
+// `name` and `description`; we only need those two scalar fields, so a dependency-free line parser
+// is sufficient (avoids pulling a YAML lib into the server bundle).
+export interface SkillFrontmatter {
+  name: string | null;
+  description: string | null;
+}
+
+function stripQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function parseSkillFrontmatter(content: string): SkillFrontmatter {
+  const result: SkillFrontmatter = { name: null, description: null };
+  if (!content.startsWith("---")) {
+    return result;
+  }
+  const end = content.indexOf("\n---", 3);
+  if (end === -1) {
+    return result;
+  }
+  const block = content.slice(3, end);
+  for (const line of block.split("\n")) {
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex === -1) {
+      continue;
+    }
+    const key = line.slice(0, separatorIndex).trim();
+    const value = stripQuotes(line.slice(separatorIndex + 1));
+    if (key === "name" && value) {
+      result.name = value;
+    } else if (key === "description" && value) {
+      result.description = value;
+    }
+  }
+  return result;
+}

--- a/packages/server/src/server/skills-catalog/repo.ts
+++ b/packages/server/src/server/skills-catalog/repo.ts
@@ -1,0 +1,309 @@
+// Ported/adapted from openchamber/openchamber (MIT): packages/web/server/lib/skills-catalog/{git.js,install.js}
+// Scoped to OMP/pi user skills (no project/targetSource matrix). Git runs via Paseo's execCommand.
+import { existsSync } from "node:fs";
+import {
+  copyFile,
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { execCommand } from "../../utils/spawn.js";
+import { parseSkillFrontmatter } from "./frontmatter.js";
+import { parseSkillRepoSource } from "./source.js";
+
+const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+import type {
+  ScannedSkill,
+  SkillsCatalogErrorKind,
+  SkillsCatalogError,
+} from "@getpaseo/protocol/skills-catalog/types";
+
+export type { ScannedSkill, SkillsCatalogErrorKind, SkillsCatalogError };
+
+interface GitResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+async function runGit(args: string[], timeoutMs: number): Promise<GitResult> {
+  try {
+    const { stdout, stderr } = await execCommand("git", args, { timeout: timeoutMs });
+    return { ok: true, stdout, stderr };
+  } catch (error) {
+    const stderr =
+      error && typeof error === "object" && "stderr" in error ? String(error.stderr) : "";
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, stdout: "", stderr: stderr || message };
+  }
+}
+
+async function assertGitAvailable(): Promise<boolean> {
+  const result = await runGit(["--version"], 5_000);
+  return result.ok;
+}
+
+function looksLikeAuthError(message: string): boolean {
+  return /authentication|could not read username|permission denied|access denied|fatal: repository .* not found/i.test(
+    message,
+  );
+}
+
+function validateSkillName(skillName: string): boolean {
+  if (skillName.length < 1 || skillName.length > 64) {
+    return false;
+  }
+  return SKILL_NAME_PATTERN.test(skillName);
+}
+
+async function safeRm(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+}
+
+async function copyDirectoryNoSymlinks(srcDir: string, dstDir: string): Promise<void> {
+  const srcReal = await realpath(srcDir);
+  await mkdir(dstDir, { recursive: true });
+  const walk = async (currentSrc: string, currentDst: string): Promise<void> => {
+    const entries = await readdir(currentSrc, { withFileTypes: true });
+    for (const entry of entries) {
+      const nextSrc = join(currentSrc, entry.name);
+      const nextDst = join(currentDst, entry.name);
+      const stat = await lstat(nextSrc);
+      if (stat.isSymbolicLink()) {
+        throw new Error("Symlinks are not supported in skills");
+      }
+      const nextRealParent = await realpath(dirname(nextSrc));
+      if (!nextRealParent.startsWith(srcReal)) {
+        throw new Error("Invalid source path traversal detected");
+      }
+      if (stat.isDirectory()) {
+        await mkdir(nextDst, { recursive: true });
+        await walk(nextSrc, nextDst);
+      } else if (stat.isFile()) {
+        await mkdir(dirname(nextDst), { recursive: true });
+        await copyFile(nextSrc, nextDst);
+        await chmod(nextDst, stat.mode & 0o777).catch(() => undefined);
+      }
+    }
+  };
+  await walk(srcDir, dstDir);
+}
+
+async function cloneNoCheckout(cloneUrl: string, tempDir: string): Promise<GitResult> {
+  const preferred = await runGit(
+    ["clone", "--depth", "1", "--filter=blob:none", "--no-checkout", cloneUrl, tempDir],
+    90_000,
+  );
+  if (preferred.ok) {
+    return preferred;
+  }
+  return runGit(["clone", "--depth", "1", "--no-checkout", cloneUrl, tempDir], 90_000);
+}
+
+/** Lists installable skills (directories containing SKILL.md) in a repository. */
+export async function scanRepository(
+  source: string,
+  subpath?: string,
+): Promise<{ ok: true; skills: ScannedSkill[] } | { ok: false; error: SkillsCatalogError }> {
+  if (!(await assertGitAvailable())) {
+    return { ok: false, error: { kind: "gitUnavailable", message: "git is not available" } };
+  }
+  const parsed = parseSkillRepoSource(source, { subpath });
+  if (!parsed.ok) {
+    return { ok: false, error: parsed.error };
+  }
+  const tempBase = await mkdtemp(join(tmpdir(), "paseo-skills-scan-"));
+  try {
+    const cloned = await cloneNoCheckout(parsed.cloneUrlHttps, tempBase);
+    if (!cloned.ok) {
+      const message = cloned.stderr.trim() || "Failed to clone repository";
+      const kind: SkillsCatalogErrorKind = looksLikeAuthError(message)
+        ? "authRequired"
+        : "networkError";
+      return { ok: false, error: { kind, message } };
+    }
+    const tree = await runGit(["-C", tempBase, "ls-tree", "-r", "HEAD", "--name-only"], 30_000);
+    if (!tree.ok) {
+      return {
+        ok: false,
+        error: { kind: "unknown", message: tree.stderr || "Failed to read repository tree" },
+      };
+    }
+    const prefix = parsed.effectiveSubpath ? `${parsed.effectiveSubpath.replace(/\/$/, "")}/` : "";
+    const skillDirs: string[] = [];
+    for (const line of tree.stdout.split("\n")) {
+      const path = line.trim();
+      if (!path.endsWith("SKILL.md")) {
+        continue;
+      }
+      if (prefix && !path.startsWith(prefix)) {
+        continue;
+      }
+      const skillDir = path.slice(0, -"/SKILL.md".length);
+      if (skillDir) {
+        skillDirs.push(skillDir);
+      }
+    }
+    if (skillDirs.length === 0) {
+      return { ok: true, skills: [] };
+    }
+    // Sparse-checkout the SKILL.md files to read names/descriptions.
+    await runGit(["-C", tempBase, "sparse-checkout", "init", "--no-cone"], 15_000);
+    await runGit(
+      ["-C", tempBase, "sparse-checkout", "set", ...skillDirs.map((dir) => `${dir}/SKILL.md`)],
+      30_000,
+    );
+    await runGit(["-C", tempBase, "checkout", "--force", "HEAD"], 60_000);
+    const skills: ScannedSkill[] = [];
+    for (const skillDir of skillDirs) {
+      const name = basename(skillDir);
+      let description: string | null = null;
+      const skillMdPath = join(tempBase, ...skillDir.split("/"), "SKILL.md");
+      if (existsSync(skillMdPath)) {
+        const frontmatter = parseSkillFrontmatter(
+          await readFile(skillMdPath, "utf8").catch(() => ""),
+        );
+        description = frontmatter.description;
+      }
+      skills.push({ skillDir, name, description });
+    }
+    return { ok: true, skills };
+  } finally {
+    await safeRm(tempBase);
+  }
+}
+
+interface InstallPlan {
+  skillDir: string;
+  skillName: string;
+  installable: boolean;
+}
+
+async function copyPlansToSkillsDir(
+  plans: InstallPlan[],
+  tempBase: string,
+  userSkillsDir: string,
+): Promise<{ installed: string[]; skipped: { skillName: string; reason: string }[] }> {
+  const installed: string[] = [];
+  const skipped: { skillName: string; reason: string }[] = [];
+  for (const plan of plans) {
+    if (!plan.installable) {
+      skipped.push({ skillName: plan.skillName, reason: "Invalid skill name" });
+      continue;
+    }
+    const srcDir = join(tempBase, ...plan.skillDir.split("/"));
+    if (!existsSync(join(srcDir, "SKILL.md"))) {
+      skipped.push({ skillName: plan.skillName, reason: "SKILL.md not found" });
+      continue;
+    }
+    const targetDir = join(userSkillsDir, plan.skillName);
+    if (existsSync(targetDir)) {
+      await safeRm(targetDir);
+    }
+    await mkdir(dirname(targetDir), { recursive: true });
+    try {
+      await copyDirectoryNoSymlinks(srcDir, targetDir);
+      installed.push(plan.skillName);
+    } catch (error) {
+      await safeRm(targetDir);
+      skipped.push({
+        skillName: plan.skillName,
+        reason: error instanceof Error ? error.message : "Failed to copy skill files",
+      });
+    }
+  }
+  return { installed, skipped };
+}
+
+/** Installs the selected skill directories from a repository into the user (pi) skills dir. */
+export async function installSkillsFromRepository(input: {
+  source: string;
+  subpath?: string;
+  skillDirs: string[];
+  userSkillsDir: string;
+  overwrite?: boolean;
+}): Promise<
+  | { ok: true; installed: string[]; skipped: { skillName: string; reason: string }[] }
+  | { ok: false; error: SkillsCatalogError }
+> {
+  if (!(await assertGitAvailable())) {
+    return { ok: false, error: { kind: "gitUnavailable", message: "git is not available" } };
+  }
+  const parsed = parseSkillRepoSource(input.source, { subpath: input.subpath });
+  if (!parsed.ok) {
+    return { ok: false, error: parsed.error };
+  }
+  const requestedDirs = input.skillDirs.map((dir) => dir.trim()).filter(Boolean);
+  if (requestedDirs.length === 0) {
+    return {
+      ok: false,
+      error: { kind: "invalidSource", message: "No skills selected for installation" },
+    };
+  }
+  const plans = requestedDirs.map((skillDir) => ({
+    skillDir,
+    skillName: basename(skillDir),
+    installable: validateSkillName(basename(skillDir)),
+  }));
+
+  const conflicts: string[] = [];
+  if (!input.overwrite) {
+    for (const plan of plans) {
+      if (plan.installable && existsSync(join(input.userSkillsDir, plan.skillName))) {
+        conflicts.push(plan.skillName);
+      }
+    }
+    if (conflicts.length > 0) {
+      return {
+        ok: false,
+        error: { kind: "conflicts", message: "Some skills already exist", conflicts },
+      };
+    }
+  }
+
+  const tempBase = await mkdtemp(join(tmpdir(), "paseo-skills-install-"));
+  try {
+    const cloned = await cloneNoCheckout(parsed.cloneUrlHttps, tempBase);
+    if (!cloned.ok) {
+      const message = cloned.stderr.trim() || "Failed to clone repository";
+      const kind: SkillsCatalogErrorKind = looksLikeAuthError(message)
+        ? "authRequired"
+        : "networkError";
+      return { ok: false, error: { kind, message } };
+    }
+    await runGit(["-C", tempBase, "sparse-checkout", "init", "--cone"], 15_000);
+    const setResult = await runGit(
+      ["-C", tempBase, "sparse-checkout", "set", ...requestedDirs],
+      30_000,
+    );
+    if (!setResult.ok) {
+      return {
+        ok: false,
+        error: {
+          kind: "unknown",
+          message: setResult.stderr || "Failed to configure sparse checkout",
+        },
+      };
+    }
+    const checkout = await runGit(["-C", tempBase, "checkout", "--force", "HEAD"], 60_000);
+    if (!checkout.ok) {
+      return {
+        ok: false,
+        error: { kind: "unknown", message: checkout.stderr || "Failed to checkout repository" },
+      };
+    }
+
+    const outcome = await copyPlansToSkillsDir(plans, tempBase, input.userSkillsDir);
+    return { ok: true, installed: outcome.installed, skipped: outcome.skipped };
+  } finally {
+    await safeRm(tempBase);
+  }
+}

--- a/packages/server/src/server/skills-catalog/service.ts
+++ b/packages/server/src/server/skills-catalog/service.ts
@@ -1,0 +1,41 @@
+import { getUserSkillsDir, listInstalledSkills, type InstalledSkill } from "./skills-dir.js";
+import {
+  installSkillsFromRepository,
+  scanRepository,
+  type ScannedSkill,
+  type SkillsCatalogError,
+} from "./repo.js";
+
+export type ScanResult =
+  | { ok: true; skills: ScannedSkill[] }
+  | { ok: false; error: SkillsCatalogError };
+
+export type InstallResult =
+  | { ok: true; installed: string[]; skipped: { skillName: string; reason: string }[] }
+  | { ok: false; error: SkillsCatalogError };
+
+/** Stateless wrapper over the skills-catalog operations, injected into Session like other services. */
+export class SkillsCatalogService {
+  listInstalled(): Promise<InstalledSkill[]> {
+    return listInstalledSkills();
+  }
+
+  scan(source: string, subpath?: string): Promise<ScanResult> {
+    return scanRepository(source, subpath);
+  }
+
+  install(input: {
+    source: string;
+    subpath?: string;
+    skillDirs: string[];
+    overwrite?: boolean;
+  }): Promise<InstallResult> {
+    return installSkillsFromRepository({
+      source: input.source,
+      subpath: input.subpath,
+      skillDirs: input.skillDirs,
+      userSkillsDir: getUserSkillsDir(),
+      overwrite: input.overwrite,
+    });
+  }
+}

--- a/packages/server/src/server/skills-catalog/skills-catalog.test.ts
+++ b/packages/server/src/server/skills-catalog/skills-catalog.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { parseSkillRepoSource } from "./source.js";
+import { parseSkillFrontmatter } from "./frontmatter.js";
+
+describe("parseSkillRepoSource", () => {
+  it("parses owner/repo shorthand", () => {
+    const result = parseSkillRepoSource("anthropics/skills");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.owner).toBe("anthropics");
+      expect(result.repo).toBe("skills");
+      expect(result.host).toBe("github.com");
+      expect(result.cloneUrlHttps).toBe("https://github.com/anthropics/skills.git");
+      expect(result.effectiveSubpath).toBeNull();
+    }
+  });
+
+  it("parses shorthand with subpath", () => {
+    const result = parseSkillRepoSource("anthropics/skills/document-skills");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.normalizedRepo).toBe("anthropics/skills");
+      expect(result.effectiveSubpath).toBe("document-skills");
+    }
+  });
+
+  it("parses https URLs and strips .git", () => {
+    const result = parseSkillRepoSource("https://github.com/owner/repo.git");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.owner).toBe("owner");
+      expect(result.repo).toBe("repo");
+    }
+  });
+
+  it("parses ssh URLs", () => {
+    const result = parseSkillRepoSource("git@github.com:owner/repo.git");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.cloneUrlSsh).toBe("git@github.com:owner/repo.git");
+    }
+  });
+
+  it("prefers explicit subpath option over shorthand subpath", () => {
+    const result = parseSkillRepoSource("owner/repo/from-shorthand", { subpath: "from-option" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.effectiveSubpath).toBe("from-option");
+    }
+  });
+
+  it("rejects empty and malformed sources", () => {
+    expect(parseSkillRepoSource("").ok).toBe(false);
+    expect(parseSkillRepoSource("notarepo").ok).toBe(false);
+  });
+});
+
+describe("parseSkillFrontmatter", () => {
+  it("extracts name and description from a YAML block", () => {
+    const content = ["---", "name: pdf-tools", "description: Work with PDFs", "---", "# Body"].join(
+      "\n",
+    );
+    const result = parseSkillFrontmatter(content);
+    expect(result.name).toBe("pdf-tools");
+    expect(result.description).toBe("Work with PDFs");
+  });
+
+  it("strips surrounding quotes", () => {
+    const content = ["---", 'name: "quoted"', "description: 'single'", "---"].join("\n");
+    const result = parseSkillFrontmatter(content);
+    expect(result.name).toBe("quoted");
+    expect(result.description).toBe("single");
+  });
+
+  it("returns nulls when there is no frontmatter", () => {
+    const result = parseSkillFrontmatter("# Just a heading\n");
+    expect(result.name).toBeNull();
+    expect(result.description).toBeNull();
+  });
+});

--- a/packages/server/src/server/skills-catalog/skills-dir.ts
+++ b/packages/server/src/server/skills-catalog/skills-dir.ts
@@ -1,0 +1,47 @@
+// Resolves the OMP/pi user skills directory and lists installed skills.
+// pi looks for skills at ~/.pi/agent/skills (commonly symlinked to ~/.agents/skills).
+import { existsSync, readFileSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parseSkillFrontmatter } from "./frontmatter.js";
+
+import type { InstalledSkill } from "@getpaseo/protocol/skills-catalog/types";
+
+export type { InstalledSkill };
+
+export function getUserSkillsDir(): string {
+  return join(homedir(), ".pi", "agent", "skills");
+}
+
+export async function listInstalledSkills(): Promise<InstalledSkill[]> {
+  const skillsDir = getUserSkillsDir();
+  if (!existsSync(skillsDir)) {
+    return [];
+  }
+  const entries = await readdir(skillsDir, { withFileTypes: true }).catch(() => []);
+  const skills: InstalledSkill[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+      continue;
+    }
+    const skillPath = join(skillsDir, entry.name);
+    const skillMdPath = join(skillPath, "SKILL.md");
+    if (!existsSync(skillMdPath)) {
+      continue;
+    }
+    let description: string | null = null;
+    let name = entry.name;
+    try {
+      const frontmatter = parseSkillFrontmatter(readFileSync(skillMdPath, "utf8"));
+      description = frontmatter.description;
+      if (frontmatter.name) {
+        name = frontmatter.name;
+      }
+    } catch {
+      // Keep directory-derived name when frontmatter is unreadable.
+    }
+    skills.push({ name, description, path: skillPath });
+  }
+  return skills.sort((left, right) => left.name.localeCompare(right.name));
+}

--- a/packages/server/src/server/skills-catalog/source.ts
+++ b/packages/server/src/server/skills-catalog/source.ts
@@ -1,0 +1,114 @@
+// Ported from openchamber/openchamber (MIT): packages/web/server/lib/skills-catalog/source.js
+const GITHUB_HOST = "github.com";
+
+export interface ParsedSkillRepoSource {
+  host: string;
+  owner: string;
+  repo: string;
+  cloneUrlSsh: string;
+  cloneUrlHttps: string;
+  effectiveSubpath: string | null;
+  normalizedRepo: string;
+}
+
+export type ParseSkillRepoResult =
+  | ({ ok: true } & ParsedSkillRepoSource)
+  | { ok: false; error: { kind: "invalidSource"; message: string } };
+
+function normalizeGitOwnerRepo(
+  owner: string,
+  repo: string,
+): { owner: string; repo: string } | null {
+  const normalizedOwner = owner.trim();
+  const normalizedRepo = repo.trim().replace(/\.git$/i, "");
+  if (!normalizedOwner || !normalizedRepo) {
+    return null;
+  }
+  return { owner: normalizedOwner, repo: normalizedRepo };
+}
+
+function splitGitSegments(rawPath: string): { owner: string; repoName: string } {
+  const segments = rawPath.split("/").filter(Boolean);
+  const repoName = segments.length > 0 ? segments[segments.length - 1].replace(/\.git$/i, "") : "";
+  const owner = segments.length > 1 ? segments.slice(0, -1).join("/") : "";
+  return { owner, repoName };
+}
+
+function parseHttpsSource(raw: string, explicitSubpath: string | null): ParseSkillRepoResult {
+  const host = raw.split("/")[2] ?? null;
+  const { owner, repoName } = splitGitSegments(raw.split("/").slice(3).join("/"));
+  const parsed = host ? normalizeGitOwnerRepo(owner, repoName) : null;
+  if (!host || !parsed) {
+    return { ok: false, error: { kind: "invalidSource", message: "Invalid https repository URL" } };
+  }
+  return buildResult(host, parsed, explicitSubpath);
+}
+
+function parseSshSource(raw: string, explicitSubpath: string | null): ParseSkillRepoResult {
+  const afterAt = raw.split("@")[1] ?? "";
+  const host = afterAt.split(":")[0] ?? null;
+  const { owner, repoName } = splitGitSegments(afterAt.split(":")[1] ?? "");
+  const parsed = host ? normalizeGitOwnerRepo(owner, repoName) : null;
+  if (!host || !parsed) {
+    return { ok: false, error: { kind: "invalidSource", message: "Invalid ssh repository URL" } };
+  }
+  return buildResult(host, parsed, explicitSubpath);
+}
+
+function parseShorthandSource(raw: string, explicitSubpath: string | null): ParseSkillRepoResult {
+  const shorthandMatch = raw.match(/^([^/\s]+)\/([^/\s]+)(?:\/(.+))?$/);
+  if (!shorthandMatch) {
+    return {
+      ok: false,
+      error: { kind: "invalidSource", message: "Unsupported repository source format" },
+    };
+  }
+  const parsed = normalizeGitOwnerRepo(shorthandMatch[1], shorthandMatch[2]);
+  if (!parsed) {
+    return { ok: false, error: { kind: "invalidSource", message: "Invalid repository source" } };
+  }
+  const shorthandSubpath = shorthandMatch[3]?.trim() ? shorthandMatch[3].trim() : null;
+  return buildResult(GITHUB_HOST, parsed, explicitSubpath || shorthandSubpath);
+}
+
+/**
+ * Parses a skill repository source: an `owner/repo[/subpath]` shorthand, an `https://host/owner/repo`
+ * URL, or an `git@host:owner/repo` SSH URL. Returns clone URLs and an optional subpath.
+ */
+export function parseSkillRepoSource(
+  input: string,
+  options: { subpath?: string } = {},
+): ParseSkillRepoResult {
+  const raw = typeof input === "string" ? input.trim() : "";
+  if (!raw) {
+    return {
+      ok: false,
+      error: { kind: "invalidSource", message: "Repository source is required" },
+    };
+  }
+  const explicitSubpath = options.subpath?.trim() ? options.subpath.trim() : null;
+  if (raw.startsWith("https://")) {
+    return parseHttpsSource(raw, explicitSubpath);
+  }
+  if (raw.startsWith("git@")) {
+    return parseSshSource(raw, explicitSubpath);
+  }
+  return parseShorthandSource(raw, explicitSubpath);
+}
+
+function buildResult(
+  host: string,
+  parsed: { owner: string; repo: string },
+  effectiveSubpath: string | null,
+): ParseSkillRepoResult {
+  return {
+    ok: true,
+    host,
+    owner: parsed.owner,
+    repo: parsed.repo,
+    cloneUrlSsh: `git@${host}:${parsed.owner}/${parsed.repo}.git`,
+    cloneUrlHttps: `https://${host}/${parsed.owner}/${parsed.repo}.git`,
+    effectiveSubpath,
+    normalizedRepo: `${parsed.owner}/${parsed.repo}`,
+  };
+}

--- a/packages/server/src/server/tunnel/cloudflare-tunnel.ts
+++ b/packages/server/src/server/tunnel/cloudflare-tunnel.ts
@@ -1,0 +1,126 @@
+// Ported concept from openchamber/openchamber (MIT): cloudflare-tunnel.js / tunnels/providers/cloudflare.js.
+// Wraps a `cloudflared tunnel --url http://127.0.0.1:<port>` quick tunnel: spawns the binary,
+// parses the public trycloudflare.com URL from its output, and manages the process lifecycle.
+// This is an OPTIONAL public-exposure path; Paseo's native remote access remains relay + pairing.
+import type { ChildProcess } from "node:child_process";
+import { spawnProcess, execCommand } from "../../utils/spawn.js";
+
+const TRY_CF_URL_REGEX = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/i;
+const STARTUP_TIMEOUT_MS = 30_000;
+
+import type { TunnelState, TunnelStatus } from "@getpaseo/protocol/tunnel/types";
+
+export type { TunnelState, TunnelStatus };
+
+export async function isCloudflaredAvailable(): Promise<boolean> {
+  try {
+    await execCommand("cloudflared", ["--version"], { timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A single Cloudflare quick tunnel. Not concurrency-safe across multiple simultaneous starts;
+ * callers (TunnelService) serialize start/stop.
+ */
+export class CloudflareTunnel {
+  private process: ChildProcess | null = null;
+  private state: TunnelState = "stopped";
+  private url: string | null = null;
+  private error: string | null = null;
+  private port: number | null = null;
+
+  getStatus(): TunnelStatus {
+    return { state: this.state, url: this.url, error: this.error, port: this.port };
+  }
+
+  isActive(): boolean {
+    return this.state === "starting" || this.state === "running";
+  }
+
+  async start(port: number): Promise<TunnelStatus> {
+    if (this.isActive()) {
+      return this.getStatus();
+    }
+    if (!(await isCloudflaredAvailable())) {
+      this.state = "error";
+      this.error = "cloudflared is not installed on this host.";
+      return this.getStatus();
+    }
+
+    this.state = "starting";
+    this.error = null;
+    this.url = null;
+    this.port = port;
+
+    const child = spawnProcess("cloudflared", [
+      "tunnel",
+      "--no-autoupdate",
+      "--url",
+      `http://127.0.0.1:${port}`,
+    ]);
+    this.process = child;
+
+    return new Promise<TunnelStatus>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (!settled) {
+          settled = true;
+          resolve(this.getStatus());
+        }
+      };
+
+      const timeout = setTimeout(() => {
+        if (this.state === "starting") {
+          this.state = "error";
+          this.error = "Timed out waiting for the tunnel URL.";
+          this.stop();
+        }
+        finish();
+      }, STARTUP_TIMEOUT_MS);
+
+      const onData = (chunk: Buffer) => {
+        const match = chunk.toString("utf8").match(TRY_CF_URL_REGEX);
+        if (match && this.state === "starting") {
+          this.url = match[0];
+          this.state = "running";
+          clearTimeout(timeout);
+          finish();
+        }
+      };
+      child.stdout?.on("data", onData);
+      child.stderr?.on("data", onData);
+
+      child.on("exit", (code) => {
+        clearTimeout(timeout);
+        this.process = null;
+        if (this.state !== "stopped") {
+          this.state = "error";
+          this.error = this.error ?? `cloudflared exited (code ${code ?? "unknown"}).`;
+          this.url = null;
+        }
+        finish();
+      });
+
+      child.on("error", (err) => {
+        clearTimeout(timeout);
+        this.state = "error";
+        this.error = err instanceof Error ? err.message : "Failed to start cloudflared.";
+        finish();
+      });
+    });
+  }
+
+  stop(): TunnelStatus {
+    if (this.process) {
+      this.process.kill("SIGTERM");
+      this.process = null;
+    }
+    this.state = "stopped";
+    this.url = null;
+    this.error = null;
+    return this.getStatus();
+  }
+}

--- a/packages/server/src/server/tunnel/service.ts
+++ b/packages/server/src/server/tunnel/service.ts
@@ -1,0 +1,21 @@
+import { CloudflareTunnel, type TunnelStatus } from "./cloudflare-tunnel.js";
+
+/**
+ * Owns the host's single Cloudflare quick tunnel. Stateless beyond the tunnel handle; the caller
+ * supplies the daemon's bound TCP port at start time.
+ */
+export class TunnelService {
+  private readonly tunnel = new CloudflareTunnel();
+
+  status(): TunnelStatus {
+    return this.tunnel.getStatus();
+  }
+
+  start(port: number): Promise<TunnelStatus> {
+    return this.tunnel.start(port);
+  }
+
+  stop(): TunnelStatus {
+    return this.tunnel.stop();
+  }
+}

--- a/packages/server/src/server/tunnel/tunnel.test.ts
+++ b/packages/server/src/server/tunnel/tunnel.test.ts
@@ -1,0 +1,89 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnProcessMock = vi.fn();
+const execCommandMock = vi.fn();
+
+vi.mock("../../utils/spawn.js", () => ({
+  spawnProcess: (...args: unknown[]) => spawnProcessMock(...args),
+  execCommand: (...args: unknown[]) => execCommandMock(...args),
+}));
+
+import { CloudflareTunnel } from "./cloudflare-tunnel.js";
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn();
+}
+
+describe("CloudflareTunnel", () => {
+  beforeEach(() => {
+    spawnProcessMock.mockReset();
+    execCommandMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports an error when cloudflared is unavailable", async () => {
+    execCommandMock.mockRejectedValue(new Error("not found"));
+    const tunnel = new CloudflareTunnel();
+    const status = await tunnel.start(4096);
+    expect(status.state).toBe("error");
+    expect(status.error).toContain("cloudflared is not installed");
+    expect(spawnProcessMock).not.toHaveBeenCalled();
+  });
+
+  it("transitions to running when the trycloudflare URL appears", async () => {
+    execCommandMock.mockResolvedValue({ stdout: "cloudflared version 1", stderr: "" });
+    const child = new FakeChild();
+    spawnProcessMock.mockReturnValue(child);
+
+    const tunnel = new CloudflareTunnel();
+    const startPromise = tunnel.start(4096);
+    // Wait until cloudflared has been spawned (after the async availability check) so listeners
+    // are attached, then simulate it emitting the public URL on stderr.
+    await vi.waitFor(() => expect(spawnProcessMock).toHaveBeenCalled());
+    child.stderr.emit("data", Buffer.from("INF |  https://brave-fox-1.trycloudflare.com  |\n"));
+
+    const status = await startPromise;
+    expect(status.state).toBe("running");
+    expect(status.url).toBe("https://brave-fox-1.trycloudflare.com");
+    expect(status.port).toBe(4096);
+    expect(spawnProcessMock).toHaveBeenCalledWith(
+      "cloudflared",
+      expect.arrayContaining(["tunnel", "--url", "http://127.0.0.1:4096"]),
+    );
+  });
+
+  it("stops the tunnel and kills the process", async () => {
+    execCommandMock.mockResolvedValue({ stdout: "v1", stderr: "" });
+    const child = new FakeChild();
+    spawnProcessMock.mockReturnValue(child);
+    const tunnel = new CloudflareTunnel();
+    const startPromise = tunnel.start(4096);
+    await vi.waitFor(() => expect(spawnProcessMock).toHaveBeenCalled());
+    child.stdout.emit("data", Buffer.from("https://x-y-z.trycloudflare.com"));
+    await startPromise;
+
+    const status = tunnel.stop();
+    expect(status.state).toBe("stopped");
+    expect(status.url).toBeNull();
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("errors when cloudflared exits before producing a URL", async () => {
+    execCommandMock.mockResolvedValue({ stdout: "v1", stderr: "" });
+    const child = new FakeChild();
+    spawnProcessMock.mockReturnValue(child);
+    const tunnel = new CloudflareTunnel();
+    const startPromise = tunnel.start(4096);
+    await vi.waitFor(() => expect(spawnProcessMock).toHaveBeenCalled());
+    child.emit("exit", 1);
+    const status = await startPromise;
+    expect(status.state).toBe("error");
+    expect(status.error).toContain("exited");
+  });
+});

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -13,6 +13,9 @@ import type { ProjectRegistry, WorkspaceRegistry } from "./workspace-registry.js
 import type { FileBackedChatService } from "./chat/chat-service.js";
 import type { LoopService } from "./loop-service.js";
 import type { ScheduleService } from "./schedule/service.js";
+import { SkillsCatalogService } from "./skills-catalog/service.js";
+import { GitIdentityService } from "./git-identity/service.js";
+import { TunnelService } from "./tunnel/service.js";
 import type { CheckoutDiffManager, CheckoutDiffMetrics } from "./checkout-diff-manager.js";
 import type { DaemonConfigStore, MutableDaemonConfig } from "./daemon-config-store.js";
 import {
@@ -400,6 +403,9 @@ export class VoiceAssistantWebSocketServer {
   private readonly chatService: FileBackedChatService;
   private readonly loopService: LoopService;
   private readonly scheduleService: ScheduleService;
+  private readonly skillsCatalogService = new SkillsCatalogService();
+  private readonly gitIdentityService = new GitIdentityService();
+  private readonly tunnelService = new TunnelService();
   private readonly checkoutDiffManager: CheckoutDiffManager;
   private readonly github: GitHubService;
   private readonly workspaceGitService: WorkspaceGitService;
@@ -988,6 +994,9 @@ export class VoiceAssistantWebSocketServer {
       chatService: this.chatService,
       loopService: this.loopService,
       scheduleService: this.scheduleService,
+      skillsCatalogService: this.skillsCatalogService,
+      gitIdentityService: this.gitIdentityService,
+      tunnelService: this.tunnelService,
       checkoutDiffManager: this.checkoutDiffManager,
       github: this.github,
       workspaceGitService: this.workspaceGitService,
@@ -1202,6 +1211,10 @@ export class VoiceAssistantWebSocketServer {
         daemonSelfUpdate: true,
         // COMPAT(agentForkContext): added in v0.1.102, remove gate after 2026-12-28.
         agentForkContext: true,
+        // COMPAT(skillsCatalog|gitIdentity|tunnel): OpenChamber feature RPCs; drop gates once host floor ships them.
+        skillsCatalog: true,
+        gitIdentity: true,
+        tunnel: true,
       },
     };
   }

--- a/scripts/dev-web.sh
+++ b/scripts/dev-web.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# One-command web dev: fixed-port daemon + Expo web (no portless required).
+# Usage: ./scripts/dev-web.sh [PORT]
+#   PORT defaults to 4111; auto-scans upward if busy.
+#   Tailscale: if tailscale is running, binds to 0.0.0.0 and uses the
+#   Tailscale IP for EXPO_PUBLIC_LOCAL_DAEMON so other Tailscale devices
+#   (phone, laptop) can reach the app at http://<tailscale-ip>:8081.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PATH="$SCRIPT_DIR/../node_modules/.bin:$PATH"
+
+# Pin a STABLE PASEO_HOME so the daemon keeps the same serverId across restarts.
+# dev.sh uses an ephemeral /tmp home (new serverId each launch), which makes the
+# web app's persisted host registry go stale and the client loops forever probing
+# a serverId that no longer exists. A fixed home avoids that. Override by exporting
+# PASEO_HOME before running.
+export PASEO_HOME="${PASEO_HOME:-$HOME/.paseo-dev-web}"
+source "$SCRIPT_DIR/dev-home.sh"
+configure_dev_paseo_home
+
+# Pick a daemon port. Default 4111 (avoids opencode's 4096 and Paseo's 6767).
+# If the chosen port is busy, auto-scan upward until a free one is found so the
+# daemon never crash-loops on EADDRINUSE.
+port_in_use() {
+  ss -ltn 2>/dev/null | grep -qE "[:.]${1}[[:space:]]"
+}
+
+REQUESTED_PORT="${1:-4111}"
+DEV_PORT="$REQUESTED_PORT"
+while port_in_use "$DEV_PORT"; do
+  echo "  Port ${DEV_PORT} is in use — trying $((DEV_PORT + 1))..."
+  DEV_PORT=$((DEV_PORT + 1))
+done
+
+# Pick an Expo web port (default 8081). Auto-scan upward if busy so a second
+# dev-web instance (or a stale Metro) doesn't collide on EADDRINUSE.
+EXPO_PORT="${EXPO_PORT:-8081}"
+while port_in_use "$EXPO_PORT"; do
+  echo "  Expo port ${EXPO_PORT} is in use — trying $((EXPO_PORT + 1))..."
+  EXPO_PORT=$((EXPO_PORT + 1))
+done
+
+if [ -z "${PASEO_LOCAL_MODELS_DIR}" ]; then
+  export PASEO_LOCAL_MODELS_DIR="$HOME/.paseo/models/local-speech"
+  mkdir -p "$PASEO_LOCAL_MODELS_DIR"
+fi
+
+# Detect Tailscale IP — if available, bind to all interfaces so remote
+# Tailscale devices can reach both the daemon and the Expo web server.
+TS_IP="$(tailscale ip -4 2>/dev/null || true)"
+if [ -n "$TS_IP" ]; then
+  BIND_HOST="0.0.0.0"
+  PUBLIC_HOST="$TS_IP"
+else
+  BIND_HOST="127.0.0.1"
+  PUBLIC_HOST="127.0.0.1"
+fi
+
+echo "══════════════════════════════════════════════════════"
+echo "  Paseo Dev (web, fixed port)"
+echo "══════════════════════════════════════════════════════"
+echo "  Home:    ${PASEO_HOME}"
+echo "  Daemon:  ${PUBLIC_HOST}:${DEV_PORT}  (bind: ${BIND_HOST})"
+echo "  App:     http://${PUBLIC_HOST}:${EXPO_PORT}"
+echo "══════════════════════════════════════════════════════"
+
+export PASEO_CORS_ORIGINS="*"
+export PASEO_NODE_INSPECT="${PASEO_NODE_INSPECT:---inspect=0}"
+export PASEO_LISTEN="${BIND_HOST}:${DEV_PORT}"
+export EXPO_PUBLIC_LOCAL_DAEMON="${PUBLIC_HOST}:${DEV_PORT}"
+
+exec concurrently \
+  --names "daemon,metro" \
+  --prefix-colors "cyan,magenta" \
+  "./scripts/dev-daemon.sh" \
+  "cd packages/app && BROWSER=none APP_VARIANT=development npx expo start --web --port ${EXPO_PORT}"


### PR DESCRIPTION
## OpenChamber-parity feature set + capability gating

Ports a set of features inspired by [OpenChamber](https://github.com/openchamber/openchamber) (MIT) into Paseo, each gated behind `server_info.features.*` capability flags so old clients/daemons degrade gracefully per the protocol contract. All ported files carry a `// Ported from openchamber/openchamber (MIT)` header.

### Features

**Server-backed (WebSocket-RPC, mirrors the existing `schedule` pattern):**
- **Quota / usage** — provider usage tracking (Claude, Codex, GitHub Copilot, OpenRouter) read from local auth; `quota/list` + `quota/fetch`; usage progress bar in host settings.
- **Skills catalog** — browse/scan/install skills from a git repo into `~/.pi/agent/skills`; `skills/list` + `skills/scan` + `skills/install`.
- **Gitmoji commits** — optional gitmoji prefix on generated commit messages (off by default; General-settings toggle).
- **Git identities** — per-repo git author/committer identity via git config; `git-identity/get` + `set`.
- **Cloudflare quick tunnel** — expose the daemon via `cloudflared tunnel --url`; `tunnel/status` + `start` + `stop`.

**Client-only (Zustand + AsyncStorage persistence):**
- **Workspace folders** — group workspaces into collapsible folders in the sidebar.
- **Multi-run launcher** — run one prompt across multiple models in parallel (one agent per model).
- **Project notes/todos** — a Notes tab in the explorer sidebar.
- **i18n runtime** — typed `useI18n()` / `translate()` with an English catalog (foundation; English-only for now).

### Notes
- Protocol stays backward-compatible: new RPCs use dotted `domain.op.request`/`.response` namespaces; new schema fields are optional; capability flags gate each feature.
- Tests: unit tests for quota, skills, gitmoji, tunnel (server) and workspace-folders, git-identities, multi-run, project-notes, i18n (app).
- Verified: `typecheck` (all workspaces), `oxlint`, `oxfmt` all green on `0.1.97-beta.2`. Smoke-tested live in the web app (folders, multi-run, notes, git identity, gitmoji toggle render and function).

Opening for maintainer feedback — happy to split into smaller PRs or adjust the capability-gating approach.
