### PR TITLE
Speed up app Playwright CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,11 @@ jobs:
         run: npm run typecheck:examples --workspace=@getpaseo/client
 
   playwright:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    name: playwright (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     env:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
@@ -280,7 +285,7 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code @openai/codex@0.105.0 opencode-ai
 
       - name: Run Playwright E2E tests
-        run: npm run test:e2e --workspace=@getpaseo/app
+        run: npm run test:e2e --workspace=@getpaseo/app -- --shard=${{ matrix.shard }}/4
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
@@ -288,7 +293,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: playwright-results
+          name: playwright-results-${{ matrix.shard }}
           path: |
             packages/app/test-results/
             packages/app/playwright-report/

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -131,6 +131,7 @@ Test suites in this repo are heavy. Running them in bulk freezes the machine, es
 - For full-suite confidence, push to CI and check GitHub Actions.
 - Never run the full Playwright E2E suite locally — defer whole-suite verification to CI. Targeted Playwright specs are allowed when you changed or need to prove that specific flow.
 - App Playwright specs share one isolated daemon per run. Helpers that create projects or workspaces must remove the daemon project record during cleanup, not only delete the temp directory. Agent helpers must pass the intended `workspaceId` through to agent creation; never infer ownership from `cwd`.
+- CI can shard app Playwright across multiple jobs; each shard still owns a full isolated daemon/relay/Metro stack from global setup. Helpers that restart the daemon must preserve the global setup environment, including disabled speech/local-model settings, so a restart does not change the tested surface or start background downloads.
 
 ## Agent authentication in tests
 

--- a/packages/app/e2e/global-setup.ts
+++ b/packages/app/e2e/global-setup.ts
@@ -10,6 +10,7 @@ import dotenv from "dotenv";
 import { loadDaemonClientConstructor } from "./helpers/daemon-client-loader";
 import { createNodeWebSocketFactory, type NodeWebSocketFactory } from "./helpers/node-ws-factory";
 import { forkPaseoHomeMetadata, resolvePaseoHomePath } from "./helpers/paseo-home-fork";
+import { withDisabledE2ESpeechEnv } from "./helpers/speech-env";
 
 const wranglerCliPath = path.resolve(__dirname, "../node_modules/wrangler/bin/wrangler.js");
 
@@ -405,15 +406,6 @@ async function waitForPairingOfferFromDaemon(args: {
   );
 }
 
-const LOCAL_SPEECH_ENV_KEYS = [
-  "PASEO_LOCAL_MODELS_DIR",
-  "PASEO_DICTATION_LOCAL_STT_MODEL",
-  "PASEO_VOICE_LOCAL_STT_MODEL",
-  "PASEO_VOICE_LOCAL_TTS_MODEL",
-  "PASEO_VOICE_LOCAL_TTS_SPEAKER_ID",
-  "PASEO_VOICE_LOCAL_TTS_SPEED",
-] as const;
-
 async function loadEnvTestFile(repoRoot: string): Promise<void> {
   const envTestPath = path.join(repoRoot, ".env.test");
   if (existsSync(envTestPath)) {
@@ -675,7 +667,7 @@ interface DaemonSpawnArgs {
 function startDaemon(args: DaemonSpawnArgs): ChildProcess {
   const serverDir = path.resolve(__dirname, "../../..", "packages/server");
   const tsxBin = execSync("which tsx").toString().trim();
-  const env: NodeJS.ProcessEnv = {
+  const env = withDisabledE2ESpeechEnv({
     ...process.env,
     PATH: `${args.fakeEditorBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
     PASEO_HOME: args.paseoHome,
@@ -684,21 +676,9 @@ function startDaemon(args: DaemonSpawnArgs): ChildProcess {
     PASEO_LISTEN: `0.0.0.0:${args.port}`,
     PASEO_RELAY_ENDPOINT: `127.0.0.1:${args.relayPort}`,
     PASEO_CORS_ORIGINS: `http://localhost:${args.metroPort}`,
-    // Default app E2E does not cover speech flows. Keep these disabled so
-    // unrelated tests never start background local-model downloads.
-    PASEO_DICTATION_ENABLED: "0",
-    PASEO_VOICE_MODE_ENABLED: "0",
-    PASEO_DICTATION_STT_PROVIDER: "openai",
-    PASEO_VOICE_TURN_DETECTION_PROVIDER: "openai",
-    PASEO_VOICE_STT_PROVIDER: "openai",
-    PASEO_VOICE_TTS_PROVIDER: "openai",
     PASEO_NODE_ENV: "development",
     NODE_ENV: "development",
-  };
-
-  for (const key of LOCAL_SPEECH_ENV_KEYS) {
-    delete env[key];
-  }
+  });
 
   const child = spawn(tsxBin, ["scripts/supervisor-entrypoint.ts", "--dev"], {
     cwd: serverDir,

--- a/packages/app/e2e/helpers/daemon-restart.ts
+++ b/packages/app/e2e/helpers/daemon-restart.ts
@@ -5,15 +5,7 @@ import net from "node:net";
 import path from "node:path";
 
 import { getE2EDaemonPort } from "./daemon-port";
-
-const LOCAL_SPEECH_ENV_KEYS = [
-  "PASEO_LOCAL_MODELS_DIR",
-  "PASEO_DICTATION_LOCAL_STT_MODEL",
-  "PASEO_VOICE_LOCAL_STT_MODEL",
-  "PASEO_VOICE_LOCAL_TTS_MODEL",
-  "PASEO_VOICE_LOCAL_TTS_SPEAKER_ID",
-  "PASEO_VOICE_LOCAL_TTS_SPEED",
-] as const;
+import { withDisabledE2ESpeechEnv } from "./speech-env";
 
 /**
  * Restarts the isolated E2E daemon against the SAME PASEO_HOME and SAME port so
@@ -102,7 +94,7 @@ function spawnSupervisor(args: {
   // inside the Playwright worker (the shim is a .mjs symlink, not an executable),
   // so resolve the CLI module and load it with node.
   const tsxCli = createRequire(path.join(serverDir, "package.json")).resolve("tsx/cli");
-  const env: NodeJS.ProcessEnv = {
+  const env = withDisabledE2ESpeechEnv({
     ...process.env,
     PASEO_HOME: args.paseoHome,
     PASEO_E2E_EDITOR_RECORD_PATH: args.editorRecordPath,
@@ -110,19 +102,9 @@ function spawnSupervisor(args: {
     PASEO_LISTEN: `0.0.0.0:${args.port}`,
     PASEO_RELAY_ENDPOINT: `127.0.0.1:${args.relayPort}`,
     PASEO_CORS_ORIGINS: `http://localhost:${args.metroPort}`,
-    PASEO_DICTATION_ENABLED: "0",
-    PASEO_VOICE_MODE_ENABLED: "0",
-    PASEO_DICTATION_STT_PROVIDER: "openai",
-    PASEO_VOICE_TURN_DETECTION_PROVIDER: "openai",
-    PASEO_VOICE_STT_PROVIDER: "openai",
-    PASEO_VOICE_TTS_PROVIDER: "openai",
     PASEO_NODE_ENV: "development",
     NODE_ENV: "development",
-  };
-
-  for (const key of LOCAL_SPEECH_ENV_KEYS) {
-    delete env[key];
-  }
+  });
 
   const child = spawn(process.execPath, [tsxCli, "scripts/supervisor-entrypoint.ts", "--dev"], {
     cwd: serverDir,

--- a/packages/app/e2e/helpers/daemon-restart.ts
+++ b/packages/app/e2e/helpers/daemon-restart.ts
@@ -6,6 +6,15 @@ import path from "node:path";
 
 import { getE2EDaemonPort } from "./daemon-port";
 
+const LOCAL_SPEECH_ENV_KEYS = [
+  "PASEO_LOCAL_MODELS_DIR",
+  "PASEO_DICTATION_LOCAL_STT_MODEL",
+  "PASEO_VOICE_LOCAL_STT_MODEL",
+  "PASEO_VOICE_LOCAL_TTS_MODEL",
+  "PASEO_VOICE_LOCAL_TTS_SPEAKER_ID",
+  "PASEO_VOICE_LOCAL_TTS_SPEED",
+] as const;
+
 /**
  * Restarts the isolated E2E daemon against the SAME PASEO_HOME and SAME port so
  * persisted state reloads and existing clients can reconnect. This exercises the
@@ -93,20 +102,31 @@ function spawnSupervisor(args: {
   // inside the Playwright worker (the shim is a .mjs symlink, not an executable),
   // so resolve the CLI module and load it with node.
   const tsxCli = createRequire(path.join(serverDir, "package.json")).resolve("tsx/cli");
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PASEO_HOME: args.paseoHome,
+    PASEO_E2E_EDITOR_RECORD_PATH: args.editorRecordPath,
+    PASEO_SERVER_ID: "srv_e2e_test_daemon",
+    PASEO_LISTEN: `0.0.0.0:${args.port}`,
+    PASEO_RELAY_ENDPOINT: `127.0.0.1:${args.relayPort}`,
+    PASEO_CORS_ORIGINS: `http://localhost:${args.metroPort}`,
+    PASEO_DICTATION_ENABLED: "0",
+    PASEO_VOICE_MODE_ENABLED: "0",
+    PASEO_DICTATION_STT_PROVIDER: "openai",
+    PASEO_VOICE_TURN_DETECTION_PROVIDER: "openai",
+    PASEO_VOICE_STT_PROVIDER: "openai",
+    PASEO_VOICE_TTS_PROVIDER: "openai",
+    PASEO_NODE_ENV: "development",
+    NODE_ENV: "development",
+  };
+
+  for (const key of LOCAL_SPEECH_ENV_KEYS) {
+    delete env[key];
+  }
 
   const child = spawn(process.execPath, [tsxCli, "scripts/supervisor-entrypoint.ts", "--dev"], {
     cwd: serverDir,
-    env: {
-      ...process.env,
-      PASEO_HOME: args.paseoHome,
-      PASEO_E2E_EDITOR_RECORD_PATH: args.editorRecordPath,
-      PASEO_SERVER_ID: "srv_e2e_test_daemon",
-      PASEO_LISTEN: `0.0.0.0:${args.port}`,
-      PASEO_RELAY_ENDPOINT: `127.0.0.1:${args.relayPort}`,
-      PASEO_CORS_ORIGINS: `http://localhost:${args.metroPort}`,
-      PASEO_NODE_ENV: "development",
-      NODE_ENV: "development",
-    },
+    env,
     stdio: ["ignore", "pipe", "pipe"],
     detached: false,
   });

--- a/packages/app/e2e/helpers/speech-env.ts
+++ b/packages/app/e2e/helpers/speech-env.ts
@@ -1,0 +1,32 @@
+const LOCAL_SPEECH_ENV_KEYS = [
+  "PASEO_LOCAL_MODELS_DIR",
+  "PASEO_DICTATION_LOCAL_STT_MODEL",
+  "PASEO_VOICE_LOCAL_STT_MODEL",
+  "PASEO_VOICE_LOCAL_TTS_MODEL",
+  "PASEO_VOICE_LOCAL_TTS_SPEAKER_ID",
+  "PASEO_VOICE_LOCAL_TTS_SPEED",
+] as const;
+
+const DISABLED_E2E_SPEECH_ENV = {
+  PASEO_DICTATION_ENABLED: "0",
+  PASEO_VOICE_MODE_ENABLED: "0",
+  PASEO_DICTATION_STT_PROVIDER: "openai",
+  PASEO_VOICE_TURN_DETECTION_PROVIDER: "openai",
+  PASEO_VOICE_STT_PROVIDER: "openai",
+  PASEO_VOICE_TTS_PROVIDER: "openai",
+} as const;
+
+export function withDisabledE2ESpeechEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  // Default app E2E does not cover speech flows; keep restarts from starting
+  // background local-model downloads for unrelated tests.
+  const next: NodeJS.ProcessEnv = {
+    ...env,
+    ...DISABLED_E2E_SPEECH_ENV,
+  };
+
+  for (const key of LOCAL_SPEECH_ENV_KEYS) {
+    delete next[key];
+  }
+
+  return next;
+}

--- a/packages/app/e2e/workspace-model-restart.spec.ts
+++ b/packages/app/e2e/workspace-model-restart.spec.ts
@@ -10,6 +10,7 @@ import { buildHostWorkspaceRoute, decodeWorkspaceIdFromPathSegment } from "@/uti
 import { buildSeededHost } from "./helpers/daemon-registry";
 import { loadDaemonClientConstructor } from "./helpers/daemon-client-loader";
 import { createNodeWebSocketFactory, type NodeWebSocketFactory } from "./helpers/node-ws-factory";
+import { withDisabledE2ESpeechEnv } from "./helpers/speech-env";
 import {
   expectNewWorkspaceProjectSelected,
   openGlobalNewWorkspaceComposer,
@@ -243,18 +244,16 @@ async function startRestartDaemon(input: {
   const tsxBin = execSync("which tsx").toString().trim();
   const child = spawn(tsxBin, ["scripts/supervisor-entrypoint.ts", "--dev"], {
     cwd: serverDir,
-    env: {
+    env: withDisabledE2ESpeechEnv({
       ...process.env,
       PASEO_HOME: input.paseoHome,
       PASEO_SERVER_ID: SERVER_ID,
       PASEO_LISTEN: `127.0.0.1:${port}`,
       PASEO_CORS_ORIGINS: input.origin,
       PASEO_RELAY_ENABLED: "0",
-      PASEO_DICTATION_ENABLED: "0",
-      PASEO_VOICE_MODE_ENABLED: "0",
       PASEO_NODE_ENV: "development",
       NODE_ENV: "development",
-    },
+    }),
     stdio: ["ignore", "ignore", "pipe"],
     detached: false,
   });


### PR DESCRIPTION
### Linked issue

Refs #440

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [x] Docs

### What does this PR do

The app Playwright job now runs across four CI shards, so the same specs still run but the long test step is split across separate isolated runners. Each shard uploads its own failure artifacts.

The E2E daemon restart helper now mirrors global setup's disabled-speech environment. That keeps restarted test daemons from switching onto local speech models or starting background downloads mid-run.

### How did you verify it

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm run test:e2e --workspace=@getpaseo/app -- --list --shard=1/4` observed 57 tests
- `npm run test:e2e --workspace=@getpaseo/app -- --list --shard=2/4` observed 52 tests
- `npm run test:e2e --workspace=@getpaseo/app -- --list --shard=3/4` observed 53 tests
- `npm run test:e2e --workspace=@getpaseo/app -- --list --shard=4/4` observed 54 tests
- `npm run test:e2e --workspace=@getpaseo/app -- e2e/worktree-restore-after-restart.spec.ts --reporter=list` passed 1 test; observed the restarted daemon kept speech disabled and did not download local speech models

CI should confirm the full Playwright suite across all shards.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A: no UI changes)
- [x] Tests added or updated where it made sense