### PR TITLE
Fix default bundled web UI path in packaged desktop CLI

### DIFF
--- a/packages/server/src/server/config-web-ui.test.ts
+++ b/packages/server/src/server/config-web-ui.test.ts
@@ -97,6 +97,7 @@ describe("daemon web UI config", () => {
         "server",
         "dist",
         "server",
+        "server",
         "config.js",
       ),
     );

--- a/packages/server/src/server/config-web-ui.test.ts
+++ b/packages/server/src/server/config-web-ui.test.ts
@@ -7,6 +7,9 @@ import { afterEach, describe, expect, test } from "vitest";
 import { loadConfig, resolveBundledWebUiDistDir } from "./config.js";
 
 const roots: string[] = [];
+const originalResourcesPath = process.resourcesPath;
+const originalElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
+const originalPaseoNodeEnv = process.env.PASEO_NODE_ENV;
 
 async function createPaseoHome(config: unknown): Promise<string> {
   const root = await mkdtemp(path.join(os.tmpdir(), "paseo-config-web-ui-"));
@@ -25,6 +28,17 @@ function expectBundledWebUiDistDir(distDir: string | null): void {
 
 describe("daemon web UI config", () => {
   afterEach(async () => {
+    process.resourcesPath = originalResourcesPath;
+    if (originalElectronRunAsNode === undefined) {
+      delete process.env.ELECTRON_RUN_AS_NODE;
+    } else {
+      process.env.ELECTRON_RUN_AS_NODE = originalElectronRunAsNode;
+    }
+    if (originalPaseoNodeEnv === undefined) {
+      delete process.env.PASEO_NODE_ENV;
+    } else {
+      process.env.PASEO_NODE_ENV = originalPaseoNodeEnv;
+    }
     await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
   });
 
@@ -65,6 +79,29 @@ describe("daemon web UI config", () => {
     expect(resolveBundledWebUiDistDir(moduleUrl)).toBe(
       path.join(packageRoot, "dist", "server", "web-ui"),
     );
+  });
+
+  test("resolves packaged desktop web UI dist dir from compiled server modules", async () => {
+    const packageRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-config-web-ui-packaged-"));
+    roots.push(packageRoot);
+    await mkdir(path.join(packageRoot, "app-dist"), { recursive: true });
+    process.env.ELECTRON_RUN_AS_NODE = "1";
+    process.env.PASEO_NODE_ENV = "production";
+    process.resourcesPath = packageRoot;
+    const moduleUrl = pathToFileURL(
+      path.join(
+        packageRoot,
+        "app.asar",
+        "node_modules",
+        "@getpaseo",
+        "server",
+        "dist",
+        "server",
+        "config.js",
+      ),
+    );
+
+    expect(resolveBundledWebUiDistDir(moduleUrl)).toBe(path.join(packageRoot, "app-dist"));
   });
 
   test("PASEO_WEB_UI_ENABLED overrides persisted setting", async () => {

--- a/packages/server/src/server/config-web-ui.test.ts
+++ b/packages/server/src/server/config-web-ui.test.ts
@@ -8,9 +8,6 @@ import { loadConfig, resolveBundledWebUiDistDir } from "./config.js";
 
 const roots: string[] = [];
 const originalResourcesPath = process.resourcesPath;
-const originalElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
-const originalPaseoNodeEnv = process.env.PASEO_NODE_ENV;
-
 async function createPaseoHome(config: unknown): Promise<string> {
   const root = await mkdtemp(path.join(os.tmpdir(), "paseo-config-web-ui-"));
   roots.push(root);
@@ -29,16 +26,6 @@ function expectBundledWebUiDistDir(distDir: string | null): void {
 describe("daemon web UI config", () => {
   afterEach(async () => {
     process.resourcesPath = originalResourcesPath;
-    if (originalElectronRunAsNode === undefined) {
-      delete process.env.ELECTRON_RUN_AS_NODE;
-    } else {
-      process.env.ELECTRON_RUN_AS_NODE = originalElectronRunAsNode;
-    }
-    if (originalPaseoNodeEnv === undefined) {
-      delete process.env.PASEO_NODE_ENV;
-    } else {
-      process.env.PASEO_NODE_ENV = originalPaseoNodeEnv;
-    }
     await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
   });
 
@@ -85,8 +72,6 @@ describe("daemon web UI config", () => {
     const packageRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-config-web-ui-packaged-"));
     roots.push(packageRoot);
     await mkdir(path.join(packageRoot, "app-dist"), { recursive: true });
-    process.env.ELECTRON_RUN_AS_NODE = "1";
-    process.env.PASEO_NODE_ENV = "production";
     process.resourcesPath = packageRoot;
     const moduleUrl = pathToFileURL(
       path.join(
@@ -103,6 +88,19 @@ describe("daemon web UI config", () => {
     );
 
     expect(resolveBundledWebUiDistDir(moduleUrl)).toBe(path.join(packageRoot, "app-dist"));
+  });
+
+  test("resolves compiled server web UI dist dir when app-dist is absent", async () => {
+    const packageRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-config-web-ui-compiled-"));
+    roots.push(packageRoot);
+    await mkdir(path.join(packageRoot, "dist", "server", "web-ui"), { recursive: true });
+    const moduleUrl = pathToFileURL(
+      path.join(packageRoot, "dist", "server", "server", "config.js"),
+    );
+
+    expect(resolveBundledWebUiDistDir(moduleUrl)).toBe(
+      path.join(packageRoot, "dist", "server", "web-ui"),
+    );
   });
 
   test("PASEO_WEB_UI_ENABLED overrides persisted setting", async () => {

--- a/packages/server/src/server/config-web-ui.test.ts
+++ b/packages/server/src/server/config-web-ui.test.ts
@@ -1,13 +1,11 @@
 import { mkdir, mkdtemp, writeFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
 
-import { loadConfig, resolveBundledWebUiDistDir } from "./config.js";
+import { loadConfig } from "./config.js";
 
 const roots: string[] = [];
-const originalResourcesPath = process.resourcesPath;
 async function createPaseoHome(config: unknown): Promise<string> {
   const root = await mkdtemp(path.join(os.tmpdir(), "paseo-config-web-ui-"));
   roots.push(root);
@@ -25,7 +23,6 @@ function expectBundledWebUiDistDir(distDir: string | null): void {
 
 describe("daemon web UI config", () => {
   afterEach(async () => {
-    process.resourcesPath = originalResourcesPath;
     await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
   });
 
@@ -48,46 +45,6 @@ describe("daemon web UI config", () => {
 
     expect(config.webUi.enabled).toBe(true);
     expectBundledWebUiDistDir(config.webUi.distDir);
-  });
-
-  test("resolves bundled web UI dist dir from TypeScript source modules", () => {
-    const packageRoot = path.join(os.tmpdir(), "paseo-config-web-ui-source-package");
-    const moduleUrl = pathToFileURL(path.join(packageRoot, "src", "server", "config.ts"));
-
-    expect(resolveBundledWebUiDistDir(moduleUrl)).toBe(
-      path.join(packageRoot, "dist", "server", "web-ui"),
-    );
-  });
-
-  test("resolves bundled web UI dist dir from compiled server modules", () => {
-    const packageRoot = path.join(os.tmpdir(), "paseo-config-web-ui-dist-package");
-    const moduleUrl = pathToFileURL(path.join(packageRoot, "dist", "server", "config.js"));
-
-    expect(resolveBundledWebUiDistDir(moduleUrl)).toBe(
-      path.join(packageRoot, "dist", "server", "web-ui"),
-    );
-  });
-
-  test("resolves packaged desktop web UI dist dir from compiled server modules", async () => {
-    const packageRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-config-web-ui-packaged-"));
-    roots.push(packageRoot);
-    await mkdir(path.join(packageRoot, "app-dist"), { recursive: true });
-    process.resourcesPath = packageRoot;
-    const moduleUrl = pathToFileURL(
-      path.join(
-        packageRoot,
-        "app.asar",
-        "node_modules",
-        "@getpaseo",
-        "server",
-        "dist",
-        "server",
-        "server",
-        "config.js",
-      ),
-    );
-
-    expect(resolveBundledWebUiDistDir(moduleUrl)).toBe(path.join(packageRoot, "app-dist"));
   });
 
   test("PASEO_WEB_UI_ENABLED overrides persisted setting", async () => {

--- a/packages/server/src/server/config-web-ui.test.ts
+++ b/packages/server/src/server/config-web-ui.test.ts
@@ -90,19 +90,6 @@ describe("daemon web UI config", () => {
     expect(resolveBundledWebUiDistDir(moduleUrl)).toBe(path.join(packageRoot, "app-dist"));
   });
 
-  test("resolves compiled server web UI dist dir when app-dist is absent", async () => {
-    const packageRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-config-web-ui-compiled-"));
-    roots.push(packageRoot);
-    await mkdir(path.join(packageRoot, "dist", "server", "web-ui"), { recursive: true });
-    const moduleUrl = pathToFileURL(
-      path.join(packageRoot, "dist", "server", "server", "config.js"),
-    );
-
-    expect(resolveBundledWebUiDistDir(moduleUrl)).toBe(
-      path.join(packageRoot, "dist", "server", "web-ui"),
-    );
-  });
-
   test("PASEO_WEB_UI_ENABLED overrides persisted setting", async () => {
     const home = await createPaseoHome({
       version: 1,

--- a/packages/server/src/server/config.test.ts
+++ b/packages/server/src/server/config.test.ts
@@ -1,22 +1,27 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 
 import { resolveBundledWebUiDistDir } from "./config.js";
 
-function fileUrlFor(...segments: string[]): URL {
-  return pathToFileURL(path.join(path.parse(process.cwd()).root, ...segments));
-}
+const roots: string[] = [];
 
 describe("server config", () => {
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
   test("resolves bundled web UI path from source-tree modules", () => {
+    const root = path.parse(process.cwd()).root;
     expect(
       resolveBundledWebUiDistDir(
-        fileUrlFor("repo", "packages", "server", "src", "server", "config.ts"),
+        pathToFileURL(path.join(root, "repo", "packages", "server", "src", "server", "config.ts")),
       ),
     ).toBe(
       path.join(
-        path.parse(process.cwd()).root,
+        root,
         "repo",
         "packages",
         "server",
@@ -27,35 +32,17 @@ describe("server config", () => {
     );
   });
 
-  test("resolves bundled web UI path from globally installed compiled modules", () => {
+  test("resolves bundled web UI path from globally installed compiled modules", async () => {
+    const packageRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-config-compiled-"));
+    roots.push(packageRoot);
+    await mkdir(path.join(packageRoot, "dist", "server", "web-ui"), { recursive: true });
+
     expect(
       resolveBundledWebUiDistDir(
-        fileUrlFor(
-          "usr",
-          "local",
-          "lib",
-          "node_modules",
-          "@getpaseo",
-          "server",
-          "dist",
-          "server",
-          "server",
-          "config.js",
+        pathToFileURL(
+          path.join(packageRoot, "dist", "server", "server", "config.js"),
         ),
       ),
-    ).toBe(
-      path.join(
-        path.parse(process.cwd()).root,
-        "usr",
-        "local",
-        "lib",
-        "node_modules",
-        "@getpaseo",
-        "server",
-        "dist",
-        "server",
-        "web-ui",
-      ),
-    );
+    ).toBe(path.join(packageRoot, "dist", "server", "web-ui"));
   });
 });

--- a/packages/server/src/server/config.test.ts
+++ b/packages/server/src/server/config.test.ts
@@ -16,9 +16,11 @@ describe("server config", () => {
   test("resolves bundled web UI path from source-tree modules", () => {
     const root = path.parse(process.cwd()).root;
     expect(
-      resolveBundledWebUiDistDir(
-        pathToFileURL(path.join(root, "repo", "packages", "server", "src", "server", "config.ts")),
-      ),
+      resolveBundledWebUiDistDir({
+        moduleUrl: pathToFileURL(
+          path.join(root, "repo", "packages", "server", "src", "server", "config.ts"),
+        ),
+      }),
     ).toBe(path.join(root, "repo", "packages", "server", "dist", "server", "web-ui"));
   });
 
@@ -28,9 +30,34 @@ describe("server config", () => {
     await mkdir(path.join(packageRoot, "dist", "server", "web-ui"), { recursive: true });
 
     expect(
-      resolveBundledWebUiDistDir(
-        pathToFileURL(path.join(packageRoot, "dist", "server", "server", "config.js")),
-      ),
+      resolveBundledWebUiDistDir({
+        moduleUrl: pathToFileURL(path.join(packageRoot, "dist", "server", "server", "config.js")),
+      }),
     ).toBe(path.join(packageRoot, "dist", "server", "web-ui"));
+  });
+
+  test("resolves packaged desktop web UI path from resources app-dist", async () => {
+    const packageRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-config-packaged-"));
+    roots.push(packageRoot);
+    await mkdir(path.join(packageRoot, "app-dist"), { recursive: true });
+
+    expect(
+      resolveBundledWebUiDistDir({
+        moduleUrl: pathToFileURL(
+          path.join(
+            packageRoot,
+            "app.asar",
+            "node_modules",
+            "@getpaseo",
+            "server",
+            "dist",
+            "server",
+            "server",
+            "config.js",
+          ),
+        ),
+        resourcesPath: packageRoot,
+      }),
+    ).toBe(path.join(packageRoot, "app-dist"));
   });
 });

--- a/packages/server/src/server/config.test.ts
+++ b/packages/server/src/server/config.test.ts
@@ -19,17 +19,7 @@ describe("server config", () => {
       resolveBundledWebUiDistDir(
         pathToFileURL(path.join(root, "repo", "packages", "server", "src", "server", "config.ts")),
       ),
-    ).toBe(
-      path.join(
-        root,
-        "repo",
-        "packages",
-        "server",
-        "dist",
-        "server",
-        "web-ui",
-      ),
-    );
+    ).toBe(path.join(root, "repo", "packages", "server", "dist", "server", "web-ui"));
   });
 
   test("resolves bundled web UI path from globally installed compiled modules", async () => {
@@ -39,9 +29,7 @@ describe("server config", () => {
 
     expect(
       resolveBundledWebUiDistDir(
-        pathToFileURL(
-          path.join(packageRoot, "dist", "server", "server", "config.js"),
-        ),
+        pathToFileURL(path.join(packageRoot, "dist", "server", "server", "config.js")),
       ),
     ).toBe(path.join(packageRoot, "dist", "server", "web-ui"));
   });

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -40,17 +40,17 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
     path.basename(path.dirname(moduleDir)) === "server" &&
     path.basename(path.dirname(path.dirname(moduleDir))) === "dist"
   ) {
+    const appDistDir =
+      typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string"
+        ? path.join((process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!, "app-dist")
+        : null;
+
     if (
-      typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string" &&
-      existsSync(
-        path.join((process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!, "app-dist"),
-      )
+      appDistDir &&
+      existsSync(appDistDir)
     ) {
       // Packaged desktop/CLI builds execute the server from app.asar and bundle the Web UI in app-dist.
-      return path.join(
-        (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!,
-        "app-dist",
-      );
+      return appDistDir;
     }
 
     return path.resolve(moduleDir, "..", "web-ui");

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolvePaseoNodeEnv } from "./paseo-env.js";
@@ -39,22 +40,23 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
     path.basename(path.dirname(moduleDir)) === "server" &&
     path.basename(path.dirname(path.dirname(moduleDir))) === "dist"
   ) {
-    if (
-      path
-        .dirname(path.dirname(moduleDir))
-        .endsWith(path.join("app.asar", "node_modules", "@getpaseo", "server", "dist")) &&
-      process.env.ELECTRON_RUN_AS_NODE === "1" &&
-      resolvePaseoNodeEnv(process.env) === "production" &&
+    const webUiDistDir = path.resolve(moduleDir, "..", "web-ui");
+    const appDistDir =
       typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string"
+        ? path.join((process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!, "app-dist")
+        : null;
+
+    if (
+      appDistDir &&
+      existsSync(appDistDir)
     ) {
       // Packaged desktop/CLI builds execute the server from app.asar and bundle the Web UI in app-dist.
-      return path.join(
-        (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!,
-        "app-dist",
-      );
+      return appDistDir;
     }
 
-    return path.resolve(moduleDir, "..", "web-ui");
+    if (existsSync(webUiDistDir)) {
+      return webUiDistDir;
+    }
   }
 
   return path.resolve(moduleDir, "web-ui");

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -28,7 +28,13 @@ const DEFAULT_RELAY_ENDPOINT = "relay.paseo.sh:443";
 const DEFAULT_APP_BASE_URL = "https://app.paseo.sh";
 const DEFAULT_TRUSTED_PROXIES = ["loopback"];
 
-export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta.url): string {
+interface ResolveBundledWebUiDistDirInput {
+  moduleUrl?: string | URL;
+  resourcesPath?: string;
+}
+
+export function resolveBundledWebUiDistDir(input: ResolveBundledWebUiDistDirInput = {}): string {
+  const moduleUrl = input.moduleUrl ?? import.meta.url;
   const moduleDir = path.dirname(fileURLToPath(moduleUrl));
 
   if (path.basename(moduleDir) === "server" && path.basename(path.dirname(moduleDir)) === "src") {
@@ -40,12 +46,9 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
     path.basename(path.dirname(moduleDir)) === "server" &&
     path.basename(path.dirname(path.dirname(moduleDir))) === "dist"
   ) {
-    const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
-    const appDistDir =
-      typeof resourcesPath === "string" ? path.join(resourcesPath, "app-dist") : null;
+    const appDistDir = input.resourcesPath ? path.join(input.resourcesPath, "app-dist") : null;
 
     if (appDistDir && existsSync(appDistDir)) {
-      // Packaged desktop/CLI builds execute the server from app.asar and bundle the Web UI in app-dist.
       return appDistDir;
     }
 
@@ -55,7 +58,10 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
   return path.resolve(moduleDir, "web-ui");
 }
 
-const BUNDLED_WEB_UI_DIST_DIR = resolveBundledWebUiDistDir();
+const processResourcesPath = "resourcesPath" in process ? process.resourcesPath : undefined;
+const BUNDLED_WEB_UI_DIST_DIR = resolveBundledWebUiDistDir({
+  resourcesPath: typeof processResourcesPath === "string" ? processResourcesPath : undefined,
+});
 
 function parseBooleanEnv(value: string | undefined): boolean | undefined {
   if (value === undefined) {

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -40,22 +40,21 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
     path.basename(path.dirname(moduleDir)) === "server" &&
     path.basename(path.dirname(path.dirname(moduleDir))) === "dist"
   ) {
-    const webUiDistDir = path.resolve(moduleDir, "..", "web-ui");
-    const appDistDir =
-      typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string"
-        ? path.join((process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!, "app-dist")
-        : null;
-
     if (
-      appDistDir &&
-      existsSync(appDistDir)
+      typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string" &&
+      existsSync(
+        path.join((process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!, "app-dist"),
+      )
     ) {
       // Packaged desktop/CLI builds execute the server from app.asar and bundle the Web UI in app-dist.
-      return appDistDir;
+      return path.join(
+        (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!,
+        "app-dist",
+      );
     }
 
-    if (existsSync(webUiDistDir)) {
-      return webUiDistDir;
+    if (existsSync(path.resolve(moduleDir, "..", "web-ui"))) {
+      return path.resolve(moduleDir, "..", "web-ui");
     }
   }
 

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -38,15 +38,15 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
   if (
     path.basename(moduleDir) === "server" &&
     path.basename(path.dirname(moduleDir)) === "dist" &&
-    path.dirname(moduleDir).endsWith(
-      path.join("app.asar", "node_modules", "@getpaseo", "server", "dist"),
-    ) &&
+    path
+      .dirname(moduleDir)
+      .endsWith(path.join("app.asar", "node_modules", "@getpaseo", "server", "dist")) &&
     process.env.ELECTRON_RUN_AS_NODE === "1" &&
     resolvePaseoNodeEnv(process.env) === "production" &&
     typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string"
   ) {
     return path.join(
-      (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath,
+      (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!,
       "app-dist",
     );
   }

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -37,26 +37,23 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
   if (
     path.basename(moduleDir) === "server" &&
     path.basename(path.dirname(moduleDir)) === "server" &&
-    path.basename(path.dirname(path.dirname(moduleDir))) === "dist" &&
-    path
-      .dirname(path.dirname(moduleDir))
-      .endsWith(path.join("app.asar", "node_modules", "@getpaseo", "server", "dist")) &&
-    process.env.ELECTRON_RUN_AS_NODE === "1" &&
-    resolvePaseoNodeEnv(process.env) === "production" &&
-    typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string"
-  ) {
-    // Packaged desktop/CLI builds execute the server from app.asar and bundle the Web UI in app-dist.
-    return path.join(
-      (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!,
-      "app-dist",
-    );
-  }
-
-  if (
-    path.basename(moduleDir) === "server" &&
-    path.basename(path.dirname(moduleDir)) === "server" &&
     path.basename(path.dirname(path.dirname(moduleDir))) === "dist"
   ) {
+    if (
+      path
+        .dirname(path.dirname(moduleDir))
+        .endsWith(path.join("app.asar", "node_modules", "@getpaseo", "server", "dist")) &&
+      process.env.ELECTRON_RUN_AS_NODE === "1" &&
+      resolvePaseoNodeEnv(process.env) === "production" &&
+      typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string"
+    ) {
+      // Packaged desktop/CLI builds execute the server from app.asar and bundle the Web UI in app-dist.
+      return path.join(
+        (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!,
+        "app-dist",
+      );
+    }
+
     return path.resolve(moduleDir, "..", "web-ui");
   }
 

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -40,13 +40,9 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
     path.basename(path.dirname(moduleDir)) === "server" &&
     path.basename(path.dirname(path.dirname(moduleDir))) === "dist"
   ) {
+    const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
     const appDistDir =
-      typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string"
-        ? path.join(
-            (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!,
-            "app-dist",
-          )
-        : null;
+      typeof resourcesPath === "string" ? path.join(resourcesPath, "app-dist") : null;
 
     if (appDistDir && existsSync(appDistDir)) {
       // Packaged desktop/CLI builds execute the server from app.asar and bundle the Web UI in app-dist.

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -34,6 +34,23 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
     return path.resolve(moduleDir, "..", "..", "dist", "server", "web-ui");
   }
 
+  // Packaged desktop/CLI builds execute the server from app.asar and bundle the Web UI in app-dist.
+  if (
+    path.basename(moduleDir) === "server" &&
+    path.basename(path.dirname(moduleDir)) === "dist" &&
+    path.dirname(moduleDir).endsWith(
+      path.join("app.asar", "node_modules", "@getpaseo", "server", "dist"),
+    ) &&
+    process.env.ELECTRON_RUN_AS_NODE === "1" &&
+    resolvePaseoNodeEnv(process.env) === "production" &&
+    typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string"
+  ) {
+    return path.join(
+      (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath,
+      "app-dist",
+    );
+  }
+
   if (
     path.basename(moduleDir) === "server" &&
     path.basename(path.dirname(moduleDir)) === "server" &&

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -53,9 +53,7 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
       );
     }
 
-    if (existsSync(path.resolve(moduleDir, "..", "web-ui"))) {
-      return path.resolve(moduleDir, "..", "web-ui");
-    }
+    return path.resolve(moduleDir, "..", "web-ui");
   }
 
   return path.resolve(moduleDir, "web-ui");

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -42,13 +42,13 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
   ) {
     const appDistDir =
       typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string"
-        ? path.join((process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!, "app-dist")
+        ? path.join(
+            (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!,
+            "app-dist",
+          )
         : null;
 
-    if (
-      appDistDir &&
-      existsSync(appDistDir)
-    ) {
+    if (appDistDir && existsSync(appDistDir)) {
       // Packaged desktop/CLI builds execute the server from app.asar and bundle the Web UI in app-dist.
       return appDistDir;
     }

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -54,22 +54,6 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
 
   if (
     path.basename(moduleDir) === "server" &&
-    path.basename(path.dirname(moduleDir)) === "dist" &&
-    path
-      .dirname(moduleDir)
-      .endsWith(path.join("app.asar", "node_modules", "@getpaseo", "server", "dist")) &&
-    process.env.ELECTRON_RUN_AS_NODE === "1" &&
-    resolvePaseoNodeEnv(process.env) === "production" &&
-    typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string"
-  ) {
-    return path.join(
-      (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!,
-      "app-dist",
-    );
-  }
-
-  if (
-    path.basename(moduleDir) === "server" &&
     path.basename(path.dirname(moduleDir)) === "server" &&
     path.basename(path.dirname(path.dirname(moduleDir))) === "dist"
   ) {

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -34,7 +34,24 @@ export function resolveBundledWebUiDistDir(moduleUrl: string | URL = import.meta
     return path.resolve(moduleDir, "..", "..", "dist", "server", "web-ui");
   }
 
-  // Packaged desktop/CLI builds execute the server from app.asar and bundle the Web UI in app-dist.
+  if (
+    path.basename(moduleDir) === "server" &&
+    path.basename(path.dirname(moduleDir)) === "server" &&
+    path.basename(path.dirname(path.dirname(moduleDir))) === "dist" &&
+    path
+      .dirname(path.dirname(moduleDir))
+      .endsWith(path.join("app.asar", "node_modules", "@getpaseo", "server", "dist")) &&
+    process.env.ELECTRON_RUN_AS_NODE === "1" &&
+    resolvePaseoNodeEnv(process.env) === "production" &&
+    typeof (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath === "string"
+  ) {
+    // Packaged desktop/CLI builds execute the server from app.asar and bundle the Web UI in app-dist.
+    return path.join(
+      (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath!,
+      "app-dist",
+    );
+  }
+
   if (
     path.basename(moduleDir) === "server" &&
     path.basename(path.dirname(moduleDir)) === "dist" &&


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
-->

### Linked issue

Closes #1898

<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

<!-- A short description of the change in your own words. What was wrong, what you changed, why it works. If you can't explain this briefly, the PR is probably too big. -->

Fixes the packaged desktop/CLI daemon web UI path.

The daemon reports that the bundled web UI is mounted but requests to http://127.0.0.1:6767/ and /index.html return 404 Not Found. The bug was that the server still tried to serve the bundled web UI from `@getpaseo/server/dist/server/web-ui`, following the normal server layout. That works in dev and in non-desktop packaging, but it is wrong for the packaged desktop app: `docs/development.md` explicitly says desktop packaging excludes `node_modules/@getpaseo/server/dist/server/web-ui/**` and ships the renderer separately as `app-dist`.

This PR keeps the existing path-resolution logic and adds a desktop-packaged case so the resolver can find the web UI in the actual shipped location under `process.resourcesPath/app-dist`. That makes `paseo daemon start --web-ui` work correctly when invoked from the installed desktop package, without changing the existing behavior for the other layouts.

### How did you verify it

<!--
This is the section I read most carefully. I need to see that *you* tested this, not that the diff looks plausible.

- For UI changes: a screenshot or short video on every affected platform (mobile, web, desktop). UI claims without visual proof are not enough.
- For behavior changes: the actual steps you ran, and what you observed.
- For bug fixes: how you reproduced the bug before, and confirmed it's fixed after.

AI-generated PR descriptions are fine in principle. AI-generated *verification claims* with no actual testing behind them are not, and they're easy to spot.
-->

1. Reproduced the packaged-app layout difference locally and confirmed the desktop bundle contains `Contents/Resources/app-dist` instead of `@getpaseo/server/dist/server/web-ui`.
2. Modified `desktop-release.yml` to enable Web UI test in a private separate PR https://github.com/yzim/paseo/pull/5/checks, which verifies the logic on macOS, Linux, and Windows.
3. Installed the macOS package locally:
   - Observed `Daemon web UI mounted`
   - Observed `distDir` resolved to `/Applications/Paseo.app/Contents/Resources/app-dist`
   - Confirmed `http://127.0.0.1:6767/` returned `200 OK`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
