### PR TITLE
Add non-Git projects across filesystem mounts

### DIFF
--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -8,10 +8,12 @@ import {
   readFileSync,
   realpathSync,
   mkdirSync,
+  statSync,
 } from "fs";
 import { join } from "path";
 import { win32 } from "node:path";
 import { tmpdir } from "os";
+import pino from "pino";
 import {
   __resetCheckoutShortstatCacheForTests,
   __resetPullRequestStatusCacheForTests,
@@ -312,6 +314,38 @@ describe("checkout git utilities", () => {
     mkdirSync(nonGitDir, { recursive: true });
 
     await expect(getCheckoutStatus(nonGitDir)).resolves.toEqual({ isGit: false });
+  });
+
+  it.runIf(
+    process.platform !== "win32" &&
+      existsSync("/dev/shm") &&
+      statSync("/dev").dev !== statSync("/dev/shm").dev,
+  )("warns and reports a non-git directory at a filesystem boundary as non-git", async () => {
+    const nonGitDir = realpathSync.native(mkdtempSync("/dev/shm/checkout-git-boundary-test-"));
+    const records: unknown[] = [];
+    const logger = pino(
+      { level: "warn" },
+      {
+        write(line: string) {
+          records.push(JSON.parse(line));
+        },
+      },
+    );
+    try {
+      await expect(getCheckoutStatus(nonGitDir, { logger })).resolves.toEqual({ isGit: false });
+      expect(records).toEqual([
+        expect.objectContaining({
+          level: 40,
+          cwd: nonGitDir,
+          msg: "Git worktree discovery failed; treating directory as non-Git",
+          err: expect.objectContaining({
+            message: expect.stringContaining("Stopping at filesystem boundary"),
+          }),
+        }),
+      ]);
+    } finally {
+      rmSync(nonGitDir, { recursive: true, force: true });
+    }
   });
 
   it("returns null for getCurrentBranch in a repo with no commits", async () => {

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -780,7 +780,7 @@ export interface MergeFromBaseOptions {
 export interface CheckoutContext {
   paseoHome?: string;
   worktreesRoot?: string;
-  logger?: Pick<Logger, "trace">;
+  logger?: Pick<Logger, "trace" | "warn">;
   facts?: CheckoutSnapshotFacts | null;
 }
 
@@ -804,13 +804,6 @@ export type CheckoutSnapshotFacts =
       branchMergeRef: string | null;
       pullRequestLookupTarget: PullRequestStatusLookupTarget | null;
     };
-
-function isNotGitRepositoryError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  return /not a git repository \(or any of the parent directories\): \.git/i.test(error.message);
-}
 
 async function requireGitRepo(cwd: string): Promise<void> {
   try {
@@ -867,10 +860,12 @@ async function getWorktreeRoot(cwd: string, context?: CheckoutContext): Promise<
     });
     return parseGitRevParsePath(stdout);
   } catch (error) {
-    if (isNotGitRepositoryError(error)) {
-      return null;
-    }
-    throw error;
+    // Git discovery is fail-open: keep the directory usable as non-Git and retain the diagnostic.
+    context?.logger?.warn(
+      { err: error, cwd },
+      "Git worktree discovery failed; treating directory as non-Git",
+    );
+    return null;
   }
 }
 

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1030,7 +1030,7 @@ async function getPaseoWorktreeForCwd(
 
   return {
     isPaseoOwnedWorktree: true,
-    worktreeRoot: knownWorktreeRoot ?? (await getWorktreeRoot(cwd)) ?? cwd,
+    worktreeRoot: knownWorktreeRoot ?? (await getWorktreeRoot(cwd, context)) ?? cwd,
   };
 }
 
@@ -2967,7 +2967,7 @@ export async function mergeToBase(
   }
   let normalizedBaseRef = baseRef;
   normalizedBaseRef = normalizeLocalBranchRefName(normalizedBaseRef);
-  const currentWorktreeRoot = (await getWorktreeRoot(cwd)) ?? cwd;
+  const currentWorktreeRoot = (await getWorktreeRoot(cwd, context)) ?? cwd;
   if (normalizedBaseRef === currentBranch) {
     return currentWorktreeRoot;
   }


### PR DESCRIPTION
### Linked issue

Reported in [Paseo Discord](https://discord.com/channels/1481169421832814616/1527952414567829585).

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adding a non-Git folder failed when Git stopped repository discovery at a filesystem mount boundary. The daemon treated that expected discovery failure as fatal, so it never saved the project.

Git worktree discovery now fails open: any failure classifies the selected directory as non-Git and emits a structured warning containing the directory and original error. Other Git operations keep their existing error behavior.

### How did you verify it

- Reproduced the original failure by running `git rev-parse --show-toplevel` in a non-Git directory under `/dev/shm`; Git exited 128 with `Stopping at filesystem boundary`.
- Added a Linux regression test using the real `/dev/shm` mount boundary. It confirms checkout status is `{ isGit: false }` and the warning retains the original Git error.
- `npx vitest run packages/server/src/utils/checkout-git.test.ts --bail=1` — 122 tests passed.
- `npm run typecheck` — passed.
- `npm run lint -- packages/server/src/utils/checkout-git.ts packages/server/src/utils/checkout-git.test.ts` — passed with no warnings or errors.
- `npm run format` — completed.

Risk: worktree discovery is also used during project reconciliation. A transient `rev-parse --show-toplevel` failure will now produce non-Git metadata for that pass, with the failure preserved in daemon warnings.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense