### PR TITLE
fix(omp): accept all command source types in slash command schema

### DIFF
--- a/packages/server/src/server/agent/providers/omp/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/omp/rpc-types.ts
@@ -141,7 +141,7 @@ export const OmpRpcSlashCommandSchema = z
   .object({
     name: z.string(),
     description: z.string().optional(),
-    source: z.enum(["extension", "prompt", "skill", "builtin"]),
+    source: z.string().optional(),
     sourceInfo: z.record(z.string(), z.unknown()).optional(),
     input: z.object({ hint: z.string().optional() }).passthrough().nullable().optional(),
   })


### PR DESCRIPTION
## Problem

The Paseo `/` autocomplete only shows `/exit` and `/clear` for omp agents — none of omp's 34 commands appear.

## Root cause

`OmpRpcSlashCommandSchema` in `rpc-types.ts` had a strict `source` enum:

```typescript
source: z.enum(["extension", "prompt", "skill", "builtin"])
```

But omp reports commands with additional source types: `"custom"` (e.g. `/green`, `/review`) and `"file"` (e.g. `/init`). When omp returned any command with one of these sources, the entire `get_available_commands` response failed Zod validation. `OmpCommandsResultSchema.parse()` threw, `getCommands()` propagated the error, and `listCommands()` returned an empty array.

The autocomplete then fell back to showing only Paseo's client-side commands (`/exit`, `/clear`, `/new`).

## Fix

Relax `source` to `z.string().optional()`, matching the already-permissive `OmpAvailableCommandSchema` used for the `available_commands_update` event (which correctly used `z.string().optional()` all along).

```typescript
source: z.string().optional(),
```

`mapOmpCommandKind` already handles any string: `"skill"` → `"skill"`, everything else → `"command"`.

## Verification

- All 11 `commands.test.ts` + `cli-runtime.test.ts` tests pass.
- Typecheck, lint, and format clean.
- Confirmed `OmpCommandsResultSchema.parse()` now accepts all 5 source types (`builtin`, `custom`, `file`, `extension`, `skill`) that omp reports.
- Reproduced the original bug: `client.listCommands()` returned 0 commands before the fix due to Zod validation failure on `source: "custom"`.