### PR TITLE
Refresh open file tabs when revisited (#445)

### DIFF
--- a/packages/app/src/components/file-pane-enabled.test.ts
+++ b/packages/app/src/components/file-pane-enabled.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isFileQueryEnabled } from "./file-pane-enabled";
+
+describe("isFileQueryEnabled", () => {
+  it("reads when there is a target, the tab is active, and the app is visible", () => {
+    expect(isFileQueryEnabled({ hasReadTarget: true, isTabActive: true, isAppVisible: true })).toBe(
+      true,
+    );
+  });
+
+  it("does not read while the tab is hidden", () => {
+    expect(
+      isFileQueryEnabled({ hasReadTarget: true, isTabActive: false, isAppVisible: true }),
+    ).toBe(false);
+  });
+
+  it("does not read while the app is backgrounded", () => {
+    expect(
+      isFileQueryEnabled({ hasReadTarget: true, isTabActive: true, isAppVisible: false }),
+    ).toBe(false);
+  });
+
+  it("does not read without a resolved file target", () => {
+    expect(
+      isFileQueryEnabled({ hasReadTarget: false, isTabActive: true, isAppVisible: true }),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/components/file-pane-enabled.ts
+++ b/packages/app/src/components/file-pane-enabled.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether `FilePane` should read its file right now.
+ *
+ * The read is gated on visibility so a revisited tab refetches instead of showing
+ * the frozen first-load snapshot (#445): React Query refetches on the
+ * disabled→enabled transition (stale-gated by the query's staleTime). The file is
+ * read only when there is something to read AND the pane can actually show it —
+ * the tab is the active one (not a hidden, mounted-but-offscreen tab) and the
+ * whole app is in the foreground.
+ */
+export function isFileQueryEnabled(input: {
+  hasReadTarget: boolean;
+  isTabActive: boolean;
+  isAppVisible: boolean;
+}): boolean {
+  return input.hasReadTarget && input.isTabActive && input.isAppVisible;
+}

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useContext, useEffect, useMemo, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { FileReadResult } from "@getpaseo/client/internal/daemon-client";
 import {
@@ -29,6 +29,9 @@ import { createPreviewAttachmentId, getFileNameFromPath } from "@/attachments/ut
 import { explorerFileFromReadResult } from "@/file-explorer/read-result";
 import { resolveFilePreviewReadTarget } from "@/file-explorer/preview-target";
 import type { WorkspaceFileLocation } from "@/workspace/file-open";
+import { MountedTabActiveContext } from "@/components/split-container";
+import { useAppVisible } from "@/hooks/use-app-visible";
+import { isFileQueryEnabled } from "@/components/file-pane-enabled";
 
 interface CodeLineProps {
   tokens: HighlightToken[];
@@ -408,9 +411,19 @@ export function FilePane({
     [normalizedFilePath, normalizedWorkspaceRoot],
   );
 
+  // Re-read the file when this pane becomes visible again (#445). `isActive`
+  // covers tab switches, `isAppVisible` the whole-app background/foreground; the
+  // gate itself lives in isFileQueryEnabled.
+  const isActive = useContext(MountedTabActiveContext);
+  const isAppVisible = useAppVisible();
+
   const query = useQuery({
     queryKey: ["workspaceFile", serverId, readTarget?.cwd ?? null, readTarget?.path ?? null],
-    enabled: Boolean(client && readTarget),
+    enabled: isFileQueryEnabled({
+      hasReadTarget: Boolean(client && readTarget),
+      isTabActive: isActive,
+      isAppVisible,
+    }),
     queryFn: async () => {
       if (!client || !readTarget) {
         return {


### PR DESCRIPTION
### Linked issue

Addresses #445. Covers the revisit/refocus case; live-while-open is a documented limitation below, so this is a reference rather than `Closes` — happy to switch to `Closes #445` if you'd rather track the remainder separately.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

File previews are read once and then frozen. Visited file tabs stay mounted-but-hidden (the LRU in `useMountedTabSet`), so `refetchOnMount` never fires again, and there's no file-watch or focus refetch — the only way to see fresh content is to close and reopen the tab.

This gates the file read's React Query `enabled` flag on visibility: `enabled: Boolean(client && readTarget) && isActive && isAppVisible`, where `isActive` comes from `MountedTabActiveContext` (tab switches) and `isAppVisible` from `useAppVisible()` (app background/foreground). When the pane becomes visible again the flag flips `false → true`, and React Query refetches on that transition — but only when the cached read is stale (the existing `staleTime: 5_000`), so a quick flip away and back doesn't re-read. No new abstraction and no daemon/protocol change; it reuses two visibility signals the app already has.

### How did you verify it

Desktop app. Base case: a coding agent and a markdown file open as tabs in the **same tab group** (one pane, no split), with the agent editing the file on disk.

- Switching from another tab in that group back to the file's tab refreshes the viewer to the current on-disk content — previously it stayed stale until I closed and reopened the tab.
- Same result after alt-tabbing away from the whole app and back (app refocus).
- `npx vitest run packages/app/src/components/file-pane-enabled.test.ts` — pure unit test of the visibility gate (`isFileQueryEnabled`): the file reads only when there’s a target and the tab is active and the app is foregrounded.
- `npm run typecheck`, `npm run lint`, `npm run format` clean (also enforced by the pre-commit hook).

### Limitations (intentional scope)

- Does **not** live-update while the file stays open in the foreground (no tab switch / app refocus). That needs the daemon to watch the file and push changes — a separate, larger change. This is the cheap, client-only win.
- 5s debounce: returning to a tab within 5s of the last read shows the cached content. Deliberate, so rapid tab-flicking doesn't re-read (matters over the relay).
- During the re-read the previous content shows briefly with no spinner; negligible locally, possibly a beat for a large file over the relay.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots — N/A (behavior change, no visual styling)
- [x] Tests added or updated where it made sense
