### PR TITLE
Keep Pi text-only sessions from bricking on images

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -26,6 +26,8 @@ Pi is a process-backed provider. Paseo requires the user to have the `pi` binary
 
 Paseo's per-agent and daemon-wide system prompts are passed to Pi with `--append-system-prompt`, so Pi keeps its default coding prompt while receiving Paseo's additional instructions.
 
+Pi model records expose input capabilities through `model.input`. Only send raw RPC `images` when the current model explicitly includes `"image"` in that list. Text-only Pi/OMP models reject image content and persist the rejected image in JSONL history, so image prompts for those models must be materialized to a local file and passed as a text path hint instead.
+
 Pi MCP support depends on the open-source `pi-mcp-adapter` extension being loaded for the agent cwd. Probe with Pi RPC `get_commands`; the adapter registers an extension command named `mcp` (often with `sourceInfo.source` containing `pi-mcp-adapter`). When Paseo injects MCP servers into Pi, write a per-agent MCP config and pass it with `--mcp-config` instead of modifying user or project MCP files. For local HTTP servers such as Paseo's own `/mcp/agents` endpoint, explicitly disable adapter OAuth (`auth: false`, `oauth: false`) in the generated config.
 
 Pi import discovery reads Pi's persisted JSONL session files because Pi RPC does not expose a recent-session listing command. Resume and full history hydration still go through `pi --mode rpc` using the session file as `nativeHandle`.

--- a/packages/server/src/server/agent/providers/claude/agent.image-rendering.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.image-rendering.test.ts
@@ -9,6 +9,7 @@ import { ClaudeAgentClient } from "./agent.js";
 
 const ONE_BY_ONE_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X1r0AAAAASUVORK5CYII=";
