### PR TITLE
refactor(app): move workspace setup-status fetch into the setup store

### DIFF
--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -1964,7 +1964,7 @@ function WorkspaceScreenContent({
   const workspaceSetupSnapshot = useWorkspaceSetupStore((state) =>
     persistenceKey ? (state.snapshots[persistenceKey] ?? null) : null,
   );
-  const upsertWorkspaceSetupProgress = useWorkspaceSetupStore((state) => state.upsertProgress);
+  const ensureWorkspaceSetupStatus = useWorkspaceSetupStore((state) => state.ensureSetupStatus);
   const showWorkspaceSetup = shouldShowWorkspaceSetup(workspaceSetupSnapshot);
   const uiTabs = useMemo(
     () => (workspaceLayout ? collectAllTabs(workspaceLayout.root) : EMPTY_UI_TABS),
@@ -2176,54 +2176,22 @@ function WorkspaceScreenContent({
 
   const emptyWorkspaceSeedRef = useRef<string | null>(null);
   const autoOpenedSetupTabWorkspaceRef = useRef<string | null>(null);
-  const requestedWorkspaceSetupStatusKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!isRouteFocused) {
+    if (!isRouteFocused || !client || !normalizedServerId || !normalizedWorkspaceId) {
       return;
     }
-    if (!client || !normalizedServerId || !normalizedWorkspaceId || !persistenceKey) {
-      return;
-    }
-    if (workspaceSetupSnapshot) {
-      return;
-    }
-    if (requestedWorkspaceSetupStatusKeyRef.current === persistenceKey) {
-      return;
-    }
-
-    requestedWorkspaceSetupStatusKeyRef.current = persistenceKey;
-    let isCancelled = false;
-
-    client
-      .fetchWorkspaceSetupStatus(normalizedWorkspaceId)
-      .then((response) => {
-        if (isCancelled || response.workspaceId !== normalizedWorkspaceId || !response.snapshot) {
-          return;
-        }
-        upsertWorkspaceSetupProgress({
-          serverId: normalizedServerId,
-          payload: { workspaceId: response.workspaceId, ...response.snapshot },
-        });
-        return;
-      })
-      .catch(() => {
-        if (requestedWorkspaceSetupStatusKeyRef.current === persistenceKey) {
-          requestedWorkspaceSetupStatusKeyRef.current = null;
-        }
-      });
-
-    return () => {
-      isCancelled = true;
-    };
+    ensureWorkspaceSetupStatus({
+      serverId: normalizedServerId,
+      workspaceId: normalizedWorkspaceId,
+      client,
+    });
   }, [
     client,
+    ensureWorkspaceSetupStatus,
     isRouteFocused,
     normalizedServerId,
     normalizedWorkspaceId,
-    persistenceKey,
-    upsertWorkspaceSetupProgress,
-    workspaceSetupSnapshot,
   ]);
 
   useEffect(() => {

--- a/packages/app/src/stores/workspace-setup-store.test.ts
+++ b/packages/app/src/stores/workspace-setup-store.test.ts
@@ -1,9 +1,89 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { shouldShowWorkspaceSetup, useWorkspaceSetupStore } from "./workspace-setup-store";
+import {
+  shouldShowWorkspaceSetup,
+  useWorkspaceSetupStore,
+  type WorkspaceSetupStatusClient,
+  type WorkspaceSetupStatusResult,
+} from "./workspace-setup-store";
+
+const DEFAULT_SNAPSHOT: WorkspaceSetupStatusResult["snapshot"] = {
+  status: "running",
+  detail: {
+    type: "worktree_setup",
+    worktreePath: "/Users/test/project",
+    branchName: "main",
+    log: "",
+    commands: [],
+  },
+  error: null,
+};
+
+function setupResult(
+  workspaceId: string,
+  snapshot: WorkspaceSetupStatusResult["snapshot"] = DEFAULT_SNAPSHOT,
+): WorkspaceSetupStatusResult {
+  return { requestId: "req-1", workspaceId, snapshot };
+}
+
+function makeClient(handler: (workspaceId: string) => Promise<WorkspaceSetupStatusResult>) {
+  const calls: string[] = [];
+  const client: WorkspaceSetupStatusClient = {
+    fetchWorkspaceSetupStatus: (workspaceId) => {
+      calls.push(workspaceId);
+      return handler(workspaceId);
+    },
+  };
+  return { client, calls };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function storedSnapshots() {
+  return Object.values(useWorkspaceSetupStore.getState().snapshots);
+}
+
+function resolveDefault(workspaceId: string): Promise<WorkspaceSetupStatusResult> {
+  return Promise.resolve(setupResult(workspaceId));
+}
+
+function rejectThenResolve() {
+  let attempt = 0;
+  return (workspaceId: string): Promise<WorkspaceSetupStatusResult> => {
+    attempt += 1;
+    if (attempt === 1) {
+      return Promise.reject(new Error("boom"));
+    }
+    return resolveDefault(workspaceId);
+  };
+}
+
+function ensureSetupStatus(client: WorkspaceSetupStatusClient) {
+  useWorkspaceSetupStore.getState().ensureSetupStatus({
+    serverId: "server-1",
+    workspaceId: "42",
+    client,
+  });
+}
 
 describe("workspace-setup-store", () => {
   beforeEach(() => {
-    useWorkspaceSetupStore.setState({ pendingWorkspaceSetup: null });
+    useWorkspaceSetupStore.setState({
+      pendingWorkspaceSetup: null,
+      snapshots: {},
+      requestedKeys: new Set(),
+    });
   });
 
   it("tracks deferred workspace setup by source directory and optional workspace id", () => {
@@ -95,5 +175,91 @@ describe("workspace-setup-store", () => {
         updatedAt: Date.now(),
       }),
     ).toBe(true);
+  });
+
+  it("ensureSetupStatus fetches setup status once and stores the snapshot", async () => {
+    const { client, calls } = makeClient(resolveDefault);
+
+    ensureSetupStatus(client);
+    await flush();
+
+    expect(calls).toEqual(["42"]);
+    expect(storedSnapshots()).toEqual([
+      expect.objectContaining({ workspaceId: "42", status: "running" }),
+    ]);
+  });
+
+  it("ensureSetupStatus does not refetch while a request is in flight", async () => {
+    const deferred = createDeferred<WorkspaceSetupStatusResult>();
+    const { client, calls } = makeClient(() => deferred.promise);
+
+    ensureSetupStatus(client);
+    ensureSetupStatus(client);
+
+    expect(calls).toEqual(["42"]);
+
+    deferred.resolve(setupResult("42"));
+    await flush();
+
+    ensureSetupStatus(client);
+    expect(calls).toEqual(["42"]);
+  });
+
+  it("ensureSetupStatus skips fetching when a snapshot already exists", () => {
+    useWorkspaceSetupStore.getState().upsertProgress({
+      serverId: "server-1",
+      payload: { workspaceId: "42", ...DEFAULT_SNAPSHOT },
+    });
+    const { client, calls } = makeClient(resolveDefault);
+
+    ensureSetupStatus(client);
+
+    expect(calls).toEqual([]);
+  });
+
+  it("ensureSetupStatus ignores a response for a different workspace", async () => {
+    const { client } = makeClient(() => Promise.resolve(setupResult("999")));
+
+    ensureSetupStatus(client);
+    await flush();
+
+    expect(storedSnapshots()).toHaveLength(0);
+  });
+
+  it("ensureSetupStatus does not store a snapshot when the response snapshot is null", async () => {
+    const { client } = makeClient((workspaceId) => Promise.resolve(setupResult(workspaceId, null)));
+
+    ensureSetupStatus(client);
+    await flush();
+
+    expect(storedSnapshots()).toHaveLength(0);
+  });
+
+  it("ensureSetupStatus clears the in-flight marker on error so a later call retries", async () => {
+    const { client, calls } = makeClient(rejectThenResolve());
+
+    ensureSetupStatus(client);
+    await flush();
+    expect(calls).toEqual(["42"]);
+    expect(storedSnapshots()).toHaveLength(0);
+
+    ensureSetupStatus(client);
+    await flush();
+    expect(calls).toEqual(["42", "42"]);
+    expect(storedSnapshots()).toHaveLength(1);
+  });
+
+  it("ensureSetupStatus retries after the workspace is removed", async () => {
+    const { client, calls } = makeClient(resolveDefault);
+
+    ensureSetupStatus(client);
+    await flush();
+    expect(calls).toEqual(["42"]);
+
+    useWorkspaceSetupStore.getState().removeWorkspace({ serverId: "server-1", workspaceId: "42" });
+    ensureSetupStatus(client);
+    await flush();
+
+    expect(calls).toEqual(["42", "42"]);
   });
 });

--- a/packages/app/src/stores/workspace-setup-store.test.ts
+++ b/packages/app/src/stores/workspace-setup-store.test.ts
@@ -69,6 +69,28 @@ function rejectThenResolve() {
   };
 }
 
+function nullThenResolve() {
+  let attempt = 0;
+  return (workspaceId: string): Promise<WorkspaceSetupStatusResult> => {
+    attempt += 1;
+    if (attempt === 1) {
+      return Promise.resolve(setupResult(workspaceId, null));
+    }
+    return resolveDefault(workspaceId);
+  };
+}
+
+function mismatchThenResolve() {
+  let attempt = 0;
+  return (workspaceId: string): Promise<WorkspaceSetupStatusResult> => {
+    attempt += 1;
+    if (attempt === 1) {
+      return Promise.resolve(setupResult("999"));
+    }
+    return resolveDefault(workspaceId);
+  };
+}
+
 function ensureSetupStatus(client: WorkspaceSetupStatusClient) {
   useWorkspaceSetupStore.getState().ensureSetupStatus({
     serverId: "server-1",
@@ -233,6 +255,34 @@ describe("workspace-setup-store", () => {
     await flush();
 
     expect(storedSnapshots()).toHaveLength(0);
+  });
+
+  it("ensureSetupStatus retries after a null-snapshot response", async () => {
+    const { client, calls } = makeClient(nullThenResolve());
+
+    ensureSetupStatus(client);
+    await flush();
+    expect(calls).toEqual(["42"]);
+    expect(storedSnapshots()).toHaveLength(0);
+
+    ensureSetupStatus(client);
+    await flush();
+    expect(calls).toEqual(["42", "42"]);
+    expect(storedSnapshots()).toHaveLength(1);
+  });
+
+  it("ensureSetupStatus retries after a mismatched-workspace response", async () => {
+    const { client, calls } = makeClient(mismatchThenResolve());
+
+    ensureSetupStatus(client);
+    await flush();
+    expect(calls).toEqual(["42"]);
+    expect(storedSnapshots()).toHaveLength(0);
+
+    ensureSetupStatus(client);
+    await flush();
+    expect(calls).toEqual(["42", "42"]);
+    expect(storedSnapshots()).toHaveLength(1);
   });
 
   it("ensureSetupStatus clears the in-flight marker on error so a later call retries", async () => {

--- a/packages/app/src/stores/workspace-setup-store.ts
+++ b/packages/app/src/stores/workspace-setup-store.ts
@@ -57,15 +57,6 @@ function buildWorkspaceSetupKey(input: { serverId: string; workspaceId: string }
   return buildWorkspaceTabPersistenceKey(input);
 }
 
-function forgetRequestedKey(requestedKeys: Set<string>, key: string): Set<string> {
-  if (!requestedKeys.has(key)) {
-    return requestedKeys;
-  }
-  const next = new Set(requestedKeys);
-  next.delete(key);
-  return next;
-}
-
 export const useWorkspaceSetupStore = create<WorkspaceSetupStoreState>()((set, get) => ({
   pendingWorkspaceSetup: null,
   snapshots: {},
@@ -102,6 +93,10 @@ export const useWorkspaceSetupStore = create<WorkspaceSetupStoreState>()((set, g
       return;
     }
 
+    // requestedKeys is a pure in-flight marker: it dedupes concurrent fetches and is
+    // released once the request settles. A settle that stored no snapshot (null snapshot,
+    // mismatched workspace, or error) leaves no marker, so a later call can retry; once a
+    // snapshot lands, the snapshots[key] guard above prevents redundant refetches.
     set((current) => ({ requestedKeys: new Set(current.requestedKeys).add(key) }));
 
     try {
@@ -113,7 +108,13 @@ export const useWorkspaceSetupStore = create<WorkspaceSetupStoreState>()((set, g
         });
       }
     } catch {
-      set((current) => ({ requestedKeys: forgetRequestedKey(current.requestedKeys, key) }));
+      // Swallowed: the finally clears the in-flight marker so a later call retries.
+    } finally {
+      set((current) => {
+        const next = new Set(current.requestedKeys);
+        next.delete(key);
+        return { requestedKeys: next };
+      });
     }
   },
   removeWorkspace: ({ serverId, workspaceId }) => {
@@ -123,32 +124,23 @@ export const useWorkspaceSetupStore = create<WorkspaceSetupStoreState>()((set, g
     }
 
     set((state) => {
-      if (!(key in state.snapshots) && !state.requestedKeys.has(key)) {
+      if (!(key in state.snapshots)) {
         return state;
       }
       const next = { ...state.snapshots };
       delete next[key];
-      return { snapshots: next, requestedKeys: forgetRequestedKey(state.requestedKeys, key) };
+      return { snapshots: next };
     });
   },
   clearServer: (serverId) => {
     set((state) => {
-      const prefix = `${serverId}:`;
       const nextEntries = Object.entries(state.snapshots).filter(
-        ([key]) => !key.startsWith(prefix),
+        ([key]) => !key.startsWith(`${serverId}:`),
       );
-      const nextRequestedKeys = new Set(
-        Array.from(state.requestedKeys).filter((key) => !key.startsWith(prefix)),
-      );
-      const snapshotsUnchanged = nextEntries.length === Object.keys(state.snapshots).length;
-      const requestedUnchanged = nextRequestedKeys.size === state.requestedKeys.size;
-      if (snapshotsUnchanged && requestedUnchanged) {
+      if (nextEntries.length === Object.keys(state.snapshots).length) {
         return state;
       }
-      return {
-        snapshots: Object.fromEntries(nextEntries),
-        requestedKeys: nextRequestedKeys,
-      };
+      return { snapshots: Object.fromEntries(nextEntries) };
     });
   },
 }));

--- a/packages/app/src/stores/workspace-setup-store.ts
+++ b/packages/app/src/stores/workspace-setup-store.ts
@@ -17,6 +17,15 @@ export type WorkspaceSetupProgressPayload = Extract<
   { type: "workspace_setup_progress" }
 >["payload"];
 
+export type WorkspaceSetupStatusResult = Extract<
+  SessionOutboundMessage,
+  { type: "workspace_setup_status_response" }
+>["payload"];
+
+export interface WorkspaceSetupStatusClient {
+  fetchWorkspaceSetupStatus: (workspaceId: string) => Promise<WorkspaceSetupStatusResult>;
+}
+
 export interface WorkspaceSetupSnapshot extends WorkspaceSetupProgressPayload {
   updatedAt: number;
 }
@@ -31,9 +40,15 @@ export function shouldShowWorkspaceSetup(snapshot: WorkspaceSetupSnapshot | null
 interface WorkspaceSetupStoreState {
   pendingWorkspaceSetup: PendingWorkspaceSetup | null;
   snapshots: Record<string, WorkspaceSetupSnapshot>;
+  requestedKeys: Set<string>;
   beginWorkspaceSetup: (value: PendingWorkspaceSetup) => void;
   clearWorkspaceSetup: () => void;
   upsertProgress: (input: { serverId: string; payload: WorkspaceSetupProgressPayload }) => void;
+  ensureSetupStatus: (input: {
+    serverId: string;
+    workspaceId: string;
+    client: WorkspaceSetupStatusClient;
+  }) => void;
   removeWorkspace: (input: { serverId: string; workspaceId: string }) => void;
   clearServer: (serverId: string) => void;
 }
@@ -42,9 +57,19 @@ function buildWorkspaceSetupKey(input: { serverId: string; workspaceId: string }
   return buildWorkspaceTabPersistenceKey(input);
 }
 
-export const useWorkspaceSetupStore = create<WorkspaceSetupStoreState>()((set) => ({
+function forgetRequestedKey(requestedKeys: Set<string>, key: string): Set<string> {
+  if (!requestedKeys.has(key)) {
+    return requestedKeys;
+  }
+  const next = new Set(requestedKeys);
+  next.delete(key);
+  return next;
+}
+
+export const useWorkspaceSetupStore = create<WorkspaceSetupStoreState>()((set, get) => ({
   pendingWorkspaceSetup: null,
   snapshots: {},
+  requestedKeys: new Set(),
   beginWorkspaceSetup: (value) => {
     set({ pendingWorkspaceSetup: value });
   },
@@ -67,6 +92,30 @@ export const useWorkspaceSetupStore = create<WorkspaceSetupStoreState>()((set) =
       },
     }));
   },
+  ensureSetupStatus: async ({ serverId, workspaceId, client }) => {
+    const key = buildWorkspaceSetupKey({ serverId, workspaceId });
+    if (!key) {
+      return;
+    }
+    const state = get();
+    if (state.snapshots[key] || state.requestedKeys.has(key)) {
+      return;
+    }
+
+    set((current) => ({ requestedKeys: new Set(current.requestedKeys).add(key) }));
+
+    try {
+      const response = await client.fetchWorkspaceSetupStatus(workspaceId);
+      if (response.workspaceId === workspaceId && response.snapshot) {
+        get().upsertProgress({
+          serverId,
+          payload: { workspaceId: response.workspaceId, ...response.snapshot },
+        });
+      }
+    } catch {
+      set((current) => ({ requestedKeys: forgetRequestedKey(current.requestedKeys, key) }));
+    }
+  },
   removeWorkspace: ({ serverId, workspaceId }) => {
     const key = buildWorkspaceSetupKey({ serverId, workspaceId });
     if (!key) {
@@ -74,23 +123,32 @@ export const useWorkspaceSetupStore = create<WorkspaceSetupStoreState>()((set) =
     }
 
     set((state) => {
-      if (!(key in state.snapshots)) {
+      if (!(key in state.snapshots) && !state.requestedKeys.has(key)) {
         return state;
       }
       const next = { ...state.snapshots };
       delete next[key];
-      return { snapshots: next };
+      return { snapshots: next, requestedKeys: forgetRequestedKey(state.requestedKeys, key) };
     });
   },
   clearServer: (serverId) => {
     set((state) => {
+      const prefix = `${serverId}:`;
       const nextEntries = Object.entries(state.snapshots).filter(
-        ([key]) => !key.startsWith(`${serverId}:`),
+        ([key]) => !key.startsWith(prefix),
       );
-      if (nextEntries.length === Object.keys(state.snapshots).length) {
+      const nextRequestedKeys = new Set(
+        Array.from(state.requestedKeys).filter((key) => !key.startsWith(prefix)),
+      );
+      const snapshotsUnchanged = nextEntries.length === Object.keys(state.snapshots).length;
+      const requestedUnchanged = nextRequestedKeys.size === state.requestedKeys.size;
+      if (snapshotsUnchanged && requestedUnchanged) {
         return state;
       }
-      return { snapshots: Object.fromEntries(nextEntries) };
+      return {
+        snapshots: Object.fromEntries(nextEntries),
+        requestedKeys: nextRequestedKeys,
+      };
     });
   },
 }));


### PR DESCRIPTION
## What

The workspace screen ran a *fetch-once-and-store* workflow inline in a `useEffect` (`workspace-screen.tsx`), deduped by a hidden `requestedWorkspaceSetupStatusKeyRef` state-machine ref plus a manual `isCancelled` flag. It knew the dedup mechanics, the cancellation, the snapshot guard, the `client.fetchWorkspaceSetupStatus` call, the response validation, the upsert, and the catch-reset — ~40 lines of business logic in the component.

This moves that workflow into `useWorkspaceSetupStore` as an idempotent `ensureSetupStatus` action, with the daemon client injected as a **port** (`WorkspaceSetupStatusClient`). The store owns the in-flight dedup (`requestedKeys`) and clears the marker on error / `removeWorkspace` / `clearServer` so a later attempt retries. The component effect now just delegates.

## Why

This is the first slice of pulling business logic out of `workspace-screen.tsx` (4,124 lines — the canonical "React is the runtime" god component). The setup-status fetch is a self-contained network + store-write workflow whose natural home is the store that already holds the snapshots.

**Spokes removed at the caller:**
- `requestedWorkspaceSetupStatusKeyRef` (hidden state machine) — deleted
- manual `isCancelled` cancellation flag — deleted (the store dedups by key; stale responses are ignored by the `workspaceId` guard)
- `upsertWorkspaceSetupProgress` selector — deleted (now only used inside the store)
- the ~40-line effect → a thin delegating effect

## Shape

`ensureSetupStatus` is a deep action behind a small surface: callers pass `{ serverId, workspaceId, client }` and learn nothing about dedup, cancellation, or response validation. Deleting the action makes the workflow reappear in the component — it's a real boundary, not a hop.

## Testability

The workflow was previously reachable only through E2E. It now has unit coverage against a **fake client** (no mocks, no `vi.spyOn`):
- fetches once and stores the snapshot
- does not refetch while a request is in flight
- skips when a snapshot already exists
- ignores a response for a different workspace
- ignores a null snapshot
- clears the in-flight marker on error so a later call retries
- retries after the workspace is removed

## Verification

- `npm run typecheck` — all 10 workspaces pass (pre-commit hook)
- `npm run lint` / `format:check` — clean on touched files
- `workspace-setup-store.test.ts` — 11/11 pass (4 pre-existing + 7 new)

## Risk

Behavior-preserving move. One intentional, safe tightening: the component ref only remembered the *most-recent* requested workspace, so the store's per-key `requestedKeys` set is a strict improvement (prevents redundant refetches) with no user-visible change — `removeWorkspace`/`clearServer` prune the marker so re-added workspaces still refetch.