### PR TITLE
fix: resolve real base branch for worktrees checked out from an existing branch

### DIFF
--- a/packages/server/src/server/paseo-worktree-service.test.ts
+++ b/packages/server/src/server/paseo-worktree-service.test.ts
@@ -424,13 +424,14 @@ test("does not mark checkout branch worktrees as eligible for first-agent rename
     createDeps(),
   );
 
+  // baseRefName must be the repo's default branch, not the checked-out branch
+  // itself — otherwise the diff panel compares the branch against itself and
+  // always shows no changes.
   expect(readPaseoWorktreeMetadata(created.worktree.worktreePath)).toMatchObject({
     version: 1,
-    baseRefName: "dev",
+    baseRefName: "main",
   });
-  // A checkout-branch worktree has no distinct base, so the workspace records a
-  // null baseBranch even though worktree.json's baseRefName is the branch itself.
-  expect(created.workspace.baseBranch).toBe(null);
+  expect(created.workspace.baseBranch).toBe("main");
   await expect(
     attemptFirstAgentBranchAutoName({
       cwd: created.worktree.worktreePath,

--- a/packages/server/src/server/paseo-worktree-service.ts
+++ b/packages/server/src/server/paseo-worktree-service.ts
@@ -72,7 +72,10 @@ export async function createPaseoWorktree(
     projectId: input.projectId,
     repoRoot: createdWorktree.repoRoot,
     worktree: createdWorktree.worktree,
-    baseBranch: resolveIntentBaseBranch(createdWorktree.intent),
+    baseBranch: resolveIntentBaseBranch(
+      createdWorktree.intent,
+      createdWorktree.worktree.worktreePath,
+    ),
     title: resolveFirstAgentPromptTitle(input.firstAgentContext),
     deps,
   });
@@ -200,15 +203,22 @@ function maybeMarkFirstAgentBranchAutoNameEligible(options: {
 }
 
 // The base branch is normalized to match worktree.json's baseRefName (origin/
-// stripped). checkout-branch worktrees have no distinct base, so they stay null.
-function resolveIntentBaseBranch(intent: WorktreeCreationIntent): string | null {
+// stripped). checkout-branch worktrees resolve their base at creation time
+// (see resolveWorktreeSourcePlan), so read it back from the metadata that was
+// just written rather than re-deriving it here.
+function resolveIntentBaseBranch(
+  intent: WorktreeCreationIntent,
+  worktreePath: string,
+): string | null {
   switch (intent.kind) {
     case "branch-off":
       return normalizeBaseRefName(intent.baseBranch);
     case "checkout-github-pr":
       return normalizeBaseRefName(intent.baseRefName);
-    case "checkout-branch":
-      return null;
+    case "checkout-branch": {
+      const metadata = readPaseoWorktreeMetadata(worktreePath);
+      return metadata ? normalizeBaseRefName(metadata.baseRefName) : null;
+    }
   }
 }
 

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -266,9 +266,12 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
         .trim();
       expect(currentBranch).toBe("dev");
 
+      // baseRefName must be the repo's default branch, not the checked-out branch
+      // itself — otherwise the diff panel compares the branch against itself and
+      // always shows no changes.
       const metadataPath = getPaseoWorktreeMetadataPath(result.worktreePath);
       const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
-      expect(metadata).toMatchObject({ version: 1, baseRefName: "dev" });
+      expect(metadata).toMatchObject({ version: 1, baseRefName: "main" });
     });
 
     it("checks out an existing local branch whose name contains uppercase letters and dots", async () => {

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -274,6 +274,27 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       expect(metadata).toMatchObject({ version: 1, baseRefName: "main" });
     });
 
+    it("falls back to the currently checked out branch when no default branch can be resolved", async () => {
+      // No origin remote and no local main/master — resolveRepositoryDefaultBranch
+      // can't find a default branch, so the fix must fall back to whatever is
+      // currently checked out in the main repo (here: "develop").
+      execFileSync("git", ["branch", "-m", "main", "develop"], { cwd: repoDir });
+      execFileSync("git", ["branch", "feature-x"], { cwd: repoDir });
+
+      const result = await createLegacyWorktreeForTest({
+        cwd: repoDir,
+        worktreeSlug: "feature-x-worktree",
+        source: { kind: "checkout-branch", branchName: "feature-x" },
+        runSetup: true,
+        paseoHome,
+      });
+
+      expect(existsSync(result.worktreePath)).toBe(true);
+      const metadataPath = getPaseoWorktreeMetadataPath(result.worktreePath);
+      const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
+      expect(metadata).toMatchObject({ version: 1, baseRefName: "develop" });
+    });
+
     it("checks out an existing local branch whose name contains uppercase letters and dots", async () => {
       execFileSync("git", ["branch", "release/1.1.15"], { cwd: repoDir });
 

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -26,6 +26,7 @@ import {
   writePaseoWorktreeRuntimeMetadata,
 } from "./worktree-metadata.js";
 import { runGitCommand } from "./run-git-command.js";
+import { resolveRepositoryDefaultBranch } from "./checkout-git.js";
 import { spawnProcess } from "./spawn.js";
 import { resolvePaseoHome } from "../server/paseo-home.js";
 import { createExternalProcessEnv } from "../server/paseo-env.js";
@@ -1299,9 +1300,13 @@ async function resolveWorktreeSourcePlan({
         throw new BranchAlreadyCheckedOutError(source.branchName);
       }
 
+      // The branch itself isn't a base to diff against — fall back to the
+      // repository's default branch so the diff panel has a real comparison target.
+      const defaultBranch = await resolveRepositoryDefaultBranch(cwd);
+
       return {
         branchName: source.branchName,
-        metadataBaseRefName: source.branchName,
+        metadataBaseRefName: defaultBranch ?? source.branchName,
         addArguments: [source.branchName],
       };
     }

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -26,7 +26,7 @@ import {
   writePaseoWorktreeRuntimeMetadata,
 } from "./worktree-metadata.js";
 import { runGitCommand } from "./run-git-command.js";
-import { resolveRepositoryDefaultBranch } from "./checkout-git.js";
+import { getCurrentBranch, resolveRepositoryDefaultBranch } from "./checkout-git.js";
 import { spawnProcess } from "./spawn.js";
 import { resolvePaseoHome } from "../server/paseo-home.js";
 import { createExternalProcessEnv } from "../server/paseo-env.js";
@@ -1300,13 +1300,9 @@ async function resolveWorktreeSourcePlan({
         throw new BranchAlreadyCheckedOutError(source.branchName);
       }
 
-      // The branch itself isn't a base to diff against — fall back to the
-      // repository's default branch so the diff panel has a real comparison target.
-      const defaultBranch = await resolveRepositoryDefaultBranch(cwd);
-
       return {
         branchName: source.branchName,
-        metadataBaseRefName: defaultBranch ?? source.branchName,
+        metadataBaseRefName: await resolveCheckoutBranchBaseRef(cwd, source.branchName),
         addArguments: [source.branchName],
       };
     }
@@ -1494,6 +1490,21 @@ function normalizeRequiredBaseBranch(baseBranch: string): string {
     throw new Error("Base branch cannot be HEAD when creating a Paseo worktree");
   }
   return normalizedBaseBranch;
+}
+
+// The checked-out branch itself isn't a base to diff against — resolve the
+// repository's default branch so the diff panel has a real comparison target.
+// If the default branch can't be determined (no origin/HEAD, no local
+// main/master — e.g. a local-only repo based on "develop"), fall back to
+// whichever branch is currently checked out in the main repo, since that's
+// almost always the branch this one was intended to be compared against.
+async function resolveCheckoutBranchBaseRef(cwd: string, branchName: string): Promise<string> {
+  const defaultBranch = await resolveRepositoryDefaultBranch(cwd);
+  if (defaultBranch) {
+    return defaultBranch;
+  }
+  const currentBranch = await getCurrentBranch(cwd);
+  return currentBranch && currentBranch !== branchName ? currentBranch : branchName;
 }
 
 async function resolveBaseBranchForWorktree(


### PR DESCRIPTION
Fixes #1873

## Problem

Creating a worktree by checking out an already-existing branch (rather than branching off `main`) causes the diff panel to always show "no changes" — even when the branch has real, unmerged commits.

## Root cause

`resolveWorktreeSourcePlan`'s `"checkout-branch"` case (`packages/server/src/utils/worktree.ts`) stored the worktree's `baseRefName` as the checked-out branch's **own name** instead of the repository's actual default branch:

```ts
metadataBaseRefName: source.branchName, // base == the branch itself
```

This value is persisted to `worktree.json` and later read back as the diff comparison base, so `base...HEAD` is always empty since base and HEAD are the same branch.

`branch-off` and `checkout-github-pr` worktrees were unaffected — they already resolve and store a real base branch.

## Fix

- `packages/server/src/utils/worktree.ts`: resolve the repository's default branch via the existing `resolveRepositoryDefaultBranch` helper (already used elsewhere for this exact purpose) and use it as `metadataBaseRefName`, falling back to the branch name only if no default branch can be determined.
- `packages/server/src/server/paseo-worktree-service.ts`: `resolveIntentBaseBranch` previously special-cased `checkout-branch` intents to always return `null` for the workspace's stored base branch. Since `worktree.json` now has a real base ref, this reads it back from the just-written metadata instead of hardcoding `null`.

## Testing

Updated the two existing tests that asserted the old (buggy) behavior, since they were pinning `baseRefName`/`baseBranch` to the checked-out branch itself:

- `packages/server/src/utils/worktree.posix.test.ts` — "checks out an existing local branch that is not checked out elsewhere"
- `packages/server/src/server/paseo-worktree-service.test.ts` — "does not mark checkout branch worktrees as eligible for first-agent rename"

Ran the following locally, all green:

```
npx vitest run src/utils/worktree.posix.test.ts --bail=1          # 42 passed | 1 skipped
npx vitest run src/server/paseo-worktree-service.test.ts --bail=1 # 16 passed
npx vitest run src/server/worktree-core.posix.test.ts src/server/resolve-worktree-creation-intent.test.ts src/server/session.workspaces.test.ts --bail=1
                                                                    # 109 passed | 4 skipped
npx vitest run src/server/agent/mcp-server.test.ts src/utils/checkout-git.test.ts --bail=1
                                                                    # 217 passed
```

Also ran `npm run typecheck`, `npm run lint`, and `npm run format` across the changed files — all clean.

No UI changes; this is a server-side data-correctness fix, so no screenshots.

## AI assistance

This PR was developed with AI assistance (Claude Code) after I hit the bug live in the desktop app, reproduced the root cause end-to-end against my own affected worktrees (confirmed via `git reflog`/`merge-base` that the "wrong" base was actually `main`), and reviewed/tested the resulting diff before opening this PR.