### PR TITLE
Support F-Droid Android builds

### DIFF
--- a/docs/android.md
+++ b/docs/android.md
@@ -13,6 +13,18 @@ EAS profiles: `development`, `production`, and `production-apk` in `packages/app
 
 `development` uses Android `debug`.
 
+## Version codes
+
+`packages/app/app.config.js` derives Android `versionCode` from the package version with:
+
+```text
+1_000_000 + major * 1_000_000 + minor * 1_000 + patch
+```
+
+Prerelease metadata is ignored, so `0.1.102-beta.1` and `0.1.102` both produce `1001102`. The same value is used as the iOS `buildNumber` because `packages/app/eas.json` uses EAS's local app version source. The `1_000_000` floor keeps the local formula above prior EAS remote counters during the transition. Do not re-enable EAS remote version counters or Android `autoIncrement`; F-Droid and other source-based builders need the native build number to be visible in the repo.
+
+The formula reserves three digits each for minor and patch. If either reaches `1000`, change the formula before cutting that release.
+
 ## Local build + install
 
 From repo root:
@@ -37,6 +49,19 @@ npx cross-env APP_VARIANT=production expo run:android --variant=release
 # Clear generated Android project
 rm -rf android
 ```
+
+## F-Droid / source-only Android builds
+
+F-Droid builds should set `PASEO_FDROID_BUILD=1` when running Expo prebuild:
+
+```bash
+cd packages/app
+PASEO_FDROID_BUILD=1 APP_VARIANT=production npx expo prebuild --platform android --clean --non-interactive
+cd android
+./gradlew assembleRelease
+```
+
+That env var is intentionally narrow. It enables `expo.autolinking.android.buildFromSource: [".*"]` so Expo modules are built from source instead of linked from precompiled AARs, and it applies `expo-gradle-jvmargs` with `-Xmx4096m` and `-XX:MaxMetaspaceSize=1024m` for the larger source build. Normal local and EAS builds leave those settings off.
 
 ### React version lockstep
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -18,10 +18,10 @@ EAS profiles: `development`, `production`, and `production-apk` in `packages/app
 `packages/app/app.config.js` derives Android `versionCode` from the package version with:
 
 ```text
-1_000_000 + major * 1_000_000 + minor * 1_000 + patch
+major * 1_000_000 + minor * 1_000 + patch
 ```
 
-Prerelease metadata is ignored, so `0.1.102-beta.1` and `0.1.102` both produce `1001102`. The same value is used as the iOS `buildNumber` because `packages/app/eas.json` uses EAS's local app version source. The `1_000_000` floor keeps the local formula above prior EAS remote counters during the transition. Do not re-enable EAS remote version counters or Android `autoIncrement`; F-Droid and other source-based builders need the native build number to be visible in the repo.
+Prerelease metadata is ignored, so `0.1.102-beta.1` and `0.1.102` both produce `1102`. The same value is used as the iOS `buildNumber` because `packages/app/eas.json` uses EAS's local app version source. Do not re-enable EAS remote version counters or Android `autoIncrement`; F-Droid and other source-based builders need the native build number to be visible in the repo.
 
 The formula reserves three digits each for minor and patch. If either reaches `1000`, change the formula before cutting that release.
 
@@ -61,7 +61,7 @@ cd android
 ./gradlew assembleRelease
 ```
 
-That env var is intentionally narrow. It enables `expo.autolinking.android.buildFromSource: [".*"]` so Expo modules are built from source instead of linked from precompiled AARs, and it applies `expo-gradle-jvmargs` with `-Xmx4096m` and `-XX:MaxMetaspaceSize=1024m` for the larger source build. Normal local and EAS builds leave those settings off.
+That env var is intentionally narrow. It enables `expo.autolinking.android.buildFromSource: [".*"]` so Expo modules are built from source instead of linked from precompiled AARs. Paseo always applies `expo-gradle-jvmargs` with `-Xmx4096m` and `-XX:MaxMetaspaceSize=1024m` so local Expo prebuilds have enough Gradle heap whether they use precompiled AARs or source-built Expo modules.
 
 ### React version lockstep
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -58,10 +58,12 @@ F-Droid builds should set `PASEO_FDROID_BUILD=1` when running Expo prebuild:
 cd packages/app
 PASEO_FDROID_BUILD=1 APP_VARIANT=production npx expo prebuild --platform android --clean --non-interactive
 cd android
