### PR TITLE
Always install the newest eligible desktop update

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -169,13 +169,13 @@ This does **not** apply to fresh releases cut via `npm run release:patch` — th
 
 ### Releasing during an active rollout
 
-If you ship N+1 while N is still ramping, N+1 starts a fresh rollout from its own publish timestamp. N's rollout effectively ends — the newer manifest supersedes it.
+If you ship N+1 while N is still ramping, N+1 starts a fresh rollout from its own publish timestamp. N's rollout effectively ends — the newer manifest supersedes it. Rollout-aware clients revalidate the manifest before installing a downloaded update on quit. If N+1 has replaced N but the client is not admitted to N+1 yet, it skips the downloaded N and waits rather than installing two updates in succession.
 
 If N+1 is a hotfix for a bug in N, dispatch `desktop-rollout.yml -f tag=v0.1.<N+1> -f rollout_hours=0` after N+1 publishes so the users who already got N reach the fix fast.
 
 ### Limitations
 
-- **No pause / kill switch.** Once a stable user is admitted, they will install the update on next quit (`autoInstallOnAppQuit = true`). To stop new admissions, ship a superseding release. To "recall" already-admitted users, ship a hotfix `+1` patch.
+- **No pause / kill switch.** To stop new admissions, ship a superseding release. Clients revalidate on quit and will not install the superseded download, but a client that already completed installation cannot be recalled; ship a hotfix `+1` patch.
 - **No rollback.** `allowDowngrade = false`. Bad release = ship a hotfix.
 - **Bootstrap caveat.** Clients running a build older than the rollout feature ignore `rolloutHours` and admit immediately. Rollout protection only applies to clients running the rollout-aware version or later.
 - **Up to ~30 min automatic admission latency.** Renderer polls every 30 minutes, so a stable user may take up to that long to be evaluated against the rollout window. Clicking **Check** is manual and bypasses rollout admission.

--- a/docs/release.md
+++ b/docs/release.md
@@ -169,7 +169,7 @@ This does **not** apply to fresh releases cut via `npm run release:patch` — th
 
 ### Releasing during an active rollout
 
-If you ship N+1 while N is still ramping, N+1 starts a fresh rollout from its own publish timestamp. N's rollout effectively ends — the newer manifest supersedes it. Rollout-aware clients revalidate the manifest before installing a downloaded update on quit. If N+1 has replaced N but the client is not admitted to N+1 yet, it skips the downloaded N and waits rather than installing two updates in succession.
+If you ship N+1 while N is still ramping, N+1 starts a fresh rollout from its own publish timestamp. N's rollout effectively ends — the newer manifest supersedes it. Rollout-aware clients revalidate the manifest for up to five seconds before installing a downloaded update on quit. If N+1 has replaced N but the client is not admitted to N+1 yet, it skips the downloaded N and waits rather than installing two updates in succession. If revalidation times out, the app exits without installing the cached update.
 
 If N+1 is a hotfix for a bug in N, dispatch `desktop-rollout.yml -f tag=v0.1.<N+1> -f rollout_hours=0` after N+1 publishes so the users who already got N reach the fix fast.
 

--- a/packages/desktop/src/daemon/quit-lifecycle.test.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { DEFAULT_DESKTOP_SETTINGS } from "../settings/desktop-settings";
 import {
@@ -23,96 +23,151 @@ describe("quit-lifecycle", () => {
   });
 
   it("short-circuits without inspecting the daemon when keep-running is on", async () => {
-    const isDesktopManagedDaemonRunning = vi.fn(() => true);
-    const stopDaemon = vi.fn(async () => undefined);
-    const showShutdownFeedback = vi.fn();
+    const events: string[] = [];
 
     const stopped = await stopDesktopManagedDaemonOnQuitIfNeeded({
       settingsStore: { get: async () => SETTINGS_KEEP_RUNNING },
-      isDesktopManagedDaemonRunning,
-      stopDaemon,
-      showShutdownFeedback,
+      isDesktopManagedDaemonRunning: () => {
+        events.push("inspect");
+        return true;
+      },
+      stopDaemon: async () => {
+        events.push("stop");
+      },
+      showShutdownFeedback: () => {
+        events.push("feedback");
+      },
     });
 
     expect(stopped).toBe(false);
-    expect(isDesktopManagedDaemonRunning).not.toHaveBeenCalled();
-    expect(stopDaemon).not.toHaveBeenCalled();
-    expect(showShutdownFeedback).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
   });
 
   it("does not stop a manually started daemon on quit", async () => {
-    const stopDaemon = vi.fn(async () => undefined);
-    const showShutdownFeedback = vi.fn();
+    const events: string[] = [];
 
     const stopped = await stopDesktopManagedDaemonOnQuitIfNeeded({
       settingsStore: { get: async () => SETTINGS_STOP_ON_QUIT },
       isDesktopManagedDaemonRunning: () => false,
-      stopDaemon,
-      showShutdownFeedback,
+      stopDaemon: async () => {
+        events.push("stop");
+      },
+      showShutdownFeedback: () => {
+        events.push("feedback");
+      },
     });
 
     expect(stopped).toBe(false);
-    expect(stopDaemon).not.toHaveBeenCalled();
-    expect(showShutdownFeedback).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
   });
 
   it("shows feedback then stops a desktop-managed daemon", async () => {
-    const stopDaemon = vi.fn(async () => undefined);
-    const showShutdownFeedback = vi.fn();
+    const events: string[] = [];
 
     const stopped = await stopDesktopManagedDaemonOnQuitIfNeeded({
       settingsStore: { get: async () => SETTINGS_STOP_ON_QUIT },
       isDesktopManagedDaemonRunning: () => true,
-      stopDaemon,
-      showShutdownFeedback,
+      stopDaemon: async () => {
+        events.push("stop");
+      },
+      showShutdownFeedback: () => {
+        events.push("feedback");
+      },
     });
 
     expect(stopped).toBe(true);
-    expect(showShutdownFeedback).toHaveBeenCalledTimes(1);
-    expect(stopDaemon).toHaveBeenCalledTimes(1);
-    expect(showShutdownFeedback.mock.invocationCallOrder[0]).toBeLessThan(
-      stopDaemon.mock.invocationCallOrder[0],
-    );
+    expect(events).toEqual(["feedback", "stop"]);
   });
 
-  it("preventDefaults the first quit, runs the async stop decision, then exits hard", async () => {
+  it("revalidates updates after daemon shutdown before exiting", async () => {
     let resolveStopDecision: (() => void) | null = null;
-    const app = { exit: vi.fn() };
-    const closeTransportSessions = vi.fn();
-    const onStopError = vi.fn();
-    const preventDefault = vi.fn();
-    const secondPreventDefault = vi.fn();
+    let resolveUpdateDecision: (() => void) | null = null;
+    const events: string[] = [];
 
     const handleBeforeQuit = createBeforeQuitHandler({
-      app,
-      closeTransportSessions,
-      stopDesktopManagedDaemonIfNeeded: vi.fn(
-        () =>
-          new Promise<boolean>((resolve) => {
-            resolveStopDecision = () => resolve(false);
-          }),
-      ),
-      onStopError,
+      app: {
+        exit: (code) => {
+          events.push(`exit:${code}`);
+        },
+      },
+      closeTransportSessions: () => {
+        events.push("close-transports");
+      },
+      stopDesktopManagedDaemonIfNeeded: () =>
+        new Promise<boolean>((resolve) => {
+          resolveStopDecision = () => {
+            events.push("daemon-stopped");
+            resolve(false);
+          };
+        }),
+      installAppUpdateOnQuit: () =>
+        new Promise<boolean>((resolve) => {
+          resolveUpdateDecision = () => {
+            events.push("update-checked");
+            resolve(false);
+          };
+        }),
+      onStopError: () => {
+        events.push("stop-error");
+      },
+      onUpdateError: () => {
+        events.push("update-error");
+      },
     });
 
-    handleBeforeQuit({ preventDefault });
+    handleBeforeQuit({
+      preventDefault: () => {
+        events.push("prevent-default");
+      },
+    });
 
-    expect(preventDefault).toHaveBeenCalledTimes(1);
-    expect(closeTransportSessions).toHaveBeenCalledTimes(1);
-    expect(app.exit).not.toHaveBeenCalled();
+    expect(events).toEqual(["close-transports", "prevent-default"]);
     expect(resolveStopDecision).not.toBeNull();
 
     resolveStopDecision?.();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(app.exit).toHaveBeenCalledWith(0);
-    expect(onStopError).not.toHaveBeenCalled();
+    expect(events).toEqual(["close-transports", "prevent-default", "daemon-stopped"]);
+    expect(resolveUpdateDecision).not.toBeNull();
 
-    handleBeforeQuit({ preventDefault: secondPreventDefault });
+    resolveUpdateDecision?.();
+    await Promise.resolve();
+    await Promise.resolve();
 
-    expect(secondPreventDefault).not.toHaveBeenCalled();
-    expect(closeTransportSessions).toHaveBeenCalledTimes(2);
-    expect(app.exit).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([
+      "close-transports",
+      "prevent-default",
+      "daemon-stopped",
+      "update-checked",
+      "exit:0",
+    ]);
+
+    handleBeforeQuit({
+      preventDefault: () => {
+        events.push("second-prevent-default");
+      },
+    });
+
+    expect(events.at(-1)).toBe("close-transports");
+    expect(events).not.toContain("second-prevent-default");
+  });
+
+  it("lets the updater own process exit when a validated update is installing", async () => {
+    const exits: number[] = [];
+    const handleBeforeQuit = createBeforeQuitHandler({
+      app: { exit: (code) => exits.push(code) },
+      closeTransportSessions: () => {},
+      stopDesktopManagedDaemonIfNeeded: async () => false,
+      installAppUpdateOnQuit: async () => true,
+      onStopError: () => {},
+      onUpdateError: () => {},
+    });
+
+    handleBeforeQuit({ preventDefault: () => {} });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(exits).toEqual([]);
   });
 });

--- a/packages/desktop/src/daemon/quit-lifecycle.test.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { DEFAULT_DESKTOP_SETTINGS } from "../settings/desktop-settings";
 import {
-  createBeforeQuitHandler,
+  createQuitLifecycle,
   shouldStopDesktopManagedDaemonOnQuit,
   stopDesktopManagedDaemonOnQuitIfNeeded,
 } from "./quit-lifecycle";
@@ -15,6 +15,18 @@ const SETTINGS_STOP_ON_QUIT = {
     keepRunningAfterQuit: false,
   },
 };
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function waitForQuitLifecycle(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
 
 describe("quit-lifecycle", () => {
   it("only stops when keepRunningAfterQuit is explicitly disabled", () => {
@@ -80,11 +92,11 @@ describe("quit-lifecycle", () => {
   });
 
   it("revalidates updates after daemon shutdown before exiting", async () => {
-    let resolveStopDecision: (() => void) | null = null;
-    let resolveUpdateDecision: (() => void) | null = null;
+    const stopDecision = deferred<boolean>();
+    const updateDecision = deferred<boolean>();
     const events: string[] = [];
 
-    const handleBeforeQuit = createBeforeQuitHandler({
+    const quitLifecycle = createQuitLifecycle({
       app: {
         exit: (code) => {
           events.push(`exit:${code}`);
@@ -93,20 +105,9 @@ describe("quit-lifecycle", () => {
       closeTransportSessions: () => {
         events.push("close-transports");
       },
-      stopDesktopManagedDaemonIfNeeded: () =>
-        new Promise<boolean>((resolve) => {
-          resolveStopDecision = () => {
-            events.push("daemon-stopped");
-            resolve(false);
-          };
-        }),
-      installAppUpdateOnQuit: () =>
-        new Promise<boolean>((resolve) => {
-          resolveUpdateDecision = () => {
-            events.push("update-checked");
-            resolve(false);
-          };
-        }),
+      stopDesktopManagedDaemonIfNeeded: () => stopDecision.promise,
+      installAppUpdateOnQuit: () => updateDecision.promise,
+      createUpdateRevalidationSignal: () => new AbortController().signal,
       onStopError: () => {
         events.push("stop-error");
       },
@@ -115,25 +116,23 @@ describe("quit-lifecycle", () => {
       },
     });
 
-    handleBeforeQuit({
+    quitLifecycle.handleBeforeQuit({
       preventDefault: () => {
         events.push("prevent-default");
       },
     });
 
     expect(events).toEqual(["close-transports", "prevent-default"]);
-    expect(resolveStopDecision).not.toBeNull();
 
-    resolveStopDecision?.();
-    await Promise.resolve();
-    await Promise.resolve();
+    events.push("daemon-stopped");
+    stopDecision.resolve(false);
+    await waitForQuitLifecycle();
 
     expect(events).toEqual(["close-transports", "prevent-default", "daemon-stopped"]);
-    expect(resolveUpdateDecision).not.toBeNull();
 
-    resolveUpdateDecision?.();
-    await Promise.resolve();
-    await Promise.resolve();
+    events.push("update-checked");
+    updateDecision.resolve(false);
+    await waitForQuitLifecycle();
 
     expect(events).toEqual([
       "close-transports",
@@ -143,7 +142,7 @@ describe("quit-lifecycle", () => {
       "exit:0",
     ]);
 
-    handleBeforeQuit({
+    quitLifecycle.handleBeforeQuit({
       preventDefault: () => {
         events.push("second-prevent-default");
       },
@@ -155,19 +154,71 @@ describe("quit-lifecycle", () => {
 
   it("lets the updater own process exit when a validated update is installing", async () => {
     const exits: number[] = [];
-    const handleBeforeQuit = createBeforeQuitHandler({
+    const quitLifecycle = createQuitLifecycle({
       app: { exit: (code) => exits.push(code) },
       closeTransportSessions: () => {},
       stopDesktopManagedDaemonIfNeeded: async () => false,
       installAppUpdateOnQuit: async () => true,
+      createUpdateRevalidationSignal: () => new AbortController().signal,
       onStopError: () => {},
       onUpdateError: () => {},
     });
 
-    handleBeforeQuit({ preventDefault: () => {} });
-    await Promise.resolve();
-    await Promise.resolve();
+    quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+    await waitForQuitLifecycle();
 
     expect(exits).toEqual([]);
+  });
+
+  it("does not intercept a quit started by a manual update", () => {
+    const events: string[] = [];
+    const quitLifecycle = createQuitLifecycle({
+      app: { exit: (code) => events.push(`exit:${code}`) },
+      closeTransportSessions: () => events.push("close-transports"),
+      stopDesktopManagedDaemonIfNeeded: async () => {
+        events.push("stop-daemon");
+        return false;
+      },
+      installAppUpdateOnQuit: async () => {
+        events.push("revalidate-update");
+        return false;
+      },
+      createUpdateRevalidationSignal: () => new AbortController().signal,
+      onStopError: () => events.push("stop-error"),
+      onUpdateError: () => events.push("update-error"),
+    });
+
+    quitLifecycle.handleBeforeQuitForUpdate();
+    quitLifecycle.handleBeforeQuit({
+      preventDefault: () => events.push("prevent-default"),
+    });
+
+    expect(events).toEqual(["close-transports"]);
+  });
+
+  it("exits when update revalidation reaches its deadline", async () => {
+    const deadline = new AbortController();
+    const updateDecision = deferred<boolean>();
+    const exits: number[] = [];
+    const quitLifecycle = createQuitLifecycle({
+      app: { exit: (code) => exits.push(code) },
+      closeTransportSessions: () => {},
+      stopDesktopManagedDaemonIfNeeded: async () => false,
+      installAppUpdateOnQuit: () => updateDecision.promise,
+      createUpdateRevalidationSignal: () => deadline.signal,
+      onStopError: () => {},
+      onUpdateError: () => {},
+    });
+
+    quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+    await waitForQuitLifecycle();
+    deadline.abort();
+    await waitForQuitLifecycle();
+
+    expect(exits).toEqual([0]);
+
+    updateDecision.resolve(true);
+    await waitForQuitLifecycle();
+    expect(exits).toEqual([0]);
   });
 });

--- a/packages/desktop/src/daemon/quit-lifecycle.test.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.test.ts
@@ -172,6 +172,28 @@ describe("quit-lifecycle", () => {
     expect(exits).toEqual([]);
   });
 
+  it("recognizes a repeated quit as updater handoff", async () => {
+    const exits: number[] = [];
+    let preventedQuitCount = 0;
+    const quitLifecycle = createQuitLifecycle({
+      app: { exit: (code) => exits.push(code) },
+      closeTransportSessions: () => {},
+      stopDesktopManagedDaemonIfNeeded: async () => false,
+      installAppUpdateOnQuit: async () => true,
+      createUpdateDeadlineSignal: () => new AbortController().signal,
+      onStopError: () => {},
+      onUpdateError: () => {},
+    });
+
+    quitLifecycle.handleBeforeQuit({ preventDefault: () => preventedQuitCount++ });
+    await waitForQuitLifecycle();
+    quitLifecycle.handleBeforeQuit({ preventDefault: () => preventedQuitCount++ });
+    await waitForQuitLifecycle();
+
+    expect(preventedQuitCount).toBe(1);
+    expect(exits).toEqual([]);
+  });
+
   it("exits when the updater does not take ownership before its deadline", async () => {
     const revalidationDeadline = new AbortController();
     const handoffDeadline = new AbortController();

--- a/packages/desktop/src/daemon/quit-lifecycle.test.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.test.ts
@@ -107,7 +107,7 @@ describe("quit-lifecycle", () => {
       },
       stopDesktopManagedDaemonIfNeeded: () => stopDecision.promise,
       installAppUpdateOnQuit: () => updateDecision.promise,
-      createUpdateRevalidationSignal: () => new AbortController().signal,
+      createUpdateDeadlineSignal: () => new AbortController().signal,
       onStopError: () => {
         events.push("stop-error");
       },
@@ -159,15 +159,41 @@ describe("quit-lifecycle", () => {
       closeTransportSessions: () => {},
       stopDesktopManagedDaemonIfNeeded: async () => false,
       installAppUpdateOnQuit: async () => true,
-      createUpdateRevalidationSignal: () => new AbortController().signal,
+      createUpdateDeadlineSignal: () => new AbortController().signal,
       onStopError: () => {},
       onUpdateError: () => {},
     });
 
     quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
     await waitForQuitLifecycle();
+    quitLifecycle.handleBeforeQuitForUpdate();
+    await waitForQuitLifecycle();
 
     expect(exits).toEqual([]);
+  });
+
+  it("exits when the updater does not take ownership before its deadline", async () => {
+    const revalidationDeadline = new AbortController();
+    const handoffDeadline = new AbortController();
+    let deadlineCount = 0;
+    const exits: number[] = [];
+    const quitLifecycle = createQuitLifecycle({
+      app: { exit: (code) => exits.push(code) },
+      closeTransportSessions: () => {},
+      stopDesktopManagedDaemonIfNeeded: async () => false,
+      installAppUpdateOnQuit: async () => true,
+      createUpdateDeadlineSignal: () =>
+        deadlineCount++ === 0 ? revalidationDeadline.signal : handoffDeadline.signal,
+      onStopError: () => {},
+      onUpdateError: () => {},
+    });
+
+    quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+    await waitForQuitLifecycle();
+    handoffDeadline.abort();
+    await waitForQuitLifecycle();
+
+    expect(exits).toEqual([0]);
   });
 
   it("does not intercept a quit started by a manual update", () => {
@@ -183,7 +209,7 @@ describe("quit-lifecycle", () => {
         events.push("revalidate-update");
         return false;
       },
-      createUpdateRevalidationSignal: () => new AbortController().signal,
+      createUpdateDeadlineSignal: () => new AbortController().signal,
       onStopError: () => events.push("stop-error"),
       onUpdateError: () => events.push("update-error"),
     });
@@ -205,7 +231,7 @@ describe("quit-lifecycle", () => {
       closeTransportSessions: () => {},
       stopDesktopManagedDaemonIfNeeded: async () => false,
       installAppUpdateOnQuit: () => updateDecision.promise,
-      createUpdateRevalidationSignal: () => deadline.signal,
+      createUpdateDeadlineSignal: () => deadline.signal,
       onStopError: () => {},
       onUpdateError: () => {},
     });

--- a/packages/desktop/src/daemon/quit-lifecycle.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.ts
@@ -46,18 +46,20 @@ export function createBeforeQuitHandler({
   app,
   closeTransportSessions,
   stopDesktopManagedDaemonIfNeeded,
+  installAppUpdateOnQuit,
   onStopError,
+  onUpdateError,
 }: {
   app: BeforeQuitApp;
   closeTransportSessions: () => void;
   stopDesktopManagedDaemonIfNeeded: () => Promise<boolean>;
+  installAppUpdateOnQuit: () => Promise<boolean>;
   onStopError: (error: unknown) => void;
+  onUpdateError: (error: unknown) => void;
 }): (event: BeforeQuitEvent) => void {
-  // We always preventDefault on first quit so we can run the async stop
-  // decision, then call app.exit(0) — which bypasses Electron's
-  // close → window-all-closed → will-quit chain. The window-all-closed
-  // listener is a darwin no-op (macOS convention) and would otherwise
-  // veto a re-fired app.quit().
+  // The first quit waits for daemon shutdown and update revalidation. A validated
+  // update re-fires app.quit(); otherwise app.exit(0) bypasses Electron's macOS
+  // window-all-closed handler, which would veto that second quit.
   let quitting = false;
 
   return (event) => {
@@ -66,12 +68,23 @@ export function createBeforeQuitHandler({
     quitting = true;
     event.preventDefault();
 
-    void stopDesktopManagedDaemonIfNeeded()
-      .catch((error) => {
+    void (async () => {
+      try {
+        await stopDesktopManagedDaemonIfNeeded();
+      } catch (error) {
         onStopError(error);
-      })
-      .finally(() => {
-        app.exit(0);
-      });
+      }
+
+      try {
+        const installingUpdate = await installAppUpdateOnQuit();
+        if (installingUpdate) {
+          return;
+        }
+      } catch (error) {
+        onUpdateError(error);
+      }
+
+      app.exit(0);
+    })();
   };
 }

--- a/packages/desktop/src/daemon/quit-lifecycle.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.ts
@@ -19,6 +19,11 @@ interface QuitLifecycle {
   handleBeforeQuitForUpdate(): void;
 }
 
+interface DeferredUpdateQuit {
+  promise: Promise<boolean>;
+  resolve(): void;
+}
+
 export interface StopOnQuitDeps {
   settingsStore: Pick<DesktopSettingsStore, "get">;
   isDesktopManagedDaemonRunning: () => boolean;
@@ -47,7 +52,7 @@ export async function stopDesktopManagedDaemonOnQuitIfNeeded(
   return true;
 }
 
-function waitForUpdateRevalidationTimeout(signal: AbortSignal): Promise<boolean> {
+function waitForUpdateDeadline(signal: AbortSignal): Promise<boolean> {
   if (signal.aborted) {
     return Promise.resolve(false);
   }
@@ -57,12 +62,20 @@ function waitForUpdateRevalidationTimeout(signal: AbortSignal): Promise<boolean>
   });
 }
 
+function createDeferredUpdateQuit(): DeferredUpdateQuit {
+  let resolvePromise!: (started: boolean) => void;
+  const promise = new Promise<boolean>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: () => resolvePromise(true) };
+}
+
 export function createQuitLifecycle({
   app,
   closeTransportSessions,
   stopDesktopManagedDaemonIfNeeded,
   installAppUpdateOnQuit,
-  createUpdateRevalidationSignal,
+  createUpdateDeadlineSignal,
   onStopError,
   onUpdateError,
 }: {
@@ -70,7 +83,7 @@ export function createQuitLifecycle({
   closeTransportSessions: () => void;
   stopDesktopManagedDaemonIfNeeded: () => Promise<boolean>;
   installAppUpdateOnQuit: (signal: AbortSignal) => Promise<boolean>;
-  createUpdateRevalidationSignal: () => AbortSignal;
+  createUpdateDeadlineSignal: () => AbortSignal;
   onStopError: (error: unknown) => void;
   onUpdateError: (error: unknown) => void;
 }): QuitLifecycle {
@@ -79,6 +92,7 @@ export function createQuitLifecycle({
   // window-all-closed handler, which would veto that second quit.
   let quitting = false;
   let quittingForUpdate = false;
+  const updateQuit = createDeferredUpdateQuit();
 
   function handleBeforeQuit(event: BeforeQuitEvent): void {
     closeTransportSessions();
@@ -93,17 +107,23 @@ export function createQuitLifecycle({
         onStopError(error);
       }
 
-      const signal = createUpdateRevalidationSignal();
+      const signal = createUpdateDeadlineSignal();
       const updateInstallation = installAppUpdateOnQuit(signal).catch((error) => {
         onUpdateError(error);
         return false;
       });
       const installingUpdate = await Promise.race([
         updateInstallation,
-        waitForUpdateRevalidationTimeout(signal),
+        waitForUpdateDeadline(signal),
       ]);
       if (installingUpdate) {
-        return;
+        const handoffStarted = await Promise.race([
+          updateQuit.promise,
+          waitForUpdateDeadline(createUpdateDeadlineSignal()),
+        ]);
+        if (handoffStarted) {
+          return;
+        }
       }
 
       app.exit(0);
@@ -114,6 +134,7 @@ export function createQuitLifecycle({
     handleBeforeQuit,
     handleBeforeQuitForUpdate() {
       quittingForUpdate = true;
+      updateQuit.resolve();
     },
   };
 }

--- a/packages/desktop/src/daemon/quit-lifecycle.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.ts
@@ -96,7 +96,13 @@ export function createQuitLifecycle({
 
   function handleBeforeQuit(event: BeforeQuitEvent): void {
     closeTransportSessions();
-    if (quitting || quittingForUpdate) return;
+    if (quittingForUpdate) return;
+    if (quitting) {
+      // MacUpdater's no-relaunch path calls app.quit() without emitting
+      // before-quit-for-update. A second quit is equivalent handoff evidence.
+      updateQuit.resolve();
+      return;
+    }
     quitting = true;
     event.preventDefault();
 

--- a/packages/desktop/src/daemon/quit-lifecycle.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.ts
@@ -14,6 +14,11 @@ interface BeforeQuitApp {
   exit(code: number): void;
 }
 
+interface QuitLifecycle {
+  handleBeforeQuit(event: BeforeQuitEvent): void;
+  handleBeforeQuitForUpdate(): void;
+}
+
 export interface StopOnQuitDeps {
   settingsStore: Pick<DesktopSettingsStore, "get">;
   isDesktopManagedDaemonRunning: () => boolean;
@@ -42,29 +47,42 @@ export async function stopDesktopManagedDaemonOnQuitIfNeeded(
   return true;
 }
 
-export function createBeforeQuitHandler({
+function waitForUpdateRevalidationTimeout(signal: AbortSignal): Promise<boolean> {
+  if (signal.aborted) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    signal.addEventListener("abort", () => resolve(false), { once: true });
+  });
+}
+
+export function createQuitLifecycle({
   app,
   closeTransportSessions,
   stopDesktopManagedDaemonIfNeeded,
   installAppUpdateOnQuit,
+  createUpdateRevalidationSignal,
   onStopError,
   onUpdateError,
 }: {
   app: BeforeQuitApp;
   closeTransportSessions: () => void;
   stopDesktopManagedDaemonIfNeeded: () => Promise<boolean>;
-  installAppUpdateOnQuit: () => Promise<boolean>;
+  installAppUpdateOnQuit: (signal: AbortSignal) => Promise<boolean>;
+  createUpdateRevalidationSignal: () => AbortSignal;
   onStopError: (error: unknown) => void;
   onUpdateError: (error: unknown) => void;
-}): (event: BeforeQuitEvent) => void {
+}): QuitLifecycle {
   // The first quit waits for daemon shutdown and update revalidation. A validated
   // update re-fires app.quit(); otherwise app.exit(0) bypasses Electron's macOS
   // window-all-closed handler, which would veto that second quit.
   let quitting = false;
+  let quittingForUpdate = false;
 
-  return (event) => {
+  function handleBeforeQuit(event: BeforeQuitEvent): void {
     closeTransportSessions();
-    if (quitting) return;
+    if (quitting || quittingForUpdate) return;
     quitting = true;
     event.preventDefault();
 
@@ -75,16 +93,27 @@ export function createBeforeQuitHandler({
         onStopError(error);
       }
 
-      try {
-        const installingUpdate = await installAppUpdateOnQuit();
-        if (installingUpdate) {
-          return;
-        }
-      } catch (error) {
+      const signal = createUpdateRevalidationSignal();
+      const updateInstallation = installAppUpdateOnQuit(signal).catch((error) => {
         onUpdateError(error);
+        return false;
+      });
+      const installingUpdate = await Promise.race([
+        updateInstallation,
+        waitForUpdateRevalidationTimeout(signal),
+      ]);
+      if (installingUpdate) {
+        return;
       }
 
       app.exit(0);
     })();
+  }
+
+  return {
+    handleBeforeQuit,
+    handleBeforeQuitForUpdate() {
+      quittingForUpdate = true;
+    },
   };
 }

--- a/packages/desktop/src/features/app-update-service.test.ts
+++ b/packages/desktop/src/features/app-update-service.test.ts
@@ -17,7 +17,10 @@ class FakeAppUpdateRuntime implements AppUpdateRuntime {
   > = [];
   private gate: ((info: RuntimeUpdateInfo) => boolean | Promise<boolean>) | null = null;
   private configuration: AppUpdateRuntimeConfiguration | null = null;
+  private downloadableUpdate: RuntimeUpdateInfo | null = null;
+  private downloadedUpdate: RuntimeUpdateInfo | null = null;
   checkCount = 0;
+  installedVersions: string[] = [];
 
   configure(input: AppUpdateRuntimeConfiguration): void {
     this.configuration = input;
@@ -59,6 +62,7 @@ class FakeAppUpdateRuntime implements AppUpdateRuntime {
   }
 
   finishUpdateDownload(info: RuntimeUpdateInfo): void {
+    this.downloadedUpdate = info;
     this.configuration?.onUpdateDownloaded(info);
   }
 
@@ -80,12 +84,22 @@ class FakeAppUpdateRuntime implements AppUpdateRuntime {
     }
     if (!result || !this.gate) return result;
     const admitted = await this.gate(result.updateInfo);
-    return { ...result, isUpdateAvailable: result.isUpdateAvailable && admitted };
+    const isUpdateAvailable = result.isUpdateAvailable && admitted;
+    this.downloadableUpdate = isUpdateAvailable ? result.updateInfo : null;
+    return { ...result, isUpdateAvailable };
   }
 
-  async downloadUpdate(): Promise<void> {}
+  async downloadUpdate(): Promise<void> {
+    if (this.downloadableUpdate) {
+      this.finishUpdateDownload(this.downloadableUpdate);
+    }
+  }
 
-  quitAndInstall(): void {}
+  quitAndInstall(): void {
+    if (this.downloadedUpdate) {
+      this.installedVersions.push(this.downloadedUpdate.version);
+    }
+  }
 }
 
 function createService(input?: { now?: () => number; bucket?: () => Promise<number> }) {
@@ -177,6 +191,111 @@ describe("app update service", () => {
       date: "2026-04-28T00:00:00.000Z",
       errorMessage: null,
     });
+  });
+
+  it("replaces a downloaded update when a newer release is admitted", async () => {
+    const { runtime, service } = createService({ bucket: async () => 0 });
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+    runtime.finishUpdateDownload(rolledOutUpdate);
+
+    const newerUpdate = { ...rolledOutUpdate, version: "1.2.5" };
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: newerUpdate });
+    const result = await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+
+    expect(result).toEqual({
+      hasUpdate: true,
+      readyToInstall: false,
+      currentVersion: "1.2.3",
+      latestVersion: "1.2.5",
+      body: null,
+      date: "2026-04-28T00:00:00.000Z",
+      errorMessage: null,
+    });
+  });
+
+  it("installs the newest admitted release when quitting with an older download", async () => {
+    const { runtime, service } = createService({ bucket: async () => 0 });
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+    runtime.finishUpdateDownload(rolledOutUpdate);
+
+    const newerUpdate = { ...rolledOutUpdate, version: "1.2.5" };
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: newerUpdate });
+    const installed = await service.installUpdateOnQuit({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+    });
+
+    expect(installed).toBe(true);
+    expect(runtime.installedVersions).toEqual(["1.2.5"]);
+  });
+
+  it("does not install an older download while its replacement is still rolling out", async () => {
+    const now = Date.parse("2026-04-28T12:00:00.000Z");
+    const { runtime, service } = createService({ now: () => now, bucket: async () => 0.4 });
+    const olderUpdate = {
+      ...rolledOutUpdate,
+      releaseDate: "2026-04-27T00:00:00.000Z",
+    };
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: olderUpdate });
+
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+    runtime.finishUpdateDownload(olderUpdate);
+
+    const newerUpdate = {
+      ...rolledOutUpdate,
+      version: "1.2.5",
+      releaseDate: "2026-04-28T12:00:00.000Z",
+    };
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: newerUpdate });
+    const installed = await service.installUpdateOnQuit({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+    });
+
+    expect(installed).toBe(false);
+    expect(runtime.installedVersions).toEqual([]);
+  });
+
+  it("rechecks for the newest release before a manual install", async () => {
+    const { runtime, service } = createService({ bucket: async () => 0.99 });
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "manual",
+    });
+    runtime.finishUpdateDownload(rolledOutUpdate);
+
+    const newerUpdate = { ...rolledOutUpdate, version: "1.2.5" };
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: newerUpdate });
+    const result = await service.downloadAndInstallUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+    });
+
+    expect(result.installed).toBe(true);
+    expect(runtime.installedVersions).toEqual(["1.2.5"]);
   });
 
   it("trusts the runtime availability decision before comparing versions", async () => {
@@ -322,40 +441,8 @@ describe("app update service", () => {
     });
   });
 
-  it("keeps preparation errors emitted before the update check rejects", async () => {
-    const { runtime, service } = createService();
-    const deferredCheck = runtime.deferNextCheck();
-    const pending = service.checkForAppUpdate({
-      currentVersion: "1.2.3",
-      releaseChannel: "stable",
-      intent: "automatic",
-    });
-
-    runtime.prepareUpdate(rolledOutUpdate);
-    runtime.failRuntime(new Error("sha512 checksum mismatch"));
-    deferredCheck.reject(new Error("sha512 checksum mismatch"));
-    const checkResult = await pending;
-    expect(checkResult.errorMessage).toBe("sha512 checksum mismatch");
-
-    const automaticResult = await service.checkForAppUpdate({
-      currentVersion: "1.2.3",
-      releaseChannel: "stable",
-      intent: "automatic",
-    });
-
-    expect(automaticResult).toEqual({
-      hasUpdate: true,
-      readyToInstall: false,
-      currentVersion: "1.2.3",
-      latestVersion: "1.2.4",
-      body: null,
-      date: "2026-04-28T00:00:00.000Z",
-      errorMessage: "sha512 checksum mismatch",
-    });
-  });
-
-  it("returns runtime update errors after an update fails to prepare", async () => {
-    const { runtime, service } = createService();
+  it("discovers newer releases after an update fails to prepare", async () => {
+    const { runtime, service } = createService({ bucket: async () => 0 });
     runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
 
     await service.checkForAppUpdate({
@@ -365,6 +452,8 @@ describe("app update service", () => {
     });
     runtime.failRuntime(new Error("sha512 checksum mismatch"));
 
+    const newerUpdate = { ...rolledOutUpdate, version: "1.2.5" };
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: newerUpdate });
     const result = await service.checkForAppUpdate({
       currentVersion: "1.2.3",
       releaseChannel: "stable",
@@ -375,10 +464,10 @@ describe("app update service", () => {
       hasUpdate: true,
       readyToInstall: false,
       currentVersion: "1.2.3",
-      latestVersion: "1.2.4",
+      latestVersion: "1.2.5",
       body: null,
       date: "2026-04-28T00:00:00.000Z",
-      errorMessage: "sha512 checksum mismatch",
+      errorMessage: null,
     });
   });
 
@@ -443,93 +532,6 @@ describe("app update service", () => {
       body: null,
       date: "2026-04-28T00:00:00.000Z",
       errorMessage: null,
-    });
-  });
-
-  it("returns runtime update errors to multiple automatic checks before a manual retry clears them", async () => {
-    const { runtime, service } = createService();
-    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
-
-    await service.checkForAppUpdate({
-      currentVersion: "1.2.3",
-      releaseChannel: "stable",
-      intent: "manual",
-    });
-    runtime.failRuntime(new Error("sha512 checksum mismatch"));
-
-    const firstAutomaticResult = await service.checkForAppUpdate({
-      currentVersion: "1.2.3",
-      releaseChannel: "stable",
-      intent: "automatic",
-    });
-    const secondAutomaticResult = await service.checkForAppUpdate({
-      currentVersion: "1.2.3",
-      releaseChannel: "stable",
-      intent: "automatic",
-    });
-
-    expect(firstAutomaticResult).toEqual({
-      hasUpdate: true,
-      readyToInstall: false,
-      currentVersion: "1.2.3",
-      latestVersion: "1.2.4",
-      body: null,
-      date: "2026-04-28T00:00:00.000Z",
-      errorMessage: "sha512 checksum mismatch",
-    });
-    expect(secondAutomaticResult).toEqual(firstAutomaticResult);
-
-    runtime.nextCheck(null);
-    const retryResult = await service.checkForAppUpdate({
-      currentVersion: "1.2.3",
-      releaseChannel: "stable",
-      intent: "manual",
-    });
-
-    expect(runtime.checkCount).toBe(2);
-    expect(retryResult).toEqual({
-      hasUpdate: false,
-      readyToInstall: false,
-      currentVersion: "1.2.3",
-      latestVersion: "1.2.3",
-      body: null,
-      date: null,
-      errorMessage: null,
-    });
-  });
-
-  it("keeps runtime update errors visible after a manual retry fails", async () => {
-    const { runtime, service } = createService();
-    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
-
-    await service.checkForAppUpdate({
-      currentVersion: "1.2.3",
-      releaseChannel: "stable",
-      intent: "manual",
-    });
-    runtime.failRuntime(new Error("sha512 checksum mismatch"));
-
-    runtime.failNextCheck(new Error("network down"));
-    const retryResult = await service.checkForAppUpdate({
-      currentVersion: "1.2.3",
-      releaseChannel: "stable",
-      intent: "manual",
-    });
-    const automaticResult = await service.checkForAppUpdate({
-      currentVersion: "1.2.3",
-      releaseChannel: "stable",
-      intent: "automatic",
-    });
-
-    expect(retryResult.errorMessage).toBe("network down");
-    expect(automaticResult).toEqual({
-      hasUpdate: true,
-      readyToInstall: false,
-      currentVersion: "1.2.3",
-      latestVersion: "1.2.4",
-      body: null,
-      date: "2026-04-28T00:00:00.000Z",
-      errorMessage: "sha512 checksum mismatch",
     });
   });
 });

--- a/packages/desktop/src/features/app-update-service.test.ts
+++ b/packages/desktop/src/features/app-update-service.test.ts
@@ -19,7 +19,15 @@ class FakeAppUpdateRuntime implements AppUpdateRuntime {
   private configuration: AppUpdateRuntimeConfiguration | null = null;
   private downloadableUpdate: RuntimeUpdateInfo | null = null;
   private downloadedUpdate: RuntimeUpdateInfo | null = null;
+  private activeDownload: {
+    info: RuntimeUpdateInfo;
+    promise: Promise<void>;
+    resolve(): void;
+    reject(error: Error): void;
+  } | null = null;
   checkCount = 0;
+  downloadCallCount = 0;
+  downloadedVersions: string[] = [];
   installedVersions: string[] = [];
   installModes: Array<{ isSilent: boolean; isForceRunAfter: boolean }> = [];
 
@@ -64,7 +72,39 @@ class FakeAppUpdateRuntime implements AppUpdateRuntime {
 
   finishUpdateDownload(info: RuntimeUpdateInfo): void {
     this.downloadedUpdate = info;
+    this.downloadedVersions.push(info.version);
     this.configuration?.onUpdateDownloaded(info);
+  }
+
+  beginUpdateDownload(info: RuntimeUpdateInfo): {
+    resolve(): void;
+    reject(error: Error): void;
+  } {
+    this.downloadableUpdate = info;
+    this.prepareUpdate(info);
+    let resolvePromise!: () => void;
+    let rejectPromise!: (error: Error) => void;
+    const promise = new Promise<void>((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    });
+    void promise.catch(() => undefined);
+    const activeDownload = {
+      info,
+      promise,
+      resolve: () => {
+        this.finishUpdateDownload(info);
+        this.activeDownload = null;
+        resolvePromise();
+      },
+      reject: (error: Error) => {
+        this.configuration?.onError(error);
+        this.activeDownload = null;
+        rejectPromise(error);
+      },
+    };
+    this.activeDownload = activeDownload;
+    return { resolve: activeDownload.resolve, reject: activeDownload.reject };
   }
 
   async checkForUpdates(): Promise<{
@@ -91,6 +131,10 @@ class FakeAppUpdateRuntime implements AppUpdateRuntime {
   }
 
   async downloadUpdate(): Promise<void> {
+    this.downloadCallCount += 1;
+    if (this.activeDownload) {
+      return this.activeDownload.promise;
+    }
     if (this.downloadableUpdate) {
       this.finishUpdateDownload(this.downloadableUpdate);
     }
@@ -162,6 +206,33 @@ describe("app update service", () => {
       date: "2026-04-28T00:00:00.000Z",
       errorMessage: null,
     });
+  });
+
+  it("waits for an automatic poll before starting a manual rollout-bypassing check", async () => {
+    const { runtime, service } = createService();
+    const automaticCheck = runtime.deferNextCheck();
+    const automaticPending = service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+    const manualPending = service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "manual",
+    });
+
+    await Promise.resolve();
+    expect(runtime.checkCount).toBe(1);
+
+    automaticCheck.resolve({ isUpdateAvailable: false, updateInfo: rolledOutUpdate });
+    await automaticPending;
+    const manualResult = await manualPending;
+
+    expect(runtime.checkCount).toBe(2);
+    expect(manualResult.hasUpdate).toBe(true);
+    expect(manualResult.latestVersion).toBe("1.2.4");
   });
 
   it("performs a fresh manual check when an update is already cached", async () => {
@@ -353,6 +424,60 @@ describe("app update service", () => {
     expect(runtime.installModes).toEqual([{ isSilent: false, isForceRunAfter: true }]);
   });
 
+  it("waits for a stale active download before downloading and installing the rechecked version", async () => {
+    const { runtime, service } = createService({ bucket: async () => 0 });
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+    const staleDownload = runtime.beginUpdateDownload(rolledOutUpdate);
+
+    const newerUpdate = { ...rolledOutUpdate, version: "1.2.5" };
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: newerUpdate });
+    const installPending = service.downloadAndInstallUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+    });
+    await Promise.resolve();
+    expect(runtime.installedVersions).toEqual([]);
+
+    staleDownload.resolve();
+    const result = await installPending;
+
+    expect(result.installed).toBe(true);
+    expect(runtime.downloadedVersions).toEqual(["1.2.4", "1.2.5"]);
+    expect(runtime.installedVersions).toEqual(["1.2.5"]);
+  });
+
+  it("installs the rechecked version when the stale active download fails", async () => {
+    const { runtime, service } = createService({ bucket: async () => 0 });
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+    const staleDownload = runtime.beginUpdateDownload(rolledOutUpdate);
+
+    const newerUpdate = { ...rolledOutUpdate, version: "1.2.5" };
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: newerUpdate });
+    const installPending = service.downloadAndInstallUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(runtime.downloadCallCount).toBe(1);
+
+    staleDownload.reject(new Error("old download failed"));
+    const result = await installPending;
+
+    expect(result.installed).toBe(true);
+    expect(runtime.downloadedVersions).toEqual(["1.2.5"]);
+    expect(runtime.installedVersions).toEqual(["1.2.5"]);
+  });
+
   it("trusts the runtime availability decision before comparing versions", async () => {
     const { runtime, service } = createService({ bucket: async () => 0 });
     runtime.nextCheck({ isUpdateAvailable: false, updateInfo: rolledOutUpdate });
@@ -505,6 +630,7 @@ describe("app update service", () => {
       releaseChannel: "stable",
       intent: "manual",
     });
+    runtime.prepareUpdate(rolledOutUpdate);
     runtime.failRuntime(new Error("sha512 checksum mismatch"));
 
     runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
@@ -543,6 +669,36 @@ describe("app update service", () => {
     });
   });
 
+  it("attributes a late preparation failure to the download that started it", async () => {
+    const { runtime, service } = createService({ bucket: async () => 0 });
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+    runtime.prepareUpdate(rolledOutUpdate);
+
+    const newerUpdate = { ...rolledOutUpdate, version: "1.2.5" };
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: newerUpdate });
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+    runtime.failRuntime(new Error("old download failed"));
+
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: newerUpdate });
+    const result = await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+
+    expect(result.latestVersion).toBe("1.2.5");
+    expect(result.errorMessage).toBeNull();
+  });
+
   it("performs a fresh manual check after an update preparation error", async () => {
     const { runtime, service } = createService();
     runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
@@ -552,6 +708,7 @@ describe("app update service", () => {
       releaseChannel: "stable",
       intent: "manual",
     });
+    runtime.prepareUpdate(rolledOutUpdate);
     runtime.failRuntime(new Error("sha512 checksum mismatch"));
 
     runtime.nextCheck({

--- a/packages/desktop/src/features/app-update-service.test.ts
+++ b/packages/desktop/src/features/app-update-service.test.ts
@@ -21,6 +21,7 @@ class FakeAppUpdateRuntime implements AppUpdateRuntime {
   private downloadedUpdate: RuntimeUpdateInfo | null = null;
   checkCount = 0;
   installedVersions: string[] = [];
+  installModes: Array<{ isSilent: boolean; isForceRunAfter: boolean }> = [];
 
   configure(input: AppUpdateRuntimeConfiguration): void {
     this.configuration = input;
@@ -95,9 +96,10 @@ class FakeAppUpdateRuntime implements AppUpdateRuntime {
     }
   }
 
-  quitAndInstall(): void {
+  quitAndInstall(isSilent: boolean, isForceRunAfter: boolean): void {
     if (this.downloadedUpdate) {
       this.installedVersions.push(this.downloadedUpdate.version);
+      this.installModes.push({ isSilent, isForceRunAfter });
     }
   }
 }
@@ -244,6 +246,7 @@ describe("app update service", () => {
 
     expect(installed).toBe(true);
     expect(runtime.installedVersions).toEqual(["1.2.5"]);
+    expect(runtime.installModes).toEqual([{ isSilent: true, isForceRunAfter: false }]);
   });
 
   it("does not install an older download while its replacement is still rolling out", async () => {
@@ -347,6 +350,7 @@ describe("app update service", () => {
 
     expect(result.installed).toBe(true);
     expect(runtime.installedVersions).toEqual(["1.2.5"]);
+    expect(runtime.installModes).toEqual([{ isSilent: false, isForceRunAfter: true }]);
   });
 
   it("trusts the runtime availability decision before comparing versions", async () => {
@@ -492,7 +496,7 @@ describe("app update service", () => {
     });
   });
 
-  it("discovers newer releases after an update fails to prepare", async () => {
+  it("surfaces preparation errors without blocking newer releases", async () => {
     const { runtime, service } = createService({ bucket: async () => 0 });
     runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
 
@@ -502,6 +506,23 @@ describe("app update service", () => {
       intent: "manual",
     });
     runtime.failRuntime(new Error("sha512 checksum mismatch"));
+
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+    const failedPreparation = await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+
+    expect(failedPreparation).toEqual({
+      hasUpdate: true,
+      readyToInstall: false,
+      currentVersion: "1.2.3",
+      latestVersion: "1.2.4",
+      body: null,
+      date: "2026-04-28T00:00:00.000Z",
+      errorMessage: "sha512 checksum mismatch",
+    });
 
     const newerUpdate = { ...rolledOutUpdate, version: "1.2.5" };
     runtime.nextCheck({ isUpdateAvailable: true, updateInfo: newerUpdate });

--- a/packages/desktop/src/features/app-update-service.test.ts
+++ b/packages/desktop/src/features/app-update-service.test.ts
@@ -305,6 +305,28 @@ describe("app update service", () => {
     expect(runtime.installedVersions).toEqual([]);
   });
 
+  it("does not install an unvalidated download when the quit-time check fails", async () => {
+    const { runtime, service } = createService({ bucket: async () => 0 });
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+    runtime.finishUpdateDownload(rolledOutUpdate);
+
+    runtime.failNextCheck(new Error("offline"));
+    const installed = await service.installUpdateOnQuit({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      signal: new AbortController().signal,
+    });
+
+    expect(installed).toBe(false);
+    expect(runtime.installedVersions).toEqual([]);
+  });
+
   it("rechecks for the newest release before a manual install", async () => {
     const { runtime, service } = createService({ bucket: async () => 0.99 });
     runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });

--- a/packages/desktop/src/features/app-update-service.test.ts
+++ b/packages/desktop/src/features/app-update-service.test.ts
@@ -239,6 +239,7 @@ describe("app update service", () => {
     const installed = await service.installUpdateOnQuit({
       currentVersion: "1.2.3",
       releaseChannel: "stable",
+      signal: new AbortController().signal,
     });
 
     expect(installed).toBe(true);
@@ -270,6 +271,34 @@ describe("app update service", () => {
     const installed = await service.installUpdateOnQuit({
       currentVersion: "1.2.3",
       releaseChannel: "stable",
+      signal: new AbortController().signal,
+    });
+
+    expect(installed).toBe(false);
+    expect(runtime.installedVersions).toEqual([]);
+  });
+
+  it("does not install after quit-time revalidation expires", async () => {
+    const { runtime, service } = createService({ bucket: async () => 0 });
+    runtime.nextCheck({ isUpdateAvailable: true, updateInfo: rolledOutUpdate });
+
+    await service.checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "automatic",
+    });
+    runtime.finishUpdateDownload(rolledOutUpdate);
+
+    const deadline = new AbortController();
+    deadline.abort();
+    runtime.nextCheck({
+      isUpdateAvailable: true,
+      updateInfo: { ...rolledOutUpdate, version: "1.2.5" },
+    });
+    const installed = await service.installUpdateOnQuit({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      signal: deadline.signal,
     });
 
     expect(installed).toBe(false);

--- a/packages/desktop/src/features/app-update-service.ts
+++ b/packages/desktop/src/features/app-update-service.ts
@@ -62,6 +62,10 @@ export interface AppUpdateService {
     },
     onBeforeQuit?: () => Promise<void>,
   ): Promise<AppUpdateInstallResult>;
+  installUpdateOnQuit(input: {
+    currentVersion: string;
+    releaseChannel: AppReleaseChannel;
+  }): Promise<boolean>;
 }
 
 export interface AppUpdateServiceDeps {
@@ -112,10 +116,7 @@ function getErrorMessage(error: unknown): string {
 export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateService {
   let cachedUpdateInfo: RuntimeUpdateInfo | null = null;
   let downloadedUpdateVersion: string | null = null;
-  let downloading = false;
   let configuredReleaseChannel: AppReleaseChannel | null = null;
-  let runtimeErrorMessage: string | null = null;
-  let inFlightUpdateCheckCount = 0;
 
   function isReadyToInstallVersion(version: string): boolean {
     return downloadedUpdateVersion === version;
@@ -124,23 +125,6 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
   function clearUpdateState(): void {
     cachedUpdateInfo = null;
     downloadedUpdateVersion = null;
-    downloading = false;
-    runtimeErrorMessage = null;
-  }
-
-  function buildRuntimeErrorResult(currentVersion: string): AppUpdateCheckResult | null {
-    if (!runtimeErrorMessage) {
-      return null;
-    }
-
-    const info = cachedUpdateInfo;
-    return buildCheckResult({
-      currentVersion,
-      hasUpdate: info?.version !== undefined && info.version !== currentVersion,
-      readyToInstall: false,
-      info,
-      errorMessage: runtimeErrorMessage,
-    });
   }
 
   function configureRuntime(releaseChannel: AppReleaseChannel, intent: AppUpdateCheckIntent): void {
@@ -166,23 +150,15 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
         const alreadyReady = downloadedUpdateVersion === info.version;
         cachedUpdateInfo = info;
         downloadedUpdateVersion = alreadyReady ? info.version : null;
-        downloading = !alreadyReady;
-        runtimeErrorMessage = null;
       },
       onUpdateDownloaded(info) {
         cachedUpdateInfo = info;
         downloadedUpdateVersion = info.version;
-        downloading = false;
-        runtimeErrorMessage = null;
       },
       onUpdateNotAvailable() {
         clearUpdateState();
       },
       onError(error) {
-        downloading = false;
-        if (inFlightUpdateCheckCount === 0 || cachedUpdateInfo) {
-          runtimeErrorMessage = getErrorMessage(error);
-        }
         deps.reportRuntimeError?.(error);
       },
     });
@@ -207,28 +183,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
 
     configureRuntime(releaseChannel, intent);
 
-    const runtimeErrorResult = buildRuntimeErrorResult(currentVersion);
-    if (runtimeErrorResult && intent === "automatic") {
-      return runtimeErrorResult;
-    }
-
-    const cachedVersion = cachedUpdateInfo?.version ?? null;
-    if (
-      !runtimeErrorResult &&
-      intent === "automatic" &&
-      cachedVersion &&
-      cachedVersion !== currentVersion
-    ) {
-      return buildCheckResult({
-        currentVersion,
-        hasUpdate: true,
-        readyToInstall: isReadyToInstallVersion(cachedVersion),
-        info: cachedUpdateInfo,
-      });
-    }
-
     try {
-      inFlightUpdateCheckCount += 1;
       const result = await deps.runtime.checkForUpdates();
       if (!result || !result.updateInfo || !result.isUpdateAvailable) {
         clearUpdateState();
@@ -245,8 +200,6 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
 
       if (hasUpdate) {
         cachedUpdateInfo = info;
-        downloading = !isReadyToInstallVersion(latestVersion);
-        runtimeErrorMessage = null;
         return buildCheckResult({
           currentVersion,
           hasUpdate: true,
@@ -269,8 +222,6 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
         readyToInstall: false,
         errorMessage: getErrorMessage(error),
       });
-    } finally {
-      inFlightUpdateCheckCount -= 1;
     }
   }
 
@@ -292,6 +243,26 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       };
     }
 
+    const check = await checkForAppUpdate({
+      currentVersion,
+      releaseChannel,
+      intent: "manual",
+    });
+    if (!check.hasUpdate) {
+      return {
+        installed: false,
+        version: currentVersion,
+        message: check.errorMessage ?? "No update available.",
+      };
+    }
+
+    return installCachedUpdate(currentVersion, onBeforeQuit);
+  }
+
+  async function installCachedUpdate(
+    currentVersion: string,
+    onBeforeQuit?: () => Promise<void>,
+  ): Promise<AppUpdateInstallResult> {
     if (!cachedUpdateInfo) {
       return {
         installed: false,
@@ -299,8 +270,6 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
         message: "No update available. Check for updates first.",
       };
     }
-
-    configureRuntime(releaseChannel, "manual");
 
     const readyVersion = cachedUpdateInfo.version;
     if (isReadyToInstallVersion(readyVersion)) {
@@ -312,20 +281,16 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       };
     }
 
-    if (downloading) {
-      return {
-        installed: false,
-        version: currentVersion,
-        message: "Update is still being prepared. Try again in a moment.",
-      };
-    }
-
-    downloading = true;
-
     try {
       await deps.runtime.downloadUpdate();
+      if (cachedUpdateInfo?.version !== readyVersion) {
+        return {
+          installed: false,
+          version: currentVersion,
+          message: "A newer update was found and will be installed later.",
+        };
+      }
       downloadedUpdateVersion = readyVersion;
-      downloading = false;
       await performQuitAndInstall(deps.runtime, onBeforeQuit);
 
       return {
@@ -334,7 +299,6 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
         message: "Update downloaded. The app will restart shortly.",
       };
     } catch (error) {
-      downloading = false;
       const message = error instanceof Error ? error.message : String(error);
       deps.reportInstallError?.(message);
       return {
@@ -345,8 +309,33 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     }
   }
 
+  async function installUpdateOnQuit({
+    currentVersion,
+    releaseChannel,
+  }: {
+    currentVersion: string;
+    releaseChannel: AppReleaseChannel;
+  }): Promise<boolean> {
+    if (!deps.isPackaged() || !downloadedUpdateVersion) {
+      return false;
+    }
+
+    const check = await checkForAppUpdate({
+      currentVersion,
+      releaseChannel,
+      intent: "automatic",
+    });
+    if (!check.hasUpdate) {
+      return false;
+    }
+
+    const result = await installCachedUpdate(currentVersion);
+    return result.installed;
+  }
+
   return {
     checkForAppUpdate,
     downloadAndInstallUpdate,
+    installUpdateOnQuit,
   };
 }

--- a/packages/desktop/src/features/app-update-service.ts
+++ b/packages/desktop/src/features/app-update-service.ts
@@ -101,10 +101,16 @@ function buildCheckResult(input: {
 
 async function performQuitAndInstall(
   runtime: AppUpdateRuntime,
-  onBeforeQuit?: () => Promise<void>,
+  {
+    onBeforeQuit,
+    restart,
+  }: {
+    onBeforeQuit?: () => Promise<void>;
+    restart: boolean;
+  },
 ): Promise<void> {
   if (onBeforeQuit) await onBeforeQuit();
-  runtime.quitAndInstall(/* isSilent */ false, /* isForceRunAfter */ true);
+  runtime.quitAndInstall(/* isSilent */ !restart, /* isForceRunAfter */ restart);
 }
 
 function getErrorMessage(error: unknown): string {
@@ -126,6 +132,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
   let cachedUpdateInfo: RuntimeUpdateInfo | null = null;
   let downloadedUpdateVersion: string | null = null;
   let configuredReleaseChannel: AppReleaseChannel | null = null;
+  let preparationError: { version: string; message: string } | null = null;
 
   function isReadyToInstallVersion(version: string): boolean {
     return downloadedUpdateVersion === version;
@@ -134,6 +141,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
   function clearUpdateState(): void {
     cachedUpdateInfo = null;
     downloadedUpdateVersion = null;
+    preparationError = null;
   }
 
   function configureRuntime(releaseChannel: AppReleaseChannel, intent: AppUpdateCheckIntent): void {
@@ -163,11 +171,18 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       onUpdateDownloaded(info) {
         cachedUpdateInfo = info;
         downloadedUpdateVersion = info.version;
+        preparationError = null;
       },
       onUpdateNotAvailable() {
         clearUpdateState();
       },
       onError(error) {
+        if (cachedUpdateInfo) {
+          preparationError = {
+            version: cachedUpdateInfo.version,
+            message: getErrorMessage(error),
+          };
+        }
         deps.reportRuntimeError?.(error);
       },
     });
@@ -209,11 +224,17 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
 
       if (hasUpdate) {
         cachedUpdateInfo = info;
+        const errorMessage =
+          preparationError?.version === latestVersion ? preparationError.message : null;
+        if (!errorMessage) {
+          preparationError = null;
+        }
         return buildCheckResult({
           currentVersion,
           hasUpdate: true,
           readyToInstall: isReadyToInstallVersion(latestVersion),
           info,
+          errorMessage,
         });
       }
 
@@ -265,13 +286,20 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       };
     }
 
-    return installCachedUpdate(currentVersion, onBeforeQuit);
+    return installCachedUpdate(currentVersion, { onBeforeQuit, restart: true });
   }
 
   async function installCachedUpdate(
     currentVersion: string,
-    onBeforeQuit?: () => Promise<void>,
-    signal?: AbortSignal,
+    {
+      onBeforeQuit,
+      signal,
+      restart,
+    }: {
+      onBeforeQuit?: () => Promise<void>;
+      signal?: AbortSignal;
+      restart: boolean;
+    },
   ): Promise<AppUpdateInstallResult> {
     if (!cachedUpdateInfo) {
       return {
@@ -287,7 +315,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     }
 
     if (isReadyToInstallVersion(readyVersion)) {
-      await performQuitAndInstall(deps.runtime, onBeforeQuit);
+      await performQuitAndInstall(deps.runtime, { onBeforeQuit, restart });
       return {
         installed: true,
         version: readyVersion,
@@ -308,7 +336,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
         };
       }
       downloadedUpdateVersion = readyVersion;
-      await performQuitAndInstall(deps.runtime, onBeforeQuit);
+      await performQuitAndInstall(deps.runtime, { onBeforeQuit, restart });
 
       return {
         installed: true,
@@ -348,7 +376,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       return false;
     }
 
-    const result = await installCachedUpdate(currentVersion, undefined, signal);
+    const result = await installCachedUpdate(currentVersion, { signal, restart: false });
     return result.installed;
   }
 

--- a/packages/desktop/src/features/app-update-service.ts
+++ b/packages/desktop/src/features/app-update-service.ts
@@ -65,6 +65,7 @@ export interface AppUpdateService {
   installUpdateOnQuit(input: {
     currentVersion: string;
     releaseChannel: AppReleaseChannel;
+    signal: AbortSignal;
   }): Promise<boolean>;
 }
 
@@ -262,6 +263,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
   async function installCachedUpdate(
     currentVersion: string,
     onBeforeQuit?: () => Promise<void>,
+    signal?: AbortSignal,
   ): Promise<AppUpdateInstallResult> {
     if (!cachedUpdateInfo) {
       return {
@@ -272,6 +274,14 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     }
 
     const readyVersion = cachedUpdateInfo.version;
+    if (signal?.aborted) {
+      return {
+        installed: false,
+        version: currentVersion,
+        message: "Update installation was deferred while the app quit.",
+      };
+    }
+
     if (isReadyToInstallVersion(readyVersion)) {
       await performQuitAndInstall(deps.runtime, onBeforeQuit);
       return {
@@ -283,7 +293,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
 
     try {
       await deps.runtime.downloadUpdate();
-      if (cachedUpdateInfo?.version !== readyVersion) {
+      if (signal?.aborted || cachedUpdateInfo?.version !== readyVersion) {
         return {
           installed: false,
           version: currentVersion,
@@ -312,9 +322,11 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
   async function installUpdateOnQuit({
     currentVersion,
     releaseChannel,
+    signal,
   }: {
     currentVersion: string;
     releaseChannel: AppReleaseChannel;
+    signal: AbortSignal;
   }): Promise<boolean> {
     if (!deps.isPackaged() || !downloadedUpdateVersion) {
       return false;
@@ -325,11 +337,11 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       releaseChannel,
       intent: "automatic",
     });
-    if (!check.hasUpdate) {
+    if (signal.aborted || !check.hasUpdate) {
       return false;
     }
 
-    const result = await installCachedUpdate(currentVersion);
+    const result = await installCachedUpdate(currentVersion, undefined, signal);
     return result.installed;
   }
 

--- a/packages/desktop/src/features/app-update-service.ts
+++ b/packages/desktop/src/features/app-update-service.ts
@@ -114,6 +114,14 @@ function getErrorMessage(error: unknown): string {
   return String(error);
 }
 
+function buildDeferredInstallResult(currentVersion: string): AppUpdateInstallResult {
+  return {
+    installed: false,
+    version: currentVersion,
+    message: "Update validation timed out. The update will be installed later.",
+  };
+}
+
 export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateService {
   let cachedUpdateInfo: RuntimeUpdateInfo | null = null;
   let downloadedUpdateVersion: string | null = null;
@@ -275,11 +283,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
 
     const readyVersion = cachedUpdateInfo.version;
     if (signal?.aborted) {
-      return {
-        installed: false,
-        version: currentVersion,
-        message: "Update installation was deferred while the app quit.",
-      };
+      return buildDeferredInstallResult(currentVersion);
     }
 
     if (isReadyToInstallVersion(readyVersion)) {
@@ -293,7 +297,10 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
 
     try {
       await deps.runtime.downloadUpdate();
-      if (signal?.aborted || cachedUpdateInfo?.version !== readyVersion) {
+      if (signal?.aborted) {
+        return buildDeferredInstallResult(currentVersion);
+      }
+      if (cachedUpdateInfo?.version !== readyVersion) {
         return {
           installed: false,
           version: currentVersion,

--- a/packages/desktop/src/features/app-update-service.ts
+++ b/packages/desktop/src/features/app-update-service.ts
@@ -133,6 +133,8 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
   let downloadedUpdateVersion: string | null = null;
   let configuredReleaseChannel: AppReleaseChannel | null = null;
   let preparationError: { version: string; message: string } | null = null;
+  let preparingUpdateVersion: string | null = null;
+  let checkQueue: Promise<void> = Promise.resolve();
 
   function isReadyToInstallVersion(version: string): boolean {
     return downloadedUpdateVersion === version;
@@ -142,6 +144,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     cachedUpdateInfo = null;
     downloadedUpdateVersion = null;
     preparationError = null;
+    preparingUpdateVersion = null;
   }
 
   function configureRuntime(releaseChannel: AppReleaseChannel, intent: AppUpdateCheckIntent): void {
@@ -167,25 +170,45 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
         const alreadyReady = downloadedUpdateVersion === info.version;
         cachedUpdateInfo = info;
         downloadedUpdateVersion = alreadyReady ? info.version : null;
+        if (!alreadyReady && preparingUpdateVersion === null) {
+          preparingUpdateVersion = info.version;
+        }
       },
       onUpdateDownloaded(info) {
-        cachedUpdateInfo = info;
+        // A superseded download can finish after a newer manifest check. Keep
+        // the validated manifest as the install target in that case.
+        cachedUpdateInfo ??= info;
         downloadedUpdateVersion = info.version;
-        preparationError = null;
+        if (preparingUpdateVersion === info.version) {
+          preparingUpdateVersion = null;
+        }
+        if (preparationError?.version === info.version) {
+          preparationError = null;
+        }
       },
       onUpdateNotAvailable() {
         clearUpdateState();
       },
       onError(error) {
-        if (cachedUpdateInfo) {
+        if (preparingUpdateVersion) {
           preparationError = {
-            version: cachedUpdateInfo.version,
+            version: preparingUpdateVersion,
             message: getErrorMessage(error),
           };
+          preparingUpdateVersion = null;
         }
         deps.reportRuntimeError?.(error);
       },
     });
+  }
+
+  function runCheckExclusively<T>(check: () => Promise<T>): Promise<T> {
+    const result = checkQueue.then(check, check);
+    checkQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 
   async function checkForAppUpdate({
@@ -205,54 +228,56 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
       });
     }
 
-    configureRuntime(releaseChannel, intent);
+    return runCheckExclusively(async () => {
+      configureRuntime(releaseChannel, intent);
 
-    try {
-      const result = await deps.runtime.checkForUpdates();
-      if (!result || !result.updateInfo || !result.isUpdateAvailable) {
+      try {
+        const result = await deps.runtime.checkForUpdates();
+        if (!result || !result.updateInfo || !result.isUpdateAvailable) {
+          clearUpdateState();
+          return buildCheckResult({
+            currentVersion,
+            hasUpdate: false,
+            readyToInstall: false,
+          });
+        }
+
+        const info = result.updateInfo;
+        const latestVersion = info.version;
+        const hasUpdate = latestVersion !== currentVersion;
+
+        if (hasUpdate) {
+          cachedUpdateInfo = info;
+          const errorMessage =
+            preparationError?.version === latestVersion ? preparationError.message : null;
+          if (!errorMessage) {
+            preparationError = null;
+          }
+          return buildCheckResult({
+            currentVersion,
+            hasUpdate: true,
+            readyToInstall: isReadyToInstallVersion(latestVersion),
+            info,
+            errorMessage,
+          });
+        }
+
         clearUpdateState();
         return buildCheckResult({
           currentVersion,
           hasUpdate: false,
           readyToInstall: false,
         });
-      }
-
-      const info = result.updateInfo;
-      const latestVersion = info.version;
-      const hasUpdate = latestVersion !== currentVersion;
-
-      if (hasUpdate) {
-        cachedUpdateInfo = info;
-        const errorMessage =
-          preparationError?.version === latestVersion ? preparationError.message : null;
-        if (!errorMessage) {
-          preparationError = null;
-        }
+      } catch (error) {
+        deps.reportCheckError?.(error);
         return buildCheckResult({
           currentVersion,
-          hasUpdate: true,
-          readyToInstall: isReadyToInstallVersion(latestVersion),
-          info,
-          errorMessage,
+          hasUpdate: false,
+          readyToInstall: false,
+          errorMessage: getErrorMessage(error),
         });
       }
-
-      clearUpdateState();
-      return buildCheckResult({
-        currentVersion,
-        hasUpdate: false,
-        readyToInstall: false,
-      });
-    } catch (error) {
-      deps.reportCheckError?.(error);
-      return buildCheckResult({
-        currentVersion,
-        hasUpdate: false,
-        readyToInstall: false,
-        errorMessage: getErrorMessage(error),
-      });
-    }
+    });
   }
 
   async function downloadAndInstallUpdate(
@@ -287,6 +312,41 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     }
 
     return installCachedUpdate(currentVersion, { onBeforeQuit, restart: true });
+  }
+
+  async function ensureUpdateDownloaded(
+    readyVersion: string,
+    signal?: AbortSignal,
+  ): Promise<"ready" | "aborted" | "superseded"> {
+    while (!isReadyToInstallVersion(readyVersion)) {
+      if (signal?.aborted) return "aborted";
+      if (cachedUpdateInfo?.version !== readyVersion) return "superseded";
+
+      const attemptedVersion: string = preparingUpdateVersion ?? readyVersion;
+      preparingUpdateVersion ??= readyVersion;
+      try {
+        await deps.runtime.downloadUpdate();
+      } catch (error) {
+        if (
+          attemptedVersion !== readyVersion &&
+          cachedUpdateInfo?.version === readyVersion &&
+          !signal?.aborted
+        ) {
+          continue;
+        }
+        throw error;
+      }
+
+      // electron-updater can return an older, already-running download. Its
+      // event clears that version, then the next iteration starts the newly
+      // validated release instead of treating the stale artifact as ready.
+      if (attemptedVersion === readyVersion && !isReadyToInstallVersion(readyVersion)) {
+        downloadedUpdateVersion = readyVersion;
+        preparingUpdateVersion = null;
+      }
+    }
+
+    return signal?.aborted ? "aborted" : "ready";
   }
 
   async function installCachedUpdate(
@@ -324,18 +384,17 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     }
 
     try {
-      await deps.runtime.downloadUpdate();
-      if (signal?.aborted) {
+      const preparation = await ensureUpdateDownloaded(readyVersion, signal);
+      if (preparation === "aborted") {
         return buildDeferredInstallResult(currentVersion);
       }
-      if (cachedUpdateInfo?.version !== readyVersion) {
+      if (preparation === "superseded") {
         return {
           installed: false,
           version: currentVersion,
           message: "A newer update was found and will be installed later.",
         };
       }
-      downloadedUpdateVersion = readyVersion;
       await performQuitAndInstall(deps.runtime, { onBeforeQuit, restart });
 
       return {

--- a/packages/desktop/src/features/auto-updater.test.ts
+++ b/packages/desktop/src/features/auto-updater.test.ts
@@ -19,17 +19,7 @@ import {
   resolveStagingUserId,
   rolloutManifestSchema,
   shouldAdmitToRollout,
-  shouldAutoInstallOnQuit,
 } from "./auto-updater";
-
-describe("shouldAutoInstallOnQuit", () => {
-  it("auto-installs on quit everywhere except Linux AppImage", () => {
-    expect(shouldAutoInstallOnQuit({ platform: "linux", isAppImage: true })).toBe(false);
-    expect(shouldAutoInstallOnQuit({ platform: "linux", isAppImage: false })).toBe(true);
-    expect(shouldAutoInstallOnQuit({ platform: "darwin", isAppImage: false })).toBe(true);
-    expect(shouldAutoInstallOnQuit({ platform: "win32", isAppImage: false })).toBe(true);
-  });
-});
 
 describe("shouldAdmitToRollout", () => {
   it("admits beta, missing rollout hours, zero-hour rollout, and missing release date", () => {

--- a/packages/desktop/src/features/auto-updater.test.ts
+++ b/packages/desktop/src/features/auto-updater.test.ts
@@ -19,7 +19,17 @@ import {
   resolveStagingUserId,
   rolloutManifestSchema,
   shouldAdmitToRollout,
+  shouldInstallAppUpdateOnQuit,
 } from "./auto-updater";
+
+describe("shouldInstallAppUpdateOnQuit", () => {
+  it("keeps Linux AppImage updates on the manual install path", () => {
+    expect(shouldInstallAppUpdateOnQuit({ platform: "linux", isAppImage: true })).toBe(false);
+    expect(shouldInstallAppUpdateOnQuit({ platform: "linux", isAppImage: false })).toBe(true);
+    expect(shouldInstallAppUpdateOnQuit({ platform: "darwin", isAppImage: false })).toBe(true);
+    expect(shouldInstallAppUpdateOnQuit({ platform: "win32", isAppImage: false })).toBe(true);
+  });
+});
 
 describe("shouldAdmitToRollout", () => {
   it("admits beta, missing rollout hours, zero-hour rollout, and missing release date", () => {

--- a/packages/desktop/src/features/auto-updater.ts
+++ b/packages/desktop/src/features/auto-updater.ts
@@ -76,31 +76,16 @@ export function getStagingUserId(): Promise<string> {
   return cachedStagingUserIdPromise;
 }
 
-// AppImages have no install step. electron-updater "installs" by unlinking the
-// running file and mv-ing the downloaded one into place; on app quit it does this
-// via a *blocking* execFileSync(newAppImage, { APPIMAGE_EXIT_AFTER_INSTALL: "true" }).
-// That env var is only honored by AppImageLauncher, so without it the freshly
-// launched process boots the full app and never exits — the quit hangs forever,
-// with the old binary already deleted. We therefore install AppImages only on
-// explicit quitAndInstall (the "Update now" button), which takes the non-blocking
-// spawn path. Every other target keeps auto-install-on-quit, which works there.
-export function shouldAutoInstallOnQuit(input: {
-  platform: NodeJS.Platform;
-  isAppImage: boolean;
-}): boolean {
-  return !(input.platform === "linux" && input.isAppImage);
-}
-
 class ElectronAppUpdateRuntime implements AppUpdateRuntime {
   private configured = false;
 
   configure(input: AppUpdateRuntimeConfiguration): void {
     autoUpdater.autoDownload = true;
     autoUpdater.autoRunAppAfterInstall = true;
-    autoUpdater.autoInstallOnAppQuit = shouldAutoInstallOnQuit({
-      platform: process.platform,
-      isAppImage: Boolean(process.env.APPIMAGE),
-    });
+    // Paseo revalidates the current manifest before explicitly installing on quit.
+    // Electron's built-in handler would install an older download without checking
+    // whether a newer release has superseded it.
+    autoUpdater.autoInstallOnAppQuit = false;
     autoUpdater.allowPrerelease = input.releaseChannel === "beta";
     autoUpdater.channel = input.releaseChannel === "beta" ? "beta" : "latest";
     autoUpdater.allowDowngrade = false;
@@ -193,4 +178,14 @@ export async function downloadAndInstallUpdate(
     { currentVersion, releaseChannel },
     onBeforeQuit,
   );
+}
+
+export async function installAppUpdateOnQuit({
+  currentVersion,
+  releaseChannel,
+}: {
+  currentVersion: string;
+  releaseChannel: AppReleaseChannel;
+}): Promise<boolean> {
+  return appUpdateService.installUpdateOnQuit({ currentVersion, releaseChannel });
 }

--- a/packages/desktop/src/features/auto-updater.ts
+++ b/packages/desktop/src/features/auto-updater.ts
@@ -183,9 +183,11 @@ export async function downloadAndInstallUpdate(
 export async function installAppUpdateOnQuit({
   currentVersion,
   releaseChannel,
+  signal,
 }: {
   currentVersion: string;
   releaseChannel: AppReleaseChannel;
+  signal: AbortSignal;
 }): Promise<boolean> {
-  return appUpdateService.installUpdateOnQuit({ currentVersion, releaseChannel });
+  return appUpdateService.installUpdateOnQuit({ currentVersion, releaseChannel, signal });
 }

--- a/packages/desktop/src/features/auto-updater.ts
+++ b/packages/desktop/src/features/auto-updater.ts
@@ -128,6 +128,7 @@ class ElectronAppUpdateRuntime implements AppUpdateRuntime {
   }
 
   quitAndInstall(isSilent: boolean, isForceRunAfter: boolean): void {
+    autoUpdater.autoRunAppAfterInstall = isForceRunAfter;
     autoUpdater.quitAndInstall(isSilent, isForceRunAfter);
   }
 }

--- a/packages/desktop/src/features/auto-updater.ts
+++ b/packages/desktop/src/features/auto-updater.ts
@@ -76,6 +76,15 @@ export function getStagingUserId(): Promise<string> {
   return cachedStagingUserIdPromise;
 }
 
+export function shouldInstallAppUpdateOnQuit(input: {
+  platform: NodeJS.Platform;
+  isAppImage: boolean;
+}): boolean {
+  // AppImage's no-relaunch install path blocks while launching the replacement
+  // binary, which can hang after the running file has already been replaced.
+  return !(input.platform === "linux" && input.isAppImage);
+}
+
 class ElectronAppUpdateRuntime implements AppUpdateRuntime {
   private configured = false;
 
@@ -190,5 +199,14 @@ export async function installAppUpdateOnQuit({
   releaseChannel: AppReleaseChannel;
   signal: AbortSignal;
 }): Promise<boolean> {
+  if (
+    !shouldInstallAppUpdateOnQuit({
+      platform: process.platform,
+      isAppImage: Boolean(process.env.APPIMAGE),
+    })
+  ) {
+    return false;
+  }
+
   return appUpdateService.installUpdateOnQuit({ currentVersion, releaseChannel, signal });
 }

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -96,7 +96,7 @@ const APP_SCHEME = "paseo";
 const PASEO_DEBUG = process.env.PASEO_DEBUG === "1";
 const DISABLE_SINGLE_INSTANCE_LOCK = process.env.PASEO_DISABLE_SINGLE_INSTANCE_LOCK === "1";
 const APP_NAME = process.env.PASEO_TEST_APP_NAME?.trim() || "Paseo";
-const UPDATE_REVALIDATION_TIMEOUT_MS = 5_000;
+const UPDATE_QUIT_DEADLINE_MS = 5_000;
 const pendingBrowserWindowOpenRequests = new PendingBrowserWindowOpenRequests();
 
 app.setName(APP_NAME);
@@ -949,7 +949,7 @@ const quitLifecycle = createQuitLifecycle({
       signal,
     });
   },
-  createUpdateRevalidationSignal: () => AbortSignal.timeout(UPDATE_REVALIDATION_TIMEOUT_MS),
+  createUpdateDeadlineSignal: () => AbortSignal.timeout(UPDATE_QUIT_DEADLINE_MS),
   onStopError: (error) => {
     log.error("[desktop daemon] failed to stop managed daemon on quit", error);
   },

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -12,6 +12,7 @@ import { existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import {
   app,
+  autoUpdater as electronAutoUpdater,
   BrowserWindow,
   clipboard,
   Menu,
@@ -81,7 +82,7 @@ import {
   stopDesktopDaemonViaCli,
 } from "./daemon/daemon-manager.js";
 import {
-  createBeforeQuitHandler,
+  createQuitLifecycle,
   stopDesktopManagedDaemonOnQuitIfNeeded,
 } from "./daemon/quit-lifecycle.js";
 import { runDesktopStartup } from "./desktop-startup.js";
@@ -95,6 +96,7 @@ const APP_SCHEME = "paseo";
 const PASEO_DEBUG = process.env.PASEO_DEBUG === "1";
 const DISABLE_SINGLE_INSTANCE_LOCK = process.env.PASEO_DISABLE_SINGLE_INSTANCE_LOCK === "1";
 const APP_NAME = process.env.PASEO_TEST_APP_NAME?.trim() || "Paseo";
+const UPDATE_REVALIDATION_TIMEOUT_MS = 5_000;
 const pendingBrowserWindowOpenRequests = new PendingBrowserWindowOpenRequests();
 
 app.setName(APP_NAME);
@@ -929,33 +931,36 @@ function showDaemonShutdownDialog(): void {
   }
 }
 
-app.on(
-  "before-quit",
-  createBeforeQuitHandler({
-    app,
-    closeTransportSessions: closeAllTransportSessions,
-    stopDesktopManagedDaemonIfNeeded: () =>
-      stopDesktopManagedDaemonOnQuitIfNeeded({
-        settingsStore: getDesktopSettingsStore(),
-        isDesktopManagedDaemonRunning: isDesktopManagedDaemonRunningSync,
-        stopDaemon: () => stopDesktopDaemonViaCli("quit"),
-        showShutdownFeedback: showDaemonShutdownDialog,
-      }),
-    installAppUpdateOnQuit: async () => {
-      const settings = await getDesktopSettingsStore().get();
-      return installAppUpdateOnQuit({
-        currentVersion: app.getVersion(),
-        releaseChannel: settings.releaseChannel,
-      });
-    },
-    onStopError: (error) => {
-      log.error("[desktop daemon] failed to stop managed daemon on quit", error);
-    },
-    onUpdateError: (error) => {
-      log.error("[auto-updater] failed to validate downloaded update on quit", error);
-    },
-  }),
-);
+const quitLifecycle = createQuitLifecycle({
+  app,
+  closeTransportSessions: closeAllTransportSessions,
+  stopDesktopManagedDaemonIfNeeded: () =>
+    stopDesktopManagedDaemonOnQuitIfNeeded({
+      settingsStore: getDesktopSettingsStore(),
+      isDesktopManagedDaemonRunning: isDesktopManagedDaemonRunningSync,
+      stopDaemon: () => stopDesktopDaemonViaCli("quit"),
+      showShutdownFeedback: showDaemonShutdownDialog,
+    }),
+  installAppUpdateOnQuit: async (signal) => {
+    const settings = await getDesktopSettingsStore().get();
+    return installAppUpdateOnQuit({
+      currentVersion: app.getVersion(),
+      releaseChannel: settings.releaseChannel,
+      signal,
+    });
+  },
+  createUpdateRevalidationSignal: () => AbortSignal.timeout(UPDATE_REVALIDATION_TIMEOUT_MS),
+  onStopError: (error) => {
+    log.error("[desktop daemon] failed to stop managed daemon on quit", error);
+  },
+  onUpdateError: (error) => {
+    log.error("[auto-updater] failed to validate downloaded update on quit", error);
+  },
+});
+
+// electron-updater forwards this event through Electron's built-in autoUpdater.
+electronAutoUpdater.on("before-quit-for-update", quitLifecycle.handleBeforeQuitForUpdate);
+app.on("before-quit", quitLifecycle.handleBeforeQuit);
 
 app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -88,6 +88,7 @@ import { runDesktopStartup } from "./desktop-startup.js";
 import { autoUpdateInstalledSkills } from "./integrations/skills/index.js";
 import { registerBrowserAutomationIpc } from "./features/browser-automation/ipc.js";
 import { BrowserKeyboard } from "./features/browser-keyboard/index.js";
+import { installAppUpdateOnQuit } from "./features/auto-updater.js";
 
 const DEV_SERVER_URL = process.env.EXPO_DEV_URL ?? "http://localhost:8081";
 const APP_SCHEME = "paseo";
@@ -940,8 +941,18 @@ app.on(
         stopDaemon: () => stopDesktopDaemonViaCli("quit"),
         showShutdownFeedback: showDaemonShutdownDialog,
       }),
+    installAppUpdateOnQuit: async () => {
+      const settings = await getDesktopSettingsStore().get();
+      return installAppUpdateOnQuit({
+        currentVersion: app.getVersion(),
+        releaseChannel: settings.releaseChannel,
+      });
+    },
     onStopError: (error) => {
       log.error("[desktop daemon] failed to stop managed daemon on quit", error);
+    },
+    onUpdateError: (error) => {
+      log.error("[auto-updater] failed to validate downloaded update on quit", error);
     },
   }),
 );


### PR DESCRIPTION
### Linked issue

Refs #2103

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Desktop now rechecks the current release manifest before installing an update that was downloaded earlier. A newer release supersedes the cached build while still respecting rollout admission; users who are not yet admitted to the replacement skip the older install instead of upgrading twice.

Manual updates also recheck before installation. Updater-initiated quits bypass normal quit handling, and quit-time revalidation stops after five seconds so a stalled network request cannot trap the app while it is closing. If validation is offline or times out, installation is deferred rather than risking a superseded cached build.

Normal quit keeps the existing silent/no-relaunch behavior, while **Update now** still restarts after installation. The updater handoff has its own five-second fallback, background preparation failures remain visible without preventing a fresh check for a newer release, and Linux AppImage builds retain their manual-install-only safety path.

### How did you verify it

- Ran 39 focused desktop tests covering newest-release precedence, rollout rejection, offline fail-closed behavior, preparation failures, manual rechecks, overlapping check/download serialization, stale-download recovery, silent versus restarting install modes, updater-initiated quit bypass, revalidation timeout, handoff timeout, AppImage policy, and prevention of late installation.
- Built the Electron main process with `npm run build:main --workspace=@getpaseo/desktop`.
- Ran `npm run typecheck`, `npm run lint`, and `npm run format` successfully.
- CI runs the full desktop test workspace on Linux and Windows and builds/smokes the unpacked Linux desktop app.

Before releasing, exercise a real packaged update on macOS and Windows: stage release N, publish N+1, then quit and confirm N+1 wins (or N is skipped when rollout denies N+1). Confirm normal quit stays closed after installing, and verify that **Update now** exits and restarts without re-entering normal quit handling. On AppImage, confirm ordinary quit does not install and **Update now** still uses the non-blocking path.

### Risk surface

The unit tests cover lifecycle ordering through typed in-process fakes. They do not execute the platform updater implementations themselves; the `before-quit-for-update` behavior still needs the packaged-update smoke above, particularly on macOS where Electron delegates installation to its native updater.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI changes)
- [x] Tests added or updated where it made sense