### PR TITLE
Persist queued agent messages on the daemon

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -52,6 +52,7 @@ $PASEO_HOME/
 ├── agents/
 │   └── {sanitized-cwd}/
 │       └── {agentId}.json               # One file per agent
+├── agent-message-queue.json             # Queued prompts pending daemon-side replay
 ├── schedules/
 │   └── {scheduleId}.json                # One file per schedule
 ├── projects/
@@ -171,6 +172,45 @@ Each agent is stored as a separate JSON file, grouped by project directory.
 Terminals are live daemon state, not persisted JSON records. A terminal carries a `workspaceId` while it is running; workspace-scoped terminal lists include only terminals with the matching `workspaceId`. Legacy live terminals without an owner remain visible to unscoped terminal reads but contribute to no workspace status.
 
 Terminal activity contributes to the workspace status bucket **per `workspaceId`**: a working terminal drives `running` onto the workspace it carries only. Same-`cwd` siblings are untouched; terminal visibility is likewise `workspaceId`-scoped.
+
+---
+
+## Agent Message Queue
+
+**Path:** `$PASEO_HOME/agent-message-queue.json`
+
+Single file containing queued prompts grouped by agent id. Writes are serialized in memory and persisted atomically. Each record stores the full dispatch payload needed for daemon-side replay and multi-client editing: text, encoded images, structured attachments, and creation time. Each agent queue also has a monotonic revision so clients can ignore stale queue broadcasts and reconnect snapshots.
+
+List responses carry the complete queued payload (`images`, `attachments`) plus summary counts. Queue update broadcasts fan out to every capable client on every queue change, so they omit both image and structured attachment payload arrays while `imageCount` and `attachmentCount` stay accurate; clients hydrate unseen payloads through the list RPC. Broadcasts are sent only to clients that advertise the queue-event client capability, so older clients can connect to newer daemons without receiving an unknown event type. The queue service replays the same payload through the normal agent send path once the agent has no in-flight run, retrying failed dispatches on an escalating delay ladder before suspending until the next agent event. On daemon startup, persisted queues are scheduled for non-internal, non-archived stored agents even before those agents are lazily loaded into memory; queue records and revision tombstones with neither a stored nor live agent are removed and broadcast as empty. Archiving or deleting an agent discards that agent's pending queued messages; enqueue eligibility is re-checked inside the store's serialized mutation so a concurrent archive cannot strand a new record. A client-supplied message id deduplicates only against records that are still pending; the queue does not keep a delivered-message ledger.
+
+Queued records are durable while waiting in the queue. Per-agent revisions are retained as queue tombstones while the agent record still exists, including after archive, so reconnecting clients can clear stale local mirrors and ignore stale broadcasts across archive/unarchive cycles. Hard delete removes the tombstone. Dispatch removes a record before starting the agent turn, registers a foreground turn-start acknowledgement before consuming the provider iterator, and waits without a timeout. A provider start failure restores the record at the front of the queue and advances the queue revision before retrying. An indefinitely hung provider start blocks that agent's queue rather than risking duplicate delivery from a late start.
+
+Provider acknowledgement cannot be atomically committed with the queue file. A daemon crash after the durable removal but before Paseo observes the provider acknowledgement can therefore lose that queue record whether or not the provider actually started the turn. Keeping the record until acknowledgement would choose the opposite failure mode: replay after restart could duplicate a turn the provider already accepted. Paseo deliberately does not use timeout retries to pretend this boundary is exactly-once.
+
+The one-time legacy local-to-daemon queue migration has a separate acknowledgement-loss window. The client keeps a local message pending until its enqueue RPC is acknowledged. If the daemon accepts the record, dispatches it, and removes it from the queue before that response is lost, reconnect migration retries the same `messageId`; pending-record deduplication no longer sees it and the turn can be duplicated. This migration edge is deliberately at-least-once and does not justify a delivered-message ledger.
+
+If a client that already mirrored a daemon queue reconnects to an older daemon without the queue capability, it removes daemon-confirmed records from the legacy local mirror and retains only the unacknowledged migration suffix. Confirmed records remain owned by the newer daemon's queue file and reappear when that daemon version is restored; the old local drain must never dispatch them a second time.
+
+If the queue file is invalid JSON or fails schema validation, the daemon renames it with a `.corrupt-<timestamp>-<uuid>` suffix, logs the quarantine path, and starts with an empty queue. This favors daemon availability and forensic recovery of the original bytes over retaining unparseable queue state; queued messages in that file are not replayed automatically. Clients treat the first snapshot from each new connection as authoritative, so stale in-memory mirrors are cleared even when the recovered store has restarted its revisions.
+
+```ts
+{
+  version: 1,
+  queues: {
+    [agentId: string]: Array<{
+      id: string
+      agentId: string
+      text: string
+      images: Array<{ data: string, mimeType: string }>
+      attachments: AgentAttachment[]
+      createdAt: string
+    }>
+  },
+  revisions: {
+    [agentId: string]: number
+  }
+}
+```
 
 ---
 

