### PR TITLE
fix: show virtual keys in terminal on tablets/foldables

### DIFF
--- a/packages/app/src/components/terminal-pane.tsx
+++ b/packages/app/src/components/terminal-pane.tsx
@@ -13,6 +13,7 @@ import type { TerminalInputModeState } from "@getpaseo/protocol/terminal-input-m
 import { useTranslation } from "react-i18next";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { useKeyboardShiftStyle } from "@/hooks/use-keyboard-shift-style";
+import { useSoftKeyboardVisible } from "@/hooks/use-soft-keyboard-visible";
 import { useAppVisible } from "@/hooks/use-app-visible";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import {
@@ -180,12 +181,12 @@ export function TerminalPane({
     return trimmed.length > 0 ? trimmed : undefined;
   }, [settings.monoFontFamily]);
   const isMobile = useIsCompactFormFactor();
+  const softKeyboardVisible = useSoftKeyboardVisible();
   const mobileView = usePanelStore((state) => state.mobileView);
   const showMobileAgentList = usePanelStore((state) => state.showMobileAgentList);
   const swipeGesturesEnabled = isMobile && mobileView === "agent";
   const { shift: keyboardShift, style: keyboardPaddingStyle } = useKeyboardShiftStyle({
     mode: "padding",
-    enabled: isMobile,
   });
 
   const client = useHostRuntimeClient(serverId);
@@ -337,14 +338,14 @@ export function TerminalPane({
   }, [clearKeyboardRefitTimeouts]);
 
   useAnimatedReaction(
-    () => isMobile && keyboardShift.value > 0,
+    () => keyboardShift.value > 0,
     (next, prev) => {
       if (next === prev) {
         return;
       }
       runOnJS(pulseKeyboardRefits)();
     },
-    [isMobile, pulseKeyboardRefits],
+    [pulseKeyboardRefits],
   );
 
   useEffect(() => {
@@ -819,7 +820,7 @@ export function TerminalPane({
         </View>
       ) : null}
 
-      {isMobile ? (
+      {softKeyboardVisible ? (
         <View style={styles.keyboardContainer} testID="terminal-virtual-keyboard">
           <View style={styles.keyboardRows}>
             <View style={styles.keyboardRow}>

--- a/packages/app/src/hooks/use-soft-keyboard-visible.d.ts
+++ b/packages/app/src/hooks/use-soft-keyboard-visible.d.ts
@@ -1,0 +1,1 @@
+export * from "./use-soft-keyboard-visible.native";

--- a/packages/app/src/hooks/use-soft-keyboard-visible.native.ts
+++ b/packages/app/src/hooks/use-soft-keyboard-visible.native.ts
@@ -1,0 +1,5 @@
+import { useKeyboardState } from "react-native-keyboard-controller";
+
+export function useSoftKeyboardVisible(): boolean {
+  return useKeyboardState((state) => state.isVisible);
+}

--- a/packages/app/src/hooks/use-soft-keyboard-visible.test.ts
+++ b/packages/app/src/hooks/use-soft-keyboard-visible.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSoftKeyboardVisible } from "@/hooks/use-soft-keyboard-visible";
+
+function installPointerMediaQuery(initialCoarse: boolean) {
+  let coarse = initialCoarse;
+  const listeners = new Set<() => void>();
+  const query = {
+    get matches() {
+      return coarse;
+    },
+    media: "(pointer: coarse)",
+    addEventListener: (_type: "change", listener: () => void) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_type: "change", listener: () => void) => {
+      listeners.delete(listener);
+    },
+  };
+  vi.stubGlobal("matchMedia", () => query);
+  return {
+    setCoarse(next: boolean) {
+      coarse = next;
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useSoftKeyboardVisible (web)", () => {
+  it("is true on a coarse-pointer (touch) device", () => {
+    installPointerMediaQuery(true);
+    const { result } = renderHook(() => useSoftKeyboardVisible());
+    expect(result.current).toBe(true);
+  });
+
+  it("is false on a fine-pointer (mouse/trackpad) device", () => {
+    installPointerMediaQuery(false);
+    const { result } = renderHook(() => useSoftKeyboardVisible());
+    expect(result.current).toBe(false);
+  });
+
+  it("reacts when the primary pointer changes to coarse", () => {
+    const pointer = installPointerMediaQuery(false);
+    const { result } = renderHook(() => useSoftKeyboardVisible());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      pointer.setCoarse(true);
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/packages/app/src/hooks/use-soft-keyboard-visible.web.ts
+++ b/packages/app/src/hooks/use-soft-keyboard-visible.web.ts
@@ -1,0 +1,36 @@
+import { useSyncExternalStore } from "react";
+
+// Browsers have no reliable soft-keyboard-visibility signal (the visual-viewport
+// heuristic breaks across mobile viewport configs), so approximate with the device
+// capability: a coarse primary pointer means touch, i.e. a soft keyboard is in use.
+const COARSE_POINTER_QUERY = "(pointer: coarse)";
+
+function getPointerQuery(): MediaQueryList | null {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return null;
+  }
+  return window.matchMedia(COARSE_POINTER_QUERY);
+}
+
+function subscribe(onChange: () => void): () => void {
+  const query = getPointerQuery();
+  if (!query) {
+    return () => {};
+  }
+  query.addEventListener("change", onChange);
+  return () => {
+    query.removeEventListener("change", onChange);
+  };
+}
+
+function getSnapshot(): boolean {
+  return getPointerQuery()?.matches ?? false;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+export function useSoftKeyboardVisible(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
### Linked issue

Doesn't fully close, but address one slice of https://github.com/getpaseo/paseo/issues/1047. Fixes using the terminal on foldables and tablets, atm they cannot use arrow keys etc. 

<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Visibility of virtual keys in the terminal pane were previously gated on screen size (`isMobile`), this PR fixes it to be based on either soft keyboard presence (on native, where we can actually know that for sure), and otherwise `pointer: coarse` / touch (on web). 

This fixes devices like foldables and tablets, where there is a large resolution (doesn't fulfil `isMobile`) but there's a touchscreen with virtual keyboard, so the virtual keys didn't display.

Note: on mobile web there's actually a pre-existing bug unrelated to my change that means that the virtual keys don't shift upward when the keyboard is shown, so they are actually obscured and non-functional... I can fix that in a follow up PR if you'd like, but probably would prefer to not fold it into this PR since its a larger change. So I can't actually show those changes here...

### How did you verify it

Did a debug build of Android APK + web UI daemon, manually tested on my Galaxy Fold 7:

|Before|After|
|-|-|
|<img width="1968" height="2184" alt="Screenshot_20260702_184802_Paseo" src="https://github.com/user-attachments/assets/46332999-6f2e-465e-8891-9c83f58c45e8" />|<img width="1968" height="2184" alt="Screenshot_20260702_165914_Paseo Debug" src="https://github.com/user-attachments/assets/edae63b3-f596-4fdd-a799-48a8829095ba" />|
|-|And screenshot of folded state / regular phone resolution to show that it doesn't break the usual case:<img width="300" alt="Screenshot_20260702_165909_Paseo Debug" src="https://github.com/user-attachments/assets/93ae9b6c-e649-443a-a433-8e1eeb14a89c" />|



I unfortunately don't have an iOS device (I guess an iPad?) to test these changes there, but the .native.ts is so simple that if something is wrong it would probably be in `react-native-keyboard-controller` itself.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
