### PR TITLE
refactor(server): introduce a ForgeService seam (rename + resolver

### DIFF
--- a/packages/server/src/server/agent/create-agent-lifecycle-dispatch.ts
+++ b/packages/server/src/server/agent/create-agent-lifecycle-dispatch.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type pino from "pino";
 
-import type { GitHubService } from "../../services/github-service.js";
+import type { ForgeService } from "../../services/github-service.js";
 import { isPaseoOwnedWorktreeCwd } from "../../utils/worktree.js";
 import {
   archiveByScope,
@@ -26,7 +26,7 @@ interface CreateAgentLifecycleDispatchDependencies {
   worktreesRoot?: string;
   agentManager: AgentManager;
   agentStorage: AgentStorage;
-  github: GitHubService;
+  github: ForgeService;
   workspaceGitService: WorkspaceGitService;
   createPaseoWorktreeWorkflow: CreatePaseoWorktreeWorkflowFn;
   archiveAgentForClose: (agentId: string) => Promise<unknown>;

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -33,7 +33,7 @@ import {
 } from "../paseo-worktree-service.js";
 import type { CreatePaseoWorktreeWorkflowFn } from "../worktree-session.js";
 import { WorkspaceGitServiceImpl } from "../workspace-git-service.js";
-import type { GitHubService } from "../../services/github-service.js";
+import type { ForgeService } from "../../services/github-service.js";
 import type { TerminalManager } from "../../terminal/terminal-manager.js";
 import { PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
 
@@ -459,7 +459,7 @@ function createManagedAgent(overrides: Partial<ManagedAgent> = {}): ManagedAgent
   } as ManagedAgent;
 }
 
-function createGitHubServiceStub(): GitHubService {
+function createGitHubServiceStub(): ForgeService {
   return {
     listPullRequests: async () => [],
     listIssues: async () => [],

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -63,7 +63,7 @@ import {
   setAgentModeCommand,
   updateAgentCommand,
 } from "../lifecycle-command.js";
-import type { GitHubService } from "../../../services/github-service.js";
+import type { ForgeService } from "../../../services/github-service.js";
 import type { WorkspaceGitService } from "../../workspace-git-service.js";
 import { WorktreeRequestError } from "../../worktree-errors.js";
 import {
@@ -88,7 +88,7 @@ export interface PaseoToolHostDependencies {
   getDaemonTcpPort?: () => number | null;
   scheduleService?: ScheduleService | null;
   providerSnapshotManager: ProviderSnapshotManager;
-  github?: GitHubService;
+  github?: ForgeService;
   workspaceGitService?: Pick<
     WorkspaceGitService,
     "getSnapshot" | "listWorktrees" | "resolveRepoRoot"

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
@@ -14,7 +14,7 @@ import {
 import type { ArchiveResult, ActiveWorkspaceRef } from "../workspace-archive-service.js";
 import type { WorkspaceGitRuntimeSnapshot } from "../workspace-git-service.js";
 import { createWorktree, type WorktreeConfig } from "../../utils/worktree.js";
-import type { GitHubService } from "../../../services/github-service.js";
+import type { ForgeService } from "../../../services/github-service.js";
 import type { StoredAgentRecord } from "../agent/agent-storage.js";
 
 const CWD = "/tmp/paseo/worktrees/repo/branch";
@@ -211,7 +211,7 @@ async function createPaseoOwnedWorktree(
   });
 }
 
-function createGitHubServiceStub(): GitHubService {
+function createGitHubServiceStub(): ForgeService {
   return {
     listPullRequests: async () => [],
     listIssues: async () => [],

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
@@ -13,7 +13,7 @@ import type {
   WorkspaceGitRuntimeSnapshot,
   WorkspaceGitServiceImpl,
 } from "../workspace-git-service.js";
-import type { GitHubService } from "../../services/github-service.js";
+import type { ForgeService } from "../../services/github-service.js";
 import type { TerminalManager } from "../../terminal/terminal-manager.js";
 import { isPaseoOwnedWorktreeCwd } from "../../utils/worktree.js";
 
@@ -22,7 +22,7 @@ export interface AutoArchiveArchiveOptions {
   paseoWorktreesBaseRoot?: string;
   daemonConfigStore: DaemonConfigStore;
   workspaceGitService: WorkspaceGitServiceImpl;
-  github: GitHubService;
+  github: ForgeService;
   agentManager: AgentManager;
   agentStorage: AgentStorage;
   terminalManager: TerminalManager;

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -90,7 +90,7 @@ function formatListenTarget(listenTarget: ListenTarget | null): string | null {
 }
 
 import { VoiceAssistantWebSocketServer } from "./websocket-server.js";
-import { createGitHubService } from "../services/github-service.js";
+import { resolveForgeService } from "../services/forge-resolver.js";
 import {
   createPaseoWorktree as createRegisteredPaseoWorktree,
   createLocalCheckoutWorkspace,
@@ -704,7 +704,7 @@ export async function createPaseoDaemon(
     paseoHome: config.paseoHome,
     logger,
   });
-  const github = createGitHubService();
+  const github = resolveForgeService();
   const workspaceGitService = new WorkspaceGitServiceImpl({
     logger,
     paseoHome: config.paseoHome,

--- a/packages/server/src/server/paseo-worktree-service.test.ts
+++ b/packages/server/src/server/paseo-worktree-service.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, expect, test, vi } from "vitest";
 
-import type { GitHubService } from "../services/github-service.js";
+import type { ForgeService } from "../services/github-service.js";
 import type { WorkspaceGitRuntimeSnapshot, WorkspaceGitService } from "./workspace-git-service.js";
 import type {
   PersistedProjectRecord,
@@ -752,7 +752,7 @@ function createPersistedWorkspaceRecordForTest(input: {
   };
 }
 
-function createGitHubServiceStub(): GitHubService {
+function createGitHubServiceStub(): ForgeService {
   return {
     listPullRequests: async () => [],
     listIssues: async () => [],

--- a/packages/server/src/server/resolve-worktree-creation-intent.test.ts
+++ b/packages/server/src/server/resolve-worktree-creation-intent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import type { GitHubService } from "../services/github-service.js";
+import type { ForgeService } from "../services/github-service.js";
 import {
   MissingCheckoutTargetError,
   resolveWorktreeCreationIntent,
@@ -12,14 +12,14 @@ interface GitHubHeadRefLookup {
 }
 
 interface ResolverHarness {
-  github: GitHubService;
+  github: ForgeService;
   headRefLookups: GitHubHeadRefLookup[];
   resolveDefaultBranch: (repoRoot: string) => Promise<string>;
 }
 
 function createResolverHarness(): ResolverHarness {
   const headRefLookups: GitHubHeadRefLookup[] = [];
-  const github: GitHubService = {
+  const github: ForgeService = {
     listPullRequests: async () => [],
     listIssues: async () => [],
     searchIssuesAndPrs: async () => ({ items: [], githubFeaturesEnabled: true }),

--- a/packages/server/src/server/resolve-worktree-creation-intent.ts
+++ b/packages/server/src/server/resolve-worktree-creation-intent.ts
@@ -1,4 +1,4 @@
-import type { GitHubPullRequestCheckoutTarget, GitHubService } from "../services/github-service.js";
+import type { GitHubPullRequestCheckoutTarget, ForgeService } from "../services/github-service.js";
 import type { WorktreeSource } from "../utils/worktree.js";
 
 export type WorktreeCreationIntent = WorktreeSource;
@@ -27,7 +27,7 @@ export type ResolveWorktreeCreationIntentInput =
     };
 
 export interface ResolveWorktreeCreationIntentDeps {
-  github: GitHubService;
+  github: ForgeService;
   resolveDefaultBranch: (repoRoot: string) => Promise<string>;
 }
 

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -39,7 +39,7 @@ import { isPlatform } from "../test-utils/platform.js";
 import type {
   GitHubCheckDetails,
   GitHubPullRequestStatusFacts,
-  GitHubService,
+  ForgeService,
 } from "../services/github-service.js";
 
 interface SessionHandlerInternals {
@@ -190,7 +190,7 @@ vi.mock("./worktree-bootstrap.js", async (importOriginal) => {
 interface SessionForTestOptions {
   agentManager?: { [K in keyof SessionOptions["agentManager"]]?: unknown };
   agentStorage?: { [K in keyof SessionOptions["agentStorage"]]?: unknown };
-  github?: Partial<GitHubService>;
+  github?: Partial<ForgeService>;
   checkoutDiffManager?: { scheduleRefreshForCwd: ReturnType<typeof vi.fn> };
   workspaceGitService?: {
     getCheckoutDiff?: ReturnType<typeof vi.fn>;
@@ -3757,7 +3757,7 @@ describe("session workspace script handling", () => {
 });
 
 describe("session pull request timeline handling", () => {
-  test("routes GitHub search requests through GitHubService", async () => {
+  test("routes GitHub search requests through ForgeService", async () => {
     const messages: unknown[] = [];
     const github = {
       invalidate: vi.fn(),
@@ -3820,7 +3820,7 @@ describe("session pull request timeline handling", () => {
     });
   });
 
-  test("passes request identity to GitHubService and emits timeline items", async () => {
+  test("passes request identity to ForgeService and emits timeline items", async () => {
     const messages: unknown[] = [];
     const github = {
       invalidate: vi.fn(),
@@ -3991,7 +3991,7 @@ describe("session pull request timeline handling", () => {
       failedJobs: [],
       truncated: false,
     };
-    const github: Partial<GitHubService> = {
+    const github: Partial<ForgeService> = {
       invalidate() {},
       async isAuthenticated() {
         return true;

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -182,7 +182,7 @@ import type pino from "pino";
 import { FileBackedChatService } from "./chat/chat-service.js";
 import { LoopService } from "./loop-service.js";
 import { ScheduleService } from "./schedule/service.js";
-import { createGitHubService, type GitHubService } from "../services/github-service.js";
+import { createGitHubService, type ForgeService } from "../services/github-service.js";
 import type { ProviderUsageService } from "../services/quota-fetcher/service.js";
 import {
   summarizeFetchWorkspacesEntries,
@@ -422,7 +422,7 @@ export interface SessionOptions {
   scheduleService: ScheduleService;
   loopService: LoopService;
   checkoutDiffManager: CheckoutDiffManager;
-  github?: GitHubService;
+  github?: ForgeService;
   createAgentMcpTransport?: AgentMcpTransportFactory;
   // Injected so tests can substitute the git branch rename without module mocks;
   // defaults to the real checkout-git implementation.
@@ -547,7 +547,7 @@ export class Session {
   private readonly projectRegistry: ProjectRegistry;
   private readonly workspaceRegistry: WorkspaceRegistry;
   private readonly filesystem: SessionFileSystem;
-  private readonly github: GitHubService;
+  private readonly github: ForgeService;
   private readonly renameCurrentBranch: typeof renameCurrentBranchDefault;
   private readonly generateWorkspaceName: typeof generateBranchNameFromFirstAgentContext;
   private readonly workspaceGitService: WorkspaceGitService;

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -182,7 +182,8 @@ import type pino from "pino";
 import { FileBackedChatService } from "./chat/chat-service.js";
 import { LoopService } from "./loop-service.js";
 import { ScheduleService } from "./schedule/service.js";
-import { createGitHubService, type ForgeService } from "../services/github-service.js";
+import { resolveForgeService } from "../services/forge-resolver.js";
+import { type ForgeService } from "../services/github-service.js";
 import type { ProviderUsageService } from "../services/quota-fetcher/service.js";
 import {
   summarizeFetchWorkspacesEntries,
@@ -673,7 +674,7 @@ export class Session {
     this.projectRegistry = projectRegistry;
     this.workspaceRegistry = workspaceRegistry;
     this.filesystem = filesystem ?? nodeSessionFileSystem;
-    this.github = github ?? createGitHubService();
+    this.github = github ?? resolveForgeService();
     this.renameCurrentBranch = renameCurrentBranch ?? renameCurrentBranchDefault;
     this.generateWorkspaceName = generateWorkspaceName ?? generateBranchNameFromFirstAgentContext;
     this.workspaceGitService = workspaceGitService;

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -35,7 +35,7 @@ import { createWorktree, UnknownBranchError } from "../utils/worktree.js";
 import { WorktreeRequestError, toWorktreeRequestError } from "./worktree-errors.js";
 import type { WorkspaceGitRuntimeSnapshot } from "./workspace-git-service.js";
 import type { GeneratedWorkspaceName } from "./worktree-branch-name-generator.js";
-import type { GitHubService } from "../services/github-service.js";
+import type { ForgeService } from "../services/github-service.js";
 import { createNoopWorkspaceGitService } from "./test-utils/workspace-git-service-stub.js";
 import {
   asSessionLogger,
@@ -527,7 +527,7 @@ function createSessionForWorkspaceTests(
     terminalManager?: TerminalManager | null;
     projectRegistry?: SessionOptions["projectRegistry"];
     workspaceRegistry?: SessionOptions["workspaceRegistry"];
-    github?: GitHubService;
+    github?: ForgeService;
     paseoHome?: string;
     worktreesRoot?: string;
     renameCurrentBranch?: (
@@ -7101,7 +7101,7 @@ function createWorkspaceCreatePrRepo(): WorkspaceCreatePrRepoFixture {
   return { tempDir, repoDir, paseoHome, headRef, prFileName, prNumber };
 }
 
-function createPrCheckoutGitHubService(params: { headRef: string }): GitHubService {
+function createPrCheckoutGitHubService(params: { headRef: string }): ForgeService {
   return {
     listPullRequests: async () => [],
     listIssues: async () => [],

--- a/packages/server/src/server/session/checkout/checkout-session.test.ts
+++ b/packages/server/src/server/session/checkout/checkout-session.test.ts
@@ -6,7 +6,7 @@ import {
   type CheckoutSessionHost,
 } from "./checkout-session.js";
 import type { GitMutationService } from "../git-mutation/git-mutation-service.js";
-import { createGitHubService, type GitHubService } from "../../../services/github-service.js";
+import { createGitHubService, type ForgeService } from "../../../services/github-service.js";
 import type { SessionOutboundMessage } from "../../messages.js";
 import type {
   CheckoutDiffCompareInput,
@@ -81,7 +81,7 @@ interface RecordedGeneratorCalls {
 function makeCheckoutSession(options?: {
   git?: Partial<WorkspaceGitService>;
   diff?: CheckoutDiffSubscriber;
-  github?: Partial<GitHubService>;
+  github?: Partial<ForgeService>;
   host?: Partial<CheckoutSessionHost>;
   gitMutation?: Partial<GitMutationFake>;
   gitMetadataGenerator?: Partial<GitMetadataGenerator>;
@@ -135,7 +135,7 @@ function makeCheckoutSession(options?: {
     },
     ...options?.gitMetadataGenerator,
   };
-  const github: GitHubService = { ...createGitHubService(), ...options?.github };
+  const github: ForgeService = { ...createGitHubService(), ...options?.github };
   const checkout = new CheckoutSession({
     host,
     gitMutation,

--- a/packages/server/src/server/session/checkout/checkout-session.ts
+++ b/packages/server/src/server/session/checkout/checkout-session.ts
@@ -31,7 +31,7 @@ import type { GitMutationService } from "../git-mutation/git-mutation-service.js
 import {
   assertPullRequestAutoMergeDisableReady,
   assertPullRequestAutoMergeEnableReady,
-  type GitHubService,
+  type ForgeService,
   type PullRequestTimelineItem,
 } from "../../../services/github-service.js";
 import {
@@ -88,7 +88,7 @@ export interface CheckoutSessionOptions {
   host: CheckoutSessionHost;
   gitMutation: Pick<GitMutationService, "checkoutExistingBranch" | "notifyGitMutation">;
   workspaceGitService: WorkspaceGitService;
-  github: GitHubService;
+  github: ForgeService;
   checkoutDiffManager: CheckoutDiffSubscriber;
   gitMetadataGenerator: GitMetadataGenerator;
   paseoHome: string;
@@ -115,7 +115,7 @@ export class CheckoutSession {
     "checkoutExistingBranch" | "notifyGitMutation"
   >;
   private readonly workspaceGitService: WorkspaceGitService;
-  private readonly github: GitHubService;
+  private readonly github: ForgeService;
   private readonly checkoutDiffManager: CheckoutDiffSubscriber;
   private readonly gitMetadataGenerator: GitMetadataGenerator;
   private readonly paseoHome: string;

--- a/packages/server/src/server/session/git-mutation/git-mutation-service.test.ts
+++ b/packages/server/src/server/session/git-mutation/git-mutation-service.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pino } from "pino";
 import { afterEach, describe, expect, test } from "vitest";
-import type { GitHubService } from "../../../services/github-service.js";
+import type { ForgeService } from "../../../services/github-service.js";
 import type {
   WorkspaceGitBranchValidationResult,
   WorkspaceGitRuntimeSnapshot,
@@ -13,7 +13,7 @@ import type {
 import { createGitMutationService } from "./git-mutation-service.js";
 
 // The production module reads only WorkspaceGitService.{validateBranchRef,getSnapshot,hasLocalBranch}
-// and GitHubService.invalidate. The fakes below implement exactly that slice as in-memory
+// and ForgeService.invalidate. The fakes below implement exactly that slice as in-memory
 // adapters; the happy-path tests cross the real git boundary against a temp repo, since that is
 // where checkoutResolvedBranch / `git checkout -b` actually run.
 
@@ -53,7 +53,7 @@ function createFakeGit(opts: FakeGitOptions = {}) {
 
 function createFakeGithub() {
   const invalidateCalls: Array<{ cwd: string }> = [];
-  const github: Pick<GitHubService, "invalidate"> = {
+  const github: Pick<ForgeService, "invalidate"> = {
     invalidate(options) {
       invalidateCalls.push(options);
     },

--- a/packages/server/src/server/session/git-mutation/git-mutation-service.ts
+++ b/packages/server/src/server/session/git-mutation/git-mutation-service.ts
@@ -1,6 +1,6 @@
 import type pino from "pino";
 import { getErrorMessage } from "@getpaseo/protocol/error-utils";
-import type { GitHubService } from "../../../services/github-service.js";
+import type { ForgeService } from "../../../services/github-service.js";
 import {
   checkoutResolvedBranch,
   type CheckoutExistingBranchResult,
@@ -42,7 +42,7 @@ type GitMutationGitSource = Pick<
 
 export function createGitMutationService(deps: {
   workspaceGitService: GitMutationGitSource;
-  github: Pick<GitHubService, "invalidate">;
+  github: Pick<ForgeService, "invalidate">;
   logger: pino.Logger;
 }): GitMutationService {
   const { workspaceGitService, github, logger } = deps;

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -51,7 +51,8 @@ import {
   buildAgentAttentionNotificationPayload,
   findLatestPermissionRequest,
 } from "@getpaseo/protocol/agent-attention-notification";
-import { createGitHubService, type ForgeService } from "../services/github-service.js";
+import { resolveForgeService } from "../services/forge-resolver.js";
+import { type ForgeService } from "../services/github-service.js";
 import {
   extractWsBearerProtocol,
   extractWsBearerToken,
@@ -513,7 +514,7 @@ export class VoiceAssistantWebSocketServer {
     this.loopService = requiredServices.loopService;
     this.scheduleService = requiredServices.scheduleService;
     this.checkoutDiffManager = requiredServices.checkoutDiffManager;
-    this.github = github ?? createGitHubService();
+    this.github = github ?? resolveForgeService();
     this.workspaceGitService = workspaceGitService ?? createFallbackWorkspaceGitService();
     this.downloadTokenStore = downloadTokenStore;
     this.paseoHome = paseoHome;

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -51,7 +51,7 @@ import {
   buildAgentAttentionNotificationPayload,
   findLatestPermissionRequest,
 } from "@getpaseo/protocol/agent-attention-notification";
-import { createGitHubService, type GitHubService } from "../services/github-service.js";
+import { createGitHubService, type ForgeService } from "../services/github-service.js";
 import {
   extractWsBearerProtocol,
   extractWsBearerToken,
@@ -401,7 +401,7 @@ export class VoiceAssistantWebSocketServer {
   private readonly loopService: LoopService;
   private readonly scheduleService: ScheduleService;
   private readonly checkoutDiffManager: CheckoutDiffManager;
-  private readonly github: GitHubService;
+  private readonly github: ForgeService;
   private readonly workspaceGitService: WorkspaceGitService;
   private readonly downloadTokenStore: DownloadTokenStore;
   private readonly paseoHome: string;
@@ -475,7 +475,7 @@ export class VoiceAssistantWebSocketServer {
     getDaemonTcpHost?: () => string | null,
     resolveScriptHealth?: (hostname: string) => ScriptHealthState | null,
     workspaceGitService?: WorkspaceGitService,
-    github?: GitHubService,
+    github?: ForgeService,
     pushNotificationSender?: PushNotificationSender,
     providerSnapshotManager?: ProviderSnapshotManager,
     daemonRuntimeConfig?: {

--- a/packages/server/src/server/workspace-archive-service.test.ts
+++ b/packages/server/src/server/workspace-archive-service.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import pino, { type Logger } from "pino";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import type { GitHubService } from "../services/github-service.js";
+import type { ForgeService } from "../services/github-service.js";
 import { createWorktree, type WorktreeConfig } from "../utils/worktree.js";
 import type { ManagedAgent } from "./agent/agent-manager.js";
 import type { AgentStorage, StoredAgentRecord } from "./agent/agent-storage.js";
@@ -34,7 +34,7 @@ function createLogger(): Logger {
   return logger;
 }
 
-function createGitHubServiceStub(): GitHubService {
+function createGitHubServiceStub(): ForgeService {
   return {
     listPullRequests: async () => [],
     listIssues: async () => [],

--- a/packages/server/src/server/workspace-archive-service.ts
+++ b/packages/server/src/server/workspace-archive-service.ts
@@ -5,7 +5,7 @@ import type { Logger } from "pino";
 import type { AgentManager } from "./agent/agent-manager.js";
 import type { AgentStorage, StoredAgentRecord } from "./agent/agent-storage.js";
 import type { WorkspaceGitService } from "./workspace-git-service.js";
-import type { GitHubService } from "../services/github-service.js";
+import type { ForgeService } from "../services/github-service.js";
 import {
   deletePaseoWorktree,
   isPaseoOwnedWorktreeCwd,
@@ -26,7 +26,7 @@ export interface ArchiveDependencies {
   // Base directory that may hold worktrees across repositories. Used as a fallback
   // when the request does not supply a per-repo root.
   paseoWorktreesBaseRoot?: string;
-  github: GitHubService;
+  github: ForgeService;
   workspaceGitService: Pick<WorkspaceGitService, "getSnapshot">;
   agentManager: Pick<AgentManager, "listAgents" | "archiveAgent" | "archiveSnapshot">;
   agentStorage: Pick<AgentStorage, "list">;

--- a/packages/server/src/server/workspace-git-service.primitive.test.ts
+++ b/packages/server/src/server/workspace-git-service.primitive.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   createGitHubService,
   type GitHubCurrentPullRequestStatus,
-  type GitHubService,
+  type ForgeService,
 } from "../services/github-service.js";
 import {
   getCheckoutDiff as getCheckoutDiffUncached,
@@ -194,7 +194,7 @@ function createSnapshot(
   };
 }
 
-function createGitHubServiceStub(): GitHubService {
+function createGitHubServiceStub(): ForgeService {
   return {
     listPullRequests: vi.fn(async () => []),
     listIssues: vi.fn(async () => []),
@@ -235,7 +235,7 @@ interface CreateServiceOptions {
   resolveRepositoryDefaultBranch?: ReturnType<typeof vi.fn>;
   listBranchSuggestions?: ReturnType<typeof vi.fn>;
   listPaseoWorktrees?: ReturnType<typeof vi.fn>;
-  github?: GitHubService;
+  github?: ForgeService;
   resolveAbsoluteGitDir?: ReturnType<typeof vi.fn>;
   hasOriginRemote?: ReturnType<typeof vi.fn>;
   runGitFetch?: ReturnType<typeof vi.fn>;

--- a/packages/server/src/server/workspace-git-service.test.ts
+++ b/packages/server/src/server/workspace-git-service.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path, { join } from "node:path";
 import type { FSWatcher } from "node:fs";
 import type pino from "pino";
-import type { GitHubService } from "../services/github-service.js";
+import type { ForgeService } from "../services/github-service.js";
 import type {
   CheckoutSnapshotFacts,
   CheckoutStatusGit,
@@ -173,7 +173,7 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
-function createGitHubServiceStub(): GitHubService {
+function createGitHubServiceStub(): ForgeService {
   return {
     listPullRequests: vi.fn(async () => []),
     listIssues: vi.fn(async () => []),
@@ -205,7 +205,7 @@ interface CreateServiceTestOptions {
   getCheckoutSnapshotFacts?: ReturnType<typeof vi.fn>;
   getCheckoutShortstat?: ReturnType<typeof vi.fn>;
   getPullRequestStatus?: ReturnType<typeof vi.fn>;
-  github?: GitHubService;
+  github?: ForgeService;
   resolveAbsoluteGitDir?: ReturnType<typeof vi.fn>;
   hasOriginRemote?: ReturnType<typeof vi.fn>;
   runGitFetch?: ReturnType<typeof vi.fn>;

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -26,7 +26,7 @@ import {
 import {
   createGitHubService,
   type GitHubPullRequestStatusFacts,
-  type GitHubService,
+  type ForgeService,
   type PullRequestMergeable,
 } from "../services/github-service.js";
 import { parseGitRevParsePath } from "../utils/git-rev-parse-path.js";
@@ -248,7 +248,7 @@ interface WorkspaceGitServiceDependencies {
   resolveRepositoryDefaultBranch: typeof resolveRepositoryDefaultBranch;
   listBranchSuggestions: typeof listBranchSuggestions;
   listPaseoWorktrees: typeof listPaseoWorktrees;
-  github: GitHubService;
+  github: ForgeService;
   resolveAbsoluteGitDir: (cwd: string) => Promise<string | null>;
   hasOriginRemote: (cwd: string) => Promise<boolean>;
   runGitFetch: (cwd: string) => Promise<void>;

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -24,11 +24,11 @@ import {
   resolveAbsoluteGitDir,
 } from "../utils/checkout-git.js";
 import {
-  createGitHubService,
   type GitHubPullRequestStatusFacts,
   type ForgeService,
   type PullRequestMergeable,
 } from "../services/github-service.js";
+import { resolveForgeService } from "../services/forge-resolver.js";
 import { parseGitRevParsePath } from "../utils/git-rev-parse-path.js";
 import { runGitCommand } from "../utils/run-git-command.js";
 import { resolveGitHubRemote, type GitHubRemoteIdentity } from "../utils/github-remote.js";
@@ -336,7 +336,7 @@ function buildDefaultWorkspaceGitServiceDeps(): WorkspaceGitServiceDependencies 
     resolveRepositoryDefaultBranch,
     listBranchSuggestions,
     listPaseoWorktrees,
-    github: createGitHubService(),
+    github: resolveForgeService(),
     resolveAbsoluteGitDir,
     hasOriginRemote,
     runGitFetch,

--- a/packages/server/src/server/worktree-core.posix.test.ts
+++ b/packages/server/src/server/worktree-core.posix.test.ts
@@ -13,13 +13,13 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, test, afterEach } from "vitest";
-import type { GitHubService } from "../services/github-service.js";
+import type { ForgeService } from "../services/github-service.js";
 import { getCheckoutStatus, pushCurrentBranch } from "../utils/checkout-git.js";
 import { UnknownBranchError } from "../utils/worktree.js";
 import { createWorktreeCore as createCoreWorktree } from "./worktree-core.js";
 import { isPlatform } from "../test-utils/platform.js";
 
-function createGitHubServiceStub(): GitHubService {
+function createGitHubServiceStub(): ForgeService {
   return {
     listPullRequests: async () => [],
     listIssues: async () => [],
@@ -46,7 +46,7 @@ function createGitHubServiceStub(): GitHubService {
   };
 }
 
-function createCoreDeps(options?: { github?: GitHubService }) {
+function createCoreDeps(options?: { github?: ForgeService }) {
   return {
     github: options?.github ?? createGitHubServiceStub(),
     workspaceGitService: {
@@ -972,11 +972,11 @@ describe.skipIf(isPlatform("win32"))("worktree-core POSIX-only", () => {
       expect(second.worktree).toEqual(first.worktree);
     });
 
-    test("uses an injectable GitHubService dependency for missing PR head refs", async () => {
+    test("uses an injectable ForgeService dependency for missing PR head refs", async () => {
       const { tempDir, repoDir, paseoHome } = createGitHubPrRemoteRepo();
       cleanupPaths.push(tempDir);
       const headRefLookups: Array<{ cwd: string; number: number }> = [];
-      const github: GitHubService = {
+      const github: ForgeService = {
         ...createGitHubServiceStub(),
         getPullRequestHeadRef: async ({ cwd, number }) => {
           headRefLookups.push({ cwd, number });

--- a/packages/server/src/server/worktree-core.ts
+++ b/packages/server/src/server/worktree-core.ts
@@ -1,6 +1,6 @@
 import { createNameId } from "mnemonic-id";
 
-import type { GitHubService } from "../services/github-service.js";
+import type { ForgeService } from "../services/github-service.js";
 import {
   createWorktree,
   resolveExistingWorktreeForSlug,
@@ -30,7 +30,7 @@ export interface CreateWorktreeCoreInput {
 }
 
 export interface CreateWorktreeCoreDeps {
-  github: GitHubService;
+  github: ForgeService;
   workspaceGitService?: Pick<WorkspaceGitService, "resolveRepoRoot" | "resolveDefaultBranch">;
   resolveDefaultBranch?: (repoRoot: string) => Promise<string>;
 }

--- a/packages/server/src/server/worktree-session.test.ts
+++ b/packages/server/src/server/worktree-session.test.ts
@@ -33,7 +33,7 @@ import type { TerminalManager } from "../terminal/terminal-manager.js";
 import type { TerminalSession } from "../terminal/terminal.js";
 import type { AgentStorage, StoredAgentRecord } from "./agent/agent-storage.js";
 import type { PersistedProjectRecord, PersistedWorkspaceRecord } from "./workspace-registry.js";
-import type { GitHubService } from "../services/github-service.js";
+import type { ForgeService } from "../services/github-service.js";
 import {
   createPaseoWorktree as createPaseoWorktreeService,
   type CreatePaseoWorktreeFn,
@@ -126,7 +126,7 @@ function createWorkflowForRequestTest(options: {
   };
 }
 
-function createGitHubServiceStub(): GitHubService {
+function createGitHubServiceStub(): ForgeService {
   return {
     listPullRequests: async () => [],
     listIssues: async () => [],

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -22,7 +22,7 @@ import {
 import type { TerminalManager } from "../terminal/terminal-manager.js";
 import type { ServiceProxySubsystem } from "./service-proxy.js";
 import type { WorkspaceScriptRuntimeStore } from "./workspace-script-runtime-store.js";
-import type { GitHubService } from "../services/github-service.js";
+import type { ForgeService } from "../services/github-service.js";
 import type { CheckoutExistingBranchResult } from "../utils/checkout-git.js";
 import { expandTilde } from "../utils/path.js";
 import {
@@ -91,7 +91,7 @@ interface BuildAgentSessionConfigDependencies {
     baseBranch: string;
     newBranchName: string;
   }) => Promise<void>;
-  github?: Pick<GitHubService, "invalidate">;
+  github?: Pick<ForgeService, "invalidate">;
 }
 
 interface CreatePaseoWorktreeInBackgroundDependencies {

--- a/packages/server/src/services/forge-resolver.ts
+++ b/packages/server/src/services/forge-resolver.ts
@@ -1,0 +1,13 @@
+import { createGitHubService, type ForgeService } from "./github-service.js";
+
+/**
+ * Resolves the forge service to use for a workspace.
+ *
+ * Every repository is currently treated as GitHub, so this returns the GitHub
+ * adapter. This is the single seam where per-forge selection (GitHub, GitLab,
+ * and future forges) will be added; see
+ * https://github.com/getpaseo/paseo/issues/1616.
+ */
+export function resolveForgeService(): ForgeService {
+  return createGitHubService();
+}

--- a/packages/server/src/services/github-service.test.ts
+++ b/packages/server/src/services/github-service.test.ts
@@ -348,7 +348,7 @@ function pullRequestTimelineJson(overrides: Record<string, unknown> = {}): strin
   });
 }
 
-describe("GitHubService", () => {
+describe("ForgeService", () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -3064,7 +3064,7 @@ describe("GitHubService", () => {
         headRef: "feature/fork",
         force: true,
       } as never),
-    ).rejects.toThrow("GitHubService forced read requires a reason");
+    ).rejects.toThrow("ForgeService forced read requires a reason");
   });
 
   it("type: force true requires a reason", () => {

--- a/packages/server/src/services/github-service.ts
+++ b/packages/server/src/services/github-service.ts
@@ -799,7 +799,7 @@ export interface CreateGitHubPullRequestOptions {
   body?: string;
 }
 
-export interface GitHubService {
+export interface ForgeService {
   listPullRequests(options: ListGitHubPullRequestsOptions): Promise<GitHubPullRequestSummary[]>;
   listIssues(options: ListGitHubIssuesOptions): Promise<GitHubIssueSummary[]>;
   getPullRequest(options: GetGitHubPullRequestOptions): Promise<GitHubPullRequestSummary>;
@@ -926,7 +926,7 @@ interface ResolvedPullRequestCandidate {
   headRepositoryOwner?: string;
 }
 
-export function createGitHubService(options: CreateGitHubServiceOptions = {}): GitHubService {
+export function createGitHubService(options: CreateGitHubServiceOptions = {}): ForgeService {
   const ttlMs = options.ttlMs ?? DEFAULT_GITHUB_CACHE_TTL_MS;
   const deps: GitHubServiceDependencies = {
     runner: options.runner ?? runGhCommand,
@@ -937,7 +937,7 @@ export function createGitHubService(options: CreateGitHubServiceOptions = {}): G
   const inFlight = new Map<string, InFlightCacheEntry>();
   const pollTargets = new Map<string, GitHubPollTarget>();
   const checkLogTailCache = new Map<string, { logTail: string; logTruncated: boolean }>();
-  let api!: GitHubService;
+  let api!: ForgeService;
 
   async function cached<T>(params: {
     cwd: string;
@@ -947,7 +947,7 @@ export function createGitHubService(options: CreateGitHubServiceOptions = {}): G
     load: () => Promise<T>;
   }): Promise<T> {
     if (params.readOptions?.force && !params.readOptions.reason) {
-      throw new Error("GitHubService forced read requires a reason");
+      throw new Error("ForgeService forced read requires a reason");
     }
 
     const key = buildCacheKey({
@@ -1370,7 +1370,7 @@ export function createGitHubService(options: CreateGitHubServiceOptions = {}): G
 
     async searchIssuesAndPrs(input) {
       if (input.force && !input.reason) {
-        throw new Error("GitHubService forced read requires a reason");
+        throw new Error("ForgeService forced read requires a reason");
       }
 
       const kinds = input.kinds ?? ["github-issue", "github-pr"];

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -46,7 +46,7 @@ import {
   GitHubCommandError,
   GitHubCliMissingError,
   type GitHubCurrentPullRequestStatus,
-  type GitHubService,
+  type ForgeService,
 } from "../services/github-service.js";
 import {
   createWorktree as createWorktreePrimitive,
@@ -104,7 +104,7 @@ function sleep(ms: number): Promise<void> {
 function createGitHubServiceForStatus(
   status: GitHubCurrentPullRequestStatus | null,
   options?: { onStatus?: () => void },
-): GitHubService {
+): ForgeService {
   return {
     listPullRequests: async () => [],
     listIssues: async () => [],
@@ -161,7 +161,7 @@ interface RecordingPullRequestTargetsOptions {
 
 function createGitHubServiceRecordingPullRequestTargets(
   options: RecordingPullRequestTargetsOptions,
-): GitHubService {
+): ForgeService {
   const github = createGitHubServiceForStatus(null);
   github.getCurrentPullRequestStatus = async (request) => {
     options.requestedTargets.push({

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -14,7 +14,7 @@ import {
   resolveGitHubRepo,
   type GitHubCurrentPullRequestStatus,
   type GitHubPullRequestStatusFacts,
-  type GitHubService,
+  type ForgeService,
   type PullRequestMergeable,
 } from "../services/github-service.js";
 import { parseGitRevParsePath, resolveGitRevParsePath } from "./git-rev-parse-path.js";
@@ -2782,7 +2782,7 @@ async function detectAndThrowMergeFromBaseConflict(
   }
 }
 
-export async function pullCurrentBranch(cwd: string, github?: GitHubService): Promise<void> {
+export async function pullCurrentBranch(cwd: string, github?: ForgeService): Promise<void> {
   await requireGitRepo(cwd);
   const currentBranch = await getCurrentBranch(cwd);
   if (!currentBranch || currentBranch === "HEAD") {
@@ -2801,7 +2801,7 @@ export async function pullCurrentBranch(cwd: string, github?: GitHubService): Pr
   }
 }
 
-export async function pushCurrentBranch(cwd: string, github?: GitHubService): Promise<void> {
+export async function pushCurrentBranch(cwd: string, github?: ForgeService): Promise<void> {
   await requireGitRepo(cwd);
   const currentBranch = await getCurrentBranch(cwd);
   if (!currentBranch || currentBranch === "HEAD") {
@@ -2982,7 +2982,7 @@ export type ReviewDecision = "approved" | "changes_requested" | "pending" | null
 export async function createPullRequest(
   cwd: string,
   options: CreatePullRequestOptions,
-  github: GitHubService = createGitHubService(),
+  github: ForgeService = createGitHubService(),
   context?: CheckoutContext,
 ): Promise<{ url: string; number: number }> {
   await requireGitRepo(cwd);
@@ -3021,7 +3021,7 @@ export async function createPullRequest(
 
 export async function getPullRequestStatus(
   cwd: string,
-  github: GitHubService = createGitHubService(),
+  github: ForgeService = createGitHubService(),
   options?: CheckoutReadCacheOptions,
   context?: CheckoutContext,
 ): Promise<PullRequestStatusResult> {
@@ -3063,7 +3063,7 @@ export async function getPullRequestStatus(
 
 async function getPullRequestStatusUncached(
   cwd: string,
-  github: GitHubService,
+  github: ForgeService,
   options?: CheckoutReadCacheOptions,
   context?: CheckoutContext,
 ): Promise<PullRequestStatusResult> {

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -10,13 +10,13 @@ import {
   GitHubAuthenticationError,
   GitHubCliMissingError,
   GitHubCommandError,
-  createGitHubService,
   resolveGitHubRepo,
   type GitHubCurrentPullRequestStatus,
   type GitHubPullRequestStatusFacts,
   type ForgeService,
   type PullRequestMergeable,
 } from "../services/github-service.js";
+import { resolveForgeService } from "../services/forge-resolver.js";
 import { parseGitRevParsePath, resolveGitRevParsePath } from "./git-rev-parse-path.js";
 import { runGitCommand } from "./run-git-command.js";
 import { isPaseoOwnedWorktreeCwd, resolvePaseoWorktreesBaseRoot } from "./worktree.js";
@@ -2982,7 +2982,7 @@ export type ReviewDecision = "approved" | "changes_requested" | "pending" | null
 export async function createPullRequest(
   cwd: string,
   options: CreatePullRequestOptions,
-  github: ForgeService = createGitHubService(),
+  github: ForgeService = resolveForgeService(),
   context?: CheckoutContext,
 ): Promise<{ url: string; number: number }> {
   await requireGitRepo(cwd);
@@ -3021,7 +3021,7 @@ export async function createPullRequest(
 
 export async function getPullRequestStatus(
   cwd: string,
-  github: ForgeService = createGitHubService(),
+  github: ForgeService = resolveForgeService(),
   options?: CheckoutReadCacheOptions,
   context?: CheckoutContext,
 ): Promise<PullRequestStatusResult> {


### PR DESCRIPTION
### Linked issue

PR1 for #1616 (forge abstraction).

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

First, behavior-preserving step of the forge abstraction discussed in #1616 — introduce the seam
that non-GitHub adapters will plug into. Two parts:

1. **Rename the `GitHubService` interface to `ForgeService`** (81 references across `packages/server`,
   mostly test-stub annotations). Full rename, no compat alias. The GitHub adapter keeps its names —
   `createGitHubService`, the `GitHub*Error` classes, the `github` injection field, and
   `github-service.ts` itself — because that file *is* the GitHub adapter, correctly named.
2. **Route forge-service construction through `forge-resolver.ts`.** A single `resolveForgeService()`
   replaces the scattered `createGitHubService()` calls at the production construction sites
   (`bootstrap`, `session`, `websocket-server`, `workspace-git-service`, and the two `checkout-git`
   defaults). It returns the GitHub adapter today; per-forge selection plugs in here later.

No behavior change, no GitLab code. The interface still returns GitHub-shaped types today — the
neutral model comes in the next PR.


### How did you verify it

- `npm run typecheck` (all packages, incl. tests) — clean.
- `npm run lint` (oxlint) — 0 warnings, 0 errors.
- `npm run format:check` — clean.
- `npx vitest run src/services/github-service.test.ts src/utils/checkout-git.test.ts` — 186 passed
  (covers both the GitHub adapter and the routed `getPullRequestStatus`/`createPullRequest` defaults).
- Behavior-preserving by construction — the resolver returns the same GitHub adapter.


### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (oxfmt/Biome)
- [ ] UI changes include screenshots or video for every affected platform — n/a, no UI changes
- [ ] Tests added or updated where it made sense — n/a, behavior-preserving (existing tests cover it)
