### PR TITLE
feat: add C# syntax highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11166,6 +11166,21 @@
         "nanoid": "^3.3.11"
       }
     },
+    "node_modules/@replit/codemirror-lang-csharp": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-lang-csharp/-/codemirror-lang-csharp-6.2.0.tgz",
+      "integrity": "sha512-6utbaWkoymhoAXj051mkRp+VIJlpwUgCX9Toevz3YatiZsz512fw3OVCedXQx+WcR0wb6zVHjChnuxqfCLtFVQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -36989,6 +37004,7 @@
         "@lezer/rust": "^1.0.2",
         "@lezer/xml": "^1.0.6",
         "@lezer/yaml": "^1.0.4",
+        "@replit/codemirror-lang-csharp": "^6.2.0",
         "lezer-elixir": "^1.1.2"
       },
       "devDependencies": {

--- a/packages/app/src/components/highlighted-code-block.tsx
+++ b/packages/app/src/components/highlighted-code-block.tsx
@@ -29,6 +29,8 @@ const LANGUAGE_ALIASES: Record<string, string> = {
   rust: "rs",
   golang: "go",
   "c++": "cpp",
+  csharp: "cs",
+  "c#": "cs",
   objc: "m",
   "objective-c": "m",
   markdown: "md",

--- a/packages/highlight/package.json
+++ b/packages/highlight/package.json
@@ -44,6 +44,7 @@
     "@lezer/rust": "^1.0.2",
     "@lezer/xml": "^1.0.6",
     "@lezer/yaml": "^1.0.4",
+    "@replit/codemirror-lang-csharp": "^6.2.0",
     "lezer-elixir": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/highlight/src/__tests__/highlighter.test.ts
+++ b/packages/highlight/src/__tests__/highlighter.test.ts
@@ -62,6 +62,19 @@ describe("highlightCode", () => {
     expect(stringToken?.style).toBe("string");
   });
 
+  it("highlights C# code", () => {
+    const code = 'class Greeter {\n    string message = "hello";\n}';
+    const result = highlightCode(code, "test.cs");
+
+    expect(result).toHaveLength(3);
+
+    const classToken = result[0].find((t) => t.text === "class");
+    expect(classToken?.style).toBe("keyword");
+
+    const stringToken = result[1].find((t) => t.text.includes("hello"));
+    expect(stringToken?.style).toBe("string");
+  });
+
   it("highlights TSX code with correct dialect", () => {
     const code = 'const el = <div className="test">hello</div>;';
     const result = highlightCode(code, "test.tsx");

--- a/packages/highlight/src/__tests__/parsers.test.ts
+++ b/packages/highlight/src/__tests__/parsers.test.ts
@@ -15,6 +15,7 @@ describe("isLanguageSupported", () => {
     expect(isLanguageSupported("test.java")).toBe(true);
     expect(isLanguageSupported("test.swift")).toBe(true);
     expect(isLanguageSupported("test.dart")).toBe(true);
+    expect(isLanguageSupported("test.cs")).toBe(true);
     expect(isLanguageSupported("test.ex")).toBe(true);
   });
 
@@ -53,6 +54,7 @@ describe("getSupportedExtensions", () => {
     expect(extensions).toContain("rs");
     expect(extensions).toContain("swift");
     expect(extensions).toContain("dart");
+    expect(extensions).toContain("cs");
     expect(extensions).toContain("json");
   });
 });

--- a/packages/highlight/src/parsers.ts
+++ b/packages/highlight/src/parsers.ts
@@ -14,6 +14,7 @@ import { parser as phpParser } from "@lezer/php";
 import { parser as rustParser } from "@lezer/rust";
 import { parser as xmlParser } from "@lezer/xml";
 import { parser as yamlParser } from "@lezer/yaml";
+import { csharpLanguage } from "@replit/codemirror-lang-csharp";
 import { parser as elixirParser } from "lezer-elixir";
 import type { Parser } from "@lezer/common";
 
@@ -62,6 +63,8 @@ const parsersByExtension: Record<string, Parser> = {
   swift: StreamLanguage.define(swift).parser,
   // Dart
   dart: StreamLanguage.define(dart).parser,
+  // C#
+  cs: csharpLanguage.parser,
   // Elixir
   ex: elixirParser,
   exs: elixirParser,


### PR DESCRIPTION
### Linked issue

Closes #1527

<!-- Proposed (with a patch) by @percyboy. -->

### Type of change

- [x] New feature (with prior issue + design alignment)

### What does this PR do

Adds C# (`.cs`) syntax highlighting, implementing the request in #1527 (proposed with a patch by @percyboy). It wires the `@replit/codemirror-lang-csharp` Lezer grammar into `@getpaseo/highlight` following the existing per-language pattern (Java/Rust/Swift), and aliases the `csharp` / `c#` markdown fence names to `cs`.

This makes C# highlight everywhere code is rendered through the shared highlighter — the file viewer, diff views, and ` ```csharp ` / ` ```cs ` / ` ```c# ` markdown code fences in agent messages.

One deliberate change from the patch in the issue: I register `csharpLanguage.parser`, not the package's raw `parser` export. The Replit package applies its highlight `styleTags` only inside `csharpLanguage` (via `parser.configure`), so the raw parser would produce a valid tree but render with **no** highlighting. This differs from `@lezer/java` etc., whose `parser` export ships highlight props baked in.

Changed files:
- `packages/highlight/package.json` — add `@replit/codemirror-lang-csharp`
- `packages/highlight/src/parsers.ts` — register `cs: csharpLanguage.parser`
- `packages/app/src/components/highlighted-code-block.tsx` — `csharp` / `c#` fence aliases
- `packages/highlight/src/__tests__/*` — parser + highlighter test cases

### How did you verify it

- Added unit tests and ran the two changed suites:
  `npx vitest run packages/highlight/src/__tests__/{parsers,highlighter}.test.ts` → 23 passed, including the new C# cases (asserts `class` → keyword, string → string).
- `npm run build:server` then `npm run typecheck` → clean across all workspaces.
- `npm run lint` → 0 warnings / 0 errors. `npm run format` → clean.
- Opened a real `.cs` file (`Program.cs`) in the running Paseo app and confirmed full highlighting (keywords, types, method names, `switch` pattern matching, interpolated strings, LINQ, comments), on **web** and **desktop (Electron)**:

  **Web (browser):**
<img width="1584" height="905" alt="csharp-app-web" src="https://github.com/user-attachments/assets/e98ffd18-4d35-45f8-a433-4863ff20b570" />

  **Desktop (Electron):**
<img width="1600" height="1000" alt="csharp-app-desktop" src="https://github.com/user-attachments/assets/15d63351-583c-4b6f-b50e-e8bcb0ca4054" />

  Verified on web + desktop; iOS/Android render through the identical cross-platform component (no platform-gated code in the highlight path), so they were not separately captured.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI change includes screenshots (web + desktop)
- [x] Tests added or updated where it made sense
