### PR TITLE
fix(server): stop stalled ACP prompts from wedging the next turn

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -86,7 +86,10 @@ describe("buildACPClientCapabilities", () => {
 
 interface ACPSessionInternals {
   sessionId: string | null;
-  connection: { prompt: (...args: unknown[]) => Promise<PromptResponse> };
+  connection: {
+    prompt: (...args: unknown[]) => Promise<PromptResponse>;
+    cancel?: (...args: unknown[]) => Promise<void>;
+  };
   activeForegroundTurnId: string | null;
   configOptions: SessionConfigOption[];
   translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[];
@@ -2331,6 +2334,88 @@ describe("ACPAgentSession", () => {
       turnId,
     });
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
+  });
+
+  test("interrupt clears the foreground turn even when the ACP prompt never settles", async () => {
+    const session = createSession();
+    const events: Array<{ type: string; turnId?: string }> = [];
+    // The agent accepts the prompt but never resolves it — mirrors a backend
+    // that stalls in inference and is slow (or fails) to return a stopReason
+    // after session/cancel.
+    const prompt = vi.fn(() => new Promise<PromptResponse>(() => {}));
+    const cancel = vi.fn(async () => {});
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+
+    session.subscribe((event) => {
+      events.push(event as { type: string; turnId?: string });
+    });
+
+    const { turnId } = await session.startTurn("hello");
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBe(turnId);
+
+    await session.interrupt();
+
+    // The interrupt must request cancellation from the agent and locally
+    // finalize the turn instead of waiting for the (possibly never-arriving)
+    // prompt response.
+    expect(cancel).toHaveBeenCalledWith({ sessionId: "session-1" });
+    expect(events.find((event) => event.type === "turn_canceled")).toMatchObject({
+      type: "turn_canceled",
+      turnId,
+    });
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
+
+    // A fresh turn must be accepted immediately — no "already active" throw.
+    const next = await session.startTurn("again");
+    expect(next.turnId).not.toBe(turnId);
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBe(next.turnId);
+  });
+
+  test("a late ACP prompt response after interrupt does not re-finalize the turn", async () => {
+    const session = createSession();
+    const events: Array<{ type: string; turnId?: string }> = [];
+    // One resolver per prompt() call so we can settle the *first* (interrupted)
+    // turn specifically, after a newer turn has already started.
+    const resolvers: Array<(value: PromptResponse) => void> = [];
+    const prompt = vi.fn(
+      () =>
+        new Promise<PromptResponse>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const cancel = vi.fn(async () => {});
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+
+    session.subscribe((event) => {
+      events.push(event as { type: string; turnId?: string });
+    });
+
+    const { turnId } = await session.startTurn("hello");
+    await session.interrupt();
+
+    // Start a new turn — the interrupted one is done as far as we're concerned.
+    const next = await session.startTurn("again");
+
+    // Now the ORIGINAL turn's prompt finally resolves. It must be ignored: no
+    // second terminal event for the old turn, and it must not clobber the new
+    // turn's active state.
+    resolvers[0]({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const terminalsForOldTurn = events.filter(
+      (event) =>
+        event.turnId === turnId &&
+        (event.type === "turn_completed" ||
+          event.type === "turn_failed" ||
+          event.type === "turn_canceled"),
+    );
+    expect(terminalsForOldTurn).toEqual([expect.objectContaining({ type: "turn_canceled" })]);
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBe(next.turnId);
   });
 
   test("startTurn emits the submitted user message even when ACP does not echo it", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2016,8 +2016,38 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
     this.pendingPermissions.clear();
 
-    if (this.activeForegroundTurnId) {
+    const turnId = this.activeForegroundTurnId;
+    if (!turnId) {
+      return;
+    }
+
+    // Ask the agent to cancel the in-flight prompt. session/cancel is an ACP
+    // notification, so this resolves once the request is flushed to the
+    // transport — it never waits for the agent to acknowledge or for the
+    // in-flight session/prompt call to return.
+    try {
       await this.connection.cancel({ sessionId: this.sessionId });
+    } catch (error) {
+      this.logger.debug({ err: error }, "ACP session/cancel failed during interrupt");
+    }
+
+    // Finalize the turn locally so the session is immediately ready for the
+    // next prompt. A backend stalled in inference can be slow to return its
+    // final stopReason after a cancel — or never return it at all — and
+    // blocking finalization on that response would leave activeForegroundTurnId
+    // set, wedging the next startTurn() with "A foreground turn is already
+    // active". finishTurn() is idempotent and handlePromptResponse() bails on a
+    // stale turn, so the eventual (or never-arriving) prompt response is a
+    // harmless no-op. Guard on turnId in case the real response won the race
+    // during the await above.
+    if (this.activeForegroundTurnId === turnId) {
+      this.synthesizeCanceledToolCalls();
+      this.finishTurn({
+        type: "turn_canceled",
+        provider: this.provider,
+        reason: "Interrupted",
+        turnId,
+      });
     }
   }
 
@@ -2640,6 +2670,14 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {
+    // The session/prompt call for this turn has resolved. If the turn was
+    // already finalized locally (e.g. interrupt() canceled it, or a newer turn
+    // has since started), ignore the response entirely — don't let its usage
+    // leak into the current turn. finishTurn() is idempotent, but bailing here
+    // keeps currentTurnUsage from being clobbered by a stale response.
+    if (turnId !== this.activeForegroundTurnId) {
+      return;
+    }
     this.currentTurnUsage = mapACPUsage(response.usage) ?? this.currentTurnUsage;
 
     switch (response.stopReason) {
@@ -2730,6 +2768,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private finishTurn(
     event: Extract<AgentStreamEvent, { type: "turn_completed" | "turn_failed" | "turn_canceled" }>,
   ): void {
+    // Idempotent: only the active foreground turn can be finalized. A late or
+    // duplicate terminal — e.g. a slow session/prompt response that resolves
+    // after interrupt() already canceled the turn locally, or after a newer
+    // turn has started — must not re-emit a terminal or disturb the live turn.
+    if (event.turnId !== this.activeForegroundTurnId) {
+      return;
+    }
     this.activeForegroundTurnId = null;
     this.fallbackAssistantMessageId = null;
     if (this.activeSubmittedUserMessage?.turnId === event.turnId) {


### PR DESCRIPTION
## Problem

Interrupting an ACP-backed agent (goose, generic ACP, Copilot, Kiro, Pi, …) sometimes wedges the session: the **next** prompt fails with

> `[System Error] A foreground turn is already active`

### Root cause

`ACPAgentSession` tracks `activeForegroundTurnId` and only clears it in `finishTurn()`, which runs when the agent's `session/prompt` call resolves with a `stopReason`. `interrupt()` fired `session/cancel` and awaited nothing else.

If the backend is slow to return its final `stopReason` after a cancel — or never returns it at all (e.g. stalled in model inference) — the turn stays `"active"`. The next `startTurn()` then throws `"A foreground turn is already active"`, which the manager surfaces as the `[System Error]` banner. In the worst case (response never arrives) the session is wedged until it's restarted.

This is timing-dependent, which is why it only happens *sometimes* — if the backend returns `Cancelled` within the manager's grace window everything looks fine.

## Fix

Mirror the pattern OpenCode already uses (`opencode-agent.ts`): cancel the backend, but **finalize the turn locally** so the session is immediately ready for the next prompt. Because the change lives in the shared `ACPAgentSession` base, every ACP-based provider benefits with no per-provider code.

- **`interrupt()`** — after firing `session/cancel`, locally emit `turn_canceled` and clear the turn instead of waiting for the prompt response.
- **`finishTurn()`** — make idempotent: only finalize the currently-active turn, so a late/duplicate terminal (the eventual, or never-arriving, prompt response) is a harmless no-op.
- **`handlePromptResponse()`** — bail if the turn is no longer active, so a stale prompt response can't leak usage into a newer turn.

Autonomous turns are unaffected: they finalize via `completeAutonomousTurn()` (direct `pushEvent`), not `finishTurn()`.

## Tests

Two new tests in `acp-agent.test.ts`:
- `interrupt` clears the foreground turn even when `session/prompt` never settles (and a fresh turn is accepted immediately).
- a late `session/prompt` response after `interrupt` does not re-finalize the turn or clobber a newer one.

Full `acp-agent.test.ts` passes (79/79).

## Notes

- No protocol/schema changes; fully backward-compatible.
- No agent-side (goose etc.) changes required — this is a host-side robustness fix so a slow/stalled backend can't wedge a session.
