### PR TITLE
feat(app): collapsible subagent tree in the agent list (Paseo subagents; provider subagents to follow)

### DIFF
--- a/packages/app/src/components/agent-list-grouping.test.ts
+++ b/packages/app/src/components/agent-list-grouping.test.ts
@@ -105,9 +105,8 @@ describe("buildFlatItems", () => {
     expect(item.childCount).toBe(0);
   });
 
-  it("never drops a grandchild: deeper-than-one-level agents stay top-level", () => {
-    // A (top) <- B (child of A) <- C (child of B). Phase 1 nests one level, so
-    // B nests under A and C must remain visible as a top-level row, not vanish.
+  it("nests several levels deep, increasing depth, only under expanded ancestors", () => {
+    // A <- B <- C: a three-level chain.
     const a = makeAgent("a", "server-1");
     const b = makeAgent("b", "server-1", {
       labels: { [PARENT_AGENT_ID_LABEL]: "a" },
@@ -116,20 +115,46 @@ describe("buildFlatItems", () => {
       labels: { [PARENT_AGENT_ID_LABEL]: "b" },
     });
 
-    // Collapsed: A (with 1 child) and C are top-level; B is hidden under A.
-    const collapsed = buildFlatItems([a, b, c], new Set())
-      .filter((i) => i.type === "agent")
-      .map((i) => (i.type === "agent" ? i : null))
-      .filter((i) => i !== null);
-    expect(collapsed.map((i) => i.agent.id).sort()).toEqual(["a", "c"]);
-    const cRow = collapsed.find((i) => i.agent.id === "c");
-    expect(cRow?.depth).toBe(0);
-    expect(cRow?.hasChildren).toBe(false);
+    // Nothing expanded: only the root A shows.
+    const collapsed = buildFlatItems([a, b, c], new Set()).filter((i) => i.type === "agent");
+    expect(collapsed).toHaveLength(1);
+    const root = collapsed[0];
+    if (root?.type !== "agent") throw new Error("expected agent item");
+    expect(root.agent.id).toBe("a");
+    expect(root.depth).toBe(0);
+    expect(root.hasChildren).toBe(true);
 
-    // Every agent renders exactly once across collapsed + expanded states.
-    const expanded = buildFlatItems([a, b, c], new Set(["server-1:a"])).filter(
+    // Expand A only: A (0) + B (1); C stays hidden under collapsed B.
+    const oneLevel = buildFlatItems([a, b, c], new Set(["server-1:a"])).filter(
       (i) => i.type === "agent",
     );
-    expect(expanded).toHaveLength(3);
+    expect(oneLevel.map((i) => (i.type === "agent" ? i.agent.id : ""))).toEqual(["a", "b"]);
+
+    // Expand A and B: the full chain renders at increasing depth.
+    const full = buildFlatItems([a, b, c], new Set(["server-1:a", "server-1:b"])).filter(
+      (i) => i.type === "agent",
+    );
+    expect(full.map((i) => (i.type === "agent" ? [i.agent.id, i.depth] : null))).toEqual([
+      ["a", 0],
+      ["b", 1],
+      ["c", 2],
+    ]);
+  });
+
+  it("renders every agent exactly once even when parent labels form a cycle", () => {
+    // A <- B and B <- A: neither is a root. The walk must still emit both
+    // exactly once (no infinite loop, no silent drop).
+    const a = makeAgent("a", "server-1", {
+      labels: { [PARENT_AGENT_ID_LABEL]: "b" },
+    });
+    const b = makeAgent("b", "server-1", {
+      labels: { [PARENT_AGENT_ID_LABEL]: "a" },
+    });
+
+    const items = buildFlatItems([a, b], new Set(["server-1:a", "server-1:b"])).filter(
+      (i) => i.type === "agent",
+    );
+    expect(items).toHaveLength(2);
+    expect(items.map((i) => (i.type === "agent" ? i.agent.id : "")).sort()).toEqual(["a", "b"]);
   });
 });

--- a/packages/app/src/components/agent-list-grouping.test.ts
+++ b/packages/app/src/components/agent-list-grouping.test.ts
@@ -104,4 +104,32 @@ describe("buildFlatItems", () => {
     expect(item.hasChildren).toBe(false);
     expect(item.childCount).toBe(0);
   });
+
+  it("never drops a grandchild: deeper-than-one-level agents stay top-level", () => {
+    // A (top) <- B (child of A) <- C (child of B). Phase 1 nests one level, so
+    // B nests under A and C must remain visible as a top-level row, not vanish.
+    const a = makeAgent("a", "server-1");
+    const b = makeAgent("b", "server-1", {
+      labels: { [PARENT_AGENT_ID_LABEL]: "a" },
+    });
+    const c = makeAgent("c", "server-1", {
+      labels: { [PARENT_AGENT_ID_LABEL]: "b" },
+    });
+
+    // Collapsed: A (with 1 child) and C are top-level; B is hidden under A.
+    const collapsed = buildFlatItems([a, b, c], new Set())
+      .filter((i) => i.type === "agent")
+      .map((i) => (i.type === "agent" ? i : null))
+      .filter((i) => i !== null);
+    expect(collapsed.map((i) => i.agent.id).sort()).toEqual(["a", "c"]);
+    const cRow = collapsed.find((i) => i.agent.id === "c");
+    expect(cRow?.depth).toBe(0);
+    expect(cRow?.hasChildren).toBe(false);
+
+    // Every agent renders exactly once across collapsed + expanded states.
+    const expanded = buildFlatItems([a, b, c], new Set(["server-1:a"])).filter(
+      (i) => i.type === "agent",
+    );
+    expect(expanded).toHaveLength(3);
+  });
 });

--- a/packages/app/src/components/agent-list-grouping.ts
+++ b/packages/app/src/components/agent-list-grouping.ts
@@ -1,0 +1,158 @@
+import type { TFunction } from "i18next";
+import { getParentAgentIdFromLabels } from "@getpaseo/protocol/agent-labels";
+import type { AggregatedAgent } from "@/hooks/use-aggregated-agents";
+
+export type DateSectionKey = "today" | "yesterday" | "thisWeek" | "thisMonth" | "older";
+
+export const DATE_SECTION_ORDER = [
+  "today",
+  "yesterday",
+  "thisWeek",
+  "thisMonth",
+  "older",
+] as const satisfies readonly DateSectionKey[];
+
+export type FlatListItem =
+  | { type: "header"; key: string; section: DateSectionKey }
+  | {
+      type: "agent";
+      key: string;
+      agent: AggregatedAgent;
+      depth: 0 | 1;
+      hasChildren: boolean;
+      expanded: boolean;
+      childCount: number;
+    };
+
+export function deriveDateSectionKey(lastActivityAt: Date): DateSectionKey {
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterdayStart = new Date(todayStart.getTime() - 24 * 60 * 60 * 1000);
+  const activityStart = new Date(
+    lastActivityAt.getFullYear(),
+    lastActivityAt.getMonth(),
+    lastActivityAt.getDate(),
+  );
+
+  if (activityStart.getTime() >= todayStart.getTime()) {
+    return "today";
+  }
+  if (activityStart.getTime() >= yesterdayStart.getTime()) {
+    return "yesterday";
+  }
+
+  const diffTime = todayStart.getTime() - activityStart.getTime();
+  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+  if (diffDays <= 7) {
+    return "thisWeek";
+  }
+  if (diffDays <= 30) {
+    return "thisMonth";
+  }
+  return "older";
+}
+
+export function formatDateSectionLabel(t: TFunction, section: DateSectionKey): string {
+  switch (section) {
+    case "today":
+      return t("agentList.dateSections.today");
+    case "yesterday":
+      return t("agentList.dateSections.yesterday");
+    case "thisWeek":
+      return t("agentList.dateSections.thisWeek");
+    case "thisMonth":
+      return t("agentList.dateSections.thisMonth");
+    case "older":
+      return t("agentList.dateSections.older");
+  }
+}
+
+/**
+ * Pure function — exported for unit testing.
+ * Builds the flat item list for the FlatList, grouping children under parents.
+ * - Children are agents whose derived parentAgentId matches another agent.id on the same serverId.
+ * - Orphan children (parent absent from `agents`) render as normal top-level rows.
+ * - Date-section headers apply to top-level rows only.
+ * - Children of an expanded parent appear immediately after the parent, sorted by createdAt asc.
+ */
+export function buildFlatItems(
+  agents: AggregatedAgent[],
+  expandedParents: ReadonlySet<string>,
+): FlatListItem[] {
+  // Fast lookup of agent ids present per server
+  const agentIdsByServer = new Map<string, Set<string>>();
+  for (const agent of agents) {
+    const serverSet = agentIdsByServer.get(agent.serverId) ?? new Set<string>();
+    serverSet.add(agent.id);
+    agentIdsByServer.set(agent.serverId, serverSet);
+  }
+
+  // Group children under their parents (orphans are excluded and remain top-level)
+  const childrenByParentKey = new Map<string, AggregatedAgent[]>();
+  const childAgentKeys = new Set<string>();
+
+  for (const agent of agents) {
+    const parentId = getParentAgentIdFromLabels(agent.labels);
+    if (parentId === null) continue;
+    const serverSet = agentIdsByServer.get(agent.serverId);
+    // Orphan: parent not in this server's agent list → stays top-level
+    if (!serverSet?.has(parentId)) continue;
+    const parentKey = `${agent.serverId}:${parentId}`;
+    const childKey = `${agent.serverId}:${agent.id}`;
+    childAgentKeys.add(childKey);
+    const siblings = childrenByParentKey.get(parentKey) ?? [];
+    siblings.push(agent);
+    childrenByParentKey.set(parentKey, siblings);
+  }
+
+  // Sort children by createdAt ascending (mirrors selectSubagentsForParent ordering)
+  for (const siblings of childrenByParentKey.values()) {
+    siblings.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+
+  // Bucket top-level agents by date section
+  const buckets = new Map<DateSectionKey, AggregatedAgent[]>();
+  for (const agent of agents) {
+    if (childAgentKeys.has(`${agent.serverId}:${agent.id}`)) continue;
+    const section = deriveDateSectionKey(agent.lastActivityAt);
+    const existing = buckets.get(section) ?? [];
+    existing.push(agent);
+    buckets.set(section, existing);
+  }
+
+  const result: FlatListItem[] = [];
+  for (const section of DATE_SECTION_ORDER) {
+    const data = buckets.get(section);
+    if (!data || data.length === 0) continue;
+    result.push({ type: "header", key: `header:${section}`, section });
+    for (const agent of data) {
+      const agentKey = `${agent.serverId}:${agent.id}`;
+      const children = childrenByParentKey.get(agentKey) ?? [];
+      const hasChildren = children.length > 0;
+      const expanded = hasChildren && expandedParents.has(agentKey);
+      result.push({
+        type: "agent",
+        key: agentKey,
+        agent,
+        depth: 0,
+        hasChildren,
+        expanded,
+        childCount: children.length,
+      });
+      if (expanded) {
+        for (const child of children) {
+          result.push({
+            type: "agent",
+            key: `${child.serverId}:${child.id}`,
+            agent: child,
+            depth: 1,
+            hasChildren: false,
+            expanded: false,
+            childCount: 0,
+          });
+        }
+      }
+    }
+  }
+  return result;
+}

--- a/packages/app/src/components/agent-list-grouping.ts
+++ b/packages/app/src/components/agent-list-grouping.ts
@@ -75,11 +75,16 @@ export function formatDateSectionLabel(t: TFunction, section: DateSectionKey): s
  * - Date-section headers apply to top-level rows only.
  * - Children of an expanded parent appear immediately after the parent, sorted by createdAt asc.
  */
-export function buildFlatItems(
-  agents: AggregatedAgent[],
-  expandedParents: ReadonlySet<string>,
-): FlatListItem[] {
-  // Fast lookup of agent ids present per server
+// Build the parent -> children grouping for one level of nesting.
+// ponytail: Phase 1 nests exactly one level — a child only nests under a
+// TOP-LEVEL parent. Deeper chains (a child whose parent is itself a child) stay
+// top-level so they are never silently dropped; recursive nesting is deferred
+// until the feature actually needs it.
+function groupChildrenByParent(agents: AggregatedAgent[]): {
+  childrenByParentKey: Map<string, AggregatedAgent[]>;
+  childAgentKeys: Set<string>;
+} {
+  // Fast lookup of agent ids present per server.
   const agentIdsByServer = new Map<string, Set<string>>();
   for (const agent of agents) {
     const serverSet = agentIdsByServer.get(agent.serverId) ?? new Set<string>();
@@ -87,28 +92,45 @@ export function buildFlatItems(
     agentIdsByServer.set(agent.serverId, serverSet);
   }
 
-  // Group children under their parents (orphans are excluded and remain top-level)
-  const childrenByParentKey = new Map<string, AggregatedAgent[]>();
-  const childAgentKeys = new Set<string>();
-
+  // Resolve each agent's in-list parent key (orphans resolve to undefined).
+  const resolvedParentKeyByChildKey = new Map<string, string>();
   for (const agent of agents) {
     const parentId = getParentAgentIdFromLabels(agent.labels);
     if (parentId === null) continue;
-    const serverSet = agentIdsByServer.get(agent.serverId);
-    // Orphan: parent not in this server's agent list → stays top-level
-    if (!serverSet?.has(parentId)) continue;
-    const parentKey = `${agent.serverId}:${parentId}`;
+    if (!agentIdsByServer.get(agent.serverId)?.has(parentId)) continue;
+    resolvedParentKeyByChildKey.set(
+      `${agent.serverId}:${agent.id}`,
+      `${agent.serverId}:${parentId}`,
+    );
+  }
+
+  const childrenByParentKey = new Map<string, AggregatedAgent[]>();
+  const childAgentKeys = new Set<string>();
+  for (const agent of agents) {
     const childKey = `${agent.serverId}:${agent.id}`;
+    const parentKey = resolvedParentKeyByChildKey.get(childKey);
+    if (parentKey === undefined) continue;
+    // Parent is itself a child → keep this agent top-level (no grandchild drop).
+    if (resolvedParentKeyByChildKey.has(parentKey)) continue;
     childAgentKeys.add(childKey);
     const siblings = childrenByParentKey.get(parentKey) ?? [];
     siblings.push(agent);
     childrenByParentKey.set(parentKey, siblings);
   }
 
-  // Sort children by createdAt ascending (mirrors selectSubagentsForParent ordering)
+  // Sort children by createdAt asc (mirrors selectSubagentsForParent ordering).
   for (const siblings of childrenByParentKey.values()) {
     siblings.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
   }
+
+  return { childrenByParentKey, childAgentKeys };
+}
+
+export function buildFlatItems(
+  agents: AggregatedAgent[],
+  expandedParents: ReadonlySet<string>,
+): FlatListItem[] {
+  const { childrenByParentKey, childAgentKeys } = groupChildrenByParent(agents);
 
   // Bucket top-level agents by date section
   const buckets = new Map<DateSectionKey, AggregatedAgent[]>();

--- a/packages/app/src/components/agent-list-grouping.ts
+++ b/packages/app/src/components/agent-list-grouping.ts
@@ -18,7 +18,7 @@ export type FlatListItem =
       type: "agent";
       key: string;
       agent: AggregatedAgent;
-      depth: 0 | 1;
+      depth: number;
       hasChildren: boolean;
       expanded: boolean;
       childCount: number;
@@ -67,22 +67,13 @@ export function formatDateSectionLabel(t: TFunction, section: DateSectionKey): s
   }
 }
 
-/**
- * Pure function — exported for unit testing.
- * Builds the flat item list for the FlatList, grouping children under parents.
- * - Children are agents whose derived parentAgentId matches another agent.id on the same serverId.
- * - Orphan children (parent absent from `agents`) render as normal top-level rows.
- * - Date-section headers apply to top-level rows only.
- * - Children of an expanded parent appear immediately after the parent, sorted by createdAt asc.
- */
-// Build the parent -> children grouping for one level of nesting.
-// ponytail: Phase 1 nests exactly one level — a child only nests under a
-// TOP-LEVEL parent. Deeper chains (a child whose parent is itself a child) stay
-// top-level so they are never silently dropped; recursive nesting is deferred
-// until the feature actually needs it.
-function groupChildrenByParent(agents: AggregatedAgent[]): {
+// Group agents into a parent -> children forest. A child is an agent whose
+// parent label resolves to another agent on the same server; everything else
+// (no label, or parent absent from the list) is a root. Nesting depth is
+// unbounded — the render walks the forest recursively.
+function groupAgentsByParent(agents: AggregatedAgent[]): {
   childrenByParentKey: Map<string, AggregatedAgent[]>;
-  childAgentKeys: Set<string>;
+  rootAgents: AggregatedAgent[];
 } {
   // Fast lookup of agent ids present per server.
   const agentIdsByServer = new Map<string, Set<string>>();
@@ -92,89 +83,109 @@ function groupChildrenByParent(agents: AggregatedAgent[]): {
     agentIdsByServer.set(agent.serverId, serverSet);
   }
 
-  // Resolve each agent's in-list parent key (orphans resolve to undefined).
-  const resolvedParentKeyByChildKey = new Map<string, string>();
+  const childrenByParentKey = new Map<string, AggregatedAgent[]>();
+  const rootAgents: AggregatedAgent[] = [];
   for (const agent of agents) {
     const parentId = getParentAgentIdFromLabels(agent.labels);
-    if (parentId === null) continue;
-    if (!agentIdsByServer.get(agent.serverId)?.has(parentId)) continue;
-    resolvedParentKeyByChildKey.set(
-      `${agent.serverId}:${agent.id}`,
-      `${agent.serverId}:${parentId}`,
-    );
-  }
-
-  const childrenByParentKey = new Map<string, AggregatedAgent[]>();
-  const childAgentKeys = new Set<string>();
-  for (const agent of agents) {
-    const childKey = `${agent.serverId}:${agent.id}`;
-    const parentKey = resolvedParentKeyByChildKey.get(childKey);
-    if (parentKey === undefined) continue;
-    // Parent is itself a child → keep this agent top-level (no grandchild drop).
-    if (resolvedParentKeyByChildKey.has(parentKey)) continue;
-    childAgentKeys.add(childKey);
+    const hasParentInList =
+      parentId !== null && agentIdsByServer.get(agent.serverId)?.has(parentId) === true;
+    if (!hasParentInList) {
+      rootAgents.push(agent);
+      continue;
+    }
+    const parentKey = `${agent.serverId}:${parentId}`;
     const siblings = childrenByParentKey.get(parentKey) ?? [];
     siblings.push(agent);
     childrenByParentKey.set(parentKey, siblings);
   }
 
-  // Sort children by createdAt asc (mirrors selectSubagentsForParent ordering).
+  // Sort siblings by createdAt asc (mirrors selectSubagentsForParent ordering).
   for (const siblings of childrenByParentKey.values()) {
     siblings.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
   }
 
-  return { childrenByParentKey, childAgentKeys };
+  return { childrenByParentKey, rootAgents };
+}
+
+// Keys reachable from any root by walking the children map (expand-independent).
+// Agents outside this set are only reachable via a parent-label cycle.
+function collectReachableKeys(
+  rootAgents: AggregatedAgent[],
+  childrenByParentKey: Map<string, AggregatedAgent[]>,
+): Set<string> {
+  const reachable = new Set<string>();
+  const stack = rootAgents.map((agent) => `${agent.serverId}:${agent.id}`);
+  while (stack.length > 0) {
+    const key = stack.pop();
+    if (key === undefined || reachable.has(key)) continue;
+    reachable.add(key);
+    for (const child of childrenByParentKey.get(key) ?? []) {
+      stack.push(`${child.serverId}:${child.id}`);
+    }
+  }
+  return reachable;
 }
 
 export function buildFlatItems(
   agents: AggregatedAgent[],
   expandedParents: ReadonlySet<string>,
 ): FlatListItem[] {
-  const { childrenByParentKey, childAgentKeys } = groupChildrenByParent(agents);
+  const { childrenByParentKey, rootAgents } = groupAgentsByParent(agents);
+  const reachable = collectReachableKeys(rootAgents, childrenByParentKey);
 
-  // Bucket top-level agents by date section
+  const result: FlatListItem[] = [];
+  const emitted = new Set<string>();
+
+  // Emit an agent and, when expanded, its descendants at increasing depth.
+  // `emitted` guards against duplicates and parent-label cycles (A <- B <- A),
+  // so the walk always terminates and never renders an agent twice.
+  const emitAgent = (agent: AggregatedAgent, depth: number): void => {
+    const key = `${agent.serverId}:${agent.id}`;
+    if (emitted.has(key)) return;
+    emitted.add(key);
+    const children = childrenByParentKey.get(key) ?? [];
+    const hasChildren = children.length > 0;
+    const expanded = hasChildren && expandedParents.has(key);
+    result.push({
+      type: "agent",
+      key,
+      agent,
+      depth,
+      hasChildren,
+      expanded,
+      childCount: children.length,
+    });
+    if (!expanded) return;
+    for (const child of children) {
+      emitAgent(child, depth + 1);
+    }
+  };
+
+  // Date-section headers apply to roots only; descendants nest under their root.
   const buckets = new Map<DateSectionKey, AggregatedAgent[]>();
-  for (const agent of agents) {
-    if (childAgentKeys.has(`${agent.serverId}:${agent.id}`)) continue;
+  for (const agent of rootAgents) {
     const section = deriveDateSectionKey(agent.lastActivityAt);
     const existing = buckets.get(section) ?? [];
     existing.push(agent);
     buckets.set(section, existing);
   }
 
-  const result: FlatListItem[] = [];
   for (const section of DATE_SECTION_ORDER) {
     const data = buckets.get(section);
     if (!data || data.length === 0) continue;
     result.push({ type: "header", key: `header:${section}`, section });
     for (const agent of data) {
-      const agentKey = `${agent.serverId}:${agent.id}`;
-      const children = childrenByParentKey.get(agentKey) ?? [];
-      const hasChildren = children.length > 0;
-      const expanded = hasChildren && expandedParents.has(agentKey);
-      result.push({
-        type: "agent",
-        key: agentKey,
-        agent,
-        depth: 0,
-        hasChildren,
-        expanded,
-        childCount: children.length,
-      });
-      if (expanded) {
-        for (const child of children) {
-          result.push({
-            type: "agent",
-            key: `${child.serverId}:${child.id}`,
-            agent: child,
-            depth: 1,
-            hasChildren: false,
-            expanded: false,
-            childCount: 0,
-          });
-        }
-      }
+      emitAgent(agent, 0);
     }
   }
+
+  // Safety net: an agent unreachable from any root (only possible via a
+  // parent-label cycle) still renders top-level so it is never silently dropped.
+  // Reachable descendants of a collapsed parent stay hidden — they are reachable.
+  for (const agent of agents) {
+    if (reachable.has(`${agent.serverId}:${agent.id}`)) continue;
+    emitAgent(agent, 0);
+  }
+
   return result;
 }

--- a/packages/app/src/components/agent-list.test.tsx
+++ b/packages/app/src/components/agent-list.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
+import { buildFlatItems } from "./agent-list-grouping";
+import type { AggregatedAgent } from "@/hooks/use-aggregated-agents";
+
+function makeAgent(
+  id: string,
+  serverId: string,
+  overrides: Partial<AggregatedAgent> = {},
+): AggregatedAgent {
+  return {
+    id,
+    serverId,
+    serverLabel: "local",
+    title: null,
+    status: "idle",
+    lastActivityAt: new Date("2025-01-10T12:00:00Z"),
+    cwd: "/",
+    provider: "claude",
+    createdAt: new Date("2025-01-10T12:00:00Z"),
+    labels: {},
+    ...overrides,
+  } as AggregatedAgent;
+}
+
+describe("buildFlatItems", () => {
+  it("parent with two children is collapsed by default — shows child count, children hidden", () => {
+    const parent = makeAgent("parent-1", "server-1");
+    const child1 = makeAgent("child-1", "server-1", {
+      labels: { [PARENT_AGENT_ID_LABEL]: "parent-1" },
+      createdAt: new Date("2025-01-10T12:01:00Z"),
+    });
+    const child2 = makeAgent("child-2", "server-1", {
+      labels: { [PARENT_AGENT_ID_LABEL]: "parent-1" },
+      createdAt: new Date("2025-01-10T12:02:00Z"),
+    });
+
+    const items = buildFlatItems([parent, child1, child2], new Set());
+    const agentItems = items.filter((i) => i.type === "agent");
+
+    // Only the parent row is visible (children hidden while collapsed)
+    expect(agentItems).toHaveLength(1);
+
+    const parentItem = agentItems[0];
+    if (parentItem.type !== "agent") throw new Error("expected agent item");
+    expect(parentItem.agent.id).toBe("parent-1");
+    expect(parentItem.hasChildren).toBe(true);
+    expect(parentItem.expanded).toBe(false);
+    expect(parentItem.childCount).toBe(2);
+    expect(parentItem.depth).toBe(0);
+  });
+
+  it("expanding a parent shows its two children in createdAt asc order immediately after", () => {
+    const parent = makeAgent("parent-1", "server-1");
+    // child2 has an earlier createdAt than child1 to verify ascending sort
+    const child1 = makeAgent("child-1", "server-1", {
+      labels: { [PARENT_AGENT_ID_LABEL]: "parent-1" },
+      createdAt: new Date("2025-01-10T12:02:00Z"),
+    });
+    const child2 = makeAgent("child-2", "server-1", {
+      labels: { [PARENT_AGENT_ID_LABEL]: "parent-1" },
+      createdAt: new Date("2025-01-10T12:01:00Z"),
+    });
+
+    const expandedKey = "server-1:parent-1";
+    const items = buildFlatItems([parent, child1, child2], new Set([expandedKey]));
+    const agentItems = items.filter((i) => i.type === "agent");
+
+    // Parent + 2 children
+    expect(agentItems).toHaveLength(3);
+
+    const [parentRow, firstChild, secondChild] = agentItems;
+
+    if (parentRow.type !== "agent") throw new Error("expected agent item");
+    expect(parentRow.agent.id).toBe("parent-1");
+    expect(parentRow.expanded).toBe(true);
+    expect(parentRow.depth).toBe(0);
+
+    if (firstChild.type !== "agent") throw new Error("expected agent item");
+    // child2 has earlier createdAt so it sorts first
+    expect(firstChild.agent.id).toBe("child-2");
+    expect(firstChild.depth).toBe(1);
+    expect(firstChild.hasChildren).toBe(false);
+
+    if (secondChild.type !== "agent") throw new Error("expected agent item");
+    expect(secondChild.agent.id).toBe("child-1");
+    expect(secondChild.depth).toBe(1);
+  });
+
+  it("orphan child (parent id not present in agents list) renders as a top-level row", () => {
+    const orphan = makeAgent("orphan-1", "server-1", {
+      labels: { [PARENT_AGENT_ID_LABEL]: "missing-parent" },
+    });
+
+    const items = buildFlatItems([orphan], new Set());
+    const agentItems = items.filter((i) => i.type === "agent");
+
+    expect(agentItems).toHaveLength(1);
+
+    const item = agentItems[0];
+    if (item.type !== "agent") throw new Error("expected agent item");
+    expect(item.agent.id).toBe("orphan-1");
+    expect(item.depth).toBe(0);
+    expect(item.hasChildren).toBe(false);
+    expect(item.childCount).toBe(0);
+  });
+});

--- a/packages/app/src/components/agent-list.tsx
+++ b/packages/app/src/components/agent-list.tsx
@@ -11,18 +11,18 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useCallback, useMemo, useState, type ReactElement } from "react";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { formatTimeAgo } from "@/utils/time";
 import { type AggregatedAgent } from "@/hooks/use-aggregated-agents";
 import { useSessionStore } from "@/stores/session-store";
-import { Archive, ChevronRight } from "lucide-react-native";
+import { Archive, ChevronDown, ChevronRight } from "lucide-react-native";
 import { getProviderIcon } from "@/components/provider-icons";
 import { navigateToAgent } from "@/utils/navigate-to-agent";
 import { useArchiveAgent } from "@/hooks/use-archive-agent";
 import { useQueryClient } from "@tanstack/react-query";
 import { agentHistoryQueryKey } from "@/hooks/agent-history-query-key";
+import { buildFlatItems, formatDateSectionLabel, type FlatListItem } from "./agent-list-grouping";
 
 interface AgentListProps {
   agents: AggregatedAgent[];
@@ -34,63 +34,6 @@ interface AgentListProps {
   listFooterComponent?: ReactElement | null;
   showAttentionIndicator?: boolean;
   showHostColumn?: boolean;
-}
-
-type DateSectionKey = "today" | "yesterday" | "thisWeek" | "thisMonth" | "older";
-
-const DATE_SECTION_ORDER = [
-  "today",
-  "yesterday",
-  "thisWeek",
-  "thisMonth",
-  "older",
-] as const satisfies readonly DateSectionKey[];
-
-type FlatListItem =
-  | { type: "header"; key: string; section: DateSectionKey }
-  | { type: "agent"; key: string; agent: AggregatedAgent };
-
-function deriveDateSectionKey(lastActivityAt: Date): DateSectionKey {
-  const now = new Date();
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const yesterdayStart = new Date(todayStart.getTime() - 24 * 60 * 60 * 1000);
-  const activityStart = new Date(
-    lastActivityAt.getFullYear(),
-    lastActivityAt.getMonth(),
-    lastActivityAt.getDate(),
-  );
-
-  if (activityStart.getTime() >= todayStart.getTime()) {
-    return "today";
-  }
-  if (activityStart.getTime() >= yesterdayStart.getTime()) {
-    return "yesterday";
-  }
-
-  const diffTime = todayStart.getTime() - activityStart.getTime();
-  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-  if (diffDays <= 7) {
-    return "thisWeek";
-  }
-  if (diffDays <= 30) {
-    return "thisMonth";
-  }
-  return "older";
-}
-
-function formatDateSectionLabel(t: TFunction, section: DateSectionKey): string {
-  switch (section) {
-    case "today":
-      return t("agentList.dateSections.today");
-    case "yesterday":
-      return t("agentList.dateSections.yesterday");
-    case "thisWeek":
-      return t("agentList.dateSections.thisWeek");
-    case "thisMonth":
-      return t("agentList.dateSections.thisMonth");
-    case "older":
-      return t("agentList.dateSections.older");
-  }
 }
 
 function SessionBadge({
@@ -203,6 +146,103 @@ function SessionRowTrailingAttention({
   );
 }
 
+const DISCLOSURE_HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 };
+
+function RowLeadingControl({
+  hasChildren,
+  depth,
+  expanded,
+  onToggle,
+  testID,
+}: {
+  hasChildren: boolean;
+  depth: 0 | 1;
+  expanded: boolean;
+  onToggle: () => void;
+  testID: string;
+}) {
+  const { theme } = useUnistyles();
+  if (hasChildren) {
+    return (
+      <Pressable
+        onPress={onToggle}
+        hitSlop={DISCLOSURE_HIT_SLOP}
+        style={styles.disclosureButton}
+        testID={testID}
+      >
+        {expanded ? (
+          <ChevronDown size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+        ) : (
+          <ChevronRight size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+        )}
+      </Pressable>
+    );
+  }
+  if (depth === 1) {
+    return <View style={styles.childIndent} />;
+  }
+  return null;
+}
+
+function SessionRowMobileMeta({
+  agent,
+  isMobile,
+  projectName,
+  branch,
+  workspaceName,
+  timeAgo,
+  showHostColumn,
+}: {
+  agent: AggregatedAgent;
+  isMobile: boolean;
+  projectName: string;
+  branch: string;
+  workspaceName: string;
+  timeAgo: string;
+  showHostColumn: boolean;
+}) {
+  if (!isMobile) {
+    return null;
+  }
+  return (
+    <View style={styles.rowMetaRow}>
+      <Text
+        style={styles.sessionMetaText}
+        numberOfLines={1}
+        testID={`agent-row-project-${agent.serverId}-${agent.id}`}
+      >
+        {projectName}
+      </Text>
+      <Text style={styles.sessionMetaSeparator}>·</Text>
+      <Text
+        style={styles.sessionMetaText}
+        numberOfLines={1}
+        testID={`agent-row-branch-${agent.serverId}-${agent.id}`}
+      >
+        {branch}
+      </Text>
+      <Text style={styles.sessionMetaSeparator}>·</Text>
+      <Text
+        style={styles.sessionMetaText}
+        numberOfLines={1}
+        testID={`agent-row-workspace-${agent.serverId}-${agent.id}`}
+      >
+        {workspaceName}
+      </Text>
+      <Text style={styles.sessionMetaSeparator}>·</Text>
+      <Text style={styles.sessionMetaText}>{timeAgo}</Text>
+      {showHostColumn && agent.serverLabel ? (
+        <>
+          <Text style={styles.sessionMetaSeparator}>·</Text>
+          <Text style={styles.sessionMetaText} numberOfLines={1}>
+            {agent.serverLabel}
+          </Text>
+        </>
+      ) : null}
+    </View>
+  );
+}
+
 function SessionRow({
   agent,
   isMobile,
@@ -211,6 +251,11 @@ function SessionRow({
   showHostColumn,
   onPress,
   onLongPress,
+  depth = 0,
+  hasChildren = false,
+  expanded = false,
+  childCount = 0,
+  onToggleExpand,
 }: {
   agent: AggregatedAgent;
   isMobile: boolean;
@@ -219,6 +264,11 @@ function SessionRow({
   showHostColumn: boolean;
   onPress: (agent: AggregatedAgent) => void;
   onLongPress: (agent: AggregatedAgent) => void;
+  depth?: 0 | 1;
+  hasChildren?: boolean;
+  expanded?: boolean;
+  childCount?: number;
+  onToggleExpand?: (agentKey: string) => void;
 }) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
@@ -243,6 +293,9 @@ function SessionRow({
 
   const handlePress = useCallback(() => onPress(agent), [onPress, agent]);
   const handleLongPress = useCallback(() => onLongPress(agent), [onLongPress, agent]);
+  const handleToggleExpand = useCallback(() => {
+    onToggleExpand?.(agentKey);
+  }, [onToggleExpand, agentKey]);
 
   const sessionTitleStyle = useMemo(
     () => [styles.sessionTitle, isSelected && styles.sessionTitleHighlighted],
@@ -263,6 +316,13 @@ function SessionRow({
       onLongPress={handleLongPress}
       testID={`agent-row-${agent.serverId}-${agent.id}`}
     >
+      <RowLeadingControl
+        hasChildren={hasChildren}
+        depth={depth}
+        expanded={expanded}
+        onToggle={handleToggleExpand}
+        testID={`agent-row-disclosure-${agent.serverId}-${agent.id}`}
+      />
       <View style={styles.rowContent}>
         <View style={styles.rowTitleRow}>
           <WorkspaceTitlePrefix
@@ -284,44 +344,17 @@ function SessionRow({
             pendingPermissionCount={pendingPermissionCount}
             showDesktopAttention={showDesktopAttention}
           />
+          {hasChildren ? <SessionBadge label={String(childCount)} /> : null}
         </View>
-        {isMobile ? (
-          <View style={styles.rowMetaRow}>
-            <Text
-              style={styles.sessionMetaText}
-              numberOfLines={1}
-              testID={`agent-row-project-${agent.serverId}-${agent.id}`}
-            >
-              {projectName}
-            </Text>
-            <Text style={styles.sessionMetaSeparator}>·</Text>
-            <Text
-              style={styles.sessionMetaText}
-              numberOfLines={1}
-              testID={`agent-row-branch-${agent.serverId}-${agent.id}`}
-            >
-              {branch}
-            </Text>
-            <Text style={styles.sessionMetaSeparator}>·</Text>
-            <Text
-              style={styles.sessionMetaText}
-              numberOfLines={1}
-              testID={`agent-row-workspace-${agent.serverId}-${agent.id}`}
-            >
-              {workspaceName}
-            </Text>
-            <Text style={styles.sessionMetaSeparator}>·</Text>
-            <Text style={styles.sessionMetaText}>{timeAgo}</Text>
-            {showHostColumn && agent.serverLabel ? (
-              <>
-                <Text style={styles.sessionMetaSeparator}>·</Text>
-                <Text style={styles.sessionMetaText} numberOfLines={1}>
-                  {agent.serverLabel}
-                </Text>
-              </>
-            ) : null}
-          </View>
-        ) : null}
+        <SessionRowMobileMeta
+          agent={agent}
+          isMobile={isMobile}
+          projectName={projectName}
+          branch={branch}
+          workspaceName={workspaceName}
+          timeAgo={timeAgo}
+          showHostColumn={showHostColumn}
+        />
       </View>
       {!isMobile ? (
         <View style={styles.rowColumns}>
@@ -372,6 +405,7 @@ export function AgentList({
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const [actionAgent, setActionAgent] = useState<AggregatedAgent | null>(null);
+  const [expandedParents, setExpandedParents] = useState<ReadonlySet<string>>(new Set());
   const isMobile = useIsCompactFormFactor();
   const { archiveAgent } = useArchiveAgent();
   const queryClient = useQueryClient();
@@ -453,28 +487,22 @@ export function AgentList({
     setActionAgent(null);
   }, [actionAgent, actionClient, archiveAgent]);
 
-  const flatItems = useMemo((): FlatListItem[] => {
-    const buckets = new Map<DateSectionKey, AggregatedAgent[]>();
-    for (const agent of agents) {
-      const section = deriveDateSectionKey(agent.lastActivityAt);
-      const existing = buckets.get(section) ?? [];
-      existing.push(agent);
-      buckets.set(section, existing);
-    }
+  const handleToggleExpand = useCallback((agentKey: string) => {
+    setExpandedParents((prev) => {
+      const next = new Set(prev);
+      if (next.has(agentKey)) {
+        next.delete(agentKey);
+      } else {
+        next.add(agentKey);
+      }
+      return next;
+    });
+  }, []);
 
-    const result: FlatListItem[] = [];
-    for (const section of DATE_SECTION_ORDER) {
-      const data = buckets.get(section);
-      if (!data || data.length === 0) {
-        continue;
-      }
-      result.push({ type: "header", key: `header:${section}`, section });
-      for (const agent of data) {
-        result.push({ type: "agent", key: `${agent.serverId}:${agent.id}`, agent });
-      }
-    }
-    return result;
-  }, [agents]);
+  const flatItems = useMemo(
+    () => buildFlatItems(agents, expandedParents),
+    [agents, expandedParents],
+  );
 
   const renderItem: ListRenderItem<FlatListItem> = useCallback(
     ({ item }) => {
@@ -494,12 +522,18 @@ export function AgentList({
           showHostColumn={showHostColumn}
           onPress={handleAgentPress}
           onLongPress={handleAgentLongPress}
+          depth={item.depth}
+          hasChildren={item.hasChildren}
+          expanded={item.expanded}
+          childCount={item.childCount}
+          onToggleExpand={handleToggleExpand}
         />
       );
     },
     [
       handleAgentLongPress,
       handleAgentPress,
+      handleToggleExpand,
       isMobile,
       selectedAgentId,
       showAttentionIndicator,
@@ -810,6 +844,14 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foreground,
     fontWeight: theme.fontWeight.semibold,
     fontSize: theme.fontSize.base,
+  },
+  disclosureButton: {
+    width: 28,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  childIndent: {
+    width: 28,
   },
 }));
 

--- a/packages/app/src/components/agent-list.tsx
+++ b/packages/app/src/components/agent-list.tsx
@@ -156,7 +156,7 @@ function RowLeadingControl({
   testID,
 }: {
   hasChildren: boolean;
-  depth: 0 | 1;
+  depth: number;
   expanded: boolean;
   onToggle: () => void;
   testID: string;
@@ -183,7 +183,7 @@ function RowLeadingControl({
       </Pressable>
     );
   }
-  if (depth === 1) {
+  if (depth >= 1) {
     return <View style={styles.childIndent} />;
   }
   return null;
@@ -269,7 +269,7 @@ function SessionRow({
   showHostColumn: boolean;
   onPress: (agent: AggregatedAgent) => void;
   onLongPress: (agent: AggregatedAgent) => void;
-  depth?: 0 | 1;
+  depth?: number;
   hasChildren?: boolean;
   expanded?: boolean;
   childCount?: number;
@@ -286,14 +286,20 @@ function SessionRow({
   const ProviderIcon = getProviderIcon(agent.provider);
   const pendingPermissionCount = agent.pendingPermissionCount ?? 0;
 
+  const rowIndentStyle = useMemo(
+    () => (depth > 0 ? { paddingLeft: theme.spacing[3] + depth * theme.spacing[4] } : null),
+    [depth, theme.spacing],
+  );
+
   const pressableStyle = useCallback(
     ({ pressed, hovered = false }: PressableStateCallbackType & { hovered?: boolean }) => [
       styles.row,
+      rowIndentStyle,
       isSelected && styles.rowSelected,
       Boolean(hovered) && styles.rowHovered,
       pressed && styles.rowPressed,
     ],
-    [isSelected],
+    [isSelected, rowIndentStyle],
   );
 
   const handlePress = useCallback(() => onPress(agent), [onPress, agent]);

--- a/packages/app/src/components/agent-list.tsx
+++ b/packages/app/src/components/agent-list.tsx
@@ -162,6 +162,8 @@ function RowLeadingControl({
   testID: string;
 }) {
   const { theme } = useUnistyles();
+  const { t } = useTranslation();
+  const accessibilityState = useMemo(() => ({ expanded }), [expanded]);
   if (hasChildren) {
     return (
       <Pressable
@@ -169,6 +171,9 @@ function RowLeadingControl({
         hitSlop={DISCLOSURE_HIT_SLOP}
         style={styles.disclosureButton}
         testID={testID}
+        accessibilityRole="button"
+        accessibilityLabel={t("subagents.toggle")}
+        accessibilityState={accessibilityState}
       >
         {expanded ? (
           <ChevronDown size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1324,6 +1324,7 @@ export const ar: TranslationResources = {
     detachTooltip: "فصل الوكيل الفرعي",
     archiveAction: "أرشيف{{label}}",
     archiveTooltip: "أرشفة الوكيل الفرعي",
+    toggle: "توسيع أو طي الوكلاء الفرعيين",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1332,6 +1332,7 @@ export const en = {
     detachTooltip: "Detach subagent",
     archiveAction: "Archive {{label}}",
     archiveTooltip: "Archive subagent",
+    toggle: "Expand or collapse subagents",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1363,6 +1363,7 @@ export const es: TranslationResources = {
     detachTooltip: "Separar subagente",
     archiveAction: "Archivo{{label}}",
     archiveTooltip: "Subagente de archivo",
+    toggle: "Expandir o contraer subagentes",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1366,6 +1366,7 @@ export const fr: TranslationResources = {
     detachTooltip: "Detacher le sous-agent",
     archiveAction: "Archiver{{label}}",
     archiveTooltip: "Sous-agent d'archivage",
+    toggle: "Développer ou réduire les sous-agents",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1341,6 +1341,7 @@ export const ja: TranslationResources = {
     detachTooltip: "サブエージェントを切り離す",
     archiveAction: "{{label}}をアーカイブ",
     archiveTooltip: "サブエージェントをアーカイブ",
+    toggle: "サブエージェントを展開または折りたたむ",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1349,6 +1349,7 @@ export const ptBR: TranslationResources = {
     detachTooltip: "Desanexar subagente",
     archiveAction: "Arquivar {{label}}",
     archiveTooltip: "Arquivar subagente",
+    toggle: "Expandir ou recolher subagentes",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1355,6 +1355,7 @@ export const ru: TranslationResources = {
     detachTooltip: "Отсоединить субагент",
     archiveAction: "Архив{{label}}",
     archiveTooltip: "Архивный субагент",
+    toggle: "Развернуть или свернуть подагенты",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1307,6 +1307,7 @@ export const zhCN: TranslationResources = {
     detachTooltip: "分离 subagent",
     archiveAction: "归档 {{label}}",
     archiveTooltip: "归档 subagent",
+    toggle: "展开或折叠子代理",
   },
   panels: {
     draft: {


### PR DESCRIPTION
> **Scope note (updated):** This PR is the **Paseo-subagent** increment of the unified subagent view tracked in #1809 — it adds the collapsible **tree UI** and the data adapter for agents created via `paseo_create_agent` (`paseo.parent-agent-id` label). **Native provider subagents** (OpenCode/Claude/Codex child sessions) are a **phase-2 follow-up** (daemon capability + capability-gated protocol field feeding the same tree). Marked draft until the unified shape is settled.

---

### Linked issue

Closes #1809

> Transparency: I filed #1809 and this PR close together. CONTRIBUTING asks for maintainer alignment on a feature before code, so treat this as a concrete proposal to react to — happy to scope it down, split it, or hold it if the direction isn't wanted.

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment) — *issue filed (#1809); design alignment still pending*
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Real Paseo subagents (agents created with the `paseo.parent-agent-id` label) currently sit as flat, separate rows in the agent list, so parent/child structure isn't visible there. This PR groups them: a parent row with children shows a disclosure chevron and a child count, and expanding it reveals the children as indented rows directly beneath it.

Scope is deliberately Phase 1 from #1809 — **real Paseo subagents only**. Provider-native subsessions (OpenCode/Codex/Claude `sub_agent` activity) are explicitly out of scope here; they need a daemon-side source of truth first.

Implementation notes:
- Grouping derives the parent from `getParentAgentIdFromLabels(agent.labels)`. Orphans (parent not present in the list) stay top-level, so nothing disappears. Date-section headers apply to top-level rows only; children sort by `createdAt` asc.
- The pure grouping logic lives in a new react-native-free module `agent-list-grouping.ts` so it's unit-testable without dragging the RN transform into vitest.
- The disclosure chevron is a separate `Pressable` (with hitSlop) so toggling expand/collapse never triggers row navigation.
- No protocol or daemon changes; `labels` are already carried on `AggregatedAgent`.

Files: `agent-list.tsx` (+grouping wiring, disclosure UI), new `agent-list-grouping.ts`, new `agent-list.test.tsx`.

### How did you verify it

Automated:
- `npm run typecheck` — pass (also enforced by the pre-commit hook)
- `npm run lint` — 0 warnings, 0 errors
- `npx vitest run packages/app/src/components/agent-list.test.tsx` — 4/4 pass (collapsed-by-default, expand order, orphan fallback, grandchild never-dropped)
- `npm run format` (Biome) — clean

Manual (real OpenCode agents on the dev daemon: one parent + two subagents carrying the parent label):

**Web — desktop (1440×900)**

Collapsed — parent row with chevron + `2` count, children hidden:

![desktop collapsed](https://raw.githubusercontent.com/omercnet/paseo/pr-assets/assets/qa-02-collapsed.png)

Expanded — two indented child rows in creation order:

![desktop expanded](https://raw.githubusercontent.com/omercnet/paseo/pr-assets/assets/qa-03-expanded.png)

**Web — mobile viewport (390×844, compact layout)**

Collapsed:

![mobile collapsed](https://raw.githubusercontent.com/omercnet/paseo/pr-assets/assets/qa-04-mobile-collapsed.png)

Expanded:

![mobile expanded](https://raw.githubusercontent.com/omercnet/paseo/pr-assets/assets/qa-05-mobile-expanded.png)

I also confirmed the disclosure toggle keeps the route on `/sessions` (it hits the `agent-row-disclosure-…` testID and does not navigate).

**Platform coverage — please note:** I verified **web only**, on real Chromium at both desktop and mobile widths. I did **not** test native iOS or Android (no simulator/device available in my environment). The change is pure presentation in `AgentList` shared across platforms, but native still needs a real check before merge.

### Checklist

- [x] One focused change. Unrelated cleanups split out. (screenshots are hosted on a separate branch, not in this diff)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform — **web desktop + web mobile included; native iOS/Android not captured**
- [x] Tests added or updated where it made sense

---

### Review round 1 (greptile) — addressed in fb571948

- **Grandchildren silently dropped (P2):** a child now only nests under a *top-level* parent. Deeper chains (A←B←C) stay top-level instead of vanishing. Added a regression test (`never drops a grandchild…`) and a comment documenting the one-level Phase 1 constraint.
- **Disclosure missing a11y attributes (P2):** added `accessibilityRole="button"`, `accessibilityLabel` (new i18n key `subagents.toggle` across all 8 locales), and a memoized `accessibilityState={{ expanded }}`.
- **Test file naming (P2):** renamed `agent-list.test.tsx` → `agent-list-grouping.test.ts` (.ts, no JSX) to sit beside the module it tests.

All review threads resolved; lint/format/typecheck green (pre-commit hook). Screenshots above are unchanged — the fixes are non-visual (grouping change only affects 3-level chains; a11y is screen-reader-only).

---

### Update: multi-level subagent tree + indentation (e0768174)

Per review feedback, nesting is no longer limited to one level. Subagents now nest **recursively to any depth** — a subagent that spawns its own subagent renders beneath it — and each row indents per level so the list reads as a tree. The disclosure chevron sits at each level's start. The walk is cycle-safe (emitted-guard) and a root-closure safety net keeps any cycle-only agent visible without leaking a collapsed parent's descendants.

Verified live with a real 3-level OpenCode chain (**Parent agent → Subagent 1 → Sub-subagent**, plus **Subagent 2** at level 1):

![multi-level tree](https://raw.githubusercontent.com/omercnet/paseo/pr-assets/assets/qa-06-tree-3levels.png)

Tests updated: the one-level grandchild test is replaced by a 3-level depth assertion (depths 0/1/2) and a parent-label cycle-guard test. Grouping + i18n suites green (37 tests), lint/format/typecheck clean.

