### PR TITLE
feat: surface native OpenCode subsessions

### DIFF
--- a/packages/app/src/components/agent-list-subsession-rows.test.ts
+++ b/packages/app/src/components/agent-list-subsession-rows.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { AgentSubsessionPayload } from "@getpaseo/protocol/messages";
+import { buildSubsessionRows } from "./agent-list-subsession-rows";
+
+function sub(
+  id: string,
+  parentSessionId: string | null,
+  status: AgentSubsessionPayload["status"] = "idle",
+): AgentSubsessionPayload {
+  return { id, title: id, status, parentSessionId };
+}
+
+describe("buildSubsessionRows", () => {
+  it("returns an empty list for missing or empty subsessions", () => {
+    expect(buildSubsessionRows(undefined)).toEqual([]);
+    expect(buildSubsessionRows([])).toEqual([]);
+  });
+
+  it("renders direct children of the agent's root session at depth 1", () => {
+    const rows = buildSubsessionRows([sub("a", "ses_root"), sub("b", "ses_root")]);
+    expect(rows.map((r) => [r.sub.id, r.depth])).toEqual([
+      ["a", 1],
+      ["b", 1],
+    ]);
+  });
+
+  it("nests subsessions under their parent subsession with increasing depth", () => {
+    const rows = buildSubsessionRows([
+      sub("child", "ses_root"),
+      sub("grandchild", "child"),
+      sub("sibling", "ses_root"),
+    ]);
+    expect(rows.map((r) => [r.sub.id, r.depth])).toEqual([
+      ["child", 1],
+      ["grandchild", 2],
+      ["sibling", 1],
+    ]);
+  });
+
+  it("renders every subsession exactly once even when parents form a cycle", () => {
+    const rows = buildSubsessionRows([sub("a", "b"), sub("b", "a")]);
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.sub.id)).size).toBe(2);
+  });
+});

--- a/packages/app/src/components/agent-list-subsession-rows.ts
+++ b/packages/app/src/components/agent-list-subsession-rows.ts
@@ -1,0 +1,52 @@
+import type { AgentSubsessionPayload } from "@getpaseo/protocol/messages";
+
+export interface SubsessionRowModel {
+  sub: AgentSubsessionPayload;
+  depth: number;
+}
+
+/**
+ * Order an agent's subsessions as a depth-first tree. Roots are subsessions
+ * whose parent is not another subsession (i.e. they hang off the agent's own
+ * root session). Cycle-safe via an emitted guard; nodes unreachable from any
+ * root still render at depth 1 so nothing is silently dropped.
+ */
+export function buildSubsessionRows(
+  subsessions: readonly AgentSubsessionPayload[] | undefined,
+): SubsessionRowModel[] {
+  if (!subsessions || subsessions.length === 0) {
+    return [];
+  }
+  const byId = new Map(subsessions.map((sub) => [sub.id, sub]));
+  const childrenByParent = new Map<string, AgentSubsessionPayload[]>();
+  const roots: AgentSubsessionPayload[] = [];
+  for (const sub of subsessions) {
+    const parentId = sub.parentSessionId ?? null;
+    if (parentId !== null && byId.has(parentId)) {
+      const siblings = childrenByParent.get(parentId) ?? [];
+      siblings.push(sub);
+      childrenByParent.set(parentId, siblings);
+    } else {
+      roots.push(sub);
+    }
+  }
+
+  const rows: SubsessionRowModel[] = [];
+  const emitted = new Set<string>();
+  const emit = (sub: AgentSubsessionPayload, depth: number): void => {
+    if (emitted.has(sub.id)) return;
+    emitted.add(sub.id);
+    rows.push({ sub, depth });
+    for (const child of childrenByParent.get(sub.id) ?? []) {
+      emit(child, depth + 1);
+    }
+  };
+  for (const root of roots) {
+    emit(root, 1);
+  }
+  // Safety net: cycle members unreachable from any root still render.
+  for (const sub of subsessions) {
+    emit(sub, 1);
+  }
+  return rows;
+}

--- a/packages/app/src/components/agent-list-subsessions.tsx
+++ b/packages/app/src/components/agent-list-subsessions.tsx
@@ -1,0 +1,136 @@
+import { memo, useCallback, useMemo } from "react";
+import { Pressable, Text, View } from "react-native";
+import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { ChevronDown, ChevronRight } from "lucide-react-native";
+import { useTranslation } from "react-i18next";
+import type { AgentSubsessionPayload } from "@getpaseo/protocol/messages";
+import { AgentStatusDot } from "@/components/agent-status-dot";
+import type { AggregatedAgent } from "@/hooks/use-aggregated-agents";
+
+const DISCLOSURE_HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 };
+
+export const SubsessionDisclosure = memo(function SubsessionDisclosure({
+  count,
+  expanded,
+  onToggle,
+  testID,
+}: {
+  count: number;
+  expanded: boolean;
+  onToggle: () => void;
+  testID: string;
+}) {
+  const { theme } = useUnistyles();
+  const { t } = useTranslation();
+  const accessibilityState = useMemo(() => ({ expanded }), [expanded]);
+  if (count <= 0) {
+    return null;
+  }
+  return (
+    <Pressable
+      onPress={onToggle}
+      hitSlop={DISCLOSURE_HIT_SLOP}
+      style={styles.disclosureButton}
+      accessibilityRole="button"
+      accessibilityLabel={t("subagents.toggle")}
+      accessibilityState={accessibilityState}
+      testID={testID}
+    >
+      {expanded ? (
+        <ChevronDown size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+      ) : (
+        <ChevronRight size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+      )}
+    </Pressable>
+  );
+});
+
+export const SubsessionRow = memo(function SubsessionRow({
+  sub,
+  depth,
+  agent,
+  onPressSubsession,
+}: {
+  sub: AgentSubsessionPayload;
+  depth: number;
+  agent: AggregatedAgent;
+  onPressSubsession: (agent: AggregatedAgent, sub: AgentSubsessionPayload) => void;
+}) {
+  const { t } = useTranslation();
+
+  const indentStyle = useMemo(() => ({ paddingLeft: depth * INDENT_PER_LEVEL }), [depth]);
+  const innerStyle = useMemo(() => [styles.rowInner, indentStyle], [indentStyle]);
+
+  const rowStyle = useCallback(
+    ({ pressed }: { pressed: boolean }) => [styles.row, pressed && styles.rowPressed],
+    [],
+  );
+
+  const handlePress = useCallback(
+    () => onPressSubsession(agent, sub),
+    [onPressSubsession, agent, sub],
+  );
+
+  const title = sub.title ?? t("subagents.fallbackTitle");
+
+  return (
+    <Pressable
+      style={rowStyle}
+      onPress={handlePress}
+      accessibilityLabel={title}
+      testID={`agent-subsession-row-${agent.serverId}-${agent.id}-${sub.id}`}
+    >
+      <View style={innerStyle}>
+        <View style={styles.statusDotSlot}>
+          <AgentStatusDot status={sub.status} requiresAttention={false} />
+        </View>
+        <Text style={styles.title} numberOfLines={1}>
+          {title}
+        </Text>
+      </View>
+    </Pressable>
+  );
+});
+
+const INDENT_PER_LEVEL = 16;
+
+const styles = StyleSheet.create((theme) => ({
+  disclosureButton: {
+    width: theme.iconSize.sm,
+    height: theme.iconSize.sm,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  row: {
+    minHeight: 28,
+    borderRadius: theme.borderRadius.lg,
+    paddingVertical: theme.spacing[1],
+    paddingHorizontal: theme.spacing[3],
+    userSelect: "none",
+  },
+  rowPressed: {
+    backgroundColor: theme.colors.surface2,
+  },
+  rowInner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    flex: 1,
+    minWidth: 0,
+  },
+  statusDotSlot: {
+    width: 8,
+    height: 8,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  title: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    opacity: 0.76,
+    flex: 1,
+    minWidth: 0,
+  },
+}));

--- a/packages/app/src/components/agent-list.tsx
+++ b/packages/app/src/components/agent-list.tsx
@@ -23,6 +23,10 @@ import { navigateToAgent } from "@/utils/navigate-to-agent";
 import { useArchiveAgent } from "@/hooks/use-archive-agent";
 import { useQueryClient } from "@tanstack/react-query";
 import { agentHistoryQueryKey } from "@/hooks/agent-history-query-key";
