### PR TITLE
Stop agent prompts renaming existing workspaces

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2411,6 +2411,7 @@ export class Session {
           initialTitle: workspacePromptTitle,
         },
       );
+      const createdDirectoryWorkspaceForAgent = !createdWorktree && !msg.workspaceId;
 
       const { snapshot, liveSnapshot } = await createAgentCommand(
         {
@@ -2441,11 +2442,8 @@ export class Session {
         },
       );
       createdAgentId = snapshot.id;
-      if (!createdWorktree && msg.workspaceId) {
-        await this.writeInitialWorkspaceTitleIfUntitled(workspaceId, workspacePromptTitle);
-      }
       await this.agentUpdates.forwardLiveAgent(snapshot);
-      if (!createdWorktree && trimmedPrompt) {
+      if (createdDirectoryWorkspaceForAgent && trimmedPrompt) {
         await this.scheduleAutoNameLocalWorkspaceTitleForFirstAgent({
           workspaceId,
           cwd: createAgentConfig.cwd,
@@ -2902,24 +2900,6 @@ export class Session {
       ...current,
       title,
       ...(input.branch ? { branch: input.branch } : {}),
-      updatedAt: new Date().toISOString(),
-    });
-  }
-
-  private async writeInitialWorkspaceTitleIfUntitled(
-    workspaceId: string,
-    title: string | null,
-  ): Promise<void> {
-    if (!title) {
-      return;
-    }
-    const current = await this.workspaceRegistry.get(workspaceId);
-    if (!current || current.title) {
-      return;
-    }
-    await this.workspaceRegistry.upsert({
-      ...current,
-      title,
       updatedAt: new Date().toISOString(),
     });
   }

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -830,7 +830,7 @@ test("create_agent_request keeps requested child cwd when grouped under an exist
   }
 });
 
-test("create_agent_request writes the first prompt title onto an untitled existing workspace", async () => {
+test("create_agent_request does not title an existing workspace from the agent prompt", async () => {
   const workdir = mkdtempSync(path.join(tmpdir(), "paseo-create-agent-existing-title-"));
   try {
     const cwd = path.join(workdir, "repo");
@@ -939,7 +939,8 @@ test("create_agent_request writes the first prompt title onto an untitled existi
     const [createdAgent] = agentManager.listAgents();
     expect(createdAgent?.workspaceId).toBe("ws-existing");
     await expect(workspaceRegistry.get("ws-existing")).resolves.toMatchObject({
-      title: "Fix login bug",
+      title: null,
+      updatedAt: "2026-05-07T00:00:00.000Z",
     });
   } finally {
     rmSync(workdir, { recursive: true, force: true });

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -831,6 +831,7 @@ test("create_agent_request keeps requested child cwd when grouped under an exist
 });
 
 test("create_agent_request does not title an existing workspace from the agent prompt", async () => {
+  vi.useFakeTimers();
   const workdir = mkdtempSync(path.join(tmpdir(), "paseo-create-agent-existing-title-"));
   try {
     const cwd = path.join(workdir, "repo");
@@ -883,6 +884,7 @@ test("create_agent_request does not title an existing workspace from the agent p
       }),
     );
 
+    let generateCalls = 0;
     const session = asTestSession(
       new Session({
         clientId: "test-client",
@@ -922,6 +924,10 @@ test("create_agent_request does not title an existing workspace from the agent p
         mcpBaseUrl: null,
         stt: null,
         tts: null,
+        generateWorkspaceName: async () => {
+          generateCalls += 1;
+          return { title: "Generated title that must not be written", branch: null };
+        },
         providerSnapshotManager: createProviderSnapshotManagerStub().manager,
         terminalManager: null,
       }),
@@ -935,14 +941,17 @@ test("create_agent_request does not title an existing workspace from the agent p
       initialPrompt: "Fix login bug\nwith better validation",
       attachments: [],
     });
+    await vi.runAllTimersAsync();
 
     const [createdAgent] = agentManager.listAgents();
     expect(createdAgent?.workspaceId).toBe("ws-existing");
+    expect(generateCalls).toBe(0);
     await expect(workspaceRegistry.get("ws-existing")).resolves.toMatchObject({
       title: null,
       updatedAt: "2026-05-07T00:00:00.000Z",
     });
   } finally {
+    vi.useRealTimers();
     rmSync(workdir, { recursive: true, force: true });
   }
 });

--- a/packages/server/src/server/workspace-same-cwd-isolation.e2e.test.ts
+++ b/packages/server/src/server/workspace-same-cwd-isolation.e2e.test.ts
@@ -410,7 +410,7 @@ test("local workspace auto-title does not broadcast provider snapshot warm-up to
   }
 }, 20_000);
 
-test("create_agent_request with initialPrompt generates a daemon-visible workspace title", async () => {
+test("create_agent_request with workspaceId does not retitle an existing workspace", async () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "paseo-agent-submit-title-"));
   const daemon = await createTestPaseoDaemon({
     agentClients: { mock: new MockLoadTestAgentClient() },
@@ -433,6 +433,8 @@ test("create_agent_request with initialPrompt generates a daemon-visible workspa
     if (!workspaceId) {
       throw new Error(created.error ?? "Expected workspace to be created");
     }
+    const originalName = await workspaceName(client, workspaceId);
+    expect(originalName).toBe(path.basename(cwd));
 
     const agent = await client.createAgent({
       provider: "mock",
@@ -443,9 +445,8 @@ test("create_agent_request with initialPrompt generates a daemon-visible workspa
     });
     expect(agent.workspaceId).toBe(workspaceId);
 
-    await expect
-      .poll(() => workspaceName(client, workspaceId), { timeout: 10_000 })
-      .toBe("Fix login bug");
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(await workspaceName(client, workspaceId)).toBe(originalName);
   } finally {
     await client.close().catch(() => undefined);
     await daemon.close();

--- a/packages/server/src/server/workspace-same-cwd-isolation.e2e.test.ts
+++ b/packages/server/src/server/workspace-same-cwd-isolation.e2e.test.ts
@@ -445,7 +445,6 @@ test("create_agent_request with workspaceId does not retitle an existing workspa
     });
     expect(agent.workspaceId).toBe(workspaceId);
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
     expect(await workspaceName(client, workspaceId)).toBe(originalName);
   } finally {
     await client.close().catch(() => undefined);


### PR DESCRIPTION
### Linked issue

None found. I searched the open issue list plus workspace title/auto-title terms; the closest result was about manual tab title editing, which this does not resolve.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Creating a new agent inside an existing workspace no longer changes the workspace title from that agent's prompt. Workspace auto-titling remains limited to workspace creation, so a follow-up task like "build to green" cannot rename the workspace it was started inside.

The server had two paths that treated an existing untitled workspace like a newly-created one: an immediate prompt-title write and a background local auto-title schedule. This removes the immediate write and only schedules local auto-title generation when the create-agent request created the directory workspace.

### How did you verify it

- `npx vitest run packages/server/src/server/session.workspaces.test.ts -t "create_agent_request does not title an existing workspace from the agent prompt" --bail=1`
- `npx vitest run packages/server/src/server/workspace-same-cwd-isolation.e2e.test.ts -t "create_agent_request with workspaceId does not retitle an existing workspace" --bail=1`
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- Pre-commit hook also reran targeted lint, format check, and typecheck successfully.

### Risk surface

This changes daemon workspace metadata behavior only. The main compatibility risk is any flow that relied on a later agent prompt naming an already-existing untitled workspace; that behavior is intentionally removed. Workspace creation with first-agent context still seeds the initial title.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A, no UI changes)
- [x] Tests added or updated where it made sense