### PR TITLE
feat: support dropping file paths into composer

### DIFF
--- a/packages/app/src/components/file-drop-zone.tsx
+++ b/packages/app/src/components/file-drop-zone.tsx
@@ -12,6 +12,7 @@ interface FileDropZoneProps {
   children: React.ReactNode;
   onFilesDropped: (files: ImageAttachment[]) => void;
   onGenericFilesDropped?: (items: DroppedItem[]) => void;
+  onTextDropped?: (text: string) => void;
   disabled?: boolean;
 }
 
@@ -21,6 +22,7 @@ export function FileDropZone({
   children,
   onFilesDropped,
   onGenericFilesDropped,
+  onTextDropped,
   disabled = false,
 }: FileDropZoneProps) {
   const { t } = useTranslation();
@@ -28,6 +30,7 @@ export function FileDropZone({
   const { isDragging, containerRef } = useFileDropZone({
     onFilesDropped,
     onGenericFilesDropped,
+    onTextDropped,
     disabled,
   });
 
@@ -47,24 +50,21 @@ export function FileDropZone({
     [overlayAnimatedStyle],
   );
 
-  // On non-web platforms, just render children
+  // On non-web platforms, just render children.
   if (!IS_WEB) {
     return children;
   }
 
   return (
     <View
-      // Cast ref for web - View renders as div on web
+      // Cast ref for web - View renders as div on web.
       ref={containerRef as unknown as React.RefObject<View>}
       style={styles.container}
     >
       {children}
 
-      {/* Drop overlay */}
       <Animated.View style={overlayStyle}>
-        {/* Backdrop */}
         <View style={styles.backdrop} />
-        {/* Content */}
         <View style={styles.overlayContent}>
           <Upload size={32} color={theme.colors.primary} />
           <Text style={styles.overlayText}>{t("composer.attachments.dropFilesHere")}</Text>

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -6,6 +6,7 @@ import { StyleSheet } from "react-native-unistyles";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useKeyboardShiftStyle } from "@/hooks/use-keyboard-shift-style";
 import { useContainerWidthBelow } from "@/hooks/use-container-width";
+import { appendDroppedFilePathText } from "@/file-drops/file-drop-paths";
 import invariant from "tiny-invariant";
 import { Composer } from "@/composer";
 import { DraftAgentModeControl } from "@/composer/agent-controls/mode-control";
@@ -544,6 +545,19 @@ export function WorkspaceDraftAgentTab({
     addImagesRef.current?.(files);
   }, []);
 
+  const draftText = draftInput.text;
+  const handleTextDropped = useCallback(
+    (text: string) => {
+      setDraftText(
+        appendDroppedFilePathText({
+          currentText: draftText,
+          droppedText: text,
+        }),
+      );
+    },
+    [draftText, setDraftText],
+  );
+
   const handleAddImagesCallback = useCallback((addImages: (images: ImageAttachment[]) => void) => {
     addImagesRef.current = addImages;
   }, []);
@@ -655,7 +669,7 @@ export function WorkspaceDraftAgentTab({
   );
 
   return (
-    <FileDropZone onFilesDropped={handleFilesDropped}>
+    <FileDropZone onFilesDropped={handleFilesDropped} onTextDropped={handleTextDropped}>
       <View style={styles.container}>
         <View style={styles.contentContainer}>
           {isSubmitting && draftAgent ? (

--- a/packages/app/src/file-drops/file-drop-paths.test.ts
+++ b/packages/app/src/file-drops/file-drop-paths.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendDroppedFilePathText,
+  extractDroppedFilePaths,
+  getDroppedImageMimeType,
+  resolveDroppedFilePaths,
+} from "./file-drop-paths";
+
+function dataTransfer(files: File[]): DataTransfer {
+  return { files } as unknown as DataTransfer;
+}
+
+function fakeFile(input: { name: string; legacyPath?: string }): File {
+  const file = { name: input.name } as unknown as File;
+  if (input.legacyPath !== undefined) {
+    Object.defineProperty(file, "path", {
+      configurable: true,
+      value: input.legacyPath,
+    });
+  }
+  return file;
+}
+
+describe("file drop paths", () => {
+  it("extracts absolute paths through Electron webUtils", () => {
+    const file = fakeFile({ name: "notes.md" });
+    const bridge = {
+      webUtils: {
+        getPathForFile: () => "/Users/me/Desktop/notes.md",
+      },
+    };
+
+    expect(extractDroppedFilePaths(dataTransfer([file]), bridge)).toEqual([
+      "/Users/me/Desktop/notes.md",
+    ]);
+  });
+
+  it("falls back to legacy Electron file paths", () => {
+    const file = fakeFile({ name: "notes.md", legacyPath: "/tmp/notes.md" });
+    const bridge = {
+      webUtils: {
+        getPathForFile: () => {
+          throw new Error("not available");
+        },
+      },
+    };
+
+    expect(extractDroppedFilePaths(dataTransfer([file]), bridge)).toEqual(["/tmp/notes.md"]);
+  });
+
+  it("splits image paths from other file paths", () => {
+    expect(
+      resolveDroppedFilePaths([
+        "/Users/me/Desktop/photo.PNG",
+        "/Users/me/Desktop/notes.md",
+        "/Users/me/Desktop/archive.tar.gz",
+        "/Users/me/Desktop/vector.svg?cache=1",
+      ]),
+    ).toEqual({
+      imagePaths: ["/Users/me/Desktop/photo.PNG", "/Users/me/Desktop/vector.svg?cache=1"],
+      textPaths: ["/Users/me/Desktop/notes.md", "/Users/me/Desktop/archive.tar.gz"],
+      text: "/Users/me/Desktop/notes.md\n/Users/me/Desktop/archive.tar.gz",
+    });
+  });
+
+  it("returns null text when every dropped path is an image", () => {
+    expect(resolveDroppedFilePaths(["/tmp/a.jpg", "/tmp/b.webp"])).toEqual({
+      imagePaths: ["/tmp/a.jpg", "/tmp/b.webp"],
+      textPaths: [],
+      text: null,
+    });
+  });
+
+  it("resolves image mime types from path extensions", () => {
+    expect(getDroppedImageMimeType("/tmp/photo.avif")).toBe("image/avif");
+    expect(getDroppedImageMimeType("/tmp/unknown")).toBe("image/jpeg");
+  });
+
+  it("appends dropped path text to the existing composer text", () => {
+    expect(
+      appendDroppedFilePathText({
+        currentText: "Please inspect",
+        droppedText: "/tmp/report.pdf\n/tmp/source.ts",
+      }),
+    ).toBe("Please inspect\n/tmp/report.pdf\n/tmp/source.ts");
+
+    expect(
+      appendDroppedFilePathText({
+        currentText: "Please inspect ",
+        droppedText: "/tmp/report.pdf",
+      }),
+    ).toBe("Please inspect /tmp/report.pdf");
+
+    expect(
+      appendDroppedFilePathText({
+        currentText: "",
+        droppedText: "/tmp/report.pdf",
+      }),
+    ).toBe("/tmp/report.pdf");
+  });
+});

--- a/packages/app/src/file-drops/file-drop-paths.ts
+++ b/packages/app/src/file-drops/file-drop-paths.ts
@@ -1,0 +1,115 @@
+import type { DesktopHostBridge } from "@/desktop/host";
+
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".bmp": "image/bmp",
+  ".svg": "image/svg+xml",
+  ".heic": "image/heic",
+  ".heif": "image/heif",
+  ".avif": "image/avif",
+  ".tif": "image/tiff",
+  ".tiff": "image/tiff",
+};
+
+export interface DroppedFilePathPayload {
+  imagePaths: string[];
+  textPaths: string[];
+  text: string | null;
+}
+
+function getLegacyFilePath(file: File): string | null {
+  const path = Reflect.get(file, "path");
+  return typeof path === "string" && path.length > 0 ? path : null;
+}
+
+function getFilePath(
+  file: File,
+  bridge: Pick<DesktopHostBridge, "webUtils"> | null,
+): string | null {
+  const getPathForFile = bridge?.webUtils?.getPathForFile;
+  if (typeof getPathForFile === "function") {
+    try {
+      const path = getPathForFile(file);
+      if (typeof path === "string" && path.length > 0) {
+        return path;
+      }
+    } catch {
+      return getLegacyFilePath(file);
+    }
+  }
+  return getLegacyFilePath(file);
+}
+
+export function extractDroppedFilePaths(
+  dataTransfer: DataTransfer | null,
+  bridge: Pick<DesktopHostBridge, "webUtils"> | null,
+): string[] {
+  if (!dataTransfer) {
+    return [];
+  }
+
+  const paths: string[] = [];
+  for (const file of Array.from(dataTransfer.files)) {
+    const path = getFilePath(file, bridge);
+    if (path) {
+      paths.push(path);
+    }
+  }
+  return paths;
+}
+
+function getFileExtension(path: string): string {
+  const normalizedPath = path.split("#", 1)[0]?.split("?", 1)[0] ?? path;
+  const extensionIndex = normalizedPath.lastIndexOf(".");
+  if (extensionIndex < 0) {
+    return "";
+  }
+  return normalizedPath.slice(extensionIndex).toLowerCase();
+}
+
+function isImagePath(path: string): boolean {
+  return getFileExtension(path) in IMAGE_MIME_BY_EXTENSION;
+}
+
+export function getDroppedImageMimeType(path: string): string {
+  return IMAGE_MIME_BY_EXTENSION[getFileExtension(path)] ?? "image/jpeg";
+}
+
+export function resolveDroppedFilePaths(paths: readonly string[]): DroppedFilePathPayload {
+  const imagePaths: string[] = [];
+  const textPaths: string[] = [];
+
+  for (const path of paths) {
+    if (isImagePath(path)) {
+      imagePaths.push(path);
+    } else {
+      textPaths.push(path);
+    }
+  }
+
+  return {
+    imagePaths,
+    textPaths,
+    text: textPaths.length > 0 ? textPaths.join("\n") : null,
+  };
+}
+
+export function appendDroppedFilePathText(input: {
+  currentText: string;
+  droppedText: string;
+}): string {
+  const { currentText, droppedText } = input;
+  if (droppedText.length === 0) {
+    return currentText;
+  }
+  if (currentText.length === 0) {
+    return droppedText;
+  }
+  return /\s$/u.test(currentText)
+    ? `${currentText}${droppedText}`
+    : `${currentText}\n${droppedText}`;
+}

--- a/packages/app/src/hooks/use-file-drop-zone.ts
+++ b/packages/app/src/hooks/use-file-drop-zone.ts
@@ -2,12 +2,13 @@ import { useState, useRef, useEffect } from "react";
 import type { ImageAttachment } from "@/composer/types";
 import { getDesktopHost } from "@/desktop/host";
 import { persistAttachmentFromBlob, persistAttachmentFromFileUri } from "@/attachments/service";
-import {
-  getRasterImageMimeTypeFromPath,
-  isRasterImageFile,
-  isRasterImagePath,
-} from "@/attachments/file-types";
+import { isRasterImageFile } from "@/attachments/file-types";
 import { isWeb } from "@/constants/platform";
+import {
+  extractDroppedFilePaths,
+  getDroppedImageMimeType,
+  resolveDroppedFilePaths,
+} from "@/file-drops/file-drop-paths";
 
 export interface DroppedFileItem {
   kind: "web-file";
@@ -22,6 +23,7 @@ export type DroppedItem = DroppedFileItem | DroppedPathItem;
 interface UseFileDropZoneOptions {
   onFilesDropped: (files: ImageAttachment[]) => void;
   onGenericFilesDropped?: (items: DroppedItem[]) => void;
+  onTextDropped?: (text: string) => void;
   disabled?: boolean;
 }
 
@@ -53,7 +55,7 @@ interface DesktopDragDropEvent {
 }
 
 async function filePathToImageAttachment(path: string): Promise<ImageAttachment> {
-  const mimeType = getRasterImageMimeTypeFromPath(path) ?? "image/jpeg";
+  const mimeType = getDroppedImageMimeType(path);
   return await persistAttachmentFromFileUri({ uri: path, mimeType });
 }
 
@@ -68,6 +70,7 @@ async function fileToImageAttachment(file: File): Promise<ImageAttachment> {
 export function useFileDropZone({
   onFilesDropped,
   onGenericFilesDropped,
+  onTextDropped,
   disabled = false,
 }: UseFileDropZoneOptions): UseFileDropZoneReturn {
   const [isDragging, setIsDragging] = useState(false);
@@ -75,8 +78,8 @@ export function useFileDropZone({
   const dragCounterRef = useRef(0);
   const onFilesDroppedRef = useRef(onFilesDropped);
   const onGenericFilesDroppedRef = useRef(onGenericFilesDropped);
+  const onTextDroppedRef = useRef(onTextDropped);
 
-  // Keep callback refs up to date
   useEffect(() => {
     onFilesDroppedRef.current = onFilesDropped;
   }, [onFilesDropped]);
@@ -85,7 +88,10 @@ export function useFileDropZone({
     onGenericFilesDroppedRef.current = onGenericFilesDropped;
   }, [onGenericFilesDropped]);
 
-  // Reset drag state when disabled changes
+  useEffect(() => {
+    onTextDroppedRef.current = onTextDropped;
+  }, [onTextDropped]);
+
   useEffect(() => {
     if (disabled) {
       setIsDragging(false);
@@ -93,7 +99,7 @@ export function useFileDropZone({
     }
   }, [disabled]);
 
-  // Set up event listeners on web
+  // Set up event listeners on web.
   useEffect(() => {
     if (!IS_WEB) return;
 
@@ -146,16 +152,20 @@ export function useFileDropZone({
 
           if (disabled) return;
 
-          const items: DroppedPathItem[] = payload.paths.map((path) => ({
-            kind: "desktop-path",
-            path,
-          }));
-
-          if (onGenericFilesDroppedRef.current && items.length > 0) {
-            onGenericFilesDroppedRef.current(items);
+          const droppedPaths = resolveDroppedFilePaths(payload.paths);
+          if (droppedPaths.text) {
+            onTextDroppedRef.current?.(droppedPaths.text);
+          } else if (!onTextDroppedRef.current && onGenericFilesDroppedRef.current) {
+            const items: DroppedPathItem[] = payload.paths.map((path) => ({
+              kind: "desktop-path",
+              path,
+            }));
+            if (items.length > 0) {
+              onGenericFilesDroppedRef.current(items);
+            }
           }
 
-          const imagePaths = payload.paths.filter(isRasterImagePath);
+          const imagePaths = droppedPaths.imagePaths;
           if (imagePaths.length === 0) {
             return;
           }
@@ -241,8 +251,12 @@ export function useFileDropZone({
           kind: "web-file",
           file,
         }));
-
-        if (onGenericFilesDroppedRef.current && genericItems.length > 0) {
+        const droppedPaths = resolveDroppedFilePaths(
+          extractDroppedFilePaths(e.dataTransfer ?? null, getDesktopHost()),
+        );
+        if (droppedPaths.text) {
+          onTextDroppedRef.current?.(droppedPaths.text);
+        } else if (onGenericFilesDroppedRef.current && genericItems.length > 0) {
           onGenericFilesDroppedRef.current(genericItems);
         }
 

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -16,12 +16,7 @@ import { Composer } from "@/composer";
 import { AgentModeControl } from "@/composer/agent-controls/mode-control";
 import { FileDropZone } from "@/components/file-drop-zone";
 import { uploadFileAttachments } from "@/composer/actions";
-import {
-  getMimeTypeFromPath,
-  isRasterImageFile,
-  isRasterImagePath,
-} from "@/attachments/file-types";
-import { readDesktopFileBytes } from "@/hooks/use-file-picker";
+import { getMimeTypeFromPath, isRasterImageFile } from "@/attachments/file-types";
 import type { DroppedItem } from "@/hooks/use-file-drop-zone";
 import type { UserComposerAttachment } from "@/attachments/types";
 import { RewindComposerRestoreProvider } from "@/components/rewind/composer-restore";
@@ -57,6 +52,7 @@ import {
   clearHistorySyncErrorAfterSuccessfulSync,
   reconcileMissingAgentStateWithPresentAgent,
 } from "@/panels/agent-panel-load-state";
+import { appendDroppedFilePathText } from "@/file-drops/file-drop-paths";
 import { usePaneContext, usePaneFocus } from "@/panels/pane-context";
 import type { PanelDescriptor, PanelRegistration } from "@/panels/panel-registry";
 import { RenderProfile } from "@/utils/render-profiler";
@@ -734,25 +730,18 @@ function ChatAgentContent({
   const handleGenericFilesDropped = useCallback(
     async (items: DroppedItem[]) => {
       if (!client || !isConnected) return;
-      const nonImageItems = items.filter((item) => {
-        if (item.kind === "web-file") return !isRasterImageFile(item.file);
-        return !isRasterImagePath(item.path);
-      });
+      const nonImageItems = items.filter(
+        (item): item is Extract<DroppedItem, { kind: "web-file" }> =>
+          item.kind === "web-file" && !isRasterImageFile(item.file),
+      );
       if (nonImageItems.length === 0) return;
       try {
         const files = await Promise.all(
-          nonImageItems.map(async (item) => {
-            if (item.kind === "web-file") {
-              return {
-                fileName: item.file.name,
-                mimeType: item.file.type || getMimeTypeFromPath(item.file.name),
-                bytes: new Uint8Array(await item.file.arrayBuffer()),
-              };
-            }
-            const fileName = item.path.split("/").pop() ?? item.path.split("\\").pop() ?? item.path;
-            const bytes = await readDesktopFileBytes(item.path);
-            return { fileName, mimeType: getMimeTypeFromPath(item.path), bytes };
-          }),
+          nonImageItems.map(async (item) => ({
+            fileName: item.file.name,
+            mimeType: item.file.type || getMimeTypeFromPath(item.file.name),
+            bytes: new Uint8Array(await item.file.arrayBuffer()),
+          })),
         );
         const uploaded = await uploadFileAttachments({ client, files });
         addFilesRef.current?.(uploaded);
@@ -1210,6 +1199,17 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
     }),
     [text, setText, attachments, setAttachments, clear, isHydrated, composerState],
   );
+  const handleTextDropped = useCallback(
+    (droppedText: string) => {
+      setText(
+        appendDroppedFilePathText({
+          currentText: text,
+          droppedText,
+        }),
+      );
+    },
+    [setText, text],
+  );
   const streamSection = (
     <RenderProfile id={`AgentStreamSection:${agentId}`}>
       <AgentStreamSection
@@ -1255,6 +1255,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
         <FileDropZone
           onFilesDropped={handleFilesDropped}
           onGenericFilesDropped={handleGenericFilesDropped}
+          onTextDropped={handleTextDropped}
           disabled={isArchivingCurrentAgent}
         >
           <View style={styles.container}>

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -13,6 +13,7 @@ import { Composer } from "@/composer";
 import { DraftAgentModeControl } from "@/composer/agent-controls/mode-control";
 import { splitComposerAttachmentsForSubmit } from "@/composer/attachments/submit";
 import { FileDropZone } from "@/components/file-drop-zone";
+import { appendDroppedFilePathText } from "@/file-drops/file-drop-paths";
 import { ProjectIconView } from "@/components/project-icon-view";
 import { Combobox, ComboboxItem } from "@/components/ui/combobox";
 import type { ComboboxOption as ComboboxOptionType } from "@/components/ui/combobox";
@@ -1281,7 +1282,7 @@ export function NewWorkspaceScreen({
   );
 
   const handleClearDraft = useCallback(() => {
-    // No-op: screen navigates away on success, text should stay for retry on error
+    // Success navigates away; failure keeps the text available for retry.
   }, []);
 
   const badgePressableStyle = useCallback(
@@ -1425,6 +1426,19 @@ export function NewWorkspaceScreen({
   const handleFilesDropped = useCallback((files: ImageAttachment[]) => {
     addImagesRef.current?.(files);
   }, []);
+  const chatDraftText = chatDraft.text;
+  const setChatDraftText = chatDraft.setText;
+  const handleTextDropped = useCallback(
+    (text: string) => {
+      setChatDraftText(
+        appendDroppedFilePathText({
+          currentText: chatDraftText,
+          droppedText: text,
+        }),
+      );
+    },
+    [chatDraftText, setChatDraftText],
+  );
 
   const renderPickerOption = useCallback(
     ({
@@ -1734,7 +1748,7 @@ export function NewWorkspaceScreen({
   const screenHeaderLeft = useMemo(() => <SidebarMenuToggle />, []);
 
   return (
-    <FileDropZone onFilesDropped={handleFilesDropped}>
+    <FileDropZone onFilesDropped={handleFilesDropped} onTextDropped={handleTextDropped}>
       <View style={styles.container}>
         <ScreenHeader left={screenHeaderLeft} borderless />
         <View style={contentStyle}>


### PR DESCRIPTION
## Summary
- Add file drop classification that keeps image drops as attachments and turns non-image file drops into absolute file path text
- Append dropped file path text into existing composer drafts across agent, workspace draft, and new workspace flows
- Add focused tests for image vs non-image path handling and text formatting

## Verification
- `npx vitest run packages/app/src/file-drops/file-drop-paths.test.ts --bail=1`
- `npm run lint -- packages/app/src/hooks/use-file-drop-zone.ts packages/app/src/components/file-drop-zone.tsx packages/app/src/panels/agent-panel.tsx packages/app/src/composer/draft/workspace-tab.tsx packages/app/src/screens/new-workspace-screen.tsx packages/app/src/file-drops/file-drop-paths.ts packages/app/src/file-drops/file-drop-paths.test.ts`
- `npm run build:app-deps`
- `npm run typecheck --workspace=@getpaseo/app`
- `npm run build:server`
- `git diff --check`