### PR TITLE
Fix project picker timeouts in large repos

### DIFF
--- a/packages/app/src/components/project-picker-modal.tsx
+++ b/packages/app/src/components/project-picker-modal.tsx
@@ -82,17 +82,18 @@ export function ProjectPickerModal() {
 
   const inputRef = useRef<TextInput>(null);
   const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [openErrorReason, setOpenErrorReason] = useState<OpenProjectFailureReason | null>(null);
   const openProject = useOpenProject(serverId);
 
   const directorySuggestionsQuery = useQuery({
-    queryKey: ["project-picker-directory-suggestions", serverId, query],
+    queryKey: ["project-picker-directory-suggestions", serverId, debouncedQuery],
     queryFn: async () => {
       if (!client) return [];
       const result = await client.getDirectorySuggestions({
-        query,
+        query: debouncedQuery,
         includeDirectories: true,
         includeFiles: false,
         limit: 30,
@@ -165,12 +166,20 @@ export function ProjectPickerModal() {
   useEffect(() => {
     if (open) {
       setQuery("");
+      setDebouncedQuery("");
       setActiveIndex(0);
       setOpenErrorReason(null);
       const id = setTimeout(() => inputRef.current?.focus(), 0);
       return () => clearTimeout(id);
     }
   }, [open]);
+
+  // Debounce the query that drives the (potentially multi-second) directory
+  // suggestions RPC so fast typing doesn't fire a filesystem scan per keystroke.
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQuery(query), 250);
+    return () => clearTimeout(id);
+  }, [query]);
 
   useEffect(() => {
     if (!open) return;

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -1886,7 +1886,9 @@ export class DaemonClient {
         cwd,
       },
       responseType: "open_project_response",
-      timeout: 10000,
+      // Large local repos (e.g. a big monorepo/brain checkout) need >10s for the
+      // daemon to resolve the path, detect git, and materialize the workspace.
+      timeout: 60000,
     });
   }
 
@@ -3512,7 +3514,9 @@ export class DaemonClient {
         limit: options.limit,
       },
       responseType: "directory_suggestions_response",
-      timeout: 10000,
+      // Home-tree scans on large home dirs can take several seconds; don't cut
+      // the suggestion request off early (it would surface as an empty list).
+      timeout: 30000,
     });
   }
 


### PR DESCRIPTION
### Linked issue

Closes #1693

### Type of change

- [x] Bug fix

### What does this PR do

Opening a project or fetching folder-picker suggestions silently times out on large home directories. The client used a 10s request timeout for both `openProject` and `getDirectorySuggestions`, but the daemon's directory scan routinely takes longer on a big `~`, so the client gave up before the daemon responded — the picker looked broken even though the daemon was still working.

This raises the client timeouts to match real scan times and debounces the suggestion query so a filesystem scan isn't fired on every keystroke:

- `daemon-client.ts`: `openProject` 10s -> 60s (it does the most filesystem work); `getDirectorySuggestions` 10s -> 30s. Inline comments explain each.
- `project-picker-modal.tsx`: 250ms debounce on the directory-suggestions query key.

No protocol or schema changes; client-only timeout/UX tuning.

### How did you verify it

Reproduced live against a daemon running on a Linux host with a large home directory, client connected over the LAN.

**Before:** the folder picker returned nothing / "open" hung. Daemon `ws_slow_request` logs showed `directory_suggestions_request` completing on the daemon side but past the 10s client deadline:

```
durationMs: 6532
durationMs: 8443
durationMs: 10670
durationMs: 11211
durationMs: 17313
```

**After:** with the raised timeouts the same scans complete and populate the picker; the 250ms debounce stops a scan firing on every keystroke while typing a path.

Checks: `npm run typecheck` (app + client) passes, `npm run lint` 0/0, `npm run format` clean.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform — N/A: no visual change, this is a timeout/debounce tuning fix (behavior, not appearance)
- [x] Tests added or updated where it made sense — covered by existing picker behavior; change is timeout/debounce constants
