### PR TITLE
feat(server): support worktree include files

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -29,6 +29,7 @@ Root checkout dev is intentionally split across terminals:
 - **Repo dev scripts** default to `$ROOT/.dev/paseo-home`, where `$ROOT` is the current checkout or worktree root. This keeps all dev state scoped to the checkout instead of the packaged desktop app.
 - **`npm run cli -- ...`** runs through the same dev-home wrapper as the dev scripts, so the in-repo CLI automatically targets the current checkout's `.dev/paseo-home` and configured dev daemon endpoint.
 - **Paseo-created worktrees** seed `$PASEO_WORKTREE_PATH/.dev/paseo-home` from `$PASEO_SOURCE_CHECKOUT_PATH/.dev/paseo-home` by copying durable JSON metadata. Runtime files like pid files, sockets, and logs are not copied.
+- **Paseo-created worktrees** also read `.worktreeinclude` from the source checkout root. Listed relative files, folders, and glob patterns such as `**/.runtime.env` are copied into the new worktree before `worktree.setup`; blank lines and whole-line `#` comments are ignored, and absolute paths, `..`, or `.git` entries are rejected.
 - **This repo's worktree setup** also best-effort seeds `packages/app/ios` and the newest `.dev/ios-build` entry from the source checkout so iOS simulator services can reuse native project and Xcode cache state when it is safe enough to do so.
 
 Override knobs:

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -1010,6 +1010,101 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
 
       expect(existsSync(join(result.worktreePath, "paseo.json"))).toBe(false);
     });
