### PR TITLE
Stop app tests failing after chat teardown

### DIFF
--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -152,6 +152,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
 
   const rowVirtualizer = useVirtualizer({
     count: segments.historyVirtualized.length,
+    enabled: shouldUseVirtualizer,
     getScrollElement: () => scrollContainerRef.current,
     getItemKey: (index: number) => segments.historyVirtualized[index]?.id ?? index,
     estimateSize: (index: number) => {


### PR DESCRIPTION
### Linked issue

None — no matching open issue.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Plain chats were starting the history virtualizer even when they had no virtualized rows. Its scroll-end fallback could leave a delayed React update alive after the view unmounted, which intermittently failed the app test job when the test environment disappeared.

The virtualizer now stays disabled until virtualized history is present. Virtualized chats keep the existing behavior, while plain chats no longer install the unused listener or delayed callback.

This addresses the identical teardown failure in [run 29144856539](https://github.com/getpaseo/paseo/actions/runs/29144856539/job/86524544590) and [run 28971467255](https://github.com/getpaseo/paseo/actions/runs/28971467255/job/85967958936).

### How did you verify it

- Added a temporary deterministic teardown assertion: a plain-chat scroll left 1 scheduled callback before the fix and 0 after it.
- Ran `npx vitest run packages/app/src/agent-stream/strategy-web.test.tsx --bail=1` ten consecutive times; all 60 tests passed.
- Ran `npm run typecheck` successfully.
- Ran `npm run lint` with 0 warnings and 0 errors.
- Ran `npm run format` successfully.

The change only gates the existing virtualizer for the already non-virtualized path. No extra platform or visual verification is needed before merge.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI change)
- [x] Tests added or updated where it made sense
