### PR TITLE
fix(server):Surface external worktrees added via "Add project"

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -4779,7 +4779,16 @@ export class Session {
       for (const project of await this.projectRegistry.list()) {
         projectsBefore.set(project.projectId, project);
       }
-      const project = await this.workspaceProvisioning.findOrCreateProjectForDirectory(cwd);
+      const { project, workspace } = await this.workspaceProvisioning.addProjectForDirectory(cwd);
+      // A worktree directory is a concrete workspace, not a bare project parent:
+      // its project root is the main repo, which usually already owns the main
+      // checkout's workspace, so a project-only add would never surface the
+      // worktree path. addProjectForDirectory materializes the workspace in that
+      // case while keeping project-only behavior for plain repos/directories.
+      if (workspace) {
+        await this.syncWorkspaceGitObserverForWorkspace(workspace);
+        await this.emitWorkspaceUpdateForWorkspaceId(workspace.workspaceId);
+      }
       this.sessionLogger.info(
         {
           requestedCwd,
@@ -4789,6 +4798,9 @@ export class Session {
           projectTransition: describeRegistryTransition(
             projectsBefore.get(project.projectId) ?? null,
           ),
+          ...(workspace
+            ? { workspaceId: workspace.workspaceId, workspaceKind: workspace.kind }
+            : {}),
         },
         "Project added",
       );

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
@@ -269,3 +269,31 @@ test("addProjectForDirectory materializes a workspace for a worktree directory",
   expect(workspaces).toHaveLength(1);
   expect(workspaces[0]?.cwd).toBe(worktreeDir);
 });
+
+test("addProjectForDirectory reuses an existing worktree workspace", async () => {
+  const mainRepo = path.join(tmpDir, "main-repo");
+  const worktreeDir = path.join(tmpDir, "feature-worktree");
+  const worktreeProvisioning = createWorkspaceProvisioningService({
+    workspaceRegistry,
+    projectRegistry,
+    workspaceGitService: createNoopWorkspaceGitService({
+      peekSnapshot: () => null,
+      getCheckout: async (cwd: string) => ({
+        cwd,
+        isGit: true,
+        currentBranch: "feature",
+        remoteUrl: null,
+        worktreeRoot: worktreeDir,
+        isPaseoOwnedWorktree: false,
+        mainRepoRoot: mainRepo,
+      }),
+    }),
+  });
+
+  const first = await worktreeProvisioning.addProjectForDirectory(worktreeDir);
+  const second = await worktreeProvisioning.addProjectForDirectory(worktreeDir);
+
+  expect(first.workspace?.workspaceId).toBeDefined();
+  expect(second.workspace?.workspaceId).toBe(first.workspace?.workspaceId);
+  expect(await workspaceRegistry.list()).toHaveLength(1);
+});

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
@@ -214,3 +214,58 @@ test("findOrCreateProjectForDirectory reuses the active project for the same roo
   expect(second.projectId).toBe(first.projectId);
   expect(await projectRegistry.list()).toHaveLength(1);
 });
+
+test("addProjectForDirectory keeps a plain repo project-only (no workspace)", async () => {
+  const repo = path.join(tmpDir, "repo");
+  gitRoots.add(repo);
+
+  const result = await provisioning.addProjectForDirectory(repo);
+
+  expect(result.workspace).toBeNull();
+  expect(result.project.rootPath).toBe(repo);
+  expect(await workspaceRegistry.list()).toHaveLength(0);
+  expect(await projectRegistry.list()).toHaveLength(1);
+});
+
+test("addProjectForDirectory keeps a non-git directory project-only (no workspace)", async () => {
+  const dir = path.join(tmpDir, "plain");
+
+  const result = await provisioning.addProjectForDirectory(dir);
+
+  expect(result.workspace).toBeNull();
+  expect(await workspaceRegistry.list()).toHaveLength(0);
+});
+
+test("addProjectForDirectory materializes a workspace for a worktree directory", async () => {
+  // A worktree reports a mainRepoRoot that differs from its own root, so it
+  // classifies as workspaceKind "worktree". Adding it must surface a workspace
+  // at the worktree path, not just register the (main repo) project parent.
+  const mainRepo = path.join(tmpDir, "main-repo");
+  const worktreeDir = path.join(tmpDir, "feature-worktree");
+  const worktreeProvisioning = createWorkspaceProvisioningService({
+    workspaceRegistry,
+    projectRegistry,
+    workspaceGitService: createNoopWorkspaceGitService({
+      peekSnapshot: () => null,
+      getCheckout: async (cwd: string) => ({
+        cwd,
+        isGit: true,
+        currentBranch: "feature",
+        remoteUrl: null,
+        worktreeRoot: worktreeDir,
+        isPaseoOwnedWorktree: false,
+        mainRepoRoot: mainRepo,
+      }),
+    }),
+  });
+
+  const result = await worktreeProvisioning.addProjectForDirectory(worktreeDir);
+
+  expect(result.workspace).not.toBeNull();
+  expect(result.workspace?.cwd).toBe(worktreeDir);
+  expect(result.workspace?.kind).toBe("worktree");
+  expect(result.workspace?.projectId).toBe(result.project.projectId);
+  const workspaces = await workspaceRegistry.list();
+  expect(workspaces).toHaveLength(1);
+  expect(workspaces[0]?.cwd).toBe(worktreeDir);
+});

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
@@ -34,6 +34,18 @@ export interface ResolveOrCreateWorkspaceIdInput {
   initialTitle: string | null;
 }
 
