### PR TITLE
Stop Pi metadata tasks from cluttering session history

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -100,7 +100,6 @@ test("keeps normal Pi agent sessions persisted", async () => {
   const client = createClient(pi);
   const session = await client.createSession(createConfig());
 
-  expect(pi.recordedLaunches[0]?.noSession).toBe(false);
   expect(pi.recordedLaunches[0]?.argv).not.toContain("--no-session");
 
   await session.close();

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -82,6 +82,30 @@ test("forwards launch-context env to the Pi process launch", async () => {
   await session.close();
 });
 
+test("starts internal Pi agents without persisting a native session", async () => {
+  const pi = new FakePi();
+  const client = createClient(pi);
+  const session = await client.createSession(createConfig({ internal: true }));
+
+  expect(pi.recordedLaunches[0]).toMatchObject({
+    noSession: true,
+    argv: expect.arrayContaining(["--no-session"]),
+  });
+
+  await session.close();
+});
+
+test("keeps normal Pi agent sessions persisted", async () => {
+  const pi = new FakePi();
+  const client = createClient(pi);
+  const session = await client.createSession(createConfig());
+
+  expect(pi.recordedLaunches[0]?.noSession).toBe(false);
+  expect(pi.recordedLaunches[0]?.argv).not.toContain("--no-session");
+
+  await session.close();
+});
+
 class SessionEvents {
   private readonly events: AgentStreamEvent[] = [];
   private readonly waiters: Array<{

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1920,6 +1920,7 @@ export class PiRpcAgentClient implements AgentClient {
         model: config.model,
         thinkingOptionId:
           normalizePiThinkingOption(config.thinkingOptionId) ?? DEFAULT_PI_THINKING_LEVEL,
+        noSession: config.internal === true,
         systemPrompt: composeSystemPromptParts(
           config.systemPrompt,
           config.daemonAppendSystemPrompt,

--- a/packages/server/src/server/agent/providers/pi/runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/runtime.ts
@@ -15,6 +15,7 @@ export interface PiRuntimeLaunch {
   model?: string;
   thinkingOptionId?: string;
   session?: string;
+  noSession?: boolean;
   systemPrompt?: string;
   mcpConfigPath?: string;
   extensionPaths?: string[];
@@ -26,6 +27,7 @@ export interface PiStartSessionInput {
   model?: string;
   thinkingOptionId?: string;
   session?: string;
+  noSession?: boolean;
   systemPrompt?: string;
   mcpConfigPath?: string;
   extensionPaths?: string[];
@@ -79,7 +81,9 @@ export function buildPiLaunch(input: {
   if (input.session.thinkingOptionId) {
     argv.push("--thinking", input.session.thinkingOptionId);
   }
-  if (input.session.session) {
+  if (input.session.noSession) {
+    argv.push("--no-session");
+  } else if (input.session.session) {
     argv.push("--session", input.session.session);
   }
   const systemPrompt = input.session.systemPrompt?.trim();
@@ -106,6 +110,7 @@ export function buildPiLaunch(input: {
     model: input.session.model,
     thinkingOptionId: input.session.thinkingOptionId,
     session: input.session.session,
+    noSession: input.session.noSession,
     systemPrompt,
     mcpConfigPath: input.session.mcpConfigPath,
     extensionPaths: input.session.extensionPaths,


### PR DESCRIPTION
### Linked issue

Closes #1988

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Internal Pi agents used for metadata generation now launch with `--no-session`, so workspace titles and similar background tasks no longer add scratch entries to Pi session history. Normal and resumed Pi sessions remain persisted.

### How did you verify it

- `npx vitest run packages/server/src/server/agent/providers/pi/agent.test.ts packages/server/src/server/agent/providers/pi/cli-runtime.test.ts` (53 tests)
- Full workspace typecheck via the pre-commit hook
- Targeted lint and formatting checks

The remaining risk surface is limited to Pi launch arguments; the focused tests cover both ephemeral internal agents and persisted normal agents.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable — no UI changes)
- [x] Tests added or updated where it made sense