### PR TITLE
Move voice subsystem under session/ to match checkout

### DIFF
--- a/docs/refactors/session-decomposition-plan.md
+++ b/docs/refactors/session-decomposition-plan.md
@@ -13,6 +13,15 @@ Each domain becomes a controller class in its own file with the **exact** contra
 
 Session shrinks to a connection/dispatch shell: it keeps `handleMessage`, the `??` chain (1739-1751), `emit`/`emitBinary`, `sessionLogger`, connection identity, inflight metrics, lifecycle intents, and the **ordered** `cleanup()`. Each `dispatchXMessage` collapses to `return this.xController.dispatch(msg)`.
 
+## Progress (shipped — diverged from the original filenames)
+
+The first carves shipped as **deep modules with a narrow Host seam**, not the `dispatch(msg)`-owned-set controllers sketched below: `session.ts` keeps each `dispatchXMessage` switch and delegates per case to the subsystem. Home convention that emerged: session subsystems live at **`session/<domain>/`**, with `session.ts` as the orchestrator shell.
+
+- **#1640 — VoiceSession** (`session/voice/voice-session.ts`, seam `VoiceSessionHost`): the STT/TTS/dictation/turn-detection subsystem. _(Originally landed at `server/voice/`; relocated under `session/` so all session subsystems share one home.)_
+- **#1644 — CheckoutSession, read side** (`session/checkout/checkout-session.ts`, seam `CheckoutSessionHost`, port `CheckoutDiffSubscriber`): status, branch validate/suggest, diff subscribe/unsubscribe, manual refresh. The workspace-git observer already delegates `emitStatusUpdate`/`scheduleDiffRefresh` to it.
+
+**Next carve — CheckoutSession mutation side (Slice 4 below).** The 17 checkout _write_ handlers still inline in `session.ts` (`dispatchCheckoutMessage`, ~2010) — branch switch/rename, commit, merge, merge-from-base, pull, push, PR create/merge, github set-auto-merge/get-check-details, PR status, PR timeline, github search, stash save/pop/list — move into the existing `session/checkout/checkout-session.ts` behind `CheckoutSessionHost`. The Slice-3 observer entanglement the table fears is already resolved: #1644 moved the status/diff read side into CheckoutSession, so the workspace observer delegates today and this no longer blocks on the WorkspaceController split.
+
 ### Why this is safe at the dispatch seam (verified)
 
 `dispatchInboundMessage` builds `a() ?? b() ?? ... ?? dispatchMiscMessage()` and short-circuits on the first non-`undefined` **Promise object** (not its resolved value). Message-type spaces are **disjoint** (no duplicate `case` labels across switches), so at most one dispatcher matches any message — collapsing to delegation cannot change which handler runs. `dispatchTerminalMessage` (2150-2153) already proves this. Two quirks preserved verbatim: schedule/\* is reached via the chat dispatcher's OWN `default` arm (2183), not the top-level `??`; and `start_workspace_script_request` (a workspace type) is special-cased before terminal delegation (2150).
@@ -117,7 +126,7 @@ In-place, separately reviewable. Split the `audio_output` TTS-debug branch out o
 
 ## Slice 7 — VoiceSessionController (XL)
 
-**Move:** voice handlers + ~25 voice fields + the TTS-debug hook (Slice 6) + `voiceModeAgentId`/`isVoiceMode` + the `shouldAutoAllowVoicePermission` predicate (Slice 3) → `packages/server/src/server/voice/voice-session-controller.ts`. Carve voice types out of `dispatchVoiceAndControlMessage`, leaving infra (restart/shutdown/heartbeat/ping/abort) on the shell.
+**Move:** voice handlers + ~25 voice fields + the TTS-debug hook (Slice 6) + `voiceModeAgentId`/`isVoiceMode` + the `shouldAutoAllowVoicePermission` predicate (Slice 3) → the existing `packages/server/src/server/session/voice/voice-session.ts` (see Progress above). Carve voice types out of `dispatchVoiceAndControlMessage`, leaving infra (restart/shutdown/heartbeat/ping/abort) on the shell.
 
 **SessionContext surface:** pure `emit`, `emitBinary`, `hasBinaryChannel`, `sessionLogger`/`sessionId`/`paseoHome`, `getSpeechReadiness`, agent-control port `{ loadAgent, reloadWithSystemPrompt, interruptIfRunning, isRunning, sendSpokenText, buildAgentPrompt }`, `getSignal`/`abortCurrent` (Slice 6).
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -167,7 +167,7 @@ import {
 } from "./workspace-registry.js";
 import { wrapSpokenInput } from "./voice-config.js";
 import { isVoicePermissionAllowed } from "./voice-permission-policy.js";
