### PR TITLE
feat(app): clearer interactive question card

### DIFF
--- a/packages/app/e2e/helpers/questions.ts
+++ b/packages/app/e2e/helpers/questions.ts
@@ -19,18 +19,19 @@ export async function expectQuestionHidden(page: Page, question: string): Promis
   await expect(page.getByText(question, { exact: true })).toHaveCount(0);
 }
 
+// Options render as radios (single-select) or checkboxes (multi-select), so match
+// either role by accessible name.
+function questionOption(page: Page, option: string) {
+  const card = page.getByTestId("question-form-card").first();
+  return card.getByRole("radio", { name: option }).or(card.getByRole("checkbox", { name: option }));
+}
+
 export async function chooseQuestionOption(page: Page, option: string): Promise<void> {
-  await page
-    .getByTestId("question-form-card")
-    .first()
-    .getByRole("button", { name: option })
-    .click();
+  await questionOption(page, option).click();
 }
 
 export async function expectQuestionOptionSelected(page: Page, option: string): Promise<void> {
-  await expect(
-    page.getByTestId("question-form-card").first().getByRole("button", { name: option }),
-  ).toHaveAttribute("aria-selected", "true");
+  await expect(questionOption(page, option)).toHaveAttribute("aria-checked", "true");
 }
 
 export async function openQuestion(

--- a/packages/app/e2e/helpers/questions.ts
+++ b/packages/app/e2e/helpers/questions.ts
@@ -10,9 +10,10 @@ export async function expectCurrentQuestion(
 ): Promise<void> {
   const card = page.getByTestId("question-form-card").first();
   await expect(card.getByTestId("question-form-current-question")).toHaveText(input.question);
-  await expect(
-    card.getByRole("button", { name: `Question ${input.index} of ${input.total}` }),
-  ).toHaveAttribute("aria-selected", "true");
+  // Nav tabs only render for multi-question cards (hidden for a lone question).
+  if (input.total > 1) {
+    await expect(questionNavTab(page, input)).toHaveAttribute("aria-selected", "true");
+  }
 }
 
 export async function expectQuestionHidden(page: Page, question: string): Promise<void> {
@@ -24,6 +25,14 @@ export async function expectQuestionHidden(page: Page, question: string): Promis
 function questionOption(page: Page, option: string) {
   const card = page.getByTestId("question-form-card").first();
   return card.getByRole("radio", { name: option }).or(card.getByRole("checkbox", { name: option }));
+}
+
+// The multi-question nav renders as a tablist; each question is a tab.
+function questionNavTab(page: Page, input: { index: number; total: number }) {
+  return page
+    .getByTestId("question-form-card")
+    .first()
+    .getByRole("tab", { name: `Question ${input.index} of ${input.total}` });
 }
 
 export async function chooseQuestionOption(page: Page, option: string): Promise<void> {
@@ -38,23 +47,14 @@ export async function openQuestion(
   page: Page,
   input: { index: number; total: number },
 ): Promise<void> {
-  await page
-    .getByTestId("question-form-card")
-    .first()
-    .getByRole("button", { name: `Question ${input.index} of ${input.total}` })
-    .click();
+  await questionNavTab(page, input).click();
 }
 
 export async function expectQuestionNavigationEnabled(
   page: Page,
   input: { index: number; total: number },
 ): Promise<void> {
-  await expect(
-    page
-      .getByTestId("question-form-card")
-      .first()
-      .getByRole("button", { name: `Question ${input.index} of ${input.total}` }),
-  ).toBeEnabled();
+  await expect(questionNavTab(page, input)).toBeEnabled();
 }
 
 export async function fillQuestionAnswer(

--- a/packages/app/src/components/question-form-card.tsx
+++ b/packages/app/src/components/question-form-card.tsx
@@ -92,30 +92,49 @@ function QuestionOptionRow({
     () => [styles.optionDescription, { color: theme.colors.foregroundMuted }],
     [theme.colors.foregroundMuted],
   );
-  const accessibilityState = useMemo(() => ({ selected: isSelected }), [isSelected]);
+  const accessibilityState = useMemo(() => ({ checked: isSelected }), [isSelected]);
+
+  // Static left-side control: square for multi-select, circle for single-select.
+  // Always rendered so toggling only swaps fill/border — the row never reflows.
+  const controlStyle = useMemo(
+    () => [
+      styles.selectionControl,
+      multiSelect ? styles.selectionControlCheckbox : styles.selectionControlRadio,
+      {
+        borderColor: isSelected ? theme.colors.accent : theme.colors.foregroundMuted,
+        backgroundColor: isSelected && multiSelect ? theme.colors.accent : "transparent",
+      },
+    ],
+    [isSelected, multiSelect, theme.colors.accent, theme.colors.foregroundMuted],
+  );
+  const radioDotStyle = useMemo(
+    () => [styles.selectionRadioDot, { backgroundColor: theme.colors.accent }],
+    [theme.colors.accent],
+  );
 
   return (
     <Pressable
       style={pressableStyle}
       onPress={handlePress}
       disabled={isResponding}
-      accessibilityRole="button"
+      accessibilityRole={multiSelect ? "checkbox" : "radio"}
       accessibilityLabel={option.label}
       accessibilityState={accessibilityState}
-      aria-selected={isSelected}
+      aria-checked={isSelected}
     >
       <View style={styles.optionItemContent}>
+        <View style={controlStyle}>
+          {isSelected && multiSelect ? (
+            <Check size={12} color={theme.colors.accentForeground} />
+          ) : null}
+          {isSelected && !multiSelect ? <View style={radioDotStyle} /> : null}
+        </View>
         <View style={styles.optionTextBlock}>
           <Text style={optionLabelStyle}>{option.label}</Text>
           {option.description ? (
             <Text style={optionDescriptionStyle}>{option.description}</Text>
           ) : null}
         </View>
-        {isSelected ? (
-          <View style={styles.optionCheckSlot}>
-            <Check size={16} color={theme.colors.foregroundMuted} />
-          </View>
-        ) : null}
       </View>
     </Pressable>
   );
@@ -124,7 +143,9 @@ function QuestionOptionRow({
 interface QuestionNavButtonProps {
   index: number;
   total: number;
+  header: string;
   isActive: boolean;
+  isAnswered: boolean;
   isResponding: boolean;
   onSelect: (index: number) => void;
 }
@@ -132,7 +153,9 @@ interface QuestionNavButtonProps {
 function QuestionNavButton({
   index,
   total,
+  header,
   isActive,
+  isAnswered,
   isResponding,
   onSelect,
 }: QuestionNavButtonProps) {
@@ -180,8 +203,54 @@ function QuestionNavButton({
       onPress={handlePress}
       disabled={isResponding}
     >
-      <Text style={textStyle}>{index + 1}</Text>
+      {isAnswered ? (
+        <Check
+          size={12}
+          color={isActive ? theme.colors.foreground : theme.colors.foregroundMuted}
+        />
+      ) : null}
+      <Text style={textStyle} numberOfLines={1}>
+        {header}
+      </Text>
     </Pressable>
+  );
+}
+
+interface QuestionNavProps {
+  questions: QuestionFormQuestion[];
+  activeIndex: number;
+  isAnswered: (qIndex: number) => boolean;
+  isResponding: boolean;
+  onSelect: (index: number) => void;
+}
+
+// Titled tabs (one per question header) with a check on answered ones. Hidden for
+// a lone question — a single "1 of 1" tab carries no information.
+function QuestionNav({
+  questions,
+  activeIndex,
+  isAnswered,
+  isResponding,
+  onSelect,
+}: QuestionNavProps) {
+  if (questions.length <= 1) {
+    return null;
+  }
+  return (
+    <View style={styles.questionNav} testID="question-form-question-nav">
+      {questions.map((question, qIndex) => (
+        <QuestionNavButton
+          key={question.header}
+          index={qIndex}
+          total={questions.length}
+          header={question.header}
+          isActive={qIndex === activeIndex}
+          isAnswered={isAnswered(qIndex)}
+          isResponding={isResponding}
+          onSelect={onSelect}
+        />
+      ))}
+    </View>
   );
 }
 
@@ -355,6 +424,12 @@ export function QuestionFormCard({ permission, onRespond, isResponding }: Questi
     setActiveQuestionIndex(index);
   }, []);
 
+  const navIsAnswered = useCallback(
+    (qIndex: number) =>
+      questions ? isQuestionAnswered(questions[qIndex], qIndex, selections, otherTexts) : false,
+    [questions, selections, otherTexts],
+  );
+
   const handlePrimaryAction = useCallback(() => {
     if (!isLastQuestion) {
       if (!activeQuestionAnswered || isResponding) return;
@@ -407,9 +482,16 @@ export function QuestionFormCard({ permission, onRespond, isResponding }: Questi
     () => [styles.questionText, { color: theme.colors.foreground }],
     [theme.colors.foreground],
   );
-  const questionNavStyle = useMemo(
-    () => [styles.questionNav, isMobile && styles.questionNavMobile],
-    [isMobile],
+  // Single-select radios need a group; checkboxes are valid standalone.
+  const optionsGroupAccessibility = useMemo(
+    () =>
+      activeQuestion && !activeQuestion.multiSelect
+        ? ({
+            accessibilityRole: "radiogroup",
+            accessibilityLabel: activeQuestion.question,
+          } as const)
+        : {},
+    [activeQuestion],
   );
   const actionsContainerStyle = useMemo(
     () => [styles.actionsContainer, !isMobile && styles.actionsContainerDesktop],
@@ -436,33 +518,23 @@ export function QuestionFormCard({ permission, onRespond, isResponding }: Questi
 
   return (
     <View style={containerStyle} testID="question-form-card">
-      <View style={styles.questionTopRow}>
-        <View style={styles.questionHeader}>
-          <Text testID="question-form-current-question" style={questionTextStyle}>
-            {activeQuestion?.question}
-          </Text>
-        </View>
-        <View style={questionNavStyle} testID="question-form-question-nav">
-          {questions.map((question, qIndex) => {
-            const isActive = qIndex === resolvedActiveQuestionIndex;
-            return (
-              <QuestionNavButton
-                key={question.header}
-                index={qIndex}
-                total={questions.length}
-                isActive={isActive}
-                isResponding={isResponding}
-                onSelect={handleSelectQuestion}
-              />
-            );
-          })}
-        </View>
+      <QuestionNav
+        questions={questions}
+        activeIndex={resolvedActiveQuestionIndex}
+        isAnswered={navIsAnswered}
+        isResponding={isResponding}
+        onSelect={handleSelectQuestion}
+      />
+      <View style={styles.questionHeader}>
+        <Text testID="question-form-current-question" style={questionTextStyle}>
+          {activeQuestion?.question}
+        </Text>
       </View>
 
       {activeQuestion ? (
         <View key={activeQuestion.question} style={styles.questionBlock}>
           {activeQuestion.options.length > 0 ? (
-            <View style={styles.optionsWrap}>
+            <View style={styles.optionsWrap} {...optionsGroupAccessibility}>
               {activeQuestion.options.map((opt, optIndex) => (
                 <QuestionOptionRow
                   key={opt.label}
@@ -546,12 +618,6 @@ const styles = StyleSheet.create((theme) => ({
   questionBlock: {
     gap: theme.spacing[2],
   },
-  questionTopRow: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    justifyContent: "space-between",
-    gap: theme.spacing[3],
-  },
   questionHeader: {
     flexDirection: "row",
     alignItems: "center",
@@ -571,24 +637,24 @@ const styles = StyleSheet.create((theme) => ({
   },
   questionNav: {
     flexDirection: "row",
+    flexWrap: "wrap",
     alignItems: "center",
-    justifyContent: "flex-end",
     gap: theme.spacing[1],
-  },
-  questionNavMobile: {
-    paddingRight: theme.spacing[1],
+    paddingHorizontal: theme.spacing[3],
   },
   questionNavButton: {
-    minWidth: 28,
-    height: 28,
+    flexDirection: "row",
     alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 999,
+    gap: theme.spacing[1],
+    minHeight: 28,
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: theme.spacing[1],
+    borderRadius: theme.borderRadius.md,
     borderWidth: theme.borderWidth[1],
   },
   questionNavText: {
-    fontSize: theme.fontSize.xs,
-    fontWeight: "700",
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
   },
   optionItem: {
     flexDirection: "row",
@@ -603,25 +669,40 @@ const styles = StyleSheet.create((theme) => ({
   optionItemContent: {
     flex: 1,
     flexDirection: "row",
-    alignItems: "center",
+    alignItems: "flex-start",
     gap: theme.spacing[2],
   },
   optionTextBlock: {
     flex: 1,
-    gap: 2,
+    gap: theme.spacing[1],
   },
   optionLabel: {
-    fontSize: theme.fontSize.sm,
+    fontSize: theme.fontSize.base,
+    fontWeight: theme.fontWeight.semibold,
+    lineHeight: 22,
   },
   optionDescription: {
-    fontSize: theme.fontSize.xs,
-    lineHeight: 16,
+    fontSize: theme.fontSize.sm,
+    lineHeight: 20,
   },
-  optionCheckSlot: {
-    width: 16,
+  selectionControl: {
+    width: 18,
+    height: 18,
     alignItems: "center",
     justifyContent: "center",
-    marginLeft: "auto",
+    borderWidth: theme.borderWidth[1],
+    marginTop: 2, // optical-align 18px control to the 22px label first line
+  },
+  selectionControlCheckbox: {
+    borderRadius: theme.borderRadius.base,
+  },
+  selectionControlRadio: {
+    borderRadius: 999,
+  },
+  selectionRadioDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 999,
   },
   otherInput: {
     borderWidth: 1,

--- a/packages/app/src/components/question-form-card.tsx
+++ b/packages/app/src/components/question-form-card.tsx
@@ -194,7 +194,7 @@ function QuestionNavButton({
 
   return (
     <Pressable
-      accessibilityRole="button"
+      accessibilityRole="tab"
       accessibilityLabel={`Question ${index + 1} of ${total}`}
       accessibilityState={accessibilityState}
       aria-selected={isActive}
@@ -237,7 +237,11 @@ function QuestionNav({
     return null;
   }
   return (
-    <View style={styles.questionNav} testID="question-form-question-nav">
+    <View
+      style={styles.questionNav}
+      testID="question-form-question-nav"
+      accessibilityRole="tablist"
+    >
       {questions.map((question, qIndex) => (
         <QuestionNavButton
           key={question.header}


### PR DESCRIPTION
### Linked issue

Closes #1642

### Type of change

- [x] New feature (with prior issue + design alignment)

### What does this PR do

Brings the interactive question card (`AskUserQuestion`) closer to the Claude Code CLI's clarity, all in one component (`packages/app/src/components/question-form-card.tsx`):

- **Legible typography** — option labels 16px semibold, descriptions 14px, matching the surrounding conversation instead of receding below it (they were 14px/12px).
- **Discoverable multi-select** — a static left-side control (square checkbox for multi-select, radio circle for single-select), always visible. Replaces a trailing check that only appeared on selection and reflowed the row.
- **Titled multi-question nav** — each question's header renders as a tab (with a check on answered ones) instead of a bare numbered circle, so you can see what each step is. Hidden for a single-question card.
- **a11y** — single-select options grouped in a `radiogroup`; per-row `checkbox`/`radio` roles; `aria-selected` → `aria-checked` (the correct state for these roles).

No protocol/schema change — `multiSelect` was already parsed on the client. Also updates the e2e question helper (`e2e/helpers/questions.ts`) for the new option roles.

### How did you verify it

- `npm run typecheck`, `npm run lint`, `npm run format` — clean.
- `npx playwright test e2e/question-prompt-pagination.spec.ts` — passes (exercises the new option roles + the updated helper).
- **Before/after screenshots are in #1642** — covering typography, the multi-select affordance, the titled nav, and the answered state (selected checkbox fills + a ✓ on the tab). Generated by driving the mock provider through the real card on web with Playwright, toggling only this component between base and change (before = left, after = right).

**Before / after** (driven through the real card via the mock provider on web; before = left, after = right):

<img width="1664" height="469" alt="Image" src="https://github.com/user-attachments/assets/29d7cb7c-f87a-480d-b5ee-049f4046f579" />

<img width="1664" height="403" alt="Image" src="https://github.com/user-attachments/assets/66a72808-f1fb-4805-8ac3-401408434258" />

<img width="1664" height="509" alt="Image" src="https://github.com/user-attachments/assets/73b396a0-867b-4bef-b1f7-bcd752de7022" />

<img width="804" height="477" alt="Image" src="https://github.com/user-attachments/assets/5947bbe5-efd6-4115-b6ae-a7b6fb407c60" />

> Web shown. It's a shared RN component, so iOS/Android/desktop render the same tree — happy to add native captures if you want them.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform — before/after in #1642 (web; shared RN component, see note)
- [x] Tests added or updated where it made sense
