### PR TITLE
Fix duplicated and out-of-order agent chat messages

### DIFF
--- a/docs/timeline-sync.md
+++ b/docs/timeline-sync.md
@@ -51,9 +51,39 @@ When a client resumes with a known cursor, it catches up after that cursor to co
 
 When a client resumes without a cursor, it fetches the latest tail page.
 
+## Selective and legacy delivery
+
+The app chooses one delivery policy from `server_info.features.selectiveAgentTimeline`:
+
+- Selective daemons receive the union of agents visible in every pane. Additions subscribe and
+  catch up immediately. Removals stay subscribed for a short grace period so quick tab and pane
+  switches do not repeatedly unsubscribe and catch up. Backgrounding, disconnecting, and disposal
+  clear that grace immediately.
+- Legacy daemons keep globally streaming agent timelines. Visibility still triggers the existing
+  authoritative catch-up, but the app does not issue selective-subscription RPCs.
+
+This policy is owned by `viewed-timeline-sync.ts`; downstream reducers do not branch on daemon
+version.
+
+## Projected pages reconcile with live presentation
+
+A projected page is canonical state, not a sequence of live deltas. One projected item can overlap
+rows already received live—for example, a tool call retained at its original display position while
+its completion advances `seqEnd`, followed by a merged assistant message. The app uses
+`sourceSeqRanges` to replace overlapping assistant and reasoning projections before applying the
+remaining page through the existing stream reducer. It must not append full projected text to a
+live prefix.
+
+Optimistic user prompts are presentation state rather than canonical history. Incremental catch-up
+temporarily separates them, applies canonical entries, lets canonical user rows reconcile through
+the existing optimistic-message rules, then restores any unmatched prompts after the caught-up
+history. This keeps late history before a newly submitted prompt without duplicating an
+acknowledged prompt.
+
 ## Relevant code
 
 - Server live stream forwarding: `packages/server/src/server/session.ts`
 - App sync planning: `packages/app/src/timeline/timeline-sync-plan.ts`
