### PR TITLE
feat(server): attribute agent-to-agent messages with a sender envelope

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -63,6 +63,29 @@ The Layer 2 block rides on the child's first user message, but the timeline must
 `displayTextForUserMessage` (`agent-prompt.ts`) extends the existing "hide a pure `<paseo-system>` envelope" rule: a message that begins with a system envelope and then has real content has the leading envelope stripped for display, while the provider still receives the full text.
 The four timeline choke points in `agent-manager.ts` route through `projectTimelineItemForDisplay`, so both live turns and history replay show the clean parent prompt.
 
+## Agent-to-agent message envelope
+
+When one agent calls `send_agent_prompt` targeting another, the receiver used to get the text verbatim - unable to tell it came from an agent (vs a human, a schedule, or a finish notification) or whom to reply to.
+The daemon now wraps agent-initiated sends in a sender-identity envelope, composed by `buildAgentMessageEnvelope` in `agent-spawn-context.ts` and applied in the `send_agent_prompt` handler **only when `callerAgentId` is present**.
+Human/app sends and other system paths (chat mentions, schedule fires, notify-on-finish) are untouched.
+
+**Envelope format.**
+The prompt is wrapped in an attributed tag: `<paseo-agent-message from="<senderId>" from_title="<title>">\n<prompt>\n</paseo-agent-message>`, followed by a trailing reply-contract line.
+This is deliberately **not** a `<paseo-system>` envelope: it must not match `SYSTEM_ENVELOPE_PATTERN` / `isSystemInjectedEnvelope`, because a full match would hide the message from the receiver's timeline (round-1 behavior) - and sender attribution is exactly what a human viewing the receiver wants to see.
+It also keeps the archived-target delivery path intact: `send_agent_prompt` calls `sendPromptToAgent` with `unarchive` defaulting to true, and because the message is not a system envelope it cannot accidentally flip that gate.
+
+**Reply contract (conditional, like the spawn-context wording).**
+The handler already arms `setupFinishNotification` back to the sender for agent-scoped background sends (`shouldNotifyOnFinish = callerAgentId && notifyOnFinish && background`).
+When that is set, the envelope tells the receiver its final idle message is automatically delivered back to the sender as its reply.
+Otherwise it tells the receiver the reply is not automatic and to use `send_agent_prompt` with the sender's agentId.
+
+**Timeline display.**
+Unlike spawn context (stripped entirely), sender attribution is useful, so `projectAgentMessageForDisplay` rewrites the turn to a compact `Message from agent <id> (<title>):` header followed by the original prompt, dropping the trailing reply-contract boilerplate.
+It runs through the same daemon-side `projectTimelineItemForDisplay` choke points, so every client - including old ones - sees the readable form.
+The receiving model still gets the full envelope (identity + reply contract) in the dispatched prompt.
+
+`composeAgentMcpInstructions` (Layer 1) also teaches every agent to recognize `<paseo-agent-message>` turns, read the `from` id, and reply via `send_agent_prompt` (or rely on the automatic relay when the envelope says so).
+
 ## Archive
 
 Archive is a **soft delete**: the agent record stays on disk with `archivedAt` set, the runtime is closed, and the agent disappears from active lists. Archive is **global** — it lives on the server and propagates to every connected client.

--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -36,6 +36,33 @@ Users can also detach an existing subagent from the subagents track. Detach remo
 
 `notifyOnFinish` defaults to `true` for agent-scoped creation and background prompt follow-ups because most delegated work needs to report back to the creating agent. Set it to `false` only for truly fire-and-forget agents or prompts.
 
+## Automatic spawn-context injection
+
+Spawned agents used to receive only the parent-authored `initialPrompt`, so a child had no deterministic way to know it runs inside a multi-agent environment, who spawned it, or that its last idle message is auto-delivered to the parent as its report.
+That awareness is now injected by the daemon on two layers, so no parent model has to hand-write a protocol block.
+
+Both layers are composed by `composeAgentMcpInstructions` / `buildSpawnContextEnvelope` in `packages/server/src/server/agent/agent-spawn-context.ts`.
+
+**Layer 1 - per-agent MCP server instructions.**
+`createAgentMcpSession(callerAgentId)` (`bootstrap.ts`) looks up the connecting agent's own record, reads its `paseo.parent-agent-id` label plus the parent's title, and composes a personalized `instructions` string that is passed to the MCP `McpServer` constructor.
+Providers that surface MCP server instructions in their system prompt (Claude Code, per the claude-peers prior art) make the agent "born knowing" its id, its parent, the `<paseo-system>` / `<agent-response>` semantics, and the delegation contract for when it spawns its own children.
+External MCP clients (no `callerAgentId`) still get the generic delegation contract, minus the identity/parent lines.
+
+**Layer 2 - daemon-side spawn-context block.**
+MCP instructions only help providers that surface them, so Layer 1 is not sufficient on its own.
+When a create comes from another agent (`callerAgentId` present), `createAgentCommand` prepends a compact `<paseo-system>` block - naming the child, the parent, and the report contract - to the child's initial prompt before dispatch (`prependSpawnContext`).
+This is applied after `createAgent` returns, because the block names the child's own id.
+The block is short by design: it duplicates only the identity + report-contract core of Layer 1, so agents on providers that already surface MCP instructions are not bloated with a second full copy.
+
+**Report contract wording follows `notifyOnFinish`, not the relationship kind.**
+The "your final message is automatically delivered to the parent as your report" sentence is emitted only when `notifyOnFinish` is set (the same flag that arms `setupFinishNotification`).
+A detached spawn still gets the identity/environment context, but is told its final message is not auto-delivered unless the parent follows up.
+
+**Timeline display.**
+The Layer 2 block rides on the child's first user message, but the timeline must still show only what the parent actually asked.
+`displayTextForUserMessage` (`agent-prompt.ts`) extends the existing "hide a pure `<paseo-system>` envelope" rule: a message that begins with a system envelope and then has real content has the leading envelope stripped for display, while the provider still receives the full text.
+The four timeline choke points in `agent-manager.ts` route through `projectTimelineItemForDisplay`, so both live turns and history replay show the clean parent prompt.
+
 ## Archive
 
 Archive is a **soft delete**: the agent record stays on disk with `archivedAt` set, the runtime is closed, and the agent disappears from active lists. Archive is **global** — it lives on the server and propagates to every connected client.

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7631,6 +7631,43 @@ test("user_message events wrapping a paseo-system envelope are not added to the 
   expect(userMessages[0].text).toBe("plain user message");
 });
 
