### PR TITLE
feat(server): add STT language config for OpenAI speech provider

### DIFF
--- a/packages/server/src/server/speech/providers/openai/config.test.ts
+++ b/packages/server/src/server/speech/providers/openai/config.test.ts
@@ -157,4 +157,53 @@ describe("resolveOpenAiSpeechConfig", () => {
     expect(resolved?.apiKey).toBe("env-key");
     expect(resolved?.baseUrl).toBe("https://env.example.com/v1");
   });
+
+  test("language is undefined when no language config is set", () => {
+    const persisted = PersistedConfigSchema.parse({
+      providers: { openai: { apiKey: "sk-test" } },
+    });
+
+    const resolved = resolveOpenAiSpeechConfig({
+      env: {},
+      persisted,
+      providers: {
+        dictationStt: { provider: "openai", explicit: true },
+        voiceStt: { provider: "openai", explicit: true },
+        voiceTts: { provider: "local", explicit: false },
+      },
+    });
+
+    expect(resolved?.stt?.language).toBeUndefined();
+  });
+
+  test("reads stt language from config or env, env wins", () => {
+    const persisted = PersistedConfigSchema.parse({
+      providers: { openai: { apiKey: "sk-test" } },
+      features: {
+        voiceMode: { stt: { provider: "openai", language: "ja" } },
+      },
+    });
+
+    const withoutEnv = resolveOpenAiSpeechConfig({
+      env: {},
+      persisted,
+      providers: {
+        dictationStt: { provider: "local", explicit: false },
+        voiceStt: { provider: "openai", explicit: true },
+        voiceTts: { provider: "local", explicit: false },
+      },
+    });
+    expect(withoutEnv?.stt?.language).toBe("ja");
+
+    const withEnv = resolveOpenAiSpeechConfig({
+      env: { STT_LANGUAGE: "zh" },
+      persisted,
+      providers: {
+        dictationStt: { provider: "local", explicit: false },
+        voiceStt: { provider: "openai", explicit: true },
+        voiceTts: { provider: "local", explicit: false },
+      },
+    });
+    expect(withEnv?.stt?.language).toBe("zh");
+  });
 });

--- a/packages/server/src/server/speech/providers/openai/config.ts
+++ b/packages/server/src/server/speech/providers/openai/config.ts
@@ -35,6 +35,7 @@ const OpenAiSpeechResolutionSchema = z.object({
   baseUrl: OptionalTrimmedStringSchema,
   sttConfidenceThreshold: OptionalFiniteNumberSchema,
   sttModel: OptionalTrimmedStringSchema,
+  sttLanguage: OptionalTrimmedStringSchema,
   ttsVoice: z.string().trim().toLowerCase().pipe(OpenAiTtsVoiceSchema).default("alloy"),
   ttsModel: z
     .string()
@@ -79,6 +80,11 @@ function buildOpenAiSttInput(params: {
       env.STT_MODEL,
       pickIfOpenAi(providers.voiceStt, persisted.features?.voiceMode?.stt?.model),
       pickIfOpenAi(providers.dictationStt, persisted.features?.dictation?.stt?.model),
+    ]),
+    sttLanguage: firstDefined<string>([
+      env.STT_LANGUAGE,
+      pickIfOpenAi(providers.voiceStt, persisted.features?.voiceMode?.stt?.language),
+      pickIfOpenAi(providers.dictationStt, persisted.features?.dictation?.stt?.language),
     ]),
   };
 }
@@ -147,6 +153,7 @@ export function resolveOpenAiSpeechConfig(params: {
         ? { confidenceThreshold: parsed.sttConfidenceThreshold }
         : {}),
       ...(parsed.sttModel ? { model: parsed.sttModel } : {}),
+      ...(parsed.sttLanguage ? { language: parsed.sttLanguage } : {}),
     },
     tts: {
       apiKey: parsed.apiKey,

--- a/packages/server/src/server/speech/providers/openai/stt.ts
+++ b/packages/server/src/server/speech/providers/openai/stt.ts
@@ -19,6 +19,7 @@ export interface STTConfig {
   apiKey: string;
   baseUrl?: string;
   model?: "whisper-1" | "gpt-4o-transcribe" | "gpt-4o-mini-transcribe" | (string & {});
+  language?: string;
   confidenceThreshold?: number; // Default: -3.0
 }
 
@@ -76,6 +77,7 @@ export class OpenAISTT implements SpeechToTextProvider {
     let previousSegmentId: string | null = null;
     let pcm16: Buffer = Buffer.alloc(0);
     const transcribeAudio = this.transcribeAudioInternal.bind(this);
+    const sttLanguage = params.language ?? this.config.language;
 
     const convertPCMToWavBuffer = (pcmBuffer: Buffer): Buffer => {
       const headerSize = 44;
@@ -143,7 +145,7 @@ export class OpenAISTT implements SpeechToTextProvider {
             const result = await transcribeAudio(
               wav,
               "audio/wav",
-              params.language ?? "en",
+              sttLanguage,
               logger,
               params.prompt,
             );
@@ -184,7 +186,7 @@ export class OpenAISTT implements SpeechToTextProvider {
   private async transcribeAudioInternal(
     audioBuffer: Buffer,
     format: string,
-    language: string,
+    language: string | undefined,
     logger: pino.Logger,
     prompt?: string,
   ): Promise<TranscriptionResult> {
@@ -205,8 +207,8 @@ export class OpenAISTT implements SpeechToTextProvider {
 
       const response = await this.openaiClient.audio.transcriptions.create({
         file: await import("fs").then((fs) => fs.createReadStream(tempFilePath!)),
-        language,
         model: modelToUse,
+        ...(language ? { language } : {}),
         ...(prompt ? { prompt } : {}),
         ...(supportsLogprobs ? { include: includeLogprobs } : {}),
         response_format: "json",


### PR DESCRIPTION
## Summary

Adds optional STT language configuration to the **OpenAI** speech provider, mirroring the same feature already available for the local provider (PR #941).

The language can be set via:
- `STT_LANGUAGE` environment variable
- `features.voiceMode.stt.language` in settings.json
- `features.dictation.stt.language` in settings.json

When unset, no `language` parameter is sent to the API — letting the server auto-detect the spoken language. This fixes a pain point where the OpenAI provider hardcoded `"en"`, breaking Chinese (and other non-English) transcription for users running local OpenAI-compatible servers like FunASR.

## Changes

- `config.ts`: Added `sttLanguage` to the resolution schema, build input, and resolved config output; reads from env → voiceMode → dictation (same precedence as `sttModel`)
- `stt.ts`: Added `language` to `STTConfig`; uses config value as fallback instead of hardcoded `"en"`; `language` is only passed to the API when explicitly set
- `config.test.ts`: 2 new test cases — default undefined, and config/env resolution with precedence

## Test plan
- [x] `npx vitest run packages/server/src/server/speech/providers/openai/` — 12/12 passed
- [x] `oxlint` — 0 warnings, 0 errors
- [x] `oxfmt` — all files correctly formatted
- [x] Server typecheck passes