+const MATERIALIZED_PNG_PATH_PATTERN = /paseo-attachments[\\/](?:[^\\/]+[\\/])?[0-9a-f]{64}\.png$/;
 
 interface ClaudeImageTestSession {
   translateMessageToEvents(message: SDKMessage): AgentStreamEvent[];
@@ -163,12 +164,17 @@ describe("Claude tool_result image rendering", () => {
     const [imageMessage, ...extraImages] = imageMessages(timelineItems);
     expect(extraImages).toEqual([]);
 
-    const source = markdownImageSource(imageMessage);
-    expect(source).toMatch(/paseo-attachments[\\/][0-9a-f]{64}\.png$/);
-    expect(existsSync(source)).toBe(true);
-    expect(JSON.stringify(events)).not.toContain(ONE_BY_ONE_PNG_BASE64);
-
-    rmSync(source, { force: true });
+    let source: string | undefined;
+    try {
+      source = markdownImageSource(imageMessage);
+      expect(source).toMatch(MATERIALIZED_PNG_PATH_PATTERN);
+      expect(existsSync(source)).toBe(true);
+      expect(JSON.stringify(events)).not.toContain(ONE_BY_ONE_PNG_BASE64);
+    } finally {
+      if (source) {
+        rmSync(source, { force: true });
+      }
+    }
   });
 
   test("replays the image as assistant markdown through history conversion", async () => {
@@ -179,12 +185,17 @@ describe("Claude tool_result image rendering", () => {
     const [imageMessage, ...extraImages] = imageMessages(items);
     expect(extraImages).toEqual([]);
 
-    const source = markdownImageSource(imageMessage);
-    expect(source).toMatch(/paseo-attachments[\\/][0-9a-f]{64}\.png$/);
-    expect(existsSync(source)).toBe(true);
-    expect(JSON.stringify(items)).not.toContain(ONE_BY_ONE_PNG_BASE64);
-
-    rmSync(source, { force: true });
+    let source: string | undefined;
+    try {
+      source = markdownImageSource(imageMessage);
+      expect(source).toMatch(MATERIALIZED_PNG_PATH_PATTERN);
+      expect(existsSync(source)).toBe(true);
+      expect(JSON.stringify(items)).not.toContain(ONE_BY_ONE_PNG_BASE64);
+    } finally {
+      if (source) {
+        rmSync(source, { force: true });
+      }
+    }
   });
 
   test("keeps base64 out of an errored tool_result that carries an image", async () => {
@@ -198,12 +209,17 @@ describe("Claude tool_result image rendering", () => {
     const [imageMessage, ...extraImages] = imageMessages(timelineItems);
     expect(extraImages).toEqual([]);
 
-    const source = markdownImageSource(imageMessage);
-    expect(existsSync(source)).toBe(true);
-    expect(JSON.stringify(events)).not.toContain(ONE_BY_ONE_PNG_BASE64);
-    expect(JSON.stringify(events)).toContain("[image]");
-
-    rmSync(source, { force: true });
+    let source: string | undefined;
+    try {
+      source = markdownImageSource(imageMessage);
+      expect(existsSync(source)).toBe(true);
+      expect(JSON.stringify(events)).not.toContain(ONE_BY_ONE_PNG_BASE64);
+      expect(JSON.stringify(events)).toContain("[image]");
+    } finally {
+      if (source) {
+        rmSync(source, { force: true });
+      }
+    }
   });
 
   test("emits one image message per image block in a multi-image tool_result", async () => {
@@ -216,12 +232,16 @@ describe("Claude tool_result image rendering", () => {
       .map((event) => (event as { item: AgentTimelineItem }).item);
     const sources = imageMessages(timelineItems).map(markdownImageSource);
 
-    expect(sources).toHaveLength(2);
-    // Identical bytes materialize to one content-hashed file (idempotent), one message per block.
-    expect(new Set(sources).size).toBe(1);
-    expect(existsSync(sources[0])).toBe(true);
-    expect(JSON.stringify(events)).not.toContain(ONE_BY_ONE_PNG_BASE64);
-
-    rmSync(sources[0], { force: true });
+    try {
+      expect(sources).toHaveLength(2);
+      // Identical bytes materialize to one content-hashed file (idempotent), one message per block.
+      expect(new Set(sources).size).toBe(1);
+      expect(existsSync(sources[0])).toBe(true);
+      expect(JSON.stringify(events)).not.toContain(ONE_BY_ONE_PNG_BASE64);
+    } finally {
+      for (const source of sources) {
+        rmSync(source, { force: true });
+      }
+    }
   });
 });

--- a/packages/server/src/server/agent/providers/claude/agent.image-rendering.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.image-rendering.test.ts
@@ -9,7 +9,8 @@ import { ClaudeAgentClient } from "./agent.js";
 
 const ONE_BY_ONE_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X1r0AAAAASUVORK5CYII=";
-const MATERIALIZED_PNG_PATH_PATTERN = /paseo-attachments[\\/](?:[^\\/]+[\\/])?[0-9a-f]{64}\.png$/;
+const MATERIALIZED_PNG_PATH_PATTERN =
+  /paseo-attachments(?:-[^\\/]+)?[\\/](?:[^\\/]+[\\/])?[0-9a-f]{64}\.png$/;
 
 interface ClaudeImageTestSession {
   translateMessageToEvents(message: SDKMessage): AgentStreamEvent[];

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -2354,7 +2354,7 @@ describe("Codex app-server provider", () => {
     expect(event.item.text).not.toContain("data:image");
     expect(event.item.text).not.toContain(ONE_BY_ONE_PNG_BASE64);
     const source = markdownImageSource(event.item.text);
-    expect(source).toMatch(/paseo-attachments[\\/].+\.png$/);
+    expect(source).toMatch(/paseo-attachments(?:-[^\\/]+)?[\\/].+\.png$/);
     expect(existsSync(source)).toBe(true);
     rmSync(source, { force: true });
   });
@@ -2470,7 +2470,7 @@ describe("Codex app-server provider", () => {
       }
       expect(JSON.stringify(events)).not.toContain(ONE_BY_ONE_PNG_BASE64);
       const source = markdownImageSource(imageEvent.item.text);
-      expect(source).toMatch(/paseo-attachments[\\/].+\.png$/);
+      expect(source).toMatch(/paseo-attachments(?:-[^\\/]+)?[\\/].+\.png$/);
       expect(existsSync(source)).toBe(true);
       rmSync(source, { force: true });
       appServer.assertNoErrors();

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -687,7 +687,9 @@ describe("PiRpcAgentSession", () => {
       expect(prompt.message).not.toContain(ONE_BY_ONE_PNG_BASE64);
       imagePath = prompt.message.match(/\[Image available at: (.+)\]/)?.[1];
       expect(imagePath).toBeTypeOf("string");
-      expect(imagePath).toMatch(/paseo-attachments[\\/].+[\\/][0-9a-f]{64}\.png$/);
+      expect(imagePath).toMatch(
+        /paseo-attachments(?:-[^\\/]+)?[\\/](?:[^\\/]+[\\/])?[0-9a-f]{64}\.png$/,
+      );
       expect(existsSync(imagePath!)).toBe(true);
     } finally {
       if (imagePath) {

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -678,16 +678,47 @@ describe("PiRpcAgentSession", () => {
       { type: "image", data: ONE_BY_ONE_PNG_BASE64, mimeType: "image/png" },
     ]);
 
-    expect(fakeSession.prompts).toHaveLength(1);
-    const prompt = fakeSession.prompts[0]!;
-    expect(prompt.imageCount).toBe(0);
-    expect(prompt.message).toContain("Describe this image.");
-    expect(prompt.message).not.toContain(ONE_BY_ONE_PNG_BASE64);
-    const imagePath = prompt.message.match(/\[Image available at: (.+)\]/)?.[1];
-    expect(imagePath).toBeTypeOf("string");
-    expect(imagePath).toMatch(/paseo-attachments[\\/][0-9a-f]{64}\.png$/);
-    expect(existsSync(imagePath!)).toBe(true);
-    rmSync(imagePath!, { force: true });
+    let imagePath: string | undefined;
+    try {
+      expect(fakeSession.prompts).toHaveLength(1);
+      const prompt = fakeSession.prompts[0]!;
+      expect(prompt.imageCount).toBe(0);
+      expect(prompt.message).toContain("Describe this image.");
+      expect(prompt.message).not.toContain(ONE_BY_ONE_PNG_BASE64);
+      imagePath = prompt.message.match(/\[Image available at: (.+)\]/)?.[1];
+      expect(imagePath).toBeTypeOf("string");
+      expect(imagePath).toMatch(/paseo-attachments[\\/].+[\\/][0-9a-f]{64}\.png$/);
+      expect(existsSync(imagePath!)).toBe(true);
+    } finally {
+      if (imagePath) {
+        rmSync(imagePath, { force: true });
+      }
+    }
+  });
+
+  test("materializes image prompts when Pi model capabilities are unknown", async () => {
+    const { pi, session } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn([
+      { type: "text", text: "Describe this image." },
+      { type: "image", data: ONE_BY_ONE_PNG_BASE64, mimeType: "image/png" },
+    ]);
+
+    let imagePath: string | undefined;
+    try {
+      expect(fakeSession.prompts).toHaveLength(1);
+      const prompt = fakeSession.prompts[0]!;
+      expect(prompt.imageCount).toBe(0);
+      expect(prompt.message).toContain("Describe this image.");
+      imagePath = prompt.message.match(/\[Image available at: (.+)\]/)?.[1];
+      expect(imagePath).toBeTypeOf("string");
+      expect(existsSync(imagePath!)).toBe(true);
+    } finally {
+      if (imagePath) {
+        rmSync(imagePath, { force: true });
+      }
+    }
   });
 
   test("forwards raw image prompts for vision-capable Pi models", async () => {

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -6,6 +6,7 @@ import {
   mkdtempSync,
   openSync,
   readSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -16,6 +17,9 @@ import { describe, expect, test } from "vitest";
 import type { AgentSession, AgentSessionConfig, AgentStreamEvent } from "../../agent-sdk-types.js";
 import { PiRpcAgentClient, PiRpcAgentSession, transformPiModels } from "./agent.js";
 import { FakePi } from "./test-utils/fake-pi.js";
+
+const ONE_BY_ONE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
 function createClient(pi = new FakePi()): PiRpcAgentClient {
   return new PiRpcAgentClient({
@@ -656,6 +660,58 @@ describe("PiRpcAgentSession", () => {
 
     expect(fakeSession.setModelRequests).toEqual([{ provider: "openrouter", modelId: "model-a" }]);
     expect(fakeSession.setThinkingLevelRequests).toEqual(["high"]);
+  });
+
+  test("materializes image prompts as text hints for text-only Pi models", async () => {
+    const { pi, session } = await createSession();
+    const fakeSession = pi.latestSession();
+    fakeSession.setModelResult = {
+      provider: "openrouter",
+      id: "openai/gpt-oss-20b:free",
+      name: "OpenAI: gpt-oss-20b (free)",
+      input: ["text"],
+    };
+
+    await session.setModel("openrouter/openai/gpt-oss-20b:free");
+    await session.startTurn([
+      { type: "text", text: "Describe this image." },
+      { type: "image", data: ONE_BY_ONE_PNG_BASE64, mimeType: "image/png" },
+    ]);
+
+    expect(fakeSession.prompts).toHaveLength(1);
+    const prompt = fakeSession.prompts[0]!;
+    expect(prompt.imageCount).toBe(0);
+    expect(prompt.message).toContain("Describe this image.");
+    expect(prompt.message).not.toContain(ONE_BY_ONE_PNG_BASE64);
+    const imagePath = prompt.message.match(/\[Image available at: (.+)\]/)?.[1];
+    expect(imagePath).toBeTypeOf("string");
+    expect(imagePath).toMatch(/paseo-attachments[\\/][0-9a-f]{64}\.png$/);
+    expect(existsSync(imagePath!)).toBe(true);
+    rmSync(imagePath!, { force: true });
+  });
+
+  test("forwards raw image prompts for vision-capable Pi models", async () => {
+    const { pi, session } = await createSession();
+    const fakeSession = pi.latestSession();
+    fakeSession.setModelResult = {
+      provider: "openai",
+      id: "gpt-4o",
+      name: "GPT-4o",
+      input: ["text", "image"],
+    };
+
+    await session.setModel("openai/gpt-4o");
+    await session.startTurn([
+      { type: "text", text: "Describe this image." },
+      { type: "image", data: ONE_BY_ONE_PNG_BASE64, mimeType: "image/png" },
+    ]);
+
+    expect(fakeSession.prompts).toEqual([
+      {
+        message: "Describe this image.",
+        imageCount: 1,
+      },
+    ]);
   });
 
   test("fails the active turn when the Pi process exits mid-turn", async () => {

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -56,6 +56,7 @@ import {
   streamPiHistory,
   type PiCapturedUserMessageEntry,
 } from "./history-mapper.js";
+import { materializeProviderImage } from "../provider-image-output.js";
 import { PiCliRuntime } from "./cli-runtime.js";
 import { revertPiConversation } from "./rewind.js";
 import { listPiImportableSessions, readPiImportSessionConfig } from "./session-descriptor.js";
@@ -362,13 +363,33 @@ function toAgentUsage(stats: PiSessionStats): AgentUsage | undefined {
   };
 }
 
-function convertPromptInput(prompt: AgentPromptInput): PiPromptPayload {
+function piModelSupportsImageInput(model: PiModel | null | undefined): boolean {
+  return model?.input === undefined || model.input.includes("image");
+}
+
+function renderTextOnlyImageHint(image: { data: string; mimeType: string }): string {
+  try {
+    const materialized = materializeProviderImage({
+      data: image.data,
+      mimeType: image.mimeType,
+    });
+    return `[Image available at: ${materialized.path}]`;
+  } catch (error) {
+    return `[Image attachment omitted: failed to write local file (${toDiagnosticErrorMessage(error)})]`;
+  }
+}
+
+function convertPromptInput(
+  prompt: AgentPromptInput,
+  options: { model: PiModel | null | undefined },
+): PiPromptPayload {
   if (typeof prompt === "string") {
     return { text: prompt };
   }
 
   const textParts: string[] = [];
   const images: PiImageContent[] = [];
+  const forwardImages = piModelSupportsImageInput(options.model);
 
   for (const block of prompt) {
     if (block.type === "text") {
@@ -377,11 +398,15 @@ function convertPromptInput(prompt: AgentPromptInput): PiPromptPayload {
     }
 
     if (block.type === "image") {
-      images.push({
-        type: "image",
-        data: block.data,
-        mimeType: block.mimeType,
-      });
+      if (forwardImages) {
+        images.push({
+          type: "image",
+          data: block.data,
+          mimeType: block.mimeType,
+        });
+      } else {
+        textParts.push(renderTextOnlyImageHint(block));
+      }
       continue;
     }
 
@@ -1046,7 +1071,7 @@ export class PiRpcAgentSession implements AgentSession {
       throw new Error("A Pi turn is already active");
     }
 
-    const payload = convertPromptInput(prompt);
+    const payload = convertPromptInput(prompt, { model: this.state.model });
     const turnId = randomUUID();
     this.activeTurnId = turnId;
 

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -364,7 +364,7 @@ function toAgentUsage(stats: PiSessionStats): AgentUsage | undefined {
 }
 
 function piModelSupportsImageInput(model: PiModel | null | undefined): boolean {
-  return model?.input === undefined || model.input.includes("image");
+  return model?.input?.includes("image") === true;
 }
 
 function renderTextOnlyImageHint(image: { data: string; mimeType: string }): string {

--- a/packages/server/src/server/agent/providers/provider-image-output.posix.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.posix.test.ts
@@ -1,0 +1,25 @@
+import { existsSync, rmSync, statSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { materializeProviderImage } from "./provider-image-output.js";
+
+describe("materializeProviderImage", () => {
+  test("writes image attachments under a private user temp directory", () => {
+    const materialized = materializeProviderImage({
+      data: "YWJjMTIz",
+      mimeType: "image/png",
+    });
+
+    try {
+      const attachmentDir = path.dirname(materialized.path);
+      expect(path.basename(path.dirname(attachmentDir))).toBe("paseo-attachments");
+      expect(path.basename(attachmentDir)).toMatch(/^user-/);
+      expect(existsSync(materialized.path)).toBe(true);
+      expect(statSync(attachmentDir).mode & 0o777).toBe(0o700);
+      expect(statSync(materialized.path).mode & 0o777).toBe(0o600);
+    } finally {
+      rmSync(materialized.path, { force: true });
+    }
+  });
+});

--- a/packages/server/src/server/agent/providers/provider-image-output.posix.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.posix.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from "vitest";
 import { materializeProviderImage } from "./provider-image-output.js";
 
 describe.skipIf(process.platform === "win32")("materializeProviderImage", () => {
-  test("writes image attachments under a private user temp directory", () => {
+  test("writes image attachments under a private temp directory", () => {
     const materialized = materializeProviderImage({
       data: "YWJjMTIz",
       mimeType: "image/png",
@@ -13,11 +13,8 @@ describe.skipIf(process.platform === "win32")("materializeProviderImage", () => 
 
     try {
       const attachmentDir = path.dirname(materialized.path);
-      const attachmentParentDir = path.dirname(attachmentDir);
-      expect(path.basename(path.dirname(attachmentDir))).toBe("paseo-attachments");
-      expect(path.basename(attachmentDir)).toMatch(/^user-/);
+      expect(path.basename(attachmentDir)).toMatch(/^paseo-attachments-/);
       expect(existsSync(materialized.path)).toBe(true);
-      expect(statSync(attachmentParentDir).mode & 0o7777).toBe(0o1777);
       expect(statSync(attachmentDir).mode & 0o777).toBe(0o700);
       expect(statSync(materialized.path).mode & 0o777).toBe(0o600);
     } finally {

--- a/packages/server/src/server/agent/providers/provider-image-output.posix.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.posix.test.ts
@@ -10,15 +10,15 @@ describe.skipIf(process.platform === "win32")("materializeProviderImage", () => 
       data: "YWJjMTIz",
       mimeType: "image/png",
     });
+    const attachmentDir = path.dirname(materialized.path);
 
     try {
-      const attachmentDir = path.dirname(materialized.path);
       expect(path.basename(attachmentDir)).toMatch(/^paseo-attachments-/);
       expect(existsSync(materialized.path)).toBe(true);
       expect(statSync(attachmentDir).mode & 0o777).toBe(0o700);
       expect(statSync(materialized.path).mode & 0o777).toBe(0o600);
     } finally {
-      rmSync(materialized.path, { force: true });
+      rmSync(attachmentDir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/server/src/server/agent/providers/provider-image-output.posix.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.posix.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 
 import { materializeProviderImage } from "./provider-image-output.js";
 
-describe("materializeProviderImage", () => {
+describe.skipIf(process.platform === "win32")("materializeProviderImage", () => {
   test("writes image attachments under a private user temp directory", () => {
     const materialized = materializeProviderImage({
       data: "YWJjMTIz",
@@ -13,9 +13,11 @@ describe("materializeProviderImage", () => {
 
     try {
       const attachmentDir = path.dirname(materialized.path);
+      const attachmentParentDir = path.dirname(attachmentDir);
       expect(path.basename(path.dirname(attachmentDir))).toBe("paseo-attachments");
       expect(path.basename(attachmentDir)).toMatch(/^user-/);
       expect(existsSync(materialized.path)).toBe(true);
+      expect(statSync(attachmentParentDir).mode & 0o7777).toBe(0o1777);
       expect(statSync(attachmentDir).mode & 0o777).toBe(0o700);
       expect(statSync(materialized.path).mode & 0o777).toBe(0o600);
     } finally {

--- a/packages/server/src/server/agent/providers/provider-image-output.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.test.ts
@@ -18,6 +18,9 @@ function renderImageMarkdown(path: string): string {
 describe("isProviderImageMarkdown", () => {
   test("matches the markdown emitted for a materialized attachment", () => {
     expect(isProviderImageMarkdown(`![Image](/tmp/paseo-attachments/${HASH}.png)`)).toBe(true);
+    expect(isProviderImageMarkdown(`![Image](/tmp/paseo-attachments/user-1000/${HASH}.png)`)).toBe(
+      true,
+    );
     expect(isProviderImageMarkdown(`![shot](/var/folders/x/paseo-attachments/${HASH}.webp)`)).toBe(
       true,
     );

--- a/packages/server/src/server/agent/providers/provider-image-output.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.test.ts
@@ -18,6 +18,9 @@ function renderImageMarkdown(path: string): string {
 describe("isProviderImageMarkdown", () => {
   test("matches the markdown emitted for a materialized attachment", () => {
     expect(isProviderImageMarkdown(`![Image](/tmp/paseo-attachments/${HASH}.png)`)).toBe(true);
+    expect(isProviderImageMarkdown(`![Image](/tmp/paseo-attachments-a1B2c3/${HASH}.png)`)).toBe(
+      true,
+    );
     expect(isProviderImageMarkdown(`![Image](/tmp/paseo-attachments/user-1000/${HASH}.png)`)).toBe(
       true,
     );

--- a/packages/server/src/server/agent/providers/provider-image-output.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.test.ts
@@ -1,14 +1,17 @@
+import { existsSync, rmSync } from "node:fs";
+import path from "node:path";
 import { describe, expect, test } from "vitest";
 
 import {
   isProviderImageMarkdown,
+  materializeProviderImage,
   renderProviderImageOutputAsAssistantMarkdown,
 } from "./provider-image-output.js";
 
 const HASH = "a".repeat(64);
 
-function renderImageMarkdown(path: string): string {
-  const item = renderProviderImageOutputAsAssistantMarkdown({ path });
+function renderImageMarkdown(imagePath: string): string {
+  const item = renderProviderImageOutputAsAssistantMarkdown({ path: imagePath });
   if (!item || item.type !== "assistant_message") {
     throw new Error("Expected provider image output to render as assistant markdown.");
   }
@@ -52,5 +55,30 @@ describe("isProviderImageMarkdown", () => {
     expect(isProviderImageMarkdown("![logo](https://example.com/logo.png)")).toBe(false);
     // Image markdown that does not start the text.
     expect(isProviderImageMarkdown("see the chart: ![chart](x.png)")).toBe(false);
+  });
+});
+
+describe("materializeProviderImage", () => {
+  test("recreates the private temp directory if the cached directory is removed", () => {
+    const first = materializeProviderImage({
+      data: "YWJjMTIz",
+      mimeType: "image/png",
+    });
+    const firstDir = path.dirname(first.path);
+    expect(existsSync(first.path)).toBe(true);
+
+    rmSync(firstDir, { recursive: true, force: true });
+
+    const second = materializeProviderImage({
+      data: "ZGVmNDU2",
+      mimeType: "image/png",
+    });
+    const secondDir = path.dirname(second.path);
+
+    try {
+      expect(existsSync(second.path)).toBe(true);
+    } finally {
+      rmSync(secondDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/server/src/server/agent/providers/provider-image-output.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.ts
@@ -19,6 +19,15 @@ export interface MaterializedProviderImage {
 
 const PROVIDER_IMAGE_ATTACHMENT_DIR = "paseo-attachments";
 
+function currentUserAttachmentDirName(): string {
+  const uid = process.getuid?.();
+  if (typeof uid === "number") {
+    return `user-${uid}`;
+  }
+  const username = os.userInfo().username;
+  return `user-${createHash("sha256").update(username).digest("hex").slice(0, 12)}`;
+}
+
 function getImageExtension(mimeType: string): string {
   switch (mimeType) {
     case "image/jpeg":
@@ -55,14 +64,18 @@ export function materializeProviderImage(image: {
   data: string;
   mimeType: string | null;
 }): MaterializedProviderImage {
-  const attachmentsDir = path.join(os.tmpdir(), PROVIDER_IMAGE_ATTACHMENT_DIR);
-  fsSync.mkdirSync(attachmentsDir, { recursive: true });
+  const attachmentsParentDir = path.join(os.tmpdir(), PROVIDER_IMAGE_ATTACHMENT_DIR);
+  fsSync.mkdirSync(attachmentsParentDir, { recursive: true });
+  const attachmentsDir = path.join(attachmentsParentDir, currentUserAttachmentDirName());
+  fsSync.mkdirSync(attachmentsDir, { recursive: true, mode: 0o700 });
+  fsSync.chmodSync(attachmentsDir, 0o700);
   const normalized = normalizeImageData(image.mimeType ?? "image/png", image.data);
   const bytes = Buffer.from(normalized.data, "base64");
   const extension = getImageExtension(normalized.mimeType);
   const hash = createHash("sha256").update(bytes).digest("hex");
   const filePath = path.join(attachmentsDir, `${hash}.${extension}`);
-  fsSync.writeFileSync(filePath, bytes);
+  fsSync.writeFileSync(filePath, bytes, { mode: 0o600 });
+  fsSync.chmodSync(filePath, 0o600);
   return { path: filePath };
 }
 
@@ -71,7 +84,7 @@ export function materializeProviderImage(image: {
 // keeps user-authored text from being mistaken for a provider image during history replay. The
 // separator still accepts old doubled-backslash Windows history; new Windows output uses file URIs.
 const PROVIDER_IMAGE_MARKDOWN = new RegExp(
-  `^!\\[[^\\]]*\\]\\([^)]*${PROVIDER_IMAGE_ATTACHMENT_DIR}[/\\\\]+[0-9a-f]{64}\\.[a-z0-9]+\\)`,
+  `^!\\[[^\\]]*\\]\\([^)]*${PROVIDER_IMAGE_ATTACHMENT_DIR}[/\\\\]+(?:[^/\\\\)]+[/\\\\]+)?[0-9a-f]{64}\\.[a-z0-9]+\\)`,
 );
 
 export function isProviderImageMarkdown(text: string): boolean {

--- a/packages/server/src/server/agent/providers/provider-image-output.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.ts
@@ -24,8 +24,24 @@ const MATERIALIZED_IMAGE_FILE_MODE = 0o600;
 
 let materializedImageAttachmentDir: string | null = null;
 
+function canReuseMaterializedImageAttachmentDir(dir: string): boolean {
+  try {
+    const stats = fsSync.lstatSync(dir);
+    if (!stats.isDirectory()) {
+      return false;
+    }
+    fsSync.chmodSync(dir, PRIVATE_ATTACHMENT_DIR_MODE);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function getMaterializedImageAttachmentDir(): string {
-  if (materializedImageAttachmentDir) {
+  if (
+    materializedImageAttachmentDir &&
+    canReuseMaterializedImageAttachmentDir(materializedImageAttachmentDir)
+  ) {
     return materializedImageAttachmentDir;
   }
 

--- a/packages/server/src/server/agent/providers/provider-image-output.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.ts
@@ -18,17 +18,22 @@ export interface MaterializedProviderImage {
 }
 
 const PROVIDER_IMAGE_ATTACHMENT_DIR = "paseo-attachments";
-const SHARED_ATTACHMENT_DIR_MODE = 0o1777;
-const USER_ATTACHMENT_DIR_MODE = 0o700;
+const PROVIDER_IMAGE_ATTACHMENT_DIR_PREFIX = `${PROVIDER_IMAGE_ATTACHMENT_DIR}-`;
+const PRIVATE_ATTACHMENT_DIR_MODE = 0o700;
 const MATERIALIZED_IMAGE_FILE_MODE = 0o600;
 
-function currentUserAttachmentDirName(): string {
-  const uid = process.getuid?.();
-  if (typeof uid === "number") {
-    return `user-${uid}`;
+let materializedImageAttachmentDir: string | null = null;
+
+function getMaterializedImageAttachmentDir(): string {
+  if (materializedImageAttachmentDir) {
+    return materializedImageAttachmentDir;
   }
-  const username = os.userInfo().username;
-  return `user-${createHash("sha256").update(username).digest("hex").slice(0, 12)}`;
+
+  materializedImageAttachmentDir = fsSync.mkdtempSync(
+    path.join(os.tmpdir(), PROVIDER_IMAGE_ATTACHMENT_DIR_PREFIX),
+  );
+  fsSync.chmodSync(materializedImageAttachmentDir, PRIVATE_ATTACHMENT_DIR_MODE);
+  return materializedImageAttachmentDir;
 }
 
 function getImageExtension(mimeType: string): string {
@@ -61,20 +66,13 @@ function normalizeImageData(mimeType: string, data: string): { mimeType: string;
 }
 
 // Filenames are a content hash of the bytes so re-materializing the same image
-// is idempotent: history replay reuses the existing temp file instead of leaking
-// a fresh one on every load.
+// within a process reuses the existing temp file instead of leaking a fresh one
+// for repeated image blocks or history replay.
 export function materializeProviderImage(image: {
   data: string;
   mimeType: string | null;
 }): MaterializedProviderImage {
-  const attachmentsParentDir = path.join(os.tmpdir(), PROVIDER_IMAGE_ATTACHMENT_DIR);
-  fsSync.mkdirSync(attachmentsParentDir, { recursive: true, mode: SHARED_ATTACHMENT_DIR_MODE });
-  if (process.platform !== "win32") {
-    fsSync.chmodSync(attachmentsParentDir, SHARED_ATTACHMENT_DIR_MODE);
-  }
-  const attachmentsDir = path.join(attachmentsParentDir, currentUserAttachmentDirName());
-  fsSync.mkdirSync(attachmentsDir, { recursive: true, mode: USER_ATTACHMENT_DIR_MODE });
-  fsSync.chmodSync(attachmentsDir, USER_ATTACHMENT_DIR_MODE);
+  const attachmentsDir = getMaterializedImageAttachmentDir();
   const normalized = normalizeImageData(image.mimeType ?? "image/png", image.data);
   const bytes = Buffer.from(normalized.data, "base64");
   const extension = getImageExtension(normalized.mimeType);
@@ -90,7 +88,7 @@ export function materializeProviderImage(image: {
 // keeps user-authored text from being mistaken for a provider image during history replay. The
 // separator still accepts old doubled-backslash Windows history; new Windows output uses file URIs.
 const PROVIDER_IMAGE_MARKDOWN = new RegExp(
-  `^!\\[[^\\]]*\\]\\([^)]*${PROVIDER_IMAGE_ATTACHMENT_DIR}[/\\\\]+(?:[^/\\\\)]+[/\\\\]+)?[0-9a-f]{64}\\.[a-z0-9]+\\)`,
+  `^!\\[[^\\]]*\\]\\([^)]*${PROVIDER_IMAGE_ATTACHMENT_DIR}(?:-[^/\\\\)]+)?[/\\\\]+(?:[^/\\\\)]+[/\\\\]+)?[0-9a-f]{64}\\.[a-z0-9]+\\)`,
 );
 
 export function isProviderImageMarkdown(text: string): boolean {

--- a/packages/server/src/server/agent/providers/provider-image-output.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.ts
@@ -18,6 +18,9 @@ export interface MaterializedProviderImage {
 }
 
 const PROVIDER_IMAGE_ATTACHMENT_DIR = "paseo-attachments";
+const SHARED_ATTACHMENT_DIR_MODE = 0o1777;
+const USER_ATTACHMENT_DIR_MODE = 0o700;
+const MATERIALIZED_IMAGE_FILE_MODE = 0o600;
 
 function currentUserAttachmentDirName(): string {
   const uid = process.getuid?.();
@@ -65,17 +68,20 @@ export function materializeProviderImage(image: {
   mimeType: string | null;
 }): MaterializedProviderImage {
   const attachmentsParentDir = path.join(os.tmpdir(), PROVIDER_IMAGE_ATTACHMENT_DIR);
-  fsSync.mkdirSync(attachmentsParentDir, { recursive: true });
+  fsSync.mkdirSync(attachmentsParentDir, { recursive: true, mode: SHARED_ATTACHMENT_DIR_MODE });
+  if (process.platform !== "win32") {
+    fsSync.chmodSync(attachmentsParentDir, SHARED_ATTACHMENT_DIR_MODE);
+  }
   const attachmentsDir = path.join(attachmentsParentDir, currentUserAttachmentDirName());
-  fsSync.mkdirSync(attachmentsDir, { recursive: true, mode: 0o700 });
-  fsSync.chmodSync(attachmentsDir, 0o700);
+  fsSync.mkdirSync(attachmentsDir, { recursive: true, mode: USER_ATTACHMENT_DIR_MODE });
+  fsSync.chmodSync(attachmentsDir, USER_ATTACHMENT_DIR_MODE);
   const normalized = normalizeImageData(image.mimeType ?? "image/png", image.data);
   const bytes = Buffer.from(normalized.data, "base64");
   const extension = getImageExtension(normalized.mimeType);
   const hash = createHash("sha256").update(bytes).digest("hex");
   const filePath = path.join(attachmentsDir, `${hash}.${extension}`);
-  fsSync.writeFileSync(filePath, bytes, { mode: 0o600 });
-  fsSync.chmodSync(filePath, 0o600);
+  fsSync.writeFileSync(filePath, bytes, { mode: MATERIALIZED_IMAGE_FILE_MODE });
+  fsSync.chmodSync(filePath, MATERIALIZED_IMAGE_FILE_MODE);
   return { path: filePath };
 }
 


### PR DESCRIPTION
### Linked issue

Closes #1930

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Pi now checks the current model's declared `input` capabilities before sending image prompt blocks to the RPC process. Raw `images` are only forwarded when the model explicitly declares image input; text-only or unknown-capability models get a local materialized image path in the prompt text so Pi does not persist rejected image blocks into the session JSONL.

Materialized image files now live under a private per-user temp subdirectory with restrictive file modes. This also documents the Pi/OMP provider invariant so future provider work keeps image forwarding tied to `model.input`.

### How did you verify it

- Reproduced the adapter bug red with `npx vitest run packages/server/src/server/agent/providers/pi/agent.test.ts --bail=1`: the new text-only model regression failed because the fake Pi runtime received `imageCount: 1`.
- Confirmed the first fix green with `npx vitest run packages/server/src/server/agent/providers/pi/agent.test.ts --bail=1`: 36 tests passed.
- Confirmed the review fixes green with `npx vitest run packages/server/src/server/agent/providers/pi/agent.test.ts packages/server/src/server/agent/providers/provider-image-output.test.ts packages/server/src/server/agent/providers/provider-image-output.posix.test.ts --bail=1`: 41 tests passed.
- Probed real `pi --mode rpc` 0.65.2 in a temp cwd. The local provider auth failed with `401 User not found` before the reported upstream `invalid_argument`, but the live Pi session JSONL showed the dangerous pre-fix behavior: a text-only model session persisted the raw `{ type: "image", data, mimeType }` user content.
- `npm run format`
- `npm run lint`
- `npm run typecheck --workspace=@getpaseo/server` is blocked in this checkout by missing dependencies/generated declarations, including `@opencode-ai/sdk`, generated protocol modules, `openai`, and stale generated protocol types. The full root `npm run typecheck` is additionally blocked by `expo-module-scripts/tsconfig.base` and missing `zod-aot`.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [ ] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A, no UI changes)
- [x] Tests added or updated where it made sense
