### PR TITLE
Record the 0.1.110 ACP hotfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.110 - 2026-07-16
+
+### Fixed
+
+- Kimi and other ACP agents now stay marked as running while a response is actively streaming ([#2148](https://github.com/getpaseo/paseo/pull/2148))
+
 ## 0.1.109 - 2026-07-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paseo",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paseo",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "workspaces": [
@@ -35162,7 +35162,7 @@
     },
     "packages/app": {
       "name": "@getpaseo/app",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -36181,12 +36181,12 @@
     },
     "packages/cli": {
       "name": "@getpaseo/cli",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "dependencies": {
         "@clack/prompts": "^1.0.0",
-        "@getpaseo/client": "0.1.109",
-        "@getpaseo/protocol": "0.1.109",
-        "@getpaseo/server": "0.1.109",
+        "@getpaseo/client": "0.1.110",
+        "@getpaseo/protocol": "0.1.110",
+        "@getpaseo/server": "0.1.110",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "mime-types": "^2.1.35",
@@ -36432,10 +36432,10 @@
     },
     "packages/client": {
       "name": "@getpaseo/client",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "dependencies": {
-        "@getpaseo/protocol": "0.1.109",
-        "@getpaseo/relay": "0.1.109",
+        "@getpaseo/protocol": "0.1.110",
+        "@getpaseo/relay": "0.1.110",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -36446,7 +36446,7 @@
     },
     "packages/desktop": {
       "name": "@getpaseo/desktop",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@getpaseo/cli": "*",
@@ -36689,7 +36689,7 @@
     },
     "packages/expo-two-way-audio": {
       "name": "@getpaseo/expo-two-way-audio",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -37585,7 +37585,7 @@
     },
     "packages/highlight": {
       "name": "@getpaseo/highlight",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "dependencies": {
         "@codemirror/language": "^6.12.3",
         "@codemirror/legacy-modes": "^6.5.3",
@@ -37817,7 +37817,7 @@
     },
     "packages/protocol": {
       "name": "@getpaseo/protocol",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "dependencies": {
         "zod": "^4.4.3"
       },
@@ -37830,7 +37830,7 @@
     },
     "packages/relay": {
       "name": "@getpaseo/relay",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "dependencies": {
         "base64-js": "^1.5.1",
         "tweetnacl": "^1.0.3",
@@ -38048,15 +38048,15 @@
     },
     "packages/server": {
       "name": "@getpaseo/server",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.17.1",
         "@anthropic-ai/claude-agent-sdk": "^0.3.195",
         "@anthropic-ai/sdk": "^0.104.2",
-        "@getpaseo/client": "0.1.109",
-        "@getpaseo/highlight": "0.1.109",
-        "@getpaseo/protocol": "0.1.109",
-        "@getpaseo/relay": "0.1.109",
+        "@getpaseo/client": "0.1.110",
+        "@getpaseo/highlight": "0.1.110",
+        "@getpaseo/protocol": "0.1.110",
+        "@getpaseo/relay": "0.1.110",
         "@isaacs/ttlcache": "^2.1.4",
         "@modelcontextprotocol/sdk": "^1.20.1",
         "@opencode-ai/sdk": "1.14.46",
@@ -38593,7 +38593,7 @@
     },
     "packages/website": {
       "name": "@getpaseo/website",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "dependencies": {
         "@cloudflare/vite-plugin": "^1.29.1",
         "@cloudflare/workers-types": "^4.20260317.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paseo",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "private": true,
   "description": "Paseo: voice-controlled development environment for local AI coding agents",
   "keywords": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/app",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "private": true,
   "main": "index.ts",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/cli",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "description": "Paseo CLI - control your AI coding agents from the command line",
   "bin": {
     "paseo": "bin/paseo"
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.0.0",
-    "@getpaseo/client": "0.1.109",
-    "@getpaseo/protocol": "0.1.109",
-    "@getpaseo/server": "0.1.109",
+    "@getpaseo/client": "0.1.110",
+    "@getpaseo/protocol": "0.1.110",
+    "@getpaseo/server": "0.1.110",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "mime-types": "^2.1.35",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/client",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "description": "Paseo client SDK package",
   "files": [
     "dist",
@@ -35,8 +35,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@getpaseo/protocol": "0.1.109",
-    "@getpaseo/relay": "0.1.109",
+    "@getpaseo/protocol": "0.1.110",
+    "@getpaseo/relay": "0.1.110",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/desktop",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "private": true,
   "description": "Paseo desktop app (Electron wrapper)",
   "homepage": "https://paseo.sh",

--- a/packages/expo-two-way-audio/package.json
+++ b/packages/expo-two-way-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/expo-two-way-audio",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "description": "Native module for two way audio streaming",
   "keywords": [
     "ExpoTwoWayAudio",

--- a/packages/highlight/package.json
+++ b/packages/highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/highlight",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "files": [
     "dist",
     "!dist/**/*.map"

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/protocol",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "description": "Paseo shared protocol schemas and wire types",
   "files": [
     "dist",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/relay",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "description": "Paseo relay for bridging daemon and client connections",
   "files": [
     "dist",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/server",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "description": "Paseo backend server",
   "files": [
     "dist/server",
@@ -67,10 +67,10 @@
     "@agentclientprotocol/sdk": "^0.17.1",
     "@anthropic-ai/claude-agent-sdk": "^0.3.195",
     "@anthropic-ai/sdk": "^0.104.2",
-    "@getpaseo/client": "0.1.109",
-    "@getpaseo/highlight": "0.1.109",
-    "@getpaseo/protocol": "0.1.109",
-    "@getpaseo/relay": "0.1.109",
+    "@getpaseo/client": "0.1.110",
+    "@getpaseo/highlight": "0.1.110",
+    "@getpaseo/protocol": "0.1.110",
+    "@getpaseo/relay": "0.1.110",
     "@isaacs/ttlcache": "^2.1.4",
     "@modelcontextprotocol/sdk": "^1.20.1",
     "@opencode-ai/sdk": "1.14.46",

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2208,8 +2208,7 @@ describe("ACPAgentSession", () => {
     expect(assistantMessages[2].messageId).not.toBe(assistantMessages[0].messageId);
   });
 
-  test("starts an autonomous turn for spontaneous session updates outside a foreground turn", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
+  test("keeps ACP configuration notifications outside the turn lifecycle", async () => {
     const session = createSession();
     asInternals<ACPSessionInternals>(session).sessionId = "session-1";
 
@@ -2221,49 +2220,26 @@ describe("ACPAgentSession", () => {
     await session.sessionUpdate({
       sessionId: "session-1",
       update: {
-        sessionUpdate: "agent_message_chunk",
-        messageId: "autonomous-msg",
-        content: { type: "text", text: "Autonomous update" },
+        sessionUpdate: "config_option_update",
+        configOptions: [
+          selectConfigOption("mode", ["plan", "yolo"], "yolo"),
+          selectConfigOption("model", ["kimi-code/kimi-for-coding"]),
+          selectConfigOption("thought_level", ["off", "on"], "on"),
+        ],
       } as SessionUpdate,
     });
 
-    // Should emit turn_started before the timeline item.
-    const turnStartedIndex = events.findIndex((e) => e.type === "turn_started");
-    expect(turnStartedIndex).toBeGreaterThanOrEqual(0);
-    const timelineIndex = events.findIndex(
-      (e) =>
-        e.type === "timeline" &&
-        e.item.type === "assistant_message" &&
-        e.item.text === "Autonomous update",
-    );
-    expect(timelineIndex).toBeGreaterThan(turnStartedIndex);
-
-    const turnStarted = events[turnStartedIndex];
-    expect(turnStarted.type).toBe("turn_started");
-    const autonomousTurnId = (turnStarted as { turnId?: string }).turnId;
-    expect(autonomousTurnId).toEqual(expect.any(String));
-
-    // Timeline item should be tagged with the autonomous turn id.
-    const timelineEvent = events[timelineIndex];
-    expect(timelineEvent.type).toBe("timeline");
-    expect((timelineEvent as { turnId?: string }).turnId).toBe(autonomousTurnId);
-
-    // Advance timers to complete the autonomous turn.
-    await vi.advanceTimersByTimeAsync(ACPAgentSession["AUTONOMOUS_TURN_TIMEOUT_MS"] + 10);
-    const turnCompleted = events.find((e) => e.type === "turn_completed");
-    expect(turnCompleted).toBeDefined();
-    expect((turnCompleted as { turnId?: string }).turnId).toBe(autonomousTurnId);
-
-    vi.useRealTimers();
+    expect(events.map((event) => event.type)).toEqual([
+      "thread_started",
+      "mode_changed",
+      "model_changed",
+      "thinking_option_changed",
+    ]);
   });
 
-  test("completes an existing autonomous turn before starting a foreground turn", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
+  test("forwards out-of-prompt ACP content without inventing a turn", async () => {
     const session = createSession();
     asInternals<ACPSessionInternals>(session).sessionId = "session-1";
-    asInternals<ACPSessionInternals>(session).connection = {
-      prompt: vi.fn(() => new Promise(() => {})),
-    };
 
     const events: AgentStreamEvent[] = [];
     session.subscribe((event) => {
@@ -2274,25 +2250,27 @@ describe("ACPAgentSession", () => {
       sessionId: "session-1",
       update: {
         sessionUpdate: "agent_message_chunk",
-        messageId: "autonomous-msg",
-        content: { type: "text", text: "Autonomous update" },
+        messageId: "unscoped-message",
+        content: { type: "text", text: "Unscoped ACP update" },
       } as SessionUpdate,
     });
 
-    const turnStarted = events.find((e) => e.type === "turn_started");
-    expect(turnStarted).toBeDefined();
-    const autonomousTurnId = (turnStarted as { turnId?: string }).turnId;
-
-    // Starting a foreground turn should complete the autonomous turn first.
-    void session.startTurn("user prompt");
-    await vi.runOnlyPendingTimersAsync();
-
-    const turnCompleted = events.find(
-      (e) => e.type === "turn_completed" && (e as { turnId?: string }).turnId === autonomousTurnId,
-    );
-    expect(turnCompleted).toBeDefined();
-
-    vi.useRealTimers();
+    expect(events).toEqual([
+      {
+        type: "thread_started",
+        provider: "claude-acp",
+        sessionId: "session-1",
+      },
+      {
+        type: "timeline",
+        provider: "claude-acp",
+        item: {
+          type: "assistant_message",
+          text: "Unscoped ACP update",
+          messageId: "unscoped-message",
+        },
+      },
+    ]);
   });
 
   test("startTurn returns before the ACP prompt settles and completes later via subscribers", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1331,9 +1331,6 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
-  private autonomousTurnId: string | null = null;
-  private autonomousTurnTimer: ReturnType<typeof setTimeout> | null = null;
-  private static readonly AUTONOMOUS_TURN_TIMEOUT_MS = 30_000;
   private fallbackAssistantMessageId: string | null = null;
   private closed = false;
   private historyPending = false;
@@ -1475,7 +1472,6 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     if (this.activeForegroundTurnId) {
       throw new Error("A foreground turn is already active");
     }
-    this.completeAutonomousTurn();
 
     const turnId = randomUUID();
     const messageId = options?.messageId ?? randomUUID();
@@ -2119,7 +2115,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         agentId: this.agentId,
         provider: this.provider,
         sessionId: this.sessionId,
-        turnId: this.activeForegroundTurnId ?? this.autonomousTurnId ?? undefined,
+        turnId: this.activeForegroundTurnId ?? undefined,
         rawEvent: params,
         events,
       },
@@ -2132,11 +2128,6 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         }
       }
       return;
-    }
-
-    if (events.length > 0 && !this.activeForegroundTurnId) {
-      this.startAutonomousTurn();
-      this.resetAutonomousTurnTimer();
     }
 
     for (const event of events) {
@@ -2672,25 +2663,23 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       type: "timeline",
       provider: this.provider,
       item,
-      turnId: this.activeForegroundTurnId ?? this.autonomousTurnId ?? undefined,
+      turnId: this.activeForegroundTurnId ?? undefined,
     };
   }
 
   private pushEvent(event: AgentStreamEvent): void {
-    const turnId = this.activeForegroundTurnId ?? this.autonomousTurnId;
-    const tagged = event.type === "timeline" && turnId ? { ...event, turnId } : event;
     this.logger.trace(
       {
         agentId: this.agentId,
         provider: this.provider,
         sessionId: this.sessionId,
-        turnId: getAgentStreamEventTurnId(tagged) ?? turnId ?? undefined,
-        event: tagged,
+        turnId: getAgentStreamEventTurnId(event) ?? this.activeForegroundTurnId ?? undefined,
+        event,
       },
       "provider.acp.event_emit",
     );
     for (const subscriber of this.subscribers) {
-      subscriber(tagged);
+      subscriber(event);
     }
   }
 
@@ -2736,41 +2725,6 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       this.activeSubmittedUserMessage = null;
     }
     this.pushEvent(event);
-  }
-
-  private startAutonomousTurn(): void {
-    if (this.autonomousTurnId) {
-      return;
-    }
-    this.autonomousTurnId = randomUUID();
-    this.pushEvent({
-      type: "turn_started",
-      provider: this.provider,
-      turnId: this.autonomousTurnId,
-    });
-  }
-
-  private completeAutonomousTurn(): void {
-    if (!this.autonomousTurnId) {
-      return;
-    }
-    if (this.autonomousTurnTimer) {
-      clearTimeout(this.autonomousTurnTimer);
-      this.autonomousTurnTimer = null;
-    }
-    const turnId = this.autonomousTurnId;
-    this.autonomousTurnId = null;
-    this.pushEvent({ type: "turn_completed", provider: this.provider, turnId });
-  }
-
-  private resetAutonomousTurnTimer(): void {
-    if (this.autonomousTurnTimer) {
-      clearTimeout(this.autonomousTurnTimer);
-    }
-    this.autonomousTurnTimer = setTimeout(() => {
-      this.completeAutonomousTurn();
-    }, ACPAgentSession.AUTONOMOUS_TURN_TIMEOUT_MS);
-    this.autonomousTurnTimer.unref?.();
   }
 
   private isSubmittedUserMessageEcho(

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/website",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- record the published v0.1.110 ACP running-status hotfix on main
- add the 0.1.110 changelog entry and synchronize every workspace version
- preserve the existing 0.1.109 desktop update notice

The ACP fix itself is already present on main through #2148, so the net merge result contains release metadata only. Merging this PR triggers the website changelog deployment and re-syncs the existing GitHub Release notes.

## Verification

- real Kimi isolated-daemon red/green QA
- ACP provider tests: 77/77
- format, lint, and full typecheck
- full release check, clean builds, daemon web export, and npm pack dry runs
- conflict-free merge-tree audit against current main