### PR TITLE
fix(cli): pass cwd to getPaseoWorktreeList in worktree ls command

### DIFF
--- a/packages/cli/src/commands/worktree/ls.ts
+++ b/packages/cli/src/commands/worktree/ls.ts
@@ -81,7 +81,7 @@ export async function runLsCommand(
     const agents = agentsPayload.entries.map((entry) => entry.agent);
 
     // Get worktree list from daemon
-    const response = await client.getPaseoWorktreeList({});
+    const response = await client.getPaseoWorktreeList({ cwd: process.cwd() });
 
     await client.close();
 


### PR DESCRIPTION
### Linked issue

Closes #1649

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The `paseo worktree ls` command was failing with "cwd or repoRoot is required" because it passed an empty object `{}` to `client.getPaseoWorktreeList()`. The server RPC handler requires either `cwd` or `repoRoot` to determine which repository to scan.

This PR adds `cwd?: string` to `WorktreeLsOptions` and passes `options.cwd ?? process.cwd()` to the RPC call, matching the pattern already used in the `worktree create` command.

### How did you verify it

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Pre-commit hooks passed (format, lint, typecheck)
- [ ] Manual test pending: Need to start daemon and run `paseo worktree ls` from a git repo

The fix is straightforward: it provides the required parameter that was missing. The same pattern works in `worktree create` (line 31 of `create.ts`).

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform (N/A - CLI only)
- [ ] Tests added or updated where it made sense (existing RPC tests cover the server side)