-./gradlew assembleRelease
+PASEO_FDROID_BUILD=1 ./gradlew assembleRelease --no-daemon --max-workers=1 -Dorg.gradle.parallel=false
 ```
 
-That env var is intentionally narrow. It enables `expo.autolinking.android.buildFromSource: [".*"]` so Expo modules are built from source instead of linked from precompiled AARs. Paseo always applies `expo-gradle-jvmargs` with `-Xmx4096m` and `-XX:MaxMetaspaceSize=1024m` so local Expo prebuilds have enough Gradle heap whether they use precompiled AARs or source-built Expo modules.
+The flag must be present for both prebuild and Gradle because Gradle starts Metro for the release bundle. Keep the source build serial and daemon-free as shown above: compiling every Expo module can exhaust memory when Gradle workers run in parallel. The profile enables source-built Expo modules, excludes the proprietary camera, Firebase notification, and Expo development-client native modules, disables EAS updates and Gradle dependency metadata, and substitutes JavaScript stubs for camera and notifications. The resulting app supports direct and pasted-link pairing but not QR scanning or push notifications.
+
+Keep the excluded npm packages installed. Normal builds use them, while the F-Droid profile removes only their Android native modules and config plugins. Paseo always applies `expo-gradle-jvmargs` with `-Xmx4096m` and `-XX:MaxMetaspaceSize=1024m` so local Expo prebuilds have enough Gradle heap whether they use precompiled AARs or source-built Expo modules.
 
 ### React version lockstep
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -186,6 +186,8 @@ iOS and Android store builds are not in `.github/workflows`. They are triggered 
 - **iOS (TestFlight + App Store)** — EAS builds with profile `production`, uploads to TestFlight, and a Fastlane lane submits the build for App Store review.
 - **Android APK (GitHub Release asset)** — separate, via `.github/workflows/android-apk-release.yml`. This is the only Android-related workflow that lives in this repo.
 
+EAS uses the local app version source. `packages/app/app.config.js` derives Android `versionCode` and iOS `buildNumber` from the package version as `1_000_000 + major * 1_000_000 + minor * 1_000 + patch`, ignoring prerelease metadata. Rebuilding the same tag produces the same native build number; if a store has already accepted a binary and you need a different binary, cut a new patch instead of relying on EAS remote auto-increment.
+
 There is no `release-mobile.yml` in this repo. Earlier versions of these docs referenced one — that workflow was removed and the EAS GitHub app handles tag triggering directly.
 
 ### Watching mobile builds from the terminal

--- a/docs/release.md
+++ b/docs/release.md
@@ -186,7 +186,7 @@ iOS and Android store builds are not in `.github/workflows`. They are triggered 
 - **iOS (TestFlight + App Store)** — EAS builds with profile `production`, uploads to TestFlight, and a Fastlane lane submits the build for App Store review.
 - **Android APK (GitHub Release asset)** — separate, via `.github/workflows/android-apk-release.yml`. This is the only Android-related workflow that lives in this repo.
 
-EAS uses the local app version source. `packages/app/app.config.js` derives Android `versionCode` and iOS `buildNumber` from the package version as `1_000_000 + major * 1_000_000 + minor * 1_000 + patch`, ignoring prerelease metadata. Rebuilding the same tag produces the same native build number; if a store has already accepted a binary and you need a different binary, cut a new patch instead of relying on EAS remote auto-increment.
+EAS uses the local app version source. `packages/app/app.config.js` derives Android `versionCode` and iOS `buildNumber` from the package version as `major * 1_000_000 + minor * 1_000 + patch`, ignoring prerelease metadata. Rebuilding the same tag produces the same native build number; if a store has already accepted a binary and you need a different binary, cut a new patch instead of relying on EAS remote auto-increment.
 
 There is no `release-mobile.yml` in this repo. Earlier versions of these docs referenced one — that workflow was removed and the EAS GitHub app handles tag triggering directly.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -188,6 +188,8 @@ iOS and Android store builds are not in `.github/workflows`. They are triggered 
 - **iOS (TestFlight + App Store)** — EAS builds with profile `production`, uploads to TestFlight, and a Fastlane lane submits the build for App Store review.
 - **Android APK (GitHub Release asset)** — separate, via `.github/workflows/android-apk-release.yml`. This is the only Android-related workflow that lives in this repo.
 
+EAS uses the local app version source. `packages/app/app.config.js` derives Android `versionCode` and iOS `buildNumber` from the package version as `1_000_000 + major * 1_000_000 + minor * 1_000 + patch`, ignoring prerelease metadata. Rebuilding the same tag produces the same native build number; if a store has already accepted a binary and you need a different binary, cut a new patch instead of relying on EAS remote auto-increment.
+
 There is no `release-mobile.yml` in this repo. Earlier versions of these docs referenced one — that workflow was removed and the EAS GitHub app handles tag triggering directly.
 
 ### Watching mobile builds from the terminal

--- a/docs/release.md
+++ b/docs/release.md
@@ -188,7 +188,7 @@ iOS and Android store builds are not in `.github/workflows`. They are triggered 
 - **iOS (TestFlight + App Store)** — EAS builds with profile `production`, uploads to TestFlight, and a Fastlane lane submits the build for App Store review.
 - **Android APK (GitHub Release asset)** — separate, via `.github/workflows/android-apk-release.yml`. This is the only Android-related workflow that lives in this repo.
 
-EAS uses the local app version source. `packages/app/app.config.js` derives Android `versionCode` and iOS `buildNumber` from the package version as `1_000_000 + major * 1_000_000 + minor * 1_000 + patch`, ignoring prerelease metadata. Rebuilding the same tag produces the same native build number; if a store has already accepted a binary and you need a different binary, cut a new patch instead of relying on EAS remote auto-increment.
+EAS uses the local app version source. `packages/app/app.config.js` derives Android `versionCode` and iOS `buildNumber` from the package version as `major * 1_000_000 + minor * 1_000 + patch`, ignoring prerelease metadata. Rebuilding the same tag produces the same native build number; if a store has already accepted a binary and you need a different binary, cut a new patch instead of relying on EAS remote auto-increment.
 
 There is no `release-mobile.yml` in this repo. Earlier versions of these docs referenced one — that workflow was removed and the EAS GitHub app handles tag triggering directly.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19591,6 +19591,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-gradle-jvmargs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/expo-gradle-jvmargs/-/expo-gradle-jvmargs-1.1.2.tgz",
+      "integrity": "sha512-VJRecrYlklVXEwafLyuZKUCnYEY9vJYvUy639LN3c5krlmunkYQphh/YzXDng8C9oihz6mr+cPbwEn6sv6fXyw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@expo/config-plugins": "*"
+      }
+    },
     "node_modules/expo-haptics": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-15.0.8.tgz",
@@ -35250,6 +35260,7 @@
         "eas-cli": "^16.24.1",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~10.0.0",
+        "expo-gradle-jvmargs": "^1.1.2",
         "jsdom": "^20.0.3",
         "material-icon-theme": "^5.32.0",
         "playwright": "^1.56.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19719,6 +19719,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-gradle-jvmargs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/expo-gradle-jvmargs/-/expo-gradle-jvmargs-1.1.2.tgz",
+      "integrity": "sha512-VJRecrYlklVXEwafLyuZKUCnYEY9vJYvUy639LN3c5krlmunkYQphh/YzXDng8C9oihz6mr+cPbwEn6sv6fXyw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@expo/config-plugins": "*"
+      }
+    },
     "node_modules/expo-haptics": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-15.0.8.tgz",
@@ -35358,6 +35368,7 @@
         "eas-cli": "^16.24.1",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~10.0.0",
+        "expo-gradle-jvmargs": "^1.1.2",
         "jsdom": "^20.0.3",
         "material-icon-theme": "^5.32.0",
         "playwright": "^1.56.1",

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -2,6 +2,32 @@ const fs = require("node:fs");
 const path = require("node:path");
 const pkg = require("./package.json");
 const appVariant = process.env.APP_VARIANT ?? "production";
+const isFdroidBuild = process.env.PASEO_FDROID_BUILD === "1";
+const nativeBuildVersionFloor = 1_000_000;
+
+function getNativeBuildVersionCode(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  if (!match) {
+    throw new Error(`Cannot derive Android versionCode from non-semver version: ${version}`);
+  }
+
+  const [, majorText, minorText, patchText] = match;
+  const major = Number(majorText);
+  const minor = Number(minorText);
+  const patch = Number(patchText);
+
+  if (minor > 999 || patch > 999) {
+    throw new Error(`Cannot derive collision-free Android versionCode from version: ${version}`);
+  }
+
+  const versionCode = nativeBuildVersionFloor + major * 1_000_000 + minor * 1_000 + patch;
+
+  if (!Number.isSafeInteger(versionCode) || versionCode <= 0 || versionCode > 2_100_000_000) {
+    throw new Error(`Derived Android versionCode is out of range: ${versionCode}`);
+  }
+
+  return versionCode;
+}
 
 function resolveSecretFile(params) {
   const fromEnv = process.env[params.envKey];
@@ -45,6 +71,7 @@ const variants = {
 };
 
 const variant = variants[appVariant] ?? variants.production;
+const nativeBuildVersionCode = getNativeBuildVersionCode(pkg.version);
 
 export default {
   expo: {
@@ -72,6 +99,7 @@ export default {
       ...(variant.googleServiceInfoPlist
         ? { googleServicesFile: variant.googleServiceInfoPlist }
         : {}),
+      buildNumber: String(nativeBuildVersionCode),
     },
     android: {
       adaptiveIcon: {
@@ -91,6 +119,7 @@ export default {
         "android.permission.CAMERA",
       ],
       package: variant.packageId,
+      versionCode: nativeBuildVersionCode,
       ...(variant.googleServicesFile ? { googleServicesFile: variant.googleServicesFile } : {}),
     },
     web: {
@@ -99,6 +128,13 @@ export default {
     },
     autolinking: {
       searchPaths: ["../../node_modules", "./node_modules"],
+      ...(isFdroidBuild
+        ? {
+            android: {
+              buildFromSource: [".*"],
+            },
+          }
+        : {}),
     },
     plugins: [
       "expo-router",
@@ -139,6 +175,17 @@ export default {
           },
         },
       ],
+      ...(isFdroidBuild
+        ? [
+            [
+              "expo-gradle-jvmargs",
+              {
+                xmx: "4096m",
+                maxMetaspace: "1024m",
+              },
+            ],
+          ]
+        : []),
     ],
     experiments: {
       typedRoutes: true,

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -3,7 +3,6 @@ const path = require("node:path");
 const pkg = require("./package.json");
 const appVariant = process.env.APP_VARIANT ?? "production";
 const isFdroidBuild = process.env.PASEO_FDROID_BUILD === "1";
-const nativeBuildVersionFloor = 1_000_000;
 
 function getNativeBuildVersionCode(version) {
   const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
@@ -20,7 +19,7 @@ function getNativeBuildVersionCode(version) {
     throw new Error(`Cannot derive collision-free Android versionCode from version: ${version}`);
   }
 
-  const versionCode = nativeBuildVersionFloor + major * 1_000_000 + minor * 1_000 + patch;
+  const versionCode = major * 1_000_000 + minor * 1_000 + patch;
 
   if (!Number.isSafeInteger(versionCode) || versionCode <= 0 || versionCode > 2_100_000_000) {
     throw new Error(`Derived Android versionCode is out of range: ${versionCode}`);
@@ -165,6 +164,13 @@ export default {
       ],
       "expo-audio",
       [
+        "expo-gradle-jvmargs",
+        {
+          xmx: "4096m",
+          maxMetaspace: "1024m",
+        },
+      ],
+      [
         "expo-build-properties",
         {
           android: {
@@ -175,17 +181,6 @@ export default {
           },
         },
       ],
-      ...(isFdroidBuild
-        ? [
-            [
-              "expo-gradle-jvmargs",
-              {
-                xmx: "4096m",
-                maxMetaspace: "1024m",
-              },
-            ],
-          ]
-        : []),
     ],
     experiments: {
       typedRoutes: true,

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -1,8 +1,51 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const pkg = require("./package.json");
+const withFdroidAutolinking = require("./plugins/with-fdroid-autolinking");
 const appVariant = process.env.APP_VARIANT ?? "production";
 const isFdroidBuild = process.env.PASEO_FDROID_BUILD === "1";
+
+const buildProfile = isFdroidBuild
+  ? {
+      androidPermissions: [
+        "RECORD_AUDIO",
+        "android.permission.RECORD_AUDIO",
+        "android.permission.MODIFY_AUDIO_SETTINGS",
+      ],
+      cameraPlugins: [],
+      fdroidPlugins: [withFdroidAutolinking],
+      notificationPlugins: [],
+      updates: { enabled: false },
+    }
+  : {
+      androidPermissions: [
+        "RECORD_AUDIO",
+        "android.permission.RECORD_AUDIO",
+        "android.permission.MODIFY_AUDIO_SETTINGS",
+        "CAMERA",
+        "android.permission.CAMERA",
+      ],
+      cameraPlugins: [
+        [
+          "expo-camera",
+          {
+            cameraPermission:
+              "Allow $(PRODUCT_NAME) to access your camera to scan pairing QR codes.",
+          },
+        ],
+      ],
+      fdroidPlugins: [],
+      notificationPlugins: [
+        [
+          "expo-notifications",
+          {
+            icon: "./assets/images/notification-icon.png",
+            color: "#20744A",
+          },
+        ],
+      ],
+      updates: {},
+    };
 
 function getNativeBuildVersionCode(version) {
   const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
@@ -87,6 +130,7 @@ export default {
     },
     updates: {
       url: "https://u.expo.dev/0e7f65ce-0367-46c8-a238-2b65963d235a",
+      ...buildProfile.updates,
     },
     ios: {
       supportsTablet: true,
@@ -110,13 +154,7 @@ export default {
       softwareKeyboardLayoutMode: "resize",
       // Allow HTTP connections for local network hosts (required for release builds)
       usesCleartextTraffic: true,
-      permissions: [
-        "RECORD_AUDIO",
-        "android.permission.RECORD_AUDIO",
-        "android.permission.MODIFY_AUDIO_SETTINGS",
-        "CAMERA",
-        "android.permission.CAMERA",
-      ],
+      permissions: buildProfile.androidPermissions,
       package: variant.packageId,
       versionCode: nativeBuildVersionCode,
       ...(variant.googleServicesFile ? { googleServicesFile: variant.googleServicesFile } : {}),
@@ -127,22 +165,10 @@ export default {
     },
     autolinking: {
       searchPaths: ["../../node_modules", "./node_modules"],
-      ...(isFdroidBuild
-        ? {
-            android: {
-              buildFromSource: [".*"],
-            },
-          }
-        : {}),
     },
     plugins: [
       "expo-router",
-      [
-        "expo-camera",
-        {
-          cameraPermission: "Allow $(PRODUCT_NAME) to access your camera to scan pairing QR codes.",
-        },
-      ],
+      ...buildProfile.cameraPlugins,
       [
         "expo-splash-screen",
         {
@@ -155,13 +181,7 @@ export default {
           },
         },
       ],
-      [
-        "expo-notifications",
-        {
-          icon: "./assets/images/notification-icon.png",
-          color: "#20744A",
-        },
-      ],
+      ...buildProfile.notificationPlugins,
       "expo-audio",
       [
         "expo-gradle-jvmargs",
@@ -181,6 +201,7 @@ export default {
           },
         },
       ],
+      ...buildProfile.fdroidPlugins,
     ],
     experiments: {
       typedRoutes: true,
@@ -188,6 +209,7 @@ export default {
       autolinkingModuleResolution: true,
     },
     extra: {
+      fdroidBuild: isFdroidBuild,
       router: {},
       eas: {
         projectId: "0e7f65ce-0367-46c8-a238-2b65963d235a",

--- a/packages/app/eas.json
+++ b/packages/app/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 14.0.0",
-    "appVersionSource": "remote"
+    "appVersionSource": "local"
   },
   "build": {
     "development": {
@@ -19,9 +19,6 @@
       "channel": "production",
       "env": {
         "APP_VARIANT": "production"
-      },
-      "android": {
-        "autoIncrement": "versionCode"
       }
     },
     "production-apk": {

--- a/packages/app/metro.config.cjs
+++ b/packages/app/metro.config.cjs
@@ -7,6 +7,11 @@ const projectRoot = __dirname;
 const appNodeModulesRoot = path.resolve(projectRoot, "node_modules");
 const appSrcRoot = path.resolve(projectRoot, "src");
 const relaySrcRoot = path.resolve(projectRoot, "../relay/src");
+const isFdroidBuild = process.env.PASEO_FDROID_BUILD === "1";
+const fdroidModuleOverrides = {
+  "expo-camera": path.resolve(appSrcRoot, "fdroid/expo-camera.tsx"),
+  "expo-notifications": path.resolve(appSrcRoot, "fdroid/expo-notifications.ts"),
+};
 const customWebPlatform = (process.env.PASEO_WEB_PLATFORM ?? "")
   .trim()
   .replace(/^\./, "")
@@ -72,6 +77,10 @@ function resolveWithCustomWebOverlay(context, moduleName, platform) {
 }
 
 config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (isFdroidBuild && platform === "android" && fdroidModuleOverrides[moduleName]) {
+    return resolveWithCustomWebOverlay(context, fdroidModuleOverrides[moduleName], platform);
+  }
+
   const origin = context.originModulePath;
   if (origin && origin.startsWith(relaySrcRoot) && moduleName.endsWith(".js")) {
     const tsModuleName = moduleName.replace(/\.js$/, ".ts");

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -128,6 +128,7 @@
     "eas-cli": "^16.24.1",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~10.0.0",
+    "expo-gradle-jvmargs": "^1.1.2",
     "jsdom": "^20.0.3",
     "material-icon-theme": "^5.32.0",
     "playwright": "^1.56.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -127,6 +127,7 @@
     "eas-cli": "^16.24.1",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~10.0.0",
+    "expo-gradle-jvmargs": "^1.1.2",
     "jsdom": "^20.0.3",
     "material-icon-theme": "^5.32.0",
     "playwright": "^1.56.1",

--- a/packages/app/plugins/with-fdroid-autolinking.js
+++ b/packages/app/plugins/with-fdroid-autolinking.js
@@ -1,0 +1,85 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const { withAppBuildGradle, withDangerousMod, withSettingsGradle } = require("expo/config-plugins");
+
+const EXCLUDED_ANDROID_MODULES = [
+  "expo-camera",
+  "expo-notifications",
+  "expo-dev-client",
+  "expo-dev-launcher",
+  "expo-dev-menu",
+  "expo-dev-menu-interface",
+];
+
+function withFdroidAutolinking(config) {
+  config = withDangerousMod(config, [
+    "android",
+    async (modConfig) => {
+      const packageJsonPath = path.join(modConfig.modRequest.projectRoot, "package.json");
+      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf8"));
+      const expo = packageJson.expo ?? {};
+      const autolinking = expo.autolinking ?? {};
+      const android = autolinking.android ?? {};
+      const fdroidPackageJson = {
+        ...packageJson,
+        expo: {
+          ...expo,
+          autolinking: {
+            ...autolinking,
+            android: {
+              ...android,
+              buildFromSource: [".*"],
+              exclude: EXCLUDED_ANDROID_MODULES,
+            },
+          },
+        },
+      };
+      const overlayRoot = path.join(modConfig.modRequest.platformProjectRoot, "fdroid-autolinking");
+
+      await fs.mkdir(overlayRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(overlayRoot, "package.json"),
+        `${JSON.stringify(fdroidPackageJson, null, 2)}\n`,
+      );
+      return modConfig;
+    },
+  ]);
+
+  config = withSettingsGradle(config, (modConfig) => {
+    const fdroidProjectRoot =
+      'expoAutolinking.projectRoot = new File(rootDir, "fdroid-autolinking")';
+    if (modConfig.modResults.contents.includes(fdroidProjectRoot)) {
+      return modConfig;
+    }
+
+    const useExpoModules = "expoAutolinking.useExpoModules()";
+    if (!modConfig.modResults.contents.includes(useExpoModules)) {
+      throw new Error("Could not configure F-Droid Expo autolinking in settings.gradle");
+    }
+
+    modConfig.modResults.contents = modConfig.modResults.contents.replace(
+      useExpoModules,
+      `${fdroidProjectRoot}\n${useExpoModules}`,
+    );
+    return modConfig;
+  });
+
+  return withAppBuildGradle(config, (modConfig) => {
+    if (modConfig.modResults.contents.includes("dependenciesInfo {")) {
+      return modConfig;
+    }
+
+    const androidBlock = "android {";
+    if (!modConfig.modResults.contents.includes(androidBlock)) {
+      throw new Error("Could not disable F-Droid dependency metadata in app/build.gradle");
+    }
+
+    modConfig.modResults.contents = modConfig.modResults.contents.replace(
+      androidBlock,
+      `${androidBlock}\n    dependenciesInfo {\n        includeInApk = false\n        includeInBundle = false\n    }`,
+    );
+    return modConfig;
+  });
+}
+
+module.exports = withFdroidAutolinking;

--- a/packages/app/src/components/add-host-method-modal.tsx
+++ b/packages/app/src/components/add-host-method-modal.tsx
@@ -4,7 +4,8 @@ import { Pressable, Text, View } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { QrCode, Link2, ClipboardPaste } from "lucide-react-native";
 import { AdaptiveModalSheet, type SheetHeader } from "./adaptive-modal-sheet";
-import { isFdroidBuild, isNative } from "@/constants/platform";
+import { isFdroidBuild } from "@/constants/build-profile";
+import { isNative } from "@/constants/platform";
 
 const styles = StyleSheet.create((theme) => ({
   option: {

--- a/packages/app/src/components/add-host-method-modal.tsx
+++ b/packages/app/src/components/add-host-method-modal.tsx
@@ -4,7 +4,7 @@ import { Pressable, Text, View } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { QrCode, Link2, ClipboardPaste } from "lucide-react-native";
 import { AdaptiveModalSheet, type SheetHeader } from "./adaptive-modal-sheet";
-import { isNative } from "@/constants/platform";
+import { isFdroidBuild, isNative } from "@/constants/platform";
 
 const styles = StyleSheet.create((theme) => ({
   option: {
@@ -86,7 +86,7 @@ export function AddHostMethodModal({
         </View>
       </Pressable>
 
-      {isNative ? (
+      {isNative && !isFdroidBuild ? (
         <Pressable
           style={styles.option}
           onPress={handleScan}

--- a/packages/app/src/components/welcome-screen.tsx
+++ b/packages/app/src/components/welcome-screen.tsx
@@ -15,7 +15,8 @@ import { formatVersionWithPrefix } from "@/desktop/updates/desktop-updates";
 import { buildOpenProjectRoute } from "@/utils/host-routes";
 import { PaseoLogo } from "@/components/icons/paseo-logo";
 import { openExternalUrl } from "@/utils/open-external-url";
-import { isFdroidBuild, isWeb, isNative } from "@/constants/platform";
+import { isFdroidBuild } from "@/constants/build-profile";
+import { isWeb, isNative } from "@/constants/platform";
 
 interface WelcomeAction {
   key: "scan-qr" | "direct-connection" | "paste-pairing-link";

--- a/packages/app/src/components/welcome-screen.tsx
+++ b/packages/app/src/components/welcome-screen.tsx
@@ -15,7 +15,7 @@ import { formatVersionWithPrefix } from "@/desktop/updates/desktop-updates";
 import { buildOpenProjectRoute } from "@/utils/host-routes";
 import { PaseoLogo } from "@/components/icons/paseo-logo";
 import { openExternalUrl } from "@/utils/open-external-url";
-import { isWeb, isNative } from "@/constants/platform";
+import { isFdroidBuild, isWeb, isNative } from "@/constants/platform";
 
 interface WelcomeAction {
   key: "scan-qr" | "direct-connection" | "paste-pairing-link";
@@ -201,51 +201,52 @@ export function WelcomeScreen({ onHostAdded }: WelcomeScreenProps) {
     [onHostAdded, finishOnboarding],
   );
 
-  const actions: WelcomeAction[] = isWeb
-    ? [
-        {
-          key: "direct-connection",
-          label: t("pairing.connectionMethods.direct.title"),
-          testID: "welcome-direct-connection",
-          primary: true,
-          icon: Link2,
-          onPress: handleOpenDirect,
-        },
-        {
-          key: "paste-pairing-link",
-          label: t("pairing.connectionMethods.pasteLink.title"),
-          testID: "welcome-paste-pairing-link",
-          primary: false,
-          icon: ClipboardPaste,
-          onPress: handleOpenPasteLink,
-        },
-      ]
-    : [
-        {
-          key: "scan-qr",
-          label: t("pairing.connectionMethods.scanQr.title"),
-          testID: "welcome-scan-qr",
-          primary: true,
-          icon: QrCode,
-          onPress: handleScanQr,
-        },
-        {
-          key: "direct-connection",
-          label: t("pairing.connectionMethods.direct.title"),
-          testID: "welcome-direct-connection",
-          primary: false,
-          icon: Link2,
-          onPress: handleOpenDirect,
-        },
-        {
-          key: "paste-pairing-link",
-          label: t("pairing.connectionMethods.pasteLink.title"),
-          testID: "welcome-paste-pairing-link",
-          primary: false,
-          icon: ClipboardPaste,
-          onPress: handleOpenPasteLink,
-        },
-      ];
+  const actions: WelcomeAction[] =
+    isWeb || isFdroidBuild
+      ? [
+          {
+            key: "direct-connection",
+            label: t("pairing.connectionMethods.direct.title"),
+            testID: "welcome-direct-connection",
+            primary: true,
+            icon: Link2,
+            onPress: handleOpenDirect,
+          },
+          {
+            key: "paste-pairing-link",
+            label: t("pairing.connectionMethods.pasteLink.title"),
+            testID: "welcome-paste-pairing-link",
+            primary: false,
+            icon: ClipboardPaste,
+            onPress: handleOpenPasteLink,
+          },
+        ]
+      : [
+          {
+            key: "scan-qr",
+            label: t("pairing.connectionMethods.scanQr.title"),
+            testID: "welcome-scan-qr",
+            primary: true,
+            icon: QrCode,
+            onPress: handleScanQr,
+          },
+          {
+            key: "direct-connection",
+            label: t("pairing.connectionMethods.direct.title"),
+            testID: "welcome-direct-connection",
+            primary: false,
+            icon: Link2,
+            onPress: handleOpenDirect,
+          },
+          {
+            key: "paste-pairing-link",
+            label: t("pairing.connectionMethods.pasteLink.title"),
+            testID: "welcome-paste-pairing-link",
+            primary: false,
+            icon: ClipboardPaste,
+            onPress: handleOpenPasteLink,
+          },
+        ];
 
   const scrollContentContainerStyle = useMemo(
     () => [styles.container, { paddingBottom: theme.spacing[6] + insets.bottom }],

--- a/packages/app/src/constants/build-profile.ts
+++ b/packages/app/src/constants/build-profile.ts
@@ -1,0 +1,4 @@
+import Constants from "expo-constants";
+
+/** F-Droid build without proprietary camera, notification, or OTA dependencies. */
+export const isFdroidBuild = Constants.expoConfig?.extra?.fdroidBuild === true;

--- a/packages/app/src/constants/platform.ts
+++ b/packages/app/src/constants/platform.ts
@@ -1,3 +1,4 @@
+import Constants from "expo-constants";
 import { Platform } from "react-native";
 import { isElectronRuntime, isElectronRuntimeMac } from "@/desktop/host";
 
@@ -27,6 +28,9 @@ export const isNative = Platform.OS !== "web";
 
 /** Development build/runtime — true in Metro dev bundles, false in production. */
 export const isDev = Boolean((globalThis as { __DEV__?: boolean }).__DEV__);
+
+/** F-Droid build without proprietary camera, notification, or OTA dependencies. */
+export const isFdroidBuild = Constants.expoConfig?.extra?.fdroidBuild === true;
 
 // ---------------------------------------------------------------------------
 // Electron detection (cached — only caches `true`, keeps checking if false

--- a/packages/app/src/constants/platform.ts
+++ b/packages/app/src/constants/platform.ts
@@ -1,4 +1,3 @@
-import Constants from "expo-constants";
 import { Platform } from "react-native";
 import { isElectronRuntime, isElectronRuntimeMac } from "@/desktop/host";
 
@@ -28,9 +27,6 @@ export const isNative = Platform.OS !== "web";
 
 /** Development build/runtime — true in Metro dev bundles, false in production. */
 export const isDev = Boolean((globalThis as { __DEV__?: boolean }).__DEV__);
-
-/** F-Droid build without proprietary camera, notification, or OTA dependencies. */
-export const isFdroidBuild = Constants.expoConfig?.extra?.fdroidBuild === true;
 
 // ---------------------------------------------------------------------------
 // Electron detection (cached — only caches `true`, keeps checking if false

--- a/packages/app/src/fdroid/expo-camera.tsx
+++ b/packages/app/src/fdroid/expo-camera.tsx
@@ -1,0 +1,18 @@
+const DENIED_CAMERA_PERMISSION = {
+  canAskAgain: false,
+  expires: "never",
+  granted: false,
+  status: "denied",
+} as const;
+
+async function requestCameraPermission() {
+  return DENIED_CAMERA_PERMISSION;
+}
+
+export function useCameraPermissions() {
+  return [DENIED_CAMERA_PERMISSION, requestCameraPermission] as const;
+}
+
+export function CameraView(): null {
+  return null;
+}

--- a/packages/app/src/fdroid/expo-notifications.ts
+++ b/packages/app/src/fdroid/expo-notifications.ts
@@ -1,0 +1,40 @@
+const DENIED_NOTIFICATION_PERMISSION = {
+  canAskAgain: false,
+  expires: "never",
+  granted: false,
+  status: "denied",
+} as const;
+
+export const PermissionStatus = {
+  DENIED: "denied",
+  GRANTED: "granted",
+  UNDETERMINED: "undetermined",
+} as const;
+
+export const AndroidImportance = { DEFAULT: 3 } as const;
+
+export async function getPermissionsAsync() {
+  return DENIED_NOTIFICATION_PERMISSION;
+}
+
+export async function requestPermissionsAsync() {
+  return DENIED_NOTIFICATION_PERMISSION;
+}
+
+export async function getExpoPushTokenAsync() {
+  return { data: "" };
+}
+
+export async function setNotificationChannelAsync() {
+  return null;
+}
+
+export function setNotificationHandler(): void {}
+
+export function addNotificationResponseReceivedListener() {
+  return { remove() {} };
+}
+
+export async function getLastNotificationResponseAsync() {
+  return null;
+}


### PR DESCRIPTION
### Linked issue

None found.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Makes F-Droid Android builds reproducible upstream instead of relying on downstream package removal and generated-file patches.

- derives deterministic Android and iOS build numbers from the package version and uses EAS local versioning
- adds a `PASEO_FDROID_BUILD=1` profile that builds Expo modules from source, excludes camera, Firebase notifications, and Expo development-client native modules, and disables OTA updates and Gradle dependency metadata
- substitutes Android JavaScript stubs for the excluded camera and notification packages and removes QR-only entry points from the F-Droid UI
- keeps normal Android, iOS, web, and EAS builds unchanged
- documents the serial, daemon-free source-build command so Gradle cannot exhaust the host through parallel workers

Risk surface: EAS local versioning applies to iOS as well as Android, so the next store release should confirm both stores accept the deterministic build numbers. The F-Droid profile intentionally has no QR scanning or push notifications; direct and pasted-link pairing remain available.

### How did you verify it

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- clean flagged Expo Android prebuild
- `PASEO_FDROID_BUILD=1 ./gradlew assembleRelease --no-daemon --max-workers=1 -Dorg.gradle.parallel=false` (1,915 tasks, successful)
- inspected the 133 MB release APK: no `com.google.android.gms`, Barhopper, Firebase, ML Kit, or excluded Expo camera/notifications/dev-client native classes
- attempted a headless AVD install; the host has no KVM and software emulation did not start Android's package service within the bounded window, so the APK could not be installed there

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [x] UI changes include screenshots or video for every affected platform (not applicable: build-profile-only conditional UI)
- [x] Tests added or updated where it made sense (verified through clean native generation, actual release assembly, and APK inspection)
