### PR TITLE
Keep CI moving through transient npm failures

### DIFF
--- a/.github/workflows/android-apk-release.yml
+++ b/.github/workflows/android-apk-release.yml
@@ -71,7 +71,7 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/android-apk-release.yml
+++ b/.github/workflows/android-apk-release.yml
@@ -71,9 +71,28 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        run: node scripts/npm-retry.mjs ci
+        uses: actions/github-script@v7
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            for (let attempt = 1; attempt <= 3; attempt += 1) {
+              const exitCode = await exec.exec("npm", ["ci"], { ignoreReturnCode: true });
+              if (exitCode === 0) {
+                return;
+              }
+
+              if (attempt === 3) {
+                core.setFailed(`npm failed with exit code ${exitCode} after ${attempt} attempts`);
+                return;
+              }
+
+              const delayMs = attempt * 20_000;
+              core.warning(
+                `npm failed with exit code ${exitCode}; retrying in ${delayMs / 1000}s (${attempt + 1}/3)`,
+              );
+              await new Promise((resolve) => setTimeout(resolve, delayMs));
+            }
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8

--- a/.github/workflows/android-apk-release.yml
+++ b/.github/workflows/android-apk-release.yml
@@ -71,28 +71,9 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        uses: actions/github-script@v7
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            for (let attempt = 1; attempt <= 3; attempt += 1) {
-              const exitCode = await exec.exec("npm", ["ci"], { ignoreReturnCode: true });
-              if (exitCode === 0) {
-                return;
-              }
-
-              if (attempt === 3) {
-                core.setFailed(`npm failed with exit code ${exitCode} after ${attempt} attempts`);
-                return;
-              }
-
-              const delayMs = attempt * 20_000;
-              core.warning(
-                `npm failed with exit code ${exitCode}; retrying in ${delayMs / 1000}s (${attempt + 1}/3)`,
-              );
-              await new Promise((resolve) => setTimeout(resolve, delayMs));
-            }
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
 
       - name: Check formatting
         run: npx oxfmt --check .
@@ -51,7 +51,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
 
       - name: Lint lockfile
         run: npx --yes lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https --validate-integrity
@@ -75,7 +75,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
       - name: Build server stack
         run: npm run build:server
 
@@ -111,9 +111,9 @@ jobs:
         run: git fetch --no-tags origin main:refs/remotes/origin/main
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
       - name: Install agent CLIs for provider tests
-        run: npm install -g @anthropic-ai/claude-code opencode-ai
+        run: node scripts/npm-retry.mjs install -g @anthropic-ai/claude-code opencode-ai
 
       - name: Build server dependencies
         run: npm run build:server-deps
@@ -139,35 +139,8 @@ jobs:
           node-version: "22"
           cache: "npm"
 
-      - name: Install dependencies with Electron retry
-        if: runner.os != 'Windows'
-        run: |
-          for attempt in 1 2 3; do
-            if npm ci; then
-              exit 0
-            else
-              exit_code=$?
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit $exit_code
-            fi
-            sleep $((attempt * 20))
-          done
-
-      - name: Install dependencies with Electron retry
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          for ($attempt = 1; $attempt -le 3; $attempt++) {
-            npm ci
-            if ($LASTEXITCODE -eq 0) {
-              exit 0
-            }
-            if ($attempt -eq 3) {
-              exit $LASTEXITCODE
-            }
-            Start-Sleep -Seconds (20 * $attempt)
-          }
+      - name: Install dependencies with retry
+        run: node scripts/npm-retry.mjs ci
       - name: Build server stack
         run: npm run build:server
 
@@ -187,18 +160,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies with retry
-        run: |
-          for attempt in 1 2 3; do
-            if npm ci; then
-              exit 0
-            else
-              exit_code=$?
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit $exit_code
-            fi
-            sleep $((attempt * 20))
-          done
+        run: node scripts/npm-retry.mjs ci
       - name: Install Playwright browsers
         timeout-minutes: 10
         run: npx playwright install chromium
@@ -222,7 +184,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
       - name: Build client dependencies
         run: npm run build:client
 
