### PR TITLE
Include the daemon version in every log entry

### DIFF
--- a/packages/server/src/server/logger.test.ts
+++ b/packages/server/src/server/logger.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { resolveDaemonVersion } from "./daemon-version.js";
 import { resolveLogConfig } from "./logger.js";
 import { loadConfig } from "./config.js";
 import type { PersistedConfig } from "./persisted-config.js";
@@ -153,6 +154,24 @@ describe("loadConfig logger config", () => {
 });
 
 describe("createRootLogger", () => {
+  it("includes the daemon version in child logger entries", async () => {
+    const paseoHome = await mkdtemp(path.join(tmpdir(), "paseo-logger-version-"));
+
+    const { stdout } = await runLoggerFixture(`
+      const logger = createRootLogger(undefined, { paseoHome: ${JSON.stringify(paseoHome)} });
+      logger.child({ name: "fixture" }).info("versioned child logger");
+      logger.flush();
+    `);
+
+    expect(JSON.parse(stdout)).toMatchObject({
+      pid: expect.any(Number),
+      hostname: expect.any(String),
+      daemonVersion: resolveDaemonVersion(),
+      name: "fixture",
+      msg: "versioned child logger",
+    });
+  });
+
   it("writes JSON to stdout by default and does not initialize file logging", async () => {
     const paseoHome = await mkdtemp(path.join(tmpdir(), "paseo-logger-default-"));
     const missingLogDir = path.join(paseoHome, "logs");

--- a/packages/server/src/server/logger.ts
+++ b/packages/server/src/server/logger.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from "node:fs";
 import path from "node:path";
 import pino from "pino";
 import pretty from "pino-pretty";
+import { resolveDaemonVersion } from "./daemon-version.js";
 import type { PersistedConfig } from "./persisted-config.js";
 import { resolvePaseoHome } from "./paseo-home.js";
 
@@ -180,13 +181,15 @@ export function createRootLogger(
         })
       : pino.destination({ dest: config.file?.path ?? 1, sync: false });
 
-  return pino(
+  const logger = pino(
     {
       level: config.file?.level ?? config.console.level,
       redact: { paths: REDACT_PATHS, remove: true },
     },
     stream,
   );
+
+  return logger.child({ daemonVersion: resolveDaemonVersion() });
 }
 
 export function createChildLogger(parent: pino.Logger, name: string): pino.Logger {


### PR DESCRIPTION
### Linked issue

None — this is a small observability improvement.

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds `daemonVersion` to the root logger metadata so every Pino daemon log entry, including entries from child loggers, records the running release. This makes daemon upgrades visible directly in Pino log history.

### How did you verify it

- Ran `npx vitest run packages/server/src/server/logger.test.ts --bail=1`; all 10 tests passed.
- The added real-process test emits JSON through a child logger and verifies `daemonVersion`, `pid`, and `hostname` are present.
- Ran `npm run typecheck`; all workspaces passed.
- Ran `npm run lint`; 0 warnings and 0 errors.
- Ran `npm run format`.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI changes)
- [x] Tests added or updated where it made sense