### PR TITLE
fix(server): surface Kiro CLI slash commands and skills over ACP

### DIFF
--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -33,6 +33,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
 import { PiRpcAgentClient } from "./providers/pi/agent.js";
 import { MockLoadTestAgentClient } from "./providers/mock-load-test-agent.js";
@@ -644,24 +645,23 @@ function addDerivedProviders(
         enabled: override.enabled !== false,
         derivedFromProviderId: null,
         providerParams: override.params,
-        createBaseClient: (logger) =>
-          providerId === "cursor"
-            ? new CursorACPAgentClient({
-                logger,
-                command,
-                env: override.env,
-                providerId,
-                label: override.label ?? providerId,
-                providerParams: override.params,
-              })
-            : new GenericACPAgentClient({
-                logger,
-                command,
-                env: override.env,
-                providerId,
-                label: override.label ?? providerId,
-                providerParams: override.params,
-              }),
+        createBaseClient: (logger) => {
+          const acpOptions = {
+            logger,
+            command,
+            env: override.env,
+            providerId,
+            label: override.label ?? providerId,
+            providerParams: override.params,
+          };
+          if (providerId === "cursor") {
+            return new CursorACPAgentClient(acpOptions);
+          }
+          if (providerId === "kiro") {
+            return new KiroACPAgentClient(acpOptions);
+          }
+          return new GenericACPAgentClient(acpOptions);
+        },
       });
       continue;
     }

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -41,6 +41,7 @@ import {
   writeCopilotProviderMode,
 } from "./copilot-acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
+import { parseKiroExtensionCommands } from "./kiro-acp-agent.js";
 import { transformPiModels } from "./pi/agent.js";
 import type { AgentStreamEvent } from "../agent-sdk-types.js";
 import type { AgentCapabilityFlags, AgentPersistenceHandle } from "../agent-sdk-types.js";
@@ -161,6 +162,35 @@ function createSessionWithConfig(
         supportsReasoningStream: true,
         supportsToolInvocations: true,
       },
+    },
+  );
+}
+
+function createKiroSession(
+  options: { waitForInitialCommands?: boolean; initialCommandsWaitTimeoutMs?: number } = {},
+  logger: ReturnType<typeof createTestLogger> = createTestLogger(),
+): ACPAgentSession {
+  return new ACPAgentSession(
+    {
+      provider: "kiro",
+      cwd: "/tmp/paseo-acp-test",
+    },
+    {
+      provider: "kiro",
+      logger,
+      defaultCommand: ["kiro-cli", "acp"],
+      defaultModes: [],
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      extensionCommandsParser: parseKiroExtensionCommands,
+      waitForInitialCommands: options.waitForInitialCommands ?? false,
+      initialCommandsWaitTimeoutMs: options.initialCommandsWaitTimeoutMs,
     },
   );
 }
@@ -1903,28 +1933,10 @@ describe("ACPAgentSession", () => {
   });
 
   test("maps the Kiro _kiro.dev/commands/available notification into slash commands and skills", async () => {
-    const session = new ACPAgentSession(
-      {
-        provider: "kiro",
-        cwd: "/tmp/paseo-acp-test",
-      },
-      {
-        provider: "kiro",
-        logger: createTestLogger(),
-        defaultCommand: ["kiro-cli", "acp"],
-        defaultModes: [],
-        capabilities: {
-          supportsStreaming: true,
-          supportsSessionPersistence: true,
-          supportsDynamicModes: true,
-          supportsMcpServers: true,
-          supportsReasoningStream: true,
-          supportsToolInvocations: true,
-        },
-        waitForInitialCommands: true,
-        initialCommandsWaitTimeoutMs: 1500,
-      },
-    );
+    const session = createKiroSession({
+      waitForInitialCommands: true,
+      initialCommandsWaitTimeoutMs: 1500,
+    });
     asInternals<ACPSessionInternals>(session).sessionId = "session-1";
 
     const listCommandsPromise = session.listCommands();
@@ -1967,8 +1979,7 @@ describe("ACPAgentSession", () => {
   });
 
   test("ignores Kiro _kiro.dev/commands/available for a different session", async () => {
-    const logger = createTestLogger();
-    const session = createSessionWithConfig({ provider: "kiro" }, logger);
+    const session = createKiroSession();
     asInternals<ACPSessionInternals>(session).sessionId = "session-1";
 
     await session.extNotification("_kiro.dev/commands/available", {
@@ -1978,6 +1989,27 @@ describe("ACPAgentSession", () => {
     });
 
     expect(await session.listCommands()).toEqual([]);
+  });
+
+  test("settles listCommands() immediately on an empty Kiro commands batch", async () => {
+    // A long timeout means a resolution can only come from settleCommandsReady()
+    // firing — not from the wait timer — so this test would hang if the empty
+    // batch failed to unblock listCommands() (the P1 regression).
+    const session = createKiroSession({
+      waitForInitialCommands: true,
+      initialCommandsWaitTimeoutMs: 60_000,
+    });
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    const listCommandsPromise = session.listCommands();
+
+    await session.extNotification("_kiro.dev/commands/available", {
+      sessionId: "session-1",
+      commands: [],
+      prompts: [],
+    });
+
+    expect(await listCommandsPromise).toEqual([]);
   });
 
   test("emits assistant and reasoning chunks as deltas while user chunks stay accumulated", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1902,6 +1902,84 @@ describe("ACPAgentSession", () => {
     );
   });
 
+  test("maps the Kiro _kiro.dev/commands/available notification into slash commands and skills", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kiro",
+        cwd: "/tmp/paseo-acp-test",
+      },
+      {
+        provider: "kiro",
+        logger: createTestLogger(),
+        defaultCommand: ["kiro-cli", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        waitForInitialCommands: true,
+        initialCommandsWaitTimeoutMs: 1500,
+      },
+    );
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    const listCommandsPromise = session.listCommands();
+
+    await session.extNotification("_kiro.dev/commands/available", {
+      sessionId: "session-1",
+      commands: [
+        {
+          name: "/agent",
+          description: "Select or list available agents",
+          meta: { inputType: "selection", hint: "swap <name>" },
+        },
+      ],
+      prompts: [
+        {
+          name: "agent-sync-doctor",
+          description: "Hand off Claude or Codex state across Macs",
+          arguments: [],
+          serverName: "skill:config",
+        },
+      ],
+      // Tools are not slash commands and must be ignored.
+      tools: [{ name: "code", description: "Code intelligence", source: "built-in" }],
+    });
+
+    expect(await listCommandsPromise).toEqual([
+      {
+        name: "agent",
+        description: "Select or list available agents",
+        argumentHint: "swap <name>",
+        kind: "command",
+      },
+      {
+        name: "agent-sync-doctor",
+        description: "Hand off Claude or Codex state across Macs",
+        argumentHint: "",
+        kind: "skill",
+      },
+    ]);
+  });
+
+  test("ignores Kiro _kiro.dev/commands/available for a different session", async () => {
+    const logger = createTestLogger();
+    const session = createSessionWithConfig({ provider: "kiro" }, logger);
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    await session.extNotification("_kiro.dev/commands/available", {
+      sessionId: "other-session",
+      commands: [{ name: "/agent", description: "Select or list available agents" }],
+      prompts: [],
+    });
+
+    expect(await session.listCommands()).toEqual([]);
+  });
+
   test("emits assistant and reasoning chunks as deltas while user chunks stay accumulated", async () => {
     const session = createSession();
     const events: Array<{ type: string; item?: { type: string; text?: string } }> = [];

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -80,6 +80,7 @@ import {
   type AgentSession,
   type AgentSessionConfig,
   type AgentSlashCommand,
+  type AgentSlashCommandKind,
   type AgentStreamEvent,
   type AgentTimelineItem,
   type AgentUsage,
@@ -120,6 +121,53 @@ function assertChildWithPipes(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+// ACP extension method (per the `_`-prefixed vendor namespace convention) that
+// Kiro CLI uses to publish its slash commands and skills after session/new.
+const KIRO_COMMANDS_AVAILABLE_METHOD = "_kiro.dev/commands/available";
+
+// Maps a `_kiro.dev/commands/available` payload onto Paseo slash commands.
+// Kiro reports built-in slash commands under `commands` (names arrive with a
+// leading "/", e.g. "/agent") and skills/prompts under `prompts` (names without
+// a slash, tagged with a `skill:` serverName). Paseo stores command names
+// without the leading slash — the composer prepends it on insertion.
+function mapKiroAvailableCommands(params: Record<string, unknown>): AgentSlashCommand[] {
+  const result: AgentSlashCommand[] = [];
+  const seen = new Set<string>();
+
+  const pushEntry = (entry: unknown): void => {
+    if (!isRecord(entry)) {
+      return;
+    }
+    const rawName = typeof entry.name === "string" ? entry.name.trim() : "";
+    const name = rawName.replace(/^\/+/, "");
+    if (!name || seen.has(name)) {
+      return;
+    }
+    seen.add(name);
+
+    const description = typeof entry.description === "string" ? entry.description : "";
+    const meta = isRecord(entry.meta) ? entry.meta : null;
+    const argumentHint = meta && typeof meta.hint === "string" ? meta.hint : "";
+    const serverName = typeof entry.serverName === "string" ? entry.serverName : "";
+    const kind: AgentSlashCommandKind = serverName.startsWith("skill:") ? "skill" : "command";
+
+    result.push({ name, description, argumentHint, kind });
+  };
+
+  if (Array.isArray(params.commands)) {
+    for (const entry of params.commands) {
+      pushEntry(entry);
+    }
+  }
+  if (Array.isArray(params.prompts)) {
+    for (const entry of params.prompts) {
+      pushEntry(entry);
+    }
+  }
+
+  return result;
 }
 
 function isACPError(value: unknown): value is ACPError {
@@ -2082,6 +2130,33 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       },
       "provider.acp.extension_notification",
     );
+
+    if (method === KIRO_COMMANDS_AVAILABLE_METHOD) {
+      this.applyKiroAvailableCommands(params);
+    }
+  }
+
+  // Kiro CLI advertises its slash commands and skills through the
+  // `_kiro.dev/commands/available` extension notification instead of the
+  // standard `available_commands_update` session update. Map both lists onto
+  // the shared slash-command cache so they surface in the composer like any
+  // other provider's commands.
+  private applyKiroAvailableCommands(params: Record<string, unknown>): void {
+    if (
+      typeof params.sessionId === "string" &&
+      this.sessionId !== null &&
+      params.sessionId !== this.sessionId
+    ) {
+      return;
+    }
+
+    const commands = mapKiroAvailableCommands(params);
+    if (commands.length === 0) {
+      return;
+    }
+
+    this.cachedCommands = commands;
+    this.settleCommandsReady();
   }
 
   async readTextFile(params: ReadTextFileRequest): Promise<{ content: string }> {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -80,7 +80,6 @@ import {
   type AgentSession,
   type AgentSessionConfig,
   type AgentSlashCommand,
-  type AgentSlashCommandKind,
   type AgentStreamEvent,
   type AgentTimelineItem,
   type AgentUsage,
@@ -121,53 +120,6 @@ function assertChildWithPipes(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
-}
-
-// ACP extension method (per the `_`-prefixed vendor namespace convention) that
-// Kiro CLI uses to publish its slash commands and skills after session/new.
-const KIRO_COMMANDS_AVAILABLE_METHOD = "_kiro.dev/commands/available";
-
-// Maps a `_kiro.dev/commands/available` payload onto Paseo slash commands.
-// Kiro reports built-in slash commands under `commands` (names arrive with a
-// leading "/", e.g. "/agent") and skills/prompts under `prompts` (names without
-// a slash, tagged with a `skill:` serverName). Paseo stores command names
-// without the leading slash — the composer prepends it on insertion.
-function mapKiroAvailableCommands(params: Record<string, unknown>): AgentSlashCommand[] {
-  const result: AgentSlashCommand[] = [];
-  const seen = new Set<string>();
-
-  const pushEntry = (entry: unknown): void => {
-    if (!isRecord(entry)) {
-      return;
-    }
-    const rawName = typeof entry.name === "string" ? entry.name.trim() : "";
-    const name = rawName.replace(/^\/+/, "");
-    if (!name || seen.has(name)) {
-      return;
-    }
-    seen.add(name);
-
-    const description = typeof entry.description === "string" ? entry.description : "";
-    const meta = isRecord(entry.meta) ? entry.meta : null;
-    const argumentHint = meta && typeof meta.hint === "string" ? meta.hint : "";
-    const serverName = typeof entry.serverName === "string" ? entry.serverName : "";
-    const kind: AgentSlashCommandKind = serverName.startsWith("skill:") ? "skill" : "command";
-
-    result.push({ name, description, argumentHint, kind });
-  };
-
-  if (Array.isArray(params.commands)) {
-    for (const entry of params.commands) {
-      pushEntry(entry);
-    }
-  }
-  if (Array.isArray(params.prompts)) {
-    for (const entry of params.prompts) {
-      pushEntry(entry);
-    }
-  }
-
-  return result;
 }
 
 function isACPError(value: unknown): value is ACPError {
@@ -382,6 +334,17 @@ export function createLoggedNdJsonStream(
   return { readable, writable };
 }
 
+// Lets a provider that publishes its slash commands through a vendor-specific
+// ACP extension notification (rather than the standard
+// `available_commands_update` session update) translate that payload into Paseo
+// slash commands, without the generic ACP session/client carrying any vendor
+// knowledge. Return the parsed commands (possibly empty) for a notification this
+// provider owns, or null to ignore notifications it does not handle.
+export type ACPExtensionCommandsParser = (
+  method: string,
+  params: Record<string, unknown>,
+) => AgentSlashCommand[] | null;
+
 interface ACPAgentClientOptions {
   provider: string;
   logger: Logger;
@@ -404,6 +367,7 @@ interface ACPAgentClientOptions {
     thinkingOptionId: string,
   ) => Promise<void>;
   capabilities?: AgentCapabilityFlags;
+  extensionCommandsParser?: ACPExtensionCommandsParser;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
@@ -431,6 +395,7 @@ interface ACPAgentSessionOptions {
     thinkingOptionId: string,
   ) => Promise<void>;
   capabilities: AgentCapabilityFlags;
+  extensionCommandsParser?: ACPExtensionCommandsParser;
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
@@ -740,6 +705,7 @@ export class ACPAgentClient implements AgentClient {
   ) => Promise<void>;
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
+  private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   protected readonly terminateProcess: ProcessTerminator;
 
   constructor(options: ACPAgentClientOptions) {
@@ -764,6 +730,7 @@ export class ACPAgentClient implements AgentClient {
     this.thinkingOptionWriter = options.thinkingOptionWriter;
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
+    this.extensionCommandsParser = options.extensionCommandsParser;
   }
 
   async createSession(
@@ -791,6 +758,7 @@ export class ACPAgentClient implements AgentClient {
         capabilities: this.capabilities,
         agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
+        extensionCommandsParser: this.extensionCommandsParser,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
       },
@@ -839,6 +807,7 @@ export class ACPAgentClient implements AgentClient {
       handle,
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
+      extensionCommandsParser: this.extensionCommandsParser,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
     });
@@ -1321,6 +1290,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private commandsReadySettled = false;
   private waitForInitialCommands: boolean;
   private initialCommandsWaitTimeoutMs: number;
+  private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
   private closed = false;
@@ -1357,6 +1327,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.currentTitle = config.title ?? null;
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
+    this.extensionCommandsParser = options.extensionCommandsParser;
   }
 
   get id(): string | null {
@@ -2131,31 +2102,37 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       "provider.acp.extension_notification",
     );
 
-    if (method === KIRO_COMMANDS_AVAILABLE_METHOD) {
-      this.applyKiroAvailableCommands(params);
+    const parsedCommands = this.extensionCommandsParser?.(method, params);
+    if (parsedCommands) {
+      this.applyResolvedCommands(parsedCommands, {
+        sessionId: typeof params.sessionId === "string" ? params.sessionId : undefined,
+      });
     }
   }
 
-  // Kiro CLI advertises its slash commands and skills through the
-  // `_kiro.dev/commands/available` extension notification instead of the
-  // standard `available_commands_update` session update. Map both lists onto
-  // the shared slash-command cache so they surface in the composer like any
-  // other provider's commands.
-  private applyKiroAvailableCommands(params: Record<string, unknown>): void {
+  // Cache an asynchronously-delivered slash-command batch and unblock any
+  // listCommands() call that is waiting on the initial batch. Used when a
+  // provider supplies an extensionCommandsParser whose result arrives after
+  // session/new (e.g. via a vendor extension notification). The ready gate is
+  // always settled — even for an empty batch — so a provider that legitimately
+  // reports no commands does not leave listCommands() blocked for the full
+  // initial-commands timeout. An optional sessionId scopes the batch to this
+  // session; notifications addressed to a different session are ignored.
+  private applyResolvedCommands(
+    commands: AgentSlashCommand[],
+    options?: { sessionId?: string },
+  ): void {
     if (
-      typeof params.sessionId === "string" &&
+      options?.sessionId !== undefined &&
       this.sessionId !== null &&
-      params.sessionId !== this.sessionId
+      options.sessionId !== this.sessionId
     ) {
       return;
     }
 
-    const commands = mapKiroAvailableCommands(params);
-    if (commands.length === 0) {
-      return;
+    if (commands.length > 0) {
+      this.cachedCommands = commands;
     }
-
-    this.cachedCommands = commands;
     this.settleCommandsReady();
   }
 

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 
 import type { AgentCapabilityFlags } from "../agent-sdk-types.js";
 import { checkProviderLaunchAvailable, resolveProviderLaunch } from "../provider-launch-config.js";
-import { ACPAgentClient, DEFAULT_ACP_CAPABILITIES } from "./acp-agent.js";
+import {
+  ACPAgentClient,
+  DEFAULT_ACP_CAPABILITIES,
+  type ACPExtensionCommandsParser,
+} from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
   formatProviderDiagnostic,
@@ -29,6 +33,7 @@ interface GenericACPAgentClientOptions {
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   diagnosticPhaseTimeoutMs?: number;
+  extensionCommandsParser?: ACPExtensionCommandsParser;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -48,6 +53,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
       capabilities: buildGenericACPCapabilities(options),
       waitForInitialCommands: options.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: options.initialCommandsWaitTimeoutMs,
+      extensionCommandsParser: options.extensionCommandsParser,
     });
 
     this.command = options.command;

--- a/packages/server/src/server/agent/providers/kiro-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/kiro-acp-agent.ts
@@ -1,6 +1,8 @@
 import type { Logger } from "pino";
 
+import type { ACPExtensionCommandsParser } from "./acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
+import type { AgentSlashCommand, AgentSlashCommandKind } from "../agent-sdk-types.js";
 
 interface KiroACPAgentClientOptions {
   logger: Logger;
@@ -13,10 +15,74 @@ interface KiroACPAgentClientOptions {
 
 // Kiro CLI publishes its slash commands and skills asynchronously through the
 // `_kiro.dev/commands/available` extension notification shortly after
-// `session/new` resolves (handled in ACPAgentSession.extNotification). Wait for
-// that first batch so listCommands() doesn't resolve to an empty list before
-// Kiro has reported its commands.
+// `session/new` resolves. Wait for that first batch so listCommands() doesn't
+// resolve to an empty list before Kiro has reported its commands.
 const KIRO_INITIAL_COMMANDS_WAIT_TIMEOUT_MS = 10_000;
+
+// ACP extension method (per the `_`-prefixed vendor namespace convention) that
+// Kiro CLI uses to publish its slash commands and skills after session/new.
+const KIRO_COMMANDS_AVAILABLE_METHOD = "_kiro.dev/commands/available";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+// Maps a `_kiro.dev/commands/available` payload onto Paseo slash commands.
+// Kiro reports built-in slash commands under `commands` (names arrive with a
+// leading "/", e.g. "/agent") and skills/prompts under `prompts` (names without
+// a slash, tagged with a `skill:` serverName). Paseo stores command names
+// without the leading slash — the composer prepends it on insertion.
+function mapKiroAvailableCommands(params: Record<string, unknown>): AgentSlashCommand[] {
+  const result: AgentSlashCommand[] = [];
+  const seen = new Set<string>();
+
+  const pushEntry = (entry: unknown): void => {
+    if (!isRecord(entry)) {
+      return;
+    }
+    const rawName = typeof entry.name === "string" ? entry.name.trim() : "";
+    const name = rawName.replace(/^\/+/, "");
+    if (!name || seen.has(name)) {
+      return;
+    }
+    seen.add(name);
+
+    const description = typeof entry.description === "string" ? entry.description : "";
+    const meta = isRecord(entry.meta) ? entry.meta : null;
+    const argumentHint = meta && typeof meta.hint === "string" ? meta.hint : "";
+    const serverName = typeof entry.serverName === "string" ? entry.serverName : "";
+    const kind: AgentSlashCommandKind = serverName.startsWith("skill:") ? "skill" : "command";
+
+    result.push({ name, description, argumentHint, kind });
+  };
+
+  if (Array.isArray(params.commands)) {
+    for (const entry of params.commands) {
+      pushEntry(entry);
+    }
+  }
+  if (Array.isArray(params.prompts)) {
+    for (const entry of params.prompts) {
+      pushEntry(entry);
+    }
+  }
+
+  return result;
+}
+
+// Provider-specific parser injected into the generic ACP session via the
+// `extensionCommandsParser` option (mirrors how Cursor/Copilot inject their
+// behavior through constructor options). Kiro advertises its slash commands and
+// skills through the `_kiro.dev/commands/available` extension notification
+// instead of the standard `available_commands_update` session update; this
+// recognizes that one method and returns the parsed commands (possibly empty),
+// or null for any other notification so the base session ignores it.
+export const parseKiroExtensionCommands: ACPExtensionCommandsParser = (method, params) => {
+  if (method !== KIRO_COMMANDS_AVAILABLE_METHOD) {
+    return null;
+  }
+  return mapKiroAvailableCommands(params);
+};
 
 export class KiroACPAgentClient extends GenericACPAgentClient {
   constructor(options: KiroACPAgentClientOptions) {
@@ -29,6 +95,7 @@ export class KiroACPAgentClient extends GenericACPAgentClient {
       providerParams: options.providerParams,
       waitForInitialCommands: true,
       initialCommandsWaitTimeoutMs: KIRO_INITIAL_COMMANDS_WAIT_TIMEOUT_MS,
+      extensionCommandsParser: parseKiroExtensionCommands,
     });
   }
 }

--- a/packages/server/src/server/agent/providers/kiro-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/kiro-acp-agent.ts
@@ -1,0 +1,34 @@
+import type { Logger } from "pino";
+
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+interface KiroACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+// Kiro CLI publishes its slash commands and skills asynchronously through the
+// `_kiro.dev/commands/available` extension notification shortly after
+// `session/new` resolves (handled in ACPAgentSession.extNotification). Wait for
+// that first batch so listCommands() doesn't resolve to an empty list before
+// Kiro has reported its commands.
+const KIRO_INITIAL_COMMANDS_WAIT_TIMEOUT_MS = 10_000;
+
+export class KiroACPAgentClient extends GenericACPAgentClient {
+  constructor(options: KiroACPAgentClientOptions) {
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId,
+      label: options.label,
+      providerParams: options.providerParams,
+      waitForInitialCommands: true,
+      initialCommandsWaitTimeoutMs: KIRO_INITIAL_COMMANDS_WAIT_TIMEOUT_MS,
+    });
+  }
+}


### PR DESCRIPTION
Fixes #1791

## Problem

The Kiro CLI provider (`kiro-cli acp`) never shows slash commands or skills in the composer, while Claude Code and Codex do.

Kiro doesn't emit the standard ACP `available_commands_update` session update. It publishes its commands through the `_kiro.dev/commands/available` vendor extension notification after `session/new` (https://kiro.dev/docs/cli/acp/#slash-commands). `ACPAgentSession.extNotification()` only trace-logged extension notifications, so the payload was received and dropped.

## Change

- `extNotification()` now recognizes `_kiro.dev/commands/available` and maps it onto the existing slash-command cache, reusing the same `settleCommandsReady()` path as `available_commands_update`.
  - `commands[]` → `kind: "command"` (names arrive as `/agent`; the leading slash is stripped to match Paseo's convention, where the composer re-adds it).
  - `prompts[]` with a `skill:` `serverName` → `kind: "skill"`; argument hints come from `meta.hint`.
  - `tools[]` / `mcpServers[]` are ignored (not slash commands). A session-id guard ignores notifications for other sessions.
- New `KiroACPAgentClient` (mirrors `CursorACPAgentClient`) sets `waitForInitialCommands: true` so the first `listCommands()` waits for Kiro's async batch instead of resolving empty. Wired into the `extends: "acp"` branch of `provider-registry`.

This keeps the change scoped to the provider/daemon layer; no UI code is touched (the commands flow through the same `listCommands()` path every other provider uses), so there are no UI changes to screenshot.

## Testing

- `npm run typecheck --workspace=@getpaseo/server` — clean.
- `vitest run acp-agent.test.ts provider-registry.test.ts` — 105 passing, including two new unit tests: one asserts `commands` + `prompts` map to the right `{name, description, argumentHint, kind}` (slash stripped, skill tagged), one asserts a mismatched `sessionId` is ignored.
- `oxlint` + `oxfmt --check` on the changed files — clean.
- End-to-end against a real `kiro-cli acp` (1.5.0) via `KiroACPAgentClient` → `createSession` → `listCommands()`: returns 60 entries (24 `command` + 36 `skill`), names carry no leading slash, argument hints populated. (Ad-hoc check, not committed since it requires an authenticated kiro-cli.)

Tested on macOS through the server/daemon path.
