### PR TITLE
Keep Pi chats usable after canceling extension commands

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -138,6 +138,13 @@ class SessionEvents {
     );
   }
 
+  nextTurnCancellation(): Promise<Extract<AgentStreamEvent, { type: "turn_canceled" }>> {
+    return this.nextEvent(
+      (event): event is Extract<AgentStreamEvent, { type: "turn_canceled" }> =>
+        event.type === "turn_canceled",
+    );
+  }
+
   nextPermissionRequest(): Promise<Extract<AgentStreamEvent, { type: "permission_requested" }>> {
     return this.nextEvent(
       (event): event is Extract<AgentStreamEvent, { type: "permission_requested" }> =>
@@ -505,6 +512,33 @@ describe("PiRpcAgentSession", () => {
         item: { type: "assistant_message", text: "Extension command output" },
       },
       { type: "turn_completed" },
+    ]);
+  });
+
+  test("canceling a silent Pi extension command leaves the session usable", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    const firstTurn = await session.startTurn("/silent-search");
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "notify-1",
+      method: "notify",
+      message: "Search finished",
+    });
+    await session.interrupt();
+    const cancellation = await events.nextTurnCancellation();
+    await session.startTurn("next request");
+
+    expect(cancellation).toEqual({
+      type: "turn_canceled",
+      provider: "pi",
+      reason: "interrupted",
+      turnId: firstTurn.turnId,
+    });
+    expect(fakeSession.prompts).toEqual([
+      { message: "/silent-search", imageCount: 0 },
+      { message: "next request", imageCount: 0 },
     ]);
   });
 

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -519,6 +519,7 @@ describe("PiRpcAgentSession", () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
 
+    fakeSession.holdNextPrompt();
     const firstTurn = await session.startTurn("/silent-search");
     fakeSession.emit({
       type: "extension_ui_request",
@@ -529,6 +530,7 @@ describe("PiRpcAgentSession", () => {
     await session.interrupt();
     const cancellation = await events.nextTurnCancellation();
     await session.startTurn("next request");
+    await fakeSession.failHeldPrompt(new Error("Canceled prompt timed out"));
 
     expect(cancellation).toEqual({
       type: "turn_canceled",
@@ -540,6 +542,9 @@ describe("PiRpcAgentSession", () => {
       { message: "/silent-search", imageCount: 0 },
       { message: "next request", imageCount: 0 },
     ]);
+    await expect(session.startTurn("overlapping request")).rejects.toThrow(
+      "A Pi turn is already active",
+    );
   });
 
   test("adds Pi assistant context to generic provider finish errors", async () => {

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1125,13 +1125,15 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeTurnId = turnId;
 
     void this.runtimeSession.prompt(payload.text, payload.images).catch((error) => {
-      const failedTurnId = this.activeTurnId ?? turnId;
+      if (this.activeTurnId !== turnId) {
+        return;
+      }
       this.activeTurnId = null;
       if (isPiRequestAbortError(error)) {
         this.emit({
           type: "turn_canceled",
           provider: PI_PROVIDER,
-          turnId: failedTurnId,
+          turnId,
           reason: toDiagnosticErrorMessage(error),
         });
         return;
@@ -1139,7 +1141,7 @@ export class PiRpcAgentSession implements AgentSession {
       this.emit({
         type: "turn_failed",
         provider: PI_PROVIDER,
-        turnId: failedTurnId,
+        turnId,
         error: toDiagnosticErrorMessage(error),
       });
     });

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1234,7 +1234,12 @@ export class PiRpcAgentSession implements AgentSession {
   }
 
   async interrupt(): Promise<void> {
+    const turnId = this.activeTurnId;
     await this.runtimeSession.abort();
+    if (turnId && this.activeTurnId === turnId) {
+      this.activeTurnId = null;
+      this.emit({ type: "turn_canceled", provider: PI_PROVIDER, reason: "interrupted", turnId });
+    }
   }
 
   async revertConversation(input: { messageId: string }): Promise<void> {

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -76,6 +76,9 @@ export class FakePiSession implements PiRuntimeSession {
   state: PiSessionState;
 
   private readonly subscribers = new Set<(event: PiRuntimeEvent) => void>();
+  private nextHeldPrompt: { promise: Promise<void>; reject: (error: Error) => void } | null = null;
+  private activeHeldPrompt: { promise: Promise<void>; reject: (error: Error) => void } | null =
+    null;
 
   constructor(launch: PiRuntimeLaunch) {
     this.state = {
@@ -103,8 +106,40 @@ export class FakePiSession implements PiRuntimeSession {
     images?: Array<{ type: "image"; data: string; mimeType: string }>,
   ): Promise<void> {
     this.prompts.push({ message, imageCount: images?.length ?? 0 });
+    const heldPrompt = this.nextHeldPrompt;
+    if (heldPrompt) {
+      this.nextHeldPrompt = null;
+      this.activeHeldPrompt = heldPrompt;
+      try {
+        await heldPrompt.promise;
+      } finally {
+        if (this.activeHeldPrompt === heldPrompt) {
+          this.activeHeldPrompt = null;
+        }
+      }
+    }
     this.handleTreeNavigationCommand(message);
     this.handleEntryCaptureCommand(message);
+  }
+
+  holdNextPrompt(): void {
+    if (this.nextHeldPrompt || this.activeHeldPrompt) {
+      throw new Error("FakePi already has a held prompt");
+    }
+    let reject!: (error: Error) => void;
+    const promise = new Promise<void>((_resolve, rejectPromise) => {
+      reject = rejectPromise;
+    });
+    this.nextHeldPrompt = { promise, reject };
+  }
+
+  async failHeldPrompt(error: Error): Promise<void> {
+    const heldPrompt = this.activeHeldPrompt ?? this.nextHeldPrompt;
+    if (!heldPrompt) {
+      throw new Error("FakePi has no held prompt");
+    }
+    heldPrompt.reject(error);
+    await new Promise<void>((resolve) => setImmediate(resolve));
   }
 
   async compact(customInstructions?: string): Promise<void> {


### PR DESCRIPTION
### Linked issue

Refs https://discord.com/channels/1481169421832814616/1521438819025555578

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

A Pi extension command can finish without emitting a terminal event that Paseo recognizes. Canceling that turn cleared the visible run but left the Pi session internally active, so every later message failed with “A Pi turn is already active.”

After Pi acknowledges the interrupt, Paseo now cancels the same locally active turn when Pi did not emit its own terminal event. The identity check preserves a terminal event that arrives during the interrupt and avoids canceling a newer turn.

### How did you verify it

- Added a regression test for a silent extension notification followed by cancel and another prompt.
- Confirmed the test failed before the fix with `A Pi turn is already active`.
- Confirmed `packages/server/src/server/agent/providers/pi/agent.test.ts` passes: 39 tests.
- Ran `npm run typecheck` successfully across all workspaces.
- Ran targeted lint successfully for the changed files.
- Ran `npm run format`.

The change is isolated to Pi turn cancellation. No additional manual platform verification is needed before merge.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI changes)
- [x] Tests added or updated where it made sense
