### PR TITLE
fix(app): show New workspace action on non-git sidebar projects

### DIFF
--- a/packages/app/e2e/new-workspace-entry.spec.ts
+++ b/packages/app/e2e/new-workspace-entry.spec.ts
@@ -13,12 +13,12 @@ import { getServerId } from "./helpers/server-id";
 import { clickArchiveWorkspaceMenuItem, expectWorkspaceAbsentFromSidebar } from "./helpers/sidebar";
 import { waitForSidebarHydration } from "./helpers/workspace-ui";
 
-// Model B entry points into the New Workspace screen. The per-project
-// "+ New workspace" sidebar row is gone; the surviving entries are the global
-// button (universal) and each git project's own new-worktree icon (preselects
-// that project). These specs prove the global entry opens the screen, the
-// project icon preselects the right project across the reused 'new' screen, and
-// non-git projects never offer the worktree Isolation control.
+// Model B entry points into the New Workspace screen. The surviving entries are
+// the global button (universal) and each project's per-row New workspace icon
+// (preselects that project) — shown for git projects and for non-git projects on
+// a multiplicity-capable host. These specs prove the global entry opens the
+// screen, the project icon preselects the right project across the reused 'new'
+// screen, and non-git projects never offer the worktree Isolation control.
 
 function projectRow(page: import("@playwright/test").Page, projectKey: string) {
   return page.getByTestId(`sidebar-project-row-${projectKey}`);
@@ -215,7 +215,7 @@ test.describe("New workspace entry points", () => {
       await expect(projectRow(page, nonGitProject.projectId)).toBeVisible({ timeout: 30_000 });
 
       // Open New Workspace for the non-git project via the global button, then
-      // select it in the picker (its row has no new-worktree icon).
+      // select it in the picker (the per-row icon would preselect it too).
       await openGlobalNewWorkspaceComposer(page);
       const trigger = page.getByTestId("new-workspace-project-picker-trigger");
       await expect(trigger).toBeVisible({ timeout: 30_000 });

--- a/packages/app/e2e/sidebar-model-b.spec.ts
+++ b/packages/app/e2e/sidebar-model-b.spec.ts
@@ -38,7 +38,7 @@ async function seedSecondWorkspace(seeded: SeededWorkspace, title: string): Prom
 test.describe("Model B sidebar shape", () => {
   test.describe.configure({ timeout: 180_000 });
 
-  test("git and non-git projects both render as expandable parents; git keeps a per-row new-worktree icon, the global button covers both", async ({
+  test("git and non-git projects both render as expandable parents, both show a per-row New workspace icon, and the global button covers both", async ({
     page,
   }) => {
     const gitProject = await seedWorkspace({ repoPrefix: "model-b-git-" });
@@ -62,14 +62,17 @@ test.describe("Model B sidebar shape", () => {
       await expect(workspaceRow(page, nonGitProject.workspaceId)).toBeVisible({ timeout: 30_000 });
       await expect(workspaceRow(page, nonGitSecondId)).toBeVisible({ timeout: 30_000 });
 
-      // The per-project "+ New workspace" row is gone. The git project keeps a
-      // per-row new-worktree icon (revealed on hover); the non-git project has
-      // none, since worktree creation needs a git checkout.
+      // Both projects show a per-row New workspace icon (revealed on hover): the
+      // git project can branch off a worktree, and the non-git project can add
+      // another workspace because the host supports workspaceMultiplicity.
       await projectRow(page, gitProject.projectId).hover();
       await expect(projectNewWorktreeIcon(page, gitProject.projectId)).toBeVisible({
         timeout: 30_000,
       });
-      await expect(projectNewWorktreeIcon(page, nonGitProject.projectId)).toHaveCount(0);
+      await projectRow(page, nonGitProject.projectId).hover();
+      await expect(projectNewWorktreeIcon(page, nonGitProject.projectId)).toBeVisible({
+        timeout: 30_000,
+      });
 
       // The global new-workspace button is the universal entry — present for both
       // kinds regardless of their per-row affordance.

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -56,6 +56,7 @@ import { NestableScrollContainer } from "react-native-draggable-flatlist";
 import { DraggableList, type DraggableRenderItemInfo } from "./draggable-list";
 import type { DraggableListDragHandleProps } from "./draggable-list.types";
 import { getHostRuntimeStore, useHosts } from "@/runtime/host-runtime";
+import { useHostFeatureMap } from "@/runtime/host-features";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useProjectIconDataByProjectKey } from "@/projects/project-icons";
 import {
@@ -1881,6 +1882,7 @@ function ProjectBlock({
   activeWorkspaceSelection,
   hostLabelByServerId,
   showHostLabels,
+  supportsMultiplicityByServerId,
 }: {
   project: SidebarProjectEntry;
   collapsed: boolean;
@@ -1902,14 +1904,16 @@ function ProjectBlock({
   activeWorkspaceSelection: ActiveWorkspaceSelection | null;
   hostLabelByServerId: ReadonlyMap<string, string>;
   showHostLabels: boolean;
+  supportsMultiplicityByServerId: ReadonlyMap<string, boolean>;
 }) {
   const rowModel = useMemo(
     () =>
       buildSidebarProjectRowModel({
         project,
         collapsed,
+        supportsMultiplicityByServerId,
       }),
-    [collapsed, project],
+    [collapsed, project, supportsMultiplicityByServerId],
   );
 
   const active = isProjectSelectedByRoute({
@@ -2062,7 +2066,7 @@ function ProjectBlock({
           containerStyle={styles.workspaceListContainer}
         />
       );
-    } else if (rowModel.trailingAction.kind === "new_worktree") {
+    } else if (rowModel.trailingAction.kind === "new_workspace") {
       projectChildren = (
         <NewWorkspaceGhostRow
           project={project}
@@ -2085,7 +2089,7 @@ function ProjectBlock({
         chevron={rowModel.chevron}
         onPress={handleToggleCollapsed}
         worktreeTarget={
-          rowModel.trailingAction.kind === "new_worktree" ? rowModel.trailingAction.target : null
+          rowModel.trailingAction.kind === "new_workspace" ? rowModel.trailingAction.target : null
         }
         isProjectActive={active}
         onWorkspacePress={onWorkspacePress}
@@ -2106,6 +2110,7 @@ function ProjectBlock({
 
 type ProjectBlockProps = Parameters<typeof ProjectBlock>[0];
 
+// oxlint-disable-next-line complexity
 function areProjectBlockPropsEqual(previous: ProjectBlockProps, next: ProjectBlockProps): boolean {
   return (
     previous.project === next.project &&
@@ -2117,6 +2122,7 @@ function areProjectBlockPropsEqual(previous: ProjectBlockProps, next: ProjectBlo
     previous.shortcutIndexByWorkspaceKey === next.shortcutIndexByWorkspaceKey &&
     previous.hostLabelByServerId === next.hostLabelByServerId &&
     previous.showHostLabels === next.showHostLabels &&
+    previous.supportsMultiplicityByServerId === next.supportsMultiplicityByServerId &&
     previous.parentGestureRef === next.parentGestureRef &&
     previous.onToggleCollapsed === next.onToggleCollapsed &&
     previous.onWorkspacePress === next.onWorkspacePress &&
@@ -2183,6 +2189,8 @@ export function SidebarWorkspaceList({
     }
     return labels;
   }, [hosts]);
+  const serverIds = useMemo(() => hosts.map((host) => host.serverId), [hosts]);
+  const supportsMultiplicityByServerId = useHostFeatureMap(serverIds, "workspaceMultiplicity");
   const showHostLabels = useMemo(() => shouldShowSidebarHostLabels(projects), [projects]);
 
   const content =
@@ -2208,6 +2216,7 @@ export function SidebarWorkspaceList({
         pathname={pathname}
         hostLabelByServerId={hostLabelByServerId}
         showHostLabels={showHostLabels}
+        supportsMultiplicityByServerId={supportsMultiplicityByServerId}
       />
     );
 
@@ -2256,6 +2265,7 @@ function ProjectModeList({
   pathname,
   hostLabelByServerId,
   showHostLabels,
+  supportsMultiplicityByServerId,
 }: Omit<
   SidebarWorkspaceListProps,
   "statusWorkspacePlacements" | "projectNamesByKey" | "groupMode" | "isRefreshing" | "onRefresh"
@@ -2263,6 +2273,7 @@ function ProjectModeList({
   pathname: string;
   hostLabelByServerId: ReadonlyMap<string, string>;
   showHostLabels: boolean;
+  supportsMultiplicityByServerId: ReadonlyMap<string, boolean>;
 }) {
   const { t } = useTranslation();
   const [creatingWorkspaceIds, setCreatingWorkspaceIds] = useState<Set<string>>(() => new Set());
@@ -2451,6 +2462,7 @@ function ProjectModeList({
           activeWorkspaceSelection={activeWorkspaceSelection}
           hostLabelByServerId={hostLabelByServerId}
           showHostLabels={showHostLabels}
+          supportsMultiplicityByServerId={supportsMultiplicityByServerId}
         />
       );
     },
@@ -2461,6 +2473,7 @@ function ProjectModeList({
       handleWorkspaceReorder,
       hostLabelByServerId,
       showHostLabels,
+      supportsMultiplicityByServerId,
       onWorkspacePress,
       onToggleProjectCollapsed,
       parentGestureRef,

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -66,7 +66,7 @@ describe("buildSidebarProjectRowModel", () => {
     });
   });
 
-  it("renders a single-workspace git project as an expandable section with the new worktree action", () => {
+  it("renders a single-workspace git project as an expandable section with the new workspace action", () => {
     const result = buildSidebarProjectRowModel({
       project: project({
         projectKind: "git",
@@ -79,13 +79,49 @@ describe("buildSidebarProjectRowModel", () => {
       kind: "project_section",
       chevron: "expand",
       trailingAction: {
-        kind: "new_worktree",
+        kind: "new_workspace",
         target: { serverId: "srv", iconWorkingDir: "/repo" },
       },
     });
   });
 
-  it("targets the project host, not route state, for new worktree actions", () => {
+  it("shows the new workspace action for a non-git project when the host supports workspace multiplicity", () => {
+    const result = buildSidebarProjectRowModel({
+      project: project({ projectKind: "directory", workspaces: [] }),
+      collapsed: false,
+      supportsMultiplicityByServerId: new Map([["srv", true]]),
+    });
+
+    expect(result.trailingAction).toEqual({
+      kind: "new_workspace",
+      target: { serverId: "srv", iconWorkingDir: "/repo" },
+    });
+  });
+
+  it("hides the new workspace action for a non-git project when the host lacks workspace multiplicity", () => {
+    const result = buildSidebarProjectRowModel({
+      project: project({ projectKind: "directory", workspaces: [] }),
+      collapsed: false,
+      supportsMultiplicityByServerId: new Map([["srv", false]]),
+    });
+
+    expect(result.trailingAction).toEqual({ kind: "none" });
+  });
+
+  it("still shows the new workspace action for a git project regardless of multiplicity", () => {
+    const result = buildSidebarProjectRowModel({
+      project: project({ projectKind: "git" }),
+      collapsed: false,
+      supportsMultiplicityByServerId: new Map([["srv", false]]),
+    });
+
+    expect(result.trailingAction).toEqual({
+      kind: "new_workspace",
+      target: { serverId: "srv", iconWorkingDir: "/repo" },
+    });
+  });
+
+  it("targets the project host, not route state, for new workspace actions", () => {
     const result = buildSidebarProjectRowModel({
       project: project({
         hosts: [
@@ -98,13 +134,34 @@ describe("buildSidebarProjectRowModel", () => {
 
     expect(result).toMatchObject({
       trailingAction: {
-        kind: "new_worktree",
+        kind: "new_workspace",
         target: { serverId: "host-b", iconWorkingDir: "/repo/b" },
       },
     });
   });
 
-  it("renders a multi-workspace git project as an expandable section with a new worktree action", () => {
+  it("targets the first multiplicity-capable host for a non-git project", () => {
+    const result = buildSidebarProjectRowModel({
+      project: project({
+        projectKind: "directory",
+        hosts: [
+          { serverId: "host-a", iconWorkingDir: "/repo/a", canCreateWorktree: false },
+          { serverId: "host-b", iconWorkingDir: "/repo/b", canCreateWorktree: false },
+        ],
+      }),
+      collapsed: false,
+      supportsMultiplicityByServerId: new Map([["host-b", true]]),
+    });
+
+    expect(result).toMatchObject({
+      trailingAction: {
+        kind: "new_workspace",
+        target: { serverId: "host-b", iconWorkingDir: "/repo/b" },
+      },
+    });
+  });
+
+  it("renders a multi-workspace git project as an expandable section with a new workspace action", () => {
     const result = buildSidebarProjectRowModel({
       project: project({
         projectKind: "git",
@@ -120,7 +177,7 @@ describe("buildSidebarProjectRowModel", () => {
       kind: "project_section",
       chevron: "expand",
       trailingAction: {
-        kind: "new_worktree",
+        kind: "new_workspace",
         target: { serverId: "srv", iconWorkingDir: "/repo" },
       },
     });
@@ -149,7 +206,7 @@ describe("buildSidebarProjectRowModel", () => {
       kind: "project_section",
       chevron: "collapse",
       trailingAction: {
-        kind: "new_worktree",
+        kind: "new_workspace",
         target: { serverId: "srv", iconWorkingDir: "/repo" },
       },
     });

--- a/packages/app/src/utils/sidebar-project-row-model.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.ts
@@ -6,7 +6,7 @@ export interface SidebarProjectHostTarget {
 }
 
 export type SidebarProjectTrailingAction =
-  | { kind: "new_worktree"; target: SidebarProjectHostTarget }
+  | { kind: "new_workspace"; target: SidebarProjectHostTarget }
   | { kind: "none" };
 
 export interface SidebarProjectSectionRowModel {
@@ -16,6 +16,8 @@ export interface SidebarProjectSectionRowModel {
 }
 
 export type SidebarProjectRowModel = SidebarProjectSectionRowModel;
+
+const EMPTY_MULTIPLICITY_MAP: ReadonlyMap<string, boolean> = new Map();
 
 function hostTarget(input: {
   serverId: string;
@@ -40,9 +42,18 @@ export function resolveSidebarProjectIconTarget(
   return null;
 }
 
-function resolveNewWorktreeTarget(project: SidebarProjectEntry): SidebarProjectHostTarget | null {
+// A project can host a brand-new workspace on a host when that host can create a
+// git worktree (git projects) OR the host supports running multiple independent
+// workspaces per directory (`workspaceMultiplicity`), which is what lets non-git
+// directories add a second workspace. Mirrors the gate used by the global "New
+// workspace" affordances (use-global-new-workspace-action.ts and left-sidebar's
+// SidebarNewWorkspaceHeaderRow): `canCreateWorktree || supportsMultiplicity`.
+function resolveNewWorkspaceTarget(
+  project: SidebarProjectEntry,
+  supportsMultiplicityByServerId: ReadonlyMap<string, boolean>,
+): SidebarProjectHostTarget | null {
   for (const host of project.hosts) {
-    if (!host.canCreateWorktree) {
+    if (!host.canCreateWorktree && !supportsMultiplicityByServerId.get(host.serverId)) {
       continue;
     }
     const target = hostTarget(host);
@@ -53,18 +64,25 @@ function resolveNewWorktreeTarget(project: SidebarProjectEntry): SidebarProjectH
   return null;
 }
 
-function projectTrailingAction(project: SidebarProjectEntry): SidebarProjectTrailingAction {
-  const target = resolveNewWorktreeTarget(project);
-  return target ? { kind: "new_worktree", target } : { kind: "none" };
+function projectTrailingAction(
+  project: SidebarProjectEntry,
+  supportsMultiplicityByServerId: ReadonlyMap<string, boolean>,
+): SidebarProjectTrailingAction {
+  const target = resolveNewWorkspaceTarget(project, supportsMultiplicityByServerId);
+  return target ? { kind: "new_workspace", target } : { kind: "none" };
 }
 
 export function buildSidebarProjectRowModel(input: {
   project: SidebarProjectEntry;
   collapsed: boolean;
+  supportsMultiplicityByServerId?: ReadonlyMap<string, boolean>;
 }): SidebarProjectRowModel {
   return {
     kind: "project_section",
     chevron: input.collapsed ? "expand" : "collapse",
-    trailingAction: projectTrailingAction(input.project),
+    trailingAction: projectTrailingAction(
+      input.project,
+      input.supportsMultiplicityByServerId ?? EMPTY_MULTIPLICITY_MAP,
+    ),
   };
 }


### PR DESCRIPTION
### Linked issue

Closes #1856

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The per-project **New workspace** affordance in the sidebar — the project-header
`+` button and the empty-project "New workspace" ghost row — was gated on
`host.canCreateWorktree`, which is `projectKind === "git"`. So a non-git project
(`non_git` / `directory`) showed no way to add a workspace from its row, even
though a host with the `workspaceMultiplicity` capability can create additional
local workspaces for it (the New Workspace screen already handles this and
defaults such projects to Local isolation).

This threads the per-host `workspaceMultiplicity` flag into the sidebar project
row model and shows the affordance when
`canCreateWorktree || supportsWorkspaceMultiplicity` — the same gate already used
by the global "New workspace" button (`SidebarNewWorkspaceHeaderRow`) and the
Cmd+N handler (`useGlobalNewWorkspaceAction`). The internal trailing-action kind
is renamed `new_worktree` → `new_workspace` (a client-only render model, not a
wire/persisted type) since it now also covers non-git workspaces.

Files: `sidebar-project-row-model.ts` (gate + rename), `sidebar-workspace-list.tsx`
(compute `useHostFeatureMap(..., "workspaceMultiplicity")` and thread it to the
row model), plus unit tests.

**Note on the lint suppression.** `areProjectBlockPropsEqual` (the `React.memo`
comparator for project rows) is a flat list of reference-equality checks. Adding
the one `supportsMultiplicityByServerId` comparison tips oxlint's `complexity`
rule (max 20) to 21, so the function carries a `// oxlint-disable-next-line
complexity` — 
matching existing precedent in the codebase (`composer/index.tsx`,
`browser-pane.electron.tsx`). I kept the explicit `previous.x === next.x &&`
chain rather than the two alternatives that would pass the rule: (a) rewriting it
as a `KEYS.every(k => previous[k] === next[k])` loop, or (b) splitting it into two
helper functions. Both hide a trivial, exhaustive prop comparison behind
indirection; the disable keeps the comparator flat and obvious (you can see at a
glance every prop it compares), which matters for a memo boundary where a missed
field is a stale-render bug.

### How did you verify it

- `npm run typecheck` — passes (full workspace)
- `npm run lint` — passes (0 warnings/errors)
- `npm run format` — clean (Biome)
- `npx vitest run packages/app/src/utils/sidebar-project-row-model.test.ts` —
  10/10 pass, including new cases: non-git + multiplicity → shows the action;
  non-git without multiplicity → none; git ignores multiplicity; multi-host picks
  the first eligible host.

Manual (on this branch):

- Added a plain non-git directory as a project. The project-header `+` (and the
  "New workspace" row on an empty non-git project) now appear, and `+` opens the
  New Workspace screen seeded to that project with isolation defaulting to Local.
- A git project's row is unchanged.

Before:

<img width="331" height="61" alt="image" src="https://github.com/user-attachments/assets/c06e6250-83d1-4910-8365-a334313dcd48" />

After:

<img width="314" height="81" alt="image" src="https://github.com/user-attachments/assets/ff7e9965-994b-48a8-acb9-9e70e16ce0ff" />


### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
