### PR TITLE
fix(workspaces): report landed worktree state truthfully

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ At the start of non-trivial work, list `docs/` and skim anything relevant to the
 | [docs/docker.md](docs/docker.md)                                   | Running the daemon and bundled web UI in Docker, volumes, agent images, security                                               |
 | [docs/release.md](docs/release.md)                                 | Release playbook, draft releases, completion checklist                                                                         |
 | [docs/terminal-activity.md](docs/terminal-activity.md)             | Terminal activity indicators — source-agnostic tracker, agent hook reporting, adding a new hook provider                       |
+| [docs/origin-default-relation.md](docs/origin-default-relation.md) | HEAD vs origin default: ancestry vs patch equivalence, fail-closed auto-archive, common-dir ref refresh                        |
 | [SECURITY.md](SECURITY.md)                                         | Relay threat model, E2E encryption, DNS rebinding, agent auth                                                                  |
 
 ## Quick start

--- a/docs/origin-default-relation.md
+++ b/docs/origin-default-relation.md
@@ -1,8 +1,13 @@
 # Origin default relation
 
 `originDefaultRelation` describes how a checkout's `HEAD` relates to the resolved
-**origin default tip** (prefer `refs/remotes/origin/HEAD`, else the repository's
-default branch under `origin/`). It is additive protocol data so already-landed
+**origin default tip**. Resolution requires authoritative
+`refs/remotes/origin/HEAD` evidence: a valid symbolic-ref whose target is under
+`refs/remotes/origin/*` and whose target ref exists. Missing, malformed,
+wrong-namespace, or dangling targets yield `unverifiable` with null
+counts/ref as appropriate — there is **no** fall back to local `main`/`master`
+for this safety field (local heuristics remain only for unrelated non-safety
+base operations such as `baseRef`). It is additive protocol data so already-landed
 work is not treated as unpushed risk.
 
 ## Ancestry vs patch equivalence
@@ -22,8 +27,9 @@ already reachable from origin default. The work has landed in the history sense.
 **Patch equivalence** is weaker. A squash merge can leave a feature tip with a
 different commit graph that happens to produce the same tree (or cherry-equivalent
 patches). That is **not** ancestral inclusion. The branch is still treated as
-protected: sidebar/archive copy says it is patch-equivalent and **not ancestral**,
-and auto-archive will not remove it on that evidence alone.
+protected: sidebar/archive copy says changes landed on the default tip while the
+branch itself is not merged, and auto-archive will not remove it on that evidence
+alone.
 
 Legacy `aheadOfOrigin` / `behindOfOrigin` continue to mean "ahead of the branch's
 configured upstream," not "ahead of origin default." Do not conflate the two.
@@ -42,14 +48,16 @@ Auto-archive is **fail closed**. All of the following are required:
 
 1. Explicit setting `autoArchiveAfterMerge === true`
 2. Merged pull request observed for that checkout
-3. Clean working tree — `isDirty === false` (null/undefined is unknown and fails)
-4. Named branch (not detached)
-5. Verifiable `originDefaultRelation` with state `exact` or `included`
-6. Relation `ahead === 0` (null/undefined/nonzero fail)
-7. Relation `uniquePatchCount === 0` (null/undefined/nonzero fail)
-8. Branch upstream `aheadOfOrigin === 0` (null/undefined/nonzero fail)
-9. Paseo-owned worktree (founder / non-Paseo checkouts are never auto-archived)
-10. Successful workspace resolution and archive path (errors skip, never force)
+3. **Forced fresh** git snapshot (`force: true`, `includeForge: false`, reason
+   `auto-archive-on-merge`) — never gate on a cached snapshot
+4. Clean working tree — `isDirty === false` (null/undefined is unknown and fails)
+5. Named branch (not detached)
+6. Verifiable `originDefaultRelation` with state `exact` or `included`
+7. Relation `ahead === 0` (null/undefined/nonzero fail)
+8. Relation `uniquePatchCount === 0` (null/undefined/nonzero fail)
+9. Branch upstream `aheadOfOrigin === 0` (null/undefined/nonzero fail)
+10. Paseo-owned worktree (founder / non-Paseo checkouts are never auto-archived)
+11. Successful workspace resolution and archive path (errors skip, never force)
 
 Unknown fields never pass: missing relation (old daemon shape), `null`/`undefined`
 counts, non-zero ahead, non-safe relation states (`ahead`,
@@ -62,7 +70,9 @@ by itself.
 
 Worktrees that share a git common directory share remote-default refs
 (`refs/remotes/origin/*`, `packed-refs`, local default under `refs/heads`).
-`WorkspaceGitService` watches those paths once per common dir and refreshes every
-registered workspace snapshot so a main-sync or Queue publish in one checkout
-updates `originDefaultRelation` (and `checkout_status_update` / `gitRuntime`) for
-siblings promptly, without a separate polling subsystem.
+`WorkspaceGitService` watches those paths once per common dir and schedules a
+**forced** debounced refresh (`force: true`, `includeForge: false`, reason
+`common-dir-refs`) for every registered workspace so a main-sync or Queue publish
+in one checkout updates `originDefaultRelation` (and `checkout_status_update` /
+`gitRuntime`) for siblings promptly. Force bypasses the 2s non-forced internal
+throttle while debounce still coalesces watcher storms; no forge/network work.

--- a/docs/origin-default-relation.md
+++ b/docs/origin-default-relation.md
@@ -42,18 +42,21 @@ Auto-archive is **fail closed**. All of the following are required:
 
 1. Explicit setting `autoArchiveAfterMerge === true`
 2. Merged pull request observed for that checkout
-3. Clean working tree
+3. Clean working tree — `isDirty === false` (null/undefined is unknown and fails)
 4. Named branch (not detached)
 5. Verifiable `originDefaultRelation` with state `exact` or `included`
-6. Non-null relation `ahead` and no unique-patch risk (`uniquePatchCount` not `> 0`)
-7. Not ahead of the branch upstream when `aheadOfOrigin` is a positive number
-8. Paseo-owned worktree (founder / non-Paseo checkouts are never auto-archived)
-9. Successful workspace resolution and archive path (errors skip, never force)
+6. Relation `ahead === 0` (null/undefined/nonzero fail)
+7. Relation `uniquePatchCount === 0` (null/undefined/nonzero fail)
+8. Branch upstream `aheadOfOrigin === 0` (null/undefined/nonzero fail)
+9. Paseo-owned worktree (founder / non-Paseo checkouts are never auto-archived)
+10. Successful workspace resolution and archive path (errors skip, never force)
 
-Missing relation (old daemon shape), `null` ahead, `ahead`,
-`patch_equivalent_not_included`, `diverged_with_unique_commits`, `unverifiable`,
-dirty trees, or archive failures **skip**. Inclusion is evidence used **only after**
-the explicit auto-archive setting; it never initiates archive by itself.
+Unknown fields never pass: missing relation (old daemon shape), `null`/`undefined`
+counts, non-zero ahead, non-safe relation states (`ahead`,
+`patch_equivalent_not_included`, `diverged_with_unique_commits`, `unverifiable`),
+dirty or unknown dirty trees, or archive failures **skip**. Inclusion is evidence
+used **only after** the explicit auto-archive setting; it never initiates archive
+by itself.
 
 ## Cross-worktree refresh
 

--- a/docs/origin-default-relation.md
+++ b/docs/origin-default-relation.md
@@ -1,0 +1,65 @@
+# Origin default relation
+
+`originDefaultRelation` describes how a checkout's `HEAD` relates to the resolved
+**origin default tip** (prefer `refs/remotes/origin/HEAD`, else the repository's
+default branch under `origin/`). It is additive protocol data so already-landed
+work is not treated as unpushed risk.
+
+## Ancestry vs patch equivalence
+
+| State                           | Meaning                                                                          | Safety for auto-archive          |
+| ------------------------------- | -------------------------------------------------------------------------------- | -------------------------------- |
+| `exact`                         | `HEAD` OID equals the origin default tip                                         | Safe evidence (with other gates) |
+| `included`                      | `HEAD` is an ancestor of origin default                                          | Safe evidence (with other gates) |
+| `ahead`                         | Origin default is an ancestor of `HEAD`; unique commits remain                   | Not safe                         |
+| `patch_equivalent_not_included` | Same tree / no unique patches, but **not** ancestral inclusion (e.g. squash tip) | Not safe — still protected       |
+| `diverged_with_unique_commits`  | Diverged with unique patch content                                               | Not safe                         |
+| `unverifiable`                  | Missing remote default, detached ambiguity, or proof budget exceeded             | Not safe                         |
+
+**Ancestral inclusion** (`exact` / `included`) means every commit on `HEAD` is
+already reachable from origin default. The work has landed in the history sense.
+
+**Patch equivalence** is weaker. A squash merge can leave a feature tip with a
+different commit graph that happens to produce the same tree (or cherry-equivalent
+patches). That is **not** ancestral inclusion. The branch is still treated as
+protected: sidebar/archive copy says it is patch-equivalent and **not ancestral**,
+and auto-archive will not remove it on that evidence alone.
+
+Legacy `aheadOfOrigin` / `behindOfOrigin` continue to mean "ahead of the branch's
+configured upstream," not "ahead of origin default." Do not conflate the two.
+
+## Explicit archive authority
+
+### Manual archive
+
+The user always retains archive authority. Confirmation still runs when the
+worktree is dirty or carries unique / unpushed risk. Inclusion may suppress a
+stale "N unpushed commits" warning, but never forces an archive.
+
+### Auto-archive after merge
+
+Auto-archive is **fail closed**. All of the following are required:
+
+1. Explicit setting `autoArchiveAfterMerge === true`
+2. Merged pull request observed for that checkout
+3. Clean working tree
+4. Named branch (not detached)
+5. Verifiable `originDefaultRelation` with state `exact` or `included`
+6. Non-null relation `ahead` and no unique-patch risk (`uniquePatchCount` not `> 0`)
+7. Not ahead of the branch upstream when `aheadOfOrigin` is a positive number
+8. Paseo-owned worktree (founder / non-Paseo checkouts are never auto-archived)
+9. Successful workspace resolution and archive path (errors skip, never force)
+
+Missing relation (old daemon shape), `null` ahead, `ahead`,
+`patch_equivalent_not_included`, `diverged_with_unique_commits`, `unverifiable`,
+dirty trees, or archive failures **skip**. Inclusion is evidence used **only after**
+the explicit auto-archive setting; it never initiates archive by itself.
+
+## Cross-worktree refresh
+
+Worktrees that share a git common directory share remote-default refs
+(`refs/remotes/origin/*`, `packed-refs`, local default under `refs/heads`).
+`WorkspaceGitService` watches those paths once per common dir and refreshes every
+registered workspace snapshot so a main-sync or Queue publish in one checkout
+updates `originDefaultRelation` (and `checkout_status_update` / `gitRuntime`) for
+siblings promptly, without a separate polling subsystem.

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -64,6 +64,7 @@ import {
   parseHostWorkspaceRouteFromPathname,
 } from "@/utils/host-routes";
 import {
+  appendSidebarRelationLabel,
   shouldShowSidebarHostLabels,
   type SidebarProjectEntry,
   type SidebarWorkspaceEntry,
@@ -1657,13 +1658,15 @@ function ProjectBlock({
         dragHandleProps?: DraggableListDragHandleProps;
       },
     ) => {
+      const workspaceEntry = workspaceEntriesByKey.get(item.workspaceKey) ?? null;
       return (
         <MemoWorkspaceRowItem
           workspace={item}
-          workspaceEntry={workspaceEntriesByKey.get(item.workspaceKey) ?? null}
-          subtitle={
-            showHostLabels ? (hostLabelByServerId.get(item.serverId) ?? item.serverId) : null
-          }
+          workspaceEntry={workspaceEntry}
+          subtitle={appendSidebarRelationLabel(
+            showHostLabels ? (hostLabelByServerId.get(item.serverId) ?? item.serverId) : null,
+            workspaceEntry?.originDefaultRelationLabel,
+          )}
           shortcutNumber={shortcutIndexByWorkspaceKey.get(item.workspaceKey) ?? null}
           showShortcutBadge={showShortcutBadges}
           canCopyBranchName={project.projectKind === "git"}
@@ -2292,12 +2295,19 @@ function ProjectModeList({
       const hostLabel = showHostLabels
         ? (hostLabelByServerId.get(workspace.serverId) ?? workspace.serverId)
         : null;
+      const workspaceEntry = workspaceEntriesByKey.get(workspace.workspaceKey) ?? null;
+      const projectSubtitle = hostLabel
+        ? `${workspace.projectName} · ${hostLabel}`
+        : workspace.projectName;
       return (
         <MemoWorkspaceRowItem
           key={workspace.workspaceKey}
           workspace={workspace}
-          workspaceEntry={workspaceEntriesByKey.get(workspace.workspaceKey) ?? null}
-          subtitle={hostLabel ? `${workspace.projectName} · ${hostLabel}` : workspace.projectName}
+          workspaceEntry={workspaceEntry}
+          subtitle={appendSidebarRelationLabel(
+            projectSubtitle,
+            workspaceEntry?.originDefaultRelationLabel,
+          )}
           shortcutNumber={shortcutIndexByWorkspaceKey.get(workspace.workspaceKey) ?? null}
           showShortcutBadge={showShortcutBadges}
           canCopyBranchName={workspace.projectKind === "git"}

--- a/packages/app/src/components/sidebar/sidebar-projection.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.test.ts
@@ -28,6 +28,7 @@ function makeWorkspace(id: string, statusBucket: SidebarWorkspaceEntry["statusBu
     prHint: null,
     archiveHasUncommittedChanges: null,
     archiveUnpushedCommitCount: null,
+    archiveOriginDefaultRelation: null,
     scripts: [],
     hasRunningScripts: false,
   };

--- a/packages/app/src/components/sidebar/sidebar-projection.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.test.ts
@@ -29,6 +29,7 @@ function makeWorkspace(id: string, statusBucket: SidebarWorkspaceEntry["statusBu
     archiveHasUncommittedChanges: null,
     archiveUnpushedCommitCount: null,
     archiveOriginDefaultRelation: null,
+    originDefaultRelationLabel: null,
     scripts: [],
     hasRunningScripts: false,
   };

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -6,6 +6,7 @@ import { navigateToWorkspace } from "@/stores/navigation-active-workspace-store"
 import { useActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
 import { type SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
 import type { StatusGroup } from "@/hooks/sidebar-status-view-model";
+import { appendSidebarRelationLabel } from "@/hooks/sidebar-workspaces-view-model";
 import { isWeb as platformIsWeb, isNative as platformIsNative } from "@/constants/platform";
 import { StyleSheet } from "react-native-unistyles";
 import type { Theme } from "@/styles/theme";
@@ -111,6 +112,7 @@ export function SidebarStatusWorkspaceList({
                     hostLabel: showHostLabels
                       ? (hostLabelByServerId.get(workspace.serverId) ?? workspace.serverId)
                       : null,
+                    originDefaultRelationLabel: workspace.originDefaultRelationLabel,
                   })}
                   shortcutNumber={statusShortcutIndex.get(workspace.workspaceKey) ?? null}
                   showShortcutBadge={showShortcutBadges}
@@ -205,6 +207,7 @@ function StatusGroupList({
                     hostLabel: showHostLabels
                       ? (hostLabelByServerId.get(workspace.serverId) ?? workspace.serverId)
                       : null,
+                    originDefaultRelationLabel: workspace.originDefaultRelationLabel,
                   })}
                   shortcutNumber={shortcutIndex.get(workspace.workspaceKey) ?? null}
                   showShortcutBadge={showShortcutBadges}
@@ -222,19 +225,26 @@ function StatusGroupList({
 }
 
 // Status mode breaks the project grouping, so the row needs the project name to stay
-// legible; the host is appended after a middle dot once labels are active.
+// legible; the host is appended after a middle dot once labels are active. When the
+// branch is already on origin default (or still has unique work), surface that relation
+// instead of a misleading unpushed count.
 function buildStatusRowSubtitle({
   projectName,
   hostLabel,
+  originDefaultRelationLabel,
 }: {
   projectName: string;
   hostLabel: string | null;
+  originDefaultRelationLabel?: string | null;
 }): string {
-  if (!hostLabel) {
-    return projectName;
+  let base = projectName;
+  if (hostLabel) {
+    base = projectName ? `${projectName} · ${hostLabel}` : hostLabel;
   }
-  return projectName ? `${projectName} · ${hostLabel}` : hostLabel;
+  return appendSidebarRelationLabel(base, originDefaultRelationLabel) ?? "";
 }
+
+export { buildStatusRowSubtitle as buildStatusRowSubtitleForTests };
 
 function StatusGroupHeader({ group, collapsed }: { group: StatusGroup; collapsed: boolean }) {
   const [isHovered, setIsHovered] = useState(false);

--- a/packages/app/src/components/workspace-hover-card.tsx
+++ b/packages/app/src/components/workspace-hover-card.tsx
@@ -306,6 +306,15 @@ function WorkspaceHoverCardContent({
               testID="hover-card-workspace-cwd"
             />
           ) : null}
+          {workspace.originDefaultRelationLabel ? (
+            <Text
+              style={styles.relationLabel}
+              numberOfLines={2}
+              testID="hover-card-origin-default-relation"
+            >
+              {workspace.originDefaultRelationLabel}
+            </Text>
+          ) : null}
           {prHint || workspace.diffStat ? (
             <View style={styles.cardMetaRow}>
               {workspace.diffStat ? (
@@ -594,6 +603,13 @@ const styles = StyleSheet.create((theme) => ({
     fontWeight: theme.fontWeight.normal,
     flex: 1,
     minWidth: 0,
+  },
+  relationLabel: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.normal,
+    paddingHorizontal: theme.spacing[3],
+    paddingBottom: theme.spacing[2],
   },
   cardMetaRow: {
     flexDirection: "row",

--- a/packages/app/src/git/use-actions.tsx
+++ b/packages/app/src/git/use-actions.tsx
@@ -24,7 +24,10 @@ import {
   type ActiveWorkspaceSelection,
 } from "@/stores/navigation-active-workspace-store";
 import { redirectIfArchivingActiveWorkspace } from "@/utils/sidebar-workspace-archive-redirect";
-import { type WorktreeArchiveWarningLabels } from "@/git/worktree-archive-warning";
+import {
+  type OriginDefaultRelation,
+  type WorktreeArchiveWarningLabels,
+} from "@/git/worktree-archive-warning";
 import { useWorkspaceArchive } from "@/workspace/use-workspace-archive";
 import { resolveWorkspaceMapKeyByIdentity } from "@/utils/workspace-identity";
 
@@ -220,10 +223,17 @@ function resolveArchiveWorkspaceDescriptor(input: {
 function resolveWorkspaceArchiveRisk(
   workspace: WorkspaceDescriptor | null,
   gitStatus: CheckoutStatusPayload | null,
-): { isDirty: boolean | null | undefined; aheadOfOrigin: number | null | undefined } {
+): {
+  isDirty: boolean | null | undefined;
+  aheadOfOrigin: number | null | undefined;
+  originDefaultRelation: OriginDefaultRelation | null | undefined;
+} {
+  const statusRelation =
+    gitStatus && gitStatus.isGit ? (gitStatus.originDefaultRelation ?? undefined) : undefined;
   return {
     isDirty: gitStatus?.isDirty ?? workspace?.gitRuntime?.isDirty,
     aheadOfOrigin: gitStatus?.aheadOfOrigin ?? workspace?.gitRuntime?.aheadOfOrigin,
+    originDefaultRelation: statusRelation ?? workspace?.gitRuntime?.originDefaultRelation ?? null,
   };
 }
 
@@ -266,6 +276,7 @@ function useWorkspaceScreenArchiveController({
     name: workspaceDescriptor?.name ?? branchLabel,
     isDirty: archiveRisk.isDirty,
     aheadOfOrigin: archiveRisk.aheadOfOrigin,
+    originDefaultRelation: archiveRisk.originDefaultRelation,
     diffStat: workspaceDescriptor?.diffStat ?? null,
     warningLabels: getWorktreeArchiveWarningLabels(t),
     onSetHiding: setIsHidingWorkspace,
@@ -1100,5 +1111,13 @@ function getWorktreeArchiveWarningLabels(
           : "workspace.git.actions.archiveWarning.unpushedCommits",
         { count },
       ),
+    includedInOriginDefault: (resolvedRef) =>
+      t("workspace.git.actions.archiveWarning.includedInOriginDefault", {
+        resolvedRef: resolvedRef || "origin/default",
+      }),
+    patchEquivalentToOriginDefault: (resolvedRef) =>
+      t("workspace.git.actions.archiveWarning.patchEquivalentToOriginDefault", {
+        resolvedRef: resolvedRef || "origin/default",
+      }),
   };
 }

--- a/packages/app/src/git/worktree-archive-warning.test.ts
+++ b/packages/app/src/git/worktree-archive-warning.test.ts
@@ -3,8 +3,59 @@ import { describe, expect, it } from "vitest";
 import {
   buildWorktreeArchiveConfirmationMessage,
   buildWorktreeArchiveRiskReasons,
+  classifyOriginDefaultArchivePushRisk,
+  formatOriginDefaultRelationLabel,
   toWorktreeArchiveRisk,
+  type OriginDefaultRelation,
 } from "@/git/worktree-archive-warning";
+
+const included: OriginDefaultRelation = {
+  state: "included",
+  resolvedRef: "origin/main",
+  ahead: 0,
+  behind: 2,
+  uniquePatchCount: 0,
+};
+
+const exact: OriginDefaultRelation = {
+  state: "exact",
+  resolvedRef: "origin/main",
+  ahead: 0,
+  behind: 0,
+  uniquePatchCount: 0,
+};
+
+const patchEquivalent: OriginDefaultRelation = {
+  state: "patch_equivalent_not_included",
+  resolvedRef: "origin/main",
+  ahead: 1,
+  behind: 1,
+  uniquePatchCount: 0,
+};
+
+const ahead: OriginDefaultRelation = {
+  state: "ahead",
+  resolvedRef: "origin/main",
+  ahead: 2,
+  behind: 0,
+  uniquePatchCount: 2,
+};
+
+const diverged: OriginDefaultRelation = {
+  state: "diverged_with_unique_commits",
+  resolvedRef: "origin/main",
+  ahead: 1,
+  behind: 1,
+  uniquePatchCount: 1,
+};
+
+const unverifiable: OriginDefaultRelation = {
+  state: "unverifiable",
+  resolvedRef: null,
+  ahead: null,
+  behind: null,
+  uniquePatchCount: null,
+};
 
 describe("workspace archive warning for worktree backing", () => {
   it("does not require a confirmation for clean and pushed worktrees", () => {
@@ -64,12 +115,81 @@ describe("workspace archive warning for worktree backing", () => {
       toWorktreeArchiveRisk({
         archiveHasUncommittedChanges: true,
         archiveUnpushedCommitCount: 3,
+        archiveOriginDefaultRelation: included,
         diffStat: { additions: 2, deletions: 1 },
       }),
     ).toEqual({
       isDirty: true,
       aheadOfOrigin: 3,
+      originDefaultRelation: included,
       diffStat: { additions: 2, deletions: 1 },
     });
+  });
+
+  it("does not treat exact/included as unpushed risk even when aheadOfOrigin is positive", () => {
+    expect(
+      buildWorktreeArchiveRiskReasons({
+        isDirty: false,
+        aheadOfOrigin: 3,
+        originDefaultRelation: included,
+        diffStat: null,
+      }),
+    ).toEqual([]);
+    expect(
+      buildWorktreeArchiveRiskReasons({
+        isDirty: false,
+        aheadOfOrigin: 1,
+        originDefaultRelation: exact,
+        diffStat: null,
+      }),
+    ).toEqual([]);
+    expect(classifyOriginDefaultArchivePushRisk(included)).toBe("included");
+    expect(classifyOriginDefaultArchivePushRisk(exact)).toBe("included");
+  });
+
+  it("labels exact/included as Included in origin/<default>", () => {
+    expect(formatOriginDefaultRelationLabel(included)).toBe("Included in origin/main");
+    expect(formatOriginDefaultRelationLabel(exact)).toBe("Included in origin/main");
+  });
+
+  it("keeps patch-equivalent visibly distinct and still protected", () => {
+    expect(
+      buildWorktreeArchiveRiskReasons({
+        isDirty: false,
+        aheadOfOrigin: 2,
+        originDefaultRelation: patchEquivalent,
+        diffStat: null,
+      }),
+    ).toEqual(["Patch-equivalent to origin/main (not ancestral; still protected)"]);
+    expect(formatOriginDefaultRelationLabel(patchEquivalent)).toBe(
+      "Patch-equivalent to origin/main (not ancestral; still protected)",
+    );
+    expect(classifyOriginDefaultArchivePushRisk(patchEquivalent)).toBe("patch_equivalent");
+  });
+
+  it("keeps ahead/diverged/unverifiable as unpushed risk when aheadOfOrigin is positive", () => {
+    for (const relation of [ahead, diverged, unverifiable]) {
+      expect(
+        buildWorktreeArchiveRiskReasons({
+          isDirty: false,
+          aheadOfOrigin: 2,
+          originDefaultRelation: relation,
+          diffStat: null,
+        }),
+      ).toEqual(["2 unpushed commits"]);
+    }
+  });
+
+  it("falls back to legacy unpushed labeling when originDefaultRelation is missing", () => {
+    expect(
+      buildWorktreeArchiveRiskReasons({
+        isDirty: false,
+        aheadOfOrigin: 4,
+        originDefaultRelation: null,
+        diffStat: null,
+      }),
+    ).toEqual(["4 unpushed commits"]);
+    expect(formatOriginDefaultRelationLabel(null, undefined, 4)).toBe("4 unpushed commits");
+    expect(classifyOriginDefaultArchivePushRisk(undefined)).toBe("unknown");
   });
 });

--- a/packages/app/src/git/worktree-archive-warning.test.ts
+++ b/packages/app/src/git/worktree-archive-warning.test.ts
@@ -149,7 +149,26 @@ describe("workspace archive warning for worktree backing", () => {
 
   it("labels exact/included as Included in origin/<default>", () => {
     expect(formatOriginDefaultRelationLabel(included)).toBe("Included in origin/main");
+    // Without currentBranch, exact still labels (display helper is opt-in suppress).
     expect(formatOriginDefaultRelationLabel(exact)).toBe("Included in origin/main");
+    // Feature branch at exact tip still shows inclusion (not a default-branch tautology).
+    expect(formatOriginDefaultRelationLabel(exact, undefined, undefined, "feature")).toBe(
+      "Included in origin/main",
+    );
+  });
+
+  it("suppresses exact label for ordinary default-branch checkout (display only)", () => {
+    expect(formatOriginDefaultRelationLabel(exact, undefined, undefined, "main")).toBeNull();
+    // Classification / archive risk path remains included — only the status label is scoped.
+    expect(classifyOriginDefaultArchivePushRisk(exact)).toBe("included");
+    expect(
+      buildWorktreeArchiveRiskReasons({
+        isDirty: false,
+        aheadOfOrigin: 1,
+        originDefaultRelation: exact,
+        diffStat: null,
+      }),
+    ).toEqual([]);
   });
 
   it("keeps patch-equivalent visibly distinct and still protected", () => {
@@ -160,9 +179,9 @@ describe("workspace archive warning for worktree backing", () => {
         originDefaultRelation: patchEquivalent,
         diffStat: null,
       }),
-    ).toEqual(["Patch-equivalent to origin/main (not ancestral; still protected)"]);
+    ).toEqual(["Changes landed in origin/main (branch not merged)"]);
     expect(formatOriginDefaultRelationLabel(patchEquivalent)).toBe(
-      "Patch-equivalent to origin/main (not ancestral; still protected)",
+      "Changes landed in origin/main (branch not merged)",
     );
     expect(classifyOriginDefaultArchivePushRisk(patchEquivalent)).toBe("patch_equivalent");
   });

--- a/packages/app/src/git/worktree-archive-warning.ts
+++ b/packages/app/src/git/worktree-archive-warning.ts
@@ -1,15 +1,33 @@
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { i18n } from "@/i18n/i18next";
 
+export type OriginDefaultRelationState =
+  | "exact"
+  | "included"
+  | "ahead"
+  | "patch_equivalent_not_included"
+  | "diverged_with_unique_commits"
+  | "unverifiable";
+
+export interface OriginDefaultRelation {
+  state: OriginDefaultRelationState;
+  resolvedRef: string | null;
+  ahead: number | null;
+  behind: number | null;
+  uniquePatchCount: number | null;
+}
+
 export interface WorktreeArchiveRisk {
   isDirty?: boolean | null;
   aheadOfOrigin?: number | null;
+  originDefaultRelation?: OriginDefaultRelation | null;
   diffStat?: { additions: number; deletions: number } | null;
 }
 
 export interface WorktreeArchiveRiskInput {
   archiveHasUncommittedChanges?: boolean | null;
   archiveUnpushedCommitCount?: number | null;
+  archiveOriginDefaultRelation?: OriginDefaultRelation | null;
   diffStat?: WorktreeArchiveRisk["diffStat"];
 }
 
@@ -26,6 +44,12 @@ export interface WorktreeArchiveWarningLabels {
   addedLine: (count: number) => string;
   deletedLine: (count: number) => string;
   unpushedCommit: (count: number) => string;
+  includedInOriginDefault: (resolvedRef: string) => string;
+  patchEquivalentToOriginDefault: (resolvedRef: string) => string;
+}
+
+function defaultResolvedRefLabel(resolvedRef: string | null | undefined): string {
+  return resolvedRef && resolvedRef.length > 0 ? resolvedRef : "origin/default";
 }
 
 export const DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS: WorktreeArchiveWarningLabels = {
@@ -47,14 +71,48 @@ export const DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS: WorktreeArchiveWarningLabe
     count === 1
       ? i18n.t("workspace.git.actions.archiveWarning.unpushedCommit", { count })
       : i18n.t("workspace.git.actions.archiveWarning.unpushedCommits", { count }),
+  includedInOriginDefault: (resolvedRef) =>
+    i18n.t("workspace.git.actions.archiveWarning.includedInOriginDefault", {
+      resolvedRef: defaultResolvedRefLabel(resolvedRef),
+    }),
+  patchEquivalentToOriginDefault: (resolvedRef) =>
+    i18n.t("workspace.git.actions.archiveWarning.patchEquivalentToOriginDefault", {
+      resolvedRef: defaultResolvedRefLabel(resolvedRef),
+    }),
 };
 
 export function toWorktreeArchiveRisk(input: WorktreeArchiveRiskInput): WorktreeArchiveRisk {
   return {
     isDirty: input.archiveHasUncommittedChanges,
     aheadOfOrigin: input.archiveUnpushedCommitCount,
+    originDefaultRelation: input.archiveOriginDefaultRelation,
     diffStat: input.diffStat,
   };
+}
+
+/**
+ * Classify how origin-default relation affects archive push risk messaging.
+ * Missing relation (old daemon) preserves legacy aheadOfOrigin behavior.
+ */
+export function classifyOriginDefaultArchivePushRisk(
+  relation: OriginDefaultRelation | null | undefined,
+): "included" | "patch_equivalent" | "risky" | "unknown" {
+  if (!relation) {
+    return "unknown";
+  }
+  switch (relation.state) {
+    case "exact":
+    case "included":
+      return "included";
+    case "patch_equivalent_not_included":
+      return "patch_equivalent";
+    case "ahead":
+    case "diverged_with_unique_commits":
+    case "unverifiable":
+      return "risky";
+    default:
+      return "unknown";
+  }
 }
 
 function formatDiffStat(
@@ -93,12 +151,60 @@ export function buildWorktreeArchiveRiskReasons(
     );
   }
 
-  if ((input.aheadOfOrigin ?? 0) > 0) {
-    const aheadOfOrigin = input.aheadOfOrigin ?? 0;
+  const aheadOfOrigin = input.aheadOfOrigin ?? 0;
+  const pushRisk = classifyOriginDefaultArchivePushRisk(input.originDefaultRelation);
+
+  if (pushRisk === "included") {
+    // Already landed on origin default — encode inclusion instead of unpushed risk.
+    // Do not add a protective unpushed reason; optional explicit inclusion label is
+    // available via formatOriginDefaultRelationLabel for status UIs.
+  } else if (pushRisk === "patch_equivalent") {
+    // Visibly distinct and still protected: branch tip is not ancestral inclusion.
+    reasons.push(
+      labels.patchEquivalentToOriginDefault(
+        defaultResolvedRefLabel(input.originDefaultRelation?.resolvedRef),
+      ),
+    );
+  } else if (aheadOfOrigin > 0) {
+    // Risky / unknown (missing field from old daemon): legacy unpushed warning.
     reasons.push(labels.unpushedCommit(aheadOfOrigin));
   }
 
   return reasons;
+}
+
+/** Status/label helper for sidebar and fallbacks — not used as archive land authority. */
+export function formatOriginDefaultRelationLabel(
+  relation: OriginDefaultRelation | null | undefined,
+  labels: Pick<
+    WorktreeArchiveWarningLabels,
+    "includedInOriginDefault" | "patchEquivalentToOriginDefault" | "unpushedCommit"
+  > = DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS,
+  fallbackAheadOfOrigin?: number | null,
+): string | null {
+  if (!relation) {
+    if ((fallbackAheadOfOrigin ?? 0) > 0) {
+      return labels.unpushedCommit(fallbackAheadOfOrigin ?? 0);
+    }
+    return null;
+  }
+
+  switch (relation.state) {
+    case "exact":
+    case "included":
+      return labels.includedInOriginDefault(defaultResolvedRefLabel(relation.resolvedRef));
+    case "patch_equivalent_not_included":
+      return labels.patchEquivalentToOriginDefault(defaultResolvedRefLabel(relation.resolvedRef));
+    case "ahead":
+    case "diverged_with_unique_commits":
+    case "unverifiable":
+      if ((fallbackAheadOfOrigin ?? relation.ahead ?? 0) > 0) {
+        return labels.unpushedCommit(fallbackAheadOfOrigin ?? relation.ahead ?? 0);
+      }
+      return null;
+    default:
+      return null;
+  }
 }
 
 export function buildWorktreeArchiveConfirmationMessage(

--- a/packages/app/src/git/worktree-archive-warning.ts
+++ b/packages/app/src/git/worktree-archive-warning.ts
@@ -173,6 +173,44 @@ export function buildWorktreeArchiveRiskReasons(
   return reasons;
 }
 
+/**
+ * Local branch name for the origin-default tip, e.g. `origin/main` → `main`.
+ * Returns null when the resolved ref is missing or not an origin/* short ref.
+ */
+function originDefaultBranchName(resolvedRef: string | null | undefined): string | null {
+  if (!resolvedRef || resolvedRef.length === 0) {
+    return null;
+  }
+  if (resolvedRef.startsWith("origin/")) {
+    const name = resolvedRef.slice("origin/".length);
+    return name.length > 0 ? name : null;
+  }
+  if (resolvedRef.startsWith("refs/remotes/origin/")) {
+    const name = resolvedRef.slice("refs/remotes/origin/".length);
+    return name.length > 0 ? name : null;
+  }
+  return null;
+}
+
+/**
+ * Ordinary default-branch checkout at the tip: "Included in origin/main" while
+ * already on `main` is a tautology. Scope is display-only — classification and
+ * archive safety are unchanged.
+ */
+function isOrdinaryExactDefaultCheckout(
+  relation: OriginDefaultRelation,
+  currentBranch: string | null | undefined,
+): boolean {
+  if (relation.state !== "exact") {
+    return false;
+  }
+  if (!currentBranch) {
+    return false;
+  }
+  const defaultBranch = originDefaultBranchName(relation.resolvedRef);
+  return defaultBranch !== null && currentBranch === defaultBranch;
+}
+
 /** Status/label helper for sidebar and fallbacks — not used as archive land authority. */
 export function formatOriginDefaultRelationLabel(
   relation: OriginDefaultRelation | null | undefined,
@@ -181,6 +219,7 @@ export function formatOriginDefaultRelationLabel(
     "includedInOriginDefault" | "patchEquivalentToOriginDefault" | "unpushedCommit"
   > = DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS,
   fallbackAheadOfOrigin?: number | null,
+  currentBranch?: string | null,
 ): string | null {
   if (!relation) {
     if ((fallbackAheadOfOrigin ?? 0) > 0) {
@@ -191,7 +230,13 @@ export function formatOriginDefaultRelationLabel(
 
   switch (relation.state) {
     case "exact":
+      // Suppress tautology on ordinary default-branch checkouts only.
+      if (isOrdinaryExactDefaultCheckout(relation, currentBranch)) {
+        return null;
+      }
+      return labels.includedInOriginDefault(defaultResolvedRefLabel(relation.resolvedRef));
     case "included":
+      // Feature worktrees/branches included in origin default still show the label.
       return labels.includedInOriginDefault(defaultResolvedRefLabel(relation.resolvedRef));
     case "patch_equivalent_not_included":
       return labels.patchEquivalentToOriginDefault(defaultResolvedRefLabel(relation.resolvedRef));

--- a/packages/app/src/hooks/sidebar-status-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-status-view-model.test.ts
@@ -30,6 +30,7 @@ function ws(
     prHint: null,
     archiveHasUncommittedChanges: null,
     archiveUnpushedCommitCount: null,
+    archiveOriginDefaultRelation: null,
     scripts: [],
     hasRunningScripts: false,
     workspaceKey: input.workspaceKey,

--- a/packages/app/src/hooks/sidebar-status-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-status-view-model.test.ts
@@ -31,6 +31,7 @@ function ws(
     archiveHasUncommittedChanges: null,
     archiveUnpushedCommitCount: null,
     archiveOriginDefaultRelation: null,
+    originDefaultRelationLabel: null,
     scripts: [],
     hasRunningScripts: false,
     workspaceKey: input.workspaceKey,

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
@@ -93,12 +93,51 @@ describe("createSidebarWorkspaceEntry originDefaultRelation labels", () => {
           uniquePatchCount: 0,
         }),
       });
+      // Feature branch currentBranch in workspaceWithRelation — not a tautology.
       expect(entry.originDefaultRelationLabel).toBe("Included in origin/master");
       expect(entry.archiveUnpushedCommitCount).toBe(3);
     }
   });
 
-  it("labels patch-equivalent as not ancestral and still protected", () => {
+  it("suppresses exact label on ordinary default-branch checkout", () => {
+    const entry = createSidebarWorkspaceEntry({
+      serverId: "srv",
+      workspace: {
+        ...workspaceWithForge("github", "https://github.com/acme/repo/pull/1"),
+        gitRuntime: {
+          currentBranch: "master",
+          isDirty: false,
+          aheadOfOrigin: 0,
+          originDefaultRelation: {
+            state: "exact",
+            resolvedRef: "origin/master",
+            ahead: 0,
+            behind: 0,
+            uniquePatchCount: 0,
+          },
+        },
+      },
+    });
+    expect(entry.originDefaultRelationLabel).toBeNull();
+    // Safety classification inputs are still present for archive flows.
+    expect(entry.archiveOriginDefaultRelation?.state).toBe("exact");
+  });
+
+  it("still labels included feature worktrees on the default tip", () => {
+    const entry = createSidebarWorkspaceEntry({
+      serverId: "srv",
+      workspace: workspaceWithRelation({
+        state: "included",
+        resolvedRef: "origin/master",
+        ahead: 0,
+        behind: 2,
+        uniquePatchCount: 0,
+      }),
+    });
+    expect(entry.originDefaultRelationLabel).toBe("Included in origin/master");
+  });
+
+  it("labels patch-equivalent with short plain copy", () => {
     const entry = createSidebarWorkspaceEntry({
       serverId: "srv",
       workspace: workspaceWithRelation({
@@ -110,7 +149,7 @@ describe("createSidebarWorkspaceEntry originDefaultRelation labels", () => {
       }),
     });
     expect(entry.originDefaultRelationLabel).toBe(
-      "Patch-equivalent to origin/master (not ancestral; still protected)",
+      "Changes landed in origin/master (branch not merged)",
     );
   });
 

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
@@ -3,6 +3,7 @@ import type { WorkspaceDescriptor } from "@/stores/session-store";
 import type { WorkspaceStructureProject } from "@/projects/workspace-structure";
 import {
   appendMissingOrderKeys,
+  appendSidebarRelationLabel,
   applyStoredOrdering,
   buildSidebarWorkspaceEntries,
   buildSidebarWorkspacePlacementModel,
@@ -61,6 +62,115 @@ describe("createSidebarWorkspaceEntry forge threading", () => {
       workspace: workspaceWithForge(undefined, "https://github.com/acme/repo/pull/42"),
     });
     expect(entry.prHint).toMatchObject({ number: 42, forge: "github" });
+  });
+});
+
+describe("createSidebarWorkspaceEntry originDefaultRelation labels", () => {
+  function workspaceWithRelation(
+    relation: NonNullable<WorkspaceDescriptor["gitRuntime"]>["originDefaultRelation"],
+    aheadOfOrigin: number | null = 3,
+  ): WorkspaceDescriptor {
+    return {
+      ...workspaceWithForge("github", "https://github.com/acme/repo/pull/1"),
+      gitRuntime: {
+        currentBranch: "fix/shab-grounded-recovery-safeguards",
+        isDirty: false,
+        aheadOfOrigin,
+        originDefaultRelation: relation,
+      },
+    };
+  }
+
+  it("labels exact and included as Included in origin/default rather than unpushed", () => {
+    for (const state of ["exact", "included"] as const) {
+      const entry = createSidebarWorkspaceEntry({
+        serverId: "srv",
+        workspace: workspaceWithRelation({
+          state,
+          resolvedRef: "origin/master",
+          ahead: 0,
+          behind: state === "included" ? 4 : 0,
+          uniquePatchCount: 0,
+        }),
+      });
+      expect(entry.originDefaultRelationLabel).toBe("Included in origin/master");
+      expect(entry.archiveUnpushedCommitCount).toBe(3);
+    }
+  });
+
+  it("labels patch-equivalent as not ancestral and still protected", () => {
+    const entry = createSidebarWorkspaceEntry({
+      serverId: "srv",
+      workspace: workspaceWithRelation({
+        state: "patch_equivalent_not_included",
+        resolvedRef: "origin/master",
+        ahead: 1,
+        behind: 1,
+        uniquePatchCount: 0,
+      }),
+    });
+    expect(entry.originDefaultRelationLabel).toBe(
+      "Patch-equivalent to origin/master (not ancestral; still protected)",
+    );
+  });
+
+  it("labels ahead with the unpushed count", () => {
+    const entry = createSidebarWorkspaceEntry({
+      serverId: "srv",
+      workspace: workspaceWithRelation(
+        {
+          state: "ahead",
+          resolvedRef: "origin/master",
+          ahead: 2,
+          behind: 0,
+          uniquePatchCount: 2,
+        },
+        2,
+      ),
+    });
+    expect(entry.originDefaultRelationLabel).toBe("2 unpushed commits");
+  });
+
+  it("labels unverifiable with the unpushed count when present", () => {
+    const entry = createSidebarWorkspaceEntry({
+      serverId: "srv",
+      workspace: workspaceWithRelation({
+        state: "unverifiable",
+        resolvedRef: null,
+        ahead: null,
+        behind: null,
+        uniquePatchCount: null,
+      }),
+    });
+    expect(entry.originDefaultRelationLabel).toBe("3 unpushed commits");
+  });
+
+  it("falls back to legacy unpushed labeling when relation is missing (old daemon)", () => {
+    const entry = createSidebarWorkspaceEntry({
+      serverId: "srv",
+      workspace: {
+        ...workspaceWithForge("github", "https://github.com/acme/repo/pull/1"),
+        gitRuntime: {
+          currentBranch: "feature",
+          isDirty: false,
+          aheadOfOrigin: 4,
+        },
+      },
+    });
+    expect(entry.archiveOriginDefaultRelation).toBeNull();
+    expect(entry.originDefaultRelationLabel).toBe("4 unpushed commits");
+  });
+});
+
+describe("appendSidebarRelationLabel", () => {
+  it("appends relation labels to project/host subtitles", () => {
+    expect(appendSidebarRelationLabel("paseo", "Included in origin/master")).toBe(
+      "paseo · Included in origin/master",
+    );
+    expect(appendSidebarRelationLabel(null, "Included in origin/master")).toBe(
+      "Included in origin/master",
+    );
+    expect(appendSidebarRelationLabel("paseo", null)).toBe("paseo");
   });
 });
 

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -203,6 +203,7 @@ export function createSidebarWorkspaceEntry(input: {
       archiveOriginDefaultRelation,
       undefined,
       archiveUnpushedCommitCount,
+      normalizeCurrentBranch(input.workspace.gitRuntime?.currentBranch),
     ),
     scripts: input.workspace.scripts,
     hasRunningScripts: input.workspace.scripts.some((script) => script.lifecycle === "running"),

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -1,3 +1,4 @@
+import type { OriginDefaultRelation } from "@/git/worktree-archive-warning";
 import type { PrHint } from "@/git/pr-hint";
 import { selectPrHintFromStatus } from "@/git/pr-hint";
 import { type HostProjectListItem } from "@/projects/host-project-model";
@@ -45,6 +46,7 @@ export interface SidebarWorkspaceEntry extends SidebarStatusWorkspacePlacement {
   prHint: PrHint | null;
   archiveHasUncommittedChanges: boolean | null;
   archiveUnpushedCommitCount: number | null;
+  archiveOriginDefaultRelation: OriginDefaultRelation | null;
   scripts: WorkspaceDescriptor["scripts"];
   hasRunningScripts: boolean;
 }
@@ -170,6 +172,7 @@ export function createSidebarWorkspaceEntry(input: {
     ),
     archiveHasUncommittedChanges: input.workspace.gitRuntime?.isDirty ?? null,
     archiveUnpushedCommitCount: input.workspace.gitRuntime?.aheadOfOrigin ?? null,
+    archiveOriginDefaultRelation: input.workspace.gitRuntime?.originDefaultRelation ?? null,
     scripts: input.workspace.scripts,
     hasRunningScripts: input.workspace.scripts.some((script) => script.lifecycle === "running"),
   };

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -1,4 +1,7 @@
-import type { OriginDefaultRelation } from "@/git/worktree-archive-warning";
+import {
+  formatOriginDefaultRelationLabel,
+  type OriginDefaultRelation,
+} from "@/git/worktree-archive-warning";
 import type { PrHint } from "@/git/pr-hint";
 import { selectPrHintFromStatus } from "@/git/pr-hint";
 import { type HostProjectListItem } from "@/projects/host-project-model";
@@ -47,6 +50,11 @@ export interface SidebarWorkspaceEntry extends SidebarStatusWorkspacePlacement {
   archiveHasUncommittedChanges: boolean | null;
   archiveUnpushedCommitCount: number | null;
   archiveOriginDefaultRelation: OriginDefaultRelation | null;
+  /**
+   * Concise origin-default relation label for sidebar/hover completion UX.
+   * Prefer inclusion over a stale unpushed count when HEAD is already on origin default.
+   */
+  originDefaultRelationLabel: string | null;
   scripts: WorkspaceDescriptor["scripts"];
   hasRunningScripts: boolean;
 }
@@ -140,6 +148,22 @@ function normalizeCurrentBranch(currentBranch: string | null | undefined): strin
   return trimmed.length === 0 || trimmed === "HEAD" ? null : trimmed;
 }
 
+/** Append a concise origin-default relation label to a sidebar subtitle line. */
+export function appendSidebarRelationLabel(
+  base: string | null | undefined,
+  relationLabel: string | null | undefined,
+): string | null {
+  const baseTrimmed = base?.trim() ?? "";
+  const relation = relationLabel?.trim() ?? "";
+  if (!relation) {
+    return baseTrimmed.length > 0 ? baseTrimmed : null;
+  }
+  if (!baseTrimmed) {
+    return relation;
+  }
+  return `${baseTrimmed} · ${relation}`;
+}
+
 export function createSidebarWorkspaceEntry(input: {
   serverId: string;
   workspace: WorkspaceDescriptor;
@@ -148,6 +172,8 @@ export function createSidebarWorkspaceEntry(input: {
 }): SidebarWorkspaceEntry {
   const projectKey = input.workspace.project?.projectKey ?? input.workspace.projectId;
   const effectiveStatus = deriveEffectiveWorkspaceStatus(input);
+  const archiveUnpushedCommitCount = input.workspace.gitRuntime?.aheadOfOrigin ?? null;
+  const archiveOriginDefaultRelation = input.workspace.gitRuntime?.originDefaultRelation ?? null;
   return {
     workspaceKey: `${input.serverId}:${input.workspace.id}`,
     serverId: input.serverId,
@@ -171,8 +197,13 @@ export function createSidebarWorkspaceEntry(input: {
       input.workspace.forge,
     ),
     archiveHasUncommittedChanges: input.workspace.gitRuntime?.isDirty ?? null,
-    archiveUnpushedCommitCount: input.workspace.gitRuntime?.aheadOfOrigin ?? null,
-    archiveOriginDefaultRelation: input.workspace.gitRuntime?.originDefaultRelation ?? null,
+    archiveUnpushedCommitCount,
+    archiveOriginDefaultRelation,
+    originDefaultRelationLabel: formatOriginDefaultRelationLabel(
+      archiveOriginDefaultRelation,
+      undefined,
+      archiveUnpushedCommitCount,
+    ),
     scripts: input.workspace.scripts,
     hasRunningScripts: input.workspace.scripts.some((script) => script.lifecycle === "running"),
   };

--- a/packages/app/src/hooks/use-sidebar-shortcut-model.test.tsx
+++ b/packages/app/src/hooks/use-sidebar-shortcut-model.test.tsx
@@ -34,6 +34,7 @@ function workspace(projectKey: string, workspaceId: string): SidebarWorkspaceEnt
     archiveHasUncommittedChanges: null,
     archiveUnpushedCommitCount: null,
     archiveOriginDefaultRelation: null,
+    originDefaultRelationLabel: null,
     scripts: [],
     hasRunningScripts: false,
   };

--- a/packages/app/src/hooks/use-sidebar-shortcut-model.test.tsx
+++ b/packages/app/src/hooks/use-sidebar-shortcut-model.test.tsx
@@ -33,6 +33,7 @@ function workspace(projectKey: string, workspaceId: string): SidebarWorkspaceEnt
     prHint: null,
     archiveHasUncommittedChanges: null,
     archiveUnpushedCommitCount: null,
+    archiveOriginDefaultRelation: null,
     scripts: [],
     hasRunningScripts: false,
   };

--- a/packages/app/src/hooks/use-sidebar-workspaces-list.ts
+++ b/packages/app/src/hooks/use-sidebar-workspaces-list.ts
@@ -19,6 +19,7 @@ import {
 
 export {
   appendMissingOrderKeys,
+  appendSidebarRelationLabel,
   applyStoredOrdering,
   buildSidebarProjectsFromHostProjects,
   buildSidebarProjectsFromStructure,

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -724,6 +724,11 @@ export const ar: TranslationResources = {
           deletedLines: "الخطوط المحذوفة{{count}}",
           unpushedCommit: "التزام{{count}}غير المدفوعة",
           unpushedCommits: "التزامات{{count}}غير المدفوعة",
+
+          includedInOriginDefault: "Included in {{resolvedRef}}",
+
+          patchEquivalentToOriginDefault:
+            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -724,11 +724,8 @@ export const ar: TranslationResources = {
           deletedLines: "الخطوط المحذوفة{{count}}",
           unpushedCommit: "التزام{{count}}غير المدفوعة",
           unpushedCommits: "التزامات{{count}}غير المدفوعة",
-
-          includedInOriginDefault: "Included in {{resolvedRef}}",
-
-          patchEquivalentToOriginDefault:
-            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
+          includedInOriginDefault: "مضمّن في {{resolvedRef}}",
+          patchEquivalentToOriginDefault: "التغييرات وصلت إلى {{resolvedRef}} (الفرع غير مدمج)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -735,6 +735,9 @@ export const en = {
           deletedLines: "{{count}} deleted lines",
           unpushedCommit: "{{count}} unpushed commit",
           unpushedCommits: "{{count}} unpushed commits",
+          includedInOriginDefault: "Included in {{resolvedRef}}",
+          patchEquivalentToOriginDefault:
+            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -736,8 +736,7 @@ export const en = {
           unpushedCommit: "{{count}} unpushed commit",
           unpushedCommits: "{{count}} unpushed commits",
           includedInOriginDefault: "Included in {{resolvedRef}}",
-          patchEquivalentToOriginDefault:
-            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
+          patchEquivalentToOriginDefault: "Changes landed in {{resolvedRef}} (branch not merged)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -755,11 +755,8 @@ export const es: TranslationResources = {
           deletedLines: "{{count}}líneas eliminadas",
           unpushedCommit: "Confirmación no enviada de{{count}}",
           unpushedCommits: "Confirmaciones no enviadas de{{count}}",
-
-          includedInOriginDefault: "Included in {{resolvedRef}}",
-
-          patchEquivalentToOriginDefault:
-            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
+          includedInOriginDefault: "Incluido en {{resolvedRef}}",
+          patchEquivalentToOriginDefault: "Cambios ya en {{resolvedRef}} (rama no fusionada)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -755,6 +755,11 @@ export const es: TranslationResources = {
           deletedLines: "{{count}}líneas eliminadas",
           unpushedCommit: "Confirmación no enviada de{{count}}",
           unpushedCommits: "Confirmaciones no enviadas de{{count}}",
+
+          includedInOriginDefault: "Included in {{resolvedRef}}",
+
+          patchEquivalentToOriginDefault:
+            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -753,11 +753,9 @@ export const fr: TranslationResources = {
           deletedLines: "{{count}}lignes supprimées",
           unpushedCommit: "Validation non poussée{{count}}",
           unpushedCommits: "Validations non poussées{{count}}",
-
-          includedInOriginDefault: "Included in {{resolvedRef}}",
-
+          includedInOriginDefault: "Inclus dans {{resolvedRef}}",
           patchEquivalentToOriginDefault:
-            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
+            "Modifications présentes dans {{resolvedRef}} (branche non fusionnée)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -753,6 +753,11 @@ export const fr: TranslationResources = {
           deletedLines: "{{count}}lignes supprimées",
           unpushedCommit: "Validation non poussée{{count}}",
           unpushedCommits: "Validations non poussées{{count}}",
+
+          includedInOriginDefault: "Included in {{resolvedRef}}",
+
+          patchEquivalentToOriginDefault:
+            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -737,6 +737,11 @@ export const ja: TranslationResources = {
           deletedLines: "{{count}}行削除",
           unpushedCommit: "{{count}}件の未プッシュコミット",
           unpushedCommits: "{{count}}件の未プッシュコミット",
+
+          includedInOriginDefault: "Included in {{resolvedRef}}",
+
+          patchEquivalentToOriginDefault:
+            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -737,11 +737,8 @@ export const ja: TranslationResources = {
           deletedLines: "{{count}}行削除",
           unpushedCommit: "{{count}}件の未プッシュコミット",
           unpushedCommits: "{{count}}件の未プッシュコミット",
-
-          includedInOriginDefault: "Included in {{resolvedRef}}",
-
-          patchEquivalentToOriginDefault:
-            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
+          includedInOriginDefault: "{{resolvedRef}} に含まれています",
+          patchEquivalentToOriginDefault: "{{resolvedRef}} に変更は反映済み（ブランチは未マージ）",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -747,6 +747,11 @@ export const ptBR: TranslationResources = {
           deletedLines: "{{count}} linhas removidas",
           unpushedCommit: "{{count}} commit não enviado",
           unpushedCommits: "{{count}} commits não enviados",
+
+          includedInOriginDefault: "Included in {{resolvedRef}}",
+
+          patchEquivalentToOriginDefault:
+            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -747,11 +747,8 @@ export const ptBR: TranslationResources = {
           deletedLines: "{{count}} linhas removidas",
           unpushedCommit: "{{count}} commit não enviado",
           unpushedCommits: "{{count}} commits não enviados",
-
-          includedInOriginDefault: "Included in {{resolvedRef}}",
-
-          patchEquivalentToOriginDefault:
-            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
+          includedInOriginDefault: "Incluído em {{resolvedRef}}",
+          patchEquivalentToOriginDefault: "Alterações em {{resolvedRef}} (branch não mesclado)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -746,6 +746,11 @@ export const ru: TranslationResources = {
           deletedLines: "{{count}}удалил строки",
           unpushedCommit: "Неотправленная фиксация{{count}}",
           unpushedCommits: "Неотправленные коммиты{{count}}",
+
+          includedInOriginDefault: "Included in {{resolvedRef}}",
+
+          patchEquivalentToOriginDefault:
+            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -746,11 +746,8 @@ export const ru: TranslationResources = {
           deletedLines: "{{count}}удалил строки",
           unpushedCommit: "Неотправленная фиксация{{count}}",
           unpushedCommits: "Неотправленные коммиты{{count}}",
-
-          includedInOriginDefault: "Included in {{resolvedRef}}",
-
-          patchEquivalentToOriginDefault:
-            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
+          includedInOriginDefault: "Включено в {{resolvedRef}}",
+          patchEquivalentToOriginDefault: "Изменения в {{resolvedRef}} (ветка не слита)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -718,6 +718,11 @@ export const zhCN: TranslationResources = {
           deletedLines: "删除 {{count}} 行",
           unpushedCommit: "{{count}} 个未 push 的 commit",
           unpushedCommits: "{{count}} 个未 push 的 commit",
+
+          includedInOriginDefault: "Included in {{resolvedRef}}",
+
+          patchEquivalentToOriginDefault:
+            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
         },
       },
       diff: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -718,11 +718,8 @@ export const zhCN: TranslationResources = {
           deletedLines: "删除 {{count}} 行",
           unpushedCommit: "{{count}} 个未 push 的 commit",
           unpushedCommits: "{{count}} 个未 push 的 commit",
-
-          includedInOriginDefault: "Included in {{resolvedRef}}",
-
-          patchEquivalentToOriginDefault:
-            "Patch-equivalent to {{resolvedRef}} (not ancestral; still protected)",
+          includedInOriginDefault: "已包含在 {{resolvedRef}}",
+          patchEquivalentToOriginDefault: "变更已进入 {{resolvedRef}}（分支未合并）",
         },
       },
       diff: {

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -27,6 +27,7 @@ function workspace(overrides: Partial<SidebarWorkspaceEntry> = {}): SidebarWorks
     archiveHasUncommittedChanges: null,
     archiveUnpushedCommitCount: null,
     archiveOriginDefaultRelation: null,
+    originDefaultRelationLabel: null,
     scripts: [],
     hasRunningScripts: false,
     statusEnteredAt: null,

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -26,6 +26,7 @@ function workspace(overrides: Partial<SidebarWorkspaceEntry> = {}): SidebarWorks
     prHint: null,
     archiveHasUncommittedChanges: null,
     archiveUnpushedCommitCount: null,
+    archiveOriginDefaultRelation: null,
     scripts: [],
     hasRunningScripts: false,
     statusEnteredAt: null,

--- a/packages/app/src/utils/sidebar-shortcuts.test.ts
+++ b/packages/app/src/utils/sidebar-shortcuts.test.ts
@@ -40,6 +40,7 @@ function workspace(input: {
     archiveHasUncommittedChanges: null,
     archiveUnpushedCommitCount: null,
     archiveOriginDefaultRelation: null,
+    originDefaultRelationLabel: null,
     scripts: [],
     hasRunningScripts: false,
   };

--- a/packages/app/src/utils/sidebar-shortcuts.test.ts
+++ b/packages/app/src/utils/sidebar-shortcuts.test.ts
@@ -39,6 +39,7 @@ function workspace(input: {
     prHint: null,
     archiveHasUncommittedChanges: null,
     archiveUnpushedCommitCount: null,
+    archiveOriginDefaultRelation: null,
     scripts: [],
     hasRunningScripts: false,
   };

--- a/packages/app/src/workspace/use-workspace-archive.ts
+++ b/packages/app/src/workspace/use-workspace-archive.ts
@@ -5,6 +5,7 @@ import { useToast } from "@/contexts/toast-context";
 import {
   confirmRiskyWorktreeArchive,
   DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS,
+  type OriginDefaultRelation,
   type WorktreeArchiveWarningLabels,
 } from "@/git/worktree-archive-warning";
 import type { WorkspaceDescriptor } from "@/stores/session-store";
@@ -30,6 +31,7 @@ export interface ArchiveWorkspaceInput {
   name: string;
   isDirty?: boolean | null;
   aheadOfOrigin?: number | null;
+  originDefaultRelation?: OriginDefaultRelation | null;
   diffStat?: { additions: number; deletions: number } | null;
   warningLabels?: WorktreeArchiveWarningLabels;
   onArchiveStarted: () => void;
@@ -48,6 +50,7 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
     name,
     isDirty,
     aheadOfOrigin,
+    originDefaultRelation,
     diffStat,
     warningLabels = DEFAULT_WORKTREE_ARCHIVE_WARNING_LABELS,
     onArchiveStarted,
@@ -90,6 +93,7 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
             workspaceName: name,
             isDirty,
             aheadOfOrigin,
+            originDefaultRelation,
             diffStat,
           },
           warningLabels,
@@ -106,6 +110,7 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
     diffStat,
     isDirty,
     name,
+    originDefaultRelation,
     warningLabels,
     workspaceKind,
   ]);

--- a/packages/protocol/src/messages.origin-default-relation.test.ts
+++ b/packages/protocol/src/messages.origin-default-relation.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import {
+  CheckoutStatusResponseSchema,
+  CheckoutStatusUpdateSchema,
+  OriginDefaultRelationSchema,
+  WorkspaceDescriptorPayloadSchema,
+} from "./messages.js";
+
+const originDefaultRelation = {
+  state: "included" as const,
+  resolvedRef: "origin/main",
+  ahead: 0,
+  behind: 2,
+  uniquePatchCount: 0,
+};
+
+describe("originDefaultRelation protocol additive compatibility", () => {
+  test("OriginDefaultRelationSchema accepts every documented state", () => {
+    for (const state of [
+      "exact",
+      "included",
+      "ahead",
+      "patch_equivalent_not_included",
+      "diverged_with_unique_commits",
+      "unverifiable",
+    ] as const) {
+      expect(
+        OriginDefaultRelationSchema.parse({
+          state,
+          resolvedRef: state === "unverifiable" ? null : "origin/main",
+          ahead: state === "unverifiable" ? null : 0,
+          behind: state === "unverifiable" ? null : 0,
+          uniquePatchCount: state === "unverifiable" ? null : 0,
+        }).state,
+      ).toBe(state);
+    }
+  });
+
+  test("checkout_status_response accepts additive originDefaultRelation and keeps legacy fields", () => {
+    const parsed = CheckoutStatusResponseSchema.parse({
+      type: "checkout_status_response",
+      payload: {
+        cwd: "/tmp/repo",
+        isGit: true,
+        isPaseoOwnedWorktree: false,
+        repoRoot: "/tmp/repo",
+        mainRepoRoot: null,
+        currentBranch: "feature",
+        isDirty: false,
+        baseRef: "main",
+        aheadBehind: { ahead: 1, behind: 0 },
+        aheadOfOrigin: 1,
+        behindOfOrigin: 0,
+        originDefaultRelation,
+        hasRemote: true,
+        remoteUrl: "https://github.com/acme/repo.git",
+        error: null,
+        requestId: "req-1",
+      },
+    });
+
+    expect(parsed.payload).toMatchObject({
+      aheadOfOrigin: 1,
+      behindOfOrigin: 0,
+      originDefaultRelation,
+    });
+  });
+
+  test("checkout_status_response without originDefaultRelation still parses (old daemon)", () => {
+    const parsed = CheckoutStatusResponseSchema.parse({
+      type: "checkout_status_response",
+      payload: {
+        cwd: "/tmp/repo",
+        isGit: true,
+        isPaseoOwnedWorktree: false,
+        repoRoot: "/tmp/repo",
+        currentBranch: "feature",
+        isDirty: false,
+        baseRef: "main",
+        aheadBehind: { ahead: 1, behind: 0 },
+        aheadOfOrigin: 1,
+        behindOfOrigin: 0,
+        hasRemote: true,
+        remoteUrl: "https://github.com/acme/repo.git",
+        error: null,
+        requestId: "req-old",
+      },
+    });
+
+    expect(parsed.payload.isGit).toBe(true);
+    if (parsed.payload.isGit) {
+      expect(parsed.payload.originDefaultRelation).toBeUndefined();
+      expect(parsed.payload.aheadOfOrigin).toBe(1);
+    }
+  });
+
+  test("checkout_status_update propagates originDefaultRelation", () => {
+    const parsed = CheckoutStatusUpdateSchema.parse({
+      type: "checkout_status_update",
+      payload: {
+        cwd: "/tmp/repo",
+        isGit: true,
+        isPaseoOwnedWorktree: true,
+        repoRoot: "/tmp/wt",
+        mainRepoRoot: "/tmp/repo",
+        currentBranch: "feature",
+        isDirty: false,
+        baseRef: "main",
+        aheadBehind: { ahead: 0, behind: 0 },
+        aheadOfOrigin: 0,
+        behindOfOrigin: 0,
+        originDefaultRelation: {
+          state: "exact",
+          resolvedRef: "origin/main",
+          ahead: 0,
+          behind: 0,
+          uniquePatchCount: 0,
+        },
+        hasRemote: true,
+        remoteUrl: "https://github.com/acme/repo.git",
+        error: null,
+        requestId: "subscription:/tmp/wt",
+      },
+    });
+
+    expect(parsed.payload).toMatchObject({
+      originDefaultRelation: {
+        state: "exact",
+        resolvedRef: "origin/main",
+      },
+    });
+  });
+
+  test("workspace gitRuntime accepts additive originDefaultRelation", () => {
+    const parsed = WorkspaceDescriptorPayloadSchema.parse({
+      id: "ws-1",
+      projectId: "remote:github.com/acme/repo",
+      projectDisplayName: "acme/repo",
+      projectRootPath: "/tmp/repo",
+      workspaceDirectory: "/tmp/repo",
+      projectKind: "git",
+      workspaceKind: "worktree",
+      name: "feature",
+      status: "done",
+      activityAt: null,
+      diffStat: null,
+      gitRuntime: {
+        currentBranch: "feature",
+        remoteUrl: "https://github.com/acme/repo.git",
+        isPaseoOwnedWorktree: true,
+        isDirty: false,
+        aheadBehind: { ahead: 0, behind: 1 },
+        aheadOfOrigin: 2,
+        behindOfOrigin: 0,
+        originDefaultRelation,
+      },
+    });
+
+    expect(parsed.gitRuntime).toMatchObject({
+      aheadOfOrigin: 2,
+      originDefaultRelation,
+    });
+  });
+
+  test("older workspace parsers ignore additive originDefaultRelation", () => {
+    const legacyGitRuntimeSchema = z.object({
+      currentBranch: z.string().nullable().optional(),
+      aheadOfOrigin: z.number().nullable().optional(),
+      behindOfOrigin: z.number().nullable().optional(),
+    });
+
+    const message = {
+      gitRuntime: {
+        currentBranch: "feature",
+        aheadOfOrigin: 2,
+        behindOfOrigin: 0,
+        originDefaultRelation,
+      },
+    };
+
+    const parsed = legacyGitRuntimeSchema.parse(message.gitRuntime);
+    expect(parsed).toEqual({
+      currentBranch: "feature",
+      aheadOfOrigin: 2,
+      behindOfOrigin: 0,
+    });
+    // Additive field is stripped by the old parser shape.
+    expect("originDefaultRelation" in parsed).toBe(false);
+  });
+});

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2923,6 +2923,25 @@ export const WorkspaceScriptPayloadSchema = z.object({
   terminalId: z.string().nullable().optional().default(null),
 });
 
+// COMPAT(originDefaultRelation): added in v0.2.x, optional forever for old daemons/clients.
+// Describes HEAD vs the resolved origin default tip so already-landed work is not shown as unpushed.
+export const OriginDefaultRelationStateSchema = z.enum([
+  "exact",
+  "included",
+  "ahead",
+  "patch_equivalent_not_included",
+  "diverged_with_unique_commits",
+  "unverifiable",
+]);
+
+export const OriginDefaultRelationSchema = z.object({
+  state: OriginDefaultRelationStateSchema,
+  resolvedRef: z.string().nullable(),
+  ahead: z.number().nullable(),
+  behind: z.number().nullable(),
+  uniquePatchCount: z.number().nullable(),
+});
+
 const WorkspaceGitRuntimePayloadSchema = z
   .object({
     currentBranch: z.string().nullable().optional(),
@@ -2938,6 +2957,8 @@ const WorkspaceGitRuntimePayloadSchema = z
       .optional(),
     aheadOfOrigin: z.number().nullable().optional(),
     behindOfOrigin: z.number().nullable().optional(),
+    // COMPAT(originDefaultRelation): added in v0.2.x — missing on old daemons; preserve unpushed behavior.
+    originDefaultRelation: OriginDefaultRelationSchema.optional(),
   })
   .optional()
   .nullable();
@@ -3819,6 +3840,8 @@ const CheckoutStatusNotGitSchema = CheckoutStatusCommonSchema.extend({
   aheadBehind: z.null(),
   aheadOfOrigin: z.null(),
   behindOfOrigin: z.null(),
+  // COMPAT(originDefaultRelation): added in v0.2.x — optional; absent on not-git is fine.
+  originDefaultRelation: OriginDefaultRelationSchema.optional(),
   hasRemote: z.boolean(),
   remoteUrl: z.null(),
 });
@@ -3834,6 +3857,8 @@ const CheckoutStatusGitNonPaseoSchema = CheckoutStatusCommonSchema.extend({
   aheadBehind: AheadBehindSchema.nullable(),
   aheadOfOrigin: z.number().nullable(),
   behindOfOrigin: z.number().nullable(),
+  // COMPAT(originDefaultRelation): added in v0.2.x — optional for old clients.
+  originDefaultRelation: OriginDefaultRelationSchema.optional(),
   hasRemote: z.boolean(),
   remoteUrl: z.string().nullable(),
 });
@@ -3849,6 +3874,8 @@ const CheckoutStatusGitPaseoSchema = CheckoutStatusCommonSchema.extend({
   aheadBehind: AheadBehindSchema.nullable(),
   aheadOfOrigin: z.number().nullable(),
   behindOfOrigin: z.number().nullable(),
+  // COMPAT(originDefaultRelation): added in v0.2.x — optional for old clients.
+  originDefaultRelation: OriginDefaultRelationSchema.optional(),
   hasRemote: z.boolean(),
   remoteUrl: z.string().nullable(),
 });
@@ -5372,6 +5399,8 @@ export type SetAgentThinkingRequestMessage = z.infer<typeof SetAgentThinkingRequ
 export type SetAgentFeatureRequestMessage = z.infer<typeof SetAgentFeatureRequestMessageSchema>;
 export type AgentDetachRequestMessage = z.infer<typeof AgentDetachRequestMessageSchema>;
 export type AgentPermissionResponseMessage = z.infer<typeof AgentPermissionResponseMessageSchema>;
+export type OriginDefaultRelationState = z.infer<typeof OriginDefaultRelationStateSchema>;
+export type OriginDefaultRelation = z.infer<typeof OriginDefaultRelationSchema>;
 export type CheckoutStatusRequest = z.infer<typeof CheckoutStatusRequestSchema>;
 export type CheckoutStatusResponse = z.infer<typeof CheckoutStatusResponseSchema>;
 export type CheckoutStatusUpdate = z.infer<typeof CheckoutStatusUpdateSchema>;

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2923,7 +2923,7 @@ export const WorkspaceScriptPayloadSchema = z.object({
   terminalId: z.string().nullable().optional().default(null),
 });
 
-// COMPAT(originDefaultRelation): added in v0.2.x, optional forever for old daemons/clients.
+// COMPAT(originDefaultRelation): optional forever for old daemons/clients.
 // Describes HEAD vs the resolved origin default tip so already-landed work is not shown as unpushed.
 export const OriginDefaultRelationStateSchema = z.enum([
   "exact",
@@ -2957,7 +2957,7 @@ const WorkspaceGitRuntimePayloadSchema = z
       .optional(),
     aheadOfOrigin: z.number().nullable().optional(),
     behindOfOrigin: z.number().nullable().optional(),
-    // COMPAT(originDefaultRelation): added in v0.2.x — missing on old daemons; preserve unpushed behavior.
+    // COMPAT(originDefaultRelation): missing on old daemons; preserve unpushed behavior.
     originDefaultRelation: OriginDefaultRelationSchema.optional(),
   })
   .optional()
@@ -3840,7 +3840,7 @@ const CheckoutStatusNotGitSchema = CheckoutStatusCommonSchema.extend({
   aheadBehind: z.null(),
   aheadOfOrigin: z.null(),
   behindOfOrigin: z.null(),
-  // COMPAT(originDefaultRelation): added in v0.2.x — optional; absent on not-git is fine.
+  // COMPAT(originDefaultRelation): optional; absent on not-git is fine.
   originDefaultRelation: OriginDefaultRelationSchema.optional(),
   hasRemote: z.boolean(),
   remoteUrl: z.null(),
@@ -3857,7 +3857,7 @@ const CheckoutStatusGitNonPaseoSchema = CheckoutStatusCommonSchema.extend({
   aheadBehind: AheadBehindSchema.nullable(),
   aheadOfOrigin: z.number().nullable(),
   behindOfOrigin: z.number().nullable(),
-  // COMPAT(originDefaultRelation): added in v0.2.x — optional for old clients.
+  // COMPAT(originDefaultRelation): optional for old clients.
   originDefaultRelation: OriginDefaultRelationSchema.optional(),
   hasRemote: z.boolean(),
   remoteUrl: z.string().nullable(),
@@ -3874,7 +3874,7 @@ const CheckoutStatusGitPaseoSchema = CheckoutStatusCommonSchema.extend({
   aheadBehind: AheadBehindSchema.nullable(),
   aheadOfOrigin: z.number().nullable(),
   behindOfOrigin: z.number().nullable(),
-  // COMPAT(originDefaultRelation): added in v0.2.x — optional for old clients.
+  // COMPAT(originDefaultRelation): optional for old clients.
   originDefaultRelation: OriginDefaultRelationSchema.optional(),
   hasRemote: z.boolean(),
   remoteUrl: z.string().nullable(),

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -4142,8 +4142,9 @@ export function commandMayHaveChangedExternalState(command: string): boolean {
     // Pushes to remote — local refs unchanged, but remote state (PR checks,
     // mergeable status) may shift immediately after.
     /\bgit\s+push\b/.test(normalized) ||
-    // Fetches update refs/remotes/ which our watchers do not watch, so
-    // ahead/behind counts can drift stale until the next refresh.
+    // Fetches update refs/remotes (and often packed-refs). WorkspaceGitService
+    // watches common-dir remotes/packed-refs, but command-driven refresh still
+    // catches forge-side drift that file watchers alone may miss.
     /\bgit\s+fetch\b/.test(normalized)
   );
 }

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
@@ -787,6 +787,11 @@ describe("archiveIfSafe", () => {
       },
       CWD,
     );
+    expect(harness.getSnapshot).toHaveBeenCalledWith(CWD, {
+      force: true,
+      includeForge: false,
+      reason: "auto-archive-on-merge",
+    });
     expect(harness.deps.archiveByScope).toHaveBeenCalledTimes(1);
     expect(harness.deps.archiveByScope).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -803,6 +808,54 @@ describe("archiveIfSafe", () => {
       "Auto-archived worktree after PR merge",
     );
     expect(harness.inFlight.has(CWD)).toBe(false);
+  });
+
+  test("refuses archive when forced fresh snapshot shows dirty after a previously safe cache", async () => {
+    // Simulates: cache would still look safe, but force refresh sees a real
+    // uncommitted edit (or unique commit) and fail-closes.
+    const getSnapshot = vi.fn(async (_cwd: string, options?: { force?: boolean }) => {
+      expect(options).toEqual({
+        force: true,
+        includeForge: false,
+        reason: "auto-archive-on-merge",
+      });
+      return createSnapshot({ git: { isDirty: true } });
+    });
+    const harness = createHarness({
+      getSnapshot: getSnapshot as unknown as () => Promise<WorkspaceGitRuntimeSnapshot | null>,
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test("refuses archive when forced fresh snapshot shows unique commits after a previously safe cache", async () => {
+    const getSnapshot = vi.fn(async () =>
+      createSnapshot({
+        git: {
+          originDefaultRelation: createIncludedRelation({
+            state: "ahead",
+            ahead: 1,
+            uniquePatchCount: 1,
+          }),
+          aheadOfOrigin: 1,
+        },
+      }),
+    );
+    const harness = createHarness({
+      getSnapshot: getSnapshot as unknown as () => Promise<WorkspaceGitRuntimeSnapshot | null>,
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(getSnapshot).toHaveBeenCalledWith(CWD, {
+      force: true,
+      includeForge: false,
+      reason: "auto-archive-on-merge",
+    });
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
   });
 
   test("resolves the merged cwd to a single workspace and does not iterate siblings", async () => {

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
@@ -35,10 +35,26 @@ function createPullRequest(
   };
 }
 
+function createIncludedRelation(
+  overrides?: Partial<NonNullable<WorkspaceGitRuntimeSnapshot["git"]["originDefaultRelation"]>>,
+): NonNullable<WorkspaceGitRuntimeSnapshot["git"]["originDefaultRelation"]> {
+  return {
+    state: "included",
+    resolvedRef: "origin/main",
+    ahead: 0,
+    behind: 1,
+    uniquePatchCount: 0,
+    ...overrides,
+  };
+}
+
 function createSnapshot(overrides?: {
   git?: Partial<WorkspaceGitRuntimeSnapshot["git"]>;
   pullRequest?: WorkspaceGitRuntimeSnapshot["forge"]["pullRequest"];
 }): WorkspaceGitRuntimeSnapshot {
+  const gitOverrides = overrides?.git;
+  const hasRelationOverride =
+    gitOverrides !== undefined && Object.hasOwn(gitOverrides, "originDefaultRelation");
   return {
     cwd: CWD,
     git: {
@@ -55,7 +71,9 @@ function createSnapshot(overrides?: {
       behindOfOrigin: 0,
       hasRemote: true,
       diffStat: { additions: 0, deletions: 0 },
-      ...overrides?.git,
+      // Default safe for auto-archive: verifiably included in origin default.
+      ...(hasRelationOverride ? {} : { originDefaultRelation: createIncludedRelation() }),
+      ...gitOverrides,
     },
     github: {
       featuresEnabled: true,
@@ -287,6 +305,7 @@ function createRealOutcomeHarness(input: {
             behindOfOrigin: 0,
             hasRemote: true,
             diffStat: { additions: 0, deletions: 0 },
+            originDefaultRelation: createIncludedRelation(),
           },
           github: {
             featuresEnabled: true,
@@ -425,10 +444,138 @@ describe("archiveIfSafe", () => {
     expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
   });
 
-  test("archives when the PR is merged and the upstream branch was deleted", async () => {
+  test("does nothing when originDefaultRelation is missing (old-shape snapshot)", async () => {
+    const harness = createHarness({
+      getSnapshot: async () => createSnapshot({ git: { originDefaultRelation: undefined } }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when HEAD is detached", async () => {
+    const harness = createHarness({
+      getSnapshot: async () => createSnapshot({ git: { currentBranch: null } }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when relation ahead is null", async () => {
     const harness = createHarness({
       getSnapshot: async () =>
-        createSnapshot({ git: { aheadOfOrigin: null, behindOfOrigin: null } }),
+        createSnapshot({
+          git: {
+            originDefaultRelation: createIncludedRelation({ ahead: null }),
+          },
+        }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    "ahead",
+    "patch_equivalent_not_included",
+    "diverged_with_unique_commits",
+    "unverifiable",
+  ] as const)("does nothing when originDefaultRelation state is %s", async (state) => {
+    const harness = createHarness({
+      getSnapshot: async () =>
+        createSnapshot({
+          git: {
+            originDefaultRelation: createIncludedRelation({
+              state,
+              ahead: state === "unverifiable" ? null : 1,
+              behind: state === "unverifiable" ? null : 1,
+              uniquePatchCount: state === "diverged_with_unique_commits" ? 1 : 0,
+            }),
+          },
+        }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when uniquePatchCount indicates unique patch risk", async () => {
+    const harness = createHarness({
+      getSnapshot: async () =>
+        createSnapshot({
+          git: {
+            originDefaultRelation: createIncludedRelation({
+              state: "exact",
+              ahead: 0,
+              behind: 0,
+              uniquePatchCount: 2,
+            }),
+          },
+        }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test("archives when the PR is merged, upstream deleted, and origin default includes HEAD", async () => {
+    const harness = createHarness({
+      getSnapshot: async () =>
+        createSnapshot({
+          git: {
+            aheadOfOrigin: null,
+            behindOfOrigin: null,
+            originDefaultRelation: createIncludedRelation({ state: "exact", behind: 0 }),
+          },
+        }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not archive on merged PR alone when upstream is deleted without inclusion", async () => {
+    const harness = createHarness({
+      getSnapshot: async () =>
+        createSnapshot({
+          git: {
+            aheadOfOrigin: null,
+            behindOfOrigin: null,
+            originDefaultRelation: createIncludedRelation({
+              state: "unverifiable",
+              ahead: null,
+              behind: null,
+              uniquePatchCount: null,
+            }),
+          },
+        }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test("archives when relation is exact", async () => {
+    const harness = createHarness({
+      getSnapshot: async () =>
+        createSnapshot({
+          git: {
+            originDefaultRelation: createIncludedRelation({
+              state: "exact",
+              ahead: 0,
+              behind: 0,
+              uniquePatchCount: 0,
+            }),
+          },
+        }),
     });
 
     await runArchiveIfSafe(harness);

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
   archiveIfSafe,
+  isSnapshotSafeForAutoArchive,
   type ArchiveIfSafeDependencies,
   type AutoArchiveArchiveOptions,
 } from "./archive-if-safe.js";
@@ -360,6 +361,88 @@ afterEach(() => {
   }
 });
 
+describe("isSnapshotSafeForAutoArchive", () => {
+  test("accepts exact known-zero state", () => {
+    expect(
+      isSnapshotSafeForAutoArchive(
+        createSnapshot({
+          git: {
+            isDirty: false,
+            aheadOfOrigin: 0,
+            originDefaultRelation: createIncludedRelation({
+              state: "exact",
+              ahead: 0,
+              behind: 0,
+              uniquePatchCount: 0,
+            }),
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("accepts included known-zero state", () => {
+    expect(isSnapshotSafeForAutoArchive(createSnapshot())).toBe(true);
+  });
+
+  test("rejects isDirty null", () => {
+    expect(isSnapshotSafeForAutoArchive(createSnapshot({ git: { isDirty: null } }))).toBe(false);
+  });
+
+  test("rejects isDirty undefined when constructible", () => {
+    const snapshot = createSnapshot();
+    // Runtime unknown: coerce past the typed boolean|null field.
+    (snapshot.git as { isDirty: boolean | null | undefined }).isDirty = undefined;
+    expect(isSnapshotSafeForAutoArchive(snapshot)).toBe(false);
+  });
+
+  test("rejects relation uniquePatchCount null", () => {
+    expect(
+      isSnapshotSafeForAutoArchive(
+        createSnapshot({
+          git: {
+            originDefaultRelation: createIncludedRelation({ uniquePatchCount: null }),
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects relation ahead null", () => {
+    expect(
+      isSnapshotSafeForAutoArchive(
+        createSnapshot({
+          git: {
+            originDefaultRelation: createIncludedRelation({ ahead: null }),
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects relation ahead nonzero", () => {
+    expect(
+      isSnapshotSafeForAutoArchive(
+        createSnapshot({
+          git: {
+            originDefaultRelation: createIncludedRelation({ ahead: 1 }),
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects aheadOfOrigin null", () => {
+    expect(isSnapshotSafeForAutoArchive(createSnapshot({ git: { aheadOfOrigin: null } }))).toBe(
+      false,
+    );
+  });
+
+  test("rejects aheadOfOrigin nonzero", () => {
+    expect(isSnapshotSafeForAutoArchive(createSnapshot({ git: { aheadOfOrigin: 1 } }))).toBe(false);
+  });
+});
+
 describe("archiveIfSafe", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -433,6 +516,16 @@ describe("archiveIfSafe", () => {
     expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
   });
 
+  test("does nothing when isDirty is unknown (null)", async () => {
+    const harness = createHarness({
+      getSnapshot: async () => createSnapshot({ git: { isDirty: null } }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
   test("does nothing when the worktree is ahead of origin", async () => {
     const harness = createHarness({
       getSnapshot: async () => createSnapshot({ git: { aheadOfOrigin: 1 } }),
@@ -441,6 +534,16 @@ describe("archiveIfSafe", () => {
     await runArchiveIfSafe(harness);
 
     expect(harness.deps.isPaseoOwnedWorktreeCwd).not.toHaveBeenCalled();
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when aheadOfOrigin is unknown (null)", async () => {
+    const harness = createHarness({
+      getSnapshot: async () => createSnapshot({ git: { aheadOfOrigin: null } }),
+    });
+
+    await runArchiveIfSafe(harness);
+
     expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
   });
 
@@ -470,6 +573,21 @@ describe("archiveIfSafe", () => {
         createSnapshot({
           git: {
             originDefaultRelation: createIncludedRelation({ ahead: null }),
+          },
+        }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when relation ahead is nonzero", async () => {
+    const harness = createHarness({
+      getSnapshot: async () =>
+        createSnapshot({
+          git: {
+            originDefaultRelation: createIncludedRelation({ ahead: 2 }),
           },
         }),
     });
@@ -524,7 +642,27 @@ describe("archiveIfSafe", () => {
     expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
   });
 
-  test("archives when the PR is merged, upstream deleted, and origin default includes HEAD", async () => {
+  test("does nothing when uniquePatchCount is unknown (null)", async () => {
+    const harness = createHarness({
+      getSnapshot: async () =>
+        createSnapshot({
+          git: {
+            originDefaultRelation: createIncludedRelation({
+              state: "exact",
+              ahead: 0,
+              behind: 0,
+              uniquePatchCount: null,
+            }),
+          },
+        }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test("does not archive when origin default includes HEAD but aheadOfOrigin is unknown", async () => {
     const harness = createHarness({
       getSnapshot: async () =>
         createSnapshot({
@@ -538,7 +676,7 @@ describe("archiveIfSafe", () => {
 
     await runArchiveIfSafe(harness);
 
-    expect(harness.deps.archiveByScope).toHaveBeenCalledTimes(1);
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
   });
 
   test("does not archive on merged PR alone when upstream is deleted without inclusion", async () => {
@@ -563,15 +701,39 @@ describe("archiveIfSafe", () => {
     expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
   });
 
-  test("archives when relation is exact", async () => {
+  test("archives when relation is exact with known-zero counts", async () => {
     const harness = createHarness({
       getSnapshot: async () =>
         createSnapshot({
           git: {
+            isDirty: false,
+            aheadOfOrigin: 0,
             originDefaultRelation: createIncludedRelation({
               state: "exact",
               ahead: 0,
               behind: 0,
+              uniquePatchCount: 0,
+            }),
+          },
+        }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).toHaveBeenCalledTimes(1);
+  });
+
+  test("archives when relation is included with known-zero counts", async () => {
+    const harness = createHarness({
+      getSnapshot: async () =>
+        createSnapshot({
+          git: {
+            isDirty: false,
+            aheadOfOrigin: 0,
+            originDefaultRelation: createIncludedRelation({
+              state: "included",
+              ahead: 0,
+              behind: 3,
               uniquePatchCount: 0,
             }),
           },

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
@@ -109,7 +109,11 @@ export async function archiveIfSafe(input: {
   try {
     let snapshot: Awaited<ReturnType<typeof options.workspaceGitService.getSnapshot>> | null;
     try {
+      // Force a fresh git snapshot so auto-archive never gates on a stale
+      // cached "safe" relation/dirty state. No forge/network work.
       snapshot = await options.workspaceGitService.getSnapshot(cwd, {
+        force: true,
+        includeForge: false,
         reason: "auto-archive-on-merge",
       });
     } catch (error) {

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
@@ -54,7 +54,8 @@ const defaultDependencies: ArchiveIfSafeDependencies = {
  * never initiates archive by itself. See docs/origin-default-relation.md.
  */
 export function isSnapshotSafeForAutoArchive(snapshot: WorkspaceGitRuntimeSnapshot): boolean {
-  if (snapshot.git.isDirty === true) {
+  // Unknown dirty state is not known-safe — require an explicit clean tree.
+  if (snapshot.git.isDirty !== false) {
     return false;
   }
   // Detached / ambiguous HEAD is not a named worktree tip we will auto-delete.
@@ -68,14 +69,16 @@ export function isSnapshotSafeForAutoArchive(snapshot: WorkspaceGitRuntimeSnapsh
   if (relation.state !== "exact" && relation.state !== "included") {
     return false;
   }
-  if (relation.ahead === null) {
+  // Null/undefined ahead is unknown; only exact zero is known-safe.
+  if (relation.ahead !== 0) {
     return false;
   }
-  if (typeof relation.uniquePatchCount === "number" && relation.uniquePatchCount > 0) {
+  // Null/undefined uniquePatchCount is unknown; only exact zero is known-safe.
+  if (relation.uniquePatchCount !== 0) {
     return false;
   }
-  // Legacy push risk: still refuse when the branch is ahead of its upstream.
-  if (typeof snapshot.git.aheadOfOrigin === "number" && snapshot.git.aheadOfOrigin > 0) {
+  // Legacy push risk: null/undefined is unknown; only exact zero is known-safe.
+  if (snapshot.git.aheadOfOrigin !== 0) {
     return false;
   }
   return true;

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
@@ -48,6 +48,39 @@ const defaultDependencies: ArchiveIfSafeDependencies = {
   killTerminalsForWorkspace,
 };
 
+/**
+ * Fail-closed snapshot gates for auto-archive. Inclusion (exact/included) is
+ * evidence for safety only after the explicit autoArchiveAfterMerge setting —
+ * never initiates archive by itself. See docs/origin-default-relation.md.
+ */
+export function isSnapshotSafeForAutoArchive(snapshot: WorkspaceGitRuntimeSnapshot): boolean {
+  if (snapshot.git.isDirty === true) {
+    return false;
+  }
+  // Detached / ambiguous HEAD is not a named worktree tip we will auto-delete.
+  if (!snapshot.git.currentBranch) {
+    return false;
+  }
+  const relation = snapshot.git.originDefaultRelation;
+  if (!relation) {
+    return false;
+  }
+  if (relation.state !== "exact" && relation.state !== "included") {
+    return false;
+  }
+  if (relation.ahead === null) {
+    return false;
+  }
+  if (typeof relation.uniquePatchCount === "number" && relation.uniquePatchCount > 0) {
+    return false;
+  }
+  // Legacy push risk: still refuse when the branch is ahead of its upstream.
+  if (typeof snapshot.git.aheadOfOrigin === "number" && snapshot.git.aheadOfOrigin > 0) {
+    return false;
+  }
+  return true;
+}
+
 export async function archiveIfSafe(input: {
   cwd: string;
   pullRequest: WorkspaceGitRuntimeSnapshot["forge"]["pullRequest"];
@@ -80,14 +113,7 @@ export async function archiveIfSafe(input: {
       log.warn({ err: error, cwd }, "Failed to read snapshot for auto-archive; skipping");
       return;
     }
-    if (!snapshot) {
-      return;
-    }
-
-    if (snapshot.git.isDirty === true) {
-      return;
-    }
-    if (typeof snapshot.git.aheadOfOrigin === "number" && snapshot.git.aheadOfOrigin > 0) {
+    if (!snapshot || !isSnapshotSafeForAutoArchive(snapshot)) {
       return;
     }
 

--- a/packages/server/src/server/checkout/status-projection.origin-default-relation.test.ts
+++ b/packages/server/src/server/checkout/status-projection.origin-default-relation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { buildCheckoutStatusPayloadFromSnapshot } from "./status-projection.js";
+import type { WorkspaceGitRuntimeSnapshot } from "../workspace-git-service.js";
+
+function gitSnapshot(
+  overrides?: Partial<WorkspaceGitRuntimeSnapshot["git"]>,
+): WorkspaceGitRuntimeSnapshot {
+  return {
+    cwd: "/tmp/repo",
+    git: {
+      isGit: true,
+      repoRoot: "/tmp/repo",
+      mainRepoRoot: null,
+      currentBranch: "feature",
+      remoteUrl: "https://github.com/acme/repo.git",
+      isPaseoOwnedWorktree: false,
+      isDirty: false,
+      baseRef: "main",
+      aheadBehind: { ahead: 1, behind: 0 },
+      aheadOfOrigin: 1,
+      behindOfOrigin: 0,
+      originDefaultRelation: {
+        state: "included",
+        resolvedRef: "origin/main",
+        ahead: 0,
+        behind: 3,
+        uniquePatchCount: 0,
+      },
+      hasRemote: true,
+      diffStat: null,
+      ...overrides,
+    },
+    forge: {
+      featuresEnabled: false,
+      authState: "no_remote",
+      pullRequest: null,
+      error: null,
+    },
+  };
+}
+
+describe("buildCheckoutStatusPayloadFromSnapshot originDefaultRelation", () => {
+  it("propagates originDefaultRelation on git checkout status", () => {
+    const payload = buildCheckoutStatusPayloadFromSnapshot({
+      cwd: "/tmp/repo",
+      requestId: "r1",
+      snapshot: gitSnapshot(),
+    });
+
+    expect(payload).toMatchObject({
+      isGit: true,
+      aheadOfOrigin: 1,
+      behindOfOrigin: 0,
+      originDefaultRelation: {
+        state: "included",
+        resolvedRef: "origin/main",
+        ahead: 0,
+        behind: 3,
+        uniquePatchCount: 0,
+      },
+    });
+  });
+
+  it("omits originDefaultRelation when snapshot lacks the field (old shape)", () => {
+    const snapshot = gitSnapshot();
+    delete snapshot.git.originDefaultRelation;
+
+    const payload = buildCheckoutStatusPayloadFromSnapshot({
+      cwd: "/tmp/repo",
+      requestId: "r2",
+      snapshot,
+    });
+
+    expect(payload.isGit).toBe(true);
+    if (payload.isGit) {
+      expect(payload.originDefaultRelation).toBeUndefined();
+      expect(payload.aheadOfOrigin).toBe(1);
+    }
+  });
+
+  it("propagates originDefaultRelation for paseo-owned worktrees", () => {
+    const payload = buildCheckoutStatusPayloadFromSnapshot({
+      cwd: "/tmp/wt",
+      requestId: "r3",
+      snapshot: gitSnapshot({
+        isPaseoOwnedWorktree: true,
+        repoRoot: "/tmp/wt",
+        mainRepoRoot: "/tmp/repo",
+        baseRef: "main",
+      }),
+    });
+
+    expect(payload).toMatchObject({
+      isGit: true,
+      isPaseoOwnedWorktree: true,
+      originDefaultRelation: {
+        state: "included",
+        resolvedRef: "origin/main",
+      },
+    });
+  });
+});

--- a/packages/server/src/server/checkout/status-projection.ts
+++ b/packages/server/src/server/checkout/status-projection.ts
@@ -63,6 +63,9 @@ export function buildCheckoutStatusPayloadFromSnapshot({
       aheadBehind: snapshot.git.aheadBehind ?? null,
       aheadOfOrigin: snapshot.git.aheadOfOrigin ?? null,
       behindOfOrigin: snapshot.git.behindOfOrigin ?? null,
+      ...(snapshot.git.originDefaultRelation
+        ? { originDefaultRelation: snapshot.git.originDefaultRelation }
+        : {}),
       hasRemote: snapshot.git.hasRemote,
       remoteUrl: snapshot.git.remoteUrl,
       isPaseoOwnedWorktree: true,
@@ -82,6 +85,9 @@ export function buildCheckoutStatusPayloadFromSnapshot({
     aheadBehind: snapshot.git.aheadBehind ?? null,
     aheadOfOrigin: snapshot.git.aheadOfOrigin ?? null,
     behindOfOrigin: snapshot.git.behindOfOrigin ?? null,
+    ...(snapshot.git.originDefaultRelation
+      ? { originDefaultRelation: snapshot.git.originDefaultRelation }
+      : {}),
     hasRemote: snapshot.git.hasRemote,
     remoteUrl: snapshot.git.remoteUrl,
     isPaseoOwnedWorktree: false,

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -3988,6 +3988,9 @@ export class Session {
       aheadBehind: snapshot.git.aheadBehind,
       aheadOfOrigin: snapshot.git.aheadOfOrigin,
       behindOfOrigin: snapshot.git.behindOfOrigin,
+      ...(snapshot.git.originDefaultRelation
+        ? { originDefaultRelation: snapshot.git.originDefaultRelation }
+        : {}),
     };
   }
 

--- a/packages/server/src/server/workspace-git-service.test.ts
+++ b/packages/server/src/server/workspace-git-service.test.ts
@@ -719,6 +719,95 @@ describe("WorkspaceGitServiceImpl", () => {
     service.dispose();
   });
 
+  test("common-dir ref invalidation refreshes siblings inside the 2s throttle window", async () => {
+    const commonDir = join(REPO_CWD, ".git");
+    const worktreeA = join(REPO_CWD, "worktrees", "feature-a");
+    const worktreeB = join(REPO_CWD, "worktrees", "feature-b");
+    const gitDirA = join(commonDir, "worktrees", "feature-a");
+    const gitDirB = join(commonDir, "worktrees", "feature-b");
+
+    const watchCallbacks = new Map<string, Array<() => void>>();
+    const watch = vi.fn(
+      (watchPath: string, _options: { recursive: boolean }, callback: () => void) => {
+        const list = watchCallbacks.get(watchPath) ?? [];
+        list.push(callback);
+        watchCallbacks.set(watchPath, list);
+        return createWatcher();
+      },
+    );
+
+    let relationState: "ahead" | "included" = "ahead";
+    const getCheckoutStatus = vi.fn(async (cwd: string) =>
+      createCheckoutStatus(cwd, {
+        currentBranch: cwd === worktreeA ? "feature-a" : "feature-b",
+        aheadOfOrigin: relationState === "ahead" ? 2 : 0,
+        originDefaultRelation: {
+          state: relationState,
+          resolvedRef: "origin/main",
+          ahead: relationState === "ahead" ? 2 : 0,
+          behind: relationState === "ahead" ? 0 : 3,
+          uniquePatchCount: relationState === "ahead" ? 2 : 0,
+        },
+      }),
+    );
+    const getCheckoutSnapshotFacts = vi.fn(async (cwd: string) => {
+      const absoluteGitDir = cwd === worktreeA ? gitDirA : gitDirB;
+      return {
+        ...createCheckoutSnapshotFacts(cwd),
+        worktreeRoot: cwd,
+        absoluteGitDir,
+        gitCommonDir: commonDir,
+        currentBranch: cwd === worktreeA ? "feature-a" : "feature-b",
+      };
+    });
+
+    // Stay inside the 2s non-forced throttle window for the whole test.
+    let nowMs = Date.parse("2026-04-12T00:00:00.000Z");
+    const service = createService({
+      watch,
+      getCheckoutStatus,
+      getCheckoutSnapshotFacts,
+      resolveAbsoluteGitDir: vi.fn(async (cwd: string) => (cwd === worktreeA ? gitDirA : gitDirB)),
+      now: () => new Date(nowMs),
+    });
+
+    const listenerA = vi.fn();
+    const listenerB = vi.fn();
+    const subA = service.registerWorkspace({ cwd: worktreeA }, listenerA);
+    const subB = service.registerWorkspace({ cwd: worktreeB }, listenerB);
+    await flushPromises();
+    await vi.waitFor(() => {
+      expect(watchCallbacks.has(join(commonDir, "refs", "remotes", "origin"))).toBe(true);
+    });
+
+    const statusCallsBefore = getCheckoutStatus.mock.calls.length;
+    relationState = "included";
+    // Burst inside the throttle window: debounce should coalesce, force should still refresh.
+    nowMs += 200;
+    for (const callback of watchCallbacks.get(join(commonDir, "refs", "remotes", "origin")) ?? []) {
+      callback();
+      callback();
+      callback();
+    }
+    // Advance only debounce (~1s), not the 2s min gap.
+    await vi.advanceTimersByTimeAsync(1_000);
+    await flushPromises();
+
+    const refreshCwds = getCheckoutStatus.mock.calls
+      .slice(statusCallsBefore)
+      .map((call) => call[0]);
+    expect(refreshCwds).toEqual(expect.arrayContaining([worktreeA, worktreeB]));
+    // Coalesced: one refresh per sibling, not one per watcher fire.
+    expect(refreshCwds.filter((cwd) => cwd === worktreeA).length).toBe(1);
+    expect(refreshCwds.filter((cwd) => cwd === worktreeB).length).toBe(1);
+    expect(listenerA.mock.calls.at(-1)?.[0].git.originDefaultRelation?.state).toBe("included");
+    expect(listenerB.mock.calls.at(-1)?.[0].git.originDefaultRelation?.state).toBe("included");
+
+    subA.unsubscribe();
+    subB.unsubscribe();
+    service.dispose();
+  });
+
   test("common-dir watcher setup tolerates missing remotes and packed-refs paths", async () => {
     const commonDir = join(REPO_CWD, ".git");
     const watch = vi.fn((watchPath: string) => {

--- a/packages/server/src/server/workspace-git-service.test.ts
+++ b/packages/server/src/server/workspace-git-service.test.ts
@@ -603,6 +603,161 @@ describe("WorkspaceGitServiceImpl", () => {
     service.dispose();
   });
 
+  test("shared common-dir ref watchers refresh every registered worktree and avoid watcher storms", async () => {
+    const commonDir = join(REPO_CWD, ".git");
+    const worktreeA = join(REPO_CWD, "worktrees", "feature-a");
+    const worktreeB = join(REPO_CWD, "worktrees", "feature-b");
+    const gitDirA = join(commonDir, "worktrees", "feature-a");
+    const gitDirB = join(commonDir, "worktrees", "feature-b");
+
+    const watchCallbacks = new Map<string, Array<() => void>>();
+    const watch = vi.fn(
+      (watchPath: string, _options: { recursive: boolean }, callback: () => void) => {
+        const list = watchCallbacks.get(watchPath) ?? [];
+        list.push(callback);
+        watchCallbacks.set(watchPath, list);
+        return createWatcher();
+      },
+    );
+
+    let relationState: "ahead" | "included" = "ahead";
+    const getCheckoutStatus = vi.fn(async (cwd: string) =>
+      createCheckoutStatus(cwd, {
+        currentBranch: cwd === worktreeA ? "feature-a" : "feature-b",
+        aheadOfOrigin: relationState === "ahead" ? 2 : 0,
+        originDefaultRelation: {
+          state: relationState,
+          resolvedRef: "origin/main",
+          ahead: relationState === "ahead" ? 2 : 0,
+          behind: relationState === "ahead" ? 0 : 3,
+          uniquePatchCount: relationState === "ahead" ? 2 : 0,
+        },
+      }),
+    );
+    const getCheckoutSnapshotFacts = vi.fn(async (cwd: string) => {
+      const absoluteGitDir = cwd === worktreeA ? gitDirA : gitDirB;
+      return {
+        ...createCheckoutSnapshotFacts(cwd),
+        worktreeRoot: cwd,
+        absoluteGitDir,
+        gitCommonDir: commonDir,
+        currentBranch: cwd === worktreeA ? "feature-a" : "feature-b",
+      };
+    });
+
+    let nowMs = Date.parse("2026-04-12T00:00:00.000Z");
+    const service = createService({
+      watch,
+      getCheckoutStatus,
+      getCheckoutSnapshotFacts,
+      resolveAbsoluteGitDir: vi.fn(async (cwd: string) => (cwd === worktreeA ? gitDirA : gitDirB)),
+      now: () => new Date(nowMs),
+    });
+
+    const listenerA = vi.fn();
+    const listenerB = vi.fn();
+    const subA = service.registerWorkspace({ cwd: worktreeA }, listenerA);
+    const subB = service.registerWorkspace({ cwd: worktreeB }, listenerB);
+    await flushPromises();
+    await vi.waitFor(() => {
+      expect(watchCallbacks.has(join(commonDir, "refs", "remotes", "origin"))).toBe(true);
+      expect(watchCallbacks.has(join(commonDir, "packed-refs"))).toBe(true);
+    });
+
+    // Shared common-dir paths: exactly one watcher callback registration each.
+    expect(watchCallbacks.get(join(commonDir, "refs", "heads"))).toHaveLength(1);
+    expect(watchCallbacks.get(join(commonDir, "refs", "remotes", "origin"))).toHaveLength(1);
+    expect(watchCallbacks.get(join(commonDir, "packed-refs"))).toHaveLength(1);
+    // Per-checkout HEAD remains private to each worktree.
+    expect(watchCallbacks.get(join(gitDirA, "HEAD"))).toHaveLength(1);
+    expect(watchCallbacks.get(join(gitDirB, "HEAD"))).toHaveLength(1);
+
+    const statusCallsBeforeRemote = getCheckoutStatus.mock.calls.length;
+    relationState = "included";
+    // Burst of remote-default updates should debounce, not storm.
+    for (const callback of watchCallbacks.get(join(commonDir, "refs", "remotes", "origin")) ?? []) {
+      callback();
+      callback();
+    }
+    nowMs += 3_000;
+    await vi.advanceTimersByTimeAsync(1_000);
+    await flushPromises();
+
+    expect(getCheckoutStatus.mock.calls.length).toBeGreaterThanOrEqual(statusCallsBeforeRemote + 2);
+    const remoteRefreshCwds = getCheckoutStatus.mock.calls
+      .slice(statusCallsBeforeRemote)
+      .map((call) => call[0]);
+    expect(remoteRefreshCwds).toEqual(expect.arrayContaining([worktreeA, worktreeB]));
+    expect(listenerA).toHaveBeenCalled();
+    expect(listenerB).toHaveBeenCalled();
+    expect(listenerA.mock.calls.at(-1)?.[0].git.originDefaultRelation?.state).toBe("included");
+    expect(listenerB.mock.calls.at(-1)?.[0].git.originDefaultRelation?.state).toBe("included");
+
+    listenerA.mockClear();
+    listenerB.mockClear();
+    const statusCallsBeforePacked = getCheckoutStatus.mock.calls.length;
+    // Change relation again so fingerprint changes and listeners re-emit.
+    relationState = "ahead";
+    for (const callback of watchCallbacks.get(join(commonDir, "packed-refs")) ?? []) {
+      callback();
+    }
+    nowMs += 3_000;
+    await vi.advanceTimersByTimeAsync(1_000);
+    await flushPromises();
+
+    const packedRefreshCwds = getCheckoutStatus.mock.calls
+      .slice(statusCallsBeforePacked)
+      .map((call) => call[0]);
+    expect(packedRefreshCwds).toEqual(expect.arrayContaining([worktreeA, worktreeB]));
+    expect(listenerA).toHaveBeenCalled();
+    expect(listenerB).toHaveBeenCalled();
+    expect(listenerA.mock.calls.at(-1)?.[0].git.originDefaultRelation?.state).toBe("ahead");
+    expect(listenerB.mock.calls.at(-1)?.[0].git.originDefaultRelation?.state).toBe("ahead");
+
+    subA.unsubscribe();
+    subB.unsubscribe();
+    service.dispose();
+  });
+
+  test("common-dir watcher setup tolerates missing remotes and packed-refs paths", async () => {
+    const commonDir = join(REPO_CWD, ".git");
+    const watch = vi.fn((watchPath: string) => {
+      if (
+        watchPath === join(commonDir, "packed-refs") ||
+        watchPath === join(commonDir, "refs", "remotes", "origin")
+      ) {
+        throw new Error(`ENOENT: ${watchPath}`);
+      }
+      return createWatcher();
+    });
+    const getCheckoutSnapshotFacts = vi.fn(async (cwd: string) => ({
+      ...createCheckoutSnapshotFacts(cwd),
+      gitCommonDir: commonDir,
+      absoluteGitDir: commonDir,
+    }));
+
+    const service = createService({
+      watch,
+      getCheckoutSnapshotFacts,
+    });
+    const subscription = service.registerWorkspace({ cwd: REPO_CWD }, vi.fn());
+    await flushPromises();
+    await vi.waitFor(() => {
+      expect(watch).toHaveBeenCalled();
+    });
+
+    // Parent paths still watched so a later origin/packed-refs creation is visible.
+    expect(watch).toHaveBeenCalledWith(
+      join(commonDir, "refs", "remotes"),
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(watch).toHaveBeenCalledWith(commonDir, expect.any(Object), expect.any(Function));
+
+    subscription.unsubscribe();
+    service.dispose();
+  });
+
   test("explicit forced snapshot refresh recomputes github state and notifies listeners", async () => {
     const getPullRequestStatus = vi
       .fn<() => Promise<PullRequestStatusResult>>()

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -317,6 +317,18 @@ interface RepoGitTarget {
   fetchInFlight: boolean;
 }
 
+/**
+ * Shared watchers for one git common directory. Multiple worktree checkouts share
+ * the same refs/remotes, packed-refs, and refs/heads; one watcher set fans out
+ * invalidation to every registered workspace for that common dir.
+ */
+interface CommonGitDirWatchTarget {
+  commonDir: string;
+  workspaceKeys: Set<string>;
+  watchers: FSWatcher[];
+  watchedPaths: Set<string>;
+}
+
 interface WorkingTreeWatchTarget {
   cwd: string;
   repoRoot: string | null;
@@ -377,6 +389,7 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
   private readonly snapshotUpdatedListeners = new Set<WorkspaceGitSnapshotUpdatedListener>();
   private readonly workspaceTargets = new Map<string, WorkspaceGitTarget>();
   private readonly repoTargets = new Map<string, RepoGitTarget>();
+  private readonly commonGitDirWatchTargets = new Map<string, CommonGitDirWatchTarget>();
   private readonly workingTreeWatchTargets = new Map<string, WorkingTreeWatchTarget>();
   private readonly workingTreeWatchSetups = new Map<string, Promise<WorkingTreeWatchTarget>>();
   private readonly linuxIgnoredDirsCache = new Map<string, { ignored: Set<string>; ts: number }>();
@@ -722,6 +735,11 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
     }
     this.repoTargets.clear();
 
+    for (const target of this.commonGitDirWatchTargets.values()) {
+      this.closeCommonGitDirWatchTarget(target);
+    }
+    this.commonGitDirWatchTargets.clear();
+
     for (const target of this.workingTreeWatchTargets.values()) {
       this.closeWorkingTreeWatchTarget(target);
     }
@@ -1056,28 +1074,149 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
     gitDir: string,
     repoGitRoot: string,
   ): void {
-    for (const watchPath of new Set([join(gitDir, "HEAD"), join(repoGitRoot, "refs", "heads")])) {
-      let watcher: FSWatcher | null = null;
-      try {
-        watcher = this.deps.watch(watchPath, { recursive: false }, () => {
-          this.scheduleWorkspaceRefresh(target);
-        });
-      } catch (error) {
-        this.logger.warn(
-          { err: error, cwd: target.cwd, watchPath },
-          "Failed to start workspace git watcher",
-        );
-      }
+    // Per-checkout HEAD only. Shared common-dir refs (local default, origin/*,
+    // packed-refs) are watched once per common dir so sibling worktrees refresh
+    // together without duplicate watcher storms.
+    this.addWorkspacePathWatcher(target, join(gitDir, "HEAD"), () => {
+      this.scheduleWorkspaceRefresh(target);
+    });
+    this.ensureCommonGitDirWatchTarget(repoGitRoot, target.cwd);
+  }
 
-      if (!watcher) {
+  private addWorkspacePathWatcher(
+    target: WorkspaceGitTarget,
+    watchPath: string,
+    onChange: () => void,
+  ): void {
+    let watcher: FSWatcher | null = null;
+    try {
+      watcher = this.deps.watch(watchPath, { recursive: false }, onChange);
+    } catch (error) {
+      this.logger.warn(
+        { err: error, cwd: target.cwd, watchPath },
+        "Failed to start workspace git watcher",
+      );
+    }
+
+    if (!watcher) {
+      return;
+    }
+
+    watcher.on("error", (error) => {
+      this.logger.warn({ err: error, cwd: target.cwd, watchPath }, "Workspace git watcher error");
+    });
+    target.watchers.push(watcher);
+  }
+
+  /**
+   * Register this workspace under the shared common-dir watcher. Observes local
+   * default branch tips, refs/remotes/origin (including HEAD and default), and
+   * packed-refs so a main-sync or Queue publish in any sibling worktree refreshes
+   * every registered snapshot for that common dir.
+   */
+  private ensureCommonGitDirWatchTarget(commonDir: string, workspaceKey: string): void {
+    const existing = this.commonGitDirWatchTargets.get(commonDir);
+    if (existing) {
+      existing.workspaceKeys.add(workspaceKey);
+      return;
+    }
+
+    const target: CommonGitDirWatchTarget = {
+      commonDir,
+      workspaceKeys: new Set([workspaceKey]),
+      watchers: [],
+      watchedPaths: new Set(),
+    };
+    this.commonGitDirWatchTargets.set(commonDir, target);
+
+    // Prefer concrete paths when present; always also watch parent dirs so
+    // missing origin/ remotes or packed-refs still become visible once created
+    // (Queue publish, first fetch, pack-refs).
+    const watchPaths = [
+      join(commonDir, "refs", "heads"),
+      join(commonDir, "refs", "remotes"),
+      join(commonDir, "refs", "remotes", "origin"),
+      join(commonDir, "packed-refs"),
+      commonDir,
+    ];
+
+    for (const watchPath of watchPaths) {
+      this.addCommonGitDirPathWatcher(target, watchPath);
+    }
+  }
+
+  private addCommonGitDirPathWatcher(target: CommonGitDirWatchTarget, watchPath: string): void {
+    if (target.watchedPaths.has(watchPath)) {
+      return;
+    }
+
+    let watcher: FSWatcher | null = null;
+    try {
+      watcher = this.deps.watch(watchPath, { recursive: false }, () => {
+        this.scheduleRefreshForCommonGitDir(target.commonDir);
+      });
+    } catch (error) {
+      // Missing dirs/files are expected (no remotes yet, no packed-refs). Parent
+      // paths in the candidate list cover creation; do not escalate to warn spam.
+      this.logger.debug(
+        { err: error, commonDir: target.commonDir, watchPath },
+        "Common-dir git watcher path unavailable",
+      );
+    }
+
+    if (!watcher) {
+      return;
+    }
+
+    watcher.on("error", (error) => {
+      this.logger.warn(
+        { err: error, commonDir: target.commonDir, watchPath },
+        "Common-dir git watcher error",
+      );
+    });
+    target.watchers.push(watcher);
+    target.watchedPaths.add(watchPath);
+  }
+
+  private scheduleRefreshForCommonGitDir(commonDir: string): void {
+    const commonTarget = this.commonGitDirWatchTargets.get(commonDir);
+    if (!commonTarget) {
+      return;
+    }
+
+    for (const workspaceKey of commonTarget.workspaceKeys) {
+      const workspaceTarget = this.workspaceTargets.get(workspaceKey);
+      if (!workspaceTarget || workspaceTarget.closed) {
         continue;
       }
-
-      watcher.on("error", (error) => {
-        this.logger.warn({ err: error, cwd: target.cwd, watchPath }, "Workspace git watcher error");
+      this.scheduleWorkspaceRefresh(workspaceTarget, {
+        force: false,
+        includeForge: false,
+        reason: "common-dir-refs",
       });
-      target.watchers.push(watcher);
     }
+  }
+
+  private releaseCommonGitDirWatchMembership(commonDir: string, workspaceKey: string): void {
+    const target = this.commonGitDirWatchTargets.get(commonDir);
+    if (!target) {
+      return;
+    }
+    target.workspaceKeys.delete(workspaceKey);
+    if (target.workspaceKeys.size > 0) {
+      return;
+    }
+    this.closeCommonGitDirWatchTarget(target);
+    this.commonGitDirWatchTargets.delete(commonDir);
+  }
+
+  private closeCommonGitDirWatchTarget(target: CommonGitDirWatchTarget): void {
+    for (const watcher of target.watchers) {
+      watcher.close();
+    }
+    target.watchers = [];
+    target.watchedPaths.clear();
+    target.workspaceKeys.clear();
   }
 
   private async ensureRepoTarget(workspaceTarget: WorkspaceGitTarget): Promise<void> {
@@ -1951,6 +2090,7 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
         this.closeRepoTarget(repoTarget);
         this.repoTargets.delete(target.repoGitRoot);
       }
+      this.releaseCommonGitDirWatchMembership(target.repoGitRoot, target.cwd);
     }
 
     this.closeWorkspaceTarget(target);

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -6,7 +6,7 @@ import pLimit from "p-limit";
 import type pino from "pino";
 import type { ProjectCheckoutLitePayload } from "@getpaseo/protocol/messages";
 import { parseGitRemoteLocation } from "@getpaseo/protocol/git-remote";
-import type { CheckoutContext } from "../utils/checkout-git.js";
+import type { CheckoutContext, OriginDefaultRelation } from "../utils/checkout-git.js";
 import {
   type BranchCheckoutResolution,
   type BranchSuggestion,
@@ -80,6 +80,8 @@ export interface WorkspaceGitRuntimeSnapshot {
     aheadBehind: { ahead: number; behind: number } | null;
     aheadOfOrigin: number | null;
     behindOfOrigin: number | null;
+    /** COMPAT(originDefaultRelation): optional; absent means old-shape / unknown. */
+    originDefaultRelation?: OriginDefaultRelation;
     hasRemote: boolean;
     diffStat: { additions: number; deletions: number } | null;
   };
@@ -1755,6 +1757,7 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
       aheadBehind: checkoutStatus.aheadBehind,
       aheadOfOrigin: checkoutStatus.aheadOfOrigin,
       behindOfOrigin: checkoutStatus.behindOfOrigin,
+      originDefaultRelation: checkoutStatus.originDefaultRelation,
       hasRemote: checkoutStatus.hasRemote,
       diffStat,
     };

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -1189,8 +1189,11 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
       if (!workspaceTarget || workspaceTarget.closed) {
         continue;
       }
+      // Force so authoritative common-dir ref invalidation is not swallowed by
+      // the 2s non-forced refresh throttle. Still debounced (coalesced) above;
+      // includeForge stays false — no network/forge work on ref watchers.
       this.scheduleWorkspaceRefresh(workspaceTarget, {
-        force: false,
+        force: true,
         includeForge: false,
         reason: "common-dir-refs",
       });

--- a/packages/server/src/utils/checkout-git.origin-default-relation.test.ts
+++ b/packages/server/src/utils/checkout-git.origin-default-relation.test.ts
@@ -161,7 +161,7 @@ describe("originDefaultRelation", () => {
   });
 
   it("reports unverifiable when origin default cannot be resolved", async () => {
-    // No remote configured.
+    // No remote configured — no refs/remotes/origin/HEAD.
     const relation = await getOriginDefaultRelation(repoDir);
     expect(relation).toEqual({
       state: "unverifiable",
@@ -180,5 +180,71 @@ describe("originDefaultRelation", () => {
     // ensure symbolic-ref is the resolution source.
     const resolved = await resolveOriginDefaultRef(repoDir);
     expect(resolved).toBe("origin/main");
+  });
+
+  it("reports unverifiable when refs/remotes/origin/HEAD is missing even if origin/main exists", async () => {
+    setupOrigin(repoDir, tempDir);
+    // Drop only the symbolic default; leave origin/main in place.
+    execFileSync("git", ["update-ref", "-d", "refs/remotes/origin/HEAD"], { cwd: repoDir });
+
+    expect(await resolveOriginDefaultRef(repoDir)).toBeNull();
+    const relation = await getOriginDefaultRelation(repoDir);
+    expect(relation).toEqual({
+      state: "unverifiable",
+      resolvedRef: null,
+      ahead: null,
+      behind: null,
+      uniquePatchCount: null,
+    });
+  });
+
+  it("reports unverifiable when origin/HEAD target is outside refs/remotes/origin/*", async () => {
+    setupOrigin(repoDir, tempDir);
+    // Malformed / wrong-namespace: point at a local heads ref instead of origin/*.
+    execFileSync("git", ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/heads/main"], {
+      cwd: repoDir,
+    });
+
+    expect(await resolveOriginDefaultRef(repoDir)).toBeNull();
+    expect(await getOriginDefaultRelation(repoDir)).toEqual({
+      state: "unverifiable",
+      resolvedRef: null,
+      ahead: null,
+      behind: null,
+      uniquePatchCount: null,
+    });
+  });
+
+  it("reports unverifiable when origin/HEAD target ref is missing", async () => {
+    setupOrigin(repoDir, tempDir);
+    execFileSync(
+      "git",
+      ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/does-not-exist"],
+      { cwd: repoDir },
+    );
+
+    expect(await resolveOriginDefaultRef(repoDir)).toBeNull();
+    expect(await getOriginDefaultRelation(repoDir)).toEqual({
+      state: "unverifiable",
+      resolvedRef: null,
+      ahead: null,
+      behind: null,
+      uniquePatchCount: null,
+    });
+  });
+
+  it("does not fall back to local main/master for originDefaultRelation safety", async () => {
+    // Local main exists (from init) but no origin remote / origin/HEAD.
+    writeFileSync(join(repoDir, "local-only.txt"), "local\n");
+    execFileSync("git", ["add", "local-only.txt"], { cwd: repoDir });
+    execFileSync("git", ["commit", "-m", "local only"], { cwd: repoDir });
+
+    expect(await resolveOriginDefaultRef(repoDir)).toBeNull();
+    const relation = await getOriginDefaultRelation(repoDir);
+    expect(relation.state).toBe("unverifiable");
+    expect(relation.resolvedRef).toBeNull();
+    expect(relation.ahead).toBeNull();
+    expect(relation.behind).toBeNull();
+    expect(relation.uniquePatchCount).toBeNull();
   });
 });

--- a/packages/server/src/utils/checkout-git.origin-default-relation.test.ts
+++ b/packages/server/src/utils/checkout-git.origin-default-relation.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  getCheckoutStatus,
+  getOriginDefaultRelation,
+  resolveOriginDefaultRef,
+} from "./checkout-git.js";
+
+function initRepo(): { tempDir: string; repoDir: string } {
+  const tempDir = mkdtempSync(join(tmpdir(), "paseo-odr-"));
+  const repoDir = join(tempDir, "repo");
+  execFileSync("git", ["init", "-b", "main", repoDir]);
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: repoDir });
+  execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repoDir });
+  writeFileSync(join(repoDir, "README.md"), "root\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repoDir });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoDir });
+  return { tempDir, repoDir };
+}
+
+function commitFile(cwd: string, path: string, content: string, message: string): void {
+  writeFileSync(join(cwd, path), content);
+  execFileSync("git", ["add", path], { cwd });
+  execFileSync("git", ["commit", "-m", message], { cwd });
+}
+
+function setupOrigin(repoDir: string, tempDir: string): string {
+  const remoteDir = join(tempDir, "remote.git");
+  execFileSync("git", ["init", "--bare", "-b", "main", remoteDir]);
+  execFileSync("git", ["remote", "add", "origin", remoteDir], { cwd: repoDir });
+  execFileSync("git", ["push", "-u", "origin", "main"], { cwd: repoDir });
+  execFileSync("git", ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], {
+    cwd: repoDir,
+  });
+  return remoteDir;
+}
+
+describe("originDefaultRelation", () => {
+  let tempDir: string;
+  let repoDir: string;
+
+  beforeEach(() => {
+    const setup = initRepo();
+    tempDir = setup.tempDir;
+    repoDir = setup.repoDir;
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reports exact when HEAD equals origin default tip", async () => {
+    setupOrigin(repoDir, tempDir);
+
+    const relation = await getOriginDefaultRelation(repoDir);
+    expect(relation).toEqual({
+      state: "exact",
+      resolvedRef: "origin/main",
+      ahead: 0,
+      behind: 0,
+      uniquePatchCount: 0,
+    });
+
+    const status = await getCheckoutStatus(repoDir);
+    expect(status.isGit).toBe(true);
+    if (status.isGit) {
+      expect(status.originDefaultRelation).toEqual(relation);
+      // Compatibility fields remain populated.
+      expect(status.aheadOfOrigin).toBe(0);
+      expect(status.behindOfOrigin).toBe(0);
+    }
+  });
+
+  it("reports included when HEAD is a strict ancestor of origin default", async () => {
+    setupOrigin(repoDir, tempDir);
+    const cloneDir = join(tempDir, "clone");
+    execFileSync("git", ["clone", join(tempDir, "remote.git"), cloneDir]);
+    execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: cloneDir });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: cloneDir });
+    commitFile(cloneDir, "on-main.txt", "main advance\n", "advance main");
+    execFileSync("git", ["push", "origin", "main"], { cwd: cloneDir });
+    execFileSync("git", ["fetch", "origin"], { cwd: repoDir });
+    // Stay on the pre-fetch commit (ancestor of origin/main).
+    execFileSync("git", ["reset", "--hard", "HEAD"], { cwd: repoDir });
+
+    const relation = await getOriginDefaultRelation(repoDir);
+    expect(relation.state).toBe("included");
+    expect(relation.resolvedRef).toBe("origin/main");
+    expect(relation.ahead).toBe(0);
+    expect(relation.behind).toBeGreaterThan(0);
+    expect(relation.uniquePatchCount).toBe(0);
+  });
+
+  it("reports ahead when origin default is an ancestor of HEAD with unique commits", async () => {
+    setupOrigin(repoDir, tempDir);
+    execFileSync("git", ["checkout", "-b", "feature"], { cwd: repoDir });
+    commitFile(repoDir, "feature.txt", "feature\n", "feature work");
+
+    const relation = await getOriginDefaultRelation(repoDir);
+    expect(relation).toEqual({
+      state: "ahead",
+      resolvedRef: "origin/main",
+      ahead: 1,
+      behind: 0,
+      uniquePatchCount: 1,
+    });
+  });
+
+  it("reports patch_equivalent_not_included when tips share a tree but not ancestry", async () => {
+    setupOrigin(repoDir, tempDir);
+    // Feature branch with unique commits.
+    execFileSync("git", ["checkout", "-b", "feature"], { cwd: repoDir });
+    commitFile(repoDir, "landed.txt", "landed content\n", "feature landed");
+    const featureTree = execFileSync("git", ["rev-parse", "HEAD^{tree}"], { cwd: repoDir })
+      .toString()
+      .trim();
+
+    // Squash the same tree onto main via a different commit (not ancestral of feature).
+    execFileSync("git", ["checkout", "main"], { cwd: repoDir });
+    commitFile(repoDir, "landed.txt", "landed content\n", "squash land");
+    const mainTree = execFileSync("git", ["rev-parse", "HEAD^{tree}"], { cwd: repoDir })
+      .toString()
+      .trim();
+    expect(mainTree).toBe(featureTree);
+    execFileSync("git", ["push", "origin", "main"], { cwd: repoDir });
+
+    // Feature tip is not an ancestor of origin/main and not a descendant either,
+    // but trees match → patch-equivalent, not inclusion.
+    execFileSync("git", ["checkout", "feature"], { cwd: repoDir });
+    const relation = await getOriginDefaultRelation(repoDir);
+    expect(relation.state).toBe("patch_equivalent_not_included");
+    expect(relation.resolvedRef).toBe("origin/main");
+    expect(relation.ahead).toBeGreaterThan(0);
+    expect(relation.behind).toBeGreaterThan(0);
+    expect(relation.uniquePatchCount).toBe(0);
+  });
+
+  it("reports diverged_with_unique_commits when histories diverge with unique patches", async () => {
+    setupOrigin(repoDir, tempDir);
+    const cloneDir = join(tempDir, "clone");
+    execFileSync("git", ["clone", join(tempDir, "remote.git"), cloneDir]);
+    execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: cloneDir });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: cloneDir });
+    commitFile(cloneDir, "main-only.txt", "main\n", "main only");
+    execFileSync("git", ["push", "origin", "main"], { cwd: cloneDir });
+
+    execFileSync("git", ["checkout", "-b", "feature"], { cwd: repoDir });
+    commitFile(repoDir, "feature-only.txt", "feature\n", "feature only");
+    execFileSync("git", ["fetch", "origin"], { cwd: repoDir });
+
+    const relation = await getOriginDefaultRelation(repoDir);
+    expect(relation.state).toBe("diverged_with_unique_commits");
+    expect(relation.resolvedRef).toBe("origin/main");
+    expect(relation.ahead).toBeGreaterThan(0);
+    expect(relation.behind).toBeGreaterThan(0);
+    expect(relation.uniquePatchCount).toBeGreaterThan(0);
+  });
+
+  it("reports unverifiable when origin default cannot be resolved", async () => {
+    // No remote configured.
+    const relation = await getOriginDefaultRelation(repoDir);
+    expect(relation).toEqual({
+      state: "unverifiable",
+      resolvedRef: null,
+      ahead: null,
+      behind: null,
+      uniquePatchCount: null,
+    });
+
+    expect(await resolveOriginDefaultRef(repoDir)).toBeNull();
+  });
+
+  it("prefers refs/remotes/origin/HEAD for resolved origin default", async () => {
+    setupOrigin(repoDir, tempDir);
+    // Point origin/HEAD at a non-main default name if present; keep main and
+    // ensure symbolic-ref is the resolution source.
+    const resolved = await resolveOriginDefaultRef(repoDir);
+    expect(resolved).toBe("origin/main");
+  });
+});

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1566,15 +1566,23 @@ function unverifiableOriginDefaultRelation(
 }
 
 /**
- * Resolve the origin default tip for landed-truth comparison.
- * Prefer `refs/remotes/origin/HEAD`; fall back to the same default-branch
- * resolution used for baseRef, then `origin/<name>` when that remote-tracking
- * ref exists.
+ * Resolve the origin default tip for landed-truth / safety comparison.
+ *
+ * Requires authoritative `refs/remotes/origin/HEAD` evidence only:
+ * - symbolic-ref must resolve
+ * - target must be under `refs/remotes/origin/*`
+ * - the target ref must exist
+ *
+ * Missing, malformed, wrong-namespace, or dangling targets return null so
+ * callers report `unverifiable`. Does **not** fall back to local main/master
+ * heuristics — those remain in `resolveRepositoryDefaultBranch` for non-safety
+ * base operations only.
  */
 export async function resolveOriginDefaultRef(
   cwd: string,
   context?: CheckoutContext,
 ): Promise<string | null> {
+  let symbolicTarget: string;
   try {
     const { stdout } = await runGitCommand(
       ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
@@ -1584,31 +1592,26 @@ export async function resolveOriginDefaultRef(
         logger: context?.logger,
       },
     );
-    const ref = stdout.trim();
-    if (ref.startsWith("refs/remotes/")) {
-      return ref.slice("refs/remotes/".length);
-    }
-    if (ref.length > 0) {
-      return ref;
-    }
+    symbolicTarget = stdout.trim();
   } catch {
-    // fall through
-  }
-
-  const defaultBranch = await resolveRepositoryDefaultBranch(cwd);
-  if (!defaultBranch) {
     return null;
   }
 
-  const localName = normalizeLocalBranchRefName(defaultBranch);
-  if (await doesGitRefExist(cwd, `refs/remotes/origin/${localName}`, context)) {
-    return `origin/${localName}`;
+  if (!symbolicTarget.startsWith("refs/remotes/origin/")) {
+    // Missing, empty, or target outside origin/* (e.g. refs/heads/main).
+    return null;
   }
-  if (defaultBranch.startsWith("origin/")) {
-    return defaultBranch;
+
+  const branchUnderOrigin = symbolicTarget.slice("refs/remotes/origin/".length);
+  if (!branchUnderOrigin || branchUnderOrigin.includes("..") || branchUnderOrigin.endsWith("/")) {
+    return null;
   }
-  // Local-only default with no origin tracking ref is not a usable origin default tip.
-  return null;
+
+  if (!(await doesGitRefExist(cwd, symbolicTarget, context))) {
+    return null;
+  }
+
+  return `origin/${branchUnderOrigin}`;
 }
 
 async function isAncestorRef(

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -716,6 +716,27 @@ export interface AheadBehind {
   behind: number;
 }
 
+/**
+ * HEAD relation to the resolved origin default tip.
+ * Ancestral inclusion is authoritative; patch equivalence is a weaker signal and
+ * never treated as inclusion for land/archive authority.
+ */
+export type OriginDefaultRelationState =
+  | "exact"
+  | "included"
+  | "ahead"
+  | "patch_equivalent_not_included"
+  | "diverged_with_unique_commits"
+  | "unverifiable";
+
+export interface OriginDefaultRelation {
+  state: OriginDefaultRelationState;
+  resolvedRef: string | null;
+  ahead: number | null;
+  behind: number | null;
+  uniquePatchCount: number | null;
+}
+
 export interface CheckoutStatus {
   isGit: false;
 }
@@ -730,6 +751,7 @@ export interface CheckoutStatusGitNonPaseo {
   aheadBehind: AheadBehind | null;
   aheadOfOrigin: number | null;
   behindOfOrigin: number | null;
+  originDefaultRelation?: OriginDefaultRelation;
   hasRemote: boolean;
   remoteUrl: string | null;
   isPaseoOwnedWorktree: false;
@@ -745,6 +767,7 @@ export interface CheckoutStatusGitPaseo {
   aheadBehind: AheadBehind | null;
   aheadOfOrigin: number | null;
   behindOfOrigin: number | null;
+  originDefaultRelation?: OriginDefaultRelation;
   hasRemote: boolean;
   remoteUrl: string | null;
   isPaseoOwnedWorktree: true;
@@ -1524,6 +1547,268 @@ async function getBehindOfOrigin(
   }
 }
 
+// Bound how many unique commits we enumerate for stable patch-id comparison.
+// Larger ranges are reported as unverifiable rather than burning unbounded git work.
+const MAX_ORIGIN_DEFAULT_PATCH_COMMITS = 64;
+
+function unverifiableOriginDefaultRelation(
+  resolvedRef: string | null = null,
+  ahead: number | null = null,
+  behind: number | null = null,
+): OriginDefaultRelation {
+  return {
+    state: "unverifiable",
+    resolvedRef,
+    ahead,
+    behind,
+    uniquePatchCount: null,
+  };
+}
+
+/**
+ * Resolve the origin default tip for landed-truth comparison.
+ * Prefer `refs/remotes/origin/HEAD`; fall back to the same default-branch
+ * resolution used for baseRef, then `origin/<name>` when that remote-tracking
+ * ref exists.
+ */
+export async function resolveOriginDefaultRef(
+  cwd: string,
+  context?: CheckoutContext,
+): Promise<string | null> {
+  try {
+    const { stdout } = await runGitCommand(
+      ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
+      {
+        cwd,
+        envOverlay: READ_ONLY_GIT_ENV,
+        logger: context?.logger,
+      },
+    );
+    const ref = stdout.trim();
+    if (ref.startsWith("refs/remotes/")) {
+      return ref.slice("refs/remotes/".length);
+    }
+    if (ref.length > 0) {
+      return ref;
+    }
+  } catch {
+    // fall through
+  }
+
+  const defaultBranch = await resolveRepositoryDefaultBranch(cwd);
+  if (!defaultBranch) {
+    return null;
+  }
+
+  const localName = normalizeLocalBranchRefName(defaultBranch);
+  if (await doesGitRefExist(cwd, `refs/remotes/origin/${localName}`, context)) {
+    return `origin/${localName}`;
+  }
+  if (defaultBranch.startsWith("origin/")) {
+    return defaultBranch;
+  }
+  // Local-only default with no origin tracking ref is not a usable origin default tip.
+  return null;
+}
+
+async function isAncestorRef(
+  cwd: string,
+  maybeAncestor: string,
+  maybeDescendant: string,
+  context?: CheckoutContext,
+): Promise<boolean> {
+  const result = await runGitCommand(
+    ["merge-base", "--is-ancestor", maybeAncestor, maybeDescendant],
+    {
+      cwd,
+      envOverlay: READ_ONLY_GIT_ENV,
+      acceptExitCodes: [0, 1],
+      logger: context?.logger,
+    },
+  );
+  return result.exitCode === 0;
+}
+
+async function revParseOid(
+  cwd: string,
+  ref: string,
+  context?: CheckoutContext,
+): Promise<string | null> {
+  try {
+    const { stdout } = await runGitCommand(["rev-parse", `${ref}^{commit}`], {
+      cwd,
+      envOverlay: READ_ONLY_GIT_ENV,
+      logger: context?.logger,
+    });
+    const oid = stdout.trim();
+    return oid.length > 0 ? oid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function revParseTreeOid(
+  cwd: string,
+  ref: string,
+  context?: CheckoutContext,
+): Promise<string | null> {
+  try {
+    const { stdout } = await runGitCommand(["rev-parse", `${ref}^{tree}`], {
+      cwd,
+      envOverlay: READ_ONLY_GIT_ENV,
+      logger: context?.logger,
+    });
+    const oid = stdout.trim();
+    return oid.length > 0 ? oid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Count commits reachable from HEAD but not from originDefault whose stable
+ * patch-id is not already present on the origin-default side (`git cherry`).
+ * Returns null when the proof cannot be completed safely.
+ */
+async function countUniquePatchesVsOriginDefault(
+  cwd: string,
+  originDefaultRef: string,
+  context?: CheckoutContext,
+): Promise<number | null> {
+  try {
+    const { stdout } = await runGitCommand(["cherry", originDefaultRef, "HEAD"], {
+      cwd,
+      envOverlay: READ_ONLY_GIT_ENV,
+      logger: context?.logger,
+    });
+    let unique = 0;
+    for (const line of stdout.split("\n")) {
+      const trimmed = line.trim();
+      // `+ <sha>` = unique patch; `- <sha>` = equivalent patch already on upstream.
+      if (trimmed.startsWith("+")) {
+        unique += 1;
+      }
+    }
+    return unique;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare HEAD to the resolved origin default tip.
+ * Never treats patch equivalence as ancestral inclusion.
+ */
+export async function getOriginDefaultRelation(
+  cwd: string,
+  context?: CheckoutContext,
+): Promise<OriginDefaultRelation> {
+  const resolvedRef = await resolveOriginDefaultRef(cwd, context);
+  if (!resolvedRef) {
+    return unverifiableOriginDefaultRelation(null);
+  }
+
+  const [headOid, defaultOid] = await Promise.all([
+    revParseOid(cwd, "HEAD", context),
+    revParseOid(cwd, resolvedRef, context),
+  ]);
+  if (!headOid || !defaultOid) {
+    return unverifiableOriginDefaultRelation(resolvedRef);
+  }
+
+  if (headOid === defaultOid) {
+    return {
+      state: "exact",
+      resolvedRef,
+      ahead: 0,
+      behind: 0,
+      uniquePatchCount: 0,
+    };
+  }
+
+  let ahead: number;
+  let behind: number;
+  try {
+    const { stdout } = await runGitCommand(
+      ["rev-list", "--left-right", "--count", `${resolvedRef}...HEAD`],
+      { cwd, envOverlay: READ_ONLY_GIT_ENV, logger: context?.logger },
+    );
+    const [behindRaw, aheadRaw] = stdout.trim().split(/\s+/);
+    behind = Number.parseInt(behindRaw ?? "", 10);
+    ahead = Number.parseInt(aheadRaw ?? "", 10);
+    if (Number.isNaN(behind) || Number.isNaN(ahead)) {
+      return unverifiableOriginDefaultRelation(resolvedRef);
+    }
+  } catch {
+    return unverifiableOriginDefaultRelation(resolvedRef);
+  }
+
+  const headIsAncestorOfDefault = await isAncestorRef(cwd, "HEAD", resolvedRef, context);
+  if (headIsAncestorOfDefault) {
+    return {
+      state: "included",
+      resolvedRef,
+      ahead: 0,
+      behind,
+      uniquePatchCount: 0,
+    };
+  }
+
+  const defaultIsAncestorOfHead = await isAncestorRef(cwd, resolvedRef, "HEAD", context);
+  if (defaultIsAncestorOfHead) {
+    return {
+      state: "ahead",
+      resolvedRef,
+      ahead,
+      behind: 0,
+      uniquePatchCount: ahead,
+    };
+  }
+
+  // Diverged ancestrally. Same tree (e.g. squash tip matches) is patch-equivalent,
+  // not inclusion. Bound commit work before cherry/patch-id proof.
+  if (ahead > MAX_ORIGIN_DEFAULT_PATCH_COMMITS || behind > MAX_ORIGIN_DEFAULT_PATCH_COMMITS) {
+    return unverifiableOriginDefaultRelation(resolvedRef, ahead, behind);
+  }
+
+  const [headTree, defaultTree] = await Promise.all([
+    revParseTreeOid(cwd, "HEAD", context),
+    revParseTreeOid(cwd, resolvedRef, context),
+  ]);
+  if (headTree && defaultTree && headTree === defaultTree) {
+    return {
+      state: "patch_equivalent_not_included",
+      resolvedRef,
+      ahead,
+      behind,
+      uniquePatchCount: 0,
+    };
+  }
+
+  const uniquePatchCount = await countUniquePatchesVsOriginDefault(cwd, resolvedRef, context);
+  if (uniquePatchCount === null) {
+    return unverifiableOriginDefaultRelation(resolvedRef, ahead, behind);
+  }
+
+  if (uniquePatchCount === 0) {
+    return {
+      state: "patch_equivalent_not_included",
+      resolvedRef,
+      ahead,
+      behind,
+      uniquePatchCount: 0,
+    };
+  }
+
+  return {
+    state: "diverged_with_unique_commits",
+    resolvedRef,
+    ahead,
+    behind,
+    uniquePatchCount,
+  };
+}
+
 interface CheckoutInspectionContext {
   worktreeRoot: string;
   currentBranch: string | null;
@@ -1913,7 +2198,7 @@ export async function getCheckoutStatus(
   const baseRef = facts.resolvedBaseRef;
   const mainRepoRoot = facts.mainRepoRoot;
   const factsContext = { ...context, facts };
-  const [aheadBehind, aheadOfOrigin, behindOfOrigin] = await Promise.all([
+  const [aheadBehind, aheadOfOrigin, behindOfOrigin, originDefaultRelation] = await Promise.all([
     baseRef && currentBranch
       ? getAheadBehind(cwd, baseRef, currentBranch, factsContext)
       : Promise.resolve(null),
@@ -1923,6 +2208,7 @@ export async function getCheckoutStatus(
     hasRemote && currentBranch
       ? getBehindOfOrigin(cwd, currentBranch, factsContext)
       : Promise.resolve(null),
+    getOriginDefaultRelation(cwd, factsContext),
   ]);
 
   if (paseoWorktree.isPaseoOwnedWorktree && baseRef) {
@@ -1936,6 +2222,7 @@ export async function getCheckoutStatus(
       aheadBehind,
       aheadOfOrigin,
       behindOfOrigin,
+      originDefaultRelation,
       hasRemote,
       remoteUrl,
       isPaseoOwnedWorktree: true,
@@ -1953,6 +2240,7 @@ export async function getCheckoutStatus(
     aheadBehind,
     aheadOfOrigin,
     behindOfOrigin,
+    originDefaultRelation,
     hasRemote,
     remoteUrl,
     isPaseoOwnedWorktree: false,


### PR DESCRIPTION
## Summary

- add an optional `originDefaultRelation` Git status object that distinguishes exact, included, unique, patch-equivalent, diverged, and unverifiable work
- invalidate all workspaces sharing a Git common directory when default refs or packed refs change
- show truthful landed-state labels without treating inclusion as archive authority
- keep auto-archive fail-closed with a forced fresh Git-only snapshot and authoritative `origin/HEAD` evidence
- add natural translations and suppress the tautological label on ordinary default-branch checkouts

## Safety

- no worktree or branch is moved, archived, deleted, or rewritten
- dirty, detached, unique, patch-equivalent-only, missing, and unverifiable states remain protected
- old protocol clients can omit the additive field
- explicit `autoArchiveAfterMerge` remains the only automatic cleanup authority

## Verification

- 150 focused tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- independent GPT-5.6-Sol correctness review: clear
- independent Fable UI/i18n review: clear