### PR TITLE
Fix desktop-managed daemon restart from settings

### DIFF
--- a/packages/app/src/screens/settings/daemon-restart.test.ts
+++ b/packages/app/src/screens/settings/daemon-restart.test.ts
@@ -24,6 +24,7 @@ function makeDeps(overrides?: {
   isElectron?: boolean;
   desktopDaemonStatus?: DesktopDaemonStatus;
   desktopSettings?: typeof desktopSettings;
+  desktopSettingsError?: Error;
   restartDesktopDaemon?: () => Promise<DesktopDaemonStatus>;
   restartServer?: (reason: string) => Promise<void>;
 }) {
@@ -36,6 +37,9 @@ function makeDeps(overrides?: {
     },
     getDesktopSettings: async () => {
       calls.push("desktop-settings");
+      if (overrides?.desktopSettingsError) {
+        throw overrides.desktopSettingsError;
+      }
       return overrides?.desktopSettings ?? desktopSettings;
     },
     restartDesktopDaemon:
@@ -62,30 +66,25 @@ describe("restartDaemonFromSettings", () => {
     expect(calls).toEqual(["desktop-status", "desktop-settings", "desktop-restart"]);
   });
 
-  it("restarts remote hosts over the daemon RPC", async () => {
-    const { calls, deps } = makeDeps();
+  it("restarts remote hosts over the daemon RPC without reading desktop settings", async () => {
+    const { calls, deps } = makeDeps({
+      desktopSettingsError: new Error("Unreadable desktop settings."),
+    });
 
     await restartDaemonFromSettings("remote-host", "settings_daemon_restart_remote", deps);
 
-    expect(calls).toEqual([
-      "desktop-status",
-      "desktop-settings",
-      "rpc-restart:settings_daemon_restart_remote",
-    ]);
+    expect(calls).toEqual(["desktop-status", "rpc-restart:settings_daemon_restart_remote"]);
   });
 
-  it("keeps manually managed local daemons on the RPC path", async () => {
+  it("keeps manually managed local daemons on the RPC path without reading desktop settings", async () => {
     const { calls, deps } = makeDeps({
       desktopDaemonStatus: { ...runningDesktopDaemonStatus, desktopManaged: false },
+      desktopSettingsError: new Error("Unreadable desktop settings."),
     });
 
     await restartDaemonFromSettings("local-desktop", "settings_daemon_restart_local", deps);
 
-    expect(calls).toEqual([
-      "desktop-status",
-      "desktop-settings",
-      "rpc-restart:settings_daemon_restart_local",
-    ]);
+    expect(calls).toEqual(["desktop-status", "rpc-restart:settings_daemon_restart_local"]);
   });
 
   it("keeps the RPC path when built-in daemon management is disabled", async () => {

--- a/packages/app/src/screens/settings/daemon-restart.test.ts
+++ b/packages/app/src/screens/settings/daemon-restart.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { DesktopDaemonStatus } from "@/desktop/daemon/desktop-daemon";
-import {
-  isLocalDesktopManagedDaemon,
-  restartDaemonFromSettings,
-  type SettingsDaemonRestartDeps,
-} from "./daemon-restart";
+import { restartDaemonFromSettings, type SettingsDaemonRestartDeps } from "./daemon-restart";
 
 const runningDesktopDaemonStatus: DesktopDaemonStatus = {
   serverId: "local-desktop",
@@ -57,54 +53,11 @@ function makeDeps(overrides?: {
   return { calls, deps };
 }
 
-describe("isLocalDesktopManagedDaemon", () => {
-  it("matches only the Electron desktop-managed daemon with the same server id", () => {
-    expect(
-      isLocalDesktopManagedDaemon(
-        " local-desktop ",
-        runningDesktopDaemonStatus,
-        desktopSettings,
-        true,
-      ),
-    ).toBe(true);
-    expect(
-      isLocalDesktopManagedDaemon("remote", runningDesktopDaemonStatus, desktopSettings, true),
-    ).toBe(false);
-    expect(
-      isLocalDesktopManagedDaemon(
-        "local-desktop",
-        runningDesktopDaemonStatus,
-        desktopSettings,
-        false,
-      ),
-    ).toBe(false);
-    expect(
-      isLocalDesktopManagedDaemon(
-        "local-desktop",
-        { ...runningDesktopDaemonStatus, desktopManaged: false },
-        desktopSettings,
-        true,
-      ),
-    ).toBe(false);
-    expect(
-      isLocalDesktopManagedDaemon(
-        "local-desktop",
-        runningDesktopDaemonStatus,
-        {
-          ...desktopSettings,
-          daemon: { ...desktopSettings.daemon, manageBuiltInDaemon: false },
-        },
-        true,
-      ),
-    ).toBe(false);
-  });
-});
-
 describe("restartDaemonFromSettings", () => {
   it("restarts the local desktop-managed daemon through the desktop bridge", async () => {
     const { calls, deps } = makeDeps();
 
-    await restartDaemonFromSettings("local-desktop", "settings_daemon_restart_local", deps);
+    await restartDaemonFromSettings(" local-desktop ", "settings_daemon_restart_local", deps);
 
     expect(calls).toEqual(["desktop-status", "desktop-settings", "desktop-restart"]);
   });

--- a/packages/app/src/screens/settings/daemon-restart.test.ts
+++ b/packages/app/src/screens/settings/daemon-restart.test.ts
@@ -18,9 +18,16 @@ const runningDesktopDaemonStatus: DesktopDaemonStatus = {
   error: null,
 };
 
+const desktopSettings = {
+  daemon: {
+    manageBuiltInDaemon: true,
+  },
+};
+
 function makeDeps(overrides?: {
   isElectron?: boolean;
   desktopDaemonStatus?: DesktopDaemonStatus;
+  desktopSettings?: typeof desktopSettings;
   restartDesktopDaemon?: () => Promise<DesktopDaemonStatus>;
   restartServer?: (reason: string) => Promise<void>;
 }) {
@@ -30,6 +37,10 @@ function makeDeps(overrides?: {
     getDesktopDaemonStatus: async () => {
       calls.push("desktop-status");
       return overrides?.desktopDaemonStatus ?? runningDesktopDaemonStatus;
+    },
+    getDesktopSettings: async () => {
+      calls.push("desktop-settings");
+      return overrides?.desktopSettings ?? desktopSettings;
     },
     restartDesktopDaemon:
       overrides?.restartDesktopDaemon ??
@@ -48,17 +59,41 @@ function makeDeps(overrides?: {
 
 describe("isLocalDesktopManagedDaemon", () => {
   it("matches only the Electron desktop-managed daemon with the same server id", () => {
-    expect(isLocalDesktopManagedDaemon(" local-desktop ", runningDesktopDaemonStatus, true)).toBe(
-      true,
-    );
-    expect(isLocalDesktopManagedDaemon("remote", runningDesktopDaemonStatus, true)).toBe(false);
-    expect(isLocalDesktopManagedDaemon("local-desktop", runningDesktopDaemonStatus, false)).toBe(
-      false,
-    );
+    expect(
+      isLocalDesktopManagedDaemon(
+        " local-desktop ",
+        runningDesktopDaemonStatus,
+        desktopSettings,
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      isLocalDesktopManagedDaemon("remote", runningDesktopDaemonStatus, desktopSettings, true),
+    ).toBe(false);
+    expect(
+      isLocalDesktopManagedDaemon(
+        "local-desktop",
+        runningDesktopDaemonStatus,
+        desktopSettings,
+        false,
+      ),
+    ).toBe(false);
     expect(
       isLocalDesktopManagedDaemon(
         "local-desktop",
         { ...runningDesktopDaemonStatus, desktopManaged: false },
+        desktopSettings,
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      isLocalDesktopManagedDaemon(
+        "local-desktop",
+        runningDesktopDaemonStatus,
+        {
+          ...desktopSettings,
+          daemon: { ...desktopSettings.daemon, manageBuiltInDaemon: false },
+        },
         true,
       ),
     ).toBe(false);
@@ -71,7 +106,7 @@ describe("restartDaemonFromSettings", () => {
 
     await restartDaemonFromSettings("local-desktop", "settings_daemon_restart_local", deps);
 
-    expect(calls).toEqual(["desktop-status", "desktop-restart"]);
+    expect(calls).toEqual(["desktop-status", "desktop-settings", "desktop-restart"]);
   });
 
   it("restarts remote hosts over the daemon RPC", async () => {
@@ -79,7 +114,11 @@ describe("restartDaemonFromSettings", () => {
 
     await restartDaemonFromSettings("remote-host", "settings_daemon_restart_remote", deps);
 
-    expect(calls).toEqual(["desktop-status", "rpc-restart:settings_daemon_restart_remote"]);
+    expect(calls).toEqual([
+      "desktop-status",
+      "desktop-settings",
+      "rpc-restart:settings_daemon_restart_remote",
+    ]);
   });
 
   it("keeps manually managed local daemons on the RPC path", async () => {
@@ -89,10 +128,31 @@ describe("restartDaemonFromSettings", () => {
 
     await restartDaemonFromSettings("local-desktop", "settings_daemon_restart_local", deps);
 
-    expect(calls).toEqual(["desktop-status", "rpc-restart:settings_daemon_restart_local"]);
+    expect(calls).toEqual([
+      "desktop-status",
+      "desktop-settings",
+      "rpc-restart:settings_daemon_restart_local",
+    ]);
   });
 
-  it("uses the RPC path outside Electron without reading desktop daemon status", async () => {
+  it("keeps the RPC path when built-in daemon management is disabled", async () => {
+    const { calls, deps } = makeDeps({
+      desktopSettings: {
+        ...desktopSettings,
+        daemon: { ...desktopSettings.daemon, manageBuiltInDaemon: false },
+      },
+    });
+
+    await restartDaemonFromSettings("local-desktop", "settings_daemon_restart_local", deps);
+
+    expect(calls).toEqual([
+      "desktop-status",
+      "desktop-settings",
+      "rpc-restart:settings_daemon_restart_local",
+    ]);
+  });
+
+  it("uses the RPC path outside Electron without reading desktop daemon status or settings", async () => {
     const { calls, deps } = makeDeps({
       isElectron: false,
     });
@@ -106,14 +166,14 @@ describe("restartDaemonFromSettings", () => {
     const { calls, deps } = makeDeps({
       restartDesktopDaemon: async () => {
         calls.push("desktop-restart");
-        throw new Error("Built-in daemon management is disabled.");
+        throw new Error("Desktop restart failed.");
       },
     });
 
     await expect(
       restartDaemonFromSettings("local-desktop", "settings_daemon_restart_local", deps),
-    ).rejects.toThrow("Built-in daemon management is disabled.");
+    ).rejects.toThrow("Desktop restart failed.");
 
-    expect(calls).toEqual(["desktop-status", "desktop-restart"]);
+    expect(calls).toEqual(["desktop-status", "desktop-settings", "desktop-restart"]);
   });
 });

--- a/packages/app/src/screens/settings/daemon-restart.test.ts
+++ b/packages/app/src/screens/settings/daemon-restart.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { DesktopDaemonStatus } from "@/desktop/daemon/desktop-daemon";
+import {
+  isLocalDesktopManagedDaemon,
+  restartDaemonFromSettings,
+  type SettingsDaemonRestartDeps,
+} from "./daemon-restart";
+
+const runningDesktopDaemonStatus: DesktopDaemonStatus = {
+  serverId: "local-desktop",
+  status: "running",
+  listen: null,
+  hostname: null,
+  pid: 123,
+  home: "/tmp/paseo",
+  version: "1.0.0",
+  desktopManaged: true,
+  error: null,
+};
+
+function makeDeps(overrides?: {
+  isElectron?: boolean;
+  desktopDaemonStatus?: DesktopDaemonStatus;
+  restartDesktopDaemon?: () => Promise<DesktopDaemonStatus>;
+  restartServer?: (reason: string) => Promise<void>;
+}) {
+  const calls: string[] = [];
+  const deps: SettingsDaemonRestartDeps = {
+    getIsElectron: () => overrides?.isElectron ?? true,
+    getDesktopDaemonStatus: async () => {
+      calls.push("desktop-status");
+      return overrides?.desktopDaemonStatus ?? runningDesktopDaemonStatus;
+    },
+    restartDesktopDaemon:
+      overrides?.restartDesktopDaemon ??
+      (async () => {
+        calls.push("desktop-restart");
+        return runningDesktopDaemonStatus;
+      }),
+    restartServer:
+      overrides?.restartServer ??
+      (async (reason) => {
+        calls.push(`rpc-restart:${reason}`);
+      }),
+  };
+  return { calls, deps };
+}
+
+describe("isLocalDesktopManagedDaemon", () => {
+  it("matches only the Electron desktop-managed daemon with the same server id", () => {
+    expect(isLocalDesktopManagedDaemon(" local-desktop ", runningDesktopDaemonStatus, true)).toBe(
+      true,
+    );
+    expect(isLocalDesktopManagedDaemon("remote", runningDesktopDaemonStatus, true)).toBe(false);
+    expect(isLocalDesktopManagedDaemon("local-desktop", runningDesktopDaemonStatus, false)).toBe(
+      false,
+    );
+    expect(
+      isLocalDesktopManagedDaemon(
+        "local-desktop",
+        { ...runningDesktopDaemonStatus, desktopManaged: false },
+        true,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("restartDaemonFromSettings", () => {
+  it("restarts the local desktop-managed daemon through the desktop bridge", async () => {
+    const { calls, deps } = makeDeps();
+
+    await restartDaemonFromSettings("local-desktop", "settings_daemon_restart_local", deps);
+
+    expect(calls).toEqual(["desktop-status", "desktop-restart"]);
+  });
+
+  it("restarts remote hosts over the daemon RPC", async () => {
+    const { calls, deps } = makeDeps();
+
+    await restartDaemonFromSettings("remote-host", "settings_daemon_restart_remote", deps);
+
+    expect(calls).toEqual(["desktop-status", "rpc-restart:settings_daemon_restart_remote"]);
+  });
+
+  it("keeps manually managed local daemons on the RPC path", async () => {
+    const { calls, deps } = makeDeps({
+      desktopDaemonStatus: { ...runningDesktopDaemonStatus, desktopManaged: false },
+    });
+
+    await restartDaemonFromSettings("local-desktop", "settings_daemon_restart_local", deps);
+
+    expect(calls).toEqual(["desktop-status", "rpc-restart:settings_daemon_restart_local"]);
+  });
+
+  it("uses the RPC path outside Electron without reading desktop daemon status", async () => {
+    const { calls, deps } = makeDeps({
+      isElectron: false,
+    });
+
+    await restartDaemonFromSettings("local-desktop", "settings_daemon_restart_local", deps);
+
+    expect(calls).toEqual(["rpc-restart:settings_daemon_restart_local"]);
+  });
+
+  it("surfaces desktop restart failures without falling back to worker recycle", async () => {
+    const { calls, deps } = makeDeps({
+      restartDesktopDaemon: async () => {
+        calls.push("desktop-restart");
+        throw new Error("Built-in daemon management is disabled.");
+      },
+    });
+
+    await expect(
+      restartDaemonFromSettings("local-desktop", "settings_daemon_restart_local", deps),
+    ).rejects.toThrow("Built-in daemon management is disabled.");
+
+    expect(calls).toEqual(["desktop-status", "desktop-restart"]);
+  });
+});

--- a/packages/app/src/screens/settings/daemon-restart.ts
+++ b/packages/app/src/screens/settings/daemon-restart.ts
@@ -19,17 +19,12 @@ export interface SettingsDaemonRestartDeps {
   restartServer: (reason: string) => Promise<unknown>;
 }
 
-export function isLocalDesktopManagedDaemon(
+function isLocalDesktopManagedDaemon(
   hostServerId: string,
   desktopDaemonStatus: DesktopDaemonRestartStatus,
   desktopSettings: DesktopDaemonRestartSettings,
-  isElectron: boolean,
 ): boolean {
-  if (
-    !isElectron ||
-    !desktopDaemonStatus.desktopManaged ||
-    !desktopSettings.daemon.manageBuiltInDaemon
-  ) {
+  if (!desktopDaemonStatus.desktopManaged || !desktopSettings.daemon.manageBuiltInDaemon) {
     return false;
   }
 
@@ -51,9 +46,7 @@ export async function restartDaemonFromSettings(
       deps.getDesktopDaemonStatus(),
       deps.getDesktopSettings(),
     ]);
-    if (
-      isLocalDesktopManagedDaemon(hostServerId, desktopDaemonStatus, desktopSettings, isElectron)
-    ) {
+    if (isLocalDesktopManagedDaemon(hostServerId, desktopDaemonStatus, desktopSettings)) {
       await deps.restartDesktopDaemon();
       return;
     }

--- a/packages/app/src/screens/settings/daemon-restart.ts
+++ b/packages/app/src/screens/settings/daemon-restart.ts
@@ -1,0 +1,43 @@
+import type { DesktopDaemonStatus } from "@/desktop/daemon/desktop-daemon";
+
+type DesktopDaemonRestartStatus = Pick<DesktopDaemonStatus, "desktopManaged" | "serverId">;
+
+export interface SettingsDaemonRestartDeps {
+  getIsElectron: () => boolean;
+  getDesktopDaemonStatus: () => Promise<DesktopDaemonRestartStatus>;
+  restartDesktopDaemon: () => Promise<DesktopDaemonStatus>;
+  restartServer: (reason: string) => Promise<unknown>;
+}
+
+export function isLocalDesktopManagedDaemon(
+  hostServerId: string,
+  desktopDaemonStatus: DesktopDaemonRestartStatus,
+  isElectron: boolean,
+): boolean {
+  if (!isElectron || !desktopDaemonStatus.desktopManaged) {
+    return false;
+  }
+
+  const normalizedHostServerId = hostServerId.trim();
+  const normalizedDesktopServerId = desktopDaemonStatus.serverId.trim();
+
+  return normalizedHostServerId.length > 0 && normalizedHostServerId === normalizedDesktopServerId;
+}
+
+export async function restartDaemonFromSettings(
+  hostServerId: string,
+  reason: string,
+  deps: SettingsDaemonRestartDeps,
+): Promise<void> {
+  const isElectron = deps.getIsElectron();
+
+  if (isElectron) {
+    const desktopDaemonStatus = await deps.getDesktopDaemonStatus();
+    if (isLocalDesktopManagedDaemon(hostServerId, desktopDaemonStatus, isElectron)) {
+      await deps.restartDesktopDaemon();
+      return;
+    }
+  }
+
+  await deps.restartServer(reason);
+}

--- a/packages/app/src/screens/settings/daemon-restart.ts
+++ b/packages/app/src/screens/settings/daemon-restart.ts
@@ -1,10 +1,20 @@
 import type { DesktopDaemonStatus } from "@/desktop/daemon/desktop-daemon";
 
-type DesktopDaemonRestartStatus = Pick<DesktopDaemonStatus, "desktopManaged" | "serverId">;
+interface DesktopDaemonRestartStatus {
+  desktopManaged: boolean;
+  serverId: string;
+}
+
+interface DesktopDaemonRestartSettings {
+  daemon: {
+    manageBuiltInDaemon: boolean;
+  };
+}
 
 export interface SettingsDaemonRestartDeps {
   getIsElectron: () => boolean;
   getDesktopDaemonStatus: () => Promise<DesktopDaemonRestartStatus>;
+  getDesktopSettings: () => Promise<DesktopDaemonRestartSettings>;
   restartDesktopDaemon: () => Promise<DesktopDaemonStatus>;
   restartServer: (reason: string) => Promise<unknown>;
 }
@@ -12,9 +22,14 @@ export interface SettingsDaemonRestartDeps {
 export function isLocalDesktopManagedDaemon(
   hostServerId: string,
   desktopDaemonStatus: DesktopDaemonRestartStatus,
+  desktopSettings: DesktopDaemonRestartSettings,
   isElectron: boolean,
 ): boolean {
-  if (!isElectron || !desktopDaemonStatus.desktopManaged) {
+  if (
+    !isElectron ||
+    !desktopDaemonStatus.desktopManaged ||
+    !desktopSettings.daemon.manageBuiltInDaemon
+  ) {
     return false;
   }
 
@@ -32,8 +47,13 @@ export async function restartDaemonFromSettings(
   const isElectron = deps.getIsElectron();
 
   if (isElectron) {
-    const desktopDaemonStatus = await deps.getDesktopDaemonStatus();
-    if (isLocalDesktopManagedDaemon(hostServerId, desktopDaemonStatus, isElectron)) {
+    const [desktopDaemonStatus, desktopSettings] = await Promise.all([
+      deps.getDesktopDaemonStatus(),
+      deps.getDesktopSettings(),
+    ]);
+    if (
+      isLocalDesktopManagedDaemon(hostServerId, desktopDaemonStatus, desktopSettings, isElectron)
+    ) {
       await deps.restartDesktopDaemon();
       return;
     }

--- a/packages/app/src/screens/settings/daemon-restart.ts
+++ b/packages/app/src/screens/settings/daemon-restart.ts
@@ -19,19 +19,28 @@ export interface SettingsDaemonRestartDeps {
   restartServer: (reason: string) => Promise<unknown>;
 }
 
-function isLocalDesktopManagedDaemon(
+async function isLocalDesktopManagedDaemon(
   hostServerId: string,
-  desktopDaemonStatus: DesktopDaemonRestartStatus,
-  desktopSettings: DesktopDaemonRestartSettings,
-): boolean {
-  if (!desktopDaemonStatus.desktopManaged || !desktopSettings.daemon.manageBuiltInDaemon) {
+  deps: SettingsDaemonRestartDeps,
+): Promise<boolean> {
+  if (!deps.getIsElectron()) {
+    return false;
+  }
+
+  const desktopDaemonStatus = await deps.getDesktopDaemonStatus();
+  if (!desktopDaemonStatus.desktopManaged) {
     return false;
   }
 
   const normalizedHostServerId = hostServerId.trim();
   const normalizedDesktopServerId = desktopDaemonStatus.serverId.trim();
 
-  return normalizedHostServerId.length > 0 && normalizedHostServerId === normalizedDesktopServerId;
+  if (normalizedHostServerId.length === 0 || normalizedHostServerId !== normalizedDesktopServerId) {
+    return false;
+  }
+
+  const desktopSettings = await deps.getDesktopSettings();
+  return desktopSettings.daemon.manageBuiltInDaemon;
 }
 
 export async function restartDaemonFromSettings(
@@ -39,17 +48,9 @@ export async function restartDaemonFromSettings(
   reason: string,
   deps: SettingsDaemonRestartDeps,
 ): Promise<void> {
-  const isElectron = deps.getIsElectron();
-
-  if (isElectron) {
-    const [desktopDaemonStatus, desktopSettings] = await Promise.all([
-      deps.getDesktopDaemonStatus(),
-      deps.getDesktopSettings(),
-    ]);
-    if (isLocalDesktopManagedDaemon(hostServerId, desktopDaemonStatus, desktopSettings)) {
-      await deps.restartDesktopDaemon();
-      return;
-    }
+  if (await isLocalDesktopManagedDaemon(hostServerId, deps)) {
+    await deps.restartDesktopDaemon();
+    return;
   }
 
   await deps.restartServer(reason);

--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -39,7 +39,7 @@ import {
 } from "@/desktop/daemon/desktop-daemon";
 import { LocalDaemonSection } from "@/desktop/components/desktop-updates-section";
 import { useDaemonStatus } from "@/desktop/hooks/use-daemon-status";
-import { useDesktopSettings } from "@/desktop/settings/desktop-settings";
+import { loadDesktopSettings, useDesktopSettings } from "@/desktop/settings/desktop-settings";
 import { PairDeviceModal } from "@/desktop/components/pair-device-modal";
 import { useDaemonConfig } from "@/hooks/use-daemon-config";
 import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
@@ -674,6 +674,7 @@ function RestartDaemonCard({ host }: { host: HostProfile }) {
         void restartDaemonFromSettings(host.serverId, `settings_daemon_restart_${host.serverId}`, {
           getIsElectron,
           getDesktopDaemonStatus,
+          getDesktopSettings: loadDesktopSettings,
           restartDesktopDaemon,
           restartServer: (reason) => daemonClient.restartServer(reason),
         }).catch((error) => {

--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -631,16 +631,38 @@ function RestartDaemonCard({ host }: { host: HostProfile }) {
     async (restartRequest: Promise<void>) => {
       const disconnectTimeoutMs = 30000;
       const reconnectTimeoutMs = 30000;
+      const requestFailureDisconnectGraceMs = 2000;
       const disconnectedPromise = isHostConnected()
         ? waitForCondition(() => !isHostConnected(), disconnectTimeoutMs)
         : Promise.resolve(true);
-      const restartSucceeded = await restartRequest.then(
-        () => true,
-        () => false,
+      const restartResult = await restartRequest.then(
+        () => ({ status: "accepted" as const }),
+        async (error) => ({
+          status: "rejected" as const,
+          error,
+          disconnectedAfterFailure: await waitForCondition(
+            () => !isHostConnected(),
+            requestFailureDisconnectGraceMs,
+            100,
+          ),
+        }),
       );
-      if (!restartSucceeded || !isMountedRef.current) return;
+      if (!isMountedRef.current) return;
 
-      const disconnected = await disconnectedPromise;
+      if (restartResult.status === "rejected" && !restartResult.disconnectedAfterFailure) {
+        console.error(`[HostPage] Failed to restart daemon ${host.label}`, restartResult.error);
+        setIsRestarting(false);
+        Alert.alert(
+          t("settings.host.daemon.restart.requestFailedTitle"),
+          t("settings.host.daemon.restart.requestFailedMessage"),
+        );
+        return;
+      }
+
+      const disconnected =
+        restartResult.status === "rejected"
+          ? restartResult.disconnectedAfterFailure
+          : await disconnectedPromise;
       const reconnected =
         disconnected && (await waitForCondition(() => isHostConnected(), reconnectTimeoutMs));
       if (isMountedRef.current) {
@@ -693,15 +715,6 @@ function RestartDaemonCard({ host }: { host: HostProfile }) {
             restartServer: (reason) => daemonClient.restartServer(reason),
           },
         );
-        void restartRequest.catch((error) => {
-          console.error(`[HostPage] Failed to restart daemon ${host.label}`, error);
-          if (!isMountedRef.current) return;
-          setIsRestarting(false);
-          Alert.alert(
-            t("settings.host.daemon.restart.requestFailedTitle"),
-            t("settings.host.daemon.restart.requestFailedMessage"),
-          );
-        });
         void waitForDaemonRestart(restartRequest);
         return;
       })

--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -627,23 +627,34 @@ function RestartDaemonCard({ host }: { host: HostProfile }) {
     [],
   );
 
-  const waitForDaemonRestart = useCallback(async () => {
-    const disconnectTimeoutMs = 7000;
-    const reconnectTimeoutMs = 30000;
-    if (isHostConnected()) {
-      await waitForCondition(() => !isHostConnected(), disconnectTimeoutMs);
-    }
-    const reconnected = await waitForCondition(() => isHostConnected(), reconnectTimeoutMs);
-    if (isMountedRef.current) {
-      setIsRestarting(false);
-      if (!reconnected) {
-        Alert.alert(
-          t("settings.host.daemon.restart.unableToReconnectTitle"),
-          t("settings.host.daemon.restart.unableToReconnectMessage", { name: host.label }),
-        );
+  const waitForDaemonRestart = useCallback(
+    async (restartRequest: Promise<void>) => {
+      const disconnectTimeoutMs = 30000;
+      const reconnectTimeoutMs = 30000;
+      const disconnectedPromise = isHostConnected()
+        ? waitForCondition(() => !isHostConnected(), disconnectTimeoutMs)
+        : Promise.resolve(true);
+      const restartSucceeded = await restartRequest.then(
+        () => true,
+        () => false,
+      );
+      if (!restartSucceeded || !isMountedRef.current) return;
+
+      const disconnected = await disconnectedPromise;
+      const reconnected =
+        disconnected && (await waitForCondition(() => isHostConnected(), reconnectTimeoutMs));
+      if (isMountedRef.current) {
+        setIsRestarting(false);
+        if (!reconnected) {
+          Alert.alert(
+            t("settings.host.daemon.restart.unableToReconnectTitle"),
+            t("settings.host.daemon.restart.unableToReconnectMessage", { name: host.label }),
+          );
+        }
       }
-    }
-  }, [host.label, isHostConnected, t, waitForCondition]);
+    },
+    [host.label, isHostConnected, t, waitForCondition],
+  );
 
   const handleRestart = useCallback(() => {
     if (!daemonClient) {
@@ -671,13 +682,18 @@ function RestartDaemonCard({ host }: { host: HostProfile }) {
       .then((confirmed) => {
         if (!confirmed) return;
         setIsRestarting(true);
-        void restartDaemonFromSettings(host.serverId, `settings_daemon_restart_${host.serverId}`, {
-          getIsElectron,
-          getDesktopDaemonStatus,
-          getDesktopSettings: loadDesktopSettings,
-          restartDesktopDaemon,
-          restartServer: (reason) => daemonClient.restartServer(reason),
-        }).catch((error) => {
+        const restartRequest = restartDaemonFromSettings(
+          host.serverId,
+          `settings_daemon_restart_${host.serverId}`,
+          {
+            getIsElectron,
+            getDesktopDaemonStatus,
+            getDesktopSettings: loadDesktopSettings,
+            restartDesktopDaemon,
+            restartServer: (reason) => daemonClient.restartServer(reason),
+          },
+        );
+        void restartRequest.catch((error) => {
           console.error(`[HostPage] Failed to restart daemon ${host.label}`, error);
           if (!isMountedRef.current) return;
           setIsRestarting(false);
@@ -686,7 +702,7 @@ function RestartDaemonCard({ host }: { host: HostProfile }) {
             t("settings.host.daemon.restart.requestFailedMessage"),
           );
         });
-        void waitForDaemonRestart();
+        void waitForDaemonRestart(restartRequest);
         return;
       })
       .catch((error) => {
@@ -726,7 +742,6 @@ function RestartDaemonCard({ host }: { host: HostProfile }) {
     </View>
   );
 }
-
 function UpdateDaemonCard({ host }: { host: HostProfile }) {
   const { t } = useTranslation();
   const { theme } = useUnistyles();

--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -30,7 +30,13 @@ import {
   ProfileDraft,
   TerminalProfileEditModal,
 } from "@/screens/settings/terminal-profile-edit-modal";
-import { startDesktopDaemon, stopDesktopDaemon } from "@/desktop/daemon/desktop-daemon";
+import { getIsElectron } from "@/constants/platform";
+import {
+  getDesktopDaemonStatus,
+  restartDesktopDaemon,
+  startDesktopDaemon,
+  stopDesktopDaemon,
+} from "@/desktop/daemon/desktop-daemon";
 import { LocalDaemonSection } from "@/desktop/components/desktop-updates-section";
 import { useDaemonStatus } from "@/desktop/hooks/use-daemon-status";
 import { useDesktopSettings } from "@/desktop/settings/desktop-settings";
@@ -62,6 +68,7 @@ import { ICON_SIZE } from "@/styles/theme";
 import type { Theme } from "@/styles/theme";
 import { getProviderIcon } from "@/components/provider-icons";
 import { BrowserToolsOptInCard } from "./browser-tools-card";
+import { restartDaemonFromSettings } from "./daemon-restart";
 
 const ThemedArrowUp = withUnistyles(ArrowUp);
 const ThemedArrowDown = withUnistyles(ArrowDown);
@@ -664,17 +671,20 @@ function RestartDaemonCard({ host }: { host: HostProfile }) {
       .then((confirmed) => {
         if (!confirmed) return;
         setIsRestarting(true);
-        void daemonClient
-          .restartServer(`settings_daemon_restart_${host.serverId}`)
-          .catch((error) => {
-            console.error(`[HostPage] Failed to restart daemon ${host.label}`, error);
-            if (!isMountedRef.current) return;
-            setIsRestarting(false);
-            Alert.alert(
-              t("settings.host.daemon.restart.requestFailedTitle"),
-              t("settings.host.daemon.restart.requestFailedMessage"),
-            );
-          });
+        void restartDaemonFromSettings(host.serverId, `settings_daemon_restart_${host.serverId}`, {
+          getIsElectron,
+          getDesktopDaemonStatus,
+          restartDesktopDaemon,
+          restartServer: (reason) => daemonClient.restartServer(reason),
+        }).catch((error) => {
+          console.error(`[HostPage] Failed to restart daemon ${host.label}`, error);
+          if (!isMountedRef.current) return;
+          setIsRestarting(false);
+          Alert.alert(
+            t("settings.host.daemon.restart.requestFailedTitle"),
+            t("settings.host.daemon.restart.requestFailedMessage"),
+          );
+        });
         void waitForDaemonRestart();
         return;
       })


### PR DESCRIPTION
### Linked issue

Refs #1492
Refs #509

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Settings restart now has two daemon restart semantics:

- Remote and manually managed hosts keep the existing `restartServer` RPC, which asks that daemon's worker to recycle under its current supervisor.
- The local desktop-managed daemon, when the app is running in Electron, uses the desktop `restartDesktopDaemon()` bridge so the desktop app stops the daemon and starts a fresh supervisor.

The worker recycle path cannot heal a poisoned supervisor environment because the supervisor respawns workers with the environment it captured when the supervisor started. If the desktop app initially launched the supervisor with a bad PATH or missing shell environment, recycling only creates another worker with the same bad environment. A desktop full restart recreates the supervisor from the desktop app's current environment plus the desktop-managed overlay.

The route decision now lives in one small settings helper that consumes the desktop status `serverId`/`desktopManaged` fields and the Electron gate. The existing confirmation dialog, reconnect watcher, and error alert path stay intact; desktop restart errors, including disabled built-in daemon management, surface through that existing request-failed path instead of silently falling back to worker recycle.

### How did you verify it

- `npm ci`
- `npm run format`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npx vitest run packages/app/src/screens/settings/daemon-restart.test.ts --bail=1`
- Commit hook also reran formatting, lint, and full typecheck on commit.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A: behavior-only settings action)
- [x] Tests added or updated where it made sense