### PR TITLE
Fix Windows daemon status output

### DIFF
--- a/packages/cli/src/commands/daemon/runtime-toolchain.ts
+++ b/packages/cli/src/commands/daemon/runtime-toolchain.ts
@@ -28,12 +28,13 @@ async function resolveNodePathFromPidUnix(pid: number): Promise<NodePathFromPidR
 async function runProcessProbe(
   command: string,
   args: string[],
+  options?: { shell?: boolean },
 ): Promise<{
   resolved: string | null;
   error?: string;
 }> {
   try {
-    const { stdout } = await execCommand(command, args);
+    const { stdout } = await execCommand(command, args, { shell: options?.shell });
     const resolved = stdout.trim();
     return resolved
       ? { resolved }
@@ -52,7 +53,7 @@ async function resolveNodePathFromPidWindows(pid: number): Promise<NodePathFromP
   }> = [
     {
       label: "powershell-cim",
-      command: "powershell",
+      command: "powershell.exe",
       args: [
         "-NoProfile",
         "-Command",
@@ -61,7 +62,7 @@ async function resolveNodePathFromPidWindows(pid: number): Promise<NodePathFromP
     },
     {
       label: "powershell-process",
-      command: "powershell",
+      command: "powershell.exe",
       args: ["-NoProfile", "-Command", `(Get-Process -Id ${pid}).Path`],
     },
     {
@@ -85,7 +86,7 @@ async function resolveNodePathFromPidWindows(pid: number): Promise<NodePathFromP
       };
     }
     const probe = probes[index];
-    const result = await runProcessProbe(probe.command, probe.args);
+    const result = await runProcessProbe(probe.command, probe.args, { shell: false });
     if (result.resolved) {
       const resolved = probe.parseValue ? probe.parseValue(result.resolved) : result.resolved;
       if (resolved) return { nodePath: resolved };

--- a/packages/cli/tests/36-daemon-status-windows-process-lookup.test.ts
+++ b/packages/cli/tests/36-daemon-status-windows-process-lookup.test.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env npx tsx
+
+import assert from "node:assert";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAvailablePort } from "./helpers/network.ts";
+
+const CLI_ENTRY = join(import.meta.dirname, "..", "dist", "index.js");
+
+interface CommandResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runLocalPaseo(args: string[], env: NodeJS.ProcessEnv): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (exitCode) => {
+      resolve({ exitCode, stdout, stderr });
+    });
+  });
+}
+
+if (process.platform !== "win32") {
+  console.log("Skipping Windows daemon status process lookup regression on non-Windows.");
+  process.exit(0);
+}
+
+console.log("=== Windows Daemon Status Process Lookup ===\n");
+
+const paseoHome = await mkdtemp(join(tmpdir(), "paseo-windows-status-home-"));
+const port = await getAvailablePort();
+const env = {
+  PASEO_HOME: paseoHome,
+  PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD: "0",
+  PASEO_DICTATION_ENABLED: "0",
+  PASEO_VOICE_MODE_ENABLED: "0",
+};
+
+try {
+  const start = await runLocalPaseo(["daemon", "restart", "--port", String(port)], env);
+  assert.strictEqual(
+    start.exitCode,
+    0,
+    `daemon restart should succeed:\nstdout:\n${start.stdout}\nstderr:\n${start.stderr}`,
+  );
+
+  const statusResult = await runLocalPaseo(
+    ["daemon", "status", "--home", paseoHome, "--json"],
+    env,
+  );
+  assert.strictEqual(
+    statusResult.exitCode,
+    0,
+    `daemon status should succeed:\nstdout:\n${statusResult.stdout}\nstderr:\n${statusResult.stderr}`,
+  );
+
+  const status = JSON.parse(statusResult.stdout) as {
+    localDaemon?: string;
+    daemonNode?: string;
+  };
+  assert.strictEqual(status.localDaemon, "running", "daemon should be running");
+  assert(status.daemonNode, "daemon status should include daemonNode");
+  assert(
+    !status.daemonNode.startsWith("unknown ("),
+    `daemonNode should resolve cleanly, got: ${status.daemonNode}`,
+  );
+  assert(
+    !status.daemonNode.includes("Get-Process") &&
+      !status.daemonNode.includes("Get-CimInstance") &&
+      !status.daemonNode.includes("wmic failed"),
+    `daemonNode should not contain process probe failures, got: ${status.daemonNode}`,
+  );
+  console.log("✓ daemon status resolves daemonNode on Windows\n");
+} finally {
+  await runLocalPaseo(["daemon", "stop", "--home", paseoHome, "--force"], env);
+  await rm(paseoHome, { recursive: true, force: true });
+}
+
+console.log("=== Windows daemon status process lookup passed ===");

