### PR TITLE
fix(acp): wire context utilization from usage_update notifications

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1330,6 +1330,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   private currentTurnUsage: AgentUsage | undefined;
+  private contextWindowMaxTokens: number | undefined;
+  private contextWindowUsedTokens: number | undefined;
+  private totalCostUsd: number | undefined;
   private activeForegroundTurnId: string | null = null;
   private fallbackAssistantMessageId: string | null = null;
   private closed = false;
@@ -2495,8 +2498,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         this.handleSessionInfoUpdate(update);
         return [];
       case "usage_update":
-        this.handleUsageUpdate(update);
-        return [];
+        return this.handleUsageUpdate(update);
       case "available_commands_update":
         this.cachedCommands = update.availableCommands.map((command) => ({
           name: command.name,
@@ -2626,8 +2628,21 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
-  private handleUsageUpdate(update: UsageUpdate): void {
-    void update;
+  private handleUsageUpdate(update: UsageUpdate): AgentStreamEvent[] {
+    this.contextWindowMaxTokens = update.size;
+    this.contextWindowUsedTokens = update.used;
+    if (update.cost?.currency === "USD") {
+      this.totalCostUsd = update.cost.amount;
+    }
+
+    const usage: AgentUsage = {
+      contextWindowMaxTokens: this.contextWindowMaxTokens,
+      contextWindowUsedTokens: this.contextWindowUsedTokens,
+    };
+    if (this.totalCostUsd !== undefined) {
+      usage.totalCostUsd = this.totalCostUsd;
+    }
+    return [{ type: "usage_updated", provider: this.provider, usage }];
   }
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {
@@ -2648,10 +2663,20 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       case "max_turn_requests":
       case "refusal":
       default:
+        const finalUsage: AgentUsage = { ...this.currentTurnUsage };
+        if (this.contextWindowMaxTokens !== undefined) {
+          finalUsage.contextWindowMaxTokens = this.contextWindowMaxTokens;
+        }
+        if (this.contextWindowUsedTokens !== undefined) {
+          finalUsage.contextWindowUsedTokens = this.contextWindowUsedTokens;
+        }
+        if (this.totalCostUsd !== undefined) {
+          finalUsage.totalCostUsd = this.totalCostUsd;
+        }
         this.finishTurn({
           type: "turn_completed",
           provider: this.provider,
-          usage: this.currentTurnUsage,
+          usage: finalUsage,
           turnId,
         });
         break;

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2633,6 +2633,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.contextWindowUsedTokens = update.used;
     if (update.cost?.currency === "USD") {
       this.totalCostUsd = update.cost.amount;
+    } else if (!update.cost) {
+      this.totalCostUsd = undefined;
     }
 
     const usage: AgentUsage = {
@@ -2662,7 +2664,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       case "max_tokens":
       case "max_turn_requests":
       case "refusal":
-      default:
+      default: {
         const finalUsage: AgentUsage = { ...this.currentTurnUsage };
         if (this.contextWindowMaxTokens !== undefined) {
           finalUsage.contextWindowMaxTokens = this.contextWindowMaxTokens;
@@ -2680,6 +2682,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
           turnId,
         });
         break;
+      }
     }
   }
 


### PR DESCRIPTION
### Linked issue

No existing issue filed yet.

<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

`ACPAgentSession.handleUsageUpdate()` was a no-op (`void update;`). ACP agents push `usage_update` session notifications carrying `{ size, used, cost }` (context window max/used tokens, cumulative cost), but Paseo silently discarded them. Without `lastUsage.contextWindowMaxTokens` and `lastUsage.contextWindowUsedTokens`, the frontend context utilization widget gate fails and renders nothing — even though `/context` works fine because it reads from a different path.

Three changes in `packages/server/src/server/agent/providers/acp-agent.ts`:

1. Added instance fields to track `contextWindowMaxTokens`, `contextWindowUsedTokens`, and `totalCostUsd`.
2. Implemented `handleUsageUpdate` to map incoming ACP `UsageUpdate.size` / `.used` / `.cost.amount` into those fields and return a `usage_updated` stream event so the data reaches `AgentManager.onStreamUsageUpdated()` -> WebSocket broadcast.
3. Merged tracked context window state into turn-completion usage in `handlePromptResponse`, because `agent-manager.ts:3197` does full assignment (`agent.lastUsage = event.usage`) which would otherwise wipe mid-turn context window data when token counts arrive at turn end.

### How did you verify it

- Typecheck (`npx tsc --noEmit -p packages/server/tsconfig.server.typecheck.json`) passes clean.
- Lint (`npm run lint -- packages/server/src/server/agent/providers/acp-agent.ts`) passes clean (0 warnings, 0 errors).
- Code review against Claude Code's `ClaudeContextUsageState` pattern (`providers/claude/agent.ts:1730`) confirms the same approach: track context window state across events, emit `usage_updated` stream events, include fields in turn-completion usage.

**Not yet tested end-to-end:** I do not have an OMP agent configured locally to confirm the widget renders after this change. The fix is mechanically correct — the data path is wired through the existing pipeline that works for all other providers — but E2E verification on a live ACP session is needed before merging.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [ ] Tests added or updated where it made sense
