### PR TITLE
Fix Codex native Paseo tool calls

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -22,6 +22,8 @@ Claude first-party model metadata lives in `packages/server/src/server/agent/pro
 
 Paseo tools are not implemented as MCP tools internally. They live in a shared tool catalog under `packages/server/src/server/agent/tools/`; MCP is only the fallback adapter. A provider that can register runtime tools directly should set `supportsNativePaseoTools: true` and consume `launchContext.paseoTools` in `createSession`/`resumeSession`. When native tools are present, `AgentManager` strips the internal Paseo MCP server from the provider launch config so the provider does not receive the same tools twice. Providers that only know MCP should keep `supportsMcpServers: true` and let the daemon inject `/mcp/agents`.
 
+Codex app-server can report an injected MCP server as ready while not exposing those MCP tools to the model tool surface on some model/provider paths. Do not depend on internal Paseo tools through Codex MCP injection. The Codex provider registers `launchContext.paseoTools` as native app-server dynamic tools via top-level `thread/start.dynamicTools` and answers app-server `item/tool/call` requests. Codex 0.142.5 persists dynamic tool specs for threads created with `dynamicTools`; passing `dynamicTools` to `thread/resume` is accepted but does not retrofit a thread that was originally created without them.
+
 Pi is a process-backed provider. Paseo requires the user to have the `pi` binary installed and talks to it through `pi --mode rpc`; the server package does not embed Pi's SDK/runtime packages.
 
 Paseo's per-agent and daemon-wide system prompts are passed to Pi with `--append-system-prompt`, so Pi keeps its default coding prompt while receiving Paseo's additional instructions.

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -604,6 +604,62 @@ describe("Codex app-server provider", () => {
     await session.close();
   });
 
+  test("matches consecutive native Paseo tool results by Codex call id", async () => {
+    const executeTool = vi
+      .fn<PaseoToolCatalog["executeTool"]>()
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "first result" }],
+      })
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "second result" }],
+      });
+    const paseoTools = createPaseoToolCatalogForTest(executeTool);
+    const appServer = createFakeCodexAppServer({
+      initialize: () => ({}),
+      "collaborationMode/list": () => ({ data: [] }),
+      "skills/list": () => ({ data: [] }),
+    });
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+      {},
+      false,
+      false,
+      false,
+      "agent-1",
+      paseoTools,
+    );
+
+    await session.connect();
+    appServer.requestDynamicTool({
+      callId: "call-first",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      tool: "create_agent",
+      arguments: { title: "First", initialPrompt: "hello" },
+    });
+    appServer.requestDynamicTool({
+      callId: "call-second",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      tool: "create_agent",
+      arguments: { title: "Second", initialPrompt: "hello again" },
+    });
+
+    await expect(appServer.waitForDynamicToolResult("call-first")).resolves.toEqual({
+      contentItems: [{ type: "inputText", text: "first result" }],
+      success: true,
+    });
+    await expect(appServer.waitForDynamicToolResult("call-second")).resolves.toEqual({
+      contentItems: [{ type: "inputText", text: "second result" }],
+      success: true,
+    });
+    appServer.assertNoErrors();
+    await session.close();
+  });
+
   test("disposes an unresponsive app-server child with SIGKILL", async () => {
     vi.useFakeTimers();
     const child = new EventEmitter() as ChildProcessWithoutNullStreams;

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { fileURLToPath } from "node:url";
+import { z } from "zod";
 
 import type {
   AgentLaunchContext,
@@ -15,6 +16,7 @@ import type {
   AgentSlashCommand,
   AgentStreamEvent,
 } from "../agent-sdk-types.js";
+import type { PaseoToolCatalog } from "../tools/types.js";
 import {
   buildCodexAppServerEnv,
   CodexAppServerAgentClient,
@@ -78,6 +80,33 @@ function createConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSession
     modeId: "auto",
     model: "gpt-5.4",
     ...overrides,
+  };
+}
+
+function createPaseoToolCatalogForTest(handler: PaseoToolCatalog["executeTool"]): PaseoToolCatalog {
+  const tools = new Map([
+    [
+      "create_agent",
+      {
+        name: "create_agent",
+        title: "Create agent",
+        description: "Create an agent.",
+        inputSchema: {
+          title: z.string(),
+          initialPrompt: z.string(),
+        },
+        handler: async () => ({
+          content: [{ type: "text", text: "unused" }],
+        }),
+      },
+    ],
+  ]);
+  return {
+    tools,
+    getTool(name) {
+      return tools.get(name);
+    },
+    executeTool: handler,
   };
 }
 
@@ -473,6 +502,106 @@ describe("Codex app-server provider", () => {
     const startCall = requests.find((req) => req.method === "thread/start");
     expect(startCall).toBeDefined();
     expect((startCall!.params as Record<string, unknown>).ephemeral).toBeUndefined();
+  });
+
+  test("registers native Paseo tools as Codex dynamic tools on thread/start", async () => {
+    const requests: Array<{ method: string; params: unknown }> = [];
+    const fakeClient: CodexClientLike = {
+      async request(method: string, params?: unknown) {
+        requests.push({ method, params });
+        if (method === "thread/start") {
+          return { thread: { id: "dynamic-tools-thread" } };
+        }
+        return null;
+      },
+    };
+    const paseoTools = createPaseoToolCatalogForTest(async () => ({
+      content: [{ type: "text", text: "created" }],
+    }));
+    const session = new CodexAppServerAgentSession(
+      createConfig({ thinkingOptionId: "medium" }),
+      null,
+      createTestLogger(),
+      () => {
+        throw new Error("Test session cannot spawn Codex app-server");
+      },
+      {},
+      false,
+      false,
+      false,
+      "agent-1",
+      paseoTools,
+    );
+    castInternals<{ client: CodexClientLike }>(session).client = fakeClient;
+
+    await castInternals<{ ensureThread: () => Promise<void> }>(session).ensureThread();
+
+    const startCall = requests.find((req) => req.method === "thread/start");
+    expect(startCall?.params).toMatchObject({
+      dynamicTools: [
+        {
+          type: "function",
+          name: "create_agent",
+          description: "Create an agent.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+              initialPrompt: { type: "string" },
+            },
+            required: ["title", "initialPrompt"],
+          },
+        },
+      ],
+    });
+  });
+
+  test("executes native Paseo tools for Codex item/tool/call requests", async () => {
+    const executeTool = vi.fn(async () => ({
+      content: [{ type: "text", text: "hello from paseo" }],
+      structuredContent: { agentId: "child-agent" },
+    }));
+    const paseoTools = createPaseoToolCatalogForTest(executeTool);
+    const appServer = createFakeCodexAppServer({
+      initialize: () => ({}),
+      "collaborationMode/list": () => ({ data: [] }),
+      "skills/list": () => ({ data: [] }),
+    });
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+      {},
+      false,
+      false,
+      false,
+      "agent-1",
+      paseoTools,
+    );
+
+    await session.connect();
+    appServer.requestDynamicTool({
+      callId: "call-create-agent",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      tool: "create_agent",
+      arguments: { title: "Smoke", initialPrompt: "hello" },
+    });
+
+    await expect(appServer.waitForDynamicToolResult("call-create-agent")).resolves.toEqual({
+      contentItems: [
+        { type: "inputText", text: "hello from paseo" },
+        { type: "inputText", text: '{\n  "agentId": "child-agent"\n}' },
+      ],
+      success: true,
+    });
+    expect(executeTool).toHaveBeenCalledWith("create_agent", {
+      title: "Smoke",
+      initialPrompt: "hello",
+    });
+    appServer.assertNoErrors();
+    await session.close();
   });
 
   test("disposes an unresponsive app-server child with SIGKILL", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -83,6 +83,7 @@ import {
   renderProviderImageOutputAsAssistantMarkdown,
   type ProviderImageOutput,
 } from "./provider-image-output.js";
+import type { PaseoToolCatalog, PaseoToolDefinition, PaseoToolResult } from "../tools/types.js";
 import { normalizeProviderReplayTimestamp } from "../provider-history-timestamps.js";
 import {
   formatProviderDiagnostic,
@@ -128,6 +129,7 @@ const CODEX_TOOL_THREAD_ITEM_TYPES = new Set([
   "commandExecution",
   "fileChange",
   "mcpToolCall",
+  "dynamicToolCall",
   "webSearch",
   "collabAgentToolCall",
 ]);
@@ -187,6 +189,7 @@ const CODEX_APP_SERVER_CAPABILITIES: AgentCapabilityFlags = {
   supportsSessionListing: true,
   supportsDynamicModes: false,
   supportsMcpServers: true,
+  supportsNativePaseoTools: true,
   supportsReasoningStream: true,
   supportsToolInvocations: true,
   supportsRewindConversation: true,
@@ -771,6 +774,25 @@ interface CodexMcpServerConfig {
   tool_timeout_sec?: number;
 }
 
+interface CodexDynamicToolFunctionSpec {
+  type: "function";
+  name: string;
+  description: string;
+  inputSchema: unknown;
+  deferLoading?: boolean;
+}
+
+interface CodexDynamicToolCallOutputContentItem {
+  type: "inputText" | "inputImage";
+  text?: string;
+  imageUrl?: string;
+}
+
+interface CodexDynamicToolCallResponse {
+  contentItems: CodexDynamicToolCallOutputContentItem[];
+  success: boolean;
+}
+
 function toCodexMcpConfig(config: McpServerConfig): CodexMcpServerConfig {
   switch (config.type) {
     case "stdio":
@@ -794,6 +816,135 @@ function toCodexMcpConfig(config: McpServerConfig): CodexMcpServerConfig {
       throw new Error(`Unsupported MCP config type: ${String(_exhaustive.type)}`);
     }
   }
+}
+
+function isZodSchema(value: unknown): value is z.ZodType {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { safeParseAsync?: unknown }).safeParseAsync === "function"
+  );
+}
+
+function toCodexDynamicToolZodSchema(tool: PaseoToolDefinition): z.ZodType {
+  if (!tool.inputSchema) {
+    return z.object({});
+  }
+  if (isZodSchema(tool.inputSchema)) {
+    return tool.inputSchema;
+  }
+  return z.object(tool.inputSchema);
+}
+
+function toCodexDynamicToolInputSchema(tool: PaseoToolDefinition, logger: Logger): unknown {
+  const schema = toCodexDynamicToolZodSchema(tool);
+  try {
+    const jsonSchema = z.toJSONSchema(schema, {
+      target: "draft-07",
+      unrepresentable: "any",
+      io: "input",
+      reused: "inline",
+      cycles: "throw",
+    });
+    if (!isRecord(jsonSchema)) {
+      return jsonSchema;
+    }
+    const { $schema: _schema, ...rest } = jsonSchema;
+    return rest;
+  } catch (error) {
+    logger.warn(
+      { err: error, toolName: tool.name },
+      "Failed to convert Paseo tool input schema for Codex dynamic tools",
+    );
+    return {
+      type: "object",
+      additionalProperties: true,
+    };
+  }
+}
+
+function toCodexDynamicToolSpec(
+  tool: PaseoToolDefinition,
+  logger: Logger,
+): CodexDynamicToolFunctionSpec | null {
+  const name = tool.name.trim();
+  if (!name) {
+    return null;
+  }
+  return {
+    type: "function",
+    name,
+    description: tool.description || name,
+    inputSchema: toCodexDynamicToolInputSchema(tool, logger),
+  };
+}
+
+function toCodexDynamicTools(
+  catalog: PaseoToolCatalog | null,
+  logger: Logger,
+): CodexDynamicToolFunctionSpec[] {
+  if (!catalog) {
+    return [];
+  }
+  return Array.from(catalog.tools.values())
+    .map((tool) => toCodexDynamicToolSpec(tool, logger))
+    .filter((tool): tool is CodexDynamicToolFunctionSpec => tool !== null);
+}
+
+function stringifyUnknownForToolResult(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function toCodexDynamicToolContentItem(block: {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+  [key: string]: unknown;
+}): CodexDynamicToolCallOutputContentItem {
+  if (block.type === "text" && typeof block.text === "string") {
+    return { type: "inputText", text: block.text };
+  }
+  if (
+    block.type === "image" &&
+    typeof block.data === "string" &&
+    typeof block.mimeType === "string"
+  ) {
+    return { type: "inputImage", imageUrl: `data:${block.mimeType};base64,${block.data}` };
+  }
+  return { type: "inputText", text: stringifyUnknownForToolResult(block) };
+}
+
+function toCodexDynamicToolResponse(result: PaseoToolResult): CodexDynamicToolCallResponse {
+  const contentItems = result.content.map((block) => toCodexDynamicToolContentItem(block));
+  if (result.structuredContent !== undefined) {
+    contentItems.push({
+      type: "inputText",
+      text: stringifyUnknownForToolResult(result.structuredContent),
+    });
+  }
+  if (contentItems.length === 0) {
+    contentItems.push({ type: "inputText", text: "" });
+  }
+  return {
+    contentItems,
+    success: result.isError !== true,
+  };
+}
+
+function toCodexDynamicToolErrorResponse(error: unknown): CodexDynamicToolCallResponse {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    contentItems: [{ type: "inputText", text: message }],
+    success: false,
+  };
 }
 
 function toObjectRecord(value: unknown): Record<string, unknown> | undefined {
@@ -1201,6 +1352,8 @@ function normalizeCodexThreadItemType(rawType: string | undefined): string | und
       return "fileChange";
     case "McpToolCall":
       return "mcpToolCall";
+    case "DynamicToolCall":
+      return "dynamicToolCall";
     case "WebSearch":
       return "webSearch";
     case "CollabAgentToolCall":
@@ -2011,6 +2164,17 @@ const ItemCommandExecutionTerminalInteractionNotificationSchema = z
     itemId: z.string().optional(),
     processId: z.union([z.string(), z.number()]).optional(),
     stdin: z.string().optional(),
+  })
+  .passthrough();
+
+const DynamicToolCallRequestParamsSchema = z
+  .object({
+    threadId: z.string(),
+    turnId: z.string(),
+    callId: z.string(),
+    namespace: z.string().nullable().optional(),
+    tool: z.string(),
+    arguments: z.unknown(),
   })
   .passthrough();
 
@@ -2946,6 +3110,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     private readonly goalsEnabled: boolean = false,
     private readonly autoReviewEnabled: boolean = false,
     private readonly agentId?: string,
+    private readonly paseoTools: PaseoToolCatalog | null = null,
   ) {
     this.logger = logger.child({
       module: "agent",
@@ -3229,6 +3394,9 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.client.setRequestHandler("item/tool/requestUserInput", (params) =>
       this.handleToolApprovalRequest(params),
     );
+    this.client.setRequestHandler("item/tool/call", (params) =>
+      this.handleDynamicToolCallRequest(params),
+    );
     // Keep the legacy method name for older Codex builds.
     this.client.setRequestHandler("tool/requestUserInput", (params) =>
       this.handleToolApprovalRequest(params),
@@ -3279,6 +3447,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       if (codexConfig) {
         params.config = codexConfig;
       }
+      this.applyCodexDynamicTools(params);
       await this.client.request("thread/resume", params);
     } catch (error) {
       const threadId = this.currentThreadId;
@@ -4159,6 +4328,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       ...(this.ephemeral ? { ephemeral: true } : {}),
     };
     applyApprovalsReviewerParam(params, preset);
+    this.applyCodexDynamicTools(params);
     const rawResponse = await this.client.request("thread/start", params);
     const response = toObjectRecord(rawResponse);
     const threadRecord = toObjectRecord(response?.thread);
@@ -4197,6 +4367,13 @@ export class CodexAppServerAgentSession implements AgentSession {
       Object.assign(innerConfig, this.deps.customCodexConfig);
     }
     return Object.keys(innerConfig).length > 0 ? innerConfig : null;
+  }
+
+  private applyCodexDynamicTools(params: Record<string, unknown>): void {
+    const dynamicTools = toCodexDynamicTools(this.paseoTools, this.logger);
+    if (dynamicTools.length > 0) {
+      params.dynamicTools = dynamicTools;
+    }
   }
 
   private async buildUserInput(prompt: CodexPromptInput): Promise<CodexAppServerUserInput[]> {
@@ -5312,6 +5489,36 @@ export class CodexAppServerAgentSession implements AgentSession {
       });
     });
   }
+
+  private async handleDynamicToolCallRequest(
+    params: unknown,
+  ): Promise<CodexDynamicToolCallResponse> {
+    const parsed = DynamicToolCallRequestParamsSchema.parse(params);
+    if (!this.paseoTools) {
+      return toCodexDynamicToolErrorResponse("Paseo tools are not available in this Codex session");
+    }
+    if (parsed.namespace) {
+      return toCodexDynamicToolErrorResponse(
+        `Unsupported Codex dynamic tool namespace: ${parsed.namespace}`,
+      );
+    }
+    try {
+      const result = await this.paseoTools.executeTool(parsed.tool, parsed.arguments);
+      return toCodexDynamicToolResponse(result);
+    } catch (error) {
+      this.logger.warn(
+        {
+          err: error,
+          toolName: parsed.tool,
+          callId: parsed.callId,
+          threadId: parsed.threadId,
+          turnId: parsed.turnId,
+        },
+        "Codex dynamic Paseo tool call failed",
+      );
+      return toCodexDynamicToolErrorResponse(error);
+    }
+  }
 }
 
 export class CodexAppServerAgentClient implements AgentClient {
@@ -5442,6 +5649,7 @@ export class CodexAppServerAgentClient implements AgentClient {
       goalsEnabled,
       autoReviewEnabled,
       launchContext?.agentId,
+      launchContext?.paseoTools ?? null,
     );
     await session.connect();
     return session;
@@ -5472,6 +5680,7 @@ export class CodexAppServerAgentClient implements AgentClient {
       goalsEnabled,
       autoReviewEnabled,
       launchContext?.agentId,
+      launchContext?.paseoTools ?? null,
     );
     await session.connect();
     return session;

--- a/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
+++ b/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
@@ -19,6 +19,15 @@ export interface FakeCodexAppServer {
   waitForTurnStart(): Promise<JsonObject>;
   nextResponse(): Promise<string>;
   completeTurn(params?: { threadId?: string }): void;
+  requestDynamicTool(params: {
+    callId: string;
+    threadId: string;
+    turnId: string;
+    tool: string;
+    arguments?: unknown;
+    namespace?: string | null;
+  }): void;
+  waitForDynamicToolResult(callId: string): Promise<unknown>;
   requestCommandApproval(params: {
     itemId: string;
     threadId: string;
@@ -106,6 +115,7 @@ export function createFakeCodexAppServer(
   const messages: JsonObject[] = [];
   const errors: Error[] = [];
   const approvalRequestIds = new Map<string, number>();
+  const dynamicToolRequestIds = new Map<string, number>();
   const waiters = new Set<{
     predicate: (message: JsonObject) => boolean;
     resolve: (message: JsonObject) => void;
@@ -222,6 +232,36 @@ export function createFakeCodexAppServer(
           params: { threadId: params.threadId ?? "thread-1", turn: { status: "completed" } },
         })}\n`,
       );
