### PR TITLE
fix(server): create autonomous turns for spontaneous ACP session updates

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2208,6 +2208,90 @@ describe("ACPAgentSession", () => {
     expect(assistantMessages[2].messageId).not.toBe(assistantMessages[0].messageId);
   });
 
+  test("starts an autonomous turn for spontaneous session updates outside a foreground turn", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const session = createSession();
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "autonomous-msg",
+        content: { type: "text", text: "Autonomous update" },
+      } as SessionUpdate,
+    });
+
+    // Should emit turn_started before the timeline item.
+    const turnStartedIndex = events.findIndex((e) => e.type === "turn_started");
+    expect(turnStartedIndex).toBeGreaterThanOrEqual(0);
+    const timelineIndex = events.findIndex(
+      (e) => e.type === "timeline" && e.item.type === "assistant_message" && e.item.text === "Autonomous update",
+    );
+    expect(timelineIndex).toBeGreaterThan(turnStartedIndex);
+
+    const turnStarted = events[turnStartedIndex];
+    expect(turnStarted.type).toBe("turn_started");
+    const autonomousTurnId = (turnStarted as { turnId?: string }).turnId;
+    expect(autonomousTurnId).toEqual(expect.any(String));
+
+    // Timeline item should be tagged with the autonomous turn id.
+    const timelineEvent = events[timelineIndex];
+    expect(timelineEvent.type).toBe("timeline");
+    expect((timelineEvent as { turnId?: string }).turnId).toBe(autonomousTurnId);
+
+    // Advance timers to complete the autonomous turn.
+    await vi.advanceTimersByTimeAsync(ACPAgentSession["AUTONOMOUS_TURN_TIMEOUT_MS"] + 10);
+    const turnCompleted = events.find((e) => e.type === "turn_completed");
+    expect(turnCompleted).toBeDefined();
+    expect((turnCompleted as { turnId?: string }).turnId).toBe(autonomousTurnId);
+
+    vi.useRealTimers();
+  });
+
+  test("completes an existing autonomous turn before starting a foreground turn", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const session = createSession();
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = {
+      prompt: vi.fn(() => new Promise(() => {})),
+    };
+
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "autonomous-msg",
+        content: { type: "text", text: "Autonomous update" },
+      } as SessionUpdate,
+    });
+
+    const turnStarted = events.find((e) => e.type === "turn_started");
+    expect(turnStarted).toBeDefined();
+    const autonomousTurnId = (turnStarted as { turnId?: string }).turnId;
+
+    // Starting a foreground turn should complete the autonomous turn first.
+    void session.startTurn("user prompt");
+    await vi.runOnlyPendingTimersAsync();
+
+    const turnCompleted = events.find(
+      (e) => e.type === "turn_completed" && (e as { turnId?: string }).turnId === autonomousTurnId,
+    );
+    expect(turnCompleted).toBeDefined();
+
+    vi.useRealTimers();
+  });
+
   test("startTurn returns before the ACP prompt settles and completes later via subscribers", async () => {
     const session = createSession();
     const events: Array<{ type: string; turnId?: string }> = [];

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2231,7 +2231,10 @@ describe("ACPAgentSession", () => {
     const turnStartedIndex = events.findIndex((e) => e.type === "turn_started");
     expect(turnStartedIndex).toBeGreaterThanOrEqual(0);
     const timelineIndex = events.findIndex(
-      (e) => e.type === "timeline" && e.item.type === "assistant_message" && e.item.text === "Autonomous update",
+      (e) =>
+        e.type === "timeline" &&
+        e.item.type === "assistant_message" &&
+        e.item.text === "Autonomous update",
     );
     expect(timelineIndex).toBeGreaterThan(turnStartedIndex);
 

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2134,10 +2134,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       return;
     }
 
-    if (events.length > 0 && !this.activeForegroundTurnId && !this.autonomousTurnId) {
+    if (events.length > 0 && !this.activeForegroundTurnId) {
       this.startAutonomousTurn();
-    }
-    if (events.length > 0) {
       this.resetAutonomousTurnTimer();
     }
 
@@ -2680,7 +2678,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   private pushEvent(event: AgentStreamEvent): void {
     const turnId = this.activeForegroundTurnId ?? this.autonomousTurnId;
-    const tagged = turnId ? { ...event, turnId } : event;
+    const tagged = event.type === "timeline" && turnId ? { ...event, turnId } : event;
     this.logger.trace(
       {
         agentId: this.agentId,
@@ -2745,7 +2743,11 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       return;
     }
     this.autonomousTurnId = randomUUID();
-    this.pushEvent({ type: "turn_started", provider: this.provider, turnId: this.autonomousTurnId });
+    this.pushEvent({
+      type: "turn_started",
+      provider: this.provider,
+      turnId: this.autonomousTurnId,
+    });
   }
 
   private completeAutonomousTurn(): void {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1331,6 +1331,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
+  private autonomousTurnId: string | null = null;
+  private autonomousTurnTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly AUTONOMOUS_TURN_TIMEOUT_MS = 30_000;
   private fallbackAssistantMessageId: string | null = null;
   private closed = false;
   private historyPending = false;
@@ -1472,6 +1475,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     if (this.activeForegroundTurnId) {
       throw new Error("A foreground turn is already active");
     }
+    this.completeAutonomousTurn();
 
     const turnId = randomUUID();
     const messageId = options?.messageId ?? randomUUID();
@@ -2115,7 +2119,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         agentId: this.agentId,
         provider: this.provider,
         sessionId: this.sessionId,
-        turnId: this.activeForegroundTurnId ?? undefined,
+        turnId: this.activeForegroundTurnId ?? this.autonomousTurnId ?? undefined,
         rawEvent: params,
         events,
       },
@@ -2128,6 +2132,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         }
       }
       return;
+    }
+
+    if (events.length > 0 && !this.activeForegroundTurnId && !this.autonomousTurnId) {
+      this.startAutonomousTurn();
+    }
+    if (events.length > 0) {
+      this.resetAutonomousTurnTimer();
     }
 
     for (const event of events) {
@@ -2663,23 +2674,25 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       type: "timeline",
       provider: this.provider,
       item,
-      turnId: this.activeForegroundTurnId ?? undefined,
+      turnId: this.activeForegroundTurnId ?? this.autonomousTurnId ?? undefined,
     };
   }
 
   private pushEvent(event: AgentStreamEvent): void {
+    const turnId = this.activeForegroundTurnId ?? this.autonomousTurnId;
+    const tagged = turnId ? { ...event, turnId } : event;
     this.logger.trace(
       {
         agentId: this.agentId,
         provider: this.provider,
         sessionId: this.sessionId,
-        turnId: getAgentStreamEventTurnId(event) ?? this.activeForegroundTurnId ?? undefined,
-        event,
+        turnId: getAgentStreamEventTurnId(tagged) ?? turnId ?? undefined,
+        event: tagged,
       },
       "provider.acp.event_emit",
     );
     for (const subscriber of this.subscribers) {
-      subscriber(event);
+      subscriber(tagged);
     }
   }
 
@@ -2725,6 +2738,37 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       this.activeSubmittedUserMessage = null;
     }
     this.pushEvent(event);
+  }
+
+  private startAutonomousTurn(): void {
+    if (this.autonomousTurnId) {
+      return;
+    }
+    this.autonomousTurnId = randomUUID();
+    this.pushEvent({ type: "turn_started", provider: this.provider, turnId: this.autonomousTurnId });
+  }
+
+  private completeAutonomousTurn(): void {
+    if (!this.autonomousTurnId) {
+      return;
+    }
+    if (this.autonomousTurnTimer) {
+      clearTimeout(this.autonomousTurnTimer);
+      this.autonomousTurnTimer = null;
+    }
+    const turnId = this.autonomousTurnId;
+    this.autonomousTurnId = null;
+    this.pushEvent({ type: "turn_completed", provider: this.provider, turnId });
+  }
+
+  private resetAutonomousTurnTimer(): void {
+    if (this.autonomousTurnTimer) {
+      clearTimeout(this.autonomousTurnTimer);
+    }
+    this.autonomousTurnTimer = setTimeout(() => {
+      this.completeAutonomousTurn();
+    }, ACPAgentSession.AUTONOMOUS_TURN_TIMEOUT_MS);
+    this.autonomousTurnTimer.unref?.();
   }
 
   private isSubmittedUserMessageEcho(


### PR DESCRIPTION
## Problem

When an ACP-based provider (e.g. kimi-code) handles background-agent completion notifications inside an existing session, the content it produces is never surfaced in Paseo's timeline. The foreground turn has already returned from the provider's point of view, so the subsequent spontaneous `session/update` messages have no active turn to attach to.

This is the root cause behind behavior where an agent can say "I'll summarize when the background agents finish" but the summary never appears in the Paseo UI.

## Solution

Mirror the autonomous-turn mechanism already used by the Claude provider:

1. When a spontaneous `sessionUpdate` arrives and there is no active foreground turn, start an autonomous turn and emit `turn_started`.
2. Tag all timeline events emitted during that autonomous turn with the autonomous turn id.
3. Reset a short inactivity timer on every autonomous update; when it expires, emit `turn_completed`.
4. Before starting a new foreground turn, complete any active autonomous turn.

## Changes

- `packages/server/src/server/agent/providers/acp-agent.ts`
  - Add `autonomousTurnId`, `autonomousTurnTimer`, and `AUTONOMOUS_TURN_TIMEOUT_MS`
  - Add `startAutonomousTurn`, `completeAutonomousTurn`, and `resetAutonomousTurnTimer`
  - `sessionUpdate` now starts/resets an autonomous turn when no foreground turn is active
  - `wrapTimeline` and `pushEvent` now fall back to the autonomous turn id
  - `startTurn` completes any pending autonomous turn first

- `packages/server/src/server/agent/providers/acp-agent.test.ts`
  - Add test for autonomous turn lifecycle on spontaneous updates
  - Add test that `startTurn` completes an autonomous turn before starting a foreground turn

## Testing

```bash
cd packages/server
vitest run src/server/agent/providers/acp-agent.test.ts
```

All 77 tests pass, including the 2 new ones.
