### PR TITLE
feat: add Claude Sonnet 5 model

### DIFF
--- a/packages/server/src/server/agent/providers/claude/models.test.ts
+++ b/packages/server/src/server/agent/providers/claude/models.test.ts
@@ -36,6 +36,7 @@ describe("getClaudeModels", () => {
     const models = getClaudeModels();
     expect(models.map((m) => m.id)).toEqual([
       "claude-fable-5",
+      "claude-sonnet-5",
       "claude-opus-4-8[1m]",
       "claude-opus-4-8",
       "claude-opus-4-7[1m]",
@@ -201,6 +202,7 @@ describe("ClaudeAgentClient.fetchCatalog", () => {
 describe("normalizeClaudeRuntimeModelId", () => {
   it("returns exact match for known model IDs", () => {
     expect(normalizeClaudeRuntimeModelId("claude-fable-5")).toBe("claude-fable-5");
+    expect(normalizeClaudeRuntimeModelId("claude-sonnet-5")).toBe("claude-sonnet-5");
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6")).toBe("claude-opus-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6[1m]")).toBe("claude-opus-4-6[1m]");
     expect(normalizeClaudeRuntimeModelId("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
@@ -209,6 +211,7 @@ describe("normalizeClaudeRuntimeModelId", () => {
 
   it("normalizes dated model IDs to base model", () => {
     expect(normalizeClaudeRuntimeModelId("claude-fable-5-20260301")).toBe("claude-fable-5");
+    expect(normalizeClaudeRuntimeModelId("claude-sonnet-5-20260601")).toBe("claude-sonnet-5");
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6-20260101")).toBe("claude-opus-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-sonnet-4-6-20260101")).toBe("claude-sonnet-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-haiku-4-5-20251001")).toBe("claude-haiku-4-5");

--- a/packages/server/src/server/agent/providers/claude/models.ts
+++ b/packages/server/src/server/agent/providers/claude/models.ts
@@ -35,6 +35,13 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
   },
   {
     provider: "claude",
+    id: "claude-sonnet-5",
+    label: "Sonnet 5",
+    description: "The best combination of speed and intelligence — fast with adaptive thinking",
+    thinkingOptions: [...CLAUDE_THINKING_OPTIONS],
+  },
+  {
+    provider: "claude",
     id: "claude-opus-4-8[1m]",
     label: "Opus 4.8 1M",
     description: "Opus 4.8 with 1M context window",
@@ -225,6 +232,15 @@ export function normalizeClaudeRuntimeModelId(value: string | null | undefined):
   const fableMatch = trimmed.match(/(?:claude-)?fable[-_ ]+(\d+)/i);
   if (fableMatch) {
     return `claude-fable-${fableMatch[1]}`;
+  }
+
+  // Sonnet 5 also uses a single-segment version (claude-sonnet-5), not the {major}-{minor}
+  // scheme. This maps dated runtime strings (e.g. claude-sonnet-5-20260601) back to the
+  // catalog ID. No [1m] variant. The negative lookahead ensures we don't match sonnet-5-0
+  // style versioned IDs (those are handled by the generic runtimeMatch below).
+  const sonnet5Match = trimmed.match(/(?:claude-)?sonnet[-_ ]+5(?:-\d{8})?$/i);
+  if (sonnet5Match) {
+    return "claude-sonnet-5";
   }
 
   // Match: claude-{family}-{major}-{minor}[1m]? possibly followed by a date suffix


### PR DESCRIPTION
## Summary
- Adds `claude-sonnet-5` to the Paseo Claude provider model catalog
- Updates `normalizeClaudeRuntimeModelId()` to handle Sonnet 5 dated runtime strings (e.g. `claude-sonnet-5-20260601` → `claude-sonnet-5`), following the same pattern as Fable 5
- Updates model list test to include the new entry, with exact-match and dated-variant normalization test cases

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] `models.test.ts` passes
- [ ] Open Paseo → Claude provider → model picker shows Sonnet 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)