### PR TITLE
feat(app): add Copy PR URL to checkout dropdown

### DIFF
--- a/packages/app/src/git/actions-split-button.tsx
+++ b/packages/app/src/git/actions-split-button.tsx
@@ -182,10 +182,11 @@ export function GitActionsSplitButton({ gitActions, hideLabels }: GitActionsSpli
                     needsSeparator={action.startsGroup}
                     showSeparator={index > 0}
                     closeOnSelect={
-                      action.status === "idle" &&
-                      action.id === "pr" &&
-                      action.label === action.pendingLabel &&
-                      action.label === action.successLabel
+                      action.id === "copy-pr-url" ||
+                      (action.status === "idle" &&
+                        action.id === "pr" &&
+                        action.label === action.pendingLabel &&
+                        action.label === action.successLabel)
                     }
                   />
                 ))}

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -35,6 +35,7 @@ import {
   ArrowDownUp,
   ChevronDown,
   Columns2,
+  Copy,
   Download,
   GitCommitHorizontal,
   GitMerge,
@@ -1111,6 +1112,7 @@ const ThemedGitHubIcon = withUnistyles(GitHubIcon);
 const ThemedGitMerge = withUnistyles(GitMerge);
 const ThemedRefreshCcw = withUnistyles(RefreshCcw);
 const ThemedArchive = withUnistyles(Archive);
+const ThemedCopy = withUnistyles(Copy);
 const ThemedChevronDown = withUnistyles(ChevronDown);
 
 interface DiffLayoutToggleGroupProps {
@@ -2100,6 +2102,7 @@ export function GitDiffPane({ serverId, workspaceId, cwd, enabled }: GitDiffPane
       merge: <ThemedGitMerge size={16} uniProps={foregroundMutedIconColorMapping} />,
       mergeFromBase: <ThemedRefreshCcw size={16} uniProps={foregroundMutedIconColorMapping} />,
       archive: <ThemedArchive size={16} uniProps={foregroundMutedIconColorMapping} />,
+      copyPrUrl: <ThemedCopy size={16} uniProps={foregroundMutedIconColorMapping} />,
     }),
     [],
   );

--- a/packages/app/src/git/policy.test.ts
+++ b/packages/app/src/git/policy.test.ts
@@ -127,6 +127,11 @@ function createInput(overrides: Partial<BuildGitActionsInput> = {}): BuildGitAct
         status: "idle",
         handler: () => undefined,
       },
+      "copy-pr-url": {
+        disabled: false,
+        status: "idle",
+        handler: () => undefined,
+      },
     },
     ...overrides,
   };

--- a/packages/app/src/git/policy.ts
+++ b/packages/app/src/git/policy.ts
@@ -23,7 +23,8 @@ export type GitActionId =
   | "disable-pr-auto-merge"
   | "merge-branch"
   | "merge-from-base"
-  | "archive-worktree";
+  | "archive-worktree"
+  | "copy-pr-url";
 
 export interface GitAction {
   id: GitActionId;
@@ -298,12 +299,31 @@ export function buildGitActions(input: BuildGitActionsInput): GitActions {
     handler: input.runtime["archive-worktree"].handler,
   });
 
+  if (input.hasPullRequest && input.pullRequestUrl) {
+    allActions.set("copy-pr-url", {
+      id: "copy-pr-url",
+      label: i18n.t("workspace.git.actions.copyPrUrl"),
+      pendingLabel: i18n.t("workspace.git.actions.copyPrUrl"),
+      successLabel: i18n.t("workspace.git.actions.copyPrUrl"),
+      disabled: input.runtime["copy-pr-url"].disabled,
+      status: input.runtime["copy-pr-url"].status,
+      icon: input.runtime["copy-pr-url"].icon,
+      startsGroup: false,
+      handler: input.runtime["copy-pr-url"].handler,
+    });
+  }
+
   const primaryActionId = getPrimaryActionId(input);
   const primary = primaryActionId ? (allActions.get(primaryActionId) ?? null) : null;
 
   const secondaryIds = [...REMOTE_ACTION_IDS];
   if (!input.isOnBaseBranch) {
-    secondaryIds.push(...getFeatureActionIds(input));
+    for (const id of getFeatureActionIds(input)) {
+      secondaryIds.push(id);
+      if (id === "pr" && input.hasPullRequest && input.pullRequestUrl) {
+        secondaryIds.push("copy-pr-url");
+      }
+    }
   }
   if (input.isPaseoOwnedWorktree) {
     secondaryIds.push("archive-worktree");

--- a/packages/app/src/git/use-actions.tsx
+++ b/packages/app/src/git/use-actions.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/git/policy";
 import type { CheckoutPrMergeMethod } from "@getpaseo/protocol/messages";
 import { openExternalUrl } from "@/utils/open-external-url";
+import { copyToClipboard } from "@/utils/copy-to-clipboard";
 import { useToast } from "@/contexts/toast-context";
 import { useSessionStore } from "@/stores/session-store";
 import {
@@ -154,6 +155,7 @@ interface UseGitActionsInput {
     merge: ReactElement;
     mergeFromBase: ReactElement;
     archive: ReactElement;
+    copyPrUrl: ReactElement;
   };
 }
 
@@ -567,6 +569,13 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
     handleCreatePr();
   }, [prStatus?.url, handleCreatePr]);
 
