### PR TITLE
feat(app): add Solarized Teal appearance theme

### DIFF
--- a/docs/unistyles.md
+++ b/docs/unistyles.md
@@ -330,7 +330,7 @@ If we ever need to avoid the transition entirely, store at least the theme prefe
 
 ## Runtime Theme Patching For User Preferences
 
-Appearance settings (UI/mono font family, font sizes, syntax-highlight theme) are applied by patching every registered theme at runtime with `UnistylesRuntime.updateTheme(name, updater)` — not by threading preference reads through components. `applyAppearance` in `packages/app/src/screens/settings/appearance/apply-appearance.ts` runs from a `ProvidersWrapper` effect on settings load/change and loops all six theme keys, returning `{ ...theme, fontFamily, fontSize, lineHeight, colors.syntax }`.
+Appearance settings (UI/mono font family, font sizes, syntax-highlight theme) are applied by patching every registered theme at runtime with `UnistylesRuntime.updateTheme(name, updater)` — not by threading preference reads through components. `applyAppearance` in `packages/app/src/screens/settings/appearance/apply-appearance.ts` runs from a `ProvidersWrapper` effect on settings load/change and loops all seven theme keys, returning `{ ...theme, fontFamily, fontSize, lineHeight, colors.syntax }`.
 
 This works without `useUnistyles()` because every consumer already reads these tokens through `StyleSheet.create((theme) => …)` (or the `withUnistyles`/`uniProps` path for the markdown renderer), so patching the theme repaints tracked views through the native ShadowRegistry with no React re-render.
 

--- a/packages/app/e2e/solarized-theme.spec.ts
+++ b/packages/app/e2e/solarized-theme.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type Page } from "./fixtures";
+import { buildSettingsSectionRoute } from "@/utils/host-routes";
+
+const APP_SETTINGS_KEY = "@paseo:app-settings";
+
+async function seedDarkTheme(page: Page): Promise<void> {
+  await page.addInitScript((settingsKey) => {
+    if (localStorage.getItem(settingsKey) === null) {
+      localStorage.setItem(settingsKey, JSON.stringify({ theme: "dark" }));
+    }
+  }, APP_SETTINGS_KEY);
+}
+
+async function openAppearance(page: Page): Promise<void> {
+  await page.goto(buildSettingsSectionRoute("appearance"));
+  await expect(page.getByText("Highlight theme", { exact: true }).first()).toBeVisible();
+}
+
+async function selectSolarizedTeal(page: Page): Promise<void> {
+  await page.getByLabel("Theme: Dark").click();
+  await page.getByRole("button", { name: "Solarized Teal", exact: true }).click();
+  await expect(page.getByLabel("Theme: Solarized Teal")).toBeVisible();
+}
+
+async function readStoredTheme(page: Page): Promise<string | null> {
+  return page.evaluate((settingsKey) => {
+    const raw = localStorage.getItem(settingsKey);
+    if (raw === null) return null;
+    const parsed = JSON.parse(raw) as { theme?: unknown };
+    return typeof parsed.theme === "string" ? parsed.theme : null;
+  }, APP_SETTINGS_KEY);
+}
+
+test("selects Solarized Teal and preserves it across reload", async ({ page }) => {
+  await seedDarkTheme(page);
+  await openAppearance(page);
+
+  await expect(page.getByTestId("settings-sidebar")).toBeVisible();
+  await expect(page.getByTestId("settings-detail-pane")).toBeVisible();
+  await selectSolarizedTeal(page);
+
+  const sidebar = page.getByTestId("settings-sidebar");
+  const appearanceRow = sidebar.getByRole("button", { name: "Appearance", exact: true });
+  const themeTrigger = page.getByLabel("Theme: Solarized Teal");
+  await expect(sidebar).toHaveCSS("background-color", "rgb(0, 33, 43)");
+  await expect(sidebar).toHaveCSS("border-right-color", "rgb(22, 72, 82)");
+  await expect(appearanceRow).toHaveCSS("background-color", "rgb(10, 76, 82)");
+  await expect(sidebar.getByText("Appearance", { exact: true })).toHaveCSS(
+    "color",
+    "rgb(201, 214, 211)",
+  );
+  await expect(themeTrigger).toHaveCSS("border-top-color", "rgb(22, 72, 82)");
+  await expect(themeTrigger.getByText("Solarized Teal", { exact: true })).toHaveCSS(
+    "color",
+    "rgb(201, 214, 211)",
+  );
+
+  await expect.poll(() => readStoredTheme(page)).toBe("solarized");
+
+  await page.reload();
+  await expect(page.getByLabel("Theme: Solarized Teal")).toBeVisible();
+  await expect.poll(() => readStoredTheme(page)).toBe("solarized");
+});
+
+test.describe("compact appearance", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("renders Solarized Teal without the desktop settings sidebar", async ({ page }) => {
+    await page.addInitScript(
+      ({ settingsKey, settings }) => {
+        localStorage.setItem(settingsKey, JSON.stringify(settings));
+      },
+      {
+        settingsKey: APP_SETTINGS_KEY,
+        settings: { theme: "solarized" },
+      },
+    );
+
+    await openAppearance(page);
+
+    await expect(page.getByRole("button", { name: "Back", exact: true })).toBeVisible();
+    await expect(page.getByText("Appearance", { exact: true }).first()).toBeVisible();
+    await expect(page.getByLabel("Theme: Solarized Teal")).toBeVisible();
+    await expect(page.locator('[data-testid="settings-sidebar"]:visible')).toHaveCount(0);
+  });
+});

--- a/packages/app/e2e/solarized-theme.spec.ts
+++ b/packages/app/e2e/solarized-theme.spec.ts
@@ -81,6 +81,6 @@ test.describe("compact appearance", () => {
     await expect(page.getByRole("button", { name: "Back", exact: true })).toBeVisible();
     await expect(page.getByText("Appearance", { exact: true }).first()).toBeVisible();
     await expect(page.getByLabel("Theme: Solarized Teal")).toBeVisible();
-    await expect(page.locator('[data-testid="settings-sidebar"]:visible')).toHaveCount(0);
+    await expect(page.getByTestId("settings-sidebar")).not.toBeVisible();
   });
 });

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -420,7 +420,15 @@ interface AppContainerProps {
   chromeEnabled?: boolean;
 }
 
-const THEME_CYCLE_ORDER: ThemeName[] = ["dark", "zinc", "midnight", "claude", "ghostty", "light"];
+const THEME_CYCLE_ORDER: ThemeName[] = [
+  "dark",
+  "zinc",
+  "midnight",
+  "claude",
+  "ghostty",
+  "solarized",
+  "light",
+];
 const WINDOW_SIDEBAR_TOGGLE_HORIZONTAL_PADDING = 12;
 
 function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppContainerProps) {
@@ -632,7 +640,7 @@ function ProvidersWrapper({ children }: { children: ReactNode }) {
 
   // Apply font / size / syntax appearance settings on mount and when they change.
   // Sibling to the theme effect above; order is irrelevant because both patch all
-  // six registered theme keys, so the active key is always current.
+  // seven registered theme keys, so the active key is always current.
   useEffect(() => {
     if (settingsLoading) return;
     applyAppearance({

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -42,6 +42,18 @@ describe("loadAppSettingsFromStorage", () => {
     expect(result.theme).toBe("auto");
   });
 
+  it("loads the persisted Solarized Teal theme", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ theme: "solarized" }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.theme).toBe("solarized");
+  });
+
   it("seeds storage with the client defaults when nothing is persisted", async () => {
     const deps = makeDeps();
 

--- a/packages/app/src/i18n/resources.test.ts
+++ b/packages/app/src/i18n/resources.test.ts
@@ -219,6 +219,7 @@ describe("translation resources", () => {
     expect(en.settings.about.title).toBe("About");
     expect(en.settings.about.releaseChannel.label).toBe("Release channel");
     expect(en.settings.appearance.theme.title).toBe("Theme");
+    expect(en.settings.appearance.theme.options.solarized).toBe("Solarized Teal");
     expect(en.settings.appearance.fonts.interfaceFont).toBe("Interface font");
     expect(en.settings.shortcuts.actions.rebind).toBe("Rebind");
     expect(en.settings.integrations.commandLine.title).toBe("Command line");

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1685,6 +1685,7 @@ export const ar: TranslationResources = {
           midnight: "منتصف الليل",
           claude: "كلود",
           ghostty: "شبحي",
+          solarized: "Solarized Teal",
           auto: "نظام",
         },
       },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1696,6 +1696,7 @@ export const en = {
           midnight: "Midnight",
           claude: "Claude",
           ghostty: "Ghostty",
+          solarized: "Solarized Teal",
           auto: "System",
         },
       },

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1732,6 +1732,7 @@ export const es: TranslationResources = {
           midnight: "Medianoche",
           claude: "claudio",
           ghostty: "fantasmal",
+          solarized: "Solarized Teal",
           auto: "Sistema",
         },
       },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1734,6 +1734,7 @@ export const fr: TranslationResources = {
           midnight: "Minuit",
           claude: "Claude",
           ghostty: "Fantôme",
+          solarized: "Solarized Teal",
           auto: "Système",
         },
       },

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1702,6 +1702,7 @@ export const ja: TranslationResources = {
           midnight: "Midnight",
           claude: "Claude",
           ghostty: "Ghostty",
+          solarized: "Solarized Teal",
           auto: "システム",
         },
       },

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1717,6 +1717,7 @@ export const ptBR: TranslationResources = {
           midnight: "Midnight",
           claude: "Claude",
           ghostty: "Ghostty",
+          solarized: "Solarized Teal",
           auto: "Sistema",
         },
       },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1722,6 +1722,7 @@ export const ru: TranslationResources = {
           midnight: "Полночь",
           claude: "Клод",
           ghostty: "Призрачный",
+          solarized: "Solarized Teal",
           auto: "Система",
         },
       },

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1667,6 +1667,7 @@ export const zhCN: TranslationResources = {
           midnight: "Midnight",
           claude: "Claude",
           ghostty: "Ghostty",
+          solarized: "Solarized Teal",
           auto: "系统",
         },
       },

--- a/packages/app/src/screens/settings/appearance/appearance-section.tsx
+++ b/packages/app/src/screens/settings/appearance/appearance-section.tsx
@@ -60,6 +60,7 @@ function getThemeLabel(t: TFunction, value: AppSettings["theme"]): string {
     midnight: "settings.appearance.theme.options.midnight",
     claude: "settings.appearance.theme.options.claude",
     ghostty: "settings.appearance.theme.options.ghostty",
+    solarized: "settings.appearance.theme.options.solarized",
     auto: "settings.appearance.theme.options.auto",
   };
   return t(labelKeys[value]);
@@ -71,6 +72,7 @@ const DARK_VARIANT_THEMES: readonly AppSettings["theme"][] = [
   "midnight",
   "claude",
   "ghostty",
+  "solarized",
 ];
 
 // Platform default stacks can be the bare native tokens ("normal"/"monospace");

--- a/packages/app/src/screens/settings/appearance/apply-appearance.test.ts
+++ b/packages/app/src/screens/settings/appearance/apply-appearance.test.ts
@@ -8,7 +8,7 @@ import { applyAppearance, type AppearanceInput } from "./apply-appearance";
 const { updateTheme } = vi.hoisted(() => ({ updateTheme: vi.fn() }));
 vi.mock("react-native-unistyles", () => ({ UnistylesRuntime: { updateTheme } }));
 
-// The six registered Unistyles theme keys, in the order applyAppearance patches them.
+// The seven registered Unistyles theme keys, in the order applyAppearance patches them.
 const ALL_THEME_KEYS = [
   "light",
   "dark",
@@ -16,6 +16,7 @@ const ALL_THEME_KEYS = [
   "darkMidnight",
   "darkClaude",
   "darkGhostty",
+  "darkSolarized",
 ] as const;
 
 // The signature of the updater passed to UnistylesRuntime.updateTheme.
@@ -87,7 +88,7 @@ describe("applyAppearance", () => {
   it("patches every registered Unistyles theme exactly once", () => {
     applyAppearance(makeInput());
 
-    expect(updateTheme).toHaveBeenCalledTimes(6);
+    expect(updateTheme).toHaveBeenCalledTimes(7);
     expect(updateTheme.mock.calls.map((call) => call[0])).toEqual([...ALL_THEME_KEYS]);
   });
 

--- a/packages/app/src/screens/settings/appearance/apply-appearance.ts
+++ b/packages/app/src/screens/settings/appearance/apply-appearance.ts
@@ -8,7 +8,7 @@ import {
 } from "@/styles/theme";
 import { applyRootUiFont } from "./apply-root-font";
 
-// All six registered Unistyles keys — pinned literal (greppable, type-checked).
+// All seven registered Unistyles keys — pinned literal (greppable, type-checked).
 // The `as const` element types are exactly `keyof UnistylesThemes`, so each key
 // is assignable to `UnistylesRuntime.updateTheme`'s first argument with no cast.
 const ALL_THEME_KEYS = [
@@ -18,6 +18,7 @@ const ALL_THEME_KEYS = [
   "darkMidnight",
   "darkClaude",
   "darkGhostty",
+  "darkSolarized",
 ] as const;
 
 // The UI font size at which the FONT_SIZE ramp is authored (1.0 scale factor).
@@ -57,7 +58,7 @@ function scaleFontSize(uiSize: number, codeSize: number): Theme["fontSize"] {
 
 /**
  * Patch every registered Unistyles theme with the user's appearance choices.
- * All six keys are patched because the active theme can change and adaptive mode
+ * All seven keys are patched because the active theme can change and adaptive mode
  * can flip light/dark — patching all keys keeps the active key always current and
  * makes ordering vs `setTheme`/`setAdaptiveThemes` irrelevant.
  */

--- a/packages/app/src/styles/theme.test.ts
+++ b/packages/app/src/styles/theme.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { darkSolarizedTheme, darkTheme, THEME_SWATCHES, THEME_TO_UNISTYLES } from "./theme";
+
+function relativeLuminance(hex: string): number {
+  const channels = hex
+    .slice(1)
+    .match(/.{2}/g)
+    ?.map((channel) => Number.parseInt(channel, 16) / 255)
+    .map((channel) => (channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4));
+  if (!channels || channels.length !== 3) throw new Error(`Invalid hex color: ${hex}`);
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background));
+  const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe("Solarized Teal app theme", () => {
+  it("registers a distinct selectable app theme without changing Paseo Dark", () => {
+    expect(THEME_TO_UNISTYLES.solarized).toBe("darkSolarized");
+    expect(THEME_SWATCHES.solarized).toBe("#2aa198");
+    expect(darkTheme.colors.surface0).toBe("#181B1A");
+    expect(darkTheme.colors.accent).toBe("#20744A");
+  });
+
+  it("uses the Solarized Teal chrome palette", () => {
+    expect(darkSolarizedTheme.colorScheme).toBe("dark");
+    expect(darkSolarizedTheme.colors).toMatchObject({
+      surface0: "#002b36",
+      surface1: "#073642",
+      surface2: "#0a3b45",
+      surface3: "#0a4548",
+      surface4: "#93a1a1",
+      surfaceDiffEmpty: "#012631",
+      surfaceSidebar: "#00212b",
+      surfaceSidebarHover: "#0a4c52",
+      surfaceWorkspace: "#002b36",
+      foreground: "#c9d6d3",
+      foregroundMuted: "#93a1a1",
+      foregroundExtraMuted: "#586e75",
+      border: "#164852",
+      borderAccent: "#586e7566",
+      accent: "#2aa198",
+      accentBright: "#55b8d8",
+      accentForeground: "#002b36",
+      ring: "#2aa19899",
+      destructive: "#dc322f",
+      success: "#859900",
+      diffAddition: "#859900",
+      diffDeletion: "#dc322f",
+      statusSuccess: "#9fb900",
+      statusDanger: "#ff746d",
+      statusWarning: "#d5a800",
+      statusMerged: "#9b9fe5",
+    });
+  });
+
+  it("uses the canonical Solarized terminal palette", () => {
+    expect(darkSolarizedTheme.colors.terminal).toEqual({
+      background: "#002b36",
+      foreground: "#e0e9e6",
+      cursor: "#2aa198",
+      cursorAccent: "#002b36",
+      selectionBackground: "#274642",
+      selectionForeground: "#e0e9e6",
+      black: "#073642",
+      red: "#dc322f",
+      green: "#859900",
+      yellow: "#b58900",
+      blue: "#268bd2",
+      magenta: "#d33682",
+      cyan: "#2aa198",
+      white: "#eee8d5",
+      brightBlack: "#002b36",
+      brightRed: "#cb4b16",
+      brightGreen: "#586e75",
+      brightYellow: "#657b83",
+      brightBlue: "#839496",
+      brightMagenta: "#6c71c4",
+      brightCyan: "#93a1a1",
+      brightWhite: "#fdf6e3",
+    });
+  });
+
+  it("keeps small muted and destructive text at WCAG AA contrast", () => {
+    const { colors } = darkSolarizedTheme;
+
+    expect(contrastRatio(colors.foregroundMuted, colors.surface1)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.foregroundMuted, colors.surface2)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.destructiveForeground, colors.destructive)).toBeGreaterThanOrEqual(
+      4.5,
+    );
+    expect(contrastRatio(colors.statusSuccess, colors.surface2)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.statusDanger, colors.surface2)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.statusWarning, colors.surface2)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(colors.statusMerged, colors.surface2)).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/packages/app/src/styles/theme.ts
+++ b/packages/app/src/styles/theme.ts
@@ -107,7 +107,7 @@ export const baseColors = {
   },
 } as const;
 
-export type ThemeName = "light" | "dark" | "zinc" | "midnight" | "claude" | "ghostty";
+export type ThemeName = "light" | "dark" | "zinc" | "midnight" | "claude" | "ghostty" | "solarized";
 
 // Diff stat colors — light uses muted tones, dark uses the brighter palette values
 const lightDiffColors = {
@@ -425,6 +425,74 @@ const ghosttyDarkColors = buildDarkSemanticColors({
   destructive: "#c44a55", // red with slight cool lean against the slate-blue surfaces
 });
 
+// Solarized Teal — VS Code Solarized Dark structure with brighter prose for
+// long agent timelines. The terminal keeps the canonical Solarized ANSI set.
+const solarizedDarkColors = {
+  ...buildDarkSemanticColors({
+    surface0: "#002b36",
+    surface1: "#073642",
+    surface2: "#0a3b45",
+    surface3: "#0a4548",
+    // surface4 is the composer placeholder token, so it must remain legible.
+    surface4: "#93a1a1",
+    surfaceDiffEmpty: "#012631",
+    surfaceSidebar: "#00212b",
+    surfaceSidebarHover: "#0a4c52",
+    foregroundMuted: "#93a1a1",
+    foregroundExtraMuted: "#586e75",
+    scrollbarHandle: "#586e75",
+    border: "#164852",
+    borderAccent: "#586e7566",
+    accent: "#2aa198",
+    accentBright: "#55b8d8",
+    accentForeground: "#002b36",
+    destructive: "#dc322f",
+  }),
+  surfaceWorkspace: "#002b36",
+  foreground: "#c9d6d3",
+  popoverForeground: "#c9d6d3",
+  primary: "#c9d6d3",
+  primaryForeground: "#002b36",
+  secondaryForeground: "#c9d6d3",
+  mutedForeground: "#93a1a1",
+  ring: "#2aa19899",
+  destructiveForeground: "#ffffff",
+  success: "#859900",
+  successForeground: "#002b36",
+  diffAddition: "#859900",
+  diffDeletion: "#dc322f",
+  // Brighter semantic variants keep 12px status text at WCAG AA contrast on
+  // elevated teal surfaces. Terminal ANSI colors remain canonical below.
+  statusSuccess: "#9fb900",
+  statusDanger: "#ff746d",
+  statusWarning: "#d5a800",
+  statusMerged: "#9b9fe5",
+  terminal: {
+    background: "#002b36",
+    foreground: "#e0e9e6",
+    cursor: "#2aa198",
+    cursorAccent: "#002b36",
+    selectionBackground: "#274642",
+    selectionForeground: "#e0e9e6",
+    black: "#073642",
+    red: "#dc322f",
+    green: "#859900",
+    yellow: "#b58900",
+    blue: "#268bd2",
+    magenta: "#d33682",
+    cyan: "#2aa198",
+    white: "#eee8d5",
+    brightBlack: "#002b36",
+    brightRed: "#cb4b16",
+    brightGreen: "#586e75",
+    brightYellow: "#657b83",
+    brightBlue: "#839496",
+    brightMagenta: "#6c71c4",
+    brightCyan: "#93a1a1",
+    brightWhite: "#fdf6e3",
+  },
+};
+
 export const SPACING = {
   0: 0,
   1: 4,
@@ -558,7 +626,13 @@ const darkShadow = {
   },
 } as const;
 
-function buildDarkTheme(semanticColors: ReturnType<typeof buildDarkSemanticColors>) {
+type DarkSemanticColors = ReturnType<typeof buildDarkSemanticColors>;
+type DarkThemeColors = Omit<DarkSemanticColors, "terminal"> & {
+  // Theme variants can supply their own ANSI palette while keeping every key.
+  terminal: { [K in keyof DarkSemanticColors["terminal"]]: string };
+};
+
+function buildDarkTheme(semanticColors: DarkThemeColors) {
   return {
     colorScheme: "dark" as const,
     colors: {
@@ -576,6 +650,7 @@ export const darkZincTheme = buildDarkTheme(zincDarkColors);
 export const darkMidnightTheme = buildDarkTheme(midnightDarkColors);
 export const darkClaudeTheme = buildDarkTheme(claudeDarkColors);
 export const darkGhosttyTheme = buildDarkTheme(ghosttyDarkColors);
+export const darkSolarizedTheme = buildDarkTheme(solarizedDarkColors);
 
 export const lightTheme = {
   colorScheme: "light" as const,
@@ -619,7 +694,8 @@ type UnistylesThemeKey =
   | "darkZinc"
   | "darkMidnight"
   | "darkClaude"
-  | "darkGhostty";
+  | "darkGhostty"
+  | "darkSolarized";
 
 export const THEME_TO_UNISTYLES: Record<ThemeName, UnistylesThemeKey> = {
   light: "light",
@@ -628,6 +704,7 @@ export const THEME_TO_UNISTYLES: Record<ThemeName, UnistylesThemeKey> = {
   midnight: "darkMidnight",
   claude: "darkClaude",
   ghostty: "darkGhostty",
+  solarized: "darkSolarized",
 };
 
 export const THEME_SWATCHES: Record<ThemeName, string> = {
@@ -637,4 +714,5 @@ export const THEME_SWATCHES: Record<ThemeName, string> = {
   midnight: "#4A6BA8",
   claude: "#D97757",
   ghostty: "#8caaee",
+  solarized: "#2aa198",
 };

--- a/packages/app/src/styles/unistyles.ts
+++ b/packages/app/src/styles/unistyles.ts
@@ -6,6 +6,7 @@ import {
   darkMidnightTheme,
   darkClaudeTheme,
   darkGhosttyTheme,
+  darkSolarizedTheme,
 } from "./theme";
 
 StyleSheet.configure({
@@ -16,6 +17,7 @@ StyleSheet.configure({
     darkMidnight: darkMidnightTheme,
     darkClaude: darkClaudeTheme,
     darkGhostty: darkGhosttyTheme,
+    darkSolarized: darkSolarizedTheme,
   },
   breakpoints: {
     xs: 0,
@@ -37,6 +39,7 @@ interface AppThemes {
   darkMidnight: typeof darkMidnightTheme;
   darkClaude: typeof darkClaudeTheme;
   darkGhostty: typeof darkGhosttyTheme;
+  darkSolarized: typeof darkSolarizedTheme;
 }
 
 interface AppBreakpoints {


### PR DESCRIPTION
### Linked issue

Closes #2087

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Adds an optional **Solarized Teal** application theme for people who use a Solarized dark-teal workstation but want to keep syntax highlighting independently selectable.

The change:

- leaves the existing Paseo Dark theme and default untouched;
- registers the theme in Unistyles, Appearance settings, keyboard theme cycling, persisted settings, and all current translations;
- uses Solarized dark surfaces and canonical terminal ANSI colors;
- uses brighter semantic UI status colors where the canonical palette would miss WCAG AA on elevated teal surfaces;
- updates runtime appearance patching to cover all seven registered themes.

### How did you verify it

Refreshed and verified on commit `8ebf7ee20` against current `main` (`c9bcfa763`):

- `npm run format:check` — all 3,006 matched files pass
- `npm run lint` — 0 warnings, 0 errors across 2,810 files
- `npm run build:app-deps` — pass
- `npm run typecheck` — all workspaces pass
- focused Vitest run — 4 files, 80 tests pass
- current-main compatibility follow-up — Solarized theme test 4/4 passes after adding the new required `foregroundExtraMuted` token
- production web export — pass on 4,523 modules
- focused Playwright run — 2/2 tests pass for selection, reload persistence, desktop styling, and compact layout
- pre-commit hook independently reran targeted formatting/lint plus full typecheck — pass

The first Playwright attempt inherited production Paseo environment variables from the operator session and was stopped before reaching tests. The clean rerun explicitly removed those variables, used the isolated E2E daemon, and passed 2/2.

**Desktop web**

![Solarized Teal desktop web](https://raw.githubusercontent.com/pmbemax/paseo/pr-assets-solarized-teal/pr-assets/solarized-teal/solarized-teal-desktop.png)

**Compact web layout**

![Solarized Teal compact web](https://raw.githubusercontent.com/pmbemax/paseo/pr-assets-solarized-teal/pr-assets/solarized-teal-compact-web.png)

Native iOS and Android visual proof has not been run. That limitation is explicit here but does not block initial maintainer review of the theme design and implementation.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` / `npm run format:check` pass
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
