### PR TITLE
fix(server): increase Pi availability check timeout from 2s to 8s

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -90,6 +90,10 @@ const PASEO_PI_CAPTURE_EXTENSION_COMMAND = "paseo_capture_entries";
 const PASEO_PI_ENTRY_CAPTURE_MARKER = "PASEO_ENTRY_CAPTURE";
 const PASEO_PI_COMMAND_RESULT_MARKER = "PASEO_COMMAND_RESULT";
 const PASEO_PI_EXTENSION_RESULT_TIMEOUT_MS = 10_000;
+// Pi cold-starts a CLI subprocess and fetches its model catalog during the availability probe,
+// which routinely takes 3-4s on real hardware. 2s was too short and made Pi report unavailable
+// (and therefore show no models in the web UI) on every snapshot refresh.
+const PI_AVAILABILITY_TIMEOUT_MS = 8_000;
 const QUESTION_RESPONSE_HEADER = "Response";
 const QUESTION_COMMENT_HEADER = "Comment";
 const PI_ASK_USER_FREEFORM_SENTINEL = "✏️ Type custom response...";
@@ -2020,7 +2024,7 @@ export class PiRpcAgentClient implements AgentClient {
             await runtimeSession.close().catch(() => undefined);
           }
         })(),
-        2000,
+        PI_AVAILABILITY_TIMEOUT_MS,
         "Pi availability check timed out",
       );
     } catch {


### PR DESCRIPTION
### Linked issue

Closes # (no existing issue - this is a regression fix)

<!-- This fixes a regression introduced in PR #1278 where Pi provider always times out during availability checks -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Pi provider was showing 0 models in the web UI Providers page despite having 548+ models available.

**Root cause**: PR #1278 (acea7f3d2, 2026-06-20) added a 2000ms timeout to `isAvailable()`, but Pi's availability check spawns a CLI subprocess and fetches the full model catalog, which takes ~3000-4000ms in practice. The 2s timeout caused Pi to always time out → marked as `unavailable` → 0 models displayed.

**Fix**: Increase the timeout from hardcoded `2000` to a constant `PI_AVAILABILITY_TIMEOUT_MS = 8_000` to accommodate Pi's cold-start latency.

### How did you verify it

**Reproduction**: Set up an isolated daemon environment with Pi configured (no auth required, direct WebSocket connection). Queried the providers snapshot via DaemonClient.

**Before fix**:
```
Pi status: unavailable
Models count: 0
listProviderModels error: "Provider pi is not available"
```

**After fix**:
```
Pi status: ready
Models count: 548
First 5 models: DeepSeek V4 Flash, DeepSeek V4 Pro, GLM-5, GLM-5.1, Kimi K2.5
listProviderModels: no error, 548 models returned
```

**Cold-start timing measurement**:
- `echo '{"type":"get_available_models","id":"t1"}' | pi --mode rpc`
- First run: 3958ms
- Second run: 2814ms
- Both exceed the original 2000ms timeout

**Unit tests**: All 33 Pi agent tests pass (`packages/server/src/server/agent/providers/pi/agent.test.ts`)

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform (N/A - server-side timeout fix)
- [x] Tests added or updated where it made sense (existing tests pass, no new test needed for timeout constant change)