+  const handleCopyPrUrl = useCallback(() => {
+    if (prStatus?.url) {
+      void copyToClipboard(prStatus.url);
+      toast.show(t("workspace.git.actions.copyPrUrlSuccess"), { variant: "success" });
+    }
+  }, [prStatus?.url, toast, t]);
+
   // Build actions
   const gitActions: GitActions = useMemo(() => {
     const actions = buildGitActions({
@@ -683,6 +692,12 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
           icon: icons.archive,
           handler: handleArchiveWorktree,
         },
+        "copy-pr-url": {
+          disabled: false,
+          status: "idle",
+          icon: icons.copyPrUrl,
+          handler: handleCopyPrUrl,
+        },
       },
     });
     return translateGitActions(actions, { baseRefLabel, hasPullRequest, t });
@@ -736,6 +751,7 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
     handleMergeBranch,
     handleMergeFromBase,
     handleArchiveWorktree,
+    handleCopyPrUrl,
     icons,
     baseRef,
   ]);
@@ -889,6 +905,12 @@ function getTranslatedGitActionLabels(
         label: t("workspace.git.actions.archive.label"),
         pendingLabel: t("workspace.git.actions.archive.pending"),
         successLabel: t("workspace.git.actions.archive.success"),
+      };
+    case "copy-pr-url":
+      return {
+        label: t("workspace.git.actions.copyPrUrl"),
+        pendingLabel: t("workspace.git.actions.copyPrUrl"),
+        successLabel: t("workspace.git.actions.copyPrUrl"),
       };
   }
 }

