### PR TITLE
fix(app): warn before opening large files

### DIFF
--- a/packages/app/e2e/large-file-warning.spec.ts
+++ b/packages/app/e2e/large-file-warning.spec.ts
@@ -4,12 +4,17 @@ import { gotoWorkspace } from "./helpers/launcher";
 import { seedWorkspace, type SeededWorkspace } from "./helpers/seed-client";
 
 let workspace: SeededWorkspace;
+const largeTextLines = Array.from(
+  { length: 1025 },
+  (_, index) => `line ${index.toString().padStart(4, "0")} ${"x".repeat(1013)}\n`,
+);
+const largeTextFileContent = largeTextLines.join("");
 
 test.beforeAll(async () => {
   workspace = await seedWorkspace({
     repoPrefix: "large-file-warning-",
     repo: {
-      files: [{ path: "large.bin", content: "\0".repeat(1024 * 1024 + 1) }],
+      files: [{ path: "large.txt", content: largeTextFileContent }],
     },
   });
 });
@@ -23,17 +28,22 @@ test("cancels or confirms opening a large file", async ({ page }) => {
   await openFileExplorer(page);
 
   const dialogPromise = page.waitForEvent("dialog");
-  const openPromise = openFileFromExplorer(page, "large.bin");
+  const openPromise = openFileFromExplorer(page, "large.txt");
   const dialog = await dialogPromise;
 
   expect(dialog.message()).toContain("Open large file?");
-  expect(dialog.message()).toContain("large.bin is 1.0 MB");
+  expect(dialog.message()).toContain("large.txt is 1.0 MB");
   await dialog.dismiss();
   await openPromise;
-  await expect(page.getByTestId("workspace-tab-file_large.bin")).toHaveCount(0);
+  await expect(page.getByTestId("workspace-tab-file_large.txt")).toHaveCount(0);
 
   page.once("dialog", (reopenDialog) => reopenDialog.accept());
-  await openFileFromExplorer(page, "large.bin");
-  await expect(page.getByTestId("workspace-tab-file_large.bin")).toBeVisible();
-  await expect(page.getByText("Binary preview unavailable", { exact: true })).toBeVisible();
+  await openFileFromExplorer(page, "large.txt");
+  await expect(page.getByTestId("workspace-tab-file_large.txt")).toBeVisible();
+  await expect(
+    page
+      .getByTestId("workspace-file-pane")
+      .getByText(/line 0000/)
+      .first(),
+  ).toBeVisible();
 });

--- a/packages/app/e2e/large-file-warning.spec.ts
+++ b/packages/app/e2e/large-file-warning.spec.ts
@@ -1,11 +1,13 @@
 import { expect, test } from "./fixtures";
+import { openSettings } from "./helpers/app";
 import { openFileExplorer, openFileFromExplorer } from "./helpers/file-explorer";
 import { gotoWorkspace } from "./helpers/launcher";
 import { seedWorkspace, type SeededWorkspace } from "./helpers/seed-client";
+import { clickSettingsBackToWorkspace } from "./helpers/settings";
 
 let workspace: SeededWorkspace;
 const largeTextLines = Array.from(
-  { length: 1025 },
+  { length: 5121 },
   (_, index) => `line ${index.toString().padStart(4, "0")} ${"x".repeat(1013)}\n`,
 );
 const largeTextFileContent = largeTextLines.join("");
@@ -31,7 +33,7 @@ test("cancels or opens a large file from the inline warning", async ({ page }) =
   await expect(page.getByTestId("workspace-tab-file_large.txt")).toBeVisible();
   const warning = page.getByTestId("large-file-warning");
   await expect(warning).toContainText("Open large file?");
-  await expect(warning).toContainText("large.txt is 1.0 MB");
+  await expect(warning).toContainText("large.txt is 5.0 MB");
 
   await page.getByTestId("large-file-warning-cancel").click();
   await expect(page.getByTestId("workspace-tab-file_large.txt")).toHaveCount(0);
@@ -40,6 +42,29 @@ test("cancels or opens a large file from the inline warning", async ({ page }) =
   await expect(page.getByTestId("large-file-warning")).toBeVisible();
   await page.getByTestId("large-file-warning-open").click();
   await expect(page.getByTestId("workspace-tab-file_large.txt")).toBeVisible();
+  await expect(
+    page
+      .getByTestId("workspace-file-pane")
+      .getByText(/line 0000/)
+      .first(),
+  ).toBeVisible();
+});
+
+test("uses the configured large-file warning threshold", async ({ page }) => {
+  await gotoWorkspace(page, workspace.workspaceId);
+  await openSettings(page);
+
+  const thresholdInput = page.getByTestId("large-file-warning-threshold-input");
+  await expect(thresholdInput).toHaveValue("5");
+  await thresholdInput.fill("6");
+  await thresholdInput.press("Enter");
+  await expect(thresholdInput).toHaveValue("6");
+
+  await clickSettingsBackToWorkspace(page);
+  await openFileExplorer(page);
+  await openFileFromExplorer(page, "large.txt");
+
+  await expect(page.getByTestId("large-file-warning")).toHaveCount(0);
   await expect(
     page
       .getByTestId("workspace-file-pane")

--- a/packages/app/e2e/large-file-warning.spec.ts
+++ b/packages/app/e2e/large-file-warning.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "./fixtures";
+import { openFileExplorer, openFileFromExplorer } from "./helpers/file-explorer";
+import { gotoWorkspace } from "./helpers/launcher";
+import { seedWorkspace, type SeededWorkspace } from "./helpers/seed-client";
+
+let workspace: SeededWorkspace;
+
+test.beforeAll(async () => {
+  workspace = await seedWorkspace({
+    repoPrefix: "large-file-warning-",
+    repo: {
+      files: [{ path: "large.bin", content: "\0".repeat(1024 * 1024 + 1) }],
+    },
+  });
+});
+
+test.afterAll(async () => {
+  await workspace?.cleanup();
+});
+
+test("cancels or confirms opening a large file", async ({ page }) => {
+  await gotoWorkspace(page, workspace.workspaceId);
+  await openFileExplorer(page);
+
+  const dialogPromise = page.waitForEvent("dialog");
+  const openPromise = openFileFromExplorer(page, "large.bin");
+  const dialog = await dialogPromise;
+
+  expect(dialog.message()).toContain("Open large file?");
+  expect(dialog.message()).toContain("large.bin is 1.0 MB");
+  await dialog.dismiss();
+  await openPromise;
+  await expect(page.getByTestId("workspace-tab-file_large.bin")).toHaveCount(0);
+
+  page.once("dialog", (reopenDialog) => reopenDialog.accept());
+  await openFileFromExplorer(page, "large.bin");
+  await expect(page.getByTestId("workspace-tab-file_large.bin")).toBeVisible();
+  await expect(page.getByText("Binary preview unavailable", { exact: true })).toBeVisible();
+});

--- a/packages/app/e2e/large-file-warning.spec.ts
+++ b/packages/app/e2e/large-file-warning.spec.ts
@@ -23,22 +23,22 @@ test.afterAll(async () => {
   await workspace?.cleanup();
 });
 
-test("cancels or confirms opening a large file", async ({ page }) => {
+test("cancels or opens a large file from the inline warning", async ({ page }) => {
   await gotoWorkspace(page, workspace.workspaceId);
   await openFileExplorer(page);
 
-  const dialogPromise = page.waitForEvent("dialog");
-  const openPromise = openFileFromExplorer(page, "large.txt");
-  const dialog = await dialogPromise;
+  await openFileFromExplorer(page, "large.txt");
+  await expect(page.getByTestId("workspace-tab-file_large.txt")).toBeVisible();
+  const warning = page.getByTestId("large-file-warning");
+  await expect(warning).toContainText("Open large file?");
+  await expect(warning).toContainText("large.txt is 1.0 MB");
 
-  expect(dialog.message()).toContain("Open large file?");
-  expect(dialog.message()).toContain("large.txt is 1.0 MB");
-  await dialog.dismiss();
-  await openPromise;
+  await page.getByTestId("large-file-warning-cancel").click();
   await expect(page.getByTestId("workspace-tab-file_large.txt")).toHaveCount(0);
 
-  page.once("dialog", (reopenDialog) => reopenDialog.accept());
   await openFileFromExplorer(page, "large.txt");
+  await expect(page.getByTestId("large-file-warning")).toBeVisible();
+  await page.getByTestId("large-file-warning-open").click();
   await expect(page.getByTestId("workspace-tab-file_large.txt")).toBeVisible();
   await expect(
     page

--- a/packages/app/e2e/large-file-warning.spec.ts
+++ b/packages/app/e2e/large-file-warning.spec.ts
@@ -48,6 +48,12 @@ test("cancels or opens a large file from the inline warning", async ({ page }) =
       .getByText(/line 0000/)
       .first(),
   ).toBeVisible();
+
+  await page.keyboard.press("Alt+Shift+W");
+  await expect(page.getByTestId("workspace-tab-file_large.txt")).toHaveCount(0);
+
+  await openFileFromExplorer(page, "large.txt");
+  await expect(page.getByTestId("large-file-warning")).toBeVisible();
 });
 
 test("uses the configured large-file warning threshold", async ({ page }) => {

--- a/packages/app/src/components/file-pane-enabled.test.ts
+++ b/packages/app/src/components/file-pane-enabled.test.ts
@@ -3,26 +3,57 @@ import { isFileQueryEnabled } from "./file-pane-enabled";
 
 describe("isFileQueryEnabled", () => {
   it("reads when there is a target, the tab is active, and the app is visible", () => {
-    expect(isFileQueryEnabled({ hasReadTarget: true, isTabActive: true, isAppVisible: true })).toBe(
-      true,
-    );
+    expect(
+      isFileQueryEnabled({
+        hasReadTarget: true,
+        isTabActive: true,
+        isAppVisible: true,
+        areAppSettingsLoaded: true,
+      }),
+    ).toBe(true);
   });
 
   it("does not read while the tab is hidden", () => {
     expect(
-      isFileQueryEnabled({ hasReadTarget: true, isTabActive: false, isAppVisible: true }),
+      isFileQueryEnabled({
+        hasReadTarget: true,
+        isTabActive: false,
+        isAppVisible: true,
+        areAppSettingsLoaded: true,
+      }),
     ).toBe(false);
   });
 
   it("does not read while the app is backgrounded", () => {
     expect(
-      isFileQueryEnabled({ hasReadTarget: true, isTabActive: true, isAppVisible: false }),
+      isFileQueryEnabled({
+        hasReadTarget: true,
+        isTabActive: true,
+        isAppVisible: false,
+        areAppSettingsLoaded: true,
+      }),
     ).toBe(false);
   });
 
   it("does not read without a resolved file target", () => {
     expect(
-      isFileQueryEnabled({ hasReadTarget: false, isTabActive: true, isAppVisible: true }),
+      isFileQueryEnabled({
+        hasReadTarget: false,
+        isTabActive: true,
+        isAppVisible: true,
+        areAppSettingsLoaded: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not read before app settings load", () => {
+    expect(
+      isFileQueryEnabled({
+        hasReadTarget: true,
+        isTabActive: true,
+        isAppVisible: true,
+        areAppSettingsLoaded: false,
+      }),
     ).toBe(false);
   });
 });

--- a/packages/app/src/components/file-pane-enabled.ts
+++ b/packages/app/src/components/file-pane-enabled.ts
@@ -12,6 +12,9 @@ export function isFileQueryEnabled(input: {
   hasReadTarget: boolean;
   isTabActive: boolean;
   isAppVisible: boolean;
+  areAppSettingsLoaded: boolean;
 }): boolean {
-  return input.hasReadTarget && input.isTabActive && input.isAppVisible;
+  return (
+    input.hasReadTarget && input.isTabActive && input.isAppVisible && input.areAppSettingsLoaded
+  );
 }

--- a/packages/app/src/components/file-pane-large-file.test.ts
+++ b/packages/app/src/components/file-pane-large-file.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   findFileSizeFromParentDirectory,
   getFileNameFromFilePath,
-  getParentDirectoryFromFilePath,
   LARGE_FILE_OPEN_WARNING_THRESHOLD_BYTES,
   shouldWarnBeforeOpeningFile,
   type FileSizeLookupClient,
@@ -15,14 +14,13 @@ describe("large file open warning helpers", () => {
   });
 
   it.each([
-    ["app.tsx", ".", "app.tsx"],
-    ["src/app.tsx", "src", "app.tsx"],
-    ["src/nested/app.tsx", "src/nested", "app.tsx"],
-    ["/repo/src/app.tsx", "/repo/src", "app.tsx"],
-    ["C:/repo/src/app.tsx", "C:/repo/src", "app.tsx"],
-    ["C:/app.tsx", "C:/", "app.tsx"],
-  ])("splits %s into parent and filename", (path, parent, fileName) => {
-    expect(getParentDirectoryFromFilePath(path)).toBe(parent);
+    ["app.tsx", "app.tsx"],
+    ["src/app.tsx", "app.tsx"],
+    ["src/nested/app.tsx", "app.tsx"],
+    ["/repo/src/app.tsx", "app.tsx"],
+    ["C:/repo/src/app.tsx", "app.tsx"],
+    ["C:/app.tsx", "app.tsx"],
+  ])("extracts the filename from %s", (path, fileName) => {
     expect(getFileNameFromFilePath(path)).toBe(fileName);
   });
 
@@ -34,7 +32,7 @@ describe("large file open warning helpers", () => {
         return {
           entries: [
             { kind: "directory", name: "other", size: 0 },
-            { kind: "file", name: "large.log", size: 2 * 1024 * 1024 },
+            { kind: "file", name: "app.tsx", size: 2 * 1024 * 1024 },
           ],
         };
       },
@@ -44,9 +42,9 @@ describe("large file open warning helpers", () => {
       findFileSizeFromParentDirectory({
         client,
         cwd: "/repo",
-        path: "logs/large.log",
+        path: "C:/app.tsx",
       }),
     ).resolves.toBe(2 * 1024 * 1024);
-    expect(calls).toEqual([{ cwd: "/repo", path: "logs" }]);
+    expect(calls).toEqual([{ cwd: "/repo", path: "C:/" }]);
   });
 });

--- a/packages/app/src/components/file-pane-large-file.test.ts
+++ b/packages/app/src/components/file-pane-large-file.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  findFileSizeFromParentDirectory,
+  getFileNameFromFilePath,
+  getParentDirectoryFromFilePath,
+  LARGE_FILE_OPEN_WARNING_THRESHOLD_BYTES,
+  shouldWarnBeforeOpeningFile,
+  type FileSizeLookupClient,
+} from "@/components/file-pane-large-file";
+
+describe("large file open warning helpers", () => {
+  it("warns only when the file is over the threshold", () => {
+    expect(shouldWarnBeforeOpeningFile(LARGE_FILE_OPEN_WARNING_THRESHOLD_BYTES)).toBe(false);
+    expect(shouldWarnBeforeOpeningFile(LARGE_FILE_OPEN_WARNING_THRESHOLD_BYTES + 1)).toBe(true);
+  });
+
+  it.each([
+    ["app.tsx", ".", "app.tsx"],
+    ["src/app.tsx", "src", "app.tsx"],
+    ["src/nested/app.tsx", "src/nested", "app.tsx"],
+    ["/repo/src/app.tsx", "/repo/src", "app.tsx"],
+    ["C:/repo/src/app.tsx", "C:/repo/src", "app.tsx"],
+    ["C:/app.tsx", "C:/", "app.tsx"],
+  ])("splits %s into parent and filename", (path, parent, fileName) => {
+    expect(getParentDirectoryFromFilePath(path)).toBe(parent);
+    expect(getFileNameFromFilePath(path)).toBe(fileName);
+  });
+
+  it("finds the target file size from its parent directory listing", async () => {
+    const calls: Array<{ cwd: string; path: string }> = [];
+    const client: FileSizeLookupClient = {
+      async listDirectory(cwd, path) {
+        calls.push({ cwd, path });
+        return {
+          entries: [
+            { kind: "directory", name: "other", size: 0 },
+            { kind: "file", name: "large.log", size: 2 * 1024 * 1024 },
+          ],
+        };
+      },
+    };
+
+    await expect(
+      findFileSizeFromParentDirectory({
+        client,
+        cwd: "/repo",
+        path: "logs/large.log",
+      }),
+    ).resolves.toBe(2 * 1024 * 1024);
+    expect(calls).toEqual([{ cwd: "/repo", path: "logs" }]);
+  });
+});

--- a/packages/app/src/components/file-pane-large-file.test.ts
+++ b/packages/app/src/components/file-pane-large-file.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "vitest";
 import {
   findFileSizeFromParentDirectory,
   getFileNameFromFilePath,
-  LARGE_FILE_OPEN_WARNING_THRESHOLD_BYTES,
   shouldWarnBeforeOpeningFile,
   type FileSizeLookupClient,
 } from "@/components/file-pane-large-file";
 
 describe("large file open warning helpers", () => {
   it("warns only when the file is over the threshold", () => {
-    expect(shouldWarnBeforeOpeningFile(LARGE_FILE_OPEN_WARNING_THRESHOLD_BYTES)).toBe(false);
-    expect(shouldWarnBeforeOpeningFile(LARGE_FILE_OPEN_WARNING_THRESHOLD_BYTES + 1)).toBe(true);
+    const thresholdBytes = 5 * 1024 * 1024;
+    expect(shouldWarnBeforeOpeningFile(thresholdBytes, thresholdBytes)).toBe(false);
+    expect(shouldWarnBeforeOpeningFile(thresholdBytes + 1, thresholdBytes)).toBe(true);
   });
 
   it.each([

--- a/packages/app/src/components/file-pane-large-file.test.ts
+++ b/packages/app/src/components/file-pane-large-file.test.ts
@@ -47,4 +47,18 @@ describe("large file open warning helpers", () => {
     ).resolves.toBe(2 * 1024 * 1024);
     expect(calls).toEqual([{ cwd: "/repo", path: "C:/" }]);
   });
+
+  it("finds the target file size when path casing differs from the directory entry", async () => {
+    const client: FileSizeLookupClient = {
+      async listDirectory() {
+        return {
+          entries: [{ kind: "file", name: "Large.txt", size: 6 * 1024 * 1024 }],
+        };
+      },
+    };
+
+    await expect(
+      findFileSizeFromParentDirectory({ client, cwd: "/repo", path: "large.txt" }),
+    ).resolves.toBe(6 * 1024 * 1024);
+  });
 });

--- a/packages/app/src/components/file-pane-large-file.ts
+++ b/packages/app/src/components/file-pane-large-file.ts
@@ -35,7 +35,7 @@ export function getFileNameFromFilePath(filePath: string): string {
   return slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
 }
 
-export function getParentDirectoryFromFilePath(filePath: string): string {
+function getParentDirectoryFromFilePath(filePath: string): string {
   const normalized = trimTrailingSeparators(filePath.replace(/\\/g, "/"));
   const slashIndex = normalized.lastIndexOf("/");
   if (slashIndex < 0) {

--- a/packages/app/src/components/file-pane-large-file.ts
+++ b/packages/app/src/components/file-pane-large-file.ts
@@ -62,9 +62,10 @@ export async function findFileSizeFromParentDirectory({
   }
 
   const directory = await client.listDirectory(cwd, getParentDirectoryFromFilePath(path));
-  const entry = directory.entries.find(
-    (candidate) => candidate.kind === "file" && candidate.name === fileName,
-  );
+  const files = directory.entries.filter((candidate) => candidate.kind === "file");
+  const entry =
+    files.find((candidate) => candidate.name === fileName) ??
+    files.find((candidate) => candidate.name.toLowerCase() === fileName.toLowerCase());
   return entry?.size ?? null;
 }
 

--- a/packages/app/src/components/file-pane-large-file.ts
+++ b/packages/app/src/components/file-pane-large-file.ts
@@ -1,0 +1,78 @@
+export const LARGE_FILE_OPEN_WARNING_THRESHOLD_BYTES = 1024 * 1024;
+
+export interface FileSizeLookupEntry {
+  name: string;
+  kind: "file" | "directory";
+  size: number;
+}
+
+export interface FileSizeLookupClient {
+  listDirectory(
+    cwd: string,
+    path: string,
+  ): Promise<{
+    entries: FileSizeLookupEntry[];
+  }>;
+}
+
+export function formatFileSize({ size }: { size: number }): string {
+  if (size < 1024) {
+    return `${size} B`;
+  }
+  if (size < 1024 * 1024) {
+    return `${(size / 1024).toFixed(1)} KB`;
+  }
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function shouldWarnBeforeOpeningFile(size: number): boolean {
+  return size > LARGE_FILE_OPEN_WARNING_THRESHOLD_BYTES;
+}
+
+export function getFileNameFromFilePath(filePath: string): string {
+  const normalized = trimTrailingSeparators(filePath.replace(/\\/g, "/"));
+  const slashIndex = normalized.lastIndexOf("/");
+  return slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+}
+
+export function getParentDirectoryFromFilePath(filePath: string): string {
+  const normalized = trimTrailingSeparators(filePath.replace(/\\/g, "/"));
+  const slashIndex = normalized.lastIndexOf("/");
+  if (slashIndex < 0) {
+    return ".";
+  }
+  if (slashIndex === 0) {
+    return "/";
+  }
+
+  const parent = normalized.slice(0, slashIndex);
+  return /^[A-Za-z]:$/.test(parent) ? `${parent}/` : parent;
+}
+
+export async function findFileSizeFromParentDirectory({
+  client,
+  cwd,
+  path,
+}: {
+  client: FileSizeLookupClient;
+  cwd: string;
+  path: string;
+}): Promise<number | null> {
+  const fileName = getFileNameFromFilePath(path);
+  if (!fileName) {
+    return null;
+  }
+
+  const directory = await client.listDirectory(cwd, getParentDirectoryFromFilePath(path));
+  const entry = directory.entries.find(
+    (candidate) => candidate.kind === "file" && candidate.name === fileName,
+  );
+  return entry?.size ?? null;
+}
+
+function trimTrailingSeparators(value: string): string {
+  if (value === "/" || /^[A-Za-z]:\/?$/.test(value)) {
+    return value;
+  }
+  return value.replace(/\/+$/, "");
+}

--- a/packages/app/src/components/file-pane-large-file.ts
+++ b/packages/app/src/components/file-pane-large-file.ts
@@ -1,5 +1,3 @@
-export const LARGE_FILE_OPEN_WARNING_THRESHOLD_BYTES = 1024 * 1024;
-
 export interface FileSizeLookupEntry {
   name: string;
   kind: "file" | "directory";
@@ -25,8 +23,8 @@ export function formatFileSize({ size }: { size: number }): string {
   return `${(size / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export function shouldWarnBeforeOpeningFile(size: number): boolean {
-  return size > LARGE_FILE_OPEN_WARNING_THRESHOLD_BYTES;
+export function shouldWarnBeforeOpeningFile(size: number, thresholdBytes: number): boolean {
+  return size > thresholdBytes;
 }
 
 export function getFileNameFromFilePath(filePath: string): string {

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { FileReadResult } from "@getpaseo/client/internal/daemon-client";
 import {
@@ -68,8 +68,6 @@ interface FileLineSelection {
   lineEnd: number;
 }
 
-const approvedLargeFileOpenKeys = new Set<string>();
-
 interface LargeFileOpenWarning {
   approvalKey: string;
   fileName: string;
@@ -129,12 +127,14 @@ async function getLargeFileOpenWarningIfNeeded({
   cwd,
   path,
   thresholdBytes,
+  approvedLargeFileOpenKey,
 }: {
   client: FileSizeLookupClient;
   serverId: string;
   cwd: string;
   path: string;
   thresholdBytes: number;
+  approvedLargeFileOpenKey: string | null;
 }): Promise<LargeFileOpenWarning | null> {
   let size: number | null = null;
   try {
@@ -147,7 +147,7 @@ async function getLargeFileOpenWarningIfNeeded({
   }
 
   const approvalKey = `${serverId}\0${cwd}\0${path}`;
-  if (approvedLargeFileOpenKeys.has(approvalKey)) {
+  if (approvedLargeFileOpenKey === approvalKey) {
     return null;
   }
 
@@ -470,6 +470,7 @@ export function FilePane({
     (settings) => settings.largeFileWarningThresholdMb,
   );
   const largeFileWarningThresholdBytes = largeFileWarningThresholdMb * 1024 * 1024;
+  const [approvedLargeFileOpenKey, setApprovedLargeFileOpenKey] = useState<string | null>(null);
   const normalizedWorkspaceRoot = useMemo(() => workspaceRoot.trim(), [workspaceRoot]);
   const normalizedFilePath = useMemo(() => trimNonEmpty(location.path), [location.path]);
   const readTarget = useMemo(
@@ -496,6 +497,7 @@ export function FilePane({
       readTarget?.cwd ?? null,
       readTarget?.path ?? null,
       largeFileWarningThresholdBytes,
+      approvedLargeFileOpenKey,
     ],
     enabled: isFileQueryEnabled({
       hasReadTarget: Boolean(client && readTarget),
@@ -518,6 +520,7 @@ export function FilePane({
           cwd: readTarget.cwd,
           path: readTarget.path,
           thresholdBytes: largeFileWarningThresholdBytes,
+          approvedLargeFileOpenKey,
         });
         if (largeFileWarning) {
           return { file: null, imageAttachment: null, error: null, largeFileWarning };
@@ -545,15 +548,13 @@ export function FilePane({
   });
   const imagePreviewUri = useAttachmentPreviewUrl(query.data?.imageAttachment ?? null);
   const largeFileWarning = query.data?.largeFileWarning ?? null;
-  const refetchFile = query.refetch;
 
   const openLargeFile = useCallback(() => {
     if (!largeFileWarning) {
       return;
     }
-    approvedLargeFileOpenKeys.add(largeFileWarning.approvalKey);
-    void refetchFile();
-  }, [largeFileWarning, refetchFile]);
+    setApprovedLargeFileOpenKey(largeFileWarning.approvalKey);
+  }, [largeFileWarning]);
 
   return (
     <View style={styles.container} testID="workspace-file-pane">

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -28,6 +28,7 @@ import { resolveFilePreviewReadTarget } from "@/file-explorer/preview-target";
 import type { WorkspaceFileLocation } from "@/workspace/file-open";
 import { useRetainedPanelActive } from "@/components/retained-panel";
 import { useAppVisible } from "@/hooks/use-app-visible";
+import { useSettings } from "@/hooks/use-settings";
 import { isFileQueryEnabled } from "@/components/file-pane-enabled";
 import {
   findFileSizeFromParentDirectory,
@@ -127,11 +128,13 @@ async function getLargeFileOpenWarningIfNeeded({
   serverId,
   cwd,
   path,
+  thresholdBytes,
 }: {
   client: FileSizeLookupClient;
   serverId: string;
   cwd: string;
   path: string;
+  thresholdBytes: number;
 }): Promise<LargeFileOpenWarning | null> {
   let size: number | null = null;
   try {
@@ -139,7 +142,7 @@ async function getLargeFileOpenWarningIfNeeded({
   } catch {
     return null;
   }
-  if (size === null || !shouldWarnBeforeOpeningFile(size)) {
+  if (size === null || !shouldWarnBeforeOpeningFile(size, thresholdBytes)) {
     return null;
   }
 
@@ -463,6 +466,10 @@ export function FilePane({
   const isMobile = useIsCompactFormFactor();
 
   const client = useSessionStore((state) => state.sessions[serverId]?.client ?? null);
+  const largeFileWarningThresholdMb = useSettings(
+    (settings) => settings.largeFileWarningThresholdMb,
+  );
+  const largeFileWarningThresholdBytes = largeFileWarningThresholdMb * 1024 * 1024;
   const normalizedWorkspaceRoot = useMemo(() => workspaceRoot.trim(), [workspaceRoot]);
   const normalizedFilePath = useMemo(() => trimNonEmpty(location.path), [location.path]);
   const readTarget = useMemo(
@@ -483,7 +490,13 @@ export function FilePane({
   const isAppVisible = useAppVisible();
 
   const query = useQuery({
-    queryKey: ["workspaceFile", serverId, readTarget?.cwd ?? null, readTarget?.path ?? null],
+    queryKey: [
+      "workspaceFile",
+      serverId,
+      readTarget?.cwd ?? null,
+      readTarget?.path ?? null,
+      largeFileWarningThresholdBytes,
+    ],
     enabled: isFileQueryEnabled({
       hasReadTarget: Boolean(client && readTarget),
       isTabActive: isActive,
@@ -504,6 +517,7 @@ export function FilePane({
           serverId,
           cwd: readTarget.cwd,
           path: readTarget.path,
+          thresholdBytes: largeFileWarningThresholdBytes,
         });
         if (largeFileWarning) {
           return { file: null, imageAttachment: null, error: null, largeFileWarning };

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -411,10 +411,12 @@ export function FilePane({
   serverId,
   workspaceRoot,
   location,
+  onLargeFileOpenCancel,
 }: {
   serverId: string;
   workspaceRoot: string;
   location: WorkspaceFileLocation;
+  onLargeFileOpenCancel: () => void;
 }) {
   const { t } = useTranslation();
   const isMobile = useIsCompactFormFactor();
@@ -452,6 +454,7 @@ export function FilePane({
           file: null as ExplorerFile | null,
           imageAttachment: null,
           error: t("workspace.terminal.hostDisconnected"),
+          cancelled: false,
         };
       }
       try {
@@ -469,7 +472,8 @@ export function FilePane({
           },
         });
         if (!confirmed) {
-          return { file: null, imageAttachment: null, error: null };
+          onLargeFileOpenCancel();
+          return { file: null, imageAttachment: null, error: null, cancelled: true };
         }
 
         const file = await client.readFile(readTarget.cwd, readTarget.path);
@@ -478,16 +482,18 @@ export function FilePane({
           file: preview.file,
           imageAttachment: preview.imageAttachment,
           error: null,
+          cancelled: false,
         };
       } catch (error) {
         return {
           file: null,
           imageAttachment: null,
           error: error instanceof Error ? error.message : t("panels.file.failedToLoad"),
+          cancelled: false,
         };
       }
     },
-    staleTime: 5_000,
+    staleTime: (fileQuery) => (fileQuery.state.data?.cancelled ? 0 : 5_000),
     refetchOnMount: true,
   });
   const imagePreviewUri = useAttachmentPreviewUrl(query.data?.imageAttachment ?? null);

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -29,6 +29,14 @@ import type { WorkspaceFileLocation } from "@/workspace/file-open";
 import { useRetainedPanelActive } from "@/components/retained-panel";
 import { useAppVisible } from "@/hooks/use-app-visible";
 import { isFileQueryEnabled } from "@/components/file-pane-enabled";
+import {
+  findFileSizeFromParentDirectory,
+  formatFileSize,
+  getFileNameFromFilePath,
+  shouldWarnBeforeOpeningFile,
+  type FileSizeLookupClient,
+} from "@/components/file-pane-large-file";
+import { confirmDialog } from "@/utils/confirm-dialog";
 
 interface CodeLineProps {
   tokens: HighlightToken[];
@@ -58,15 +66,7 @@ interface FileLineSelection {
   lineEnd: number;
 }
 
-function formatFileSize({ size }: { size: number }): string {
-  if (size < 1024) {
-    return `${size} B`;
-  }
-  if (size < 1024 * 1024) {
-    return `${(size / 1024).toFixed(1)} KB`;
-  }
-  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
-}
+const approvedLargeFileOpenKeys = new Set<string>();
 
 async function createFilePanePreview(file: FileReadResult | null): Promise<{
   file: ExplorerFile | null;
@@ -113,6 +113,54 @@ function clampLineSelection(input: {
     input.lineEnd && input.lineEnd >= input.lineStart ? input.lineEnd : input.lineStart;
   const lineEnd = Math.min(Math.floor(rawLineEnd), input.lineCount);
   return { lineStart, lineEnd: Math.max(lineStart, lineEnd) };
+}
+
+async function confirmLargeFileOpenIfNeeded({
+  client,
+  serverId,
+  cwd,
+  path,
+  labels,
+}: {
+  client: FileSizeLookupClient;
+  serverId: string;
+  cwd: string;
+  path: string;
+  labels: {
+    title: string;
+    message: (input: { fileName: string; size: string }) => string;
+    confirmLabel: string;
+    cancelLabel: string;
+  };
+}): Promise<boolean> {
+  let size: number | null = null;
+  try {
+    size = await findFileSizeFromParentDirectory({ client, cwd, path });
+  } catch {
+    return true;
+  }
+  if (size === null || !shouldWarnBeforeOpeningFile(size)) {
+    return true;
+  }
+
+  const approvalKey = `${serverId}\0${cwd}\0${path}`;
+  if (approvedLargeFileOpenKeys.has(approvalKey)) {
+    return true;
+  }
+
+  const confirmed = await confirmDialog({
+    title: labels.title,
+    message: labels.message({
+      fileName: getFileNameFromFilePath(path),
+      size: formatFileSize({ size }),
+    }),
+    confirmLabel: labels.confirmLabel,
+    cancelLabel: labels.cancelLabel,
+  });
+  if (confirmed) {
+    approvedLargeFileOpenKeys.add(approvalKey);
+  }
+  return confirmed;
 }
 
 const CodeLine = React.memo(function CodeLine({
@@ -402,10 +450,28 @@ export function FilePane({
       if (!client || !readTarget) {
         return {
           file: null as ExplorerFile | null,
+          imageAttachment: null,
           error: t("workspace.terminal.hostDisconnected"),
         };
       }
       try {
+        const confirmed = await confirmLargeFileOpenIfNeeded({
+          client,
+          serverId,
+          cwd: readTarget.cwd,
+          path: readTarget.path,
+          labels: {
+            title: t("panels.file.largeFileWarningTitle"),
+            message: ({ fileName, size }) =>
+              t("panels.file.largeFileWarningMessage", { fileName, size }),
+            confirmLabel: t("panels.file.largeFileWarningOpen"),
+            cancelLabel: t("panels.file.largeFileWarningCancel"),
+          },
+        });
+        if (!confirmed) {
+          return { file: null, imageAttachment: null, error: null };
+        }
+
         const file = await client.readFile(readTarget.cwd, readTarget.path);
         const preview = await createFilePanePreview(file);
         return {

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { FileReadResult } from "@getpaseo/client/internal/daemon-client";
 import {
@@ -36,7 +36,8 @@ import {
   shouldWarnBeforeOpeningFile,
   type FileSizeLookupClient,
 } from "@/components/file-pane-large-file";
-import { confirmDialog } from "@/utils/confirm-dialog";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 
 interface CodeLineProps {
   tokens: HighlightToken[];
@@ -67,6 +68,12 @@ interface FileLineSelection {
 }
 
 const approvedLargeFileOpenKeys = new Set<string>();
+
+interface LargeFileOpenWarning {
+  approvalKey: string;
+  fileName: string;
+  size: string;
+}
 
 async function createFilePanePreview(file: FileReadResult | null): Promise<{
   file: ExplorerFile | null;
@@ -115,52 +122,37 @@ function clampLineSelection(input: {
   return { lineStart, lineEnd: Math.max(lineStart, lineEnd) };
 }
 
-async function confirmLargeFileOpenIfNeeded({
+async function getLargeFileOpenWarningIfNeeded({
   client,
   serverId,
   cwd,
   path,
-  labels,
 }: {
   client: FileSizeLookupClient;
   serverId: string;
   cwd: string;
   path: string;
-  labels: {
-    title: string;
-    message: (input: { fileName: string; size: string }) => string;
-    confirmLabel: string;
-    cancelLabel: string;
-  };
-}): Promise<boolean> {
+}): Promise<LargeFileOpenWarning | null> {
   let size: number | null = null;
   try {
     size = await findFileSizeFromParentDirectory({ client, cwd, path });
   } catch {
-    return true;
+    return null;
   }
   if (size === null || !shouldWarnBeforeOpeningFile(size)) {
-    return true;
+    return null;
   }
 
   const approvalKey = `${serverId}\0${cwd}\0${path}`;
   if (approvedLargeFileOpenKeys.has(approvalKey)) {
-    return true;
+    return null;
   }
 
-  const confirmed = await confirmDialog({
-    title: labels.title,
-    message: labels.message({
-      fileName: getFileNameFromFilePath(path),
-      size: formatFileSize({ size }),
-    }),
-    confirmLabel: labels.confirmLabel,
-    cancelLabel: labels.cancelLabel,
-  });
-  if (confirmed) {
-    approvedLargeFileOpenKeys.add(approvalKey);
-  }
-  return confirmed;
+  return {
+    approvalKey,
+    fileName: getFileNameFromFilePath(path),
+    size: formatFileSize({ size }),
+  };
 }
 
 const CodeLine = React.memo(function CodeLine({
@@ -407,6 +399,55 @@ function FilePreviewBody({
   );
 }
 
+function LargeFileWarning({
+  warning,
+  isOpening,
+  onOpen,
+  onCancel,
+}: {
+  warning: LargeFileOpenWarning;
+  isOpening: boolean;
+  onOpen: () => void;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.largeFileWarningContainer}>
+      <View style={styles.largeFileWarningContent}>
+        <Alert
+          testID="large-file-warning"
+          variant="warning"
+          title={t("panels.file.largeFileWarningTitle")}
+          description={t("panels.file.largeFileWarningMessage", {
+            fileName: warning.fileName,
+            size: warning.size,
+          })}
+        >
+          <Button
+            testID="large-file-warning-open"
+            variant="outline"
+            size="sm"
+            loading={isOpening}
+            onPress={onOpen}
+          >
+            {t("panels.file.largeFileWarningOpen")}
+          </Button>
+          <Button
+            testID="large-file-warning-cancel"
+            variant="ghost"
+            size="sm"
+            disabled={isOpening}
+            onPress={onCancel}
+          >
+            {t("panels.file.largeFileWarningCancel")}
+          </Button>
+        </Alert>
+      </View>
+    </View>
+  );
+}
+
 export function FilePane({
   serverId,
   workspaceRoot,
@@ -454,26 +495,18 @@ export function FilePane({
           file: null as ExplorerFile | null,
           imageAttachment: null,
           error: t("workspace.terminal.hostDisconnected"),
-          cancelled: false,
+          largeFileWarning: null,
         };
       }
       try {
-        const confirmed = await confirmLargeFileOpenIfNeeded({
+        const largeFileWarning = await getLargeFileOpenWarningIfNeeded({
           client,
           serverId,
           cwd: readTarget.cwd,
           path: readTarget.path,
-          labels: {
-            title: t("panels.file.largeFileWarningTitle"),
-            message: ({ fileName, size }) =>
-              t("panels.file.largeFileWarningMessage", { fileName, size }),
-            confirmLabel: t("panels.file.largeFileWarningOpen"),
-            cancelLabel: t("panels.file.largeFileWarningCancel"),
-          },
         });
-        if (!confirmed) {
-          onLargeFileOpenCancel();
-          return { file: null, imageAttachment: null, error: null, cancelled: true };
+        if (largeFileWarning) {
+          return { file: null, imageAttachment: null, error: null, largeFileWarning };
         }
 
         const file = await client.readFile(readTarget.cwd, readTarget.path);
@@ -482,21 +515,31 @@ export function FilePane({
           file: preview.file,
           imageAttachment: preview.imageAttachment,
           error: null,
-          cancelled: false,
+          largeFileWarning: null,
         };
       } catch (error) {
         return {
           file: null,
           imageAttachment: null,
           error: error instanceof Error ? error.message : t("panels.file.failedToLoad"),
-          cancelled: false,
+          largeFileWarning: null,
         };
       }
     },
-    staleTime: (fileQuery) => (fileQuery.state.data?.cancelled ? 0 : 5_000),
+    staleTime: 5_000,
     refetchOnMount: true,
   });
   const imagePreviewUri = useAttachmentPreviewUrl(query.data?.imageAttachment ?? null);
+  const largeFileWarning = query.data?.largeFileWarning ?? null;
+  const refetchFile = query.refetch;
+
+  const openLargeFile = useCallback(() => {
+    if (!largeFileWarning) {
+      return;
+    }
+    approvedLargeFileOpenKeys.add(largeFileWarning.approvalKey);
+    void refetchFile();
+  }, [largeFileWarning, refetchFile]);
 
   return (
     <View style={styles.container} testID="workspace-file-pane">
@@ -506,13 +549,22 @@ export function FilePane({
         </View>
       ) : null}
 
-      <FilePreviewBody
-        preview={query.data?.file ?? null}
-        isLoading={query.isFetching}
-        isMobile={isMobile}
-        location={location}
-        imagePreviewUri={imagePreviewUri}
-      />
+      {largeFileWarning ? (
+        <LargeFileWarning
+          warning={largeFileWarning}
+          isOpening={query.isFetching}
+          onOpen={openLargeFile}
+          onCancel={onLargeFileOpenCancel}
+        />
+      ) : (
+        <FilePreviewBody
+          preview={query.data?.file ?? null}
+          isLoading={query.isFetching}
+          isMobile={isMobile}
+          location={location}
+          imagePreviewUri={imagePreviewUri}
+        />
+      )}
     </View>
   );
 }
@@ -528,6 +580,16 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     justifyContent: "center",
     padding: theme.spacing[4],
+  },
+  largeFileWarningContainer: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: theme.spacing[4],
+  },
+  largeFileWarningContent: {
+    width: "100%",
+    maxWidth: 480,
   },
   loadingText: {
     marginTop: theme.spacing[2],

--- a/packages/app/src/components/file-pane.tsx
+++ b/packages/app/src/components/file-pane.tsx
@@ -28,7 +28,7 @@ import { resolveFilePreviewReadTarget } from "@/file-explorer/preview-target";
 import type { WorkspaceFileLocation } from "@/workspace/file-open";
 import { useRetainedPanelActive } from "@/components/retained-panel";
 import { useAppVisible } from "@/hooks/use-app-visible";
-import { useSettings } from "@/hooks/use-settings";
+import { useAppSettings } from "@/hooks/use-settings";
 import { isFileQueryEnabled } from "@/components/file-pane-enabled";
 import {
   findFileSizeFromParentDirectory,
@@ -466,9 +466,8 @@ export function FilePane({
   const isMobile = useIsCompactFormFactor();
 
   const client = useSessionStore((state) => state.sessions[serverId]?.client ?? null);
-  const largeFileWarningThresholdMb = useSettings(
-    (settings) => settings.largeFileWarningThresholdMb,
-  );
+  const { settings: appSettings, isLoading: areAppSettingsLoading } = useAppSettings();
+  const largeFileWarningThresholdMb = appSettings.largeFileWarningThresholdMb;
   const largeFileWarningThresholdBytes = largeFileWarningThresholdMb * 1024 * 1024;
   const [approvedLargeFileOpenKey, setApprovedLargeFileOpenKey] = useState<string | null>(null);
   const normalizedWorkspaceRoot = useMemo(() => workspaceRoot.trim(), [workspaceRoot]);
@@ -503,6 +502,7 @@ export function FilePane({
       hasReadTarget: Boolean(client && readTarget),
       isTabActive: isActive,
       isAppVisible,
+      areAppSettingsLoaded: !areAppSettingsLoading,
     }),
     queryFn: async () => {
       if (!client || !readTarget) {

--- a/packages/app/src/hooks/use-settings/index.ts
+++ b/packages/app/src/hooks/use-settings/index.ts
@@ -16,18 +16,22 @@ import {
   DEFAULT_APP_SETTINGS,
   DEFAULT_CLIENT_SETTINGS,
   DEFAULT_CODE_FONT_SIZE,
+  DEFAULT_LARGE_FILE_WARNING_THRESHOLD_MB,
   DEFAULT_TERMINAL_SCROLLBACK_LINES,
   DEFAULT_UI_FONT_SIZE,
   MAX_CODE_FONT_SIZE,
+  MAX_LARGE_FILE_WARNING_THRESHOLD_MB,
   MAX_TERMINAL_SCROLLBACK_LINES,
   MAX_UI_FONT_SIZE,
   MIN_CODE_FONT_SIZE,
+  MIN_LARGE_FILE_WARNING_THRESHOLD_MB,
   MIN_TERMINAL_SCROLLBACK_LINES,
   MIN_UI_FONT_SIZE,
   loadAppSettingsFromStorage as loadAppSettingsFromStoragePure,
   loadSettingsFromStorage as loadSettingsFromStoragePure,
   normalizeAppSettings,
   parseClampedFontSize,
+  parseLargeFileWarningThresholdMb,
   parseTerminalScrollbackLines,
   sanitizeFontFamily,
   saveAppSettings as saveAppSettingsPure,
@@ -47,15 +51,19 @@ export {
   DEFAULT_APP_SETTINGS,
   DEFAULT_CLIENT_SETTINGS,
   DEFAULT_CODE_FONT_SIZE,
+  DEFAULT_LARGE_FILE_WARNING_THRESHOLD_MB,
   DEFAULT_TERMINAL_SCROLLBACK_LINES,
   DEFAULT_UI_FONT_SIZE,
   MAX_CODE_FONT_SIZE,
+  MAX_LARGE_FILE_WARNING_THRESHOLD_MB,
   MAX_TERMINAL_SCROLLBACK_LINES,
   MAX_UI_FONT_SIZE,
   MIN_CODE_FONT_SIZE,
+  MIN_LARGE_FILE_WARNING_THRESHOLD_MB,
   MIN_TERMINAL_SCROLLBACK_LINES,
   MIN_UI_FONT_SIZE,
   parseClampedFontSize,
+  parseLargeFileWarningThresholdMb,
   parseTerminalScrollbackLines,
   sanitizeFontFamily,
 };
@@ -166,6 +174,9 @@ export function useSettings<TSelected>(
       }
       if (updates.terminalScrollbackLines !== undefined) {
         appUpdates.terminalScrollbackLines = updates.terminalScrollbackLines;
+      }
+      if (updates.largeFileWarningThresholdMb !== undefined) {
+        appUpdates.largeFileWarningThresholdMb = updates.largeFileWarningThresholdMb;
       }
       if (updates.uiFontFamily !== undefined) {
         appUpdates.uiFontFamily = updates.uiFontFamily;

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -6,10 +6,12 @@ import {
   DEFAULT_APP_SETTINGS,
   DEFAULT_CLIENT_SETTINGS,
   DEFAULT_CODE_FONT_SIZE,
+  DEFAULT_LARGE_FILE_WARNING_THRESHOLD_MB,
   DEFAULT_UI_FONT_SIZE,
   loadAppSettingsFromStorage,
   loadSettingsFromStorage,
   parseClampedFontSize,
+  parseLargeFileWarningThresholdMb,
   parseTerminalScrollbackLines,
   saveAppSettings,
   type SettingsDeps,
@@ -80,6 +82,18 @@ describe("loadAppSettingsFromStorage", () => {
     const result = await loadAppSettingsFromStorage(deps);
 
     expect(result.terminalScrollbackLines).toBe(42_000);
+  });
+
+  it("loads a configured large-file warning threshold", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ largeFileWarningThresholdMb: 12 }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.largeFileWarningThresholdMb).toBe(12);
   });
 
   it("loads configured workspace title source from app settings", async () => {
@@ -310,6 +324,16 @@ describe("parseTerminalScrollbackLines", () => {
   it("clamps negative values to the minimum and rejects non-numeric strings", () => {
     expect(parseTerminalScrollbackLines("-10")).toBe(0);
     expect(parseTerminalScrollbackLines("abc")).toBeNull();
+  });
+});
+
+describe("parseLargeFileWarningThresholdMb", () => {
+  it("defaults to 5 MB and clamps configured values", () => {
+    expect(DEFAULT_LARGE_FILE_WARNING_THRESHOLD_MB).toBe(5);
+    expect(parseLargeFileWarningThresholdMb("12")).toBe(12);
+    expect(parseLargeFileWarningThresholdMb(0)).toBe(1);
+    expect(parseLargeFileWarningThresholdMb(2048)).toBe(1024);
+    expect(parseLargeFileWarningThresholdMb("abc")).toBeNull();
   });
 });
 

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -21,6 +21,9 @@ const VALID_TOOL_CALL_DETAIL_LEVELS = new Set<ToolCallDetailLevel>(["overview", 
 export const DEFAULT_TERMINAL_SCROLLBACK_LINES = 10_000;
 export const MIN_TERMINAL_SCROLLBACK_LINES = 0;
 export const MAX_TERMINAL_SCROLLBACK_LINES = 1_000_000;
+export const DEFAULT_LARGE_FILE_WARNING_THRESHOLD_MB = 5;
+export const MIN_LARGE_FILE_WARNING_THRESHOLD_MB = 1;
+export const MAX_LARGE_FILE_WARNING_THRESHOLD_MB = 1024;
 export const DEFAULT_UI_FONT_SIZE = 16; // == FONT_SIZE.base
 export const MIN_UI_FONT_SIZE = 11;
 export const MAX_UI_FONT_SIZE = 24;
@@ -35,6 +38,7 @@ export interface AppSettings {
   sendBehavior: SendBehavior;
   serviceUrlBehavior: ServiceUrlBehavior;
   terminalScrollbackLines: number;
+  largeFileWarningThresholdMb: number;
   uiFontFamily: string; // "" = platform default UI stack
   monoFontFamily: string; // "" = platform default mono stack
   uiFontSize: number; // clamped px, default 16
@@ -58,6 +62,7 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   sendBehavior: "interrupt",
   serviceUrlBehavior: "ask",
   terminalScrollbackLines: DEFAULT_TERMINAL_SCROLLBACK_LINES,
+  largeFileWarningThresholdMb: DEFAULT_LARGE_FILE_WARNING_THRESHOLD_MB,
   uiFontFamily: "",
   monoFontFamily: "",
   uiFontSize: DEFAULT_UI_FONT_SIZE,
@@ -208,6 +213,12 @@ function pickAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
   if (terminalScrollbackLines !== null) {
     result.terminalScrollbackLines = terminalScrollbackLines;
   }
+  const largeFileWarningThresholdMb = parseLargeFileWarningThresholdMb(
+    stored.largeFileWarningThresholdMb,
+  );
+  if (largeFileWarningThresholdMb !== null) {
+    result.largeFileWarningThresholdMb = largeFileWarningThresholdMb;
+  }
   const uiFontFamily = sanitizeFontFamily(stored.uiFontFamily);
   if (uiFontFamily !== null) {
     result.uiFontFamily = uiFontFamily;
@@ -271,6 +282,13 @@ export function parseTerminalScrollbackLines(value: unknown): number | null {
     MAX_TERMINAL_SCROLLBACK_LINES,
     Math.max(MIN_TERMINAL_SCROLLBACK_LINES, Math.floor(numericValue)),
   );
+}
+
+export function parseLargeFileWarningThresholdMb(value: unknown): number | null {
+  return parseClampedFontSize(value, {
+    min: MIN_LARGE_FILE_WARNING_THRESHOLD_MB,
+    max: MAX_LARGE_FILE_WARNING_THRESHOLD_MB,
+  });
 }
 
 export function parseClampedFontSize(

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1386,6 +1386,11 @@ export const ar: TranslationResources = {
       binaryPreviewUnavailable: "المعاينة الثنائية غير متاحة",
       failedToLoad: "فشل تحميل الملف",
       failedToLoadPreview: "فشل تحميل معاينة الملف",
+      largeFileWarningTitle: "فتح ملف كبير؟",
+      largeFileWarningMessage:
+        "{{fileName}} حجمه {{size}}. قد يؤدي فتحه إلى جعل واجهة المستخدم غير مستقرة.",
+      largeFileWarningOpen: "فتح",
+      largeFileWarningCancel: "إلغاء",
     },
   },
   toolCallDetails: {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1531,6 +1531,11 @@ export const ar: TranslationResources = {
         description: "يتم الاحتفاظ بالخطوط في المخزن المؤقت الطرفي المدمج",
         accessibilityLabel: "خطوط التمرير Terminal",
       },
+      largeFileWarning: {
+        label: "تحذير الملفات الكبيرة",
+        description: "التحذير قبل فتح الملفات التي تتجاوز هذا الحجم",
+        accessibilityLabel: "حد تحذير الملفات الكبيرة بالميغابايت",
+      },
       autoExpandReasoning: {
         label: "عرض التفكير دائماً",
         description: "إظهار تفكير الوكيل وخطوات الاستدلال بشكل كامل بشكل افتراضي",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1394,6 +1394,10 @@ export const en = {
       binaryPreviewUnavailable: "Binary preview unavailable",
       failedToLoad: "Failed to load file",
       failedToLoadPreview: "Failed to load file preview",
+      largeFileWarningTitle: "Open large file?",
+      largeFileWarningMessage: "{{fileName}} is {{size}}. Opening it could make the UI unstable.",
+      largeFileWarningOpen: "Open",
+      largeFileWarningCancel: "Cancel",
     },
   },
   toolCallDetails: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1537,6 +1537,11 @@ export const en = {
         description: "Lines kept in the built-in terminal buffer",
         accessibilityLabel: "Terminal scrollback lines",
       },
+      largeFileWarning: {
+        label: "Large file warning",
+        description: "Warn before opening files larger than this size",
+        accessibilityLabel: "Large file warning threshold in megabytes",
+      },
       autoExpandReasoning: {
         label: "Always expand reasoning",
         description: "Show agent thinking and chain-of-thought blocks fully expanded by default",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1573,6 +1573,11 @@ export const es: TranslationResources = {
         description: "Líneas mantenidas en el búfer de terminal incorporado",
         accessibilityLabel: "Líneas del historial de terminal",
       },
+      largeFileWarning: {
+        label: "Advertencia de archivos grandes",
+        description: "Avisar antes de abrir archivos que superen este tamaño",
+        accessibilityLabel: "Umbral de advertencia de archivos grandes en megabytes",
+      },
       autoExpandReasoning: {
         label: "Siempre expandir razonamiento",
         description:

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1425,6 +1425,11 @@ export const es: TranslationResources = {
       binaryPreviewUnavailable: "Vista previa binaria no disponible",
       failedToLoad: "No se pudo cargar el archivo",
       failedToLoadPreview: "No se pudo cargar la vista previa del archivo",
+      largeFileWarningTitle: "¿Abrir archivo grande?",
+      largeFileWarningMessage:
+        "{{fileName}} ocupa {{size}}. Abrirlo podría volver inestable la interfaz.",
+      largeFileWarningOpen: "Abrir",
+      largeFileWarningCancel: "Cancelar",
     },
   },
   toolCallDetails: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1575,6 +1575,11 @@ export const fr: TranslationResources = {
         description: "Lignes conservées dans le tampon du terminal intégré",
         accessibilityLabel: "Lignes de défilementTerminal",
       },
+      largeFileWarning: {
+        label: "Avertissement de fichier volumineux",
+        description: "Avertir avant d'ouvrir les fichiers dépassant cette taille",
+        accessibilityLabel: "Seuil d'avertissement en mégaoctets",
+      },
       autoExpandReasoning: {
         label: "Toujours afficher le raisonnement",
         description: "Afficher le raisonnement de l'agent entièrement développé par défaut",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1428,6 +1428,11 @@ export const fr: TranslationResources = {
       binaryPreviewUnavailable: "Aperçu binaire indisponible",
       failedToLoad: "Échec du chargement du fichier",
       failedToLoadPreview: "Échec du chargement de l'aperçu du fichier",
+      largeFileWarningTitle: "Ouvrir un fichier volumineux ?",
+      largeFileWarningMessage:
+        "{{fileName}} fait {{size}}. Son ouverture pourrait rendre l'interface instable.",
+      largeFileWarningOpen: "Ouvrir",
+      largeFileWarningCancel: "Annuler",
     },
   },
   toolCallDetails: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1547,6 +1547,11 @@ export const ja: TranslationResources = {
         description: "組み込みターミナルバッファに保持する行数",
         accessibilityLabel: "ターミナルスクロールバック行数",
       },
+      largeFileWarning: {
+        label: "大きなファイルの警告",
+        description: "このサイズを超えるファイルを開く前に警告します",
+        accessibilityLabel: "大きなファイルの警告しきい値（メガバイト）",
+      },
       autoExpandReasoning: {
         label: "常に思考プロセスを展開",
         description: "デフォルトでAIのエージェント思考・推論ブロックを完全に展開して表示します",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1403,6 +1403,11 @@ export const ja: TranslationResources = {
       binaryPreviewUnavailable: "バイナリプレビューが利用できません",
       failedToLoad: "ファイルの読み込みに失敗しました",
       failedToLoadPreview: "ファイルプレビューの読み込みに失敗しました",
+      largeFileWarningTitle: "大きなファイルを開きますか？",
+      largeFileWarningMessage:
+        "{{fileName}} は {{size}} です。開くとUIが不安定になる可能性があります。",
+      largeFileWarningOpen: "開く",
+      largeFileWarningCancel: "キャンセル",
     },
   },
   toolCallDetails: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1411,6 +1411,11 @@ export const ptBR: TranslationResources = {
       binaryPreviewUnavailable: "Prévia binária indisponível",
       failedToLoad: "Falha ao carregar arquivo",
       failedToLoadPreview: "Falha ao carregar prévia do arquivo",
+      largeFileWarningTitle: "Abrir arquivo grande?",
+      largeFileWarningMessage:
+        "{{fileName}} tem {{size}}. Abri-lo pode deixar a interface instável.",
+      largeFileWarningOpen: "Abrir",
+      largeFileWarningCancel: "Cancelar",
     },
   },
   toolCallDetails: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1557,6 +1557,11 @@ export const ptBR: TranslationResources = {
         description: "Linhas mantidas no buffer do terminal integrado",
         accessibilityLabel: "Linhas do scrollback do terminal",
       },
+      largeFileWarning: {
+        label: "Aviso de arquivo grande",
+        description: "Avisar antes de abrir arquivos maiores que este tamanho",
+        accessibilityLabel: "Limite de aviso de arquivo grande em megabytes",
+      },
       autoExpandReasoning: {
         label: "Sempre expandir raciocínio",
         description:

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1417,6 +1417,11 @@ export const ru: TranslationResources = {
       binaryPreviewUnavailable: "Предварительный просмотр двоичного файла недоступен.",
       failedToLoad: "Не удалось загрузить файл",
       failedToLoadPreview: "Не удалось загрузить предварительный просмотр файла.",
+      largeFileWarningTitle: "Открыть большой файл?",
+      largeFileWarningMessage:
+        "{{fileName}} имеет размер {{size}}. Открытие может сделать интерфейс нестабильным.",
+      largeFileWarningOpen: "Открыть",
+      largeFileWarningCancel: "Отмена",
     },
   },
   toolCallDetails: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1562,6 +1562,11 @@ export const ru: TranslationResources = {
         description: "Строки, хранящиеся во встроенном буфере терминала.",
         accessibilityLabel: "Линии прокрутки Terminal",
       },
+      largeFileWarning: {
+        label: "Предупреждение о больших файлах",
+        description: "Предупреждать перед открытием файлов больше указанного размера",
+        accessibilityLabel: "Порог предупреждения о больших файлах в мегабайтах",
+      },
       autoExpandReasoning: {
         label: "Всегда разворачивать размышления",
         description:

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1513,6 +1513,11 @@ export const zhCN: TranslationResources = {
         description: "内置终端缓冲区保留的行数",
         accessibilityLabel: "终端回滚行数",
       },
+      largeFileWarning: {
+        label: "大文件警告",
+        description: "打开超过此大小的文件前发出警告",
+        accessibilityLabel: "大文件警告阈值（MB）",
+      },
       autoExpandReasoning: {
         label: "始终展开推理过程",
         description: "默认情况下完全展开 AI 的思考和推理过程",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1370,6 +1370,10 @@ export const zhCN: TranslationResources = {
       binaryPreviewUnavailable: "二进制预览不可用",
       failedToLoad: "加载文件失败",
       failedToLoadPreview: "加载文件预览失败",
+      largeFileWarningTitle: "打开大文件？",
+      largeFileWarningMessage: "{{fileName}} 的大小为 {{size}}。打开它可能会导致界面不稳定。",
+      largeFileWarningOpen: "打开",
+      largeFileWarningCancel: "取消",
     },
   },
   toolCallDetails: {

--- a/packages/app/src/panels/file-panel.tsx
+++ b/packages/app/src/panels/file-panel.tsx
@@ -27,7 +27,7 @@ function useFilePanelDescriptor(target: { kind: "file"; path: string }) {
 
 function FilePanel() {
   const { t } = useTranslation();
-  const { serverId, workspaceId, target } = usePaneContext();
+  const { serverId, workspaceId, target, closeCurrentTab } = usePaneContext();
   const workspaceDirectory = useWorkspaceDirectory(serverId, workspaceId);
   invariant(target.kind === "file", "FilePanel requires file target");
   if (!workspaceDirectory) {
@@ -37,7 +37,14 @@ function FilePanel() {
       </View>
     );
   }
-  return <FilePane serverId={serverId} workspaceRoot={workspaceDirectory} location={target} />;
+  return (
+    <FilePane
+      serverId={serverId}
+      workspaceRoot={workspaceDirectory}
+      location={target}
+      onLargeFileOpenCancel={closeCurrentTab}
+    />
+  );
 }
 
 export const filePanelRegistration: PanelRegistration<"file"> = {

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -47,6 +47,7 @@ import { AppearanceSection } from "@/screens/settings/appearance/appearance-sect
 import {
   useAppSettings,
   useSettings,
+  parseLargeFileWarningThresholdMb,
   parseTerminalScrollbackLines,
   type AppSettings,
   type SendBehavior,
@@ -246,6 +247,7 @@ interface GeneralSectionProps {
   handleServiceUrlBehaviorChange: (behavior: ServiceUrlBehavior) => void;
   handleLanguageChange: (language: AppLanguage) => void;
   handleTerminalScrollbackLinesChange: (lines: number) => void;
+  handleLargeFileWarningThresholdChange: (thresholdMb: number) => void;
 }
 
 interface ServiceUrlBehaviorMenuItemProps {
@@ -302,6 +304,7 @@ function GeneralSection({
   handleServiceUrlBehaviorChange,
   handleLanguageChange,
   handleTerminalScrollbackLinesChange,
+  handleLargeFileWarningThresholdChange,
 }: GeneralSectionProps) {
   const { t, i18n } = useTranslation();
   const activeLocale = getActiveLocale(i18n.language);
@@ -322,6 +325,9 @@ function GeneralSection({
     : settings.language;
   const [terminalScrollbackValue, setTerminalScrollbackValue] = useState(
     String(settings.terminalScrollbackLines),
+  );
+  const [largeFileWarningThresholdValue, setLargeFileWarningThresholdValue] = useState(
+    String(settings.largeFileWarningThresholdMb),
   );
 
   const handleTerminalScrollbackChangeText = useCallback((value: string) => {
@@ -344,6 +350,27 @@ function GeneralSection({
   useEffect(() => {
     setTerminalScrollbackValue(String(settings.terminalScrollbackLines));
   }, [settings.terminalScrollbackLines]);
+
+  const handleLargeFileWarningThresholdChangeText = useCallback((value: string) => {
+    setLargeFileWarningThresholdValue(value.replace(/[^\d]/g, ""));
+  }, []);
+
+  const commitLargeFileWarningThreshold = useCallback(() => {
+    const parsed = parseLargeFileWarningThresholdMb(largeFileWarningThresholdValue);
+    const nextValue = parsed ?? settings.largeFileWarningThresholdMb;
+    setLargeFileWarningThresholdValue(String(nextValue));
+    if (nextValue !== settings.largeFileWarningThresholdMb) {
+      handleLargeFileWarningThresholdChange(nextValue);
+    }
+  }, [
+    handleLargeFileWarningThresholdChange,
+    largeFileWarningThresholdValue,
+    settings.largeFileWarningThresholdMb,
+  ]);
+
+  useEffect(() => {
+    setLargeFileWarningThresholdValue(String(settings.largeFileWarningThresholdMb));
+  }, [settings.largeFileWarningThresholdMb]);
 
   return (
     <SettingsSection title={t("settings.general.title")}>
@@ -431,9 +458,34 @@ function GeneralSection({
             keyboardType="number-pad"
             inputMode="numeric"
             selectTextOnFocus
-            style={styles.terminalScrollbackInput}
+            style={styles.numericInput}
             accessibilityLabel={t("settings.general.terminalScrollback.accessibilityLabel")}
           />
+        </View>
+        <View style={ROW_WITH_BORDER_STYLE} testID="large-file-warning-threshold-row">
+          <View style={settingsStyles.rowContent}>
+            <Text style={settingsStyles.rowTitle}>
+              {t("settings.general.largeFileWarning.label")}
+            </Text>
+            <Text style={settingsStyles.rowHint}>
+              {t("settings.general.largeFileWarning.description")}
+            </Text>
+          </View>
+          <View style={styles.numericInputWithUnit}>
+            <TextInput
+              testID="large-file-warning-threshold-input"
+              value={largeFileWarningThresholdValue}
+              onChangeText={handleLargeFileWarningThresholdChangeText}
+              onBlur={commitLargeFileWarningThreshold}
+              onSubmitEditing={commitLargeFileWarningThreshold}
+              keyboardType="number-pad"
+              inputMode="numeric"
+              selectTextOnFocus
+              style={styles.numericInput}
+              accessibilityLabel={t("settings.general.largeFileWarning.accessibilityLabel")}
+            />
+            <Text style={styles.numericInputUnit}>MB</Text>
+          </View>
         </View>
       </View>
     </SettingsSection>
@@ -1188,6 +1240,13 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     [updateSettings],
   );
 
+  const handleLargeFileWarningThresholdChange = useCallback(
+    (largeFileWarningThresholdMb: number) => {
+      void updateSettings({ largeFileWarningThresholdMb });
+    },
+    [updateSettings],
+  );
+
   const handlePlaybackTest = useCallback(async () => {
     if (!voiceAudioEngine || isPlaybackTestRunning) {
       return;
@@ -1394,6 +1453,7 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
                 handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
                 handleLanguageChange={handleLanguageChange}
                 handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
+                handleLargeFileWarningThresholdChange={handleLargeFileWarningThresholdChange}
               />
               {isDesktopApp ? <BrowserDataSection /> : null}
             </>
@@ -1614,7 +1674,7 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foreground,
     fontSize: theme.fontSize.sm,
   },
-  terminalScrollbackInput: {
+  numericInput: {
     width: 112,
     minHeight: 36,
     paddingVertical: theme.spacing[2],
@@ -1626,6 +1686,15 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foreground,
     fontSize: theme.fontSize.sm,
     textAlign: "right",
+  },
+  numericInputWithUnit: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  numericInputUnit: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
   },
   placeholder: {
     flex: 1,


### PR DESCRIPTION
### Linked issue

Closes #811

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Opening a large workspace file can make the client unresponsive and restore the same file into a crash loop after restart.

This change checks parent-directory metadata before reading a file. Files larger than the configured threshold render an inline warning in the file pane with Open and Cancel actions. Open approves only the current file tab and loads its contents; Cancel closes the tab. Closing and reopening a previously approved or cancelled file shows the warning again.

The threshold defaults to 5 MB and can be changed under Settings > General.

The file read waits for persisted app settings, and filename lookup preserves the warning when path casing differs on case-insensitive hosts. If size metadata is unavailable, the existing read behavior continues.

### How did you verify it

Reproduction from #811:

1. Open a workspace file larger than the warning threshold.
2. The client can become unresponsive while rendering it.
3. Restart Paseo and restore the same file tab.
4. The client can become unresponsive again before the tab can be closed.

For the close-and-reopen regression, the automated browser test opens the 5.0 MB file, approves it, closes its tab, and reopens it. Before this fix, the cached approval bypassed the warning. After the fix, the warning is shown again before any content is read.

Automated checks run after rebasing onto `getpaseo/main`:

- `npx vitest run packages/app/src/components/file-pane-enabled.test.ts packages/app/src/components/file-pane-large-file.test.ts packages/app/src/hooks/use-settings/storage.test.ts packages/app/src/i18n/resources.test.ts --bail=1` passed: 81 tests
- `npm run test:e2e --workspace=@getpaseo/app -- e2e/large-file-warning.spec.ts` passed: 2 tests against an isolated daemon and a seeded 5,243,904-byte text file
- Unit coverage verifies file reads wait for persisted app settings and directory lookup handles filename casing differences
- The E2E flow verified the 5 MB default warning, Cancel and Open behavior, close-and-reopen prompting, the General setting, and that changing the threshold to 6 MB opens the same file without warning
- `npm run format` completed successfully
- `npm run lint` passed with 0 warnings and 0 errors
- `npm run build:client` refreshed protocol/client declarations required by current main
- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck` passed

#### Web screenshots

The General setting defaults to 5 MB:

![Large file warning threshold setting on web](https://raw.githubusercontent.com/amcfague/paseo/35c78ed646cb426af9deeb2ed5d3b1861e29f415/.github/pr-assets/2075/web-settings.png)

The text file just over 5 MiB renders an inline warning before its contents are read:

![Large text file warning on web](https://raw.githubusercontent.com/amcfague/paseo/35c78ed646cb426af9deeb2ed5d3b1861e29f415/.github/pr-assets/2075/web-warning.png)

After choosing **Open**, the text preview replaces the warning in the file pane:

![Large text file opened on web](https://raw.githubusercontent.com/amcfague/paseo/35c78ed646cb426af9deeb2ed5d3b1861e29f415/.github/pr-assets/2075/web-opened.png)

iOS, Android, and Electron screenshots are still outstanding. The Android emulator is running for manual capture; iOS is unavailable because full Xcode is not installed; Electron capture is still pending.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