+/**
+ * Result of adding a project for a directory. A bare project parent (a plain
+ * repo root or non-git directory) returns `workspace: null` — "add project
+ * without creating a workspace". A directory that is itself a concrete checkout
+ * (a worktree) also materializes its workspace, because it has no separate
+ * project-parent directory of its own to stand in for it in the sidebar.
+ */
+export interface AddProjectResult {
+  project: PersistedProjectRecord;
+  workspace: PersistedWorkspaceRecord | null;
+}
+
 export interface WorkspaceProvisioningService {
   findOrCreateWorkspaceForDirectory(cwd: string): Promise<PersistedWorkspaceRecord>;
   resolveOrCreateWorkspaceIdForCreateAgent(input: ResolveOrCreateWorkspaceIdInput): Promise<string>;
@@ -42,6 +54,7 @@ export interface WorkspaceProvisioningService {
     title?: string | null,
   ): Promise<PersistedWorkspaceRecord>;
   findOrCreateProjectForDirectory(cwd: string): Promise<PersistedProjectRecord>;
+  addProjectForDirectory(cwd: string): Promise<AddProjectResult>;
   ensureWorkspaceRecordUnarchived(
     workspace: PersistedWorkspaceRecord,
   ): Promise<PersistedWorkspaceRecord>;
@@ -250,6 +263,29 @@ export function createWorkspaceProvisioningService(deps: {
     return projectRecord;
   }
 
+  async function addProjectForDirectory(cwd: string): Promise<AddProjectResult> {
+    const normalizedCwd = resolve(cwd);
+    const checkout = await workspaceGitService.getCheckout(normalizedCwd);
+    const membership = classifyDirectoryForProjectMembership({ cwd: normalizedCwd, checkout });
+
+    // A worktree's project parent is the main repo root, a *different* directory
+    // that usually already owns the main checkout's workspace. Registering only
+    // the project would resolve to that non-empty parent, so the worktree path
+    // gets no workspace row and never surfaces in the sidebar. Materialize its
+    // workspace (as open_project does) so the worktree is visible. Plain repos
+    // and non-git directories keep the project-only behavior.
+    if (membership.workspaceKind === "worktree") {
+      const workspace = await findOrCreateWorkspaceForDirectory(normalizedCwd);
+      const project =
+        (await projectRegistry.get(workspace.projectId)) ??
+        (await findOrCreateProjectForDirectory(normalizedCwd));
+      return { project, workspace };
+    }
+
+    const project = await findOrCreateProjectForDirectory(normalizedCwd);
+    return { project, workspace: null };
+  }
+
   async function ensureWorkspaceRecordUnarchived(
     workspace: PersistedWorkspaceRecord,
   ): Promise<PersistedWorkspaceRecord> {
@@ -279,6 +315,7 @@ export function createWorkspaceProvisioningService(deps: {
     resolveOrCreateWorkspaceIdForCreateAgent,
     createWorkspaceForDirectory,
     findOrCreateProjectForDirectory,
+    addProjectForDirectory,
     ensureWorkspaceRecordUnarchived,
   };
 }

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
@@ -282,7 +282,11 @@ export function createWorkspaceProvisioningService(deps: {
       return { project, workspace };
     }
 
-    const project = await findOrCreateProjectForDirectory(normalizedCwd);
+    const project = await resolveProjectRecordForPlacement({
+      membership,
+      timestamp: new Date().toISOString(),
+    });
+    await projectRegistry.upsert(project);
     return { project, workspace: null };
   }
 


### PR DESCRIPTION
Fixes #1797

## Problem

Adding an external git worktree through `Add project` could register only the project parent without surfacing the selected worktree as a visible workspace.

When the selected directory is a non-Paseo worktree, its project key resolves to the main repo root or remote. If that parent project already has an active workspace (for example, the main checkout), the added worktree is not treated as an empty project and also does not get its own workspace row, so the client appears to do nothing.

## Repro

1. Start with an existing git repository already known to Paseo.
2. Create an external git worktree from that repository outside `~/.paseo/worktrees`.
3. In the client, use `Add project` and select the external worktree path.
4. Observe that the worktree does not appear as a workspace under the project.

## Change

- materialize a workspace when `Add project` targets a directory that classifies as a concrete worktree
- keep the existing project-only behavior for plain repo roots and non-git directories
- add targeted coverage for worktree and project-only add-project paths

## QA / Testing

- `npm run build:server`
- `npm run typecheck`
- `npm run lint -- packages/server/src/server/session.ts packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts`
- `./node_modules/.bin/vitest run packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts --bail=1`
- manually restarted the local daemon and verified the external worktree appears after `Add project`

## Platforms

- Tested on desktop/daemon flow only
- No UI code changes
