### PR TITLE
Keep the composer visible after voice dictation

### DIFF
--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -25,7 +25,6 @@ import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { useTranslation } from "react-i18next";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import { ArrowUp, Mic, MicOff, CornerDownLeft, Plus, Square } from "lucide-react-native";
-import Animated, { useSharedValue, useAnimatedStyle, withTiming } from "react-native-reanimated";
 import { useDictation } from "@/hooks/use-dictation";
 import { DictationOverlay } from "@/components/dictation-controls";
 import { RealtimeVoiceOverlay } from "@/components/realtime-voice-overlay";
@@ -68,6 +67,7 @@ import {
 } from "./labels";
 import {
   computeCanStartDictation,
+  resolveComposerSurfacePresentation,
   runAlternateSendAction,
   runDefaultSendAction,
   stopRealtimeVoice,
@@ -1290,7 +1290,6 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       getNativeElement: () => (isWeb ? getTextInputNativeElement(textInputRef.current) : null),
     }));
     const inputHeightRef = useRef(MIN_INPUT_HEIGHT);
-    const overlayTransition = useSharedValue(0);
     const sendAfterTranscriptRef = useRef(false);
     const valueRef = useRef(value);
     const serverInfo = useSessionStore(
@@ -1407,6 +1406,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     );
     const showRealtimeOverlay = isRealtimeVoiceForCurrentAgent;
     const showOverlay = showDictationOverlay || showRealtimeOverlay;
+    const surfacePresentation = resolveComposerSurfacePresentation(showOverlay);
 
     useEffect(() => {
       if (isDictating || isDictationProcessing) {
@@ -1426,22 +1426,6 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
         }),
       [canStartDictation, dictationUnavailableMessage, startDictation, toast],
     );
-
-    // Animate overlay
-    useEffect(() => {
-      overlayTransition.value = withTiming(showOverlay ? 1 : 0, {
-        duration: 200,
-      });
-    }, [overlayTransition, showOverlay]);
-
-    const overlayAnimatedStyle = useAnimatedStyle(() => ({
-      opacity: overlayTransition.value,
-      pointerEvents: overlayTransition.value > 0.5 ? "auto" : "none",
-    }));
-
-    const inputAnimatedStyle = useAnimatedStyle(() => ({
-      opacity: 1 - overlayTransition.value,
-    }));
 
     const handleVoicePress = useCallback(
       () =>
@@ -1760,8 +1744,12 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     }, [handleStopRealtimeVoice]);
 
     const inputWrapperCombinedStyle = useMemo(
-      () => [styles.inputWrapper, inputWrapperStyle, inputAnimatedStyle],
-      [inputWrapperStyle, inputAnimatedStyle],
+      () => [
+        styles.inputWrapper,
+        inputWrapperStyle,
+        { opacity: surfacePresentation.input.opacity },
+      ],
+      [inputWrapperStyle, surfacePresentation.input.opacity],
     );
     const textInputStyle = useMemo(
       () => [styles.textInput, computeTextInputHeightStyle(inputHeight, maxInputHeight)],
@@ -1772,8 +1760,8 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       [isSendButtonDisabled],
     );
     const overlayContainerStyle = useMemo(
-      () => [styles.overlayContainer, overlayAnimatedStyle],
-      [overlayAnimatedStyle],
+      () => [styles.overlayContainer, { opacity: surfacePresentation.overlay.opacity }],
+      [surfacePresentation.overlay.opacity],
     );
 
     const renderAttachButtonIcon = useCallback(
@@ -1802,7 +1790,11 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     return (
       <View ref={rootRef} style={styles.container} testID="message-input-root">
         {/* Regular input */}
-        <Animated.View ref={inputWrapperRef} style={inputWrapperCombinedStyle}>
+        <View
+          ref={inputWrapperRef}
+          style={inputWrapperCombinedStyle}
+          pointerEvents={surfacePresentation.input.pointerEvents}
+        >
           {attachmentSlot}
           {/* Text input */}
           <View style={styles.textInputScrollWrapper}>
@@ -1881,9 +1873,12 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
               />
             </View>
           </View>
-        </Animated.View>
+        </View>
 
-        <Animated.View style={overlayContainerStyle}>
+        <View
+          style={overlayContainerStyle}
+          pointerEvents={surfacePresentation.overlay.pointerEvents}
+        >
           <MessageInputOverlay
             showDictationOverlay={showDictationOverlay}
             showRealtimeOverlay={showRealtimeOverlay}
@@ -1901,7 +1896,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
             onDiscardFailedRecording={handleDiscardFailedRecording}
             onRealtimeVoiceStop={handleRealtimeVoiceStop}
           />
-        </Animated.View>
+        </View>
       </View>
     );
   },