--- a/packages/desktop/scripts/smoke-packaged-desktop-app.js
+++ b/packages/desktop/scripts/smoke-packaged-desktop-app.js
@@ -367,7 +367,7 @@ async function smokeCliShim({ appPath, env }) {
     args: ["daemon", "status"],
     label: "Bundled CLI shim daemon status",
   });
-  assertCleanDaemonStatusOutput(result.stdout);
+  assertCleanDaemonStatusOutput(`${result.stdout}\n${result.stderr}`);
 }
 
 function assertCleanDaemonStatusOutput(output) {

--- a/packages/desktop/scripts/smoke-packaged-desktop-app.js
+++ b/packages/desktop/scripts/smoke-packaged-desktop-app.js
@@ -361,12 +361,26 @@ async function runCliShimJsonCommand({ appPath, env, args, label }) {
 
 async function smokeCliShim({ appPath, env }) {
   console.log("Packaged desktop smoke: running bundled CLI shim daemon status");
-  await runCliShimCommand({
+  const result = await runCliShimCommand({
     appPath,
     env,
     args: ["daemon", "status"],
     label: "Bundled CLI shim daemon status",
   });
+  assertCleanDaemonStatusOutput(result.stdout);
+}
+
+function assertCleanDaemonStatusOutput(output) {
+  const failureNeedles = [
+    "Get-CimInstance",
+    "Get-Process :",
+    "Cannot bind parameter",
+    "wmic failed",
+  ];
+  const failure = failureNeedles.find((needle) => output.includes(needle));
+  if (failure) {
+    throw new Error(`Bundled CLI shim daemon status included process lookup failure: ${failure}`);
+  }
 }
 
 async function smokeCliTerminal({ appPath, env }) {


### PR DESCRIPTION
### Linked issue

Closes #1476

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fixes Windows daemon status so the daemon executable lookup no longer prints PowerShell syntax errors in the status output.

The Windows status probe now invokes `powershell.exe` directly with shell execution disabled, so `cmd.exe` does not inject caret escapes into the PowerShell expression. The packaged desktop smoke also fails if `daemon status` includes the PowerShell/WMIC lookup failure text instead of silently accepting exit code 0.

### How did you verify it

- Reproduced the failure on the Windows probe box: the old shell-routed command passed literal `^` characters into PowerShell and failed to parse the PID.
- Verified the fixed Windows command shape on the Windows probe box: `powershell.exe` with `shell: false` resolved the process path cleanly.
- Ran `npm run format`.
- Ran `npm run lint -- packages/cli/src/commands/daemon/runtime-toolchain.ts packages/desktop/scripts/smoke-packaged-desktop-app.js packages/cli/tests/36-daemon-status-windows-process-lookup.test.ts`.
- Ran `npm run typecheck --workspace=@getpaseo/cli`.
- Ran `npx tsx packages/cli/tests/36-daemon-status-windows-process-lookup.test.ts` on macOS and confirmed it skips outside Windows.
- Pre-commit hook also ran repository `lint`, `format:check`, and `typecheck` successfully.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
