### PR TITLE
fix(app): refresh checkout status when opening New Workspace

### DIFF
--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -1687,8 +1687,12 @@ export function NewWorkspaceScreen({
       return connectedClient.getCheckoutStatus(selectedSourceDirectory);
     },
     enabled: clientReady && hasSelectedSourceDirectory,
-    staleTime: Infinity,
-    refetchOnMount: false,
+    // The New Workspace screen is opened deliberately and short-lived, so it must
+    // reflect the project's live checkout each time. A frozen cache (staleTime:
+    // Infinity) would pre-fill a stale base branch after the user switches branches
+    // in the underlying checkout. Refetch on mount with a short stale window.
+    staleTime: 5_000,
+    refetchOnMount: true,
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
   });


### PR DESCRIPTION
## Problem

The New Workspace base-ref picker pre-fills a stale base branch. It reads the project's checkout status from a react-query cache pinned with `staleTime: Infinity` and every refetch trigger disabled, so the value is fetched once and frozen for the session. After switching branches in the underlying checkout, the picker keeps offering the old branch as the base — and new worktrees then branch off / compare against the wrong base (surfacing as "No changes vs `<stale-branch>`" in the diff panel).

Fixes #1969.

## Fix

`/new` is an expo-router route that remounts on each navigation, so refetching on mount is enough to reflect live git state. Set `refetchOnMount: true` with a short finite `staleTime` (5s, to suppress churn during rapid reopens) on the checkout-status query.

## Verification

- `npm run typecheck` (full workspace, via pre-commit hook) — clean
- `npm run lint` / `npm run format:check` on the changed file — clean
- Confirmed the route remounts on navigation (`packages/app/src/app/new.tsx`), so `refetchOnMount` fires each open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)