### PR TITLE
Fix desktop PATH resolution when shell startup fails

### DIFF
--- a/packages/desktop/src/login-shell-env.test.ts
+++ b/packages/desktop/src/login-shell-env.test.ts
@@ -25,6 +25,7 @@ interface RecordedLog {
 }
 
 interface RecordedSpawn {
+  argv0: string | undefined;
   shell: string;
   args: string[];
   timeoutMs: number | undefined;
@@ -76,7 +77,7 @@ function spawnResult(fields: SpawnResultFields): SpawnSyncReturns<string> {
   const stderr = fields.stderr ?? "";
   return {
     pid: 0,
-    output: [stdout, stdout, stderr],
+    output: [null, stdout, stderr],
     stdout,
     stderr,
     status: fields.status === undefined ? 0 : fields.status,
@@ -120,6 +121,7 @@ describe("login shell env retry behavior", () => {
     const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
       const recordedArgs = Array.isArray(args) ? args.map(String) : [];
       calls.push({
+        argv0: options?.argv0,
         shell: String(shell),
         args: recordedArgs,
         timeoutMs: options?.timeout,
@@ -169,6 +171,7 @@ describe("login shell env retry behavior", () => {
     const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
       const recordedArgs = Array.isArray(args) ? args.map(String) : [];
       calls.push({
+        argv0: options?.argv0,
         shell: String(shell),
         args: recordedArgs,
         timeoutMs: options?.timeout,
@@ -240,6 +243,7 @@ describe("login shell env retry behavior", () => {
     const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
       const recordedArgs = Array.isArray(args) ? args.map(String) : [];
       calls.push({
+        argv0: options?.argv0,
         shell: String(shell),
         args: recordedArgs,
         timeoutMs: options?.timeout,
@@ -295,6 +299,7 @@ describe("login shell env retry behavior", () => {
     const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
       const recordedArgs = Array.isArray(args) ? args.map(String) : [];
       calls.push({
+        argv0: options?.argv0,
         shell: String(shell),
         args: recordedArgs,
         timeoutMs: options?.timeout,
@@ -366,6 +371,7 @@ describe("login shell env retry behavior", () => {
     const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
       const recordedArgs = Array.isArray(args) ? args.map(String) : [];
       calls.push({
+        argv0: options?.argv0,
         shell: String(shell),
         args: recordedArgs,
         timeoutMs: options?.timeout,
@@ -388,6 +394,57 @@ describe("login shell env retry behavior", () => {
     expect(logger.infos[2]?.fields).toMatchObject({
       durationMs: 4,
       timeoutMs: 1234,
+    });
+  });
+
+  it("uses argv0 for the non-interactive tcsh login retry", () => {
+    const env = {
+      ...createEnv(fakeHome),
+      SHELL: "/bin/tcsh",
+    };
+    const logger = new RecordingLoginShellLogger();
+    const clock = createTestClock();
+    const calls: RecordedSpawn[] = [];
+    const nonInteractivePath = "/tcsh/login/bin:/usr/bin:/bin";
+    const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
+      const recordedArgs = Array.isArray(args) ? args.map(String) : [];
+      calls.push({
+        argv0: options?.argv0,
+        shell: String(shell),
+        args: recordedArgs,
+        timeoutMs: options?.timeout,
+      });
+
+      if (calls.length === 1) {
+        clock.advance(8);
+        return spawnResult({ stdout: "no marker\n" });
+      }
+
+      clock.advance(2);
+      return successResult(String(recordedArgs.at(-1)), { ...env, PATH: nonInteractivePath });
+    };
+
+    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
+
+    expect(env.PATH).toBe(nonInteractivePath);
+    expect(calls).toHaveLength(2);
+    expect(shellArgsFromRecordedCall(calls[0])).toEqual(["-ic"]);
+    expect(calls[0]?.argv0).toBeUndefined();
+    expect(shellArgsFromRecordedCall(calls[1])).toEqual(["-c"]);
+    expect(calls[1]?.argv0).toBe("-tcsh");
+    expect(calls[1]?.timeoutMs).toBe(29_992);
+    expect(logger.warnings[0]?.fields).toMatchObject({
+      attemptKind: "interactive",
+      shellArgs: ["-ic"],
+      reason: "marker-missing",
+      timeoutMs: 15_000,
+    });
+    expect(logger.infos[1]?.fields).toMatchObject({
+      attemptKind: "non-interactive",
+      argv0: "-tcsh",
+      shellArgs: ["-c"],
+      reason: "success",
+      timeoutMs: 29_992,
     });
   });
 });

--- a/packages/desktop/src/login-shell-env.test.ts
+++ b/packages/desktop/src/login-shell-env.test.ts
@@ -130,7 +130,7 @@ describe("login shell env retry behavior", () => {
       return successResult(String(recordedArgs.at(-1)), { ...env, PATH: interactivePath });
     };
 
-    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
+    inheritLoginShellEnv({ env, logger, now: clock.now, platform: "darwin", spawnSync });
 
     expect(env.PATH).toBe(interactivePath);
     expect(calls).toHaveLength(1);
@@ -193,7 +193,7 @@ describe("login shell env retry behavior", () => {
       return successResult(String(recordedArgs.at(-1)), { ...env, PATH: nonInteractivePath });
     };
 
-    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
+    inheritLoginShellEnv({ env, logger, now: clock.now, platform: "darwin", spawnSync });
 
     expect(env.PATH).toBe(nonInteractivePath);
     expect(calls).toHaveLength(2);
@@ -258,7 +258,7 @@ describe("login shell env retry behavior", () => {
       return successResult(String(recordedArgs.at(-1)), { ...env, PATH: nonInteractivePath });
     };
 
-    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
+    inheritLoginShellEnv({ env, logger, now: clock.now, platform: "darwin", spawnSync });
 
     expect(env.PATH).toBe(nonInteractivePath);
     expect(calls).toHaveLength(2);
@@ -318,7 +318,7 @@ describe("login shell env retry behavior", () => {
       });
     };
 
-    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
+    inheritLoginShellEnv({ env, logger, now: clock.now, platform: "darwin", spawnSync });
 
     expect(env.PATH).toBe(basePath);
     expect(calls).toHaveLength(2);
@@ -380,7 +380,7 @@ describe("login shell env retry behavior", () => {
       return successResult(String(recordedArgs.at(-1)), { ...env, PATH: configuredPath });
     };
 
-    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
+    inheritLoginShellEnv({ env, logger, now: clock.now, platform: "darwin", spawnSync });
 
     expect(env.PATH).toBe(configuredPath);
     expect(calls).toHaveLength(1);
@@ -424,7 +424,7 @@ describe("login shell env retry behavior", () => {
       return successResult(String(recordedArgs.at(-1)), { ...env, PATH: nonInteractivePath });
     };
 
-    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
+    inheritLoginShellEnv({ env, logger, now: clock.now, platform: "darwin", spawnSync });
 
     expect(env.PATH).toBe(nonInteractivePath);
     expect(calls).toHaveLength(2);

--- a/packages/desktop/src/login-shell-env.test.ts
+++ b/packages/desktop/src/login-shell-env.test.ts
@@ -10,12 +10,27 @@ import { inheritLoginShellEnv } from "./login-shell-env";
 const zsh = "/bin/zsh";
 const describeIfZsh = existsSync(zsh) ? describe : describe.skip;
 const basePath = "/usr/bin:/bin:/usr/sbin:/sbin";
+const fakeHome = path.join(os.tmpdir(), "paseo-login-shell-env-fake-home");
 type LoginShellEnvInput = NonNullable<Parameters<typeof inheritLoginShellEnv>[0]>;
 type LoginShellSpawnSync = NonNullable<LoginShellEnvInput["spawnSync"]>;
 
 interface RecordedLog {
   message: string;
   fields: Record<string, unknown>;
+}
+
+interface RecordedSpawn {
+  shell: string;
+  args: string[];
+  timeoutMs: number | undefined;
+}
+
+interface SpawnResultFields {
+  stdout?: string;
+  stderr?: string;
+  status?: number | null;
+  signal?: NodeJS.Signals | null;
+  error?: Error;
 }
 
 class RecordingLoginShellLogger {
@@ -41,6 +56,31 @@ function createEnv(home: string): NodeJS.ProcessEnv {
   };
 }
 
+function spawnResult(fields: SpawnResultFields): SpawnSyncReturns<string> {
+  const stdout = fields.stdout ?? "";
+  const stderr = fields.stderr ?? "";
+  return {
+    pid: 0,
+    output: [stdout, stdout, stderr],
+    stdout,
+    stderr,
+    status: fields.status === undefined ? 0 : fields.status,
+    signal: fields.signal ?? null,
+    error: fields.error,
+  } satisfies SpawnSyncReturns<string>;
+}
+
+function successResult(shellCommand: string, env: NodeJS.ProcessEnv): SpawnSyncReturns<string> {
+  const marker = markerFromShellCommand(shellCommand);
+  const stdout = `${marker}${JSON.stringify(env)}${marker}`;
+  return spawnResult({ stdout });
+}
+
+function shellArgsFromRecordedCall(call: RecordedSpawn | undefined): string[] {
+  if (!call) return [];
+  return call.args.slice(0, -1);
+}
+
 function markerFromShellCommand(shellCommand: string): string {
   const match = /"([0-9a-f]{12})" \+ JSON\.stringify\(process\.env\) \+ "\1"/.exec(shellCommand);
   if (!match?.[1]) throw new Error(`missing env marker in shell command: ${shellCommand}`);
@@ -54,6 +94,252 @@ function expectNoRawStdout(fields: Record<string, unknown>): void {
 async function createShellHome(): Promise<string> {
   return await mkdtemp(path.join(os.tmpdir(), "paseo-login-shell-env-"));
 }
+
+describe("login shell env retry behavior", () => {
+  it("applies the interactive env without retrying", () => {
+    const env = createEnv(fakeHome);
+    const logger = new RecordingLoginShellLogger();
+    const calls: RecordedSpawn[] = [];
+    const interactivePath = "/interactive/bin:/usr/bin:/bin";
+    const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
+      const recordedArgs = Array.isArray(args) ? args.map(String) : [];
+      calls.push({
+        shell: String(shell),
+        args: recordedArgs,
+        timeoutMs: options?.timeout,
+      });
+      return successResult(String(recordedArgs.at(-1)), { ...env, PATH: interactivePath });
+    };
+
+    inheritLoginShellEnv({ env, logger, spawnSync });
+
+    expect(env.PATH).toBe(interactivePath);
+    expect(calls).toHaveLength(1);
+    expect(shellArgsFromRecordedCall(calls[0])).toEqual(["-i", "-l", "-c"]);
+    expect(calls[0]?.timeoutMs).toBe(30_000);
+    expect(logger.infos.map((entry) => entry.message)).toEqual([
+      "[login-shell-env] start",
+      "[login-shell-env] attempt applied",
+      "[login-shell-env] applied",
+    ]);
+    expect(logger.infos[1]?.fields).toMatchObject({
+      attemptKind: "interactive",
+      shellArgs: ["-i", "-l", "-c"],
+      reason: "success",
+      timeoutMs: 30_000,
+    });
+    expect(logger.infos[2]?.fields).toMatchObject({
+      attemptKind: "interactive",
+      beforePath: basePath,
+      afterPath: interactivePath,
+      pathChanged: true,
+    });
+    expect(logger.warnings).toEqual([]);
+  });
+
+  it("retries non-interactively after an interactive timeout", () => {
+    const env = createEnv(fakeHome);
+    const logger = new RecordingLoginShellLogger();
+    const calls: RecordedSpawn[] = [];
+    const nonInteractivePath = "/login/bin:/usr/bin:/bin";
+    const timeoutError = Object.assign(new Error("spawnSync ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    let timedOutStdout = "";
+    const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
+      const recordedArgs = Array.isArray(args) ? args.map(String) : [];
+      calls.push({
+        shell: String(shell),
+        args: recordedArgs,
+        timeoutMs: options?.timeout,
+      });
+
+      if (calls.length === 1) {
+        const marker = markerFromShellCommand(String(recordedArgs.at(-1)));
+        timedOutStdout = `${marker}${JSON.stringify({ ...env, PATH: "/timed-out/bin" })}${marker}`;
+        return spawnResult({
+          stdout: timedOutStdout,
+          status: null,
+          signal: "SIGTERM",
+          error: timeoutError,
+        });
+      }
+
+      return successResult(String(recordedArgs.at(-1)), { ...env, PATH: nonInteractivePath });
+    };
+
+    inheritLoginShellEnv({ env, logger, spawnSync });
+
+    expect(env.PATH).toBe(nonInteractivePath);
+    expect(calls).toHaveLength(2);
+    expect(shellArgsFromRecordedCall(calls[0])).toEqual(["-i", "-l", "-c"]);
+    expect(shellArgsFromRecordedCall(calls[1])).toEqual(["-l", "-c"]);
+    expect(logger.warnings).toHaveLength(1);
+    expect(logger.warnings[0]?.message).toBe("[login-shell-env] attempt failed; retrying");
+    expect(logger.warnings[0]?.fields).toMatchObject({
+      reason: "timeout",
+      attemptKind: "interactive",
+      shellArgs: ["-i", "-l", "-c"],
+      status: null,
+      signal: "SIGTERM",
+      stdoutLength: timedOutStdout.length,
+      markerFound: true,
+      errorCode: "ETIMEDOUT",
+      timeoutMs: 30_000,
+    });
+    expect(logger.infos[1]?.fields).toMatchObject({
+      attemptKind: "non-interactive",
+      shellArgs: ["-l", "-c"],
+      reason: "success",
+    });
+    expect(logger.infos[2]?.fields).toMatchObject({
+      attemptKind: "non-interactive",
+      beforePath: basePath,
+      afterPath: nonInteractivePath,
+      pathChanged: true,
+    });
+    expectNoRawStdout(logger.warnings[0]?.fields ?? {});
+  });
+
+  it("retries non-interactively when the interactive marker is missing", () => {
+    const env = createEnv(fakeHome);
+    const logger = new RecordingLoginShellLogger();
+    const calls: RecordedSpawn[] = [];
+    const nonInteractivePath = "/profile/bin:/usr/bin:/bin";
+    const missingMarkerStdout = "switched shells before command\n";
+    const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
+      const recordedArgs = Array.isArray(args) ? args.map(String) : [];
+      calls.push({
+        shell: String(shell),
+        args: recordedArgs,
+        timeoutMs: options?.timeout,
+      });
+
+      if (calls.length === 1) {
+        return spawnResult({ stdout: missingMarkerStdout });
+      }
+
+      return successResult(String(recordedArgs.at(-1)), { ...env, PATH: nonInteractivePath });
+    };
+
+    inheritLoginShellEnv({ env, logger, spawnSync });
+
+    expect(env.PATH).toBe(nonInteractivePath);
+    expect(calls).toHaveLength(2);
+    expect(shellArgsFromRecordedCall(calls[0])).toEqual(["-i", "-l", "-c"]);
+    expect(shellArgsFromRecordedCall(calls[1])).toEqual(["-l", "-c"]);
+    expect(logger.warnings).toHaveLength(1);
+    expect(logger.warnings[0]?.message).toBe("[login-shell-env] attempt failed; retrying");
+    expect(logger.warnings[0]?.fields).toMatchObject({
+      reason: "marker-missing",
+      attemptKind: "interactive",
+      shellArgs: ["-i", "-l", "-c"],
+      status: 0,
+      signal: null,
+      stdoutLength: missingMarkerStdout.length,
+      markerFound: false,
+      timeoutMs: 30_000,
+    });
+    expect(logger.infos[1]?.fields).toMatchObject({
+      attemptKind: "non-interactive",
+      reason: "success",
+    });
+    expectNoRawStdout(logger.warnings[0]?.fields ?? {});
+  });
+
+  it("keeps the inherited env after both attempts fail", () => {
+    const env = createEnv(fakeHome);
+    const logger = new RecordingLoginShellLogger();
+    const calls: RecordedSpawn[] = [];
+    const spawnError = Object.assign(new Error("spawnSync ENOENT"), {
+      code: "ENOENT",
+    });
+    const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
+      const recordedArgs = Array.isArray(args) ? args.map(String) : [];
+      calls.push({
+        shell: String(shell),
+        args: recordedArgs,
+        timeoutMs: options?.timeout,
+      });
+
+      if (calls.length === 1) {
+        return spawnResult({ stdout: "no marker\n" });
+      }
+
+      return spawnResult({
+        status: null,
+        signal: null,
+        error: spawnError,
+      });
+    };
+
+    inheritLoginShellEnv({ env, logger, spawnSync });
+
+    expect(env.PATH).toBe(basePath);
+    expect(calls).toHaveLength(2);
+    expect(logger.infos.map((entry) => entry.message)).toEqual(["[login-shell-env] start"]);
+    expect(logger.warnings.map((entry) => entry.message)).toEqual([
+      "[login-shell-env] attempt failed; retrying",
+      "[login-shell-env] attempt failed",
+      "[login-shell-env] failed; keeping inherited env",
+    ]);
+    expect(logger.warnings[0]?.fields).toMatchObject({
+      reason: "marker-missing",
+      attemptKind: "interactive",
+      shellArgs: ["-i", "-l", "-c"],
+    });
+    expect(logger.warnings[1]?.fields).toMatchObject({
+      reason: "spawn-error",
+      attemptKind: "non-interactive",
+      shellArgs: ["-l", "-c"],
+      errorCode: "ENOENT",
+    });
+    expect(logger.warnings[2]?.fields).toMatchObject({
+      reason: "spawn-error",
+      attemptKind: "non-interactive",
+      shellArgs: ["-l", "-c"],
+      errorCode: "ENOENT",
+      beforePath: basePath,
+      afterPath: basePath,
+      pathChanged: false,
+    });
+    expectNoRawStdout(logger.warnings[2]?.fields ?? {});
+  });
+
+  it("uses the configured shell env timeout", () => {
+    const env = {
+      ...createEnv(fakeHome),
+      PASEO_SHELL_ENV_TIMEOUT_MS: "1234",
+    };
+    const logger = new RecordingLoginShellLogger();
+    const calls: RecordedSpawn[] = [];
+    const configuredPath = "/configured/bin:/usr/bin:/bin";
+    const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
+      const recordedArgs = Array.isArray(args) ? args.map(String) : [];
+      calls.push({
+        shell: String(shell),
+        args: recordedArgs,
+        timeoutMs: options?.timeout,
+      });
+      return successResult(String(recordedArgs.at(-1)), { ...env, PATH: configuredPath });
+    };
+
+    inheritLoginShellEnv({ env, logger, spawnSync });
+
+    expect(env.PATH).toBe(configuredPath);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.timeoutMs).toBe(1234);
+    expect(logger.infos[0]?.fields).toMatchObject({
+      timeoutMs: 1234,
+    });
+    expect(logger.infos[1]?.fields).toMatchObject({
+      timeoutMs: 1234,
+    });
+    expect(logger.infos[2]?.fields).toMatchObject({
+      timeoutMs: 1234,
+    });
+  });
+});
 
 describeIfZsh("login shell env", () => {
   const homes = new Set<string>();
@@ -77,10 +363,17 @@ describeIfZsh("login shell env", () => {
     expect(env.PATH?.split(path.delimiter)[0]).toBe(binDir);
     expect(logger.infos.map((entry) => entry.message)).toEqual([
       "[login-shell-env] start",
+      "[login-shell-env] attempt applied",
       "[login-shell-env] applied",
     ]);
     expect(logger.warnings).toEqual([]);
     expect(logger.infos[1]?.fields).toMatchObject({
+      attemptKind: "interactive",
+      shellArgs: ["-i", "-l", "-c"],
+      reason: "success",
+    });
+    expect(logger.infos[2]?.fields).toMatchObject({
+      attemptKind: "interactive",
       beforePath: basePath,
       afterPath: env.PATH,
       pathChanged: true,
@@ -100,6 +393,7 @@ describeIfZsh("login shell env", () => {
     expect(env.PASEO_TEST_ZSHRC_LOADED).toBe("1");
     expect(logger.infos.map((entry) => entry.message)).toEqual([
       "[login-shell-env] start",
+      "[login-shell-env] attempt applied",
       "[login-shell-env] applied",
     ]);
     expect(logger.warnings).toEqual([]);
@@ -116,12 +410,34 @@ describeIfZsh("login shell env", () => {
 
     expect(env.PATH).toBe(basePath);
     expect(logger.infos.map((entry) => entry.message)).toEqual(["[login-shell-env] start"]);
-    expect(logger.warnings).toHaveLength(1);
-    expect(logger.warnings[0]?.message).toBe("[login-shell-env] failed; keeping inherited env");
+    expect(logger.warnings.map((entry) => entry.message)).toEqual([
+      "[login-shell-env] attempt failed; retrying",
+      "[login-shell-env] attempt failed",
+      "[login-shell-env] failed; keeping inherited env",
+    ]);
     expect(logger.warnings[0]?.fields).toMatchObject({
       reason: "non-zero-exit",
+      attemptKind: "interactive",
       shell: zsh,
       shellArgs: ["-i", "-l", "-c"],
+      status: 42,
+      stdoutLength: "premarker\n".length,
+      markerFound: false,
+    });
+    expect(logger.warnings[1]?.fields).toMatchObject({
+      reason: "non-zero-exit",
+      attemptKind: "non-interactive",
+      shell: zsh,
+      shellArgs: ["-l", "-c"],
+      status: 42,
+      stdoutLength: "premarker\n".length,
+      markerFound: false,
+    });
+    expect(logger.warnings[2]?.fields).toMatchObject({
+      reason: "non-zero-exit",
+      attemptKind: "non-interactive",
+      shell: zsh,
+      shellArgs: ["-l", "-c"],
       status: 42,
       stdoutLength: "premarker\n".length,
       markerFound: false,
@@ -129,7 +445,7 @@ describeIfZsh("login shell env", () => {
       afterPath: basePath,
       pathChanged: false,
     });
-    expectNoRawStdout(logger.warnings[0]?.fields ?? {});
+    expectNoRawStdout(logger.warnings[2]?.fields ?? {});
   });
 
   it("keeps the inherited env when a timed-out shell printed an env marker", async () => {
@@ -162,12 +478,38 @@ describeIfZsh("login shell env", () => {
 
     expect(env.PATH).toBe(basePath);
     expect(logger.infos.map((entry) => entry.message)).toEqual(["[login-shell-env] start"]);
-    expect(logger.warnings).toHaveLength(1);
-    expect(logger.warnings[0]?.message).toBe("[login-shell-env] failed; keeping inherited env");
+    expect(logger.warnings.map((entry) => entry.message)).toEqual([
+      "[login-shell-env] attempt failed; retrying",
+      "[login-shell-env] attempt failed",
+      "[login-shell-env] failed; keeping inherited env",
+    ]);
     expect(logger.warnings[0]?.fields).toMatchObject({
-      reason: "spawn-error",
+      reason: "timeout",
+      attemptKind: "interactive",
       shell: zsh,
       shellArgs: ["-i", "-l", "-c"],
+      status: null,
+      signal: "SIGTERM",
+      stdoutLength: stdout.length,
+      markerFound: true,
+      errorCode: "ETIMEDOUT",
+    });
+    expect(logger.warnings[1]?.fields).toMatchObject({
+      reason: "timeout",
+      attemptKind: "non-interactive",
+      shell: zsh,
+      shellArgs: ["-l", "-c"],
+      status: null,
+      signal: "SIGTERM",
+      stdoutLength: stdout.length,
+      markerFound: true,
+      errorCode: "ETIMEDOUT",
+    });
+    expect(logger.warnings[2]?.fields).toMatchObject({
+      reason: "timeout",
+      attemptKind: "non-interactive",
+      shell: zsh,
+      shellArgs: ["-l", "-c"],
       status: null,
       signal: "SIGTERM",
       stdoutLength: stdout.length,
@@ -177,6 +519,6 @@ describeIfZsh("login shell env", () => {
       afterPath: basePath,
       pathChanged: false,
     });
-    expectNoRawStdout(logger.warnings[0]?.fields ?? {});
+    expectNoRawStdout(logger.warnings[2]?.fields ?? {});
   });
 });

--- a/packages/desktop/src/login-shell-env.test.ts
+++ b/packages/desktop/src/login-shell-env.test.ts
@@ -14,6 +14,11 @@ const fakeHome = path.join(os.tmpdir(), "paseo-login-shell-env-fake-home");
 type LoginShellEnvInput = NonNullable<Parameters<typeof inheritLoginShellEnv>[0]>;
 type LoginShellSpawnSync = NonNullable<LoginShellEnvInput["spawnSync"]>;
 
+interface TestClock {
+  advance: (ms: number) => void;
+  now: () => number;
+}
+
 interface RecordedLog {
   message: string;
   fields: Record<string, unknown>;
@@ -53,6 +58,16 @@ function createEnv(home: string): NodeJS.ProcessEnv {
     LOGNAME: "paseo-test",
     SHELL: zsh,
     PATH: basePath,
+  };
+}
+
+function createTestClock(): TestClock {
+  let currentMs = 1_000;
+  return {
+    advance: (ms: number) => {
+      currentMs += ms;
+    },
+    now: () => currentMs,
   };
 }
 
@@ -99,6 +114,7 @@ describe("login shell env retry behavior", () => {
   it("applies the interactive env without retrying", () => {
     const env = createEnv(fakeHome);
     const logger = new RecordingLoginShellLogger();
+    const clock = createTestClock();
     const calls: RecordedSpawn[] = [];
     const interactivePath = "/interactive/bin:/usr/bin:/bin";
     const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
@@ -108,15 +124,16 @@ describe("login shell env retry behavior", () => {
         args: recordedArgs,
         timeoutMs: options?.timeout,
       });
+      clock.advance(5);
       return successResult(String(recordedArgs.at(-1)), { ...env, PATH: interactivePath });
     };
 
-    inheritLoginShellEnv({ env, logger, spawnSync });
+    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
 
     expect(env.PATH).toBe(interactivePath);
     expect(calls).toHaveLength(1);
     expect(shellArgsFromRecordedCall(calls[0])).toEqual(["-i", "-l", "-c"]);
-    expect(calls[0]?.timeoutMs).toBe(30_000);
+    expect(calls[0]?.timeoutMs).toBe(15_000);
     expect(logger.infos.map((entry) => entry.message)).toEqual([
       "[login-shell-env] start",
       "[login-shell-env] attempt applied",
@@ -126,10 +143,12 @@ describe("login shell env retry behavior", () => {
       attemptKind: "interactive",
       shellArgs: ["-i", "-l", "-c"],
       reason: "success",
-      timeoutMs: 30_000,
+      timeoutMs: 15_000,
     });
     expect(logger.infos[2]?.fields).toMatchObject({
       attemptKind: "interactive",
+      durationMs: 5,
+      timeoutMs: 30_000,
       beforePath: basePath,
       afterPath: interactivePath,
       pathChanged: true,
@@ -140,6 +159,7 @@ describe("login shell env retry behavior", () => {
   it("retries non-interactively after an interactive timeout", () => {
     const env = createEnv(fakeHome);
     const logger = new RecordingLoginShellLogger();
+    const clock = createTestClock();
     const calls: RecordedSpawn[] = [];
     const nonInteractivePath = "/login/bin:/usr/bin:/bin";
     const timeoutError = Object.assign(new Error("spawnSync ETIMEDOUT"), {
@@ -157,6 +177,7 @@ describe("login shell env retry behavior", () => {
       if (calls.length === 1) {
         const marker = markerFromShellCommand(String(recordedArgs.at(-1)));
         timedOutStdout = `${marker}${JSON.stringify({ ...env, PATH: "/timed-out/bin" })}${marker}`;
+        clock.advance(15_000);
         return spawnResult({
           stdout: timedOutStdout,
           status: null,
@@ -165,15 +186,18 @@ describe("login shell env retry behavior", () => {
         });
       }
 
+      clock.advance(3);
       return successResult(String(recordedArgs.at(-1)), { ...env, PATH: nonInteractivePath });
     };
 
-    inheritLoginShellEnv({ env, logger, spawnSync });
+    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
 
     expect(env.PATH).toBe(nonInteractivePath);
     expect(calls).toHaveLength(2);
     expect(shellArgsFromRecordedCall(calls[0])).toEqual(["-i", "-l", "-c"]);
     expect(shellArgsFromRecordedCall(calls[1])).toEqual(["-l", "-c"]);
+    expect(calls[0]?.timeoutMs).toBe(15_000);
+    expect(calls[1]?.timeoutMs).toBe(15_000);
     expect(logger.warnings).toHaveLength(1);
     expect(logger.warnings[0]?.message).toBe("[login-shell-env] attempt failed; retrying");
     expect(logger.warnings[0]?.fields).toMatchObject({
@@ -185,15 +209,20 @@ describe("login shell env retry behavior", () => {
       stdoutLength: timedOutStdout.length,
       markerFound: true,
       errorCode: "ETIMEDOUT",
-      timeoutMs: 30_000,
+      durationMs: 15_000,
+      timeoutMs: 15_000,
     });
     expect(logger.infos[1]?.fields).toMatchObject({
       attemptKind: "non-interactive",
       shellArgs: ["-l", "-c"],
       reason: "success",
+      durationMs: 3,
+      timeoutMs: 15_000,
     });
     expect(logger.infos[2]?.fields).toMatchObject({
       attemptKind: "non-interactive",
+      durationMs: 15_003,
+      timeoutMs: 30_000,
       beforePath: basePath,
       afterPath: nonInteractivePath,
       pathChanged: true,
@@ -204,6 +233,7 @@ describe("login shell env retry behavior", () => {
   it("retries non-interactively when the interactive marker is missing", () => {
     const env = createEnv(fakeHome);
     const logger = new RecordingLoginShellLogger();
+    const clock = createTestClock();
     const calls: RecordedSpawn[] = [];
     const nonInteractivePath = "/profile/bin:/usr/bin:/bin";
     const missingMarkerStdout = "switched shells before command\n";
@@ -216,18 +246,22 @@ describe("login shell env retry behavior", () => {
       });
 
       if (calls.length === 1) {
+        clock.advance(25);
         return spawnResult({ stdout: missingMarkerStdout });
       }
 
+      clock.advance(2);
       return successResult(String(recordedArgs.at(-1)), { ...env, PATH: nonInteractivePath });
     };
 
-    inheritLoginShellEnv({ env, logger, spawnSync });
+    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
 
     expect(env.PATH).toBe(nonInteractivePath);
     expect(calls).toHaveLength(2);
     expect(shellArgsFromRecordedCall(calls[0])).toEqual(["-i", "-l", "-c"]);
     expect(shellArgsFromRecordedCall(calls[1])).toEqual(["-l", "-c"]);
+    expect(calls[0]?.timeoutMs).toBe(15_000);
+    expect(calls[1]?.timeoutMs).toBe(29_975);
     expect(logger.warnings).toHaveLength(1);
     expect(logger.warnings[0]?.message).toBe("[login-shell-env] attempt failed; retrying");
     expect(logger.warnings[0]?.fields).toMatchObject({
@@ -238,11 +272,14 @@ describe("login shell env retry behavior", () => {
       signal: null,
       stdoutLength: missingMarkerStdout.length,
       markerFound: false,
-      timeoutMs: 30_000,
+      durationMs: 25,
+      timeoutMs: 15_000,
     });
     expect(logger.infos[1]?.fields).toMatchObject({
       attemptKind: "non-interactive",
       reason: "success",
+      durationMs: 2,
+      timeoutMs: 29_975,
     });
     expectNoRawStdout(logger.warnings[0]?.fields ?? {});
   });
@@ -250,6 +287,7 @@ describe("login shell env retry behavior", () => {
   it("keeps the inherited env after both attempts fail", () => {
     const env = createEnv(fakeHome);
     const logger = new RecordingLoginShellLogger();
+    const clock = createTestClock();
     const calls: RecordedSpawn[] = [];
     const spawnError = Object.assign(new Error("spawnSync ENOENT"), {
       code: "ENOENT",
@@ -263,9 +301,11 @@ describe("login shell env retry behavior", () => {
       });
 
       if (calls.length === 1) {
+        clock.advance(10);
         return spawnResult({ stdout: "no marker\n" });
       }
 
+      clock.advance(5);
       return spawnResult({
         status: null,
         signal: null,
@@ -273,10 +313,12 @@ describe("login shell env retry behavior", () => {
       });
     };
 
-    inheritLoginShellEnv({ env, logger, spawnSync });
+    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
 
     expect(env.PATH).toBe(basePath);
     expect(calls).toHaveLength(2);
+    expect(calls[0]?.timeoutMs).toBe(15_000);
+    expect(calls[1]?.timeoutMs).toBe(29_990);
     expect(logger.infos.map((entry) => entry.message)).toEqual(["[login-shell-env] start"]);
     expect(logger.warnings.map((entry) => entry.message)).toEqual([
       "[login-shell-env] attempt failed; retrying",
@@ -287,18 +329,24 @@ describe("login shell env retry behavior", () => {
       reason: "marker-missing",
       attemptKind: "interactive",
       shellArgs: ["-i", "-l", "-c"],
+      durationMs: 10,
+      timeoutMs: 15_000,
     });
     expect(logger.warnings[1]?.fields).toMatchObject({
       reason: "spawn-error",
       attemptKind: "non-interactive",
       shellArgs: ["-l", "-c"],
+      durationMs: 5,
       errorCode: "ENOENT",
+      timeoutMs: 29_990,
     });
     expect(logger.warnings[2]?.fields).toMatchObject({
       reason: "spawn-error",
       attemptKind: "non-interactive",
       shellArgs: ["-l", "-c"],
       errorCode: "ENOENT",
+      durationMs: 15,
+      timeoutMs: 30_000,
       beforePath: basePath,
       afterPath: basePath,
       pathChanged: false,
@@ -312,6 +360,7 @@ describe("login shell env retry behavior", () => {
       PASEO_SHELL_ENV_TIMEOUT_MS: "1234",
     };
     const logger = new RecordingLoginShellLogger();
+    const clock = createTestClock();
     const calls: RecordedSpawn[] = [];
     const configuredPath = "/configured/bin:/usr/bin:/bin";
     const spawnSync: LoginShellSpawnSync = (shell, args, options) => {
@@ -321,21 +370,23 @@ describe("login shell env retry behavior", () => {
         args: recordedArgs,
         timeoutMs: options?.timeout,
       });
+      clock.advance(4);
       return successResult(String(recordedArgs.at(-1)), { ...env, PATH: configuredPath });
     };
 
-    inheritLoginShellEnv({ env, logger, spawnSync });
+    inheritLoginShellEnv({ env, logger, now: clock.now, spawnSync });
 
     expect(env.PATH).toBe(configuredPath);
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.timeoutMs).toBe(1234);
+    expect(calls[0]?.timeoutMs).toBe(617);
     expect(logger.infos[0]?.fields).toMatchObject({
       timeoutMs: 1234,
     });
     expect(logger.infos[1]?.fields).toMatchObject({
-      timeoutMs: 1234,
+      timeoutMs: 617,
     });
     expect(logger.infos[2]?.fields).toMatchObject({
+      durationMs: 4,
       timeoutMs: 1234,
     });
   });

--- a/packages/desktop/src/login-shell-env.ts
+++ b/packages/desktop/src/login-shell-env.ts
@@ -78,6 +78,57 @@ interface ResolvedShellEnv {
   attemptKind: ShellEnvAttemptKind;
 }
 
+interface AttemptTimeoutInput {
+  totalTimeoutMs: number;
+  attemptsStartedAt: number;
+  now: () => number;
+  attempts: ShellEnvAttempt[];
+  index: number;
+}
+
+interface ThrowIfShellFailedInput {
+  result: SpawnSyncReturns<string>;
+  regex: RegExp;
+  shell: string;
+  attempt: ShellEnvAttempt;
+}
+
+interface ShellEnvForAttemptInput {
+  deps: Required<LoginShellEnvDependencies>;
+  shellEnv: NodeJS.ProcessEnv;
+  shell: string;
+  command: string;
+  regex: RegExp;
+  attempt: ShellEnvAttempt;
+  timeoutMs: number;
+}
+
+interface ShellAttemptErrorDetailsInput {
+  error: unknown;
+  shell: string;
+  attempt: ShellEnvAttempt;
+}
+
+interface LogShellAttemptFailureInput {
+  deps: Required<LoginShellEnvDependencies>;
+  error: unknown;
+  details: ShellEnvErrorDetails;
+  durationMs: number;
+  timeoutMs: number;
+  willRetry: boolean;
+}
+
+interface RestoreElectronEnvInput {
+  env: Record<string, string>;
+  savedRunAsNode: string | undefined;
+  savedNoAttach: string | undefined;
+}
+
+interface ResolveShellEnvInput {
+  deps: Required<LoginShellEnvDependencies>;
+  timeoutMs: number;
+}
+
 function timeoutMsFromEnv(env: NodeJS.ProcessEnv): number {
   const rawTimeoutMs = env[TIMEOUT_ENV_KEY];
   if (!rawTimeoutMs) return DEFAULT_RESOLVE_TIMEOUT_MS;
@@ -86,13 +137,13 @@ function timeoutMsFromEnv(env: NodeJS.ProcessEnv): number {
   return Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_RESOLVE_TIMEOUT_MS;
 }
 
-function timeoutMsForAttempt(
-  totalTimeoutMs: number,
-  attemptsStartedAt: number,
-  now: () => number,
-  attempts: ShellEnvAttempt[],
-  index: number,
-): number | null {
+function timeoutMsForAttempt({
+  totalTimeoutMs,
+  attemptsStartedAt,
+  now,
+  attempts,
+  index,
+}: AttemptTimeoutInput): number | null {
   if (attempts.length === 1) return totalTimeoutMs;
   if (index === 0) return Math.max(1, Math.floor(totalTimeoutMs / 2));
 
@@ -109,12 +160,7 @@ function shellFailureReason(result: SpawnSyncReturns<string>): string {
   return result.error ? "spawn-error" : "signal";
 }
 
-function throwIfShellFailed(
-  result: SpawnSyncReturns<string>,
-  regex: RegExp,
-  shell: string,
-  attempt: ShellEnvAttempt,
-): void {
+function throwIfShellFailed({ result, regex, shell, attempt }: ThrowIfShellFailedInput): void {
   if (result.error || result.signal) {
     throw new ShellEnvError(
       "login shell did not complete",
@@ -181,7 +227,7 @@ function getSystemShell(
   return deps.platform === "darwin" ? "/bin/zsh" : "/bin/bash";
 }
 
-function shellEnvCommand(shell: string, mark: string): ShellEnvCommand {
+function shellEnvCommand({ shell, mark }: { shell: string; mark: string }): ShellEnvCommand {
   const name = basename(shell);
 
   if (/^(?:pwsh|powershell)(?:-preview)?$/.test(name)) {
@@ -230,15 +276,15 @@ function shellEnvCommand(shell: string, mark: string): ShellEnvCommand {
   };
 }
 
-function shellEnvForAttempt(
-  deps: Required<LoginShellEnvDependencies>,
-  shellEnv: NodeJS.ProcessEnv,
-  shell: string,
-  command: string,
-  regex: RegExp,
-  attempt: ShellEnvAttempt,
-  timeoutMs: number,
-): Record<string, string> {
+function shellEnvForAttempt({
+  deps,
+  shellEnv,
+  shell,
+  command,
+  regex,
+  attempt,
+  timeoutMs,
+}: ShellEnvForAttemptInput): Record<string, string> {
   const result = deps.spawnSync(shell, [...attempt.shellArgs, command], {
     argv0: attempt.argv0,
     encoding: "utf8",
@@ -251,7 +297,7 @@ function shellEnvForAttempt(
     },
   });
 
-  throwIfShellFailed(result, regex, shell, attempt);
+  throwIfShellFailed({ result, regex, shell, attempt });
 
   const match = regex.exec(result.stdout);
   if (!match?.[1]) {
@@ -291,11 +337,11 @@ function shellEnvForAttempt(
   }
 }
 
-function shellAttemptErrorDetails(
-  error: unknown,
-  shell: string,
-  attempt: ShellEnvAttempt,
-): ShellEnvErrorDetails {
+function shellAttemptErrorDetails({
+  error,
+  shell,
+  attempt,
+}: ShellAttemptErrorDetailsInput): ShellEnvErrorDetails {
   return error instanceof ShellEnvError
     ? error.details
     : {
@@ -307,14 +353,14 @@ function shellAttemptErrorDetails(
       };
 }
 
-function logShellAttemptFailure(
-  deps: Required<LoginShellEnvDependencies>,
-  error: unknown,
-  details: ShellEnvErrorDetails,
-  durationMs: number,
-  timeoutMs: number,
-  willRetry: boolean,
-): void {
+function logShellAttemptFailure({
+  deps,
+  error,
+  details,
+  durationMs,
+  timeoutMs,
+  willRetry,
+}: LogShellAttemptFailureInput): void {
   const cause = error instanceof Error ? error.cause : undefined;
   deps.logger.warn(
     willRetry ? "[login-shell-env] attempt failed; retrying" : "[login-shell-env] attempt failed",
@@ -329,11 +375,7 @@ function logShellAttemptFailure(
   );
 }
 
-function restoreElectronEnv(
-  env: Record<string, string>,
-  savedRunAsNode: string | undefined,
-  savedNoAttach: string | undefined,
-): void {
+function restoreElectronEnv({ env, savedRunAsNode, savedNoAttach }: RestoreElectronEnvInput): void {
   if (savedRunAsNode) {
     env.ELECTRON_RUN_AS_NODE = savedRunAsNode;
   } else {
@@ -349,10 +391,7 @@ function restoreElectronEnv(
   delete env.XDG_RUNTIME_DIR;
 }
 
-function resolveShellEnv(
-  deps: Required<LoginShellEnvDependencies>,
-  timeoutMs: number,
-): ResolvedShellEnv {
+function resolveShellEnv({ deps, timeoutMs }: ResolveShellEnvInput): ResolvedShellEnv {
   if (deps.platform === "win32") {
     throw new ShellEnvError("login shell env is not resolved on Windows", { reason: "win32" });
   }
@@ -364,7 +403,7 @@ function resolveShellEnv(
   const regex = new RegExp(mark + "({.*})" + mark);
 
   const shell = getSystemShell(deps);
-  const { command, attempts } = shellEnvCommand(shell, mark);
+  const { command, attempts } = shellEnvCommand({ shell, mark });
 
   const shellEnv = { ...deps.env };
   delete shellEnv.PASEO_NODE_ENV;
@@ -387,29 +426,29 @@ function resolveShellEnv(
   const attemptsStartedAt = deps.now();
 
   for (const [index, attempt] of attempts.entries()) {
-    const attemptTimeoutMs = timeoutMsForAttempt(
-      timeoutMs,
+    const attemptTimeoutMs = timeoutMsForAttempt({
+      totalTimeoutMs: timeoutMs,
       attemptsStartedAt,
-      deps.now,
+      now: deps.now,
       attempts,
       index,
-    );
+    });
     if (attemptTimeoutMs === null) break;
 
     const attemptStartedAt = deps.now();
 
     try {
-      const env = shellEnvForAttempt(
+      const env = shellEnvForAttempt({
         deps,
         shellEnv,
         shell,
         command,
         regex,
         attempt,
-        attemptTimeoutMs,
-      );
+        timeoutMs: attemptTimeoutMs,
+      });
       const durationMs = deps.now() - attemptStartedAt;
-      restoreElectronEnv(env, savedRunAsNode, savedNoAttach);
+      restoreElectronEnv({ env, savedRunAsNode, savedNoAttach });
 
       deps.logger.info("[login-shell-env] attempt applied", {
         attemptKind: attempt.kind,
@@ -423,13 +462,26 @@ function resolveShellEnv(
 
       return { env, attemptKind: attempt.kind };
     } catch (error) {
-      const details = shellAttemptErrorDetails(error, shell, attempt);
+      const details = shellAttemptErrorDetails({ error, shell, attempt });
       const durationMs = deps.now() - attemptStartedAt;
       const willRetry =
         index < attempts.length - 1 &&
-        timeoutMsForAttempt(timeoutMs, attemptsStartedAt, deps.now, attempts, index + 1) !== null;
+        timeoutMsForAttempt({
+          totalTimeoutMs: timeoutMs,
+          attemptsStartedAt,
+          now: deps.now,
+          attempts,
+          index: index + 1,
+        }) !== null;
       lastError = error;
-      logShellAttemptFailure(deps, error, details, durationMs, attemptTimeoutMs, willRetry);
+      logShellAttemptFailure({
+        deps,
+        error,
+        details,
+        durationMs,
+        timeoutMs: attemptTimeoutMs,
+        willRetry,
+      });
     }
   }
 
@@ -458,7 +510,7 @@ export function inheritLoginShellEnv(input: LoginShellEnvDependencies = {}): voi
   const timeoutMs = timeoutMsFromEnv(deps.env);
 
   try {
-    const { env, attemptKind } = resolveShellEnv(deps, timeoutMs);
+    const { env, attemptKind } = resolveShellEnv({ deps, timeoutMs });
     Object.assign(deps.env, env);
     deps.logger.info("[login-shell-env] applied", {
       attemptKind,

--- a/packages/desktop/src/login-shell-env.ts
+++ b/packages/desktop/src/login-shell-env.ts
@@ -9,10 +9,12 @@ import { userInfo as defaultUserInfo } from "node:os";
 import { basename } from "node:path";
 import defaultLog from "electron-log/main";
 
-const RESOLVE_TIMEOUT_MS = 10_000;
+const DEFAULT_RESOLVE_TIMEOUT_MS = 30_000;
+const TIMEOUT_ENV_KEY = "PASEO_SHELL_ENV_TIMEOUT_MS";
 const STDERR_LOG_LIMIT = 2000;
 
 type LoginShellEnvLogger = Pick<typeof defaultLog, "info" | "warn">;
+type ShellEnvAttemptKind = "interactive" | "non-interactive";
 
 interface LoginShellEnvDependencies {
   env?: NodeJS.ProcessEnv;
@@ -37,6 +39,7 @@ function pathEnv(env: NodeJS.ProcessEnv | Record<string, string>): string | null
 
 interface ShellEnvErrorDetails {
   reason: string;
+  attemptKind?: ShellEnvAttemptKind;
   shell?: string;
   shellArgs?: string[];
   status?: number | null;
@@ -57,19 +60,52 @@ class ShellEnvError extends Error {
   }
 }
 
+interface ShellEnvAttempt {
+  kind: ShellEnvAttemptKind;
+  shellArgs: string[];
+}
+
+interface ShellEnvCommand {
+  command: string;
+  attempts: ShellEnvAttempt[];
+}
+
+interface ResolvedShellEnv {
+  env: Record<string, string>;
+  attemptKind: ShellEnvAttemptKind;
+}
+
+function timeoutMsFromEnv(env: NodeJS.ProcessEnv): number {
+  const rawTimeoutMs = env[TIMEOUT_ENV_KEY];
+  if (!rawTimeoutMs) return DEFAULT_RESOLVE_TIMEOUT_MS;
+
+  const timeoutMs = Number.parseInt(rawTimeoutMs, 10);
+  return Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_RESOLVE_TIMEOUT_MS;
+}
+
+function errorCode(error: unknown): string | null {
+  return error instanceof Error ? ((error as NodeJS.ErrnoException).code ?? null) : null;
+}
+
+function shellFailureReason(result: SpawnSyncReturns<string>): string {
+  if (errorCode(result.error) === "ETIMEDOUT") return "timeout";
+  return result.error ? "spawn-error" : "signal";
+}
+
 function throwIfShellFailed(
   result: SpawnSyncReturns<string>,
   regex: RegExp,
   shell: string,
-  shellArgs: string[],
+  attempt: ShellEnvAttempt,
 ): void {
   if (result.error || result.signal) {
     throw new ShellEnvError(
       "login shell did not complete",
       {
-        reason: result.error ? "spawn-error" : "signal",
+        reason: shellFailureReason(result),
+        attemptKind: attempt.kind,
         shell,
-        shellArgs,
+        shellArgs: attempt.shellArgs,
         status: result.status,
         signal: result.signal,
         stdoutLength: result.stdout?.length ?? 0,
@@ -82,8 +118,9 @@ function throwIfShellFailed(
   if (result.status !== 0 && result.status !== null) {
     throw new ShellEnvError("login shell exited non-zero", {
       reason: "non-zero-exit",
+      attemptKind: attempt.kind,
       shell,
-      shellArgs,
+      shellArgs: attempt.shellArgs,
       status: result.status,
       signal: result.signal,
       stdoutLength: result.stdout?.length ?? 0,
@@ -96,8 +133,9 @@ function throwIfShellFailed(
       "login shell produced no stdout",
       {
         reason: "no-stdout",
+        attemptKind: attempt.kind,
         shell,
-        shellArgs,
+        shellArgs: attempt.shellArgs,
         status: result.status,
         signal: result.signal,
         stdoutLength: result.stdout?.length ?? 0,
@@ -123,7 +161,174 @@ function getSystemShell(
   return deps.platform === "darwin" ? "/bin/zsh" : "/bin/bash";
 }
 
-function resolveShellEnv(deps: Required<LoginShellEnvDependencies>): Record<string, string> {
+function shellEnvCommand(shell: string, mark: string): ShellEnvCommand {
+  const name = basename(shell);
+
+  if (/^(?:pwsh|powershell)(?:-preview)?$/.test(name)) {
+    return {
+      command: `& '${process.execPath}' -p '''${mark}'' + JSON.stringify(process.env) + ''${mark}'''`,
+      attempts: [{ kind: "non-interactive", shellArgs: ["-Login", "-Command"] }],
+    };
+  }
+
+  if (name === "nu") {
+    return {
+      command: `^'${process.execPath}' -p '"${mark}" + JSON.stringify(process.env) + "${mark}"'`,
+      attempts: [
+        { kind: "interactive", shellArgs: ["-i", "-l", "-c"] },
+        { kind: "non-interactive", shellArgs: ["-l", "-c"] },
+      ],
+    };
+  }
+
+  if (name === "xonsh") {
+    return {
+      command: `import os, json; print("${mark}", json.dumps(dict(os.environ)), "${mark}")`,
+      attempts: [
+        { kind: "interactive", shellArgs: ["-i", "-l", "-c"] },
+        { kind: "non-interactive", shellArgs: ["-l", "-c"] },
+      ],
+    };
+  }
+
+  if (name === "tcsh" || name === "csh") {
+    return {
+      command: `'${process.execPath}' -p '"${mark}" + JSON.stringify(process.env) + "${mark}"'`,
+      attempts: [
+        { kind: "interactive", shellArgs: ["-ic"] },
+        { kind: "non-interactive", shellArgs: ["-lc"] },
+      ],
+    };
+  }
+
+  return {
+    command: `'${process.execPath}' -p '"${mark}" + JSON.stringify(process.env) + "${mark}"'`,
+    attempts: [
+      { kind: "interactive", shellArgs: ["-i", "-l", "-c"] },
+      { kind: "non-interactive", shellArgs: ["-l", "-c"] },
+    ],
+  };
+}
+
+function shellEnvForAttempt(
+  deps: Required<LoginShellEnvDependencies>,
+  shellEnv: NodeJS.ProcessEnv,
+  shell: string,
+  command: string,
+  regex: RegExp,
+  attempt: ShellEnvAttempt,
+  timeoutMs: number,
+): Record<string, string> {
+  const result = deps.spawnSync(shell, [...attempt.shellArgs, command], {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    windowsHide: true,
+    env: {
+      ...shellEnv,
+      ELECTRON_RUN_AS_NODE: "1",
+      ELECTRON_NO_ATTACH_CONSOLE: "1",
+    },
+  });
+
+  throwIfShellFailed(result, regex, shell, attempt);
+
+  const match = regex.exec(result.stdout);
+  if (!match?.[1]) {
+    throw new ShellEnvError("login shell output did not contain environment marker", {
+      reason: "marker-missing",
+      attemptKind: attempt.kind,
+      shell,
+      shellArgs: attempt.shellArgs,
+      status: result.status,
+      signal: result.signal,
+      stdoutLength: result.stdout.length,
+      markerFound: false,
+      stderr: result.stderr,
+    });
+  }
+
+  try {
+    return JSON.parse(match[1]) as Record<string, string>;
+  } catch (error) {
+    throw new ShellEnvError(
+      "failed to parse login shell environment JSON",
+      {
+        reason: "json-parse",
+        attemptKind: attempt.kind,
+        shell,
+        shellArgs: attempt.shellArgs,
+        status: result.status,
+        signal: result.signal,
+        stdoutLength: result.stdout.length,
+        markerFound: true,
+        stderr: result.stderr,
+      },
+      { cause: error },
+    );
+  }
+}
+
+function shellAttemptErrorDetails(
+  error: unknown,
+  shell: string,
+  attempt: ShellEnvAttempt,
+): ShellEnvErrorDetails {
+  return error instanceof ShellEnvError
+    ? error.details
+    : {
+        reason: "throw",
+        attemptKind: attempt.kind,
+        shell,
+        shellArgs: attempt.shellArgs,
+      };
+}
+
+function logShellAttemptFailure(
+  deps: Required<LoginShellEnvDependencies>,
+  error: unknown,
+  details: ShellEnvErrorDetails,
+  durationMs: number,
+  timeoutMs: number,
+  willRetry: boolean,
+): void {
+  const cause = error instanceof Error ? error.cause : undefined;
+  deps.logger.warn(
+    willRetry ? "[login-shell-env] attempt failed; retrying" : "[login-shell-env] attempt failed",
+    {
+      ...details,
+      durationMs,
+      timeoutMs,
+      error: error instanceof Error ? error.message : String(error),
+      errorCode: error instanceof ShellEnvError ? errorCode(cause) : errorCode(error),
+      stderr: truncateForLog(details.stderr),
+    },
+  );
+}
+
+function restoreElectronEnv(
+  env: Record<string, string>,
+  savedRunAsNode: string | undefined,
+  savedNoAttach: string | undefined,
+): void {
+  if (savedRunAsNode) {
+    env.ELECTRON_RUN_AS_NODE = savedRunAsNode;
+  } else {
+    delete env.ELECTRON_RUN_AS_NODE;
+  }
+
+  if (savedNoAttach) {
+    env.ELECTRON_NO_ATTACH_CONSOLE = savedNoAttach;
+  } else {
+    delete env.ELECTRON_NO_ATTACH_CONSOLE;
+  }
+
+  delete env.XDG_RUNTIME_DIR;
+}
+
+function resolveShellEnv(
+  deps: Required<LoginShellEnvDependencies>,
+  timeoutMs: number,
+): ResolvedShellEnv {
   if (deps.platform === "win32") {
     throw new ShellEnvError("login shell env is not resolved on Windows", { reason: "win32" });
   }
@@ -135,28 +340,7 @@ function resolveShellEnv(deps: Required<LoginShellEnvDependencies>): Record<stri
   const regex = new RegExp(mark + "({.*})" + mark);
 
   const shell = getSystemShell(deps);
-  const name = basename(shell);
-
-  let command: string;
-  let shellArgs: string[];
-
-  if (/^(?:pwsh|powershell)(?:-preview)?$/.test(name)) {
-    command = `& '${process.execPath}' -p '''${mark}'' + JSON.stringify(process.env) + ''${mark}'''`;
-    shellArgs = ["-Login", "-Command"];
-  } else if (name === "nu") {
-    command = `^'${process.execPath}' -p '"${mark}" + JSON.stringify(process.env) + "${mark}"'`;
-    shellArgs = ["-i", "-l", "-c"];
-  } else if (name === "xonsh") {
-    command = `import os, json; print("${mark}", json.dumps(dict(os.environ)), "${mark}")`;
-    shellArgs = ["-i", "-l", "-c"];
-  } else {
-    command = `'${process.execPath}' -p '"${mark}" + JSON.stringify(process.env) + "${mark}"'`;
-    if (name === "tcsh" || name === "csh") {
-      shellArgs = ["-ic"];
-    } else {
-      shellArgs = ["-i", "-l", "-c"];
-    }
-  }
+  const { command, attempts } = shellEnvCommand(shell, mark);
 
   const shellEnv = { ...deps.env };
   delete shellEnv.PASEO_NODE_ENV;
@@ -165,72 +349,45 @@ function resolveShellEnv(deps: Required<LoginShellEnvDependencies>): Record<stri
 
   deps.logger.info("[login-shell-env] start", {
     shell,
-    shellArgs,
-    timeoutMs: RESOLVE_TIMEOUT_MS,
+    shellArgs: attempts[0]?.shellArgs ?? [],
+    attempts: attempts.map((attempt) => ({
+      attemptKind: attempt.kind,
+      shellArgs: attempt.shellArgs,
+    })),
+    timeoutMs,
     beforePath: pathEnv(deps.env),
   });
 
-  const result = deps.spawnSync(shell, [...shellArgs, command], {
-    encoding: "utf8",
-    timeout: RESOLVE_TIMEOUT_MS,
-    windowsHide: true,
-    env: {
-      ...shellEnv,
-      ELECTRON_RUN_AS_NODE: "1",
-      ELECTRON_NO_ATTACH_CONSOLE: "1",
-    },
-  });
+  let lastError: unknown;
 
-  throwIfShellFailed(result, regex, shell, shellArgs);
+  for (const [index, attempt] of attempts.entries()) {
+    const attemptStartedAt = Date.now();
 
-  const match = regex.exec(result.stdout);
-  if (!match?.[1]) {
-    throw new ShellEnvError("login shell output did not contain environment marker", {
-      reason: "marker-missing",
-      shell,
-      shellArgs,
-      status: result.status,
-      signal: result.signal,
-      stdoutLength: result.stdout.length,
-      markerFound: false,
-      stderr: result.stderr,
-    });
-  }
+    try {
+      const env = shellEnvForAttempt(deps, shellEnv, shell, command, regex, attempt, timeoutMs);
+      const durationMs = Date.now() - attemptStartedAt;
+      restoreElectronEnv(env, savedRunAsNode, savedNoAttach);
 
-  try {
-    const env = JSON.parse(match[1]) as Record<string, string>;
-
-    if (savedRunAsNode) {
-      env.ELECTRON_RUN_AS_NODE = savedRunAsNode;
-    } else {
-      delete env.ELECTRON_RUN_AS_NODE;
-    }
-
-    if (savedNoAttach) {
-      env.ELECTRON_NO_ATTACH_CONSOLE = savedNoAttach;
-    } else {
-      delete env.ELECTRON_NO_ATTACH_CONSOLE;
-    }
-
-    delete env.XDG_RUNTIME_DIR;
-
-    return env;
-  } catch (error) {
-    throw new ShellEnvError(
-      "failed to parse login shell environment JSON",
-      {
-        reason: "json-parse",
+      deps.logger.info("[login-shell-env] attempt applied", {
+        attemptKind: attempt.kind,
         shell,
-        shellArgs,
-        status: result.status,
-        signal: result.signal,
-        stdoutLength: result.stdout.length,
-        markerFound: true,
-        stderr: result.stderr,
-      },
-      { cause: error },
-    );
+        shellArgs: attempt.shellArgs,
+        reason: "success",
+        durationMs,
+        timeoutMs,
+      });
+
+      return { env, attemptKind: attempt.kind };
+    } catch (error) {
+      const details = shellAttemptErrorDetails(error, shell, attempt);
+      const durationMs = Date.now() - attemptStartedAt;
+      const willRetry = index < attempts.length - 1;
+      lastError = error;
+      logShellAttemptFailure(deps, error, details, durationMs, timeoutMs, willRetry);
+    }
   }
+
+  throw lastError;
 }
 
 /**
@@ -251,12 +408,15 @@ export function inheritLoginShellEnv(input: LoginShellEnvDependencies = {}): voi
   };
   const beforePath = pathEnv(deps.env);
   const startedAt = Date.now();
+  const timeoutMs = timeoutMsFromEnv(deps.env);
 
   try {
-    const env = resolveShellEnv(deps);
+    const { env, attemptKind } = resolveShellEnv(deps, timeoutMs);
     Object.assign(deps.env, env);
     deps.logger.info("[login-shell-env] applied", {
+      attemptKind,
       durationMs: Date.now() - startedAt,
+      timeoutMs,
       beforePath,
       afterPath: pathEnv(deps.env),
       pathChanged: beforePath !== pathEnv(deps.env),
@@ -271,7 +431,7 @@ export function inheritLoginShellEnv(input: LoginShellEnvDependencies = {}): voi
     deps.logger.warn("[login-shell-env] failed; keeping inherited env", {
       ...details,
       durationMs: Date.now() - startedAt,
-      timeoutMs: RESOLVE_TIMEOUT_MS,
+      timeoutMs,
       error: error instanceof Error ? error.message : String(error),
       errorCode: (cause as NodeJS.ErrnoException | undefined)?.code ?? null,
       stderr: truncateForLog(details.stderr),

--- a/packages/desktop/src/login-shell-env.ts
+++ b/packages/desktop/src/login-shell-env.ts
@@ -19,6 +19,7 @@ type ShellEnvAttemptKind = "interactive" | "non-interactive";
 interface LoginShellEnvDependencies {
   env?: NodeJS.ProcessEnv;
   logger?: LoginShellEnvLogger;
+  now?: () => number;
   platform?: NodeJS.Platform;
   spawnSync?: typeof defaultSpawnSync;
   userInfo?: typeof defaultUserInfo;
@@ -81,6 +82,20 @@ function timeoutMsFromEnv(env: NodeJS.ProcessEnv): number {
 
   const timeoutMs = Number.parseInt(rawTimeoutMs, 10);
   return Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_RESOLVE_TIMEOUT_MS;
+}
+
+function timeoutMsForAttempt(
+  totalTimeoutMs: number,
+  attemptsStartedAt: number,
+  now: () => number,
+  attempts: ShellEnvAttempt[],
+  index: number,
+): number | null {
+  if (attempts.length === 1) return totalTimeoutMs;
+  if (index === 0) return Math.max(1, Math.floor(totalTimeoutMs / 2));
+
+  const remainingMs = totalTimeoutMs - (now() - attemptsStartedAt);
+  return remainingMs > 0 ? remainingMs : null;
 }
 
 function errorCode(error: unknown): string | null {
@@ -359,13 +374,31 @@ function resolveShellEnv(
   });
 
   let lastError: unknown;
+  const attemptsStartedAt = deps.now();
 
   for (const [index, attempt] of attempts.entries()) {
-    const attemptStartedAt = Date.now();
+    const attemptTimeoutMs = timeoutMsForAttempt(
+      timeoutMs,
+      attemptsStartedAt,
+      deps.now,
+      attempts,
+      index,
+    );
+    if (attemptTimeoutMs === null) break;
+
+    const attemptStartedAt = deps.now();
 
     try {
-      const env = shellEnvForAttempt(deps, shellEnv, shell, command, regex, attempt, timeoutMs);
-      const durationMs = Date.now() - attemptStartedAt;
+      const env = shellEnvForAttempt(
+        deps,
+        shellEnv,
+        shell,
+        command,
+        regex,
+        attempt,
+        attemptTimeoutMs,
+      );
+      const durationMs = deps.now() - attemptStartedAt;
       restoreElectronEnv(env, savedRunAsNode, savedNoAttach);
 
       deps.logger.info("[login-shell-env] attempt applied", {
@@ -374,16 +407,18 @@ function resolveShellEnv(
         shellArgs: attempt.shellArgs,
         reason: "success",
         durationMs,
-        timeoutMs,
+        timeoutMs: attemptTimeoutMs,
       });
 
       return { env, attemptKind: attempt.kind };
     } catch (error) {
       const details = shellAttemptErrorDetails(error, shell, attempt);
-      const durationMs = Date.now() - attemptStartedAt;
-      const willRetry = index < attempts.length - 1;
+      const durationMs = deps.now() - attemptStartedAt;
+      const willRetry =
+        index < attempts.length - 1 &&
+        timeoutMsForAttempt(timeoutMs, attemptsStartedAt, deps.now, attempts, index + 1) !== null;
       lastError = error;
-      logShellAttemptFailure(deps, error, details, durationMs, timeoutMs, willRetry);
+      logShellAttemptFailure(deps, error, details, durationMs, attemptTimeoutMs, willRetry);
     }
   }
 
@@ -402,12 +437,13 @@ export function inheritLoginShellEnv(input: LoginShellEnvDependencies = {}): voi
   const deps: Required<LoginShellEnvDependencies> = {
     env: input.env ?? process.env,
     logger: input.logger ?? defaultLog,
+    now: input.now ?? Date.now,
     platform: input.platform ?? process.platform,
     spawnSync: input.spawnSync ?? defaultSpawnSync,
     userInfo: input.userInfo ?? defaultUserInfo,
   };
   const beforePath = pathEnv(deps.env);
-  const startedAt = Date.now();
+  const startedAt = deps.now();
   const timeoutMs = timeoutMsFromEnv(deps.env);
 
   try {
@@ -415,7 +451,7 @@ export function inheritLoginShellEnv(input: LoginShellEnvDependencies = {}): voi
     Object.assign(deps.env, env);
     deps.logger.info("[login-shell-env] applied", {
       attemptKind,
-      durationMs: Date.now() - startedAt,
+      durationMs: deps.now() - startedAt,
       timeoutMs,
       beforePath,
       afterPath: pathEnv(deps.env),
@@ -430,7 +466,7 @@ export function inheritLoginShellEnv(input: LoginShellEnvDependencies = {}): voi
     const cause = error instanceof Error ? error.cause : undefined;
     deps.logger.warn("[login-shell-env] failed; keeping inherited env", {
       ...details,
-      durationMs: Date.now() - startedAt,
+      durationMs: deps.now() - startedAt,
       timeoutMs,
       error: error instanceof Error ? error.message : String(error),
       errorCode: (cause as NodeJS.ErrnoException | undefined)?.code ?? null,

--- a/packages/desktop/src/login-shell-env.ts
+++ b/packages/desktop/src/login-shell-env.ts
@@ -41,6 +41,7 @@ function pathEnv(env: NodeJS.ProcessEnv | Record<string, string>): string | null
 interface ShellEnvErrorDetails {
   reason: string;
   attemptKind?: ShellEnvAttemptKind;
+  argv0?: string;
   shell?: string;
   shellArgs?: string[];
   status?: number | null;
@@ -63,6 +64,7 @@ class ShellEnvError extends Error {
 
 interface ShellEnvAttempt {
   kind: ShellEnvAttemptKind;
+  argv0?: string;
   shellArgs: string[];
 }
 
@@ -119,6 +121,7 @@ function throwIfShellFailed(
       {
         reason: shellFailureReason(result),
         attemptKind: attempt.kind,
+        argv0: attempt.argv0,
         shell,
         shellArgs: attempt.shellArgs,
         status: result.status,
@@ -134,6 +137,7 @@ function throwIfShellFailed(
     throw new ShellEnvError("login shell exited non-zero", {
       reason: "non-zero-exit",
       attemptKind: attempt.kind,
+      argv0: attempt.argv0,
       shell,
       shellArgs: attempt.shellArgs,
       status: result.status,
@@ -149,6 +153,7 @@ function throwIfShellFailed(
       {
         reason: "no-stdout",
         attemptKind: attempt.kind,
+        argv0: attempt.argv0,
         shell,
         shellArgs: attempt.shellArgs,
         status: result.status,
@@ -211,7 +216,7 @@ function shellEnvCommand(shell: string, mark: string): ShellEnvCommand {
       command: `'${process.execPath}' -p '"${mark}" + JSON.stringify(process.env) + "${mark}"'`,
       attempts: [
         { kind: "interactive", shellArgs: ["-ic"] },
-        { kind: "non-interactive", shellArgs: ["-lc"] },
+        { kind: "non-interactive", argv0: `-${name}`, shellArgs: ["-c"] },
       ],
     };
   }
@@ -235,6 +240,7 @@ function shellEnvForAttempt(
   timeoutMs: number,
 ): Record<string, string> {
   const result = deps.spawnSync(shell, [...attempt.shellArgs, command], {
+    argv0: attempt.argv0,
     encoding: "utf8",
     timeout: timeoutMs,
     windowsHide: true,
@@ -252,6 +258,7 @@ function shellEnvForAttempt(
     throw new ShellEnvError("login shell output did not contain environment marker", {
       reason: "marker-missing",
       attemptKind: attempt.kind,
+      argv0: attempt.argv0,
       shell,
       shellArgs: attempt.shellArgs,
       status: result.status,
@@ -270,6 +277,7 @@ function shellEnvForAttempt(
       {
         reason: "json-parse",
         attemptKind: attempt.kind,
+        argv0: attempt.argv0,
         shell,
         shellArgs: attempt.shellArgs,
         status: result.status,
@@ -293,6 +301,7 @@ function shellAttemptErrorDetails(
     : {
         reason: "throw",
         attemptKind: attempt.kind,
+        argv0: attempt.argv0,
         shell,
         shellArgs: attempt.shellArgs,
       };
@@ -367,6 +376,7 @@ function resolveShellEnv(
     shellArgs: attempts[0]?.shellArgs ?? [],
     attempts: attempts.map((attempt) => ({
       attemptKind: attempt.kind,
+      argv0: attempt.argv0,
       shellArgs: attempt.shellArgs,
     })),
     timeoutMs,
@@ -403,6 +413,7 @@ function resolveShellEnv(
 
       deps.logger.info("[login-shell-env] attempt applied", {
         attemptKind: attempt.kind,
+        argv0: attempt.argv0,
         shell,
         shellArgs: attempt.shellArgs,
         reason: "success",


### PR DESCRIPTION
### Linked issue

Fixes #1492

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Failure modes fixed:

- Slow interactive shell startup could exceed the probe timeout, leaving the desktop-managed daemon with the bare GUI-launch PATH.
- Interactive rc files could replace the shell before the marker command ran, producing `marker-missing` and the same inherited PATH fallback.

The desktop probe now treats 30s as the default total startup budget, with `PASEO_SHELL_ENV_TIMEOUT_MS` overriding that total. The interactive attempt still runs first, but it gets half the budget by default (15s); if it fails, the non-interactive login-shell retry gets the elapsed-time-adjusted remainder. That keeps the worst-case synchronous Electron startup delay capped at the configured budget while still giving profile/login PATH setup a second chance. Logs include per-attempt kind, reason, duration, timeout, and shell args so support diagnostics show exactly what happened.

### How did you verify it

Added/updated `packages/desktop/src/login-shell-env.test.ts` coverage for:

- Interactive success without retry.
- Interactive timeout followed by non-interactive success using the remaining total budget.
- Interactive marker-missing followed by non-interactive success with elapsed time subtracted.
- Both attempts failing and keeping the inherited env.
- `PASEO_SHELL_ENV_TIMEOUT_MS` overriding the total probe timeout and splitting the interactive attempt budget.

Commands run:

- `npm ci`
- `npm run format`
- `npx vitest run packages/desktop/src/login-shell-env.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint`

The pre-commit hook also reran lint, format check, and typecheck successfully.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not a UI change)
- [x] Tests added or updated where it made sense