### PR TITLE
fix(cli): avoid global agent fetch for chat names

### DIFF
--- a/packages/cli/src/commands/chat/shared.test.ts
+++ b/packages/cli/src/commands/chat/shared.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { attachAgentNamesToMessages, type ChatAgentNameClient } from "./shared.js";
+import type { ChatMessageRow } from "./schema.js";
+
+const message: ChatMessageRow = {
+  id: "msg-1",
+  author: "agent-1",
+  authorName: null,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  replyTo: "-",
+  mentionAgentIds: ["agent-2"],
+  mentionLabels: ["agent-2"],
+  body: "hello @agent-2",
+};
+
+describe("attachAgentNamesToMessages", () => {
+  it("keeps chat output usable when agent-name enrichment fails", async () => {
+    const fetchAgent = vi.fn(async () => {
+      throw Object.assign(new Error("Project not found for workspace wks_missing"), {
+        code: "fetch_agent_failed",
+      });
+    });
+    const client: ChatAgentNameClient = { fetchAgent };
+
+    await expect(attachAgentNamesToMessages(client, [message])).resolves.toEqual([message]);
+    expect(fetchAgent).toHaveBeenCalledTimes(2);
+    expect(fetchAgent).toHaveBeenCalledWith({ agentId: "agent-1" });
+    expect(fetchAgent).toHaveBeenCalledWith({ agentId: "agent-2" });
+  });
+});

--- a/packages/cli/src/commands/chat/shared.ts
+++ b/packages/cli/src/commands/chat/shared.ts
@@ -7,6 +7,8 @@ export interface ChatCommandOptions extends CommandOptions {
   host?: string;
 }
 
+export type ChatAgentNameClient = Pick<Awaited<ReturnType<typeof connectToDaemon>>, "fetchAgent">;
+
 export async function connectChatClient(host?: string) {
   const daemonHost = getDaemonHost({ host });
   try {
@@ -24,7 +26,7 @@ export async function connectChatClient(host?: string) {
 }
 
 export async function attachAgentNamesToMessages(
-  client: Awaited<ReturnType<typeof connectToDaemon>>,
+  client: ChatAgentNameClient,
   messages: ChatMessageRow[],
   options: { timeout?: number; bestEffort?: boolean } = {},
 ): Promise<ChatMessageRow[]> {
@@ -40,23 +42,27 @@ export async function attachAgentNamesToMessages(
     return messages;
   }
 
-  let payload: Awaited<ReturnType<typeof client.fetchAgents>>;
-  try {
-    payload = await client.fetchAgents({
-      filter: { includeArchived: true },
-      ...(typeof options.timeout === "number" ? { timeout: options.timeout } : {}),
-    });
-  } catch (error) {
-    if (options.bestEffort) {
-      return messages;
-    }
-    throw error;
-  }
+  const resolvedNames = await Promise.all(
+    Array.from(agentIds).map(async (agentId): Promise<{ agentId: string; name: string } | null> => {
+      try {
+        const result = await client.fetchAgent({
+          agentId,
+          ...(typeof options.timeout === "number" ? { timeout: options.timeout } : {}),
+        });
+        const title = result?.agent.title?.trim();
+        return title ? { agentId, name: title } : null;
+      } catch (error) {
+        if (options.bestEffort === false) {
+          throw error;
+        }
+        return null;
+      }
+    }),
+  );
   const agentNames = new Map<string, string>();
-  for (const entry of payload.entries) {
-    const title = entry.agent.title?.trim();
-    if (title) {
-      agentNames.set(entry.agent.id, title);
+  for (const resolved of resolvedNames) {
+    if (resolved) {
+      agentNames.set(resolved.agentId, resolved.name);
     }
   }
 


### PR DESCRIPTION
## Summary
- Change chat message name enrichment to resolve only the authors/mentions present in the messages instead of fetching the global agent roster.
- Keep enrichment best-effort by default so `paseo chat post/read/wait` still render with agent IDs if an agent lookup cannot build project placement.
- Add a focused regression test for the project-lookup failure path.

## Root cause
`paseo chat create` and `paseo chat ls` only call chat RPCs. `paseo chat post`, `read`, and `wait` call the chat RPC successfully, then `attachAgentNamesToMessages` did a global `fetch_agents_request` to decorate output with agent titles. That global roster fetch builds project placement for every returned agent workspace, so one stale/orphaned workspace can fail the whole chat command with `Project not found for workspace wks_...`, even when the chat room and caller workspace are valid.

## Verification
- `npx vitest run packages/cli/src/commands/chat/shared.test.ts --bail=1`
- `npm run lint -- packages/cli/src/commands/chat/shared.ts packages/cli/src/commands/chat/shared.test.ts`
- `npm run typecheck --workspace=@getpaseo/cli`
- `npx tsx packages/cli/tests/30-chat.test.ts`
- source CLI read-only smoke against the live daemon: `npx tsx packages/cli/src/index.ts chat read 0475dc8b-31b3-4363-bb40-bb0435142411 --limit 1`
- pre-commit hook: lint, format check, repo-wide typecheck

No production daemon restart is required for the daemon side; this is a CLI behavior change. Users need an updated CLI build/package for the fix to take effect.