### PR TITLE
feat(app): make thinking sections scrollable when expanded

### DIFF
--- a/packages/app/src/components/tool-call-details.tsx
+++ b/packages/app/src/components/tool-call-details.tsx
@@ -518,23 +518,16 @@ function FetchDetailSection({ url, result, ds }: FetchDetailProps) {
 
 function ScrollablePlainTextSection({ text, ds }: { text: string; ds: DetailStyles }) {
   return (
-    <View style={styles.plainTextSection}>
+    <View style={styles.section}>
       <ScrollView
         style={ds.scrollAreaStyle}
         contentContainerStyle={styles.scrollContent}
         nestedScrollEnabled
         showsVerticalScrollIndicator
       >
-        <ScrollView
-          horizontal
-          nestedScrollEnabled
-          showsHorizontalScrollIndicator
-          style={ds.webScrollbarStyle}
-        >
-          <Text selectable style={styles.plainText}>
-            {text}
-          </Text>
-        </ScrollView>
+        <Text selectable style={styles.plainText}>
+          {text}
+        </Text>
       </ScrollView>
     </View>
   );

--- a/packages/app/src/components/tool-call-details.tsx
+++ b/packages/app/src/components/tool-call-details.tsx
@@ -516,12 +516,26 @@ function FetchDetailSection({ url, result, ds }: FetchDetailProps) {
   );
 }
 
-function PlainTextSection({ text }: { text: string }) {
+function ScrollablePlainTextSection({ text, ds }: { text: string; ds: DetailStyles }) {
   return (
     <View style={styles.plainTextSection}>
-      <Text selectable style={styles.plainText}>
-        {text}
-      </Text>
+      <ScrollView
+        style={ds.scrollAreaStyle}
+        contentContainerStyle={styles.scrollContent}
+        nestedScrollEnabled
+        showsVerticalScrollIndicator
+      >
+        <ScrollView
+          horizontal
+          nestedScrollEnabled
+          showsHorizontalScrollIndicator
+          style={ds.webScrollbarStyle}
+        >
+          <Text selectable style={styles.plainText}>
+            {text}
+          </Text>
+        </ScrollView>
+      </ScrollView>
     </View>
   );
 }
@@ -607,13 +621,7 @@ function buildUnknownSections(detail: UnknownDetail, ds: DetailStyles, t: TFunct
     typeof detail.input === "string" && detail.output === null ? detail.input : null;
 
   if (plainInputText !== null) {
-    return [
-      <View key="unknown-plain-text" style={styles.plainTextSection}>
-        <Text selectable style={styles.plainText}>
-          {plainInputText}
-        </Text>
-      </View>,
-    ];
+    return [<ScrollablePlainTextSection key="unknown-plain-text" text={plainInputText} ds={ds} />];
   }
 
   const sectionsFromTopLevel = [
@@ -729,7 +737,7 @@ function buildDetailSections(
   }
   if (detail.type === "plain_text") {
     if (!detail.text) return [];
-    return [<PlainTextSection key="plain-text" text={detail.text} />];
+    return [<ScrollablePlainTextSection key="plain-text" text={detail.text} ds={ds} />];
   }
   if (detail.type === "unknown") {
     return buildUnknownSections(detail, ds, t);


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Thinking/reasoning content renders as a `ToolCall` with `toolName="thinking"`. When expanded on desktop, it uses `PlainTextSection` — a plain `<View>` + `<Text selectable>` with **no scroll container and no max-height**. Unlike every other detail section (shell, edit, read, write, fetch, search), which all use `ScrollView` with `maxHeight` constraints from `useDetailStyles`, thinking text grows infinitely. This means long reasoning chains consume massive screen real estate even though they're inside an expandable badge.

Changed `PlainTextSection` → `ScrollablePlainTextSection`: wraps the same text in nested `ScrollView`s (vertical outer + horizontal inner) using the identical style tokens (`scrollAreaStyle`, `webScrollbarStyle`) that other sections already use. The `maxHeight` is inherited from `ToolCallDetailsContent`'s `maxHeight={400}` prop, so scrolling kicks in at 400px — consistent with everything else. Both call sites updated: `buildUnknownSections` (thinking/reasoning via unknown detail type) and `buildDetailSections` (explicit `plain_text` type).

### How did you verify it

- Verified `npm run typecheck` passes for `tool-call-details.tsx` (zero new errors; remaining errors are pre-existing upstream mismatches on unrelated files)
- Verified `npm run lint -- tool-call-details.tsx` passes clean
- Verified `npm run format -- tool-call-details.tsx` makes no changes (already formatted by oxfmt)
- Reviewed diff: replaced one non-scrolling `<View>`+`<Text>` with a nested scroll pattern matching shell/edit/read/write/fetch/search sections exactly

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (oxfmt)
- [ ] UI changes include screenshots or video for every affected platform
- [ ] Tests added or updated where it made sense