### PR TITLE
Show only commands in Codex shell tool calls

### DIFF
--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
@@ -51,23 +51,26 @@ describe("codex tool-call mapper", () => {
     });
   });
 
-  it("unwraps /usr/bin zsh wrapper strings for commandExecution", () => {
-    const item = expectMapped(
-      mapCodexToolCallFromThreadItem({
-        type: "commandExecution",
-        id: "codex-call-wrapper-string",
-        status: "running",
-        command: '/usr/bin/zsh -lc "echo hello"',
-        cwd: "/tmp/repo",
-      }),
-    );
+  it.each(['/bin/zsh -lc "echo hello"', '/usr/bin/zsh -lc "echo hello"'])(
+    "unwraps zsh wrapper strings for commandExecution: %s",
+    (command) => {
+      const item = expectMapped(
+        mapCodexToolCallFromThreadItem({
+          type: "commandExecution",
+          id: "codex-call-wrapper-string",
+          status: "running",
+          command,
+          cwd: "/tmp/repo",
+        }),
+      );
 
-    expect(item.detail).toEqual({
-      type: "shell",
-      command: "echo hello",
-      cwd: "/tmp/repo",
-    });
-  });
+      expect(item.detail).toEqual({
+        type: "shell",
+        command: "echo hello",
+        cwd: "/tmp/repo",
+      });
+    },
+  );
 
   it("unwraps pwsh wrapper strings for commandExecution on Windows", () => {
     const item = expectMapped(

--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
@@ -51,13 +51,13 @@ describe("codex tool-call mapper", () => {
     });
   });
 
-  it("unwraps shell wrapper strings for commandExecution", () => {
+  it("unwraps /usr/bin zsh wrapper strings for commandExecution", () => {
     const item = expectMapped(
       mapCodexToolCallFromThreadItem({
         type: "commandExecution",
         id: "codex-call-wrapper-string",
         status: "running",
-        command: '/bin/zsh -lc "echo hello"',
+        command: '/usr/bin/zsh -lc "echo hello"',
         cwd: "/tmp/repo",
       }),
     );

--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
@@ -221,7 +221,9 @@ const CodexThreadItemSchema = z.discriminatedUnion("type", [
 
 function maybeUnwrapShellWrapperCommand(command: string): string {
   const trimmed = command.trim();
-  const unixWrapperMatch = trimmed.match(/^(?:\/bin\/)?(?:zsh|bash|sh)\s+-(?:lc|c)\s+([\s\S]+)$/);
+  const unixWrapperMatch = trimmed.match(
+    /^(?:(?:\/[^/\s]+)*\/)?(?:zsh|bash|sh)\s+-(?:lc|c)\s+([\s\S]+)$/,
+  );
   if (unixWrapperMatch) {
     const candidate = unixWrapperMatch[1]?.trim() ?? "";
     if (!candidate) {


### PR DESCRIPTION
### Linked issue

Reported in [Discord](https://discord.com/channels/1481169421832814616/1525963009896222830/1525963009896222830).

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Codex shell tool calls now show the command itself when the shell executable lives outside `/bin`, including `/usr/bin/zsh`. The command mapper previously kept that launcher wrapper intact, so it appeared in every affected tool-call summary.

### How did you verify it

- Changed the mapper case to the reported `/usr/bin/zsh -lc` input and ran `npx vitest run packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts --bail=1`. Before the fix it received the full launcher instead of `echo hello`; after the fix all 38 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run format`

### Risk surface

Codex command summaries only. Command execution and the wire protocol are unchanged, and the focused mapper test covers the reported input shape.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense