### PR TITLE
Feat/task indicator

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -889,6 +889,7 @@ function AppWithSidebar({ children }: { children: ReactNode }) {
     (pathname === "/open-project" ||
       pathname === "/new" ||
       pathname === "/sessions" ||
+      pathname === "/tasks" ||
       routeHasKnownHost);
 
   // Parse selectedAgentKey directly from pathname

--- a/packages/app/src/app/tasks.tsx
+++ b/packages/app/src/app/tasks.tsx
@@ -1,0 +1,10 @@
+import { HostRouteBootstrapBoundary } from "@/components/host-route-bootstrap-boundary";
+import { TasksScreen } from "@/screens/tasks-screen";
+
+export default function TasksRoute() {
+  return (
+    <HostRouteBootstrapBoundary>
+      <TasksScreen />
+    </HostRouteBootstrapBoundary>
+  );
+}

--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -1,5 +1,15 @@
 import { router, usePathname } from "expo-router";
-import { FolderPlus, History, Home, Plus, Search, Server, Settings, X } from "lucide-react-native";
+import {
+  FolderPlus,
+  History,
+  Home,
+  ListTodo,
+  Plus,
+  Search,
+  Server,
+  Settings,
+  X,
+} from "lucide-react-native";
 import { useTranslation } from "react-i18next";
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import {
@@ -53,6 +63,7 @@ import {
   buildOpenProjectRoute,
   buildNewWorkspaceRoute,
   buildSessionsRoute,
+  buildTasksRoute,
   buildSettingsAddHostRoute,
   buildSettingsHostSectionRoute,
   buildSettingsRoute,
@@ -102,6 +113,7 @@ interface SidebarLabels {
   switchHost: string;
   searchHosts: string;
   sessions: string;
+  tasks: string;
   closeSidebar: string;
 }
 
@@ -232,6 +244,7 @@ export const LeftSidebar = memo(function LeftSidebar({
       switchHost: t("sidebar.host.switchTitle"),
       searchHosts: t("sidebar.host.searchPlaceholder"),
       sessions: t("sidebar.sections.sessions"),
+      tasks: t("taskProgress.sidebar"),
       closeSidebar: t("sidebar.actions.closeSidebar"),
     }),
     [t],
@@ -514,6 +527,7 @@ function MobileSidebar({
 }: MobileSidebarProps) {
   const pathname = usePathname();
   const isSessionsActive = pathname.includes("/sessions");
+  const isTasksActive = pathname.includes("/tasks");
   const {
     translateX,
     backdropOpacity,
@@ -540,6 +554,13 @@ function MobileSidebar({
     closeSidebar();
     handleViewMoreNavigate();
   }, [backdropOpacity, closeSidebar, handleViewMoreNavigate, translateX, windowWidth]);
+
+  const handleTasks = useCallback(() => {
+    translateX.value = -windowWidth;
+    backdropOpacity.value = 0;
+    closeSidebar();
+    router.push(buildTasksRoute());
+  }, [backdropOpacity, closeSidebar, translateX, windowWidth]);
 
   const handleWorkspacePress = useCallback(() => {
     closeSidebar();
@@ -700,6 +721,14 @@ function MobileSidebar({
                 shortcutKeys={newWorkspaceKeys}
               />
               <SidebarHeaderRow
+                icon={ListTodo}
+                label={labels.tasks}
+                onPress={handleTasks}
+                isActive={isTasksActive}
+                testID="sidebar-tasks"
+                variant="compact"
+              />
+              <SidebarHeaderRow
                 icon={History}
                 label={labels.sessions}
                 onPress={handleViewMore}
@@ -791,6 +820,10 @@ function DesktopSidebar({
 }: DesktopSidebarProps) {
   const pathname = usePathname();
   const isSessionsActive = pathname.includes("/sessions");
+  const isTasksActive = pathname.includes("/tasks");
+  const handleTasks = useCallback(() => {
+    router.push(buildTasksRoute());
+  }, []);
   const padding = useWindowControlsPadding("sidebar");
   const sidebarWidth = usePanelStore((state) => state.sidebarWidth);
   const setSidebarWidth = usePanelStore((state) => state.setSidebarWidth);
@@ -863,6 +896,14 @@ function DesktopSidebar({
               testID="sidebar-global-new-workspace"
               variant="compact"
               shortcutKeys={newWorkspaceKeys}
+            />
+            <SidebarHeaderRow
+              icon={ListTodo}
+              label={labels.tasks}
+              onPress={handleTasks}
+              isActive={isTasksActive}
+              testID="sidebar-tasks"
+              variant="compact"
             />
             <SidebarHeaderRow
               icon={History}

--- a/packages/app/src/components/task-progress-track.tsx
+++ b/packages/app/src/components/task-progress-track.tsx
@@ -1,0 +1,273 @@
+import { useCallback, useMemo, useState, type ReactElement } from "react";
+import { Pressable, ScrollView, Text, View, type PressableStateCallbackType } from "react-native";
+import { useTranslation } from "react-i18next";
+import { Check, ChevronDown, ChevronRight, ListTodo } from "lucide-react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import type { TaskProgressPayload } from "@getpaseo/protocol/messages";
+import { MAX_CONTENT_WIDTH } from "@/constants/layout";
+import type { Theme } from "@/styles/theme";
+
+const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedChevronRight = withUnistyles(ChevronRight);
+const ThemedListTodo = withUnistyles(ListTodo);
+const ThemedCheck = withUnistyles(Check);
+
+const foregroundMutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+const primaryForegroundColorMapping = (theme: Theme) => ({
+  color: theme.colors.primaryForeground,
+});
+
+export interface TaskProgressTrackProps {
+  taskProgress: TaskProgressPayload;
+}
+
+const LIST_MAX_HEIGHT = 200;
+
+/**
+ * A persistent, collapsible task-progress bar shown above the composer. Unlike
+ * the inline TodoListCard (which scrolls away with the message stream), this
+ * stays pinned so the user can always see overall task progress. Mirrors the
+ * SubagentsTrack surface styling so the two read as a coherent stack.
+ */
+export function TaskProgressTrack({ taskProgress }: TaskProgressTrackProps): ReactElement | null {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleExpanded = useCallback(() => {
+    setExpanded((current) => !current);
+  }, []);
+
+  const surfaceStyle = useMemo(
+    () => [styles.surface, expanded && styles.surfaceExpanded],
+    [expanded],
+  );
+
+  const headerStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType) => [
+      styles.header,
+      expanded ? styles.headerDivider : styles.headerCollapsed,
+      (hovered || pressed) && styles.headerActive,
+    ],
+    [expanded],
+  );
+
+  // Task text can repeat across rows, so suffix duplicates with an occurrence
+  // count to keep keys stable and content-derived (no array index).
+  const keyedTaskItems = useMemo(() => {
+    const seen = new Map<string, number>();
+    return taskProgress.items.map((item) => {
+      const occurrence = seen.get(item.text) ?? 0;
+      seen.set(item.text, occurrence + 1);
+      return { ...item, key: `${item.text}#${occurrence}` };
+    });
+  }, [taskProgress.items]);
+
+  const { total, completed } = taskProgress;
+  if (total === 0) {
+    return null;
+  }
+
+  const ratio = Math.max(0, Math.min(1, completed / total));
+  const nextTask = taskProgress.items.find((item) => item.status !== "completed")?.text;
+  const headerLabel = t("taskProgress.progress", { completed, total });
+
+  return (
+    <View style={styles.outer} testID="task-progress-track">
+      <View style={styles.track}>
+        <View style={surfaceStyle}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={headerLabel}
+            testID="task-progress-track-header"
+            onPress={toggleExpanded}
+            style={headerStyle}
+          >
+            {expanded ? (
+              <ThemedChevronDown size={12} uniProps={foregroundMutedColorMapping} />
+            ) : (
+              <ThemedChevronRight size={12} uniProps={foregroundMutedColorMapping} />
+            )}
+            <ThemedListTodo size={12} uniProps={foregroundMutedColorMapping} />
+            <Text style={styles.headerLabel} numberOfLines={1}>
+              {headerLabel}
+            </Text>
+            {!expanded && nextTask ? (
+              <Text style={styles.headerSecondary} numberOfLines={1}>
+                {nextTask}
+              </Text>
+            ) : null}
+            <View style={styles.progressTrack}>
+              <ProgressFill ratio={ratio} />
+            </View>
+          </Pressable>
+          {expanded ? (
+            <ScrollView
+              style={styles.scroll}
+              contentContainerStyle={styles.scrollContent}
+              showsVerticalScrollIndicator={false}
+              nestedScrollEnabled
+            >
+              {keyedTaskItems.map((item) => (
+                <TaskProgressRow key={item.key} text={item.text} status={item.status} />
+              ))}
+            </ScrollView>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function ProgressFill({ ratio }: { ratio: number }): ReactElement {
+  const fillStyle = useMemo(
+    () => [styles.progressFill, { width: `${ratio * 100}%` as const }],
+    [ratio],
+  );
+  return <View style={fillStyle} />;
+}
+
+function getBadgeStatusStyle(
+  status: TaskProgressPayload["items"][number]["status"],
+): typeof styles.radioBadgeComplete {
+  if (status === "completed") {
+    return styles.radioBadgeComplete;
+  }
+  if (status === "in_progress") {
+    return styles.radioBadgeInProgress;
+  }
+  return styles.radioBadgeIncomplete;
+}
+
+function TaskProgressRow({
+  text,
+  status,
+}: {
+  text: string;
+  status: TaskProgressPayload["items"][number]["status"];
+}): ReactElement {
+  const completed = status === "completed";
+  const badgeStyle = useMemo(() => [styles.radioBadge, getBadgeStatusStyle(status)], [status]);
+  const textStyle = useMemo(
+    () => [styles.itemText, completed && styles.itemTextCompleted],
+    [completed],
+  );
+  return (
+    <View style={styles.itemRow}>
+      <View style={badgeStyle}>
+        {completed ? <ThemedCheck size={12} uniProps={primaryForegroundColorMapping} /> : null}
+      </View>
+      <Text style={textStyle} numberOfLines={2}>
+        {text}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  outer: {
+    width: "100%",
+    alignItems: "center",
+    paddingHorizontal: theme.spacing[4],
+  },
+  track: {
+    width: "100%",
+    maxWidth: MAX_CONTENT_WIDTH,
+    marginBottom: -theme.spacing[4],
+  },
+  surface: {
+    alignSelf: "stretch",
+    backgroundColor: theme.colors.surface1,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.borderAccent,
+    borderBottomWidth: 0,
+    borderTopLeftRadius: theme.borderRadius["2xl"],
+    borderTopRightRadius: theme.borderRadius["2xl"],
+    overflow: "hidden",
+  },
+  surfaceExpanded: {
+    paddingBottom: theme.spacing[4],
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[2],
+  },
+  headerCollapsed: {
+    paddingBottom: theme.spacing[6],
+  },
+  headerActive: {
+    backgroundColor: theme.colors.surface2,
+  },
+  headerDivider: {
+    borderBottomWidth: theme.borderWidth[1],
+    borderBottomColor: theme.colors.border,
+  },
+  headerLabel: {
+    flexShrink: 0,
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+  },
+  headerSecondary: {
+    flexShrink: 1,
+    minWidth: 0,
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+    opacity: 0.7,
+  },
+  progressTrack: {
+    width: 56,
+    height: 4,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.surface3,
+    overflow: "hidden",
+    marginLeft: "auto",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.palette.blue[500],
+  },
+  scroll: {
+    maxHeight: LIST_MAX_HEIGHT,
+  },
+  scrollContent: {
+    paddingVertical: theme.spacing[1],
+    paddingHorizontal: theme.spacing[3],
+    gap: theme.spacing[1],
+  },
+  itemRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  radioBadge: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  radioBadgeIncomplete: {
+    backgroundColor: theme.colors.foregroundMuted,
+    opacity: 0.45,
+  },
+  radioBadgeInProgress: {
+    backgroundColor: theme.colors.palette.blue[500],
+    opacity: 0.9,
+  },
+  radioBadgeComplete: {
+    backgroundColor: theme.colors.foregroundMuted,
+    opacity: 0.95,
+  },
+  itemText: {
+    flex: 1,
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  itemTextCompleted: {
+    color: theme.colors.foregroundMuted,
+    textDecorationLine: "line-through",
+  },
+}));

--- a/packages/app/src/hooks/use-agent-history.ts
+++ b/packages/app/src/hooks/use-agent-history.ts
@@ -85,6 +85,8 @@ export async function fetchAgentHistoryPage(input: {
       createdAt: agent.createdAt,
       labels: agent.labels,
       projectPlacement: agent.projectPlacement,
+      parentAgentId: agent.parentAgentId,
+      taskProgress: agent.taskProgress ?? null,
     })),
     pageInfo: payload.pageInfo,
   };

--- a/packages/app/src/hooks/use-aggregated-agents.ts
+++ b/packages/app/src/hooks/use-aggregated-agents.ts
@@ -88,6 +88,8 @@ export function useAggregatedAgents(options?: {
           createdAt: agent.createdAt,
           labels: agent.labels,
           projectPlacement: agent.projectPlacement,
+          parentAgentId: agent.parentAgentId,
+          taskProgress: agent.taskProgress ?? null,
         };
         const cacheKey = `${serverId}:${agent.id}`;
         const prev = prevAgentsRef.current.get(cacheKey);

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1316,6 +1316,16 @@ export const ar: TranslationResources = {
     archiveAction: "أرشيف{{label}}",
     archiveTooltip: "أرشفة الوكيل الفرعي",
   },
+  taskProgress: {
+    title: "المهام",
+    progress: "{{completed}}/{{total}} مهمة",
+    sidebar: "المهام",
+    dashboardTitle: "المهام",
+    empty: "لا توجد مهام نشطة",
+    emptyHint: "يظهر تقدم المهام هنا عندما ينشئ وكلاؤك قوائم مهام.",
+    subagentsLabel: "{{count}} وكيل فرعي",
+    subagentsLabel_other: "{{count}} وكلاء فرعيون",
+  },
   panels: {
     draft: {
       newAgent: "وكيل جديد",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1323,6 +1323,16 @@ export const en = {
     archiveAction: "Archive {{label}}",
     archiveTooltip: "Archive subagent",
   },
+  taskProgress: {
+    title: "Tasks",
+    progress: "{{completed}}/{{total}} tasks",
+    sidebar: "Tasks",
+    dashboardTitle: "Tasks",
+    empty: "No active tasks",
+    emptyHint: "Task progress appears here when your agents create task lists.",
+    subagentsLabel: "{{count}} subagent",
+    subagentsLabel_other: "{{count}} subagents",
+  },
   panels: {
     draft: {
       newAgent: "New Agent",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1352,6 +1352,16 @@ export const es: TranslationResources = {
     archiveAction: "Archivo{{label}}",
     archiveTooltip: "Subagente de archivo",
   },
+  taskProgress: {
+    title: "Tareas",
+    progress: "{{completed}}/{{total}} tareas",
+    sidebar: "Tareas",
+    dashboardTitle: "Tareas",
+    empty: "No hay tareas activas",
+    emptyHint: "El progreso de las tareas aparece aquí cuando tus agentes crean listas de tareas.",
+    subagentsLabel: "{{count}} subagente",
+    subagentsLabel_other: "{{count}} subagentes",
+  },
   panels: {
     draft: {
       newAgent: "Nuevo agente",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1355,6 +1355,17 @@ export const fr: TranslationResources = {
     archiveAction: "Archiver{{label}}",
     archiveTooltip: "Sous-agent d'archivage",
   },
+  taskProgress: {
+    title: "Tâches",
+    progress: "{{completed}}/{{total}} tâches",
+    sidebar: "Tâches",
+    dashboardTitle: "Tâches",
+    empty: "Aucune tâche active",
+    emptyHint:
+      "La progression des tâches apparaît ici lorsque vos agents créent des listes de tâches.",
+    subagentsLabel: "{{count}} sous-agent",
+    subagentsLabel_other: "{{count}} sous-agents",
+  },
   panels: {
     draft: {
       newAgent: "Nouvel agent",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1332,6 +1332,16 @@ export const ja: TranslationResources = {
     archiveAction: "{{label}}をアーカイブ",
     archiveTooltip: "サブエージェントをアーカイブ",
   },
+  taskProgress: {
+    title: "タスク",
+    progress: "{{completed}}/{{total}} 件のタスク",
+    sidebar: "タスク",
+    dashboardTitle: "タスク",
+    empty: "進行中のタスクはありません",
+    emptyHint: "エージェントがタスクリストを作成すると、ここに進捗が表示されます。",
+    subagentsLabel: "{{count}} 個のサブエージェント",
+    subagentsLabel_other: "{{count}} 個のサブエージェント",
+  },
   panels: {
     draft: {
       newAgent: "新しいエージェント",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1338,6 +1338,16 @@ export const ptBR: TranslationResources = {
     archiveAction: "Arquivar {{label}}",
     archiveTooltip: "Arquivar subagente",
   },
+  taskProgress: {
+    title: "Tarefas",
+    progress: "{{completed}}/{{total}} tarefas",
+    sidebar: "Tarefas",
+    dashboardTitle: "Tarefas",
+    empty: "Nenhuma tarefa ativa",
+    emptyHint: "O progresso das tarefas aparece aqui quando seus agentes criam listas de tarefas.",
+    subagentsLabel: "{{count}} subagente",
+    subagentsLabel_other: "{{count}} subagentes",
+  },
   panels: {
     draft: {
       newAgent: "Novo Agente",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1344,6 +1344,16 @@ export const ru: TranslationResources = {
     archiveAction: "Архив{{label}}",
     archiveTooltip: "Архивный субагент",
   },
+  taskProgress: {
+    title: "Задачи",
+    progress: "{{completed}}/{{total}} задач",
+    sidebar: "Задачи",
+    dashboardTitle: "Задачи",
+    empty: "Нет активных задач",
+    emptyHint: "Прогресс задач появится здесь, когда ваши агенты создадут списки задач.",
+    subagentsLabel: "{{count}} субагент",
+    subagentsLabel_other: "{{count}} субагентов",
+  },
   panels: {
     draft: {
       newAgent: "Новый агент",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1299,6 +1299,16 @@ export const zhCN: TranslationResources = {
     archiveAction: "归档 {{label}}",
     archiveTooltip: "归档 subagent",
   },
+  taskProgress: {
+    title: "任务",
+    progress: "{{completed}}/{{total}} 个任务",
+    sidebar: "任务",
+    dashboardTitle: "任务",
+    empty: "暂无进行中的任务",
+    emptyHint: "当 agent 创建任务列表时，进度会显示在这里。",
+    subagentsLabel: "{{count}} 个子 agent",
+    subagentsLabel_other: "{{count}} 个子 agent",
+  },
   panels: {
     draft: {
       newAgent: "新建 Agent",

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -72,6 +72,7 @@ import { buildWorkspaceTabPersistenceKey } from "@/stores/workspace-tabs-store";
 import type { Theme } from "@/styles/theme";
 import { useArchiveSubagent, useDetachSubagent, useSubagentsForParent } from "@/subagents";
 import { SubagentsTrack } from "@/subagents/track";
+import { TaskProgressTrack } from "@/components/task-progress-track";
 import type { PendingPermission } from "@/types/shared";
 import type { StreamItem } from "@/types/stream";
 import { getInitDeferred, getInitKey } from "@/utils/agent-initialization";
@@ -1364,6 +1365,18 @@ function ActiveAgentComposer({
   const canDetachSubagents = useSessionStore(
     (state) => state.sessions[serverId]?.serverInfo?.features?.agentDetach === true,
   );
+  const supportsTaskProgress = useSessionStore(
+    (state) => state.sessions[serverId]?.serverInfo?.features?.taskProgress === true,
+  );
+  const taskProgress = useStoreWithEqualityFn(
+    useSessionStore,
+    (state) => {
+      const session = state.sessions[serverId];
+      const agent = session?.agents?.get(agentId) ?? session?.agentDetails?.get(agentId) ?? null;
+      return agent?.taskProgress ?? null;
+    },
+    (a, b) => a === b || JSON.stringify(a) === JSON.stringify(b),
+  );
   const handleOpenSubagent = useCallback(
     (subagentId: string) => {
       navigateToAgent({ serverId, agentId: subagentId });
@@ -1464,6 +1477,9 @@ function ActiveAgentComposer({
 
   return (
     <ReanimatedAnimated.View style={inputAreaStyle} onLayout={onInputAreaLayout}>
+      {supportsTaskProgress && taskProgress ? (
+        <TaskProgressTrack taskProgress={taskProgress} />
+      ) : null}
       <SubagentsTrack
         rows={subagentRows}
         onOpenSubagent={handleOpenSubagent}

--- a/packages/app/src/screens/tasks-screen.tsx
+++ b/packages/app/src/screens/tasks-screen.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useMemo, type ReactElement } from "react";
+import { FlatList, Pressable, Text, View } from "react-native";
+import { useIsFocused } from "@react-navigation/native";
+import { useTranslation } from "react-i18next";
+import { StyleSheet, useUnistyles, withUnistyles } from "react-native-unistyles";
+import { getProviderIcon } from "@/components/provider-icons";
+import { AgentStatusDot } from "@/components/agent-status-dot";
+import { MenuHeader } from "@/components/headers/menu-header";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { useAggregatedAgents, type AggregatedAgent } from "@/hooks/use-aggregated-agents";
+import type { Theme } from "@/styles/theme";
+import { navigateToAgent } from "@/utils/navigate-to-agent";
+
+interface TaskRowAgent extends AggregatedAgent {
+  taskProgress: NonNullable<AggregatedAgent["taskProgress"]>;
+}
+
+function hasActiveTasks(agent: AggregatedAgent): agent is TaskRowAgent {
+  return Boolean(agent.taskProgress && agent.taskProgress.total > 0);
+}
+
+export function TasksScreen(): ReactElement {
+  const isFocused = useIsFocused();
+  if (!isFocused) {
+    return <View style={styles.container} />;
+  }
+  return <TasksScreenContent />;
+}
+
+function TasksScreenContent(): ReactElement {
+  const { t } = useTranslation();
+  const { theme } = useUnistyles();
+  const { agents, isInitialLoad } = useAggregatedAgents();
+
+  const taskAgents = useMemo(() => {
+    // Running agents first, then most task activity. useAggregatedAgents already
+    // sorts running-first by recency, so just filter to those with task lists.
+    return agents.filter(hasActiveTasks);
+  }, [agents]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: TaskRowAgent }) => <TaskAgentRow agent={item} />,
+    [],
+  );
+
+  const keyExtractor = useCallback((item: TaskRowAgent) => `${item.serverId}:${item.id}`, []);
+
+  function renderBody(): ReactElement {
+    if (isInitialLoad) {
+      return (
+        <View style={styles.centerState}>
+          <LoadingSpinner size="large" color={theme.colors.foregroundMuted} />
+        </View>
+      );
+    }
+    if (taskAgents.length === 0) {
+      return (
+        <View style={styles.centerState}>
+          <Text style={styles.emptyText}>{t("taskProgress.empty")}</Text>
+          <Text style={styles.emptyHint}>{t("taskProgress.emptyHint")}</Text>
+        </View>
+      );
+    }
+    return (
+      <FlatList
+        data={taskAgents}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        contentContainerStyle={styles.listContent}
+      />
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <MenuHeader title={t("taskProgress.dashboardTitle")} />
+      {renderBody()}
+    </View>
+  );
+}
+
+function rowPressableStyle({ pressed }: { pressed: boolean }) {
+  return [styles.row, pressed && styles.rowPressed];
+}
+
+function ProgressFill({ ratio }: { ratio: number }): ReactElement {
+  const fillStyle = useMemo(
+    () => [styles.progressFill, { width: `${ratio * 100}%` as const }],
+    [ratio],
+  );
+  return <View style={fillStyle} />;
+}
+
+function TaskAgentRow({ agent }: { agent: TaskRowAgent }): ReactElement {
+  const { serverId, id, taskProgress } = agent;
+  const Icon = useMemo(() => withUnistyles(getProviderIcon(agent.provider)), [agent.provider]);
+  const title = agent.title?.trim() || agent.cwd.split("/").pop() || agent.id.slice(0, 7);
+  const { completed, total } = taskProgress;
+  const ratio = total > 0 ? Math.max(0, Math.min(1, completed / total)) : 0;
+
+  const handlePress = useCallback(() => {
+    navigateToAgent({ serverId, agentId: id, workspaceId: agent.workspaceId });
+  }, [agent.workspaceId, id, serverId]);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      testID={`tasks-row-${id}`}
+      onPress={handlePress}
+      style={rowPressableStyle}
+    >
+      <View style={styles.rowHeader}>
+        <Icon size={16} uniProps={iconColorMapping} />
+        <Text style={styles.rowTitle} numberOfLines={1}>
+          {title}
+        </Text>
+        <AgentStatusDot
+          status={agent.status}
+          requiresAttention={agent.requiresAttention}
+          attentionReason={agent.attentionReason}
+          pendingPermissionCount={agent.pendingPermissionCount}
+        />
+        <Text style={styles.rowCount}>
+          {completed}/{total}
+        </Text>
+      </View>
+      <View style={styles.progressTrack}>
+        <ProgressFill ratio={ratio} />
+      </View>
+    </Pressable>
+  );
+}
+
+const iconColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.surface0,
+  },
+  centerState: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    padding: theme.spacing[6],
+  },
+  emptyText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.lg,
+  },
+  emptyHint: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    textAlign: "center",
+  },
+  listContent: {
+    padding: theme.spacing[3],
+    gap: theme.spacing[2],
+  },
+  row: {
+    backgroundColor: theme.colors.surface1,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.lg,
+    padding: theme.spacing[3],
+    gap: theme.spacing[2],
+  },
+  rowPressed: {
+    backgroundColor: theme.colors.surface2,
+  },
+  rowHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  rowTitle: {
+    flex: 1,
+    minWidth: 0,
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+    fontWeight: theme.fontWeight.medium,
+  },
+  rowCount: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  progressTrack: {
+    height: 4,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.surface3,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.palette.blue[500],
+  },
+}));

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -25,6 +25,7 @@ import type {
   ServerInfoStatusPayload,
   ProjectPlacementPayload,
   ServerCapabilities,
+  TaskProgressPayload,
   WorkspaceDescriptorPayload,
   WorkspaceProjectDescriptorPayload,
 } from "@getpaseo/protocol/messages";
@@ -118,6 +119,7 @@ export interface Agent {
   parentAgentId: string | null;
   labels: Record<string, string>;
   projectPlacement?: ProjectPlacementPayload | null;
+  taskProgress?: TaskProgressPayload | null;
 }
 
 export interface WorkspaceDescriptor {
@@ -1612,6 +1614,8 @@ export const useSessionStore = create<SessionStore>()(
             attentionTimestamp: agent.attentionTimestamp ?? null,
             createdAt: agent.createdAt,
             labels: agent.labels,
+            parentAgentId: agent.parentAgentId,
+            taskProgress: agent.taskProgress ?? null,
           });
         }
         return entries;

--- a/packages/app/src/types/agent-directory.ts
+++ b/packages/app/src/types/agent-directory.ts
@@ -17,6 +17,8 @@ export type AgentDirectoryEntry = Pick<
   | "createdAt"
   | "labels"
   | "projectPlacement"
+  | "parentAgentId"
+  | "taskProgress"
 > & {
   pendingPermissionCount?: number;
 };

--- a/packages/app/src/utils/agent-snapshots.ts
+++ b/packages/app/src/utils/agent-snapshots.ts
@@ -57,5 +57,6 @@ export function normalizeAgentSnapshot(snapshot: AgentSnapshotPayload, serverId:
     archivedAt,
     parentAgentId,
     labels: snapshot.labels,
+    taskProgress: snapshot.taskProgress ?? null,
   };
 }

--- a/packages/app/src/utils/host-routes.ts
+++ b/packages/app/src/utils/host-routes.ts
@@ -415,6 +415,10 @@ export function buildSessionsRoute() {
   return "/sessions" as const;
 }
 
+export function buildTasksRoute() {
+  return "/tasks" as const;
+}
+
 export function buildOpenProjectRoute() {
   return "/open-project" as const;
 }

--- a/packages/app/src/utils/tool-call-parsers.ts
+++ b/packages/app/src/utils/tool-call-parsers.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 import type { HighlightToken } from "@getpaseo/highlight";
 
 export interface DiffSegment {
@@ -258,83 +257,8 @@ export function parseUnifiedDiff(diffText?: string): DiffLine[] {
 }
 
 // ---- Task Extraction (cross-provider) ----
-
-export type TaskStatus = "pending" | "in_progress" | "completed";
-
-export interface TaskEntry {
-  text: string;
-  status: TaskStatus;
-  completed: boolean;
-}
-
-const TaskStatusSchema = z.enum(["pending", "in_progress", "completed"]);
-
-const ClaudeTodoWriteSchema = z.object({
-  todos: z.array(
-    z.object({
-      content: z.string(),
-      status: TaskStatusSchema,
-      activeForm: z.string().optional(),
-    }),
-  ),
-});
-
-const UpdatePlanSchema = z.object({
-  plan: z.array(
-    z.object({
-      step: z.string(),
-      status: TaskStatusSchema.catch("pending"),
-    }),
-  ),
-});
-
-function normalizeToolName(toolName: string): string {
-  return toolName
-    .trim()
-    .replace(/[.\s-]+/g, "_")
-    .toLowerCase();
-}
-
-export function extractTaskEntriesFromToolCall(
-  toolName: string,
-  input: unknown,
-): TaskEntry[] | null {
-  const normalized = normalizeToolName(toolName);
-
-  // Claude's plan mode uses ExitPlanMode for the approval prompt; it is not a task list.
-  if (normalized === "exitplanmode") {
-    return null;
-  }
-
-  if (normalized === "todowrite" || normalized === "todo_write") {
-    const parsed = ClaudeTodoWriteSchema.safeParse(input);
-    if (!parsed.success) {
-      return null;
-    }
-    return parsed.data.todos.map((todo) => {
-      const status = todo.status;
-      const text = todo.activeForm?.trim() || todo.content.trim();
-      return {
-        text: text.length ? text : todo.content,
-        status,
-        completed: status === "completed",
-      };
-    });
-  }
-
-  if (normalized === "update_plan") {
-    const parsed = UpdatePlanSchema.safeParse(input);
-    if (!parsed.success) {
-      return null;
-    }
-    return parsed.data.plan
-      .map((entry) => ({
-        text: entry.step.trim(),
-        status: entry.status,
-        completed: entry.status === "completed",
-      }))
-      .filter((entry) => entry.text.length > 0);
-  }
-
-  return null;
-}
+// Parsing lives in @getpaseo/protocol/task-progress so the daemon and the app
+// share one implementation. Re-exported here to preserve existing import sites.
+export type { TaskEntry } from "@getpaseo/protocol/task-progress";
+export type { TaskStatus } from "@getpaseo/protocol/messages";
+export { extractTaskEntriesFromToolCall } from "@getpaseo/protocol/task-progress";

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -666,6 +666,30 @@ const AgentRuntimeInfoSchema: z.ZodType<AgentRuntimeInfo> = z.object({
   extra: z.record(z.string(), z.unknown()).optional(),
 });
 
+export const TaskStatusSchema = z.enum(["pending", "in_progress", "completed"]);
+export type TaskStatus = z.infer<typeof TaskStatusSchema>;
+
+export const TaskProgressItemSchema = z.object({
+  text: z.string(),
+  status: TaskStatusSchema,
+});
+export type TaskProgressItem = z.infer<typeof TaskProgressItemSchema>;
+
+/**
+ * A persisted snapshot of an agent's latest task list (Claude TodoWrite /
+ * OpenCode todos / Codex UpdatePlan). Carried on the agent snapshot so every
+ * client — even ones that never opened the agent — can render task progress.
+ */
+export const TaskProgressPayloadSchema = z.object({
+  items: z.array(TaskProgressItemSchema),
+  pending: z.number().int(),
+  inProgress: z.number().int(),
+  completed: z.number().int(),
+  total: z.number().int(),
+  updatedAt: z.string(),
+});
+export type TaskProgressPayload = z.infer<typeof TaskProgressPayloadSchema>;
+
 export const AgentSnapshotPayloadSchema = z.object({
   id: z.string(),
   provider: AgentProviderSchema,
@@ -694,6 +718,8 @@ export const AgentSnapshotPayloadSchema = z.object({
   attentionTimestamp: z.string().nullable().optional(),
   archivedAt: z.string().nullable().optional(),
   providerUnavailable: z.boolean().optional(),
+  // COMPAT(taskProgress): added in v0.1.X, drop the gate when floor >= v0.1.X.
+  taskProgress: TaskProgressPayloadSchema.optional(),
 });
 
 export type AgentSnapshotPayload = z.infer<typeof AgentSnapshotPayloadSchema>;
@@ -2335,6 +2361,8 @@ export const ServerInfoStatusPayloadSchema = z
         daemonDiagnostics: z.boolean().optional(),
         // COMPAT(daemonSelfUpdate): added in v0.1.93, remove gate after 2026-12-13.
         daemonSelfUpdate: z.boolean().optional(),
+        // COMPAT(taskProgress): added in v0.1.X, drop the gate when floor >= v0.1.X.
+        taskProgress: z.boolean().optional(),
       })
       .optional(),
   })

--- a/packages/protocol/src/task-progress.test.ts
+++ b/packages/protocol/src/task-progress.test.ts
@@ -132,6 +132,15 @@ describe("applyTaskDelta", () => {
     ]);
   });
 
+  it("assigns a non-colliding id after a deletion shrinks the list", () => {
+    // Regression: create 1, 2 → delete 1 → create → must NOT reuse "2".
+    let entries = applyTaskDelta([], { kind: "create", text: "a", status: "pending" }, "c1");
+    entries = applyTaskDelta(entries, { kind: "create", text: "b", status: "pending" }, "c2");
+    entries = applyTaskDelta(entries, { kind: "delete", id: "1" });
+    entries = applyTaskDelta(entries, { kind: "create", text: "c", status: "pending" }, "c3");
+    expect(entries.map((entry) => entry.id)).toEqual(["2", "3"]);
+  });
+
   it("is a no-op when updating an unknown id", () => {
     const start: TaskEntryWithId[] = [{ id: "1", text: "a", status: "pending" }];
     expect(applyTaskDelta(start, { kind: "update", id: "99", status: "completed" })).toBe(start);

--- a/packages/protocol/src/task-progress.test.ts
+++ b/packages/protocol/src/task-progress.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTaskProgress, extractTaskEntriesFromToolCall } from "./task-progress.js";
+
+describe("extractTaskEntriesFromToolCall", () => {
+  it("extracts TodoWrite entries with three-way status", () => {
+    const tasks = extractTaskEntriesFromToolCall("TodoWrite", {
+      todos: [
+        { content: "Task 1", status: "pending" },
+        { content: "Task 2", status: "in_progress" },
+        { content: "Task 3", status: "completed" },
+      ],
+    });
+
+    expect(tasks?.map((task) => task.status)).toEqual(["pending", "in_progress", "completed"]);
+    expect(tasks?.map((task) => task.completed)).toEqual([false, false, true]);
+  });
+
+  it("prefers activeForm over content for the text", () => {
+    const tasks = extractTaskEntriesFromToolCall("TodoWrite", {
+      todos: [{ content: "Write tests", status: "in_progress", activeForm: "Writing tests" }],
+    });
+
+    expect(tasks?.[0]?.text).toBe("Writing tests");
+  });
+
+  it("normalizes separator variants of the tool name", () => {
+    for (const name of ["todo.write", "todo-write", "Todo Write", "todo_write"]) {
+      expect(extractTaskEntriesFromToolCall(name, { todos: [] })).toEqual([]);
+    }
+  });
+
+  it("returns null for non task-list tools and ExitPlanMode", () => {
+    expect(extractTaskEntriesFromToolCall("Bash", { command: "ls" })).toBeNull();
+    expect(extractTaskEntriesFromToolCall("ExitPlanMode", { plan: "x" })).toBeNull();
+  });
+
+  it("parses Codex UpdatePlan steps", () => {
+    const tasks = extractTaskEntriesFromToolCall("update_plan", {
+      plan: [
+        { step: "Investigate", status: "completed" },
+        { step: "Implement", status: "pending" },
+      ],
+    });
+
+    expect(tasks?.map((task) => task.text)).toEqual(["Investigate", "Implement"]);
+  });
+});
+
+describe("buildTaskProgress", () => {
+  it("aggregates counts and preserves order", () => {
+    const entries = extractTaskEntriesFromToolCall("TodoWrite", {
+      todos: [
+        { content: "a", status: "completed" },
+        { content: "b", status: "in_progress" },
+        { content: "c", status: "pending" },
+        { content: "d", status: "pending" },
+      ],
+    });
+
+    const progress = buildTaskProgress(entries ?? [], "2026-06-28T00:00:00.000Z");
+
+    expect(progress).toEqual({
+      items: [
+        { text: "a", status: "completed" },
+        { text: "b", status: "in_progress" },
+        { text: "c", status: "pending" },
+        { text: "d", status: "pending" },
+      ],
+      pending: 2,
+      inProgress: 1,
+      completed: 1,
+      total: 4,
+      updatedAt: "2026-06-28T00:00:00.000Z",
+    });
+  });
+});

--- a/packages/protocol/src/task-progress.test.ts
+++ b/packages/protocol/src/task-progress.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { buildTaskProgress, extractTaskEntriesFromToolCall } from "./task-progress.js";
+import {
+  applyTaskDelta,
+  buildTaskProgress,
+  extractTaskDeltaFromToolCall,
+  extractTaskEntriesFromToolCall,
+  taskEntriesToProgress,
+  type TaskEntryWithId,
+} from "./task-progress.js";
 
 describe("extractTaskEntriesFromToolCall", () => {
   it("extracts TodoWrite entries with three-way status", () => {
@@ -44,6 +51,105 @@ describe("extractTaskEntriesFromToolCall", () => {
     });
 
     expect(tasks?.map((task) => task.text)).toEqual(["Investigate", "Implement"]);
+  });
+});
+
+describe("extractTaskDeltaFromToolCall", () => {
+  it("parses TaskCreate into a create delta (pending)", () => {
+    const delta = extractTaskDeltaFromToolCall("TaskCreate", {
+      subject: "Build the CLI",
+      description: "long form",
+    });
+    expect(delta).toEqual({ kind: "create", text: "Build the CLI", status: "pending" });
+  });
+
+  it("prefers activeForm over subject for create text", () => {
+    const delta = extractTaskDeltaFromToolCall("TaskCreate", {
+      subject: "Build the CLI",
+      activeForm: "Building the CLI",
+    });
+    expect(delta).toMatchObject({ kind: "create", text: "Building the CLI" });
+  });
+
+  it("parses TaskUpdate status changes", () => {
+    expect(
+      extractTaskDeltaFromToolCall("TaskUpdate", { taskId: 2, status: "in_progress" }),
+    ).toEqual({ kind: "update", id: "2", status: "in_progress" });
+  });
+
+  it("maps TaskUpdate deleted status to a delete delta", () => {
+    expect(extractTaskDeltaFromToolCall("TaskUpdate", { taskId: "3", status: "deleted" })).toEqual({
+      kind: "delete",
+      id: "3",
+    });
+  });
+
+  it("normalizes separator variants of the task tool names", () => {
+    for (const name of ["TaskCreate", "taskcreate", "task_create", "task.create", "Task Create"]) {
+      expect(extractTaskDeltaFromToolCall(name, { subject: "x" })).toMatchObject({
+        kind: "create",
+      });
+    }
+  });
+
+  it("returns null for unrelated tools", () => {
+    expect(extractTaskDeltaFromToolCall("Bash", { command: "ls" })).toBeNull();
+    expect(extractTaskDeltaFromToolCall("TodoWrite", { todos: [] })).toBeNull();
+  });
+});
+
+describe("applyTaskDelta", () => {
+  it("appends on create, assigning a positional logical id", () => {
+    const after = applyTaskDelta([], { kind: "create", text: "a", status: "pending" }, "call-1");
+    expect(after).toEqual([{ id: "1", callId: "call-1", text: "a", status: "pending" }]);
+  });
+
+  it("dedupes a create recorded twice under the same callId", () => {
+    let entries = applyTaskDelta([], { kind: "create", text: "a", status: "pending" }, "call-1");
+    // Same call recorded again (running → completed) with fuller text.
+    entries = applyTaskDelta(
+      entries,
+      { kind: "create", text: "Task A", status: "pending" },
+      "call-1",
+    );
+    expect(entries).toEqual([{ id: "1", callId: "call-1", text: "Task A", status: "pending" }]);
+  });
+
+  it("mutates status of the matching logical id on update", () => {
+    const start: TaskEntryWithId[] = [{ id: "1", callId: "c1", text: "a", status: "pending" }];
+    expect(applyTaskDelta(start, { kind: "update", id: "1", status: "completed" })).toEqual([
+      { id: "1", callId: "c1", text: "a", status: "completed" },
+    ]);
+  });
+
+  it("drops the matching logical id on delete", () => {
+    const start: TaskEntryWithId[] = [
+      { id: "1", text: "a", status: "pending" },
+      { id: "2", text: "b", status: "pending" },
+    ];
+    expect(applyTaskDelta(start, { kind: "delete", id: "1" })).toEqual([
+      { id: "2", text: "b", status: "pending" },
+    ]);
+  });
+
+  it("is a no-op when updating an unknown id", () => {
+    const start: TaskEntryWithId[] = [{ id: "1", text: "a", status: "pending" }];
+    expect(applyTaskDelta(start, { kind: "update", id: "99", status: "completed" })).toBe(start);
+  });
+
+  it("accumulates a create/update sequence into the expected counts", () => {
+    let entries: TaskEntryWithId[] = [];
+    ["a", "b", "c"].forEach((text, index) => {
+      entries = applyTaskDelta(
+        entries,
+        { kind: "create", text, status: "pending" },
+        `call-${index}`,
+      );
+    });
+    entries = applyTaskDelta(entries, { kind: "update", id: "1", status: "in_progress" });
+    entries = applyTaskDelta(entries, { kind: "update", id: "1", status: "completed" });
+    const progress = taskEntriesToProgress(entries, "2026-06-28T00:00:00.000Z");
+    expect(progress).toMatchObject({ pending: 2, inProgress: 0, completed: 1, total: 3 });
   });
 });
 

--- a/packages/protocol/src/task-progress.ts
+++ b/packages/protocol/src/task-progress.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+import { type TaskProgressPayload, type TaskStatus, TaskStatusSchema } from "./messages.js";
+
+export interface TaskEntry {
+  text: string;
+  status: TaskStatus;
+  completed: boolean;
+}
+
+const ClaudeTodoWriteSchema = z.object({
+  todos: z.array(
+    z.object({
+      content: z.string(),
+      status: TaskStatusSchema,
+      activeForm: z.string().optional(),
+    }),
+  ),
+});
+
+const UpdatePlanSchema = z.object({
+  plan: z.array(
+    z.object({
+      step: z.string(),
+      status: TaskStatusSchema.catch("pending"),
+    }),
+  ),
+});
+
+/**
+ * Normalize a tool name for task-list detection. Kept distinct from
+ * protocol's `normalizeToolName` (which only lowercases) because task
+ * detection collapses separators so "todo.write" / "todo-write" / "Todo Write"
+ * all match "todo_write".
+ */
+function normalizeTaskToolName(toolName: string): string {
+  return toolName
+    .trim()
+    .replace(/[.\s-]+/g, "_")
+    .toLowerCase();
+}
+
+/**
+ * Extract task entries (with full three-way status) from a task-list tool call.
+ * Handles Claude's TodoWrite and Codex's UpdatePlan. Returns null when the tool
+ * is not a task list. Shared by the daemon (to persist taskProgress) and the
+ * app (to render the inline TodoListCard) so the two never drift.
+ */
+export function extractTaskEntriesFromToolCall(
+  toolName: string,
+  input: unknown,
+): TaskEntry[] | null {
+  const normalized = normalizeTaskToolName(toolName);
+
+  // Claude's plan mode uses ExitPlanMode for the approval prompt; it is not a task list.
+  if (normalized === "exitplanmode") {
+    return null;
+  }
+
+  if (normalized === "todowrite" || normalized === "todo_write") {
+    const parsed = ClaudeTodoWriteSchema.safeParse(input);
+    if (!parsed.success) {
+      return null;
+    }
+    return parsed.data.todos.map((todo) => {
+      const status = todo.status;
+      const text = todo.activeForm?.trim() || todo.content.trim();
+      return {
+        text: text.length ? text : todo.content,
+        status,
+        completed: status === "completed",
+      };
+    });
+  }
+
+  if (normalized === "update_plan") {
+    const parsed = UpdatePlanSchema.safeParse(input);
+    if (!parsed.success) {
+      return null;
+    }
+    return parsed.data.plan
+      .map((entry) => ({
+        text: entry.step.trim(),
+        status: entry.status,
+        completed: entry.status === "completed",
+      }))
+      .filter((entry) => entry.text.length > 0);
+  }
+
+  return null;
+}
+
+/**
+ * Aggregate task entries into a persisted TaskProgress snapshot with counts.
+ * `updatedAt` is supplied by the caller (ISO string) so this stays pure.
+ */
+export function buildTaskProgress(entries: TaskEntry[], updatedAt: string): TaskProgressPayload {
+  let pending = 0;
+  let inProgress = 0;
+  let completed = 0;
+  for (const entry of entries) {
+    if (entry.status === "completed") {
+      completed += 1;
+    } else if (entry.status === "in_progress") {
+      inProgress += 1;
+    } else {
+      pending += 1;
+    }
+  }
+  return {
+    items: entries.map((entry) => ({ text: entry.text, status: entry.status })),
+    pending,
+    inProgress,
+    completed,
+    total: entries.length,
+    updatedAt,
+  };
+}

--- a/packages/protocol/src/task-progress.ts
+++ b/packages/protocol/src/task-progress.ts
@@ -217,6 +217,18 @@ export function extractTaskDeltaFromToolCall(toolName: string, input: unknown): 
  * - update: mutate text/status of the matching logical id; no-op if unknown.
  * - delete: drop the matching logical id.
  */
+/** Next monotonic logical id: one past the highest numeric id in use. */
+function nextTaskId(entries: TaskEntryWithId[]): number {
+  let max = 0;
+  for (const entry of entries) {
+    const parsed = Number(entry.id);
+    if (Number.isInteger(parsed) && parsed > max) {
+      max = parsed;
+    }
+  }
+  return max + 1;
+}
+
 export function applyTaskDelta(
   entries: TaskEntryWithId[],
   delta: TaskDelta,
@@ -237,7 +249,11 @@ export function applyTaskDelta(
         return next;
       }
     }
-    const id = String(entries.length + 1);
+    // Derive the next id from the max existing numeric id, never the list
+    // length: after a delete the length shrinks and a length-based id would
+    // collide with a surviving entry (delete "1" from ["1","2"] then create →
+    // length 1 → "2", colliding with the survivor). Max-based ids stay unique.
+    const id = String(nextTaskId(entries));
     const created: TaskEntryWithId = {
       id,
       ...(callId !== undefined ? { callId } : {}),

--- a/packages/protocol/src/task-progress.ts
+++ b/packages/protocol/src/task-progress.ts
@@ -89,6 +89,196 @@ export function extractTaskEntriesFromToolCall(
   return null;
 }
 
+// ---------------------------------------------------------------------------
+// Incremental (delta) task tools
+//
+// Full-list tools (TodoWrite / UpdatePlan, above) send the entire task array on
+// every call, so they are stateless. Other harnesses — notably Claude Code's
+// built-in TaskCreate / TaskUpdate — emit one task at a time as deltas, so the
+// daemon must accumulate them per agent. This layer parses a single tool call
+// into a TaskDelta and applies it to a running list.
+// ---------------------------------------------------------------------------
+
+/**
+ * Accumulated list element. `id` is the harness's logical task id (assigned in
+ * creation order: "1", "2", …) that TaskUpdate references. `callId` is the
+ * timeline tool-call id used to dedupe a create that is recorded multiple times
+ * (running → completed) so it doesn't append twice.
+ */
+export interface TaskEntryWithId {
+  id: string;
+  callId?: string;
+  text: string;
+  status: TaskStatus;
+}
+
+export type TaskDelta =
+  | { kind: "create"; text: string; status: TaskStatus }
+  | { kind: "update"; id: string; text?: string; status?: TaskStatus }
+  | { kind: "delete"; id: string };
+
+/** A tool whose calls are incremental task deltas rather than a full list. */
+interface TaskDeltaToolAdapter {
+  matches(normalizedName: string): boolean;
+  parse(input: unknown): TaskDelta | null;
+}
+
+const ClaudeTaskCreateSchema = z.object({
+  subject: z.string(),
+  description: z.string().optional(),
+  activeForm: z.string().optional(),
+});
+
+// TaskUpdate carries a "deleted" status in addition to the three-way set, which
+// we translate into a delete delta.
+const TaskUpdateStatusSchema = z.enum(["pending", "in_progress", "completed", "deleted"]);
+
+const ClaudeTaskUpdateSchema = z.object({
+  taskId: z.union([z.string(), z.number()]).optional(),
+  id: z.union([z.string(), z.number()]).optional(),
+  status: TaskUpdateStatusSchema.optional(),
+  subject: z.string().optional(),
+});
+
+function toIdString(value: string | number | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+  const str = String(value).trim();
+  return str.length ? str : null;
+}
+
+const claudeCodeTaskAdapter: TaskDeltaToolAdapter = {
+  matches(normalizedName) {
+    return (
+      normalizedName === "taskcreate" ||
+      normalizedName === "task_create" ||
+      normalizedName === "taskupdate" ||
+      normalizedName === "task_update"
+    );
+  },
+  parse(input) {
+    // A TaskUpdate is distinguished by carrying taskId/status; a TaskCreate
+    // carries a subject. Check update first so a create that happens to omit a
+    // subject (the transient "running" event has empty input) is not mistaken
+    // for a create with empty text.
+    const updated = ClaudeTaskUpdateSchema.safeParse(input);
+    if (updated.success && (updated.data.taskId !== undefined || updated.data.id !== undefined)) {
+      const id = toIdString(updated.data.taskId ?? updated.data.id);
+      if (!id) {
+        return null;
+      }
+      if (updated.data.status === "deleted") {
+        return { kind: "delete", id };
+      }
+      const text = updated.data.subject?.trim();
+      return {
+        kind: "update",
+        id,
+        ...(text ? { text } : {}),
+        ...(updated.data.status ? { status: updated.data.status } : {}),
+      };
+    }
+    const created = ClaudeTaskCreateSchema.safeParse(input);
+    if (created.success && created.data.subject.trim().length > 0) {
+      const text = created.data.activeForm?.trim() || created.data.subject.trim();
+      return { kind: "create", text, status: "pending" };
+    }
+    return null;
+  },
+};
+
+const TASK_DELTA_ADAPTERS: TaskDeltaToolAdapter[] = [claudeCodeTaskAdapter];
+
+/**
+ * Parse a single tool call into a TaskDelta when it belongs to an incremental
+ * task tool (e.g. Claude Code's TaskCreate/TaskUpdate). Returns null otherwise.
+ * Adding a new incremental tool means adding one adapter — no daemon changes.
+ */
+export function extractTaskDeltaFromToolCall(toolName: string, input: unknown): TaskDelta | null {
+  const normalized = normalizeTaskToolName(toolName);
+  for (const adapter of TASK_DELTA_ADAPTERS) {
+    if (adapter.matches(normalized)) {
+      return adapter.parse(input);
+    }
+  }
+  return null;
+}
+
+/**
+ * Apply a single delta to a running task list. Pure: returns a new array.
+ *
+ * `callId` is the timeline tool-call id. The same TaskCreate call is recorded
+ * multiple times (running → completed), so creates are deduped by `callId`:
+ * the first occurrence appends with the next ordinal logical id ("1", "2", …),
+ * and later occurrences of the same call update that entry's text in place.
+ * TaskUpdate references the logical id via its `id`.
+ * - create: append (deduped by callId); assign ordinal logical id.
+ * - update: mutate text/status of the matching logical id; no-op if unknown.
+ * - delete: drop the matching logical id.
+ */
+export function applyTaskDelta(
+  entries: TaskEntryWithId[],
+  delta: TaskDelta,
+  callId?: string,
+): TaskEntryWithId[] {
+  if (delta.kind === "create") {
+    if (callId !== undefined) {
+      const existingIndex = entries.findIndex((entry) => entry.callId === callId);
+      if (existingIndex !== -1) {
+        // Same create call recorded again (e.g. completed after running):
+        // refresh its text/status rather than appending a duplicate.
+        const next = [...entries];
+        next[existingIndex] = {
+          ...next[existingIndex],
+          text: delta.text || next[existingIndex].text,
+          status: delta.status,
+        };
+        return next;
+      }
+    }
+    const id = String(entries.length + 1);
+    const created: TaskEntryWithId = {
+      id,
+      ...(callId !== undefined ? { callId } : {}),
+      text: delta.text,
+      status: delta.status,
+    };
+    return [...entries, created];
+  }
+  if (delta.kind === "delete") {
+    return entries.filter((entry) => entry.id !== delta.id);
+  }
+  let matched = false;
+  const next = entries.map((entry) => {
+    if (entry.id !== delta.id) {
+      return entry;
+    }
+    matched = true;
+    return {
+      ...entry,
+      ...(delta.text !== undefined ? { text: delta.text } : {}),
+      ...(delta.status !== undefined ? { status: delta.status } : {}),
+    };
+  });
+  return matched ? next : entries;
+}
+
+/** Build a TaskProgress snapshot from an accumulated (id-carrying) task list. */
+export function taskEntriesToProgress(
+  entries: TaskEntryWithId[],
+  updatedAt: string,
+): TaskProgressPayload {
+  return buildTaskProgress(
+    entries.map((entry) => ({
+      text: entry.text,
+      status: entry.status,
+      completed: entry.status === "completed",
+    })),
+    updatedAt,
+  );
+}
+
 /**
  * Aggregate task entries into a persisted TaskProgress snapshot with counts.
  * `updatedAt` is supplied by the caller (ISO string) so this stays pure.

--- a/packages/server/src/server/agent/agent-loading.ts
+++ b/packages/server/src/server/agent/agent-loading.ts
@@ -71,6 +71,9 @@ export async function ensureAgentLoaded(
     }
 
     await deps.agentManager.hydrateTimelineFromProvider(agentId);
+    // Restore persisted task progress + incremental accumulator onto the live
+    // agent so the indicator and further deltas survive a daemon restart.
+    deps.agentManager.restoreTaskState(agentId, record);
     return deps.agentManager.getAgent(agentId) ?? snapshot;
   })();
 

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -43,6 +43,11 @@ import {
   type ListImportableSessionsOptions,
 } from "./agent-sdk-types.js";
 import { buildArchivedAgentRecord, type ArchivedStoredAgentRecord } from "./agent-archive.js";
+import type { TaskProgressPayload } from "../messages.js";
+import {
+  buildTaskProgress,
+  extractTaskEntriesFromToolCall,
+} from "@getpaseo/protocol/task-progress";
 import type { StoredAgentRecord, AgentStorage } from "./agent-storage.js";
 import {
   InMemoryAgentTimelineStore,
@@ -147,6 +152,55 @@ export type AgentManagerEvent =
     };
 
 export type AgentSubscriber = (event: AgentManagerEvent) => void;
+
+/**
+ * Derive a TaskProgress snapshot from a timeline item, or null when the item is
+ * not a task list. Handles Claude's TodoWrite (raw input on the tool_call
+ * detail) and OpenCode's `todo` item (already collapsed to completed booleans,
+ * so in_progress cannot be distinguished for OpenCode).
+ */
+function deriveTaskProgressFromTimelineItem(item: AgentTimelineItem): TaskProgressPayload | null {
+  const updatedAt = new Date().toISOString();
+  if (item.type === "tool_call" && item.detail.type === "unknown") {
+    const entries = extractTaskEntriesFromToolCall(item.name, item.detail.input);
+    if (!entries) {
+      return null;
+    }
+    return buildTaskProgress(entries, updatedAt);
+  }
+  if (item.type === "todo") {
+    const entries = item.items.map((todo) => ({
+      text: todo.text,
+      status: (todo.completed
+        ? "completed"
+        : "pending") as TaskProgressPayload["items"][number]["status"],
+      completed: todo.completed,
+    }));
+    return buildTaskProgress(entries, updatedAt);
+  }
+  return null;
+}
+
+function taskProgressEqual(a: TaskProgressPayload | undefined, b: TaskProgressPayload): boolean {
+  if (!a) {
+    return false;
+  }
+  if (
+    a.pending !== b.pending ||
+    a.inProgress !== b.inProgress ||
+    a.completed !== b.completed ||
+    a.total !== b.total ||
+    a.items.length !== b.items.length
+  ) {
+    return false;
+  }
+  for (let i = 0; i < a.items.length; i += 1) {
+    if (a.items[i].text !== b.items[i].text || a.items[i].status !== b.items[i].status) {
+      return false;
+    }
+  }
+  return true;
+}
 
 export interface SubscribeOptions {
   agentId?: string;
@@ -288,6 +342,12 @@ interface ManagedAgentBase {
   lastUserMessageAt: Date | null;
   lastUsage?: AgentUsage;
   lastError?: string;
+  /**
+   * Latest task-list snapshot (Claude TodoWrite / OpenCode todos / Codex
+   * UpdatePlan) with three-way status counts. Persisted on the agent record so
+   * every client can render task progress without loading the agent's stream.
+   */
+  taskProgress?: TaskProgressPayload;
   attention: AttentionState;
   foregroundTurnWaiters: Set<ForegroundTurnWaiter>;
   finalizedForegroundTurnIds: Set<string>;
@@ -2983,9 +3043,42 @@ export class AgentManager {
       this.dispatchStream(agent.id, event, { timestamp: new Date().toISOString() });
     }
 
+    if (!options?.fromHistory && event.type === "timeline") {
+      void this.maybeUpdateTaskProgress(agent, event.item);
+    }
+
     this.traceHandleStreamEventEnd(agent, event, eventTurnId, flags);
 
     return flags.shouldNotifyWaiters;
+  }
+
+  /**
+   * Persist + broadcast an updated task-progress snapshot when a timeline item
+   * carries a task list. A TodoWrite tool call (Claude) or a `todo` item
+   * (OpenCode) does not constitute a lifecycle change on its own, so we must
+   * emit an explicit agent-state update for clients to see live progress.
+   */
+  private async maybeUpdateTaskProgress(
+    agent: ManagedAgent,
+    item: AgentTimelineItem,
+  ): Promise<void> {
+    if (agent.internal) {
+      return;
+    }
+    const next = deriveTaskProgressFromTimelineItem(item);
+    if (!next) {
+      return;
+    }
+    if (taskProgressEqual(agent.taskProgress, next)) {
+      return;
+    }
+    agent.taskProgress = next;
+    try {
+      await this.persistSnapshot(agent);
+    } catch (error) {
+      this.logger.warn({ agentId: agent.id, error }, "agent.manager.task_progress.persist_failed");
+    }
+    this.emitState(agent, { persist: false });
   }
 
   private traceHandleStreamEventStart(

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -45,8 +45,12 @@ import {
 import { buildArchivedAgentRecord, type ArchivedStoredAgentRecord } from "./agent-archive.js";
 import type { TaskProgressPayload } from "../messages.js";
 import {
+  applyTaskDelta,
   buildTaskProgress,
+  extractTaskDeltaFromToolCall,
   extractTaskEntriesFromToolCall,
+  taskEntriesToProgress,
+  type TaskEntryWithId,
 } from "@getpaseo/protocol/task-progress";
 import type { StoredAgentRecord, AgentStorage } from "./agent-storage.js";
 import {
@@ -348,6 +352,12 @@ interface ManagedAgentBase {
    * every client can render task progress without loading the agent's stream.
    */
   taskProgress?: TaskProgressPayload;
+  /**
+   * Running list accumulated from incremental task tools (Claude Code
+   * TaskCreate/TaskUpdate). Full-list tools (TodoWrite/UpdatePlan) clear this.
+   * Persisted so deltas survive a daemon restart.
+   */
+  taskDeltaEntries?: TaskEntryWithId[];
   attention: AttentionState;
   foregroundTurnWaiters: Set<ForegroundTurnWaiter>;
   finalizedForegroundTurnIds: Set<string>;
@@ -3043,10 +3053,6 @@ export class AgentManager {
       this.dispatchStream(agent.id, event, { timestamp: new Date().toISOString() });
     }
 
-    if (!options?.fromHistory && event.type === "timeline") {
-      void this.maybeUpdateTaskProgress(agent, event.item);
-    }
-
     this.traceHandleStreamEventEnd(agent, event, eventTurnId, flags);
 
     return flags.shouldNotifyWaiters;
@@ -3065,7 +3071,7 @@ export class AgentManager {
     if (agent.internal) {
       return;
     }
-    const next = deriveTaskProgressFromTimelineItem(item);
+    const next = this.deriveNextTaskProgress(agent, item);
     if (!next) {
       return;
     }
@@ -3079,6 +3085,50 @@ export class AgentManager {
       this.logger.warn({ agentId: agent.id, error }, "agent.manager.task_progress.persist_failed");
     }
     this.emitState(agent, { persist: false });
+  }
+
+  /**
+   * Compute the next task-progress snapshot for a timeline item. Incremental
+   * tools (Claude Code TaskCreate/TaskUpdate) accumulate into a per-agent list;
+   * full-list tools (TodoWrite/UpdatePlan/OpenCode todos) replace it and clear
+   * the incremental accumulator so the two semantics never double-count.
+   */
+  private deriveNextTaskProgress(
+    agent: ManagedAgent,
+    item: AgentTimelineItem,
+  ): TaskProgressPayload | null {
+    if (item.type === "tool_call" && item.detail.type === "unknown") {
+      const delta = extractTaskDeltaFromToolCall(item.name, item.detail.input);
+      if (delta) {
+        // callId dedupes a create recorded multiple times (running → completed).
+        const current: TaskEntryWithId[] = agent.taskDeltaEntries ?? [];
+        agent.taskDeltaEntries = applyTaskDelta(current, delta, item.callId);
+        return taskEntriesToProgress(agent.taskDeltaEntries, new Date().toISOString());
+      }
+    }
+    const fullList = deriveTaskProgressFromTimelineItem(item);
+    if (fullList) {
+      // A full-list snapshot supersedes any incremental accumulation.
+      agent.taskDeltaEntries = undefined;
+    }
+    return fullList;
+  }
+
+  /**
+   * Seed task state onto a freshly loaded agent from its stored record so
+   * progress (and the incremental accumulator) survive a daemon restart.
+   */
+  restoreTaskState(agentId: string, record: StoredAgentRecord): void {
+    const agent = this.agents.get(agentId);
+    if (!agent) {
+      return;
+    }
+    if (record.taskProgress) {
+      agent.taskProgress = record.taskProgress;
+    }
+    if (record.taskDeltaEntries) {
+      agent.taskDeltaEntries = record.taskDeltaEntries;
+    }
   }
 
   private traceHandleStreamEventStart(
@@ -3531,6 +3581,14 @@ export class AgentManager {
   ): AgentTimelineRow {
     const row = this.timelineStore.append(agentId, item, options);
     this.enqueueDurableTimelineAppend(agentId, row);
+    // recordTimeline is the single funnel for every timeline write — provider
+    // stream events AND MCP tool results (Claude Code TaskCreate/TaskUpdate
+    // arrive via the latter, bypassing handleStreamEvent). Derive task progress
+    // here so both paths are covered.
+    const agent = this.agents.get(agentId);
+    if (agent) {
+      void this.maybeUpdateTaskProgress(agent, item);
+    }
     return row;
   }
 

--- a/packages/server/src/server/agent/agent-projections.test.ts
+++ b/packages/server/src/server/agent/agent-projections.test.ts
@@ -439,6 +439,25 @@ describe("taskProgress projection", () => {
     const payload = buildStoredAgentPayload(record, ["claude"]);
     expect(payload.taskProgress).toEqual(progress);
   });
+
+  it("round-trips the incremental task-delta accumulator on the stored record", () => {
+    const agent = createManagedAgent({
+      taskDeltaEntries: [
+        { id: "1", callId: "c1", text: "a", status: "completed" },
+        { id: "2", callId: "c2", text: "b", status: "pending" },
+      ],
+    });
+    const record = toStoredAgentRecord(agent);
+    expect(record.taskDeltaEntries).toEqual([
+      { id: "1", callId: "c1", text: "a", status: "completed" },
+      { id: "2", callId: "c2", text: "b", status: "pending" },
+    ]);
+  });
+
+  it("omits the accumulator fields when absent", () => {
+    const record = toStoredAgentRecord(createManagedAgent());
+    expect(record.taskDeltaEntries).toBeUndefined();
+  });
 });
 
 describe("toRecentProviderSessionDescriptorPayload", () => {

--- a/packages/server/src/server/agent/agent-projections.test.ts
+++ b/packages/server/src/server/agent/agent-projections.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import { AGENT_LIFECYCLE_STATUSES } from "./agent-manager.js";
 import {
+  buildStoredAgentPayload,
   toAgentPayload,
   toRecentProviderSessionDescriptorPayload,
   toStoredAgentRecord,
   type ManagedAgent,
 } from "./agent-projections.js";
+import type { TaskProgressPayload } from "../messages.js";
 import type { AgentSession } from "./agent-sdk-types.js";
 import type {
   AgentFeature,
@@ -396,6 +398,46 @@ describe("toAgentPayload", () => {
     const payload = toAgentPayload(agent);
 
     expect(payload.features).toEqual(features);
+  });
+});
+
+describe("taskProgress projection", () => {
+  const progress: TaskProgressPayload = {
+    items: [
+      { text: "Investigate", status: "completed" },
+      { text: "Implement", status: "in_progress" },
+      { text: "Test", status: "pending" },
+    ],
+    pending: 1,
+    inProgress: 1,
+    completed: 1,
+    total: 3,
+    updatedAt: "2026-06-28T00:00:00.000Z",
+  };
+
+  it("persists taskProgress on the stored record", () => {
+    const agent = createManagedAgent({ taskProgress: progress });
+    const record = toStoredAgentRecord(agent);
+    expect(record.taskProgress).toEqual(progress);
+  });
+
+  it("includes taskProgress in the live snapshot payload", () => {
+    const agent = createManagedAgent({ taskProgress: progress });
+    const payload = toAgentPayload(agent);
+    expect(payload.taskProgress).toEqual(progress);
+  });
+
+  it("omits taskProgress when absent", () => {
+    const agent = createManagedAgent();
+    expect(toAgentPayload(agent)).not.toHaveProperty("taskProgress");
+    expect(toStoredAgentRecord(agent).taskProgress).toBeUndefined();
+  });
+
+  it("restores taskProgress from the stored record snapshot", () => {
+    const agent = createManagedAgent({ taskProgress: progress });
+    const record = toStoredAgentRecord(agent);
+    const payload = buildStoredAgentPayload(record, ["claude"]);
+    expect(payload.taskProgress).toEqual(progress);
   });
 });
 

--- a/packages/server/src/server/agent/agent-projections.ts
+++ b/packages/server/src/server/agent/agent-projections.ts
@@ -93,6 +93,7 @@ export function toStoredAgentRecord(
       ? agent.attention.attentionTimestamp.toISOString()
       : null,
     internal: options?.internal,
+    taskProgress: agent.taskProgress,
   } satisfies StoredAgentRecord;
 }
 
@@ -147,6 +148,10 @@ export function toAgentPayload(
   } else {
     payload.attentionReason = null;
     payload.attentionTimestamp = null;
+  }
+
+  if (agent.taskProgress) {
+    payload.taskProgress = agent.taskProgress;
   }
 
   return payload;
@@ -236,6 +241,7 @@ export function buildStoredAgentPayload(
     archivedAt: record.archivedAt ?? null,
     labels: normalizeLabels(record.labels),
     ...(providerAvailable ? {} : { providerUnavailable: true }),
+    ...(record.taskProgress ? { taskProgress: record.taskProgress } : {}),
   };
 }
 

--- a/packages/server/src/server/agent/agent-projections.ts
+++ b/packages/server/src/server/agent/agent-projections.ts
@@ -94,6 +94,7 @@ export function toStoredAgentRecord(
       : null,
     internal: options?.internal,
     taskProgress: agent.taskProgress,
+    ...(agent.taskDeltaEntries ? { taskDeltaEntries: agent.taskDeltaEntries } : {}),
   } satisfies StoredAgentRecord;
 }
 

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -4,7 +4,12 @@ import { z } from "zod";
 import type { Logger } from "pino";
 
 import { writeJsonFileAtomic } from "../atomic-file.js";
-import { AgentFeatureSchema, AgentStatusSchema, TaskProgressPayloadSchema } from "../messages.js";
+import {
+  AgentFeatureSchema,
+  AgentStatusSchema,
+  TaskProgressPayloadSchema,
+  TaskStatusSchema,
+} from "../messages.js";
 import { toStoredAgentRecord } from "./agent-projections.js";
 import type { ManagedAgent } from "./agent-manager.js";
 import type { AgentSessionConfig } from "./agent-sdk-types.js";
@@ -66,6 +71,19 @@ const STORED_AGENT_SCHEMA = z.object({
   archivedAt: z.string().nullable().optional(),
   // COMPAT(taskProgress): added in v0.1.X. Old records read back undefined (optional).
   taskProgress: TaskProgressPayloadSchema.optional(),
+  // COMPAT(taskDeltaAccumulator): added in v0.1.X, optional; old records read back
+  // undefined. Persists the running list built from incremental task tools
+  // (Claude Code TaskCreate/TaskUpdate) so deltas survive a daemon restart.
+  taskDeltaEntries: z
+    .array(
+      z.object({
+        id: z.string(),
+        callId: z.string().optional(),
+        text: z.string(),
+        status: TaskStatusSchema,
+      }),
+    )
+    .optional(),
 });
 
 export type SerializableAgentConfig = Pick<

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import type { Logger } from "pino";
 
 import { writeJsonFileAtomic } from "../atomic-file.js";
-import { AgentFeatureSchema, AgentStatusSchema } from "../messages.js";
+import { AgentFeatureSchema, AgentStatusSchema, TaskProgressPayloadSchema } from "../messages.js";
 import { toStoredAgentRecord } from "./agent-projections.js";
 import type { ManagedAgent } from "./agent-manager.js";
 import type { AgentSessionConfig } from "./agent-sdk-types.js";
@@ -64,6 +64,8 @@ const STORED_AGENT_SCHEMA = z.object({
   attentionTimestamp: z.string().nullable().optional(),
   internal: z.boolean().optional(),
   archivedAt: z.string().nullable().optional(),
+  // COMPAT(taskProgress): added in v0.1.X. Old records read back undefined (optional).
+  taskProgress: TaskProgressPayloadSchema.optional(),
 });
 
 export type SerializableAgentConfig = Pick<

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -163,6 +163,7 @@ function buildAgentManagerSpies() {
     getTimeline: vi.fn().mockReturnValue([]),
     resumeAgentFromPersistence: vi.fn(),
     hydrateTimelineFromProvider: vi.fn().mockResolvedValue(undefined),
+    restoreTaskState: vi.fn(),
     appendTimelineItem: vi.fn().mockResolvedValue(undefined),
     emitLiveTimelineItem: vi.fn().mockResolvedValue(undefined),
     hasInFlightRun: vi.fn().mockReturnValue(false),

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1182,6 +1182,8 @@ export class VoiceAssistantWebSocketServer {
         daemonDiagnostics: true,
         // COMPAT(daemonSelfUpdate): added in v0.1.93, remove gate after 2026-12-13.
         daemonSelfUpdate: true,
+        // COMPAT(taskProgress): added in v0.1.X, drop the gate when floor >= v0.1.X.
+        taskProgress: true,
       },
     };
   }


### PR DESCRIPTION
### Linked issue

Closes #<!-- 填对应 issue 号 -->

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Surface agent task lists as live progress. The daemon parses task-list tool calls,
persists a `taskProgress` snapshot on the agent, and streams it over the protocol;
the app renders an inline progress track and a Tasks dashboard reachable from the
main sidebar.

- Shared protocol helper (`task-progress.ts`) extracts task entries from full-list
  tools (Claude TodoWrite, Codex UpdatePlan, OpenCode todos) **and** incremental
  tools (Claude Code TaskCreate/TaskUpdate, which emit one task at a time as
  deltas). Deltas accumulate into a per-agent list, deduped by tool-call id and
  reduced to counts — used by both daemon (persist) and app (render) so the two
  never drift.
- Server: derive progress in `recordTimeline` (the single funnel for every timeline
  write) so both provider-stream and MCP-ingested tool calls are covered; persist
  the accumulator on the agent record so it survives a daemon restart.
- App: inline `TaskProgressTrack` indicator + `TasksScreen` dashboard listing agents
  with active task lists (progress bar, status, click-through to the agent); new
  `/tasks` route + sidebar entry.
- i18n `taskProgress` strings for all 8 locales.

### How did you verify it

- `npm run typecheck`, `npm run lint`, `npm run format:check` pass (pre-commit hook
  enforced).
- Unit tests: `task-progress.test.ts` (18 passed — full-list + delta parsing,
  dedupe, accumulation→counts) and `agent-projections.test.ts` (22 passed —
  taskProgress + accumulator stored-record round-trip).
- End-to-end (dev daemon + a real `claude` agent): an agent that creates 5 tasks
  and works through them yields a persisted
  `taskProgress {total:5, completed:4, inProgress:1, pending:0}` with correct
  per-item statuses.
  <!-- TODO: 修复 live-快照投影 bug 后，附桌面端 Tasks 仪表盘 + 内联进度条截图 -->

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform <!-- 待补 -->
- [x] Tests added or updated where it made sense
