### PR TITLE
Verify real agent workflows through the hosted relay

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -60,6 +60,7 @@
     "test:e2e:all": "vitest run e2e.test.ts --maxWorkers=1",
     "test:e2e:real": "npm run test:integration:real",
     "test:e2e:local": "npm run test:integration:local",
+    "test:e2e:relay:live": "cross-env RUN_LIVE_RELAY_E2E=1 vitest run src/server/daemon-e2e/live-relay.real.e2e.test.ts --maxWorkers=1",
     "test:e2e:ui": "vitest --ui e2e.test.ts"
   },
   "dependencies": {

--- a/packages/server/src/server/daemon-e2e/live-relay.real.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/live-relay.real.e2e.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { DaemonClient } from "../test-utils/daemon-client.js";
+import { createTestPaseoDaemon, type TestPaseoDaemon } from "../test-utils/paseo-daemon.js";
+import { generateLocalPairingOffer } from "../pairing-offer.js";
+import { buildRelayWebSocketUrl } from "@getpaseo/protocol/daemon-endpoints";
+import {
+  parseConnectionOfferFromUrl,
+  type ConnectionOffer,
+} from "@getpaseo/protocol/connection-offer";
+
+const relayEndpoint = process.env.PASEO_LIVE_RELAY_ENDPOINT ?? "paseo-relay-next.fly.dev:443";
+const liveTest = process.env.RUN_LIVE_RELAY_E2E === "1" ? test : test.skip;
+
+function requireOffer(url: string): ConnectionOffer {
+  const offer = parseConnectionOfferFromUrl(url);
+  if (!offer) {
+    throw new Error("Pairing did not produce a relay connection offer");
+  }
+  return offer;
+}
+
+async function pairingOfferFor(daemon: TestPaseoDaemon): Promise<ConnectionOffer> {
+  const pairing = await generateLocalPairingOffer({
+    paseoHome: daemon.paseoHome,
+    relayEnabled: true,
+    relayEndpoint,
+    relayPublicEndpoint: relayEndpoint,
+    relayUseTls: true,
+    relayPublicUseTls: true,
+    includeQr: false,
+  });
+  if (!pairing.url) {
+    throw new Error("Pairing did not produce a URL");
+  }
+  return requireOffer(pairing.url);
+}
+
+function clientFor(offer: ConnectionOffer): DaemonClient {
+  return new DaemonClient({
+    url: buildRelayWebSocketUrl({
+      endpoint: offer.relay.endpoint,
+      useTls: true,
+      serverId: offer.serverId,
+      role: "client",
+    }),
+    clientId: "clid_live_relay_acceptance",
+    clientType: "cli",
+    connectTimeoutMs: 30_000,
+    e2ee: { enabled: true, daemonPublicKeyB64: offer.daemonPublicKeyB64 },
+    reconnect: { enabled: false },
+  });
+}
+
+describe("live hosted relay", () => {
+  let daemon: TestPaseoDaemon | null = null;
+  let client: DaemonClient | null = null;
+
+  afterEach(async () => {
+    await client?.close().catch(() => undefined);
+    await daemon?.close();
+  });
+
+  liveTest(
+    "carries a complete DaemonClient agent workflow through the hosted relay",
+    async () => {
+      daemon = await createTestPaseoDaemon({
+        listen: "127.0.0.1",
+        relayEnabled: true,
+        relayEndpoint,
+        relayUseTls: true,
+      });
+      const offer = await pairingOfferFor(daemon);
+      client = clientFor(offer);
+
+      await client.connect();
+      const initialAgents = await client.fetchAgents();
+      const agent = await client.createAgent({
+        provider: "codex",
+        cwd: daemon.staticDir,
+        title: "Live relay acceptance",
+        modeId: "full-access",
+      });
+      await client.sendMessage(agent.id, "Respond with exactly: RELAY_ACCEPTANCE_OK");
+      const finished = await client.waitForFinish(agent.id, 10_000);
+      const timeline = await client.fetchAgentTimeline(agent.id, {
+        direction: "tail",
+        limit: 1,
+        projection: "canonical",
+      });
+
+      expect(initialAgents.entries).toEqual([]);
+      expect(agent).toMatchObject({
+        provider: "codex",
+        cwd: daemon.staticDir,
+        status: "idle",
+      });
+      expect(finished).toMatchObject({ status: "idle" });
+      expect(timeline.entries.map((entry) => entry.item)).toEqual([
+        { type: "assistant_message", text: "RELAY_ACCEPTANCE_OK" },
+      ]);
+    },
+    60_000,
+  );
+});

--- a/packages/server/src/server/daemon-e2e/live-relay.real.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/live-relay.real.e2e.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from "vitest";
+import pino from "pino";
 
 import { DaemonClient } from "../test-utils/daemon-client.js";
 import { createTestPaseoDaemon, type TestPaseoDaemon } from "../test-utils/paseo-daemon.js";
 import { generateLocalPairingOffer } from "../pairing-offer.js";
+import { CodexAppServerAgentClient } from "../agent/providers/codex-app-server-agent.js";
 import { buildRelayWebSocketUrl } from "@getpaseo/protocol/daemon-endpoints";
 import {
   parseConnectionOfferFromUrl,
@@ -64,11 +66,14 @@ describe("live hosted relay", () => {
   liveTest(
     "carries a complete DaemonClient agent workflow through the hosted relay",
     async () => {
+      const logger = pino({ level: "silent" });
       daemon = await createTestPaseoDaemon({
         listen: "127.0.0.1",
         relayEnabled: true,
         relayEndpoint,
         relayUseTls: true,
+        agentClients: { codex: new CodexAppServerAgentClient(logger) },
+        logger,
       });
       const offer = await pairingOfferFor(daemon);
       client = clientFor(offer);
@@ -82,12 +87,16 @@ describe("live hosted relay", () => {
         modeId: "full-access",
       });
       await client.sendMessage(agent.id, "Respond with exactly: RELAY_ACCEPTANCE_OK");
-      const finished = await client.waitForFinish(agent.id, 30_000);
+      const finished = await client.waitForFinish(agent.id, 120_000);
       const timeline = await client.fetchAgentTimeline(agent.id, {
         direction: "tail",
-        limit: 1,
+        limit: 20,
         projection: "canonical",
       });
+      const assistantText = timeline.entries
+        .filter((entry) => entry.item.type === "assistant_message")
+        .map((entry) => entry.item.text)
+        .join("");
 
       expect(initialAgents.entries).toEqual([]);
       expect(agent).toMatchObject({
@@ -96,13 +105,8 @@ describe("live hosted relay", () => {
         status: "idle",
       });
       expect(finished).toMatchObject({ status: "idle" });
-      expect(timeline.entries.map((entry) => entry.item)).toEqual([
-        {
-          type: "assistant_message",
-          text: expect.stringMatching(/^RELAY_ACCEPTANCE_OK\s*$/),
-        },
-      ]);
+      expect(assistantText).toMatch(/^RELAY_ACCEPTANCE_OK\s*$/);
     },
-    90_000,
+    180_000,
   );
 });

--- a/packages/server/src/server/daemon-e2e/live-relay.real.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/live-relay.real.e2e.test.ts
@@ -82,7 +82,7 @@ describe("live hosted relay", () => {
         modeId: "full-access",
       });
       await client.sendMessage(agent.id, "Respond with exactly: RELAY_ACCEPTANCE_OK");
-      const finished = await client.waitForFinish(agent.id, 10_000);
+      const finished = await client.waitForFinish(agent.id, 30_000);
       const timeline = await client.fetchAgentTimeline(agent.id, {
         direction: "tail",
         limit: 1,
@@ -97,9 +97,12 @@ describe("live hosted relay", () => {
       });
       expect(finished).toMatchObject({ status: "idle" });
       expect(timeline.entries.map((entry) => entry.item)).toEqual([
-        { type: "assistant_message", text: "RELAY_ACCEPTANCE_OK" },
+        {
+          type: "assistant_message",
+          text: expect.stringMatching(/^RELAY_ACCEPTANCE_OK\s*$/),
+        },
       ]);
     },
-    60_000,
+    90_000,
   );
 });

--- a/packages/server/src/server/test-utils/paseo-daemon.ts
+++ b/packages/server/src/server/test-utils/paseo-daemon.ts
@@ -23,6 +23,8 @@ interface TestPaseoDaemonOptions {
   isDev?: boolean;
   relayEnabled?: boolean;
   relayEndpoint?: string;
+  relayUseTls?: boolean;
+  relayPublicUseTls?: boolean;
   agentClients?: Partial<Record<AgentProvider, AgentClient>>;
   providerOverrides?: PaseoDaemonConfig["providerOverrides"];
   paseoHomeRoot?: string;
@@ -166,6 +168,8 @@ async function prepareTestDaemonConfig(
     agentStoragePath: path.join(paseoHome, "agents"),
     relayEnabled: options.relayEnabled ?? false,
     relayEndpoint: options.relayEndpoint ?? "relay.paseo.sh:443",
+    relayUseTls: options.relayUseTls,
+    relayPublicUseTls: options.relayPublicUseTls,
     appBaseUrl: "https://app.paseo.sh",
     auth: options.auth,
     pushNotificationSender: options.pushNotificationSender,


### PR DESCRIPTION
### Linked issue

None — this is focused integration-test coverage.

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds an opt-in end-to-end test that pairs an isolated daemon through the hosted TLS relay, connects an encrypted client, creates a real Codex agent, sends a message, waits for completion, and verifies the final timeline response. It also lets the daemon test harness configure relay TLS so the acceptance test exercises the deployed connection shape.

This gives us one explicit command for validating the full hosted relay path instead of proving only its local pieces.

### How did you verify it

- `npm run test:e2e:relay:live --workspace=@getpaseo/server` — 1 test passed against `paseo-relay-next.fly.dev:443`, including the exact `RELAY_ACCEPTANCE_OK` agent response.
- `npm run typecheck`
- `npm run lint`
- `npm run format`

The live test depends on hosted relay availability and local Codex authentication, so it remains an explicit acceptance command rather than part of deterministic default CI.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] No UI changes
- [x] Tests added or updated where it made sense
