### PR TITLE
fix(server): fall back to MiniMax CN endpoint when global returns no usage

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -22,6 +22,7 @@ Provider IDs must be lowercase alphanumeric with hyphens (`/^[a-z][a-z0-9-]*$/`)
 ## Table of Contents
 
 - [Extending a built-in provider](#extending-a-built-in-provider)
+- [MiniMax Token Plan](#minimax-token-plan)
 - [Z.AI (Zhipu) coding plan](#zai-zhipu-coding-plan)
 - [Alibaba Cloud (Qwen) coding plan](#alibaba-cloud-qwen-coding-plan)
 - [Codex with a custom OpenAI-compatible endpoint](#codex-with-a-custom-openai-compatible-endpoint)
@@ -61,6 +62,70 @@ Required fields for custom providers:
 - `label` — display name in the UI
 
 See [Codex with a custom OpenAI-compatible endpoint](#codex-with-a-custom-openai-compatible-endpoint) below for the dedicated Codex example.
+
+---
+
+## MiniMax Token Plan
+
+[MiniMax](https://www.minimax.com) offers a Token Plan that exposes OpenAI-compatible and Anthropic-compatible API endpoints. Paseo can display your remaining token balance on the **Host Usage** page.
+
+### Setup
+
+1. Subscribe to a MiniMax Token Plan and create an API key from the MiniMax dashboard.
+2. Set the environment variable for the daemon process:
+
+```bash
+export MINIMAX_API_KEY="<your-minimax-api-key>"
+```
+
+Paseo reads this variable when fetching usage. If you run the desktop app, make sure the variable is visible to the packaged daemon (for example, by setting it in your shell profile and launching the app from that shell).
+
+### Endpoints
+
+| Region | Base URL                   |
+| ------ | -------------------------- |
+| Global | `https://api.minimax.io`   |
+| China  | `https://api.minimaxi.com` |
+
+By default, Paseo queries the **global** endpoint. If your key is only valid on the China endpoint, Paseo automatically falls back to `https://api.minimaxi.com` when the global endpoint returns no usable quota data.
+
+To force a specific endpoint, set `MINIMAX_BASE_URL`:
+
+```bash
+export MINIMAX_BASE_URL=https://api.minimaxi.com
+```
+
+When `MINIMAX_BASE_URL` is set explicitly, Paseo does **not** fall back to the other endpoint.
+
+### Usage in agent providers
+
+MiniMax is not a built-in agent provider. To actually use MiniMax models inside Paseo, extend `claude` or `codex` with the Anthropic-compatible or OpenAI-compatible MiniMax endpoint. For example:
+
+```json
+{
+  "agents": {
+    "providers": {
+      "minimax": {
+        "extends": "claude",
+        "label": "MiniMax",
+        "description": "MiniMax Token Plan via Anthropic-compatible API",
+        "env": {
+          "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+          "ANTHROPIC_API_KEY": "<your-minimax-api-key>"
+        },
+        "disallowedTools": ["WebSearch"],
+        "models": [
+          { "id": "MiniMax-M2.5", "label": "MiniMax-M2.5" },
+          { "id": "MiniMax-M2.7", "label": "MiniMax-M2.7", "isDefault": true },
+          { "id": "MiniMax-M3", "label": "MiniMax-M3" }
+        ]
+      }
+    }
+  }
+}
+```
+
+> Note: The Host Usage fetcher and the agent provider use separate credential paths. `MINIMAX_API_KEY` controls the usage display; `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` inside the provider `env` controls model calls. You can set both to the same MiniMax key.
 
 ---
 

--- a/packages/server/src/services/quota-fetcher/providers/minimax.ts
+++ b/packages/server/src/services/quota-fetcher/providers/minimax.ts
@@ -168,16 +168,43 @@ export class MiniMaxQuotaProvider implements ProviderUsageFetcher {
     const auth = await this.resolveAuth();
     if (!auth) return unavailableUsage(this);
 
-    const res = await fetchProviderApi(this.fetchApi, `${auth.baseUrl}/v1/token_plan/remains`, {
+    let result = await this.fetchFromBaseUrl(auth.token, auth.baseUrl);
+
+    const isExplicitBaseUrl =
+      auth.baseUrl !== MINIMAX_GLOBAL_BASE_URL && auth.baseUrl !== MINIMAX_CN_BASE_URL;
+    const shouldFallback =
+      !isExplicitBaseUrl && result.windows.length === 0 && auth.baseUrl === MINIMAX_GLOBAL_BASE_URL;
+
+    if (shouldFallback) {
+      result = await this.fetchFromBaseUrl(auth.token, MINIMAX_CN_BASE_URL);
+    }
+
+    return {
+      providerId: this.providerId,
+      displayName: this.displayName,
+      status: result.windows.length > 0 ? "available" : "unavailable",
+      planLabel: null,
+      windows: result.windows,
+      balances: [],
+      details: [],
+      error: null,
+    };
+  }
+
+  private async fetchFromBaseUrl(
+    token: string,
+    baseUrl: string,
+  ): Promise<{ windows: ProviderUsageWindow[] }> {
+    const res = await fetchProviderApi(this.fetchApi, `${baseUrl}/v1/token_plan/remains`, {
       headers: {
-        Authorization: `Bearer ${auth.token}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/json",
       },
     });
 
     if (!res.ok) {
-      this.logger.debug({ status: res.status }, "MiniMax usage fetch failed");
-      return unavailableUsage(this);
+      this.logger.debug({ status: res.status, baseUrl }, "MiniMax usage fetch failed");
+      return { windows: [] };
     }
 
     const resp = MiniMaxQuotaResponseSchema.parse(await res.json());
@@ -192,16 +219,7 @@ export class MiniMaxQuotaProvider implements ProviderUsageFetcher {
       if (weeklyWindow) windows.push(weeklyWindow);
     }
 
-    return {
-      providerId: this.providerId,
-      displayName: this.displayName,
-      status: windows.length > 0 ? "available" : "unavailable",
-      planLabel: null,
-      windows,
-      balances: [],
-      details: [],
-      error: null,
-    };
+    return { windows };
   }
 
   private async resolveAuth(): Promise<MiniMaxResolvedAuth | null> {

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -830,6 +830,73 @@ describe("real provider usage fetchers", () => {
     });
   });
 
+  it("falls back to the CN endpoint when global MiniMax endpoint yields no usage", async () => {
+    process.env["MINIMAX_API_KEY"] = "minimax_test_token";
+    const requestedUrls: string[] = [];
+    fetchApi = (async (url: RequestInfo | URL, _init?: RequestInit) => {
+      requestedUrls.push(url.toString());
+      if (url.toString() === "https://api.minimax.io/v1/token_plan/remains") {
+        return jsonResponse({
+          base_resp: { status_code: 2049, status_msg: "invalid api key" },
+        });
+      }
+      return jsonResponse({
+        model_remains: [
+          {
+            model_name: "general",
+            end_time: Date.parse("2026-06-19T05:00:00.000Z"),
+            weekly_end_time: Date.parse("2026-06-26T00:00:00.000Z"),
+            current_interval_total_count: 1000,
+            current_interval_usage_count: 250,
+            current_interval_remaining_percent: 75,
+            current_weekly_total_count: 5000,
+            current_weekly_usage_count: 1200,
+            current_weekly_remaining_percent: 76,
+          },
+        ],
+      });
+    }) as unknown as typeof fetch;
+
+    const miniMax = findProvider(await service().listUsage(), "minimax");
+
+    expect(requestedUrls).toEqual([
+      "https://api.minimax.io/v1/token_plan/remains",
+      "https://api.minimaxi.com/v1/token_plan/remains",
+    ]);
+    expect(miniMax).toMatchObject({
+      status: "available",
+      windows: expect.arrayContaining([
+        expect.objectContaining({
+          id: "interval_general",
+          label: "general · Interval",
+          usedPct: 25,
+        }),
+        expect.objectContaining({
+          id: "weekly_general",
+          label: "general · Weekly",
+          usedPct: 24,
+        }),
+      ]),
+    });
+  });
+
+  it("does not fall back to the CN endpoint when an explicit base URL is configured", async () => {
+    process.env["MINIMAX_API_KEY"] = "minimax_test_token";
+    process.env["MINIMAX_BASE_URL"] = "https://api.minimax.io";
+    const requestedUrls: string[] = [];
+    fetchApi = (async (url: RequestInfo | URL, _init?: RequestInit) => {
+      requestedUrls.push(url.toString());
+      return jsonResponse({
+        base_resp: { status_code: 2049, status_msg: "invalid api key" },
+      });
+    }) as unknown as typeof fetch;
+
+    const miniMax = findProvider(await service().listUsage(), "minimax");
+
+    expect(requestedUrls).toEqual(["https://api.minimax.io/v1/token_plan/remains"]);
+    expect(miniMax.status).toBe("unavailable");
+  });
+
   it("returns unavailable MiniMax usage when no credentials are configured", async () => {
     fetchApi = vi.fn() as never;
 


### PR DESCRIPTION
Fixes MiniMax Token Plan usage not appearing on the Host Usage page.

The MiniMax quota fetcher was always querying the global endpoint (`https://api.minimax.io`). Some MiniMax API keys are only valid on the China endpoint (`https://api.minimaxi.com`), causing the fetcher to return `unavailable` even though the key and subscription were valid.

Changes:
- Query the global endpoint first, then fall back to the CN endpoint when no usable quota windows are returned.
- Skip the fallback when `MINIMAX_BASE_URL` is explicitly configured.
- Add tests for the fallback behavior and explicit-base-url behavior.
- Add a MiniMax Token Plan section to `docs/custom-providers.md`.

Note: The repo-wide `typecheck` currently fails in `packages/client` due to a pre-existing unrelated issue (`focusedWorkspaceId` missing from client heartbeat). Lint, format, and server typecheck pass for the changed files.