### PR TITLE
fix(app): open existing git worktrees as workspaces

### DIFF
--- a/packages/app/src/hooks/open-project.ts
+++ b/packages/app/src/hooks/open-project.ts
@@ -2,7 +2,9 @@ import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import type { ProjectAddResponse } from "@getpaseo/protocol/messages";
 import {
   normalizeEmptyProjectDescriptor as normalizeProjectWithoutWorkspacesDescriptor,
+  normalizeWorkspaceDescriptor,
   type EmptyProjectDescriptor as ProjectWithoutWorkspacesDescriptor,
+  type WorkspaceDescriptor,
 } from "@/stores/session-store";
 
 type OpenProjectPayload = ProjectAddResponse["payload"];
@@ -10,6 +12,7 @@ type OpenProjectErrorCode = NonNullable<OpenProjectPayload["errorCode"]>;
 
 export interface OpenProjectSuccess {
   ok: true;
+  workspaceId: string | null;
 }
 
 export interface OpenProjectFailure {
@@ -40,9 +43,26 @@ export interface OpenProjectDirectlyInput {
   projectPath: string;
   isConnected: boolean;
   canAddProject: boolean;
-  client: Pick<DaemonClient, "addProject"> | null;
+  client: Pick<DaemonClient, "addProject" | "createWorkspace" | "getCheckoutStatus"> | null;
   addEmptyProject: (serverId: string, project: ProjectWithoutWorkspacesDescriptor) => void;
+  mergeWorkspaces: (serverId: string, workspaces: WorkspaceDescriptor[]) => void;
   setHasHydratedWorkspaces: (serverId: string, hydrated: boolean) => void;
+}
+
+async function isExistingGitWorktree(
+  client: Pick<DaemonClient, "getCheckoutStatus">,
+  path: string,
+): Promise<boolean> {
+  try {
+    const status = await client.getCheckoutStatus(path);
+    return (
+      status.isGit === true &&
+      typeof status.mainRepoRoot === "string" &&
+      status.mainRepoRoot.length > 0
+    );
+  } catch {
+    return false;
+  }
 }
 
 export async function openProjectDirectly(
@@ -62,6 +82,23 @@ export async function openProjectDirectly(
     };
   }
 
+  if (await isExistingGitWorktree(input.client, trimmedPath)) {
+    const payload = await input.client.createWorkspace({
+      source: { kind: "directory", path: trimmedPath },
+    });
+    if (payload.error || !payload.workspace) {
+      return {
+        ok: false,
+        errorCode: null,
+        error: payload.error,
+      };
+    }
+    const workspace = normalizeWorkspaceDescriptor(payload.workspace);
+    input.mergeWorkspaces(normalizedServerId, [workspace]);
+    input.setHasHydratedWorkspaces(normalizedServerId, true);
+    return { ok: true, workspaceId: workspace.id };
+  }
+
   const payload = await input.client.addProject(trimmedPath);
   if (payload.error || !payload.project) {
     return {
@@ -76,5 +113,5 @@ export async function openProjectDirectly(
     normalizeProjectWithoutWorkspacesDescriptor(payload.project),
   );
   input.setHasHydratedWorkspaces(normalizedServerId, true);
-  return { ok: true };
+  return { ok: true, workspaceId: null };
 }

--- a/packages/app/src/hooks/use-open-project.test.ts
+++ b/packages/app/src/hooks/use-open-project.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { getOpenProjectFailureReason, openProjectDirectly } from "@/hooks/open-project";
-import type { EmptyProjectDescriptor as ProjectWithoutWorkspacesDescriptor } from "@/stores/session-store";
+import {
+  getOpenProjectFailureReason,
+  openProjectDirectly,
+  type OpenProjectDirectlyInput,
+} from "@/hooks/open-project";
+import type {
+  EmptyProjectDescriptor as ProjectWithoutWorkspacesDescriptor,
+  WorkspaceDescriptor,
+} from "@/stores/session-store";
+import type { CheckoutStatusResponse, WorkspaceCreateResponse } from "@getpaseo/protocol/messages";
 
 const SERVER_ID = "server-1";
 const PROJECT_PATH = "/repo/project";
+const WORKTREE_PATH = "/repo-worktrees/feature-a";
+
+type TestClient = NonNullable<OpenProjectDirectlyInput["client"]>;
 
 function buildProjectPayload() {
   return {
@@ -14,9 +25,77 @@ function buildProjectPayload() {
   };
 }
 
+function buildCheckoutStatus(mainRepoRoot: string | null): CheckoutStatusResponse["payload"] {
+  return {
+    cwd: mainRepoRoot ? WORKTREE_PATH : PROJECT_PATH,
+    requestId: "checkout-status",
+    error: null,
+    isGit: true,
+    isPaseoOwnedWorktree: false,
+    repoRoot: mainRepoRoot ? WORKTREE_PATH : PROJECT_PATH,
+    mainRepoRoot,
+    currentBranch: mainRepoRoot ? "feature-a" : "main",
+    isDirty: false,
+    baseRef: null,
+    aheadBehind: null,
+    aheadOfOrigin: null,
+    behindOfOrigin: null,
+    hasRemote: false,
+    remoteUrl: null,
+  };
+}
+
+function buildWorkspaceCreatePayload(): WorkspaceCreateResponse["payload"] {
+  return {
+    requestId: "request-worktree",
+    error: null,
+    setupTerminalId: null,
+    workspace: {
+      id: "wks_feature_a",
+      projectId: "project-1",
+      projectDisplayName: "project",
+      projectCustomName: null,
+      projectRootPath: PROJECT_PATH,
+      workspaceDirectory: WORKTREE_PATH,
+      projectKind: "git",
+      workspaceKind: "worktree",
+      name: "feature-a",
+      title: null,
+      archivingAt: null,
+      status: "done",
+      statusEnteredAt: null,
+      activityAt: null,
+      diffStat: null,
+      scripts: [],
+      gitRuntime: null,
+      githubRuntime: null,
+    },
+  };
+}
+
+function createClient(overrides: Partial<TestClient> = {}): TestClient {
+  return {
+    getCheckoutStatus: async () => buildCheckoutStatus(null),
+    createWorkspace: async () => {
+      throw new Error("createWorkspace should not be called");
+    },
+    addProject: async () => ({
+      requestId: "request-1",
+      error: null,
+      project: buildProjectPayload(),
+    }),
+    ...overrides,
+  };
+}
+
 interface RecordedProject {
   serverId: string;
   project: ProjectWithoutWorkspacesDescriptor;
+}
+
+interface RecordedWorkspace {
+  serverId: string;
+  workspaces: WorkspaceDescriptor[];
 }
 
 interface RecordedHydrated {
@@ -26,12 +105,17 @@ interface RecordedHydrated {
 
 function createFakeSession() {
   const projects: RecordedProject[] = [];
+  const workspaces: RecordedWorkspace[] = [];
   const hydrated: RecordedHydrated[] = [];
   return {
     projects,
+    workspaces,
     hydrated,
     addEmptyProject: (serverId: string, project: ProjectWithoutWorkspacesDescriptor) => {
       projects.push({ serverId, project });
+    },
+    mergeWorkspaces: (serverId: string, nextWorkspaces: WorkspaceDescriptor[]) => {
+      workspaces.push({ serverId, workspaces: nextWorkspaces });
     },
     setHasHydratedWorkspaces: (serverId: string, value: boolean) => {
       hydrated.push({ serverId, hydrated: value });
@@ -49,18 +133,19 @@ describe("openProjectDirectly", () => {
       projectPath: PROJECT_PATH,
       isConnected: true,
       canAddProject: true,
-      client: {
+      client: createClient({
         addProject: async () => ({
           requestId: "request-1",
           error: null,
           project: projectPayload,
         }),
-      },
+      }),
       addEmptyProject: session.addEmptyProject,
+      mergeWorkspaces: session.mergeWorkspaces,
       setHasHydratedWorkspaces: session.setHasHydratedWorkspaces,
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({ ok: true, workspaceId: null });
     expect(session.projects).toEqual([
       {
         serverId: SERVER_ID,
@@ -73,6 +158,51 @@ describe("openProjectDirectly", () => {
         },
       },
     ]);
+    expect(session.workspaces).toEqual([]);
+    expect(session.hydrated).toEqual([{ serverId: SERVER_ID, hydrated: true }]);
+  });
+
+  it("opens an existing git worktree as a workspace instead of adding the project again", async () => {
+    const session = createFakeSession();
+    let addProjectCalled = false;
+
+    const result = await openProjectDirectly({
+      serverId: SERVER_ID,
+      projectPath: WORKTREE_PATH,
+      isConnected: true,
+      canAddProject: true,
+      client: createClient({
+        getCheckoutStatus: async () => buildCheckoutStatus(PROJECT_PATH),
+        createWorkspace: async () => buildWorkspaceCreatePayload(),
+        addProject: async () => {
+          addProjectCalled = true;
+          return {
+            requestId: "request-unexpected",
+            error: null,
+            project: buildProjectPayload(),
+          };
+        },
+      }),
+      addEmptyProject: session.addEmptyProject,
+      mergeWorkspaces: session.mergeWorkspaces,
+      setHasHydratedWorkspaces: session.setHasHydratedWorkspaces,
+    });
+
+    expect(result).toEqual({ ok: true, workspaceId: "wks_feature_a" });
+    expect(addProjectCalled).toBe(false);
+    expect(session.projects).toEqual([]);
+    expect(session.workspaces).toEqual([
+      {
+        serverId: SERVER_ID,
+        workspaces: [
+          expect.objectContaining({
+            id: "wks_feature_a",
+            workspaceDirectory: WORKTREE_PATH,
+            workspaceKind: "worktree",
+          }),
+        ],
+      },
+    ]);
     expect(session.hydrated).toEqual([{ serverId: SERVER_ID, hydrated: true }]);
   });
 
@@ -83,14 +213,18 @@ describe("openProjectDirectly", () => {
       projectPath: PROJECT_PATH,
       isConnected: true,
       canAddProject: false,
-      client: {
+      client: createClient({
+        getCheckoutStatus: async () => {
+          throw new Error("getCheckoutStatus should not be called");
+        },
         addProject: async () => ({
           requestId: "request-unsupported",
           error: null,
           project: buildProjectPayload(),
         }),
-      },
+      }),
       addEmptyProject: session.addEmptyProject,
+      mergeWorkspaces: session.mergeWorkspaces,
       setHasHydratedWorkspaces: session.setHasHydratedWorkspaces,
     });
 
@@ -111,15 +245,16 @@ describe("openProjectDirectly", () => {
       projectPath: PROJECT_PATH,
       isConnected: true,
       canAddProject: true,
-      client: {
+      client: createClient({
         addProject: async () => ({
           requestId: "request-2",
           error: "Directory not found: /repo/project",
           errorCode: "directory_not_found" as const,
           project: null,
         }),
-      },
+      }),
       addEmptyProject: session.addEmptyProject,
+      mergeWorkspaces: session.mergeWorkspaces,
       setHasHydratedWorkspaces: session.setHasHydratedWorkspaces,
     });
 

--- a/packages/app/src/hooks/use-open-project.ts
+++ b/packages/app/src/hooks/use-open-project.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { useSessionStore } from "@/stores/session-store";
 import { openProjectDirectly, type OpenProjectResult } from "@/hooks/open-project";
+import { navigateToWorkspace } from "@/stores/navigation-active-workspace-store";
 
 export function useOpenProject(
   serverId: string | null,
@@ -15,6 +16,7 @@ export function useOpenProject(
       : false,
   );
   const addEmptyProject = useSessionStore((state) => state.addEmptyProject);
+  const mergeWorkspaces = useSessionStore((state) => state.mergeWorkspaces);
   const setHasHydratedWorkspaces = useSessionStore((state) => state.setHasHydratedWorkspaces);
 
   return useCallback(
@@ -26,8 +28,12 @@ export function useOpenProject(
         canAddProject,
         client,
         addEmptyProject,
+        mergeWorkspaces,
         setHasHydratedWorkspaces,
       });
+      if (result.ok && result.workspaceId) {
+        navigateToWorkspace(normalizedServerId, result.workspaceId);
+      }
       return result;
     },
     [
@@ -35,6 +41,7 @@ export function useOpenProject(
       canAddProject,
       client,
       isConnected,
+      mergeWorkspaces,
       normalizedServerId,
       setHasHydratedWorkspaces,
     ],


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
-->

### Linked issue

Closes #1797.

<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fixes an Add Project/Open Project no-op when the selected path is an existing external git worktree for a project Paseo already knows about.

Previously, that path could only re-add the parent project, so if the main checkout was already present the selected worktree did not surface as a workspace. The flow now checks whether the selected directory is a concrete git worktree and, when it is, creates a workspace directly from that directory instead of only adding the project parent.

Plain repo roots and non-git directories keep the existing project-add behavior.

### How did you verify it

- Manually reproduced the original failure by opening one worktree from a git repository, then trying to add another existing worktree from the same repository.
- Verified the fix by repeating that flow and confirming the second worktree was added successfully as its own workspace.
- Added coverage in `packages/app/src/hooks/use-open-project.test.ts` for opening an existing git worktree as a workspace instead of adding the project again.
- Ran `npm run test --workspace=@getpaseo/app -- src/hooks/use-open-project.test.ts`.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [ ] UI changes include screenshots or video for every affected platform
  - N/A: no visual UI changes.
- [x] Tests added or updated where it made sense
