### PR TITLE
Fix settings host sections showing "host not found" when the local daemon is stopped

### DIFF
--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -55,7 +55,11 @@ import {
 } from "@/hooks/use-settings";
 import { useHostRuntimeIsConnected, useHosts } from "@/runtime/host-runtime";
 import { useSessionStore } from "@/stores/session-store";
-import { orderHostsLocalFirst, type HostProfile } from "@/types/host-connection";
+import {
+  orderHostsLocalFirst,
+  resolveActiveHostServerId,
+  type HostProfile,
+} from "@/types/host-connection";
 import { TitlebarDragRegion } from "@/components/desktop/titlebar-drag-region";
 import { WindowChromeRegion, WindowChromeSafeArea } from "@/utils/desktop-window";
 import { confirmDialog } from "@/utils/confirm-dialog";
@@ -1143,15 +1147,6 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const [selectedSettingsHostServerId, setSelectedSettingsHostServerId] = useState<string | null>(
     view.kind === "host" ? view.serverId : null,
   );
-  const knownSelectedSettingsHostServerId = useMemo(() => {
-    if (!selectedSettingsHostServerId) {
-      return null;
-    }
-    return hosts.some((host) => host.serverId === selectedSettingsHostServerId)
-      ? selectedSettingsHostServerId
-      : null;
-  }, [hosts, selectedSettingsHostServerId]);
-
   useEffect(() => {
     if (view.kind === "host") {
       setSelectedSettingsHostServerId(view.serverId);
@@ -1159,11 +1154,16 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   }, [view]);
 
   // The host the four sections scope to: the host on the active view, otherwise
-  // the picker choice, otherwise the local daemon, otherwise the first host.
+  // the picker choice, otherwise the connected local daemon, otherwise the first host.
   const activeHostServerId = useMemo(() => {
     if (view.kind === "host") return view.serverId;
-    return knownSelectedSettingsHostServerId ?? localServerId ?? sortedHosts[0]?.serverId ?? null;
-  }, [view, knownSelectedSettingsHostServerId, localServerId, sortedHosts]);
+    return resolveActiveHostServerId({
+      selectedServerId: selectedSettingsHostServerId,
+      localServerId,
+      hosts,
+      orderedHosts: sortedHosts,
+    });
+  }, [view, selectedSettingsHostServerId, localServerId, hosts, sortedHosts]);
 
   const handleSendBehaviorChange = useCallback(
     (behavior: SendBehavior) => {

--- a/packages/app/src/types/host-connection.test.ts
+++ b/packages/app/src/types/host-connection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   normalizeStoredHostProfile,
   orderHostsLocalFirst,
+  resolveActiveHostServerId,
   type HostProfile,
 } from "./host-connection";
 
@@ -112,5 +113,77 @@ describe("normalizeStoredHostProfile", () => {
       useTls: true,
       daemonPublicKeyB64: "pubkey",
     });
+  });
+});
+
+describe("resolveActiveHostServerId", () => {
+  it("uses the selected host when one is set", () => {
+    expect(
+      resolveActiveHostServerId({
+        selectedServerId: "srv_selected",
+        localServerId: "srv_local",
+        hosts: [makeHost("srv_local"), makeHost("srv_selected")],
+        orderedHosts: [makeHost("srv_local"), makeHost("srv_selected")],
+      }),
+    ).toBe("srv_selected");
+  });
+
+  it("falls back to the local host when it is connected", () => {
+    expect(
+      resolveActiveHostServerId({
+        selectedServerId: null,
+        localServerId: "srv_local",
+        hosts: [makeHost("srv_local"), makeHost("srv_remote")],
+        orderedHosts: [makeHost("srv_local"), makeHost("srv_remote")],
+      }),
+    ).toBe("srv_local");
+  });
+
+  it("skips a stopped local daemon and uses the first connected host", () => {
+    // Regression: a stopped local daemon's serverId persists but isn't in `hosts`.
+    // Falling back to it would resolve the section to an unknown id ("host not found").
+    expect(
+      resolveActiveHostServerId({
+        selectedServerId: null,
+        localServerId: "srv_local_stopped",
+        hosts: [makeHost("srv_remote")],
+        orderedHosts: [makeHost("srv_remote")],
+      }),
+    ).toBe("srv_remote");
+  });
+
+  it("returns null when no hosts are connected", () => {
+    expect(
+      resolveActiveHostServerId({
+        selectedServerId: null,
+        localServerId: "srv_local_stopped",
+        hosts: [],
+        orderedHosts: [],
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores a selected host that is not connected", () => {
+    // A stale selection (e.g. the host was removed) must not be used unless it is
+    // currently connected, or the section resolves to an unknown id ("host not found").
+    expect(
+      resolveActiveHostServerId({
+        selectedServerId: "srv_stale_selection",
+        localServerId: null,
+        hosts: [makeHost("srv_remote")],
+        orderedHosts: [makeHost("srv_remote")],
+      }),
+    ).toBe("srv_remote");
+  });
+
+  it("falls through a disconnected selection to the connected local host", () => {
+    expect(
+      resolveActiveHostServerId({
+        selectedServerId: "srv_stale_selection",
+        localServerId: "srv_local",
+        hosts: [makeHost("srv_local"), makeHost("srv_remote")],
+        orderedHosts: [makeHost("srv_local"), makeHost("srv_remote")],
+      }),
+    ).toBe("srv_local");
   });
 });

--- a/packages/app/src/types/host-connection.ts
+++ b/packages/app/src/types/host-connection.ts
@@ -75,6 +75,29 @@ export function orderHostsLocalFirst<T extends { serverId: string }>(
   return ordered;
 }
 
+/**
+ * Resolves which host a settings host section should target: the picker
+ * selection, else the local daemon, else the first connected host.
+ *
+ * Only a serverId that names a currently connected host is used. Both the
+ * selection and the local daemon can name a host that isn't connected (a stale
+ * selection, or a local daemon whose id persists in storage while it's stopped);
+ * using one would resolve the section to an unknown id and render "host not found".
+ */
+export function resolveActiveHostServerId(params: {
+  selectedServerId: string | null;
+  localServerId: string | null;
+  hosts: readonly { serverId: string }[];
+  orderedHosts: readonly { serverId: string }[];
+}): string | null {
+  const { selectedServerId, localServerId, hosts, orderedHosts } = params;
+  const connected = (serverId: string | null): string | null =>
+    serverId && hosts.some((host) => host.serverId === serverId) ? serverId : null;
+  return (
+    connected(selectedServerId) ?? connected(localServerId) ?? orderedHosts[0]?.serverId ?? null
+  );
+}
+
 function hostConnectionEquals(left: HostConnection, right: HostConnection): boolean {
   if (left.type !== right.type || left.id !== right.id) {
     return false;


### PR DESCRIPTION
### Linked issue

Closes #1747

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Settings host sections now stay on a connected host when the local daemon is
stopped. On desktop, opening Settings and clicking a host section (e.g. **Host**)
without manually re-selecting a host showed "host not found".

The device remembers the local daemon's `serverId` even while that daemon is
stopped, so it isn't among the connected `hosts`. The resolver fell back to that
stale id without checking it was connected, so the section resolved to an unknown
host. The fallback now only uses `localServerId` when it's a real connected host,
otherwise it drops to the first connected host. The resolution is extracted into a
pure `resolveActiveHostServerId` helper so it can be unit-tested.

### How did you verify it

Desktop-specific bug (depends on a local-daemon serverId that persists while the
daemon is stopped). Tested on Windows 11:

- Before the fix: local daemon stopped, connected to a remote host, open Settings,
  click the **Host** menu without re-selecting a host. The pane shows "host not
  found".
- After the fix: the same flow renders the host's content (screenshots below).

Added regression tests for the resolver and confirmed they go red on the old
fallback before passing on the fixed one:

- `npx vitest run packages/app/src/types/host-connection.test.ts` (10 passed; the
  stopped-local-daemon case returns the stale local serverId and fails without the
  guard).
- `npm run typecheck`
- `npm run lint`
- `npm run format`

Other platforms not tested.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (desktop only; other platforms not affected)
- [x] Tests added or updated where it made sense

---

**After**: directly clicking the Host menu renders the host content:

<img width="1632" height="872" alt="image" src="https://github.com/user-attachments/assets/496965b8-aa43-4f98-b4c5-dd14e2348332" />

**Before**: the same flow showed "host not found":

<img width="1584" height="868" alt="image" src="https://github.com/user-attachments/assets/d7b555e8-a71a-460b-b279-9ed321d6f47a" />


https://github.com/user-attachments/assets/78dab19f-dd9e-44ec-99d0-d66cf7fe4056


