### PR TITLE
Stop new browser tabs from an agent stealing your focus

### DIFF
--- a/packages/app/src/browser-automation/handler.test.ts
+++ b/packages/app/src/browser-automation/handler.test.ts
@@ -250,7 +250,7 @@ describe("mountBrowserAutomationHandler", () => {
     useWorkspaceLayoutStore.setState({ layoutByWorkspace: {} });
   });
 
-  test("browser_new_tab creates and focuses a workspace browser tab", async () => {
+  test("browser_new_tab creates a workspace browser tab without stealing focus", async () => {
     const browser = new BrowserAutomationHandlerHarness();
     const workspaceKey = buildWorkspaceTabPersistenceKey({
       serverId: "server-1",
@@ -278,7 +278,7 @@ describe("mountBrowserAutomationHandler", () => {
     expect(layout?.root).toEqual(
       expect.objectContaining({
         kind: "pane",
-        pane: expect.objectContaining({ focusedTabId: openedTabs[0]?.tabId }),
+        pane: expect.objectContaining({ focusedTabId: previousFocusedTabId }),
       }),
     );
     expect(openedTabs[0]?.tabId).not.toBe(previousFocusedTabId);

--- a/packages/app/src/browser-automation/handler.test.ts
+++ b/packages/app/src/browser-automation/handler.test.ts
@@ -285,9 +285,7 @@ describe("mountBrowserAutomationHandler", () => {
     expect(browser.browser.registeredWorkspaceBrowsers).toEqual([
       { browserId: result.browserId, workspaceId: "wks_workspace_a" },
     ]);
-    expect(browser.browser.activeWorkspaceBrowsers).toEqual([
-      { browserId: result.browserId, workspaceId: "wks_workspace_a" },
-    ]);
+    expect(browser.browser.activeWorkspaceBrowsers).toEqual([]);
     expect(browser.resident.ensuredWebviews).toEqual([
       { browserId: result.browserId, url: "https://example.com" },
     ]);

--- a/packages/app/src/browser-automation/handler.ts
+++ b/packages/app/src/browser-automation/handler.ts
@@ -185,7 +185,6 @@ async function openBrowserTabForRequest(params: {
   });
 
   await browserHost?.registerWorkspaceBrowser?.({ browserId, workspaceId });
-  await browserHost?.setWorkspaceActiveBrowser?.({ browserId, workspaceId });
 
   if (browserHost?.executeAutomationCommand) {
     ensureResidentBrowserWebview({ browserId, url: normalizedUrl });

--- a/packages/app/src/browser-automation/handler.ts
+++ b/packages/app/src/browser-automation/handler.ts
@@ -179,7 +179,7 @@ async function openBrowserTabForRequest(params: {
       message: "Cannot create a browser tab without a workspace context.",
     });
   }
-  useWorkspaceLayoutStore.getState().openTabFocused(workspaceKey, {
+  useWorkspaceLayoutStore.getState().openTabInBackground(workspaceKey, {
     kind: "browser",
     browserId,
   });

--- a/packages/server/src/server/browser-tools/tools.ts
+++ b/packages/server/src/server/browser-tools/tools.ts
@@ -115,7 +115,7 @@ export function registerBrowserTools(options: RegisterBrowserToolsOptions): void
     {
       title: "Create browser tab",
       description:
-        "Create and focus a new Paseo desktop browser tab in this agent's workspace. Pass an http(s) URL or a scheme-less host URL, which is treated as http; the returned browserId is used by tab-scoped tools.",
+        "Create a new Paseo desktop browser tab in this agent's workspace, opened in the background without switching the user's view. Pass an http(s) URL or a scheme-less host URL, which is treated as http; the returned browserId is used by tab-scoped tools.",
       inputSchema: {
         url: BrowserHttpUrlInputSchema.optional(),
       },


### PR DESCRIPTION
## What changed

When an agent's `browser_new_tab` MCP tool call opened a new in-app browser tab, it switched the workspace view to that tab immediately — pulling focus away from whatever you were looking at (chat, terminal, another tab). Agent-opened tabs now open in the background instead: the tab is created and ready for the agent's follow-up automation calls (screenshot, click, snapshot, etc.), but your view stays put until you switch to it yourself.

Background tabs stay fully functional for automation — Paseo keeps browser webviews resident and paintable even when they're not the visible tab, so nothing about screenshotting or interacting with the page changes.

Opening a tab in the background also means it should not become the desktop app's "active" browser — that status is reserved for whatever tab the user is actually looking at, and it drives things like the Cmd/Ctrl+R Reload menu. The PR stops marking background tabs active so Reload keeps targeting whatever the user is really viewing instead of a hidden agent tab.

## How to verify beyond CI

- Manual check on the Electron desktop app: have an agent call `browser_new_tab` while you're focused on a chat or terminal tab, and confirm the view doesn't jump to the new browser tab. Then confirm `browser_screenshot`/`browser_click` etc. still work against that background tab.
- Manual check: with a background browser tab open from an agent, press Cmd/Ctrl+R while looking at a different tab and confirm it reloads what you're viewing (or the app window), not the hidden tab.
- CI covers the store-level (`openTabInBackground` doesn't move focus) and handler-level (MCP `new_tab` request wires to the background action, previous focus is preserved, active-browser registry is left untouched) behavior; the manual passes above are for the real Electron UI and native menu, which aren't exercised by these unit tests.

## Risk surface

- Electron-only feature (desktop browser automation) — no impact on iOS/Android/mobile web.