### PR TITLE
feat(app): show commit counts on the git sync actions

### DIFF
--- a/packages/app/src/git/action-label.test.ts
+++ b/packages/app/src/git/action-label.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { withCount } from "./action-label";
+
+describe("withCount", () => {
+  it("appends a positive count in parentheses", () => {
+    expect(withCount("Pull", 3)).toBe("Pull (3)");
+    expect(withCount("Push", 1)).toBe("Push (1)");
+  });
+
+  it("renders the bare label when the count is zero or undefined", () => {
+    expect(withCount("Pull", 0)).toBe("Pull");
+    expect(withCount("Pull", undefined)).toBe("Pull");
+    expect(withCount("Push")).toBe("Push");
+  });
+});

--- a/packages/app/src/git/action-label.ts
+++ b/packages/app/src/git/action-label.ts
@@ -1,0 +1,8 @@
+/**
+ * Appends a commit count after a git action's idle label, e.g. `withCount("Pull", 3) === "Pull (3)"`.
+ * A falsy count (0 or undefined) renders the bare label. Kept as a pure module so it can be
+ * unit-tested without pulling in the React Native render component.
+ */
+export function withCount(label: string, count?: number): string {
+  return count ? `${label} (${count})` : label;
+}

--- a/packages/app/src/git/actions-split-button.tsx
+++ b/packages/app/src/git/actions-split-button.tsx
@@ -21,6 +21,7 @@ import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import type { ShortcutKey } from "@/utils/format-shortcut";
 import { useToast } from "@/contexts/toast-context";
