### PR TITLE
fix(server): terminate OpenCode server process on startup timeout

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-server-manager.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-server-manager.test.ts
@@ -93,6 +93,18 @@ describe("OpenCodeServerManager generations", () => {
     expect(runtime.terminatedPorts).toEqual([4402, 4401]);
   });
 
+  test("terminates process when server startup times out", { timeout: 35_000 }, async () => {
+    const { manager, runtime } = createTestManager([4601]);
+
+    runtime.delayListeningAnnouncement = 31_000;
+
+    const acquisitionPromise = manager.acquire({ force: false });
+
+    await expect(acquisitionPromise).rejects.toThrow(/OpenCode server (startup timeout|exited)/);
+
+    expect(runtime.terminatedPorts).toEqual([4601]);
+  });
+
   test("shutdown still signals a process after an earlier kill signal if it has not exited", async () => {
     const { manager, runtime } = createTestManager([4451]);
 
@@ -179,6 +191,7 @@ class FakeOpenCodeServerRuntime {
   private readonly ports: number[];
   private readonly processesByChild = new Map<ChildProcess, FakeOpenCodeProcess>();
   private readonly processesByPort = new Map<number, FakeOpenCodeProcess>();
+  delayListeningAnnouncement = 0;
 
   constructor(ports: number[]) {
     this.ports = [...ports];
@@ -206,7 +219,11 @@ class FakeOpenCodeServerRuntime {
     const process = new FakeOpenCodeProcess({ port, pid: 10_000 + port });
     this.processesByChild.set(process.child, process);
     this.processesByPort.set(port, process);
-    queueMicrotask(() => process.announceListening());
+    if (this.delayListeningAnnouncement > 0) {
+      setTimeout(() => process.announceListening(), this.delayListeningAnnouncement);
+    } else {
+      queueMicrotask(() => process.announceListening());
+    }
     return process.child;
   };
 

--- a/packages/server/src/server/agent/providers/opencode/server-manager.ts
+++ b/packages/server/src/server/agent/providers/opencode/server-manager.ts
@@ -275,6 +275,21 @@ export class OpenCodeServerManager implements OpenCodeServerManagerLike {
       };
       const timeout = setTimeout(() => {
         if (!started) {
+          this.removeManagedProcessRecordWhenResolved(managedProcessRecord);
+          void this.terminateProcess(serverProcess, {
+            gracefulTimeoutMs: 1_000,
+            forceTimeoutMs: 1_000,
+          })
+            .then(() => {
+              this.logger.warn({ port }, "Killed OpenCode server process after startup timeout");
+              return undefined;
+            })
+            .catch((error) => {
+              this.logger.error(
+                { err: error, port },
+                "Failed to kill OpenCode server process after timeout",
+              );
+            });
           reject(new Error(buildStartupErrorMessage("OpenCode server startup timeout")));
         }
       }, 30_000);


### PR DESCRIPTION
### Linked issue

Closes #1676

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

This PR fixes a critical memory leak in the OpenCode provider where server processes were not being terminated after startup timeouts.

**The problem:**
When `opencode serve --port <N>` failed to start within 30 seconds, the timeout handler would reject the Promise but never kill the spawned process. On Windows, each spawn creates a process tree (`pwsh.exe` → `node.exe` → OpenCode server), and all three processes would persist as zombies.

With multiple concurrent provider operations (e.g., `refresh_providers_snapshot` + `fetch_recent_provider_sessions`), this quickly accumulated hundreds of zombie processes consuming 100GB+ of RAM.

**The fix:**
- Modified the timeout handler in `OpenCodeServerManager.startServer()` to call `terminateProcess()` before rejecting
- Uses graceful shutdown (SIGTERM) with 1-second timeout, then force kill (SIGKILL)
- Removes managed process records immediately to prevent stale entries
- Logs termination success/failure for debugging

**Impact:**
Timed-out processes are now cleaned up within ~2 seconds instead of persisting indefinitely, preventing memory exhaustion.

### How did you verify it

**1. Added test coverage:**
- New test case: "terminates process when server startup times out"
- Simulates a 31-second startup delay (exceeding 30s timeout)
- Verifies the Promise rejects with appropriate error
- **Verifies the process is actually terminated** (checks `runtime.terminatedPorts`)
- Test passes consistently with 30-second runtime

**2. Ran existing test suite:**
```bash
npx vitest run src/server/agent/providers/opencode-server-manager.test.ts
# ✓ 10 tests passed (including the new timeout test)
```

**3. Verified code quality:**
```bash
npm run typecheck  # ✓ passes
npm run lint       # ✓ passes  
npm run format     # ✓ passes
```

**4. Manual verification of the fix logic:**
- Reviewed the termination code path to ensure:
  - `terminateProcess()` is called with proper timeouts
  - Managed process record is removed via `removeManagedProcessRecordWhenResolved()`
  - Error handling covers both success and failure cases
  - The fix doesn't interfere with normal startup flow (only runs if `!started`)

**5. Confirmed the root cause:**
- Analyzed the issue logs showing repeated "OpenCode server startup timeout" errors
- Confirmed the user's observation of 533 `opencode serve` zombie processes
- Verified this matches the symptom: timeout rejects Promise but doesn't kill process

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform (N/A - server-side fix)
- [x] Tests added or updated where it made sense
