### PR TITLE
Reduce composer overhead while typing

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -16,7 +16,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { useWindowDimensions, View } from "react-native";
+import { AppState, useWindowDimensions, View } from "react-native";
 import { GestureDetector, GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -97,6 +97,7 @@ import {
 import { getDaemonStartService } from "@/runtime/daemon-start-service";
 import { applyAppearance } from "@/screens/settings/appearance/apply-appearance";
 import { selectIsAgentListOpen, usePanelStore } from "@/stores/panel-store";
+import { flushDraftPersistStorage } from "@/stores/draft-store";
 import { THEME_TO_UNISTYLES, type ThemeName } from "@/styles/theme";
 import { installWebScrollbarStyles } from "@/styles/install-web-scrollbar-styles";
 import type { HostProfile } from "@/types/host-connection";
@@ -959,6 +960,14 @@ function RootAppTree() {
 
 export default function RootLayout() {
   useEffect(() => installWebScrollbarStyles(), []);
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState !== "active") {
+        void flushDraftPersistStorage();
+      }
+    });
+    return () => subscription.remove();
+  }, []);
 
   return (
     <QueryProvider>

--- a/packages/app/src/stores/draft-store/index.ts
+++ b/packages/app/src/stores/draft-store/index.ts
@@ -50,6 +50,13 @@ type DraftStore = DraftStoreState & DraftStoreActions;
 
 const draftGenerations = new Map<string, number>();
 let gcScheduled = false;
+const draftPersistStorage = createDraftPersistStorage(
+  createJSONStorage<DraftStoreState>(() => AsyncStorage),
+);
+
+export function flushDraftPersistStorage(): Promise<void> {
+  return draftPersistStorage?.flush() ?? Promise.resolve();
+}
 
 function createDraftRecord(input: {
   draft: DraftInput;
@@ -379,7 +386,7 @@ export const useDraftStore = create<DraftStore>()(
     {
       name: "paseo-drafts",
       version: DRAFT_STORE_VERSION,
-      storage: createDraftPersistStorage(createJSONStorage(() => AsyncStorage)),
+      storage: draftPersistStorage,
       migrate: (persistedState) => {
         return migratePersistedState(persistedState, {
           migrateLegacyImages,

--- a/packages/app/src/stores/draft-store/index.ts
+++ b/packages/app/src/stores/draft-store/index.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { createJSONStorage, persist } from "zustand/middleware";
+import { createJSONStorage, persist, type PersistStorage } from "zustand/middleware";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { AttachmentMetadata } from "@/attachments/types";
 import {
@@ -47,8 +47,57 @@ interface DraftStoreActions {
 
 type DraftStore = DraftStoreState & DraftStoreActions;
 
+const DRAFT_PERSIST_INTERVAL_MS = 200;
 const draftGenerations = new Map<string, number>();
 let gcScheduled = false;
+
+function createThrottledStorage<T>(
+  storage: PersistStorage<T> | undefined,
+): PersistStorage<T> | undefined {
+  if (!storage) {
+    return undefined;
+  }
+
+  let pending: { name: string; value: Parameters<typeof storage.setItem>[1] } | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let lastWriteAt = -Infinity;
+
+  const cancelTimer = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+  const flush = () => {
+    cancelTimer();
+    const write = pending;
+    pending = null;
+    if (!write) {
+      return;
+    }
+    storage.setItem(write.name, write.value);
+    lastWriteAt = Date.now();
+  };
+
+  return {
+    getItem: (name) => storage.getItem(name),
+    setItem: (name, value) => {
+      pending = { name, value };
+      const delay = DRAFT_PERSIST_INTERVAL_MS - (Date.now() - lastWriteAt);
+      if (delay <= 0) {
+        flush();
+        return;
+      }
+      timer ??= setTimeout(flush, delay);
+    },
+    removeItem: (name) => {
+      cancelTimer();
+      pending = null;
+      lastWriteAt = Date.now();
+      return storage.removeItem(name);
+    },
+  };
+}
 
 function createDraftRecord(input: {
   draft: DraftInput;
@@ -378,7 +427,7 @@ export const useDraftStore = create<DraftStore>()(
     {
       name: "paseo-drafts",
       version: DRAFT_STORE_VERSION,
-      storage: createJSONStorage(() => AsyncStorage),
+      storage: createThrottledStorage(createJSONStorage(() => AsyncStorage)),
       migrate: (persistedState) => {
         return migratePersistedState(persistedState, {
           migrateLegacyImages,

--- a/packages/app/src/stores/draft-store/index.ts
+++ b/packages/app/src/stores/draft-store/index.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { createJSONStorage, persist, type PersistStorage } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { AttachmentMetadata } from "@/attachments/types";
 import {
@@ -26,6 +26,7 @@ import {
   type DraftStoreState,
 } from "./state";
 import { migrateDraftInput, migratePersistedState, type MigrateLegacyImages } from "./migration";
+import { createDraftPersistStorage } from "./persistence";
 
 export type { DraftInput, DraftLifecycleState } from "./state";
 
@@ -47,57 +48,8 @@ interface DraftStoreActions {
 
 type DraftStore = DraftStoreState & DraftStoreActions;
 
-const DRAFT_PERSIST_INTERVAL_MS = 200;
 const draftGenerations = new Map<string, number>();
 let gcScheduled = false;
-
-function createThrottledStorage<T>(
-  storage: PersistStorage<T> | undefined,
-): PersistStorage<T> | undefined {
-  if (!storage) {
-    return undefined;
-  }
-
-  let pending: { name: string; value: Parameters<typeof storage.setItem>[1] } | null = null;
-  let timer: ReturnType<typeof setTimeout> | null = null;
-  let lastWriteAt = -Infinity;
-
-  const cancelTimer = () => {
-    if (timer !== null) {
-      clearTimeout(timer);
-      timer = null;
-    }
-  };
-  const flush = () => {
-    cancelTimer();
-    const write = pending;
-    pending = null;
-    if (!write) {
-      return;
-    }
-    storage.setItem(write.name, write.value);
-    lastWriteAt = Date.now();
-  };
-
-  return {
-    getItem: (name) => storage.getItem(name),
-    setItem: (name, value) => {
-      pending = { name, value };
-      const delay = DRAFT_PERSIST_INTERVAL_MS - (Date.now() - lastWriteAt);
-      if (delay <= 0) {
-        flush();
-        return;
-      }
-      timer ??= setTimeout(flush, delay);
-    },
-    removeItem: (name) => {
-      cancelTimer();
-      pending = null;
-      lastWriteAt = Date.now();
-      return storage.removeItem(name);
-    },
-  };
-}
 
 function createDraftRecord(input: {
   draft: DraftInput;
@@ -427,7 +379,7 @@ export const useDraftStore = create<DraftStore>()(
     {
       name: "paseo-drafts",
       version: DRAFT_STORE_VERSION,
-      storage: createThrottledStorage(createJSONStorage(() => AsyncStorage)),
+      storage: createDraftPersistStorage(createJSONStorage(() => AsyncStorage)),
       migrate: (persistedState) => {
         return migratePersistedState(persistedState, {
           migrateLegacyImages,

--- a/packages/app/src/stores/draft-store/persistence.test.ts
+++ b/packages/app/src/stores/draft-store/persistence.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { PersistStorage, StorageValue } from "zustand/middleware";
+import {
+  createDraftPersistStorage,
+  DRAFT_PERSIST_INTERVAL_MS,
+  type PersistenceScheduler,
+} from "./persistence";
+
+interface DraftState {
+  text: string;
+}
+
+function createDraftPersistence() {
+  let nowMs = 0;
+  let saved: StorageValue<DraftState> | null = null;
+  let scheduled: { callback: () => void; dueAt: number } | null = null;
+  const storage: PersistStorage<DraftState> = {
+    getItem: () => saved,
+    setItem: (_name, value) => {
+      saved = value;
+    },
+    removeItem: () => {
+      saved = null;
+    },
+  };
+  const scheduler: PersistenceScheduler = {
+    now: () => nowMs,
+    schedule: (callback, delayMs) => (scheduled = { callback, dueAt: nowMs + delayMs }),
+    cancel: () => {
+      scheduled = null;
+    },
+  };
+  const drafts = createDraftPersistStorage(storage, scheduler);
+
+  return {
+    save(text: string) {
+      drafts.setItem("drafts", { state: { text } });
+    },
+    remove() {
+      drafts.removeItem("drafts");
+    },
+    advance(ms: number) {
+      nowMs += ms;
+      if (scheduled && scheduled.dueAt <= nowMs) {
+        const { callback } = scheduled;
+        scheduled = null;
+        callback();
+      }
+    },
+    text() {
+      return saved?.state.text ?? null;
+    },
+  };
+}
+
+describe("draft persistence", () => {
+  it("checkpoints the first change and the latest change in each interval", () => {
+    const drafts = createDraftPersistence();
+
+    drafts.save("a");
+    drafts.save("ab");
+    drafts.save("abc");
+    expect(drafts.text()).toBe("a");
+
+    drafts.advance(DRAFT_PERSIST_INTERVAL_MS - 1);
+    expect(drafts.text()).toBe("a");
+
+    drafts.advance(1);
+    expect(drafts.text()).toBe("abc");
+  });
+
+  it("does not restore a pending draft after storage is cleared", () => {
+    const drafts = createDraftPersistence();
+
+    drafts.save("first checkpoint");
+    drafts.save("pending checkpoint");
+    drafts.remove();
+    drafts.advance(DRAFT_PERSIST_INTERVAL_MS);
+
+    expect(drafts.text()).toBeNull();
+  });
+});

--- a/packages/app/src/stores/draft-store/persistence.test.ts
+++ b/packages/app/src/stores/draft-store/persistence.test.ts
@@ -39,6 +39,9 @@ function createDraftPersistence() {
     remove() {
       drafts.removeItem("drafts");
     },
+    flush() {
+      return drafts.flush();
+    },
     advance(ms: number) {
       nowMs += ms;
       if (scheduled && scheduled.dueAt <= nowMs) {
@@ -78,5 +81,29 @@ describe("draft persistence", () => {
     drafts.advance(DRAFT_PERSIST_INTERVAL_MS);
 
     expect(drafts.text()).toBeNull();
+  });
+
+  it("continues checkpointing the latest change across consecutive intervals", () => {
+    const drafts = createDraftPersistence();
+
+    drafts.save("first");
+    drafts.save("first interval");
+    drafts.advance(DRAFT_PERSIST_INTERVAL_MS);
+    expect(drafts.text()).toBe("first interval");
+
+    drafts.save("second");
+    drafts.save("second interval");
+    drafts.advance(DRAFT_PERSIST_INTERVAL_MS);
+    expect(drafts.text()).toBe("second interval");
+  });
+
+  it("flushes the latest pending change before the interval ends", async () => {
+    const drafts = createDraftPersistence();
+
+    drafts.save("first checkpoint");
+    drafts.save("pending checkpoint");
+    await drafts.flush();
+
+    expect(drafts.text()).toBe("pending checkpoint");
   });
 });

--- a/packages/app/src/stores/draft-store/persistence.ts
+++ b/packages/app/src/stores/draft-store/persistence.ts
@@ -1,0 +1,72 @@
+import type { PersistStorage } from "zustand/middleware";
+
+export const DRAFT_PERSIST_INTERVAL_MS = 200;
+
+export interface PersistenceScheduler {
+  now: () => number;
+  schedule: (callback: () => void, delayMs: number) => unknown;
+  cancel: (handle: unknown) => void;
+}
+
+const systemScheduler: PersistenceScheduler = {
+  now: Date.now,
+  schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+  cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+export function createDraftPersistStorage<T>(
+  storage: PersistStorage<T>,
+  scheduler?: PersistenceScheduler,
+): PersistStorage<T>;
+export function createDraftPersistStorage<T>(
+  storage: PersistStorage<T> | undefined,
+  scheduler?: PersistenceScheduler,
+): PersistStorage<T> | undefined;
+export function createDraftPersistStorage<T>(
+  storage: PersistStorage<T> | undefined,
+  scheduler: PersistenceScheduler = systemScheduler,
+): PersistStorage<T> | undefined {
+  if (!storage) {
+    return undefined;
+  }
+
+  let pending: { name: string; value: Parameters<typeof storage.setItem>[1] } | null = null;
+  let timer: unknown = null;
+  let lastWriteAt = -Infinity;
+
+  const cancelTimer = () => {
+    if (timer !== null) {
+      scheduler.cancel(timer);
+      timer = null;
+    }
+  };
+  const flush = () => {
+    cancelTimer();
+    const write = pending;
+    pending = null;
+    if (!write) {
+      return;
+    }
+    storage.setItem(write.name, write.value);
+    lastWriteAt = scheduler.now();
+  };
+
+  return {
+    getItem: (name) => storage.getItem(name),
+    setItem: (name, value) => {
+      pending = { name, value };
+      const delay = DRAFT_PERSIST_INTERVAL_MS - (scheduler.now() - lastWriteAt);
+      if (delay <= 0) {
+        flush();
+        return;
+      }
+      timer ??= scheduler.schedule(flush, delay);
+    },
+    removeItem: (name) => {
+      cancelTimer();
+      pending = null;
+      lastWriteAt = scheduler.now();
+      return storage.removeItem(name);
+    },
+  };
+}

--- a/packages/app/src/stores/draft-store/persistence.ts
+++ b/packages/app/src/stores/draft-store/persistence.ts
@@ -8,6 +8,10 @@ export interface PersistenceScheduler {
   cancel: (handle: unknown) => void;
 }
 
+export interface DraftPersistStorage<T> extends PersistStorage<T> {
+  flush: () => Promise<void>;
+}
+
 const systemScheduler: PersistenceScheduler = {
   now: Date.now,
   schedule: (callback, delayMs) => setTimeout(callback, delayMs),
@@ -17,15 +21,15 @@ const systemScheduler: PersistenceScheduler = {
 export function createDraftPersistStorage<T>(
   storage: PersistStorage<T>,
   scheduler?: PersistenceScheduler,
-): PersistStorage<T>;
+): DraftPersistStorage<T>;
 export function createDraftPersistStorage<T>(
   storage: PersistStorage<T> | undefined,
   scheduler?: PersistenceScheduler,
-): PersistStorage<T> | undefined;
+): DraftPersistStorage<T> | undefined;
 export function createDraftPersistStorage<T>(
   storage: PersistStorage<T> | undefined,
   scheduler: PersistenceScheduler = systemScheduler,
-): PersistStorage<T> | undefined {
+): DraftPersistStorage<T> | undefined {
   if (!storage) {
     return undefined;
   }
@@ -40,15 +44,19 @@ export function createDraftPersistStorage<T>(
       timer = null;
     }
   };
-  const flush = () => {
+  const flush = async (): Promise<void> => {
     cancelTimer();
     const write = pending;
     pending = null;
     if (!write) {
       return;
     }
-    storage.setItem(write.name, write.value);
     lastWriteAt = scheduler.now();
+    try {
+      await storage.setItem(write.name, write.value);
+    } catch (error) {
+      console.warn("[DraftStore] Failed to persist draft checkpoint", error);
+    }
   };
 
   return {
@@ -57,10 +65,11 @@ export function createDraftPersistStorage<T>(
       pending = { name, value };
       const delay = DRAFT_PERSIST_INTERVAL_MS - (scheduler.now() - lastWriteAt);
       if (delay <= 0) {
-        flush();
-        return;
+        return flush();
       }
-      timer ??= scheduler.schedule(flush, delay);
+      timer ??= scheduler.schedule(() => {
+        void flush();
+      }, delay);
     },
     removeItem: (name) => {
       cancelTimer();
@@ -68,5 +77,6 @@ export function createDraftPersistStorage<T>(
       lastWriteAt = scheduler.now();
       return storage.removeItem(name);
     },
+    flush,
   };
 }


### PR DESCRIPTION
### Linked issue

Refs #118

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

Keeps composer draft state current in memory on every keystroke while checkpointing persisted storage at most once every 200 ms. Sustained typing still receives regular leading and trailing checkpoints, but duplicate persistence work is coalesced instead of writing for every state update.

The throttle lives at the storage boundary. Pending checkpoints flush when the app leaves the foreground, draft removal cancels pending writes, and asynchronous persistence failures are reported in logs.

### How did you verify it

- Measured a 200-character typing sequence in a long chat with throwaway Playwright against the current daemon. Before the change it produced 400 draft storage writes; after the change it produced 15 writes at 200–228 ms intervals, with the complete final text persisted.
- `npx vitest run packages/app/src/stores/draft-store/persistence.test.ts --bail=1` covers leading/latest-trailing checkpoints, consecutive throttle intervals, forced lifecycle flushing, and pending-write cancellation when storage is cleared.
- `npx vitest run packages/app/src/composer/draft/input-draft.live.test.tsx --bail=1`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

Risk surface: during sustained typing, persisted storage may trail the current in-memory draft by up to 200 ms. Normal backgrounding flushes that pending checkpoint immediately; only abrupt process termination without a lifecycle transition retains that bounded window.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI change)
- [x] Tests added or updated where it made sense
