### PR TITLE
Pin tab: keep pinned tabs left and synced across devices

### DIFF
--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -98,6 +98,9 @@ interface SplitContainerProps {
   onCloseTabsToLeft: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
+  // Undefined when the daemon doesn't support tab pins — the menu entry is omitted.
+  pinnedTabKeys?: readonly string[];
+  onTogglePinTab?: (tab: WorkspaceTabDescriptor) => void;
   onCreateDraftTab: (input: { paneId?: string }) => void;
   onCreateTerminalTab: (input: { paneId?: string; profile?: TerminalProfileInput }) => void;
   onCreateBrowserTab: (input: { paneId?: string }) => void;
@@ -286,13 +289,14 @@ function computeTabOverDropPreview(input: {
   rects: DragMoveRects;
   panesById: Map<string, SplitPane>;
   uiTabs: WorkspaceTab[];
+  pinnedTabKeys: readonly string[] | undefined;
 }): TabDropPreview | null {
-  const { activeData, overData, rects, panesById, uiTabs } = input;
+  const { activeData, overData, rects, panesById, uiTabs, pinnedTabKeys } = input;
   const targetPane = panesById.get(overData.paneId) ?? null;
   if (!targetPane) {
     return null;
   }
-  const targetTabs = getWorkspacePaneDescriptors({ pane: targetPane, tabs: uiTabs });
+  const targetTabs = getWorkspacePaneDescriptors({ pane: targetPane, tabs: uiTabs, pinnedTabKeys });
   return computeTabDropPreview({
     activePaneId: activeData.paneId,
     activeTabId: activeData.tabId,
@@ -379,6 +383,8 @@ export function SplitContainer({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  pinnedTabKeys,
+  onTogglePinTab,
   onCreateDraftTab,
   onCreateTerminalTab,
   onCreateBrowserTab,
@@ -464,6 +470,7 @@ export function SplitContainer({
           rects,
           panesById,
           uiTabs,
+          pinnedTabKeys,
         });
         setDropPreview(null);
         setTabDropPreview(preview);
@@ -478,7 +485,7 @@ export function SplitContainer({
 
       setDropPreview(computePaneOverDropPreview({ overData, rects }));
     },
-    [panesById, uiTabs],
+    [panesById, pinnedTabKeys, uiTabs],
   );
 
   const applyTabDropEnd = useCallback(
@@ -490,8 +497,16 @@ export function SplitContainer({
         return;
       }
 
-      const sourceTabs = getWorkspacePaneDescriptors({ pane: sourcePane, tabs: uiTabs });
-      const targetTabs = getWorkspacePaneDescriptors({ pane: targetPane, tabs: uiTabs });
+      const sourceTabs = getWorkspacePaneDescriptors({
+        pane: sourcePane,
+        tabs: uiTabs,
+        pinnedTabKeys,
+      });
+      const targetTabs = getWorkspacePaneDescriptors({
+        pane: targetPane,
+        tabs: uiTabs,
+        pinnedTabKeys,
+      });
       const sourceIndex = sourceTabs.findIndex((tab) => tab.tabId === activeData.tabId);
       const resolvedTabDropPreview =
         tabDropPreview?.paneId === overData.paneId ? tabDropPreview : null;
@@ -519,7 +534,7 @@ export function SplitContainer({
       onMoveTabToPane(activeData.tabId, overData.paneId);
       onReorderTabsInPane(overData.paneId, nextTargetTabIds);
     },
-    [onMoveTabToPane, onReorderTabsInPane, panesById, tabDropPreview, uiTabs],
+    [onMoveTabToPane, onReorderTabsInPane, panesById, pinnedTabKeys, tabDropPreview, uiTabs],
   );
 
   const applyPaneDropEnd = useCallback(
@@ -596,6 +611,8 @@ export function SplitContainer({
           onCloseTabsToLeft={onCloseTabsToLeft}
           onCloseTabsToRight={onCloseTabsToRight}
           onCloseOtherTabs={onCloseOtherTabs}
+          pinnedTabKeys={pinnedTabKeys}
+          onTogglePinTab={onTogglePinTab}
           onCreateDraftTab={onCreateDraftTab}
           onCreateTerminalTab={onCreateTerminalTab}
           onCreateBrowserTab={onCreateBrowserTab}
@@ -739,6 +756,8 @@ function SplitNodeView({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  pinnedTabKeys,
+  onTogglePinTab,
   onCreateDraftTab,
   onCreateTerminalTab,
   onCreateBrowserTab,
@@ -792,6 +811,8 @@ function SplitNodeView({
         onCloseTabsToLeft={onCloseTabsToLeft}
         onCloseTabsToRight={onCloseTabsToRight}
         onCloseOtherTabs={onCloseOtherTabs}
+        pinnedTabKeys={pinnedTabKeys}
+        onTogglePinTab={onTogglePinTab}
         onCreateDraftTab={onCreateDraftTab}
         onCreateTerminalTab={onCreateTerminalTab}
         onCreateBrowserTab={onCreateBrowserTab}
@@ -838,6 +859,8 @@ function SplitNodeView({
               onCloseTabsToLeft={onCloseTabsToLeft}
               onCloseTabsToRight={onCloseTabsToRight}
               onCloseOtherTabs={onCloseOtherTabs}
+              pinnedTabKeys={pinnedTabKeys}
+              onTogglePinTab={onTogglePinTab}
               onCreateDraftTab={onCreateDraftTab}
               onCreateTerminalTab={onCreateTerminalTab}
               onCreateBrowserTab={onCreateBrowserTab}
@@ -890,6 +913,8 @@ function SplitPaneView({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  pinnedTabKeys,
+  onTogglePinTab,
   onCreateDraftTab,
   onCreateTerminalTab,
   onCreateBrowserTab,
@@ -914,8 +939,9 @@ function SplitPaneView({
       deriveWorkspacePaneState({
         pane,
         tabs: uiTabs,
+        pinnedTabKeys,
       }),
-    [pane, uiTabs],
+    [pane, pinnedTabKeys, uiTabs],
   );
   const paneTabs = useMemo(() => paneState.tabs.map((tab) => tab.descriptor), [paneState.tabs]);
   const paneTabIds = useMemo(() => paneTabs.map((tab) => tab.tabId), [paneTabs]);
@@ -1032,6 +1058,8 @@ function SplitPaneView({
             onCloseTabsToLeft={handleCloseTabsToLeft}
             onCloseTabsToRight={handleCloseTabsToRight}
             onCloseOtherTabs={handleCloseOtherTabs}
+            pinnedTabKeys={pinnedTabKeys}
+            onTogglePinTab={onTogglePinTab}
             onCreateDraftTab={onCreateDraftTab}
             onCreateTerminalTab={onCreateTerminalTab}
             onCreateBrowserTab={onCreateBrowserTab}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -479,6 +479,8 @@ export const ar: TranslationResources = {
         closeOthers: "أغلق علامات التبويب الأخرى",
         reloadAgent: "إعادة تحميل الوكيل",
         reloadAgentTooltip: "قم بإعادة تحميل الوكيل لتحديث المهارات أو MCPs أو حالة تسجيل الدخول.",
+        pinTab: "تثبيت علامة التبويب",
+        unpinTab: "إلغاء تثبيت علامة التبويب",
         close: "يغلق",
         renameTerminal: "إعادة تسمية المحطة",
         renameAgent: "إعادة تسمية الوكيل",
@@ -513,6 +515,7 @@ export const ar: TranslationResources = {
         reloadingAgent: "وكيل إعادة التحميل...",
         reloadedAgent: "وكيل إعادة تحميل",
         failedToReloadAgent: "فشل في إعادة تحميل الوكيل",
+        failedToPinTab: "فشل في تحديث علامات التبويب المثبتة",
       },
       confirmations: {
         close: "يغلق",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -479,6 +479,8 @@ export const en = {
         closeOthers: "Close other tabs",
         reloadAgent: "Reload agent",
         reloadAgentTooltip: "Reload agent to update skills, MCPs or login status.",
+        pinTab: "Pin tab",
+        unpinTab: "Unpin tab",
         close: "Close",
         renameTerminal: "Rename terminal",
         renameAgent: "Rename agent",
@@ -513,6 +515,7 @@ export const en = {
         reloadingAgent: "Reloading agent...",
         reloadedAgent: "Reloaded agent",
         failedToReloadAgent: "Failed to reload agent",
+        failedToPinTab: "Failed to update pinned tabs",
       },
       confirmations: {
         close: "Close",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -484,6 +484,8 @@ export const es: TranslationResources = {
         reloadAgent: "Recargar agente",
         reloadAgentTooltip:
           "Vuelva a cargar el agente para actualizar habilidades, MCP o estado de inicio de sesión.",
+        pinTab: "Anclar pestaña",
+        unpinTab: "Desanclar pestaña",
         close: "Cerca",
         renameTerminal: "Cambiar nombre de terminal",
         renameAgent: "Cambiar nombre del agente",
@@ -518,6 +520,7 @@ export const es: TranslationResources = {
         reloadingAgent: "Agente de recarga...",
         reloadedAgent: "Agente recargado",
         failedToReloadAgent: "No se pudo recargar el agente",
+        failedToPinTab: "No se pudieron actualizar las pestañas ancladas",
       },
       confirmations: {
         close: "Cerca",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -484,6 +484,8 @@ export const fr: TranslationResources = {
         reloadAgent: "Agent de rechargement",
         reloadAgentTooltip:
           "Rechargez l'agent pour mettre à jour les compétences, les MCP ou le statut de connexion.",
+        pinTab: "Épingler l'onglet",
+        unpinTab: "Désépingler l'onglet",
         close: "Fermer",
         renameTerminal: "Renommer le terminal",
         renameAgent: "Renommer l'agent",
@@ -518,6 +520,7 @@ export const fr: TranslationResources = {
         reloadingAgent: "Agent de rechargement...",
         reloadedAgent: "Agent rechargé",
         failedToReloadAgent: "Échec du rechargement de l'agent",
+        failedToPinTab: "Échec de la mise à jour des onglets épinglés",
       },
       confirmations: {
         close: "Fermer",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -484,6 +484,8 @@ export const ja: TranslationResources = {
         reloadAgent: "エージェントを再読み込み",
         reloadAgentTooltip:
           "スキル、MCP、ログイン状態を更新するためにエージェントを再読み込みします。",
+        pinTab: "タブをピン留め",
+        unpinTab: "ピン留めを解除",
         close: "閉じる",
         renameTerminal: "ターミナルの名前を変更",
         renameAgent: "エージェントの名前を変更",
@@ -518,6 +520,7 @@ export const ja: TranslationResources = {
         reloadingAgent: "エージェントを再読み込み中...",
         reloadedAgent: "エージェントを再読み込みしました",
         failedToReloadAgent: "エージェントの再読み込みに失敗しました",
+        failedToPinTab: "ピン留めタブの更新に失敗しました",
       },
       confirmations: {
         close: "閉じる",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -483,6 +483,8 @@ export const ptBR: TranslationResources = {
         closeOthers: "Fechar outras abas",
         reloadAgent: "Recarregar agente",
         reloadAgentTooltip: "Recarregue o agente para atualizar skills, MCPs ou status de login.",
+        pinTab: "Fixar guia",
+        unpinTab: "Desafixar guia",
         close: "Fechar",
         renameTerminal: "Renomear terminal",
         renameAgent: "Renomear agente",
@@ -517,6 +519,7 @@ export const ptBR: TranslationResources = {
         reloadingAgent: "Recarregando agente...",
         reloadedAgent: "Agente recarregado",
         failedToReloadAgent: "Falha ao recarregar agente",
+        failedToPinTab: "Falha ao atualizar guias fixadas",
       },
       confirmations: {
         close: "Fechar",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -483,6 +483,8 @@ export const ru: TranslationResources = {
         closeOthers: "Закрыть другие вкладки",
         reloadAgent: "Перезагрузить агент",
         reloadAgentTooltip: "Перезагрузите агента, чтобы обновить навыки, MCP или статус входа.",
+        pinTab: "Закрепить вкладку",
+        unpinTab: "Открепить вкладку",
         close: "Закрывать",
         renameTerminal: "Переименование терминала",
         renameAgent: "Переименовать агента",
@@ -517,6 +519,7 @@ export const ru: TranslationResources = {
         reloadingAgent: "Перезагрузка агента...",
         reloadedAgent: "Перезагруженный агент",
         failedToReloadAgent: "Не удалось перезагрузить агент",
+        failedToPinTab: "Не удалось обновить закреплённые вкладки",
       },
       confirmations: {
         close: "Закрывать",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -479,6 +479,8 @@ export const zhCN: TranslationResources = {
         closeOthers: "关闭其他标签",
         reloadAgent: "重新加载 Agent",
         reloadAgentTooltip: "重新加载 Agent 以更新 skills、MCPs 或登录状态。",
+        pinTab: "固定标签页",
+        unpinTab: "取消固定标签页",
         close: "关闭",
         renameTerminal: "重命名 Terminal",
         renameAgent: "重命名 Agent",
@@ -513,6 +515,7 @@ export const zhCN: TranslationResources = {
         reloadingAgent: "正在重新加载 Agent...",
         reloadedAgent: "已重新加载 Agent",
         failedToReloadAgent: "重新加载 Agent 失败",
+        failedToPinTab: "更新固定标签页失败",
       },
       confirmations: {
         close: "关闭",

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -24,6 +24,8 @@ import {
   Columns2,
   Copy,
   Pencil,
+  Pin,
+  PinOff,
   RotateCw,
   Rows2,
   Globe,
@@ -68,6 +70,7 @@ import {
   type WorkspaceTabPresentation,
 } from "@/screens/workspace/workspace-tab-presentation";
 import { buildDeterministicWorkspaceTabId } from "@/workspace-tabs/identity";
+import { isWorkspaceTabPinned } from "@/screens/workspace/workspace-tab-pins";
 import {
   buildWorkspaceDesktopTabActions,
   type WorkspaceDesktopTabActions,
@@ -102,6 +105,8 @@ const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
 const ThemedArrowRightToLine = withUnistyles(ArrowRightToLine);
 const ThemedCopyX = withUnistyles(CopyX);
 const ThemedPencil = withUnistyles(Pencil);
+const ThemedPin = withUnistyles(Pin);
+const ThemedPinOff = withUnistyles(PinOff);
 const ThemedSquarePen = withUnistyles(SquarePen);
 const ThemedSquareTerminal = withUnistyles(SquareTerminal);
 const ThemedChevronDown = withUnistyles(ChevronDown);
@@ -338,6 +343,10 @@ function TabContextMenuItem({
         return <ThemedCopyX size={16} uniProps={mutedColorMapping} />;
       case "pencil":
         return <ThemedPencil size={16} uniProps={mutedColorMapping} />;
+      case "pin":
+        return <ThemedPin size={16} uniProps={mutedColorMapping} />;
+      case "pin-off":
+        return <ThemedPinOff size={16} uniProps={mutedColorMapping} />;
       case "x":
         return <ThemedX size={16} uniProps={mutedColorMapping} />;
       default:
@@ -425,6 +434,9 @@ interface WorkspaceDesktopTabsRowProps {
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  // Undefined when the daemon doesn't support tab pins — the menu entry is omitted.
+  pinnedTabKeys?: readonly string[];
+  onTogglePinTab?: (tab: WorkspaceTabDescriptor) => void;
   onCreateDraftTab: (input: { paneId?: string }) => void;
   onCreateTerminalTab: (input: { paneId?: string; profile?: TerminalProfileInput }) => void;
   onCreateBrowserTab: (input: { paneId?: string }) => void;
@@ -745,6 +757,8 @@ export function WorkspaceDesktopTabsRow({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  pinnedTabKeys,
+  onTogglePinTab,
   onCreateDraftTab,
   onCreateTerminalTab,
   onCreateBrowserTab,
@@ -820,6 +834,8 @@ export function WorkspaceDesktopTabsRow({
       closeOthers: t("workspace.tabs.menu.closeOthers"),
       reloadAgent: t("workspace.tabs.menu.reloadAgent"),
       reloadAgentTooltip: t("workspace.tabs.menu.reloadAgentTooltip"),
+      pinTab: t("workspace.tabs.menu.pinTab"),
+      unpinTab: t("workspace.tabs.menu.unpinTab"),
       close: t("workspace.tabs.menu.close"),
     }),
     [t],
@@ -915,6 +931,8 @@ export function WorkspaceDesktopTabsRow({
           onCloseTabsToLeft={onCloseTabsToLeft}
           onCloseTabsToRight={onCloseTabsToRight}
           onCloseOtherTabs={onCloseOtherTabs}
+          pinnedTabKeys={pinnedTabKeys}
+          onTogglePinTab={onTogglePinTab}
           resolvedTabWidth={resolvedTabWidth}
           showLabel={showLabel}
           showCloseButton={shouldShowCloseButton}
@@ -945,6 +963,8 @@ export function WorkspaceDesktopTabsRow({
       onNavigateTab,
       onReloadAgent,
       onRenameTab,
+      onTogglePinTab,
+      pinnedTabKeys,
       setHoveredCloseTabKey,
       tabMenuLabels,
       tabDropPreviewIndex,
@@ -1042,6 +1062,8 @@ function ResolvedDesktopTabChip({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  pinnedTabKeys,
+  onTogglePinTab,
   resolvedTabWidth,
   showLabel,
   showCloseButton,
@@ -1068,6 +1090,8 @@ function ResolvedDesktopTabChip({
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  pinnedTabKeys: readonly string[] | undefined;
+  onTogglePinTab: ((tab: WorkspaceTabDescriptor) => void) | undefined;
   resolvedTabWidth: number;
   showLabel: boolean;
   showCloseButton: boolean;
@@ -1095,6 +1119,13 @@ function ResolvedDesktopTabChip({
         onCloseTabsToLeft,
         onCloseTabsToRight,
         onCloseOtherTabs,
+        pin:
+          pinnedTabKeys && onTogglePinTab
+            ? {
+                isPinned: isWorkspaceTabPinned(pinnedTabKeys, item.tab.target),
+                onToggle: () => onTogglePinTab(item.tab),
+              }
+            : undefined,
         labels,
       }),
     [
@@ -1110,6 +1141,8 @@ function ResolvedDesktopTabChip({
       labels,
       onReloadAgent,
       onRenameTab,
+      onTogglePinTab,
+      pinnedTabKeys,
       tabCount,
     ],
   );

--- a/packages/app/src/screens/workspace/workspace-pane-state.test.ts
+++ b/packages/app/src/screens/workspace/workspace-pane-state.test.ts
@@ -62,6 +62,37 @@ describe("workspace-pane-state", () => {
     expect(state.activeTabId).toBe("agent_agent-a");
   });
 
+  it("orders pinned tabs first while keeping unpinned pane order", () => {
+    const pane = {
+      id: "main",
+      tabIds: ["agent_agent-a", "file_/repo/README.md", "terminal_term-1"],
+      focusedTabId: "agent_agent-a",
+    };
+    const tabs: WorkspaceTab[] = [
+      createTab("agent_agent-a", { kind: "agent", agentId: "agent-a" }),
+      createTab("file_/repo/README.md", { kind: "file", path: "/repo/README.md" }),
+      createTab("terminal_term-1", { kind: "terminal", terminalId: "term-1" }),
+    ];
+
+    const state = deriveWorkspacePaneState({
+      pane,
+      tabs,
+      pinnedTabKeys: ["terminal_term-1"],
+    });
+
+    expect(state.tabs.map((tab) => tab.descriptor.tabId)).toEqual([
+      "terminal_term-1",
+      "agent_agent-a",
+      "file_/repo/README.md",
+    ]);
+    expect(state.activeTabId).toBe("agent_agent-a");
+    expect(
+      getWorkspacePaneDescriptors({ pane, tabs, pinnedTabKeys: ["terminal_term-1"] }).map(
+        (tab) => tab.tabId,
+      ),
+    ).toEqual(["terminal_term-1", "agent_agent-a", "file_/repo/README.md"]);
+  });
+
   it("falls back to the first ordered pane tab when focusedTabId is empty", () => {
     const pane = {
       id: "main",

--- a/packages/app/src/screens/workspace/workspace-pane-state.ts
+++ b/packages/app/src/screens/workspace/workspace-pane-state.ts
@@ -11,6 +11,7 @@ import {
   workspaceTabTargetsEqual,
 } from "@/workspace-tabs/identity";
 import { findAdjacentPane } from "@/utils/split-navigation";
+import { sortWorkspaceTabsPinnedFirst } from "@/screens/workspace/workspace-tab-pins";
 
 export interface WorkspaceDerivedTab {
   descriptor: WorkspaceTabDescriptor;
@@ -164,6 +165,7 @@ export function deriveWorkspacePaneState(input: {
   tabs: WorkspaceTab[];
   focusedTabId?: string | null;
   preferredTarget?: WorkspaceTabTarget | null;
+  pinnedTabKeys?: readonly string[];
 }): WorkspacePaneState {
   const pane = getPane({
     layout: input.layout ?? null,
@@ -175,9 +177,14 @@ export function deriveWorkspacePaneState(input: {
     tabs: input.tabs,
   });
   const normalizedTabs = normalizeWorkspacePaneTabs(orderedTabs);
+  const sortedTabs = sortWorkspaceTabsPinnedFirst(
+    normalizedTabs.tabs,
+    input.pinnedTabKeys ?? [],
+    (tab) => tab.descriptor.target,
+  );
   const focusedTabId = pane?.focusedTabId ?? trimNonEmpty(input.focusedTabId) ?? null;
   const activeTabId = getActiveTabId({
-    tabs: normalizedTabs.tabs,
+    tabs: sortedTabs,
     openTabIds: normalizedTabs.openTabIds,
     focusedTabId,
     preferredTarget: input.preferredTarget,
@@ -185,11 +192,11 @@ export function deriveWorkspacePaneState(input: {
 
   return {
     pane,
-    tabs: normalizedTabs.tabs,
+    tabs: sortedTabs,
     focusedTabId,
     activeTabId,
     activeTab: activeTabId
-      ? (normalizedTabs.tabs.find((tab) => tab.descriptor.tabId === activeTabId) ?? null)
+      ? (sortedTabs.find((tab) => tab.descriptor.tabId === activeTabId) ?? null)
       : null,
   };
 }
@@ -199,6 +206,7 @@ export function getWorkspacePaneDescriptors(input: {
   pane?: SplitPane | null;
   paneId?: string | null;
   tabs: WorkspaceTab[];
+  pinnedTabKeys?: readonly string[];
 }): WorkspaceTabDescriptor[] {
   return deriveWorkspacePaneState(input).tabs.map((tab) => tab.descriptor);
 }

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -28,6 +28,8 @@ import {
   Import as ImportIcon,
   PanelRight,
   Pencil,
+  Pin,
+  PinOff,
   RotateCw,
   Settings,
   SquarePen,
@@ -147,6 +149,10 @@ import {
   workspaceAgentVisibilityEqual,
 } from "@/workspace-tabs/agent-visibility";
 import {
+  isWorkspaceTabPinned,
+  toggleWorkspaceTabPinKey,
+} from "@/screens/workspace/workspace-tab-pins";
+import {
   deriveWorkspacePaneState,
   resolveSideFileOpenPlacement,
 } from "@/screens/workspace/workspace-pane-state";
@@ -206,6 +212,24 @@ function getWorkspaceScripts(
   return workspaceDescriptor?.scripts ?? EMPTY_WORKSPACE_SCRIPTS;
 }
 
+// COMPAT(workspaceTabPins): added in v0.1.104, drop the gate when floor >= v0.1.104.
+// Undefined means the daemon doesn't support tab pins — pin UI stays hidden.
+function useWorkspacePinnedTabKeys(
+  serverId: string,
+  workspaceDescriptor: WorkspaceDescriptor | null | undefined,
+): readonly string[] | undefined {
+  const tabPinsSupported = useSessionStore(
+    (state) => state.sessions[serverId]?.serverInfo?.features?.workspaceTabPins === true,
+  );
+  const pinnedTabs = workspaceDescriptor?.pinnedTabs;
+  return useMemo(() => {
+    if (!tabPinsSupported) {
+      return undefined;
+    }
+    return pinnedTabs ?? [];
+  }, [tabPinsSupported, pinnedTabs]);
+}
+
 interface WorkspaceFileLocationFields {
   path: string | null;
   lineStart?: number;
@@ -241,6 +265,8 @@ const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
 const ThemedArrowRightToLine = withUnistyles(ArrowRightToLine);
 const ThemedCopyX = withUnistyles(CopyX);
 const ThemedPencil = withUnistyles(Pencil);
+const ThemedPin = withUnistyles(Pin);
+const ThemedPinOff = withUnistyles(PinOff);
 const ThemedX = withUnistyles(X);
 const ThemedSquarePen = withUnistyles(SquarePen);
 const ThemedSquareTerminal = withUnistyles(SquareTerminal);
@@ -397,6 +423,9 @@ interface MobileWorkspaceTabSwitcherProps {
   onCloseTabsAbove: (tabId: string) => Promise<void> | void;
   onCloseTabsBelow: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  // Undefined when the daemon doesn't support tab pins — the menu entry is omitted.
+  pinnedTabKeys?: readonly string[];
+  onTogglePinTab?: (tab: WorkspaceTabDescriptor) => void;
 }
 
 function MobileActiveTabTrigger({
@@ -542,6 +571,10 @@ function MobileTabDropdownMenuItem({
         return <ThemedCopyX size={16} uniProps={mutedColorMapping} />;
       case "pencil":
         return <ThemedPencil size={16} uniProps={mutedColorMapping} />;
+      case "pin":
+        return <ThemedPin size={16} uniProps={mutedColorMapping} />;
+      case "pin-off":
+        return <ThemedPinOff size={16} uniProps={mutedColorMapping} />;
       case "x":
         return <ThemedX size={16} uniProps={mutedColorMapping} />;
       default:
@@ -585,6 +618,8 @@ function MobileWorkspaceTabOption({
   onCloseTabsAbove,
   onCloseTabsBelow,
   onCloseOtherTabs,
+  pinnedTabKeys,
+  onTogglePinTab,
 }: {
   tab: WorkspaceTabDescriptor;
   tabIndex: number;
@@ -603,6 +638,8 @@ function MobileWorkspaceTabOption({
   onCloseTabsAbove: (tabId: string) => Promise<void> | void;
   onCloseTabsBelow: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  pinnedTabKeys: readonly string[] | undefined;
+  onTogglePinTab: ((tab: WorkspaceTabDescriptor) => void) | undefined;
 }) {
   const { t } = useTranslation();
   const tabMenuLabels = useMemo<WorkspaceTabMenuLabels>(
@@ -618,6 +655,8 @@ function MobileWorkspaceTabOption({
       closeOthers: t("workspace.tabs.menu.closeOthers"),
       reloadAgent: t("workspace.tabs.menu.reloadAgent"),
       reloadAgentTooltip: t("workspace.tabs.menu.reloadAgentTooltip"),
+      pinTab: t("workspace.tabs.menu.pinTab"),
+      unpinTab: t("workspace.tabs.menu.unpinTab"),
       close: t("workspace.tabs.menu.close"),
     }),
     [t],
@@ -638,6 +677,13 @@ function MobileWorkspaceTabOption({
     onCloseTabsBefore: onCloseTabsAbove,
     onCloseTabsAfter: onCloseTabsBelow,
     onCloseOtherTabs,
+    pin:
+      pinnedTabKeys && onTogglePinTab
+        ? {
+            isPinned: isWorkspaceTabPinned(pinnedTabKeys, tab.target),
+            onToggle: () => onTogglePinTab(tab),
+          }
+        : undefined,
     labels: tabMenuLabels,
   });
 
@@ -705,6 +751,8 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
   onCloseTabsAbove,
   onCloseTabsBelow,
   onCloseOtherTabs,
+  pinnedTabKeys,
+  onTogglePinTab,
 }: MobileWorkspaceTabSwitcherProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -761,6 +809,8 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
           onCloseTabsAbove={onCloseTabsAbove}
           onCloseTabsBelow={onCloseTabsBelow}
           onCloseOtherTabs={onCloseOtherTabs}
+          pinnedTabKeys={pinnedTabKeys}
+          onTogglePinTab={onTogglePinTab}
         />
       );
     },
@@ -779,6 +829,8 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
       onCloseTabsAbove,
       onCloseTabsBelow,
       onCloseOtherTabs,
+      pinnedTabKeys,
+      onTogglePinTab,
     ],
   );
 
@@ -1937,13 +1989,16 @@ function WorkspaceScreenContent({
     [closeWorkspaceTab, hideWorkspaceAgent, persistenceKey, unpinWorkspaceAgent],
   );
 
+  const pinnedTabKeys = useWorkspacePinnedTabKeys(normalizedServerId, workspaceDescriptor);
+
   const focusedPaneTabState = useMemo(
     () =>
       deriveWorkspacePaneState({
         layout: workspaceLayout,
         tabs: uiTabs,
+        pinnedTabKeys,
       }),
-    [uiTabs, workspaceLayout],
+    [pinnedTabKeys, uiTabs, workspaceLayout],
   );
   const setFocusedAgentId = useSessionStore((state) => state.setFocusedAgentId);
   const setFocusedTerminalId = useSessionStore((state) => state.setFocusedTerminalId);
@@ -2687,6 +2742,25 @@ function WorkspaceScreenContent({
       }
     },
     [client, isConnected, normalizedServerId, toast, t],
+  );
+
+  const handleTogglePinTab = useCallback(
+    (tab: WorkspaceTabDescriptor) => {
+      if (!pinnedTabKeys || !normalizedWorkspaceId) {
+        return;
+      }
+      if (!client || !isConnected) {
+        toast.error(t("workspace.terminal.hostDisconnected"));
+        return;
+      }
+      const nextPinnedTabs = toggleWorkspaceTabPinKey(pinnedTabKeys, tab.target);
+      void client.setWorkspaceTabPins(normalizedWorkspaceId, nextPinnedTabs).catch((error) => {
+        toast.error(
+          error instanceof Error ? error.message : t("workspace.tabs.toasts.failedToPinTab"),
+        );
+      });
+    },
+    [client, isConnected, normalizedWorkspaceId, pinnedTabKeys, toast, t],
   );
 
   const handleCopyWorkspacePath = useCallback(async () => {
@@ -3454,6 +3528,8 @@ function WorkspaceScreenContent({
         onCloseTabsToLeft={handleCloseTabsToLeftInPane}
         onCloseTabsToRight={handleCloseTabsToRightInPane}
         onCloseOtherTabs={handleCloseOtherTabsInPane}
+        pinnedTabKeys={pinnedTabKeys}
+        onTogglePinTab={handleTogglePinTab}
         onCreateDraftTab={handleCreateDraftTab}
         onCreateTerminalTab={handleCreateTerminal}
         onCreateBrowserTab={handleCreateBrowserTab}
@@ -3489,6 +3565,8 @@ function WorkspaceScreenContent({
     handleCloseTabsToLeftInPane,
     handleCloseTabsToRightInPane,
     handleCloseOtherTabsInPane,
+    pinnedTabKeys,
+    handleTogglePinTab,
     handleCreateDraftTab,
     handleCreateTerminal,
     handleCreateBrowserTab,
@@ -3571,6 +3649,8 @@ function WorkspaceScreenContent({
           onCloseTabsAbove={handleCloseTabsToLeft}
           onCloseTabsBelow={handleCloseTabsToRight}
           onCloseOtherTabs={handleCloseOtherTabs}
+          pinnedTabKeys={pinnedTabKeys}
+          onTogglePinTab={handleTogglePinTab}
         />
       ) : null}
 
@@ -3592,6 +3672,8 @@ function WorkspaceScreenContent({
           onCloseTabsToLeft={handleCloseTabsToLeft}
           onCloseTabsToRight={handleCloseTabsToRight}
           onCloseOtherTabs={handleCloseOtherTabs}
+          pinnedTabKeys={pinnedTabKeys}
+          onTogglePinTab={handleTogglePinTab}
           onCreateDraftTab={handleCreateDraftTab}
           onCreateTerminalTab={handleCreateTerminal}
           onCreateBrowserTab={handleCreateBrowserTab}

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -150,6 +150,7 @@ import {
 } from "@/workspace-tabs/agent-visibility";
 import {
   isWorkspaceTabPinned,
+  reorderWorkspaceTabPinKeys,
   toggleWorkspaceTabPinKey,
 } from "@/screens/workspace/workspace-tab-pins";
 import {
@@ -214,20 +215,31 @@ function getWorkspaceScripts(
 
 // COMPAT(workspaceTabPins): added in v0.1.104, drop the gate when floor >= v0.1.104.
 // Undefined means the daemon doesn't support tab pins — pin UI stays hidden.
+// The optimistic setter overlays a local pin list while a setWorkspaceTabPins
+// RPC round-trips so pin mutations (toggle, drag reorder) don't snap back; the
+// overlay clears whenever the server descriptor's pin list content changes.
 function useWorkspacePinnedTabKeys(
   serverId: string,
   workspaceDescriptor: WorkspaceDescriptor | null | undefined,
-): readonly string[] | undefined {
+): [readonly string[] | undefined, (next: readonly string[] | null) => void] {
   const tabPinsSupported = useSessionStore(
     (state) => state.sessions[serverId]?.serverInfo?.features?.workspaceTabPins === true,
   );
   const pinnedTabs = workspaceDescriptor?.pinnedTabs;
-  return useMemo(() => {
+  const [optimisticPinnedTabs, setOptimisticPinnedTabs] = useState<readonly string[] | null>(null);
+  // Compare by content, not reference — workspace_update replaces the array
+  // on every message, and an unrelated update must not drop the overlay.
+  const pinnedTabsFingerprint = useMemo(() => JSON.stringify(pinnedTabs ?? []), [pinnedTabs]);
+  useEffect(() => {
+    setOptimisticPinnedTabs(null);
+  }, [pinnedTabsFingerprint]);
+  const pinnedTabKeys = useMemo(() => {
     if (!tabPinsSupported) {
       return undefined;
     }
-    return pinnedTabs ?? [];
-  }, [tabPinsSupported, pinnedTabs]);
+    return optimisticPinnedTabs ?? pinnedTabs ?? [];
+  }, [tabPinsSupported, pinnedTabs, optimisticPinnedTabs]);
+  return [pinnedTabKeys, setOptimisticPinnedTabs];
 }
 
 interface WorkspaceFileLocationFields {
@@ -1989,7 +2001,10 @@ function WorkspaceScreenContent({
     [closeWorkspaceTab, hideWorkspaceAgent, persistenceKey, unpinWorkspaceAgent],
   );
 
-  const pinnedTabKeys = useWorkspacePinnedTabKeys(normalizedServerId, workspaceDescriptor);
+  const [pinnedTabKeys, setOptimisticPinnedTabs] = useWorkspacePinnedTabKeys(
+    normalizedServerId,
+    workspaceDescriptor,
+  );
 
   const focusedPaneTabState = useMemo(
     () =>
@@ -2754,13 +2769,15 @@ function WorkspaceScreenContent({
         return;
       }
       const nextPinnedTabs = toggleWorkspaceTabPinKey(pinnedTabKeys, tab.target);
+      setOptimisticPinnedTabs(nextPinnedTabs);
       void client.setWorkspaceTabPins(normalizedWorkspaceId, nextPinnedTabs).catch((error) => {
+        setOptimisticPinnedTabs(null);
         toast.error(
           error instanceof Error ? error.message : t("workspace.tabs.toasts.failedToPinTab"),
         );
       });
     },
-    [client, isConnected, normalizedWorkspaceId, pinnedTabKeys, toast, t],
+    [client, isConnected, normalizedWorkspaceId, pinnedTabKeys, setOptimisticPinnedTabs, toast, t],
   );
 
   const handleCopyWorkspacePath = useCallback(async () => {
@@ -3279,14 +3296,60 @@ function WorkspaceScreenContent({
     [persistenceKey, resizeWorkspaceSplit],
   );
 
+  // Drag reorders run against the pinned-first sorted order, so a same-pane
+  // drop that changes the relative order of pinned tabs must rewrite the
+  // workspace pin list too — otherwise the next render re-applies the stale
+  // pin order and snaps the drag back. Optimistic overlay hides the RPC
+  // round-trip. Cross-pane moves don't change pin membership or order.
+  const syncTabPinOrderAfterReorder = useCallback(
+    (orderedTabIds: readonly string[]) => {
+      if (!pinnedTabKeys || pinnedTabKeys.length === 0 || !normalizedWorkspaceId) {
+        return;
+      }
+      if (!client || !isConnected) {
+        return;
+      }
+      const targetsByTabId = new Map(uiTabs.map((tab) => [tab.tabId, tab.target]));
+      const orderedTargets: WorkspaceTabTarget[] = [];
+      for (const tabId of orderedTabIds) {
+        const target = targetsByTabId.get(tabId);
+        if (target) {
+          orderedTargets.push(target);
+        }
+      }
+      const nextPinnedTabs = reorderWorkspaceTabPinKeys(pinnedTabKeys, orderedTargets);
+      if (nextPinnedTabs.every((key, index) => key === pinnedTabKeys[index])) {
+        return;
+      }
+      setOptimisticPinnedTabs(nextPinnedTabs);
+      void client.setWorkspaceTabPins(normalizedWorkspaceId, nextPinnedTabs).catch((error) => {
+        setOptimisticPinnedTabs(null);
+        toast.error(
+          error instanceof Error ? error.message : t("workspace.tabs.toasts.failedToPinTab"),
+        );
+      });
+    },
+    [
+      client,
+      isConnected,
+      normalizedWorkspaceId,
+      pinnedTabKeys,
+      setOptimisticPinnedTabs,
+      toast,
+      t,
+      uiTabs,
+    ],
+  );
+
   const handleReorderTabsInPane = useCallback(
     function handleReorderTabsInPane(paneId: string, tabIds: string[]) {
       if (!persistenceKey) {
         return;
       }
       reorderWorkspaceTabsInPane(persistenceKey, paneId, tabIds);
+      syncTabPinOrderAfterReorder(tabIds);
     },
-    [persistenceKey, reorderWorkspaceTabsInPane],
+    [persistenceKey, reorderWorkspaceTabsInPane, syncTabPinOrderAfterReorder],
   );
 
   const handleReorderTabsInFocusedPane = useCallback(

--- a/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
@@ -253,6 +253,94 @@ describe("buildWorkspaceTabMenuEntries", () => {
     expect(onCopyFilePath).toHaveBeenCalledWith("/some/path.ts");
   });
 
+  it("omits the pin entry when no pin input is provided", () => {
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab: createAgentTab(),
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: "workspace-tab-context-agent_123",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    expect(entries.some((entry) => entry.kind === "item" && entry.key === "toggle-pin")).toBe(
+      false,
+    );
+  });
+
+  it("shows Pin tab for unpinned tabs and invokes the toggle", () => {
+    const onToggle = vi.fn();
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab: createAgentTab(),
+      index: 0,
+      tabCount: 2,
+      menuTestIDBase: "workspace-tab-context-agent_123",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+      pin: { isPinned: false, onToggle },
+    });
+
+    const pinEntry = entries.find((entry) => entry.kind === "item" && entry.key === "toggle-pin");
+    if (!pinEntry || pinEntry.kind !== "item") {
+      throw new Error("Pin entry missing");
+    }
+    expect(pinEntry.label).toBe("Pin tab");
+    expect(pinEntry.icon).toBe("pin");
+    expect(pinEntry.testID).toBe("workspace-tab-context-agent_123-toggle-pin");
+    pinEntry.onSelect();
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    const pinIndex = entries.indexOf(pinEntry);
+    expect(entries[pinIndex + 1]).toEqual({ kind: "separator", key: "pin-separator" });
+    const closeBeforeIndex = entries.findIndex(
+      (entry) => entry.kind === "item" && entry.key === "close-before",
+    );
+    expect(pinIndex).toBeLessThan(closeBeforeIndex);
+  });
+
+  it("shows Unpin tab for pinned tabs", () => {
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "mobile",
+      tab: createAgentTab(),
+      index: 0,
+      tabCount: 2,
+      menuTestIDBase: "workspace-tab-menu-agent_123",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+      pin: { isPinned: true, onToggle: vi.fn() },
+    });
+
+    const pinEntry = entries.find((entry) => entry.kind === "item" && entry.key === "toggle-pin");
+    if (!pinEntry || pinEntry.kind !== "item") {
+      throw new Error("Pin entry missing");
+    }
+    expect(pinEntry.label).toBe("Unpin tab");
+    expect(pinEntry.icon).toBe("pin-off");
+  });
+
   it("uses the same rename entry shape for agent and terminal tabs", () => {
     const terminalTab: WorkspaceTabDescriptor = {
       key: "terminal_abc",

--- a/packages/app/src/screens/workspace/workspace-tab-menu.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.ts
@@ -10,6 +10,8 @@ export interface WorkspaceTabMenuLabels {
   copyAgentId: string;
   copyFilePath: string;
   rename: string;
+  pinTab: string;
+  unpinTab: string;
   closeAbove: string;
   closeBelow: string;
   closeLeft: string;
@@ -25,6 +27,8 @@ export const DEFAULT_WORKSPACE_TAB_MENU_LABELS: WorkspaceTabMenuLabels = {
   copyAgentId: i18n.t("workspace.tabs.menu.copyAgentId"),
   copyFilePath: i18n.t("workspace.tabs.menu.copyFilePath"),
   rename: i18n.t("workspace.tabs.menu.rename"),
+  pinTab: i18n.t("workspace.tabs.menu.pinTab"),
+  unpinTab: i18n.t("workspace.tabs.menu.unpinTab"),
   closeAbove: i18n.t("workspace.tabs.menu.closeAbove"),
   closeBelow: i18n.t("workspace.tabs.menu.closeBelow"),
   closeLeft: i18n.t("workspace.tabs.menu.closeLeft"),
@@ -47,6 +51,8 @@ export type WorkspaceTabMenuEntry =
         | "arrow-right-to-line"
         | "copy-x"
         | "pencil"
+        | "pin"
+        | "pin-off"
         | "x";
       hint?: string;
       tooltip?: string;
@@ -75,7 +81,14 @@ interface BuildWorkspaceTabMenuEntriesInput {
   onCloseTabsBefore: (tabId: string) => Promise<void> | void;
   onCloseTabsAfter: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  // Absent when the daemon doesn't support tab pins — the entry is omitted.
+  pin?: WorkspaceTabPinMenuInput;
   labels?: WorkspaceTabMenuLabels;
+}
+
+export interface WorkspaceTabPinMenuInput {
+  isPinned: boolean;
+  onToggle: () => void;
 }
 
 interface BuildWorkspaceDesktopTabActionsInput {
@@ -91,6 +104,7 @@ interface BuildWorkspaceDesktopTabActionsInput {
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  pin?: WorkspaceTabPinMenuInput;
   labels?: WorkspaceTabMenuLabels;
 }
 
@@ -159,6 +173,7 @@ export function buildWorkspaceTabMenuEntries(
     onCloseTabsBefore,
     onCloseTabsAfter,
     onCloseOtherTabs,
+    pin,
   } = input;
   const labels = input.labels ?? DEFAULT_WORKSPACE_TAB_MENU_LABELS;
   const isFirstTab = index === 0;
@@ -219,6 +234,21 @@ export function buildWorkspaceTabMenuEntries(
     entries.push({
       kind: "separator",
       key: "rename-separator",
+    });
+  }
+
+  if (pin) {
+    entries.push({
+      kind: "item",
+      key: "toggle-pin",
+      label: pin.isPinned ? labels.unpinTab : labels.pinTab,
+      icon: pin.isPinned ? "pin-off" : "pin",
+      testID: `${menuTestIDBase}-toggle-pin`,
+      onSelect: pin.onToggle,
+    });
+    entries.push({
+      kind: "separator",
+      key: "pin-separator",
     });
   }
 
@@ -304,6 +334,7 @@ export function buildWorkspaceDesktopTabActions(
       onCloseTabsBefore: input.onCloseTabsToLeft,
       onCloseTabsAfter: input.onCloseTabsToRight,
       onCloseOtherTabs: input.onCloseOtherTabs,
+      pin: input.pin,
       labels: input.labels,
     }),
     closeButtonTestId: getCloseButtonTestId(input.tab),

--- a/packages/app/src/screens/workspace/workspace-tab-pins.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-pins.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  isWorkspaceTabPinned,
+  sortWorkspaceTabsPinnedFirst,
+  toggleWorkspaceTabPinKey,
+  workspaceTabPinKey,
+} from "@/screens/workspace/workspace-tab-pins";
+import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
+
+function agentTab(agentId: string): WorkspaceTabDescriptor {
+  return {
+    key: `agent_${agentId}`,
+    tabId: `agent_${agentId}`,
+    kind: "agent",
+    target: { kind: "agent", agentId },
+  };
+}
+
+function fileTab(path: string): WorkspaceTabDescriptor {
+  return {
+    key: `file_${path}`,
+    tabId: `file_${path}`,
+    kind: "file",
+    target: { kind: "file", path },
+  };
+}
+
+describe("workspaceTabPinKey", () => {
+  it("derives deterministic keys from tab targets", () => {
+    expect(workspaceTabPinKey({ kind: "agent", agentId: "a1" })).toBe("agent_a1");
+    expect(workspaceTabPinKey({ kind: "file", path: "/x/y.ts" })).toBe("file_/x/y.ts");
+  });
+});
+
+describe("toggleWorkspaceTabPinKey", () => {
+  it("appends the key when not pinned", () => {
+    expect(toggleWorkspaceTabPinKey([], { kind: "agent", agentId: "a1" })).toEqual(["agent_a1"]);
+    expect(toggleWorkspaceTabPinKey(["agent_a1"], { kind: "agent", agentId: "a2" })).toEqual([
+      "agent_a1",
+      "agent_a2",
+    ]);
+  });
+
+  it("removes the key when already pinned", () => {
+    expect(
+      toggleWorkspaceTabPinKey(["agent_a1", "agent_a2"], { kind: "agent", agentId: "a1" }),
+    ).toEqual(["agent_a2"]);
+  });
+});
+
+describe("isWorkspaceTabPinned", () => {
+  it("matches by deterministic key", () => {
+    expect(isWorkspaceTabPinned(["agent_a1"], { kind: "agent", agentId: "a1" })).toBe(true);
+    expect(isWorkspaceTabPinned(["agent_a1"], { kind: "agent", agentId: "a2" })).toBe(false);
+  });
+});
+
+describe("sortWorkspaceTabsPinnedFirst", () => {
+  it("keeps order untouched when nothing is pinned", () => {
+    const tabs = [agentTab("a1"), fileTab("/x.ts"), agentTab("a2")];
+    expect(sortWorkspaceTabsPinnedFirst(tabs, [], (tab) => tab.target)).toEqual(tabs);
+  });
+
+  it("moves pinned tabs to the front in pin order", () => {
+    const tabs = [agentTab("a1"), fileTab("/x.ts"), agentTab("a2"), fileTab("/y.ts")];
+    const sorted = sortWorkspaceTabsPinnedFirst(
+      tabs,
+      ["agent_a2", "file_/x.ts"],
+      (tab) => tab.target,
+    );
+    expect(sorted.map((tab) => tab.tabId)).toEqual([
+      "agent_a2",
+      "file_/x.ts",
+      "agent_a1",
+      "file_/y.ts",
+    ]);
+  });
+
+  it("ignores pin keys with no matching open tab", () => {
+    const tabs = [agentTab("a1"), agentTab("a2")];
+    const sorted = sortWorkspaceTabsPinnedFirst(
+      tabs,
+      ["agent_gone", "agent_a2"],
+      (tab) => tab.target,
+    );
+    expect(sorted.map((tab) => tab.tabId)).toEqual(["agent_a2", "agent_a1"]);
+  });
+
+  it("preserves relative order of unpinned tabs", () => {
+    const tabs = [fileTab("/a.ts"), fileTab("/b.ts"), fileTab("/c.ts"), fileTab("/d.ts")];
+    const sorted = sortWorkspaceTabsPinnedFirst(tabs, ["file_/c.ts"], (tab) => tab.target);
+    expect(sorted.map((tab) => tab.tabId)).toEqual([
+      "file_/c.ts",
+      "file_/a.ts",
+      "file_/b.ts",
+      "file_/d.ts",
+    ]);
+  });
+});

--- a/packages/app/src/screens/workspace/workspace-tab-pins.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-pins.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isWorkspaceTabPinned,
+  reorderWorkspaceTabPinKeys,
   sortWorkspaceTabsPinnedFirst,
   toggleWorkspaceTabPinKey,
   workspaceTabPinKey,
@@ -52,6 +53,54 @@ describe("isWorkspaceTabPinned", () => {
   it("matches by deterministic key", () => {
     expect(isWorkspaceTabPinned(["agent_a1"], { kind: "agent", agentId: "a1" })).toBe(true);
     expect(isWorkspaceTabPinned(["agent_a1"], { kind: "agent", agentId: "a2" })).toBe(false);
+  });
+});
+
+describe("reorderWorkspaceTabPinKeys", () => {
+  const agent = (agentId: string) => ({ kind: "agent", agentId }) as const;
+
+  it("is a no-op when nothing is pinned", () => {
+    expect(reorderWorkspaceTabPinKeys([], [agent("a1"), agent("a2")])).toEqual([]);
+  });
+
+  it("adopts the new relative order of pinned tabs", () => {
+    const next = reorderWorkspaceTabPinKeys(
+      ["agent_a1", "agent_a2", "agent_a3"],
+      [agent("a2"), agent("a1"), agent("a3"), agent("x")],
+    );
+    expect(next).toEqual(["agent_a2", "agent_a1", "agent_a3"]);
+  });
+
+  it("clamps a pinned tab dragged past unpinned tabs to the end of the pinned section", () => {
+    // Visual drop order: a2 stayed first, unpinned x in the middle, pinned a1
+    // dragged to the end. a1 stays pinned but moves after a2.
+    const next = reorderWorkspaceTabPinKeys(
+      ["agent_a1", "agent_a2"],
+      [agent("a2"), agent("x"), agent("a1")],
+    );
+    expect(next).toEqual(["agent_a2", "agent_a1"]);
+  });
+
+  it("leaves pins untouched when an unpinned tab is dragged into the pinned zone", () => {
+    const next = reorderWorkspaceTabPinKeys(
+      ["agent_a1", "agent_a2"],
+      [agent("a1"), agent("x"), agent("a2")],
+    );
+    expect(next).toEqual(["agent_a1", "agent_a2"]);
+  });
+
+  it("keeps pinned keys absent from the reordered pane at their original positions", () => {
+    // Pane only shows a2 and a3; a1 is pinned in another pane and keeps slot 0.
+    const next = reorderWorkspaceTabPinKeys(
+      ["agent_a1", "agent_a2", "agent_a3"],
+      [agent("a3"), agent("a2")],
+    );
+    expect(next).toEqual(["agent_a1", "agent_a3", "agent_a2"]);
+  });
+
+  it("ignores unpinned targets entirely", () => {
+    const next = reorderWorkspaceTabPinKeys(["agent_a1"], [agent("x"), agent("a1"), agent("y")]);
+    expect(next).toEqual(["agent_a1"]);
   });
 });
 

--- a/packages/app/src/screens/workspace/workspace-tab-pins.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-pins.ts
@@ -1,0 +1,55 @@
+import type { WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
+import { buildDeterministicWorkspaceTabId } from "@/workspace-tabs/identity";
+
+// Pin keys are deterministic tab ids so the same tab resolves to the same key
+// on every device; the key list itself lives on the daemon's workspace record.
+export function workspaceTabPinKey(target: WorkspaceTabTarget): string {
+  return buildDeterministicWorkspaceTabId(target);
+}
+
+export function isWorkspaceTabPinned(
+  pinnedTabKeys: readonly string[],
+  target: WorkspaceTabTarget,
+): boolean {
+  return pinnedTabKeys.includes(workspaceTabPinKey(target));
+}
+
+export function toggleWorkspaceTabPinKey(
+  pinnedTabKeys: readonly string[],
+  target: WorkspaceTabTarget,
+): string[] {
+  const key = workspaceTabPinKey(target);
+  const next = pinnedTabKeys.filter((entry) => entry !== key);
+  if (next.length === pinnedTabKeys.length) {
+    next.push(key);
+  }
+  return next;
+}
+
+// Pinned tabs render first, ordered by their position in the pin list (pin
+// order); unpinned tabs keep their local order. Pin keys with no matching open
+// tab are ignored.
+export function sortWorkspaceTabsPinnedFirst<T>(
+  tabs: readonly T[],
+  pinnedTabKeys: readonly string[],
+  getTarget: (tab: T) => WorkspaceTabTarget,
+): T[] {
+  if (pinnedTabKeys.length === 0) {
+    return [...tabs];
+  }
+  const pinned: T[] = [];
+  const unpinned: T[] = [];
+  for (const tab of tabs) {
+    if (isWorkspaceTabPinned(pinnedTabKeys, getTarget(tab))) {
+      pinned.push(tab);
+    } else {
+      unpinned.push(tab);
+    }
+  }
+  pinned.sort(
+    (a, b) =>
+      pinnedTabKeys.indexOf(workspaceTabPinKey(getTarget(a))) -
+      pinnedTabKeys.indexOf(workspaceTabPinKey(getTarget(b))),
+  );
+  return [...pinned, ...unpinned];
+}

--- a/packages/app/src/screens/workspace/workspace-tab-pins.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-pins.ts
@@ -26,6 +26,24 @@ export function toggleWorkspaceTabPinKey(
   return next;
 }
 
+// Recompute the pin list after a same-pane drag so pin order follows the new
+// visual order. Pinned keys present in `orderedTargets` adopt their relative
+// order there; pinned keys not present (pins are workspace-wide — a pane sees
+// a subset) keep their original index positions. Membership never changes, so
+// a pinned tab dropped into the unpinned zone clamps to the end of the pinned
+// section, and an unpinned tab dropped into the pinned zone stays unpinned.
+export function reorderWorkspaceTabPinKeys(
+  pinnedTabKeys: readonly string[],
+  orderedTargets: readonly WorkspaceTabTarget[],
+): string[] {
+  const pinnedSet = new Set(pinnedTabKeys);
+  const presentQueue = orderedTargets
+    .map((target) => workspaceTabPinKey(target))
+    .filter((key) => pinnedSet.has(key));
+  const presentSet = new Set(presentQueue);
+  return pinnedTabKeys.map((key) => (presentSet.has(key) ? (presentQueue.shift() ?? key) : key));
+}
+
 // Pinned tabs render first, ordered by their position in the pin list (pin
 // order); unpinned tabs keep their local order. Pin keys with no matching open
 // tab are ignored.

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -131,6 +131,7 @@ export interface WorkspaceDescriptor {
   workspaceKind: WorkspaceDescriptorPayload["workspaceKind"];
   name: string;
   title?: string | null;
+  pinnedTabs?: string[];
   status: WorkspaceDescriptorPayload["status"];
   statusEnteredAt: Date | null;
   archivingAt: string | null;
@@ -163,6 +164,7 @@ export function normalizeWorkspaceDescriptor(
     workspaceKind: payload.workspaceKind,
     name: payload.name,
     title: payload.title ?? null,
+    pinnedTabs: payload.pinnedTabs ?? [],
     status: payload.status,
     statusEnteredAt,
     archivingAt: payload.archivingAt ?? null,

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -2295,6 +2295,26 @@ export class DaemonClient {
     return { title: payload.title };
   }
 
+  async setWorkspaceTabPins(
+    workspaceId: string,
+    pinnedTabs: string[],
+    requestId?: string,
+  ): Promise<{ pinnedTabs: string[] }> {
+    const payload = await this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "workspace.tabs.pins.set.request",
+        workspaceId,
+        pinnedTabs,
+      },
+      responseType: "workspace.tabs.pins.set.response",
+    });
+    if (!payload.accepted) {
+      throw new Error(payload.error ?? "setWorkspaceTabPins rejected");
+    }
+    return { pinnedTabs: payload.pinnedTabs };
+  }
+
   async resumeAgent(
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -831,6 +831,15 @@ export const WorkspaceTitleSetRequestSchema = z.object({
   requestId: z.string(),
 });
 
+export const WorkspaceTabPinsSetRequestSchema = z.object({
+  type: z.literal("workspace.tabs.pins.set.request"),
+  workspaceId: z.string(),
+  // Full replacement list of pinned tab keys (deterministic tab ids), in pin
+  // order. An empty array clears all pins.
+  pinnedTabs: z.array(z.string()),
+  requestId: z.string(),
+});
+
 export const SetVoiceModeMessageSchema = z.object({
   type: z.literal("set_voice_mode"),
   enabled: z.boolean(),
@@ -1432,6 +1441,19 @@ export const WorkspaceTitleSetResponsePayloadSchema = z.object({
 export const WorkspaceTitleSetResponseSchema = z.object({
   type: z.literal("workspace.title.set.response"),
   payload: WorkspaceTitleSetResponsePayloadSchema,
+});
+
+export const WorkspaceTabPinsSetResponsePayloadSchema = z.object({
+  requestId: z.string(),
+  workspaceId: z.string(),
+  accepted: z.boolean(),
+  pinnedTabs: z.array(z.string()),
+  error: z.string().nullable(),
+});
+
+export const WorkspaceTabPinsSetResponseSchema = z.object({
+  type: z.literal("workspace.tabs.pins.set.response"),
+  payload: WorkspaceTabPinsSetResponsePayloadSchema,
 });
 
 export const SetVoiceModeResponseMessageSchema = z.object({
@@ -2058,6 +2080,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   ProjectRenameRequestSchema,
   ProjectRemoveRequestSchema,
   WorkspaceTitleSetRequestSchema,
+  WorkspaceTabPinsSetRequestSchema,
   SetVoiceModeMessageSchema,
   SendAgentMessageRequestSchema,
   WaitForFinishRequestSchema,
@@ -2367,6 +2390,8 @@ export const ServerInfoStatusPayloadSchema = z
         daemonSelfUpdate: z.boolean().optional(),
         // COMPAT(agentForkContext): added in v0.1.102, remove gate after 2026-12-28.
         agentForkContext: z.boolean().optional(),
+        // COMPAT(workspaceTabPins): added in v0.1.104, drop the gate when floor >= v0.1.104.
+        workspaceTabPins: z.boolean().optional(),
       })
       .optional(),
   })
@@ -2645,6 +2670,10 @@ export const WorkspaceDescriptorPayloadSchema = z
     // its input and offer a "reset to branch name" action. Null means the name
     // is derived from the branch/directory.
     title: z.string().nullable().optional(),
+    // COMPAT(workspaceTabPins): added in v0.1.104, drop the optional gate when floor >= v0.1.104.
+    // Deterministic tab ids the user pinned in this workspace, in pin order.
+    // Pinned tabs render first in the tab strip on every device.
+    pinnedTabs: z.array(z.string()).optional(),
     archivingAt: z.string().nullable().optional().default(null),
     status: WorkspaceStateBucketSchema,
     // Best-effort workspace status entry timestamp. Old daemons omit the
@@ -4231,6 +4260,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   ProjectRenameResponseSchema,
   ProjectRemoveResponseSchema,
   WorkspaceTitleSetResponseSchema,
+  WorkspaceTabPinsSetResponseSchema,
   WaitForFinishResponseMessageSchema,
   AgentPermissionRequestMessageSchema,
   AgentPermissionResolvedMessageSchema,
@@ -4387,6 +4417,10 @@ export type WorkspaceTitleSetResponse = z.infer<typeof WorkspaceTitleSetResponse
 export type WorkspaceTitleSetResponsePayload = z.infer<
   typeof WorkspaceTitleSetResponsePayloadSchema
 >;
+export type WorkspaceTabPinsSetResponse = z.infer<typeof WorkspaceTabPinsSetResponseSchema>;
+export type WorkspaceTabPinsSetResponsePayload = z.infer<
+  typeof WorkspaceTabPinsSetResponsePayloadSchema
+>;
 export type WorkspaceCreateRequest = z.infer<typeof WorkspaceCreateRequestSchema>;
 export type WorkspaceCreateResponse = z.infer<typeof WorkspaceCreateResponseSchema>;
 export type ProjectRenameResponsePayload = z.infer<typeof ProjectRenameResponsePayloadSchema>;
@@ -4519,6 +4553,7 @@ export type UpdateAgentRequestMessage = z.infer<typeof UpdateAgentRequestMessage
 export type ProjectRenameRequest = z.infer<typeof ProjectRenameRequestSchema>;
 export type ProjectRemoveRequest = z.infer<typeof ProjectRemoveRequestSchema>;
 export type WorkspaceTitleSetRequest = z.infer<typeof WorkspaceTitleSetRequestSchema>;
+export type WorkspaceTabPinsSetRequest = z.infer<typeof WorkspaceTabPinsSetRequestSchema>;
 export type SetAgentModeRequestMessage = z.infer<typeof SetAgentModeRequestMessageSchema>;
 export type SetAgentModelRequestMessage = z.infer<typeof SetAgentModelRequestMessageSchema>;
 export type SetAgentThinkingRequestMessage = z.infer<typeof SetAgentThinkingRequestMessageSchema>;

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -284,6 +284,17 @@ function buildWorkspaceCheckout(
   };
 }
 
+function dedupeNonEmptyStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      seen.add(trimmed);
+    }
+  }
+  return Array.from(seen);
+}
+
 function isAppVersionAtLeast(appVersion: string | null, minVersion: string): boolean {
   if (!appVersion) return false;
   // Strip prerelease suffix: "0.1.45-beta.4" -> "0.1.45"
@@ -1624,6 +1635,12 @@ export class Session {
         return this.handleWorkspaceClearAttentionRequest(msg);
       case "workspace.title.set.request":
         return this.handleWorkspaceTitleSetRequest(msg.workspaceId, msg.title, msg.requestId);
+      case "workspace.tabs.pins.set.request":
+        return this.handleWorkspaceTabPinsSetRequest(
+          msg.workspaceId,
+          msg.pinnedTabs,
+          msg.requestId,
+        );
       case "file_explorer_request":
         return this.workspaceFilesSession.handleFileExplorerRequest(msg);
       case "project_icon_request":
@@ -2304,6 +2321,72 @@ export class Session {
           accepted: false,
           title: null,
           error: getErrorMessageOr(error, "Failed to set workspace title"),
+        },
+      });
+    }
+  }
+
+  private async handleWorkspaceTabPinsSetRequest(
+    workspaceId: string,
+    pinnedTabs: string[],
+    requestId: string,
+  ): Promise<void> {
+    this.sessionLogger.info(
+      { workspaceId, requestId, pinCount: pinnedTabs.length },
+      "session: workspace.tabs.pins.set.request",
+    );
+
+    try {
+      const existing = await this.workspaceRegistry.get(workspaceId);
+      if (!existing) {
+        this.emit({
+          type: "workspace.tabs.pins.set.response",
+          payload: {
+            requestId,
+            workspaceId,
+            accepted: false,
+            pinnedTabs: [],
+            error: "Workspace not found",
+          },
+        });
+        return;
+      }
+
+      const nextPinnedTabs = dedupeNonEmptyStrings(pinnedTabs);
+
+      await this.workspaceRegistry.upsert({
+        ...existing,
+        pinnedTabs: nextPinnedTabs,
+        updatedAt: new Date().toISOString(),
+      });
+
+      this.emit({
+        type: "workspace.tabs.pins.set.response",
+        payload: {
+          requestId,
+          workspaceId,
+          accepted: true,
+          pinnedTabs: nextPinnedTabs,
+          error: null,
+        },
+      });
+
+      await this.emitWorkspaceUpdatesForWorkspaceIds([workspaceId], {
+        skipReconcile: true,
+      });
+    } catch (error) {
+      this.sessionLogger.error(
+        { err: error, workspaceId, requestId },
+        "session: workspace.tabs.pins.set.request error",
+      );
+      this.emit({
+        type: "workspace.tabs.pins.set.response",
+        payload: {
+          requestId,
+          workspaceId,
+          accepted: false,
+          pinnedTabs: [],
+          error: getErrorMessageOr(error, "Failed to set workspace tab pins"),
         },
       });
     }
@@ -3523,6 +3606,7 @@ export class Session {
       workspaceKind: workspace.kind,
       name: resolveWorkspaceDisplayName(workspace),
       title: workspace.title,
+      pinnedTabs: workspace.pinnedTabs,
       archivingAt: null,
       status: "done",
       statusEnteredAt: null,
@@ -3607,6 +3691,7 @@ export class Session {
         derivedDisplayName: result.worktree.branchName || result.workspace.displayName,
       }),
       title: result.workspace.title,
+      pinnedTabs: result.workspace.pinnedTabs,
       archivingAt: null,
       status: "done",
       statusEnteredAt: result.workspace.createdAt,

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -6678,6 +6678,147 @@ test("workspace.title.set.request returns accepted=false when workspace is not f
   expect(response?.payload.error).toBeTruthy();
 });
 
+test("workspace.tabs.pins.set.request stores deduped pins and emits an updated descriptor", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const session = asTestSession(
+    createSessionForWorkspaceTests({ onMessage: (message) => emitted.push(message) }),
+  );
+
+  const project = createPersistedProjectRecord({
+    projectId: "proj-1",
+    rootPath: REPO_CWD,
+    kind: "git",
+    displayName: "acme/repo",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-1",
+    projectId: project.projectId,
+    cwd: REPO_CWD,
+    kind: "local_checkout",
+    displayName: "main",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+
+  const projects = new Map([[project.projectId, project]]);
+  const workspaces = new Map([[workspace.workspaceId, workspace]]);
+  session.projectRegistry.get = async (id: string) => projects.get(id) ?? null;
+  session.projectRegistry.list = async () => Array.from(projects.values());
+  session.workspaceRegistry.list = async () => Array.from(workspaces.values());
+  session.workspaceRegistry.get = async (id: string) => workspaces.get(id) ?? null;
+  session.workspaceRegistry.upsert = async (record: unknown) => {
+    const parsed = record as typeof workspace;
+    workspaces.set(parsed.workspaceId, parsed);
+  };
+
+  session.workspaceUpdatesSubscription = {
+    subscriptionId: "sub-workspaces",
+    filter: {},
+    isBootstrapping: false,
+    lastEmittedByWorkspaceId: new Map(),
+    pendingUpdatesByWorkspaceId: new Map(),
+  };
+
+  await session.handleMessage({
+    type: "workspace.tabs.pins.set.request",
+    workspaceId: workspace.workspaceId,
+    pinnedTabs: ["agent_a1", " file_/repo/README.md ", "agent_a1", ""],
+    requestId: "req-pins-1",
+  });
+
+  const response = findByType(emitted, "workspace.tabs.pins.set.response");
+  expect(response?.payload).toEqual({
+    requestId: "req-pins-1",
+    workspaceId: workspace.workspaceId,
+    accepted: true,
+    pinnedTabs: ["agent_a1", "file_/repo/README.md"],
+    error: null,
+  });
+
+  expect(workspaces.get(workspace.workspaceId)?.pinnedTabs).toEqual([
+    "agent_a1",
+    "file_/repo/README.md",
+  ]);
+
+  const update = findByType(emitted, "workspace_update");
+  expect(update?.payload).toMatchObject({
+    kind: "upsert",
+    workspace: {
+      id: "ws-1",
+      pinnedTabs: ["agent_a1", "file_/repo/README.md"],
+    },
+  });
+});
+
+test("workspace.tabs.pins.set.request with an empty list clears the pins", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const session = asTestSession(
+    createSessionForWorkspaceTests({ onMessage: (message) => emitted.push(message) }),
+  );
+
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-1",
+    projectId: "proj-1",
+    cwd: REPO_CWD,
+    kind: "local_checkout",
+    displayName: "main",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  workspace.pinnedTabs.push("agent_a1");
+
+  const workspaces = new Map([[workspace.workspaceId, workspace]]);
+  session.workspaceRegistry.list = async () => Array.from(workspaces.values());
+  session.workspaceRegistry.get = async (id: string) => workspaces.get(id) ?? null;
+  session.workspaceRegistry.upsert = async (record: unknown) => {
+    const parsed = record as typeof workspace;
+    workspaces.set(parsed.workspaceId, parsed);
+  };
+
+  await session.handleMessage({
+    type: "workspace.tabs.pins.set.request",
+    workspaceId: workspace.workspaceId,
+    pinnedTabs: [],
+    requestId: "req-pins-clear",
+  });
+
+  const response = findByType(emitted, "workspace.tabs.pins.set.response");
+  expect(response?.payload).toEqual({
+    requestId: "req-pins-clear",
+    workspaceId: workspace.workspaceId,
+    accepted: true,
+    pinnedTabs: [],
+    error: null,
+  });
+  expect(workspaces.get(workspace.workspaceId)?.pinnedTabs).toEqual([]);
+});
+
+test("workspace.tabs.pins.set.request returns accepted=false when workspace is not found", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const session = asTestSession(
+    createSessionForWorkspaceTests({ onMessage: (message) => emitted.push(message) }),
+  );
+  session.workspaceRegistry.get = async () => null;
+
+  await session.handleMessage({
+    type: "workspace.tabs.pins.set.request",
+    workspaceId: "does-not-exist",
+    pinnedTabs: ["agent_a1"],
+    requestId: "req-pins-missing",
+  });
+
+  const response = findByType(emitted, "workspace.tabs.pins.set.response");
+  expect(response?.payload).toMatchObject({
+    requestId: "req-pins-missing",
+    workspaceId: "does-not-exist",
+    accepted: false,
+    pinnedTabs: [],
+  });
+  expect(response?.payload.error).toBeTruthy();
+});
+
 function createSessionWithTerminalManager(options: {
   workspaces: PersistedWorkspaceRecord[];
   projects: PersistedProjectRecord[];

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1238,6 +1238,8 @@ export class VoiceAssistantWebSocketServer {
         daemonSelfUpdate: true,
         // COMPAT(agentForkContext): added in v0.1.102, remove gate after 2026-12-28.
         agentForkContext: true,
+        // COMPAT(workspaceTabPins): added in v0.1.104, drop the gate when floor >= v0.1.104.
+        workspaceTabPins: true,
       },
     };
   }

--- a/packages/server/src/server/workspace-registry.test.ts
+++ b/packages/server/src/server/workspace-registry.test.ts
@@ -211,4 +211,44 @@ describe("workspace registries", () => {
     expect(await workspaceRegistry.get("/tmp/repo")).toBeNull();
     expect(await workspaceRegistry.list()).toEqual([]);
   });
+
+  test("workspace record schema defaults pinnedTabs to [] (legacy on-disk records)", async () => {
+    await workspaceRegistry.initialize();
+
+    await workspaceRegistry.upsert(
+      createPersistedWorkspaceRecord({
+        workspaceId: "/tmp/repo",
+        projectId: "remote:github.com/acme/repo",
+        cwd: "/tmp/repo",
+        kind: "local_checkout",
+        displayName: "main",
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    );
+
+    const record = await workspaceRegistry.get("/tmp/repo");
+    expect(record?.pinnedTabs).toEqual([]);
+  });
+
+  test("workspace record persists pinnedTabs across upserts", async () => {
+    await workspaceRegistry.initialize();
+
+    const base = createPersistedWorkspaceRecord({
+      workspaceId: "/tmp/repo",
+      projectId: "remote:github.com/acme/repo",
+      cwd: "/tmp/repo",
+      kind: "local_checkout",
+      displayName: "main",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    });
+    await workspaceRegistry.upsert({
+      ...base,
+      pinnedTabs: ["agent_a1", "file_/tmp/repo/README.md"],
+    });
+
+    const record = await workspaceRegistry.get("/tmp/repo");
+    expect(record?.pinnedTabs).toEqual(["agent_a1", "file_/tmp/repo/README.md"]);
+  });
 });

--- a/packages/server/src/server/workspace-registry.ts
+++ b/packages/server/src/server/workspace-registry.ts
@@ -53,6 +53,13 @@ const PersistedWorkspaceRecordSchema = z.object({
     .nullable()
     .optional()
     .transform((value) => value ?? null),
+  // Deterministic tab ids the user pinned in this workspace, in pin order.
+  // Pinned tabs render first in the tab strip on every device. Keys for tabs
+  // that no longer exist are harmless — clients ignore unknown keys.
+  pinnedTabs: z
+    .array(z.string())
+    .optional()
+    .transform((value) => value ?? []),
   createdAt: z.string(),
   updatedAt: z.string(),
   archivedAt: z.string().nullable(),


### PR DESCRIPTION
## Summary

Adds a **Pin tab** option to the workspace tab context menu (desktop and mobile). Pinned tabs stick to the left of the tab strip, and the pinned state is persisted on the daemon — open the workspace on any device and the same tabs are pinned in the same order.

## How it works

- **Pin keys are deterministic tab ids** (`agent_<id>`, `file_<path>`, `terminal_<id>`, …) via the existing `buildDeterministicWorkspaceTabId`, so a pin made on one device resolves to the same tab on every other device — local `tabId`s never leave the client.
- **Server-side persistence:** the pin list lives on the workspace registry record (`workspaces.json`), mutated by a new `workspace.tabs.pins.set.request`/`.response` RPC that mirrors `workspace.title.set`. The handler dedupes/trims keys, upserts the record, and emits a `workspace_update` so connected clients converge.
- **Ordering:** `deriveWorkspacePaneState` sorts pinned tabs first (in pin order; unpinned tabs keep their local order), which covers the desktop tab row, split panes (including drag-and-drop index math), and the mobile tab switcher from one choke point. Stale pin keys with no matching open tab are ignored harmlessly.
- **Menu:** `Pin tab` / `Unpin tab` entry with lucide `Pin`/`PinOff` icons, placed above the close group, localized in all 8 locales.

## Protocol compatibility

- `WorkspaceDescriptorPayloadSchema.pinnedTabs` is a new **optional** field; old clients ignore it, old daemons omit it.
- New capability flag `server_info.features.workspaceTabPins` gates the UI — on older daemons the menu entry simply doesn't render, no fallback paths. Tagged `COMPAT(workspaceTabPins)` per convention.
- New RPC follows the dotted-namespace convention from docs/rpc-namespacing.md.

## Tests

- `workspace-tab-pins.test.ts` (new): key derivation, toggle, pinned-first sorting.
- `workspace-tab-menu.test.ts`: pin entry presence/absence, labels, icons, placement, toggle callback.
- `workspace-pane-state.test.ts`: pinned-first pane ordering.
- `session.workspaces.test.ts`: RPC handler — dedupe + descriptor update, clearing pins, unknown workspace.
- `workspace-registry.test.ts`: legacy records default to `[]`, pins persist across upserts.

`npm run typecheck`, `npm run lint`, and all targeted suites pass; full protocol AOT validator regen is clean.
