### PR TITLE
fix(server): name both refs in the base ref mismatch error

### DIFF
--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -2785,6 +2785,20 @@ const x = 1;
     expect(baseDiff.diff).not.toContain("file.txt");
   });
 
+  it("names both refs when a requested base ref does not match the stored one", async () => {
+    const worktree = await createLegacyWorktreeForTest({
+      branchName: "mismatch-feature",
+      cwd: repoDir,
+      baseBranch: "main",
+      worktreeSlug: "mismatch-feature",
+      paseoHome,
+    });
+
+    await expect(
+      getCheckoutDiff(worktree.worktreePath, { mode: "base", baseRef: "other" }, { paseoHome }),
+    ).rejects.toThrow("Base ref mismatch: stored main, requested other");
+  });
+
   it("excludes dirty working tree changes from Paseo worktree base diffs", async () => {
     const worktree = await createLegacyWorktreeForTest({
       branchName: "feature",

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1087,6 +1087,12 @@ async function resolveBaseRefForCwd(
   };
 }
 
+// Names both refs rather than labelling either one correct: a caller's ref can be stale, but the
+// stored ref can equally be wrong, so the message states the two facts and leaves the diagnosis open.
+function baseRefMismatchError(refs: { stored: string; requested: string }): Error {
+  return new Error(`Base ref mismatch: stored ${refs.stored}, requested ${refs.requested}`);
+}
+
 async function isWorkingTreeDirty(cwd: string, context?: CheckoutContext): Promise<boolean> {
   const { stdout } = await runGitCommand(["status", "--porcelain"], {
     cwd,
@@ -2753,7 +2759,7 @@ async function resolveCheckoutDiffRefs(
     return null;
   }
   if (storedBaseRef && compare.baseRef && compare.baseRef !== storedBaseRef) {
-    throw new Error(`Base ref mismatch: expected ${baseRef}, got ${compare.baseRef}`);
+    throw baseRefMismatchError({ stored: storedBaseRef, requested: compare.baseRef });
   }
   const bestBaseRef = await resolveBestComparisonBaseRef(cwd, baseRef);
   return {
@@ -2967,7 +2973,7 @@ export async function mergeToBase(
     throw new Error("Unable to determine base branch for merge");
   }
   if (storedBaseRef && options.baseRef && options.baseRef !== storedBaseRef) {
-    throw new Error(`Base ref mismatch: expected ${baseRef}, got ${options.baseRef}`);
+    throw baseRefMismatchError({ stored: storedBaseRef, requested: options.baseRef });
   }
   if (!currentBranch) {
     throw new Error("Unable to determine current branch for merge");
@@ -3043,7 +3049,7 @@ export async function mergeFromBase(
     throw new Error("Unable to determine base branch for merge");
   }
   if (storedBaseRef && options.baseRef && options.baseRef !== storedBaseRef) {
-    throw new Error(`Base ref mismatch: expected ${baseRef}, got ${options.baseRef}`);
+    throw baseRefMismatchError({ stored: storedBaseRef, requested: options.baseRef });
   }
 
   const requireCleanTarget = options.requireCleanTarget ?? true;
@@ -3381,7 +3387,7 @@ export async function createPullRequest(
   }
   const normalizedBase = normalizeLocalBranchRefName(base);
   if (storedBaseRef && options.base && options.base !== storedBaseRef) {
-    throw new Error(`Base ref mismatch: expected ${base}, got ${options.base}`);
+    throw baseRefMismatchError({ stored: storedBaseRef, requested: options.base });
   }
 
   // The push deliberately happens before the adapter resolves the target


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The base ref mismatch error printed the same ref on both sides, so it always read
`Base ref mismatch: expected master, got master` — which says nothing about what mismatched.

All four throw sites computed `baseRef = compare.baseRef ?? resolvedBaseRef` and then
printed `baseRef` as "expected" against the caller's ref as "got". The guard only fires when
the caller passed a ref, so at the throw `baseRef` *is* the caller's ref — both sides were
the same string by construction, on every path. The value that actually differs, the stored
`baseRefName` from `<gitdir>/paseo/worktree.json`, was never shown.

The message is now built in one place and thrown by the four guards:

```
Base ref mismatch: stored main, requested other
```

Two deliberate choices worth flagging for review:

- **`stored`/`requested`, not `expected`/`got`.** A caller's ref can be stale, but the
  stored ref can equally be the wrong one — a worktree whose recorded base has drifted looks
  exactly like this. The message states both facts and leaves the diagnosis open rather than
  asserting either side is correct.
- **The guards stay inline; only the message moved.** One shared string is what stops the
  four copies drifting apart again, but folding the `if`s into an assert helper would have
  hidden the firing condition from each call site and forced the helper to re-accept the
  `null`/`undefined` shapes. Building only the error keeps each throw's condition visible and
  narrows both refs to plain `string` before the message is built.

Throw conditions are unchanged — same inputs still throw, only the text differs.

### How did you verify it

Wrote the test first and watched it fail on the real message before changing any source.
Against a Paseo worktree whose stored base is `main`, requesting a diff with
`baseRef: "other"`:

```
AssertionError: expected [Function] to throw error including 'Base ref mismatch: stored main, reque…'
                                                but got 'Base ref mismatch: expected other, got other'

Expected: "Base ref mismatch: stored main, requested other"
Received: "Base ref mismatch: expected other, got other"
```

`expected other, got other` is the bug reproduced: two different refs, one of them printed
twice. After the change that test passes and the message names both refs.

- `npx vitest run packages/server/src/utils/checkout-git.test.ts` — **121 passed** (120 existing + 1 new)
- `npm run typecheck` — clean
- `npm run lint` — 0 warnings, 0 errors
- `npm run format:check` — clean


### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform — n/a, no UI change
- [x] Tests added or updated where it made sense
