### PR TITLE
Make daemon status report health without loading agents

### DIFF
--- a/packages/cli/src/commands/daemon/status.ts
+++ b/packages/cli/src/commands/daemon/status.ts
@@ -27,15 +27,12 @@ interface DaemonStatus {
   startedAt: string | null;
   owner: string | null;
   logPath: string;
-  runningAgents: number | null;
-  idleAgents: number | null;
   daemonNode: string;
   cliNode: string;
   cliVersion: string;
   daemonVersion: string | null;
   desktopManaged: boolean;
   providers: ProviderBinaryStatus[];
-  agentsUnavailableReason?: string;
   note?: string;
 }
 
@@ -134,18 +131,6 @@ function toStatusRows(status: DaemonStatus): StatusRow[] {
     { key: "Daemon Version", value: status.daemonVersion ?? "-" },
   ];
 
-  if (status.runningAgents !== null && status.idleAgents !== null) {
-    rows.push({
-      key: "Agents",
-      value: `${status.runningAgents} running, ${status.idleAgents} idle`,
-    });
-  } else {
-    rows.push({
-      key: "Agents",
-      value: `Unavailable (${status.agentsUnavailableReason ?? "daemon API not reachable"})`,
-    });
-  }
-
   if (status.note) {
     rows.push({ key: "Note", value: status.note });
   }
@@ -217,11 +202,8 @@ interface DaemonProbeResult {
   connectedDaemon: DaemonStatus["connectedDaemon"];
   localDaemonOverride?: DaemonStatus["localDaemon"];
   daemonVersion?: string | null;
-  runningAgents?: number;
-  idleAgents?: number;
   daemonNodeOverride?: string;
   daemonProviders?: ProviderBinaryStatus[];
-  agentsUnavailableReason?: string;
   note?: string;
 }
 
@@ -241,11 +223,6 @@ function describeDaemonAuthProbeFailure(host: string, failure: DaemonAuthProbeFa
   return `Daemon is reachable at ${host} but the supplied password was rejected. Check PASEO_PASSWORD and retry.`;
 }
 