+
+    it("copies .worktreeinclude files and folders before setup runs", async () => {
+      writeFileSync(
+        join(repoDir, ".worktreeinclude"),
+        [
+          "# local worktree seed files",
+          ".credentials.local.json",
+          "**/.runtime.env",
+          ".cache-dev/**",
+          ".tool-state/**",
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(join(repoDir, ".credentials.local.json"), '{"secret":true}\n');
+      writeFileSync(join(repoDir, ".runtime.env"), "ROOT_RUNTIME=local\n");
+      mkdirSync(join(repoDir, "packages", "api"), { recursive: true });
+      writeFileSync(join(repoDir, "packages", "api", ".runtime.env"), "API_RUNTIME=local\n");
+      mkdirSync(join(repoDir, ".cache-dev", "state"), { recursive: true });
+      writeFileSync(join(repoDir, ".cache-dev", "state", "snapshot.txt"), "cache-state\n");
+      mkdirSync(join(repoDir, ".tool-state", "runtime"), { recursive: true });
+      writeFileSync(join(repoDir, ".tool-state", "runtime", "config.json"), '{"local":true}\n');
+      writeFileSync(
+        join(repoDir, "paseo.json"),
+        JSON.stringify({ worktree: { setup: "cat packages/api/.runtime.env > setup-env.log" } }),
+      );
+
+      const result = await createLegacyWorktreeForTest({
+        cwd: repoDir,
+        worktreeSlug: "include-local-files",
+        source: { kind: "branch-off", baseBranch: "main", branchName: "feature/include" },
+        runSetup: true,
+        paseoHome,
+      });
+
+      expect(readFileSync(join(result.worktreePath, ".credentials.local.json"), "utf8")).toBe(
+        '{"secret":true}\n',
+      );
+      expect(readFileSync(join(result.worktreePath, ".runtime.env"), "utf8")).toBe(
+        "ROOT_RUNTIME=local\n",
+      );
+      expect(
+        readFileSync(join(result.worktreePath, "packages", "api", ".runtime.env"), "utf8"),
+      ).toBe("API_RUNTIME=local\n");
+      expect(readFileSync(join(result.worktreePath, "setup-env.log"), "utf8")).toBe(
+        "API_RUNTIME=local\n",
+      );
+      expect(
+        readFileSync(join(result.worktreePath, ".cache-dev", "state", "snapshot.txt"), "utf8"),
+      ).toBe("cache-state\n");
+      expect(
+        readFileSync(join(result.worktreePath, ".tool-state", "runtime", "config.json"), "utf8"),
+      ).toBe('{"local":true}\n');
+    });
+
+    it("rejects unsafe .worktreeinclude entries", async () => {
+      writeFileSync(join(repoDir, ".worktreeinclude"), "../outside.txt\n");
+
+      await expect(
+        createLegacyWorktreeForTest({
+          cwd: repoDir,
+          worktreeSlug: "unsafe-include",
+          source: { kind: "branch-off", baseBranch: "main", branchName: "feature/unsafe" },
+          runSetup: false,
+          paseoHome,
+        }),
+      ).rejects.toThrow("Invalid .worktreeinclude entry '../outside.txt'");
+    });
+
+    it("reports unmatched recursive .worktreeinclude folders clearly", async () => {
+      const projectHash = await deriveWorktreeProjectHash(repoDir);
+      const expectedWorktreePath = join(
+        paseoHome,
+        "worktrees",
+        projectHash,
+        "missing-include-folder",
+      );
+      writeFileSync(join(repoDir, ".worktreeinclude"), ".missing-cache/**\n");
+
+      await expect(
+        createLegacyWorktreeForTest({
+          cwd: repoDir,
+          worktreeSlug: "missing-include-folder",
+          source: { kind: "branch-off", baseBranch: "main", branchName: "feature/missing-include" },
+          runSetup: false,
+          paseoHome,
+        }),
+      ).rejects.toThrow("No paths matched .worktreeinclude entry '.missing-cache/**'");
+
+      const worktreeList = execFileSync("git", ["worktree", "list", "--porcelain"], {
+        cwd: repoDir,
+        encoding: "utf8",
+      });
+      expect(existsSync(expectedWorktreePath)).toBe(false);
+      expect(worktreeList).not.toContain(expectedWorktreePath);
+    });
   });
 
   describe("paseo worktree manager", () => {

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1,7 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { existsSync, mkdirSync, realpathSync, rmSync, statSync } from "fs";
-import { copyFile, rm, stat } from "fs/promises";
+import { copyFile, cp, mkdir, readFile, readdir, rm, stat } from "fs/promises";
 import { join, basename, dirname, isAbsolute, resolve, sep } from "path";
 import net from "node:net";
 import { createHash } from "node:crypto";
@@ -39,6 +39,7 @@ const execFileAsync = promisify(execFile);
 const READ_ONLY_GIT_ENV = {
   GIT_OPTIONAL_LOCKS: "0",
 } as const;
+const WORKTREE_INCLUDE_FILE_NAME = ".worktreeinclude";
 
 export interface WorktreeConfig {
   branchName: string;
@@ -628,14 +629,7 @@ export async function runWorktreeSetupCommands(options: {
 
     if (result.exitCode !== 0) {
       if (options.cleanupOnFailure) {
-        try {
-          await runGitCommand(["worktree", "remove", options.worktreePath, "--force"], {
-            cwd: options.worktreePath,
-            timeout: 120_000,
-          });
-        } catch {
-          rmSync(options.worktreePath, { recursive: true, force: true });
-        }
+        await removeFailedWorktree(options.worktreePath);
       }
       throw new WorktreeSetupError(
         `Worktree setup command failed: ${cmd}\n${result.stderr}`.trim(),
@@ -1165,6 +1159,205 @@ async function removeDirectoryWithRetries(path: string): Promise<void> {
   }
 }
 
+async function removeFailedWorktree(worktreePath: string): Promise<void> {
+  try {
+    await runGitCommand(["worktree", "remove", worktreePath, "--force"], {
+      cwd: worktreePath,
+      timeout: 120_000,
+    });
+  } catch {
+    rmSync(worktreePath, { recursive: true, force: true });
+  }
+}
+
+interface WorktreeIncludeEntry {
+  raw: string;
+  path: string;
+}
+
+function parseWorktreeIncludeEntries(contents: string): WorktreeIncludeEntry[] {
+  return contents
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"))
+    .map(normalizeWorktreeIncludeEntry);
+}
+
+function normalizeWorktreeIncludeEntry(entry: string): WorktreeIncludeEntry {
+  const fail = (reason: string): never => {
+    throw new Error(`Invalid ${WORKTREE_INCLUDE_FILE_NAME} entry '${entry}': ${reason}`);
+  };
+
+  if (isAbsolute(entry)) {
+    fail("absolute paths are not allowed");
+  }
+
+  const segments = entry.split(/[\\/]+/).filter((segment) => segment.length > 0 && segment !== ".");
+
+  if (segments.length === 0) {
+    fail("path must not be empty");
+  }
+  if (segments.includes("..")) {
+    fail("parent-directory segments are not allowed");
+  }
+  if (segments.includes(".git")) {
+    fail("git metadata cannot be copied");
+  }
+
+  return {
+    raw: entry,
+    path: join(...segments),
+  };
+}
+
+async function readWorktreeIncludeEntries(sourceRoot: string): Promise<WorktreeIncludeEntry[]> {
+  try {
+    const contents = await readFile(join(sourceRoot, WORKTREE_INCLUDE_FILE_NAME), "utf8");
+    return parseWorktreeIncludeEntries(contents);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function splitRelativePathSegments(relativePath: string): string[] {
+  return relativePath.split(/[\\/]+/).filter((segment) => segment.length > 0);
+}
+
+function getRecursiveDirectoryIncludePath(entry: WorktreeIncludeEntry): string | null {
+  const segments = splitRelativePathSegments(entry.path);
+  if (
+    segments.length > 1 &&
+    segments.at(-1) === "**" &&
+    segments.slice(0, -1).every((segment) => !segment.includes("*"))
+  ) {
+    return join(...segments.slice(0, -1));
+  }
+  return null;
+}
+
+function segmentGlobMatches(pattern: string, value: string): boolean {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*");
+  return new RegExp(`^${escaped}$`).test(value);
+}
+
+function worktreeIncludeGlobMatches(pattern: string, candidate: string): boolean {
+  const patternSegments = splitRelativePathSegments(pattern);
+  const candidateSegments = splitRelativePathSegments(candidate);
+
+  function match(patternIndex: number, candidateIndex: number): boolean {
+    const patternSegment = patternSegments[patternIndex];
+    if (patternSegment === undefined) {
+      return candidateIndex === candidateSegments.length;
+    }
+    if (patternSegment === "**") {
+      return (
+        match(patternIndex + 1, candidateIndex) ||
+        (candidateIndex < candidateSegments.length && match(patternIndex, candidateIndex + 1))
+      );
+    }
+
+    const candidateSegment = candidateSegments[candidateIndex];
+    return (
+      candidateSegment !== undefined &&
+      segmentGlobMatches(patternSegment, candidateSegment) &&
+      match(patternIndex + 1, candidateIndex + 1)
+    );
+  }
+
+  return match(0, 0);
+}
+
+async function collectWorktreeIncludeCandidates(sourceRoot: string): Promise<string[]> {
+  const candidates: string[] = [];
+
+  async function visit(directoryPath: string, directorySegments: string[]): Promise<void> {
+    const entries = await readdir(directoryPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.name === ".git") {
+        continue;
+      }
+
+      const pathSegments = [...directorySegments, entry.name];
+      const relativePath = join(...pathSegments);
+      candidates.push(relativePath);
+
+      if (entry.isDirectory()) {
+        await visit(join(directoryPath, entry.name), pathSegments);
+      }
+    }
+  }
+
+  await visit(sourceRoot, []);
+  return candidates;
+}
+
+function resolveWorktreeIncludeGlobMatches(
+  entry: WorktreeIncludeEntry,
+  candidates: string[],
+): string[] {
+  const recursiveDirectoryPath = getRecursiveDirectoryIncludePath(entry);
+  if (recursiveDirectoryPath) {
+    return [recursiveDirectoryPath];
+  }
+
+  return candidates.filter((candidate) => worktreeIncludeGlobMatches(entry.path, candidate)).sort();
+}
+
+async function copyWorktreeIncludeEntries(options: {
+  sourceRoot: string;
+  worktreePath: string;
+  entries: WorktreeIncludeEntry[];
+}): Promise<void> {
+  const needsCandidates = options.entries.some(
+    (entry) => entry.path.includes("*") && !getRecursiveDirectoryIncludePath(entry),
+  );
+  const candidates = needsCandidates
+    ? await collectWorktreeIncludeCandidates(options.sourceRoot)
+    : [];
+
+  for (const entry of options.entries) {
+    const paths = entry.path.includes("*")
+      ? resolveWorktreeIncludeGlobMatches(entry, candidates)
+      : [entry.path];
+    await copyWorktreeIncludeEntryPaths({
+      sourceRoot: options.sourceRoot,
+      worktreePath: options.worktreePath,
+      entry,
+      relativePaths: paths,
+    });
+  }
+}
+
+async function copyWorktreeIncludeEntryPaths(options: {
+  sourceRoot: string;
+  worktreePath: string;
+  entry: WorktreeIncludeEntry;
+  relativePaths: string[];
+}): Promise<void> {
+  let copied = false;
+  for (const relativePath of options.relativePaths) {
+    const sourcePath = resolve(options.sourceRoot, relativePath);
+    if (!(await pathExists(sourcePath))) {
+      continue;
+    }
+    const destinationPath = resolve(options.worktreePath, relativePath);
+    await mkdir(dirname(destinationPath), { recursive: true });
+    await cp(sourcePath, destinationPath, {
+      recursive: true,
+      force: true,
+    });
+    copied = true;
+  }
+
+  if (!copied) {
+    throw new Error(`No paths matched ${WORKTREE_INCLUDE_FILE_NAME} entry '${options.entry.raw}'`);
+  }
+}
+
 /**
  * Create a git worktree with proper naming conventions
  */
@@ -1177,6 +1370,7 @@ export const createWorktree = async ({
   worktreesRoot,
 }: CreateWorktreeOptions): Promise<WorktreeConfig> => {
   const sourcePlan = await resolveWorktreeSourcePlan({ cwd, source, desiredSlug: worktreeSlug });
+  const worktreeIncludeEntries = await readWorktreeIncludeEntries(cwd);
   let worktreePath = join(await getPaseoWorktreesRoot(cwd, paseoHome, worktreesRoot), worktreeSlug);
   mkdirSync(dirname(worktreePath), { recursive: true });
 
@@ -1223,6 +1417,17 @@ export const createWorktree = async ({
     await copyFile(mainConfigPath, worktreeConfigPath).catch((err) => {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
     });
+  }
+
+  try {
+    await copyWorktreeIncludeEntries({
+      sourceRoot: cwd,
+      worktreePath,
+      entries: worktreeIncludeEntries,
+    });
+  } catch (error) {
+    await removeFailedWorktree(worktreePath);
+    throw error;
   }
 
   if (runSetup) {

--- a/public-docs/worktrees.md
+++ b/public-docs/worktrees.md
@@ -74,6 +74,22 @@ Both fields accept a multiline shell script or an array of commands; commands ru
 
 Commands run with the worktree as `cwd`. Use `$PASEO_SOURCE_CHECKOUT_PATH` to reach files in the original checkout (untracked config, local caches, etc).
 
+## .worktreeinclude
+
+For local files that every new worktree should receive, add a `.worktreeinclude` file at the source checkout root. Paseo reads it from the current source checkout, copies the listed paths after `git worktree add`, and finishes before `worktree.setup` runs.
+
+Each nonblank line is a file path, folder path, or glob pattern relative to the source checkout. Whole-line `#` comments are ignored. A `**` path segment matches recursively; for example, `**/.runtime.env` copies every `.runtime.env` file, and `.cache-dev/**` copies the whole `.cache-dev` folder.
+
+```gitignore
+# copied from the source checkout into each new worktree
+.credentials.local.json
+**/.runtime.env
+.cache-dev/**
+.tool-state/**
+```
+
+Absolute paths, `..` segments, and `.git` metadata paths are rejected.
+
 ## Scripts and services
 
 `scripts` are named commands you can run inside a worktree on demand. Mark one as a _service_ and Paseo supervises it as a long-running process, assigns it a port, and routes HTTP traffic to it through the daemon's reverse proxy.


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Adds `.worktreeinclude` support for Paseo-created worktrees. When a source checkout has a `.worktreeinclude` file, Paseo copies the listed relative files or folders into the new worktree after `git worktree add` and before `worktree.setup` runs.

The include file ignores blank lines and whole-line `#` comments, and rejects unsafe entries such as absolute paths, `..`, or `.git` metadata paths.

### How did you verify it

Ran dev server, created a worktree from a repo with a existing .worktreeinclude file. Result: Files were copied.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A, no UI changes)
- [x] Tests added or updated where it made sense
