### PR TITLE
feat(server): add option to disable context usage probing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ At the start of non-trivial work, list `docs/` and skim anything relevant to the
 | [docs/android.md](docs/android.md)                             | App variants, local/cloud builds, EAS workflows                                                                                |
 | [docs/release.md](docs/release.md)                             | Release playbook, draft releases, completion checklist                                                                         |
 | [docs/terminal-activity.md](docs/terminal-activity.md)         | Terminal activity indicators — source-agnostic tracker, agent hook reporting, adding a new hook provider                       |
+| [docs/context-usage-probing.md](docs/context-usage-probing.md) | Context usage probing — how it works, disabling to reduce API calls, fallback behavior                                         |
 | [SECURITY.md](SECURITY.md)                                     | Relay threat model, E2E encryption, DNS rebinding, agent auth                                                                  |
 
 ## Quick start

--- a/docs/context-usage-probing.md
+++ b/docs/context-usage-probing.md
@@ -1,0 +1,93 @@
+# Context Usage Probing
+
+## Overview
+
+Starting in v0.1.98, Paseo's Claude provider queries the current context window usage after each successful message completion by calling `getContextUsage()`. This provides precise context usage statistics but doubles the API request count.
+
+**Prior to v0.1.98**, context usage was calculated from stream events and result usage data without additional API calls. This configuration allows you to restore that behavior.
+
+## How it works
+
+After each successful message, the daemon calls `getContextUsage()` on the Claude SDK, which sends a probe API request (with `max_tokens=1`) to retrieve:
+
+- `totalTokens`: Current context window usage
+- `maxTokens`: Maximum context window size for the current model
+
+This information powers the context usage meter in the Paseo UI.
+
+## Disabling context usage probing
+
+If you want to reduce API request count and avoid the extra probe requests, you can disable this feature using an environment variable.
+
+### Option 1: Environment variable (recommended)
+
+Set `PASEO_DISABLE_CONTEXT_USAGE_PROBE=true` before starting the daemon:
+
+```bash
+export PASEO_DISABLE_CONTEXT_USAGE_PROBE=true
+paseo daemon restart
+```
+
+Or add it to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
+
+```bash
+echo 'export PASEO_DISABLE_CONTEXT_USAGE_PROBE=true' >> ~/.bashrc
+source ~/.bashrc
+```
+
+### Option 2: Per-provider configuration
+
+You can also set it per provider in `~/.paseo/config.json`:
+
+```json
+{
+  "providers": {
+    "claude": {
+      "env": {
+        "PASEO_DISABLE_CONTEXT_USAGE_PROBE": "true"
+      }
+    }
+  }
+}
+```
+
+## Impact of disabling
+
+When context usage probing is disabled, Paseo reverts to the **v0.1.97 behavior**:
+
+### What changes:
+
+- No additional API probe requests after each message
+- Context usage is calculated from existing data (stream events and result usage)
+- Slightly less precise in edge cases, but generally accurate
+
+### What you gain:
+
+- **50% fewer API requests** (no probe request after each message)
+- **Reduced latency** (no 3-second timeout wait for context usage query)
+- **Lower risk of hitting rate limits** during high-frequency usage
+- **Lower API costs**
+
+### Fallback behavior (same as v0.1.97)
+
+Context usage is calculated from:
+
+1. **Stream events** (`message_start`, `message_delta`): Incremental token counts during message streaming
+2. **Result usage**: Final usage data included in the API response (`message.usage`)
+
+This is the **exact same mechanism used in v0.1.97** and provides accurate usage statistics for normal operation.
+
+## When to disable
+
+Consider disabling context usage probing if:
+
+- You're experiencing rate limit issues
+- You're cost-conscious about API usage
+- You frequently send many messages in quick succession
+- You don't need real-time precise context window metrics
+
+## Related
+
+- GitHub issue: [#1685](https://github.com/getpaseo/paseo/issues/1685)
+- Feature introduced in: v0.1.98 (commit `a924059da`)
+- Fallback mechanism: See `buildResultUsage()` in `packages/server/src/server/agent/providers/claude/agent.ts`

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -3456,8 +3456,12 @@ class ClaudeAgentSession implements AgentSession {
     messageIdHint: string | null,
     turnId: string | null,
   ): Promise<AgentStreamEvent[]> {
+    // Allow disabling context usage probing to reduce API calls (restores v0.1.97 behavior).
+    // When disabled, context usage is calculated from stream events and result usage data
+    // via the fallback mechanism in buildResultUsage() - same as v0.1.97.
+    const shouldProbeContextUsage = process.env.PASEO_DISABLE_CONTEXT_USAGE_PROBE !== "true";
     const currentContextUsage =
-      message.type === "result" && message.subtype === "success"
+      shouldProbeContextUsage && message.type === "result" && message.subtype === "success"
         ? await this.queryCurrentContextUsage(activeQuery)
         : undefined;
     const messageEvents = this.translateMessageToEvents(message, {


### PR DESCRIPTION
### Linked issue

Closes #1685

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds `PASEO_DISABLE_CONTEXT_USAGE_PROBE` environment variable to allow disabling the `getContextUsage()` API probe calls introduced in v0.1.98.

**Background:** In v0.1.98 (commit `a924059da`), the Claude provider started calling `getContextUsage()` after every successful message to get precise context usage statistics. While this provides accurate data, it doubles the API request count - each message now triggers:
1. The actual message request
2. A probe request with `max_tokens=1` to query context usage

**This PR:** Adds an opt-out via environment variable. When `PASEO_DISABLE_CONTEXT_USAGE_PROBE=true`, the daemon skips the probe call and falls back to v0.1.97 behavior: calculating context usage from stream events and result usage data.

**Benefits when disabled:**
- 50% fewer API requests (no probe after each message)
- Reduced latency (no 3-second timeout for context query)
- Lower risk of hitting rate limits
- Lower API costs

**Context usage remains accurate** - the fallback mechanism (`buildResultUsage()`) uses:
1. Stream events (`message_start`, `message_delta`) for incremental token counts
2. Result usage data from the final API response

This is the same mechanism used successfully in v0.1.97.

### How did you verify it

**1. Code review:**
- Verified the fallback logic in `buildResultUsage()` (lines 1826-1827) properly handles `undefined` currentContextUsage
- Confirmed environment variable is checked before calling `queryCurrentContextUsage()`
- Reviewed the three-tier fallback: `currentContextUsage?.totalTokens ?? this.streamUsedTokens() ?? activeResultUsageTokens`

**2. Pre-commit hooks passed:**
- ✅ `npm run lint` - 0 warnings, 0 errors
- ✅ `npm run format:check` - all files correctly formatted  
- ✅ `npm run typecheck` - all workspaces pass (23s)

**3. Tested behavior (manual):**
```bash
# Without the env var (default behavior - probe enabled)
npm run cli -- daemon restart
# Observed: getContextUsage() called after each message (doubles API requests)

# With the env var (probe disabled)
export PASEO_DISABLE_CONTEXT_USAGE_PROBE=true
npm run cli -- daemon restart
# Observed: no additional probe requests, context usage still reported correctly
```

**4. Verified backward compatibility:**
- When env var is not set or set to anything other than `"true"`, behavior is unchanged (probe enabled)
- Existing deployments unaffected

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A - server-side only)
- [x] Tests added or updated where it made sense (existing test mocks already handle `getContextUsage` returning undefined)