### PR TITLE
fix(server): frame Codex app-server JSONL on LF only

### DIFF
--- a/packages/server/src/server/agent/providers/codex/app-server-transport.test.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.test.ts
@@ -111,4 +111,98 @@ describe("Codex app-server transport", () => {
     codex.child.stderr.end();
     codex.child.stdin.end();
   });
+
+  // #2021: node:readline treats literal U+2028/U+2029 as line boundaries.
+  // JSON.stringify escapes those code points; Codex app-server can emit the
+  // literal characters inside JSON strings, so the fixture writes them raw.
+  test("keeps unicode line separators inside one Codex JSONL record", async () => {
+    const child = createCodexAppServerChildProcess();
+    const client = new CodexAppServerClient(child, createTestLogger());
+    const calls: Array<{ method: string; params: unknown }> = [];
+    client.setNotificationHandler((method, params) => {
+      calls.push({ method, params });
+    });
+
+    const params = {
+      text: "before\u2028middle\u2029after",
+    };
+    // Build the wire record with literal U+2028/U+2029 inside the JSON string.
+    child.stdout.write(
+      `{"method":"item/completed","params":{"text":"before\u2028middle\u2029after"}}\n`,
+    );
+
+    // Stream consumers process the write after the current turn.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(calls).toEqual([
+      {
+        method: "item/completed",
+        params,
+      },
+    ]);
+
+    child.stdout.end();
+    child.stderr.end();
+    child.stdin.end();
+  });
+
+  test("reassembles a Codex JSONL record split across stdout chunks", async () => {
+    const child = createCodexAppServerChildProcess();
+    const client = new CodexAppServerClient(child, createTestLogger());
+    const calls: Array<{ method: string; params: unknown }> = [];
+    client.setNotificationHandler((method, params) => {
+      calls.push({ method, params });
+    });
+
+    const params = {
+      text: "chunk\u2028split\u2029record",
+    };
+    const record = `{"method":"item/completed","params":{"text":"chunk\u2028split\u2029record"}}\n`;
+    const splitAt = Math.floor(record.length / 2);
+    child.stdout.write(record.slice(0, splitAt));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(calls).toEqual([]);
+
+    child.stdout.write(record.slice(splitAt));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(calls).toEqual([
+      {
+        method: "item/completed",
+        params,
+      },
+    ]);
+
+    child.stdout.end();
+    child.stderr.end();
+    child.stdin.end();
+  });
+
+  test("accepts CRLF-terminated Codex JSONL records", async () => {
+    const child = createCodexAppServerChildProcess();
+    const client = new CodexAppServerClient(child, createTestLogger());
+    const calls: Array<{ method: string; params: unknown }> = [];
+    client.setNotificationHandler((method, params) => {
+      calls.push({ method, params });
+    });
+
+    const params = {
+      text: "crlf\u2028still\u2029data",
+    };
+    child.stdout.write(
+      `{"method":"item/completed","params":{"text":"crlf\u2028still\u2029data"}}\r\n`,
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(calls).toEqual([
+      {
+        method: "item/completed",
+        params,
+      },
+    ]);
+
+    child.stdout.end();
+    child.stderr.end();
+    child.stdin.end();
+  });
 });

--- a/packages/server/src/server/agent/providers/codex/app-server-transport.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-transport.ts
@@ -1,5 +1,4 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
-import readline from "node:readline";
 import type { Logger } from "pino";
 import { z } from "zod";
 
@@ -156,13 +155,13 @@ function readProviderTurnId(params: unknown): string | undefined {
 }
 
 export class CodexAppServerClient {
-  private readonly rl: readline.Interface;
   private readonly pending = new Map<number, PendingRequest>();
   private readonly requestHandlers = new Map<string, RequestHandler>();
   private notificationHandler: NotificationHandler | null = null;
   private unexpectedTerminationHandler: UnexpectedTerminationHandler | null = null;
   private nextId = 1;
   private disposed = false;
+  private stdoutBuffer = "";
   private stderrBuffer = "";
 
   constructor(
@@ -170,11 +169,10 @@ export class CodexAppServerClient {
     private readonly logger: Logger,
     private readonly getTraceContext: () => CodexAppServerTraceContext = () => ({}),
   ) {
-    this.rl = readline.createInterface({ input: child.stdout });
-    this.rl.on("line", (line) => {
-      void this.handleLine(line).catch((error) => {
-        this.logger.warn({ error, line }, "Failed to handle Codex app-server stdout line");
-      });
+    // JSONL framing must use LF only. node:readline also treats U+2028/U+2029 as
+    // line boundaries (Node 24+ / Electron), which splits valid JSON strings.
+    child.stdout.on("data", (chunk) => {
+      this.handleStdoutChunk(chunk.toString());
     });
 
     child.stderr.on("data", (chunk) => {
@@ -248,7 +246,6 @@ export class CodexAppServerClient {
     if (this.disposed) return;
     this.disposed = true;
     this.unexpectedTerminationHandler = null;
-    this.rl.close();
     try {
       this.child.stdin.end();
     } catch {
@@ -277,7 +274,6 @@ export class CodexAppServerClient {
       return;
     }
     this.disposed = true;
-    this.rl.close();
     for (const pending of this.pending.values()) {
       clearTimeout(pending.timer);
       pending.reject(error);
@@ -303,6 +299,21 @@ export class CodexAppServerClient {
       this.child.stdin.write(`${JSON.stringify(response)}\n`);
     } catch (error) {
       this.logger.debug({ error }, "Failed to write Codex app-server JSON-RPC response");
+    }
+  }
+
+  private handleStdoutChunk(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    for (;;) {
+      const newlineIndex = this.stdoutBuffer.indexOf("\n");
+      if (newlineIndex === -1) {
+        break;
+      }
+      const line = this.stdoutBuffer.slice(0, newlineIndex).replace(/\r$/, "");
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      void this.handleLine(line).catch((error) => {
+        this.logger.warn({ error, line }, "Failed to handle Codex app-server stdout line");
+      });
     }
   }
 


### PR DESCRIPTION
## Problem

Codex app-server JSONL was framed with `node:readline`, which treats literal
U+2028/U+2029 characters inside JSON strings as line boundaries. This split
valid JSON-RPC messages and caused session resume requests to time out.

## Solution

- replace `node:readline` framing with an LF-only stdout buffer
- preserve U+2028/U+2029 as JSON string data
- retain CRLF compatibility
- add deterministic regression coverage

## Testing

- `npx vitest run packages/server/src/server/agent/providers/codex/app-server-transport.test.ts --bail=1`
- `npm run lint -- <changed files>`
- `npm run typecheck --workspace=@getpaseo/server`

Closes #2021