@@ -258,18 +220,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies with retry
-        run: |
-          for attempt in 1 2 3; do
-            if npm ci; then
-              exit 0
-            else
-              exit_code=$?
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit $exit_code
-            fi
-            sleep $((attempt * 20))
-          done
+        run: node scripts/npm-retry.mjs ci
       - name: Install Playwright browsers
         timeout-minutes: 10
         run: npx playwright install chromium
@@ -282,7 +233,7 @@ jobs:
 
       - name: Install agent CLIs for provider tests
         if: ${{ !matrix.desktop }}
-        run: npm install -g @anthropic-ai/claude-code @openai/codex@0.105.0 opencode-ai
+        run: node scripts/npm-retry.mjs install -g @anthropic-ai/claude-code @openai/codex@0.105.0 opencode-ai
 
       - name: Run Playwright E2E tests
         if: ${{ !matrix.desktop }}
@@ -317,7 +268,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
 
       - name: Build relay
         run: npm run build:relay
@@ -343,10 +294,10 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
 
       - name: Install agent CLIs for provider tests
-        run: npm install -g @anthropic-ai/claude-code @openai/codex@0.105.0 opencode-ai
+        run: node scripts/npm-retry.mjs install -g @anthropic-ai/claude-code @openai/codex@0.105.0 opencode-ai
 
       - name: Run CLI tests
         run: npm run test --workspace=@getpaseo/cli

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -24,7 +24,7 @@ jobs:
           scope: "@boudra"
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build app dependencies

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -18,7 +18,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci --workspace=@getpaseo/relay --include-workspace-root
+        run: node scripts/npm-retry.mjs ci --workspace=@getpaseo/relay --include-workspace-root
 
       - name: Typecheck
         run: npm run typecheck --workspace=@getpaseo/relay

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -29,7 +29,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci --workspace=@getpaseo/website --include-workspace-root
+        run: node scripts/npm-retry.mjs ci --workspace=@getpaseo/website --include-workspace-root
 
       - name: Typecheck
         run: npm run typecheck --workspace=@getpaseo/website

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -127,7 +127,7 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -227,7 +227,7 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -325,7 +325,7 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -425,7 +425,7 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -127,9 +127,28 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        run: node scripts/npm-retry.mjs ci
+        uses: actions/github-script@v7
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            for (let attempt = 1; attempt <= 3; attempt += 1) {
+              const exitCode = await exec.exec("npm", ["ci"], { ignoreReturnCode: true });
+              if (exitCode === 0) {
+                return;
+              }
+
+              if (attempt === 3) {
+                core.setFailed(`npm failed with exit code ${exitCode} after ${attempt} attempts`);
+                return;
+              }
+
+              const delayMs = attempt * 20_000;
+              core.warning(
+                `npm failed with exit code ${exitCode}; retrying in ${delayMs / 1000}s (${attempt + 1}/3)`,
+              );
+              await new Promise((resolve) => setTimeout(resolve, delayMs));
+            }
 
       - name: Set desktop package version from tag
         shell: bash
@@ -227,9 +246,28 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        run: node scripts/npm-retry.mjs ci
+        uses: actions/github-script@v7
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            for (let attempt = 1; attempt <= 3; attempt += 1) {
+              const exitCode = await exec.exec("npm", ["ci"], { ignoreReturnCode: true });
+              if (exitCode === 0) {
+                return;
+              }
+
+              if (attempt === 3) {
+                core.setFailed(`npm failed with exit code ${exitCode} after ${attempt} attempts`);
+                return;
+              }
+
+              const delayMs = attempt * 20_000;
+              core.warning(
+                `npm failed with exit code ${exitCode}; retrying in ${delayMs / 1000}s (${attempt + 1}/3)`,
+              );
+              await new Promise((resolve) => setTimeout(resolve, delayMs));
+            }
 
       - name: Set desktop package version from tag
         shell: bash
