### PR TITLE
Show Windows file links relative to their workspace

### DIFF
--- a/packages/app/src/assistant-file-links/link.tsx
+++ b/packages/app/src/assistant-file-links/link.tsx
@@ -18,6 +18,7 @@ import { useStableEvent } from "@/hooks/use-stable-event";
 import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
 import { useAssistantFileLinkResolverContext } from "./provider";
 import type { AssistantFileLinkSource } from "./resolver";
+import { formatFileLinkTooltipPath } from "./tooltip-path";
 import { useFileLink } from "./use-file-link";
 
 interface AssistantMarkdownLinkProps {
@@ -38,7 +39,7 @@ export function AssistantMarkdownLink({
   const { configRef } = useAssistantFileLinkResolverContext();
   const workspaceRoot = configRef.current.workspaceRoot;
   const tooltipPath = useMemo(
-    () => (target ? formatInlinePathTargetForTooltip(target, workspaceRoot) : null),
+    () => (target ? formatFileLinkTooltipPath({ target, workspaceRoot }) : null),
     [target, workspaceRoot],
   );
   const handleAnchorClickCapture = useStableEvent((event: MouseEvent<HTMLAnchorElement>) => {
@@ -145,38 +146,6 @@ export function AssistantMarkdownCodeLink({
       {children}
     </AssistantMarkdownLink>
   );
-}
-
-function formatInlinePathTargetForTooltip(
-  target: { path: string; lineStart?: number; lineEnd?: number },
-  workspaceRoot: string | undefined,
-): string {
-  let result = relativizePathToWorkspace(target.path, workspaceRoot);
-  if (target.lineStart) {
-    result += `:${target.lineStart}`;
-    if (target.lineEnd && target.lineEnd !== target.lineStart) {
-      result += `-${target.lineEnd}`;
-    }
-  }
-  return result;
-}
-
-function relativizePathToWorkspace(filePath: string, workspaceRoot: string | undefined): string {
-  if (!workspaceRoot) {
-    return filePath;
-  }
-  const root = workspaceRoot.replace(/\/+$/, "");
-  if (!root) {
-    return filePath;
-  }
-  if (filePath === root) {
-    return ".";
-  }
-  const prefix = `${root}/`;
-  if (filePath.startsWith(prefix)) {
-    return filePath.slice(prefix.length);
-  }
-  return filePath;
 }
 
 interface AssistantInlineCodePathLinkProps {

--- a/packages/app/src/assistant-file-links/tooltip-path.test.ts
+++ b/packages/app/src/assistant-file-links/tooltip-path.test.ts
@@ -14,4 +14,28 @@ describe("formatFileLinkTooltipPath", () => {
       }),
     ).toBe("src/app.ts:12-20");
   });
+
+  it("shows the workspace root as a dot", () => {
+    expect(
+      formatFileLinkTooltipPath({
+        target: { path: "/Users/me/repo" },
+        workspaceRoot: "/Users/me/repo",
+      }),
+    ).toBe(".");
+  });
+
+  it("keeps an absolute path outside the workspace", () => {
+    expect(
+      formatFileLinkTooltipPath({
+        target: { path: "/Users/me/notes.md" },
+        workspaceRoot: "/Users/me/repo",
+      }),
+    ).toBe("/Users/me/notes.md");
+  });
+
+  it("keeps the target path when the workspace root is unavailable", () => {
+    expect(formatFileLinkTooltipPath({ target: { path: "src/app.ts", lineStart: 12 } })).toBe(
+      "src/app.ts:12",
+    );
+  });
 });

--- a/packages/app/src/assistant-file-links/tooltip-path.test.ts
+++ b/packages/app/src/assistant-file-links/tooltip-path.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { formatFileLinkTooltipPath } from "./tooltip-path";
+
+describe("formatFileLinkTooltipPath", () => {
+  it("shows a Windows file path relative to its workspace regardless of separators", () => {
+    expect(
+      formatFileLinkTooltipPath({
+        target: {
+          path: "C:/Users/me/repo/src/app.ts",
+          lineStart: 12,
+          lineEnd: 20,
+        },
+        workspaceRoot: "C:\\Users\\me\\repo",
+      }),
+    ).toBe("src/app.ts:12-20");
+  });
+});

--- a/packages/app/src/assistant-file-links/tooltip-path.ts
+++ b/packages/app/src/assistant-file-links/tooltip-path.ts
@@ -1,4 +1,5 @@
 import { resolveWorkspaceFilePaths, type WorkspaceFileLocation } from "@/workspace/file-open";
+import { normalizeWorkspacePath } from "@/utils/workspace-identity";
 
 interface FormatFileLinkTooltipPathInput {
   target: WorkspaceFileLocation;
@@ -9,10 +10,21 @@ export function formatFileLinkTooltipPath({
   target,
   workspaceRoot,
 }: FormatFileLinkTooltipPathInput): string {
+  const normalizedTargetPath = normalizeWorkspacePath(target.path);
+  const normalizedWorkspaceRoot = normalizeWorkspacePath(workspaceRoot);
+  let isWorkspaceRoot = false;
+  if (normalizedTargetPath && normalizedWorkspaceRoot) {
+    isWorkspaceRoot = normalizedTargetPath === normalizedWorkspaceRoot;
+    if (/^[A-Za-z]:\//.test(normalizedTargetPath)) {
+      isWorkspaceRoot =
+        normalizedTargetPath.toLowerCase() === normalizedWorkspaceRoot.toLowerCase();
+    }
+  }
+
   const resolvedPaths = workspaceRoot
     ? resolveWorkspaceFilePaths({ path: target.path, workspaceRoot })
     : null;
-  let result = resolvedPaths?.relativePath ?? target.path;
+  let result = isWorkspaceRoot ? "." : (resolvedPaths?.relativePath ?? target.path);
   if (target.lineStart) {
     result += `:${target.lineStart}`;
     if (target.lineEnd && target.lineEnd !== target.lineStart) {

--- a/packages/app/src/assistant-file-links/tooltip-path.ts
+++ b/packages/app/src/assistant-file-links/tooltip-path.ts
@@ -1,0 +1,23 @@
+import { resolveWorkspaceFilePaths, type WorkspaceFileLocation } from "@/workspace/file-open";
+
+interface FormatFileLinkTooltipPathInput {
+  target: WorkspaceFileLocation;
+  workspaceRoot?: string;
+}
+
+export function formatFileLinkTooltipPath({
+  target,
+  workspaceRoot,
+}: FormatFileLinkTooltipPathInput): string {
+  const resolvedPaths = workspaceRoot
+    ? resolveWorkspaceFilePaths({ path: target.path, workspaceRoot })
+    : null;
+  let result = resolvedPaths?.relativePath ?? target.path;
+  if (target.lineStart) {
+    result += `:${target.lineStart}`;
+    if (target.lineEnd && target.lineEnd !== target.lineStart) {
+      result += `-${target.lineEnd}`;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Assistant file-link tooltips could show a full Windows path when the resolved file used forward slashes and the workspace root used backslashes. Tooltip formatting now reuses the existing workspace file-path resolver, so in-workspace files display as normalized relative paths while line and range suffixes stay intact. Workspace-root links keep their existing `.` display.

### How did you verify it

- Added focused coverage for mixed Windows separators, workspace-root display, out-of-workspace paths, and missing workspace roots.
- Confirmed the workspace-root regression test failed before the review fix and all four cases passed afterward.
- `npx vitest run packages/app/src/assistant-file-links/tooltip-path.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint -- packages/app/src/assistant-file-links/tooltip-path.ts packages/app/src/assistant-file-links/tooltip-path.test.ts`
- `npm run format`

Before merge, smoke the tooltip on Windows desktop; this environment did not provide a Windows UI capture.

### Risk surface

Only tooltip display formatting changes. File-link resolution and click behavior are unchanged.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
