### PR TITLE
fix: suppress ACP user prompt echoes

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1916,6 +1916,40 @@ describe("ACPAgentSession", () => {
     ).toHaveLength(1);
   });
 
+  test("startTurn ignores ACP user echo chunks that rewrite the submitted message id", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    const prompt = vi.fn(() => new Promise<PromptResponse>(() => {}));
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    const { turnId } = await session.startTurn("follow-up", { messageId: "msg-client-1" });
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "user_message_chunk",
+        messageId: "provider-echo-1",
+        content: { type: "text", text: "initial questionfollow-up" },
+      } as SessionUpdate,
+    });
+
+    expect(
+      events.filter((event) => event.type === "timeline" && event.item.type === "user_message"),
+    ).toEqual([
+      {
+        type: "timeline",
+        provider: "claude-acp",
+        turnId,
+        item: { type: "user_message", text: "follow-up", messageId: "msg-client-1" },
+      },
+    ]);
+  });
+
   test("startTurn converts background prompt rejections into turn_failed events", async () => {
     const session = createSession();
     const events: Array<{ type: string; turnId?: string; error?: string }> = [];

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2012,11 +2012,20 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[] {
     switch (update.sessionUpdate) {
       case "user_message_chunk": {
-        const item = this.createMessageTimelineItem("user_message", update);
-        if (!item) {
+        // ACP providers often echo submitted user prompts back as user_message_chunk
+        // updates. Paseo already emits the submitted prompt locally in startTurn().
+        // Some providers rewrite or omit the original messageId, and can replay
+        // cumulative user text across follow-ups, so messageId-only de-duping is
+        // not enough. While a foreground turn is active, keep the local submitted
+        // user bubble and ignore provider echoes.
+        if (this.activeForegroundTurnId) {
           return [];
         }
         if (update.messageId && this.submittedUserMessageIds.has(update.messageId)) {
+          return [];
+        }
+        const item = this.createMessageTimelineItem("user_message", update);
+        if (!item) {
           return [];
         }
         return [this.wrapTimeline(item)];


### PR DESCRIPTION
## Summary
- Suppress live ACP `user_message_chunk` echoes while a foreground turn is active.
- Keep the submitted user bubble emitted by `startTurn()` as the timeline source of truth.
- Add a regression for providers that echo a user prompt with a rewritten message id and cumulative text across follow-ups.

## Why
Some ACP providers echo submitted user prompts back as `user_message_chunk` updates. Paseo already emits the submitted prompt locally, so those provider echoes can duplicate the user message. Message-id de-duping is insufficient when the provider rewrites or omits the original client message id.

## Validation
- Reproduced failure first with the new focused regression.
- `npm exec --workspace=@getpaseo/server -- vitest run src/server/agent/providers/acp-agent.test.ts -t "startTurn ignores ACP user echo chunks that rewrite the submitted message id"`
- `npm exec --workspace=@getpaseo/server -- vitest run src/server/agent/providers/acp-agent.test.ts`
- `npm run typecheck --workspace=@getpaseo/server`
- `npm run build:server`
- pre-commit: `oxlint`, `oxfmt --check`, and workspace `typecheck`