+test("user_message events with a leading paseo-system block show only the trailing prompt", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-envelope-leading-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  const spawnContext = formatSystemNotificationPrompt(
+    "You are agent child-1, spawned by agent parent-1 inside Paseo's multi-agent environment.",
+  );
+  const codex = fakeCodexEmitting({
+    turnItems: [
+      {
+        type: "user_message",
+        text: `${spawnContext}\n\nImplement the feature`,
+      },
+    ],
+  });
+
+  const manager = new AgentManager({
+    clients: { codex },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-0000000005a3",
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+
+  await manager.runAgent(snapshot.id, { text: "do something" });
+
+  const timeline = manager.getTimeline(snapshot.id);
+  const userMessages = timeline.filter((item) => item.type === "user_message");
+
+  expect(userMessages).toHaveLength(1);
+  expect(userMessages[0].text).toBe("Implement the feature");
+});
+
 test("user_message events wrapping a paseo-system envelope are not restored during history replay", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-envelope-history-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7668,6 +7668,42 @@ test("user_message events with a leading paseo-system block show only the traili
   expect(userMessages[0].text).toBe("Implement the feature");
 });
 
+test("user_message events wrapping an agent-to-agent envelope show a readable sender header", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-sender-envelope-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  const senderEnvelope =
+    '<paseo-agent-message from="agent-a" from_title="Ship the release">\n' +
+    "Please review the auth changes.\n" +
+    "</paseo-agent-message>\n\n" +
+    "When you finish this turn and go idle, your last assistant message is automatically delivered back to agent agent-a as your reply - make it complete and self-contained.";
+  const codex = fakeCodexEmitting({
+    turnItems: [{ type: "user_message", text: senderEnvelope }],
+  });
+
+  const manager = new AgentManager({
+    clients: { codex },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-0000000005a4",
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+
+  await manager.runAgent(snapshot.id, { text: "do something" });
+
+  const timeline = manager.getTimeline(snapshot.id);
+  const userMessages = timeline.filter((item) => item.type === "user_message");
+
+  expect(userMessages).toHaveLength(1);
+  expect(userMessages[0].text).toBe(
+    "Message from agent agent-a (Ship the release):\n\nPlease review the auth changes.",
+  );
+});
+
 test("user_message events wrapping a paseo-system envelope are not restored during history replay", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-envelope-history-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -63,6 +63,7 @@ import { AgentRunState, type ForegroundTurnWaiter } from "./agent-run-state.js";
 import { getAgentProviderDefinition } from "@getpaseo/protocol/provider-manifest";
 import { invokeRewindCapability, type RewindMode } from "./rewind/rewind.js";
 import { displayTextForUserMessage } from "./agent-prompt.js";
+import { projectAgentMessageForDisplay } from "./agent-spawn-context.js";
 import { stripInternalPaseoMcpServer, withRuntimePaseoMcpServer } from "./runtime-mcp-config.js";
 import { resolveCreateAgentTitles } from "./create-agent-title.js";
 import type { PaseoToolCatalogFactory } from "./tools/types.js";
@@ -505,10 +506,12 @@ function buildExplicitTimelineSeedForRegister(
   };
 }
 
-// Shapes a timeline item for display: drops fully system-injected user messages
-// and trims a leading <paseo-system> spawn-context block off the visible first
-// user message. The provider already received the full text; this only affects
-// what the timeline shows. Returns null when the item should be hidden.
+// Shapes a timeline item for display: drops fully system-injected user messages,
+// trims a leading <paseo-system> spawn-context block off the visible first user
+// message, and rewrites an agent-to-agent <paseo-agent-message> turn to a
+// readable "Message from agent ..." header. The provider already received the
+// full text; this only affects what the timeline shows. Returns null when the
+// item should be hidden.
 function projectTimelineItemForDisplay<Item extends AgentTimelineItem>(item: Item): Item | null {
   if (item.type !== "user_message") {
     return item;
@@ -517,7 +520,8 @@ function projectTimelineItemForDisplay<Item extends AgentTimelineItem>(item: Ite
   if (display === null) {
     return null;
   }
-  return display === item.text ? item : { ...item, text: display };
+  const projected = projectAgentMessageForDisplay(display);
+  return projected === item.text ? item : { ...item, text: projected };
 }
 
 function buildImportedTimelineRows(entries: readonly ImportedTimelineEntry[]): AgentTimelineRow[] {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -62,7 +62,7 @@ import { limitAgentTimelineItemContent } from "./agent-timeline-content.js";
 import { AgentRunState, type ForegroundTurnWaiter } from "./agent-run-state.js";
 import { getAgentProviderDefinition } from "@getpaseo/protocol/provider-manifest";
 import { invokeRewindCapability, type RewindMode } from "./rewind/rewind.js";
-import { isSystemInjectedEnvelope } from "./agent-prompt.js";
+import { displayTextForUserMessage } from "./agent-prompt.js";
 import { stripInternalPaseoMcpServer, withRuntimePaseoMcpServer } from "./runtime-mcp-config.js";
 import { resolveCreateAgentTitles } from "./create-agent-title.js";
 import type { PaseoToolCatalogFactory } from "./tools/types.js";
@@ -505,16 +505,32 @@ function buildExplicitTimelineSeedForRegister(
   };
 }
 
+// Shapes a timeline item for display: drops fully system-injected user messages
+// and trims a leading <paseo-system> spawn-context block off the visible first
+// user message. The provider already received the full text; this only affects
+// what the timeline shows. Returns null when the item should be hidden.
+function projectTimelineItemForDisplay<Item extends AgentTimelineItem>(item: Item): Item | null {
+  if (item.type !== "user_message") {
+    return item;
+  }
+  const display = displayTextForUserMessage(item.text);
+  if (display === null) {
+    return null;
+  }
+  return display === item.text ? item : { ...item, text: display };
+}
+
 function buildImportedTimelineRows(entries: readonly ImportedTimelineEntry[]): AgentTimelineRow[] {
   const rows: AgentTimelineRow[] = [];
   for (const entry of entries) {
-    if (entry.item.type === "user_message" && isSystemInjectedEnvelope(entry.item.text)) {
+    const displayItem = projectTimelineItemForDisplay(entry.item);
+    if (!displayItem) {
       continue;
     }
     rows.push({
       seq: rows.length + 1,
       timestamp: entry.timestamp ?? new Date().toISOString(),
-      item: limitAgentTimelineItemContent(entry.item),
+      item: limitAgentTimelineItemContent(displayItem),
     });
   }
   return rows;
@@ -3008,10 +3024,11 @@ export class AgentManager {
     const providerSubagentEvents: Extract<AgentStreamEvent, { type: "provider_subagent" }>[] = [];
     for await (const event of agent.session.streamHistory()) {
       if (event.type === "timeline") {
-        if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
+        const displayItem = projectTimelineItemForDisplay(event.item);
+        if (!displayItem) {
           continue;
         }
-        historyEvents.push(event);
+        historyEvents.push(displayItem === event.item ? event : { ...event, item: displayItem });
       } else if (event.type === "provider_subagent") {
         providerSubagentEvents.push(event);
       }
@@ -3069,12 +3086,13 @@ export class AgentManager {
         if (event.type !== "timeline") {
           continue;
         }
-        if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
+        const displayItem = projectTimelineItemForDisplay(event.item);
+        if (!displayItem) {
           continue;
         }
         this.recordTimeline(
           agent.id,
-          event.item,
+          displayItem,
           event.timestamp ? { timestamp: event.timestamp } : undefined,
         );
       }
@@ -3328,7 +3346,8 @@ export class AgentManager {
   }): Promise<void> {
     const { agent, event, options, flags } = params;
 
-    if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
+    const displayItem = projectTimelineItemForDisplay(event.item);
+    if (!displayItem) {
       flags.shouldDispatchEvent = false;
       flags.shouldNotifyWaiters = false;
       return;
@@ -3337,7 +3356,7 @@ export class AgentManager {
     if (options?.fromHistory) {
       this.recordTimeline(
         agent.id,
-        event.item,
+        displayItem,
         event.timestamp ? { timestamp: event.timestamp } : undefined,
       );
       flags.shouldDispatchEvent = false;
@@ -3345,7 +3364,7 @@ export class AgentManager {
       return;
     }
 
-    this.recordAndDispatchTimelineItem(agent.id, event.item, event.provider, event.turnId);
+    this.recordAndDispatchTimelineItem(agent.id, displayItem, event.provider, event.turnId);
     if (event.item.type === "user_message") {
       agent.lastUserMessageAt = new Date();
       this.emitState(agent);

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -115,6 +115,29 @@ export function isSystemInjectedEnvelope(text: string): boolean {
   return SYSTEM_ENVELOPE_PATTERN.test(text);
 }
 
+// Matches a <paseo-system> block at the START of a message that has further
+// content after it (spawn-context injection: envelope + blank line + prompt).
+// Non-greedy so the first closing tag ends the envelope.
+const LEADING_SYSTEM_ENVELOPE_PATTERN = /^<paseo-system>\n[\s\S]*?\n<\/paseo-system>\n\n/;
+
+/**
+ * Resolve what a user_message should display in the timeline once daemon-injected
+ * context is accounted for:
+ * - `null` when the whole message is a system envelope (hide it entirely).
+ * - the trailing body when an envelope only prefixes real content, so the
+ *   visible first message is exactly what the parent/user asked for.
+ * - the text unchanged otherwise.
+ *
+ * The provider still receives the full text; this only shapes the display echo.
+ */
+export function displayTextForUserMessage(text: string): string | null {
+  if (isSystemInjectedEnvelope(text)) {
+    return null;
+  }
+  const leadingEnvelope = LEADING_SYSTEM_ENVELOPE_PATTERN.exec(text);
+  return leadingEnvelope ? text.slice(leadingEnvelope[0].length) : text;
+}
+
 export interface SendPromptToAgentParams {
   agentManager: AgentManager;
   agentStorage: AgentStorage;

--- a/packages/server/src/server/agent/agent-spawn-context.test.ts
+++ b/packages/server/src/server/agent/agent-spawn-context.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildAgentMessageEnvelope,
   buildSpawnContextEnvelope,
   composeAgentMcpInstructions,
   prependSpawnContext,
+  projectAgentMessageForDisplay,
 } from "./agent-spawn-context.js";
-import { isSystemInjectedEnvelope } from "./agent-prompt.js";
+import { displayTextForUserMessage, isSystemInjectedEnvelope } from "./agent-prompt.js";
 
 describe("composeAgentMcpInstructions", () => {
   it("states the agent's own id and the parent report contract for a spawned child", () => {
@@ -20,6 +22,14 @@ describe("composeAgentMcpInstructions", () => {
     expect(instructions).toContain("AUTOMATICALLY delivered to that agent as your report");
     expect(instructions).toContain("<agent-response>");
     expect(instructions).toContain("do NOT need to copy any protocol block");
+  });
+
+  it("teaches the agent-to-agent message envelope and how to reply", () => {
+    const instructions = composeAgentMcpInstructions({ callerAgentId: "agent-child" });
+
+    expect(instructions).toContain("<paseo-agent-message");
+    expect(instructions).toContain("was sent to you by another agent");
+    expect(instructions).toContain("reply via send_agent_prompt to that id");
   });
 
   it("omits the parent report contract when the caller has no parent", () => {
@@ -116,5 +126,111 @@ describe("prependSpawnContext", () => {
       { type: "text", text: `${envelope}\n\n` },
       { type: "image", data: "abc", mimeType: "image/png" },
     ]);
+  });
+});
+
+describe("buildAgentMessageEnvelope", () => {
+  it("wraps the prompt with sender identity and the auto-reply contract", () => {
+    const envelope = buildAgentMessageEnvelope({
+      senderAgentId: "agent-a",
+      senderTitle: "Ship the release",
+      prompt: "Please review the auth changes.",
+      autoReply: true,
+    });
+
+    expect(envelope).toBe(
+      '<paseo-agent-message from="agent-a" from_title="Ship the release">\n' +
+        "Please review the auth changes.\n" +
+        "</paseo-agent-message>\n\n" +
+        "When you finish this turn and go idle, your last assistant message is automatically delivered back to agent agent-a as your reply - make it complete and self-contained.",
+    );
+  });
+
+  it("states manual reply when auto-delivery is off", () => {
+    const envelope = buildAgentMessageEnvelope({
+      senderAgentId: "agent-a",
+      senderTitle: null,
+      prompt: "fyi",
+      autoReply: false,
+    });
+
+    expect(envelope).toContain('<paseo-agent-message from="agent-a">\nfyi\n</paseo-agent-message>');
+    expect(envelope).not.toContain("from_title=");
+    expect(envelope).toContain(
+      "Your reply is not automatically delivered; reach the sender via send_agent_prompt with agentId agent-a",
+    );
+  });
+
+  it("is not a system envelope, so it is never hidden from the timeline", () => {
+    const envelope = buildAgentMessageEnvelope({
+      senderAgentId: "agent-a",
+      senderTitle: "Ship",
+      prompt: "hi",
+      autoReply: true,
+    });
+
+    expect(isSystemInjectedEnvelope(envelope)).toBe(false);
+    // The timeline system-envelope projection leaves it intact for the sender
+    // projection to handle.
+    expect(displayTextForUserMessage(envelope)).toBe(envelope);
+  });
+
+  it("escapes XML-significant characters in the sender title", () => {
+    const envelope = buildAgentMessageEnvelope({
+      senderAgentId: "agent-a",
+      senderTitle: 'A & B <"tricky">',
+      prompt: "hi",
+      autoReply: true,
+    });
+
+    expect(envelope).toContain('from_title="A &amp; B &lt;&quot;tricky&quot;&gt;"');
+    expect(projectAgentMessageForDisplay(envelope)).toContain(
+      'Message from agent agent-a (A & B <"tricky">):',
+    );
+  });
+});
+
+describe("projectAgentMessageForDisplay", () => {
+  it("rewrites a sender envelope to a readable header plus the original prompt", () => {
+    const envelope = buildAgentMessageEnvelope({
+      senderAgentId: "agent-a",
+      senderTitle: "Ship the release",
+      prompt: "Please review the auth changes.",
+      autoReply: true,
+    });
+
+    expect(projectAgentMessageForDisplay(envelope)).toBe(
+      "Message from agent agent-a (Ship the release):\n\nPlease review the auth changes.",
+    );
+  });
+
+  it("drops the trailing reply-contract boilerplate from the visible message", () => {
+    const envelope = buildAgentMessageEnvelope({
+      senderAgentId: "agent-a",
+      senderTitle: null,
+      prompt: "Do the thing",
+      autoReply: false,
+    });
+
+    const projected = projectAgentMessageForDisplay(envelope);
+    expect(projected).toBe("Message from agent agent-a:\n\nDo the thing");
+    expect(projected).not.toContain("send_agent_prompt");
+  });
+
+  it("preserves multi-paragraph prompts inside the envelope", () => {
+    const envelope = buildAgentMessageEnvelope({
+      senderAgentId: "agent-a",
+      senderTitle: "Reviewer",
+      prompt: "First line.\n\nSecond paragraph.",
+      autoReply: true,
+    });
+
+    expect(projectAgentMessageForDisplay(envelope)).toBe(
+      "Message from agent agent-a (Reviewer):\n\nFirst line.\n\nSecond paragraph.",
+    );
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(projectAgentMessageForDisplay("just a normal prompt")).toBe("just a normal prompt");
   });
 });

--- a/packages/server/src/server/agent/agent-spawn-context.test.ts
+++ b/packages/server/src/server/agent/agent-spawn-context.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSpawnContextEnvelope,
+  composeAgentMcpInstructions,
+  prependSpawnContext,
+} from "./agent-spawn-context.js";
+import { isSystemInjectedEnvelope } from "./agent-prompt.js";
+
+describe("composeAgentMcpInstructions", () => {
+  it("states the agent's own id and the parent report contract for a spawned child", () => {
+    const instructions = composeAgentMcpInstructions({
+      callerAgentId: "agent-child",
+      parentAgentId: "agent-parent",
+      parentTitle: "Ship the release",
+    });
+
+    expect(instructions).toContain("Your agentId is agent-child.");
+    expect(instructions).toContain("spawned by agent agent-parent (Ship the release)");
+    expect(instructions).toContain("AUTOMATICALLY delivered to that agent as your report");
+    expect(instructions).toContain("<agent-response>");
+    expect(instructions).toContain("do NOT need to copy any protocol block");
+  });
+
+  it("omits the parent report contract when the caller has no parent", () => {
+    const instructions = composeAgentMcpInstructions({ callerAgentId: "agent-root" });
+
+    expect(instructions).toContain("Your agentId is agent-root.");
+    expect(instructions).not.toContain("spawned by agent");
+    expect(instructions).not.toContain("delivered to that agent as your report");
+    expect(instructions).toContain("When you spawn children with create_agent");
+  });
+
+  it("drops identity lines entirely for external clients with no caller agent", () => {
+    const instructions = composeAgentMcpInstructions({});
+
+    expect(instructions).not.toContain("Your agentId is");
+    expect(instructions).not.toContain("spawned by agent");
+    expect(instructions).toContain("You are connected to Paseo");
+    expect(instructions).toContain("When you spawn children with create_agent");
+  });
+
+  it("falls back to the bare parent id when no title resolves", () => {
+    const instructions = composeAgentMcpInstructions({
+      callerAgentId: "agent-child",
+      parentAgentId: "agent-parent",
+      parentTitle: null,
+    });
+
+    expect(instructions).toContain("spawned by agent agent-parent.");
+    expect(instructions).not.toContain("agent-parent (");
+  });
+
+  it("stays compact enough to live in a system prompt", () => {
+    const instructions = composeAgentMcpInstructions({
+      callerAgentId: "agent-child",
+      parentAgentId: "agent-parent",
+      parentTitle: "Ship the release",
+    });
+
+    expect(instructions.split(/\s+/).length).toBeLessThan(600);
+  });
+});
+
+describe("buildSpawnContextEnvelope", () => {
+  it("promises automatic report delivery when notifyOnFinish is set", () => {
+    const envelope = buildSpawnContextEnvelope({
+      childAgentId: "agent-child",
+      parentAgentId: "agent-parent",
+      parentTitle: "Ship the release",
+      notifyOnFinish: true,
+    });
+
+    expect(isSystemInjectedEnvelope(envelope)).toBe(true);
+    expect(envelope).toContain(
+      "You are agent agent-child, spawned by agent agent-parent (Ship the release)",
+    );
+    expect(envelope).toContain("automatically delivered to agent agent-parent as your report");
+  });
+
+  it("states no automatic delivery when notifyOnFinish is unset", () => {
+    const envelope = buildSpawnContextEnvelope({
+      childAgentId: "agent-child",
+      parentAgentId: "agent-parent",
+      parentTitle: null,
+      notifyOnFinish: false,
+    });
+
+    expect(isSystemInjectedEnvelope(envelope)).toBe(true);
+    expect(envelope).toContain("not automatically delivered back");
+    expect(envelope).toContain("agent agent-parent follows up if it needs your result");
+  });
+});
+
+describe("prependSpawnContext", () => {
+  const envelope = buildSpawnContextEnvelope({
+    childAgentId: "agent-child",
+    parentAgentId: "agent-parent",
+    parentTitle: "Ship the release",
+    notifyOnFinish: true,
+  });
+
+  it("prepends the envelope and a blank line to a string prompt", () => {
+    const result = prependSpawnContext("Do the work", envelope);
+
+    expect(result).toBe(`${envelope}\n\nDo the work`);
+  });
+
+  it("prepends a leading text block to a structured prompt", () => {
+    const result = prependSpawnContext(
+      [{ type: "image", data: "abc", mimeType: "image/png" }],
+      envelope,
+    );
+
+    expect(result).toEqual([
+      { type: "text", text: `${envelope}\n\n` },
+      { type: "image", data: "abc", mimeType: "image/png" },
+    ]);
+  });
+});

--- a/packages/server/src/server/agent/agent-spawn-context.ts
+++ b/packages/server/src/server/agent/agent-spawn-context.ts
@@ -1,0 +1,109 @@
+import { formatSystemNotificationPrompt } from "./agent-prompt.js";
+import type { AgentPromptInput } from "./agent-sdk-types.js";
+
+/**
+ * Deterministic, daemon-composed text that teaches every Paseo-managed agent
+ * about the multi-agent environment it runs in. Two surfaces consume this:
+ *
+ * - Layer 1 (`composeAgentMcpInstructions`) is handed to the per-agent MCP
+ *   server as its `instructions` string. Providers that surface MCP server
+ *   instructions in their system prompt (Claude Code) make the agent "born
+ *   knowing" the contract with zero per-spawn prompt discipline.
+ * - Layer 2 (`buildSpawnContextEnvelope`) is prepended to the child's initial
+ *   prompt as a `<paseo-system>` block, guaranteeing the identity/report
+ *   contract reaches agents on providers that do NOT surface MCP instructions.
+ */
+
+export interface AgentMcpInstructionsInput {
+  /** The agent that owns this MCP session (the connecting agent itself). */
+  callerAgentId?: string;
+  /** Parent linkage read from the caller's `paseo.parent-agent-id` label. */
+  parentAgentId?: string | null;
+  /** Human-facing title of the parent agent, when resolvable. */
+  parentTitle?: string | null;
+}
+
+function describeAgent(agentId: string, title: string | null | undefined): string {
+  const trimmedTitle = title?.trim();
+  return trimmedTitle ? `${agentId} (${trimmedTitle})` : agentId;
+}
+
+const DELEGATION_CONTRACT = [
+  "When you spawn children with create_agent: capture the returned agentId, leave notifyOnFinish at its default so their reports come back to you, and do NOT poll for status - the daemon notifies you when a child finishes, errors, or needs permission.",
+  "Use send_agent_prompt to follow up with a child, and list_pending_permissions plus respond_to_permission to unblock a child waiting on approval - a blocked child stays blocked until you answer.",
+].join(" ");
+
+const ENVELOPE_SEMANTICS =
+  "Messages wrapped in <paseo-system>...</paseo-system> are daemon-injected context, not user turns. A finish notification from a child you spawned carries that child's report inside <agent-response>...</agent-response>. If a <paseo-system> message relays a prompt from another agent, respond promptly and address the sender via send_agent_prompt using their agentId.";
+
+const NO_COPY_NOTE =
+  "The daemon automatically gives every spawned agent this same context - you do NOT need to copy any protocol block into a child's initialPrompt.";
+
+/**
+ * Compose the MCP `instructions` string for a connecting agent. Compact by
+ * design (well under ~600 words): it lands verbatim in the agent's system
+ * prompt on providers that surface MCP instructions.
+ */
+export function composeAgentMcpInstructions(input: AgentMcpInstructionsInput): string {
+  const paragraphs: string[] = [];
+
+  if (input.callerAgentId) {
+    paragraphs.push(
+      `You are running inside Paseo, a multi-agent environment where AI coding agents spawn, message, and supervise each other. Your agentId is ${input.callerAgentId}.`,
+    );
+    if (input.parentAgentId) {
+      paragraphs.push(
+        `You were spawned by agent ${describeAgent(input.parentAgentId, input.parentTitle)}. When you go idle, your last assistant message is AUTOMATICALLY delivered to that agent as your report. Make your final message a complete, self-contained report - the task, what you did, key findings, files changed, what failed or is uncertain, and the recommended next step. Do not end with a bare sign-off like "Done"; end with the report itself, and do not poll the parent for acknowledgement.`,
+      );
+    }
+  } else {
+    paragraphs.push(
+      "You are connected to Paseo, a multi-agent environment where AI coding agents spawn, message, and supervise each other through these tools.",
+    );
+  }
+
+  paragraphs.push(ENVELOPE_SEMANTICS, DELEGATION_CONTRACT, NO_COPY_NOTE);
+  return paragraphs.join("\n\n");
+}
+
+export interface SpawnContextInput {
+  childAgentId: string;
+  parentAgentId: string;
+  parentTitle?: string | null;
+  /**
+   * True when the daemon will auto-deliver the child's final message to the
+   * parent (create-agent's notifyOnFinish). Detached spawns can still set it;
+   * the report promise follows notifyOnFinish, not the relationship kind.
+   */
+  notifyOnFinish: boolean;
+}
+
+/**
+ * Build the short `<paseo-system>` block prepended to a child's initial prompt.
+ * Duplicates only the identity + report-contract core of the MCP instructions
+ * so agents on providers that already surface those instructions are not
+ * bloated with a second full copy.
+ */
+export function buildSpawnContextEnvelope(input: SpawnContextInput): string {
+  const identity = `You are agent ${input.childAgentId}, spawned by agent ${describeAgent(
+    input.parentAgentId,
+    input.parentTitle,
+  )} inside Paseo's multi-agent environment.`;
+  const contract = input.notifyOnFinish
+    ? `When you finish and go idle, your last assistant message is automatically delivered to agent ${input.parentAgentId} as your report. Make your final message a complete, self-contained report of the task, what you did, files changed, failures or uncertainties, and recommended next steps - never a bare sign-off.`
+    : `Your final message is not automatically delivered back; agent ${input.parentAgentId} follows up if it needs your result. Still, make your final message a complete, self-contained summary of what you did.`;
+  return formatSystemNotificationPrompt(`${identity} ${contract}`);
+}
+
+/**
+ * Prepend a spawn-context envelope to a child's initial prompt. The envelope is
+ * a self-contained `<paseo-system>` block, so the timeline layer strips it from
+ * the visible first user message (see displayTextForUserMessage) while the
+ * provider still receives it in full.
+ */
+export function prependSpawnContext(prompt: AgentPromptInput, envelope: string): AgentPromptInput {
+  if (typeof prompt === "string") {
+    return `${envelope}\n\n${prompt}`;
+  }
+  return [{ type: "text", text: `${envelope}\n\n` }, ...prompt];
+}

--- a/packages/server/src/server/agent/agent-spawn-context.ts
+++ b/packages/server/src/server/agent/agent-spawn-context.ts
@@ -34,7 +34,7 @@ const DELEGATION_CONTRACT = [
 ].join(" ");
 
 const ENVELOPE_SEMANTICS =
-  "Messages wrapped in <paseo-system>...</paseo-system> are daemon-injected context, not user turns. A finish notification from a child you spawned carries that child's report inside <agent-response>...</agent-response>. If a <paseo-system> message relays a prompt from another agent, respond promptly and address the sender via send_agent_prompt using their agentId.";
+  'Messages wrapped in <paseo-system>...</paseo-system> are daemon-injected context (schedules, finish notifications), not user turns. A finish notification from a child you spawned carries that child\'s report inside <agent-response>...</agent-response>. A turn wrapped in <paseo-agent-message from="..." from_title="...">...</paseo-agent-message> was sent to you by another agent: read the from id, respond promptly, and reply via send_agent_prompt to that id - or, when the envelope says your reply is auto-delivered, simply make your final message a complete, self-contained reply.';
 
 const NO_COPY_NOTE =
   "The daemon automatically gives every spawned agent this same context - you do NOT need to copy any protocol block into a child's initialPrompt.";
@@ -106,4 +106,97 @@ export function prependSpawnContext(prompt: AgentPromptInput, envelope: string):
     return `${envelope}\n\n${prompt}`;
   }
   return [{ type: "text", text: `${envelope}\n\n` }, ...prompt];
+}
+
+// --- Agent-to-agent sender envelope ---------------------------------------
+//
+// When one agent sends a prompt to another via send_agent_prompt, the receiver
+// used to get the text verbatim with no way to tell it came from an agent or
+// whom to reply to. buildAgentMessageEnvelope wraps the prompt in an attributed
+// <paseo-agent-message> tag carrying the sender's identity plus a reply
+// contract. The tag is deliberately NOT a <paseo-system> envelope: it must not
+// match SYSTEM_ENVELOPE_PATTERN (which would hide it from the timeline and can
+// gate archived-target delivery), and sender attribution is useful for a human
+// reading the receiver's timeline, so it is projected to a readable header
+// rather than stripped.
+
+const AGENT_MESSAGE_TAG = "paseo-agent-message";
+
+// Attribute values (the sender title) may contain arbitrary characters. Escape
+// the five XML-significant ones so `from_title="..."` parses unambiguously and
+// no title can break out of the tag.
+function escapeAttributeValue(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function unescapeAttributeValue(value: string): string {
+  return value
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&amp;/g, "&");
+}
+
+export interface AgentMessageEnvelopeInput {
+  senderAgentId: string;
+  senderTitle?: string | null;
+  prompt: string;
+  /**
+   * True when the daemon will auto-relay the receiver's final message back to
+   * the sender (send_agent_prompt's notify-on-finish path). Drives the reply
+   * contract wording, mirroring the spawn-context notifyOnFinish gate.
+   */
+  autoReply: boolean;
+}
+
+/**
+ * Wrap a sender's prompt in an attributed <paseo-agent-message> tag. The tag
+ * wraps only the original prompt; the reply contract rides as a trailing
+ * model-only line that the timeline projection drops for display.
+ */
+export function buildAgentMessageEnvelope(input: AgentMessageEnvelopeInput): string {
+  const trimmedTitle = input.senderTitle?.trim();
+  const titleAttribute = trimmedTitle ? ` from_title="${escapeAttributeValue(trimmedTitle)}"` : "";
+  const replyContract = input.autoReply
+    ? `When you finish this turn and go idle, your last assistant message is automatically delivered back to agent ${input.senderAgentId} as your reply - make it complete and self-contained.`
+    : `Your reply is not automatically delivered; reach the sender via send_agent_prompt with agentId ${input.senderAgentId} if a response is needed.`;
+  return `<${AGENT_MESSAGE_TAG} from="${input.senderAgentId}"${titleAttribute}>\n${input.prompt}\n</${AGENT_MESSAGE_TAG}>\n\n${replyContract}`;
+}
+
+// Matches a leading <paseo-agent-message ...> block (the tag wraps the original
+// prompt; anything after the close tag is model-only reply boilerplate).
+const AGENT_MESSAGE_PATTERN = new RegExp(
+  `^<${AGENT_MESSAGE_TAG} ([^>]*)>\\n([\\s\\S]*?)\\n</${AGENT_MESSAGE_TAG}>`,
+);
+
+function parseAttribute(attributes: string, name: string): string | null {
+  const match = new RegExp(`${name}="([^"]*)"`).exec(attributes);
+  return match ? unescapeAttributeValue(match[1]) : null;
+}
+
+/**
+ * Project a received agent-to-agent message to a compact, human-readable form
+ * for the receiver's timeline: a `Message from agent <id> (<title>):` header
+ * followed by the original prompt. Non-agent-message text is returned
+ * unchanged. Runs daemon-side so every client (including old ones) sees the
+ * readable form.
+ */
+export function projectAgentMessageForDisplay(text: string): string {
+  const match = AGENT_MESSAGE_PATTERN.exec(text);
+  if (!match) {
+    return text;
+  }
+  const senderAgentId = parseAttribute(match[1], "from");
+  if (!senderAgentId) {
+    return text;
+  }
+  const senderTitle = parseAttribute(match[1], "from_title");
+  const header = `Message from agent ${describeAgent(senderAgentId, senderTitle)}:`;
+  return `${header}\n\n${match[2]}`;
 }

--- a/packages/server/src/server/agent/create-agent/create.test.ts
+++ b/packages/server/src/server/agent/create-agent/create.test.ts
@@ -401,3 +401,145 @@ test("session create keeps an explicit title after the initial prompt settles", 
     rmSync(workdir, { recursive: true, force: true });
   }
 });
+
+test("mcp create prepends a spawn-context envelope naming the child and parent", async () => {
+  const parent = {
+    id: "agent-parent",
+    provider: "claude",
+    cwd: "/tmp/paseo-create-test",
+    workspaceId: "ws-parent",
+    config: { title: "Ship the release" },
+  } as ManagedAgent;
+  const child = {
+    id: "agent-child",
+    provider: "claude",
+    cwd: "/tmp/paseo-create-test",
+    runtimeInfo: null,
+  } as ManagedAgent;
+  const streamAgent = vi.fn(() => (async function* noop() {})());
+  const dependencies: Parameters<typeof createAgentCommand>[0] = {
+    agentManager: {
+      createAgent: vi.fn(async () => child),
+      getAgent: vi.fn((id: string) => (id === "agent-parent" ? parent : child)),
+      tryRunOutOfBand: vi.fn(() => false),
+      hasInFlightRun: vi.fn(() => false),
+      streamAgent,
+      waitForAgentRunStart: vi.fn(async () => undefined),
+      subscribe: vi.fn(() => () => {}),
+    } as unknown as Parameters<typeof createAgentCommand>[0]["agentManager"],
+    agentStorage: {
+      get: vi.fn(async () => null),
+    } as unknown as Parameters<typeof createAgentCommand>[0]["agentStorage"],
+    logger: createTestLogger(),
+    providerSnapshotManager: {
+      resolveCreateConfig: vi.fn(async () => ({})),
+    } as Parameters<typeof createAgentCommand>[0]["providerSnapshotManager"],
+  };
+
+  await createAgentCommand(dependencies, {
+    kind: "mcp",
+    provider: "claude",
+    title: "child",
+    initialPrompt: "Do the work",
+    background: true,
+    notifyOnFinish: true,
+    callerAgentId: "agent-parent",
+  });
+
+  expect(streamAgent).toHaveBeenCalledTimes(1);
+  const dispatched = streamAgent.mock.calls[0][1] as string;
+  expect(dispatched).toContain("<paseo-system>");
+  expect(dispatched).toContain(
+    "You are agent agent-child, spawned by agent agent-parent (Ship the release)",
+  );
+  expect(dispatched).toContain("automatically delivered to agent agent-parent as your report");
+  expect(dispatched.endsWith("</paseo-system>\n\nDo the work")).toBe(true);
+});
+
+test("mcp create states no auto-delivery for notifyOnFinish=false spawns", async () => {
+  const parent = {
+    id: "agent-parent",
+    provider: "claude",
+    cwd: "/tmp/paseo-create-test",
+    workspaceId: "ws-parent",
+    config: { title: "Ship the release" },
+  } as ManagedAgent;
+  const child = {
+    id: "agent-child",
+    provider: "claude",
+    cwd: "/tmp/paseo-create-test",
+    runtimeInfo: null,
+  } as ManagedAgent;
+  const streamAgent = vi.fn(() => (async function* noop() {})());
+  const dependencies: Parameters<typeof createAgentCommand>[0] = {
+    agentManager: {
+      createAgent: vi.fn(async () => child),
+      getAgent: vi.fn((id: string) => (id === "agent-parent" ? parent : child)),
+      tryRunOutOfBand: vi.fn(() => false),
+      hasInFlightRun: vi.fn(() => false),
+      streamAgent,
+      waitForAgentRunStart: vi.fn(async () => undefined),
+      subscribe: vi.fn(() => () => {}),
+    } as unknown as Parameters<typeof createAgentCommand>[0]["agentManager"],
+    agentStorage: {
+      get: vi.fn(async () => null),
+    } as unknown as Parameters<typeof createAgentCommand>[0]["agentStorage"],
+    logger: createTestLogger(),
+    providerSnapshotManager: {
+      resolveCreateConfig: vi.fn(async () => ({})),
+    } as Parameters<typeof createAgentCommand>[0]["providerSnapshotManager"],
+  };
+
+  await createAgentCommand(dependencies, {
+    kind: "mcp",
+    provider: "claude",
+    title: "child",
+    initialPrompt: "Do the work",
+    background: true,
+    notifyOnFinish: false,
+    detached: true,
+    callerAgentId: "agent-parent",
+  });
+
+  const dispatched = streamAgent.mock.calls[0][1] as string;
+  expect(dispatched).toContain("not automatically delivered back");
+  expect(dispatched.endsWith("</paseo-system>\n\nDo the work")).toBe(true);
+});
+
+test("mcp create without a caller leaves the initial prompt untouched", async () => {
+  const child = {
+    id: "agent-solo",
+    provider: "claude",
+    cwd: "/tmp/paseo-create-test",
+    runtimeInfo: null,
+  } as ManagedAgent;
+  const streamAgent = vi.fn(() => (async function* noop() {})());
+  const dependencies: Parameters<typeof createAgentCommand>[0] = {
+    agentManager: {
+      createAgent: vi.fn(async () => child),
+      getAgent: vi.fn(() => child),
+      tryRunOutOfBand: vi.fn(() => false),
+      hasInFlightRun: vi.fn(() => false),
+      streamAgent,
+      waitForAgentRunStart: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof createAgentCommand>[0]["agentManager"],
+    agentStorage: {} as Parameters<typeof createAgentCommand>[0]["agentStorage"],
+    logger: createTestLogger(),
+    providerSnapshotManager: {
+      resolveCreateConfig: vi.fn(async () => ({})),
+    } as Parameters<typeof createAgentCommand>[0]["providerSnapshotManager"],
+  };
+
+  await createAgentCommand(dependencies, {
+    kind: "mcp",
+    provider: "claude",
+    cwd: "/tmp/paseo-create-test",
+    workspaceId: "ws-solo",
+    title: "solo",
+    initialPrompt: "Do the work",
+    background: true,
+    notifyOnFinish: false,
+  });
+
+  expect(streamAgent).toHaveBeenCalledWith("agent-solo", "Do the work", undefined);
+});

--- a/packages/server/src/server/agent/create-agent/create.ts
+++ b/packages/server/src/server/agent/create-agent/create.ts
@@ -17,6 +17,7 @@ import type { AgentPromptInput, AgentRunOptions, AgentSessionConfig } from "../a
 import type { AgentStorage } from "../agent-storage.js";
 import type { ProviderSnapshotManager } from "../provider-snapshot-manager.js";
 import { setupFinishNotification, startCreatedAgentInitialPrompt } from "../agent-prompt.js";
+import { buildSpawnContextEnvelope, prependSpawnContext } from "../agent-spawn-context.js";
 import { resolveCreateAgentTitles } from "../create-agent-title.js";
 import { buildAgentPrompt } from "../prompt-attachments.js";
 import { normalizeClientMessageId, resolveClientMessageId } from "../../client-message-id.js";
@@ -149,6 +150,12 @@ function resolveProviderModel(providerValue: string): ResolvedProviderModel {
   return { provider: providerInput, model: undefined };
 }
 
+interface ResolvedSpawnContext {
+  parentAgentId: string;
+  parentTitle: string | null;
+  notifyOnFinish: boolean;
+}
+
 interface ResolvedCreateAgent {
   config: AgentSessionConfig;
   createOptions: CreateAgentOptions;
@@ -158,6 +165,11 @@ interface ResolvedCreateAgent {
   background: boolean;
   promptFailure: CreateAgentPromptFailureMode;
   promptLogger?: Logger;
+  // Present when another agent spawned this one: the daemon prepends a
+  // <paseo-system> identity/report-contract block to the initial prompt so the
+  // contract reaches every provider, not only those that surface MCP
+  // instructions. Applied after createAgent so the child's own id is known.
+  spawnContext?: ResolvedSpawnContext;
 }
 
 export async function createAgentCommand(
@@ -178,6 +190,20 @@ export async function createAgentCommand(
   resolved.setupContinuation?.startAfterAgentCreate({
     agentId: snapshot.id,
   });
+
+  // The child's own id is only known after createAgent, so the spawn-context
+  // block (which names the child) is prepended here rather than at resolve time.
+  if (resolved.prompt !== undefined && resolved.spawnContext) {
+    resolved.prompt = prependSpawnContext(
+      resolved.prompt,
+      buildSpawnContextEnvelope({
+        childAgentId: snapshot.id,
+        parentAgentId: resolved.spawnContext.parentAgentId,
+        parentTitle: resolved.spawnContext.parentTitle,
+        notifyOnFinish: resolved.spawnContext.notifyOnFinish,
+      }),
+    );
+  }
 
   let liveSnapshot = snapshot;
   let initialPromptStarted = false;
@@ -343,6 +369,15 @@ async function resolveMcpCreateAgent(
     setupContinuation,
     background: input.background,
     promptFailure: input.promptFailure ?? "log",
+    ...(input.callerAgentId
+      ? {
+          spawnContext: {
+            parentAgentId: input.callerAgentId,
+            parentTitle: parentAgent?.config.title ?? null,
+            notifyOnFinish: input.notifyOnFinish,
+          },
+        }
+      : {}),
   };
 }
 

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -5399,3 +5399,46 @@ describe("agent snapshot MCP serialization", () => {
     expect(content).not.toContain("first answer");
   });
 });
+
+describe("agent MCP server instructions", () => {
+  const logger = createTestLogger();
+
+  it("surfaces composed instructions to the connected client", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createClaudeOnlyManager(),
+      instructions: "You are running inside Paseo. Your agentId is agent-child.",
+      logger,
+    });
+    const client = await connectInMemoryMcpClient(server);
+
+    try {
+      expect(client.getInstructions()).toBe(
+        "You are running inside Paseo. Your agentId is agent-child.",
+      );
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("omits instructions when none are composed", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createClaudeOnlyManager(),
+      logger,
+    });
+    const client = await connectInMemoryMcpClient(server);
+
+    try {
+      expect(client.getInstructions()).toBeUndefined();
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -3461,6 +3461,129 @@ describe("send_agent_prompt MCP tool", () => {
       expect.objectContaining({ waitForActive: true }),
     );
   });
+
+  it("wraps agent-to-agent sends in a sender-identity envelope with the auto-reply contract", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const parentAgent = {
+      id: "parent-agent",
+      cwd: existingCwd,
+      workspaceId: "wks_parent",
+      provider: "codex",
+      currentModeId: "full-access",
+    } as ManagedAgent;
+    const childAgent = {
+      id: "child-agent",
+      cwd: existingCwd,
+      lifecycle: "running",
+      currentModeId: null,
+      availableModes: [],
+      config: { title: "Child" },
+    } as ManagedAgent;
+    spies.agentManager.getAgent.mockImplementation((agentId: string) => {
+      if (agentId === "parent-agent") return parentAgent;
+      if (agentId === "child-agent") return childAgent;
+      return null;
+    });
+    spies.agentStorage.get.mockImplementation(async (agentId: string) =>
+      agentId === "parent-agent"
+        ? createStoredRecord({ id: "parent-agent", title: "Reviewer" })
+        : null,
+    );
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      callerAgentId: "parent-agent",
+      logger,
+    });
+
+    const tool = registeredTool(server, "send_agent_prompt");
+    await invokeToolWithParsedInput(tool, {
+      agentId: "child-agent",
+      prompt: "Please review the auth changes.",
+    });
+
+    expect(spies.agentManager.streamAgent).toHaveBeenCalledTimes(1);
+    const dispatched = spies.agentManager.streamAgent.mock.calls[0][1] as string;
+    expect(dispatched).toContain('<paseo-agent-message from="parent-agent" from_title="Reviewer">');
+    expect(dispatched).toContain("Please review the auth changes.");
+    expect(dispatched).toContain(
+      "automatically delivered back to agent parent-agent as your reply",
+    );
+  });
+
+  it("states manual reply for fire-and-forget agent-to-agent sends", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    const parentAgent = {
+      id: "parent-agent",
+      cwd: existingCwd,
+      workspaceId: "wks_parent",
+      provider: "codex",
+      currentModeId: "full-access",
+    } as ManagedAgent;
+    const childAgent = {
+      id: "child-agent",
+      cwd: existingCwd,
+      lifecycle: "idle",
+      currentModeId: null,
+      availableModes: [],
+      config: { title: "Child" },
+    } as ManagedAgent;
+    spies.agentManager.getAgent.mockImplementation((agentId: string) => {
+      if (agentId === "parent-agent") return parentAgent;
+      if (agentId === "child-agent") return childAgent;
+      return null;
+    });
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      callerAgentId: "parent-agent",
+      logger,
+    });
+
+    const tool = registeredTool(server, "send_agent_prompt");
+    await invokeToolWithParsedInput(tool, {
+      agentId: "child-agent",
+      prompt: "fyi",
+      notifyOnFinish: false,
+    });
+
+    const dispatched = spies.agentManager.streamAgent.mock.calls[0][1] as string;
+    expect(dispatched).toContain('<paseo-agent-message from="parent-agent"');
+    expect(dispatched).toContain("Your reply is not automatically delivered");
+  });
+
+  it("leaves human/app sends without a caller agent untouched", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    spies.agentManager.getAgent.mockReturnValue({
+      id: "child-agent",
+      cwd: existingCwd,
+      lifecycle: "idle",
+      currentModeId: null,
+      availableModes: [],
+      config: { title: "Child" },
+    } as ManagedAgent);
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      logger,
+    });
+
+    const tool = registeredTool(server, "send_agent_prompt");
+    await invokeToolWithParsedInput(tool, {
+      agentId: "child-agent",
+      prompt: "Follow up",
+      background: false,
+    });
+
+    expect(spies.agentManager.streamAgent).toHaveBeenCalledTimes(1);
+    expect(spies.agentManager.streamAgent.mock.calls[0][1]).toBe("Follow up");
+  });
 });
 
 describe("update_agent MCP tool", () => {

--- a/packages/server/src/server/agent/mcp-server.ts
+++ b/packages/server/src/server/agent/mcp-server.ts
@@ -9,7 +9,14 @@ import type {
 import { createPaseoToolCatalog, type PaseoToolHostDependencies } from "./tools/paseo-tools.js";
 import type { PaseoToolResult } from "./tools/types.js";
 
-export type AgentMcpServerOptions = PaseoToolHostDependencies;
+export interface AgentMcpServerOptions extends PaseoToolHostDependencies {
+  /**
+   * Per-agent instructions surfaced in the connecting agent's system prompt on
+   * providers that expose MCP server instructions (e.g. Claude Code). Composed
+   * by the daemon from the caller's identity - see composeAgentMcpInstructions.
+   */
+  instructions?: string;
+}
 
 type McpToolContext = RequestHandlerExtra<ServerRequest, ServerNotification>;
 
@@ -73,10 +80,13 @@ function toMcpToolResult(result: PaseoToolResult): CallToolResult {
 
 export async function createAgentMcpServer(options: AgentMcpServerOptions): Promise<McpServer> {
   const catalog = await createPaseoToolCatalog(options);
-  const server = new McpServer({
-    name: "agent-mcp",
-    version: "2.0.0",
-  });
+  const server = new McpServer(
+    {
+      name: "agent-mcp",
+      version: "2.0.0",
+    },
+    options.instructions ? { instructions: options.instructions } : undefined,
+  );
 
   for (const tool of catalog.tools.values()) {
     server.registerTool(

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -55,6 +55,7 @@ import {
   waitForAgentWithTimeout,
 } from "../mcp-shared.js";
 import { sendPromptToAgent, setupFinishNotification } from "../agent-prompt.js";
+import { buildAgentMessageEnvelope } from "../agent-spawn-context.js";
 import { respondToAgentPermission } from "../permission-response.js";
 import {
   archiveAgentCommand,
@@ -1431,11 +1432,25 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
     }) => {
       const shouldNotifyOnFinish = Boolean(callerAgentId && notifyOnFinish && background);
 
+      // Agent-to-agent sends get a sender-identity envelope so the receiver knows
+      // who is asking and how to reply. Human/app sends and other system paths
+      // (chat mentions, schedule fires, notify-on-finish) are left untouched.
+      let deliveredPrompt = prompt;
+      if (callerAgentId) {
+        const senderRecord = await agentStorage.get(callerAgentId);
+        deliveredPrompt = buildAgentMessageEnvelope({
+          senderAgentId: callerAgentId,
+          senderTitle: senderRecord?.title ?? null,
+          prompt,
+          autoReply: shouldNotifyOnFinish,
+        });
+      }
+
       await sendPromptToAgent({
         agentManager,
         agentStorage,
         agentId,
-        prompt,
+        prompt: deliveredPrompt,
         sessionMode,
         logger: childLogger,
       });

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -105,6 +105,8 @@ import { AgentManager } from "./agent/agent-manager.js";
 import { AgentStorage } from "./agent/agent-storage.js";
 import { attachAgentStoragePersistence } from "./persistence-hooks.js";
 import { createAgentMcpServer } from "./agent/mcp-server.js";
+import { composeAgentMcpInstructions } from "./agent/agent-spawn-context.js";
+import { getParentAgentIdFromLabels } from "@getpaseo/protocol/agent-labels";
 import {
   createPaseoToolCatalog,
   type PaseoToolHostDependencies,
@@ -1131,10 +1133,27 @@ export async function createPaseoDaemon(
   if (mcpEnabled) {
     const agentMcpRoute = "/mcp/agents";
 
+    // Compose the per-agent MCP instructions from the caller's own record:
+    // its id plus its parent linkage (and the parent's title, when resolvable).
+    // Providers that surface MCP instructions read this in their system prompt,
+    // so the agent is "born knowing" the multi-agent contract.
+    const composeMcpInstructionsForCaller = async (callerAgentId?: string): Promise<string> => {
+      if (!callerAgentId) {
+        return composeAgentMcpInstructions({});
+      }
+      const callerRecord = await agentStorage.get(callerAgentId);
+      const parentAgentId = getParentAgentIdFromLabels(callerRecord?.labels);
+      const parentTitle = parentAgentId
+        ? ((await agentStorage.get(parentAgentId))?.title ?? null)
+        : null;
+      return composeAgentMcpInstructions({ callerAgentId, parentAgentId, parentTitle });
+    };
+
     const createAgentMcpSession = async (callerAgentId?: string) => {
-      const agentMcpServer = await createAgentMcpServer(
-        createAgentToolHostDependencies({ callerAgentId }),
-      );
+      const agentMcpServer = await createAgentMcpServer({
+        ...createAgentToolHostDependencies({ callerAgentId }),
+        instructions: await composeMcpInstructionsForCaller(callerAgentId),
+      });
 
       // Stateless mode: each HTTP request builds a fresh server + transport that is
       // torn down when the response closes, so no per-session state is retained between


### PR DESCRIPTION
> **Stacked on #2136 - review only the commits after that branch point.**
> This branch (`agent-sender-envelope`) is cut off `agent-spawn-auto-context` (PR #2136) and reuses that PR's daemon-side timeline-projection machinery. Until #2136 merges, the diff against `main` will also show #2136's commit; the only new commit here is `feat(server): attribute agent-to-agent messages with a sender envelope`. Merge #2136 first, then this.

Round 2 of porting claude-peers' communication strengths into Paseo: the **sender-identity envelope** for `send_agent_prompt`.

## Problem

When agent A calls `send_agent_prompt` targeting agent B, the handler passed the prompt verbatim. B could not tell the message came from another agent (vs a human, a schedule, or a finish notification) and had no idea whom to reply to - even though the handler already arms `setupFinishNotification` back to A by default, so B's final message is auto-relayed to A. The mechanical reply path worked; the receiver just did not know about it. Same disease cured in #2136 for spawn context; same fix (tell the receiver, deterministically, daemon-side).

## What changed

**Injection (daemon-side, agent-to-agent only).** In the `send_agent_prompt` handler, the prompt is wrapped **only when `callerAgentId` is present**. Human/app sends and other system paths (chat mentions, schedule fires, notify-on-finish) are untouched.

**Envelope format - a distinct attributed tag, not `<paseo-system>`.**
```
<paseo-agent-message from="<senderId>" from_title="<title>">
<original prompt>
</paseo-agent-message>

<reply-contract line>
```
Chosen over reusing the `<paseo-system>` header convention deliberately: a full `<paseo-system>` match would make `isSystemInjectedEnvelope` true, which (per #2136) **hides the message from the receiver's timeline** and is also the shape that gates system-injected handling - exactly wrong for attribution a human wants to see. A distinct tag never matches `SYSTEM_ENVELOPE_PATTERN`, so it is never hidden and cannot perturb the archived-target unarchive path (`send_agent_prompt` calls `sendPromptToAgent` with `unarchive` defaulting to true). Attribute values are XML-escaped so arbitrary titles cannot break out of the tag.

**Conditional reply contract** (mirrors #2136's notify wording), gated on the same `shouldNotifyOnFinish = callerAgentId && notifyOnFinish && background` the handler already computes:
- notify: "When you finish this turn and go idle, your last assistant message is automatically delivered back to agent `<id>` as your reply - make it complete and self-contained."
- no-notify: "Your reply is not automatically delivered; reach the sender via send_agent_prompt with agentId `<id>` if a response is needed."

**Timeline display** - unlike spawn context (stripped entirely), sender attribution is useful, so `projectAgentMessageForDisplay` rewrites the turn to `Message from agent <id> (<title>):` + the original prompt, dropping the trailing reply boilerplate. It runs through the same daemon-side `projectTimelineItemForDisplay` choke points from #2136, so **every client, including old ones, gets the readable form**. The receiving model still gets the full envelope in the dispatched prompt.

**Layer 1 instructions** (`composeAgentMcpInstructions`) now teach every agent to recognize `<paseo-agent-message>`, read the `from` id, and reply via `send_agent_prompt` (or rely on the auto relay when the envelope says so).

## Tests

- `agent-spawn-context.test.ts` - envelope compose (auto/manual reply, no-title, XML escaping, not-a-system-envelope) and `projectAgentMessageForDisplay` (header rewrite, boilerplate dropped, multi-paragraph, passthrough); Layer 1 teaching assertion.
- `mcp-server.test.ts` - handler wraps agent-to-agent sends with the correct reply variant, and leaves human/app sends untouched.
- `agent-manager.test.ts` - a `<paseo-agent-message>` turn renders as a readable sender header in the real timeline.

Lint, format, and full-workspace typecheck pass via the pre-commit hook.

## Out of scope (as specified)

Non-destructive delivery to busy agents (the replaceRunning interruption problem) and set_summary-style presence. Docs: `docs/agent-lifecycle.md` gains an "Agent-to-agent message envelope" section.