### PR TITLE
Fix OMP imports with leading title records

### DIFF
--- a/packages/server/src/server/agent/providers/pi/session-descriptor.test.ts
+++ b/packages/server/src/server/agent/providers/pi/session-descriptor.test.ts
@@ -13,6 +13,51 @@ async function writeSession(root: string, lines: unknown[]): Promise<string> {
   return filePath;
 }
 
+test("lists OMP sessions with a title record before the session header", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "paseo-omp-leading-title-"));
+  const cwd = path.join(root, "repo");
+  const sessionFile = await writeSession(root, [
+    {
+      type: "title",
+      v: 1,
+      title: "Leading metadata title",
+      updatedAt: "2026-06-09T00:00:00.000Z",
+    },
+    {
+      type: "session",
+      version: 3,
+      id: "session-with-leading-title",
+      timestamp: "2026-06-09T00:00:01.000Z",
+      cwd,
+    },
+    {
+      type: "message",
+      id: "user-1",
+      timestamp: "2026-06-09T00:00:02.000Z",
+      message: { role: "user", content: "import this session" },
+    },
+    {
+      type: "session_info",
+      id: "info-1",
+      timestamp: "2026-06-09T00:00:03.000Z",
+      name: "Imported OMP session",
+    },
+  ]);
+
+  const sessions = await listPiImportableSessions({ sessionDir: path.join(root, "sessions") });
+
+  expect(sessions).toEqual([
+    {
+      providerHandleId: sessionFile,
+      cwd,
+      title: "Imported OMP session",
+      firstPromptPreview: "import this session",
+      lastPromptPreview: "import this session",
+      lastActivityAt: new Date("2026-06-09T00:00:02.000Z"),
+    },
+  ]);
+});
+
 test("Pi import config preserves the latest recorded model and thinking level", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "paseo-pi-session-model-"));
   const cwd = path.join(root, "repo");

--- a/packages/server/src/server/agent/providers/pi/session-descriptor.ts
+++ b/packages/server/src/server/agent/providers/pi/session-descriptor.ts
@@ -201,9 +201,7 @@ async function readPiImportableSession(
 }
 
 async function readPiSessionDescriptor(filePath: string): Promise<PiSessionDescriptor | null> {
-  const firstLine = await readFirstLine(filePath);
-  if (!firstLine) return null;
-  const header = parseSessionHeader(firstLine);
+  const header = await readSessionHeader(filePath);
   if (!header) return null;
 
   const tail = await readTail(filePath).catch(() => "");
@@ -233,16 +231,19 @@ function toPiImportSessionConfig(descriptor: PiSessionDescriptor): PiImportSessi
   };
 }
 
-async function readFirstLine(filePath: string): Promise<string | null> {
+async function readSessionHeader(filePath: string): Promise<PiSessionHeader | null> {
   const handle = await open(filePath, "r").catch(() => null);
   if (!handle) return null;
   try {
     const buffer = Buffer.alloc(HEAD_BYTES);
     const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
     if (bytesRead <= 0) return null;
-    const chunk = buffer.subarray(0, bytesRead).toString("utf8");
-    const newlineIndex = chunk.indexOf("\n");
-    return (newlineIndex === -1 ? chunk : chunk.slice(0, newlineIndex)).trim();
+    const lines = buffer.subarray(0, bytesRead).toString("utf8").split(/\r?\n/u);
+    for (const line of lines) {
+      const header = parseSessionHeader(line.trim());
+      if (header) return header;
+    }
+    return null;
   } finally {
     await handle.close().catch(() => undefined);
   }
@@ -270,8 +271,8 @@ async function readFileMtime(filePath: string): Promise<Date | null> {
   }
 }
 
-function parseSessionHeader(firstLine: string): PiSessionHeader | null {
-  const entry = parseJsonRecord(firstLine);
+function parseSessionHeader(line: string): PiSessionHeader | null {
+  const entry = parseJsonRecord(line);
   if (!entry || entry.type !== "session") return null;
   const sessionId = typeof entry.id === "string" ? entry.id : null;
   const cwd = typeof entry.cwd === "string" ? entry.cwd : null;


### PR DESCRIPTION
### Linked issue

Closes #2006

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

OMP session files can start with a `title` metadata record before the `session` record. The import parser previously checked only the first line, so it rejected those files and omitted them from the import list.

This changes the parser to scan the existing bounded 64 KiB file prefix for the first valid session header. The rest of the import path remains unchanged, including title, prompt, model, and thinking-level extraction.

### How did you verify it

- Added a regression test using a real temporary JSONL file with `title` before `session`.
- Before the implementation, `npx vitest run packages/server/src/server/agent/providers/pi/session-descriptor.test.ts --bail=1` failed because the import result was `[]`.
- After the implementation, the same command passed all 4 tests.
- `npm run build:server` passed.
- `npm run typecheck` passed for all workspaces.
- `npm run lint` passed with 0 warnings and 0 errors.
- `npm run format` completed successfully.

No UI behavior changed, so screenshots are not applicable.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; server-only change)
- [x] Tests added or updated where it made sense
