### PR TITLE
fix: send push notifications for permission requests when user is not focused

### DIFF
--- a/packages/server/src/server/agent-attention-policy.ts
+++ b/packages/server/src/server/agent-attention-policy.ts
@@ -24,6 +24,9 @@ interface ComputeNotificationPlanInput {
   // Whether a push notification is allowed when no client is present.
   pushEligible: boolean;
   nowMs: number;
+  // When true, skip the presence window check. Clients are treated as absent
+  // regardless of recent activity. The focus check still applies.
+  skipPresence?: boolean;
 }
 
 function isFocusedOnTarget(
@@ -44,9 +47,21 @@ export function computeNotificationPlan({
   focusTarget,
   pushEligible,
   nowMs,
+  skipPresence = false,
 }: ComputeNotificationPlanInput): NotificationPlan {
   let mostRecentPresentIndex: number | null = null;
   let mostRecentPresentAtMs = Number.NEGATIVE_INFINITY;
+
+  if (skipPresence) {
+    // Focus check only: suppress push if any client is viewing the target.
+    // Presence is irrelevant — the user needs to know the agent is waiting.
+    for (const state of allStates) {
+      if (state.appVisible && isFocusedOnTarget(state, focusTarget)) {
+        return { inAppRecipientIndex: null, shouldPush: false };
+      }
+    }
+    return { inAppRecipientIndex: null, shouldPush: pushEligible };
+  }
 
   for (const [clientIndex, state] of allStates.entries()) {
     const clampedActivityAtMs =

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1818,6 +1818,7 @@ export class VoiceAssistantWebSocketServer {
       focusTarget: { kind: "agent", id: params.agentId },
       pushEligible: isPushEligibleAttentionReason(params.reason),
       nowMs,
+      skipPresence: params.reason === "permission",
     });
 
     if (plan.shouldPush) {


### PR DESCRIPTION
Closes #1764

## Problem

When an agent asks the user a question (permission request), Paseo suppresses push notifications if any client was active within 180 seconds — even if the user is on a different page and won't see the in-app dialog.

## Fix

Add a `skipPresence` parameter to `computeNotificationPlan`. For `permission` reason, skip the 180s presence window. The focus check (`appVisible && focusedAgentId === agent.id`) still applies: no push if the user is literally looking at the agent.

## Changes

- **`agent-attention-policy.ts`**: Add optional `skipPresence` flag. When true, all clients are treated as absent regardless of recent activity.
- **`websocket-server.ts`**: Pass `skipPresence: params.reason === "permission"` to `computeNotificationPlan`.