+    },
+    requestDynamicTool(params) {
+      const requestId = 0;
+      dynamicToolRequestIds.set(params.callId, requestId);
+      child.stdout.write(
+        `${JSON.stringify({
+          id: requestId,
+          method: "item/tool/call",
+          params: {
+            threadId: params.threadId,
+            turnId: params.turnId,
+            callId: params.callId,
+            namespace: params.namespace ?? null,
+            tool: params.tool,
+            arguments: params.arguments ?? {},
+          },
+        })}\n`,
+      );
+    },
+    async waitForDynamicToolResult(callId) {
+      const requestId = dynamicToolRequestIds.get(callId);
+      if (requestId === undefined) {
+        throw new Error(`No pending fake Codex app-server dynamic tool call for ${callId}`);
+      }
+      const message = await waitForMessage(
+        (candidate) =>
+          candidate.id === requestId && !("method" in candidate) && "result" in candidate,
+        "dynamic tool response",
+      );
+      return message.result;
     },
     requestCommandApproval(params) {
       const requestId = nextServerRequestId;

--- a/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
+++ b/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
@@ -234,10 +234,12 @@ export function createFakeCodexAppServer(
       );
     },
     requestDynamicTool(params) {
-      const requestId = 0;
+      const requestId = nextServerRequestId;
+      nextServerRequestId += 1;
       dynamicToolRequestIds.set(params.callId, requestId);
       child.stdout.write(
         `${JSON.stringify({
+          jsonrpc: "2.0",
           id: requestId,
           method: "item/tool/call",
           params: {

--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
@@ -218,6 +218,34 @@ describe("codex tool-call mapper", () => {
     });
   });
 
+  it("maps dynamicToolCall data URI images into canonical image content", () => {
+    const item = mapCodexToolCallFromThreadItem({
+      type: "dynamicToolCall",
+      id: "call-dynamic-image",
+      status: "completed",
+      namespace: null,
+      tool: "browser_screenshot",
+      arguments: { browserId: "11111111-1111-4111-8111-111111111111" },
+      contentItems: [{ type: "inputImage", imageUrl: "data:image/png;base64,iVBORw0KGgo=" }],
+      success: true,
+    });
+
+    expect(item).toEqual({
+      type: "tool_call",
+      callId: "call-dynamic-image",
+      name: "browser_screenshot",
+      status: "completed",
+      error: null,
+      detail: {
+        type: "unknown",
+        input: { browserId: "11111111-1111-4111-8111-111111111111" },
+        output: {
+          content: [{ type: "image", mimeType: "image/png", data: "iVBORw0KGgo=" }],
+        },
+      },
+    });
+  });
+
   it("maps collabAgentToolCall into canonical sub-agent detail", () => {
     const item = mapCodexToolCallFromThreadItem({
       type: "collabAgentToolCall",

--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
@@ -192,6 +192,32 @@ describe("codex tool-call mapper", () => {
     });
   });
 
+  it("maps dynamicToolCall items into canonical tool calls", () => {
+    const item = mapCodexToolCallFromThreadItem({
+      type: "dynamicToolCall",
+      id: "call-dynamic-1",
+      status: "completed",
+      namespace: null,
+      tool: "create_agent",
+      arguments: { title: "Smoke", initialPrompt: "hello" },
+      contentItems: [{ type: "inputText", text: "created child-agent" }],
+      success: true,
+    });
+
+    expect(item).toEqual({
+      type: "tool_call",
+      callId: "call-dynamic-1",
+      name: "create_agent",
+      status: "completed",
+      error: null,
+      detail: {
+        type: "unknown",
+        input: { title: "Smoke", initialPrompt: "hello" },
+        output: { content: [{ type: "text", text: "created child-agent" }] },
+      },
+    });
+  });
+
   it("maps collabAgentToolCall into canonical sub-agent detail", () => {
     const item = mapCodexToolCallFromThreadItem({
       type: "collabAgentToolCall",

--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
@@ -169,6 +169,27 @@ const CodexMcpToolCallItemSchema = z
   })
   .passthrough();
 
+const CodexDynamicToolCallContentItemSchema = z
+  .object({
+    type: z.enum(["inputText", "inputImage"]),
+    text: z.string().optional(),
+    imageUrl: z.string().optional(),
+  })
+  .passthrough();
+
+const CodexDynamicToolCallItemSchema = z
+  .object({
+    type: z.literal("dynamicToolCall"),
+    id: z.string().min(1),
+    status: z.string().optional(),
+    namespace: z.string().nullable().optional(),
+    tool: z.string().min(1),
+    arguments: z.unknown().optional(),
+    contentItems: z.array(CodexDynamicToolCallContentItemSchema).nullable().optional(),
+    success: z.boolean().nullable().optional(),
+  })
+  .passthrough();
+
 const CodexWebSearchItemSchema = z
   .object({
     type: z.literal("webSearch"),
@@ -197,6 +218,7 @@ const CodexToolThreadItemSchema = z.discriminatedUnion("type", [
   CodexCommandExecutionItemSchema,
   CodexFileChangeItemSchema,
   CodexMcpToolCallItemSchema,
+  CodexDynamicToolCallItemSchema,
   CodexWebSearchItemSchema,
 ]);
 
@@ -204,6 +226,7 @@ const CodexThreadItemSchema = z.discriminatedUnion("type", [
   CodexCommandExecutionItemSchema,
   CodexFileChangeItemSchema,
   CodexMcpToolCallItemSchema,
+  CodexDynamicToolCallItemSchema,
   CodexWebSearchItemSchema,
   CodexCollabAgentToolCallItemSchema,
 ]);
@@ -606,6 +629,15 @@ function buildMcpToolName(server: string | undefined, tool: string): string {
   return trimmedTool;
 }
 
+function buildDynamicToolName(namespace: string | null | undefined, tool: string): string {
+  const trimmedTool = tool.trim();
+  if (!trimmedTool) {
+    return "tool";
+  }
+  const trimmedNamespace = typeof namespace === "string" ? namespace.trim() : "";
+  return trimmedNamespace ? `${trimmedNamespace}.${trimmedTool}` : trimmedTool;
+}
+
 function readMcpImageContent(block: unknown): CodexMcpToolResultImage | null {
   if (!isRecord(block)) {
     return null;
@@ -924,6 +956,50 @@ function mapMcpToolCallItem(
   };
 }
 
+function dynamicToolContentItemToOutput(
+  item: z.infer<typeof CodexDynamicToolCallContentItemSchema>,
+): Record<string, unknown> {
+  if (item.type === "inputText") {
+    return {
+      type: "text",
+      text: item.text ?? "",
+    };
+  }
+  return {
+    type: "image_url",
+    imageUrl: item.imageUrl ?? "",
+  };
+}
+
+function mapDynamicToolCallItem(
+  item: z.infer<typeof CodexDynamicToolCallItemSchema>,
+  options?: CodexMapperOptions,
+): CodexNormalizedToolCallEnvelope | null {
+  const tool = item.tool.trim();
+  if (!tool) {
+    return null;
+  }
+  const name = buildDynamicToolName(item.namespace, tool);
+  const input = item.arguments ?? null;
+  const contentItems = item.contentItems ?? null;
+  const output = contentItems
+    ? { content: contentItems.map((contentItem) => dynamicToolContentItemToOutput(contentItem)) }
+    : null;
+  const error = item.success === false ? { message: "Tool call failed" } : null;
+  const status =
+    item.success === false ? "failed" : normalizeToolCallStatus(item.status, error, output);
+
+  return {
+    callId: item.id,
+    name,
+    input,
+    output,
+    status,
+    error,
+    cwd: options?.cwd ?? null,
+  };
+}
+
 function mapWebSearchItem(
   item: z.infer<typeof CodexWebSearchItemSchema>,
 ): CodexNormalizedToolCallEnvelope {
@@ -988,6 +1064,8 @@ function mapThreadItemToNormalizedEnvelope(
       return mapFileChangeItem(item, options);
     case "mcpToolCall":
       return mapMcpToolCallItem(item, options);
+    case "dynamicToolCall":
+      return mapDynamicToolCallItem(item, options);
     case "webSearch":
       return mapWebSearchItem(item);
     default: {

--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
@@ -965,9 +965,18 @@ function dynamicToolContentItemToOutput(
       text: item.text ?? "",
     };
   }
+  const dataUri = item.imageUrl ?? "";
+  const match = /^data:([^;]+);base64,(.+)$/.exec(dataUri);
+  if (match) {
+    return {
+      type: "image",
+      mimeType: match[1],
+      data: match[2],
+    };
+  }
   return {
     type: "image_url",
-    imageUrl: item.imageUrl ?? "",
+    imageUrl: dataUri,
   };
 }
 


### PR DESCRIPTION
### Linked issue

Closes #1932

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Paseo-created Codex app-server agents were receiving the internal `mcpServers.paseo` fallback config, but Codex 0.142.5 can report that MCP server as ready without exposing those MCP tools to the model tool surface on some custom/OpenAI-compatible provider paths. In that state, asking a Codex agent to create a subagent could end with no `mcpToolCall`, no `item/tool/call`, and no final assistant response.

This changes the Codex provider to use Paseo's native tool catalog instead of relying on internal Paseo MCP injection:

- advertises `supportsNativePaseoTools` for Codex app-server
- registers `launchContext.paseoTools` as top-level Codex `thread/start.dynamicTools`
- handles Codex `item/tool/call` requests by executing the Paseo tool catalog
- maps `dynamicToolCall` thread items into standard Paseo tool-call timeline rows
- documents the Codex MCP gotcha in `docs/providers.md`

### How did you verify it

Repro before the fix:

- Failing parent agent: `a7db8877-a9b1-4421-bfdd-f9f763e47185`
- Codex thread/session: `019f3c4d-a53b-7193-9f0d-38deeddf8d61`
- Raw JSONL: `~/.codex/sessions/2026/07/07/rollout-2026-07-07T19-19-09-019f3c4d-a53b-7193-9f0d-38deeddf8d61.jsonl`
- The persisted agent had `mcpServers.paseo`, but the Codex JSONL had no `mcpToolCall`, no `item/tool/call`, no `create_agent`, and completed with `last_agent_message:null`.

Runtime smoke after the fix:

- Parent agent: `d955b5a2-4565-4ca0-beb1-0c0daadfdb4f`
- Child agent created by the parent: `360454ed-f28d-4370-acbb-2a90e3649c51`
- The parent Codex JSONL includes a `create_agent` function call and returns the child id.
- The child agent has label `paseo.parent-agent-id=d955b5a2-4565-4ca0-beb1-0c0daadfdb4f` and replied to the `hello` initial prompt.

Local checks after rebasing onto `upstream/main` (`d3e1fe48f`):

- `PATH=/home/yangfei/Projects/paseo/node_modules/.bin:$PATH npm run build:server`
- `/home/yangfei/Projects/paseo/node_modules/.bin/vitest run packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1` (2 files, 110 tests)
- `PATH=/home/yangfei/Projects/paseo/node_modules/.bin:$PATH npm run typecheck`
- `PATH=/home/yangfei/Projects/paseo/node_modules/.bin:$PATH npm run lint`
- `PATH=/home/yangfei/Projects/paseo/node_modules/.bin:$PATH npm run format:check`
- `PATH=/home/yangfei/Projects/paseo/node_modules/.bin:$PATH npm run format`

No UI changes; screenshots/video are not applicable.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A - no UI changes)
- [x] Tests added or updated where it made sense
