### PR TITLE
Keep oversized tool output out of chat timelines

### DIFF
--- a/docs/timeline-sync.md
+++ b/docs/timeline-sync.md
@@ -9,6 +9,11 @@ The invariant is:
 
 > If the daemon has committed timeline rows for an agent, any connected client that opens or resumes that agent eventually displays every row through the daemon's current tail.
 
+Tool output is bounded before it enters either delivery path. Canonical shell tool output keeps
+the head and tail within a 64 KiB UTF-8 budget, and the same bounded item is used for durable
+timeline rows and live stream events. Provider history hydration applies the same rule so reopening
+an agent cannot restore an oversized tool payload.
+
 ## Presence is not delivery
 
 Client heartbeat reports presence:

--- a/docs/timeline-sync.md
+++ b/docs/timeline-sync.md
@@ -9,10 +9,10 @@ The invariant is:
 
 > If the daemon has committed timeline rows for an agent, any connected client that opens or resumes that agent eventually displays every row through the daemon's current tail.
 
-Tool output is bounded before it enters either delivery path. Canonical shell tool output keeps
-the head and tail within a 64 KiB UTF-8 budget, and the same bounded item is used for durable
-timeline rows and live stream events. Provider history hydration applies the same rule so reopening
-an agent cannot restore an oversized tool payload.
+Tool output is bounded before it enters either delivery path. Canonical shell tool output is sliced
+to 64 KiB, and the same bounded item is used for durable timeline rows and live stream events.
+Provider history hydration applies the same rule so reopening an agent cannot restore an oversized
+tool payload.
 
 ## Presence is not delivery
 

--- a/packages/server/src/server/agent/agent-manager-stream-coalescing.test.ts
+++ b/packages/server/src/server/agent/agent-manager-stream-coalescing.test.ts
@@ -30,6 +30,8 @@ import type {
 
 const COALESCE_WINDOW_MS = AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS;
 const BEFORE_COALESCE_WINDOW_MS = Math.max(COALESCE_WINDOW_MS - 1, 0);
+const TOOL_CALL_CONTENT_MAX_BYTES = 64 * 1024;
+const TOOL_CALL_CONTENT_TRUNCATION_MARKER = "\n...<tool output truncated in the middle>...\n";
 
 const TEST_CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: false,
@@ -81,6 +83,15 @@ function toolCall(options?: {
       exitCode: status === "completed" ? 0 : null,
     },
   };
+}
+
+function boundedToolCallOutput(head: string, tail: string): string {
+  const availableBytes =
+    TOOL_CALL_CONTENT_MAX_BYTES - Buffer.byteLength(TOOL_CALL_CONTENT_TRUNCATION_MARKER);
+  const headBytes = Math.floor(availableBytes / 2);
+  return `${head.repeat(headBytes)}${TOOL_CALL_CONTENT_TRUNCATION_MARKER}${tail.repeat(
+    availableBytes - headBytes,
+  )}`;
 }
 
 class TestAgentSession implements AgentSession {
@@ -377,6 +388,101 @@ afterEach(() => {
 });
 
 describe("target coalesced behavior", () => {
+  test("bounds tool output before persisting and streaming it", async () => {
+    const harness = createHarness();
+    try {
+      const { agentId, session } = await createManagedSession(harness);
+      const output = `${"a".repeat(512 * 1024)}${"z".repeat(512 * 1024)}`;
+      const expectedItem = toolCall({
+        status: "completed",
+        output: boundedToolCallOutput("a", "z"),
+      });
+
+      session.pushEvent(timelineEvent(toolCall({ status: "completed", output })));
+      await waitForSessionEventQueue();
+
+      const rows = await harness.manager.getTimelineRows(agentId);
+      const events = getTimelineStreamEvents(harness.events, agentId);
+
+      expect(getTimelineItems(rows)).toEqual([expectedItem]);
+      expect(
+        events.map((event) => (event.type === "agent_stream" ? event.event.item : null)),
+      ).toEqual([expectedItem]);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test("bounds appended tool output before persisting and streaming it", async () => {
+    const harness = createHarness();
+    try {
+      const { agentId } = await createManagedSession(harness);
+      const output = `${"a".repeat(512 * 1024)}${"z".repeat(512 * 1024)}`;
+      const expectedItem = toolCall({
+        status: "completed",
+        output: boundedToolCallOutput("a", "z"),
+      });
+
+      await harness.manager.appendTimelineItem(agentId, toolCall({ status: "completed", output }));
+
+      const rows = await harness.manager.getTimelineRows(agentId);
+      const events = getTimelineStreamEvents(harness.events, agentId);
+
+      expect(getTimelineItems(rows)).toEqual([expectedItem]);
+      expect(
+        events.map((event) => (event.type === "agent_stream" ? event.event.item : null)),
+      ).toEqual([expectedItem]);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test("bounds tool output while hydrating provider history", async () => {
+    const harness = createHarness();
+    try {
+      const { agentId, session } = await createManagedSession(harness);
+      const output = `${"a".repeat(512 * 1024)}${"z".repeat(512 * 1024)}`;
+      const expectedItem = toolCall({
+        status: "completed",
+        output: boundedToolCallOutput("a", "z"),
+      });
+      session.setHistory([timelineEvent(toolCall({ status: "completed", output }))]);
+
+      await harness.manager.hydrateTimelineFromProvider(agentId);
+
+      expect(getTimelineItems(await harness.manager.getTimelineRows(agentId))).toEqual([
+        expectedItem,
+      ]);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test("bounds tool output emitted only to the live stream", async () => {
+    const harness = createHarness();
+    try {
+      const { agentId } = await createManagedSession(harness);
+      const output = `${"a".repeat(512 * 1024)}${"z".repeat(512 * 1024)}`;
+      const expectedItem = toolCall({
+        status: "completed",
+        output: boundedToolCallOutput("a", "z"),
+      });
+
+      await harness.manager.emitLiveTimelineItem(
+        agentId,
+        toolCall({ status: "completed", output }),
+      );
+
+      const events = getTimelineStreamEvents(harness.events, agentId);
+      expect(await harness.manager.getTimelineRows(agentId)).toEqual([]);
+      expect(
+        events.map((event) => (event.type === "agent_stream" ? event.event.item : null)),
+      ).toEqual([expectedItem]);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
   test(`coalesces a same-tick assistant burst after the ${COALESCE_WINDOW_MS}ms window`, async () => {
     vi.useFakeTimers();
     const harness = createHarness();

--- a/packages/server/src/server/agent/agent-manager-stream-coalescing.test.ts
+++ b/packages/server/src/server/agent/agent-manager-stream-coalescing.test.ts
@@ -473,6 +473,27 @@ describe("target coalesced behavior", () => {
     }
   });
 
+  test("bounds failed shell output carried in the error", async () => {
+    const harness = createHarness();
+    try {
+      const { agentId, session } = await createManagedSession(harness);
+      const content = `${"a".repeat(512 * 1024)}${"z".repeat(512 * 1024)}`;
+      const expectedItem = toolCall({
+        status: "failed",
+        error: { content: "a".repeat(TOOL_CALL_CONTENT_MAX_LENGTH) },
+      });
+
+      session.pushEvent(timelineEvent(toolCall({ status: "failed", error: { content } })));
+      await waitForSessionEventQueue();
+
+      expect(getTimelineItems(await harness.manager.getTimelineRows(agentId))).toEqual([
+        expectedItem,
+      ]);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
   test(`coalesces a same-tick assistant burst after the ${COALESCE_WINDOW_MS}ms window`, async () => {
     vi.useFakeTimers();
     const harness = createHarness();

--- a/packages/server/src/server/agent/agent-manager-stream-coalescing.test.ts
+++ b/packages/server/src/server/agent/agent-manager-stream-coalescing.test.ts
@@ -30,8 +30,7 @@ import type {
 
 const COALESCE_WINDOW_MS = AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS;
 const BEFORE_COALESCE_WINDOW_MS = Math.max(COALESCE_WINDOW_MS - 1, 0);
-const TOOL_CALL_CONTENT_MAX_BYTES = 64 * 1024;
-const TOOL_CALL_CONTENT_TRUNCATION_MARKER = "\n...<tool output truncated in the middle>...\n";
+const TOOL_CALL_CONTENT_MAX_LENGTH = 64 * 1024;
 
 const TEST_CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: false,
@@ -83,15 +82,6 @@ function toolCall(options?: {
       exitCode: status === "completed" ? 0 : null,
     },
   };
-}
-
-function boundedToolCallOutput(head: string, tail: string): string {
-  const availableBytes =
-    TOOL_CALL_CONTENT_MAX_BYTES - Buffer.byteLength(TOOL_CALL_CONTENT_TRUNCATION_MARKER);
-  const headBytes = Math.floor(availableBytes / 2);
-  return `${head.repeat(headBytes)}${TOOL_CALL_CONTENT_TRUNCATION_MARKER}${tail.repeat(
-    availableBytes - headBytes,
-  )}`;
 }
 
 class TestAgentSession implements AgentSession {
@@ -395,7 +385,7 @@ describe("target coalesced behavior", () => {
       const output = `${"a".repeat(512 * 1024)}${"z".repeat(512 * 1024)}`;
       const expectedItem = toolCall({
         status: "completed",
-        output: boundedToolCallOutput("a", "z"),
+        output: "a".repeat(TOOL_CALL_CONTENT_MAX_LENGTH),
       });
 
       session.pushEvent(timelineEvent(toolCall({ status: "completed", output })));
@@ -420,7 +410,7 @@ describe("target coalesced behavior", () => {
       const output = `${"a".repeat(512 * 1024)}${"z".repeat(512 * 1024)}`;
       const expectedItem = toolCall({
         status: "completed",
-        output: boundedToolCallOutput("a", "z"),
+        output: "a".repeat(TOOL_CALL_CONTENT_MAX_LENGTH),
       });
 
       await harness.manager.appendTimelineItem(agentId, toolCall({ status: "completed", output }));
@@ -444,7 +434,7 @@ describe("target coalesced behavior", () => {
       const output = `${"a".repeat(512 * 1024)}${"z".repeat(512 * 1024)}`;
       const expectedItem = toolCall({
         status: "completed",
-        output: boundedToolCallOutput("a", "z"),
+        output: "a".repeat(TOOL_CALL_CONTENT_MAX_LENGTH),
       });
       session.setHistory([timelineEvent(toolCall({ status: "completed", output }))]);
 
@@ -465,7 +455,7 @@ describe("target coalesced behavior", () => {
       const output = `${"a".repeat(512 * 1024)}${"z".repeat(512 * 1024)}`;
       const expectedItem = toolCall({
         status: "completed",
-        output: boundedToolCallOutput("a", "z"),
+        output: "a".repeat(TOOL_CALL_CONTENT_MAX_LENGTH),
       });
 
       await harness.manager.emitLiveTimelineItem(

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -2314,6 +2314,22 @@ test("importProviderSession imports the selected session without listing and pub
             item: { type: "assistant_message" as const, text: "Done" },
             timestamp: "2026-01-02T00:00:01.000Z",
           },
+          {
+            item: {
+              type: "tool_call" as const,
+              callId: "large-shell-result",
+              name: "shell",
+              status: "completed" as const,
+              error: null,
+              detail: {
+                type: "shell" as const,
+                command: "print output",
+                output: "x".repeat(1024 * 1024),
+                exitCode: 0,
+              },
+            },
+            timestamp: "2026-01-02T00:00:02.000Z",
+          },
         ],
       };
     }
@@ -2343,6 +2359,19 @@ test("importProviderSession imports the selected session without listing and pub
   expect(manager.getTimeline(imported.id)).toEqual([
     { type: "user_message", text: "Trace provider imports" },
     { type: "assistant_message", text: "Done" },
+    {
+      type: "tool_call",
+      callId: "large-shell-result",
+      name: "shell",
+      status: "completed",
+      error: null,
+      detail: {
+        type: "shell",
+        command: "print output",
+        output: "x".repeat(64 * 1024),
+        exitCode: 0,
+      },
+    },
   ]);
   expect(events).toHaveLength(1);
   expect(events[0]).toMatchObject({

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -494,7 +494,7 @@ function buildImportedTimelineRows(entries: readonly ImportedTimelineEntry[]): A
     rows.push({
       seq: rows.length + 1,
       timestamp: entry.timestamp ?? new Date().toISOString(),
-      item: entry.item,
+      item: limitAgentTimelineItemContent(entry.item),
     });
   }
   return rows;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -58,6 +58,7 @@ import {
   AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS,
   AgentStreamCoalescer,
 } from "./agent-stream-coalescer.js";
+import { limitAgentTimelineItemContent } from "./agent-timeline-content.js";
 import { ForegroundRunState, type ForegroundTurnWaiter } from "./foreground-run-state.js";
 import { getAgentProviderDefinition } from "@getpaseo/protocol/provider-manifest";
 import { invokeRewindCapability, type RewindMode } from "./rewind/rewind.js";
@@ -1752,6 +1753,7 @@ export class AgentManager {
 
   async appendTimelineItem(agentId: string, item: AgentTimelineItem): Promise<void> {
     const agent = this.requireAgent(agentId);
+    item = limitAgentTimelineItemContent(item);
     this.touchUpdatedAt(agent);
     const row = this.recordTimeline(agentId, item);
     this.dispatchStream(
@@ -2990,17 +2992,22 @@ export class AgentManager {
       agent.historyPrimed = true;
 
       for (const event of historyEvents) {
+        const item = limitAgentTimelineItemContent(event.item);
         const row = this.recordTimeline(
           agent.id,
-          event.item,
+          item,
           event.timestamp ? { timestamp: event.timestamp } : undefined,
         );
         if (options?.broadcast) {
-          this.dispatchStream(agent.id, event, {
-            seq: row.seq,
-            epoch: this.timelineStore.getEpoch(agent.id),
-            timestamp: row.timestamp,
-          });
+          this.dispatchStream(
+            agent.id,
+            { ...event, item },
+            {
+              seq: row.seq,
+              epoch: this.timelineStore.getEpoch(agent.id),
+              timestamp: row.timestamp,
+            },
+          );
         }
       }
       this.touchUpdatedAt(agent);
@@ -3057,6 +3064,12 @@ export class AgentManager {
     event: AgentStreamEvent,
     options?: HandleStreamEventOptions,
   ): Promise<boolean> {
+    if (event.type === "timeline") {
+      event = {
+        ...event,
+        item: limitAgentTimelineItemContent(event.item),
+      };
+    }
     const eventTurnId = getAgentStreamEventTurnId(event);
     const isForegroundEvent = Boolean(eventTurnId && agent.activeForegroundTurnId === eventTurnId);
     this.traceHandleStreamEventStart(agent, event, eventTurnId, isForegroundEvent);
@@ -3553,6 +3566,7 @@ export class AgentManager {
     item: AgentTimelineItem,
     options?: { timestamp?: string },
   ): AgentTimelineRow {
+    item = limitAgentTimelineItemContent(item);
     const row = this.timelineStore.append(agentId, item, options);
     this.enqueueDurableTimelineAppend(agentId, row);
     return row;
@@ -3742,6 +3756,12 @@ export class AgentManager {
     event: AgentStreamEvent,
     metadata?: { seq?: number; epoch?: string; timestamp?: string },
   ): void {
+    if (event.type === "timeline") {
+      event = {
+        ...event,
+        item: limitAgentTimelineItemContent(event.item),
+      };
+    }
     const agent = this.agents.get(agentId);
     this.logger.trace(
       {

--- a/packages/server/src/server/agent/agent-timeline-content.ts
+++ b/packages/server/src/server/agent/agent-timeline-content.ts
@@ -1,0 +1,75 @@
+import type { AgentTimelineItem } from "./agent-sdk-types.js";
+
+const TOOL_CALL_CONTENT_MAX_BYTES = 64 * 1024;
+const TOOL_CALL_CONTENT_TRUNCATION_MARKER = "\n...<tool output truncated in the middle>...\n";
+
+function utf8ByteLength(text: string): number {
+  return Buffer.byteLength(text, "utf8");
+}
+
+function takeFirstUtf8Bytes(text: string, maxBytes: number): string {
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const midpoint = Math.ceil((low + high) / 2);
+    if (utf8ByteLength(text.slice(0, midpoint)) <= maxBytes) {
+      low = midpoint;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+  if (low > 0 && low < text.length && /[\uD800-\uDBFF]/.test(text[low - 1] ?? "")) {
+    low -= 1;
+  }
+  return text.slice(0, low);
+}
+
+function takeLastUtf8Bytes(text: string, maxBytes: number): string {
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const length = Math.ceil((low + high) / 2);
+    if (utf8ByteLength(text.slice(text.length - length)) <= maxBytes) {
+      low = length;
+    } else {
+      high = length - 1;
+    }
+  }
+  let start = text.length - low;
+  if (start > 0 && start < text.length && /[\uDC00-\uDFFF]/.test(text[start] ?? "")) {
+    start += 1;
+  }
+  return text.slice(start);
+}
+
+function limitToolCallText(text: string): string {
+  if (utf8ByteLength(text) <= TOOL_CALL_CONTENT_MAX_BYTES) {
+    return text;
+  }
+  const availableBytes =
+    TOOL_CALL_CONTENT_MAX_BYTES - utf8ByteLength(TOOL_CALL_CONTENT_TRUNCATION_MARKER);
+  const headBytes = Math.floor(availableBytes / 2);
+  const tailBytes = availableBytes - headBytes;
+  return `${takeFirstUtf8Bytes(text, headBytes)}${TOOL_CALL_CONTENT_TRUNCATION_MARKER}${takeLastUtf8Bytes(text, tailBytes)}`;
+}
+
+export function limitAgentTimelineItemContent(item: AgentTimelineItem): AgentTimelineItem {
+  if (
+    item.type !== "tool_call" ||
+    item.detail.type !== "shell" ||
+    typeof item.detail.output !== "string"
+  ) {
+    return item;
+  }
+  const output = limitToolCallText(item.detail.output);
+  if (output === item.detail.output) {
+    return item;
+  }
+  return {
+    ...item,
+    detail: {
+      ...item.detail,
+      output,
+    },
+  };
+}

--- a/packages/server/src/server/agent/agent-timeline-content.ts
+++ b/packages/server/src/server/agent/agent-timeline-content.ts
@@ -2,7 +2,30 @@ import type { AgentTimelineItem } from "./agent-sdk-types.js";
 
 const TOOL_CALL_CONTENT_MAX_LENGTH = 64 * 1024;
 
+function limitFailedShellError(item: AgentTimelineItem): AgentTimelineItem {
+  if (
+    item.type !== "tool_call" ||
+    item.detail.type !== "shell" ||
+    item.status !== "failed" ||
+    typeof item.error !== "object" ||
+    item.error === null ||
+    !("content" in item.error) ||
+    typeof item.error.content !== "string" ||
+    item.error.content.length <= TOOL_CALL_CONTENT_MAX_LENGTH
+  ) {
+    return item;
+  }
+  return {
+    ...item,
+    error: {
+      ...item.error,
+      content: item.error.content.slice(0, TOOL_CALL_CONTENT_MAX_LENGTH),
+    },
+  };
+}
+
 export function limitAgentTimelineItemContent(item: AgentTimelineItem): AgentTimelineItem {
+  item = limitFailedShellError(item);
   if (
     item.type !== "tool_call" ||
     item.detail.type !== "shell" ||

--- a/packages/server/src/server/agent/agent-timeline-content.ts
+++ b/packages/server/src/server/agent/agent-timeline-content.ts
@@ -1,57 +1,6 @@
 import type { AgentTimelineItem } from "./agent-sdk-types.js";
 
-const TOOL_CALL_CONTENT_MAX_BYTES = 64 * 1024;
-const TOOL_CALL_CONTENT_TRUNCATION_MARKER = "\n...<tool output truncated in the middle>...\n";
-
-function utf8ByteLength(text: string): number {
-  return Buffer.byteLength(text, "utf8");
-}
-
-function takeFirstUtf8Bytes(text: string, maxBytes: number): string {
-  let low = 0;
-  let high = text.length;
-  while (low < high) {
-    const midpoint = Math.ceil((low + high) / 2);
-    if (utf8ByteLength(text.slice(0, midpoint)) <= maxBytes) {
-      low = midpoint;
-    } else {
-      high = midpoint - 1;
-    }
-  }
-  if (low > 0 && low < text.length && /[\uD800-\uDBFF]/.test(text[low - 1] ?? "")) {
-    low -= 1;
-  }
-  return text.slice(0, low);
-}
-
-function takeLastUtf8Bytes(text: string, maxBytes: number): string {
-  let low = 0;
-  let high = text.length;
-  while (low < high) {
-    const length = Math.ceil((low + high) / 2);
-    if (utf8ByteLength(text.slice(text.length - length)) <= maxBytes) {
-      low = length;
-    } else {
-      high = length - 1;
-    }
-  }
-  let start = text.length - low;
-  if (start > 0 && start < text.length && /[\uDC00-\uDFFF]/.test(text[start] ?? "")) {
-    start += 1;
-  }
-  return text.slice(start);
-}
-
-function limitToolCallText(text: string): string {
-  if (utf8ByteLength(text) <= TOOL_CALL_CONTENT_MAX_BYTES) {
-    return text;
-  }
-  const availableBytes =
-    TOOL_CALL_CONTENT_MAX_BYTES - utf8ByteLength(TOOL_CALL_CONTENT_TRUNCATION_MARKER);
-  const headBytes = Math.floor(availableBytes / 2);
-  const tailBytes = availableBytes - headBytes;
-  return `${takeFirstUtf8Bytes(text, headBytes)}${TOOL_CALL_CONTENT_TRUNCATION_MARKER}${takeLastUtf8Bytes(text, tailBytes)}`;
-}
+const TOOL_CALL_CONTENT_MAX_LENGTH = 64 * 1024;
 
 export function limitAgentTimelineItemContent(item: AgentTimelineItem): AgentTimelineItem {
   if (
@@ -61,15 +10,14 @@ export function limitAgentTimelineItemContent(item: AgentTimelineItem): AgentTim
   ) {
     return item;
   }
-  const output = limitToolCallText(item.detail.output);
-  if (output === item.detail.output) {
+  if (item.detail.output.length <= TOOL_CALL_CONTENT_MAX_LENGTH) {
     return item;
   }
   return {
     ...item,
     detail: {
       ...item.detail,
-      output,
+      output: item.detail.output.slice(0, TOOL_CALL_CONTENT_MAX_LENGTH),
     },
   };
 }


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Large shell tool output could be stored in an agent timeline and sent through the live stream unchanged, making chat history unnecessarily heavy. This slices canonical shell output and failed-shell error content to the first 64 KiB before coalescing, persistence, import, history hydration, or live delivery.

The limit lives after provider mapping, so every provider follows the same timeline policy.

### How did you verify it

- Added an AgentManager test with a 1 MiB shell result and observed it fail because the full payload was persisted and streamed.
- Added vertical TDD coverage for provider streaming, direct timeline append, provider history hydration, streaming-only emission, failed-shell error content, and provider-session imports.
- `agent-manager-stream-coalescing.test.ts`: 26 tests pass.
- Focused provider import test passes.
- `npm run typecheck` passes.
- `npm run lint` passes with zero warnings.
- `npm run format` completed successfully.

Risk surface: this applies only to newly ingested timeline items. Previously persisted oversized rows are unchanged.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI changes)
- [x] Tests added or updated where it made sense