### PR TITLE
Show every Codex terminal command in agent timelines

### DIFF
--- a/packages/server/src/server/agent/agent-timeline-content.test.ts
+++ b/packages/server/src/server/agent/agent-timeline-content.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+
+import { limitAgentTimelineItemContent } from "./agent-timeline-content.js";
+
+describe("agent timeline content", () => {
+  test("limits terminal input to the tool-call content budget", () => {
+    const oversizedInput = "x".repeat(64 * 1024 + 1);
+
+    const item = limitAgentTimelineItemContent({
+      type: "tool_call",
+      callId: "terminal-session-4242",
+      name: "terminal",
+      status: "completed",
+      error: null,
+      detail: {
+        type: "plain_text",
+        text: oversizedInput,
+        icon: "square_terminal",
+      },
+    });
+
+    expect(item).toEqual({
+      type: "tool_call",
+      callId: "terminal-session-4242",
+      name: "terminal",
+      status: "completed",
+      error: null,
+      detail: {
+        type: "plain_text",
+        text: "x".repeat(64 * 1024),
+        icon: "square_terminal",
+      },
+    });
+  });
+});

--- a/packages/server/src/server/agent/agent-timeline-content.ts
+++ b/packages/server/src/server/agent/agent-timeline-content.ts
@@ -24,8 +24,27 @@ function limitFailedShellError(item: AgentTimelineItem): AgentTimelineItem {
   };
 }
 
