### PR TITLE
feat(composer): Alt+Enter and Shift+Enter insert newline

### DIFF
--- a/packages/app/src/composer/input/input.test.tsx
+++ b/packages/app/src/composer/input/input.test.tsx
@@ -1,0 +1,268 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleDesktopKeyPressImpl, insertNewlineAtSelection } from "./keyboard";
+import type { MessagePayload } from "@/composer/types";
+
+interface WebTextInputKeyPressEvent {
+  nativeEvent: {
+    key: string;
+    shiftKey?: boolean;
+    altKey?: boolean;
+    metaKey?: boolean;
+    ctrlKey?: boolean;
+    isComposing?: boolean;
+    keyCode?: number;
+  };
+  preventDefault: () => void;
+}
+
+function makeEvent(options: {
+  key?: string;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  isComposing?: boolean;
+  keyCode?: number;
+}): WebTextInputKeyPressEvent {
+  return {
+    nativeEvent: {
+      key: options.key ?? "Enter",
+      shiftKey: options.shiftKey ?? false,
+      altKey: options.altKey ?? false,
+      metaKey: options.metaKey ?? false,
+      ctrlKey: options.ctrlKey ?? false,
+      isComposing: options.isComposing,
+      keyCode: options.keyCode,
+    },
+    preventDefault: vi.fn(),
+  } as unknown as WebTextInputKeyPressEvent;
+}
+
+function makeContext(overrides?: {
+  value?: string;
+  selection?: { start: number; end: number };
+  submitOnEnter?: boolean;
+  isSubmitDisabled?: boolean;
+  isSubmitLoading?: boolean;
+  disabled?: boolean;
+  isAgentRunning?: boolean;
+  onQueue?: ((payload: MessagePayload) => void) | undefined;
+  onKeyPressCallback?:
+    | ((event: { key: string; preventDefault: () => void }) => boolean)
+    | undefined;
+}) {
+  const value = overrides?.value ?? "hello world";
+  const selection = overrides?.selection ?? { start: value.length, end: value.length };
+  const onChangeText = vi.fn();
+  const onSelectionChange = vi.fn();
+  const handleDefaultSendAction = vi.fn();
+  const handleAlternateSendAction = vi.fn();
+
+  return {
+    value,
+    selection,
+    onChangeText,
+    onSelectionChange,
+    handleDefaultSendAction,
+    handleAlternateSendAction,
+    ctx: {
+      onKeyPressCallback: overrides?.onKeyPressCallback,
+      submitOnEnter: overrides?.submitOnEnter ?? true,
+      isAgentRunning: overrides?.isAgentRunning ?? false,
+      onQueue: overrides?.onQueue,
+      isSubmitDisabled: overrides?.isSubmitDisabled ?? false,
+      isSubmitLoading: overrides?.isSubmitLoading ?? false,
+      disabled: overrides?.disabled ?? false,
+      value,
+      selection,
+      onChangeText,
+      onSelectionChange,
+      handleAlternateSendAction,
+      handleDefaultSendAction,
+    },
+  };
+}
+
+describe("insertNewlineAtSelection", () => {
+  it("inserts a newline at the end by default", () => {
+    const result = insertNewlineAtSelection("hello", { start: 5, end: 5 });
+    expect(result.nextValue).toBe("hello\n");
+    expect(result.nextSelection).toEqual({ start: 6, end: 6 });
+  });
+
+  it("inserts a newline in the middle", () => {
+    const result = insertNewlineAtSelection("hello world", { start: 5, end: 5 });
+    expect(result.nextValue).toBe("hello\n world");
+    expect(result.nextSelection).toEqual({ start: 6, end: 6 });
+  });
+
+  it("inserts a newline at the start", () => {
+    const result = insertNewlineAtSelection("hello", { start: 0, end: 0 });
+    expect(result.nextValue).toBe("\nhello");
+    expect(result.nextSelection).toEqual({ start: 1, end: 1 });
+  });
+
+  it("replaces the selected range with a newline", () => {
+    const result = insertNewlineAtSelection("hello world", { start: 2, end: 8 });
+    expect(result.nextValue).toBe("he\nrld");
+    expect(result.nextSelection).toEqual({ start: 3, end: 3 });
+  });
+});
+
+describe("handleDesktopKeyPressImpl newline insertion", () => {
+  it("inserts a newline on Shift+Enter and prevents default", () => {
+    const { ctx, onChangeText, onSelectionChange } = makeContext();
+    const event = makeEvent({ shiftKey: true });
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(onChangeText).toHaveBeenCalledWith("hello world\n");
+    expect(onSelectionChange).toHaveBeenCalledWith({ start: 12, end: 12 });
+    expect(ctx.handleDefaultSendAction).not.toHaveBeenCalled();
+    expect(ctx.handleAlternateSendAction).not.toHaveBeenCalled();
+  });
+
+  it("inserts a newline on Alt+Enter and prevents default", () => {
+    const { ctx, onChangeText, onSelectionChange } = makeContext();
+    const event = makeEvent({ altKey: true });
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(onChangeText).toHaveBeenCalledWith("hello world\n");
+    expect(onSelectionChange).toHaveBeenCalledWith({ start: 12, end: 12 });
+    expect(ctx.handleDefaultSendAction).not.toHaveBeenCalled();
+    expect(ctx.handleAlternateSendAction).not.toHaveBeenCalled();
+  });
+
+  it("inserts a newline in the middle of text", () => {
+    const { ctx, onChangeText, onSelectionChange } = makeContext({
+      value: "hello world",
+      selection: { start: 5, end: 5 },
+    });
+    const event = makeEvent({ altKey: true });
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(onChangeText).toHaveBeenCalledWith("hello\n world");
+    expect(onSelectionChange).toHaveBeenCalledWith({ start: 6, end: 6 });
+  });
+
+  it("replaces the selected text with a newline", () => {
+    const { ctx, onChangeText, onSelectionChange } = makeContext({
+      value: "hello world",
+      selection: { start: 2, end: 8 },
+    });
+    const event = makeEvent({ shiftKey: true });
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(onChangeText).toHaveBeenCalledWith("he\nrld");
+    expect(onSelectionChange).toHaveBeenCalledWith({ start: 3, end: 3 });
+  });
+
+  it("still inserts a newline when submitOnEnter is false", () => {
+    const { ctx, onChangeText } = makeContext({ submitOnEnter: false });
+    const event = makeEvent({ shiftKey: true });
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(onChangeText).toHaveBeenCalledWith("hello world\n");
+    expect(ctx.handleDefaultSendAction).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleDesktopKeyPressImpl send behavior", () => {
+  it("submits on plain Enter", () => {
+    const { ctx } = makeContext();
+    const event = makeEvent({});
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(ctx.handleDefaultSendAction).toHaveBeenCalled();
+  });
+
+  it("does not submit when submitOnEnter is false", () => {
+    const { ctx } = makeContext({ submitOnEnter: false });
+    const event = makeEvent({});
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(ctx.handleDefaultSendAction).not.toHaveBeenCalled();
+  });
+
+  it("queues on Mod+Enter when agent is running and queue is available", () => {
+    const onQueue = vi.fn();
+    const { ctx } = makeContext({
+      isAgentRunning: true,
+      onQueue,
+    });
+    const event = makeEvent({ metaKey: true });
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(ctx.handleAlternateSendAction).toHaveBeenCalled();
+    expect(ctx.handleDefaultSendAction).not.toHaveBeenCalled();
+  });
+
+  it("does not submit when disabled", () => {
+    const { ctx } = makeContext({ disabled: true });
+    const event = makeEvent({});
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(ctx.handleDefaultSendAction).not.toHaveBeenCalled();
+  });
+
+  it("does not submit when loading", () => {
+    const { ctx } = makeContext({ isSubmitLoading: true });
+    const event = makeEvent({});
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(ctx.handleDefaultSendAction).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleDesktopKeyPressImpl IME and interception", () => {
+  it("does nothing during IME composition", () => {
+    const { ctx, onChangeText, handleDefaultSendAction } = makeContext();
+    const event = makeEvent({ isComposing: true });
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(onChangeText).not.toHaveBeenCalled();
+    expect(handleDefaultSendAction).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when keyCode is 229 (legacy IME)", () => {
+    const { ctx, onChangeText, handleDefaultSendAction } = makeContext();
+    const event = makeEvent({ keyCode: 229 });
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(onChangeText).not.toHaveBeenCalled();
+    expect(handleDefaultSendAction).not.toHaveBeenCalled();
+  });
+
+  it("lets onKeyPressCallback handle the event first", () => {
+    const onKeyPressCallback = vi.fn(() => true);
+    const { ctx, onChangeText, handleDefaultSendAction } = makeContext({
+      onKeyPressCallback,
+    });
+    const event = makeEvent({ shiftKey: true });
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(onKeyPressCallback).toHaveBeenCalledWith({
+      key: "Enter",
+      preventDefault: expect.any(Function),
+    });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(onChangeText).not.toHaveBeenCalled();
+    expect(handleDefaultSendAction).not.toHaveBeenCalled();
+  });
+
+  it("falls through to newline when onKeyPressCallback returns false", () => {
+    const onKeyPressCallback = vi.fn(() => false);
+    const { ctx, onChangeText } = makeContext({ onKeyPressCallback });
+    const event = makeEvent({ altKey: true });
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(onChangeText).toHaveBeenCalledWith("hello world\n");
+  });
+});
+
+describe("handleDesktopKeyPressImpl non-Enter keys", () => {
+  it("ignores non-Enter keys", () => {
+    const { ctx, onChangeText, handleDefaultSendAction } = makeContext();
+    const event = makeEvent({ key: "Escape" });
+    handleDesktopKeyPressImpl(event, ctx);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(onChangeText).not.toHaveBeenCalled();
+    expect(handleDefaultSendAction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/composer/input/input.test.tsx
+++ b/packages/app/src/composer/input/input.test.tsx
@@ -1,19 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { handleDesktopKeyPressImpl, insertNewlineAtSelection } from "./keyboard";
+import type { WebTextInputKeyPressEvent } from "./keyboard";
 import type { MessagePayload } from "@/composer/types";
-
-interface WebTextInputKeyPressEvent {
-  nativeEvent: {
-    key: string;
-    shiftKey?: boolean;
-    altKey?: boolean;
-    metaKey?: boolean;
-    ctrlKey?: boolean;
-    isComposing?: boolean;
-    keyCode?: number;
-  };
-  preventDefault: () => void;
-}
 
 function makeEvent(options: {
   key?: string;

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -57,10 +57,10 @@ import { useIosHardwareKeyboardSubmit } from "@/hooks/use-ios-hardware-keyboard-
 import { formatShortcut, type ShortcutKey } from "@/utils/format-shortcut";
 import { getShortcutOs } from "@/utils/shortcut-platform";
 import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
-import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
 import { isWeb } from "@/constants/platform";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useComposerHeightMirror } from "./height-mirror";
+import { handleDesktopKeyPressImpl } from "./keyboard";
 import {
   resolveSendTooltipLabel,
   resolveSubmitAccessibilityLabel,
@@ -162,6 +162,7 @@ type WebTextInputKeyPressEvent = NativeSyntheticEvent<
     metaKey?: boolean;
     ctrlKey?: boolean;
     shiftKey?: boolean;
+    altKey?: boolean;
     // Web-only: present on DOM KeyboardEvent during IME composition (CJK input).
     isComposing?: boolean;
     keyCode?: number;
@@ -445,50 +446,6 @@ function SendButtonContent({
     return <ThemedCornerDownLeft size={buttonIconSize} uniProps={iconAccentForegroundMapping} />;
   }
   return <ThemedArrowUp size={buttonIconSize} uniProps={iconAccentForegroundMapping} />;
-}
-
-interface DesktopKeyPressContext {
-  onKeyPressCallback: ((event: { key: string; preventDefault: () => void }) => boolean) | undefined;
-  submitOnEnter: boolean;
-  isAgentRunning: boolean;
-  onQueue: ((payload: MessagePayload) => void) | undefined;
-  isSubmitDisabled: boolean;
-  isSubmitLoading: boolean;
-  disabled: boolean;
-  handleAlternateSendAction: () => void;
-  handleDefaultSendAction: () => void;
-}
-
-function handleDesktopKeyPressImpl(
-  event: WebTextInputKeyPressEvent,
-  ctx: DesktopKeyPressContext,
-): void {
-  if (isImeComposingKeyboardEvent(event.nativeEvent)) return;
-
-  if (ctx.onKeyPressCallback) {
-    const handled = ctx.onKeyPressCallback({
-      key: event.nativeEvent.key,
-      preventDefault: () => event.preventDefault(),
-    });
-    if (handled) return;
-  }
-
-  const { shiftKey, metaKey, ctrlKey } = event.nativeEvent;
-
-  if (event.nativeEvent.key !== "Enter") return;
-  if (!ctx.submitOnEnter) return;
-  if (shiftKey) return;
-
-  if ((metaKey || ctrlKey) && ctx.isAgentRunning && ctx.onQueue) {
-    if (ctx.isSubmitDisabled || ctx.isSubmitLoading || ctx.disabled) return;
-    event.preventDefault();
-    ctx.handleAlternateSendAction();
-    return;
-  }
-
-  if (ctx.isSubmitDisabled || ctx.isSubmitLoading || ctx.disabled) return;
-  event.preventDefault();
-  ctx.handleDefaultSendAction();
 }
 
 interface KeyboardActionHandlers {
@@ -1281,6 +1238,10 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     const focusInputKeys = useShortcutKeys("focus-message-input");
     const [inputHeight, setInputHeight] = useState(MIN_INPUT_HEIGHT);
     const [isInputFocused, setIsInputFocused] = useState(false);
+    const [selection, setSelection] = useState<{ start: number; end: number }>({
+      start: value.length,
+      end: value.length,
+    });
     const rootRef = useRef<View | null>(null);
     const inputWrapperRef = useRef<View | null>(null);
     const textInputRef = useRef<TextInput | (TextInput & { getNativeRef?: () => unknown }) | null>(
@@ -1327,6 +1288,10 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
 
     useEffect(() => {
       valueRef.current = value;
+      setSelection((previous) => ({
+        start: Math.min(previous.start, value.length),
+        end: Math.min(previous.end, value.length),
+      }));
     }, [value]);
 
     useEffect(() => {
@@ -1664,6 +1629,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       (event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
         const start = event.nativeEvent.selection?.start ?? 0;
         const end = event.nativeEvent.selection?.end ?? start;
+        setSelection({ start, end });
         onSelectionChangeCallback?.({ start, end });
       },
       [onSelectionChangeCallback],
@@ -1682,6 +1648,10 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
         isSubmitDisabled,
         isSubmitLoading,
         disabled,
+        value,
+        selection,
+        onChangeText: handleInputChange,
+        onSelectionChange: setSelection,
         handleAlternateSendAction,
         handleDefaultSendAction,
       });
@@ -1840,6 +1810,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
               editable={!isDictating && !isRealtimeVoiceForCurrentAgent && !disabled}
               onKeyPress={shouldHandleWebKeyPress ? handleDesktopKeyPress : undefined}
               onSelectionChange={handleSelectionChange}
+              selection={selection}
               autoFocus={isWeb && autoFocus}
             />
             {inputScrollbar}

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -1184,6 +1184,28 @@ function extractErrorMessage(error: unknown): string | null {
   return null;
 }
 
+function useClampedSelection(value: string): {
+  selection: { start: number; end: number };
+  setReportedSelection: (selection: { start: number; end: number }) => void;
+} {
+  const [reportedSelection, setReportedSelection] = useState<{ start: number; end: number }>({
+    start: value.length,
+    end: value.length,
+  });
+  const selection = useMemo(
+    () => ({
+      start: Math.min(reportedSelection.start, value.length),
+      end: Math.min(reportedSelection.end, value.length),
+    }),
+    [reportedSelection, value.length],
+  );
+  return { selection, setReportedSelection };
+}
+
+function shouldShowNewlineHint(isWebPlatform: boolean, isCompact: boolean): boolean {
+  return isWebPlatform && !isCompact;
+}
+
 export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
   function MessageInput(props, ref) {
     const {
@@ -1238,10 +1260,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     const focusInputKeys = useShortcutKeys("focus-message-input");
     const [inputHeight, setInputHeight] = useState(MIN_INPUT_HEIGHT);
     const [isInputFocused, setIsInputFocused] = useState(false);
-    const [selection, setSelection] = useState<{ start: number; end: number }>({
-      start: value.length,
-      end: value.length,
-    });
+    const { selection, setReportedSelection } = useClampedSelection(value);
     const rootRef = useRef<View | null>(null);
     const inputWrapperRef = useRef<View | null>(null);
     const textInputRef = useRef<TextInput | (TextInput & { getNativeRef?: () => unknown }) | null>(
@@ -1288,10 +1307,6 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
 
     useEffect(() => {
       valueRef.current = value;
-      setSelection((previous) => ({
-        start: Math.min(previous.start, value.length),
-        end: Math.min(previous.end, value.length),
-      }));
     }, [value]);
 
     useEffect(() => {
@@ -1629,10 +1644,10 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       (event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
         const start = event.nativeEvent.selection?.start ?? 0;
         const end = event.nativeEvent.selection?.end ?? start;
-        setSelection({ start, end });
+        setReportedSelection({ start, end });
         onSelectionChangeCallback?.({ start, end });
       },
-      [onSelectionChangeCallback],
+      [onSelectionChangeCallback, setReportedSelection],
     );
 
     const shouldHandleWebKeyPress = isWeb;
@@ -1651,7 +1666,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
         value,
         selection,
         onChangeText: handleInputChange,
-        onSelectionChange: setSelection,
+        onSelectionChange: setReportedSelection,
         handleAlternateSendAction,
         handleDefaultSendAction,
       });
@@ -1701,6 +1716,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     const sendTooltipLabel = resolveSendTooltipLabel({
       submitButtonAccessibilityLabel,
       defaultActionQueues,
+      showNewlineHint: shouldShowNewlineHint(isWeb, isCompact),
       t,
     });
 

--- a/packages/app/src/composer/input/keyboard.ts
+++ b/packages/app/src/composer/input/keyboard.ts
@@ -1,0 +1,82 @@
+import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
+import type { MessagePayload } from "@/composer/types";
+
+export interface WebTextInputKeyPressEvent {
+  nativeEvent: {
+    key: string;
+    shiftKey?: boolean;
+    altKey?: boolean;
+    metaKey?: boolean;
+    ctrlKey?: boolean;
+    isComposing?: boolean;
+    keyCode?: number;
+  };
+  preventDefault: () => void;
+}
+
+export interface DesktopKeyPressContext {
+  onKeyPressCallback: ((event: { key: string; preventDefault: () => void }) => boolean) | undefined;
+  submitOnEnter: boolean;
+  isAgentRunning: boolean;
+  onQueue: ((payload: MessagePayload) => void) | undefined;
+  isSubmitDisabled: boolean;
+  isSubmitLoading: boolean;
+  disabled: boolean;
+  value: string;
+  selection: { start: number; end: number };
+  onChangeText: (text: string) => void;
+  onSelectionChange: (selection: { start: number; end: number }) => void;
+  handleAlternateSendAction: () => void;
+  handleDefaultSendAction: () => void;
+}
+
+export function insertNewlineAtSelection(
+  value: string,
+  selection: { start: number; end: number },
+): { nextValue: string; nextSelection: { start: number; end: number } } {
+  const before = value.slice(0, selection.start);
+  const after = value.slice(selection.end);
+  const nextValue = `${before}\n${after}`;
+  const cursor = selection.start + 1;
+  return { nextValue, nextSelection: { start: cursor, end: cursor } };
+}
+
+export function handleDesktopKeyPressImpl(
+  event: WebTextInputKeyPressEvent,
+  ctx: DesktopKeyPressContext,
+): void {
+  if (isImeComposingKeyboardEvent(event.nativeEvent)) return;
+
+  if (ctx.onKeyPressCallback) {
+    const handled = ctx.onKeyPressCallback({
+      key: event.nativeEvent.key,
+      preventDefault: () => event.preventDefault(),
+    });
+    if (handled) return;
+  }
+
+  const { shiftKey, altKey, metaKey, ctrlKey } = event.nativeEvent;
+
+  if (event.nativeEvent.key !== "Enter") return;
+
+  if (shiftKey || altKey) {
+    event.preventDefault();
+    const { nextValue, nextSelection } = insertNewlineAtSelection(ctx.value, ctx.selection);
+    ctx.onChangeText(nextValue);
+    ctx.onSelectionChange(nextSelection);
+    return;
+  }
+
+  if (!ctx.submitOnEnter) return;
+
+  if ((metaKey || ctrlKey) && ctx.isAgentRunning && ctx.onQueue) {
+    if (ctx.isSubmitDisabled || ctx.isSubmitLoading || ctx.disabled) return;
+    event.preventDefault();
+    ctx.handleAlternateSendAction();
+    return;
+  }
+
+  if (ctx.isSubmitDisabled || ctx.isSubmitLoading || ctx.disabled) return;
+  event.preventDefault();
+  ctx.handleDefaultSendAction();
+}

--- a/packages/app/src/composer/input/labels.test.ts
+++ b/packages/app/src/composer/input/labels.test.ts
@@ -13,6 +13,7 @@ const translations: Record<string, string> = {
   "composer.input.sendMessage": "Send message",
   "composer.input.queue": "Queue",
   "composer.input.send": "Send",
+  "composer.input.sendWithNewline": "Send (Shift+Enter or Alt+Enter for new line)",
   "composer.voice.unmuteVoiceMode": "Unmute Voice mode",
   "composer.voice.muteVoiceMode": "Mute Voice mode",
   "composer.voice.stopDictation": "Stop dictation",
@@ -132,6 +133,6 @@ describe("composer input labels", () => {
         defaultActionQueues: false,
         t,
       }),
-    ).toBe("Send");
+    ).toBe("Send (Shift+Enter or Alt+Enter for new line)");
   });
 });

--- a/packages/app/src/composer/input/labels.test.ts
+++ b/packages/app/src/composer/input/labels.test.ts
@@ -124,6 +124,7 @@ describe("composer input labels", () => {
       resolveSendTooltipLabel({
         submitButtonAccessibilityLabel: undefined,
         defaultActionQueues: true,
+        showNewlineHint: true,
         t,
       }),
     ).toBe("Queue");
@@ -131,8 +132,17 @@ describe("composer input labels", () => {
       resolveSendTooltipLabel({
         submitButtonAccessibilityLabel: undefined,
         defaultActionQueues: false,
+        showNewlineHint: true,
         t,
       }),
     ).toBe("Send (Shift+Enter or Alt+Enter for new line)");
+    expect(
+      resolveSendTooltipLabel({
+        submitButtonAccessibilityLabel: undefined,
+        defaultActionQueues: false,
+        showNewlineHint: false,
+        t,
+      }),
+    ).toBe("Send");
   });
 });

--- a/packages/app/src/composer/input/labels.ts
+++ b/packages/app/src/composer/input/labels.ts
@@ -45,9 +45,11 @@ export function resolveVoiceTooltipText(input: {
 export function resolveSendTooltipLabel(input: {
   submitButtonAccessibilityLabel: string | undefined;
   defaultActionQueues: boolean;
+  showNewlineHint: boolean;
   t: TFunction;
 }): string {
   if (input.submitButtonAccessibilityLabel) return input.submitButtonAccessibilityLabel;
   if (input.defaultActionQueues) return input.t("composer.input.queue");
-  return input.t("composer.input.sendWithNewline");
+  if (input.showNewlineHint) return input.t("composer.input.sendWithNewline");
+  return input.t("composer.input.send");
 }

--- a/packages/app/src/composer/input/labels.ts
+++ b/packages/app/src/composer/input/labels.ts
@@ -48,7 +48,6 @@ export function resolveSendTooltipLabel(input: {
   t: TFunction;
 }): string {
   if (input.submitButtonAccessibilityLabel) return input.submitButtonAccessibilityLabel;
-  return input.defaultActionQueues
-    ? input.t("composer.input.queue")
-    : input.t("composer.input.send");
+  if (input.defaultActionQueues) return input.t("composer.input.queue");
+  return input.t("composer.input.sendWithNewline");
 }

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -79,6 +79,7 @@ export const ar: TranslationResources = {
       sendMessage: "أرسل رسالة",
       queue: "طابور",
       send: "يرسل",
+      sendWithNewline: "إرسال (Shift+Enter أو Alt+Enter لسطر جديد)",
     },
     cancel: {
       cancelingAgent: "وكيل الإلغاء",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -77,6 +77,7 @@ export const en = {
       sendMessage: "Send message",
       queue: "Queue",
       send: "Send",
+      sendWithNewline: "Send (Shift+Enter or Alt+Enter for new line)",
     },
     cancel: {
       cancelingAgent: "Canceling agent",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -79,6 +79,7 @@ export const es: TranslationResources = {
       sendMessage: "enviar mensaje",
       queue: "Cola",
       send: "Enviar",
+      sendWithNewline: "Enviar (Shift+Enter o Alt+Enter para nueva línea)",
     },
     cancel: {
       cancelingAgent: "Agente de cancelación",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -80,6 +80,7 @@ export const fr: TranslationResources = {
       sendMessage: "Envoyer un message",
       queue: "File d'attente",
       send: "Envoyer",
+      sendWithNewline: "Envoyer (Shift+Entrée ou Alt+Entrée pour un saut de ligne)",
     },
     cancel: {
       cancelingAgent: "Agent d'annulation",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -79,6 +79,7 @@ export const ja: TranslationResources = {
       sendMessage: "メッセージを送信",
       queue: "キュー",
       send: "送信",
+      sendWithNewline: "送信（Shift+Enter または Alt+Enter で改行）",
     },
     cancel: {
       cancelingAgent: "エージェントをキャンセル中",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -79,6 +79,7 @@ export const ptBR: TranslationResources = {
       sendMessage: "Enviar mensagem",
       queue: "Fila",
       send: "Enviar",
+      sendWithNewline: "Enviar (Shift+Enter ou Alt+Enter para nova linha)",
     },
     cancel: {
       cancelingAgent: "Cancelando agente",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -79,6 +79,7 @@ export const ru: TranslationResources = {
       sendMessage: "Отправить сообщение",
       queue: "Очередь",
       send: "Отправлять",
+      sendWithNewline: "Отправить (Shift+Enter или Alt+Enter для новой строки)",
     },
     cancel: {
       cancelingAgent: "Отменяющий агент",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -79,6 +79,7 @@ export const zhCN: TranslationResources = {
       sendMessage: "发送消息",
       queue: "排队",
       send: "发送",
+      sendWithNewline: "发送（Shift+Enter 或 Alt+Enter 换行）",
     },
     cancel: {
       cancelingAgent: "正在取消 Agent",


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds explicit newline insertion for the composer input on web/desktop:

- Shift+Enter and Alt+Enter now insert a newline at the current cursor/selection.
- Plain Enter and Mod+Enter keep the existing send/queue behavior.
- Adds controlled selection state so the cursor lands immediately after the inserted newline.
- Updates the send button tooltip to indicate the newline shortcut, but only on web/non-compact where the shortcuts are active.
- Adds composer.input.sendWithNewline translations for all supported locales.
- Extracts the desktop key-handling logic into a pure keyboard.ts helper and adds unit tests for newline insertion, send behavior, IME interception, and the onKeyPress callback override.

### How did you verify it

- Ran npm run lint on all changed files: passed.
- Ran npm run format: passed.
- Ran npx vitest run packages/app/src/composer/input/input.test.tsx packages/app/src/composer/input/labels.test.ts packages/app/src/composer/input/state.test.ts --bail=1: 32 tests passed.
- Note: npm run typecheck fails in this checkout due to pre-existing repository-wide issues (missing zod-aot, browser-automation protocol mismatches, etc.) unrelated to this change. No new type errors were introduced in packages/app/src/composer/input/* or packages/app/src/i18n/resources/*.
- UI was not manually screenshot-tested; this change is limited to keyboard behavior in the existing composer input.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [ ] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense