### PR TITLE
fix(cli): scope worktree ls and archive by cwd

### DIFF
--- a/packages/cli/src/commands/worktree/archive.test.ts
+++ b/packages/cli/src/commands/worktree/archive.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { runArchiveCommandWithDeps } from "./archive.js";
 
@@ -29,10 +29,6 @@ function createFakeDaemonClient(
 // worktree-session.test.ts prove real filesystem removal end-to-end.
 
 describe("runArchiveCommand", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("sends scope worktree when archiving by worktree path", async () => {
     const cwd = "/tmp/source-repo";
     const worktreePath = "/tmp/paseo-home/worktrees/repo/feature";
@@ -72,6 +68,7 @@ describe("runArchiveCommand", () => {
       { cwd },
       {
         connectToDaemon: async () => fakeClient,
+        getCwd: () => "/tmp/unused-repo",
       },
     );
 
@@ -92,7 +89,6 @@ describe("runArchiveCommand", () => {
 
   it("archives by matching branch name when no directory name matches", async () => {
     const cwd = "/tmp/current-repo";
-    vi.spyOn(process, "cwd").mockReturnValue(cwd);
 
     const worktreePath = "/tmp/paseo-home/worktrees/repo/feature-branch";
     const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
@@ -131,6 +127,7 @@ describe("runArchiveCommand", () => {
       {},
       {
         connectToDaemon: async () => fakeClient,
+        getCwd: () => cwd,
       },
     );
 
@@ -155,6 +152,7 @@ describe("runArchiveCommand", () => {
         {},
         {
           connectToDaemon: async () => fakeClient,
+          getCwd: () => "/tmp/current-repo",
         },
       ),
     ).rejects.toMatchObject({

--- a/packages/cli/src/commands/worktree/archive.test.ts
+++ b/packages/cli/src/commands/worktree/archive.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { runArchiveCommandWithDeps } from "./archive.js";
 
@@ -29,24 +29,33 @@ function createFakeDaemonClient(
 // worktree-session.test.ts prove real filesystem removal end-to-end.
 
 describe("runArchiveCommand", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("sends scope worktree when archiving by worktree path", async () => {
+    const cwd = "/tmp/source-repo";
     const worktreePath = "/tmp/paseo-home/worktrees/repo/feature";
+    const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
     const archiveCalls: Array<{
       input: Parameters<DaemonClient["archivePaseoWorktree"]>[0];
     }> = [];
     const fakeClient = createFakeDaemonClient({
-      getPaseoWorktreeList: async () => ({
-        worktrees: [
-          {
-            worktreePath,
-            branchName: "feature",
-            head: "abc123",
-            createdAt: "2026-04-12T00:00:00.000Z",
-          },
-        ],
-        error: null,
-        requestId: "req-list",
-      }),
+      getPaseoWorktreeList: async (input) => {
+        listCalls.push(input);
+        return {
+          worktrees: [
+            {
+              worktreePath,
+              branchName: "feature",
+              head: "abc123",
+              createdAt: "2026-04-12T00:00:00.000Z",
+            },
+          ],
+          error: null,
+          requestId: "req-list",
+        };
+      },
       archivePaseoWorktree: async (input) => {
         archiveCalls.push({ input });
         return {
@@ -60,12 +69,13 @@ describe("runArchiveCommand", () => {
 
     const result = await runArchiveCommandWithDeps(
       "feature",
-      {},
+      { cwd },
       {
         connectToDaemon: async () => fakeClient,
       },
     );
 
+    expect(listCalls).toEqual([{ cwd }]);
     expect(archiveCalls).toHaveLength(1);
     expect(archiveCalls[0]?.input.scope).toBe("worktree");
     expect(archiveCalls[0]?.input.worktreePath).toBe(worktreePath);
@@ -81,23 +91,30 @@ describe("runArchiveCommand", () => {
   });
 
   it("archives by matching branch name when no directory name matches", async () => {
+    const cwd = "/tmp/current-repo";
+    vi.spyOn(process, "cwd").mockReturnValue(cwd);
+
     const worktreePath = "/tmp/paseo-home/worktrees/repo/feature-branch";
+    const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
     const archiveCalls: Array<{
       input: Parameters<DaemonClient["archivePaseoWorktree"]>[0];
     }> = [];
     const fakeClient = createFakeDaemonClient({
-      getPaseoWorktreeList: async () => ({
-        worktrees: [
-          {
-            worktreePath,
-            branchName: "feature-x",
-            head: "abc123",
-            createdAt: "2026-04-12T00:00:00.000Z",
-          },
-        ],
-        error: null,
-        requestId: "req-list",
-      }),
+      getPaseoWorktreeList: async (input) => {
+        listCalls.push(input);
+        return {
+          worktrees: [
+            {
+              worktreePath,
+              branchName: "feature-x",
+              head: "abc123",
+              createdAt: "2026-04-12T00:00:00.000Z",
+            },
+          ],
+          error: null,
+          requestId: "req-list",
+        };
+      },
       archivePaseoWorktree: async (input) => {
         archiveCalls.push({ input });
         return {
@@ -117,6 +134,7 @@ describe("runArchiveCommand", () => {
       },
     );
 
+    expect(listCalls).toEqual([{ cwd }]);
     expect(archiveCalls).toHaveLength(1);
     expect(archiveCalls[0]?.input.scope).toBe("worktree");
     expect(archiveCalls[0]?.input.worktreePath).toBe(worktreePath);

--- a/packages/cli/src/commands/worktree/archive.ts
+++ b/packages/cli/src/commands/worktree/archive.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 import type { Command } from "commander";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
@@ -31,6 +31,7 @@ export const archiveSchema: OutputSchema<WorktreeArchiveResult> = {
 
 export interface WorktreeArchiveOptions extends CommandOptions {
   host?: string;
+  cwd?: string;
 }
 
 export type WorktreeArchiveCommandResult = SingleResult<WorktreeArchiveResult>;
@@ -49,6 +50,7 @@ export async function runArchiveCommandWithDeps(
   deps: { connectToDaemon: typeof connectToDaemon },
 ): Promise<WorktreeArchiveCommandResult> {
   const host = getDaemonHost({ host: options.host });
+  const cwd = options.cwd ?? process.cwd();
 
   // Validate arguments
   if (!nameArg || nameArg.trim().length === 0) {
@@ -75,7 +77,7 @@ export async function runArchiveCommandWithDeps(
 
   try {
     // Get the list of worktrees first to resolve the name
-    const listResponse = await client.getPaseoWorktreeList({});
+    const listResponse = await client.getPaseoWorktreeList({ cwd });
 
     if (listResponse.error) {
       const error: CommandError = {

--- a/packages/cli/src/commands/worktree/archive.ts
+++ b/packages/cli/src/commands/worktree/archive.ts
@@ -41,16 +41,19 @@ export async function runArchiveCommand(
   options: WorktreeArchiveOptions,
   _command: Command,
 ): Promise<WorktreeArchiveCommandResult> {
-  return runArchiveCommandWithDeps(nameArg, options, { connectToDaemon });
+  return runArchiveCommandWithDeps(nameArg, options, {
+    connectToDaemon,
+    getCwd: () => process.cwd(),
+  });
 }
 
 export async function runArchiveCommandWithDeps(
   nameArg: string,
   options: WorktreeArchiveOptions,
-  deps: { connectToDaemon: typeof connectToDaemon },
+  deps: { connectToDaemon: typeof connectToDaemon; getCwd: () => string },
 ): Promise<WorktreeArchiveCommandResult> {
   const host = getDaemonHost({ host: options.host });
-  const cwd = options.cwd ?? process.cwd();
+  const cwd = options.cwd ?? deps.getCwd();
 
   // Validate arguments
   if (!nameArg || nameArg.trim().length === 0) {

--- a/packages/cli/src/commands/worktree/index.ts
+++ b/packages/cli/src/commands/worktree/index.ts
@@ -9,7 +9,10 @@ export function createWorktreeCommand(): Command {
   const worktree = new Command("worktree").description("Manage Paseo-managed git worktrees");
 
   addJsonAndDaemonHostOptions(
-    worktree.command("ls").description("List Paseo-managed git worktrees"),
+    worktree
+      .command("ls")
+      .description("List Paseo-managed git worktrees")
+      .option("--cwd <path>", "Repository directory (default: current)"),
   ).action(withOutput(runLsCommand));
 
   addJsonAndDaemonHostOptions(
@@ -31,7 +34,8 @@ export function createWorktreeCommand(): Command {
     worktree
       .command("archive")
       .description("Archive a worktree (removes worktree and associated branch)")
-      .argument("<name>", "Worktree name or branch name"),
+      .argument("<name>", "Worktree name or branch name")
+      .option("--cwd <path>", "Repository directory (default: current)"),
   ).action(withOutput(runArchiveCommand));
 
   return worktree;

--- a/packages/cli/src/commands/worktree/ls.test.ts
+++ b/packages/cli/src/commands/worktree/ls.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { runLsCommandWithDeps } from "./ls.js";
 
@@ -23,13 +23,8 @@ function createFakeDaemonClient(
 }
 
 describe("runLsCommand", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("lists worktrees for the current cwd by default", async () => {
     const cwd = "/tmp/current-repo";
-    vi.spyOn(process, "cwd").mockReturnValue(cwd);
 
     const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
     const fakeClient = createFakeDaemonClient({
@@ -47,6 +42,7 @@ describe("runLsCommand", () => {
       {},
       {
         connectToDaemon: async () => fakeClient,
+        getCwd: () => cwd,
       },
     );
 
@@ -79,6 +75,7 @@ describe("runLsCommand", () => {
       { cwd },
       {
         connectToDaemon: async () => fakeClient,
+        getCwd: () => "/tmp/unused-repo",
       },
     );
 

--- a/packages/cli/src/commands/worktree/ls.test.ts
+++ b/packages/cli/src/commands/worktree/ls.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import { runLsCommandWithDeps } from "./ls.js";
+
+function createFakeDaemonClient(
+  overrides: Partial<Pick<DaemonClient, "fetchAgents" | "getPaseoWorktreeList" | "close">> = {},
+): DaemonClient {
+  return {
+    fetchAgents: async () => ({
+      entries: [],
+      total: 0,
+      nextCursor: undefined,
+      requestId: "req-agents",
+    }),
+    getPaseoWorktreeList: async () => ({
+      worktrees: [],
+      error: null,
+      requestId: "req-list",
+    }),
+    close: async () => {},
+    ...overrides,
+  } as unknown as DaemonClient;
+}
+
+describe("runLsCommand", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists worktrees for the current cwd by default", async () => {
+    const cwd = "/tmp/current-repo";
+    vi.spyOn(process, "cwd").mockReturnValue(cwd);
+
+    const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
+    const fakeClient = createFakeDaemonClient({
+      getPaseoWorktreeList: async (input) => {
+        listCalls.push(input);
+        return {
+          worktrees: [],
+          error: null,
+          requestId: "req-list",
+        };
+      },
+    });
+
+    await runLsCommandWithDeps(
+      {},
+      {
+        connectToDaemon: async () => fakeClient,
+      },
+    );
+
+    expect(listCalls).toEqual([{ cwd }]);
+  });
+
+  it("passes explicit cwd to the daemon worktree list request", async () => {
+    const cwd = "/tmp/source-repo";
+    const worktreePath = "/tmp/paseo-home/worktrees/repo/feature";
+    const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
+    const fakeClient = createFakeDaemonClient({
+      getPaseoWorktreeList: async (input) => {
+        listCalls.push(input);
+        return {
+          worktrees: [
+            {
+              worktreePath,
+              branchName: "feature",
+              head: "abc123",
+              createdAt: "2026-04-12T00:00:00.000Z",
+            },
+          ],
+          error: null,
+          requestId: "req-list",
+        };
+      },
+    });
+
+    const result = await runLsCommandWithDeps(
+      { cwd },
+      {
+        connectToDaemon: async () => fakeClient,
+      },
+    );
+
+    expect(listCalls).toEqual([{ cwd }]);
+    expect(result).toEqual({
+      type: "list",
+      data: [
+        {
+          name: "feature",
+          branch: "feature",
+          cwd: worktreePath,
+          agent: "-",
+        },
+      ],
+      schema: expect.any(Object),
+    });
+  });
+});

--- a/packages/cli/src/commands/worktree/ls.ts
+++ b/packages/cli/src/commands/worktree/ls.ts
@@ -62,15 +62,18 @@ export async function runLsCommand(
   options: WorktreeLsOptions,
   _command: Command,
 ): Promise<WorktreeLsResult> {
-  return runLsCommandWithDeps(options, { connectToDaemon });
+  return runLsCommandWithDeps(options, {
+    connectToDaemon,
+    getCwd: () => process.cwd(),
+  });
 }
 
 export async function runLsCommandWithDeps(
   options: WorktreeLsOptions,
-  deps: { connectToDaemon: typeof connectToDaemon },
+  deps: { connectToDaemon: typeof connectToDaemon; getCwd: () => string },
 ): Promise<WorktreeLsResult> {
   const host = getDaemonHost({ host: options.host });
-  const cwd = options.cwd ?? process.cwd();
+  const cwd = options.cwd ?? deps.getCwd();
 
   let client: DaemonClient;
   try {

--- a/packages/cli/src/commands/worktree/ls.ts
+++ b/packages/cli/src/commands/worktree/ls.ts
@@ -55,17 +55,26 @@ export type WorktreeLsResult = ListResult<WorktreeListItem>;
 
 export interface WorktreeLsOptions extends CommandOptions {
   host?: string;
+  cwd?: string;
 }
 
 export async function runLsCommand(
   options: WorktreeLsOptions,
   _command: Command,
 ): Promise<WorktreeLsResult> {
+  return runLsCommandWithDeps(options, { connectToDaemon });
+}
+
+export async function runLsCommandWithDeps(
+  options: WorktreeLsOptions,
+  deps: { connectToDaemon: typeof connectToDaemon },
+): Promise<WorktreeLsResult> {
   const host = getDaemonHost({ host: options.host });
+  const cwd = options.cwd ?? process.cwd();
 
   let client: DaemonClient;
   try {
-    client = await connectToDaemon({ host: options.host });
+    client = await deps.connectToDaemon({ host: options.host });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const error: CommandError = {
@@ -80,8 +89,7 @@ export async function runLsCommand(
     const agentsPayload = await client.fetchAgents({ filter: { includeArchived: true } });
     const agents = agentsPayload.entries.map((entry) => entry.agent);
 
-    // Get worktree list from daemon
-    const response = await client.getPaseoWorktreeList({});
+    const response = await client.getPaseoWorktreeList({ cwd });
 
     await client.close();
 


### PR DESCRIPTION
## Summary

- Pass the current or explicit cwd into worktree list requests from the CLI.
- Expose `--cwd` on `worktree ls` and `worktree archive` for parity with `worktree create`.
- Add focused CLI tests for `ls` and `archive` cwd routing.

## Why

Closes #1649.

`paseo worktree ls` sent an empty worktree-list request, while the daemon requires `cwd` or `repoRoot`. That made the command fail immediately with `cwd or repoRoot is required`.

`worktree archive` used the same list request to resolve its target before archiving, so it needed the same cwd scope fix.

## Testing

- `npm run build:server`
- `npx vitest run packages/cli/src/commands/worktree/ls.test.ts packages/cli/src/commands/worktree/archive.test.ts --bail=1`
- `npm run lint -- packages/cli/src/commands/worktree/ls.ts packages/cli/src/commands/worktree/index.ts packages/cli/src/commands/worktree/archive.ts packages/cli/src/commands/worktree/archive.test.ts packages/cli/src/commands/worktree/ls.test.ts`
- `npm run typecheck --workspace=@getpaseo/cli`
- `npm run build --workspace=@getpaseo/cli`
- `npm run format:check:files -- packages/cli/src/commands/worktree/ls.ts packages/cli/src/commands/worktree/index.ts packages/cli/src/commands/worktree/archive.ts packages/cli/src/commands/worktree/archive.test.ts packages/cli/src/commands/worktree/ls.test.ts`
- `node packages/cli/bin/paseo --json worktree ls --cwd /Users/everton/www/ai/paseo --host 127.0.0.1:6767` returned `[]` with exit 0
