### PR TITLE
fix(server): set opencode serve cwd to home dir to stop full-filesystem scan

### DIFF
--- a/packages/server/src/server/agent/providers/opencode/server-manager.ts
+++ b/packages/server/src/server/agent/providers/opencode/server-manager.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import net from "node:net";
+import os from "node:os";
 import type { Logger } from "pino";
 
 import { findExecutable } from "../../../../executable-resolution/executable-resolution.js";
@@ -201,6 +202,7 @@ export class OpenCodeServerManager implements OpenCodeServerManagerLike {
         launchPrefix.command,
         [...launchPrefix.args, "serve", "--port", String(port)],
         {
+          cwd: os.homedir(),
           detached: process.platform !== "win32",
           stdio: ["ignore", "pipe", "pipe"],
           ...createProviderEnvSpec({


### PR DESCRIPTION
## Root cause

When Paseo's daemon is launched as a macOS GUI app (via launchd), its working directory is `/`. `OpenCodeServerManager` spawned `opencode serve` without setting `cwd`, so the child process inherited `/`. With cwd `/`, opencode's `fff_search` scanned and watched the **entire filesystem**, causing 300%+ CPU and 1GB+ RAM usage.

## Fix

Add `cwd: os.homedir()` to the `spawnProcess` options in `startServer`. This is the only spawn site for `opencode serve` (the dedicated-per-env path calls the same `startServer` method), so one change covers both code paths.

`os.homedir()` is used instead of `process.env.HOME` — it's more correct and works on Windows.

## Per-session directory is unaffected

The working directory set here is only the search/watch root for the `opencode serve` process. The actual per-session project directory is passed separately via the OpenCode SDK's `session.create({ directory })` call and is not affected by this change.

Fixes #1617