### PR TITLE
Find .opencode files in workspace search

### DIFF
--- a/packages/server/src/server/daemon-client.e2e.test.ts
+++ b/packages/server/src/server/daemon-client.e2e.test.ts
@@ -892,6 +892,42 @@ test("returns typed relative suggestions within a requested directory", async ()
   }
 }, 30000);
 
+test("finds workspace files inside the OpenCode directory", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "paseo-opencode-suggestion-"));
+  const target = path.join(
+    cwd,
+    ".opencode",
+    "command",
+    "workflow",
+    "00-kickoff",
+    "00-user-stories.md",
+  );
+
+  try {
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, "");
+
+    const result = await ctx.client.getDirectorySuggestions({
+      cwd,
+      query: "00-user-stories.md",
+      includeFiles: true,
+      includeDirectories: false,
+      limit: 20,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.directories).toEqual([]);
+    expect(result.entries).toEqual([
+      {
+        path: ".opencode/command/workflow/00-kickoff/00-user-stories.md",
+        kind: "file",
+      },
+    ]);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}, 30000);
+
 test("receives server_info on websocket connect", async () => {
   const client = new DaemonClient({
     url: `ws://127.0.0.1:${ctx.daemon.port}/ws`,

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -174,7 +174,10 @@ import {
   type AgentUpdatesService,
 } from "./session/agent-updates/agent-updates-service.js";
 import { expandTilde } from "../utils/path.js";
-import { searchDirectoryEntries } from "../utils/directory-suggestions.js";
+import {
+  searchDirectoryEntries,
+  WORKSPACE_SEARCH_HIDDEN_DIRECTORIES,
+} from "../utils/directory-suggestions.js";
 import type { CheckoutDiffManager } from "./checkout-diff-manager.js";
 import type { Resolvable } from "./speech/provider-resolver.js";
 import type { SpeechReadinessSnapshot } from "./speech/speech-runtime.js";
@@ -224,16 +227,6 @@ import { CreateAgentLifecycleDispatch } from "./agent/create-agent-lifecycle-dis
 // the entire session message if they encounter an unknown provider.
 const LEGACY_PROVIDER_IDS = new Set(["claude", "codex", "opencode"]);
 const MIN_VERSION_ALL_PROVIDERS = "0.1.45";
-const WORKSPACE_SEARCH_HIDDEN_DIRECTORIES = [
-  ".agents",
-  ".claude",
-  ".codex",
-  ".github",
-  ".opencode",
-  ".paseo",
-  ".vscode",
-];
-
 function errorToFriendlyMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   if (typeof error === "string") return error;

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -229,6 +229,7 @@ const WORKSPACE_SEARCH_HIDDEN_DIRECTORIES = [
   ".claude",
   ".codex",
   ".github",
+  ".opencode",
   ".paseo",
   ".vscode",
 ];

--- a/packages/server/src/utils/directory-suggestions.test.ts
+++ b/packages/server/src/utils/directory-suggestions.test.ts
@@ -15,7 +15,15 @@ import { searchDirectoryEntries } from "./directory-suggestions.js";
 
 const isWindows = isPlatform("win32");
 const filesystemRootDirectoryName = isWindows ? "Windows" : "usr";
-const workspaceHiddenDirectories = [".agents", ".claude", ".codex", ".github", ".paseo", ".vscode"];
+const workspaceHiddenDirectories = [
+  ".agents",
+  ".claude",
+  ".codex",
+  ".github",
+  ".opencode",
+  ".paseo",
+  ".vscode",
+];
 
 async function searchAbsoluteDirectoryPaths(options: {
   homeDir: string;

--- a/packages/server/src/utils/directory-suggestions.test.ts
+++ b/packages/server/src/utils/directory-suggestions.test.ts
@@ -11,20 +11,13 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isPlatform } from "../test-utils/platform.js";
-import { searchDirectoryEntries } from "./directory-suggestions.js";
+import {
+  searchDirectoryEntries,
+  WORKSPACE_SEARCH_HIDDEN_DIRECTORIES,
+} from "./directory-suggestions.js";
 
 const isWindows = isPlatform("win32");
 const filesystemRootDirectoryName = isWindows ? "Windows" : "usr";
-const workspaceHiddenDirectories = [
-  ".agents",
-  ".claude",
-  ".codex",
-  ".github",
-  ".opencode",
-  ".paseo",
-  ".vscode",
-];
-
 async function searchAbsoluteDirectoryPaths(options: {
   homeDir: string;
   query: string;
@@ -68,7 +61,7 @@ async function searchRelativeDirectoryEntries(options: {
     matchMode: options.matchMode,
     pathQueryPolicy: "slashes",
     blankQueryBehavior: "children",
-    traversableHiddenDirectoryNames: workspaceHiddenDirectories,
+    traversableHiddenDirectoryNames: WORKSPACE_SEARCH_HIDDEN_DIRECTORIES,
     limit: options.limit,
     maxDepth: options.maxDepth,
     maxEntriesScanned: options.maxEntriesScanned,

--- a/packages/server/src/utils/directory-suggestions.ts
+++ b/packages/server/src/utils/directory-suggestions.ts
@@ -24,7 +24,7 @@ export interface SearchDirectoryEntriesOptions {
   pathQueryPolicy?: PathQueryPolicy;
   rootAliases?: string[];
   blankQueryBehavior?: BlankQueryBehavior;
-  traversableHiddenDirectoryNames?: string[];
+  traversableHiddenDirectoryNames?: readonly string[];
   limit?: number;
   maxDepth?: number;
   maxEntriesScanned?: number;
@@ -84,6 +84,15 @@ const NO_SEGMENT_INDEX = Number.MAX_SAFE_INTEGER;
 const NO_MATCH_OFFSET = Number.MAX_SAFE_INTEGER;
 const NO_FUZZY_SCORE = Number.MAX_SAFE_INTEGER;
 const NO_MATCH_TIER = 5;
+export const WORKSPACE_SEARCH_HIDDEN_DIRECTORIES = [
+  ".agents",
+  ".claude",
+  ".codex",
+  ".github",
+  ".opencode",
+  ".paseo",
+  ".vscode",
+] as const;
 const IGNORED_DIRECTORY_NAMES = new Set([
   "node_modules",
   "venv",


### PR DESCRIPTION
### Linked issue

No matching GitHub issue; reported in Paseo's public Discord.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Workspace file search skipped `.opencode` because dot-directories are traversed only when allowlisted, and this provider directory was missing from that policy. Add it to the workspace allowlist so nested commands and workflows appear in composer file search while other hidden directories remain excluded. Production and tests now import the same workspace search policy so future allowlist changes cannot drift between them.

### How did you verify it

- Added a daemon E2E regression using `.opencode/command/workflow/00-kickoff/00-user-stories.md`.
- Before the change, the focused E2E test returned an empty result and failed.
- After the change, the focused E2E test passed.
- `npx vitest run packages/server/src/utils/directory-suggestions.test.ts --bail=1` — 28 passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed with zero warnings and errors.
- `npm run format` — completed.

### Risk surface

Limited to daemon-owned workspace file search. General hidden-directory exclusion remains in place; only `.opencode` gains traversal.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI changes)
- [x] Tests added or updated where it made sense
