### PR TITLE
Show nested git repo changes in checkout diffs

### DIFF
--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -378,6 +378,40 @@ describe("checkout git utilities", () => {
     expect(message).toBe("update file");
   });
 
+  it("includes dirty nested git repository changes ignored by the parent checkout", async () => {
+    const subrepoDir = join(repoDir, "vendor", "tool");
+    mkdirSync(subrepoDir, { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: subrepoDir });
+    execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: subrepoDir });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: subrepoDir });
+    writeFileSync(join(subrepoDir, "nested.txt"), "nested initial\n");
+    execFileSync("git", ["add", "nested.txt"], { cwd: subrepoDir });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "nested initial"], {
+      cwd: subrepoDir,
+    });
+
+    writeFileSync(join(repoDir, ".git", "info", "exclude"), "vendor/\n");
+
+    writeFileSync(join(subrepoDir, "nested.txt"), "nested updated\n");
+    const parentStatus = execFileSync("git", ["status", "--porcelain"], { cwd: repoDir })
+      .toString()
+      .trim();
+    expect(parentStatus).toBe("");
+
+    const status = await getCheckoutStatus(repoDir);
+    expect(status.isGit).toBe(true);
+    expect(status.isDirty).toBe(true);
+
+    const diff = await getCheckoutDiff(repoDir, {
+      mode: "uncommitted",
+      includeStructured: true,
+    });
+
+    expect(diff.structured?.map((file) => file.path)).toContain("vendor/tool/nested.txt");
+    expect(diff.diff).toContain("diff --git a/vendor/tool/nested.txt b/vendor/tool/nested.txt");
+    expect(diff.diff).toContain("+nested updated");
+  });
+
   it("reuses checkout snapshot facts across status, shortstat, and PR status reads", async () => {
     setupRemoteTrackingMain(repoDir, tempDir);
     execFileSync("git", ["checkout", "-b", "feature/facts"], { cwd: repoDir });

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1,6 +1,6 @@
-import { resolve, dirname, basename } from "path";
+import { resolve, dirname, basename, relative, sep } from "path";
 import { existsSync, realpathSync } from "fs";
-import { open as openFile, readFile, stat as statFile } from "fs/promises";
+import { open as openFile, readFile, readdir, stat as statFile } from "fs/promises";
 import { TTLCache } from "@isaacs/ttlcache";
 import type { Logger } from "pino";
 import type { ParsedDiffFile } from "../server/utils/diff-highlighter.js";
@@ -51,6 +51,25 @@ const DEFAULT_PULL_REQUEST_STATUS_CACHE_TTL_MS = 30_000;
 const PULL_REQUEST_STATUS_CACHE_MAX = 1_000;
 const DEFAULT_SHORTSTAT_CACHE_TTL_MS = 15_000;
 const SHORTSTAT_CACHE_MAX = 1_000;
+const NESTED_GIT_REPO_ROOT_CACHE_TTL_MS = 15_000;
+const NESTED_GIT_REPO_ROOT_CACHE_MAX = 256;
+const NESTED_GIT_REPO_SEARCH_MAX_DEPTH = 8;
+const NESTED_GIT_REPO_SEARCH_MAX_REPOS = 128;
+const NESTED_GIT_REPO_PRUNED_DIR_NAMES = new Set([
+  ".git",
+  ".paseo",
+  ".expo",
+  ".next",
+  ".turbo",
+  ".cache",
+  ".gradle",
+  "DerivedData",
+  "Pods",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+]);
 
 let pullRequestStatusCacheTtlMs = DEFAULT_PULL_REQUEST_STATUS_CACHE_TTL_MS;
 let pullRequestStatusCache = createPullRequestStatusCache(pullRequestStatusCacheTtlMs);
@@ -59,6 +78,10 @@ const lastSuccessfulPullRequestStatus = new Map<string, PullRequestStatusResult>
 let shortstatCacheTtlMs = DEFAULT_SHORTSTAT_CACHE_TTL_MS;
 let shortstatCache = createShortstatCache(shortstatCacheTtlMs);
 const shortstatInFlight = new Map<string, Promise<CheckoutShortstat | null>>();
+const nestedGitRepoRootCache = new TTLCache<string, string[]>({
+  max: NESTED_GIT_REPO_ROOT_CACHE_MAX,
+  ttl: NESTED_GIT_REPO_ROOT_CACHE_TTL_MS,
+});
 
 interface CheckoutReadCacheOptions {
   force?: boolean;
@@ -804,6 +827,191 @@ export type CheckoutSnapshotFacts =
       branchMergeRef: string | null;
       pullRequestLookupTarget: PullRequestStatusLookupTarget | null;
     };
+
+function checkoutContextWithoutFacts(
+  context: CheckoutContext | undefined,
+): CheckoutContext | undefined {
+  if (!context) {
+    return undefined;
+  }
+  return {
+    paseoHome: context.paseoHome,
+    worktreesRoot: context.worktreesRoot,
+    logger: context.logger,
+  };
+}
+
+function toGitRelativePath(repoRoot: string, nestedRoot: string): string | null {
+  const relativePath = relative(repoRoot, nestedRoot).split(sep).join("/");
+  if (
+    !relativePath ||
+    relativePath === "." ||
+    relativePath === ".." ||
+    relativePath.startsWith("../")
+  ) {
+    return null;
+  }
+  return relativePath;
+}
+
+function prefixGitPath(prefix: string, path: string): string {
+  return `${prefix}/${path}`.replace(/\/+/g, "/");
+}
+
+function prefixParsedDiffFiles(files: ParsedDiffFile[], prefix: string): ParsedDiffFile[] {
+  return files.map((file) => ({
+    ...file,
+    path: prefixGitPath(prefix, file.path),
+  }));
+}
+
+function prefixGitDiffText(diff: string, prefix: string): string {
+  if (!diff) {
+    return "";
+  }
+
+  const prefixed = diff
+    .replace(/^diff --git a\/(.+) b\/(.+)$/gm, (_line, oldPath: string, newPath: string) => {
+      return `diff --git a/${prefixGitPath(prefix, oldPath)} b/${prefixGitPath(prefix, newPath)}`;
+    })
+    .replace(/^--- a\/(.+)$/gm, (_line, path: string) => `--- a/${prefixGitPath(prefix, path)}`)
+    .replace(/^\+\+\+ b\/(.+)$/gm, (_line, path: string) => `+++ b/${prefixGitPath(prefix, path)}`)
+    .replace(/^rename from (.+)$/gm, (_line, path: string) => {
+      return `rename from ${prefixGitPath(prefix, path)}`;
+    })
+    .replace(/^rename to (.+)$/gm, (_line, path: string) => {
+      return `rename to ${prefixGitPath(prefix, path)}`;
+    })
+    .replace(/^copy from (.+)$/gm, (_line, path: string) => {
+      return `copy from ${prefixGitPath(prefix, path)}`;
+    })
+    .replace(/^copy to (.+)$/gm, (_line, path: string) => {
+      return `copy to ${prefixGitPath(prefix, path)}`;
+    });
+
+  return prefixed.endsWith("\n") ? prefixed : `${prefixed}\n`;
+}
+
+async function collectNestedGitRepoRoots(input: {
+  repoRoot: string;
+  dir: string;
+  depth: number;
+  roots: string[];
+}): Promise<void> {
+  if (
+    input.depth > NESTED_GIT_REPO_SEARCH_MAX_DEPTH ||
+    input.roots.length >= NESTED_GIT_REPO_SEARCH_MAX_REPOS
+  ) {
+    return;
+  }
+
+  let entries;
+  try {
+    entries = await readdir(input.dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  if (input.dir !== input.repoRoot && entries.some((entry) => entry.name === ".git")) {
+    input.roots.push(input.dir);
+    return;
+  }
+
+  for (const entry of entries) {
+    if (input.roots.length >= NESTED_GIT_REPO_SEARCH_MAX_REPOS) {
+      return;
+    }
+    if (!entry.isDirectory() || NESTED_GIT_REPO_PRUNED_DIR_NAMES.has(entry.name)) {
+      continue;
+    }
+    await collectNestedGitRepoRoots({
+      repoRoot: input.repoRoot,
+      dir: resolve(input.dir, entry.name),
+      depth: input.depth + 1,
+      roots: input.roots,
+    });
+  }
+}
+
+async function listNestedGitRepoRoots(repoRoot: string): Promise<string[]> {
+  const normalizedRepoRoot = resolve(repoRoot);
+  const cached = nestedGitRepoRootCache.get(normalizedRepoRoot);
+  if (cached) {
+    return cached;
+  }
+
+  const roots: string[] = [];
+  await collectNestedGitRepoRoots({
+    repoRoot: normalizedRepoRoot,
+    dir: normalizedRepoRoot,
+    depth: 0,
+    roots,
+  });
+  roots.sort((a, b) => {
+    if (a === b) return 0;
+    return a < b ? -1 : 1;
+  });
+  nestedGitRepoRootCache.set(normalizedRepoRoot, roots);
+  return roots;
+}
+
+async function hasDirtyNestedGitRepo(
+  repoRoot: string,
+  context: CheckoutContext | undefined,
+): Promise<boolean> {
+  const nestedContext = checkoutContextWithoutFacts(context);
+  for (const nestedRoot of await listNestedGitRepoRoots(repoRoot)) {
+    try {
+      if (await isWorkingTreeDirty(nestedRoot, nestedContext)) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+function buildNestedCheckoutDiffCompare(compare: CheckoutDiffCompare): CheckoutDiffCompare {
+  const common = {
+    ...(compare.ignoreWhitespace === true ? { ignoreWhitespace: true } : {}),
+    ...(compare.includeStructured === true ? { includeStructured: true } : {}),
+  };
+  if (compare.mode === "uncommitted") {
+    return { mode: "uncommitted", ...common };
+  }
+  return { mode: "base", ...common };
+}
+
+async function appendNestedCheckoutDiffs(input: {
+  repoRoot: string;
+  compare: CheckoutDiffCompare;
+  context: CheckoutContext | undefined;
+  structured: ParsedDiffFile[];
+  appendDiff: (text: string) => void;
+}): Promise<void> {
+  const nestedContext = checkoutContextWithoutFacts(input.context);
+  const nestedCompare = buildNestedCheckoutDiffCompare(input.compare);
+  for (const nestedRoot of await listNestedGitRepoRoots(input.repoRoot)) {
+    const prefix = toGitRelativePath(input.repoRoot, nestedRoot);
+    if (!prefix) {
+      continue;
+    }
+
+    try {
+      const diff = await getCheckoutDiff(nestedRoot, nestedCompare, nestedContext);
+      input.appendDiff(prefixGitDiffText(diff.diff, prefix));
+      if (input.compare.includeStructured === true && diff.structured) {
+        input.structured.push(...prefixParsedDiffFiles(diff.structured, prefix));
+      }
+    } catch (error) {
+      input.context?.logger?.trace?.(
+        { repoRoot: input.repoRoot, nestedRoot, error },
+        "Skipping nested git repository diff",
+      );
+    }
+  }
+}
 
 function isGitError(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -1872,7 +2080,11 @@ export async function getCheckoutStatus(
   const currentBranch = facts.currentBranch;
   const remoteUrl = facts.remoteUrl;
   const paseoWorktree = facts.paseoWorktree;
-  const isDirty = await isWorkingTreeDirty(cwd, context);
+  const [ownDirty, nestedDirty] = await Promise.all([
+    isWorkingTreeDirty(cwd, context),
+    hasDirtyNestedGitRepo(worktreeRoot, context),
+  ]);
+  const isDirty = ownDirty || nestedDirty;
   const hasRemote = remoteUrl !== null;
   const baseRef = facts.resolvedBaseRef;
   const mainRepoRoot = facts.mainRepoRoot;
@@ -2413,30 +2625,11 @@ export async function getCheckoutDiff(
   compare: CheckoutDiffCompare,
   context?: CheckoutContext,
 ): Promise<CheckoutDiffResult> {
-  await requireGitRepo(cwd);
-
-  const refsForDiff = await resolveCheckoutDiffRefs(cwd, compare, context);
-  if (!refsForDiff) {
-    return { diff: "" };
+  const facts = await getCheckoutSnapshotFacts(cwd, context);
+  if (!facts.isGit) {
+    throw new NotGitRepoError(cwd);
   }
-
-  const ignoreWhitespace = compare.ignoreWhitespace === true;
-  let effectiveRefsForDiff = refsForDiff;
-  let changes: CheckoutFileChange[];
-  try {
-    changes = await listCheckoutFileChanges(cwd, effectiveRefsForDiff, ignoreWhitespace);
-  } catch (error) {
-    if (!isUnbornHeadDiffError(error)) {
-      throw error;
-    }
-    effectiveRefsForDiff = { ...refsForDiff, baseRef: EMPTY_TREE_OBJECT_ID };
-    changes = await listCheckoutFileChanges(cwd, effectiveRefsForDiff, ignoreWhitespace);
-  }
-  changes.sort((a, b) => {
-    if (a.path === b.path) return 0;
-    return a.path < b.path ? -1 : 1;
-  });
-
+  const factsContext: CheckoutContext = { ...context, facts };
   const structured: ParsedDiffFile[] = [];
   let diffText = "";
   let diffBytes = 0;
@@ -2456,63 +2649,91 @@ export async function getCheckoutDiff(
     }
   };
 
-  const trackedChanges = changes.filter((change) => !change.isUntracked);
-  const untrackedChanges = changes.filter((change) => change.isUntracked === true);
-  const trackedDiff = await processTrackedChanges({
-    cwd,
-    refsForDiff: effectiveRefsForDiff,
-    trackedChanges,
-    ignoreWhitespace,
-    appendDiff,
-  });
-
-  const appendTrackedPlaceholderComment = (
-    change: CheckoutFileChange,
-    status: "binary" | "too_large",
-  ) => {
-    if (status === "binary") {
-      appendDiff(`# ${change.path}: binary diff omitted\n`);
-      return;
+  const refsForDiff = await resolveCheckoutDiffRefs(cwd, compare, factsContext);
+  if (refsForDiff) {
+    const ignoreWhitespace = compare.ignoreWhitespace === true;
+    let effectiveRefsForDiff = refsForDiff;
+    let changes: CheckoutFileChange[];
+    try {
+      changes = await listCheckoutFileChanges(cwd, effectiveRefsForDiff, ignoreWhitespace);
+    } catch (error) {
+      if (!isUnbornHeadDiffError(error)) {
+        throw error;
+      }
+      effectiveRefsForDiff = { ...refsForDiff, baseRef: EMPTY_TREE_OBJECT_ID };
+      changes = await listCheckoutFileChanges(cwd, effectiveRefsForDiff, ignoreWhitespace);
     }
-    appendDiff(`# ${change.path}: diff too large omitted\n`);
-  };
-
-  if (compare.includeStructured) {
-    await appendStructuredTrackedDiffs({
-      cwd,
-      trackedChanges,
-      trackedChangeByPath: trackedDiff.trackedChangeByPath,
-      trackedNumstatByPath: trackedDiff.trackedNumstatByPath,
-      trackedPlaceholderByPath: trackedDiff.trackedPlaceholderByPath,
-      trackedDiffText: trackedDiff.trackedDiffText,
-      refsForDiff: effectiveRefsForDiff,
-      ignoreWhitespace,
-      structured,
-      appendDiff,
-      appendTrackedPlaceholderComment,
+    changes.sort((a, b) => {
+      if (a.path === b.path) return 0;
+      return a.path < b.path ? -1 : 1;
     });
-  } else {
-    for (const change of trackedChanges) {
-      const placeholder = trackedDiff.trackedPlaceholderByPath.get(change.path);
-      if (placeholder) {
-        appendTrackedPlaceholderComment(change, placeholder.status);
+
+    const trackedChanges = changes.filter((change) => !change.isUntracked);
+    const untrackedChanges = changes.filter((change) => change.isUntracked === true);
+    const trackedDiff = await processTrackedChanges({
+      cwd,
+      refsForDiff: effectiveRefsForDiff,
+      trackedChanges,
+      ignoreWhitespace,
+      appendDiff,
+    });
+
+    const appendTrackedPlaceholderComment = (
+      change: CheckoutFileChange,
+      status: "binary" | "too_large",
+    ) => {
+      if (status === "binary") {
+        appendDiff(`# ${change.path}: binary diff omitted\n`);
+        return;
+      }
+      appendDiff(`# ${change.path}: diff too large omitted\n`);
+    };
+
+    if (compare.includeStructured) {
+      await appendStructuredTrackedDiffs({
+        cwd,
+        trackedChanges,
+        trackedChangeByPath: trackedDiff.trackedChangeByPath,
+        trackedNumstatByPath: trackedDiff.trackedNumstatByPath,
+        trackedPlaceholderByPath: trackedDiff.trackedPlaceholderByPath,
+        trackedDiffText: trackedDiff.trackedDiffText,
+        refsForDiff: effectiveRefsForDiff,
+        ignoreWhitespace,
+        structured,
+        appendDiff,
+        appendTrackedPlaceholderComment,
+      });
+    } else {
+      for (const change of trackedChanges) {
+        const placeholder = trackedDiff.trackedPlaceholderByPath.get(change.path);
+        if (placeholder) {
+          appendTrackedPlaceholderComment(change, placeholder.status);
+        }
       }
     }
+
+    for (const change of untrackedChanges) {
+      if (diffBytes >= TOTAL_DIFF_MAX_BYTES) {
+        break;
+      }
+      await processUntrackedChange({
+        cwd,
+        change,
+        ignoreWhitespace,
+        includeStructured: compare.includeStructured === true,
+        structured,
+        appendDiff,
+      });
+    }
   }
 
-  for (const change of untrackedChanges) {
-    if (diffBytes >= TOTAL_DIFF_MAX_BYTES) {
-      break;
-    }
-    await processUntrackedChange({
-      cwd,
-      change,
-      ignoreWhitespace,
-      includeStructured: compare.includeStructured === true,
-      structured,
-      appendDiff,
-    });
-  }
+  await appendNestedCheckoutDiffs({
+    repoRoot: facts.worktreeRoot,
+    compare,
+    context: factsContext,
+    structured,
+    appendDiff,
+  });
 
   if (compare.includeStructured) {
     return { diff: diffText, structured };


### PR DESCRIPTION
### Linked issue

N/A - small focused bug fix for nested git repository changes in the Git page.

### Type of change

- [] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

Paseo's Git page previously only reflected changes from the top-level checkout. If a workspace contained a nested git repository that the parent checkout ignored, dirty files inside that nested repo were invisible in checkout status and diff views.

This updates checkout git utilities to discover nested git repositories under the workspace root, cache that discovery briefly, fold dirty nested repos into checkout dirty status, and append nested repo diffs with parent-relative paths such as `vendor/tool/nested.txt`. Nested diff reads use the nested repository's own comparison context so parent refs are not incorrectly applied to subrepos.

A regression test covers a parent repo that ignores `vendor/` while `vendor/tool` is its own dirty git repository.

### How did you verify it

- `npm run format`
- `npx vitest run packages/server/src/utils/checkout-git.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint`
- Pre-commit hook also passed targeted lint, format check, and typecheck.
- Manual verification with a temporary fixture repo at `/private/tmp/paseo-subrepo-demo`: parent repo had a dirty `README.md`; ignored nested repo `vendor/tool` had a dirty `nested.txt`. The dev daemon checkout diff returned both `README.md` and `vendor/tool/nested.txt`, and the web app connected successfully to the dev daemon.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

No UI code changed; this is server-side checkout/git behavior exercised by the existing Git page.
