### PR TITLE
fix(agent-hooks): stop POSIX hook guard from leaking exit 1

### DIFF
--- a/packages/server/src/terminal/agent-hooks/agent-hook-installer.ts
+++ b/packages/server/src/terminal/agent-hooks/agent-hook-installer.ts
@@ -138,7 +138,7 @@ export function buildAgentHookShellCommand<TConfig>(
   event: AgentHookEventDefinition,
 ): string {
   const hookCommand = `"\${PASEO_HOOK_CLI:-paseo}" hooks ${shellToken(provider.id)} ${shellToken(event.event)}`;
-  return `[ -n "$PASEO_TERMINAL_ID" ] && ${hookCommand}`;
+  return `[ -z "$PASEO_TERMINAL_ID" ] || ${hookCommand}`;
 }
 
 export function buildAgentHookWindowsCommand<TConfig>(

--- a/packages/server/src/terminal/agent-hooks/claude/claude.test.ts
+++ b/packages/server/src/terminal/agent-hooks/claude/claude.test.ts
@@ -81,7 +81,7 @@ describe("Claude terminal agent hooks", () => {
       );
       expect(paseoCommands).toHaveLength(1);
       expect(paseoCommands[0]).toBe(
-        `[ -n "$PASEO_TERMINAL_ID" ] && "\${PASEO_HOOK_CLI:-paseo}" hooks ${provider.id} ${event.event}`,
+        `[ -z "$PASEO_TERMINAL_ID" ] || "\${PASEO_HOOK_CLI:-paseo}" hooks ${provider.id} ${event.event}`,
       );
     }
     expect(registeredAgentHooksAreInstalled({ configDir })).toBe(true);
@@ -146,7 +146,7 @@ describe("Claude terminal agent hooks", () => {
     const command = buildAgentHookShellCommand(provider, provider.events[0]);
 
     expect(command).toBe(
-      '[ -n "$PASEO_TERMINAL_ID" ] && "${PASEO_HOOK_CLI:-paseo}" hooks claude UserPromptSubmit',
+      '[ -z "$PASEO_TERMINAL_ID" ] || "${PASEO_HOOK_CLI:-paseo}" hooks claude UserPromptSubmit',
     );
   });
 

--- a/packages/server/src/terminal/agent-hooks/codex/codex.test.ts
+++ b/packages/server/src/terminal/agent-hooks/codex/codex.test.ts
@@ -68,7 +68,7 @@ describe("Codex terminal agent hooks", () => {
     for (const event of codexAgentHookProvider.events) {
       expect(commandHooks(config, event.event)).toEqual([
         {
-          command: `[ -n "$PASEO_TERMINAL_ID" ] && "\${PASEO_HOOK_CLI:-paseo}" hooks codex ${event.event}`,
+          command: `[ -z "$PASEO_TERMINAL_ID" ] || "\${PASEO_HOOK_CLI:-paseo}" hooks codex ${event.event}`,
           commandWindows: `if defined PASEO_TERMINAL_ID (if defined PASEO_HOOK_CLI ("%PASEO_HOOK_CLI%" hooks codex ${event.event}) else (paseo hooks codex ${event.event}))`,
         },
       ]);
@@ -102,7 +102,7 @@ describe("Codex terminal agent hooks", () => {
     const stopCommands = commandHooks(readHooksFile(configDir), "Stop").map((hook) => hook.command);
     expect(stopCommands).toEqual([
       "say codex done",
-      '[ -n "$PASEO_TERMINAL_ID" ] && "${PASEO_HOOK_CLI:-paseo}" hooks codex Stop',
+      '[ -z "$PASEO_TERMINAL_ID" ] || "${PASEO_HOOK_CLI:-paseo}" hooks codex Stop',
     ]);
   });
 


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
-->

### Linked issue

Closes #1666

<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->

### Type of change

- [X] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

`buildAgentHookShellCommand` emitted the POSIX hook command as:

    [ -n "$PASEO_TERMINAL_ID" ] && "${PASEO_HOOK_CLI:-paseo}" hooks <agent> <event>

When `PASEO_TERMINAL_ID` is unset (i.e. the terminal isn't being driven by paseo), the `[ -n "" ]` test itself returns exit 1 and the `&&` short-circuits, so the whole hook command exits 1. Agents treat any non-zero hook exit as a failure: Claude Code surfaces it on every prompt as

    UserPromptSubmit hook error
    Failed with non-blocking status code: No stderr output

and Codex reports the same for its events. It's noise — the hook is meant to be a no-op when paseo isn't attached.

Emit a guard that no-ops cleanly instead:

    [ -z "$PASEO_TERMINAL_ID" ] || "${PASEO_HOOK_CLI:-paseo}" hooks <agent> <event>

When the var is unset the guard is true and short-circuits with exit 0; when it is set, the hook runs and its real exit code is preserved. Same active behavior, no spurious failure when paseo isn't driving the terminal.

Affects both the claude and codex providers (both call buildAgentHookShellCommand). The Windows variant uses `if defined ... (...)`, which leaves errorlevel intact when the var is undefined, so it is unchanged.

Updates the four test assertions that pin the exact generated command string.

### How did you verify it

Tested locally

### Checklist

- [X] One focused change. Unrelated cleanups split out.
- [X] `npm run typecheck` passes
- [X] `npm run lint` passes
- [X] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [ ] Tests added or updated where it made sense
