### PR TITLE
Show agent history errors without a one-minute wait

### DIFF
--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -4947,13 +4947,18 @@ test("parses canonical fetch_agent_timeline_response payloads without crashing",
   expect(logger.warn).not.toHaveBeenCalled();
 });
 
-test("rejects a correlated request when its response violates the protocol schema", async () => {
+test("rejects and logs a correlated response that violates the protocol schema", async () => {
   const mock = createMockTransport();
+  const warnings: string[] = [];
+  const logger: Logger = {
+    ...noopLogger,
+    warn: (_fields, message) => warnings.push(message ?? ""),
+  };
 
   const client = new DaemonClient({
     url: "ws://test",
     clientId: "clsk_unit_test",
-    logger: noopLogger,
+    logger,
     reconnect: { enabled: false },
     transportFactory: () => mock.transport,
   });
@@ -5016,6 +5021,7 @@ test("rejects a correlated request when its response violates the protocol schem
     requestId: "req-invalid",
     message: expect.stringMatching(/validation/i),
   });
+  expect(warnings).toEqual(["Message validation failed"]);
 });
 
 test("sends subscribe/unsubscribe terminals messages", async () => {

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -4947,14 +4947,13 @@ test("parses canonical fetch_agent_timeline_response payloads without crashing",
   expect(logger.warn).not.toHaveBeenCalled();
 });
 
-test("drops invalid fetch_agent_timeline_response tool_call payloads and logs validation warning", async () => {
-  const logger = createMockLogger();
+test("rejects a correlated request when its response violates the protocol schema", async () => {
   const mock = createMockTransport();
 
   const client = new DaemonClient({
     url: "ws://test",
     clientId: "clsk_unit_test",
-    logger,
+    logger: noopLogger,
     reconnect: { enabled: false },
     transportFactory: () => mock.transport,
   });
@@ -4964,9 +4963,9 @@ test("drops invalid fetch_agent_timeline_response tool_call payloads and logs va
   mock.triggerOpen();
   await connectPromise;
 
-  const received: unknown[] = [];
-  const unsubscribe = client.on("fetch_agent_timeline_response", (msg) => {
-    received.push(msg);
+  const response = client.fetchAgentTimeline("agent_cli", {
+    requestId: "req-invalid",
+    timeout: 1,
   });
 
   mock.triggerMessage(
@@ -5013,10 +5012,10 @@ test("drops invalid fetch_agent_timeline_response tool_call payloads and logs va
     }),
   );
 
-  unsubscribe();
-
-  expect(received).toHaveLength(0);
-  expect(logger.warn).toHaveBeenCalled();
+  await expect(response).rejects.toMatchObject({
+    requestId: "req-invalid",
+    message: expect.stringMatching(/validation/i),
+  });
 });
 
 test("sends subscribe/unsubscribe terminals messages", async () => {

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -5024,6 +5024,51 @@ test("rejects and logs a correlated response that violates the protocol schema",
   expect(warnings).toEqual(["Message validation failed"]);
 });
 
+test("does not reject a request for an invalid correlated progress event", async () => {
+  const mock = createMockTransport();
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger: noopLogger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const response = client.updateDaemon("req-update");
+
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "daemon.update.progress",
+      payload: {
+        requestId: "req-update",
+        phase: "verifying",
+      },
+    }),
+  );
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "daemon.update.response",
+      payload: {
+        requestId: "req-update",
+        success: true,
+        error: null,
+        previousVersion: "0.1.106",
+        newVersion: "0.1.107",
+      },
+    }),
+  );
+
+  await expect(response).resolves.toMatchObject({
+    requestId: "req-update",
+    success: true,
+  });
+});
+
 test("sends subscribe/unsubscribe terminals messages", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -187,6 +187,17 @@ function extractCorrelatedResponseIdentity(input: unknown): CorrelatedResponseId
   }
 
   const message = envelope.message as { type?: unknown; payload?: unknown };
+  if (
+    typeof message.type !== "string" ||
+    !(
+      message.type === "rpc_error" ||
+      message.type.endsWith("_response") ||
+      message.type.endsWith(".response") ||
+      message.type.endsWith("/response")
+    )
+  ) {
+    return null;
+  }
   if (!message.payload || typeof message.payload !== "object") {
     return null;
   }
@@ -198,7 +209,7 @@ function extractCorrelatedResponseIdentity(input: unknown): CorrelatedResponseId
 
   return {
     requestId: payload.requestId,
-    ...(typeof message.type === "string" ? { responseType: message.type } : {}),
+    responseType: message.type,
   };
 }
 

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -176,6 +176,32 @@ function normalizePassword(value: string | undefined): string | null {
   return value.length > 0 ? value : null;
 }
 
+function extractCorrelatedResponseIdentity(input: unknown): CorrelatedResponseIdentity | null {
+  if (!input || typeof input !== "object") {
+    return null;
+  }
+
+  const envelope = input as { type?: unknown; message?: unknown };
+  if (envelope.type !== "session" || !envelope.message || typeof envelope.message !== "object") {
+    return null;
+  }
+
+  const message = envelope.message as { type?: unknown; payload?: unknown };
+  if (!message.payload || typeof message.payload !== "object") {
+    return null;
+  }
+
+  const payload = message.payload as { requestId?: unknown };
+  if (typeof payload.requestId !== "string") {
+    return null;
+  }
+
+  return {
+    requestId: payload.requestId,
+    ...(typeof message.type === "string" ? { responseType: message.type } : {}),
+  };
+}
+
 export type {
   DaemonTransport,
   DaemonTransportFactory,
@@ -789,11 +815,22 @@ interface Waiter<T> {
   resolve(value: T): void;
   reject(error: Error): void;
   timeoutHandle: ReturnType<typeof setTimeout> | null;
+  requestId?: string;
 }
 
 interface WaitHandle<T> {
   promise: Promise<T>;
   cancel: (error: Error) => void;
+}
+
+interface WaitOptions {
+  skipQueue?: boolean;
+  requestId?: string;
+}
+
+interface CorrelatedResponseIdentity {
+  requestId: string;
+  responseType?: string;
 }
 
 interface PendingBinaryFileRead {
@@ -845,6 +882,20 @@ class DaemonRpcError extends Error {
     this.requestId = params.requestId;
     this.requestType = params.requestType;
     this.code = params.code;
+  }
+}
+
+class DaemonProtocolError extends Error {
+  readonly requestId: string;
+  readonly responseType?: string;
+  readonly code = "invalid_response";
+
+  constructor(identity: CorrelatedResponseIdentity) {
+    const responseLabel = identity.responseType ?? "unknown response";
+    super(`Response validation failed for ${responseLabel}`);
+    this.name = "DaemonProtocolError";
+    this.requestId = identity.requestId;
+    this.responseType = identity.responseType;
   }
 }
 
@@ -1548,7 +1599,7 @@ export class DaemonClient {
         return { kind: "ok", value };
       },
       timeout,
-      params.options,
+      { ...params.options, requestId: params.requestId },
     );
 
     try {
@@ -4934,14 +4985,22 @@ export class DaemonClient {
 
     const parsed = validateWSOutboundMessage(parsedJson);
     if (!parsed.success) {
-      const msgType =
+      const responseIdentity = extractCorrelatedResponseIdentity(parsedJson);
+      const envelopeType =
         parsedJson != null &&
         typeof parsedJson === "object" &&
         "type" in parsedJson &&
         typeof parsedJson.type === "string"
           ? parsedJson.type
           : "unknown";
+      const msgType = responseIdentity?.responseType ?? envelopeType;
       this.logger.warn({ msgType, error: parsed.error.message }, "Message validation failed");
+      if (responseIdentity) {
+        this.rejectWaitersForRequestId(
+          responseIdentity.requestId,
+          new DaemonProtocolError(responseIdentity),
+        );
+      }
       return;
     }
 
@@ -5262,6 +5321,19 @@ export class DaemonClient {
     }
   }
 
+  private rejectWaitersForRequestId(requestId: string, error: Error): void {
+    for (const waiter of Array.from(this.waiters)) {
+      if (waiter.requestId !== requestId) {
+        continue;
+      }
+      this.waiters.delete(waiter);
+      if (waiter.timeoutHandle) {
+        clearTimeout(waiter.timeoutHandle);
+      }
+      waiter.reject(error);
+    }
+  }
+
   private clearWaiters(error: Error): void {
     for (const waiter of Array.from(this.waiters)) {
       if (waiter.timeoutHandle) {
@@ -5331,7 +5403,7 @@ export class DaemonClient {
   private waitForWithCancel<T>(
     predicate: (msg: SessionOutboundMessage) => T | null,
     timeout = 30000,
-    _options?: { skipQueue?: boolean },
+    options?: WaitOptions,
   ): WaitHandle<T> {
     // Capture stack trace at call site, not inside setTimeout
     const timeoutError = new Error(`Timeout waiting for message (${timeout}ms)`);
@@ -5368,6 +5440,7 @@ export class DaemonClient {
         resolve: wrappedResolve,
         reject: wrappedReject,
         timeoutHandle,
+        requestId: options?.requestId,
       };
       this.waiters.add(waiter);
     });


### PR DESCRIPTION
### Linked issue

Reported in the [Paseo Discord thread](https://discord.com/channels/1481169421832814616/1527025346602336427).

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

When a daemon response carried the expected request ID but failed protocol validation, the client discarded it before request matching. The caller then waited for the full RPC timeout and showed a misleading timeout error.

The client now preserves only the correlation identity from an invalid response envelope, rejects the matching request with a protocol-validation error, and continues withholding the invalid payload from normal message consumers.

### How did you verify it

- Added a regression test that first reproduced the failure as `Timeout waiting for message (1ms)` despite a matching request ID.
- Confirmed the test passes with an immediate correlated validation error after the fix.
- Ran `npx vitest run packages/client/src/daemon-client.test.ts --bail=1`: 100 tests passed.
- Ran `npm run typecheck` successfully.
- Ran targeted lint successfully and `npm run format`.

No extra platform verification is needed: this changes the shared TypeScript client boundary and the client unit suite covers the affected transport behavior.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI changes)
- [x] Tests added or updated where it made sense