### PR TITLE
feat: expose Grok native Always Approve for ACP sessions

### DIFF
--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -34,6 +34,11 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import {
+  GROK_ASK_MODE_ID,
+  GROK_ALWAYS_APPROVE_MODE_ID,
+  GrokACPAgentClient,
+} from "./providers/grok-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
 import { OmpAgentClient } from "./providers/omp/agent.js";
@@ -646,6 +651,7 @@ function addDerivedProviders(
       // Capture command in const for closure - TypeScript can't track type refinement inside closures
       const command = override.command;
 
+      const isGrok = providerId === "grok";
       resolvedProviders.set(providerId, {
         definition: createDerivedDefinition(
           providerId,
@@ -653,8 +659,27 @@ function addDerivedProviders(
             id: providerId,
             label: override.label ?? providerId,
             description: override.description ?? "Custom ACP provider",
-            defaultModeId: null,
-            modes: [],
+            defaultModeId: isGrok ? GROK_ASK_MODE_ID : null,
+            modes: isGrok
+              ? [
+                  {
+                    id: GROK_ASK_MODE_ID,
+                    label: "Ask",
+                    description: "Prompt before shell and tool executions",
+                    icon: "ShieldCheck",
+                    colorTier: "safe",
+                  },
+                  {
+                    id: GROK_ALWAYS_APPROVE_MODE_ID,
+                    label: "Always Approve",
+                    description:
+                      "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
+                    icon: "ShieldOff",
+                    colorTier: "dangerous",
+                    isUnattended: true,
+                  },
+                ]
+              : [],
           },
           override,
         ),
@@ -676,6 +701,9 @@ function addDerivedProviders(
           };
           if (providerId === "cursor") {
             return new CursorACPAgentClient(acpOptions);
+          }
+          if (providerId === "grok") {
+            return new GrokACPAgentClient(acpOptions);
           }
           if (providerId === "kiro") {
             return new KiroACPAgentClient(acpOptions);

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -34,11 +34,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
-import {
-  GROK_ASK_MODE_ID,
-  GROK_ALWAYS_APPROVE_MODE_ID,
-  GrokACPAgentClient,
-} from "./providers/grok-acp-agent.js";
+import { GROK_ASK_MODE_ID, GROK_MODES, GrokACPAgentClient } from "./providers/grok-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
 import { OmpAgentClient } from "./providers/omp/agent.js";
@@ -660,26 +656,8 @@ function addDerivedProviders(
             label: override.label ?? providerId,
             description: override.description ?? "Custom ACP provider",
             defaultModeId: isGrok ? GROK_ASK_MODE_ID : null,
-            modes: isGrok
-              ? [
-                  {
-                    id: GROK_ASK_MODE_ID,
-                    label: "Ask",
-                    description: "Prompt before shell and tool executions",
-                    icon: "ShieldCheck",
-                    colorTier: "safe",
-                  },
-                  {
-                    id: GROK_ALWAYS_APPROVE_MODE_ID,
-                    label: "Always Approve",
-                    description:
-                      "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
-                    icon: "ShieldOff",
-                    colorTier: "dangerous",
-                    isUnattended: true,
-                  },
-                ]
-              : [],
+            // Canonical Grok modes live in grok-acp-agent.ts (icons, colorTier, isUnattended).
+            modes: isGrok ? GROK_MODES : [],
           },
           override,
         ),

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -719,6 +719,97 @@ describe("deriveModesFromACP", () => {
     });
   });
 
+  test("re-attaches fallback icon, colorTier, and isUnattended by mode id", () => {
+    const result = deriveModesFromACP(
+      [
+        {
+          id: "ask",
+          label: "Ask fallback",
+          icon: "ShieldCheck",
+          colorTier: "safe",
+        },
+        {
+          id: "always-approve",
+          label: "Always Approve fallback",
+          icon: "ShieldOff",
+          colorTier: "dangerous",
+          isUnattended: true,
+        },
+      ],
+      {
+        availableModes: [
+          { id: "ask", name: "Ask", description: "Prompt before tools" },
+          {
+            id: "always-approve",
+            name: "Always Approve",
+            description: "Skip permission prompts",
+          },
+        ],
+        currentModeId: "always-approve",
+      },
+      [],
+    );
+
+    expect(result.currentModeId).toBe("always-approve");
+    expect(result.modes).toEqual([
+      {
+        id: "ask",
+        label: "Ask",
+        description: "Prompt before tools",
+        icon: "ShieldCheck",
+        colorTier: "safe",
+      },
+      {
+        id: "always-approve",
+        label: "Always Approve",
+        description: "Skip permission prompts",
+        icon: "ShieldOff",
+        colorTier: "dangerous",
+        isUnattended: true,
+      },
+    ]);
+  });
+
+  test("re-attaches fallback metadata when modes come from config options", () => {
+    const result = deriveModesFromACP(
+      [
+        {
+          id: "full-access",
+          label: "Full Access fallback",
+          icon: "ShieldOff",
+          colorTier: "dangerous",
+          isUnattended: true,
+        },
+      ],
+      null,
+      [
+        {
+          id: "mode",
+          name: "Mode",
+          category: "mode",
+          type: "select",
+          currentValue: "full-access",
+          options: [
+            { value: "auto", name: "Default" },
+            { value: "full-access", name: "Full Access" },
+          ],
+        },
+      ],
+    );
+
+    expect(result.modes).toEqual([
+      { id: "auto", label: "Default", description: undefined },
+      {
+        id: "full-access",
+        label: "Full Access",
+        description: undefined,
+        icon: "ShieldOff",
+        colorTier: "dangerous",
+        isUnattended: true,
+      },
+    ]);
+  });
+
   test("falls back to config options when explicit mode state is absent", () => {
     const result = deriveModesFromACP([{ id: "fallback", label: "Fallback" }], null, [
       {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -628,6 +628,29 @@ export function resolveACPModelSelection({
   };
 }
 
+/**
+ * ACP SessionMode only carries id/name/description. Re-attach provider-declared
+ * metadata (icon, colorTier, isUnattended) from fallbackModes by id so session
+ * availableModes keep unattended semantics and UI visuals.
+ */
+function attachFallbackModeMetadata(
+  mode: Pick<AgentMode, "id" | "label" | "description">,
+  fallbackModes: AgentMode[],
+): AgentMode {
+  const fallback = fallbackModes.find((entry) => entry.id === mode.id);
+  if (!fallback) {
+    return mode;
+  }
+  return {
+    id: mode.id,
+    label: mode.label,
+    description: mode.description,
+    ...(fallback.icon !== undefined ? { icon: fallback.icon } : {}),
+    ...(fallback.colorTier !== undefined ? { colorTier: fallback.colorTier } : {}),
+    ...(fallback.isUnattended !== undefined ? { isUnattended: fallback.isUnattended } : {}),
+  };
+}
+
 export function deriveModesFromACP(
   fallbackModes: AgentMode[],
   modeState?: { availableModes?: SessionMode[] | null; currentModeId?: string | null } | null,
@@ -635,11 +658,16 @@ export function deriveModesFromACP(
 ): { modes: AgentMode[]; currentModeId: string | null } {
   if (modeState?.availableModes?.length) {
     return {
-      modes: modeState.availableModes.map((mode) => ({
-        id: mode.id,
-        label: mode.name,
-        description: mode.description ?? undefined,
-      })),
+      modes: modeState.availableModes.map((mode) =>
+        attachFallbackModeMetadata(
+          {
+            id: mode.id,
+            label: mode.name,
+            description: mode.description ?? undefined,
+          },
+          fallbackModes,
+        ),
+      ),
       currentModeId: modeState.currentModeId ?? null,
     };
   }
@@ -648,11 +676,16 @@ export function deriveModesFromACP(
   if (modeOption) {
     const flatOptions = flattenSelectOptions(modeOption.options);
     return {
-      modes: flatOptions.map((option) => ({
-        id: option.value,
-        label: option.name,
-        description: option.description ?? undefined,
-      })),
+      modes: flatOptions.map((option) =>
+        attachFallbackModeMetadata(
+          {
+            id: option.value,
+            label: option.name,
+            description: option.description ?? undefined,
+          },
+          fallbackModes,
+        ),
+      ),
       currentModeId: modeOption.currentValue,
     };
   }

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -373,13 +373,24 @@ interface ACPAgentClientOptions {
   defaultCommand: [string, ...string[]];
   defaultModes?: AgentMode[];
   modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
-  sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
+  sessionResponseTransformer?: (
+    response: SessionStateResponse,
+    sessionConfig?: AgentSessionConfig,
+  ) => SessionStateResponse;
   configOptionsTransformer?: (configOptions: SessionConfigOption[]) => SessionConfigOption[];
   configFeatureOptions?: ACPConfigFeatureOption[];
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   modeIdTransformer?: (modeId: string) => string | null;
   toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  /**
+   * Optional per-session rewrite of the provider launch command (e.g. inject
+   * Grok `--always-approve` when the session mode requires it).
+   */
+  resolveSessionCommand?: (
+    command: [string, ...string[]],
+    config: AgentSessionConfig,
+  ) => [string, ...string[]];
   providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
@@ -389,6 +400,14 @@ interface ACPAgentClientOptions {
     sessionId: string,
     thinkingOptionId: string,
   ) => Promise<void>;
+  /**
+   * Mode IDs that auto-approve ACP `session/request_permission` without UI.
+   * Use as a client-side fallback when the upstream provider still requests
+   * permission even though the session is in an unattended mode (e.g. Grok
+   * Always Approve race / older builds). Prefer driving the provider's native
+   * always-approve path first.
+   */
+  autoApproveModeIds?: string[];
   capabilities?: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
   waitForInitialCommands?: boolean;
@@ -403,13 +422,20 @@ interface ACPAgentSessionOptions {
   defaultCommand: [string, ...string[]];
   defaultModes: AgentMode[];
   modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
-  sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
+  sessionResponseTransformer?: (
+    response: SessionStateResponse,
+    sessionConfig?: AgentSessionConfig,
+  ) => SessionStateResponse;
   configOptionsTransformer?: (configOptions: SessionConfigOption[]) => SessionConfigOption[];
   configFeatureOptions?: ACPConfigFeatureOption[];
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   modeIdTransformer?: (modeId: string) => string | null;
   toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  resolveSessionCommand?: (
+    command: [string, ...string[]],
+    config: AgentSessionConfig,
+  ) => [string, ...string[]];
   providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
@@ -419,6 +445,7 @@ interface ACPAgentSessionOptions {
     sessionId: string,
     thinkingOptionId: string,
   ) => Promise<void>;
+  autoApproveModeIds?: string[];
   capabilities: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
   handle?: AgentPersistenceHandle;
@@ -705,6 +732,7 @@ export class ACPAgentClient implements AgentClient {
   private readonly modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   private readonly sessionResponseTransformer?: (
     response: SessionStateResponse,
+    sessionConfig?: AgentSessionConfig,
   ) => SessionStateResponse;
   private readonly configOptionsTransformer?: (
     configOptions: SessionConfigOption[],
@@ -714,6 +742,10 @@ export class ACPAgentClient implements AgentClient {
   private readonly clientCapabilityMeta?: ACPClientCapabilityMeta;
   private readonly modeIdTransformer?: (modeId: string) => string | null;
   private readonly toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  private readonly resolveSessionCommand?: (
+    command: [string, ...string[]],
+    config: AgentSessionConfig,
+  ) => [string, ...string[]];
   private readonly providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
@@ -725,6 +757,7 @@ export class ACPAgentClient implements AgentClient {
     sessionId: string,
     thinkingOptionId: string,
   ) => Promise<void>;
+  private readonly autoApproveModeIds: string[];
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
@@ -749,9 +782,11 @@ export class ACPAgentClient implements AgentClient {
     this.clientCapabilityMeta = options.clientCapabilityMeta;
     this.modeIdTransformer = options.modeIdTransformer;
     this.toolSnapshotTransformer = options.toolSnapshotTransformer;
+    this.resolveSessionCommand = options.resolveSessionCommand;
     this.providerModeWriter = options.providerModeWriter;
     this.beforeModeWriter = options.beforeModeWriter;
     this.thinkingOptionWriter = options.thinkingOptionWriter;
+    this.autoApproveModeIds = options.autoApproveModeIds ?? [];
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
@@ -778,9 +813,11 @@ export class ACPAgentClient implements AgentClient {
         clientCapabilityMeta: this.clientCapabilityMeta,
         modeIdTransformer: this.modeIdTransformer,
         toolSnapshotTransformer: this.toolSnapshotTransformer,
+        resolveSessionCommand: this.resolveSessionCommand,
         providerModeWriter: this.providerModeWriter,
         beforeModeWriter: this.beforeModeWriter,
         thinkingOptionWriter: this.thinkingOptionWriter,
+        autoApproveModeIds: this.autoApproveModeIds,
         capabilities: this.capabilities,
         agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
@@ -828,9 +865,11 @@ export class ACPAgentClient implements AgentClient {
       clientCapabilityMeta: this.clientCapabilityMeta,
       modeIdTransformer: this.modeIdTransformer,
       toolSnapshotTransformer: this.toolSnapshotTransformer,
+      resolveSessionCommand: this.resolveSessionCommand,
       providerModeWriter: this.providerModeWriter,
       beforeModeWriter: this.beforeModeWriter,
       thinkingOptionWriter: this.thinkingOptionWriter,
+      autoApproveModeIds: this.autoApproveModeIds,
       capabilities: this.capabilities,
       handle,
       agentId: launchContext?.agentId,
@@ -1273,6 +1312,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   protected readonly modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   private readonly sessionResponseTransformer?: (
     response: SessionStateResponse,
+    sessionConfig?: AgentSessionConfig,
   ) => SessionStateResponse;
   private readonly configOptionsTransformer?: (
     configOptions: SessionConfigOption[],
@@ -1282,6 +1322,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly clientCapabilityMeta?: ACPClientCapabilityMeta;
   private readonly modeIdTransformer?: (modeId: string) => string | null;
   private readonly toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  private readonly resolveSessionCommand?: (
+    command: [string, ...string[]],
+    config: AgentSessionConfig,
+  ) => [string, ...string[]];
   private readonly providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
@@ -1293,6 +1337,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     sessionId: string,
     thinkingOptionId: string,
   ) => Promise<void>;
+  private readonly autoApproveModeIds: ReadonlySet<string>;
   private readonly agentId?: string;
   private readonly launchEnv?: Record<string, string>;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
@@ -1348,9 +1393,11 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.clientCapabilityMeta = options.clientCapabilityMeta;
     this.modeIdTransformer = options.modeIdTransformer;
     this.toolSnapshotTransformer = options.toolSnapshotTransformer;
+    this.resolveSessionCommand = options.resolveSessionCommand;
     this.providerModeWriter = options.providerModeWriter;
     this.beforeModeWriter = options.beforeModeWriter;
     this.thinkingOptionWriter = options.thinkingOptionWriter;
+    this.autoApproveModeIds = new Set(options.autoApproveModeIds ?? []);
     this.availableModes = options.defaultModes;
     this.agentId = options.agentId;
     this.launchEnv = options.launchEnv;
@@ -2083,7 +2130,42 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
-    // Match Zed acp.rs:3189-3220: generic ACP permission requests stay pure pass-through.
+    // Client-side fallback for unattended modes. Prefer provider-native always-approve
+    // (e.g. Grok `--always-approve` / `/always-approve`) so requestPermission is never
+    // emitted; this path covers races and older builds that still ask the client.
+    // Generic ACP requests otherwise stay pure pass-through (match Zed acp.rs:3189-3220).
+    if (this.currentMode && this.autoApproveModeIds.has(this.currentMode)) {
+      const allowOption = selectPermissionOption(params.options, { behavior: "allow" });
+      if (allowOption) {
+        this.logger.debug(
+          {
+            agentId: this.agentId,
+            provider: this.provider,
+            modeId: this.currentMode,
+            toolCallId: params.toolCall.toolCallId,
+            optionId: allowOption.optionId,
+          },
+          "provider.acp.permission.auto_approved",
+        );
+        return {
+          outcome: {
+            outcome: "selected",
+            optionId: allowOption.optionId,
+          },
+        };
+      }
+      this.logger.warn(
+        {
+          agentId: this.agentId,
+          provider: this.provider,
+          modeId: this.currentMode,
+          toolCallId: params.toolCall.toolCallId,
+        },
+        "provider.acp.permission.auto_approve_missing_allow_option",
+      );
+      return { outcome: { outcome: "cancelled" } };
+    }
+
     const requestId = randomUUID();
     let toolSnapshot =
       this.toolCalls.get(params.toolCall.toolCallId) ??
@@ -2309,17 +2391,20 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private async spawnProcess(): Promise<SpawnedACPProcess> {
+    const sessionCommand = this.resolveSessionCommand
+      ? this.resolveSessionCommand(this.defaultCommand, this.config)
+      : this.defaultCommand;
     const prefix = await resolveProviderLaunch({
       commandConfig: this.runtimeSettings?.command,
-      defaultBinary: this.defaultCommand[0],
+      defaultBinary: sessionCommand[0],
     });
     const availability = await checkProviderLaunchAvailable(prefix);
     if (!availability.available) {
-      throw new Error(`${this.provider} command '${this.defaultCommand[0]}' not found`);
+      throw new Error(`${this.provider} command '${sessionCommand[0]}' not found`);
     }
 
     const command = prefix.command;
-    const args = [...prefix.args, ...this.defaultCommand.slice(1)];
+    const args = [...prefix.args, ...sessionCommand.slice(1)];
     const child = spawnProcess(command, args, {
       cwd: this.config.cwd,
       ...createProviderEnvSpec({
@@ -2388,7 +2473,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   private applySessionState(response: SessionStateResponse): void {
     const transformed = this.sessionResponseTransformer
-      ? this.sessionResponseTransformer(response)
+      ? this.sessionResponseTransformer(response, this.config)
       : response;
 
     this.configOptions = this.transformConfigOptions(transformed.configOptions ?? []);

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -1,14 +1,18 @@
 import type { Logger } from "pino";
 import { z } from "zod";
 
-import type { AgentCapabilityFlags } from "../agent-sdk-types.js";
+import type { AgentCapabilityFlags, AgentMode, AgentSessionConfig } from "../agent-sdk-types.js";
 import { checkProviderLaunchAvailable, resolveProviderLaunch } from "../provider-launch-config.js";
 import {
   ACPAgentClient,
+  type ACPBeforeModeWriteResult,
   type ACPClientCapabilityMeta,
   type ACPConfigFeatureOption,
+  type ACPProviderModeWriteResult,
+  type ACPProviderModeWriterContext,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
+  type SessionStateResponse,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -49,6 +53,20 @@ interface GenericACPAgentClientOptions {
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  defaultModes?: AgentMode[];
+  sessionResponseTransformer?: (
+    response: SessionStateResponse,
+    sessionConfig?: AgentSessionConfig,
+  ) => SessionStateResponse;
+  resolveSessionCommand?: (
+    command: [string, ...string[]],
+    config: AgentSessionConfig,
+  ) => [string, ...string[]];
+  providerModeWriter?: (
+    context: ACPProviderModeWriterContext,
+  ) => Promise<ACPProviderModeWriteResult>;
+  beforeModeWriter?: (context: ACPProviderModeWriterContext) => Promise<ACPBeforeModeWriteResult>;
+  autoApproveModeIds?: string[];
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -66,6 +84,12 @@ export class GenericACPAgentClient extends ACPAgentClient {
         env: options.env,
       },
       defaultCommand: options.command,
+      defaultModes: options.defaultModes,
+      sessionResponseTransformer: options.sessionResponseTransformer,
+      resolveSessionCommand: options.resolveSessionCommand,
+      providerModeWriter: options.providerModeWriter,
+      beforeModeWriter: options.beforeModeWriter,
+      autoApproveModeIds: options.autoApproveModeIds,
       capabilities: buildGenericACPCapabilities(providerParams),
       waitForInitialCommands: options.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: options.initialCommandsWaitTimeoutMs,

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,0 +1,330 @@
+import { expect, test, vi } from "vitest";
+import type { PermissionOption, RequestPermissionRequest } from "@agentclientprotocol/sdk";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import { asInternals } from "../../test-utils/class-mocks.js";
+import { ACPAgentSession } from "./acp-agent.js";
+import {
+  GROK_ALWAYS_APPROVE_MODE_ID,
+  GROK_ASK_MODE_ID,
+  GROK_MODES,
+  resolveGrokSessionCommand,
+  transformGrokSessionResponse,
+  withGrokAlwaysApproveLaunchFlag,
+  writeGrokProviderMode,
+} from "./grok-acp-agent.js";
+
+test("withGrokAlwaysApproveLaunchFlag injects flag after agent subcommand", () => {
+  expect(withGrokAlwaysApproveLaunchFlag(["grok", "agent", "stdio"], true)).toEqual([
+    "grok",
+    "agent",
+    "--always-approve",
+    "stdio",
+  ]);
+});
+
+test("withGrokAlwaysApproveLaunchFlag is idempotent and strips yolo aliases when disabling", () => {
+  expect(
+    withGrokAlwaysApproveLaunchFlag(["grok", "agent", "--always-approve", "stdio"], true),
+  ).toEqual(["grok", "agent", "--always-approve", "stdio"]);
+  expect(withGrokAlwaysApproveLaunchFlag(["grok", "agent", "--yolo", "stdio"], false)).toEqual([
+    "grok",
+    "agent",
+    "stdio",
+  ]);
+});
+
+test("resolveGrokSessionCommand enables launch flag only for Always Approve mode", () => {
+  expect(
+    resolveGrokSessionCommand(["grok", "agent", "stdio"], {
+      provider: "acp",
+      cwd: "/tmp",
+      modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+    }),
+  ).toEqual(["grok", "agent", "--always-approve", "stdio"]);
+  expect(
+    resolveGrokSessionCommand(["grok", "agent", "stdio"], {
+      provider: "acp",
+      cwd: "/tmp",
+      modeId: GROK_ASK_MODE_ID,
+    }),
+  ).toEqual(["grok", "agent", "stdio"]);
+});
+
+test("transformGrokSessionResponse injects Ask and Always Approve when ACP advertises no modes", () => {
+  const transformed = transformGrokSessionResponse({
+    sessionId: "session-1",
+    modes: null,
+  });
+
+  expect(transformed.modes?.availableModes?.map((mode) => mode.id)).toEqual([
+    GROK_ASK_MODE_ID,
+    GROK_ALWAYS_APPROVE_MODE_ID,
+  ]);
+  expect(transformed.modes?.currentModeId).toBe(GROK_ASK_MODE_ID);
+});
+
+test("transformGrokSessionResponse preserves configured Always Approve when injecting modes", () => {
+  const transformed = transformGrokSessionResponse(
+    {
+      sessionId: "session-1",
+      modes: null,
+    },
+    {
+      provider: "acp",
+      cwd: "/tmp",
+      modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+    },
+  );
+
+  expect(transformed.modes?.currentModeId).toBe(GROK_ALWAYS_APPROVE_MODE_ID);
+});
+
+test("transformGrokSessionResponse appends Always Approve without dropping upstream modes", () => {
+  const transformed = transformGrokSessionResponse({
+    sessionId: "session-1",
+    modes: {
+      currentModeId: "plan",
+      availableModes: [
+        {
+          id: "plan",
+          name: "Plan",
+          description: "Plan mode",
+        },
+      ],
+    },
+  });
+
+  expect(transformed.modes?.availableModes?.map((mode) => mode.id)).toEqual([
+    "plan",
+    GROK_ASK_MODE_ID,
+    GROK_ALWAYS_APPROVE_MODE_ID,
+  ]);
+  expect(transformed.modes?.currentModeId).toBe("plan");
+});
+
+test("writeGrokProviderMode enables native always-approve via slash command", async () => {
+  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+  const setSessionMode = vi.fn(async () => undefined);
+  const setSessionConfigOption = vi.fn(async () => ({ configOptions: [] }));
+
+  await expect(
+    writeGrokProviderMode({
+      connection: { prompt, setSessionMode, setSessionConfigOption } as never,
+      sessionId: "session-1",
+      requestedModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      currentModeId: GROK_ASK_MODE_ID,
+      selection: {
+        availableMode: GROK_MODES[1] ?? null,
+        configOption: null,
+        configChoice: null,
+        hasAvailableModes: true,
+      },
+      configOptions: [],
+      logger: createTestLogger(),
+    }),
+  ).resolves.toEqual({
+    handled: true,
+    currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+  });
+
+  expect(prompt).toHaveBeenCalledWith({
+    sessionId: "session-1",
+    prompt: [{ type: "text", text: "/always-approve on" }],
+  });
+  expect(setSessionMode).not.toHaveBeenCalled();
+  expect(setSessionConfigOption).not.toHaveBeenCalled();
+});
+
+test("writeGrokProviderMode disables native always-approve when switching to Ask", async () => {
+  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+
+  await expect(
+    writeGrokProviderMode({
+      connection: { prompt } as never,
+      sessionId: "session-1",
+      requestedModeId: GROK_ASK_MODE_ID,
+      currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      selection: {
+        availableMode: GROK_MODES[0] ?? null,
+        configOption: null,
+        configChoice: null,
+        hasAvailableModes: true,
+      },
+      configOptions: [],
+      logger: createTestLogger(),
+    }),
+  ).resolves.toEqual({
+    handled: true,
+    currentModeId: GROK_ASK_MODE_ID,
+  });
+
+  expect(prompt).toHaveBeenCalledWith({
+    sessionId: "session-1",
+    prompt: [{ type: "text", text: "/always-approve off" }],
+  });
+});
+
+test("writeGrokProviderMode does not re-prompt when already in the requested mode", async () => {
+  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+
+  await expect(
+    writeGrokProviderMode({
+      connection: { prompt } as never,
+      sessionId: "session-1",
+      requestedModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      selection: {
+        availableMode: GROK_MODES[1] ?? null,
+        configOption: null,
+        configChoice: null,
+        hasAvailableModes: true,
+      },
+      configOptions: [],
+      logger: createTestLogger(),
+    }),
+  ).resolves.toEqual({
+    handled: true,
+    currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+  });
+
+  expect(prompt).not.toHaveBeenCalled();
+});
+
+test("writeGrokProviderMode leaves unknown ACP modes to the generic path", async () => {
+  await expect(
+    writeGrokProviderMode({
+      connection: {} as never,
+      sessionId: "session-1",
+      requestedModeId: "plan",
+      currentModeId: GROK_ASK_MODE_ID,
+      selection: {
+        availableMode: { id: "plan", label: "Plan" },
+        configOption: null,
+        configChoice: null,
+        hasAvailableModes: true,
+      },
+      configOptions: [],
+      logger: createTestLogger(),
+    }),
+  ).resolves.toEqual({ handled: false });
+});
+
+test("Always Approve fallback auto-approves ACP permission requests without UI events", async () => {
+  const session = new ACPAgentSession(
+    {
+      provider: "acp",
+      cwd: "/tmp/paseo-grok-test",
+      modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+    },
+    {
+      provider: "acp",
+      logger: createTestLogger(),
+      defaultCommand: ["grok", "agent", "stdio"],
+      defaultModes: GROK_MODES,
+      autoApproveModeIds: [GROK_ALWAYS_APPROVE_MODE_ID],
+      providerModeWriter: writeGrokProviderMode,
+      sessionResponseTransformer: transformGrokSessionResponse,
+      resolveSessionCommand: resolveGrokSessionCommand,
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+    },
+  );
+
+  const events: Array<{ type: string }> = [];
+  session.subscribe((event) => {
+    events.push(event);
+  });
+
+  asInternals<{
+    sessionId: string | null;
+    currentMode: string | null;
+    availableModes: typeof GROK_MODES;
+  }>(session).sessionId = "session-1";
+  asInternals<{ currentMode: string | null }>(session).currentMode = GROK_ALWAYS_APPROVE_MODE_ID;
+
+  const permissionOptions: PermissionOption[] = [
+    { optionId: "allow-once", name: "Allow", kind: "allow_once" },
+    { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+  ];
+
+  await expect(
+    session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "tool-1",
+        title: "Run shell",
+        kind: "execute",
+        status: "pending",
+      },
+      options: permissionOptions,
+    } satisfies RequestPermissionRequest),
+  ).resolves.toEqual({
+    outcome: { outcome: "selected", optionId: "allow-once" },
+  });
+
+  expect(events.some((event) => event.type === "permission_requested")).toBe(false);
+});
+
+test("Ask mode still surfaces ACP permission requests", async () => {
+  const session = new ACPAgentSession(
+    {
+      provider: "acp",
+      cwd: "/tmp/paseo-grok-test",
+      modeId: GROK_ASK_MODE_ID,
+    },
+    {
+      provider: "acp",
+      logger: createTestLogger(),
+      defaultCommand: ["grok", "agent", "stdio"],
+      defaultModes: GROK_MODES,
+      autoApproveModeIds: [GROK_ALWAYS_APPROVE_MODE_ID],
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+    },
+  );
+
+  const events: Array<{ type: string; request?: { id: string } }> = [];
+  session.subscribe((event) => {
+    events.push(event as { type: string; request?: { id: string } });
+  });
+
+  asInternals<{ sessionId: string | null; currentMode: string | null }>(session).sessionId =
+    "session-1";
+  asInternals<{ currentMode: string | null }>(session).currentMode = GROK_ASK_MODE_ID;
+
+  const permission = session.requestPermission({
+    sessionId: "session-1",
+    toolCall: {
+      toolCallId: "tool-2",
+      title: "Edit file",
+      kind: "edit",
+      status: "pending",
+    },
+    options: [
+      { optionId: "allow-once", name: "Allow", kind: "allow_once" },
+      { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+    ],
+  } satisfies RequestPermissionRequest);
+
+  await Promise.resolve();
+  const requested = events.find((event) => event.type === "permission_requested");
+  expect(requested?.request?.id).toEqual(expect.any(String));
+
+  await session.respondToPermission(requested!.request!.id, { behavior: "allow" });
+  await expect(permission).resolves.toEqual({
+    outcome: { outcome: "selected", optionId: "allow-once" },
+  });
+});

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,9 +1,13 @@
-import { expect, test, vi } from "vitest";
+import { expect, test } from "vitest";
 import type { PermissionOption, RequestPermissionRequest } from "@agentclientprotocol/sdk";
 
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { asInternals } from "../../test-utils/class-mocks.js";
-import { ACPAgentSession } from "./acp-agent.js";
+import {
+  isDefaultAgentCreateConfigUnattended,
+  resolveDefaultAgentCreateConfig,
+} from "../create-agent-mode.js";
+import { ACPAgentSession, deriveModesFromACP } from "./acp-agent.js";
 import {
   GROK_ALWAYS_APPROVE_MODE_ID,
   GROK_ASK_MODE_ID,
@@ -13,6 +17,55 @@ import {
   withGrokAlwaysApproveLaunchFlag,
   writeGrokProviderMode,
 } from "./grok-acp-agent.js";
+
+function createRecordingGrokConnection() {
+  const prompts: Array<{ sessionId: string; prompt: Array<{ type: string; text: string }> }> = [];
+  const sessionModeCalls: unknown[] = [];
+  const configOptionCalls: unknown[] = [];
+
+  return {
+    prompts,
+    sessionModeCalls,
+    configOptionCalls,
+    connection: {
+      prompt: async (params: {
+        sessionId: string;
+        prompt: Array<{ type: string; text: string }>;
+      }) => {
+        prompts.push(params);
+        return { stopReason: "end_turn" };
+      },
+      setSessionMode: async (params: unknown) => {
+        sessionModeCalls.push(params);
+      },
+      setSessionConfigOption: async (params: unknown) => {
+        configOptionCalls.push(params);
+        return { configOptions: [] };
+      },
+    },
+  };
+}
+
+test("GROK_MODES is the full canonical definition including visuals and unattended", () => {
+  expect(GROK_MODES).toEqual([
+    {
+      id: GROK_ASK_MODE_ID,
+      label: "Ask",
+      description: "Prompt before shell and tool executions",
+      icon: "ShieldCheck",
+      colorTier: "safe",
+    },
+    {
+      id: GROK_ALWAYS_APPROVE_MODE_ID,
+      label: "Always Approve",
+      description:
+        "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
+      icon: "ShieldOff",
+      colorTier: "dangerous",
+      isUnattended: true,
+    },
+  ]);
+});
 
 test("withGrokAlwaysApproveLaunchFlag injects flag after agent subcommand", () => {
   expect(withGrokAlwaysApproveLaunchFlag(["grok", "agent", "stdio"], true)).toEqual([
@@ -103,14 +156,93 @@ test("transformGrokSessionResponse appends Always Approve without dropping upstr
   expect(transformed.modes?.currentModeId).toBe("plan");
 });
 
+test("transform + deriveModesFromACP keeps Always Approve unattended and visual metadata", () => {
+  const transformed = transformGrokSessionResponse(
+    {
+      sessionId: "session-1",
+      modes: null,
+    },
+    {
+      provider: "acp",
+      cwd: "/tmp",
+      modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+    },
+  );
+
+  const derived = deriveModesFromACP(GROK_MODES, transformed.modes);
+
+  expect(derived.currentModeId).toBe(GROK_ALWAYS_APPROVE_MODE_ID);
+  expect(derived.modes).toEqual([
+    {
+      id: GROK_ASK_MODE_ID,
+      label: "Ask",
+      description: "Prompt before shell and tool executions",
+      icon: "ShieldCheck",
+      colorTier: "safe",
+    },
+    {
+      id: GROK_ALWAYS_APPROVE_MODE_ID,
+      label: "Always Approve",
+      description:
+        "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
+      icon: "ShieldOff",
+      colorTier: "dangerous",
+      isUnattended: true,
+    },
+  ]);
+});
+
+test("derived session modes mark Always Approve as unattended for create-config inheritance", () => {
+  const transformed = transformGrokSessionResponse({
+    sessionId: "session-1",
+    modes: null,
+  });
+  const availableModes = deriveModesFromACP(GROK_MODES, transformed.modes).modes;
+
+  expect(
+    isDefaultAgentCreateConfigUnattended({
+      modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      availableModes,
+      config: {
+        provider: "acp",
+        cwd: "/tmp",
+        modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      },
+      features: [],
+    }),
+  ).toBe(true);
+
+  expect(
+    isDefaultAgentCreateConfigUnattended({
+      modeId: GROK_ASK_MODE_ID,
+      availableModes,
+      config: {
+        provider: "acp",
+        cwd: "/tmp",
+        modeId: GROK_ASK_MODE_ID,
+      },
+      features: [],
+    }),
+  ).toBe(false);
+
+  // Unattended create needs the unattended mode id from availableModes.
+  const resolved = resolveDefaultAgentCreateConfig({
+    provider: "acp",
+    requestedMode: undefined,
+    unattended: true,
+    availableModes,
+    parent: null,
+    featureValues: undefined,
+  });
+  expect(resolved.modeId).toBe(GROK_ALWAYS_APPROVE_MODE_ID);
+});
+
 test("writeGrokProviderMode enables native always-approve via slash command", async () => {
-  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
-  const setSessionMode = vi.fn(async () => undefined);
-  const setSessionConfigOption = vi.fn(async () => ({ configOptions: [] }));
+  const recording = createRecordingGrokConnection();
 
   await expect(
     writeGrokProviderMode({
-      connection: { prompt, setSessionMode, setSessionConfigOption } as never,
+      connection: recording.connection as never,
       sessionId: "session-1",
       requestedModeId: GROK_ALWAYS_APPROVE_MODE_ID,
       currentModeId: GROK_ASK_MODE_ID,
@@ -128,20 +260,22 @@ test("writeGrokProviderMode enables native always-approve via slash command", as
     currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
   });
 
-  expect(prompt).toHaveBeenCalledWith({
-    sessionId: "session-1",
-    prompt: [{ type: "text", text: "/always-approve on" }],
-  });
-  expect(setSessionMode).not.toHaveBeenCalled();
-  expect(setSessionConfigOption).not.toHaveBeenCalled();
+  expect(recording.prompts).toEqual([
+    {
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "/always-approve on" }],
+    },
+  ]);
+  expect(recording.sessionModeCalls).toEqual([]);
+  expect(recording.configOptionCalls).toEqual([]);
 });
 
 test("writeGrokProviderMode disables native always-approve when switching to Ask", async () => {
-  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+  const recording = createRecordingGrokConnection();
 
   await expect(
     writeGrokProviderMode({
-      connection: { prompt } as never,
+      connection: recording.connection as never,
       sessionId: "session-1",
       requestedModeId: GROK_ASK_MODE_ID,
       currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
@@ -159,18 +293,20 @@ test("writeGrokProviderMode disables native always-approve when switching to Ask
     currentModeId: GROK_ASK_MODE_ID,
   });
 
-  expect(prompt).toHaveBeenCalledWith({
-    sessionId: "session-1",
-    prompt: [{ type: "text", text: "/always-approve off" }],
-  });
+  expect(recording.prompts).toEqual([
+    {
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "/always-approve off" }],
+    },
+  ]);
 });
 
 test("writeGrokProviderMode does not re-prompt when already in the requested mode", async () => {
-  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+  const recording = createRecordingGrokConnection();
 
   await expect(
     writeGrokProviderMode({
-      connection: { prompt } as never,
+      connection: recording.connection as never,
       sessionId: "session-1",
       requestedModeId: GROK_ALWAYS_APPROVE_MODE_ID,
       currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
@@ -188,7 +324,7 @@ test("writeGrokProviderMode does not re-prompt when already in the requested mod
     currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
   });
 
-  expect(prompt).not.toHaveBeenCalled();
+  expect(recording.prompts).toEqual([]);
 });
 
 test("writeGrokProviderMode leaves unknown ACP modes to the generic path", async () => {

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,0 +1,199 @@
+import type { Logger } from "pino";
+
+import type { AgentMode, AgentSessionConfig } from "../agent-sdk-types.js";
+import {
+  type ACPProviderModeWriteResult,
+  type ACPProviderModeWriterContext,
+  type SessionStateResponse,
+} from "./acp-agent.js";
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+/** Ask before tool executions — Grok's interactive default (`permission_mode = "ask"`). */
+export const GROK_ASK_MODE_ID = "ask";
+
+/**
+ * Grok's native unattended permission mode.
+ * Matches CLI `--always-approve` / `--yolo` and config `permission_mode = "always-approve"`.
+ * Grok does not advertise this as an ACP session mode; Paseo maps it onto the native
+ * launch flag and the `/always-approve on|off` available command.
+ */
+export const GROK_ALWAYS_APPROVE_MODE_ID = "always-approve";
+
+const GROK_ALWAYS_APPROVE_LAUNCH_FLAGS = new Set(["--always-approve", "--yolo"]);
+
+export const GROK_MODES: AgentMode[] = [
+  {
+    id: GROK_ASK_MODE_ID,
+    label: "Ask",
+    description: "Prompt before shell and tool executions",
+  },
+  {
+    id: GROK_ALWAYS_APPROVE_MODE_ID,
+    label: "Always Approve",
+    description:
+      "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
+    isUnattended: true,
+  },
+];
+
+interface GrokACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+/**
+ * Grok is installed from the ACP catalog as `grok agent stdio`. Grok's permission
+ * modes are not ACP session modes — they are process/session settings controlled by:
+ *   - `grok agent --always-approve stdio` (session launch)
+ *   - `/always-approve on|off` (in-session available command)
+ *   - `~/.grok/config.toml` `[ui] permission_mode` (user global; not used here)
+ *
+ * Paseo surfaces Ask / Always Approve in the mode picker, drives Grok through those
+ * native paths, and keeps a client-side auto-approve fallback if Grok still emits
+ * `session/request_permission` while Always Approve is selected.
+ */
+export class GrokACPAgentClient extends GenericACPAgentClient {
+  constructor(options: GrokACPAgentClientOptions) {
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId ?? "grok",
+      label: options.label ?? "Grok",
+      providerParams: options.providerParams,
+      defaultModes: GROK_MODES,
+      sessionResponseTransformer: transformGrokSessionResponse,
+      resolveSessionCommand: resolveGrokSessionCommand,
+      providerModeWriter: writeGrokProviderMode,
+      // Fallback only: when Grok is correctly in always-approve it does not call
+      // session/request_permission. This covers races / older Grok builds.
+      autoApproveModeIds: [GROK_ALWAYS_APPROVE_MODE_ID],
+    });
+  }
+}
+
+/**
+ * Inject or strip Grok's native `--always-approve` launch flag.
+ * Catalog command is `["grok", "agent", "stdio"]` → `["grok", "agent", "--always-approve", "stdio"]`.
+ */
+export function withGrokAlwaysApproveLaunchFlag(
+  command: [string, ...string[]],
+  enabled: boolean,
+): [string, ...string[]] {
+  const [binary, ...args] = command;
+  const withoutFlags = args.filter((arg) => !GROK_ALWAYS_APPROVE_LAUNCH_FLAGS.has(arg));
+  if (!enabled) {
+    return withoutFlags.length > 0
+      ? ([binary, ...withoutFlags] as [string, ...string[]])
+      : [binary];
+  }
+
+  const agentIndex = withoutFlags.indexOf("agent");
+  if (agentIndex >= 0) {
+    const next = [...withoutFlags];
+    next.splice(agentIndex + 1, 0, "--always-approve");
+    return [binary, ...next] as [string, ...string[]];
+  }
+
+  const stdioIndex = withoutFlags.lastIndexOf("stdio");
+  if (stdioIndex >= 0) {
+    const next = [...withoutFlags];
+    next.splice(stdioIndex, 0, "--always-approve");
+    return [binary, ...next] as [string, ...string[]];
+  }
+
+  return [binary, "--always-approve", ...withoutFlags] as [string, ...string[]];
+}
+
+export function resolveGrokSessionCommand(
+  command: [string, ...string[]],
+  config: AgentSessionConfig,
+): [string, ...string[]] {
+  return withGrokAlwaysApproveLaunchFlag(command, config.modeId === GROK_ALWAYS_APPROVE_MODE_ID);
+}
+
+function isGrokPermissionModeId(modeId: string | null | undefined): modeId is string {
+  return modeId === GROK_ASK_MODE_ID || modeId === GROK_ALWAYS_APPROVE_MODE_ID;
+}
+
+export function transformGrokSessionResponse(
+  response: SessionStateResponse,
+  sessionConfig?: AgentSessionConfig,
+): SessionStateResponse {
+  const upstreamModes = response.modes?.availableModes ?? [];
+  const upstreamIds = new Set(upstreamModes.map((mode) => mode.id));
+  const syntheticModes = GROK_MODES.filter((mode) => !upstreamIds.has(mode.id)).map((mode) => ({
+    id: mode.id,
+    name: mode.label,
+    description: mode.description ?? null,
+  }));
+  const preferredModeId = isGrokPermissionModeId(sessionConfig?.modeId)
+    ? sessionConfig.modeId
+    : GROK_ASK_MODE_ID;
+
+  if (upstreamModes.length === 0) {
+    return {
+      ...response,
+      modes: {
+        availableModes: GROK_MODES.map((mode) => ({
+          id: mode.id,
+          name: mode.label,
+          description: mode.description ?? null,
+        })),
+        // Prefer the session's configured Paseo mode so Always Approve at create
+        // time is not rewritten to Ask before applyConfiguredOverrides.
+        currentModeId: response.modes?.currentModeId ?? preferredModeId,
+      },
+    };
+  }
+
+  return {
+    ...response,
+    modes: {
+      ...response.modes,
+      availableModes: [...upstreamModes, ...syntheticModes],
+      // SessionModeState.currentModeId is a required string in the ACP schema.
+      currentModeId: response.modes?.currentModeId ?? upstreamModes[0]?.id ?? preferredModeId,
+    },
+  };
+}
+
+/**
+ * Drive Grok's native in-session permission toggle via the documented
+ * `/always-approve on|off` available command (not ACP setSessionMode).
+ */
+export async function writeGrokProviderMode(
+  context: ACPProviderModeWriterContext,
+): Promise<ACPProviderModeWriteResult> {
+  if (context.requestedModeId === GROK_ALWAYS_APPROVE_MODE_ID) {
+    if (context.currentModeId !== GROK_ALWAYS_APPROVE_MODE_ID) {
+      await context.connection.prompt({
+        sessionId: context.sessionId,
+        prompt: [{ type: "text", text: "/always-approve on" }],
+      });
+    }
+    return {
+      handled: true,
+      currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+    };
+  }
+
+  if (context.requestedModeId === GROK_ASK_MODE_ID) {
+    if (context.currentModeId === GROK_ALWAYS_APPROVE_MODE_ID) {
+      await context.connection.prompt({
+        sessionId: context.sessionId,
+        prompt: [{ type: "text", text: "/always-approve off" }],
+      });
+    }
+    return {
+      handled: true,
+      currentModeId: GROK_ASK_MODE_ID,
+    };
+  }
+
+  return { handled: false };
+}

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -21,17 +21,26 @@ export const GROK_ALWAYS_APPROVE_MODE_ID = "always-approve";
 
 const GROK_ALWAYS_APPROVE_LAUNCH_FLAGS = new Set(["--always-approve", "--yolo"]);
 
+/**
+ * Single source of truth for Grok session + provider-definition modes.
+ * Keep icon/colorTier/isUnattended here so registry definition and runtime
+ * availableModes stay aligned after ACP mode derivation.
+ */
 export const GROK_MODES: AgentMode[] = [
   {
     id: GROK_ASK_MODE_ID,
     label: "Ask",
     description: "Prompt before shell and tool executions",
+    icon: "ShieldCheck",
+    colorTier: "safe",
   },
   {
     id: GROK_ALWAYS_APPROVE_MODE_ID,
     label: "Always Approve",
     description:
       "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
+    icon: "ShieldOff",
+    colorTier: "dangerous",
     isUnattended: true,
   },
 ];

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,6 +1,7 @@
 import type { Logger } from "pino";
+import type { AgentProviderModeDefinition } from "@getpaseo/protocol/provider-manifest";
 
-import type { AgentMode, AgentSessionConfig } from "../agent-sdk-types.js";
+import type { AgentSessionConfig } from "../agent-sdk-types.js";
 import {
   type ACPProviderModeWriteResult,
   type ACPProviderModeWriterContext,
@@ -23,10 +24,10 @@ const GROK_ALWAYS_APPROVE_LAUNCH_FLAGS = new Set(["--always-approve", "--yolo"])
 
 /**
  * Single source of truth for Grok session + provider-definition modes.
- * Keep icon/colorTier/isUnattended here so registry definition and runtime
- * availableModes stay aligned after ACP mode derivation.
+ * Typed as AgentProviderModeDefinition so registry.modes (required icon/colorTier)
+ * and session defaultModes stay one list.
  */
-export const GROK_MODES: AgentMode[] = [
+export const GROK_MODES: AgentProviderModeDefinition[] = [
   {
     id: GROK_ASK_MODE_ID,
     label: "Ask",


### PR DESCRIPTION
## Summary

- Grok catalog ACP sessions (`grok agent stdio`) never advertised permission modes, so Paseo showed no Ask / Always Approve picker and every gated tool call blocked on Accept/Deny.
- Wire Paseo session modes to **Grok's documented native controls** (not client-only auto-click):
  - Launch Always Approve sessions as `grok agent --always-approve stdio`
  - Mid-session switch via `/always-approve on|off`
  - Keep a client-side `request_permission` auto-approve fallback for races / older Grok builds
- Does **not** rewrite `~/.grok/config.toml` (that is a user-global default, not a per-session control).

Closes #2053

## Why this shape

Grok ACP `session/new` returns `modes: null`. Permission behavior is controlled by process/session settings (`--always-approve`, `/always-approve`, or global config), not ACP `setSessionMode`. Verified locally: with ask config, `session/request_permission` fires; with `--always-approve` or `/always-approve on`, it does not.

## Security note

Always Approve is marked `isUnattended` / dangerous. It auto-approves potentially destructive shell and file operations for that session only.

## Test plan

- [x] `npx vitest run packages/server/src/server/agent/providers/grok-acp-agent.test.ts --bail=1` (12/12)
- [x] Related ACP permission / registry tests
- [x] Lint + format on touched files
- [ ] CI
- [ ] Manual: create Grok agent → mode picker shows Ask / Always Approve → Always Approve runs tools without permission cards → switch back to Ask restores prompts