-function describeAgentsUnavailableReason(failure: DaemonAuthProbeFailure): string {
-  if (failure === "auth_required") return "password required";
-  return "incorrect password";
-}
-
 async function probeDaemonOverWebsocket(args: {
   host: string;
   state: ReturnType<typeof resolveLocalDaemonState>;
@@ -259,7 +236,6 @@ async function probeDaemonOverWebsocket(args: {
     if (authFailure) {
       return {
         connectedDaemon: authFailure,
-        agentsUnavailableReason: describeAgentsUnavailableReason(authFailure),
         note: describeDaemonAuthProbeFailure(host, authFailure),
       };
     }
@@ -275,44 +251,23 @@ async function probeDaemonOverWebsocket(args: {
   }
 
   const daemonVersion = client.getLastServerInfoMessage()?.version ?? null;
-  const supportsDaemonStatusRpc =
-    client.getLastServerInfoMessage()?.features?.daemonStatusRpc === true;
   try {
-    const agentsPayload = await client.fetchAgents({
-      filter: { includeArchived: true },
+    const statusPayload = await client.getDaemonStatus({
       timeout: DAEMON_STATUS_PROBE_TIMEOUT_MS,
     });
-    const agents = agentsPayload.entries.map((entry) => entry.agent);
-    const runningAgents = agents.filter((a) => a.status === "running").length;
-    const idleAgents = agents.filter((a) => a.status === "idle").length;
-
-    let daemonProviders: ProviderBinaryStatus[] | undefined;
-    if (supportsDaemonStatusRpc) {
-      try {
-        const statusPayload = await client.getDaemonStatus({
-          timeout: DAEMON_STATUS_PROBE_TIMEOUT_MS,
-        });
-        const labelMap = new Map(PROVIDER_BINARIES.map((p) => [p.binary, p.label]));
-        daemonProviders = statusPayload.providers.map((p) => ({
-          label: labelMap.get(p.provider) ?? p.provider,
-          path: p.available ? "available" : null,
-          version: p.available ? null : (p.error ?? null),
-          source: "daemon" as const,
-        }));
-      } catch {
-        // COMPAT(daemon-rpc-rollout): fall back to CLI-side provider resolution while
-        // old daemons lack daemonStatusRpc. Remove once the daemon floor is past
-        // v0.1.76; status should come from daemon.get_status.
-      }
-    }
+    const labelMap = new Map(PROVIDER_BINARIES.map((p) => [p.binary, p.label]));
+    const daemonProviders = statusPayload.providers.map((p) => ({
+      label: labelMap.get(p.provider) ?? p.provider,
+      path: p.available ? "available" : null,
+      version: p.available ? null : (p.error ?? null),
+      source: "daemon" as const,
+    }));
 
     if (!state.running) {
       return {
         connectedDaemon: "reachable",
-        daemonVersion,
-        runningAgents,
-        idleAgents,
-        daemonNodeOverride: "unknown (API reachable, PID unresolved)",
+        daemonVersion: statusPayload.version ?? daemonVersion,
+        daemonNodeOverride: statusPayload.nodePath,
         daemonProviders,
         note: state.pidInfo
           ? `Connected daemon is reachable at ${host} even though local daemon PID ${state.pidInfo.pid} is stale`
@@ -322,9 +277,8 @@ async function probeDaemonOverWebsocket(args: {
 
     return {
       connectedDaemon: "reachable",
-      daemonVersion,
-      runningAgents,
-      idleAgents,
+      daemonVersion: statusPayload.version ?? daemonVersion,
+      daemonNodeOverride: statusPayload.nodePath,
       daemonProviders,
     };
   } catch {
@@ -333,8 +287,8 @@ async function probeDaemonOverWebsocket(args: {
       daemonVersion,
       localDaemonOverride: state.running ? "unresponsive" : undefined,
       note: state.running
-        ? `Local daemon PID is running but API requests to ${host} failed`
-        : `Connected daemon websocket is reachable at ${host} but fetch_agents failed`,
+        ? `Local daemon PID is running but daemon status request to ${host} failed`
+        : `Connected daemon websocket is reachable at ${host} but daemon status request failed`,
     };
   } finally {
     await client.close().catch(() => {});
@@ -347,10 +301,7 @@ interface ProbeMergeState {
   localDaemon: DaemonStatus["localDaemon"];
   daemonNode: string;
   daemonVersion: string | null;
-  runningAgents: number | null;
-  idleAgents: number | null;
   daemonProviders: ProviderBinaryStatus[] | undefined;
-  agentsUnavailableReason: string | undefined;
   note: string | undefined;
 }
 
@@ -361,10 +312,7 @@ function applyProbeToStatus(input: ProbeMergeState): Omit<ProbeMergeState, "prob
     localDaemon: probe.localDaemonOverride ?? input.localDaemon,
     daemonNode: probe.daemonNodeOverride ?? input.daemonNode,
     daemonVersion: probe.daemonVersion !== undefined ? probe.daemonVersion : input.daemonVersion,
-    runningAgents: probe.runningAgents !== undefined ? probe.runningAgents : input.runningAgents,
-    idleAgents: probe.idleAgents !== undefined ? probe.idleAgents : input.idleAgents,
     daemonProviders: probe.daemonProviders ?? input.daemonProviders,
-    agentsUnavailableReason: probe.agentsUnavailableReason ?? input.agentsUnavailableReason,
     note: probe.note ? appendNote(input.note, probe.note) : input.note,
   };
 }
@@ -410,11 +358,8 @@ export async function runStatusCommand(
   const cliNode = process.execPath;
   let localDaemon: DaemonStatus["localDaemon"] = state.running ? "running" : "stopped";
   let connectedDaemon: DaemonStatus["connectedDaemon"] = "not_probed";
-  let runningAgents: number | null = null;
-  let idleAgents: number | null = null;
   let daemonVersion: string | null = null;
   let daemonProviders: ProviderBinaryStatus[] | undefined;
-  let agentsUnavailableReason: string | undefined;
   let note: string | undefined;
 
   if (!state.running && state.stalePidFile && state.pidInfo) {
@@ -424,28 +369,16 @@ export async function runStatusCommand(
 
   if (host) {
     const probe = await probeDaemonOverWebsocket({ host, state });
-    ({
-      connectedDaemon,
-      localDaemon,
-      daemonNode,
-      daemonVersion,
-      runningAgents,
-      idleAgents,
-      daemonProviders,
-      agentsUnavailableReason,
-      note,
-    } = applyProbeToStatus({
-      probe,
-      connectedDaemon,
-      localDaemon,
-      daemonNode,
-      daemonVersion,
-      runningAgents,
-      idleAgents,
-      daemonProviders,
-      agentsUnavailableReason,
-      note,
-    }));
+    ({ connectedDaemon, localDaemon, daemonNode, daemonVersion, daemonProviders, note } =
+      applyProbeToStatus({
+        probe,
+        connectedDaemon,
+        localDaemon,
+        daemonNode,
+        daemonVersion,
+        daemonProviders,
+        note,
+      }));
   } else {
     note = appendNote(note, "Daemon is configured for unix socket listen; API probe skipped");
   }
@@ -472,15 +405,12 @@ export async function runStatusCommand(
     startedAt: state.pidInfo?.startedAt ?? null,
     owner,
     logPath: state.logPath,
-    runningAgents,
-    idleAgents,
     daemonNode,
     cliNode,
     cliVersion,
     daemonVersion,
     desktopManaged: state.pidInfo?.desktopManaged === true,
     providers,
-    agentsUnavailableReason,
     note,
   };
 

--- a/packages/cli/src/commands/daemon/status.ts
+++ b/packages/cli/src/commands/daemon/status.ts
@@ -285,9 +285,8 @@ async function probeDaemonOverWebsocket(args: {
     return {
       connectedDaemon: "reachable",
       daemonVersion,
-      localDaemonOverride: state.running ? "unresponsive" : undefined,
       note: state.running
-        ? `Local daemon PID is running but daemon status request to ${host} failed`
+        ? `Local daemon PID is running but daemon detail request to ${host} failed`
         : `Connected daemon websocket is reachable at ${host} but daemon status request failed`,
     };
   } finally {

--- a/packages/cli/tests/34-daemon-status-auth.test.ts
+++ b/packages/cli/tests/34-daemon-status-auth.test.ts
@@ -43,8 +43,8 @@ try {
 
     assert.strictEqual(status.localDaemon, "running");
     assert.strictEqual(status.connectedDaemon, "auth_required");
-    assert.strictEqual(status.runningAgents, null);
-    assert.strictEqual(status.idleAgents, null);
+    assert(!("runningAgents" in status), "status should not fetch agent counts");
+    assert(!("idleAgents" in status), "status should not fetch agent counts");
     assert.match(status.note, /requires a password/i);
     assert.doesNotMatch(status.note, /not reachable/i);
     console.log("✓ missing password reports auth_required\n");
@@ -81,8 +81,8 @@ try {
 
     assert.strictEqual(status.localDaemon, "running");
     assert.strictEqual(status.connectedDaemon, "reachable");
-    assert.strictEqual(status.runningAgents, 0);
-    assert.strictEqual(status.idleAgents, 0);
+    assert(!("runningAgents" in status), "status should not fetch agent counts");
+    assert(!("idleAgents" in status), "status should not fetch agent counts");
     console.log("✓ password-authenticated status remains reachable\n");
   }
 } finally {


### PR DESCRIPTION
### Linked issue

Refs #1114

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

`paseo daemon status` now checks daemon health with the dedicated daemon status RPC instead of loading the full agent directory. It also drops the running/idle agent counts from status output so a broken or slow agent inventory cannot make a reachable daemon look unresponsive.

Provider status still comes from the daemon when available, and auth failures continue to report as `auth_required` / `auth_failed` without downgrading the daemon to unreachable.

### How did you verify it

- `npm run build --workspace=@getpaseo/cli`
- `npx tsx packages/cli/tests/34-daemon-status-auth.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

The commit hook also re-ran targeted lint, format check, and full typecheck successfully.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A, no UI changes)
- [x] Tests added or updated where it made sense