### PR TITLE
feat(agent): add doom-loop circuit breaker in shared layer

### DIFF
--- a/packages/server/src/server/agent/agent-loop-guard.test.ts
+++ b/packages/server/src/server/agent/agent-loop-guard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   createLoopGuardState,
   DEFAULT_LOOP_GUARD_THRESHOLD,
@@ -31,6 +31,11 @@ function shellCall(
 }
 
 describe("agent-loop-guard", () => {
+  // Reset per test so generated callId uniqueness never depends on execution order.
+  beforeEach(() => {
+    callSeq = 0;
+  });
+
   it("does not trip on productive (exit 0) repeated commands", () => {
     const state = createLoopGuardState();
     for (let i = 0; i < DEFAULT_LOOP_GUARD_THRESHOLD * 2; i++) {

--- a/packages/server/src/server/agent/agent-loop-guard.test.ts
+++ b/packages/server/src/server/agent/agent-loop-guard.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  createLoopGuardState,
+  DEFAULT_LOOP_GUARD_THRESHOLD,
+  observeToolCall,
+  toolCallSignature,
+} from "./agent-loop-guard.js";
+import type { ToolCallTimelineItem } from "./agent-sdk-types.js";
+
+let callSeq = 0;
+
+function shellCall(
+  command: string,
+  opts: {
+    status?: "running" | "completed" | "failed";
+    exitCode?: number | null;
+    callId?: string;
+  } = {},
+): ToolCallTimelineItem {
+  const status = opts.status ?? "completed";
+  const base = {
+    type: "tool_call" as const,
+    callId: opts.callId ?? `call-${++callSeq}`,
+    name: "shell",
+    detail: { type: "shell" as const, command, exitCode: opts.exitCode ?? 0 },
+  };
+  if (status === "failed") {
+    return { ...base, status, error: new Error("boom") };
+  }
+  return { ...base, status, error: null };
+}
+
+describe("agent-loop-guard", () => {
+  it("does not trip on productive (exit 0) repeated commands", () => {
+    const state = createLoopGuardState();
+    for (let i = 0; i < DEFAULT_LOOP_GUARD_THRESHOLD * 2; i++) {
+      const outcome = observeToolCall(state, shellCall("npm test", { exitCode: 0 }), "turn-1");
+      expect(outcome.tripped).toBe(false);
+    }
+  });
+
+  it("trips on a shell command that completes with a non-zero exit code repeatedly", () => {
+    // The rtk-lint case: tool 'completes' but the command itself fails (exit != 0).
+    const state = createLoopGuardState();
+    let tripped: { tripped: true; signature: string; count: number } | null = null;
+    for (let i = 0; i < DEFAULT_LOOP_GUARD_THRESHOLD; i++) {
+      const outcome = observeToolCall(state, shellCall("rtk lint", { exitCode: 127 }), "turn-1");
+      if (outcome.tripped) {
+        tripped = outcome;
+      }
+    }
+    expect(tripped).not.toBeNull();
+    expect(tripped?.signature).toBe("shell:rtk lint");
+    expect(tripped?.count).toBe(DEFAULT_LOOP_GUARD_THRESHOLD);
+  });
+
+  it("trips on repeated status:failed tool calls", () => {
+    const state = createLoopGuardState();
+    const outcomes = Array.from({ length: DEFAULT_LOOP_GUARD_THRESHOLD }, () =>
+      observeToolCall(state, shellCall("flaky", { status: "failed" }), "turn-1"),
+    );
+    expect(outcomes.filter((o) => o.tripped)).toHaveLength(1);
+  });
+
+  it("fires the trip exactly once per stuck streak", () => {
+    const state = createLoopGuardState();
+    let trips = 0;
+    for (let i = 0; i < DEFAULT_LOOP_GUARD_THRESHOLD + 10; i++) {
+      if (observeToolCall(state, shellCall("rtk lint", { exitCode: 1 }), "turn-1").tripped) {
+        trips++;
+      }
+    }
+    expect(trips).toBe(1);
+  });
+
+  it("resets the streak when a different action runs in between", () => {
+    const state = createLoopGuardState();
+    for (let i = 0; i < DEFAULT_LOOP_GUARD_THRESHOLD - 1; i++) {
+      expect(observeToolCall(state, shellCall("rtk lint", { exitCode: 1 }), "turn-1").tripped).toBe(
+        false,
+      );
+    }
+    // A different (productive) action breaks the streak.
+    observeToolCall(state, shellCall("npm run build", { exitCode: 0 }), "turn-1");
+    // Back to the bad command — counter restarted, so one more does not trip.
+    expect(observeToolCall(state, shellCall("rtk lint", { exitCode: 1 }), "turn-1").tripped).toBe(
+      false,
+    );
+  });
+
+  it("resets the streak on a new turn", () => {
+    const state = createLoopGuardState();
+    for (let i = 0; i < DEFAULT_LOOP_GUARD_THRESHOLD - 1; i++) {
+      observeToolCall(state, shellCall("rtk lint", { exitCode: 1 }), "turn-1");
+    }
+    // New turn id resets everything.
+    expect(observeToolCall(state, shellCall("rtk lint", { exitCode: 1 }), "turn-2").tripped).toBe(
+      false,
+    );
+  });
+
+  it("does not double-count status transitions of the same call id", () => {
+    const state = createLoopGuardState();
+    // The same callId emitting a terminal event twice must count once.
+    for (let i = 0; i < DEFAULT_LOOP_GUARD_THRESHOLD * 2; i++) {
+      const outcome = observeToolCall(
+        state,
+        shellCall("rtk lint", { exitCode: 1, callId: "same-call" }),
+        "turn-1",
+      );
+      expect(outcome.tripped).toBe(false);
+    }
+  });
+
+  it("ignores running tool calls", () => {
+    const state = createLoopGuardState();
+    for (let i = 0; i < DEFAULT_LOOP_GUARD_THRESHOLD * 2; i++) {
+      expect(
+        observeToolCall(state, shellCall("rtk lint", { status: "running" }), "turn-1").tripped,
+      ).toBe(false);
+    }
+  });
+
+  it("builds stable signatures per detail type", () => {
+    expect(toolCallSignature(shellCall("ls -la"))).toBe("shell:ls -la");
+  });
+});

--- a/packages/server/src/server/agent/agent-loop-guard.test.ts
+++ b/packages/server/src/server/agent/agent-loop-guard.test.ts
@@ -78,6 +78,36 @@ describe("agent-loop-guard", () => {
     expect(trips).toBe(1);
   });
 
+  it("trips on the first unproductive call when configured with a threshold of one", () => {
+    const state = createLoopGuardState();
+
+    expect(observeToolCall(state, shellCall("rtk lint", { exitCode: 1 }), "turn-1", 1)).toEqual({
+      tripped: true,
+      signature: "shell:rtk lint",
+      count: 1,
+    });
+  });
+
+  it("can trip again after a productive call starts a new streak in the same turn", () => {
+    const state = createLoopGuardState();
+
+    expect(
+      observeToolCall(state, shellCall("rtk lint", { exitCode: 1 }), "turn-1", 2).tripped,
+    ).toBe(false);
+    expect(
+      observeToolCall(state, shellCall("rtk lint", { exitCode: 1 }), "turn-1", 2).tripped,
+    ).toBe(true);
+    expect(
+      observeToolCall(state, shellCall("npm test", { exitCode: 0 }), "turn-1", 2).tripped,
+    ).toBe(false);
+    expect(
+      observeToolCall(state, shellCall("rtk lint", { exitCode: 1 }), "turn-1", 2).tripped,
+    ).toBe(false);
+    expect(
+      observeToolCall(state, shellCall("rtk lint", { exitCode: 1 }), "turn-1", 2).tripped,
+    ).toBe(true);
+  });
+
   it("resets the streak when a different action runs in between", () => {
     const state = createLoopGuardState();
     for (let i = 0; i < DEFAULT_LOOP_GUARD_THRESHOLD - 1; i++) {

--- a/packages/server/src/server/agent/agent-loop-guard.ts
+++ b/packages/server/src/server/agent/agent-loop-guard.ts
@@ -35,6 +35,8 @@ export type LoopGuardOutcome =
   | { tripped: false }
   | { tripped: true; signature: string; count: number };
 
+const NO_LOOP_GUARD_TRIP: LoopGuardOutcome = { tripped: false };
+
 export function createLoopGuardState(): LoopGuardState {
   return {
     turnId: undefined,
@@ -92,12 +94,10 @@ export function observeToolCall(
   turnId: string | undefined,
   threshold: number = DEFAULT_LOOP_GUARD_THRESHOLD,
 ): LoopGuardOutcome {
-  // Only terminal outcomes carry signal. Ignore "running" / "canceled".
   if (item.status !== "completed" && item.status !== "failed") {
-    return { tripped: false };
+    return NO_LOOP_GUARD_TRIP;
   }
 
-  // A new turn resets the streak entirely.
   if (turnId !== state.turnId) {
     state.turnId = turnId;
     state.signature = null;
@@ -106,35 +106,32 @@ export function observeToolCall(
     state.countedCallIds.clear();
   }
 
-  // Already tripped this turn — don't fire repeatedly.
-  if (state.tripped) {
-    return { tripped: false };
-  }
-
-  const unproductive = isUnproductive(item);
-  const signature = toolCallSignature(item);
-
-  // A productive call, or a different action, breaks the streak.
-  if (!unproductive || signature !== state.signature) {
-    state.signature = unproductive ? signature : null;
-    state.unproductiveCount = unproductive ? 1 : 0;
+  if (!isUnproductive(item)) {
+    state.signature = null;
+    state.unproductiveCount = 0;
+    state.tripped = false;
     state.countedCallIds.clear();
-    if (unproductive) {
-      state.countedCallIds.add(item.callId);
+    return NO_LOOP_GUARD_TRIP;
+  }
+
+  const signature = toolCallSignature(item);
+  if (signature !== state.signature) {
+    state.signature = signature;
+    state.unproductiveCount = 1;
+    state.tripped = false;
+    state.countedCallIds.clear();
+    state.countedCallIds.add(item.callId);
+  } else {
+    if (state.tripped || state.countedCallIds.has(item.callId)) {
+      return NO_LOOP_GUARD_TRIP;
     }
-    return { tripped: false };
+    state.countedCallIds.add(item.callId);
+    state.unproductiveCount += 1;
   }
 
-  // Same unproductive action again. Dedupe status transitions of one call.
-  if (state.countedCallIds.has(item.callId)) {
-    return { tripped: false };
+  if (state.unproductiveCount < threshold) {
+    return NO_LOOP_GUARD_TRIP;
   }
-  state.countedCallIds.add(item.callId);
-  state.unproductiveCount += 1;
-
-  if (state.unproductiveCount >= threshold) {
-    state.tripped = true;
-    return { tripped: true, signature, count: state.unproductiveCount };
-  }
-  return { tripped: false };
+  state.tripped = true;
+  return { tripped: true, signature, count: state.unproductiveCount };
 }

--- a/packages/server/src/server/agent/agent-loop-guard.ts
+++ b/packages/server/src/server/agent/agent-loop-guard.ts
@@ -1,0 +1,140 @@
+import type { ToolCallTimelineItem } from "./agent-sdk-types.js";
+
+/**
+ * Circuit breaker for stuck agents that repeat the same unproductive tool call.
+ *
+ * The model's tool-call loop runs inside the provider process (OpenCode server,
+ * Codex app-server, Claude CLI, ACP agent); Paseo only observes it over the
+ * provider event stream. When a model gets wedged — e.g. re-issuing a shell
+ * command that always fails — nothing in the provider stops it, so a single turn
+ * can burn many minutes and hundreds of identical tool calls while the UI shows
+ * an indistinguishable-from-hung "running…" state.
+ *
+ * This guard is provider-agnostic: it observes the shared `tool_call` timeline
+ * items every provider funnels through `AgentManager.recordAndDispatchTimelineItem`
+ * and trips when the same *unproductive* tool call repeats N times in a row within
+ * one turn. The caller is expected to cancel the turn and surface a clear message.
+ *
+ * "Unproductive" is repetition + a non-success outcome, NOT just `status: "failed"`.
+ * A failing shell command (e.g. `rtk lint` with no such subcommand) usually arrives
+ * as `status: "completed"` with a non-zero `exitCode` — the tool ran fine, the
+ * command failed — so keying on `failed` alone would miss the most common loop.
+ */
+
+export const DEFAULT_LOOP_GUARD_THRESHOLD = 12;
+
+export interface LoopGuardState {
+  turnId: string | undefined;
+  signature: string | null;
+  unproductiveCount: number;
+  tripped: boolean;
+  countedCallIds: Set<string>;
+}
+
+export type LoopGuardOutcome =
+  | { tripped: false }
+  | { tripped: true; signature: string; count: number };
+
+export function createLoopGuardState(): LoopGuardState {
+  return {
+    turnId: undefined,
+    signature: null,
+    unproductiveCount: 0,
+    tripped: false,
+    countedCallIds: new Set(),
+  };
+}
+
+/**
+ * Stable identity for a tool call, ignoring volatile fields (callId, output,
+ * timing). Two calls with the same signature are "the same action".
+ */
+export function toolCallSignature(item: ToolCallTimelineItem): string {
+  const detail = item.detail;
+  switch (detail.type) {
+    case "shell":
+      return `shell:${detail.command}`;
+    case "read":
+      return `read:${detail.filePath}`;
+    case "edit":
+      return `edit:${detail.filePath}`;
+    case "write":
+      return `write:${detail.filePath}`;
+    case "search":
+      return `search:${detail.toolName ?? "search"}:${detail.query}`;
+    case "fetch":
+      return `fetch:${detail.url}`;
+    default:
+      return `${item.name}:${detail.type}`;
+  }
+}
+
+function isUnproductive(item: ToolCallTimelineItem): boolean {
+  if (item.status === "failed") {
+    return true;
+  }
+  if (item.status === "completed" && item.detail.type === "shell") {
+    const exitCode = item.detail.exitCode;
+    return typeof exitCode === "number" && exitCode !== 0;
+  }
+  return false;
+}
+
+/**
+ * Observe a terminal `tool_call` timeline item and mutate `state` accordingly.
+ * Returns `{ tripped: true, ... }` exactly once per stuck streak per turn — the
+ * caller should react (cancel the turn) and not be called again until the streak
+ * resets (new turn, productive call, or a different action).
+ */
+export function observeToolCall(
+  state: LoopGuardState,
+  item: ToolCallTimelineItem,
+  turnId: string | undefined,
+  threshold: number = DEFAULT_LOOP_GUARD_THRESHOLD,
+): LoopGuardOutcome {
+  // Only terminal outcomes carry signal. Ignore "running" / "canceled".
+  if (item.status !== "completed" && item.status !== "failed") {
+    return { tripped: false };
+  }
+
+  // A new turn resets the streak entirely.
+  if (turnId !== state.turnId) {
+    state.turnId = turnId;
+    state.signature = null;
+    state.unproductiveCount = 0;
+    state.tripped = false;
+    state.countedCallIds.clear();
+  }
+
+  // Already tripped this turn — don't fire repeatedly.
+  if (state.tripped) {
+    return { tripped: false };
+  }
+
+  const unproductive = isUnproductive(item);
+  const signature = toolCallSignature(item);
+
+  // A productive call, or a different action, breaks the streak.
+  if (!unproductive || signature !== state.signature) {
+    state.signature = unproductive ? signature : null;
+    state.unproductiveCount = unproductive ? 1 : 0;
+    state.countedCallIds.clear();
+    if (unproductive) {
+      state.countedCallIds.add(item.callId);
+    }
+    return { tripped: false };
+  }
+
+  // Same unproductive action again. Dedupe status transitions of one call.
+  if (state.countedCallIds.has(item.callId)) {
+    return { tripped: false };
+  }
+  state.countedCallIds.add(item.callId);
+  state.unproductiveCount += 1;
+
+  if (state.unproductiveCount >= threshold) {
+    state.tripped = true;
+    return { tripped: true, signature, count: state.unproductiveCount };
+  }
+  return { tripped: false };
+}

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7933,6 +7933,93 @@ test("archiveAgent cascade surfaces partial child archive failures", async () =>
   );
 });
 
+test("doom-loop guard explains the interruption before canceling the turn", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-loop-guard-"));
+  const turnId = "loop-guard-turn";
+
+  class LoopingSession extends TestAgentSession {
+    interruptCount = 0;
+
+    override async startTurn(): Promise<{ turnId: string }> {
+      queueMicrotask(() => {
+        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+        for (let index = 0; index < 3; index++) {
+          this.pushEvent({
+            type: "timeline",
+            provider: this.provider,
+            turnId,
+            item: {
+              type: "tool_call",
+              callId: `failed-call-${index}`,
+              name: "shell",
+              status: "completed",
+              error: null,
+              detail: { type: "shell", command: "rtk lint", exitCode: 127 },
+            },
+          });
+        }
+      });
+      return { turnId };
+    }
+
+    override async interrupt(): Promise<void> {
+      this.interruptCount += 1;
+      this.pushEvent({ type: "turn_canceled", provider: this.provider, turnId });
+    }
+  }
+
+  const session = new LoopingSession({ provider: "codex", cwd: workdir });
+  const manager = new AgentManager({
+    clients: {
+      codex: new (class extends TestAgentClient {
+        override async createSession(): Promise<AgentSession> {
+          return session;
+        }
+      })(),
+    },
+    loopGuardThreshold: 3,
+    logger,
+  });
+  const observed: string[] = [];
+  let agentId: string | null = null;
+
+  try {
+    const agent = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    agentId = agent.id;
+    manager.subscribe(
+      (event) => {
+        if (event.type !== "agent_stream") return;
+        if (
+          event.event.type === "timeline" &&
+          event.event.item.type === "assistant_message" &&
+          event.event.item.text.includes("Agent appears stuck")
+        ) {
+          observed.push("explanation");
+        }
+        if (event.event.type === "turn_canceled") {
+          observed.push("canceled");
+        }
+      },
+      { agentId: agent.id, replayState: false },
+    );
+
+    const result = await manager.runAgent(agent.id, "repeat a bad command");
+
+    expect(result.canceled).toBe(true);
+    expect(session.interruptCount).toBe(1);
+    expect(observed).toEqual(["explanation", "canceled"]);
+    expect(manager.getTimeline(agent.id)).toContainEqual({
+      type: "assistant_message",
+      text: expect.stringContaining("repeated the same unproductive action 3 times"),
+    });
+  } finally {
+    if (agentId) await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("turn_failed emits a system error assistant timeline message and keeps error lifecycle", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-turn-failed-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -4393,7 +4393,7 @@ export class AgentManager {
     }
     const outcome = observeToolCall(state, item, turnId, this.loopGuardThreshold);
     if (outcome.tripped) {
-      this.tripLoopGuard(agentId, provider, outcome.signature, outcome.count);
+      void this.tripLoopGuard(agentId, provider, outcome.signature, outcome.count);
     }
   }
 
@@ -4402,29 +4402,38 @@ export class AgentManager {
    * leave a human-readable breadcrumb so the loop is not silent. Provider-agnostic:
    * every provider funnels tool_call items through recordAndDispatchTimelineItem.
    */
-  private tripLoopGuard(
+  private async tripLoopGuard(
     agentId: string,
     provider: AgentProvider,
     signature: string,
     count: number,
-  ): void {
+  ): Promise<void> {
     this.logger.warn(
       { agentId, provider, signature, count },
       "agent.loop_guard.tripped: canceling stuck turn",
     );
+    // Write+dispatch the explanation BEFORE canceling. cancelAgentRun pushes a
+    // turn_canceled event to live subscribers; if we started the cancel first,
+    // the async message write (it does a store round-trip before dispatch) could
+    // resume after subscribers already closed, so a live watcher would see the
+    // turn end with no reason. Sequencing guarantees the breadcrumb lands first.
     const agent = this.agents.get(agentId);
     if (agent) {
-      void this.appendSystemErrorTimelineMessage(
-        agent,
-        provider,
-        `Agent appears stuck: it repeated the same unproductive action ${count} times in a row (${signature}). Paseo auto-canceled this turn. Try rephrasing the task, or run the command yourself to see the error.`,
-      ).catch((error) => {
+      try {
+        await this.appendSystemErrorTimelineMessage(
+          agent,
+          provider,
+          `Agent appears stuck: it repeated the same unproductive action ${count} times in a row (${signature}). Paseo auto-canceled this turn. Try rephrasing the task, or run the command yourself to see the error.`,
+        );
+      } catch (error) {
         this.logger.warn({ err: error, agentId }, "agent.loop_guard.message_failed");
-      });
+      }
     }
-    void this.cancelAgentRun(agentId).catch((error) => {
+    try {
+      await this.cancelAgentRun(agentId);
+    } catch (error) {
       this.logger.warn({ err: error, agentId }, "agent.loop_guard.cancel_failed");
-    });
+    }
   }
 
   private async appendSystemErrorTimelineMessage(

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -42,6 +42,7 @@ import {
   type SteerResult,
   type AgentStreamEvent,
   type AgentTimelineItem,
+  type ToolCallTimelineItem,
   type AgentUsage,
   type AgentRuntimeInfo,
   type ImportedTimelineEntry,
@@ -49,6 +50,12 @@ import {
   type ListImportableSessionsOptions,
 } from "./agent-sdk-types.js";
 import { buildArchivedAgentRecord, type ArchivedStoredAgentRecord } from "./agent-archive.js";
+import {
+  createLoopGuardState,
+  DEFAULT_LOOP_GUARD_THRESHOLD,
+  observeToolCall,
+  type LoopGuardState,
+} from "./agent-loop-guard.js";
 import type { StoredAgentRecord, AgentStorage } from "./agent-storage.js";
 import type { AgentOwner } from "./agent-owner.js";
 import {
@@ -290,6 +297,11 @@ export interface AgentManagerOptions {
     agentId: string;
     expectedTurnId: string;
   }) => Promise<void>;
+  /**
+   * Trip the doom-loop circuit breaker after this many consecutive identical
+   * unproductive tool calls in one turn. Defaults to DEFAULT_LOOP_GUARD_THRESHOLD.
+   */
+  loopGuardThreshold?: number;
   logger: Logger;
 }
 
@@ -702,6 +714,8 @@ export class AgentManager {
   private readonly rescueTimeouts: Required<AgentManagerRescueTimeouts>;
   private readonly beforeSteerUnavailableFallback?: AgentManagerOptions["beforeSteerUnavailableFallback"];
   private acceptingAgentRegistrations = true;
+  private readonly loopGuards = new Map<string, LoopGuardState>();
+  private readonly loopGuardThreshold: number;
 
   constructor(options: AgentManagerOptions) {
     this.idFactory = options?.idFactory ?? (() => randomUUID());
@@ -721,6 +735,7 @@ export class AgentManager {
         options.rescueTimeouts?.interruptSessionMs ?? INTERRUPT_SESSION_TIMEOUT_MS,
     };
     this.beforeSteerUnavailableFallback = options.beforeSteerUnavailableFallback;
+    this.loopGuardThreshold = options.loopGuardThreshold ?? DEFAULT_LOOP_GUARD_THRESHOLD;
     this.agentStreamCoalescer = new AgentStreamCoalescer({
       windowMs: options.agentStreamCoalesceWindowMs ?? AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS,
       timers: { setTimeout, clearTimeout },
@@ -3363,6 +3378,7 @@ export class AgentManager {
     this.agentStreamCoalescer.flushAndDiscard(agent.id);
     this.agents.delete(agent.id);
     this.previousStatuses.delete(agent.id);
+    this.loopGuards.delete(agent.id);
     if (agent.unsubscribeSession) {
       agent.unsubscribeSession();
       agent.unsubscribeSession = null;
@@ -4309,6 +4325,10 @@ export class AgentManager {
       }
     }
 
+    if (item.type === "tool_call") {
+      this.observeToolCallForLoopGuard(agentId, item, provider, turnId);
+    }
+
     return event;
   }
 
@@ -4358,6 +4378,53 @@ export class AgentManager {
       if (enriched) this.enqueueDurableTimelineUpdate(agent.id, enriched);
     }
     return existing;
+  }
+
+  private observeToolCallForLoopGuard(
+    agentId: string,
+    item: ToolCallTimelineItem,
+    provider: AgentProvider,
+    turnId: string | undefined,
+  ): void {
+    let state = this.loopGuards.get(agentId);
+    if (!state) {
+      state = createLoopGuardState();
+      this.loopGuards.set(agentId, state);
+    }
+    const outcome = observeToolCall(state, item, turnId, this.loopGuardThreshold);
+    if (outcome.tripped) {
+      this.tripLoopGuard(agentId, provider, outcome.signature, outcome.count);
+    }
+  }
+
+  /**
+   * Cancel a turn that is stuck repeating the same unproductive tool call, and
+   * leave a human-readable breadcrumb so the loop is not silent. Provider-agnostic:
+   * every provider funnels tool_call items through recordAndDispatchTimelineItem.
+   */
+  private tripLoopGuard(
+    agentId: string,
+    provider: AgentProvider,
+    signature: string,
+    count: number,
+  ): void {
+    this.logger.warn(
+      { agentId, provider, signature, count },
+      "agent.loop_guard.tripped: canceling stuck turn",
+    );
+    const agent = this.agents.get(agentId);
+    if (agent) {
+      void this.appendSystemErrorTimelineMessage(
+        agent,
+        provider,
+        `Agent appears stuck: it repeated the same unproductive action ${count} times in a row (${signature}). Paseo auto-canceled this turn. Try rephrasing the task, or run the command yourself to see the error.`,
+      ).catch((error) => {
+        this.logger.warn({ err: error, agentId }, "agent.loop_guard.message_failed");
+      });
+    }
+    void this.cancelAgentRun(agentId).catch((error) => {
+      this.logger.warn({ err: error, agentId }, "agent.loop_guard.cancel_failed");
+    });
   }
 
   private async appendSystemErrorTimelineMessage(

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -3410,7 +3410,7 @@ export class AgentManager {
     }
     const outcome = observeToolCall(state, item, turnId, this.loopGuardThreshold);
     if (outcome.tripped) {
-      this.tripLoopGuard(agentId, provider, outcome.signature, outcome.count);
+      void this.tripLoopGuard(agentId, provider, outcome.signature, outcome.count);
     }
   }
 
@@ -3419,29 +3419,38 @@ export class AgentManager {
    * leave a human-readable breadcrumb so the loop is not silent. Provider-agnostic:
    * every provider funnels tool_call items through recordAndDispatchTimelineItem.
    */
-  private tripLoopGuard(
+  private async tripLoopGuard(
     agentId: string,
     provider: AgentProvider,
     signature: string,
     count: number,
-  ): void {
+  ): Promise<void> {
     this.logger.warn(
       { agentId, provider, signature, count },
       "agent.loop_guard.tripped: canceling stuck turn",
     );
+    // Write+dispatch the explanation BEFORE canceling. cancelAgentRun pushes a
+    // turn_canceled event to live subscribers; if we started the cancel first,
+    // the async message write (it does a store round-trip before dispatch) could
+    // resume after subscribers already closed, so a live watcher would see the
+    // turn end with no reason. Sequencing guarantees the breadcrumb lands first.
     const agent = this.agents.get(agentId);
     if (agent) {
-      void this.appendSystemErrorTimelineMessage(
-        agent,
-        provider,
-        `Agent appears stuck: it repeated the same unproductive action ${count} times in a row (${signature}). Paseo auto-canceled this turn. Try rephrasing the task, or run the command yourself to see the error.`,
-      ).catch((error) => {
+      try {
+        await this.appendSystemErrorTimelineMessage(
+          agent,
+          provider,
+          `Agent appears stuck: it repeated the same unproductive action ${count} times in a row (${signature}). Paseo auto-canceled this turn. Try rephrasing the task, or run the command yourself to see the error.`,
+        );
+      } catch (error) {
         this.logger.warn({ err: error, agentId }, "agent.loop_guard.message_failed");
-      });
+      }
     }
-    void this.cancelAgentRun(agentId).catch((error) => {
+    try {
+      await this.cancelAgentRun(agentId);
+    } catch (error) {
       this.logger.warn({ err: error, agentId }, "agent.loop_guard.cancel_failed");
-    });
+    }
   }
 
   private async appendSystemErrorTimelineMessage(

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -36,6 +36,7 @@ import {
   type AgentSessionConfig,
   type AgentStreamEvent,
   type AgentTimelineItem,
+  type ToolCallTimelineItem,
   type AgentUsage,
   type AgentRuntimeInfo,
   type ImportedTimelineEntry,
@@ -43,6 +44,12 @@ import {
   type ListImportableSessionsOptions,
 } from "./agent-sdk-types.js";
 import { buildArchivedAgentRecord, type ArchivedStoredAgentRecord } from "./agent-archive.js";
+import {
+  createLoopGuardState,
+  DEFAULT_LOOP_GUARD_THRESHOLD,
+  observeToolCall,
+  type LoopGuardState,
+} from "./agent-loop-guard.js";
 import type { StoredAgentRecord, AgentStorage } from "./agent-storage.js";
 import {
   InMemoryAgentTimelineStore,
@@ -212,6 +219,11 @@ export interface AgentManagerOptions {
   appendSystemPrompt?: string;
   agentStreamCoalesceWindowMs?: number;
   rescueTimeouts?: AgentManagerRescueTimeouts;
+  /**
+   * Trip the doom-loop circuit breaker after this many consecutive identical
+   * unproductive tool calls in one turn. Defaults to DEFAULT_LOOP_GUARD_THRESHOLD.
+   */
+  loopGuardThreshold?: number;
   logger: Logger;
 }
 
@@ -536,6 +548,8 @@ export class AgentManager {
   private onWorkspaceStateMayHaveChanged?: (params: { cwd: string }) => void;
   private logger: Logger;
   private readonly rescueTimeouts: Required<AgentManagerRescueTimeouts>;
+  private readonly loopGuards = new Map<string, LoopGuardState>();
+  private readonly loopGuardThreshold: number;
 
   constructor(options: AgentManagerOptions) {
     this.idFactory = options?.idFactory ?? (() => randomUUID());
@@ -554,6 +568,7 @@ export class AgentManager {
       interruptSessionMs:
         options.rescueTimeouts?.interruptSessionMs ?? INTERRUPT_SESSION_TIMEOUT_MS,
     };
+    this.loopGuardThreshold = options.loopGuardThreshold ?? DEFAULT_LOOP_GUARD_THRESHOLD;
     this.agentStreamCoalescer = new AgentStreamCoalescer({
       windowMs: options.agentStreamCoalesceWindowMs ?? AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS,
       timers: { setTimeout, clearTimeout },
@@ -2630,6 +2645,7 @@ export class AgentManager {
     this.agentStreamCoalescer.flushAndDiscard(agent.id);
     this.agents.delete(agent.id);
     this.previousStatuses.delete(agent.id);
+    this.loopGuards.delete(agent.id);
     if (agent.unsubscribeSession) {
       agent.unsubscribeSession();
       agent.unsubscribeSession = null;
@@ -3374,7 +3390,58 @@ export class AgentManager {
       }
     }
 
+    if (item.type === "tool_call") {
+      this.observeToolCallForLoopGuard(agentId, item, provider, turnId);
+    }
+
     return event;
+  }
+
+  private observeToolCallForLoopGuard(
+    agentId: string,
+    item: ToolCallTimelineItem,
+    provider: AgentProvider,
+    turnId: string | undefined,
+  ): void {
+    let state = this.loopGuards.get(agentId);
+    if (!state) {
+      state = createLoopGuardState();
+      this.loopGuards.set(agentId, state);
+    }
+    const outcome = observeToolCall(state, item, turnId, this.loopGuardThreshold);
+    if (outcome.tripped) {
+      this.tripLoopGuard(agentId, provider, outcome.signature, outcome.count);
+    }
+  }
+
+  /**
+   * Cancel a turn that is stuck repeating the same unproductive tool call, and
+   * leave a human-readable breadcrumb so the loop is not silent. Provider-agnostic:
+   * every provider funnels tool_call items through recordAndDispatchTimelineItem.
+   */
+  private tripLoopGuard(
+    agentId: string,
+    provider: AgentProvider,
+    signature: string,
+    count: number,
+  ): void {
+    this.logger.warn(
+      { agentId, provider, signature, count },
+      "agent.loop_guard.tripped: canceling stuck turn",
+    );
+    const agent = this.agents.get(agentId);
+    if (agent) {
+      void this.appendSystemErrorTimelineMessage(
+        agent,
+        provider,
+        `Agent appears stuck: it repeated the same unproductive action ${count} times in a row (${signature}). Paseo auto-canceled this turn. Try rephrasing the task, or run the command yourself to see the error.`,
+      ).catch((error) => {
+        this.logger.warn({ err: error, agentId }, "agent.loop_guard.message_failed");
+      });
+    }
+    void this.cancelAgentRun(agentId).catch((error) => {
+      this.logger.warn({ err: error, agentId }, "agent.loop_guard.cancel_failed");
+    });
   }
 
   private async appendSystemErrorTimelineMessage(


### PR DESCRIPTION
## What

Adds a provider-agnostic doom-loop circuit breaker. When an agent repeats the same unproductive tool call enough times in one turn, Paseo cancels the turn and records a clear timeline explanation instead of allowing the provider process to spin silently.

Fixes #1822.

## Why

A subagent repeated the same failing `rtk lint` command about 150 times over roughly 29 minutes. The provider remained healthy, so Paseo had no existing lifecycle failure to react to. The repeated tool calls were visible only through the normalized provider event stream.

## How

- Adds `agent-loop-guard.ts`, a provider-neutral state machine for consecutive unproductive tool calls.
- Treats both failed tool calls and completed shell calls with non-zero exit codes as unproductive.
- De-duplicates repeated terminal updates for one `callId`.
- Resets the streak on a new turn, a productive call, or a different action. A recovered agent can therefore trip a later independent streak in the same turn.
- Integrates at `AgentManager.recordAndDispatchTimelineItem`, the shared timeline path used by Claude, Codex, Copilot, OpenCode, Pi, OMP, and ACP-backed providers.
- Records and dispatches the `[System Error]` explanation before invoking the existing cancellation path, so live subscribers see the reason before `turn_canceled`.
- Uses a configurable `AgentManagerOptions.loopGuardThreshold`, defaulting to 12.

No protocol or schema changes.

## QA

- `npx vitest run packages/server/src/server/agent/agent-loop-guard.test.ts packages/server/src/server/agent/agent-manager.test.ts --bail=1` - 2 files, 180 tests passed
- `npm run typecheck` - passed
- `npm run lint` - 0 warnings, 0 errors
- `npm run format` - passed
- `npm run format:check` - passed

Coverage includes non-zero shell exits, failed tool calls, productive calls, per-turn and per-streak resets, duplicate call IDs, running calls, threshold 1, stable signatures, one cancellation per stuck streak, and observable explanation-before-cancellation ordering through `AgentManager`.

## Files

- `packages/server/src/server/agent/agent-loop-guard.ts`
- `packages/server/src/server/agent/agent-loop-guard.test.ts`
- `packages/server/src/server/agent/agent-manager.ts`
- `packages/server/src/server/agent/agent-manager.test.ts`
