### PR TITLE
Let two checkouts of the same repo be separate projects

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -416,20 +416,29 @@ Single file containing an array of all loop records. Writes are direct (not atom
 
 Array of project records.
 
-| Field         | Type                        | Description                              |
-| ------------- | --------------------------- | ---------------------------------------- |
-| `projectId`   | `string`                    | Primary key                              |
-| `rootPath`    | `string`                    | Filesystem root of the project           |
-| `kind`        | `"git" \| "non_git"`        |                                          |
-| `displayName` | `string`                    |                                          |
-| `createdAt`   | `string` (ISO 8601)         |                                          |
-| `updatedAt`   | `string` (ISO 8601)         |                                          |
-| `archivedAt`  | `string \| null` (ISO 8601) | Soft-delete timestamp; required nullable |
+| Field         | Type                        | Description                                                                                                                                                                        |
+| ------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `projectId`   | `string`                    | Primary key. The repository root path for records created since v0.1.104; legacy records may use a `remote:<host>/<owner>/<repo>` id (still valid, matched by `rootPath`).         |
+| `rootPath`    | `string`                    | Filesystem root of the project                                                                                                                                                     |
+| `kind`        | `"git" \| "non_git"`        |                                                                                                                                                                                    |
+| `displayName` | `string`                    | Derived name (`owner/repo` from the remote, else the directory name)                                                                                                               |
+| `customName`  | `string \| null`            | User-set name override layered over `displayName`; reconciliation never touches it                                                                                                 |
+| `remoteKey`   | `string \| null`            | Remote-derived key (`remote:<host>/<owner>/<repo>`) for the display name and the GitHub link, or null for non-git / no-remote. Distinct from `projectId`. Added in v0.1.104 (#987) |
+| `createdAt`   | `string` (ISO 8601)         |                                                                                                                                                                                    |
+| `updatedAt`   | `string` (ISO 8601)         |                                                                                                                                                                                    |
+| `archivedAt`  | `string \| null` (ISO 8601) | Soft-delete timestamp; required nullable                                                                                                                                           |
 
-Active git projects are unique by normalized `rootPath`. Startup reconciliation repairs older bad
-states by moving workspaces from duplicate path-keyed projects onto the canonical project,
-preferring remote-keyed project IDs such as `remote:github.com/owner/repo`, then archiving the
-emptied duplicate.
+Project **identity is the repository root**: each independent checkout is its own project, so two
+clones of the same remote at different paths are distinct projects (#987). Clients key projects by
+this identity everywhere — there is no remote-based cross-host merging, so the same repo checked out
+on two machines shows as one project per checkout; `remoteKey` carries the remote only for the
+derived display name and the GitHub link. A repo and its git worktrees share the same `rootPath`
+(`mainRepoRoot`) and so group under one project. Active git projects are unique by normalized
+`rootPath`. Startup
+reconciliation repairs older bad states by moving workspaces from duplicate projects that share a
+`rootPath` onto the canonical project (grouping strictly by `rootPath`, never by `remoteKey`, so
+distinct clones stay distinct), preferring remote-keyed project IDs such as
+`remote:github.com/owner/repo`, then archiving the emptied duplicate.
 
 ---
 

--- a/packages/app/src/projects/workspace-structure.test.ts
+++ b/packages/app/src/projects/workspace-structure.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { EmptyProjectDescriptor } from "@/stores/session-store";
+import { buildWorkspaceStructureProjects } from "./workspace-structure";
+
+function emptyProject(input: {
+  projectId: string;
+  remoteKey: string | null;
+  projectRootPath: string;
+  projectDisplayName?: string;
+}): EmptyProjectDescriptor {
+  return {
+    projectId: input.projectId,
+    remoteKey: input.remoteKey,
+    projectDisplayName: input.projectDisplayName ?? "acme/app",
+    projectCustomName: null,
+    projectRootPath: input.projectRootPath,
+    projectKind: "git",
+  };
+}
+
+describe("buildWorkspaceStructureProjects", () => {
+  it("keeps two clones of one remote as two distinct projects within a host (#987)", () => {
+    // The reported bug: adding a second clone of the same repo failed. Both folders
+    // are now distinct projects (keyed by repo-root identity) that share a remote
+    // grouping key.
+    const projects = buildWorkspaceStructureProjects({
+      sessions: [
+        {
+          serverId: "local",
+          workspaces: [],
+          emptyProjects: [
+            emptyProject({
+              projectId: "/home/me/work/app",
+              remoteKey: "remote:github.com/acme/app",
+              projectRootPath: "/home/me/work/app",
+            }),
+            emptyProject({
+              projectId: "/home/me/scratch/app",
+              remoteKey: "remote:github.com/acme/app",
+              projectRootPath: "/home/me/scratch/app",
+            }),
+          ],
+        },
+      ],
+    });
+
+    // Two distinct identities → two sidebar projects, even though they share a remote.
+    expect(projects).toHaveLength(2);
+    expect(projects.map((project) => project.projectKey).sort()).toEqual([
+      "/home/me/scratch/app",
+      "/home/me/work/app",
+    ]);
+  });
+});

--- a/packages/app/src/projects/workspace-structure.ts
+++ b/packages/app/src/projects/workspace-structure.ts
@@ -8,6 +8,9 @@ export interface WorkspaceStructureHostPlacement {
 }
 
 export interface WorkspaceStructureProject {
+  // Identity of the checkout (repo-root path, or a legacy remote id). Drives sidebar
+  // grouping/selection and daemon ops (remove/create). Two clones of one remote have
+  // distinct projectKeys, so they render as two projects. See #987.
   projectKey: string;
   projectName: string;
   projectKind: WorkspaceDescriptor["projectKind"];

--- a/packages/app/src/screens/project-settings-screen.tsx
+++ b/packages/app/src/screens/project-settings-screen.tsx
@@ -31,6 +31,7 @@ import { SettingsGroup } from "@/screens/settings/settings-group";
 import { SettingsSection } from "@/screens/settings/settings-section";
 import { settingsStyles } from "@/styles/settings";
 import { useProjects } from "@/hooks/use-projects";
+import { useSessionStore } from "@/stores/session-store";
 import { useProjectIconDataByProjectKey } from "@/projects/project-icons";
 import { useHostRuntimeClient, useHostRuntimeSnapshot } from "@/runtime/host-runtime";
 import { useToast } from "@/contexts/toast-context";
@@ -241,7 +242,7 @@ function ProjectSettingsBody({
             projectName={project.projectName}
             projectKey={project.projectKey}
           />
-          <ProjectNameEditor project={project} client={client} />
+          <ProjectNameEditor project={project} client={client} serverId={selectedHost.serverId} />
         </View>
         <HostContext hosts={hosts} selectedHost={selectedHost} onSelectHost={onSelectHost} />
       </View>
@@ -791,9 +792,10 @@ function ResolveSpinnerColor(): string {
 interface ProjectNameEditorProps {
   project: ProjectSummary;
   client: DaemonClient;
+  serverId: string;
 }
 
-function ProjectNameEditor({ project, client }: ProjectNameEditorProps) {
+function ProjectNameEditor({ project, client, serverId }: ProjectNameEditorProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const toast = useToast();
@@ -802,7 +804,11 @@ function ProjectNameEditor({ project, client }: ProjectNameEditorProps) {
 
   const renameMutation = useMutation({
     mutationFn: (customName: string | null) => client.renameProject(project.projectKey, customName),
-    onSuccess: () => {
+    onSuccess: (_result, customName) => {
+      // Reflect the rename immediately in the session-store-driven sidebar. The daemon
+      // re-emits workspace descriptors for workspace-backed projects, but sends nothing
+      // for empty (workspace-less) ones, so update the store here too. See #987.
+      useSessionStore.getState().applyProjectRename(serverId, project.projectKey, customName);
       queryClient.invalidateQueries({ queryKey: ["projects"] });
       setIsEditing(false);
       toast.show(t("settings.project.rename.renamedToast"), { variant: "success" });

--- a/packages/app/src/stores/session-store-hooks/selectors.test.ts
+++ b/packages/app/src/stores/session-store-hooks/selectors.test.ts
@@ -227,6 +227,7 @@ describe("workspace structure composition", () => {
     });
     const emptyProject: EmptyProjectDescriptor = {
       projectId: "project-a",
+      remoteKey: null,
       projectDisplayName: "Project A",
       projectCustomName: null,
       projectRootPath: "/repo/a",
@@ -281,6 +282,7 @@ describe("workspace structure composition", () => {
     useSessionStore.getState().setEmptyProjects(SERVER_ID, [
       {
         projectId: "empty-project",
+        remoteKey: null,
         projectDisplayName: "Empty Project",
         projectCustomName: null,
         projectRootPath: "/repo/empty",

--- a/packages/app/src/stores/session-store.test.ts
+++ b/packages/app/src/stores/session-store.test.ts
@@ -456,6 +456,7 @@ describe("removeEmptyProject", () => {
     store.setEmptyProjects("test-server", [
       {
         projectId: "project-empty",
+        remoteKey: null,
         projectDisplayName: "Empty",
         projectCustomName: null,
         projectRootPath: "/repo/empty",
@@ -474,6 +475,7 @@ describe("removeEmptyProject", () => {
     store.setEmptyProjects("test-server", [
       {
         projectId: "project-empty",
+        remoteKey: null,
         projectDisplayName: "Empty",
         projectCustomName: null,
         projectRootPath: "/repo/empty",

--- a/packages/app/src/stores/session-store.test.ts
+++ b/packages/app/src/stores/session-store.test.ts
@@ -493,6 +493,69 @@ describe("removeEmptyProject", () => {
   });
 });
 
+describe("applyProjectRename", () => {
+  it("updates an empty project's custom name so the sidebar reflects the rename (#987)", () => {
+    const store = useSessionStore.getState();
+    initializeTestSession();
+    store.setEmptyProjects("test-server", [
+      {
+        projectId: "/repo/app",
+        remoteKey: "remote:github.com/acme/app",
+        projectDisplayName: "acme/app",
+        projectCustomName: null,
+        projectRootPath: "/repo/app",
+        projectKind: "git",
+      },
+    ]);
+
+    store.applyProjectRename("test-server", "/repo/app", "acme (work)");
+
+    expect(getTestSessionReferences().emptyProjects.get("/repo/app")?.projectCustomName).toBe(
+      "acme (work)",
+    );
+  });
+
+  it("clears the custom name on reset", () => {
+    const store = useSessionStore.getState();
+    initializeTestSession();
+    store.setEmptyProjects("test-server", [
+      {
+        projectId: "/repo/app",
+        remoteKey: null,
+        projectDisplayName: "app",
+        projectCustomName: "Renamed",
+        projectRootPath: "/repo/app",
+        projectKind: "git",
+      },
+    ]);
+
+    store.applyProjectRename("test-server", "/repo/app", null);
+
+    expect(getTestSessionReferences().emptyProjects.get("/repo/app")?.projectCustomName).toBeNull();
+  });
+
+  it("preserves identity when the project id is unknown (workspace-backed projects use the daemon re-emit)", () => {
+    const store = useSessionStore.getState();
+    initializeTestSession();
+    store.setEmptyProjects("test-server", [
+      {
+        projectId: "/repo/app",
+        remoteKey: null,
+        projectDisplayName: "app",
+        projectCustomName: null,
+        projectRootPath: "/repo/app",
+        projectKind: "git",
+      },
+    ]);
+    const before = getTestSessionReferences();
+
+    store.applyProjectRename("test-server", "/repo/other", "X");
+    const after = getTestSessionReferences();
+
+    expect(after.emptyProjects).toBe(before.emptyProjects);
+  });
+});
+
 describe("patchWorkspaceScripts", () => {
   it("preserves workspace entry identity when scripts are content-equal", () => {
     const script = {

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -176,6 +176,9 @@ export function normalizeWorkspaceDescriptor(
 
 export interface EmptyProjectDescriptor {
   projectId: string;
+  // Cross-host grouping / GitHub key ("remote:...") or null; distinct from projectId
+  // (identity) so two clones of one remote stay distinct but group across hosts. #987.
+  remoteKey: string | null;
   projectDisplayName: string;
   projectCustomName: string | null;
   projectRootPath: string;
@@ -187,6 +190,7 @@ export function normalizeEmptyProjectDescriptor(
 ): EmptyProjectDescriptor {
   return {
     projectId: payload.projectId,
+    remoteKey: payload.remoteKey ?? null,
     projectDisplayName: payload.projectDisplayName,
     projectCustomName: payload.projectCustomName ?? null,
     projectRootPath: payload.projectRootPath,
@@ -234,6 +238,7 @@ function emptyProjectDescriptorFromWorkspace(
 ): EmptyProjectDescriptor {
   return {
     projectId: workspace.projectId,
+    remoteKey: workspace.project?.remoteKey ?? null,
     projectDisplayName: workspace.projectDisplayName,
     projectCustomName: workspace.projectCustomName ?? null,
     projectRootPath: workspace.projectRootPath,

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -490,6 +490,7 @@ interface SessionStoreActions {
   setEmptyProjects: (serverId: string, emptyProjects: Iterable<EmptyProjectDescriptor>) => void;
   addEmptyProject: (serverId: string, emptyProject: EmptyProjectDescriptor) => void;
   removeEmptyProject: (serverId: string, projectId: string) => void;
+  applyProjectRename: (serverId: string, projectId: string, customName: string | null) => void;
   setWorkspaceRestoreStatus: (
     serverId: string,
     workspaceId: string,
@@ -1303,6 +1304,31 @@ export const useSessionStore = create<SessionStore>()(
           }
           const next = new Map(session.emptyProjects);
           next.delete(projectId);
+          return {
+            ...prev,
+            sessions: {
+              ...prev.sessions,
+              [serverId]: { ...session, emptyProjects: next },
+            },
+          };
+        });
+      },
+
+      applyProjectRename: (serverId, projectId, customName) => {
+        set((prev) => {
+          const session = prev.sessions[serverId];
+          if (!session) {
+            return prev;
+          }
+          const existing = session.emptyProjects.get(projectId);
+          // Only workspace-less (empty) projects need this optimistic update: the daemon
+          // re-emits workspace descriptors for projects that have workspaces, but sends
+          // nothing for empty ones, so the sidebar would otherwise miss the rename. #987.
+          if (!existing || (existing.projectCustomName ?? null) === (customName ?? null)) {
+            return prev;
+          }
+          const next = new Map(session.emptyProjects);
+          next.set(projectId, { ...existing, projectCustomName: customName });
           return {
             ...prev,
             sessions: {

--- a/packages/app/src/utils/projects.test.ts
+++ b/packages/app/src/utils/projects.test.ts
@@ -8,10 +8,12 @@ function placement(input: {
   projectName: string;
   cwd: string;
   remoteUrl: string | null;
+  remoteKey?: string | null;
   mainRepoRoot?: string | null;
 }): ProjectPlacementPayload {
   return {
     projectKey: input.projectKey,
+    remoteKey: input.remoteKey ?? null,
     projectName: input.projectName,
     checkout: {
       cwd: input.cwd,
@@ -139,7 +141,6 @@ describe("buildProjects", () => {
     expect(summary?.hostCount).toBe(2);
     expect(summary?.onlineHostCount).toBe(2);
     expect(summary?.totalWorkspaceCount).toBe(5);
-    expect(summary?.githubUrl).toBe("https://github.com/acme/app");
     expect(summary?.hosts).toHaveLength(2);
     const local = summary?.hosts.find((host) => host.serverId === "local");
     const laptop = summary?.hosts.find((host) => host.serverId === "laptop");
@@ -147,6 +148,110 @@ describe("buildProjects", () => {
     expect(laptop?.workspaceCount).toBe(2);
     expect(local?.workspaces.map((entry) => entry.id)).toEqual(["main", "feature-a", "feature-b"]);
     expect(laptop?.workspaces.map((entry) => entry.id)).toEqual(["main", "feature"]);
+  });
+
+  it("shows the same repo on two hosts (different paths) as two projects; unification is by identity", () => {
+    // Identity is the repo path, and different machines have different paths, so the
+    // same repo shows per checkout. The GitHub URL still derives from the shared remoteKey.
+    const result = buildProjects({
+      hosts: [
+        {
+          serverId: "local",
+          serverName: "Local",
+          isOnline: true,
+          workspaces: [
+            workspace({
+              id: "local-main",
+              repoRoot: "/home/me/app",
+              projectId: "/home/me/app",
+              project: placement({
+                projectKey: "/home/me/app",
+                remoteKey: "remote:github.com/acme/app",
+                projectName: "acme/app",
+                cwd: "/home/me/app",
+                remoteUrl: "https://github.com/acme/app.git",
+              }),
+            }),
+          ],
+        },
+        {
+          serverId: "laptop",
+          serverName: "Laptop",
+          isOnline: true,
+          workspaces: [
+            workspace({
+              id: "laptop-main",
+              repoRoot: "/Users/me/app",
+              projectId: "/Users/me/app",
+              project: placement({
+                projectKey: "/Users/me/app",
+                remoteKey: "remote:github.com/acme/app",
+                projectName: "acme/app",
+                cwd: "/Users/me/app",
+                remoteUrl: "git@github.com:acme/app.git",
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+
+    expect(result.projects.map((project) => project.projectKey).sort()).toEqual([
+      "/Users/me/app",
+      "/home/me/app",
+    ]);
+    expect(
+      result.projects.every((project) => project.githubUrl === "https://github.com/acme/app"),
+    ).toBe(true);
+  });
+
+  it("shows two clones of one remote on a single host as two distinct projects (#987)", () => {
+    const result = buildProjects({
+      hosts: [
+        {
+          serverId: "local",
+          serverName: "Local",
+          isOnline: true,
+          workspaces: [
+            workspace({
+              id: "work",
+              repoRoot: "/home/me/work/app",
+              projectId: "/home/me/work/app",
+              project: placement({
+                projectKey: "/home/me/work/app",
+                remoteKey: "remote:github.com/acme/app",
+                projectName: "acme/app",
+                cwd: "/home/me/work/app",
+                remoteUrl: "https://github.com/acme/app.git",
+              }),
+            }),
+            workspace({
+              id: "scratch",
+              repoRoot: "/home/me/scratch/app",
+              projectId: "/home/me/scratch/app",
+              project: placement({
+                projectKey: "/home/me/scratch/app",
+                remoteKey: "remote:github.com/acme/app",
+                projectName: "acme/app",
+                cwd: "/home/me/scratch/app",
+                remoteUrl: "https://github.com/acme/app.git",
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+
+    // Two clones of one repo are two distinct projects (keyed by path), each with one
+    // workspace and each carrying the shared repo's GitHub URL.
+    expect(result.projects.map((project) => project.projectKey).sort()).toEqual([
+      "/home/me/scratch/app",
+      "/home/me/work/app",
+    ]);
+    expect(result.projects.every((project) => project.totalWorkspaceCount === 1)).toBe(true);
+    expect(
+      result.projects.every((project) => project.githubUrl === "https://github.com/acme/app"),
+    ).toBe(true);
   });
 
   it("collapses five workspaces on one host into a single host entry whose workspaceCount is five", () => {
@@ -225,7 +330,7 @@ describe("buildProjects", () => {
     expect(legacy?.hosts[0]?.repoRoot).toBe("/repo/legacy");
   });
 
-  it("derives githubUrl only when projectKey matches remote:github.com/{owner}/{repo}", () => {
+  it("derives githubUrl from remoteKey (github remotes only), independent of the identity projectKey", () => {
     const result = buildProjects({
       hosts: [
         {
@@ -237,7 +342,8 @@ describe("buildProjects", () => {
               id: "github",
               repoRoot: "/repo/app",
               project: placement({
-                projectKey: "remote:github.com/acme/app",
+                projectKey: "/repo/app",
+                remoteKey: "remote:github.com/acme/app",
                 projectName: "acme/app",
                 cwd: "/repo/app",
                 remoteUrl: "https://github.com/acme/app.git",
@@ -258,9 +364,7 @@ describe("buildProjects", () => {
       ],
     });
 
-    const github = result.projects.find(
-      (project) => project.projectKey === "remote:github.com/acme/app",
-    );
+    const github = result.projects.find((project) => project.projectKey === "/repo/app");
     const local = result.projects.find((project) => project.projectKey === "/repo/local");
 
     expect(github?.githubUrl).toBe("https://github.com/acme/app");
@@ -526,6 +630,7 @@ describe("buildProjects", () => {
           emptyProjects: [
             {
               projectId: "/repo/fresh",
+              remoteKey: null,
               projectDisplayName: "fresh",
               projectCustomName: null,
               projectRootPath: "/repo/fresh",

--- a/packages/app/src/utils/projects.ts
+++ b/packages/app/src/utils/projects.ts
@@ -63,6 +63,9 @@ interface HostGroup {
 
 interface ProjectGroup {
   projectKey: string;
+  // Remote key ("remote:...") or null; internal only (not exposed on ProjectSummary).
+  // Projects are keyed by identity; this is kept solely to derive the GitHub URL. #987.
+  remoteKey: string | null;
   projectName: string;
   projectCustomName: string | null;
   hostsByServerId: Map<string, HostGroup>;
@@ -97,8 +100,11 @@ function buildHostProjectEntries(host: ProjectHost): HostProjectListItem[] {
   });
 }
 
-function deriveGithubUrl(projectKey: string): string | undefined {
-  const match = projectKey.match(GITHUB_PROJECT_KEY_PATTERN);
+function deriveGithubUrl(remoteKey: string | null): string | undefined {
+  if (!remoteKey) {
+    return undefined;
+  }
+  const match = remoteKey.match(GITHUB_PROJECT_KEY_PATTERN);
   if (!match) {
     return undefined;
   }
@@ -162,18 +168,36 @@ function toProjectSummary(draft: ProjectGroup): ProjectSummary {
     totalWorkspaceCount,
     hostCount: hosts.length,
     onlineHostCount,
-    githubUrl: deriveGithubUrl(draft.projectKey),
+    githubUrl: deriveGithubUrl(draft.remoteKey),
   };
+}
+
+// Per-identity lookups for one host: repo root for workspace-less project parents, and
+// the remote key (used only to derive the GitHub link). Projects are keyed by identity
+// (repo path), so two clones of one remote stay distinct. See #987.
+function indexHostProjectMetadata(host: ProjectHost): {
+  emptyRepoRootByProjectId: Map<string, string>;
+  remoteKeyByProjectId: Map<string, string | null>;
+} {
+  const emptyRepoRootByProjectId = new Map<string, string>();
+  const remoteKeyByProjectId = new Map<string, string | null>();
+  for (const emptyProject of host.emptyProjects ?? []) {
+    emptyRepoRootByProjectId.set(emptyProject.projectId, emptyProject.projectRootPath);
+    remoteKeyByProjectId.set(emptyProject.projectId, emptyProject.remoteKey ?? null);
+  }
+  for (const workspace of host.workspaces) {
+    if (!remoteKeyByProjectId.has(workspace.projectId)) {
+      remoteKeyByProjectId.set(workspace.projectId, workspace.project?.remoteKey ?? null);
+    }
+  }
+  return { emptyRepoRootByProjectId, remoteKeyByProjectId };
 }
 
 export function buildProjects(input: BuildProjectsInput): BuildProjectsResult {
   const groups = new Map<string, ProjectGroup>();
 
   for (const host of input.hosts) {
-    const emptyRepoRootByProjectKey = new Map<string, string>();
-    for (const emptyProject of host.emptyProjects ?? []) {
-      emptyRepoRootByProjectKey.set(emptyProject.projectId, emptyProject.projectRootPath);
-    }
+    const { emptyRepoRootByProjectId, remoteKeyByProjectId } = indexHostProjectMetadata(host);
 
     const hostProjects = buildHostProjectEntries(host);
     for (const hostProject of hostProjects) {
@@ -182,6 +206,7 @@ export function buildProjects(input: BuildProjectsInput): BuildProjectsResult {
       if (!group) {
         group = {
           projectKey: hostProject.projectKey,
+          remoteKey: remoteKeyByProjectId.get(hostProject.projectKey) ?? null,
           projectName: customName?.displayName ?? hostProject.projectName,
           projectCustomName: customName?.customName ?? null,
           hostsByServerId: new Map(),
@@ -198,7 +223,7 @@ export function buildProjects(input: BuildProjectsInput): BuildProjectsResult {
           serverName: host.serverName,
           isOnline: host.isOnline,
           workspaces: [],
-          fallbackRepoRoot: emptyRepoRootByProjectKey.get(hostProject.projectKey) ?? "",
+          fallbackRepoRoot: emptyRepoRootByProjectId.get(hostProject.projectKey) ?? "",
         });
       }
     }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2538,6 +2538,11 @@ export const ProjectCheckoutLitePayloadSchema = z.union([
 
 export const ProjectPlacementPayloadSchema = z.object({
   projectKey: z.string(),
+  // COMPAT(projectRemoteKey): added in v0.1.104, drop the optional gate when floor >= v0.1.104.
+  // Cross-host grouping / GitHub key ("remote:...") or null; distinct from projectKey,
+  // which is the per-checkout repo-root identity the client targets for remove/create.
+  // Old daemons omit it; old clients ignore it and group by projectKey. See #987.
+  remoteKey: z.string().nullable().optional(),
   projectName: z.string(),
   workspaceName: z.string().nullable().optional(),
   checkout: ProjectCheckoutLitePayloadSchema,
@@ -2761,6 +2766,11 @@ export const FetchRecentProviderSessionsResponseMessageSchema = z.object({
 // workspace is archived.
 export const WorkspaceProjectDescriptorPayloadSchema = z.object({
   projectId: z.string(),
+  // COMPAT(projectRemoteKey): added in v0.1.104, drop the optional gate when floor >= v0.1.104.
+  // Cross-host grouping / GitHub key ("remote:...") or null; distinct from projectId,
+  // which is the per-checkout repo-root identity. Old daemons omit it; old clients ignore
+  // it and fall back to grouping by projectId. See #987.
+  remoteKey: z.string().nullable().optional(),
   projectDisplayName: z.string(),
   projectCustomName: z.string().nullable().optional(),
   projectRootPath: z.string(),

--- a/packages/server/src/server/paseo-worktree-service.ts
+++ b/packages/server/src/server/paseo-worktree-service.ts
@@ -247,6 +247,7 @@ async function upsertWorkspaceForWorktree(options: {
       kind: sourceProject.kind,
       displayName: sourceProject.displayName,
       customName: sourceProject.customName,
+      remoteKey: sourceProject.remoteKey,
       createdAt: sourceProject.createdAt ?? now,
       updatedAt: now,
       archivedAt: null,
@@ -335,6 +336,7 @@ async function resolveProjectRecordForMembership(options: {
       rootPath,
       kind: options.membership.projectKind,
       displayName: options.membership.projectName,
+      remoteKey: options.membership.projectRemoteKey,
       createdAt: options.timestamp,
       updatedAt: options.timestamp,
     });
@@ -346,6 +348,9 @@ async function resolveProjectRecordForMembership(options: {
     kind: options.membership.projectKind,
     archivedAt: null,
     updatedAt: options.timestamp,
+    // Backfill the grouping key on legacy records that predate it, but never
+    // overwrite an existing one. See #987.
+    remoteKey: existingProject.remoteKey ?? options.membership.projectRemoteKey,
   };
 }
 
@@ -355,6 +360,7 @@ interface SourceProjectForWorktree {
   kind: "git";
   displayName: string;
   customName: string | null;
+  remoteKey: string | null;
   createdAt: string | null;
 }
 
@@ -363,6 +369,7 @@ function sourceProjectFromRecord(record: {
   rootPath: string;
   displayName: string;
   customName?: string | null;
+  remoteKey?: string | null;
   createdAt?: string | null;
 }): SourceProjectForWorktree {
   return {
@@ -371,6 +378,7 @@ function sourceProjectFromRecord(record: {
     kind: "git",
     displayName: record.displayName,
     customName: record.customName ?? null,
+    remoteKey: record.remoteKey ?? null,
     createdAt: record.createdAt ?? null,
   };
 }
@@ -398,6 +406,7 @@ async function resolveWorkspaceProjectForWorktree(options: {
     displayName:
       sourceProject?.displayName ?? deriveProjectGroupingName(options.sourceWorkspace.projectId),
     customName: sourceProject?.customName ?? null,
+    remoteKey: sourceProject?.remoteKey ?? null,
     createdAt: sourceProject?.createdAt ?? null,
   });
 }
@@ -413,6 +422,7 @@ async function resolveFallbackProjectForWorktree(options: {
     displayName:
       existingFallbackProject?.displayName ?? deriveProjectGroupingName(options.repoRoot),
     customName: existingFallbackProject?.customName ?? null,
+    remoteKey: existingFallbackProject?.remoteKey ?? null,
     createdAt: existingFallbackProject?.createdAt ?? null,
   });
 }

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1280,7 +1280,11 @@ export class Session {
       this.workspaceGitService.peekSnapshot(workspace.cwd)?.git.currentBranch ?? null;
     const checkout = buildWorkspaceCheckout(workspace, project, liveBranch);
     return {
+      // Identity of this checkout's project (the daemon projectId, now the repo-root
+      // path). The client targets it for remove/create and to keep two clones of one
+      // remote distinct; cross-host grouping uses remoteKey instead. See #987.
       projectKey: project.projectId,
+      remoteKey: project.remoteKey,
       projectName: resolveProjectDisplayName(project),
       workspaceName: resolveWorkspaceDisplayName(workspace),
       checkout,
@@ -3753,6 +3757,9 @@ export class Session {
   ): WorkspaceProjectDescriptorPayload {
     return {
       projectId: project.projectId,
+      // Cross-host grouping / GitHub key ("remote:...") or null; distinct from projectId
+      // (identity) so two clones of one remote group across hosts but stay distinct. #987.
+      remoteKey: project.remoteKey,
       projectDisplayName: resolveProjectDisplayName(project),
       projectCustomName: project.customName ?? null,
       projectRootPath: project.rootPath,

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -3976,7 +3976,6 @@ test("open_project_request reclassifies an archived directory workspace when git
     "orchestrate",
     "desktop-daemon-settings",
   );
-  const remoteProjectId = "remote:github.com/getpaseo/paseo";
   const archivedAt = "2026-04-24T09:48:36.168Z";
   const workspaceId = "ws-desktop-daemon-settings";
 
@@ -4054,10 +4053,13 @@ test("open_project_request reclassifies an archived directory workspace when git
   const response = findByType(emitted, "open_project_response");
 
   expect(response?.payload.error).toBeNull();
-  expect(response?.payload.workspace?.projectId).toBe(remoteProjectId);
+  // A worktree reclassifies under its MAIN repo root (identity), not the remote
+  // key — while still carrying the remote for grouping/display. See #987.
+  expect(response?.payload.workspace?.projectId).toBe(repoRoot);
   expect(response?.payload.workspace?.workspaceKind).toBe("worktree");
-  expect(projects.get(remoteProjectId)?.kind).toBe("git");
-  expect(workspaces.get(workspaceId)?.projectId).toBe(remoteProjectId);
+  expect(projects.get(repoRoot)?.kind).toBe("git");
+  expect(projects.get(repoRoot)?.remoteKey).toBe("remote:github.com/getpaseo/paseo");
+  expect(workspaces.get(workspaceId)?.projectId).toBe(repoRoot);
   expect(workspaces.get(workspaceId)?.kind).toBe("worktree");
   expect(workspaces.get(workspaceId)?.displayName).toBe("feature/desktop-daemon-settings");
 });

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, expect, test } from "vitest";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { createNoopWorkspaceGitService } from "../../test-utils/workspace-git-service-stub.js";
 import {
+  createPersistedProjectRecord,
   FileBackedProjectRegistry,
   FileBackedWorkspaceRegistry,
 } from "../../workspace-registry.js";
@@ -25,6 +26,9 @@ const ARCHIVED_AT = "2026-01-01T00:00:00.000Z";
 
 let tmpDir: string;
 let gitRoots: Set<string>;
+// Per-root git facts the stub reports; empty by default (existing tests stay no-remote).
+let remoteByRoot: Map<string, string>;
+let mainRepoRootByPath: Map<string, string>;
 let workspaceRegistry: FileBackedWorkspaceRegistry;
 let projectRegistry: FileBackedProjectRegistry;
 let provisioning: WorkspaceProvisioningService;
@@ -46,10 +50,10 @@ function gitService() {
         cwd,
         isGit: worktreeRoot !== null,
         currentBranch: worktreeRoot ? "main" : null,
-        remoteUrl: null,
+        remoteUrl: worktreeRoot ? (remoteByRoot.get(worktreeRoot) ?? null) : null,
         worktreeRoot,
         isPaseoOwnedWorktree: false,
-        mainRepoRoot: null,
+        mainRepoRoot: worktreeRoot ? (mainRepoRootByPath.get(worktreeRoot) ?? null) : null,
       };
     },
   });
@@ -58,6 +62,8 @@ function gitService() {
 beforeEach(async () => {
   tmpDir = mkdtempSync(path.join(os.tmpdir(), "workspace-provisioning-"));
   gitRoots = new Set();
+  remoteByRoot = new Map();
+  mainRepoRootByPath = new Map();
   workspaceRegistry = new FileBackedWorkspaceRegistry(
     path.join(tmpDir, "projects", "workspaces.json"),
     logger,
@@ -212,5 +218,71 @@ test("findOrCreateProjectForDirectory reuses the active project for the same roo
   const second = await provisioning.findOrCreateProjectForDirectory(path.join(repo, "sub"));
 
   expect(second.projectId).toBe(first.projectId);
+  expect(await projectRegistry.list()).toHaveLength(1);
+});
+
+test("two independent clones of the same remote become two distinct projects (#987)", async () => {
+  const work = path.join(tmpDir, "work", "repo");
+  const scratch = path.join(tmpDir, "scratch", "repo");
+  gitRoots.add(work);
+  gitRoots.add(scratch);
+  remoteByRoot.set(work, "https://github.com/acme/repo.git");
+  remoteByRoot.set(scratch, "https://github.com/acme/repo.git");
+
+  const first = await provisioning.findOrCreateProjectForDirectory(work);
+  const second = await provisioning.findOrCreateProjectForDirectory(scratch);
+
+  // Distinct identities (repo roots), so neither add overwrites the other...
+  expect(first.projectId).not.toBe(second.projectId);
+  expect(first.rootPath).toBe(work);
+  expect(second.rootPath).toBe(scratch);
+  expect(await projectRegistry.list()).toHaveLength(2);
+  // ...but both carry the shared remote key for cross-host grouping.
+  expect(first.remoteKey).toBe("remote:github.com/acme/repo");
+  expect(second.remoteKey).toBe("remote:github.com/acme/repo");
+});
+
+test("a worktree of a clone stays under that clone's project, not a sibling clone", async () => {
+  const work = path.join(tmpDir, "work", "repo");
+  gitRoots.add(work);
+  remoteByRoot.set(work, "https://github.com/acme/repo.git");
+  const root = await provisioning.findOrCreateProjectForDirectory(work);
+
+  // A linked worktree of `work`: its own git root, but mainRepoRoot points back at
+  // the main checkout, so it must group under `work`'s project.
+  const worktree = path.join(tmpDir, "work", "repo-feature");
+  gitRoots.add(worktree);
+  remoteByRoot.set(worktree, "https://github.com/acme/repo.git");
+  mainRepoRootByPath.set(worktree, work);
+
+  const worktreeProject = await provisioning.findOrCreateProjectForDirectory(worktree);
+
+  expect(worktreeProject.projectId).toBe(root.projectId);
+  expect(await projectRegistry.list()).toHaveLength(1);
+});
+
+test("re-opening a legacy remote-keyed project by its root preserves its id (no migration)", async () => {
+  const work = path.join(tmpDir, "work", "repo");
+  gitRoots.add(work);
+  remoteByRoot.set(work, "https://github.com/acme/repo.git");
+
+  // Seed a pre-#987 record whose id is the remote key at this root.
+  await projectRegistry.upsert(
+    createPersistedProjectRecord({
+      projectId: "remote:github.com/acme/repo",
+      rootPath: work,
+      kind: "git",
+      displayName: "acme/repo",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    }),
+  );
+
+  const resolved = await provisioning.findOrCreateProjectForDirectory(work);
+
+  // Matched by rootPath, so its legacy id is preserved (workspaces/agents keyed to
+  // it keep resolving) and the remote key is backfilled in place.
+  expect(resolved.projectId).toBe("remote:github.com/acme/repo");
+  expect(resolved.remoteKey).toBe("remote:github.com/acme/repo");
   expect(await projectRegistry.list()).toHaveLength(1);
 });

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
@@ -95,6 +95,7 @@ export function createWorkspaceProvisioningService(deps: {
         rootPath,
         kind,
         displayName: input.membership.projectName,
+        remoteKey: input.membership.projectRemoteKey,
         createdAt: input.timestamp,
         updatedAt: input.timestamp,
       });
@@ -106,6 +107,9 @@ export function createWorkspaceProvisioningService(deps: {
       kind,
       archivedAt: null,
       updatedAt: input.timestamp,
+      // Backfill the grouping key on legacy records that predate it, but never
+      // overwrite an existing one. See #987.
+      remoteKey: existingProject.remoteKey ?? input.membership.projectRemoteKey,
     };
   }
 

--- a/packages/server/src/server/workspace-git-metadata.ts
+++ b/packages/server/src/server/workspace-git-metadata.ts
@@ -1,13 +1,15 @@
 import { basename } from "path";
 import { parseGitHubRemoteUrl } from "../utils/github-remote.js";
 import { slugify } from "../utils/worktree.js";
-import { deriveProjectGroupingKey, deriveProjectGroupingName } from "./workspace-registry-model.js";
+import { deriveProjectGroupingName, deriveProjectRemoteKey } from "./workspace-registry-model.js";
 
 export interface WorkspaceGitMetadata {
   projectKind: "git" | "directory";
   projectDisplayName: string;
   workspaceDisplayName: string;
   gitRemote: string | null;
+  // Cross-host grouping key derived from the remote ("remote:...") or null. See #987.
+  remoteKey: string | null;
   isWorktree: boolean;
   projectSlug: string;
   repoRoot: string | null;
@@ -49,6 +51,7 @@ export function buildWorkspaceGitMetadataFromSnapshot(input: {
       projectDisplayName: input.directoryName,
       workspaceDisplayName: input.directoryName,
       gitRemote: null,
+      remoteKey: null,
       isWorktree: false,
       projectSlug: deriveProjectSlug(input.cwd),
       repoRoot: null,
@@ -59,20 +62,15 @@ export function buildWorkspaceGitMetadataFromSnapshot(input: {
 
   const isWorktree =
     input.mainRepoRoot !== null && input.repoRoot !== null && input.mainRepoRoot !== input.repoRoot;
-  const projectKey = deriveProjectGroupingKey({
-    cwd: input.repoRoot ?? input.cwd,
-    remoteUrl: input.remoteUrl,
-    mainRepoRoot: input.mainRepoRoot,
-  });
-  const projectDisplayName = projectKey.startsWith("remote:")
-    ? deriveProjectGroupingName(projectKey)
-    : input.directoryName;
+  const remoteKey = deriveProjectRemoteKey(input.remoteUrl);
+  const projectDisplayName = remoteKey ? deriveProjectGroupingName(remoteKey) : input.directoryName;
 
   return {
     projectKind: "git",
     projectDisplayName,
     workspaceDisplayName: input.currentBranch ?? input.directoryName,
     gitRemote: input.remoteUrl,
+    remoteKey,
     isWorktree,
     projectSlug: deriveProjectSlug(input.cwd, input.remoteUrl),
     repoRoot: input.repoRoot,

--- a/packages/server/src/server/workspace-reconciliation-service.test.ts
+++ b/packages/server/src/server/workspace-reconciliation-service.test.ts
@@ -15,6 +15,7 @@ import type {
   WorkspaceRegistry,
 } from "./workspace-registry.js";
 import { WorkspaceReconciliationService } from "./workspace-reconciliation-service.js";
+import { deriveProjectRemoteKey } from "./workspace-registry-model.js";
 
 function createTestRegistries() {
   const projects = new Map<string, PersistedProjectRecord>();
@@ -115,6 +116,7 @@ function createWorkspaceGitServiceStub(
           projectDisplayName: directoryName,
           workspaceDisplayName: directoryName,
           gitRemote: null,
+          remoteKey: null,
           isWorktree: false,
           projectSlug: "untitled",
           repoRoot: null,
@@ -122,13 +124,15 @@ function createWorkspaceGitServiceStub(
           remoteUrl: null,
         };
       }
+      const gitRemote = metadata.gitRemote ?? null;
       return {
-        gitRemote: metadata.gitRemote ?? null,
+        gitRemote,
+        remoteKey: deriveProjectRemoteKey(gitRemote),
         isWorktree: false,
         projectSlug: "repo",
         repoRoot: cwd,
         currentBranch: metadata.workspaceDisplayName,
-        remoteUrl: metadata.gitRemote ?? null,
+        remoteUrl: gitRemote,
         ...metadata,
       };
     }),
@@ -790,5 +794,92 @@ describe("WorkspaceReconciliationService", () => {
     await service.runOnce();
 
     expect(infoRecords).toEqual([]);
+  });
+
+  test("does not merge two clones of one remote that live at different roots (#987)", async () => {
+    const work = createTempGitRepo("reconcile-clone-work-");
+    const scratch = createTempGitRepo("reconcile-clone-scratch-");
+    tempDirs.push(work, scratch);
+    const { projects, projectRegistry, workspaceRegistry } = createTestRegistries();
+
+    const remote = "git@github.com:acme/repo.git";
+    for (const root of [work, scratch]) {
+      projects.set(
+        root,
+        createPersistedProjectRecord({
+          projectId: root,
+          rootPath: root,
+          kind: "git",
+          displayName: "acme/repo",
+          remoteKey: "remote:github.com/acme/repo",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        }),
+      );
+    }
+
+    const service = new WorkspaceReconciliationService({
+      projectRegistry,
+      workspaceRegistry,
+      logger: createTestLogger(),
+      workspaceGitService: createWorkspaceGitServiceStub({
+        [work]: {
+          projectKind: "git",
+          projectDisplayName: "acme/repo",
+          workspaceDisplayName: "main",
+          gitRemote: remote,
+        },
+        [scratch]: {
+          projectKind: "git",
+          projectDisplayName: "acme/repo",
+          workspaceDisplayName: "main",
+          gitRemote: remote,
+        },
+      }),
+    });
+
+    const result = await service.runOnce();
+
+    // Grouping is by rootPath, not remoteKey — distinct clones must both survive.
+    expect(result.changesApplied.find((c) => c.kind === "project_archived")).toBeUndefined();
+    expect(projects.get(work)!.archivedAt).toBeFalsy();
+    expect(projects.get(scratch)!.archivedAt).toBeFalsy();
+  });
+
+  test("backfills remoteKey on a legacy project record from the live remote", async () => {
+    const dir = createTempGitRepo("reconcile-remotekey-");
+    tempDirs.push(dir);
+    const { projects, projectRegistry, workspaceRegistry } = createTestRegistries();
+
+    projects.set(
+      "p1",
+      createPersistedProjectRecord({
+        projectId: "p1",
+        rootPath: dir,
+        kind: "git",
+        displayName: "acme/repo",
+        // Legacy record predating remoteKey.
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      }),
+    );
+
+    const service = new WorkspaceReconciliationService({
+      projectRegistry,
+      workspaceRegistry,
+      logger: createTestLogger(),
+      workspaceGitService: createWorkspaceGitServiceStub({
+        [dir]: {
+          projectKind: "git",
+          projectDisplayName: "acme/repo",
+          workspaceDisplayName: "main",
+          gitRemote: "git@github.com:acme/repo.git",
+        },
+      }),
+    });
+
+    await service.runOnce();
+
+    expect(projects.get("p1")!.remoteKey).toBe("remote:github.com/acme/repo");
   });
 });

--- a/packages/server/src/server/workspace-reconciliation-service.ts
+++ b/packages/server/src/server/workspace-reconciliation-service.ts
@@ -331,8 +331,9 @@ export class WorkspaceReconciliationService {
       projectUpdates.displayName = currentGit.projectDisplayName;
     }
 
-    // Backfill the cross-host grouping key on records created before it existed.
-    // Only set it from a live remote; never clear an existing key. See #987.
+    // Keep the cross-host grouping key fresh from the live remote: set it on records
+    // that predate it, and update it when the repo's remote changes. It is only ever
+    // assigned from a non-null live remote, so it is never cleared to null. See #987.
     if (currentGit.remoteKey && project.remoteKey !== currentGit.remoteKey) {
       projectUpdates.remoteKey = currentGit.remoteKey;
     }

--- a/packages/server/src/server/workspace-reconciliation-service.ts
+++ b/packages/server/src/server/workspace-reconciliation-service.ts
@@ -20,6 +20,11 @@ function deriveWorkspaceKindFromMetadata(metadata: {
   return "local_checkout";
 }
 
+// Picks the survivor when several project records share ONE rootPath (e.g. a legacy
+// remote-keyed record and a newer path-keyed record for the same physical repo).
+// Prefers the legacy "remote:"-prefixed id so agents/workspaces keyed to it don't
+// orphan. This only consolidates same-root duplicates; it never groups distinct
+// clones (those have different roots — see mergeDuplicateProjectsByRoot). See #987.
 function chooseCanonicalProject(projects: PersistedProjectRecord[]): PersistedProjectRecord {
   return [...projects].sort((left, right) => {
     const leftRemote = left.projectId.startsWith("remote:");
@@ -43,7 +48,10 @@ export type ReconciliationChange =
       projectId: string;
       directory: string;
       fields: Partial<
-        Pick<PersistedProjectRecord, "kind" | "displayName" | "rootPath" | "customName">
+        Pick<
+          PersistedProjectRecord,
+          "kind" | "displayName" | "rootPath" | "customName" | "remoteKey"
+        >
       >;
     }
   | {
@@ -205,6 +213,9 @@ export class WorkspaceReconciliationService {
     workspacesByProject: Map<string, PersistedWorkspaceRecord[]>,
     changes: ReconciliationChange[],
   ): Promise<void> {
+    // Group strictly by resolved rootPath, NOT by remoteKey: two independent clones
+    // of the same remote have different roots and must stay distinct projects.
+    // Merging by remoteKey here would re-introduce the #987 collapse via the reconciler.
     const projectsByRoot = new Map<string, PersistedProjectRecord[]>();
     for (const project of activeProjects) {
       if (project.kind !== "git") {
@@ -302,7 +313,7 @@ export class WorkspaceReconciliationService {
     const currentGit = await this.readWorkspaceGitMetadata(project.rootPath, directoryName);
 
     const projectUpdates: Partial<
-      Pick<PersistedProjectRecord, "kind" | "displayName" | "rootPath">
+      Pick<PersistedProjectRecord, "kind" | "displayName" | "rootPath" | "remoteKey">
     > = {};
 
     const mappedKind = currentGit.projectKind === "git" ? "git" : "non_git";
@@ -318,6 +329,12 @@ export class WorkspaceReconciliationService {
       project.displayName !== currentGit.projectDisplayName
     ) {
       projectUpdates.displayName = currentGit.projectDisplayName;
+    }
+
+    // Backfill the cross-host grouping key on records created before it existed.
+    // Only set it from a live remote; never clear an existing key. See #987.
+    if (currentGit.remoteKey && project.remoteKey !== currentGit.remoteKey) {
+      projectUpdates.remoteKey = currentGit.remoteKey;
     }
 
     if (Object.keys(projectUpdates).length > 0) {
@@ -380,6 +397,7 @@ export class WorkspaceReconciliationService {
         projectDisplayName: directoryName,
         workspaceDisplayName: directoryName,
         gitRemote: null,
+        remoteKey: null,
         isWorktree: false,
         projectSlug: "untitled",
         repoRoot: null,

--- a/packages/server/src/server/workspace-registry-model.test.ts
+++ b/packages/server/src/server/workspace-registry-model.test.ts
@@ -197,11 +197,45 @@ describe("git worktree grouping", () => {
       workspaceDirectoryKey: "/tmp/repo-feature",
       workspaceKind: "worktree",
       workspaceDisplayName: "feature/plain",
-      projectKey: "remote:github.com/acme/repo",
+      // Identity groups the worktree under its main repo root; the remote key is
+      // grouping/display only. See #987.
+      projectKey: "/tmp/repo",
+      projectRemoteKey: "remote:github.com/acme/repo",
       projectName: "acme/repo",
       projectRootPath: "/tmp/repo",
       projectKind: "git",
     });
+  });
+
+  test("two independent clones of one remote get distinct project keys but share a remote key (#987)", () => {
+    const remoteUrl = "https://github.com/acme/repo.git";
+    const classifyClone = (root: string, branch: string) =>
+      classifyDirectoryForProjectMembership({
+        cwd: root,
+        checkout: {
+          cwd: root,
+          isGit: true,
+          currentBranch: branch,
+          remoteUrl,
+          worktreeRoot: root,
+          isPaseoOwnedWorktree: false,
+          // A plain clone (not a linked worktree) reports mainRepoRoot: null.
+          mainRepoRoot: null,
+        },
+      });
+
+    const work = classifyClone("/home/me/work/repo", "main");
+    const scratch = classifyClone("/home/me/scratch/repo", "feature");
+
+    // Identity is the repo root, so the two clones are distinct projects...
+    expect(work.projectKey).toBe("/home/me/work/repo");
+    expect(scratch.projectKey).toBe("/home/me/scratch/repo");
+    expect(work.projectKey).not.toBe(scratch.projectKey);
+    // ...while the remote key (grouping/display) is shared.
+    expect(work.projectRemoteKey).toBe("remote:github.com/acme/repo");
+    expect(scratch.projectRemoteKey).toBe(work.projectRemoteKey);
+    expect(work.projectName).toBe("acme/repo");
+    expect(scratch.projectName).toBe("acme/repo");
   });
 
   test("uses mainRepoRoot as the project root for plain git worktrees", () => {

--- a/packages/server/src/server/workspace-registry-model.ts
+++ b/packages/server/src/server/workspace-registry-model.ts
@@ -235,6 +235,7 @@ export function buildProjectPlacementForCwd(input: {
   const membership = classifyDirectoryForProjectMembership(input);
   return {
     projectKey: membership.projectKey,
+    remoteKey: membership.projectRemoteKey,
     projectName: membership.projectName,
     checkout: membership.checkout,
   };

--- a/packages/server/src/server/workspace-registry-model.ts
+++ b/packages/server/src/server/workspace-registry-model.ts
@@ -18,6 +18,10 @@ export interface DirectoryProjectMembership {
   workspaceKind: PersistedWorkspaceKind;
   workspaceDisplayName: string;
   projectKey: string;
+  // Cross-host grouping/display key ("remote:...") or null. Distinct from
+  // projectKey (the repo-root identity) so two clones of one remote are distinct
+  // projects that still group across hosts. See #987.
+  projectRemoteKey: string | null;
   projectName: string;
   projectRootPath: string;
   projectKind: PersistedProjectKind;
@@ -42,7 +46,11 @@ export function deriveWorkspaceDirectoryKey(
   return worktreeRoot ?? resolve(cwd);
 }
 
-function deriveRemoteProjectKey(remoteUrl: string | null): string | null {
+// Cross-host grouping and display key derived from the git remote (e.g.
+// "remote:github.com/owner/repo"). NOT the project identity — two independent
+// clones of one remote share this key but are distinct projects keyed by their
+// root path. Null for non-git / no-remote / unparseable remotes. See #987.
+export function deriveProjectRemoteKey(remoteUrl: string | null): string | null {
   if (!remoteUrl) {
     return null;
   }
@@ -89,22 +97,16 @@ function deriveRemoteProjectKey(remoteUrl: string | null): string | null {
   return `remote:${cleanedHost}/${cleanedPath}`;
 }
 
+// Identity key for a project: the repository root. Two independent clones of the
+// same remote have distinct roots (so they become distinct projects); a repo and
+// its git worktrees share mainRepoRoot (so they group under one project). The
+// remote-based grouping/display key now lives in deriveProjectRemoteKey. See #987.
 export function deriveProjectGroupingKey(options: {
   cwd: string;
-  remoteUrl: string | null;
   mainRepoRoot: string | null;
 }): string {
-  const remoteKey = deriveRemoteProjectKey(options.remoteUrl);
-  if (remoteKey) {
-    return remoteKey;
-  }
-
   const mainRepoRoot = options.mainRepoRoot?.trim();
-  if (mainRepoRoot) {
-    return mainRepoRoot;
-  }
-
-  return options.cwd;
+  return mainRepoRoot ? mainRepoRoot : options.cwd;
 }
 
 export function deriveProjectGroupingName(projectKey: string): string {
@@ -248,11 +250,21 @@ export function classifyDirectoryForProjectMembership(input: {
     cwd: normalizedCwd,
   };
 
+  const projectRootPath = deriveProjectRootPath({
+    cwd: normalizedCwd,
+    checkout,
+  });
+  // Project identity is the repository root (the worktree root, or the main repo
+  // root for a linked worktree) — NOT the remote. Two independent clones of one
+  // remote get distinct roots (so they are distinct projects); a repo and its
+  // worktrees share mainRepoRoot (so they group under one project); a subpath of a
+  // repo still resolves to the repo root. The remote key drives cross-host grouping
+  // and display only. See #987.
   const projectKey = deriveProjectGroupingKey({
     cwd: checkout.worktreeRoot ?? normalizedCwd,
-    remoteUrl: checkout.remoteUrl,
     mainRepoRoot: checkout.mainRepoRoot,
   });
+  const projectRemoteKey = deriveProjectRemoteKey(checkout.remoteUrl);
 
   return {
     cwd: normalizedCwd,
@@ -264,11 +276,9 @@ export function classifyDirectoryForProjectMembership(input: {
       checkout,
     }),
     projectKey,
-    projectName: deriveProjectGroupingName(projectKey),
-    projectRootPath: deriveProjectRootPath({
-      cwd: normalizedCwd,
-      checkout,
-    }),
+    projectRemoteKey,
+    projectName: deriveProjectGroupingName(projectRemoteKey ?? projectKey),
+    projectRootPath,
     projectKind: deriveProjectKind(checkout),
   };
 }

--- a/packages/server/src/server/workspace-registry.test.ts
+++ b/packages/server/src/server/workspace-registry.test.ts
@@ -99,19 +99,53 @@ describe("workspace registries", () => {
     expect(await projectRegistry.list()).toEqual([]);
   });
 
-  test("PIN: two checkouts of the same git remote collapse into a single project record", async () => {
-    // Reproduces the situation in #987: two directories that share a git remote
-    // both derive the same projectKey/displayName. Because the registry is keyed
-    // by projectId, the second upsert overwrites the first — so the registry can
-    // only ever hold one record per remote, and there is no way to distinguish
-    // the two checkouts in the UI.
+  test("two checkouts of one remote persist as two records when keyed by repo root (#987)", async () => {
+    // #987: two independent clones of one repo used to derive the same
+    // remote-based projectId and collapse into a single record (the second upsert
+    // overwrote the first). Identity is now the repo root path, so the two roots
+    // persist as two distinct projects while sharing the remote key for cross-host
+    // grouping.
     await projectRegistry.initialize();
-
-    const remoteKey = "remote:github.com/acme/repo";
 
     await projectRegistry.upsert(
       createPersistedProjectRecord({
-        projectId: remoteKey,
+        projectId: "/home/me/work/repo",
+        rootPath: "/home/me/work/repo",
+        kind: "git",
+        displayName: "acme/repo",
+        remoteKey: "remote:github.com/acme/repo",
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    );
+
+    await projectRegistry.upsert(
+      createPersistedProjectRecord({
+        projectId: "/home/me/scratch/repo",
+        rootPath: "/home/me/scratch/repo",
+        kind: "git",
+        displayName: "acme/repo",
+        remoteKey: "remote:github.com/acme/repo",
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-02T00:00:00.000Z",
+      }),
+    );
+
+    const all = await projectRegistry.list();
+    expect(all).toHaveLength(2);
+    expect(all.map((project) => project.rootPath).sort()).toEqual([
+      "/home/me/scratch/repo",
+      "/home/me/work/repo",
+    ]);
+    expect(all.every((project) => project.remoteKey === "remote:github.com/acme/repo")).toBe(true);
+  });
+
+  test("project record schema accepts records without remoteKey (legacy on-disk records)", async () => {
+    await projectRegistry.initialize();
+
+    await projectRegistry.upsert(
+      createPersistedProjectRecord({
+        projectId: "remote:github.com/acme/repo",
         rootPath: "/home/me/work/repo",
         kind: "git",
         displayName: "acme/repo",
@@ -120,22 +154,8 @@ describe("workspace registries", () => {
       }),
     );
 
-    await projectRegistry.upsert(
-      createPersistedProjectRecord({
-        projectId: remoteKey,
-        rootPath: "/home/me/scratch/repo",
-        kind: "git",
-        displayName: "acme/repo",
-        createdAt: "2026-03-01T00:00:00.000Z",
-        updatedAt: "2026-03-02T00:00:00.000Z",
-      }),
-    );
-
-    const all = await projectRegistry.list();
-    expect(all).toHaveLength(1);
-    expect(all[0]?.displayName).toBe("acme/repo");
-    // Second upsert wins — the first rootPath is lost.
-    expect(all[0]?.rootPath).toBe("/home/me/scratch/repo");
+    const record = await projectRegistry.get("remote:github.com/acme/repo");
+    expect(record?.remoteKey).toBeNull();
   });
 
   test("project record schema accepts records without customName (legacy on-disk records)", async () => {

--- a/packages/server/src/server/workspace-registry.ts
+++ b/packages/server/src/server/workspace-registry.ts
@@ -18,6 +18,16 @@ const PersistedProjectRecordSchema = z.object({
     .nullable()
     .optional()
     .transform((value) => value ?? null),
+  // Cross-host/display grouping key ("remote:github.com/owner/repo"); null for
+  // non-git or no-remote checkouts. Decoupled from projectId (which is the repo
+  // root path) so two independent clones of one remote are distinct projects but
+  // still group across hosts and share a GitHub link. Legacy on-disk records omit
+  // it and parse to null. Added for #987.
+  remoteKey: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((value) => value ?? null),
   createdAt: z.string(),
   updatedAt: z.string(),
   archivedAt: z.string().nullable(),
@@ -230,6 +240,7 @@ export function createPersistedProjectRecord(input: {
   kind: PersistedProjectKind;
   displayName: string;
   customName?: string | null;
+  remoteKey?: string | null;
   createdAt: string;
   updatedAt: string;
   archivedAt?: string | null;
@@ -237,6 +248,7 @@ export function createPersistedProjectRecord(input: {
   return PersistedProjectRecordSchema.parse({
     ...input,
     customName: input.customName ?? null,
+    remoteKey: input.remoteKey ?? null,
     archivedAt: input.archivedAt ?? null,
   });
 }


### PR DESCRIPTION
### Linked issue

Closes #987

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Paseo identified a project by its git **remote URL**, so two independent clones of the same repo (different folders, same `origin`) derived the same `projectId` and the second overwrote the first — you could never keep two checkouts of one repo at once (#987).

This makes **project identity the repository root path**:

- Each checkout is its own project. Two clones of a repo are two projects; a repo and its git worktrees still share one project (they share `mainRepoRoot`).
- The `remote:<host>/<owner>/<repo>` value is persisted as a new `remoteKey` and used for the derived display name and the GitHub link — no longer as identity. It ships as an additive, optional wire field (`COMPAT(projectRemoteKey)`), so the protocol stays backward-compatible.
- Clients key projects by identity everywhere — the sidebar, the Projects screen, and the rename/remove/settings/create-workspace operations that target the daemon `projectId`.

**Behavior change (please weigh in):** because identity is now the path, the *same repo on two different machines* shows as **two projects (one per checkout)** instead of one cross-host-unified row. The remote key still powers the GitHub link. This trades remote-based cross-host merging for unambiguous per-checkout identity that per-project operations can target; the pinned cross-host tests are updated to the new model.

No data migration: existing `remote:`-keyed records are matched by `rootPath` and preserved (they gain a `remoteKey` on the next reconcile).

Commits are split so the fix is easy to review:
1. **`fix: let two checkouts of the same repo be separate projects`** — the identity change (server + protocol + client + tests + docs).
2. **`fix: reflect empty-project renames in the sidebar`** — a small related fix: `project.rename` only re-broadcast descriptors for workspaces *under* a project, so renaming a workspace-less project (now common, since you can add bare clones) didn't refresh the store-driven sidebar. The client applies the rename to its session store on success. Happy to split this into its own PR if preferred.

### How did you verify it

Reproduced first, fixed after — daemon logs + app screenshots.

- **Daemon:** adding two clones of one repo now logs both `project.add` as `projectTransition: "created"` (the old build logged the second as `"existing"` and collapsed to one record); `projects.json` holds two records with distinct path `projectId`s and equal `remoteKey`.
- **App (web):** two clones render as two distinct projects in the sidebar and the Projects screen; rename / remove / open-settings work per project; a rename reflects immediately in the sidebar. Screenshots below.

Automated (run individually, per the repo's test guidance):

- server: `workspace-provisioning-service` (primary #987 guard), `workspace-registry`, `workspace-registry-model`, `paseo-worktree-service`, `workspace-reconciliation-service`, `session.workspaces`, `session`.
- app: `utils/projects`, `projects/workspace-structure`, `projects/host-projects`, `hooks/use-projects`, `stores/session-store` (incl. new `applyProjectRename`), `selectors`.
- `npm run typecheck`, `npm run lint` (0 errors), `npm run format` — all pass (also enforced by the pre-commit hook on both commits).

<img width="1467" height="796" alt="Screenshot 2026-07-06 at 19 54 21" src="https://github.com/user-attachments/assets/115350a0-9ede-45a2-bb43-736bcfa0470d" />
<img width="1466" height="794" alt="Screenshot 2026-07-06 at 19 54 54" src="https://github.com/user-attachments/assets/75284e1b-51f7-4e04-b89e-3f0f8b4c22de" />


### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)
