### PR TITLE
feat(schedule): opt new-agent schedules out of auto-archive (keepAlive)

### DIFF
--- a/packages/cli/src/commands/schedule/create.ts
+++ b/packages/cli/src/commands/schedule/create.ts
@@ -19,6 +19,7 @@ export interface ScheduleCreateOptions extends ScheduleCommandOptions {
   provider?: string;
   mode?: string;
   cwd?: string;
+  keepAlive?: boolean;
   maxRuns?: string;
   expiresIn?: string;
   runNow?: boolean;
@@ -41,6 +42,7 @@ export async function runCreateCommand(
     provider: options.provider,
     mode: options.mode,
     cwd: options.cwd,
+    keepAlive: options.keepAlive,
     host: options.host,
     maxRuns: options.maxRuns,
     expiresIn: options.expiresIn,

--- a/packages/cli/src/commands/schedule/index.ts
+++ b/packages/cli/src/commands/schedule/index.ts
@@ -33,6 +33,10 @@ export function createScheduleCommand(): Command {
         "Provider-specific mode (e.g. claude bypassPermissions, opencode build)",
       )
       .option("--cwd <path>", "Working directory (default: current; required with --host)")
+      .option(
+        "--keep-alive",
+        "Keep the spawned agent after each run instead of archiving it (new-agent target)",
+      )
       .option("--run-now", "Fire one immediate run on creation (only with --cron)")
       .option("--no-run-now", "Wait the full interval before the first run (only with --every)")
       .option("--max-runs <n>", "Maximum number of runs")

--- a/packages/cli/src/commands/schedule/shared.ts
+++ b/packages/cli/src/commands/schedule/shared.ts
@@ -136,6 +136,7 @@ export function parseScheduleCreateInput(options: {
   provider?: string;
   mode?: string;
   cwd?: string;
+  keepAlive?: boolean;
   host?: string;
   maxRuns?: string;
   expiresIn?: string;
@@ -182,6 +183,7 @@ export function parseScheduleCreateInput(options: {
         cwd: cwdInput ?? process.cwd(),
         ...(resolvedProviderModel.model ? { model: resolvedProviderModel.model } : {}),
         ...(modeId ? { modeId } : {}),
+        ...(options.keepAlive ? { keepAlive: true } : {}),
       },
     };
   };

--- a/packages/cli/src/commands/schedule/shared.ts
+++ b/packages/cli/src/commands/schedule/shared.ts
@@ -108,7 +108,7 @@ function resolveScheduleTarget(args: {
   if (hasExplicitNewAgentOption) {
     throw {
       code: "INVALID_TARGET",
-      message: "--provider/--mode can only be used with a new-agent target",
+      message: "--provider/--mode/--keep-alive can only be used with a new-agent target",
       details: "Use --target new-agent or omit --target to create a new agent schedule",
     } satisfies CommandError;
   }
@@ -171,7 +171,8 @@ export function parseScheduleCreateInput(options: {
 
   const targetValue = options.target?.trim();
   const modeId = options.mode?.trim();
-  const hasExplicitNewAgentOption = options.provider !== undefined || options.mode !== undefined;
+  const hasExplicitNewAgentOption =
+    options.provider !== undefined || options.mode !== undefined || options.keepAlive === true;
   const createNewAgentTarget = (): ScheduleTarget => {
     const resolvedProviderModel = resolveProviderAndModel({
       provider: options.provider,

--- a/packages/protocol/src/schedule/types.ts
+++ b/packages/protocol/src/schedule/types.ts
@@ -45,6 +45,11 @@ export const ScheduleTargetSchema = z.discriminatedUnion("type", [
         .optional(),
       systemPrompt: z.string().optional(),
       mcpServers: z.record(z.string(), z.unknown()).optional(),
+      // When true, the scheduler leaves the spawned agent in place after a
+      // successful run instead of archiving it, so agents whose work outlives a
+      // single run turn (self-scheduled follow-ups, polling, multi-phase jobs)
+      // can keep going. Defaults to false (archive after each run).
+      keepAlive: z.boolean().optional(),
     }),
   }),
 ]);

--- a/packages/server/src/server/schedule/service.test.ts
+++ b/packages/server/src/server/schedule/service.test.ts
@@ -250,7 +250,7 @@ describe("ScheduleService", () => {
     const inspected = await service.inspect(created.id);
     const agentId = inspected.runs[0]?.agentId;
     const storedAgent = await agentStorage.get(agentId!);
-    expect(storedAgent?.archivedAt).toBeTruthy();
+    expect(storedAgent?.archivedAt).toEqual(expect.any(String));
   });
 
   test("keeps the scheduled new agent alive when keepAlive is set", async () => {

--- a/packages/server/src/server/schedule/service.test.ts
+++ b/packages/server/src/server/schedule/service.test.ts
@@ -215,6 +215,84 @@ describe("ScheduleService", () => {
     );
   });
 
+  test("archives the scheduled new agent after a run by default", async () => {
+    const manager = new AgentManager({
+      logger: createTestLogger(),
+      clients: createTestAgentClients(),
+      registry: agentStorage,
+    });
+    const service = new ScheduleService({
+      paseoHome: tempDir,
+      logger: createTestLogger(),
+      agentManager: manager,
+      agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
+      now: () => now,
+    });
+
+    const created = await service.create({
+      prompt: "Respond with exactly hello",
+      cadence: { type: "every", everyMs: 60_000 },
+      target: {
+        type: "new-agent",
+        config: {
+          provider: "claude",
+          cwd: tempDir,
+          approvalPolicy: "never",
+        },
+      },
+      maxRuns: 1,
+    });
+
+    now = new Date("2026-01-01T00:01:00.000Z");
+    await service.tick();
+
+    const inspected = await service.inspect(created.id);
+    const agentId = inspected.runs[0]?.agentId;
+    const storedAgent = await agentStorage.get(agentId!);
+    expect(storedAgent?.archivedAt).toBeTruthy();
+  });
+
+  test("keeps the scheduled new agent alive when keepAlive is set", async () => {
+    const manager = new AgentManager({
+      logger: createTestLogger(),
+      clients: createTestAgentClients(),
+      registry: agentStorage,
+    });
+    const service = new ScheduleService({
+      paseoHome: tempDir,
+      logger: createTestLogger(),
+      agentManager: manager,
+      agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
+      now: () => now,
+    });
+
+    const created = await service.create({
+      prompt: "Respond with exactly hello",
+      cadence: { type: "every", everyMs: 60_000 },
+      target: {
+        type: "new-agent",
+        config: {
+          provider: "claude",
+          cwd: tempDir,
+          approvalPolicy: "never",
+          keepAlive: true,
+        },
+      },
+      maxRuns: 1,
+    });
+
+    now = new Date("2026-01-01T00:01:00.000Z");
+    await service.tick();
+
+    const inspected = await service.inspect(created.id);
+    expect(inspected.runs[0]?.status).toBe("succeeded");
+    const agentId = inspected.runs[0]?.agentId;
+    const storedAgent = await agentStorage.get(agentId!);
+    expect(storedAgent?.archivedAt ?? null).toBeNull();
+  });
+
   test("titles scheduled new agents from the schedule prompt", async () => {
     const manager = new AgentManager({
       logger: createTestLogger(),

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -611,7 +611,9 @@ export class ScheduleService {
       throw error;
     }
 
-    await this.agentManager.archiveAgent(agent.id);
+    if (!targetConfig.keepAlive) {
+      await this.agentManager.archiveAgent(agent.id);
+    }
     const timelineText = curateAgentActivity(result.timeline);
     return {
       agentId: agent.id,


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

A `new-agent` schedule archives the agent it spawns as soon as the first run
settles (`ScheduleService.executeSchedule`). That is the right default for
one-shot jobs: run a prompt on a cron, do not leave agents lying around.

It does not fit agents whose work outlives a single run turn. Some scheduled
agents kick off long-running or asynchronous work and then go idle, intending to
wake themselves later to continue or report: self-scheduled follow-ups, polling
external state, multi-phase jobs that report over time. Archiving closes the
agent's process and drops those in-memory continuations, so the job is cut off
after the first turn, with no way to opt out.

This adds an opt-in `keepAlive` flag on the new-agent target config, surfaced on
the CLI as `paseo schedule create --keep-alive`. When set, the scheduler leaves
the agent in place after a successful run instead of archiving it, so the agent
can drive its own lifecycle. The default is unchanged. A failed run still
archives the agent so broken ones do not accumulate.

### How did you verify it

- Added unit tests covering both paths: the default still archives the spawned
  agent after a run, and `keepAlive: true` leaves it un-archived.
- I have not run the full local toolchain (format / typecheck / lint / vitest)
  in this environment, so I am relying on CI for that. The change follows the
  existing schedule schema and create path; the flag lives on the protocol
  new-agent config, which the RPC create schema already reuses.

### Notes

- Scope kept to the CLI + daemon path. The MCP `create_schedule` tool and the
  app's schedule UI are untouched; both could surface `keepAlive` later as a
  small addition since the protocol and service already support it.
- The `agent` target (reuse an existing agent) already never archives, so the
  flag is only meaningful for `new-agent`.
