### PR TITLE
fix(desktop): reserve macOS sidebar titlebar space

### DIFF
--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -32,7 +32,7 @@ import { SidebarDisplayPreferencesMenu } from "@/components/sidebar/sidebar-disp
 import { SidebarHelpMenu } from "@/components/sidebar/sidebar-help-menu";
 import { Shortcut } from "@/components/ui/shortcut";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { HEADER_INNER_HEIGHT, useIsCompactFormFactor } from "@/constants/layout";
+import { useIsCompactFormFactor } from "@/constants/layout";
 import { isWeb } from "@/constants/platform";
 import { useOpenAddProject } from "@/hooks/use-open-add-project";
 import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
@@ -52,7 +52,7 @@ import { useHosts } from "@/runtime/host-runtime";
 import { useActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
 import { useWorkspace } from "@/stores/session-store-hooks";
 import { usePanelStore } from "@/stores/panel-store";
-import { useOwnsWindowChromeCorner, WindowChromeSafeArea } from "@/utils/desktop-window";
+import { WindowChromeSafeArea } from "@/utils/desktop-window";
 import { useCloseAgentListGesture } from "@/mobile-panels/gestures";
 import { MobilePanelOverlay } from "@/mobile-panels/presentation";
 import {
@@ -703,7 +703,6 @@ function DesktopSidebar({
   handleViewMore,
   handleViewSchedules,
 }: DesktopSidebarProps) {
-  const ownsTopLeft = useOwnsWindowChromeCorner("top-left");
   const pathname = usePathname();
   const hasActiveHostFilter = useSidebarViewStore((state) => state.hostFilters.length > 0);
   const isSessionsActive = pathname.includes("/sessions");
@@ -761,10 +760,6 @@ function DesktopSidebar({
     () => [styles.desktopSidebarBorder, { flex: 1, paddingTop: insetsTop }],
     [insetsTop],
   );
-  const sidebarHeaderGroupStyle = useMemo(
-    () => [styles.sidebarHeaderGroup, ownsTopLeft && styles.sidebarHeaderGroupBelowChrome],
-    [ownsTopLeft],
-  );
   const resizeHandleStyle = useMemo(
     () => [styles.resizeHandle, isWeb && ({ cursor: "col-resize" } as object)],
     [],
@@ -779,14 +774,9 @@ function DesktopSidebar({
     >
       <View style={desktopSidebarBorderStyle}>
         <View style={styles.sidebarDragArea}>
-          {ownsTopLeft ? (
-            <View style={styles.desktopChromeRow}>
-              <TitlebarDragRegion />
-            </View>
-          ) : (
-            <TitlebarDragRegion />
-          )}
-          <View style={sidebarHeaderGroupStyle}>
+          <TitlebarDragRegion />
+          <WindowChromeSafeArea placement="below" />
+          <View style={styles.sidebarHeaderGroup}>
             <SidebarNewWorkspaceHeaderRow
               label={labels.newWorkspace}
               testID="sidebar-global-new-workspace"
@@ -935,9 +925,6 @@ const styles = StyleSheet.create((theme) => ({
     borderBottomWidth: 1,
     borderBottomColor: theme.colors.border,
   },
-  sidebarHeaderGroupBelowChrome: {
-    paddingTop: 0,
-  },
   workspacesSectionHeader: {
     flexDirection: "row",
     alignItems: "center",
@@ -1008,14 +995,6 @@ const styles = StyleSheet.create((theme) => ({
   },
   sidebarDragArea: {
     position: "relative",
-  },
-  desktopChromeRow: {
-    position: "relative",
-    height: HEADER_INNER_HEIGHT,
-    flexDirection: "row",
-    alignItems: "center",
-    borderBottomWidth: theme.borderWidth[1],
-    borderBottomColor: "transparent",
   },
   sidebarFooter: {
     flexDirection: "row",


### PR DESCRIPTION
### Linked issue

Closes #2113

### Type of change

- [x] Bug fix

### What does this PR do

On macOS, the native traffic-light controls were overlapping the top-left sidebar navigation rows. This replaces the sidebar's fixed titlebar spacer with the shared `WindowChromeSafeArea`, so it reserves the actual Electron obstruction height.

### Before evidence

The linked issue contains the reporter-supplied Paseo 0.1.108 screenshot showing the overlap: #2113.

### How did you verify it

- `git diff --check` passes.
- Reviewed the existing `WindowChromeRegion` ownership and `WindowChromeSafeArea` implementation.
- The fixed web renderer was launched at `http://100.68.25.25:8081`; a real macOS after screenshot is still pending because this environment is Linux.
- Repository checks were attempted but could not complete because the installed toolchain currently fails with an existing TypeScript declaration parse error and `oxfmt` bus error.

### Checklist

- [x] One focused change.
- [ ] `npm run typecheck` passes — blocked by environment/toolchain error.
- [ ] `npm run lint` passes — blocked by environment/toolchain error.
- [ ] `npm run format` ran — `oxfmt` aborts with a bus error.
- [ ] macOS after screenshot — requires macOS hardware.
- [ ] Tests added or updated where it made sense.