### PR TITLE
fix(attachments): compress oversized images and guard the send budget

### DIFF
--- a/packages/app/src/attachments/image-compression.test.ts
+++ b/packages/app/src/attachments/image-compression.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AttachmentTooLargeError,
+  base64Bytes,
+  encodeAttachmentsToBudget,
+  IMAGE_COMPRESS_TRIGGER_BASE64_CHARS,
+  isCompressibleImage,
+  MAX_TOTAL_ATTACHMENT_BASE64_CHARS,
+  type BudgetAttachment,
+  type EncodeBudgetDeps,
+} from "./image-compression";
+
+function att(id: string, mimeType = "image/png"): BudgetAttachment {
+  return { id, mimeType };
+}
+
+function deps(overrides: Partial<EncodeBudgetDeps>): EncodeBudgetDeps {
+  return {
+    encodeBase64: async (id) => `${id}:base64`,
+    resolvePreviewUrl: async (id) => `blob:${id}`,
+    releasePreviewUrl: async () => {},
+    compress: async () => null,
+    ...overrides,
+  };
+}
+
+describe("base64Bytes", () => {
+  it("estimates decoded byte length", () => {
+    expect(base64Bytes("")).toBe(0);
+    expect(base64Bytes("AAAA")).toBe(3); // 4 chars, no padding
+    expect(base64Bytes("AAA=")).toBe(2);
+    expect(base64Bytes("AA==")).toBe(1);
+  });
+
+  it("ignores a data-url prefix", () => {
+    expect(base64Bytes("data:image/jpeg;base64,AAAA")).toBe(3);
+  });
+});
+
+describe("isCompressibleImage", () => {
+  it("accepts jpeg/png/webp, rejects gif/svg/non-image", () => {
+    expect(isCompressibleImage("image/png")).toBe(true);
+    expect(isCompressibleImage("image/jpeg")).toBe(true);
+    expect(isCompressibleImage("image/webp")).toBe(true);
+    expect(isCompressibleImage("image/gif")).toBe(false);
+    expect(isCompressibleImage("image/svg+xml")).toBe(false);
+    expect(isCompressibleImage("application/pdf")).toBe(false);
+  });
+});
+
+describe("encodeAttachmentsToBudget", () => {
+  it("passes small attachments through without compressing", async () => {
+    const compress = vi.fn(async () => null);
+    const result = await encodeAttachmentsToBudget([att("a", "image/jpeg")], deps({ compress }));
+    expect(result).toEqual([{ data: "a:base64", mimeType: "image/jpeg" }]);
+    expect(compress).not.toHaveBeenCalled();
+  });
+
+  it("compresses attachments whose base64 exceeds the trigger", async () => {
+    const big = "x".repeat(IMAGE_COMPRESS_TRIGGER_BASE64_CHARS + 10);
+    const compress = vi.fn(async () => ({ data: "small", mimeType: "image/jpeg" }));
+    const release = vi.fn(async () => {});
+
+    const result = await encodeAttachmentsToBudget(
+      [att("big", "image/png")],
+      deps({ encodeBase64: async () => big, compress, releasePreviewUrl: release }),
+    );
+
+    expect(compress).toHaveBeenCalledWith({
+      url: "blob:big",
+      mimeType: "image/png",
+      targetBytes: expect.any(Number),
+    });
+    expect(result).toEqual([{ data: "small", mimeType: "image/jpeg" }]);
+    // preview url is released even on the success path
+    expect(release).toHaveBeenCalledWith("big", "blob:big");
+  });
+
+  it("keeps the original when compression returns a larger result", async () => {
+    const big = "x".repeat(IMAGE_COMPRESS_TRIGGER_BASE64_CHARS + 10);
+    const result = await encodeAttachmentsToBudget(
+      [att("big", "image/png")],
+      deps({
+        encodeBase64: async () => big,
+        compress: async () => ({ data: "y".repeat(big.length + 100), mimeType: "image/jpeg" }),
+      }),
+    );
+    expect(result[0].data).toBe(big);
+  });
+
+  it("does not compress non-compressible images (gif)", async () => {
+    const big = "x".repeat(IMAGE_COMPRESS_TRIGGER_BASE64_CHARS + 10);
+    const compress = vi.fn(async () => ({ data: "small", mimeType: "image/jpeg" }));
+    // gif small enough to stay under total budget so it passes through untouched
+    const small = "g".repeat(1000);
+    void big;
+    const result = await encodeAttachmentsToBudget(
+      [att("g", "image/gif")],
+      deps({ encodeBase64: async () => small, compress }),
+    );
+    expect(compress).not.toHaveBeenCalled();
+    expect(result).toEqual([{ data: small, mimeType: "image/gif" }]);
+  });
+
+  it("throws AttachmentTooLargeError when still over budget after compression", async () => {
+    const big = "x".repeat(MAX_TOTAL_ATTACHMENT_BASE64_CHARS + 100_000);
+    await expect(
+      encodeAttachmentsToBudget(
+        [att("big", "image/png")],
+        deps({
+          encodeBase64: async () => big,
+          // compressor shrinks the image but not below the total budget
+          compress: async () => ({
+            data: "z".repeat(MAX_TOTAL_ATTACHMENT_BASE64_CHARS + 1),
+            mimeType: "image/jpeg",
+          }),
+        }),
+      ),
+    ).rejects.toBeInstanceOf(AttachmentTooLargeError);
+  });
+
+  it("throws when the sum of several attachments exceeds the budget", async () => {
+    const half = "y".repeat(Math.ceil(MAX_TOTAL_ATTACHMENT_BASE64_CHARS * 0.6));
+    await expect(
+      encodeAttachmentsToBudget(
+        [att("a", "image/gif"), att("b", "image/gif")],
+        deps({ encodeBase64: async (id) => (id === "a" ? half : half) }),
+      ),
+    ).rejects.toBeInstanceOf(AttachmentTooLargeError);
+  });
+
+  it("skips attachments that fail to encode instead of throwing", async () => {
+    const result = await encodeAttachmentsToBudget(
+      [att("bad"), att("good", "image/jpeg")],
+      deps({
+        encodeBase64: async (id) => {
+          if (id === "bad") throw new Error("boom");
+          return `${id}:base64`;
+        },
+      }),
+    );
+    expect(result).toEqual([{ data: "good:base64", mimeType: "image/jpeg" }]);
+  });
+});

