### PR TITLE
Improve OMP and ACP interactive rendering

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1075,6 +1075,155 @@ describe("ACPAgentSession Zed parity", () => {
       outcome: { outcome: "selected", optionId: "allow-once" },
     });
   });
+  test("maps structured ACP question permission requests to question cards", async () => {
+    const session = createSessionWithConfig({
+      provider: "kimi-acp",
+      modeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    });
+    const events: AgentStreamEvent[] = [];
+    const permissionOptions: PermissionOption[] = [
+      { optionId: "submit", name: "Submit", kind: "allow_once" },
+      { optionId: "cancel", name: "Cancel", kind: "reject_once" },
+    ];
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    const permission = session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "question-1",
+        title: "Need input",
+        kind: "other",
+        status: "pending",
+        rawInput: {
+          questions: [
+            {
+              header: "Scope",
+              question: "What should the change include?",
+              options: [
+                { label: "Option A", description: "Small change" },
+                { label: "Option B", description: "Larger change" },
+              ],
+            },
+          ],
+        },
+      },
+      options: permissionOptions,
+    } satisfies RequestPermissionRequest);
+
+    await Promise.resolve();
+
+    const requested = events.find((event) => event.type === "permission_requested");
+    expect(requested).toMatchObject({
+      type: "permission_requested",
+      provider: "kimi-acp",
+      request: {
+        id: expect.any(String),
+        provider: "kimi-acp",
+        name: "Need input",
+        kind: "question",
+        title: "Need input",
+        input: {
+          questions: [
+            {
+              header: "Scope",
+              question: "What should the change include?",
+              options: [
+                { label: "Option A", description: "Small change" },
+                { label: "Option B", description: "Larger change" },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    await session.respondToPermission(requested!.request.id, {
+      behavior: "allow",
+      updatedInput: {
+        answers: {
+          Scope: "Option B",
+        },
+      },
+    });
+
+    await expect(permission).resolves.toEqual({
+      _meta: {
+        updatedInput: {
+          answers: {
+            Scope: "Option B",
+          },
+        },
+      },
+      outcome: { outcome: "selected", optionId: "submit" },
+    });
+  });
+
+  test("uses permission-time rawInput questions when a tool snapshot already exists", async () => {
+    const session = createSessionWithConfig({
+      provider: "kimi-acp",
+      modeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    });
+    const events: AgentStreamEvent[] = [];
+    const permissionOptions: PermissionOption[] = [
+      { optionId: "submit", name: "Submit", kind: "allow_once" },
+      { optionId: "cancel", name: "Cancel", kind: "reject_once" },
+    ];
+    const internals = asInternals<ACPSessionInternals>(session);
+
+    internals.sessionId = "session-1";
+    session.subscribe((event) => {
+      events.push(event);
+    });
+    internals.translateSessionUpdate({
+      sessionUpdate: "tool_call",
+      toolCallId: "question-1",
+      title: "Need input",
+      kind: "other",
+      status: "pending",
+    });
+
+    void session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "question-1",
+        title: "Need input",
+        kind: "other",
+        status: "pending",
+        rawInput: {
+          questions: [
+            {
+              header: "Scope",
+              question: "What should the change include?",
+              options: [{ label: "Option B", description: "Larger change" }],
+            },
+          ],
+        },
+      },
+      options: permissionOptions,
+    } satisfies RequestPermissionRequest);
+
+    await Promise.resolve();
+
+    expect(events.find((event) => event.type === "permission_requested")).toMatchObject({
+      type: "permission_requested",
+      request: {
+        kind: "question",
+        input: {
+          questions: [
+            {
+              header: "Scope",
+              question: "What should the change include?",
+              options: [{ label: "Option B", description: "Larger change" }],
+            },
+          ],
+        },
+      },
+    });
+  });
 
   test("maps Copilot Allow All mode to allow_all ACP config on session start", async () => {
     const setSessionConfigOption = vi.fn(async () => ({

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1225,6 +1225,121 @@ describe("ACPAgentSession Zed parity", () => {
     });
   });
 
+  test("keeps ACP mode approvals as mode when rawInput contains questions", async () => {
+    const session = createSessionWithConfig({
+      provider: "kimi-acp",
+      modeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    });
+    const events: AgentStreamEvent[] = [];
+    const permissionOptions: PermissionOption[] = [
+      { optionId: "allow", name: "Allow", kind: "allow_once" },
+      { optionId: "reject", name: "Reject", kind: "reject_once" },
+    ];
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    void session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "mode-1",
+        title: "Switch mode",
+        kind: "switch_mode",
+        status: "pending",
+        rawInput: {
+          questions: [
+            {
+              header: "Mode",
+              question: "Switch modes?",
+              options: [{ label: "Yes" }],
+            },
+          ],
+        },
+      },
+      options: permissionOptions,
+    } satisfies RequestPermissionRequest);
+
+    await Promise.resolve();
+
+    const requested = events.find((event) => event.type === "permission_requested");
+    expect(requested).toMatchObject({
+      type: "permission_requested",
+      request: {
+        kind: "mode",
+        detail: {
+          type: "plain_text",
+          label: "Switch mode",
+        },
+      },
+    });
+    if (requested?.type !== "permission_requested") {
+      throw new Error("Expected permission request");
+    }
+    expect(requested.request.input).toBeUndefined();
+  });
+
+  test("keeps typed ACP tool approvals as tools when rawInput contains questions", async () => {
+    const session = createSessionWithConfig({
+      provider: "kimi-acp",
+      modeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    });
+    const events: AgentStreamEvent[] = [];
+    const permissionOptions: PermissionOption[] = [
+      { optionId: "allow", name: "Allow", kind: "allow_once" },
+      { optionId: "reject", name: "Reject", kind: "reject_once" },
+    ];
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    void session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "edit-1",
+        title: "Edit file",
+        kind: "edit",
+        status: "pending",
+        rawInput: {
+          path: "src/example.ts",
+          oldString: "before",
+          newString: "after",
+          questions: [
+            {
+              header: "Edit",
+              question: "Which edit?",
+              options: [{ label: "A" }],
+            },
+          ],
+        },
+      },
+      options: permissionOptions,
+    } satisfies RequestPermissionRequest);
+
+    await Promise.resolve();
+
+    const requested = events.find((event) => event.type === "permission_requested");
+    expect(requested).toMatchObject({
+      type: "permission_requested",
+      request: {
+        kind: "tool",
+        detail: {
+          type: "edit",
+          filePath: "src/example.ts",
+          oldString: "before",
+          newString: "after",
+        },
+      },
+    });
+    if (requested?.type !== "permission_requested") {
+      throw new Error("Expected permission request");
+    }
+    expect(requested.request.input).toBeUndefined();
+  });
+
   test("maps Copilot Allow All mode to allow_all ACP config on session start", async () => {
     const setSessionConfigOption = vi.fn(async () => ({
       configOptions: [

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -3293,12 +3293,15 @@ function mapPermissionRequest(
   params: RequestPermissionRequest,
   snapshot: ACPToolSnapshot,
 ): AgentPermissionRequest {
-  const questionInput = parseACPQuestionInput(snapshot.rawInput);
+  const questionInput =
+    snapshot.kind === "other" || snapshot.kind == null
+      ? parseACPQuestionInput(snapshot.rawInput)
+      : null;
   let kind: AgentPermissionRequestKind = "tool";
-  if (questionInput) {
-    kind = "question";
-  } else if (snapshot.kind === "switch_mode") {
+  if (snapshot.kind === "switch_mode") {
     kind = "mode";
+  } else if (questionInput) {
+    kind = "question";
   }
   return {
     id: requestId,

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1918,16 +1918,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
     this.pendingPermissions.delete(requestId);
     const selectedOption = selectPermissionOption(pending.options, response);
-    pending.resolve(
-      selectedOption
-        ? {
-            outcome: {
-              outcome: "selected",
-              optionId: selectedOption.optionId,
-            },
-          }
-        : { outcome: { outcome: "cancelled" } },
-    );
+    pending.resolve(buildPermissionResponse(selectedOption, response));
 
     this.pushEvent({
       type: "permission_resolved",
@@ -2023,12 +2014,15 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
     // Match Zed acp.rs:3189-3220: generic ACP permission requests stay pure pass-through.
     const requestId = randomUUID();
-    let toolSnapshot =
-      this.toolCalls.get(params.toolCall.toolCallId) ??
-      mergeToolSnapshot(params.toolCall.toolCallId, params.toolCall);
+    let toolSnapshot = mergeToolSnapshot(
+      params.toolCall.toolCallId,
+      params.toolCall,
+      this.toolCalls.get(params.toolCall.toolCallId),
+    );
     if (this.toolSnapshotTransformer) {
       toolSnapshot = this.toolSnapshotTransformer(toolSnapshot);
     }
+    this.toolCalls.set(params.toolCall.toolCallId, toolSnapshot);
     const request = mapPermissionRequest(this.provider, requestId, params, toolSnapshot);
 
     const promise = new Promise<RequestPermissionResponse>((resolve, reject) => {
@@ -3219,26 +3213,126 @@ function extractTerminalContent(
   };
 }
 
+function parseACPQuestionOption(input: unknown): AgentMetadata | null {
+  const optionRecord = readRecord(input);
+  const label = readString(optionRecord, ["label"]);
+  if (!label) {
+    return null;
+  }
+  return {
+    label,
+    ...(typeof optionRecord?.description === "string"
+      ? { description: optionRecord.description }
+      : {}),
+  };
+}
+
+function parseACPQuestion(input: unknown): AgentMetadata | null {
+  const questionRecord = readRecord(input);
+  if (!questionRecord) {
+    return null;
+  }
+
+  const question = readString(questionRecord, ["question"]);
+  const header = readString(questionRecord, ["header"]);
+  const rawOptions = questionRecord.options;
+  if (!question || !header || !Array.isArray(rawOptions)) {
+    return null;
+  }
+
+  const options: AgentMetadata[] = [];
+  for (const option of rawOptions) {
+    const parsedOption = parseACPQuestionOption(option);
+    if (!parsedOption) {
+      return null;
+    }
+    options.push(parsedOption);
+  }
+
+  return {
+    question,
+    header,
+    options,
+    ...(questionRecord.multiSelect === true || questionRecord.multiple === true
+      ? { multiSelect: true }
+      : {}),
+    ...(questionRecord.allowOther === true || questionRecord.isOther === true
+      ? { allowOther: true }
+      : {}),
+    ...(questionRecord.allowEmpty === true ? { allowEmpty: true } : {}),
+    ...(typeof questionRecord.placeholder === "string"
+      ? { placeholder: questionRecord.placeholder }
+      : {}),
+    ...(typeof questionRecord.dismissLabel === "string"
+      ? { dismissLabel: questionRecord.dismissLabel }
+      : {}),
+  };
+}
+
+function parseACPQuestionInput(input: unknown): AgentMetadata | null {
+  const record = readRecord(input);
+  if (!Array.isArray(record?.questions)) {
+    return null;
+  }
+
+  const questions: AgentMetadata[] = [];
+  for (const item of record.questions) {
+    const question = parseACPQuestion(item);
+    if (!question) {
+      return null;
+    }
+    questions.push(question);
+  }
+
+  return questions.length > 0 ? { questions } : null;
+}
+
 function mapPermissionRequest(
   provider: string,
   requestId: string,
   params: RequestPermissionRequest,
   snapshot: ACPToolSnapshot,
 ): AgentPermissionRequest {
-  const kind: AgentPermissionRequestKind = snapshot.kind === "switch_mode" ? "mode" : "tool";
+  const questionInput = parseACPQuestionInput(snapshot.rawInput);
+  let kind: AgentPermissionRequestKind = "tool";
+  if (questionInput) {
+    kind = "question";
+  } else if (snapshot.kind === "switch_mode") {
+    kind = "mode";
+  }
   return {
     id: requestId,
     provider,
-    name: snapshot.kind ?? snapshot.title,
+    name: questionInput ? snapshot.title : (snapshot.kind ?? snapshot.title),
     kind,
     title: params.toolCall.title ?? snapshot.title,
-    detail: mapToolDetail(snapshot, new Map()),
+    ...(questionInput ? { input: questionInput } : { detail: mapToolDetail(snapshot, new Map()) }),
     metadata: {
       toolCallId: params.toolCall.toolCallId,
       rawRequest: params,
       options: params.options,
     },
   };
+}
+
+function buildPermissionResponse(
+  selectedOption: PermissionOption | null,
+  response: AgentPermissionResponse,
+): RequestPermissionResponse {
+  if (!selectedOption) {
+    return { outcome: { outcome: "cancelled" } };
+  }
+
+  const result: RequestPermissionResponse = {
+    outcome: {
+      outcome: "selected",
+      optionId: selectedOption.optionId,
+    },
+  };
+  if (response.behavior === "allow" && response.updatedInput) {
+    result._meta = { updatedInput: response.updatedInput };
+  }
+  return result;
 }
 
 function selectPermissionOption(

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -504,6 +504,52 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("collapses Pi custom skill payloads into a completed skill card", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    const skillPayload = [
+      "---",
+      "name: diagnose",
+      "description: Diagnose tricky failures.",
+      "---",
+      "# Diagnose",
+      "Find the root cause before proposing fixes.",
+      "x".repeat(8_000),
+    ].join("\n");
+
+    await session.startTurn("/skill:diagnose");
+    fakeSession.emit({
+      type: "message_end",
+      message: {
+        role: "custom",
+        content: [{ type: "text", text: skillPayload }],
+      },
+    });
+
+    expect(events.timelineAndCompletionEvents()).toEqual([
+      {
+        type: "timeline",
+        item: expect.objectContaining({
+          type: "tool_call",
+          name: "skill",
+          status: "completed",
+          detail: {
+            type: "plain_text",
+            label: "diagnose",
+            icon: "sparkles",
+            text: skillPayload,
+          },
+          error: null,
+        }),
+      },
+      { type: "turn_completed" },
+    ]);
+    expect(events.timelineItems()).not.toContainEqual({
+      type: "assistant_message",
+      text: skillPayload,
+    });
+  });
+
   test("adds Pi assistant context to generic provider finish errors", async () => {
     const { pi, session, events } = await createSession();
 

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -673,6 +673,52 @@ function optionalString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+const CUSTOM_SKILL_PAYLOAD_COLLAPSE_MIN_CHARS = 4_000;
+const SKILL_FILE_MARKER_PATTERN = /(?:^|\n)\/skill:(\S*SKILL\.md)\b/m;
+const SKILL_FRONTMATTER_NAME_PATTERN = /^---\s*\n(?:[^\n]*\n)*?name:\s*["']?([^"'\n]+)["']?/;
+
+function inferSkillNameFromPath(skillPath: string): string | null {
+  const parts = skillPath.split(/[\\/]+/).filter((part) => part.length > 0);
+  const filename = parts.at(-1)?.toLowerCase();
+  if (filename !== "skill.md") {
+    return null;
+  }
+  return parts.at(-2) ?? null;
+}
+
+function parseCustomSkillPayload(text: string): { name: string } | null {
+  if (text.length < CUSTOM_SKILL_PAYLOAD_COLLAPSE_MIN_CHARS) {
+    return null;
+  }
+  const pathMatch = SKILL_FILE_MARKER_PATTERN.exec(text);
+  const frontmatterName = SKILL_FRONTMATTER_NAME_PATTERN.exec(text)?.[1]?.trim();
+  const pathName = pathMatch?.[1] ? inferSkillNameFromPath(pathMatch[1]) : null;
+  const name = frontmatterName || pathName;
+  return name ? { name } : null;
+}
+
+function mapCustomMessageToTimelineItem(
+  text: string,
+): Extract<AgentStreamEvent, { type: "timeline" }>["item"] {
+  const skill = parseCustomSkillPayload(text);
+  if (!skill) {
+    return { type: "assistant_message", text };
+  }
+  return {
+    type: "tool_call",
+    callId: `custom-skill-${randomUUID()}`,
+    name: "skill",
+    status: "completed",
+    detail: {
+      type: "plain_text",
+      label: skill.name,
+      icon: "sparkles",
+      text,
+    },
+    error: null,
+  };
+}
+
 function parseExtensionMarkerPayload(
   message: string,
   marker: string,
@@ -1772,7 +1818,7 @@ export class PiRpcAgentSession implements AgentSession {
           type: "timeline",
           provider: PI_PROVIDER,
           turnId,
-          item: { type: "assistant_message", text },
+          item: mapCustomMessageToTimelineItem(text),
         });
       }
       this.completeTurn(turnId, []);


### PR DESCRIPTION
### Linked issue

Closes #1753
Refs #1726

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

This fixes two related interaction-rendering paths without changing provider execution semantics.

1. **ACP structured questions**

ACP providers can send structured question payloads in `requestPermission` tool-call `rawInput`, but Paseo mapped those requests to generic tool approval. The app then rendered the question JSON as raw tool input instead of the existing interactive question form.

This detects valid `{ questions: [...] }` payloads for ACP `other`/unknown tool snapshots, maps them to `kind: "question"` with `input.questions`, and carries submitted answers back to ACP in `_meta.updatedInput`. It also merges permission-time `toolCall` updates into any cached tool snapshot before classification, so pre-announced tool calls still render question cards when the permission request supplies the question payload.

Mode approvals and typed ACP tool approvals remain on their existing approval paths even if their `rawInput` includes a question-shaped field.

2. **OMP/Pi large skill payloads**

OMP can emit large injected skill bodies as Pi-compatible `role: "custom"` messages. Paseo previously rendered those directly as assistant messages, which floods the timeline for large skills.

This detects large skill-shaped custom payloads and emits a completed `skill` tool-call card with `plain_text` details instead. The full payload remains available behind the expandable tool card; normal small custom extension messages still render as assistant messages.

### Scope notes

- This helps OMP users who run through ACP/custom-provider mode for structured questions.
- It also addresses the large-skill timeline-flooding part of #1726 for built-in Pi/OMP RPC sessions.
- It does **not** claim to solve built-in OMP RPC structured Ask UI from #1726, because that path depends on OMP emitting UI/permission requests instead of falling back to prose questions.
- It does not duplicate #1446; provider snapshot reliability is already covered by #1314.

### How did you verify it

- Reproduced ACP direct structured-question bug with a failing regression test.
- Reproduced ACP cached-snapshot edge case with a failing regression test.
- Reproduced ACP mode/tool approval override review regressions with failing tests before the fix.
- Reproduced OMP/Pi large skill payload flooding with a failing regression test.
- `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1` — 73 passed
- `npx vitest run packages/server/src/server/agent/providers/pi/agent.test.ts packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1` — 108 passed
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run format:check` — passed

No visual UI code was changed; this reuses the existing question-card and expandable tool-call renderers.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense