### PR TITLE
Keep tool call summaries neutral

### DIFF
--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1420,7 +1420,6 @@ export const ar: TranslationResources = {
       other: "استدعى Paseo {{count}} مرات",
     },
     and: "و",
-    failed: "فشل {{count}}",
   },
   renameModal: {
     rename: "إعادة تسمية",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1428,7 +1428,6 @@ export const en = {
       other: "called Paseo {{count}} times",
     },
     and: "and",
-    failed: "{{count}} failed",
   },
   renameModal: {
     rename: "Rename",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1459,7 +1459,6 @@ export const es: TranslationResources = {
       other: "llamó a Paseo {{count}} veces",
     },
     and: "y",
-    failed: "{{count}} con error",
   },
   renameModal: {
     rename: "Rebautizar",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1462,7 +1462,6 @@ export const fr: TranslationResources = {
       other: "a appelé Paseo {{count}} fois",
     },
     and: "et",
-    failed: "{{count}} en échec",
   },
   renameModal: {
     rename: "Rebaptiser",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1437,7 +1437,6 @@ export const ja: TranslationResources = {
       other: "Paseoを{{count}}回呼び出し",
     },
     and: "および",
-    failed: "{{count}}件失敗",
   },
   renameModal: {
     rename: "名前を変更",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1445,7 +1445,6 @@ export const ptBR: TranslationResources = {
       other: "chamou o Paseo {{count}} vezes",
     },
     and: "e",
-    failed: "{{count}} com falha",
   },
   renameModal: {
     rename: "Renomear",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1451,7 +1451,6 @@ export const ru: TranslationResources = {
       other: "Paseo вызван {{count}} раз",
     },
     and: "и",
-    failed: "С ошибкой: {{count}}",
   },
   renameModal: {
     rename: "Переименовать",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1404,7 +1404,6 @@ export const zhCN: TranslationResources = {
       other: "调用了 Paseo {{count}} 次",
     },
     and: "并",
-    failed: "{{count}} 次失败",
   },
   renameModal: {
     rename: "重命名",

--- a/packages/app/src/tool-calls/detail-level/overview/model.ts
+++ b/packages/app/src/tool-calls/detail-level/overview/model.ts
@@ -17,7 +17,6 @@ export interface OverviewToolCallGroup {
   mode: "overview";
   run: ToolCallRun;
   summary: OverviewSummary;
-  failedCount: number;
   isLoading: boolean;
 }
 
@@ -32,7 +31,6 @@ function isSearchCall(name: string): boolean {
 export function buildOverviewGroup(run: ToolCallRun): OverviewToolCallGroup {
   const editedFiles = new Set<string>();
   const readFiles = new Set<string>();
-  let failedCount = 0;
   let isLoading = false;
   let commandCount = 0;
   let searchCount = 0;
@@ -42,7 +40,6 @@ export function buildOverviewGroup(run: ToolCallRun): OverviewToolCallGroup {
   for (const call of run.calls) {
     const descriptor = describeToolCall(call);
     const normalizedName = descriptor.name.trim().toLowerCase();
-    failedCount += descriptor.status === "failed" ? 1 : 0;
     isLoading ||= descriptor.status === "running" || descriptor.status === "executing";
     if (isPaseoCall(descriptor.name, normalizedName)) {
       paseoCallCount += 1;
@@ -70,7 +67,6 @@ export function buildOverviewGroup(run: ToolCallRun): OverviewToolCallGroup {
   return {
     mode: "overview",
     run,
-    failedCount,
     isLoading,
     summary,
   };

--- a/packages/app/src/tool-calls/detail-level/overview/view.tsx
+++ b/packages/app/src/tool-calls/detail-level/overview/view.tsx
@@ -58,11 +58,8 @@ export const OverviewToolCallGroupView = memo(function OverviewToolCallGroupView
   onExpandedChange,
   children,
 }: OverviewGroupProps) {
-  const { t } = useTranslation();
   const scrollRef = useRef<ScrollView>(null);
   const aggregateSummary = useOverviewSummary(group.summary);
-  const failedSummary =
-    group.failedCount > 0 ? t("toolCallGroup.failed", { count: group.failedCount }) : undefined;
   const scrollToLatest = useCallback(() => {
     scrollRef.current?.scrollToEnd({ animated: false });
   }, []);
@@ -89,10 +86,8 @@ export const OverviewToolCallGroupView = memo(function OverviewToolCallGroupView
     <ExpandableBadge
       testID="tool-call-group"
       label={aggregateSummary}
-      secondaryLabel={failedSummary}
       icon={Wrench}
       isLoading={group.isLoading}
-      isError={group.failedCount > 0}
       isExpanded={expanded}
       isLastInSequence={isLastInSequence}
       onToggle={toggle}

--- a/packages/app/src/tool-calls/detail-level/projection.test.ts
+++ b/packages/app/src/tool-calls/detail-level/projection.test.ts
@@ -231,7 +231,6 @@ describe("tool call detail-level projection", () => {
     expect(overview.groupsByHostId.get("1")).toEqual({
       mode: "overview",
       run: expect.any(Object),
-      failedCount: 1,
       isLoading: false,
       summary: {
         editedFileCount: 1,
@@ -260,7 +259,6 @@ describe("tool call detail-level projection", () => {
     const result = project({ level: "overview", head: calls });
 
     expect(result.groupsByHostId.get("1")).toMatchObject({
-      failedCount: 1,
       summary: {
         editedFileCount: 0,
         commandCount: 0,


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Tool-call summaries now keep the neutral wrench icon and category counts when an individual call reports a non-success result. The expanded list still preserves each call's status and details, but a handled tool result no longer makes the aggregate look like the overall work failed.

### How did you verify it

- Ran `npx vitest run packages/app/src/tool-calls/detail-level/projection.test.ts --bail=1`: 17 tests passed, including failed child calls remaining categorized in neutral overview groups.
- Ran `npm run typecheck`: passed across all workspaces.
- Ran targeted `npm run lint -- ...`: no warnings or errors.
- Ran `npm run format`: completed successfully.
- Manual cross-platform visual smoke was not performed; the change removes aggregate error props without changing layout structure.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense