### PR TITLE
feat(app): group the Changes flat file list by directory

### DIFF
--- a/packages/app/e2e/diff-row-alignment.spec.ts
+++ b/packages/app/e2e/diff-row-alignment.spec.ts
@@ -311,9 +311,14 @@ async function useUnwrappedDiffLines(page: Page): Promise<void> {
 }
 
 async function expectFlatFileList(page: Page): Promise<void> {
+  // No collapsible folder rows — those are tree mode only.
   await expect(page.locator('[data-testid^="diff-folder-"]')).toHaveCount(0);
+  // The flat list groups files under a directory-path label instead of repeating
+  // the directory inline on every row, so `src` now sits above the file rather
+  // than beside it. This assertion previously required the inline suffix.
+  await expect(page.getByTestId("diff-dir-label-src")).toContainText("src/");
   await expect(page.getByTestId("diff-file-0")).toContainText("use-mounted-tab-set.ts");
-  await expect(page.getByTestId("diff-file-0")).toContainText("src");
+  await expect(page.getByTestId("diff-file-0")).not.toContainText("src");
 }
 
 async function expectDiffCodeFontSize(page: Page, fontSize: number): Promise<void> {

--- a/packages/app/src/git/diff-flat-items.test.ts
+++ b/packages/app/src/git/diff-flat-items.test.ts
@@ -11,6 +11,9 @@ function summarize(items: DiffFlatItem[]): string[] {
     if (item.type === "folder") {
       return `${"  ".repeat(item.depth)}[${item.displayName}]${item.collapsed ? " (collapsed)" : ""}`;
     }
+    if (item.type === "dirLabel") {
+      return `${item.dirPath}/`;
+    }
     const base = item.file.path.split("/").pop();
     return `${"  ".repeat(item.depth)}${item.type === "body" ? "body:" : ""}${base}`;
   });
@@ -33,7 +36,7 @@ describe("buildDiffFlatItems", () => {
     expect(items[0].type).toBe("header");
   });
 
-  it("emits the old flat list without folder rows or indentation", () => {
+  it("groups flat files under directory-path labels, never folder rows", () => {
     const { items, stickyHeaderIndices } = buildDiffFlatItems({
       files,
       viewMode: "flat",
@@ -41,9 +44,60 @@ describe("buildDiffFlatItems", () => {
       expandedPaths: new Set(["src/app/a.ts"]),
     });
 
-    expect(summarize(items)).toEqual(["a.ts", "body:a.ts", "b.ts"]);
-    expect(stickyHeaderIndices).toEqual([0]);
+    // Each file sits under its own directory label; the label is not indented and
+    // sticky indices still point only at expanded file headers.
+    expect(summarize(items)).toEqual(["src/app/", "a.ts", "body:a.ts", "src/app/nested/", "b.ts"]);
+    expect(stickyHeaderIndices).toEqual([1]);
     expect(items.every((item) => item.type !== "folder")).toBe(true);
+  });
+
+  it("shares one directory label for consecutive files in the same directory", () => {
+    const { items } = buildDiffFlatItems({
+      files: [createFile("src/a.ts"), createFile("src/b.ts")],
+      viewMode: "flat",
+      collapsedFolders: new Set(),
+      expandedPaths: new Set(),
+    });
+    expect(summarize(items)).toEqual(["src/", "a.ts", "b.ts"]);
+  });
+
+  it("emits no directory label for root-level files in flat mode", () => {
+    const { items } = buildDiffFlatItems({
+      files: [createFile("a.ts"), createFile("b.ts")],
+      viewMode: "flat",
+      collapsedFolders: new Set(),
+      expandedPaths: new Set(),
+    });
+    expect(summarize(items)).toEqual(["a.ts", "b.ts"]);
+    expect(items.every((item) => item.type === "header")).toBe(true);
+  });
+
+  it("indents a flat file only when a directory label was emitted above it", () => {
+    // A root file has no label, so indenting it would indent it under nothing.
+    const { items } = buildDiffFlatItems({
+      files: [createFile("README.md"), createFile("src/a.ts")],
+      viewMode: "flat",
+      collapsedFolders: new Set(),
+      expandedPaths: new Set(),
+    });
+    expect(summarize(items)).toEqual(["README.md", "src/", "a.ts"]);
+    const headers = items.filter((item) => item.type === "header");
+    expect(headers.map((h) => (h.type === "header" ? h.underDirLabel : null))).toEqual([
+      false,
+      true,
+    ]);
+  });
+
+  it("never marks tree-mode files as sitting under a flat directory label", () => {
+    // Tree mode indents via `depth`; underDirLabel is a flat-list concern only.
+    const { items } = buildDiffFlatItems({
+      files,
+      viewMode: "tree",
+      collapsedFolders: new Set(),
+      expandedPaths: new Set(),
+    });
+    const headers = items.filter((item) => item.type === "header");
+    expect(headers.every((h) => h.type === "header" && h.underDirLabel === false)).toBe(true);
   });
 
   it("groups files under compressed folder rows, all expanded by default", () => {

--- a/packages/app/src/git/diff-flat-items.ts
+++ b/packages/app/src/git/diff-flat-items.ts
@@ -19,7 +19,24 @@ export type DiffFlatItem =
       additions: number;
       deletions: number;
     }
-  | { type: "header"; file: ParsedDiffFile; fileIndex: number; isExpanded: boolean; depth: number }
+  // Flat-view directory group header. Files are grouped by their directory and
+  // listed under a plain path label (GitLab-style), so the filename row no longer
+  // carries an inline dir suffix. Never emitted in tree mode.
+  | { type: "dirLabel"; dirPath: string }
+  | {
+      type: "header";
+      file: ParsedDiffFile;
+      fileIndex: number;
+      isExpanded: boolean;
+      depth: number;
+      /**
+       * Flat mode: a `dirLabel` was emitted above this file, so the row is
+       * indented one level under it. Root-level files get no label and so are
+       * not indented — there is nothing above them to indent under. Always
+       * false in tree mode, where `depth` drives indentation instead.
+       */
+      underDirLabel: boolean;
+    }
   | { type: "body"; file: ParsedDiffFile; fileIndex: number; depth: number };
 
 export interface DiffFlatItemsResult {
@@ -29,6 +46,14 @@ export interface DiffFlatItemsResult {
 }
 
 export interface BuildDiffFlatItemsInput {
+  /**
+   * PRECONDITION: sorted by path (see `orderCheckoutDiffFiles`). Flat mode emits
+   * one directory label per *run* of same-directory files, so unsorted input
+   * silently yields a repeated label (`src/`, `lib/`, `src/` again) rather than
+   * an error. Both current callers satisfy this: the checkout diff is sorted in
+   * the push router because it merges staged/unstaged/untracked, and the commit
+   * diff inherits git's own path ordering.
+   */
   files: ParsedDiffFile[];
   viewMode: "flat" | "tree";
   /** Full uncompressed directory paths that are collapsed (empty = all expanded). */
@@ -61,9 +86,14 @@ export function buildDiffFlatItems({
   const items: DiffFlatItem[] = [];
   const stickyHeaderIndices: number[] = [];
 
-  const pushFile = (file: ParsedDiffFile, fileIndex: number, depth: number): void => {
+  const pushFile = (
+    file: ParsedDiffFile,
+    fileIndex: number,
+    depth: number,
+    underDirLabel = false,
+  ): void => {
     const isExpanded = expandedPaths.has(file.path);
-    items.push({ type: "header", file, fileIndex, isExpanded, depth });
+    items.push({ type: "header", file, fileIndex, isExpanded, depth, underDirLabel });
     if (isExpanded) {
       stickyHeaderIndices.push(items.length - 1);
       items.push({ type: "body", file, fileIndex, depth });
@@ -71,8 +101,23 @@ export function buildDiffFlatItems({
   };
 
   if (viewMode === "flat") {
+    // Files arrive path-sorted, so files sharing a directory are already
+    // consecutive: emit one directory-path label when the directory changes,
+    // then the file rows beneath it. Root-level files (no directory) get no
+    // label — there is nothing to group them under, so they are not indented
+    // either. `underDirLabel` is decided here, next to the label itself, so the
+    // indent cannot disagree with whether a label was actually emitted.
+    let currentDir: string | undefined;
     for (const [fileIndex, file] of files.entries()) {
-      pushFile(file, fileIndex, 0);
+      const slashIndex = file.path.lastIndexOf("/");
+      const dir = slashIndex === -1 ? "" : file.path.slice(0, slashIndex);
+      if (dir !== currentDir) {
+        currentDir = dir;
+        if (dir !== "") {
+          items.push({ type: "dirLabel", dirPath: dir });
+        }
+      }
+      pushFile(file, fileIndex, 0, dir !== "");
     }
     return { items, stickyHeaderIndices };
   }

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -202,8 +202,10 @@ interface DiffFileSectionProps {
   isExpanded: boolean;
   /** Tree indentation level (0 on the flat/mobile path). */
   depth?: number;
-  /** Show the muted directory suffix (flat list); false inside the folder tree. */
-  showDir?: boolean;
+  /** Flat list: the row sits under a directory-path label, so indent it one
+   * level to match (no tree guide lines). Root-level files have no label and
+   * so are not indented. */
+  underDirLabel?: boolean;
   interactive?: boolean;
   onToggle?: (path: string) => void;
   onHeaderHeightChange?: (path: string, height: number) => void;
@@ -900,11 +902,47 @@ function SplitDiffColumn({
   );
 }
 
+// Material file-type icon for a diff row. Its own component so the header's JSX
+// stays inside the nesting limit, and so both view modes render it identically.
+const DiffFileIcon = memo(function DiffFileIcon({ fileName }: { fileName: string }) {
+  return (
+    <View style={styles.fileIcon}>
+      <SvgXml xml={getFileIconSvg(fileName)} width={16} height={16} />
+    </View>
+  );
+});
+
+// Flat-view directory group header: the full directory path of the files listed
+// beneath it, shown as a plain muted label with a trailing slash (GitLab-style).
+const DiffDirLabelRow = memo(function DiffDirLabelRow({
+  dirPath,
+  onHeightChange,
+  testID,
+}: {
+  dirPath: string;
+  onHeightChange?: (height: number) => void;
+  testID?: string;
+}) {
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      onHeightChange?.(event.nativeEvent.layout.height);
+    },
+    [onHeightChange],
+  );
+  return (
+    <View style={styles.dirLabelRow} onLayout={handleLayout} testID={testID}>
+      <Text style={styles.dirLabelText} numberOfLines={1}>
+        {`${dirPath}/`}
+      </Text>
+    </View>
+  );
+});
+
 const DiffFileHeader = memo(function DiffFileHeader({
   file,
   isExpanded,
   depth = 0,
-  showDir = true,
+  underDirLabel = false,
   interactive = true,
   onToggle,
   onHeaderHeightChange,
@@ -967,37 +1005,34 @@ const DiffFileHeader = memo(function DiffFileHeader({
   );
 
   const headerPressableStyle = useCallback(
-    (state: PressableStateCallbackType) =>
-      depth > 0
+    (state: PressableStateCallbackType) => {
+      // Flat list: files sit one level under their directory-path label, but
+      // without the tree's vertical guide lines (depth stays 0).
+      if (underDirLabel) {
+        return [fileHeaderPressableStyle(state), styles.fileHeaderFlatIndent];
+      }
+      return depth > 0
         ? [
             fileHeaderPressableStyle(state),
             inlineUnistylesStyle({ paddingLeft: treeRowPaddingLeft(depth) }),
           ]
-        : fileHeaderPressableStyle(state),
-    [depth],
+        : fileHeaderPressableStyle(state);
+    },
+    [depth, underDirLabel],
   );
 
   const fileName = file.path.split("/").pop() ?? file.path;
   const headerContent = (
     <>
       <View style={styles.fileHeaderLeft}>
-        {showDir ? null : (
-          <View style={styles.fileIcon}>
-            <SvgXml xml={getFileIconSvg(fileName)} width={16} height={16} />
-          </View>
-        )}
+        <DiffFileIcon fileName={fileName} />
         <Text style={styles.fileName} numberOfLines={1}>
           {fileName}
         </Text>
-        {showDir ? (
-          <Text style={styles.fileDir} numberOfLines={1}>
-            {file.path.includes("/") ? ` ${file.path.slice(0, file.path.lastIndexOf("/"))}` : ""}
-          </Text>
-        ) : (
-          // Flex spacer in tree mode (no dir suffix) so the New/Deleted badge
-          // stays right-aligned next to the diff stats, as in the flat list.
-          <View style={styles.fileDirSpacer} />
-        )}
+        {/* Flex spacer (no inline dir suffix — the directory is shown as a group
+            label above the file in flat mode, and by the tree in tree mode) so
+            the New/Deleted badge stays right-aligned by the stats. */}
+        <View style={styles.fileDirSpacer} />
         {file.isNew && (
           <View style={styles.newBadge}>
             <Text style={styles.newBadgeText}>{t("workspace.git.diff.newFile")}</Text>
@@ -1672,6 +1707,8 @@ export function SharedDiffView({ files, displayPreferences, mode }: SharedDiffVi
   const headerHeightByPathRef = useRef<Record<string, number>>({});
   const bodyHeightByKeyRef = useRef<Record<string, number>>({});
   const folderRowHeightRef = useRef<number>(0);
+  // Flat-view directory-path labels all share one height (same style).
+  const dirLabelRowHeightRef = useRef<number>(0);
   const defaultHeaderHeightRef = useRef<number>(44);
   const [heightVersion, setHeightVersion] = useState(0);
   const diffBodyChromeHeight = BORDER_WIDTH[1] * 2;
@@ -1731,6 +1768,9 @@ export function SharedDiffView({ files, displayPreferences, mode }: SharedDiffVi
       if (item.type === "folder") {
         return folderRowHeightRef.current || defaultHeaderHeightRef.current;
       }
+      if (item.type === "dirLabel") {
+        return dirLabelRowHeightRef.current || DIFF_DIR_LABEL_ESTIMATED_HEIGHT;
+      }
       if (item.type === "header") {
         return headerHeightByPathRef.current[item.file.path] ?? defaultHeaderHeightRef.current;
       }
@@ -1749,6 +1789,18 @@ export function SharedDiffView({ files, displayPreferences, mode }: SharedDiffVi
       return;
     }
     folderRowHeightRef.current = height;
+    setHeightVersion((version) => version + 1);
+  }, []);
+
+  const handleDirLabelHeightChange = useCallback((height: number) => {
+    if (!Number.isFinite(height) || height <= 0) {
+      return;
+    }
+    const previousHeight = dirLabelRowHeightRef.current;
+    if (previousHeight > 0 && Math.abs(previousHeight - height) <= DIFF_HEIGHT_CHANGE_EPSILON) {
+      return;
+    }
+    dirLabelRowHeightRef.current = height;
     setHeightVersion((version) => version + 1);
   }, []);
 
@@ -1901,13 +1953,22 @@ export function SharedDiffView({ files, displayPreferences, mode }: SharedDiffVi
           />
         );
       }
+      if (item.type === "dirLabel") {
+        return (
+          <DiffDirLabelRow
+            dirPath={item.dirPath}
+            onHeightChange={handleDirLabelHeightChange}
+            testID={`diff-dir-label-${item.dirPath}`}
+          />
+        );
+      }
       if (item.type === "header") {
         return (
           <DiffFileHeader
             file={item.file}
             isExpanded={item.isExpanded}
             depth={item.depth}
-            showDir={viewMode === "flat"}
+            underDirLabel={item.underDirLabel}
             interactive={interactive}
             onToggle={interactive ? handleToggleExpanded : undefined}
             onHeaderHeightChange={handleHeaderHeightChange}
@@ -1931,6 +1992,7 @@ export function SharedDiffView({ files, displayPreferences, mode }: SharedDiffVi
     [
       codeFontSize,
       handleBodyHeightChange,
+      handleDirLabelHeightChange,
       handleFolderRowHeightChange,
       handleHeaderHeightChange,
       handleToggleExpanded,
@@ -1938,17 +2000,20 @@ export function SharedDiffView({ files, displayPreferences, mode }: SharedDiffVi
       layout,
       reviewActions,
       textMetricsStyle,
-      viewMode,
       wrapLines,
       interactive,
     ],
   );
 
-  const flatKeyExtractor = useCallback(
-    (item: DiffFlatItem) =>
-      item.type === "folder" ? `folder-${item.dirPath}` : `${item.type}-${item.file.path}`,
-    [],
-  );
+  const flatKeyExtractor = useCallback((item: DiffFlatItem) => {
+    if (item.type === "folder") {
+      return `folder-${item.dirPath}`;
+    }
+    if (item.type === "dirLabel") {
+      return `dirLabel-${item.dirPath}`;
+    }
+    return `${item.type}-${item.file.path}`;
+  }, []);
 
   const getFlatItemLayout = useCallback<DiffFlatItemLayoutGetter>(
     (_data, index) => {
@@ -2756,11 +2821,25 @@ const styles = StyleSheet.create((theme) => ({
     flexShrink: 1,
     minWidth: 0,
   },
-  fileDir: {
-    fontSize: theme.fontSize.sm,
-    fontWeight: theme.fontWeight.normal,
+  // Flat list: indent a file one level under its directory-path label. Matches a
+  // single tree level (treeRowPaddingLeft(1)) but draws no vertical guide line.
+  fileHeaderFlatIndent: {
+    paddingLeft: treeRowPaddingLeft(1),
+  },
+  // Padding is asymmetric on purpose: the gap above separates this group from
+  // the previous one, while no gap below leaves the label attached to its own
+  // files (the file row's own top padding supplies that space). Keeps the label
+  // cheap in vertical space — it is pure overhead on top of the file rows.
+  dirLabelRow: {
+    paddingLeft: theme.spacing[3],
+    paddingRight: theme.spacing[2],
+    paddingTop: theme.spacing[2],
+    minWidth: 0,
+  },
+  dirLabelText: {
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.medium,
     color: theme.colors.foregroundMuted,
-    flex: 1,
     minWidth: 0,
   },
   fileDirSpacer: {
@@ -2961,3 +3040,5 @@ const FILE_SECTION_BODY_STYLE = [styles.fileSectionBodyContainer, styles.fileSec
 const DIFF_CONTENT_SPLIT_ROW_STYLE = [styles.diffContent, styles.splitRow];
 const DIFF_CONTENT_ROW_STYLE = [styles.diffContent, styles.diffContentRow];
 const DIFF_HEIGHT_CHANGE_EPSILON = 0.5;
+// getItemLayout fallback for a flat-view directory label before it is measured.
+const DIFF_DIR_LABEL_ESTIMATED_HEIGHT = 24;


### PR DESCRIPTION
### Linked issue

None — opening directly, since the screenshots make the case better than a
description would. Happy to move it to a feature request if you'd rather
settle the shape first.

**Your call:** flat is the default view mode, so this changes the Changes
list everyone sees out of the box, and there's no way back to the old rows.

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Groups the flat file list by directory, and gives every row its file-type
icon.

Before: one row per file — `filename` plus a muted inline directory suffix,
no icon (icons landed in #1918, but only in tree mode). The directory
string repeated on every row, and it truncated the filename first in a
narrow sidebar.

After: each directory appears once as a path label with its files beneath
it. Files sharing a directory share a label; root files get none.

The shape is taken from GitLab's merge-request file list, used deliberately
as a best-practice reference — the same reasoning as the tree's single-child
compression in #1918 following VS Code and GitHub: reach for a pattern
people already read fluently rather than invent one. The grouping only,
though. Paseo's `+/-` stats, New/Deleted badges and end-ellipsis truncation
stay as they are, not GitLab's status glyphs and middle-truncated paths.

**Trade-off: it's taller.** Every group adds a label row — the diff in the
screenshots goes from 5 rows to 8. The label is cheap (smaller text, top
padding only) but not free, and it narrows the density gap with tree mode,
which renders the same diff in 9 rows and can at least collapse. What it
buys is width for the filename.

That diff is close to the worst case for this, by the way: three groups over
five files, two of them single-file. The label amortizes where more files
share a directory — the three `commands/` files here pay one label between
them.

I considered keeping the directory inline for single-file groups to save
the label (the screenshots have two), and dropped it: GitLab doesn't do it
either — its flat list is mostly single-file groups and they all get labels
— and rows would change shape live as an agent adds a second file to a
directory.

Client-only, built from the existing `ParsedDiffFile` paths — no protocol
or server change, tree mode untouched, icons reuse the existing
`getFileIconSvg`. The one non-obvious bit: labels get their own measured
height feeding `getItemLayout`, and sticky indices stay file-headers-only
so a label can't enter the sticky stack.


### How did you verify it

- `npm run typecheck`, `npm run lint`, `npm run format` clean. All 224
  tests across the 21 `git/` test files pass. Three cases in
  `diff-flat-items.test.ts` cover the new grouping: one shared label for
  same-directory files, no label at root, and the sticky index still
  landing on the expanded file header. Existing tree-mode tests unchanged
  and passing — that's what pins "tree mode is unaffected".
- Live in the Electron desktop app on this branch, against a real diff:
  the three groups label correctly, `commands/` collects its three files
  under one label, icons resolve, and `+/-` stats stay right-aligned.
  Toggled to tree and back — unchanged.

Before:

<img width="369" height="330" alt="image" src="https://github.com/user-attachments/assets/54abb509-35c9-4104-8fe8-d577a6bc860a" />

After:

<img width="369" height="372" alt="image" src="https://github.com/user-attachments/assets/d84a103f-f5f2-467e-a28b-edd670c74200" />

Tree, for comparison (unchanged):

<img width="363" height="410" alt="image" src="https://github.com/user-attachments/assets/4a3ba021-73ed-4477-83de-defb3c1d9ec4" />


### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform <!-- Electron desktop only; see platform note -->
- [x] Tests added or updated where it made sense

