### PR TITLE
Document iOS/Android local dev setup and fix the mise Android toolchain

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,10 @@
 [env]
-ANDROID_HOME = "{{env.HOME}}/.local/share/mise/installs/android-sdk/1.0"
+ANDROID_HOME = "{{env.HOME}}/.local/share/mise/installs/android-sdk/21.0"
 _.path = [
-  "{{env.HOME}}/.local/share/mise/installs/android-sdk/1.0/platform-tools",
-  "{{env.HOME}}/.local/share/mise/installs/android-sdk/1.0/emulator",
+  "{{env.HOME}}/.local/share/mise/installs/android-sdk/21.0/cmdline-tools/21.0/bin",
+  "{{env.HOME}}/.local/share/mise/installs/android-sdk/21.0/platform-tools",
+  "{{env.HOME}}/.local/share/mise/installs/android-sdk/21.0/emulator",
 ]
 
 [tools]
-java = "17"
+java = "21"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 rust        1.85.1
 nodejs      22.20.0
 java        21
-android-sdk latest
+android-sdk 21.0

--- a/docs/android.md
+++ b/docs/android.md
@@ -35,13 +35,23 @@ mise install        # java 21 + android-sdk 21.0 command-line tools
 
 > **Pin a real `android-sdk` version, not `latest`.** The mise `android-sdk` plugin's `latest` resolved to the ancient `1.0` bundle, whose `sdkmanager` (3.6.0) predates the `emulator` package and fails with `Failed to find package emulator`. `21.0` ships a current `sdkmanager`. If you bump it, update the version in `.tool-versions` and in all four paths in `.mise.toml`.
 
-`mise install` only lays down the command-line tools. Install the rest and create an emulator — Apple Silicon uses `arm64-v8a` system images (use `x86_64` on Intel):
+`mise install` only lays down the command-line tools. Install the rest and create an emulator. On Apple Silicon:
 
 ```bash
 sdkmanager --licenses
 sdkmanager "platform-tools" "emulator" "platforms;android-35" "build-tools;35.0.0" \
            "system-images;android-35;google_apis;arm64-v8a"
 avdmanager create avd -n paseo -k "system-images;android-35;google_apis;arm64-v8a" -d pixel_7
+emulator @paseo     # start it; leave running
+```
+
+On an Intel Mac, use the `x86_64` system image:
+
+```bash
+sdkmanager --licenses
+sdkmanager "platform-tools" "emulator" "platforms;android-35" "build-tools;35.0.0" \
+           "system-images;android-35;google_apis;x86_64"
+avdmanager create avd -n paseo -k "system-images;android-35;google_apis;x86_64" -d pixel_7
 emulator @paseo     # start it; leave running
 ```
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -25,6 +25,28 @@ Prerelease metadata is ignored, so `0.1.102-beta.1` and `0.1.102` both produce `
 
 The formula reserves three digits each for minor and patch. If either reaches `1000`, change the formula before cutting that release.
 
+## Prerequisites (local dev)
+
+Local Android builds run on macOS (or Linux) and need the Android toolchain, pinned in `.tool-versions` (`java 21`, `android-sdk 21.0`) and wired up by `.mise.toml` (which sets `ANDROID_HOME` and puts `cmdline-tools/21.0/bin`, `platform-tools`, and `emulator` on `PATH`). With [mise](https://mise.jdx.dev):
+
+```bash
+mise install        # java 21 + android-sdk 21.0 command-line tools
+```
+
+> **Pin a real `android-sdk` version, not `latest`.** The mise `android-sdk` plugin's `latest` resolved to the ancient `1.0` bundle, whose `sdkmanager` (3.6.0) predates the `emulator` package and fails with `Failed to find package emulator`. `21.0` ships a current `sdkmanager`. If you bump it, update the version in `.tool-versions` and in all four paths in `.mise.toml`.
+
+`mise install` only lays down the command-line tools. Install the rest and create an emulator — Apple Silicon uses `arm64-v8a` system images (use `x86_64` on Intel):
+
+```bash
+sdkmanager --licenses
+sdkmanager "platform-tools" "emulator" "platforms;android-35" "build-tools;35.0.0" \
+           "system-images;android-35;google_apis;arm64-v8a"
+avdmanager create avd -n paseo -k "system-images;android-35;google_apis;arm64-v8a" -d pixel_7
+emulator @paseo     # start it; leave running
+```
+
+Gradle auto-fetches the platform/build-tools it needs once licenses are accepted, so adjust `android-35` only if it asks for a different level.
+
 ## Local build + install
 
 From repo root:
@@ -49,6 +71,31 @@ npx cross-env APP_VARIANT=production expo run:android --variant=release
 # Clear generated Android project
 rm -rf android
 ```
+
+## Running on an emulator against a worktree daemon
+
+`npm run android` builds and installs the dev client, but two connections have to reach your Mac from inside the emulator — Metro (the JS bundle) and the Paseo daemon — and **the emulator does not share the host's loopback**: `localhost` inside the emulator is the emulator itself. Reach the host at `10.0.2.2` (the standard AVD's host alias) for both:
+
+```bash
+REACT_NATIVE_PACKAGER_HOSTNAME=10.0.2.2 \
+  EXPO_PUBLIC_LOCAL_DAEMON=10.0.2.2:$PASEO_SERVICE_DAEMON_PORT \
+  npm run android
+```
+
+- **`REACT_NATIVE_PACKAGER_HOSTNAME=10.0.2.2`** — without it, Expo bakes your Mac's LAN IP into the dev client's Metro URL, which the emulator can't route to, and the app dies with `Failed to connect to /<lan-ip>:8081` before any JS loads.
+- **`EXPO_PUBLIC_LOCAL_DAEMON=10.0.2.2:<port>`** — the client's daemon endpoint (`packages/app/src/runtime/host-runtime.ts`); when unset it defaults to `localhost:6767`, the production daemon. Use `$PASEO_SERVICE_DAEMON_PORT` for a worktree daemon running as a Paseo service, or `6768` for a standalone `npm run dev:server`. It is inlined into the JS bundle at Metro bundle time, so set it on the build command and clear the Metro cache (`npx expo start -c`) if a change doesn't take.
+
+**Alternative — `adb reverse` + `localhost`** (if `10.0.2.2` misbehaves):
+
+```bash
+adb reverse tcp:8081 tcp:8081
+adb reverse tcp:$PASEO_SERVICE_DAEMON_PORT tcp:$PASEO_SERVICE_DAEMON_PORT
+REACT_NATIVE_PACKAGER_HOSTNAME=localhost \
+  EXPO_PUBLIC_LOCAL_DAEMON=localhost:$PASEO_SERVICE_DAEMON_PORT \
+  npm run android
+```
+
+This is the Android counterpart of the iOS local-simulator flow in [development.md](development.md): on iOS the simulator shares the Mac's loopback so `localhost:<port>` works directly; on Android you need `10.0.2.2` or `adb reverse`.
 
 ## F-Droid / source-only Android builds
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -59,11 +59,42 @@ startup routing, remembered workspace restore, or active workspace selection.
 
 Paseo worktrees expose the native iOS dev app through the `ios-simulator` service in `paseo.json`. The service URL serves the simulator preview at `/.sim`, so the preview link is `${PASEO_URL}/.sim`.
 
+**Prerequisites (macOS only).** The service shells out to the Apple toolchain, so beyond the `npm ci` that worktree setup runs you must install:
+
+- **Xcode** (the full app, not just the Command Line Tools) — install it from the Mac App Store, or from `developer.apple.com/download` for a specific version. It provides `xcodebuild` and `xcrun simctl`; accept its license and let first-run component installation finish before starting the service.
+- **An iOS Simulator runtime with at least one iPhone device type**. Recent Xcode versions may not bundle a runtime — add one via Xcode → Settings → Components (older Xcode: "Platforms"). The service targets `iPhone 16 Pro` by default (override with `PASEO_IOS_DEVICE_TYPE`) and falls back to any iPhone; it fails with `No iPhone simulator device type is installed` when none exist.
+- **Homebrew** — CocoaPods itself installs automatically: `expo prebuild` runs `pod install` on a cold worktree, and when the CocoaPods CLI is missing the runner installs it for you. It tries `gem install cocoapods` first and falls back to Homebrew (`brew install cocoapods`), so having Homebrew available lets that fallback succeed without a manual step.
+
+`serve-sim`, Expo, and Metro come from `npm ci`, and CocoaPods installs itself on the first prebuild as described above.
+
 The service is designed for concurrent worktrees: it derives a deterministic simulator identity from the worktree path, uses the worktree's assigned `PASEO_PORT`, pins `serve-sim` to that simulator UDID, and only tears down that worktree's helper/simulator state. It must not rely on the globally booted simulator or any fixed Metro port.
 
 Worktree setup best-effort seeds the generated iOS project and newest native build cache from the source checkout before the service runs. The service still validates the native project by running Expo prebuild and Xcode; the seed only avoids paying all setup/build cost from a cold worktree every time.
 
-Starting the service must not create, focus, reveal, or leave behind macOS Simulator.app windows. The browser preview is the user-visible simulator surface.
+Starting the service must not create, focus, reveal, or leave behind macOS Simulator.app windows — a guard hides Simulator.app every 250ms, so the native window vanishes if you focus it. The user-visible surface is the interactive `/.sim` preview: a `serve-sim` stream (60 FPS MJPEG + a WebSocket control channel) that Metro mounts at `basePath: "/.sim"` (`packages/app/metro.config.cjs`) and that forwards taps and gestures, so first-launch prompts like "Open in PaseoDebug?" are answered there, not in the native window. Open the `${PASEO_URL}/.sim` link the service prints — not `serve-sim`'s raw stream port (`:3100`), which is view-only. Because the stream sits behind the daemon proxy it is convenient for remote viewing but laggy up close; for fast local dev at the Mac, use the native simulator path below.
+
+**Troubleshooting.** If `xcrun simctl` fails with `unable to find utility "simctl"`, the active developer directory is still the Command Line Tools even though Xcode is installed. Point it at Xcode: `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`, then confirm with `xcrun --find simctl`.
+
+### Running the iOS app on a local simulator
+
+For fast, native, interactive iOS dev at the Mac — as opposed to the remote `/.sim` preview above — skip the service and build the dev client directly:
+
+```bash
+npm run ios        # → expo run:ios (packages/app): builds and launches the app in the real Simulator.app
+```
+
+`expo run:ios` starts its own Metro and gives you the normal Simulator.app window (full speed, native touch, no stream).
+
+**Pointing the app at a daemon.** The client resolves its local daemon from `EXPO_PUBLIC_LOCAL_DAEMON` (`packages/app/src/runtime/host-runtime.ts`); when unset it falls back to `localhost:6767`, the production `~/.paseo` daemon. To target a worktree's dev daemon instead, set it on the build command:
+
+```bash
+EXPO_PUBLIC_LOCAL_DAEMON=localhost:${PASEO_SERVICE_DAEMON_PORT} npm run ios   # worktree daemon running as a Paseo service
+EXPO_PUBLIC_LOCAL_DAEMON=localhost:6768 npm run ios                          # standalone `npm run dev:server`
+```
+
+The iOS simulator shares the Mac's loopback, so `localhost:<port>` reaches the host daemon directly.
+
+**Gotcha — `EXPO_PUBLIC_*` is inlined into the JS bundle at Metro bundle time, not read at runtime.** Set it in the same shell that starts Metro. If the app still connects to the old daemon, Metro served a cached bundle; re-bundle clean with `cd packages/app && EXPO_PUBLIC_LOCAL_DAEMON=… npx expo start -c` and reload the app.
 
 ### Desktop renderer profiling
 


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [x] Docs

### What does this PR do

Documents how to run the app on a local **iOS simulator** and **Android emulator** against a worktree's dev daemon, and fixes the mise Android toolchain that made the Android path fail out of the box.

- **Docs — iOS (`docs/development.md`):** prerequisites for the `ios-simulator` preview service (Xcode, an iOS runtime, automatic CocoaPods install), the `xcode-select`/`simctl` troubleshooting fix, and a new *"Running the iOS app on a local simulator"* section covering `npm run ios` and pointing the app at a worktree daemon via `EXPO_PUBLIC_LOCAL_DAEMON`.
- **Docs — Android (`docs/android.md`):** a *"Prerequisites (local dev)"* section (mise `java 21` + `android-sdk 21.0`, `sdkmanager` components, AVD creation) and a *"Running on an emulator against a worktree daemon"* section covering `REACT_NATIVE_PACKAGER_HOSTNAME` + `EXPO_PUBLIC_LOCAL_DAEMON=10.0.2.2` for reaching the host daemon (the emulator doesn't share the host loopback the way the iOS simulator does).
- **Toolchain fix (`.mise.toml`, `.tool-versions`):** `android-sdk latest` had resolved to the ancient `1.0` cmdline-tools (sdkmanager 3.6.0), whose catalog lacks the `emulator` package (`Failed to find package emulator`). Pin `android-sdk 21.0`, correct the hardcoded install paths, add `cmdline-tools/21.0/bin` to `PATH`, and unify Java on 21 (`.mise.toml` had overridden `.tool-versions`' 21 with 17).


### How did you verify it

Ran the whole flow end-to-end on macOS (Apple Silicon, arm64):

- **iOS:** `EXPO_PUBLIC_LOCAL_DAEMON=localhost:$PASEO_SERVICE_DAEMON_PORT npm run ios` builds and launches the dev client in the native simulator and connects to the worktree daemon. Confirmed `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer` resolves `xcrun: unable to find utility "simctl"`.
- **Android:** after `mise install` + the `sdkmanager`/`avdmanager` steps, `REACT_NATIVE_PACKAGER_HOSTNAME=10.0.2.2 EXPO_PUBLIC_LOCAL_DAEMON=10.0.2.2:$PASEO_SERVICE_DAEMON_PORT npm run android` builds, installs, and loads the app on the emulator against the worktree daemon. Also confirmed:
  - Pinning `android-sdk 21.0` fixes `Failed to find package emulator` — its `sdkmanager` catalog lists `emulator 36.6.11` (the old 3.6.0 catalog had no `emulator` entry).
  - The Gradle build succeeds on **JDK 21** (the version this PR unifies on).
  - Without `REACT_NATIVE_PACKAGER_HOSTNAME`, the dev client dies with `Failed to connect to /<lan-ip>:8081` because Expo bakes the Mac's LAN IP into the Metro URL, which the emulator can't route to.

No app/runtime code changed — docs plus mise config. `npm run typecheck` and `oxfmt --check` pass (pre-commit hook); lint has no JS/TS files to inspect.


### Checklist

- [x] One focused change (local mobile-dev setup); can split docs vs toolchain if preferred
- [x] `npm run typecheck` passes (ran via pre-commit hook)
- [x] `npm run lint` passes (no JS/TS files changed — skipped)
- [x] `npm run format` ran (oxfmt; `format:check` clean)
- [x] UI changes include screenshots or video for every affected platform (n/a — no UI changes)
- [x] Tests added or updated where it made sense (n/a — docs + toolchain config)
