### PR TITLE
Fix stale Ask Question permission responses

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -5714,6 +5714,76 @@ test("respondToPermission emits refreshed state before permission_resolved", asy
   expect(resolvedIndex).toBeGreaterThan(refreshedStateIndex);
 });
 
+test("respondToPermission resolves stale permission cards when provider request is already gone", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-stale-permission-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  class StalePermissionSession extends TestAgentSession {
+    override async respondToPermission(requestId: string): Promise<void> {
+      throw new Error(`No pending permission request with id '${requestId}'`);
+    }
+  }
+
+  class StalePermissionClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new StalePermissionSession(config);
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: {
+      codex: new StalePermissionClient(),
+    },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000135",
+  });
+
+  const snapshot = await manager.createAgent({
+    provider: "codex",
+    cwd: workdir,
+  });
+  const agent = manager.getAgent(snapshot.id);
+  if (!agent) {
+    throw new Error("Expected managed agent");
+  }
+  agent.pendingPermissions.set("stale-question-1", {
+    id: "stale-question-1",
+    provider: "codex",
+    name: "request_user_input",
+    kind: "question",
+    title: "Question",
+    input: {
+      questions: [{ id: "q1", header: "Q1", question: "Pick one?", options: [] }],
+    },
+  });
+
+  const seen: string[] = [];
+  manager.subscribe(
+    (event) => {
+      if (event.type === "agent_state") {
+        seen.push(`state:${event.agent.id}`);
+        return;
+      }
+      if (event.type === "agent_stream" && event.event.type === "permission_resolved") {
+        seen.push(`resolved:${event.event.requestId}:${event.event.resolution.behavior}`);
+      }
+    },
+    { agentId: snapshot.id, replayState: false },
+  );
+
+  await expect(
+    manager.respondToPermission(snapshot.id, "stale-question-1", {
+      behavior: "deny",
+      message: "Dismissed by user",
+    }),
+  ).resolves.toBeUndefined();
+
+  expect(manager.getAgent(snapshot.id)?.pendingPermissions.size).toBe(0);
+  expect(seen).toEqual([`state:${snapshot.id}`, "resolved:stale-question-1:deny"]);
+});
+
 test("close during in-flight stream does not clear persistence sessionId", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -418,6 +418,10 @@ function createAbortError(signal: AbortSignal | undefined, fallbackMessage: stri
   return Object.assign(new Error(message), { name: "AbortError" });
 }
 
+function isNoPendingPermissionError(error: unknown): boolean {
+  return error instanceof Error && /No pending permission request/i.test(error.message);
+}
+
 function validateAgentId(agentId: string, source: string): string {
   const result = AgentIdSchema.safeParse(agentId);
   if (!result.success) {
@@ -1993,10 +1997,24 @@ export class AgentManager {
     response: AgentPermissionResponse,
   ): Promise<AgentPermissionResult | void> {
     const agent = this.requireAgent(agentId);
+    if (!agent.pendingPermissions.has(requestId)) {
+      await this.resolveStalePermissionResponse(agent, requestId, response);
+      return undefined;
+    }
+
     agent.inFlightPermissionResponses.add(requestId);
 
     try {
-      const result = await agent.session.respondToPermission(requestId, response);
+      let result: AgentPermissionResult | void;
+      try {
+        result = await agent.session.respondToPermission(requestId, response);
+      } catch (error) {
+        if (isNoPendingPermissionError(error)) {
+          await this.resolveStalePermissionResponse(agent, requestId, response);
+          return undefined;
+        }
+        throw error;
+      }
       agent.pendingPermissions.delete(requestId);
 
       try {
@@ -2020,6 +2038,32 @@ export class AgentManager {
       agent.inFlightPermissionResponses.delete(requestId);
       agent.bufferedPermissionResolutions.delete(requestId);
     }
+  }
+
+  private async resolveStalePermissionResponse(
+    agent: ActiveManagedAgent,
+    requestId: string,
+    response: AgentPermissionResponse,
+  ): Promise<void> {
+    const hadPending = agent.pendingPermissions.delete(requestId);
+    agent.bufferedPermissionResolutions.delete(requestId);
+
+    if (hadPending) {
+      this.touchUpdatedAt(agent);
+      await this.persistSnapshot(agent);
+      this.emitState(agent);
+    }
+
+    this.dispatchStream(
+      agent.id,
+      {
+        type: "permission_resolved",
+        provider: agent.provider,
+        requestId,
+        resolution: response,
+      },
+      { timestamp: new Date().toISOString() },
+    );
   }
 
   async cancelAgentRun(agentId: string): Promise<boolean> {


### PR DESCRIPTION
### Linked issue

Closes #1742

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

`AgentManager.respondToPermission` assumed that if a pending Ask Question
permission existed in `pendingPermissions`, the underlying provider session
still had it too. When the request had already been resolved on the
provider side (e.g. the user answered the same request through the
terminal or directly via the agent), the provider would throw
`No pending permission request with id '<id>'`, the error would bubble out
of `respondToPermission`, and no `permission_resolved` stream event was
ever dispatched. The desktop Ask Question card then stayed in its loading
state forever.

This change makes `respondToPermission` idempotent for that case:

- If the manager itself has no `pendingPermissions` entry for the request
  anymore, treat it as a stale response, dispatch `permission_resolved`,
  and return without calling the provider.
- If the provider call throws with the `No pending permission request`
  shape, treat it the same way: clear the pending entry (if any),
  re-emit state, and dispatch `permission_resolved` so the UI can release
  the card.

No other code paths are changed.

### How did you verify it

- `./node_modules/.bin/vitest run packages/server/src/server/agent/agent-manager.test.ts` — 117/117 pass, including a new regression test (`respondToPermission resolves stale permission cards when provider request is already gone`) that fails on `main` and passes with this change.
- `npm run typecheck` — passes (via the lefthook `pre-commit` hook).
- `npm run lint` and `npm run format:check:files` on the two changed files — clean.
- `git diff --check` — clean.

I have **not** independently reproduced the original symptom end-to-end in a fresh desktop build; verification of the fix in this PR is at the daemon / `AgentManager` layer via the regression test. If you'd like me to attach a desktop video of the before/after, I'm happy to set that up — let me know which path you'd prefer to reproduce against (e.g. answering a Codex `request_user_input` in the terminal vs. in the Paseo card).

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (oxfmt — no changes needed)
- [ ] UI changes include screenshots or video for every affected platform _(server-only change, no UI diff; see note above re: desktop video)_
- [x] Tests added or updated where it made sense
