### PR TITLE
Render provider images from paths with spaces

### DIFF
--- a/packages/app/src/attachments/utils.test.ts
+++ b/packages/app/src/attachments/utils.test.ts
@@ -34,6 +34,10 @@ describe("fileUriToPath", () => {
   it("converts Windows drive-letter file URIs back to paths", () => {
     expect(fileUriToPath("file:///C:/Users/file.txt")).toBe("C:/Users/file.txt");
   });
+
+  it("converts host-based file URIs back to UNC paths", () => {
+    expect(fileUriToPath("file://server/share/shot%231.png")).toBe("\\\\server\\share\\shot#1.png");
+  });
 });
 
 describe("localFileSourceToPath", () => {

--- a/packages/app/src/attachments/utils.ts
+++ b/packages/app/src/attachments/utils.ts
@@ -162,7 +162,11 @@ export function fileUriToPath(uri: string): string {
   if (!uri.startsWith("file://")) {
     return uri;
   }
-  const decodedPath = decodeFilePathSource(uri.replace(/^file:\/\//, ""));
+  const fileSource = uri.slice("file://".length);
+  const decodedPath = decodeFilePathSource(fileSource);
+  if (!fileSource.startsWith("/")) {
+    return `\\\\${decodedPath.replace(/\//g, "\\")}`;
+  }
   return normalizeWindowsDrivePath(decodedPath.replace(/^\/([A-Za-z]:[\\/])/, "$1"));
 }
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -3515,7 +3515,7 @@ describe("Codex app-server provider", () => {
     });
   });
 
-  test("emits imageView thread items as assistant markdown images using the path", () => {
+  test("emits imageView paths with spaces as valid assistant markdown images", () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];
     session.subscribe((event) => events.push(event));
@@ -3535,7 +3535,7 @@ describe("Codex app-server provider", () => {
         turnId: "test-turn",
         item: {
           type: "assistant_message",
-          text: "![Image](/tmp/paseo image.png)",
+          text: "![Image](file:///tmp/paseo%20image.png)",
         },
       },
     ]);

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -3542,8 +3542,8 @@ describe("Codex app-server provider", () => {
   });
 
   test.each([
-    ["savedPath", { savedPath: "/tmp/generated-camel.png" }, "/tmp/generated-camel.png"],
-    ["saved_path", { saved_path: "/tmp/generated-snake.png" }, "/tmp/generated-snake.png"],
+    ["savedPath", { savedPath: "/tmp/generated-camel.png" }, "file:///tmp/generated-camel.png"],
+    ["saved_path", { saved_path: "/tmp/generated-snake.png" }, "file:///tmp/generated-snake.png"],
   ])(
     "emits imageGeneration thread items with %s as assistant markdown images",
     (_fieldName, imageFields, expectedPath) => {

--- a/packages/server/src/server/agent/providers/provider-image-output.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.test.ts
@@ -63,6 +63,17 @@ describe("isProviderImageMarkdown", () => {
     expect(markdown).toBe("![Image](file:///tmp/screenshot%231%3Fdraft.png)");
   });
 
+  test.each([
+    ["UNC", "\\\\server\\share\\shot#1.png", "file://server/share/shot%231.png"],
+    [
+      "extended UNC",
+      "\\\\?\\UNC\\server\\share\\shot?draft.png",
+      "file://server/share/shot%3Fdraft.png",
+    ],
+  ])("encodes %s image paths as file URIs", (_label, imagePath, expectedSource) => {
+    expect(renderImageMarkdown(imagePath)).toBe(`![Image](${expectedSource})`);
+  });
+
   test("rejects user-authored markdown that is not a materialized attachment", () => {
     // No content hash — a hand-written path, not something the writer produced.
     expect(isProviderImageMarkdown("![diagram](./paseo-attachments/notes.png)")).toBe(false);

--- a/packages/server/src/server/agent/providers/provider-image-output.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.test.ts
@@ -49,6 +49,14 @@ describe("isProviderImageMarkdown", () => {
     expect(isProviderImageMarkdown(markdown)).toBe(true);
   });
 
+  test("emits POSIX file paths with spaces as valid file URI markdown", () => {
+    const markdown = renderImageMarkdown("/home/user/Projects/Project With Spaces/screenshot.png");
+
+    expect(markdown).toBe(
+      "![Image](file:///home/user/Projects/Project%20With%20Spaces/screenshot.png)",
+    );
+  });
+
   test("rejects user-authored markdown that is not a materialized attachment", () => {
     // No content hash — a hand-written path, not something the writer produced.
     expect(isProviderImageMarkdown("![diagram](./paseo-attachments/notes.png)")).toBe(false);

--- a/packages/server/src/server/agent/providers/provider-image-output.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.test.ts
@@ -57,6 +57,12 @@ describe("isProviderImageMarkdown", () => {
     );
   });
 
+  test("encodes URI-significant characters in POSIX file paths", () => {
+    const markdown = renderImageMarkdown("/tmp/screenshot#1?draft.png");
+
+    expect(markdown).toBe("![Image](file:///tmp/screenshot%231%3Fdraft.png)");
+  });
+
   test("rejects user-authored markdown that is not a materialized attachment", () => {
     // No content hash — a hand-written path, not something the writer produced.
     expect(isProviderImageMarkdown("![diagram](./paseo-attachments/notes.png)")).toBe(false);

--- a/packages/server/src/server/agent/providers/provider-image-output.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.test.ts
@@ -63,6 +63,12 @@ describe("isProviderImageMarkdown", () => {
     expect(markdown).toBe("![Image](file:///tmp/screenshot%231%3Fdraft.png)");
   });
 
+  test("preserves double-leading slashes in POSIX file paths", () => {
+    const markdown = renderImageMarkdown("//tmp/screenshot#1.png");
+
+    expect(markdown).toBe("![Image](file:////tmp/screenshot%231.png)");
+  });
+
   test.each([
     ["UNC", "\\\\server\\share\\shot#1.png", "file://server/share/shot%231.png"],
     [

--- a/packages/server/src/server/agent/providers/provider-image-output.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.ts
@@ -136,6 +136,7 @@ function encodeFilePath(value: string): string {
 }
 
 function windowsFileUri(value: string): string | null {
+  const isWindowsNetworkPath = value.startsWith("\\\\");
   let normalizedPath = value.replace(/\\/g, "/");
   if (/^\/\/\?\/UNC\//i.test(normalizedPath)) {
     normalizedPath = `//${normalizedPath.slice(8)}`;
@@ -147,7 +148,7 @@ function windowsFileUri(value: string): string | null {
     const drive = normalizedPath.slice(0, 2);
     return `file:///${drive}${encodeFilePath(normalizedPath.slice(2))}`;
   }
-  if (normalizedPath.startsWith("//")) {
+  if (isWindowsNetworkPath && normalizedPath.startsWith("//")) {
     return `file:${encodeFilePath(normalizedPath)}`;
   }
   return null;

--- a/packages/server/src/server/agent/providers/provider-image-output.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.ts
@@ -128,9 +128,21 @@ function escapeMarkdownImageAlt(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/\]/g, "\\]");
 }
 
+function encodeFilePath(value: string): string {
+  return value
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
 function markdownImageSource(value: string): string {
   if (/^[A-Za-z]:[\\/]/.test(value)) {
-    return `file:///${value.replace(/\\/g, "/")}`;
+    const normalizedPath = value.replace(/\\/g, "/");
+    const drive = normalizedPath.slice(0, 2);
+    return `file:///${drive}${encodeFilePath(normalizedPath.slice(2))}`;
+  }
+  if (value.startsWith("/") && /\s/.test(value)) {
+    return `file://${encodeFilePath(value)}`;
   }
   return value;
 }

--- a/packages/server/src/server/agent/providers/provider-image-output.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.ts
@@ -135,11 +135,28 @@ function encodeFilePath(value: string): string {
     .join("/");
 }
 
-function markdownImageSource(value: string): string {
-  if (/^[A-Za-z]:[\\/]/.test(value)) {
-    const normalizedPath = value.replace(/\\/g, "/");
+function windowsFileUri(value: string): string | null {
+  let normalizedPath = value.replace(/\\/g, "/");
+  if (/^\/\/\?\/UNC\//i.test(normalizedPath)) {
+    normalizedPath = `//${normalizedPath.slice(8)}`;
+  } else if (/^\/\/\?\/[A-Za-z]:\//.test(normalizedPath)) {
+    normalizedPath = normalizedPath.slice(4);
+  }
+
+  if (/^[A-Za-z]:\//.test(normalizedPath)) {
     const drive = normalizedPath.slice(0, 2);
     return `file:///${drive}${encodeFilePath(normalizedPath.slice(2))}`;
+  }
+  if (normalizedPath.startsWith("//")) {
+    return `file:${encodeFilePath(normalizedPath)}`;
+  }
+  return null;
+}
+
+function markdownImageSource(value: string): string {
+  const windowsUri = windowsFileUri(value);
+  if (windowsUri) {
+    return windowsUri;
   }
   if (value.startsWith("/")) {
     return `file://${encodeFilePath(value)}`;

--- a/packages/server/src/server/agent/providers/provider-image-output.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.ts
@@ -141,7 +141,7 @@ function markdownImageSource(value: string): string {
     const drive = normalizedPath.slice(0, 2);
     return `file:///${drive}${encodeFilePath(normalizedPath.slice(2))}`;
   }
-  if (value.startsWith("/") && /\s/.test(value)) {
+  if (value.startsWith("/")) {
     return `file://${encodeFilePath(value)}`;
   }
   return value;


### PR DESCRIPTION
Local provider images now render inline when their absolute file paths contain spaces. Raw spaces made the Markdown parser treat the image syntax as assistant text; spaced paths are now emitted as encoded file URIs that the client already resolves.

The provider audit found that both adapters which project local image paths use this shared renderer. The remaining adapters do not send local result paths through Markdown, so they do not share this failure mode.

## Verification

- `npx vitest run packages/server/src/server/agent/providers/provider-image-output.test.ts packages/server/src/server/agent/providers/codex-app-server-agent.test.ts packages/server/src/server/agent/providers/claude/agent.image-rendering.test.ts --bail=1` (105 tests)
- `npm run typecheck`
- `npm run lint -- packages/server/src/server/agent/providers/provider-image-output.ts packages/server/src/server/agent/providers/provider-image-output.test.ts packages/server/src/server/agent/providers/codex-app-server-agent.test.ts`

## Before merge

- Smoke an inline image from a Linux desktop workspace whose path contains spaces; the server behavior is covered, but the desktop renderer is not exercised by these focused tests.

## Risk surface

- Absolute POSIX image paths containing whitespace now travel as encoded `file://` URIs. Windows file URI segments are encoded by the same boundary.