-import { VoiceSession } from "./voice/voice-session.js";
+import { VoiceSession } from "./session/voice/voice-session.js";
 import { CheckoutSession } from "./session/checkout/checkout-session.js";
 import {
   listDirectoryEntries,

--- a/packages/server/src/server/session/voice/voice-session.test.ts
+++ b/packages/server/src/server/session/voice/voice-session.test.ts
@@ -3,18 +3,18 @@ import pino from "pino";
 import { describe, expect, test, vi } from "vitest";
 
 import { VoiceSession, type VoiceSessionHost } from "./voice-session.js";
-import type { ManagedAgent } from "../agent/agent-manager.js";
-import type { SessionOutboundMessage } from "../messages.js";
+import type { ManagedAgent } from "../../agent/agent-manager.js";
+import type { SessionOutboundMessage } from "../../messages.js";
 import type {
   SpeechToTextProvider,
   StreamingTranscriptionCommittedEvent,
   StreamingTranscriptionEvent,
   StreamingTranscriptionSession,
-} from "../speech/speech-provider.js";
+} from "../../speech/speech-provider.js";
 import type {
   TurnDetectionProvider,
   TurnDetectionSession,
-} from "../speech/turn-detection-provider.js";
+} from "../../speech/turn-detection-provider.js";
 
 const VOICE_AGENT_ID = "11111111-1111-4111-8111-111111111111";
 

--- a/packages/server/src/server/session/voice/voice-session.ts
+++ b/packages/server/src/server/session/voice/voice-session.ts
@@ -2,25 +2,25 @@ import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 import type pino from "pino";
 import { getErrorMessage } from "@getpaseo/protocol/error-utils";
-import type { SessionInboundMessage, SessionOutboundMessage } from "../messages.js";
-import { TTSManager } from "../agent/tts-manager.js";
-import { STTManager } from "../agent/stt-manager.js";
-import type { SpeechToTextProvider, TextToSpeechProvider } from "../speech/speech-provider.js";
-import type { TurnDetectionProvider } from "../speech/turn-detection-provider.js";
-import { maybePersistTtsDebugAudio } from "../agent/tts-debug.js";
-import { isPaseoDictationDebugEnabled } from "../agent/recordings-debug.js";
+import type { SessionInboundMessage, SessionOutboundMessage } from "../../messages.js";
+import { TTSManager } from "../../agent/tts-manager.js";
+import { STTManager } from "../../agent/stt-manager.js";
+import type { SpeechToTextProvider, TextToSpeechProvider } from "../../speech/speech-provider.js";
+import type { TurnDetectionProvider } from "../../speech/turn-detection-provider.js";
+import { maybePersistTtsDebugAudio } from "../../agent/tts-debug.js";
+import { isPaseoDictationDebugEnabled } from "../../agent/recordings-debug.js";
 import {
   DictationStreamManager,
   type DictationStreamOutboundMessage,
-} from "../dictation/dictation-stream-manager.js";
+} from "../../dictation/dictation-stream-manager.js";
 import { createVoiceTurnController, type VoiceTurnController } from "./voice-turn-controller.js";
-import { buildVoiceModeSystemPrompt, stripVoiceModeSystemPrompt } from "../voice-config.js";
-import type { VoiceCallerContext, VoiceSpeakHandler } from "../voice-types.js";
-import type { ManagedAgent } from "../agent/agent-manager.js";
-import type { AgentSessionConfig } from "../agent/agent-sdk-types.js";
-import type { LocalSpeechModelId } from "../speech/providers/local/models.js";
-import { toResolver, type Resolvable } from "../speech/provider-resolver.js";
-import type { SpeechReadinessSnapshot, SpeechReadinessState } from "../speech/speech-runtime.js";
+import { buildVoiceModeSystemPrompt, stripVoiceModeSystemPrompt } from "../../voice-config.js";
+import type { VoiceCallerContext, VoiceSpeakHandler } from "../../voice-types.js";
+import type { ManagedAgent } from "../../agent/agent-manager.js";
+import type { AgentSessionConfig } from "../../agent/agent-sdk-types.js";
+import type { LocalSpeechModelId } from "../../speech/providers/local/models.js";
+import { toResolver, type Resolvable } from "../../speech/provider-resolver.js";
+import type { SpeechReadinessSnapshot, SpeechReadinessState } from "../../speech/speech-runtime.js";
 
 const PCM_SAMPLE_RATE = 16000;
 const PCM_CHANNELS = 1;