--- a/packages/app/src/git/use-actions.tsx
+++ b/packages/app/src/git/use-actions.tsx
@@ -571,10 +571,15 @@ export function useGitActions({ serverId, cwd, icons }: UseGitActionsInput): Use
 
   const handleCopyPrUrl = useCallback(() => {
     if (prStatus?.url) {
-      void copyToClipboard(prStatus.url);
-      toast.show(t("workspace.git.actions.copyPrUrlSuccess"), { variant: "success" });
+      void copyToClipboard(prStatus.url)
+        .then(() => {
+          return toast.show(t("workspace.git.actions.copyPrUrlSuccess"), { variant: "success" });
+        })
+        .catch((error: unknown) => {
+          toastActionError(error, t("workspace.git.actions.toasts.failedCopyPrUrl"));
+        });
     }
-  }, [prStatus?.url, toast, t]);
+  }, [prStatus?.url, toast, t, toastActionError]);
 
   // Build actions
   const gitActions: GitActions = useMemo(() => {

--- a/packages/app/src/git/workspace-actions.tsx
+++ b/packages/app/src/git/workspace-actions.tsx
@@ -2,6 +2,7 @@ import { withUnistyles } from "react-native-unistyles";
 import {
   Archive,
   ArrowDownUp,
+  Copy,
   Download,
   GitCommitHorizontal,
   GitMerge,
@@ -27,6 +28,7 @@ const ThemedGitHubIcon = withUnistyles(GitHubIcon);
 const ThemedGitMerge = withUnistyles(GitMerge);
 const ThemedRefreshCcw = withUnistyles(RefreshCcw);
 const ThemedArchive = withUnistyles(Archive);
+const ThemedCopy = withUnistyles(Copy);
 
 const mutedColorMapping = (theme: Theme) => ({
   color: theme.colors.foregroundMuted,
@@ -45,6 +47,7 @@ const ICONS = {
   merge: <ThemedGitMerge size={16} uniProps={mutedColorMapping} />,
   mergeFromBase: <ThemedRefreshCcw size={16} uniProps={mutedColorMapping} />,
   archive: <ThemedArchive size={16} uniProps={mutedColorMapping} />,
+  copyPrUrl: <ThemedCopy size={16} uniProps={mutedColorMapping} />,
 };
 
 export function WorkspaceGitActions({ serverId, cwd, hideLabels }: WorkspaceGitActionsProps) {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -669,6 +669,7 @@ export const ar: TranslationResources = {
           failedMergeFromBase: "فشل الدمج من القاعدة",
           worktreePathUnavailable: "مسار شجرة العمل غير متوفر",
           failedArchive: "فشل في أرشفة شجرة العمل",
+          failedCopyPrUrl: "فشل في نسخ رابط PR",
         },
         archiveWarning: {
           title: 'الأرشيف "{{worktreeName}}"؟',

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -583,6 +583,8 @@ export const ar: TranslationResources = {
           success: "سحبت ودفعت",
         },
         viewPr: "عرض PR",
+        copyPrUrl: "نسخ رابط PR",
+        copyPrUrlSuccess: "تم نسخ الرابط",
         createPr: {
           label: "إنشاء PR",
           pending: "إنشاء PR...",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -582,6 +582,8 @@ export const en = {
           success: "Pulled and pushed",
         },
         viewPr: "View PR",
+        copyPrUrl: "Copy PR URL",
+        copyPrUrlSuccess: "URL copied",
         createPr: {
           label: "Create PR",
           pending: "Creating PR...",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -676,6 +676,7 @@ export const en = {
           failedMergeFromBase: "Failed to merge from base",
           worktreePathUnavailable: "Worktree path unavailable",
           failedArchive: "Failed to archive worktree",
+          failedCopyPrUrl: "Failed to copy PR URL",
         },
         archiveWarning: {
           title: 'Archive "{{worktreeName}}"?',

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -589,6 +589,8 @@ export const es: TranslationResources = {
           success: "Tirado y empujado",
         },
         viewPr: "VerPR",
+        copyPrUrl: "Copiar URL del PR",
+        copyPrUrlSuccess: "URL copiada",
         createPr: {
           label: "CrearPR",
           pending: "CreandoPR...",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -696,6 +696,7 @@ export const es: TranslationResources = {
           failedMergeFromBase: "No se pudo fusionar desde la base",
           worktreePathUnavailable: "Ruta del árbol de trabajo no disponible",
           failedArchive: "No se pudo archivar el árbol de trabajo",
+          failedCopyPrUrl: "No se pudo copiar la URL del PR",
         },
         archiveWarning: {
           title: '¿Archivo "{{worktreeName}}"?',

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -695,6 +695,7 @@ export const fr: TranslationResources = {
           failedMergeFromBase: "Échec de la fusion à partir de la base",
           worktreePathUnavailable: "Chemin d'accès à l'arbre de travail indisponible",
           failedArchive: "Échec de l'archivage de l'arbre de travail",
+          failedCopyPrUrl: "Impossible de copier l'URL du PR",
         },
         archiveWarning: {
           title: "Archiver «{{worktreeName}}»?",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -589,6 +589,8 @@ export const fr: TranslationResources = {
           success: "Tiré et poussé",
         },
         viewPr: "VoirPR",
+        copyPrUrl: "Copier l'URL du PR",
+        copyPrUrlSuccess: "URL copiée",
         createPr: {
           label: "CréerPR",
           pending: "Création dePR...",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -688,6 +688,7 @@ export const ru: TranslationResources = {
           failedMergeFromBase: "Не удалось объединиться с базой.",
           worktreePathUnavailable: "Путь к рабочему дереву недоступен.",
           failedArchive: "Не удалось заархивировать рабочее дерево.",
+          failedCopyPrUrl: "Не удалось скопировать URL PR",
         },
         archiveWarning: {
           title: 'Архив "{{worktreeName}}"?',

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -588,6 +588,8 @@ export const ru: TranslationResources = {
           success: "Вытащил и толкнул",
         },
         viewPr: "Посмотреть PR",
+        copyPrUrl: "Скопировать URL PR",
+        copyPrUrlSuccess: "URL скопирован",
         createPr: {
           label: "Создать PR",
           pending: "Создание PR...",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -581,6 +581,8 @@ export const zhCN: TranslationResources = {
           success: "已 pull 并 push",
         },
         viewPr: "查看 PR",
+        copyPrUrl: "复制 PR 链接",
+        copyPrUrlSuccess: "链接已复制",
         createPr: {
           label: "创建 PR",
           pending: "正在创建 PR...",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -663,6 +663,7 @@ export const zhCN: TranslationResources = {
           failedMergeFromBase: "从 base merge 失败",
           worktreePathUnavailable: "Worktree 路径不可用",
           failedArchive: "归档 worktree 失败",
+          failedCopyPrUrl: "复制 PR 链接失败",
         },
         archiveWarning: {
           title: "归档「{{worktreeName}}」？",


### PR DESCRIPTION
Closes #1655

## What changed

Added a **Copy PR URL** item to the git actions dropdown, positioned immediately after **View PR**.

- Tapping it copies the PR URL to the clipboard
- Shows a **"URL copied"** success toast
- Dropdown closes immediately on select
- Only visible when a PR exists for the current branch

## Testing

Tested on desktop web with a branch that has an open PR:
- "Copy PR URL" appears right below "View PR" in the dropdown
- Tapping it closes the dropdown and shows the success toast
- Pasting confirms the correct PR URL was copied

## Platforms tested

- [x] Desktop (web/Electron)

> I only tested on desktop. I don't have a native device setup to test iOS/Android, but the change uses `expo-clipboard` (`Clipboard.setStringAsync`) which is the same cross-platform utility already used elsewhere in the app.