### PR TITLE
fix(agent): allow cross-provider creation for modeless providers

### DIFF
--- a/packages/server/src/server/agent/create-agent-mode.test.ts
+++ b/packages/server/src/server/agent/create-agent-mode.test.ts
@@ -96,6 +96,19 @@ describe("resolveAndValidateCreateAgentMode", () => {
     );
   });
 
+  it("uses the provider default when the cross-provider target has no modes", () => {
+    const resolved = resolveAndValidateCreateAgentMode({
+      requestedMode: undefined,
+      targetProvider: "pi",
+      parent: agentParent("codex", "auto"),
+      unattended: false,
+      availableModes: [],
+      targetUnattendedMode: undefined,
+    });
+
+    expect(resolved).toBeUndefined();
+  });
+
   it("passes through an explicit mode when the target provider's modes are unknown", () => {
     const resolved = resolveAndValidateCreateAgentMode({
       requestedMode: "default",

--- a/packages/server/src/server/agent/create-agent-mode.test.ts
+++ b/packages/server/src/server/agent/create-agent-mode.test.ts
@@ -109,6 +109,19 @@ describe("resolveAndValidateCreateAgentMode", () => {
     expect(resolved).toBeUndefined();
   });
 
+  it("uses the provider default when an unattended parent targets a provider with no modes", () => {
+    const resolved = resolveAndValidateCreateAgentMode({
+      requestedMode: undefined,
+      targetProvider: "pi",
+      parent: agentParent("claude", "bypassPermissions", true),
+      unattended: false,
+      availableModes: [],
+      targetUnattendedMode: undefined,
+    });
+
+    expect(resolved).toBeUndefined();
+  });
+
   it("passes through an explicit mode when the target provider's modes are unknown", () => {
     const resolved = resolveAndValidateCreateAgentMode({
       requestedMode: "default",

--- a/packages/server/src/server/agent/create-agent-mode.ts
+++ b/packages/server/src/server/agent/create-agent-mode.ts
@@ -14,6 +14,7 @@ export interface ResolveCreateAgentModeInput {
   unattended: boolean;
   // `undefined` = target provider's modes unknown: explicit modes pass through
   // unvalidated, but cross-provider inheritance is still refused.
+  // `[]` = target provider explicitly has no modes: use its default behavior.
   availableModes: string[] | undefined;
   // Target provider's own unattended mode id, if it has one. Used to bridge
   // unattended parents into unattended children across providers.

--- a/packages/server/src/server/agent/create-agent-mode.ts
+++ b/packages/server/src/server/agent/create-agent-mode.ts
@@ -71,6 +71,10 @@ export function resolveAndValidateCreateAgentMode(
     return input.targetUnattendedMode;
   }
 
+  if (availableModes?.length === 0) {
+    return undefined;
+  }
+
   throw new Error(
     `cannot inherit mode '${formatCreateConfigParentMode(parent)}' from ${formatCreateConfigParentSource(parent)} for new agent (provider '${targetProvider}'). Pass an explicit mode. Available modes for '${targetProvider}': ${listModes(availableModes)}`,
   );


### PR DESCRIPTION
## Summary

- use the target provider default when it explicitly advertises no agent modes
- retain existing cross-provider validation for providers with known modes or unknown mode metadata
- add regression coverage for attended and unattended cross-provider creation targeting Pi

## Problem

Agent-scoped `create_agent` attempted to inherit the caller mode across providers even when the target provider reported `modes: []`. Creating a Pi subagent from Codex therefore failed with a mode-inheritance error, despite Pi having no mode to select.

## Testing

- `npx vitest run packages/server/src/server/agent/create-agent-mode.test.ts` (16 tests)
- full workspace typecheck via the pre-commit hook
- targeted lint and formatting checks

Fixes #1862