### PR TITLE
feat: Add an Allow All mode that auto-approves Cursor ACP permission prompts

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -18,6 +18,8 @@ import {
 import {
   ACPAgentClient,
   ACPAgentSession,
+  type ACPProviderModeWriterContext,
+  type ACPProviderModeWriteResult,
   type SpawnedACPProcess,
   type SessionStateResponse,
   buildACPClientCapabilities,
@@ -45,7 +47,11 @@ import { GenericACPAgentClient } from "./generic-acp-agent.js";
 import { parseKiroExtensionCommands } from "./kiro-acp-agent.js";
 import { transformPiModels } from "./pi/agent.js";
 import type { AgentStreamEvent } from "../agent-sdk-types.js";
-import type { AgentCapabilityFlags, AgentPersistenceHandle } from "../agent-sdk-types.js";
+import type {
+  AgentCapabilityFlags,
+  AgentMode,
+  AgentPersistenceHandle,
+} from "../agent-sdk-types.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { buildStringCommandShellInvocation } from "../../../utils/string-command-shell.js";
 import { asInternals } from "../../test-utils/class-mocks.js";
@@ -294,6 +300,48 @@ function createCopilotSessionWithConfig(
       modeIdTransformer: transformCopilotModeId,
       providerModeWriter: writeCopilotProviderMode,
       beforeModeWriter: beforeCopilotModeWriter,
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+    },
+  );
+}
+
+const SYNTHETIC_ALLOW_ALL_MODE: AgentMode = {
+  id: "synthetic-allow-all",
+  label: "Allow All",
+  isUnattended: true,
+};
+
+async function writeSyntheticProviderMode(
+  context: ACPProviderModeWriterContext,
+): Promise<ACPProviderModeWriteResult> {
+  if (context.requestedModeId !== SYNTHETIC_ALLOW_ALL_MODE.id) {
+    return { handled: false };
+  }
+  return { handled: true, currentModeId: context.requestedModeId };
+}
+
+function createSyntheticModeSessionWithConfig(modeId?: string | null): ACPAgentSession {
+  return new ACPAgentSession(
+    {
+      provider: "acp",
+      cwd: "/tmp/paseo-acp-test",
+      modeId: modeId ?? undefined,
+    },
+    {
+      provider: "acp",
+      logger: createTestLogger(),
+      defaultCommand: ["mock-acp-agent", "acp"],
+      defaultModes: [],
+      syntheticModes: [SYNTHETIC_ALLOW_ALL_MODE],
+      autoApprovePermissionModeIds: [SYNTHETIC_ALLOW_ALL_MODE.id],
+      providerModeWriter: writeSyntheticProviderMode,
       capabilities: {
         supportsStreaming: true,
         supportsSessionPersistence: true,
@@ -1150,6 +1198,204 @@ describe("ACPAgentSession Zed parity", () => {
     await expect(permission).resolves.toEqual({
       outcome: { outcome: "selected", optionId: "allow-once" },
     });
+  });
+
+  test("auto-approves permission requests in an auto-approve synthetic mode without prompting", async () => {
+    const session = createSyntheticModeSessionWithConfig(SYNTHETIC_ALLOW_ALL_MODE.id);
+    const events: Array<{ type: string }> = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event as { type: string }));
+
+    await expect(
+      session.requestPermission({
+        sessionId: "session-1",
+        toolCall: {
+          toolCallId: "tool-1",
+          title: "Web search",
+          kind: "search",
+          status: "pending",
+        },
+        options: [
+          { optionId: "allow-once", name: "Allow", kind: "allow_once" },
+          { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+        ],
+      } satisfies RequestPermissionRequest),
+    ).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "allow-once" },
+    });
+
+    expect(events.some((event) => event.type === "permission_requested")).toBe(false);
+  });
+
+  test("keeps prompting in a native agent-reported mode", async () => {
+    const session = createSyntheticModeSessionWithConfig("agent");
+    const events: Array<{ type: string; request?: { id: string } }> = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => {
+      events.push(event as { type: string; request?: { id: string } });
+    });
+
+    const permission = session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "tool-1",
+        title: "Run command",
+        kind: "execute",
+        status: "pending",
+      },
+      options: [
+        { optionId: "allow-once", name: "Allow", kind: "allow_once" },
+        { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+      ],
+    } satisfies RequestPermissionRequest);
+    let settled = false;
+    void permission.finally(() => {
+      settled = true;
+    });
+
+    // Flush a full macrotask so a wrongly auto-resolved promise's .finally
+    // would have fired before the settled assertion below.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const requested = events.find((event) => event.type === "permission_requested");
+    expect(requested?.request?.id).toEqual(expect.any(String));
+    expect(settled).toBe(false);
+    expect(session.getPendingPermissions()).toHaveLength(1);
+
+    await session.respondToPermission(requested!.request!.id, { behavior: "allow" });
+    await expect(permission).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "allow-once" },
+    });
+  });
+
+  test("falls back to prompting when the auto-approve mode has no allow option", async () => {
+    const session = createSyntheticModeSessionWithConfig(SYNTHETIC_ALLOW_ALL_MODE.id);
+    const events: Array<{ type: string; request?: { id: string } }> = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => {
+      events.push(event as { type: string; request?: { id: string } });
+    });
+
+    const permission = session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "tool-1",
+        title: "Run command",
+        kind: "execute",
+        status: "pending",
+      },
+      options: [{ optionId: "reject-once", name: "Reject", kind: "reject_once" }],
+    } satisfies RequestPermissionRequest);
+    let settled = false;
+    void permission.finally(() => {
+      settled = true;
+    });
+
+    // Flush a full macrotask so a wrongly auto-resolved promise's .finally
+    // would have fired before the settled assertion below.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const requested = events.find((event) => event.type === "permission_requested");
+    expect(requested?.request?.id).toEqual(expect.any(String));
+    expect(settled).toBe(false);
+    expect(session.getPendingPermissions()).toHaveLength(1);
+
+    await session.respondToPermission(requested!.request!.id, { behavior: "deny" });
+    await expect(permission).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "reject-once" },
+    });
+  });
+
+  test("switches synthetic modes locally without ACP writes", async () => {
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({ configOptions: [] }));
+    const session = createSyntheticModeSessionWithConfig();
+    const internals = asInternals<ACPConfiguredOverrideInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+    const events: AgentStreamEvent[] = [];
+    const unsubscribe = session.subscribe((event) => events.push(event));
+
+    await session.setMode(SYNTHETIC_ALLOW_ALL_MODE.id);
+    unsubscribe();
+
+    expect(setSessionMode).not.toHaveBeenCalled();
+    expect(setSessionConfigOption).not.toHaveBeenCalled();
+    await expect(session.getCurrentMode()).resolves.toBe(SYNTHETIC_ALLOW_ALL_MODE.id);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "mode_changed",
+        currentModeId: SYNTHETIC_ALLOW_ALL_MODE.id,
+      }),
+    );
+
+    await expect(
+      session.requestPermission({
+        sessionId: "session-1",
+        toolCall: {
+          toolCallId: "tool-2",
+          title: "Edit file",
+          kind: "edit",
+          status: "pending",
+        },
+        options: [
+          { optionId: "allow-once", name: "Allow", kind: "allow_once" },
+          { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+        ],
+      } satisfies RequestPermissionRequest),
+    ).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "allow-once" },
+    });
+  });
+
+  test("keeps native mode switching on the ACP path alongside a synthetic mode", async () => {
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({ configOptions: [] }));
+    const session = createSyntheticModeSessionWithConfig();
+    const internals = asInternals<
+      ACPConfiguredOverrideInternals & { availableModes: AgentStreamEvent[] }
+    >(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+    asInternals<{ availableModes: unknown[] }>(session).availableModes = [
+      { id: "agent", label: "Agent" },
+      { id: "plan", label: "Plan" },
+      { id: SYNTHETIC_ALLOW_ALL_MODE.id, label: "Allow All", isUnattended: true },
+    ];
+
+    await session.setMode(SYNTHETIC_ALLOW_ALL_MODE.id);
+    expect(setSessionMode).not.toHaveBeenCalled();
+    await expect(session.getCurrentMode()).resolves.toBe(SYNTHETIC_ALLOW_ALL_MODE.id);
+
+    await session.setMode("plan");
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "plan" });
+    await expect(session.getCurrentMode()).resolves.toBe("plan");
+  });
+
+  test("keeps a synthetic mode active across config-option echoes of the native mode", async () => {
+    const session = createSyntheticModeSessionWithConfig(SYNTHETIC_ALLOW_ALL_MODE.id);
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-1";
+
+    internals.translateSessionUpdate({
+      sessionUpdate: "config_option_update",
+      configOptions: [selectConfigOption("mode", ["agent", "plan"], "agent")],
+    } as SessionUpdate);
+
+    await expect(session.getCurrentMode()).resolves.toBe(SYNTHETIC_ALLOW_ALL_MODE.id);
+  });
+
+  test("lets an explicit agent mode change switch out of a synthetic mode", async () => {
+    const session = createSyntheticModeSessionWithConfig(SYNTHETIC_ALLOW_ALL_MODE.id);
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-1";
+
+    internals.translateSessionUpdate({
+      sessionUpdate: "current_mode_update",
+      currentModeId: "plan",
+    } as SessionUpdate);
+
+    await expect(session.getCurrentMode()).resolves.toBe("plan");
   });
 
   test("maps Copilot Allow All mode to allow_all ACP config on session start", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1353,15 +1353,27 @@ describe("ACPAgentSession Zed parity", () => {
     const setSessionConfigOption = vi.fn(async () => ({ configOptions: [] }));
     const session = createSyntheticModeSessionWithConfig();
     const internals = asInternals<
-      ACPConfiguredOverrideInternals & { availableModes: AgentStreamEvent[] }
+      ACPConfiguredOverrideInternals & {
+        applySessionState(response: SessionStateResponse): void;
+      }
     >(session);
     internals.sessionId = "session-1";
     internals.connection = { setSessionMode, setSessionConfigOption };
-    asInternals<{ availableModes: unknown[] }>(session).availableModes = [
-      { id: "agent", label: "Agent" },
-      { id: "plan", label: "Plan" },
-      { id: SYNTHETIC_ALLOW_ALL_MODE.id, label: "Allow All", isUnattended: true },
-    ];
+    internals.applySessionState({
+      sessionId: "session-1",
+      modes: {
+        currentModeId: "agent",
+        availableModes: [
+          { id: "agent", name: "Agent", description: null },
+          { id: "plan", name: "Plan", description: null },
+        ],
+      },
+      configOptions: [],
+    });
+
+    await expect(session.getAvailableModes()).resolves.toContainEqual(
+      expect.objectContaining({ id: SYNTHETIC_ALLOW_ALL_MODE.id, isUnattended: true }),
+    );
 
     await session.setMode(SYNTHETIC_ALLOW_ALL_MODE.id);
     expect(setSessionMode).not.toHaveBeenCalled();
@@ -1390,11 +1402,16 @@ describe("ACPAgentSession Zed parity", () => {
     const internals = asInternals<ACPSessionInternals>(session);
     internals.sessionId = "session-1";
 
-    internals.translateSessionUpdate({
+    const events = internals.translateSessionUpdate({
       sessionUpdate: "current_mode_update",
       currentModeId: "plan",
     } as SessionUpdate);
 
+    // The switch out of the synthetic mode is announced immediately so the
+    // mode picker cannot keep showing it while auto-approve is inactive.
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "mode_changed", currentModeId: "plan" }),
+    );
     await expect(session.getCurrentMode()).resolves.toBe("plan");
   });
 

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -372,6 +372,14 @@ interface ACPAgentClientOptions {
   runtimeSettings?: ProviderRuntimeSettings;
   defaultCommand: [string, ...string[]];
   defaultModes?: AgentMode[];
+  // Paseo-owned modes appended to the agent-reported mode list (only when the
+  // agent reports any). Selection must be handled locally via providerModeWriter.
+  // An active synthetic mode survives config-option echoes of the native mode,
+  // but an explicit current_mode_update from the agent still switches out of it.
+  syntheticModes?: AgentMode[];
+  // Mode ids whose permission requests Paseo auto-approves client-side, for
+  // agents (e.g. cursor-agent) with no native ACP allow-all mode or config.
+  autoApprovePermissionModeIds?: string[];
   modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
   configOptionsTransformer?: (configOptions: SessionConfigOption[]) => SessionConfigOption[];
@@ -402,6 +410,8 @@ interface ACPAgentSessionOptions {
   runtimeSettings?: ProviderRuntimeSettings;
   defaultCommand: [string, ...string[]];
   defaultModes: AgentMode[];
+  syntheticModes?: AgentMode[];
+  autoApprovePermissionModeIds?: string[];
   modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
   configOptionsTransformer?: (configOptions: SessionConfigOption[]) => SessionConfigOption[];
@@ -606,6 +616,17 @@ export function resolveACPModelSelection({
   };
 }
 
+// Synthetic modes only extend a non-empty agent-reported list: with no native
+// modes there is no mode picker, and a picker offering only synthetic entries
+// would have no way back to normal operation.
+function appendSyntheticModes(modes: AgentMode[], syntheticModes: AgentMode[]): AgentMode[] {
+  if (syntheticModes.length === 0 || modes.length === 0) {
+    return modes;
+  }
+  const existingIds = new Set(modes.map((mode) => mode.id));
+  return [...modes, ...syntheticModes.filter((mode) => !existingIds.has(mode.id))];
+}
+
 export function deriveModesFromACP(
   fallbackModes: AgentMode[],
   modeState?: { availableModes?: SessionMode[] | null; currentModeId?: string | null } | null,
@@ -707,6 +728,8 @@ export class ACPAgentClient implements AgentClient {
   protected readonly runtimeSettings?: ProviderRuntimeSettings;
   protected readonly defaultCommand: [string, ...string[]];
   protected readonly defaultModes: AgentMode[];
+  private readonly syntheticModes: AgentMode[];
+  private readonly autoApprovePermissionModeIds: string[];
   private readonly modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   private readonly sessionResponseTransformer?: (
     response: SessionStateResponse,
@@ -746,6 +769,8 @@ export class ACPAgentClient implements AgentClient {
     this.runtimeSettings = options.runtimeSettings;
     this.defaultCommand = options.defaultCommand;
     this.defaultModes = options.defaultModes ?? [];
+    this.syntheticModes = options.syntheticModes ?? [];
+    this.autoApprovePermissionModeIds = options.autoApprovePermissionModeIds ?? [];
     this.modelTransformer = options.modelTransformer;
     this.sessionResponseTransformer = options.sessionResponseTransformer;
     this.configOptionsTransformer = options.configOptionsTransformer;
@@ -775,6 +800,8 @@ export class ACPAgentClient implements AgentClient {
         runtimeSettings: this.runtimeSettings,
         defaultCommand: this.defaultCommand,
         defaultModes: this.defaultModes,
+        syntheticModes: this.syntheticModes,
+        autoApprovePermissionModeIds: this.autoApprovePermissionModeIds,
         modelTransformer: this.modelTransformer,
         sessionResponseTransformer: this.sessionResponseTransformer,
         configOptionsTransformer: this.configOptionsTransformer,
@@ -825,6 +852,8 @@ export class ACPAgentClient implements AgentClient {
       runtimeSettings: this.runtimeSettings,
       defaultCommand: this.defaultCommand,
       defaultModes: this.defaultModes,
+      syntheticModes: this.syntheticModes,
+      autoApprovePermissionModeIds: this.autoApprovePermissionModeIds,
       modelTransformer: this.modelTransformer,
       sessionResponseTransformer: this.sessionResponseTransformer,
       configOptionsTransformer: this.configOptionsTransformer,
@@ -880,7 +909,7 @@ export class ACPAgentClient implements AgentClient {
         );
         return {
           models: this.modelTransformer ? this.modelTransformer(models) : models,
-          modes: modeInfo.modes,
+          modes: appendSyntheticModes(modeInfo.modes, this.syntheticModes),
         };
       })();
 
@@ -1275,6 +1304,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly runtimeSettings?: ProviderRuntimeSettings;
   private readonly defaultCommand: [string, ...string[]];
   private readonly defaultModes: AgentMode[];
+  private readonly syntheticModes: AgentMode[];
+  private readonly autoApprovePermissionModeIds: string[];
   protected readonly modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   private readonly sessionResponseTransformer?: (
     response: SessionStateResponse,
@@ -1346,6 +1377,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.runtimeSettings = options.runtimeSettings;
     this.defaultCommand = options.defaultCommand;
     this.defaultModes = options.defaultModes;
+    this.syntheticModes = options.syntheticModes ?? [];
+    this.autoApprovePermissionModeIds = options.autoApprovePermissionModeIds ?? [];
     this.modelTransformer = options.modelTransformer;
     this.sessionResponseTransformer = options.sessionResponseTransformer;
     this.configOptionsTransformer = options.configOptionsTransformer;
@@ -1638,8 +1671,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       this.currentMode = providerResult.currentModeId ?? modeId;
       if (providerResult.configOptions) {
         this.configOptions = this.transformConfigOptions(providerResult.configOptions);
+        // Only re-derive from config options when the writer returned them;
+        // locally-handled synthetic modes must not clobber ACP-reported modes.
+        this.availableModes = appendSyntheticModes(
+          deriveModesFromACP(this.defaultModes, null, this.configOptions).modes,
+          this.syntheticModes,
+        );
       }
-      this.availableModes = deriveModesFromACP(this.defaultModes, null, this.configOptions).modes;
       this.pushEvent({
         type: "mode_changed",
         provider: this.provider,
@@ -1713,7 +1751,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       requestedValue: modeId,
       label: "mode",
     });
-    this.availableModes = deriveModesFromACP(this.defaultModes, null, this.configOptions).modes;
+    this.availableModes = appendSyntheticModes(
+      deriveModesFromACP(this.defaultModes, null, this.configOptions).modes,
+      this.syntheticModes,
+    );
     this.pushEvent({
       type: "mode_changed",
       provider: this.provider,
@@ -2066,6 +2107,26 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
+    // Paseo-enforced allow-all: when the current mode opts into client-side
+    // auto-approval, answer immediately without surfacing a prompt. This covers
+    // agents (e.g. cursor-agent) whose own permission config still prompts over
+    // ACP for some tool kinds (web search, MCP).
+    if (this.currentMode !== null && this.autoApprovePermissionModeIds.includes(this.currentMode)) {
+      const allowOption = selectPermissionOption(params.options, { behavior: "allow" });
+      if (allowOption) {
+        this.logger.info(
+          {
+            agentId: this.agentId,
+            toolCallId: params.toolCall.toolCallId,
+            optionId: allowOption.optionId,
+            modeId: this.currentMode,
+          },
+          "Auto-approving ACP permission request (allow-all mode)",
+        );
+        return { outcome: { outcome: "selected", optionId: allowOption.optionId } };
+      }
+    }
+
     // Match Zed acp.rs:3189-3220: generic ACP permission requests stay pure pass-through.
     const requestId = randomUUID();
     let toolSnapshot =
@@ -2369,8 +2430,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.configOptions = this.transformConfigOptions(transformed.configOptions ?? []);
 
     const modeInfo = deriveModesFromACP(this.defaultModes, transformed.modes, this.configOptions);
-    this.availableModes = modeInfo.modes;
-    this.currentMode = modeInfo.currentModeId ?? this.currentMode;
+    this.availableModes = appendSyntheticModes(modeInfo.modes, this.syntheticModes);
+    if (!this.isSyntheticMode(this.currentMode)) {
+      this.currentMode = modeInfo.currentModeId ?? this.currentMode;
+    }
 
     this.availableModels = transformed.models?.availableModels ?? null;
     this.currentModel =
@@ -2383,6 +2446,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     return this.configOptionsTransformer
       ? this.configOptionsTransformer(configOptions)
       : configOptions;
+  }
+
+  private isSyntheticMode(modeId: string | null): boolean {
+    return modeId !== null && this.syntheticModes.some((mode) => mode.id === modeId);
   }
 
   private transformModeId(modeId: string): string | null {
@@ -2576,6 +2643,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private handleCurrentModeUpdate(update: CurrentModeUpdate): void {
+    // An explicit current_mode_update is a genuine agent-side mode change (e.g.
+    // a slash command switching to plan), so it may also switch out of a
+    // synthetic mode.
     this.currentMode = this.transformModeId(update.currentModeId);
   }
 
@@ -2586,8 +2656,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     const nextModel = deriveCurrentConfigValue(this.configOptions, "model");
     const nextThinkingOptionId = deriveCurrentConfigValue(this.configOptions, "thought_level");
 
-    this.availableModes = modeInfo.modes;
-    this.currentMode = nextMode ?? this.currentMode;
+    this.availableModes = appendSyntheticModes(modeInfo.modes, this.syntheticModes);
+    // Unlike current_mode_update, config option updates merely echo the native
+    // mode value alongside unrelated changes (e.g. a feature toggle), so they
+    // must not silently drop an active synthetic mode.
+    if (!this.isSyntheticMode(this.currentMode)) {
+      this.currentMode = nextMode ?? this.currentMode;
+    }
     this.currentModel = nextModel ?? this.currentModel;
     this.thinkingOptionId = nextThinkingOptionId ?? this.thinkingOptionId;
 

--- a/packages/server/src/server/agent/providers/cursor-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/cursor-acp-agent.test.ts
@@ -124,6 +124,41 @@ describe("CursorACPAgentClient model discovery", () => {
     });
   });
 
+  test("appends Allow All to natively reported Cursor modes", async () => {
+    const client = new TestCursorACPAgentClient({
+      sessionId: "session-1",
+      models: null,
+      configOptions: [],
+      modes: {
+        currentModeId: "agent",
+        availableModes: [
+          { id: "agent", name: "Agent", description: null },
+          { id: "plan", name: "Plan", description: null },
+          { id: "ask", name: "Ask", description: null },
+        ],
+      },
+    });
+
+    await expect(
+      client.fetchCatalog({ scope: "workspace", cwd: "/tmp/cursor", force: false }),
+    ).resolves.toEqual({
+      models: [],
+      modes: [
+        { id: "agent", label: "Agent", description: undefined },
+        { id: "plan", label: "Plan", description: undefined },
+        { id: "ask", label: "Ask", description: undefined },
+        {
+          id: "allow-all",
+          label: "Allow All",
+          description: "Automatically approves all Cursor permission requests (use with caution)",
+          icon: "ShieldOff",
+          colorTier: "dangerous",
+          isUnattended: true,
+        },
+      ],
+    });
+  });
+
   test("exposes Cursor fast mode through provider features", async () => {
     const client = new TestCursorACPAgentClient({
       sessionId: "session-1",

--- a/packages/server/src/server/agent/providers/cursor-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/cursor-acp-agent.ts
@@ -1,6 +1,11 @@
 import type { Logger } from "pino";
 
-import type { ACPConfigFeatureOption } from "./acp-agent.js";
+import type { AgentMode } from "../agent-sdk-types.js";
+import type {
+  ACPConfigFeatureOption,
+  ACPProviderModeWriterContext,
+  ACPProviderModeWriteResult,
+} from "./acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
 
 interface CursorACPAgentClientOptions {
@@ -26,6 +31,34 @@ export const CURSOR_FAST_FEATURE_OPTION: ACPConfigFeatureOption = {
   icon: "zap",
 };
 
+export const CURSOR_ALLOW_ALL_MODE_ID = "allow-all";
+
+// Paseo-owned synthetic mode: cursor-agent has no native allow-all, and its own
+// permission config (approvalMode, --force) still prompts over ACP for some
+// tool kinds (web search, MCP). Selecting it makes the daemon auto-approve
+// every permission request client-side; nothing is written to cursor-agent. It
+// is appended to the modes cursor-agent reports (Agent/Plan/Ask on current
+// builds; older builds report none and keep no mode picker at all).
+export const CURSOR_ALLOW_ALL_MODE: AgentMode = {
+  id: CURSOR_ALLOW_ALL_MODE_ID,
+  label: "Allow All",
+  description: "Automatically approves all Cursor permission requests (use with caution)",
+  icon: "ShieldOff",
+  colorTier: "dangerous",
+  isUnattended: true,
+};
+
+// The synthetic mode resolves locally (there is nothing to write to
+// cursor-agent); native mode ids fall through to the normal ACP path.
+export async function writeCursorProviderMode(
+  context: ACPProviderModeWriterContext,
+): Promise<ACPProviderModeWriteResult> {
+  if (context.requestedModeId !== CURSOR_ALLOW_ALL_MODE_ID) {
+    return { handled: false };
+  }
+  return { handled: true, currentModeId: context.requestedModeId };
+}
+
 export class CursorACPAgentClient extends GenericACPAgentClient {
   constructor(options: CursorACPAgentClientOptions) {
     super({
@@ -40,6 +73,9 @@ export class CursorACPAgentClient extends GenericACPAgentClient {
       initialCommandsWaitTimeoutMs: CURSOR_INITIAL_COMMANDS_WAIT_TIMEOUT_MS,
       clientCapabilityMeta: CURSOR_CLIENT_CAPABILITY_META,
       configFeatureOptions: [CURSOR_FAST_FEATURE_OPTION],
+      syntheticModes: [CURSOR_ALLOW_ALL_MODE],
+      autoApprovePermissionModeIds: [CURSOR_ALLOW_ALL_MODE_ID],
+      providerModeWriter: writeCursorProviderMode,
     });
   }
 }

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -1,12 +1,14 @@
 import type { Logger } from "pino";
 import { z } from "zod";
 
-import type { AgentCapabilityFlags } from "../agent-sdk-types.js";
+import type { AgentCapabilityFlags, AgentMode } from "../agent-sdk-types.js";
 import { checkProviderLaunchAvailable, resolveProviderLaunch } from "../provider-launch-config.js";
 import {
   ACPAgentClient,
   type ACPClientCapabilityMeta,
   type ACPConfigFeatureOption,
+  type ACPProviderModeWriterContext,
+  type ACPProviderModeWriteResult,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
 } from "./acp-agent.js";
@@ -49,6 +51,11 @@ interface GenericACPAgentClientOptions {
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  syntheticModes?: AgentMode[];
+  autoApprovePermissionModeIds?: string[];
+  providerModeWriter?: (
+    context: ACPProviderModeWriterContext,
+  ) => Promise<ACPProviderModeWriteResult>;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -73,6 +80,9 @@ export class GenericACPAgentClient extends ACPAgentClient {
       clientCapabilityMeta: options.clientCapabilityMeta,
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
+      syntheticModes: options.syntheticModes,
+      autoApprovePermissionModeIds: options.autoApprovePermissionModeIds,
+      providerModeWriter: options.providerModeWriter,
     });
 
     this.command = options.command;


### PR DESCRIPTION
### Linked issue

Closes #1926

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Cursor sessions get a Paseo-owned **Allow All** mode. When selected, the daemon answers every ACP `session/request_permission` with the allow option instead of surfacing a prompt. This is implemented client-side because cursor-agent's own config cannot silence prompts over ACP: the built-in web search prompts unconditionally, MCP approval ignores `--approve-mcps`/`--force`, and the auto-review classifier doesn't run in ACP mode.

The shared ACP adapter gains two generic options. `syntheticModes` appends Paseo-owned modes to the agent-reported mode list wherever modes are derived; they only extend a non-empty native list, selection is resolved locally by the provider mode writer, and an active synthetic mode survives config-option echoes of the native mode while an explicit `current_mode_update` still switches out of it. `autoApprovePermissionModeIds` makes `requestPermission` resolve immediately with the allow option while such a mode is active (logged, no prompt event) — the same shape as OpenCode's `auto_accept` and the voice-session speak-tool auto-allow. Cursor wires these up with a single Allow All mode (ShieldOff / dangerous / `isUnattended`, so unattended launches auto-select it); native Agent/Plan/Ask switching keeps using the normal ACP path.

This also fixes a latent bug where a locally-handled mode switch re-derived `availableModes` from config options, clobbering ACP-reported modes.

### How did you verify it

- Manual testing against a dev daemon connected over a Paseo client; in Allow All, verified that command gets auto-approved; in default Agent mode, verified that commands require permission; also verified that switching mode in the middle of a session respects the new mode.
- Live against cursor-agent 2026.07.16 with an isolated dev daemon: in Allow All, a prompt that triggers a web search plus a non-allowlisted destructive shell command (`rm -rf .git/refs/tags`) ran end-to-end with zero permission prompts; the daemon logged `Auto-approving ACP permission request (allow-all mode)` for both the `web_search_0` tool call and the shell call, and the file-system effects were confirmed on disk.
- Control run in native Agent mode with the same web-search prompt: the request parked as a pending permission (visible in `paseo permit ls`) until manually denied — prompting behavior unchanged outside Allow All.
- Verified the provider catalog reports `Agent, Plan, Ask, Allow All` with a real cursor-agent, and that switching Allow All ↔ native modes mid-session behaves (native switches still issue `session/set_mode`; selecting Allow All writes nothing to cursor-agent).
- Probed `cursor-agent acp` directly to confirm the premise: `approvalMode`/`--force` gaps over ACP, and that mode switches don't retract config options (basis for the config-echo guard).
- `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts packages/server/src/server/agent/providers/cursor-acp-agent.test.ts packages/server/src/server/agent/providers/generic-acp-agent.test.ts --bail=1` — 91 passed (new coverage: auto-approve in synthetic mode, still-prompts in native mode and when no allow option exists, local vs ACP-path mode switching, config-echo stickiness vs explicit switch-out).
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run format` — ran (Biome/oxfmt).

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform — not applicable; no app/UI changes (the mode surfaces through the existing mode picker)
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)