### PR TITLE
feat(app): support foldable phones with correct form factor detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20100,6 +20100,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/expo-screen-orientation": {
+      "version": "9.0.9",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/expo-screen-orientation/-/expo-screen-orientation-9.0.9.tgz",
+      "integrity": "sha512-UTU745XoqBvQJkZ820GTfMuOxlkppYqaeQ+x0wdu44cyrZiZugqe+egFF2+zC+SaxgAltU5EuO8GIj9xSF+YMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-server": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.5.tgz",
@@ -35180,6 +35190,7 @@
         "expo-localization": "~17.0.9",
         "expo-notifications": "^0.32.16",
         "expo-router": "~6.0.13",
+        "expo-screen-orientation": "~9.0.9",
         "expo-sharing": "^14.0.8",
         "expo-splash-screen": "~31.0.10",
         "expo-system-ui": "~6.0.7",

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -51,7 +51,10 @@ export default {
     name: variant.name,
     slug: "voice-mobile",
     version: pkg.version,
-    orientation: "portrait",
+    // Static lock removed so foldables/tablets can rotate into landscape.
+    // Per-device orientation is controlled at runtime by useAdaptiveOrientation:
+    // phones stay portrait, large-screen/unfolded devices unlock rotation.
+    orientation: "default",
     icon: "./assets/images/icon.png",
     scheme: "paseo",
     userInterfaceStyle: "automatic",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -77,6 +77,7 @@
     "expo-localization": "~17.0.9",
     "expo-notifications": "^0.32.16",
     "expo-router": "~6.0.13",
+    "expo-screen-orientation": "~9.0.9",
     "expo-sharing": "^14.0.8",
     "expo-splash-screen": "~31.0.10",
     "expo-system-ui": "~6.0.7",

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -77,6 +77,7 @@ import { useGlobalNewWorkspaceAction } from "@/hooks/use-global-new-workspace-ac
 import { useFaviconStatus } from "@/hooks/use-favicon-status";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { KeyboardShiftProvider } from "@/hooks/use-keyboard-shift-style";
+import { useAdaptiveOrientation } from "@/hooks/use-adaptive-orientation";
 import { useCompactWebViewportZoomLock } from "@/hooks/use-compact-web-viewport-zoom-lock";
 import { useOpenProject } from "@/hooks/use-open-project";
 import { useAppSettings } from "@/hooks/use-settings";
@@ -438,6 +439,7 @@ function AppContainer({
 
   const isCompactLayout = useIsCompactFormFactor();
   useCompactWebViewportZoomLock(isCompactLayout);
+  useAdaptiveOrientation();
   const pathname = usePathname();
   const chromeEnabled = chromeEnabledOverride ?? daemons.length > 0;
   const toggleAgentList = isCompactLayout ? toggleMobileAgentList : toggleDesktopAgentList;

--- a/packages/app/src/constants/form-factor.test.ts
+++ b/packages/app/src/constants/form-factor.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  LARGE_SCREEN_MIN_SHORTEST_SIDE,
+  computeIsCompactFormFactor,
+  isLargeScreenShortestSide,
+} from "./form-factor";
+
+describe("isLargeScreenShortestSide", () => {
+  it("treats the threshold shortest side as large-screen", () => {
+    expect(isLargeScreenShortestSide(LARGE_SCREEN_MIN_SHORTEST_SIDE)).toBe(true);
+  });
+
+  it("treats one dp below the threshold as not large-screen", () => {
+    expect(isLargeScreenShortestSide(LARGE_SCREEN_MIN_SHORTEST_SIDE - 1)).toBe(false);
+  });
+
+  it("treats a typical phone shortest side as small", () => {
+    expect(isLargeScreenShortestSide(390)).toBe(false);
+  });
+
+  it("treats an unfolded foldable shortest side as large", () => {
+    expect(isLargeScreenShortestSide(760)).toBe(true);
+  });
+});
+
+describe("computeIsCompactFormFactor", () => {
+  it("stays compact single-pane for a phone in portrait (narrow breakpoint, small screen, native)", () => {
+    expect(
+      computeIsCompactFormFactor({ compactBreakpoint: true, largeScreenForm: false, native: true }),
+    ).toBe(true);
+  });
+
+  it("goes two-pane for an unfolded foldable in portrait (narrow breakpoint, large screen, native)", () => {
+    expect(
+      computeIsCompactFormFactor({ compactBreakpoint: true, largeScreenForm: true, native: true }),
+    ).toBe(false);
+  });
+
+  it("goes two-pane for a wide breakpoint (tablet or large window)", () => {
+    expect(
+      computeIsCompactFormFactor({ compactBreakpoint: false, largeScreenForm: true, native: true }),
+    ).toBe(false);
+  });
+
+  it("stays compact on web/desktop for a narrow tall window despite a large physical screen", () => {
+    expect(
+      computeIsCompactFormFactor({ compactBreakpoint: true, largeScreenForm: true, native: false }),
+    ).toBe(true);
+  });
+});

--- a/packages/app/src/constants/form-factor.ts
+++ b/packages/app/src/constants/form-factor.ts
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------------
+// Foldable / large-screen form-factor logic (pure, framework-free).
+//
+// Kept separate from constants/layout.ts so it can be unit-tested without
+// pulling in Unistyles or platform modules. The hooks in layout.ts just wire
+// window dimensions + breakpoint + platform into these functions.
+// ---------------------------------------------------------------------------
+
+/**
+ * Usable-area shortest side (dp) at which we treat the device as a large-screen
+ * form factor (tablet or an unfolded foldable/tri-fold).
+ *
+ * 600 == Android's `sw600dp` tablet baseline, matching Pilot Kit's
+ * `device_utils.dart` (`shortestSide >= 600`). We compare the *shortest* side
+ * (min of width/height) rather than the current width so the result is
+ * orientation-insensitive and shrinks correctly under split-screen.
+ *
+ * TODO(fold): calibrate against a real Huawei Mate X / Mate XT unfolded state
+ * via `adb shell wm size` + density once hardware is available.
+ */
+export const LARGE_SCREEN_MIN_SHORTEST_SIDE = 600;
+
+/** Whether the usable-area shortest side reaches the large-screen threshold. */
+export function isLargeScreenShortestSide(shortestSide: number): boolean {
+  return shortestSide >= LARGE_SCREEN_MIN_SHORTEST_SIDE;
+}
+
+/**
+ * Decide whether to use the compact (phone, single-pane) layout.
+ *
+ * - web/desktop: breakpoint (window width) only — existing behavior preserved.
+ * - native: an unfolded foldable in a large-screen form factor uses the
+ *   two-pane layout even when the window is narrow (portrait), so a phone
+ *   stays compact while a tri-fold expands into tablet layout.
+ */
+export function computeIsCompactFormFactor(args: {
+  compactBreakpoint: boolean;
+  largeScreenForm: boolean;
+  native: boolean;
+}): boolean {
+  return args.compactBreakpoint && !(args.native && args.largeScreenForm);
+}

--- a/packages/app/src/constants/form-factor.ts
+++ b/packages/app/src/constants/form-factor.ts
@@ -15,8 +15,7 @@
  * (min of width/height) rather than the current width so the result is
  * orientation-insensitive and shrinks correctly under split-screen.
  *
- * TODO(fold): calibrate against a real Huawei Mate X / Mate XT unfolded state
- * via `adb shell wm size` + density once hardware is available.
+ * Verified against Resizable AVD at real Huawei Mate XT densities.
  */
 export const LARGE_SCREEN_MIN_SHORTEST_SIDE = 600;
 

--- a/packages/app/src/constants/layout.ts
+++ b/packages/app/src/constants/layout.ts
@@ -1,5 +1,7 @@
+import { useWindowDimensions } from "react-native";
 import { useUnistyles } from "react-native-unistyles";
-import { isWeb } from "@/constants/platform";
+import { computeIsCompactFormFactor, isLargeScreenShortestSide } from "@/constants/form-factor";
+import { isNative, isWeb } from "@/constants/platform";
 
 export const FOOTER_HEIGHT = 75;
 
@@ -30,12 +32,31 @@ export {
 } from "./platform";
 
 /**
+ * Reactive hook — true when the device is in a large-screen form factor
+ * (tablet, or an unfolded foldable/tri-fold). Uses the usable-area shortest
+ * side so it is orientation-insensitive and shrinks under split-screen.
+ * Re-renders when window dimensions change (fold/unfold, rotate, resize).
+ */
+export function useIsLargeScreenForm(): boolean {
+  const { width, height } = useWindowDimensions();
+  return isLargeScreenShortestSide(Math.min(width, height));
+}
+
+/**
  * Reactive hook — re-renders the component when the breakpoint changes.
  * Always use this instead of reading UnistylesRuntime.breakpoint directly.
+ *
+ * On native, an unfolded foldable in a large-screen form factor stays
+ * two-pane even while portrait (narrow window); a phone stays compact.
  */
 export function useIsCompactFormFactor(): boolean {
   const { rt } = useUnistyles();
-  return rt.breakpoint === "xs" || rt.breakpoint === "sm";
+  const isLargeScreen = useIsLargeScreenForm();
+  return computeIsCompactFormFactor({
+    compactBreakpoint: rt.breakpoint === "xs" || rt.breakpoint === "sm",
+    largeScreenForm: isLargeScreen,
+    native: isNative,
+  });
 }
 
 // SplitContainer relies on dnd-kit and DOM-backed accessibility helpers.

--- a/packages/app/src/hooks/use-adaptive-orientation.ts
+++ b/packages/app/src/hooks/use-adaptive-orientation.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import * as ScreenOrientation from "expo-screen-orientation";
+import { useIsLargeScreenForm } from "@/constants/layout";
+import { isNative } from "@/constants/platform";
+
+/**
+ * Locks phones to portrait, and unlocks rotation once the device is in a
+ * large-screen form factor (tablet, or an unfolded foldable/tri-fold) so it
+ * can rotate into landscape tablet layout.
+ *
+ * Native only — the web/desktop build has no screen-orientation lock. Tracks
+ * `useIsLargeScreenForm()` (usable-area shortest side) so folding/unfolding
+ * re-applies the correct lock automatically.
+ */
+export function useAdaptiveOrientation(): void {
+  const isLargeScreen = useIsLargeScreenForm();
+
+  useEffect(() => {
+    if (!isNative) {
+      return;
+    }
+    if (isLargeScreen) {
+      void ScreenOrientation.unlockAsync();
+    } else {
+      void ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+    }
+  }, [isLargeScreen]);
+}


### PR DESCRIPTION
The current version does not support foldable phones. In a dual-fold state, it cannot be correctly recognized as tablet mode. In a triple-fold state, it is recognized as a phone and converted to portrait mode. The correct behavior should be to properly detect the user's device form factor changes and use the correct phone or tablet mode.

- Drop the static portrait lock (orientation: "default") and control orientation at runtime via a new useAdaptiveOrientation hook backed by expo-screen-orientation: lockAsync(PORTRAIT_UP) on phones, unlockAsync on large-screen/unfolded devices.
- Add form-factor.ts pure logic keyed off the usable-area shortest side (>=600dp): orientation-insensitive and split-screen safe.
- useIsCompactFormFactor now exempts native large-screen forms so an unfolded device stays two-pane while portrait; web/desktop unchanged.

Verified on two Android foldable emulators (Pixel 9 Pro Fold + Resizable):
- Layout follows real Huawei Mate XT tri-fold sizes (single 350dp single-pane; dual 712dp and triple 776dp two-pane tablet).
- Orientation on real fold events: unfolded unlocks rotation, folded locks portrait.

Scope: Android foldables/large screens. Pure-HarmonyOS (NEXT) devices can't run the Android apk and are out of scope.

<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
-->

### Linked issue

Closes #1861

<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

<!-- A short description of the change in your own words. What was wrong, what you changed, why it works. If you can't explain this briefly, the PR is probably too big. -->

The current version does not support foldable phones. In a dual-fold state, it
cannot be correctly recognized as tablet mode. In a triple-fold state, it is
recognized as a phone and converted to portrait mode. The correct behavior
should be to properly detect the user's device form factor changes and use the
correct phone or tablet mode.

Two root causes:
- `app.config.js` hard-locked `orientation: "portrait"` globally, so the app
  could never rotate even on a large unfolded screen.
- `useIsCompactFormFactor` keyed the compact (single-pane) layout off the
  current window *width*. An unfolded-but-portrait device is a narrow window, so
  it stayed in phone layout.

The fix makes form factor a runtime, per-device decision driven by one signal —
the usable-area **shortest side** (`min(width, height)`), which is
orientation-insensitive and shrinks correctly under split-screen:

- **Orientation** (`useAdaptiveOrientation`, native-only, via
  `expo-screen-orientation`): phones `lockAsync(PORTRAIT_UP)`; large-screen /
- **Layout**: `useIsCompactFormFactor` now exempts native large-screen forms, so
  an unfolded device is two-pane even while portrait. Web/desktop are unchanged
  (the exemption is native-gated).
- Decision logic lives in a small pure module (`form-factor.ts`) with unit
  tests; the hooks are just wiring. Threshold is `600dp` (Android `sw600dp`).

### How did you verify it

<!--
This is the section I read most carefully. I need to see that *you* tested this, not that the diff looks plausible.

- For UI changes: a screenshot or short video on every affected platform (mobile, web, desktop). UI claims without visual proof are not enough.
- For behavior changes: the actual steps you ran, and what you observed.
- For bug fixes: how you reproduced the bug before, and confirmed it's fixed after.

AI-generated PR descriptions are fine in principle. AI-generated *verification claims* with no actual testing behind them are not, and they're easy to spot.
-->

**Unit tests:** 8 new tests over the pure form-factor logic (threshold boundary,
the native large-screen exemption, and the web/desktop no-op path). All green.

**Real devices — two Android foldable emulators:**

*Pixel 9 Pro Fold* (real fold events via `device_state`):
- Folded (443dp): `requestedOrientation=PORTRAIT`, single-pane. Forcing landscape
  holds portrait — lock confirmed.
- Unfolded (852dp): `requestedOrientation=UNSPECIFIED`, two-pane tablet layout,
  even in portrait. 
  
*Resizable AVD in foldable mode*, with the display resized to real **Huawei Mate
XT tri-fold** form factors to check all three states:
| state  | size       | shortest side | layout        |
|--------|------------|---------------|---------------|
| single | 1008×2232  | 350dp         | single-pane   |
| dual   | 2048×2232  | 712dp         | two-pane      |
| triple | 3184×2232  | 776dp         | two-pane      |

Fold ⇄ unfold re-applies both orientation and layout live, on every transition.

**Scope of testing:** Android foldables only. Web/desktop behavior is unchanged
(native-gated exemption + unit-covered no-op path) but not separately captured.
Not tested on iOS. Pure-HarmonyOS (HarmonyOS NEXT) devices can't install an
Android apk, so they're out of scope.

<img width="1008" height="2232" alt="rz_single" src="https://github.com/user-attachments/assets/8a54d4f8-a2e7-4a08-966e-54d7d5e2b06f" />

**Single**

<img width="2048" height="2232" alt="rz_dual" src="https://github.com/user-attachments/assets/970d0cd8-bc47-4d6c-9d90-3cfbd6c6425b" />

**Dual**

<img width="3184" height="2232" alt="rz_triple" src="https://github.com/user-attachments/assets/75829af8-e8dc-4ea7-bcc3-3198d84e83eb" />

**Triple**

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots (Android foldable; web/desktop unaffected, iOS not tested)
- [x] Tests added or updated where it made sense
