### PR TITLE
Fix desktop file uploads with extensions

### DIFF
--- a/packages/app/src/attachments/file-types.test.ts
+++ b/packages/app/src/attachments/file-types.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe("attachment file types", () => {
   it("keeps SVG as a file while treating raster image files as images", () => {
-    expect(getMimeTypeFromPath("/tmp/logo.svg")).toBe("image/svg+xml");
+    expect(getMimeTypeFromPath("/tmp/logo.svg")).toBe("application/octet-stream");
     expect(isRasterImagePath("/tmp/logo.svg")).toBe(false);
     expect(isRasterImageMimeType("image/svg+xml")).toBe(false);
     expect(isRasterImageFile(new File(["<svg />"], "logo.svg", { type: "image/svg+xml" }))).toBe(
@@ -18,9 +18,18 @@ describe("attachment file types", () => {
     );
 
     expect(getRasterImageMimeTypeFromPath("/tmp/screenshot.PNG?cache=1")).toBe("image/png");
+    expect(getMimeTypeFromPath("/tmp/screenshot.PNG?cache=1")).toBe("image/png");
     expect(isRasterImagePath("/tmp/screenshot.PNG?cache=1")).toBe(true);
     expect(isRasterImageMimeType("image/png; charset=binary")).toBe(true);
     expect(isRasterImageFile(new File([new Uint8Array([0])], "screenshot.png"))).toBe(true);
+  });
+
+  it("does not require MIME table entries for generic file attachments", () => {
+    expect(getMimeTypeFromPath("/tmp/notes.md")).toBe("application/octet-stream");
+    expect(getMimeTypeFromPath("/tmp/archive.zip")).toBe("application/octet-stream");
+    expect(getMimeTypeFromPath("/tmp/report.docx")).toBe("application/octet-stream");
+    expect(getMimeTypeFromPath("/tmp/runtime.log")).toBe("application/octet-stream");
+    expect(getMimeTypeFromPath("/tmp/export.anything")).toBe("application/octet-stream");
   });
 
   it("does not offer SVG in the image picker extension list", () => {

--- a/packages/app/src/attachments/file-types.ts
+++ b/packages/app/src/attachments/file-types.ts
@@ -1,45 +1,3 @@
-const MIME_TYPE_BY_EXTENSION: Record<string, string> = {
-  ".png": "image/png",
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".gif": "image/gif",
-  ".webp": "image/webp",
-  ".bmp": "image/bmp",
-  ".svg": "image/svg+xml",
-  ".heic": "image/heic",
-  ".heif": "image/heif",
-  ".avif": "image/avif",
-  ".tif": "image/tiff",
-  ".tiff": "image/tiff",
-  ".pdf": "application/pdf",
-  ".txt": "text/plain",
-  ".md": "text/markdown",
-  ".json": "application/json",
-  ".js": "text/javascript",
-  ".ts": "text/typescript",
-  ".tsx": "text/typescript-jsx",
-  ".jsx": "text/javascript",
-  ".html": "text/html",
-  ".css": "text/css",
-  ".xml": "text/xml",
-  ".csv": "text/csv",
-  ".zip": "application/zip",
-  ".gz": "application/gzip",
-  ".tar": "application/x-tar",
-  ".mp3": "audio/mpeg",
-  ".mp4": "video/mp4",
-  ".mov": "video/quicktime",
-  ".webm": "video/webm",
-  ".wav": "audio/wav",
-  ".ogg": "audio/ogg",
-  ".doc": "application/msword",
-  ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  ".xls": "application/vnd.ms-excel",
-  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-  ".ppt": "application/vnd.ms-powerpoint",
-  ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-};
-
 const RASTER_IMAGE_MIME_TYPE_BY_EXTENSION: Record<string, string> = {
   ".png": "image/png",
   ".jpg": "image/jpeg",
@@ -55,6 +13,7 @@ const RASTER_IMAGE_MIME_TYPE_BY_EXTENSION: Record<string, string> = {
 };
 
 const RASTER_IMAGE_MIME_TYPES = new Set(Object.values(RASTER_IMAGE_MIME_TYPE_BY_EXTENSION));
+const GENERIC_FILE_MIME_TYPE = "application/octet-stream";
 
 export const RASTER_IMAGE_FILE_EXTENSIONS = Object.keys(RASTER_IMAGE_MIME_TYPE_BY_EXTENSION).map(
   (extension) => extension.slice(1),
@@ -75,7 +34,7 @@ export function getFileTypeLabel(path: string): string | null {
 }
 
 export function getMimeTypeFromPath(path: string): string {
-  return MIME_TYPE_BY_EXTENSION[getFileExtension(path)] ?? "application/octet-stream";
+  return getRasterImageMimeTypeFromPath(path) ?? GENERIC_FILE_MIME_TYPE;
 }
 
 export function getRasterImageMimeTypeFromPath(path: string): string | null {

--- a/packages/app/src/hooks/use-file-picker.ts
+++ b/packages/app/src/hooks/use-file-picker.ts
@@ -26,7 +26,7 @@ export async function readDesktopFileBytes(path: string): Promise<Uint8Array> {
   const { path: managedPath } = await copyDesktopAttachmentFile({
     attachmentId: crypto.randomUUID(),
     sourcePath: path,
-    extension: getFileExtension(path).slice(1) || null,
+    extension: getFileExtension(path) || null,
   });
   const base64 = await readDesktopFileBase64(managedPath);
   return base64ToUint8Array(base64);
@@ -63,7 +63,7 @@ async function pickFilesWithDesktopDialog(): Promise<PickedFile[] | null> {
     const { path: managedPath } = await copyDesktopAttachmentFile({
       attachmentId: crypto.randomUUID(),
       sourcePath: filePath,
-      extension: getFileExtension(filePath).slice(1) || null,
+      extension: getFileExtension(filePath) || null,
     });
 
     const base64 = await readDesktopFileBase64(managedPath);

--- a/packages/desktop/src/features/attachments.test.ts
+++ b/packages/desktop/src/features/attachments.test.ts
@@ -1,0 +1,47 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { copyAttachmentFileToManagedStorage } from "./attachments";
+
+const originalPaseoHome = process.env.PASEO_HOME;
+let testHome: string | null = null;
+
+async function useTempPaseoHome(): Promise<string> {
+  testHome = await mkdtemp(path.join(os.tmpdir(), "paseo-desktop-attachments-"));
+  process.env.PASEO_HOME = testHome;
+  return testHome;
+}
+
+describe("desktop attachment files", () => {
+  afterEach(async () => {
+    if (originalPaseoHome === undefined) {
+      delete process.env.PASEO_HOME;
+    } else {
+      process.env.PASEO_HOME = originalPaseoHome;
+    }
+
+    if (testHome) {
+      await rm(testHome, { recursive: true, force: true });
+      testHome = null;
+    }
+  });
+
+  it("accepts picker-style bare extensions for managed copies", async () => {
+    const paseoHome = await useTempPaseoHome();
+    const sourcePath = path.join(paseoHome, "report.md");
+    await writeFile(sourcePath, "# Report\n");
+
+    const result = await copyAttachmentFileToManagedStorage({
+      attachmentId: "att_markdown",
+      sourcePath,
+      extension: "md",
+    });
+
+    expect(result).toEqual({
+      path: path.join(paseoHome, "desktop-attachments", "att_markdown.md"),
+      byteSize: 9,
+    });
+    await expect(readFile(result.path, "utf8")).resolves.toBe("# Report\n");
+  });
+});

--- a/packages/desktop/src/features/attachments.test.ts
+++ b/packages/desktop/src/features/attachments.test.ts
@@ -27,7 +27,7 @@ describe("desktop attachment files", () => {
     }
   });
 
-  it("accepts picker-style bare extensions for managed copies", async () => {
+  it("accepts dot-prefixed picker extensions for managed copies", async () => {
     const paseoHome = await useTempPaseoHome();
     const sourcePath = path.join(paseoHome, "report.md");
     await writeFile(sourcePath, "# Report\n");
@@ -35,11 +35,29 @@ describe("desktop attachment files", () => {
     const result = await copyAttachmentFileToManagedStorage({
       attachmentId: "att_markdown",
       sourcePath,
-      extension: "md",
+      extension: ".md",
     });
 
     expect(result).toEqual({
       path: path.join(paseoHome, "desktop-attachments", "att_markdown.md"),
+      byteSize: 9,
+    });
+    await expect(readFile(result.path, "utf8")).resolves.toBe("# Report\n");
+  });
+
+  it("normalizes legacy bare extensions for managed copies", async () => {
+    const paseoHome = await useTempPaseoHome();
+    const sourcePath = path.join(paseoHome, "report.md");
+    await writeFile(sourcePath, "# Report\n");
+
+    const result = await copyAttachmentFileToManagedStorage({
+      attachmentId: "att_markdown_legacy",
+      sourcePath,
+      extension: "md",
+    });
+
+    expect(result).toEqual({
+      path: path.join(paseoHome, "desktop-attachments", "att_markdown_legacy.md"),
       byteSize: 9,
     });
     await expect(readFile(result.path, "utf8")).resolves.toBe("# Report\n");

--- a/packages/desktop/src/features/attachments.ts
+++ b/packages/desktop/src/features/attachments.ts
@@ -40,10 +40,11 @@ function normalizeExtension(value: unknown): string {
     throw new Error("Attachment extension must be a string.");
   }
   const normalized = value.trim().toLowerCase();
-  if (!EXTENSION_PATTERN.test(normalized)) {
+  const extension = normalized.startsWith(".") ? normalized : `.${normalized}`;
+  if (!EXTENSION_PATTERN.test(extension)) {
     throw new Error(`Invalid attachment extension: ${value}`);
   }
-  return normalized;
+  return extension;
 }
 
 async function buildManagedAttachmentPath(input: {


### PR DESCRIPTION
### Linked issue

Closes #1547
Closes #1630

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Desktop file uploads now work when the selected file has an extension such as `.md`, `.zip`, `.docx`, `.log`, or `.txt`.

The generic file picker was copying selected files through desktop-managed storage before upload, but it sent extensions without the leading dot. The desktop command rejected values like `md` before the file reached the upload path. This keeps the picker on the dot-prefixed shape and makes the desktop command normalize bare alphanumeric extensions defensively.

It also removes the hand-maintained non-image MIME table from the app upload path. Raster images are still identified as images; everything else without a platform-provided MIME type is uploaded as a generic file with `application/octet-stream`.

### How did you verify it

- Added a regression test that failed before the fix with `Invalid attachment extension: md`, then passed after the fix: `npx vitest run packages/desktop/src/features/attachments.test.ts --bail=1`
- Added coverage that generic file attachments do not need per-extension MIME table entries: `npx vitest run packages/app/src/attachments/file-types.test.ts --bail=1`
- `npm run format`
- `npm run typecheck`
- `npm run lint`

### Risk surface

This touches the Electron generic file-upload staging path, the desktop attachment IPC validator, and app-side MIME inference for path-only uploads. It does not change mobile, web IndexedDB attachments, or the daemon upload protocol. I did not run a manual Electron picker smoke test in the desktop app; the regression covers the rejected IPC payload from the report.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A: no UI rendering change)
- [x] Tests added or updated where it made sense