### PR TITLE
Keep renamed host names after reconnect

### DIFF
--- a/packages/app/src/runtime/host-runtime.test.ts
+++ b/packages/app/src/runtime/host-runtime.test.ts
@@ -1775,6 +1775,41 @@ describe("HostRuntimeStore", () => {
     store.syncHosts([]);
   });
 
+  it("preserves a manual host rename when desktop status re-advertises the daemon hostname", async () => {
+    const advertisedHostname = "macbook-pro.local";
+    const store = new HostRuntimeStore({
+      deps: {
+        createClient: () => new FakeDaemonClient() as unknown as DaemonClient,
+        connectToDaemon: async ({ host }) => ({
+          client: makeConnectedProbeClient(5) as unknown as DaemonClient,
+          serverId: host.serverId,
+          hostname: advertisedHostname,
+        }),
+        getClientId: async () => "cid_test_runtime",
+      },
+      storage: createMemoryHostRuntimeStorage(),
+    });
+
+    try {
+      await store.upsertConnectionFromListen({
+        listenAddress: "127.0.0.1:6767",
+        serverId: "srv_desktop",
+        hostname: advertisedHostname,
+      });
+      await store.renameHost("srv_desktop", "mac-dev");
+
+      await store.upsertConnectionFromListen({
+        listenAddress: "127.0.0.1:6767",
+        serverId: "srv_desktop",
+        hostname: advertisedHostname,
+      });
+
+      expect(store.getHosts().find((h) => h.serverId === "srv_desktop")?.label).toBe("mac-dev");
+    } finally {
+      store.syncHosts([]);
+    }
+  });
+
   it("upsertDirectConnection stores SSL and password settings", async () => {
     const store = new HostRuntimeStore({
       deps: {
@@ -1982,7 +2017,7 @@ describe("HostRuntimeStore", () => {
     store.syncHosts([]);
   });
 
-  it("uses the latest advertised hostname when re-pairing an existing relay host", async () => {
+  it("preserves the existing host label when re-pairing an existing relay host", async () => {
     const store = new HostRuntimeStore({
       deps: {
         createClient: () => new FakeDaemonClient() as unknown as DaemonClient,
@@ -1993,6 +2028,7 @@ describe("HostRuntimeStore", () => {
         }),
         getClientId: async () => "cid_test_runtime",
       },
+      storage: createMemoryHostRuntimeStorage(),
     });
 
     await store.upsertRelayConnection({
@@ -2005,7 +2041,7 @@ describe("HostRuntimeStore", () => {
     await store.upsertConnectionFromOffer(makeOffer(), "mbp");
 
     const pairedHost = store.getHosts().find((host) => host.serverId === "srv_offer");
-    expect(pairedHost?.label).toBe("mbp");
+    expect(pairedHost?.label).toBe("Custom name");
 
     store.syncHosts([]);
   });

--- a/packages/app/src/types/host-connection.ts
+++ b/packages/app/src/types/host-connection.ts
@@ -165,7 +165,7 @@ export function upsertHostConnectionInProfiles(input: {
     input.connection,
   ]);
   const nextLifecycle = prev.lifecycle;
-  const nextLabel = labelTrimmed || (prev.label === prev.serverId ? derivedLabel : prev.label);
+  const nextLabel = prev.label === prev.serverId ? derivedLabel : prev.label;
   const nextPreferredConnectionId =
     prev.preferredConnectionId &&
     nextConnections.some((connection) => connection.id === prev.preferredConnectionId)


### PR DESCRIPTION
### Linked issue

Closes #1531

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Host names edited in settings now survive daemon startup/status refreshes and re-pairing. The app still uses the daemon-advertised hostname when first creating a host, but later connection refreshes no longer treat that hostname as an authoritative rename over a label the user already changed.

This fixes the case where a host appears renamed in the UI, then reverts after app restart, daemon restart, or another registration pass.

### How did you verify it

Reproduced the bug with a failing host-runtime regression test first: desktop status re-advertised the daemon hostname after a manual rename, and the label reverted. After the change, the same test preserves the manual label.

Commands run:

- `npx vitest run packages/app/src/runtime/host-runtime.test.ts --bail=1`
- `npx vitest run packages/app/src/types/host-connection.test.ts --bail=1`
- `npm run lint -- packages/app/src/types/host-connection.ts packages/app/src/runtime/host-runtime.test.ts`
- `npm run format`
- `npm run typecheck`

### Risk surface

This changes host registry merge behavior. New/default hosts still get auto-named from the advertised hostname, but existing non-default labels are preserved on later connection upserts. There is no visual UI change.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable: no visual UI change)
- [x] Tests added or updated where it made sense
