### PR TITLE
fix: hide console windows for daemon worker and terminal worker spawns on Windows

### DIFF
--- a/packages/server/scripts/supervisor.ts
+++ b/packages/server/scripts/supervisor.ts
@@ -183,12 +183,14 @@ export function runSupervisor(options: SupervisorOptions): void {
       child = spawn(spawnSpec.command, spawnSpec.args, {
         stdio: ["inherit", "pipe", "pipe", "ipc"],
         env: spawnSpec.env ?? workerEnv,
+        windowsHide: true,
       });
     } else {
       child = fork(workerEntry, workerArgs, {
         stdio: ["inherit", "pipe", "pipe", "ipc"],
         env: workerEnv,
         execArgv: workerExecArgv,
+        windowsHide: true,
       });
     }
 

--- a/packages/server/src/terminal/worker-terminal-manager.ts
+++ b/packages/server/src/terminal/worker-terminal-manager.ts
@@ -144,6 +144,7 @@ function forkTerminalWorker(): TerminalWorkerProcess {
     execArgv: resolveWorkerExecArgv(),
     serialization: "advanced",
     stdio: ["ignore", "ignore", "inherit", "ipc"],
+    windowsHide: true,
   }) as TerminalWorkerProcess;
 }
 


### PR DESCRIPTION
## Problem

On Windows, every daemon start produces a **persistent visible console window titled "Paseo Daemon"** on the desktop. Closing that window kills the daemon (and every agent it manages), so users are stuck with a stray black window.

## Root cause

The CLI launches the supervisor detached with `windowsHide: true` (via the shared `spawnProcess` helper), so the supervisor runs **console-less**. The supervisor then launches the daemon worker with raw `spawn()`/`fork()` **without** `windowsHide` (`packages/server/scripts/supervisor.ts`). On Windows, a console-application child of a console-less parent gets a brand-new visible console allocated by the OS -- the worker sets the process title, hence the "Paseo Daemon" window.

`forkTerminalWorker()` in `packages/server/src/terminal/worker-terminal-manager.ts` has the same omission (currently masked because the terminal worker inherits the daemon worker's console).

## Fix

Add `windowsHide: true` to the three spawn/fork option objects. `windowsHide` is a no-op on macOS/Linux.

## Testing

Verified on Windows 11 (CLI 0.1.104, applying the same change to the installed `dist`):

- **Before:** every daemon start creates a visible console window owned by the daemon-worker process (confirmed by mapping `MainWindowTitle` to the worker PID in the process tree).
- **After:** no visible windows; daemon healthy (status `running`, port listening, password auth working); agents and terminal workers unaffected.

Related: #1846 -- same bug family (unhidden child consoles on Windows). This fixes the persistent daemon-worker console; the transient flashes described there may involve additional spawn sites (e.g. git/gh grandchildren).

🤖 Generated with [Claude Code](https://claude.com/claude-code)