### PR TITLE
Keep attachments visible after creating an agent

### DIFF
--- a/packages/app/e2e/assistant-fork-menu.spec.ts
+++ b/packages/app/e2e/assistant-fork-menu.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test as base, type Page } from "./fixtures";
 import { scrollAgentChatToBottom } from "./helpers/agent-bottom-anchor";
 import { awaitAssistantMessage } from "./helpers/agent-stream";
-import { expectComposerVisible } from "./helpers/composer";
+import { expectComposerVisible, submitMessage } from "./helpers/composer";
 import { getE2EDaemonPort } from "./helpers/daemon-port";
 import {
   openAgentRoute,
@@ -11,6 +11,7 @@ import {
 } from "./helpers/mock-agent";
 import { getServerId } from "./helpers/server-id";
 import { seedSavedSettingsHosts } from "./helpers/settings";
+import { submitNewWorkspaceEmpty } from "./helpers/new-workspace";
 
 const test = base.extend<{
   seedForkWorkspace: (options: MockAgentOptions) => Promise<MockAgentWorkspace>;
@@ -75,6 +76,33 @@ test.describe("Assistant fork menu", () => {
     await expectChatHistoryPill(page);
   });
 
+  test("keeps the fork attachment after submitting an existing-workspace draft tab", async ({
+    page,
+    seedForkWorkspace,
+  }) => {
+    const session = await seedForkWorkspace({
+      repoPrefix: "assistant-fork-tab-submit-",
+      title: "Assistant fork tab submit",
+      initialPrompt: "emit 1 coalesced agent stream updates for assistant fork tab submit.",
+      model: "ten-second-stream",
+    });
+
+    await openAgentRoute(page, session);
+    await expectComposerVisible(page);
+    await awaitAssistantMessage(page);
+    await session.client.waitForFinish(session.agentId, 45_000);
+
+    await openAssistantForkMenu(page);
+    await page.getByTestId("assistant-fork-menu-new-tab").click();
+    await expectChatHistoryPill(page);
+
+    await submitMessage(page, "");
+
+    const userMessage = page.getByTestId("user-message").filter({ hasText: "Chat history" }).last();
+    await expect(userMessage).toBeVisible({ timeout: 30_000 });
+    await expect(userMessage).not.toContainText("Source agent:");
+  });
+
   test("forks an assistant turn into New Workspace and keeps the attachment across host changes", async ({
     page,
     seedForkWorkspace,
@@ -117,5 +145,32 @@ test.describe("Assistant fork menu", () => {
       .getByTestId("new-workspace-host-picker-option-secondary-assistant-fork-host")
       .click();
     await expectChatHistoryPill(page);
+  });
+
+  test("keeps the fork attachment after the new agent receives its user message", async ({
+    page,
+    seedForkWorkspace,
+  }) => {
+    const session = await seedForkWorkspace({
+      repoPrefix: "assistant-fork-submit-",
+      title: "Assistant fork submit",
+      initialPrompt: "emit 1 coalesced agent stream updates for assistant fork submit.",
+      model: "ten-second-stream",
+    });
+
+    await openAgentRoute(page, session);
+    await expectComposerVisible(page);
+    await awaitAssistantMessage(page);
+    await session.client.waitForFinish(session.agentId, 45_000);
+
+    await openAssistantForkMenu(page);
+    await page.getByTestId("assistant-fork-menu-new-workspace").click();
+    await expectChatHistoryPill(page);
+
+    await submitNewWorkspaceEmpty(page);
+
+    const userMessage = page.getByTestId("user-message").filter({ hasText: "Chat history" }).last();
+    await expect(userMessage).toBeVisible({ timeout: 30_000 });
+    await expect(userMessage).not.toContainText("Source agent:");
   });
 });

--- a/packages/app/src/composer/draft/create-flow.ts
+++ b/packages/app/src/composer/draft/create-flow.ts
@@ -123,8 +123,8 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
   const updatePendingAgentId = useCreateFlowStore((state) => state.updateAgentId);
   const markPendingCreateLifecycle = useCreateFlowStore((state) => state.markLifecycle);
   const clearPendingCreateAttempt = useCreateFlowStore((state) => state.clear);
-  const appendOptimisticUserMessageToAgentStream = useSessionStore(
-    (state) => state.appendOptimisticUserMessageToAgentStream,
+  const handoffCreatedAgentUserMessage = useSessionStore(
+    (state) => state.handoffCreatedAgentUserMessage,
   );
 
   const formErrorMessage = machine.tag === "draft" ? machine.errorMessage : "";
@@ -189,7 +189,7 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
 
         if (createResult.agentId) {
           updatePendingAgentId({ draftId, agentId: createResult.agentId });
-          appendOptimisticUserMessageToAgentStream(
+          handoffCreatedAgentUserMessage(
             pendingServerId,
             createResult.agentId,
             buildOptimisticUserMessage({
@@ -199,7 +199,6 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
               images: attempt.images,
               attachments: attempt.attachments,
             }),
-            { placement: "tail", skipIfUserMessageExists: true },
           );
           markPendingCreateLifecycle({ draftId, lifecycle: "sent" });
         }
@@ -216,7 +215,7 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
       }
     },
     [
-      appendOptimisticUserMessageToAgentStream,
+      handoffCreatedAgentUserMessage,
       clearPendingCreateAttempt,
       createRequest,
       draftId,

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -4,8 +4,7 @@ import { subscribeWithSelector } from "zustand/middleware";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import type { AgentDirectoryEntry } from "@/types/agent-directory";
 import {
-  appendOptimisticUserMessageToStream,
-  type OptimisticUserMessagePlacement,
+  handoffCreatedAgentUserMessageToStream,
   type StreamItem,
   type UserMessageItem,
 } from "@/types/stream";
@@ -432,14 +431,10 @@ interface SessionStoreActions {
     agentId: string,
     state: { tail?: StreamItem[]; head?: StreamItem[] },
   ) => void;
-  appendOptimisticUserMessageToAgentStream: (
+  handoffCreatedAgentUserMessage: (
     serverId: string,
     agentId: string,
     message: UserMessageItem,
-    options: {
-      placement: OptimisticUserMessagePlacement;
-      skipIfUserMessageExists?: boolean;
-    },
   ) => boolean;
   clearAgentStreamHead: (serverId: string, agentId: string) => void;
   setAgentTimelineCursor: (
@@ -958,8 +953,8 @@ export const useSessionStore = create<SessionStore>()(
         });
       },
 
-      appendOptimisticUserMessageToAgentStream: (serverId, agentId, message, options) => {
-        let didAppend = false;
+      handoffCreatedAgentUserMessage: (serverId, agentId, message) => {
+        let didHandoff = false;
         set((prev) => {
           const session = prev.sessions[serverId];
           if (!session) {
@@ -968,12 +963,10 @@ export const useSessionStore = create<SessionStore>()(
 
           const currentTail = session.agentStreamTail.get(agentId) ?? [];
           const currentHead = session.agentStreamHead.get(agentId) ?? [];
-          const result = appendOptimisticUserMessageToStream({
+          const result = handoffCreatedAgentUserMessageToStream({
             tail: currentTail,
             head: currentHead,
             message,
-            placement: options.placement,
-            skipIfUserMessageExists: options.skipIfUserMessageExists,
           });
           if (!result.changedTail && !result.changedHead) {
             return prev;
@@ -985,7 +978,7 @@ export const useSessionStore = create<SessionStore>()(
           const nextHead = result.changedHead
             ? new Map(session.agentStreamHead).set(agentId, result.head)
             : session.agentStreamHead;
-          didAppend = true;
+          didHandoff = true;
 
           return {
             ...prev,
@@ -999,7 +992,7 @@ export const useSessionStore = create<SessionStore>()(
             },
           };
         });
-        return didAppend;
+        return didHandoff;
       },
 
       clearAgentStreamHead: (serverId, agentId) => {

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -352,6 +352,29 @@ describe("processTimelineResponse", () => {
       attachments: [attachment],
     });
     expect(userMessages[0]?.optimistic).toBeUndefined();
+
+    const repeated = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: result.tail,
+      payload: {
+        ...baseTimelineInput.payload,
+        reset: true,
+        startCursor: { seq: 1 },
+        endCursor: { seq: 1 },
+        entries: [
+          {
+            ...makeTimelineEntry(1, "Analyze this", "user_message"),
+            item: {
+              type: "user_message",
+              text: "server-rendered attachment text",
+              messageId: "canonical-create-user",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(repeated.tail.filter((item) => item.kind === "user_message")).toEqual(userMessages);
   });
 
   it("keeps an unmatched optimistic user message during tail replacement", () => {

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -306,16 +306,16 @@ function collectLocallyPresentedUserMessages(items: StreamItem[]): Array<{
 
 function mergeCanonicalUserWithLocalPresentation(
   canonical: UserMessageItem,
-  optimistic: UserMessageItem,
+  local: UserMessageItem,
 ): UserMessageItem {
   return {
     kind: "user_message",
     id: canonical.id,
-    text: optimistic.text,
-    timestamp: optimistic.timestamp,
-    ...(optimistic.images && optimistic.images.length > 0 ? { images: optimistic.images } : {}),
-    ...(optimistic.attachments && optimistic.attachments.length > 0
-      ? { attachments: optimistic.attachments }
+    text: local.text,
+    timestamp: local.timestamp,
+    ...(local.images && local.images.length > 0 ? { images: local.images } : {}),
+    ...(local.attachments && local.attachments.length > 0
+      ? { attachments: local.attachments }
       : {}),
   };
 }

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -262,7 +262,7 @@ function applyTimelineReplacePath(args: {
   const { timelineUnits, payload, bootstrapPolicy, currentTail, currentHead, toHydratedEvents } =
     args;
   const hydratedTail = hydrateStreamState(toHydratedEvents(timelineUnits), { source: "canonical" });
-  const reconciledTail = reconcileOptimisticUsersAfterReplace({
+  const reconciledTail = reconcileLocalUserPresentationAfterReplace({
     canonicalTail: hydratedTail,
     previousTail: currentTail,
     previousHead: currentHead,
@@ -286,25 +286,25 @@ function applyTimelineReplacePath(args: {
   return { tail, head, cursor, cursorChanged: true, sideEffects };
 }
 
-function collectOptimisticUserMessages(items: StreamItem[]): Array<{
+function collectLocallyPresentedUserMessages(items: StreamItem[]): Array<{
   ordinal: number;
   item: UserMessageItem;
 }> {
-  const optimistic: Array<{ ordinal: number; item: UserMessageItem }> = [];
+  const localUsers: Array<{ ordinal: number; item: UserMessageItem }> = [];
   let ordinal = 0;
   for (const item of items) {
     if (item.kind !== "user_message") {
       continue;
     }
-    if (item.optimistic) {
-      optimistic.push({ ordinal, item });
+    if (item.optimistic || item.images?.length || item.attachments?.length) {
+      localUsers.push({ ordinal, item });
     }
     ordinal += 1;
   }
-  return optimistic;
+  return localUsers;
 }
 
-function mergeCanonicalUserWithOptimistic(
+function mergeCanonicalUserWithLocalPresentation(
   canonical: UserMessageItem,
   optimistic: UserMessageItem,
 ): UserMessageItem {
@@ -320,16 +320,16 @@ function mergeCanonicalUserWithOptimistic(
   };
 }
 
-function reconcileOptimisticUsersAfterReplace(params: {
+function reconcileLocalUserPresentationAfterReplace(params: {
   canonicalTail: StreamItem[];
   previousTail: StreamItem[];
   previousHead: StreamItem[];
 }): StreamItem[] {
-  const optimisticUsers = collectOptimisticUserMessages([
+  const localUsers = collectLocallyPresentedUserMessages([
     ...params.previousTail,
     ...params.previousHead,
   ]);
-  if (optimisticUsers.length === 0) {
+  if (localUsers.length === 0) {
     return params.canonicalTail;
   }
 
@@ -345,22 +345,32 @@ function reconcileOptimisticUsersAfterReplace(params: {
   let searchFromOrdinal = 0;
   const unmatched: UserMessageItem[] = [];
 
-  for (const optimistic of optimisticUsers) {
-    const canonicalOrdinal = canonicalUserIndexes.findIndex(
-      (_index, ordinal) => ordinal >= Math.max(optimistic.ordinal, searchFromOrdinal),
-    );
+  for (const local of localUsers) {
+    const canonicalOrdinal = canonicalUserIndexes.findIndex((index, ordinal) => {
+      if (ordinal < searchFromOrdinal) {
+        return false;
+      }
+      if (local.item.optimistic) {
+        return ordinal >= local.ordinal;
+      }
+      return params.canonicalTail[index]?.id === local.item.id;
+    });
     if (canonicalOrdinal < 0) {
-      unmatched.push(optimistic.item);
+      if (local.item.optimistic) {
+        unmatched.push(local.item);
+      }
       continue;
     }
 
     const canonicalIndex = canonicalUserIndexes[canonicalOrdinal];
     const canonicalItem = canonicalIndex !== undefined ? nextTail[canonicalIndex] : undefined;
     if (!canonicalItem || canonicalItem.kind !== "user_message") {
-      unmatched.push(optimistic.item);
+      if (local.item.optimistic) {
+        unmatched.push(local.item);
+      }
       continue;
     }
-    nextTail[canonicalIndex] = mergeCanonicalUserWithOptimistic(canonicalItem, optimistic.item);
+    nextTail[canonicalIndex] = mergeCanonicalUserWithLocalPresentation(canonicalItem, local.item);
     searchFromOrdinal = canonicalOrdinal + 1;
     changed = true;
   }

--- a/packages/app/src/types/stream.test.ts
+++ b/packages/app/src/types/stream.test.ts
@@ -1336,14 +1336,35 @@ describe("turn lifecycle events", () => {
 
     assert.deepStrictEqual(handedOff.tail, [
       {
-        ...optimistic,
+        kind: "user_message",
         id: "provider-user",
+        text: optimistic.text,
+        timestamp: optimistic.timestamp,
+        images: optimistic.images,
+        attachments: optimistic.attachments,
       },
     ]);
     assert.deepStrictEqual(handedOff.head, []);
-    assert.strictEqual(repeated.changedTail, false);
-    assert.strictEqual(repeated.changedHead, false);
     assert.deepStrictEqual(repeated.tail, handedOff.tail);
+    assert.deepStrictEqual(repeated.head, handedOff.head);
+
+    const afterNextUser = reduceStreamUpdate(
+      handedOff.tail,
+      {
+        type: "timeline",
+        provider: "claude",
+        item: {
+          type: "user_message",
+          text: "Next prompt",
+          messageId: "provider-next-user",
+        },
+      },
+      new Date("2025-01-01T15:04:00Z"),
+    );
+    assert.deepStrictEqual(
+      afterNextUser.filter((item) => item.kind === "user_message").map((item) => item.id),
+      ["provider-user", "provider-next-user"],
+    );
   });
 
   it("reconciles an optimistic user message that was pending in the streaming head", () => {

--- a/packages/app/src/types/stream.test.ts
+++ b/packages/app/src/types/stream.test.ts
@@ -7,6 +7,7 @@ import {
   appendOptimisticUserMessageToStream,
   buildOptimisticUserMessage,
   clearOptimisticUserMessages,
+  handoffCreatedAgentUserMessageToStream,
   hydrateStreamState,
   mergeToolCallDetail,
   reduceStreamUpdate,
@@ -1284,27 +1285,65 @@ describe("turn lifecycle events", () => {
       message: optimistic,
       placement: "active-head",
     });
-    const skipped = appendOptimisticUserMessageToStream({
-      tail: [
-        {
-          kind: "user_message",
-          id: "canonical-user",
-          text: "already canonical",
-          timestamp: new Date("2025-01-01T15:03:21Z"),
-        },
-      ],
-      head: [],
-      message: optimistic,
-      placement: "tail",
-      skipIfUserMessageExists: true,
-    });
-
     assert.deepStrictEqual(first.tail, []);
     assert.deepStrictEqual(first.head, [headItem, optimistic]);
     assert.strictEqual(second.changedHead, false);
     assert.strictEqual(second.head, first.head);
-    assert.strictEqual(skipped.changedTail, false);
-    assert.strictEqual(skipped.tail.length, 1);
+  });
+
+  it("hands rich optimistic content to an authoritative create message without duplicating it", () => {
+    const timestamp = new Date("2025-01-01T15:03:20Z");
+    const optimistic = buildOptimisticUserMessage({
+      id: "client-user",
+      text: "",
+      timestamp,
+      images: [
+        {
+          id: "image-1",
+          mimeType: "image/png",
+          storageType: "web-indexeddb",
+          storageKey: "image-1",
+          createdAt: timestamp.getTime(),
+        },
+      ],
+      attachments: [
+        {
+          type: "text",
+          mimeType: "text/plain",
+          text: "Previous conversation",
+          title: "Chat history",
+          contextKind: "chat_history",
+        },
+      ],
+    });
+    const canonical: StreamItem = {
+      kind: "user_message",
+      id: "provider-user",
+      text: "server-rendered attachment text",
+      timestamp: new Date("2025-01-01T15:03:21Z"),
+    };
+
+    const handedOff = handoffCreatedAgentUserMessageToStream({
+      tail: [canonical],
+      head: [],
+      message: optimistic,
+    });
+    const repeated = handoffCreatedAgentUserMessageToStream({
+      tail: handedOff.tail,
+      head: handedOff.head,
+      message: optimistic,
+    });
+
+    assert.deepStrictEqual(handedOff.tail, [
+      {
+        ...optimistic,
+        id: "provider-user",
+      },
+    ]);
+    assert.deepStrictEqual(handedOff.head, []);
+    assert.strictEqual(repeated.changedTail, false);
+    assert.strictEqual(repeated.changedHead, false);
+    assert.deepStrictEqual(repeated.tail, handedOff.tail);
   });
 
   it("reconciles an optimistic user message that was pending in the streaming head", () => {

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -272,23 +272,14 @@ export function buildOptimisticUserMessage(input: OptimisticUserMessageInput): U
   };
 }
 
-function hasUserMessage(state: StreamItem[]): boolean {
-  return state.some((item) => item.kind === "user_message");
-}
-
 export function appendOptimisticUserMessageToStream(params: {
   tail: StreamItem[];
   head: StreamItem[];
   message: UserMessageItem;
   placement: OptimisticUserMessagePlacement;
-  skipIfUserMessageExists?: boolean;
 }): ApplyStreamEventResult {
   const { tail, head, message, placement } = params;
-  if (
-    tail.some((item) => item.id === message.id) ||
-    head.some((item) => item.id === message.id) ||
-    (params.skipIfUserMessageExists && (hasUserMessage(tail) || hasUserMessage(head)))
-  ) {
+  if (tail.some((item) => item.id === message.id) || head.some((item) => item.id === message.id)) {
     return { tail, head, changedTail: false, changedHead: false };
   }
 
@@ -307,6 +298,43 @@ export function appendOptimisticUserMessageToStream(params: {
     changedTail: true,
     changedHead: false,
   };
+}
+
+export function handoffCreatedAgentUserMessageToStream(params: {
+  tail: StreamItem[];
+  head: StreamItem[];
+  message: UserMessageItem;
+}): ApplyStreamEventResult {
+  const { tail, head, message } = params;
+  const items = [...tail, ...head];
+  const userIndex = items.findIndex((item) => item.kind === "user_message");
+  if (userIndex < 0) {
+    return appendOptimisticUserMessageToStream({
+      tail,
+      head,
+      message,
+      placement: "tail",
+    });
+  }
+
+  const userMessage = items[userIndex];
+  if (!userMessage || userMessage.kind !== "user_message" || userMessage.optimistic) {
+    return { tail, head, changedTail: false, changedHead: false };
+  }
+
+  const handedOffMessage: UserMessageItem = {
+    ...message,
+    id: userMessage.id,
+  };
+  if (userIndex < tail.length) {
+    const nextTail = [...tail];
+    nextTail[userIndex] = handedOffMessage;
+    return { tail: nextTail, head, changedTail: true, changedHead: false };
+  }
+
+  const nextHead = [...head];
+  nextHead[userIndex - tail.length] = handedOffMessage;
+  return { tail, head: nextHead, changedTail: false, changedHead: true };
 }
 
 function appendUserMessage(

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -322,10 +322,12 @@ export function handoffCreatedAgentUserMessageToStream(params: {
     return { tail, head, changedTail: false, changedHead: false };
   }
 
-  const handedOffMessage: UserMessageItem = {
-    ...message,
+  const handedOffMessage = buildUserMessageItem({
     id: userMessage.id,
-  };
+    text: message.text,
+    timestamp: message.timestamp,
+    optimistic: message,
+  });
   if (userIndex < tail.length) {
     const nextTail = [...tail];
     nextTail[userIndex] = handedOffMessage;


### PR DESCRIPTION
### Linked issue

Refs #1479

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Keeps the rich user message visible after creating an agent from either a workspace draft tab or the New Workspace screen. Forked chat context, images, and other attachments no longer flash briefly and get replaced by the raw server prompt.

The client now hands the local rich presentation to the matching authoritative user message, adopts its server ID, and preserves that presentation through later timeline hydration.

### How did you verify it

- Reproduced both creation flows with Playwright before the fix.
- Ran `npm --workspace packages/app run test:e2e -- --grep \"keeps the fork attachment after\"` — 2 passed.
- Ran `npx vitest run packages/app/src/types/stream.test.ts packages/app/src/timeline/session-stream-reducers.test.ts --bail=1` — 104 passed.
- Ran `npm run typecheck` — passed.
- Ran `npm run lint` — passed with 0 warnings and 0 errors.
- Ran `npm run format` — completed successfully.

### Risk surface

This changes user-message reconciliation ordering in the shared app timeline. The focused reducer tests cover duplicate avoidance, optimistic-first and authoritative-first arrival, and repeated hydration. Playwright covers browser/Electron-style rendering; native uses the same store and reducer path but was not separately smoke-tested.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense