### PR TITLE
feat(server): keep workspace scripts in paseo.json order

### DIFF
--- a/packages/server/src/server/script-status-projection.test.ts
+++ b/packages/server/src/server/script-status-projection.test.ts
@@ -449,6 +449,58 @@ describe("script-status-projection", () => {
     }
   });
 
+  it("keeps configured scripts in paseo.json order and trails orphans alphabetically", () => {
+    const workspaceId = "workspace-script-order";
+    // File order is deliberately non-alphabetical so a re-sort would be observable.
+    const workspace = createWorkspaceRepo({
+      paseoConfig: {
+        scripts: {
+          dev: { command: "npm run dev" },
+          build: { command: "npm run build" },
+          api: { command: "npm run api" },
+        },
+      },
+    });
+    const routeStore = new ScriptRouteStore();
+    const runtimeStore = new WorkspaceScriptRuntimeStore();
+    // Two running-but-unconfigured ("orphan") scripts, registered out of alphabetical order.
+    runtimeStore.set({
+      workspaceId,
+      scriptName: "ztask",
+      type: "script",
+      lifecycle: "running",
+      terminalId: "term-z",
+      exitCode: null,
+    });
+    runtimeStore.set({
+      workspaceId,
+      scriptName: "mtask",
+      type: "script",
+      lifecycle: "running",
+      terminalId: "term-m",
+      exitCode: null,
+    });
+
+    try {
+      const payloads = buildPayloads({
+        workspaceId,
+        workspaceDirectory: workspace.repoDir,
+        routeStore,
+        runtimeStore,
+        daemonPort: 6767,
+      });
+      expect(payloads.map((payload) => payload.scriptName)).toEqual([
+        "dev",
+        "build",
+        "api",
+        "mtask",
+        "ztask",
+      ]);
+    } finally {
+      workspace.cleanup();
+    }
+  });
+
   it("readPaseoConfig fails with configPath and error when paseo.json is malformed", () => {
     const workspace = createWorkspaceRepo();
     const configPath = path.join(workspace.repoDir, "paseo.json");

--- a/packages/server/src/server/script-status-projection.ts
+++ b/packages/server/src/server/script-status-projection.ts
@@ -233,17 +233,19 @@ export function buildWorkspaceScriptPayloads(
     resolveHealth: options.resolveHealth,
   };
 
-  const payloads: WorkspaceScriptPayload[] = [];
+  const configuredPayloads: WorkspaceScriptPayload[] = [];
 
   for (const [scriptName, config] of scriptConfigs.entries()) {
     const runtimeEntry = runtimeEntries.get(scriptName) ?? null;
     const serviceState = isServiceScript(config)
       ? projectWorkspaceServiceState({ workspaceId, scriptName, ctx })
       : null;
-    payloads.push(
+    configuredPayloads.push(
       buildConfiguredScriptPayload(scriptName, config, runtimeEntry, serviceState, ctx),
     );
   }
+
+  const orphanPayloads: WorkspaceScriptPayload[] = [];
 
   for (const runtimeEntry of runtimeEntries.values()) {
     if (scriptConfigs.has(runtimeEntry.scriptName) || runtimeEntry.lifecycle !== "running") {
@@ -253,10 +255,10 @@ export function buildWorkspaceScriptPayloads(
       runtimeEntry.type === "service"
         ? projectWorkspaceServiceState({ workspaceId, scriptName: runtimeEntry.scriptName, ctx })
         : null;
-    payloads.push(buildOrphanRuntimePayload(runtimeEntry, serviceState, ctx));
+    orphanPayloads.push(buildOrphanRuntimePayload(runtimeEntry, serviceState, ctx));
   }
 
-  return sortPayloads(payloads);
+  return [...configuredPayloads, ...sortPayloads(orphanPayloads)];
 }
 
 function buildScriptStatusUpdateMessage(params: {


### PR DESCRIPTION
### Linked issue

Closes #1686

### Type of change

- [x] New feature (with prior issue + design alignment)
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Docs

This implements the "Phase 1" proposed in #1686.

### What does this PR do

Workspace scripts in the run dropdown were alphabetized by a final `sortPayloads` call in `buildWorkspaceScriptPayloads`, discarding the order authors write in `paseo.json` (so grouping related scripts like `dev`, `dev:api`, `dev:web` was lost).

That sort was the only thing dropping file order. `scriptConfigs` already iterates in config key-insertion order, which survives the read round-trip. So:

- Configured scripts now keep their `paseo.json` order.
- Running-but-unconfigured ("orphan") scripts have no file position, so they trail the configured ones in a stable alphabetical order.

No schema or protocol change.

### How did you verify it

- Added a unit test in `script-status-projection.test.ts`: scripts defined `dev, build, api, deploy` now project in that file order (previously alphabetized to `api, build, deploy, dev`), and two orphan runtime scripts registered out of order trail alphabetically.
- `npx vitest run src/server/script-status-projection.test.ts` → 12 passing (11 existing + 1 new).
- `npm run typecheck`, `npm run lint`, `npm run format` all clean.
- Ran the dev daemon + web app and opened the workspace Scripts dropdown against a `paseo.json` with `dev, build, api, deploy`. Before/after below.

Server-only change; the screenshots are of the run dropdown it feeds.

**Before** (`main`, alphabetical):


<img width="298" height="233" alt="Screenshot 2026-06-28 at 11 27 17" src="https://github.com/user-attachments/assets/5e7802d7-546b-4ef4-8407-67d6e23f55f4" />

**After** (this branch, file order):

<img width="286" height="237" alt="Screenshot 2026-06-28 at 11 25 52" src="https://github.com/user-attachments/assets/03f81247-4f11-4a1a-ae71-e0c942bb4221" />


### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
