### PR TITLE
Clarify PR merge action labels

### DIFF
--- a/packages/app/src/git/policy.test.ts
+++ b/packages/app/src/git/policy.test.ts
@@ -377,7 +377,7 @@ describe("git-actions-policy", () => {
 
     expect(actions.primary).toMatchObject({
       id: "merge-pr-squash",
-      label: "Merge",
+      label: "Merge PR (squash)",
     });
   });
 
@@ -398,7 +398,7 @@ describe("git-actions-policy", () => {
 
     expect(actions.primary).toMatchObject({
       id: "merge-pr-squash",
-      label: "Merge",
+      label: "Merge PR (squash)",
     });
   });
 
@@ -458,7 +458,7 @@ describe("git-actions-policy", () => {
 
     expect(actions.primary).toMatchObject({
       id: "merge-pr-squash",
-      label: "Merge",
+      label: "Merge PR (squash)",
     });
   });
 
@@ -512,7 +512,7 @@ describe("git-actions-policy", () => {
 
     expect(actions.primary).toMatchObject({
       id: "merge-pr-squash",
-      label: "Merge",
+      label: "Merge PR (squash)",
     });
     expect(actions.secondary.some((action) => action.id === "merge-branch")).toBe(true);
   });
@@ -583,7 +583,7 @@ describe("git-actions-policy", () => {
       },
       {
         id: "merge-pr-squash",
-        label: "Merge",
+        label: "Merge PR (squash)",
         pendingLabel: "Merging PR...",
         successLabel: "PR merged",
         disabled: false,
@@ -592,7 +592,7 @@ describe("git-actions-policy", () => {
       },
       {
         id: "merge-pr-merge",
-        label: "Merge",
+        label: "Merge PR (merge)",
         pendingLabel: "Merging PR...",
         successLabel: "PR merged",
         disabled: false,
@@ -601,7 +601,7 @@ describe("git-actions-policy", () => {
       },
       {
         id: "merge-pr-rebase",
-        label: "Merge",
+        label: "Merge PR (rebase)",
         pendingLabel: "Merging PR...",
         successLabel: "PR merged",
         disabled: false,
@@ -703,7 +703,10 @@ describe("git-actions-policy", () => {
     );
 
     expect(oldDaemonStatus.github).toBeUndefined();
-    expect(actions.primary).toMatchObject({ id: "merge-pr-squash", label: "Merge" });
+    expect(actions.primary).toMatchObject({
+      id: "merge-pr-squash",
+      label: "Merge PR (squash)",
+    });
     expect(actions.secondary.map((action) => action.id)).toEqual([
       "pull",
       "push",
@@ -744,7 +747,7 @@ describe("git-actions-policy", () => {
 
     expect(actions.primary).toMatchObject({
       id: "enable-pr-auto-merge-squash",
-      label: "Auto merge",
+      label: "Auto merge (squash)",
     });
     expect(actions.secondary.map((action) => action.id)).toEqual([
       "pull",
@@ -851,7 +854,7 @@ describe("git-actions-policy", () => {
 
     expect(actions.primary).toMatchObject({
       id: "merge-pr-merge",
-      label: "Merge",
+      label: "Merge PR (merge)",
     });
     expect(actions.secondary.map((action) => action.id)).toEqual([
       "pull",

--- a/packages/app/src/git/policy.test.ts
+++ b/packages/app/src/git/policy.test.ts
@@ -765,6 +765,41 @@ describe("git-actions-policy", () => {
     ).toBe(false);
   });
 
+  it.each([
+    ["SQUASH", "enable-pr-auto-merge-squash", "Auto merge (squash)"],
+    ["MERGE", "enable-pr-auto-merge-merge", "Auto merge (merge)"],
+    ["REBASE", "enable-pr-auto-merge-rebase", "Auto merge (rebase)"],
+  ] as const)(
+    "labels the %s auto-merge action with its method",
+    (viewerDefaultMergeMethod, id, label) => {
+      const actions = buildGitActions(
+        createInput({
+          hasRemote: true,
+          isOnBaseBranch: false,
+          aheadCount: 2,
+          hasPullRequest: true,
+          pullRequestUrl: "https://example.com/pr/993",
+          pullRequestState: "open",
+          pullRequestMergeable: "MERGEABLE",
+          pullRequestGithub: githubStatus({
+            mergeStateStatus: "BLOCKED",
+            viewerCanEnableAutoMerge: true,
+            repository: {
+              autoMergeAllowed: true,
+              mergeCommitAllowed: true,
+              squashMergeAllowed: true,
+              rebaseMergeAllowed: true,
+              viewerDefaultMergeMethod,
+            },
+          }),
+          shipDefault: "pr",
+        }),
+      );
+
+      expect(actions.primary).toMatchObject({ id, label });
+    },
+  );
+
   it("does not offer auto-merge when the daemon feature gate is missing", () => {
     const actions = buildGitActions(
       createInput({

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -601,9 +601,9 @@ export const ar: TranslationResources = {
           success: "مؤرشف",
         },
         mergePr: {
-          squash: "دمج",
-          merge: "دمج",
-          rebase: "دمج",
+          squash: "دمج PR (squash)",
+          merge: "دمج PR (merge)",
+          rebase: "دمج PR (rebase)",
           pending: "دمج PR...",
           success: "تم دمج PR",
         },

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -608,9 +608,9 @@ export const ar: TranslationResources = {
           success: "تم دمج PR",
         },
         autoMerge: {
-          enableSquash: "دمج تلقائي",
-          enableMerge: "دمج تلقائي",
-          enableRebase: "دمج تلقائي",
+          enableSquash: "دمج تلقائي (squash)",
+          enableMerge: "دمج تلقائي (merge)",
+          enableRebase: "دمج تلقائي (rebase)",
           enabled: "تم تمكين الدمج التلقائي",
           enabling: "تمكين الدمج التلقائي...",
           disabling: "تعطيل الدمج التلقائي...",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -599,9 +599,9 @@ export const en = {
           success: "Archived",
         },
         mergePr: {
-          squash: "Merge",
-          merge: "Merge",
-          rebase: "Merge",
+          squash: "Merge PR (squash)",
+          merge: "Merge PR (merge)",
+          rebase: "Merge PR (rebase)",
           pending: "Merging PR...",
           success: "PR merged",
         },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -606,9 +606,9 @@ export const en = {
           success: "PR merged",
         },
         autoMerge: {
-          enableSquash: "Auto merge",
-          enableMerge: "Auto merge",
-          enableRebase: "Auto merge",
+          enableSquash: "Auto merge (squash)",
+          enableMerge: "Auto merge (merge)",
+          enableRebase: "Auto merge (rebase)",
           enabled: "Auto-merge enabled",
           enabling: "Enabling auto-merge...",
           disabling: "Disabling auto-merge...",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -613,9 +613,9 @@ export const es: TranslationResources = {
           success: "PRfusionado",
         },
         autoMerge: {
-          enableSquash: "Fusión automática",
-          enableMerge: "Fusión automática",
-          enableRebase: "Fusión automática",
+          enableSquash: "Fusión automática (squash)",
+          enableMerge: "Fusión automática (merge)",
+          enableRebase: "Fusión automática (rebase)",
           enabled: "Combinación automática habilitada",
           enabling: "Habilitando la fusión automática...",
           disabling: "Desactivando la fusión automática...",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -606,9 +606,9 @@ export const es: TranslationResources = {
           success: "Archivado",
         },
         mergePr: {
-          squash: "Fusionar",
-          merge: "Fusionar",
-          rebase: "Fusionar",
+          squash: "Fusionar PR (squash)",
+          merge: "Fusionar PR (merge)",
+          rebase: "Fusionar PR (rebase)",
           pending: "FusionandoPR...",
           success: "PRfusionado",
         },

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -609,8 +609,8 @@ export const es: TranslationResources = {
           squash: "Fusionar PR (squash)",
           merge: "Fusionar PR (merge)",
           rebase: "Fusionar PR (rebase)",
-          pending: "FusionandoPR...",
-          success: "PRfusionado",
+          pending: "Fusionando PR...",
+          success: "PR fusionado",
         },
         autoMerge: {
           enableSquash: "Fusión automática (squash)",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -613,9 +613,9 @@ export const fr: TranslationResources = {
           success: "PRfusionné",
         },
         autoMerge: {
-          enableSquash: "Fusion automatique",
-          enableMerge: "Fusion automatique",
-          enableRebase: "Fusion automatique",
+          enableSquash: "Fusion automatique (squash)",
+          enableMerge: "Fusion automatique (merge)",
+          enableRebase: "Fusion automatique (rebase)",
           enabled: "Fusion automatique activée",
           enabling: "Activation de la fusion automatique...",
           disabling: "Désactivation de la fusion automatique...",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -606,9 +606,9 @@ export const fr: TranslationResources = {
           success: "Archivé",
         },
         mergePr: {
-          squash: "Fusionner",
-          merge: "Fusionner",
-          rebase: "Fusionner",
+          squash: "Fusionner PR (squash)",
+          merge: "Fusionner PR (merge)",
+          rebase: "Fusionner PR (rebase)",
           pending: "Fusion dePR...",
           success: "PRfusionné",
         },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -609,8 +609,8 @@ export const fr: TranslationResources = {
           squash: "Fusionner PR (squash)",
           merge: "Fusionner PR (merge)",
           rebase: "Fusionner PR (rebase)",
-          pending: "Fusion dePR...",
-          success: "PRfusionné",
+          pending: "Fusion de PR...",
+          success: "PR fusionné",
         },
         autoMerge: {
           enableSquash: "Fusion automatique (squash)",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -605,9 +605,9 @@ export const ru: TranslationResources = {
           success: "В архиве",
         },
         mergePr: {
-          squash: "Объединить",
-          merge: "Объединить",
-          rebase: "Объединить",
+          squash: "Объединить PR (squash)",
+          merge: "Объединить PR (merge)",
+          rebase: "Объединить PR (rebase)",
           pending: "Объединение PR...",
           success: "PR объединен",
         },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -612,9 +612,9 @@ export const ru: TranslationResources = {
           success: "PR объединен",
         },
         autoMerge: {
-          enableSquash: "Автообъединение",
-          enableMerge: "Автообъединение",
-          enableRebase: "Автообъединение",
+          enableSquash: "Автообъединение (squash)",
+          enableMerge: "Автообъединение (merge)",
+          enableRebase: "Автообъединение (rebase)",
           enabled: "Автоматическое объединение включено",
           enabling: "Включение автоматического объединения...",
           disabling: "Отключение автоматического объединения...",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -606,9 +606,9 @@ export const zhCN: TranslationResources = {
           success: "PR 已 merge",
         },
         autoMerge: {
-          enableSquash: "Auto merge",
-          enableMerge: "Auto merge",
-          enableRebase: "Auto merge",
+          enableSquash: "Auto merge (squash)",
+          enableMerge: "Auto merge (merge)",
+          enableRebase: "Auto merge (rebase)",
           enabled: "Auto-merge 已启用",
           enabling: "正在启用 auto-merge...",
           disabling: "正在禁用 auto-merge...",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -599,9 +599,9 @@ export const zhCN: TranslationResources = {
           success: "已归档",
         },
         mergePr: {
-          squash: "Merge",
-          merge: "Merge",
-          rebase: "Merge",
+          squash: "Merge PR (squash)",
+          merge: "Merge PR (merge)",
+          rebase: "Merge PR (rebase)",
           pending: "正在 merge PR...",
           success: "PR 已 merge",
         },


### PR DESCRIPTION
### Linked issue

Supersedes #1590. That fork branch has maintainer edits disabled, and CI needed a small test update plus the adjacent auto-merge label fix.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

PR merge actions now show the selected method in their labels, so squash, merge commit, and rebase are distinguishable in the actions menu. It also applies the same method suffix to auto-merge labels and updates the git action policy test expectations.

### How did you verify it

- `npx vitest run packages/app/src/git/policy.test.ts --bail=1`
- `npm run format`
- `npm run typecheck`
- `npm run lint`

CI should cover the remaining app, server, desktop, CLI, SDK, relay, and Playwright surfaces before merge.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

Screenshot/video omitted because this is a string-only menu label change and the targeted policy test asserts the visible action labels.
