### PR TITLE
Mark bundled-CLI daemons as desktop managed

### DIFF
--- a/packages/desktop/bin/paseo
+++ b/packages/desktop/bin/paseo
@@ -44,4 +44,6 @@ fi
 RUNNER_PATH="${RESOURCES_DIR}/app.asar.unpacked/dist/daemon/node-entrypoint-runner.js"
 CLI_ENTRYPOINT="${RESOURCES_DIR}/app.asar/node_modules/@getpaseo/cli/dist/index.js"
 
-exec env ELECTRON_RUN_AS_NODE=1 PASEO_NODE_ENV=production "${APP_EXECUTABLE}" --disable-warning=DEP0040 "${RUNNER_PATH}" node-script "${CLI_ENTRYPOINT}" "$@"
+# PASEO_DESKTOP_MANAGED marks daemons started through this bundled CLI as
+# desktop-managed, so the desktop app restarts them when it upgrades.
+exec env ELECTRON_RUN_AS_NODE=1 PASEO_NODE_ENV=production PASEO_DESKTOP_MANAGED=1 "${APP_EXECUTABLE}" --disable-warning=DEP0040 "${RUNNER_PATH}" node-script "${CLI_ENTRYPOINT}" "$@"

--- a/packages/desktop/bin/paseo.cmd
+++ b/packages/desktop/bin/paseo.cmd
@@ -11,5 +11,8 @@ if not exist "%APP_EXECUTABLE%" (
 
 set "ELECTRON_RUN_AS_NODE=1"
 set "PASEO_NODE_ENV=production"
+rem PASEO_DESKTOP_MANAGED marks daemons started through this bundled CLI as
+rem desktop-managed, so the desktop app restarts them when it upgrades.
+set "PASEO_DESKTOP_MANAGED=1"
 "%APP_EXECUTABLE%" --disable-warning=DEP0040 "%RESOURCES_DIR%\app.asar.unpacked\dist\daemon\node-entrypoint-runner.js" node-script "%RESOURCES_DIR%\app.asar\node_modules\@getpaseo\cli\dist\index.js" %*
 exit /b %errorlevel%


### PR DESCRIPTION
### Linked issue

Follow-up to the closure of #1917.

### Type of change

- [x] Bug fix

### What does this PR do

Daemons started through the desktop-bundled CLI shim (`Resources/bin/paseo`) were not marked as desktop-managed: the `PASEO_DESKTOP_MANAGED=1` env var was only set by the desktop app's own spawn path, so a `paseo daemon restart` from a terminal produced a pid lock without the flag. The desktop's version-mismatch check (`shouldRestartForVersion`) then classified the daemon as unmanaged and never restarted it on app upgrade — the app's files updated underneath a running daemon that stayed on the old version forever.

Fix: the bundled shim scripts (`packages/desktop/bin/paseo` and `paseo.cmd`) now set `PASEO_DESKTOP_MANAGED=1` themselves. Bundledness is a build-time fact, so the shim is the one place that knows it: every launcher of the desktop-bundled runner now declares managed status, and the npm-installed CLI (a separate artifact) never sets it.

#1917 attempted the same outcome by recording `process.execPath` in the pid lock and deriving managed status via install-root containment. That replaced a one-bit state with a stored path plus a cross-platform classifier — closed in favor of this one-line-per-platform declaration.

The flag stays confined to Paseo-internal processes: `RUNTIME_CONTROL_ENV_KEYS` in `packages/server/src/server/paseo-env.ts` already scrubs it from all external process envs (agents, terminals), and internal spawns (`envMode: "internal"` in `startLocalDaemonDetached`) pass it through to the supervisor, which writes the pid lock.

### How did you verify it

- Traced the env path end to end: shim → node-entrypoint-runner (no env scrubbing) → CLI `buildChildEnv` (`{...process.env}`) → supervisor → `acquirePidLock` writes `desktopManaged: true` when the var is set (`pid-lock.ts`).
- Verified the flag is deleted for external process envs (`paseo-env.ts` RUNTIME_CONTROL_ENV_KEYS) so it does not leak into agent/terminal processes.
- `npm run typecheck` + lint via pre-commit hook (shell scripts only; no TS changes).
- Full packaged-app verification requires a desktop build; the shim scripts are copied verbatim via electron-builder `extraResources`.

### Risk surface

Shell-script-only change to the packaged CLI shims. Worst case is the env var appearing in CLI subprocesses, which the existing external-env scrubbing already prevents.