### PR TITLE
Add pin workspace option that lifts pinned workspaces to a top section

### DIFF
--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -36,7 +36,10 @@ import { useOpenProjectPicker } from "@/hooks/use-open-project-picker";
 import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
 import { canCreateWorktreeForProjectKind } from "@/projects/host-projects";
 import { useHostFeature } from "@/runtime/host-features";
-import { type SidebarProjectEntry } from "@/hooks/use-sidebar-workspaces-list";
+import {
+  type SidebarProjectEntry,
+  type SidebarWorkspacePlacement,
+} from "@/hooks/use-sidebar-workspaces-list";
 import { useSidebarModel } from "@/components/sidebar/sidebar-model";
 import type { StatusGroup } from "@/hooks/sidebar-status-view-model";
 import { type SidebarGroupMode } from "@/stores/sidebar-view-store";
@@ -75,6 +78,7 @@ interface SidebarSharedProps {
   theme: SidebarTheme;
   statusGroups: StatusGroup[];
   projects: SidebarProjectEntry[];
+  pinnedWorkspaces: SidebarWorkspacePlacement[];
   projectNamesByKey: Map<string, string>;
   isInitialLoad: boolean;
   isRevalidating: boolean;
@@ -132,6 +136,7 @@ export const LeftSidebar = memo(function LeftSidebar() {
 
   const {
     projects,
+    pinnedWorkspaces,
     projectNamesByKey,
     isInitialLoad,
     isRevalidating,
@@ -235,6 +240,7 @@ export const LeftSidebar = memo(function LeftSidebar() {
     theme,
     statusGroups,
     projects,
+    pinnedWorkspaces,
     projectNamesByKey,
     isInitialLoad,
     isRevalidating,
@@ -533,6 +539,7 @@ function MobileSidebar({
   theme,
   statusGroups,
   projects,
+  pinnedWorkspaces,
   projectNamesByKey,
   isInitialLoad,
   isRevalidating,
@@ -644,6 +651,7 @@ function MobileSidebar({
             groupMode={groupMode}
             statusGroups={statusGroups}
             projects={projects}
+            pinnedWorkspaces={pinnedWorkspaces}
             projectNamesByKey={projectNamesByKey}
             isRefreshing={isManualRefresh && isRevalidating}
             onRefresh={handleRefresh}
@@ -671,6 +679,7 @@ function DesktopSidebar({
   theme,
   statusGroups,
   projects,
+  pinnedWorkspaces,
   projectNamesByKey,
   isInitialLoad,
   isRevalidating,
@@ -796,6 +805,7 @@ function DesktopSidebar({
             groupMode={groupMode}
             statusGroups={statusGroups}
             projects={projects}
+            pinnedWorkspaces={pinnedWorkspaces}
             projectNamesByKey={projectNamesByKey}
             isRefreshing={isManualRefresh && isRevalidating}
             onRefresh={handleRefresh}

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -52,6 +52,7 @@ import { NestableScrollContainer } from "react-native-draggable-flatlist";
 import { DraggableList, type DraggableRenderItemInfo } from "./draggable-list";
 import type { DraggableListDragHandleProps } from "./draggable-list.types";
 import { getHostRuntimeStore, useHosts } from "@/runtime/host-runtime";
+import { useSessionStore } from "@/stores/session-store";
 import { useHostFeatureMap } from "@/runtime/host-features";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useProjectIconDataByProjectKey } from "@/projects/project-icons";
@@ -127,6 +128,8 @@ import {
 import { getDesktopHost } from "@/desktop/host";
 
 const workspaceKeyExtractor = (workspace: SidebarWorkspacePlacement) => workspace.workspaceKey;
+
+const EMPTY_PINNED_WORKSPACES: SidebarWorkspacePlacement[] = [];
 
 const projectKeyExtractor = (project: SidebarProjectEntry) => project.projectKey;
 
@@ -222,6 +225,7 @@ function selectionForSelectedWorkspace(
 
 interface SidebarWorkspaceListProps {
   statusGroups: StatusGroup[];
+  pinnedWorkspaces?: SidebarWorkspacePlacement[];
   projects: SidebarProjectEntry[];
   projectNamesByKey: Map<string, string>;
   collapsedProjectKeys: ReadonlySet<string>;
@@ -281,6 +285,8 @@ interface WorkspaceRowInnerProps {
   onCopyPath?: () => void;
   onRename?: () => void;
   onMarkAsRead?: () => void;
+  onTogglePinned?: () => void;
+  isPinned?: boolean;
   archiveShortcutKeys?: ShortcutKey[][] | null;
 }
 
@@ -632,6 +638,8 @@ function WorkspaceRowRightGroup({
   onCopyBranchName,
   onCopyPath,
   onRename,
+  onTogglePinned,
+  isPinned,
 }: {
   workspace: SidebarWorkspaceEntry;
   isHovered: boolean;
@@ -648,6 +656,8 @@ function WorkspaceRowRightGroup({
   onCopyBranchName?: () => void;
   onCopyPath?: () => void;
   onRename?: () => void;
+  onTogglePinned?: () => void;
+  isPinned?: boolean;
 }) {
   const { t } = useTranslation();
   const showShortcut = showShortcutBadge && shortcutNumber !== null;
@@ -680,6 +690,8 @@ function WorkspaceRowRightGroup({
                 onCopyBranchName={onCopyBranchName}
                 onRename={onRename}
                 onMarkAsRead={onMarkAsRead}
+                onTogglePinned={onTogglePinned}
+                isPinned={isPinned}
                 onArchive={onArchive}
                 archiveLabel={archiveLabel}
                 archiveStatus={archiveStatus}
@@ -1328,6 +1340,9 @@ function WorkspaceRowInner({
   onCopyBranchName,
   onCopyPath,
   onRename,
+  onMarkAsRead,
+  onTogglePinned,
+  isPinned,
   archiveShortcutKeys,
 }: WorkspaceRowInnerProps) {
   const _isCompact = useIsCompactFormFactor();
@@ -1415,6 +1430,9 @@ function WorkspaceRowInner({
                   onCopyBranchName={onCopyBranchName}
                   onCopyPath={onCopyPath}
                   onRename={onRename}
+                  onMarkAsRead={onMarkAsRead}
+                  onTogglePinned={onTogglePinned}
+                  isPinned={isPinned}
                 />
               </SidebarWorkspaceRowContent>
             </Pressable>
@@ -1531,6 +1549,31 @@ function WorkspaceRowWithMenu({
     },
   });
 
+  // COMPAT(workspacePins): added in v0.1.106, drop the gate when floor >= v0.1.106.
+  const supportsWorkspacePins = useSessionStore(
+    (s) => s.sessions[workspace.serverId]?.serverInfo?.features?.workspacePins === true,
+  );
+  const isPinned = workspace.pinnedAt !== null;
+  const pinMutation = useMutation({
+    mutationFn: async (pinned: boolean) => {
+      const client = getHostRuntimeStore().getClient(workspace.serverId);
+      if (!client) {
+        throw new Error(t("sidebar.workspace.toasts.hostDisconnected"));
+      }
+      await client.setWorkspacePinned(workspace.workspaceId, pinned);
+    },
+  });
+  const handleTogglePinned = useCallback(() => {
+    // No optimistic update: the daemon confirms via a workspace_update push.
+    pinMutation.mutate(!isPinned, {
+      onError: (error) => {
+        toast.error(
+          error instanceof Error ? error.message : t("sidebar.workspace.toasts.pinFailed"),
+        );
+      },
+    });
+  }, [isPinned, pinMutation, t, toast]);
+
   const handleOpenRename = useCallback(() => {
     setIsRenameOpen(true);
   }, []);
@@ -1595,6 +1638,8 @@ function WorkspaceRowWithMenu({
         onCopyPath={handleCopyPath}
         onRename={handleOpenRename}
         onMarkAsRead={hasClearableAttention ? handleMarkAsRead : undefined}
+        onTogglePinned={supportsWorkspacePins ? handleTogglePinned : undefined}
+        isPinned={isPinned}
         archiveShortcutKeys={selected ? archiveShortcutKeys : null}
       />
       <AdaptiveRenameModal
@@ -2055,8 +2100,61 @@ function areProjectBlockSelectionsEqual(
 
 const MemoProjectBlock = memo(ProjectBlock, areProjectBlockPropsEqual);
 
+// Pinned workspaces sit above every project group; they are excluded from their
+// project blocks by the view-model partition and ordered by pinnedAt ascending.
+function PinnedWorkspacesSection({
+  pinnedWorkspaces,
+  selectionEnabled,
+  activeWorkspaceSelection,
+  showShortcutBadges,
+  shortcutIndexByWorkspaceKey,
+  hostLabelByServerId,
+  showHostLabels,
+  creatingWorkspaceIds,
+  onWorkspacePress,
+}: {
+  pinnedWorkspaces: SidebarWorkspacePlacement[];
+  selectionEnabled: boolean;
+  activeWorkspaceSelection: ActiveWorkspaceSelection | null;
+  showShortcutBadges: boolean;
+  shortcutIndexByWorkspaceKey: Map<string, number>;
+  hostLabelByServerId: ReadonlyMap<string, string>;
+  showHostLabels: boolean;
+  creatingWorkspaceIds: ReadonlySet<string>;
+  onWorkspacePress?: () => void;
+}) {
+  const { t } = useTranslation();
+  if (pinnedWorkspaces.length === 0) {
+    return null;
+  }
+  return (
+    <View style={styles.pinnedSection} testID="sidebar-pinned-section">
+      <Text style={styles.pinnedSectionTitle}>{t("sidebar.sections.pinned")}</Text>
+      {pinnedWorkspaces.map((placement) => (
+        <MemoWorkspaceRowItem
+          key={placement.workspaceKey}
+          workspace={placement}
+          subtitle={
+            showHostLabels
+              ? (hostLabelByServerId.get(placement.serverId) ?? placement.serverId)
+              : null
+          }
+          shortcutNumber={shortcutIndexByWorkspaceKey.get(placement.workspaceKey) ?? null}
+          showShortcutBadge={showShortcutBadges}
+          canCopyBranchName={placement.projectKind === "git"}
+          isCreating={creatingWorkspaceIds.has(placement.workspaceId)}
+          selectionEnabled={selectionEnabled}
+          activeWorkspaceSelection={activeWorkspaceSelection}
+          onWorkspacePress={onWorkspacePress}
+        />
+      ))}
+    </View>
+  );
+}
+
 export function SidebarWorkspaceList({
   statusGroups,
+  pinnedWorkspaces,
   projects,
   projectNamesByKey,
   collapsedProjectKeys,
@@ -2095,6 +2193,7 @@ export function SidebarWorkspaceList({
       />
     ) : (
       <ProjectModeList
+        pinnedWorkspaces={pinnedWorkspaces}
         projects={projects}
         collapsedProjectKeys={collapsedProjectKeys}
         onToggleProjectCollapsed={onToggleProjectCollapsed}
@@ -2144,6 +2243,7 @@ function SidebarStatusModeWrapper({
 }
 
 function ProjectModeList({
+  pinnedWorkspaces,
   projects,
   collapsedProjectKeys,
   onToggleProjectCollapsed,
@@ -2377,6 +2477,17 @@ function ProjectModeList({
 
   const content = (
     <>
+      <PinnedWorkspacesSection
+        pinnedWorkspaces={pinnedWorkspaces ?? EMPTY_PINNED_WORKSPACES}
+        selectionEnabled={selectionEnabled}
+        activeWorkspaceSelection={activeWorkspaceSelection}
+        showShortcutBadges={showShortcutBadges}
+        shortcutIndexByWorkspaceKey={shortcutIndexByWorkspaceKey}
+        hostLabelByServerId={hostLabelByServerId}
+        showHostLabels={showHostLabels}
+        creatingWorkspaceIds={creatingWorkspaceIds}
+        onWorkspacePress={onWorkspacePress}
+      />
       {projects.length === 0 ? (
         <View style={styles.emptyContainer}>
           <Text style={styles.emptyTitle} testID="sidebar-project-empty-state">
@@ -2446,6 +2557,17 @@ const styles = StyleSheet.create((theme) => ({
   },
   projectListContainer: {
     width: "100%",
+  },
+  pinnedSection: {
+    marginBottom: theme.spacing[2],
+  },
+  pinnedSectionTitle: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.medium,
+    paddingHorizontal: theme.spacing[2],
+    paddingBottom: theme.spacing[1],
+    userSelect: "none",
   },
   projectBlock: {
     marginBottom: theme.spacing[1],

--- a/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { type PressableStateCallbackType } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
-import { Archive, CircleCheck, Copy, MoreVertical, Pencil } from "lucide-react-native";
+import { Archive, CircleCheck, Copy, MoreVertical, Pencil, Pin, PinOff } from "lucide-react-native";
 import { isNative, isWeb } from "@/constants/platform";
 import type { Theme } from "@/styles/theme";
 import type { ShortcutKey } from "@/utils/format-shortcut";
@@ -24,6 +24,8 @@ const ThemedCopy = withUnistyles(Copy);
 const ThemedArchive = withUnistyles(Archive);
 const ThemedPencil = withUnistyles(Pencil);
 const ThemedCircleCheck = withUnistyles(CircleCheck);
+const ThemedPin = withUnistyles(Pin);
+const ThemedPinOff = withUnistyles(PinOff);
 
 const copyLeadingIcon = <ThemedCopy size={14} uniProps={foregroundMutedColorMapping} />;
 const renameLeadingIcon = <ThemedPencil size={14} uniProps={foregroundMutedColorMapping} />;
@@ -31,6 +33,8 @@ const markAsReadLeadingIcon = (
   <ThemedCircleCheck size={14} uniProps={foregroundMutedColorMapping} />
 );
 const archiveLeadingIcon = <ThemedArchive size={14} uniProps={foregroundMutedColorMapping} />;
+const pinLeadingIcon = <ThemedPin size={14} uniProps={foregroundMutedColorMapping} />;
+const unpinLeadingIcon = <ThemedPinOff size={14} uniProps={foregroundMutedColorMapping} />;
 
 function renderTriggerIcon({ hovered }: { hovered?: boolean }) {
   return (
@@ -47,6 +51,8 @@ interface SidebarWorkspaceMenuProps {
   onCopyBranchName?: () => void;
   onRename?: () => void;
   onMarkAsRead?: () => void;
+  onTogglePinned?: () => void;
+  isPinned?: boolean;
   onArchive: () => void;
   archiveLabel?: string;
   archiveStatus?: "idle" | "pending" | "success";
@@ -60,6 +66,8 @@ export function SidebarWorkspaceMenu({
   onCopyBranchName,
   onRename,
   onMarkAsRead,
+  onTogglePinned,
+  isPinned = false,
   onArchive,
   archiveLabel,
   archiveStatus,
@@ -109,6 +117,17 @@ export function SidebarWorkspaceMenu({
             onSelect={onRename}
           >
             {t("sidebar.workspace.actions.rename")}
+          </DropdownMenuItem>
+        ) : null}
+        {onTogglePinned ? (
+          <DropdownMenuItem
+            testID={`sidebar-workspace-menu-toggle-pinned-${workspaceKey}`}
+            leading={isPinned ? unpinLeadingIcon : pinLeadingIcon}
+            onSelect={onTogglePinned}
+          >
+            {isPinned
+              ? t("sidebar.workspace.actions.unpinWorkspace")
+              : t("sidebar.workspace.actions.pinWorkspace")}
           </DropdownMenuItem>
         ) : null}
         {onMarkAsRead ? (

--- a/packages/app/src/hooks/sidebar-status-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-status-view-model.test.ts
@@ -22,6 +22,7 @@ function ws(
     workspaceKind: input.workspaceKind ?? "worktree",
     name: input.name ?? "main",
     title: input.title ?? null,
+    pinnedAt: null,
     currentBranch: input.currentBranch ?? null,
     statusBucket: input.statusBucket ?? "done",
     statusEnteredAt: input.statusEnteredAt ?? null,

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
@@ -9,6 +9,7 @@ import {
   buildSidebarProjectsFromStructure,
   computeSidebarOrderUpdates,
   deriveSidebarLoadingState,
+  partitionPinnedSidebarWorkspaces,
   shouldShowSidebarHostLabels,
   type SidebarProjectEntry,
 } from "./sidebar-workspaces-view-model";
@@ -297,6 +298,70 @@ describe("shared sidebar workspace model", () => {
       ],
     );
     expect(model.projectNamesByKey).toEqual(new Map([["getpaseo/paseo", "getpaseo/paseo"]]));
+  });
+});
+
+describe("partitionPinnedSidebarWorkspaces", () => {
+  it("lifts pinned placements out of their project groups into the pinned section", () => {
+    const projects = [
+      sidebarProject({ projectKey: "project-a", workspaceKeys: ["ws-1", "ws-2", "ws-3"] }),
+      sidebarProject({ projectKey: "project-b", workspaceKeys: ["ws-4"] }),
+    ];
+    const pinnedAtByKey = new Map<string, string>([
+      ["srv:ws-2", "2026-01-01T00:00:00.000Z"],
+      ["srv:ws-4", "2026-02-01T00:00:00.000Z"],
+    ]);
+
+    const result = partitionPinnedSidebarWorkspaces({
+      projects,
+      getPinnedAt: (workspaceKey) => pinnedAtByKey.get(workspaceKey) ?? null,
+    });
+
+    expect(result.projects[0]?.workspaces.map((placement) => placement.workspaceKey)).toEqual([
+      "srv:ws-1",
+      "srv:ws-3",
+    ]);
+    expect(result.projects[1]?.workspaces.map((placement) => placement.workspaceKey)).toEqual([]);
+    expect(result.pinnedWorkspaces.map((placement) => placement.workspaceKey)).toEqual([
+      "srv:ws-2",
+      "srv:ws-4",
+    ]);
+  });
+
+  it("orders pinned workspaces by pinnedAt ascending so the most recent pin is last", () => {
+    const projects = [sidebarProject({ projectKey: "project-a", workspaceKeys: ["a", "b", "c"] })];
+    const pinnedAtByKey = new Map<string, string>([
+      ["srv:a", "2026-03-01T00:00:00.000Z"],
+      ["srv:b", "2026-01-01T00:00:00.000Z"],
+      ["srv:c", "2026-02-01T00:00:00.000Z"],
+    ]);
+
+    const result = partitionPinnedSidebarWorkspaces({
+      projects,
+      getPinnedAt: (workspaceKey) => pinnedAtByKey.get(workspaceKey) ?? null,
+    });
+
+    expect(result.pinnedWorkspaces.map((placement) => placement.workspaceKey)).toEqual([
+      "srv:b",
+      "srv:c",
+      "srv:a",
+    ]);
+    expect(result.projects[0]?.workspaces).toEqual([]);
+  });
+
+  it("preserves project identity and returns no pins when nothing is pinned", () => {
+    const projects = [
+      sidebarProject({ projectKey: "project-a", workspaceKeys: ["ws-1", "ws-2"] }),
+      sidebarProject({ projectKey: "project-b", workspaceKeys: ["ws-3"] }),
+    ];
+
+    const result = partitionPinnedSidebarWorkspaces({
+      projects,
+      getPinnedAt: () => null,
+    });
+
+    expect(result.projects).toBe(projects);
+    expect(result.pinnedWorkspaces).toEqual([]);
   });
 });
 

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -37,6 +37,8 @@ export interface SidebarWorkspaceEntry extends SidebarStatusWorkspacePlacement {
   // Raw user-set title (null when the name is derived from branch/directory).
   // Prefills the rename input and signals whether a reset is available.
   title: string | null;
+  // When the workspace is pinned to the sidebar's Pinned section (null when unpinned).
+  pinnedAt: string | null;
   // Checkout branch (null when not a git checkout or detached HEAD).
   currentBranch: string | null;
   archivingAt: string | null;
@@ -110,6 +112,7 @@ export function createSidebarWorkspaceEntry(input: {
     workspaceKind: input.workspace.workspaceKind,
     name: input.workspace.name,
     title: input.workspace.title ?? null,
+    pinnedAt: input.workspace.pinnedAt ?? null,
     currentBranch: normalizeCurrentBranch(input.workspace.gitRuntime?.currentBranch),
     statusBucket: effectiveStatus.status,
     statusEnteredAt: effectiveStatus.enteredAt,
@@ -322,6 +325,48 @@ export function buildSidebarProjectsFromHostProjects(input: {
       }),
     ),
   }));
+}
+
+export interface SidebarPinnedWorkspacesPartition {
+  // Pinned workspaces sorted by pinnedAt ascending (most recently pinned last).
+  pinnedWorkspaces: SidebarWorkspacePlacement[];
+  // Project groups with pinned workspaces removed; identity preserved for
+  // untouched projects so memoized rows don't re-render.
+  projects: SidebarProjectEntry[];
+}
+
+// Pure derivation of the sidebar's Pinned section: workspaces with a pinnedAt
+// timestamp leave their project group and gather in a top-level section.
+export function partitionPinnedSidebarWorkspaces(input: {
+  projects: SidebarProjectEntry[];
+  getPinnedAt: (workspaceKey: string) => string | null;
+}): SidebarPinnedWorkspacesPartition {
+  const pinned: Array<{ placement: SidebarWorkspacePlacement; pinnedAt: string }> = [];
+  let anyProjectChanged = false;
+
+  const projects = input.projects.map((project) => {
+    const remaining: SidebarWorkspacePlacement[] = [];
+    for (const placement of project.workspaces) {
+      const pinnedAt = input.getPinnedAt(placement.workspaceKey);
+      if (pinnedAt !== null) {
+        pinned.push({ placement, pinnedAt });
+      } else {
+        remaining.push(placement);
+      }
+    }
+    if (remaining.length === project.workspaces.length) {
+      return project;
+    }
+    anyProjectChanged = true;
+    return { ...project, workspaces: remaining };
+  });
+
+  pinned.sort((left, right) => left.pinnedAt.localeCompare(right.pinnedAt));
+
+  return {
+    pinnedWorkspaces: pinned.map((entry) => entry.placement),
+    projects: anyProjectChanged ? projects : input.projects,
+  };
 }
 
 // Host labels disambiguate which machine a workspace lives on; they only earn their

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -361,7 +361,13 @@ export function partitionPinnedSidebarWorkspaces(input: {
     return { ...project, workspaces: remaining };
   });
 
-  pinned.sort((left, right) => left.pinnedAt.localeCompare(right.pinnedAt));
+  // ISO 8601 timestamps sort chronologically under plain ASCII comparison; a
+  // direct comparison avoids locale-sensitive collation from localeCompare.
+  pinned.sort((left, right) => {
+    if (left.pinnedAt < right.pinnedAt) return -1;
+    if (left.pinnedAt > right.pinnedAt) return 1;
+    return 0;
+  });
 
   return {
     pinnedWorkspaces: pinned.map((entry) => entry.placement),

--- a/packages/app/src/hooks/use-sidebar-shortcut-model.test.tsx
+++ b/packages/app/src/hooks/use-sidebar-shortcut-model.test.tsx
@@ -25,6 +25,7 @@ function workspace(projectKey: string, workspaceId: string): SidebarWorkspaceEnt
     workspaceKind: "worktree",
     name: workspaceId,
     title: null,
+    pinnedAt: null,
     currentBranch: null,
     statusBucket: "done",
     statusEnteredAt: null,

--- a/packages/app/src/hooks/use-sidebar-workspaces-list.ts
+++ b/packages/app/src/hooks/use-sidebar-workspaces-list.ts
@@ -16,12 +16,15 @@ import {
   computeSidebarOrderUpdates,
   createSidebarWorkspaceEntry,
   deriveSidebarLoadingState,
+  partitionPinnedSidebarWorkspaces,
   type SidebarProjectEntry,
   type SidebarWorkspaceEntry,
   type SidebarWorkspacePlacement,
 } from "./sidebar-workspaces-view-model";
 
 export {
+  partitionPinnedSidebarWorkspaces,
+  type SidebarPinnedWorkspacesPartition,
   appendMissingOrderKeys,
   applyStoredOrdering,
   buildSidebarProjectsFromHostProjects,
@@ -82,6 +85,7 @@ const EMPTY_PROJECT_NAMES = new Map<string, string>();
 
 export interface SidebarWorkspacesListResult {
   workspacePlacements: SidebarWorkspacePlacement[];
+  pinnedWorkspaces: SidebarWorkspacePlacement[];
   projects: SidebarProjectEntry[];
   projectNamesByKey: Map<string, string>;
   isLoading: boolean;
@@ -143,7 +147,40 @@ export function useSidebarWorkspacesList(options?: {
     [hostProjects],
   );
 
-  const projects = sidebarModel.projects.length > 0 ? sidebarModel.projects : EMPTY_PROJECTS;
+  // Pinned timestamps keyed by `${serverId}:${workspaceId}` — shallow-compared so
+  // unrelated workspace updates don't rebuild the partition.
+  const pinnedAtByWorkspaceKey = useStoreWithEqualityFn(
+    useSessionStore,
+    (state) => {
+      const pins: Record<string, string> = {};
+      for (const serverId of serverIds) {
+        const workspaces = state.sessions[serverId]?.workspaces;
+        if (!workspaces) continue;
+        for (const workspace of workspaces.values()) {
+          if (workspace.pinnedAt) {
+            pins[`${serverId}:${workspace.id}`] = workspace.pinnedAt;
+          }
+        }
+      }
+      return pins;
+    },
+    shallow,
+  );
+
+  const pinnedPartition = useMemo(
+    () =>
+      partitionPinnedSidebarWorkspaces({
+        projects: sidebarModel.projects,
+        getPinnedAt: (workspaceKey) => pinnedAtByWorkspaceKey[workspaceKey] ?? null,
+      }),
+    [pinnedAtByWorkspaceKey, sidebarModel.projects],
+  );
+
+  const projects = pinnedPartition.projects.length > 0 ? pinnedPartition.projects : EMPTY_PROJECTS;
+  const pinnedWorkspaces =
+    pinnedPartition.pinnedWorkspaces.length > 0
+      ? pinnedPartition.pinnedWorkspaces
+      : EMPTY_WORKSPACES;
   const workspacePlacements =
     sidebarModel.workspaces.length > 0 ? sidebarModel.workspaces : EMPTY_WORKSPACES;
   const projectNamesByKey =
@@ -212,6 +249,7 @@ export function useSidebarWorkspacesList(options?: {
 
   return {
     workspacePlacements,
+    pinnedWorkspaces,
     projects,
     projectNamesByKey,
     ...loadingState,

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -793,6 +793,7 @@ export const ar: TranslationResources = {
     sections: {
       sessions: "السجل",
       schedules: "الجداول",
+      pinned: "المثبتة",
     },
     worktreeSetup: {
       title: "إعداد البرامج النصية لشجرة العمل",
@@ -840,6 +841,8 @@ export const ar: TranslationResources = {
         rename: "إعادة تسمية مساحة العمل",
         archive: "أرشيف",
         archiveWorktree: "أرشفة شجرة العمل",
+        pinWorkspace: "تثبيت مساحة العمل",
+        unpinWorkspace: "إلغاء تثبيت مساحة العمل",
         hideFromSidebar: "إخفاء من الشريط الجانبي",
         archiving: "أرشفة...",
         hiding: "إخفاء...",
@@ -863,6 +866,7 @@ export const ar: TranslationResources = {
         hostDisconnected: "Host غير متصل",
         hideFailed: "فشل في إخفاء مساحة العمل",
         archiveFailed: "فشل في أرشفة شجرة العمل",
+        pinFailed: "فشل في تثبيت مساحة العمل",
       },
     },
   },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -800,6 +800,7 @@ export const en = {
     sections: {
       sessions: "History",
       schedules: "Schedules",
+      pinned: "Pinned",
     },
     worktreeSetup: {
       title: "Set up worktree scripts",
@@ -847,6 +848,8 @@ export const en = {
         rename: "Rename workspace",
         archive: "Archive",
         archiveWorktree: "Archive worktree",
+        pinWorkspace: "Pin workspace",
+        unpinWorkspace: "Unpin workspace",
         hideFromSidebar: "Hide from sidebar",
         archiving: "Archiving...",
         hiding: "Hiding...",
@@ -870,6 +873,7 @@ export const en = {
         hostDisconnected: "Host is not connected",
         hideFailed: "Failed to hide workspace",
         archiveFailed: "Failed to archive worktree",
+        pinFailed: "Failed to pin workspace",
       },
     },
   },

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -820,6 +820,7 @@ export const es: TranslationResources = {
     sections: {
       sessions: "Historial",
       schedules: "Horarios",
+      pinned: "Fijados",
     },
     worktreeSetup: {
       title: "Configurar secuencias de comandos del árbol de trabajo",
@@ -867,6 +868,8 @@ export const es: TranslationResources = {
         rename: "Cambiar nombre del espacio de trabajo",
         archive: "Archivo",
         archiveWorktree: "Árbol de trabajo de archivo",
+        pinWorkspace: "Fijar espacio de trabajo",
+        unpinWorkspace: "Dejar de fijar espacio de trabajo",
         hideFromSidebar: "Ocultar de la barra lateral",
         archiving: "Archivando...",
         hiding: "Ocultación...",
@@ -890,6 +893,7 @@ export const es: TranslationResources = {
         hostDisconnected: "Hostno está conectado",
         hideFailed: "No se pudo ocultar el espacio de trabajo",
         archiveFailed: "No se pudo archivar el árbol de trabajo",
+        pinFailed: "No se pudo fijar el espacio de trabajo",
       },
     },
   },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -819,6 +819,7 @@ export const fr: TranslationResources = {
     sections: {
       sessions: "Historique",
       schedules: "Planifications",
+      pinned: "Épinglés",
     },
     worktreeSetup: {
       title: "Configurer les scripts d'arbre de travail",
@@ -866,6 +867,8 @@ export const fr: TranslationResources = {
         rename: "Renommer l'espace de travail",
         archive: "Archive",
         archiveWorktree: "Arbre de travail d'archivage",
+        pinWorkspace: "Épingler l'espace de travail",
+        unpinWorkspace: "Désépingler l'espace de travail",
         hideFromSidebar: "Masquer de la barre latérale",
         archiving: "Archivage...",
         hiding: "Dissimulation...",
@@ -889,6 +892,7 @@ export const fr: TranslationResources = {
         hostDisconnected: "Hostn'est pas connecté",
         hideFailed: "Échec du masquage de l'espace de travail",
         archiveFailed: "Échec de l'archivage de l'arbre de travail",
+        pinFailed: "Échec de l'épinglage de l'espace de travail",
       },
     },
   },

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -805,6 +805,7 @@ export const ja: TranslationResources = {
     sections: {
       sessions: "履歴",
       schedules: "スケジュール",
+      pinned: "ピン留め",
     },
     worktreeSetup: {
       title: "ワークツリースクリプトを設定",
@@ -852,6 +853,8 @@ export const ja: TranslationResources = {
         rename: "ワークスペースの名前を変更",
         archive: "アーカイブ",
         archiveWorktree: "ワークツリーをアーカイブ",
+        pinWorkspace: "ワークスペースをピン留め",
+        unpinWorkspace: "ワークスペースのピン留めを解除",
         hideFromSidebar: "サイドバーから非表示",
         archiving: "アーカイブ中...",
         hiding: "非表示にしています...",
@@ -875,6 +878,7 @@ export const ja: TranslationResources = {
         hostDisconnected: "ホストが接続されていません",
         hideFailed: "ワークスペースの非表示に失敗しました",
         archiveFailed: "ワークツリーのアーカイブに失敗しました",
+        pinFailed: "ワークスペースのピン留めに失敗しました",
       },
     },
   },

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -811,6 +811,7 @@ export const ptBR: TranslationResources = {
     sections: {
       sessions: "Histórico",
       schedules: "Agendamentos",
+      pinned: "Fixados",
     },
     worktreeSetup: {
       title: "Configurar scripts de worktree",
@@ -858,6 +859,8 @@ export const ptBR: TranslationResources = {
         rename: "Renomear workspace",
         archive: "Arquivar",
         archiveWorktree: "Arquivar worktree",
+        pinWorkspace: "Fixar workspace",
+        unpinWorkspace: "Desafixar workspace",
         hideFromSidebar: "Ocultar da barra lateral",
         archiving: "Arquivando...",
         hiding: "Ocultando...",
@@ -881,6 +884,7 @@ export const ptBR: TranslationResources = {
         hostDisconnected: "Host não está conectado",
         hideFailed: "Falha ao ocultar workspace",
         archiveFailed: "Falha ao arquivar worktree",
+        pinFailed: "Falha ao fixar workspace",
       },
     },
   },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -812,6 +812,7 @@ export const ru: TranslationResources = {
     sections: {
       sessions: "История",
       schedules: "Расписания",
+      pinned: "Закреплённые",
     },
     worktreeSetup: {
       title: "Настройка сценариев рабочего дерева",
@@ -859,6 +860,8 @@ export const ru: TranslationResources = {
         rename: "Переименовать рабочую область",
         archive: "Архив",
         archiveWorktree: "Архив рабочего дерева",
+        pinWorkspace: "Закрепить рабочую область",
+        unpinWorkspace: "Открепить рабочую область",
         hideFromSidebar: "Скрыть с боковой панели",
         archiving: "Архивирование...",
         hiding: "Скрытие...",
@@ -882,6 +885,7 @@ export const ru: TranslationResources = {
         hostDisconnected: "Host не подключен",
         hideFailed: "Не удалось скрыть рабочую область.",
         archiveFailed: "Не удалось заархивировать рабочее дерево.",
+        pinFailed: "Не удалось закрепить рабочую область",
       },
     },
   },

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -787,6 +787,7 @@ export const zhCN: TranslationResources = {
     sections: {
       sessions: "历史",
       schedules: "计划",
+      pinned: "已固定",
     },
     worktreeSetup: {
       title: "设置 worktree scripts",
@@ -832,6 +833,8 @@ export const zhCN: TranslationResources = {
         rename: "重命名 workspace",
         archive: "归档",
         archiveWorktree: "归档 worktree",
+        pinWorkspace: "固定 workspace",
+        unpinWorkspace: "取消固定 workspace",
         hideFromSidebar: "从侧边栏隐藏",
         archiving: "正在归档...",
         hiding: "正在隐藏...",
@@ -854,6 +857,7 @@ export const zhCN: TranslationResources = {
         hostDisconnected: "Host 未连接",
         hideFailed: "隐藏 workspace 失败",
         archiveFailed: "归档 worktree 失败",
+        pinFailed: "固定 workspace 失败",
       },
     },
   },

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -135,6 +135,7 @@ export interface WorkspaceDescriptor {
   workspaceKind: WorkspaceDescriptorPayload["workspaceKind"];
   name: string;
   title?: string | null;
+  pinnedAt?: string | null;
   status: WorkspaceDescriptorPayload["status"];
   statusEnteredAt: Date | null;
   archivingAt: string | null;
@@ -167,6 +168,7 @@ export function normalizeWorkspaceDescriptor(
     workspaceKind: payload.workspaceKind,
     name: payload.name,
     title: payload.title ?? null,
+    pinnedAt: payload.pinnedAt ?? null,
     status: payload.status,
     statusEnteredAt,
     archivingAt: payload.archivingAt ?? null,

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -20,6 +20,7 @@ function workspace(overrides: Partial<SidebarWorkspaceEntry> = {}): SidebarWorks
     workspaceKind: "checkout",
     name: "paseo",
     title: null,
+    pinnedAt: null,
     currentBranch: null,
     statusBucket: "done",
     diffStat: null,

--- a/packages/app/src/utils/sidebar-shortcuts.test.ts
+++ b/packages/app/src/utils/sidebar-shortcuts.test.ts
@@ -31,6 +31,7 @@ function workspace(input: {
     workspaceKind: "checkout",
     name: input.name,
     title: null,
+    pinnedAt: null,
     currentBranch: null,
     statusBucket: input.statusBucket ?? "done",
     archivingAt: null,

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -2295,6 +2295,26 @@ export class DaemonClient {
     return { title: payload.title };
   }
 
+  async setWorkspacePinned(
+    workspaceId: string,
+    pinned: boolean,
+    requestId?: string,
+  ): Promise<{ pinnedAt: string | null }> {
+    const payload = await this.sendCorrelatedSessionRequest({
+      requestId,
+      message: {
+        type: "workspace.pin.set.request",
+        workspaceId,
+        pinned,
+      },
+      responseType: "workspace.pin.set.response",
+    });
+    if (!payload.accepted) {
+      throw new Error(payload.error ?? "setWorkspacePinned rejected");
+    }
+    return { pinnedAt: payload.pinnedAt };
+  }
+
   async resumeAgent(
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -831,6 +831,13 @@ export const WorkspaceTitleSetRequestSchema = z.object({
   requestId: z.string(),
 });
 
+export const WorkspacePinSetRequestSchema = z.object({
+  type: z.literal("workspace.pin.set.request"),
+  workspaceId: z.string(),
+  pinned: z.boolean(),
+  requestId: z.string(),
+});
+
 export const SetVoiceModeMessageSchema = z.object({
   type: z.literal("set_voice_mode"),
   enabled: z.boolean(),
@@ -1432,6 +1439,20 @@ export const WorkspaceTitleSetResponsePayloadSchema = z.object({
 export const WorkspaceTitleSetResponseSchema = z.object({
   type: z.literal("workspace.title.set.response"),
   payload: WorkspaceTitleSetResponsePayloadSchema,
+});
+
+export const WorkspacePinSetResponsePayloadSchema = z.object({
+  requestId: z.string(),
+  workspaceId: z.string(),
+  accepted: z.boolean(),
+  // ISO timestamp when the workspace was pinned; null when unpinned.
+  pinnedAt: z.string().nullable(),
+  error: z.string().nullable(),
+});
+
+export const WorkspacePinSetResponseSchema = z.object({
+  type: z.literal("workspace.pin.set.response"),
+  payload: WorkspacePinSetResponsePayloadSchema,
 });
 
 export const SetVoiceModeResponseMessageSchema = z.object({
@@ -2058,6 +2079,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   ProjectRenameRequestSchema,
   ProjectRemoveRequestSchema,
   WorkspaceTitleSetRequestSchema,
+  WorkspacePinSetRequestSchema,
   SetVoiceModeMessageSchema,
   SendAgentMessageRequestSchema,
   WaitForFinishRequestSchema,
@@ -2367,6 +2389,8 @@ export const ServerInfoStatusPayloadSchema = z
         daemonSelfUpdate: z.boolean().optional(),
         // COMPAT(agentForkContext): added in v0.1.102, remove gate after 2026-12-28.
         agentForkContext: z.boolean().optional(),
+        // COMPAT(workspacePins): added in v0.1.106, drop the gate when floor >= v0.1.106.
+        workspacePins: z.boolean().optional(),
       })
       .optional(),
   })
@@ -2645,6 +2669,10 @@ export const WorkspaceDescriptorPayloadSchema = z
     // its input and offer a "reset to branch name" action. Null means the name
     // is derived from the branch/directory.
     title: z.string().nullable().optional(),
+    // COMPAT(workspacePins): added in v0.1.106, drop the gate when floor >= v0.1.106.
+    // When the user pinned this workspace (ISO timestamp), mirroring archivedAt.
+    // Null or missing means the workspace is not pinned.
+    pinnedAt: z.string().nullable().optional(),
     archivingAt: z.string().nullable().optional().default(null),
     status: WorkspaceStateBucketSchema,
     // Best-effort workspace status entry timestamp. Old daemons omit the
@@ -4231,6 +4259,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   ProjectRenameResponseSchema,
   ProjectRemoveResponseSchema,
   WorkspaceTitleSetResponseSchema,
+  WorkspacePinSetResponseSchema,
   WaitForFinishResponseMessageSchema,
   AgentPermissionRequestMessageSchema,
   AgentPermissionResolvedMessageSchema,
@@ -4387,6 +4416,8 @@ export type WorkspaceTitleSetResponse = z.infer<typeof WorkspaceTitleSetResponse
 export type WorkspaceTitleSetResponsePayload = z.infer<
   typeof WorkspaceTitleSetResponsePayloadSchema
 >;
+export type WorkspacePinSetResponse = z.infer<typeof WorkspacePinSetResponseSchema>;
+export type WorkspacePinSetResponsePayload = z.infer<typeof WorkspacePinSetResponsePayloadSchema>;
 export type WorkspaceCreateRequest = z.infer<typeof WorkspaceCreateRequestSchema>;
 export type WorkspaceCreateResponse = z.infer<typeof WorkspaceCreateResponseSchema>;
 export type ProjectRenameResponsePayload = z.infer<typeof ProjectRenameResponsePayloadSchema>;
@@ -4519,6 +4550,7 @@ export type UpdateAgentRequestMessage = z.infer<typeof UpdateAgentRequestMessage
 export type ProjectRenameRequest = z.infer<typeof ProjectRenameRequestSchema>;
 export type ProjectRemoveRequest = z.infer<typeof ProjectRemoveRequestSchema>;
 export type WorkspaceTitleSetRequest = z.infer<typeof WorkspaceTitleSetRequestSchema>;
+export type WorkspacePinSetRequest = z.infer<typeof WorkspacePinSetRequestSchema>;
 export type SetAgentModeRequestMessage = z.infer<typeof SetAgentModeRequestMessageSchema>;
 export type SetAgentModelRequestMessage = z.infer<typeof SetAgentModelRequestMessageSchema>;
 export type SetAgentThinkingRequestMessage = z.infer<typeof SetAgentThinkingRequestMessageSchema>;

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1632,6 +1632,8 @@ export class Session {
         return this.handleWorkspaceClearAttentionRequest(msg);
       case "workspace.title.set.request":
         return this.handleWorkspaceTitleSetRequest(msg.workspaceId, msg.title, msg.requestId);
+      case "workspace.pin.set.request":
+        return this.handleWorkspacePinSetRequest(msg.workspaceId, msg.pinned, msg.requestId);
       case "file_explorer_request":
         return this.workspaceFilesSession.handleFileExplorerRequest(msg);
       case "project_icon_request":
@@ -2312,6 +2314,72 @@ export class Session {
           accepted: false,
           title: null,
           error: getErrorMessageOr(error, "Failed to set workspace title"),
+        },
+      });
+    }
+  }
+
+  private async handleWorkspacePinSetRequest(
+    workspaceId: string,
+    pinned: boolean,
+    requestId: string,
+  ): Promise<void> {
+    this.sessionLogger.info(
+      { workspaceId, requestId, pinned },
+      "session: workspace.pin.set.request",
+    );
+
+    try {
+      const existing = await this.workspaceRegistry.get(workspaceId);
+      if (!existing) {
+        this.emit({
+          type: "workspace.pin.set.response",
+          payload: {
+            requestId,
+            workspaceId,
+            accepted: false,
+            pinnedAt: null,
+            error: "Workspace not found",
+          },
+        });
+        return;
+      }
+
+      const pinnedAt = pinned ? new Date().toISOString() : null;
+
+      await this.workspaceRegistry.upsert({
+        ...existing,
+        pinnedAt,
+        updatedAt: new Date().toISOString(),
+      });
+
+      this.emit({
+        type: "workspace.pin.set.response",
+        payload: {
+          requestId,
+          workspaceId,
+          accepted: true,
+          pinnedAt,
+          error: null,
+        },
+      });
+
+      await this.emitWorkspaceUpdatesForWorkspaceIds([workspaceId], {
+        skipReconcile: true,
+      });
+    } catch (error) {
+      this.sessionLogger.error(
+        { err: error, workspaceId, requestId },
+        "session: workspace.pin.set.request error",
+      );
+      this.emit({
+        type: "workspace.pin.set.response",
+        payload: {
+          requestId,
+          workspaceId,
+          accepted: false,
+          pinnedAt: null,
+          error: getErrorMessageOr(error, "Failed to set workspace pin"),
         },
       });
     }
@@ -3532,6 +3600,7 @@ export class Session {
       workspaceKind: workspace.kind,
       name: resolveWorkspaceDisplayName(workspace),
       title: workspace.title,
+      pinnedAt: workspace.pinnedAt,
       archivingAt: null,
       status: "done",
       statusEnteredAt: null,
@@ -3616,6 +3685,7 @@ export class Session {
         derivedDisplayName: result.worktree.branchName || result.workspace.displayName,
       }),
       title: result.workspace.title,
+      pinnedAt: result.workspace.pinnedAt,
       archivingAt: null,
       status: "done",
       statusEnteredAt: result.workspace.createdAt,

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -6678,6 +6678,145 @@ test("workspace.title.set.request returns accepted=false when workspace is not f
   expect(response?.payload.error).toBeTruthy();
 });
 
+test("workspace.pin.set.request pins the workspace and emits an updated descriptor", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const session = asTestSession(
+    createSessionForWorkspaceTests({ onMessage: (message) => emitted.push(message) }),
+  );
+
+  const project = createPersistedProjectRecord({
+    projectId: "proj-1",
+    rootPath: REPO_CWD,
+    kind: "git",
+    displayName: "acme/repo",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-1",
+    projectId: project.projectId,
+    cwd: REPO_CWD,
+    kind: "local_checkout",
+    displayName: "main",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+
+  const projects = new Map([[project.projectId, project]]);
+  const workspaces = new Map([[workspace.workspaceId, workspace]]);
+  session.projectRegistry.get = async (id: string) => projects.get(id) ?? null;
+  session.projectRegistry.list = async () => Array.from(projects.values());
+  session.workspaceRegistry.list = async () => Array.from(workspaces.values());
+  session.workspaceRegistry.get = async (id: string) => workspaces.get(id) ?? null;
+  session.workspaceRegistry.upsert = async (record: unknown) => {
+    const parsed = record as typeof workspace;
+    workspaces.set(parsed.workspaceId, parsed);
+  };
+
+  session.workspaceUpdatesSubscription = {
+    subscriptionId: "sub-workspaces",
+    filter: {},
+    isBootstrapping: false,
+    lastEmittedByWorkspaceId: new Map(),
+    pendingUpdatesByWorkspaceId: new Map(),
+  };
+
+  await session.handleMessage({
+    type: "workspace.pin.set.request",
+    workspaceId: workspace.workspaceId,
+    pinned: true,
+    requestId: "req-pin-1",
+  });
+
+  const response = findByType(emitted, "workspace.pin.set.response");
+  expect(response?.payload).toMatchObject({
+    requestId: "req-pin-1",
+    workspaceId: workspace.workspaceId,
+    accepted: true,
+    error: null,
+  });
+  const pinnedAt = response?.payload.pinnedAt;
+  expect(typeof pinnedAt).toBe("string");
+
+  expect(workspaces.get(workspace.workspaceId)?.pinnedAt).toBe(pinnedAt);
+
+  const update = findByType(emitted, "workspace_update");
+  expect(update?.payload).toMatchObject({
+    kind: "upsert",
+    workspace: {
+      id: "ws-1",
+      pinnedAt,
+    },
+  });
+});
+
+test("workspace.pin.set.request with pinned=false clears pinnedAt", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const session = asTestSession(
+    createSessionForWorkspaceTests({ onMessage: (message) => emitted.push(message) }),
+  );
+
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-1",
+    projectId: "proj-1",
+    cwd: REPO_CWD,
+    kind: "local_checkout",
+    displayName: "main",
+    pinnedAt: "2026-03-01T12:00:00.000Z",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+
+  const workspaces = new Map([[workspace.workspaceId, workspace]]);
+  session.workspaceRegistry.list = async () => Array.from(workspaces.values());
+  session.workspaceRegistry.get = async (id: string) => workspaces.get(id) ?? null;
+  session.workspaceRegistry.upsert = async (record: unknown) => {
+    const parsed = record as typeof workspace;
+    workspaces.set(parsed.workspaceId, parsed);
+  };
+
+  await session.handleMessage({
+    type: "workspace.pin.set.request",
+    workspaceId: workspace.workspaceId,
+    pinned: false,
+    requestId: "req-pin-clear",
+  });
+
+  const response = findByType(emitted, "workspace.pin.set.response");
+  expect(response?.payload).toEqual({
+    requestId: "req-pin-clear",
+    workspaceId: workspace.workspaceId,
+    accepted: true,
+    pinnedAt: null,
+    error: null,
+  });
+  expect(workspaces.get(workspace.workspaceId)?.pinnedAt).toBeNull();
+});
+
+test("workspace.pin.set.request returns accepted=false when workspace is not found", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const session = asTestSession(
+    createSessionForWorkspaceTests({ onMessage: (message) => emitted.push(message) }),
+  );
+  session.workspaceRegistry.get = async () => null;
+
+  await session.handleMessage({
+    type: "workspace.pin.set.request",
+    workspaceId: "does-not-exist",
+    pinned: true,
+    requestId: "req-pin-missing",
+  });
+
+  const response = findByType(emitted, "workspace.pin.set.response");
+  expect(response?.payload).toMatchObject({
+    requestId: "req-pin-missing",
+    workspaceId: "does-not-exist",
+    accepted: false,
+    pinnedAt: null,
+  });
+  expect(response?.payload.error).toBeTruthy();
+});
+
 function createSessionWithTerminalManager(options: {
   workspaces: PersistedWorkspaceRecord[];
   projects: PersistedProjectRecord[];

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1238,6 +1238,8 @@ export class VoiceAssistantWebSocketServer {
         daemonSelfUpdate: true,
         // COMPAT(agentForkContext): added in v0.1.102, remove gate after 2026-12-28.
         agentForkContext: true,
+        // COMPAT(workspacePins): added in v0.1.106, drop the gate when floor >= v0.1.106.
+        workspacePins: true,
       },
     };
   }

--- a/packages/server/src/server/workspace-registry.test.ts
+++ b/packages/server/src/server/workspace-registry.test.ts
@@ -211,4 +211,44 @@ describe("workspace registries", () => {
     expect(await workspaceRegistry.get("/tmp/repo")).toBeNull();
     expect(await workspaceRegistry.list()).toEqual([]);
   });
+
+  test("workspace record schema defaults pinnedAt to null (legacy on-disk records)", async () => {
+    await workspaceRegistry.initialize();
+
+    await workspaceRegistry.upsert(
+      createPersistedWorkspaceRecord({
+        workspaceId: "/tmp/repo",
+        projectId: "remote:github.com/acme/repo",
+        cwd: "/tmp/repo",
+        kind: "local_checkout",
+        displayName: "main",
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    );
+
+    const record = await workspaceRegistry.get("/tmp/repo");
+    expect(record?.pinnedAt).toBeNull();
+  });
+
+  test("workspace record persists pinnedAt across upserts", async () => {
+    await workspaceRegistry.initialize();
+
+    const base = createPersistedWorkspaceRecord({
+      workspaceId: "/tmp/repo",
+      projectId: "remote:github.com/acme/repo",
+      cwd: "/tmp/repo",
+      kind: "local_checkout",
+      displayName: "main",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    });
+    await workspaceRegistry.upsert({
+      ...base,
+      pinnedAt: "2026-03-02T00:00:00.000Z",
+    });
+
+    const record = await workspaceRegistry.get("/tmp/repo");
+    expect(record?.pinnedAt).toBe("2026-03-02T00:00:00.000Z");
+  });
 });

--- a/packages/server/src/server/workspace-registry.ts
+++ b/packages/server/src/server/workspace-registry.ts
@@ -53,6 +53,13 @@ const PersistedWorkspaceRecordSchema = z.object({
     .nullable()
     .optional()
     .transform((value) => value ?? null),
+  // When the user pinned this workspace (ISO timestamp), mirroring archivedAt.
+  // Null means the workspace is not pinned.
+  pinnedAt: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((value) => value ?? null),
   createdAt: z.string(),
   updatedAt: z.string(),
   archivedAt: z.string().nullable(),
@@ -254,6 +261,7 @@ export function createPersistedWorkspaceRecord(input: {
   title?: string | null;
   branch?: string | null;
   baseBranch?: string | null;
+  pinnedAt?: string | null;
   createdAt: string;
   updatedAt: string;
   archivedAt?: string | null;
@@ -263,6 +271,7 @@ export function createPersistedWorkspaceRecord(input: {
     title: input.title ?? null,
     branch: input.branch ?? null,
     baseBranch: input.baseBranch ?? null,
+    pinnedAt: input.pinnedAt ?? null,
     archivedAt: input.archivedAt ?? null,
   });
 }


### PR DESCRIPTION
## What

Workspace kebab menus (desktop and mobile) gain a **Pin workspace / Unpin workspace** entry. Pinning lifts a workspace OUT of its project group into a new **"Pinned" section at the very top** of the sidebar; unpinning returns it to its project group. Multiple pinned workspaces are ordered by pin time (most recently pinned last).

Pinned state is stored **on the daemon's workspace record** so the same workspaces stay pinned across every device — same server-synced contract as the tab-pin feature.

## How

**Protocol** (`packages/protocol/src/messages.ts`)
- New `workspace.pin.set.request` / `workspace.pin.set.response` RPC (mirrors `workspace.title.set`), registered in the inbound/outbound unions; AOT validator regenerates on typecheck.
- Optional `pinnedAt: string | null` on `WorkspaceDescriptorPayload`.
- New `workspacePins` feature flag in `server_info.features`.
- Back-compat preserved: all new fields optional; old clients/daemons unaffected. Tagged `// COMPAT(workspacePins): ... v0.1.106`.

**Server**
- `pinnedAt` persisted on the file-backed workspace registry record with a nullable default (no migration).
- Session handler upserts an ISO timestamp (or null to unpin), returns the value, and emits a `workspace_update`. `pinnedAt` threaded into workspace descriptors.
- `workspacePins: true` set in `buildServerInfoStatusPayload`.

**Client** — `DaemonClient.setWorkspacePinned(workspaceId, pinned)`.

**App**
- `partitionPinnedSidebarWorkspaces` derives the Pinned section as a pure function (sorted by `pinnedAt` ascending, excluded from project groups).
- Menu entry gated on the `workspacePins` capability — hidden on old daemons, no fallback path. No optimistic update; UI converges on the pushed `workspace_update`.
- Labels added to all 8 locales.

## Tests

- `workspace-registry.test.ts` — legacy records default `pinnedAt` to null; persists across upserts.
- `session.workspaces.test.ts` — pin set → response + registry value + `workspace_update` descriptor; unpin clears to null; unknown workspace → `accepted: false`.
- `sidebar-workspaces-view-model.test.ts` — partition lifts pinned placements out of groups, orders by `pinnedAt` ascending, preserves project identity when nothing is pinned.

typecheck, lint, format, and all touched test files pass. Running-app verification (screenshots) to follow.