### PR TITLE
Fix web terminal scroll lag

### DIFF
--- a/packages/app/src/components/terminal-emulator.tsx
+++ b/packages/app/src/components/terminal-emulator.tsx
@@ -291,6 +291,19 @@ export default function TerminalEmulator({
   const [isScrollActive, setIsScrollActive] = useState(false);
   const [isDropActive, setIsDropActive] = useState(false);
   const dropActiveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const updateViewportMetricsState = useCallback((metrics: ViewportMetrics) => {
+    const lastMetrics = lastMetricsRef.current;
+    if (
+      metrics.offset === lastMetrics.offset &&
+      metrics.viewportSize === lastMetrics.viewportSize &&
+      metrics.contentSize === lastMetrics.contentSize
+    ) {
+      return;
+    }
+
+    lastMetricsRef.current = metrics;
+    setViewportMetrics(metrics);
+  }, []);
 
   const domBridgeRef = useRef<DOMImperativeFactory | null>(null);
   useDOMImperativeHandle(
@@ -576,29 +589,17 @@ export default function TerminalEmulator({
     const viewportElement = host.querySelector<HTMLElement>(".xterm-viewport");
     if (!viewportElement) {
       viewportRef.current = null;
-      setViewportMetrics({ offset: 0, viewportSize: 0, contentSize: 0 });
+      updateViewportMetricsState({ offset: 0, viewportSize: 0, contentSize: 0 });
       return () => {};
     }
 
     viewportRef.current = viewportElement;
 
-    const lastMetrics = lastMetricsRef.current;
-
     const updateViewportMetrics = () => {
       const offset = Math.max(0, viewportElement.scrollTop);
       const viewportSize = Math.max(0, viewportElement.clientHeight);
       const contentSize = Math.max(0, viewportElement.scrollHeight);
-      if (
-        offset === lastMetrics.offset &&
-        viewportSize === lastMetrics.viewportSize &&
-        contentSize === lastMetrics.contentSize
-      ) {
-        return;
-      }
-      lastMetrics.offset = offset;
-      lastMetrics.viewportSize = viewportSize;
-      lastMetrics.contentSize = contentSize;
-      setViewportMetrics({ offset, viewportSize, contentSize });
+      updateViewportMetricsState({ offset, viewportSize, contentSize });
     };
 
     updateViewportMetrics();
@@ -636,7 +637,7 @@ export default function TerminalEmulator({
         viewportRef.current = null;
       }
     };
-  }, [streamKey]);
+  }, [streamKey, updateViewportMetricsState]);
 
   useEffect(() => {
     const maxScrollOffset = Math.max(0, viewportMetrics.contentSize - viewportMetrics.viewportSize);
@@ -712,7 +713,7 @@ export default function TerminalEmulator({
         return;
       }
       viewportElement.scrollTop = nextOffset;
-      setViewportMetrics({
+      updateViewportMetricsState({
         offset: nextOffset,
         viewportSize: Math.max(0, viewportElement.clientHeight),
         contentSize: Math.max(0, viewportElement.scrollHeight),
@@ -732,7 +733,12 @@ export default function TerminalEmulator({
       window.removeEventListener("pointerup", stopDragging);
       window.removeEventListener("pointercancel", stopDragging);
     };
-  }, [isDraggingScrollbar, scrollbarGeometry.maxHandleOffset, scrollbarGeometry.maxScrollOffset]);
+  }, [
+    isDraggingScrollbar,
+    scrollbarGeometry.maxHandleOffset,
+    scrollbarGeometry.maxScrollOffset,
+    updateViewportMetricsState,
+  ]);
 
   const handleVisible =
     scrollbarGeometry.isVisible && (isDraggingScrollbar || isScrollVisible || isHandleHovered);

--- a/packages/app/src/components/terminal-emulator.tsx
+++ b/packages/app/src/components/terminal-emulator.tsx
@@ -252,6 +252,7 @@ export default function TerminalEmulator({
   const scrollVisibilityTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollActiveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastObservedOffsetRef = useRef<number | null>(null);
+  const lastMetricsRef = useRef({ offset: 0, viewportSize: 0, contentSize: 0 });
   const themeKey = useMemo(() => buildXtermThemeKey(xtermTheme), [xtermTheme]);
   const xtermThemeRef = useRef(xtermTheme);
   xtermThemeRef.current = xtermTheme;
@@ -581,18 +582,36 @@ export default function TerminalEmulator({
 
     viewportRef.current = viewportElement;
 
+    const lastMetrics = lastMetricsRef.current;
+
     const updateViewportMetrics = () => {
-      setViewportMetrics({
-        offset: Math.max(0, viewportElement.scrollTop),
-        viewportSize: Math.max(0, viewportElement.clientHeight),
-        contentSize: Math.max(0, viewportElement.scrollHeight),
-      });
+      const offset = Math.max(0, viewportElement.scrollTop);
+      const viewportSize = Math.max(0, viewportElement.clientHeight);
+      const contentSize = Math.max(0, viewportElement.scrollHeight);
+      if (
+        offset === lastMetrics.offset &&
+        viewportSize === lastMetrics.viewportSize &&
+        contentSize === lastMetrics.contentSize
+      ) {
+        return;
+      }
+      lastMetrics.offset = offset;
+      lastMetrics.viewportSize = viewportSize;
+      lastMetrics.contentSize = contentSize;
+      setViewportMetrics({ offset, viewportSize, contentSize });
     };
 
     updateViewportMetrics();
 
+    let scrollRafId: number | null = null;
     const handleViewportScroll = () => {
-      updateViewportMetrics();
+      if (scrollRafId !== null) {
+        return;
+      }
+      scrollRafId = requestAnimationFrame(() => {
+        scrollRafId = null;
+        updateViewportMetrics();
+      });
     };
 
     const resizeObserver = new ResizeObserver(() => {
@@ -604,22 +623,15 @@ export default function TerminalEmulator({
       resizeObserver.observe(scrollAreaElement);
     }
 
-    const mutationObserver = new MutationObserver(() => {
-      updateViewportMetrics();
-    });
-    mutationObserver.observe(host, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ["style", "class"],
-    });
-
     viewportElement.addEventListener("scroll", handleViewportScroll, { passive: true });
 
     return () => {
+      if (scrollRafId !== null) {
+        cancelAnimationFrame(scrollRafId);
+        scrollRafId = null;
+      }
       viewportElement.removeEventListener("scroll", handleViewportScroll);
       resizeObserver.disconnect();
-      mutationObserver.disconnect();
       if (viewportRef.current === viewportElement) {
         viewportRef.current = null;
       }


### PR DESCRIPTION
Web terminal scrolling no longer asks React to reconcile on every xterm DOM mutation. The terminal now updates scrollbar metrics from scroll and resize signals, throttles scroll updates to one frame, and keeps the metrics dedupe ref in sync across resize, missing-viewport reset, and custom scrollbar drag.

Closes #1621

## Verification

- npm install
- npm run build:server
- npm run typecheck
- npm run lint
- npm run format

## Risk surface

Web terminal only. CI covers typing and linting, but it does not prove frame-time scroll smoothness; the remaining non-CI surface is a browser smoke with active terminal output and wheel/custom-scrollbar movement.