### PR TITLE
Show Add Project search loading state

### DIFF
--- a/packages/app/e2e/empty-project-persists.spec.ts
+++ b/packages/app/e2e/empty-project-persists.spec.ts
@@ -73,6 +73,23 @@ async function waitForSidebarProjectListReady(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: 60_000 });
 }
 
+test.describe("Project picker search", () => {
+  test("shows a loading state after typing while directory suggestions are pending", async ({
+    page,
+  }) => {
+    await gotoAppShell(page);
+    await waitForSidebarProjectListReady(page);
+    await page.getByTestId("sidebar-add-project").click();
+
+    const input = page.getByPlaceholder("Type a directory path...");
+    await expect(input).toBeVisible({ timeout: 30_000 });
+    await input.fill("paseo-loading-state-no-match");
+
+    await expect(page.getByText("Start typing a path", { exact: true })).toHaveCount(0);
+    await expect(page.getByText("Searching...", { exact: true })).toBeVisible();
+  });
+});
+
 // Projects are parents in the sidebar. Archiving the last workspace leaves the
 // project row in place with a ghost "+ New workspace" child row.
 test.describe("Project with no workspaces persists", () => {

--- a/packages/app/src/components/project-picker-modal.tsx
+++ b/packages/app/src/components/project-picker-modal.tsx
@@ -7,6 +7,8 @@ import {
   TextInput,
   View,
   type PressableStateCallbackType,
+  type StyleProp,
+  type TextStyle,
 } from "react-native";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
@@ -68,6 +70,67 @@ function PathRow({ option, active, onSelect }: PathRowProps) {
   );
 }
 
+interface ProjectPickerResultsProps {
+  options: ProjectPickerOption[];
+  activeIndex: number;
+  isSubmitting: boolean;
+  openErrorMessage: string | null;
+  hasQuery: boolean;
+  isSearching: boolean;
+  emptyTextStyle: StyleProp<TextStyle>;
+  errorTextStyle: StyleProp<TextStyle>;
+  onSelect: (path: string) => void;
+}
+
+function ProjectPickerResults({
+  options,
+  activeIndex,
+  isSubmitting,
+  openErrorMessage,
+  hasQuery,
+  isSearching,
+  emptyTextStyle,
+  errorTextStyle,
+  onSelect,
+}: ProjectPickerResultsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <ScrollView
+      style={styles.results}
+      contentContainerStyle={styles.resultsContent}
+      keyboardShouldPersistTaps="always"
+      showsVerticalScrollIndicator={false}
+    >
+      {isSubmitting ? <Text style={emptyTextStyle}>{t("projectPicker.opening")}</Text> : null}
+      {!isSubmitting && openErrorMessage ? (
+        <Text style={errorTextStyle}>{openErrorMessage}</Text>
+      ) : null}
+      {!isSubmitting && options.length === 0 && !hasQuery ? (
+        <Text style={emptyTextStyle}>{t("projectPicker.empty")}</Text>
+      ) : null}
+      {!isSubmitting && isSearching ? (
+        <Text style={emptyTextStyle}>{t("projectPicker.searching")}</Text>
+      ) : null}
+      {!isSubmitting && !isSearching && options.length === 0 && hasQuery ? (
+        <Text style={emptyTextStyle}>{t("common.empty.noOptionsMatchSearch")}</Text>
+      ) : null}
+      {!isSubmitting && options.length > 0 ? (
+        <>
+          {options.map((option, index) => (
+            <PathRow
+              key={`${option.kind}:${option.path}`}
+              option={option}
+              active={index === activeIndex}
+              onSelect={onSelect}
+            />
+          ))}
+        </>
+      ) : null}
+    </ScrollView>
+  );
+}
+
 export function ProjectPickerModal() {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
@@ -116,6 +179,11 @@ export function ProjectPickerModal() {
       }),
     [directorySuggestionsQuery.data, query, recommendedPaths],
   );
+  const hasQuery = query.trim().length > 0;
+  const isSearching =
+    hasQuery &&
+    options.length === 0 &&
+    (query !== debouncedQuery || directorySuggestionsQuery.isFetching);
 
   const openErrorMessage = useMemo(() => {
     if (!openErrorReason) {
@@ -276,32 +344,17 @@ export function ProjectPickerModal() {
             />
           </View>
 
-          <ScrollView
-            style={styles.results}
-            contentContainerStyle={styles.resultsContent}
-            keyboardShouldPersistTaps="always"
-            showsVerticalScrollIndicator={false}
-          >
-            {isSubmitting ? <Text style={emptyTextStyle}>{t("projectPicker.opening")}</Text> : null}
-            {!isSubmitting && openErrorMessage ? (
-              <Text style={errorTextStyle}>{openErrorMessage}</Text>
-            ) : null}
-            {!isSubmitting && options.length === 0 && !query.trim() ? (
-              <Text style={emptyTextStyle}>{t("projectPicker.empty")}</Text>
-            ) : null}
-            {!isSubmitting && !(options.length === 0 && !query.trim()) ? (
-              <>
-                {options.map((option, index) => (
-                  <PathRow
-                    key={`${option.kind}:${option.path}`}
-                    option={option}
-                    active={index === activeIndex}
-                    onSelect={handleSelectPath}
-                  />
-                ))}
-              </>
-            ) : null}
-          </ScrollView>
+          <ProjectPickerResults
+            options={options}
+            activeIndex={activeIndex}
+            isSubmitting={isSubmitting}
+            openErrorMessage={openErrorMessage}
+            hasQuery={hasQuery}
+            isSearching={isSearching}
+            emptyTextStyle={emptyTextStyle}
+            errorTextStyle={errorTextStyle}
+            onSelect={handleSelectPath}
+          />
         </View>
       </View>
     </Modal>

--- a/packages/app/src/components/project-picker-modal.tsx
+++ b/packages/app/src/components/project-picker-modal.tsx
@@ -94,6 +94,7 @@ function ProjectPickerResults({
   onSelect,
 }: ProjectPickerResultsProps) {
   const { t } = useTranslation();
+  const canShowResultState = !isSubmitting && !openErrorMessage;
 
   return (
     <ScrollView
@@ -106,16 +107,16 @@ function ProjectPickerResults({
       {!isSubmitting && openErrorMessage ? (
         <Text style={errorTextStyle}>{openErrorMessage}</Text>
       ) : null}
-      {!isSubmitting && options.length === 0 && !hasQuery ? (
+      {canShowResultState && options.length === 0 && !hasQuery ? (
         <Text style={emptyTextStyle}>{t("projectPicker.empty")}</Text>
       ) : null}
-      {!isSubmitting && isSearching ? (
+      {canShowResultState && isSearching ? (
         <Text style={emptyTextStyle}>{t("projectPicker.searching")}</Text>
       ) : null}
-      {!isSubmitting && !isSearching && options.length === 0 && hasQuery ? (
+      {canShowResultState && !isSearching && options.length === 0 && hasQuery ? (
         <Text style={emptyTextStyle}>{t("common.empty.noOptionsMatchSearch")}</Text>
       ) : null}
-      {!isSubmitting && options.length > 0 ? (
+      {canShowResultState && options.length > 0 ? (
         <>
           {options.map((option, index) => (
             <PathRow

--- a/packages/app/src/i18n/resources.test.ts
+++ b/packages/app/src/i18n/resources.test.ts
@@ -388,6 +388,7 @@ describe("translation resources", () => {
   it("includes picker, file pane, and tool detail keys for the Batch 4L migration", () => {
     expect(en.projectPicker.placeholder).toBe("Type a directory path...");
     expect(en.projectPicker.opening).toBe("Opening project...");
+    expect(en.projectPicker.searching).toBe("Searching...");
     expect(en.projectPicker.empty).toBe("Start typing a path");
     expect(en.branchSwitcher.currentBranch).toBe(
       "Current branch: {{branchName}}. Press to switch branch.",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1054,6 +1054,7 @@ export const ar: TranslationResources = {
   projectPicker: {
     placeholder: "اكتب مسار الدليل...",
     opening: "افتتاح المشروع...",
+    searching: "جارٍ البحث...",
     empty: "ابدأ بكتابة المسار",
     errors: {
       directory_not_found: "لم يتم العثور على الدليل.",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1060,6 +1060,7 @@ export const en = {
   projectPicker: {
     placeholder: "Type a directory path...",
     opening: "Opening project...",
+    searching: "Searching...",
     empty: "Start typing a path",
     errors: {
       directory_not_found: "Directory not found.",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1087,7 +1087,7 @@ export const es: TranslationResources = {
   projectPicker: {
     placeholder: "Escriba una ruta de directorio...",
     opening: "Proyecto de apertura...",
-    searching: "Búsqueda...",
+    searching: "Buscando...",
     empty: "Comience a escribir una ruta",
     errors: {
       directory_not_found: "No se encontró el directorio.",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1087,6 +1087,7 @@ export const es: TranslationResources = {
   projectPicker: {
     placeholder: "Escriba una ruta de directorio...",
     opening: "Proyecto de apertura...",
+    searching: "Búsqueda...",
     empty: "Comience a escribir una ruta",
     errors: {
       directory_not_found: "No se encontró el directorio.",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1089,7 +1089,7 @@ export const fr: TranslationResources = {
   projectPicker: {
     placeholder: "Tapez un chemin de répertoire...",
     opening: "Projet d'ouverture...",
-    searching: "Recherche...",
+    searching: "Recherche en cours...",
     empty: "Commencez à taper un chemin",
     errors: {
       directory_not_found: "Répertoire introuvable.",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1089,6 +1089,7 @@ export const fr: TranslationResources = {
   projectPicker: {
     placeholder: "Tapez un chemin de répertoire...",
     opening: "Projet d'ouverture...",
+    searching: "Recherche...",
     empty: "Commencez à taper un chemin",
     errors: {
       directory_not_found: "Répertoire introuvable.",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1067,6 +1067,7 @@ export const ja: TranslationResources = {
   projectPicker: {
     placeholder: "ディレクトリパスを入力...",
     opening: "プロジェクトを開いています...",
+    searching: "検索中...",
     empty: "パスを入力してください",
     errors: {
       directory_not_found: "ディレクトリが見つかりません。",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1073,6 +1073,7 @@ export const ptBR: TranslationResources = {
   projectPicker: {
     placeholder: "Digite um caminho de diretório...",
     opening: "Abrindo projeto...",
+    searching: "Buscando...",
     empty: "Comece digitando um caminho",
     errors: {
       directory_not_found: "Diretório não encontrado.",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1077,6 +1077,7 @@ export const ru: TranslationResources = {
   projectPicker: {
     placeholder: "Введите путь к каталогу...",
     opening: "Открытие проекта...",
+    searching: "Идет поиск...",
     empty: "Начните вводить путь",
     errors: {
       directory_not_found: "Каталог не найден.",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1039,6 +1039,7 @@ export const zhCN: TranslationResources = {
   projectPicker: {
     placeholder: "输入目录路径...",
     opening: "正在打开 project...",
+    searching: "正在搜索...",
     empty: "开始输入路径",
     errors: {
       directory_not_found: "找不到目录。",


### PR DESCRIPTION
### Linked issue

None found in the open issue search.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The Add Project picker now shows a real loading state after the user types a search query and directory suggestions are still pending. Previously the picker could show the initial \"Start typing a path\" prompt or fall through to a blank result area while the typed query was still ahead of the debounced directory search.

The picker now separates initial-empty, searching, no-match, and results states. A typed query with no rows shows \"Searching...\" while the debounce/RPC is pending, and a completed empty search falls back to the shared no-options message.

### How did you verify it

- `npm run format`
- `npm run lint -- packages/app/src/components/project-picker-modal.tsx packages/app/src/i18n/resources/en.ts packages/app/src/i18n/resources/es.ts packages/app/src/i18n/resources/fr.ts packages/app/src/i18n/resources/pt-BR.ts packages/app/src/i18n/resources/ru.ts packages/app/src/i18n/resources/ja.ts packages/app/src/i18n/resources/zh-CN.ts packages/app/src/i18n/resources/ar.ts packages/app/src/i18n/resources.test.ts packages/app/e2e/empty-project-persists.spec.ts`
- `npm run typecheck --workspace=@getpaseo/app`
- `npx vitest run packages/app/src/i18n/resources.test.ts --bail=1`
- `npm run test:e2e --workspace=@getpaseo/app -- empty-project-persists.spec.ts -g \"shows a loading state after typing while directory suggestions are pending\"`

For the Playwright run, I applied the Wrangler harness fix from https://github.com/getpaseo/paseo/pull/1761 locally and then restored it before committing. This branch intentionally does not include that Wrangler/package change.

No screenshot is attached; the affected UI state is transient and is covered by the targeted Playwright assertion.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense