### PR TITLE
fix: allow non-git directories to be added as projects

### DIFF
--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -805,13 +805,6 @@ export type CheckoutSnapshotFacts =
       pullRequestLookupTarget: PullRequestStatusLookupTarget | null;
     };
 
-function isNotGitRepositoryError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  return /not a git repository \(or any of the parent directories\): \.git/i.test(error.message);
-}
-
 async function requireGitRepo(cwd: string): Promise<void> {
   try {
     await runGitCommand(["rev-parse", "--git-dir"], { cwd, envOverlay: READ_ONLY_GIT_ENV });
@@ -859,19 +852,19 @@ async function getRebaseHeadBranch(cwd: string): Promise<string | null> {
 }
 
 async function getWorktreeRoot(cwd: string, context?: CheckoutContext): Promise<string | null> {
-  try {
-    const { stdout } = await runGitCommand(["rev-parse", "--show-toplevel"], {
-      cwd,
-      envOverlay: READ_ONLY_GIT_ENV,
-      logger: context?.logger,
-    });
-    return parseGitRevParsePath(stdout);
-  } catch (error) {
-    if (isNotGitRepositoryError(error)) {
-      return null;
-    }
-    throw error;
+  // git rev-parse --show-toplevel exits 128 when the cwd is not inside a git
+  // repository. Accept that exit code and check it programmatically rather than
+  // matching against git's stderr text, which changed between git versions.
+  const result = await runGitCommand(["rev-parse", "--show-toplevel"], {
+    cwd,
+    envOverlay: READ_ONLY_GIT_ENV,
+    logger: context?.logger,
+    acceptExitCodes: [0, 128],
+  });
+  if (result.exitCode !== 0) {
+    return null;
   }
+  return parseGitRevParsePath(result.stdout);
 }
 
 export async function getMainRepoRoot(cwd: string): Promise<string> {


### PR DESCRIPTION
## Problem

Adding a non-git folder via "Add project" fails with a generic "Unable to add project" error. Non-git directories are supposed to be supported as projects — the server creates `non_git` projects, the app handles `isGit: false` throughout, and there's an e2e test (`project-becomes-git.e2e.test.ts`) that verifies non-git projects work and can be upgraded to git later.

## Root cause

`getWorktreeRoot` in `checkout-git.ts` detected non-git directories by regex-matching git's stderr error message via `isNotGitRepositoryError`. The regex expected:

```
not a git repository (or any of the parent directories): .git
```

But **git 2.55+ changed the message to:**

```
not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

The regex no longer matched, so the error was re-thrown instead of returning `null`. This propagated through `getCheckout` → `findOrCreateProjectForDirectory` → `handleProjectAddRequest`, causing every non-git project add to fail.

## Fix

Replace the regex-based `isNotGitRepositoryError` with a programmatic exit-code check. `git rev-parse --show-toplevel` exits with code 128 when the cwd is not inside a git repository — this is a stable contract, not human-readable text that changes between versions.

```typescript
const result = await runGitCommand(["rev-parse", "--show-toplevel"], {
  cwd,
  envOverlay: READ_ONLY_GIT_ENV,
  logger: context?.logger,
  acceptExitCodes: [0, 128],
});
if (result.exitCode !== 0) {
  return null;
}
return parseGitRevParsePath(result.stdout);
```

The `acceptExitCodes` pattern is already used throughout the codebase (e.g. `acceptExitCodes: [0, 1]` for ref verification). Removed the now-unused `isNotGitRepositoryError` function.

## Verification

- All 121 `checkout-git.test.ts` tests pass.
- All 22 `checkout-git-rev-parse.test.ts` + `workspace-git-service.test.ts` tests pass.
- Typecheck, lint, and format clean.
- Confirmed `git rev-parse --show-toplevel` exits 128 for non-git dirs and 0 for git dirs on git 2.55.0.
- Reproduced the original error via `client.addProject("/tmp/paseo-non-git-test")` before the fix; the fix resolves it.