### PR TITLE
feat(app): Insert slash commands from agent output into the composer

### DIFF
--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -52,6 +52,8 @@ import type { AgentScreenAgent } from "@/hooks/use-agent-screen-state-machine";
 import { useSessionStore } from "@/stores/session-store";
 import { useFileExplorerActions } from "@/hooks/use-file-explorer-actions";
 import { useLoadOlderAgentHistory } from "@/hooks/use-load-older-agent-history";
+import { useAgentCommandsQuery } from "@/hooks/use-agent-commands-query";
+import { useComposerInsert } from "@/components/composer-insert";
 import { useSettings } from "@/hooks/use-settings";
 import type { ToastApi } from "@/components/toast-host";
 import { returnToTimelineTail } from "./timeline-tail-navigation";
@@ -448,6 +450,28 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       handleInlinePathPress({ raw: filePath, path: filePath }, "main");
     });
 
+    // A `/command` token in agent output is treated as a known slash command
+    // (append to composer) only when there is a live composer to insert into.
+    // In read-only/preview streams there is no composer, so tokens keep their
+    // file-path behavior. The commands list is shared (TanStack cache) with the
+    // composer's own query, so this adds no extra network.
+    const composerInsert = useComposerInsert();
+    const commandInsertionEnabled =
+      !readOnly && composerInsert != null && !!resolvedServerId && !!agentId;
+    const { commands: agentCommands } = useAgentCommandsQuery({
+      serverId: resolvedServerId,
+      agentId,
+      enabled: commandInsertionEnabled,
+    });
+    const commandNames = useMemo(
+      () => new Set(agentCommands.map((command) => command.name)),
+      [agentCommands],
+    );
+    const isSlashCommand = useCallback(
+      (name: string) => commandInsertionEnabled && commandNames.has(name),
+      [commandInsertionEnabled, commandNames],
+    );
+
     const handleForkAssistantTurn: AssistantTurnForkHandler = useStableEvent(
       async ({ target, boundary }) => {
         await forkAgent({
@@ -644,6 +668,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             workspaceRoot={workspaceRoot}
             onOpenWorkspaceFile={handleInlinePathPress}
             toast={toast}
+            isSlashCommand={isSlashCommand}
           >
             <AssistantMessage
               occurrenceKey={createAssistantImageOccurrenceKey({ agentId, itemId: item.id })}
@@ -658,7 +683,15 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
           </AssistantFileLinkResolverProvider>
         );
       },
-      [agentId, client, handleInlinePathPress, resolvedServerId, toast, workspaceRoot],
+      [
+        agentId,
+        client,
+        handleInlinePathPress,
+        isSlashCommand,
+        resolvedServerId,
+        toast,
+        workspaceRoot,
+      ],
     );
 
     const renderThoughtItem = useCallback(

--- a/packages/app/src/assistant-file-links/index.ts
+++ b/packages/app/src/assistant-file-links/index.ts
@@ -1,8 +1,10 @@
 export {
   AssistantInlineCodePathLink,
+  AssistantInlineSlashCommandLink,
   AssistantMarkdownCodeLink,
   AssistantMarkdownLink,
 } from "./link";
+export { appendSlashCommandToken, parseSlashCommandToken } from "./slash-command";
 export { type AssistantLinkPress, useAssistantLinkPress } from "./link-press-context";
 export {
   classifyAssistantFileLink,

--- a/packages/app/src/assistant-file-links/link.tsx
+++ b/packages/app/src/assistant-file-links/link.tsx
@@ -1,5 +1,13 @@
-import { useMemo, type CSSProperties, type MouseEvent, type ReactNode } from "react";
-import { Platform, Text, View, type StyleProp, type TextStyle, type ViewStyle } from "react-native";
+import { useMemo, useState, type CSSProperties, type MouseEvent, type ReactNode } from "react";
+import {
+  Platform,
+  Pressable,
+  Text,
+  View,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+} from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { isNative, isWeb } from "@/constants/platform";
 import { MarkdownTextSpan } from "@/components/markdown-text";
@@ -13,6 +21,7 @@ import { markdownCopyDataSet } from "@/assistant-selection-copy/markup";
 import { useAssistantFileLinkResolverContext } from "./provider";
 import type { AssistantFileLinkSource } from "./resolver";
 import { useFileLink } from "./use-file-link";
+import { useComposerInsert } from "@/components/composer-insert";
 
 interface AssistantMarkdownLinkProps {
   source: AssistantFileLinkSource;
@@ -203,6 +212,82 @@ export function AssistantInlineCodePathLink({
   );
 }
 
+interface AssistantInlineSlashCommandLinkProps {
+  token: string;
+  inheritedStyles: TextStyle;
+  codeInlineStyle: TextStyle;
+  linkStyle: TextStyle;
+}
+
+// A leading-slash inline-code token that matches a known slash command / skill
+// for the current agent. Unlike AssistantInlineCodePathLink this is an *action*
+// (append the command to the composer), not navigation — so there is no <a>
+// href on web and no side-pane aux press.
+export function AssistantInlineSlashCommandLink({
+  token,
+  inheritedStyles,
+  codeInlineStyle,
+  linkStyle,
+}: AssistantInlineSlashCommandLinkProps) {
+  const [hovered, setHovered] = useState(false);
+  const composerInsert = useComposerInsert();
+  const style = useMemo(
+    () => [inheritedStyles, codeInlineStyle, linkStyle],
+    [inheritedStyles, codeInlineStyle, linkStyle],
+  );
+  const onPress = useStableEvent(() => composerInsert?.insertSlashCommand(token));
+  const handleHoverIn = useStableEvent(() => setHovered(true));
+  const handleHoverOut = useStableEvent(() => setHovered(false));
+  const hoveredTextStyle = useMemo<StyleProp<TextStyle>>(
+    () => [style, hovered && { textDecorationLine: "underline" as const }],
+    [style, hovered],
+  );
+  const linkPress = useMemo<AssistantLinkPress>(
+    () => ({ onPress, accessibilityRole: "button" }),
+    [onPress],
+  );
+  const tooltipBody = useMemo(
+    () => (
+      <View style={styles.tooltipBody}>
+        <Text selectable={false} style={styles.tooltipPath}>
+          Insert into composer
+        </Text>
+      </View>
+    ),
+    [],
+  );
+
+  if (isNative) {
+    // Same UITextView constraint as AssistantMarkdownLink: use MarkdownTextSpan
+    // and thread onPress down through AssistantLinkPressProvider on iOS.
+    const span = (
+      <MarkdownTextSpan accessibilityRole="button" monoSurface onPress={onPress} style={style}>
+        {token}
+      </MarkdownTextSpan>
+    );
+    return Platform.OS === "ios" ? (
+      <AssistantLinkPressProvider value={linkPress}>{span}</AssistantLinkPressProvider>
+    ) : (
+      span
+    );
+  }
+
+  const trigger = (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      onHoverIn={handleHoverIn}
+      onHoverOut={handleHoverOut}
+    >
+      <Text dataSet={CODE_SURFACE_DATASET} style={hoveredTextStyle}>
+        {token}
+      </Text>
+    </Pressable>
+  );
+
+  return <InlineLinkTooltip body={tooltipBody}>{trigger}</InlineLinkTooltip>;
+}
+
 const FILE_LINK_TOOLTIP_TRIGGER_STYLE: ViewStyle = {
   // RN doesn't type "inline-flex" but RN-web honors it at runtime, which keeps
   // the tooltip wrapper from breaking inline link flow.
@@ -211,13 +296,9 @@ const FILE_LINK_TOOLTIP_TRIGGER_STYLE: ViewStyle = {
 
 const FILE_LINK_TOOLTIP_MOD_KEYS = ["mod"];
 
-function FileLinkHoverTooltip({
-  filePath,
-  children,
-}: {
-  filePath: string | null;
-  children: ReactNode;
-}) {
+// Shared hover-tooltip shell for inline links (web only). Callers supply the
+// tooltip body; a null body renders the trigger with no tooltip content.
+function InlineLinkTooltip({ body, children }: { body: ReactNode; children: ReactNode }) {
   if (!isWeb) {
     return children;
   }
@@ -226,23 +307,41 @@ function FileLinkHoverTooltip({
       <TooltipTrigger asChild>
         <View style={FILE_LINK_TOOLTIP_TRIGGER_STYLE}>{children}</View>
       </TooltipTrigger>
-      {filePath ? (
+      {body ? (
         <TooltipContent side="top" align="start" maxWidth={520}>
-          <View style={styles.tooltipBody}>
-            <Text selectable={false} style={styles.tooltipPath}>
-              {filePath}
-            </Text>
-            <View style={styles.tooltipHintRow}>
-              <Shortcut keys={FILE_LINK_TOOLTIP_MOD_KEYS} />
-              <Text selectable={false} style={styles.tooltipHintText}>
-                click for side pane
-              </Text>
-            </View>
-          </View>
+          {body}
         </TooltipContent>
       ) : null}
     </Tooltip>
   );
+}
+
+function FileLinkHoverTooltip({
+  filePath,
+  children,
+}: {
+  filePath: string | null;
+  children: ReactNode;
+}) {
+  const body = useMemo(
+    () =>
+      filePath ? (
+        <View style={styles.tooltipBody}>
+          <Text selectable={false} style={styles.tooltipPath}>
+            {filePath}
+          </Text>
+          <View style={styles.tooltipHintRow}>
+            <Shortcut keys={FILE_LINK_TOOLTIP_MOD_KEYS} />
+            <Text selectable={false} style={styles.tooltipHintText}>
+              click for side pane
+            </Text>
+          </View>
+        </View>
+      ) : null,
+    [filePath],
+  );
+
+  return <InlineLinkTooltip body={body}>{children}</InlineLinkTooltip>;
 }
 
 const LINK_ANCHOR_STYLE: CSSProperties = {

--- a/packages/app/src/assistant-file-links/link.tsx
+++ b/packages/app/src/assistant-file-links/link.tsx
@@ -9,6 +9,7 @@ import {
   type ViewStyle,
 } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
+import { useTranslation } from "react-i18next";
 import { isNative, isWeb } from "@/constants/platform";
 import { MarkdownTextSpan } from "@/components/markdown-text";
 import { MarkdownLinkText } from "@/components/markdown/link-text";
@@ -229,6 +230,7 @@ export function AssistantInlineSlashCommandLink({
   codeInlineStyle,
   linkStyle,
 }: AssistantInlineSlashCommandLinkProps) {
+  const { t } = useTranslation();
   const [hovered, setHovered] = useState(false);
   const composerInsert = useComposerInsert();
   const style = useMemo(
@@ -250,11 +252,11 @@ export function AssistantInlineSlashCommandLink({
     () => (
       <View style={styles.tooltipBody}>
         <Text selectable={false} style={styles.tooltipPath}>
-          Insert into composer
+          {t("message.actions.insertIntoComposer")}
         </Text>
       </View>
     ),
-    [],
+    [t],
   );
 
   if (isNative) {

--- a/packages/app/src/assistant-file-links/provider.tsx
+++ b/packages/app/src/assistant-file-links/provider.tsx
@@ -23,6 +23,10 @@ export interface AssistantFileLinkResolverConfig {
   workspaceRoot?: string;
   onOpenWorkspaceFile?: (target: InlinePathTarget, disposition: OpenFileDisposition) => void;
   toast?: ToastApi | null;
+  // Recognizes a leading-slash inline-code token (bare command name, no slash)
+  // as a known slash command / skill for the current agent, so the code_inline
+  // rule can render it as a command chip instead of a file link.
+  isSlashCommand?: (name: string) => boolean;
 }
 
 export interface AssistantFileLinkResolverProviderProps extends AssistantFileLinkResolverConfig {
@@ -43,6 +47,7 @@ export function AssistantFileLinkResolverProvider({
   workspaceRoot,
   onOpenWorkspaceFile,
   toast,
+  isSlashCommand,
   children,
 }: AssistantFileLinkResolverProviderProps) {
   const configRef = useRef<AssistantFileLinkResolverConfig>({
@@ -51,8 +56,16 @@ export function AssistantFileLinkResolverProvider({
     workspaceRoot,
     onOpenWorkspaceFile,
     toast,
+    isSlashCommand,
   });
-  configRef.current = { client, serverId, workspaceRoot, onOpenWorkspaceFile, toast };
+  configRef.current = {
+    client,
+    serverId,
+    workspaceRoot,
+    onOpenWorkspaceFile,
+    toast,
+    isSlashCommand,
+  };
 
   const getDirectorySuggestions = useCallback<GetDirectorySuggestions>(async (input) => {
     const activeClient = configRef.current.client;

--- a/packages/app/src/assistant-file-links/provider.tsx
+++ b/packages/app/src/assistant-file-links/provider.tsx
@@ -23,19 +23,27 @@ export interface AssistantFileLinkResolverConfig {
   workspaceRoot?: string;
   onOpenWorkspaceFile?: (target: InlinePathTarget, disposition: OpenFileDisposition) => void;
   toast?: ToastApi | null;
+}
+
+export interface AssistantFileLinkResolverProviderProps extends AssistantFileLinkResolverConfig {
   // Recognizes a leading-slash inline-code token (bare command name, no slash)
   // as a known slash command / skill for the current agent, so the code_inline
   // rule can render it as a command chip instead of a file link.
   isSlashCommand?: (name: string) => boolean;
-}
-
-export interface AssistantFileLinkResolverProviderProps extends AssistantFileLinkResolverConfig {
   children: ReactNode;
 }
 
 export interface AssistantFileLinkResolverContextValue {
   configRef: MutableRefObject<AssistantFileLinkResolverConfig>;
   getDirectorySuggestions: GetDirectorySuggestions;
+  // Carried by value, unlike the rest of the config, because it decides what a
+  // token *renders as* rather than what a press *does*. The per-agent command
+  // list arrives from the network after the transcript first renders, and
+  // AssistantMessage is memoized, so a configRef mutation would never reach an
+  // already-rendered history message. A context value change re-renders every
+  // consumer even behind memo, which is what makes late-arriving commands show
+  // up as chips.
+  isSlashCommand?: (name: string) => boolean;
 }
 
 const AssistantFileLinkResolverContext =
@@ -56,7 +64,6 @@ export function AssistantFileLinkResolverProvider({
     workspaceRoot,
     onOpenWorkspaceFile,
     toast,
-    isSlashCommand,
   });
   configRef.current = {
     client,
@@ -64,7 +71,6 @@ export function AssistantFileLinkResolverProvider({
     workspaceRoot,
     onOpenWorkspaceFile,
     toast,
-    isSlashCommand,
   };
 
   const getDirectorySuggestions = useCallback<GetDirectorySuggestions>(async (input) => {
@@ -78,8 +84,8 @@ export function AssistantFileLinkResolverProvider({
   }, []);
 
   const value = useMemo<AssistantFileLinkResolverContextValue>(
-    () => ({ configRef, getDirectorySuggestions }),
-    [getDirectorySuggestions],
+    () => ({ configRef, getDirectorySuggestions, isSlashCommand }),
+    [getDirectorySuggestions, isSlashCommand],
   );
 
   return (

--- a/packages/app/src/assistant-file-links/slash-command.test.ts
+++ b/packages/app/src/assistant-file-links/slash-command.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { appendSlashCommandToken, parseSlashCommandToken } from "./slash-command";
+
+describe("parseSlashCommandToken", () => {
+  it("extracts a bare command name", () => {
+    expect(parseSlashCommandToken("/autoplan")).toBe("autoplan");
+    expect(parseSlashCommandToken("  /autoplan  ")).toBe("autoplan");
+  });
+
+  it("allows namespaced and dashed/underscored names", () => {
+    expect(parseSlashCommandToken("/a-b:c")).toBe("a-b:c");
+    expect(parseSlashCommandToken("/gstack:browse")).toBe("gstack:browse");
+    expect(parseSlashCommandToken("/code_review")).toBe("code_review");
+  });
+
+  it("rejects multi-segment paths", () => {
+    expect(parseSlashCommandToken("/foo/bar")).toBeNull();
+    expect(parseSlashCommandToken("/usr/local/bin")).toBeNull();
+  });
+
+  it("rejects filenames with extensions", () => {
+    expect(parseSlashCommandToken("/foo.ts")).toBeNull();
+    expect(parseSlashCommandToken("/.eslintrc")).toBeNull();
+  });
+
+  it("rejects tokens that are not a single leading-slash name", () => {
+    expect(parseSlashCommandToken("/")).toBeNull();
+    expect(parseSlashCommandToken("autoplan")).toBeNull();
+    expect(parseSlashCommandToken("/auto plan")).toBeNull();
+    expect(parseSlashCommandToken("")).toBeNull();
+  });
+});
+
+describe("appendSlashCommandToken", () => {
+  it("inserts into empty text with a trailing space", () => {
+    expect(appendSlashCommandToken({ text: "", token: "/autoplan" })).toBe("/autoplan ");
+  });
+
+  it("adds a separating space when text does not end in whitespace", () => {
+    expect(appendSlashCommandToken({ text: "run", token: "/autoplan" })).toBe("run /autoplan ");
+  });
+
+  it("does not double-space when text already ends in whitespace", () => {
+    expect(appendSlashCommandToken({ text: "run ", token: "/autoplan" })).toBe("run /autoplan ");
+    expect(appendSlashCommandToken({ text: "run\n", token: "/autoplan" })).toBe("run\n/autoplan ");
+  });
+});

--- a/packages/app/src/assistant-file-links/slash-command.ts
+++ b/packages/app/src/assistant-file-links/slash-command.ts
@@ -1,0 +1,22 @@
+// A leading-slash token in agent output (e.g. `/autoplan`) is ambiguous: it
+// looks like an absolute path but is often a slash command / skill the agent is
+// referring to. We extract a *candidate* name here; whether it is actually a
+// command is decided by membership in the per-agent command list (see the
+// `code_inline` rule in components/message.tsx), so this stays deliberately
+// permissive and only rejects tokens that can't be a single command name —
+// multi-segment paths (`/foo/bar`) and filenames (`/foo.ts`).
+const SLASH_COMMAND_TOKEN = /^\/([A-Za-z0-9][A-Za-z0-9:_-]*)$/;
+
+export function parseSlashCommandToken(value: string): string | null {
+  const match = SLASH_COMMAND_TOKEN.exec(value.trim());
+  return match ? match[1] : null;
+}
+
+// Append a slash-command token to the current composer draft, inserting a
+// single separating space when the existing text doesn't already end in
+// whitespace, and leaving a trailing space so the user can keep typing args.
+export function appendSlashCommandToken(input: { text: string; token: string }): string {
+  const { text, token } = input;
+  const needsSeparator = text.length > 0 && !/\s$/.test(text);
+  return `${text}${needsSeparator ? " " : ""}${token} `;
+}

--- a/packages/app/src/assistant-file-links/use-file-link.test.tsx
+++ b/packages/app/src/assistant-file-links/use-file-link.test.tsx
@@ -362,4 +362,43 @@ describe("useAssistantFileLinkActions slash commands", () => {
 
     expect(result.current.isSlashCommand("autoplan")).toBe(false);
   });
+
+  // The per-agent command list arrives from the network after the transcript has
+  // already rendered. AssistantMessage is memoized and its markdown rules are
+  // memoized on the actions object, so the late matcher only reaches an existing
+  // message if the actions identity changes with it. When isSlashCommand was read
+  // through configRef the identity was permanently stable, and history messages
+  // kept rendering `/command` tokens as file links forever.
+  it("changes actions identity when the command matcher loads late", () => {
+    const queryClient = createQueryClient();
+    // The matcher lives outside the tree so the test can swap it between renders,
+    // standing in for the commands query resolving after the first paint.
+    let matcher: ((name: string) => boolean) | undefined;
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <AssistantFileLinkResolverProvider
+            serverId="server-1"
+            workspaceRoot="/Users/test/project"
+            isSlashCommand={matcher}
+          >
+            {children}
+          </AssistantFileLinkResolverProvider>
+        </QueryClientProvider>
+      );
+    }
+
+    const { result, rerender } = renderHook(() => useAssistantFileLinkActions(), {
+      wrapper: Wrapper,
+    });
+
+    const beforeLoad = result.current;
+    expect(beforeLoad.isSlashCommand("autoplan")).toBe(false);
+
+    matcher = (name: string) => name === "autoplan";
+    rerender();
+
+    expect(result.current).not.toBe(beforeLoad);
+    expect(result.current.isSlashCommand("autoplan")).toBe(true);
+  });
 });

--- a/packages/app/src/assistant-file-links/use-file-link.test.tsx
+++ b/packages/app/src/assistant-file-links/use-file-link.test.tsx
@@ -9,7 +9,7 @@ import type { ToastApi } from "@/components/toast-host";
 import type { InlinePathTarget } from "./parse";
 import { AssistantFileLinkResolverProvider } from "./provider";
 import type { DirectorySuggestionResult } from "./resolver";
-import { useFileLink } from "./use-file-link";
+import { useAssistantFileLinkActions, useFileLink } from "./use-file-link";
 import type { OpenFileDisposition } from "@/workspace/file-open";
 
 vi.mock("@/utils/open-external-url", () => ({
@@ -327,3 +327,39 @@ describe("useFileLink", () => {
 });
 
 const WorkspaceSwitchContext = React.createContext<(workspaceRoot: string) => void>(() => {});
+
+describe("useAssistantFileLinkActions slash commands", () => {
+  function createActionsWrapper(input: { isSlashCommand?: (name: string) => boolean }) {
+    const queryClient = createQueryClient();
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <AssistantFileLinkResolverProvider
+            serverId="server-1"
+            workspaceRoot="/Users/test/project"
+            isSlashCommand={input.isSlashCommand}
+          >
+            {children}
+          </AssistantFileLinkResolverProvider>
+        </QueryClientProvider>
+      );
+    };
+  }
+
+  it("matches known command names and defaults to false", () => {
+    const { result } = renderHook(() => useAssistantFileLinkActions(), {
+      wrapper: createActionsWrapper({ isSlashCommand: (name) => name === "autoplan" }),
+    });
+
+    expect(result.current.isSlashCommand("autoplan")).toBe(true);
+    expect(result.current.isSlashCommand("nope")).toBe(false);
+  });
+
+  it("returns false when no matcher is configured", () => {
+    const { result } = renderHook(() => useAssistantFileLinkActions(), {
+      wrapper: createActionsWrapper({}),
+    });
+
+    expect(result.current.isSlashCommand("autoplan")).toBe(false);
+  });
+});

--- a/packages/app/src/assistant-file-links/use-file-link.ts
+++ b/packages/app/src/assistant-file-links/use-file-link.ts
@@ -157,9 +157,13 @@ export function useAssistantFileLinkActions(): AssistantFileLinkActions {
       canResolveAssistantFileLinkToFile(source, context.configRef.current.workspaceRoot),
     [context.configRef],
   );
+  // Read off the context value, not configRef: this feeds a render decision, so
+  // its identity has to change when the command list loads (see the note on
+  // AssistantFileLinkResolverContextValue.isSlashCommand).
+  const contextIsSlashCommand = context.isSlashCommand;
   const isSlashCommand = useCallback(
-    (name: string) => context.configRef.current.isSlashCommand?.(name) ?? false,
-    [context.configRef],
+    (name: string) => contextIsSlashCommand?.(name) ?? false,
+    [contextIsSlashCommand],
   );
 
   return useMemo(

--- a/packages/app/src/assistant-file-links/use-file-link.ts
+++ b/packages/app/src/assistant-file-links/use-file-link.ts
@@ -28,6 +28,7 @@ export interface AssistantFileLinkActions {
   open(source: AssistantFileLinkSource, disposition: OpenFileDisposition): void;
   canOpen(source: AssistantFileLinkSource): boolean;
   canResolveFile(source: AssistantFileLinkSource): boolean;
+  isSlashCommand(name: string): boolean;
 }
 
 type AssistantFileLinkQueryKey = readonly [
@@ -156,8 +157,15 @@ export function useAssistantFileLinkActions(): AssistantFileLinkActions {
       canResolveAssistantFileLinkToFile(source, context.configRef.current.workspaceRoot),
     [context.configRef],
   );
+  const isSlashCommand = useCallback(
+    (name: string) => context.configRef.current.isSlashCommand?.(name) ?? false,
+    [context.configRef],
+  );
 
-  return useMemo(() => ({ open, canOpen, canResolveFile }), [open, canOpen, canResolveFile]);
+  return useMemo(
+    () => ({ open, canOpen, canResolveFile, isSlashCommand }),
+    [open, canOpen, canResolveFile, isSlashCommand],
+  );
 }
 
 function openAssistantFileLink(input: {

--- a/packages/app/src/components/composer-insert.test.tsx
+++ b/packages/app/src/components/composer-insert.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import React, { useCallback, useState, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ComposerInsertProvider, useComposerInsert } from "./composer-insert";
+
+function createWrapper(setText: (text: string) => void) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const [text, internalSetText] = useState("run");
+    const apply = useCallback((next: string) => {
+      internalSetText(next);
+      setText(next);
+    }, []);
+    return (
+      <ComposerInsertProvider text={text} setText={apply}>
+        {children}
+      </ComposerInsertProvider>
+    );
+  };
+}
+
+describe("ComposerInsertProvider", () => {
+  it("appends the command and focuses the registered composer", () => {
+    const setText = vi.fn();
+    const focus = vi.fn();
+    const { result } = renderHook(() => useComposerInsert(), {
+      wrapper: createWrapper(setText),
+    });
+
+    act(() => {
+      result.current?.registerFocusHandler(focus);
+      result.current?.insertSlashCommand("/autoplan");
+    });
+
+    expect(setText).toHaveBeenCalledWith("run /autoplan ");
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when no focus handler is registered", () => {
+    const setText = vi.fn();
+    const { result } = renderHook(() => useComposerInsert(), {
+      wrapper: createWrapper(setText),
+    });
+
+    act(() => {
+      result.current?.insertSlashCommand("/autoplan");
+    });
+
+    expect(setText).toHaveBeenCalledWith("run /autoplan ");
+  });
+
+  it("stops focusing after the composer unregisters", () => {
+    const setText = vi.fn();
+    const focus = vi.fn();
+    const { result } = renderHook(() => useComposerInsert(), {
+      wrapper: createWrapper(setText),
+    });
+
+    act(() => {
+      result.current?.registerFocusHandler(focus);
+      result.current?.registerFocusHandler(null);
+      result.current?.insertSlashCommand("/autoplan");
+    });
+
+    expect(focus).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/components/composer-insert.tsx
+++ b/packages/app/src/components/composer-insert.tsx
@@ -1,0 +1,62 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from "react";
+import { appendSlashCommandToken } from "@/assistant-file-links/slash-command";
+
+interface ComposerInsertContextValue {
+  insertSlashCommand: (token: string) => void;
+  // The composer registers its focus function here so an insert can focus the
+  // input afterwards. Called with `null` when the composer unmounts.
+  registerFocusHandler: (focus: (() => void) | null) => void;
+}
+
+interface ComposerInsertProviderProps {
+  text: string;
+  setText: (text: string) => void;
+  children: ReactNode;
+}
+
+const ComposerInsertContext = createContext<ComposerInsertContextValue | null>(null);
+
+// Lets code outside the composer (e.g. a slash-command chip rendered inside an
+// assistant message) append text to the active composer draft. Mirrors
+// RewindComposerRestoreProvider: it is fed the same live `text`/`setText` from
+// the agent input draft and holds a ref so consumers append relative to the
+// latest value without re-subscribing on every keystroke.
+export function ComposerInsertProvider({ text, setText, children }: ComposerInsertProviderProps) {
+  const textRef = useRef(text);
+  const focusRef = useRef<(() => void) | null>(null);
+
+  // Keep the latest draft text in a ref via render-time assignment (same pattern
+  // as AssistantFileLinkResolverProvider's configRef) so an insert reads the
+  // current value with no one-render stale window.
+  textRef.current = text;
+
+  const registerFocusHandler = useCallback((focus: (() => void) | null) => {
+    focusRef.current = focus;
+  }, []);
+
+  const insertSlashCommand = useCallback(
+    (token: string) => {
+      setText(appendSlashCommandToken({ text: textRef.current, token }));
+      focusRef.current?.();
+    },
+    [setText],
+  );
+
+  const value = useMemo(
+    () => ({ insertSlashCommand, registerFocusHandler }),
+    [insertSlashCommand, registerFocusHandler],
+  );
+
+  return <ComposerInsertContext.Provider value={value}>{children}</ComposerInsertContext.Provider>;
+}
+
+export function useComposerInsert(): ComposerInsertContextValue | null {
+  return useContext(ComposerInsertContext);
+}

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -87,10 +87,12 @@ import { useToolCallSheet } from "./tool-call-sheet";
 import { ToolCallDetailsContent } from "./tool-call-details";
 import {
   AssistantInlineCodePathLink,
+  AssistantInlineSlashCommandLink,
   type AssistantFileLinkSource,
   AssistantMarkdownCodeLink,
   AssistantMarkdownLink,
   type InlinePathTarget,
+  parseSlashCommandToken,
   useAssistantFileLinkActions,
   useAssistantLinkPress,
 } from "@/assistant-file-links";
@@ -1715,6 +1717,27 @@ export const AssistantMessage = memo(function AssistantMessage({
       ) => {
         const content = node.content ?? "";
         const isLinkedInlineCode = nodeHasParentType(parent, "link");
+
+        // A leading-slash token like `/autoplan` looks like an absolute path but
+        // may be a slash command / skill the agent is referring to. When it
+        // matches a known command for this agent, render it as a command chip
+        // (append to composer on press) instead of a file link. This runs before
+        // the path branch so a known command wins over the path interpretation.
+        if (!isLinkedInlineCode) {
+          const commandName = parseSlashCommandToken(content);
+          if (commandName && fileLinkActions.isSlashCommand(commandName)) {
+            return (
+              <AssistantInlineSlashCommandLink
+                key={node.key}
+                token={`/${commandName}`}
+                inheritedStyles={inheritedStyles}
+                codeInlineStyle={styles.code_inline}
+                linkStyle={styles.link}
+              />
+            );
+          }
+        }
+
         const inlineCodeSource: AssistantFileLinkSource = {
           href: content,
           text: content,

--- a/packages/app/src/hooks/use-agent-commands-query.ts
+++ b/packages/app/src/hooks/use-agent-commands-query.ts
@@ -7,6 +7,7 @@ import { agentCommandsQueryKey, type AgentCommandsDraftConfig } from "@/hooks/ag
 
 const DRAFT_COMMANDS_STALE_TIME = Number.POSITIVE_INFINITY;
 const SESSION_COMMANDS_STALE_TIME = 60_000;
+const NO_COMMANDS: AgentSlashCommand[] = [];
 
 export interface AgentSlashCommand {
   name: string;
@@ -76,7 +77,9 @@ export function useAgentCommandsQuery({
   const isLoading = query.isPending || query.isLoading;
 
   return {
-    commands: query.data ?? [],
+    // Stable reference while the query has no data, so callers can memoize on
+    // `commands` without recomputing on every render during loading.
+    commands: query.data ?? NO_COMMANDS,
     isLoading,
     isError: query.isError,
     error: query.error,

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -294,6 +294,7 @@ export const ar: TranslationResources = {
       forkMissingWorkspace: "هذا الوكيل ليس في مساحة عمل.",
       forkFailed: "فشل تفريع المحادثة",
       openFile: "افتح الملف",
+      insertIntoComposer: "إدراج في مربع الإنشاء",
       copied: "منقول",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -294,7 +294,7 @@ export const ar: TranslationResources = {
       forkMissingWorkspace: "هذا الوكيل ليس في مساحة عمل.",
       forkFailed: "فشل تفريع المحادثة",
       openFile: "افتح الملف",
-      insertIntoComposer: "إدراج في مربع الإنشاء",
+      insertIntoComposer: "إدراج في الرسالة",
       copied: "منقول",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -292,6 +292,7 @@ export const en = {
       forkMissingWorkspace: "This agent is not in a workspace.",
       forkFailed: "Failed to fork chat",
       openFile: "Open file",
+      insertIntoComposer: "Insert into composer",
       copied: "Copied",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -297,6 +297,7 @@ export const es: TranslationResources = {
       forkMissingWorkspace: "Este agente no está en un espacio de trabajo.",
       forkFailed: "No se pudo bifurcar el chat",
       openFile: "Abrir archivo",
+      insertIntoComposer: "Insertar en el compositor",
       copied: "Copiado",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -297,7 +297,7 @@ export const es: TranslationResources = {
       forkMissingWorkspace: "Este agente no está en un espacio de trabajo.",
       forkFailed: "No se pudo bifurcar el chat",
       openFile: "Abrir archivo",
-      insertIntoComposer: "Insertar en el compositor",
+      insertIntoComposer: "Insertar en el mensaje",
       copied: "Copiado",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -298,7 +298,7 @@ export const fr: TranslationResources = {
       forkMissingWorkspace: "Cet agent n'est pas dans un espace de travail.",
       forkFailed: "Impossible de dupliquer le chat",
       openFile: "Ouvrir le fichier",
-      insertIntoComposer: "Insérer dans le compositeur",
+      insertIntoComposer: "Insérer dans le message",
       copied: "Copié",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -298,6 +298,7 @@ export const fr: TranslationResources = {
       forkMissingWorkspace: "Cet agent n'est pas dans un espace de travail.",
       forkFailed: "Impossible de dupliquer le chat",
       openFile: "Ouvrir le fichier",
+      insertIntoComposer: "Insérer dans le compositeur",
       copied: "Copié",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -297,6 +297,7 @@ export const ja: TranslationResources = {
       forkMissingWorkspace: "このエージェントはワークスペース内にありません。",
       forkFailed: "チャットのフォークに失敗しました",
       openFile: "ファイルを開く",
+      insertIntoComposer: "コンポーザーに挿入",
       copied: "コピーしました",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -297,7 +297,7 @@ export const ja: TranslationResources = {
       forkMissingWorkspace: "このエージェントはワークスペース内にありません。",
       forkFailed: "チャットのフォークに失敗しました",
       openFile: "ファイルを開く",
-      insertIntoComposer: "コンポーザーに挿入",
+      insertIntoComposer: "メッセージに挿入",
       copied: "コピーしました",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -295,6 +295,7 @@ export const ko: TranslationResources = {
       forkMissingWorkspace: "이 에이전트는 워크스페이스에 속해 있지 않습니다.",
       forkFailed: "채팅을 분기하지 못했습니다.",
       openFile: "파일 열기",
+      insertIntoComposer: "작성기에 삽입",
       copied: "복사됨",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -295,7 +295,7 @@ export const ko: TranslationResources = {
       forkMissingWorkspace: "이 에이전트는 워크스페이스에 속해 있지 않습니다.",
       forkFailed: "채팅을 분기하지 못했습니다.",
       openFile: "파일 열기",
-      insertIntoComposer: "작성기에 삽입",
+      insertIntoComposer: "메시지에 삽입",
       copied: "복사됨",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -297,7 +297,7 @@ export const ptBR: TranslationResources = {
       forkMissingWorkspace: "Este agente não está em um workspace.",
       forkFailed: "Falha ao bifurcar o chat",
       openFile: "Abrir arquivo",
-      insertIntoComposer: "Inserir no compositor",
+      insertIntoComposer: "Inserir na mensagem",
       copied: "Copiado",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -297,6 +297,7 @@ export const ptBR: TranslationResources = {
       forkMissingWorkspace: "Este agente não está em um workspace.",
       forkFailed: "Falha ao bifurcar o chat",
       openFile: "Abrir arquivo",
+      insertIntoComposer: "Inserir no compositor",
       copied: "Copiado",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -296,6 +296,7 @@ export const ru: TranslationResources = {
       forkMissingWorkspace: "Этот агент не находится в рабочем пространстве.",
       forkFailed: "Не удалось форкнуть чат",
       openFile: "Открыть файл",
+      insertIntoComposer: "Вставить в композитор",
       copied: "Скопировано",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -296,7 +296,7 @@ export const ru: TranslationResources = {
       forkMissingWorkspace: "Этот агент не находится в рабочем пространстве.",
       forkFailed: "Не удалось форкнуть чат",
       openFile: "Открыть файл",
-      insertIntoComposer: "Вставить в композитор",
+      insertIntoComposer: "Вставить в сообщение",
       copied: "Скопировано",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -294,6 +294,7 @@ export const zhCN: TranslationResources = {
       forkMissingWorkspace: "此 Agent 不在工作区中。",
       forkFailed: "分叉聊天失败",
       openFile: "打开文件",
+      insertIntoComposer: "插入到编辑器",
       copied: "已复制",
     },
     attachments: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -294,7 +294,7 @@ export const zhCN: TranslationResources = {
       forkMissingWorkspace: "此 Agent 不在工作区中。",
       forkFailed: "分叉聊天失败",
       openFile: "打开文件",
-      insertIntoComposer: "插入到编辑器",
+      insertIntoComposer: "插入到消息框",
       copied: "已复制",
     },
     attachments: {

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -26,6 +26,7 @@ import { useRetainedPanelActive } from "@/components/retained-panel";
 import { SidebarCallout } from "@/components/sidebar-callout";
 import { Composer } from "@/composer";
 import { getActiveMessageSubmissions } from "@/composer/submission/model";
+import { ComposerInsertProvider, useComposerInsert } from "@/components/composer-insert";
 import { RewindComposerRestoreProvider } from "@/components/rewind/composer-restore";
 import { getProviderIcon } from "@/components/provider-icons";
 import {
@@ -1306,37 +1307,41 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
       text={agentInputDraft.text}
       setText={agentInputDraft.replaceText}
     >
-      <View style={styles.root}>
-        <FileDropZone style={styles.container} disabled={isArchivingCurrentAgent}>
-          {contentContainer}
+      <ComposerInsertProvider text={agentInputDraft.text} setText={agentInputDraft.replaceText}>
+        <View style={styles.root}>
+          <FileDropZone style={styles.container} disabled={isArchivingCurrentAgent}>
+            {contentContainer}
 
-          {showHistorySyncError ? (
-            <SidebarCallout
-              title={t("agentPanel.states.timelineSyncFailed")}
-              variant="error"
-              testID="agent-timeline-sync-error"
-            />
-          ) : null}
+            {showHistorySyncError ? (
+              <SidebarCallout
+                title={t("agentPanel.states.timelineSyncFailed")}
+                variant="error"
+                testID="agent-timeline-sync-error"
+              />
+            ) : null}
 
-          {composerSection}
+            {composerSection}
 
-          {showHistorySyncOverlay ? (
-            <View style={styles.historySyncOverlay} testID="agent-history-overlay">
-              <ThemedLoadingSpinner size="large" uniProps={foregroundMutedColorMapping} />
+            {showHistorySyncOverlay ? (
+              <View style={styles.historySyncOverlay} testID="agent-history-overlay">
+                <ThemedLoadingSpinner size="large" uniProps={foregroundMutedColorMapping} />
+              </View>
+            ) : null}
+
+            <ToastViewport toast={toast} onDismiss={dismiss} placement="panel" />
+          </FileDropZone>
+
+          {isArchivingCurrentAgent ? (
+            <View style={styles.archivingOverlay} testID="agent-archiving-overlay">
+              <ThemedLoadingSpinner size="large" uniProps={foregroundColorMapping} />
+              <Text style={styles.archivingTitle}>{t("agentPanel.states.archivingTitle")}</Text>
+              <Text style={styles.archivingSubtitle}>
+                {t("agentPanel.states.archivingSubtitle")}
+              </Text>
             </View>
           ) : null}
-
-          <ToastViewport toast={toast} onDismiss={dismiss} placement="panel" />
-        </FileDropZone>
-
-        {isArchivingCurrentAgent ? (
-          <View style={styles.archivingOverlay} testID="agent-archiving-overlay">
-            <ThemedLoadingSpinner size="large" uniProps={foregroundColorMapping} />
-            <Text style={styles.archivingTitle}>{t("agentPanel.states.archivingTitle")}</Text>
-            <Text style={styles.archivingSubtitle}>{t("agentPanel.states.archivingSubtitle")}</Text>
-          </View>
-        ) : null}
-      </View>
+        </View>
+      </ComposerInsertProvider>
     </RewindComposerRestoreProvider>
   );
 });
@@ -1608,6 +1613,16 @@ function ActiveAgentComposer({
     ],
   );
 
+  // Let a slash-command chip in the transcript focus this composer after it
+  // appends the command. ComposerInsertProvider wraps both the transcript and
+  // this composer, so registering here reaches the chip's insert path. Clear the
+  // handler on unmount so a stale focus fn doesn't linger past this composer.
+  const composerInsert = useComposerInsert();
+  const registerComposerFocus = composerInsert?.registerFocusHandler;
+  useEffect(() => {
+    return () => registerComposerFocus?.(null);
+  }, [registerComposerFocus]);
+
   const { style: composerKeyboardStyle } = useKeyboardShiftStyle({
     mode: "translate",
   });
@@ -1656,6 +1671,7 @@ function ActiveAgentComposer({
         onComposerHeightChange={onComposerHeightChange}
         onMessageSent={onMessageSent}
         onClientSlashCommand={handleClientSlashCommand}
+        onFocusInput={registerComposerFocus}
         isCompactLayout={isCompactComposerLayout}
       />
     </ReanimatedAnimated.View>


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [ ] Bug fix
- [x] New feature (trivial - no prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

**Why**

Agents regularly recommend the next skill or command to run (`/code-review`,
`/simplify`, …). The suggestion is right there on screen, but the only way to act
on it is to retype it by hand.

That hurts most in touch- and voice-driven workflows: on a tablet, acting on a
suggested skill means opening the on-screen keyboard to type a command I can
already see. On desktop it's milder, but retyping something that's visible in
front of me is still friction.

**The Change**

When an agent's message contains an inline-code token like `/code-review`, it
was rendered as a file link and clicking it tried to open the absolute path
`/code-review` — a file that doesn't exist. Leading-slash tokens are classified as
absolute paths by the assistant-file-link layer, so any `/command` in agent
output became a dead file link.

This makes a `/command` token clickable as a command instead: when the token
matches a known slash command / skill for that agent, it renders as a chip that
**appends the command to the composer and focuses the input**, so you can add
args and send. Tokens that aren't known commands keep today's file-path
behavior.

How it works:

- The command list comes from the existing `listCommands` query (shared cache
  with the composer — no extra network), gated to live agent streams that have a
  composer to insert into.
- Detection runs *before* the file-path branch in the inline-code markdown rule,
  so a known command wins over the path interpretation.
- The chip appends via a small `ComposerInsertProvider` that mirrors the existing
  rewind-restore seam, and focuses the input through the composer's existing
  `onFocusInput` handle.

Client-only; no protocol change. Inline-code only (plain-text `/foo` isn't
linkified today and is untouched).


### How did you verify it

Automated (run locally, all green):

- `npm run typecheck`
- `npm run lint`
- `npm run format` (Biome)
- Unit tests — 19 passing across:
  - `parseSlashCommandToken` / `appendSlashCommandToken` (token parsing + append
    semantics: `/autoplan` → command, `/foo/bar` and `/foo.ts` → not a command,
    whitespace handling)
  - `useAssistantFileLinkActions` slash-command matching (known vs unknown vs no
    matcher)
  - `ComposerInsertProvider` (appends + focuses the registered composer; no-op
    when nothing registered / after unregister)

Manual QA (video attached):


https://github.com/user-attachments/assets/9d20ee84-f80b-4e26-a66f-393eb99b2d08


### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
