### PR TITLE
Reimport archived sessions into the current workspace

### DIFF
--- a/packages/app/src/components/import-session-sheet-view-model.test.ts
+++ b/packages/app/src/components/import-session-sheet-view-model.test.ts
@@ -9,6 +9,7 @@ import {
   getPromptPreview,
   getSessionTitle,
   resolveProvidersToFetch,
+  requiresImportSessionsHostUpgrade,
   type SessionsQueryResult,
   sumFilteredAlreadyImportedCount,
 } from "@/components/import-session-sheet-view-model";
@@ -67,6 +68,35 @@ describe("resolveProvidersToFetch", () => {
       { provider: "z-ai", enabled: false },
     ]);
     expect(providers).toEqual([]);
+  });
+});
+
+describe("requiresImportSessionsHostUpgrade", () => {
+  it("allows home imports on hosts without workspace targeting", () => {
+    expect(
+      requiresImportSessionsHostUpgrade({
+        supportsSnapshot: true,
+        workspaceId: null,
+        supportsWorkspaceTarget: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("requires host support for imports opened from a workspace", () => {
+    expect(
+      requiresImportSessionsHostUpgrade({
+        supportsSnapshot: true,
+        workspaceId: "ws-current",
+        supportsWorkspaceTarget: false,
+      }),
+    ).toBe(true);
+    expect(
+      requiresImportSessionsHostUpgrade({
+        supportsSnapshot: true,
+        workspaceId: "ws-current",
+        supportsWorkspaceTarget: true,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/app/src/components/import-session-sheet-view-model.ts
+++ b/packages/app/src/components/import-session-sheet-view-model.ts
@@ -5,6 +5,14 @@ import { i18n } from "@/i18n/i18next";
 export const PER_PROVIDER_LIMIT = 15;
 export const ALL_FILTER_VALUE = "__all__";
 
+export function requiresImportSessionsHostUpgrade(input: {
+  supportsSnapshot: boolean;
+  workspaceId?: string | null;
+  supportsWorkspaceTarget: boolean;
+}): boolean {
+  return !input.supportsSnapshot || (Boolean(input.workspaceId) && !input.supportsWorkspaceTarget);
+}
+
 export interface SessionsQueryResult {
   data:
     | {

--- a/packages/app/src/components/import-session-sheet.tsx
+++ b/packages/app/src/components/import-session-sheet.tsx
@@ -44,6 +44,7 @@ interface ImportSessionSheetProps {
   client: RecentProviderSessionsClient | null;
   serverId: string | null;
   cwd?: string | null;
+  workspaceId?: string | null;
   onClose: () => void;
   onImportedAgent?: (agentId: string) => void;
   onImported?: (agent: ImportedAgent) => void;
@@ -260,6 +261,7 @@ export function ImportSessionSheet({
   client,
   serverId,
   cwd,
+  workspaceId,
   onClose,
   onImportedAgent,
   onImported,
@@ -408,6 +410,7 @@ export function ImportSessionSheet({
         providerId: entry.providerId,
         providerHandleId: entry.providerHandleId,
         cwd: entry.cwd,
+        ...(workspaceId ? { workspaceId } : {}),
       });
       return agent;
     },

--- a/packages/app/src/components/import-session-sheet.tsx
+++ b/packages/app/src/components/import-session-sheet.tsx
@@ -15,6 +15,7 @@ import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/com
 import { getProviderIcon } from "@/components/provider-icons";
 import { formatTimeAgo } from "@/utils/time";
 import { useProvidersSnapshot } from "@/hooks/use-providers-snapshot";
+import { useHostFeature } from "@/runtime/host-features";
 import { i18n } from "@/i18n/i18next";
 import {
   aggregateSessionEntries,
@@ -26,6 +27,7 @@ import {
   getSessionTitle,
   PER_PROVIDER_LIMIT,
   resolveProvidersToFetch,
+  requiresImportSessionsHostUpgrade,
   sumFilteredAlreadyImportedCount,
 } from "@/components/import-session-sheet-view-model";
 
@@ -274,10 +276,16 @@ export function ImportSessionSheet({
     cwd,
     enabled: visible,
   });
+  const supportsWorkspaceTarget = useHostFeature(serverId, "importSessionWorkspaceTarget");
+  const requiresHostUpgrade = requiresImportSessionsHostUpgrade({
+    supportsSnapshot,
+    workspaceId,
+    supportsWorkspaceTarget,
+  });
 
   const providersToFetch = useMemo(
-    () => resolveProvidersToFetch(supportsSnapshot, snapshotEntries),
-    [supportsSnapshot, snapshotEntries],
+    () => (requiresHostUpgrade ? null : resolveProvidersToFetch(supportsSnapshot, snapshotEntries)),
+    [requiresHostUpgrade, supportsSnapshot, snapshotEntries],
   );
 
   const providerLabelById = useMemo(
@@ -453,7 +461,7 @@ export function ImportSessionSheet({
     [isRefreshing, handleRefresh, t],
   );
 
-  const isSnapshotUnsupported = !supportsSnapshot;
+  const isSnapshotUnsupported = requiresHostUpgrade;
   const isWaitingForSnapshot = supportsSnapshot && snapshotEntries === undefined;
   const hasNoImportableProviders = providersToFetch !== null && providersToFetch.length === 0;
   const isQueryingProviders = queries.length > 0;

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -3683,6 +3683,7 @@ function WorkspaceScreenContent({
               client={client}
               serverId={normalizedServerId}
               cwd={workspaceDirectory}
+              workspaceId={normalizedWorkspaceId}
               onClose={closeImportSheet}
               onImportedAgent={handleImportedAgent}
             />

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -156,6 +156,7 @@ const PROJECT_GITHUB_CLONE_TIMEOUT_MS = 5 * 60 * 1000;
 
 interface ImportAgentInputBase {
   cwd?: string;
+  workspaceId?: string;
   labels?: Record<string, string>;
 }
 
@@ -2429,6 +2430,7 @@ export class DaemonClient {
         ? { providerId: input.providerId, providerHandleId: input.providerHandleId }
         : { provider: input.provider, sessionId: input.sessionId }),
       ...(input.cwd ? { cwd: input.cwd } : {}),
+      ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
       ...(input.labels && Object.keys(input.labels).length > 0 ? { labels: input.labels } : {}),
     });
 

--- a/packages/protocol/src/messages.test.ts
+++ b/packages/protocol/src/messages.test.ts
@@ -293,6 +293,21 @@ describe("agent detach RPC", () => {
     }
     expect(parsed.features?.agentDetach).toBe(true);
   });
+
+  test("parses the workspace-targeted session import feature gate", () => {
+    const parsed = parseServerInfoStatusPayload({
+      status: "server_info",
+      serverId: "srv-test",
+      features: {
+        importSessionWorkspaceTarget: true,
+      },
+    });
+
+    if (!parsed) {
+      throw new Error("Expected server info payload to parse");
+    }
+    expect(parsed.features?.importSessionWorkspaceTarget).toBe(true);
+  });
 });
 
 describe("agent setting action responses", () => {

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2476,6 +2476,8 @@ export const ServerInfoStatusPayloadSchema = z
         projectCreateDirectory: z.boolean().optional(),
         // COMPAT(providerRemoval): added in v0.1.105, drop the gate when floor >= v0.1.105.
         providerRemoval: z.boolean().optional(),
+        // COMPAT(importSessionWorkspaceTarget): added in v0.1.110, remove gate after 2027-01-16.
+        importSessionWorkspaceTarget: z.boolean().optional(),
       })
       .optional(),
   })

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1255,6 +1255,7 @@ export const ImportAgentRequestMessageSchema = z.object({
   sessionId: z.string().optional(),
   providerHandleId: z.string().optional(),
   cwd: z.string().optional(),
+  workspaceId: z.string().optional(),
   labels: z.record(z.string(), z.string()).optional(),
   requestId: z.string(),
 });

--- a/packages/server/src/server/agent/agent-loading.ts
+++ b/packages/server/src/server/agent/agent-loading.ts
@@ -13,7 +13,7 @@ import {
 
 const pendingAgentInitializations = new Map<string, Promise<ManagedAgent>>();
 
-type AgentLoaderManager = Pick<
+export type AgentLoaderManager = Pick<
   AgentManager,
   | "createAgent"
   | "getAgent"

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -5975,7 +5975,10 @@ test("unarchiveSnapshot unarchives native provider storage before clearing archi
   await manager.archiveAgent(agent.id);
   client.readArchivedAtDuringUnarchive = async () => (await storage.get(agent.id))?.archivedAt;
 
-  const unarchived = await manager.unarchiveSnapshot(agent.id);
+  const unarchived = await manager.unarchiveSnapshot(agent.id, {
+    workspaceId: "ws-restored",
+    labels: { source: "reimport" },
+  });
   const stored = await storage.get(agent.id);
 
   expect(unarchived).toBe(true);
@@ -5983,6 +5986,8 @@ test("unarchiveSnapshot unarchives native provider storage before clearing archi
   expect(client.unarchivedHandles).toEqual(client.archivedHandles);
   expect(client.archivedAtDuringUnarchive).toEqual(expect.any(String));
   expect(stored?.archivedAt).toBeNull();
+  expect(stored?.workspaceId).toBe("ws-restored");
+  expect(stored?.labels).toMatchObject({ source: "reimport" });
 });
 
 test("unarchiveSnapshotByHandle unarchives native provider storage for the matched snapshot", async () => {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -5970,14 +5970,17 @@ test("unarchiveSnapshot unarchives native provider storage before clearing archi
       title: "Native unarchive target",
     },
     undefined,
-    { workspaceId: undefined },
+    {
+      workspaceId: undefined,
+      labels: { [PARENT_AGENT_ID_LABEL]: "archived-parent", retained: "yes" },
+    },
   );
   await manager.archiveAgent(agent.id);
   client.readArchivedAtDuringUnarchive = async () => (await storage.get(agent.id))?.archivedAt;
 
   const unarchived = await manager.unarchiveSnapshot(agent.id, {
     workspaceId: "ws-restored",
-    labels: { source: "reimport" },
+    labels: { [PARENT_AGENT_ID_LABEL]: null, source: "reimport" },
   });
   const stored = await storage.get(agent.id);
 
@@ -5987,7 +5990,7 @@ test("unarchiveSnapshot unarchives native provider storage before clearing archi
   expect(client.archivedAtDuringUnarchive).toEqual(expect.any(String));
   expect(stored?.archivedAt).toBeNull();
   expect(stored?.workspaceId).toBe("ws-restored");
-  expect(stored?.labels).toMatchObject({ source: "reimport" });
+  expect(stored?.labels).toEqual({ retained: "yes", source: "reimport" });
 });
 
 test("unarchiveSnapshotByHandle unarchives native provider storage for the matched snapshot", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1671,7 +1671,7 @@ export class AgentManager {
 
   async unarchiveSnapshot(
     agentId: string,
-    updates?: { workspaceId?: string; labels?: Record<string, string> },
+    updates?: { workspaceId?: string; labels?: AgentLabelPatch },
   ): Promise<boolean> {
     const registry = this.requireRegistry();
     const record = await registry.get(agentId);
@@ -1684,7 +1684,7 @@ export class AgentManager {
     await registry.upsert({
       ...record,
       ...(updates?.workspaceId ? { workspaceId: updates.workspaceId } : {}),
-      ...(updates?.labels ? { labels: { ...record.labels, ...updates.labels } } : {}),
+      ...(updates?.labels ? { labels: applyLabelPatch(record.labels, updates.labels) } : {}),
       archivedAt: null,
       updatedAt: new Date().toISOString(),
     });

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1669,7 +1669,10 @@ export class AgentManager {
     return nextRecord;
   }
 
-  async unarchiveSnapshot(agentId: string): Promise<boolean> {
+  async unarchiveSnapshot(
+    agentId: string,
+    updates?: { workspaceId?: string; labels?: Record<string, string> },
+  ): Promise<boolean> {
     const registry = this.requireRegistry();
     const record = await registry.get(agentId);
     if (!record || !record.archivedAt) {
@@ -1680,6 +1683,8 @@ export class AgentManager {
 
     await registry.upsert({
       ...record,
+      ...(updates?.workspaceId ? { workspaceId: updates.workspaceId } : {}),
+      ...(updates?.labels ? { labels: { ...record.labels, ...updates.labels } } : {}),
       archivedAt: null,
       updatedAt: new Date().toISOString(),
     });

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -93,7 +93,7 @@ export async function unarchiveAgentState(
   _agentStorage: AgentStorage,
   agentManager: AgentManager,
   agentId: string,
-  updates?: { workspaceId?: string; labels?: Record<string, string> },
+  updates?: { workspaceId?: string; labels?: Record<string, string | null> },
 ): Promise<boolean> {
   const unarchived = await agentManager.unarchiveSnapshot(agentId, updates);
   if (!unarchived) return false;

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -93,8 +93,9 @@ export async function unarchiveAgentState(
   _agentStorage: AgentStorage,
   agentManager: AgentManager,
   agentId: string,
+  updates?: { workspaceId?: string; labels?: Record<string, string> },
 ): Promise<boolean> {
-  const unarchived = await agentManager.unarchiveSnapshot(agentId);
+  const unarchived = await agentManager.unarchiveSnapshot(agentId, updates);
   if (!unarchived) return false;
   agentManager.notifyAgentState(agentId);
   return true;

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -5,6 +5,8 @@ import type { AgentManager, ManagedAgent } from "./agent-manager.js";
 import type { AgentStorage } from "./agent-storage.js";
 import { ensureAgentLoaded } from "./agent-loading.js";
 
+export type AgentUnarchiveController = Pick<AgentManager, "notifyAgentState" | "unarchiveSnapshot">;
+
 export type AgentRunController = Pick<
   AgentManager,
   "getAgent" | "tryRunOutOfBand" | "hasInFlightRun" | "replaceAgentRun" | "streamAgent"
@@ -91,7 +93,7 @@ export async function startAgentRun(
  */
 export async function unarchiveAgentState(
   _agentStorage: AgentStorage,
-  agentManager: AgentManager,
+  agentManager: AgentUnarchiveController,
   agentId: string,
   updates?: { workspaceId?: string; labels?: Record<string, string | null> },
 ): Promise<boolean> {

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -636,6 +636,52 @@ test("importProviderSession restores an archived subagent as the same standalone
   expect(result).toEqual({ snapshot, timelineSize: 1 });
 });
 
+test("importProviderSession rejects an archived session from a different cwd before restoring it", async () => {
+  const archivedRecord = {
+    id: "00000000-0000-4000-8000-000000000637",
+    provider: "codex",
+    cwd: "/tmp/other-agent",
+    workspaceId: "ws-other",
+    createdAt: "2026-04-30T10:00:00.000Z",
+    updatedAt: "2026-04-30T11:00:00.000Z",
+    labels: {},
+    config: { provider: "codex", cwd: "/tmp/other-agent" },
+    persistence: {
+      provider: "codex",
+      sessionId: "thread-other-cwd",
+      nativeHandle: "thread-other-cwd",
+      metadata: { provider: "codex", cwd: "/tmp/other-agent" },
+    },
+    archivedAt: "2026-04-30T12:00:00.000Z",
+  } as StoredAgentRecord;
+  let unarchiveAttempted = false;
+  const agentManager = {
+    unarchiveSnapshot: async () => {
+      unarchiveAttempted = true;
+      return true;
+    },
+  } as unknown as AgentManager;
+  const agentStorage = {
+    list: async () => [archivedRecord],
+  } as unknown as AgentStorage;
+
+  await expect(
+    importProviderSession({
+      request: {
+        requestId: "reimport-other-cwd",
+        provider: "codex",
+        providerHandleId: "thread-other-cwd",
+        cwd: "/tmp/target-agent",
+      },
+      workspaceId: "ws-target",
+      agentManager,
+      agentStorage,
+      logger: { warn: () => {}, error: () => {} } as never,
+    }),
+  ).rejects.toThrow("Provider session cwd does not match import cwd: thread-other-cwd");
+  expect(unarchiveAttempted).toBe(false);
+});
+
 test("importProviderSession restores the archived record when provider resume fails", async () => {
   const cwd = "/tmp/imported-agent";
   const agentId = "00000000-0000-4000-8000-000000000635";

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -275,6 +275,51 @@ test("listImportableProviderSessions includes a provider session after its Paseo
   expect(result.filteredAlreadyImportedCount).toBe(0);
 });
 
+test("listImportableProviderSessions includes an archived provider session still loaded in memory", async () => {
+  const cwd = "/tmp/project";
+  const agentId = "00000000-0000-4000-8000-000000000633";
+  const archivedSession = makeImportableSession({
+    provider: "claude",
+    sessionId: "archived-live-session",
+    cwd,
+    title: "Archived live import",
+    lastActivityAt: "2026-04-30T12:00:00.000Z",
+    firstPrompt: "import the loaded session again",
+  });
+
+  const result = await listImportableProviderSessions({
+    request: makeRequest({ cwd, providers: ["claude"] }),
+    agentManager: {
+      listAgents: () => [
+        makeManagedAgent({
+          id: agentId,
+          provider: "claude",
+          cwd,
+          sessionId: "archived-live-session",
+        }),
+      ],
+      listImportableSessions: async () => [archivedSession],
+    },
+    agentStorage: {
+      list: async () => [
+        {
+          id: agentId,
+          provider: "claude",
+          archivedAt: "2026-04-30T12:01:00.000Z",
+          persistence: {
+            provider: "claude",
+            sessionId: "archived-live-session",
+          },
+        } as StoredAgentRecord,
+      ],
+    },
+    providerSnapshotManager: { getProviderLabel: () => "Claude" },
+  });
+
+  expect(result.entries.map((entry) => entry.providerHandleId)).toEqual(["archived-live-session"]);
+  expect(result.filteredAlreadyImportedCount).toBe(0);
+});
+
 test("listImportableProviderSessions filters out metadata generation sessions", async () => {
   const cwd = "/tmp/project";
   const sessions = [
@@ -479,6 +524,100 @@ test("importProviderSession passes labels through the manager import operation",
     workspaceId: "ws-imported",
     labels: { source: "import" },
   });
+});
+
+test("importProviderSession restores an archived session as the same Paseo agent", async () => {
+  const cwd = "/tmp/imported-agent";
+  const agentId = "00000000-0000-4000-8000-000000000634";
+  const persistence = {
+    provider: "codex",
+    sessionId: "thread-archived",
+    nativeHandle: "thread-archived",
+    metadata: { provider: "codex", cwd },
+  };
+  const archivedRecord = {
+    id: agentId,
+    provider: "codex",
+    cwd,
+    workspaceId: "ws-archived",
+    createdAt: "2026-04-30T10:00:00.000Z",
+    updatedAt: "2026-04-30T11:00:00.000Z",
+    lastActivityAt: "2026-04-30T10:30:00.000Z",
+    lastUserMessageAt: null,
+    labels: { existing: "label" },
+    config: { provider: "codex", cwd },
+    persistence,
+    archivedAt: "2026-04-30T12:00:00.000Z",
+  } as StoredAgentRecord;
+  const snapshot = makeManagedAgent({
+    id: agentId,
+    provider: "codex",
+    cwd,
+    sessionId: "thread-archived",
+    nativeHandle: "thread-archived",
+  });
+  let freshImportAttempted = false;
+  let unarchivedAgentId: string | undefined;
+  let unarchiveUpdates: { workspaceId?: string; labels?: Record<string, string> } | undefined;
+  let resumedAgentId: string | undefined;
+  let resumeOptions: { workspaceId?: string; labels?: Record<string, string> } | undefined;
+  const agentManager = {
+    importProviderSession: async () => {
+      freshImportAttempted = true;
+      return snapshot;
+    },
+    unarchiveSnapshot: async (
+      id: string,
+      updates?: { workspaceId?: string; labels?: Record<string, string> },
+    ) => {
+      unarchivedAgentId = id;
+      unarchiveUpdates = updates;
+      return true;
+    },
+    notifyAgentState: () => {},
+    resumeAgentFromPersistence: async (
+      _handle: unknown,
+      _overrides: unknown,
+      id?: string,
+      options?: { workspaceId?: string; labels?: Record<string, string> },
+    ) => {
+      resumedAgentId = id;
+      resumeOptions = options;
+      return snapshot;
+    },
+    hydrateTimelineFromProvider: async () => {},
+    getTimeline: () => [{ type: "user_message", text: "restored" }],
+  } as unknown as AgentManager;
+  const agentStorage = {
+    list: async () => [archivedRecord],
+  } as unknown as AgentStorage;
+
+  const result = await importProviderSession({
+    request: {
+      requestId: "reimport-thread",
+      provider: "codex",
+      providerHandleId: "thread-archived",
+      cwd,
+      labels: { source: "reimport" },
+    },
+    workspaceId: "ws-restored",
+    agentManager,
+    agentStorage,
+    logger: { warn: () => {}, error: () => {} } as never,
+  });
+
+  expect(freshImportAttempted).toBe(false);
+  expect(unarchivedAgentId).toBe(agentId);
+  expect(unarchiveUpdates).toEqual({
+    workspaceId: "ws-restored",
+    labels: { source: "reimport" },
+  });
+  expect(resumedAgentId).toBe(agentId);
+  expect(resumeOptions).toMatchObject({
+    workspaceId: "ws-restored",
+    labels: { existing: "label", source: "reimport" },
+  });
+  expect(result).toEqual({ snapshot, timelineSize: 1 });
 });
 
 test("importProviderSession requires cwd from the selected provider row", async () => {

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -620,6 +620,75 @@ test("importProviderSession restores an archived session as the same Paseo agent
   expect(result).toEqual({ snapshot, timelineSize: 1 });
 });
 
+test("importProviderSession restores the archived record when provider resume fails", async () => {
+  const cwd = "/tmp/imported-agent";
+  const agentId = "00000000-0000-4000-8000-000000000635";
+  const archivedAt = "2026-04-30T12:00:00.000Z";
+  const archivedRecord = {
+    id: agentId,
+    provider: "codex",
+    cwd,
+    workspaceId: "ws-archived",
+    createdAt: "2026-04-30T10:00:00.000Z",
+    updatedAt: "2026-04-30T11:00:00.000Z",
+    lastActivityAt: "2026-04-30T10:30:00.000Z",
+    lastUserMessageAt: null,
+    labels: { existing: "label" },
+    config: { provider: "codex", cwd },
+    persistence: {
+      provider: "codex",
+      sessionId: "thread-stale",
+      nativeHandle: "thread-stale",
+      metadata: { provider: "codex", cwd },
+    },
+    archivedAt,
+  } as StoredAgentRecord;
+  let rearchivedAgentId: string | undefined;
+  let rearchivedAt: string | undefined;
+  let restoredRecord: StoredAgentRecord | undefined;
+  const agentManager = {
+    importProviderSession: async () => {
+      throw new Error("fresh import should not run");
+    },
+    unarchiveSnapshot: async () => true,
+    notifyAgentState: () => {},
+    resumeAgentFromPersistence: async () => {
+      throw new Error("provider session is unavailable");
+    },
+    getAgent: () => null,
+    archiveSnapshot: async (id: string, timestamp: string) => {
+      rearchivedAgentId = id;
+      rearchivedAt = timestamp;
+      return archivedRecord;
+    },
+  } as unknown as AgentManager;
+  const agentStorage = {
+    list: async () => [archivedRecord],
+    upsert: async (record: StoredAgentRecord) => {
+      restoredRecord = record;
+    },
+  } as unknown as AgentStorage;
+
+  await expect(
+    importProviderSession({
+      request: {
+        requestId: "reimport-stale-thread",
+        provider: "codex",
+        providerHandleId: "thread-stale",
+        cwd,
+      },
+      workspaceId: "ws-restored",
+      agentManager,
+      agentStorage,
+      logger: { warn: () => {}, error: () => {} } as never,
+    }),
+  ).rejects.toThrow("provider session is unavailable");
+
+  expect(rearchivedAgentId).toBe(agentId);
+  expect(rearchivedAt).toBe(archivedAt);
+  expect(restoredRecord).toBe(archivedRecord);
+});
+
 test("importProviderSession requires cwd from the selected provider row", async () => {
   const agentManager = {} as unknown as AgentManager;
 

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -705,7 +705,7 @@ test("importProviderSession restores the archived record when provider resume fa
   expect(restoredRecord).toBe(archivedRecord);
 });
 
-test("importProviderSession leaves the winning agent active when two clients restore it concurrently", async () => {
+test("importProviderSession serializes legacy and native aliases for one archived session", async () => {
   const cwd = "/tmp/imported-agent";
   const agentId = "00000000-0000-4000-8000-000000000636";
   let storedRecord = {
@@ -721,8 +721,8 @@ test("importProviderSession leaves the winning agent active when two clients res
     config: { provider: "codex", cwd },
     persistence: {
       provider: "codex",
-      sessionId: "thread-concurrent",
-      nativeHandle: "thread-concurrent",
+      sessionId: "legacy-thread-concurrent",
+      nativeHandle: "native-thread-concurrent",
       metadata: { provider: "codex", cwd },
     },
     archivedAt: "2026-04-30T12:00:00.000Z",
@@ -731,8 +731,8 @@ test("importProviderSession leaves the winning agent active when two clients res
     id: agentId,
     provider: "codex",
     cwd,
-    sessionId: "thread-concurrent",
-    nativeHandle: "thread-concurrent",
+    sessionId: "legacy-thread-concurrent",
+    nativeHandle: "native-thread-concurrent",
   });
   const unarchive = createUnarchiveGate();
   const closedAgentIds: string[] = [];
@@ -779,7 +779,7 @@ test("importProviderSession leaves the winning agent active when two clients res
     request: {
       requestId: "reimport-concurrent-thread",
       provider: "codex" as const,
-      providerHandleId: "thread-concurrent",
+      providerHandleId: "native-thread-concurrent",
       cwd,
     },
     workspaceId: "ws-restored",
@@ -789,12 +789,18 @@ test("importProviderSession leaves the winning agent active when two clients res
   };
 
   const winningRestore = importProviderSession(input);
-  const duplicateRestore = importProviderSession(input);
+  const duplicateRestore = importProviderSession({
+    ...input,
+    request: {
+      ...input.request,
+      providerHandleId: "legacy-thread-concurrent",
+    },
+  });
   unarchive.allowUnarchive();
 
   await expect(winningRestore).resolves.toEqual({ snapshot, timelineSize: 0 });
   await expect(duplicateRestore).rejects.toThrow(
-    "Provider session is already imported: thread-concurrent",
+    "Provider session is already imported: legacy-thread-concurrent",
   );
   expect(storedRecord.archivedAt).toBeNull();
   expect(closedAgentIds).toEqual([]);

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -99,6 +99,18 @@ function makeManagedAgent(args: {
   } satisfies ManagedAgent;
 }
 
+function createUnarchiveGate() {
+  let allowUnarchive: () => void = () => {};
+  const unarchiveAllowed = new Promise<void>((resolve) => {
+    allowUnarchive = resolve;
+  });
+
+  return {
+    holdUnarchive: () => unarchiveAllowed,
+    allowUnarchive,
+  };
+}
+
 function makeRequest(
   overrides: Partial<FetchRecentProviderSessionsRequestMessage> = {},
 ): FetchRecentProviderSessionsRequestMessage {
@@ -691,6 +703,101 @@ test("importProviderSession restores the archived record when provider resume fa
   expect(rearchivedAgentId).toBe(agentId);
   expect(rearchivedAt).toBe(archivedAt);
   expect(restoredRecord).toBe(archivedRecord);
+});
+
+test("importProviderSession leaves the winning agent active when two clients restore it concurrently", async () => {
+  const cwd = "/tmp/imported-agent";
+  const agentId = "00000000-0000-4000-8000-000000000636";
+  let storedRecord = {
+    id: agentId,
+    provider: "codex",
+    cwd,
+    workspaceId: "ws-archived",
+    createdAt: "2026-04-30T10:00:00.000Z",
+    updatedAt: "2026-04-30T11:00:00.000Z",
+    lastActivityAt: "2026-04-30T10:30:00.000Z",
+    lastUserMessageAt: null,
+    labels: {},
+    config: { provider: "codex", cwd },
+    persistence: {
+      provider: "codex",
+      sessionId: "thread-concurrent",
+      nativeHandle: "thread-concurrent",
+      metadata: { provider: "codex", cwd },
+    },
+    archivedAt: "2026-04-30T12:00:00.000Z",
+  } as StoredAgentRecord;
+  const snapshot = makeManagedAgent({
+    id: agentId,
+    provider: "codex",
+    cwd,
+    sessionId: "thread-concurrent",
+    nativeHandle: "thread-concurrent",
+  });
+  const unarchive = createUnarchiveGate();
+  const closedAgentIds: string[] = [];
+  let activeAgent: ManagedAgent | null = null;
+  let resumeAttempts = 0;
+  const agentManager = {
+    unarchiveSnapshot: async (_id: string, updates?: { workspaceId?: string }) => {
+      await unarchive.holdUnarchive();
+      storedRecord = {
+        ...storedRecord,
+        ...(updates?.workspaceId ? { workspaceId: updates.workspaceId } : {}),
+        archivedAt: null,
+      };
+      return true;
+    },
+    notifyAgentState: () => {},
+    resumeAgentFromPersistence: async () => {
+      resumeAttempts += 1;
+      if (resumeAttempts > 1) {
+        throw new Error(`Agent with id ${agentId} already exists`);
+      }
+      activeAgent = snapshot;
+      return snapshot;
+    },
+    hydrateTimelineFromProvider: async () => {},
+    getTimeline: () => [],
+    getAgent: () => activeAgent,
+    closeAgent: async (id: string) => {
+      closedAgentIds.push(id);
+      activeAgent = null;
+    },
+    archiveSnapshot: async (_id: string, archivedAt: string) => {
+      storedRecord = { ...storedRecord, archivedAt };
+      return storedRecord;
+    },
+  } as unknown as AgentManager;
+  const agentStorage = {
+    list: async () => [{ ...storedRecord }],
+    upsert: async (record: StoredAgentRecord) => {
+      storedRecord = record;
+    },
+  } as unknown as AgentStorage;
+  const input = {
+    request: {
+      requestId: "reimport-concurrent-thread",
+      provider: "codex" as const,
+      providerHandleId: "thread-concurrent",
+      cwd,
+    },
+    workspaceId: "ws-restored",
+    agentManager,
+    agentStorage,
+    logger: { warn: () => {}, error: () => {} } as never,
+  };
+
+  const winningRestore = importProviderSession(input);
+  const duplicateRestore = importProviderSession(input);
+  unarchive.allowUnarchive();
+
+  await expect(winningRestore).resolves.toEqual({ snapshot, timelineSize: 0 });
+  await expect(duplicateRestore).rejects.toThrow(
+    "Provider session is already imported: thread-concurrent",
+  );
+  expect(storedRecord.archivedAt).toBeNull();
+  expect(closedAgentIds).toEqual([]);
 });
 
 test("importProviderSession requires cwd from the selected provider row", async () => {

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -239,6 +239,42 @@ test("listImportableProviderSessions filters, sorts, limits, and projects import
   });
 });
 
+test("listImportableProviderSessions includes a provider session after its Paseo agent is archived", async () => {
+  const cwd = "/tmp/project";
+  const archivedSession = makeImportableSession({
+    provider: "claude",
+    sessionId: "archived-session",
+    cwd,
+    title: "Archived import",
+    lastActivityAt: "2026-04-30T12:00:00.000Z",
+    firstPrompt: "import me again",
+  });
+
+  const result = await listImportableProviderSessions({
+    request: makeRequest({ cwd, providers: ["claude"] }),
+    agentManager: {
+      listAgents: () => [],
+      listImportableSessions: async () => [archivedSession],
+    },
+    agentStorage: {
+      list: async () => [
+        {
+          provider: "claude",
+          archivedAt: "2026-04-30T12:01:00.000Z",
+          persistence: {
+            provider: "claude",
+            sessionId: "archived-session",
+          },
+        } as StoredAgentRecord,
+      ],
+    },
+    providerSnapshotManager: { getProviderLabel: () => "Claude" },
+  });
+
+  expect(result.entries.map((entry) => entry.providerHandleId)).toEqual(["archived-session"]);
+  expect(result.filteredAlreadyImportedCount).toBe(0);
+});
+
 test("listImportableProviderSessions filters out metadata generation sessions", async () => {
   const cwd = "/tmp/project";
   const sessions = [

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "./agent-manager.js";
 import type { AgentStorage, StoredAgentRecord } from "./agent-storage.js";
 import type { FetchRecentProviderSessionsRequestMessage } from "@getpaseo/protocol/messages";
+import { PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
 import type { AgentTimelineItem } from "./agent-sdk-types.js";
 import {
   ImportSessionsRequestError,
@@ -526,7 +527,7 @@ test("importProviderSession passes labels through the manager import operation",
   });
 });
 
-test("importProviderSession restores an archived session as the same Paseo agent", async () => {
+test("importProviderSession restores an archived subagent as the same standalone Paseo agent", async () => {
   const cwd = "/tmp/imported-agent";
   const agentId = "00000000-0000-4000-8000-000000000634";
   const persistence = {
@@ -544,7 +545,7 @@ test("importProviderSession restores an archived session as the same Paseo agent
     updatedAt: "2026-04-30T11:00:00.000Z",
     lastActivityAt: "2026-04-30T10:30:00.000Z",
     lastUserMessageAt: null,
-    labels: { existing: "label" },
+    labels: { existing: "label", [PARENT_AGENT_ID_LABEL]: "archived-parent" },
     config: { provider: "codex", cwd },
     persistence,
     archivedAt: "2026-04-30T12:00:00.000Z",
@@ -558,7 +559,9 @@ test("importProviderSession restores an archived session as the same Paseo agent
   });
   let freshImportAttempted = false;
   let unarchivedAgentId: string | undefined;
-  let unarchiveUpdates: { workspaceId?: string; labels?: Record<string, string> } | undefined;
+  let unarchiveUpdates:
+    | { workspaceId?: string; labels?: Record<string, string | null> }
+    | undefined;
   let resumedAgentId: string | undefined;
   let resumeOptions: { workspaceId?: string; labels?: Record<string, string> } | undefined;
   const agentManager = {
@@ -568,7 +571,7 @@ test("importProviderSession restores an archived session as the same Paseo agent
     },
     unarchiveSnapshot: async (
       id: string,
-      updates?: { workspaceId?: string; labels?: Record<string, string> },
+      updates?: { workspaceId?: string; labels?: Record<string, string | null> },
     ) => {
       unarchivedAgentId = id;
       unarchiveUpdates = updates;
@@ -610,13 +613,14 @@ test("importProviderSession restores an archived session as the same Paseo agent
   expect(unarchivedAgentId).toBe(agentId);
   expect(unarchiveUpdates).toEqual({
     workspaceId: "ws-restored",
-    labels: { source: "reimport" },
+    labels: { [PARENT_AGENT_ID_LABEL]: null, source: "reimport" },
   });
   expect(resumedAgentId).toBe(agentId);
   expect(resumeOptions).toMatchObject({
     workspaceId: "ws-restored",
     labels: { existing: "label", source: "reimport" },
   });
+  expect(resumeOptions?.labels).not.toHaveProperty(PARENT_AGENT_ID_LABEL);
   expect(result).toEqual({ snapshot, timelineSize: 1 });
 });
 

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, expect, test, vi } from "vitest";
-import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from "node:fs";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type {
@@ -7,11 +7,15 @@ import type {
   ManagedAgent,
   ManagedImportableProviderSession,
 } from "./agent-manager.js";
-import type { AgentStorage, StoredAgentRecord } from "./agent-storage.js";
+import { AgentStorage, type StoredAgentRecord } from "./agent-storage.js";
 import type { FetchRecentProviderSessionsRequestMessage } from "@getpaseo/protocol/messages";
 import { PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
 import type { AgentTimelineItem } from "./agent-sdk-types.js";
+import { createPersistedWorkspaceRecord } from "../workspace-registry.js";
+import type { WorkspaceProvisioningService } from "../session/workspace-provisioning/workspace-provisioning-service.js";
+import { createTestLogger } from "../../test-utils/test-logger.js";
 import {
+  type ImportSessionAgentManager,
   ImportSessionsRequestError,
   importProviderSession,
   listImportableProviderSessions,
@@ -19,6 +23,7 @@ import {
 } from "./import-sessions.js";
 
 const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+const importTestDirectories: string[] = [];
 
 const TEST_CAPABILITIES = {
   supportsStreaming: true,
@@ -31,6 +36,12 @@ const TEST_CAPABILITIES = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  for (const directory of importTestDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 function makeImportableSession(args: {
@@ -99,15 +110,25 @@ function makeManagedAgent(args: {
   } satisfies ManagedAgent;
 }
 
-function createUnarchiveGate() {
-  let allowUnarchive: () => void = () => {};
-  const unarchiveAllowed = new Promise<void>((resolve) => {
-    allowUnarchive = resolve;
-  });
-
+function createImportWorkspace(
+  workspaceId: string,
+): Pick<WorkspaceProvisioningService, "runInImportWorkspace"> {
   return {
-    holdUnarchive: () => unarchiveAllowed,
-    allowUnarchive,
+    async runInImportWorkspace(input, operation) {
+      const workspace = createPersistedWorkspaceRecord({
+        workspaceId,
+        projectId: `project-${workspaceId}`,
+        cwd: input.cwd,
+        kind: "directory",
+        displayName: "imported",
+        createdAt: "2026-04-30T00:00:00.000Z",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+      });
+      return {
+        value: await operation(workspace),
+        createdWorkspace: null,
+      };
+    },
   };
 }
 
@@ -451,421 +472,335 @@ test("normalizeImportAgentRequest accepts new and legacy import handle shapes", 
   });
 });
 
-test("importProviderSession imports a selected provider session without listing", async () => {
-  const cwd = "/tmp/imported-agent";
-  const timeline: AgentTimelineItem[] = [
-    { type: "user_message", text: "Trace recent provider sessions\n\nkeep it tight" },
+function makeStoredProviderSession(input: {
+  id: string;
+  cwd: string;
+  sessionId: string;
+  nativeHandle?: string;
+  workspaceId?: string;
+  labels?: Record<string, string>;
+  archivedAt?: string | null;
+}): StoredAgentRecord {
+  return {
+    id: input.id,
+    provider: "codex",
+    cwd: input.cwd,
+    workspaceId: input.workspaceId ?? "ws-archived",
+    createdAt: "2026-04-30T10:00:00.000Z",
+    updatedAt: "2026-04-30T11:00:00.000Z",
+    lastActivityAt: "2026-04-30T10:30:00.000Z",
+    lastUserMessageAt: null,
+    labels: input.labels ?? {},
+    config: { provider: "codex", cwd: input.cwd },
+    persistence: {
+      provider: "codex",
+      sessionId: input.sessionId,
+      nativeHandle: input.nativeHandle ?? input.sessionId,
+      metadata: { provider: "codex", cwd: input.cwd },
+    },
+    archivedAt: input.archivedAt === undefined ? "2026-04-30T12:00:00.000Z" : input.archivedAt,
+  };
+}
+
+class ProviderImportHarness {
+  readonly storage: AgentStorage;
+  readonly manager: ImportSessionAgentManager;
+  readonly snapshot: ManagedAgent;
+  readonly freshImports: unknown[] = [];
+  readonly closedAgentIds: string[] = [];
+  timeline: AgentTimelineItem[] = [];
+  activeAgent: ManagedAgent | null = null;
+  resumeError: Error | null = null;
+  resumeAttempts = 0;
+  private unarchiveWait: Promise<void> | null = null;
+  private releaseUnarchive: (() => void) | null = null;
+
+  private constructor(input: { storage: AgentStorage; snapshot: ManagedAgent }) {
+    this.storage = input.storage;
+    this.snapshot = input.snapshot;
+    this.manager = {
+      importProviderSession: async (request: unknown) => {
+        this.freshImports.push(request);
+        this.activeAgent = this.snapshot;
+        return this.snapshot;
+      },
+      unarchiveSnapshot: async (
+        agentId: string,
+        updates?: { workspaceId?: string; labels?: Record<string, string | null> },
+      ) => {
+        if (this.unarchiveWait) {
+          await this.unarchiveWait;
+        }
+        const record = await this.storage.get(agentId);
+        if (!record?.archivedAt) {
+          return false;
+        }
+        const labels = { ...record.labels };
+        for (const [key, value] of Object.entries(updates?.labels ?? {})) {
+          if (value === null) {
+            delete labels[key];
+          } else {
+            labels[key] = value;
+          }
+        }
+        await this.storage.upsert({
+          ...record,
+          workspaceId: updates?.workspaceId ?? record.workspaceId,
+          labels,
+          archivedAt: null,
+        });
+        return true;
+      },
+      notifyAgentState: () => {},
+      getAgent: () => this.activeAgent,
+      getRegisteredProviderIds: () => ["codex"],
+      createAgent: async () => {
+        throw new Error("Stored provider imports must resume their persisted session");
+      },
+      resumeAgentFromPersistence: async (
+        _handle: unknown,
+        _overrides: unknown,
+        _agentId?: string,
+        _options?: unknown,
+      ) => {
+        this.resumeAttempts += 1;
+        if (this.resumeError) {
+          this.activeAgent = this.snapshot;
+          throw this.resumeError;
+        }
+        this.activeAgent = this.snapshot;
+        return this.snapshot;
+      },
+      hydrateTimelineFromProvider: async () => {},
+      getTimeline: () => this.timeline,
+      closeAgent: async (agentId: string) => {
+        this.closedAgentIds.push(agentId);
+        this.activeAgent = null;
+      },
+      archiveSnapshot: async (agentId: string, archivedAt: string) => {
+        const record = await this.storage.get(agentId);
+        if (!record) {
+          throw new Error("Agent not found: " + agentId);
+        }
+        const archived = { ...record, archivedAt };
+        await this.storage.upsert(archived);
+        return archived;
+      },
+    } satisfies ImportSessionAgentManager;
+  }
+
+  static async create(
+    input: {
+      id?: string;
+      cwd?: string;
+      sessionId?: string;
+      nativeHandle?: string;
+    } = {},
+  ): Promise<ProviderImportHarness> {
+    const directory = mkdtempSync(path.join(tmpdir(), "provider-import-"));
+    importTestDirectories.push(directory);
+    const storage = new AgentStorage(path.join(directory, "agents"), createTestLogger());
+    await storage.initialize();
+    const cwd = input.cwd ?? "/tmp/imported-agent";
+    const sessionId = input.sessionId ?? "thread-imported";
+    const snapshot = makeManagedAgent({
+      id: input.id,
+      provider: "codex",
+      cwd,
+      sessionId,
+      nativeHandle: input.nativeHandle,
+    });
+    return new ProviderImportHarness({ storage, snapshot });
+  }
+
+  async seed(record: StoredAgentRecord): Promise<void> {
+    await this.storage.upsert(record);
+  }
+
+  blockUnarchive(): () => void {
+    this.unarchiveWait = new Promise<void>((resolve) => {
+      this.releaseUnarchive = resolve;
+    });
+    return () => {
+      this.releaseUnarchive?.();
+      this.unarchiveWait = null;
+      this.releaseUnarchive = null;
+    };
+  }
+
+  import(input: { providerHandleId: string; cwd?: string; labels?: Record<string, string> }) {
+    return importProviderSession({
+      request: {
+        requestId: "import-thread",
+        provider: "codex",
+        providerHandleId: input.providerHandleId,
+        cwd: input.cwd,
+        labels: input.labels,
+      },
+      workspaceProvisioning: createImportWorkspace("ws-restored"),
+      agentManager: this.manager,
+      agentStorage: this.storage,
+      logger: createTestLogger(),
+    });
+  }
+}
+
+test("importProviderSession uses the provider import path with the requested labels", async () => {
+  const harness = await ProviderImportHarness.create();
+  harness.timeline = [
+    { type: "user_message", text: "Trace recent provider sessions" },
     { type: "assistant_message", text: "I will inspect the provider listing." },
   ];
-  const snapshot = makeManagedAgent({
-    id: "00000000-0000-4000-8000-000000000633",
-    provider: "custom-codex",
-    cwd,
-    sessionId: "thread-imported",
-    nativeHandle: "provider-thread-imported",
-    title: null,
-  });
-  const agentManager = {
-    importProviderSession: vi.fn().mockResolvedValue(snapshot),
-    getTimeline: vi.fn().mockReturnValue(timeline),
-    unarchiveSnapshot: vi.fn().mockResolvedValue(false),
-  } as unknown as AgentManager;
-  const agentStorage = {
-    list: vi.fn().mockResolvedValue([]),
-    get: vi.fn().mockResolvedValue(null),
-  } as unknown as AgentStorage;
 
-  const result = await importProviderSession({
-    request: {
-      requestId: "import-thread",
-      provider: "custom-codex",
-      providerHandleId: "provider-thread-imported",
-      cwd,
-    },
-    workspaceId: "ws-imported",
-    agentManager,
-    agentStorage,
-    logger: { warn: vi.fn(), error: vi.fn() } as never,
-  });
-
-  expect(agentManager.importProviderSession).toHaveBeenCalledWith({
-    provider: "custom-codex",
-    providerHandleId: "provider-thread-imported",
-    cwd,
-    workspaceId: "ws-imported",
-    labels: undefined,
-  });
-  expect(result).toEqual({ snapshot, timelineSize: 2 });
-});
-
-test("importProviderSession passes labels through the manager import operation", async () => {
-  const cwd = "/tmp/imported-agent";
-  const snapshot = makeManagedAgent({
-    provider: "codex",
-    cwd,
-    sessionId: "thread-imported",
-    nativeHandle: "thread-imported",
-  });
-  const agentManager = {
-    importProviderSession: vi.fn().mockResolvedValue(snapshot),
-    getTimeline: vi.fn().mockReturnValue([]),
-    unarchiveSnapshot: vi.fn().mockResolvedValue(false),
-  } as unknown as AgentManager;
-  const agentStorage = {
-    list: vi.fn().mockResolvedValue([]),
-    get: vi.fn().mockResolvedValue(null),
-  } as unknown as AgentStorage;
-
-  await importProviderSession({
-    request: {
-      requestId: "import-thread",
-      provider: "codex",
-      providerHandleId: "thread-imported",
-      cwd,
-      labels: { source: "import" },
-    },
-    workspaceId: "ws-imported",
-    agentManager,
-    agentStorage,
-    logger: { warn: vi.fn(), error: vi.fn() } as never,
-  });
-
-  expect(agentManager.importProviderSession).toHaveBeenCalledWith({
-    provider: "codex",
+  const result = await harness.import({
     providerHandleId: "thread-imported",
-    cwd,
-    workspaceId: "ws-imported",
+    cwd: "/tmp/imported-agent",
     labels: { source: "import" },
   });
+
+  expect(harness.freshImports).toEqual([
+    {
+      provider: "codex",
+      providerHandleId: "thread-imported",
+      cwd: "/tmp/imported-agent",
+      workspaceId: "ws-restored",
+      labels: { source: "import" },
+    },
+  ]);
+  expect(result).toEqual({
+    snapshot: harness.snapshot,
+    timelineSize: 2,
+    createdWorkspace: null,
+  });
 });
 
-test("importProviderSession restores an archived subagent as the same standalone Paseo agent", async () => {
-  const cwd = "/tmp/imported-agent";
-  const agentId = "00000000-0000-4000-8000-000000000634";
-  const persistence = {
-    provider: "codex",
+test("importProviderSession rejects a provider session with an active stored owner", async () => {
+  const harness = await ProviderImportHarness.create({ sessionId: "thread-active" });
+  await harness.seed(
+    makeStoredProviderSession({
+      id: harness.snapshot.id,
+      cwd: harness.snapshot.cwd,
+      sessionId: "thread-active",
+      archivedAt: null,
+    }),
+  );
+
+  await expect(
+    harness.import({ providerHandleId: "thread-active", cwd: harness.snapshot.cwd }),
+  ).rejects.toThrow("Provider session is already imported: thread-active");
+  expect(harness.freshImports).toEqual([]);
+});
+
+test("importProviderSession restores an archived session as the same standalone agent", async () => {
+  const harness = await ProviderImportHarness.create({ sessionId: "thread-archived" });
+  harness.timeline = [{ type: "user_message", text: "restored" }];
+  const archived = makeStoredProviderSession({
+    id: harness.snapshot.id,
+    cwd: harness.snapshot.cwd,
     sessionId: "thread-archived",
-    nativeHandle: "thread-archived",
-    metadata: { provider: "codex", cwd },
-  };
-  const archivedRecord = {
-    id: agentId,
-    provider: "codex",
-    cwd,
-    workspaceId: "ws-archived",
-    createdAt: "2026-04-30T10:00:00.000Z",
-    updatedAt: "2026-04-30T11:00:00.000Z",
-    lastActivityAt: "2026-04-30T10:30:00.000Z",
-    lastUserMessageAt: null,
     labels: { existing: "label", [PARENT_AGENT_ID_LABEL]: "archived-parent" },
-    config: { provider: "codex", cwd },
-    persistence,
-    archivedAt: "2026-04-30T12:00:00.000Z",
-  } as StoredAgentRecord;
-  const snapshot = makeManagedAgent({
-    id: agentId,
-    provider: "codex",
-    cwd,
-    sessionId: "thread-archived",
-    nativeHandle: "thread-archived",
   });
-  let freshImportAttempted = false;
-  let unarchivedAgentId: string | undefined;
-  let unarchiveUpdates:
-    | { workspaceId?: string; labels?: Record<string, string | null> }
-    | undefined;
-  let resumedAgentId: string | undefined;
-  let resumeOptions: { workspaceId?: string; labels?: Record<string, string> } | undefined;
-  const agentManager = {
-    importProviderSession: async () => {
-      freshImportAttempted = true;
-      return snapshot;
-    },
-    unarchiveSnapshot: async (
-      id: string,
-      updates?: { workspaceId?: string; labels?: Record<string, string | null> },
-    ) => {
-      unarchivedAgentId = id;
-      unarchiveUpdates = updates;
-      return true;
-    },
-    notifyAgentState: () => {},
-    resumeAgentFromPersistence: async (
-      _handle: unknown,
-      _overrides: unknown,
-      id?: string,
-      options?: { workspaceId?: string; labels?: Record<string, string> },
-    ) => {
-      resumedAgentId = id;
-      resumeOptions = options;
-      return snapshot;
-    },
-    hydrateTimelineFromProvider: async () => {},
-    getTimeline: () => [{ type: "user_message", text: "restored" }],
-  } as unknown as AgentManager;
-  const agentStorage = {
-    list: async () => [archivedRecord],
-  } as unknown as AgentStorage;
+  await harness.seed(archived);
 
-  const result = await importProviderSession({
-    request: {
-      requestId: "reimport-thread",
-      provider: "codex",
-      providerHandleId: "thread-archived",
-      cwd,
-      labels: { source: "reimport" },
-    },
-    workspaceId: "ws-restored",
-    agentManager,
-    agentStorage,
-    logger: { warn: () => {}, error: () => {} } as never,
+  const result = await harness.import({
+    providerHandleId: "thread-archived",
+    cwd: harness.snapshot.cwd,
+    labels: { source: "reimport" },
   });
 
-  expect(freshImportAttempted).toBe(false);
-  expect(unarchivedAgentId).toBe(agentId);
-  expect(unarchiveUpdates).toEqual({
-    workspaceId: "ws-restored",
-    labels: { [PARENT_AGENT_ID_LABEL]: null, source: "reimport" },
+  expect(result).toEqual({
+    snapshot: harness.snapshot,
+    timelineSize: 1,
+    createdWorkspace: null,
   });
-  expect(resumedAgentId).toBe(agentId);
-  expect(resumeOptions).toMatchObject({
+  expect(await harness.storage.get(harness.snapshot.id)).toMatchObject({
+    id: harness.snapshot.id,
     workspaceId: "ws-restored",
     labels: { existing: "label", source: "reimport" },
+    archivedAt: null,
   });
-  expect(resumeOptions?.labels).not.toHaveProperty(PARENT_AGENT_ID_LABEL);
-  expect(result).toEqual({ snapshot, timelineSize: 1 });
+  expect((await harness.storage.get(harness.snapshot.id))?.labels).not.toHaveProperty(
+    PARENT_AGENT_ID_LABEL,
+  );
+  expect(harness.resumeAttempts).toBe(1);
+  expect(harness.freshImports).toEqual([]);
 });
 
-test("importProviderSession rejects an archived session from a different cwd before restoring it", async () => {
-  const archivedRecord = {
-    id: "00000000-0000-4000-8000-000000000637",
-    provider: "codex",
+test("importProviderSession rejects an archived session from a different cwd before restoring", async () => {
+  const harness = await ProviderImportHarness.create({ sessionId: "thread-other-cwd" });
+  const archived = makeStoredProviderSession({
+    id: harness.snapshot.id,
     cwd: "/tmp/other-agent",
-    workspaceId: "ws-other",
-    createdAt: "2026-04-30T10:00:00.000Z",
-    updatedAt: "2026-04-30T11:00:00.000Z",
-    labels: {},
-    config: { provider: "codex", cwd: "/tmp/other-agent" },
-    persistence: {
-      provider: "codex",
-      sessionId: "thread-other-cwd",
-      nativeHandle: "thread-other-cwd",
-      metadata: { provider: "codex", cwd: "/tmp/other-agent" },
-    },
-    archivedAt: "2026-04-30T12:00:00.000Z",
-  } as StoredAgentRecord;
-  let unarchiveAttempted = false;
-  const agentManager = {
-    unarchiveSnapshot: async () => {
-      unarchiveAttempted = true;
-      return true;
-    },
-  } as unknown as AgentManager;
-  const agentStorage = {
-    list: async () => [archivedRecord],
-  } as unknown as AgentStorage;
+    sessionId: "thread-other-cwd",
+  });
+  await harness.seed(archived);
 
   await expect(
-    importProviderSession({
-      request: {
-        requestId: "reimport-other-cwd",
-        provider: "codex",
-        providerHandleId: "thread-other-cwd",
-        cwd: "/tmp/target-agent",
-      },
-      workspaceId: "ws-target",
-      agentManager,
-      agentStorage,
-      logger: { warn: () => {}, error: () => {} } as never,
-    }),
+    harness.import({ providerHandleId: "thread-other-cwd", cwd: "/tmp/target-agent" }),
   ).rejects.toThrow("Provider session cwd does not match import cwd: thread-other-cwd");
-  expect(unarchiveAttempted).toBe(false);
+  expect(await harness.storage.get(harness.snapshot.id)).toEqual(archived);
+  expect(harness.resumeAttempts).toBe(0);
 });
 
-test("importProviderSession restores the archived record when provider resume fails", async () => {
-  const cwd = "/tmp/imported-agent";
-  const agentId = "00000000-0000-4000-8000-000000000635";
-  const archivedAt = "2026-04-30T12:00:00.000Z";
-  const archivedRecord = {
-    id: agentId,
-    provider: "codex",
-    cwd,
-    workspaceId: "ws-archived",
-    createdAt: "2026-04-30T10:00:00.000Z",
-    updatedAt: "2026-04-30T11:00:00.000Z",
-    lastActivityAt: "2026-04-30T10:30:00.000Z",
-    lastUserMessageAt: null,
-    labels: { existing: "label" },
-    config: { provider: "codex", cwd },
-    persistence: {
-      provider: "codex",
-      sessionId: "thread-stale",
-      nativeHandle: "thread-stale",
-      metadata: { provider: "codex", cwd },
-    },
-    archivedAt,
-  } as StoredAgentRecord;
-  let rearchivedAgentId: string | undefined;
-  let rearchivedAt: string | undefined;
-  let restoredRecord: StoredAgentRecord | undefined;
-  const agentManager = {
-    importProviderSession: async () => {
-      throw new Error("fresh import should not run");
-    },
-    unarchiveSnapshot: async () => true,
-    notifyAgentState: () => {},
-    resumeAgentFromPersistence: async () => {
-      throw new Error("provider session is unavailable");
-    },
-    getAgent: () => null,
-    archiveSnapshot: async (id: string, timestamp: string) => {
-      rearchivedAgentId = id;
-      rearchivedAt = timestamp;
-      return archivedRecord;
-    },
-  } as unknown as AgentManager;
-  const agentStorage = {
-    list: async () => [archivedRecord],
-    upsert: async (record: StoredAgentRecord) => {
-      restoredRecord = record;
-    },
-  } as unknown as AgentStorage;
+test("importProviderSession restores storage and closes a partial runtime when loading fails", async () => {
+  const harness = await ProviderImportHarness.create({ sessionId: "thread-stale" });
+  const archived = makeStoredProviderSession({
+    id: harness.snapshot.id,
+    cwd: harness.snapshot.cwd,
+    sessionId: "thread-stale",
+  });
+  await harness.seed(archived);
+  harness.resumeError = new Error("provider session is unavailable");
 
   await expect(
-    importProviderSession({
-      request: {
-        requestId: "reimport-stale-thread",
-        provider: "codex",
-        providerHandleId: "thread-stale",
-        cwd,
-      },
-      workspaceId: "ws-restored",
-      agentManager,
-      agentStorage,
-      logger: { warn: () => {}, error: () => {} } as never,
-    }),
+    harness.import({ providerHandleId: "thread-stale", cwd: harness.snapshot.cwd }),
   ).rejects.toThrow("provider session is unavailable");
 
-  expect(rearchivedAgentId).toBe(agentId);
-  expect(rearchivedAt).toBe(archivedAt);
-  expect(restoredRecord).toBe(archivedRecord);
+  expect(await harness.storage.get(harness.snapshot.id)).toEqual(archived);
+  expect(harness.activeAgent).toBeNull();
+  expect(harness.closedAgentIds).toEqual([harness.snapshot.id]);
 });
 
 test("importProviderSession serializes legacy and native aliases for one archived session", async () => {
-  const cwd = "/tmp/imported-agent";
-  const agentId = "00000000-0000-4000-8000-000000000636";
-  let storedRecord = {
-    id: agentId,
-    provider: "codex",
-    cwd,
-    workspaceId: "ws-archived",
-    createdAt: "2026-04-30T10:00:00.000Z",
-    updatedAt: "2026-04-30T11:00:00.000Z",
-    lastActivityAt: "2026-04-30T10:30:00.000Z",
-    lastUserMessageAt: null,
-    labels: {},
-    config: { provider: "codex", cwd },
-    persistence: {
-      provider: "codex",
-      sessionId: "legacy-thread-concurrent",
-      nativeHandle: "native-thread-concurrent",
-      metadata: { provider: "codex", cwd },
-    },
-    archivedAt: "2026-04-30T12:00:00.000Z",
-  } as StoredAgentRecord;
-  const snapshot = makeManagedAgent({
-    id: agentId,
-    provider: "codex",
-    cwd,
-    sessionId: "legacy-thread-concurrent",
-    nativeHandle: "native-thread-concurrent",
+  const harness = await ProviderImportHarness.create({
+    sessionId: "legacy-thread",
+    nativeHandle: "native-thread",
   });
-  const unarchive = createUnarchiveGate();
-  const closedAgentIds: string[] = [];
-  let activeAgent: ManagedAgent | null = null;
-  let resumeAttempts = 0;
-  const agentManager = {
-    unarchiveSnapshot: async (_id: string, updates?: { workspaceId?: string }) => {
-      await unarchive.holdUnarchive();
-      storedRecord = {
-        ...storedRecord,
-        ...(updates?.workspaceId ? { workspaceId: updates.workspaceId } : {}),
-        archivedAt: null,
-      };
-      return true;
-    },
-    notifyAgentState: () => {},
-    resumeAgentFromPersistence: async () => {
-      resumeAttempts += 1;
-      if (resumeAttempts > 1) {
-        throw new Error(`Agent with id ${agentId} already exists`);
-      }
-      activeAgent = snapshot;
-      return snapshot;
-    },
-    hydrateTimelineFromProvider: async () => {},
-    getTimeline: () => [],
-    getAgent: () => activeAgent,
-    closeAgent: async (id: string) => {
-      closedAgentIds.push(id);
-      activeAgent = null;
-    },
-    archiveSnapshot: async (_id: string, archivedAt: string) => {
-      storedRecord = { ...storedRecord, archivedAt };
-      return storedRecord;
-    },
-  } as unknown as AgentManager;
-  const agentStorage = {
-    list: async () => [{ ...storedRecord }],
-    upsert: async (record: StoredAgentRecord) => {
-      storedRecord = record;
-    },
-  } as unknown as AgentStorage;
-  const input = {
-    request: {
-      requestId: "reimport-concurrent-thread",
-      provider: "codex" as const,
-      providerHandleId: "native-thread-concurrent",
-      cwd,
-    },
-    workspaceId: "ws-restored",
-    agentManager,
-    agentStorage,
-    logger: { warn: () => {}, error: () => {} } as never,
-  };
-
-  const winningRestore = importProviderSession(input);
-  const duplicateRestore = importProviderSession({
-    ...input,
-    request: {
-      ...input.request,
-      providerHandleId: "legacy-thread-concurrent",
-    },
-  });
-  unarchive.allowUnarchive();
-
-  await expect(winningRestore).resolves.toEqual({ snapshot, timelineSize: 0 });
-  await expect(duplicateRestore).rejects.toThrow(
-    "Provider session is already imported: legacy-thread-concurrent",
+  await harness.seed(
+    makeStoredProviderSession({
+      id: harness.snapshot.id,
+      cwd: harness.snapshot.cwd,
+      sessionId: "legacy-thread",
+      nativeHandle: "native-thread",
+    }),
   );
-  expect(storedRecord.archivedAt).toBeNull();
-  expect(closedAgentIds).toEqual([]);
+  const releaseUnarchive = harness.blockUnarchive();
+
+  const winningRestore = harness.import({
+    providerHandleId: "native-thread",
+    cwd: harness.snapshot.cwd,
+  });
+  const duplicateRestore = harness.import({
+    providerHandleId: "legacy-thread",
+    cwd: harness.snapshot.cwd,
+  });
+  releaseUnarchive();
+
+  await expect(winningRestore).resolves.toMatchObject({
+    snapshot: { id: harness.snapshot.id },
+    timelineSize: 0,
+  });
+  await expect(duplicateRestore).rejects.toThrow(
+    "Provider session is already imported: legacy-thread",
+  );
+  expect(harness.resumeAttempts).toBe(1);
+  expect(harness.closedAgentIds).toEqual([]);
 });
 
 test("importProviderSession requires cwd from the selected provider row", async () => {
-  const agentManager = {} as unknown as AgentManager;
+  const harness = await ProviderImportHarness.create();
 
-  await expect(
-    importProviderSession({
-      request: {
-        requestId: "import-thread",
-        provider: "opencode",
-        providerHandleId: "thread-imported",
-      },
-      workspaceId: "ws-imported",
-      agentManager,
-      agentStorage: { list: vi.fn() } as unknown as AgentStorage,
-      logger: { warn: vi.fn(), error: vi.fn() } as never,
-    }),
-  ).rejects.toThrow("Import requires cwd from the selected provider session");
+  await expect(harness.import({ providerHandleId: "thread-imported" })).rejects.toThrow(
+    "Import requires cwd from the selected provider session",
+  );
 });

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -10,6 +10,7 @@ import type { AgentStorage, StoredAgentRecord } from "./agent-storage.js";
 import type { AgentPersistenceHandle, AgentProvider } from "./agent-sdk-types.js";
 import { unarchiveAgentState } from "./agent-prompt.js";
 import { toRecentProviderSessionDescriptorPayload } from "./agent-projections.js";
+import { buildConfigOverrides, extractTimestamps } from "../persistence-hooks.js";
 import type {
   FetchRecentProviderSessionsRequestMessage,
   ImportAgentRequestMessageSchema,
@@ -146,7 +147,41 @@ export async function importProviderSession(
   }
 
   const handle = buildImportPersistenceHandle({ provider, providerHandleId, cwd });
-  await unarchiveAgentByHandle(input.agentStorage, input.agentManager, handle);
+  const matchingRecords = (await input.agentStorage.list()).filter((record) =>
+    recordMatchesProviderHandle(record, handle),
+  );
+  const activeRecord = matchingRecords.find((record) => !record.archivedAt);
+  if (activeRecord) {
+    throw new Error(`Provider session is already imported: ${providerHandleId}`);
+  }
+  const archivedRecord = matchingRecords.find((record) => record.archivedAt);
+  if (archivedRecord?.persistence) {
+    const restoredLabels = input.request.labels
+      ? { ...archivedRecord.labels, ...input.request.labels }
+      : archivedRecord.labels;
+    const restoredRecord = {
+      ...archivedRecord,
+      workspaceId: input.workspaceId,
+      labels: restoredLabels,
+      archivedAt: null,
+    };
+    await unarchiveAgentState(input.agentStorage, input.agentManager, archivedRecord.id, {
+      workspaceId: input.workspaceId,
+      labels: input.request.labels,
+    });
+    const snapshot = await input.agentManager.resumeAgentFromPersistence(
+      archivedRecord.persistence,
+      buildConfigOverrides(restoredRecord),
+      archivedRecord.id,
+      extractTimestamps(restoredRecord),
+    );
+    await input.agentManager.hydrateTimelineFromProvider(snapshot.id);
+    return {
+      snapshot,
+      timelineSize: input.agentManager.getTimeline(snapshot.id).length,
+    };
+  }
+
   const snapshot = await input.agentManager.importProviderSession({
     provider,
     providerHandleId,
@@ -162,22 +197,15 @@ export async function importProviderSession(
   };
 }
 
-async function unarchiveAgentByHandle(
-  agentStorage: AgentStorage,
-  agentManager: AgentManager,
+function recordMatchesProviderHandle(
+  record: StoredAgentRecord,
   handle: AgentPersistenceHandle,
-): Promise<void> {
-  const records = await agentStorage.list();
-  const matched = records.find(
-    (record) =>
-      record.persistence?.provider === handle.provider &&
-      (record.persistence.sessionId === handle.sessionId ||
-        record.persistence.nativeHandle === handle.nativeHandle),
+): boolean {
+  return (
+    record.persistence?.provider === handle.provider &&
+    (record.persistence.sessionId === handle.sessionId ||
+      record.persistence.nativeHandle === handle.nativeHandle)
   );
-  if (!matched) {
-    return;
-  }
-  await unarchiveAgentState(agentStorage, agentManager, matched.id);
 }
 
 function parseRecentProviderSessionsSince(since: string | undefined): number | null {
@@ -212,12 +240,17 @@ async function collectImportedProviderSessionHandles(
   agentStorage: Pick<AgentStorage, "list">,
 ): Promise<Set<string>> {
   const handles = new Set<string>();
+  const records = await agentStorage.list();
+  const storedRecordsById = new Map(records.map((record) => [record.id, record]));
 
   for (const agent of agentManager.listAgents()) {
+    if (storedRecordsById.get(agent.id)?.archivedAt) {
+      continue;
+    }
     collectProviderSessionHandleKeys(handles, agent.provider, agent.persistence);
   }
 
-  for (const record of await agentStorage.list()) {
+  for (const record of records) {
     if (record.archivedAt) {
       continue;
     }

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -8,9 +8,11 @@ import type {
 } from "./agent-manager.js";
 import type { AgentStorage, StoredAgentRecord } from "./agent-storage.js";
 import type { AgentPersistenceHandle, AgentProvider } from "./agent-sdk-types.js";
+import { ensureAgentLoaded, type AgentLoaderManager } from "./agent-loading.js";
 import { unarchiveAgentState } from "./agent-prompt.js";
 import { toRecentProviderSessionDescriptorPayload } from "./agent-projections.js";
-import { buildConfigOverrides, extractTimestamps } from "../persistence-hooks.js";
+import type { WorkspaceProvisioningService } from "../session/workspace-provisioning/workspace-provisioning-service.js";
+import type { PersistedWorkspaceRecord } from "../workspace-registry.js";
 import type {
   FetchRecentProviderSessionsRequestMessage,
   ImportAgentRequestMessageSchema,
@@ -23,7 +25,21 @@ type ImportAgentRequestMessage = z.infer<typeof ImportAgentRequestMessageSchema>
 
 const METADATA_GENERATION_PROMPT_PREFIX =
   "Generate metadata for a coding agent based on the user prompt.";
-const providerSessionImportMutations = new WeakMap<AgentManager, Map<string, Promise<unknown>>>();
+export type ImportSessionAgentManager = AgentLoaderManager &
+  Pick<
+    AgentManager,
+    | "archiveSnapshot"
+    | "closeAgent"
+    | "getTimeline"
+    | "importProviderSession"
+    | "notifyAgentState"
+    | "unarchiveSnapshot"
+  >;
+
+const providerSessionImportMutations = new WeakMap<
+  ImportSessionAgentManager,
+  Map<string, Promise<unknown>>
+>();
 
 export interface NormalizedImportAgentRequest {
   provider: AgentProvider;
@@ -58,13 +74,19 @@ export interface ListImportableProviderSessionsResult {
 
 export interface ImportProviderSessionInput {
   request: NormalizedImportAgentRequest;
-  workspaceId: string;
-  agentManager: AgentManager;
+  workspaceProvisioning: Pick<WorkspaceProvisioningService, "runInImportWorkspace">;
+  agentManager: ImportSessionAgentManager;
   agentStorage: AgentStorage;
   logger: Logger;
 }
 
 export interface ImportProviderSessionResult {
+  snapshot: ManagedAgent;
+  timelineSize: number;
+  createdWorkspace: PersistedWorkspaceRecord | null;
+}
+
+interface ImportedProviderSession {
   snapshot: ManagedAgent;
   timelineSize: number;
 }
@@ -148,15 +170,20 @@ export async function importProviderSession(
     throw new Error("Import requires cwd from the selected provider session");
   }
   const key = await resolveProviderSessionImportMutationKey(input);
-  return serializeProviderSessionImport(input.agentManager, key, () =>
-    importProviderSessionNow(input, cwd),
-  );
+  return serializeProviderSessionImport(input.agentManager, key, async () => {
+    const placement = await input.workspaceProvisioning.runInImportWorkspace(
+      { cwd, requestedWorkspaceId: input.request.workspaceId },
+      (workspace) => importProviderSessionNow(input, cwd, workspace.workspaceId),
+    );
+    return { ...placement.value, createdWorkspace: placement.createdWorkspace };
+  });
 }
 
 async function importProviderSessionNow(
   input: ImportProviderSessionInput,
   cwd: string,
-): Promise<ImportProviderSessionResult> {
+  workspaceId: string,
+): Promise<ImportedProviderSession> {
   const { provider, providerHandleId, labels } = input.request;
 
   const matchingRecords = (await input.agentStorage.list()).filter((record) =>
@@ -171,13 +198,7 @@ async function importProviderSessionNow(
     if (!createRealpathAwarePathMatcher(cwd)(archivedRecord.cwd)) {
       throw new Error(`Provider session cwd does not match import cwd: ${providerHandleId}`);
     }
-    const restoredLabels = { ...archivedRecord.labels, ...input.request.labels };
     const requestedParentAgentId = getParentAgentIdFromLabels(input.request.labels);
-    if (requestedParentAgentId) {
-      restoredLabels[PARENT_AGENT_ID_LABEL] = requestedParentAgentId;
-    } else {
-      delete restoredLabels[PARENT_AGENT_ID_LABEL];
-    }
     const labelPatch: Record<string, string | null> = { ...input.request.labels };
     if (
       Object.hasOwn(archivedRecord.labels, PARENT_AGENT_ID_LABEL) ||
@@ -185,24 +206,16 @@ async function importProviderSessionNow(
     ) {
       labelPatch[PARENT_AGENT_ID_LABEL] = requestedParentAgentId;
     }
-    const restoredRecord = {
-      ...archivedRecord,
-      workspaceId: input.workspaceId,
-      labels: restoredLabels,
-      archivedAt: null,
-    };
     await unarchiveAgentState(input.agentStorage, input.agentManager, archivedRecord.id, {
-      workspaceId: input.workspaceId,
+      workspaceId,
       labels: Object.keys(labelPatch).length > 0 ? labelPatch : undefined,
     });
     try {
-      const snapshot = await input.agentManager.resumeAgentFromPersistence(
-        archivedRecord.persistence,
-        buildConfigOverrides(restoredRecord),
-        archivedRecord.id,
-        extractTimestamps(restoredRecord),
-      );
-      await input.agentManager.hydrateTimelineFromProvider(snapshot.id);
+      const snapshot = await ensureAgentLoaded(archivedRecord.id, {
+        agentManager: input.agentManager,
+        agentStorage: input.agentStorage,
+        logger: input.logger,
+      });
       return {
         snapshot,
         timelineSize: input.agentManager.getTimeline(snapshot.id).length,
@@ -217,7 +230,7 @@ async function importProviderSessionNow(
     provider,
     providerHandleId,
     cwd,
-    workspaceId: input.workspaceId,
+    workspaceId,
     labels,
   });
   await unarchiveAgentState(input.agentStorage, input.agentManager, snapshot.id);
@@ -229,7 +242,7 @@ async function importProviderSessionNow(
 }
 
 async function serializeProviderSessionImport<T>(
-  agentManager: AgentManager,
+  agentManager: ImportSessionAgentManager,
   key: string,
   operation: () => Promise<T>,
 ): Promise<T> {

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -23,6 +23,7 @@ type ImportAgentRequestMessage = z.infer<typeof ImportAgentRequestMessageSchema>
 
 const METADATA_GENERATION_PROMPT_PREFIX =
   "Generate metadata for a coding agent based on the user prompt.";
+const providerSessionImportMutations = new WeakMap<AgentManager, Map<string, Promise<unknown>>>();
 
 export interface NormalizedImportAgentRequest {
   provider: AgentProvider;
@@ -142,6 +143,15 @@ export async function listImportableProviderSessions(
 export async function importProviderSession(
   input: ImportProviderSessionInput,
 ): Promise<ImportProviderSessionResult> {
+  const key = toProviderSessionHandleKey(input.request.provider, input.request.providerHandleId);
+  return serializeProviderSessionImport(input.agentManager, key, () =>
+    importProviderSessionNow(input),
+  );
+}
+
+async function importProviderSessionNow(
+  input: ImportProviderSessionInput,
+): Promise<ImportProviderSessionResult> {
   const { provider, providerHandleId, cwd, labels } = input.request;
   if (!cwd) {
     throw new Error("Import requires cwd from the selected provider session");
@@ -212,6 +222,29 @@ export async function importProviderSession(
     snapshot,
     timelineSize: input.agentManager.getTimeline(snapshot.id).length,
   };
+}
+
+async function serializeProviderSessionImport<T>(
+  agentManager: AgentManager,
+  key: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  let mutations = providerSessionImportMutations.get(agentManager);
+  if (!mutations) {
+    mutations = new Map();
+    providerSessionImportMutations.set(agentManager, mutations);
+  }
+
+  const previous = mutations.get(key) ?? Promise.resolve();
+  const next = previous.catch(() => undefined).then(operation);
+  mutations.set(key, next);
+  try {
+    return await next;
+  } finally {
+    if (mutations.get(key) === next) {
+      mutations.delete(key);
+    }
+  }
 }
 
 async function rollbackArchivedImport(

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -168,6 +168,9 @@ async function importProviderSessionNow(
   }
   const archivedRecord = matchingRecords.find((record) => record.archivedAt);
   if (archivedRecord?.persistence && archivedRecord.archivedAt) {
+    if (!createRealpathAwarePathMatcher(cwd)(archivedRecord.cwd)) {
+      throw new Error(`Provider session cwd does not match import cwd: ${providerHandleId}`);
+    }
     const restoredLabels = { ...archivedRecord.labels, ...input.request.labels };
     const requestedParentAgentId = getParentAgentIdFromLabels(input.request.labels);
     if (requestedParentAgentId) {

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -26,6 +26,7 @@ export interface NormalizedImportAgentRequest {
   provider: AgentProvider;
   providerHandleId: string;
   cwd?: string;
+  workspaceId?: string;
   labels?: Record<string, string>;
   requestId: string;
 }
@@ -82,6 +83,7 @@ export function normalizeImportAgentRequest(
     provider: provider as AgentProvider,
     providerHandleId,
     cwd: msg.cwd,
+    workspaceId: msg.workspaceId,
     labels: msg.labels,
     requestId: msg.requestId,
   };
@@ -216,6 +218,9 @@ async function collectImportedProviderSessionHandles(
   }
 
   for (const record of await agentStorage.list()) {
+    if (record.archivedAt) {
+      continue;
+    }
     collectProviderSessionHandleKeys(handles, record.provider, record.persistence);
   }
 

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -143,23 +143,24 @@ export async function listImportableProviderSessions(
 export async function importProviderSession(
   input: ImportProviderSessionInput,
 ): Promise<ImportProviderSessionResult> {
-  const key = toProviderSessionHandleKey(input.request.provider, input.request.providerHandleId);
+  const cwd = input.request.cwd;
+  if (!cwd) {
+    throw new Error("Import requires cwd from the selected provider session");
+  }
+  const key = await resolveProviderSessionImportMutationKey(input);
   return serializeProviderSessionImport(input.agentManager, key, () =>
-    importProviderSessionNow(input),
+    importProviderSessionNow(input, cwd),
   );
 }
 
 async function importProviderSessionNow(
   input: ImportProviderSessionInput,
+  cwd: string,
 ): Promise<ImportProviderSessionResult> {
-  const { provider, providerHandleId, cwd, labels } = input.request;
-  if (!cwd) {
-    throw new Error("Import requires cwd from the selected provider session");
-  }
+  const { provider, providerHandleId, labels } = input.request;
 
-  const handle = buildImportPersistenceHandle({ provider, providerHandleId, cwd });
   const matchingRecords = (await input.agentStorage.list()).filter((record) =>
-    recordMatchesProviderHandle(record, handle),
+    recordMatchesProviderHandle(record, { provider, providerHandleId }),
   );
   const activeRecord = matchingRecords.find((record) => !record.archivedAt);
   if (activeRecord) {
@@ -247,6 +248,21 @@ async function serializeProviderSessionImport<T>(
   }
 }
 
+async function resolveProviderSessionImportMutationKey(
+  input: ImportProviderSessionInput,
+): Promise<string> {
+  const identity = {
+    provider: input.request.provider,
+    providerHandleId: input.request.providerHandleId,
+  };
+  const matchingRecord = (await input.agentStorage.list()).find((record) =>
+    recordMatchesProviderHandle(record, identity),
+  );
+  return matchingRecord
+    ? `agent\0${matchingRecord.id}`
+    : `handle\0${toProviderSessionHandleKey(identity.provider, identity.providerHandleId)}`;
+}
+
 async function rollbackArchivedImport(
   input: ImportProviderSessionInput,
   archivedRecord: StoredAgentRecord,
@@ -276,12 +292,12 @@ async function rollbackArchivedImport(
 
 function recordMatchesProviderHandle(
   record: StoredAgentRecord,
-  handle: AgentPersistenceHandle,
+  identity: { provider: string; providerHandleId: string },
 ): boolean {
   return (
-    record.persistence?.provider === handle.provider &&
-    (record.persistence.sessionId === handle.sessionId ||
-      record.persistence.nativeHandle === handle.nativeHandle)
+    record.persistence?.provider === identity.provider &&
+    (record.persistence.sessionId === identity.providerHandleId ||
+      record.persistence.nativeHandle === identity.providerHandleId)
   );
 }
 
@@ -294,22 +310,6 @@ function parseRecentProviderSessionsSince(since: string | undefined): number | n
     throw new ImportSessionsRequestError("invalid_since", "Invalid recent provider sessions since");
   }
   return timestamp;
-}
-
-function buildImportPersistenceHandle(input: {
-  provider: string;
-  providerHandleId: string;
-  cwd: string;
-}): AgentPersistenceHandle {
-  return {
-    provider: input.provider,
-    sessionId: input.providerHandleId,
-    nativeHandle: input.providerHandleId,
-    metadata: {
-      provider: input.provider,
-      cwd: input.cwd,
-    },
-  };
 }
 
 async function collectImportedProviderSessionHandles(

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -16,6 +16,7 @@ import type {
   ImportAgentRequestMessageSchema,
   RecentProviderSessionDescriptorPayload,
 } from "@getpaseo/protocol/messages";
+import { getParentAgentIdFromLabels, PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
 import { createRealpathAwarePathMatcher } from "../../utils/path.js";
 
 type ImportAgentRequestMessage = z.infer<typeof ImportAgentRequestMessageSchema>;
@@ -156,9 +157,20 @@ export async function importProviderSession(
   }
   const archivedRecord = matchingRecords.find((record) => record.archivedAt);
   if (archivedRecord?.persistence && archivedRecord.archivedAt) {
-    const restoredLabels = input.request.labels
-      ? { ...archivedRecord.labels, ...input.request.labels }
-      : archivedRecord.labels;
+    const restoredLabels = { ...archivedRecord.labels, ...input.request.labels };
+    const requestedParentAgentId = getParentAgentIdFromLabels(input.request.labels);
+    if (requestedParentAgentId) {
+      restoredLabels[PARENT_AGENT_ID_LABEL] = requestedParentAgentId;
+    } else {
+      delete restoredLabels[PARENT_AGENT_ID_LABEL];
+    }
+    const labelPatch: Record<string, string | null> = { ...input.request.labels };
+    if (
+      Object.hasOwn(archivedRecord.labels, PARENT_AGENT_ID_LABEL) ||
+      Object.hasOwn(input.request.labels ?? {}, PARENT_AGENT_ID_LABEL)
+    ) {
+      labelPatch[PARENT_AGENT_ID_LABEL] = requestedParentAgentId;
+    }
     const restoredRecord = {
       ...archivedRecord,
       workspaceId: input.workspaceId,
@@ -167,7 +179,7 @@ export async function importProviderSession(
     };
     await unarchiveAgentState(input.agentStorage, input.agentManager, archivedRecord.id, {
       workspaceId: input.workspaceId,
-      labels: input.request.labels,
+      labels: Object.keys(labelPatch).length > 0 ? labelPatch : undefined,
     });
     try {
       const snapshot = await input.agentManager.resumeAgentFromPersistence(

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -155,7 +155,7 @@ export async function importProviderSession(
     throw new Error(`Provider session is already imported: ${providerHandleId}`);
   }
   const archivedRecord = matchingRecords.find((record) => record.archivedAt);
-  if (archivedRecord?.persistence) {
+  if (archivedRecord?.persistence && archivedRecord.archivedAt) {
     const restoredLabels = input.request.labels
       ? { ...archivedRecord.labels, ...input.request.labels }
       : archivedRecord.labels;
@@ -169,17 +169,22 @@ export async function importProviderSession(
       workspaceId: input.workspaceId,
       labels: input.request.labels,
     });
-    const snapshot = await input.agentManager.resumeAgentFromPersistence(
-      archivedRecord.persistence,
-      buildConfigOverrides(restoredRecord),
-      archivedRecord.id,
-      extractTimestamps(restoredRecord),
-    );
-    await input.agentManager.hydrateTimelineFromProvider(snapshot.id);
-    return {
-      snapshot,
-      timelineSize: input.agentManager.getTimeline(snapshot.id).length,
-    };
+    try {
+      const snapshot = await input.agentManager.resumeAgentFromPersistence(
+        archivedRecord.persistence,
+        buildConfigOverrides(restoredRecord),
+        archivedRecord.id,
+        extractTimestamps(restoredRecord),
+      );
+      await input.agentManager.hydrateTimelineFromProvider(snapshot.id);
+      return {
+        snapshot,
+        timelineSize: input.agentManager.getTimeline(snapshot.id).length,
+      };
+    } catch (error) {
+      await rollbackArchivedImport(input, archivedRecord, archivedRecord.archivedAt);
+      throw error;
+    }
   }
 
   const snapshot = await input.agentManager.importProviderSession({
@@ -195,6 +200,33 @@ export async function importProviderSession(
     snapshot,
     timelineSize: input.agentManager.getTimeline(snapshot.id).length,
   };
+}
+
+async function rollbackArchivedImport(
+  input: ImportProviderSessionInput,
+  archivedRecord: StoredAgentRecord,
+  archivedAt: string,
+): Promise<void> {
+  try {
+    if (input.agentManager.getAgent(archivedRecord.id)) {
+      await input.agentManager.closeAgent(archivedRecord.id);
+    }
+    await input.agentManager.archiveSnapshot(archivedRecord.id, archivedAt);
+  } catch (error) {
+    input.logger.error(
+      { err: error, agentId: archivedRecord.id },
+      "Failed to re-archive provider session after import failure",
+    );
+  }
+
+  try {
+    await input.agentStorage.upsert(archivedRecord);
+  } catch (error) {
+    input.logger.error(
+      { err: error, agentId: archivedRecord.id },
+      "Failed to restore archived agent record after import failure",
+    );
+  }
 }
 
 function recordMatchesProviderHandle(

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2709,6 +2709,7 @@ export class Session {
         throw new Error("Import requires cwd from the selected provider session");
       }
       let workspace: PersistedWorkspaceRecord | null = null;
+      let previousProject: PersistedProjectRecord | null = null;
       let workspaceId: string;
       if (normalized.workspaceId) {
         const requestedWorkspace = await this.workspaceRegistry.get(normalized.workspaceId);
@@ -2724,8 +2725,16 @@ export class Session {
         }
         workspaceId = requestedWorkspace.workspaceId;
       } else {
-        workspace = await this.workspaceProvisioning.createWorkspaceForDirectory(normalized.cwd);
-        workspaceId = workspace.workspaceId;
+        const projectsBeforeImport = await this.projectRegistry.list();
+        const createdWorkspace = await this.workspaceProvisioning.createWorkspaceForDirectory(
+          normalized.cwd,
+        );
+        workspace = createdWorkspace;
+        previousProject =
+          projectsBeforeImport.find(
+            (project) => project.projectId === createdWorkspace.projectId,
+          ) ?? null;
+        workspaceId = createdWorkspace.workspaceId;
       }
       let importResult: Awaited<ReturnType<typeof importProviderSession>>;
       try {
@@ -2738,12 +2747,7 @@ export class Session {
         });
       } catch (error) {
         if (workspace) {
-          await this.workspaceRegistry.remove(workspace.workspaceId).catch((cleanupError) => {
-            this.sessionLogger.error(
-              { err: cleanupError, workspaceId: workspace.workspaceId },
-              "Failed to remove workspace after provider import failure",
-            );
-          });
+          await this.rollbackWorkspaceCreatedForFailedImport(workspace, previousProject);
         }
         throw error;
       }
@@ -4487,6 +4491,31 @@ export class Session {
       this.sessionLogger.warn(
         { err: error, workspaceId: workspace.workspaceId, cwd: workspace.cwd },
         "Failed to register workspace for imported agent",
+      );
+    }
+  }
+
+  private async rollbackWorkspaceCreatedForFailedImport(
+    workspace: PersistedWorkspaceRecord,
+    previousProject: PersistedProjectRecord | null,
+  ): Promise<void> {
+    try {
+      await this.workspaceRegistry.remove(workspace.workspaceId);
+      const projectHasActiveWorkspace = (await this.workspaceRegistry.list()).some(
+        (candidate) => candidate.projectId === workspace.projectId && !candidate.archivedAt,
+      );
+      if (projectHasActiveWorkspace) {
+        return;
+      }
+      if (previousProject?.archivedAt) {
+        await this.projectRegistry.upsert(previousProject);
+      } else if (!previousProject) {
+        await this.projectRegistry.remove(workspace.projectId);
+      }
+    } catch (error) {
+      this.sessionLogger.error(
+        { err: error, workspaceId: workspace.workspaceId, projectId: workspace.projectId },
+        "Failed to restore workspace state after provider import failure",
       );
     }
   }

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -172,7 +172,7 @@ import {
   matchesAgentUpdatesFilter,
   type AgentUpdatesService,
 } from "./session/agent-updates/agent-updates-service.js";
-import { createRealpathAwarePathMatcher, expandTilde } from "../utils/path.js";
+import { expandTilde } from "../utils/path.js";
 import {
   searchDirectoryEntries,
   WORKSPACE_SEARCH_HIDDEN_DIRECTORIES,
@@ -696,6 +696,7 @@ export class Session {
       workspaceRegistry: this.workspaceRegistry,
       projectRegistry: this.projectRegistry,
       workspaceGitService: this.workspaceGitService,
+      logger: this.sessionLogger,
     });
     this.checkoutSession = new CheckoutSession({
       host: {
@@ -2708,52 +2709,15 @@ export class Session {
       if (!normalized.cwd) {
         throw new Error("Import requires cwd from the selected provider session");
       }
-      let workspace: PersistedWorkspaceRecord | null = null;
-      let previousProject: PersistedProjectRecord | null = null;
-      let workspaceId: string;
-      if (normalized.workspaceId) {
-        const requestedWorkspace = await this.workspaceRegistry.get(normalized.workspaceId);
-        if (!requestedWorkspace || requestedWorkspace.archivedAt) {
-          throw new Error(`Workspace not found: ${normalized.workspaceId}`);
-        }
-        if (!createRealpathAwarePathMatcher(requestedWorkspace.cwd)(normalized.cwd)) {
-          throw new Error(`Import cwd does not match workspace: ${normalized.workspaceId}`);
-        }
-        const requestedProject = await this.projectRegistry.get(requestedWorkspace.projectId);
-        if (!requestedProject || requestedProject.archivedAt) {
-          throw new Error(`Project not found: ${requestedWorkspace.projectId}`);
-        }
-        workspaceId = requestedWorkspace.workspaceId;
-      } else {
-        const projectsBeforeImport = await this.projectRegistry.list();
-        const createdWorkspace = await this.workspaceProvisioning.createWorkspaceForDirectory(
-          normalized.cwd,
-        );
-        workspace = createdWorkspace;
-        previousProject =
-          projectsBeforeImport.find(
-            (project) => project.projectId === createdWorkspace.projectId,
-          ) ?? null;
-        workspaceId = createdWorkspace.workspaceId;
-      }
-      let importResult: Awaited<ReturnType<typeof importProviderSession>>;
-      try {
-        importResult = await importProviderSession({
-          request: normalized,
-          workspaceId,
-          agentManager: this.agentManager,
-          agentStorage: this.agentStorage,
-          logger: this.sessionLogger,
-        });
-      } catch (error) {
-        if (workspace) {
-          await this.rollbackWorkspaceCreatedForFailedImport(workspace, previousProject);
-        }
-        throw error;
-      }
-      const { snapshot, timelineSize } = importResult;
-      if (workspace) {
-        await this.registerWorkspaceForImportedAgent(workspace);
+      const { snapshot, timelineSize, createdWorkspace } = await importProviderSession({
+        request: normalized,
+        workspaceProvisioning: this.workspaceProvisioning,
+        agentManager: this.agentManager,
+        agentStorage: this.agentStorage,
+        logger: this.sessionLogger,
+      });
+      if (createdWorkspace) {
+        await this.registerWorkspaceForImportedAgent(createdWorkspace);
       }
       const agentPayload = await this.buildAgentPayload(snapshot);
       this.emit({
@@ -4491,31 +4455,6 @@ export class Session {
       this.sessionLogger.warn(
         { err: error, workspaceId: workspace.workspaceId, cwd: workspace.cwd },
         "Failed to register workspace for imported agent",
-      );
-    }
-  }
-
-  private async rollbackWorkspaceCreatedForFailedImport(
-    workspace: PersistedWorkspaceRecord,
-    previousProject: PersistedProjectRecord | null,
-  ): Promise<void> {
-    try {
-      await this.workspaceRegistry.remove(workspace.workspaceId);
-      const projectHasActiveWorkspace = (await this.workspaceRegistry.list()).some(
-        (candidate) => candidate.projectId === workspace.projectId && !candidate.archivedAt,
-      );
-      if (projectHasActiveWorkspace) {
-        return;
-      }
-      if (previousProject?.archivedAt) {
-        await this.projectRegistry.upsert(previousProject);
-      } else if (!previousProject) {
-        await this.projectRegistry.remove(workspace.projectId);
-      }
-    } catch (error) {
-      this.sessionLogger.error(
-        { err: error, workspaceId: workspace.workspaceId, projectId: workspace.projectId },
-        "Failed to restore workspace state after provider import failure",
       );
     }
   }

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2718,6 +2718,10 @@ export class Session {
         if (!createRealpathAwarePathMatcher(requestedWorkspace.cwd)(normalized.cwd)) {
           throw new Error(`Import cwd does not match workspace: ${normalized.workspaceId}`);
         }
+        const requestedProject = await this.projectRegistry.get(requestedWorkspace.projectId);
+        if (!requestedProject || requestedProject.archivedAt) {
+          throw new Error(`Project not found: ${requestedWorkspace.projectId}`);
+        }
         workspaceId = requestedWorkspace.workspaceId;
       } else {
         workspace = await this.workspaceProvisioning.createWorkspaceForDirectory(normalized.cwd);

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2708,19 +2708,24 @@ export class Session {
       if (!normalized.cwd) {
         throw new Error("Import requires cwd from the selected provider session");
       }
-      // An imported agent mints its own workspace; ownership is its workspaceId,
-      // never an existing same-cwd workspace resolved by path.
-      const workspace = await this.workspaceProvisioning.createWorkspaceForDirectory(
-        normalized.cwd,
-      );
+      let workspace: PersistedWorkspaceRecord | null = null;
+      let workspaceId: string;
+      if (normalized.workspaceId) {
+        workspaceId = normalized.workspaceId;
+      } else {
+        workspace = await this.workspaceProvisioning.createWorkspaceForDirectory(normalized.cwd);
+        workspaceId = workspace.workspaceId;
+      }
       const { snapshot, timelineSize } = await importProviderSession({
         request: normalized,
-        workspaceId: workspace.workspaceId,
+        workspaceId,
         agentManager: this.agentManager,
         agentStorage: this.agentStorage,
         logger: this.sessionLogger,
       });
-      await this.registerWorkspaceForImportedAgent(workspace);
+      if (workspace) {
+        await this.registerWorkspaceForImportedAgent(workspace);
+      }
       const agentPayload = await this.buildAgentPayload(snapshot);
       this.emit({
         type: "status",

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -172,7 +172,7 @@ import {
   matchesAgentUpdatesFilter,
   type AgentUpdatesService,
 } from "./session/agent-updates/agent-updates-service.js";
-import { expandTilde } from "../utils/path.js";
+import { createRealpathAwarePathMatcher, expandTilde } from "../utils/path.js";
 import {
   searchDirectoryEntries,
   WORKSPACE_SEARCH_HIDDEN_DIRECTORIES,
@@ -2711,7 +2711,14 @@ export class Session {
       let workspace: PersistedWorkspaceRecord | null = null;
       let workspaceId: string;
       if (normalized.workspaceId) {
-        workspaceId = normalized.workspaceId;
+        const requestedWorkspace = await this.workspaceRegistry.get(normalized.workspaceId);
+        if (!requestedWorkspace || requestedWorkspace.archivedAt) {
+          throw new Error(`Workspace not found: ${normalized.workspaceId}`);
+        }
+        if (!createRealpathAwarePathMatcher(requestedWorkspace.cwd)(normalized.cwd)) {
+          throw new Error(`Import cwd does not match workspace: ${normalized.workspaceId}`);
+        }
+        workspaceId = requestedWorkspace.workspaceId;
       } else {
         workspace = await this.workspaceProvisioning.createWorkspaceForDirectory(normalized.cwd);
         workspaceId = workspace.workspaceId;

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2727,13 +2727,27 @@ export class Session {
         workspace = await this.workspaceProvisioning.createWorkspaceForDirectory(normalized.cwd);
         workspaceId = workspace.workspaceId;
       }
-      const { snapshot, timelineSize } = await importProviderSession({
-        request: normalized,
-        workspaceId,
-        agentManager: this.agentManager,
-        agentStorage: this.agentStorage,
-        logger: this.sessionLogger,
-      });
+      let importResult: Awaited<ReturnType<typeof importProviderSession>>;
+      try {
+        importResult = await importProviderSession({
+          request: normalized,
+          workspaceId,
+          agentManager: this.agentManager,
+          agentStorage: this.agentStorage,
+          logger: this.sessionLogger,
+        });
+      } catch (error) {
+        if (workspace) {
+          await this.workspaceRegistry.remove(workspace.workspaceId).catch((cleanupError) => {
+            this.sessionLogger.error(
+              { err: cleanupError, workspaceId: workspace.workspaceId },
+              "Failed to remove workspace after provider import failure",
+            );
+          });
+        }
+        throw error;
+      }
+      const { snapshot, timelineSize } = importResult;
       if (workspace) {
         await this.registerWorkspaceForImportedAgent(workspace);
       }

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -3693,6 +3693,48 @@ test("import_agent_request registers a workspace for a never-seen cwd", async ()
   ).toBe(true);
 });
 
+test("failed import_agent_request removes the workspace created for the import", async () => {
+  const workdir = mkdtempSync(path.join(tmpdir(), "paseo-failed-import-"));
+  const emitted: SessionOutboundMessage[] = [];
+  const logger = createTestLogger();
+  const projectRegistry = new FileBackedProjectRegistry(
+    path.join(workdir, "projects.json"),
+    logger,
+  );
+  const workspaceRegistry = new FileBackedWorkspaceRegistry(
+    path.join(workdir, "workspaces.json"),
+    logger,
+  );
+  const session = createSessionForWorkspaceTests({
+    onMessage: (message) => emitted.push(message),
+    projectRegistry,
+    workspaceRegistry,
+  });
+  session.agentStorage.list = async () => [];
+  session.agentManager.importProviderSession = async () => {
+    throw new Error("provider session is unavailable");
+  };
+
+  try {
+    await session.handleMessage({
+      type: "import_agent_request",
+      requestId: "req-failed-import",
+      providerId: "codex",
+      providerHandleId: "stale-session",
+      cwd: path.resolve("/tmp/stale-import"),
+    });
+
+    await expect(workspaceRegistry.list()).resolves.toEqual([]);
+    expect(findByType(emitted, "status")?.payload).toMatchObject({
+      status: "agent_create_failed",
+      requestId: "req-failed-import",
+      error: "provider session is unavailable",
+    });
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("import_agent_request imports into the workspace that opened the import sheet", async () => {
   const session = createSessionForWorkspaceTests();
   const workspaceId = "ws-repo-running";

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -3693,47 +3693,69 @@ test("import_agent_request registers a workspace for a never-seen cwd", async ()
   ).toBe(true);
 });
 
-test("failed import_agent_request removes the workspace created for the import", async () => {
-  const workdir = mkdtempSync(path.join(tmpdir(), "paseo-failed-import-"));
-  const emitted: SessionOutboundMessage[] = [];
-  const logger = createTestLogger();
-  const projectRegistry = new FileBackedProjectRegistry(
-    path.join(workdir, "projects.json"),
-    logger,
-  );
-  const workspaceRegistry = new FileBackedWorkspaceRegistry(
-    path.join(workdir, "workspaces.json"),
-    logger,
-  );
-  const session = createSessionForWorkspaceTests({
-    onMessage: (message) => emitted.push(message),
-    projectRegistry,
-    workspaceRegistry,
-  });
-  session.agentStorage.list = async () => [];
-  session.agentManager.importProviderSession = async () => {
-    throw new Error("provider session is unavailable");
-  };
-
-  try {
-    await session.handleMessage({
-      type: "import_agent_request",
-      requestId: "req-failed-import",
-      providerId: "codex",
-      providerHandleId: "stale-session",
-      cwd: path.resolve("/tmp/stale-import"),
+test.each(["missing", "archived"] as const)(
+  "failed import_agent_request restores the %s project state",
+  async (projectState) => {
+    const workdir = mkdtempSync(path.join(tmpdir(), "paseo-failed-import-"));
+    const importedCwd = path.resolve("/tmp/stale-import");
+    const emitted: SessionOutboundMessage[] = [];
+    const logger = createTestLogger();
+    const projectRegistry = new FileBackedProjectRegistry(
+      path.join(workdir, "projects.json"),
+      logger,
+    );
+    const workspaceRegistry = new FileBackedWorkspaceRegistry(
+      path.join(workdir, "workspaces.json"),
+      logger,
+    );
+    const originalProject =
+      projectState === "archived"
+        ? createPersistedProjectRecord({
+            projectId: importedCwd,
+            rootPath: importedCwd,
+            kind: "non_git",
+            displayName: "stale-import",
+            createdAt: "2026-05-21T00:00:00.000Z",
+            updatedAt: "2026-05-21T00:01:00.000Z",
+            archivedAt: "2026-05-21T00:02:00.000Z",
+          })
+        : null;
+    if (originalProject) {
+      await projectRegistry.upsert(originalProject);
+    }
+    const session = createSessionForWorkspaceTests({
+      onMessage: (message) => emitted.push(message),
+      projectRegistry,
+      workspaceRegistry,
     });
+    session.agentStorage.list = async () => [];
+    session.agentManager.importProviderSession = async () => {
+      throw new Error("provider session is unavailable");
+    };
 
-    await expect(workspaceRegistry.list()).resolves.toEqual([]);
-    expect(findByType(emitted, "status")?.payload).toMatchObject({
-      status: "agent_create_failed",
-      requestId: "req-failed-import",
-      error: "provider session is unavailable",
-    });
-  } finally {
-    rmSync(workdir, { recursive: true, force: true });
-  }
-});
+    try {
+      await session.handleMessage({
+        type: "import_agent_request",
+        requestId: "req-failed-import",
+        providerId: "codex",
+        providerHandleId: "stale-session",
+        cwd: importedCwd,
+      });
+
+      await expect(workspaceRegistry.list()).resolves.toEqual([]);
+      await expect(projectRegistry.list()).resolves.toEqual(
+        originalProject ? [originalProject] : [],
+      );
+      expect(findByType(emitted, "status")?.payload).toMatchObject({
+        status: "agent_create_failed",
+        requestId: "req-failed-import",
+        error: "provider session is unavailable",
+      });
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  },
+);
 
 test("import_agent_request imports into the workspace that opened the import sheet", async () => {
   const session = createSessionForWorkspaceTests();

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -3693,74 +3693,11 @@ test("import_agent_request registers a workspace for a never-seen cwd", async ()
   ).toBe(true);
 });
 
-test.each(["missing", "archived"] as const)(
-  "failed import_agent_request restores the %s project state",
-  async (projectState) => {
-    const workdir = mkdtempSync(path.join(tmpdir(), "paseo-failed-import-"));
-    const importedCwd = path.resolve("/tmp/stale-import");
-    const emitted: SessionOutboundMessage[] = [];
-    const logger = createTestLogger();
-    const projectRegistry = new FileBackedProjectRegistry(
-      path.join(workdir, "projects.json"),
-      logger,
-    );
-    const workspaceRegistry = new FileBackedWorkspaceRegistry(
-      path.join(workdir, "workspaces.json"),
-      logger,
-    );
-    const originalProject =
-      projectState === "archived"
-        ? createPersistedProjectRecord({
-            projectId: importedCwd,
-            rootPath: importedCwd,
-            kind: "non_git",
-            displayName: "stale-import",
-            createdAt: "2026-05-21T00:00:00.000Z",
-            updatedAt: "2026-05-21T00:01:00.000Z",
-            archivedAt: "2026-05-21T00:02:00.000Z",
-          })
-        : null;
-    if (originalProject) {
-      await projectRegistry.upsert(originalProject);
-    }
-    const session = createSessionForWorkspaceTests({
-      onMessage: (message) => emitted.push(message),
-      projectRegistry,
-      workspaceRegistry,
-    });
-    session.agentStorage.list = async () => [];
-    session.agentManager.importProviderSession = async () => {
-      throw new Error("provider session is unavailable");
-    };
-
-    try {
-      await session.handleMessage({
-        type: "import_agent_request",
-        requestId: "req-failed-import",
-        providerId: "codex",
-        providerHandleId: "stale-session",
-        cwd: importedCwd,
-      });
-
-      await expect(workspaceRegistry.list()).resolves.toEqual([]);
-      await expect(projectRegistry.list()).resolves.toEqual(
-        originalProject ? [originalProject] : [],
-      );
-      expect(findByType(emitted, "status")?.payload).toMatchObject({
-        status: "agent_create_failed",
-        requestId: "req-failed-import",
-        error: "provider session is unavailable",
-      });
-    } finally {
-      rmSync(workdir, { recursive: true, force: true });
-    }
-  },
-);
-
 test("import_agent_request imports into the workspace that opened the import sheet", async () => {
   const session = createSessionForWorkspaceTests();
   const workspaceId = "ws-repo-running";
   let importedWorkspaceId: string | undefined;
+  let workspaceCreated = false;
 
   session.projectRegistry.get = async () =>
     createPersistedProjectRecord({
@@ -3771,6 +3708,9 @@ test("import_agent_request imports into the workspace that opened the import she
       createdAt: "2026-03-01T12:00:00.000Z",
       updatedAt: "2026-03-01T12:00:00.000Z",
     });
+  session.workspaceRegistry.upsert = async () => {
+    workspaceCreated = true;
+  };
 
   session.agentManager.importProviderSession = async (input: unknown) => {
     importedWorkspaceId = (input as { workspaceId: string }).workspaceId;
@@ -3797,144 +3737,41 @@ test("import_agent_request imports into the workspace that opened the import she
   });
 
   expect(importedWorkspaceId).toBe(workspaceId);
+  expect(workspaceCreated).toBe(false);
 });
 
-test.each([
-  ["missing", null],
-  [
-    "archived",
-    createPersistedWorkspaceRecord({
-      workspaceId: "ws-unavailable-import",
-      projectId: "proj-unavailable-import",
-      cwd: REPO_CWD,
-      kind: "directory",
-      displayName: "unavailable import",
-      createdAt: "2026-05-21T00:00:00.000Z",
-      updatedAt: "2026-05-21T00:01:00.000Z",
-      archivedAt: "2026-05-21T00:02:00.000Z",
-    }),
-  ],
-])("import_agent_request rejects an %s target workspace", async (_state, workspace) => {
+test("import_agent_request maps an import failure to agent_create_failed", async () => {
   const emitted: SessionOutboundMessage[] = [];
   const session = createSessionForWorkspaceTests({
     onMessage: (message) => emitted.push(message),
   });
-  let importAttempted = false;
-
-  session.workspaceRegistry.get = async () => workspace;
-  session.agentManager.importProviderSession = async () => {
-    importAttempted = true;
-    return makeManagedAgent({
-      id: "imported-agent",
-      cwd: REPO_CWD,
-      workspaceId: "ws-unavailable-import",
-      lifecycle: "idle",
-      updatedAt: "2026-05-21T00:03:00.000Z",
-    });
-  };
-
-  await session.handleMessage({
-    type: "import_agent_request",
-    requestId: "req-import-unavailable-workspace",
-    providerId: "codex",
-    providerHandleId: "session-xyz",
-    cwd: REPO_CWD,
-    workspaceId: "ws-unavailable-import",
-  });
-
-  expect(importAttempted).toBe(false);
-  expect(findByType(emitted, "status")?.payload).toMatchObject({
-    status: "agent_create_failed",
-    requestId: "req-import-unavailable-workspace",
-    error: "Workspace not found: ws-unavailable-import",
-  });
-});
-
-test.each([
-  ["missing", null],
-  [
-    "archived",
+  session.projectRegistry.get = async () =>
     createPersistedProjectRecord({
       projectId: "proj-repo-running",
       rootPath: REPO_CWD,
       kind: "non_git",
       displayName: "repo",
       createdAt: "2026-03-01T12:00:00.000Z",
-      updatedAt: "2026-03-01T12:01:00.000Z",
-      archivedAt: "2026-03-01T12:02:00.000Z",
-    }),
-  ],
-])(
-  "import_agent_request rejects a target workspace whose project is %s",
-  async (_state, project) => {
-    const emitted: SessionOutboundMessage[] = [];
-    const session = createSessionForWorkspaceTests({
-      onMessage: (message) => emitted.push(message),
+      updatedAt: "2026-03-01T12:00:00.000Z",
     });
-    let importAttempted = false;
-
-    session.projectRegistry.get = async () => project;
-    session.agentManager.importProviderSession = async () => {
-      importAttempted = true;
-      return makeManagedAgent({
-        id: "imported-agent",
-        cwd: REPO_CWD,
-        workspaceId: "ws-repo-running",
-        lifecycle: "idle",
-        updatedAt: "2026-05-21T00:03:00.000Z",
-      });
-    };
-
-    await session.handleMessage({
-      type: "import_agent_request",
-      requestId: "req-import-unavailable-project",
-      providerId: "codex",
-      providerHandleId: "session-xyz",
-      cwd: REPO_CWD,
-      workspaceId: "ws-repo-running",
-    });
-
-    expect(importAttempted).toBe(false);
-    expect(findByType(emitted, "status")?.payload).toMatchObject({
-      status: "agent_create_failed",
-      requestId: "req-import-unavailable-project",
-      error: "Project not found: proj-repo-running",
-    });
-  },
-);
-
-test("import_agent_request rejects a session outside the target workspace", async () => {
-  const emitted: SessionOutboundMessage[] = [];
-  const session = createSessionForWorkspaceTests({
-    onMessage: (message) => emitted.push(message),
-  });
-  let importAttempted = false;
-
+  session.agentStorage.list = async () => [];
   session.agentManager.importProviderSession = async () => {
-    importAttempted = true;
-    return makeManagedAgent({
-      id: "imported-agent",
-      cwd: "/tmp/different-project",
-      workspaceId: "ws-repo-running",
-      lifecycle: "idle",
-      updatedAt: "2026-05-21T00:03:00.000Z",
-    });
+    throw new Error("provider session is unavailable");
   };
 
   await session.handleMessage({
     type: "import_agent_request",
-    requestId: "req-import-wrong-workspace",
+    requestId: "req-failed-import",
     providerId: "codex",
-    providerHandleId: "session-xyz",
-    cwd: "/tmp/different-project",
+    providerHandleId: "stale-session",
+    cwd: REPO_CWD,
     workspaceId: "ws-repo-running",
   });
 
-  expect(importAttempted).toBe(false);
   expect(findByType(emitted, "status")?.payload).toMatchObject({
     status: "agent_create_failed",
-    requestId: "req-import-wrong-workspace",
-    error: "Import cwd does not match workspace: ws-repo-running",
+    requestId: "req-failed-import",
+    error: "provider session is unavailable",
   });
 });
 

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -3698,6 +3698,16 @@ test("import_agent_request imports into the workspace that opened the import she
   const workspaceId = "ws-repo-running";
   let importedWorkspaceId: string | undefined;
 
+  session.projectRegistry.get = async () =>
+    createPersistedProjectRecord({
+      projectId: "proj-repo-running",
+      rootPath: REPO_CWD,
+      kind: "non_git",
+      displayName: "repo",
+      createdAt: "2026-03-01T12:00:00.000Z",
+      updatedAt: "2026-03-01T12:00:00.000Z",
+    });
+
   session.agentManager.importProviderSession = async (input: unknown) => {
     importedWorkspaceId = (input as { workspaceId: string }).workspaceId;
     return makeManagedAgent({
@@ -3775,6 +3785,59 @@ test.each([
     error: "Workspace not found: ws-unavailable-import",
   });
 });
+
+test.each([
+  ["missing", null],
+  [
+    "archived",
+    createPersistedProjectRecord({
+      projectId: "proj-repo-running",
+      rootPath: REPO_CWD,
+      kind: "non_git",
+      displayName: "repo",
+      createdAt: "2026-03-01T12:00:00.000Z",
+      updatedAt: "2026-03-01T12:01:00.000Z",
+      archivedAt: "2026-03-01T12:02:00.000Z",
+    }),
+  ],
+])(
+  "import_agent_request rejects a target workspace whose project is %s",
+  async (_state, project) => {
+    const emitted: SessionOutboundMessage[] = [];
+    const session = createSessionForWorkspaceTests({
+      onMessage: (message) => emitted.push(message),
+    });
+    let importAttempted = false;
+
+    session.projectRegistry.get = async () => project;
+    session.agentManager.importProviderSession = async () => {
+      importAttempted = true;
+      return makeManagedAgent({
+        id: "imported-agent",
+        cwd: REPO_CWD,
+        workspaceId: "ws-repo-running",
+        lifecycle: "idle",
+        updatedAt: "2026-05-21T00:03:00.000Z",
+      });
+    };
+
+    await session.handleMessage({
+      type: "import_agent_request",
+      requestId: "req-import-unavailable-project",
+      providerId: "codex",
+      providerHandleId: "session-xyz",
+      cwd: REPO_CWD,
+      workspaceId: "ws-repo-running",
+    });
+
+    expect(importAttempted).toBe(false);
+    expect(findByType(emitted, "status")?.payload).toMatchObject({
+      status: "agent_create_failed",
+      requestId: "req-import-unavailable-project",
+      error: "Project not found: proj-repo-running",
+    });
+  },
+);
 
 test("import_agent_request rejects a session outside the target workspace", async () => {
   const emitted: SessionOutboundMessage[] = [];

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -3725,6 +3725,92 @@ test("import_agent_request imports into the workspace that opened the import she
   expect(importedWorkspaceId).toBe(workspaceId);
 });
 
+test.each([
+  ["missing", null],
+  [
+    "archived",
+    createPersistedWorkspaceRecord({
+      workspaceId: "ws-unavailable-import",
+      projectId: "proj-unavailable-import",
+      cwd: REPO_CWD,
+      kind: "directory",
+      displayName: "unavailable import",
+      createdAt: "2026-05-21T00:00:00.000Z",
+      updatedAt: "2026-05-21T00:01:00.000Z",
+      archivedAt: "2026-05-21T00:02:00.000Z",
+    }),
+  ],
+])("import_agent_request rejects an %s target workspace", async (_state, workspace) => {
+  const emitted: SessionOutboundMessage[] = [];
+  const session = createSessionForWorkspaceTests({
+    onMessage: (message) => emitted.push(message),
+  });
+  let importAttempted = false;
+
+  session.workspaceRegistry.get = async () => workspace;
+  session.agentManager.importProviderSession = async () => {
+    importAttempted = true;
+    return makeManagedAgent({
+      id: "imported-agent",
+      cwd: REPO_CWD,
+      workspaceId: "ws-unavailable-import",
+      lifecycle: "idle",
+      updatedAt: "2026-05-21T00:03:00.000Z",
+    });
+  };
+
+  await session.handleMessage({
+    type: "import_agent_request",
+    requestId: "req-import-unavailable-workspace",
+    providerId: "codex",
+    providerHandleId: "session-xyz",
+    cwd: REPO_CWD,
+    workspaceId: "ws-unavailable-import",
+  });
+
+  expect(importAttempted).toBe(false);
+  expect(findByType(emitted, "status")?.payload).toMatchObject({
+    status: "agent_create_failed",
+    requestId: "req-import-unavailable-workspace",
+    error: "Workspace not found: ws-unavailable-import",
+  });
+});
+
+test("import_agent_request rejects a session outside the target workspace", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const session = createSessionForWorkspaceTests({
+    onMessage: (message) => emitted.push(message),
+  });
+  let importAttempted = false;
+
+  session.agentManager.importProviderSession = async () => {
+    importAttempted = true;
+    return makeManagedAgent({
+      id: "imported-agent",
+      cwd: "/tmp/different-project",
+      workspaceId: "ws-repo-running",
+      lifecycle: "idle",
+      updatedAt: "2026-05-21T00:03:00.000Z",
+    });
+  };
+
+  await session.handleMessage({
+    type: "import_agent_request",
+    requestId: "req-import-wrong-workspace",
+    providerId: "codex",
+    providerHandleId: "session-xyz",
+    cwd: "/tmp/different-project",
+    workspaceId: "ws-repo-running",
+  });
+
+  expect(importAttempted).toBe(false);
+  expect(findByType(emitted, "status")?.payload).toMatchObject({
+    status: "agent_create_failed",
+    requestId: "req-import-wrong-workspace",
+    error: "Import cwd does not match workspace: ws-repo-running",
+  });
+});
+
 test("open_project_response returns immediately even when the GitHub fetch is slow", async () => {
   const emitted: SessionOutboundMessage[] = [];
   const session = createSessionForWorkspaceTests();

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -3693,6 +3693,38 @@ test("import_agent_request registers a workspace for a never-seen cwd", async ()
   ).toBe(true);
 });
 
+test("import_agent_request imports into the workspace that opened the import sheet", async () => {
+  const session = createSessionForWorkspaceTests();
+  const workspaceId = "ws-repo-running";
+  let importedWorkspaceId: string | undefined;
+
+  session.agentManager.importProviderSession = async (input: unknown) => {
+    importedWorkspaceId = (input as { workspaceId: string }).workspaceId;
+    return makeManagedAgent({
+      id: "imported-agent",
+      cwd: REPO_CWD,
+      workspaceId: importedWorkspaceId,
+      lifecycle: "idle",
+      updatedAt: "2026-05-21T00:00:00.000Z",
+    });
+  };
+  session.agentManager.getTimeline = () => [];
+  session.agentStorage.list = async () => [];
+  session.agentStorage.get = async () => null;
+  session.agentUpdates.forwardLiveAgent = async () => undefined;
+
+  await session.handleMessage({
+    type: "import_agent_request",
+    requestId: "req-import-current-workspace",
+    providerId: "codex",
+    providerHandleId: "session-xyz",
+    cwd: REPO_CWD,
+    workspaceId,
+  });
+
+  expect(importedWorkspaceId).toBe(workspaceId);
+});
+
 test("open_project_response returns immediately even when the GitHub fetch is slow", async () => {
   const emitted: SessionOutboundMessage[] = [];
   const session = createSessionForWorkspaceTests();

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 
 import { afterEach, beforeEach, expect, test } from "vitest";
 
@@ -9,6 +9,7 @@ import { createNoopWorkspaceGitService } from "../../test-utils/workspace-git-se
 import {
   FileBackedProjectRegistry,
   FileBackedWorkspaceRegistry,
+  type PersistedProjectRecord,
 } from "../../workspace-registry.js";
 import type { CreatePaseoWorktreeWorkflowResult } from "../../worktree-session.js";
 import {
@@ -22,6 +23,7 @@ import {
 
 const logger = createTestLogger();
 const ARCHIVED_AT = "2026-01-01T00:00:00.000Z";
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
 
 let tmpDir: string;
 let gitRoots: Set<string>;
@@ -72,6 +74,7 @@ beforeEach(async () => {
     workspaceRegistry,
     projectRegistry,
     workspaceGitService: gitService(),
+    logger,
   });
 });
 
@@ -214,3 +217,137 @@ test("findOrCreateProjectForDirectory reuses the active project for the same roo
   expect(second.projectId).toBe(first.projectId);
   expect(await projectRegistry.list()).toHaveLength(1);
 });
+
+test("runInImportWorkspace uses an active requested workspace without creating another", async () => {
+  const cwd = path.join(tmpDir, "requested");
+  mkdirSync(cwd);
+  const workspace = await provisioning.createWorkspaceForDirectory(cwd);
+
+  const result = await provisioning.runInImportWorkspace(
+    { cwd, requestedWorkspaceId: workspace.workspaceId },
+    async (target) => target.workspaceId,
+  );
+
+  expect(result).toEqual({ value: workspace.workspaceId, createdWorkspace: null });
+  expect(await workspaceRegistry.list()).toEqual([workspace]);
+});
+
+test.each(["missing", "archived"] as const)(
+  "runInImportWorkspace rejects a %s requested workspace before importing",
+  async (state) => {
+    const cwd = path.join(tmpDir, "unavailable-workspace");
+    mkdirSync(cwd);
+    const workspace = await provisioning.createWorkspaceForDirectory(cwd);
+    if (state === "archived") {
+      await workspaceRegistry.archive(workspace.workspaceId, ARCHIVED_AT);
+    } else {
+      await workspaceRegistry.remove(workspace.workspaceId);
+    }
+    let imported = false;
+
+    await expect(
+      provisioning.runInImportWorkspace(
+        { cwd, requestedWorkspaceId: workspace.workspaceId },
+        async () => {
+          imported = true;
+        },
+      ),
+    ).rejects.toThrow(`Workspace not found: ${workspace.workspaceId}`);
+    expect(imported).toBe(false);
+  },
+);
+
+test.each(["missing", "archived"] as const)(
+  "runInImportWorkspace rejects a requested workspace whose project is %s before importing",
+  async (state) => {
+    const cwd = path.join(tmpDir, "unavailable-project");
+    mkdirSync(cwd);
+    const workspace = await provisioning.createWorkspaceForDirectory(cwd);
+    if (state === "archived") {
+      await projectRegistry.archive(workspace.projectId, ARCHIVED_AT);
+    } else {
+      await projectRegistry.remove(workspace.projectId);
+    }
+    let imported = false;
+
+    await expect(
+      provisioning.runInImportWorkspace(
+        { cwd, requestedWorkspaceId: workspace.workspaceId },
+        async () => {
+          imported = true;
+        },
+      ),
+    ).rejects.toThrow(`Project not found: ${workspace.projectId}`);
+    expect(imported).toBe(false);
+  },
+);
+
+test("runInImportWorkspace accepts a filesystem-equivalent requested cwd", async () => {
+  const cwd = path.join(tmpDir, "real-directory");
+  const alias = path.join(tmpDir, "directory-alias");
+  mkdirSync(cwd);
+  symlinkSync(cwd, alias, directorySymlinkType);
+  const workspace = await provisioning.createWorkspaceForDirectory(cwd);
+
+  const result = await provisioning.runInImportWorkspace(
+    { cwd: alias, requestedWorkspaceId: workspace.workspaceId },
+    async (target) => target.workspaceId,
+  );
+
+  expect(result.value).toBe(workspace.workspaceId);
+});
+
+test("runInImportWorkspace rejects a requested workspace with a different cwd", async () => {
+  const cwd = path.join(tmpDir, "workspace-directory");
+  const otherCwd = path.join(tmpDir, "other-directory");
+  mkdirSync(cwd);
+  mkdirSync(otherCwd);
+  const workspace = await provisioning.createWorkspaceForDirectory(cwd);
+  let imported = false;
+
+  await expect(
+    provisioning.runInImportWorkspace(
+      { cwd: otherCwd, requestedWorkspaceId: workspace.workspaceId },
+      async () => {
+        imported = true;
+      },
+    ),
+  ).rejects.toThrow(`Import cwd does not match workspace: ${workspace.workspaceId}`);
+  expect(imported).toBe(false);
+});
+
+test("runInImportWorkspace creates one fresh workspace for an untargeted import", async () => {
+  const cwd = path.join(tmpDir, "fresh-import");
+  mkdirSync(cwd);
+
+  const result = await provisioning.runInImportWorkspace(
+    { cwd },
+    async (workspace) => workspace.workspaceId,
+  );
+
+  expect(result.value).toBe(result.createdWorkspace?.workspaceId);
+  expect(await workspaceRegistry.list()).toEqual([result.createdWorkspace]);
+});
+
+test.each(["missing", "archived"] as const)(
+  "runInImportWorkspace restores the exact %s project state when an untargeted import fails",
+  async (state) => {
+    const cwd = path.join(tmpDir, `failed-import-${state}`);
+    mkdirSync(cwd);
+    let previousProject: PersistedProjectRecord | null = null;
+    if (state === "archived") {
+      const project = await provisioning.findOrCreateProjectForDirectory(cwd);
+      await projectRegistry.archive(project.projectId, ARCHIVED_AT);
+      previousProject = await projectRegistry.get(project.projectId);
+    }
+
+    await expect(
+      provisioning.runInImportWorkspace({ cwd }, async () => {
+        throw new Error("provider session is unavailable");
+      }),
+    ).rejects.toThrow("provider session is unavailable");
+
+    expect(await workspaceRegistry.list()).toEqual([]);
+    expect(await projectRegistry.list()).toEqual(previousProject ? [previousProject] : []);
+  },
+);

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path";
+import type { Logger } from "pino";
 import {
   checkoutLiteFromGitSnapshot,
   classifyDirectoryForProjectMembership,
@@ -14,6 +15,7 @@ import {
 } from "../../workspace-registry.js";
 import type { WorkspaceGitService } from "../../workspace-git-service.js";
 import type { CreatePaseoWorktreeWorkflowResult } from "../../worktree-session.js";
+import { createRealpathAwarePathMatcher } from "../../../utils/path.js";
 
 /**
  * Resolves which workspace and project records a directory belongs to, creating,
@@ -34,7 +36,21 @@ export interface ResolveOrCreateWorkspaceIdInput {
   initialTitle: string | null;
 }
 
+export interface ImportWorkspaceInput {
+  cwd: string;
+  requestedWorkspaceId?: string;
+}
+
+export interface ImportWorkspaceResult<T> {
+  value: T;
+  createdWorkspace: PersistedWorkspaceRecord | null;
+}
+
 export interface WorkspaceProvisioningService {
+  runInImportWorkspace<T>(
+    input: ImportWorkspaceInput,
+    operation: (workspace: PersistedWorkspaceRecord) => Promise<T>,
+  ): Promise<ImportWorkspaceResult<T>>;
   findOrCreateWorkspaceForDirectory(cwd: string): Promise<PersistedWorkspaceRecord>;
   resolveOrCreateWorkspaceIdForCreateAgent(input: ResolveOrCreateWorkspaceIdInput): Promise<string>;
   createWorkspaceForDirectory(
@@ -51,8 +67,72 @@ export function createWorkspaceProvisioningService(deps: {
   workspaceRegistry: WorkspaceRegistry;
   projectRegistry: ProjectRegistry;
   workspaceGitService: Pick<WorkspaceGitService, "getCheckout" | "peekSnapshot">;
+  logger: Logger;
 }): WorkspaceProvisioningService {
-  const { workspaceRegistry, projectRegistry, workspaceGitService } = deps;
+  const { workspaceRegistry, projectRegistry, workspaceGitService, logger } = deps;
+
+  async function runInImportWorkspace<T>(
+    input: ImportWorkspaceInput,
+    operation: (workspace: PersistedWorkspaceRecord) => Promise<T>,
+  ): Promise<ImportWorkspaceResult<T>> {
+    if (input.requestedWorkspaceId) {
+      const workspace = await workspaceRegistry.get(input.requestedWorkspaceId);
+      if (!workspace || workspace.archivedAt) {
+        throw new Error(`Workspace not found: ${input.requestedWorkspaceId}`);
+      }
+      const project = await projectRegistry.get(workspace.projectId);
+      if (!project || project.archivedAt) {
+        throw new Error(`Project not found: ${workspace.projectId}`);
+      }
+      if (!createRealpathAwarePathMatcher(workspace.cwd)(input.cwd)) {
+        throw new Error(`Import cwd does not match workspace: ${workspace.workspaceId}`);
+      }
+      return {
+        value: await operation(workspace),
+        createdWorkspace: null,
+      };
+    }
+
+    const projectsBeforeImport = await projectRegistry.list();
+    const workspace = await createWorkspaceForDirectory(input.cwd);
+    const previousProject =
+      projectsBeforeImport.find((project) => project.projectId === workspace.projectId) ?? null;
+
+    try {
+      return {
+        value: await operation(workspace),
+        createdWorkspace: workspace,
+      };
+    } catch (error) {
+      await rollbackFailedImportWorkspace(workspace, previousProject);
+      throw error;
+    }
+  }
+
+  async function rollbackFailedImportWorkspace(
+    workspace: PersistedWorkspaceRecord,
+    previousProject: PersistedProjectRecord | null,
+  ): Promise<void> {
+    try {
+      await workspaceRegistry.remove(workspace.workspaceId);
+      const projectHasActiveWorkspace = (await workspaceRegistry.list()).some(
+        (candidate) => candidate.projectId === workspace.projectId && !candidate.archivedAt,
+      );
+      if (projectHasActiveWorkspace) {
+        return;
+      }
+      if (previousProject?.archivedAt) {
+        await projectRegistry.upsert(previousProject);
+      } else if (!previousProject) {
+        await projectRegistry.remove(workspace.projectId);
+      }
+    } catch (error) {
+      logger.error(
+        { err: error, workspaceId: workspace.workspaceId, projectId: workspace.projectId },
+        "Failed to restore workspace state after provider import failure",
+      );
+    }
+  }
 
   async function resolveWorkspaceDirectory(
     cwd: string,
@@ -275,6 +355,7 @@ export function createWorkspaceProvisioningService(deps: {
   }
 
   return {
+    runInImportWorkspace,
     findOrCreateWorkspaceForDirectory,
     resolveOrCreateWorkspaceIdForCreateAgent,
     createWorkspaceForDirectory,

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1255,6 +1255,8 @@ export class VoiceAssistantWebSocketServer {
         projectCreateDirectory: true,
         // COMPAT(providerRemoval): added in v0.1.105, drop the gate when floor >= v0.1.105.
         providerRemoval: true,
+        // COMPAT(importSessionWorkspaceTarget): added in v0.1.110, remove gate after 2027-01-16.
+        importSessionWorkspaceTarget: true,
       },
     };
   }


### PR DESCRIPTION
### Linked issue

Closes #1435

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Archived provider sessions return to the import picker after their Paseo agent is archived. When a user imports from inside a workspace, the session now opens in that workspace instead of creating a duplicate workspace; imports started outside a workspace keep creating one as before.

Archived records no longer count as active imports, allowing the existing native-unarchive path to restore them. Workspace context is carried as an optional import request field through the app, client, protocol, and daemon.

### How did you verify it

- Added regression coverage for archived sessions returning to the import list.
- Added regression coverage for workspace-originated imports retaining their workspace.
- Ran focused server, protocol, client, and app tests: 248 passed.
- Ran `npm run typecheck` and `npm run lint` successfully.
- Ran `npm run format`.
- No visual layout changed, so screenshots are not applicable.

Before merge, verify a new app against the previous daemon version: older daemons cannot honor the new workspace target even though the request field is optional.

### Risk surface

The import request crosses app/daemon version boundaries. Old clients continue omitting the optional field; a new client connected to an older daemon will retain the prior behavior of creating a workspace for the imported session.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable: no visual changes)
- [x] Tests added or updated where it made sense