### PR TITLE
fix(app): decode percent-encoded assistant file paths

### DIFF
--- a/packages/app/src/assistant-file-links/parse.test.ts
+++ b/packages/app/src/assistant-file-links/parse.test.ts
@@ -271,6 +271,48 @@ describe("parseAssistantFileLink", () => {
     });
   });
 
+  it("decodes percent-encoded unicode in workspace-relative hrefs", () => {
+    expect(
+      parseAssistantFileLink("docs/%E4%B8%AD%E6%96%87/%E6%8A%A5%E5%91%8A.md", {
+        workspaceRoot: "/Users/test/project",
+      }),
+    ).toEqual({
+      raw: "docs/%E4%B8%AD%E6%96%87/%E6%8A%A5%E5%91%8A.md",
+      path: "/Users/test/project/docs/中文/报告.md",
+      lineStart: undefined,
+      lineEnd: undefined,
+    });
+  });
+
+  it("decodes percent-encoded unicode before parsing an absolute href line suffix", () => {
+    expect(
+      parseAssistantFileLink(
+        "/Users/test/project/docs/%E4%B8%AD%E6%96%87/%E6%8A%A5%E5%91%8A.md:89",
+        {
+          workspaceRoot: "/Users/test/project",
+        },
+      ),
+    ).toEqual({
+      raw: "/Users/test/project/docs/%E4%B8%AD%E6%96%87/%E6%8A%A5%E5%91%8A.md:89",
+      path: "/Users/test/project/docs/中文/报告.md",
+      lineStart: 89,
+      lineEnd: undefined,
+    });
+  });
+
+  it("decodes percent-encoded paths exactly once", () => {
+    expect(
+      parseAssistantFileLink("docs/%2525-notes.md", {
+        workspaceRoot: "/Users/test/project",
+      }),
+    ).toEqual({
+      raw: "docs/%2525-notes.md",
+      path: "/Users/test/project/docs/%25-notes.md",
+      lineStart: undefined,
+      lineEnd: undefined,
+    });
+  });
+
   it("parses absolute POSIX hrefs inside the active workspace", () => {
     expect(
       parseAssistantFileLink("/Users/test/project/src/app.tsx#L33", {
@@ -307,6 +349,19 @@ describe("parseAssistantFileLink", () => {
       path: "C:/repo/src/app.tsx",
       lineStart: 12,
       lineEnd: 20,
+    });
+  });
+
+  it("decodes percent-encoded unicode in absolute Windows hrefs", () => {
+    expect(
+      parseAssistantFileLink("C:/repo/docs/%E4%B8%AD%E6%96%87/%E6%8A%A5%E5%91%8A.md", {
+        workspaceRoot: "C:/repo",
+      }),
+    ).toEqual({
+      raw: "C:/repo/docs/%E4%B8%AD%E6%96%87/%E6%8A%A5%E5%91%8A.md",
+      path: "C:/repo/docs/中文/报告.md",
+      lineStart: undefined,
+      lineEnd: undefined,
     });
   });
 

--- a/packages/app/src/assistant-file-links/parse.ts
+++ b/packages/app/src/assistant-file-links/parse.ts
@@ -172,7 +172,7 @@ export function parseInlinePathToken(value: string): InlinePathTarget | null {
     return null;
   }
 
-  const normalizedPath = normalizePathToken(basePathRaw);
+  const normalizedPath = normalizePathToken(safeDecodeURIComponent(basePathRaw));
   if (!normalizedPath) {
     return null;
   }
@@ -315,7 +315,7 @@ export function parseAssistantFileLink(
 
   const windowsPathMatch = trimmed.match(/^([A-Za-z]:[\\/][^?#]*)(#[^?]+)?$/);
   if (windowsPathMatch) {
-    const normalizedPath = normalizePathToken(windowsPathMatch[1] ?? "");
+    const normalizedPath = normalizePathToken(safeDecodeURIComponent(windowsPathMatch[1] ?? ""));
     if (!normalizedPath) {
       return null;
     }
@@ -451,16 +451,17 @@ function parseLocalPathParts(
     };
   }
 
-  if (!beforeHash || beforeHash.includes(":")) {
+  const decodedPath = normalizePathToken(safeDecodeURIComponent(beforeHash));
+  if (!decodedPath || decodedPath.includes(":")) {
     return null;
   }
 
-  if (!isPlausibleAssistantLocalPath(beforeHash)) {
+  if (!isPlausibleAssistantLocalPath(decodedPath)) {
     return null;
   }
 
   return {
-    path: beforeHash,
+    path: decodedPath,
     lines: fragmentLines,
   };
 }


### PR DESCRIPTION
### Linked issue

Closes #684

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Assistant Markdown hrefs arrive percent-encoded. The parser already decoded `file://` URLs and plain absolute paths, but workspace-relative paths and paths with line suffixes bypassed that decoding. The encoded path then reached the daemon's filesystem read and failed with `ENOENT` for CJK filenames.

This change safely decodes each parsed path component exactly once across relative, line-suffixed, and Windows absolute hrefs. Invalid percent sequences keep the existing fallback behavior, and double-encoded literal percent signs are not over-decoded.

### How did you verify it

- Added regression coverage for workspace-relative CJK hrefs, line-suffixed absolute CJK hrefs, Windows CJK hrefs, and one-layer-only decoding.
- Confirmed the new relative-path test failed before the implementation because the returned filesystem path still contained `%E4...`.
- Ran `npx vitest run packages/app/src/assistant-file-links/parse.test.ts packages/app/src/assistant-file-links/resolver.test.ts packages/app/src/assistant-file-links/use-file-link.test.tsx --bail=1` (59 tests passed).
- Ran `npm run typecheck`.
- Ran `npm run lint`.
- Ran `npm run format` and the targeted format check.
- Web desktop manual QA: seeded a mock assistant response whose Markdown href was `docs/%E4%B8%AD%E6%96%87/%E6%8A%A5%E5%91%8A.md`, clicked it, and confirmed the `报告.md` tab rendered the real file's heading and body. No `ENOENT` was logged.
- Manual UI QA was performed on the Web desktop client. iOS, Android, and Electron were not separately tested; this does not change UI rendering.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI screenshots or video not applicable; there is no visual UI change
- [x] Tests added or updated where it made sense
