### PR TITLE
Show Fork chat for every agent provider

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2056,11 +2056,16 @@ describe("ACPAgentSession", () => {
 
   test("emits assistant and reasoning chunks as deltas while user chunks stay accumulated", async () => {
     const session = createSession();
-    const events: Array<{ type: string; item?: { type: string; text?: string } }> = [];
+    const events: Array<{
+      type: string;
+      item?: { type: string; text?: string; messageId?: string };
+    }> = [];
     asInternals<ACPSessionInternals>(session).sessionId = "session-1";
 
     session.subscribe((event) => {
-      events.push(event as { type: string; item?: { type: string; text?: string } });
+      events.push(
+        event as { type: string; item?: { type: string; text?: string; messageId?: string } },
+      );
     });
 
     await session.sessionUpdate({
@@ -2118,13 +2123,55 @@ describe("ACPAgentSession", () => {
       .filter(Boolean);
 
     expect(timeline).toEqual([
-      { type: "assistant_message", text: "Hey!" },
-      { type: "assistant_message", text: " How are you?" },
+      { type: "assistant_message", text: "Hey!", messageId: "assistant-1" },
+      { type: "assistant_message", text: " How are you?", messageId: "assistant-1" },
       { type: "reasoning", text: "Thinking" },
       { type: "reasoning", text: " more" },
       { type: "user_message", text: "hel", messageId: "user-1" },
       { type: "user_message", text: "hello", messageId: "user-1" },
     ]);
+  });
+
+  test("assigns one fallback ID per contiguous assistant message", async () => {
+    const session = createSession();
+    const assistantMessages: Array<{ text: string; messageId?: string }> = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    session.subscribe((event) => {
+      if (event.type === "timeline" && event.item.type === "assistant_message") {
+        assistantMessages.push(event.item);
+      }
+    });
+
+    for (const text of ["First", " message"]) {
+      await session.sessionUpdate({
+        sessionId: "session-1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text },
+        } as SessionUpdate,
+      });
+    }
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "Next response" },
+      } as SessionUpdate,
+    });
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Second message" },
+      } as SessionUpdate,
+    });
+
+    expect(assistantMessages).toHaveLength(3);
+    expect(assistantMessages[0].messageId).toEqual(expect.any(String));
+    expect(assistantMessages[1].messageId).toBe(assistantMessages[0].messageId);
+    expect(assistantMessages[2].messageId).toEqual(expect.any(String));
+    expect(assistantMessages[2].messageId).not.toBe(assistantMessages[0].messageId);
   });
 
   test("startTurn returns before the ACP prompt settles and completes later via subscribers", async () => {
@@ -2691,6 +2738,103 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
       cwd: "/tmp/paseo-acp-test",
       mcpServers: [],
     });