--- a/packages/app/src/attachments/image-compression.ts
+++ b/packages/app/src/attachments/image-compression.ts
@@ -1,0 +1,157 @@
+/**
+ * Attachment send budget + image compression contract.
+ *
+ * Why this exists: outbound agent messages travel as a single WebSocket frame.
+ * Over the E2EE relay the image `data` field is base64 (~1.33x the raw bytes),
+ * the whole JSON message is then encrypted and re-encoded as base64 by the relay
+ * channel (~1.33x again), so the final frame is roughly 1.77x the raw image bytes.
+ * Cloudflare closes any WebSocket frame over ~1 MiB with close code 1009
+ * ("message too big"), which tears down the whole transport. A large screenshot
+ * attachment therefore used to kill the session on send.
+ *
+ * The fix has two parts, both driven from here:
+ *  1. Compress oversized images down to a byte target before encoding.
+ *  2. Hard budget guard — if the encoded attachments still exceed the budget,
+ *     throw {@link AttachmentTooLargeError} instead of sending, so the frame is
+ *     never emitted and the socket survives.
+ *
+ * Budgets are expressed in base64 characters because that is exactly what lands
+ * in the JSON payload. 640k base64 chars ≈ 470 KB of JSON, which stays well under
+ * 1 MiB after encryption + relay base64 wrapping, leaving room for the message text.
+ */
+
+export interface EncodedAttachment {
+  data: string;
+  mimeType: string;
+}
+
+/** Total base64 characters allowed across all attachments in one message. */
+export const MAX_TOTAL_ATTACHMENT_BASE64_CHARS = 640_000;
+
+/** Above this per-image base64 length we attempt compression before sending. */
+export const IMAGE_COMPRESS_TRIGGER_BASE64_CHARS = 480_000;
+
+/** Byte target the compressor aims for per image (base64 of this stays comfortably under budget). */
+export const IMAGE_COMPRESS_TARGET_BYTES = 320_000;
+
+export interface CompressImageInput {
+  /** Loadable URL for the source image (blob: URL on web, file:// URI on native). */
+  url: string;
+  mimeType: string;
+  /** Target encoded size in bytes; the compressor aims at or below this. */
+  targetBytes: number;
+}
+
+/** Compresses an image to (at best) `targetBytes`. Returns null if it cannot compress. */
+export type ImageCompressor = (input: CompressImageInput) => Promise<EncodedAttachment | null>;
+
+export class AttachmentTooLargeError extends Error {
+  readonly totalChars: number;
+  readonly limitChars: number;
+
+  constructor(totalChars: number, limitChars: number) {
+    super("Attachment is too large to send even after compression. Please attach a smaller image.");
+    this.name = "AttachmentTooLargeError";
+    this.totalChars = totalChars;
+    this.limitChars = limitChars;
+  }
+}
+
+/** Approximate decoded byte length of a base64 string (ignoring any data-URL prefix). */
+export function base64Bytes(base64: string): number {
+  const comma = base64.indexOf(",");
+  const body =
+    comma >= 0 && base64.slice(0, comma).includes(";base64") ? base64.slice(comma + 1) : base64;
+  const len = body.length;
+  if (len === 0) return 0;
+  let padding = 0;
+  if (body.endsWith("==")) padding = 2;
+  else if (body.endsWith("=")) padding = 1;
+  return Math.floor((len * 3) / 4) - padding;
+}
+
+/**
+ * Whether an image mime type can be safely re-encoded as JPEG. We skip vector
+ * (svg) and animated (gif) formats because JPEG re-encoding would destroy them.
+ */
+export function isCompressibleImage(mimeType: string): boolean {
+  const type = mimeType.toLowerCase();
+  if (!type.startsWith("image/")) return false;
+  return type !== "image/gif" && type !== "image/svg+xml";
+}
+
+export interface EncodeBudgetDeps {
+  encodeBase64: (attachmentId: string) => Promise<string>;
+  resolvePreviewUrl: (attachmentId: string) => Promise<string>;
+  releasePreviewUrl?: (attachmentId: string, url: string) => Promise<void>;
+  compress: ImageCompressor;
+}
+
+export interface BudgetAttachment {
+  id: string;
+  mimeType: string;
+}
+
+/**
+ * Encodes attachments to base64, compressing any that exceed the per-image
+ * trigger, then enforces the total budget. Throws {@link AttachmentTooLargeError}
+ * if the total is still over budget so the caller never sends an oversized frame.
+ *
+ * Per-attachment encode failures are logged and skipped (matching prior behavior);
+ * only the budget guard throws.
+ */
+export async function encodeAttachmentsToBudget(
+  attachments: readonly BudgetAttachment[],
+  deps: EncodeBudgetDeps,
+): Promise<EncodedAttachment[]> {
+  const results: EncodedAttachment[] = [];
+
+  for (const attachment of attachments) {
+    let data: string;
+    try {
+      data = await deps.encodeBase64(attachment.id);
+    } catch (error) {
+      console.error("[attachments] Failed to encode attachment for send", {
+        id: attachment.id,
+        error,
+      });
+      continue;
+    }
+
+    let mimeType = attachment.mimeType;
+
+    if (
+      data.length > IMAGE_COMPRESS_TRIGGER_BASE64_CHARS &&
+      isCompressibleImage(attachment.mimeType)
+    ) {
+      const url = await deps.resolvePreviewUrl(attachment.id);
+      try {
+        const compressed = await deps.compress({
+          url,
+          mimeType: attachment.mimeType,
+          targetBytes: IMAGE_COMPRESS_TARGET_BYTES,
+        });
+        if (compressed && compressed.data.length < data.length) {
+          data = compressed.data;
+          mimeType = compressed.mimeType;
+        }
+      } catch (error) {
+        console.warn("[attachments] Image compression failed; sending original", {
+          id: attachment.id,
+          error,
+        });
+      } finally {
+        await deps.releasePreviewUrl?.(attachment.id, url);
+      }
+    }
+
+    results.push({ data, mimeType });
+  }
+
+  const totalChars = results.reduce((sum, entry) => sum + entry.data.length, 0);
+  if (totalChars > MAX_TOTAL_ATTACHMENT_BASE64_CHARS) {
+    throw new AttachmentTooLargeError(totalChars, MAX_TOTAL_ATTACHMENT_BASE64_CHARS);
+  }
+
+  return results;
+}

--- a/packages/app/src/attachments/image-compressor.native.ts
+++ b/packages/app/src/attachments/image-compressor.native.ts
@@ -1,0 +1,64 @@
+import { ImageManipulator, SaveFormat } from "expo-image-manipulator";
+import {
+  base64Bytes,
+  type CompressImageInput,
+  type EncodedAttachment,
+} from "@/attachments/image-compression";
+
+/** Longest edge we scale down to on the first resize pass. */
+const MAX_EDGE_PX = 1568;
+const MIN_EDGE_PX = 320;
+const MAX_ATTEMPTS = 5;
+const MIN_QUALITY = 0.4;
+
+/**
+ * Native image compressor (expo-image-manipulator). First pass re-encodes as
+ * JPEG without resizing; subsequent passes shrink the longest edge and lower
+ * quality until the encoded size drops under `targetBytes`. Returns the smallest
+ * result produced (best effort) even if the target is not reached.
+ */
+export async function compressImage({
+  url,
+  targetBytes,
+}: CompressImageInput): Promise<EncodedAttachment | null> {
+  let best: EncodedAttachment | null = null;
+  let width = MAX_EDGE_PX;
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const quality = Math.max(MIN_QUALITY, 0.8 - attempt * 0.1);
+    // First attempt: recompress only (no resize) to avoid upscaling small images.
+    const context =
+      attempt === 0
+        ? ImageManipulator.manipulate(url)
+        : ImageManipulator.manipulate(url).resize({ width });
+
+    let image: Awaited<ReturnType<typeof context.renderAsync>> | null = null;
+    try {
+      image = await context.renderAsync();
+      const result = await image.saveAsync({
+        format: SaveFormat.JPEG,
+        compress: quality,
+        base64: true,
+      });
+      const base64 = result.base64 ?? null;
+      if (base64) {
+        if (!best || base64.length < best.data.length) {
+          best = { data: base64, mimeType: "image/jpeg" };
+        }
+        if (base64Bytes(base64) <= targetBytes) {
+          return best;
+        }
+      }
+    } catch (error) {
+      console.warn("[attachments] Native compression attempt failed", { attempt, error });
+    } finally {
+      image?.release();
+      context.release();
+    }
+
+    if (width <= MIN_EDGE_PX) break;
+    width = Math.max(MIN_EDGE_PX, Math.round(width * 0.8));
+  }
+
+  return best;
+}

--- a/packages/app/src/attachments/image-compressor.ts
+++ b/packages/app/src/attachments/image-compressor.ts
@@ -1,0 +1,10 @@
+import type { CompressImageInput, EncodedAttachment } from "@/attachments/image-compression";
+
+/**
+ * Fallback compressor for environments without a platform image pipeline
+ * (Node/test). Metro resolves `.web.ts` / `.native.ts` for real runtimes.
+ * Returning null means "not compressed"; the caller's budget guard still applies.
+ */
+export async function compressImage(_input: CompressImageInput): Promise<EncodedAttachment | null> {
+  return null;
+}

--- a/packages/app/src/attachments/image-compressor.web.ts
+++ b/packages/app/src/attachments/image-compressor.web.ts
@@ -1,0 +1,71 @@
+import {
+  base64Bytes,
+  type CompressImageInput,
+  type EncodedAttachment,
+} from "@/attachments/image-compression";
+
+/** Longest edge we keep. Larger images are scaled down before re-encoding. */
+const MAX_EDGE_PX = 1568;
+const MAX_ATTEMPTS = 6;
+const MIN_QUALITY = 0.4;
+const MIN_SCALE = 0.3;
+
+function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.addEventListener("load", () => resolve(img), { once: true });
+    img.addEventListener("error", () => reject(new Error("Failed to load image for compression")), {
+      once: true,
+    });
+    img.src = url;
+  });
+}
+
+/**
+ * Web image compressor: draws the source into a canvas at decreasing scale and
+ * JPEG quality until the encoded size drops under `targetBytes`. Returns the
+ * smallest result produced (best effort) even if the target is not reached.
+ */
+export async function compressImage({
+  url,
+  targetBytes,
+}: CompressImageInput): Promise<EncodedAttachment | null> {
+  if (typeof document === "undefined") return null;
+
+  const img = await loadImage(url);
+  const naturalWidth = img.naturalWidth || img.width;
+  const naturalHeight = img.naturalHeight || img.height;
+  if (naturalWidth === 0 || naturalHeight === 0) return null;
+
+  // Never upscale: start at 1 and only shrink if the image is larger than MAX_EDGE_PX.
+  let scale = Math.min(1, MAX_EDGE_PX / Math.max(naturalWidth, naturalHeight));
+  let best: EncodedAttachment | null = null;
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const width = Math.max(1, Math.round(naturalWidth * scale));
+    const height = Math.max(1, Math.round(naturalHeight * scale));
+
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return best;
+    ctx.drawImage(img, 0, 0, width, height);
+
+    const quality = Math.max(MIN_QUALITY, 0.82 - attempt * 0.12);
+    const dataUrl = canvas.toDataURL("image/jpeg", quality);
+    const base64 = dataUrl.slice(dataUrl.indexOf(",") + 1);
+
+    if (!best || base64.length < best.data.length) {
+      best = { data: base64, mimeType: "image/jpeg" };
+    }
+    if (base64Bytes(base64) <= targetBytes) {
+      return best;
+    }
+
+    if (scale <= MIN_SCALE && quality <= MIN_QUALITY) break;
+    scale = Math.max(MIN_SCALE, scale * 0.8);
+  }
+
+  return best;
+}

--- a/packages/app/src/attachments/service.test.ts
+++ b/packages/app/src/attachments/service.test.ts
@@ -1,7 +1,12 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AttachmentMetadata, AttachmentStore, SaveAttachmentInput } from "@/attachments/types";
+import { AttachmentTooLargeError, IMAGE_COMPRESS_TRIGGER_BASE64_CHARS } from "./image-compression";
 import { __setAttachmentStoreForTests } from "./store";
-import { encodeAttachmentsForSend, persistAttachmentFromBytes } from "./service";
+import {
+  __setImageCompressorForTests,
+  encodeAttachmentsForSend,
+  persistAttachmentFromBytes,
+} from "./service";
 
 function createAttachment(input: Partial<AttachmentMetadata> = {}): AttachmentMetadata {
   return {
@@ -52,6 +57,7 @@ function createRecordingStore(): AttachmentStore & {
 describe("attachment service", () => {
   afterEach(() => {
     __setAttachmentStoreForTests(null);
+    __setImageCompressorForTests(null);
   });
 
   it("persists raw bytes without requiring a base64 wrapper", async () => {
@@ -93,5 +99,35 @@ describe("attachment service", () => {
     await expect(encodeAttachmentsForSend([attachment])).resolves.toEqual([
       { data: "att_send:base64", mimeType: "image/jpeg" },
     ]);
+  });
+
+  it("compresses oversized images through the injected compressor", async () => {
+    const store = createRecordingStore();
+    const big = "x".repeat(IMAGE_COMPRESS_TRIGGER_BASE64_CHARS + 10);
+    store.encodeBase64 = async () => big;
+    __setAttachmentStoreForTests(store);
+
+    const compress = vi.fn(async () => ({ data: "compressed", mimeType: "image/jpeg" }));
+    __setImageCompressorForTests(compress);
+
+    const attachment = createAttachment({ id: "att_big", mimeType: "image/png" });
+    await expect(encodeAttachmentsForSend([attachment])).resolves.toEqual([
+      { data: "compressed", mimeType: "image/jpeg" },
+    ]);
+    expect(compress).toHaveBeenCalledOnce();
+    expect(store.releasedUrls).toEqual(["blob:att_big"]);
+  });
+
+  it("throws AttachmentTooLargeError when an image stays over budget", async () => {
+    const store = createRecordingStore();
+    const big = "x".repeat(IMAGE_COMPRESS_TRIGGER_BASE64_CHARS + 10);
+    store.encodeBase64 = async () => big.repeat(3);
+    __setAttachmentStoreForTests(store);
+    __setImageCompressorForTests(async () => null);
+
+    const attachment = createAttachment({ id: "att_huge", mimeType: "image/png" });
+    await expect(encodeAttachmentsForSend([attachment])).rejects.toBeInstanceOf(
+      AttachmentTooLargeError,
+    );
   });
 });

--- a/packages/app/src/attachments/service.ts
+++ b/packages/app/src/attachments/service.ts
@@ -1,5 +1,23 @@
 import type { AttachmentMetadata } from "@/attachments/types";
 import { getAttachmentStore } from "@/attachments/store";
+import {
+  encodeAttachmentsToBudget,
+  type EncodedAttachment,
+  type ImageCompressor,
+} from "@/attachments/image-compression";
+
+let compressorOverride: ImageCompressor | null = null;
+
+/** Test-only hook to inject a deterministic image compressor. */
+export function __setImageCompressorForTests(compressor: ImageCompressor | null): void {
+  compressorOverride = compressor;
+}
+
+const lazyImageCompressor: ImageCompressor = async (input) => {
+  if (compressorOverride) return compressorOverride(input);
+  const mod = await import("@/attachments/image-compressor");
+  return mod.compressImage(input);
+};
 
 export async function persistAttachmentFromBlob(input: {
   blob: Blob;
@@ -63,34 +81,26 @@ export async function persistAttachmentFromFileUri(input: {
 
 export async function encodeAttachmentsForSend(
   attachments: readonly AttachmentMetadata[] | undefined,
-): Promise<Array<{ data: string; mimeType: string }> | undefined> {
+): Promise<EncodedAttachment[] | undefined> {
   if (!attachments || attachments.length === 0) {
     return undefined;
   }
 
   const store = await getAttachmentStore();
-  const encoded = await Promise.all(
-    attachments.map(async (attachment) => {
-      try {
-        const data = await store.encodeBase64({ attachment });
-        return {
-          data,
-          mimeType: attachment.mimeType,
-        };
-      } catch (error) {
-        console.error("[attachments] Failed to encode attachment for send", {
-          id: attachment.id,
-          error,
-        });
-        return null;
-      }
-    }),
+  const byId = new Map(attachments.map((attachment) => [attachment.id, attachment]));
+  const encoded = await encodeAttachmentsToBudget(
+    attachments.map((attachment) => ({ id: attachment.id, mimeType: attachment.mimeType })),
+    {
+      encodeBase64: (id) => store.encodeBase64({ attachment: byId.get(id)! }),
+      resolvePreviewUrl: (id) => store.resolvePreviewUrl({ attachment: byId.get(id)! }),
+      releasePreviewUrl: store.releasePreviewUrl
+        ? (id, url) => store.releasePreviewUrl!({ attachment: byId.get(id)!, url })
+        : undefined,
+      compress: lazyImageCompressor,
+    },
   );
 
-  const valid = encoded.filter(
-    (entry): entry is { data: string; mimeType: string } => entry !== null,
-  );
-  return valid.length > 0 ? valid : undefined;
+  return encoded.length > 0 ? encoded : undefined;
 }
 
 export async function resolveAttachmentPreviewUrl(attachment: AttachmentMetadata): Promise<string> {

--- a/packages/app/src/composer/actions.ts
+++ b/packages/app/src/composer/actions.ts
@@ -167,6 +167,10 @@ export async function dispatchComposerAgentMessage(
 ): Promise<void> {
   const wirePayload = splitComposerAttachmentsForSubmit(input.attachments);
   const messageId = generateMessageId();
+  // Encode/compress attachments before showing the optimistic message so an
+  // oversized-attachment rejection surfaces as a send error instead of leaving
+  // a ghost message in the stream (and never blows the transport with a 1009).
+  const imagesData = await input.encodeImages(wirePayload.images);
   const userMessage = buildOptimisticUserMessage({
     id: messageId,
     text: input.text,
@@ -175,7 +179,6 @@ export async function dispatchComposerAgentMessage(
     attachments: wirePayload.attachments,
   });
   appendUserMessageToStream(input.agentId, userMessage, input.stream);
-  const imagesData = await input.encodeImages(wirePayload.images);
   await input.client.sendAgentMessage(input.agentId, input.text, {
     messageId,
     images: imagesData ?? [],

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -62,6 +62,7 @@ import { derivePendingPermissionKey, normalizeAgentSnapshot } from "@/utils/agen
 import { resolveProjectPlacement } from "@/utils/project-placement";
 import { buildDraftStoreKey } from "@/stores/draft-keys";
 import type { AttachmentMetadata } from "@/attachments/types";
+import type { EncodedAttachment } from "@/attachments/image-compression";
 import { splitComposerAttachmentsForSubmit } from "@/composer/attachments/submit";
 import { reconcilePreviousAgentStatuses } from "@/contexts/session-status-tracking";
 import { patchWorkspaceScripts } from "@/contexts/session-workspace-scripts";
@@ -1817,6 +1818,17 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
       attachments?: AgentAttachment[],
     ) => {
       const messageId = generateMessageId();
+
+      // Encode/compress attachments before the optimistic append so an oversized
+      // attachment fails cleanly (no ghost message, no 1009 transport kill).
+      let imagesData: EncodedAttachment[] | undefined;
+      try {
+        imagesData = await encodeImages(images);
+      } catch (error) {
+        console.error("[Session] Failed to encode attachments for send:", error);
+        return;
+      }
+
       const userMessage: StreamItem = {
         kind: "user_message",
         id: messageId,
@@ -1849,7 +1861,6 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
         });
       }
 
-      const imagesData = await encodeImages(images);
       if (!client) {
         console.warn("[Session] sendAgentMessage skipped: daemon unavailable");
         return;


### PR DESCRIPTION
## Problem

Sending an agent message with an image attachment could kill the whole session with **`Transport closed (code 1009)`**.

Attachments are base64-encoded and sent as a **single WebSocket frame** with no size limit. Over the E2EE relay the image `data` field is base64 (~1.33× raw bytes), then the whole JSON message is encrypted and re-encoded as base64 by the relay channel (~1.33× again) — so the final frame is roughly **1.77× the raw image bytes**. Cloudflare force-closes any WebSocket frame over ~1 MiB with close code **1009 ("message too big")**, tearing down the transport. A typical phone screenshot (2–5 MB) blew past the cap on send.

There was **no compression, size limit, or chunking** anywhere in the stack.

## Fix

All send paths funnel through `encodeImages` → `encodeAttachmentsForSend`, so the fix lives at that single chokepoint:

1. **Compression** — images whose base64 exceeds a trigger are downscaled + re-encoded (JPEG) to a byte target before sending. Platform-split: canvas on web, `expo-image-manipulator` on native (already a dependency). GIF/SVG are skipped.
2. **Hard budget guard** — if the encoded attachments still exceed the total budget, throw `AttachmentTooLargeError` **instead of emitting the frame**. The socket is never killed; the error surfaces in the existing composer send-error banner ("attachment too large, attach a smaller image").
3. **Ordering** — encoding now runs *before* the optimistic message append, so an oversized attachment no longer leaves a ghost message in the stream.

Budgets are expressed in base64 characters (what actually lands in the JSON): 640k chars total ≈ 470 KB JSON, comfortably under 1 MiB after encryption + relay base64 wrapping.

## Tests

- New `image-compression.test.ts` — pure budget/compression logic (pass-through, trigger, best-effort, non-compressible skip, budget throw, multi-attachment sum, encode-failure skip).
- Extended `service.test.ts` — store + injected-compressor wiring and the too-large throw path.
- 47 tests green across `image-compression`, `service`, and `composer/actions`. Typecheck (0 errors), oxlint (0 errors), formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)