### PR TITLE
Manage the built-in daemon from one place in settings

### DIFF
--- a/packages/app/e2e/helpers/settings.ts
+++ b/packages/app/e2e/helpers/settings.ts
@@ -371,6 +371,7 @@ export async function expectRetiredSidebarSectionsAbsent(page: Page): Promise<vo
   await expect(sidebar.getByRole("button", { name: "General", exact: true })).toBeVisible();
   await expect(sidebar.getByRole("button", { name: "Diagnostics", exact: true })).toBeVisible();
   await expect(sidebar.getByRole("button", { name: "About", exact: true })).toBeVisible();
+  await expect(sidebar.getByRole("button", { name: "Daemon", exact: true })).toHaveCount(0);
 
   // Host group rows are now flat top-level sections (no drill-in).
   await expect(sidebar.getByTestId("settings-host-section-connections")).toBeVisible();

--- a/packages/app/e2e/settings-host-page.spec.ts
+++ b/packages/app/e2e/settings-host-page.spec.ts
@@ -64,7 +64,7 @@ test.describe("Settings host page", () => {
     await openSettingsHost(page, serverId);
 
     await openHostSection(page, serverId, "host");
-    await expectSettingsHeader(page, "Host");
+    await expectSettingsHeader(page, "Overview");
     await expectHostLabelDisplayed(page);
     await expectHostActionCards(page, serverId);
   });

--- a/packages/app/src/app/settings/[section].tsx
+++ b/packages/app/src/app/settings/[section].tsx
@@ -2,10 +2,7 @@ import { Redirect, useLocalSearchParams } from "expo-router";
 import { useMemo } from "react";
 import { useHostRuntimeBootstrapState } from "@/app/_layout";
 import { HostRouteBootstrapBoundary } from "@/components/host-route-bootstrap-boundary";
-import {
-  useIsLocalDaemonServerIdResolved,
-  useLocalDaemonServerId,
-} from "@/hooks/use-is-local-daemon";
+import { useLocalDaemonServerIdState } from "@/hooks/use-is-local-daemon";
 import { useHosts } from "@/runtime/host-runtime";
 import SettingsScreen from "@/screens/settings-screen";
 import { StartupSplashScreen } from "@/screens/startup-splash-screen";
@@ -19,16 +16,19 @@ import {
 // COMPAT(settingsDaemonRedirect): added 2026-07-08, remove after 2027-01-08.
 function SettingsDaemonRedirect() {
   const hosts = useHosts();
-  const localServerId = useLocalDaemonServerId();
-  const isLocalServerIdResolved = useIsLocalDaemonServerIdResolved();
+  const localDaemon = useLocalDaemonServerIdState();
   const bootstrapState = useHostRuntimeBootstrapState();
 
-  if (!isLocalServerIdResolved) {
+  if (localDaemon.status === "loading") {
     return <StartupSplashScreen bootstrapState={bootstrapState} />;
   }
 
-  if (localServerId && hosts.some((host) => host.serverId === localServerId)) {
-    return <Redirect href={buildSettingsHostSectionRoute(localServerId, "host")} />;
+  if (
+    localDaemon.status === "resolved" &&
+    localDaemon.serverId !== null &&
+    hosts.some((host) => host.serverId === localDaemon.serverId)
+  ) {
+    return <Redirect href={buildSettingsHostSectionRoute(localDaemon.serverId, "host")} />;
   }
 
   return <Redirect href={buildSettingsRoute()} />;

--- a/packages/app/src/app/settings/[section].tsx
+++ b/packages/app/src/app/settings/[section].tsx
@@ -1,7 +1,38 @@
-import { useLocalSearchParams } from "expo-router";
+import { Redirect, useLocalSearchParams } from "expo-router";
 import { useMemo } from "react";
+import { useHostRuntimeBootstrapState } from "@/app/_layout";
+import { HostRouteBootstrapBoundary } from "@/components/host-route-bootstrap-boundary";
+import {
+  useIsLocalDaemonServerIdResolved,
+  useLocalDaemonServerId,
+} from "@/hooks/use-is-local-daemon";
+import { useHosts } from "@/runtime/host-runtime";
 import SettingsScreen from "@/screens/settings-screen";
-import { isSettingsSectionSlug, type SettingsSectionSlug } from "@/utils/host-routes";
+import { StartupSplashScreen } from "@/screens/startup-splash-screen";
+import {
+  buildSettingsHostSectionRoute,
+  buildSettingsRoute,
+  isSettingsSectionSlug,
+  type SettingsSectionSlug,
+} from "@/utils/host-routes";
+
+// COMPAT(settingsDaemonRedirect): added 2026-07-08, remove after 2027-01-08.
+function SettingsDaemonRedirect() {
+  const hosts = useHosts();
+  const localServerId = useLocalDaemonServerId();
+  const isLocalServerIdResolved = useIsLocalDaemonServerIdResolved();
+  const bootstrapState = useHostRuntimeBootstrapState();
+
+  if (!isLocalServerIdResolved) {
+    return <StartupSplashScreen bootstrapState={bootstrapState} />;
+  }
+
+  if (localServerId && hosts.some((host) => host.serverId === localServerId)) {
+    return <Redirect href={buildSettingsHostSectionRoute(localServerId, "host")} />;
+  }
+
+  return <Redirect href={buildSettingsRoute()} />;
+}
 
 export default function SettingsSectionRoute() {
   const params = useLocalSearchParams<{ section?: string; addHost?: string }>();
@@ -9,6 +40,15 @@ export default function SettingsSectionRoute() {
   const section: SettingsSectionSlug = isSettingsSectionSlug(rawSection) ? rawSection : "general";
   const openAddHostIntent = typeof params.addHost === "string" ? params.addHost : null;
   const view = useMemo(() => ({ kind: "section" as const, section }), [section]);
+
+  // COMPAT(settingsDaemonRedirect): added 2026-07-08, remove after 2027-01-08.
+  if (rawSection === "daemon") {
+    return (
+      <HostRouteBootstrapBoundary>
+        <SettingsDaemonRedirect />
+      </HostRouteBootstrapBoundary>
+    );
+  }
 
   return <SettingsScreen view={view} openAddHostIntent={openAddHostIntent} />;
 }

--- a/packages/app/src/components/hosts/host-picker-constants.ts
+++ b/packages/app/src/components/hosts/host-picker-constants.ts
@@ -1,5 +1,6 @@
 export const ADD_HOST_OPTION_ID = "__add_host__";
 export const ALL_HOSTS_OPTION_ID = "__all_hosts__";
+export const ENABLE_BUILT_IN_DAEMON_OPTION_ID = "__enable_built_in_daemon__";
 
 export function getHostPickerLabel(
   hosts: Array<{ label: string; serverId: string }>,

--- a/packages/app/src/components/hosts/host-picker.tsx
+++ b/packages/app/src/components/hosts/host-picker.tsx
@@ -11,10 +11,16 @@ import { orderHostsLocalFirst } from "@/types/host-connection";
 import {
   ADD_HOST_OPTION_ID,
   ALL_HOSTS_OPTION_ID,
+  ENABLE_BUILT_IN_DAEMON_OPTION_ID,
   getHostPickerLabel,
 } from "./host-picker-constants";
 
-export { ADD_HOST_OPTION_ID, ALL_HOSTS_OPTION_ID, getHostPickerLabel };
+export {
+  ADD_HOST_OPTION_ID,
+  ALL_HOSTS_OPTION_ID,
+  ENABLE_BUILT_IN_DAEMON_OPTION_ID,
+  getHostPickerLabel,
+};
 
 const SEARCHABLE_THRESHOLD = 10;
 type RenderHostOption = NonNullable<ComboboxProps["renderOption"]>;
@@ -115,6 +121,12 @@ export function HostPickerOption({
   );
 }
 
+const SYSTEM_HOST_PICKER_OPTION_LABELS: Record<"add" | "all" | "enableBuiltInDaemon", string> = {
+  add: "Add host",
+  all: "All hosts",
+  enableBuiltInDaemon: "Enable built-in daemon",
+};
+
 function SystemHostPickerOption({
   active,
   selected,
@@ -125,12 +137,12 @@ function SystemHostPickerOption({
   active: boolean;
   selected?: boolean;
   onPress: () => void;
-  kind: "add" | "all";
+  kind: "add" | "all" | "enableBuiltInDaemon";
   testID?: string;
 }): ReactElement {
   const { theme } = useUnistyles();
   const Icon = kind === "add" ? Plus : Server;
-  const label = kind === "add" ? "Add host" : "All hosts";
+  const label = SYSTEM_HOST_PICKER_OPTION_LABELS[kind];
   const leadingSlot = useMemo(
     () => <Icon size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />,
     [Icon, theme.colors.foregroundMuted, theme.iconSize.sm],
@@ -158,6 +170,8 @@ export interface HostPickerProps {
   includeAllHost?: boolean;
   includeAddHost?: boolean;
   onAddHost?: () => void;
+  includeEnableBuiltInDaemon?: boolean;
+  onEnableBuiltInDaemon?: () => void;
   showActiveConnection?: boolean;
   onOpenHostSettings?: (serverId: string) => void;
   searchable?: boolean;
@@ -179,6 +193,8 @@ export function HostPicker({
   includeAllHost,
   includeAddHost,
   onAddHost,
+  includeEnableBuiltInDaemon,
+  onEnableBuiltInDaemon,
   showActiveConnection,
   onOpenHostSettings,
   searchable,
@@ -199,8 +215,13 @@ export function HostPicker({
     const hostOptions = orderedHosts.map((host) => ({ id: host.serverId, label: host.label }));
     if (includeAllHost) hostOptions.unshift({ id: ALL_HOSTS_OPTION_ID, label: "All hosts" });
     if (includeAddHost) hostOptions.push({ id: ADD_HOST_OPTION_ID, label: "Add host" });
+    if (includeEnableBuiltInDaemon)
+      hostOptions.push({
+        id: ENABLE_BUILT_IN_DAEMON_OPTION_ID,
+        label: "Enable built-in daemon",
+      });
     return hostOptions;
-  }, [orderedHosts, includeAllHost, includeAddHost]);
+  }, [orderedHosts, includeAllHost, includeAddHost, includeEnableBuiltInDaemon]);
 
   const isSearchable = searchable === true && orderedHosts.length > SEARCHABLE_THRESHOLD;
 
@@ -208,12 +229,14 @@ export function HostPicker({
     (id: string) => {
       if (id === ADD_HOST_OPTION_ID) {
         onAddHost?.();
+      } else if (id === ENABLE_BUILT_IN_DAEMON_OPTION_ID) {
+        onEnableBuiltInDaemon?.();
       } else {
         onSelect(id);
       }
       onOpenChange(false);
     },
-    [onAddHost, onOpenChange, onSelect],
+    [onAddHost, onEnableBuiltInDaemon, onOpenChange, onSelect],
   );
 
   const handleOpenHostSettings = useCallback(
@@ -244,6 +267,11 @@ export function HostPicker({
             selected={selected}
             onPress={onPress}
           />
+        );
+      }
+      if (option.id === ENABLE_BUILT_IN_DAEMON_OPTION_ID) {
+        return (
+          <SystemHostPickerOption kind="enableBuiltInDaemon" active={active} onPress={onPress} />
         );
       }
       return (

--- a/packages/app/src/desktop/hooks/use-built-in-daemon-management.ts
+++ b/packages/app/src/desktop/hooks/use-built-in-daemon-management.ts
@@ -34,6 +34,7 @@ interface UseBuiltInDaemonManagementInput {
 interface UseBuiltInDaemonManagementResult {
   isUpdating: boolean;
   toggle: () => void;
+  enable: () => Promise<DaemonManagementToggleResult | null>;
 }
 
 export function useBuiltInDaemonManagement(
@@ -42,12 +43,16 @@ export function useBuiltInDaemonManagement(
   const { t } = useTranslation();
   const { daemonStatus, settings, updateSettings, setStatus, refreshStatus } = input;
   const reportError = useDesktopIpcErrorReporter();
-  const { mutate: toggleDaemonManagement, isPending: isUpdating } = useMutation<
-    DaemonManagementToggleResult,
-    Error
-  >({
-    mutationFn: async () => {
-      const wasManagingDaemon = settings.manageBuiltInDaemon;
+  const {
+    mutate: toggleDaemonManagement,
+    mutateAsync: toggleDaemonManagementAsync,
+    isPending: isUpdating,
+  } = useMutation<DaemonManagementToggleResult, Error, { forceEnable: boolean }>({
+    mutationFn: async ({ forceEnable }) => {
+      // forceEnable takes the enable branch regardless of the persisted
+      // setting — the recovery affordance must never reach the stop/confirm
+      // path even if manageBuiltInDaemon was left true.
+      const wasManagingDaemon = forceEnable ? false : settings.manageBuiltInDaemon;
       try {
         const result = await executeDaemonManagementToggle(wasManagingDaemon, daemonStatus, {
           confirm: () =>
@@ -109,8 +114,21 @@ export function useBuiltInDaemonManagement(
       return;
     }
 
-    toggleDaemonManagement();
+    toggleDaemonManagement({ forceEnable: false });
   }, [isUpdating, toggleDaemonManagement]);
 
-  return { isUpdating, toggle };
+  const enable = useCallback(async () => {
+    if (isUpdating) {
+      return null;
+    }
+
+    try {
+      return await toggleDaemonManagementAsync({ forceEnable: true });
+    } catch {
+      // onError has already surfaced the failure; callers only act on success.
+      return null;
+    }
+  }, [isUpdating, toggleDaemonManagementAsync]);
+
+  return { isUpdating, toggle, enable };
 }

--- a/packages/app/src/desktop/hooks/use-enable-built-in-daemon-option.ts
+++ b/packages/app/src/desktop/hooks/use-enable-built-in-daemon-option.ts
@@ -1,10 +1,7 @@
 import { useCallback } from "react";
 import { router } from "expo-router";
 import { getIsElectron } from "@/constants/platform";
-import {
-  useIsLocalDaemonServerIdResolved,
-  useLocalDaemonServerId,
-} from "@/hooks/use-is-local-daemon";
+import { useLocalDaemonServerIdState } from "@/hooks/use-is-local-daemon";
 import { useHosts } from "@/runtime/host-runtime";
 import { useDesktopSettings } from "@/desktop/settings/desktop-settings";
 import { useDaemonStatus } from "@/desktop/hooks/use-daemon-status";
@@ -13,8 +10,7 @@ import { buildSettingsHostSectionRoute } from "@/utils/host-routes";
 
 export function useEnableBuiltInDaemonOption(): { visible: boolean; onPress: () => void } {
   const isElectron = getIsElectron();
-  const isLocalServerIdResolved = useIsLocalDaemonServerIdResolved();
-  const localServerId = useLocalDaemonServerId();
+  const localDaemon = useLocalDaemonServerIdState();
   const hosts = useHosts();
   const { settings, updateSettings } = useDesktopSettings();
   const { data, setStatus, refetch } = useDaemonStatus();
@@ -27,8 +23,10 @@ export function useEnableBuiltInDaemonOption(): { visible: boolean; onPress: () 
   });
 
   const isLocalhostConfigured =
-    localServerId !== null && hosts.some((host) => host.serverId === localServerId);
-  const visible = isElectron && isLocalServerIdResolved && !isLocalhostConfigured;
+    localDaemon.status === "resolved" &&
+    localDaemon.serverId !== null &&
+    hosts.some((host) => host.serverId === localDaemon.serverId);
+  const visible = isElectron && localDaemon.status === "resolved" && !isLocalhostConfigured;
 
   const onPress = useCallback(() => {
     void (async () => {

--- a/packages/app/src/desktop/hooks/use-enable-built-in-daemon-option.ts
+++ b/packages/app/src/desktop/hooks/use-enable-built-in-daemon-option.ts
@@ -8,7 +8,12 @@ import { useDaemonStatus } from "@/desktop/hooks/use-daemon-status";
 import { useBuiltInDaemonManagement } from "@/desktop/hooks/use-built-in-daemon-management";
 import { buildSettingsHostSectionRoute } from "@/utils/host-routes";
 
-export function useEnableBuiltInDaemonOption(): { visible: boolean; onPress: () => void } {
+export interface EnableBuiltInDaemonOption {
+  visible: boolean;
+  onPress: () => void;
+}
+
+export function useEnableBuiltInDaemonOption(): EnableBuiltInDaemonOption {
   const isElectron = getIsElectron();
   const localDaemon = useLocalDaemonServerIdState();
   const hosts = useHosts();

--- a/packages/app/src/desktop/hooks/use-enable-built-in-daemon-option.ts
+++ b/packages/app/src/desktop/hooks/use-enable-built-in-daemon-option.ts
@@ -1,0 +1,43 @@
+import { useCallback } from "react";
+import { router } from "expo-router";
+import { getIsElectron } from "@/constants/platform";
+import {
+  useIsLocalDaemonServerIdResolved,
+  useLocalDaemonServerId,
+} from "@/hooks/use-is-local-daemon";
+import { useHosts } from "@/runtime/host-runtime";
+import { useDesktopSettings } from "@/desktop/settings/desktop-settings";
+import { useDaemonStatus } from "@/desktop/hooks/use-daemon-status";
+import { useBuiltInDaemonManagement } from "@/desktop/hooks/use-built-in-daemon-management";
+import { buildSettingsHostSectionRoute } from "@/utils/host-routes";
+
+export function useEnableBuiltInDaemonOption(): { visible: boolean; onPress: () => void } {
+  const isElectron = getIsElectron();
+  const isLocalServerIdResolved = useIsLocalDaemonServerIdResolved();
+  const localServerId = useLocalDaemonServerId();
+  const hosts = useHosts();
+  const { settings, updateSettings } = useDesktopSettings();
+  const { data, setStatus, refetch } = useDaemonStatus();
+  const { enable } = useBuiltInDaemonManagement({
+    daemonStatus: data?.status ?? null,
+    settings: settings.daemon,
+    updateSettings: (updates) => updateSettings({ daemon: updates }),
+    setStatus,
+    refreshStatus: refetch,
+  });
+
+  const isLocalhostConfigured =
+    localServerId !== null && hosts.some((host) => host.serverId === localServerId);
+  const visible = isElectron && isLocalServerIdResolved && !isLocalhostConfigured;
+
+  const onPress = useCallback(() => {
+    void (async () => {
+      const result = await enable();
+      if (result?.kind === "enabled") {
+        router.push(buildSettingsHostSectionRoute(result.newStatus.serverId, "host"));
+      }
+    })();
+  }, [enable]);
+
+  return { visible, onPress };
+}

--- a/packages/app/src/hooks/use-is-local-daemon.ts
+++ b/packages/app/src/hooks/use-is-local-daemon.ts
@@ -43,9 +43,25 @@ export function useLocalDaemonServerId(): string | null {
   return query.data?.serverId ?? null;
 }
 
-export function useIsLocalDaemonServerIdResolved(): boolean {
+export type LocalDaemonServerIdState =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "resolved"; serverId: string | null };
+
+export function useLocalDaemonServerIdState(): LocalDaemonServerIdState {
+  const isDesktopApp = shouldUseDesktopDaemon();
   const query = useLocalDaemonServerIdQuery();
-  return !query.isLoading;
+
+  if (!isDesktopApp) {
+    return { status: "resolved", serverId: null };
+  }
+  if (query.isError) {
+    return { status: "error" };
+  }
+  if (query.isSuccess) {
+    return { status: "resolved", serverId: query.data.serverId };
+  }
+  return { status: "loading" };
 }
 
 export function useIsLocalDaemon(serverId: string): boolean {

--- a/packages/app/src/hooks/use-is-local-daemon.ts
+++ b/packages/app/src/hooks/use-is-local-daemon.ts
@@ -15,10 +15,10 @@ async function loadDesktopDaemonServerId(): Promise<DesktopDaemonServerIdResult>
   };
 }
 
-export function useLocalDaemonServerId(): string | null {
+function useLocalDaemonServerIdQuery() {
   const isDesktopApp = shouldUseDesktopDaemon();
 
-  const query = useQuery({
+  return useQuery({
     queryKey: DESKTOP_DAEMON_SERVER_ID_QUERY_KEY,
     queryFn: loadDesktopDaemonServerId,
     enabled: isDesktopApp,
@@ -30,12 +30,22 @@ export function useLocalDaemonServerId(): string | null {
     refetchOnWindowFocus: false,
     retry: false,
   });
+}
+
+export function useLocalDaemonServerId(): string | null {
+  const isDesktopApp = shouldUseDesktopDaemon();
+  const query = useLocalDaemonServerIdQuery();
 
   if (!isDesktopApp) {
     return null;
   }
 
   return query.data?.serverId ?? null;
+}
+
+export function useIsLocalDaemonServerIdResolved(): boolean {
+  const query = useLocalDaemonServerIdQuery();
+  return !query.isLoading;
 }
 
 export function useIsLocalDaemon(serverId: string): boolean {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1412,7 +1412,6 @@ export const ar: TranslationResources = {
     groupInfo: "حول{{title}}",
     sections: {
       general: "عام",
-      daemon: "Daemon",
       appearance: "مظهر",
       shortcuts: "الاختصارات",
       integrations: "التكامل",
@@ -1427,7 +1426,7 @@ export const ar: TranslationResources = {
       providers: "مقدمي الخدمات",
       usage: "الاستخدام",
       terminals: "Terminals",
-      host: "Host",
+      host: "نظرة عامة",
     },
     general: {
       title: "عام",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1404,6 +1404,7 @@ export const ar: TranslationResources = {
     },
     backToWorkspace: "خلف",
     addHost: "أضف مضيفًا",
+    enableBuiltInDaemon: "تفعيل البرنامج الخفي المدمج",
     projects: "المشاريع",
     projectList: {
       hostLoadFailed: "تعذر تحميل المشاريع من المضيف{{hostName}}:{{message}}",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1412,6 +1412,7 @@ export const en = {
     },
     backToWorkspace: "Back",
     addHost: "Add host",
+    enableBuiltInDaemon: "Enable built-in daemon",
     projects: "Projects",
     projectList: {
       hostLoadFailed: "Couldn't load projects from host {{hostName}}: {{message}}",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1420,7 +1420,6 @@ export const en = {
     groupInfo: "About {{title}}",
     sections: {
       general: "General",
-      daemon: "Daemon",
       appearance: "Appearance",
       shortcuts: "Shortcuts",
       integrations: "Integrations",
@@ -1435,7 +1434,7 @@ export const en = {
       providers: "Providers",
       usage: "Usage",
       terminals: "Terminals",
-      host: "Host",
+      host: "Overview",
     },
     general: {
       title: "General",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1451,7 +1451,6 @@ export const es: TranslationResources = {
     groupInfo: "Acerca de{{title}}",
     sections: {
       general: "General",
-      daemon: "Daemon",
       appearance: "Apariencia",
       shortcuts: "Atajos",
       integrations: "Integraciones",
@@ -1466,7 +1465,7 @@ export const es: TranslationResources = {
       providers: "Proveedores",
       usage: "Uso",
       terminals: "Terminals",
-      host: "Host",
+      host: "Resumen",
     },
     general: {
       title: "General",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1443,6 +1443,7 @@ export const es: TranslationResources = {
     },
     backToWorkspace: "Atrás",
     addHost: "Agregar anfitrión",
+    enableBuiltInDaemon: "Activar el demonio integrado",
     projects: "Proyectos",
     projectList: {
       hostLoadFailed: "No se pudieron cargar proyectos desde el host{{hostName}}:{{message}}",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1454,7 +1454,6 @@ export const fr: TranslationResources = {
     groupInfo: "À propos de{{title}}",
     sections: {
       general: "Général",
-      daemon: "Daemon",
       appearance: "Apparence",
       shortcuts: "Raccourcis",
       integrations: "Intégrations",
@@ -1469,7 +1468,7 @@ export const fr: TranslationResources = {
       providers: "Fournisseurs",
       usage: "Utilisation",
       terminals: "Terminals",
-      host: "Host",
+      host: "Aperçu",
     },
     general: {
       title: "Général",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1446,6 +1446,7 @@ export const fr: TranslationResources = {
     },
     backToWorkspace: "Dos",
     addHost: "Ajouter un hôte",
+    enableBuiltInDaemon: "Activer le démon intégré",
     projects: "Projets",
     projectList: {
       hostLoadFailed: "Impossible de charger les projets depuis l'hôte{{hostName}}:{{message}}",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1429,7 +1429,6 @@ export const ja: TranslationResources = {
     groupInfo: "{{title}}について",
     sections: {
       general: "一般",
-      daemon: "デーモン",
       appearance: "外観",
       shortcuts: "ショートカット",
       integrations: "連携",
@@ -1444,7 +1443,7 @@ export const ja: TranslationResources = {
       providers: "プロバイダー",
       usage: "使用状況",
       terminals: "ターミナル",
-      host: "ホスト",
+      host: "概要",
     },
     general: {
       title: "一般",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1421,6 +1421,7 @@ export const ja: TranslationResources = {
     },
     backToWorkspace: "戻る",
     addHost: "ホストを追加",
+    enableBuiltInDaemon: "組み込みデーモンを有効にする",
     projects: "プロジェクト",
     projectList: {
       hostLoadFailed: "ホスト{{hostName}}からプロジェクトを読み込めませんでした: {{message}}",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1437,7 +1437,6 @@ export const ptBR: TranslationResources = {
     groupInfo: "Sobre {{title}}",
     sections: {
       general: "Geral",
-      daemon: "Daemon",
       appearance: "Aparência",
       shortcuts: "Atalhos",
       integrations: "Integrações",
@@ -1452,7 +1451,7 @@ export const ptBR: TranslationResources = {
       providers: "Provedores",
       usage: "Uso",
       terminals: "Terminais",
-      host: "Host",
+      host: "Visão geral",
     },
     general: {
       title: "Geral",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1429,6 +1429,7 @@ export const ptBR: TranslationResources = {
     },
     backToWorkspace: "Voltar",
     addHost: "Adicionar host",
+    enableBuiltInDaemon: "Ativar o daemon integrado",
     projects: "Projetos",
     projectList: {
       hostLoadFailed: "Não foi possível carregar projetos do host {{hostName}}: {{message}}",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1435,6 +1435,7 @@ export const ru: TranslationResources = {
     },
     backToWorkspace: "Назад",
     addHost: "Добавить хост",
+    enableBuiltInDaemon: "Включить встроенный демон",
     projects: "Проекты",
     projectList: {
       hostLoadFailed: "Не удалось загрузить проекты с хоста{{hostName}}:{{message}}.",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1443,7 +1443,6 @@ export const ru: TranslationResources = {
     groupInfo: "О{{title}}",
     sections: {
       general: "Общий",
-      daemon: "Daemon",
       appearance: "Появление",
       shortcuts: "Ярлыки",
       integrations: "Интеграции",
@@ -1458,7 +1457,7 @@ export const ru: TranslationResources = {
       providers: "Провайдеры",
       usage: "Использование",
       terminals: "Terminals",
-      host: "Host",
+      host: "Обзор",
     },
     general: {
       title: "Общий",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1395,7 +1395,6 @@ export const zhCN: TranslationResources = {
     groupInfo: "关于 {{title}}",
     sections: {
       general: "通用",
-      daemon: "Daemon",
       appearance: "外观",
       shortcuts: "快捷键",
       integrations: "集成",
@@ -1410,7 +1409,7 @@ export const zhCN: TranslationResources = {
       providers: "Providers",
       usage: "使用情况",
       terminals: "Terminals",
-      host: "Host",
+      host: "概览",
     },
     general: {
       title: "通用",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1387,6 +1387,7 @@ export const zhCN: TranslationResources = {
     },
     backToWorkspace: "返回",
     addHost: "添加主机",
+    enableBuiltInDaemon: "启用内置 daemon",
     projects: "项目",
     projectList: {
       hostLoadFailed: "无法从 Host {{hostName}} 加载 projects：{{message}}",

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -99,7 +99,10 @@ import ProjectsScreen from "@/screens/projects-screen";
 import ProjectSettingsScreen from "@/screens/project-settings-screen";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useLocalDaemonServerId } from "@/hooks/use-is-local-daemon";
-import { useEnableBuiltInDaemonOption } from "@/desktop/hooks/use-enable-built-in-daemon-option";
+import {
+  type EnableBuiltInDaemonOption,
+  useEnableBuiltInDaemonOption,
+} from "@/desktop/hooks/use-enable-built-in-daemon-option";
 import { useWebScrollbarStyle } from "@/hooks/use-web-scrollbar-style";
 import {
   buildOpenProjectRoute,
@@ -892,6 +895,7 @@ interface HostPickerProps {
   sortedHosts: HostProfile[];
   onSelectHost: (serverId: string) => void;
   onAddHost: () => void;
+  enableBuiltInDaemonOption: EnableBuiltInDaemonOption;
 }
 
 /**
@@ -901,13 +905,18 @@ interface HostPickerProps {
  * is using right now; an "Add host" row is always reachable from the list —
  * even with a single host.
  */
-function HostPicker({ activeServerId, sortedHosts, onSelectHost, onAddHost }: HostPickerProps) {
+function HostPicker({
+  activeServerId,
+  sortedHosts,
+  onSelectHost,
+  onAddHost,
+  enableBuiltInDaemonOption,
+}: HostPickerProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<View | null>(null);
   const activeHost =
     sortedHosts.find((host) => host.serverId === activeServerId) ?? sortedHosts[0] ?? null;
-  const enableBuiltInDaemonOption = useEnableBuiltInDaemonOption();
 
   const handleOpen = useCallback(() => setIsOpen(true), []);
   const hostOptionTestID = useCallback(
@@ -992,6 +1001,7 @@ function SettingsSidebar({
   const localServerId = useLocalDaemonServerId();
   const sortedHosts = useSortedHosts(hosts, localServerId);
   const hasHosts = sortedHosts.length > 0;
+  const enableBuiltInDaemonOption = useEnableBuiltInDaemonOption();
   const isDesktopApp = isElectronRuntime();
   const items = SIDEBAR_SECTION_ITEMS.filter((item) => !item.desktopOnly || isDesktopApp);
   const insets = useSafeAreaInsets();
@@ -1038,6 +1048,7 @@ function SettingsSidebar({
             sortedHosts={sortedHosts}
             onSelectHost={onSelectHost}
             onAddHost={onAddHost}
+            enableBuiltInDaemonOption={enableBuiltInDaemonOption}
           />
           {HOST_SECTION_ITEMS.map((item) => (
             <SidebarHostSectionButton
@@ -1064,6 +1075,20 @@ function SettingsSidebar({
               {t("settings.addHost")}
             </Text>
           </Pressable>
+          {enableBuiltInDaemonOption.visible ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t("settings.enableBuiltInDaemon")}
+              onPress={enableBuiltInDaemonOption.onPress}
+              testID="settings-enable-built-in-daemon"
+              style={sidebarItemStyle}
+            >
+              <Server size={theme.iconSize.md} color={theme.colors.foregroundMuted} />
+              <Text style={sidebarStyles.label} numberOfLines={1}>
+                {t("settings.enableBuiltInDaemon")}
+              </Text>
+            </Pressable>
+          ) : null}
         </View>
       )}
     </>

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -72,7 +72,6 @@ import { SegmentedControl } from "@/components/ui/segmented-control";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { DesktopPermissionsSection } from "@/desktop/components/desktop-permissions-section";
 import { IntegrationsSection } from "@/desktop/components/integrations-section";
-import { LocalDaemonSection } from "@/desktop/components/desktop-updates-section";
 import { isElectronRuntime } from "@/desktop/host";
 import { useDesktopAppUpdater } from "@/desktop/updates/use-desktop-app-updater";
 import { formatVersionWithPrefix } from "@/desktop/updates/desktop-updates";
@@ -100,6 +99,7 @@ import ProjectsScreen from "@/screens/projects-screen";
 import ProjectSettingsScreen from "@/screens/project-settings-screen";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useLocalDaemonServerId } from "@/hooks/use-is-local-daemon";
+import { useEnableBuiltInDaemonOption } from "@/desktop/hooks/use-enable-built-in-daemon-option";
 import { useWebScrollbarStyle } from "@/hooks/use-web-scrollbar-style";
 import {
   buildOpenProjectRoute,
@@ -131,7 +131,6 @@ interface SidebarSectionItem {
 
 const SIDEBAR_SECTION_ITEMS: SidebarSectionItem[] = [
   { id: "general", labelKey: "settings.sections.general", icon: Settings },
-  { id: "daemon", labelKey: "settings.sections.daemon", icon: Server, desktopOnly: true },
   { id: "appearance", labelKey: "settings.sections.appearance", icon: Palette },
   { id: "shortcuts", labelKey: "settings.sections.shortcuts", icon: Keyboard, desktopOnly: true },
   {
@@ -157,13 +156,13 @@ interface HostSectionItem {
 }
 
 const HOST_SECTION_ITEMS: HostSectionItem[] = [
+  { id: "host", labelKey: "settings.hostSections.host", icon: Server },
   { id: "connections", labelKey: "settings.hostSections.connections", icon: Network },
   { id: "agents", labelKey: "settings.hostSections.agents", icon: Bot },
   { id: "workspaces", labelKey: "settings.hostSections.workspaces", icon: FolderGit2 },
   { id: "providers", labelKey: "settings.hostSections.providers", icon: Boxes },
   { id: "usage", labelKey: "settings.hostSections.usage", icon: Gauge },
   { id: "terminals", labelKey: "settings.hostSections.terminals", icon: SquareTerminal },
-  { id: "host", labelKey: "settings.hostSections.host", icon: Server },
 ];
 
 function renderHostSettingsContent(
@@ -908,6 +907,7 @@ function HostPicker({ activeServerId, sortedHosts, onSelectHost, onAddHost }: Ho
   const triggerRef = useRef<View | null>(null);
   const activeHost =
     sortedHosts.find((host) => host.serverId === activeServerId) ?? sortedHosts[0] ?? null;
+  const enableBuiltInDaemonOption = useEnableBuiltInDaemonOption();
 
   const handleOpen = useCallback(() => setIsOpen(true), []);
   const hostOptionTestID = useCallback(
@@ -932,6 +932,8 @@ function HostPicker({ activeServerId, sortedHosts, onSelectHost, onAddHost }: Ho
       anchorRef={triggerRef}
       includeAddHost
       onAddHost={onAddHost}
+      includeEnableBuiltInDaemon={enableBuiltInDaemonOption.visible}
+      onEnableBuiltInDaemon={enableBuiltInDaemonOption.onPress}
       showActiveConnection
       searchable={false}
       title={t("settings.hostPicker.switchHost")}
@@ -1387,8 +1389,6 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
               handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
             />
           );
-        case "daemon":
-          return <LocalDaemonSection />;
         case "appearance":
           return <AppearanceSection />;
         case "shortcuts":

--- a/packages/app/src/utils/host-routes.test.ts
+++ b/packages/app/src/utils/host-routes.test.ts
@@ -15,6 +15,7 @@ import {
   decodeWorkspaceIdFromPathSegment,
   encodeFilePathForPathSegment,
   encodeWorkspaceIdForPathSegment,
+  isSettingsSectionSlug,
   normalizeHostSectionSlug,
   parseHostAgentRouteFromPathname,
   parseHostWorkspaceOpenIntentFromPathname,
@@ -263,6 +264,12 @@ describe("host settings section slugs", () => {
   it("maps old host settings sections to their new names", () => {
     expect(normalizeHostSectionSlug("orchestration")).toBe("agents");
     expect(normalizeHostSectionSlug("daemon")).toBe("host");
+  });
+});
+
+describe("settings section slugs", () => {
+  it("no longer treats daemon as a valid app-level settings section", () => {
+    expect(isSettingsSectionSlug("daemon")).toBe(false);
   });
 });
 

--- a/packages/app/src/utils/host-routes.ts
+++ b/packages/app/src/utils/host-routes.ts
@@ -482,7 +482,6 @@ export function resolveKnownHostRoute(input: {
 
 export const SETTINGS_SECTION_SLUGS = [
   "general",
-  "daemon",
   "appearance",
   "shortcuts",
   "integrations",


### PR DESCRIPTION
### Linked issue

Refs #1747

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Settings had two identical-looking daemon cards: the app-level **Daemon** section and the host page for localhost rendered the same component in two places, and only one of them had Restart/Remove. This consolidates daemon management into the host page as the single home:

- The app-level Daemon section is removed (it was desktop-only; mobile already lived with the host-page-only model).
- The Host sidebar group now leads with **Overview** (renamed from "Host", moved above Connections) so the host selector reads as the title of the page beneath it.
- New recovery affordance: after "Remove localhost connection", the host switcher shows **Enable built-in daemon** (Electron-only, only while localhost is not configured). Pressing it re-enables daemon management, recreates the localhost connection, and lands on Overview. The enable path is forced explicitly through the management mutation so it can never hit the pause/stop confirmation branch, and navigation happens linearly from the enable result — no state watching.
- Old `settings/daemon` deep links redirect to the localhost Overview (COMPAT-tagged with a removal date), waiting for the local server id to resolve before deciding.

All the affordance's hooks live in one settings-scoped hook (`use-enable-built-in-daemon-option`) — nothing mounts in the app shell, zero cost on mobile/web.

### How did you verify it

- `npm run typecheck`, `npm run lint`, `npm run format` — green (also enforced by the pre-commit hook).
- `npx vitest run` on the three touched test surfaces: `host-routes.test.ts` (38 passed, includes new assertion that `daemon` is no longer a valid settings slug while the legacy `daemon → host` alias still normalizes), `host-picker.test.tsx` (6 passed), `i18n/resources.test.ts` (32 passed — key parity across all 8 locales after the label changes).
- Not yet manually exercised: the full remove-localhost → "Enable built-in daemon" → Overview flow on a packaged desktop build. Worth one manual pass on desktop before merge; the sidebar reorder and section removal are visible immediately in any desktop/web run.

Risk surface beyond CI: the redirect touches Expo Router route resolution (it only intercepts the raw `daemon` section slug and defers until the local-daemon id query resolves, so startup restore and other sections are untouched); the dropdown affordance is gated by `getIsElectron()` plus a resolved-id check, and all desktop hooks it uses no-op off Electron.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform (settings IA change — screenshots to follow after desktop smoke)