+- App viewed-agent synchronization: `packages/app/src/timeline/viewed-timeline-sync.ts`
 - App stream/timeline reducer: `packages/app/src/timeline/session-stream-reducers.ts`
 - Session wiring: `packages/app/src/contexts/session-context.tsx`

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -734,26 +734,32 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
           .getState()
           .sessions[serverId]?.agentAuthoritativeHistoryApplied.get(agentId) === true,
       fetchPage: async (agentId, request) => {
+        const session = useSessionStore.getState().sessions[serverId];
         const initKey = getInitKey(serverId, agentId);
-        if (!getInitDeferred(initKey)) {
-          const deferred = createInitDeferred(initKey, request.direction ?? "tail");
-          void deferred.promise.catch(() => undefined);
+        const shouldInitialize = session?.agentAuthoritativeHistoryApplied.get(agentId) !== true;
+        if (shouldInitialize) {
+          if (!getInitDeferred(initKey)) {
+            const deferred = createInitDeferred(initKey, request.direction ?? "tail");
+            void deferred.promise.catch(() => undefined);
+          }
+          refreshAgentInitializationTimeout({
+            key: initKey,
+            agentId,
+            setAgentInitializing,
+          });
+          setAgentInitializing(agentId, true);
         }
-        refreshAgentInitializationTimeout({
-          key: initKey,
-          agentId,
-          setAgentInitializing,
-        });
-        setAgentInitializing(agentId, true);
         try {
           const page = await getHostRuntimeStore().fetchAgentTimeline(serverId, agentId, request);
-          if (getInitDeferred(initKey)) {
+          if (shouldInitialize && getInitDeferred(initKey)) {
             refreshAgentInitializationTimeout({ key: initKey, agentId, setAgentInitializing });
           }
           return page;
         } catch (error) {
-          setAgentInitializing(agentId, false);
-          rejectInitDeferred(initKey, error instanceof Error ? error : new Error(String(error)));
+          if (shouldInitialize) {
+            setAgentInitializing(agentId, false);
+            rejectInitDeferred(initKey, error instanceof Error ? error : new Error(String(error)));
+          }
           throw error;
         }
       },

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -20,7 +20,11 @@ import {
 } from "@/timeline/session-stream-reducers";
 import { useCreateFlowStore } from "@/stores/create-flow-store";
 import { isTimelineCatchUpComplete } from "@/timeline/timeline-sync-plan";
-import { createViewedTimelineSync, type ViewedTimelineSync } from "@/timeline/viewed-timeline-sync";
+import {
+  createViewedTimelineSync,
+  type TimelineDeliveryMode,
+  type ViewedTimelineSync,
+} from "@/timeline/viewed-timeline-sync";
 import type { AgentAttachment, SessionOutboundMessage } from "@getpaseo/protocol/messages";
 import { parseServerInfoStatusPayload } from "@getpaseo/protocol/messages";
 import {
@@ -77,6 +81,11 @@ interface BufferedAudioChunk {
   audio: string;
   format: string;
   id: string;
+}
+
+// COMPAT(selectiveAgentTimeline): added in v0.1.106, remove after 2027-01-12.
+function getTimelineDeliveryMode(selectiveAgentTimeline?: boolean): TimelineDeliveryMode {
+  return selectiveAgentTimeline ? "selective" : "legacy";
 }
 
 function decodeBase64Chunk(base64: string): Uint8Array {
@@ -712,7 +721,11 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
 
   useEffect(() => {
     const setAgentInitializing = createSetAgentInitializing(serverId, setInitializingAgents);
+    const initialDeliveryMode = getTimelineDeliveryMode(
+      client.getLastServerInfoMessage()?.features?.selectiveAgentTimeline,
+    );
     const sync = createViewedTimelineSync({
+      initialDeliveryMode,
       setSubscription: (agentIds) => client.setAgentTimelineSubscription(agentIds),
       readCursor: (agentId) =>
         useSessionStore.getState().sessions[serverId]?.agentTimelineCursor.get(agentId),
@@ -721,20 +734,17 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
           .getState()
           .sessions[serverId]?.agentAuthoritativeHistoryApplied.get(agentId) === true,
       fetchPage: async (agentId, request) => {
-        const session = useSessionStore.getState().sessions[serverId];
         const initKey = getInitKey(serverId, agentId);
-        if (session?.agentAuthoritativeHistoryApplied.get(agentId) !== true) {
-          if (!getInitDeferred(initKey)) {
-            const deferred = createInitDeferred(initKey, request.direction ?? "tail");
-            void deferred.promise.catch(() => undefined);
-          }
-          refreshAgentInitializationTimeout({
-            key: initKey,
-            agentId,
-            setAgentInitializing,
-          });
-          setAgentInitializing(agentId, true);
+        if (!getInitDeferred(initKey)) {
+          const deferred = createInitDeferred(initKey, request.direction ?? "tail");
+          void deferred.promise.catch(() => undefined);
         }
+        refreshAgentInitializationTimeout({
+          key: initKey,
+          agentId,
+          setAgentInitializing,
+        });
+        setAgentInitializing(agentId, true);
         try {
           const page = await getHostRuntimeStore().fetchAgentTimeline(serverId, agentId, request);
           if (getInitDeferred(initKey)) {
@@ -750,8 +760,8 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
       reportError: (error) => {
         console.warn("[Session] viewed timeline synchronization failed", { serverId, error });
       },
-      scheduleRetry: (retry) => {
-        const timeout = setTimeout(retry, 1_000);
+      schedule: (task, delayMs) => {
+        const timeout = setTimeout(task, delayMs);
         return () => clearTimeout(timeout);
       },
     });
@@ -855,6 +865,9 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
       if (message.type !== "status") return;
       const serverInfo = parseServerInfoStatusPayload(message.payload);
       if (serverInfo) {
+        viewedTimelineSyncRef.current?.setDeliveryMode(
+          getTimelineDeliveryMode(serverInfo.features?.selectiveAgentTimeline),
+        );
         updateSessionServerInfo(serverId, {
           serverId: serverInfo.serverId,
           hostname: serverInfo.hostname,

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -107,7 +107,10 @@ function makeStreamReducerEvent(
   };
 }
 
-function makeAssistantItem(text: string, id = `assistant-${text.length}`): StreamItem {
+function makeAssistantItem(
+  text: string,
+  id = `assistant-${text.length}`,
+): Extract<StreamItem, { kind: "assistant_message" }> {
   return {
     kind: "assistant_message",
     id,
@@ -609,6 +612,81 @@ describe("processTimelineResponse", () => {
     ]);
   });
 
+  it("keeps a tail optimistic prompt before a reconciled live assistant head", () => {
+    const prompt = makeOptimisticUserMessage("new prompt", "optimistic-new-prompt");
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: [prompt],
+      currentHead: [
+        {
+          ...makeAssistantItem("Hel", "answer-1"),
+          messageId: "answer-1",
+        },
+      ],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 2 },
+      payload: {
+        ...baseTimelineInput.payload,
+        direction: "after",
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 3 },
+        entries: [
+          {
+            ...makeTimelineEntry(2, "Hello", "assistant_message", 3),
+            sourceSeqRanges: [{ startSeq: 2, endSeq: 3 }],
+            item: {
+              type: "assistant_message",
+              text: "Hello",
+              messageId: "answer-1",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      [...result.tail, ...result.head]
+        .filter((item) => item.kind === "assistant_message" || item.kind === "user_message")
+        .map((item) => item.text),
+    ).toEqual(["new prompt", "Hello"]);
+  });
+
+  it("keeps a tail optimistic prompt before a live head flushed by catch-up", () => {
+    const prompt = makeOptimisticUserMessage("new prompt", "optimistic-new-prompt");
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: [prompt],
+      currentHead: [
+        {
+          ...makeAssistantItem("Live response", "answer-1"),
+          messageId: "answer-1",
+        },
+      ],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 2 },
+      payload: {
+        ...baseTimelineInput.payload,
+        direction: "after",
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 3 },
+        entries: [
+          makeToolCallTimelineEntry(3, "call-1", "running", {
+            type: "read",
+            filePath: "/tmp/example.ts",
+          }),
+        ],
+      },
+    });
+
+    expect(
+      [...result.tail, ...result.head]
+        .filter((item) => item.kind === "assistant_message" || item.kind === "user_message")
+        .map((item) => item.text),
+    ).toEqual(["new prompt", "Live response"]);
+  });
+
   it("keeps an active assistant head live when an incremental fetch accepts same-turn assistant text", () => {
     const existingCursor: TimelineCursor = {
       epoch: "epoch-1",
@@ -716,6 +794,51 @@ describe("processTimelineResponse", () => {
     );
     expect(assistants).toHaveLength(1);
     expect(assistants[0]).toMatchObject({ text: "Hello", messageId: "answer-1" });
+  });
+
+  it("replaces every promoted assistant block when reconciling a projected message", () => {
+    const live = processAgentStreamEvents({
+      events: [makeStreamReducerEvent(makeAssistantTimelineEvent("First paragraph.\n\nSec"), 2)],
+      currentTail: [],
+      currentHead: [],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 1 },
+      currentAgent: null,
+    });
+    expect(getAssistantTexts(live.tail)).toHaveLength(1);
+    expect(getAssistantTexts(live.head)).toHaveLength(1);
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: live.tail,
+      currentHead: live.head,
+      currentCursor: live.cursor ?? undefined,
+      payload: {
+        ...baseTimelineInput.payload,
+        direction: "after",
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 3 },
+        entries: [
+          {
+            ...makeTimelineEntry(
+              2,
+              "First paragraph.\n\nSecond paragraph.",
+              "assistant_message",
+              3,
+            ),
+            sourceSeqRanges: [{ startSeq: 2, endSeq: 3 }],
+            item: {
+              type: "assistant_message",
+              text: "First paragraph.\n\nSecond paragraph.",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(getAssistantTexts([...result.tail, ...result.head])).toEqual([
+      "First paragraph.\n\nSecond paragraph.",
+    ]);
   });
 
   it("does not replay a reasoning prefix when catch-up completes an earlier tool call", () => {

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -912,6 +912,77 @@ describe("processTimelineResponse", () => {
     ).toEqual(["Earlier answer", "Missed answer", "New prompt"]);
   });
 
+  it("keeps delayed catch-up history between a live head and its unmatched head prompt", () => {
+    const prompt = makeOptimisticUserMessage("New prompt", "new-prompt");
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: [],
+      currentHead: [makeAssistantItem("Live answer", "live-answer"), prompt],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 2 },
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 3 },
+        entries: [
+          makeToolCallTimelineEntry(3, "missed-call", "completed", {
+            type: "read",
+            filePath: "/tmp/missed.ts",
+          }),
+        ],
+      },
+    });
+
+    expect([...result.tail, ...result.head].map((item) => item.kind)).toEqual([
+      "assistant_message",
+      "tool_call",
+      "user_message",
+    ]);
+  });
+
+  it("keeps delayed catch-up history between a live head and its acknowledged head prompt", () => {
+    const prompt = makeOptimisticUserMessage("New prompt", "new-prompt");
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: [],
+      currentHead: [makeAssistantItem("Live answer", "live-answer"), prompt],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 2 },
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 4 },
+        entries: [
+          makeToolCallTimelineEntry(3, "missed-call", "completed", {
+            type: "read",
+            filePath: "/tmp/missed.ts",
+          }),
+          {
+            ...makeTimelineEntry(4, "New prompt", "user_message"),
+            item: {
+              type: "user_message",
+              text: "New prompt",
+              messageId: "new-prompt",
+            },
+          },
+        ],
+      },
+    });
+
+    expect([...result.tail, ...result.head].map((item) => item.kind)).toEqual([
+      "assistant_message",
+      "tool_call",
+      "user_message",
+    ]);
+    expect(
+      [...result.tail, ...result.head]
+        .filter((item) => item.kind === "user_message")
+        .map((item) => item.optimistic),
+    ).toEqual([undefined]);
+  });
+
   it("keeps unrelated delayed history before the prompt and its live response", () => {
     const prompt = makeOptimisticUserMessage("New prompt", "new-prompt");
 

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -559,7 +559,7 @@ describe("processTimelineResponse", () => {
             item: {
               type: "user_message",
               text: "sent while catching up",
-              messageId: "canonical-after",
+              messageId: "optimistic-after",
             },
           },
         ],
@@ -568,7 +568,7 @@ describe("processTimelineResponse", () => {
 
     const userMessages = result.tail.filter((item) => item.kind === "user_message");
     expect(userMessages).toHaveLength(1);
-    expect(userMessages[0]?.id).toBe("canonical-after");
+    expect(userMessages[0]?.id).toBe("optimistic-after");
     expect(userMessages[0]?.optimistic).toBeUndefined();
   });
 
@@ -588,14 +588,14 @@ describe("processTimelineResponse", () => {
         entries: [
           {
             ...makeTimelineEntry(2, "first prompt", "user_message"),
-            item: { type: "user_message", text: "first prompt", messageId: "canonical-first" },
+            item: { type: "user_message", text: "first prompt", messageId: "optimistic-first" },
           },
           {
             ...makeTimelineEntry(3, "second prompt", "user_message"),
             item: {
               type: "user_message",
               text: "second prompt",
-              messageId: "canonical-second",
+              messageId: "optimistic-second",
             },
           },
         ],
@@ -607,8 +607,8 @@ describe("processTimelineResponse", () => {
         .filter((item) => item.kind === "user_message")
         .map((item) => ({ id: item.id, text: item.text, optimistic: item.optimistic })),
     ).toEqual([
-      { id: "canonical-first", text: "first prompt", optimistic: undefined },
-      { id: "canonical-second", text: "second prompt", optimistic: undefined },
+      { id: "optimistic-first", text: "first prompt", optimistic: undefined },
+      { id: "optimistic-second", text: "second prompt", optimistic: undefined },
     ]);
   });
 
@@ -951,6 +951,42 @@ describe("processTimelineResponse", () => {
     ).toEqual(["Earlier answer", "Missed answer", "Remote prompt", "New prompt", "Live response"]);
   });
 
+  it("keeps delayed history before a prompt whose live answer has promoted blocks", () => {
+    const prompt = makeOptimisticUserMessage("New prompt", "new-prompt");
+    const live = processAgentStreamEvents({
+      events: [
+        makeStreamReducerEvent(
+          makeAssistantTimelineEvent("First paragraph.\n\nSecond paragraph", "live-response"),
+          2,
+        ),
+      ],
+      currentTail: [prompt],
+      currentHead: [],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 1 },
+      currentAgent: null,
+    });
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: live.tail,
+      currentHead: live.head,
+      currentCursor: live.cursor ?? undefined,
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 3 },
+        entries: [makeTimelineEntry(3, "Missed answer")],
+      },
+    });
+
+    expect(
+      [...result.tail, ...result.head]
+        .filter((item) => item.kind === "assistant_message" || item.kind === "user_message")
+        .map((item) => item.text),
+    ).toEqual(["Missed answer", "New prompt", "First paragraph.", "Second paragraph"]);
+  });
+
   it("matches a local optimistic prompt after an unrelated remote user row", () => {
     const prompt = makeOptimisticUserMessage("Local prompt", "local-prompt");
 
@@ -977,7 +1013,7 @@ describe("processTimelineResponse", () => {
             item: {
               type: "user_message",
               text: "Local prompt",
-              messageId: "provider-local-prompt",
+              messageId: "local-prompt",
             },
           },
         ],
@@ -1026,6 +1062,41 @@ describe("processTimelineResponse", () => {
     ).toEqual([
       { text: "Remote prompt", optimistic: undefined },
       { text: "Local prompt", optimistic: true },
+    ]);
+  });
+
+  it("does not match equal prompt text when canonical message ids differ", () => {
+    const prompt = makeOptimisticUserMessage("continue", "local-prompt");
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: [prompt],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 1 },
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 2 },
+        endCursor: { seq: 2 },
+        entries: [
+          {
+            ...makeTimelineEntry(2, "continue", "user_message"),
+            item: {
+              type: "user_message",
+              text: "continue",
+              messageId: "remote-prompt",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      result.tail
+        .filter((item) => item.kind === "user_message")
+        .map((item) => ({ id: item.id, optimistic: item.optimistic })),
+    ).toEqual([
+      { id: "remote-prompt", optimistic: undefined },
+      { id: "local-prompt", optimistic: true },
     ]);
   });
 

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -569,6 +569,46 @@ describe("processTimelineResponse", () => {
     expect(userMessages[0]?.optimistic).toBeUndefined();
   });
 
+  it("reconciles multiple optimistic user messages in canonical order", () => {
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: [
+        makeOptimisticUserMessage("first prompt", "optimistic-first"),
+        makeOptimisticUserMessage("second prompt", "optimistic-second"),
+      ],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 1 },
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 2 },
+        endCursor: { seq: 3 },
+        entries: [
+          {
+            ...makeTimelineEntry(2, "first prompt", "user_message"),
+            item: { type: "user_message", text: "first prompt", messageId: "canonical-first" },
+          },
+          {
+            ...makeTimelineEntry(3, "second prompt", "user_message"),
+            item: {
+              type: "user_message",
+              text: "second prompt",
+              messageId: "canonical-second",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      result.tail
+        .filter((item) => item.kind === "user_message")
+        .map((item) => ({ id: item.id, text: item.text, optimistic: item.optimistic })),
+    ).toEqual([
+      { id: "canonical-first", text: "first prompt", optimistic: undefined },
+      { id: "canonical-second", text: "second prompt", optimistic: undefined },
+    ]);
+  });
+
   it("keeps an active assistant head live when an incremental fetch accepts same-turn assistant text", () => {
     const existingCursor: TimelineCursor = {
       epoch: "epoch-1",

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -987,6 +987,48 @@ describe("processTimelineResponse", () => {
     ).toEqual(["Missed answer", "New prompt", "First paragraph.", "Second paragraph"]);
   });
 
+  it("keeps delayed tool history before a prompt whose live answer has promoted blocks", () => {
+    const prompt = makeOptimisticUserMessage("New prompt", "new-prompt");
+    const live = processAgentStreamEvents({
+      events: [
+        makeStreamReducerEvent(
+          makeAssistantTimelineEvent("First paragraph.\n\nSecond paragraph", "live-response"),
+          2,
+        ),
+      ],
+      currentTail: [prompt],
+      currentHead: [],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 1 },
+      currentAgent: null,
+    });
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: live.tail,
+      currentHead: live.head,
+      currentCursor: live.cursor ?? undefined,
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 3 },
+        entries: [
+          makeToolCallTimelineEntry(3, "missed-call", "completed", {
+            type: "read",
+            filePath: "/tmp/missed.ts",
+          }),
+        ],
+      },
+    });
+
+    expect([...result.tail, ...result.head].map((item) => item.kind)).toEqual([
+      "tool_call",
+      "user_message",
+      "assistant_message",
+      "assistant_message",
+    ]);
+  });
+
   it("matches a local optimistic prompt after an unrelated remote user row", () => {
     const prompt = makeOptimisticUserMessage("Local prompt", "local-prompt");
 

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -597,6 +597,158 @@ describe("processTimelineResponse", () => {
     });
   });
 
+  it("does not replay an assistant prefix when catch-up completes an earlier tool call", () => {
+    const live = processAgentStreamEvents({
+      events: [
+        makeStreamReducerEvent(makeToolCallTimelineEvent("call-1"), 1),
+        makeStreamReducerEvent(makeAssistantTimelineEvent("Hel", "answer-1"), 2),
+      ],
+      currentTail: [],
+      currentHead: [],
+      currentCursor: undefined,
+      currentAgent: null,
+    });
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: live.tail,
+      currentHead: live.head,
+      currentCursor: live.cursor ?? undefined,
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 4 },
+        entries: [
+          {
+            ...makeToolCallTimelineEntry(1, "call-1", "completed", {
+              type: "read",
+              filePath: "/tmp/example.ts",
+            }),
+            seqEnd: 4,
+            sourceSeqRanges: [
+              { startSeq: 1, endSeq: 1 },
+              { startSeq: 4, endSeq: 4 },
+            ],
+          },
+          {
+            ...makeTimelineEntry(2, "Hello", "assistant_message", 3),
+            sourceSeqRanges: [{ startSeq: 2, endSeq: 3 }],
+            item: {
+              type: "assistant_message",
+              text: "Hello",
+              messageId: "answer-1",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(getAssistantTexts([...result.tail, ...result.head])).toEqual(["Hello"]);
+  });
+
+  it("reconciles an identified projection with an overlapping anonymous live prefix", () => {
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentHead: [makeAssistantItem("Hel")],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 2 },
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 3 },
+        entries: [
+          {
+            ...makeTimelineEntry(2, "Hello", "assistant_message", 3),
+            sourceSeqRanges: [{ startSeq: 2, endSeq: 3 }],
+            item: {
+              type: "assistant_message",
+              text: "Hello",
+              messageId: "answer-1",
+            },
+          },
+        ],
+      },
+    });
+
+    const assistants = [...result.tail, ...result.head].filter(
+      (item) => item.kind === "assistant_message",
+    );
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]).toMatchObject({ text: "Hello", messageId: "answer-1" });
+  });
+
+  it("does not replay a reasoning prefix when catch-up completes an earlier tool call", () => {
+    const live = processAgentStreamEvents({
+      events: [
+        makeStreamReducerEvent(makeToolCallTimelineEvent("call-1"), 1),
+        makeStreamReducerEvent(makeTimelineEvent("Thi", "reasoning"), 2),
+      ],
+      currentTail: [],
+      currentHead: [],
+      currentCursor: undefined,
+      currentAgent: null,
+    });
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: live.tail,
+      currentHead: live.head,
+      currentCursor: live.cursor ?? undefined,
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 4 },
+        entries: [
+          {
+            ...makeToolCallTimelineEntry(1, "call-1", "completed", {
+              type: "read",
+              filePath: "/tmp/example.ts",
+            }),
+            seqEnd: 4,
+            sourceSeqRanges: [
+              { startSeq: 1, endSeq: 1 },
+              { startSeq: 4, endSeq: 4 },
+            ],
+          },
+          {
+            ...makeTimelineEntry(2, "Thinking", "reasoning", 3),
+            sourceSeqRanges: [{ startSeq: 2, endSeq: 3 }],
+          },
+        ],
+      },
+    });
+
+    const thoughts = [...result.tail, ...result.head].filter((item) => item.kind === "thought");
+    expect(thoughts).toHaveLength(1);
+    expect(thoughts[0]?.text).toBe("Thinking");
+  });
+
+  it("keeps delayed catch-up history before a newly submitted prompt", () => {
+    const prompt = makeOptimisticUserMessage("New prompt", "new-prompt");
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: [makeAssistantItem("Earlier answer", "earlier-answer"), prompt],
+      currentHead: [],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 2 },
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 3 },
+        entries: [makeTimelineEntry(3, "Missed answer")],
+      },
+    });
+
+    expect(
+      [...result.tail, ...result.head]
+        .filter((item) => item.kind === "assistant_message" || item.kind === "user_message")
+        .map((item) => item.text),
+    ).toEqual(["Earlier answer", "Missed answer", "New prompt"]);
+  });
+
   it("hydrates a fetched in-progress tool call as one item and streams the next update on top", () => {
     const fetched = processTimelineResponse({
       ...baseTimelineInput,

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -912,6 +912,123 @@ describe("processTimelineResponse", () => {
     ).toEqual(["Earlier answer", "Missed answer", "New prompt"]);
   });
 
+  it("keeps unrelated delayed history before the prompt and its live response", () => {
+    const prompt = makeOptimisticUserMessage("New prompt", "new-prompt");
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: [makeAssistantItem("Earlier answer", "earlier-answer"), prompt],
+      currentHead: [
+        {
+          ...makeAssistantItem("Live response", "live-response"),
+          messageId: "live-response",
+        },
+      ],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 2 },
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 3 },
+        endCursor: { seq: 4 },
+        entries: [
+          makeTimelineEntry(3, "Missed answer"),
+          {
+            ...makeTimelineEntry(4, "Remote prompt", "user_message"),
+            item: {
+              type: "user_message",
+              text: "Remote prompt",
+              messageId: "remote-prompt",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      [...result.tail, ...result.head]
+        .filter((item) => item.kind === "assistant_message" || item.kind === "user_message")
+        .map((item) => item.text),
+    ).toEqual(["Earlier answer", "Missed answer", "Remote prompt", "New prompt", "Live response"]);
+  });
+
+  it("matches a local optimistic prompt after an unrelated remote user row", () => {
+    const prompt = makeOptimisticUserMessage("Local prompt", "local-prompt");
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: [prompt],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 1 },
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 2 },
+        endCursor: { seq: 3 },
+        entries: [
+          {
+            ...makeTimelineEntry(2, "Remote prompt", "user_message"),
+            item: {
+              type: "user_message",
+              text: "Remote prompt",
+              messageId: "remote-prompt",
+            },
+          },
+          {
+            ...makeTimelineEntry(3, "Local prompt", "user_message"),
+            item: {
+              type: "user_message",
+              text: "Local prompt",
+              messageId: "provider-local-prompt",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      result.tail
+        .filter((item) => item.kind === "user_message")
+        .map((item) => ({ text: item.text, optimistic: item.optimistic })),
+    ).toEqual([
+      { text: "Remote prompt", optimistic: undefined },
+      { text: "Local prompt", optimistic: undefined },
+    ]);
+  });
+
+  it("keeps an unmatched optimistic prompt when catch-up contains only a remote user row", () => {
+    const prompt = makeOptimisticUserMessage("Local prompt", "local-prompt");
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      currentTail: [prompt],
+      currentCursor: { epoch: "epoch-1", startSeq: 1, endSeq: 1 },
+      payload: {
+        ...baseTimelineInput.payload,
+        epoch: "epoch-1",
+        startCursor: { seq: 2 },
+        endCursor: { seq: 2 },
+        entries: [
+          {
+            ...makeTimelineEntry(2, "Remote prompt", "user_message"),
+            item: {
+              type: "user_message",
+              text: "Remote prompt",
+              messageId: "remote-prompt",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      result.tail
+        .filter((item) => item.kind === "user_message")
+        .map((item) => ({ text: item.text, optimistic: item.optimistic })),
+    ).toEqual([
+      { text: "Remote prompt", optimistic: undefined },
+      { text: "Local prompt", optimistic: true },
+    ]);
+  });
+
   it("hydrates a fetched in-progress tool call as one item and streams the next update on top", () => {
     const fetched = processTimelineResponse({
       ...baseTimelineInput,

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -709,21 +709,19 @@ function stageOptimisticUserForCanonicalEvent(params: {
   tail: StreamItem[];
   head: StreamItem[];
   event: AgentStreamEventPayload;
-  optimistic: UserMessageItem[];
-}): { tail: StreamItem[]; head: StreamItem[] } {
+  optimistic: UserMessageItem | undefined;
+}): { tail: StreamItem[]; head: StreamItem[]; consumed: boolean } {
   if (
     params.event.type !== "timeline" ||
     params.event.item.type !== "user_message" ||
-    params.optimistic.length === 0
+    !params.optimistic
   ) {
-    return { tail: params.tail, head: params.head };
+    return { tail: params.tail, head: params.head, consumed: false };
   }
-  const pending = params.optimistic.shift();
-  if (!pending) return { tail: params.tail, head: params.head };
   if (params.head.length > 0) {
-    return { tail: params.tail, head: [...params.head, pending] };
+    return { tail: params.tail, head: [...params.head, params.optimistic], consumed: true };
   }
-  return { tail: [...params.tail, pending], head: params.head };
+  return { tail: [...params.tail, params.optimistic], head: params.head, consumed: true };
 }
 
 function applyCanonicalForwardUnit(params: {
@@ -801,6 +799,7 @@ function applyAcceptedForwardTimelineUnits(params: {
   });
   let tail = reconciled.tail;
   let head = reconciled.head;
+  let consumedOptimisticCount = 0;
 
   for (const unit of params.units) {
     if (reconciled.reconciledUnits.has(unit)) continue;
@@ -808,8 +807,9 @@ function applyAcceptedForwardTimelineUnits(params: {
       tail,
       head,
       event: unit.event,
-      optimistic,
+      optimistic: optimistic[consumedOptimisticCount],
     });
+    if (staged.consumed) consumedOptimisticCount += 1;
     const applied = applyCanonicalForwardUnit({
       tail: staged.tail,
       head: staged.head,
@@ -822,7 +822,11 @@ function applyAcceptedForwardTimelineUnits(params: {
     head = applied.head;
   }
 
-  return appendOptimisticUserMessages({ tail, head, optimistic });
+  return appendOptimisticUserMessages({
+    tail,
+    head,
+    optimistic: optimistic.slice(consumedOptimisticCount),
+  });
 }
 
 function applyTimelineIncrementalPath(args: {

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -570,54 +570,73 @@ function detachOptimisticUserMessages(params: { tail: StreamItem[]; head: Stream
   };
 }
 
+function belongsToPreviousHead(item: StreamItem, previousHead: StreamItem[]): boolean {
+  return previousHead.some((existing) => {
+    if (item.id === existing.id) return true;
+    if (item.kind !== "assistant_message" || existing.kind !== "assistant_message") {
+      return false;
+    }
+    const existingGroupId = existing.blockGroupId ?? existing.id;
+    return (
+      item.blockGroupId === existingGroupId ||
+      item.id === existingGroupId ||
+      (item.messageId !== undefined && item.messageId === existing.messageId)
+    );
+  });
+}
+
+function insertBeforePreviousHead(params: {
+  tail: StreamItem[];
+  head: StreamItem[];
+  items: StreamItem[];
+  previousHead: StreamItem[];
+}): { tail: StreamItem[]; head: StreamItem[] } {
+  if (params.items.length === 0) return { tail: params.tail, head: params.head };
+
+  const matchesPreviousHead = (item: StreamItem) =>
+    belongsToPreviousHead(item, params.previousHead);
+  const tailAnchorIndex = params.tail.findIndex(matchesPreviousHead);
+  if (tailAnchorIndex >= 0) {
+    return {
+      tail: params.tail.toSpliced(tailAnchorIndex, 0, ...params.items),
+      head: params.head,
+    };
+  }
+
+  const headAnchorIndex = params.head.findIndex(matchesPreviousHead);
+  if (params.head.length > 0) {
+    let insertionIndex = params.previousHead.length > 0 ? 0 : params.head.length;
+    if (headAnchorIndex >= 0) insertionIndex = headAnchorIndex;
+    return {
+      tail: params.tail,
+      head: params.head.toSpliced(insertionIndex, 0, ...params.items),
+    };
+  }
+  return { tail: [...params.tail, ...params.items], head: params.head };
+}
+
 function restoreOptimisticUserMessages(params: {
   tail: StreamItem[];
   head: StreamItem[];
   optimistic: DetachedOptimisticUserMessage[];
   previousHead: StreamItem[];
+  precedingItems: StreamItem[];
 }): { tail: StreamItem[]; head: StreamItem[] } {
-  if (params.optimistic.length === 0) {
-    return { tail: params.tail, head: params.head };
-  }
   const tailOptimistic = params.optimistic
     .filter(({ placement }) => placement === "tail")
     .map(({ item }) => item);
   const headOptimistic = params.optimistic
     .filter(({ placement }) => placement === "head")
     .map(({ item }) => item);
-  let tail = params.tail;
-  let head = params.head;
-  if (tailOptimistic.length > 0) {
-    const matchesPreviousHead = (item: StreamItem) =>
-      params.previousHead.some((existing) => {
-        if (item.id === existing.id) return true;
-        if (item.kind !== "assistant_message" || existing.kind !== "assistant_message") {
-          return false;
-        }
-        const existingGroupId = existing.blockGroupId ?? existing.id;
-        return (
-          item.blockGroupId === existingGroupId ||
-          item.id === existingGroupId ||
-          (item.messageId !== undefined && item.messageId === existing.messageId)
-        );
-      });
-    const tailAnchorIndex = tail.findIndex(matchesPreviousHead);
-    const headAnchorIndex = head.findIndex(matchesPreviousHead);
-    if (tailAnchorIndex >= 0) {
-      tail = [...tail.slice(0, tailAnchorIndex), ...tailOptimistic, ...tail.slice(tailAnchorIndex)];
-    } else if (headAnchorIndex >= 0) {
-      head = [...head.slice(0, headAnchorIndex), ...tailOptimistic, ...head.slice(headAnchorIndex)];
-    } else if (params.previousHead.length > 0 && head.length > 0) {
-      head = [...tailOptimistic, ...head];
-    } else if (head.length > 0) {
-      head = [...head, ...tailOptimistic];
-    } else {
-      tail = [...tail, ...tailOptimistic];
-    }
-  }
+  const restored = insertBeforePreviousHead({
+    tail: params.tail,
+    head: params.head,
+    items: [...params.precedingItems, ...tailOptimistic],
+    previousHead: params.previousHead,
+  });
   return {
-    tail,
-    head: [...head, ...headOptimistic],
+    tail: restored.tail,
+    head: [...restored.head, ...headOptimistic],
   };
 }
 
@@ -793,10 +812,10 @@ function matchesOptimisticUserMessage(params: {
   if (event.type !== "timeline" || event.item.type !== "user_message") {
     return false;
   }
-  return (
-    event.item.messageId === params.optimistic.item.id ||
-    event.item.text === params.optimistic.item.text
-  );
+  if (event.item.messageId !== undefined) {
+    return event.item.messageId === params.optimistic.item.id;
+  }
+  return event.item.text.length > 0 && event.item.text === params.optimistic.item.text;
 }
 
 function acknowledgeOptimisticUserMessage(params: {
@@ -805,6 +824,8 @@ function acknowledgeOptimisticUserMessage(params: {
   unit: TimelineUnit;
   epoch: string;
   optimistic: DetachedOptimisticUserMessage;
+  previousHead: StreamItem[];
+  precedingItems: StreamItem[];
 }): { tail: StreamItem[]; head: StreamItem[] } {
   const { event, timestamp, seqEnd } = params.unit;
   const timelineCursor = { epoch: params.epoch, seq: seqEnd };
@@ -812,9 +833,18 @@ function acknowledgeOptimisticUserMessage(params: {
     source: "canonical",
     timelineCursor,
   });
+  const restored = insertBeforePreviousHead({
+    tail: params.tail,
+    head: params.head,
+    items:
+      params.optimistic.placement === "tail"
+        ? [...params.precedingItems, ...acknowledged]
+        : params.precedingItems,
+    previousHead: params.previousHead,
+  });
   return params.optimistic.placement === "head"
-    ? { tail: params.tail, head: [...params.head, ...acknowledged] }
-    : { tail: [...params.tail, ...acknowledged], head: params.head };
+    ? { tail: restored.tail, head: [...restored.head, ...acknowledged] }
+    : restored;
 }
 
 function applyCanonicalForwardUnit(params: {
@@ -881,7 +911,7 @@ function applyAcceptedForwardTimelineUnits(params: {
     if (reconciled.reconciledUnits.has(unit)) continue;
     const nextOptimistic = optimistic[optimisticIndex];
     if (nextOptimistic && matchesOptimisticUserMessage({ unit, optimistic: nextOptimistic })) {
-      tail = flushHeadToTail(tail, delayedHistoryHead);
+      const precedingItems = flushHeadToTail([], delayedHistoryHead);
       delayedHistoryHead = [];
       const applied = acknowledgeOptimisticUserMessage({
         tail,
@@ -889,6 +919,8 @@ function applyAcceptedForwardTimelineUnits(params: {
         unit,
         epoch: params.epoch,
         optimistic: nextOptimistic,
+        previousHead: params.currentHead,
+        precedingItems,
       });
       tail = applied.tail;
       head = applied.head;
@@ -925,13 +957,12 @@ function applyAcceptedForwardTimelineUnits(params: {
     head = applied.head;
   }
 
-  tail = flushHeadToTail(tail, delayedHistoryHead);
-
   return restoreOptimisticUserMessages({
     tail,
     head,
     optimistic: optimistic.slice(optimisticIndex),
     previousHead: params.currentHead,
+    precedingItems: flushHeadToTail([], delayedHistoryHead),
   });
 }
 

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -5,6 +5,7 @@ import { useSessionStore } from "@/stores/session-store";
 import type { AssistantMessageItem, StreamItem, UserMessageItem } from "@/types/stream";
 import {
   applyStreamEvent,
+  flushHeadToTail,
   hydrateStreamState,
   isAgentToolCallItem,
   mergeAgentToolCallItem,
@@ -784,31 +785,36 @@ function reconcileOverlappingProjectedStreamItems(params: {
   return { tail, head, reconciledUnits };
 }
 
-function stageOptimisticUserForCanonicalEvent(params: {
+function matchesOptimisticUserMessage(params: {
+  unit: TimelineUnit;
+  optimistic: DetachedOptimisticUserMessage;
+}): boolean {
+  const { event } = params.unit;
+  if (event.type !== "timeline" || event.item.type !== "user_message") {
+    return false;
+  }
+  return (
+    event.item.messageId === params.optimistic.item.id ||
+    event.item.text === params.optimistic.item.text
+  );
+}
+
+function acknowledgeOptimisticUserMessage(params: {
   tail: StreamItem[];
   head: StreamItem[];
-  event: AgentStreamEventPayload;
-  optimistic: DetachedOptimisticUserMessage | undefined;
-}): { tail: StreamItem[]; head: StreamItem[]; consumed: boolean } {
-  if (
-    params.event.type !== "timeline" ||
-    params.event.item.type !== "user_message" ||
-    !params.optimistic
-  ) {
-    return { tail: params.tail, head: params.head, consumed: false };
-  }
-  if (params.optimistic.placement === "head") {
-    return {
-      tail: params.tail,
-      head: [...params.head, params.optimistic.item],
-      consumed: true,
-    };
-  }
-  return {
-    tail: [...params.tail, params.optimistic.item],
-    head: params.head,
-    consumed: true,
-  };
+  unit: TimelineUnit;
+  epoch: string;
+  optimistic: DetachedOptimisticUserMessage;
+}): { tail: StreamItem[]; head: StreamItem[] } {
+  const { event, timestamp, seqEnd } = params.unit;
+  const timelineCursor = { epoch: params.epoch, seq: seqEnd };
+  const acknowledged = reduceStreamUpdate([params.optimistic.item], event, timestamp, {
+    source: "canonical",
+    timelineCursor,
+  });
+  return params.optimistic.placement === "head"
+    ? { tail: params.tail, head: [...params.head, ...acknowledged] }
+    : { tail: [...params.tail, ...acknowledged], head: params.head };
 }
 
 function applyCanonicalForwardUnit(params: {
@@ -816,32 +822,16 @@ function applyCanonicalForwardUnit(params: {
   head: StreamItem[];
   unit: TimelineUnit;
   epoch: string;
-  applyThroughHead: boolean;
-  optimisticPromptSeparatesHistory: boolean;
 }): { tail: StreamItem[]; head: StreamItem[] } {
   const { event, timestamp, seqEnd } = params.unit;
   const timelineCursor = { epoch: params.epoch, seq: seqEnd };
-  if (!params.applyThroughHead) {
+  if (params.head.length === 0) {
     return {
       tail: reduceStreamUpdate(params.tail, event, timestamp, {
         source: "canonical",
         timelineCursor,
       }),
       head: params.head,
-    };
-  }
-  if (
-    params.optimisticPromptSeparatesHistory &&
-    params.head.length === 0 &&
-    event.type === "timeline" &&
-    event.item.type === "assistant_message"
-  ) {
-    return {
-      tail: params.tail,
-      head: reduceStreamUpdate(params.head, event, timestamp, {
-        source: "canonical",
-        timelineCursor,
-      }),
     };
   }
   const replacedHead = replaceLiveAssistantWithProjectedText({
@@ -875,8 +865,6 @@ function applyAcceptedForwardTimelineUnits(params: {
     head: params.currentHead,
   });
   const optimistic = [...detached.optimistic];
-  const optimisticPromptSeparatesHistory = optimistic.length > 0;
-  const applyThroughHead = params.currentHead.length > 0 || optimisticPromptSeparatesHistory;
   const reconciled = reconcileOverlappingProjectedStreamItems({
     tail: detached.tail,
     head: detached.head,
@@ -886,33 +874,63 @@ function applyAcceptedForwardTimelineUnits(params: {
   });
   let tail = reconciled.tail;
   let head = reconciled.head;
-  let consumedOptimisticCount = 0;
+  let delayedHistoryHead: StreamItem[] = [];
+  let optimisticIndex = 0;
 
   for (const unit of params.units) {
     if (reconciled.reconciledUnits.has(unit)) continue;
-    const staged = stageOptimisticUserForCanonicalEvent({
-      tail,
-      head,
-      event: unit.event,
-      optimistic: optimistic[consumedOptimisticCount],
-    });
-    if (staged.consumed) consumedOptimisticCount += 1;
-    const applied = applyCanonicalForwardUnit({
-      tail: staged.tail,
-      head: staged.head,
-      unit,
-      epoch: params.epoch,
-      applyThroughHead,
-      optimisticPromptSeparatesHistory,
-    });
+    const nextOptimistic = optimistic[optimisticIndex];
+    if (nextOptimistic && matchesOptimisticUserMessage({ unit, optimistic: nextOptimistic })) {
+      tail = flushHeadToTail(tail, delayedHistoryHead);
+      delayedHistoryHead = [];
+      const applied = acknowledgeOptimisticUserMessage({
+        tail,
+        head,
+        unit,
+        epoch: params.epoch,
+        optimistic: nextOptimistic,
+      });
+      tail = applied.tail;
+      head = applied.head;
+      optimisticIndex += 1;
+      continue;
+    }
+    if (nextOptimistic) {
+      if (
+        unit.event.type === "timeline" &&
+        (unit.event.item.type === "assistant_message" || unit.event.item.type === "reasoning")
+      ) {
+        delayedHistoryHead = reduceStreamUpdate(delayedHistoryHead, unit.event, unit.timestamp, {
+          source: "canonical",
+          timelineCursor: { epoch: params.epoch, seq: unit.seqEnd },
+        });
+        continue;
+      }
+      const applied = applyStreamEvent({
+        tail,
+        head: delayedHistoryHead,
+        event: unit.event,
+        timestamp: unit.timestamp,
+        source: "canonical",
+        timelineCursor: { epoch: params.epoch, seq: unit.seqEnd },
+      });
+      tail = applied.tail;
+      delayedHistoryHead = applied.head;
+      continue;
+    }
+    tail = flushHeadToTail(tail, delayedHistoryHead);
+    delayedHistoryHead = [];
+    const applied = applyCanonicalForwardUnit({ tail, head, unit, epoch: params.epoch });
     tail = applied.tail;
     head = applied.head;
   }
 
+  tail = flushHeadToTail(tail, delayedHistoryHead);
+
   return restoreOptimisticUserMessages({
     tail,
     head,
-    optimistic: optimistic.slice(consumedOptimisticCount),
+    optimistic: optimistic.slice(optimisticIndex),
     previousHead: params.currentHead,
   });
 }

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -544,6 +544,287 @@ function replaceLiveAssistantWithProjectedText(params: {
   return next;
 }
 
+function detachOptimisticUserMessages(params: { tail: StreamItem[]; head: StreamItem[] }): {
+  tail: StreamItem[];
+  head: StreamItem[];
+  optimistic: UserMessageItem[];
+} {
+  const optimistic: UserMessageItem[] = [];
+  const withoutOptimistic = (items: StreamItem[]) =>
+    items.filter((item) => {
+      if (item.kind !== "user_message" || !item.optimistic) return true;
+      optimistic.push(item);
+      return false;
+    });
+
+  return {
+    tail: withoutOptimistic(params.tail),
+    head: withoutOptimistic(params.head),
+    optimistic,
+  };
+}
+
+function appendOptimisticUserMessages(params: {
+  tail: StreamItem[];
+  head: StreamItem[];
+  optimistic: UserMessageItem[];
+}): { tail: StreamItem[]; head: StreamItem[] } {
+  if (params.optimistic.length === 0) {
+    return { tail: params.tail, head: params.head };
+  }
+  if (params.head.length > 0) {
+    return { tail: params.tail, head: [...params.head, ...params.optimistic] };
+  }
+  return { tail: [...params.tail, ...params.optimistic], head: params.head };
+}
+
+function reconcileOverlappingProjectedAssistant(params: {
+  tail: StreamItem[];
+  head: StreamItem[];
+  unit: TimelineUnit;
+  epoch: string;
+  currentEndSeq: number;
+}): { tail: StreamItem[]; head: StreamItem[]; reconciled: boolean } {
+  const { unit } = params;
+  if (
+    unit.event.type !== "timeline" ||
+    unit.event.item.type !== "assistant_message" ||
+    !unit.sourceSeqRanges.some(
+      (range) => range.startSeq <= params.currentEndSeq && range.endSeq > params.currentEndSeq,
+    )
+  ) {
+    return { tail: params.tail, head: params.head, reconciled: false };
+  }
+
+  const projectedText = unit.event.item.text;
+  const projectedMessageId = unit.event.item.messageId;
+  const matches = (item: StreamItem) => {
+    if (item.kind !== "assistant_message") return false;
+    if (projectedMessageId && item.messageId) return item.messageId === projectedMessageId;
+    return projectedText.startsWith(item.text);
+  };
+  const replaceIn = (items: StreamItem[]): StreamItem[] | null => {
+    const index = items.findLastIndex(matches);
+    const current = items[index];
+    if (!current || current.kind !== "assistant_message") return null;
+    const next = [...items];
+    next[index] = {
+      ...current,
+      ...(projectedMessageId ? { messageId: projectedMessageId } : {}),
+      text: projectedText,
+      timestamp: unit.timestamp,
+      timelineCursor: { epoch: params.epoch, seq: unit.seqEnd },
+    };
+    return next;
+  };
+
+  const nextHead = replaceIn(params.head);
+  if (nextHead) {
+    return { tail: params.tail, head: nextHead, reconciled: true };
+  }
+  const nextTail = replaceIn(params.tail);
+  return nextTail
+    ? { tail: nextTail, head: params.head, reconciled: true }
+    : { tail: params.tail, head: params.head, reconciled: false };
+}
+
+function reconcileOverlappingProjectedReasoning(params: {
+  tail: StreamItem[];
+  head: StreamItem[];
+  unit: TimelineUnit;
+  currentEndSeq: number;
+}): { tail: StreamItem[]; head: StreamItem[]; reconciled: boolean } {
+  const { unit } = params;
+  if (
+    unit.event.type !== "timeline" ||
+    unit.event.item.type !== "reasoning" ||
+    !unit.sourceSeqRanges.some(
+      (range) => range.startSeq <= params.currentEndSeq && range.endSeq > params.currentEndSeq,
+    )
+  ) {
+    return { tail: params.tail, head: params.head, reconciled: false };
+  }
+
+  const projectedText = unit.event.item.text;
+  const replaceIn = (items: StreamItem[]): StreamItem[] | null => {
+    const index = items.findLastIndex(
+      (item) => item.kind === "thought" && projectedText.startsWith(item.text),
+    );
+    const current = items[index];
+    if (!current || current.kind !== "thought") return null;
+    const next = [...items];
+    next[index] = {
+      ...current,
+      text: projectedText,
+      timestamp: unit.timestamp,
+      status: "loading",
+    };
+    return next;
+  };
+
+  const nextHead = replaceIn(params.head);
+  if (nextHead) return { tail: params.tail, head: nextHead, reconciled: true };
+  const nextTail = replaceIn(params.tail);
+  return nextTail
+    ? { tail: nextTail, head: params.head, reconciled: true }
+    : { tail: params.tail, head: params.head, reconciled: false };
+}
+
+function reconcileOverlappingProjectedStreamItems(params: {
+  tail: StreamItem[];
+  head: StreamItem[];
+  units: TimelineUnit[];
+  epoch: string;
+  currentEndSeq: number | undefined;
+}): { tail: StreamItem[]; head: StreamItem[]; reconciledUnits: Set<TimelineUnit> } {
+  let tail = params.tail;
+  let head = params.head;
+  const reconciledUnits = new Set<TimelineUnit>();
+  if (params.currentEndSeq === undefined) return { tail, head, reconciledUnits };
+
+  for (const unit of params.units) {
+    let reconciled = reconcileOverlappingProjectedAssistant({
+      tail,
+      head,
+      unit,
+      epoch: params.epoch,
+      currentEndSeq: params.currentEndSeq,
+    });
+    if (!reconciled.reconciled) {
+      reconciled = reconcileOverlappingProjectedReasoning({
+        tail,
+        head,
+        unit,
+        currentEndSeq: params.currentEndSeq,
+      });
+    }
+    tail = reconciled.tail;
+    head = reconciled.head;
+    if (reconciled.reconciled) reconciledUnits.add(unit);
+  }
+  return { tail, head, reconciledUnits };
+}
+
+function stageOptimisticUserForCanonicalEvent(params: {
+  tail: StreamItem[];
+  head: StreamItem[];
+  event: AgentStreamEventPayload;
+  optimistic: UserMessageItem[];
+}): { tail: StreamItem[]; head: StreamItem[] } {
+  if (
+    params.event.type !== "timeline" ||
+    params.event.item.type !== "user_message" ||
+    params.optimistic.length === 0
+  ) {
+    return { tail: params.tail, head: params.head };
+  }
+  const pending = params.optimistic.shift();
+  if (!pending) return { tail: params.tail, head: params.head };
+  if (params.head.length > 0) {
+    return { tail: params.tail, head: [...params.head, pending] };
+  }
+  return { tail: [...params.tail, pending], head: params.head };
+}
+
+function applyCanonicalForwardUnit(params: {
+  tail: StreamItem[];
+  head: StreamItem[];
+  unit: TimelineUnit;
+  epoch: string;
+  applyThroughHead: boolean;
+  optimisticPromptSeparatesHistory: boolean;
+}): { tail: StreamItem[]; head: StreamItem[] } {
+  const { event, timestamp, seqEnd } = params.unit;
+  const timelineCursor = { epoch: params.epoch, seq: seqEnd };
+  if (!params.applyThroughHead) {
+    return {
+      tail: reduceStreamUpdate(params.tail, event, timestamp, {
+        source: "canonical",
+        timelineCursor,
+      }),
+      head: params.head,
+    };
+  }
+  if (
+    params.optimisticPromptSeparatesHistory &&
+    params.head.length === 0 &&
+    event.type === "timeline" &&
+    event.item.type === "assistant_message"
+  ) {
+    return {
+      tail: params.tail,
+      head: reduceStreamUpdate(params.head, event, timestamp, {
+        source: "canonical",
+        timelineCursor,
+      }),
+    };
+  }
+  const replacedHead = replaceLiveAssistantWithProjectedText({
+    head: params.head,
+    event,
+    timestamp,
+    timelineCursor,
+  });
+  if (replacedHead) return { tail: params.tail, head: replacedHead };
+
+  const applied = applyStreamEvent({
+    tail: params.tail,
+    head: params.head,
+    event,
+    timestamp,
+    source: "canonical",
+    timelineCursor,
+  });
+  return { tail: applied.tail, head: applied.head };
+}
+
+function applyAcceptedForwardTimelineUnits(params: {
+  units: TimelineUnit[];
+  epoch: string;
+  currentTail: StreamItem[];
+  currentHead: StreamItem[];
+  currentEndSeq: number | undefined;
+}): { tail: StreamItem[]; head: StreamItem[] } {
+  const detached = detachOptimisticUserMessages({
+    tail: params.currentTail,
+    head: params.currentHead,
+  });
+  const optimistic = [...detached.optimistic];
+  const optimisticPromptSeparatesHistory = optimistic.length > 0;
+  const applyThroughHead = params.currentHead.length > 0 || optimisticPromptSeparatesHistory;
+  const reconciled = reconcileOverlappingProjectedStreamItems({
+    tail: detached.tail,
+    head: detached.head,
+    units: params.units,
+    epoch: params.epoch,
+    currentEndSeq: params.currentEndSeq,
+  });
+  let tail = reconciled.tail;
+  let head = reconciled.head;
+
+  for (const unit of params.units) {
+    if (reconciled.reconciledUnits.has(unit)) continue;
+    const staged = stageOptimisticUserForCanonicalEvent({
+      tail,
+      head,
+      event: unit.event,
+      optimistic,
+    });
+    const applied = applyCanonicalForwardUnit({
+      tail: staged.tail,
+      head: staged.head,
+      unit,
+      epoch: params.epoch,
+      applyThroughHead,
+      optimisticPromptSeparatesHistory,
+    });
+    tail = applied.tail;
+    head = applied.head;
+  }
+
+  return appendOptimisticUserMessages({ tail, head, optimistic });
+}
+
 function applyTimelineIncrementalPath(args: {
   timelineUnits: TimelineUnit[];
   payload: ProcessTimelineResponseInput["payload"];
@@ -586,39 +867,16 @@ function applyTimelineIncrementalPath(args: {
         { source: "canonical" },
       );
       nextTail = mergePrependedCanonicalTail(olderTail, currentTail);
-    } else if (currentHead.length > 0) {
-      for (const { event, timestamp, seqEnd } of acceptedUnits) {
-        const timelineCursor = { epoch: payload.epoch, seq: seqEnd };
-        const replacedHead = replaceLiveAssistantWithProjectedText({
-          head: nextHead,
-          event,
-          timestamp,
-          timelineCursor,
-        });
-        if (replacedHead) {
-          nextHead = replacedHead;
-          continue;
-        }
-        const applied = applyStreamEvent({
-          tail: nextTail,
-          head: nextHead,
-          event,
-          timestamp,
-          source: "canonical",
-          timelineCursor,
-        });
-        nextTail = applied.tail;
-        nextHead = applied.head;
-      }
     } else {
-      nextTail = acceptedUnits.reduce<StreamItem[]>(
-        (state, { event, timestamp, seqEnd }) =>
-          reduceStreamUpdate(state, event, timestamp, {
-            source: "canonical",
-            timelineCursor: { epoch: payload.epoch, seq: seqEnd },
-          }),
-        currentTail,
-      );
+      const applied = applyAcceptedForwardTimelineUnits({
+        units: acceptedUnits,
+        epoch: payload.epoch,
+        currentTail: nextTail,
+        currentHead: nextHead,
+        currentEndSeq: currentCursor?.endSeq,
+      });
+      nextTail = applied.tail;
+      nextHead = applied.head;
     }
   }
 

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -2,7 +2,7 @@ import type { AgentStreamEventPayload } from "@getpaseo/protocol/messages";
 import type { AgentLifecycleStatus } from "@getpaseo/protocol/agent-lifecycle";
 import type { Agent } from "@/stores/session-store";
 import { useSessionStore } from "@/stores/session-store";
-import type { StreamItem, UserMessageItem } from "@/types/stream";
+import type { AssistantMessageItem, StreamItem, UserMessageItem } from "@/types/stream";
 import {
   applyStreamEvent,
   hydrateStreamState,
@@ -544,38 +544,80 @@ function replaceLiveAssistantWithProjectedText(params: {
   return next;
 }
 
+interface DetachedOptimisticUserMessage {
+  item: UserMessageItem;
+  placement: "tail" | "head";
+}
+
 function detachOptimisticUserMessages(params: { tail: StreamItem[]; head: StreamItem[] }): {
   tail: StreamItem[];
   head: StreamItem[];
-  optimistic: UserMessageItem[];
+  optimistic: DetachedOptimisticUserMessage[];
 } {
-  const optimistic: UserMessageItem[] = [];
-  const withoutOptimistic = (items: StreamItem[]) =>
+  const optimistic: DetachedOptimisticUserMessage[] = [];
+  const withoutOptimistic = (items: StreamItem[], placement: "tail" | "head") =>
     items.filter((item) => {
       if (item.kind !== "user_message" || !item.optimistic) return true;
-      optimistic.push(item);
+      optimistic.push({ item, placement });
       return false;
     });
 
   return {
-    tail: withoutOptimistic(params.tail),
-    head: withoutOptimistic(params.head),
+    tail: withoutOptimistic(params.tail, "tail"),
+    head: withoutOptimistic(params.head, "head"),
     optimistic,
   };
 }
 
-function appendOptimisticUserMessages(params: {
+function restoreOptimisticUserMessages(params: {
   tail: StreamItem[];
   head: StreamItem[];
-  optimistic: UserMessageItem[];
+  optimistic: DetachedOptimisticUserMessage[];
+  previousHead: StreamItem[];
 }): { tail: StreamItem[]; head: StreamItem[] } {
   if (params.optimistic.length === 0) {
     return { tail: params.tail, head: params.head };
   }
-  if (params.head.length > 0) {
-    return { tail: params.tail, head: [...params.head, ...params.optimistic] };
+  const tailOptimistic = params.optimistic
+    .filter(({ placement }) => placement === "tail")
+    .map(({ item }) => item);
+  const headOptimistic = params.optimistic
+    .filter(({ placement }) => placement === "head")
+    .map(({ item }) => item);
+  let tail = params.tail;
+  let head = params.head;
+  if (tailOptimistic.length > 0) {
+    const matchesPreviousHead = (item: StreamItem) =>
+      params.previousHead.some((existing) => {
+        if (item.id === existing.id) return true;
+        if (item.kind !== "assistant_message" || existing.kind !== "assistant_message") {
+          return false;
+        }
+        const existingGroupId = existing.blockGroupId ?? existing.id;
+        return (
+          item.blockGroupId === existingGroupId ||
+          item.id === existingGroupId ||
+          (item.messageId !== undefined && item.messageId === existing.messageId)
+        );
+      });
+    const tailAnchorIndex = tail.findIndex(matchesPreviousHead);
+    const headAnchorIndex = head.findIndex(matchesPreviousHead);
+    if (tailAnchorIndex >= 0) {
+      tail = [...tail.slice(0, tailAnchorIndex), ...tailOptimistic, ...tail.slice(tailAnchorIndex)];
+    } else if (headAnchorIndex >= 0) {
+      head = [...head.slice(0, headAnchorIndex), ...tailOptimistic, ...head.slice(headAnchorIndex)];
+    } else if (params.previousHead.length > 0 && head.length > 0) {
+      head = [...tailOptimistic, ...head];
+    } else if (head.length > 0) {
+      head = [...head, ...tailOptimistic];
+    } else {
+      tail = [...tail, ...tailOptimistic];
+    }
   }
-  return { tail: [...params.tail, ...params.optimistic], head: params.head };
+  return {
+    tail,
+    head: [...head, ...headOptimistic],
+  };
 }
 
 function reconcileOverlappingProjectedAssistant(params: {
@@ -603,29 +645,66 @@ function reconcileOverlappingProjectedAssistant(params: {
     if (projectedMessageId && item.messageId) return item.messageId === projectedMessageId;
     return projectedText.startsWith(item.text);
   };
-  const replaceIn = (items: StreamItem[]): StreamItem[] | null => {
+  const findMatch = (items: StreamItem[]) => {
     const index = items.findLastIndex(matches);
     const current = items[index];
-    if (!current || current.kind !== "assistant_message") return null;
-    const next = [...items];
-    next[index] = {
-      ...current,
-      ...(projectedMessageId ? { messageId: projectedMessageId } : {}),
-      text: projectedText,
-      timestamp: unit.timestamp,
-      timelineCursor: { epoch: params.epoch, seq: unit.seqEnd },
-    };
+    return current?.kind === "assistant_message" ? { current, index } : null;
+  };
+
+  const headMatch = findMatch(params.head);
+  const tailMatch = headMatch ? null : findMatch(params.tail);
+  const match = headMatch ?? tailMatch;
+  if (!match) {
+    return { tail: params.tail, head: params.head, reconciled: false };
+  }
+
+  const blockGroupId = match.current.blockGroupId;
+  const messageId = projectedMessageId ?? match.current.messageId;
+  const replacement: AssistantMessageItem = {
+    kind: "assistant_message",
+    id: blockGroupId ?? match.current.id,
+    ...(messageId !== undefined ? { messageId } : {}),
+    text: projectedText,
+    timestamp: unit.timestamp,
+    timelineCursor: { epoch: params.epoch, seq: unit.seqEnd },
+  };
+  const belongsToBlockGroup = (item: StreamItem) =>
+    blockGroupId !== undefined &&
+    item.kind === "assistant_message" &&
+    item.blockGroupId === blockGroupId;
+  const removeBlockGroup = (items: StreamItem[]) =>
+    blockGroupId !== undefined ? items.filter((item) => !belongsToBlockGroup(item)) : items;
+  const replaceMatch = (items: StreamItem[], index: number) => {
+    if (!blockGroupId) {
+      const next = [...items];
+      next[index] = replacement;
+      return next;
+    }
+    const next: StreamItem[] = [];
+    let inserted = false;
+    for (const item of items) {
+      if (!belongsToBlockGroup(item)) {
+        next.push(item);
+      } else if (!inserted) {
+        next.push(replacement);
+        inserted = true;
+      }
+    }
     return next;
   };
 
-  const nextHead = replaceIn(params.head);
-  if (nextHead) {
-    return { tail: params.tail, head: nextHead, reconciled: true };
+  if (headMatch) {
+    return {
+      tail: removeBlockGroup(params.tail),
+      head: replaceMatch(params.head, headMatch.index),
+      reconciled: true,
+    };
   }
-  const nextTail = replaceIn(params.tail);
-  return nextTail
-    ? { tail: nextTail, head: params.head, reconciled: true }
-    : { tail: params.tail, head: params.head, reconciled: false };
+  return {
+    tail: replaceMatch(params.tail, match.index),
+    head: removeBlockGroup(params.head),
+    reconciled: true,
+  };
 }
 
 function reconcileOverlappingProjectedReasoning(params: {
@@ -709,7 +788,7 @@ function stageOptimisticUserForCanonicalEvent(params: {
   tail: StreamItem[];
   head: StreamItem[];
   event: AgentStreamEventPayload;
-  optimistic: UserMessageItem | undefined;
+  optimistic: DetachedOptimisticUserMessage | undefined;
 }): { tail: StreamItem[]; head: StreamItem[]; consumed: boolean } {
   if (
     params.event.type !== "timeline" ||
@@ -718,10 +797,18 @@ function stageOptimisticUserForCanonicalEvent(params: {
   ) {
     return { tail: params.tail, head: params.head, consumed: false };
   }
-  if (params.head.length > 0) {
-    return { tail: params.tail, head: [...params.head, params.optimistic], consumed: true };
+  if (params.optimistic.placement === "head") {
+    return {
+      tail: params.tail,
+      head: [...params.head, params.optimistic.item],
+      consumed: true,
+    };
   }
-  return { tail: [...params.tail, params.optimistic], head: params.head, consumed: true };
+  return {
+    tail: [...params.tail, params.optimistic.item],
+    head: params.head,
+    consumed: true,
+  };
 }
 
 function applyCanonicalForwardUnit(params: {
@@ -822,10 +909,11 @@ function applyAcceptedForwardTimelineUnits(params: {
     head = applied.head;
   }
 
-  return appendOptimisticUserMessages({
+  return restoreOptimisticUserMessages({
     tail,
     head,
     optimistic: optimistic.slice(consumedOptimisticCount),
+    previousHead: params.currentHead,
   });
 }
 

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -598,7 +598,11 @@ function insertBeforePreviousHead(params: {
   const tailAnchorIndex = params.tail.findIndex(matchesPreviousHead);
   if (tailAnchorIndex >= 0) {
     return {
-      tail: params.tail.toSpliced(tailAnchorIndex, 0, ...params.items),
+      tail: [
+        ...params.tail.slice(0, tailAnchorIndex),
+        ...params.items,
+        ...params.tail.slice(tailAnchorIndex),
+      ],
       head: params.head,
     };
   }
@@ -609,7 +613,11 @@ function insertBeforePreviousHead(params: {
     if (headAnchorIndex >= 0) insertionIndex = headAnchorIndex;
     return {
       tail: params.tail,
-      head: params.head.toSpliced(insertionIndex, 0, ...params.items),
+      head: [
+        ...params.head.slice(0, insertionIndex),
+        ...params.items,
+        ...params.head.slice(insertionIndex),
+      ],
     };
   }
   return { tail: [...params.tail, ...params.items], head: params.head };

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -904,6 +904,7 @@ function applyAcceptedForwardTimelineUnits(params: {
   });
   let tail = reconciled.tail;
   let head = reconciled.head;
+  let delayedHistoryTail: StreamItem[] = [];
   let delayedHistoryHead: StreamItem[] = [];
   let optimisticIndex = 0;
 
@@ -911,7 +912,8 @@ function applyAcceptedForwardTimelineUnits(params: {
     if (reconciled.reconciledUnits.has(unit)) continue;
     const nextOptimistic = optimistic[optimisticIndex];
     if (nextOptimistic && matchesOptimisticUserMessage({ unit, optimistic: nextOptimistic })) {
-      const precedingItems = flushHeadToTail([], delayedHistoryHead);
+      const precedingItems = flushHeadToTail(delayedHistoryTail, delayedHistoryHead);
+      delayedHistoryTail = [];
       delayedHistoryHead = [];
       const applied = acknowledgeOptimisticUserMessage({
         tail,
@@ -939,18 +941,20 @@ function applyAcceptedForwardTimelineUnits(params: {
         continue;
       }
       const applied = applyStreamEvent({
-        tail,
+        tail: delayedHistoryTail,
         head: delayedHistoryHead,
         event: unit.event,
         timestamp: unit.timestamp,
         source: "canonical",
         timelineCursor: { epoch: params.epoch, seq: unit.seqEnd },
       });
-      tail = applied.tail;
+      delayedHistoryTail = applied.tail;
       delayedHistoryHead = applied.head;
       continue;
     }
-    tail = flushHeadToTail(tail, delayedHistoryHead);
+    const precedingItems = flushHeadToTail(delayedHistoryTail, delayedHistoryHead);
+    tail = flushHeadToTail(tail, precedingItems);
+    delayedHistoryTail = [];
     delayedHistoryHead = [];
     const applied = applyCanonicalForwardUnit({ tail, head, unit, epoch: params.epoch });
     tail = applied.tail;
@@ -962,7 +966,7 @@ function applyAcceptedForwardTimelineUnits(params: {
     head,
     optimistic: optimistic.slice(optimisticIndex),
     previousHead: params.currentHead,
-    precedingItems: flushHeadToTail([], delayedHistoryHead),
+    precedingItems: flushHeadToTail(delayedHistoryTail, delayedHistoryHead),
   });
 }
 

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -545,106 +545,59 @@ function replaceLiveAssistantWithProjectedText(params: {
   return next;
 }
 
-interface DetachedOptimisticUserMessage {
+interface OptimisticUserMessagePosition {
   item: UserMessageItem;
   placement: "tail" | "head";
+  index: number;
 }
 
-function detachOptimisticUserMessages(params: { tail: StreamItem[]; head: StreamItem[] }): {
+function findOptimisticUserMessage(params: {
   tail: StreamItem[];
   head: StreamItem[];
-  optimistic: DetachedOptimisticUserMessage[];
-} {
-  const optimistic: DetachedOptimisticUserMessage[] = [];
-  const withoutOptimistic = (items: StreamItem[], placement: "tail" | "head") =>
-    items.filter((item) => {
-      if (item.kind !== "user_message" || !item.optimistic) return true;
-      optimistic.push({ item, placement });
-      return false;
-    });
+}): OptimisticUserMessagePosition | null {
+  const tailIndex = params.tail.findIndex(
+    (item) => item.kind === "user_message" && item.optimistic,
+  );
+  const tailItem = params.tail[tailIndex];
+  if (tailItem?.kind === "user_message") {
+    return { item: tailItem, placement: "tail", index: tailIndex };
+  }
 
-  return {
-    tail: withoutOptimistic(params.tail, "tail"),
-    head: withoutOptimistic(params.head, "head"),
-    optimistic,
-  };
+  const headIndex = params.head.findIndex(
+    (item) => item.kind === "user_message" && item.optimistic,
+  );
+  const headItem = params.head[headIndex];
+  return headItem?.kind === "user_message"
+    ? { item: headItem, placement: "head", index: headIndex }
+    : null;
 }
 
-function belongsToPreviousHead(item: StreamItem, previousHead: StreamItem[]): boolean {
-  return previousHead.some((existing) => {
-    if (item.id === existing.id) return true;
-    if (item.kind !== "assistant_message" || existing.kind !== "assistant_message") {
-      return false;
-    }
-    const existingGroupId = existing.blockGroupId ?? existing.id;
-    return (
-      item.blockGroupId === existingGroupId ||
-      item.id === existingGroupId ||
-      (item.messageId !== undefined && item.messageId === existing.messageId)
-    );
-  });
-}
-
-function insertBeforePreviousHead(params: {
+function replaceOptimisticUserMessage(params: {
   tail: StreamItem[];
   head: StreamItem[];
-  items: StreamItem[];
-  previousHead: StreamItem[];
+  position: OptimisticUserMessagePosition;
+  precedingItems: StreamItem[];
+  replacement: StreamItem[];
 }): { tail: StreamItem[]; head: StreamItem[] } {
-  if (params.items.length === 0) return { tail: params.tail, head: params.head };
-
-  const matchesPreviousHead = (item: StreamItem) =>
-    belongsToPreviousHead(item, params.previousHead);
-  const tailAnchorIndex = params.tail.findIndex(matchesPreviousHead);
-  if (tailAnchorIndex >= 0) {
+  const { position } = params;
+  const items = [...params.precedingItems, ...params.replacement];
+  if (position.placement === "tail") {
     return {
       tail: [
-        ...params.tail.slice(0, tailAnchorIndex),
-        ...params.items,
-        ...params.tail.slice(tailAnchorIndex),
+        ...params.tail.slice(0, position.index),
+        ...items,
+        ...params.tail.slice(position.index + 1),
       ],
       head: params.head,
     };
   }
-
-  const headAnchorIndex = params.head.findIndex(matchesPreviousHead);
-  if (params.head.length > 0) {
-    let insertionIndex = params.previousHead.length > 0 ? 0 : params.head.length;
-    if (headAnchorIndex >= 0) insertionIndex = headAnchorIndex;
-    return {
-      tail: params.tail,
-      head: [
-        ...params.head.slice(0, insertionIndex),
-        ...params.items,
-        ...params.head.slice(insertionIndex),
-      ],
-    };
-  }
-  return { tail: [...params.tail, ...params.items], head: params.head };
-}
-
-function restoreOptimisticUserMessages(params: {
-  tail: StreamItem[];
-  head: StreamItem[];
-  optimistic: DetachedOptimisticUserMessage[];
-  previousHead: StreamItem[];
-  precedingItems: StreamItem[];
-}): { tail: StreamItem[]; head: StreamItem[] } {
-  const tailOptimistic = params.optimistic
-    .filter(({ placement }) => placement === "tail")
-    .map(({ item }) => item);
-  const headOptimistic = params.optimistic
-    .filter(({ placement }) => placement === "head")
-    .map(({ item }) => item);
-  const restored = insertBeforePreviousHead({
-    tail: params.tail,
-    head: params.head,
-    items: [...params.precedingItems, ...tailOptimistic],
-    previousHead: params.previousHead,
-  });
   return {
-    tail: restored.tail,
-    head: [...restored.head, ...headOptimistic],
+    tail: params.tail,
+    head: [
+      ...params.head.slice(0, position.index),
+      ...items,
+      ...params.head.slice(position.index + 1),
+    ],
   };
 }
 
@@ -814,16 +767,16 @@ function reconcileOverlappingProjectedStreamItems(params: {
 
 function matchesOptimisticUserMessage(params: {
   unit: TimelineUnit;
-  optimistic: DetachedOptimisticUserMessage;
+  optimistic: UserMessageItem;
 }): boolean {
   const { event } = params.unit;
   if (event.type !== "timeline" || event.item.type !== "user_message") {
     return false;
   }
   if (event.item.messageId !== undefined) {
-    return event.item.messageId === params.optimistic.item.id;
+    return event.item.messageId === params.optimistic.id;
   }
-  return event.item.text.length > 0 && event.item.text === params.optimistic.item.text;
+  return event.item.text.length > 0 && event.item.text === params.optimistic.text;
 }
 
 function acknowledgeOptimisticUserMessage(params: {
@@ -831,8 +784,7 @@ function acknowledgeOptimisticUserMessage(params: {
   head: StreamItem[];
   unit: TimelineUnit;
   epoch: string;
-  optimistic: DetachedOptimisticUserMessage;
-  previousHead: StreamItem[];
+  optimistic: OptimisticUserMessagePosition;
   precedingItems: StreamItem[];
 }): { tail: StreamItem[]; head: StreamItem[] } {
   const { event, timestamp, seqEnd } = params.unit;
@@ -841,18 +793,13 @@ function acknowledgeOptimisticUserMessage(params: {
     source: "canonical",
     timelineCursor,
   });
-  const restored = insertBeforePreviousHead({
+  return replaceOptimisticUserMessage({
     tail: params.tail,
     head: params.head,
-    items:
-      params.optimistic.placement === "tail"
-        ? [...params.precedingItems, ...acknowledged]
-        : params.precedingItems,
-    previousHead: params.previousHead,
+    position: params.optimistic,
+    precedingItems: params.precedingItems,
+    replacement: acknowledged,
   });
-  return params.optimistic.placement === "head"
-    ? { tail: restored.tail, head: [...restored.head, ...acknowledged] }
-    : restored;
 }
 
 function applyCanonicalForwardUnit(params: {
@@ -898,14 +845,9 @@ function applyAcceptedForwardTimelineUnits(params: {
   currentHead: StreamItem[];
   currentEndSeq: number | undefined;
 }): { tail: StreamItem[]; head: StreamItem[] } {
-  const detached = detachOptimisticUserMessages({
+  const reconciled = reconcileOverlappingProjectedStreamItems({
     tail: params.currentTail,
     head: params.currentHead,
-  });
-  const optimistic = [...detached.optimistic];
-  const reconciled = reconcileOverlappingProjectedStreamItems({
-    tail: detached.tail,
-    head: detached.head,
     units: params.units,
     epoch: params.epoch,
     currentEndSeq: params.currentEndSeq,
@@ -914,12 +856,11 @@ function applyAcceptedForwardTimelineUnits(params: {
   let head = reconciled.head;
   let delayedHistoryTail: StreamItem[] = [];
   let delayedHistoryHead: StreamItem[] = [];
-  let optimisticIndex = 0;
 
   for (const unit of params.units) {
     if (reconciled.reconciledUnits.has(unit)) continue;
-    const nextOptimistic = optimistic[optimisticIndex];
-    if (nextOptimistic && matchesOptimisticUserMessage({ unit, optimistic: nextOptimistic })) {
+    const nextOptimistic = findOptimisticUserMessage({ tail, head });
+    if (nextOptimistic && matchesOptimisticUserMessage({ unit, optimistic: nextOptimistic.item })) {
       const precedingItems = flushHeadToTail(delayedHistoryTail, delayedHistoryHead);
       delayedHistoryTail = [];
       delayedHistoryHead = [];
@@ -929,12 +870,10 @@ function applyAcceptedForwardTimelineUnits(params: {
         unit,
         epoch: params.epoch,
         optimistic: nextOptimistic,
-        previousHead: params.currentHead,
         precedingItems,
       });
       tail = applied.tail;
       head = applied.head;
-      optimisticIndex += 1;
       continue;
     }
     if (nextOptimistic) {
@@ -960,21 +899,21 @@ function applyAcceptedForwardTimelineUnits(params: {
       delayedHistoryHead = applied.head;
       continue;
     }
-    const precedingItems = flushHeadToTail(delayedHistoryTail, delayedHistoryHead);
-    tail = flushHeadToTail(tail, precedingItems);
-    delayedHistoryTail = [];
-    delayedHistoryHead = [];
     const applied = applyCanonicalForwardUnit({ tail, head, unit, epoch: params.epoch });
     tail = applied.tail;
     head = applied.head;
   }
 
-  return restoreOptimisticUserMessages({
+  const remainingOptimistic = findOptimisticUserMessage({ tail, head });
+  if (!remainingOptimistic) return { tail, head };
+  const precedingItems = flushHeadToTail(delayedHistoryTail, delayedHistoryHead);
+  if (precedingItems.length === 0) return { tail, head };
+  return replaceOptimisticUserMessage({
     tail,
     head,
-    optimistic: optimistic.slice(optimisticIndex),
-    previousHead: params.currentHead,
-    precedingItems: flushHeadToTail(delayedHistoryTail, delayedHistoryHead),
+    position: remainingOptimistic,
+    precedingItems,
+    replacement: [remainingOptimistic.item],
   });
 }
 

--- a/packages/app/src/timeline/viewed-timeline-sync.test.ts
+++ b/packages/app/src/timeline/viewed-timeline-sync.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "vitest";
 import type { ProjectedTimelineForwardFetchPlan } from "./timeline-sync-plan";
-import { createViewedTimelineSync } from "./viewed-timeline-sync";
+import {
+  createViewedTimelineSync,
+  VIEWED_TIMELINE_UNSUBSCRIBE_GRACE_MS,
+} from "./viewed-timeline-sync";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -34,6 +37,7 @@ interface TimelineFetch {
 class TimelineWorld {
   readonly errors: string[] = [];
   readonly sync = createViewedTimelineSync({
+    initialDeliveryMode: "selective",
     setSubscription: async (agentIds) => {
       const result = deferred<void>();
       this.memberships.push({
@@ -69,13 +73,17 @@ class TimelineWorld {
       const waiter = this.errorWaiters.shift();
       if (waiter) waiter(this.errors.at(-1) ?? "");
     },
-    scheduleRetry: (retry) => {
-      this.retries.push(retry);
+    schedule: (task, delayMs) => {
+      const scheduled = { task, delayMs };
+      this.scheduled.push(scheduled);
       const waiter = this.retryWaiters.shift();
-      if (waiter) waiter(this.retries.shift()!);
+      if (waiter && delayMs === 1_000) {
+        this.scheduled.splice(this.scheduled.indexOf(scheduled), 1);
+        waiter(task);
+      }
       return () => {
-        const index = this.retries.indexOf(retry);
-        if (index >= 0) this.retries.splice(index, 1);
+        const index = this.scheduled.indexOf(scheduled);
+        if (index >= 0) this.scheduled.splice(index, 1);
       };
     },
   });
@@ -90,7 +98,7 @@ class TimelineWorld {
   private readonly cursors = new Map<string, { epoch: string; startSeq: number; endSeq: number }>();
   private readonly authoritativeHistory = new Set<string>();
   private readonly errorWaiters: Array<(message: string) => void> = [];
-  private readonly retries: Array<() => void> = [];
+  private readonly scheduled: Array<{ task: () => void; delayMs: number }> = [];
   private readonly retryWaiters: Array<(retry: () => void) => void> = [];
 
   setCursor(agentId: string, endSeq: number): void {
@@ -129,9 +137,23 @@ class TimelineWorld {
   }
 
   nextRetry(): Promise<() => void> {
-    const retry = this.retries.shift();
-    if (retry) return Promise.resolve(retry);
+    const index = this.scheduled.findIndex((entry) => entry.delayMs === 1_000);
+    if (index >= 0) return Promise.resolve(this.scheduled.splice(index, 1)[0].task);
     return new Promise((resolve) => this.retryWaiters.push(resolve));
+  }
+
+  runUnsubscribeGrace(): void {
+    const index = this.scheduled.findIndex(
+      (entry) => entry.delayMs === VIEWED_TIMELINE_UNSUBSCRIBE_GRACE_MS,
+    );
+    expect(index).toBeGreaterThanOrEqual(0);
+    this.scheduled.splice(index, 1)[0].task();
+  }
+
+  expectNoPendingUnsubscribe(): void {
+    expect(
+      this.scheduled.filter((entry) => entry.delayMs === VIEWED_TIMELINE_UNSUBSCRIBE_GRACE_MS),
+    ).toEqual([]);
   }
 
   private releaseMembershipWaiter(): void {
@@ -211,6 +233,7 @@ test("membership changes during acknowledgement never catch up the stale set", a
   const staleMembership = await world.nextMembership();
 
   world.sync.replaceVisibleAgentIds("workspace", ["agent-b"]);
+  world.runUnsubscribeGrace();
   staleMembership.succeed();
   const currentMembership = await world.nextMembership();
   currentMembership.succeed();
@@ -236,6 +259,7 @@ test("removing one agent during paging cancels only that agent", async () => {
   ]);
 
   world.sync.replaceVisibleAgentIds("workspace", ["agent-b"]);
+  world.runUnsubscribeGrace();
   const replacement = await world.nextMembership();
   agentA.respond({ hasNewer: true, seq: 4 });
   agentB.respond({ hasNewer: true, seq: 7 });
@@ -283,7 +307,9 @@ test("overlapping sources deduplicate membership and source removal preserves re
 
   world.sync.replaceVisibleAgentIds("left-route", []);
   world.expectNoPendingMembership();
+  world.expectNoPendingUnsubscribe();
   world.sync.replaceVisibleAgentIds("right-route", ["agent-b"]);
+  world.runUnsubscribeGrace();
   const remaining = await world.nextMembership();
   remaining.succeed();
 
@@ -417,6 +443,7 @@ test("stale membership retry cannot overwrite a newer effective set", async () =
   const staleRetry = await world.nextRetry();
 
   world.sync.replaceVisibleAgentIds("workspace", ["agent-b"]);
+  world.runUnsubscribeGrace();
   const current = await world.nextMembership();
   staleRetry();
   current.succeed();
@@ -445,4 +472,154 @@ test("membership retry cannot run while disconnected", async () => {
   catchUp.respond({ hasNewer: false });
 
   expect(restored.agentIds).toEqual(["agent-a"]);
+});
+
+test("quickly returning to an agent cancels its pending unsubscribe without another catch-up", async () => {
+  const world = new TimelineWorld();
+  world.sync.setConnected(true);
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+  const membership = await world.nextMembership();
+  membership.succeed();
+  const initialCatchUp = await world.nextFetch("agent-a");
+  initialCatchUp.respond({ hasNewer: false });
+
+  world.sync.replaceVisibleAgentIds("workspace", []);
+  world.expectNoPendingMembership();
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+
+  world.expectNoPendingUnsubscribe();
+  world.expectNoPendingMembership();
+  world.expectNoPendingFetch();
+});
+
+test("unsubscribe grace expiry removes the agent exactly once", async () => {
+  const world = new TimelineWorld();
+  world.sync.setConnected(true);
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+  const membership = await world.nextMembership();
+  membership.succeed();
+  const catchUp = await world.nextFetch("agent-a");
+  catchUp.respond({ hasNewer: false });
+
+  world.sync.replaceVisibleAgentIds("workspace", []);
+  world.runUnsubscribeGrace();
+  const unsubscribe = await world.nextMembership();
+  unsubscribe.succeed();
+
+  expect(unsubscribe.agentIds).toEqual([]);
+  world.expectNoPendingUnsubscribe();
+  world.expectNoPendingMembership();
+});
+
+test("a new visible agent subscribes immediately while the previous agent lingers", async () => {
+  const world = new TimelineWorld();
+  world.sync.setConnected(true);
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+  const initialMembership = await world.nextMembership();
+  initialMembership.succeed();
+  const initialCatchUp = await world.nextFetch("agent-a");
+  initialCatchUp.respond({ hasNewer: false });
+
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-b"]);
+  const expandedMembership = await world.nextMembership();
+  expandedMembership.succeed();
+  const agentBCatchUp = await world.nextFetch("agent-b");
+  agentBCatchUp.respond({ hasNewer: false });
+
+  expect(expandedMembership.agentIds).toEqual(["agent-a", "agent-b"]);
+  world.runUnsubscribeGrace();
+  const settledMembership = await world.nextMembership();
+  settledMembership.succeed();
+  expect(settledMembership.agentIds).toEqual(["agent-b"]);
+});
+
+test("backgrounding clears pending unsubscribe grace and membership immediately", async () => {
+  const world = new TimelineWorld();
+  world.sync.setConnected(true);
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+  const membership = await world.nextMembership();
+  membership.succeed();
+  const catchUp = await world.nextFetch("agent-a");
+  catchUp.respond({ hasNewer: false });
+
+  world.sync.replaceVisibleAgentIds("workspace", []);
+  world.sync.setActive(false);
+  const unsubscribe = await world.nextMembership();
+  unsubscribe.succeed();
+
+  expect(unsubscribe.agentIds).toEqual([]);
+  world.expectNoPendingUnsubscribe();
+});
+
+test("disconnecting cancels pending unsubscribe grace without publishing on the closed socket", async () => {
+  const world = new TimelineWorld();
+  world.sync.setConnected(true);
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+  const membership = await world.nextMembership();
+  membership.succeed();
+  const catchUp = await world.nextFetch("agent-a");
+  catchUp.respond({ hasNewer: false });
+
+  world.sync.replaceVisibleAgentIds("workspace", []);
+  world.sync.setConnected(false);
+
+  world.expectNoPendingUnsubscribe();
+  world.expectNoPendingMembership();
+});
+
+test("disposing cancels pending unsubscribe grace", async () => {
+  const world = new TimelineWorld();
+  world.sync.setConnected(true);
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+  const membership = await world.nextMembership();
+  membership.succeed();
+  const catchUp = await world.nextFetch("agent-a");
+  catchUp.respond({ hasNewer: false });
+
+  world.sync.replaceVisibleAgentIds("workspace", []);
+  world.sync.dispose();
+
+  world.expectNoPendingUnsubscribe();
+  world.expectNoPendingMembership();
+});
+
+test("legacy delivery skips subscription RPCs while retaining visibility catch-up and gap recovery", async () => {
+  const world = new TimelineWorld();
+  world.sync.setDeliveryMode("legacy");
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+  world.sync.setConnected(true);
+
+  world.expectNoPendingMembership();
+  const initial = await world.nextFetch("agent-a");
+  initial.respond({ hasNewer: false });
+
+  world.sync.recoverGap("agent-a", { epoch: "epoch-agent-a", endSeq: 10 });
+  const recovery = await world.nextFetch("agent-a");
+  recovery.respond({ hasNewer: false });
+
+  expect(recovery.request).toEqual({
+    direction: "after",
+    cursor: { epoch: "epoch-agent-a", seq: 10 },
+    limit: 100,
+    projection: "projected",
+  });
+});
+
+test("switching from legacy to selective delivery publishes membership and catches up once", async () => {
+  const world = new TimelineWorld();
+  world.sync.setDeliveryMode("legacy");
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+  world.sync.setConnected(true);
+  const legacyCatchUp = await world.nextFetch("agent-a");
+  legacyCatchUp.respond({ hasNewer: false });
+
+  world.sync.setDeliveryMode("selective");
+  const membership = await world.nextMembership();
+  membership.succeed();
+  const catchUp = await world.nextFetch("agent-a");
+  catchUp.respond({ hasNewer: false });
+
+  expect(membership.agentIds).toEqual(["agent-a"]);
+  world.expectNoPendingMembership();
+  world.expectNoPendingFetch();
 });

--- a/packages/app/src/timeline/viewed-timeline-sync.ts
+++ b/packages/app/src/timeline/viewed-timeline-sync.ts
@@ -12,6 +12,7 @@ interface TimelinePageResult {
 }
 
 interface ViewedTimelineSyncPorts {
+  initialDeliveryMode: TimelineDeliveryMode;
   setSubscription(agentIds: string[]): Promise<void>;
   readCursor(agentId: string): AgentTimelineCursorState | undefined;
   hasAuthoritativeHistory(agentId: string): boolean;
@@ -20,8 +21,10 @@ interface ViewedTimelineSyncPorts {
     request: ProjectedTimelineForwardFetchPlan,
   ): Promise<TimelinePageResult>;
   reportError(error: unknown): void;
-  scheduleRetry(retry: () => void): () => void;
+  schedule(task: () => void, delayMs: number): () => void;
 }
+
+export type TimelineDeliveryMode = "legacy" | "selective";
 
 export interface ViewedTimelineUiBridge {
   replaceVisibleAgentIds(sourceId: string, agentIds: string[]): void;
@@ -30,9 +33,13 @@ export interface ViewedTimelineUiBridge {
 export interface ViewedTimelineSync extends ViewedTimelineUiBridge {
   setActive(active: boolean): void;
   setConnected(connected: boolean): void;
+  setDeliveryMode(mode: TimelineDeliveryMode): void;
   recoverGap(agentId: string, cursor: { epoch: string; endSeq: number }): void;
   dispose(): void;
 }
+
+const RETRY_DELAY_MS = 1_000;
+export const VIEWED_TIMELINE_UNSUBSCRIBE_GRACE_MS = 5_000;
 
 type CatchUpStatus = "running" | "complete" | "error";
 
@@ -80,8 +87,10 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
   const catchUps = new Map<string, CatchUpState>();
   const catchUpGenerations = new Map<string, number>();
   const pendingGaps = new Map<string, ProjectedTimelineForwardFetchPlan>();
+  const lingeringRemovals = new Map<string, () => void>();
   let active = true;
   let connected = false;
+  let deliveryMode = ports.initialDeliveryMode;
   let disposed = false;
   let desired: string[] = [];
   let acknowledged: string[] = [];
@@ -91,7 +100,9 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
   let membershipNeedsRetry = false;
   let cancelMembershipRetry: (() => void) | null = null;
 
-  const effectiveAgentIds = () => (active ? normalizeAgentIds([...sources.values()].flat()) : []);
+  const visibleAgentIds = () => (active ? normalizeAgentIds([...sources.values()].flat()) : []);
+  const effectiveAgentIds = () =>
+    normalizeAgentIds([...visibleAgentIds(), ...lingeringRemovals.keys()]);
 
   const isAcknowledged = (agentId: string) => acknowledged.includes(agentId);
   const isDesired = (agentId: string) => desired.includes(agentId);
@@ -139,11 +150,11 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
       catchUps.set(agentId, { generation, status: "complete" });
     } catch (error) {
       if (catchUps.get(agentId)?.generation === generation) {
-        const cancelRetry = ports.scheduleRetry(() => {
+        const cancelRetry = ports.schedule(() => {
           const current = catchUps.get(agentId);
           if (current?.generation !== generation || current.status !== "error") return;
           startCatchUp(agentId);
-        });
+        }, RETRY_DELAY_MS);
         catchUps.set(agentId, { generation, status: "error", cancelRetry });
         ports.reportError(error);
       }
@@ -188,7 +199,7 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
   };
 
   const reconcileLatestMembership = async (): Promise<void> => {
-    if (disposed || !connected) return;
+    if (disposed || !connected || deliveryMode !== "selective") return;
     const generation = membershipGeneration;
     const requested = desired;
     if (!membershipNeedsRetry && sameAgentIds(requested, acknowledged)) return;
@@ -198,7 +209,7 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
     } catch (error) {
       membershipNeedsRetry = true;
       cancelMembershipRetry?.();
-      cancelMembershipRetry = ports.scheduleRetry(() => {
+      cancelMembershipRetry = ports.schedule(() => {
         cancelMembershipRetry = null;
         if (
           disposed ||
@@ -209,13 +220,13 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
           return;
         }
         void reconcileMembership();
-      });
+      }, RETRY_DELAY_MS);
       ports.reportError(error);
       return;
     }
     cancelMembershipRetry?.();
     cancelMembershipRetry = null;
-    if (disposed || !connected) return;
+    if (disposed || !connected || deliveryMode !== "selective") return;
     acknowledged = requested;
     if (generation !== membershipGeneration) {
       await reconcileLatestMembership();
@@ -236,12 +247,13 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
       await reconcileLatestMembership();
     } finally {
       reconciling = false;
-      if (reconcileRequested && !disposed && connected) {
+      if (reconcileRequested && !disposed && connected && deliveryMode === "selective") {
         reconcileRequested = false;
         void reconcileMembership();
       } else if (
         !disposed &&
         connected &&
+        deliveryMode === "selective" &&
         !membershipNeedsRetry &&
         !sameAgentIds(desired, acknowledged)
       ) {
@@ -256,10 +268,9 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
     }
   };
 
-  const publishEffectiveMembership = () => {
-    const nextDesired = effectiveAgentIds();
+  const commitDesiredMembership = (nextDesired: string[]) => {
     if (sameAgentIds(nextDesired, desired)) {
-      if (membershipNeedsRetry) void reconcileMembership();
+      if (deliveryMode === "selective" && membershipNeedsRetry) void reconcileMembership();
       retryFailedCatchUps();
       return;
     }
@@ -271,7 +282,40 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
     cancelMembershipRetry = null;
     desired = nextDesired;
     membershipGeneration += 1;
+    if (deliveryMode === "legacy") {
+      acknowledged = connected ? desired : [];
+      if (connected) startAcknowledgedCatchUps();
+      return;
+    }
     void reconcileMembership();
+  };
+
+  const clearLingeringRemovals = () => {
+    for (const cancel of lingeringRemovals.values()) cancel();
+    lingeringRemovals.clear();
+  };
+
+  const publishVisibleMembership = (allowGrace: boolean) => {
+    const visible = visibleAgentIds();
+    for (const agentId of visible) {
+      lingeringRemovals.get(agentId)?.();
+      lingeringRemovals.delete(agentId);
+    }
+
+    if (allowGrace && connected && active && deliveryMode === "selective") {
+      for (const agentId of desired) {
+        if (visible.includes(agentId) || lingeringRemovals.has(agentId)) continue;
+        const cancel = ports.schedule(() => {
+          lingeringRemovals.delete(agentId);
+          commitDesiredMembership(effectiveAgentIds());
+        }, VIEWED_TIMELINE_UNSUBSCRIBE_GRACE_MS);
+        lingeringRemovals.set(agentId, cancel);
+      }
+    } else {
+      clearLingeringRemovals();
+    }
+
+    commitDesiredMembership(effectiveAgentIds());
   };
 
   return {
@@ -279,17 +323,19 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
       const normalized = normalizeAgentIds(agentIds);
       if (normalized.length === 0) sources.delete(sourceId);
       else sources.set(sourceId, normalized);
-      publishEffectiveMembership();
+      publishVisibleMembership(true);
     },
     setActive(nextActive) {
       if (active === nextActive) return;
       active = nextActive;
-      publishEffectiveMembership();
+      publishVisibleMembership(false);
     },
     setConnected(nextConnected) {
       if (connected === nextConnected) return;
       connected = nextConnected;
       if (!connected) {
+        clearLingeringRemovals();
+        commitDesiredMembership(visibleAgentIds());
         cancelMembershipRetry?.();
         cancelMembershipRetry = null;
         acknowledged = [];
@@ -298,7 +344,26 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
         return;
       }
       membershipGeneration += 1;
-      void reconcileMembership();
+      if (deliveryMode === "legacy") {
+        acknowledged = desired;
+        startAcknowledgedCatchUps();
+      } else {
+        void reconcileMembership();
+      }
+    },
+    setDeliveryMode(nextMode) {
+      if (deliveryMode === nextMode) return;
+      deliveryMode = nextMode;
+      clearLingeringRemovals();
+      cancelMembershipRetry?.();
+      cancelMembershipRetry = null;
+      membershipNeedsRetry = false;
+      membershipGeneration += 1;
+      for (const agentId of desired) cancelCatchUp(agentId);
+      desired = visibleAgentIds();
+      acknowledged = deliveryMode === "legacy" && connected ? desired : [];
+      if (deliveryMode === "selective" && connected) void reconcileMembership();
+      else if (connected) startAcknowledgedCatchUps();
     },
     recoverGap(agentId, cursor) {
       if (!isDesired(agentId)) return;
@@ -309,6 +374,7 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
     },
     dispose() {
       disposed = true;
+      clearLingeringRemovals();
       cancelMembershipRetry?.();
       cancelMembershipRetry = null;
       sources.clear();


### PR DESCRIPTION
### Linked issue

No matching open issue.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Fixes agent chat items being duplicated or appearing after a newly submitted prompt when a viewed agent catches up with canonical timeline history.

Projected catch-up pages can overlap rows already received from the live stream. The app now reconciles those full assistant and reasoning projections before passing the remaining entries through the existing stream reducer, and keeps optimistic prompts after delayed history without losing the reducer's existing tool, attachment, and message behavior.

Selective timeline delivery now subscribes additions immediately but waits five seconds before removing an agent, so quick tab and pane switches keep streaming. Backgrounding, disconnecting, and disposal still clear subscriptions immediately. Legacy daemons retain global streaming and authoritative catch-up without selective subscription RPCs.

### How did you verify it

- Added deterministic reducer reproductions for overlapping tool/assistant and tool/reasoning projections, plus an idle-agent prompt submitted before delayed history arrives.
- Added viewed-sync coverage for quick switching, multi-pane ownership, immediate additions, grace expiry, background/disconnect/disposal, retries, and legacy/selective transitions.
- `npx vitest run packages/app/src/timeline/session-stream-reducers.test.ts packages/app/src/timeline/viewed-timeline-sync.test.ts --bail=1` — 89 tests passed.
- Related session-context and timeline-planning tests — 9 tests passed.
- `npm run typecheck` passed across all workspaces.
- Targeted `npm run lint -- ...` passed.
- `npm run format` and the repository format check passed.

Before merge, smoke an idle agent prompt immediately after returning to its view, and switch away/back within five seconds against both a selective daemon and an older daemon. There is no visual UI change to capture.

### Risk surface

This changes ordering at the live-stream/canonical-history boundary and subscription timing during rapid view changes. The deterministic model tests cover the known races, but a real relay connection is still the best final check for network timing. No protocol schema or persisted data shape changes.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform — not applicable; no visual UI change
- [x] Tests added or updated where it made sense