### PR TITLE
Restore the mobile left sidebar swipe

### DIFF
--- a/docs/mobile-panels.md
+++ b/docs/mobile-panels.md
@@ -70,6 +70,9 @@ definition, no longer eligible to begin.
 
 - Callers request semantic targets through `panel-store`; they never write shared values.
 - Gesture behavior comes from the four explicit hooks in `mobile-panels/gestures.ts`.
+- Keep `SidebarModelProvider` outside `MobileGestureWrapper`. The provider shares sidebar derivation
+  across consumers, while Gesture Handler requires the wrapper's direct child to be a native `View`
+  so its injected `collapsable={false}` reaches Android/Fabric.
 - Mobile sidebars render through `MobilePanelOverlay`; do not duplicate overlay lifecycle or motion
   styles in sidebar components.
 - Animated panel nodes use React Native static styles plus inline theme values. Do not attach

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -464,33 +464,33 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
     </View>
   );
 
-  const content = (
-    <SidebarModelProvider>
-      <View style={layoutStyles.surfaceFill}>
-        {workspaceChrome}
-        <FloatingPanelPortalHost />
-        {isCompactLayout && chromeEnabled && <LeftSidebar />}
-        <DownloadToast />
-        <RosettaCalloutSource />
-        <UpdateCalloutSource />
-        <WorktreeSetupCalloutSource />
-        <CommandCenter />
-        <HostChooserModal />
-        <ProjectPickerModal />
-        <ProviderSettingsHost />
-        <WorkspaceShortcutTargetsSubscriber enabled={keyboardShortcutsEnabled} />
-        <WorkspaceSetupDialog />
-        <KeyboardShortcutsDialog />
-        <QuittingOverlay />
-      </View>
-    </SidebarModelProvider>
+  const surface = (
+    <View style={layoutStyles.surfaceFill}>
+      {workspaceChrome}
+      <FloatingPanelPortalHost />
+      {isCompactLayout && chromeEnabled && <LeftSidebar />}
+      <DownloadToast />
+      <RosettaCalloutSource />
+      <UpdateCalloutSource />
+      <WorktreeSetupCalloutSource />
+      <CommandCenter />
+      <HostChooserModal />
+      <ProjectPickerModal />
+      <ProviderSettingsHost />
+      <WorkspaceShortcutTargetsSubscriber enabled={keyboardShortcutsEnabled} />
+      <WorkspaceSetupDialog />
+      <KeyboardShortcutsDialog />
+      <QuittingOverlay />
+    </View>
   );
 
-  if (!isCompactLayout) {
-    return content;
-  }
+  const content = isCompactLayout ? (
+    <MobileGestureWrapper chromeEnabled={chromeEnabled}>{surface}</MobileGestureWrapper>
+  ) : (
+    surface
+  );
 
-  return <MobileGestureWrapper chromeEnabled={chromeEnabled}>{content}</MobileGestureWrapper>;
+  return <SidebarModelProvider>{content}</SidebarModelProvider>;
 }
 
 function MobileGestureWrapper({


### PR DESCRIPTION
### Linked issue

None found after searching the open issue tracker for mobile sidebar and gesture reports.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Restores opening the left sidebar with a rightward swipe on compact native layouts.

The shared sidebar model had become the root gesture detector's direct child, which allowed Android/Fabric to flatten the native attachment view. This keeps one shared sidebar model for the responsiveness optimization while restoring the existing native surface as the gesture owner. The revisioned mobile-panel state, gesture hooks, and presentation lifecycle remain unchanged.

### How did you verify it

- Reproduced on a USB-connected Android development client served by Metro on port 8081: an exact left-edge drag did nothing before the fix, while the menu button still opened the sidebar and the close swipe still worked.
- After the change and a full Metro reload, the same edge drag opened the left sidebar and the flattening warning no longer appeared in LogBox or the captured app log.
- Verified left-panel open/close, right-panel open/close, partial-drag cancellation, and a full open immediately after cancellation on the physical device.
- Ran `npx vitest run packages/app/src/mobile-panels/model.test.ts packages/app/src/components/workspace-shortcut-targets-subscriber.test.tsx --bail=1` — 11 tests passed.
- Ran `npm run typecheck`, `npm run lint`, and `npm run format`.

### Risk surface

This changes only the compact React Native component tree. Non-compact desktop layout still renders one shared provider around the same native surface, and there are no state, protocol, or persistence changes. The failing path was verified on Android/Fabric; an iOS compact-layout smoke test remains useful before merge.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
