### PR TITLE
Open a project with Cmd+O

### DIFF
--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -395,6 +395,16 @@ describe("keyboard-shortcuts", () => {
       event: { key: "T", code: "KeyT", altKey: true, shiftKey: true },
     },
     {
+      name: "does not keep old Cmd+Shift+O open-project binding after rebind to Cmd+O",
+      event: { key: "O", code: "KeyO", metaKey: true, shiftKey: true },
+      context: { isMac: true },
+    },
+    {
+      name: "does not keep old Ctrl+Shift+O open-project binding after rebind to Ctrl+O",
+      event: { key: "O", code: "KeyO", ctrlKey: true, shiftKey: true },
+      context: { isMac: false },
+    },
+    {
       name: "does not match question-mark shortcut inside editable scopes",
       event: { key: "?", code: "Slash", shiftKey: true },
       context: { focusScope: "message-input" },

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -124,8 +124,8 @@ interface HelpSectionCase {
 describe("keyboard-shortcuts", () => {
   const matchingCases: MatchingShortcutCase[] = [
     {
-      name: "matches Mod+Shift+O to create new agent",
-      event: { key: "O", code: "KeyO", metaKey: true, shiftKey: true },
+      name: "matches Cmd+O to open project",
+      event: { key: "o", code: "KeyO", metaKey: true },
       context: { isMac: true },
       action: "agent.new",
     },
@@ -227,8 +227,8 @@ describe("keyboard-shortcuts", () => {
       action: "workspace.tab.close.current",
     },
     {
-      name: "matches Ctrl+Shift+O to create new agent on non-mac",
-      event: { key: "O", code: "KeyO", ctrlKey: true, shiftKey: true },
+      name: "matches Ctrl+O to open project on non-mac",
+      event: { key: "o", code: "KeyO", ctrlKey: true },
       context: { isMac: false },
       action: "agent.new",
     },
@@ -580,7 +580,7 @@ describe("keyboard-shortcut help sections", () => {
       name: "uses web defaults for workspace and tab jump",
       context: { isMac: true, isDesktop: false },
       expectedKeys: {
-        "new-agent": ["mod", "shift", "O"],
+        "new-agent": ["mod", "O"],
         "workspace-tab-new": ["mod", "T"],
         "workspace-jump-index": ["alt", "1-9"],
         "workspace-tab-jump-index": ["alt", "shift", "1-9"],
@@ -594,7 +594,7 @@ describe("keyboard-shortcut help sections", () => {
       name: "uses desktop defaults for workspace and tab jump",
       context: { isMac: true, isDesktop: true },
       expectedKeys: {
-        "new-agent": ["mod", "shift", "O"],
+        "new-agent": ["mod", "O"],
         "new-workspace": ["mod", "N"],
         "workspace-tab-new": ["mod", "T"],
         "workspace-jump-index": ["mod", "1-9"],

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -121,7 +121,6 @@ const SHORTCUT_HELP_SECTION_LABEL_KEYS: Record<ShortcutSectionId, string> = {
 const SHORTCUT_HELP_LABEL_KEYS: Record<string, string> = {
   "new-agent": "settings.shortcuts.help.openProject",
   "new-workspace": "settings.shortcuts.help.newWorkspace",
-  "new-worktree": "settings.shortcuts.help.newWorktree",
   "archive-worktree": "settings.shortcuts.help.archiveWorktree",
   "workspace-tab-new": "settings.shortcuts.help.newTab",
   "workspace-tab-close-current": "settings.shortcuts.help.closeCurrentTab",
@@ -166,29 +165,29 @@ const SHORTCUT_HELP_NOTE_KEYS: Record<string, string> = {
 // --- Binding definitions ---
 
 const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
-  // --- New agent ---
+  // --- Open project ---
   {
-    id: "agent-new-cmd-shift-o-mac",
+    id: "agent-new-cmd-o-mac",
     action: "agent.new",
-    combo: "Cmd+Shift+O",
+    combo: "Cmd+O",
     when: { mac: true },
     help: {
       id: "new-agent",
       section: "projects",
       label: "Open project",
-      keys: ["mod", "shift", "O"],
+      keys: ["mod", "O"],
     },
   },
   {
-    id: "agent-new-ctrl-shift-o-non-mac",
+    id: "agent-new-ctrl-o-non-mac",
     action: "agent.new",
-    combo: "Ctrl+Shift+O",
+    combo: "Ctrl+O",
     when: { mac: false, terminal: false },
     help: {
       id: "new-agent",
       section: "projects",
       label: "Open project",
-      keys: ["mod", "shift", "O"],
+      keys: ["mod", "O"],
     },
   },
 
@@ -215,32 +214,6 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
       section: "projects",
       label: "New workspace",
       keys: ["mod", "N"],
-    },
-  },
-
-  // --- New worktree ---
-  {
-    id: "worktree-new-cmd-o-mac",
-    action: "worktree.new",
-    combo: "Cmd+O",
-    when: { mac: true, commandCenter: false },
-    help: {
-      id: "new-worktree",
-      section: "projects",
-      label: "New worktree",
-      keys: ["mod", "O"],
-    },
-  },
-  {
-    id: "worktree-new-ctrl-o-non-mac",
-    action: "worktree.new",
-    combo: "Ctrl+O",
-    when: { mac: false, commandCenter: false, terminal: false },
-    help: {
-      id: "new-worktree",
-      section: "projects",
-      label: "New worktree",
-      keys: ["mod", "O"],
     },
   },
 

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -166,8 +166,12 @@ const SHORTCUT_HELP_NOTE_KEYS: Record<string, string> = {
 
 const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
   // --- Open project ---
+  // Open project moved from Cmd+Shift+O to Cmd+O. The binding ids intentionally
+  // keep their original "cmd-shift-o" / "ctrl-shift-o" names: user shortcut
+  // overrides are keyed by binding id, so renaming them would silently drop a
+  // user's customized Open project shortcut on upgrade.
   {
-    id: "agent-new-cmd-o-mac",
+    id: "agent-new-cmd-shift-o-mac",
     action: "agent.new",
     combo: "Cmd+O",
     when: { mac: true },
@@ -179,7 +183,7 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
     },
   },
   {
-    id: "agent-new-ctrl-o-non-mac",
+    id: "agent-new-ctrl-shift-o-non-mac",
     action: "agent.new",
     combo: "Ctrl+O",
     when: { mac: false, terminal: false },

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -90,6 +90,7 @@ const FORWARDED_PASEO_SHORTCUT_KEYS = new Set([
   "w",
   "t",
   "k",
+  "o",
   "/",
   "\\",
   ",",


### PR DESCRIPTION
### Linked issue

None — direct user-requested keyboard-shortcut change, no prior issue. Happy to file one if you'd prefer it tracked.

### Type of change

- [ ] Bug fix
- [x] New feature (small behavior change — see note above; no prior design doc)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Rebinds **Open project** to `Cmd+O` (`Ctrl+O` on non-mac), moving it off `Cmd+Shift+O`. **New workspace** stays on `Cmd+N`.

**New worktree**, which previously lived on `Cmd+O`, is now unbound — it has no keyboard shortcut and no longer appears in Settings → Keyboard shortcuts. Its sidebar `+` button still creates a worktree; only the shortcut is gone (that button never went through the shortcut system).

Everything downstream is driven off the binding table, so it followed automatically: the command center's "Open project" row now shows `Cmd+O`, and the sidebar's new-worktree tooltip stops showing a shortcut hint.

### How did you verify it

- Updated and ran the affected unit tests: `packages/app/src/keyboard/keyboard-shortcuts.test.ts` — 69/69 pass. Covers `Cmd+O` → `agent.new` on mac and `Ctrl+O` on non-mac, plus the help-section key output (`["mod", "O"]`).
- `npm run typecheck`, `npm run lint`, `npm run format` — all green (also enforced by the pre-commit hook on this commit).
- Not manually smoked in a running app — the change is pure binding-resolution logic, but see the risk note below for what's worth a real click before merge.

### Maintainer checklist before merge

- **Web + Electron `Cmd+O` collision (the main thing to check):** `Cmd+O`/`Ctrl+O` is the browser's native "Open File" shortcut; the old `Cmd+Shift+O` never collided. The matcher sets `preventDefault`, so the app should intercept it and open the project picker instead of the OS/browser file dialog — worth confirming in a real browser and in the desktop build on both mac and non-mac.
- Native (iOS/Android) is unaffected — these bindings are hardware-keyboard/desktop-web surfaces; no visual UI component changed (only a tooltip's shortcut hint stops rendering, so there's nothing meaningful to screenshot).

### Risk surface

- The `worktree.new` action plumbing (`useActiveWorktreeNewAction` + its `_layout.tsx` mount, the `PASSTHROUGH_DISPATCH` routing entry, and the action id in the two unions) is now **dormant** — nothing can dispatch it since the only entry point was the removed binding. Left in place intentionally rather than expanding scope into a cross-file cleanup; can be removed as a focused follow-up.
- Cross-platform binding differences (`Cmd` on mac, `Ctrl` elsewhere) are exercised by the unit tests.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots — n/a (no visual component change; a tooltip shortcut hint stops rendering)
- [x] Tests added or updated where it made sense