### PR TITLE
Fix Windows Kimi usage test isolation

### DIFF
--- a/packages/server/src/services/quota-fetcher/providers/kimi.ts
+++ b/packages/server/src/services/quota-fetcher/providers/kimi.ts
@@ -24,6 +24,7 @@ const KimiAuthSchema = z.object({
 interface KimiQuotaProviderOptions {
   logger: Logger;
   fetch?: ProviderApiFetch;
+  homeDir?: string;
 }
 
 export class KimiQuotaProvider implements ProviderUsageFetcher {
@@ -32,10 +33,12 @@ export class KimiQuotaProvider implements ProviderUsageFetcher {
 
   private readonly logger: Logger;
   private readonly fetchApi: ProviderApiFetch;
+  private readonly homeDir?: string;
 
   constructor(options: KimiQuotaProviderOptions) {
     this.logger = options.logger;
     this.fetchApi = options.fetch ?? fetch;
+    this.homeDir = options.homeDir;
   }
 
   async fetchUsage(): Promise<ProviderUsage> {
@@ -88,13 +91,14 @@ export class KimiQuotaProvider implements ProviderUsageFetcher {
   }
 
   private async readKimiToken(): Promise<string | null> {
+    const homeDir = this.homeDir ?? homedir();
     const paths = [
       join(
-        process.env["KIMI_CODE_HOME"] || join(homedir(), ".kimi-code"),
+        process.env["KIMI_CODE_HOME"] || join(homeDir, ".kimi-code"),
         "credentials",
         "kimi-code.json",
       ),
-      join(homedir(), ".kimi", "credentials", "kimi-code.json"),
+      join(homeDir, ".kimi", "credentials", "kimi-code.json"),
     ];
 
     for (const path of paths) {

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -335,7 +335,11 @@ describe("real provider usage fetchers", () => {
   });
 
   function service(
-    options: { platform?: typeof process.platform; keychain?: () => Promise<unknown | null> } = {},
+    options: {
+      platform?: typeof process.platform;
+      keychain?: () => Promise<unknown | null>;
+      kimiHomeDir?: string;
+    } = {},
   ) {
     const logger = createLogger();
     const fetchThroughTestDouble = ((url: RequestInfo | URL, init?: RequestInit) =>
@@ -356,7 +360,11 @@ describe("real provider usage fetchers", () => {
         new CursorQuotaProvider({ logger, fetch: fetchThroughTestDouble }),
         new ZaiQuotaProvider({ logger, fetch: fetchThroughTestDouble }),
         new GrokQuotaProvider({ logger, fetch: fetchThroughTestDouble }),
-        new KimiQuotaProvider({ logger, fetch: fetchThroughTestDouble }),
+        new KimiQuotaProvider({
+          logger,
+          fetch: fetchThroughTestDouble,
+          homeDir: options.kimiHomeDir,
+        }),
       ],
       cacheTtlMs: 0,
     });
@@ -712,11 +720,11 @@ describe("real provider usage fetchers", () => {
 
   it("fetches Kimi usage from the CLI credential home", async () => {
     writeKimiCredentials(join(homeDir, ".kimi-code"), "kimi_cli_token");
-    fetchApi = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
-      expect(url.toString()).toBe("https://api.kimi.com/coding/v1/usages");
-      expect((init?.headers as Record<string, string> | undefined)?.Authorization).toBe(
-        "Bearer kimi_cli_token",
-      );
+    let requestedUrl: string | null = null;
+    let authorization: string | null = null;
+    fetchApi = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      requestedUrl = url.toString();
+      authorization = (init?.headers as Record<string, string> | undefined)?.Authorization ?? null;
       return jsonResponse({
         usage: {
           limit: "200",
@@ -726,8 +734,10 @@ describe("real provider usage fetchers", () => {
       });
     }) as unknown as typeof fetch;
 
-    const kimi = findProvider(await service().listUsage(), "kimi");
+    const kimi = findProvider(await service({ kimiHomeDir: homeDir }).listUsage(), "kimi");
 
+    expect(requestedUrl).toBe("https://api.kimi.com/coding/v1/usages");
+    expect(authorization).toBe("Bearer kimi_cli_token");
     expect(kimi).toMatchObject({
       status: "available",
       windows: [


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The Kimi usage test no longer depends on mutating the process home environment. The Kimi quota provider now accepts an injected home directory, so the test can point the provider at its temp credential home directly and still verify the default `.kimi-code` credential lookup.

This should fix the Windows CI failure where Node resolved `os.homedir()` from the runner profile instead of the test's `HOME` override.

### How did you verify it

- `npx vitest run packages/server/src/services/quota-fetcher/service.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- Pre-commit hook reran targeted lint, format check, and typecheck.

Windows-specific verification is the CI `server-tests (windows-latest)` job on this PR.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense