### PR TITLE
feat(app): allow unbinding default keyboard shortcuts in settings

### DIFF
--- a/packages/app/src/hooks/use-command-center.ts
+++ b/packages/app/src/hooks/use-command-center.ts
@@ -136,7 +136,10 @@ function resolveActionShortcutKeys(
   const bindingId = getBindingIdForAction(actionId, platform);
   if (!bindingId) return undefined;
   const override = overrides[bindingId];
-  if (override) return chordStringToShortcutKeys(override);
+  if (override !== undefined) {
+    // An empty override means the shortcut was explicitly unbound.
+    return override === "" ? undefined : chordStringToShortcutKeys(override);
+  }
   const defaultKeys = getDefaultKeysForAction(actionId, platform);
   return defaultKeys ? [defaultKeys] : undefined;
 }

--- a/packages/app/src/hooks/use-shortcut-keys.ts
+++ b/packages/app/src/hooks/use-shortcut-keys.ts
@@ -17,8 +17,9 @@ export function useShortcutKeys(actionId: string): ShortcutKey[][] | null {
     if (!bindingId) return null;
 
     const override = overrides[bindingId];
-    if (override) {
-      return chordStringToShortcutKeys(override);
+    if (override !== undefined) {
+      // An empty override means the shortcut was explicitly unbound.
+      return override === "" ? null : chordStringToShortcutKeys(override);
     }
 
     const defaultKeys = getDefaultKeysForAction(actionId, platform);

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1715,10 +1715,12 @@ export const ar: TranslationResources = {
       dialogTitle: "الاختصارات",
       unavailableOnMobile: "اختصارات لوحة المفاتيح متاحة فقط على سطح المكتب",
       capturePrompt: "اضغط على الاختصار...",
+      unbound: "غير معيّن",
       actions: {
         done: "منتهي",
         cancel: "يلغي",
         rebind: "إعادة ربط",
+        unbind: "إلغاء التعيين",
         reset: "إعادة ضبط",
         resetAll: "إعادة ضبط الكل",
       },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1726,10 +1726,12 @@ export const en = {
       dialogTitle: "Shortcuts",
       unavailableOnMobile: "Keyboard shortcuts are only available on desktop",
       capturePrompt: "Press shortcut...",
+      unbound: "Not set",
       actions: {
         done: "Done",
         cancel: "Cancel",
         rebind: "Rebind",
+        unbind: "Unbind",
         reset: "Reset",
         resetAll: "Reset all",
       },

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1763,10 +1763,12 @@ export const es: TranslationResources = {
       dialogTitle: "Atajos",
       unavailableOnMobile: "Los atajos de teclado solo están disponibles en el escritorio",
       capturePrompt: "Presione el acceso directo...",
+      unbound: "Sin asignar",
       actions: {
         done: "Hecho",
         cancel: "Cancelar",
         rebind: "Reencuadernar",
+        unbind: "Desasignar",
         reset: "Reiniciar",
         resetAll: "Restablecer todo",
       },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1764,10 +1764,12 @@ export const fr: TranslationResources = {
       dialogTitle: "Raccourcis",
       unavailableOnMobile: "Les raccourcis clavier ne sont disponibles que sur le bureau",
       capturePrompt: "Appuyez sur le raccourci...",
+      unbound: "Non défini",
       actions: {
         done: "Fait",
         cancel: "Annuler",
         rebind: "Relier",
+        unbind: "Dissocier",
         reset: "Réinitialiser",
         resetAll: "Tout réinitialiser",
       },

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1733,10 +1733,12 @@ export const ja: TranslationResources = {
       dialogTitle: "ショートカット",
       unavailableOnMobile: "キーボードショートカットはデスクトップでのみ利用できます",
       capturePrompt: "ショートカットを押してください...",
+      unbound: "未設定",
       actions: {
         done: "完了",
         cancel: "キャンセル",
         rebind: "再割り当て",
+        unbind: "割り当て解除",
         reset: "リセット",
         resetAll: "すべてリセット",
       },

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1747,10 +1747,12 @@ export const ptBR: TranslationResources = {
       dialogTitle: "Atalhos",
       unavailableOnMobile: "Atalhos de teclado estão disponíveis apenas no desktop",
       capturePrompt: "Pressione o atalho...",
+      unbound: "Não definido",
       actions: {
         done: "Concluído",
         cancel: "Cancelar",
         rebind: "Reatribuir",
+        unbind: "Desvincular",
         reset: "Redefinir",
         resetAll: "Redefinir tudo",
       },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1754,10 +1754,12 @@ export const ru: TranslationResources = {
       dialogTitle: "Ярлыки",
       unavailableOnMobile: "Сочетания клавиш доступны только на рабочем столе.",
       capturePrompt: "Нажмите ярлык...",
+      unbound: "Не задано",
       actions: {
         done: "Сделанный",
         cancel: "Отмена",
         rebind: "Перепривязка",
+        unbind: "Отвязать",
         reset: "Перезагрузить",
         resetAll: "Сбросить все",
       },

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1696,10 +1696,12 @@ export const zhCN: TranslationResources = {
       dialogTitle: "快捷键",
       unavailableOnMobile: "键盘快捷键仅在桌面端可用",
       capturePrompt: "按下快捷键...",
+      unbound: "未设置",
       actions: {
         done: "完成",
         cancel: "取消",
         rebind: "重新绑定",
+        unbind: "取消绑定",
         reset: "重置",
         resetAll: "全部重置",
       },

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -665,6 +665,40 @@ describe("keyboard-shortcut help sections", () => {
     expect(showShortcuts?.noteKey).toBe("settings.shortcuts.helpNotes.showKeyboardShortcuts");
   });
 
+  it("deactivates default-bound shortcuts when an empty override unbinds them", () => {
+    const bindings = buildEffectiveBindings({
+      "workspace-terminal-new-ctrl-shift-t-non-mac": "",
+    });
+    const terminalBinding = bindings.find(
+      (binding) => binding.id === "workspace-terminal-new-ctrl-shift-t-non-mac",
+    );
+    expect(terminalBinding?.combo).toBe("");
+    expect(terminalBinding?.parsedChord).toHaveLength(0);
+
+    const result = resolveKeyboardShortcut({
+      event: {
+        key: "T",
+        code: "KeyT",
+        metaKey: false,
+        ctrlKey: true,
+        altKey: false,
+        shiftKey: true,
+        repeat: false,
+      },
+      context: {
+        isMac: false,
+        isDesktop: true,
+        focusScope: "other",
+        commandCenterOpen: false,
+      },
+      chordState: { candidateIndices: [], step: 0, timeoutId: null },
+      onChordReset: () => {},
+      bindings,
+    });
+
+    expect(result.match).toBeNull();
+  });
+
   it("does not expose Enter send behavior as rebindable shortcut rows", () => {
     const sections = buildKeyboardShortcutHelpSections({ isMac: true, isDesktop: true });
 

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -1054,6 +1054,11 @@ export function buildEffectiveBindings(overrides: Record<string, string>): Parse
     if (override === undefined) {
       return binding;
     }
+    // An empty override unbinds the shortcut entirely; the matcher skips
+    // bindings with an empty chord.
+    if (override.trim() === "") {
+      return { ...binding, combo: "", parsedChord: [] };
+    }
     let parsedChord: KeyCombo[];
     try {
       parsedChord = parseChordString(override);

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -1056,7 +1056,7 @@ export function buildEffectiveBindings(overrides: Record<string, string>): Parse
     }
     // An empty override unbinds the shortcut entirely; the matcher skips
     // bindings with an empty chord.
-    if (override.trim() === "") {
+    if (override === "") {
       return { ...binding, combo: "", parsedChord: [] };
     }
     let parsedChord: KeyCombo[];

--- a/packages/app/src/screens/settings/keyboard-shortcuts-section.tsx
+++ b/packages/app/src/screens/settings/keyboard-shortcuts-section.tsx
@@ -137,7 +137,7 @@ function ShortcutRow({
       // An empty override means the shortcut was explicitly unbound.
       return overrideCombo === "" ? [] : chordStringToShortcutKeys(overrideCombo);
     }
-    return [row.keys];
+    return row.keys.length > 0 ? [row.keys] : [];
   }, [overrideCombo, row.keys]);
   const rowStyle = useMemo(() => [styles.row, isCapturing && styles.rowCapturing], [isCapturing]);
 

--- a/packages/app/src/screens/settings/keyboard-shortcuts-section.tsx
+++ b/packages/app/src/screens/settings/keyboard-shortcuts-section.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { View, Text } from "react-native";
 import { useIsFocused } from "@react-navigation/native";
@@ -61,6 +61,7 @@ interface ShortcutRowContainerProps {
   onSaveCapture: () => void;
   onCancelCapture: () => void;
   onRemoveOverride: (bindingId: string) => void;
+  onUnbind: (bindingId: string) => void;
 }
 
 function ShortcutRowContainer({
@@ -74,6 +75,7 @@ function ShortcutRowContainer({
   onSaveCapture,
   onCancelCapture,
   onRemoveOverride,
+  onUnbind,
 }: ShortcutRowContainerProps) {
   const handleRebind = useCallback(() => {
     if (bindingId) onStartCapture(bindingId);
@@ -82,6 +84,10 @@ function ShortcutRowContainer({
   const handleReset = useCallback(() => {
     if (bindingId) onRemoveOverride(bindingId);
   }, [bindingId, onRemoveOverride]);
+
+  const handleUnbind = useCallback(() => {
+    if (bindingId) onUnbind(bindingId);
+  }, [bindingId, onUnbind]);
 
   return (
     <ShortcutRow
@@ -95,6 +101,7 @@ function ShortcutRowContainer({
       onDone={onSaveCapture}
       onCancel={onCancelCapture}
       onReset={handleReset}
+      onUnbind={handleUnbind}
     />
   );
 }
@@ -110,6 +117,7 @@ function ShortcutRow({
   onDone,
   onCancel,
   onReset,
+  onUnbind,
 }: {
   row: KeyboardShortcutHelpRow;
   bindingId: string | null;
@@ -121,23 +129,32 @@ function ShortcutRow({
   onDone: () => void;
   onCancel: () => void;
   onReset: () => void;
+  onUnbind: () => void;
 }) {
   const { t } = useTranslation();
-  const displayChord = useMemo(
-    () => (overrideCombo ? chordStringToShortcutKeys(overrideCombo) : [row.keys]),
-    [overrideCombo, row.keys],
-  );
+  const displayChord = useMemo(() => {
+    if (overrideCombo !== undefined) {
+      // An empty override means the shortcut was explicitly unbound.
+      return overrideCombo === "" ? [] : chordStringToShortcutKeys(overrideCombo);
+    }
+    return [row.keys];
+  }, [overrideCombo, row.keys]);
   const rowStyle = useMemo(() => [styles.row, isCapturing && styles.rowCapturing], [isCapturing]);
+
+  let shortcutDisplay: ReactNode;
+  if (isCapturing) {
+    shortcutDisplay = <ShortcutSequence chord={capturedCombos} heldModifiers={heldModifiers} />;
+  } else if (displayChord.length > 0) {
+    shortcutDisplay = <Shortcut chord={displayChord} />;
+  } else {
+    shortcutDisplay = <Text style={styles.unboundText}>{t("settings.shortcuts.unbound")}</Text>;
+  }
 
   return (
     <View style={rowStyle}>
       <Text style={styles.rowLabel}>{t(row.labelKey)}</Text>
       <View style={styles.rowActions}>
-        {isCapturing ? (
-          <ShortcutSequence chord={capturedCombos} heldModifiers={heldModifiers} />
-        ) : (
-          <Shortcut chord={displayChord} />
-        )}
+        {shortcutDisplay}
         {bindingId !== null && (
           <>
             {isCapturing && capturedCombos.length > 0 ? (
@@ -150,6 +167,11 @@ function ShortcutRow({
                 ? t("settings.shortcuts.actions.cancel")
                 : t("settings.shortcuts.actions.rebind")}
             </Button>
+            {!isCapturing && displayChord.length > 0 ? (
+              <Button variant="ghost" size="sm" onPress={onUnbind}>
+                <Text style={styles.resetText}>{t("settings.shortcuts.actions.unbind")}</Text>
+              </Button>
+            ) : null}
           </>
         )}
         {overrideCombo !== undefined && !isCapturing && (
@@ -260,6 +282,11 @@ export function KeyboardShortcutsSection() {
     (bindingId: string) => void removeOverride(bindingId),
     [removeOverride],
   );
+  // An empty override disables the binding entirely (see buildEffectiveBindings).
+  const handleUnbind = useCallback(
+    (bindingId: string) => void setOverride(bindingId, ""),
+    [setOverride],
+  );
 
   if (isNative) {
     return (
@@ -309,6 +336,7 @@ export function KeyboardShortcutsSection() {
                       onSaveCapture={saveCapture}
                       onCancelCapture={cancelCapture}
                       onRemoveOverride={handleRemoveOverride}
+                      onUnbind={handleUnbind}
                     />
                     {index < section.rows.length - 1 && <View style={styles.separator} />}
                   </View>
@@ -344,6 +372,10 @@ const styles = StyleSheet.create((theme) => ({
     gap: theme.spacing[2],
   },
   capturingText: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foregroundMuted,
+  },
+  unboundText: {
     fontSize: theme.fontSize.sm,
     color: theme.colors.foregroundMuted,
   },


### PR DESCRIPTION
### Linked issue

None — small settings-pane enhancement.

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The keyboard shortcut settings pane only allowed rebinding a shortcut or resetting an override back to the default — there was no way to disable a shortcut that ships with a default binding.

Each bound shortcut row now has an **Unbind** action. It stores an empty override, the row shows "Not set", and the existing **Reset** action restores the default. `buildEffectiveBindings` maps an empty override to an empty chord, which the matcher already skips, so an unbound shortcut simply never resolves.

Shortcut hint surfaces (`useShortcutKeys`, command center items) previously used truthiness checks on overrides and would have kept showing default key hints for an explicitly unbound shortcut; they now treat an empty override as unbound and hide the hint. The new "Not set" and "Unbind" labels are added to all eight locales.

### How did you verify it

- Added a unit test: an empty override produces an empty chord, and pressing the default combo (Ctrl+Shift+T, new terminal) no longer resolves a match.
- `npx vitest run packages/app/src/keyboard/keyboard-shortcuts.test.ts --bail=1` — 74 passed.
- `npx vitest run packages/app/src/i18n/resources.test.ts --bail=1` — 32 passed (locale key parity).
- `npm run typecheck` passed for all workspaces.
- `npm run lint` passed with zero warnings.
- `npm run format` ran, including the pre-commit format check.
- Built and ran local app, tried unbinding "Open Project" - verified that Command+O no longer triggers that.

### Risk surface

Web/desktop only — the settings pane renders a mobile notice on native. Overrides are stored client-side in AsyncStorage; no protocol or persisted-daemon-data shapes change. An empty override on an older client build falls into the existing `parseChordString` catch and is ignored, leaving the default binding active.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

<img width="1084" height="453" alt="Screenshot 2026-07-17 at 11 58 50 PM" src="https://github.com/user-attachments/assets/fb0758be-5d08-49cb-8c4f-3c6dd7a9fc03" />
