### PR TITLE
feat(composer): long-press send button to queue message

### DIFF
--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -58,8 +58,9 @@ import { formatShortcut, type ShortcutKey } from "@/utils/format-shortcut";
 import { getShortcutOs } from "@/utils/shortcut-platform";
 import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
 import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
-import { isWeb } from "@/constants/platform";
+import { isWeb, isNative } from "@/constants/platform";
 import { useIsCompactFormFactor } from "@/constants/layout";
+import * as Haptics from "expo-haptics";
 import { useComposerHeightMirror } from "./height-mirror";
 import {
   resolveSendTooltipLabel,
@@ -67,7 +68,12 @@ import {
   resolveVoiceAccessibilityLabel,
   resolveVoiceTooltipText,
 } from "./labels";
-import { computeCanStartDictation, runAlternateSendAction, runDefaultSendAction } from "./state";
+import {
+  computeCanStartDictation,
+  runAlternateSendAction,
+  runDefaultSendAction,
+  runLongPressQueueAction,
+} from "./state";
 
 const DEFAULT_SEND_KEYS: ShortcutKey[][] = [["Enter"]];
 
@@ -783,6 +789,9 @@ function SendButtonTooltip({
   canPressLoadingButton,
   onSubmitLoadingPress,
   onDefaultSendAction,
+  onLongPressQueue,
+  isQueueAvailable,
+  queueAccessibilityHint,
   isSendButtonDisabled,
   submitAccessibilityLabel,
   sendButtonCombinedStyle,
@@ -797,6 +806,9 @@ function SendButtonTooltip({
   canPressLoadingButton: boolean;
   onSubmitLoadingPress: (() => void) | undefined;
   onDefaultSendAction: () => void;
+  onLongPressQueue: (() => void) | undefined;
+  isQueueAvailable: boolean;
+  queueAccessibilityHint: string | undefined;
   isSendButtonDisabled: boolean;
   submitAccessibilityLabel: string;
   sendButtonCombinedStyle: React.ComponentProps<typeof TooltipTrigger>["style"];
@@ -808,10 +820,15 @@ function SendButtonTooltip({
   sendTooltipLabel: string;
 }) {
   if (!shouldShow) return null;
+  // Long-press to queue only applies when queueing is available and the button
+  // is in its normal send state (not the loading/cancel affordance).
+  const longPressQueue = canPressLoadingButton || !isQueueAvailable ? undefined : onLongPressQueue;
   return (
     <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
       <TooltipTrigger
         onPress={canPressLoadingButton ? onSubmitLoadingPress : onDefaultSendAction}
+        onLongPress={longPressQueue}
+        accessibilityHint={longPressQueue ? queueAccessibilityHint : undefined}
         disabled={isSendButtonDisabled}
         accessibilityLabel={submitAccessibilityLabel}
         accessibilityRole="button"
@@ -1019,13 +1036,14 @@ interface QueueMessageContext {
   onMinimizeHeight: () => void;
 }
 
-function queueMessageImpl(ctx: QueueMessageContext): void {
-  if (!ctx.onQueue) return;
+function queueMessageImpl(ctx: QueueMessageContext): boolean {
+  if (!ctx.onQueue) return false;
   const trimmed = ctx.value.trim();
-  if (!trimmed && ctx.attachments.length === 0) return;
+  if (!trimmed && ctx.attachments.length === 0) return false;
   ctx.onQueue({ text: trimmed, attachments: ctx.attachments, cwd: ctx.cwd });
   ctx.onChangeText("");
   ctx.onMinimizeHeight();
+  return true;
 }
 
 function computeIsRealtimeVoiceForAgent(
@@ -1583,6 +1601,20 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       [attachments, cwd, onQueue, onChangeText, minimizeInputHeight],
     );
 
+    // Long-pressing the send button queues the draft instead of sending it,
+    // regardless of the default send behavior setting. Tap still sends.
+    const handleLongPressSend = useCallback(() => {
+      runLongPressQueueAction({
+        onQueue,
+        queueMessage: handleQueueMessage,
+        onQueued: () => {
+          if (isNative) {
+            void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
+          }
+        },
+      });
+    }, [onQueue, handleQueueMessage]);
+
     const handleDefaultSendAction = useCallback(() => {
       runDefaultSendAction({
         defaultSendBehavior,
@@ -1887,6 +1919,9 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
                 canPressLoadingButton={canPressLoadingButton}
                 onSubmitLoadingPress={onSubmitLoadingPress}
                 onDefaultSendAction={handleDefaultSendAction}
+                onLongPressQueue={handleLongPressSend}
+                isQueueAvailable={Boolean(onQueue)}
+                queueAccessibilityHint={t("composer.input.queueMessage")}
                 isSendButtonDisabled={isSendButtonDisabled}
                 submitAccessibilityLabel={submitAccessibilityLabel}
                 sendButtonCombinedStyle={sendButtonCombinedStyle}

--- a/packages/app/src/composer/input/state.test.ts
+++ b/packages/app/src/composer/input/state.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { computeCanStartDictation, runAlternateSendAction, runDefaultSendAction } from "./state";
+import { describe, expect, it, vi } from "vitest";
+import {
+  computeCanStartDictation,
+  runAlternateSendAction,
+  runDefaultSendAction,
+  runLongPressQueueAction,
+} from "./state";
 
 const connected = { isConnected: true } as never;
 const disconnected = { isConnected: false } as never;
@@ -147,5 +152,31 @@ describe("composer send behavior", () => {
 
     expect(defaultAction.calls).toEqual(["queue"]);
     expect(alternateAction.calls).toEqual(["send"]);
+  });
+});
+
+describe("runLongPressQueueAction", () => {
+  it("does nothing when queueing is unavailable", () => {
+    const queueMessage = vi.fn(() => true);
+    const onQueued = vi.fn();
+    runLongPressQueueAction({ onQueue: undefined, queueMessage, onQueued });
+    expect(queueMessage).not.toHaveBeenCalled();
+    expect(onQueued).not.toHaveBeenCalled();
+  });
+
+  it("queues and fires the queued side effect when there is content", () => {
+    const queueMessage = vi.fn(() => true);
+    const onQueued = vi.fn();
+    runLongPressQueueAction({ onQueue: () => undefined, queueMessage, onQueued });
+    expect(queueMessage).toHaveBeenCalledTimes(1);
+    expect(onQueued).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the queued side effect when nothing was queued", () => {
+    const queueMessage = vi.fn(() => false);
+    const onQueued = vi.fn();
+    runLongPressQueueAction({ onQueue: () => undefined, queueMessage, onQueued });
+    expect(queueMessage).toHaveBeenCalledTimes(1);
+    expect(onQueued).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/composer/input/state.ts
+++ b/packages/app/src/composer/input/state.ts
@@ -41,3 +41,25 @@ export function runAlternateSendAction(ctx: SendActionContext): void {
     ctx.handleQueueMessage();
   }
 }
+
+interface LongPressQueueContext {
+  onQueue: ((payload: MessagePayload) => void) | undefined;
+  /** Queues the current draft. Returns true when something was actually queued. */
+  queueMessage: () => boolean;
+  /** Side effect (e.g. haptic feedback) fired only when a message was queued. */
+  onQueued: () => void;
+}
+
+/**
+ * Long-pressing the send button queues the message instead of sending it,
+ * independent of the configured default send behavior. This reuses the same
+ * queue path as Mod+Enter / the "queue" send setting, but exposes it as a touch
+ * gesture so mobile users can queue without changing a setting. No-ops when
+ * queueing is unavailable (`onQueue` missing) or there is nothing to queue.
+ */
+export function runLongPressQueueAction(ctx: LongPressQueueContext): void {
+  if (!ctx.onQueue) return;
+  if (ctx.queueMessage()) {
+    ctx.onQueued();
+  }
+}


### PR DESCRIPTION
### Linked issue

_None yet._ There's no prior issue or design discussion for this. Per `CONTRIBUTING.md`, a new feature normally wants a linked issue + design alignment first — happy to file a feature request and discuss scope/fit before you spend time on this, or to close it if long-press-to-queue isn't a direction you want. Opening as a **draft** for visibility.

### Type of change

- [ ] Bug fix
- [x] New feature (interaction/UX change — **no prior design alignment yet**, see above)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds a **long-press gesture on the send button that queues the current draft** instead of sending it. Tap/click still sends exactly as before — behaviour on a normal press is unchanged.

It does **not** introduce a new queue mechanism. It reuses the existing one (`queueComposerMessage` / `onQueue` / the session `queuedMessages` store) that already powers the `sendBehavior: "queue"` setting and the `Mod+Enter` shortcut. This PR just exposes that same path through an additional trigger, so mobile users can queue a follow-up while an agent is running without changing a setting.

Concretely:
- New pure helper `runLongPressQueueAction` in `composer/input/state.ts` (queues, then fires an optional side effect only if something was actually queued).
- `queueMessageImpl` now returns whether it queued, so the native haptic only fires on a real queue.
- The send button gains `onLongPress` (gated to the normal send state and to composers that actually support queueing) plus an `accessibilityHint` reusing the existing `composer.input.queueMessage` string — no new i18n keys.
- Medium haptic feedback on native (`expo-haptics`, `isNative`-gated) so the queue action is felt on mobile.

Three files changed: `composer/input/input.tsx`, `composer/input/state.ts`, `composer/input/state.test.ts`.

### How did you verify it

Honest disclosure up front: **I have not run the app on a device/simulator, so there are no per-platform screenshots or video yet.** I don't want to pass off automated checks as UI testing. What I actually ran, locally on this branch:

- `npm run test --workspace=@getpaseo/app` scoped to `packages/app/src/composer` → **97 tests pass (12 files)**, including **3 new unit tests** for `runLongPressQueueAction` (no-op when queueing unavailable; fires the side effect only when a message is queued; skips it when there's nothing to queue).
- `npm run typecheck` (app workspace, after `build:client` + `build:server` deps) → clean.
- `npm run lint` on the changed files → 0 warnings, 0 errors.
- `npm run format` (oxfmt) → all three files already match.

What I have **not** done and what this still needs before merge:
- Real on-device verification of the gesture on **iOS, Android, desktop, and web** (tap still sends; ~500 ms hold queues + haptic on native; queued item shows in the queue track; auto-dispatches on the running→idle transition). The queue logic itself is the existing, already-shipping path, but the long-press trigger and haptic have only been exercised by unit tests, not by hand on each platform.

Glad to gather that evidence or hand it off — flagging clearly rather than implying testing I didn't do.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome/oxfmt)
- [ ] UI changes include screenshots or video for every affected platform — **not done yet** (see above)
- [x] Tests added or updated where it made sense