--- a/packages/app/e2e/browser/agent-message-submission.spec.ts
+++ b/packages/app/e2e/browser/agent-message-submission.spec.ts
@@ -407,7 +407,7 @@ async function expectInterruptedTurnOrderAfterReconnect(
     await page.getByRole("button", { name: "Send queued message now" }).click();
     const promptRow = page.getByTestId("user-message").filter({ hasText: prompt });
     await expect(promptRow).toBeVisible();
-    await gate.waitForServerMessage("send_agent_message_response");
+    await gate.waitForServerMessage("queue.agent_message.dispatch.response");
     await gate.drop();
     await agent.client.waitForFinish(agent.agentId, 30_000);
     gate.setAgentStreamSuppressed(false);
@@ -1220,7 +1220,7 @@ test.describe("Agent message submission", () => {
     await replaySteeredSleepTurnInBrowser(page, testInfo, "codex");
   });
 
-  test("restores overlapping queued sends when their connection fails", async ({
+  test("restores queued sends when their dispatch request is rejected", async ({
     page,
   }, testInfo) => {
     test.setTimeout(120_000);
@@ -1236,9 +1236,11 @@ test.describe("Agent message submission", () => {
       await queueMessage(page, prompts[1]);
       await page.getByRole("button", { name: "Send queued message now" }).first().click();
       await gate.waitForRequest(1);
-      await page.getByRole("button", { name: "Send queued message now" }).first().click();
+      gate.reject(0);
+      await expectQueuedSendFailuresRestored(page, prompts);
+      await page.getByRole("button", { name: "Send queued message now" }).last().click();
       await gate.waitForRequest(2);
-      await gate.disconnect();
+      gate.reject(1);
       await expectQueuedSendFailuresRestored(page, prompts);
     } finally {
       await agent.cleanup();

--- a/packages/app/e2e/support/helpers/agent-message-gate.ts
+++ b/packages/app/e2e/support/helpers/agent-message-gate.ts
@@ -3,15 +3,16 @@ import { daemonWsRoutePattern } from "./daemon-port";
 
 type WebSocketMessage = string | Buffer;
 
-interface SendAgentMessageRequest {
-  type: "send_agent_message_request";
+interface AgentMessageDispatchRequest {
+  type: "send_agent_message_request" | "queue.agent_message.dispatch.request";
   requestId: string;
   agentId: string;
   /** Absent when the client sends into an idle agent. */
   activeTurnBehavior?: string;
+  queuedMessageId?: string;
 }
 
-function readSendRequest(message: WebSocketMessage): SendAgentMessageRequest | null {
+function readDispatchRequest(message: WebSocketMessage): AgentMessageDispatchRequest | null {
   if (typeof message !== "string") return null;
   try {
     const envelope = JSON.parse(message) as {
@@ -20,18 +21,22 @@ function readSendRequest(message: WebSocketMessage): SendAgentMessageRequest | n
     };
     const request = envelope.type === "session" ? envelope.message : null;
     if (
-      request?.type !== "send_agent_message_request" ||
+      (request?.type !== "send_agent_message_request" &&
+        request?.type !== "queue.agent_message.dispatch.request") ||
       typeof request.requestId !== "string" ||
       typeof request.agentId !== "string"
     ) {
       return null;
     }
     return {
-      type: "send_agent_message_request",
+      type: request.type,
       requestId: request.requestId,
       agentId: request.agentId,
       activeTurnBehavior:
         typeof request.activeTurnBehavior === "string" ? request.activeTurnBehavior : undefined,
+      ...(typeof request.queuedMessageId === "string"
+        ? { queuedMessageId: request.queuedMessageId }
+        : {}),
     };
   } catch {
     return null;
@@ -42,7 +47,7 @@ export async function gateNextAgentMessage(page: Page) {
   let serverSocket: WebSocketRoute | null = null;
   let browserSocket: WebSocketRoute | null = null;
   const heldMessages: Array<WebSocketMessage | null> = [];
-  const requests: SendAgentMessageRequest[] = [];
+  const requests: AgentMessageDispatchRequest[] = [];
   const requestWaiters = new Set<() => void>();
 
   await page.routeWebSocket(daemonWsRoutePattern(), (ws) => {
@@ -51,7 +56,7 @@ export async function gateNextAgentMessage(page: Page) {
     serverSocket = server;
 
     ws.onMessage((message) => {
-      const request = readSendRequest(message);
+      const request = readDispatchRequest(message);
       if (request) {
         heldMessages.push(message);
         requests.push(request);
@@ -65,7 +70,7 @@ export async function gateNextAgentMessage(page: Page) {
     server.onMessage((message) => ws.send(message));
   });
 
-  const waitForRequest = async (count = 1): Promise<SendAgentMessageRequest> => {
+  const waitForRequest = async (count = 1): Promise<AgentMessageDispatchRequest> => {
     while (requests.length < count) {
       await new Promise<void>((resolve) => requestWaiters.add(resolve));
     }
@@ -80,6 +85,33 @@ export async function gateNextAgentMessage(page: Page) {
         throw new Error("No held send-agent-message request to accept");
       }
       serverSocket.send(heldMessage);
+      heldMessages[index] = null;
+    },
+    reject(index = 0) {
+      const request = requests[index];
+      if (
+        !browserSocket ||
+        !request ||
+        request.type !== "queue.agent_message.dispatch.request" ||
+        !request.queuedMessageId
+      ) {
+        throw new Error("No held queued-message dispatch request to reject");
+      }
+      browserSocket.send(
+        JSON.stringify({
+          type: "session",
+          message: {
+            type: "queue.agent_message.dispatch.response",
+            payload: {
+              requestId: request.requestId,
+              agentId: request.agentId,
+              queuedMessageId: request.queuedMessageId,
+              accepted: false,
+              error: "Requested queued-message dispatch rejection",
+            },
+          },
+        }),
+      );
       heldMessages[index] = null;
     },
     async disconnect(): Promise<void> {

--- a/packages/app/src/composer/actions.test.ts
+++ b/packages/app/src/composer/actions.test.ts
@@ -22,6 +22,7 @@ import {
   dispatchComposerAgentMessage,
   editQueuedComposerMessage,
   findForgeItemByOption,
+  getQueuedComposerMessageEditDraft,
   isAttachmentSelectedForForgeItem,
   openComposerAttachment,
   pickAndPersistImages,
@@ -749,6 +750,36 @@ describe("queueComposerMessage", () => {
       { kind: "image", metadata: image },
       review,
     ]);
+  });
+});
+
+describe("getQueuedComposerMessageEditDraft", () => {
+  it("returns null when the message id is missing", () => {
+    const result = getQueuedComposerMessageEditDraft({
+      messages: [{ id: "other", text: "other", attachments: [] }],
+      messageId: "missing",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns the text and only user attachments from a readonly queue mirror", () => {
+    const review = reviewWorkspaceAttachment("Queued snapshot.");
+    const image = imageWithId("img-queued-server-edit");
+    const result = getQueuedComposerMessageEditDraft({
+      messages: [
+        {
+          id: "msg-1",
+          text: "server queued draft",
+          attachments: [{ kind: "image", metadata: image }, review],
+        },
+      ],
+      messageId: "msg-1",
+    });
+
+    expect(result).toEqual({
+      text: "server queued draft",
+      attachments: [{ kind: "image", metadata: image }],
+    });
   });
 });
 

--- a/packages/app/src/composer/actions.ts
+++ b/packages/app/src/composer/actions.ts
@@ -22,6 +22,8 @@ export interface QueuedComposerMessage {
   id: string;
   text: string;
   attachments: ComposerAttachment[];
+  /** False when a daemon wire attachment cannot be safely reconstructed for editing. */
+  canEdit?: boolean;
 }
 
 export interface AttachmentPersister {
@@ -255,11 +257,26 @@ export interface EditQueuedComposerMessageResult {
   attachments: UserComposerAttachment[];
 }
 
+export function getQueuedComposerMessageEditDraft(input: {
+  messages: readonly QueuedComposerMessage[];
+  messageId: string;
+}): EditQueuedComposerMessageResult | null {
+  const item = input.messages.find((q) => q.id === input.messageId);
+  if (!item || item.canEdit === false) return null;
+  return {
+    text: item.text,
+    attachments: userAttachmentsOnly(item.attachments),
+  };
+}
+
 export function editQueuedComposerMessage(
   input: EditQueuedComposerMessageInput,
 ): EditQueuedComposerMessageResult | null {
-  const item = input.queue.read(input.agentId).find((q) => q.id === input.messageId);
-  if (!item) return null;
+  const result = getQueuedComposerMessageEditDraft({
+    messages: input.queue.read(input.agentId),
+    messageId: input.messageId,
+  });
+  if (!result) return null;
   input.queue.write((prev) => {
     const next = new Map(prev);
     next.set(
@@ -268,10 +285,7 @@ export function editQueuedComposerMessage(
     );
     return next;
   });
-  return {
-    text: item.text,
-    attachments: userAttachmentsOnly(item.attachments),
-  };
+  return result;
 }
 
 export interface SendQueuedComposerMessageNowInput {

--- a/packages/app/src/composer/draft-coordinator.test.ts
+++ b/packages/app/src/composer/draft-coordinator.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vitest";
+import type { UserComposerAttachment } from "@/attachments/types";
+import { createComposerDraftCoordinator, type ComposerDraftSnapshot } from "./draft-coordinator";
+
+type ComposerDraftCoordinator = ReturnType<typeof createComposerDraftCoordinator>;
+
+function image(id: string): UserComposerAttachment {
+  return {
+    kind: "image",
+    metadata: {
+      id,
+      mimeType: "image/png",
+      storageType: "web-indexeddb",
+      storageKey: id,
+      createdAt: 1,
+    },
+  };
+}
+
+function file(id: string): UserComposerAttachment {
+  return {
+    kind: "file",
+    attachment: {
+      type: "uploaded_file",
+      id,
+      fileName: `${id}.txt`,
+      mimeType: "text/plain",
+      size: 12,
+      path: `/uploads/${id}.txt`,
+    },
+  };
+}
+
+function syncDraft(
+  coordinator: ComposerDraftCoordinator,
+  ownerId: string,
+  draft: ComposerDraftSnapshot,
+): void {
+  coordinator.syncDraft({ ownerId, draft });
+}
+
+function startAttempt(
+  coordinator: ComposerDraftCoordinator,
+  ownerId: string,
+  draft: ComposerDraftSnapshot,
+): number | null {
+  return coordinator.beginDraftAttempt({ ownerId, draft });
+}
+
+describe("composer draft coordinator", () => {
+  it("accepts the latest synchronously updated draft without a render refresh", () => {
+    const coordinator = createComposerDraftCoordinator();
+    const rendered = { text: "rendered draft", attachments: [] };
+    const latest = { text: "latest draft", attachments: [image("latest")] };
+
+    syncDraft(coordinator, "agent-a", rendered);
+    syncDraft(coordinator, "agent-a", latest);
+
+    expect(startAttempt(coordinator, "agent-a", latest)).toBe(1);
+  });
+
+  it("rejects another draft attempt while one is pending", () => {
+    const coordinator = createComposerDraftCoordinator();
+    const draft = { text: "send once", attachments: [] };
+
+    syncDraft(coordinator, "agent-a", draft);
+    expect(startAttempt(coordinator, "agent-a", draft)).toBe(1);
+    expect(startAttempt(coordinator, "agent-a", draft)).toBeNull();
+    expect(coordinator.getSnapshot("agent-a")?.pending?.kind).toBe("draft");
+  });
+
+  it("keeps typing and attachments entered while an attempt is pending", () => {
+    const coordinator = createComposerDraftCoordinator();
+    const attempted = { text: "attempted", attachments: [image("attempted")] };
+    const current = { text: "typed during send", attachments: [file("current")] };
+
+    syncDraft(coordinator, "agent-a", attempted);
+    startAttempt(coordinator, "agent-a", attempted);
+    syncDraft(coordinator, "agent-a", current);
+
+    expect(coordinator.getSnapshot("agent-a")?.draft).toEqual(current);
+  });
+
+  it("restores a failed draft before current input and preserves duplicate text", () => {
+    const coordinator = createComposerDraftCoordinator();
+    const attemptedShared = image("shared");
+    const attempted = {
+      text: "same text",
+      attachments: [attemptedShared, file("attempted")],
+    };
+    const current = {
+      text: "same text",
+      attachments: [image("shared"), file("current")],
+    };
+
+    syncDraft(coordinator, "agent-a", attempted);
+    startAttempt(coordinator, "agent-a", attempted);
+    syncDraft(coordinator, "agent-a", current);
+
+    expect(
+      coordinator.settleDraftAttempt({
+        ownerId: "agent-a",
+        attemptId: 1,
+        outcome: "failed",
+      }),
+    ).toEqual({
+      text: "same text\n\nsame text",
+      attachments: [attemptedShared, attempted.attachments[1], current.attachments[1]],
+    });
+  });
+
+  it("preserves current input when a draft attempt succeeds", () => {
+    const coordinator = createComposerDraftCoordinator();
+    const attempted = { text: "attempted", attachments: [] };
+    const current = { text: "typed during send", attachments: [file("current")] };
+
+    syncDraft(coordinator, "agent-a", attempted);
+    startAttempt(coordinator, "agent-a", attempted);
+    syncDraft(coordinator, "agent-a", current);
+
+    expect(
+      coordinator.settleDraftAttempt({
+        ownerId: "agent-a",
+        attemptId: 1,
+        outcome: "accepted",
+      }),
+    ).toBeNull();
+    expect(coordinator.getSnapshot("agent-a")?.draft).toEqual(current);
+  });
+
+  it("allows a new draft attempt after either successful or failed settlement", () => {
+    const coordinator = createComposerDraftCoordinator();
+    const repeated = { text: "repeat me", attachments: [] };
+
+    syncDraft(coordinator, "agent-a", repeated);
+    startAttempt(coordinator, "agent-a", repeated);
+    coordinator.settleDraftAttempt({
+      ownerId: "agent-a",
+      attemptId: 1,
+      outcome: "accepted",
+    });
+    syncDraft(coordinator, "agent-a", repeated);
+
+    expect(startAttempt(coordinator, "agent-a", repeated)).toBe(2);
+    coordinator.settleDraftAttempt({
+      ownerId: "agent-a",
+      attemptId: 2,
+      outcome: "failed",
+    });
+    syncDraft(coordinator, "agent-a", repeated);
+
+    expect(startAttempt(coordinator, "agent-a", repeated)).toBe(3);
+  });
+
+  it("merges an edited queued draft before input entered during its cancel request", () => {
+    const coordinator = createComposerDraftCoordinator();
+    const initial = { text: "draft before edit", attachments: [image("shared")] };
+    const current = {
+      text: "draft before edit plus new typing",
+      attachments: [image("shared"), file("current")],
+    };
+    const queued = { text: "older queued message", attachments: [image("queued")] };
+
+    syncDraft(coordinator, "agent-a", initial);
+    coordinator.beginQueuedAction({
+      ownerId: "agent-a",
+      currentDraft: initial,
+      messageId: "queued-1",
+      action: "edit",
+    });
+    syncDraft(coordinator, "agent-a", current);
+
+    expect(
+      coordinator.settleQueuedAction({
+        ownerId: "agent-a",
+        messageId: "queued-1",
+        action: "edit",
+        outcome: { kind: "edited", draft: queued },
+      }),
+    ).toEqual({
+      text: "older queued message\n\ndraft before edit plus new typing",
+      attachments: [...queued.attachments, ...current.attachments],
+    });
+  });
+
+  it("preserves current input when a queued edit fails", () => {
+    const coordinator = createComposerDraftCoordinator();
+    const initial = { text: "draft before edit", attachments: [] };
+    const current = { text: "typed while cancelling", attachments: [file("current")] };
+
+    syncDraft(coordinator, "agent-a", initial);
+    coordinator.beginQueuedAction({
+      ownerId: "agent-a",
+      currentDraft: initial,
+      messageId: "queued-1",
+      action: "edit",
+    });
+    syncDraft(coordinator, "agent-a", current);
+
+    expect(
+      coordinator.settleQueuedAction({
+        ownerId: "agent-a",
+        messageId: "queued-1",
+        action: "edit",
+        outcome: { kind: "failed" },
+      }),
+    ).toBeNull();
+    expect(coordinator.getSnapshot("agent-a")?.draft).toEqual(current);
+  });
+
+  it("settles an attempt only against its originating owner after retargeting", () => {
+    const coordinator = createComposerDraftCoordinator();
+    const attempted = { text: "agent A attempted", attachments: [image("agent-a")] };
+    const agentACurrent = { text: "agent A current", attachments: [file("agent-a-current")] };
+    const agentB = { text: "agent B draft", attachments: [image("agent-b")] };
+
+    syncDraft(coordinator, "agent-a", attempted);
+    startAttempt(coordinator, "agent-a", attempted);
+    syncDraft(coordinator, "agent-a", agentACurrent);
+    syncDraft(coordinator, "agent-b", agentB);
+    expect(
+      coordinator.beginQueuedAction({
+        ownerId: "agent-b",
+        currentDraft: agentB,
+        messageId: "agent-b-queued",
+        action: "send",
+      }),
+    ).toBe(true);
+
+    expect(
+      coordinator.settleDraftAttempt({
+        ownerId: "agent-a",
+        attemptId: 1,
+        outcome: "failed",
+      }),
+    ).toEqual({
+      text: "agent A attempted\n\nagent A current",
+      attachments: [...attempted.attachments, ...agentACurrent.attachments],
+    });
+    expect(coordinator.getSnapshot("agent-b")?.draft).toEqual(agentB);
+    expect(coordinator.getSnapshot("agent-b")?.pending).toEqual({
+      kind: "queued",
+      messageId: "agent-b-queued",
+      action: "send",
+    });
+  });
+
+  it("excludes draft attempts and queued actions while any owner action is pending", () => {
+    const coordinator = createComposerDraftCoordinator();
+    const draft = { text: "current", attachments: [] };
+
+    syncDraft(coordinator, "agent-a", draft);
+    startAttempt(coordinator, "agent-a", draft);
+    expect(
+      coordinator.beginQueuedAction({
+        ownerId: "agent-a",
+        currentDraft: draft,
+        messageId: "queued-1",
+        action: "edit",
+      }),
+    ).toBe(false);
+
+    coordinator.settleDraftAttempt({
+      ownerId: "agent-a",
+      attemptId: 1,
+      outcome: "accepted",
+    });
+    expect(
+      coordinator.beginQueuedAction({
+        ownerId: "agent-a",
+        currentDraft: draft,
+        messageId: "queued-1",
+        action: "edit",
+      }),
+    ).toBe(true);
+    expect(startAttempt(coordinator, "agent-a", draft)).toBeNull();
+    expect(
+      coordinator.beginQueuedAction({
+        ownerId: "agent-a",
+        currentDraft: draft,
+        messageId: "queued-2",
+        action: "send",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/composer/draft-coordinator.ts
+++ b/packages/app/src/composer/draft-coordinator.ts
@@ -1,0 +1,277 @@
+import type { UserComposerAttachment } from "@/attachments/types";
+import { getWorkspaceFileAttachmentKey } from "@/attachments/workspace-file";
+
+export interface ComposerDraftSnapshot {
+  text: string;
+  attachments: UserComposerAttachment[];
+}
+
+export type QueuedComposerActionKind = "edit" | "send";
+
+export interface PendingQueuedComposerAction {
+  messageId: string;
+  action: QueuedComposerActionKind;
+}
+
+export type QueuedComposerActionOutcome =
+  | { kind: "edited"; draft: ComposerDraftSnapshot }
+  | { kind: "sent" }
+  | { kind: "failed" };
+
+interface DraftAttempt {
+  kind: "draft";
+  id: number;
+  draft: ComposerDraftSnapshot;
+}
+
+interface QueuedAction extends PendingQueuedComposerAction {
+  kind: "queued";
+}
+
+type PendingAction = DraftAttempt | QueuedAction | null;
+
+interface DraftOwner {
+  draft: ComposerDraftSnapshot;
+  pending: PendingAction;
+  errorMessage: string | null;
+}
+
+interface SyncDraftInput {
+  ownerId: string;
+  draft: ComposerDraftSnapshot;
+}
+
+interface SettleDraftAttemptInput {
+  ownerId: string;
+  attemptId: number;
+  outcome: "accepted" | "failed";
+}
+
+interface BeginQueuedActionInput {
+  ownerId: string;
+  currentDraft: ComposerDraftSnapshot;
+  messageId: string;
+  action: QueuedComposerActionKind;
+}
+
+interface SettleQueuedActionInput {
+  ownerId: string;
+  messageId: string;
+  action: QueuedComposerActionKind;
+  outcome: QueuedComposerActionOutcome;
+}
+
+interface ComposerDraftCoordinator {
+  getSnapshot: (ownerId: string) => DraftOwner | undefined;
+  subscribe: (listener: () => void) => () => void;
+  syncDraft: (input: SyncDraftInput) => void;
+  beginDraftAttempt: (input: SyncDraftInput) => number | null;
+  settleDraftAttempt: (input: SettleDraftAttemptInput) => ComposerDraftSnapshot | null;
+  beginQueuedAction: (input: BeginQueuedActionInput) => boolean;
+  settleQueuedAction: (input: SettleQueuedActionInput) => ComposerDraftSnapshot | null;
+  setError: (ownerId: string, message: string | null) => void;
+}
+
+const EMPTY_DRAFT: ComposerDraftSnapshot = { text: "", attachments: [] };
+
+function copyDraft(draft: ComposerDraftSnapshot): ComposerDraftSnapshot {
+  return { text: draft.text, attachments: [...draft.attachments] };
+}
+
+function createOwner(draft: ComposerDraftSnapshot): DraftOwner {
+  return {
+    draft: copyDraft(draft),
+    pending: null,
+    errorMessage: null,
+  };
+}
+
+function getAttachmentIdentity(attachment: UserComposerAttachment): string {
+  switch (attachment.kind) {
+    case "image":
+      return `image:${attachment.metadata.id}`;
+    case "file":
+      return `file:${attachment.attachment.id}`;
+    case "workspace_file":
+      return `workspace-file:${getWorkspaceFileAttachmentKey(attachment)}`;
+    case "plugin_resource":
+      return `plugin:${attachment.pluginId}:${attachment.sourceId}:${attachment.item.id}`;
+    case "forge_issue":
+    case "forge_change_request":
+    case "github_issue":
+    case "github_pr":
+      return `forge:${attachment.item.kind}:${attachment.item.url}`;
+  }
+}
+
+function haveSameAttachmentIds(
+  left: readonly UserComposerAttachment[],
+  right: readonly UserComposerAttachment[],
+): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((attachment, index) => {
+    const candidate = right[index];
+    return candidate
+      ? getAttachmentIdentity(attachment) === getAttachmentIdentity(candidate)
+      : false;
+  });
+}
+
+function areDraftsEqual(left: ComposerDraftSnapshot, right: ComposerDraftSnapshot): boolean {
+  if (left.text !== right.text || left.attachments.length !== right.attachments.length)
+    return false;
+  return left.attachments.every((attachment, index) => attachment === right.attachments[index]);
+}
+
+function isCurrentDraft(current: ComposerDraftSnapshot, attempted: ComposerDraftSnapshot): boolean {
+  return (
+    current.text.trim() === attempted.text &&
+    haveSameAttachmentIds(current.attachments, attempted.attachments)
+  );
+}
+
+function mergeDrafts(
+  older: ComposerDraftSnapshot,
+  current: ComposerDraftSnapshot,
+): ComposerDraftSnapshot {
+  const text = [older.text, current.text].filter((part) => part.length > 0).join("\n\n");
+  const seen = new Set<string>();
+  const attachments: UserComposerAttachment[] = [];
+  for (const attachment of [...older.attachments, ...current.attachments]) {
+    const identity = getAttachmentIdentity(attachment);
+    if (seen.has(identity)) continue;
+    seen.add(identity);
+    attachments.push(attachment);
+  }
+  return { text, attachments };
+}
+
+export function createComposerDraftCoordinator(): ComposerDraftCoordinator {
+  const owners = new Map<string, DraftOwner>();
+  const listeners = new Set<() => void>();
+  let nextAttemptId = 1;
+
+  function commit(ownerId: string, owner: DraftOwner): void {
+    owners.set(ownerId, owner);
+    for (const listener of listeners) listener();
+  }
+
+  function getSnapshot(ownerId: string): DraftOwner | undefined {
+    return owners.get(ownerId);
+  }
+
+  function subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return function unsubscribe() {
+      listeners.delete(listener);
+    };
+  }
+
+  function syncDraft(input: SyncDraftInput): void {
+    const owner = owners.get(input.ownerId);
+    if (!owner) {
+      commit(input.ownerId, createOwner(input.draft));
+      return;
+    }
+    if (areDraftsEqual(owner.draft, input.draft)) return;
+    commit(input.ownerId, {
+      ...owner,
+      draft: copyDraft(input.draft),
+    });
+  }
+
+  function beginDraftAttempt(input: SyncDraftInput): number | null {
+    const owner = owners.get(input.ownerId) ?? createOwner(input.draft);
+    if (owner.pending || !isCurrentDraft(owner.draft, input.draft)) return null;
+
+    const attempt: DraftAttempt = {
+      kind: "draft",
+      id: nextAttemptId,
+      draft: copyDraft(input.draft),
+    };
+    nextAttemptId += 1;
+    commit(input.ownerId, {
+      draft: copyDraft(EMPTY_DRAFT),
+      pending: attempt,
+      errorMessage: null,
+    });
+    return attempt.id;
+  }
+
+  function settleDraftAttempt(input: SettleDraftAttemptInput): ComposerDraftSnapshot | null {
+    const owner = owners.get(input.ownerId);
+    if (!owner || owner.pending?.kind !== "draft" || owner.pending.id !== input.attemptId) {
+      return null;
+    }
+
+    let draft = owner.draft;
+    if (input.outcome === "failed") {
+      draft = mergeDrafts(owner.pending.draft, owner.draft);
+    }
+    commit(input.ownerId, {
+      ...owner,
+      draft,
+      pending: null,
+    });
+    if (input.outcome === "failed") return draft;
+    return null;
+  }
+
+  function beginQueuedAction(input: BeginQueuedActionInput): boolean {
+    const owner = owners.get(input.ownerId) ?? createOwner(input.currentDraft);
+    if (owner.pending) return false;
+    const action: QueuedAction = {
+      kind: "queued",
+      messageId: input.messageId,
+      action: input.action,
+    };
+    commit(input.ownerId, {
+      ...owner,
+      pending: action,
+      errorMessage: null,
+    });
+    return true;
+  }
+
+  function settleQueuedAction(input: SettleQueuedActionInput): ComposerDraftSnapshot | null {
+    const owner = owners.get(input.ownerId);
+    const pending = owner?.pending;
+    const matches =
+      pending?.kind === "queued" &&
+      pending.messageId === input.messageId &&
+      pending.action === input.action;
+    if (!owner || !matches) return null;
+
+    let draft = owner.draft;
+    if (input.outcome.kind === "edited") {
+      draft = mergeDrafts(input.outcome.draft, owner.draft);
+    }
+    commit(input.ownerId, {
+      ...owner,
+      draft,
+      pending: null,
+    });
+    if (input.outcome.kind === "edited") return draft;
+    return null;
+  }
+
+  function setError(ownerId: string, message: string | null): void {
+    const owner = owners.get(ownerId) ?? createOwner(EMPTY_DRAFT);
+    if (owner.errorMessage === message) return;
+    commit(ownerId, {
+      ...owner,
+      errorMessage: message,
+    });
+  }
+
+  return {
+    getSnapshot,
+    subscribe,
+    syncDraft,
+    beginDraftAttempt,
+    settleDraftAttempt,
+    beginQueuedAction,
+    settleQueuedAction,
+    setError,
+  };
+}

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -112,6 +112,7 @@ import type { KeyboardActionDefinition } from "@/keyboard/keyboard-action-dispat
 import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
 import { submitAgentInput } from "@/composer/submit";
 import { createMessageSubmissionWriter } from "@/composer/submission/writer";
+import { createUserMessage, generateMessageId } from "@/types/stream";
 import { ComposerKeyboardScopeProvider, useComposerKeyboardScope } from "@/composer/keyboard-scope";
 import { useAppSettings } from "@/hooks/use-settings";
 import { RenderProfile } from "@/utils/render-profiler";
@@ -2065,10 +2066,34 @@ function ComposerContentImpl({
     async (id: string) => {
       if (serverQueuesAgentMessages) {
         if (!client || !beginQueuedAction(id, "send")) return;
+        const queued = queuedMessages.find((message) => message.id === id);
+        if (!queued) {
+          settleQueuedAction(id, "send", { kind: "failed" });
+          return;
+        }
+        const wirePayload = splitComposerAttachmentsForSubmit(queued.attachments, {
+          format: resolveComposerAttachmentSubmitFormat({
+            supportsForgeAttachments: supportsForgeSearch,
+          }),
+        });
+        const clientMessageId = generateMessageId();
+        const submission = createMessageSubmissionWriter(serverId);
+        submission.begin(
+          agentId,
+          createUserMessage({
+            clientMessageId,
+            text: queued.text,
+            timestamp: new Date(),
+            images: wirePayload.images,
+            attachments: wirePayload.attachments,
+          }),
+        );
         try {
           await client.dispatchQueuedAgentMessage(agentId, id);
+          submission.accept(agentId, clientMessageId);
           settleQueuedAction(id, "send", { kind: "sent" });
         } catch (error) {
+          submission.reject(agentId, clientMessageId);
           settleQueuedAction(id, "send", { kind: "failed" });
           setSendError(error instanceof Error ? error.message : t("composer.errors.failedToSend"));
         }
@@ -2105,11 +2130,14 @@ function ComposerContentImpl({
       agentId,
       beginQueuedAction,
       client,
+      queuedMessages,
       queueWriter,
+      serverId,
       serverQueuesAgentMessages,
       setSendError,
       settleQueuedAction,
       submitMessage,
+      supportsForgeSearch,
       t,
     ],
   );

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -112,7 +112,7 @@ import type { KeyboardActionDefinition } from "@/keyboard/keyboard-action-dispat
 import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
 import { submitAgentInput } from "@/composer/submit";
 import { createMessageSubmissionWriter } from "@/composer/submission/writer";
-import { createUserMessage, generateMessageId } from "@/types/stream";
+import { createUserMessage } from "@/types/stream";
 import { ComposerKeyboardScopeProvider, useComposerKeyboardScope } from "@/composer/keyboard-scope";
 import { useAppSettings } from "@/hooks/use-settings";
 import { RenderProfile } from "@/utils/render-profiler";
@@ -2076,7 +2076,7 @@ function ComposerContentImpl({
             supportsForgeAttachments: supportsForgeSearch,
           }),
         });
-        const clientMessageId = generateMessageId();
+        const clientMessageId = id;
         const submission = createMessageSubmissionWriter(serverId);
         submission.begin(
           agentId,

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -13,6 +13,7 @@ import {
   useRef,
   useCallback,
   useMemo,
+  useSyncExternalStore,
   memo,
   type ReactElement,
   type ReactNode,
@@ -63,6 +64,7 @@ import {
   dispatchComposerAgentMessage,
   editQueuedComposerMessage,
   findForgeItemByOption,
+  getQueuedComposerMessageEditDraft,
   isAttachmentSelectedForForgeItem,
   openComposerAttachment,
   pickAndPersistImages,
@@ -75,6 +77,13 @@ import {
   type QueueWriter,
   type QueuedComposerMessage,
 } from "@/composer/actions";
+import {
+  createComposerDraftCoordinator,
+  type ComposerDraftSnapshot,
+  type PendingQueuedComposerAction,
+  type QueuedComposerActionKind,
+  type QueuedComposerActionOutcome,
+} from "@/composer/draft-coordinator";
 import { useVoiceOptional } from "@/contexts/voice-context";
 import { useToast } from "@/contexts/toast-context";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -121,6 +130,7 @@ import { resolveComposerAttachmentSubmitFormat } from "@/composer/attachments/su
 import { composerWorkspaceAttachment } from "@/composer/attachments/workspace";
 import { useWorkspaceAttachmentsForScopes } from "@/attachments/workspace-attachments-store";
 import { droppedItemsToPickedFiles } from "@/composer/attachments/drop";
+import { splitComposerAttachmentsForSubmit } from "@/composer/attachments/submit";
 import { getFileTypeLabel } from "@/attachments/file-types";
 import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/combobox";
 import { AttachmentLabel, AttachmentPill, AttachmentThumbnail } from "@/components/attachment-pill";
@@ -137,6 +147,7 @@ import { readClipboardImage } from "./clipboard-image";
 import { normalizeNativePastedImages, type NativePastedFile } from "./native-pasted-image";
 import { PluginResourceAttachmentPill, usePluginAttachmentPicker } from "@/plugins";
 import { resolveClientSlashCommand, type ClientSlashCommand } from "@/client-slash-commands";
+import { buildDraftStoreKey } from "@/stores/draft-keys";
 import {
   appendWorkspaceFileAttachment,
   getWorkspaceFileAttachmentKey,
@@ -146,6 +157,7 @@ import {
   resolveWorkspaceFileDrop,
   type WorkspaceFileDragPayload,
 } from "@/attachments/workspace-file-drag";
+import { supportsAgentMessageQueue } from "@/utils/server-info-capabilities";
 
 const composerImageAttachmentPersister: Pick<
   AttachmentPersister,
@@ -331,6 +343,7 @@ interface RenderAttachmentTrayArgs {
   handleRemoveAttachment: (index: number) => void;
   labels: {
     openImage: string;
+    openFile: string;
     removeImage: string;
     removeFile: string;
     openGithub: (kind: string, numberLabel: string) => string;
@@ -367,13 +380,22 @@ interface RenderQueueTrackArgs {
   queuedMessages: readonly QueuedMessage[];
   handleEditQueuedMessage: (id: string) => void;
   handleSendQueuedNow: (id: string) => Promise<void>;
+  actionsDisabled: boolean;
+  pendingAction: PendingQueuedComposerAction | null;
   editLabel: string;
   sendNowLabel: string;
 }
 
 function renderQueueTrack(args: RenderQueueTrackArgs): ReactElement | null {
-  const { queuedMessages, handleEditQueuedMessage, handleSendQueuedNow, editLabel, sendNowLabel } =
-    args;
+  const {
+    queuedMessages,
+    handleEditQueuedMessage,
+    handleSendQueuedNow,
+    actionsDisabled,
+    pendingAction,
+    editLabel,
+    sendNowLabel,
+  } = args;
   if (queuedMessages.length === 0) return null;
   return (
     <View style={styles.queueTrack}>
@@ -383,6 +405,8 @@ function renderQueueTrack(args: RenderQueueTrackArgs): ReactElement | null {
           item={item}
           onEdit={handleEditQueuedMessage}
           onSendNow={handleSendQueuedNow}
+          actionsDisabled={actionsDisabled}
+          pendingAction={pendingAction}
           editLabel={editLabel}
           sendNowLabel={sendNowLabel}
         />
@@ -655,6 +679,8 @@ interface QueuedMessageRowProps {
   item: QueuedMessage;
   onEdit: (id: string) => void;
   onSendNow: (id: string) => void;
+  actionsDisabled: boolean;
+  pendingAction: PendingQueuedComposerAction | null;
   editLabel: string;
   sendNowLabel: string;
 }
@@ -663,6 +689,8 @@ function QueuedMessageRow({
   item,
   onEdit,
   onSendNow,
+  actionsDisabled,
+  pendingAction,
   editLabel,
   sendNowLabel,
 }: QueuedMessageRowProps) {
@@ -672,27 +700,42 @@ function QueuedMessageRow({
   const handleSendNow = useCallback(() => {
     onSendNow(item.id);
   }, [onSendNow, item.id]);
+  const pendingEdit = pendingAction?.messageId === item.id && pendingAction.action === "edit";
+  const pendingSend = pendingAction?.messageId === item.id && pendingAction.action === "send";
+  const disabledStyle = actionsDisabled ? styles.buttonDisabled : undefined;
   return (
     <View style={styles.queueItem}>
       <Text style={styles.queueText} numberOfLines={2} ellipsizeMode="tail">
         {item.text}
       </Text>
       <View style={styles.queueActions}>
-        <Pressable
-          onPress={handleEdit}
-          style={styles.queueActionButton}
-          accessibilityLabel={editLabel}
-          accessibilityRole="button"
-        >
-          <ThemedPencil size={ICON_SIZE.sm} uniProps={iconForegroundMapping} />
-        </Pressable>
+        {item.canEdit !== false ? (
+          <Pressable
+            onPress={handleEdit}
+            disabled={actionsDisabled}
+            style={[styles.queueActionButton, disabledStyle]}
+            accessibilityLabel={editLabel}
+            accessibilityRole="button"
+          >
+            {pendingEdit ? (
+              <ThemedLoadingSpinner size="small" uniProps={iconForegroundMutedMapping} />
+            ) : (
+              <ThemedPencil size={ICON_SIZE.sm} uniProps={iconForegroundMapping} />
+            )}
+          </Pressable>
+        ) : null}
         <Pressable
           onPress={handleSendNow}
-          style={[styles.queueActionButton, styles.queueSendButton]}
+          disabled={actionsDisabled}
+          style={[styles.queueActionButton, styles.queueSendButton, disabledStyle]}
           accessibilityLabel={sendNowLabel}
           accessibilityRole="button"
         >
-          <ThemedArrowUp size={ICON_SIZE.sm} uniProps={iconAccentForegroundMapping} />
+          {pendingSend ? (
+            <ThemedLoadingSpinner size="small" uniProps={iconAccentForegroundMapping} />
+          ) : (
+            <ThemedArrowUp size={ICON_SIZE.sm} uniProps={iconAccentForegroundMapping} />
+          )}
         </Pressable>
       </View>
     </View>
@@ -1205,6 +1248,9 @@ function ComposerContentImpl({
     state.sessions[serverId]?.queuedMessages?.get(agentId),
   );
   const queuedMessages = queuedMessagesRaw ?? EMPTY_ARRAY;
+  const serverQueuesAgentMessages = useSessionStore((state) =>
+    supportsAgentMessageQueue(state.sessions[serverId]?.serverInfo),
+  );
 
   const setQueuedMessages = useSessionStore((state) => state.setQueuedMessages);
 
@@ -1214,7 +1260,34 @@ function ComposerContentImpl({
   const isDesktopLayout = resolveIsDesktopWebBreakpoint(isCompactLayout);
   const messagePlaceholder = resolveMessagePlaceholder(inputMode, isDesktopLayout, t, placeholder);
   const userInput = value;
-  const setUserInput = onChangeText;
+  const draftOwnerId = buildDraftStoreKey({ serverId, agentId });
+  const [draftCoordinator] = useState(createComposerDraftCoordinator);
+  const getDraftOwnerSnapshot = useCallback(
+    () => draftCoordinator.getSnapshot(draftOwnerId),
+    [draftCoordinator, draftOwnerId],
+  );
+  const draftCoordinatorState = useSyncExternalStore(
+    draftCoordinator.subscribe,
+    getDraftOwnerSnapshot,
+    getDraftOwnerSnapshot,
+  );
+  const getCurrentDraft = useCallback((): ComposerDraftSnapshot => {
+    return draftCoordinator.getSnapshot(draftOwnerId)?.draft ?? { text: userInput, attachments };
+  }, [attachments, draftCoordinator, draftOwnerId, userInput]);
+  const setUserInput = useCallback(
+    (text: string) => {
+      const current = getCurrentDraft();
+      draftCoordinator.syncDraft({
+        ownerId: draftOwnerId,
+        draft: { ...current, text },
+      });
+      if (text.length > 0) {
+        draftCoordinator.setError(draftOwnerId, null);
+      }
+      onChangeText(text);
+    },
+    [draftCoordinator, draftOwnerId, getCurrentDraft, onChangeText],
+  );
   const workspaceAttachments = useWorkspaceAttachmentsForScopes(attachmentScopeKeys);
   const {
     selectedAttachments,
@@ -1230,7 +1303,25 @@ function ComposerContentImpl({
     workspaceAttachments,
     onOpenWorkspaceAttachment,
   });
-  const setSelectedAttachments = onChangeAttachments;
+  const setSelectedAttachments = useCallback(
+    (updater: AttachmentListUpdater) => {
+      const current = getCurrentDraft();
+      const nextAttachments =
+        typeof updater === "function" ? updater(current.attachments) : updater;
+      draftCoordinator.syncDraft({
+        ownerId: draftOwnerId,
+        draft: { ...current, attachments: nextAttachments },
+      });
+      onChangeAttachments(nextAttachments);
+    },
+    [draftCoordinator, draftOwnerId, getCurrentDraft, onChangeAttachments],
+  );
+  useEffect(() => {
+    draftCoordinator.syncDraft({
+      ownerId: draftOwnerId,
+      draft: { text: userInput, attachments },
+    });
+  }, [attachments, draftCoordinator, draftOwnerId, userInput]);
   const checkoutStatusQuery = useCheckoutStatusQuery({ serverId, cwd });
   const supportsForgeSearch = useSessionStore(
     (state) => state.sessions[serverId]?.serverInfo?.features?.forgeSearch === true,
@@ -1253,7 +1344,13 @@ function ComposerContentImpl({
   const [isProcessing, setIsProcessing] = useState(false);
   const [isUploadingFile, setIsUploadingFile] = useState(false);
   const [pendingNativeImagePastes, setPendingNativeImagePastes] = useState(0);
-  const [sendError, setSendError] = useState<string | null>(null);
+  const sendError = draftCoordinatorState?.errorMessage ?? null;
+  const setSendError = useCallback(
+    (message: string | null) => {
+      draftCoordinator.setError(draftOwnerId, message);
+    },
+    [draftCoordinator, draftOwnerId],
+  );
   const [isMessageInputFocused, setIsMessageInputFocused] = useState(false);
   const [isGithubPickerOpen, setIsGithubPickerOpen] = useState(false);
   const [githubSearchQuery, setGithubSearchQuery] = useState("");
@@ -1314,6 +1411,7 @@ function ComposerContentImpl({
       clearDraft,
       onClientSlashCommand,
       resetSuppression,
+      setSendError,
       setSelectedAttachments,
       replaceUserInput,
     ],
@@ -1341,7 +1439,6 @@ function ComposerContentImpl({
     [selectAutocompleteOption],
   );
 
-  // Clear send error when user edits the input
   useEffect(() => {
     setCursorIndex((current) => Math.min(current, userInput.length));
   }, [userInput.length]);
@@ -1493,6 +1590,44 @@ function ComposerContentImpl({
   );
   const hasAgent = agentState.status !== null;
 
+  const applyDraftReplacement = useCallback(
+    (draft: ComposerDraftSnapshot | null) => {
+      if (!draft) return;
+      setUserInput(draft.text);
+      setSelectedAttachments(draft.attachments);
+    },
+    [setSelectedAttachments, setUserInput],
+  );
+
+  const beginDraftAttempt = useCallback(
+    (text: string, outgoingAttachments: ComposerAttachment[]): number | null => {
+      const draft = {
+        text,
+        attachments: composerWorkspaceAttachment.userAttachmentsOnly(outgoingAttachments),
+      };
+      const attemptId = draftCoordinator.beginDraftAttempt({
+        ownerId: draftOwnerId,
+        draft,
+      });
+      if (attemptId === null) return null;
+      clearDraft("sent");
+      return attemptId;
+    },
+    [clearDraft, draftCoordinator, draftOwnerId],
+  );
+
+  const settleDraftAttempt = useCallback(
+    (attemptId: number, outcome: "accepted" | "failed") => {
+      const draft = draftCoordinator.settleDraftAttempt({
+        ownerId: draftOwnerId,
+        attemptId,
+        outcome,
+      });
+      applyDraftReplacement(draft);
+    },
+    [applyDraftReplacement, draftCoordinator, draftOwnerId],
+  );
+
   const queueWriter = useMemo<QueueWriter>(
     () => ({
       read: (id) => useSessionStore.getState().sessions[serverId]?.queuedMessages?.get(id) ?? [],
@@ -1502,10 +1637,44 @@ function ComposerContentImpl({
   );
 
   const queueMessage = useCallback(
-    (queuedMessage: string, queuedAttachments: ComposerAttachment[]) => {
+    async (queuedMessage: string, queuedAttachments: ComposerAttachment[]) => {
+      const trimmed = queuedMessage.trim();
+      if (!trimmed && queuedAttachments.length === 0) {
+        return;
+      }
+
+      if (serverQueuesAgentMessages) {
+        if (!client) {
+          throw new Error(t("workspace.terminal.hostDisconnected"));
+        }
+        const attemptId = beginDraftAttempt(trimmed, queuedAttachments);
+        if (attemptId === null) {
+          return;
+        }
+        resetSuppression();
+        try {
+          const wirePayload = splitComposerAttachmentsForSubmit(queuedAttachments, {
+            format: resolveComposerAttachmentSubmitFormat({
+              supportsForgeAttachments: supportsForgeSearch,
+            }),
+          });
+          const imagesData = await encodeImages(wirePayload.images);
+          await client.queueAgentMessage(agentId, trimmed, {
+            ...(imagesData && imagesData.length > 0 ? { images: imagesData } : {}),
+            ...(wirePayload.attachments.length > 0 ? { attachments: wirePayload.attachments } : {}),
+          });
+        } catch (error) {
+          settleDraftAttempt(attemptId, "failed");
+          throw error;
+        }
+        settleDraftAttempt(attemptId, "accepted");
+        clearSentAttachments(queuedAttachments);
+        return;
+      }
+
       const result = queueComposerMessage({
         agentId,
-        text: queuedMessage,
+        text: trimmed,
         attachments: queuedAttachments,
         queue: queueWriter,
       });
@@ -1518,11 +1687,17 @@ function ComposerContentImpl({
     },
     [
       agentId,
+      beginDraftAttempt,
       clearSentAttachments,
+      client,
       queueWriter,
       resetSuppression,
+      serverQueuesAgentMessages,
+      settleDraftAttempt,
       setSelectedAttachments,
       replaceUserInput,
+      supportsForgeSearch,
+      t,
     ],
   );
 
@@ -1543,20 +1718,17 @@ function ComposerContentImpl({
         // Parent-managed submits are still valid submit paths even when the
         // transport is disconnected, because the parent decides the failure mode.
         canSubmit: Boolean(sendAgentMessageRef.current || onSubmitMessageRef.current),
-        queueMessage: ({ message: queuedText, attachments: queuedAttachments }) => {
-          queueMessage(queuedText, queuedAttachments);
-        },
+        queueMessage: ({ message: queuedText, attachments: queuedAttachments }) =>
+          queueMessage(queuedText, queuedAttachments),
         submitMessage: async ({ message: submitText, attachments: submitAttachments }) => {
           if (submitBehavior !== "preserve-and-lock") {
             beginSubmit(submitAttachments);
           }
           await submitMessage(submitText, submitAttachments);
         },
-        clearDraft,
-        setUserInput: replaceUserInput,
-        setAttachments: (nextAttachments) => {
-          setSelectedAttachments(composerWorkspaceAttachment.userAttachmentsOnly(nextAttachments));
-        },
+        beginDraftAttempt: ({ message: submitText, attachments: submitAttachments }) =>
+          beginDraftAttempt(submitText, submitAttachments),
+        settleDraftAttempt: ({ attemptId, outcome }) => settleDraftAttempt(attemptId, outcome),
         setSendError,
         setIsProcessing,
         onSubmitError: (error) => {
@@ -1572,13 +1744,13 @@ function ComposerContentImpl({
     [
       allowEmptySubmit,
       beginSubmit,
-      clearDraft,
+      beginDraftAttempt,
       completeSubmit,
       hasExternalContent,
       isAgentRunning,
       queueMessage,
-      setSelectedAttachments,
-      replaceUserInput,
+      setSendError,
+      settleDraftAttempt,
       submitBehavior,
       submitMessage,
       t,
@@ -1587,7 +1759,7 @@ function ComposerContentImpl({
 
   const handleSubmit = useCallback(
     (payload: MessagePayload) => {
-      const outgoingAttachments = buildOutgoingAttachments(attachments);
+      const outgoingAttachments = buildOutgoingAttachments(getCurrentDraft().attachments);
       const clientSlashCommand = resolveClientSlashCommand({
         text: payload.text,
         hasAttachments: outgoingAttachments.length > 0,
@@ -1602,9 +1774,9 @@ function ComposerContentImpl({
       void sendMessageWithContent(payload.text, outgoingAttachments, payload.forceSend);
     },
     [
-      attachments,
       blurOnSubmit,
       buildOutgoingAttachments,
+      getCurrentDraft,
       runClientSlashCommand,
       sendMessageWithContent,
     ],
@@ -1817,23 +1989,98 @@ function ComposerContentImpl({
     });
   }, [agentId, hasAgent, isConnected, serverId, voice]);
 
+  const beginQueuedAction = useCallback(
+    (messageId: string, action: QueuedComposerActionKind): boolean => {
+      return draftCoordinator.beginQueuedAction({
+        ownerId: draftOwnerId,
+        currentDraft: getCurrentDraft(),
+        messageId,
+        action,
+      });
+    },
+    [draftCoordinator, draftOwnerId, getCurrentDraft],
+  );
+
+  const settleQueuedAction = useCallback(
+    (messageId: string, action: QueuedComposerActionKind, outcome: QueuedComposerActionOutcome) => {
+      const draft = draftCoordinator.settleQueuedAction({
+        ownerId: draftOwnerId,
+        messageId,
+        action,
+        outcome,
+      });
+      applyDraftReplacement(draft);
+    },
+    [applyDraftReplacement, draftCoordinator, draftOwnerId],
+  );
+
   const handleEditQueuedMessage = useCallback(
     (id: string) => {
+      const messages = serverQueuesAgentMessages ? queuedMessages : queueWriter.read(agentId);
+      const draft = getQueuedComposerMessageEditDraft({ messages, messageId: id });
+      if (!draft || (serverQueuesAgentMessages && !client) || !beginQueuedAction(id, "edit")) {
+        return;
+      }
+
+      if (serverQueuesAgentMessages && client) {
+        void (async () => {
+          try {
+            await client.cancelQueuedAgentMessage(agentId, id);
+            settleQueuedAction(id, "edit", { kind: "edited", draft });
+          } catch (error) {
+            settleQueuedAction(id, "edit", { kind: "failed" });
+            console.error("[Composer] Failed to cancel queued message for edit:", error);
+            setSendError(
+              error instanceof Error ? error.message : t("composer.errors.failedToSend"),
+            );
+          }
+        })();
+        return;
+      }
+
       const result = editQueuedComposerMessage({
         agentId,
         messageId: id,
         queue: queueWriter,
       });
-      if (!result) return;
-      replaceUserInput(result.text);
-      setSelectedAttachments(result.attachments);
+      const outcome: QueuedComposerActionOutcome = result
+        ? { kind: "edited", draft: result }
+        : { kind: "failed" };
+      settleQueuedAction(id, "edit", outcome);
     },
-    [agentId, queueWriter, replaceUserInput, setSelectedAttachments],
+    [
+      agentId,
+      beginQueuedAction,
+      client,
+      queuedMessages,
+      queueWriter,
+      serverQueuesAgentMessages,
+      setSendError,
+      settleQueuedAction,
+      t,
+    ],
   );
 
   const handleSendQueuedNow = useCallback(
     async (id: string) => {
-      if (!sendAgentMessageRef.current && !onSubmitMessageRef.current) return;
+      if (serverQueuesAgentMessages) {
+        if (!client || !beginQueuedAction(id, "send")) return;
+        try {
+          await client.dispatchQueuedAgentMessage(agentId, id);
+          settleQueuedAction(id, "send", { kind: "sent" });
+        } catch (error) {
+          settleQueuedAction(id, "send", { kind: "failed" });
+          setSendError(error instanceof Error ? error.message : t("composer.errors.failedToSend"));
+        }
+        return;
+      }
+
+      if (
+        (!sendAgentMessageRef.current && !onSubmitMessageRef.current) ||
+        !beginQueuedAction(id, "send")
+      ) {
+        return;
+      }
       // Reuse the regular send path; server-side send atomically interrupts any active run.
       const result = await sendQueuedComposerMessageNow({
         agentId,
@@ -1844,15 +2091,32 @@ function ComposerContentImpl({
         failedToSendMessage: t("composer.errors.failedToSend"),
       });
       if (result.status === "failed") {
+        settleQueuedAction(id, "send", { kind: "failed" });
         setSendError(result.errorMessage);
+        return;
       }
+      let outcome: QueuedComposerActionOutcome = { kind: "failed" };
+      if (result.status === "submitted") {
+        outcome = { kind: "sent" };
+      }
+      settleQueuedAction(id, "send", outcome);
     },
-    [agentId, queueWriter, submitMessage, t],
+    [
+      agentId,
+      beginQueuedAction,
+      client,
+      queueWriter,
+      serverQueuesAgentMessages,
+      setSendError,
+      settleQueuedAction,
+      submitMessage,
+      t,
+    ],
   );
 
   const handleQueue = useCallback(
     (payload: MessagePayload) => {
-      const outgoingAttachments = buildOutgoingAttachments(attachments);
+      const outgoingAttachments = buildOutgoingAttachments(getCurrentDraft().attachments);
       const clientSlashCommand = resolveClientSlashCommand({
         text: payload.text,
         hasAttachments: outgoingAttachments.length > 0,
@@ -1860,12 +2124,26 @@ function ComposerContentImpl({
       if (clientSlashCommand && runClientSlashCommand(clientSlashCommand)) {
         return;
       }
-      queueMessage(payload.text, outgoingAttachments);
+      void queueMessage(payload.text, outgoingAttachments).catch((error) => {
+        console.error("[Composer] Failed to queue message:", error);
+        setSendError(error instanceof Error ? error.message : t("composer.errors.failedToSend"));
+      });
     },
-    [attachments, buildOutgoingAttachments, queueMessage, runClientSlashCommand],
+    [
+      buildOutgoingAttachments,
+      getCurrentDraft,
+      queueMessage,
+      runClientSlashCommand,
+      setSendError,
+      t,
+    ],
   );
 
   const hasSendableContent = userInput.trim().length > 0 || selectedAttachments.length > 0;
+  const pendingAction = draftCoordinatorState?.pending ?? null;
+  const pendingQueuedAction = pendingAction?.kind === "queued" ? pendingAction : null;
+  const isDraftAttemptPending = pendingAction?.kind === "draft";
+  const queuedActionsDisabled = pendingQueuedAction !== null || isDraftAttemptPending;
 
   // Handle keyboard navigation for command autocomplete.
   const handleCommandKeyPress = useCallback(
@@ -2192,6 +2470,7 @@ function ComposerContentImpl({
         handleRemoveAttachment,
         labels: {
           openImage: t("composer.attachments.openImage"),
+          openFile: t("message.actions.openFile"),
           removeImage: t("composer.attachments.removeImage"),
           removeFile: t("composer.attachments.removeFile"),
           openGithub: (kind: string, numberLabel: string) =>
@@ -2209,22 +2488,37 @@ function ComposerContentImpl({
         queuedMessages,
         handleEditQueuedMessage,
         handleSendQueuedNow,
+        actionsDisabled: queuedActionsDisabled,
+        pendingAction: pendingQueuedAction,
         editLabel: t("composer.attachments.editQueuedMessage"),
         sendNowLabel: t("composer.attachments.sendQueuedMessageNow"),
       }),
-    [handleEditQueuedMessage, handleSendQueuedNow, queuedMessages, t],
+    [
+      handleEditQueuedMessage,
+      handleSendQueuedNow,
+      pendingQueuedAction,
+      queuedActionsDisabled,
+      queuedMessages,
+      t,
+    ],
   );
 
   const messageInputContainerRef = useRef<View>(null);
 
   const isSubmitLoadingVisible =
-    isProcessing || isSubmitLoading || isUploadingFile || pendingNativeImagePastes > 0;
+    isProcessing ||
+    isDraftAttemptPending ||
+    isSubmitLoading ||
+    isUploadingFile ||
+    pendingNativeImagePastes > 0;
   const isSubmitDisabled =
-    isSubmitLoadingVisible || (waitForForgeAutoAttachOnSubmit && forgeAutoAttach.isResolving);
+    isSubmitLoadingVisible ||
+    pendingQueuedAction !== null ||
+    (waitForForgeAutoAttachOnSubmit && forgeAutoAttach.isResolving);
 
   // Disable drops while submitting/uploading: the submit path clears and restores attachments,
-  // so a drop in that window would be lost or land on a locked draft. `disabled` hides the
-  // backdrop and rejects the drop atomically, instead of accepting a drop with no feedback.
+  // so a drop in that window would be lost or land on a locked draft. Background pull request
+  // resolution only gates submission and does not own the draft, so it leaves file drop enabled.
   useFileDrop(
     {
       onFiles: addImages,
@@ -2496,6 +2790,7 @@ const styles = StyleSheet.create((theme: Theme) => ({
 
 const ThemedPencil = withUnistyles(Pencil);
 const ThemedArrowUp = withUnistyles(ArrowUp);
+const ThemedLoadingSpinner = withUnistyles(LoadingSpinner);
 const ThemedGitPullRequest = withUnistyles(GitPullRequest);
 const ThemedCircleDot = withUnistyles(CircleDot);
 const ThemedAudioLines = withUnistyles(AudioLines);

--- a/packages/app/src/composer/submit.test.ts
+++ b/packages/app/src/composer/submit.test.ts
@@ -1,30 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 import { submitAgentInput } from "./submit";
 
-function createDeferredPromise<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((nextResolve, nextReject) => {
-    resolve = nextResolve;
-    reject = nextReject;
-  });
-  return {
-    promise,
-    resolve,
-    reject,
-  };
+function createDeferredPromise<T>(): PromiseWithResolvers<T> {
+  return Promise.withResolvers<T>();
 }
 
 describe("submitAgentInput", () => {
-  it("clears the composer before an in-flight submit resolves", async () => {
+  it("starts a draft attempt before an in-flight submit resolves", async () => {
     const deferred = createDeferredPromise<void>();
     const queueMessage = vi.fn();
     const submitMessage = vi.fn(async () => {
       await deferred.promise;
     });
-    const clearDraft = vi.fn();
-    const setUserInput = vi.fn();
-    const setAttachments = vi.fn();
+    const beginDraftAttempt = vi.fn(() => 1);
+    const settleDraftAttempt = vi.fn();
     const setSendError = vi.fn();
     const setIsProcessing = vi.fn();
 
@@ -35,9 +24,8 @@ describe("submitAgentInput", () => {
       canSubmit: true,
       queueMessage,
       submitMessage,
-      clearDraft,
-      setUserInput,
-      setAttachments,
+      beginDraftAttempt,
+      settleDraftAttempt,
       setSendError,
       setIsProcessing,
     });
@@ -47,28 +35,25 @@ describe("submitAgentInput", () => {
       message: "hello world",
       attachments: [],
     });
-    expect(setUserInput).toHaveBeenCalledWith("");
-    expect(setAttachments).toHaveBeenCalledWith([]);
+    expect(beginDraftAttempt).toHaveBeenCalledWith({ message: "hello world", attachments: [] });
     expect(setSendError).toHaveBeenCalledWith(null);
     expect(setIsProcessing).toHaveBeenCalledWith(true);
-    expect(clearDraft).not.toHaveBeenCalled();
 
     deferred.resolve();
 
     await expect(submitPromise).resolves.toBe("submitted");
-    expect(clearDraft).toHaveBeenCalledWith("sent");
+    expect(settleDraftAttempt).toHaveBeenCalledWith({ attemptId: 1, outcome: "accepted" });
   });
 
-  it("preserves the composer before an in-flight submit resolves when requested", async () => {
+  it("does not start a draft attempt for preserve-and-lock submits", async () => {
     const deferred = createDeferredPromise<void>();
     const attachments = [{ id: "img-1" }];
     const queueMessage = vi.fn();
     const submitMessage = vi.fn(async () => {
       await deferred.promise;
     });
-    const clearDraft = vi.fn();
-    const setUserInput = vi.fn();
-    const setAttachments = vi.fn();
+    const beginDraftAttempt = vi.fn(() => 1);
+    const settleDraftAttempt = vi.fn();
     const setSendError = vi.fn();
     const setIsProcessing = vi.fn();
 
@@ -80,9 +65,8 @@ describe("submitAgentInput", () => {
       canSubmit: true,
       queueMessage,
       submitMessage,
-      clearDraft,
-      setUserInput,
-      setAttachments,
+      beginDraftAttempt,
+      settleDraftAttempt,
       setSendError,
       setIsProcessing,
     });
@@ -92,24 +76,21 @@ describe("submitAgentInput", () => {
       message: "keep me",
       attachments,
     });
-    expect(setUserInput).not.toHaveBeenCalled();
-    expect(setAttachments).not.toHaveBeenCalled();
+    expect(beginDraftAttempt).not.toHaveBeenCalled();
+    expect(settleDraftAttempt).not.toHaveBeenCalled();
     expect(setSendError).toHaveBeenCalledWith(null);
     expect(setIsProcessing).toHaveBeenCalledWith(true);
-    expect(clearDraft).not.toHaveBeenCalled();
 
     deferred.resolve();
 
     await expect(submitPromise).resolves.toBe("submitted");
-    expect(clearDraft).toHaveBeenCalledWith("sent");
   });
 
-  it("queues while the agent is running and clears the composer immediately", async () => {
+  it("queues while the agent is running and leaves clearing to queueMessage", async () => {
     const queueMessage = vi.fn();
     const submitMessage = vi.fn();
-    const clearDraft = vi.fn();
-    const setUserInput = vi.fn();
-    const setAttachments = vi.fn();
+    const beginDraftAttempt = vi.fn(() => 1);
+    const settleDraftAttempt = vi.fn();
     const setSendError = vi.fn();
     const setIsProcessing = vi.fn();
 
@@ -121,9 +102,8 @@ describe("submitAgentInput", () => {
         canSubmit: true,
         queueMessage,
         submitMessage,
-        clearDraft,
-        setUserInput,
-        setAttachments,
+        beginDraftAttempt,
+        settleDraftAttempt,
         setSendError,
         setIsProcessing,
       }),
@@ -134,11 +114,10 @@ describe("submitAgentInput", () => {
       attachments: [{ id: "img-1" }],
     });
     expect(submitMessage).not.toHaveBeenCalled();
-    expect(setUserInput).toHaveBeenCalledWith("");
-    expect(setAttachments).toHaveBeenCalledWith([]);
+    expect(beginDraftAttempt).not.toHaveBeenCalled();
+    expect(settleDraftAttempt).not.toHaveBeenCalled();
     expect(setSendError).not.toHaveBeenCalled();
     expect(setIsProcessing).not.toHaveBeenCalled();
-    expect(clearDraft).not.toHaveBeenCalled();
   });
 
   it("restores the composer when submit fails", async () => {
@@ -147,9 +126,8 @@ describe("submitAgentInput", () => {
     const submitMessage = vi.fn(async () => {
       throw submitError;
     });
-    const clearDraft = vi.fn();
-    const setUserInput = vi.fn();
-    const setAttachments = vi.fn();
+    const beginDraftAttempt = vi.fn(() => 7);
+    const settleDraftAttempt = vi.fn();
     const setSendError = vi.fn();
     const setIsProcessing = vi.fn();
     const onSubmitError = vi.fn();
@@ -163,9 +141,8 @@ describe("submitAgentInput", () => {
         canSubmit: true,
         queueMessage,
         submitMessage,
-        clearDraft,
-        setUserInput,
-        setAttachments,
+        beginDraftAttempt,
+        settleDraftAttempt,
         setSendError,
         setIsProcessing,
         onSubmitError,
@@ -173,56 +150,85 @@ describe("submitAgentInput", () => {
     ).resolves.toBe("failed");
 
     expect(onSubmitError).toHaveBeenCalledWith(submitError);
-    expect(setUserInput).toHaveBeenNthCalledWith(1, "");
-    expect(setUserInput).toHaveBeenNthCalledWith(2, "hello world");
-    expect(setAttachments).toHaveBeenNthCalledWith(1, []);
-    expect(setAttachments).toHaveBeenNthCalledWith(2, attachments);
+    expect(beginDraftAttempt).toHaveBeenCalledWith({
+      message: "hello world",
+      attachments,
+    });
+    expect(settleDraftAttempt).toHaveBeenCalledWith({ attemptId: 7, outcome: "failed" });
     expect(setSendError).toHaveBeenNthCalledWith(1, null);
     expect(setSendError).toHaveBeenNthCalledWith(2, "No host selected");
     expect(setIsProcessing).toHaveBeenNthCalledWith(1, true);
     expect(setIsProcessing).toHaveBeenNthCalledWith(2, false);
-    expect(clearDraft).not.toHaveBeenCalled();
+  });
+
+  it("does not submit a duplicate draft attempt while one is pending", async () => {
+    const queueMessage = vi.fn();
+    const submitMessage = vi.fn(async () => {});
+    const beginDraftAttempt = vi.fn(() => null);
+    const settleDraftAttempt = vi.fn();
+    const setSendError = vi.fn();
+    const setIsProcessing = vi.fn();
+
+    await expect(
+      submitAgentInput({
+        message: "duplicate",
+        attachments: [],
+        isAgentRunning: false,
+        canSubmit: true,
+        queueMessage,
+        submitMessage,
+        beginDraftAttempt,
+        settleDraftAttempt,
+        setSendError,
+        setIsProcessing,
+      }),
+    ).resolves.toBe("noop");
+
+    expect(submitMessage).not.toHaveBeenCalled();
+    expect(settleDraftAttempt).not.toHaveBeenCalled();
+    expect(setIsProcessing).not.toHaveBeenCalled();
   });
 
   it("restores a steered active-turn draft after an ambiguous immediate-send error", async () => {
     const error = new Error("connection lost after delivery");
-    const setUserInput = vi.fn();
-    const setAttachments = vi.fn();
+    const attachments = [{ id: "img-1" }];
+    const queueMessage = vi.fn();
+    const submitMessage = vi.fn(async () => {
+      throw error;
+    });
+    const beginDraftAttempt = vi.fn(() => 9);
+    const settleDraftAttempt = vi.fn();
     const setSendError = vi.fn();
     const setIsProcessing = vi.fn();
 
     await expect(
       submitAgentInput({
         message: "  steer this turn  ",
-        attachments: [{ id: "img-1" }],
+        attachments,
         forceSend: true,
         isAgentRunning: true,
         canSubmit: true,
-        queueMessage: vi.fn(),
-        submitMessage: async () => {
-          throw error;
-        },
-        clearDraft: vi.fn(),
-        setUserInput,
-        setAttachments,
+        queueMessage,
+        submitMessage,
+        beginDraftAttempt,
+        settleDraftAttempt,
         setSendError,
         setIsProcessing,
       }),
     ).resolves.toBe("failed");
 
-    expect(setUserInput).toHaveBeenNthCalledWith(1, "");
-    expect(setUserInput).toHaveBeenNthCalledWith(2, "steer this turn");
-    expect(setAttachments).toHaveBeenNthCalledWith(1, []);
-    expect(setAttachments).toHaveBeenNthCalledWith(2, [{ id: "img-1" }]);
+    expect(queueMessage).not.toHaveBeenCalled();
+    expect(submitMessage).toHaveBeenCalledWith({ message: "steer this turn", attachments });
+    expect(beginDraftAttempt).toHaveBeenCalledWith({ message: "steer this turn", attachments });
+    expect(settleDraftAttempt).toHaveBeenCalledWith({ attemptId: 9, outcome: "failed" });
     expect(setSendError).toHaveBeenLastCalledWith("connection lost after delivery");
   });
 
   it("submits when empty submit is explicitly allowed", async () => {
     const queueMessage = vi.fn();
     const submitMessage = vi.fn(async () => {});
-    const clearDraft = vi.fn();
-    const setUserInput = vi.fn();
-    const setAttachments = vi.fn();
+    const beginDraftAttempt = vi.fn(() => 1);
+    const settleDraftAttempt = vi.fn();
     const setSendError = vi.fn();
     const setIsProcessing = vi.fn();
 
@@ -235,9 +241,8 @@ describe("submitAgentInput", () => {
         canSubmit: true,
         queueMessage,
         submitMessage,
-        clearDraft,
-        setUserInput,
-        setAttachments,
+        beginDraftAttempt,
+        settleDraftAttempt,
         setSendError,
         setIsProcessing,
       }),
@@ -248,6 +253,5 @@ describe("submitAgentInput", () => {
       message: "",
       attachments: [],
     });
-    expect(clearDraft).toHaveBeenCalledWith("sent");
   });
 });

--- a/packages/app/src/composer/submit.ts
+++ b/packages/app/src/composer/submit.ts
@@ -11,11 +11,10 @@ export interface AgentInputSubmitActionInput<TAttachment> {
   forceSend?: boolean;
   isAgentRunning: boolean;
   canSubmit: boolean;
-  queueMessage: (input: { message: string; attachments: TAttachment[] }) => void;
+  queueMessage: (input: { message: string; attachments: TAttachment[] }) => Promise<void> | void;
   submitMessage: (input: { message: string; attachments: TAttachment[] }) => Promise<void>;
-  clearDraft: (lifecycle: "sent" | "abandoned") => void;
-  setUserInput: (text: string) => void;
-  setAttachments: (attachments: TAttachment[]) => void;
+  beginDraftAttempt: (input: { message: string; attachments: TAttachment[] }) => number | null;
+  settleDraftAttempt: (input: { attemptId: number; outcome: "accepted" | "failed" }) => void;
   setSendError: (message: string | null) => void;
   setIsProcessing: (isProcessing: boolean) => void;
   onSubmitError?: (error: unknown) => void;
@@ -43,32 +42,43 @@ export async function submitAgentInput<TAttachment>(
   }
 
   if (input.isAgentRunning && !input.forceSend) {
-    input.queueMessage({ message: trimmedMessage, attachments });
-    if (shouldClearOnSubmit) {
-      input.setUserInput("");
-      input.setAttachments([]);
+    try {
+      // queueMessage owns the synchronous clear and reconciles a failed
+      // queued draft with input entered during its network round-trip.
+      await input.queueMessage({ message: trimmedMessage, attachments });
+      return "queued";
+    } catch (error) {
+      input.onSubmitError?.(error);
+      input.setSendError(
+        error instanceof Error
+          ? error.message
+          : (input.failedToSendMessage ?? i18n.t("composer.errors.failedToSend")),
+      );
+      return "failed";
     }
-    return "queued";
   }
 
-  // Clear immediately so the submitted timeline row and composer state stay in sync.
+  let draftAttemptId: number | null = null;
   if (shouldClearOnSubmit) {
-    input.setUserInput("");
-    input.setAttachments([]);
+    draftAttemptId = input.beginDraftAttempt({ message: trimmedMessage, attachments });
+    if (draftAttemptId === null) {
+      return "noop";
+    }
   }
   input.setSendError(null);
   input.setIsProcessing(true);
 
   try {
     await input.submitMessage({ message: trimmedMessage, attachments });
-    input.clearDraft("sent");
+    if (draftAttemptId !== null) {
+      input.settleDraftAttempt({ attemptId: draftAttemptId, outcome: "accepted" });
+    }
     input.setIsProcessing(false);
     return "submitted";
   } catch (error) {
     input.onSubmitError?.(error);
-    if (shouldClearOnSubmit) {
-      input.setUserInput(trimmedMessage);
-      input.setAttachments(attachments);
+    if (draftAttemptId !== null) {
+      input.settleDraftAttempt({ attemptId: draftAttemptId, outcome: "failed" });
     }
     input.setSendError(
       error instanceof Error

--- a/packages/app/src/runtime/agent-message-queue-sync.test.ts
+++ b/packages/app/src/runtime/agent-message-queue-sync.test.ts
@@ -257,6 +257,27 @@ describe("AgentMessageQueueSync", () => {
     sync.dispose();
   });
 
+  it("retries a failed initial sync on the next directory commit", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const harness = createClientHarness();
+    harness.listQueuedAgentMessages
+      .mockRejectedValueOnce(new Error("temporary list failure"))
+      .mockResolvedValueOnce([queuePayload("agent-a", 1, ["recovered-message"])]);
+    const sync = new AgentMessageQueueSync(SERVER_ID);
+
+    connect(sync, harness.client, FIRST_SOURCE, ["agent-a"]);
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledTimes(1));
+
+    sync.directoryCommitted(new Set(["agent-a"]), FIRST_SOURCE);
+    await vi.waitFor(() =>
+      expect(useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.get("agent-a")).toEqual(
+        [expect.objectContaining({ id: "recovered-message" })],
+      ),
+    );
+    expect(harness.listQueuedAgentMessages).toHaveBeenCalledTimes(2);
+    sync.dispose();
+  });
+
   it("hydrates omitted image and attachment payloads from a queue update", async () => {
     __setAttachmentStoreForTests(
       createLocalFileAttachmentStore({

--- a/packages/app/src/runtime/agent-message-queue-sync.test.ts
+++ b/packages/app/src/runtime/agent-message-queue-sync.test.ts
@@ -1,0 +1,438 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DaemonClient,
+  type NormalizedQueuedAgentMessageQueuePayload,
+} from "@getpaseo/client/internal/daemon-client";
+import type { SessionOutboundMessage } from "@getpaseo/protocol/messages";
+import { createLocalFileAttachmentStore } from "@/attachments/local-file-attachment-store";
+import { __setAttachmentStoreForTests } from "@/attachments/store";
+import { createTestAttachmentFileSystem } from "@/attachments/test-attachment-file-system";
+import type { QueuedComposerMessage } from "@/composer/actions";
+import type { DirectorySourceToken } from "@/runtime/directory-sync/transaction";
+import { useSessionStore } from "@/stores/session-store";
+import { AgentMessageQueueSync } from "./agent-message-queue-sync";
+
+const SERVER_ID = "queue-sync-test";
+const FIRST_SOURCE = { clientGeneration: 1, connectionEpoch: 1 } as const;
+const SECOND_SOURCE = { clientGeneration: 1, connectionEpoch: 2 } as const;
+const THIRD_SOURCE = { clientGeneration: 1, connectionEpoch: 3 } as const;
+const FOURTH_SOURCE = { clientGeneration: 1, connectionEpoch: 4 } as const;
+
+type QueueUpdateMessage = Extract<SessionOutboundMessage, { type: "queue.agent_message.updated" }>;
+type QueueConnection = Parameters<AgentMessageQueueSync["connectionChanged"]>[0];
+type QueueClient = NonNullable<QueueConnection["client"]>;
+
+function deferred<T>(): PromiseWithResolvers<T> {
+  return Promise.withResolvers<T>();
+}
+
+function queuePayload(
+  agentId: string,
+  revision: number,
+  messageIds: readonly string[],
+): NormalizedQueuedAgentMessageQueuePayload {
+  return {
+    agentId,
+    revision,
+    messages: messageIds.map((id) => ({
+      id,
+      agentId,
+      text: id,
+      createdAt: "2026-07-30T00:00:00.000Z",
+      images: [],
+      attachments: [],
+      imageCount: 0,
+      attachmentCount: 0,
+    })),
+  };
+}
+
+function localMessage(id: string): QueuedComposerMessage {
+  return { id, text: id, attachments: [] };
+}
+
+function createClientHarness(options: { agentMessageQueue?: boolean } = {}) {
+  const listeners = new Set<(message: QueueUpdateMessage) => void | Promise<void>>();
+  const queueAgentMessage = vi.fn<DaemonClient["queueAgentMessage"]>(async () => null);
+  const listQueuedAgentMessages = vi.fn<DaemonClient["listQueuedAgentMessages"]>(async () => []);
+  const client = {
+    identity: {},
+    getLastServerInfoMessage: () => ({
+      status: "server_info" as const,
+      serverId: SERVER_ID,
+      hostname: null,
+      version: "0.2.5",
+      features: { agentMessageQueue: options.agentMessageQueue ?? true },
+    }),
+    subscribeQueueUpdates: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    queueAgentMessage,
+    listQueuedAgentMessages,
+  } satisfies QueueClient;
+
+  return {
+    client,
+    queueAgentMessage,
+    listQueuedAgentMessages,
+    async emit(message: QueueUpdateMessage): Promise<void> {
+      await Promise.all(Array.from(listeners, async (listener) => await listener(message)));
+    },
+  };
+}
+
+function connect(
+  sync: AgentMessageQueueSync,
+  client: QueueClient,
+  source: DirectorySourceToken,
+  agentIds: readonly string[],
+): void {
+  sync.connectionChanged({ client, status: "online", source });
+  sync.directoryCommitted(new Set(agentIds), source);
+}
+
+beforeEach(() => {
+  const store = useSessionStore.getState();
+  store.initializeSession(SERVER_ID, null);
+  store.updateSessionServerInfo(SERVER_ID, {
+    serverId: SERVER_ID,
+    hostname: null,
+    version: "0.2.5",
+    features: { agentMessageQueue: true, forgeSearch: true },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  __setAttachmentStoreForTests(null);
+  useSessionStore.getState().clearSession(SERVER_ID);
+});
+
+describe("AgentMessageQueueSync", () => {
+  it("preserves a failed suffix and retries only unacknowledged ids after reconnect", async () => {
+    const first = localMessage("first");
+    const second = localMessage("second");
+    const third = localMessage("third");
+    useSessionStore
+      .getState()
+      .setQueuedMessages(SERVER_ID, new Map([["agent-a", [first, second, third]]]));
+    const harness = createClientHarness();
+    harness.queueAgentMessage.mockImplementation(async (_agentId, _text, options) => {
+      if (options?.messageId === "second") throw new Error("temporary failure");
+      return null;
+    });
+    harness.listQueuedAgentMessages.mockResolvedValueOnce([queuePayload("agent-a", 1, ["first"])]);
+    const sync = new AgentMessageQueueSync(SERVER_ID);
+
+    connect(sync, harness.client, FIRST_SOURCE, ["agent-a"]);
+    await vi.waitFor(() => expect(harness.listQueuedAgentMessages).toHaveBeenCalledTimes(1));
+
+    expect(harness.queueAgentMessage.mock.calls.map(([, , options]) => options?.messageId)).toEqual(
+      ["first", "second"],
+    );
+    expect(useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.get("agent-a")).toEqual([
+      first,
+      second,
+      third,
+    ]);
+
+    harness.queueAgentMessage.mockImplementation(async () => null);
+    harness.listQueuedAgentMessages.mockResolvedValueOnce([
+      queuePayload("agent-a", 2, ["first", "second", "third"]),
+    ]);
+    connect(sync, harness.client, SECOND_SOURCE, ["agent-a"]);
+    await vi.waitFor(() => expect(harness.listQueuedAgentMessages).toHaveBeenCalledTimes(2));
+
+    expect(harness.queueAgentMessage.mock.calls.map(([, , options]) => options?.messageId)).toEqual(
+      ["first", "second", "second", "third"],
+    );
+    expect(useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.get("agent-a")).toEqual([
+      first,
+      second,
+      third,
+    ]);
+    sync.dispose();
+  });
+
+  it("does not legacy-drain daemon-owned mirrors after a host downgrade", async () => {
+    const pending = localMessage("pending-migration");
+    useSessionStore.getState().setQueuedMessages(SERVER_ID, new Map([["agent-a", [pending]]]));
+    const currentHarness = createClientHarness();
+    currentHarness.queueAgentMessage.mockRejectedValue(new Error("migration unavailable"));
+    currentHarness.listQueuedAgentMessages.mockResolvedValue([
+      queuePayload("agent-a", 1, ["daemon-owned"]),
+    ]);
+    const legacyHarness = createClientHarness({ agentMessageQueue: false });
+    const sync = new AgentMessageQueueSync(SERVER_ID);
+
+    sync.connectionChanged({
+      client: currentHarness.client,
+      status: "online",
+      source: FIRST_SOURCE,
+    });
+    sync.connectionChanged({
+      client: legacyHarness.client,
+      status: "online",
+      source: SECOND_SOURCE,
+    });
+    expect(useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.get("agent-a")).toEqual([
+      pending,
+    ]);
+
+    connect(sync, currentHarness.client, THIRD_SOURCE, ["agent-a"]);
+    await vi.waitFor(() =>
+      expect(useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.get("agent-a")).toEqual(
+        [expect.objectContaining({ id: "daemon-owned" }), pending],
+      ),
+    );
+
+    connect(sync, legacyHarness.client, FOURTH_SOURCE, ["agent-a"]);
+
+    expect(useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.get("agent-a")).toEqual([
+      pending,
+    ]);
+    expect(legacyHarness.listQueuedAgentMessages).not.toHaveBeenCalled();
+    sync.dispose();
+  });
+
+  it("continues initial sync without restoring agents removed during migration", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const migration = deferred<null>();
+    useSessionStore.getState().setQueuedMessages(
+      SERVER_ID,
+      new Map([
+        ["agent-archive", [localMessage("archive-message")]],
+        ["agent-delete", [localMessage("delete-message")]],
+      ]),
+    );
+    const harness = createClientHarness();
+    harness.queueAgentMessage.mockImplementationOnce(async () => await migration.promise);
+    harness.listQueuedAgentMessages.mockResolvedValue([
+      queuePayload("active-agent", 1, ["server-message"]),
+    ]);
+    const sync = new AgentMessageQueueSync(SERVER_ID);
+
+    connect(sync, harness.client, FIRST_SOURCE, ["agent-archive", "agent-delete", "active-agent"]);
+    await vi.waitFor(() => expect(harness.queueAgentMessage).toHaveBeenCalledTimes(1));
+    sync.removeAgent("agent-archive", FIRST_SOURCE);
+    sync.removeAgent("agent-delete", FIRST_SOURCE);
+    migration.reject(new Error("archived while migrating"));
+
+    await vi.waitFor(() => expect(harness.listQueuedAgentMessages).toHaveBeenCalledTimes(1));
+    expect(useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages).toEqual(
+      new Map([
+        [
+          "active-agent",
+          [
+            {
+              id: "server-message",
+              text: "server-message",
+              attachments: [],
+              canEdit: true,
+            },
+          ],
+        ],
+      ]),
+    );
+    sync.dispose();
+  });
+
+  it("prunes local queues missing from the authoritative active directory", async () => {
+    useSessionStore
+      .getState()
+      .setQueuedMessages(
+        SERVER_ID,
+        new Map([["removed-while-disconnected", [localMessage("pending")]]]),
+      );
+    const harness = createClientHarness();
+    const sync = new AgentMessageQueueSync(SERVER_ID);
+
+    connect(sync, harness.client, FIRST_SOURCE, ["active-agent"]);
+    await vi.waitFor(() => expect(harness.listQueuedAgentMessages).toHaveBeenCalledTimes(1));
+
+    expect(harness.queueAgentMessage).not.toHaveBeenCalled();
+    expect(useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages).toEqual(new Map());
+    sync.dispose();
+  });
+
+  it("hydrates omitted image and attachment payloads from a queue update", async () => {
+    __setAttachmentStoreForTests(
+      createLocalFileAttachmentStore({
+        storageType: "desktop-file",
+        baseDirectoryName: "queue-sync-test",
+        fileSystem: createTestAttachmentFileSystem(),
+        resolvePreviewUrl: async (attachment) => `file://${attachment.storageKey}`,
+      }),
+    );
+    const harness = createClientHarness();
+    const sync = new AgentMessageQueueSync(SERVER_ID);
+    connect(sync, harness.client, FIRST_SOURCE, ["agent-a"]);
+    await vi.waitFor(() => expect(harness.listQueuedAgentMessages).toHaveBeenCalledTimes(1));
+
+    const hydrated = queuePayload("agent-a", 1, ["hydrated"]);
+    hydrated.messages[0] = {
+      ...hydrated.messages[0],
+      images: [{ data: "aGVsbG8=", mimeType: "image/png" }],
+      attachments: [
+        {
+          type: "uploaded_file",
+          id: "uploaded-1",
+          fileName: "notes.txt",
+          mimeType: "text/plain",
+          size: 5,
+          path: "/uploads/notes.txt",
+        },
+      ],
+      imageCount: 1,
+      attachmentCount: 1,
+    };
+    const hydration = deferred<NormalizedQueuedAgentMessageQueuePayload[]>();
+    harness.listQueuedAgentMessages.mockImplementationOnce(async () => await hydration.promise);
+
+    let applicationFinished = false;
+    const applying = harness.emit({
+      type: "queue.agent_message.updated",
+      payload: {
+        agentId: "agent-a",
+        revision: 1,
+        messages: [
+          {
+            id: "hydrated",
+            agentId: "agent-a",
+            text: "hydrated",
+            createdAt: "2026-07-30T00:00:00.000Z",
+            imageCount: 1,
+            attachmentCount: 1,
+          },
+        ],
+      },
+    });
+    const applicationCompleted = applying.finally(() => {
+      applicationFinished = true;
+    });
+    await vi.waitFor(() => expect(harness.listQueuedAgentMessages).toHaveBeenCalledTimes(2));
+    expect(applicationFinished).toBe(false);
+
+    hydration.resolve([hydrated]);
+    await applicationCompleted;
+
+    expect(harness.listQueuedAgentMessages).toHaveBeenLastCalledWith("agent-a");
+    expect(useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.get("agent-a")).toEqual([
+      {
+        id: "hydrated",
+        text: "hydrated",
+        attachments: [
+          {
+            kind: "image",
+            metadata: expect.objectContaining({
+              id: "queued:queue-sync-test:agent-a:hydrated:image:0",
+              mimeType: "image/png",
+              storageType: "desktop-file",
+            }),
+          },
+          { kind: "file", attachment: hydrated.messages[0]?.attachments[0] },
+        ],
+        canEdit: true,
+      },
+    ]);
+    sync.dispose();
+  });
+
+  it("does not resurrect an agent removed while broadcast hydration is in flight", async () => {
+    const harness = createClientHarness();
+    const sync = new AgentMessageQueueSync(SERVER_ID);
+    connect(sync, harness.client, FIRST_SOURCE, ["agent-a"]);
+    await vi.waitFor(() => expect(harness.listQueuedAgentMessages).toHaveBeenCalledTimes(1));
+
+    const hydration = deferred<NormalizedQueuedAgentMessageQueuePayload[]>();
+    harness.listQueuedAgentMessages.mockImplementationOnce(async () => await hydration.promise);
+    let applicationFinished = false;
+    const applying = harness.emit({
+      type: "queue.agent_message.updated",
+      payload: {
+        agentId: "agent-a",
+        revision: 1,
+        messages: [
+          {
+            id: "stale-hydration",
+            agentId: "agent-a",
+            text: "stale-hydration",
+            createdAt: "2026-07-30T00:00:00.000Z",
+            imageCount: 1,
+            attachmentCount: 0,
+          },
+        ],
+      },
+    });
+    const applicationCompleted = applying.finally(() => {
+      applicationFinished = true;
+    });
+    await vi.waitFor(() => expect(harness.listQueuedAgentMessages).toHaveBeenCalledTimes(2));
+    expect(applicationFinished).toBe(false);
+
+    sync.directoryCommitted(new Set(), FIRST_SOURCE);
+    hydration.resolve([queuePayload("agent-a", 1, ["stale-hydration"])]);
+    await applicationCompleted;
+
+    expect(applicationFinished).toBe(true);
+    expect(useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.has("agent-a")).toBe(
+      false,
+    );
+    sync.dispose();
+  });
+
+  it("applies revisions within one source and resets them for a new authoritative snapshot", async () => {
+    const harness = createClientHarness();
+    harness.listQueuedAgentMessages
+      .mockResolvedValueOnce([queuePayload("agent-a", 5, ["old-server-message"])])
+      .mockResolvedValueOnce([]);
+    const sync = new AgentMessageQueueSync(SERVER_ID);
+
+    connect(sync, harness.client, FIRST_SOURCE, ["agent-a"]);
+    await vi.waitFor(() =>
+      expect(
+        useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.get("agent-a")?.[0]?.id,
+      ).toBe("old-server-message"),
+    );
+
+    await harness.emit({
+      type: "queue.agent_message.updated",
+      payload: queuePayload("agent-a", 4, ["stale"]),
+    });
+    await vi.waitFor(() =>
+      expect(
+        useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.get("agent-a")?.[0]?.id,
+      ).toBe("old-server-message"),
+    );
+    await harness.emit({
+      type: "queue.agent_message.updated",
+      payload: queuePayload("agent-a", 5, ["same-revision-refresh"]),
+    });
+    await vi.waitFor(() =>
+      expect(
+        useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.get("agent-a")?.[0]?.id,
+      ).toBe("same-revision-refresh"),
+    );
+
+    connect(sync, harness.client, SECOND_SOURCE, ["agent-a"]);
+    await vi.waitFor(() => expect(harness.listQueuedAgentMessages).toHaveBeenCalledTimes(2));
+    expect(useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.has("agent-a")).toBe(
+      false,
+    );
+
+    await harness.emit({
+      type: "queue.agent_message.updated",
+      payload: queuePayload("agent-a", 1, ["fresh-after-reset"]),
+    });
+    await vi.waitFor(() =>
+      expect(
+        useSessionStore.getState().sessions[SERVER_ID]?.queuedMessages.get("agent-a")?.[0]?.id,
+      ).toBe("fresh-after-reset"),
+    );
+    sync.directoryCommitted(new Set(["agent-a"]), SECOND_SOURCE);
+    expect(harness.listQueuedAgentMessages).toHaveBeenCalledTimes(2);
+    sync.dispose();
+  });
+});

--- a/packages/app/src/runtime/agent-message-queue-sync.ts
+++ b/packages/app/src/runtime/agent-message-queue-sync.ts
@@ -350,6 +350,7 @@ export class AgentMessageQueueSync {
     void this.runInitialSync(client, source).catch((error) => {
       if (this.isCurrent(client, source)) {
         console.error("[AgentMessageQueue] Failed to sync queued messages:", error);
+        this.hasStartedInitialSync = false;
       }
     });
   }

--- a/packages/app/src/runtime/agent-message-queue-sync.ts
+++ b/packages/app/src/runtime/agent-message-queue-sync.ts
@@ -1,0 +1,497 @@
+import {
+  normalizeQueuedAgentMessageQueuePayload,
+  type DaemonClient,
+  type NormalizedQueuedAgentMessagePayload,
+  type NormalizedQueuedAgentMessageQueuePayload,
+} from "@getpaseo/client/internal/daemon-client";
+import type {
+  AgentAttachment,
+  ForgeSearchItem,
+  SessionOutboundMessage,
+} from "@getpaseo/protocol/messages";
+import { persistAttachmentFromDataUrl } from "@/attachments/service";
+import type { ComposerAttachment, UserComposerAttachment } from "@/attachments/types";
+import type { QueuedComposerMessage } from "@/composer/actions";
+import {
+  resolveComposerAttachmentSubmitFormat,
+  splitComposerAttachmentsForSubmit,
+} from "@/composer/attachments/submit";
+import type { DirectoryConnection } from "@/runtime/directory-sync";
+import type { DirectorySourceToken } from "@/runtime/directory-sync/transaction";
+import { useSessionStore } from "@/stores/session-store";
+import { encodeImages } from "@/utils/encode-images";
+import { supportsAgentMessageQueue } from "@/utils/server-info-capabilities";
+
+interface AgentQueueSyncState {
+  revision: number | null;
+  // COMPAT(localAgentQueueMigration): added in v0.6.2. Remove after 2027-02-26
+  // once all supported clients have migrated their legacy local queue state.
+  pendingMigration: QueuedComposerMessage[];
+}
+
+interface BuiltComposerAttachments {
+  attachments: ComposerAttachment[];
+  fullyEditable: boolean;
+}
+
+type AgentMessageQueueUpdatedEvent = Extract<
+  SessionOutboundMessage,
+  { type: "queue.agent_message.updated" }
+>;
+
+interface AgentMessageQueueClient {
+  identity: object;
+  getLastServerInfoMessage: DaemonClient["getLastServerInfoMessage"];
+  listQueuedAgentMessages: DaemonClient["listQueuedAgentMessages"];
+  queueAgentMessage: DaemonClient["queueAgentMessage"];
+  subscribeQueueUpdates(
+    listener: (message: AgentMessageQueueUpdatedEvent) => void | Promise<void>,
+  ): () => void;
+}
+
+interface AgentMessageQueueConnection extends Omit<DirectoryConnection, "client"> {
+  client: AgentMessageQueueClient | null;
+}
+
+export function toAgentMessageQueueConnection(
+  connection: DirectoryConnection,
+): AgentMessageQueueConnection {
+  const client = connection.client;
+  return {
+    ...connection,
+    client: client
+      ? {
+          identity: client,
+          getLastServerInfoMessage: () => client.getLastServerInfoMessage(),
+          listQueuedAgentMessages: (agentId) => client.listQueuedAgentMessages(agentId),
+          queueAgentMessage: (agentId, text, options) =>
+            client.queueAgentMessage(agentId, text, options),
+          subscribeQueueUpdates: (listener) => client.on("queue.agent_message.updated", listener),
+        }
+      : null,
+  };
+}
+
+function sourcesEqual(left: DirectorySourceToken, right: DirectorySourceToken): boolean {
+  return (
+    left.clientGeneration === right.clientGeneration &&
+    left.connectionEpoch === right.connectionEpoch
+  );
+}
+
+function forgeSearchItemFromAttachment(
+  attachment: Extract<
+    AgentAttachment,
+    { type: "forge_issue" | "forge_change_request" | "github_issue" | "github_pr" }
+  >,
+): ForgeSearchItem {
+  const isChangeRequest =
+    attachment.type === "forge_change_request" || attachment.type === "github_pr";
+  return {
+    kind: isChangeRequest ? "change_request" : "issue",
+    forge: "forge" in attachment ? (attachment.forge ?? "github") : "github",
+    number: attachment.number,
+    title: attachment.title,
+    url: attachment.url,
+    state: "unknown",
+    body: attachment.body ?? null,
+    labels: [],
+    ...(isChangeRequest && attachment.baseRefName ? { baseRefName: attachment.baseRefName } : {}),
+    ...(isChangeRequest && attachment.headRefName ? { headRefName: attachment.headRefName } : {}),
+    ...("projectPath" in attachment && attachment.projectPath
+      ? { projectPath: attachment.projectPath }
+      : {}),
+  };
+}
+
+function composerAttachmentFromAgentAttachment(
+  attachment: AgentAttachment,
+): UserComposerAttachment | null {
+  switch (attachment.type) {
+    case "uploaded_file":
+      return { kind: "file", attachment };
+    case "forge_issue":
+      return { kind: "forge_issue", item: forgeSearchItemFromAttachment(attachment) };
+    case "forge_change_request":
+      return { kind: "forge_change_request", item: forgeSearchItemFromAttachment(attachment) };
+    case "github_issue":
+      return { kind: "github_issue", item: forgeSearchItemFromAttachment(attachment) };
+    case "github_pr":
+      return { kind: "github_pr", item: forgeSearchItemFromAttachment(attachment) };
+    case "review":
+    case "text":
+      // These wire shapes do not retain enough current-main composer ownership
+      // to reconstruct a safe editable attachment. The queued turn still keeps
+      // the original wire payload on the daemon and can always be dispatched.
+      return null;
+  }
+}
+
+async function buildComposerAttachments(input: {
+  serverId: string;
+  message: NormalizedQueuedAgentMessagePayload;
+}): Promise<BuiltComposerAttachments> {
+  let fullyEditable = true;
+  const images = await Promise.all(
+    input.message.images.map(async (image, index) => {
+      try {
+        return {
+          kind: "image" as const,
+          metadata: await persistAttachmentFromDataUrl({
+            id: `queued:${input.serverId}:${input.message.agentId}:${input.message.id}:image:${index}`,
+            dataUrl: `data:${image.mimeType};base64,${image.data}`,
+            mimeType: image.mimeType,
+          }),
+        };
+      } catch (error) {
+        fullyEditable = false;
+        console.error("[AgentMessageQueue] Failed to persist queued image:", error);
+        return null;
+      }
+    }),
+  );
+  const attachments: ComposerAttachment[] = images.filter(
+    (image): image is NonNullable<typeof image> => image !== null,
+  );
+  for (const attachment of input.message.attachments) {
+    const composerAttachment = composerAttachmentFromAgentAttachment(attachment);
+    if (composerAttachment) {
+      attachments.push(composerAttachment);
+    } else {
+      fullyEditable = false;
+    }
+  }
+  fullyEditable &&=
+    input.message.imageCount === input.message.images.length &&
+    input.message.attachmentCount === input.message.attachments.length;
+  return { attachments, fullyEditable };
+}
+
+function needsPayloadHydration(
+  queue: NormalizedQueuedAgentMessageQueuePayload,
+  mirrored: readonly QueuedComposerMessage[] | undefined,
+): boolean {
+  const mirroredIds = new Set((mirrored ?? []).map((message) => message.id));
+  return queue.messages.some(
+    (message) =>
+      !mirroredIds.has(message.id) &&
+      (message.imageCount > message.images.length ||
+        message.attachmentCount > message.attachments.length),
+  );
+}
+
+async function mergeQueuedMessages(input: {
+  serverId: string;
+  previous: readonly QueuedComposerMessage[] | undefined;
+  incoming: NormalizedQueuedAgentMessagePayload[];
+}): Promise<QueuedComposerMessage[]> {
+  const previousById = new Map((input.previous ?? []).map((message) => [message.id, message]));
+  return await Promise.all(
+    input.incoming.map(async (message) => {
+      const previous = previousById.get(message.id);
+      if (previous) {
+        return previous;
+      }
+      const built = await buildComposerAttachments({ serverId: input.serverId, message });
+      return {
+        id: message.id,
+        text: message.text,
+        attachments: built.attachments,
+        canEdit: built.fullyEditable,
+      };
+    }),
+  );
+}
+
+/**
+ * Per-host owner for daemon queue mirroring and one-time migration of the
+ * legacy local queue. Its source token and active-agent set come from the same
+ * HostRuntime/DirectorySync lifecycle that owns every other directory replica.
+ */
+export class AgentMessageQueueSync {
+  private readonly stateByAgent = new Map<string, AgentQueueSyncState>();
+  private connection: AgentMessageQueueConnection = {
+    client: null,
+    status: "offline",
+    source: { clientGeneration: 0, connectionEpoch: 0 },
+  };
+  private activeAgentIds: Set<string> | null = null;
+  private unsubscribeQueueUpdates: (() => void) | null = null;
+  private hasStartedInitialSync = false;
+  private ownsDaemonQueueMirror = false;
+
+  constructor(private serverId: string) {}
+
+  adoptServerId(serverId: string): void {
+    this.serverId = serverId;
+  }
+
+  connectionChanged(connection: AgentMessageQueueConnection): boolean {
+    const changed =
+      this.connection.client?.identity !== connection.client?.identity ||
+      this.connection.status !== connection.status ||
+      !sourcesEqual(this.connection.source, connection.source);
+    if (!changed) {
+      this.startInitialSyncIfReady();
+      return false;
+    }
+
+    this.unsubscribeQueueUpdates?.();
+    this.unsubscribeQueueUpdates = null;
+    this.connection = connection;
+    this.activeAgentIds = null;
+    this.hasStartedInitialSync = false;
+    for (const state of this.stateByAgent.values()) state.revision = null;
+
+    const serverInfo = connection.client?.getLastServerInfoMessage();
+    if (
+      connection.status === "online" &&
+      connection.client &&
+      !supportsAgentMessageQueue(serverInfo) &&
+      this.ownsDaemonQueueMirror
+    ) {
+      this.restorePendingMigrationQueues();
+      this.ownsDaemonQueueMirror = false;
+    }
+    if (
+      connection.status !== "online" ||
+      !connection.client ||
+      !supportsAgentMessageQueue(serverInfo)
+    ) {
+      return true;
+    }
+    const client = connection.client;
+    const source = connection.source;
+    this.unsubscribeQueueUpdates = client.subscribeQueueUpdates((message) => {
+      if (message.type !== "queue.agent_message.updated" || !this.isCurrent(client, source)) return;
+      return this.applyEventQueue(
+        client,
+        source,
+        normalizeQueuedAgentMessageQueuePayload(message.payload),
+      ).catch((error) => {
+        if (this.isCurrent(client, source)) {
+          console.error("[AgentMessageQueue] Failed to apply queue update:", error);
+        }
+      });
+    });
+    return true;
+  }
+
+  directoryCommitted(agentIds: Iterable<string>, source: DirectorySourceToken): void {
+    if (!sourcesEqual(this.connection.source, source)) return;
+    const nextAgentIds = new Set(agentIds);
+    this.activeAgentIds = nextAgentIds;
+    for (const agentId of this.stateAndMirrorAgentIds()) {
+      if (!nextAgentIds.has(agentId)) this.removeAgent(agentId, source);
+    }
+    this.startInitialSyncIfReady();
+  }
+
+  removeAgent(agentId: string, source: DirectorySourceToken): void {
+    if (!sourcesEqual(this.connection.source, source)) return;
+    this.stateByAgent.delete(agentId);
+    this.activeAgentIds?.delete(agentId);
+    useSessionStore.getState().setQueuedMessages(this.serverId, (previous) => {
+      if (!previous.has(agentId)) return previous;
+      const next = new Map(previous);
+      next.delete(agentId);
+      return next;
+    });
+  }
+
+  isDaemonQueueEnabled(): boolean {
+    return supportsAgentMessageQueue(this.connection.client?.getLastServerInfoMessage());
+  }
+
+  dispose(): void {
+    this.unsubscribeQueueUpdates?.();
+    this.unsubscribeQueueUpdates = null;
+    this.connection = {
+      client: null,
+      status: "offline",
+      source: this.connection.source,
+    };
+    this.activeAgentIds = null;
+    this.hasStartedInitialSync = false;
+    this.ownsDaemonQueueMirror = false;
+    this.stateByAgent.clear();
+  }
+
+  private restorePendingMigrationQueues(): void {
+    const pendingByAgent = new Map<string, QueuedComposerMessage[]>();
+    for (const [agentId, state] of this.stateByAgent) {
+      if (state.pendingMigration.length > 0) {
+        pendingByAgent.set(agentId, [...state.pendingMigration]);
+      }
+    }
+    this.stateByAgent.clear();
+    useSessionStore.getState().setQueuedMessages(this.serverId, pendingByAgent);
+  }
+
+  private stateAndMirrorAgentIds(): Set<string> {
+    return new Set([
+      ...this.stateByAgent.keys(),
+      ...(useSessionStore.getState().sessions[this.serverId]?.queuedMessages.keys() ?? []),
+    ]);
+  }
+
+  private startInitialSyncIfReady(): void {
+    const { client, status, source } = this.connection;
+    if (
+      this.hasStartedInitialSync ||
+      status !== "online" ||
+      !client ||
+      !this.activeAgentIds ||
+      !this.isDaemonQueueEnabled()
+    ) {
+      return;
+    }
+    this.hasStartedInitialSync = true;
+    void this.runInitialSync(client, source).catch((error) => {
+      if (this.isCurrent(client, source)) {
+        console.error("[AgentMessageQueue] Failed to sync queued messages:", error);
+      }
+    });
+  }
+
+  private async runInitialSync(
+    client: AgentMessageQueueClient,
+    source: DirectorySourceToken,
+  ): Promise<void> {
+    const localQueues =
+      useSessionStore.getState().sessions[this.serverId]?.queuedMessages ?? new Map();
+    for (const [agentId, messages] of localQueues) {
+      if (!this.isActiveAgent(agentId) || this.stateByAgent.has(agentId)) continue;
+      this.stateByAgent.set(agentId, {
+        revision: null,
+        pendingMigration: [...messages],
+      });
+    }
+    this.ownsDaemonQueueMirror = true;
+
+    for (const [agentId, state] of this.stateByAgent) {
+      if (!this.isCurrent(client, source)) return;
+      if (!this.isActiveAgent(agentId)) continue;
+      await this.migrateAgentQueue(client, source, agentId, state);
+    }
+
+    const queues = await client.listQueuedAgentMessages();
+    if (!this.isCurrent(client, source)) return;
+    const seenAgentIds = new Set(queues.map((queue) => queue.agentId));
+    for (const queue of queues) {
+      await this.applyQueue(client, source, queue);
+    }
+    for (const agentId of this.stateAndMirrorAgentIds()) {
+      if (!this.isCurrent(client, source)) return;
+      if (this.isActiveAgent(agentId) && !seenAgentIds.has(agentId)) {
+        await this.applyQueue(client, source, { agentId, revision: 0, messages: [] });
+      }
+    }
+  }
+
+  private async migrateAgentQueue(
+    client: AgentMessageQueueClient,
+    source: DirectorySourceToken,
+    agentId: string,
+    initialState: AgentQueueSyncState,
+  ): Promise<void> {
+    for (const message of initialState.pendingMigration) {
+      if (!this.isCurrent(client, source) || !this.isActiveAgent(agentId)) return;
+      try {
+        const session = useSessionStore.getState().sessions[this.serverId];
+        const payload = splitComposerAttachmentsForSubmit(message.attachments, {
+          format: resolveComposerAttachmentSubmitFormat({
+            supportsForgeAttachments: session?.serverInfo?.features?.forgeSearch === true,
+          }),
+        });
+        const images = await encodeImages(payload.images);
+        await client.queueAgentMessage(agentId, message.text, {
+          messageId: message.id,
+          ...(images && images.length > 0 ? { images } : {}),
+          ...(payload.attachments.length > 0 ? { attachments: payload.attachments } : {}),
+        });
+      } catch (error) {
+        console.error("[AgentMessageQueue] Failed to migrate locally queued message:", error);
+        // Preserve FIFO: once one item fails, its entire suffix remains local
+        // and is retried in order on the next connection.
+        return;
+      }
+      if (!this.isCurrent(client, source)) return;
+      const current = this.stateByAgent.get(agentId);
+      if (!current) return;
+      current.pendingMigration = current.pendingMigration.filter(
+        (candidate) => candidate.id !== message.id,
+      );
+    }
+  }
+
+  private async applyEventQueue(
+    client: AgentMessageQueueClient,
+    source: DirectorySourceToken,
+    queue: NormalizedQueuedAgentMessageQueuePayload,
+  ): Promise<void> {
+    if (!this.isActiveAgent(queue.agentId)) return;
+    const mirrored = useSessionStore
+      .getState()
+      .sessions[this.serverId]?.queuedMessages.get(queue.agentId);
+    const hydrated = needsPayloadHydration(queue, mirrored)
+      ? (await client.listQueuedAgentMessages(queue.agentId))[0]
+      : queue;
+    if (hydrated) await this.applyQueue(client, source, hydrated);
+  }
+
+  private async applyQueue(
+    client: AgentMessageQueueClient,
+    source: DirectorySourceToken,
+    queue: NormalizedQueuedAgentMessageQueuePayload,
+  ): Promise<void> {
+    if (!this.isCurrent(client, source) || !this.isActiveAgent(queue.agentId)) return;
+    const state = this.stateByAgent.get(queue.agentId) ?? {
+      revision: null,
+      pendingMigration: [],
+    };
+    if (state.revision !== null && queue.revision < state.revision) return;
+
+    const previous = useSessionStore
+      .getState()
+      .sessions[this.serverId]?.queuedMessages.get(queue.agentId);
+    const serverMessages = await mergeQueuedMessages({
+      serverId: this.serverId,
+      previous,
+      incoming: queue.messages,
+    });
+    if (!this.isCurrent(client, source) || !this.isActiveAgent(queue.agentId)) return;
+    const latest = this.stateByAgent.get(queue.agentId) ?? state;
+    if (latest.revision !== null && queue.revision < latest.revision) return;
+
+    latest.revision = queue.revision;
+    this.stateByAgent.set(queue.agentId, latest);
+    const serverIds = new Set(serverMessages.map((message) => message.id));
+    const pending = latest.pendingMigration.filter((message) => !serverIds.has(message.id));
+    const messages = [...serverMessages, ...pending];
+    useSessionStore.getState().setQueuedMessages(this.serverId, (current) => {
+      const existing = current.get(queue.agentId);
+      if (messages.length === 0) {
+        if (!existing) return current;
+        const next = new Map(current);
+        next.delete(queue.agentId);
+        return next;
+      }
+      const next = new Map(current);
+      next.set(queue.agentId, messages);
+      return next;
+    });
+  }
+
+  private isCurrent(client: AgentMessageQueueClient, source: DirectorySourceToken): boolean {
+    return (
+      this.connection.client === client &&
+      this.connection.status === "online" &&
+      sourcesEqual(this.connection.source, source)
+    );
+  }
+
+  private isActiveAgent(agentId: string): boolean {
+    return this.activeAgentIds?.has(agentId) === true;
+  }
+}

--- a/packages/app/src/runtime/directory-sync/agent-replica.test.ts
+++ b/packages/app/src/runtime/directory-sync/agent-replica.test.ts
@@ -50,12 +50,18 @@ function entry(agent: AgentSnapshotPayload): FetchAgentsEntry {
   };
 }
 
+const NOOP_REPLICA_CALLBACKS = {
+  onStoppedRunning: () => undefined,
+  onAgentInactive: () => undefined,
+  onDirectoryCommitted: () => undefined,
+};
+
 describe("AgentDirectoryReplica", () => {
   it("accepts the requested agent from the authoritative timeline after a cache miss", () => {
     const serverId = "agent-replica-cache-miss";
     const store = useSessionStore.getState();
     store.initializeSession(serverId, null as unknown as DaemonClient);
-    const replica = new AgentDirectoryReplica(serverId, () => undefined);
+    const replica = new AgentDirectoryReplica(serverId, NOOP_REPLICA_CALLBACKS);
 
     expect(replica.submitTimelineAgent(replica.captureTimeline("agent"), payload("network"))).toBe(
       true,
@@ -70,7 +76,7 @@ describe("AgentDirectoryReplica", () => {
     const serverId = "agent-replica-catch-up";
     const store = useSessionStore.getState();
     store.initializeSession(serverId, null as unknown as DaemonClient);
-    const replica = new AgentDirectoryReplica(serverId, () => undefined);
+    const replica = new AgentDirectoryReplica(serverId, NOOP_REPLICA_CALLBACKS);
     replica.commitSnapshot(
       [
         entry({
@@ -95,7 +101,7 @@ describe("AgentDirectoryReplica", () => {
     const serverId = "agent-replica";
     const store = useSessionStore.getState();
     store.initializeSession(serverId, null as unknown as DaemonClient);
-    const replica = new AgentDirectoryReplica(serverId, () => undefined);
+    const replica = new AgentDirectoryReplica(serverId, NOOP_REPLICA_CALLBACKS);
     replica.commitSnapshot([entry(payload("directory"))], []);
     const directoryPlacement = useSessionStore
       .getState()

--- a/packages/app/src/runtime/directory-sync/agent-replica.ts
+++ b/packages/app/src/runtime/directory-sync/agent-replica.ts
@@ -33,7 +33,11 @@ export class AgentDirectoryReplica {
 
   constructor(
     private readonly serverId: string,
-    private readonly onStoppedRunning: (agentId: string) => void,
+    private readonly callbacks: {
+      onStoppedRunning: (agentId: string) => void;
+      onAgentInactive: (agentId: string) => void;
+      onDirectoryCommitted: (agentIds: ReadonlySet<string>) => void;
+    },
   ) {}
 
   captureTimeline(agentId: string): AgentLifecycleToken {
@@ -98,11 +102,13 @@ export class AgentDirectoryReplica {
     if (delta.kind === "remove") {
       this.members.delete(delta.agentId);
       this.advance(delta.agentId);
+      this.callbacks.onAgentInactive(delta.agentId);
     } else {
       this.members.add(delta.agent.id);
       if (!before) this.advance(delta.agent.id);
     }
-    if (result.stoppedRunning) this.onStoppedRunning(result.agentId);
+    if (result.stoppedRunning) this.callbacks.onStoppedRunning(result.agentId);
+    this.callbacks.onDirectoryCommitted(new Set(this.members));
   }
 
   commitSnapshot(
@@ -122,7 +128,10 @@ export class AgentDirectoryReplica {
       if (!this.members.has(agentId)) this.advance(agentId);
     }
     for (const agentId of previous.keys()) {
-      if (!nextIds.has(agentId)) removeAgentDirectoryReplica(this.serverId, agentId);
+      if (!nextIds.has(agentId)) {
+        removeAgentDirectoryReplica(this.serverId, agentId);
+        this.callbacks.onAgentInactive(agentId);
+      }
     }
     this.members.clear();
     this.pendingCacheReads.clear();
@@ -131,7 +140,10 @@ export class AgentDirectoryReplica {
       serverId: this.serverId,
       entries: reconciled.entries,
     });
-    for (const agentId of reconciled.stoppedRunningAgentIds) this.onStoppedRunning(agentId);
+    for (const agentId of reconciled.stoppedRunningAgentIds) {
+      this.callbacks.onStoppedRunning(agentId);
+    }
+    this.callbacks.onDirectoryCommitted(nextIds);
     return agents;
   }
 
@@ -155,6 +167,7 @@ export class AgentDirectoryReplica {
   }
 
   archive(agentId: string, archivedAt: string): void {
+    this.members.delete(agentId);
     this.advance(agentId);
     useSessionStore.getState().setAgents(this.serverId, (current) => {
       const agent = current.get(agentId);
@@ -164,12 +177,14 @@ export class AgentDirectoryReplica {
       return next;
     });
     clearArchiveAgentPending({ queryClient, serverId: this.serverId, agentId });
+    this.callbacks.onAgentInactive(agentId);
   }
 
   remove(agentId: string): void {
     this.members.delete(agentId);
     this.advance(agentId);
     removeAgentDirectoryReplica(this.serverId, agentId);
+    this.callbacks.onAgentInactive(agentId);
   }
 
   private advance(agentId: string): void {

--- a/packages/app/src/runtime/directory-sync/index.test.ts
+++ b/packages/app/src/runtime/directory-sync/index.test.ts
@@ -123,6 +123,12 @@ class FakeDirectoryClient {
 
 const serverIds = new Set<string>();
 
+const NOOP_DIRECTORY_CALLBACKS = {
+  onAgentStoppedRunning: () => undefined,
+  onAgentInactive: () => undefined,
+  onAgentDirectoryCommitted: () => undefined,
+};
+
 function createDirectory(serverId: string): {
   client: FakeDirectoryClient;
   directory: DirectorySync;
@@ -130,7 +136,7 @@ function createDirectory(serverId: string): {
   serverIds.add(serverId);
   const client = new FakeDirectoryClient();
   const directory = new DirectorySync(serverId, {
-    onAgentStoppedRunning: () => undefined,
+    ...NOOP_DIRECTORY_CALLBACKS,
     markAgentLoading: () => undefined,
     markAgentReady: () => undefined,
     markAgentError: () => undefined,
@@ -211,7 +217,7 @@ describe("DirectorySync session readiness", () => {
     const directory = new DirectorySync(
       serverId,
       {
-        onAgentStoppedRunning: () => undefined,
+        ...NOOP_DIRECTORY_CALLBACKS,
         markAgentLoading: () => undefined,
         markAgentReady: () => undefined,
         markAgentError: () => undefined,
@@ -267,7 +273,7 @@ describe("DirectorySync session readiness", () => {
     const directory = new DirectorySync(
       serverId,
       {
-        onAgentStoppedRunning: () => undefined,
+        ...NOOP_DIRECTORY_CALLBACKS,
         markAgentLoading: () => undefined,
         markAgentReady: () => undefined,
         markAgentError: () => undefined,
@@ -305,7 +311,7 @@ describe("DirectorySync session readiness", () => {
     const directory = new DirectorySync(
       serverId,
       {
-        onAgentStoppedRunning: () => undefined,
+        ...NOOP_DIRECTORY_CALLBACKS,
         markAgentLoading: () => undefined,
         markAgentReady: () => undefined,
         markAgentError: () => undefined,
@@ -460,7 +466,7 @@ describe("DirectorySync session readiness", () => {
     const directory = new DirectorySync(
       serverId,
       {
-        onAgentStoppedRunning: () => undefined,
+        ...NOOP_DIRECTORY_CALLBACKS,
         markAgentLoading: () => undefined,
         markAgentReady: () => undefined,
         markAgentError: () => undefined,
@@ -542,7 +548,7 @@ describe("DirectorySync session readiness", () => {
     const directory = new DirectorySync(
       serverId,
       {
-        onAgentStoppedRunning: () => undefined,
+        ...NOOP_DIRECTORY_CALLBACKS,
         markAgentLoading: () => undefined,
         markAgentReady: () => undefined,
         markAgentError: () => undefined,
@@ -608,7 +614,7 @@ describe("DirectorySync session readiness", () => {
     const directory = new DirectorySync(
       serverId,
       {
-        onAgentStoppedRunning: () => undefined,
+        ...NOOP_DIRECTORY_CALLBACKS,
         markAgentLoading: () => undefined,
         markAgentReady: () => undefined,
         markAgentError: () => undefined,
@@ -693,7 +699,7 @@ describe("DirectorySync session readiness", () => {
     const directory = new DirectorySync(
       serverId,
       {
-        onAgentStoppedRunning: () => undefined,
+        ...NOOP_DIRECTORY_CALLBACKS,
         markAgentLoading: () => undefined,
         markAgentReady: () => undefined,
         markAgentError: () => undefined,
@@ -741,7 +747,7 @@ describe("DirectorySync session readiness", () => {
     const directory = new DirectorySync(
       serverId,
       {
-        onAgentStoppedRunning: () => undefined,
+        ...NOOP_DIRECTORY_CALLBACKS,
         markAgentLoading: () => undefined,
         markAgentReady: () => undefined,
         markAgentError: () => undefined,
@@ -793,7 +799,7 @@ describe("DirectorySync session readiness", () => {
     const directory = new DirectorySync(
       serverId,
       {
-        onAgentStoppedRunning: () => undefined,
+        ...NOOP_DIRECTORY_CALLBACKS,
         markAgentLoading: () => undefined,
         markAgentReady: () => undefined,
         markAgentError: () => undefined,
@@ -909,7 +915,7 @@ describe("DirectorySync session readiness", () => {
     const directory = new DirectorySync(
       serverId,
       {
-        onAgentStoppedRunning: () => undefined,
+        ...NOOP_DIRECTORY_CALLBACKS,
         markAgentLoading: () => undefined,
         markAgentReady: () => undefined,
         markAgentError: () => undefined,

--- a/packages/app/src/runtime/directory-sync/index.ts
+++ b/packages/app/src/runtime/directory-sync/index.ts
@@ -133,13 +133,23 @@ export class DirectorySync {
     private readonly serverId: string,
     private readonly callbacks: {
       onAgentStoppedRunning: (agentId: string) => void;
+      onAgentInactive: (agentId: string, source: DirectorySourceToken) => void;
+      onAgentDirectoryCommitted: (
+        agentIds: ReadonlySet<string>,
+        source: DirectorySourceToken,
+      ) => void;
       markAgentLoading: () => void;
       markAgentReady: () => void;
       markAgentError: (error: string) => void;
     },
     private readonly checkpoints?: DirectoryCheckpointStorage,
   ) {
-    this.agents = new AgentDirectoryReplica(serverId, callbacks.onAgentStoppedRunning);
+    this.agents = new AgentDirectoryReplica(serverId, {
+      onStoppedRunning: callbacks.onAgentStoppedRunning,
+      onAgentInactive: (agentId) => callbacks.onAgentInactive(agentId, this.connection.source),
+      onDirectoryCommitted: (agentIds) =>
+        callbacks.onAgentDirectoryCommitted(agentIds, this.connection.source),
+    });
     this.workspaces = new WorkspaceDirectoryReplica(serverId);
   }
 

--- a/packages/app/src/runtime/host-runtime.test.ts
+++ b/packages/app/src/runtime/host-runtime.test.ts
@@ -3417,6 +3417,41 @@ describe("HostRuntimeStore", () => {
   });
 });
 
+describe("HostRuntimeStore queue identity reconciliation", () => {
+  it("preserves local migration candidates when a placeholder server id is reconciled", async () => {
+    const oldServerId = "placeholder-server";
+    const newServerId = "srv_reconciled";
+    const host = makeHost({ serverId: oldServerId });
+    const fakeClient = new FakeDaemonClient();
+    // DaemonClient has private nominal state, so the established legacy fake
+    // cannot satisfy it structurally. Keep that boundary to one local value.
+    const daemonClient = fakeClient as unknown as DaemonClient;
+    const store = new HostRuntimeStore({
+      deps: {
+        createClient: () => daemonClient,
+        connectToDaemon: async () => ({
+          client: daemonClient,
+          serverId: oldServerId,
+          hostname: null,
+        }),
+        getClientId: async () => "cid_reconciled_queue",
+      },
+    });
+    store.syncHosts([host]);
+    await vi.waitFor(() => expect(store.getSnapshot(oldServerId)?.client).toBe(fakeClient));
+    const queued = [{ id: "message-1", text: "migrate me", attachments: [] }];
+    useSessionStore.getState().setQueuedMessages(oldServerId, new Map([["agent-1", queued]]));
+
+    store.reconcileServerId(oldServerId, newServerId);
+
+    expect(useSessionStore.getState().sessions[oldServerId]).toBeUndefined();
+    expect(useSessionStore.getState().sessions[newServerId]?.queuedMessages.get("agent-1")).toEqual(
+      queued,
+    );
+    store.syncHosts([]);
+  });
+});
+
 describe("readInitialDaemonConnectionHint", () => {
   it("returns null when no hint is present", () => {
     expect(readInitialDaemonConnectionHint({ isWebRuntime: true })).toBeNull();

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -60,6 +60,10 @@ import { createMessageSubmissionWriter } from "@/composer/submission/writer";
 import { resolveComposerAttachmentSubmitFormat } from "@/composer/attachments/submit";
 import { encodeImages } from "@/utils/encode-images";
 import { DirectorySync, type RefreshAgentDirectoryResult } from "@/runtime/directory-sync";
+import {
+  AgentMessageQueueSync,
+  toAgentMessageQueueConnection,
+} from "@/runtime/agent-message-queue-sync";
 import { ReplicaCache } from "@/runtime/replica-cache";
 import type { ReplicaRowStore } from "@/runtime/replica-cache/row-store";
 import { createReplicaRowStore } from "@/runtime/replica-cache/row-store-factory";
@@ -1395,6 +1399,7 @@ export class HostRuntimeStore {
   private queuedAgentDrainInFlight = new Set<string>();
   private directorySyncByServer = new Map<string, DirectorySync>();
   private timelineReplicaByServer = new Map<string, TimelineReplica>();
+  private agentMessageQueueSyncByServer = new Map<string, AgentMessageQueueSync>();
   private configuredOverrideBootstrapInFlight: Promise<void> | null = null;
   private bootPromise: Promise<void> | null = null;
   private storage: HostRuntimeStorage;
@@ -1644,14 +1649,23 @@ export class HostRuntimeStore {
     rekeyMap(this.lastConnectionStatusByServer, oldServerId, newServerId);
     rekeyMap(this.connectionStatusStartedAtByServer, oldServerId, newServerId);
     this.replicaCache.reconcileServerId(oldServerId, newServerId);
+    const queuedMessages = useSessionStore.getState().sessions[oldServerId]?.queuedMessages;
     projectIconCache.reconcileServerId(oldServerId, newServerId);
     this.directorySyncByServer.get(oldServerId)?.dispose();
     this.directorySyncByServer.delete(oldServerId);
     this.timelineReplicaByServer.delete(oldServerId);
+    const queueSync =
+      this.agentMessageQueueSyncByServer.get(oldServerId) ?? new AgentMessageQueueSync(newServerId);
+    this.agentMessageQueueSyncByServer.delete(oldServerId);
+    queueSync.adoptServerId(newServerId);
+    this.agentMessageQueueSyncByServer.set(newServerId, queueSync);
     const directory = new DirectorySync(
       newServerId,
       {
         onAgentStoppedRunning: (agentId) => this.drainQueuedAgentMessage(newServerId, agentId),
+        onAgentInactive: (agentId, source) => queueSync.removeAgent(agentId, source),
+        onAgentDirectoryCommitted: (agentIds, source) =>
+          queueSync.directoryCommitted(agentIds, source),
         markAgentLoading: () => controller.markAgentDirectorySyncLoading(),
         markAgentReady: () => controller.markAgentDirectorySyncReady(),
         markAgentError: (error) => controller.markAgentDirectorySyncError(error),
@@ -1671,14 +1685,19 @@ export class HostRuntimeStore {
     const snapshot = controller.getSnapshot();
     this.clearHostReplica(oldServerId);
     this.syncSessionReplica(newServerId, snapshot);
-    directory.connectionChanged({
+    if (queuedMessages && queuedMessages.size > 0) {
+      useSessionStore.getState().setQueuedMessages(newServerId, queuedMessages);
+    }
+    const connection = {
       client: snapshot.client,
       status: snapshot.connectionStatus === "online" ? "online" : "offline",
       source: {
         clientGeneration: snapshot.clientGeneration,
         connectionEpoch: snapshot.connectionEpoch,
       },
-    });
+    } as const;
+    queueSync.connectionChanged(toAgentMessageQueueConnection(connection));
+    directory.connectionChanged(connection);
 
     const listeners = this.serverListeners.get(oldServerId);
     if (listeners) {
@@ -2042,6 +2061,8 @@ export class HostRuntimeStore {
       this.directorySyncByServer.get(serverId)?.dispose();
       this.directorySyncByServer.delete(serverId);
       this.timelineReplicaByServer.delete(serverId);
+      this.agentMessageQueueSyncByServer.get(serverId)?.dispose();
+      this.agentMessageQueueSyncByServer.delete(serverId);
       this.clearHostReplica(serverId);
       void controller.stop();
       this.emit(serverId);
@@ -2066,10 +2087,15 @@ export class HostRuntimeStore {
       });
       this.controllers.set(host.serverId, controller);
       useSessionStore.getState().initializeSession(host.serverId, null);
+      const queueSync = new AgentMessageQueueSync(host.serverId);
+      this.agentMessageQueueSyncByServer.set(host.serverId, queueSync);
       const directory = new DirectorySync(
         host.serverId,
         {
           onAgentStoppedRunning: (agentId) => this.drainQueuedAgentMessage(host.serverId, agentId),
+          onAgentInactive: (agentId, source) => queueSync.removeAgent(agentId, source),
+          onAgentDirectoryCommitted: (agentIds, source) =>
+            queueSync.directoryCommitted(agentIds, source),
           markAgentLoading: () => controller.markAgentDirectorySyncLoading(),
           markAgentReady: () => controller.markAgentDirectorySyncReady(),
           markAgentError: (error) => controller.markAgentDirectorySyncError(error),
@@ -2132,15 +2158,18 @@ export class HostRuntimeStore {
       return;
     }
     const snapshot = controller.getSnapshot();
-    const directory = this.directorySyncByServer.get(serverId);
-    directory?.connectionChanged({
+    const connection = {
       client: snapshot.client,
       status: snapshot.connectionStatus === "online" ? "online" : "offline",
       source: {
         clientGeneration: snapshot.clientGeneration,
         connectionEpoch: snapshot.connectionEpoch,
       },
-    });
+    } as const;
+    this.agentMessageQueueSyncByServer
+      .get(serverId)
+      ?.connectionChanged(toAgentMessageQueueConnection(connection));
+    this.directorySyncByServer.get(serverId)?.connectionChanged(connection);
     const previousStatus = this.lastConnectionStatusByServer.get(serverId);
     const statusChanged = previousStatus !== snapshot.connectionStatus;
     const isUnavailable =
@@ -2165,6 +2194,9 @@ export class HostRuntimeStore {
   }
 
   drainQueuedAgentMessage(serverId: string, agentId: string): void {
+    if (this.agentMessageQueueSyncByServer.get(serverId)?.isDaemonQueueEnabled()) {
+      return;
+    }
     const drainKey = `${serverId}:${agentId}`;
     if (this.queuedAgentDrainInFlight.has(drainKey)) return;
     const store = useSessionStore.getState();

--- a/packages/app/src/utils/server-info-capabilities.ts
+++ b/packages/app/src/utils/server-info-capabilities.ts
@@ -3,6 +3,14 @@ import type { DaemonServerInfo } from "@/stores/session-store";
 
 export type VoiceReadinessMode = "dictation" | "voice";
 
+// COMPAT(agentMessageQueue): added in v0.6.2, drop the gate after 2027-02-26
+// once the supported daemon floor is >= v0.6.2.
+export function supportsAgentMessageQueue(
+  serverInfo: DaemonServerInfo | null | undefined,
+): boolean {
+  return serverInfo?.features?.agentMessageQueue === true;
+}
+
 export function getServerCapabilities(params: {
   serverInfo: DaemonServerInfo | null | undefined;
 }): DaemonServerInfo["capabilities"] | null {

--- a/packages/client/src/compat/normalize-agent-message-queue.test.ts
+++ b/packages/client/src/compat/normalize-agent-message-queue.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeAgentMessageQueueMessage,
+  normalizeQueuedAgentMessagePayload,
+  normalizeQueuedAgentMessageQueuePayload,
+} from "./normalize-agent-message-queue.js";
+
+describe("agent message queue compatibility normalization", () => {
+  it("applies old-daemon defaults after structural wire parsing", () => {
+    expect(
+      normalizeQueuedAgentMessageQueuePayload({
+        agentId: "agent-1",
+        messages: [
+          {
+            id: "message-1",
+            agentId: "agent-1",
+            text: "hello",
+            createdAt: "2026-07-30T00:00:00.000Z",
+          },
+        ],
+      }),
+    ).toEqual({
+      agentId: "agent-1",
+      revision: 0,
+      messages: [
+        {
+          id: "message-1",
+          agentId: "agent-1",
+          text: "hello",
+          createdAt: "2026-07-30T00:00:00.000Z",
+          images: [],
+          attachments: [],
+          imageCount: 0,
+          attachmentCount: 0,
+        },
+      ],
+    });
+  });
+
+  it("drops unknown attachment shapes but retains their count", () => {
+    const normalized = normalizeQueuedAgentMessagePayload({
+      id: "message-1",
+      agentId: "agent-1",
+      text: "hello",
+      createdAt: "2026-07-30T00:00:00.000Z",
+      attachments: [
+        {
+          type: "uploaded_file",
+          id: "file-1",
+          fileName: "notes.txt",
+          mimeType: "text/plain",
+          size: 5,
+          path: "/tmp/notes.txt",
+        },
+        { type: "future_attachment", payload: "opaque" },
+      ],
+    });
+
+    expect(normalized.attachments).toHaveLength(1);
+    expect(normalized.attachmentCount).toBe(2);
+  });
+
+  it("normalizes queue events before consumers and request waiters see them", () => {
+    const normalized = normalizeAgentMessageQueueMessage({
+      type: "queue.agent_message.updated",
+      payload: { agentId: "agent-1", messages: [] },
+    });
+
+    expect(normalized).toEqual({
+      type: "queue.agent_message.updated",
+      payload: { agentId: "agent-1", revision: 0, messages: [] },
+    });
+  });
+});

--- a/packages/client/src/compat/normalize-agent-message-queue.ts
+++ b/packages/client/src/compat/normalize-agent-message-queue.ts
@@ -1,0 +1,80 @@
+import {
+  normalizeAgentAttachments,
+  type AgentAttachment,
+  type QueuedAgentMessagePayload,
+  type QueuedAgentMessageQueuePayload,
+  type SessionOutboundMessage,
+} from "@getpaseo/protocol/messages";
+
+export type NormalizedQueuedAgentMessagePayload = Omit<
+  QueuedAgentMessagePayload,
+  "images" | "attachments" | "imageCount" | "attachmentCount"
+> & {
+  images: NonNullable<QueuedAgentMessagePayload["images"]>;
+  attachments: AgentAttachment[];
+  imageCount: number;
+  attachmentCount: number;
+};
+
+export type NormalizedQueuedAgentMessageQueuePayload = Omit<
+  QueuedAgentMessageQueuePayload,
+  "revision" | "messages"
+> & {
+  revision: number;
+  messages: NormalizedQueuedAgentMessagePayload[];
+};
+
+export function normalizeQueuedAgentMessagePayload(
+  payload: QueuedAgentMessagePayload,
+): NormalizedQueuedAgentMessagePayload {
+  const images = payload.images ?? [];
+  const attachments = normalizeAgentAttachments(payload.attachments);
+  const wireAttachmentCount = payload.attachments?.length ?? 0;
+  return {
+    ...payload,
+    images,
+    attachments,
+    imageCount: payload.imageCount ?? images.length,
+    attachmentCount: payload.attachmentCount ?? wireAttachmentCount,
+  };
+}
+
+export function normalizeQueuedAgentMessageQueuePayload(
+  payload: QueuedAgentMessageQueuePayload,
+): NormalizedQueuedAgentMessageQueuePayload {
+  return {
+    ...payload,
+    revision: payload.revision ?? 0,
+    messages: payload.messages.map(normalizeQueuedAgentMessagePayload),
+  };
+}
+
+export function normalizeAgentMessageQueueMessage(
+  message: SessionOutboundMessage,
+): SessionOutboundMessage {
+  if (message.type === "queue.agent_message.updated") {
+    return {
+      ...message,
+      payload: normalizeQueuedAgentMessageQueuePayload(message.payload),
+    };
+  }
+  if (message.type === "queue.agent_message.list.response") {
+    return {
+      ...message,
+      payload: {
+        ...message.payload,
+        queues: message.payload.queues.map(normalizeQueuedAgentMessageQueuePayload),
+      },
+    };
+  }
+  if (message.type === "queue.agent_message.enqueue.response" && message.payload.message) {
+    return {
+      ...message,
+      payload: {
+        ...message.payload,
+        message: normalizeQueuedAgentMessagePayload(message.payload.message),
+      },
+    };
+  }
+  return message;
+}

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -743,6 +743,7 @@ test("advertises client capabilities in hello", async () => {
       provider_subagents: true,
       reasoning_merge_enum: true,
       terminal_reflowable_snapshot: true,
+      agent_message_queue_events: true,
       browser_host: {
         supportedCommands: ["list_tabs"],
         hostKind: "desktop app",

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -152,6 +152,20 @@ import {
   normalizeProviderSnapshotUpdateMessage,
   normalizeProvidersSnapshotPayload,
 } from "./compat/normalize-provider-models.js";
+import {
+  normalizeAgentMessageQueueMessage,
+  normalizeQueuedAgentMessagePayload,
+  normalizeQueuedAgentMessageQueuePayload,
+  type NormalizedQueuedAgentMessagePayload,
+  type NormalizedQueuedAgentMessageQueuePayload,
+} from "./compat/normalize-agent-message-queue.js";
+
+export {
+  normalizeQueuedAgentMessagePayload,
+  normalizeQueuedAgentMessageQueuePayload,
+  type NormalizedQueuedAgentMessagePayload,
+  type NormalizedQueuedAgentMessageQueuePayload,
+};
 import { TerminalStreamRouter, type TerminalStreamEvent } from "./terminal-stream-router.js";
 import type {
   BrowserAutomationExecuteRequest,
@@ -354,6 +368,8 @@ export interface AgentAttentionRequiredNotification {
   shouldNotify: boolean;
   notification?: AgentAttentionNotificationPayload;
 }
+
+export type QueueAgentMessageOptions = SendMessageOptions;
 
 type AgentConfigOverrides = Partial<Omit<AgentSessionConfig, "provider" | "cwd">>;
 
@@ -3077,6 +3093,73 @@ export class DaemonClient {
     await this.sendAgentMessage(agentId, text, options);
   }
 
+  async queueAgentMessage(
+    agentId: string,
+    text: string,
+    options?: QueueAgentMessageOptions,
+  ): Promise<NormalizedQueuedAgentMessagePayload | null> {
+    const messageId = options?.messageId ?? crypto.randomUUID();
+    const payload =
+      await this.sendNamespacedCorrelatedSessionRequest<"queue.agent_message.enqueue.response">({
+        message: {
+          type: "queue.agent_message.enqueue.request",
+          agentId,
+          text,
+          messageId,
+          ...(options?.images ? { images: options.images } : {}),
+          ...(options?.attachments ? { attachments: options.attachments } : {}),
+        },
+      });
+    if (!payload.accepted) {
+      throw new Error(payload.error ?? "queueAgentMessage rejected");
+    }
+    return payload.message ? normalizeQueuedAgentMessagePayload(payload.message) : null;
+  }
+
+  async listQueuedAgentMessages(
+    agentId?: string,
+  ): Promise<NormalizedQueuedAgentMessageQueuePayload[]> {
+    const payload =
+      await this.sendNamespacedCorrelatedSessionRequest<"queue.agent_message.list.response">({
+        message: {
+          type: "queue.agent_message.list.request",
+          ...(agentId ? { agentId } : {}),
+        },
+      });
+    if (payload.error) {
+      throw new Error(payload.error);
+    }
+    return payload.queues.map(normalizeQueuedAgentMessageQueuePayload);
+  }
+
+  async cancelQueuedAgentMessage(agentId: string, queuedMessageId: string): Promise<void> {
+    const payload =
+      await this.sendNamespacedCorrelatedSessionRequest<"queue.agent_message.cancel.response">({
+        message: {
+          type: "queue.agent_message.cancel.request",
+          agentId,
+          queuedMessageId,
+        },
+      });
+    if (!payload.accepted) {
+      throw new Error(payload.error ?? "cancelQueuedAgentMessage rejected");
+    }
+  }
+
+  async dispatchQueuedAgentMessage(agentId: string, queuedMessageId: string): Promise<void> {
+    const payload =
+      await this.sendNamespacedCorrelatedSessionRequest<"queue.agent_message.dispatch.response">({
+        message: {
+          type: "queue.agent_message.dispatch.request",
+          agentId,
+          queuedMessageId,
+        },
+      });
+    if (!payload.accepted) {
+      throw new Error(payload.error ?? "dispatchQueuedAgentMessage rejected");
+    }
+  }
+
   async rewindAgent(
     agentId: string,
     messageId: string,
@@ -5603,6 +5686,7 @@ export class DaemonClient {
           [CLIENT_CAPS.providerSubagents]: true,
           [CLIENT_CAPS.projectUpdates]: true,
           [CLIENT_CAPS.compactProviderSnapshots]: true,
+          [CLIENT_CAPS.agentMessageQueueEvents]: true,
           ...this.config.capabilities,
         },
         ...(this.config.appVersion ? { appVersion: this.config.appVersion } : {}),
@@ -6024,7 +6108,9 @@ export class DaemonClient {
   }
 
   private handleSessionMessage(msg: SessionOutboundMessage): void {
-    const consumerMessage = normalizeProviderSnapshotUpdateMessage(msg);
+    const consumerMessage = normalizeAgentMessageQueueMessage(
+      normalizeProviderSnapshotUpdateMessage(msg),
+    );
 
     if (consumerMessage.type === "status") {
       const serverInfo = parseServerInfoStatusPayload(consumerMessage.payload);

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -99,6 +99,9 @@ async function connectClient(
     type: "hello",
     clientType: "cli",
     protocolVersion: 1,
+    capabilities: {
+      agent_message_queue_events: true,
+    },
   });
   expect(hello.clientId).toEqual(expect.stringMatching(/^paseo-sdk-/));
   ws.message(

--- a/packages/protocol/src/client-capabilities.ts
+++ b/packages/protocol/src/client-capabilities.ts
@@ -28,6 +28,9 @@ export const CLIENT_CAPS = {
   // reconstructed timeline replay after 2027-02-21 once the client floor supports invalidation.
   timelineReplacementInvalidation: "timeline_replacement_invalidation",
   browserHost: "browser_host",
+  // The daemon sends queue.agent_message.updated only to clients that know the
+  // event type; the compatibility cleanup site lives at the broadcast filter.
+  agentMessageQueueEvents: "agent_message_queue_events",
 } as const;
 
 export type ClientCapability = (typeof CLIENT_CAPS)[keyof typeof CLIENT_CAPS];

--- a/packages/protocol/src/messages.test.ts
+++ b/packages/protocol/src/messages.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "vitest";
+import { z } from "zod";
 import {
   FileExplorerRequestSchema,
   PaseoWorktreeArchiveRequestSchema,
   parseServerInfoStatusPayload,
+  QueuedAgentMessageQueuePayloadSchema,
   SessionInboundMessageSchema,
   SessionOutboundMessageSchema,
   WorkspaceProjectDescriptorPayloadSchema,
@@ -343,6 +345,49 @@ describe("agent detach RPC", () => {
       throw new Error("Expected server info payload to parse");
     }
     expect(parsed.features?.importSessionWorkspaceTarget).toBe(true);
+  });
+});
+
+describe("queued agent message compatibility", () => {
+  test("wire parsing leaves queue compatibility defaults to explicit normalization", () => {
+    const parsedQueue = QueuedAgentMessageQueuePayloadSchema.parse({
+      agentId: "agent-1",
+      messages: [],
+    });
+
+    expect(parsedQueue.revision).toBeUndefined();
+
+    const parsedMessage = SessionOutboundMessageSchema.parse({
+      type: "queue.agent_message.updated",
+      payload: {
+        agentId: "agent-1",
+        messages: [],
+      },
+    });
+
+    expect(parsedMessage.type).toBe("queue.agent_message.updated");
+    if (parsedMessage.type !== "queue.agent_message.updated") {
+      throw new Error("Expected queue.agent_message.updated");
+    }
+    expect(parsedMessage.payload.revision).toBeUndefined();
+  });
+
+  test("old queue payload schema strips new daemon revision field", () => {
+    const LegacyQueuedAgentMessageQueuePayloadSchema = z.object({
+      agentId: z.string(),
+      messages: z.array(z.unknown()),
+    });
+
+    const parsed = LegacyQueuedAgentMessageQueuePayloadSchema.parse({
+      agentId: "agent-1",
+      revision: 4,
+      messages: [],
+    });
+
+    expect(parsed).toEqual({
+      agentId: "agent-1",
+      messages: [],
+    });
   });
 });
 

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1171,7 +1171,7 @@ export const AgentAttachmentSchema = z.discriminatedUnion("type", [
   UploadedFileAttachmentSchema,
 ]);
 
-function normalizeAgentAttachments(input: unknown): AgentAttachment[] {
+export function normalizeAgentAttachments(input: unknown): AgentAttachment[] {
   if (!Array.isArray(input)) {
     return [];
   }
@@ -1194,7 +1194,7 @@ export const ChangeRequestCheckoutSourceSchema = z.object({
   projectPath: z.string().optional(),
 });
 
-const ImageAttachmentSchema = z.object({
+export const ImageAttachmentSchema = z.object({
   data: z.string(), // base64 encoded image
   mimeType: z.string(), // e.g., "image/jpeg", "image/png"
 });
@@ -1363,6 +1363,60 @@ export const SendAgentMessageRequestSchema = z.object({
   activeTurnBehavior: ActiveTurnBehaviorSchema.optional(),
   images: z.array(ImageAttachmentSchema).optional(),
   attachments: AgentAttachmentsSchema,
+});
+
+export const QueuedAgentMessagePayloadSchema = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  text: z.string(),
+  createdAt: z.string(),
+  images: z.array(ImageAttachmentSchema).optional(),
+  // Keep the wire array forward-compatible with attachment kinds introduced
+  // after this client. Consumers explicitly retain the attachment kinds they
+  // understand with normalizeAgentAttachments().
+  attachments: z.array(z.unknown()).optional(),
+  imageCount: z.number().int().nonnegative().optional(),
+  attachmentCount: z.number().int().nonnegative().optional(),
+});
+
+export const QueuedAgentMessageQueuePayloadSchema = z.object({
+  agentId: z.string(),
+  revision: z.number().int().nonnegative().optional(),
+  messages: z.array(QueuedAgentMessagePayloadSchema),
+});
+
+export const QueueAgentMessageRequestSchema = z.object({
+  type: z.literal("queue.agent_message.enqueue.request"),
+  requestId: z.string(),
+  /** Accepts full ID, unique prefix, or exact full title (server resolves). */
+  agentId: z.string(),
+  text: z.string(),
+  messageId: z.string().optional(),
+  images: z.array(ImageAttachmentSchema).optional(),
+  attachments: z.array(z.unknown()).optional(),
+});
+
+export const QueueAgentMessageListRequestSchema = z.object({
+  type: z.literal("queue.agent_message.list.request"),
+  requestId: z.string(),
+  /** Omit to list queued messages for all agents. */
+  agentId: z.string().optional(),
+});
+
+export const QueueAgentMessageCancelRequestSchema = z.object({
+  type: z.literal("queue.agent_message.cancel.request"),
+  requestId: z.string(),
+  /** Accepts full ID, unique prefix, or exact full title (server resolves). */
+  agentId: z.string(),
+  queuedMessageId: z.string(),
+});
+
+export const QueueAgentMessageDispatchRequestSchema = z.object({
+  type: z.literal("queue.agent_message.dispatch.request"),
+  requestId: z.string(),
+  /** Accepts full ID, unique prefix, or exact full title (server resolves). */
+  agentId: z.string(),
+  queuedMessageId: z.string(),
 });
 
 export const WaitForFinishRequestSchema = z.object({
@@ -3004,6 +3058,10 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   WorkspaceRecoveryRestoreRequestSchema,
   SetVoiceModeMessageSchema,
   SendAgentMessageRequestSchema,
+  QueueAgentMessageRequestSchema,
+  QueueAgentMessageListRequestSchema,
+  QueueAgentMessageCancelRequestSchema,
+  QueueAgentMessageDispatchRequestSchema,
   WaitForFinishRequestSchema,
   DaemonGetStatusRequestSchema,
   DaemonGetPairingOfferRequestSchema,
@@ -3472,6 +3530,8 @@ export const ServerInfoStatusPayloadSchema = z
         agentProfiles: z.boolean().optional(),
         // COMPAT(agentConfigApply): added in v0.3.2, remove gate after 2027-02-11.
         agentConfigApply: z.boolean().optional(),
+        // COMPAT(agentMessageQueue): added in v0.6.2, remove gate after 2027-02-26.
+        agentMessageQueue: z.boolean().optional(),
       })
       .optional(),
   })
@@ -4533,6 +4593,53 @@ export const SendAgentMessageResponseMessageSchema = z.object({
     accepted: z.boolean(),
     error: z.string().nullable(),
   }),
+});
+
+export const QueueAgentMessageResponseMessageSchema = z.object({
+  type: z.literal("queue.agent_message.enqueue.response"),
+  payload: z.object({
+    requestId: z.string(),
+    agentId: z.string(),
+    accepted: z.boolean(),
+    message: QueuedAgentMessagePayloadSchema.nullable(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const QueueAgentMessageListResponseMessageSchema = z.object({
+  type: z.literal("queue.agent_message.list.response"),
+  payload: z.object({
+    requestId: z.string(),
+    queues: z.array(QueuedAgentMessageQueuePayloadSchema),
+    error: z.string().nullable(),
+  }),
+});
+
+export const QueueAgentMessageCancelResponseMessageSchema = z.object({
+  type: z.literal("queue.agent_message.cancel.response"),
+  payload: z.object({
+    requestId: z.string(),
+    agentId: z.string(),
+    queuedMessageId: z.string(),
+    accepted: z.boolean(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const QueueAgentMessageDispatchResponseMessageSchema = z.object({
+  type: z.literal("queue.agent_message.dispatch.response"),
+  payload: z.object({
+    requestId: z.string(),
+    agentId: z.string(),
+    queuedMessageId: z.string(),
+    accepted: z.boolean(),
+    error: z.string().nullable(),
+  }),
+});
+
+export const QueueAgentMessageUpdatedMessageSchema = z.object({
+  type: z.literal("queue.agent_message.updated"),
+  payload: QueuedAgentMessageQueuePayloadSchema,
 });
 
 export const WaitForFinishResponseMessageSchema = z.object({
@@ -6355,6 +6462,11 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   WorkspaceCreateResponseSchema,
   WorkspaceClearAttentionResponseSchema,
   SendAgentMessageResponseMessageSchema,
+  QueueAgentMessageResponseMessageSchema,
+  QueueAgentMessageListResponseMessageSchema,
+  QueueAgentMessageCancelResponseMessageSchema,
+  QueueAgentMessageDispatchResponseMessageSchema,
+  QueueAgentMessageUpdatedMessageSchema,
   SetVoiceModeResponseMessageSchema,
   DaemonGetStatusResponseSchema,
   DaemonGetPairingOfferResponseSchema,
@@ -6561,6 +6673,19 @@ export type AgentTimelineListPromptsResponseMessage = z.infer<
 export type AgentForkContextResponseMessage = z.infer<typeof AgentForkContextResponseMessageSchema>;
 export type CancelAgentResponseMessage = z.infer<typeof CancelAgentResponseMessageSchema>;
 export type SendAgentMessageResponseMessage = z.infer<typeof SendAgentMessageResponseMessageSchema>;
+export type QueueAgentMessageResponseMessage = z.infer<
+  typeof QueueAgentMessageResponseMessageSchema
+>;
+export type QueueAgentMessageListResponseMessage = z.infer<
+  typeof QueueAgentMessageListResponseMessageSchema
+>;
+export type QueueAgentMessageCancelResponseMessage = z.infer<
+  typeof QueueAgentMessageCancelResponseMessageSchema
+>;
+export type QueueAgentMessageDispatchResponseMessage = z.infer<
+  typeof QueueAgentMessageDispatchResponseMessageSchema
+>;
+export type QueueAgentMessageUpdatedMessage = z.infer<typeof QueueAgentMessageUpdatedMessageSchema>;
 export type SetVoiceModeResponseMessage = z.infer<typeof SetVoiceModeResponseMessageSchema>;
 export type SetAgentModeResponseMessage = z.infer<typeof SetAgentModeResponseMessageSchema>;
 export type SetAgentModelResponseMessage = z.infer<typeof SetAgentModelResponseMessageSchema>;
@@ -6664,6 +6789,14 @@ export type ProjectListRequestMessage = z.infer<typeof ProjectListRequestMessage
 export type FetchAgentRequestMessage = z.infer<typeof FetchAgentRequestMessageSchema>;
 export type AgentForkContextRequestMessage = z.infer<typeof AgentForkContextRequestMessageSchema>;
 export type SendAgentMessageRequest = z.infer<typeof SendAgentMessageRequestSchema>;
+export type QueueAgentMessageRequest = z.infer<typeof QueueAgentMessageRequestSchema>;
+export type QueueAgentMessageListRequest = z.infer<typeof QueueAgentMessageListRequestSchema>;
+export type QueueAgentMessageCancelRequest = z.infer<typeof QueueAgentMessageCancelRequestSchema>;
+export type QueueAgentMessageDispatchRequest = z.infer<
+  typeof QueueAgentMessageDispatchRequestSchema
+>;
+export type QueuedAgentMessagePayload = z.infer<typeof QueuedAgentMessagePayloadSchema>;
+export type QueuedAgentMessageQueuePayload = z.infer<typeof QueuedAgentMessageQueuePayloadSchema>;
 export type WaitForFinishRequest = z.infer<typeof WaitForFinishRequestSchema>;
 export type DictationStreamStartMessage = z.infer<typeof DictationStreamStartMessageSchema>;
 export type DictationStreamChunkMessage = z.infer<typeof DictationStreamChunkMessageSchema>;
@@ -6952,6 +7085,7 @@ export const WSHelloMessageSchema = z.object({
       [CLIENT_CAPS.compactProviderSnapshots]: z.boolean().optional(),
       [CLIENT_CAPS.timelineReplacementInvalidation]: z.boolean().optional(),
       [CLIENT_CAPS.browserHost]: BrowserAutomationHostCapabilitySchema.optional(),
+      [CLIENT_CAPS.agentMessageQueueEvents]: z.boolean().optional(),
     })
     .passthrough()
     .optional(),

--- a/packages/server/src/server/agent-message-queue.test.ts
+++ b/packages/server/src/server/agent-message-queue.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -995,25 +995,24 @@ test("dispatchNow durably restores a message after an asynchronous turn-start fa
 
 test("a failed persist leaves no phantom record in memory", async () => {
   const { dir, store } = await createStore();
+  const filePath = path.join(dir, "agent-message-queue.json");
   await store.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
 
-  // A read-only directory makes the next persist fail after the in-memory
-  // draft was already mutated.
-  await chmod(dir, 0o555);
-  try {
-    await expect(
-      store.enqueue({ agentId: "agent-a", messageId: "queued-2", text: "second" }),
-    ).rejects.toThrow();
+  // Replacing the persisted file with a directory makes the atomic rename
+  // fail on every platform after the in-memory draft has been mutated.
+  await rm(filePath);
+  await mkdir(filePath);
 
-    await expect(store.listQueues("agent-a")).resolves.toMatchObject([
-      { messages: [{ id: "queued-1" }] },
-    ]);
-    await expect(store.listQueues("agent-a")).resolves.toMatchObject([
-      { agentId: "agent-a", revision: 1 },
-    ]);
-  } finally {
-    await chmod(dir, 0o755);
-  }
+  await expect(
+    store.enqueue({ agentId: "agent-a", messageId: "queued-2", text: "second" }),
+  ).rejects.toThrow();
+
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    { messages: [{ id: "queued-1" }] },
+  ]);
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    { agentId: "agent-a", revision: 1 },
+  ]);
 });
 
 test("auto drain stops retrying after consecutive dispatch failures", async () => {

--- a/packages/server/src/server/agent-message-queue.test.ts
+++ b/packages/server/src/server/agent-message-queue.test.ts
@@ -1,0 +1,1202 @@
+import { chmod, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import pino from "pino";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { AgentStorage, type StoredAgentRecord } from "./agent/agent-storage.js";
+import {
+  type AgentMessageQueueAgentManager,
+  type AgentMessageQueueAgent,
+  type AgentMessageQueueAgentStorage,
+  AgentMessageQueueService,
+  AgentMessageQueueStore,
+  buildQueuedAgentPrompt,
+} from "./agent-message-queue.js";
+
+const tempDirs: string[] = [];
+
+async function createStore(): Promise<{ dir: string; store: AgentMessageQueueStore }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "paseo-agent-message-queue-"));
+  tempDirs.push(dir);
+  return {
+    dir,
+    store: new AgentMessageQueueStore({
+      filePath: path.join(dir, "agent-message-queue.json"),
+      logger: pino({ level: "silent" }),
+    }),
+  };
+}
+
+function createStoredRecord(overrides: Partial<StoredAgentRecord> = {}): StoredAgentRecord {
+  const now = "2026-06-30T00:00:00.000Z";
+  return {
+    id: "agent-record",
+    provider: "codex",
+    cwd: "/workspace/project",
+    createdAt: now,
+    updatedAt: now,
+    labels: {},
+    lastStatus: "idle",
+    config: null,
+    persistence: null,
+    ...overrides,
+  };
+}
+
+function deferred<T>(): PromiseWithResolvers<T> {
+  return Promise.withResolvers<T>();
+}
+
+function createQueueAgentManager(
+  methods: AgentMessageQueueAgentManager,
+): AgentMessageQueueAgentManager {
+  return methods;
+}
+
+function createQueueAgentStorage(get: AgentStorage["get"]): AgentMessageQueueAgentStorage {
+  return {
+    get,
+    list: async () => [],
+    addAgentHardDeletedCallback: () => () => {},
+  };
+}
+
+async function noopDispatch(): Promise<void> {}
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+test("persists queued agent messages and exposes summary payloads", async () => {
+  const { dir, store } = await createStore();
+
+  const first = await store.enqueue({
+    agentId: "agent-a",
+    messageId: "queued-1",
+    text: "  first message  ",
+    images: [{ data: "base64-image", mimeType: "image/png" }],
+    attachments: [
+      {
+        type: "text",
+        mimeType: "text/plain",
+        title: "notes.txt",
+        text: "attachment body",
+      },
+    ],
+  });
+  await store.enqueue({
+    agentId: "agent-a",
+    messageId: "queued-2",
+    text: "second message",
+  });
+
+  expect(first.text).toBe("first message");
+
+  const reloadedStore = new AgentMessageQueueStore({
+    filePath: path.join(dir, "agent-message-queue.json"),
+    logger: pino({ level: "silent" }),
+  });
+
+  await expect(reloadedStore.listQueues("agent-a")).resolves.toEqual([
+    {
+      agentId: "agent-a",
+      revision: 2,
+      messages: [
+        {
+          id: "queued-1",
+          agentId: "agent-a",
+          text: "first message",
+          createdAt: expect.any(String),
+          images: [{ data: "base64-image", mimeType: "image/png" }],
+          attachments: [
+            {
+              type: "text",
+              mimeType: "text/plain",
+              title: "notes.txt",
+              text: "attachment body",
+            },
+          ],
+          imageCount: 1,
+          attachmentCount: 1,
+        },
+        {
+          id: "queued-2",
+          agentId: "agent-a",
+          text: "second message",
+          createdAt: expect.any(String),
+          images: [],
+          attachments: [],
+          imageCount: 0,
+          attachmentCount: 0,
+        },
+      ],
+    },
+  ]);
+
+  await expect(readFile(path.join(dir, "agent-message-queue.json"), "utf8")).resolves.toContain(
+    '"revisions"',
+  );
+});
+
+test("reads legacy client ids and omits them from the next persisted state", async () => {
+  const { dir, store } = await createStore();
+  const filePath = path.join(dir, "agent-message-queue.json");
+  await writeFile(
+    filePath,
+    JSON.stringify({
+      version: 1,
+      queues: {
+        "agent-a": [
+          {
+            id: "queued-legacy",
+            agentId: "agent-a",
+            text: "legacy",
+            images: [],
+            attachments: [],
+            createdAt: "2026-06-30T00:00:00.000Z",
+            createdByClientId: "legacy-client",
+          },
+        ],
+      },
+      revisions: { "agent-a": 1 },
+    }),
+    "utf8",
+  );
+
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    {
+      agentId: "agent-a",
+      revision: 1,
+      messages: [{ id: "queued-legacy", text: "legacy" }],
+    },
+  ]);
+
+  await store.enqueue({ agentId: "agent-a", messageId: "queued-current", text: "current" });
+  await expect(readFile(filePath, "utf8")).resolves.not.toContain("createdByClientId");
+});
+
+test("remove, shift, and unshift preserve queue order", async () => {
+  const { store } = await createStore();
+
+  await store.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+  await store.enqueue({ agentId: "agent-a", messageId: "queued-2", text: "second" });
+  await store.enqueue({ agentId: "agent-a", messageId: "queued-3", text: "third" });
+
+  await expect(store.remove("agent-a", "missing")).resolves.toBeNull();
+  await expect(store.remove("agent-a", "queued-2")).resolves.toMatchObject({
+    id: "queued-2",
+    text: "second",
+  });
+
+  const shifted = await store.shift("agent-a");
+  expect(shifted?.id).toBe("queued-1");
+
+  if (!shifted) {
+    throw new Error("Expected shifted queued message");
+  }
+  await store.unshift(shifted);
+
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    {
+      messages: [
+        { id: "queued-1", text: "first" },
+        { id: "queued-3", text: "third" },
+      ],
+    },
+  ]);
+
+  await expect(store.shift("agent-a")).resolves.toMatchObject({ id: "queued-1" });
+  await expect(store.shift("agent-a")).resolves.toMatchObject({ id: "queued-3" });
+  await expect(store.listQueues("agent-a")).resolves.toEqual([
+    {
+      agentId: "agent-a",
+      revision: 8,
+      messages: [],
+    },
+  ]);
+});
+
+test("explicit message ids are idempotent while the durable record is pending", async () => {
+  const { store } = await createStore();
+
+  const first = await store.enqueue({
+    agentId: "agent-a",
+    messageId: "queued-1",
+    text: "first",
+  });
+  const duplicate = await store.enqueue({
+    agentId: "agent-a",
+    messageId: "queued-1",
+    text: "duplicate text ignored",
+  });
+
+  expect(duplicate).toEqual(first);
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    {
+      agentId: "agent-a",
+      revision: 1,
+      messages: [{ id: "queued-1", text: "first" }],
+    },
+  ]);
+});
+
+test("quarantines a corrupt queue file and starts from an empty store", async () => {
+  const { dir, store } = await createStore();
+  await writeFile(path.join(dir, "agent-message-queue.json"), "{not-json", "utf8");
+
+  await expect(store.listQueues()).resolves.toEqual([]);
+
+  const entries = await readdir(dir);
+  expect(entries).toHaveLength(1);
+  expect(entries[0]).toMatch(/^agent-message-queue\.json\.corrupt-/);
+});
+
+test("clearAgent keeps archive tombstones until delete drops them", async () => {
+  const { store } = await createStore();
+
+  await store.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+  await expect(store.clearAgent("agent-a")).resolves.toEqual({
+    agentId: "agent-a",
+    revision: 2,
+    messages: [],
+  });
+
+  await expect(store.listQueues("agent-a")).resolves.toEqual([
+    {
+      agentId: "agent-a",
+      revision: 2,
+      messages: [],
+    },
+  ]);
+  await expect(store.listQueues()).resolves.toEqual([
+    {
+      agentId: "agent-a",
+      revision: 2,
+      messages: [],
+    },
+  ]);
+
+  await expect(store.clearAgent("agent-a")).resolves.toBeNull();
+  await expect(store.clearAgent("agent-a", { dropRevision: true })).resolves.toEqual({
+    agentId: "agent-a",
+    revision: 3,
+    messages: [],
+  });
+  await expect(store.listQueues()).resolves.toEqual([]);
+  await expect(store.listQueues("agent-a")).resolves.toEqual([
+    {
+      agentId: "agent-a",
+      revision: 0,
+      messages: [],
+    },
+  ]);
+});
+
+test("the daemon-global archive callback clears queued messages", async () => {
+  vi.useFakeTimers();
+  const { store } = await createStore();
+  let archiveCallback:
+    | Parameters<AgentMessageQueueAgentManager["addAgentArchivedCallback"]>[0]
+    | null = null;
+  const agentManager = {
+    getAgent: () => null,
+    hasInFlightRun: () => false,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: (
+      callback: Parameters<AgentMessageQueueAgentManager["addAgentArchivedCallback"]>[0],
+    ) => {
+      archiveCallback = callback;
+      return () => {
+        archiveCallback = null;
+      };
+    },
+  } satisfies AgentMessageQueueAgentManager;
+  const agentStorage = {
+    get: async (agentId: string) => createStoredRecord({ id: agentId }),
+    list: async () => [],
+    addAgentHardDeletedCallback: () => () => {},
+  } satisfies AgentMessageQueueAgentStorage;
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage: noopDispatch,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: () => {},
+  });
+  await service.start();
+  await store.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+
+  if (!archiveCallback) throw new Error("Expected archive callback registration");
+  await archiveCallback("agent-a");
+
+  await expect(store.listQueues("agent-a")).resolves.toEqual([
+    { agentId: "agent-a", revision: 2, messages: [] },
+  ]);
+  service.stop();
+});
+
+test("startup removes orphan queues and revision tombstones durably", async () => {
+  const { dir, store } = await createStore();
+  const logger = pino({ level: "silent" });
+  const agentStorage = new AgentStorage(path.join(dir, "agents"), logger);
+  await agentStorage.initialize();
+  await agentStorage.upsert(createStoredRecord({ id: "agent-stored" }));
+
+  await store.enqueue({ agentId: "agent-orphan", messageId: "orphan-message", text: "orphan" });
+  await store.enqueue({
+    agentId: "agent-orphan-tombstone",
+    messageId: "orphan-tombstone-message",
+    text: "orphan tombstone",
+  });
+  await store.clearAgent("agent-orphan-tombstone");
+  await store.enqueue({ agentId: "agent-stored", messageId: "stored-message", text: "stored" });
+  await store.clearAgent("agent-stored");
+  await store.enqueue({ agentId: "agent-live", messageId: "live-message", text: "live" });
+  await store.clearAgent("agent-live");
+
+  const liveAgent = {
+    id: "agent-live",
+    lifecycle: "idle",
+  } satisfies AgentMessageQueueAgent;
+
+  const updates: Array<{ agentId: string; revision: number; messageCount: number }> = [];
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager: createQueueAgentManager({
+      getAgent: (agentId) => (agentId === "agent-live" ? liveAgent : undefined),
+      hasInFlightRun: () => false,
+      subscribeAgentState: () => () => {},
+      addAgentArchivedCallback: () => () => {},
+    }),
+    agentStorage,
+    dispatchMessage: noopDispatch,
+    logger,
+    onQueueUpdated: (queue) => {
+      updates.push({
+        agentId: queue.agentId,
+        revision: queue.revision,
+        messageCount: queue.messages.length,
+      });
+    },
+  });
+
+  await service.start();
+
+  await expect(store.listQueues()).resolves.toEqual([
+    { agentId: "agent-live", revision: 2, messages: [] },
+    { agentId: "agent-stored", revision: 2, messages: [] },
+  ]);
+  expect(updates).toEqual([
+    { agentId: "agent-orphan", revision: 2, messageCount: 0 },
+    { agentId: "agent-orphan-tombstone", revision: 3, messageCount: 0 },
+  ]);
+  await expect(readFile(path.join(dir, "agent-message-queue.json"), "utf8")).resolves.not.toContain(
+    "agent-orphan",
+  );
+  service.stop();
+});
+
+test("the durable agent hard-delete boundary clears queue records and tombstones", async () => {
+  vi.useFakeTimers();
+  const { dir, store } = await createStore();
+  const logger = pino({ level: "silent" });
+  const agentStorage = new AgentStorage(path.join(dir, "agents"), logger);
+  await agentStorage.initialize();
+  await agentStorage.upsert(createStoredRecord({ id: "agent-delete" }));
+  await store.enqueue({ agentId: "agent-delete", messageId: "queued-delete", text: "delete" });
+
+  const updates: Array<{ agentId: string; revision: number; messageCount: number }> = [];
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager: createQueueAgentManager({
+      getAgent: () => undefined,
+      hasInFlightRun: () => false,
+      subscribeAgentState: () => () => {},
+      addAgentArchivedCallback: () => () => {},
+    }),
+    agentStorage,
+    dispatchMessage: noopDispatch,
+    logger,
+    onQueueUpdated: (queue) => {
+      updates.push({
+        agentId: queue.agentId,
+        revision: queue.revision,
+        messageCount: queue.messages.length,
+      });
+    },
+  });
+  await service.start();
+
+  await agentStorage.remove("agent-delete");
+
+  await expect(agentStorage.get("agent-delete")).resolves.toBeNull();
+  await expect(store.listQueues()).resolves.toEqual([]);
+  expect(updates).toEqual([{ agentId: "agent-delete", revision: 2, messageCount: 0 }]);
+  await expect(readFile(path.join(dir, "agent-message-queue.json"), "utf8")).resolves.toBe(
+    JSON.stringify({ version: 1, queues: {}, revisions: {} }, null, 2),
+  );
+  service.stop();
+});
+
+test("agent state events schedule drains only when the queue has messages", async () => {
+  vi.useFakeTimers();
+  const { store } = await createStore();
+  let listener: ((agent: AgentMessageQueueAgent) => void) | null = null;
+  const agentManager = createQueueAgentManager({
+    getAgent: () => undefined,
+    hasInFlightRun: () => false,
+    subscribeAgentState: (nextListener) => {
+      listener = nextListener;
+      return () => {
+        listener = null;
+      };
+    },
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = {
+    get: async () => null,
+    list: async () => [],
+    addAgentHardDeletedCallback: () => () => {},
+  } satisfies AgentMessageQueueAgentStorage;
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage: noopDispatch,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: () => {},
+  });
+  await service.start();
+
+  const agent = { id: "agent-a", lifecycle: "idle" } satisfies AgentMessageQueueAgent;
+  listener?.(agent);
+  await store.hasMessages("agent-a");
+  expect(vi.getTimerCount()).toBe(0);
+
+  await store.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "queued" });
+  listener?.(agent);
+  await store.hasMessages("agent-a");
+  await Promise.resolve();
+  expect(vi.getTimerCount()).toBe(1);
+  service.stop();
+});
+
+test("dispatch failure does not restore messages for non-replayable agents", async () => {
+  const { store } = await createStore();
+  const updates: Array<{ revision: number; messages: Array<{ id: string }> }> = [];
+  const agentManager = createQueueAgentManager({
+    getAgent: () => null,
+    hasInFlightRun: () => false,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async () => null);
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage: async () => {
+      throw new Error("Agent not found: missing-agent");
+    },
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: (queue) => {
+      updates.push({
+        revision: queue.revision,
+        messages: queue.messages.map((message) => ({ id: message.id })),
+      });
+    },
+  });
+
+  await store.enqueue({ agentId: "missing-agent", messageId: "queued-1", text: "first" });
+
+  await expect(service.dispatchNow("missing-agent", "queued-1")).rejects.toThrow(
+    "Agent not found: missing-agent",
+  );
+  await expect(store.listQueues("missing-agent")).resolves.toEqual([
+    {
+      agentId: "missing-agent",
+      revision: 2,
+      messages: [],
+    },
+  ]);
+  expect(updates).toEqual([{ revision: 2, messages: [] }]);
+});
+
+test("dispatch failure does not restore messages for live internal agents", async () => {
+  const { store } = await createStore();
+  const updates: Array<{ revision: number; messages: Array<{ id: string }> }> = [];
+  const agentManager = createQueueAgentManager({
+    getAgent: () =>
+      ({
+        id: "internal-agent",
+        lifecycle: "idle",
+        internal: true,
+      }) satisfies AgentMessageQueueAgent,
+    hasInFlightRun: () => false,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async () => null);
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage: async () => {
+      throw new Error("Cannot dispatch message to internal agent: internal-agent");
+    },
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: (queue) => {
+      updates.push({
+        revision: queue.revision,
+        messages: queue.messages.map((message) => ({ id: message.id })),
+      });
+    },
+  });
+
+  await store.enqueue({ agentId: "internal-agent", messageId: "queued-1", text: "first" });
+
+  await expect(service.dispatchNow("internal-agent", "queued-1")).rejects.toThrow();
+  await expect(store.listQueues("internal-agent")).resolves.toEqual([
+    {
+      agentId: "internal-agent",
+      revision: 2,
+      messages: [],
+    },
+  ]);
+  expect(updates).toEqual([{ revision: 2, messages: [] }]);
+});
+
+test("dispatch reports archived agents without restoring messages", async () => {
+  const { store } = await createStore();
+  const updates: Array<{ revision: number; messages: Array<{ id: string }> }> = [];
+  const agentManager = createQueueAgentManager({
+    getAgent: () =>
+      ({
+        id: "archiving-agent",
+        lifecycle: "idle",
+      }) satisfies AgentMessageQueueAgent,
+    hasInFlightRun: () => false,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async (agentId: string) =>
+    createStoredRecord({
+      id: agentId,
+      archivedAt: "2026-06-30T00:00:01.000Z",
+    }),
+  );
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage: async () => {
+      throw new Error("Queued message target agent is archived: archiving-agent");
+    },
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: (queue) => {
+      updates.push({
+        revision: queue.revision,
+        messages: queue.messages.map((message) => ({ id: message.id })),
+      });
+    },
+  });
+
+  await store.enqueue({ agentId: "archiving-agent", messageId: "queued-1", text: "first" });
+
+  await expect(service.dispatchNow("archiving-agent", "queued-1")).rejects.toThrow(
+    "Queued message target agent is archived: archiving-agent",
+  );
+  await expect(store.listQueues("archiving-agent")).resolves.toEqual([
+    {
+      agentId: "archiving-agent",
+      revision: 2,
+      messages: [],
+    },
+  ]);
+  expect(updates).toEqual([{ revision: 2, messages: [] }]);
+});
+
+test("auto drain dispatches queued messages FIFO one idle turn at a time", async () => {
+  vi.useFakeTimers();
+  const { store } = await createStore();
+  let inFlight = false;
+  const agent = {
+    id: "agent-a",
+    lifecycle: "idle",
+    provider: "codex",
+  } satisfies AgentMessageQueueAgent;
+  const dispatchMessage = vi.fn(async () => {
+    inFlight = true;
+  });
+  const agentManager = createQueueAgentManager({
+    getAgent: () => agent,
+    hasInFlightRun: () => inFlight,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async (agentId) =>
+    createStoredRecord({ id: agentId }),
+  );
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: () => {},
+  });
+
+  await service.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+  await service.enqueue({ agentId: "agent-a", messageId: "queued-2", text: "second" });
+
+  await vi.runOnlyPendingTimersAsync();
+
+  await vi.waitFor(() => {
+    expect(dispatchMessage).toHaveBeenCalledTimes(1);
+  });
+  expect(dispatchMessage).toHaveBeenCalledWith(
+    expect.objectContaining({ id: "queued-1", text: "first" }),
+    { replaceRunning: false },
+  );
+  await vi.waitFor(async () => {
+    const queues = await store.listQueues("agent-a");
+    expect(queues).toMatchObject([
+      {
+        messages: [{ id: "queued-2", text: "second" }],
+      },
+    ]);
+  });
+});
+
+test("auto drain requeues instead of replacing a run that starts after the availability check", async () => {
+  vi.useFakeTimers();
+  const { store } = await createStore();
+  let inFlight = false;
+  let sawShiftedQueue = false;
+  const agent = {
+    id: "agent-a",
+    lifecycle: "idle",
+    provider: "codex",
+  } satisfies AgentMessageQueueAgent;
+  const dispatchMessage = vi.fn(async () => {
+    if (inFlight) {
+      throw new Error("Agent agent-a already has an active run");
+    }
+  });
+  const agentManager = createQueueAgentManager({
+    getAgent: () => agent,
+    hasInFlightRun: () => inFlight,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async (agentId) =>
+    createStoredRecord({ id: agentId }),
+  );
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: (queue) => {
+      if (queue.revision === 2 && queue.messages.length === 0) {
+        sawShiftedQueue = true;
+        inFlight = true;
+      }
+    },
+  });
+
+  await service.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+
+  await vi.runOnlyPendingTimersAsync();
+
+  await vi.waitFor(() => {
+    expect(sawShiftedQueue).toBe(true);
+  });
+  expect(sawShiftedQueue).toBe(true);
+  expect(dispatchMessage).toHaveBeenCalledTimes(1);
+  await vi.waitFor(async () => {
+    const queues = await store.listQueues("agent-a");
+    expect(queues).toMatchObject([
+      {
+        messages: [{ id: "queued-1", text: "first" }],
+      },
+    ]);
+  });
+});
+
+test("dispatchNow does not replace an auto-drained message in the same dispatch window", async () => {
+  vi.useFakeTimers();
+  const { store } = await createStore();
+  let inFlight = false;
+  let dispatchNowResult: Promise<string> | null = null;
+  const agent = {
+    id: "agent-a",
+    lifecycle: "idle",
+    provider: "codex",
+  } satisfies AgentMessageQueueAgent;
+  const dispatchMessage = vi.fn(async () => {
+    inFlight = true;
+  });
+  const agentManager = createQueueAgentManager({
+    getAgent: () => agent,
+    hasInFlightRun: () => inFlight,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async (agentId) =>
+    createStoredRecord({ id: agentId }),
+  );
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: (queue) => {
+      if (queue.revision === 3 && queue.messages.some((message) => message.id === "queued-2")) {
+        dispatchNowResult ??= service.dispatchNow("agent-a", "queued-2").then(
+          () => "resolved",
+          (error) => (error instanceof Error ? error.message : String(error)),
+        );
+      }
+    },
+  });
+
+  await service.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+  await service.enqueue({ agentId: "agent-a", messageId: "queued-2", text: "second" });
+
+  await vi.runOnlyPendingTimersAsync();
+
+  await vi.waitFor(() => {
+    expect(dispatchNowResult).not.toBeNull();
+  });
+  await expect(dispatchNowResult).resolves.toBe("Agent queue is already dispatching: agent-a");
+  expect(dispatchMessage).toHaveBeenCalledTimes(1);
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    {
+      messages: [{ id: "queued-2", text: "second" }],
+    },
+  ]);
+});
+
+test("dispatchNow blocks a scheduled auto drain until the explicit dispatch finishes", async () => {
+  vi.useFakeTimers();
+  const { store } = await createStore();
+  const dispatchStarted = deferred<void>();
+  const releaseDispatch = deferred<void>();
+  const agent = {
+    id: "agent-a",
+    lifecycle: "idle",
+    provider: "codex",
+  } satisfies AgentMessageQueueAgent;
+  const dispatchMessage = vi.fn(async () => {
+    dispatchStarted.resolve();
+    await releaseDispatch.promise;
+  });
+  const agentManager = createQueueAgentManager({
+    getAgent: () => agent,
+    hasInFlightRun: () => false,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async (agentId) =>
+    createStoredRecord({ id: agentId }),
+  );
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: () => {},
+  });
+
+  await service.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+  await service.enqueue({ agentId: "agent-a", messageId: "queued-2", text: "second" });
+
+  const dispatchNowResult = service.dispatchNow("agent-a", "queued-1");
+
+  await dispatchStarted.promise;
+  await vi.runOnlyPendingTimersAsync();
+  await Promise.resolve();
+
+  expect(dispatchMessage).toHaveBeenCalledTimes(1);
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    {
+      messages: [{ id: "queued-2", text: "second" }],
+    },
+  ]);
+
+  releaseDispatch.resolve();
+  await expect(dispatchNowResult).resolves.toBeUndefined();
+  expect(dispatchMessage).toHaveBeenCalledWith(
+    expect.objectContaining({ id: "queued-1", text: "first" }),
+    { replaceRunning: true },
+  );
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    {
+      messages: [{ id: "queued-2", text: "second" }],
+    },
+  ]);
+});
+
+test("dispatchNow does not retry a delayed turn start after the former timeout", async () => {
+  vi.useFakeTimers();
+  const { store } = await createStore();
+  const releaseStart = deferred<void>();
+  let dispatchSettled = false;
+  const agent = {
+    id: "agent-a",
+    lifecycle: "idle",
+    provider: "codex",
+  } satisfies AgentMessageQueueAgent;
+  const dispatchMessage = vi.fn(async () => await releaseStart.promise);
+  const agentManager = createQueueAgentManager({
+    getAgent: () => agent,
+    hasInFlightRun: () => false,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async (agentId) =>
+    createStoredRecord({ id: agentId }),
+  );
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: () => {},
+  });
+
+  await service.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+  const dispatch = service.dispatchNow("agent-a", "queued-1").finally(() => {
+    dispatchSettled = true;
+  });
+
+  await vi.waitFor(() => {
+    expect(dispatchMessage).toHaveBeenCalledTimes(1);
+  });
+  await vi.advanceTimersByTimeAsync(60_000);
+
+  expect(dispatchSettled).toBe(false);
+  expect(dispatchMessage).toHaveBeenCalledTimes(1);
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([{ messages: [] }]);
+
+  releaseStart.resolve();
+  await expect(dispatch).resolves.toBeUndefined();
+  expect(dispatchMessage).toHaveBeenCalledTimes(1);
+});
+
+test("auto drain retries after a transient dispatch failure", async () => {
+  vi.useFakeTimers();
+  const { store } = await createStore();
+  let inFlight = false;
+  const agent = {
+    id: "agent-a",
+    lifecycle: "idle",
+    provider: "codex",
+  } satisfies AgentMessageQueueAgent;
+  const dispatchMessage = vi.fn(async () => {
+    if (dispatchMessage.mock.calls.length === 1) {
+      throw new Error("Transient async turn-start failure");
+    }
+    inFlight = true;
+  });
+  const agentManager = createQueueAgentManager({
+    getAgent: () => agent,
+    hasInFlightRun: () => inFlight,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async (agentId) =>
+    createStoredRecord({ id: agentId }),
+  );
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: () => {},
+  });
+
+  await service.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+
+  await vi.runOnlyPendingTimersAsync();
+  await vi.waitFor(() => {
+    expect(dispatchMessage).toHaveBeenCalledTimes(1);
+  });
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    {
+      messages: [{ id: "queued-1", text: "first" }],
+    },
+  ]);
+
+  await vi.advanceTimersByTimeAsync(25);
+
+  await vi.waitFor(() => {
+    expect(dispatchMessage).toHaveBeenCalledTimes(2);
+  });
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    {
+      messages: [],
+    },
+  ]);
+});
+
+test("dispatchNow durably restores a message after an asynchronous turn-start failure", async () => {
+  const { store } = await createStore();
+  const agent = {
+    id: "agent-a",
+    lifecycle: "idle",
+    provider: "codex",
+  } satisfies AgentMessageQueueAgent;
+  const dispatchMessage = vi.fn(async () => {
+    await Promise.resolve();
+    throw new Error("Explicit async turn-start failure");
+  });
+  const agentManager = createQueueAgentManager({
+    getAgent: () => agent,
+    hasInFlightRun: () => false,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async (agentId) =>
+    createStoredRecord({ id: agentId }),
+  );
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: () => {},
+  });
+
+  await service.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+
+  await expect(service.dispatchNow("agent-a", "queued-1")).rejects.toThrow(
+    "Explicit async turn-start failure",
+  );
+  expect(dispatchMessage).toHaveBeenCalledTimes(1);
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    {
+      revision: 3,
+      messages: [{ id: "queued-1", text: "first" }],
+    },
+  ]);
+});
+
+test("a failed persist leaves no phantom record in memory", async () => {
+  const { dir, store } = await createStore();
+  await store.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+
+  // A read-only directory makes the next persist fail after the in-memory
+  // draft was already mutated.
+  await chmod(dir, 0o555);
+  try {
+    await expect(
+      store.enqueue({ agentId: "agent-a", messageId: "queued-2", text: "second" }),
+    ).rejects.toThrow();
+
+    await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+      { messages: [{ id: "queued-1" }] },
+    ]);
+    await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+      { agentId: "agent-a", revision: 1 },
+    ]);
+  } finally {
+    await chmod(dir, 0o755);
+  }
+});
+
+test("auto drain stops retrying after consecutive dispatch failures", async () => {
+  vi.useFakeTimers();
+  const { store } = await createStore();
+  const agent = {
+    id: "agent-a",
+    lifecycle: "idle",
+    provider: "codex",
+  } satisfies AgentMessageQueueAgent;
+  const dispatchMessage = vi.fn(async () => {
+    throw new Error("Persistent dispatch failure");
+  });
+  const agentManager = createQueueAgentManager({
+    getAgent: () => agent,
+    hasInFlightRun: () => false,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async (agentId) =>
+    createStoredRecord({ id: agentId }),
+  );
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: () => {},
+  });
+
+  await service.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" });
+
+  // One initial attempt plus one retry per remaining rung of the delay
+  // ladder; afterwards the drain waits for the next agent event instead of
+  // looping.
+  await vi.runOnlyPendingTimersAsync();
+  await vi.waitFor(() => {
+    expect(dispatchMessage).toHaveBeenCalledTimes(1);
+  });
+  for (const [attempt, delayMs] of [25, 100, 250, 1000].entries()) {
+    await vi.advanceTimersByTimeAsync(delayMs);
+    await vi.waitFor(() => {
+      expect(dispatchMessage).toHaveBeenCalledTimes(attempt + 2);
+    });
+  }
+
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(dispatchMessage).toHaveBeenCalledTimes(5);
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    {
+      messages: [{ id: "queued-1", text: "first" }],
+    },
+  ]);
+});
+
+test("enqueue is rejected inside the mutation when the agent is archived", async () => {
+  const { store } = await createStore();
+  const agentManager = createQueueAgentManager({
+    getAgent: () => undefined,
+    hasInFlightRun: () => false,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async (agentId: string) =>
+    createStoredRecord({ id: agentId, archivedAt: "2026-06-30T00:00:00.000Z" }),
+  );
+  const updates: string[] = [];
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage: noopDispatch,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: (queue) => {
+      updates.push(queue.agentId);
+    },
+  });
+
+  await expect(
+    service.enqueue({ agentId: "agent-a", messageId: "queued-1", text: "first" }),
+  ).rejects.toThrow("Cannot queue message for archived agent: agent-a");
+
+  expect(updates).toEqual([]);
+  await expect(store.listQueues("agent-a")).resolves.toEqual([
+    { agentId: "agent-a", revision: 0, messages: [] },
+  ]);
+});
+
+test("queue update broadcasts omit image and structured attachment payloads but keep counts", async () => {
+  vi.useFakeTimers();
+  const { store } = await createStore();
+  const agent = {
+    id: "agent-a",
+    lifecycle: "running",
+    provider: "codex",
+  } satisfies AgentMessageQueueAgent;
+  const agentManager = createQueueAgentManager({
+    getAgent: () => agent,
+    hasInFlightRun: () => true,
+    subscribeAgentState: () => () => {},
+    addAgentArchivedCallback: () => () => {},
+  });
+  const agentStorage = createQueueAgentStorage(async (agentId: string) =>
+    createStoredRecord({ id: agentId }),
+  );
+  const broadcasts: Array<{
+    images: Array<{ data: string; mimeType: string }>;
+    attachments: unknown[];
+    imageCount: number;
+    attachmentCount: number;
+  }> = [];
+  const service = new AgentMessageQueueService({
+    store,
+    agentManager,
+    agentStorage,
+    dispatchMessage: noopDispatch,
+    logger: pino({ level: "silent" }),
+    onQueueUpdated: (queue) => {
+      for (const message of queue.messages) {
+        broadcasts.push({
+          images: message.images,
+          attachments: message.attachments,
+          imageCount: message.imageCount,
+          attachmentCount: message.attachmentCount,
+        });
+      }
+    },
+  });
+
+  await service.enqueue({
+    agentId: "agent-a",
+    messageId: "queued-1",
+    text: "first",
+    images: [{ data: "base64-image", mimeType: "image/png" }],
+    attachments: [
+      {
+        type: "text",
+        mimeType: "text/plain",
+        title: "notes.txt",
+        text: "attachment body",
+      },
+    ],
+  });
+
+  expect(broadcasts).toEqual([{ images: [], attachments: [], imageCount: 1, attachmentCount: 1 }]);
+  // The store keeps the full payload for list responses and replay.
+  await expect(store.listQueues("agent-a")).resolves.toMatchObject([
+    {
+      messages: [
+        {
+          images: [{ data: "base64-image", mimeType: "image/png" }],
+          attachments: [{ type: "text", text: "attachment body" }],
+        },
+      ],
+    },
+  ]);
+});
+
+test("buildQueuedAgentPrompt preserves text, image, and structured attachments", () => {
+  expect(
+    buildQueuedAgentPrompt(
+      "  replay this  ",
+      [{ data: "base64-image", mimeType: "image/png" }],
+      [
+        {
+          type: "text",
+          mimeType: "text/plain",
+          title: "notes.txt",
+          text: "attachment body",
+        },
+      ],
+    ),
+  ).toEqual([
+    { type: "text", text: "replay this" },
+    { type: "image", data: "base64-image", mimeType: "image/png" },
+    {
+      type: "text",
+      mimeType: "text/plain",
+      title: "notes.txt",
+      text: "attachment body",
+    },
+  ]);
+
+  expect(buildQueuedAgentPrompt("  plain text  ", [], [])).toBe("plain text");
+});

--- a/packages/server/src/server/agent-message-queue.ts
+++ b/packages/server/src/server/agent-message-queue.ts
@@ -1,0 +1,715 @@
+import { randomUUID } from "node:crypto";
+import { readFile, rename } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import type { Logger } from "pino";
+import {
+  AgentAttachmentSchema,
+  ImageAttachmentSchema,
+  type AgentAttachment,
+  type QueuedAgentMessagePayload,
+  type QueuedAgentMessageQueuePayload,
+} from "./messages.js";
+import type { AgentPromptContentBlock, AgentPromptInput } from "./agent/agent-sdk-types.js";
+import type { AgentManager } from "./agent/agent-manager.js";
+import type { AgentStorage } from "./agent/agent-storage.js";
+import { sendPromptToAgent } from "./agent/agent-prompt.js";
+import { writeJsonFileAtomic } from "./atomic-file.js";
+
+const DRAIN_RETRY_DELAYS_MS = [0, 25, 100, 250, 1000] as const;
+
+const QueuedAgentMessageRecordSchema = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  text: z.string(),
+  images: z.array(ImageAttachmentSchema).default([]),
+  attachments: z.array(AgentAttachmentSchema).default([]),
+  createdAt: z.string(),
+});
+
+const PersistedAgentMessageQueueSchema = z
+  .object({
+    version: z.literal(1).default(1),
+    queues: z.record(z.string(), z.array(QueuedAgentMessageRecordSchema)).default({}),
+    revisions: z.record(z.string(), z.number().int().nonnegative()).default({}),
+  })
+  .default({ version: 1, queues: {}, revisions: {} });
+
+export type QueuedAgentMessageRecord = z.infer<typeof QueuedAgentMessageRecordSchema>;
+
+export type AgentMessageQueuePayload = Omit<
+  QueuedAgentMessagePayload,
+  "images" | "attachments" | "imageCount" | "attachmentCount"
+> & {
+  images: Array<{ data: string; mimeType: string }>;
+  attachments: AgentAttachment[];
+  imageCount: number;
+  attachmentCount: number;
+};
+
+export type AgentMessageQueueSnapshot = Omit<
+  QueuedAgentMessageQueuePayload,
+  "revision" | "messages"
+> & {
+  revision: number;
+  messages: AgentMessageQueuePayload[];
+};
+
+type PersistedAgentMessageQueue = z.infer<typeof PersistedAgentMessageQueueSchema>;
+
+export interface EnqueueAgentMessageInput {
+  agentId: string;
+  text: string;
+  messageId?: string;
+  images?: Array<{ data: string; mimeType: string }>;
+  attachments?: AgentAttachment[];
+}
+
+export interface AgentMessageQueueStoreOptions {
+  filePath: string;
+  logger: Logger;
+}
+
+export class AgentMessageQueueStore {
+  private cache: PersistedAgentMessageQueue | null = null;
+  private loadPromise: Promise<PersistedAgentMessageQueue> | null = null;
+  private mutationQueue: Promise<void> = Promise.resolve();
+
+  constructor(private readonly options: AgentMessageQueueStoreOptions) {}
+
+  async hasMessages(agentId: string): Promise<boolean> {
+    await this.mutationQueue;
+    const state = await this.load();
+    return (state.queues[agentId]?.length ?? 0) > 0;
+  }
+
+  async listQueues(agentId?: string): Promise<AgentMessageQueueSnapshot[]> {
+    await this.mutationQueue;
+    const state = await this.load();
+    const agentIds = agentId
+      ? [agentId]
+      : Array.from(new Set([...Object.keys(state.queues), ...Object.keys(state.revisions)])).sort(
+          (left, right) => left.localeCompare(right),
+        );
+    return agentIds
+      .map((id) => toQueuedAgentMessageQueuePayload(state, id))
+      .filter((queue) => agentId || queue.messages.length > 0 || queue.revision > 0);
+  }
+
+  async enqueue(
+    input: EnqueueAgentMessageInput,
+    options?: { ensureEligible?: () => Promise<void> },
+  ): Promise<QueuedAgentMessageRecord> {
+    const text = input.text.trim();
+    if (!text && (input.images?.length ?? 0) === 0 && (input.attachments?.length ?? 0) === 0) {
+      throw new Error("Queued message is empty");
+    }
+
+    return await this.mutate(async (state) => {
+      // Runs inside the serialized mutation so an archive/delete cleanup that
+      // was ordered ahead of this enqueue cannot be outrun by it.
+      await options?.ensureEligible?.();
+      if (input.messageId) {
+        // This deduplicates only records that are still pending. Delivered ids
+        // are not retained in a ledger and must not be treated as exactly-once.
+        const existing = (state.queues[input.agentId] ?? []).find(
+          (record) => record.id === input.messageId,
+        );
+        if (existing) {
+          return cloneRecord(existing);
+        }
+      }
+      const record: QueuedAgentMessageRecord = {
+        id: input.messageId ?? randomUUID(),
+        agentId: input.agentId,
+        text,
+        images: input.images ?? [],
+        attachments: input.attachments ?? [],
+        createdAt: new Date().toISOString(),
+      };
+      state.queues[input.agentId] = [...(state.queues[input.agentId] ?? []), record];
+      bumpQueueRevision(state, input.agentId);
+      return cloneRecord(record);
+    });
+  }
+
+  async remove(agentId: string, queuedMessageId: string): Promise<QueuedAgentMessageRecord | null> {
+    return await this.mutate(async (state) => {
+      const queue = state.queues[agentId] ?? [];
+      const index = queue.findIndex((record) => record.id === queuedMessageId);
+      if (index === -1) {
+        return null;
+      }
+      const [removed] = queue.splice(index, 1);
+      setQueue(state, agentId, queue);
+      bumpQueueRevision(state, agentId);
+      return removed ? cloneRecord(removed) : null;
+    });
+  }
+
+  async shift(agentId: string): Promise<QueuedAgentMessageRecord | null> {
+    return await this.mutate(async (state) => {
+      const queue = state.queues[agentId] ?? [];
+      const removed = queue.shift() ?? null;
+      setQueue(state, agentId, queue);
+      if (removed) {
+        bumpQueueRevision(state, agentId);
+      }
+      return removed ? cloneRecord(removed) : null;
+    });
+  }
+
+  async unshift(record: QueuedAgentMessageRecord): Promise<void> {
+    await this.mutate(async (state) => {
+      state.queues[record.agentId] = [cloneRecord(record), ...(state.queues[record.agentId] ?? [])];
+      bumpQueueRevision(state, record.agentId);
+    });
+  }
+
+  async clearAgent(
+    agentId: string,
+    options?: { dropRevision?: boolean },
+  ): Promise<AgentMessageQueueSnapshot | null> {
+    return await this.mutate(async (state) => {
+      const hadQueue = (state.queues[agentId]?.length ?? 0) > 0;
+      const hadRevision = state.revisions[agentId] !== undefined;
+      if (!hadQueue && (!options?.dropRevision || !hadRevision)) {
+        return null;
+      }
+      const revision = getQueueRevision(state, agentId) + 1;
+      delete state.queues[agentId];
+      if (options?.dropRevision) {
+        delete state.revisions[agentId];
+      } else {
+        state.revisions[agentId] = revision;
+      }
+      return { agentId, revision, messages: [] };
+    });
+  }
+
+  private async mutate<T>(
+    operation: (state: PersistedAgentMessageQueue) => Promise<T> | T,
+  ): Promise<T> {
+    const task = this.mutationQueue.then(async () => {
+      // Mutate a draft and commit it to the cache only after the write
+      // succeeds, so a failed persist cannot leave the in-memory state
+      // claiming a change that was never durably stored.
+      const draft = structuredClone(await this.load());
+      const result = await operation(draft);
+      await this.persist(draft);
+      this.cache = draft;
+      return result;
+    });
+    this.mutationQueue = task.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await task;
+  }
+
+  private async load(): Promise<PersistedAgentMessageQueue> {
+    if (this.cache) {
+      return this.cache;
+    }
+    if (this.loadPromise) {
+      return await this.loadPromise;
+    }
+    const loadPromise = this.loadFromDisk();
+    this.loadPromise = loadPromise;
+    try {
+      return await loadPromise;
+    } finally {
+      if (this.loadPromise === loadPromise) {
+        this.loadPromise = null;
+      }
+    }
+  }
+
+  private async loadFromDisk(): Promise<PersistedAgentMessageQueue> {
+    try {
+      const raw = await readFile(this.options.filePath, "utf8");
+      this.cache = PersistedAgentMessageQueueSchema.parse(JSON.parse(raw));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        this.cache = { version: 1, queues: {}, revisions: {} };
+      } else if (error instanceof SyntaxError || error instanceof z.ZodError) {
+        const corruptPath = `${this.options.filePath}.corrupt-${Date.now()}-${randomUUID()}`;
+        await rename(this.options.filePath, corruptPath);
+        this.options.logger.error(
+          { err: error, corruptPath },
+          "Quarantined corrupt agent message queue and started empty",
+        );
+        this.cache = { version: 1, queues: {}, revisions: {} };
+      } else {
+        this.options.logger.error({ err: error }, "Failed to load agent message queue");
+        throw error;
+      }
+    }
+    return this.cache;
+  }
+
+  private async persist(state: PersistedAgentMessageQueue): Promise<void> {
+    pruneEmptyQueues(state);
+    await writeJsonFileAtomic(this.options.filePath, state);
+  }
+}
+
+export interface AgentMessageQueueServiceOptions {
+  store: AgentMessageQueueStore;
+  agentManager: AgentMessageQueueAgentManager;
+  agentStorage: AgentMessageQueueAgentStorage;
+  dispatchMessage: (
+    record: QueuedAgentMessageRecord,
+    options?: { replaceRunning?: boolean },
+  ) => Promise<void>;
+  logger: Logger;
+  onQueueUpdated: (queue: AgentMessageQueueSnapshot) => void;
+}
+
+export interface AgentMessageQueueAgent {
+  id: string;
+  internal?: boolean;
+  lifecycle: NonNullable<ReturnType<AgentManager["getAgent"]>>["lifecycle"];
+}
+
+export interface AgentMessageQueueAgentManager {
+  getAgent(agentId: string): AgentMessageQueueAgent | null | undefined;
+  hasInFlightRun(agentId: string): boolean;
+  subscribeAgentState(listener: (agent: AgentMessageQueueAgent) => void): () => void;
+  addAgentArchivedCallback: AgentManager["addAgentArchivedCallback"];
+}
+
+export interface AgentMessageQueueAgentStorage {
+  get: AgentStorage["get"];
+  list: AgentStorage["list"];
+  addAgentHardDeletedCallback: AgentStorage["addAgentHardDeletedCallback"];
+}
+
+export interface AgentMessageQueueController {
+  enqueue(input: EnqueueAgentMessageInput): Promise<AgentMessageQueuePayload>;
+  list(agentId?: string): Promise<AgentMessageQueueSnapshot[]>;
+  cancel(agentId: string, queuedMessageId: string): Promise<boolean>;
+  dispatchNow(agentId: string, queuedMessageId: string): Promise<void>;
+  clearAgent(agentId: string, options?: { dropRevision?: boolean }): Promise<void>;
+}
+
+export class AgentMessageQueueService implements AgentMessageQueueController {
+  private unsubscribeAgentEvents: (() => void) | null = null;
+  private unsubscribeAgentArchived: (() => void) | null = null;
+  private unsubscribeAgentHardDeleted: (() => void) | null = null;
+  private readonly scheduledDrainTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly drainingAgents = new Set<string>();
+  private readonly drainSendFailures = new Map<string, number>();
+
+  constructor(private readonly options: AgentMessageQueueServiceOptions) {}
+
+  async start(): Promise<void> {
+    if (this.unsubscribeAgentEvents) {
+      return;
+    }
+    this.unsubscribeAgentEvents = this.options.agentManager.subscribeAgentState((agent) => {
+      if (agent.lifecycle !== "closed") {
+        void this.scheduleDrainAgentQueueIfPresent(agent.id).catch((error) => {
+          this.options.logger.error(
+            { err: error, agentId: agent.id },
+            "Failed to inspect queued agent messages",
+          );
+        });
+      }
+    });
+    this.unsubscribeAgentArchived = this.options.agentManager.addAgentArchivedCallback(
+      async (agentId) => {
+        await this.clearAgent(agentId);
+      },
+    );
+    this.unsubscribeAgentHardDeleted = this.options.agentStorage.addAgentHardDeletedCallback(
+      async (agentId) => {
+        await this.clearAgent(agentId, { dropRevision: true });
+      },
+    );
+    await this.reconcilePersistedQueues().catch((error) => {
+      this.options.logger.error(
+        { err: error },
+        "Failed to reconcile persisted agent message queues",
+      );
+    });
+  }
+
+  stop(): void {
+    this.unsubscribeAgentEvents?.();
+    this.unsubscribeAgentEvents = null;
+    this.unsubscribeAgentArchived?.();
+    this.unsubscribeAgentArchived = null;
+    this.unsubscribeAgentHardDeleted?.();
+    this.unsubscribeAgentHardDeleted = null;
+    for (const timeout of this.scheduledDrainTimers.values()) {
+      clearTimeout(timeout);
+    }
+    this.scheduledDrainTimers.clear();
+    this.drainSendFailures.clear();
+  }
+
+  async enqueue(input: EnqueueAgentMessageInput): Promise<AgentMessageQueuePayload> {
+    const record = await this.options.store.enqueue(input, {
+      ensureEligible: async () => {
+        const reason = await this.getQueueUnavailableReason(input.agentId);
+        if (reason) {
+          throw new Error(reason);
+        }
+      },
+    });
+    this.drainSendFailures.delete(input.agentId);
+    await this.emitQueueUpdated(input.agentId);
+    this.scheduleDrainAgentQueue(input.agentId);
+    return toQueuedAgentMessagePayload(record);
+  }
+
+  async getQueueUnavailableReason(agentId: string): Promise<string | null> {
+    const live = this.options.agentManager.getAgent(agentId);
+    if (live?.internal) {
+      return `Cannot queue message for internal agent: ${agentId}`;
+    }
+    if (live?.lifecycle === "closed") {
+      return `Cannot queue message for closed agent: ${agentId}`;
+    }
+
+    const stored = await this.options.agentStorage.get(agentId);
+    if (!live && !stored) {
+      return `Agent not found: ${agentId}`;
+    }
+    if (stored?.internal) {
+      return `Cannot queue message for internal agent: ${agentId}`;
+    }
+    if (stored?.archivedAt) {
+      return `Cannot queue message for archived agent: ${agentId}`;
+    }
+
+    return null;
+  }
+
+  async list(agentId?: string): Promise<AgentMessageQueueSnapshot[]> {
+    return await this.options.store.listQueues(agentId);
+  }
+
+  async cancel(agentId: string, queuedMessageId: string): Promise<boolean> {
+    const removed = await this.options.store.remove(agentId, queuedMessageId);
+    if (removed) {
+      await this.emitQueueUpdated(agentId);
+    }
+    return Boolean(removed);
+  }
+
+  async dispatchNow(agentId: string, queuedMessageId: string): Promise<void> {
+    if (this.drainingAgents.has(agentId)) {
+      throw new Error(`Agent queue is already dispatching: ${agentId}`);
+    }
+    this.drainingAgents.add(agentId);
+    try {
+      const record = await this.options.store.remove(agentId, queuedMessageId);
+      if (!record) {
+        throw new Error(`Queued message not found: ${queuedMessageId}`);
+      }
+      await this.emitQueueUpdated(agentId);
+      try {
+        await this.sendQueuedMessage(record, { replaceRunning: true });
+        this.drainSendFailures.delete(agentId);
+      } catch (error) {
+        if (await this.canAgentEverReplay(agentId)) {
+          await this.options.store.unshift(record);
+          await this.emitQueueUpdated(agentId);
+        }
+        throw error;
+      }
+    } finally {
+      this.drainingAgents.delete(agentId);
+    }
+  }
+
+  async clearAgent(agentId: string, options?: { dropRevision?: boolean }): Promise<void> {
+    const scheduled = this.scheduledDrainTimers.get(agentId);
+    if (scheduled) {
+      clearTimeout(scheduled);
+      this.scheduledDrainTimers.delete(agentId);
+    }
+    this.drainSendFailures.delete(agentId);
+    const clearedQueue = await this.options.store.clearAgent(agentId, options);
+    if (clearedQueue) {
+      this.options.onQueueUpdated(clearedQueue);
+    }
+  }
+
+  private scheduleDrainAgentQueue(agentId: string, attempt = 0): void {
+    if (this.scheduledDrainTimers.has(agentId)) {
+      return;
+    }
+
+    const delayMs = DRAIN_RETRY_DELAYS_MS[Math.min(attempt, DRAIN_RETRY_DELAYS_MS.length - 1)] ?? 0;
+    const timeout = setTimeout(() => {
+      this.scheduledDrainTimers.delete(agentId);
+      void this.runScheduledDrain(agentId, attempt).catch((error) => {
+        this.options.logger.error({ err: error, agentId }, "Failed to drain queued agent messages");
+      });
+    }, delayMs);
+    this.scheduledDrainTimers.set(agentId, timeout);
+  }
+
+  private async scheduleDrainAgentQueueIfPresent(agentId: string): Promise<void> {
+    if (await this.options.store.hasMessages(agentId)) {
+      this.scheduleDrainAgentQueue(agentId);
+    }
+  }
+
+  private async runScheduledDrain(agentId: string, attempt: number): Promise<void> {
+    if (await this.isAgentAvailableForAutoReplay(agentId)) {
+      if (await this.hasQueuedMessages(agentId)) {
+        await this.drainAgentQueue(agentId);
+      }
+      return;
+    }
+    if (attempt + 1 < DRAIN_RETRY_DELAYS_MS.length && (await this.canAgentEverReplay(agentId))) {
+      this.scheduleDrainAgentQueue(agentId, attempt + 1);
+    }
+  }
+
+  private async reconcilePersistedQueues(): Promise<void> {
+    const queues = await this.options.store.listQueues();
+    const storedAgentIds = new Set(
+      (await this.options.agentStorage.list()).map((record) => record.id),
+    );
+    for (const queue of queues) {
+      const hasStoredAgent = storedAgentIds.has(queue.agentId);
+      const hasLiveAgent = Boolean(this.options.agentManager.getAgent(queue.agentId));
+      const hasAgent = hasStoredAgent || hasLiveAgent;
+      if (!hasAgent) {
+        await this.clearAgent(queue.agentId, { dropRevision: true });
+        continue;
+      }
+      if (queue.messages.length > 0) {
+        this.scheduleDrainAgentQueue(queue.agentId);
+      }
+    }
+  }
+
+  private async hasQueuedMessages(agentId: string): Promise<boolean> {
+    return await this.options.store.hasMessages(agentId);
+  }
+
+  private async drainAgentQueue(agentId: string): Promise<void> {
+    if (this.drainingAgents.has(agentId)) {
+      return;
+    }
+    this.drainingAgents.add(agentId);
+    let retryAfterFailure = false;
+    try {
+      while (await this.isAgentAvailableForAutoReplay(agentId)) {
+        const record = await this.options.store.shift(agentId);
+        if (!record) {
+          return;
+        }
+        await this.emitQueueUpdated(agentId);
+        try {
+          await this.sendQueuedMessage(record, { replaceRunning: false });
+          this.drainSendFailures.delete(agentId);
+        } catch (error) {
+          if (await this.canAgentEverReplay(agentId)) {
+            await this.options.store.unshift(record);
+            await this.emitQueueUpdated(agentId);
+            retryAfterFailure = true;
+          }
+          this.options.logger.warn(
+            { err: error, agentId, queuedMessageId: record.id },
+            "Failed to dispatch queued agent message",
+          );
+          return;
+        }
+      }
+    } finally {
+      this.drainingAgents.delete(agentId);
+      if (retryAfterFailure) {
+        // Escalate the delay across consecutive send failures; after the
+        // ladder is exhausted, wait for the next agent event (or a new
+        // enqueue) instead of retrying in a tight loop.
+        const attempt = (this.drainSendFailures.get(agentId) ?? 0) + 1;
+        this.drainSendFailures.set(agentId, attempt);
+        if (attempt < DRAIN_RETRY_DELAYS_MS.length) {
+          this.scheduleDrainAgentQueue(agentId, attempt);
+        } else {
+          this.options.logger.warn(
+            { agentId },
+            "Suspending queued message replay until the next agent event",
+          );
+        }
+      }
+    }
+  }
+
+  private async isAgentAvailableForAutoReplay(agentId: string): Promise<boolean> {
+    if (!(await this.canAgentEverReplay(agentId))) {
+      return false;
+    }
+    return !this.options.agentManager.hasInFlightRun(agentId);
+  }
+
+  private async canAgentEverReplay(agentId: string): Promise<boolean> {
+    return (await this.getQueueUnavailableReason(agentId)) === null;
+  }
+
+  private async sendQueuedMessage(
+    record: QueuedAgentMessageRecord,
+    options?: { replaceRunning?: boolean },
+  ): Promise<void> {
+    await this.options.dispatchMessage(record, options);
+  }
+
+  private async emitQueueUpdated(agentId: string): Promise<void> {
+    const [queue] = await this.options.store.listQueues(agentId);
+    const payload = queue ?? { agentId, revision: 0, messages: [] };
+    // Updates fan out to every capable client on every queue change, so omit
+    // large image and attachment payloads from the broadcast. Counts stay
+    // accurate; clients hydrate unseen messages via queue.agent_message.list.
+    // listQueues returns cloned records, so mutating them here is safe.
+    for (const message of payload.messages) {
+      message.images = [];
+      message.attachments = [];
+    }
+    this.options.onQueueUpdated(payload);
+  }
+}
+
+export function createAgentMessageQueueService(input: {
+  paseoHome: string;
+  agentManager: AgentManager;
+  agentStorage: AgentStorage;
+  logger: Logger;
+  onQueueUpdated: (queue: AgentMessageQueueSnapshot) => void;
+}): AgentMessageQueueService {
+  return new AgentMessageQueueService({
+    store: new AgentMessageQueueStore({
+      filePath: join(input.paseoHome, "agent-message-queue.json"),
+      logger: input.logger,
+    }),
+    agentManager: {
+      getAgent: (agentId) => input.agentManager.getAgent(agentId),
+      hasInFlightRun: (agentId) => input.agentManager.hasInFlightRun(agentId),
+      subscribeAgentState: (listener) =>
+        input.agentManager.subscribe(
+          (event) => {
+            if (event.type === "agent_state") listener(event.agent);
+          },
+          { replayState: false },
+        ),
+      addAgentArchivedCallback: (callback) => input.agentManager.addAgentArchivedCallback(callback),
+    },
+    agentStorage: {
+      get: (agentId) => input.agentStorage.get(agentId),
+      list: () => input.agentStorage.list(),
+      addAgentHardDeletedCallback: (callback) =>
+        input.agentStorage.addAgentHardDeletedCallback(callback),
+    },
+    dispatchMessage: async (record, options) => {
+      const prompt = buildQueuedAgentPrompt(record.text, record.images, record.attachments);
+      const result = await sendPromptToAgent({
+        agentManager: input.agentManager,
+        agentStorage: input.agentStorage,
+        agentId: record.agentId,
+        prompt,
+        messageId: record.id,
+        replaceRunning: options?.replaceRunning,
+        unarchive: false,
+        logger: input.logger,
+      });
+      if (result.skippedReason === "archived") {
+        throw new Error(`Queued message target agent is archived: ${record.agentId}`);
+      }
+      if (result.disposition === "turn_started") {
+        await result.startAcknowledged;
+      }
+    },
+    logger: input.logger,
+    onQueueUpdated: input.onQueueUpdated,
+  });
+}
+
+export function toQueuedAgentMessagePayload(
+  record: QueuedAgentMessageRecord,
+): AgentMessageQueuePayload {
+  return {
+    id: record.id,
+    agentId: record.agentId,
+    text: record.text,
+    createdAt: record.createdAt,
+    images: record.images.map((image) => ({ ...image })),
+    attachments: record.attachments.map((attachment) => ({ ...attachment })),
+    imageCount: record.images.length,
+    attachmentCount: record.attachments.length,
+  };
+}
+
+function toQueuedAgentMessageQueuePayload(
+  state: PersistedAgentMessageQueue,
+  agentId: string,
+): AgentMessageQueueSnapshot {
+  return {
+    agentId,
+    revision: getQueueRevision(state, agentId),
+    messages: (state.queues[agentId] ?? []).map(toQueuedAgentMessagePayload),
+  };
+}
+
+export function buildQueuedAgentPrompt(
+  text: string,
+  images: Array<{ data: string; mimeType: string }>,
+  attachments: AgentAttachment[],
+): AgentPromptInput {
+  const normalized = text.trim();
+  if (images.length === 0 && attachments.length === 0) {
+    return normalized;
+  }
+  const blocks: AgentPromptContentBlock[] = [];
+  if (normalized.length > 0) {
+    blocks.push({ type: "text", text: normalized });
+  }
+  for (const image of images) {
+    blocks.push({ type: "image", data: image.data, mimeType: image.mimeType });
+  }
+  for (const attachment of attachments) {
+    blocks.push(attachment);
+  }
+  return blocks;
+}
+
+function setQueue(
+  state: PersistedAgentMessageQueue,
+  agentId: string,
+  queue: QueuedAgentMessageRecord[],
+): void {
+  if (queue.length === 0) {
+    delete state.queues[agentId];
+    return;
+  }
+  state.queues[agentId] = queue;
+}
+
+function pruneEmptyQueues(state: PersistedAgentMessageQueue): void {
+  for (const [agentId, queue] of Object.entries(state.queues)) {
+    if (queue.length === 0) {
+      delete state.queues[agentId];
+    }
+  }
+}
+
+function getQueueRevision(state: PersistedAgentMessageQueue, agentId: string): number {
+  return state.revisions[agentId] ?? 0;
+}
+
+function bumpQueueRevision(state: PersistedAgentMessageQueue, agentId: string): void {
+  state.revisions[agentId] = getQueueRevision(state, agentId) + 1;
+}
+
+function cloneRecord(record: QueuedAgentMessageRecord): QueuedAgentMessageRecord {
+  return {
+    ...record,
+    images: record.images.map((image) => ({ ...image })),
+    attachments: record.attachments.map((attachment) => ({ ...attachment })),
+  };
+}

--- a/packages/server/src/server/agent-message-queue.ts
+++ b/packages/server/src/server/agent-message-queue.ts
@@ -234,11 +234,18 @@ export class AgentMessageQueueStore {
         this.cache = { version: 1, queues: {}, revisions: {} };
       } else if (error instanceof SyntaxError || error instanceof z.ZodError) {
         const corruptPath = `${this.options.filePath}.corrupt-${Date.now()}-${randomUUID()}`;
-        await rename(this.options.filePath, corruptPath);
-        this.options.logger.error(
-          { err: error, corruptPath },
-          "Quarantined corrupt agent message queue and started empty",
-        );
+        try {
+          await rename(this.options.filePath, corruptPath);
+          this.options.logger.error(
+            { err: error, corruptPath },
+            "Quarantined corrupt agent message queue and started empty",
+          );
+        } catch (quarantineError) {
+          this.options.logger.error(
+            { err: error, quarantineError, corruptPath },
+            "Could not quarantine corrupt agent message queue; started empty",
+          );
+        }
         this.cache = { version: 1, queues: {}, revisions: {} };
       } else {
         this.options.logger.error({ err: error }, "Failed to load agent message queue");

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7351,11 +7351,15 @@ test("streamAgent marks a run in-flight before the provider turn starts", async 
   });
 
   try {
-    const agent = await manager.createAgent({
-      provider: "codex",
-      cwd: workdir,
-      title: "Pending run marker",
-    });
+    const agent = await manager.createAgent(
+      {
+        provider: "codex",
+        cwd: workdir,
+        title: "Pending run marker",
+      },
+      undefined,
+      {},
+    );
 
     const stream = manager.streamAgent(agent.id, "hello");
     expect(manager.hasInFlightRun(agent.id)).toBe(true);

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7276,13 +7276,21 @@ test("fires onAgentArchived for archived parent and cascaded children", async ()
   const storagePath = join(workdir, "agents");
   const storage = new AgentStorage(storagePath, logger);
   const archivedIds: string[] = [];
+  const beforeSetArchivedIds: string[] = [];
+  const additionalArchivedIds: string[] = [];
   const manager = new AgentManager({
     clients: { codex: new TestAgentClient() },
     registry: storage,
     logger,
   });
+  manager.addAgentArchivedCallback((agentId) => {
+    beforeSetArchivedIds.push(agentId);
+  });
   manager.setAgentArchivedCallback((agentId) => {
     archivedIds.push(agentId);
+  });
+  manager.addAgentArchivedCallback((agentId) => {
+    additionalArchivedIds.push(agentId);
   });
 
   const liveParent = await manager.createAgent(
@@ -7301,7 +7309,9 @@ test("fires onAgentArchived for archived parent and cascaded children", async ()
   );
 
   await manager.archiveAgent(liveParent.id);
+  expect([...beforeSetArchivedIds].sort()).toEqual([liveChild.id, liveParent.id].sort());
   expect([...archivedIds].sort()).toEqual([liveChild.id, liveParent.id].sort());
+  expect([...additionalArchivedIds].sort()).toEqual([liveChild.id, liveParent.id].sort());
 });
 
 test("fires onAgentArchived for stored-only snapshot archives", async () => {
@@ -7331,6 +7341,33 @@ test("fires onAgentArchived for stored-only snapshot archives", async () => {
 
   await manager.archiveSnapshot(storedOnly.id, new Date().toISOString());
   expect(archivedIds).toEqual([storedOnly.id]);
+});
+
+test("streamAgent marks a run in-flight before the provider turn starts", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-pending-run-"));
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    logger,
+  });
+
+  try {
+    const agent = await manager.createAgent({
+      provider: "codex",
+      cwd: workdir,
+      title: "Pending run marker",
+    });
+
+    const stream = manager.streamAgent(agent.id, "hello");
+    expect(manager.hasInFlightRun(agent.id)).toBe(true);
+
+    for await (const _event of stream) {
+      // Drain the foreground stream so the pending run settles before the test exits.
+    }
+
+    expect(manager.hasInFlightRun(agent.id)).toBe(false);
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("unarchiveSnapshot skips native provider unarchive for active records", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2243,6 +2243,7 @@ export class AgentManager {
       }
       const turnStartedAt = new Date();
       pendingRun.started = true;
+      pendingRun.acknowledgeStart();
       pendingRun.turnId = turnId;
       agent.activeForegroundTurnId = turnId;
       this.openActiveTurn(agent, turnId, turnStartedAt);
@@ -2682,6 +2683,10 @@ export class AgentManager {
 
       checkCurrentState();
     });
+  }
+
+  getPendingAgentRunStartAcknowledged(agentId: string): Promise<void> | null {
+    return this.runs.getPendingRun(agentId)?.startAcknowledged ?? null;
   }
 
   async respondToPermission(

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -696,7 +696,8 @@ export class AgentManager {
   private paseoToolCatalogFactory: PaseoToolCatalogFactory | null = null;
   private appendSystemPrompt: string;
   private onAgentAttention?: AgentAttentionCallback;
-  private onAgentArchived?: AgentArchivedCallback;
+  private readonly agentArchivedCallbacks = new Set<AgentArchivedCallback>();
+  private replaceableAgentArchivedCallbackUnsubscribe: (() => void) | null = null;
   private onWorkspaceStateMayHaveChanged?: (params: { cwd: string }) => void;
   private logger: Logger;
   private readonly rescueTimeouts: Required<AgentManagerRescueTimeouts>;
@@ -774,7 +775,15 @@ export class AgentManager {
   }
 
   setAgentArchivedCallback(callback: AgentArchivedCallback): void {
-    this.onAgentArchived = callback;
+    this.replaceableAgentArchivedCallbackUnsubscribe?.();
+    this.replaceableAgentArchivedCallbackUnsubscribe = this.addAgentArchivedCallback(callback);
+  }
+
+  addAgentArchivedCallback(callback: AgentArchivedCallback): () => void {
+    this.agentArchivedCallbacks.add(callback);
+    return () => {
+      this.agentArchivedCallbacks.delete(callback);
+    };
   }
 
   setMcpBaseUrl(url: string | null): void {
@@ -1646,14 +1655,15 @@ export class AgentManager {
   }
 
   private async fireAgentArchived(agentId: string): Promise<void> {
-    const callback = this.onAgentArchived;
-    if (!callback) {
+    if (this.agentArchivedCallbacks.size === 0) {
       return;
     }
-    try {
-      await callback(agentId);
-    } catch (error) {
-      this.logger.warn({ err: error, agentId }, "onAgentArchived callback failed");
+    for (const callback of this.agentArchivedCallbacks) {
+      try {
+        await callback(agentId);
+      } catch (error) {
+        this.logger.warn({ err: error, agentId }, "onAgentArchived callback failed");
+      }
     }
   }
 

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -9,9 +9,12 @@ import { createTestLogger } from "../../test-utils/test-logger.js";
 import { AgentManager } from "./agent-manager.js";
 import { AgentStorage } from "./agent-storage.js";
 import {
+  type AgentRunController,
   formatSystemNotificationPrompt,
   isSystemInjectedEnvelope,
+  sendPromptToAgent,
   setupFinishNotification,
+  startAgentRun,
   waitForAgentRunStartWithTimeout,
 } from "./agent-prompt.js";
 import type { AgentManagerEvent, ManagedAgent } from "./agent-manager.js";
@@ -262,6 +265,78 @@ function createFinishNotificationScenario(
 test("isSystemInjectedEnvelope matches the envelope formatSystemNotificationPrompt produces", () => {
   expect(isSystemInjectedEnvelope(formatSystemNotificationPrompt("child finished"))).toBe(true);
   expect(isSystemInjectedEnvelope("hello world")).toBe(false);
+});
+
+test("sendPromptToAgent forwards the client message id as run options", async () => {
+  const agent: ManagedAgent = Object.create(null);
+  Reflect.set(agent, "id", "agent-1");
+  Reflect.set(agent, "provider", "codex");
+
+  const streamAgentSpy = vi.fn(() => (async function* noop() {})());
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(
+    agentManager,
+    "getAgent",
+    vi.fn(() => agent),
+  );
+  Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "streamAgent", streamAgentSpy);
+
+  const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
+  Reflect.set(
+    agentStorage,
+    "get",
+    vi.fn(async () => null),
+  );
+
+  await sendPromptToAgent({
+    agentManager,
+    agentStorage,
+    agentId: "agent-1",
+    prompt: "hello",
+    messageId: "msg-client-1",
+    runOptions: { outputSchema: { type: "object" } },
+    logger: createTestLogger(),
+  });
+
+  expect(streamAgentSpy).toHaveBeenCalledWith("agent-1", "hello", {
+    outputSchema: { type: "object" },
+    clientMessageId: "msg-client-1",
+  });
+});
+
+test("startAgentRun registers acknowledgement before consuming a fast iterator", async () => {
+  const turnStarted = Promise.withResolvers<void>();
+  let acknowledgementRegistered = false;
+  let deliveries = 0;
+  const streamAgent = vi.fn(() =>
+    (async function* startAndFinish() {
+      if (!acknowledgementRegistered) {
+        throw new Error("Iterator consumed before acknowledgement registration");
+      }
+      deliveries += 1;
+      turnStarted.resolve();
+      yield { type: "turn_started", provider: "codex", turnId: "turn-1" } as const;
+    })(),
+  );
+  const agentManager = {
+    getAgent: () => undefined,
+    tryRunOutOfBand: () => false,
+    hasInFlightRun: () => false,
+    replaceAgentRun: async () => (async function* noop() {})(),
+    streamAgent,
+    waitForAgentRunStart: async () => {
+      acknowledgementRegistered = true;
+      await turnStarted.promise;
+    },
+  } satisfies AgentRunController;
+
+  const result = await startAgentRun(agentManager, "agent-1", "hello", createTestLogger());
+  await result.startAcknowledged;
+
+  expect(streamAgent).toHaveBeenCalledTimes(1);
+  expect(deliveries).toBe(1);
 });
 
 test("finish notifications tell the parent the child's last assistant message", async () => {

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -330,6 +330,7 @@ test("startAgentRun registers acknowledgement before consuming a fast iterator",
     tryRunOutOfBand: () => false,
     hasInFlightRun: () => false,
     replaceAgentRun: async () => (async function* noop() {})(),
+    steerOrReplaceActiveTurn: async () => ({ status: "inactive" as const }),
     streamAgent,
     getPendingAgentRunStartAcknowledged: () => {
       acknowledgementRegistered = true;

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -282,6 +282,11 @@ test("sendPromptToAgent forwards the client message id as run options", async ()
   Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
   Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(false));
   Reflect.set(agentManager, "streamAgent", streamAgentSpy);
+  Reflect.set(
+    agentManager,
+    "getPendingAgentRunStartAcknowledged",
+    vi.fn(() => Promise.resolve()),
+  );
 
   const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
   Reflect.set(
@@ -326,8 +331,11 @@ test("startAgentRun registers acknowledgement before consuming a fast iterator",
     hasInFlightRun: () => false,
     replaceAgentRun: async () => (async function* noop() {})(),
     streamAgent,
-    waitForAgentRunStart: async () => {
+    getPendingAgentRunStartAcknowledged: () => {
       acknowledgementRegistered = true;
+      return turnStarted.promise;
+    },
+    waitForAgentRunStart: async () => {
       await turnStarted.promise;
     },
   } satisfies AgentRunController;

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -21,6 +21,7 @@ export type AgentRunController = Pick<
   | "replaceAgentRun"
   | "steerOrReplaceActiveTurn"
   | "streamAgent"
+  | "getPendingAgentRunStartAcknowledged"
   | "waitForAgentRunStart"
 >;
 
@@ -84,6 +85,13 @@ export interface StartAgentRunResult {
   startAcknowledged: Promise<void>;
 }
 
+function getStartAcknowledged(agentManager: AgentRunController, agentId: string): Promise<void> {
+  return (
+    agentManager.getPendingAgentRunStartAcknowledged(agentId) ??
+    agentManager.waitForAgentRunStart(agentId)
+  );
+}
+
 export async function startAgentRun(
   agentManager: AgentRunController,
   agentId: string,
@@ -126,7 +134,7 @@ export async function startAgentRun(
     },
     "agent.session.start_stream.iterator_returned",
   );
-  const startAcknowledged = agentManager.waitForAgentRunStart(agentId);
+  const startAcknowledged = getStartAcknowledged(agentManager, agentId);
   void startAcknowledged.catch(() => {});
   void (async () => {
     try {

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -21,6 +21,7 @@ export type AgentRunController = Pick<
   | "replaceAgentRun"
   | "steerOrReplaceActiveTurn"
   | "streamAgent"
+  | "waitForAgentRunStart"
 >;
 
 export interface StartAgentRunOptions {
@@ -78,13 +79,18 @@ async function startOrReplaceRun(
   return { iterator, replaced };
 }
 
+export interface StartAgentRunResult {
+  disposition: PromptDispatchDisposition;
+  startAcknowledged: Promise<void>;
+}
+
 export async function startAgentRun(
   agentManager: AgentRunController,
   agentId: string,
   prompt: AgentPromptInput,
   logger: Logger,
   options?: StartAgentRunOptions,
-): Promise<{ disposition: PromptDispatchDisposition }> {
+): Promise<StartAgentRunResult> {
   const snapshot = agentManager.getAgent(agentId);
   logger.trace(
     {
@@ -102,11 +108,11 @@ export async function startAgentRun(
   // in-flight turn — replaceAgentRun would interrupt the running turn. The
   // intercept lives at this layer so it covers every prompt entrypoint.
   if (agentManager.tryRunOutOfBand(agentId, prompt, options?.runOptions)) {
-    return { disposition: "out_of_band" };
+    return { disposition: "out_of_band", startAcknowledged: Promise.resolve() };
   }
   const steered = await steerOrReplaceActiveRun(agentManager, agentId, prompt, options);
   if (steered?.disposition === "steered") {
-    return steered;
+    return { ...steered, startAcknowledged: Promise.resolve() };
   }
   const { iterator, replaced } = steered
     ? { iterator: steered.iterator, replaced: true }
@@ -120,6 +126,8 @@ export async function startAgentRun(
     },
     "agent.session.start_stream.iterator_returned",
   );
+  const startAcknowledged = agentManager.waitForAgentRunStart(agentId);
+  void startAcknowledged.catch(() => {});
   void (async () => {
     try {
       for await (const _ of iterator) {
@@ -146,7 +154,7 @@ export async function startAgentRun(
       logger.error({ err: error, agentId }, "Agent stream failed");
     }
   })();
-  return { disposition: "turn_started" };
+  return { disposition: "turn_started", startAcknowledged };
 }
 
 /**
@@ -190,6 +198,8 @@ export interface SendPromptToAgentParams {
   messageId?: string;
   activeTurnBehavior?: ActiveTurnBehavior;
   runOptions?: AgentRunOptions;
+  /** Whether this send may interrupt an active foreground run. Defaults to true. */
+  replaceRunning?: boolean;
   /** Optional mode to set on the agent before the run starts. */
   sessionMode?: string;
   /**
@@ -201,6 +211,12 @@ export interface SendPromptToAgentParams {
   /** See {@link StartAgentRunOptions.clearPendingPermissions}. */
   clearPendingPermissions?: boolean;
   logger: Logger;
+}
+
+export interface SendPromptToAgentResult {
+  disposition: PromptDispatchDisposition;
+  startAcknowledged: Promise<void>;
+  skippedReason?: "archived";
 }
 
 export interface StartCreatedAgentInitialPromptParams {
@@ -241,7 +257,6 @@ export async function waitForAgentRunStartWithTimeout(
       ),
     AGENT_RUN_START_TIMEOUT_MS,
   );
-
   try {
     await agentManager.waitForAgentRunStart(agentId, { signal: startAbort.signal });
   } finally {
@@ -257,18 +272,22 @@ export async function waitForAgentRunStartWithTimeout(
  * chat mentions, notify-on-finish) MUST go through this so behavior can never
  * drift between them.
  *
- * When `unarchive` is false and the agent is archived, the call is a silent
- * no-op (returns the normal turn-start disposition) — the agent is not run.
+ * When `unarchive` is false and the agent is archived, the call is a no-op
+ * with `skippedReason: "archived"` — the agent is not run.
  */
 export async function sendPromptToAgent(
   params: SendPromptToAgentParams,
-): Promise<{ disposition: PromptDispatchDisposition }> {
+): Promise<SendPromptToAgentResult> {
   const unarchive = params.unarchive ?? true;
 
   const record = await params.agentStorage.get(params.agentId);
   if (record?.archivedAt) {
     if (!unarchive) {
-      return { disposition: "turn_started" };
+      return {
+        disposition: "turn_started",
+        startAcknowledged: Promise.resolve(),
+        skippedReason: "archived",
+      };
     }
     await unarchiveAgentState(params.agentStorage, params.agentManager, params.agentId);
   }
@@ -288,7 +307,7 @@ export async function sendPromptToAgent(
     : params.runOptions;
 
   return await startAgentRun(params.agentManager, params.agentId, params.prompt, params.logger, {
-    replaceRunning: true,
+    replaceRunning: params.replaceRunning ?? true,
     activeTurnBehavior: params.activeTurnBehavior,
     clearPendingPermissions: params.clearPendingPermissions,
     runOptions,

--- a/packages/server/src/server/agent/agent-run-state.ts
+++ b/packages/server/src/server/agent/agent-run-state.ts
@@ -16,6 +16,9 @@ export interface PendingForegroundRun {
   stagedEvents: AgentStreamEvent[];
   turnId: string | null;
   started: boolean;
+  startAcknowledged: Promise<void>;
+  acknowledgeStart: () => void;
+  failStart: (error: Error) => void;
   settled: boolean;
   settledPromise: Promise<void>;
   resolveSettled: () => void;
@@ -201,6 +204,9 @@ export class AgentRunState {
 
   private clearRun(agentId: string, run: TrackedAgentRun): void {
     this.runs.delete(agentId);
+    if (run.kind === "foreground" && !run.started) {
+      run.failStart(new Error(`Agent ${agentId} run finished before starting`));
+    }
     settleTrackedRun(run);
   }
 }
@@ -265,11 +271,21 @@ export class ForegroundTurnStream {
 }
 
 function createPendingForegroundRun(): PendingForegroundRun {
+  let acknowledgeStart!: () => void;
+  let failStart!: (error: Error) => void;
+  const startAcknowledged = new Promise<void>((resolve, reject) => {
+    acknowledgeStart = resolve;
+    failStart = reject;
+  });
+  void startAcknowledged.catch(() => {});
   return {
     ...createTrackedRunState(),
     kind: "foreground",
     turnId: null,
     started: false,
+    startAcknowledged,
+    acknowledgeStart,
+    failStart,
     stagedEvents: [],
   };
 }

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -94,6 +94,8 @@ export function parseStoredAgentRecord(value: unknown): StoredAgentRecord {
   return STORED_AGENT_SCHEMA.parse(value);
 }
 
+type AgentHardDeletedCallback = (agentId: string) => Promise<void> | void;
+
 export class AgentStorage {
   private cache: Map<string, StoredAgentRecord> = new Map();
   private pathById: Map<string, string> = new Map();
@@ -102,6 +104,7 @@ export class AgentStorage {
   private deleting: Set<string> = new Set();
   private daemonAgentIdsByExecution: Map<string, string> = new Map();
   private daemonExecutionKeysByAgentId: Map<string, string> = new Map();
+  private hardDeletedCallbacks = new Set<AgentHardDeletedCallback>();
   private loaded = false;
   private baseDir: string;
   private loadPromise: Promise<StoredAgentRecord[]> | null = null;
@@ -210,6 +213,13 @@ export class AgentStorage {
     this.deleting.add(agentId);
   }
 
+  addAgentHardDeletedCallback(callback: AgentHardDeletedCallback): () => void {
+    this.hardDeletedCallbacks.add(callback);
+    return () => {
+      this.hardDeletedCallbacks.delete(callback);
+    };
+  }
+
   async remove(agentId: string): Promise<void> {
     await this.load();
     this.beginDelete(agentId);
@@ -235,6 +245,14 @@ export class AgentStorage {
     this.removeOwnerIndex(agentId);
     this.pathById.delete(agentId);
     this.pathsById.delete(agentId);
+
+    for (const callback of this.hardDeletedCallbacks) {
+      try {
+        await callback(agentId);
+      } catch (error) {
+        this.logger.warn({ err: error, agentId }, "onAgentHardDeleted callback failed");
+      }
+    }
   }
 
   async applySnapshot(

--- a/packages/server/src/server/agent/permission-response.test.ts
+++ b/packages/server/src/server/agent/permission-response.test.ts
@@ -44,6 +44,8 @@ class FakePermissionAgentManager {
     return this.hasRunInFlight;
   }
 
+  async waitForAgentRunStart(): Promise<void> {}
+
   streamAgent(
     agentId: string,
     prompt: AgentPromptInput,

--- a/packages/server/src/server/daemon-client.e2e.test.ts
+++ b/packages/server/src/server/daemon-client.e2e.test.ts
@@ -557,6 +557,12 @@ test("queued agent messages replay after a daemon restart loads the persisted ag
       paseoHomeRoot,
       staticDir,
       cleanup: false,
+      agentClients: {
+        codex: new StubAgentClient({
+          sessionId: "queue-restart-blocked-session",
+          supportsStreaming: true,
+        }),
+      },
     });
     firstClient = new DaemonClient({
       url: `ws://127.0.0.1:${firstDaemon.port}/ws`,
@@ -571,7 +577,7 @@ test("queued agent messages replay after a daemon restart loads the persisted ag
       title: "Restart queued replay agent",
       modeId: "full-access",
       model: "gpt-5.4-mini",
-      initialPrompt: "Run exactly: sleep 30",
+      initialPrompt: "Keep this run active until the daemon restarts",
     });
     expect(agent.status).toBe("running");
 

--- a/packages/server/src/server/daemon-client.e2e.test.ts
+++ b/packages/server/src/server/daemon-client.e2e.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { execSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
+import { CLIENT_CAPS } from "@getpaseo/protocol/client-capabilities";
 
 import {
   createDaemonTestContext,
@@ -398,6 +399,249 @@ class RejectingMcpResumeClient implements AgentClient {
   }
 }
 
+test("queued agent messages are replayed by the daemon after the queuing client disconnects", async () => {
+  const cwd = tmpCwd();
+  const daemon = await createTestPaseoDaemon();
+  const firstClient = new DaemonClient({
+    url: `ws://127.0.0.1:${daemon.port}/ws`,
+    appVersion: "0.1.82",
+  });
+  const secondClient = new DaemonClient({
+    url: `ws://127.0.0.1:${daemon.port}/ws`,
+    appVersion: "0.1.82",
+  });
+
+  try {
+    await firstClient.connect();
+    await firstClient.fetchAgents({ subscribe: { subscriptionId: "server-queue-first-client" } });
+
+    const agent = await firstClient.createAgent({
+      provider: "codex",
+      cwd,
+      title: "Server queued replay agent",
+      modeId: "full-access",
+      model: "gpt-5.4-mini",
+      initialPrompt: "Run exactly: sleep 30",
+    });
+
+    expect(agent.status).toBe("running");
+
+    const queuedUpdatePromise = waitForSignal(15000, (resolve) => {
+      const unsubscribe = firstClient.on("queue.agent_message.updated", (message) => {
+        if (message.type !== "queue.agent_message.updated") {
+          return;
+        }
+        if (message.payload.agentId !== agent.id) {
+          return;
+        }
+        if (hasQueuedMessage(message.payload.messages, "queued-after-disconnect")) {
+          resolve(message);
+        }
+      });
+      return unsubscribe;
+    });
+
+    await expect(
+      firstClient.queueAgentMessage(agent.id, "respond with exactly: SERVER_QUEUE_REPLAYED", {
+        messageId: "queued-after-disconnect",
+      }),
+    ).resolves.toMatchObject({
+      id: "queued-after-disconnect",
+      agentId: agent.id,
+      text: "respond with exactly: SERVER_QUEUE_REPLAYED",
+    });
+    await queuedUpdatePromise;
+
+    await firstClient.close();
+
+    await secondClient.connect();
+    await secondClient.fetchAgents({
+      subscribe: { subscriptionId: "server-queue-second-client" },
+    });
+
+    await expect(
+      waitForTimelineText(secondClient, agent.id, "SERVER_QUEUE_REPLAYED", 30000),
+    ).resolves.toBe(true);
+
+    const queues = await secondClient.listQueuedAgentMessages(agent.id);
+    expect(queues).toEqual([
+      {
+        agentId: agent.id,
+        revision: 2,
+        messages: [],
+      },
+    ]);
+  } finally {
+    await firstClient.close();
+    await secondClient.close();
+    await daemon.close();
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}, 45000);
+
+test("queue updates are only broadcast to clients that advertise queue event support", async () => {
+  const cwd = tmpCwd();
+  const daemon = await createTestPaseoDaemon();
+  const client = new DaemonClient({
+    url: `ws://127.0.0.1:${daemon.port}/ws`,
+    appVersion: "0.1.103",
+  });
+  const legacyClient = new DaemonClient({
+    url: `ws://127.0.0.1:${daemon.port}/ws`,
+    appVersion: "0.1.102",
+    capabilities: { [CLIENT_CAPS.agentMessageQueueEvents]: false },
+  });
+  let legacyQueueUpdateCount = 0;
+
+  try {
+    const unsubscribeLegacyQueueUpdates = legacyClient.on("queue.agent_message.updated", () => {
+      legacyQueueUpdateCount += 1;
+    });
+
+    await legacyClient.connect();
+    await client.connect();
+    await client.fetchAgents({ subscribe: { subscriptionId: "queue-event-capable-client" } });
+
+    const agent = await client.createAgent({
+      provider: "codex",
+      cwd,
+      title: "Queue event capability agent",
+      modeId: "full-access",
+      model: "gpt-5.4-mini",
+      initialPrompt: "Run exactly: sleep 30",
+    });
+    expect(agent.status).toBe("running");
+
+    const queuedUpdatePromise = waitForSignal(15000, (resolve) => {
+      const unsubscribe = client.on("queue.agent_message.updated", (message) => {
+        if (message.type !== "queue.agent_message.updated") {
+          return;
+        }
+        if (message.payload.agentId !== agent.id) {
+          return;
+        }
+        if (hasQueuedMessage(message.payload.messages, "queued-event-capability")) {
+          resolve(message);
+        }
+      });
+      return unsubscribe;
+    });
+
+    await client.queueAgentMessage(agent.id, "respond with exactly: QUEUE_EVENT_CAPABILITY", {
+      messageId: "queued-event-capability",
+    });
+    await queuedUpdatePromise;
+    await legacyClient.listQueuedAgentMessages(agent.id);
+
+    expect(legacyQueueUpdateCount).toBe(0);
+    unsubscribeLegacyQueueUpdates();
+  } finally {
+    await legacyClient.close();
+    await client.close();
+    await daemon.close();
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}, 45000);
+
+test("queued agent messages replay after a daemon restart loads the persisted agent lazily", async () => {
+  const cwd = tmpCwd();
+  const paseoHomeRoot = mkdtempSync(path.join(tmpdir(), "paseo-queue-restart-home-"));
+  const staticDir = mkdtempSync(path.join(tmpdir(), "paseo-queue-restart-static-"));
+  let firstDaemon: Awaited<ReturnType<typeof createTestPaseoDaemon>> | null = null;
+  let secondDaemon: Awaited<ReturnType<typeof createTestPaseoDaemon>> | null = null;
+  let firstClient: DaemonClient | null = null;
+  let secondClient: DaemonClient | null = null;
+
+  try {
+    firstDaemon = await createTestPaseoDaemon({
+      paseoHomeRoot,
+      staticDir,
+      cleanup: false,
+    });
+    firstClient = new DaemonClient({
+      url: `ws://127.0.0.1:${firstDaemon.port}/ws`,
+      appVersion: "0.1.82",
+    });
+    await firstClient.connect();
+    await firstClient.fetchAgents({ subscribe: { subscriptionId: "server-queue-restart-first" } });
+
+    const agent = await firstClient.createAgent({
+      provider: "codex",
+      cwd,
+      title: "Restart queued replay agent",
+      modeId: "full-access",
+      model: "gpt-5.4-mini",
+      initialPrompt: "Run exactly: sleep 30",
+    });
+    expect(agent.status).toBe("running");
+
+    const queuedUpdatePromise = waitForSignal(15000, (resolve) => {
+      const unsubscribe = firstClient?.on("queue.agent_message.updated", (message) => {
+        if (message.type !== "queue.agent_message.updated") {
+          return;
+        }
+        if (message.payload.agentId !== agent.id) {
+          return;
+        }
+        if (hasQueuedMessage(message.payload.messages, "queued-after-daemon-restart")) {
+          resolve(message);
+        }
+      });
+      return () => unsubscribe?.();
+    });
+
+    await firstClient.queueAgentMessage(
+      agent.id,
+      "respond with exactly: SERVER_QUEUE_REPLAYED_AFTER_RESTART",
+      {
+        messageId: "queued-after-daemon-restart",
+      },
+    );
+    await queuedUpdatePromise;
+    await firstClient.close();
+    firstClient = null;
+
+    const queueFilePath = path.join(firstDaemon.paseoHome, "agent-message-queue.json");
+    await firstDaemon.close();
+    firstDaemon = null;
+
+    await expect(readFile(queueFilePath, "utf8").then(JSON.parse)).resolves.toMatchObject({
+      queues: {
+        [agent.id]: [expect.objectContaining({ id: "queued-after-daemon-restart" })],
+      },
+    });
+
+    secondDaemon = await createTestPaseoDaemon({
+      paseoHomeRoot,
+      staticDir,
+      cleanup: false,
+    });
+    secondClient = new DaemonClient({
+      url: `ws://127.0.0.1:${secondDaemon.port}/ws`,
+      appVersion: "0.1.82",
+    });
+    await secondClient.connect();
+    await secondClient.fetchAgents({
+      subscribe: { subscriptionId: "server-queue-restart-second" },
+    });
+
+    await expect(
+      waitForTimelineText(secondClient, agent.id, "SERVER_QUEUE_REPLAYED_AFTER_RESTART", 30000),
+    ).resolves.toBe(true);
+    await expect(secondClient.listQueuedAgentMessages(agent.id)).resolves.toMatchObject([
+      { agentId: agent.id, messages: [] },
+    ]);
+  } finally {
+    await firstClient?.close();
+    await secondClient?.close();
+    await firstDaemon?.close();
+    await secondDaemon?.close();
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(paseoHomeRoot, { recursive: true, force: true });
+    rmSync(staticDir, { recursive: true, force: true });
+  }
+}, 45000);
+
 test("createAgent fails when the initial turn cannot start", async () => {
   const testAgent = new StubAgentClient({
     sessionId: "start-turn-failure-session",
@@ -511,6 +755,46 @@ function waitForSignal<T>(
       },
     );
   });
+}
+
+function hasQueuedMessage(messages: ReadonlyArray<{ id: string }>, id: string): boolean {
+  for (const message of messages) {
+    if (message.id === id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function waitForTimelineText(
+  client: DaemonClient,
+  agentId: string,
+  expectedText: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  let lastEntryCount = 0;
+
+  while (Date.now() < deadline) {
+    const timeline = await client.fetchAgentTimeline(agentId, {
+      direction: "tail",
+      limit: 0,
+    });
+    lastEntryCount = timeline.entries.length;
+    if (
+      timeline.entries.some(
+        (entry) =>
+          entry.item.type === "assistant_message" && entry.item.text.includes(expectedText),
+      )
+    ) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error(
+    `Timed out waiting for timeline text "${expectedText}" after ${timeoutMs}ms; last entry count: ${lastEntryCount}`,
+  );
 }
 
 class NonPersistentReloadSession implements AgentSession {

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -207,6 +207,8 @@ type ScheduleAgentManager = Pick<
   | "replaceAgentRun"
   | "steerOrReplaceActiveTurn"
   | "streamAgent"
+  | "getPendingAgentRunStartAcknowledged"
+  | "waitForAgentRunStart"
 > &
   Pick<
     AgentManager,

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -155,6 +155,8 @@ import {
   setProjectCustomIcon,
 } from "../utils/project-custom-icon.js";
 import { VoiceSession } from "./session/voice/voice-session.js";
+import type { AgentMessageQueueController } from "./agent-message-queue.js";
+import { AgentMessageQueueSession } from "./session/agent-message-queue/agent-message-queue-session.js";
 import { CheckoutSession } from "./session/checkout/checkout-session.js";
 import {
   createWorkspaceGitObserverService,
@@ -451,6 +453,7 @@ export interface SessionOptions {
   worktreesRoot?: string;
   agentManager: AgentManager;
   agentStorage: AgentStorage;
+  agentMessageQueue?: AgentMessageQueueController;
   projectRegistry: ProjectRegistry;
   workspaceRegistry: WorkspaceRegistry;
   directorySync?: DirectorySyncService;
@@ -677,6 +680,7 @@ export class Session {
 
   private agentManager: AgentManager;
   private readonly agentStorage: AgentStorage;
+  private readonly agentMessageQueueSession: AgentMessageQueueSession;
   private readonly projectRegistry: ProjectRegistry;
   private readonly workspaceRegistry: WorkspaceRegistry;
   private readonly directorySync: DirectorySyncService;
@@ -770,6 +774,7 @@ export class Session {
       worktreesRoot,
       agentManager,
       agentStorage,
+      agentMessageQueue,
       projectRegistry,
       workspaceRegistry,
       directorySync,
@@ -843,6 +848,13 @@ export class Session {
     });
     this.agentManager = agentManager;
     this.agentStorage = agentStorage;
+    this.agentMessageQueueSession = new AgentMessageQueueSession({
+      host: {
+        emit: (message, source) => this.emitForSource(message, source),
+        resolveAgentIdentifier: (identifier) => this.resolveAgentIdentifier(identifier),
+      },
+      queue: agentMessageQueue,
+    });
     this.projectRegistry = projectRegistry;
     this.workspaceRegistry = workspaceRegistry;
     this.directorySync = resolveDirectorySync(directorySync);
@@ -1927,7 +1939,7 @@ export class Session {
       this.dispatchVoiceAndControlMessage(msg) ??
       this.dispatchAgentRewindMessage(msg, source) ??
       this.dispatchAgentRelationshipMessage(msg) ??
-      this.dispatchAgentTimelineMessage(msg, source) ??
+      this.dispatchAgentConversationMessage(msg, source) ??
       this.dispatchHubExecutionMessage(msg) ??
       this.dispatchAgentLifecycleMessage(msg) ??
       this.dispatchAgentConfigMessage(msg) ??
@@ -2229,7 +2241,7 @@ export class Session {
     }
   }
 
-  private dispatchAgentTimelineMessage(
+  private dispatchAgentConversationMessage(
     msg: SessionInboundMessage,
     source?: object,
   ): Promise<void> | undefined {
@@ -2262,7 +2274,7 @@ export class Session {
       case "agent.fork_context.request":
         return this.handleAgentForkContextRequest(msg);
       default:
-        return undefined;
+        return this.agentMessageQueueSession.dispatch(msg, source);
     }
   }
 
@@ -7312,7 +7324,7 @@ export class Session {
         },
         "agent.session.send_agent_message",
       );
-      let dispatchResult: { disposition: "out_of_band" | "steered" | "turn_started" };
+      let dispatchResult: Awaited<ReturnType<typeof sendPromptToAgent>>;
       try {
         dispatchResult = await sendPromptToAgent({
           agentManager: this.agentManager,

--- a/packages/server/src/server/session/agent-message-queue/agent-message-queue-session.test.ts
+++ b/packages/server/src/server/session/agent-message-queue/agent-message-queue-session.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionOutboundMessage } from "../../messages.js";
+import type { AgentMessageQueueController } from "../../agent-message-queue.js";
+import {
+  type AgentIdentifierResolution,
+  AgentMessageQueueSession,
+} from "./agent-message-queue-session.js";
+
+function createHarness(options?: {
+  queue?: AgentMessageQueueController;
+  resolveAgentIdentifier?: (identifier: string) => Promise<AgentIdentifierResolution>;
+}) {
+  const emitted: Array<{ message: SessionOutboundMessage; source?: object }> = [];
+  const source = {};
+  const resolveAgentIdentifier = vi.fn(
+    options?.resolveAgentIdentifier ??
+      (async (identifier: string) => ({
+        ok: true as const,
+        agentId: `resolved:${identifier}`,
+      })),
+  );
+  const session = new AgentMessageQueueSession({
+    host: {
+      emit: (message, messageSource) => emitted.push({ message, source: messageSource }),
+      resolveAgentIdentifier,
+    },
+    queue: options?.queue,
+  });
+  return { emitted, resolveAgentIdentifier, session, source };
+}
+
+function createQueue(): AgentMessageQueueController {
+  return {
+    enqueue: vi.fn(async (input) => ({
+      id: input.messageId ?? "generated-id",
+      agentId: input.agentId,
+      text: input.text,
+      createdAt: "2026-07-30T00:00:00.000Z",
+      images: input.images ?? [],
+      attachments: input.attachments ?? [],
+      imageCount: input.images?.length ?? 0,
+      attachmentCount: input.attachments?.length ?? 0,
+    })),
+    list: vi.fn(async () => []),
+    cancel: vi.fn(async () => true),
+    dispatchNow: vi.fn(async () => undefined),
+    clearAgent: vi.fn(async () => undefined),
+  };
+}
+
+describe("AgentMessageQueueSession", () => {
+  it("owns queue request recognition, normalization, and source-aware responses", async () => {
+    const queue = createQueue();
+    const { emitted, session, source } = createHarness({ queue });
+
+    expect(
+      session.dispatch({
+        type: "ping",
+        requestId: "ping-1",
+      }),
+    ).toBeUndefined();
+
+    await session.dispatch(
+      {
+        type: "queue.agent_message.enqueue.request",
+        requestId: "request-1",
+        agentId: "agent-prefix",
+        text: "hello",
+        messageId: "message-1",
+        attachments: [
+          {
+            type: "uploaded_file",
+            id: "file-1",
+            fileName: "notes.txt",
+            mimeType: "text/plain",
+            size: 5,
+            path: "/tmp/notes.txt",
+          },
+          { type: "future_attachment", payload: "opaque" },
+        ],
+      },
+      source,
+    );
+
+    expect(queue.enqueue).toHaveBeenCalledWith({
+      agentId: "resolved:agent-prefix",
+      text: "hello",
+      messageId: "message-1",
+      images: [],
+      attachments: [
+        {
+          type: "uploaded_file",
+          id: "file-1",
+          fileName: "notes.txt",
+          mimeType: "text/plain",
+          size: 5,
+          path: "/tmp/notes.txt",
+        },
+      ],
+    });
+    expect(emitted).toEqual([
+      {
+        source,
+        message: {
+          type: "queue.agent_message.enqueue.response",
+          payload: {
+            requestId: "request-1",
+            agentId: "resolved:agent-prefix",
+            accepted: true,
+            message: expect.objectContaining({ id: "message-1" }),
+            error: null,
+          },
+        },
+      },
+    ]);
+  });
+
+  it("keeps list, cancel, and dispatch result envelopes inside the queue domain", async () => {
+    const queue = createQueue();
+    vi.mocked(queue.list).mockResolvedValue([
+      { agentId: "resolved:agent", revision: 2, messages: [] },
+    ]);
+    vi.mocked(queue.cancel).mockResolvedValue(false);
+    vi.mocked(queue.dispatchNow).mockRejectedValue(new Error("provider refused replacement"));
+    const { emitted, session } = createHarness({ queue });
+
+    await session.dispatch({
+      type: "queue.agent_message.list.request",
+      requestId: "list-1",
+      agentId: "agent",
+    });
+    await session.dispatch({
+      type: "queue.agent_message.cancel.request",
+      requestId: "cancel-1",
+      agentId: "agent",
+      queuedMessageId: "missing",
+    });
+    await session.dispatch({
+      type: "queue.agent_message.dispatch.request",
+      requestId: "dispatch-1",
+      agentId: "agent",
+      queuedMessageId: "message-1",
+    });
+
+    expect(emitted.map(({ message }) => message)).toEqual([
+      {
+        type: "queue.agent_message.list.response",
+        payload: {
+          requestId: "list-1",
+          queues: [{ agentId: "resolved:agent", revision: 2, messages: [] }],
+          error: null,
+        },
+      },
+      {
+        type: "queue.agent_message.cancel.response",
+        payload: {
+          requestId: "cancel-1",
+          agentId: "resolved:agent",
+          queuedMessageId: "missing",
+          accepted: false,
+          error: "Queued message not found: missing",
+        },
+      },
+      {
+        type: "queue.agent_message.dispatch.response",
+        payload: {
+          requestId: "dispatch-1",
+          agentId: "resolved:agent",
+          queuedMessageId: "message-1",
+          accepted: false,
+          error: "provider refused replacement",
+        },
+      },
+    ]);
+  });
+
+  it("returns an RPC rejection when the daemon-global queue is unavailable", async () => {
+    const { emitted, session } = createHarness();
+
+    await session.dispatch({
+      type: "queue.agent_message.enqueue.request",
+      requestId: "request-1",
+      agentId: "agent",
+      text: "hello",
+    });
+
+    expect(emitted[0]?.message).toEqual({
+      type: "queue.agent_message.enqueue.response",
+      payload: {
+        requestId: "request-1",
+        agentId: "resolved:agent",
+        accepted: false,
+        message: null,
+        error: "Agent message queue is unavailable",
+      },
+    });
+  });
+
+  it("returns typed errors without exposing identifier resolution failures", async () => {
+    const queue = createQueue();
+    const { emitted, session } = createHarness({
+      queue,
+      resolveAgentIdentifier: async () => {
+        throw new Error("storage path /private/paseo/agents failed");
+      },
+    });
+
+    await session.dispatch({
+      type: "queue.agent_message.enqueue.request",
+      requestId: "enqueue-1",
+      agentId: "agent",
+      text: "hello",
+    });
+    await session.dispatch({
+      type: "queue.agent_message.list.request",
+      requestId: "list-1",
+      agentId: "agent",
+    });
+    await session.dispatch({
+      type: "queue.agent_message.cancel.request",
+      requestId: "cancel-1",
+      agentId: "agent",
+      queuedMessageId: "queued-1",
+    });
+    await session.dispatch({
+      type: "queue.agent_message.dispatch.request",
+      requestId: "dispatch-1",
+      agentId: "agent",
+      queuedMessageId: "queued-1",
+    });
+
+    expect(emitted.map(({ message }) => message)).toEqual([
+      {
+        type: "queue.agent_message.enqueue.response",
+        payload: {
+          requestId: "enqueue-1",
+          agentId: "agent",
+          accepted: false,
+          message: null,
+          error: "Failed to resolve agent identifier",
+        },
+      },
+      {
+        type: "queue.agent_message.list.response",
+        payload: {
+          requestId: "list-1",
+          queues: [],
+          error: "Failed to resolve agent identifier",
+        },
+      },
+      {
+        type: "queue.agent_message.cancel.response",
+        payload: {
+          requestId: "cancel-1",
+          agentId: "agent",
+          queuedMessageId: "queued-1",
+          accepted: false,
+          error: "Failed to resolve agent identifier",
+        },
+      },
+      {
+        type: "queue.agent_message.dispatch.response",
+        payload: {
+          requestId: "dispatch-1",
+          agentId: "agent",
+          queuedMessageId: "queued-1",
+          accepted: false,
+          error: "Failed to resolve agent identifier",
+        },
+      },
+    ]);
+    expect(queue.enqueue).not.toHaveBeenCalled();
+    expect(queue.list).not.toHaveBeenCalled();
+    expect(queue.cancel).not.toHaveBeenCalled();
+    expect(queue.dispatchNow).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/server/session/agent-message-queue/agent-message-queue-session.ts
+++ b/packages/server/src/server/session/agent-message-queue/agent-message-queue-session.ts
@@ -1,0 +1,257 @@
+import { getErrorMessageOr } from "@getpaseo/protocol/error-utils";
+import {
+  normalizeAgentAttachments,
+  type SessionInboundMessage,
+  type SessionOutboundMessage,
+} from "../../messages.js";
+import type { AgentMessageQueueController } from "../../agent-message-queue.js";
+
+type QueueRequest = Extract<
+  SessionInboundMessage,
+  {
+    type:
+      | "queue.agent_message.enqueue.request"
+      | "queue.agent_message.list.request"
+      | "queue.agent_message.cancel.request"
+      | "queue.agent_message.dispatch.request";
+  }
+>;
+
+export type AgentIdentifierResolution =
+  | { ok: true; agentId: string }
+  | { ok: false; error: string };
+
+export interface AgentMessageQueueSessionOptions {
+  host: {
+    emit(message: SessionOutboundMessage, source?: object): void;
+    resolveAgentIdentifier(identifier: string): Promise<AgentIdentifierResolution>;
+  };
+  queue?: AgentMessageQueueController;
+}
+
+/**
+ * Owns the queue RPC surface for one client session: request normalization,
+ * identifier resolution, response envelopes, and source-aware delivery. The
+ * queue itself remains daemon-global and is injected by the WebSocket server.
+ */
+export class AgentMessageQueueSession {
+  private readonly host: AgentMessageQueueSessionOptions["host"];
+  private readonly queue: AgentMessageQueueController | null;
+
+  constructor(options: AgentMessageQueueSessionOptions) {
+    this.host = options.host;
+    this.queue = options.queue ?? null;
+  }
+
+  dispatch(message: SessionInboundMessage, source?: object): Promise<void> | undefined {
+    switch (message.type) {
+      case "queue.agent_message.enqueue.request":
+        return this.handleEnqueue(message, source);
+      case "queue.agent_message.list.request":
+        return this.handleList(message, source);
+      case "queue.agent_message.cancel.request":
+        return this.handleCancel(message, source);
+      case "queue.agent_message.dispatch.request":
+        return this.handleDispatch(message, source);
+      default:
+        return undefined;
+    }
+  }
+
+  private requireQueue(): AgentMessageQueueController {
+    if (!this.queue) {
+      throw new Error("Agent message queue is unavailable");
+    }
+    return this.queue;
+  }
+
+  private async handleEnqueue(
+    message: Extract<QueueRequest, { type: "queue.agent_message.enqueue.request" }>,
+    source?: object,
+  ): Promise<void> {
+    const resolved = await this.resolveAgentIdentifier(message.agentId);
+    if (!resolved.ok) {
+      this.host.emit(
+        {
+          type: "queue.agent_message.enqueue.response",
+          payload: {
+            requestId: message.requestId,
+            agentId: message.agentId,
+            accepted: false,
+            message: null,
+            error: resolved.error,
+          },
+        },
+        source,
+      );
+      return;
+    }
+
+    try {
+      const queued = await this.requireQueue().enqueue({
+        agentId: resolved.agentId,
+        text: message.text,
+        messageId: message.messageId,
+        images: message.images ?? [],
+        attachments: normalizeAgentAttachments(message.attachments),
+      });
+      this.host.emit(
+        {
+          type: "queue.agent_message.enqueue.response",
+          payload: {
+            requestId: message.requestId,
+            agentId: resolved.agentId,
+            accepted: true,
+            message: queued,
+            error: null,
+          },
+        },
+        source,
+      );
+    } catch (error) {
+      this.host.emit(
+        {
+          type: "queue.agent_message.enqueue.response",
+          payload: {
+            requestId: message.requestId,
+            agentId: resolved.agentId,
+            accepted: false,
+            message: null,
+            error: getErrorMessageOr(error, "Failed to queue agent message"),
+          },
+        },
+        source,
+      );
+    }
+  }
+
+  private async handleList(
+    message: Extract<QueueRequest, { type: "queue.agent_message.list.request" }>,
+    source?: object,
+  ): Promise<void> {
+    try {
+      let agentId: string | undefined;
+      if (message.agentId) {
+        const resolved = await this.resolveAgentIdentifier(message.agentId);
+        if (!resolved.ok) {
+          this.host.emit(
+            {
+              type: "queue.agent_message.list.response",
+              payload: { requestId: message.requestId, queues: [], error: resolved.error },
+            },
+            source,
+          );
+          return;
+        }
+        agentId = resolved.agentId;
+      }
+      const queues = await this.requireQueue().list(agentId);
+      this.host.emit(
+        {
+          type: "queue.agent_message.list.response",
+          payload: { requestId: message.requestId, queues, error: null },
+        },
+        source,
+      );
+    } catch (error) {
+      this.host.emit(
+        {
+          type: "queue.agent_message.list.response",
+          payload: {
+            requestId: message.requestId,
+            queues: [],
+            error: getErrorMessageOr(error, "Failed to list queued agent messages"),
+          },
+        },
+        source,
+      );
+    }
+  }
+
+  private async handleCancel(
+    message: Extract<QueueRequest, { type: "queue.agent_message.cancel.request" }>,
+    source?: object,
+  ): Promise<void> {
+    const resolved = await this.resolveAgentIdentifier(message.agentId);
+    if (!resolved.ok) {
+      this.emitMutationResult(message, message.agentId, false, resolved.error, source);
+      return;
+    }
+    try {
+      const removed = await this.requireQueue().cancel(resolved.agentId, message.queuedMessageId);
+      this.emitMutationResult(
+        message,
+        resolved.agentId,
+        removed,
+        removed ? null : `Queued message not found: ${message.queuedMessageId}`,
+        source,
+      );
+    } catch (error) {
+      this.emitMutationResult(
+        message,
+        resolved.agentId,
+        false,
+        getErrorMessageOr(error, "Failed to cancel queued agent message"),
+        source,
+      );
+    }
+  }
+
+  private async handleDispatch(
+    message: Extract<QueueRequest, { type: "queue.agent_message.dispatch.request" }>,
+    source?: object,
+  ): Promise<void> {
+    const resolved = await this.resolveAgentIdentifier(message.agentId);
+    if (!resolved.ok) {
+      this.emitMutationResult(message, message.agentId, false, resolved.error, source);
+      return;
+    }
+    try {
+      await this.requireQueue().dispatchNow(resolved.agentId, message.queuedMessageId);
+      this.emitMutationResult(message, resolved.agentId, true, null, source);
+    } catch (error) {
+      this.emitMutationResult(
+        message,
+        resolved.agentId,
+        false,
+        getErrorMessageOr(error, "Failed to dispatch queued agent message"),
+        source,
+      );
+    }
+  }
+
+  private emitMutationResult(
+    message: Extract<
+      QueueRequest,
+      {
+        type: "queue.agent_message.cancel.request" | "queue.agent_message.dispatch.request";
+      }
+    >,
+    agentId: string,
+    accepted: boolean,
+    error: string | null,
+    source?: object,
+  ): void {
+    const payload = {
+      requestId: message.requestId,
+      agentId,
+      queuedMessageId: message.queuedMessageId,
+      accepted,
+      error,
+    };
+    this.host.emit(
+      message.type === "queue.agent_message.cancel.request"
+        ? { type: "queue.agent_message.cancel.response", payload }
+        : { type: "queue.agent_message.dispatch.response", payload },
+      source,
+    );
+  }
+
+  private async resolveAgentIdentifier(identifier: string): Promise<AgentIdentifierResolution> {
+    try {
+      return await this.host.resolveAgentIdentifier(identifier);
+    } catch {
+      return { ok: false, error: "Failed to resolve agent identifier" };
+    }
+  }
+}

--- a/packages/server/src/server/websocket-server.browser-tools.test.ts
+++ b/packages/server/src/server/websocket-server.browser-tools.test.ts
@@ -274,6 +274,7 @@ function createVoiceAssistantWebSocketServer(params: {
   const agentManager = {
     setAgentAttentionCallback() {},
     subscribe: () => () => {},
+    addAgentArchivedCallback: () => () => {},
     getMetricsSnapshot: () => ({
       total: 0,
       byLifecycle: {},

--- a/packages/server/src/server/websocket-server.notifications.test.ts
+++ b/packages/server/src/server/websocket-server.notifications.test.ts
@@ -86,6 +86,7 @@ function createServer(agentManagerOverrides?: Record<string, unknown>) {
   const agentManager = {
     subscribe: vi.fn(() => () => {}),
     setAgentAttentionCallback: vi.fn(),
+    addAgentArchivedCallback: vi.fn(() => () => {}),
     getAgent: vi.fn(() => ({ workspaceId: WORKSPACE_ID, pendingPermissions: new Map() })),
     getLastAssistantMessage: vi.fn(async () => null),
     getMetricsSnapshot: vi.fn(() => ({

--- a/packages/server/src/server/websocket-server.relay-reconnect.test.ts
+++ b/packages/server/src/server/websocket-server.relay-reconnect.test.ts
@@ -235,6 +235,7 @@ function createServer(options?: {
     createStub<AgentManager>({
       subscribe: vi.fn(() => () => {}),
       setAgentAttentionCallback: vi.fn(),
+      addAgentArchivedCallback: vi.fn(() => () => {}),
       getAgent: vi.fn(() => null),
       getMetricsSnapshot: vi.fn(() => ({
         totalAgents: 0,

--- a/packages/server/src/server/websocket-server.terminal-notifications.test.ts
+++ b/packages/server/src/server/websocket-server.terminal-notifications.test.ts
@@ -118,6 +118,7 @@ function createServer(terminalManager: TerminalManager, workspaceRegistry?: Work
   const agentManager = {
     setAgentAttentionCallback: vi.fn(),
     subscribe: vi.fn(() => () => {}),
+    addAgentArchivedCallback: vi.fn(() => () => {}),
     getAgent: vi.fn(() => null),
     getLastAssistantMessage: vi.fn(async () => null),
     getMetricsSnapshot: vi.fn(() => ({

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -17,6 +17,7 @@ import type { DaemonConfigStore, MutableDaemonConfig } from "./daemon-config-sto
 import {
   type ServerInfoStatusPayload,
   type SessionOutboundMessage,
+  type QueuedAgentMessageQueuePayload,
   type WorkspaceSetupSnapshot,
   type WSHelloMessage,
   type WSInboundMessage,
@@ -26,6 +27,10 @@ import {
   type WSOutboundMessage,
   wrapSessionMessage,
 } from "./messages.js";
+import {
+  createAgentMessageQueueService,
+  type AgentMessageQueueService,
+} from "./agent-message-queue.js";
 import { asUint8Array, decodeBinaryFrame } from "@getpaseo/protocol/binary-frames/index";
 import type { TerminalActivity } from "@getpaseo/protocol/terminal-activity";
 import type { HostnamesConfig } from "./hostnames.js";
@@ -582,6 +587,7 @@ export class VoiceAssistantWebSocketServer {
   private readonly workspaceSetupRuntime: WorkspaceSetupRuntime;
   private readonly providerSnapshotManager: ProviderSnapshotManager;
   private onLifecycleIntent!: ((intent: SessionLifecycleIntent) => void) | null;
+  private readonly agentMessageQueue: AgentMessageQueueService;
   private onBranchChanged!:
     | ((workspaceId: string, oldBranch: string | null, newBranch: string | null) => void)
     | null;
@@ -730,6 +736,17 @@ export class VoiceAssistantWebSocketServer {
       filePath: join(paseoHome, "push-tokens.json"),
     });
     this.pushNotificationSender = pushNotificationSender ?? this.pushNotifications;
+
+    this.agentMessageQueue = createAgentMessageQueueService({
+      paseoHome,
+      agentManager: this.agentManager,
+      agentStorage: this.agentStorage,
+      logger: this.logger.child({ module: "agent-message-queue" }),
+      onQueueUpdated: (queue) => this.broadcastAgentMessageQueueUpdated(queue),
+    });
+    void this.agentMessageQueue.start().catch((error) => {
+      this.logger.error({ err: error }, "Failed to start agent message queue");
+    });
 
     this.agentManager.setAgentAttentionCallback((params) => {
       void this.broadcastAgentAttention(params).catch((err) => {
@@ -1046,6 +1063,7 @@ export class VoiceAssistantWebSocketServer {
 
   public async close(): Promise<void> {
     this.prepareForShutdown();
+    this.agentMessageQueue.stop();
     this.unsubscribeSpeechReadiness?.();
     this.unsubscribeSpeechReadiness = null;
     this.unsubscribeDaemonConfigChange?.();
@@ -1430,6 +1448,7 @@ export class VoiceAssistantWebSocketServer {
       worktreesRoot: this.worktreesRoot,
       agentManager: this.agentManager,
       agentStorage: this.agentStorage,
+      agentMessageQueue: this.agentMessageQueue,
       projectRegistry: this.projectRegistry,
       workspaceRegistry: this.workspaceRegistry,
       workspaceLabelService: this.workspaceLabelService ?? undefined,
@@ -1776,6 +1795,8 @@ export class VoiceAssistantWebSocketServer {
         agentProfiles: true,
         // COMPAT(agentConfigApply): added in v0.3.2, remove gate after 2027-02-11.
         agentConfigApply: true,
+        // COMPAT(agentMessageQueue): added in v0.6.2, remove gate after 2027-02-26.
+        agentMessageQueue: true,
       },
     };
   }
@@ -1806,6 +1827,24 @@ export class VoiceAssistantWebSocketServer {
 
   private broadcastDaemonConfigChanged(config: MutableDaemonConfig): void {
     this.broadcast(this.createDaemonConfigChangedMessage(config));
+  }
+
+  private broadcastAgentMessageQueueUpdated(queue: QueuedAgentMessageQueuePayload): void {
+    // COMPAT(agentMessageQueueEvents): added in v0.6.2. Remove the per-source
+    // capability filter after 2027-02-26 once the supported client floor is >= v0.6.2.
+    const capableSockets = [...this.sessions].flatMap(([socket, connection]) =>
+      connection.kind === "trusted" &&
+      connection.session.supportsForSource(CLIENT_CAPS.agentMessageQueueEvents, socket)
+        ? [socket]
+        : [],
+    );
+    this.sendMessageToSockets(
+      capableSockets,
+      wrapSessionMessage({
+        type: "queue.agent_message.updated",
+        payload: queue,
+      }),
+    );
   }
 
   private bindSocketHandlers(ws: WebSocketLike): void {

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1053,6 +1053,7 @@ export class VoiceAssistantWebSocketServer {
 
   public prepareForShutdown(): void {
     this.connectionLifecycle = "stopping";
+    this.agentMessageQueue.stop();
   }
 
   public beginAcceptingConnections(): void {
@@ -1063,7 +1064,6 @@ export class VoiceAssistantWebSocketServer {
 
   public async close(): Promise<void> {
     this.prepareForShutdown();
-    this.agentMessageQueue.stop();
     this.unsubscribeSpeechReadiness?.();
     this.unsubscribeSpeechReadiness = null;
     this.unsubscribeDaemonConfigChange?.();


### PR DESCRIPTION
### Linked issues

Closes #1546
Closes #1291

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### Why

Queued follow-up prompts were owned only by the app process. Switching apps on mobile, refreshing the page, disconnecting, or handing the session to another client could therefore lose a large prompt before the agent became available.

This change makes the daemon the durable and authoritative queue owner. Pending prompts survive client lifecycle changes and ordinary daemon restarts, and every connected capable client sees the same queue.

### Design

- Adds an atomically persisted per-agent FIFO queue at `$PASEO_HOME/agent-message-queue.json`. Records contain the complete dispatch payload, stable message id, creation metadata, and a monotonic per-agent revision.
- Keeps persistence, replay, retry, revision, and lifecycle policy inside one daemon queue service. Queue RPC envelopes and source-aware responses live in a narrow Session domain rather than `session.ts`.
- Adds dotted enqueue/list/cancel/dispatch RPCs. Update events omit image and structured attachment payload arrays while retaining counts; clients hydrate unseen payloads through list.
- Broadcasts queue events only to trusted physical sockets advertising `agent_message_queue_events`. Hub sessions and older clients do not receive the new event type.
- Waits for a foreground turn-start acknowledgement registered before provider iterator consumption. Async start rejection durably restores the record to the front and uses bounded backoff. `dispatchNow` retains replacement semantics.
- Mirrors daemon queues through one per-host runtime sync owner using the same connection generation and authoritative active-agent directory as other replicas. Revisions reject stale events; a new connection snapshot is authoritative.
- Migrates legacy local queues with their existing ids. A migration failure retains that message and its suffix locally to preserve FIFO; reconnect retries only that unacknowledged suffix. Archive, delete, directory prune, source changes, and stale hydration results cannot resurrect removed entries.
- Keeps capability detection centralized under `server_info.features.agentMessageQueue`. Existing local queue behavior remains unchanged with older daemons.
- Keeps WebSocket schemas structural and backward-compatible. Optional wire fields are normalized explicitly in the client after validation; unknown future attachment kinds are retained in counts and made non-editable rather than misrepresented.
- Quarantines invalid queue JSON/schema files with a `.corrupt-<timestamp>-<uuid>` suffix and starts empty, preserving the original bytes for forensic recovery.

### Verification

Focused behavior:

- Server queue service: 23 passed
- Queue Session domain: 3 passed
- Agent prompt acknowledgement: 7 passed
- Daemon queue E2E: 3 passed (remaining tests skipped by focused filter)
- App queue synchronization: 7 passed
- Composer actions and failure reconciliation: 42 passed
- Directory sync/replica queue integration: 6 passed
- HostRuntime queue-focused cases: passed
- Client/protocol queue normalization and RPC coverage: passed
- DaemonClient baseline: 105 passed

Build and static checks:

- `npm run build:server`
- `npm run format`
- `npm run typecheck`
- `npm run lint` — 0 warnings, 0 errors
- Pre-commit format check, typecheck, and lint
- `git diff --check main...HEAD`

### Operational trade-offs

- Delivery is deliberately not exactly-once. The queue removes a record durably before starting the provider turn. A daemon crash before Paseo observes start acknowledgement can lose that in-flight record; retaining/retrying it could instead duplicate a turn the provider already accepted.
- A provider start that never settles blocks only that agent's queue. There is no timeout retry because a late provider success could duplicate delivery.
- Client-supplied message ids deduplicate records only while they remain pending. The daemon does not keep a delivered-message ledger.
- A quarantined corrupt file is not recovered automatically; availability and preservation of the original bytes take priority over guessing at invalid state.

### Checklist

- [x] One focused change
- [x] Tests cover success, failure, reconnect, lifecycle, compatibility, hydration, and restart behavior
- [x] Typecheck, lint, format, and server build pass
- [ ] UI changes include screenshots or video for every affected platform
