### PR TITLE
fix(schedule): give scheduled new agents a workspace

### DIFF
--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -786,12 +786,20 @@ export async function createPaseoDaemon(
   });
   await loopService.initialize();
   logger.info({ elapsed: elapsed() }, "Loop service initialized");
+  const ensureWorkspaceForCreateExternal = async (cwd: string): Promise<string> => {
+    const workspace = await createLocalCheckoutWorkspace(
+      { cwd },
+      { projectRegistry, workspaceRegistry, workspaceGitService },
+    );
+    return workspace.workspaceId;
+  };
   const scheduleService = new ScheduleService({
     paseoHome: config.paseoHome,
     logger,
     agentManager,
     agentStorage,
     providerSnapshotManager,
+    ensureWorkspaceForCreate: ensureWorkspaceForCreateExternal,
   });
   await scheduleService.start();
   agentManager.setAgentArchivedCallback(async (agentId) => {
@@ -831,13 +839,6 @@ export async function createPaseoDaemon(
   // arrive with a worktree path and no workspaceId (old clients / CLI).
   const findWorkspaceIdForCwdExternal = async (cwd: string): Promise<string | null> => {
     return resolveWorkspaceIdForPath(cwd, await workspaceRegistry.list());
-  };
-  const ensureWorkspaceForCreateExternal = async (cwd: string): Promise<string> => {
-    const workspace = await createLocalCheckoutWorkspace(
-      { cwd },
-      { projectRegistry, workspaceRegistry, workspaceGitService },
-    );
-    return workspace.workspaceId;
   };
   const listActiveWorkspacesExternal = async (): Promise<ActiveWorkspaceRef[]> => {
     const workspaces = await workspaceRegistry.list();

--- a/packages/server/src/server/schedule/service.test.ts
+++ b/packages/server/src/server/schedule/service.test.ts
@@ -254,6 +254,51 @@ describe("ScheduleService", () => {
     expect(storedAgent?.title).toBe("Audit flaky checkout flow");
   });
 
+  test("stamps the resolved workspaceId on scheduled new agents", async () => {
+    const manager = new AgentManager({
+      logger: createTestLogger(),
+      clients: createTestAgentClients(),
+      registry: agentStorage,
+    });
+    let capturedCwd: string | undefined;
+    const service = new ScheduleService({
+      paseoHome: tempDir,
+      logger: createTestLogger(),
+      agentManager: manager,
+      agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
+      now: () => now,
+      ensureWorkspaceForCreate: async (cwd) => {
+        capturedCwd = cwd;
+        return "ws-scheduled";
+      },
+    });
+
+    const created = await service.create({
+      prompt: "Respond with exactly hello",
+      cadence: { type: "every", everyMs: 60_000 },
+      target: {
+        type: "new-agent",
+        config: {
+          provider: "claude",
+          cwd: tempDir,
+          approvalPolicy: "never",
+        },
+      },
+      maxRuns: 1,
+    });
+
+    now = new Date("2026-01-01T00:01:00.000Z");
+    await service.tick();
+
+    const inspected = await service.inspect(created.id);
+    const agentId = inspected.runs[0]?.agentId;
+    expect(agentId).toMatch(/^[0-9a-f-]{36}$/);
+    const storedAgent = await agentStorage.get(agentId!);
+    expect(storedAgent?.workspaceId).toBe("ws-scheduled");
+    expect(capturedCwd).toBe(tempDir);
+  });
+
   test("shows scheduled new-agent prompts as normal user turns", async () => {
     class PromptEchoScheduleSession implements AgentSession {
       readonly provider = "claude";

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -147,6 +147,7 @@ export interface ScheduleServiceOptions {
   agentManager: AgentManager;
   agentStorage: AgentStorage;
   providerSnapshotManager: CreateConfigResolver;
+  ensureWorkspaceForCreate?: (cwd: string) => Promise<string>;
   now?: () => Date;
   runner?: (schedule: StoredSchedule, runId: string) => Promise<ScheduleExecutionResult>;
 }
@@ -157,6 +158,7 @@ export class ScheduleService {
   private readonly agentManager: AgentManager;
   private readonly agentStorage: AgentStorage;
   private readonly createConfigResolver: CreateConfigResolver;
+  private readonly ensureWorkspaceForCreate?: (cwd: string) => Promise<string>;
   private readonly now: () => Date;
   private readonly runner: (
     schedule: StoredSchedule,
@@ -171,6 +173,7 @@ export class ScheduleService {
     this.agentManager = options.agentManager;
     this.agentStorage = options.agentStorage;
     this.createConfigResolver = options.providerSnapshotManager;
+    this.ensureWorkspaceForCreate = options.ensureWorkspaceForCreate;
     this.now = options.now ?? (() => new Date());
     this.runner = options.runner ?? ((schedule, runId) => this.executeSchedule(schedule, runId));
   }
@@ -525,6 +528,25 @@ export class ScheduleService {
     await this.store.put(updated);
   }
 
+  private async resolveScheduledWorkspaceId(
+    cwd: string,
+    scheduleId: string,
+    runId: string,
+  ): Promise<string | undefined> {
+    if (!this.ensureWorkspaceForCreate) {
+      return undefined;
+    }
+    try {
+      return await this.ensureWorkspaceForCreate(cwd);
+    } catch (error) {
+      this.logger.warn(
+        { err: error, scheduleId, runId, cwd },
+        "Failed to resolve workspace for scheduled agent; continuing without workspace association",
+      );
+      return undefined;
+    }
+  }
+
   private async executeSchedule(
     schedule: StoredSchedule,
     runId: string,
@@ -591,10 +613,12 @@ export class ScheduleService {
       "paseo.schedule-id": schedule.id,
       "paseo.schedule-run": runId,
     };
+    const workspaceId = await this.resolveScheduledWorkspaceId(targetConfig.cwd, schedule.id, runId);
     const agent = await this.agentManager.createAgent(config, undefined, {
       labels,
       initialPrompt: schedule.prompt,
       initialTitle: provisionalTitle,
+      workspaceId,
     });
     let result;
     try {


### PR DESCRIPTION
### Linked issue

None. Reproduced locally (steps below).

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

A `new-agent` schedule creates its agent by calling `agentManager.createAgent`
directly from `ScheduleService.executeSchedule`, with no `workspaceId`.

That was harmless while workspace membership was keyed by directory — a scheduled
agent showed up under its cwd's workspace regardless. Commit
[`9966e49`](https://github.com/getpaseo/paseo/commit/9966e49) ("Key workspace
status and ownership by ID, not directory") made the `workspaceId` field
authoritative and added a one-time backfill that stamps pre-existing agents by
cwd. The schedule path was never updated to stamp `workspaceId` at create time,
so any scheduled agent created **after** that backfill has no workspace: it shows
up in neither the active nor the archived session list (both keyed by workspace
now) and is only reachable by id via `paseo inspect <id>`. For a recurring
schedule whose agent is meant to be found and unarchived later, it effectively
disappears.

The fix resolves the workspace from the target `cwd` before creating the agent —
the same cwd→workspace resolution the other create paths and the backfill use —
and passes the id through to `createAgent`. If resolution throws it logs and
continues without a workspace, so a workspace hiccup cannot take down an
otherwise healthy run.

### How did you verify it

- Reproduced on a throwaway schedule: `paseo schedule create ... --target
  new-agent --run-now`. The run reports `succeeded`, but the resulting agent has
  no `workspaceId`, is absent from `paseo ls --all`, and is only reachable via
  `paseo inspect <id>`. With this change the agent picks up the cwd's workspace
  and lists normally.
- Added a regression test that asserts the target cwd is forwarded to
  `ensureWorkspaceForCreate` and the returned id is stamped on the stored agent.

### Note

`loop-service.ts` creates its worker and verifier agents the same way (a bare
`agentManager.createAgent` with no `workspaceId`), so loop agents likely share
this gap. Left out here to keep the change focused on the reported schedule case.
