### PR TITLE
fix: make Light theme ANSI white readable in terminal

### DIFF
--- a/packages/app/src/styles/theme.ts
+++ b/packages/app/src/styles/theme.ts
@@ -205,8 +205,8 @@ const lightSemanticColors = {
     blue: "#2563eb",
     magenta: "#9333ea",
     cyan: "#0891b2",
-    white: "#ffffff",
-
+    // ANSI white slots must contrast on white background (e.g. PSReadLine args)
+    white: "#71717a",
     brightBlack: "#3f3f46",
     brightRed: "#ef4444",
     brightGreen: "#22c55e",
@@ -214,7 +214,8 @@ const lightSemanticColors = {
     brightBlue: "#3b82f6",
     brightMagenta: "#a855f7",
     brightCyan: "#06b6d4",
-    brightWhite: "#fafafa",
+    // readable bright/default on white — not near-background #fafafa
+    brightWhite: "#1a1a1e",
   },
 } as const;
 


### PR DESCRIPTION
## Summary

Fixes #1796.

On Light theme, PowerShell 7 (PSReadLine) argument tokens were nearly white-on-white in the Paseo terminal. PSReadLine colors arguments with ANSI SGR white / bright white; Light theme mapped those palette slots to `#ffffff` and `#fafafa` against a `#ffffff` background, and xterm `minimumContrastRatio: 1` does not rescue the contrast.

This PR only adjusts the Light theme ANSI white slots so they remain readable on white, without changing Dark theme, PowerShell profiles, or xterm contrast settings.

### What changed

**File:** `packages/app/src/styles/theme.ts` (Light `terminal` palette only)

| Slot | Before | After | Why |
|------|--------|-------|-----|
| `white` | `#ffffff` | `#71717a` | Muted zinc gray, readable on `#ffffff` (same as UI `mutedForeground`) |
| `brightWhite` | `#fafafa` | `#1a1a1e` | Matches Light `terminal.foreground` |

### Why this approach

- ANSI palette names are logical slots, not literal paint colors; light terminal themes commonly map “white” to a dark/muted foreground.
- Reuses existing Light theme tokens for consistency.
- Helps any program that emits ANSI white on Light theme, not only `pwsh.exe`.

### Intentionally not changed

- Dark theme terminal palette (already contrasts on dark backgrounds)
- `minimumContrastRatio` in `terminal-emulator-runtime.ts` (left at `1` to avoid broader rendering impact; optional follow-up)
- `to-xterm-theme.ts` / `terminal-pane.tsx` (already pass the palette through)

## Test plan

- [ ] Desktop, Light theme: open a PowerShell 7 terminal profile
- [ ] Type something like `ping www.example.com` — command **and** arguments should be readable without selecting text
- [ ] Light theme + `cmd.exe`: still readable (no regression)
- [ ] Dark theme + PowerShell 7: still readable (no regression)
- [ ] Spot-check other ANSI colors on Light (red/green/yellow/blue tokens still look correct)

Local verification already run: format, lint on `theme.ts`, full monorepo typecheck (pre-commit hook).