### PR TITLE
Fix Pi slash commands hanging after local completion

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import pino from "pino";
+import { setImmediate as waitForImmediate } from "node:timers/promises";
 import { describe, expect, onTestFinished, test } from "vitest";
 
 import type { AgentSession, AgentSessionConfig, AgentStreamEvent } from "../../agent-sdk-types.js";
@@ -53,6 +54,9 @@ function readUtf8File(pathname: string): string {
   } finally {
     closeSync(fd);
   }
+}
+async function flushTurnScheduling(): Promise<void> {
+  await waitForImmediate();
 }
 
 async function createSession(pi = new FakePi()): Promise<{
@@ -145,6 +149,13 @@ class SessionEvents {
       }
       return [];
     });
+  }
+
+  turnCompletedEvents() {
+    return this.events.filter(
+      (event): event is Extract<AgentStreamEvent, { type: "turn_completed" }> =>
+        event.type === "turn_completed",
+    );
   }
 
   nextTurnCompletion(): Promise<Extract<AgentStreamEvent, { type: "turn_completed" }>> {
@@ -884,6 +895,137 @@ describe("PiRpcAgentSession", () => {
     await expect(events.nextTurnFailure()).resolves.toMatchObject({
       error: "Pi exited",
     });
+  });
+  test("completes locally handled slash commands when agentInvoked is false", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    fakeSession.promptAck = { agentInvoked: false };
+
+    const { turnId: usageTurnId } = await session.startTurn("/usage");
+    fakeSession.emit({
+      type: "command_output",
+      text: "\u001b[38;2;138;138;138mUsage 12%\u001b[39m",
+    });
+
+    await flushTurnScheduling();
+    const usageCompletion = await events.nextTurnCompletion();
+    expect(usageCompletion).toMatchObject({ type: "turn_completed", turnId: usageTurnId });
+    expect(events.timelineAndCompletionEvents()).toEqual([
+      { type: "timeline", item: { type: "user_message", text: "/usage" } },
+      { type: "timeline", item: { type: "assistant_message", text: "Usage 12%" } },
+      { type: "turn_completed" },
+    ]);
+
+    const { turnId: helloTurnId } = await session.startTurn("hello");
+    fakeSession.finishTurn();
+    await flushTurnScheduling();
+    expect(events.turnCompletedEvents()).toHaveLength(2);
+    expect(events.turnCompletedEvents()[1]).toMatchObject({
+      type: "turn_completed",
+      turnId: helloTurnId,
+    });
+  });
+
+  test("does not synthesize completion when agentInvoked is true for slash prompts", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    fakeSession.promptAck = { agentInvoked: true };
+
+    const { turnId } = await session.startTurn("/usage");
+    await flushTurnScheduling();
+    expect(events.turnCompletedEvents()).toHaveLength(0);
+
+    fakeSession.emit({ type: "agent_start" });
+    fakeSession.finishTurn();
+    await flushTurnScheduling();
+
+    const completion = await events.nextTurnCompletion();
+    expect(completion).toMatchObject({ type: "turn_completed", turnId });
+    expect(events.turnCompletedEvents()).toHaveLength(1);
+  });
+
+  test("probes slash prompts without agentInvoked and surfaces buffered notify output", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    const { turnId } = await session.startTurn("/plan on");
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "notify-plan",
+      method: "notify",
+      message: "Plan mode enabled",
+    });
+
+    await flushTurnScheduling();
+    const completion = await events.nextTurnCompletion();
+    expect(completion).toMatchObject({ type: "turn_completed", turnId });
+    expect(events.timelineAndCompletionEvents()).toEqual([
+      { type: "timeline", item: { type: "user_message", text: "/plan on" } },
+      { type: "timeline", item: { type: "assistant_message", text: "Plan mode enabled" } },
+      { type: "turn_completed" },
+    ]);
+  });
+
+  test("does not synthesize completion when lifecycle starts before the no-turn probe", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    const { turnId } = await session.startTurn("/custom-template-cmd");
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "notify-buffered",
+      method: "notify",
+      message: "Should not appear after turn starts",
+    });
+    fakeSession.emit({ type: "agent_start" });
+
+    await flushTurnScheduling();
+    expect(events.turnCompletedEvents()).toHaveLength(0);
+    expect(events.timelineItems()).toEqual([]);
+
+    fakeSession.finishTurn();
+    await flushTurnScheduling();
+    const completion = await events.nextTurnCompletion();
+    expect(completion).toMatchObject({ type: "turn_completed", turnId });
+    expect(events.turnCompletedEvents()).toHaveLength(1);
+  });
+
+  test("fails slash turns when the no-turn getState barrier errors", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    fakeSession.getStateError = new Error("get_state timed out");
+
+    const { turnId } = await session.startTurn("/local-command on");
+    await flushTurnScheduling();
+
+    await expect(events.nextTurnFailure()).resolves.toMatchObject({
+      turnId,
+      error: "get_state timed out",
+    });
+
+    fakeSession.getStateError = null;
+    const { turnId: recoveryTurnId } = await session.startTurn("hello");
+    fakeSession.finishTurn();
+    await flushTurnScheduling();
+    await expect(events.nextTurnCompletion()).resolves.toMatchObject({
+      type: "turn_completed",
+      turnId: recoveryTurnId,
+    });
+  });
+
+  test("does not probe non-slash prompts when agentInvoked is missing", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    const { turnId } = await session.startTurn("hello");
+    await flushTurnScheduling();
+    expect(events.turnCompletedEvents()).toHaveLength(0);
+
+    fakeSession.finishTurn();
+    await flushTurnScheduling();
+    const completion = await events.nextTurnCompletion();
+    expect(completion).toMatchObject({ type: "turn_completed", turnId });
+    expect(events.turnCompletedEvents()).toHaveLength(1);
   });
 });
 

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { homedir, tmpdir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
 import type { Logger } from "pino";
+import stripAnsi from "strip-ansi";
 import { z } from "zod";
 
 import {
@@ -1064,6 +1065,9 @@ export class PiRpcAgentSession implements AgentSession {
   private activeAskUserDialog: ActiveAskUserDialog | null = null;
   private pendingCombinedAskUserResponse: PendingCombinedAskUserResponse | null = null;
   private activeTurnId: string | null = null;
+  private activeTurnStarted = false;
+  private activeNoTurnPromptText: string | null = null;
+  private readonly pendingNoTurnOutputs: Array<{ turnId: string; message: string }> = [];
   private activeAssistantMessageId: string | null = null;
   private lastKnownThinkingOptionId: string | null;
   currentLeafOverrideId: string | null | undefined;
@@ -1124,29 +1128,46 @@ export class PiRpcAgentSession implements AgentSession {
     const payload = convertPromptInput(prompt, { model: this.state.model });
     const turnId = randomUUID();
     this.activeTurnId = turnId;
+    this.activeTurnStarted = false;
+    this.clearNoTurnBuffers();
+    this.activeNoTurnPromptText = payload.text;
     this.activeAssistantMessageId = null;
+    const shouldProbeForNoTurnPrompt = this.parseSlashCommandInput(payload.text) !== null;
 
-    void this.runtimeSession.prompt(payload.text, payload.images).catch((error) => {
-      if (this.activeTurnId !== turnId) {
-        return;
-      }
-      this.activeTurnId = null;
-      if (isPiRequestAbortError(error)) {
+    void (async () => {
+      try {
+        const ack = await this.runtimeSession.prompt(payload.text, payload.images);
+        if (ack.agentInvoked === false) {
+          await this.completeNoTurnPrompt(turnId);
+          return;
+        }
+        if (ack.agentInvoked === undefined && shouldProbeForNoTurnPrompt) {
+          await this.completePromptIfHandledWithoutTurn(turnId);
+        }
+      } catch (error) {
+        if (this.activeTurnId !== turnId) {
+          return;
+        }
+        this.activeTurnId = null;
+        this.activeTurnStarted = false;
+        this.clearNoTurnBuffers();
+        if (isPiRequestAbortError(error)) {
+          this.emit({
+            type: "turn_canceled",
+            provider: PI_PROVIDER,
+            turnId,
+            reason: toDiagnosticErrorMessage(error),
+          });
+          return;
+        }
         this.emit({
-          type: "turn_canceled",
+          type: "turn_failed",
           provider: PI_PROVIDER,
           turnId,
-          reason: toDiagnosticErrorMessage(error),
+          error: toDiagnosticErrorMessage(error),
         });
-        return;
       }
-      this.emit({
-        type: "turn_failed",
-        provider: PI_PROVIDER,
-        turnId,
-        error: toDiagnosticErrorMessage(error),
-      });
-    });
+    })();
 
     return { turnId };
   }
@@ -1369,6 +1390,85 @@ export class PiRpcAgentSession implements AgentSession {
 
   private currentTurnIdForEvent(): string | undefined {
     return this.activeTurnId ?? undefined;
+  }
+
+  private async completeNoTurnPrompt(turnId: string): Promise<void> {
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    if (this.activeTurnId !== turnId || this.activeTurnStarted) {
+      return;
+    }
+    this.emitBufferedNoTurnOutputs(turnId);
+    this.completeTurn(turnId, []);
+  }
+
+  private async completePromptIfHandledWithoutTurn(turnId: string): Promise<void> {
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    let runtimeState: PiSessionState;
+    try {
+      runtimeState = await this.runtimeSession.getState();
+    } catch (error) {
+      if (this.activeTurnId === turnId && !this.activeTurnStarted) {
+        throw error;
+      }
+      return;
+    }
+    this.state = runtimeState;
+
+    if (this.activeTurnId !== turnId || this.activeTurnStarted || runtimeState.isStreaming) {
+      return;
+    }
+
+    this.emitBufferedNoTurnOutputs(turnId);
+    this.completeTurn(turnId, []);
+  }
+
+  private clearNoTurnBuffers(): void {
+    this.activeNoTurnPromptText = null;
+    this.pendingNoTurnOutputs.splice(0, this.pendingNoTurnOutputs.length);
+  }
+
+  private emitBufferedNoTurnOutputs(turnId: string): void {
+    const promptText = this.activeNoTurnPromptText;
+    const outputs = this.pendingNoTurnOutputs.filter((output) => output.turnId === turnId);
+    this.clearNoTurnBuffers();
+    if (promptText) {
+      this.emit({
+        type: "timeline",
+        provider: PI_PROVIDER,
+        turnId,
+        item: {
+          type: "user_message",
+          text: promptText,
+        },
+      });
+    }
+    for (const output of outputs) {
+      this.emit({
+        type: "timeline",
+        provider: PI_PROVIDER,
+        turnId,
+        item: {
+          type: "assistant_message",
+          text: output.message,
+        },
+      });
+    }
+  }
+
+  private recordNoTurnNotification(message: string): void {
+    this.bufferNoTurnOutput(message);
+  }
+
+  private bufferNoTurnOutput(message: string): void {
+    if (!this.activeTurnId || this.activeTurnStarted) {
+      return;
+    }
+    this.pendingNoTurnOutputs.push({ turnId: this.activeTurnId, message });
   }
 
   private parseSlashCommandInput(text: string): PiSlashCommandInvocation | null {
@@ -1613,6 +1713,7 @@ export class PiRpcAgentSession implements AgentSession {
       if (this.handleEntryCaptureMarker(message) || this.handleCommandResultMarker(message)) {
         return;
       }
+      this.recordNoTurnNotification(message);
     }
 
     if (this.respondToCombinedAskUserFollowUp(event)) {
@@ -1667,6 +1768,23 @@ export class PiRpcAgentSession implements AgentSession {
     return false;
   }
 
+  private handleCommandOutput(textValue: unknown): void {
+    const text = stripAnsi(optionalString(textValue) ?? "").trim();
+    if (!text) {
+      return;
+    }
+    if (this.activeTurnId && !this.activeTurnStarted) {
+      this.bufferNoTurnOutput(text);
+      return;
+    }
+    this.emit({
+      type: "timeline",
+      provider: PI_PROVIDER,
+      turnId: this.currentTurnIdForEvent(),
+      item: { type: "assistant_message", text },
+    });
+  }
+
   private handleRuntimeEvent(event: PiRuntimeEvent): void {
     if (event.type === "extension_ui_request") {
       this.handleExtensionUiRequest(event);
@@ -1674,6 +1792,10 @@ export class PiRpcAgentSession implements AgentSession {
     }
     if (event.type === "process_exit") {
       this.handleProcessExit(event.error);
+      return;
+    }
+    if (event.type === "command_output") {
+      this.handleCommandOutput("text" in event ? event.text : undefined);
       return;
     }
     this.handleSessionEvent(event);
@@ -1686,6 +1808,8 @@ export class PiRpcAgentSession implements AgentSession {
     }
     const turnId = this.activeTurnId;
     this.activeTurnId = null;
+    this.activeTurnStarted = false;
+    this.clearNoTurnBuffers();
     this.emit({
       type: "turn_failed",
       provider: PI_PROVIDER,
@@ -1699,6 +1823,8 @@ export class PiRpcAgentSession implements AgentSession {
 
     switch (event.type) {
       case "agent_start":
+        this.activeTurnStarted = true;
+        this.clearNoTurnBuffers();
         this.emit({
           type: "thread_started",
           provider: PI_PROVIDER,
@@ -1706,6 +1832,8 @@ export class PiRpcAgentSession implements AgentSession {
         });
         return;
       case "turn_start":
+        this.activeTurnStarted = true;
+        this.clearNoTurnBuffers();
         this.emit({
           type: "turn_started",
           provider: PI_PROVIDER,
@@ -1922,6 +2050,8 @@ export class PiRpcAgentSession implements AgentSession {
 
   private completeTurn(turnId: string | undefined, messages: PiAgentMessage[]): void {
     this.activeTurnId = null;
+    this.activeTurnStarted = false;
+    this.clearNoTurnBuffers();
     this.activeAssistantMessageId = null;
     const errorMessage = latestPiErrorMessage(messages);
     if (typeof errorMessage === "string" && errorMessage.length > 0) {

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1460,10 +1460,6 @@ export class PiRpcAgentSession implements AgentSession {
     }
   }
 
-  private recordNoTurnNotification(message: string): void {
-    this.bufferNoTurnOutput(message);
-  }
-
   private bufferNoTurnOutput(message: string): void {
     if (!this.activeTurnId || this.activeTurnStarted) {
       return;
@@ -1713,7 +1709,7 @@ export class PiRpcAgentSession implements AgentSession {
       if (this.handleEntryCaptureMarker(message) || this.handleCommandResultMarker(message)) {
         return;
       }
-      this.recordNoTurnNotification(message);
+      this.bufferNoTurnOutput(message);
     }
 
     if (this.respondToCombinedAskUserFollowUp(event)) {
@@ -1769,11 +1765,14 @@ export class PiRpcAgentSession implements AgentSession {
   }
 
   private handleCommandOutput(textValue: unknown): void {
+    if (!this.activeTurnId) {
+      return;
+    }
     const text = stripAnsi(optionalString(textValue) ?? "").trim();
     if (!text) {
       return;
     }
-    if (this.activeTurnId && !this.activeTurnStarted) {
+    if (!this.activeTurnStarted) {
       this.bufferNoTurnOutput(text);
       return;
     }
@@ -1795,7 +1794,7 @@ export class PiRpcAgentSession implements AgentSession {
       return;
     }
     if (event.type === "command_output") {
-      this.handleCommandOutput("text" in event ? event.text : undefined);
+      this.handleCommandOutput(event.text);
       return;
     }
     this.handleSessionEvent(event);

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -229,6 +229,12 @@ interface PendingPiUserMessage {
   turnId: string | undefined;
 }
 
+interface PendingLocalPrompt {
+  turnId: string;
+  text: string;
+  outputs: string[];
+}
+
 interface PendingExtensionResult {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
@@ -1065,9 +1071,7 @@ export class PiRpcAgentSession implements AgentSession {
   private activeAskUserDialog: ActiveAskUserDialog | null = null;
   private pendingCombinedAskUserResponse: PendingCombinedAskUserResponse | null = null;
   private activeTurnId: string | null = null;
-  private activeTurnStarted = false;
-  private activeNoTurnPromptText: string | null = null;
-  private readonly pendingNoTurnOutputs: Array<{ turnId: string; message: string }> = [];
+  private pendingLocalPrompt: PendingLocalPrompt | null = null;
   private activeAssistantMessageId: string | null = null;
   private lastKnownThinkingOptionId: string | null;
   currentLeafOverrideId: string | null | undefined;
@@ -1128,9 +1132,7 @@ export class PiRpcAgentSession implements AgentSession {
     const payload = convertPromptInput(prompt, { model: this.state.model });
     const turnId = randomUUID();
     this.activeTurnId = turnId;
-    this.activeTurnStarted = false;
-    this.clearNoTurnBuffers();
-    this.activeNoTurnPromptText = payload.text;
+    this.pendingLocalPrompt = { turnId, text: payload.text, outputs: [] };
     this.activeAssistantMessageId = null;
     const shouldProbeForNoTurnPrompt = this.parseSlashCommandInput(payload.text) !== null;
 
@@ -1149,8 +1151,7 @@ export class PiRpcAgentSession implements AgentSession {
           return;
         }
         this.activeTurnId = null;
-        this.activeTurnStarted = false;
-        this.clearNoTurnBuffers();
+        this.pendingLocalPrompt = null;
         if (isPiRequestAbortError(error)) {
           this.emit({
             type: "turn_canceled",
@@ -1263,6 +1264,7 @@ export class PiRpcAgentSession implements AgentSession {
     await this.runtimeSession.abort();
     if (turnId && this.activeTurnId === turnId) {
       this.activeTurnId = null;
+      this.pendingLocalPrompt = null;
       this.emit({ type: "turn_canceled", provider: PI_PROVIDER, reason: "interrupted", turnId });
     }
   }
@@ -1396,10 +1398,10 @@ export class PiRpcAgentSession implements AgentSession {
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
-    if (this.activeTurnId !== turnId || this.activeTurnStarted) {
+    if (this.activeTurnId !== turnId || this.pendingLocalPrompt?.turnId !== turnId) {
       return;
     }
-    this.emitBufferedNoTurnOutputs(turnId);
+    this.emitPendingLocalPrompt();
     this.completeTurn(turnId, []);
   }
 
@@ -1412,59 +1414,60 @@ export class PiRpcAgentSession implements AgentSession {
     try {
       runtimeState = await this.runtimeSession.getState();
     } catch (error) {
-      if (this.activeTurnId === turnId && !this.activeTurnStarted) {
+      if (this.activeTurnId === turnId && this.pendingLocalPrompt?.turnId === turnId) {
         throw error;
       }
       return;
     }
-    this.state = runtimeState;
 
-    if (this.activeTurnId !== turnId || this.activeTurnStarted || runtimeState.isStreaming) {
+    if (
+      this.activeTurnId !== turnId ||
+      this.pendingLocalPrompt?.turnId !== turnId ||
+      runtimeState.isStreaming
+    ) {
       return;
     }
+    this.state = runtimeState;
 
-    this.emitBufferedNoTurnOutputs(turnId);
+    this.emitPendingLocalPrompt();
     this.completeTurn(turnId, []);
   }
 
-  private clearNoTurnBuffers(): void {
-    this.activeNoTurnPromptText = null;
-    this.pendingNoTurnOutputs.splice(0, this.pendingNoTurnOutputs.length);
-  }
-
-  private emitBufferedNoTurnOutputs(turnId: string): void {
-    const promptText = this.activeNoTurnPromptText;
-    const outputs = this.pendingNoTurnOutputs.filter((output) => output.turnId === turnId);
-    this.clearNoTurnBuffers();
-    if (promptText) {
-      this.emit({
-        type: "timeline",
-        provider: PI_PROVIDER,
-        turnId,
-        item: {
-          type: "user_message",
-          text: promptText,
-        },
-      });
-    }
-    for (const output of outputs) {
-      this.emit({
-        type: "timeline",
-        provider: PI_PROVIDER,
-        turnId,
-        item: {
-          type: "assistant_message",
-          text: output.message,
-        },
-      });
-    }
-  }
-
-  private bufferNoTurnOutput(message: string): void {
-    if (!this.activeTurnId || this.activeTurnStarted) {
+  private emitPendingLocalPrompt(): void {
+    const prompt = this.pendingLocalPrompt;
+    this.pendingLocalPrompt = null;
+    if (!prompt) {
       return;
     }
-    this.pendingNoTurnOutputs.push({ turnId: this.activeTurnId, message });
+    if (prompt.text) {
+      this.emit({
+        type: "timeline",
+        provider: PI_PROVIDER,
+        turnId: prompt.turnId,
+        item: {
+          type: "user_message",
+          text: prompt.text,
+        },
+      });
+    }
+    for (const output of prompt.outputs) {
+      this.emit({
+        type: "timeline",
+        provider: PI_PROVIDER,
+        turnId: prompt.turnId,
+        item: {
+          type: "assistant_message",
+          text: output,
+        },
+      });
+    }
+  }
+
+  private bufferLocalPromptOutput(message: string): void {
+    if (!this.pendingLocalPrompt) {
+      return;
+    }
+    this.pendingLocalPrompt.outputs.push(message);
   }
 
   private parseSlashCommandInput(text: string): PiSlashCommandInvocation | null {
@@ -1709,7 +1712,7 @@ export class PiRpcAgentSession implements AgentSession {
       if (this.handleEntryCaptureMarker(message) || this.handleCommandResultMarker(message)) {
         return;
       }
-      this.bufferNoTurnOutput(message);
+      this.bufferLocalPromptOutput(message);
     }
 
     if (this.respondToCombinedAskUserFollowUp(event)) {
@@ -1772,8 +1775,8 @@ export class PiRpcAgentSession implements AgentSession {
     if (!text) {
       return;
     }
-    if (!this.activeTurnStarted) {
-      this.bufferNoTurnOutput(text);
+    if (this.pendingLocalPrompt) {
+      this.bufferLocalPromptOutput(text);
       return;
     }
     this.emit({
@@ -1807,8 +1810,7 @@ export class PiRpcAgentSession implements AgentSession {
     }
     const turnId = this.activeTurnId;
     this.activeTurnId = null;
-    this.activeTurnStarted = false;
-    this.clearNoTurnBuffers();
+    this.pendingLocalPrompt = null;
     this.emit({
       type: "turn_failed",
       provider: PI_PROVIDER,
@@ -1822,8 +1824,7 @@ export class PiRpcAgentSession implements AgentSession {
 
     switch (event.type) {
       case "agent_start":
-        this.activeTurnStarted = true;
-        this.clearNoTurnBuffers();
+        this.pendingLocalPrompt = null;
         this.emit({
           type: "thread_started",
           provider: PI_PROVIDER,
@@ -1831,8 +1832,7 @@ export class PiRpcAgentSession implements AgentSession {
         });
         return;
       case "turn_start":
-        this.activeTurnStarted = true;
-        this.clearNoTurnBuffers();
+        this.pendingLocalPrompt = null;
         this.emit({
           type: "turn_started",
           provider: PI_PROVIDER,
@@ -2049,8 +2049,7 @@ export class PiRpcAgentSession implements AgentSession {
 
   private completeTurn(turnId: string | undefined, messages: PiAgentMessage[]): void {
     this.activeTurnId = null;
-    this.activeTurnStarted = false;
-    this.clearNoTurnBuffers();
+    this.pendingLocalPrompt = null;
     this.activeAssistantMessageId = null;
     const errorMessage = latestPiErrorMessage(messages);
     if (typeof errorMessage === "string" && errorMessage.length > 0) {

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.ts
@@ -15,6 +15,7 @@ import type {
   PiAgentMessage,
   PiCommandsRpcType,
   PiModel,
+  PiPromptAck,
   PiRpcCommand,
   PiRpcResponse,
   PiRpcSlashCommand,
@@ -136,8 +137,19 @@ class PiCliRuntimeSession implements PiRuntimeSession {
   async prompt(
     message: string,
     images?: Array<{ type: "image"; data: string; mimeType: string }>,
-  ): Promise<void> {
-    await this.request({ type: "prompt", message, ...(images?.length ? { images } : {}) });
+  ): Promise<PiPromptAck> {
+    const data = await this.request({
+      type: "prompt",
+      message,
+      ...(images?.length ? { images } : {}),
+    });
+    if (typeof data === "object" && data !== null && !Array.isArray(data)) {
+      const { agentInvoked } = data as Record<string, unknown>;
+      if (typeof agentInvoked === "boolean") {
+        return { agentInvoked };
+      }
+    }
+    return {};
   }
 
   async compact(customInstructions?: string): Promise<void> {

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -5,6 +5,9 @@ export interface PiImageContent {
   data: string;
   mimeType: string;
 }
+export interface PiPromptAck {
+  agentInvoked?: boolean;
+}
 
 export interface PiTextContent {
   type: "text";
@@ -180,6 +183,10 @@ export type PiRuntimeEvent =
       id: string;
       method: string;
       [key: string]: unknown;
+    }
+  | {
+      type: "command_output";
+      text?: string;
     }
   | {
       type: "process_exit";

--- a/packages/server/src/server/agent/providers/pi/runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/runtime.ts
@@ -1,6 +1,7 @@
 import type {
   PiAgentMessage,
   PiModel,
+  PiPromptAck,
   PiRpcSlashCommand,
   PiRuntimeEvent,
   PiSessionState,
@@ -38,7 +39,7 @@ export interface PiRuntimeSession {
   prompt(
     message: string,
     images?: Array<{ type: "image"; data: string; mimeType: string }>,
-  ): Promise<void>;
+  ): Promise<PiPromptAck>;
   compact(customInstructions?: string): Promise<void>;
   setAutoCompaction(enabled: boolean): Promise<void>;
   abort(): Promise<void>;

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -7,6 +7,7 @@ import type {
 import type {
   PiAgentMessage,
   PiModel,
+  PiPromptAck,
   PiRpcSlashCommand,
   PiRuntimeEvent,
   PiSessionState,
@@ -73,6 +74,8 @@ export class FakePiSession implements PiRuntimeSession {
   commands: PiRpcSlashCommand[] = [];
   compactError: Error | null = null;
   emitCompactEnd = true;
+  getStateError: Error | null = null;
+  promptAck: PiPromptAck = {};
   state: PiSessionState;
 
   private readonly subscribers = new Set<(event: PiRuntimeEvent) => void>();
@@ -104,7 +107,7 @@ export class FakePiSession implements PiRuntimeSession {
   async prompt(
     message: string,
     images?: Array<{ type: "image"; data: string; mimeType: string }>,
-  ): Promise<void> {
+  ): Promise<PiPromptAck> {
     this.prompts.push({ message, imageCount: images?.length ?? 0 });
     const heldPrompt = this.nextHeldPrompt;
     if (heldPrompt) {
@@ -120,6 +123,7 @@ export class FakePiSession implements PiRuntimeSession {
     }
     this.handleTreeNavigationCommand(message);
     this.handleEntryCaptureCommand(message);
+    return this.promptAck;
   }
 
   holdNextPrompt(): void {
@@ -166,6 +170,9 @@ export class FakePiSession implements PiRuntimeSession {
   }
 
   async getState(): Promise<PiSessionState> {
+    if (this.getStateError) {
+      throw this.getStateError;
+    }
     return this.state;
   }
 


### PR DESCRIPTION
### Linked issue

None — reproduced directly against Pi RPC; no matching open issue describes this local-completion hang.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Pi slash commands handled entirely inside the CLI could leave Paseo showing a running turn forever because no model lifecycle ever started and Pi therefore emitted no terminal turn event.

This change recognizes locally completed prompt acknowledgements, preserves compatibility with Pi binaries that omit that correlation through an ordered state probe, surfaces local command output in the timeline with ANSI removed, and completes the Paseo turn. The pending local-prompt state is owned as one lifecycle value and cleared on turn start, failure, exit, interruption, or completion.

### How did you verify it

- Reproduced with Pi 0.73.1 in RPC mode using an ephemeral local extension command and `--no-session`: Pi emitted the command notification and a successful prompt response, but no `agent_start`, `turn_start`, or `agent_end`. That leaves the old Paseo path without a completion signal.
- `npx vitest run packages/server/src/server/agent/providers/pi --bail=1` — 5 files / 74 tests passed, including local completion, output, compatibility probe, lifecycle race, failure recovery, and ordinary-prompt coverage.
- `npm run typecheck`
- `npm run lint`
- `npm run format`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [x] UI changes include screenshots or video for every affected platform — not applicable; no UI changes
- [x] Tests added or updated where it made sense