### PR TITLE
Include desktop app logs in diagnostics

### DIFF
--- a/packages/app/src/components/app-diagnostic-sheet.tsx
+++ b/packages/app/src/components/app-diagnostic-sheet.tsx
@@ -9,7 +9,6 @@ import { AdaptiveModalSheet, type SheetHeader } from "@/components/adaptive-moda
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { ScrollableCodeSurface, SurfaceCard } from "@/components/ui/scrollable-code-surface";
 import { useToast } from "@/contexts/toast-context";
-import { getDesktopDaemonLogs, getDesktopDaemonStatus } from "@/desktop/daemon/desktop-daemon";
 import {
   formatAppDiagnosticHeader,
   formatDiagnosticSection,
@@ -17,6 +16,7 @@ import {
   formatServerInfoSection,
   redactAppDiagnosticReport,
 } from "@/diagnostics/app-diagnostic-report";
+import { collectDesktopDiagnosticSections } from "@/diagnostics/desktop-diagnostic-report";
 import { getHostRuntimeStore, useHosts, type HostRuntimeSnapshot } from "@/runtime/host-runtime";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import type { HostProfile } from "@/types/host-connection";
@@ -261,35 +261,6 @@ export function AppDiagnosticSheet({
   );
 }
 
-async function collectDesktopDiagnosticSections(): Promise<DiagnosticCollectionResult> {
-  try {
-    const [status, logs] = await Promise.all([getDesktopDaemonStatus(), getDesktopDaemonLogs()]);
-    return {
-      status: "done",
-      sections: [
-        formatDiagnosticSection("Desktop", [
-          { label: "Daemon status", value: status.status },
-          { label: "Desktop managed", value: String(status.desktopManaged) },
-          { label: "Daemon PID", value: status.pid === null ? "none" : String(status.pid) },
-          { label: "Daemon version", value: status.version ?? "unknown" },
-          { label: "Daemon home", value: status.home || "unknown" },
-          { label: "Log path", value: logs.logPath || "unknown" },
-          { label: "Error", value: status.error ?? "none" },
-        ]),
-        [
-          "Desktop daemon log tail",
-          logs.contents ? indentBlock(logs.contents) : "  No log lines found",
-        ].join("\n"),
-      ],
-    };
-  } catch (error) {
-    return {
-      status: "failed",
-      sections: [formatDiagnosticSection("Desktop", [{ label: "Error", value: toMessage(error) }])],
-    };
-  }
-}
-
 async function collectHostDiagnosticSections(
   host: HostProfile,
   snapshot: HostRuntimeSnapshot | null,
@@ -336,14 +307,6 @@ async function collectHostDiagnosticSections(
     );
     return { sections, status: "failed" };
   }
-}
-
-function indentBlock(value: string): string {
-  return value
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => `  ${line}`)
-    .join("\n");
 }
 
 function toMessage(error: unknown): string {

--- a/packages/app/src/desktop/daemon/desktop-daemon.ts
+++ b/packages/app/src/desktop/daemon/desktop-daemon.ts
@@ -28,6 +28,11 @@ export interface DesktopDaemonLogs {
   contents: string;
 }
 
+export interface DesktopAppLogs {
+  logPath: string;
+  contents: string;
+}
+
 export interface DesktopPairingOffer {
   relayEnabled: boolean;
   url: string | null;
@@ -107,6 +112,16 @@ function parseDesktopDaemonLogs(raw: unknown): DesktopDaemonLogs {
   };
 }
 
+function parseDesktopAppLogs(raw: unknown): DesktopAppLogs {
+  if (!isRecord(raw)) {
+    throw new Error("Unexpected desktop app logs response.");
+  }
+  return {
+    logPath: toStringOrNull(raw.logPath) ?? "",
+    contents: typeof raw.contents === "string" ? raw.contents : "",
+  };
+}
+
 function parseDesktopPairingOffer(raw: unknown): DesktopPairingOffer {
   if (!isRecord(raw)) {
     throw new Error("Unexpected desktop daemon pairing response.");
@@ -142,6 +157,10 @@ export async function restartDesktopDaemon(): Promise<DesktopDaemonStatus> {
 
 export async function getDesktopDaemonLogs(): Promise<DesktopDaemonLogs> {
   return parseDesktopDaemonLogs(await invokeDesktopCommand("desktop_daemon_logs"));
+}
+
+export async function getDesktopAppLogs(): Promise<DesktopAppLogs> {
+  return parseDesktopAppLogs(await invokeDesktopCommand("desktop_app_logs"));
 }
 
 export async function getDesktopDaemonPairing(): Promise<DesktopPairingOffer> {

--- a/packages/app/src/desktop/daemon/desktop-daemon.ts
+++ b/packages/app/src/desktop/daemon/desktop-daemon.ts
@@ -112,16 +112,6 @@ function parseDesktopDaemonLogs(raw: unknown): DesktopDaemonLogs {
   };
 }
 
-function parseDesktopAppLogs(raw: unknown): DesktopAppLogs {
-  if (!isRecord(raw)) {
-    throw new Error("Unexpected desktop app logs response.");
-  }
-  return {
-    logPath: toStringOrNull(raw.logPath) ?? "",
-    contents: typeof raw.contents === "string" ? raw.contents : "",
-  };
-}
-
 function parseDesktopPairingOffer(raw: unknown): DesktopPairingOffer {
   if (!isRecord(raw)) {
     throw new Error("Unexpected desktop daemon pairing response.");
@@ -160,7 +150,14 @@ export async function getDesktopDaemonLogs(): Promise<DesktopDaemonLogs> {
 }
 
 export async function getDesktopAppLogs(): Promise<DesktopAppLogs> {
-  return parseDesktopAppLogs(await invokeDesktopCommand("desktop_app_logs"));
+  const raw = await invokeDesktopCommand("desktop_app_logs");
+  if (!isRecord(raw)) {
+    throw new Error("Unexpected desktop app logs response.");
+  }
+  return {
+    logPath: toStringOrNull(raw.logPath) ?? "",
+    contents: typeof raw.contents === "string" ? raw.contents : "",
+  };
 }
 
 export async function getDesktopDaemonPairing(): Promise<DesktopPairingOffer> {

--- a/packages/app/src/diagnostics/app-diagnostic-report.test.ts
+++ b/packages/app/src/diagnostics/app-diagnostic-report.test.ts
@@ -82,6 +82,7 @@ describe("app diagnostics report", () => {
     const host = makeHost();
     const redacted = redactAppDiagnosticReport(
       [
+        "Desktop app log tail",
         "secret.example.test:6767",
         "relay.secret.test:443",
         "daemon-public-key-secret",

--- a/packages/app/src/diagnostics/desktop-diagnostic-report.test.ts
+++ b/packages/app/src/diagnostics/desktop-diagnostic-report.test.ts
@@ -29,6 +29,36 @@ function makeSources(): DesktopDiagnosticSources {
 }
 
 describe("desktop diagnostic report", () => {
+  test("starts desktop diagnostic requests together", async () => {
+    const calls: string[] = [];
+    let releaseAppLogs: () => void = () => {};
+    const appLogGate = new Promise<void>((resolve) => {
+      releaseAppLogs = resolve;
+    });
+    const sources: DesktopDiagnosticSources = {
+      ...makeSources(),
+      getStatus: async () => {
+        calls.push("status");
+        return makeSources().getStatus();
+      },
+      getDaemonLogs: async () => {
+        calls.push("daemonLogs");
+        return makeSources().getDaemonLogs();
+      },
+      getAppLogs: async () => {
+        calls.push("appLogs");
+        await appLogGate;
+        return makeSources().getAppLogs();
+      },
+    };
+
+    const resultPromise = collectDesktopDiagnosticSectionsFromSources(sources);
+
+    expect(calls).toEqual(["status", "daemonLogs", "appLogs"]);
+    releaseAppLogs();
+    await expect(resultPromise).resolves.toMatchObject({ status: "done" });
+  });
+
   test("includes the Electron main-process log after the daemon log", async () => {
     const result = await collectDesktopDiagnosticSectionsFromSources(makeSources());
     const report = result.sections.join("\n\n");

--- a/packages/app/src/diagnostics/desktop-diagnostic-report.test.ts
+++ b/packages/app/src/diagnostics/desktop-diagnostic-report.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
-  collectDesktopDiagnosticSectionsFromSources,
+  collectDesktopDiagnosticSections,
   type DesktopDiagnosticSources,
 } from "./desktop-diagnostic-report";
 
@@ -52,7 +52,7 @@ describe("desktop diagnostic report", () => {
       },
     };
 
-    const resultPromise = collectDesktopDiagnosticSectionsFromSources(sources);
+    const resultPromise = collectDesktopDiagnosticSections(sources);
 
     expect(calls).toEqual(["status", "daemonLogs", "appLogs"]);
     releaseAppLogs();
@@ -60,7 +60,7 @@ describe("desktop diagnostic report", () => {
   });
 
   test("includes the Electron main-process log after the daemon log", async () => {
-    const result = await collectDesktopDiagnosticSectionsFromSources(makeSources());
+    const result = await collectDesktopDiagnosticSections(makeSources());
     const report = result.sections.join("\n\n");
 
     expect(result.status).toBe("done");
@@ -83,7 +83,7 @@ describe("desktop diagnostic report", () => {
       },
     };
 
-    const result = await collectDesktopDiagnosticSectionsFromSources(sources);
+    const result = await collectDesktopDiagnosticSections(sources);
     const report = result.sections.join("\n\n");
 
     expect(result.status).toBe("failed");

--- a/packages/app/src/diagnostics/desktop-diagnostic-report.test.ts
+++ b/packages/app/src/diagnostics/desktop-diagnostic-report.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import {
+  collectDesktopDiagnosticSectionsFromSources,
+  type DesktopDiagnosticSources,
+} from "./desktop-diagnostic-report";
+
+function makeSources(): DesktopDiagnosticSources {
+  return {
+    getStatus: async () => ({
+      serverId: "server-1",
+      status: "running",
+      listen: "127.0.0.1:6767",
+      hostname: "host",
+      pid: 4242,
+      home: "/paseo/home",
+      version: "1.2.3",
+      desktopManaged: true,
+      error: null,
+    }),
+    getDaemonLogs: async () => ({
+      logPath: "/paseo/home/daemon.log",
+      contents: "daemon line one\ndaemon line two",
+    }),
+    getAppLogs: async () => ({
+      logPath: "/logs/Paseo/main.log",
+      contents: "[login-shell-env] start\n[login-shell-env] failed",
+    }),
+  };
+}
+
+describe("desktop diagnostic report", () => {
+  test("includes the Electron main-process log after the daemon log", async () => {
+    const result = await collectDesktopDiagnosticSectionsFromSources(makeSources());
+    const report = result.sections.join("\n\n");
+
+    expect(result.status).toBe("done");
+    expect(report).toContain("  Log path: /paseo/home/daemon.log");
+    expect(report).toContain("  App log path: /logs/Paseo/main.log");
+    expect(report).toContain("Desktop daemon log tail\n  daemon line one\n  daemon line two");
+    expect(report).toContain(
+      "Desktop app log tail\n  [login-shell-env] start\n  [login-shell-env] failed",
+    );
+    expect(report.indexOf("Desktop app log tail")).toBeGreaterThan(
+      report.indexOf("Desktop daemon log tail"),
+    );
+  });
+
+  test("keeps daemon diagnostics when the Electron app log fails", async () => {
+    const sources = {
+      ...makeSources(),
+      getAppLogs: async () => {
+        throw new Error("app log unavailable");
+      },
+    };
+
+    const result = await collectDesktopDiagnosticSectionsFromSources(sources);
+    const report = result.sections.join("\n\n");
+
+    expect(result.status).toBe("failed");
+    expect(report).toContain("Desktop daemon log tail\n  daemon line one\n  daemon line two");
+    expect(report).toContain("Desktop app log tail\n  Error: app log unavailable");
+  });
+});

--- a/packages/app/src/diagnostics/desktop-diagnostic-report.ts
+++ b/packages/app/src/diagnostics/desktop-diagnostic-report.ts
@@ -21,16 +21,14 @@ export interface DesktopDiagnosticSources {
   getAppLogs: () => Promise<DesktopAppLogs>;
 }
 
-export async function collectDesktopDiagnosticSections(): Promise<DesktopDiagnosticCollectionResult> {
-  return collectDesktopDiagnosticSectionsFromSources({
-    getStatus: getDesktopDaemonStatus,
-    getDaemonLogs: getDesktopDaemonLogs,
-    getAppLogs: getDesktopAppLogs,
-  });
-}
+const DEFAULT_DESKTOP_DIAGNOSTIC_SOURCES: DesktopDiagnosticSources = {
+  getStatus: getDesktopDaemonStatus,
+  getDaemonLogs: getDesktopDaemonLogs,
+  getAppLogs: getDesktopAppLogs,
+};
 
-export async function collectDesktopDiagnosticSectionsFromSources(
-  sources: DesktopDiagnosticSources,
+export async function collectDesktopDiagnosticSections(
+  sources: DesktopDiagnosticSources = DEFAULT_DESKTOP_DIAGNOSTIC_SOURCES,
 ): Promise<DesktopDiagnosticCollectionResult> {
   const sections: string[] = [];
   let failed = false;

--- a/packages/app/src/diagnostics/desktop-diagnostic-report.ts
+++ b/packages/app/src/diagnostics/desktop-diagnostic-report.ts
@@ -1,0 +1,105 @@
+import {
+  getDesktopAppLogs,
+  getDesktopDaemonLogs,
+  getDesktopDaemonStatus,
+  type DesktopAppLogs,
+  type DesktopDaemonLogs,
+  type DesktopDaemonStatus,
+} from "@/desktop/daemon/desktop-daemon";
+import { formatDiagnosticSection } from "./app-diagnostic-report";
+
+type DesktopDiagnosticStatus = "done" | "failed";
+
+export interface DesktopDiagnosticCollectionResult {
+  sections: string[];
+  status: DesktopDiagnosticStatus;
+}
+
+export interface DesktopDiagnosticSources {
+  getStatus: () => Promise<DesktopDaemonStatus>;
+  getDaemonLogs: () => Promise<DesktopDaemonLogs>;
+  getAppLogs: () => Promise<DesktopAppLogs>;
+}
+
+export async function collectDesktopDiagnosticSections(): Promise<DesktopDiagnosticCollectionResult> {
+  return collectDesktopDiagnosticSectionsFromSources({
+    getStatus: getDesktopDaemonStatus,
+    getDaemonLogs: getDesktopDaemonLogs,
+    getAppLogs: getDesktopAppLogs,
+  });
+}
+
+export async function collectDesktopDiagnosticSectionsFromSources(
+  sources: DesktopDiagnosticSources,
+): Promise<DesktopDiagnosticCollectionResult> {
+  const sections: string[] = [];
+  let failed = false;
+  let appLogs: DesktopAppLogs | null = null;
+
+  try {
+    appLogs = await sources.getAppLogs();
+  } catch (error) {
+    failed = true;
+    sections.push(
+      formatDiagnosticSection("Desktop app log tail", [
+        { label: "Error", value: toMessage(error) },
+      ]),
+    );
+  }
+
+  try {
+    const [status, daemonLogs] = await Promise.all([sources.getStatus(), sources.getDaemonLogs()]);
+    sections.unshift(...formatDesktopDaemonSections({ status, daemonLogs, appLogs }));
+  } catch (error) {
+    failed = true;
+    sections.unshift(
+      formatDiagnosticSection("Desktop", [{ label: "Error", value: toMessage(error) }]),
+    );
+  }
+
+  if (appLogs) {
+    sections.push(formatLogTailSection("Desktop app log tail", appLogs.contents));
+  }
+
+  return {
+    status: failed ? "failed" : "done",
+    sections,
+  };
+}
+
+function formatDesktopDaemonSections(input: {
+  status: DesktopDaemonStatus;
+  daemonLogs: DesktopDaemonLogs;
+  appLogs: DesktopAppLogs | null;
+}): string[] {
+  const { status, daemonLogs, appLogs } = input;
+  return [
+    formatDiagnosticSection("Desktop", [
+      { label: "Daemon status", value: status.status },
+      { label: "Desktop managed", value: String(status.desktopManaged) },
+      { label: "Daemon PID", value: status.pid === null ? "none" : String(status.pid) },
+      { label: "Daemon version", value: status.version ?? "unknown" },
+      { label: "Daemon home", value: status.home || "unknown" },
+      { label: "Log path", value: daemonLogs.logPath || "unknown" },
+      { label: "App log path", value: appLogs?.logPath || "unavailable" },
+      { label: "Error", value: status.error ?? "none" },
+    ]),
+    formatLogTailSection("Desktop daemon log tail", daemonLogs.contents),
+  ];
+}
+
+function formatLogTailSection(title: string, contents: string): string {
+  return [title, contents ? indentBlock(contents) : "  No log lines found"].join("\n");
+}
+
+function indentBlock(value: string): string {
+  return value
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => `  ${line}`)
+    .join("\n");
+}
+
+function toMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/app/src/diagnostics/desktop-diagnostic-report.ts
+++ b/packages/app/src/diagnostics/desktop-diagnostic-report.ts
@@ -34,31 +34,34 @@ export async function collectDesktopDiagnosticSectionsFromSources(
 ): Promise<DesktopDiagnosticCollectionResult> {
   const sections: string[] = [];
   let failed = false;
-  let appLogs: DesktopAppLogs | null = null;
 
-  try {
-    appLogs = await sources.getAppLogs();
-  } catch (error) {
+  const [daemonResult, appLogsResult] = await Promise.allSettled([
+    Promise.all([sources.getStatus(), sources.getDaemonLogs()]),
+    sources.getAppLogs(),
+  ]);
+
+  if (daemonResult.status === "fulfilled") {
+    const [status, daemonLogs] = daemonResult.value;
+    const appLogs = appLogsResult.status === "fulfilled" ? appLogsResult.value : null;
+    sections.unshift(...formatDesktopDaemonSections({ status, daemonLogs, appLogs }));
+  } else {
     failed = true;
-    sections.push(
-      formatDiagnosticSection("Desktop app log tail", [
-        { label: "Error", value: toMessage(error) },
+    sections.unshift(
+      formatDiagnosticSection("Desktop", [
+        { label: "Error", value: toMessage(daemonResult.reason) },
       ]),
     );
   }
 
-  try {
-    const [status, daemonLogs] = await Promise.all([sources.getStatus(), sources.getDaemonLogs()]);
-    sections.unshift(...formatDesktopDaemonSections({ status, daemonLogs, appLogs }));
-  } catch (error) {
+  if (appLogsResult.status === "fulfilled") {
+    sections.push(formatLogTailSection("Desktop app log tail", appLogsResult.value.contents));
+  } else {
     failed = true;
-    sections.unshift(
-      formatDiagnosticSection("Desktop", [{ label: "Error", value: toMessage(error) }]),
+    sections.push(
+      formatDiagnosticSection("Desktop app log tail", [
+        { label: "Error", value: toMessage(appLogsResult.reason) },
+      ]),
     );
-  }
-
-  if (appLogs) {
-    sections.push(formatLogTailSection("Desktop app log tail", appLogs.contents));
   }
 
   return {

--- a/packages/desktop/src/daemon/daemon-manager.test.ts
+++ b/packages/desktop/src/daemon/daemon-manager.test.ts
@@ -19,6 +19,8 @@ const mocks = vi.hoisted(() => ({
   spawnProcess: vi.fn(),
   logInfo: vi.fn(),
   logError: vi.fn(),
+  appLogPath: "/tmp/paseo-desktop-daemon-manager-test-main.log",
+  getElectronLogFile: vi.fn(),
 }));
 
 vi.mock("electron", () => ({
@@ -32,7 +34,15 @@ vi.mock("electron", () => ({
 }));
 
 vi.mock("electron-log/main", () => ({
-  default: { info: mocks.logInfo, error: mocks.logError },
+  default: {
+    info: mocks.logInfo,
+    error: mocks.logError,
+    transports: {
+      file: {
+        getFile: mocks.getElectronLogFile,
+      },
+    },
+  },
 }));
 
 vi.mock("@getpaseo/server", () => ({
@@ -105,11 +115,15 @@ describe("daemon-manager commands", () => {
     mocks.spawnProcess.mockReset();
     mocks.logInfo.mockReset();
     mocks.logError.mockReset();
+    mocks.getElectronLogFile.mockReset();
+    mocks.getElectronLogFile.mockReturnValue({ path: mocks.appLogPath });
     rmSync(mocks.paseoHome, { recursive: true, force: true });
+    rmSync(mocks.appLogPath, { force: true });
   });
 
   afterEach(() => {
     rmSync(mocks.paseoHome, { recursive: true, force: true });
+    rmSync(mocks.appLogPath, { force: true });
   });
 
   it("refuses start and restart while built-in daemon management is disabled", async () => {
@@ -434,5 +448,20 @@ describe("daemon-manager commands", () => {
         envOverlay: expect.objectContaining({ PASEO_WEB_UI_ENABLED: "false" }),
       }),
     );
+  });
+
+  it("returns the Electron main-process log tail from electron-log", () => {
+    writeFileSync(
+      mocks.appLogPath,
+      Array.from({ length: 105 }, (_value, index) => `main log line ${index + 1}`).join("\n"),
+    );
+    const handlers = createDaemonCommandHandlers();
+
+    expect(handlers.desktop_app_logs()).toEqual({
+      logPath: mocks.appLogPath,
+      contents: Array.from({ length: 100 }, (_value, index) => `main log line ${index + 6}`).join(
+        "\n",
+      ),
+    });
   });
 });

--- a/packages/desktop/src/daemon/daemon-manager.ts
+++ b/packages/desktop/src/daemon/daemon-manager.ts
@@ -39,6 +39,7 @@ import {
 import type { DesktopSettings } from "../settings/desktop-settings.js";
 import { getDesktopSettingsStore } from "../settings/desktop-settings-electron.js";
 import { isRunningUnderARM64Translation } from "../system/arm64-translation.js";
+import { getDesktopAppLogs } from "../diagnostics/app-logs.js";
 
 const DAEMON_LOG_FILENAME = "daemon.log";
 const STARTUP_POLL_INTERVAL_MS = 200;
@@ -574,6 +575,7 @@ export function createDaemonCommandHandlers(): Record<string, DesktopCommandHand
     stop_desktop_daemon: (args) => stopDesktopDaemon(parseDesktopDaemonStopReason(args)),
     restart_desktop_daemon: () => restartDaemon(),
     desktop_daemon_logs: () => getDaemonLogs(),
+    desktop_app_logs: () => getDesktopAppLogs(),
     desktop_daemon_pairing: () => getDaemonPairing(),
     desktop_get_system_idle_time: () => powerMonitor.getSystemIdleTime() * 1000,
     cli_daemon_status: () => getCliDaemonStatus(),

--- a/packages/desktop/src/daemon/daemon-manager.ts
+++ b/packages/desktop/src/daemon/daemon-manager.ts
@@ -40,6 +40,7 @@ import type { DesktopSettings } from "../settings/desktop-settings.js";
 import { getDesktopSettingsStore } from "../settings/desktop-settings-electron.js";
 import { isRunningUnderARM64Translation } from "../system/arm64-translation.js";
 import { getDesktopAppLogs } from "../diagnostics/app-logs.js";
+import { tailFile } from "../diagnostics/tail-file.js";
 
 const DAEMON_LOG_FILENAME = "daemon.log";
 const STARTUP_POLL_INTERVAL_MS = 200;
@@ -210,15 +211,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-}
-
-function tailFile(filePath: string, lines = 50): string {
-  try {
-    const content = readFileSync(filePath, "utf-8");
-    return content.split("\n").filter(Boolean).slice(-lines).join("\n");
-  } catch {
-    return "";
-  }
 }
 
 function logDesktopDaemonLifecycle(message: string, details?: Record<string, unknown>): void {

--- a/packages/desktop/src/diagnostics/app-logs.ts
+++ b/packages/desktop/src/diagnostics/app-logs.ts
@@ -12,6 +12,6 @@ export function getDesktopAppLogs(): DesktopAppLogs {
   const logPath = log.transports.file.getFile().path;
   return {
     logPath,
-    contents: tailFile(logPath, APP_LOG_TAIL_LINES),
+    contents: tailFile(logPath, APP_LOG_TAIL_LINES, { throwOnReadError: true }),
   };
 }

--- a/packages/desktop/src/diagnostics/app-logs.ts
+++ b/packages/desktop/src/diagnostics/app-logs.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
 import log from "electron-log/main";
+import { tailFile } from "./tail-file.js";
 
 const APP_LOG_TAIL_LINES = 100;
 
@@ -14,13 +14,4 @@ export function getDesktopAppLogs(): DesktopAppLogs {
     logPath,
     contents: tailFile(logPath, APP_LOG_TAIL_LINES),
   };
-}
-
-function tailFile(filePath: string, lines: number): string {
-  try {
-    const content = readFileSync(filePath, "utf-8");
-    return content.split("\n").filter(Boolean).slice(-lines).join("\n");
-  } catch {
-    return "";
-  }
 }

--- a/packages/desktop/src/diagnostics/app-logs.ts
+++ b/packages/desktop/src/diagnostics/app-logs.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import log from "electron-log/main";
+
+const APP_LOG_TAIL_LINES = 100;
+
+export interface DesktopAppLogs {
+  logPath: string;
+  contents: string;
+}
+
+export function getDesktopAppLogs(): DesktopAppLogs {
+  const logPath = log.transports.file.getFile().path;
+  return {
+    logPath,
+    contents: tailFile(logPath, APP_LOG_TAIL_LINES),
+  };
+}
+
+function tailFile(filePath: string, lines: number): string {
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    return content.split("\n").filter(Boolean).slice(-lines).join("\n");
+  } catch {
+    return "";
+  }
+}

--- a/packages/desktop/src/diagnostics/tail-file.test.ts
+++ b/packages/desktop/src/diagnostics/tail-file.test.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { tailFile } from "./tail-file";
+
+let testDir = "";
+
+describe("tailFile", () => {
+  beforeEach(() => {
+    testDir = mkdtempSync(path.join(tmpdir(), "paseo-tail-file-"));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("returns the requested tail lines", () => {
+    const filePath = path.join(testDir, "main.log");
+    writeFileSync(filePath, "one\ntwo\nthree\n");
+
+    expect(tailFile(filePath, 2)).toBe("two\nthree");
+  });
+
+  it("keeps missing files empty", () => {
+    expect(tailFile(path.join(testDir, "missing.log"), 2)).toBe("");
+    expect(tailFile(path.join(testDir, "missing.log"), 2, { throwOnReadError: true })).toBe("");
+  });
+
+  it("can propagate read failures", () => {
+    expect(() => tailFile(testDir, 2, { throwOnReadError: true })).toThrow();
+    expect(tailFile(testDir, 2)).toBe("");
+  });
+});

--- a/packages/desktop/src/diagnostics/tail-file.ts
+++ b/packages/desktop/src/diagnostics/tail-file.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+
+export function tailFile(filePath: string, lines = 50): string {
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    return content.split("\n").filter(Boolean).slice(-lines).join("\n");
+  } catch {
+    return "";
+  }
+}

--- a/packages/desktop/src/diagnostics/tail-file.ts
+++ b/packages/desktop/src/diagnostics/tail-file.ts
@@ -1,10 +1,21 @@
 import { readFileSync } from "node:fs";
 
-export function tailFile(filePath: string, lines = 50): string {
+interface TailFileOptions {
+  throwOnReadError?: boolean;
+}
+
+export function tailFile(filePath: string, lines = 50, options: TailFileOptions = {}): string {
   try {
     const content = readFileSync(filePath, "utf-8");
     return content.split("\n").filter(Boolean).slice(-lines).join("\n");
-  } catch {
+  } catch (error) {
+    if (options.throwOnReadError && !isMissingFileError(error)) {
+      throw error;
+    }
     return "";
   }
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
 }


### PR DESCRIPTION
### Linked issue

Refs #1904

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Problem: the app diagnostics report included daemon status and the daemon log tail, but not the Electron main-process log. That left desktop startup and environment-probe failures out of the report.

Mechanics: the desktop app already exposes daemon logs through Electron IPC and the app bridge. This adds a separate `desktop_app_logs` IPC command that resolves electron-log's active file transport path at runtime and returns the same last-100-lines shape.

Fix: Settings diagnostics now adds a `Desktop app log tail` section immediately after `Desktop daemon log tail`, keeps the same final redaction pass, and degrades app-log failures into a section error instead of dropping the rest of the report.

### How did you verify it

- `npm run build:server` to restore missing workspace build artifacts before desktop-side tests
- `npx vitest run packages/app/src/diagnostics/app-diagnostic-report.test.ts packages/app/src/diagnostics/desktop-diagnostic-report.test.ts packages/desktop/src/daemon/daemon-manager.test.ts --bail=1` (app diagnostics passed; desktop import needed the build above)
- `npx vitest run packages/desktop/src/daemon/daemon-manager.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A: diagnostic text content only)
- [x] Tests added or updated where it made sense