### PR TITLE
fix(app): refresh projects settings after add and keep host on settings exit

### DIFF
--- a/packages/app/src/hooks/use-projects.ts
+++ b/packages/app/src/hooks/use-projects.ts
@@ -39,6 +39,15 @@ export function useProjects(): UseProjectsResult {
   const projectsQuery = useQuery({
     queryKey: projectsQueryKey,
     queryFn: () => fetchAggregatedProjects({ hosts: hostInputs, runtime }),
+    // The global QueryClient pins staleTime/gcTime to Infinity and disables
+    // refetchOnMount, so an invalidate fired while this screen is unmounted (the
+    // usual "add a project from the sidebar" path) only marks the cache stale
+    // without refetching. Without this, opening the projects settings screen
+    // shows the pre-add cache until something else triggers a refetch. With
+    // staleTime Infinity the cache only goes stale via an explicit invalidate,
+    // so refetch-if-stale on mount picks up a freshly-added project without
+    // refetching on every visit.
+    refetchOnMount: true,
   });
 
   return {

--- a/packages/app/src/hooks/use-projects.ts
+++ b/packages/app/src/hooks/use-projects.ts
@@ -39,14 +39,9 @@ export function useProjects(): UseProjectsResult {
   const projectsQuery = useQuery({
     queryKey: projectsQueryKey,
     queryFn: () => fetchAggregatedProjects({ hosts: hostInputs, runtime }),
-    // The global QueryClient pins staleTime/gcTime to Infinity and disables
-    // refetchOnMount, so an invalidate fired while this screen is unmounted (the
-    // usual "add a project from the sidebar" path) only marks the cache stale
-    // without refetching. Without this, opening the projects settings screen
-    // shows the pre-add cache until something else triggers a refetch. With
-    // staleTime Infinity the cache only goes stale via an explicit invalidate,
-    // so refetch-if-stale on mount picks up a freshly-added project without
-    // refetching on every visit.
+    // Refetch-if-stale on mount so a project added (and the cache invalidated)
+    // while this screen was unmounted isn't silently served stale. With the
+    // global staleTime: Infinity the cache only goes stale via that invalidate.
     refetchOnMount: true,
   });
 

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -101,6 +101,7 @@ import { useIsCompactFormFactor } from "@/constants/layout";
 import { useLocalDaemonServerId } from "@/hooks/use-is-local-daemon";
 import { useWebScrollbarStyle } from "@/hooks/use-web-scrollbar-style";
 import {
+  buildHostOpenProjectRoute,
   buildOpenProjectRoute,
   buildProjectsSettingsRoute,
   buildSettingsHostSectionRoute,
@@ -108,7 +109,10 @@ import {
   type HostSectionSlug,
   type SettingsSectionSlug,
 } from "@/utils/host-routes";
-import { navigateToLastWorkspace } from "@/stores/navigation-active-workspace-store";
+import {
+  getLastActiveHostServerId,
+  navigateToLastWorkspace,
+} from "@/stores/navigation-active-workspace-store";
 
 // ---------------------------------------------------------------------------
 // View model
@@ -1332,8 +1336,17 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     if (navigateToLastWorkspace()) {
       return;
     }
+    // No remembered workspace (the user never opened one this session). Fall
+    // back to the host they were last looking at instead of the no-host route,
+    // which would otherwise re-select the default host and look like the host
+    // "changed" on exit.
+    const lastHostServerId = getLastActiveHostServerId();
+    if (lastHostServerId && hosts.some((host) => host.serverId === lastHostServerId)) {
+      router.replace(buildHostOpenProjectRoute(lastHostServerId));
+      return;
+    }
     router.replace(buildOpenProjectRoute());
-  }, [router]);
+  }, [hosts, router]);
 
   const detailHeader = ((): {
     title: string;

--- a/packages/app/src/stores/last-active-host.ts
+++ b/packages/app/src/stores/last-active-host.ts
@@ -19,19 +19,15 @@ function normalizeServerId(input: unknown): string | null {
  * paths that fall back on the last workspace would then drop to a no-host route
  * and re-select the default host. This store fills that gap: any route carrying
  * a serverId records it, so we can return to the same host on exit.
+ *
+ * Read access is one-shot via getServerId() (settings exit reads it
+ * imperatively), so this store deliberately has no subscribe/useSyncExternalStore
+ * surface, unlike the reactive last-workspace-selection store.
  */
 export function createLastActiveHostStore(storage: LastActiveHostStorage) {
   let serverId: string | null = null;
-  let hydrated = false;
   let hydrationPromise: Promise<void> | null = null;
   let revision = 0;
-  const listeners = new Set<() => void>();
-
-  function notifyListeners() {
-    for (const listener of listeners) {
-      listener();
-    }
-  }
 
   function remember(next: string) {
     const normalized = normalizeServerId(next);
@@ -40,7 +36,6 @@ export function createLastActiveHostStore(storage: LastActiveHostStorage) {
     }
     serverId = normalized;
     revision += 1;
-    notifyListeners();
     void storage.write(normalized).catch(() => {});
   }
 
@@ -61,10 +56,6 @@ export function createLastActiveHostStore(storage: LastActiveHostStorage) {
         if (revision === hydrationRevision) {
           serverId = null;
         }
-      })
-      .finally(() => {
-        hydrated = true;
-        notifyListeners();
       });
     return hydrationPromise;
   }
@@ -72,13 +63,6 @@ export function createLastActiveHostStore(storage: LastActiveHostStorage) {
   return {
     getServerId: () => serverId,
     hydrate,
-    isHydrated: () => hydrated,
     remember,
-    subscribe: (listener: () => void): (() => void) => {
-      listeners.add(listener);
-      return () => {
-        listeners.delete(listener);
-      };
-    },
   };
 }

--- a/packages/app/src/stores/last-active-host.ts
+++ b/packages/app/src/stores/last-active-host.ts
@@ -1,0 +1,84 @@
+export interface LastActiveHostStorage {
+  read(): Promise<string | null>;
+  write(value: string): Promise<void>;
+}
+
+function normalizeServerId(input: unknown): string | null {
+  if (typeof input !== "string") {
+    return null;
+  }
+  const trimmed = input.trim();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * Remembers the host (serverId) the user was last looking at, independent of
+ * whether they had a workspace open. The last-*workspace* selection only
+ * persists when both serverId and workspaceId are present, so a user sitting on
+ * a host's open-project / project-list screen has no remembered workspace. Exit
+ * paths that fall back on the last workspace would then drop to a no-host route
+ * and re-select the default host. This store fills that gap: any route carrying
+ * a serverId records it, so we can return to the same host on exit.
+ */
+export function createLastActiveHostStore(storage: LastActiveHostStorage) {
+  let serverId: string | null = null;
+  let hydrated = false;
+  let hydrationPromise: Promise<void> | null = null;
+  let revision = 0;
+  const listeners = new Set<() => void>();
+
+  function notifyListeners() {
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+
+  function remember(next: string) {
+    const normalized = normalizeServerId(next);
+    if (!normalized || serverId === normalized) {
+      return;
+    }
+    serverId = normalized;
+    revision += 1;
+    notifyListeners();
+    void storage.write(normalized).catch(() => {});
+  }
+
+  function hydrate(): Promise<void> {
+    if (hydrationPromise) {
+      return hydrationPromise;
+    }
+    const hydrationRevision = revision;
+    hydrationPromise = storage
+      .read()
+      .then((stored) => {
+        if (revision === hydrationRevision) {
+          serverId = normalizeServerId(stored);
+        }
+        return undefined;
+      })
+      .catch(() => {
+        if (revision === hydrationRevision) {
+          serverId = null;
+        }
+      })
+      .finally(() => {
+        hydrated = true;
+        notifyListeners();
+      });
+    return hydrationPromise;
+  }
+
+  return {
+    getServerId: () => serverId,
+    hydrate,
+    isHydrated: () => hydrated,
+    remember,
+    subscribe: (listener: () => void): (() => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/packages/app/src/stores/navigation-active-workspace-store/index.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/index.ts
@@ -6,6 +6,8 @@ import {
   type ActiveWorkspaceSelection,
   type LastWorkspaceSelectionStorage,
 } from "@/stores/last-workspace-selection";
+import { createLastActiveHostStore, type LastActiveHostStorage } from "@/stores/last-active-host";
+import { parseServerIdFromPathname } from "@/utils/host-routes";
 import {
   navigateToLastWorkspace as navigateToLastWorkspacePure,
   navigateToWorkspace as navigateToWorkspacePure,
@@ -23,6 +25,7 @@ interface NavigateToWorkspaceOptions {
 }
 
 const LAST_WORKSPACE_SELECTION_STORAGE_KEY = "paseo:last-workspace-route-selection";
+const LAST_ACTIVE_HOST_STORAGE_KEY = "paseo:last-active-host";
 
 const lastWorkspaceSelectionStorage: LastWorkspaceSelectionStorage = {
   read: () => AsyncStorage.getItem(LAST_WORKSPACE_SELECTION_STORAGE_KEY),
@@ -32,6 +35,13 @@ const lastWorkspaceSelectionStorage: LastWorkspaceSelectionStorage = {
 const lastWorkspaceSelectionStore = createLastWorkspaceSelectionStore(
   lastWorkspaceSelectionStorage,
 );
+
+const lastActiveHostStorage: LastActiveHostStorage = {
+  read: () => AsyncStorage.getItem(LAST_ACTIVE_HOST_STORAGE_KEY),
+  write: (value) => AsyncStorage.setItem(LAST_ACTIVE_HOST_STORAGE_KEY, value),
+};
+
+const lastActiveHostStore = createLastActiveHostStore(lastActiveHostStorage);
 
 function navigateDeps(): NavigateToWorkspaceDeps {
   return {
@@ -50,7 +60,13 @@ function navigateDeps(): NavigateToWorkspaceDeps {
 }
 
 export function hydrateLastWorkspaceSelection(): Promise<void> {
-  return lastWorkspaceSelectionStore.hydrate();
+  return Promise.all([lastWorkspaceSelectionStore.hydrate(), lastActiveHostStore.hydrate()]).then(
+    () => undefined,
+  );
+}
+
+export function getLastActiveHostServerId(): string | null {
+  return lastActiveHostStore.getServerId();
 }
 
 export function getLastWorkspaceSelection(): ActiveWorkspaceSelection | null {
@@ -81,9 +97,20 @@ export function useActiveWorkspaceSelection(): ActiveWorkspaceSelection | null {
     serverId?: string | string[];
     workspaceId?: string | string[];
   }>();
-  const selection = parseActiveWorkspaceSelection({ pathname: usePathname(), params });
+  const pathname = usePathname();
+  const selection = parseActiveWorkspaceSelection({ pathname, params });
   const serverId = selection?.serverId ?? null;
   const workspaceId = selection?.workspaceId ?? null;
+  // Remember the host even when no workspace is open (e.g. the host's
+  // open-project screen), so exit paths can return to the same host instead of
+  // falling back to the default one. parseServerIdFromPathname covers host
+  // routes that carry no workspace; the parsed selection covers the rest.
+  const routeServerId = serverId ?? parseServerIdFromPathname(pathname);
+  useEffect(() => {
+    if (routeServerId) {
+      lastActiveHostStore.remember(routeServerId);
+    }
+  }, [routeServerId]);
   useEffect(() => {
     if (!serverId || !workspaceId) {
       return;

--- a/packages/app/src/stores/navigation-active-workspace-store/index.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/index.ts
@@ -59,7 +59,7 @@ function navigateDeps(): NavigateToWorkspaceDeps {
   };
 }
 
-export function hydrateLastWorkspaceSelection(): Promise<void> {
+export function hydrateNavigationStores(): Promise<void> {
   return Promise.all([lastWorkspaceSelectionStore.hydrate(), lastActiveHostStore.hydrate()]).then(
     () => undefined,
   );
@@ -136,4 +136,4 @@ export function useIsLastWorkspaceSelectionHydrated(): boolean {
   );
 }
 
-void hydrateLastWorkspaceSelection();
+void hydrateNavigationStores();


### PR DESCRIPTION
### Linked issue

No existing issue — filing this as two small, objective navigation/state bug fixes. Happy to open issues first if you'd prefer that flow.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fixes two independent bugs in the app client. They are unrelated in mechanism but both showed up in the same "go into settings / add a project" flow, so they're bundled here. Easy to split into two PRs if you'd rather.

**1. A newly-added project doesn't appear in the projects settings screen.**

The sidebar project list reads the Zustand session store, which is updated synchronously when a project is added (`addEmptyProject`), so it shows the new project immediately. The **projects settings screen** (`ProjectsScreen`) instead reads the React Query `["projects"]` cache via `useProjects()`.

The global `QueryClient` pins `staleTime: Infinity`, `gcTime: Infinity`, and `refetchOnMount: false` (`packages/app/src/query/query-client.ts`). When you add a project from the sidebar, `useOpenProject` does call `invalidateQueries(["projects"])` — but at that moment the settings screen is unmounted, so the query has no active observer and the invalidate only marks the cache **stale without refetching**. When you later open the settings screen, `refetchOnMount: false` means it does not refetch a stale cache either, so you see the pre-add list until some other event triggers a refetch (or an app restart).

Fix: opt the `["projects"]` query into `refetchOnMount: true`. Because the global `staleTime` is `Infinity`, this query only becomes stale via the explicit invalidate, so this refetches exactly when a project was added and not on every visit.

**2. Exiting settings re-selects the default host instead of keeping the current one.**

The settings exit handler (`handleBackToWorkspace`) restores the last **workspace** via `navigateToLastWorkspace()`, falling back to the no-host `/open-project` route. But the last-workspace selection is only persisted when the route carries **both** `serverId` and `workspaceId` (`useActiveWorkspaceSelection`). A user sitting on a host's open-project / project-list screen — no workspace open — has no remembered workspace. So exit falls through to `/open-project`, which carries no `serverId`, and the host selection resolves to the default (local daemon or first host). The visible symptom is "the host keeps changing when I leave settings."

Fix: add a lightweight `last-active-host` store that records the host from **any** route carrying a `serverId` (workspace not required), mirroring the existing `last-workspace-selection` store. On settings exit, if there's no remembered workspace, fall back to that host's `/h/[serverId]/open-project` route (guarded by a check that the host still exists) before the no-host route.

New file: `packages/app/src/stores/last-active-host.ts`. Wiring added in `navigation-active-workspace-store/index.ts` and consumed in `settings-screen.tsx`.

### How did you verify it

Static checks only so far — I have **not** run the app and visually confirmed the two flows, so I'm not attaching screenshots/video rather than fabricate them:

- `npm run typecheck` — passes (full workspace, via pre-commit hook)
- `npm run lint` — passes, 0 warnings / 0 errors on the changed files
- `npm run format` (oxfmt/Biome) — ran, changed files already conform

The fixes are derived from reading the data flow:

- Bug 1: confirmed the two list consumers use different sources (sidebar → Zustand store; settings → React Query `["projects"]`) and that the global QueryClient config (`staleTime: Infinity` + `refetchOnMount: false`) prevents the post-invalidate refetch on next mount. A useful manual cross-check for a reviewer: adding a project **while already on the settings screen** should work today (query is active), while adding from the sidebar then navigating in should not — that asymmetry is the bug.
- Bug 2: confirmed `useActiveWorkspaceSelection` only persists when both `serverId` and `workspaceId` are present, and that `buildOpenProjectRoute()` carries no `serverId`.

If a maintainer wants, I can follow up with recorded web/desktop verification of both flows before merge.

### Checklist

- [x] One focused change. Unrelated cleanups split out. <!-- two small related bug fixes; can split if preferred -->
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform <!-- not yet; see verification note above -->
- [ ] Tests added or updated where it made sense <!-- happy to add coverage for the last-active-host store and the settings exit fallback if desired -->
