### PR TITLE
Add Claude Sonnet 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.103 - 2026-07-01
+
+### Added
+
+- Claude Sonnet 5 is available in the Claude model picker ([#1850](https://github.com/getpaseo/paseo/pull/1850))
+
 ## 0.1.102 - 2026-06-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paseo",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paseo",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "workspaces": [
@@ -35132,7 +35132,7 @@
     },
     "packages/app": {
       "name": "@getpaseo/app",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -36150,12 +36150,12 @@
     },
     "packages/cli": {
       "name": "@getpaseo/cli",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "dependencies": {
         "@clack/prompts": "^1.0.0",
-        "@getpaseo/client": "0.1.102",
-        "@getpaseo/protocol": "0.1.102",
-        "@getpaseo/server": "0.1.102",
+        "@getpaseo/client": "0.1.103",
+        "@getpaseo/protocol": "0.1.103",
+        "@getpaseo/server": "0.1.103",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "mime-types": "^2.1.35",
@@ -36401,10 +36401,10 @@
     },
     "packages/client": {
       "name": "@getpaseo/client",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "dependencies": {
-        "@getpaseo/protocol": "0.1.102",
-        "@getpaseo/relay": "0.1.102",
+        "@getpaseo/protocol": "0.1.103",
+        "@getpaseo/relay": "0.1.103",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -36415,7 +36415,7 @@
     },
     "packages/desktop": {
       "name": "@getpaseo/desktop",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@getpaseo/cli": "*",
@@ -36658,7 +36658,7 @@
     },
     "packages/expo-two-way-audio": {
       "name": "@getpaseo/expo-two-way-audio",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -37554,7 +37554,7 @@
     },
     "packages/highlight": {
       "name": "@getpaseo/highlight",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "dependencies": {
         "@codemirror/language": "^6.12.3",
         "@codemirror/legacy-modes": "^6.5.3",
@@ -37786,7 +37786,7 @@
     },
     "packages/protocol": {
       "name": "@getpaseo/protocol",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "dependencies": {
         "zod": "^4.4.3"
       },
@@ -37798,7 +37798,7 @@
     },
     "packages/relay": {
       "name": "@getpaseo/relay",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "dependencies": {
         "base64-js": "^1.5.1",
         "tweetnacl": "^1.0.3",
@@ -38016,15 +38016,15 @@
     },
     "packages/server": {
       "name": "@getpaseo/server",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.17.1",
         "@anthropic-ai/claude-agent-sdk": "^0.3.195",
         "@anthropic-ai/sdk": "^0.104.2",
-        "@getpaseo/client": "0.1.102",
-        "@getpaseo/highlight": "0.1.102",
-        "@getpaseo/protocol": "0.1.102",
-        "@getpaseo/relay": "0.1.102",
+        "@getpaseo/client": "0.1.103",
+        "@getpaseo/highlight": "0.1.103",
+        "@getpaseo/protocol": "0.1.103",
+        "@getpaseo/relay": "0.1.103",
         "@isaacs/ttlcache": "^2.1.4",
         "@modelcontextprotocol/sdk": "^1.20.1",
         "@opencode-ai/sdk": "1.14.46",
@@ -38561,7 +38561,7 @@
     },
     "packages/website": {
       "name": "@getpaseo/website",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "dependencies": {
         "@cloudflare/vite-plugin": "^1.29.1",
         "@cloudflare/workers-types": "^4.20260317.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paseo",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "private": true,
   "description": "Paseo: voice-controlled development environment for local AI coding agents",
   "keywords": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/app",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "private": true,
   "main": "index.ts",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/cli",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "description": "Paseo CLI - control your AI coding agents from the command line",
   "bin": {
     "paseo": "bin/paseo"
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.0.0",
-    "@getpaseo/client": "0.1.102",
-    "@getpaseo/protocol": "0.1.102",
-    "@getpaseo/server": "0.1.102",
+    "@getpaseo/client": "0.1.103",
+    "@getpaseo/protocol": "0.1.103",
+    "@getpaseo/server": "0.1.103",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "mime-types": "^2.1.35",

--- a/packages/cli/tests/15-provider.test.ts
+++ b/packages/cli/tests/15-provider.test.ts
@@ -61,6 +61,11 @@ const EXPECTED_CLAUDE_MODELS = [
     descriptionFragment: "Latest release",
   },
   {
+    id: "claude-sonnet-5",
+    model: "Sonnet 5",
+    descriptionFragment: "Efficient for routine tasks",
+  },
+  {
     id: "claude-opus-4-7[1m]",
     model: "Opus 4.7 1M",
     descriptionFragment: "1M context window",
@@ -392,7 +397,7 @@ try {
       "--quiet should print the current Claude catalog IDs",
     );
     assert(
-      claudeModelsFromJson.some((m) => m.id === "claude-sonnet-4-6"),
+      claudeModelsFromJson.some((m) => m.id === "claude-sonnet-5"),
       "captured --json output should include the current Claude everyday model id",
     );
     console.log("✓ provider models --quiet outputs model IDs only\n");

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/client",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "description": "Paseo client SDK package",
   "files": [
     "dist",
@@ -35,8 +35,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@getpaseo/protocol": "0.1.102",
-    "@getpaseo/relay": "0.1.102",
+    "@getpaseo/protocol": "0.1.103",
+    "@getpaseo/relay": "0.1.103",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/desktop",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "private": true,
   "description": "Paseo desktop app (Electron wrapper)",
   "homepage": "https://paseo.sh",

--- a/packages/expo-two-way-audio/package.json
+++ b/packages/expo-two-way-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/expo-two-way-audio",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "description": "Native module for two way audio streaming",
   "keywords": [
     "ExpoTwoWayAudio",

--- a/packages/highlight/package.json
+++ b/packages/highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/highlight",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "files": [
     "dist",
     "!dist/**/*.map"

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/protocol",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "description": "Paseo shared protocol schemas and wire types",
   "files": [
     "dist",

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -77,6 +77,7 @@ export interface AgentModelDefinition {
   label: string;
   description?: string;
   isDefault?: boolean;
+  contextWindowMaxTokens?: number;
   metadata?: AgentMetadata;
   thinkingOptions?: AgentSelectOption[];
   defaultThinkingOptionId?: string;

--- a/packages/protocol/src/messages.providers-snapshot.test.ts
+++ b/packages/protocol/src/messages.providers-snapshot.test.ts
@@ -48,6 +48,7 @@ describe("provider snapshot message schemas", () => {
           id: "MiniMax-M2.7",
           label: "MiniMax-M2.7",
           isDefault: true,
+          contextWindowMaxTokens: 200_000,
           thinkingOptions: [
             { id: "off", label: "Off" },
             { id: "max", label: "Max", isDefault: true },
@@ -62,6 +63,7 @@ describe("provider snapshot message schemas", () => {
         id: "MiniMax-M2.7",
         label: "MiniMax-M2.7",
         isDefault: true,
+        contextWindowMaxTokens: 200_000,
         thinkingOptions: [
           { id: "off", label: "Off" },
           { id: "max", label: "Max", isDefault: true },

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -242,6 +242,7 @@ const AgentModelDefinitionSchema: z.ZodType<AgentModelDefinition> = z
     label: z.string(),
     description: z.string().optional(),
     isDefault: z.boolean().optional(),
+    contextWindowMaxTokens: z.number().optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
     thinkingOptions: z.array(AgentSelectOptionSchema).optional(),
     defaultThinkingOptionId: z.string().optional(),

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/relay",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "description": "Paseo relay for bridging daemon and client connections",
   "files": [
     "dist",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/server",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "description": "Paseo backend server",
   "files": [
     "dist/server",
@@ -65,10 +65,10 @@
     "@agentclientprotocol/sdk": "^0.17.1",
     "@anthropic-ai/claude-agent-sdk": "^0.3.195",
     "@anthropic-ai/sdk": "^0.104.2",
-    "@getpaseo/client": "0.1.102",
-    "@getpaseo/highlight": "0.1.102",
-    "@getpaseo/protocol": "0.1.102",
-    "@getpaseo/relay": "0.1.102",
+    "@getpaseo/client": "0.1.103",
+    "@getpaseo/highlight": "0.1.103",
+    "@getpaseo/protocol": "0.1.103",
+    "@getpaseo/relay": "0.1.103",
     "@isaacs/ttlcache": "^2.1.4",
     "@modelcontextprotocol/sdk": "^1.20.1",
     "@opencode-ai/sdk": "1.14.46",

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -78,6 +78,7 @@ export interface AgentModelDefinition {
   label: string;
   description?: string;
   isDefault?: boolean;
+  contextWindowMaxTokens?: number;
   metadata?: AgentMetadata;
   thinkingOptions?: AgentSelectOption[];
   defaultThinkingOptionId?: string;

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -416,6 +416,7 @@ describe("ClaudeAgentClient.fetchCatalog", () => {
         "claude-fable-5",
         "claude-opus-4-8[1m]",
         "claude-opus-4-8",
+        "claude-sonnet-5",
         "claude-opus-4-7[1m]",
         "claude-opus-4-7",
         "claude-opus-4-6[1m]",
@@ -457,6 +458,8 @@ describe("ClaudeAgentClient.fetchCatalog", () => {
       expect(getThinkingIds("claude-fable-5")).toContain("ultracode");
       expect(getThinkingIds("claude-opus-4-8[1m]")).toContain("ultracode");
       expect(getThinkingIds("claude-opus-4-8")).toContain("ultracode");
+      expect(getThinkingIds("claude-sonnet-5")).toContain("xhigh");
+      expect(getThinkingIds("claude-sonnet-5")).not.toContain("ultracode");
       expect(getThinkingIds("claude-opus-4-7")).not.toContain("ultracode");
       expect(getThinkingIds("claude-sonnet-4-6")).not.toContain("ultracode");
     } finally {

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -1892,6 +1892,45 @@ describe("ClaudeAgentSession context window usage", () => {
     }
   });
 
+  test("selected native-1M Claude models seed active context window usage with 1M max tokens", async () => {
+    const session = await createSessionForTurns(
+      [
+        [
+          createInitMessage(),
+          createMessageStartEvent(),
+          createSuccessResult({ modelUsage: undefined }),
+        ],
+      ],
+      { model: "claude-sonnet-5" },
+    );
+
+    try {
+      const events = await collectStreamEvents(session);
+
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "usage_updated",
+          provider: "claude",
+          usage: {
+            contextWindowMaxTokens: 1_000_000,
+            contextWindowUsedTokens: 150,
+          },
+        }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "turn_completed",
+          provider: "claude",
+          usage: expect.objectContaining({
+            contextWindowMaxTokens: 1_000_000,
+          }),
+        }),
+      );
+    } finally {
+      await session.close();
+    }
+  });
+
   test("message_delta stream events update per-request usage", async () => {
     const session = await createSessionForTurns([
       [

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -1634,7 +1634,8 @@ function resolveInitialContextWindowSize(modelId: string | null | undefined): nu
   if (normalized.includes("[1m]") || normalized.includes("context-1m")) {
     return 1_000_000;
   }
-  if (normalized.includes("claude-fable-5")) {
+  const catalogModelId = normalizeClaudeRuntimeModelId(normalized);
+  if (catalogModelId === "claude-fable-5" || catalogModelId === "claude-sonnet-5") {
     return 1_000_000;
   }
   if (/(?:^|[~/_-])(?:claude[-_ ]*)?(opus|sonnet|haiku)(?:$|[-_ ./])/.test(normalized)) {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -29,7 +29,11 @@ import {
   mapTaskNotificationSystemRecordToToolCall,
   mapTaskNotificationUserContentToToolCall,
 } from "./task-notification-tool-call.js";
-import { getClaudeModelsWithSettings, normalizeClaudeRuntimeModelId } from "./models.js";
+import {
+  findClaudeModel,
+  getClaudeModelsWithSettings,
+  normalizeClaudeRuntimeModelId,
+} from "./models.js";
 import { parsePartialJsonObject } from "./partial-json.js";
 import { ClaudeSidechainTracker } from "./sidechain-tracker.js";
 import { buildClaudeFeatures, claudeModelSupportsFastMode } from "./feature-definitions.js";
@@ -1626,24 +1630,6 @@ function extractContextWindowSize(modelUsage: unknown): number | undefined {
   return maxContextWindow;
 }
 
-function resolveInitialContextWindowSize(modelId: string | null | undefined): number | undefined {
-  const normalized = typeof modelId === "string" ? modelId.trim().toLowerCase() : "";
-  if (!normalized) {
-    return undefined;
-  }
-  if (normalized.includes("[1m]") || normalized.includes("context-1m")) {
-    return 1_000_000;
-  }
-  const catalogModelId = normalizeClaudeRuntimeModelId(normalized);
-  if (catalogModelId === "claude-fable-5" || catalogModelId === "claude-sonnet-5") {
-    return 1_000_000;
-  }
-  if (/(?:^|[~/_-])(?:claude[-_ ]*)?(opus|sonnet|haiku)(?:$|[-_ ./])/.test(normalized)) {
-    return 200_000;
-  }
-  return undefined;
-}
-
 function readStreamRequestInputTokens(event: Record<string, unknown>): number | undefined {
   const messageUsage = toObjectRecord(toObjectRecord(event.message)?.usage);
   if (!messageUsage) {
@@ -1942,7 +1928,7 @@ class ClaudeAgentSession implements AgentSession {
     this.queryFactory = options.queryFactory;
     this.resolveBinary = options.resolveBinary;
     this.contextUsage = new ClaudeContextUsageState(
-      resolveInitialContextWindowSize(this.config.model),
+      findClaudeModel(this.config.model)?.contextWindowMaxTokens,
     );
     const handle = options.handle;
 
@@ -2188,7 +2174,7 @@ class ClaudeAgentSession implements AgentSession {
       await this.applyFastModeFeature(false, activeQuery);
     }
     this.contextUsage.setInitialContextWindowMaxTokens(
-      resolveInitialContextWindowSize(this.config.model),
+      findClaudeModel(this.config.model)?.contextWindowMaxTokens,
     );
     this.lastOptionsModel = normalizedModelId ?? this.lastOptionsModel;
     this.lastRuntimeModel = null;

--- a/packages/server/src/server/agent/providers/claude/models.test.ts
+++ b/packages/server/src/server/agent/providers/claude/models.test.ts
@@ -38,6 +38,7 @@ describe("getClaudeModels", () => {
       "claude-fable-5",
       "claude-opus-4-8[1m]",
       "claude-opus-4-8",
+      "claude-sonnet-5",
       "claude-opus-4-7[1m]",
       "claude-opus-4-7",
       "claude-opus-4-6[1m]",
@@ -203,12 +204,14 @@ describe("normalizeClaudeRuntimeModelId", () => {
     expect(normalizeClaudeRuntimeModelId("claude-fable-5")).toBe("claude-fable-5");
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6")).toBe("claude-opus-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6[1m]")).toBe("claude-opus-4-6[1m]");
+    expect(normalizeClaudeRuntimeModelId("claude-sonnet-5")).toBe("claude-sonnet-5");
     expect(normalizeClaudeRuntimeModelId("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-haiku-4-5")).toBe("claude-haiku-4-5");
   });
 
   it("normalizes dated model IDs to base model", () => {
     expect(normalizeClaudeRuntimeModelId("claude-fable-5-20260301")).toBe("claude-fable-5");
+    expect(normalizeClaudeRuntimeModelId("claude-sonnet-5-20260101")).toBe("claude-sonnet-5");
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6-20260101")).toBe("claude-opus-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-sonnet-4-6-20260101")).toBe("claude-sonnet-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-haiku-4-5-20251001")).toBe("claude-haiku-4-5");
@@ -216,6 +219,7 @@ describe("normalizeClaudeRuntimeModelId", () => {
 
   it("preserves [1m] suffix from runtime model strings", () => {
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6[1m]")).toBe("claude-opus-4-6[1m]");
+    expect(normalizeClaudeRuntimeModelId("claude-sonnet-5[1m]")).toBe("claude-sonnet-5");
   });
 
   it("returns null for empty/null/undefined", () => {

--- a/packages/server/src/server/agent/providers/claude/models.test.ts
+++ b/packages/server/src/server/agent/providers/claude/models.test.ts
@@ -219,6 +219,9 @@ describe("normalizeClaudeRuntimeModelId", () => {
 
   it("preserves [1m] suffix from runtime model strings", () => {
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6[1m]")).toBe("claude-opus-4-6[1m]");
+  });
+
+  it("strips [1m] suffix for natively-1M models", () => {
     expect(normalizeClaudeRuntimeModelId("claude-sonnet-5[1m]")).toBe("claude-sonnet-5");
   });
 

--- a/packages/server/src/server/agent/providers/claude/models.test.ts
+++ b/packages/server/src/server/agent/providers/claude/models.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createTestLogger } from "../../../../test-utils/test-logger.js";
 import { ClaudeAgentClient } from "./agent.js";
-import { getClaudeModels, normalizeClaudeRuntimeModelId } from "./models.js";
+import { findClaudeModel, getClaudeModels, normalizeClaudeRuntimeModelId } from "./models.js";
 
 const createdClaudeConfigDirs: string[] = [];
 
@@ -54,6 +54,22 @@ describe("getClaudeModels", () => {
     const defaults = models.filter((m) => m.isDefault);
     expect(defaults).toHaveLength(1);
     expect(defaults[0].id).toBe("claude-opus-4-8");
+  });
+
+  it("keeps fixed context windows on the model entries", () => {
+    const modelsById = new Map(getClaudeModels().map((model) => [model.id, model]));
+
+    expect(modelsById.get("claude-fable-5")?.contextWindowMaxTokens).toBe(1_000_000);
+    expect(modelsById.get("claude-opus-4-8[1m]")?.contextWindowMaxTokens).toBe(1_000_000);
+    expect(modelsById.get("claude-opus-4-8")?.contextWindowMaxTokens).toBe(200_000);
+    expect(modelsById.get("claude-sonnet-5")?.contextWindowMaxTokens).toBe(1_000_000);
+    expect(modelsById.get("claude-sonnet-4-6")?.contextWindowMaxTokens).toBe(200_000);
+    expect(modelsById.get("claude-haiku-4-5")?.contextWindowMaxTokens).toBe(200_000);
+  });
+
+  it("finds models through the runtime normalizer", () => {
+    expect(findClaudeModel("claude-sonnet-5-20260101")?.id).toBe("claude-sonnet-5");
+    expect(findClaudeModel("claude-sonnet-5[1m]")?.contextWindowMaxTokens).toBe(1_000_000);
   });
 
   it("returns fresh copies each call", () => {

--- a/packages/server/src/server/agent/providers/claude/models.ts
+++ b/packages/server/src/server/agent/providers/claude/models.ts
@@ -12,7 +12,7 @@ const CLAUDE_THINKING_OPTIONS = [
   { id: "max", label: "Max" },
 ] as const;
 
-const CLAUDE_OPUS_EXTENDED_THINKING_OPTIONS = [
+const CLAUDE_EXTENDED_THINKING_OPTIONS = [
   { id: "low", label: "Low" },
   { id: "medium", label: "Medium" },
   { id: "high", label: "High" },
@@ -21,7 +21,7 @@ const CLAUDE_OPUS_EXTENDED_THINKING_OPTIONS = [
 ] as const;
 
 const CLAUDE_ULTRACODE_THINKING_OPTIONS = [
-  ...CLAUDE_OPUS_EXTENDED_THINKING_OPTIONS,
+  ...CLAUDE_EXTENDED_THINKING_OPTIONS,
   { id: "ultracode", label: "Ultracode" },
 ] as const;
 
@@ -50,17 +50,24 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
   },
   {
     provider: "claude",
+    id: "claude-sonnet-5",
+    label: "Sonnet 5",
+    description: "Sonnet 5 · Efficient for routine tasks",
+    thinkingOptions: [...CLAUDE_EXTENDED_THINKING_OPTIONS],
+  },
+  {
+    provider: "claude",
     id: "claude-opus-4-7[1m]",
     label: "Opus 4.7 1M",
     description: "Opus 4.7 with 1M context window",
-    thinkingOptions: [...CLAUDE_OPUS_EXTENDED_THINKING_OPTIONS],
+    thinkingOptions: [...CLAUDE_EXTENDED_THINKING_OPTIONS],
   },
   {
     provider: "claude",
     id: "claude-opus-4-7",
     label: "Opus 4.7",
     description: "Opus 4.7 · Previous release",
-    thinkingOptions: [...CLAUDE_OPUS_EXTENDED_THINKING_OPTIONS],
+    thinkingOptions: [...CLAUDE_EXTENDED_THINKING_OPTIONS],
   },
   {
     provider: "claude",
@@ -218,13 +225,16 @@ export function normalizeClaudeRuntimeModelId(value: string | null | undefined):
     return trimmed;
   }
 
-  // Fable uses a single-segment version (claude-fable-5), not the {major}-{minor}
-  // scheme of opus/sonnet/haiku, so match it separately. This maps dated runtime
-  // strings (e.g. claude-fable-5-20260301) back to the catalog ID. No [1m] variant:
-  // Fable 5 is natively 1M, so there is no 200K-default model to opt into 1M.
-  const fableMatch = trimmed.match(/(?:claude-)?fable[-_ ]+(\d+)/i);
-  if (fableMatch) {
-    return `claude-fable-${fableMatch[1]}`;
+  // Fable and Sonnet 5 use single-segment versions, not the {major}-{minor}
+  // scheme of older opus/sonnet/haiku models. They are natively 1M, so map
+  // dated or suffixed runtime strings back to the one catalog ID.
+  const singleSegmentMatch = trimmed.match(/(?:claude-)?(fable|sonnet)[-_ ]+(\d+)/i);
+  if (singleSegmentMatch) {
+    const family = singleSegmentMatch[1].toLowerCase();
+    const major = singleSegmentMatch[2];
+    if (family === "fable" || (family === "sonnet" && major === "5")) {
+      return `claude-${family}-${major}`;
+    }
   }
 
   // Match: claude-{family}-{major}-{minor}[1m]? possibly followed by a date suffix

--- a/packages/server/src/server/agent/providers/claude/models.ts
+++ b/packages/server/src/server/agent/providers/claude/models.ts
@@ -225,15 +225,16 @@ export function normalizeClaudeRuntimeModelId(value: string | null | undefined):
     return trimmed;
   }
 
-  // Fable and Sonnet 5 use single-segment versions, not the {major}-{minor}
-  // scheme of older opus/sonnet/haiku models. They are natively 1M, so map
-  // dated or suffixed runtime strings back to the one catalog ID.
+  // Some new Claude model families use single-segment versions, not the
+  // {major}-{minor} scheme of older opus/sonnet/haiku models. Map dated or
+  // suffixed runtime strings back to the matching catalog ID.
   const singleSegmentMatch = trimmed.match(/(?:claude-)?(fable|sonnet)[-_ ]+(\d+)/i);
   if (singleSegmentMatch) {
     const family = singleSegmentMatch[1].toLowerCase();
     const major = singleSegmentMatch[2];
-    if (family === "fable" || (family === "sonnet" && major === "5")) {
-      return `claude-${family}-${major}`;
+    const modelId = `claude-${family}-${major}`;
+    if (CLAUDE_MODELS.some((model) => model.id === modelId)) {
+      return modelId;
     }
   }
 

--- a/packages/server/src/server/agent/providers/claude/models.ts
+++ b/packages/server/src/server/agent/providers/claude/models.ts
@@ -31,6 +31,7 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
     id: "claude-fable-5",
     label: "Fable 5",
     description: "Fable 5 · Most powerful model",
+    contextWindowMaxTokens: 1_000_000,
     thinkingOptions: [...CLAUDE_ULTRACODE_THINKING_OPTIONS],
   },
   {
@@ -38,6 +39,7 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
     id: "claude-opus-4-8[1m]",
     label: "Opus 4.8 1M",
     description: "Opus 4.8 with 1M context window",
+    contextWindowMaxTokens: 1_000_000,
     thinkingOptions: [...CLAUDE_ULTRACODE_THINKING_OPTIONS],
   },
   {
@@ -46,6 +48,7 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
     label: "Opus 4.8",
     description: "Opus 4.8 · Latest release",
     isDefault: true,
+    contextWindowMaxTokens: 200_000,
     thinkingOptions: [...CLAUDE_ULTRACODE_THINKING_OPTIONS],
   },
   {
@@ -53,6 +56,7 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
     id: "claude-sonnet-5",
     label: "Sonnet 5",
     description: "Sonnet 5 · Efficient for routine tasks",
+    contextWindowMaxTokens: 1_000_000,
     thinkingOptions: [...CLAUDE_EXTENDED_THINKING_OPTIONS],
   },
   {
@@ -60,6 +64,7 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
     id: "claude-opus-4-7[1m]",
     label: "Opus 4.7 1M",
     description: "Opus 4.7 with 1M context window",
+    contextWindowMaxTokens: 1_000_000,
     thinkingOptions: [...CLAUDE_EXTENDED_THINKING_OPTIONS],
   },
   {
@@ -67,6 +72,7 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
     id: "claude-opus-4-7",
     label: "Opus 4.7",
     description: "Opus 4.7 · Previous release",
+    contextWindowMaxTokens: 200_000,
     thinkingOptions: [...CLAUDE_EXTENDED_THINKING_OPTIONS],
   },
   {
@@ -74,6 +80,7 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
     id: "claude-opus-4-6[1m]",
     label: "Opus 4.6 1M",
     description: "Opus 4.6 with 1M context window",
+    contextWindowMaxTokens: 1_000_000,
     thinkingOptions: [...CLAUDE_THINKING_OPTIONS],
   },
   {
@@ -81,6 +88,7 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
     id: "claude-opus-4-6",
     label: "Opus 4.6",
     description: "Opus 4.6 · Most capable for complex work",
+    contextWindowMaxTokens: 200_000,
     thinkingOptions: [...CLAUDE_THINKING_OPTIONS],
   },
   {
@@ -88,6 +96,7 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
     id: "claude-sonnet-4-6[1m]",
     label: "Sonnet 4.6 1M",
     description: "Sonnet 4.6 with 1M context window",
+    contextWindowMaxTokens: 1_000_000,
     thinkingOptions: [...CLAUDE_THINKING_OPTIONS],
   },
   {
@@ -95,6 +104,7 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
     id: "claude-sonnet-4-6",
     label: "Sonnet 4.6",
     description: "Sonnet 4.6 · Best for everyday tasks",
+    contextWindowMaxTokens: 200_000,
     thinkingOptions: [...CLAUDE_THINKING_OPTIONS],
   },
   {
@@ -102,6 +112,7 @@ const CLAUDE_MODELS: AgentModelDefinition[] = [
     id: "claude-haiku-4-5",
     label: "Haiku 4.5",
     description: "Haiku 4.5 · Fastest for quick answers",
+    contextWindowMaxTokens: 200_000,
   },
 ];
 
@@ -115,6 +126,14 @@ const CLAUDE_SETTINGS_MODEL_ENV_KEYS = [
 
 export function getClaudeModels(): AgentModelDefinition[] {
   return CLAUDE_MODELS.map((model) => ({ ...model }));
+}
+
+export function findClaudeModel(modelId: string | null | undefined): AgentModelDefinition | null {
+  const normalizedModelId = normalizeClaudeRuntimeModelId(modelId);
+  if (!normalizedModelId) {
+    return null;
+  }
+  return CLAUDE_MODELS.find((model) => model.id === normalizedModelId) ?? null;
 }
 
 export async function getClaudeModelsWithSettings(

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/website",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
closes #1837 

This prepares a stable-only patch branch from `v0.1.102` with Claude Sonnet 5 in the Claude provider model catalog. The PR targets `stable-0.1.103-sonnet-5`, which is rooted at the latest stable tag, so it avoids the post-stable commits currently on `main`.

Claude users can now select `claude-sonnet-5` from Paseo. The catalog treats Sonnet 5 as a native 1M-context model with no separate `[1m]` catalog row; defensive runtime normalization still collapses dated or suffixed Sonnet 5 strings back to the same catalog ID. Sonnet 5 sessions also seed the context meter with the native 1M window before SDK `modelUsage` arrives.

## Verification

- Real Claude Agent SDK probe using `@anthropic-ai/claude-agent-sdk@0.3.195` with Claude Code `2.1.197`: system init model, assistant message model, and `modelUsage` key were all `claude-sonnet-5`; no `[1m]` suffix was emitted. `modelUsage.claude-sonnet-5.contextWindow` reported `1000000`.
- `npm run format`
- `npm run build:server`
- `npm run test:unit --workspace=@getpaseo/server -- src/server/agent/providers/claude/models.test.ts src/server/agent/providers/claude/agent.test.ts --bail=1`
- `npx tsx packages/cli/tests/15-provider.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run release:prepare`
- `npm run release:check`
- `npm run acp:version-drift:check` reports 8 stale package-runner pins; left unchanged intentionally to keep this stable branch scoped to Sonnet 5.

## Risk surface

Claude provider catalog and Claude context-window usage seeding only. If Claude Code changes this model ID again, the picker could show a stale option; current Claude Code resolves the `sonnet` alias to `claude-sonnet-5` through the SDK path Paseo uses.
