### PR TITLE
feat: real provider-native session fork (Kiro)

### DIFF
--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -92,6 +92,7 @@ interface SplitContainerProps {
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
+  onForkAgent: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
@@ -373,6 +374,7 @@ export function SplitContainer({
   onCloseTab,
   onCopyResumeCommand,
   onCopyAgentId,
+  onForkAgent,
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
@@ -590,6 +592,7 @@ export function SplitContainer({
           onCloseTab={onCloseTab}
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
+          onForkAgent={onForkAgent}
           onCopyFilePath={onCopyFilePath}
           onReloadAgent={onReloadAgent}
           onRenameTab={onRenameTab}
@@ -733,6 +736,7 @@ function SplitNodeView({
   onCloseTab,
   onCopyResumeCommand,
   onCopyAgentId,
+  onForkAgent,
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
@@ -786,6 +790,7 @@ function SplitNodeView({
         onCloseTab={onCloseTab}
         onCopyResumeCommand={onCopyResumeCommand}
         onCopyAgentId={onCopyAgentId}
+        onForkAgent={onForkAgent}
         onCopyFilePath={onCopyFilePath}
         onReloadAgent={onReloadAgent}
         onRenameTab={onRenameTab}
@@ -832,6 +837,7 @@ function SplitNodeView({
               onCloseTab={onCloseTab}
               onCopyResumeCommand={onCopyResumeCommand}
               onCopyAgentId={onCopyAgentId}
+              onForkAgent={onForkAgent}
               onCopyFilePath={onCopyFilePath}
               onReloadAgent={onReloadAgent}
               onRenameTab={onRenameTab}
@@ -884,6 +890,7 @@ function SplitPaneView({
   onCloseTab,
   onCopyResumeCommand,
   onCopyAgentId,
+  onForkAgent,
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
@@ -1026,6 +1033,7 @@ function SplitPaneView({
             onCloseTab={onCloseTab}
             onCopyResumeCommand={onCopyResumeCommand}
             onCopyAgentId={onCopyAgentId}
+            onForkAgent={onForkAgent}
             onCopyFilePath={onCopyFilePath}
             onReloadAgent={onReloadAgent}
             onRenameTab={onRenameTab}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -450,6 +450,7 @@ export const ar: TranslationResources = {
         openFor: "فتح القائمة لـ{{label}}",
         copyResumeCommand: "نسخ أمر السيرة الذاتية",
         copyAgentId: "نسخ معرف الوكيل",
+        forkAgent: "تفريع المحادثة",
         copyFilePath: "Copy file path",
         rename: "إعادة تسمية",
         closeAbove: "إغلاق علامات التبويب أعلاه",
@@ -1275,6 +1276,12 @@ export const ar: TranslationResources = {
       mute: "كتم صوت الوقت الحقيقي",
       unmute: "إلغاء كتم صوت الوقت الحقيقي",
       stop: "إيقاف الصوت في الوقت الحقيقي ومقاطعة الدوران",
+    },
+  },
+  fork: {
+    tooltip: "تفريع من هنا",
+    errors: {
+      failed: "فشل تفريع المحادثة",
     },
   },
   rewind: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -450,6 +450,7 @@ export const en = {
         openFor: "Open menu for {{label}}",
         copyResumeCommand: "Copy resume command",
         copyAgentId: "Copy agent id",
+        forkAgent: "Fork agent",
         copyFilePath: "Copy file path",
         rename: "Rename",
         closeAbove: "Close tabs above",
@@ -1282,6 +1283,12 @@ export const en = {
       mute: "Mute realtime voice",
       unmute: "Unmute realtime voice",
       stop: "Stop realtime voice and interrupt turn",
+    },
+  },
+  fork: {
+    tooltip: "Fork from here",
+    errors: {
+      failed: "Failed to fork conversation",
     },
   },
   rewind: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -454,6 +454,7 @@ export const es: TranslationResources = {
         openFor: "Menú abierto para{{label}}",
         copyResumeCommand: "Copiar comando de reanudación",
         copyAgentId: "Copiar ID del agente",
+        forkAgent: "Bifurcar conversación",
         copyFilePath: "Copy file path",
         rename: "Rebautizar",
         closeAbove: "Cerrar pestañas arriba",
@@ -1311,6 +1312,12 @@ export const es: TranslationResources = {
       mute: "Silenciar voz en tiempo real",
       unmute: "Activar voz en tiempo real",
       stop: "Detener la voz en tiempo real e interrumpir el turno.",
+    },
+  },
+  fork: {
+    tooltip: "Bifurcar desde aquí",
+    errors: {
+      failed: "No se pudo bifurcar la conversación",
     },
   },
   rewind: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -454,6 +454,7 @@ export const fr: TranslationResources = {
         openFor: "Ouvrir le menu pour{{label}}",
         copyResumeCommand: "Copier la commande de reprise",
         copyAgentId: "Copier l'identifiant de l'agent",
+        forkAgent: "Forker la conversation",
         copyFilePath: "Copy file path",
         rename: "Rebaptiser",
         closeAbove: "Fermer les onglets ci-dessus",
@@ -1314,6 +1315,12 @@ export const fr: TranslationResources = {
       mute: "Couper la voix en temps réel",
       unmute: "Réactiver la voix en temps réel",
       stop: "Arrêtez la voix en temps réel et interrompez le tour",
+    },
+  },
+  fork: {
+    tooltip: "Bifurquer ici",
+    errors: {
+      failed: "Échec de la bifurcation de la conversation",
     },
   },
   rewind: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -454,6 +454,7 @@ export const ja: TranslationResources = {
         openFor: "{{label}}のメニューを開く",
         copyResumeCommand: "再開コマンドをコピー",
         copyAgentId: "エージェントIDをコピー",
+        forkAgent: "会話を分岐",
         copyFilePath: "ファイルパスをコピー",
         rename: "名前を変更",
         closeAbove: "上のタブを閉じる",
@@ -1291,6 +1292,12 @@ export const ja: TranslationResources = {
       mute: "リアルタイム音声をミュート",
       unmute: "リアルタイム音声のミュートを解除",
       stop: "リアルタイム音声を停止してターンを中断",
+    },
+  },
+  fork: {
+    tooltip: "ここから分岐",
+    errors: {
+      failed: "会話の分岐に失敗しました",
     },
   },
   rewind: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -454,6 +454,7 @@ export const ptBR: TranslationResources = {
         openFor: "Abrir menu de {{label}}",
         copyResumeCommand: "Copiar comando de retomada",
         copyAgentId: "Copiar ID do agente",
+        forkAgent: "Bifurcar conversa",
         copyFilePath: "Copiar caminho do arquivo",
         rename: "Renomear",
         closeAbove: "Fechar abas acima",
@@ -1297,6 +1298,12 @@ export const ptBR: TranslationResources = {
       mute: "Silenciar voz em tempo real",
       unmute: "Ativar voz em tempo real",
       stop: "Parar voz em tempo real e interromper a resposta",
+    },
+  },
+  fork: {
+    tooltip: "Bifurcar a partir daqui",
+    errors: {
+      failed: "Falha ao bifurcar a conversa",
     },
   },
   rewind: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -454,6 +454,7 @@ export const ru: TranslationResources = {
         openFor: "Открыть меню для{{label}}",
         copyResumeCommand: "Копировать команду возобновления",
         copyAgentId: "Скопировать идентификатор агента",
+        forkAgent: "Разветвить разговор",
         copyFilePath: "Copy file path",
         rename: "Переименовать",
         closeAbove: "Закрыть вкладки выше",
@@ -1303,6 +1304,12 @@ export const ru: TranslationResources = {
       mute: "Отключить звук в реальном времени",
       unmute: "Включить звук голоса в реальном времени",
       stop: "Остановить голос в реальном времени и прервать поворот",
+    },
+  },
+  fork: {
+    tooltip: "Разветвить отсюда",
+    errors: {
+      failed: "Не удалось разветвить разговор",
     },
   },
   rewind: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -450,6 +450,7 @@ export const zhCN: TranslationResources = {
         openFor: "打开 {{label}} 的菜单",
         copyResumeCommand: "复制恢复命令",
         copyAgentId: "复制 Agent ID",
+        forkAgent: "分叉会话",
         copyFilePath: "Copy file path",
         rename: "重命名",
         closeAbove: "关闭上方标签",
@@ -1258,6 +1259,12 @@ export const zhCN: TranslationResources = {
       mute: "静音 realtime voice",
       unmute: "取消静音 realtime voice",
       stop: "停止 realtime voice 并中断 turn",
+    },
+  },
+  fork: {
+    tooltip: "从这里分叉",
+    errors: {
+      failed: "分叉会话失败",
     },
   },
   rewind: {

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -19,6 +19,7 @@ import {
 import {
   CopyX,
   ArrowLeftToLine,
+  GitBranch,
   ArrowRightToLine,
   ChevronDown,
   Columns2,
@@ -99,6 +100,7 @@ const ThemedX = withUnistyles(X);
 const ThemedCopy = withUnistyles(Copy);
 const ThemedRotateCw = withUnistyles(RotateCw);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
+const ThemedGitBranch = withUnistyles(GitBranch);
 const ThemedArrowRightToLine = withUnistyles(ArrowRightToLine);
 const ThemedCopyX = withUnistyles(CopyX);
 const ThemedPencil = withUnistyles(Pencil);
@@ -328,6 +330,8 @@ function TabContextMenuItem({
     switch (entry.icon) {
       case "copy":
         return <ThemedCopy size={16} uniProps={mutedColorMapping} />;
+      case "git-branch":
+        return <ThemedGitBranch size={16} uniProps={mutedColorMapping} />;
       case "rotate-cw":
         return <ThemedRotateCw size={16} uniProps={mutedColorMapping} />;
       case "arrow-left-to-line":
@@ -419,6 +423,7 @@ interface WorkspaceDesktopTabsRowProps {
   onCloseTab: (tabId: string) => Promise<void> | void;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
+  onForkAgent: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
@@ -739,6 +744,7 @@ export function WorkspaceDesktopTabsRow({
   onCloseTab,
   onCopyResumeCommand,
   onCopyAgentId,
+  onForkAgent,
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
@@ -811,6 +817,7 @@ export function WorkspaceDesktopTabsRow({
     () => ({
       copyResumeCommand: t("workspace.tabs.menu.copyResumeCommand"),
       copyAgentId: t("workspace.tabs.menu.copyAgentId"),
+      forkAgent: t("workspace.tabs.menu.forkAgent"),
       copyFilePath: t("workspace.tabs.menu.copyFilePath"),
       rename: t("workspace.tabs.menu.rename"),
       closeAbove: t("workspace.tabs.menu.closeAbove"),
@@ -909,6 +916,7 @@ export function WorkspaceDesktopTabsRow({
           normalizedWorkspaceId={normalizedWorkspaceId}
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
+          onForkAgent={onForkAgent}
           onCopyFilePath={onCopyFilePath}
           onReloadAgent={onReloadAgent}
           onRenameTab={onRenameTab}
@@ -940,6 +948,7 @@ export function WorkspaceDesktopTabsRow({
       onCloseTabsToLeft,
       onCloseTabsToRight,
       onCopyAgentId,
+      onForkAgent,
       onCopyFilePath,
       onCopyResumeCommand,
       onNavigateTab,
@@ -1036,6 +1045,7 @@ function ResolvedDesktopTabChip({
   normalizedWorkspaceId,
   onCopyResumeCommand,
   onCopyAgentId,
+  onForkAgent,
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
@@ -1062,6 +1072,7 @@ function ResolvedDesktopTabChip({
   normalizedWorkspaceId: string;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
+  onForkAgent: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
@@ -1088,6 +1099,7 @@ function ResolvedDesktopTabChip({
         tabCount,
         onCopyResumeCommand,
         onCopyAgentId,
+        onForkAgent,
         onCopyFilePath,
         onReloadAgent,
         onRenameTab,
@@ -1105,6 +1117,7 @@ function ResolvedDesktopTabChip({
       onCloseTabsToLeft,
       onCloseTabsToRight,
       onCopyAgentId,
+      onForkAgent,
       onCopyFilePath,
       onCopyResumeCommand,
       labels,

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -19,6 +19,7 @@ import { DiffStat } from "@/components/diff-stat";
 import {
   CopyX,
   ArrowLeftToLine,
+  GitBranch,
   ArrowRightToLine,
   ChevronDown,
   Copy,
@@ -237,6 +238,7 @@ const ThemedChevronDown = withUnistyles(ChevronDown);
 const ThemedCopy = withUnistyles(Copy);
 const ThemedRotateCw = withUnistyles(RotateCw);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
+const ThemedGitBranch = withUnistyles(GitBranch);
 const ThemedArrowRightToLine = withUnistyles(ArrowRightToLine);
 const ThemedCopyX = withUnistyles(CopyX);
 const ThemedPencil = withUnistyles(Pencil);
@@ -386,6 +388,7 @@ interface MobileWorkspaceTabSwitcherProps {
   onSelectSwitcherTab: (key: string) => void;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
+  onForkAgent: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
@@ -528,6 +531,8 @@ function MobileTabDropdownMenuItem({
     switch (entry.icon) {
       case "copy":
         return <ThemedCopy size={16} uniProps={mutedColorMapping} />;
+      case "git-branch":
+        return <ThemedGitBranch size={16} uniProps={mutedColorMapping} />;
       case "rotate-cw":
         return <ThemedRotateCw size={16} uniProps={mutedColorMapping} />;
       case "arrow-left-to-line":
@@ -574,6 +579,7 @@ function MobileWorkspaceTabOption({
   onPress,
   onCopyResumeCommand,
   onCopyAgentId,
+  onForkAgent,
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
@@ -592,6 +598,7 @@ function MobileWorkspaceTabOption({
   onPress: () => void;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
+  onForkAgent: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
@@ -605,6 +612,7 @@ function MobileWorkspaceTabOption({
     () => ({
       copyResumeCommand: t("workspace.tabs.menu.copyResumeCommand"),
       copyAgentId: t("workspace.tabs.menu.copyAgentId"),
+      forkAgent: t("workspace.tabs.menu.forkAgent"),
       copyFilePath: t("workspace.tabs.menu.copyFilePath"),
       rename: t("workspace.tabs.menu.rename"),
       closeAbove: t("workspace.tabs.menu.closeAbove"),
@@ -627,6 +635,7 @@ function MobileWorkspaceTabOption({
     menuTestIDBase,
     onCopyResumeCommand,
     onCopyAgentId,
+    onForkAgent,
     onCopyFilePath,
     onReloadAgent,
     onRenameTab,
@@ -694,6 +703,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
   onSelectSwitcherTab,
   onCopyResumeCommand,
   onCopyAgentId,
+  onForkAgent,
   onCopyFilePath,
   onReloadAgent,
   onRenameTab,
@@ -750,6 +760,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
           onPress={onPress}
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
+          onForkAgent={onForkAgent}
           onCopyFilePath={onCopyFilePath}
           onReloadAgent={onReloadAgent}
           onRenameTab={onRenameTab}
@@ -768,6 +779,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
       normalizedWorkspaceId,
       onCopyResumeCommand,
       onCopyAgentId,
+      onForkAgent,
       onCopyFilePath,
       onReloadAgent,
       onRenameTab,
@@ -2602,6 +2614,24 @@ function WorkspaceScreenContent({
     [toast, t],
   );
 
+  const handleForkAgent = useCallback(
+    async (agentId: string) => {
+      if (!agentId) return;
+      if (!client) {
+        toast.error(t("common.errors.daemonClientUnavailable"));
+        return;
+      }
+      try {
+        // Forks the whole conversation into a new, independent parallel agent;
+        // the daemon broadcasts the new agent so it appears in the workspace.
+        await client.forkAgent(agentId);
+      } catch {
+        toast.error(t("fork.errors.failed"));
+      }
+    },
+    [client, toast, t],
+  );
+
   const handleCopyFilePath = useCallback(
     async (path: string) => {
       if (!path) return;
@@ -3439,6 +3469,7 @@ function WorkspaceScreenContent({
         onCloseTab={handleCloseTabById}
         onCopyResumeCommand={handleCopyResumeCommand}
         onCopyAgentId={handleCopyAgentId}
+        onForkAgent={handleForkAgent}
         onCopyFilePath={handleCopyFilePath}
         onReloadAgent={handleReloadAgent}
         onRenameTab={handleRenameTab}
@@ -3474,6 +3505,7 @@ function WorkspaceScreenContent({
     handleCloseTabById,
     handleCopyResumeCommand,
     handleCopyAgentId,
+    handleForkAgent,
     handleCopyFilePath,
     handleReloadAgent,
     handleRenameTab,
@@ -3555,6 +3587,7 @@ function WorkspaceScreenContent({
           onSelectSwitcherTab={handleSelectSwitcherTab}
           onCopyResumeCommand={handleCopyResumeCommand}
           onCopyAgentId={handleCopyAgentId}
+          onForkAgent={handleForkAgent}
           onCopyFilePath={handleCopyFilePath}
           onReloadAgent={handleReloadAgent}
           onRenameTab={handleRenameTab}
@@ -3577,6 +3610,7 @@ function WorkspaceScreenContent({
           onCloseTab={handleCloseTabById}
           onCopyResumeCommand={handleCopyResumeCommand}
           onCopyAgentId={handleCopyAgentId}
+          onForkAgent={handleForkAgent}
           onCopyFilePath={handleCopyFilePath}
           onReloadAgent={handleReloadAgent}
           onRenameTab={handleRenameTab}

--- a/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
@@ -15,6 +15,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
   it("uses desktop tab ordering labels for desktop menus", () => {
     const onCopyResumeCommand = vi.fn();
     const onCopyAgentId = vi.fn();
+    const onForkAgent = vi.fn();
     const onCopyFilePath = vi.fn();
     const onReloadAgent = vi.fn();
     const onRenameTab = vi.fn();
@@ -31,6 +32,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       menuTestIDBase: "workspace-tab-context-agent_123",
       onCopyResumeCommand,
       onCopyAgentId,
+      onForkAgent,
       onCopyFilePath,
       onReloadAgent,
       onRenameTab,
@@ -43,6 +45,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
     expect(entries.filter((entry) => entry.kind === "item").map((entry) => entry.label)).toEqual([
       "Copy resume command",
       "Copy agent id",
+      "Fork agent",
       "Rename",
       "Close to the left",
       "Close to the right",
@@ -61,6 +64,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       menuTestIDBase: "workspace-tab-menu-agent_123",
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
+      onForkAgent: vi.fn(),
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab: vi.fn(),
@@ -73,6 +77,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
     expect(entries.filter((entry) => entry.kind === "item").map((entry) => entry.label)).toEqual([
       "Copy resume command",
       "Copy agent id",
+      "Fork agent",
       "Rename",
       "Close tabs above",
       "Close tabs below",
@@ -96,6 +101,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       menuTestIDBase: "workspace-tab-menu-draft_123",
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
+      onForkAgent: vi.fn(),
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab: vi.fn(),
@@ -124,6 +130,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       menuTestIDBase: "workspace-tab-context-agent_123",
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
+      onForkAgent: vi.fn(),
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab: vi.fn(),
@@ -142,6 +149,39 @@ describe("buildWorkspaceTabMenuEntries", () => {
     );
   });
 
+  it("invokes onForkAgent with the agent id when the fork entry is selected", () => {
+    const onForkAgent = vi.fn();
+    const tab = createAgentTab();
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab,
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: "workspace-tab-context-agent_123",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onForkAgent,
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    const forkEntry = entries.find(
+      (entry) => entry.kind === "item" && entry.label === "Fork agent",
+    );
+    if (!forkEntry || forkEntry.kind !== "item") {
+      throw new Error("Fork entry missing");
+    }
+    expect(forkEntry.icon).toBe("git-branch");
+    forkEntry.onSelect();
+
+    expect(onForkAgent).toHaveBeenCalledWith("agent-123");
+  });
+
   it("invokes onRenameTab when the rename entry is selected for agent tabs", () => {
     const onRenameTab = vi.fn();
     const tab = createAgentTab();
@@ -153,6 +193,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       menuTestIDBase: "workspace-tab-context-agent_123",
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
+      onForkAgent: vi.fn(),
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab,
@@ -187,6 +228,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       menuTestIDBase: "workspace-tab-context-terminal_abc",
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
+      onForkAgent: vi.fn(),
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab,
@@ -227,6 +269,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       menuTestIDBase: "workspace-tab-context-file_abc",
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
+      onForkAgent: vi.fn(),
       onCopyFilePath,
       onReloadAgent: vi.fn(),
       onRenameTab: vi.fn(),
@@ -268,6 +311,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       menuTestIDBase,
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
+      onForkAgent: vi.fn(),
       onCopyFilePath: vi.fn(),
       onReloadAgent: vi.fn(),
       onRenameTab: vi.fn(),

--- a/packages/app/src/screens/workspace/workspace-tab-menu.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.ts
@@ -8,6 +8,7 @@ export type WorkspaceTabMenuSurface = "desktop" | "mobile";
 export interface WorkspaceTabMenuLabels {
   copyResumeCommand: string;
   copyAgentId: string;
+  forkAgent: string;
   copyFilePath: string;
   rename: string;
   closeAbove: string;
@@ -23,6 +24,7 @@ export interface WorkspaceTabMenuLabels {
 export const DEFAULT_WORKSPACE_TAB_MENU_LABELS: WorkspaceTabMenuLabels = {
   copyResumeCommand: i18n.t("workspace.tabs.menu.copyResumeCommand"),
   copyAgentId: i18n.t("workspace.tabs.menu.copyAgentId"),
+  forkAgent: i18n.t("workspace.tabs.menu.forkAgent"),
   copyFilePath: i18n.t("workspace.tabs.menu.copyFilePath"),
   rename: i18n.t("workspace.tabs.menu.rename"),
   closeAbove: i18n.t("workspace.tabs.menu.closeAbove"),
@@ -42,6 +44,7 @@ export type WorkspaceTabMenuEntry =
       label: string;
       icon?:
         | "copy"
+        | "git-branch"
         | "rotate-cw"
         | "arrow-left-to-line"
         | "arrow-right-to-line"
@@ -68,6 +71,7 @@ interface BuildWorkspaceTabMenuEntriesInput {
   menuTestIDBase: string;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
+  onForkAgent: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
@@ -84,6 +88,7 @@ interface BuildWorkspaceDesktopTabActionsInput {
   tabCount: number;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
+  onForkAgent: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
   onRenameTab: (tab: WorkspaceTabDescriptor) => void;
@@ -152,6 +157,7 @@ export function buildWorkspaceTabMenuEntries(
     menuTestIDBase,
     onCopyResumeCommand,
     onCopyAgentId,
+    onForkAgent,
     onCopyFilePath,
     onReloadAgent,
     onRenameTab,
@@ -187,6 +193,16 @@ export function buildWorkspaceTabMenuEntries(
       testID: `${menuTestIDBase}-copy-agent-id`,
       onSelect: () => {
         void onCopyAgentId(agentId);
+      },
+    });
+    entries.push({
+      kind: "item",
+      key: "fork-agent",
+      label: labels.forkAgent,
+      icon: "git-branch",
+      testID: `${menuTestIDBase}-fork-agent`,
+      onSelect: () => {
+        void onForkAgent(agentId);
       },
     });
   }
@@ -297,6 +313,7 @@ export function buildWorkspaceDesktopTabActions(
       menuTestIDBase: contextMenuTestId,
       onCopyResumeCommand: input.onCopyResumeCommand,
       onCopyAgentId: input.onCopyAgentId,
+      onForkAgent: input.onForkAgent,
       onCopyFilePath: input.onCopyFilePath,
       onReloadAgent: input.onReloadAgent,
       onRenameTab: input.onRenameTab,

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -70,6 +70,7 @@ import type {
   DaemonGetPairingOfferResponse,
   DiagnosticsResponse,
   AgentRewindResponseMessage,
+  AgentForkResponseMessage,
   ListTerminalsResponse,
   CreateTerminalResponse,
   SubscribeTerminalResponse,
@@ -2439,6 +2440,38 @@ export class DaemonClient {
     });
     if (!payload.ok) {
       throw new Error(payload.error ?? "Agent rewind failed");
+    }
+    return payload;
+  }
+
+  async forkAgent(
+    agentId: string,
+    messageId?: string,
+  ): Promise<AgentForkResponseMessage["payload"]> {
+    const requestId = this.createRequestId();
+    const message = SessionInboundMessageSchema.parse({
+      type: "agent.fork.request",
+      requestId,
+      agentId,
+      ...(messageId ? { messageId } : {}),
+    });
+    const payload = await this.sendRequest({
+      requestId,
+      message,
+      timeout: 30000,
+      options: { skipQueue: true },
+      select: (msg) => {
+        if (msg.type !== "agent.fork.response") {
+          return null;
+        }
+        if (msg.payload.requestId !== requestId) {
+          return null;
+        }
+        return msg.payload;
+      },
+    });
+    if (!payload.ok) {
+      throw new Error(payload.error ?? "Agent fork failed");
     }
     return payload;
   }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1362,6 +1362,26 @@ export const AgentRewindResponseMessageSchema = z.object({
   }),
 });
 
+export const AgentForkRequestMessageSchema = z.object({
+  type: z.literal("agent.fork.request"),
+  agentId: z.string(),
+  // Optional fork point: keep history up to and including this user message id.
+  messageId: z.string().optional(),
+  requestId: z.string(),
+});
+
+export const AgentForkResponseMessageSchema = z.object({
+  type: z.literal("agent.fork.response"),
+  payload: z.object({
+    requestId: z.string(),
+    agentId: z.string(),
+    ok: z.boolean(),
+    // Id of the newly created (forked) agent on success.
+    newAgentId: z.string().nullable(),
+    error: z.string().nullable(),
+  }),
+});
+
 export const UpdateAgentResponseMessageSchema = z.object({
   type: z.literal("update_agent_response"),
   payload: AgentActionResponsePayloadSchema,
@@ -2066,6 +2086,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   SetAgentFeatureRequestMessageSchema,
   AgentDetachRequestMessageSchema,
   AgentRewindRequestMessageSchema,
+  AgentForkRequestMessageSchema,
   AgentPermissionResponseMessageSchema,
   CheckoutStatusRequestSchema,
   SubscribeCheckoutDiffRequestSchema,
@@ -4177,6 +4198,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   SetAgentFeatureResponseMessageSchema,
   AgentDetachResponseMessageSchema,
   AgentRewindResponseMessageSchema,
+  AgentForkResponseMessageSchema,
   UpdateAgentResponseMessageSchema,
   ProjectRenameResponseSchema,
   ProjectRemoveResponseSchema,
@@ -4329,6 +4351,7 @@ export type SetAgentThinkingResponseMessage = z.infer<typeof SetAgentThinkingRes
 export type SetAgentFeatureResponseMessage = z.infer<typeof SetAgentFeatureResponseMessageSchema>;
 export type AgentDetachResponseMessage = z.infer<typeof AgentDetachResponseMessageSchema>;
 export type AgentRewindResponseMessage = z.infer<typeof AgentRewindResponseMessageSchema>;
+export type AgentForkResponseMessage = z.infer<typeof AgentForkResponseMessageSchema>;
 export type UpdateAgentResponseMessage = z.infer<typeof UpdateAgentResponseMessageSchema>;
 export type ProjectRenameResponse = z.infer<typeof ProjectRenameResponseSchema>;
 export type ProjectRemoveResponse = z.infer<typeof ProjectRemoveResponseSchema>;

--- a/packages/server/src/server/agent/agent-manager-fork.test.ts
+++ b/packages/server/src/server/agent/agent-manager-fork.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import { createTestAgentClients } from "../test-utils/fake-agent-client.js";
+import { AgentManager } from "./agent-manager.js";
+import type { AgentClient } from "./agent-sdk-types.js";
+
+function createManager(clients = createTestAgentClients()): AgentManager {
+  return new AgentManager({
+    clients,
+    providerDefinitions: {
+      claude: { enabled: true },
+      codex: { enabled: true },
+      opencode: { enabled: true },
+    },
+    logger: createTestLogger(),
+  });
+}
+
+test("forkAgent creates an independent parallel session that preserves full context", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "paseo-fork-test-"));
+  try {
+    const manager = createManager();
+    const source = await manager.createAgent({ provider: "claude", cwd });
+    await manager.runAgent(source.id, "say 'state saved'");
+
+    const sourceRowsBefore = await manager.getTimelineRows(source.id);
+    expect(sourceRowsBefore.length).toBeGreaterThan(0);
+    const sourceSessionId = manager.getAgent(source.id)?.persistence?.sessionId;
+    expect(sourceSessionId).toBeTruthy();
+
+    const fork = await manager.forkAgent(source.id);
+
+    // Distinct managed agent + distinct provider session (real fork mints a new id).
+    expect(fork.id).not.toBe(source.id);
+    expect(fork.persistence?.sessionId).toBeTruthy();
+    expect(fork.persistence?.sessionId).not.toBe(sourceSessionId);
+    expect(fork.labels.forkedFromAgentId).toBe(source.id);
+    // No cosmetic snapshot mode — this is a real provider fork.
+    expect(fork.labels.forkMode).toBeUndefined();
+
+    // Source untouched + BOTH live in parallel.
+    const ids = manager.listAgents().map((a) => a.id);
+    expect(ids).toContain(source.id);
+    expect(ids).toContain(fork.id);
+    expect(manager.getAgent(source.id)?.persistence?.sessionId).toBe(sourceSessionId);
+    expect(manager.getAgent(source.id)?.lifecycle).not.toBe("closed");
+    expect(manager.getAgent(fork.id)?.lifecycle).not.toBe("closed");
+
+    // Fork is seeded with the FULL source context (not a truncated view).
+    const forkRows = await manager.getTimelineRows(fork.id);
+    expect(forkRows.map((r) => r.item)).toEqual(sourceRowsBefore.map((r) => r.item));
+
+    // Both run independently afterwards.
+    await manager.runAgent(fork.id, "say 'timeline test'");
+    await manager.runAgent(source.id, "say 'state saved'");
+    expect(manager.getAgent(source.id)?.persistence?.sessionId).toBe(sourceSessionId);
+    expect(manager.getAgent(fork.id)?.persistence?.sessionId).not.toBe(sourceSessionId);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("forkAgent throws for a provider that does not support a real fork (no snapshot fallback)", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "paseo-fork-nofork-"));
+  try {
+    const clients = createTestAgentClients();
+    // Disable native fork on this provider for this manager instance.
+    const claude = clients.claude as AgentClient;
+    Object.defineProperty(claude, "capabilities", {
+      value: { ...claude.capabilities, supportsFork: false },
+      configurable: true,
+    });
+    const manager = createManager(clients);
+    const source = await manager.createAgent({ provider: "claude", cwd });
+    await manager.runAgent(source.id, "say 'state saved'");
+
+    await expect(manager.forkAgent(source.id)).rejects.toThrow(/does not support forking/);
+    // Source remains the only agent — no meaningless snapshot agent was created.
+    expect(manager.listAgents().map((a) => a.id)).toEqual([source.id]);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("forkAgent throws when the agent has no persisted session", async () => {
+  const manager = createManager();
+  await expect(manager.forkAgent("00000000-0000-4000-8000-000000000000")).rejects.toThrow();
+});

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -20,6 +20,7 @@ import {
   type AgentClient,
   type AgentCreateSessionOptions,
   type AgentFeature,
+  type AgentForkOptions,
   type AgentLaunchContext,
   type AgentSlashCommand,
   type AgentMode,
@@ -511,6 +512,19 @@ function getFirstUserMessageTextFromRows(rows: readonly AgentTimelineRow[]): str
   return null;
 }
 
+/** Lineage labels stamped onto a forked agent. */
+function buildForkLabels(
+  sourceAgentId: string,
+  messageId: string | undefined,
+  extra: Record<string, string> | undefined,
+): Record<string, string> {
+  const labels: Record<string, string> = { ...extra, forkedFromAgentId: sourceAgentId };
+  if (messageId) {
+    labels.forkedFromMessageId = messageId;
+  }
+  return labels;
+}
+
 export class AgentManager {
   private readonly clients = new Map<AgentProvider, AgentClient>();
   private readonly providerEnabled = new Map<AgentProvider, boolean>();
@@ -989,6 +1003,92 @@ export class AgentManager {
     const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
     const session = await client.resumeSession(handle, providerLaunchConfig, launchContext);
     return this.registerSession(session, storedConfig, resolvedAgentId, options);
+  }
+
+  /**
+   * Fork an existing agent's session into a new, independent parallel session.
+   * Only providers that implement a REAL provider-native fork
+   * (`capabilities.supportsFork` + `forkSession`, e.g. Kiro duplicates its
+   * on-disk session record) are supported — there is intentionally no cosmetic
+   * "snapshot" fallback, because a fork that merely replays prior messages
+   * without real provider context is misleading. Unsupported providers throw.
+   *
+   * The fork preserves the full conversation context (the forked provider
+   * session carries it), is seeded with the full source timeline, and never
+   * mutates the source — so the original and the fork run in parallel.
+   */
+  async forkAgent(
+    sourceAgentId: string,
+    options?: {
+      messageId?: string;
+      labels?: Record<string, string>;
+      workspaceId?: string;
+      agentId?: string;
+    },
+  ): Promise<ManagedAgent> {
+    const source = this.requireAgent(sourceAgentId);
+    const handle = source.persistence;
+    if (!handle) {
+      throw new Error(`Agent ${sourceAgentId} has no persisted session to fork`);
+    }
+    const client = this.requireClient(handle.provider);
+    if (!client.capabilities.supportsFork || !client.forkSession) {
+      throw new Error(`Provider '${handle.provider}' does not support forking sessions`);
+    }
+    const available = await client.isAvailable();
+    if (!available) {
+      throw new Error(
+        `Provider '${handle.provider}' is not available. Please ensure the CLI is installed.`,
+      );
+    }
+
+    const newAgentId = validateAgentId(options?.agentId ?? this.idFactory(), "forkAgent");
+    const metadata = (handle.metadata ?? {}) as Partial<AgentSessionConfig>;
+    const mergedConfig = {
+      ...metadata,
+      provider: handle.provider,
+      cwd: source.cwd,
+    } as AgentSessionConfig;
+    const { storedConfig, launchConfig } = await this.prepareSessionConfig(
+      mergedConfig,
+      newAgentId,
+    );
+    const launchContext = await this.buildLaunchContext(newAgentId, client);
+    const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
+
+    // The forked provider session carries the full native context, so seed the
+    // new agent with the full source timeline (not a truncated view).
+    const forkRows = await this.getTimelineRows(sourceAgentId);
+    const forkOptions: AgentForkOptions = options?.messageId
+      ? { upToMessageId: options.messageId }
+      : {};
+    const session = await client.forkSession(
+      handle,
+      forkOptions,
+      providerLaunchConfig,
+      launchContext,
+    );
+
+    const registered = await this.registerSession(session, storedConfig, newAgentId, {
+      labels: buildForkLabels(sourceAgentId, options?.messageId, options?.labels),
+      workspaceId: options?.workspaceId ?? source.workspaceId,
+      timelineRows: forkRows,
+      timelineNextSeq: forkRows.length + 1,
+      historyPrimed: true,
+    });
+
+    this.logger.info(
+      {
+        sourceAgentId,
+        newAgentId,
+        provider: handle.provider,
+        messageId: options?.messageId ?? null,
+        seededRows: forkRows.length,
+      },
+      "agent.fork.complete",
+    );
+
+    return registered;
   }
 
   async importProviderSession(input: {

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -176,6 +176,11 @@ export interface AgentCapabilityFlags {
   supportsRewindConversation?: boolean;
   supportsRewindFiles?: boolean;
   supportsRewindBoth?: boolean;
+  /**
+   * Provider can fork a persisted session into a new, independent session
+   * (parallel branch) without mutating the original.
+   */
+  supportsFork?: boolean;
 }
 
 export interface AgentPersistenceHandle {
@@ -184,6 +189,15 @@ export interface AgentPersistenceHandle {
   /** Provider specific handle (Codex thread id, Claude resume token, etc). */
   nativeHandle?: string;
   metadata?: AgentMetadata;
+}
+
+export interface AgentForkOptions {
+  /**
+   * Fork the conversation so the new session contains history up to and
+   * including this user message id, then branches independently. When omitted,
+   * the fork copies the full session at its current state.
+   */
+  upToMessageId?: string;
 }
 
 export type AgentPromptContentBlock =
@@ -671,6 +685,18 @@ export interface AgentClient {
   ): Promise<AgentSession>;
   resumeSession(
     handle: AgentPersistenceHandle,
+    overrides?: Partial<AgentSessionConfig>,
+    launchContext?: AgentLaunchContext,
+  ): Promise<AgentSession>;
+  /**
+   * Fork a persisted session into a new, independent session (a parallel
+   * branch). The returned session must describe a NEW persistence handle
+   * (distinct sessionId) so the original is never mutated. Only implemented by
+   * providers advertising `capabilities.supportsFork`.
+   */
+  forkSession?(
+    handle: AgentPersistenceHandle,
+    options: AgentForkOptions,
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
   ): Promise<AgentSession>;

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -33,6 +33,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
 import { PiRpcAgentClient } from "./providers/pi/agent.js";
 import { MockLoadTestAgentClient } from "./providers/mock-load-test-agent.js";
@@ -644,24 +645,23 @@ function addDerivedProviders(
         enabled: override.enabled !== false,
         derivedFromProviderId: null,
         providerParams: override.params,
-        createBaseClient: (logger) =>
-          providerId === "cursor"
-            ? new CursorACPAgentClient({
-                logger,
-                command,
-                env: override.env,
-                providerId,
-                label: override.label ?? providerId,
-                providerParams: override.params,
-              })
-            : new GenericACPAgentClient({
-                logger,
-                command,
-                env: override.env,
-                providerId,
-                label: override.label ?? providerId,
-                providerParams: override.params,
-              }),
+        createBaseClient: (logger) => {
+          const acpOptions = {
+            logger,
+            command,
+            env: override.env,
+            providerId,
+            label: override.label ?? providerId,
+            providerParams: override.params,
+          };
+          if (providerId === "cursor") {
+            return new CursorACPAgentClient(acpOptions);
+          }
+          if (providerId === "kiro") {
+            return new KiroACPAgentClient(acpOptions);
+          }
+          return new GenericACPAgentClient(acpOptions);
+        },
       });
       continue;
     }

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -41,6 +41,7 @@ import {
   writeCopilotProviderMode,
 } from "./copilot-acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
+import { parseKiroExtensionCommands } from "./kiro-acp-agent.js";
 import { transformPiModels } from "./pi/agent.js";
 import type { AgentStreamEvent } from "../agent-sdk-types.js";
 import type { AgentCapabilityFlags, AgentPersistenceHandle } from "../agent-sdk-types.js";
@@ -161,6 +162,35 @@ function createSessionWithConfig(
         supportsReasoningStream: true,
         supportsToolInvocations: true,
       },
+    },
+  );
+}
+
+function createKiroSession(
+  options: { waitForInitialCommands?: boolean; initialCommandsWaitTimeoutMs?: number } = {},
+  logger: ReturnType<typeof createTestLogger> = createTestLogger(),
+): ACPAgentSession {
+  return new ACPAgentSession(
+    {
+      provider: "kiro",
+      cwd: "/tmp/paseo-acp-test",
+    },
+    {
+      provider: "kiro",
+      logger,
+      defaultCommand: ["kiro-cli", "acp"],
+      defaultModes: [],
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      extensionCommandsParser: parseKiroExtensionCommands,
+      waitForInitialCommands: options.waitForInitialCommands ?? false,
+      initialCommandsWaitTimeoutMs: options.initialCommandsWaitTimeoutMs,
     },
   );
 }
@@ -1903,28 +1933,10 @@ describe("ACPAgentSession", () => {
   });
 
   test("maps the Kiro _kiro.dev/commands/available notification into slash commands and skills", async () => {
-    const session = new ACPAgentSession(
-      {
-        provider: "kiro",
-        cwd: "/tmp/paseo-acp-test",
-      },
-      {
-        provider: "kiro",
-        logger: createTestLogger(),
-        defaultCommand: ["kiro-cli", "acp"],
-        defaultModes: [],
-        capabilities: {
-          supportsStreaming: true,
-          supportsSessionPersistence: true,
-          supportsDynamicModes: true,
-          supportsMcpServers: true,
-          supportsReasoningStream: true,
-          supportsToolInvocations: true,
-        },
-        waitForInitialCommands: true,
-        initialCommandsWaitTimeoutMs: 1500,
-      },
-    );
+    const session = createKiroSession({
+      waitForInitialCommands: true,
+      initialCommandsWaitTimeoutMs: 1500,
+    });
     asInternals<ACPSessionInternals>(session).sessionId = "session-1";
 
     const listCommandsPromise = session.listCommands();
@@ -1967,8 +1979,7 @@ describe("ACPAgentSession", () => {
   });
 
   test("ignores Kiro _kiro.dev/commands/available for a different session", async () => {
-    const logger = createTestLogger();
-    const session = createSessionWithConfig({ provider: "kiro" }, logger);
+    const session = createKiroSession();
     asInternals<ACPSessionInternals>(session).sessionId = "session-1";
 
     await session.extNotification("_kiro.dev/commands/available", {
@@ -1978,6 +1989,27 @@ describe("ACPAgentSession", () => {
     });
 
     expect(await session.listCommands()).toEqual([]);
+  });
+
+  test("settles listCommands() immediately on an empty Kiro commands batch", async () => {
+    // A long timeout means a resolution can only come from settleCommandsReady()
+    // firing — not from the wait timer — so this test would hang if the empty
+    // batch failed to unblock listCommands() (the P1 regression).
+    const session = createKiroSession({
+      waitForInitialCommands: true,
+      initialCommandsWaitTimeoutMs: 60_000,
+    });
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    const listCommandsPromise = session.listCommands();
+
+    await session.extNotification("_kiro.dev/commands/available", {
+      sessionId: "session-1",
+      commands: [],
+      prompts: [],
+    });
+
+    expect(await listCommandsPromise).toEqual([]);
   });
 
   test("emits assistant and reasoning chunks as deltas while user chunks stay accumulated", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1902,6 +1902,84 @@ describe("ACPAgentSession", () => {
     );
   });
 
+  test("maps the Kiro _kiro.dev/commands/available notification into slash commands and skills", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kiro",
+        cwd: "/tmp/paseo-acp-test",
+      },
+      {
+        provider: "kiro",
+        logger: createTestLogger(),
+        defaultCommand: ["kiro-cli", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        waitForInitialCommands: true,
+        initialCommandsWaitTimeoutMs: 1500,
+      },
+    );
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    const listCommandsPromise = session.listCommands();
+
+    await session.extNotification("_kiro.dev/commands/available", {
+      sessionId: "session-1",
+      commands: [
+        {
+          name: "/agent",
+          description: "Select or list available agents",
+          meta: { inputType: "selection", hint: "swap <name>" },
+        },
+      ],
+      prompts: [
+        {
+          name: "agent-sync-doctor",
+          description: "Hand off Claude or Codex state across Macs",
+          arguments: [],
+          serverName: "skill:config",
+        },
+      ],
+      // Tools are not slash commands and must be ignored.
+      tools: [{ name: "code", description: "Code intelligence", source: "built-in" }],
+    });
+
+    expect(await listCommandsPromise).toEqual([
+      {
+        name: "agent",
+        description: "Select or list available agents",
+        argumentHint: "swap <name>",
+        kind: "command",
+      },
+      {
+        name: "agent-sync-doctor",
+        description: "Hand off Claude or Codex state across Macs",
+        argumentHint: "",
+        kind: "skill",
+      },
+    ]);
+  });
+
+  test("ignores Kiro _kiro.dev/commands/available for a different session", async () => {
+    const logger = createTestLogger();
+    const session = createSessionWithConfig({ provider: "kiro" }, logger);
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    await session.extNotification("_kiro.dev/commands/available", {
+      sessionId: "other-session",
+      commands: [{ name: "/agent", description: "Select or list available agents" }],
+      prompts: [],
+    });
+
+    expect(await session.listCommands()).toEqual([]);
+  });
+
   test("emits assistant and reasoning chunks as deltas while user chunks stay accumulated", async () => {
     const session = createSession();
     const events: Array<{ type: string; item?: { type: string; text?: string } }> = [];

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -80,6 +80,7 @@ import {
   type AgentSession,
   type AgentSessionConfig,
   type AgentSlashCommand,
+  type AgentSlashCommandKind,
   type AgentStreamEvent,
   type AgentTimelineItem,
   type AgentUsage,
@@ -120,6 +121,53 @@ function assertChildWithPipes(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+// ACP extension method (per the `_`-prefixed vendor namespace convention) that
+// Kiro CLI uses to publish its slash commands and skills after session/new.
+const KIRO_COMMANDS_AVAILABLE_METHOD = "_kiro.dev/commands/available";
+
+// Maps a `_kiro.dev/commands/available` payload onto Paseo slash commands.
+// Kiro reports built-in slash commands under `commands` (names arrive with a
+// leading "/", e.g. "/agent") and skills/prompts under `prompts` (names without
+// a slash, tagged with a `skill:` serverName). Paseo stores command names
+// without the leading slash — the composer prepends it on insertion.
+function mapKiroAvailableCommands(params: Record<string, unknown>): AgentSlashCommand[] {
+  const result: AgentSlashCommand[] = [];
+  const seen = new Set<string>();
+
+  const pushEntry = (entry: unknown): void => {
+    if (!isRecord(entry)) {
+      return;
+    }
+    const rawName = typeof entry.name === "string" ? entry.name.trim() : "";
+    const name = rawName.replace(/^\/+/, "");
+    if (!name || seen.has(name)) {
+      return;
+    }
+    seen.add(name);
+
+    const description = typeof entry.description === "string" ? entry.description : "";
+    const meta = isRecord(entry.meta) ? entry.meta : null;
+    const argumentHint = meta && typeof meta.hint === "string" ? meta.hint : "";
+    const serverName = typeof entry.serverName === "string" ? entry.serverName : "";
+    const kind: AgentSlashCommandKind = serverName.startsWith("skill:") ? "skill" : "command";
+
+    result.push({ name, description, argumentHint, kind });
+  };
+
+  if (Array.isArray(params.commands)) {
+    for (const entry of params.commands) {
+      pushEntry(entry);
+    }
+  }
+  if (Array.isArray(params.prompts)) {
+    for (const entry of params.prompts) {
+      pushEntry(entry);
+    }
+  }
+
+  return result;
 }
 
 function isACPError(value: unknown): value is ACPError {
@@ -2082,6 +2130,33 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       },
       "provider.acp.extension_notification",
     );
+
+    if (method === KIRO_COMMANDS_AVAILABLE_METHOD) {
+      this.applyKiroAvailableCommands(params);
+    }
+  }
+
+  // Kiro CLI advertises its slash commands and skills through the
+  // `_kiro.dev/commands/available` extension notification instead of the
+  // standard `available_commands_update` session update. Map both lists onto
+  // the shared slash-command cache so they surface in the composer like any
+  // other provider's commands.
+  private applyKiroAvailableCommands(params: Record<string, unknown>): void {
+    if (
+      typeof params.sessionId === "string" &&
+      this.sessionId !== null &&
+      params.sessionId !== this.sessionId
+    ) {
+      return;
+    }
+
+    const commands = mapKiroAvailableCommands(params);
+    if (commands.length === 0) {
+      return;
+    }
+
+    this.cachedCommands = commands;
+    this.settleCommandsReady();
   }
 
   async readTextFile(params: ReadTextFileRequest): Promise<{ content: string }> {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -80,7 +80,6 @@ import {
   type AgentSession,
   type AgentSessionConfig,
   type AgentSlashCommand,
-  type AgentSlashCommandKind,
   type AgentStreamEvent,
   type AgentTimelineItem,
   type AgentUsage,
@@ -121,53 +120,6 @@ function assertChildWithPipes(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
-}
-
-// ACP extension method (per the `_`-prefixed vendor namespace convention) that
-// Kiro CLI uses to publish its slash commands and skills after session/new.
-const KIRO_COMMANDS_AVAILABLE_METHOD = "_kiro.dev/commands/available";
-
-// Maps a `_kiro.dev/commands/available` payload onto Paseo slash commands.
-// Kiro reports built-in slash commands under `commands` (names arrive with a
-// leading "/", e.g. "/agent") and skills/prompts under `prompts` (names without
-// a slash, tagged with a `skill:` serverName). Paseo stores command names
-// without the leading slash — the composer prepends it on insertion.
-function mapKiroAvailableCommands(params: Record<string, unknown>): AgentSlashCommand[] {
-  const result: AgentSlashCommand[] = [];
-  const seen = new Set<string>();
-
-  const pushEntry = (entry: unknown): void => {
-    if (!isRecord(entry)) {
-      return;
-    }
-    const rawName = typeof entry.name === "string" ? entry.name.trim() : "";
-    const name = rawName.replace(/^\/+/, "");
-    if (!name || seen.has(name)) {
-      return;
-    }
-    seen.add(name);
-
-    const description = typeof entry.description === "string" ? entry.description : "";
-    const meta = isRecord(entry.meta) ? entry.meta : null;
-    const argumentHint = meta && typeof meta.hint === "string" ? meta.hint : "";
-    const serverName = typeof entry.serverName === "string" ? entry.serverName : "";
-    const kind: AgentSlashCommandKind = serverName.startsWith("skill:") ? "skill" : "command";
-
-    result.push({ name, description, argumentHint, kind });
-  };
-
-  if (Array.isArray(params.commands)) {
-    for (const entry of params.commands) {
-      pushEntry(entry);
-    }
-  }
-  if (Array.isArray(params.prompts)) {
-    for (const entry of params.prompts) {
-      pushEntry(entry);
-    }
-  }
-
-  return result;
 }
 
 function isACPError(value: unknown): value is ACPError {
@@ -382,6 +334,17 @@ export function createLoggedNdJsonStream(
   return { readable, writable };
 }
 
+// Lets a provider that publishes its slash commands through a vendor-specific
+// ACP extension notification (rather than the standard
+// `available_commands_update` session update) translate that payload into Paseo
+// slash commands, without the generic ACP session/client carrying any vendor
+// knowledge. Return the parsed commands (possibly empty) for a notification this
+// provider owns, or null to ignore notifications it does not handle.
+export type ACPExtensionCommandsParser = (
+  method: string,
+  params: Record<string, unknown>,
+) => AgentSlashCommand[] | null;
+
 interface ACPAgentClientOptions {
   provider: string;
   logger: Logger;
@@ -404,6 +367,7 @@ interface ACPAgentClientOptions {
     thinkingOptionId: string,
   ) => Promise<void>;
   capabilities?: AgentCapabilityFlags;
+  extensionCommandsParser?: ACPExtensionCommandsParser;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
@@ -431,6 +395,7 @@ interface ACPAgentSessionOptions {
     thinkingOptionId: string,
   ) => Promise<void>;
   capabilities: AgentCapabilityFlags;
+  extensionCommandsParser?: ACPExtensionCommandsParser;
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
@@ -740,6 +705,7 @@ export class ACPAgentClient implements AgentClient {
   ) => Promise<void>;
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
+  private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   protected readonly terminateProcess: ProcessTerminator;
 
   constructor(options: ACPAgentClientOptions) {
@@ -764,6 +730,7 @@ export class ACPAgentClient implements AgentClient {
     this.thinkingOptionWriter = options.thinkingOptionWriter;
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
+    this.extensionCommandsParser = options.extensionCommandsParser;
   }
 
   async createSession(
@@ -791,6 +758,7 @@ export class ACPAgentClient implements AgentClient {
         capabilities: this.capabilities,
         agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
+        extensionCommandsParser: this.extensionCommandsParser,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
       },
@@ -839,6 +807,7 @@ export class ACPAgentClient implements AgentClient {
       handle,
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
+      extensionCommandsParser: this.extensionCommandsParser,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
     });
@@ -1321,6 +1290,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private commandsReadySettled = false;
   private waitForInitialCommands: boolean;
   private initialCommandsWaitTimeoutMs: number;
+  private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
   private closed = false;
@@ -1357,6 +1327,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.currentTitle = config.title ?? null;
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
+    this.extensionCommandsParser = options.extensionCommandsParser;
   }
 
   get id(): string | null {
@@ -2131,31 +2102,37 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       "provider.acp.extension_notification",
     );
 
-    if (method === KIRO_COMMANDS_AVAILABLE_METHOD) {
-      this.applyKiroAvailableCommands(params);
+    const parsedCommands = this.extensionCommandsParser?.(method, params);
+    if (parsedCommands) {
+      this.applyResolvedCommands(parsedCommands, {
+        sessionId: typeof params.sessionId === "string" ? params.sessionId : undefined,
+      });
     }
   }
 
-  // Kiro CLI advertises its slash commands and skills through the
-  // `_kiro.dev/commands/available` extension notification instead of the
-  // standard `available_commands_update` session update. Map both lists onto
-  // the shared slash-command cache so they surface in the composer like any
-  // other provider's commands.
-  private applyKiroAvailableCommands(params: Record<string, unknown>): void {
+  // Cache an asynchronously-delivered slash-command batch and unblock any
+  // listCommands() call that is waiting on the initial batch. Used when a
+  // provider supplies an extensionCommandsParser whose result arrives after
+  // session/new (e.g. via a vendor extension notification). The ready gate is
+  // always settled — even for an empty batch — so a provider that legitimately
+  // reports no commands does not leave listCommands() blocked for the full
+  // initial-commands timeout. An optional sessionId scopes the batch to this
+  // session; notifications addressed to a different session are ignored.
+  private applyResolvedCommands(
+    commands: AgentSlashCommand[],
+    options?: { sessionId?: string },
+  ): void {
     if (
-      typeof params.sessionId === "string" &&
+      options?.sessionId !== undefined &&
       this.sessionId !== null &&
-      params.sessionId !== this.sessionId
+      options.sessionId !== this.sessionId
     ) {
       return;
     }
 
-    const commands = mapKiroAvailableCommands(params);
-    if (commands.length === 0) {
-      return;
+    if (commands.length > 0) {
+      this.cachedCommands = commands;
     }
-
-    this.cachedCommands = commands;
     this.settleCommandsReady();
   }
 

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 
 import type { AgentCapabilityFlags } from "../agent-sdk-types.js";
 import { checkProviderLaunchAvailable, resolveProviderLaunch } from "../provider-launch-config.js";
-import { ACPAgentClient, DEFAULT_ACP_CAPABILITIES } from "./acp-agent.js";
+import {
+  ACPAgentClient,
+  DEFAULT_ACP_CAPABILITIES,
+  type ACPExtensionCommandsParser,
+} from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
   formatProviderDiagnostic,
@@ -29,6 +33,7 @@ interface GenericACPAgentClientOptions {
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   diagnosticPhaseTimeoutMs?: number;
+  extensionCommandsParser?: ACPExtensionCommandsParser;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -48,6 +53,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
       capabilities: buildGenericACPCapabilities(options),
       waitForInitialCommands: options.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: options.initialCommandsWaitTimeoutMs,
+      extensionCommandsParser: options.extensionCommandsParser,
     });
 
     this.command = options.command;

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -34,6 +34,8 @@ interface GenericACPAgentClientOptions {
   initialCommandsWaitTimeoutMs?: number;
   diagnosticPhaseTimeoutMs?: number;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  /** Provider-specific capability flags merged on top of the ACP defaults. */
+  capabilityOverrides?: Partial<AgentCapabilityFlags>;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -50,7 +52,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
         env: options.env,
       },
       defaultCommand: options.command,
-      capabilities: buildGenericACPCapabilities(options),
+      capabilities: { ...buildGenericACPCapabilities(options), ...options.capabilityOverrides },
       waitForInitialCommands: options.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: options.initialCommandsWaitTimeoutMs,
       extensionCommandsParser: options.extensionCommandsParser,

--- a/packages/server/src/server/agent/providers/kiro-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/kiro-acp-agent.ts
@@ -1,6 +1,8 @@
 import type { Logger } from "pino";
 
+import type { ACPExtensionCommandsParser } from "./acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
+import type { AgentSlashCommand, AgentSlashCommandKind } from "../agent-sdk-types.js";
 
 interface KiroACPAgentClientOptions {
   logger: Logger;
@@ -13,10 +15,74 @@ interface KiroACPAgentClientOptions {
 
 // Kiro CLI publishes its slash commands and skills asynchronously through the
 // `_kiro.dev/commands/available` extension notification shortly after
-// `session/new` resolves (handled in ACPAgentSession.extNotification). Wait for
-// that first batch so listCommands() doesn't resolve to an empty list before
-// Kiro has reported its commands.
+// `session/new` resolves. Wait for that first batch so listCommands() doesn't
+// resolve to an empty list before Kiro has reported its commands.
 const KIRO_INITIAL_COMMANDS_WAIT_TIMEOUT_MS = 10_000;
+
+// ACP extension method (per the `_`-prefixed vendor namespace convention) that
+// Kiro CLI uses to publish its slash commands and skills after session/new.
+const KIRO_COMMANDS_AVAILABLE_METHOD = "_kiro.dev/commands/available";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+// Maps a `_kiro.dev/commands/available` payload onto Paseo slash commands.
+// Kiro reports built-in slash commands under `commands` (names arrive with a
+// leading "/", e.g. "/agent") and skills/prompts under `prompts` (names without
+// a slash, tagged with a `skill:` serverName). Paseo stores command names
+// without the leading slash — the composer prepends it on insertion.
+function mapKiroAvailableCommands(params: Record<string, unknown>): AgentSlashCommand[] {
+  const result: AgentSlashCommand[] = [];
+  const seen = new Set<string>();
+
+  const pushEntry = (entry: unknown): void => {
+    if (!isRecord(entry)) {
+      return;
+    }
+    const rawName = typeof entry.name === "string" ? entry.name.trim() : "";
+    const name = rawName.replace(/^\/+/, "");
+    if (!name || seen.has(name)) {
+      return;
+    }
+    seen.add(name);
+
+    const description = typeof entry.description === "string" ? entry.description : "";
+    const meta = isRecord(entry.meta) ? entry.meta : null;
+    const argumentHint = meta && typeof meta.hint === "string" ? meta.hint : "";
+    const serverName = typeof entry.serverName === "string" ? entry.serverName : "";
+    const kind: AgentSlashCommandKind = serverName.startsWith("skill:") ? "skill" : "command";
+
+    result.push({ name, description, argumentHint, kind });
+  };
+
+  if (Array.isArray(params.commands)) {
+    for (const entry of params.commands) {
+      pushEntry(entry);
+    }
+  }
+  if (Array.isArray(params.prompts)) {
+    for (const entry of params.prompts) {
+      pushEntry(entry);
+    }
+  }
+
+  return result;
+}
+
+// Provider-specific parser injected into the generic ACP session via the
+// `extensionCommandsParser` option (mirrors how Cursor/Copilot inject their
+// behavior through constructor options). Kiro advertises its slash commands and
+// skills through the `_kiro.dev/commands/available` extension notification
+// instead of the standard `available_commands_update` session update; this
+// recognizes that one method and returns the parsed commands (possibly empty),
+// or null for any other notification so the base session ignores it.
+export const parseKiroExtensionCommands: ACPExtensionCommandsParser = (method, params) => {
+  if (method !== KIRO_COMMANDS_AVAILABLE_METHOD) {
+    return null;
+  }
+  return mapKiroAvailableCommands(params);
+};
 
 export class KiroACPAgentClient extends GenericACPAgentClient {
   constructor(options: KiroACPAgentClientOptions) {
@@ -29,6 +95,7 @@ export class KiroACPAgentClient extends GenericACPAgentClient {
       providerParams: options.providerParams,
       waitForInitialCommands: true,
       initialCommandsWaitTimeoutMs: KIRO_INITIAL_COMMANDS_WAIT_TIMEOUT_MS,
+      extensionCommandsParser: parseKiroExtensionCommands,
     });
   }
 }

--- a/packages/server/src/server/agent/providers/kiro-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/kiro-acp-agent.ts
@@ -1,0 +1,34 @@
+import type { Logger } from "pino";
+
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+interface KiroACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+// Kiro CLI publishes its slash commands and skills asynchronously through the
+// `_kiro.dev/commands/available` extension notification shortly after
+// `session/new` resolves (handled in ACPAgentSession.extNotification). Wait for
+// that first batch so listCommands() doesn't resolve to an empty list before
+// Kiro has reported its commands.
+const KIRO_INITIAL_COMMANDS_WAIT_TIMEOUT_MS = 10_000;
+
+export class KiroACPAgentClient extends GenericACPAgentClient {
+  constructor(options: KiroACPAgentClientOptions) {
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId,
+      label: options.label,
+      providerParams: options.providerParams,
+      waitForInitialCommands: true,
+      initialCommandsWaitTimeoutMs: KIRO_INITIAL_COMMANDS_WAIT_TIMEOUT_MS,
+    });
+  }
+}

--- a/packages/server/src/server/agent/providers/kiro-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/kiro-acp-agent.ts
@@ -2,7 +2,16 @@ import type { Logger } from "pino";
 
 import type { ACPExtensionCommandsParser } from "./acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
-import type { AgentSlashCommand, AgentSlashCommandKind } from "../agent-sdk-types.js";
+import { forkKiroSessionFiles, resolveKiroSessionsDir } from "./kiro-session-fork.js";
+import type {
+  AgentForkOptions,
+  AgentLaunchContext,
+  AgentPersistenceHandle,
+  AgentSession,
+  AgentSessionConfig,
+  AgentSlashCommand,
+  AgentSlashCommandKind,
+} from "../agent-sdk-types.js";
 
 interface KiroACPAgentClientOptions {
   logger: Logger;
@@ -15,8 +24,9 @@ interface KiroACPAgentClientOptions {
 
 // Kiro CLI publishes its slash commands and skills asynchronously through the
 // `_kiro.dev/commands/available` extension notification shortly after
-// `session/new` resolves. Wait for that first batch so listCommands() doesn't
-// resolve to an empty list before Kiro has reported its commands.
+// `session/new` resolves (handled in ACPAgentSession.extNotification via the
+// injected extensionCommandsParser). Wait for that first batch so listCommands()
+// doesn't resolve to an empty list before Kiro has reported its commands.
 const KIRO_INITIAL_COMMANDS_WAIT_TIMEOUT_MS = 10_000;
 
 // ACP extension method (per the `_`-prefixed vendor namespace convention) that
@@ -96,6 +106,39 @@ export class KiroACPAgentClient extends GenericACPAgentClient {
       waitForInitialCommands: true,
       initialCommandsWaitTimeoutMs: KIRO_INITIAL_COMMANDS_WAIT_TIMEOUT_MS,
       extensionCommandsParser: parseKiroExtensionCommands,
+      // Kiro supports a real provider-native fork: we duplicate its on-disk
+      // session record into a new id and load it (see forkSession).
+      capabilityOverrides: { supportsFork: true },
     });
+  }
+
+  /**
+   * Real Kiro fork: duplicate the persisted session on disk into a NEW Kiro
+   * session id (full conversation context preserved via Kiro's session_state),
+   * then load the forked id as an independent session. The original session is
+   * never mutated, so the two run in parallel.
+   *
+   * `upToMessageId` is accepted for interface compatibility but not used to
+   * truncate: Kiro's `session_state.rts_model_state` is an opaque model-side
+   * blob that cannot be safely truncated, so the fork duplicates the whole
+   * conversation and the branch continues from its end.
+   */
+  async forkSession(
+    handle: AgentPersistenceHandle,
+    _options: AgentForkOptions,
+    overrides?: Partial<AgentSessionConfig>,
+    launchContext?: AgentLaunchContext,
+  ): Promise<AgentSession> {
+    const newId = forkKiroSessionFiles({
+      sessionsDir: resolveKiroSessionsDir(),
+      sourceId: handle.sessionId,
+      titleSuffix: " (fork)",
+    });
+    const forkedHandle: AgentPersistenceHandle = {
+      ...handle,
+      sessionId: newId,
+      nativeHandle: newId,
+    };
+    return this.resumeSession(forkedHandle, overrides, launchContext);
   }
 }

--- a/packages/server/src/server/agent/providers/kiro-session-fork.test.ts
+++ b/packages/server/src/server/agent/providers/kiro-session-fork.test.ts
@@ -1,0 +1,93 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { forkKiroSessionFiles, resolveKiroSessionsDir } from "./kiro-session-fork";
+
+describe("resolveKiroSessionsDir", () => {
+  const original = process.env.KIRO_SESSIONS_DIR;
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.KIRO_SESSIONS_DIR;
+    } else {
+      process.env.KIRO_SESSIONS_DIR = original;
+    }
+  });
+
+  it("defaults to ~/.kiro/sessions/cli and honors the override", () => {
+    delete process.env.KIRO_SESSIONS_DIR;
+    expect(resolveKiroSessionsDir().endsWith(path.join(".kiro", "sessions", "cli"))).toBe(true);
+    process.env.KIRO_SESSIONS_DIR = "/tmp/custom-kiro";
+    expect(resolveKiroSessionsDir()).toBe("/tmp/custom-kiro");
+  });
+});
+
+describe("forkKiroSessionFiles", () => {
+  let dir: string;
+  const sourceId = "11111111-1111-4111-8111-111111111111";
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "kiro-fork-test-"));
+    writeFileSync(
+      path.join(dir, `${sourceId}.json`),
+      JSON.stringify({
+        session_id: sourceId,
+        cwd: "/work",
+        title: "Original",
+        session_state: { version: 1, conversation_metadata: { messages: ["m1", "m2"] } },
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      path.join(dir, `${sourceId}.jsonl`),
+      `{"kind":"Prompt","data":{"message_id":"m1"}}\n{"kind":"AssistantMessage","data":{"message_id":"a1"}}\n`,
+      "utf8",
+    );
+    writeFileSync(path.join(dir, `${sourceId}.history`), "hi\n", "utf8");
+    mkdirSync(path.join(dir, sourceId));
+    writeFileSync(path.join(dir, sourceId, "extra.bin"), "x", "utf8");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("duplicates all session files into a new id, rewriting session_id", () => {
+    const newId = forkKiroSessionFiles({ sessionsDir: dir, sourceId, titleSuffix: " (fork)" });
+
+    expect(newId).not.toBe(sourceId);
+
+    const forked = JSON.parse(readFileSync(path.join(dir, `${newId}.json`), "utf8"));
+    // New id, full context preserved (session_state copied verbatim), title annotated.
+    expect(forked.session_id).toBe(newId);
+    expect(forked.title).toBe("Original (fork)");
+    expect(forked.session_state).toEqual({
+      version: 1,
+      conversation_metadata: { messages: ["m1", "m2"] },
+    });
+
+    // Event log + history + sidecar dir copied.
+    expect(readFileSync(path.join(dir, `${newId}.jsonl`), "utf8")).toBe(
+      readFileSync(path.join(dir, `${sourceId}.jsonl`), "utf8"),
+    );
+    expect(readFileSync(path.join(dir, `${newId}.history`), "utf8")).toBe("hi\n");
+    expect(existsSync(path.join(dir, newId, "extra.bin"))).toBe(true);
+
+    // Source is untouched.
+    const source = JSON.parse(readFileSync(path.join(dir, `${sourceId}.json`), "utf8"));
+    expect(source.session_id).toBe(sourceId);
+    expect(source.title).toBe("Original");
+  });
+
+  it("uses the provided new id when given", () => {
+    const newId = "22222222-2222-4222-8222-222222222222";
+    expect(forkKiroSessionFiles({ sessionsDir: dir, sourceId, newId })).toBe(newId);
+    expect(existsSync(path.join(dir, `${newId}.json`))).toBe(true);
+  });
+
+  it("throws when the source session metadata is missing", () => {
+    expect(() => forkKiroSessionFiles({ sessionsDir: dir, sourceId: "does-not-exist" })).toThrow(
+      /not found/,
+    );
+  });
+});

--- a/packages/server/src/server/agent/providers/kiro-session-fork.ts
+++ b/packages/server/src/server/agent/providers/kiro-session-fork.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from "node:crypto";
+import { copyFileSync, cpSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+/**
+ * Location of Kiro CLI's persisted ACP sessions. Kiro stores each session as
+ * `<id>.json` (metadata + reconstructable `session_state`), `<id>.jsonl` (event
+ * log) and `<id>.history` under `~/.kiro/sessions/cli`. Overridable via
+ * `KIRO_SESSIONS_DIR` (used by tests).
+ */
+export function resolveKiroSessionsDir(): string {
+  const override = process.env.KIRO_SESSIONS_DIR;
+  if (override && override.trim()) {
+    return override.trim();
+  }
+  return path.join(homedir(), ".kiro", "sessions", "cli");
+}
+
+/**
+ * Duplicate a Kiro session on disk into a new session id, preserving the FULL
+ * conversation context. Kiro reconstructs a session from the `session_state`
+ * embedded in `<id>.json`, so a faithful fork copies every session file and
+ * rewrites the internal `session_id` to the new id. Returns the new id.
+ *
+ * This is a real fork (the new id is an independent, loadable Kiro session that
+ * carries the original's context) — not a cosmetic timeline snapshot. Mid-point
+ * truncation is intentionally NOT attempted: `session_state.rts_model_state` is
+ * an opaque model-side blob that cannot be safely truncated, so the fork
+ * duplicates the whole conversation and the branch continues from its end.
+ *
+ * Throws if the source metadata file does not exist.
+ */
+export function forkKiroSessionFiles(input: {
+  sessionsDir: string;
+  sourceId: string;
+  newId?: string;
+  titleSuffix?: string;
+}): string {
+  const { sessionsDir, sourceId } = input;
+  const newId = input.newId ?? randomUUID();
+
+  const sourceJsonPath = path.join(sessionsDir, `${sourceId}.json`);
+  if (!existsSync(sourceJsonPath)) {
+    throw new Error(`Kiro session metadata not found: ${sourceJsonPath}`);
+  }
+
+  // Metadata: rewrite session_id (filename and internal id must agree) and
+  // optionally annotate the title so the fork is recognizable.
+  const metadata = JSON.parse(readFileSync(sourceJsonPath, "utf8")) as Record<string, unknown>;
+  metadata.session_id = newId;
+  if (input.titleSuffix && typeof metadata.title === "string") {
+    metadata.title = `${metadata.title}${input.titleSuffix}`;
+  }
+  writeFileSync(path.join(sessionsDir, `${newId}.json`), JSON.stringify(metadata), "utf8");
+
+  // Event log + readline history: verbatim copy when present.
+  for (const ext of [".jsonl", ".history"]) {
+    const src = path.join(sessionsDir, `${sourceId}${ext}`);
+    if (existsSync(src)) {
+      copyFileSync(src, path.join(sessionsDir, `${newId}${ext}`));
+    }
+  }
+
+  // Some sessions carry a sidecar directory (`<id>/`); copy it recursively.
+  const sidecar = path.join(sessionsDir, sourceId);
+  if (existsSync(sidecar)) {
+    cpSync(sidecar, path.join(sessionsDir, newId), { recursive: true });
+  }
+
+  return newId;
+}

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1431,6 +1431,8 @@ export class Session {
     switch (msg.type) {
       case "agent.rewind.request":
         return this.handleAgentRewindRequest(msg);
+      case "agent.fork.request":
+        return this.handleAgentForkRequest(msg);
       default:
         return undefined;
     }
@@ -2775,6 +2777,37 @@ export class Session {
           agentId: msg.agentId,
           ok: false,
           error: error instanceof Error ? error.message : "Failed to rewind agent",
+        },
+      });
+    }
+  }
+
+  private async handleAgentForkRequest(
+    msg: Extract<SessionInboundMessage, { type: "agent.fork.request" }>,
+  ): Promise<void> {
+    try {
+      const forked = await this.agentManager.forkAgent(msg.agentId, {
+        messageId: msg.messageId,
+      });
+      this.emit({
+        type: "agent.fork.response",
+        payload: {
+          requestId: msg.requestId,
+          agentId: msg.agentId,
+          ok: true,
+          newAgentId: forked.id,
+          error: null,
+        },
+      });
+    } catch (error) {
+      this.emit({
+        type: "agent.fork.response",
+        payload: {
+          requestId: msg.requestId,
+          agentId: msg.agentId,
+          ok: false,
+          newAgentId: null,
+          error: error instanceof Error ? error.message : "Failed to fork agent",
         },
       });
     }

--- a/packages/server/src/server/test-utils/fake-agent-client.ts
+++ b/packages/server/src/server/test-utils/fake-agent-client.ts
@@ -7,6 +7,7 @@ import type {
   AgentCapabilityFlags,
   AgentClient,
   AgentFeature,
+  AgentForkOptions,
   AgentLaunchContext,
   AgentMode,
   AgentModelDefinition,
@@ -34,6 +35,7 @@ const TEST_CAPABILITIES: AgentCapabilityFlags = {
   supportsRewindConversation: false,
   supportsRewindFiles: false,
   supportsRewindBoth: false,
+  supportsFork: true,
 };
 
 const TEST_FEATURE_ID = "test_feature";
@@ -1182,6 +1184,31 @@ class FakeAgentClient implements AgentClient {
       this.provider,
       cfg,
       handle.sessionId,
+      typeof marker === "string" ? marker : null,
+    );
+  }
+
+  async forkSession(
+    handle: AgentPersistenceHandle,
+    _options: AgentForkOptions,
+    overrides?: Partial<AgentSessionConfig>,
+    _launchContext?: AgentLaunchContext,
+  ): Promise<AgentSession> {
+    const cfg: AgentSessionConfig = {
+      provider: this.provider,
+      cwd: overrides?.cwd ?? process.cwd(),
+      ...overrides,
+    };
+    const marker =
+      (handle.metadata as Record<string, unknown> | undefined)?.marker ??
+      (handle.metadata as Record<string, unknown> | undefined)?.conversationId ??
+      null;
+    // A real fork mints a NEW provider session id so the original is never
+    // mutated. Pass no sessionId so FakeAgentSession generates a fresh one.
+    return new FakeAgentSession(
+      this.provider,
+      cfg,
+      undefined,
       typeof marker === "string" ? marker : null,
     );
   }


### PR DESCRIPTION
Addresses #1479. **Stacked on #1792** (which introduces `KiroACPAgentClient`) — review/merge that first; this PR's lower commit is #1792.

## What this PR does

Adds `AgentManager.forkAgent(sourceAgentId)`: create a new, **independent** agent that inherits the source's **full** conversation context, so the original and the fork run in parallel (the `create_agent` `forkFrom` capability requested in #1479).

- Capability-gated (`AgentClient.capabilities.supportsFork` + `forkSession`), with **no lossy fallback** — providers that can't do a real fork throw rather than seeding a summary. This complements #1788 ("Fork assistant turns into new drafts", a text-summary draft) with the *real session* fork #1479 asks for.
- **Kiro provider fork**: duplicates Kiro's on-disk session record (`~/.kiro/sessions/cli/<id>.json` with `session_state` rewritten to a new id, plus `.jsonl`/`.history`) into a new session and loads it.
- Protocol wire (`agent.fork.request/response`) + `daemonClient.forkAgent`.
- UI: a **"Fork agent"** entry in the agent tab menu (matching the "right-click agent tab → Fork agent" UX in #1479), threaded through `split-container`/`tabs-row`; i18n in all 8 locales.

## Type of change

- [x] New feature (with prior issue: #1479)

## Scope note

Whole-conversation fork (not mid-message): Kiro's `session_state.rts_model_state` is an opaque model blob that can't be safely truncated, so the fork duplicates the whole conversation and branches from the end. Per-provider mid-point fork (e.g. Claude `forkSession` + conversation rewind) can layer on later.

## How I verified

- `protocol` + `client` + `server` + `app` typecheck.
- `vitest`: 130 server tests (`agent-manager-fork` 3 + `kiro-session-fork` 4 + `agent-manager` 116 regression + `wire-compat` 7) + 41 app tests (`workspace-tab-menu` 9 + i18n resources 32).
- `oxlint` + `oxfmt --check` clean on all changed files.
- **Real `kiro-cli` e2e** (local, not committed): forked an existing on-disk session; kiro-cli loaded the forked copy and replayed its history (full context carried over); original session untouched.

## Platforms — honest status

The tab-menu entry is RN (works desktop/web/native via the shared menu). I have **not** captured on-device screenshots yet; visual verification (web + iOS simulator) is in progress and I'll attach before merge. Flagging per CONTRIBUTING. Happy to adjust UX placement to your preference.
