### PR TITLE
fix(server): raise executable probe timeout for slow agent CLIs

### DIFF
--- a/packages/server/src/executable-resolution/executable-resolution.probe.test.ts
+++ b/packages/server/src/executable-resolution/executable-resolution.probe.test.ts
@@ -13,7 +13,7 @@ import { performance } from "node:perf_hooks";
 import { afterEach, describe, expect, test } from "vitest";
 
 import { isPlatform } from "../test-utils/platform.js";
-import { probeExecutable } from "./executable-resolution.js";
+import { findExecutable, probeExecutable } from "./executable-resolution.js";
 
 const timeoutMs = 1000;
 const timeoutSlackMs = 500;
@@ -179,4 +179,29 @@ describe("probeExecutable", () => {
       }
     },
   );
+});
+
+// Regression test for getpaseo/paseo#1665:
+// `findExecutable()` must honour the configured probe timeout when an agent CLI
+// hangs past it. The elapsed window is bounded on both sides so a silent
+// regression of the constant fails loudly instead of letting slow CLIs be
+// misclassified.
+const EXPECTED_PROBE_TIMEOUT_MS = 5000;
+const REGRESSION_SLACK_MS = 3000;
+
+describe("findExecutable timeout", () => {
+  test("honours PROBE_TIMEOUT_MS for a hanging agent CLI", async () => {
+    const hangsPath = createHangingFixture(makeTempDir());
+    const startedAt = performance.now();
+
+    // The probe sends SIGKILL once the timeout elapses, so findExecutable
+    // resolves with the candidate path rather than throwing. The two timing
+    // assertions below pin the configured timeout.
+    const result = await findExecutable(hangsPath);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(typeof result).toBe("string");
+    expect(elapsedMs).toBeGreaterThan(EXPECTED_PROBE_TIMEOUT_MS);
+    expect(elapsedMs).toBeLessThan(EXPECTED_PROBE_TIMEOUT_MS + REGRESSION_SLACK_MS);
+  });
 });

--- a/packages/server/src/executable-resolution/executable-resolution.ts
+++ b/packages/server/src/executable-resolution/executable-resolution.ts
@@ -10,7 +10,7 @@ type Which = (command: string, options: { all: true }) => Promise<string[]>;
 
 const require = createRequire(import.meta.url);
 const which = require("which") as Which;
-const PROBE_TIMEOUT_MS = 2000;
+const PROBE_TIMEOUT_MS = 5000;
 
 function hasPathSeparator(value: string): boolean {
   return value.includes("/") || value.includes("\\");


### PR DESCRIPTION
### Linked issue

Closes #1665

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

`PROBE_TIMEOUT_MS` in `packages/server/src/executable-resolution/executable-resolution.ts` was 2000ms. `pi --version` takes 1.8–2.1s on cold start, so the probe fires before pi finishes and `--version` is killed. `findExecutable()` then classifies the CLI as missing, and the pi provider reports `unavailable` even when installed and on PATH. Regressed in v0.1.98.

The bug report also points at `node_modules/@getpaseo/server/dist/.../agent.js`, where the v0.1.98 `isAvailable()` wrapper had its own 2000ms `withTimeout`. In upstream `main` both call sites already consume the single `PROBE_TIMEOUT_MS` constant after the executable-resolution refactor, so the fix is one line: bump to 5000ms. Aligns with the existing 3000ms timeout in `enumerateCandidatesViaSystemWhich` in the same file.

### How did you verify it

**Reproduced before**: Paseo daemon v0.1.98 (AppImage), pi v0.79.9, Linux x86_64. `time pi --version` consistently 1.8–2.1s cold. Provider status `unavailable` despite `pi` resolving on PATH. Downgrading to v0.1.97 made the provider available (per the issue comments).

**Verified after**: `npm run typecheck`, `npm run lint`, `npm run format`, and `npx vitest run src/executable-resolution/executable-resolution.test.ts src/executable-resolution/executable-resolution.probe.test.ts` all green. The new regression test under `findExecutable timeout` pins `PROBE_TIMEOUT_MS` against the hang fixture: elapsed must be `> 5000ms` and `< 8000ms`.

**Not verified (flagged honestly)**: the AppImage was not rebuilt and `paseo provider ls` was not re-run end-to-end on the patched code. The change is a single constant on a tested code path. A provider-status screenshot after a full rebuild can be attached on request.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