--- a/packages/server/src/server/session/voice/voice-turn-controller.test.ts
+++ b/packages/server/src/server/session/voice/voice-turn-controller.test.ts
@@ -7,11 +7,11 @@ import type {
   StreamingTranscriptionCommittedEvent,
   StreamingTranscriptionEvent,
   StreamingTranscriptionSession,
-} from "../speech/speech-provider.js";
+} from "../../speech/speech-provider.js";
 import type {
   TurnDetectionProvider,
   TurnDetectionSession,
-} from "../speech/turn-detection-provider.js";
+} from "../../speech/turn-detection-provider.js";
 import { createVoiceTurnController } from "./voice-turn-controller.js";
 
 class FakeTurnDetectionSession extends EventEmitter implements TurnDetectionSession {

--- a/packages/server/src/server/session/voice/voice-turn-controller.ts
+++ b/packages/server/src/server/session/voice/voice-turn-controller.ts
@@ -2,14 +2,14 @@ import { Buffer } from "node:buffer";
 import type { Logger } from "pino";
 import { v4 as uuidv4 } from "uuid";
 
-import { Pcm16MonoResampler } from "../agent/pcm16-resampler.js";
-import { parsePcmRateFromFormat } from "../speech/audio.js";
+import { Pcm16MonoResampler } from "../../agent/pcm16-resampler.js";
+import { parsePcmRateFromFormat } from "../../speech/audio.js";
 import type {
   SpeechToTextProvider,
   StreamingTranscriptionEvent,
   StreamingTranscriptionSession,
-} from "../speech/speech-provider.js";
-import type { TurnDetectionProvider } from "../speech/turn-detection-provider.js";
+} from "../../speech/speech-provider.js";
+import type { TurnDetectionProvider } from "../../speech/turn-detection-provider.js";
 
 const VOICE_FINAL_TRANSCRIPT_TIMEOUT_MS = 10_000;
 


### PR DESCRIPTION
Internal refactor — **no user-visible change**. Continues the incremental decomposition of the 9k-line `session.ts` god object (see `docs/refactors/session-decomposition-plan.md`).

The two subsystems carved out of `session.ts` so far landed in inconsistent homes: voice at `server/voice/` (a peer of `session.ts`, from #1640) and checkout-read at `server/session/checkout/` (from #1644). This relocates `server/voice/` → `server/session/voice/` so every session subsystem shares one discoverable home alongside `session/checkout/`, giving the ongoing carve series a single destination.

It's a pure relocation:
- git-tracked renames of the 4 voice files (`voice-session.ts`, `voice-turn-controller.ts`, + tests) — history preserved.
- relative imports bumped one level (`../` → `../../`), mirroring how `session/checkout/checkout-session.ts` already reaches back.
- the only external touch point is the one import path in `session.ts:170`.
- the decomposition-plan doc is updated to record the actual shipped layout and the next carve (the checkout *mutation* handlers still inline in `session.ts` → `session/checkout/checkout-session.ts`), and its now-stale voice path is fixed.

## How to verify beyond CI
CI matrix covers every surface this touches. The 17 voice unit tests (`session/voice/voice-session.test.ts`, `session/voice/voice-turn-controller.test.ts`) pass unchanged before and after the move, and the pre-commit hook ran full-workspace typecheck + lint + format green. No runtime behavior changed, so no manual smoke is needed — a quick grep that nothing still references `server/voice/` (none does) is the only spot-check.

## Risk surface
Low. No protocol, schema, or persisted-state changes; no platform-specific code; voice message dispatch, construction, and cleanup in `session.ts` are untouched apart from the import path. The realistic failure mode for a file move — a missed import reference to the old path — is closed by the full-workspace typecheck passing and a repo-wide grep showing `session.ts:170` was the only importer.