### PR TITLE
feat(server): resume interrupted agents on daemon boot (opt-in)

### DIFF
--- a/packages/server/src/server/agent/agent-boot-resume.ts
+++ b/packages/server/src/server/agent/agent-boot-resume.ts
@@ -1,0 +1,56 @@
+import type { Logger } from "pino";
+
+import type { AgentManager } from "./agent-manager.js";
+import type { AgentStorage, StoredAgentRecord } from "./agent-storage.js";
+import { ensureAgentLoaded } from "./agent-loading.js";
+
+export interface ResumeInterruptedAgentsDeps {
+  agentManager: AgentManager;
+  agentStorage: AgentStorage;
+  logger: Logger;
+}
+
+function wasInterrupted(record: StoredAgentRecord): boolean {
+  if (record.archivedAt || record.internal || !record.persistence) {
+    return false;
+  }
+  if (record.interruptedAt) {
+    return true;
+  }
+  // No marker but a live-looking status means the previous daemon never ran
+  // its graceful close pass — i.e. it crashed mid-run.
+  return record.lastStatus === "running" || record.lastStatus === "initializing";
+}
+
+export async function resumeInterruptedAgents(deps: ResumeInterruptedAgentsDeps): Promise<void> {
+  const { agentManager, agentStorage, logger } = deps;
+  const records = await agentStorage.list();
+  const interrupted = records.filter(wasInterrupted);
+  if (interrupted.length === 0) {
+    return;
+  }
+
+  logger.info(
+    { count: interrupted.length },
+    "Resuming agents interrupted by the previous daemon shutdown",
+  );
+
+  for (const record of interrupted) {
+    try {
+      await ensureAgentLoaded(record.id, { agentManager, agentStorage, logger });
+      logger.info(
+        { agentId: record.id, provider: record.provider },
+        "Interrupted agent resumed on boot",
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error({ err: error, agentId: record.id }, "Failed to resume interrupted agent");
+      // ensureAgentLoaded persists a fresh snapshot only on success, so clear
+      // the marker explicitly to avoid retrying this agent on every boot.
+      const current = await agentStorage.get(record.id);
+      if (current) {
+        await agentStorage.upsert({ ...current, interruptedAt: null, lastError: message });
+      }
+    }
+  }
+}

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -64,6 +64,11 @@ const STORED_AGENT_SCHEMA = z.object({
   attentionTimestamp: z.string().nullable().optional(),
   internal: z.boolean().optional(),
   archivedAt: z.string().nullable().optional(),
+  // Set during graceful daemon shutdown for agents that were mid-run; cleared
+  // by the next applySnapshot (the projection never emits it) or by the boot
+  // resume pass. Records with lastStatus "running" and no marker indicate an
+  // unclean shutdown (crash) — both shapes are picked up by resume-on-boot.
+  interruptedAt: z.string().nullable().optional(),
 });
 
 export type SerializableAgentConfig = Pick<

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -103,6 +103,7 @@ import type { RequestedSpeechProviders } from "./speech/speech-types.js";
 import { createSpeechService } from "./speech/speech-runtime.js";
 import { AgentManager } from "./agent/agent-manager.js";
 import { AgentStorage } from "./agent/agent-storage.js";
+import { resumeInterruptedAgents } from "./agent/agent-boot-resume.js";
 import { attachAgentStoragePersistence } from "./persistence-hooks.js";
 import { createAgentMcpServer } from "./agent/mcp-server.js";
 import {
@@ -355,6 +356,7 @@ export interface PaseoDaemonConfig {
     enabled: boolean;
     distDir: string | null;
   };
+  resumeAgentsOnBoot?: boolean;
   appBaseUrl?: string;
   auth?: DaemonAuthConfig;
   openai?: PaseoOpenAIConfig;
@@ -830,6 +832,10 @@ export async function createPaseoDaemon(
     { elapsed: elapsed() },
     `Agent registry loaded (${persistedRecords.length} record${persistedRecords.length === 1 ? "" : "s"}); agents will initialize on demand`,
   );
+  if (config.resumeAgentsOnBoot) {
+    await resumeInterruptedAgents({ agentManager, agentStorage, logger });
+    logger.info({ elapsed: elapsed() }, "Interrupted-agent resume pass complete");
+  }
   logger.info(
     "Voice mode configured for agent-scoped resume flow (no dedicated voice assistant provider)",
   );
@@ -1313,7 +1319,7 @@ export async function createPaseoDaemon(
 
   const stop = async () => {
     scriptHealthMonitor.stop();
-    await closeAllAgents(logger, agentManager);
+    await closeAllAgents(logger, agentManager, agentStorage);
     await agentManager.flush().catch(() => undefined);
     detachAgentStoragePersistence();
     await agentStorage.flush().catch(() => undefined);
@@ -1357,14 +1363,32 @@ export async function createPaseoDaemon(
   };
 }
 
-async function closeAllAgents(logger: Logger, agentManager: AgentManager): Promise<void> {
+async function closeAllAgents(
+  logger: Logger,
+  agentManager: AgentManager,
+  agentStorage: AgentStorage,
+): Promise<void> {
   const agents = agentManager.listAgents();
   await Promise.all(
     agents.map(async (agent) => {
+      const wasActive = agent.lifecycle === "running" || agent.lifecycle === "initializing";
       try {
         await agentManager.closeAgent(agent.id);
       } catch (err) {
         logger.error({ err, agentId: agent.id }, "Failed to close agent");
+      }
+      if (!wasActive || agent.internal) {
+        return;
+      }
+      // closeAgent persisted lastStatus "closed", erasing that this agent was
+      // mid-run. Stamp the record so resume-on-boot can find it after restart.
+      try {
+        const record = await agentStorage.get(agent.id);
+        if (record && !record.archivedAt) {
+          await agentStorage.upsert({ ...record, interruptedAt: new Date().toISOString() });
+        }
+      } catch (err) {
+        logger.error({ err, agentId: agent.id }, "Failed to mark agent as interrupted");
       }
     }),
   );

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -495,6 +495,10 @@ export function loadConfig(
     relayPublicUseTls: relay.publicUseTls,
     serviceProxy,
     webUi,
+    resumeAgentsOnBoot:
+      parseBooleanEnv(env.PASEO_RESUME_AGENTS_ON_BOOT) ??
+      persisted.features?.resumeAgentsOnBoot?.enabled ??
+      false,
     appBaseUrl,
     auth: resolveAuthConfig(env, persisted),
     openai,

--- a/packages/server/src/server/daemon-e2e/daemon-boot-resume.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/daemon-boot-resume.e2e.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createDaemonTestContext, type DaemonTestContext } from "../test-utils/index.js";
+
+function tmpCwd(): string {
+  return mkdtempSync(path.join(tmpdir(), "daemon-boot-resume-"));
+}
+
+interface StoredRecordOnDisk {
+  filePath: string;
+  record: {
+    id: string;
+    lastStatus: string;
+    interruptedAt?: string | null;
+    persistence?: unknown;
+  };
+}
+
+function findStoredRecord(paseoHome: string, agentId: string): StoredRecordOnDisk {
+  const agentsRoot = path.join(paseoHome, "agents");
+  for (const dir of readdirSync(agentsRoot, { withFileTypes: true })) {
+    if (!dir.isDirectory()) {
+      continue;
+    }
+    const filePath = path.join(agentsRoot, dir.name, `${agentId}.json`);
+    try {
+      const record = JSON.parse(readFileSync(filePath, "utf8")) as StoredRecordOnDisk["record"];
+      return { filePath, record };
+    } catch {
+      // keep scanning other cwd directories
+    }
+  }
+  throw new Error(`Stored record for agent ${agentId} not found under ${agentsRoot}`);
+}
+
+/**
+ * Drives a fake Codex agent into a running state (blocked on a pending
+ * permission) so the daemon shuts down while the agent is mid-turn.
+ */
+async function createAgentRunningAtShutdown(
+  ctx: DaemonTestContext,
+  cwd: string,
+  marker: string,
+): Promise<string> {
+  const agent = await ctx.client.createAgent({
+    provider: "codex",
+    cwd,
+    title: "Boot Resume Test Agent",
+    modeId: "read-only",
+  });
+
+  await ctx.client.sendMessage(agent.id, `Remember this marker string for a test: "${marker}".`);
+  const afterRemember = await ctx.client.waitForFinish(agent.id, 5_000);
+  expect(afterRemember.status).toBe("idle");
+  expect(afterRemember.final?.persistence).toBeTruthy();
+
+  await ctx.client.sendMessage(
+    agent.id,
+    'Request approval to run the command `printf "ok" > permission.txt`.',
+  );
+  const pendingState = await ctx.client.waitForFinish(agent.id, 5_000);
+  expect(pendingState.final?.pendingPermissions?.length).toBeGreaterThan(0);
+
+  return agent.id;
+}
+
+describe("daemon boot resume", () => {
+  let ctx: DaemonTestContext | null = null;
+  let paseoHomeRoot: string | null = null;
+
+  afterEach(async () => {
+    await ctx?.cleanup();
+    ctx = null;
+    if (paseoHomeRoot) {
+      rmSync(paseoHomeRoot, { recursive: true, force: true });
+      paseoHomeRoot = null;
+    }
+  }, 60_000);
+
+  test("graceful shutdown marks mid-run agents and boot resumes them when enabled", async () => {
+    const cwd = tmpCwd();
+    const marker = `BOOT_RESUME_MARKER_${Date.now()}`;
+    paseoHomeRoot = await mkdtemp(path.join(tmpdir(), "paseo-home-boot-resume-"));
+    try {
+      ctx = await createDaemonTestContext({ paseoHomeRoot, cleanup: false });
+      const paseoHome = ctx.daemon.paseoHome;
+      const agentId = await createAgentRunningAtShutdown(ctx, cwd, marker);
+
+      await ctx.cleanup();
+      ctx = null;
+
+      const stored = findStoredRecord(paseoHome, agentId);
+      expect(stored.record.lastStatus).toBe("closed");
+      expect(stored.record.interruptedAt).toBeTruthy();
+      expect(stored.record.persistence).toBeTruthy();
+
+      ctx = await createDaemonTestContext({
+        paseoHomeRoot,
+        cleanup: false,
+        resumeAgentsOnBoot: true,
+      });
+
+      // Resumed during boot — present in the manager without any resume RPC.
+      expect(ctx.daemon.daemon.agentManager.getAgent(agentId)).toBeTruthy();
+
+      // The marker self-clears once the resumed agent persists a snapshot.
+      await ctx.client.sendMessage(
+        agentId,
+        "What was the marker string I asked you to remember earlier?",
+      );
+      const afterRecall = await ctx.client.waitForFinish(agentId, 5_000);
+      expect(afterRecall.status).toBe("idle");
+      expect(afterRecall.final!.persistence!.metadata).toMatchObject({ marker });
+
+      const afterResume = findStoredRecord(paseoHome, agentId);
+      expect(afterResume.record.interruptedAt ?? null).toBeNull();
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("boot does not resume interrupted agents when the flag is off", async () => {
+    const cwd = tmpCwd();
+    const marker = `BOOT_RESUME_OFF_MARKER_${Date.now()}`;
+    paseoHomeRoot = await mkdtemp(path.join(tmpdir(), "paseo-home-boot-resume-off-"));
+    try {
+      ctx = await createDaemonTestContext({ paseoHomeRoot, cleanup: false });
+      const paseoHome = ctx.daemon.paseoHome;
+      const agentId = await createAgentRunningAtShutdown(ctx, cwd, marker);
+
+      await ctx.cleanup();
+      ctx = null;
+
+      expect(findStoredRecord(paseoHome, agentId).record.interruptedAt).toBeTruthy();
+
+      ctx = await createDaemonTestContext({ paseoHomeRoot, cleanup: false });
+
+      expect(ctx.daemon.daemon.agentManager.getAgent(agentId)).toBeNull();
+      expect(findStoredRecord(paseoHome, agentId).record.interruptedAt).toBeTruthy();
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("boot resumes agents left with a running status by an unclean shutdown", async () => {
+    const cwd = tmpCwd();
+    const marker = `BOOT_RESUME_CRASH_MARKER_${Date.now()}`;
+    paseoHomeRoot = await mkdtemp(path.join(tmpdir(), "paseo-home-boot-resume-crash-"));
+    try {
+      ctx = await createDaemonTestContext({ paseoHomeRoot, cleanup: false });
+      const paseoHome = ctx.daemon.paseoHome;
+
+      const agent = await ctx.client.createAgent({
+        provider: "codex",
+        cwd,
+        title: "Boot Resume Crash Test Agent",
+        modeId: "read-only",
+      });
+      await ctx.client.sendMessage(
+        agent.id,
+        `Remember this marker string for a test: "${marker}".`,
+      );
+      const afterRemember = await ctx.client.waitForFinish(agent.id, 5_000);
+      expect(afterRemember.status).toBe("idle");
+      expect(afterRemember.final?.persistence).toBeTruthy();
+
+      await ctx.cleanup();
+      ctx = null;
+
+      // Simulate a crash: an unclean exit never runs the graceful close pass,
+      // so the record keeps its live status and gets no interruptedAt marker.
+      const stored = findStoredRecord(paseoHome, agent.id);
+      writeFileSync(
+        stored.filePath,
+        JSON.stringify({ ...stored.record, lastStatus: "running", interruptedAt: null }),
+      );
+
+      ctx = await createDaemonTestContext({
+        paseoHomeRoot,
+        cleanup: false,
+        resumeAgentsOnBoot: true,
+      });
+
+      expect(ctx.daemon.daemon.agentManager.getAgent(agent.id)).toBeTruthy();
+
+      await ctx.client.sendMessage(
+        agent.id,
+        "What was the marker string I asked you to remember earlier?",
+      );
+      const afterRecall = await ctx.client.waitForFinish(agent.id, 5_000);
+      expect(afterRecall.status).toBe("idle");
+      expect(afterRecall.final!.persistence!.metadata).toMatchObject({ marker });
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -155,6 +155,12 @@ const FeatureWebUiSchema = z
   })
   .strict();
 
+const FeatureResumeAgentsOnBootSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+  })
+  .strict();
+
 const StructuredGenerationProviderConfigSchema = z
   .object({
     provider: z.string().min(1),
@@ -307,6 +313,7 @@ export const PersistedConfigSchema = z
         dictation: FeatureDictationSchema.optional(),
         voiceMode: FeatureVoiceModeSchema.optional(),
         webUi: FeatureWebUiSchema.optional(),
+        resumeAgentsOnBoot: FeatureResumeAgentsOnBootSchema.optional(),
       })
       .strict()
       .optional(),

--- a/packages/server/src/server/test-utils/paseo-daemon.ts
+++ b/packages/server/src/server/test-utils/paseo-daemon.ts
@@ -39,6 +39,7 @@ interface TestPaseoDaemonOptions {
   serviceProxy?: PaseoDaemonConfig["serviceProxy"];
   webUi?: PaseoDaemonConfig["webUi"];
   trustedProxies?: PaseoDaemonConfig["trustedProxies"];
+  resumeAgentsOnBoot?: boolean;
 }
 
 export interface TestPaseoDaemon {
@@ -179,6 +180,7 @@ async function prepareTestDaemonConfig(
     voiceLlmModel: options.voiceLlmModel ?? null,
     dictationFinalTimeoutMs: options.dictationFinalTimeoutMs,
     downloadTokenTtlMs: options.downloadTokenTtlMs,
+    resumeAgentsOnBoot: options.resumeAgentsOnBoot,
   };
   return { config, paseoHomeRoot, paseoHome, staticDir };
 }


### PR DESCRIPTION
## Summary

Daemon restarts (container image rolls, upgrades, crashes) kill every agent subprocess, and nothing resumes automatically: agent records persist with a provider `sessionId`, but `resumeAgentFromPersistence()` only runs via the manual resume RPC or lazy `ensureAgentLoaded()` when a client touches the agent. This PR adds an **opt-in** boot pass that resumes agents interrupted by the previous shutdown.

- **Shutdown marker:** `closeAllAgents()` stamps `interruptedAt` on records of agents that were `running`/`initializing` at stop — the graceful close otherwise overwrites `lastStatus` to `"closed"`, erasing that information. Crash shutdowns need no marker: they leave `lastStatus: "running"` behind, which is the crash signal.
- **Boot resume pass** (`agent-boot-resume.ts`): when enabled, runs during bootstrap before the HTTP listener (same shape as `ScheduleService.recoverInterruptedRuns()`). Reuses `ensureAgentLoaded()` — provider validation, session re-attach, timeline hydration, and in-flight dedup all come for free. Per-agent failures log, clear the marker, and never block boot.
- **Opt-in:** `features.resumeAgentsOnBoot.enabled` in `config.json` or `PASEO_RESUME_AGENTS_ON_BOOT=true`. Default **off** — zero behavior change for existing daemons.
- **Self-cleaning marker:** the storage projection never emits `interruptedAt`, so the first snapshot after a successful resume clears it; the failure path clears it explicitly to prevent boot-loop retries.
- **No protocol or app changes.** Resumed agents reach clients through the existing agent-list/status paths. Storage schema change is additive-optional (no migration).

Mid-turn state is not recoverable by design — a resumed agent comes back idle with its full conversation history; the interrupted turn itself is lost.

## Motivation

Running the daemon as a long-lived container (e.g. on a k8s cluster) makes restarts routine — an unattended nightly image roll shouldn't strand every open agent behind a manual per-agent resume tap.

## Test plan

- New `daemon-e2e/daemon-boot-resume.e2e.test.ts` (3 tests, passing):
  1. Graceful shutdown mid-run → `interruptedAt` stamped → boot with flag on → agent auto-resumed (no RPC) and recalls prior-conversation marker; marker self-clears after resume.
  2. Flag off → agent not loaded at boot, marker untouched.
  3. Crash simulation (`lastStatus: "running"`, no marker) → auto-resumed with memory intact.
- Existing `daemon-restart-resume.e2e.test.ts` (manual resume path) still green.
- Full `npm run typecheck` across all workspace packages green; lint/format hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oTWPNJXMd1dq8YPmZcn9y