--- a/packages/app/src/composer/input/state.test.ts
+++ b/packages/app/src/composer/input/state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   computeCanStartDictation,
+  resolveComposerSurfacePresentation,
   runAlternateSendAction,
   runDefaultSendAction,
   stopRealtimeVoice,
@@ -8,6 +9,22 @@ import {
 
 const connected = { isConnected: true } as never;
 const disconnected = { isConnected: false } as never;
+
+describe("composer surface presentation", () => {
+  it("shows only the input when no voice overlay is active", () => {
+    expect(resolveComposerSurfacePresentation(false)).toEqual({
+      input: { opacity: 1, pointerEvents: "auto" },
+      overlay: { opacity: 0, pointerEvents: "none" },
+    });
+  });
+
+  it("shows only the voice overlay while voice UI is active", () => {
+    expect(resolveComposerSurfacePresentation(true)).toEqual({
+      input: { opacity: 0, pointerEvents: "none" },
+      overlay: { opacity: 1, pointerEvents: "auto" },
+    });
+  });
+});
 
 describe("computeCanStartDictation", () => {
   it("returns false when socket is disconnected", () => {

--- a/packages/app/src/composer/input/state.ts
+++ b/packages/app/src/composer/input/state.ts
@@ -3,6 +3,32 @@ import type { MessagePayload } from "@/composer/types";
 
 export type SendBehavior = "interrupt" | "queue";
 
+interface ComposerSurfaceState {
+  opacity: 0 | 1;
+  pointerEvents: "auto" | "none";
+}
+
+export interface ComposerSurfacePresentation {
+  input: ComposerSurfaceState;
+  overlay: ComposerSurfaceState;
+}
+
+const INPUT_PRESENTATION: ComposerSurfacePresentation = {
+  input: { opacity: 1, pointerEvents: "auto" },
+  overlay: { opacity: 0, pointerEvents: "none" },
+};
+
+const OVERLAY_PRESENTATION: ComposerSurfacePresentation = {
+  input: { opacity: 0, pointerEvents: "none" },
+  overlay: { opacity: 1, pointerEvents: "auto" },
+};
+
+export function resolveComposerSurfacePresentation(
+  showOverlay: boolean,
+): ComposerSurfacePresentation {
+  return showOverlay ? OVERLAY_PRESENTATION : INPUT_PRESENTATION;
+}
+
 interface StopRealtimeVoiceContext {
   voice: { stopVoice: () => Promise<unknown> } | null | undefined;
   isRealtimeVoiceForCurrentAgent: boolean;


### PR DESCRIPTION
### Linked issue

Reported directly; no matching open issue found.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Keeps the message composer visible after submitting a dictated prompt and returning to the app.

The voice overlay and composer previously shared an animated opacity value that could remain stale when Android backgrounded the app during the transition. Both surfaces now derive visibility and touch handling directly from the active voice state, so they cannot disagree after resume. This also removes the empty exit fade that ran after the overlay content had already unmounted.

### How did you verify it

- `npx vitest run packages/app/src/composer/input/state.test.ts --bail=1` — 13 tests passed, including both composer surface states.
- `npm run typecheck` — all workspaces passed.
- `npm run lint` — zero warnings and errors.
- `npm run format` completed.

The Android emulator configured on this machine cannot boot because the host has no KVM/CPU virtualization. Before merge, smoke dictation submit followed by immediate background/foreground on an Android device. The composer should return and remain interactive; realtime voice entry/exit should also switch surfaces correctly.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense