### PR TITLE
fix(desktop): stop sandboxed preload from requiring a local module

### DIFF
--- a/packages/desktop/src/preload-sandbox.test.ts
+++ b/packages/desktop/src/preload-sandbox.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import { PASEO_BROWSER_PROFILE_PARTITION } from "./features/browser-profile.js";
+
+// The preload runs inside Electron's sandbox and is tsc-compiled (not bundled), so at
+// runtime it may only load Electron's sandbox allowlist. Any other module (local or
+// third-party) emits a require() that the sandbox rejects synchronously, aborting the
+// preload before contextBridge.exposeInMainWorld runs and leaving window.paseoDesktop
+// undefined. That regression (0.1.108, #2103) is what this test guards against.
+const SANDBOX_ALLOWLIST = new Set(["electron"]);
+
+const preloadPath = join(dirname(fileURLToPath(import.meta.url)), "preload.ts");
+
+// Collect every module specifier that survives to emitted JavaScript as a runtime load.
+// Type-only imports/exports are erased by tsc and are therefore ignored.
+function runtimeModuleSpecifiers(source: string): string[] {
+  const sourceFile = ts.createSourceFile(
+    "preload.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  );
+  const specifiers: string[] = [];
+
+  const record = (node: ts.Expression | undefined): void => {
+    if (node && ts.isStringLiteralLike(node)) {
+      specifiers.push(node.text);
+    }
+  };
+
+  const isTypeOnlyImport = (node: ts.ImportDeclaration): boolean => {
+    const clause = node.importClause;
+    if (!clause) {
+      // Side-effect import: `import "./x.js"` — always a runtime load.
+      return false;
+    }
+    if (clause.isTypeOnly) {
+      return true;
+    }
+    const bindings = clause.namedBindings;
+    // `import { type A, type B } from "x"` erases entirely; a default or namespace
+    // binding, or any value-named binding, keeps the module at runtime.
+    return (
+      clause.name === undefined &&
+      bindings !== undefined &&
+      ts.isNamedImports(bindings) &&
+      bindings.elements.length > 0 &&
+      bindings.elements.every((element) => element.isTypeOnly)
+    );
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      if (!isTypeOnlyImport(node)) {
+        record(node.moduleSpecifier);
+      }
+    } else if (ts.isExportDeclaration(node) && !node.isTypeOnly && node.moduleSpecifier) {
+      record(node.moduleSpecifier);
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference)
+    ) {
+      record(node.moduleReference.expression);
+    } else if (ts.isCallExpression(node)) {
+      const isRequire = ts.isIdentifier(node.expression) && node.expression.text === "require";
+      const isDynamicImport = node.expression.kind === ts.SyntaxKind.ImportKeyword;
+      if (isRequire || isDynamicImport) {
+        record(node.arguments[0]);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return specifiers;
+}
+
+describe("preload sandbox safety", () => {
+  it("only loads Electron's sandbox allowlist at runtime", () => {
+    const source = readFileSync(preloadPath, "utf8");
+    const disallowed = runtimeModuleSpecifiers(source).filter(
+      (specifier) => !SANDBOX_ALLOWLIST.has(specifier),
+    );
+    expect(disallowed).toEqual([]);
+  });
+
+  it("inlines the browser profile partition instead of importing it", () => {
+    const source = readFileSync(preloadPath, "utf8");
+    const match = source.match(/const\s+PASEO_BROWSER_PROFILE_PARTITION\s*=\s*"([^"]+)"/);
+    expect(match?.[1]).toBe(PASEO_BROWSER_PROFILE_PARTITION);
+  });
+});

--- a/packages/desktop/src/preload-sandbox.test.ts
+++ b/packages/desktop/src/preload-sandbox.test.ts
@@ -90,6 +90,10 @@ describe("preload sandbox safety", () => {
   it("inlines the browser profile partition instead of importing it", () => {
     const source = readFileSync(preloadPath, "utf8");
     const match = source.match(/const\s+PASEO_BROWSER_PROFILE_PARTITION\s*=\s*"([^"]+)"/);
-    expect(match?.[1]).toBe(PASEO_BROWSER_PROFILE_PARTITION);
+    expect(
+      match,
+      "PASEO_BROWSER_PROFILE_PARTITION not found as a double-quoted string literal in preload.ts",
+    ).not.toBeNull();
+    expect(match![1]).toBe(PASEO_BROWSER_PROFILE_PARTITION);
   });
 });

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -1,5 +1,12 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
-import { PASEO_BROWSER_PROFILE_PARTITION } from "./features/browser-profile.js";
+
+// This preload runs in Electron's sandbox and is tsc-compiled (not bundled), so it MUST
+// NOT emit any runtime module load other than "electron" — a require() of a local or
+// third-party module throws and aborts the preload before exposeInMainWorld runs, leaving
+// window.paseoDesktop undefined (the 0.1.108 regression, #2103). Keep this literal in sync
+// with PASEO_BROWSER_PROFILE_PARTITION in features/browser-profile.ts; preload-sandbox.test.ts
+// guards both the no-local-import rule and this drift. Type-only imports are fine (erased at emit).
+const PASEO_BROWSER_PROFILE_PARTITION = "persist:paseo-browser";
 
 type EventHandler = (payload: unknown) => void;
 


### PR DESCRIPTION
### Linked issue

Closes #2103
Closes #2106

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do
On 0.1.108 the desktop app can't start its local daemon by itself (users work around it
with `paseo start`; downgrading to 0.1.107 fixes it).

`packages/desktop/src/preload.ts` imported a local module —
`import { PASEO_BROWSER_PROFILE_PARTITION } from "./features/browser-profile.js"` — added
in 0.1.108 by #2089. The preload runs in Electron's sandbox (`webPreferences.sandbox`
defaults to `true`; `main.ts` doesn't override it) and is tsc-compiled, not bundled
(`build:main: "tsc -p tsconfig.json"`), so that import emits
`require("./features/browser-profile.js")` at the top of `preload.js`. A sandboxed preload
can't `require` a local module, so it throws before
`contextBridge.exposeInMainWorld("paseoDesktop", …)`. `window.paseoDesktop` is then
undefined, so `isElectronRuntime()` (`getDesktopHost() !== null`) is false,
`shouldUseDesktopDaemon()` is false, and the renderer never starts the built-in daemon.

This inlines the one value the preload needs (the partition string) so it stops loading
any local module, keeping `features/browser-profile.ts` as the source of truth for the
main process. It also adds `preload-sandbox.test.ts`, which parses `preload.ts` with the
TypeScript compiler API and asserts the only runtime module load is `electron` (covering
value/side-effect imports, re-exports, `require`, dynamic `import`, and import-equals;
type-only imports are ignored), plus a drift check that the inlined literal matches the
canonical constant. That turns "a local import in the sandboxed preload" into a unit-test
failure instead of a bug that only shows up in a packaged build.

### How did you verify it

Traced the root cause in code (sandbox default, tsc emit, import ordering vs
`exposeInMainWorld`, and the `isElectronRuntime` → `shouldStartBuiltInDaemon` gate), then:

- **Compiled artifact (the actual failing call):** on `main`, `npm run build:main` emits
  `require("./features/browser-profile.js")` at the top of `dist/preload.js` — the call the
  sandbox rejects. After the fix, `dist/preload.js` contains only
  `const electron_1 = require("electron")` and no local `require("./…")`.
- **Regression test, both directions:** `npx vitest run packages/desktop/src/preload-sandbox.test.ts`
  fails on `main` (`expected [ './features/browser-profile.js' ] to deeply equal []`) and
  passes after the fix (2/2).
- `npm run typecheck`, `npm run lint`, and `npm run format` are clean (also enforced by the
  pre-commit hook).
- Manually verified on macOS - now traffic lights also get rendered correctly again and not over the content.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform — n/a, no UI change
- [x] Tests added or updated where it made sense

