### PR TITLE
feat(app): auto-preview HTML files in a sandboxed webview

### DIFF
--- a/packages/app/src/components/file-pane-render-mode.test.ts
+++ b/packages/app/src/components/file-pane-render-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isRenderedMarkdownFile } from "@/components/file-pane-render-mode";
+import { isRenderedMarkdownFile, resolveTextPreviewMode } from "@/components/file-pane-render-mode";
 
 describe("isRenderedMarkdownFile", () => {
   it("detects .md files", () => {
@@ -19,5 +19,30 @@ describe("isRenderedMarkdownFile", () => {
   it("does not treat other text files as rendered markdown", () => {
     expect(isRenderedMarkdownFile("src/index.ts")).toBe(false);
     expect(isRenderedMarkdownFile("README.md.txt")).toBe(false);
+  });
+});
+
+describe("resolveTextPreviewMode", () => {
+  it("renders markdown for markdown files", () => {
+    expect(resolveTextPreviewMode("README.md")).toBe("markdown");
+  });
+
+  it("renders live html for html files", () => {
+    expect(resolveTextPreviewMode("index.html")).toBe("html");
+    expect(resolveTextPreviewMode("page.htm")).toBe("html");
+  });
+
+  it("renders source code for everything else", () => {
+    expect(resolveTextPreviewMode("main.ts")).toBe("code");
+    expect(resolveTextPreviewMode("Makefile")).toBe("code");
+    // SVG is an image (handled by the image viewer), not an html text preview.
+    expect(resolveTextPreviewMode("diagram.svg")).toBe("code");
+    // .mdx is not rendered markdown.
+    expect(resolveTextPreviewMode("page.mdx")).toBe("code");
+  });
+
+  it("forces source view when a specific line is targeted", () => {
+    expect(resolveTextPreviewMode("index.html", { hasLineSelection: true })).toBe("code");
+    expect(resolveTextPreviewMode("README.md", { hasLineSelection: true })).toBe("code");
   });
 });

--- a/packages/app/src/components/file-pane-render-mode.ts
+++ b/packages/app/src/components/file-pane-render-mode.ts
@@ -1,4 +1,38 @@
+import { isAutoPreviewHtml, resolveFilePreviewKind } from "@/file-explorer/preview-kind";
+
 export function isRenderedMarkdownFile(filePath: string): boolean {
   const normalizedPath = filePath.trim().toLowerCase();
   return normalizedPath.endsWith(".md") || normalizedPath.endsWith(".markdown");
+}
+
+export type TextPreviewMode = "markdown" | "html" | "code";
+
+/**
+ * Decides how a text file should render in the file pane:
+ * - `code`     — syntax-highlighted source (default, and forced when the user
+ *                opened a specific line so they can read the exact source).
+ * - `markdown` — rendered markdown.
+ * - `html`     — live, sandboxed HTML preview ("open an html file and it just
+ *                previews"). Falls back to source via the pane's line target.
+ *
+ * Markdown/HTML detection both go through `resolveFilePreviewKind` so there is a
+ * single source of truth for file classification (no parallel classifier to
+ * drift). Pure + headlessly testable; the file pane consumes the result.
+ */
+export function resolveTextPreviewMode(
+  filePath: string,
+  options?: { hasLineSelection?: boolean },
+): TextPreviewMode {
+  // A specific line target means the user wants the exact source at that line.
+  if (options?.hasLineSelection) {
+    return "code";
+  }
+  const kind = resolveFilePreviewKind(filePath);
+  if (kind === "markdown") {
+    return "markdown";
+  }
+  if (isAutoPreviewHtml(filePath)) {
+    return "html";
+  }
+  return "code";
 }

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -20,7 +20,8 @@ import { syntaxTokenStyleFor } from "@/styles/syntax-token-styles";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { lineNumberGutterWidth } from "@/components/code-insets";
 import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
-import { isRenderedMarkdownFile } from "@/components/file-pane-render-mode";
+import { resolveTextPreviewMode } from "@/components/file-pane-render-mode";
+import { HtmlFilePreview } from "@/components/html-file-preview";
 import { isWeb } from "@/constants/platform";
 import type { AttachmentMetadata } from "@/attachments/types";
 import { useAttachmentPreviewUrl } from "@/attachments/use-attachment-preview-url";
@@ -200,8 +201,11 @@ function FilePreviewBody({
   const { theme } = useUnistyles();
   const { t } = useTranslation();
   const filePath = location.path;
-  const isMarkdownFile =
-    preview?.kind === "text" && isRenderedMarkdownFile(filePath) && !location.lineStart;
+  const textPreviewMode =
+    preview?.kind === "text"
+      ? resolveTextPreviewMode(filePath, { hasLineSelection: Boolean(location.lineStart) })
+      : "code";
+  const isMarkdownFile = textPreviewMode === "markdown";
 
   const previewScrollRef = useRef<RNScrollView>(null);
   const webScrollbarStyle = useWebScrollbarStyle();
@@ -210,12 +214,12 @@ function FilePreviewBody({
   });
 
   const highlightedLines = useMemo(() => {
-    if (!preview || preview.kind !== "text" || isMarkdownFile) {
+    if (!preview || preview.kind !== "text" || textPreviewMode !== "code") {
       return null;
     }
 
     return highlightCode(preview.content ?? "", filePath);
-  }, [isMarkdownFile, preview, filePath]);
+  }, [textPreviewMode, preview, filePath]);
 
   const gutterWidth = useMemo(() => {
     if (!highlightedLines) return 0;
@@ -285,6 +289,14 @@ function FilePreviewBody({
             <MarkdownRenderer text={preview.content ?? ""} />
           </RNScrollView>
           {scrollbar.overlay}
+        </View>
+      );
+    }
+
+    if (textPreviewMode === "html") {
+      return (
+        <View style={styles.previewScrollContainer}>
+          <HtmlFilePreview content={preview.content ?? ""} />
         </View>
       );
     }

--- a/packages/app/src/components/html-file-preview.tsx
+++ b/packages/app/src/components/html-file-preview.tsx
@@ -8,8 +8,8 @@ const ORIGIN_WHITELIST = ["*"];
 // Navigation policy for the previewed content. The injected HTML loads with an
 // empty baseUrl, so the document and all in-page navigation live on
 // `about:blank`:
-//   - the initial load and in-page anchor / fragment jumps (`#section`) stay on
-//     about:blank → allowed, so in-page links work.
+//   - the initial load and in-page anchor / fragment jumps (which resolve to
+//     `about:blank#section`) → allowed, so in-page links work.
 //   - external links (http/https/mailto/…) are opened in the system browser
 //     instead of letting the preview navigate the WebView pane away to an
 //     external page (which would break the sandboxed-preview guarantee).
@@ -18,7 +18,7 @@ const handleWebViewNavigation: NonNullable<
   ComponentProps<typeof WebView>["onShouldStartLoadWithRequest"]
 > = (request) => {
   const url = request.url;
-  if (url === "" || url.startsWith("about:blank") || url.startsWith("#")) {
+  if (url === "" || url.startsWith("about:blank")) {
     return true;
   }
   void Linking.openURL(url).catch(() => {

--- a/packages/app/src/components/html-file-preview.tsx
+++ b/packages/app/src/components/html-file-preview.tsx
@@ -1,0 +1,59 @@
+import { useMemo, type ComponentProps } from "react";
+import * as Linking from "expo-linking";
+import { StyleSheet } from "react-native-unistyles";
+import { WebView } from "react-native-webview";
+
+const ORIGIN_WHITELIST = ["*"];
+
+// Navigation policy for the previewed content. The injected HTML loads with an
+// empty baseUrl, so the document and all in-page navigation live on
+// `about:blank`:
+//   - the initial load and in-page anchor / fragment jumps (`#section`) stay on
+//     about:blank → allowed, so in-page links work.
+//   - external links (http/https/mailto/…) are opened in the system browser
+//     instead of letting the preview navigate the WebView pane away to an
+//     external page (which would break the sandboxed-preview guarantee).
+// Hoisted to module scope so it's a stable prop reference.
+const handleWebViewNavigation: NonNullable<
+  ComponentProps<typeof WebView>["onShouldStartLoadWithRequest"]
+> = (request) => {
+  const url = request.url;
+  if (url === "" || url.startsWith("about:blank") || url.startsWith("#")) {
+    return true;
+  }
+  void Linking.openURL(url).catch(() => {
+    // Ignore: nothing to do if the OS can't open the URL.
+  });
+  return false;
+};
+
+/**
+ * Native (iOS / Android) HTML preview. Renders the file content inside a
+ * react-native-webview, which is an isolated web context separate from the app
+ * (the analog of the sandboxed iframe used on web in html-file-preview.web.tsx).
+ * `setSupportMultipleWindows={false}` blocks `window.open()` popups, and
+ * `onShouldStartLoadWithRequest` blocks any in-place navigation triggered by
+ * the previewed content (links, `meta refresh`, JS `location` changes) so the
+ * preview cannot navigate the pane away to an external URL.
+ */
+export function HtmlFilePreview({ content }: { content: string }) {
+  const source = useMemo(() => ({ html: content, baseUrl: "" }), [content]);
+  return (
+    <WebView
+      originWhitelist={ORIGIN_WHITELIST}
+      source={source}
+      style={styles.webview}
+      setSupportMultipleWindows={false}
+      onShouldStartLoadWithRequest={handleWebViewNavigation}
+      // Keep horizontal layout sane for documents authored for desktop widths.
+      scalesPageToFit
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  webview: {
+    flex: 1,
+    backgroundColor: "#ffffff",
+  },
+});

--- a/packages/app/src/components/html-file-preview.web.tsx
+++ b/packages/app/src/components/html-file-preview.web.tsx
@@ -1,0 +1,28 @@
+import { createElement, type CSSProperties } from "react";
+
+const IFRAME_STYLE: CSSProperties = {
+  border: "none",
+  width: "100%",
+  height: "100%",
+  backgroundColor: "#ffffff",
+};
+
+/**
+ * Renders HTML file content live in a sandboxed iframe.
+ *
+ * Security: `sandbox="allow-scripts"` WITHOUT `allow-same-origin` gives the
+ * frame a unique opaque origin — scripts can run for the preview, but they
+ * cannot reach the parent app, its DOM, cookies, or storage. This mirrors the
+ * sandboxed-iframe pattern used across the ecosystem for agent-generated HTML.
+ *
+ * `createElement` is used (as in browser-pane.electron.tsx) so the DOM element
+ * typechecks cleanly inside this React Native + react-native-web project.
+ */
+export function HtmlFilePreview({ content }: { content: string }) {
+  return createElement("iframe", {
+    title: "HTML preview",
+    srcDoc: content,
+    sandbox: "allow-scripts",
+    style: IFRAME_STYLE,
+  });
+}

--- a/packages/app/src/components/html-file-preview.web.tsx
+++ b/packages/app/src/components/html-file-preview.web.tsx
@@ -1,4 +1,4 @@
-import { createElement, type CSSProperties } from "react";
+import { createElement, useCallback, useEffect, useRef, type CSSProperties } from "react";
 
 const IFRAME_STYLE: CSSProperties = {
   border: "none",
@@ -11,18 +11,52 @@ const IFRAME_STYLE: CSSProperties = {
  * Renders HTML file content live in a sandboxed iframe.
  *
  * Security: `sandbox="allow-scripts"` WITHOUT `allow-same-origin` gives the
- * frame a unique opaque origin — scripts can run for the preview, but they
- * cannot reach the parent app, its DOM, cookies, or storage. This mirrors the
- * sandboxed-iframe pattern used across the ecosystem for agent-generated HTML.
+ * frame a unique opaque origin — scripts can run (so the preview stays
+ * interactive: buttons, JS, in-page `#anchor` jumps all work) but they cannot
+ * reach the parent app, its DOM, cookies, or storage.
+ *
+ * Navigation guard (web equivalent of the native renderer's
+ * `onShouldStartLoadWithRequest`): a sandboxed iframe can still navigate its OWN
+ * browsing context, so a preview document doing `location.href = …`, a
+ * `meta refresh`, or a plain link click could otherwise replace the pane with an
+ * arbitrary external page. We allow only the initial `srcDoc` load; any
+ * subsequent top-level load means the preview tried to navigate away, so we
+ * restore the original content. In-page fragment navigation does NOT trigger a
+ * `load` event, so anchor links and interactivity are preserved.
  *
  * `createElement` is used (as in browser-pane.electron.tsx) so the DOM element
  * typechecks cleanly inside this React Native + react-native-web project.
  */
 export function HtmlFilePreview({ content }: { content: string }) {
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const initialLoadDoneRef = useRef(false);
+
+  // Treat the load triggered by a new file's content as a fresh initial load.
+  useEffect(() => {
+    initialLoadDoneRef.current = false;
+  }, [content]);
+
+  const handleLoad = useCallback(() => {
+    if (!initialLoadDoneRef.current) {
+      initialLoadDoneRef.current = true;
+      return;
+    }
+    // A full navigation happened after the initial render — snap the preview
+    // back to its own content so it can't be hijacked to an external page.
+    // The restore re-loads `srcDoc`, which counts as the next "initial" load.
+    initialLoadDoneRef.current = false;
+    const frame = frameRef.current;
+    if (frame) {
+      frame.srcdoc = content;
+    }
+  }, [content]);
+
   return createElement("iframe", {
+    ref: frameRef,
     title: "HTML preview",
     srcDoc: content,
     sandbox: "allow-scripts",
+    onLoad: handleLoad,
     style: IFRAME_STYLE,
   });
 }

--- a/packages/app/src/components/html-file-preview.web.tsx
+++ b/packages/app/src/components/html-file-preview.web.tsx
@@ -1,4 +1,4 @@
-import { createElement, useCallback, useEffect, useRef, type CSSProperties } from "react";
+import { createElement, useCallback, useLayoutEffect, useRef, type CSSProperties } from "react";
 
 const IFRAME_STYLE: CSSProperties = {
   border: "none",
@@ -32,7 +32,10 @@ export function HtmlFilePreview({ content }: { content: string }) {
   const initialLoadDoneRef = useRef(false);
 
   // Treat the load triggered by a new file's content as a fresh initial load.
-  useEffect(() => {
+  // useLayoutEffect runs synchronously after the DOM commit, before the browser
+  // can dispatch the iframe's `load` event — so the flag is reset before the
+  // new content's initial load fires (a plain useEffect could race it).
+  useLayoutEffect(() => {
     initialLoadDoneRef.current = false;
   }, [content]);
 

--- a/packages/app/src/file-explorer/preview-kind.test.ts
+++ b/packages/app/src/file-explorer/preview-kind.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { getFileExtension, isAutoPreviewHtml, resolveFilePreviewKind } from "./preview-kind";
+
+describe("getFileExtension", () => {
+  it("returns the lowercased extension", () => {
+    expect(getFileExtension("index.HTML")).toBe("html");
+    expect(getFileExtension("a/b/c/report.Md")).toBe("md");
+  });
+
+  it("returns empty for extensionless files and dotfiles", () => {
+    expect(getFileExtension("Makefile")).toBe("");
+    expect(getFileExtension(".gitignore")).toBe("");
+    expect(getFileExtension("/a/b/LICENSE")).toBe("");
+  });
+});
+
+describe("resolveFilePreviewKind", () => {
+  it("treats html variants as html", () => {
+    expect(resolveFilePreviewKind("index.html")).toBe("html");
+    expect(resolveFilePreviewKind("page.htm")).toBe("html");
+    expect(resolveFilePreviewKind("doc.xhtml")).toBe("html");
+    expect(resolveFilePreviewKind("/abs/path/Report.HTML")).toBe("html");
+  });
+
+  it("classifies images (incl. svg), markdown, pdf, and text", () => {
+    // SVG is served as an image by the server; the classifier stays aligned.
+    expect(resolveFilePreviewKind("icon.svg")).toBe("image");
+    expect(resolveFilePreviewKind("photo.PNG")).toBe("image");
+    expect(resolveFilePreviewKind("notes.md")).toBe("markdown");
+    // .mdx is not rendered markdown (matches isRenderedMarkdownFile).
+    expect(resolveFilePreviewKind("page.mdx")).toBe("text");
+    expect(resolveFilePreviewKind("paper.pdf")).toBe("pdf");
+    expect(resolveFilePreviewKind("main.ts")).toBe("text");
+    expect(resolveFilePreviewKind("Makefile")).toBe("text");
+  });
+});
+
+describe("isAutoPreviewHtml", () => {
+  it("is true for html only, false otherwise", () => {
+    expect(isAutoPreviewHtml("/tmp/out.html")).toBe(true);
+    expect(isAutoPreviewHtml("page.htm")).toBe(true);
+    // SVG is an image (server-served as such), not an html auto-preview.
+    expect(isAutoPreviewHtml("diagram.svg")).toBe(false);
+    expect(isAutoPreviewHtml("readme.md")).toBe(false);
+    expect(isAutoPreviewHtml("app.tsx")).toBe(false);
+    expect(isAutoPreviewHtml("photo.png")).toBe(false);
+  });
+});

--- a/packages/app/src/file-explorer/preview-kind.ts
+++ b/packages/app/src/file-explorer/preview-kind.ts
@@ -1,0 +1,65 @@
+/**
+ * Decides how a file should be previewed in the file pane, based on its path
+ * (extension). This is the pure, headlessly-testable core of the "HTML files
+ * auto-preview" feature: the file pane renders `html` in a sandboxed webview
+ * instead of showing raw source. All other kinds keep their existing rendering
+ * (image viewer, markdown, syntax-highlighted text).
+ *
+ * Classification is kept consistent with the server's own file-kind detection
+ * (`.svg` is served as an image), so this never claims a render path the file
+ * pane can't actually reach.
+ */
+export type FilePreviewKind = "html" | "image" | "markdown" | "pdf" | "text";
+
+const HTML_EXTENSIONS = new Set(["html", "htm", "xhtml"]);
+const MARKDOWN_EXTENSIONS = new Set(["md", "markdown"]);
+const PDF_EXTENSIONS = new Set(["pdf"]);
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "bmp",
+  "ico",
+  "avif",
+  "apng",
+  // The server serves SVG as an image too; keep this classifier aligned.
+  "svg",
+]);
+
+/**
+ * Returns the lowercased file extension (without the dot) for a path. Ignores
+ * leading-dot "dotfiles" (e.g. `.gitignore` has no preview extension).
+ */
+export function getFileExtension(path: string): string {
+  const base = path.split(/[\\/]/).pop() ?? path;
+  const dotIndex = base.lastIndexOf(".");
+  if (dotIndex <= 0) {
+    // No dot, or a leading-dot dotfile with no further extension.
+    return "";
+  }
+  return base.slice(dotIndex + 1).toLowerCase();
+}
+
+export function resolveFilePreviewKind(path: string): FilePreviewKind {
+  const ext = getFileExtension(path);
+  if (HTML_EXTENSIONS.has(ext)) {
+    return "html";
+  }
+  if (IMAGE_EXTENSIONS.has(ext)) {
+    return "image";
+  }
+  if (MARKDOWN_EXTENSIONS.has(ext)) {
+    return "markdown";
+  }
+  if (PDF_EXTENSIONS.has(ext)) {
+    return "pdf";
+  }
+  return "text";
+}
+
+/** Whether a path should auto-render as live HTML (vs. showing source text). */
+export function isAutoPreviewHtml(path: string): boolean {
+  return resolveFilePreviewKind(path) === "html";
+}


### PR DESCRIPTION
Closes #1816

## What this PR does

Opening an `.html`/`.htm`/`.xhtml` file in the file pane now renders it **live** in a sandboxed webview instead of showing raw source. A specific line target still shows the syntax-highlighted source.

- `file-pane-render-mode`: `resolveTextPreviewMode(path, { hasLineSelection }) → "markdown" | "html" | "code"` (pure). HTML auto-preview unless a line was targeted. (SVG keeps using the existing image viewer — the server serves it as an image.)
- `preview-kind`: `resolveFilePreviewKind` / `isAutoPreviewHtml` extension classifier.
- `html-file-preview`:
  - web/desktop → `<iframe sandbox="allow-scripts">` (no `allow-same-origin` → opaque origin; scripts run for the preview but can't reach the app/DOM/cookies/storage).
  - native (iOS/Android) → `react-native-webview` (already a dependency), an isolated context.
- `file-pane`: routes the text branch through `resolveTextPreviewMode`; renders the sandboxed preview for html; skips syntax highlighting for non-code modes.

## Type of change

- [x] New feature (proposed in #1816)

## How I verified

- `npx vitest run preview-kind.test.ts file-pane-render-mode.test.ts` → 14 pass (incl. the existing `isRenderedMarkdownFile` cases, preserved).
- `oxlint` + `oxfmt --check` clean on all changed files.
- Changed files typecheck (no errors attributable to them).

## Testing evidence / platforms — honest status

Logic is unit-tested and the sandboxing is in place. I have **not** yet captured on-device/render screenshots for desktop/web/iOS/Android — visual verification (web via Playwright, iOS via simulator) is in progress and I'll attach screenshots for the affected platforms before this is ready to merge. Flagging clearly per CONTRIBUTING. Happy to adjust the UX/placement to the maintainer's preference.

