### PR TITLE
Let agents rename workspaces

### DIFF
--- a/docs/product.md
+++ b/docs/product.md
@@ -73,7 +73,7 @@ Anyone who builds software:
 - Built-in providers: Claude Code (Agent SDK), Codex (app-server), GitHub Copilot (ACP), OpenCode, Pi, OMP
 - One-click ACP provider catalog: CodeWhale, Cursor, Hermes, Qwen Coder, Kimi Code, and others — plus custom ACP providers
 - Voice mode: dictate prompts or talk through problems hands-free
-- MCP server exposes the daemon to other agents (create_agent, send_agent_prompt, schedules, terminals, worktrees)
+- MCP server exposes the daemon to other agents (create_agent, send_agent_prompt, schedules, terminals, worktrees, workspace renaming)
 - Scheduled agents (cron-style triggers) via app, CLI, and MCP
 - Frequent releases (multiple per week)
 - Community contributions across packaging, providers, and bug fixes

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -3135,6 +3135,118 @@ describe("rename_workspace MCP tool", () => {
     });
     expect(emittedWorkspaceIds).toEqual([["wks_parent"]]);
   });
+
+  it("rejects an explicit workspace outside the caller workspace", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const parentWorkspace = createPersistedWorkspaceRecord({
+      workspaceId: "wks_parent",
+      projectId: "proj_parent",
+      cwd: REPO_CWD,
+      kind: "local_checkout",
+      displayName: "main",
+      createdAt: "2026-07-03T09:00:00.000Z",
+      updatedAt: "2026-07-03T09:00:00.000Z",
+    });
+    const otherWorkspace = createPersistedWorkspaceRecord({
+      workspaceId: "wks_other",
+      projectId: "proj_other",
+      cwd: TARGET_CWD,
+      kind: "local_checkout",
+      displayName: "other",
+      createdAt: "2026-07-03T09:00:00.000Z",
+      updatedAt: "2026-07-03T09:00:00.000Z",
+    });
+    const workspaces = new Map([
+      [parentWorkspace.workspaceId, parentWorkspace],
+      [otherWorkspace.workspaceId, otherWorkspace],
+    ]);
+    const upsertedWorkspaces: PersistedWorkspaceRecord[] = [];
+    const emittedWorkspaceIds: string[][] = [];
+    spies.agentManager.getAgent.mockReturnValue(
+      createManagedAgent({
+        id: "parent-agent",
+        cwd: REPO_CWD,
+        workspaceId: parentWorkspace.workspaceId,
+      }),
+    );
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      workspaceRegistry: {
+        get: async (workspaceId) => workspaces.get(workspaceId) ?? null,
+        upsert: async (record) => {
+          upsertedWorkspaces.push(record);
+          workspaces.set(record.workspaceId, record);
+        },
+      },
+      emitWorkspaceUpdatesForWorkspaceIds: async (workspaceIds) => {
+        emittedWorkspaceIds.push(Array.from(workspaceIds));
+      },
+      callerAgentId: "parent-agent",
+      logger,
+    });
+    const tool = registeredTool(server, "rename_workspace");
+
+    await expect(
+      invokeToolWithParsedInput(tool, {
+        workspaceId: "wks_other",
+        title: "Payments flow",
+      }),
+    ).rejects.toThrow("Workspace wks_other is outside your current workspace");
+    expect(upsertedWorkspaces).toEqual([]);
+    expect(emittedWorkspaceIds).toEqual([]);
+  });
+
+  it("rejects archived workspaces", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const workspace = createPersistedWorkspaceRecord({
+      workspaceId: "wks_archived",
+      projectId: "proj_parent",
+      cwd: REPO_CWD,
+      kind: "local_checkout",
+      displayName: "main",
+      archivedAt: "2026-07-03T10:00:00.000Z",
+      createdAt: "2026-07-03T09:00:00.000Z",
+      updatedAt: "2026-07-03T10:00:00.000Z",
+    });
+    const workspaces = new Map([[workspace.workspaceId, workspace]]);
+    const upsertedWorkspaces: PersistedWorkspaceRecord[] = [];
+    const emittedWorkspaceIds: string[][] = [];
+    spies.agentManager.getAgent.mockReturnValue(
+      createManagedAgent({
+        id: "parent-agent",
+        cwd: REPO_CWD,
+        workspaceId: workspace.workspaceId,
+      }),
+    );
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      workspaceRegistry: {
+        get: async (workspaceId) => workspaces.get(workspaceId) ?? null,
+        upsert: async (record) => {
+          upsertedWorkspaces.push(record);
+          workspaces.set(record.workspaceId, record);
+        },
+      },
+      emitWorkspaceUpdatesForWorkspaceIds: async (workspaceIds) => {
+        emittedWorkspaceIds.push(Array.from(workspaceIds));
+      },
+      callerAgentId: "parent-agent",
+      logger,
+    });
+    const tool = registeredTool(server, "rename_workspace");
+
+    await expect(
+      invokeToolWithParsedInput(tool, {
+        title: "Payments flow",
+      }),
+    ).rejects.toThrow("Workspace wks_archived is archived");
+    expect(upsertedWorkspaces).toEqual([]);
+    expect(emittedWorkspaceIds).toEqual([]);
+  });
 });
 
 describe("create_schedule MCP tool", () => {

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -3136,7 +3136,7 @@ describe("rename_workspace MCP tool", () => {
     expect(emittedWorkspaceIds).toEqual([["wks_parent"]]);
   });
 
-  it("rejects an explicit workspace outside the caller workspace", async () => {
+  it("renames an explicit workspace outside the caller workspace", async () => {
     const { agentManager, agentStorage, spies } = createTestDeps();
     const parentWorkspace = createPersistedWorkspaceRecord({
       workspaceId: "wks_parent",
@@ -3188,14 +3188,24 @@ describe("rename_workspace MCP tool", () => {
     });
     const tool = registeredTool(server, "rename_workspace");
 
-    await expect(
-      invokeToolWithParsedInput(tool, {
-        workspaceId: "wks_other",
+    const response = await invokeToolWithParsedInput(tool, {
+      workspaceId: "wks_other",
+      title: "Payments flow",
+    });
+
+    expect(upsertedWorkspaces).toEqual([
+      {
+        ...otherWorkspace,
         title: "Payments flow",
-      }),
-    ).rejects.toThrow("Workspace wks_other is outside your current workspace");
-    expect(upsertedWorkspaces).toEqual([]);
-    expect(emittedWorkspaceIds).toEqual([]);
+        updatedAt: expect.any(String),
+      },
+    ]);
+    expect(response.structuredContent).toEqual({
+      success: true,
+      workspaceId: "wks_other",
+      title: "Payments flow",
+    });
+    expect(emittedWorkspaceIds).toEqual([["wks_other"]]);
   });
 
   it("rejects archived workspaces", async () => {

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -23,7 +23,11 @@ import {
   AgentPermissionRequestPayloadSchema,
   AgentSnapshotPayloadSchema,
 } from "@getpaseo/protocol/messages";
-import type { PersistedProjectRecord, PersistedWorkspaceRecord } from "../workspace-registry.js";
+import {
+  createPersistedWorkspaceRecord,
+  type PersistedProjectRecord,
+  type PersistedWorkspaceRecord,
+} from "../workspace-registry.js";
 import type {
   CreateScheduleInput,
   StoredSchedule,
@@ -3067,6 +3071,69 @@ describe("update_agent MCP tool", () => {
 
     expect(spies.agentStorage.get).not.toHaveBeenCalled();
     expect(spies.agentManager.updateAgentMetadata).not.toHaveBeenCalled();
+  });
+});
+
+describe("rename_workspace MCP tool", () => {
+  const logger = createTestLogger();
+
+  it("renames the caller workspace when workspaceId is omitted", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const workspace = createPersistedWorkspaceRecord({
+      workspaceId: "wks_parent",
+      projectId: "proj_parent",
+      cwd: REPO_CWD,
+      kind: "local_checkout",
+      displayName: "main",
+      createdAt: "2026-07-03T09:00:00.000Z",
+      updatedAt: "2026-07-03T09:00:00.000Z",
+    });
+    const workspaces = new Map([[workspace.workspaceId, workspace]]);
+    const upsertedWorkspaces: PersistedWorkspaceRecord[] = [];
+    const emittedWorkspaceIds: string[][] = [];
+    spies.agentManager.getAgent.mockReturnValue(
+      createManagedAgent({
+        id: "parent-agent",
+        cwd: REPO_CWD,
+        workspaceId: workspace.workspaceId,
+      }),
+    );
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      workspaceRegistry: {
+        get: async (workspaceId) => workspaces.get(workspaceId) ?? null,
+        upsert: async (record) => {
+          upsertedWorkspaces.push(record);
+          workspaces.set(record.workspaceId, record);
+        },
+      },
+      emitWorkspaceUpdatesForWorkspaceIds: async (workspaceIds) => {
+        emittedWorkspaceIds.push(Array.from(workspaceIds));
+      },
+      callerAgentId: "parent-agent",
+      logger,
+    });
+    const tool = registeredTool(server, "rename_workspace");
+
+    const response = await invokeToolWithParsedInput(tool, {
+      title: "  Payments flow  ",
+    });
+
+    expect(upsertedWorkspaces).toEqual([
+      {
+        ...workspace,
+        title: "Payments flow",
+        updatedAt: expect.any(String),
+      },
+    ]);
+    expect(response.structuredContent).toEqual({
+      success: true,
+      workspaceId: "wks_parent",
+      title: "Payments flow",
+    });
+    expect(emittedWorkspaceIds).toEqual([["wks_parent"]]);
   });
 });
 

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -65,6 +65,7 @@ import {
 } from "../lifecycle-command.js";
 import type { GitHubService } from "../../../services/github-service.js";
 import type { WorkspaceGitService } from "../../workspace-git-service.js";
+import type { WorkspaceRegistry } from "../../workspace-registry.js";
 import { WorktreeRequestError } from "../../worktree-errors.js";
 import {
   archiveCommand,
@@ -99,6 +100,7 @@ export interface PaseoToolHostDependencies {
   listActiveWorkspaces?: ArchiveDependencies["listActiveWorkspaces"];
   archiveWorkspaceRecord?: ArchiveDependencies["archiveWorkspaceRecord"];
   emitWorkspaceUpdatesForWorkspaceIds?: ArchiveDependencies["emitWorkspaceUpdatesForWorkspaceIds"];
+  workspaceRegistry?: Pick<WorkspaceRegistry, "get" | "upsert">;
   markWorkspaceArchiving?: ArchiveDependencies["markWorkspaceArchiving"];
   clearWorkspaceArchiving?: ArchiveDependencies["clearWorkspaceArchiving"];
   createPaseoWorktree?: CreatePaseoWorktreeWorkflowFn;
@@ -552,6 +554,24 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
     }
 
     return options.ensureWorkspaceForCreate(resolvedCwd);
+  }
+
+  function resolveWorkspaceIdForRename(requestedWorkspaceId?: string): string {
+    const explicitWorkspaceId = requestedWorkspaceId?.trim();
+    if (explicitWorkspaceId) {
+      return explicitWorkspaceId;
+    }
+
+    const callerAgent = resolveCallerAgent();
+    if (callerAgent?.workspaceId) {
+      return callerAgent.workspaceId;
+    }
+
+    throw new Error(
+      callerAgentId
+        ? `Caller agent ${callerAgentId} has no current workspace`
+        : "workspaceId is required outside an agent-scoped session",
+    );
   }
 
   const buildCallerAgentScheduleConfigExtras = (
@@ -1777,6 +1797,63 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       return {
         content: [],
         structuredContent: ensureValidJson({ success: true }),
+      };
+    },
+  );
+
+  registerTool(
+    "rename_workspace",
+    {
+      title: "Rename workspace",
+      description:
+        "Rename a workspace by setting its user-visible title. Omit workspaceId to rename your current workspace.",
+      inputSchema: {
+        workspaceId: z
+          .string()
+          .trim()
+          .min(1)
+          .optional()
+          .describe("Workspace id to rename. Omit to rename your current workspace."),
+        title: z
+          .string()
+          .trim()
+          .min(1, "title is required")
+          .describe("New user-visible workspace title."),
+      },
+      outputSchema: {
+        success: z.boolean(),
+        workspaceId: z.string(),
+        title: z.string(),
+      },
+    },
+    async ({ workspaceId: requestedWorkspaceId, title }) => {
+      if (!options.workspaceRegistry) {
+        throw new Error("Workspace registry is required to rename workspaces");
+      }
+      if (!options.emitWorkspaceUpdatesForWorkspaceIds) {
+        throw new Error("Workspace update emitter is required to rename workspaces");
+      }
+
+      const workspaceId = resolveWorkspaceIdForRename(requestedWorkspaceId);
+      const existing = await options.workspaceRegistry.get(workspaceId);
+      if (!existing) {
+        throw new Error(`Workspace ${workspaceId} not found`);
+      }
+
+      await options.workspaceRegistry.upsert({
+        ...existing,
+        title,
+        updatedAt: new Date().toISOString(),
+      });
+      await options.emitWorkspaceUpdatesForWorkspaceIds([workspaceId]);
+
+      return {
+        content: [],
+        structuredContent: ensureValidJson({
+          success: true,
+          workspaceId,
+          title,
+        }),
       };
     },
   );

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -558,20 +558,16 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
 
   function resolveWorkspaceIdForRename(requestedWorkspaceId?: string): string {
     const explicitWorkspaceId = requestedWorkspaceId?.trim();
+    if (explicitWorkspaceId) {
+      return explicitWorkspaceId;
+    }
+
     if (callerAgentId) {
       const callerAgent = resolveCallerAgent();
       if (!callerAgent?.workspaceId) {
         throw new Error(`Caller agent ${callerAgentId} has no current workspace`);
       }
-      const callerWorkspaceId = callerAgent.workspaceId;
-      if (explicitWorkspaceId && explicitWorkspaceId !== callerWorkspaceId) {
-        throw new Error(`Workspace ${explicitWorkspaceId} is outside your current workspace`);
-      }
-      return callerWorkspaceId;
-    }
-
-    if (explicitWorkspaceId) {
-      return explicitWorkspaceId;
+      return callerAgent.workspaceId;
     }
     throw new Error("workspaceId is required outside an agent-scoped session");
   }

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -558,20 +558,22 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
 
   function resolveWorkspaceIdForRename(requestedWorkspaceId?: string): string {
     const explicitWorkspaceId = requestedWorkspaceId?.trim();
+    if (callerAgentId) {
+      const callerAgent = resolveCallerAgent();
+      if (!callerAgent?.workspaceId) {
+        throw new Error(`Caller agent ${callerAgentId} has no current workspace`);
+      }
+      const callerWorkspaceId = callerAgent.workspaceId;
+      if (explicitWorkspaceId && explicitWorkspaceId !== callerWorkspaceId) {
+        throw new Error(`Workspace ${explicitWorkspaceId} is outside your current workspace`);
+      }
+      return callerWorkspaceId;
+    }
+
     if (explicitWorkspaceId) {
       return explicitWorkspaceId;
     }
-
-    const callerAgent = resolveCallerAgent();
-    if (callerAgent?.workspaceId) {
-      return callerAgent.workspaceId;
-    }
-
-    throw new Error(
-      callerAgentId
-        ? `Caller agent ${callerAgentId} has no current workspace`
-        : "workspaceId is required outside an agent-scoped session",
-    );
+    throw new Error("workspaceId is required outside an agent-scoped session");
   }
 
   const buildCallerAgentScheduleConfigExtras = (
@@ -1838,6 +1840,9 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       const existing = await options.workspaceRegistry.get(workspaceId);
       if (!existing) {
         throw new Error(`Workspace ${workspaceId} not found`);
+      }
+      if (existing.archivedAt) {
+        throw new Error(`Workspace ${workspaceId} is archived`);
       }
 
       await options.workspaceRegistry.upsert({

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -976,6 +976,7 @@ export async function createPaseoDaemon(
     listActiveWorkspaces: listActiveWorkspacesExternal,
     archiveWorkspaceRecord: archiveWorkspaceRecordExternal,
     emitWorkspaceUpdatesForWorkspaceIds: emitWorkspaceUpdatesExternal,
+    workspaceRegistry,
     markWorkspaceArchiving: markWorkspaceArchivingExternal,
     clearWorkspaceArchiving: clearWorkspaceArchivingExternal,
     ensureWorkspaceForCreate: ensureWorkspaceForCreateExternal,


### PR DESCRIPTION
### Linked issue

No matching GitHub issue found.

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Agents can now rename a workspace after they have enough context to choose a better title. The new `rename_workspace` tool sets the existing workspace title override, defaults to the calling agent's own workspace when `workspaceId` is omitted, and emits workspace updates so connected clients see the change.

This uses the existing workspace title field instead of adding a new naming path, so the behavior matches the app's workspace rename model.

Risk surface: this touches the agent tool catalog and workspace persistence. It does not add a wire protocol field, and it reuses the existing nullable workspace title storage; the main edge cases are missing caller workspace context, missing workspace records, and connected clients receiving the emitted workspace update.

### How did you verify it

- Confirmed the new TDD case failed first because `rename_workspace` was not registered.
- `npx vitest run packages/server/src/server/agent/mcp-server.test.ts -t "rename_workspace" --bail=1`
- `npx vitest run packages/server/src/server/agent/mcp-server.test.ts --bail=1`
- `npm run lint -- docs/product.md packages/server/src/server/agent/mcp-server.test.ts packages/server/src/server/agent/tools/paseo-tools.ts packages/server/src/server/bootstrap.ts`
- `npm run typecheck`
- `npm run format`

No UI screenshot is included because this changes the server-side agent tool surface, not app rendering.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense