### PR TITLE
fix(server): speed up OMP/Pi import session listing

### DIFF
--- a/packages/server/src/server/agent/providers/pi/session-descriptor.test.ts
+++ b/packages/server/src/server/agent/providers/pi/session-descriptor.test.ts
@@ -13,6 +13,45 @@ async function writeSession(root: string, lines: unknown[]): Promise<string> {
   return filePath;
 }
 
+async function writeNamedSession(
+  root: string,
+  cwdDir: string,
+  fileName: string,
+  lines: unknown[],
+  nestedDir?: string,
+): Promise<string> {
+  const sessionsDir = nestedDir
+    ? path.join(root, "sessions", cwdDir, nestedDir)
+    : path.join(root, "sessions", cwdDir);
+  await mkdir(sessionsDir, { recursive: true });
+  const filePath = path.join(sessionsDir, fileName);
+  await writeFile(filePath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+  return filePath;
+}
+
+function sessionHeader(id: string, cwd: string, timestamp: string) {
+  return {
+    type: "session",
+    version: 3,
+    id,
+    timestamp,
+    cwd,
+  };
+}
+
+function userMessage(id: string, timestamp: string, text: string) {
+  return {
+    type: "message",
+    id,
+    timestamp,
+    message: {
+      role: "user",
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
+
 test("Pi import config preserves the latest recorded model and thinking level", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "paseo-pi-session-model-"));
   const cwd = path.join(root, "repo");
@@ -168,5 +207,128 @@ test("Pi import config preserves thinking before a later model in large sessions
   expect(importConfig).toEqual({
     model: "openrouter/google/gemini-2.5-pro",
     thinkingOptionId: "low",
+  });
+});
+
+test("Pi import listing skips nested subagent transcripts", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "paseo-pi-session-skip-nested-"));
+  const cwd = path.join(root, "repo");
+  const parent = await writeNamedSession(
+    root,
+    "project",
+    "2026-06-09T00-00-00-000Z_parent.jsonl",
+    [
+      sessionHeader("parent-1", cwd, "2026-06-09T00:00:00.000Z"),
+      userMessage("user-1", "2026-06-09T00:00:01.000Z", "parent prompt"),
+    ],
+  );
+  await writeNamedSession(
+    root,
+    "project",
+    "subagent.jsonl",
+    [
+      sessionHeader("subagent-1", cwd, "2026-06-09T00:00:02.000Z"),
+      userMessage("user-2", "2026-06-09T00:00:03.000Z", "nested subagent prompt"),
+    ],
+    "2026-06-09T00-00-00-000Z_parent",
+  );
+
+  const sessions = await listPiImportableSessions({ sessionDir: path.join(root, "sessions") });
+
+  expect(sessions).toHaveLength(1);
+  expect(sessions[0]).toMatchObject({
+    providerHandleId: parent,
+    cwd,
+    firstPromptPreview: "parent prompt",
+  });
+});
+
+test("OMP import listing accepts title-first session headers", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "paseo-omp-session-title-first-"));
+  const cwd = path.join(root, "repo");
+  const sessionFile = await writeNamedSession(
+    root,
+    "project",
+    "2026-06-09T00-00-00-000Z_title_first.jsonl",
+    [
+      {
+        type: "title",
+        id: "title-1",
+        timestamp: "2026-06-09T00:00:00.000Z",
+        title: "Deploy paseo and verify",
+      },
+      sessionHeader("session-title-first", cwd, "2026-06-09T00:00:00.100Z"),
+      {
+        type: "model_change",
+        id: "model-1",
+        timestamp: "2026-06-09T00:00:00.200Z",
+        model: "openai-codex/gpt-5.1",
+      },
+      userMessage("user-1", "2026-06-09T00:00:01.000Z", "import me"),
+    ],
+  );
+
+  const sessions = await listPiImportableSessions({ sessionDir: path.join(root, "sessions") });
+  const importConfig = await readPiImportSessionConfig(sessionFile);
+
+  expect(sessions).toHaveLength(1);
+  expect(sessions[0]).toMatchObject({
+    providerHandleId: sessionFile,
+    cwd,
+    title: "Deploy paseo and verify",
+    firstPromptPreview: "import me",
+  });
+  expect(importConfig).toEqual({
+    model: "openai-codex/gpt-5.1",
+  });
+});
+
+test("Pi import listing prefers recent parent sessions without scanning nested trees", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "paseo-pi-session-recent-limit-"));
+  const cwd = path.join(root, "repo");
+  const older = await writeNamedSession(
+    root,
+    "project",
+    "2026-06-08T00-00-00-000Z_old.jsonl",
+    [
+      sessionHeader("old-session", cwd, "2026-06-08T00:00:00.000Z"),
+      userMessage("user-old", "2026-06-08T00:00:01.000Z", "old prompt"),
+    ],
+  );
+  const newer = await writeNamedSession(
+    root,
+    "project",
+    "2026-06-09T00-00-00-000Z_new.jsonl",
+    [
+      sessionHeader("new-session", cwd, "2026-06-09T00:00:00.000Z"),
+      userMessage("user-new", "2026-06-09T00:00:01.000Z", "new prompt"),
+    ],
+  );
+  // Nested noise should never appear in the importable list.
+  await writeNamedSession(
+    root,
+    "project",
+    "noise.jsonl",
+    [
+      sessionHeader("noise-session", cwd, "2026-06-09T12:00:00.000Z"),
+      userMessage("user-noise", "2026-06-09T12:00:01.000Z", "noise prompt"),
+    ],
+    "2026-06-09T00-00-00-000Z_new",
+  );
+
+  // Ensure mtime ordering is deterministic across filesystems.
+  const { utimes } = await import("node:fs/promises");
+  await utimes(older, new Date("2026-06-08T00:00:00.000Z"), new Date("2026-06-08T00:00:00.000Z"));
+  await utimes(newer, new Date("2026-06-09T00:00:00.000Z"), new Date("2026-06-09T00:00:00.000Z"));
+
+  const sessions = await listPiImportableSessions({
+    sessionDir: path.join(root, "sessions"),
+    limit: 1,
+  });
+
+  expect(sessions).toHaveLength(1);
+  expect(sessions[0]).toMatchObject({
+    providerHandleId: newer,
+    firstPromptPreview: "new prompt",
   });
 });

--- a/packages/server/src/server/agent/providers/pi/session-descriptor.ts
+++ b/packages/server/src/server/agent/providers/pi/session-descriptor.ts
@@ -15,6 +15,14 @@ const PI_SESSION_DIR_ENV = "PI_CODING_AGENT_SESSION_DIR";
 const HEAD_BYTES = 64 * 1024;
 const TAIL_BYTES = 256 * 1024;
 const FULL_SCAN_LINE_LIMIT = 2_000;
+// Parent sessions live at <sessionsDir>/<cwdDir>/<session>.jsonl.
+// Nested <sessionsDir>/<cwdDir>/<session>/<subagent>.jsonl files are subagent
+// transcripts and must not be treated as importable parent sessions.
+const PARENT_SESSION_MAX_DEPTH = 2;
+// Overscan by mtime so cwd filters and non-session nested files still leave
+// enough valid parent sessions for the requested limit.
+const IMPORT_CANDIDATE_OVERSCAN = 40;
+const IMPORT_CANDIDATE_MIN = 400;
 
 interface PiSessionDescriptorOptions extends ListImportableSessionsOptions {
   sessionDir?: string;
@@ -54,6 +62,11 @@ interface PiSessionDescriptor {
   thinkingOptionId: string | null;
 }
 
+interface RankedSessionFile {
+  file: string;
+  mtime: Date;
+}
+
 export interface PiImportSessionConfig {
   model?: string;
   thinkingOptionId?: string;
@@ -63,16 +76,21 @@ export async function listPiImportableSessions(
   options: PiSessionDescriptorOptions = {},
 ): Promise<ImportableProviderSession[]> {
   const sessionsDir = await resolvePiSessionsDir(options);
-  const files = await walkJsonlFiles(sessionsDir);
+  const files = await walkParentSessionJsonlFiles(sessionsDir);
   const matchesCwd = options.cwd ? createRealpathAwarePathMatcher(options.cwd) : null;
   const limit = options.limit ?? 20;
+  const ranked = await rankSessionFilesByMtime(files);
+  const candidateLimit = Math.max(limit * IMPORT_CANDIDATE_OVERSCAN, IMPORT_CANDIDATE_MIN);
   const sessions: ImportableProviderSession[] = [];
 
-  for (const file of files) {
-    const session = await readPiImportableSession(file);
+  for (const entry of ranked.slice(0, candidateLimit)) {
+    const session = await readPiImportableSession(entry.file);
     if (!session) continue;
     if (matchesCwd && !matchesCwd(session.cwd)) continue;
     sessions.push(session);
+    if (sessions.length >= limit) {
+      break;
+    }
   }
 
   return sessions
@@ -162,7 +180,11 @@ function resolveConfigPath(value: string, options: { baseDir: string; homeDir: s
   return path.isAbsolute(value) ? value : path.resolve(options.baseDir, value);
 }
 
-async function walkJsonlFiles(root: string): Promise<string[]> {
+async function walkParentSessionJsonlFiles(root: string): Promise<string[]> {
+  return await walkJsonlFiles(root, 1);
+}
+
+async function walkJsonlFiles(root: string, depth: number): Promise<string[]> {
   let entries: import("node:fs").Dirent[];
   try {
     entries = await readdir(root, { withFileTypes: true });
@@ -174,12 +196,27 @@ async function walkJsonlFiles(root: string): Promise<string[]> {
     entries.map(async (entry) => {
       const entryPath = path.join(root, entry.name);
       if (entry.isDirectory()) {
-        return await walkJsonlFiles(entryPath);
+        if (depth >= PARENT_SESSION_MAX_DEPTH) {
+          return [];
+        }
+        return await walkJsonlFiles(entryPath, depth + 1);
       }
       return entry.isFile() && entry.name.endsWith(".jsonl") ? [entryPath] : [];
     }),
   );
   return files.flat();
+}
+
+async function rankSessionFilesByMtime(files: string[]): Promise<RankedSessionFile[]> {
+  const ranked = await Promise.all(
+    files.map(async (file) => {
+      const mtime = await readFileMtime(file);
+      return mtime ? { file, mtime } : null;
+    }),
+  );
+  return ranked
+    .filter((entry): entry is RankedSessionFile => entry !== null)
+    .sort((left, right) => right.mtime.getTime() - left.mtime.getTime());
 }
 
 async function readPiImportableSession(
@@ -201,14 +238,16 @@ async function readPiImportableSession(
 }
 
 async function readPiSessionDescriptor(filePath: string): Promise<PiSessionDescriptor | null> {
-  const firstLine = await readFirstLine(filePath);
-  if (!firstLine) return null;
-  const header = parseSessionHeader(firstLine);
+  // OMP may emit title/session_info lines before the session header. Scan the
+  // file head for the first type:"session" record instead of requiring line 1.
+  const headChunk = await readHeadChunk(filePath);
+  if (!headChunk) return null;
+  const header = parseSessionHeaderFromChunk(headChunk);
   if (!header) return null;
 
   const tail = await readTail(filePath).catch(() => "");
   const tailInfo = parseSessionTail(tail);
-  const headInfo = await scanSessionHead(filePath);
+  const headInfo = parseSessionHeadFromChunk(headChunk);
   const title = tailInfo.title ?? headInfo.title ?? headInfo.firstUserMessage;
   const model = tailInfo.model ?? headInfo.model;
   const thinkingOptionId = tailInfo.thinkingOptionId ?? headInfo.thinkingOptionId;
@@ -233,19 +272,64 @@ function toPiImportSessionConfig(descriptor: PiSessionDescriptor): PiImportSessi
   };
 }
 
-async function readFirstLine(filePath: string): Promise<string | null> {
+async function readHeadChunk(filePath: string): Promise<string | null> {
   const handle = await open(filePath, "r").catch(() => null);
   if (!handle) return null;
   try {
     const buffer = Buffer.alloc(HEAD_BYTES);
     const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
     if (bytesRead <= 0) return null;
-    const chunk = buffer.subarray(0, bytesRead).toString("utf8");
-    const newlineIndex = chunk.indexOf("\n");
-    return (newlineIndex === -1 ? chunk : chunk.slice(0, newlineIndex)).trim();
+    return buffer.subarray(0, bytesRead).toString("utf8");
   } finally {
     await handle.close().catch(() => undefined);
   }
+}
+
+function parseSessionHeaderFromChunk(chunk: string): PiSessionHeader | null {
+  for (const line of chunk.split(/\r?\n/u)) {
+    const header = parseSessionHeader(line.trim());
+    if (header) return header;
+  }
+  return null;
+}
+
+function parseSessionHeadFromChunk(chunk: string): PiSessionHead {
+  let title: string | null = null;
+  let firstUserMessage: string | null = null;
+  let model: string | null = null;
+  let thinkingOptionId: string | null = null;
+  let lineCount = 0;
+
+  for (const rawLine of chunk.split(/\r?\n/u)) {
+    lineCount += 1;
+    const entry = parseJsonRecord(rawLine.trim());
+    if (!entry) continue;
+
+    if (entry.type === "session_info") {
+      title = readNonEmptyString(entry.name) ?? title;
+    }
+    if (entry.type === "title") {
+      title = readNonEmptyString(entry.title) ?? title;
+    }
+
+    model = extractModel(entry) ?? model;
+    thinkingOptionId = extractThinkingOptionId(entry) ?? thinkingOptionId;
+
+    if (!firstUserMessage && entry.type === "message" && isRecord(entry.message)) {
+      if (entry.message.role === "user") {
+        firstUserMessage = extractMessageText(entry.message.content);
+      }
+    }
+
+    if (title && firstUserMessage && model && thinkingOptionId) {
+      break;
+    }
+    if (lineCount >= FULL_SCAN_LINE_LIMIT && firstUserMessage) {
+      break;
+    }
+  }
+
+  return { title, firstUserMessage, model, thinkingOptionId };
 }
 
 async function readTail(filePath: string): Promise<string> {
@@ -296,6 +380,9 @@ function parseSessionTail(tail: string): PiSessionTail {
     if (!title && entry.type === "session_info") {
       title = readNonEmptyString(entry.name);
     }
+    if (!title && entry.type === "title") {
+      title = readNonEmptyString(entry.title);
+    }
 
     if (!model) {
       model = extractModel(entry);
@@ -330,52 +417,13 @@ function parseSessionTail(tail: string): PiSessionTail {
   };
 }
 
-async function scanSessionHead(filePath: string): Promise<PiSessionHead> {
-  let content: string;
-  try {
-    content = await readFile(filePath, "utf8");
-  } catch {
-    return { title: null, firstUserMessage: null, model: null, thinkingOptionId: null };
-  }
-
-  let title: string | null = null;
-  let firstUserMessage: string | null = null;
-  let model: string | null = null;
-  let thinkingOptionId: string | null = null;
-  let lineCount = 0;
-
-  for (const rawLine of content.split(/\r?\n/u)) {
-    lineCount += 1;
-    const entry = parseJsonRecord(rawLine.trim());
-    if (!entry) continue;
-
-    if (entry.type === "session_info") {
-      title = readNonEmptyString(entry.name) ?? title;
-    }
-
-    model = extractModel(entry) ?? model;
-    thinkingOptionId = extractThinkingOptionId(entry) ?? thinkingOptionId;
-
-    if (!firstUserMessage && entry.type === "message" && isRecord(entry.message)) {
-      if (entry.message.role === "user") {
-        firstUserMessage = extractMessageText(entry.message.content);
-      }
-    }
-
-    if (title && firstUserMessage && model && thinkingOptionId) {
-      break;
-    }
-    if (lineCount >= FULL_SCAN_LINE_LIMIT && firstUserMessage) {
-      break;
-    }
-  }
-
-  return { title, firstUserMessage, model, thinkingOptionId };
-}
-
 function extractModel(entry: Record<string, unknown>): string | null {
   if (entry.type === "model_change") {
-    return buildModelId(entry.provider, entry.modelId);
+    // Pi records provider + modelId; OMP records a combined model string.
+    return (
+      buildModelId(entry.provider, entry.modelId) ??
+      readNonEmptyString(entry.model)
+    );
   }
 
   if (entry.type === "message" && isRecord(entry.message)) {


### PR DESCRIPTION
## Summary
- Stop recursive import scans of nested Pi/OMP subagent transcripts (`<session>/<subagent>.jsonl`), which can turn large OMP histories (tens of thousands of files / multi-GB) into a permanent Import UI loading state.
- Rank parent session files by mtime and only fully parse a bounded recent candidate set for the requested limit.
- Accept OMP session formats that put a `title` record before the `session` header, and OMP `model_change` payloads that store a combined `model` string.

## Test plan
- [x] `npx vitest run packages/server/src/server/agent/providers/pi/session-descriptor.test.ts` (6/6 pass)
- [x] Local repro against a large `~/.omp/agent/sessions` tree: listing 20 sessions dropped from multi-minute hang to ~tens of ms after the patch
- [ ] UI: open Import → OMP and confirm recent parent sessions appear without infinite loading
- [ ] UI: import one OMP session that starts with a `title` line and confirm model metadata still hydrates

## Notes
- Parent sessions remain at `<sessionsDir>/<cwdDir>/<session>.jsonl`.
- Nested subagent transcripts remain importable only through their parent session, which matches the intended import surface.