@@ -325,9 +363,28 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        run: node scripts/npm-retry.mjs ci
+        uses: actions/github-script@v7
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            for (let attempt = 1; attempt <= 3; attempt += 1) {
+              const exitCode = await exec.exec("npm", ["ci"], { ignoreReturnCode: true });
+              if (exitCode === 0) {
+                return;
+              }
+
+              if (attempt === 3) {
+                core.setFailed(`npm failed with exit code ${exitCode} after ${attempt} attempts`);
+                return;
+              }
+
+              const delayMs = attempt * 20_000;
+              core.warning(
+                `npm failed with exit code ${exitCode}; retrying in ${delayMs / 1000}s (${attempt + 1}/3)`,
+              );
+              await new Promise((resolve) => setTimeout(resolve, delayMs));
+            }
 
       - name: Set desktop package version from tag
         shell: bash
@@ -425,9 +482,28 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        run: node scripts/npm-retry.mjs ci
+        uses: actions/github-script@v7
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            for (let attempt = 1; attempt <= 3; attempt += 1) {
+              const exitCode = await exec.exec("npm", ["ci"], { ignoreReturnCode: true });
+              if (exitCode === 0) {
+                return;
+              }
+
+              if (attempt === 3) {
+                core.setFailed(`npm failed with exit code ${exitCode} after ${attempt} attempts`);
+                return;
+              }
+
+              const delayMs = attempt * 20_000;
+              core.warning(
+                `npm failed with exit code ${exitCode}; retrying in ${delayMs / 1000}s (${attempt + 1}/3)`,
+              );
+              await new Promise((resolve) => setTimeout(resolve, delayMs));
+            }
 
       - name: Download mac manifest artifacts
         if: env.IS_SMOKE_TAG != 'true' && needs.publish-macos.result == 'success'

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -127,28 +127,9 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        uses: actions/github-script@v7
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            for (let attempt = 1; attempt <= 3; attempt += 1) {
-              const exitCode = await exec.exec("npm", ["ci"], { ignoreReturnCode: true });
-              if (exitCode === 0) {
-                return;
-              }
-
-              if (attempt === 3) {
-                core.setFailed(`npm failed with exit code ${exitCode} after ${attempt} attempts`);
-                return;
-              }
-
-              const delayMs = attempt * 20_000;
-              core.warning(
-                `npm failed with exit code ${exitCode}; retrying in ${delayMs / 1000}s (${attempt + 1}/3)`,
-              );
-              await new Promise((resolve) => setTimeout(resolve, delayMs));
-            }
 
       - name: Set desktop package version from tag
         shell: bash
@@ -246,28 +227,9 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        uses: actions/github-script@v7
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            for (let attempt = 1; attempt <= 3; attempt += 1) {
-              const exitCode = await exec.exec("npm", ["ci"], { ignoreReturnCode: true });
-              if (exitCode === 0) {
-                return;
-              }
-
-              if (attempt === 3) {
-                core.setFailed(`npm failed with exit code ${exitCode} after ${attempt} attempts`);
-                return;
-              }
-
-              const delayMs = attempt * 20_000;
-              core.warning(
-                `npm failed with exit code ${exitCode}; retrying in ${delayMs / 1000}s (${attempt + 1}/3)`,
-              );
-              await new Promise((resolve) => setTimeout(resolve, delayMs));
-            }
 
       - name: Set desktop package version from tag
         shell: bash
@@ -363,28 +325,9 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        uses: actions/github-script@v7
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            for (let attempt = 1; attempt <= 3; attempt += 1) {
-              const exitCode = await exec.exec("npm", ["ci"], { ignoreReturnCode: true });
-              if (exitCode === 0) {
-                return;
-              }
-
-              if (attempt === 3) {
-                core.setFailed(`npm failed with exit code ${exitCode} after ${attempt} attempts`);
-                return;
-              }
-
-              const delayMs = attempt * 20_000;
-              core.warning(
-                `npm failed with exit code ${exitCode}; retrying in ${delayMs / 1000}s (${attempt + 1}/3)`,
-              );
-              await new Promise((resolve) => setTimeout(resolve, delayMs));
-            }
 
       - name: Set desktop package version from tag
         shell: bash
@@ -482,28 +425,9 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        uses: actions/github-script@v7
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            for (let attempt = 1; attempt <= 3; attempt += 1) {
-              const exitCode = await exec.exec("npm", ["ci"], { ignoreReturnCode: true });
-              if (exitCode === 0) {
-                return;
-              }
-
-              if (attempt === 3) {
-                core.setFailed(`npm failed with exit code ${exitCode} after ${attempt} attempts`);
-                return;
-              }
-
-              const delayMs = attempt * 20_000;
-              core.warning(
-                `npm failed with exit code ${exitCode}; retrying in ${delayMs / 1000}s (${attempt + 1}/3)`,
-              );
-              await new Promise((resolve) => setTimeout(resolve, delayMs));
-            }
 
       - name: Download mac manifest artifacts
         if: env.IS_SMOKE_TAG != 'true' && needs.publish-macos.result == 'success'

--- a/.github/workflows/desktop-rollout.yml
+++ b/.github/workflows/desktop-rollout.yml
@@ -47,7 +47,7 @@ jobs:
           scope: "@boudra"
 
       - name: Install JS dependencies
-        run: npm ci
+        run: node scripts/npm-retry.mjs ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/scripts/npm-retry.mjs
+++ b/scripts/npm-retry.mjs
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process";
+import { resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_BACKOFF_MS = 20_000;
+
+function runNpm(args) {
+  const command = process.platform === "win32" ? "npm.cmd" : "npm";
+  const result = spawnSync(command, args, {
+    shell: process.platform === "win32",
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    console.error(`Failed to start npm: ${result.error.message}`);
+    return 1;
+  }
+
+  return result.status ?? 1;
+}
+
+function wait(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+export async function runWithRetry(
+  args,
+  { attempts = DEFAULT_ATTEMPTS, backoffMs = DEFAULT_BACKOFF_MS, run = runNpm, sleep = wait } = {},
+) {
+  let exitCode = 1;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    exitCode = run(args);
+    if (exitCode === 0) {
+      return 0;
+    }
+
+    if (attempt < attempts) {
+      const delayMs = attempt * backoffMs;
+      console.warn(
+        `npm failed with exit code ${exitCode}; retrying in ${delayMs / 1000}s (${attempt + 1}/${attempts})`,
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  return exitCode;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolvePath(process.argv[1])) {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error("Usage: node scripts/npm-retry.mjs <npm arguments...>");
+    process.exitCode = 2;
+  } else {
+    process.exitCode = await runWithRetry(args);
+  }
+}

--- a/scripts/npm-retry.mjs
+++ b/scripts/npm-retry.mjs
@@ -31,7 +31,7 @@ export async function runWithRetry(
   let exitCode = 1;
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    exitCode = run(args);
+    exitCode = await run(args);
     if (exitCode === 0) {
       return 0;
     }


### PR DESCRIPTION
### Type of change

- [x] Bug fix
- [x] Refactor / code improvement

### What does this PR do

Retries npm dependency and global CLI installs up to three times with 20-second and 40-second backoffs. A transient registry or package-download failure now delays the affected job instead of requiring a manual workflow rerun.

A shared cross-platform wrapper replaces the duplicated Bash and PowerShell loops across CI, deploy, rollout, and release workflows. Every npm install site calls the same helper.

### How did you verify it

- Simulated two asynchronous failures followed by success and observed three attempts with 20s/40s backoff.
- Simulated exhausted retries and confirmed the final npm exit code is preserved.
- Ran the wrapper against the installed npm CLI.
- Confirmed every GitHub Actions `npm ci` and global `npm install` invocation uses a bounded retry.
- `actionlint` passes after excluding four pre-existing informational ShellCheck findings.
- `npm run typecheck` passes.
- `npm run lint` passes.
- `npm run format` ran successfully.

Earlier PR heads passed all applicable checks on Linux and Windows. Release and deployment workflows use the same retry policy but are not triggered by pull requests.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable)
- [x] Tests added or updated where it made sense