+  });
+
+  test("preserves assistant message IDs from loadSession replay", async () => {
+    let session!: ACPAgentSession;
+    const loadSession = async () => {
+      await session.sessionUpdate({
+        sessionId: "session-1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          messageId: "assistant-replay-1",
+          content: { type: "text", text: "Welcome back" },
+        } as SessionUpdate,
+      });
+      return {
+        sessionId: "session-1",
+        modes: null,
+        models: null,
+        configOptions: [],
+      };
+    };
+    ({ session } = makeTestSession({
+      capabilities: { loadSession: true },
+      handle: { sessionId: "session-1", provider: "claude-acp" },
+      loadSession,
+    }));
+
+    await session.initializeResumedSession();
+
+    const history: AgentStreamEvent[] = [];
+    for await (const event of session.streamHistory()) {
+      history.push(event);
+    }
+    expect(history).toEqual([
+      {
+        type: "timeline",
+        provider: "claude-acp",
+        item: {
+          type: "assistant_message",
+          text: "Welcome back",
+          messageId: "assistant-replay-1",
+        },
+      },
+    ]);
+  });
+
+  test("assigns stable fallback IDs to ID-less assistant messages during loadSession replay", async () => {
+    let session!: ACPAgentSession;
+    const loadSession = async () => {
+      for (const text of ["Loaded", " response"]) {
+        await session.sessionUpdate({
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text },
+          } as SessionUpdate,
+        });
+      }
+      await session.sessionUpdate({
+        sessionId: "session-1",
+        update: {
+          sessionUpdate: "user_message_chunk",
+          content: { type: "text", text: "Follow up" },
+        } as SessionUpdate,
+      });
+      await session.sessionUpdate({
+        sessionId: "session-1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Loaded second response" },
+        } as SessionUpdate,
+      });
+      return {
+        sessionId: "session-1",
+        modes: null,
+        models: null,
+        configOptions: [],
+      };
+    };
+    ({ session } = makeTestSession({
+      capabilities: { loadSession: true },
+      handle: { sessionId: "session-1", provider: "claude-acp" },
+      loadSession,
+    }));
+
+    await session.initializeResumedSession();
+
+    const assistantMessages: Array<{ text: string; messageId?: string }> = [];
+    for await (const event of session.streamHistory()) {
+      if (event.type === "timeline" && event.item.type === "assistant_message") {
+        assistantMessages.push(event.item);
+      }
+    }
+    expect(assistantMessages).toHaveLength(3);
+    expect(assistantMessages[0].messageId).toEqual(expect.any(String));
+    expect(assistantMessages[1].messageId).toBe(assistantMessages[0].messageId);
+    expect(assistantMessages[2].messageId).toEqual(expect.any(String));
+    expect(assistantMessages[2].messageId).not.toBe(assistantMessages[0].messageId);
   });
 
   test("loadSession is always called with mcpServers even when supportsMcpServers is false", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1316,6 +1316,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
+  private fallbackAssistantMessageId: string | null = null;
   private closed = false;
   private historyPending = false;
   private replayingHistory = false;
@@ -1459,6 +1460,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     const turnId = randomUUID();
     const messageId = options?.messageId ?? randomUUID();
     this.activeForegroundTurnId = turnId;
+    this.fallbackAssistantMessageId = null;
     this.activeSubmittedUserMessage = null;
     this.emitBootstrapThreadEvent();
     this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
@@ -2424,6 +2426,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[] {
     switch (update.sessionUpdate) {
       case "user_message_chunk": {
+        this.fallbackAssistantMessageId = null;
         const item = this.createMessageTimelineItem("user_message", update);
         if (!item) {
           return [];
@@ -2441,10 +2444,12 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         return item ? [this.wrapTimeline(item)] : [];
       }
       case "agent_thought_chunk": {
+        this.fallbackAssistantMessageId = null;
         const item = this.createMessageTimelineItem("reasoning", update);
         return item ? [this.wrapTimeline(item)] : [];
       }
       case "tool_call":
+        this.fallbackAssistantMessageId = null;
         return this.handleToolCallUpdate(update.toolCallId, update, undefined);
       case "tool_call_update":
         return this.handleToolCallUpdate(
@@ -2453,6 +2458,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
           this.toolCalls.get(update.toolCallId),
         );
       case "plan":
+        this.fallbackAssistantMessageId = null;
         return [this.wrapTimeline(mapPlanToTimeline(update))];
       case "current_mode_update":
         this.handleCurrentModeUpdate(update);
@@ -2507,7 +2513,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     >,
   ):
     | { type: "user_message"; text: string; messageId?: string }
-    | { type: "assistant_message"; text: string }
+    | { type: "assistant_message"; text: string; messageId: string }
     | { type: "reasoning"; text: string }
     | null {
     const chunkText = contentBlockToText(update.content);
@@ -2523,9 +2529,22 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       return { type: "user_message", text: state.text, messageId: update.messageId ?? undefined };
     }
     if (type === "assistant_message") {
-      return { type: "assistant_message", text: chunkText };
+      return {
+        type: "assistant_message",
+        text: chunkText,
+        messageId: this.resolveAssistantMessageId(update.messageId),
+      };
     }
     return { type: "reasoning", text: chunkText };
+  }
+
+  private resolveAssistantMessageId(messageId: string | null | undefined): string {
+    if (messageId) {
+      this.fallbackAssistantMessageId = null;
+      return messageId;
+    }
+    this.fallbackAssistantMessageId ??= randomUUID();
+    return this.fallbackAssistantMessageId;
   }
 
   private messageAssemblyKey(
@@ -2682,6 +2701,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     event: Extract<AgentStreamEvent, { type: "turn_completed" | "turn_failed" | "turn_canceled" }>,
   ): void {
     this.activeForegroundTurnId = null;
+    this.fallbackAssistantMessageId = null;
     if (this.activeSubmittedUserMessage?.turnId === event.turnId) {
       this.activeSubmittedUserMessage = null;
     }

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -215,12 +215,13 @@ describe("OpenCodeAgentClient adapter smoke tests", () => {
 
     expect(turn.turnCompleted).toBe(true);
     expect(turn.turnFailed).toBe(false);
-    expect(turn.assistantMessages.length).toBeGreaterThan(0);
-    for (const msg of turn.assistantMessages) {
-      expect(msg.text.length).toBeGreaterThan(0);
-    }
-    const fullResponse = turn.assistantMessages.map((m) => m.text).join("");
-    expect(fullResponse).toBe("Hello from OpenCode");
+    expect(turn.assistantMessages).toEqual([
+      {
+        type: "assistant_message",
+        text: "Hello from OpenCode",
+        messageId: "msg_assistant",
+      },
+    ]);
     expect(openCodeClient.calls.sessionPromptAsync).toEqual([
       expect.objectContaining({
         sessionID: "session-1",
@@ -233,6 +234,74 @@ describe("OpenCodeAgentClient adapter smoke tests", () => {
     await session.close();
     rmSync(cwd, { recursive: true, force: true });
   }, 120_000);
+
+  test("completed and structured assistant messages preserve OpenCode message IDs", async () => {
+    const cwd = tmpCwd();
+    const runtime = new TestOpenCodeHarness();
+    const openCodeClient = new TestOpenCodeClient();
+    openCodeClient.sessionPromptAsyncEvents = [
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_structured",
+            sessionID: "session-1",
+            role: "assistant",
+            structured: "structured reply",
+            time: { completed: 1 },
+          },
+        },
+      },
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_completed",
+            sessionID: "session-1",
+            role: "assistant",
+          },
+        },
+      },
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "prt_completed",
+            sessionID: "session-1",
+            messageID: "msg_completed",
+            type: "text",
+            text: "completed reply",
+            time: { start: 1, end: 2 },
+          },
+        },
+      },
+      { type: "session.idle", properties: { sessionID: "session-1" } },
+    ];
+    runtime.enqueueClient(openCodeClient);
+    const client = new OpenCodeAgentClient(logger, undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const session = await client.createSession(buildConfig(cwd));
+
+    const turn = await collectTurnEvents(streamSession(session, "Reply twice"));
+
+    expect(turn.assistantMessages).toEqual([
+      {
+        type: "assistant_message",
+        text: "structured reply",
+        messageId: "msg_structured",
+      },
+      {
+        type: "assistant_message",
+        text: "completed reply",
+        messageId: "msg_completed",
+      },
+    ]);
+
+    await session.close();
+    rmSync(cwd, { recursive: true, force: true });
+  });
 
   test("manual compact hides the generated summary text", async () => {
     const cwd = tmpCwd();
@@ -1470,7 +1539,11 @@ describe("OpenCode adapter startTurn error handling", () => {
         type: "timeline",
         provider: "opencode",
         timestamp: "2026-05-14T12:41:23.612Z",
-        item: { type: "assistant_message", text: "probe ok" },
+        item: {
+          type: "assistant_message",
+          text: "probe ok",
+          messageId: "msg_assistant",
+        },
       },
     ]);
   });
@@ -1522,7 +1595,11 @@ describe("OpenCode adapter startTurn error handling", () => {
       {
         type: "timeline",
         provider: "opencode",
-        item: { type: "assistant_message", text: "no clocks here" },
+        item: {
+          type: "assistant_message",
+          text: "no clocks here",
+          messageId: "msg_assistant",
+        },
       },
     ]);
   });

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -2532,7 +2532,7 @@ function appendOpenCodeMessagePartDelta(
     return;
   }
   if (state.suppressAssistantMessagesUntilIdle?.active === true) {
-    state.compactionSummaryMessageIds.add(messageID);
+    state.compactionSummaryMessageIds.add(assistantMessageId);
     return;
   }
   if (partID) {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -2527,7 +2527,8 @@ function appendOpenCodeMessagePartDelta(
   if (messageRole === "user") {
     return;
   }
-  if (!messageID) {
+  const assistantMessageId = messageID || partID;
+  if (!assistantMessageId) {
     return;
   }
   if (state.suppressAssistantMessagesUntilIdle?.active === true) {
@@ -2543,7 +2544,7 @@ function appendOpenCodeMessagePartDelta(
     item: {
       type: "assistant_message",
       text: delta,
-      messageId: messageID,
+      messageId: assistantMessageId,
     },
   });
 }

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -989,12 +989,16 @@ function buildOpenCodeReplayTimelineEvent(params: {
 
 function buildOpenCodeReplayPartTimelineEvent(params: {
   part: OpenCodePart;
-  message: { structured?: unknown; time?: { created?: number; completed?: number } | undefined };
+  message: {
+    id: string;
+    structured?: unknown;
+    time?: { created?: number; completed?: number } | undefined;
+  };
 }): Extract<AgentStreamEvent, { type: "timeline" }> | null {
   const { part, message } = params;
   if (part.type === "text" && part.text) {
     return buildOpenCodeReplayTimelineEvent({
-      item: { type: "assistant_message", text: part.text },
+      item: { type: "assistant_message", text: part.text, messageId: message.id },
       message,
       part,
     });
@@ -1183,7 +1187,7 @@ function buildOpenCodeReplayTimelineEvents(
     if (text) {
       events.push(
         buildOpenCodeReplayTimelineEvent({
-          item: { type: "assistant_message", text },
+          item: { type: "assistant_message", text, messageId: info.id },
           message: info,
         }),
       );
@@ -2329,7 +2333,7 @@ function appendOpenCodeMessageUpdated(
   events.push({
     type: "timeline",
     provider: "opencode",
-    item: { type: "assistant_message", text },
+    item: { type: "assistant_message", text, messageId: info.id },
   });
 }
 
@@ -2457,7 +2461,7 @@ function appendOpenCodeTextPart(
     events.push({
       type: "timeline",
       provider: "opencode",
-      item: { type: "assistant_message", text: part.text },
+      item: { type: "assistant_message", text: part.text, messageId: part.messageID },
     });
   }
 }
@@ -2523,7 +2527,10 @@ function appendOpenCodeMessagePartDelta(
   if (messageRole === "user") {
     return;
   }
-  if (messageID && state.suppressAssistantMessagesUntilIdle?.active === true) {
+  if (!messageID) {
+    return;
+  }
+  if (state.suppressAssistantMessagesUntilIdle?.active === true) {
     state.compactionSummaryMessageIds.add(messageID);
     return;
   }
@@ -2533,7 +2540,11 @@ function appendOpenCodeMessagePartDelta(
   events.push({
     type: "timeline",
     provider: "opencode",
-    item: { type: "assistant_message", text: delta },
+    item: {
+      type: "assistant_message",
+      text: delta,
+      messageId: messageID,
+    },
   });
 }
 

--- a/packages/server/src/server/agent/providers/opencode/event-translator.test.ts
+++ b/packages/server/src/server/agent/providers/opencode/event-translator.test.ts
@@ -124,7 +124,11 @@ describe("translateOpenCodeEvent", () => {
       {
         type: "timeline",
         provider: "opencode",
-        item: { type: "assistant_message", text: "hey! what can I help with?" },
+        item: {
+          type: "assistant_message",
+          text: "hey! what can I help with?",
+          messageId: "message-1",
+        },
       },
     ]);
   });
@@ -167,7 +171,7 @@ describe("translateOpenCodeEvent", () => {
       {
         type: "timeline",
         provider: "opencode",
-        item: { type: "assistant_message", text: "final text" },
+        item: { type: "assistant_message", text: "final text", messageId: "message-2" },
       },
     ]);
   });
@@ -269,12 +273,12 @@ describe("translateOpenCodeEvent", () => {
       {
         type: "timeline",
         provider: "opencode",
-        item: { type: "assistant_message", text: "hey! " },
+        item: { type: "assistant_message", text: "hey! ", messageId: "msg-d1" },
       },
       {
         type: "timeline",
         provider: "opencode",
-        item: { type: "assistant_message", text: "what's up?" },
+        item: { type: "assistant_message", text: "what's up?", messageId: "msg-d1" },
       },
     ]);
   });
@@ -1073,7 +1077,7 @@ describe("translateOpenCodeEvent", () => {
       {
         type: "timeline",
         provider: "opencode",
-        item: { type: "assistant_message", text: "hello there" },
+        item: { type: "assistant_message", text: "hello there", messageId: "msg-dd1" },
       },
     ]);
   });
@@ -1274,7 +1278,11 @@ describe("translateOpenCodeEvent", () => {
       {
         type: "timeline",
         provider: "opencode",
-        item: { type: "assistant_message", text: '{"summary":"hello"}' },
+        item: {
+          type: "assistant_message",
+          text: '{"summary":"hello"}',
+          messageId: "message-structured-1",
+        },
       },
     ]);
     expect(second).toEqual([]);

--- a/packages/server/src/server/agent/providers/opencode/event-translator.test.ts
+++ b/packages/server/src/server/agent/providers/opencode/event-translator.test.ts
@@ -312,6 +312,27 @@ describe("translateOpenCodeEvent", () => {
     ]);
   });
 
+  it("suppresses part-id-only assistant deltas by their resolved identity", () => {
+    const state = createState();
+    state.suppressAssistantMessagesUntilIdle = { active: true };
+
+    const events = translateOpenCodeEvent(
+      {
+        type: "message.part.delta",
+        properties: {
+          sessionID: "session-1",
+          partID: "compaction-part",
+          field: "text",
+          delta: "hidden summary",
+        },
+      },
+      state,
+    );
+
+    expect(events).toEqual([]);
+    expect(state.compactionSummaryMessageIds).toEqual(new Set(["compaction-part"]));
+  });
+
   it("humanizes permission requests and includes shell detail when command metadata exists", () => {
     const state = createState();
 

--- a/packages/server/src/server/agent/providers/opencode/event-translator.test.ts
+++ b/packages/server/src/server/agent/providers/opencode/event-translator.test.ts
@@ -283,6 +283,35 @@ describe("translateOpenCodeEvent", () => {
     ]);
   });
 
+  it("uses the part id when an assistant delta omits its message id", () => {
+    const state = createState();
+
+    const events = translateOpenCodeEvent(
+      {
+        type: "message.part.delta",
+        properties: {
+          sessionID: "session-1",
+          partID: "part-without-message",
+          field: "text",
+          delta: "still visible",
+        },
+      },
+      state,
+    );
+
+    expect(events).toEqual([
+      {
+        type: "timeline",
+        provider: "opencode",
+        item: {
+          type: "assistant_message",
+          text: "still visible",
+          messageId: "part-without-message",
+        },
+      },
+    ]);
+  });
+
   it("humanizes permission requests and includes shell detail when command metadata exists", () => {
     const state = createState();
 

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -427,9 +427,18 @@ describe("PiRpcAgentSession", () => {
 
     await session.startTurn("hello");
     fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [], responseId: "response-1" },
+    });
+    fakeSession.emit({
       type: "message_update",
-      message: { role: "assistant", content: [] },
-      assistantMessageEvent: { type: "text_delta", delta: "hello" },
+      message: { role: "assistant", content: [], responseId: "response-1" },
+      assistantMessageEvent: { type: "text_delta", delta: "hel" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "response-1" },
+      assistantMessageEvent: { type: "text_delta", delta: "lo" },
     });
     fakeSession.emit({
       type: "message_update",
@@ -454,7 +463,8 @@ describe("PiRpcAgentSession", () => {
     await events.nextTurnCompletion();
 
     expect(events.timelineItems()).toEqual([
-      { type: "assistant_message", text: "hello" },
+      { type: "assistant_message", text: "hel", messageId: "response-1" },
+      { type: "assistant_message", text: "lo", messageId: "response-1" },
       { type: "reasoning", text: "thinking" },
       {
         type: "tool_call",
@@ -473,6 +483,39 @@ describe("PiRpcAgentSession", () => {
         error: null,
       },
     ]);
+  });
+
+  test("keeps one generated message id across chunks when Pi omits a response id", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [] },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: { type: "text_delta", delta: "hel" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: { type: "text_delta", delta: "lo" },
+    });
+
+    const [firstChunk, secondChunk] = events.timelineItems();
+    expect(firstChunk).toMatchObject({
+      type: "assistant_message",
+      text: "hel",
+      messageId: expect.any(String),
+    });
+    expect(secondChunk).toEqual({
+      type: "assistant_message",
+      text: "lo",
+      messageId: firstChunk?.type === "assistant_message" ? firstChunk.messageId : null,
+    });
   });
 
   test("emits live user messages with captured Pi tree entry ids", async () => {

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -485,15 +485,11 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
-  test("keeps one generated message id across chunks when Pi omits a response id", async () => {
+  test("keeps one generated message id when Pi omits message start and response id", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
 
     await session.startTurn("hello");
-    fakeSession.emit({
-      type: "message_start",
-      message: { role: "assistant", content: [] },
-    });
     fakeSession.emit({
       type: "message_update",
       message: { role: "assistant", content: [] },
@@ -511,10 +507,11 @@ describe("PiRpcAgentSession", () => {
       text: "hel",
       messageId: expect.any(String),
     });
+    const firstMessageId = (firstChunk as { messageId: string }).messageId;
     expect(secondChunk).toEqual({
       type: "assistant_message",
       text: "lo",
-      messageId: firstChunk?.type === "assistant_message" ? firstChunk.messageId : null,
+      messageId: firstMessageId,
     });
   });
 

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -515,6 +515,30 @@ describe("PiRpcAgentSession", () => {
     });
   });
 
+  test("uses a response id that first appears on the assistant update", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [] },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "late-response-id" },
+      assistantMessageEvent: { type: "text_delta", delta: "hello" },
+    });
+
+    expect(events.timelineItems()).toEqual([
+      {
+        type: "assistant_message",
+        text: "hello",
+        messageId: "late-response-id",
+      },
+    ]);
+  });
+
   test("emits live user messages with captured Pi tree entry ids", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1064,6 +1064,7 @@ export class PiRpcAgentSession implements AgentSession {
   private activeAskUserDialog: ActiveAskUserDialog | null = null;
   private pendingCombinedAskUserResponse: PendingCombinedAskUserResponse | null = null;
   private activeTurnId: string | null = null;
+  private activeAssistantMessageId: string | null = null;
   private lastKnownThinkingOptionId: string | null;
   currentLeafOverrideId: string | null | undefined;
   private readonly capturedUserEntries: PiCapturedEntry[] = [];
@@ -1123,6 +1124,7 @@ export class PiRpcAgentSession implements AgentSession {
     const payload = convertPromptInput(prompt, { model: this.state.model });
     const turnId = randomUUID();
     this.activeTurnId = turnId;
+    this.activeAssistantMessageId = null;
 
     void this.runtimeSession.prompt(payload.text, payload.images).catch((error) => {
       if (this.activeTurnId !== turnId) {
@@ -1711,6 +1713,7 @@ export class PiRpcAgentSession implements AgentSession {
         });
         return;
       case "message_start":
+        this.handleMessageStart(event);
         return;
       case "message_end":
         this.handleMessageEnd(event, turnId);
@@ -1818,6 +1821,7 @@ export class PiRpcAgentSession implements AgentSession {
       return;
     }
     if (event.assistantMessageEvent.type === "text_delta") {
+      this.activeAssistantMessageId ??= event.message.responseId || randomUUID();
       this.emit({
         type: "timeline",
         provider: PI_PROVIDER,
@@ -1825,6 +1829,7 @@ export class PiRpcAgentSession implements AgentSession {
         item: {
           type: "assistant_message",
           text: event.assistantMessageEvent.delta ?? "",
+          messageId: this.activeAssistantMessageId,
         },
       });
       return;
@@ -1842,10 +1847,20 @@ export class PiRpcAgentSession implements AgentSession {
     }
   }
 
+  private handleMessageStart(event: Extract<PiAgentSessionEvent, { type: "message_start" }>): void {
+    if (event.message.role === "assistant") {
+      this.activeAssistantMessageId = event.message.responseId || randomUUID();
+    }
+  }
+
   private handleMessageEnd(
     event: Extract<PiAgentSessionEvent, { type: "message_end" }>,
     turnId: string | undefined,
   ): void {
+    if (event.message.role === "assistant") {
+      this.activeAssistantMessageId = null;
+      return;
+    }
     if (event.message.role === "custom") {
       const text = getUserMessageText(event.message.content);
       if (text) {
@@ -1906,6 +1921,7 @@ export class PiRpcAgentSession implements AgentSession {
 
   private completeTurn(turnId: string | undefined, messages: PiAgentMessage[]): void {
     this.activeTurnId = null;
+    this.activeAssistantMessageId = null;
     const errorMessage = latestPiErrorMessage(messages);
     if (typeof errorMessage === "string" && errorMessage.length > 0) {
       this.emit({

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1821,6 +1821,7 @@ export class PiRpcAgentSession implements AgentSession {
       return;
     }
     if (event.assistantMessageEvent.type === "text_delta") {
+      // Pi-compatible runtimes may emit updates without a preceding message_start.
       this.activeAssistantMessageId ??= event.message.responseId || randomUUID();
       this.emit({
         type: "timeline",

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1850,7 +1850,7 @@ export class PiRpcAgentSession implements AgentSession {
 
   private handleMessageStart(event: Extract<PiAgentSessionEvent, { type: "message_start" }>): void {
     if (event.message.role === "assistant") {
-      this.activeAssistantMessageId = event.message.responseId || randomUUID();
+      this.activeAssistantMessageId = event.message.responseId || null;
     }
   }
 

--- a/packages/server/src/server/agent/providers/pi/history-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/pi/history-mapper.test.ts
@@ -29,6 +29,7 @@ describe("Pi history mapper", () => {
         },
         {
           role: "assistant",
+          responseId: "response-1",
           content: [
             { type: "thinking", thinking: "checking file" },
             { type: "toolCall", id: "tool-1", name: "read", arguments: { path: "note.txt" } },
@@ -77,7 +78,7 @@ describe("Pi history mapper", () => {
       {
         type: "timeline",
         provider: "pi",
-        item: { type: "assistant_message", text: "done" },
+        item: { type: "assistant_message", text: "done", messageId: "response-1" },
       },
       {
         type: "timeline",
@@ -153,7 +154,11 @@ describe("Pi history mapper", () => {
       {
         type: "timeline",
         provider: "pi",
-        item: { type: "assistant_message", text: "first answer" },
+        item: {
+          type: "assistant_message",
+          text: "first answer",
+          messageId: "pi-history-assistant-1",
+        },
       },
       {
         type: "timeline",

--- a/packages/server/src/server/agent/providers/pi/history-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/history-mapper.ts
@@ -44,6 +44,7 @@ export async function* streamPiHistory(
 ): AsyncGenerator<AgentStreamEvent> {
   const pendingToolCalls = new Map<string, PiTrackedToolCall>();
   let userIndex = 0;
+  let assistantIndex = 0;
 
   for (const message of messages) {
     if (message.role === "user") {
@@ -65,12 +66,14 @@ export async function* streamPiHistory(
     }
 
     if (message.role === "assistant") {
+      assistantIndex += 1;
+      const messageId = message.responseId || `${provider}-history-assistant-${assistantIndex}`;
       for (const content of message.content) {
         if (content.type === "text" && content.text) {
           yield {
             type: "timeline",
             provider,
-            item: { type: "assistant_message", text: content.text },
+            item: { type: "assistant_message", text: content.text, messageId },
           };
           continue;
         }


### PR DESCRIPTION
### Linked issue

None found.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fork chat now appears for completed assistant turns from every built-in provider and providers built on the shared ACP adapter.

The UI already treats assistant message identity as a provider-agnostic semantic requirement, while the wire field remains optional for backward compatibility. This change makes the provider adapters uphold that contract: they preserve runtime message IDs where available and assign stable adapter-owned IDs when a runtime omits them. Synthetic status and error rows remain unidentified and do not expose Fork.

### How did you verify it

- Reproduced the OpenCode replay failure with a red assertion: the runtime supplied `msg_assistant`, but the adapter omitted it.
- Verified OpenCode live, completed, structured, replayed, and imported assistant messages retain their runtime IDs.
- Verified ACP live and replay paths preserve runtime IDs and assign stable fallbacks across contiguous ID-less chunks, with distinct IDs across message boundaries.
- Verified Pi/OMP use `responseId` when available, generate one stable live ID per assistant message otherwise, and assign deterministic replay IDs.
- Ran the four affected provider test files together: 158 tests passed.
- Re-ran the ACP suite after tightening its fallback coverage: 73 tests passed.
- `npm run typecheck` passed.
- Targeted lint passed, and `npm run format` completed.

Risk surface: fallback identity depends on the provider adapter's message boundaries when a runtime does not supply an ID. Focused tests cover contiguous chunks, semantic boundaries, separate turns, and replay. No protocol schema or UI rendering code changed.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (no UI code changed)
- [x] Tests added or updated where it made sense