+import { SubsessionDisclosure, SubsessionRow } from "@/components/agent-list-subsessions";
+import { buildSubsessionRows } from "@/components/agent-list-subsession-rows";
+import type { AgentSubsessionPayload } from "@getpaseo/protocol/messages";
+import { useOpenSubsession } from "@/subagents";
 
 interface AgentListProps {
   agents: AggregatedAgent[];
@@ -48,7 +52,14 @@ const DATE_SECTION_ORDER = [
 
 type FlatListItem =
   | { type: "header"; key: string; section: DateSectionKey }
-  | { type: "agent"; key: string; agent: AggregatedAgent };
+  | { type: "agent"; key: string; agent: AggregatedAgent }
+  | {
+      type: "subsession";
+      key: string;
+      agent: AggregatedAgent;
+      sub: AgentSubsessionPayload;
+      depth: number;
+    };
 
 function deriveDateSectionKey(lastActivityAt: Date): DateSectionKey {
   const now = new Date();
@@ -157,11 +168,13 @@ function SessionRowBadges({
   agent,
   archivedIcon,
   pendingPermissionCount,
+  subsessionCount,
   showDesktopAttention,
 }: {
   agent: AggregatedAgent;
   archivedIcon: ReactElement;
   pendingPermissionCount: number;
+  subsessionCount: number;
   showDesktopAttention: boolean;
 }) {
   const { t } = useTranslation();
@@ -179,6 +192,7 @@ function SessionRowBadges({
       {showDesktopAttention ? (
         <SessionBadge label={t("agentList.badges.attention")} tone="danger" />
       ) : null}
+      {subsessionCount > 0 ? <SessionBadge label={String(subsessionCount)} /> : null}
     </>
   );
 }
@@ -211,6 +225,9 @@ function SessionRow({
   showHostColumn,
   onPress,
   onLongPress,
+  expanded = false,
+  subsessionCount = 0,
+  onToggleExpand,
 }: {
   agent: AggregatedAgent;
   isMobile: boolean;
@@ -219,6 +236,9 @@ function SessionRow({
   showHostColumn: boolean;
   onPress: (agent: AggregatedAgent) => void;
   onLongPress: (agent: AggregatedAgent) => void;
+  expanded?: boolean;
+  subsessionCount?: number;
+  onToggleExpand?: (agentKey: string) => void;
 }) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
@@ -243,6 +263,9 @@ function SessionRow({
 
   const handlePress = useCallback(() => onPress(agent), [onPress, agent]);
   const handleLongPress = useCallback(() => onLongPress(agent), [onLongPress, agent]);
+  const handleToggleExpand = useCallback(() => {
+    onToggleExpand?.(agentKey);
+  }, [onToggleExpand, agentKey]);
 
   const sessionTitleStyle = useMemo(
     () => [styles.sessionTitle, isSelected && styles.sessionTitleHighlighted],
@@ -265,6 +288,12 @@ function SessionRow({
     >
       <View style={styles.rowContent}>
         <View style={styles.rowTitleRow}>
+          <SubsessionDisclosure
+            count={subsessionCount}
+            expanded={expanded}
+            onToggle={handleToggleExpand}
+            testID={`agent-row-disclosure-${agent.serverId}-${agent.id}`}
+          />
           <WorkspaceTitlePrefix
             visible={!isMobile && Boolean(workspaceName)}
             workspaceName={workspaceName}
@@ -283,6 +312,7 @@ function SessionRow({
             archivedIcon={archivedIcon}
             pendingPermissionCount={pendingPermissionCount}
             showDesktopAttention={showDesktopAttention}
+            subsessionCount={subsessionCount}
           />
         </View>
         {isMobile ? (
@@ -372,6 +402,7 @@ export function AgentList({
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const [actionAgent, setActionAgent] = useState<AggregatedAgent | null>(null);
+  const [expandedAgents, setExpandedAgents] = useState<ReadonlySet<string>>(new Set());
   const isMobile = useIsCompactFormFactor();
   const { archiveAgent } = useArchiveAgent();
   const queryClient = useQueryClient();
@@ -382,6 +413,14 @@ export function AgentList({
 
   const isActionSheetVisible = actionAgent !== null;
   const isActionDaemonUnavailable = Boolean(actionAgent?.serverId && !actionClient);
+
+  const openSubsession = useOpenSubsession();
+  const handleSubsessionPress = useCallback(
+    (agent: AggregatedAgent, sub: AgentSubsessionPayload) => {
+      openSubsession({ serverId: agent.serverId, agentId: agent.id, subsessionId: sub.id });
+    },
+    [openSubsession],
+  );
 
   const handleAgentPress = useCallback(
     (agent: AggregatedAgent) => {
@@ -444,6 +483,18 @@ export function AgentList({
     setActionAgent(null);
   }, []);
 
+  const handleToggleExpand = useCallback((agentKey: string) => {
+    setExpandedAgents((prev) => {
+      const next = new Set(prev);
+      if (next.has(agentKey)) {
+        next.delete(agentKey);
+      } else {
+        next.add(agentKey);
+      }
+      return next;
+    });
+  }, []);
+
   const handleArchiveAgent = useCallback(() => {
     if (!actionAgent || !actionClient) {
       return;
@@ -470,11 +521,24 @@ export function AgentList({
       }
       result.push({ type: "header", key: `header:${section}`, section });
       for (const agent of data) {
-        result.push({ type: "agent", key: `${agent.serverId}:${agent.id}`, agent });
+        const agentKey = `${agent.serverId}:${agent.id}`;
+        result.push({ type: "agent", key: agentKey, agent });
+        if (!expandedAgents.has(agentKey)) {
+          continue;
+        }
+        for (const row of buildSubsessionRows(agent.subsessions)) {
+          result.push({
+            type: "subsession",
+            key: `${agentKey}:sub:${row.sub.id}`,
+            agent,
+            sub: row.sub,
+            depth: row.depth,
+          });
+        }
       }
     }
     return result;
-  }, [agents]);
+  }, [agents, expandedAgents]);
 
   const renderItem: ListRenderItem<FlatListItem> = useCallback(
     ({ item }) => {
@@ -483,6 +547,16 @@ export function AgentList({
           <View style={styles.sectionHeading}>
             <Text style={styles.sectionTitle}>{formatDateSectionLabel(t, item.section)}</Text>
           </View>
+        );
+      }
+      if (item.type === "subsession") {
+        return (
+          <SubsessionRow
+            sub={item.sub}
+            depth={item.depth}
+            agent={item.agent}
+            onPressSubsession={handleSubsessionPress}
+          />
         );
       }
       return (
@@ -494,17 +568,23 @@ export function AgentList({
           showHostColumn={showHostColumn}
           onPress={handleAgentPress}
           onLongPress={handleAgentLongPress}
+          expanded={expandedAgents.has(item.key)}
+          subsessionCount={item.agent.subsessions?.length ?? 0}
+          onToggleExpand={handleToggleExpand}
         />
       );
     },
     [
       handleAgentLongPress,
       handleAgentPress,
+      handleSubsessionPress,
       isMobile,
       selectedAgentId,
       showAttentionIndicator,
       showHostColumn,
       t,
+      expandedAgents,
+      handleToggleExpand,
     ],
   );
 

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -14,6 +14,9 @@ import * as Haptics from "expo-haptics";
 import { useMutation } from "@tanstack/react-query";
 import { ProjectIconView } from "@/components/project-icon-view";
 import { AdaptiveRenameModal } from "@/components/rename-modal";
+import { SubsessionDisclosure } from "@/components/agent-list-subsessions";
+import { WorkspaceSubsessionList } from "@/components/sidebar-workspace-subsessions";
+import { useWorkspaceSubsessionAgents } from "@/subagents";
 import {
   memo,
   useCallback,
@@ -1838,27 +1841,67 @@ function WorkspaceRow({
   selected: boolean;
 }) {
   const hydratedWorkspace = useSidebarWorkspaceEntry(workspace.serverId, workspace.workspaceId);
+  const subsessionAgents = useWorkspaceSubsessionAgents({
+    serverId: workspace.serverId,
+    workspaceId: workspace.workspaceId,
+  });
+  const [subsessionsExpanded, setSubsessionsExpanded] = useState(false);
+  const toggleSubsessions = useCallback(() => {
+    setSubsessionsExpanded((current) => !current);
+  }, []);
+  const subsessionCount = useMemo(
+    () => subsessionAgents.reduce((total, agent) => total + agent.subsessions.length, 0),
+    [subsessionAgents],
+  );
 
   if (!hydratedWorkspace) {
     return null;
   }
 
   return (
-    <WorkspaceRowWithMenu
-      workspace={hydratedWorkspace}
-      subtitle={subtitle}
-      selected={selected}
-      shortcutNumber={shortcutNumber}
-      showShortcutBadge={showShortcutBadge}
-      onPress={onPress}
-      drag={drag}
-      isDragging={isDragging}
-      dragHandleProps={dragHandleProps}
-      canCopyBranchName={canCopyBranchName}
-      isCreating={isCreating}
-    />
+    <View>
+      <View style={workspaceRowLineStyle}>
+        <View style={workspaceDisclosureOverlayStyle}>
+          <SubsessionDisclosure
+            count={subsessionCount}
+            expanded={subsessionsExpanded}
+            onToggle={toggleSubsessions}
+            testID={`sidebar-workspace-subsessions-disclosure-${workspace.workspaceKey}`}
+          />
+        </View>
+        <View style={workspaceRowBodyStyle}>
+          <WorkspaceRowWithMenu
+            workspace={hydratedWorkspace}
+            subtitle={subtitle}
+            selected={selected}
+            shortcutNumber={shortcutNumber}
+            showShortcutBadge={showShortcutBadge}
+            onPress={onPress}
+            drag={drag}
+            isDragging={isDragging}
+            dragHandleProps={dragHandleProps}
+            canCopyBranchName={canCopyBranchName}
+            isCreating={isCreating}
+          />
+        </View>
+      </View>
+      {subsessionsExpanded ? (
+        <WorkspaceSubsessionList serverId={workspace.serverId} agents={subsessionAgents} />
+      ) : null}
+    </View>
   );
 }
+
+const workspaceRowLineStyle: ViewStyle = { position: "relative" };
+const workspaceDisclosureOverlayStyle: ViewStyle = {
+  position: "absolute",
+  left: 4,
+  top: 0,
+  bottom: 0,
+  justifyContent: "center",
+  zIndex: 1,
+};
+const workspaceRowBodyStyle: ViewStyle = { flex: 1, minWidth: 0 };
 
 function ProjectBlock({
   project,

--- a/packages/app/src/components/sidebar-workspace-subsessions.tsx
+++ b/packages/app/src/components/sidebar-workspace-subsessions.tsx
@@ -1,0 +1,149 @@
+import { memo, useCallback, useMemo } from "react";
+import { Pressable, Text, View, type PressableStateCallbackType } from "react-native";
+import { useTranslation } from "react-i18next";
+import { StyleSheet } from "react-native-unistyles";
+import {
+  buildSubsessionRows,
+  type SubsessionRowModel,
+} from "@/components/agent-list-subsession-rows";
+import { AgentStatusDot } from "@/components/agent-status-dot";
+import { useOpenSubsession, type WorkspaceSubsessionAgent } from "@/subagents";
+
+interface FlattenedLeaf {
+  key: string;
+  agentId: string;
+  model: SubsessionRowModel;
+}
+
+function flattenWorkspaceSubsessions(agents: readonly WorkspaceSubsessionAgent[]): FlattenedLeaf[] {
+  const leaves: FlattenedLeaf[] = [];
+  for (const agent of agents) {
+    for (const model of buildSubsessionRows(agent.subsessions)) {
+      leaves.push({ key: `${agent.agentId}:${model.sub.id}`, agentId: agent.agentId, model });
+    }
+  }
+  return leaves;
+}
+
+export const WorkspaceSubsessionList = memo(function WorkspaceSubsessionList({
+  serverId,
+  agents,
+}: {
+  serverId: string;
+  agents: readonly WorkspaceSubsessionAgent[];
+}) {
+  const leaves = useMemo(() => flattenWorkspaceSubsessions(agents), [agents]);
+  const openSubsession = useOpenSubsession();
+  const handleOpenSubsession = useCallback(
+    (agentId: string, subsessionId: string) => {
+      openSubsession({ serverId, agentId, subsessionId });
+    },
+    [openSubsession, serverId],
+  );
+
+  if (leaves.length === 0) {
+    return null;
+  }
+
+  return (
+    <View testID={`sidebar-workspace-subsessions-${serverId}`}>
+      {leaves.map((leaf) => (
+        <WorkspaceSubsessionLeaf
+          key={leaf.key}
+          serverId={serverId}
+          agentId={leaf.agentId}
+          model={leaf.model}
+          onOpen={handleOpenSubsession}
+        />
+      ))}
+    </View>
+  );
+});
+
+function WorkspaceSubsessionLeaf({
+  serverId,
+  agentId,
+  model,
+  onOpen,
+}: {
+  serverId: string;
+  agentId: string;
+  model: SubsessionRowModel;
+  onOpen: (agentId: string, subsessionId: string) => void;
+}) {
+  const { t } = useTranslation();
+  const title = model.sub.title ?? t("subagents.fallbackTitle");
+
+  const handlePress = useCallback(() => {
+    onOpen(agentId, model.sub.id);
+  }, [onOpen, agentId, model.sub.id]);
+
+  const rowStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType) => [
+      styles.row,
+      (hovered || pressed) && styles.rowActive,
+    ],
+    [],
+  );
+
+  const innerStyle = useMemo(
+    () => [styles.inner, { paddingLeft: INDENT_BASE + model.depth * INDENT_PER_LEVEL }],
+    [model.depth],
+  );
+
+  return (
+    <Pressable
+      style={rowStyle}
+      onPress={handlePress}
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      testID={`sidebar-workspace-subsession-${serverId}-${agentId}-${model.sub.id}`}
+    >
+      <View style={innerStyle}>
+        <View style={styles.dotSlot}>
+          <AgentStatusDot status={model.sub.status} requiresAttention={false} />
+        </View>
+        <Text style={styles.title} numberOfLines={1}>
+          {title}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+const INDENT_BASE = 0;
+const INDENT_PER_LEVEL = 14;
+
+const styles = StyleSheet.create((theme) => ({
+  row: {
+    minHeight: 26,
+    borderRadius: theme.borderRadius.lg,
+    paddingVertical: theme.spacing[1],
+    paddingHorizontal: theme.spacing[2],
+    userSelect: "none",
+  },
+  rowActive: {
+    backgroundColor: theme.colors.surface2,
+  },
+  inner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    flex: 1,
+    minWidth: 0,
+  },
+  dotSlot: {
+    width: 8,
+    height: 8,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  title: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    opacity: 0.76,
+    flex: 1,
+    minWidth: 0,
+  },
+}));

--- a/packages/app/src/hooks/use-agent-history.ts
+++ b/packages/app/src/hooks/use-agent-history.ts
@@ -84,6 +84,7 @@ export async function fetchAgentHistoryPage(input: {
       archivedAt: agent.archivedAt ?? null,
       createdAt: agent.createdAt,
       labels: agent.labels,
+      subsessions: agent.subsessions,
       projectPlacement: agent.projectPlacement,
     })),
     pageInfo: payload.pageInfo,

--- a/packages/app/src/hooks/use-aggregated-agents.ts
+++ b/packages/app/src/hooks/use-aggregated-agents.ts
@@ -87,6 +87,7 @@ export function useAggregatedAgents(options?: {
           archivedAt: agent.archivedAt,
           createdAt: agent.createdAt,
           labels: agent.labels,
+          subsessions: agent.subsessions,
           projectPlacement: agent.projectPlacement,
         };
         const cacheKey = `${serverId}:${agent.id}`;

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1347,6 +1347,9 @@ export const ar: TranslationResources = {
     detachTooltip: "فصل الوكيل الفرعي",
     archiveAction: "أرشيف{{label}}",
     archiveTooltip: "أرشفة الوكيل الفرعي",
+    toggle: "توسيع أو طي الوكلاء الفرعيين",
+    fallbackTitle: "وكيل فرعي",
+    openFailed: "تعذر فتح جلسة الوكيل الفرعي",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1355,6 +1355,9 @@ export const en = {
     detachTooltip: "Detach subagent",
     archiveAction: "Archive {{label}}",
     archiveTooltip: "Archive subagent",
+    toggle: "Expand or collapse subagents",
+    fallbackTitle: "Subagent",
+    openFailed: "Couldn't open the subagent session",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1386,6 +1386,9 @@ export const es: TranslationResources = {
     detachTooltip: "Separar subagente",
     archiveAction: "Archivo{{label}}",
     archiveTooltip: "Subagente de archivo",
+    toggle: "Expandir o contraer subagentes",
+    fallbackTitle: "Subagente",
+    openFailed: "No se pudo abrir la sesión del subagente",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1389,6 +1389,9 @@ export const fr: TranslationResources = {
     detachTooltip: "Detacher le sous-agent",
     archiveAction: "Archiver{{label}}",
     archiveTooltip: "Sous-agent d'archivage",
+    toggle: "Développer ou réduire les sous-agents",
+    fallbackTitle: "Sous-agent",
+    openFailed: "Impossible d'ouvrir la session du sous-agent",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1364,6 +1364,9 @@ export const ja: TranslationResources = {
     detachTooltip: "サブエージェントを切り離す",
     archiveAction: "{{label}}をアーカイブ",
     archiveTooltip: "サブエージェントをアーカイブ",
+    toggle: "サブエージェントを展開または折りたたむ",
+    fallbackTitle: "サブエージェント",
+    openFailed: "サブエージェントのセッションを開けませんでした",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1372,6 +1372,9 @@ export const ptBR: TranslationResources = {
     detachTooltip: "Desanexar subagente",
     archiveAction: "Arquivar {{label}}",
     archiveTooltip: "Arquivar subagente",
+    toggle: "Expandir ou recolher subagentes",
+    fallbackTitle: "Subagente",
+    openFailed: "Não foi possível abrir a sessão do subagente",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1378,6 +1378,9 @@ export const ru: TranslationResources = {
     detachTooltip: "Отсоединить субагент",
     archiveAction: "Архив{{label}}",
     archiveTooltip: "Архивный субагент",
+    toggle: "Развернуть или свернуть подагенты",
+    fallbackTitle: "Подагент",
+    openFailed: "Не удалось открыть сессию субагента",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1330,6 +1330,9 @@ export const zhCN: TranslationResources = {
     detachTooltip: "分离 subagent",
     archiveAction: "归档 {{label}}",
     archiveTooltip: "归档 subagent",
+    toggle: "展开或折叠子代理",
+    fallbackTitle: "子代理",
+    openFailed: "无法打开子代理会话",
   },
   panels: {
     draft: {

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -68,7 +68,13 @@ import { type Agent, useSessionStore } from "@/stores/session-store";
 import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
 import { buildWorkspaceTabPersistenceKey } from "@/stores/workspace-tabs-store";
 import type { Theme } from "@/styles/theme";
-import { useArchiveSubagent, useDetachSubagent, useSubagentsForParent } from "@/subagents";
+import {
+  useArchiveSubagent,
+  useDetachSubagent,
+  useOpenSubsession,
+  useSubagentsForParent,
+  useSubsessionsForAgent,
+} from "@/subagents";
 import { SubagentsTrack } from "@/subagents/track";
 import type { PendingPermission } from "@/types/shared";
 import type { StreamItem } from "@/types/stream";
@@ -1373,6 +1379,14 @@ function ActiveAgentComposer({
     serverId,
     parentAgentId: agentId,
   });
+  const agentSubsessions = useSubsessionsForAgent({ serverId, agentId });
+  const openSubsession = useOpenSubsession();
+  const handleOpenSubsessionPress = useCallback(
+    (subsessionId: string) => {
+      openSubsession({ serverId, agentId, subsessionId });
+    },
+    [openSubsession, serverId, agentId],
+  );
   const canDetachSubagents = useSessionStore(
     (state) => state.sessions[serverId]?.serverInfo?.features?.agentDetach === true,
   );
@@ -1484,6 +1498,8 @@ function ActiveAgentComposer({
         onOpenSubagent={handleOpenSubagent}
         onArchiveSubagent={handleArchiveSubagent}
         onDetachSubagent={canDetachSubagents ? handleDetachSubagent : undefined}
+        subsessions={agentSubsessions}
+        onOpenSubsession={handleOpenSubsessionPress}
       />
       <Composer
         agentId={agentId}

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -23,6 +23,7 @@ import type {
 } from "@getpaseo/protocol/agent-types";
 import type {
   ServerInfoStatusPayload,
+  AgentSubsessionPayload,
   ProjectPlacementPayload,
   ServerCapabilities,
   WorkspaceDescriptorPayload,
@@ -117,6 +118,7 @@ export interface Agent {
   archivedAt?: Date | null;
   parentAgentId: string | null;
   labels: Record<string, string>;
+  subsessions?: AgentSubsessionPayload[];
   projectPlacement?: ProjectPlacementPayload | null;
 }
 
@@ -1612,6 +1614,7 @@ export const useSessionStore = create<SessionStore>()(
             attentionTimestamp: agent.attentionTimestamp ?? null,
             createdAt: agent.createdAt,
             labels: agent.labels,
+            subsessions: agent.subsessions,
           });
         }
         return entries;

--- a/packages/app/src/subagents/find-agent-for-provider-session.test.ts
+++ b/packages/app/src/subagents/find-agent-for-provider-session.test.ts
@@ -1,0 +1,136 @@
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import { afterEach, describe, expect, it } from "vitest";
+import { findAgentIdForProviderSession } from "./find-agent-for-provider-session";
+import { useSessionStore, type Agent } from "@/stores/session-store";
+
+const SERVER_ID = "server-1";
+const AGENT_TIMESTAMP = new Date("2026-03-08T10:00:00.000Z");
+
+const AGENT_DEFAULTS: Agent = {
+  serverId: SERVER_ID,
+  id: "agent",
+  provider: "opencode",
+  status: "idle",
+  createdAt: AGENT_TIMESTAMP,
+  updatedAt: AGENT_TIMESTAMP,
+  lastUserMessageAt: null,
+  lastActivityAt: AGENT_TIMESTAMP,
+  capabilities: {
+    supportsStreaming: true,
+    supportsSessionPersistence: true,
+    supportsDynamicModes: true,
+    supportsMcpServers: true,
+    supportsReasoningStream: true,
+    supportsToolInvocations: true,
+  },
+  currentModeId: null,
+  availableModes: [],
+  pendingPermissions: [],
+  persistence: null,
+  runtimeInfo: undefined,
+  lastUsage: undefined,
+  lastError: null,
+  title: "Agent",
+  cwd: "/tmp/project",
+  model: null,
+  features: undefined,
+  thinkingOptionId: undefined,
+  requiresAttention: false,
+  attentionReason: null,
+  attentionTimestamp: null,
+  archivedAt: null,
+  parentAgentId: null,
+  labels: {},
+  projectPlacement: null,
+};
+
+function makeAgent(input: Partial<Agent> & Pick<Agent, "id">): Agent {
+  return { ...AGENT_DEFAULTS, ...input };
+}
+
+function initializeSession(): void {
+  useSessionStore.getState().initializeSession(SERVER_ID, null as unknown as DaemonClient);
+}
+
+afterEach(() => {
+  useSessionStore.getState().clearSession(SERVER_ID);
+});
+
+describe("findAgentIdForProviderSession", () => {
+  it("finds the agent bound to the session id via its persistence handle", () => {
+    initializeSession();
+    useSessionStore.getState().setAgents(
+      SERVER_ID,
+      new Map([
+        [
+          "parent",
+          makeAgent({ id: "parent", persistence: { provider: "opencode", sessionId: "ses_root" } }),
+        ],
+        [
+          "imported",
+          makeAgent({
+            id: "imported",
+            persistence: { provider: "opencode", sessionId: "ses_child" },
+          }),
+        ],
+      ]),
+    );
+
+    expect(
+      findAgentIdForProviderSession(useSessionStore.getState(), {
+        serverId: SERVER_ID,
+        sessionId: "ses_child",
+      }),
+    ).toBe("imported");
+  });
+
+  it("falls back to agentDetails when the agent is not in the list map", () => {
+    initializeSession();
+    useSessionStore.getState().setAgentDetails(
+      SERVER_ID,
+      new Map([
+        [
+          "detail",
+          makeAgent({
+            id: "detail",
+            persistence: { provider: "opencode", sessionId: "ses_detail" },
+          }),
+        ],
+      ]),
+    );
+
+    expect(
+      findAgentIdForProviderSession(useSessionStore.getState(), {
+        serverId: SERVER_ID,
+        sessionId: "ses_detail",
+      }),
+    ).toBe("detail");
+  });
+
+  it("returns null when no agent is bound to the session id", () => {
+    initializeSession();
+    useSessionStore.getState().setAgents(
+      SERVER_ID,
+      new Map([
+        [
+          "parent",
+          makeAgent({ id: "parent", persistence: { provider: "opencode", sessionId: "ses_root" } }),
+        ],
+        ["no-handle", makeAgent({ id: "no-handle" })],
+      ]),
+    );
+
+    expect(
+      findAgentIdForProviderSession(useSessionStore.getState(), {
+        serverId: SERVER_ID,
+        sessionId: "ses_missing",
+      }),
+    ).toBe(null);
+    expect(
+      findAgentIdForProviderSession(useSessionStore.getState(), {
+        serverId: "unknown-server",
+        sessionId: "ses_root",
+      }),
+    ).toBe(null);
+  });
+});

--- a/packages/app/src/subagents/find-agent-for-provider-session.ts
+++ b/packages/app/src/subagents/find-agent-for-provider-session.ts
@@ -1,0 +1,25 @@
+import type { useSessionStore } from "@/stores/session-store";
+
+type SessionStoreSnapshot = ReturnType<typeof useSessionStore.getState>;
+
+/**
+ * Find the Paseo agent already bound to a provider session id — an earlier
+ * import of the same subsession, matched via the agent's persistence handle.
+ */
+export function findAgentIdForProviderSession(
+  state: SessionStoreSnapshot,
+  params: { serverId: string; sessionId: string },
+): string | null {
+  const session = state.sessions[params.serverId];
+  if (!session) {
+    return null;
+  }
+  for (const source of [session.agents, session.agentDetails]) {
+    for (const agent of source.values()) {
+      if (agent.persistence?.sessionId === params.sessionId) {
+        return agent.id;
+      }
+    }
+  }
+  return null;
+}

--- a/packages/app/src/subagents/index.ts
+++ b/packages/app/src/subagents/index.ts
@@ -1,5 +1,14 @@
-export type { SubagentRow } from "./select";
-export { selectSubagentsForParent, useSubagentsForParent } from "./select";
+export type { SubagentRow, WorkspaceSubsessionAgent } from "./select";
+export {
+  selectSubagentsForParent,
+  useSubagentsForParent,
+  selectSubsessionsForAgent,
+  useSubsessionsForAgent,
+  selectWorkspaceSubsessionAgents,
+  useWorkspaceSubsessionAgents,
+} from "./select";
+export { findAgentIdForProviderSession } from "./find-agent-for-provider-session";
+export { useOpenSubsession, type OpenSubsessionInput } from "./use-open-subsession";
 export { useArchiveSubagent, type UseArchiveSubagentInput } from "./use-archive-subagent";
 export { useDetachSubagent, type UseDetachSubagentInput } from "./use-detach-subagent";
 export { resolveCloseAgentTabPolicy, type CloseAgentTabPolicy } from "./close-tab-policy";

--- a/packages/app/src/subagents/select.test.ts
+++ b/packages/app/src/subagents/select.test.ts
@@ -1,6 +1,11 @@
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import type { AgentSubsessionPayload } from "@getpaseo/protocol/messages";
 import { afterEach, describe, expect, it } from "vitest";
-import { selectSubagentsForParent } from "./select";
+import {
+  selectSubagentsForParent,
+  selectSubsessionsForAgent,
+  selectWorkspaceSubsessionAgents,
+} from "./select";
 import { useSessionStore, type Agent } from "@/stores/session-store";
 
 const SERVER_ID = "server-1";
@@ -310,5 +315,115 @@ describe("selectSubagentsForParent", () => {
         EMPTY_PENDING_ARCHIVE_IDS,
       ),
     );
+  });
+});
+
+function makeSubsession(
+  id: string,
+  status: AgentSubsessionPayload["status"] = "idle",
+): AgentSubsessionPayload {
+  return { id, title: `Sub ${id}`, status, parentSessionId: null };
+}
+
+describe("selectSubsessionsForAgent", () => {
+  it("returns the agent's subsessions from the agents map", () => {
+    const subsessions = [makeSubsession("s1"), makeSubsession("s2", "running")];
+    setAgents([makeAgent({ id: "agent-a", subsessions })]);
+
+    expect(
+      selectSubsessionsForAgent(useSessionStore.getState(), {
+        serverId: SERVER_ID,
+        agentId: "agent-a",
+      }),
+    ).toEqual(subsessions);
+  });
+
+  it("falls back to agentDetails when the agent is not in the list map", () => {
+    const subsessions = [makeSubsession("s1")];
+    useSessionStore.getState().initializeSession(SERVER_ID, null as unknown as DaemonClient);
+    useSessionStore
+      .getState()
+      .setAgentDetails(
+        SERVER_ID,
+        new Map([["agent-a", makeAgent({ id: "agent-a", subsessions })]]),
+      );
+
+    expect(
+      selectSubsessionsForAgent(useSessionStore.getState(), {
+        serverId: SERVER_ID,
+        agentId: "agent-a",
+      }),
+    ).toEqual(subsessions);
+  });
+
+  it("returns the shared empty array when the agent has no subsessions", () => {
+    setAgents([makeAgent({ id: "agent-a" })]);
+
+    const withoutSubsessions = selectSubsessionsForAgent(useSessionStore.getState(), {
+      serverId: SERVER_ID,
+      agentId: "agent-a",
+    });
+    const missingAgent = selectSubsessionsForAgent(useSessionStore.getState(), {
+      serverId: SERVER_ID,
+      agentId: "missing",
+    });
+
+    expect(withoutSubsessions).toEqual([]);
+    expect(withoutSubsessions).toBe(missingAgent);
+  });
+});
+
+describe("selectWorkspaceSubsessionAgents", () => {
+  it("returns only workspace agents that have subsessions, sorted by createdAt", () => {
+    const subsA = [makeSubsession("a1")];
+    const subsB = [makeSubsession("b1", "running"), makeSubsession("b2")];
+    setAgents([
+      makeAgent({
+        id: "late",
+        workspaceId: "ws-1",
+        subsessions: subsA,
+        createdAt: new Date("2026-03-08T11:00:00.000Z"),
+      }),
+      makeAgent({
+        id: "early",
+        workspaceId: "ws-1",
+        subsessions: subsB,
+        createdAt: new Date("2026-03-08T09:00:00.000Z"),
+      }),
+      makeAgent({ id: "no-subs", workspaceId: "ws-1" }),
+      makeAgent({ id: "other-ws", workspaceId: "ws-2", subsessions: subsA }),
+      makeAgent({
+        id: "archived",
+        workspaceId: "ws-1",
+        subsessions: subsA,
+        archivedAt: new Date("2026-03-08T12:00:00.000Z"),
+      }),
+    ]);
+
+    expect(
+      selectWorkspaceSubsessionAgents(useSessionStore.getState(), {
+        serverId: SERVER_ID,
+        workspaceId: "ws-1",
+      }),
+    ).toEqual([
+      { agentId: "early", subsessions: subsB },
+      { agentId: "late", subsessions: subsA },
+    ]);
+  });
+
+  it("returns the shared empty array when nothing matches", () => {
+    setAgents([makeAgent({ id: "agent-a", workspaceId: "ws-1" })]);
+
+    const noSubsessions = selectWorkspaceSubsessionAgents(useSessionStore.getState(), {
+      serverId: SERVER_ID,
+      workspaceId: "ws-1",
+    });
+    const missingServer = selectWorkspaceSubsessionAgents(useSessionStore.getState(), {
+      serverId: "missing",
+      workspaceId: "ws-1",
+    });
+
+    expect(noSubsessions).toEqual([]);
+    expect(noSubsessions).toBe(missingServer);
   });
 });

--- a/packages/app/src/subagents/select.ts
+++ b/packages/app/src/subagents/select.ts
@@ -1,6 +1,7 @@
 import { usePendingArchiveAgentIds } from "@/hooks/use-archive-agent";
 import equal from "fast-deep-equal";
 import { useStoreWithEqualityFn } from "zustand/traditional";
+import type { AgentSubsessionPayload } from "@getpaseo/protocol/messages";
 import { useSessionStore, type Agent } from "@/stores/session-store";
 
 export interface SubagentRow {
@@ -67,6 +68,84 @@ export function useSubagentsForParent(params: SelectSubagentsParams): SubagentRo
   return useStoreWithEqualityFn(
     useSessionStore,
     (state) => selectSubagentsForParent(state, params, pendingArchiveIds),
+    equal,
+  );
+}
+
+const EMPTY_SUBSESSIONS: AgentSubsessionPayload[] = [];
+
+interface SelectSubsessionsParams {
+  serverId: string;
+  agentId: string;
+}
+
+export function selectSubsessionsForAgent(
+  state: SessionStoreSnapshot,
+  params: SelectSubsessionsParams,
+): AgentSubsessionPayload[] {
+  const session = state.sessions[params.serverId];
+  const agent = session?.agents.get(params.agentId) ?? session?.agentDetails.get(params.agentId);
+  const subsessions = agent?.subsessions;
+  return subsessions && subsessions.length > 0 ? subsessions : EMPTY_SUBSESSIONS;
+}
+
+export function useSubsessionsForAgent(params: SelectSubsessionsParams): AgentSubsessionPayload[] {
+  return useStoreWithEqualityFn(
+    useSessionStore,
+    (state) => selectSubsessionsForAgent(state, params),
+    equal,
+  );
+}
+
+export interface WorkspaceSubsessionAgent {
+  agentId: string;
+  subsessions: AgentSubsessionPayload[];
+}
+
+const EMPTY_WORKSPACE_SUBSESSION_AGENTS: WorkspaceSubsessionAgent[] = [];
+
+interface SelectWorkspaceSubsessionsParams {
+  serverId: string;
+  workspaceId: string;
+}
+
+export function selectWorkspaceSubsessionAgents(
+  state: SessionStoreSnapshot,
+  params: SelectWorkspaceSubsessionsParams,
+): WorkspaceSubsessionAgent[] {
+  const session = state.sessions[params.serverId];
+  if (!session || session.agents.size === 0) {
+    return EMPTY_WORKSPACE_SUBSESSION_AGENTS;
+  }
+
+  const entries: { createdAtMs: number; entry: WorkspaceSubsessionAgent }[] = [];
+  for (const agent of session.agents.values()) {
+    if (agent.archivedAt || agent.workspaceId !== params.workspaceId) {
+      continue;
+    }
+    if (!agent.subsessions || agent.subsessions.length === 0) {
+      continue;
+    }
+    entries.push({
+      createdAtMs: agent.createdAt.getTime(),
+      entry: { agentId: agent.id, subsessions: agent.subsessions },
+    });
+  }
+
+  if (entries.length === 0) {
+    return EMPTY_WORKSPACE_SUBSESSION_AGENTS;
+  }
+
+  entries.sort((left, right) => left.createdAtMs - right.createdAtMs);
+  return entries.map(({ entry }) => entry);
+}
+
+export function useWorkspaceSubsessionAgents(
+  params: SelectWorkspaceSubsessionsParams,
+): WorkspaceSubsessionAgent[] {
+  return useStoreWithEqualityFn(
+    useSessionStore,
+    (state) => selectWorkspaceSubsessionAgents(state, params),
     equal,
   );
 }

--- a/packages/app/src/subagents/track-presentation.test.ts
+++ b/packages/app/src/subagents/track-presentation.test.ts
@@ -67,6 +67,19 @@ describe("formatHeaderLabel", () => {
   it("uses singular 'subagent' for a single row that requires attention upstream", () => {
     expect(formatHeaderLabel([row({ id: "a", requiresAttention: true })])).toBe("1 subagent");
   });
+
+  it("counts subsessions in the total and running suffix", () => {
+    expect(formatHeaderLabel([row({ id: "a" })], [{ status: "running" }, { status: "idle" }])).toBe(
+      "3 subagents · 1 running",
+    );
+  });
+
+  it("formats a subsession-only track", () => {
+    expect(formatHeaderLabel([], [{ status: "idle" }])).toBe("1 subagent");
+    expect(formatHeaderLabel([], [{ status: "running" }, { status: "error" }])).toBe(
+      "2 subagents · 1 running",
+    );
+  });
 });
 
 describe("resolveRowLabel", () => {

--- a/packages/app/src/subagents/track-presentation.ts
+++ b/packages/app/src/subagents/track-presentation.ts
@@ -1,3 +1,4 @@
+import type { AgentSubsessionPayload } from "@getpaseo/protocol/messages";
 import type { SidebarStateBucket } from "@/utils/sidebar-agent-state";
 import { deriveSidebarStateBucket } from "@/utils/sidebar-agent-state";
 import type { SubagentRow } from "./select";
@@ -26,15 +27,26 @@ export function buildSubagentRowPresentationData(row: SubagentRow): SubagentRowP
   };
 }
 
-export function formatHeaderLabel(rows: readonly SubagentRow[]): string {
+const NO_SUBSESSIONS: readonly Pick<AgentSubsessionPayload, "status">[] = [];
+
+export function formatHeaderLabel(
+  rows: readonly SubagentRow[],
+  subsessions: readonly Pick<AgentSubsessionPayload, "status">[] = NO_SUBSESSIONS,
+): string {
   let runningCount = 0;
   for (const row of rows) {
     if (row.status === "running") {
       runningCount += 1;
     }
   }
+  for (const sub of subsessions) {
+    if (sub.status === "running") {
+      runningCount += 1;
+    }
+  }
 
-  const parts = [`${rows.length} ${rows.length === 1 ? "subagent" : "subagents"}`];
+  const total = rows.length + subsessions.length;
+  const parts = [`${total} ${total === 1 ? "subagent" : "subagents"}`];
   if (runningCount > 0) {
     parts.push(`${runningCount} running`);
   }

--- a/packages/app/src/subagents/track.tsx
+++ b/packages/app/src/subagents/track.tsx
@@ -3,6 +3,12 @@ import { Pressable, ScrollView, Text, View, type PressableStateCallbackType } fr
 import { useTranslation } from "react-i18next";
 import { Archive, ChevronDown, ChevronRight, Unlink } from "lucide-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import type { AgentSubsessionPayload } from "@getpaseo/protocol/messages";
+import {
+  buildSubsessionRows,
+  type SubsessionRowModel,
+} from "@/components/agent-list-subsession-rows";
+import { AgentStatusDot } from "@/components/agent-status-dot";
 import { getProviderIcon } from "@/components/provider-icons";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useIsCompactFormFactor, MAX_CONTENT_WIDTH } from "@/constants/layout";
@@ -30,9 +36,12 @@ export interface SubagentsTrackProps {
   onOpenSubagent: (id: string) => void;
   onArchiveSubagent: (id: string) => void;
   onDetachSubagent?: (id: string) => void;
+  subsessions?: AgentSubsessionPayload[];
+  onOpenSubsession: (subsessionId: string) => void;
 }
 
 const SUBAGENTS_LIST_MAX_HEIGHT = 200;
+const EMPTY_SUBSESSIONS: AgentSubsessionPayload[] = [];
 
 function buildRowPresentation(row: SubagentRow): WorkspaceTabPresentation {
   return {
@@ -46,6 +55,8 @@ export function SubagentsTrack({
   onOpenSubagent,
   onArchiveSubagent,
   onDetachSubagent,
+  subsessions = EMPTY_SUBSESSIONS,
+  onOpenSubsession,
 }: SubagentsTrackProps): ReactElement | null {
   const [expanded, setExpanded] = useState(false);
 
@@ -67,11 +78,13 @@ export function SubagentsTrack({
     [expanded],
   );
 
-  if (rows.length === 0) {
+  const subsessionRows = useMemo(() => buildSubsessionRows(subsessions), [subsessions]);
+
+  if (rows.length === 0 && subsessionRows.length === 0) {
     return null;
   }
 
-  const headerLabel = formatHeaderLabel(rows);
+  const headerLabel = formatHeaderLabel(rows, subsessions);
 
   return (
     <View style={styles.outer} testID="subagents-track">
@@ -107,6 +120,13 @@ export function SubagentsTrack({
                   onOpenSubagent={onOpenSubagent}
                   onArchiveSubagent={onArchiveSubagent}
                   onDetachSubagent={onDetachSubagent}
+                />
+              ))}
+              {subsessionRows.map((model) => (
+                <SubsessionTrackRow
+                  key={model.sub.id}
+                  model={model}
+                  onOpenSubsession={onOpenSubsession}
                 />
               ))}
             </ScrollView>
@@ -178,6 +198,48 @@ function SubagentsTrackRow({
         )}
       </Pressable>
     </View>
+  );
+}
+
+const SUBSESSION_INDENT_BASE = 12;
+const SUBSESSION_INDENT_PER_LEVEL = 16;
+
+function SubsessionTrackRow({
+  model,
+  onOpenSubsession,
+}: {
+  model: SubsessionRowModel;
+  onOpenSubsession: (subsessionId: string) => void;
+}): ReactElement {
+  const { t } = useTranslation();
+  const title = model.sub.title ?? t("subagents.fallbackTitle");
+  const handlePress = useCallback(
+    () => onOpenSubsession(model.sub.id),
+    [onOpenSubsession, model.sub.id],
+  );
+  const rowStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType) => [
+      styles.row,
+      { paddingLeft: SUBSESSION_INDENT_BASE + model.depth * SUBSESSION_INDENT_PER_LEVEL },
+      (hovered || pressed) && styles.rowActive,
+    ],
+    [model.depth],
+  );
+  return (
+    <Pressable
+      style={rowStyle}
+      onPress={handlePress}
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      testID={`subagents-track-subsession-${model.sub.id}`}
+    >
+      <View style={styles.subsessionDotSlot}>
+        <AgentStatusDot status={model.sub.status} requiresAttention={false} />
+      </View>
+      <Text style={styles.subsessionLabel} numberOfLines={1}>
+        {title}
+      </Text>
+    </Pressable>
   );
 }
 
@@ -341,6 +403,20 @@ const styles = StyleSheet.create((theme) => ({
     minWidth: 0,
     fontSize: theme.fontSize.sm,
     color: theme.colors.foreground,
+  },
+  subsessionDotSlot: {
+    width: 8,
+    height: 8,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  subsessionLabel: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foreground,
+    opacity: 0.76,
   },
   actionClusterVisible: {
     flexDirection: "row",

--- a/packages/app/src/subagents/use-open-subsession.ts
+++ b/packages/app/src/subagents/use-open-subsession.ts
@@ -1,0 +1,84 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useToast } from "@/contexts/toast-context";
+import { getHostRuntimeStore } from "@/runtime/host-runtime";
+import { useSessionStore } from "@/stores/session-store";
+import { navigateToAgent } from "@/utils/navigate-to-agent";
+import { findAgentIdForProviderSession } from "./find-agent-for-provider-session";
+
+export interface OpenSubsessionInput {
+  serverId: string;
+  /** The agent that reported the subsession (owns the provider session tree). */
+  agentId: string;
+  /** Provider-native session id of the subsession. */
+  subsessionId: string;
+}
+
+// One import per subsession at a time — double-clicks and parallel surfaces
+// (sidebar, history, track) share the same pending import.
+const inflightImports = new Map<string, Promise<string>>();
+
+async function resolveSubsessionAgentId({
+  serverId,
+  agentId,
+  subsessionId,
+}: OpenSubsessionInput): Promise<string> {
+  const state = useSessionStore.getState();
+  const existing = findAgentIdForProviderSession(state, { serverId, sessionId: subsessionId });
+  if (existing) {
+    return existing;
+  }
+
+  const session = state.sessions[serverId];
+  const owner = session?.agents.get(agentId) ?? session?.agentDetails.get(agentId);
+  if (!owner) {
+    throw new Error("Owning agent not found");
+  }
+  const client = getHostRuntimeStore().getClient(serverId);
+  if (!client) {
+    throw new Error("Host disconnected");
+  }
+
+  const key = `${serverId}:${subsessionId}`;
+  let pending = inflightImports.get(key);
+  if (!pending) {
+    pending = client
+      .importAgent({
+        providerId: owner.provider,
+        providerHandleId: subsessionId,
+        cwd: owner.cwd,
+        workspaceId: owner.workspaceId,
+      })
+      .then((snapshot) => snapshot.id)
+      .finally(() => {
+        inflightImports.delete(key);
+      });
+    inflightImports.set(key, pending);
+  }
+  return pending;
+}
+
+/**
+ * Open a provider subsession as a full Paseo session: navigate to the agent
+ * already bound to it, or import it (attach an agent to the provider session)
+ * and navigate to the result.
+ */
+export function useOpenSubsession(): (input: OpenSubsessionInput) => void {
+  const toast = useToast();
+  const { t } = useTranslation();
+
+  return useCallback(
+    (input: OpenSubsessionInput) => {
+      void resolveSubsessionAgentId(input)
+        .then((targetAgentId) =>
+          navigateToAgent({ serverId: input.serverId, agentId: targetAgentId }),
+        )
+        .catch((error: unknown) => {
+          toast.error(
+            error instanceof Error && error.message ? error.message : t("subagents.openFailed"),
+          );
+        });
+    },
+    [toast, t],
+  );
+}

--- a/packages/app/src/types/agent-directory.ts
+++ b/packages/app/src/types/agent-directory.ts
@@ -16,6 +16,7 @@ export type AgentDirectoryEntry = Pick<
   | "archivedAt"
   | "createdAt"
   | "labels"
+  | "subsessions"
   | "projectPlacement"
 > & {
   pendingPermissionCount?: number;

--- a/packages/app/src/utils/agent-snapshots.ts
+++ b/packages/app/src/utils/agent-snapshots.ts
@@ -57,5 +57,6 @@ export function normalizeAgentSnapshot(snapshot: AgentSnapshotPayload, serverId:
     archivedAt,
     parentAgentId,
     labels: snapshot.labels,
+    subsessions: snapshot.subsessions ?? [],
   };
 }

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -145,6 +145,7 @@ const perfNow: () => number =
 
 interface ImportAgentInputBase {
   cwd?: string;
+  workspaceId?: string;
   labels?: Record<string, string>;
 }
 
@@ -2324,6 +2325,7 @@ export class DaemonClient {
         ? { providerId: input.providerId, providerHandleId: input.providerHandleId }
         : { provider: input.provider, sessionId: input.sessionId }),
       ...(input.cwd ? { cwd: input.cwd } : {}),
+      ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
       ...(input.labels && Object.keys(input.labels).length > 0 ? { labels: input.labels } : {}),
     });
 

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -678,6 +678,18 @@ const AgentRuntimeInfoSchema: z.ZodType<AgentRuntimeInfo> = z.object({
   extra: z.record(z.string(), z.unknown()).optional(),
 });
 
+// COMPAT(subsessions): added in v0.1.103. Optional in both directions — old
+// clients ignore the field, old daemons never send it (absence = feature
+// absent, which renders as "no subsessions").
+export const AgentSubsessionPayloadSchema = z.object({
+  id: z.string(),
+  title: z.string().nullable(),
+  status: z.enum(["running", "idle", "error"]),
+  parentSessionId: z.string().nullable().optional(),
+});
+
+export type AgentSubsessionPayload = z.infer<typeof AgentSubsessionPayloadSchema>;
+
 export const AgentSnapshotPayloadSchema = z.object({
   id: z.string(),
   provider: AgentProviderSchema,
@@ -706,6 +718,7 @@ export const AgentSnapshotPayloadSchema = z.object({
   attentionTimestamp: z.string().nullable().optional(),
   archivedAt: z.string().nullable().optional(),
   providerUnavailable: z.boolean().optional(),
+  subsessions: z.array(AgentSubsessionPayloadSchema).optional(),
 });
 
 export type AgentSnapshotPayload = z.infer<typeof AgentSnapshotPayloadSchema>;
@@ -729,6 +742,7 @@ export const AgentListItemPayloadSchema = z.object({
   attentionTimestamp: z.string().nullable().optional(),
   labels: z.record(z.string(), z.string()).default({}),
   providerUnavailable: z.boolean().optional(),
+  subsessions: z.array(AgentSubsessionPayloadSchema).optional(),
 });
 
 export type AgentListItemPayload = z.infer<typeof AgentListItemPayloadSchema>;
@@ -1243,6 +1257,7 @@ export const ImportAgentRequestMessageSchema = z.object({
   sessionId: z.string().optional(),
   providerHandleId: z.string().optional(),
   cwd: z.string().optional(),
+  workspaceId: z.string().optional(),
   labels: z.record(z.string(), z.string()).optional(),
   requestId: z.string(),
 });

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -38,6 +38,7 @@ import {
   type AgentTimelineItem,
   type AgentUsage,
   type AgentRuntimeInfo,
+  type AgentSubsession,
   type ImportedTimelineEntry,
   type ImportableProviderSession,
   type ListImportableSessionsOptions,
@@ -271,6 +272,11 @@ interface ManagedAgentBase {
   capabilities: AgentCapabilityFlags;
   config: AgentSessionConfig;
   runtimeInfo?: AgentRuntimeInfo;
+  /**
+   * Provider-native child sessions (subagents) of this agent's root session,
+   * reported live by the provider. Absent for providers without support.
+   */
+  subsessions?: AgentSubsession[];
   createdAt: Date;
   updatedAt: Date;
   availableModes: AgentMode[];
@@ -3063,6 +3069,11 @@ export class AgentManager {
         return undefined;
       case "usage_updated":
         agent.lastUsage = event.usage;
+        this.emitState(agent);
+        return undefined;
+      case "subsessions_changed":
+        agent.subsessions = event.subsessions;
+        flags.shouldDispatchEvent = false;
         this.emitState(agent);
         return undefined;
       case "mode_changed":

--- a/packages/server/src/server/agent/agent-projections.ts
+++ b/packages/server/src/server/agent/agent-projections.ts
@@ -128,6 +128,9 @@ export function toAgentPayload(
     persistence: sanitizePersistenceHandle(agent.persistence),
     title: options?.title ?? null,
     labels: agent.labels,
+    ...(agent.subsessions && agent.subsessions.length > 0
+      ? { subsessions: agent.subsessions }
+      : {}),
   };
 
   const usage = sanitizeUsage(agent.lastUsage);
@@ -258,6 +261,9 @@ export function toAgentListItemPayload(agent: AgentSnapshotPayload): AgentListIt
     attentionReason: agent.attentionReason ?? null,
     attentionTimestamp: agent.attentionTimestamp ?? null,
     labels: agent.labels,
+    ...(agent.subsessions && agent.subsessions.length > 0
+      ? { subsessions: agent.subsessions }
+      : {}),
     ...(agent.providerUnavailable ? { providerUnavailable: true } : {}),
   };
 }

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -375,11 +375,24 @@ export type AgentTimelineItem =
   | { type: "error"; message: string }
   | CompactionTimelineItem;
 
+/**
+ * A provider-native child session (subagent) of an agent's root session.
+ * Subsessions are ordinary sessions with a parent: they carry their own live
+ * activity status and stay tracked until deleted on the provider side.
+ */
+export interface AgentSubsession {
+  id: string;
+  title: string | null;
+  status: "running" | "idle" | "error";
+  parentSessionId: string | null;
+}
+
 export type AgentStreamEvent =
   | { type: "thread_started"; sessionId: string; provider: AgentProvider }
   | { type: "turn_started"; provider: AgentProvider; turnId?: string }
   | { type: "turn_completed"; provider: AgentProvider; usage?: AgentUsage; turnId?: string }
   | { type: "usage_updated"; provider: AgentProvider; usage: AgentUsage; turnId?: string }
+  | { type: "subsessions_changed"; provider: AgentProvider; subsessions: AgentSubsession[] }
   | {
       type: "mode_changed";
       provider: AgentProvider;

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -355,6 +355,21 @@ test("normalizeImportAgentRequest accepts new and legacy import handle shapes", 
     provider: "codex",
     providerHandleId: "thread-2",
   });
+
+  expect(
+    normalizeImportAgentRequest({
+      type: "import_agent_request",
+      requestId: "with-workspace",
+      providerId: "opencode",
+      providerHandleId: "ses-1",
+      workspaceId: "wks_parent",
+    }),
+  ).toEqual({
+    requestId: "with-workspace",
+    provider: "opencode",
+    providerHandleId: "ses-1",
+    workspaceId: "wks_parent",
+  });
 });
 
 test("importProviderSession imports a selected provider session without listing", async () => {

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -26,6 +26,7 @@ export interface NormalizedImportAgentRequest {
   provider: AgentProvider;
   providerHandleId: string;
   cwd?: string;
+  workspaceId?: string;
   labels?: Record<string, string>;
   requestId: string;
 }
@@ -82,6 +83,7 @@ export function normalizeImportAgentRequest(
     provider: provider as AgentProvider,
     providerHandleId,
     cwd: msg.cwd,
+    workspaceId: msg.workspaceId,
     labels: msg.labels,
     requestId: msg.requestId,
   };

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -11,6 +11,7 @@ import {
   type Session as OpenCodeSession,
   type TextPartInput as OpenCodeTextPartInput,
 } from "@opencode-ai/sdk/v2/client";
+import { OpenCodeSubsessionTracker, type OpenCodeSubsessionSeed } from "./opencode/subsessions.js";
 import fs from "node:fs/promises";
 import { createPathEquivalenceMatcher } from "../../../utils/path.js";
 import pLimit from "p-limit";
@@ -2785,6 +2786,7 @@ class OpenCodeAgentSession implements AgentSession {
   private subAgentsByCallId = new Map<string, OpenCodeSubAgentActivityState>();
   private subAgentCallIdByChildSessionId = new Map<string, string>();
   private pendingChildToolPartsBySessionId = new Map<string, OpenCodeToolPartEventPart[]>();
+  private readonly subsessionTracker: OpenCodeSubsessionTracker;
   private selectedModelContextWindowMaxTokens: number | undefined;
   private releaseServer: (() => void) | null;
   private eventStreamAbortController: AbortController | null = null;
@@ -2806,6 +2808,7 @@ class OpenCodeAgentSession implements AgentSession {
     this.config = config;
     this.client = client;
     this.sessionId = sessionId;
+    this.subsessionTracker = new OpenCodeSubsessionTracker(sessionId);
     this.logger = logger.child({ agentId: this.agentId });
     this.modelContextWindowsByModelKey = modelContextWindowsByModelKey;
     this.currentMode = normalizeOpenCodeModeId(config.modeId);
@@ -2816,6 +2819,7 @@ class OpenCodeAgentSession implements AgentSession {
       config.model,
     );
     this.startEventStream();
+    void this.hydrateSubsessions();
   }
 
   get id(): string | null {
@@ -3138,8 +3142,49 @@ class OpenCodeAgentSession implements AgentSession {
 
     return { turnId };
   }
+
+  private emitSubsessionsChanged(): void {
+    this.notifySubscribers({
+      type: "subsessions_changed",
+      provider: "opencode",
+      subsessions: this.subsessionTracker.list(),
+    });
+  }
+
+  /**
+   * Enumerate already-existing child sessions (session resume, daemon
+   * restart) so the tracker starts from the provider's persisted tree.
+   * Live updates then come from the event stream. Non-fatal on failure.
+   */
+  private async hydrateSubsessions(): Promise<void> {
+    try {
+      const seeds = await collectOpenCodeDescendantSessions(
+        this.client,
+        this.sessionId,
+        this.config.cwd,
+      );
+      if (this.closed) {
+        return;
+      }
+      if (this.subsessionTracker.seed(seeds)) {
+        this.emitSubsessionsChanged();
+      }
+    } catch (error) {
+      this.logger.debug(
+        { err: error, sessionId: this.sessionId },
+        "Failed to hydrate OpenCode subsessions",
+      );
+    }
+  }
   subscribe(callback: (event: AgentStreamEvent) => void): () => void {
     this.subscribers.add(callback);
+    // Replay the current subsession tree so late subscribers (the manager
+    // subscribes after createSession/resumeSession returns) never miss the
+    // hydrated state.
+    const subsessions = this.subsessionTracker.list();
+    if (subsessions.length > 0) {
+      callback({ type: "subsessions_changed", provider: "opencode", subsessions });
+    }
     return () => {
       this.subscribers.delete(callback);
     };
@@ -3263,6 +3308,12 @@ class OpenCodeAgentSession implements AgentSession {
     });
     if (!event) {
       return;
+    }
+    // Subsession lifecycle is tracked between turns too — a background child
+    // keeps running after the parent's turn ends — so this runs before the
+    // no-active-turn gate below drops the event.
+    if (this.subsessionTracker.handleEvent(event)) {
+      this.emitSubsessionsChanged();
     }
     if (!turnId) {
       this.traceOpenCode("provider.opencode.event.skip", {
@@ -3803,4 +3854,45 @@ class OpenCodeAgentSession implements AgentSession {
     }
     return this.modelContextWindowsByModelKey.get(modelLookupKey);
   }
+}
+
+const OPENCODE_SUBSESSION_ENUMERATION_LIMIT = 50;
+
+async function collectOpenCodeDescendantSessions(
+  client: Pick<OpencodeClient, "session">,
+  rootSessionId: string,
+  directory: string,
+): Promise<OpenCodeSubsessionSeed[]> {
+  const seeds: OpenCodeSubsessionSeed[] = [];
+  const queue = [rootSessionId];
+  const visited = new Set<string>([rootSessionId]);
+  while (queue.length > 0 && seeds.length < OPENCODE_SUBSESSION_ENUMERATION_LIMIT) {
+    const parentSessionId = queue.shift();
+    if (parentSessionId === undefined) {
+      break;
+    }
+    const response = await client.session.children({
+      sessionID: parentSessionId,
+      directory,
+    });
+    if (response.error) {
+      throw new Error(`Failed to list OpenCode child sessions: ${JSON.stringify(response.error)}`);
+    }
+    for (const child of response.data ?? []) {
+      if (seeds.length >= OPENCODE_SUBSESSION_ENUMERATION_LIMIT) {
+        break;
+      }
+      if (visited.has(child.id)) {
+        continue;
+      }
+      visited.add(child.id);
+      seeds.push({
+        id: child.id,
+        title: normalizeOpenCodeSessionTitle(child.title),
+        parentSessionId,
+      });
+      queue.push(child.id);
+    }
+  }
+  return seeds;
 }

--- a/packages/server/src/server/agent/providers/opencode/subsessions.test.ts
+++ b/packages/server/src/server/agent/providers/opencode/subsessions.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import type {
+  Event as OpenCodeEvent,
+  Session as OpenCodeSession,
+} from "@opencode-ai/sdk/v2/client";
+import { OpenCodeSubsessionTracker } from "./subsessions.js";
+
+const ROOT = "ses_root";
+
+function makeSession(id: string, parentID: string | undefined, title = ""): OpenCodeSession {
+  return {
+    id,
+    slug: id,
+    projectID: "project-1",
+    directory: "/tmp/project",
+    title,
+    version: "1",
+    time: { created: 1, updated: 1 },
+    ...(parentID ? { parentID } : {}),
+  };
+}
+
+function sessionCreated(id: string, parentID: string | undefined, title = ""): OpenCodeEvent {
+  return {
+    id: `evt_${id}`,
+    type: "session.created",
+    properties: { sessionID: id, info: makeSession(id, parentID, title) },
+  };
+}
+
+function sessionUpdated(id: string, parentID: string | undefined, title = ""): OpenCodeEvent {
+  return {
+    id: `evt_${id}`,
+    type: "session.updated",
+    properties: { sessionID: id, info: makeSession(id, parentID, title) },
+  };
+}
+
+function sessionStatus(id: string, statusType: "busy" | "idle"): OpenCodeEvent {
+  return {
+    id: `evt_status_${id}`,
+    type: "session.status",
+    properties: {
+      sessionID: id,
+      status: statusType === "idle" ? { type: "idle" } : { type: "busy" },
+    },
+  };
+}
+
+describe("OpenCodeSubsessionTracker", () => {
+  it("tracks a created child session as running with its title", () => {
+    const tracker = new OpenCodeSubsessionTracker(ROOT);
+
+    expect(tracker.handleEvent(sessionCreated("ses_child", ROOT, "Investigate flaky test"))).toBe(
+      true,
+    );
+
+    expect(tracker.list()).toEqual([
+      {
+        id: "ses_child",
+        title: "Investigate flaky test",
+        status: "running",
+        parentSessionId: ROOT,
+      },
+    ]);
+  });
+
+  it("ignores sessions that belong to another agent's tree and root sessions", () => {
+    const tracker = new OpenCodeSubsessionTracker(ROOT);
+
+    expect(tracker.handleEvent(sessionCreated("ses_other", "ses_unrelated"))).toBe(false);
+    expect(tracker.handleEvent(sessionCreated("ses_root_like", undefined))).toBe(false);
+    expect(tracker.list()).toEqual([]);
+  });
+
+  it("tracks nested descendants once their parent is known", () => {
+    const tracker = new OpenCodeSubsessionTracker(ROOT);
+
+    tracker.handleEvent(sessionCreated("ses_child", ROOT));
+    expect(tracker.handleEvent(sessionCreated("ses_grandchild", "ses_child"))).toBe(true);
+
+    const ids = tracker.list().map((s) => [s.id, s.parentSessionId]);
+    expect(ids).toEqual([
+      ["ses_child", ROOT],
+      ["ses_grandchild", "ses_child"],
+    ]);
+  });
+
+  it("updates live status from session.status and session.idle events", () => {
+    const tracker = new OpenCodeSubsessionTracker(ROOT);
+    tracker.handleEvent(sessionCreated("ses_child", ROOT));
+
+    expect(tracker.handleEvent(sessionStatus("ses_child", "idle"))).toBe(true);
+    expect(tracker.list()[0]?.status).toBe("idle");
+
+    expect(tracker.handleEvent(sessionStatus("ses_child", "busy"))).toBe(true);
+    expect(tracker.list()[0]?.status).toBe("running");
+
+    const idleEvent: OpenCodeEvent = {
+      id: "evt_idle",
+      type: "session.idle",
+      properties: { sessionID: "ses_child" },
+    };
+    expect(tracker.handleEvent(idleEvent)).toBe(true);
+    expect(tracker.list()[0]?.status).toBe("idle");
+
+    // No change -> no re-emit.
+    expect(tracker.handleEvent(idleEvent)).toBe(false);
+  });
+
+  it("marks a child as error on session.error and removes it on session.deleted", () => {
+    const tracker = new OpenCodeSubsessionTracker(ROOT);
+    tracker.handleEvent(sessionCreated("ses_child", ROOT));
+
+    const errorEvent: OpenCodeEvent = {
+      id: "evt_err",
+      type: "session.error",
+      properties: { sessionID: "ses_child" },
+    };
+    expect(tracker.handleEvent(errorEvent)).toBe(true);
+    expect(tracker.list()[0]?.status).toBe("error");
+
+    const deletedEvent: OpenCodeEvent = {
+      id: "evt_del",
+      type: "session.deleted",
+      properties: { sessionID: "ses_child", info: makeSession("ses_child", ROOT) },
+    };
+    expect(tracker.handleEvent(deletedEvent)).toBe(true);
+    expect(tracker.list()).toEqual([]);
+  });
+
+  it("removes descendants when a parent subsession is deleted", () => {
+    const tracker = new OpenCodeSubsessionTracker(ROOT);
+    tracker.handleEvent(sessionCreated("ses_child", ROOT));
+    tracker.handleEvent(sessionCreated("ses_grandchild", "ses_child"));
+    tracker.handleEvent(sessionCreated("ses_great_grandchild", "ses_grandchild"));
+
+    expect(
+      tracker.handleEvent({
+        id: "evt_del_parent",
+        type: "session.deleted",
+        properties: { sessionID: "ses_child", info: makeSession("ses_child", ROOT) },
+      }),
+    ).toBe(true);
+    expect(tracker.list()).toEqual([]);
+  });
+
+  it("picks up a late title via session.updated without resetting status", () => {
+    const tracker = new OpenCodeSubsessionTracker(ROOT);
+    tracker.handleEvent(sessionCreated("ses_child", ROOT));
+    tracker.handleEvent(sessionStatus("ses_child", "idle"));
+
+    expect(tracker.handleEvent(sessionUpdated("ses_child", ROOT, "Summarized title"))).toBe(true);
+    expect(tracker.list()).toEqual([
+      { id: "ses_child", title: "Summarized title", status: "idle", parentSessionId: ROOT },
+    ]);
+  });
+
+  it("seeds enumerated children as idle without overriding event-derived state", () => {
+    const tracker = new OpenCodeSubsessionTracker(ROOT);
+    tracker.handleEvent(sessionCreated("ses_live", ROOT));
+
+    const changed = tracker.seed([
+      { id: "ses_live", title: "Live child", parentSessionId: ROOT },
+      { id: "ses_persisted", title: "Old child", parentSessionId: ROOT },
+      { id: ROOT, title: "Root itself", parentSessionId: null },
+    ]);
+
+    expect(changed).toBe(true);
+    expect(tracker.list()).toEqual([
+      // Status from the live event stream wins; seed only fills the title.
+      { id: "ses_live", title: "Live child", status: "running", parentSessionId: ROOT },
+      { id: "ses_persisted", title: "Old child", status: "idle", parentSessionId: ROOT },
+    ]);
+  });
+});

--- a/packages/server/src/server/agent/providers/opencode/subsessions.ts
+++ b/packages/server/src/server/agent/providers/opencode/subsessions.ts
@@ -1,0 +1,146 @@
+import type { Event as OpenCodeEvent } from "@opencode-ai/sdk/v2/client";
+import type { AgentSubsession } from "../../agent-sdk-types.js";
+
+/** Hard cap so a runaway session tree cannot grow tracker memory unbounded. */
+const MAX_TRACKED_SUBSESSIONS = 100;
+
+export interface OpenCodeSubsessionSeed {
+  id: string;
+  title: string | null;
+  parentSessionId: string | null;
+}
+
+/**
+ * Tracks an agent's native OpenCode subsessions (child sessions) from the
+ * `/global/event` stream. A subsession is just a session whose `parentID`
+ * chain reaches the agent's root session: it has its own live status and
+ * stays tracked until the provider deletes it.
+ *
+ * Deliberately separate from the per-turn translation state: subsession
+ * activity keeps flowing between turns (a background child keeps running
+ * after the parent's turn ends), so tracking must live at session scope and
+ * be fed before the no-active-turn gate drops events.
+ */
+export class OpenCodeSubsessionTracker {
+  private readonly subsessions = new Map<string, AgentSubsession>();
+
+  constructor(private readonly rootSessionId: string) {}
+
+  /**
+   * Ingest sessions enumerated from the children endpoint (create/resume
+   * hydration). Event-derived state wins: seeding never overwrites the status
+   * of an already-tracked subsession.
+   */
+  seed(seeds: readonly OpenCodeSubsessionSeed[]): boolean {
+    let changed = false;
+    for (const seed of seeds) {
+      if (seed.id === this.rootSessionId) continue;
+      const existing = this.subsessions.get(seed.id);
+      if (existing) {
+        if (existing.title === null && seed.title !== null) {
+          this.subsessions.set(seed.id, { ...existing, title: seed.title });
+          changed = true;
+        }
+        continue;
+      }
+      if (this.subsessions.size >= MAX_TRACKED_SUBSESSIONS) continue;
+      this.subsessions.set(seed.id, {
+        id: seed.id,
+        title: seed.title,
+        status: "idle",
+        parentSessionId: seed.parentSessionId,
+      });
+      changed = true;
+    }
+    return changed;
+  }
+
+  /** Returns true when the tracked list changed and should be re-emitted. */
+  handleEvent(event: OpenCodeEvent): boolean {
+    switch (event.type) {
+      case "session.created":
+      case "session.updated":
+        return this.upsertFromSessionInfo(event.properties.info, event.type === "session.created");
+      case "session.status": {
+        const status = event.properties.status.type === "idle" ? "idle" : "running";
+        return this.setStatus(event.properties.sessionID, status);
+      }
+      case "session.idle":
+        return this.setStatus(event.properties.sessionID, "idle");
+      case "session.error": {
+        const sessionId = event.properties.sessionID;
+        return sessionId === undefined ? false : this.setStatus(sessionId, "error");
+      }
+      case "session.deleted":
+        return this.deleteSubtree(event.properties.sessionID);
+      default:
+        return false;
+    }
+  }
+
+  list(): AgentSubsession[] {
+    return [...this.subsessions.values()];
+  }
+
+  private upsertFromSessionInfo(
+    info: { id: string; parentID?: string; title: string },
+    isCreated: boolean,
+  ): boolean {
+    const parentSessionId = info.parentID ?? null;
+    if (parentSessionId === null) {
+      // Roots are never subsessions of anything.
+      return false;
+    }
+    const existing = this.subsessions.get(info.id);
+    if (!existing) {
+      const isKnownParent =
+        parentSessionId === this.rootSessionId || this.subsessions.has(parentSessionId);
+      if (!isKnownParent) {
+        // Belongs to some other agent's session tree.
+        return false;
+      }
+      if (this.subsessions.size >= MAX_TRACKED_SUBSESSIONS) {
+        return false;
+      }
+      this.subsessions.set(info.id, {
+        id: info.id,
+        title: normalizeSubsessionTitle(info.title),
+        // A freshly created child was spawned to do work; an update for a
+        // session we have not seen yet carries no activity signal.
+        status: isCreated ? "running" : "idle",
+        parentSessionId,
+      });
+      return true;
+    }
+    const title = normalizeSubsessionTitle(info.title) ?? existing.title;
+    if (title !== existing.title || parentSessionId !== existing.parentSessionId) {
+      this.subsessions.set(info.id, { ...existing, title, parentSessionId });
+      return true;
+    }
+    return false;
+  }
+
+  private setStatus(sessionId: string, status: AgentSubsession["status"]): boolean {
+    const existing = this.subsessions.get(sessionId);
+    if (!existing || existing.status === status) {
+      return false;
+    }
+    this.subsessions.set(sessionId, { ...existing, status });
+    return true;
+  }
+
+  private deleteSubtree(sessionId: string): boolean {
+    let changed = this.subsessions.delete(sessionId);
+    for (const [candidateId, sub] of this.subsessions) {
+      if (sub.parentSessionId === sessionId) {
+        changed = this.deleteSubtree(candidateId) || changed;
+      }
+    }
+    return changed;
+  }
+}
+
+function normalizeSubsessionTitle(title: string | null | undefined): string | null {
+  const normalized = title?.trim();
+  return normalized ? normalized : null;
+}

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2620,11 +2620,19 @@ export class Session {
       if (!normalized.cwd) {
         throw new Error("Import requires cwd from the selected provider session");
       }
-      // An imported agent mints its own workspace; ownership is its workspaceId,
-      // never an existing same-cwd workspace resolved by path.
-      const workspace = await this.workspaceProvisioning.createWorkspaceForDirectory(
-        normalized.cwd,
-      );
+      // A subsession dive imports into the workspace the caller supplies (the
+      // owning agent's workspace). A plain import (Import-session sheet) mints
+      // its own workspace; ownership is its workspaceId, never an existing
+      // same-cwd workspace resolved by path.
+      const requestedWorkspace = normalized.workspaceId
+        ? await this.workspaceRegistry.get(normalized.workspaceId)
+        : null;
+      if (normalized.workspaceId && !requestedWorkspace) {
+        throw new Error(`Workspace ${normalized.workspaceId} not found`);
+      }
+      const workspace =
+        requestedWorkspace ??
+        (await this.workspaceProvisioning.createWorkspaceForDirectory(normalized.cwd));
       const { snapshot, timelineSize } = await importProviderSession({
         request: normalized,
         workspaceId: workspace.workspaceId,
@@ -2632,7 +2640,9 @@ export class Session {
         agentStorage: this.agentStorage,
         logger: this.sessionLogger,
       });
-      await this.registerWorkspaceForImportedAgent(workspace);
+      if (!requestedWorkspace) {
+        await this.registerWorkspaceForImportedAgent(workspace);
+      }
       const agentPayload = await this.buildAgentPayload(snapshot);
       this.emit({
         type: "status",


### PR DESCRIPTION
### Linked issue

Closes #1809

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

When an OpenCode agent spawns native subagents (child sessions), they are only visible as `sub_agent` tool-calls inside that chat's timeline. There is no way to see *which subagents an agent has and what they are doing* from outside the chat.

This PR surfaces them outside the chat on three surfaces:

- **Agent list (History)** — an agent row with subsessions gets a disclosure chevron and a count badge; expanding reveals the subsessions as depth-indented leaf rows with **their own live status dots**, staying listed until the provider deletes them.
- **Workspaces sidebar** — a workspace row grows a chevron when any of its agents report subsessions; expanding renders the same tree as indented leaves.
- **In-chat subagents track** — the parent's subsessions appear as status rows alongside Paseo subagent rows; the header counts both (e.g. `5 subagents · 1 running`).

**Tapping a subsession opens it as its own session, as a tab beside its parent.** The first open imports the provider session through the existing `import_agent_request` flow (same path as the Import-session sheet), so the subsession becomes a full Paseo agent with its complete timeline and composer. `import_agent_request` gains an optional `workspaceId` (additive, old daemons strip it and fall back to cwd placement): the dive path passes the owning agent's workspace, so the imported agent joins that workspace and opens as a tab there instead of switching to a cwd-derived workspace — the sheet keeps its mint-a-workspace behavior. Subsequent opens focus that agent — it's matched via the agent's persistence handle (`persistence.sessionId`), and in-flight imports are shared across surfaces so double-clicks can't create duplicates.

The model follows OpenCode's own: a subagent is just a session with a `parentID` and its own activity status.

**Daemon (OpenCode provider)** — a session-scoped `OpenCodeSubsessionTracker` (`providers/opencode/subsessions.ts`):
- hydrates existing children on create/resume via the SDK's session children endpoint (BFS, capped), so the tree survives daemon restarts once the agent resumes;
- tracks live updates from the `/global/event` stream (`session.created/updated/status/idle/error/deleted`), keyed by known ancestor IDs so nesting works;
- runs **before** the provider's no-active-turn gate, because a background child keeps running (and reporting status) after the parent's turn ends;
- replays the current tree to late subscribers, closing the subscribe-timing race.

**Manager / protocol** — a new `subsessions_changed` stream event stores the list on the agent and emits state. Agent payloads gain an optional `subsessions` field (`{ id, title, status: running|idle|error, parentSessionId }`), marked `COMPAT(subsessions)`. Old clients strip the unknown field; old daemons never send it — absence naturally renders as "no subsessions", so no separate `server_info.features` flag is needed (happy to add one if preferred).

**App** — the History list renders the tree: disclosure chevron (separate pressable, doesn't navigate, a11y role/label/state), child-count badge, depth-indented leaves nested by `parentSessionId` (cycle-safe pure builder with tests), live status via the existing status-dot primitives. Tapping a leaf opens the subsession itself (import-or-focus via `useOpenSubsession`). New i18n keys (`subagents.toggle`, `subagents.fallbackTitle`, `subagents.openFailed`) added across all 8 locales. The sidebar and subagents track reuse the same pure tree builder, status primitives, and open behavior; both are store-driven, so `subsessions_changed` pushes update them live without a refresh.

Other providers: only OpenCode emits subsessions for now, but the event/payload/UI path is provider-neutral — Claude/Codex can adopt the same stream event later.

### How did you verify it

Automated:
- New unit tests: subsession tracker (created/nested/status/error/deleted/cascade-delete/seed semantics), UI tree builder (depth, nesting, cycles), store selectors (per-agent subsessions incl. the `agentDetails` fallback, per-workspace subsession agents), track header-label counts, and the import-dedupe finder (`findAgentIdForProviderSession`) — focused suites green, i18n parity suite green
- `npm run typecheck` — pass across all workspaces; `npm run lint` — 0/0 on all 24 changed files; `npm run format` clean (all enforced again by the pre-commit hook)

Manual, end-to-end against a real OpenCode agent on the dev daemon (web, Chromium):
1. Asked a real agent to launch native subagents (foreground + `run_in_background`) via its own subagent tooling.
2. Verified ground truth at each layer: the OpenCode server's `/session/:id/children` returns the children with `parentID`; daemon trace shows `subsessions_changed` flowing session → manager (`handle_stream_event`) → `emitState`; a raw `@getpaseo/client` probe confirmed `fetch_agents_response` carries `subsessions` on the wire.
3. UI: the agent row shows the chevron + count; expanding lists every subsession with its real title.
4. Dive-in: clicked a subsession leaf in the sidebar — it imported the child session and opened it as a full agent tab showing the subagent's own conversation; clicking the same subsession from the parent's in-chat track focused the same agent (a wire probe confirmed exactly one agent bound to the session id, no duplicate import).

Collapsed (chevron + count on the clean `Subagent demo` agent; the sidebar shows the same tree under the workspace row):

![collapsed](https://raw.githubusercontent.com/omercnet/paseo/pr-assets/assets/qa-sub-01-collapsed.png)

Expanded — the native OpenCode subsessions as leaves, in History and in the sidebar:

![expanded](https://raw.githubusercontent.com/omercnet/paseo/pr-assets/assets/qa-sub-02-expanded.png)

**Live status from outside the chat** — a freshly launched background subagent (`demo-active2`) showing its running dot in both surfaces while its finished siblings sit idle:

![running](https://raw.githubusercontent.com/omercnet/paseo/pr-assets/assets/qa-sub-03-running.png)

**Workspaces sidebar tree** — chevron on the workspace row, subsession leaves nested under it; the freshly launched `demo-active2` subagent shows its running dot live (no refresh):

![sidebar](https://raw.githubusercontent.com/omercnet/paseo/pr-assets/assets/qa-sub-05-sidebar-running.png)

**In-chat subagents track** — the header counts subsessions (`5 subagents · 1 running`) and the rows expand above the composer:

![track](https://raw.githubusercontent.com/omercnet/paseo/pr-assets/assets/qa-sub-04-track-expanded.png)

Platform coverage: verified on **web** (desktop + compact widths). Not tested on native iOS/Android (no simulator available here); the UI reuses existing cross-platform list/status primitives, but native needs a real check before merge.

Known behavior notes:
- After a daemon restart, subsessions reappear when the agent's session resumes (they are hydrated from the provider, not persisted in the agent record).
- The History screen refreshes subsessions with its normal fetch/refresh cycle; store-driven surfaces get them on every agent state emit.

### Checklist

- [x] One focused change. Unrelated cleanups split out. (screenshots hosted on a separate branch, not in this diff)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform — **web included; native iOS/Android not captured**
- [x] Tests added or updated where it made sense




