### PR TITLE
Fix Claude quota panel erroring when a usage window has no reset time

### DIFF
--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -37,7 +37,7 @@ const ClaudeCredentialsSchema = z.object({
 
 const ClaudeUsageWindowSchema = z.object({
   utilization: ApiNumberSchema,
-  resets_at: z.string().optional(),
+  resets_at: z.string().nullish(),
 });
 
 const ClaudeUsageResponseSchema = z.object({

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -434,6 +434,33 @@ describe("real provider usage fetchers", () => {
     );
   });
 
+  it("accepts a null Claude resets_at when a window has no scheduled reset", async () => {
+    writeClaudeCredentials(claudeHome, "at_valid");
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api.anthropic.com/api/oauth/usage",
+          () =>
+            jsonResponse({
+              five_hour: { utilization: 0, resets_at: null },
+              seven_day: { utilization: 1, resets_at: "2026-06-04T00:00:00Z" },
+            }),
+        ],
+      ]),
+    );
+
+    const result = await service().listUsage();
+    const claude = findProvider(result, "claude");
+
+    expect(claude).toMatchObject({
+      status: "available",
+      windows: expect.arrayContaining([
+        expect.objectContaining({ id: "five_hour", usedPct: 0, resetsAt: null }),
+        expect.objectContaining({ id: "weekly", usedPct: 1 }),
+      ]),
+    });
+  });
+
   it("returns unavailable Claude usage when credentials are missing", async () => {
     fetchApi = vi.fn() as never;
 


### PR DESCRIPTION
## What changed

The Claude entry in the provider quota panel could show an error instead of usage data. The Anthropic usage API returns `"resets_at": null` for a window with no scheduled reset (e.g. no active 5-hour session), and our response schema only accepted a string or an absent field, so the whole fetch failed validation. The consuming code already handled a null reset time — only the schema was stricter than the API. The schema now accepts null.

The error was transient and self-healing (it disappears once a session is active again), which is why it only surfaced as a DEBUG-level `Provider usage fetch failed` log.

## How to verify beyond CI

Reproduced against the live API and frozen in a regression test (`service.test.ts` — "accepts a null Claude resets_at when a window has no scheduled reset") that failed before the one-line schema change and passes after. CI covers the surface; no extra verification needed before merge.

## Risk surface

One-word schema widening (`optional` → `nullish`) in the server-side quota fetcher; no protocol or client changes. Downstream code already normalized the value with `?? null`.