### PR TITLE
Keep projects visible after archiving workspaces

### DIFF
--- a/packages/app/src/stores/session-store-hooks/selectors.test.ts
+++ b/packages/app/src/stores/session-store-hooks/selectors.test.ts
@@ -16,7 +16,11 @@ import {
   workspaceEqualityFns,
   type SidebarOrderSnapshot,
 } from "./selectors";
-import { useSessionStore, type WorkspaceDescriptor } from "../session-store";
+import {
+  useSessionStore,
+  type EmptyProjectDescriptor,
+  type WorkspaceDescriptor,
+} from "../session-store";
 
 const SERVER_ID = "test-server";
 
@@ -85,6 +89,12 @@ function emptySidebarOrder(): SidebarOrderSnapshot {
     projectOrderByServerId: {},
     workspaceOrderByServerAndProject: {},
   };
+}
+
+function selectWorkspaceStructureProjectKeys(
+  state: Parameters<typeof selectWorkspaceStructureProjects>[0],
+): string[] {
+  return selectWorkspaceStructureProjects(state, SERVER_ID).map((project) => project.projectKey);
 }
 
 afterEach(() => {
@@ -207,6 +217,38 @@ describe("workspace structure composition", () => {
       workspaceOrderByScope: selectWorkspaceOrderByScopeForServer(sidebar, serverId),
     });
   }
+
+  it("keeps a project parent visible throughout the last workspace archive transition", () => {
+    const workspace = createWorkspace({
+      id: "workspace-a",
+      projectId: "project-a",
+      projectDisplayName: "Project A",
+      projectRootPath: "/repo/a",
+      workspaceDirectory: "/repo/a",
+    });
+    const emptyProject: EmptyProjectDescriptor = {
+      projectId: "project-a",
+      projectDisplayName: "Project A",
+      projectCustomName: null,
+      projectRootPath: "/repo/a",
+      projectKind: "git",
+    };
+    initializeWorkspaces([workspace]);
+
+    const emittedProjectKeys = [selectWorkspaceStructureProjectKeys(useSessionStore.getState())];
+    const stop = useSessionStore.subscribe((state) => {
+      emittedProjectKeys.push(selectWorkspaceStructureProjectKeys(state));
+    });
+
+    try {
+      useSessionStore.getState().removeWorkspace(SERVER_ID, workspace.id);
+      useSessionStore.getState().addEmptyProject(SERVER_ID, emptyProject);
+    } finally {
+      stop();
+    }
+
+    expect(emittedProjectKeys).toEqual([["project-a"], ["project-a"]]);
+  });
 
   it("changes for membership updates but not status-only updates", () => {
     const workspaceA = createWorkspace({ id: "workspace-a", name: "A" });

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -229,6 +229,30 @@ function preserveWorkspaceMapIdentity(
   return changed ? next : existing;
 }
 
+function emptyProjectDescriptorFromWorkspace(
+  workspace: WorkspaceDescriptor,
+): EmptyProjectDescriptor {
+  return {
+    projectId: workspace.projectId,
+    projectDisplayName: workspace.projectDisplayName,
+    projectCustomName: workspace.projectCustomName ?? null,
+    projectRootPath: workspace.projectRootPath,
+    projectKind: workspace.projectKind,
+  };
+}
+
+function hasWorkspaceInProject(
+  workspaces: ReadonlyMap<string, WorkspaceDescriptor>,
+  projectId: string,
+): boolean {
+  for (const workspace of workspaces.values()) {
+    if (workspace.projectId === projectId) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export type ExplorerEntryKind = "file" | "directory";
 export type ExplorerFileKind = "text" | "image" | "binary";
 export type ExplorerEncoding = "utf-8" | "base64" | "none";
@@ -1393,13 +1417,31 @@ export const useSessionStore = create<SessionStore>()(
           if (!session || !workspaceKey) {
             return prev;
           }
+          const removedWorkspace = session.workspaces.get(workspaceKey);
+          if (!removedWorkspace) {
+            return prev;
+          }
           const next = new Map(session.workspaces);
           next.delete(workspaceKey);
+          let nextEmptyProjects = session.emptyProjects;
+          if (hasWorkspaceInProject(next, removedWorkspace.projectId)) {
+            if (nextEmptyProjects.has(removedWorkspace.projectId)) {
+              nextEmptyProjects = new Map(nextEmptyProjects);
+              nextEmptyProjects.delete(removedWorkspace.projectId);
+            }
+          } else {
+            const emptyProject = emptyProjectDescriptorFromWorkspace(removedWorkspace);
+            const existing = nextEmptyProjects.get(emptyProject.projectId);
+            if (!existing || !equal(existing, emptyProject)) {
+              nextEmptyProjects = new Map(nextEmptyProjects);
+              nextEmptyProjects.set(emptyProject.projectId, emptyProject);
+            }
+          }
           return {
             ...prev,
             sessions: {
               ...prev.sessions,
-              [serverId]: { ...session, workspaces: next },
+              [serverId]: { ...session, workspaces: next, emptyProjects: nextEmptyProjects },
             },
           };
         });


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Archiving the last workspace in a project no longer makes the project briefly disappear from the sidebar. The frontend now preserves an empty project parent in the same store update that removes the workspace, so the sidebar never renders an intermediate no-project state. Explicit project removal still removes the project.

### How did you verify it

Reproduced the bug with a red store/selector test that emitted `[["project-a"], [], ["project-a"]]` during the archive transition. Confirmed the fix keeps the project visible throughout.

Commands run:

- `npx vitest run packages/app/src/stores/session-store-hooks/selectors.test.ts --bail=1`
- `npx vitest run packages/app/src/stores/session-store.test.ts --bail=1`
- `npm run lint -- packages/app/src/stores/session-store.ts packages/app/src/stores/session-store-hooks/selectors.test.ts`
- `npm run typecheck`
- `npm run format`

Risk surface: frontend session-store ordering for project/workspace sidebar state. The regression test covers the last-workspace archive transition; manual project removal remains covered by the existing remove path.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense