### PR TITLE
fix(app): update project name immediately after rename

### DIFF
--- a/packages/app/src/hooks/use-projects.test.ts
+++ b/packages/app/src/hooks/use-projects.test.ts
@@ -86,6 +86,31 @@ function emptyProject(input: {
 }
 
 describe("deriveProjectsFromReplica", () => {
+  it("derives the custom project name from a renamed workspace descriptor", () => {
+    const base = workspace({
+      id: "main",
+      projectKey: "remote:github.com/acme/app",
+      projectName: "acme/app",
+      cwd: "/repo/app",
+      remoteUrl: "https://github.com/acme/app.git",
+    });
+    const renamed: WorkspaceDescriptor = {
+      ...base,
+      projectCustomName: "My Project",
+      projectDisplayName: "My Project",
+    };
+
+    const result = deriveProjectsFromReplica({
+      replicas: [
+        { serverId: "local", serverName: "Local", workspaces: [renamed], emptyProjects: [] },
+      ],
+      runtimeStates: [runtimeState({ serverId: "local", isOnline: true })],
+    });
+
+    expect(result.projects[0]?.projectName).toBe("My Project");
+    expect(result.projects[0]?.projectCustomName).toBe("My Project");
+  });
+
   it("aggregates store workspaces and empty projects sorted by display name", () => {
     const replicas: ProjectHostReplica[] = [
       {

--- a/packages/app/src/screens/project-settings-screen.tsx
+++ b/packages/app/src/screens/project-settings-screen.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/utils/project-config-form";
 import { buildProjectsSettingsRoute } from "@/utils/host-routes";
 import type { ProjectHostEntry, ProjectSummary } from "@/utils/projects";
+import { useSessionStore } from "@/stores/session-store";
 
 const SCRIPT_SERVICE_TYPE = "service";
 
@@ -241,7 +242,7 @@ function ProjectSettingsBody({
             projectName={project.projectName}
             projectKey={project.projectKey}
           />
-          <ProjectNameEditor project={project} client={client} />
+          <ProjectNameEditor project={project} client={client} serverId={selectedHost.serverId} />
         </View>
         <HostContext hosts={hosts} selectedHost={selectedHost} onSelectHost={onSelectHost} />
       </View>
@@ -791,18 +792,24 @@ function ResolveSpinnerColor(): string {
 interface ProjectNameEditorProps {
   project: ProjectSummary;
   client: DaemonClient;
+  serverId: string;
 }
 
-function ProjectNameEditor({ project, client }: ProjectNameEditorProps) {
+function ProjectNameEditor({ project, client, serverId }: ProjectNameEditorProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const toast = useToast();
+  const applyProjectCustomName = useSessionStore((state) => state.applyProjectCustomName);
   const [isEditing, setIsEditing] = useState(false);
   const [value, setValue] = useState(project.projectCustomName ?? "");
 
   const renameMutation = useMutation({
     mutationFn: (customName: string | null) => client.renameProject(project.projectKey, customName),
-    onSuccess: () => {
+    // Snapshot the issuing host/project so a host switch while the RPC is in
+    // flight cannot redirect the optimistic update to the wrong session.
+    onMutate: () => ({ serverId, projectKey: project.projectKey }),
+    onSuccess: (_result, customName, context) => {
+      applyProjectCustomName(context.serverId, context.projectKey, customName);
       queryClient.invalidateQueries({ queryKey: ["projects"] });
       setIsEditing(false);
       toast.show(t("settings.project.rename.renamedToast"), { variant: "success" });

--- a/packages/app/src/stores/session-store.test.ts
+++ b/packages/app/src/stores/session-store.test.ts
@@ -446,6 +446,90 @@ describe("removeEmptyProject", () => {
   });
 });
 
+describe("applyProjectCustomName", () => {
+  const PROJECT_KEY = "remote:github.com/acme/app";
+
+  function seedWorkspace(
+    id: string,
+    overrides: Partial<WorkspaceDescriptor> = {},
+  ): WorkspaceDescriptor {
+    return {
+      ...createWorkspace({ id, projectId: PROJECT_KEY, projectDisplayName: "acme/app" }),
+      projectCustomName: null,
+      ...overrides,
+    };
+  }
+
+  it("sets the custom name and display name on every matching workspace and empty project", () => {
+    const store = useSessionStore.getState();
+    initializeTestSession();
+    store.setWorkspaces(
+      "test-server",
+      new Map([
+        ["/repo/a", seedWorkspace("/repo/a")],
+        ["/repo/b", seedWorkspace("/repo/b")],
+      ]),
+    );
+    store.setEmptyProjects("test-server", [
+      {
+        projectId: PROJECT_KEY,
+        projectDisplayName: "acme/app",
+        projectCustomName: null,
+        projectRootPath: "/repo/app",
+        projectKind: "git",
+      },
+    ]);
+
+    store.applyProjectCustomName("test-server", PROJECT_KEY, "My Project");
+
+    const refs = getTestSessionReferences();
+    for (const id of ["/repo/a", "/repo/b"]) {
+      expect(refs.workspaces.get(id)?.projectCustomName).toBe("My Project");
+      expect(refs.workspaces.get(id)?.projectDisplayName).toBe("My Project");
+    }
+    expect(refs.emptyProjects.get(PROJECT_KEY)?.projectCustomName).toBe("My Project");
+    expect(refs.emptyProjects.get(PROJECT_KEY)?.projectDisplayName).toBe("My Project");
+  });
+
+  it("reverts to the repository-derived display name when the custom name is cleared", () => {
+    const store = useSessionStore.getState();
+    initializeTestSession();
+    store.setWorkspaces(
+      "test-server",
+      new Map([
+        [
+          "/repo/a",
+          seedWorkspace("/repo/a", {
+            projectCustomName: "My Project",
+            projectDisplayName: "My Project",
+          }),
+        ],
+      ]),
+    );
+
+    store.applyProjectCustomName("test-server", PROJECT_KEY, null);
+
+    const refs = getTestSessionReferences();
+    expect(refs.workspaces.get("/repo/a")?.projectCustomName).toBeNull();
+    expect(refs.workspaces.get("/repo/a")?.projectDisplayName).toBe("acme/app");
+  });
+
+  it("preserves state identity when no descriptor matches the project", () => {
+    const store = useSessionStore.getState();
+    initializeTestSession();
+    store.setWorkspaces("test-server", new Map([["/repo/a", seedWorkspace("/repo/a")]]));
+    const before = getTestSessionReferences();
+
+    store.applyProjectCustomName("test-server", "remote:github.com/other/repo", "Ignored");
+    const after = getTestSessionReferences();
+
+    expect(after.sessions).toBe(before.sessions);
+    expect(after.session).toBe(before.session);
+    expect(after.workspaces).toBe(before.workspaces);
+    expect(after.emptyProjects).toBe(before.emptyProjects);
+  });
+});
+
 describe("patchWorkspaceScripts", () => {
   it("preserves workspace entry identity when scripts are content-equal", () => {
     const script = {

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -40,6 +40,7 @@ import {
   buildWorkspaceAgentActivityIndex,
   type WorkspaceAgentActivity,
 } from "@/utils/workspace-agent-activity";
+import { projectDisplayNameFromProjectId } from "@/utils/project-display-name";
 
 // Re-export types that were in session-context
 export type MessageEntry =
@@ -483,6 +484,7 @@ interface SessionStoreActions {
   setEmptyProjects: (serverId: string, emptyProjects: Iterable<EmptyProjectDescriptor>) => void;
   addEmptyProject: (serverId: string, emptyProject: EmptyProjectDescriptor) => void;
   removeEmptyProject: (serverId: string, projectId: string) => void;
+  applyProjectCustomName: (serverId: string, projectKey: string, customName: string | null) => void;
   // Agent activity timestamps
   setAgentLastActivity: (agentId: string, timestamp: Date) => void;
   setAgentLastActivityBatch: (
@@ -1313,6 +1315,74 @@ export const useSessionStore = create<SessionStore>()(
             sessions: {
               ...prev.sessions,
               [serverId]: { ...session, emptyProjects: next },
+            },
+          };
+        });
+      },
+
+      applyProjectCustomName: (serverId, projectKey, customName) => {
+        set((prev) => {
+          const session = prev.sessions[serverId];
+          if (!session) {
+            return prev;
+          }
+          const trimmed = customName?.trim() ?? "";
+          const nextCustomName = trimmed.length > 0 ? trimmed : null;
+          const nextDisplayName = nextCustomName ?? projectDisplayNameFromProjectId(projectKey);
+
+          let workspacesChanged = false;
+          const nextWorkspaces = new Map(session.workspaces);
+          for (const [id, workspace] of session.workspaces) {
+            if (workspace.projectId !== projectKey) {
+              continue;
+            }
+            if (
+              workspace.projectCustomName === nextCustomName &&
+              workspace.projectDisplayName === nextDisplayName
+            ) {
+              continue;
+            }
+            nextWorkspaces.set(id, {
+              ...workspace,
+              projectCustomName: nextCustomName,
+              projectDisplayName: nextDisplayName,
+            });
+            workspacesChanged = true;
+          }
+
+          let emptyProjectsChanged = false;
+          const nextEmptyProjects = new Map(session.emptyProjects);
+          for (const [id, emptyProject] of session.emptyProjects) {
+            if (emptyProject.projectId !== projectKey) {
+              continue;
+            }
+            if (
+              emptyProject.projectCustomName === nextCustomName &&
+              emptyProject.projectDisplayName === nextDisplayName
+            ) {
+              continue;
+            }
+            nextEmptyProjects.set(id, {
+              ...emptyProject,
+              projectCustomName: nextCustomName,
+              projectDisplayName: nextDisplayName,
+            });
+            emptyProjectsChanged = true;
+          }
+
+          if (!workspacesChanged && !emptyProjectsChanged) {
+            return prev;
+          }
+
+          return {
+            ...prev,
+            sessions: {
+              ...prev.sessions,
+              [serverId]: {
+                ...session,
+                workspaces: workspacesChanged ? nextWorkspaces : session.workspaces,
+                emptyProjects: emptyProjectsChanged ? nextEmptyProjects : session.emptyProjects,
+              },
             },
           };
         });


### PR DESCRIPTION
### Linked issue

Closes #2134

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Renaming a project from Settings -> Projects showed a "renamed" success toast, but the displayed name did not change until the app was restarted.

Root cause: the rename mutation's `onSuccess` only ran `queryClient.invalidateQueries({ queryKey: ["projects"] })`, but the displayed project name is not served by any React Query cache. `useProjects()` derives project names from the zustand `session-store` (via `buildProjects()`), so invalidating that query key refreshes nothing the screen reads. The stale name only cleared when a fresh daemon directory sync repopulated the store on restart.

Fix: add a `applyProjectCustomName(serverId, projectKey, customName)` action to the session-store that updates the matching workspace and empty-project descriptors, and call it from the rename mutation. It updates both `projectCustomName` and `projectDisplayName` to mirror exactly what a real directory sync sends (the daemon computes `projectDisplayName = customName ?? repoDisplayName`), so `useProjects()` re-derives the new name immediately; clearing the custom name reverts to the repository-derived default. The action preserves referential stability (returns the previous state when no descriptor matches) so unrelated projects don't re-render.

The rename host/project is snapshotted in the mutation's `onMutate` context, so switching hosts while the rename RPC is in flight cannot redirect the update to the wrong session.

### How did you verify it

Verification is through automated tests at the state layer, which is exactly where the bug lives (the UI stays correct once the store re-derives). I did not capture on-device screenshots.

- Added `applyProjectCustomName` store tests in `session-store.test.ts`: sets the custom name and display name on every matching workspace and empty project; reverts to the repository-derived name when cleared; preserves state identity (no re-render) when no descriptor matches.
- Added an end-to-end derivation test in `use-projects.test.ts` asserting `deriveProjectsFromReplica` produces the renamed `projectName` from an updated descriptor (proving the store update flows through `buildProjects()` to the value the screen renders).
- Before/after: with the store action stubbed to a no-op, the two store tests fail (`expected null to be 'My Project'`); with the action in place they pass. Full run: 22 tests pass across both files.
- `npm run typecheck`, `npm run lint`, and `npm run format` all pass.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

### Known limitation

Clearing a custom name on a project that currently has no active workspaces reconstructs the repository-derived base name from the project key (the app's existing `projectDisplayNameFromProjectId` fallback). For a non-GitHub remote this can differ slightly from the daemon's persisted name until the next directory sync or reconnect. Projects with active workspaces receive an authoritative `workspace_update` from the daemon and self-correct immediately. Setting a name is always exact.

---

AI was used for assistance. I read the repo docs (root and app guides), understand the change, and ran the verification above myself.
