### PR TITLE
Simplify assistant fork boundary handling

### DIFF
--- a/packages/app/src/agent-stream/turn-boundary.test.ts
+++ b/packages/app/src/agent-stream/turn-boundary.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { StreamItem } from "@/types/stream";
-import {
-  resolveAssistantTurnBoundaryMessageId,
-  resolveAssistantTurnForkBoundary,
-} from "./turn-boundary";
+import { resolveAssistantTurnForkBoundary } from "./turn-boundary";
 
 function timestamp(seed: number): Date {
   return new Date(`2026-01-01T00:00:${seed.toString().padStart(2, "0")}.000Z`);
@@ -31,40 +28,6 @@ function assistantMessage(
     ...(messageId ? { messageId } : {}),
   };
 }
-
-describe("resolveAssistantTurnBoundaryMessageId", () => {
-  it("uses the selected assistant message id", () => {
-    const selected = assistantMessage("assistant-1", 2, "msg-assistant-1");
-
-    expect(
-      resolveAssistantTurnBoundaryMessageId({
-        items: [userMessage("user-1", 1), selected],
-        startIndex: 1,
-      }),
-    ).toBe("msg-assistant-1");
-  });
-
-  it("does not borrow a boundary id from another assistant in the same turn", () => {
-    const first = assistantMessage("assistant-1", 2, "msg-assistant-1");
-    const selected = assistantMessage("assistant-2", 3);
-
-    expect(
-      resolveAssistantTurnBoundaryMessageId({
-        items: [userMessage("user-1", 1), first, selected],
-        startIndex: 2,
-      }),
-    ).toBeUndefined();
-  });
-
-  it("requires the selected item to be an assistant message", () => {
-    expect(
-      resolveAssistantTurnBoundaryMessageId({
-        items: [userMessage("user-1", 1), assistantMessage("assistant-1", 2, "msg-assistant-1")],
-        startIndex: 0,
-      }),
-    ).toBeUndefined();
-  });
-});
 
 describe("resolveAssistantTurnForkBoundary", () => {
   it("forks a failed assistant turn from its Paseo timeline cursor without a provider message id", () => {
@@ -115,6 +78,29 @@ describe("resolveAssistantTurnForkBoundary", () => {
         supportsTimelineCursor: false,
       }),
     ).toEqual({ boundaryMessageId: "msg-assistant-1" });
+  });
+
+  it("does not borrow a provider message id from another assistant in the same turn", () => {
+    const first = assistantMessage("assistant-1", 2, "msg-assistant-1");
+    const selected = assistantMessage("assistant-2", 3);
+
+    expect(
+      resolveAssistantTurnForkBoundary({
+        items: [userMessage("user-1", 1), first, selected],
+        startIndex: 2,
+        supportsTimelineCursor: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("requires the selected item to be an assistant message", () => {
+    expect(
+      resolveAssistantTurnForkBoundary({
+        items: [userMessage("user-1", 1), assistantMessage("assistant-1", 2, "msg-assistant-1")],
+        startIndex: 0,
+        supportsTimelineCursor: false,
+      }),
+    ).toBeUndefined();
   });
 
   it("does not offer an unavailable boundary", () => {

--- a/packages/app/src/agent-stream/turn-boundary.ts
+++ b/packages/app/src/agent-stream/turn-boundary.ts
@@ -4,18 +4,6 @@ export type AssistantTurnForkBoundary =
   | { boundaryCursor: TimelinePosition; boundaryMessageId?: string }
   | { boundaryCursor?: undefined; boundaryMessageId: string };
 
-export function resolveAssistantTurnBoundaryMessageId(input: {
-  items: readonly StreamItem[];
-  startIndex: number;
-}): string | undefined {
-  const item = input.items[input.startIndex];
-  if (item?.kind !== "assistant_message") {
-    return undefined;
-  }
-  // Forking without the selected assistant's durable message id would send the wrong slice.
-  return item.messageId || undefined;
-}
-
 export function resolveAssistantTurnForkBoundary(input: {
   items: readonly StreamItem[];
   startIndex: number;


### PR DESCRIPTION
### Linked issue

Refs #262
Refs #1479
Follow-up to #2063.

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

Keeps assistant fork-boundary policy in one resolver. The legacy message-ID-only resolver had no production callers after #2063, so this removes that parallel API and moves its selected-item and assistant-only guarantees onto the resolver the UI actually uses.

Behavior is unchanged: supported hosts still prefer timeline cursors, older hosts still fall back to provider message IDs, and unavailable boundaries remain hidden.

### How did you verify it

- `npx vitest run packages/app/src/agent-stream/turn-boundary.test.ts --bail=1` — 6 tests passed
- `npm run typecheck` — passed
- `npm run lint` — passed with zero warnings and errors
- `npm run format` — completed

This is a pure resolver/test consolidation with no UI or platform-specific behavior change; no additional manual verification is needed before merge.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI change)
- [x] Tests added or updated where it made sense