### PR TITLE
Update MiniMax metadata model to M3

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -171,7 +171,7 @@ For pay-as-you-go, use `ANTHROPIC_API_KEY` with a standard Model Studio key (`sk
 | `qwen3-coder-next` | Optimized for coding        |
 | `kimi-k2.5`        | Vision capable              |
 | `glm-5`            | Zhipu GLM                   |
-| `MiniMax-M2.5`     | MiniMax                     |
+| `MiniMax-M3`       | MiniMax                     |
 
 **Additional models (pay-as-you-go):**
 `qwen3-max`, `qwen3.5-flash`, `qwen3-coder-plus`, `qwen3-coder-flash`, `qwen3-vl-plus`, `qwen3-vl-flash`

--- a/packages/server/src/server/agent/structured-generation-providers.test.ts
+++ b/packages/server/src/server/agent/structured-generation-providers.test.ts
@@ -68,7 +68,7 @@ describe("resolveStructuredGenerationProviders", () => {
         status: READY,
         enabled: true,
         models: [
-          { provider: "router", id: "minimax-m2.5-free", label: "MiniMax M2.5", isDefault: true },
+          { provider: "router", id: "minimax-m3-free", label: "MiniMax M3", isDefault: true },
           { provider: "router", id: "nemotron-3-super-free", label: "Nemotron 3 Super" },
         ],
       },
@@ -87,7 +87,7 @@ describe("resolveStructuredGenerationProviders", () => {
     expect(providers).toEqual([
       { provider: "work-claude", model: "claude-haiku-2026" },
       { provider: "work-codex", model: "gpt-5.4-mini-2026", thinkingOptionId: "low" },
-      { provider: "router", model: "minimax-m2.5-free" },
+      { provider: "router", model: "minimax-m3-free" },
       { provider: "router", model: "nemotron-3-super-free" },
       { provider: "focused-provider", model: "focused-model", thinkingOptionId: "high" },
     ]);

--- a/packages/server/src/server/agent/structured-generation-providers.ts
+++ b/packages/server/src/server/agent/structured-generation-providers.ts
@@ -25,7 +25,7 @@ export const DEFAULT_STRUCTURED_GENERATION_PROVIDERS: readonly StructuredGenerat
   [
     { modelSubstring: "haiku" },
     { modelSubstring: "gpt-5.4-mini", thinkingOptionId: "low" },
-    { modelSubstring: "minimax-m2.5" },
+    { modelSubstring: "minimax-m3" },
     { modelSubstring: "nemotron-3-super" },
   ] as const;
 

--- a/public-docs/metadata-generation.md
+++ b/public-docs/metadata-generation.md
@@ -29,7 +29,7 @@ The candidate list is assembled in this order:
 2. **Built-in defaults**, matched against the models of the providers you have enabled:
    1. a `haiku` model
    2. `gpt-5.4-mini` (low reasoning)
-   3. `minimax-m2.5`
+   3. `minimax-m3`
    4. `nemotron-3-super`
 3. **The model currently selected** for that agent or draft, as a last resort.
 


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Update the structured metadata generation fallback from MiniMax M2.5 to MiniMax M3.
- Align the structured generation unit test fixture and docs references with MiniMax M3.

## Test plan
- Secret scan passed on the pending diff.
- `npm test -- packages/server/src/server/agent/structured-generation-providers.test.ts` could not run because dependencies were missing (`expo-module`, `vitest`, `zod-aot`, `tsx`).
- `npm run typecheck:server` could not run because dependencies were missing (`tsgo`).
- `npm install` could not complete in this environment due to unsupported Node 20 for Node 22 packages and `ENOSPC: no space left on device`.