### PR TITLE
fix(opencode): resolve provider from server catalog when model lacks prefix

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -807,56 +807,6 @@ describe("OpenCode adapter context-window normalization", () => {
     expect(lookup.get("anthropic/claude-opus")).toBeUndefined();
   });
 
-  test("buildOpenCodeModelProviderLookup maps modelID to providerID for connected providers", () => {
-    const lookup = __openCodeInternals.buildOpenCodeModelProviderLookup({
-      connected: ["opencode-go", "openai"],
-      all: [
-        {
-          id: "opencode-go",
-          source: "api",
-          models: {
-            "glm-5.2": { limit: { context: 128_000 } },
-          },
-        },
-        {
-          id: "openai",
-          source: "env",
-          models: {
-            "gpt-5": { limit: { context: 400_000 } },
-          },
-        },
-        {
-          id: "anthropic",
-          source: "env",
-          models: {
-            "claude-opus": { limit: { context: 1_000_000 } },
-          },
-        },
-      ],
-    });
-
-    expect(lookup.get("glm-5.2")).toBe("opencode-go");
-    expect(lookup.get("gpt-5")).toBe("openai");
-    expect(lookup.get("claude-opus")).toBeUndefined();
-  });
-
-  test("buildOpenCodeModelProviderLookup includes api-source providers absent from connected", () => {
-    const lookup = __openCodeInternals.buildOpenCodeModelProviderLookup({
-      connected: [],
-      all: [
-        {
-          id: "opencode-go",
-          source: "api",
-          models: {
-            "glm-5.2": {},
-          },
-        },
-      ],
-    });
-
-    expect(lookup.get("glm-5.2")).toBe("opencode-go");
-  });
-
   test("parseModel resolves provider from server catalog when model lacks prefix", async () => {
     const cwd = tmpCwd();
     const runtime = new TestOpenCodeHarness();

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -807,6 +807,142 @@ describe("OpenCode adapter context-window normalization", () => {
     expect(lookup.get("anthropic/claude-opus")).toBeUndefined();
   });
 
+  test("buildOpenCodeModelProviderLookup maps modelID to providerID for connected providers", () => {
+    const lookup = __openCodeInternals.buildOpenCodeModelProviderLookup({
+      connected: ["opencode-go", "openai"],
+      all: [
+        {
+          id: "opencode-go",
+          source: "api",
+          models: {
+            "glm-5.2": { limit: { context: 128_000 } },
+          },
+        },
+        {
+          id: "openai",
+          source: "env",
+          models: {
+            "gpt-5": { limit: { context: 400_000 } },
+          },
+        },
+        {
+          id: "anthropic",
+          source: "env",
+          models: {
+            "claude-opus": { limit: { context: 1_000_000 } },
+          },
+        },
+      ],
+    });
+
+    expect(lookup.get("glm-5.2")).toBe("opencode-go");
+    expect(lookup.get("gpt-5")).toBe("openai");
+    expect(lookup.get("claude-opus")).toBeUndefined();
+  });
+
+  test("buildOpenCodeModelProviderLookup includes api-source providers absent from connected", () => {
+    const lookup = __openCodeInternals.buildOpenCodeModelProviderLookup({
+      connected: [],
+      all: [
+        {
+          id: "opencode-go",
+          source: "api",
+          models: {
+            "glm-5.2": {},
+          },
+        },
+      ],
+    });
+
+    expect(lookup.get("glm-5.2")).toBe("opencode-go");
+  });
+
+  test("parseModel resolves provider from server catalog when model lacks prefix", async () => {
+    const cwd = tmpCwd();
+    const runtime = new TestOpenCodeHarness();
+    const openCodeClient = new TestOpenCodeClient();
+    openCodeClient.sessionPromptAsyncEvents = assistantTurnEvents();
+    openCodeClient.providerListResponse = {
+      data: {
+        connected: [],
+        all: [
+          {
+            id: "opencode-go",
+            name: "OpenCode Go",
+            source: "api",
+            models: {
+              "glm-5.2": { name: "GLM 5.2" },
+            },
+          },
+        ],
+      },
+    };
+    runtime.enqueueClient(openCodeClient);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const session = await client.createSession({
+      provider: "opencode",
+      cwd,
+      model: "glm-5.2",
+    });
+
+    const iterator = streamSession(session, "Say hello");
+    await collectTurnEvents(iterator);
+
+    expect(openCodeClient.calls.sessionPromptAsync).toEqual([
+      expect.objectContaining({
+        model: { providerID: "opencode-go", modelID: "glm-5.2" },
+      }),
+    ]);
+
+    await session.close();
+    rmSync(cwd, { recursive: true, force: true });
+  }, 60_000);
+
+  test("parseModel returns undefined for unknown model without prefix", async () => {
+    const cwd = tmpCwd();
+    const runtime = new TestOpenCodeHarness();
+    const openCodeClient = new TestOpenCodeClient();
+    openCodeClient.sessionPromptAsyncEvents = assistantTurnEvents();
+    openCodeClient.providerListResponse = {
+      data: {
+        connected: [],
+        all: [
+          {
+            id: "opencode-go",
+            name: "OpenCode Go",
+            source: "api",
+            models: {
+              "glm-5.2": { name: "GLM 5.2" },
+            },
+          },
+        ],
+      },
+    };
+    runtime.enqueueClient(openCodeClient);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const session = await client.createSession({
+      provider: "opencode",
+      cwd,
+      model: "totally-unknown-model",
+    });
+
+    const iterator = streamSession(session, "Say hello");
+    await collectTurnEvents(iterator);
+
+    expect(openCodeClient.calls.sessionPromptAsync).toEqual([
+      expect.not.objectContaining({ model: expect.anything() }),
+    ]);
+
+    await session.close();
+    rmSync(cwd, { recursive: true, force: true });
+  }, 60_000);
+
   test("normalizes step-finish usage into AgentUsage context window fields", () => {
     const usage = { contextWindowMaxTokens: 400_000 };
 

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -771,6 +771,39 @@ function buildOpenCodeModelContextWindowLookup(
   return lookup;
 }
 
+function buildOpenCodeModelProviderLookup(
+  providers:
+    | {
+        connected?: string[];
+        all?: Array<{
+          id: string;
+          source?: string;
+          models?: Record<string, unknown>;
+        }>;
+      }
+    | null
+    | undefined,
+): Map<string, string> {
+  const lookup = new Map<string, string>();
+  if (!providers) {
+    return lookup;
+  }
+
+  const connectedProviderIds = new Set(providers.connected ?? []);
+  for (const provider of providers.all ?? []) {
+    if (!connectedProviderIds.has(provider.id) && provider.source !== "api") {
+      continue;
+    }
+    for (const modelId of Object.keys(provider.models ?? {})) {
+      if (!lookup.has(modelId)) {
+        lookup.set(modelId, provider.id);
+      }
+    }
+  }
+
+  return lookup;
+}
+
 function resolveOpenCodeModelLookupKeyFromAssistantMessage(
   info: OpenCodeAssistantMessage,
 ): string | undefined {
@@ -1199,6 +1232,7 @@ export const __openCodeInternals = {
   buildOpenCodeModelContextWindowLookup,
   buildOpenCodeModelDefinition,
   buildOpenCodeModelLookupKey,
+  buildOpenCodeModelProviderLookup,
   extractOpenCodeModelContextWindow,
   hasNormalizedOpenCodeUsage,
   mergeOpenCodeStepFinishUsage,
@@ -1239,6 +1273,7 @@ export class OpenCodeAgentClient implements AgentClient {
   private readonly logger: Logger;
   private readonly runtimeSettings?: ProviderRuntimeSettings;
   private readonly modelContextWindows = new Map<string, number>();
+  private readonly modelProviderByModelId = new Map<string, string>();
 
   constructor(
     logger: Logger,
@@ -1299,6 +1334,7 @@ export class OpenCodeAgentClient implements AgentClient {
         acquisition.release,
         options?.persistSession,
         launchContext?.agentId,
+        new Map(this.modelProviderByModelId),
       );
     } catch (error) {
       acquisition.release();
@@ -1343,6 +1379,7 @@ export class OpenCodeAgentClient implements AgentClient {
         acquisition.release,
         undefined,
         launchContext?.agentId,
+        new Map(this.modelProviderByModelId),
       );
     } catch (error) {
       acquisition.release();
@@ -1548,6 +1585,7 @@ export class OpenCodeAgentClient implements AgentClient {
 
     const models: AgentModelDefinition[] = [];
     this.modelContextWindows.clear();
+    this.modelProviderByModelId.clear();
     for (const provider of providers.all) {
       if (!isAccessible(provider)) {
         continue;
@@ -1561,6 +1599,9 @@ export class OpenCodeAgentClient implements AgentClient {
             buildOpenCodeModelLookupKey(provider.id, modelId),
             contextWindowMaxTokens,
           );
+        }
+        if (!this.modelProviderByModelId.has(modelId)) {
+          this.modelProviderByModelId.set(modelId, provider.id);
         }
         models.push(definition);
       }
@@ -1604,10 +1645,16 @@ export class OpenCodeAgentClient implements AgentClient {
       return;
     }
 
-    const lookup = buildOpenCodeModelContextWindowLookup(response.data);
+    const contextWindowLookup = buildOpenCodeModelContextWindowLookup(response.data);
     this.modelContextWindows.clear();
-    for (const [modelLookupKey, contextWindowMaxTokens] of lookup.entries()) {
+    for (const [modelLookupKey, contextWindowMaxTokens] of contextWindowLookup.entries()) {
       this.modelContextWindows.set(modelLookupKey, contextWindowMaxTokens);
+    }
+
+    const providerLookup = buildOpenCodeModelProviderLookup(response.data);
+    this.modelProviderByModelId.clear();
+    for (const [modelId, providerId] of providerLookup.entries()) {
+      this.modelProviderByModelId.set(modelId, providerId);
     }
   }
 }
@@ -2755,6 +2802,7 @@ class OpenCodeAgentSession implements AgentSession {
   private readonly sessionId: string;
   private readonly logger: Logger;
   private readonly modelContextWindowsByModelKey: ReadonlyMap<string, number>;
+  private readonly modelProviderByModelId: ReadonlyMap<string, string>;
   private currentMode: string = "default";
   private autoAcceptEnabled = false;
   private pendingPermissions = new Map<string, AgentPermissionRequest>();
@@ -2802,12 +2850,14 @@ class OpenCodeAgentSession implements AgentSession {
     releaseServer?: () => void,
     persistSession = true,
     private readonly agentId?: string,
+    modelProviderByModelId: ReadonlyMap<string, string> = new Map(),
   ) {
     this.config = config;
     this.client = client;
     this.sessionId = sessionId;
     this.logger = logger.child({ agentId: this.agentId });
     this.modelContextWindowsByModelKey = modelContextWindowsByModelKey;
+    this.modelProviderByModelId = modelProviderByModelId;
     this.currentMode = normalizeOpenCodeModeId(config.modeId);
     this.autoAcceptEnabled = isOpenCodeAutoAcceptEnabled(config);
     this.releaseServer = releaseServer ?? null;
@@ -3023,7 +3073,7 @@ class OpenCodeAgentSession implements AgentSession {
           directory: this.config.cwd,
           command: slashCommand.commandName,
           arguments: slashCommand.args ?? "",
-          ...(this.config.model ? { model: this.config.model } : {}),
+          ...(model ? { model: `${model.providerID}/${model.modelID}` } : {}),
           ...(effectiveMode ? { agent: effectiveMode } : {}),
           ...(effectiveVariant ? { variant: effectiveVariant } : {}),
         })
@@ -3647,7 +3697,11 @@ class OpenCodeAgentSession implements AgentSession {
     if (parts.length >= 2) {
       return { providerID: parts[0], modelID: parts.slice(1).join("/") };
     }
-    return { providerID: "opencode", modelID: model };
+    const resolvedProviderId = this.modelProviderByModelId.get(model);
+    if (resolvedProviderId) {
+      return { providerID: resolvedProviderId, modelID: model };
+    }
+    return undefined;
   }
 
   private async ensureMcpServersConfigured(): Promise<void> {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -1323,7 +1323,7 @@ export class OpenCodeAgentClient implements AgentClient {
         throw new Error("OpenCode session creation returned no data");
       }
 
-      await this.populateModelContextWindowCache(client, openCodeConfig.cwd);
+      await this.populateModelMetadataCache(client, openCodeConfig.cwd);
 
       return new OpenCodeAgentSession(
         openCodeConfig,
@@ -1368,7 +1368,7 @@ export class OpenCodeAgentClient implements AgentClient {
     });
 
     try {
-      await this.populateModelContextWindowCache(client, openCodeConfig.cwd);
+      await this.populateModelMetadataCache(client, openCodeConfig.cwd);
 
       return new OpenCodeAgentSession(
         openCodeConfig,
@@ -1585,7 +1585,6 @@ export class OpenCodeAgentClient implements AgentClient {
 
     const models: AgentModelDefinition[] = [];
     this.modelContextWindows.clear();
-    this.modelProviderByModelId.clear();
     for (const provider of providers.all) {
       if (!isAccessible(provider)) {
         continue;
@@ -1600,11 +1599,14 @@ export class OpenCodeAgentClient implements AgentClient {
             contextWindowMaxTokens,
           );
         }
-        if (!this.modelProviderByModelId.has(modelId)) {
-          this.modelProviderByModelId.set(modelId, provider.id);
-        }
         models.push(definition);
       }
+    }
+
+    const providerLookup = buildOpenCodeModelProviderLookup(providers);
+    this.modelProviderByModelId.clear();
+    for (const [modelId, providerId] of providerLookup.entries()) {
+      this.modelProviderByModelId.set(modelId, providerId);
     }
 
     return models;
@@ -1636,10 +1638,7 @@ export class OpenCodeAgentClient implements AgentClient {
     return normalizeOpenCodeConfig({ ...config, provider: "opencode" });
   }
 
-  private async populateModelContextWindowCache(
-    client: OpencodeClient,
-    cwd: string,
-  ): Promise<void> {
+  private async populateModelMetadataCache(client: OpencodeClient, cwd: string): Promise<void> {
     const response = await openCodeMetadataLimit(() => client.provider.list({ directory: cwd }));
     if (response.error || !response.data) {
       return;
@@ -3701,6 +3700,10 @@ class OpenCodeAgentSession implements AgentSession {
     if (resolvedProviderId) {
       return { providerID: resolvedProviderId, modelID: model };
     }
+    this.logger.warn(
+      { model },
+      "OpenCode model has no provider prefix and is not in the server catalog; omitting model so the server can use its default",
+    );
     return undefined;
   }
 


### PR DESCRIPTION
### Linked issue

Closes #1925

### Type of change

- [x] Bug fix

### What does this PR do

When an OpenCode model ID lacks a `/` prefix (e.g. `glm-5.2` configured via `additionalModels` in config.json), `parseModel` hardcoded `providerID: "opencode"`. But the OpenCode server has two distinct built-in providers — `opencode` (free models) and `opencode-go` (GLM, DeepSeek, etc.) — so models that live under other providers were sent to the wrong provider, producing:

```
Model not found: opencode/glm-5.2. Did you mean: glm-5.2?
```

**Fix:**

- Added `buildOpenCodeModelProviderLookup()` — builds a `modelID → providerID` map from the server's provider list at session create/resume time.
- `parseModel()` now uses this map to resolve the correct provider when the model string has no `/` prefix. If the model is not found in the lookup, it returns `undefined` (no model sent) so the server falls back to its default instead of receiving a wrong providerID.
- The `command()` slash-command path also forwards the resolved `providerID/modelID` string instead of the raw (possibly prefix-less) config model.

### How did you verify it

**Before the fix (reproduction):**

1. Added `additionalModels: [{ id: "glm-5.2", label: "glm-5.2" }]` to the opencode provider section in `~/.paseo/config.json`.
2. Created an OpenCode agent in the Paseo desktop app and selected the `glm-5.2` model from the picker.
3. Sent a prompt. The turn failed with: `Model not found: opencode/glm-5.2. Did you mean: glm-5.2?`
4. Confirmed in `~/.paseo/daemon.log` that `set_agent_model_request` sent `modelId: "glm-5.2"` (no provider prefix), and `parseModel` defaulted the providerID to `"opencode"`.

**After the fix:**

1. Rebuilt the server (`npm run build:server`) and the desktop AppImage.
2. Ran the existing OpenCode agent test suite (44 tests, all pass) plus 4 new tests:
   - `buildOpenCodeModelProviderLookup` maps modelID → providerID for connected/api-source providers
   - `buildOpenCodeModelProviderLookup` includes api-source providers absent from connected
   - `parseModel` resolves the correct provider from the server catalog when the model lacks a prefix (verifies `promptAsync` receives `{ providerID: "opencode-go", modelID: "glm-5.2" }`)
   - `parseModel` returns `undefined` for unknown models without a prefix (verifies no `model` field is sent)
3. Ran `npm run typecheck`, `npm run lint`, `npm run format` — all clean.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