+function limitPlainText(item: AgentTimelineItem): AgentTimelineItem {
+  if (
+    item.type !== "tool_call" ||
+    item.detail.type !== "plain_text" ||
+    typeof item.detail.text !== "string" ||
+    item.detail.text.length <= TOOL_CALL_CONTENT_MAX_LENGTH
+  ) {
+    return item;
+  }
+  return {
+    ...item,
+    detail: {
+      ...item.detail,
+      text: item.detail.text.slice(0, TOOL_CALL_CONTENT_MAX_LENGTH),
+    },
+  };
+}
+
 export function limitAgentTimelineItemContent(item: AgentTimelineItem): AgentTimelineItem {
   item = limitFailedShellError(item);
+  item = limitPlainText(item);
   if (
     item.type !== "tool_call" ||
     item.detail.type !== "shell" ||

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -32,6 +32,7 @@ import {
   type FakeCodexAppServer,
   waitForNextPermission,
   waitForNextTimelineItem,
+  waitForTimelineToolCall,
 } from "./codex/test-utils/fake-app-server.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { asInternals as castInternals, createStub } from "../../test-utils/class-mocks.js";
@@ -599,6 +600,49 @@ describe("Codex app-server provider", () => {
     }
   });
 
+  test("shows a silent shell command from legacy live notifications", async () => {
+    const appServer = createFakeCodexAppServer();
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+
+    try {
+      await session.connect();
+      const nextTimelineItem = waitForNextTimelineItem(session);
+
+      appServer.completesSilentLegacyCommand({
+        threadId: "thread-1",
+        callId: "legacy-silent-merge",
+        command: "gh pr merge 2030 --squash",
+        cwd: "/workspace/project",
+      });
+
+      await expect(nextTimelineItem).resolves.toEqual({
+        type: "timeline",
+        provider: "codex",
+        item: {
+          type: "tool_call",
+          callId: "legacy-silent-merge",
+          name: "shell",
+          status: "completed",
+          error: null,
+          detail: {
+            type: "shell",
+            command: "gh pr merge 2030 --squash",
+            cwd: "/workspace/project",
+            exitCode: 0,
+          },
+        },
+      });
+      appServer.assertNoErrors();
+    } finally {
+      await session.close();
+    }
+  });
+
   test("shows the exact bytes Codex writes into an existing terminal", async () => {
     const appServer = createFakeCodexAppServer();
     const session = new CodexAppServerAgentSession(
@@ -631,6 +675,35 @@ describe("Codex app-server provider", () => {
           error: null,
           detail: {
             type: "plain_text",
+            text: "gh pr merge 2030 --squash\n",
+            icon: "square_terminal",
+          },
+          metadata: {
+            processId: "4242",
+          },
+        },
+      });
+
+      const relabeledTerminal = waitForTimelineToolCall(session, "terminal-session-4242");
+      appServer.runsLegacyCommand({
+        threadId: "thread-1",
+        callId: "interactive-shell",
+        command: "sleep 30",
+        output: "Process running with session id 4242",
+      });
+
+      await expect(relabeledTerminal).resolves.toEqual({
+        type: "timeline",
+        provider: "codex",
+        item: {
+          type: "tool_call",
+          callId: "terminal-session-4242",
+          name: "terminal",
+          status: "completed",
+          error: null,
+          detail: {
+            type: "plain_text",
+            label: "sleep 30",
             text: "gh pr merge 2030 --squash\n",
             icon: "square_terminal",
           },

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -669,7 +669,7 @@ describe("Codex app-server provider", () => {
         provider: "codex",
         item: {
           type: "tool_call",
-          callId: "terminal-session-4242",
+          callId: "terminal-session-4242-1",
           name: "terminal",
           status: "completed",
           error: null,
@@ -684,7 +684,7 @@ describe("Codex app-server provider", () => {
         },
       });
 
-      const relabeledTerminal = waitForTimelineToolCall(session, "terminal-session-4242");
+      const relabeledTerminal = waitForTimelineToolCall(session, "terminal-session-4242-1");
       appServer.runsLegacyCommand({
         threadId: "thread-1",
         callId: "interactive-shell",
@@ -697,7 +697,7 @@ describe("Codex app-server provider", () => {
         provider: "codex",
         item: {
           type: "tool_call",
-          callId: "terminal-session-4242",
+          callId: "terminal-session-4242-1",
           name: "terminal",
           status: "completed",
           error: null,
@@ -711,6 +711,53 @@ describe("Codex app-server provider", () => {
             processId: "4242",
           },
         },
+      });
+      appServer.assertNoErrors();
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("keeps repeated writes to one terminal as separate timeline rows", async () => {
+    const appServer = createFakeCodexAppServer();
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+
+    try {
+      await session.connect();
+
+      const firstTimelineItem = waitForNextTimelineItem(session);
+      appServer.typesIntoTerminal({
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "interactive-shell",
+        processId: "4242",
+        text: "git status\n",
+      });
+
+      const secondTimelineItem = waitForNextTimelineItem(session);
+      appServer.typesIntoTerminal({
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "interactive-shell",
+        processId: "4242",
+        text: "git push\n",
+      });
+
+      const [first, second] = await Promise.all([firstTimelineItem, secondTimelineItem]);
+      expect(first.item).toMatchObject({
+        type: "tool_call",
+        callId: "terminal-session-4242-1",
+        detail: { type: "plain_text", text: "git status\n" },
+      });
+      expect(second.item).toMatchObject({
+        type: "tool_call",
+        callId: "terminal-session-4242-2",
+        detail: { type: "plain_text", text: "git push\n" },
       });
       appServer.assertNoErrors();
     } finally {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -31,6 +31,7 @@ import {
   createFakeCodexAppServer,
   type FakeCodexAppServer,
   waitForNextPermission,
+  waitForNextTimelineItem,
 } from "./codex/test-utils/fake-app-server.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { asInternals as castInternals, createStub } from "../../test-utils/class-mocks.js";
@@ -552,6 +553,96 @@ describe("Codex app-server provider", () => {
     });
     appServer.assertNoErrors();
     await session.close();
+  });
+
+  test("shows a successful shell command that produces no output", async () => {
+    const appServer = createFakeCodexAppServer();
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+
+    try {
+      await session.connect();
+      const nextTimelineItem = waitForNextTimelineItem(session);
+
+      appServer.completesSilentCommand({
+        threadId: "thread-1",
+        callId: "silent-merge",
+        command: "gh pr merge 2030 --squash",
+        cwd: "/workspace/project",
+      });
+      appServer.says({ threadId: "thread-1", text: "Merged." });
+
+      await expect(nextTimelineItem).resolves.toEqual({
+        type: "timeline",
+        provider: "codex",
+        item: {
+          type: "tool_call",
+          callId: "silent-merge",
+          name: "shell",
+          status: "completed",
+          error: null,
+          detail: {
+            type: "shell",
+            command: "gh pr merge 2030 --squash",
+            cwd: "/workspace/project",
+            exitCode: 0,
+          },
+        },
+      });
+      appServer.assertNoErrors();
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("shows the exact bytes Codex writes into an existing terminal", async () => {
+    const appServer = createFakeCodexAppServer();
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+
+    try {
+      await session.connect();
+      const nextTimelineItem = waitForNextTimelineItem(session);
+
+      appServer.typesIntoTerminal({
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "interactive-shell",
+        processId: "4242",
+        text: "gh pr merge 2030 --squash\n",
+      });
+
+      await expect(nextTimelineItem).resolves.toEqual({
+        type: "timeline",
+        provider: "codex",
+        item: {
+          type: "tool_call",
+          callId: "terminal-session-4242",
+          name: "terminal",
+          status: "completed",
+          error: null,
+          detail: {
+            type: "plain_text",
+            text: "gh pr merge 2030 --squash\n",
+            icon: "square_terminal",
+          },
+          metadata: {
+            processId: "4242",
+          },
+        },
+      });
+      appServer.assertNoErrors();
+    } finally {
+      await session.close();
+    }
   });
 
   test("surfaces an MCP elicitation and returns Codex's required approval action", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -2113,8 +2113,8 @@ const CodexEventExecCommandEndNotificationSchema = z
         cwd: z.string().optional(),
         stdout: z.string().optional(),
         stderr: z.string().optional(),
-        aggregated_output: z.string().optional(),
-        aggregatedOutput: z.string().optional(),
+        aggregated_output: z.string().nullable().optional(),
+        aggregatedOutput: z.string().nullable().optional(),
         formatted_output: z.string().optional(),
         exit_code: z.number().nullable().optional(),
         exitCode: z.number().nullable().optional(),
@@ -3104,7 +3104,7 @@ export class CodexAppServerAgentSession implements AgentSession {
   private pendingFileChangeOutputDeltas = new Map<string, string[]>();
   private pendingAssistantMessageBoundary = false;
   private terminalCommandByProcessId = new Map<string, string>();
-  private pendingUnlabeledTerminalInteractions = new Set<string>();
+  private pendingUnlabeledTerminalInteractions = new Map<string, string | null>();
   private emittedTerminalInteractionKeys = new Set<string>();
   private emittedExecCommandStartedCallIds = new Set<string>();
   private emittedExecCommandCompletedCallIds = new Set<string>();
@@ -5450,7 +5450,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       (parsed.processId ? this.terminalCommandByProcessId.get(parsed.processId) : undefined) ??
       null;
     if (!command && parsed.processId) {
-      this.pendingUnlabeledTerminalInteractions.add(parsed.processId);
+      this.pendingUnlabeledTerminalInteractions.set(parsed.processId, parsed.stdin);
     }
     const timelineItem = mapCodexTerminalInteractionToToolCall({
       processId: parsed.processId,
@@ -5865,6 +5865,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     if (!this.pendingUnlabeledTerminalInteractions.has(processId)) {
       return;
     }
+    const pendingStdin = this.pendingUnlabeledTerminalInteractions.get(processId) ?? null;
     this.pendingUnlabeledTerminalInteractions.delete(processId);
     this.emitEvent({
       type: "timeline",
@@ -5872,6 +5873,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       item: mapCodexTerminalInteractionToToolCall({
         processId,
         command: displayCommand,
+        stdin: pendingStdin,
       }),
     });
   }

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -1517,6 +1517,7 @@ function mapCodexTerminalInteractionToToolCall(params: {
   processId?: string | null;
   fallbackCallId?: string | null;
   command?: string | null;
+  stdin?: string | null;
 }): ToolCallTimelineItem {
   const processId = nonEmptyString(params.processId ?? undefined);
   const callId = processId
@@ -1532,6 +1533,7 @@ function mapCodexTerminalInteractionToToolCall(params: {
     detail: {
       type: "plain_text",
       ...(label ? { label } : {}),
+      ...(params.stdin !== null && params.stdin !== undefined ? { text: params.stdin } : {}),
       icon: "square_terminal",
     },
     ...(processId ? { metadata: { processId } } : {}),
@@ -5454,6 +5456,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       processId: parsed.processId,
       fallbackCallId: parsed.callId,
       command,
+      stdin: parsed.stdin,
     });
     this.emitEvent({ type: "timeline", provider: CODEX_PROVIDER, item: timelineItem });
   }

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -1514,19 +1514,16 @@ export function mapCodexPatchNotificationToToolCall(params: {
 }
 
 function mapCodexTerminalInteractionToToolCall(params: {
+  callId: string;
   processId?: string | null;
-  fallbackCallId?: string | null;
   command?: string | null;
   stdin?: string | null;
 }): ToolCallTimelineItem {
   const processId = nonEmptyString(params.processId ?? undefined);
-  const callId = processId
-    ? `terminal-session-${processId}`
-    : (nonEmptyString(params.fallbackCallId ?? undefined) ?? "terminal-interaction");
   const label = nonEmptyString(params.command ?? undefined);
   return {
     type: "tool_call",
-    callId,
+    callId: params.callId,
     name: "terminal",
     status: "completed",
     error: null,
@@ -3104,7 +3101,11 @@ export class CodexAppServerAgentSession implements AgentSession {
   private pendingFileChangeOutputDeltas = new Map<string, string[]>();
   private pendingAssistantMessageBoundary = false;
   private terminalCommandByProcessId = new Map<string, string>();
-  private pendingUnlabeledTerminalInteractions = new Map<string, string | null>();
+  private pendingUnlabeledTerminalInteractions = new Map<
+    string,
+    Array<{ callId: string; stdin: string | null }>
+  >();
+  private nextTerminalInteractionOrdinal = 0;
   private emittedTerminalInteractionKeys = new Set<string>();
   private emittedExecCommandStartedCallIds = new Set<string>();
   private emittedExecCommandCompletedCallIds = new Set<string>();
@@ -5449,12 +5450,16 @@ export class CodexAppServerAgentSession implements AgentSession {
     const command =
       (parsed.processId ? this.terminalCommandByProcessId.get(parsed.processId) : undefined) ??
       null;
+    const callId = this.createTerminalInteractionCallId(parsed.processId, parsed.callId);
     if (!command && parsed.processId) {
-      this.pendingUnlabeledTerminalInteractions.set(parsed.processId, parsed.stdin);
+      const pendingInteractions =
+        this.pendingUnlabeledTerminalInteractions.get(parsed.processId) ?? [];
+      pendingInteractions.push({ callId, stdin: parsed.stdin });
+      this.pendingUnlabeledTerminalInteractions.set(parsed.processId, pendingInteractions);
     }
     const timelineItem = mapCodexTerminalInteractionToToolCall({
+      callId,
       processId: parsed.processId,
-      fallbackCallId: parsed.callId,
       command,
       stdin: parsed.stdin,
     });
@@ -5865,17 +5870,31 @@ export class CodexAppServerAgentSession implements AgentSession {
     if (!this.pendingUnlabeledTerminalInteractions.has(processId)) {
       return;
     }
-    const pendingStdin = this.pendingUnlabeledTerminalInteractions.get(processId) ?? null;
+    const pendingInteractions = this.pendingUnlabeledTerminalInteractions.get(processId) ?? [];
     this.pendingUnlabeledTerminalInteractions.delete(processId);
-    this.emitEvent({
-      type: "timeline",
-      provider: CODEX_PROVIDER,
-      item: mapCodexTerminalInteractionToToolCall({
-        processId,
-        command: displayCommand,
-        stdin: pendingStdin,
-      }),
-    });
+    for (const pendingInteraction of pendingInteractions) {
+      this.emitEvent({
+        type: "timeline",
+        provider: CODEX_PROVIDER,
+        item: mapCodexTerminalInteractionToToolCall({
+          callId: pendingInteraction.callId,
+          processId,
+          command: displayCommand,
+          stdin: pendingInteraction.stdin,
+        }),
+      });
+    }
+  }
+
+  private createTerminalInteractionCallId(
+    processId: string | null,
+    fallbackCallId: string | null,
+  ): string {
+    const baseCallId = processId
+      ? `terminal-session-${processId}`
+      : (nonEmptyString(fallbackCallId ?? undefined) ?? "terminal-interaction");
+    this.nextTerminalInteractionOrdinal += 1;
+    return `${baseCallId}-${this.nextTerminalInteractionOrdinal}`;
   }
 
   private shouldEmitTerminalInteractionKey(key: string): boolean {

--- a/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
+++ b/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
@@ -493,40 +493,37 @@ function toJsonObject(value: unknown): JsonObject {
   return {};
 }
 
-export function waitForNextPermission(
+type StreamEventType = AgentStreamEvent["type"];
+type StreamEventOfType<TType extends StreamEventType> = Extract<AgentStreamEvent, { type: TType }>;
+
+function waitForNextEvent<TType extends StreamEventType>(
   session: AgentSession,
-): Promise<Extract<AgentStreamEvent, { type: "permission_requested" }>> {
+  type: TType,
+): Promise<StreamEventOfType<TType>> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
       unsubscribe();
-      reject(new Error("Timed out waiting for permission_requested"));
+      reject(new Error(`Timed out waiting for ${type}`));
     }, 1000);
     const unsubscribe = session.subscribe((event) => {
-      if (event.type !== "permission_requested") {
+      if (event.type !== type) {
         return;
       }
       clearTimeout(timeout);
       unsubscribe();
-      resolve(event);
+      resolve(event as StreamEventOfType<TType>);
     });
   });
 }
 
-type TimelineEvent = Extract<AgentStreamEvent, { type: "timeline" }>;
+type TimelineEvent = StreamEventOfType<"timeline">;
+
+export function waitForNextPermission(
+  session: AgentSession,
+): Promise<StreamEventOfType<"permission_requested">> {
+  return waitForNextEvent(session, "permission_requested");
+}
 
 export function waitForNextTimelineItem(session: AgentSession): Promise<TimelineEvent> {
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      unsubscribe();
-      reject(new Error("Timed out waiting for timeline item"));
-    }, 1000);
-    const unsubscribe = session.subscribe((event) => {
-      if (event.type !== "timeline") {
-        return;
-      }
-      clearTimeout(timeout);
-      unsubscribe();
-      resolve(event);
-    });
-  });
+  return waitForNextEvent(session, "timeline");
 }

--- a/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
+++ b/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
@@ -65,6 +65,7 @@ export interface FakeCodexAppServer {
   appliesLegacyPatch(params: FakeLegacyPatch): void;
   completesCommand(params: FakeLegacyCommand): void;
   completesSilentCommand(params: FakeSilentCommand): void;
+  completesSilentLegacyCommand(params: FakeSilentCommand): void;
   typesIntoTerminal(params: FakeTerminalInput): void;
   says(params: { threadId: string; itemId?: string; text: string; chunks?: string[] }): void;
   requestCommandApproval(params: {
@@ -392,6 +393,17 @@ export function createFakeCodexAppServer(
         exitCode: 0,
       });
     },
+    completesSilentLegacyCommand(params) {
+      writeLegacyEvent(params.threadId, "codex/event/exec_command_end", {
+        type: "exec_command_end",
+        call_id: params.callId,
+        command: params.command,
+        cwd: params.cwd,
+        aggregatedOutput: null,
+        exit_code: 0,
+        success: true,
+      });
+    },
     typesIntoTerminal(params) {
       writeNotification("item/commandExecution/terminalInteraction", {
         threadId: params.threadId,
@@ -499,6 +511,7 @@ type StreamEventOfType<TType extends StreamEventType> = Extract<AgentStreamEvent
 function waitForNextEvent<TType extends StreamEventType>(
   session: AgentSession,
   type: TType,
+  accepts?: (event: StreamEventOfType<TType>) => boolean,
 ): Promise<StreamEventOfType<TType>> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
@@ -509,9 +522,13 @@ function waitForNextEvent<TType extends StreamEventType>(
       if (event.type !== type) {
         return;
       }
+      const typedEvent = event as StreamEventOfType<TType>;
+      if (accepts && !accepts(typedEvent)) {
+        return;
+      }
       clearTimeout(timeout);
       unsubscribe();
-      resolve(event as StreamEventOfType<TType>);
+      resolve(typedEvent);
     });
   });
 }
@@ -526,4 +543,15 @@ export function waitForNextPermission(
 
 export function waitForNextTimelineItem(session: AgentSession): Promise<TimelineEvent> {
   return waitForNextEvent(session, "timeline");
+}
+
+export function waitForTimelineToolCall(
+  session: AgentSession,
+  callId: string,
+): Promise<TimelineEvent> {
+  return waitForNextEvent(
+    session,
+    "timeline",
+    (event) => event.item.type === "tool_call" && event.item.callId === callId,
+  );
 }

--- a/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
+++ b/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
@@ -19,6 +19,19 @@ interface FakeLegacyCommand {
   command: string;
   output: string;
 }
+interface FakeSilentCommand {
+  threadId: string;
+  callId: string;
+  command: string;
+  cwd: string;
+}
+interface FakeTerminalInput {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  processId: string;
+  text: string;
+}
 interface FakeLegacyPatch {
   threadId: string;
   callId: string;
@@ -51,6 +64,8 @@ export interface FakeCodexAppServer {
   runsLegacyCommand(params: FakeLegacyCommand): void;
   appliesLegacyPatch(params: FakeLegacyPatch): void;
   completesCommand(params: FakeLegacyCommand): void;
+  completesSilentCommand(params: FakeSilentCommand): void;
+  typesIntoTerminal(params: FakeTerminalInput): void;
   says(params: { threadId: string; itemId?: string; text: string; chunks?: string[] }): void;
   requestCommandApproval(params: {
     itemId: string;
@@ -366,6 +381,26 @@ export function createFakeCodexAppServer(
         exitCode: 0,
       });
     },
+    completesSilentCommand(params) {
+      completeItem(params.threadId, {
+        type: "commandExecution",
+        id: params.callId,
+        status: "completed",
+        command: params.command,
+        cwd: params.cwd,
+        aggregatedOutput: null,
+        exitCode: 0,
+      });
+    },
+    typesIntoTerminal(params) {
+      writeNotification("item/commandExecution/terminalInteraction", {
+        threadId: params.threadId,
+        turnId: params.turnId,
+        itemId: params.itemId,
+        processId: params.processId,
+        stdin: params.text,
+      });
+    },
     says(params) {
       if (params.itemId) {
         for (const chunk of params.chunks ?? [params.text]) {
@@ -468,6 +503,25 @@ export function waitForNextPermission(
     }, 1000);
     const unsubscribe = session.subscribe((event) => {
       if (event.type !== "permission_requested") {
+        return;
+      }
+      clearTimeout(timeout);
+      unsubscribe();
+      resolve(event);
+    });
+  });
+}
+
+type TimelineEvent = Extract<AgentStreamEvent, { type: "timeline" }>;
+
+export function waitForNextTimelineItem(session: AgentSession): Promise<TimelineEvent> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(new Error("Timed out waiting for timeline item"));
+    }, 1000);
+    const unsubscribe = session.subscribe((event) => {
+      if (event.type !== "timeline") {
         return;
       }
       clearTimeout(timeout);

--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
@@ -141,7 +141,7 @@ const CodexCommandExecutionItemSchema = z
     error: z.unknown().optional(),
     command: CodexCommandValueSchema.optional(),
     cwd: z.string().optional(),
-    aggregatedOutput: z.string().optional(),
+    aggregatedOutput: z.string().nullable().optional(),
     exitCode: z.number().nullable().optional(),
   })
   .passthrough();
@@ -694,7 +694,7 @@ function mapCommandExecutionItem(
   item: z.infer<typeof CodexCommandExecutionItemSchema>,
 ): CodexNormalizedToolCallEnvelope {
   const command = normalizeCommandExecutionCommand(item.command);
-  const parsedOutput = extractCodexShellOutput(item.aggregatedOutput);
+  const parsedOutput = extractCodexShellOutput(item.aggregatedOutput ?? undefined);
   const input = toNullableObject({
     ...(command !== undefined ? { command } : {}),
     ...(item.cwd !== undefined ? { cwd: item.cwd } : {}),


### PR DESCRIPTION
### Linked issue

No matching open issue.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Paseo now keeps successful Codex shell commands visible even when they produce no output. It also preserves the exact input Codex sends to an existing terminal, so side effects remain auditable instead of appearing only as a generic terminal badge.

Codex reports silent command output as null and sends terminal input on a separate interaction event. The provider now accepts both canonical and legacy live protocol shapes, retains terminal input when a later event adds the command label, gives every write to a reused terminal its own timeline identity, and applies the existing 64 KiB timeline content budget.

#### Risk surface

This changes only Codex timeline projection and the shared size limit for plain-text tool details; it does not change the wire protocol or other provider mappings. Terminal interaction history is still transient across daemon restarts, and subagent terminal interactions remain outside this PR.

### How did you verify it

- Added provider-boundary regressions for canonical and legacy successful silent shell commands, exact terminal stdin, repeated writes to one process, and late terminal relabeling.
- Added a timeline-content regression for the 64 KiB plain-text limit.
- Confirmed the original tests failed before the fix: the silent command was skipped in favor of the following assistant message, terminal items omitted stdin, and repeated writes reused one call ID.
- Confirmed all focused tests pass after the fix.
- Ran the full affected provider, mapper, and content files: 136 tests passed.
- Ran full workspace typecheck, targeted lint, and repository formatting successfully.

No additional manual platform verification is needed because this changes server-side timeline data and reuses the existing shell and plain-text renderers.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI component changed)
- [x] Tests added or updated where it made sense
