### PR TITLE
Keep ACP tool execution in the agent environment

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -457,26 +457,25 @@ Paseo tools such as subagent creation come from the shared internal tool catalog
 }
 ```
 
-ACP agents normally receive access to Paseo's filesystem and terminal through
-the client capabilities advertised during initialization. For a compliant agent
-running in a container or remote environment, disable those capabilities so it
-keeps file and command execution in the agent environment:
+ACP agents execute filesystem and terminal operations in their own environment
+by default. To let a compliant agent delegate those operations to Paseo instead,
+enable the corresponding client capabilities:
 
 ```json
 {
   "agents": {
     "providers": {
-      "container-agent": {
+      "local-agent": {
         "extends": "acp",
-        "label": "Container Agent",
-        "command": ["container-agent", "acp"],
+        "label": "Local Agent",
+        "command": ["local-agent", "acp"],
         "params": {
           "clientCapabilities": {
             "fs": {
-              "readTextFile": false,
-              "writeTextFile": false
+              "readTextFile": true,
+              "writeTextFile": true
             },
-            "terminal": false
+            "terminal": true
           }
         }
       }
@@ -485,9 +484,9 @@ keeps file and command execution in the agent environment:
 }
 ```
 
-The defaults remain enabled for compatibility with local ACP agents. Configure
-both environments with equivalent absolute workspace paths before enabling
-client filesystem or terminal delegation across a process boundary.
+Only enable capabilities Paseo should execute. When the agent and Paseo run in
+different environments, configure equivalent absolute workspace paths before
+delegating filesystem or terminal operations to Paseo.
 
 ### Generic ACP diagnostics
 

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -52,13 +52,13 @@ import { asInternals } from "../../test-utils/class-mocks.js";
 import * as spawnUtils from "../../../utils/spawn.js";
 
 describe("buildACPClientCapabilities", () => {
-  test("preserves the default client filesystem and terminal capabilities", () => {
+  test("keeps filesystem and terminal execution with the agent by default", () => {
     expect(buildACPClientCapabilities()).toEqual({
       fs: {
-        readTextFile: true,
-        writeTextFile: true,
+        readTextFile: false,
+        writeTextFile: false,
       },
-      terminal: true,
+      terminal: false,
     });
   });
 
@@ -68,17 +68,17 @@ describe("buildACPClientCapabilities", () => {
         { source: "provider" },
         {
           fs: {
-            readTextFile: false,
+            readTextFile: true,
           },
-          terminal: false,
+          terminal: true,
         },
       ),
     ).toEqual({
       fs: {
-        readTextFile: false,
-        writeTextFile: true,
+        readTextFile: true,
+        writeTextFile: false,
       },
-      terminal: false,
+      terminal: true,
       _meta: { source: "provider" },
     });
   });

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -231,10 +231,10 @@ export const DEFAULT_ACP_CAPABILITIES: AgentCapabilityFlags = {
 
 const BASE_ACP_CLIENT_CAPABILITIES: ACPClientCapabilities = {
   fs: {
-    readTextFile: true,
-    writeTextFile: true,
+    readTextFile: false,
+    writeTextFile: false,
   },
-  terminal: true,
+  terminal: false,
 };
 
 export type ACPClientCapabilityMeta = Record<string, unknown>;

--- a/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
@@ -108,10 +108,10 @@ describe("GenericACPAgentClient diagnostics", () => {
         providerParams: {
           clientCapabilities: {
             fs: {
-              readTextFile: false,
-              writeTextFile: false,
+              readTextFile: true,
+              writeTextFile: true,
             },
-            terminal: false,
+            terminal: true,
           },
         },
       });
@@ -127,19 +127,19 @@ describe("GenericACPAgentClient diagnostics", () => {
         {
           clientCapabilities: {
             fs: {
-              readTextFile: false,
-              writeTextFile: false,
+              readTextFile: true,
+              writeTextFile: true,
             },
-            terminal: false,
+            terminal: true,
           },
         },
         {
           clientCapabilities: {
             fs: {
-              readTextFile: false,
-              writeTextFile: false,
+              readTextFile: true,
+              writeTextFile: true,
             },
-            terminal: false,
+            terminal: true,
           },
         },
       ]);


### PR DESCRIPTION
### Linked issue

Refs #2012

Follow-up to #2011.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

ACP agents now keep filesystem reads, writes, and terminal commands in their own environment by default. Providers must explicitly opt into delegating those operations to the Paseo host through the `clientCapabilities` configuration added in #2011.

This makes the default match Paseo’s ownership model: Paseo does not execute ACP tools unless the provider is deliberately configured to delegate them.

### How did you verify it

- 78 focused ACP/provider tests passed, including subprocess-backed assertions of the real initialization payload.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run format` passed.

Risk surface: existing ACP providers that relied on implicit Paseo-hosted filesystem or terminal execution must opt into those capabilities explicitly.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform — no UI changes
- [x] Tests added or updated where it made sense