### PR TITLE
Recover daemon startup from stale PID locks

### DIFF
--- a/packages/server/src/server/pid-lock.test.ts
+++ b/packages/server/src/server/pid-lock.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
@@ -55,7 +55,6 @@ describe("pid-lock ownership", () => {
     const replacementOwnerPid = process.pid + 10_000;
 
     try {
-      await mkdir(paseoHome, { recursive: true });
       await writeFile(
         join(paseoHome, "paseo.pid"),
         JSON.stringify({

--- a/packages/server/src/server/pid-lock.test.ts
+++ b/packages/server/src/server/pid-lock.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
@@ -45,6 +45,34 @@ describe("pid-lock ownership", () => {
       )(paseoHome, { ownerPid });
       const lockAfterOwnerRelease = await getPidLockInfo(paseoHome);
       expect(lockAfterOwnerRelease).toBeNull();
+    } finally {
+      await rm(paseoHome, { recursive: true, force: true });
+    }
+  });
+
+  test("reclaims a stale lock when the recorded pid belongs to a different process", async () => {
+    const paseoHome = await mkdtemp(join(tmpdir(), "paseo-pid-lock-reused-"));
+    const replacementOwnerPid = process.pid + 10_000;
+
+    try {
+      await mkdir(paseoHome, { recursive: true });
+      await writeFile(
+        join(paseoHome, "paseo.pid"),
+        JSON.stringify({
+          pid: process.pid,
+          startedAt: "2026-01-01T00:00:00.000Z",
+          hostname: "old-host",
+          uid: process.getuid?.() ?? 0,
+          listen: "127.0.0.1:6767",
+          desktopManaged: true,
+        }),
+      );
+
+      await acquirePidLock(paseoHome, null, { ownerPid: replacementOwnerPid });
+
+      const lock = await getPidLockInfo(paseoHome);
+      expect(lock?.pid).toBe(replacementOwnerPid);
+      expect(lock?.listen).toBeNull();
     } finally {
       await rm(paseoHome, { recursive: true, force: true });
     }

--- a/packages/server/src/server/pid-lock.ts
+++ b/packages/server/src/server/pid-lock.ts
@@ -37,6 +37,7 @@ export class PidLockError extends Error {
 
 const PROCESS_START_SKEW_TOLERANCE_MS = 60_000;
 const PROCESS_LOCK_ACQUIRE_TOLERANCE_MS = 5 * 60_000;
+const POSIX_PROCESS_TIME_ENV = { ...process.env, LC_ALL: "C", LANG: "C" };
 let cachedClockTicksPerSecond: number | null = null;
 
 function isPidRunning(pid: number): boolean {
@@ -96,6 +97,7 @@ function readPsProcessStartedAtMs(pid: number): number | null {
   try {
     const output = execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
       encoding: "utf8",
+      env: POSIX_PROCESS_TIME_ENV,
       timeout: 1000,
     }).trim();
     const parsed = Date.parse(output);

--- a/packages/server/src/server/pid-lock.ts
+++ b/packages/server/src/server/pid-lock.ts
@@ -1,5 +1,6 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { open, readFile, unlink, mkdir } from "node:fs/promises";
-import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { hostname } from "node:os";
 import { z } from "zod";
@@ -34,6 +35,10 @@ export class PidLockError extends Error {
   }
 }
 
+const PROCESS_START_SKEW_TOLERANCE_MS = 60_000;
+const PROCESS_LOCK_ACQUIRE_TOLERANCE_MS = 5 * 60_000;
+let cachedClockTicksPerSecond: number | null = null;
+
 function isPidRunning(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -41,6 +46,125 @@ function isPidRunning(pid: number): boolean {
   } catch {
     return false;
   }
+}
+
+function readClockTicksPerSecond(): number {
+  if (cachedClockTicksPerSecond !== null) {
+    return cachedClockTicksPerSecond;
+  }
+
+  try {
+    const output = execFileSync("getconf", ["CLK_TCK"], {
+      encoding: "utf8",
+      timeout: 1000,
+    }).trim();
+    const value = Number(output);
+    cachedClockTicksPerSecond = Number.isFinite(value) && value > 0 ? value : 100;
+  } catch {
+    cachedClockTicksPerSecond = 100;
+  }
+
+  return cachedClockTicksPerSecond;
+}
+
+function readLinuxProcessStartedAtMs(pid: number): number | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const closeParen = stat.lastIndexOf(")");
+    if (closeParen === -1) return null;
+
+    const fieldsAfterCommand = stat
+      .slice(closeParen + 2)
+      .trim()
+      .split(/\s+/);
+    const startTicks = Number(fieldsAfterCommand[19]);
+    if (!Number.isFinite(startTicks)) return null;
+
+    const bootTimeLine = readFileSync("/proc/stat", "utf8")
+      .split("\n")
+      .find((line) => line.startsWith("btime "));
+    const bootSeconds = Number(bootTimeLine?.trim().split(/\s+/)[1]);
+    if (!Number.isFinite(bootSeconds)) return null;
+
+    return bootSeconds * 1000 + (startTicks / readClockTicksPerSecond()) * 1000;
+  } catch {
+    return null;
+  }
+}
+
+function readPsProcessStartedAtMs(pid: number): number | null {
+  try {
+    const output = execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
+      encoding: "utf8",
+      timeout: 1000,
+    }).trim();
+    const parsed = Date.parse(output);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function readWindowsProcessStartedAtMs(pid: number): number | null {
+  try {
+    const command = [
+      `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"`,
+      'if ($p) { $p.CreationDate.ToUniversalTime().ToString("o") }',
+    ].join("; ");
+    const output = execFileSync(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", command],
+      {
+        encoding: "utf8",
+        timeout: 3000,
+      },
+    ).trim();
+    const parsed = Date.parse(output);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function readProcessStartedAtMs(pid: number): number | null {
+  if (process.platform === "linux") {
+    return readLinuxProcessStartedAtMs(pid) ?? readPsProcessStartedAtMs(pid);
+  }
+  if (process.platform === "win32") {
+    return readWindowsProcessStartedAtMs(pid);
+  }
+  return readPsProcessStartedAtMs(pid);
+}
+
+function lockMatchesLiveProcessIdentity(lock: PidLockInfo): boolean {
+  const lockStartedAtMs = Date.parse(lock.startedAt);
+  if (!Number.isFinite(lockStartedAtMs)) {
+    return false;
+  }
+
+  const processStartedAtMs = readProcessStartedAtMs(lock.pid);
+  if (processStartedAtMs === null) {
+    return true;
+  }
+
+  if (processStartedAtMs - lockStartedAtMs > PROCESS_START_SKEW_TOLERANCE_MS) {
+    return false;
+  }
+  if (lockStartedAtMs - processStartedAtMs > PROCESS_LOCK_ACQUIRE_TOLERANCE_MS) {
+    return false;
+  }
+
+  return true;
+}
+
+function isPidLockOwnerRunning(lock: PidLockInfo): boolean {
+  if (!isPidRunning(lock.pid)) {
+    return false;
+  }
+
+  // PIDs can be reused after an unclean daemon exit. Treat a live PID as the
+  // lock owner only when its process start time still lines up with the lock.
+  return lockMatchesLiveProcessIdentity(lock);
 }
 
 function getPidFilePath(paseoHome: string): string {
@@ -78,7 +202,7 @@ export async function acquirePidLock(
   // Check if existing lock is stale
   const lockOwnerPid = resolveOwnerPid(options?.ownerPid);
   if (existingLock) {
-    if (isPidRunning(existingLock.pid)) {
+    if (isPidLockOwnerRunning(existingLock)) {
       if (existingLock.pid === lockOwnerPid) {
         return;
       }
@@ -197,7 +321,7 @@ export async function isLocked(
   if (!info) {
     return { locked: false };
   }
-  if (!isPidRunning(info.pid)) {
+  if (!isPidLockOwnerRunning(info)) {
     return { locked: false, info };
   }
   return { locked: true, info };


### PR DESCRIPTION
### Linked issue

Closes #1950
Refs #1904

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Desktop daemon startup can fail with `Daemon failed to start: exit code 1` when `~/.paseo/paseo.pid` is left behind and the recorded PID now belongs to a different live process. The launcher only saw that a process with that PID existed, so it refused to replace the stale singleton lock and exited before the daemon worker could start.

This verifies the lock owner by comparing the live process start time with the lock's `startedAt` timestamp before treating the PID as authoritative. If the PID has been reused, the stale lock is reclaimed and startup proceeds normally. A regression test covers the reused-PID stale-lock case.

### How did you verify it

- Reproduced the reported failure against an isolated `PASEO_HOME`: wrote `paseo.pid` with a live unrelated `sleep` PID and an old `startedAt`, then launched `packages/server/scripts/supervisor-entrypoint.ts`; before the fix it exited with status 1 and `Another Paseo daemon is already running`.
- Added the regression in `packages/server/src/server/pid-lock.test.ts`; confirmed it failed before the implementation change, then passed after.
- Re-ran the real startup path against the built supervisor entrypoint with the same stale lock; after the fix it replaced the stale lock, bound an ephemeral local port, and shut down cleanly on SIGTERM.
- `npm run build:server`
- `npx vitest run packages/server/src/server/pid-lock.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense