### PR TITLE
fix(server): apply the default model's default thinking option when it is auto-filled

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -471,6 +471,72 @@ test("normalizeConfig injects the provider default model when omitted", async ()
   expect(snapshot.config.modeId).toBe("auto");
 });
 
+class DefaultThinkingClient extends TestAgentClient {
+  override async fetchCatalog() {
+    return {
+      models: [
+        {
+          provider: "codex",
+          id: "gpt-5.4",
+          label: "GPT-5.4",
+          isDefault: true,
+          defaultThinkingOptionId: "high",
+          thinkingOptions: [
+            { id: "low", label: "Low" },
+            { id: "high", label: "High", isDefault: true },
+          ],
+        },
+      ],
+      modes: [],
+    };
+  }
+}
+
+test("normalizeConfig pairs the auto-filled default model with its default thinking option", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const manager = new AgentManager({
+    clients: {
+      codex: new DefaultThinkingClient(),
+    },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000102",
+  });
+
+  const snapshot = await manager.createAgent({
+    provider: "codex",
+    cwd: workdir,
+  });
+
+  expect(snapshot.config.model).toBe("gpt-5.4");
+  expect(snapshot.config.thinkingOptionId).toBe("high");
+});
+
+test("normalizeConfig keeps an explicit thinking option while auto-filling the default model", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const manager = new AgentManager({
+    clients: {
+      codex: new DefaultThinkingClient(),
+    },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000103",
+  });
+
+  const snapshot = await manager.createAgent({
+    provider: "codex",
+    cwd: workdir,
+    thinkingOptionId: "low",
+  });
+
+  expect(snapshot.config.model).toBe("gpt-5.4");
+  expect(snapshot.config.thinkingOptionId).toBe("low");
+});
+
 test("createAgent forwards request env into the spawned provider process", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-env-test-"));
   const client = new EnvProbeAgentClient();

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -23,6 +23,7 @@ import {
   type AgentLaunchContext,
   type AgentSlashCommand,
   type AgentMode,
+  type AgentModelDefinition,
   type AgentPermissionRequest,
   type AgentPermissionResponse,
   type AgentPermissionResult,
@@ -3676,12 +3677,8 @@ export class AgentManager {
       normalized.model = trimmed.length > 0 && trimmed !== "default" ? trimmed : undefined;
     }
 
-    const shouldResolveDefaultModel = options.resolveDefaultModel ?? true;
-    if (shouldResolveDefaultModel && !normalized.model) {
-      const defaultModelId = await this.resolveDefaultModelId(normalized);
-      if (defaultModelId) {
-        normalized.model = defaultModelId;
-      }
+    if (options.resolveDefaultModel ?? true) {
+      await this.applyDefaultModelAndThinking(normalized);
     }
 
     if (!normalized.modeId) {
@@ -3696,7 +3693,34 @@ export class AgentManager {
     return normalized;
   }
 
-  private async resolveDefaultModelId(config: AgentSessionConfig): Promise<string | undefined> {
+  private async applyDefaultModelAndThinking(normalized: AgentSessionConfig): Promise<void> {
+    if (normalized.model) {
+      return;
+    }
+    const defaultModel = await this.resolveDefaultModel(normalized);
+    if (!defaultModel) {
+      return;
+    }
+    normalized.model = defaultModel.id;
+    // Mirror the create-agent picker: when a model is auto-selected it is paired with
+    // that model's default thinking option. Without this, an agent created with neither
+    // model nor thinking specified would run without the default thinking a provider
+    // marked isDefault (e.g. a model whose default is a higher reasoning effort), since
+    // the default model was filled but its thinking option was left unset.
+    if (normalized.thinkingOptionId) {
+      return;
+    }
+    const defaultThinkingOptionId =
+      defaultModel.defaultThinkingOptionId ??
+      defaultModel.thinkingOptions?.find((option) => option.isDefault)?.id;
+    if (defaultThinkingOptionId) {
+      normalized.thinkingOptionId = defaultThinkingOptionId;
+    }
+  }
+
+  private async resolveDefaultModel(
+    config: AgentSessionConfig,
+  ): Promise<AgentModelDefinition | undefined> {
     const client = this.clients.get(config.provider);
     if (!client) {
       return undefined;
@@ -3707,7 +3731,7 @@ export class AgentManager {
         cwd: config.cwd,
         force: false,
       });
-      return (catalog.models.find((model) => model.isDefault) ?? catalog.models[0])?.id;
+      return catalog.models.find((model) => model.isDefault) ?? catalog.models[0];
     } catch {
       // Provider may not support model listing — leave model undefined.
       return undefined;


### PR DESCRIPTION
## Problem

When an agent is created **without an explicit model and without a thinking option**,
`AgentManager.normalizeConfig` resolves and fills the provider's default model
(`catalog.models.find(m => m.isDefault)`) and the provider's default mode (`defaultModeId`) —
but it leaves `thinkingOptionId` unset.

The Claude provider's `resolveThinkingConfig` treats an empty thinking option as "no extended
thinking", so the newly-created agent runs **without the default model's default thinking
option**, even when the catalog explicitly marks a thinking option `isDefault` (or exposes
`defaultThinkingOptionId`).

This is inconsistent with the create-agent picker, which always pairs an auto-selected model
with that model's default thinking (`resolve-agent-form.ts` → `resolveThinkingOptionId`). The
only time the client submits an empty thinking option is when it also submitted no model —
exactly the case the server fills the default model. So the server fills the model but drops
its default thinking.

### Repro

```
paseo run --provider claude "hello"
paseo inspect <id>
```

- **Before:** `Model` is the default model, but `Thinking` is the SDK/adaptive default — the
  model's `defaultThinkingOptionId` is not applied.
- **After:** `Thinking` is the default model's default thinking option.

## Fix

In `normalizeConfig`, when the default model is auto-filled and no thinking option was
provided, also set `thinkingOptionId` from the resolved model's `defaultThinkingOptionId`
(falling back to `thinkingOptions.find(o => o.isDefault)`). This mirrors the picker and the
existing default-model / default-mode fills. The private `resolveDefaultModelId` is refactored
to `resolveDefaultModel` so the caller can read the model's thinking metadata.

This does **not** change the create-agent picker UX — the fresh picker still does not
auto-select a model (that behavior and its test in `resolve-agent-form.test.ts` are unchanged).
It only affects server-side config normalization for agents created without an explicit
thinking option.

## Tests

Two new cases in `agent-manager.test.ts`:
- the auto-filled default model is paired with its default thinking option;
- an explicit thinking option is preserved when the default model is auto-filled.
