### PR TITLE
Allow Codex MCP approval prompts

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -604,7 +604,7 @@ describe("Codex app-server provider", () => {
 
     await expect(appServer.waitForMcpElicitationDecision()).resolves.toEqual({
       action: "accept",
-      content: null,
+      content: {},
       _meta: null,
     });
     await session.close();

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -554,6 +554,62 @@ describe("Codex app-server provider", () => {
     await session.close();
   });
 
+  test("surfaces an MCP elicitation and returns Codex's required approval action", async () => {
+    const appServer = createFakeCodexAppServer();
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+
+    await session.connect();
+
+    const permissionRequested = waitForNextPermission(session);
+    appServer.requestMcpElicitation({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      serverName: "browser",
+      message: "Allow the browser to open this page?",
+      requestedSchema: {
+        type: "object",
+        properties: {},
+      },
+    });
+
+    const permission = await permissionRequested;
+    expect(permission.request).toEqual({
+      id: expect.any(String),
+      provider: "codex",
+      name: "CodexMcpElicitation",
+      kind: "tool",
+      title: "MCP approval: browser",
+      description: "Allow the browser to open this page?",
+      input: {
+        mode: "openai/form",
+        requestedSchema: {
+          type: "object",
+          properties: {},
+        },
+        url: null,
+      },
+      metadata: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        serverName: "browser",
+        elicitationId: null,
+      },
+    });
+    await session.respondToPermission(permission.request.id, { behavior: "allow" });
+
+    await expect(appServer.waitForMcpElicitationDecision()).resolves.toEqual({
+      action: "accept",
+      content: null,
+      _meta: null,
+    });
+    await session.close();
+  });
+
   test("initializes Codex app-server without making Paseo the request originator", async () => {
     let initializeParams: unknown;
     const appServer = createFakeCodexAppServer({

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -564,6 +564,8 @@ describe("Codex app-server provider", () => {
     );
 
     await session.connect();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
 
     const permissionRequested = waitForNextPermission(session);
     appServer.requestMcpElicitation({
@@ -606,6 +608,22 @@ describe("Codex app-server provider", () => {
       action: "accept",
       content: {},
       _meta: null,
+    });
+    appServer.resolvesMcpElicitation();
+
+    await vi.waitFor(() => {
+      expect(events).toContainEqual({
+        type: "permission_resolved",
+        provider: "codex",
+        requestId: permission.request.id,
+        resolution: { behavior: "allow" },
+      });
+    });
+    expect(events).not.toContainEqual({
+      type: "permission_resolved",
+      provider: "codex",
+      requestId: permission.request.id,
+      resolution: { behavior: "deny", interrupt: true },
     });
     await session.close();
   });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -653,7 +653,7 @@ describe("Codex app-server provider", () => {
         title: "Codex App Server Daemon",
         version: "0.0.0",
       },
-      capabilities: { experimentalApi: true },
+      capabilities: { experimentalApi: true, mcpServerOpenaiFormElicitation: true },
     });
     appServer.assertNoErrors();
     await session.close();
@@ -3845,7 +3845,7 @@ describe("Codex importable sessions", () => {
             title: "Codex App Server Daemon",
             version: "0.0.0",
           },
-          capabilities: { experimentalApi: true },
+          capabilities: { experimentalApi: true, mcpServerOpenaiFormElicitation: true },
         },
       },
       { method: "thread/list", params: { limit: 50, cwd: "/workspace/project-a" } },

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -5837,7 +5837,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     const parsed = z
       .object({
         threadId: z.string(),
-        turnId: z.string().nullable(),
+        turnId: z.string().nullable().optional(),
         serverName: z.string(),
         mode: z.enum(["form", "openai/form", "url"]),
         message: z.string(),
@@ -5846,6 +5846,9 @@ export class CodexAppServerAgentSession implements AgentSession {
         elicitationId: z.string().optional(),
       })
       .parse(params);
+    if (parsed.mode === "url") {
+      return Promise.resolve({ action: "decline", content: null, _meta: null });
+    }
     const requestId = `permission-${randomUUID()}`;
     const request: AgentPermissionRequest = {
       id: requestId,
@@ -5861,7 +5864,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       },
       metadata: {
         threadId: parsed.threadId,
-        turnId: parsed.turnId,
+        turnId: parsed.turnId ?? null,
         serverName: parsed.serverName,
         elicitationId: parsed.elicitationId ?? null,
       },

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -5860,6 +5860,10 @@ export class CodexAppServerAgentSession implements AgentSession {
     if (parsed.mode === "url") {
       return Promise.resolve({ action: "decline", content: null, _meta: null });
     }
+    const requiredFields = toObjectRecord(parsed.requestedSchema)?.required;
+    if (Array.isArray(requiredFields) && requiredFields.length > 0) {
+      return Promise.resolve({ action: "decline", content: null, _meta: null });
+    }
     const requestId = `permission-${randomUUID()}`;
     const request: AgentPermissionRequest = {
       id: requestId,

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -4489,9 +4489,12 @@ export class CodexAppServerAgentSession implements AgentSession {
       if (requestId) {
         const pending = this.pendingPermissionHandlers.get(requestId);
         this.mcpElicitationPermissionIds.delete(notificationParams.requestId);
+        if (!pending) {
+          return;
+        }
         this.pendingPermissions.delete(requestId);
         this.pendingPermissionHandlers.delete(requestId);
-        pending?.resolve({ action: "cancel", content: null, _meta: null });
+        pending.resolve({ action: "cancel", content: null, _meta: null });
         this.emitEvent({
           type: "permission_resolved",
           provider: CODEX_PROVIDER,

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3081,6 +3081,7 @@ export class CodexAppServerAgentSession implements AgentSession {
   private historyPending = false;
   private persistedHistory: PersistedTimelineEntry[] = [];
   private pendingPermissions = new Map<string, AgentPermissionRequest>();
+  private mcpElicitationPermissionIds = new Map<number, string>();
   private pendingPermissionHandlers = new Map<
     string,
     {
@@ -3427,8 +3428,8 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.client.setRequestHandler("item/tool/requestUserInput", (params) =>
       this.handleToolApprovalRequest(params),
     );
-    this.client.setRequestHandler("mcpServer/elicitation/request", (params) =>
-      this.handleMcpElicitationRequest(params),
+    this.client.setRequestHandler("mcpServer/elicitation/request", (params, requestId) =>
+      this.handleMcpElicitationRequest(params, requestId),
     );
     // Keep the legacy method name for older Codex builds.
     this.client.setRequestHandler("tool/requestUserInput", (params) =>
@@ -4482,6 +4483,16 @@ export class CodexAppServerAgentSession implements AgentSession {
   }
 
   private handleNotification(method: string, params: unknown): void {
+    const notificationParams = toObjectRecord(params);
+    if (method === "serverRequest/resolved" && typeof notificationParams?.requestId === "number") {
+      const requestId = this.mcpElicitationPermissionIds.get(notificationParams.requestId);
+      if (requestId) {
+        this.mcpElicitationPermissionIds.delete(notificationParams.requestId);
+        this.pendingPermissions.delete(requestId);
+        this.pendingPermissionHandlers.delete(requestId);
+      }
+      return;
+    }
     const parsed = CodexNotificationSchema.parse({ method, params });
     this.traceParsedNotification(method, params, parsed);
     const route = this.resolveCodexThreadRoute(getCodexNotificationThreadId(parsed));
@@ -5833,7 +5844,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     });
   }
 
-  private handleMcpElicitationRequest(params: unknown): Promise<unknown> {
+  private handleMcpElicitationRequest(params: unknown, serverRequestId: number): Promise<unknown> {
     const parsed = z
       .object({
         threadId: z.string(),
@@ -5870,6 +5881,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       },
     };
     this.pendingPermissions.set(requestId, request);
+    this.mcpElicitationPermissionIds.set(serverRequestId, requestId);
     this.emitEvent({ type: "permission_requested", provider: CODEX_PROVIDER, request });
     return new Promise((resolve) => {
       this.pendingPermissionHandlers.set(requestId, { resolve, kind: "mcp_elicitation" });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -4487,9 +4487,17 @@ export class CodexAppServerAgentSession implements AgentSession {
     if (method === "serverRequest/resolved" && typeof notificationParams?.requestId === "number") {
       const requestId = this.mcpElicitationPermissionIds.get(notificationParams.requestId);
       if (requestId) {
+        const pending = this.pendingPermissionHandlers.get(requestId);
         this.mcpElicitationPermissionIds.delete(notificationParams.requestId);
         this.pendingPermissions.delete(requestId);
         this.pendingPermissionHandlers.delete(requestId);
+        pending?.resolve({ action: "cancel", content: null, _meta: null });
+        this.emitEvent({
+          type: "permission_resolved",
+          provider: CODEX_PROVIDER,
+          requestId,
+          resolution: { behavior: "deny", interrupt: true },
+        });
       }
       return;
     }

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3955,7 +3955,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     if (pending.kind === "mcp_elicitation") {
       pending.resolve({
         action: resolvePermissionDecision(response),
-        content: null,
+        content: response.behavior === "allow" ? {} : null,
         _meta: null,
       });
       return;

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3085,7 +3085,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     string,
     {
       resolve: (value: unknown) => void;
-      kind: "command" | "file" | "question" | "plan";
+      kind: "command" | "file" | "question" | "mcp_elicitation" | "plan";
       questions?: CodexQuestionPrompt[];
       planText?: string;
     }
@@ -3426,6 +3426,9 @@ export class CodexAppServerAgentSession implements AgentSession {
     );
     this.client.setRequestHandler("item/tool/requestUserInput", (params) =>
       this.handleToolApprovalRequest(params),
+    );
+    this.client.setRequestHandler("mcpServer/elicitation/request", (params) =>
+      this.handleMcpElicitationRequest(params),
     );
     // Keep the legacy method name for older Codex builds.
     this.client.setRequestHandler("tool/requestUserInput", (params) =>
@@ -3949,6 +3952,15 @@ export class CodexAppServerAgentSession implements AgentSession {
       return;
     }
 
+    if (pending.kind === "mcp_elicitation") {
+      pending.resolve({
+        action: resolvePermissionDecision(response),
+        content: null,
+        _meta: null,
+      });
+      return;
+    }
+
     const questions = pending.questions ?? [];
     const itemId =
       typeof pendingRequest?.metadata?.itemId === "string"
@@ -4003,7 +4015,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     response: AgentPermissionResponse;
     pending: {
       resolve: (value: unknown) => void;
-      kind: "command" | "file" | "question" | "plan";
+      kind: "command" | "file" | "question" | "mcp_elicitation" | "plan";
       questions?: CodexQuestionPrompt[];
       planText?: string;
     };
@@ -5818,6 +5830,46 @@ export class CodexAppServerAgentSession implements AgentSession {
         kind: "question",
         questions,
       });
+    });
+  }
+
+  private handleMcpElicitationRequest(params: unknown): Promise<unknown> {
+    const parsed = z
+      .object({
+        threadId: z.string(),
+        turnId: z.string().nullable(),
+        serverName: z.string(),
+        mode: z.enum(["form", "openai/form", "url"]),
+        message: z.string(),
+        requestedSchema: z.unknown().optional(),
+        url: z.string().optional(),
+        elicitationId: z.string().optional(),
+      })
+      .parse(params);
+    const requestId = `permission-${randomUUID()}`;
+    const request: AgentPermissionRequest = {
+      id: requestId,
+      provider: CODEX_PROVIDER,
+      name: "CodexMcpElicitation",
+      kind: "tool",
+      title: `MCP approval: ${parsed.serverName}`,
+      description: parsed.message,
+      input: {
+        mode: parsed.mode,
+        requestedSchema: parsed.requestedSchema ?? null,
+        url: parsed.url ?? null,
+      },
+      metadata: {
+        threadId: parsed.threadId,
+        turnId: parsed.turnId,
+        serverName: parsed.serverName,
+        elicitationId: parsed.elicitationId ?? null,
+      },
+    };
+    this.pendingPermissions.set(requestId, request);
+    this.emitEvent({ type: "permission_requested", provider: CODEX_PROVIDER, request });
+    return new Promise((resolve) => {
+      this.pendingPermissionHandlers.set(requestId, { resolve, kind: "mcp_elicitation" });
     });
   }
 }

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -2997,12 +2997,13 @@ export function buildCodexAppServerEnv(
 
 function buildCodexAppServerInitializeParams(): {
   clientInfo: { name: string; title: string; version: string };
-  capabilities: { experimentalApi: true };
+  capabilities: { experimentalApi: true; mcpServerOpenaiFormElicitation: true };
 } {
   return {
     clientInfo: CODEX_NON_ORIGINATING_APP_SERVER_CLIENT_INFO,
     capabilities: {
       experimentalApi: true,
+      mcpServerOpenaiFormElicitation: true,
     },
   };
 }

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.ts
@@ -33,7 +33,7 @@ interface PendingRequest {
   timer: NodeJS.Timeout;
 }
 
-type RequestHandler = (params: unknown) => unknown;
+type RequestHandler = (params: unknown, requestId: number) => unknown;
 type NotificationHandler = (method: string, params: unknown) => void;
 
 export interface CodexThreadForkParams {
@@ -321,7 +321,7 @@ export class CodexAppServerClient {
         this.traceRawEvent(request);
         const handler = this.requestHandlers.get(request.method);
         try {
-          const result = handler ? await handler(request.params) : {};
+          const result = handler ? await handler(request.params, request.id) : {};
           this.writeJsonRpcResponse({ id: request.id, result });
         } catch (error) {
           this.writeJsonRpcResponse({

--- a/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
+++ b/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
@@ -61,6 +61,14 @@ export interface FakeCodexAppServer {
     reason: string;
   }): void;
   waitForCommandApprovalDecision(itemId: string): Promise<unknown>;
+  requestMcpElicitation(params: {
+    threadId: string;
+    turnId: string | null;
+    serverName: string;
+    message: string;
+    requestedSchema: Record<string, unknown>;
+  }): void;
+  waitForMcpElicitationDecision(): Promise<unknown>;
 }
 
 export function createCodexAppServerChildProcess(): CodexAppServerChildProcess {
@@ -139,6 +147,7 @@ export function createFakeCodexAppServer(
   const messages: JsonObject[] = [];
   const errors: Error[] = [];
   const approvalRequestIds = new Map<string, number>();
+  let mcpElicitationRequestId: number | undefined;
   const waiters = new Set<{
     predicate: (message: JsonObject) => boolean;
     resolve: (message: JsonObject) => void;
@@ -399,6 +408,36 @@ export function createFakeCodexAppServer(
         (candidate) =>
           candidate.id === requestId && !("method" in candidate) && "result" in candidate,
         "command approval response",
+      );
+      return message.result;
+    },
+    requestMcpElicitation(params) {
+      const requestId = nextServerRequestId;
+      nextServerRequestId += 1;
+      mcpElicitationRequestId = requestId;
+      child.stdout.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: requestId,
+          method: "mcpServer/elicitation/request",
+          params: {
+            ...params,
+            mode: "openai/form",
+            _meta: null,
+          },
+        })}\n`,
+      );
+    },
+    async waitForMcpElicitationDecision() {
+      if (mcpElicitationRequestId === undefined) {
+        throw new Error("No pending fake Codex app-server MCP elicitation");
+      }
+      const message = await waitForMessage(
+        (candidate) =>
+          candidate.id === mcpElicitationRequestId &&
+          !("method" in candidate) &&
+          "result" in candidate,
+        "MCP elicitation response",
       );
       return message.result;
     },

--- a/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
+++ b/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
@@ -69,6 +69,7 @@ export interface FakeCodexAppServer {
     requestedSchema: Record<string, unknown>;
   }): void;
   waitForMcpElicitationDecision(): Promise<unknown>;
+  resolvesMcpElicitation(): void;
 }
 
 export function createCodexAppServerChildProcess(): CodexAppServerChildProcess {
@@ -440,6 +441,12 @@ export function createFakeCodexAppServer(
         "MCP elicitation response",
       );
       return message.result;
+    },
+    resolvesMcpElicitation() {
+      if (mcpElicitationRequestId === undefined) {
+        throw new Error("No pending fake Codex app-server MCP elicitation");
+      }
+      writeNotification("serverRequest/resolved", { requestId: mcpElicitationRequestId });
     },
   };
 }


### PR DESCRIPTION
Codex MCP elicitations now appear as Paseo permission prompts instead of being implicitly declined before the MCP host receives a command. Approving a prompt returns the app-server response shape Codex requires.

Refs #1713

## Verification

- `npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint -- packages/server/src/server/agent/providers/codex-app-server-agent.ts packages/server/src/server/agent/providers/codex-app-server-agent.test.ts packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts`

## Risk surface

The bridge intentionally returns no structured form content. It covers approval-style MCP elicitations; collecting form-input values is separate behavior.