+import { withCount } from "@/git/action-label";
 import type { GitAction, GitActions } from "@/git/policy";
 
 interface GitActionsSplitButtonProps {
@@ -72,7 +73,7 @@ function GitActionMenuItem({
         closeOnSelect={closeOnSelect}
         onSelect={handleSelect}
       >
-        {action.label}
+        {withCount(action.label, action.count)}
       </DropdownMenuItem>
     </View>
   );
@@ -87,7 +88,7 @@ export function GitActionsSplitButton({ gitActions, hideLabels }: GitActionsSpli
   const getActionDisplayLabel = useCallback((action: GitAction): string => {
     if (action.status === "pending") return action.pendingLabel;
     if (action.status === "success") return action.successLabel;
-    return action.label;
+    return withCount(action.label, action.count);
   }, []);
 
   const handleActionSelect = useCallback(
@@ -143,7 +144,7 @@ export function GitActionsSplitButton({ gitActions, hideLabels }: GitActionsSpli
             onPress={handlePrimaryPress}
             disabled={gitActions.primary.disabled}
             accessibilityRole="button"
-            accessibilityLabel={gitActions.primary.label}
+            accessibilityLabel={withCount(gitActions.primary.label, gitActions.primary.count)}
           >
             {gitActions.primary.status === "pending" ? (
               <ActivityIndicator

--- a/packages/app/src/git/actions-split-button.tsx
+++ b/packages/app/src/git/actions-split-button.tsx
@@ -15,6 +15,7 @@ import { Shortcut } from "@/components/ui/shortcut";
 import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import type { ShortcutKey } from "@/utils/format-shortcut";
+import { withCount } from "@/git/action-label";
 import type { GitAction, GitActions } from "@/git/policy";
 import { useGitActionRunner } from "@/git/use-actions";
 
@@ -67,7 +68,7 @@ function GitActionMenuItem({
         closeOnSelect={closeOnSelect}
         onSelect={handleSelect}
       >
-        {action.label}
+        {withCount(action.label, action.count)}
       </DropdownMenuItem>
     </View>
   );
@@ -82,7 +83,7 @@ export function GitActionsSplitButton({ gitActions, hideLabels }: GitActionsSpli
   const getActionDisplayLabel = useCallback((action: GitAction): string => {
     if (action.status === "pending") return action.pendingLabel;
     if (action.status === "success") return action.successLabel;
-    return action.label;
+    return withCount(action.label, action.count);
   }, []);
 
   const handlePrimaryPress = useCallback(() => {
@@ -124,7 +125,7 @@ export function GitActionsSplitButton({ gitActions, hideLabels }: GitActionsSpli
             onPress={handlePrimaryPress}
             disabled={gitActions.primary.disabled}
             accessibilityRole="button"
-            accessibilityLabel={gitActions.primary.label}
+            accessibilityLabel={withCount(gitActions.primary.label, gitActions.primary.count)}
           >
             {gitActions.primary.status === "pending" ? (
               <LoadingSpinner

--- a/packages/app/src/git/policy.test.ts
+++ b/packages/app/src/git/policy.test.ts
@@ -151,7 +151,7 @@ describe("git-actions-policy", () => {
       }),
     );
 
-    expect(actions.primary).toMatchObject({ id: "pull", label: "Pull" });
+    expect(actions.primary).toMatchObject({ id: "pull", label: "Pull", count: 2 });
   });
 
   it("keeps push clickable with a clearer message when the branch diverged", () => {
@@ -168,7 +168,41 @@ describe("git-actions-policy", () => {
       disabled: false,
       unavailableMessage:
         "Push isn't available yet because there are newer changes to bring in first",
+      count: 1,
     });
+  });
+
+  it("shows the behind/ahead counts on the pull and push actions", () => {
+    const actions = buildGitActions(
+      createInput({ hasRemote: true, behindOfOrigin: 3, aheadOfOrigin: 2 }),
+    );
+
+    expect(actions.secondary.find((action) => action.id === "pull")).toMatchObject({ count: 3 });
+    expect(actions.secondary.find((action) => action.id === "push")).toMatchObject({ count: 2 });
+  });
+
+  it("omits the count when the branch is in sync with its remote", () => {
+    const actions = buildGitActions(
+      createInput({ hasRemote: true, behindOfOrigin: 0, aheadOfOrigin: 0 }),
+    );
+
+    expect(actions.secondary.find((action) => action.id === "pull")?.count).toBeUndefined();
+    expect(actions.secondary.find((action) => action.id === "push")?.count).toBeUndefined();
+  });
+
+  it("counts the local commits of a no-upstream Paseo worktree as pushable", () => {
+    const actions = buildGitActions(
+      createInput({
+        hasRemote: true,
+        isPaseoOwnedWorktree: true,
+        isOnBaseBranch: false,
+        aheadCount: 1,
+        aheadOfOrigin: null,
+        behindOfOrigin: null,
+      }),
+    );
+
+    expect(actions.secondary.find((action) => action.id === "push")).toMatchObject({ count: 1 });
   });
 
   it("keeps push available for a no-upstream Paseo worktree with local commits", () => {
@@ -206,7 +240,7 @@ describe("git-actions-policy", () => {
       }),
     );
 
-    expect(actions.primary).toMatchObject({ id: "push", label: "Push" });
+    expect(actions.primary).toMatchObject({ id: "push", label: "Push", count: 2 });
   });
 
   it("shows update-from-base only on feature branches that are behind the base branch", () => {
@@ -221,6 +255,7 @@ describe("git-actions-policy", () => {
 
     expect(updateAction).toMatchObject({
       label: "Update from main",
+      count: 3,
       disabled: false,
       unavailableMessage: undefined,
     });
@@ -620,7 +655,18 @@ describe("git-actions-policy", () => {
     );
     const action = actions.secondary.find((entry) => entry.id === "merge-branch");
 
-    expect(action).toMatchObject({ label: "Merge locally" });
+    expect(action).toMatchObject({ label: "Merge locally", count: 2 });
+  });
+
+  it("omits the count on base-branch actions when nothing diverges from the base", () => {
+    const actions = buildGitActions(
+      createInput({ isOnBaseBranch: false, aheadCount: 0, behindBaseCount: 0 }),
+    );
+
+    expect(actions.secondary.find((entry) => entry.id === "merge-branch")?.count).toBeUndefined();
+    expect(
+      actions.secondary.find((entry) => entry.id === "merge-from-base")?.count,
+    ).toBeUndefined();
   });
 
   it("uses the active language for policy-owned action labels and unavailable messages", async () => {

--- a/packages/app/src/git/policy.test.ts
+++ b/packages/app/src/git/policy.test.ts
@@ -187,7 +187,7 @@ describe("git-actions-policy", () => {
       }),
     );
 
-    expect(actions.primary).toMatchObject({ id: "pull", label: "Pull" });
+    expect(actions.primary).toMatchObject({ id: "pull", label: "Pull", count: 2 });
   });
 
   it("keeps push clickable with a clearer message when the branch diverged", () => {
@@ -204,7 +204,41 @@ describe("git-actions-policy", () => {
       disabled: false,
       unavailableMessage:
         "Push isn't available yet because there are newer changes to bring in first",
+      count: 1,
     });
+  });
+
+  it("shows the behind/ahead counts on the pull and push actions", () => {
+    const actions = buildGitActions(
+      createInput({ hasRemote: true, behindOfOrigin: 3, aheadOfOrigin: 2 }),
+    );
+
+    expect(actions.secondary.find((action) => action.id === "pull")).toMatchObject({ count: 3 });
+    expect(actions.secondary.find((action) => action.id === "push")).toMatchObject({ count: 2 });
+  });
+
+  it("omits the count when the branch is in sync with its remote", () => {
+    const actions = buildGitActions(
+      createInput({ hasRemote: true, behindOfOrigin: 0, aheadOfOrigin: 0 }),
+    );
+
+    expect(actions.secondary.find((action) => action.id === "pull")?.count).toBeUndefined();
+    expect(actions.secondary.find((action) => action.id === "push")?.count).toBeUndefined();
+  });
+
+  it("counts the local commits of a no-upstream Paseo worktree as pushable", () => {
+    const actions = buildGitActions(
+      createInput({
+        hasRemote: true,
+        isPaseoOwnedWorktree: true,
+        isOnBaseBranch: false,
+        aheadCount: 1,
+        aheadOfOrigin: null,
+        behindOfOrigin: null,
+      }),
+    );
+
+    expect(actions.secondary.find((action) => action.id === "push")).toMatchObject({ count: 1 });
   });
 
   it("keeps push available for a no-upstream Paseo worktree with local commits", () => {
@@ -242,7 +276,7 @@ describe("git-actions-policy", () => {
       }),
     );
 
-    expect(actions.primary).toMatchObject({ id: "push", label: "Push" });
+    expect(actions.primary).toMatchObject({ id: "push", label: "Push", count: 2 });
   });
 
   it("shows update-from-base only on feature branches that are behind the base branch", () => {
@@ -257,6 +291,7 @@ describe("git-actions-policy", () => {
 
     expect(updateAction).toMatchObject({
       label: "Update from main",
+      count: 3,
       disabled: false,
       unavailableMessage: undefined,
     });
@@ -739,7 +774,18 @@ describe("git-actions-policy", () => {
     );
     const action = actions.secondary.find((entry) => entry.id === "merge-branch");
 
-    expect(action).toMatchObject({ label: "Merge locally" });
+    expect(action).toMatchObject({ label: "Merge locally", count: 2 });
+  });
+
+  it("omits the count on base-branch actions when nothing diverges from the base", () => {
+    const actions = buildGitActions(
+      createInput({ isOnBaseBranch: false, aheadCount: 0, behindBaseCount: 0 }),
+    );
+
+    expect(actions.secondary.find((entry) => entry.id === "merge-branch")?.count).toBeUndefined();
+    expect(
+      actions.secondary.find((entry) => entry.id === "merge-from-base")?.count,
+    ).toBeUndefined();
   });
 
   it("uses the active language for policy-owned action labels and unavailable messages", async () => {

--- a/packages/app/src/git/policy.ts
+++ b/packages/app/src/git/policy.ts
@@ -34,6 +34,8 @@ export interface GitAction {
   status: ActionStatus;
   unavailableMessage?: string;
   icon?: ReactElement;
+  /** When set (>0), rendered after the idle label, e.g. "Pull (3)". */
+  count?: number;
   /** When true, a menu separator should be rendered before this item. */
   startsGroup: boolean;
   handler: () => void;
@@ -216,6 +218,7 @@ export function buildGitActions(input: BuildGitActionsInput): GitActions {
     status: input.runtime.pull.status,
     unavailableMessage: input.runtime.pull.disabled ? undefined : getPullUnavailableMessage(input),
     icon: input.runtime.pull.icon,
+    count: getPullBehindCount(input) || undefined,
     startsGroup: false,
     handler: input.runtime.pull.handler,
   });
@@ -229,6 +232,7 @@ export function buildGitActions(input: BuildGitActionsInput): GitActions {
     status: input.runtime.push.status,
     unavailableMessage: input.runtime.push.disabled ? undefined : getPushUnavailableMessage(input),
     icon: input.runtime.push.icon,
+    count: getPushAheadCount(input) || undefined,
     startsGroup: false,
     handler: input.runtime.push.handler,
   });
@@ -263,6 +267,7 @@ export function buildGitActions(input: BuildGitActionsInput): GitActions {
       ? undefined
       : getMergeBranchUnavailableMessage(input),
     icon: input.runtime["merge-branch"].icon,
+    count: input.aheadCount || undefined,
     startsGroup: false,
     handler: input.runtime["merge-branch"].handler,
   });
@@ -278,6 +283,7 @@ export function buildGitActions(input: BuildGitActionsInput): GitActions {
       ? undefined
       : getMergeFromBaseUnavailableMessage(input),
     icon: input.runtime["merge-from-base"].icon,
+    count: input.behindBaseCount || undefined,
     startsGroup: true,
     handler: input.runtime["merge-from-base"].handler,
   });
@@ -504,20 +510,36 @@ function getEnablePullRequestAutoMergeActionLabel(id: PullRequestAutoMergeEnable
 }
 
 function canPull(input: BuildGitActionsInput): boolean {
-  return input.hasRemote && !input.hasUncommittedChanges && (input.behindOfOrigin ?? 0) > 0;
+  return input.hasRemote && !input.hasUncommittedChanges && getPullBehindCount(input) > 0;
 }
 
 function canPush(input: BuildGitActionsInput): boolean {
   return input.hasRemote && hasPushableCommits(input) && (input.behindOfOrigin ?? 0) === 0;
 }
 
-function hasPushableCommits(input: BuildGitActionsInput): boolean {
+/** Commits the branch is behind its remote — the number shown after the Pull label. */
+export function getPullBehindCount(input: BuildGitActionsInput): number {
+  return input.behindOfOrigin ?? 0;
+}
+
+/**
+ * Commits that would actually be pushed — the number shown after the Push label, and the single
+ * source of truth for push eligibility (see hasPushableCommits).
+ */
+export function getPushAheadCount(input: BuildGitActionsInput): number {
   if ((input.aheadOfOrigin ?? 0) > 0) {
-    return true;
+    return input.aheadOfOrigin ?? 0;
   }
   // No-upstream Paseo worktrees are first-pushable: the daemon push sets upstream with `git push -u`.
   // Do not fold this into aheadOfOrigin; null also covers deleted/pruned upstream branches.
-  return input.isPaseoOwnedWorktree && input.aheadOfOrigin === null && input.aheadCount > 0;
+  if (input.aheadOfOrigin === null && input.isPaseoOwnedWorktree && input.aheadCount > 0) {
+    return input.aheadCount;
+  }
+  return 0;
+}
+
+function hasPushableCommits(input: BuildGitActionsInput): boolean {
+  return getPushAheadCount(input) > 0;
 }
 
 function canMergeFromBase(input: BuildGitActionsInput): boolean {

--- a/packages/app/src/git/policy.ts
+++ b/packages/app/src/git/policy.ts
@@ -32,6 +32,8 @@ export interface GitAction {
   status: ActionStatus;
   unavailableMessage?: string;
   icon?: ReactElement;
+  /** When set (>0), rendered after the idle label, e.g. "Pull (3)". */
+  count?: number;
   /** When true, a menu separator should be rendered before this item. */
   startsGroup: boolean;
   handler: () => void;
@@ -216,6 +218,7 @@ export function buildGitActions(input: BuildGitActionsInput): GitActions {
     status: input.runtime.pull.status,
     unavailableMessage: input.runtime.pull.disabled ? undefined : getPullUnavailableMessage(input),
     icon: input.runtime.pull.icon,
+    count: getPullBehindCount(input) || undefined,
     startsGroup: false,
     handler: input.runtime.pull.handler,
   });
@@ -229,6 +232,7 @@ export function buildGitActions(input: BuildGitActionsInput): GitActions {
     status: input.runtime.push.status,
     unavailableMessage: input.runtime.push.disabled ? undefined : getPushUnavailableMessage(input),
     icon: input.runtime.push.icon,
+    count: getPushAheadCount(input) || undefined,
     startsGroup: false,
     handler: input.runtime.push.handler,
   });
@@ -263,6 +267,7 @@ export function buildGitActions(input: BuildGitActionsInput): GitActions {
       ? undefined
       : getMergeBranchUnavailableMessage(input),
     icon: input.runtime["merge-branch"].icon,
+    count: input.aheadCount || undefined,
     startsGroup: false,
     handler: input.runtime["merge-branch"].handler,
   });
@@ -278,6 +283,7 @@ export function buildGitActions(input: BuildGitActionsInput): GitActions {
       ? undefined
       : getMergeFromBaseUnavailableMessage(input),
     icon: input.runtime["merge-from-base"].icon,
+    count: input.behindBaseCount || undefined,
     startsGroup: true,
     handler: input.runtime["merge-from-base"].handler,
   });
@@ -510,20 +516,36 @@ function getEnablePullRequestAutoMergeActionLabel(id: PullRequestAutoMergeEnable
 }
 
 function canPull(input: BuildGitActionsInput): boolean {
-  return input.hasRemote && !input.hasUncommittedChanges && (input.behindOfOrigin ?? 0) > 0;
+  return input.hasRemote && !input.hasUncommittedChanges && getPullBehindCount(input) > 0;
 }
 
 function canPush(input: BuildGitActionsInput): boolean {
   return input.hasRemote && hasPushableCommits(input) && (input.behindOfOrigin ?? 0) === 0;
 }
 
-function hasPushableCommits(input: BuildGitActionsInput): boolean {
+/** Commits the branch is behind its remote — the number shown after the Pull label. */
+export function getPullBehindCount(input: BuildGitActionsInput): number {
+  return input.behindOfOrigin ?? 0;
+}
+
+/**
+ * Commits that would actually be pushed — the number shown after the Push label, and the single
+ * source of truth for push eligibility (see hasPushableCommits).
+ */
+export function getPushAheadCount(input: BuildGitActionsInput): number {
   if ((input.aheadOfOrigin ?? 0) > 0) {
-    return true;
+    return input.aheadOfOrigin ?? 0;
   }
   // No-upstream Paseo worktrees are first-pushable: the daemon push sets upstream with `git push -u`.
   // Do not fold this into aheadOfOrigin; null also covers deleted/pruned upstream branches.
-  return input.isPaseoOwnedWorktree && input.aheadOfOrigin === null && input.aheadCount > 0;
+  if (input.aheadOfOrigin === null && input.isPaseoOwnedWorktree && input.aheadCount > 0) {
+    return input.aheadCount;
+  }
+  return 0;
+}
+
+function hasPushableCommits(input: BuildGitActionsInput): boolean {
+  return getPushAheadCount(input) > 0;
 }
 
 function canMergeFromBase(input: BuildGitActionsInput): boolean {


### PR DESCRIPTION
### Linked issue

No prior issue — this is a small, self-contained UI change, so I'm putting it up
directly as the proposal. Happy to file a feature request or scope it down if you'd
rather align first.

### Type of change

- [ ] Bug fix
- [x] New feature (small, self-contained)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The git sync actions are already enabled/disabled based on how many commits the branch is
ahead/behind, but the number was never shown — you could see *that* you could sync, not
*how much*. The daemon already sends these counts; this surfaces them on every
single-direction sync action's label:

- **`Pull (3)`** / **`Push (2)`** — commits behind/ahead the **remote** (`behindOfOrigin` /
  `aheadOfOrigin`).
- **`Update from main (5)`** / **`Merge locally (2)`** — commits behind/ahead the **base
  branch** (`behindBaseCount` / `aheadCount`). (Different reference point than the remote, so
  these can legitimately differ from Pull/Push.)

Details:

- The count shows whenever it's > 0, including when the action isn't currently clickable —
  a diverged branch reads as enabled `Pull (2)` next to a greyed `Push (1)` (a state
  indicator: "1 local commit, pull first").
- The count is carried as a structured field on the action and formatted once at render via
  `withCount()`, so the reactive translate layer needs no change and there's no new i18n key
  (the parenthesised number is locale-neutral).
- `hasPushableCommits` is folded into `getPushAheadCount(input) > 0` so the displayed number
  and push-eligibility can't drift.
- The compound "Pull and push" stays uncounted (a single number is ambiguous with both
  directions), and PR / Merge-PR / Auto-merge / Archive stay label-only.


### How did you verify it

- **Ran the app end-to-end (web).** Built a throwaway repo whose branch genuinely diverges
  from both its remote and its base, opened it as a workspace, and confirmed every count
  renders live in the git split button's dropdown: **`Pull (1)`**, **`Push (1)`** (greyed
  but counted — the branch is diverged, so push isn't runnable yet), **`Update from main (2)`**,
  **`Merge locally (3)`**. "Pull and push" and "Create PR" correctly show no count.
  _(screenshot below)_
- **Desktop:** `Push (1)` confirmed on the primary button on a branch with one unpushed commit.
- **Automated:** `npm run typecheck`, `npm run lint`, `npm run format` all clean; unit tests
  cover the count derivation (`policy.test.ts`: behind/ahead, in-sync → no count, no-upstream
  worktree, diverged-but-shown) and the rendered string (`action-label.test.ts`).

<img width="560" height="290" alt="git-sync-counts-dropdown" src="https://github.com/user-attachments/assets/eea73910-a617-4e74-ac38-5f1861f7134f" />

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform - desktop attached; mobile/web not separately captured
- [x] Tests added or updated where it made sense
