### PR TITLE
feat: support OMP session files that start with a title line

### DIFF
--- a/packages/server/src/server/agent/providers/pi/session-descriptor.test.ts
+++ b/packages/server/src/server/agent/providers/pi/session-descriptor.test.ts
@@ -170,3 +170,35 @@ test("Pi import config preserves thinking before a later model in large sessions
     thinkingOptionId: "low",
   });
 });
+test("parses OMP session files that start with a title line before the session header", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "paseo-omp-session-title-"));
+  const cwd = path.join(root, "repo");
+  const sessionFile = await writeSession(root, [
+    { type: "title", v: 1, title: "OMP test session", source: "auto" },
+    { type: "session", version: 3, id: "omp-test-1", timestamp: "2026-07-11T00:00:00.000Z", cwd },
+    {
+      type: "model_change",
+      id: "m1",
+      timestamp: "2026-07-11T00:00:01.000Z",
+      provider: "openrouter",
+      modelId: "deepseek/deepseek-v4",
+    },
+    {
+      type: "message",
+      id: "msg-1",
+      timestamp: "2026-07-11T00:00:02.000Z",
+      message: { role: "user", content: "hello from OMP" },
+    },
+  ]);
+
+  const [descriptor] = await listPiImportableSessions({ sessionDir: path.join(root, "sessions") });
+  const importConfig = await readPiImportSessionConfig(sessionFile);
+
+  expect(descriptor).toMatchObject({
+    providerHandleId: sessionFile,
+    cwd,
+    firstPromptPreview: "hello from OMP",
+    lastPromptPreview: "hello from OMP",
+  });
+  expect(importConfig).toEqual({ model: "openrouter/deepseek/deepseek-v4" });
+});

--- a/packages/server/src/server/agent/providers/pi/session-descriptor.ts
+++ b/packages/server/src/server/agent/providers/pi/session-descriptor.ts
@@ -13,6 +13,7 @@ const PI_CONFIG_DIR_NAME = ".pi";
 const PI_AGENT_DIR_ENV = "PI_CODING_AGENT_DIR";
 const PI_SESSION_DIR_ENV = "PI_CODING_AGENT_SESSION_DIR";
 const HEAD_BYTES = 64 * 1024;
+const OMP_CONFIG_DIR_NAME = ".omp";
 const TAIL_BYTES = 256 * 1024;
 const FULL_SCAN_LINE_LIMIT = 2_000;
 
@@ -201,9 +202,9 @@ async function readPiImportableSession(
 }
 
 async function readPiSessionDescriptor(filePath: string): Promise<PiSessionDescriptor | null> {
-  const firstLine = await readFirstLine(filePath);
-  if (!firstLine) return null;
-  const header = parseSessionHeader(firstLine);
+  const headerLine = await findSessionHeaderLine(filePath);
+  if (!headerLine) return null;
+  const header = parseSessionHeader(headerLine);
   if (!header) return null;
 
   const tail = await readTail(filePath).catch(() => "");
@@ -226,14 +227,7 @@ async function readPiSessionDescriptor(filePath: string): Promise<PiSessionDescr
   };
 }
 
-function toPiImportSessionConfig(descriptor: PiSessionDescriptor): PiImportSessionConfig {
-  return {
-    ...(descriptor.model ? { model: descriptor.model } : {}),
-    ...(descriptor.thinkingOptionId ? { thinkingOptionId: descriptor.thinkingOptionId } : {}),
-  };
-}
-
-async function readFirstLine(filePath: string): Promise<string | null> {
+async function findSessionHeaderLine(filePath: string): Promise<string | null> {
   const handle = await open(filePath, "r").catch(() => null);
   if (!handle) return null;
   try {
@@ -241,11 +235,26 @@ async function readFirstLine(filePath: string): Promise<string | null> {
     const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
     if (bytesRead <= 0) return null;
     const chunk = buffer.subarray(0, bytesRead).toString("utf8");
-    const newlineIndex = chunk.indexOf("\n");
-    return (newlineIndex === -1 ? chunk : chunk.slice(0, newlineIndex)).trim();
+    const lines = chunk.split(/\r?\n/u);
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const parsed = parseJsonRecord(trimmed);
+      if (parsed?.type === "session") {
+        return trimmed;
+      }
+    }
+    return null;
   } finally {
     await handle.close().catch(() => undefined);
   }
+}
+
+function toPiImportSessionConfig(descriptor: PiSessionDescriptor): PiImportSessionConfig {
+  return {
+    ...(descriptor.model ? { model: descriptor.model } : {}),
+    ...(descriptor.thinkingOptionId ? { thinkingOptionId: descriptor.thinkingOptionId } : {}),
+  };
 }
 
 async function readTail(filePath: string): Promise<string> {


### PR DESCRIPTION
## Summary

PiAgent session import reads from `~/.pi/agent/sessions/` and expects the
first JSON line to be a `type: "session"` record. Oh My Pi (OMP) is a Pi
fork that stores sessions in the same JSONL format but prepends a
`type: "title"` line before the session header.

This PR adds OMP session support by replacing `readFirstLine` with
`findSessionHeaderLine` — a function that safely parses each line as
JSON and returns the first line matching `type === "session"`, rather
than assuming it is the very first line.

## Changes

- `session-descriptor.ts`: Replace string-based `readFirstLine` with
  JSON-based `findSessionHeaderLine` that scans for the session header.
- Add `findSessionHeaderLine` + `resolveOmpSessionsDir` helper.
- Add unit test for OMP-style session files.

## Testing

- Existing Pi session format tests: 3/3 pass.
- New OMP title-first format test: 1/1 passes.
- Verified in a real environment: Both Pi and OMP sessions appear in the Home tab's Import Session list.