### PR TITLE
fix(cli): pass cwd to worktree ls and archive

### DIFF
--- a/packages/cli/src/commands/worktree/archive.test.ts
+++ b/packages/cli/src/commands/worktree/archive.test.ts
@@ -143,4 +143,63 @@ describe("runArchiveCommand", () => {
       code: "WORKTREE_NOT_FOUND",
     });
   });
+
+  it("passes process.cwd() to getPaseoWorktreeList when cwd is omitted", async () => {
+    const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
+    const fakeClient = createFakeDaemonClient({
+      getPaseoWorktreeList: async (input) => {
+        listCalls.push(input);
+        return {
+          worktrees: [],
+          error: null,
+          requestId: "req-list",
+        };
+      },
+    });
+
+    await expect(
+      runArchiveCommandWithDeps(
+        "missing",
+        {},
+        {
+          connectToDaemon: async () => fakeClient,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "WORKTREE_NOT_FOUND",
+    });
+
+    expect(listCalls).toHaveLength(1);
+    expect(listCalls[0]).toEqual({ cwd: process.cwd() });
+  });
+
+  it("passes explicit cwd to getPaseoWorktreeList when provided", async () => {
+    const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
+    const explicitCwd = "/tmp/explicit-repo-root";
+    const fakeClient = createFakeDaemonClient({
+      getPaseoWorktreeList: async (input) => {
+        listCalls.push(input);
+        return {
+          worktrees: [],
+          error: null,
+          requestId: "req-list",
+        };
+      },
+    });
+
+    await expect(
+      runArchiveCommandWithDeps(
+        "missing",
+        { cwd: explicitCwd },
+        {
+          connectToDaemon: async () => fakeClient,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "WORKTREE_NOT_FOUND",
+    });
+
+    expect(listCalls).toHaveLength(1);
+    expect(listCalls[0]).toEqual({ cwd: explicitCwd });
+  });
 });

--- a/packages/cli/src/commands/worktree/archive.ts
+++ b/packages/cli/src/commands/worktree/archive.ts
@@ -31,6 +31,7 @@ export const archiveSchema: OutputSchema<WorktreeArchiveResult> = {
 
 export interface WorktreeArchiveOptions extends CommandOptions {
   host?: string;
+  cwd?: string;
 }
 
 export type WorktreeArchiveCommandResult = SingleResult<WorktreeArchiveResult>;
@@ -49,6 +50,7 @@ export async function runArchiveCommandWithDeps(
   deps: { connectToDaemon: typeof connectToDaemon },
 ): Promise<WorktreeArchiveCommandResult> {
   const host = getDaemonHost({ host: options.host });
+  const cwd = options.cwd ?? process.cwd();
 
   // Validate arguments
   if (!nameArg || nameArg.trim().length === 0) {
@@ -75,7 +77,7 @@ export async function runArchiveCommandWithDeps(
 
   try {
     // Get the list of worktrees first to resolve the name
-    const listResponse = await client.getPaseoWorktreeList({});
+    const listResponse = await client.getPaseoWorktreeList({ cwd });
 
     if (listResponse.error) {
       const error: CommandError = {

--- a/packages/cli/src/commands/worktree/index.ts
+++ b/packages/cli/src/commands/worktree/index.ts
@@ -9,7 +9,10 @@ export function createWorktreeCommand(): Command {
   const worktree = new Command("worktree").description("Manage Paseo-managed git worktrees");
 
   addJsonAndDaemonHostOptions(
-    worktree.command("ls").description("List Paseo-managed git worktrees"),
+    worktree
+      .command("ls")
+      .description("List Paseo-managed git worktrees")
+      .option("--cwd <path>", "Repository directory (default: current)"),
   ).action(withOutput(runLsCommand));
 
   addJsonAndDaemonHostOptions(
@@ -31,7 +34,8 @@ export function createWorktreeCommand(): Command {
     worktree
       .command("archive")
       .description("Archive a worktree (removes worktree and associated branch)")
-      .argument("<name>", "Worktree name or branch name"),
+      .argument("<name>", "Worktree name or branch name")
+      .option("--cwd <path>", "Repository directory (default: current)"),
   ).action(withOutput(runArchiveCommand));
 
   return worktree;

--- a/packages/cli/src/commands/worktree/ls.test.ts
+++ b/packages/cli/src/commands/worktree/ls.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import { runLsCommandWithDeps } from "./ls.js";
+
+function createFakeDaemonClient(
+  overrides: Partial<Pick<DaemonClient, "fetchAgents" | "getPaseoWorktreeList" | "close">> = {},
+): DaemonClient {
+  return {
+    fetchAgents: async () => ({
+      entries: [],
+      requestId: "req-agents",
+    }),
+    getPaseoWorktreeList: async () => ({
+      worktrees: [],
+      error: null,
+      requestId: "req-list",
+    }),
+    close: async () => {},
+    ...overrides,
+  } as unknown as DaemonClient;
+}
+
+describe("runLsCommand", () => {
+  it("passes process.cwd() to getPaseoWorktreeList when cwd is omitted", async () => {
+    const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
+    const fakeClient = createFakeDaemonClient({
+      getPaseoWorktreeList: async (input) => {
+        listCalls.push(input);
+        return {
+          worktrees: [],
+          error: null,
+          requestId: "req-list",
+        };
+      },
+    });
+
+    await runLsCommandWithDeps(
+      {},
+      {
+        connectToDaemon: async () => fakeClient,
+      },
+    );
+
+    expect(listCalls).toHaveLength(1);
+    expect(listCalls[0]).toEqual({ cwd: process.cwd() });
+  });
+
+  it("passes explicit cwd to getPaseoWorktreeList when provided", async () => {
+    const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
+    const explicitCwd = "/tmp/explicit-repo-root";
+    const fakeClient = createFakeDaemonClient({
+      getPaseoWorktreeList: async (input) => {
+        listCalls.push(input);
+        return {
+          worktrees: [],
+          error: null,
+          requestId: "req-list",
+        };
+      },
+    });
+
+    await runLsCommandWithDeps(
+      { cwd: explicitCwd },
+      {
+        connectToDaemon: async () => fakeClient,
+      },
+    );
+
+    expect(listCalls).toHaveLength(1);
+    expect(listCalls[0]).toEqual({ cwd: explicitCwd });
+  });
+});

--- a/packages/cli/src/commands/worktree/ls.ts
+++ b/packages/cli/src/commands/worktree/ls.ts
@@ -55,17 +55,26 @@ export type WorktreeLsResult = ListResult<WorktreeListItem>;
 
 export interface WorktreeLsOptions extends CommandOptions {
   host?: string;
+  cwd?: string;
 }
 
 export async function runLsCommand(
   options: WorktreeLsOptions,
   _command: Command,
 ): Promise<WorktreeLsResult> {
+  return runLsCommandWithDeps(options, { connectToDaemon });
+}
+
+export async function runLsCommandWithDeps(
+  options: WorktreeLsOptions,
+  deps: { connectToDaemon: typeof connectToDaemon },
+): Promise<WorktreeLsResult> {
   const host = getDaemonHost({ host: options.host });
+  const cwd = options.cwd ?? process.cwd();
 
   let client: DaemonClient;
   try {
-    client = await connectToDaemon({ host: options.host });
+    client = await deps.connectToDaemon({ host: options.host });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const error: CommandError = {
@@ -81,7 +90,7 @@ export async function runLsCommand(
     const agents = agentsPayload.entries.map((entry) => entry.agent);
 
     // Get worktree list from daemon
-    const response = await client.getPaseoWorktreeList({});
+    const response = await client.getPaseoWorktreeList({ cwd });
 
     await client.close();
 

--- a/packages/cli/tests/14-worktree.test.ts
+++ b/packages/cli/tests/14-worktree.test.ts
@@ -49,6 +49,7 @@ try {
     const result = await $`npx paseo worktree ls --help`.nothrow();
     assert.strictEqual(result.exitCode, 0, "worktree ls --help should exit 0");
     assert(result.stdout.includes("--host"), "help should mention --host option");
+    assert(result.stdout.includes("--cwd"), "help should mention --cwd option");
     console.log("✓ worktree ls --help shows options\n");
   }
 
@@ -85,6 +86,7 @@ try {
     const result = await $`npx paseo worktree archive --help`.nothrow();
     assert.strictEqual(result.exitCode, 0, "worktree archive --help should exit 0");
     assert(result.stdout.includes("--host"), "help should mention --host option");
+    assert(result.stdout.includes("--cwd"), "help should mention --cwd option");
     assert(result.stdout.includes("<name>"), "help should mention required name argument");
     console.log("✓ worktree archive --help shows options\n");
   }
@@ -160,6 +162,28 @@ try {
     assert.strictEqual(result.exitCode, 0, "paseo --help should exit 0");
     assert(!result.stdout.includes("worktree"), "help should not advertise worktree subcommand");
     console.log("✓ paseo --help hides worktree compatibility command\n");
+  }
+
+  // Test 12: worktree ls with --cwd flag is accepted
+  {
+    console.log("Test 12: worktree ls with --cwd flag is accepted");
+    const result =
+      await $`PASEO_HOST=localhost:${port} PASEO_HOME=${paseoHome} npx paseo worktree ls --cwd /tmp`.nothrow();
+    const output = result.stdout + result.stderr;
+    assert(!output.includes("unknown option"), "should accept --cwd flag");
+    assert(!output.includes("error: option"), "should not have option parsing error");
+    console.log("✓ worktree ls with --cwd flag is accepted\n");
+  }
+
+  // Test 13: worktree archive with --cwd flag is accepted
+  {
+    console.log("Test 13: worktree archive with --cwd flag is accepted");
+    const result =
+      await $`PASEO_HOST=localhost:${port} PASEO_HOME=${paseoHome} npx paseo worktree archive test-worktree --cwd /tmp`.nothrow();
+    const output = result.stdout + result.stderr;
+    assert(!output.includes("unknown option"), "should accept --cwd flag");
+    assert(!output.includes("error: option"), "should not have option parsing error");
+    console.log("✓ worktree archive with --cwd flag is accepted\n");
   }
 } finally {
   // Clean up temp directory


### PR DESCRIPTION
### Linked issue

Closes #1649

#2010 was closed as a duplicate of #1649. This PR is the fuller CLI fix named on that duplicate (ls + archive). Related: #1679 only hardcodes `process.cwd()` for `worktree ls`.

Rebased onto current `main` (`90f3d9541`). The empty `getPaseoWorktreeList({})` calls are still on `main`; the daemon still returns `cwd or repoRoot is required`.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

`paseo worktree ls` and `paseo worktree archive` called `getPaseoWorktreeList({})`. The daemon requires `cwd` or `repoRoot`, so both commands failed with:

```text
Failed to list worktrees: cwd or repoRoot is required
```

This PR:

1. Adds `--cwd <path>` to `worktree ls` and `worktree archive` (same wording as `worktree create`)
2. Defaults to `process.cwd()` when omitted
3. Passes `{ cwd }` into `getPaseoWorktreeList(...)`
4. Adds unit tests for both commands and CLI help/flag coverage

No daemon changes. No `repoRoot` flag (unless maintainers prefer one later).

### How did you verify it

**Root cause before the fix**

Both call sites on current `main` still pass an empty object:

- `packages/cli/src/commands/worktree/ls.ts` → `getPaseoWorktreeList({})`
- `packages/cli/src/commands/worktree/archive.ts` → `getPaseoWorktreeList({})`

**Unit tests (RPC argument contract)**

```bash
npx vitest run packages/cli/src/commands/worktree/ls.test.ts packages/cli/src/commands/worktree/archive.test.ts --bail=1
```

Result: **7/7 passed**, including:

- default `process.cwd()` is sent when `cwd` is omitted
- explicit `cwd` is sent when provided

**Typecheck / lint / format (touched files)**

- `npm run typecheck --workspace=@getpaseo/cli` — pass
- `npm run lint -- <changed files>` — 0 warnings / 0 errors
- `npm run format:files -- <changed files>` — formatted

I did not run the full monorepo suite locally (repo guidance: avoid full suite; rely on CI).

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [x] UI changes include screenshots or video for every affected platform (N/A — CLI only)
- [x] Tests added or updated where it made sense