### PR TITLE
Fix shortcut capture ignoring - = ; ' keys

### DIFF
--- a/packages/app/src/desktop/host.ts
+++ b/packages/app/src/desktop/host.ts
@@ -85,6 +85,7 @@ export interface DesktopWebUtilsBridge {
 
 export interface DesktopMenuBridge {
   showContextMenu?: (input?: { kind?: "terminal"; hasSelection?: boolean }) => Promise<void>;
+  setCapturingShortcut?: (capturing: boolean) => Promise<void>;
 }
 
 export interface DesktopWindowControlsOverlayUpdate {

--- a/packages/app/src/keyboard/shortcut-string.test.ts
+++ b/packages/app/src/keyboard/shortcut-string.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  keyComboToString,
+  keyboardEventToComboString,
+  parseShortcutString,
+} from "./shortcut-string";
+
+function keyboardEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    key: "",
+    code: "",
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    repeat: false,
+    ...overrides,
+  } as KeyboardEvent;
+}
+
+describe("keyboardEventToComboString", () => {
+  it("captures the minus key (regression: previously returned null)", () => {
+    expect(keyboardEventToComboString(keyboardEvent({ key: "-", code: "Minus" }))).toBe("-");
+  });
+
+  it("captures minus with modifiers", () => {
+    expect(
+      keyboardEventToComboString(keyboardEvent({ key: "-", code: "Minus", metaKey: true })),
+    ).toBe("Cmd+-");
+    expect(
+      keyboardEventToComboString(keyboardEvent({ key: "_", code: "Minus", shiftKey: true })),
+    ).toBe("Shift+-");
+  });
+
+  it("captures equal, semicolon, and quote", () => {
+    expect(keyboardEventToComboString(keyboardEvent({ key: "=", code: "Equal" }))).toBe("=");
+    expect(keyboardEventToComboString(keyboardEvent({ key: ";", code: "Semicolon" }))).toBe(";");
+    expect(keyboardEventToComboString(keyboardEvent({ key: "'", code: "Quote" }))).toBe("'");
+  });
+
+  it("still returns null for modifier-only presses", () => {
+    expect(keyboardEventToComboString(keyboardEvent({ code: "ShiftLeft" }))).toBeNull();
+  });
+});
+
+describe("parseShortcutString round-trips punctuation keys", () => {
+  const cases: ReadonlyArray<[string, string, string, string]> = [
+    ["-", "Minus", "-", "_"],
+    ["=", "Equal", "=", "+"],
+    [";", "Semicolon", ";", ":"],
+    ["'", "Quote", "'", '"'],
+  ];
+
+  for (const [humanKey, code, key, shiftedKey] of cases) {
+    it(`round-trips ${humanKey}`, () => {
+      const combo = parseShortcutString(humanKey);
+      expect(combo.code).toBe(code);
+      expect(combo.key).toBe(key);
+      expect(combo.shiftedKey).toBe(shiftedKey);
+      expect(keyComboToString(combo)).toBe(humanKey);
+    });
+  }
+
+  it("round-trips a modifier combo with minus", () => {
+    const combo = parseShortcutString("Cmd+-");
+    expect(combo.meta).toBe(true);
+    expect(combo.code).toBe("Minus");
+    expect(keyComboToString(combo)).toBe("Cmd+-");
+  });
+});

--- a/packages/app/src/keyboard/shortcut-string.ts
+++ b/packages/app/src/keyboard/shortcut-string.ts
@@ -42,9 +42,13 @@ KEY_MAP["9"].shiftedKey = "(";
 KEY_MAP["0"].shiftedKey = ")";
 
 KEY_MAP["Digit"] = { code: "Digit" };
+KEY_MAP["-"] = { code: "Minus", key: "-", shiftedKey: "_" };
+KEY_MAP["="] = { code: "Equal", key: "=", shiftedKey: "+" };
 KEY_MAP["\\"] = { code: "Backslash", key: "\\", shiftedKey: "|" };
 KEY_MAP["["] = { code: "BracketLeft", key: "[", shiftedKey: "{" };
 KEY_MAP["]"] = { code: "BracketRight", key: "]", shiftedKey: "}" };
+KEY_MAP[";"] = { code: "Semicolon", key: ";", shiftedKey: ":" };
+KEY_MAP["'"] = { code: "Quote", key: "'", shiftedKey: '"' };
 KEY_MAP[","] = { code: "Comma", key: ",", shiftedKey: "<" };
 KEY_MAP["."] = { code: "Period", key: ".", shiftedKey: ">" };
 KEY_MAP["`"] = { code: "Backquote", key: "`", shiftedKey: "~" };

--- a/packages/app/src/screens/settings/keyboard-shortcuts-section.tsx
+++ b/packages/app/src/screens/settings/keyboard-shortcuts-section.tsx
@@ -23,6 +23,7 @@ import { useKeyboardShortcutsStore } from "@/stores/keyboard-shortcuts-store";
 import { getShortcutOs } from "@/utils/shortcut-platform";
 import { getIsElectronRuntime } from "@/constants/layout";
 import { isNative } from "@/constants/platform";
+import { getDesktopHost } from "@/desktop/host";
 
 const EMPTY_CAPTURED_COMBOS: string[] = [];
 
@@ -169,6 +170,7 @@ export function KeyboardShortcutsSection() {
   const { overrides, hasOverrides, setOverride, removeOverride, resetAll } =
     useKeyboardShortcutOverrides();
   const setCapturingShortcut = useKeyboardShortcutsStore((s) => s.setCapturingShortcut);
+  const capturing = useKeyboardShortcutsStore((s) => s.capturingShortcut);
 
   const isFocused = useIsFocused();
   const isMac = getShortcutOs() === "mac";
@@ -241,6 +243,17 @@ export function KeyboardShortcutsSection() {
       setCapturingShortcut(false);
     };
   }, [setCapturingShortcut]);
+
+  // Suppress desktop zoom accelerators while capturing so combos like Cmd+- are
+  // recorded instead of zooming the window. No-op outside Electron.
+  useEffect(() => {
+    if (isNative) return;
+    const menu = getDesktopHost()?.menu;
+    void menu?.setCapturingShortcut?.(capturing);
+    return () => {
+      void menu?.setCapturingShortcut?.(false);
+    };
+  }, [capturing]);
 
   const handleResetAll = useCallback(() => void resetAll(), [resetAll]);
   const handleRemoveOverride = useCallback(

--- a/packages/app/src/screens/settings/keyboard-shortcuts-section.tsx
+++ b/packages/app/src/screens/settings/keyboard-shortcuts-section.tsx
@@ -247,9 +247,9 @@ export function KeyboardShortcutsSection() {
   // Suppress desktop zoom accelerators while capturing so combos like Cmd+- are
   // recorded instead of zooming the window. No-op outside Electron.
   useEffect(() => {
-    if (isNative) return;
+    if (isNative || !capturing) return;
     const menu = getDesktopHost()?.menu;
-    void menu?.setCapturingShortcut?.(capturing);
+    void menu?.setCapturingShortcut?.(true);
     return () => {
       void menu?.setCapturingShortcut?.(false);
     };

--- a/packages/desktop/src/features/menu.ts
+++ b/packages/desktop/src/features/menu.ts
@@ -208,4 +208,16 @@ export function setupApplicationMenu(options: ApplicationMenuOptions): void {
     capturingShortcut = capturing === true;
     rebuildApplicationMenu();
   });
+
+  // If the renderer reloads mid-capture (e.g. Cmd+R) the renderer-side effect
+  // never gets to send `false`, so reset the flag from the main process when a
+  // main window finishes loading. Workspace browser webviews are not
+  // BrowserWindows, so they don't trigger this.
+  app.on("browser-window-created", (_event, win) => {
+    win.webContents.on("did-finish-load", () => {
+      if (!capturingShortcut) return;
+      capturingShortcut = false;
+      rebuildApplicationMenu();
+    });
+  });
 }

--- a/packages/desktop/src/features/menu.ts
+++ b/packages/desktop/src/features/menu.ts
@@ -47,8 +47,10 @@ function reloadFocusedContentsOrWindow(win: BrowserWindow, options?: { ignoreCac
 
 function buildApplicationMenuTemplate(
   options: ApplicationMenuOptions,
+  capturing: boolean,
 ): Electron.MenuItemConstructorOptions[] {
   const isMac = process.platform === "darwin";
+  const zoomEnabled = !capturing;
 
   return [
     ...(isMac
@@ -99,6 +101,7 @@ function buildApplicationMenuTemplate(
         {
           label: "Zoom In",
           accelerator: "CmdOrCtrl+=",
+          enabled: zoomEnabled,
           click: withBrowserWindow((win) => {
             win.webContents.setZoomLevel(win.webContents.getZoomLevel() + 0.5);
           }),
@@ -106,6 +109,7 @@ function buildApplicationMenuTemplate(
         {
           label: "Zoom Out",
           accelerator: "CmdOrCtrl+-",
+          enabled: zoomEnabled,
           click: withBrowserWindow((win) => {
             win.webContents.setZoomLevel(win.webContents.getZoomLevel() - 0.5);
           }),
@@ -113,6 +117,7 @@ function buildApplicationMenuTemplate(
         {
           label: "Actual Size",
           accelerator: "CmdOrCtrl+0",
+          enabled: zoomEnabled,
           click: withBrowserWindow((win) => {
             win.webContents.setZoomLevel(0);
           }),
@@ -150,9 +155,20 @@ function buildApplicationMenuTemplate(
   ];
 }
 
-export function setupApplicationMenu(options: ApplicationMenuOptions): void {
-  const menu = Menu.buildFromTemplate(buildApplicationMenuTemplate(options));
+let applicationMenuOptions: ApplicationMenuOptions | null = null;
+let capturingShortcut = false;
+
+function rebuildApplicationMenu(): void {
+  if (!applicationMenuOptions) return;
+  const menu = Menu.buildFromTemplate(
+    buildApplicationMenuTemplate(applicationMenuOptions, capturingShortcut),
+  );
   Menu.setApplicationMenu(menu);
+}
+
+export function setupApplicationMenu(options: ApplicationMenuOptions): void {
+  applicationMenuOptions = options;
+  rebuildApplicationMenu();
 
   ipcMain.handle("paseo:menu:showContextMenu", (event, input?: ShowContextMenuInput) => {
     const win = BrowserWindow.fromWebContents(event.sender);
@@ -184,5 +200,12 @@ export function setupApplicationMenu(options: ApplicationMenuOptions): void {
     ]);
 
     contextMenu.popup({ window: win });
+  });
+
+  // Disable the zoom accelerators while capturing a shortcut so combos like
+  // Cmd+- / Cmd+= reach the renderer instead of zooming the window.
+  ipcMain.handle("paseo:menu:set-capturing-shortcut", (_event, capturing?: boolean) => {
+    capturingShortcut = capturing === true;
+    rebuildApplicationMenu();
   });
 }

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -72,6 +72,8 @@ contextBridge.exposeInMainWorld("paseoDesktop", {
   menu: {
     showContextMenu: (input?: Record<string, unknown>) =>
       ipcRenderer.invoke("paseo:menu:showContextMenu", input),
+    setCapturingShortcut: (capturing: boolean) =>
+      ipcRenderer.invoke("paseo:menu:set-capturing-shortcut", capturing),
   },
   browser: {
     registerWorkspaceBrowser: (input: { browserId: string; workspaceId: string }) =>


### PR DESCRIPTION
## Problem
Couldn't bind `-` (or combos with `-`) as a keyboard shortcut. The capture UI showed nothing when pressing `-`, and combos never completed. Two independent causes.

## Root causes

**1. Missing physical keys in `KEY_MAP` (all platforms)**
`keyboardEventToComboString` resolves `event.code` through `CODE_TO_KEY`, which is built from `KEY_MAP`. `KEY_MAP` enumerated `\\ [ ] , . \` /` but was missing `Minus` (`-`), `Equal` (`=`), `Semicolon` (`;`), and `Quote` (`'`). For those codes the lookup returned `undefined`, so `keyboardEventToComboString` returned `null` and the capture handler treated it as a modifier-only press - silently dropping it (bare key: nothing shown; combo: only the held modifier shown, never committed).

**2. Electron zoom accelerators swallow `Cmd+-` / `Cmd+=` / `Cmd+0` (desktop only)**
`packages/desktop/src/features/menu.ts` registers `View > Zoom In/Out/Actual Size` with those accelerators. Electron dispatches menu accelerators in the main process before the renderer's `keydown`, so capturing those combos zoomed the window instead of reaching the capture listener. The `capturingShortcut` flag lived only in the renderer store.

## Fix
- Add `Minus`/`Equal`/`Semicolon`/`Quote` to `KEY_MAP` with shifted variants, following the existing punctuation pattern.
- Add a `paseo:menu:set-capturing-shortcut` IPC. While capturing, the desktop app disables the three zoom menu items (disabled items don't fire accelerators) and re-enables them on capture end / unmount. No-op outside Electron.

## Testing
- New `shortcut-string.test.ts`: `keyboardEventToComboString` + `parseShortcutString`/`keyComboToString` round-trip for `- = ; '`, including `Cmd+-` and `Shift+-`.
- Existing `keyboard-shortcuts.test.ts` (71 tests) still green.
- Lint, format, and full-workspace typecheck green (lefthook pre-commit).
