### PR TITLE
fix(acp): close metadata probe sessions after probe reads

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1530,6 +1530,47 @@ describe("ACPAgentClient fetchCatalog", () => {
     });
   });
 
+  test("closes catalog probe sessions so metadata refreshes do not pollute provider history", async () => {
+    const newSession = vi.fn().mockResolvedValue({
+      sessionId: "probe-session-1",
+      modes: null,
+      models: null,
+      configOptions: [],
+    });
+    const unstableCloseSession = vi.fn().mockResolvedValue({});
+    const child = {
+      kill: vi.fn(),
+      exitCode: 0,
+      signalCode: null,
+      once: vi.fn(),
+      stdin: { destroy: vi.fn() },
+      stdout: { destroy: vi.fn() },
+      stderr: { destroy: vi.fn() },
+    };
+
+    class TestACPAgentClient extends ACPAgentClient {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child,
+          connection: { newSession, unstable_closeSession: unstableCloseSession },
+          initialize: { agentCapabilities: { sessionCapabilities: { close: true } } },
+        } as unknown as SpawnedACPProcess;
+      }
+    }
+
+    const client = new TestACPAgentClient({
+      provider: "pi",
+      logger: createTestLogger(),
+      defaultCommand: ["test-acp"],
+      defaultModes: [],
+    });
+
+    await client.fetchCatalog({ scope: "workspace", cwd: "/tmp/acp-mode-cwd", force: false });
+
+    expect(unstableCloseSession).toHaveBeenCalledWith({ sessionId: "probe-session-1" });
+    expect(child.stdin.destroy).toHaveBeenCalled();
+  });
+
   test("returns an empty modes array when no ACP modes are reported and fallback modes are empty", async () => {
     class TestACPAgentClient extends ACPAgentClient {
       protected override async spawnProcess(): Promise<SpawnedACPProcess> {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -802,6 +802,7 @@ export class ACPAgentClient implements AgentClient {
     const cwd = options.scope === "global" ? homedir() : options.cwd;
     const timeoutMs = options.timeoutMs ?? ACP_CATALOG_TIMEOUT_MS;
     let probe: UninitializedACPProcess | null = null;
+    let probeSessionId: string | null = null;
     try {
       const catalogProbe = (async () => {
         const initializedProbe = await this.spawnProcess(PROBE_ENV, {
@@ -817,6 +818,7 @@ export class ACPAgentClient implements AgentClient {
             mcpServers: [],
           }),
         );
+        probeSessionId = response.sessionId ?? null;
         const transformed = this.transformSessionResponse(response);
         const models = deriveModelDefinitionsFromACP(
           this.provider,
@@ -841,7 +843,7 @@ export class ACPAgentClient implements AgentClient {
       );
     } finally {
       if (probe) {
-        await this.closeProbe(probe);
+        await this.closeProbe(probe, probeSessionId);
       }
     }
   }
@@ -853,6 +855,7 @@ export class ACPAgentClient implements AgentClient {
 
     this.assertProvider(config);
     const probe = await this.spawnProcess(PROBE_ENV);
+    let probeSessionId: string | null = null;
     try {
       const response = await this.runACPRequest(() =>
         probe.connection.newSession({
@@ -860,10 +863,11 @@ export class ACPAgentClient implements AgentClient {
           mcpServers: [],
         }),
       );
+      probeSessionId = response.sessionId ?? null;
       const transformed = this.transformSessionResponse(response);
       return deriveFeaturesFromACP(transformed.configOptions, this.configFeatureOptions);
     } finally {
-      await this.closeProbe(probe);
+      await this.closeProbe(probe, probeSessionId);
     }
   }
 
@@ -1053,10 +1057,20 @@ export class ACPAgentClient implements AgentClient {
     };
   }
 
-  protected async closeProbe(probe: UninitializedACPProcess): Promise<void> {
+  protected async closeProbe(
+    probe: UninitializedACPProcess,
+    sessionId?: string | null,
+  ): Promise<void> {
     try {
-      if (probe.initialize?.agentCapabilities?.sessionCapabilities?.close) {
-        // No active session to close here; ignore capability.
+      if (sessionId && probe.initialize?.agentCapabilities?.sessionCapabilities?.close) {
+        try {
+          await this.runACPRequest(() => probe.connection.unstable_closeSession({ sessionId }));
+        } catch (error) {
+          this.logger.debug(
+            { err: error, provider: this.provider, sessionId },
+            "ACP closeSession failed during probe shutdown",
+          );
+        }
       }
     } finally {
       await terminateChildProcess(probe.child, 2_000, this.terminateProcess);


### PR DESCRIPTION
## Summary
- close ACP metadata probe sessions after catalog/feature probes create scratch sessions
- prevents ACP providers like Hermes from persisting empty probe sessions that pollute recent-session/search surfaces
- add regression coverage for closeSession on probe shutdown

## Test
- `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1`
- `npm run lint -- packages/server/src/server/agent/providers/acp-agent.ts packages/server/src/server/agent/providers/acp-agent.test.ts`
- `npm run typecheck -- --pretty false` fails on current branch with pre-existing workspace/type-dependency drift; targeted test+lint pass
