### PR TITLE
Refresh Claude provider compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38051,7 +38051,7 @@
       "version": "0.2.0-beta.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.17.1",
-        "@anthropic-ai/claude-agent-sdk": "^0.3.195",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.214",
         "@anthropic-ai/sdk": "^0.104.2",
         "@getpaseo/client": "0.2.0-beta.1",
         "@getpaseo/highlight": "0.2.0-beta.1",
@@ -38100,22 +38100,22 @@
       }
     },
     "packages/server/node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.195.tgz",
-      "integrity": "sha512-FVmXu9pvOMbuBKWrF8YsYQdQ/upOpv5rS8lFAnFO5jbyXT/2hN7kEPd2vd2GJpaMvNcO/KptyQUK5AxjjTz3+w==",
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.214.tgz",
+      "integrity": "sha512-wt5ImwhU+p259Zt4K/Q9v5xVi6ruxYO5+KFICyJxnjs/QFEClAeSRqhcXx1J8jgGfatPW1faw09hkm66680UjA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.195",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.195"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.214",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.214"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -38123,10 +38123,10 @@
         "zod": "^4.0.0"
       }
     },
-    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.195.tgz",
-      "integrity": "sha512-WIMM/8HRCLsTDHFTIwQvvE8WCA/oaMJtdQxsP7iNyfzIGwXbuOyU95V8vYIhZfaO2yaSpbBRncunq4CtR5H4ng==",
+    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.214.tgz",
+      "integrity": "sha512-vAAOeVtlXs3p7MpFVfvfu9ja32eaKtB+MDZnPxCbdzxJk5nofCHlNsHa1UJwXHOsP9lOnFYNIccYztsZ4DNaJA==",
       "cpu": [
         "arm64"
       ],
@@ -38136,10 +38136,10 @@
         "darwin"
       ]
     },
-    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.195.tgz",
-      "integrity": "sha512-RY7DB+4LXosE0MJ+XELmakfPrDN1YX4lkk9CTDm28jGCVcESRz9kAEqbyaiC48dZcmN9V1NCLutzINGdcr1TBg==",
+    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.214.tgz",
+      "integrity": "sha512-NTbV8U2yucxCWqEiDC7L0MUehNmd8x3Op8OGzLZRhMF3xmQBy2DxpXiNZgSwwKWNDC3HdgKmJM5ZBbT7XrF/0g==",
       "cpu": [
         "x64"
       ],
@@ -38149,10 +38149,10 @@
         "darwin"
       ]
     },
-    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.195.tgz",
-      "integrity": "sha512-JuIq5Fnz/F1snl0aqi1gcuRZqPWoPNrL9dJ0DuievCxKkO8hnEz/Mmn5Zos7x1X8HE//ZnEvmQXoEQEZXonJew==",
+    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.214.tgz",
+      "integrity": "sha512-KBCf+BlusG0ZcgvpjjHwv1kh+6WiR8vJbPjpR2udwkrtcQgKLN+24l+FeaQEzO2TL+ExCmM1KC4tNPvnPpy+tw==",
       "cpu": [
         "arm64"
       ],
@@ -38162,10 +38162,10 @@
         "linux"
       ]
     },
-    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.195.tgz",
-      "integrity": "sha512-ZmyBA/AFzhgutcxb7dbhCm6GTjJytwNYXTxJoKE2B3A409WCYccjMqeji6vCMNxyyfylglGo5D8dVMIxW9aoug==",
+    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.214.tgz",
+      "integrity": "sha512-i06wQRsmevE7spY1ryYfs+NP+xdZ1FwAyTjDaF0k/xG+cgtzZYghTFUemdYF3GVwgWgpcava9GiCFDT3DoHI6w==",
       "cpu": [
         "arm64"
       ],
@@ -38175,10 +38175,10 @@
         "linux"
       ]
     },
-    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.195.tgz",
-      "integrity": "sha512-s1lNi1cL93luoqsItH+fNO4KpIhdkvnVhWGGQUQ/8ftwa2gfmcIQnOg1hG8Ks+KzeD3UUQ8L9YEVHVADnFI/9A==",
+    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.214.tgz",
+      "integrity": "sha512-vqadSceJkBKHaTUszxI35uTuECGWtsHWK/mOwIJ4b9DUtYYySz6EJEk4gHg4ccutisJ/oRVCpFXHIKFb+osrKw==",
       "cpu": [
         "x64"
       ],
@@ -38188,10 +38188,10 @@
         "linux"
       ]
     },
-    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.195.tgz",
-      "integrity": "sha512-nf8Q/LauB+ZOC6QDjxNhbsvwUtYjKYnaWJLTYFwhkmsLujePnety1AtT/1ubaUoq5AM1j297DhMlYTasa79OUA==",
+    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.214.tgz",
+      "integrity": "sha512-948RstHDhs0E69h+2dKYWIAL1kcwEme4zvtgNUwP8XpKXzWOhrTKmd6MAokHn25zwfuSx5d+HE0XHfFH6R4hLg==",
       "cpu": [
         "x64"
       ],
@@ -38201,10 +38201,10 @@
         "linux"
       ]
     },
-    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.195.tgz",
-      "integrity": "sha512-hbkDE+xPIZzRWm+D+BKrH9uJH6USIZdDIlsyrIlGi3JFHoieYoA1vdUNyldSS9+F3ZqQtfPjr2Qy08IVB6akYA==",
+    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.214.tgz",
+      "integrity": "sha512-CEKlPFCPv+ee79utQMEDSsgeo2f27ulhNHpjrKIt1jXz5G04J7lAWN/QwvPDv9XaLBkWpyfqZWiPXlRcwuaO/w==",
       "cpu": [
         "arm64"
       ],
@@ -38214,10 +38214,10 @@
         "win32"
       ]
     },
-    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.195",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.195.tgz",
-      "integrity": "sha512-av0piEB3X1Dzhpr8A+DqHVZ9y8s1jpn8enzwX0TKKUPBn5IqLTWC7wD6v66aoUgu4f+g4ThZirmDZA6shyPEZQ==",
+    "packages/server/node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.214",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.214.tgz",
+      "integrity": "sha512-cJMJfFoR9IWBZWnTtt9PnEm89hGOsZjoDNjOCEOF3+x+g/ANIXAjMJTcaQYv2HKh6MylWZ0AkxBASI+twkukaQ==",
       "cpu": [
         "x64"
       ],

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.17.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.195",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.214",
     "@anthropic-ai/sdk": "^0.104.2",
     "@getpaseo/client": "0.2.0-beta.1",
     "@getpaseo/highlight": "0.2.0-beta.1",


### PR DESCRIPTION
### Linked issue

Refs #2034

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

Updates the Claude Agent SDK dependency used by the server's Claude provider from `0.3.195` to `0.3.214`.

This keeps Paseo on the current SDK compatibility line for Claude Code sessions, including upstream fixes around process tracking, abort handling, subprocess errors, command lifecycle reporting, and permission-mode validation.

### How did you verify it

- `npm ls @anthropic-ai/claude-agent-sdk --workspace=@getpaseo/server --all` reports `0.3.214`
- Started a real isolated daemon on a random local port with the real Claude provider, created an agent, sent `Do not use tools. Reply with exactly: OK`, and observed final status `idle`, runtime model set, and assistant response `OK`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A, no UI changes)
- [x] Tests added or updated where it made sense (N/A, dependency-only update with daemon smoke)