### PR TITLE
fix(server): honor Grok hideFromScrollback and render background tasks

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -8,7 +8,9 @@ This guide walks through adding a new agent provider end-to-end. There are two i
 
 Extend `ACPAgentClient` from `packages/server/src/server/agent/providers/acp-agent.ts`. The base class handles process spawning, stdio transport, session lifecycle, streaming, permissions, and model discovery. You provide configuration (command, modes, capabilities) and optionally override `isAvailable()` for auth checks.
 
-The only built-in ACP provider today is `copilot` (`copilot-acp-agent.ts`). `GenericACPAgentClient` (`generic-acp-agent.ts`) is also ACP-based but is used for user-defined custom providers configured via `extends: "acp"` overrides — see [docs/custom-providers.md](custom-providers.md).
+Built-in ACP providers include `copilot` (`copilot-acp-agent.ts`), `cursor` (`cursor-acp-agent.ts`), `kiro` (`kiro-acp-agent.ts`), `trae` (`trae-acp-agent.ts`), and `grok` (`grok-acp-agent.ts`). `GenericACPAgentClient` (`generic-acp-agent.ts`) is also ACP-based and is used for user-defined custom providers configured via `extends: "acp"` overrides — see [docs/custom-providers.md](custom-providers.md).
+
+Grok-specific ACP behavior stays in the Grok adapter (and small adjacent modules such as `grok-background-tasks.ts`): mode mapping for Always Approve, suppression of `user_message_chunk` when `_meta.hideFromScrollback === true`, and structured `_x.ai/session/update` task events rendered as synthetic `tool_call` timeline items. Shared ACP only exposes narrow hooks (`shouldSuppressUserMessageChunk`, `extensionNotificationHandler`) so other providers remain unaffected.
 
 Copilot custom agents are exposed through ACP session config, not the slash-command list. When custom agents are available, Copilot returns a select config option with `id: "agent"` and `category: "_agent"`; Paseo maps that to the `agent` provider feature. Copilot uses the agent display name as the option value, and the blank value means the default Copilot agent.
 

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -34,6 +34,11 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import {
+  GROK_ASK_MODE_ID,
+  GROK_ALWAYS_APPROVE_MODE_ID,
+  GrokACPAgentClient,
+} from "./providers/grok-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
 import { OmpAgentClient } from "./providers/omp/agent.js";
@@ -646,6 +651,7 @@ function addDerivedProviders(
       // Capture command in const for closure - TypeScript can't track type refinement inside closures
       const command = override.command;
 
+      const isGrok = providerId === "grok";
       resolvedProviders.set(providerId, {
         definition: createDerivedDefinition(
           providerId,
@@ -653,8 +659,27 @@ function addDerivedProviders(
             id: providerId,
             label: override.label ?? providerId,
             description: override.description ?? "Custom ACP provider",
-            defaultModeId: null,
-            modes: [],
+            defaultModeId: isGrok ? GROK_ASK_MODE_ID : null,
+            modes: isGrok
+              ? [
+                  {
+                    id: GROK_ASK_MODE_ID,
+                    label: "Ask",
+                    description: "Prompt before shell and tool executions",
+                    icon: "ShieldCheck",
+                    colorTier: "safe",
+                  },
+                  {
+                    id: GROK_ALWAYS_APPROVE_MODE_ID,
+                    label: "Always Approve",
+                    description:
+                      "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
+                    icon: "ShieldOff",
+                    colorTier: "dangerous",
+                    isUnattended: true,
+                  },
+                ]
+              : [],
           },
           override,
         ),
@@ -676,6 +701,9 @@ function addDerivedProviders(
           };
           if (providerId === "cursor") {
             return new CursorACPAgentClient(acpOptions);
+          }
+          if (providerId === "grok") {
+            return new GrokACPAgentClient(acpOptions);
           }
           if (providerId === "kiro") {
             return new KiroACPAgentClient(acpOptions);

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -34,11 +34,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
-import {
-  GROK_ASK_MODE_ID,
-  GROK_ALWAYS_APPROVE_MODE_ID,
-  GrokACPAgentClient,
-} from "./providers/grok-acp-agent.js";
+import { GROK_ASK_MODE_ID, GROK_MODES, GrokACPAgentClient } from "./providers/grok-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
 import { OmpAgentClient } from "./providers/omp/agent.js";
@@ -660,26 +656,8 @@ function addDerivedProviders(
             label: override.label ?? providerId,
             description: override.description ?? "Custom ACP provider",
             defaultModeId: isGrok ? GROK_ASK_MODE_ID : null,
-            modes: isGrok
-              ? [
-                  {
-                    id: GROK_ASK_MODE_ID,
-                    label: "Ask",
-                    description: "Prompt before shell and tool executions",
-                    icon: "ShieldCheck",
-                    colorTier: "safe",
-                  },
-                  {
-                    id: GROK_ALWAYS_APPROVE_MODE_ID,
-                    label: "Always Approve",
-                    description:
-                      "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
-                    icon: "ShieldOff",
-                    colorTier: "dangerous",
-                    isUnattended: true,
-                  },
-                ]
-              : [],
+            // Canonical Grok modes live in grok-acp-agent.ts (icons, colorTier, isUnattended).
+            modes: isGrok ? GROK_MODES : [],
           },
           override,
         ),

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -719,6 +719,97 @@ describe("deriveModesFromACP", () => {
     });
   });
 
+  test("re-attaches fallback icon, colorTier, and isUnattended by mode id", () => {
+    const result = deriveModesFromACP(
+      [
+        {
+          id: "ask",
+          label: "Ask fallback",
+          icon: "ShieldCheck",
+          colorTier: "safe",
+        },
+        {
+          id: "always-approve",
+          label: "Always Approve fallback",
+          icon: "ShieldOff",
+          colorTier: "dangerous",
+          isUnattended: true,
+        },
+      ],
+      {
+        availableModes: [
+          { id: "ask", name: "Ask", description: "Prompt before tools" },
+          {
+            id: "always-approve",
+            name: "Always Approve",
+            description: "Skip permission prompts",
+          },
+        ],
+        currentModeId: "always-approve",
+      },
+      [],
+    );
+
+    expect(result.currentModeId).toBe("always-approve");
+    expect(result.modes).toEqual([
+      {
+        id: "ask",
+        label: "Ask",
+        description: "Prompt before tools",
+        icon: "ShieldCheck",
+        colorTier: "safe",
+      },
+      {
+        id: "always-approve",
+        label: "Always Approve",
+        description: "Skip permission prompts",
+        icon: "ShieldOff",
+        colorTier: "dangerous",
+        isUnattended: true,
+      },
+    ]);
+  });
+
+  test("re-attaches fallback metadata when modes come from config options", () => {
+    const result = deriveModesFromACP(
+      [
+        {
+          id: "full-access",
+          label: "Full Access fallback",
+          icon: "ShieldOff",
+          colorTier: "dangerous",
+          isUnattended: true,
+        },
+      ],
+      null,
+      [
+        {
+          id: "mode",
+          name: "Mode",
+          category: "mode",
+          type: "select",
+          currentValue: "full-access",
+          options: [
+            { value: "auto", name: "Default" },
+            { value: "full-access", name: "Full Access" },
+          ],
+        },
+      ],
+    );
+
+    expect(result.modes).toEqual([
+      { id: "auto", label: "Default", description: undefined },
+      {
+        id: "full-access",
+        label: "Full Access",
+        description: undefined,
+        icon: "ShieldOff",
+        colorTier: "dangerous",
+        isUnattended: true,
+      },
+    ]);
+  });
+
   test("falls back to config options when explicit mode state is absent", () => {
     const result = deriveModesFromACP([{ id: "fallback", label: "Fallback" }], null, [
       {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -366,6 +366,32 @@ export type ACPExtensionCommandsParser = (
   params: Record<string, unknown>,
 ) => AgentSlashCommand[] | null;
 
+/**
+ * Provider-owned display policy for ACP `user_message_chunk` updates.
+ * Return true to drop the chunk before message assembly or timeline emission
+ * (e.g. Grok `_meta.hideFromScrollback === true`). Generic ACP keeps false.
+ */
+export type ACPUserMessageChunkFilter = (
+  update: Extract<SessionUpdate, { sessionUpdate: "user_message_chunk" }>,
+) => boolean;
+
+export interface ACPExtensionNotificationContext {
+  sessionId: string | null;
+}
+
+/**
+ * Provider-owned ACP extension notification → timeline items.
+ * Return null when the method is not owned by this handler. Return an empty
+ * array when owned but ignored (wrong session, malformed payload). Returned
+ * timeline items take the same live-stream vs history-replay path as
+ * `session/update` events.
+ */
+export type ACPExtensionNotificationHandler = (
+  method: string,
+  params: Record<string, unknown>,
+  context: ACPExtensionNotificationContext,
+) => AgentTimelineItem[] | null;
+
 interface ACPAgentClientOptions {
   provider: string;
   logger: Logger;
@@ -410,6 +436,8 @@ interface ACPAgentClientOptions {
   autoApproveModeIds?: string[];
   capabilities?: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  shouldSuppressUserMessageChunk?: ACPUserMessageChunkFilter;
+  extensionNotificationHandler?: ACPExtensionNotificationHandler;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
@@ -448,6 +476,8 @@ interface ACPAgentSessionOptions {
   autoApproveModeIds?: string[];
   capabilities: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  shouldSuppressUserMessageChunk?: ACPUserMessageChunkFilter;
+  extensionNotificationHandler?: ACPExtensionNotificationHandler;
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
@@ -794,6 +824,8 @@ export class ACPAgentClient implements AgentClient {
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly shouldSuppressUserMessageChunk?: ACPUserMessageChunkFilter;
+  private readonly extensionNotificationHandler?: ACPExtensionNotificationHandler;
   protected readonly terminateProcess: ProcessTerminator;
 
   constructor(options: ACPAgentClientOptions) {
@@ -823,6 +855,8 @@ export class ACPAgentClient implements AgentClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.shouldSuppressUserMessageChunk = options.shouldSuppressUserMessageChunk;
+    this.extensionNotificationHandler = options.extensionNotificationHandler;
   }
 
   async createSession(
@@ -855,6 +889,8 @@ export class ACPAgentClient implements AgentClient {
         agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
         extensionCommandsParser: this.extensionCommandsParser,
+        shouldSuppressUserMessageChunk: this.shouldSuppressUserMessageChunk,
+        extensionNotificationHandler: this.extensionNotificationHandler,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
       },
@@ -908,6 +944,8 @@ export class ACPAgentClient implements AgentClient {
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
       extensionCommandsParser: this.extensionCommandsParser,
+      shouldSuppressUserMessageChunk: this.shouldSuppressUserMessageChunk,
+      extensionNotificationHandler: this.extensionNotificationHandler,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
     });
@@ -1401,6 +1439,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private waitForInitialCommands: boolean;
   private initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly shouldSuppressUserMessageChunk?: ACPUserMessageChunkFilter;
+  private readonly extensionNotificationHandler?: ACPExtensionNotificationHandler;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
   private fallbackAssistantMessageId: string | null = null;
@@ -1443,6 +1483,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.shouldSuppressUserMessageChunk = options.shouldSuppressUserMessageChunk;
+    this.extensionNotificationHandler = options.extensionNotificationHandler;
   }
 
   get id(): string | null {
@@ -2289,6 +2331,14 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         sessionId: typeof params.sessionId === "string" ? params.sessionId : undefined,
       });
     }
+
+    const timelineItems = this.extensionNotificationHandler?.(method, params, {
+      sessionId: this.sessionId,
+    });
+    if (!timelineItems) {
+      return;
+    }
+    this.deliverTranslatedEvents(timelineItems.map((item) => this.wrapTimeline(item)));
   }
 
   // Cache an asynchronously-delivered slash-command batch and unblock any
@@ -2655,6 +2705,11 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private handleUserMessageChunk(
     update: Extract<SessionUpdate, { sessionUpdate: "user_message_chunk" }>,
   ): AgentStreamEvent[] {
+    // Provider filter runs before assembly so hidden chunks cannot contaminate
+    // fallback message-ID state used by a later visible user message.
+    if (this.shouldSuppressUserMessageChunk?.(update)) {
+      return [];
+    }
     this.fallbackAssistantMessageId = null;
     if (
       this.activeForegroundTurnId &&

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -628,6 +628,29 @@ export function resolveACPModelSelection({
   };
 }
 
+/**
+ * ACP SessionMode only carries id/name/description. Re-attach provider-declared
+ * metadata (icon, colorTier, isUnattended) from fallbackModes by id so session
+ * availableModes keep unattended semantics and UI visuals.
+ */
+function attachFallbackModeMetadata(
+  mode: Pick<AgentMode, "id" | "label" | "description">,
+  fallbackModes: AgentMode[],
+): AgentMode {
+  const fallback = fallbackModes.find((entry) => entry.id === mode.id);
+  if (!fallback) {
+    return mode;
+  }
+  return {
+    id: mode.id,
+    label: mode.label,
+    description: mode.description,
+    ...(fallback.icon !== undefined ? { icon: fallback.icon } : {}),
+    ...(fallback.colorTier !== undefined ? { colorTier: fallback.colorTier } : {}),
+    ...(fallback.isUnattended !== undefined ? { isUnattended: fallback.isUnattended } : {}),
+  };
+}
+
 export function deriveModesFromACP(
   fallbackModes: AgentMode[],
   modeState?: { availableModes?: SessionMode[] | null; currentModeId?: string | null } | null,
@@ -635,11 +658,16 @@ export function deriveModesFromACP(
 ): { modes: AgentMode[]; currentModeId: string | null } {
   if (modeState?.availableModes?.length) {
     return {
-      modes: modeState.availableModes.map((mode) => ({
-        id: mode.id,
-        label: mode.name,
-        description: mode.description ?? undefined,
-      })),
+      modes: modeState.availableModes.map((mode) =>
+        attachFallbackModeMetadata(
+          {
+            id: mode.id,
+            label: mode.name,
+            description: mode.description ?? undefined,
+          },
+          fallbackModes,
+        ),
+      ),
       currentModeId: modeState.currentModeId ?? null,
     };
   }
@@ -648,11 +676,16 @@ export function deriveModesFromACP(
   if (modeOption) {
     const flatOptions = flattenSelectOptions(modeOption.options);
     return {
-      modes: flatOptions.map((option) => ({
-        id: option.value,
-        label: option.name,
-        description: option.description ?? undefined,
-      })),
+      modes: flatOptions.map((option) =>
+        attachFallbackModeMetadata(
+          {
+            id: option.value,
+            label: option.name,
+            description: option.description ?? undefined,
+          },
+          fallbackModes,
+        ),
+      ),
       currentModeId: modeOption.currentValue,
     };
   }

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -373,13 +373,24 @@ interface ACPAgentClientOptions {
   defaultCommand: [string, ...string[]];
   defaultModes?: AgentMode[];
   modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
-  sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
+  sessionResponseTransformer?: (
+    response: SessionStateResponse,
+    sessionConfig?: AgentSessionConfig,
+  ) => SessionStateResponse;
   configOptionsTransformer?: (configOptions: SessionConfigOption[]) => SessionConfigOption[];
   configFeatureOptions?: ACPConfigFeatureOption[];
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   modeIdTransformer?: (modeId: string) => string | null;
   toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  /**
+   * Optional per-session rewrite of the provider launch command (e.g. inject
+   * Grok `--always-approve` when the session mode requires it).
+   */
+  resolveSessionCommand?: (
+    command: [string, ...string[]],
+    config: AgentSessionConfig,
+  ) => [string, ...string[]];
   providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
@@ -389,6 +400,14 @@ interface ACPAgentClientOptions {
     sessionId: string,
     thinkingOptionId: string,
   ) => Promise<void>;
+  /**
+   * Mode IDs that auto-approve ACP `session/request_permission` without UI.
+   * Use as a client-side fallback when the upstream provider still requests
+   * permission even though the session is in an unattended mode (e.g. Grok
+   * Always Approve race / older builds). Prefer driving the provider's native
+   * always-approve path first.
+   */
+  autoApproveModeIds?: string[];
   capabilities?: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
   waitForInitialCommands?: boolean;
@@ -403,13 +422,20 @@ interface ACPAgentSessionOptions {
   defaultCommand: [string, ...string[]];
   defaultModes: AgentMode[];
   modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
-  sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
+  sessionResponseTransformer?: (
+    response: SessionStateResponse,
+    sessionConfig?: AgentSessionConfig,
+  ) => SessionStateResponse;
   configOptionsTransformer?: (configOptions: SessionConfigOption[]) => SessionConfigOption[];
   configFeatureOptions?: ACPConfigFeatureOption[];
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   modeIdTransformer?: (modeId: string) => string | null;
   toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  resolveSessionCommand?: (
+    command: [string, ...string[]],
+    config: AgentSessionConfig,
+  ) => [string, ...string[]];
   providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
@@ -419,6 +445,7 @@ interface ACPAgentSessionOptions {
     sessionId: string,
     thinkingOptionId: string,
   ) => Promise<void>;
+  autoApproveModeIds?: string[];
   capabilities: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
   handle?: AgentPersistenceHandle;
@@ -705,6 +732,7 @@ export class ACPAgentClient implements AgentClient {
   private readonly modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   private readonly sessionResponseTransformer?: (
     response: SessionStateResponse,
+    sessionConfig?: AgentSessionConfig,
   ) => SessionStateResponse;
   private readonly configOptionsTransformer?: (
     configOptions: SessionConfigOption[],
@@ -714,6 +742,10 @@ export class ACPAgentClient implements AgentClient {
   private readonly clientCapabilityMeta?: ACPClientCapabilityMeta;
   private readonly modeIdTransformer?: (modeId: string) => string | null;
   private readonly toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  private readonly resolveSessionCommand?: (
+    command: [string, ...string[]],
+    config: AgentSessionConfig,
+  ) => [string, ...string[]];
   private readonly providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
@@ -725,6 +757,7 @@ export class ACPAgentClient implements AgentClient {
     sessionId: string,
     thinkingOptionId: string,
   ) => Promise<void>;
+  private readonly autoApproveModeIds: string[];
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
@@ -749,9 +782,11 @@ export class ACPAgentClient implements AgentClient {
     this.clientCapabilityMeta = options.clientCapabilityMeta;
     this.modeIdTransformer = options.modeIdTransformer;
     this.toolSnapshotTransformer = options.toolSnapshotTransformer;
+    this.resolveSessionCommand = options.resolveSessionCommand;
     this.providerModeWriter = options.providerModeWriter;
     this.beforeModeWriter = options.beforeModeWriter;
     this.thinkingOptionWriter = options.thinkingOptionWriter;
+    this.autoApproveModeIds = options.autoApproveModeIds ?? [];
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
@@ -778,9 +813,11 @@ export class ACPAgentClient implements AgentClient {
         clientCapabilityMeta: this.clientCapabilityMeta,
         modeIdTransformer: this.modeIdTransformer,
         toolSnapshotTransformer: this.toolSnapshotTransformer,
+        resolveSessionCommand: this.resolveSessionCommand,
         providerModeWriter: this.providerModeWriter,
         beforeModeWriter: this.beforeModeWriter,
         thinkingOptionWriter: this.thinkingOptionWriter,
+        autoApproveModeIds: this.autoApproveModeIds,
         capabilities: this.capabilities,
         agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
@@ -828,9 +865,11 @@ export class ACPAgentClient implements AgentClient {
       clientCapabilityMeta: this.clientCapabilityMeta,
       modeIdTransformer: this.modeIdTransformer,
       toolSnapshotTransformer: this.toolSnapshotTransformer,
+      resolveSessionCommand: this.resolveSessionCommand,
       providerModeWriter: this.providerModeWriter,
       beforeModeWriter: this.beforeModeWriter,
       thinkingOptionWriter: this.thinkingOptionWriter,
+      autoApproveModeIds: this.autoApproveModeIds,
       capabilities: this.capabilities,
       handle,
       agentId: launchContext?.agentId,
@@ -1273,6 +1312,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   protected readonly modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
   private readonly sessionResponseTransformer?: (
     response: SessionStateResponse,
+    sessionConfig?: AgentSessionConfig,
   ) => SessionStateResponse;
   private readonly configOptionsTransformer?: (
     configOptions: SessionConfigOption[],
@@ -1282,6 +1322,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly clientCapabilityMeta?: ACPClientCapabilityMeta;
   private readonly modeIdTransformer?: (modeId: string) => string | null;
   private readonly toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  private readonly resolveSessionCommand?: (
+    command: [string, ...string[]],
+    config: AgentSessionConfig,
+  ) => [string, ...string[]];
   private readonly providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
@@ -1293,6 +1337,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     sessionId: string,
     thinkingOptionId: string,
   ) => Promise<void>;
+  private readonly autoApproveModeIds: ReadonlySet<string>;
   private readonly agentId?: string;
   private readonly launchEnv?: Record<string, string>;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
@@ -1348,9 +1393,11 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.clientCapabilityMeta = options.clientCapabilityMeta;
     this.modeIdTransformer = options.modeIdTransformer;
     this.toolSnapshotTransformer = options.toolSnapshotTransformer;
+    this.resolveSessionCommand = options.resolveSessionCommand;
     this.providerModeWriter = options.providerModeWriter;
     this.beforeModeWriter = options.beforeModeWriter;
     this.thinkingOptionWriter = options.thinkingOptionWriter;
+    this.autoApproveModeIds = new Set(options.autoApproveModeIds ?? []);
     this.availableModes = options.defaultModes;
     this.agentId = options.agentId;
     this.launchEnv = options.launchEnv;
@@ -2083,7 +2130,42 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
-    // Match Zed acp.rs:3189-3220: generic ACP permission requests stay pure pass-through.
+    // Client-side fallback for unattended modes. Prefer provider-native always-approve
+    // (e.g. Grok `--always-approve` / `/always-approve`) so requestPermission is never
+    // emitted; this path covers races and older builds that still ask the client.
+    // Generic ACP requests otherwise stay pure pass-through (match Zed acp.rs:3189-3220).
+    if (this.currentMode && this.autoApproveModeIds.has(this.currentMode)) {
+      const allowOption = selectPermissionOption(params.options, { behavior: "allow" });
+      if (allowOption) {
+        this.logger.debug(
+          {
+            agentId: this.agentId,
+            provider: this.provider,
+            modeId: this.currentMode,
+            toolCallId: params.toolCall.toolCallId,
+            optionId: allowOption.optionId,
+          },
+          "provider.acp.permission.auto_approved",
+        );
+        return {
+          outcome: {
+            outcome: "selected",
+            optionId: allowOption.optionId,
+          },
+        };
+      }
+      this.logger.warn(
+        {
+          agentId: this.agentId,
+          provider: this.provider,
+          modeId: this.currentMode,
+          toolCallId: params.toolCall.toolCallId,
+        },
+        "provider.acp.permission.auto_approve_missing_allow_option",
+      );
+      return { outcome: { outcome: "cancelled" } };
+    }
+
     const requestId = randomUUID();
     let toolSnapshot =
       this.toolCalls.get(params.toolCall.toolCallId) ??
@@ -2309,17 +2391,20 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private async spawnProcess(): Promise<SpawnedACPProcess> {
+    const sessionCommand = this.resolveSessionCommand
+      ? this.resolveSessionCommand(this.defaultCommand, this.config)
+      : this.defaultCommand;
     const prefix = await resolveProviderLaunch({
       commandConfig: this.runtimeSettings?.command,
-      defaultBinary: this.defaultCommand[0],
+      defaultBinary: sessionCommand[0],
     });
     const availability = await checkProviderLaunchAvailable(prefix);
     if (!availability.available) {
-      throw new Error(`${this.provider} command '${this.defaultCommand[0]}' not found`);
+      throw new Error(`${this.provider} command '${sessionCommand[0]}' not found`);
     }
 
     const command = prefix.command;
-    const args = [...prefix.args, ...this.defaultCommand.slice(1)];
+    const args = [...prefix.args, ...sessionCommand.slice(1)];
     const child = spawnProcess(command, args, {
       cwd: this.config.cwd,
       ...createProviderEnvSpec({
@@ -2388,7 +2473,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   private applySessionState(response: SessionStateResponse): void {
     const transformed = this.sessionResponseTransformer
-      ? this.sessionResponseTransformer(response)
+      ? this.sessionResponseTransformer(response, this.config)
       : response;
 
     this.configOptions = this.transformConfigOptions(transformed.configOptions ?? []);

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -8,8 +8,10 @@ import {
   type ACPBeforeModeWriteResult,
   type ACPClientCapabilityMeta,
   type ACPConfigFeatureOption,
+  type ACPExtensionNotificationHandler,
   type ACPProviderModeWriteResult,
   type ACPProviderModeWriterContext,
+  type ACPUserMessageChunkFilter,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
   type SessionStateResponse,
@@ -53,6 +55,8 @@ interface GenericACPAgentClientOptions {
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  shouldSuppressUserMessageChunk?: ACPUserMessageChunkFilter;
+  extensionNotificationHandler?: ACPExtensionNotificationHandler;
   defaultModes?: AgentMode[];
   sessionResponseTransformer?: (
     response: SessionStateResponse,
@@ -97,6 +101,8 @@ export class GenericACPAgentClient extends ACPAgentClient {
       clientCapabilityMeta: options.clientCapabilityMeta,
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
+      shouldSuppressUserMessageChunk: options.shouldSuppressUserMessageChunk,
+      extensionNotificationHandler: options.extensionNotificationHandler,
     });
 
     this.command = options.command;

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -1,14 +1,18 @@
 import type { Logger } from "pino";
 import { z } from "zod";
 
-import type { AgentCapabilityFlags } from "../agent-sdk-types.js";
+import type { AgentCapabilityFlags, AgentMode, AgentSessionConfig } from "../agent-sdk-types.js";
 import { checkProviderLaunchAvailable, resolveProviderLaunch } from "../provider-launch-config.js";
 import {
   ACPAgentClient,
+  type ACPBeforeModeWriteResult,
   type ACPClientCapabilityMeta,
   type ACPConfigFeatureOption,
+  type ACPProviderModeWriteResult,
+  type ACPProviderModeWriterContext,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
+  type SessionStateResponse,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -49,6 +53,20 @@ interface GenericACPAgentClientOptions {
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  defaultModes?: AgentMode[];
+  sessionResponseTransformer?: (
+    response: SessionStateResponse,
+    sessionConfig?: AgentSessionConfig,
+  ) => SessionStateResponse;
+  resolveSessionCommand?: (
+    command: [string, ...string[]],
+    config: AgentSessionConfig,
+  ) => [string, ...string[]];
+  providerModeWriter?: (
+    context: ACPProviderModeWriterContext,
+  ) => Promise<ACPProviderModeWriteResult>;
+  beforeModeWriter?: (context: ACPProviderModeWriterContext) => Promise<ACPBeforeModeWriteResult>;
+  autoApproveModeIds?: string[];
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -66,6 +84,12 @@ export class GenericACPAgentClient extends ACPAgentClient {
         env: options.env,
       },
       defaultCommand: options.command,
+      defaultModes: options.defaultModes,
+      sessionResponseTransformer: options.sessionResponseTransformer,
+      resolveSessionCommand: options.resolveSessionCommand,
+      providerModeWriter: options.providerModeWriter,
+      beforeModeWriter: options.beforeModeWriter,
+      autoApproveModeIds: options.autoApproveModeIds,
       capabilities: buildGenericACPCapabilities(providerParams),
       waitForInitialCommands: options.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: options.initialCommandsWaitTimeoutMs,

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -357,6 +357,29 @@ test("writeGrokProviderMode leaves unknown ACP modes to the generic path", async
   ).resolves.toEqual({ handled: false });
 });
 
+test("writeGrokProviderMode does not claim Ask when leaving an upstream ACP mode", async () => {
+  const recording = createRecordingGrokConnection();
+
+  await expect(
+    writeGrokProviderMode({
+      connection: recording.connection as never,
+      sessionId: "session-1",
+      requestedModeId: GROK_ASK_MODE_ID,
+      currentModeId: "plan",
+      selection: {
+        availableMode: GROK_MODES[0] ?? null,
+        configOption: null,
+        configChoice: null,
+        hasAvailableModes: true,
+      },
+      configOptions: [],
+      logger: createTestLogger(),
+    }),
+  ).resolves.toEqual({ handled: false });
+
+  expect(recording.prompts).toEqual([]);
+});
+
 test("Always Approve fallback auto-approves ACP permission requests without UI events", async () => {
   const session = new ACPAgentSession(
     {

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,0 +1,330 @@
+import { expect, test, vi } from "vitest";
+import type { PermissionOption, RequestPermissionRequest } from "@agentclientprotocol/sdk";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import { asInternals } from "../../test-utils/class-mocks.js";
+import { ACPAgentSession } from "./acp-agent.js";
+import {
+  GROK_ALWAYS_APPROVE_MODE_ID,
+  GROK_ASK_MODE_ID,
+  GROK_MODES,
+  resolveGrokSessionCommand,
+  transformGrokSessionResponse,
+  withGrokAlwaysApproveLaunchFlag,
+  writeGrokProviderMode,
+} from "./grok-acp-agent.js";
+
+test("withGrokAlwaysApproveLaunchFlag injects flag after agent subcommand", () => {
+  expect(withGrokAlwaysApproveLaunchFlag(["grok", "agent", "stdio"], true)).toEqual([
+    "grok",
+    "agent",
+    "--always-approve",
+    "stdio",
+  ]);
+});
+
+test("withGrokAlwaysApproveLaunchFlag is idempotent and strips yolo aliases when disabling", () => {
+  expect(
+    withGrokAlwaysApproveLaunchFlag(["grok", "agent", "--always-approve", "stdio"], true),
+  ).toEqual(["grok", "agent", "--always-approve", "stdio"]);
+  expect(withGrokAlwaysApproveLaunchFlag(["grok", "agent", "--yolo", "stdio"], false)).toEqual([
+    "grok",
+    "agent",
+    "stdio",
+  ]);
+});
+
+test("resolveGrokSessionCommand enables launch flag only for Always Approve mode", () => {
+  expect(
+    resolveGrokSessionCommand(["grok", "agent", "stdio"], {
+      provider: "acp",
+      cwd: "/tmp",
+      modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+    }),
+  ).toEqual(["grok", "agent", "--always-approve", "stdio"]);
+  expect(
+    resolveGrokSessionCommand(["grok", "agent", "stdio"], {
+      provider: "acp",
+      cwd: "/tmp",
+      modeId: GROK_ASK_MODE_ID,
+    }),
+  ).toEqual(["grok", "agent", "stdio"]);
+});
+
+test("transformGrokSessionResponse injects Ask and Always Approve when ACP advertises no modes", () => {
+  const transformed = transformGrokSessionResponse({
+    sessionId: "session-1",
+    modes: null,
+  });
+
+  expect(transformed.modes?.availableModes?.map((mode) => mode.id)).toEqual([
+    GROK_ASK_MODE_ID,
+    GROK_ALWAYS_APPROVE_MODE_ID,
+  ]);
+  expect(transformed.modes?.currentModeId).toBe(GROK_ASK_MODE_ID);
+});
+
+test("transformGrokSessionResponse preserves configured Always Approve when injecting modes", () => {
+  const transformed = transformGrokSessionResponse(
+    {
+      sessionId: "session-1",
+      modes: null,
+    },
+    {
+      provider: "acp",
+      cwd: "/tmp",
+      modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+    },
+  );
+
+  expect(transformed.modes?.currentModeId).toBe(GROK_ALWAYS_APPROVE_MODE_ID);
+});
+
+test("transformGrokSessionResponse appends Always Approve without dropping upstream modes", () => {
+  const transformed = transformGrokSessionResponse({
+    sessionId: "session-1",
+    modes: {
+      currentModeId: "plan",
+      availableModes: [
+        {
+          id: "plan",
+          name: "Plan",
+          description: "Plan mode",
+        },
+      ],
+    },
+  });
+
+  expect(transformed.modes?.availableModes?.map((mode) => mode.id)).toEqual([
+    "plan",
+    GROK_ASK_MODE_ID,
+    GROK_ALWAYS_APPROVE_MODE_ID,
+  ]);
+  expect(transformed.modes?.currentModeId).toBe("plan");
+});
+
+test("writeGrokProviderMode enables native always-approve via slash command", async () => {
+  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+  const setSessionMode = vi.fn(async () => undefined);
+  const setSessionConfigOption = vi.fn(async () => ({ configOptions: [] }));
+
+  await expect(
+    writeGrokProviderMode({
+      connection: { prompt, setSessionMode, setSessionConfigOption } as never,
+      sessionId: "session-1",
+      requestedModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      currentModeId: GROK_ASK_MODE_ID,
+      selection: {
+        availableMode: GROK_MODES[1] ?? null,
+        configOption: null,
+        configChoice: null,
+        hasAvailableModes: true,
+      },
+      configOptions: [],
+      logger: createTestLogger(),
+    }),
+  ).resolves.toEqual({
+    handled: true,
+    currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+  });
+
+  expect(prompt).toHaveBeenCalledWith({
+    sessionId: "session-1",
+    prompt: [{ type: "text", text: "/always-approve on" }],
+  });
+  expect(setSessionMode).not.toHaveBeenCalled();
+  expect(setSessionConfigOption).not.toHaveBeenCalled();
+});
+
+test("writeGrokProviderMode disables native always-approve when switching to Ask", async () => {
+  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+
+  await expect(
+    writeGrokProviderMode({
+      connection: { prompt } as never,
+      sessionId: "session-1",
+      requestedModeId: GROK_ASK_MODE_ID,
+      currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      selection: {
+        availableMode: GROK_MODES[0] ?? null,
+        configOption: null,
+        configChoice: null,
+        hasAvailableModes: true,
+      },
+      configOptions: [],
+      logger: createTestLogger(),
+    }),
+  ).resolves.toEqual({
+    handled: true,
+    currentModeId: GROK_ASK_MODE_ID,
+  });
+
+  expect(prompt).toHaveBeenCalledWith({
+    sessionId: "session-1",
+    prompt: [{ type: "text", text: "/always-approve off" }],
+  });
+});
+
+test("writeGrokProviderMode does not re-prompt when already in the requested mode", async () => {
+  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+
+  await expect(
+    writeGrokProviderMode({
+      connection: { prompt } as never,
+      sessionId: "session-1",
+      requestedModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      selection: {
+        availableMode: GROK_MODES[1] ?? null,
+        configOption: null,
+        configChoice: null,
+        hasAvailableModes: true,
+      },
+      configOptions: [],
+      logger: createTestLogger(),
+    }),
+  ).resolves.toEqual({
+    handled: true,
+    currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+  });
+
+  expect(prompt).not.toHaveBeenCalled();
+});
+
+test("writeGrokProviderMode leaves unknown ACP modes to the generic path", async () => {
+  await expect(
+    writeGrokProviderMode({
+      connection: {} as never,
+      sessionId: "session-1",
+      requestedModeId: "plan",
+      currentModeId: GROK_ASK_MODE_ID,
+      selection: {
+        availableMode: { id: "plan", label: "Plan" },
+        configOption: null,
+        configChoice: null,
+        hasAvailableModes: true,
+      },
+      configOptions: [],
+      logger: createTestLogger(),
+    }),
+  ).resolves.toEqual({ handled: false });
+});
+
+test("Always Approve fallback auto-approves ACP permission requests without UI events", async () => {
+  const session = new ACPAgentSession(
+    {
+      provider: "acp",
+      cwd: "/tmp/paseo-grok-test",
+      modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+    },
+    {
+      provider: "acp",
+      logger: createTestLogger(),
+      defaultCommand: ["grok", "agent", "stdio"],
+      defaultModes: GROK_MODES,
+      autoApproveModeIds: [GROK_ALWAYS_APPROVE_MODE_ID],
+      providerModeWriter: writeGrokProviderMode,
+      sessionResponseTransformer: transformGrokSessionResponse,
+      resolveSessionCommand: resolveGrokSessionCommand,
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+    },
+  );
+
+  const events: Array<{ type: string }> = [];
+  session.subscribe((event) => {
+    events.push(event);
+  });
+
+  asInternals<{
+    sessionId: string | null;
+    currentMode: string | null;
+    availableModes: typeof GROK_MODES;
+  }>(session).sessionId = "session-1";
+  asInternals<{ currentMode: string | null }>(session).currentMode = GROK_ALWAYS_APPROVE_MODE_ID;
+
+  const permissionOptions: PermissionOption[] = [
+    { optionId: "allow-once", name: "Allow", kind: "allow_once" },
+    { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+  ];
+
+  await expect(
+    session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "tool-1",
+        title: "Run shell",
+        kind: "execute",
+        status: "pending",
+      },
+      options: permissionOptions,
+    } satisfies RequestPermissionRequest),
+  ).resolves.toEqual({
+    outcome: { outcome: "selected", optionId: "allow-once" },
+  });
+
+  expect(events.some((event) => event.type === "permission_requested")).toBe(false);
+});
+
+test("Ask mode still surfaces ACP permission requests", async () => {
+  const session = new ACPAgentSession(
+    {
+      provider: "acp",
+      cwd: "/tmp/paseo-grok-test",
+      modeId: GROK_ASK_MODE_ID,
+    },
+    {
+      provider: "acp",
+      logger: createTestLogger(),
+      defaultCommand: ["grok", "agent", "stdio"],
+      defaultModes: GROK_MODES,
+      autoApproveModeIds: [GROK_ALWAYS_APPROVE_MODE_ID],
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+    },
+  );
+
+  const events: Array<{ type: string; request?: { id: string } }> = [];
+  session.subscribe((event) => {
+    events.push(event as { type: string; request?: { id: string } });
+  });
+
+  asInternals<{ sessionId: string | null; currentMode: string | null }>(session).sessionId =
+    "session-1";
+  asInternals<{ currentMode: string | null }>(session).currentMode = GROK_ASK_MODE_ID;
+
+  const permission = session.requestPermission({
+    sessionId: "session-1",
+    toolCall: {
+      toolCallId: "tool-2",
+      title: "Edit file",
+      kind: "edit",
+      status: "pending",
+    },
+    options: [
+      { optionId: "allow-once", name: "Allow", kind: "allow_once" },
+      { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+    ],
+  } satisfies RequestPermissionRequest);
+
+  await Promise.resolve();
+  const requested = events.find((event) => event.type === "permission_requested");
+  expect(requested?.request?.id).toEqual(expect.any(String));
+
+  await session.respondToPermission(requested!.request!.id, { behavior: "allow" });
+  await expect(permission).resolves.toEqual({
+    outcome: { outcome: "selected", optionId: "allow-once" },
+  });
+});

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,8 +1,13 @@
 import { expect, test } from "vitest";
-import type { PermissionOption, RequestPermissionRequest } from "@agentclientprotocol/sdk";
+import type {
+  PermissionOption,
+  RequestPermissionRequest,
+  SessionUpdate,
+} from "@agentclientprotocol/sdk";
 
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { asInternals } from "../../test-utils/class-mocks.js";
+import type { AgentStreamEvent, AgentTimelineItem } from "../agent-sdk-types.js";
 import {
   isDefaultAgentCreateConfigUnattended,
   resolveDefaultAgentCreateConfig,
@@ -17,6 +22,12 @@ import {
   withGrokAlwaysApproveLaunchFlag,
   writeGrokProviderMode,
 } from "./grok-acp-agent.js";
+import {
+  GROK_SESSION_UPDATE_METHOD,
+  buildGrokBackgroundTaskCallId,
+  isGrokHiddenFromScrollbackUserChunk,
+  mapGrokExtensionNotificationToTimelineItems,
+} from "./grok-background-tasks.js";
 
 function createRecordingGrokConnection() {
   const prompts: Array<{ sessionId: string; prompt: Array<{ type: string; text: string }> }> = [];
@@ -463,4 +474,387 @@ test("Ask mode still surfaces ACP permission requests", async () => {
   await expect(permission).resolves.toEqual({
     outcome: { outcome: "selected", optionId: "allow-once" },
   });
+});
+
+const GROK_ACP_CAPABILITIES = {
+  supportsStreaming: true,
+  supportsSessionPersistence: true,
+  supportsDynamicModes: true,
+  supportsMcpServers: true,
+  supportsReasoningStream: true,
+  supportsToolInvocations: true,
+} as const;
+
+function createGrokBackgroundTaskSession(): ACPAgentSession {
+  return new ACPAgentSession(
+    {
+      provider: "grok",
+      cwd: "/tmp/paseo-grok-bg-test",
+    },
+    {
+      provider: "grok",
+      logger: createTestLogger(),
+      defaultCommand: ["grok", "agent", "stdio"],
+      defaultModes: GROK_MODES,
+      capabilities: GROK_ACP_CAPABILITIES,
+      shouldSuppressUserMessageChunk: isGrokHiddenFromScrollbackUserChunk,
+      extensionNotificationHandler: mapGrokExtensionNotificationToTimelineItems,
+    },
+  );
+}
+
+function createGenericAcpSession(): ACPAgentSession {
+  return new ACPAgentSession(
+    {
+      provider: "claude-acp",
+      cwd: "/tmp/paseo-generic-acp-test",
+    },
+    {
+      provider: "claude-acp",
+      logger: createTestLogger(),
+      defaultCommand: ["claude", "--acp"],
+      defaultModes: [],
+      capabilities: GROK_ACP_CAPABILITIES,
+    },
+  );
+}
+
+function collectTimelineItems(session: ACPAgentSession): AgentTimelineItem[] {
+  const items: AgentTimelineItem[] = [];
+  session.subscribe((event: AgentStreamEvent) => {
+    if (event.type === "timeline") {
+      items.push(event.item);
+    }
+  });
+  return items;
+}
+
+function hiddenUserChunk(
+  text: string,
+  messageId?: string | null,
+): Extract<SessionUpdate, { sessionUpdate: "user_message_chunk" }> {
+  return {
+    sessionUpdate: "user_message_chunk",
+    content: { type: "text", text },
+    ...(messageId !== undefined ? { messageId } : {}),
+    _meta: { hideFromScrollback: true, modelId: "grok-4.5" },
+  };
+}
+
+test("live Grok session suppresses hideFromScrollback user chunks", async () => {
+  const session = createGrokBackgroundTaskSession();
+  const items = collectTimelineItems(session);
+  asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: hiddenUserChunk(
+      '<system-reminder>Background task "task-1" completed (exit code: 0).</system-reminder>',
+      "msg-hidden",
+    ),
+  });
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "user_message_chunk",
+      content: { type: "text", text: "real user prompt" },
+      messageId: "msg-visible",
+    },
+  });
+
+  expect(items).toEqual([
+    { type: "user_message", text: "real user prompt", messageId: "msg-visible" },
+  ]);
+});
+
+test("history replay also suppresses hideFromScrollback user chunks", async () => {
+  const session = createGrokBackgroundTaskSession();
+  const internals = asInternals<{
+    sessionId: string | null;
+    replayingHistory: boolean;
+    persistedHistory: AgentTimelineItem[];
+  }>(session);
+  internals.sessionId = "session-1";
+  internals.replayingHistory = true;
+
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: hiddenUserChunk("<system-reminder>Background task completed</system-reminder>"),
+  });
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "user_message_chunk",
+      content: { type: "text", text: "visible during load" },
+      messageId: "msg-load",
+    },
+  });
+
+  expect(internals.persistedHistory).toEqual([
+    { type: "user_message", text: "visible during load", messageId: "msg-load" },
+  ]);
+});
+
+test("hidden chunk without messageId does not contaminate a later visible user message", async () => {
+  const session = createGrokBackgroundTaskSession();
+  const items = collectTimelineItems(session);
+  asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: hiddenUserChunk("<system-reminder>hidden wake-up without messageId</system-reminder>"),
+  });
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "user_message_chunk",
+      content: { type: "text", text: "first visible" },
+    },
+  });
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "user_message_chunk",
+      content: { type: "text", text: " second" },
+    },
+  });
+
+  // User chunks emit accumulated text per chunk; the hidden wake-up must never
+  // enter messageAssemblies for the shared no-messageId key.
+  expect(items.map((item) => ("text" in item ? item.text : null))).toEqual([
+    "first visible",
+    "first visible second",
+  ]);
+  expect(items.every((item) => !("text" in item && item.text.includes("system-reminder")))).toBe(
+    true,
+  );
+});
+
+test("generic ACP provider still renders hideFromScrollback chunks as user messages", async () => {
+  const session = createGenericAcpSession();
+  const items = collectTimelineItems(session);
+  asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: hiddenUserChunk("<system-reminder>would be hidden only for Grok</system-reminder>"),
+  });
+
+  expect(items).toEqual([
+    {
+      type: "user_message",
+      text: "<system-reminder>would be hidden only for Grok</system-reminder>",
+    },
+  ]);
+});
+
+test("Grok task_backgrounded then task_completed project one synthetic tool lifecycle", async () => {
+  const session = createGrokBackgroundTaskSession();
+  const items = collectTimelineItems(session);
+  asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+  const callId = buildGrokBackgroundTaskCallId("task-lifecycle");
+
+  await session.extNotification(GROK_SESSION_UPDATE_METHOD, {
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "task_backgrounded",
+      task_snapshot: {
+        task_id: "task-lifecycle",
+        command: "npm test",
+        cwd: "/tmp",
+        output: null,
+        truncated: false,
+        exit_code: null,
+        signal: null,
+        completed: false,
+        kind: "bash",
+      },
+    },
+  });
+  await session.extNotification(GROK_SESSION_UPDATE_METHOD, {
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "task_completed",
+      task_snapshot: {
+        task_id: "task-lifecycle",
+        command: "npm test",
+        cwd: "/tmp",
+        output: "ok",
+        truncated: false,
+        exit_code: 0,
+        signal: null,
+        completed: true,
+        kind: "bash",
+      },
+      will_wake: true,
+    },
+  });
+
+  expect(items).toHaveLength(2);
+  expect(items[0]).toMatchObject({ type: "tool_call", callId, status: "running" });
+  expect(items[1]).toMatchObject({ type: "tool_call", callId, status: "completed", error: null });
+});
+
+test("Grok failed, canceled, missing-output, and truncated task states", async () => {
+  const session = createGrokBackgroundTaskSession();
+  const items = collectTimelineItems(session);
+  asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+
+  await session.extNotification(GROK_SESSION_UPDATE_METHOD, {
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "task_completed",
+      task_snapshot: {
+        task_id: "fail",
+        command: "false",
+        exit_code: 1,
+        signal: null,
+        output: "err",
+        truncated: false,
+        completed: true,
+        kind: "bash",
+      },
+    },
+  });
+  await session.extNotification(GROK_SESSION_UPDATE_METHOD, {
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "task_completed",
+      task_snapshot: {
+        task_id: "cancel",
+        command: "sleep 99",
+        exit_code: null,
+        signal: "SIGINT",
+        output: null,
+        truncated: false,
+        completed: true,
+        kind: "bash",
+      },
+    },
+  });
+  await session.extNotification(GROK_SESSION_UPDATE_METHOD, {
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "task_completed",
+      task_snapshot: {
+        task_id: "no-out",
+        command: "true",
+        exit_code: 0,
+        signal: null,
+        output: null,
+        truncated: false,
+        completed: true,
+        kind: "bash",
+      },
+    },
+  });
+  await session.extNotification(GROK_SESSION_UPDATE_METHOD, {
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "task_completed",
+      task_snapshot: {
+        task_id: "trunc",
+        command: "yes",
+        exit_code: 0,
+        signal: null,
+        output: "partial",
+        truncated: true,
+        completed: true,
+        kind: "bash",
+      },
+    },
+  });
+
+  expect(items).toHaveLength(4);
+  expect(items[0]).toMatchObject({
+    callId: buildGrokBackgroundTaskCallId("fail"),
+    status: "failed",
+  });
+  expect(items[1]).toMatchObject({
+    callId: buildGrokBackgroundTaskCallId("cancel"),
+    status: "canceled",
+  });
+  expect(items[2]).toMatchObject({
+    callId: buildGrokBackgroundTaskCallId("no-out"),
+    status: "completed",
+    detail: expect.objectContaining({ text: expect.stringContaining("(no output)") }),
+  });
+  expect(items[3]).toMatchObject({
+    callId: buildGrokBackgroundTaskCallId("trunc"),
+    status: "completed",
+    detail: expect.objectContaining({ text: expect.stringContaining("Output truncated") }),
+  });
+});
+
+test("repeated and history-replayed Grok task notifications keep stable callId", async () => {
+  const session = createGrokBackgroundTaskSession();
+  const liveItems = collectTimelineItems(session);
+  const internals = asInternals<{
+    sessionId: string | null;
+    replayingHistory: boolean;
+    persistedHistory: AgentTimelineItem[];
+  }>(session);
+  internals.sessionId = "session-1";
+  const callId = buildGrokBackgroundTaskCallId("dedupe-1");
+  const completedPayload = {
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "task_completed" as const,
+      task_snapshot: {
+        task_id: "dedupe-1",
+        command: "echo hi",
+        exit_code: 0,
+        signal: null,
+        output: "hi",
+        truncated: false,
+        completed: true,
+        kind: "bash",
+      },
+    },
+  };
+
+  await session.extNotification(GROK_SESSION_UPDATE_METHOD, completedPayload);
+  await session.extNotification(GROK_SESSION_UPDATE_METHOD, completedPayload);
+  expect(liveItems).toHaveLength(2);
+  expect(liveItems[0]).toMatchObject({ callId, status: "completed" });
+  expect(liveItems[1]).toMatchObject({ callId, status: "completed" });
+
+  internals.replayingHistory = true;
+  await session.extNotification(GROK_SESSION_UPDATE_METHOD, completedPayload);
+  expect(internals.persistedHistory).toEqual([
+    expect.objectContaining({ type: "tool_call", callId, status: "completed" }),
+  ]);
+});
+
+test("malformed and wrong-session Grok extension notifications are ignored safely", async () => {
+  const session = createGrokBackgroundTaskSession();
+  const items = collectTimelineItems(session);
+  asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+
+  await session.extNotification(GROK_SESSION_UPDATE_METHOD, {
+    sessionId: "other-session",
+    update: {
+      sessionUpdate: "task_completed",
+      task_snapshot: {
+        task_id: "x",
+        command: "echo",
+        exit_code: 0,
+        signal: null,
+        output: "x",
+        truncated: false,
+        completed: true,
+        kind: "bash",
+      },
+    },
+  });
+  await session.extNotification(GROK_SESSION_UPDATE_METHOD, {
+    sessionId: "session-1",
+    update: { sessionUpdate: "task_completed" },
+  });
+  await session.extNotification("_other/vendor", {
+    sessionId: "session-1",
+    update: { sessionUpdate: "task_completed" },
+  });
+
+  expect(items).toEqual([]);
 });

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,9 +1,13 @@
-import { expect, test, vi } from "vitest";
+import { expect, test } from "vitest";
 import type { PermissionOption, RequestPermissionRequest } from "@agentclientprotocol/sdk";
 
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { asInternals } from "../../test-utils/class-mocks.js";
-import { ACPAgentSession } from "./acp-agent.js";
+import {
+  isDefaultAgentCreateConfigUnattended,
+  resolveDefaultAgentCreateConfig,
+} from "../create-agent-mode.js";
+import { ACPAgentSession, deriveModesFromACP } from "./acp-agent.js";
 import {
   GROK_ALWAYS_APPROVE_MODE_ID,
   GROK_ASK_MODE_ID,
@@ -13,6 +17,55 @@ import {
   withGrokAlwaysApproveLaunchFlag,
   writeGrokProviderMode,
 } from "./grok-acp-agent.js";
+
+function createRecordingGrokConnection() {
+  const prompts: Array<{ sessionId: string; prompt: Array<{ type: string; text: string }> }> = [];
+  const sessionModeCalls: unknown[] = [];
+  const configOptionCalls: unknown[] = [];
+
+  return {
+    prompts,
+    sessionModeCalls,
+    configOptionCalls,
+    connection: {
+      prompt: async (params: {
+        sessionId: string;
+        prompt: Array<{ type: string; text: string }>;
+      }) => {
+        prompts.push(params);
+        return { stopReason: "end_turn" };
+      },
+      setSessionMode: async (params: unknown) => {
+        sessionModeCalls.push(params);
+      },
+      setSessionConfigOption: async (params: unknown) => {
+        configOptionCalls.push(params);
+        return { configOptions: [] };
+      },
+    },
+  };
+}
+
+test("GROK_MODES is the full canonical definition including visuals and unattended", () => {
+  expect(GROK_MODES).toEqual([
+    {
+      id: GROK_ASK_MODE_ID,
+      label: "Ask",
+      description: "Prompt before shell and tool executions",
+      icon: "ShieldCheck",
+      colorTier: "safe",
+    },
+    {
+      id: GROK_ALWAYS_APPROVE_MODE_ID,
+      label: "Always Approve",
+      description:
+        "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
+      icon: "ShieldOff",
+      colorTier: "dangerous",
+      isUnattended: true,
+    },
+  ]);
+});
 
 test("withGrokAlwaysApproveLaunchFlag injects flag after agent subcommand", () => {
   expect(withGrokAlwaysApproveLaunchFlag(["grok", "agent", "stdio"], true)).toEqual([
@@ -103,14 +156,93 @@ test("transformGrokSessionResponse appends Always Approve without dropping upstr
   expect(transformed.modes?.currentModeId).toBe("plan");
 });
 
+test("transform + deriveModesFromACP keeps Always Approve unattended and visual metadata", () => {
+  const transformed = transformGrokSessionResponse(
+    {
+      sessionId: "session-1",
+      modes: null,
+    },
+    {
+      provider: "acp",
+      cwd: "/tmp",
+      modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+    },
+  );
+
+  const derived = deriveModesFromACP(GROK_MODES, transformed.modes);
+
+  expect(derived.currentModeId).toBe(GROK_ALWAYS_APPROVE_MODE_ID);
+  expect(derived.modes).toEqual([
+    {
+      id: GROK_ASK_MODE_ID,
+      label: "Ask",
+      description: "Prompt before shell and tool executions",
+      icon: "ShieldCheck",
+      colorTier: "safe",
+    },
+    {
+      id: GROK_ALWAYS_APPROVE_MODE_ID,
+      label: "Always Approve",
+      description:
+        "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
+      icon: "ShieldOff",
+      colorTier: "dangerous",
+      isUnattended: true,
+    },
+  ]);
+});
+
+test("derived session modes mark Always Approve as unattended for create-config inheritance", () => {
+  const transformed = transformGrokSessionResponse({
+    sessionId: "session-1",
+    modes: null,
+  });
+  const availableModes = deriveModesFromACP(GROK_MODES, transformed.modes).modes;
+
+  expect(
+    isDefaultAgentCreateConfigUnattended({
+      modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      availableModes,
+      config: {
+        provider: "acp",
+        cwd: "/tmp",
+        modeId: GROK_ALWAYS_APPROVE_MODE_ID,
+      },
+      features: [],
+    }),
+  ).toBe(true);
+
+  expect(
+    isDefaultAgentCreateConfigUnattended({
+      modeId: GROK_ASK_MODE_ID,
+      availableModes,
+      config: {
+        provider: "acp",
+        cwd: "/tmp",
+        modeId: GROK_ASK_MODE_ID,
+      },
+      features: [],
+    }),
+  ).toBe(false);
+
+  // Unattended create needs the unattended mode id from availableModes.
+  const resolved = resolveDefaultAgentCreateConfig({
+    provider: "acp",
+    requestedMode: undefined,
+    unattended: true,
+    availableModes,
+    parent: null,
+    featureValues: undefined,
+  });
+  expect(resolved.modeId).toBe(GROK_ALWAYS_APPROVE_MODE_ID);
+});
+
 test("writeGrokProviderMode enables native always-approve via slash command", async () => {
-  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
-  const setSessionMode = vi.fn(async () => undefined);
-  const setSessionConfigOption = vi.fn(async () => ({ configOptions: [] }));
+  const recording = createRecordingGrokConnection();
 
   await expect(
     writeGrokProviderMode({
-      connection: { prompt, setSessionMode, setSessionConfigOption } as never,
+      connection: recording.connection as never,
       sessionId: "session-1",
       requestedModeId: GROK_ALWAYS_APPROVE_MODE_ID,
       currentModeId: GROK_ASK_MODE_ID,
@@ -128,20 +260,22 @@ test("writeGrokProviderMode enables native always-approve via slash command", as
     currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
   });
 
-  expect(prompt).toHaveBeenCalledWith({
-    sessionId: "session-1",
-    prompt: [{ type: "text", text: "/always-approve on" }],
-  });
-  expect(setSessionMode).not.toHaveBeenCalled();
-  expect(setSessionConfigOption).not.toHaveBeenCalled();
+  expect(recording.prompts).toEqual([
+    {
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "/always-approve on" }],
+    },
+  ]);
+  expect(recording.sessionModeCalls).toEqual([]);
+  expect(recording.configOptionCalls).toEqual([]);
 });
 
 test("writeGrokProviderMode disables native always-approve when switching to Ask", async () => {
-  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+  const recording = createRecordingGrokConnection();
 
   await expect(
     writeGrokProviderMode({
-      connection: { prompt } as never,
+      connection: recording.connection as never,
       sessionId: "session-1",
       requestedModeId: GROK_ASK_MODE_ID,
       currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
@@ -159,18 +293,20 @@ test("writeGrokProviderMode disables native always-approve when switching to Ask
     currentModeId: GROK_ASK_MODE_ID,
   });
 
-  expect(prompt).toHaveBeenCalledWith({
-    sessionId: "session-1",
-    prompt: [{ type: "text", text: "/always-approve off" }],
-  });
+  expect(recording.prompts).toEqual([
+    {
+      sessionId: "session-1",
+      prompt: [{ type: "text", text: "/always-approve off" }],
+    },
+  ]);
 });
 
 test("writeGrokProviderMode does not re-prompt when already in the requested mode", async () => {
-  const prompt = vi.fn(async () => ({ stopReason: "end_turn" }));
+  const recording = createRecordingGrokConnection();
 
   await expect(
     writeGrokProviderMode({
-      connection: { prompt } as never,
+      connection: recording.connection as never,
       sessionId: "session-1",
       requestedModeId: GROK_ALWAYS_APPROVE_MODE_ID,
       currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
@@ -188,7 +324,7 @@ test("writeGrokProviderMode does not re-prompt when already in the requested mod
     currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
   });
 
-  expect(prompt).not.toHaveBeenCalled();
+  expect(recording.prompts).toEqual([]);
 });
 
 test("writeGrokProviderMode leaves unknown ACP modes to the generic path", async () => {

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -552,6 +552,24 @@ function collectTimelineItems(session: ACPAgentSession): AgentTimelineItem[] {
   return items;
 }
 
+/**
+ * ACP accumulates user_message_chunk into pendingUserMessage and only emits on
+ * a later non-user update (flushPendingUserMessage). Empty agent_message_chunk
+ * flushes without adding an assistant bubble — same pattern as acp-agent tests.
+ */
+async function flushPendingUserMessages(
+  session: ACPAgentSession,
+  sessionId = "session-1",
+): Promise<void> {
+  await session.sessionUpdate({
+    sessionId,
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "" },
+    },
+  });
+}
+
 function hiddenUserChunk(
   text: string,
   messageId?: string | null,
@@ -584,10 +602,16 @@ test("live Grok session suppresses hideFromScrollback user chunks", async () => 
       messageId: "msg-visible",
     },
   });
+  // Deferred assembly: visible text is pending until a non-user update flushes.
+  expect(items).toEqual([]);
+  await flushPendingUserMessages(session);
 
   expect(items).toEqual([
     { type: "user_message", text: "real user prompt", messageId: "msg-visible" },
   ]);
+  expect(items.every((item) => !("text" in item && item.text.includes("system-reminder")))).toBe(
+    true,
+  );
 });
 
 test("history replay also suppresses hideFromScrollback user chunks", async () => {
@@ -612,10 +636,18 @@ test("history replay also suppresses hideFromScrollback user chunks", async () =
       messageId: "msg-load",
     },
   });
+  expect(internals.persistedHistory).toEqual([]);
+  // loadSession ends with flushPendingUserMessage; mirror that boundary here.
+  await flushPendingUserMessages(session);
 
   expect(internals.persistedHistory).toEqual([
     { type: "user_message", text: "visible during load", messageId: "msg-load" },
   ]);
+  expect(
+    internals.persistedHistory.every(
+      (item) => !("text" in item && item.text.includes("system-reminder")),
+    ),
+  ).toBe(true);
 });
 
 test("hidden chunk without messageId does not contaminate a later visible user message", async () => {
@@ -641,11 +673,12 @@ test("hidden chunk without messageId does not contaminate a later visible user m
       content: { type: "text", text: " second" },
     },
   });
+  expect(items).toEqual([]);
+  await flushPendingUserMessages(session);
 
-  // User chunks emit accumulated text per chunk; the hidden wake-up must never
-  // enter messageAssemblies for the shared no-messageId key.
+  // Contiguous ID-less chunks coalesce into one pending message; the hidden
+  // wake-up must never join that assembly (suppress runs before pending).
   expect(items.map((item) => ("text" in item ? item.text : null))).toEqual([
-    "first visible",
     "first visible second",
   ]);
   expect(items.every((item) => !("text" in item && item.text.includes("system-reminder")))).toBe(
@@ -662,12 +695,98 @@ test("generic ACP provider still renders hideFromScrollback chunks as user messa
     sessionId: "session-1",
     update: hiddenUserChunk("<system-reminder>would be hidden only for Grok</system-reminder>"),
   });
+  expect(items).toEqual([]);
+  await flushPendingUserMessages(session);
 
   expect(items).toEqual([
     {
       type: "user_message",
       text: "<system-reminder>would be hidden only for Grok</system-reminder>",
     },
+  ]);
+});
+
+test("Grok hidden-only user chunks stay off the timeline after flush", async () => {
+  const session = createGrokBackgroundTaskSession();
+  const items = collectTimelineItems(session);
+  asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: hiddenUserChunk("<system-reminder>only hidden</system-reminder>", "msg-only-hidden"),
+  });
+  await flushPendingUserMessages(session);
+
+  expect(items).toEqual([]);
+});
+
+test("Grok suppress does not contaminate a later pending message with a different id", async () => {
+  const session = createGrokBackgroundTaskSession();
+  const items = collectTimelineItems(session);
+  asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "user_message_chunk",
+      content: { type: "text", text: "first" },
+      messageId: "msg-a",
+    },
+  });
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: hiddenUserChunk("<system-reminder>interleaved</system-reminder>", "msg-hidden"),
+  });
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "user_message_chunk",
+      content: { type: "text", text: "second" },
+      messageId: "msg-b",
+    },
+  });
+  // Different messageId flushes the previous pending message immediately.
+  expect(items).toEqual([{ type: "user_message", text: "first", messageId: "msg-a" }]);
+  await flushPendingUserMessages(session);
+  expect(items).toEqual([
+    { type: "user_message", text: "first", messageId: "msg-a" },
+    { type: "user_message", text: "second", messageId: "msg-b" },
+  ]);
+  expect(items.every((item) => !("text" in item && item.text.includes("system-reminder")))).toBe(
+    true,
+  );
+});
+
+test("Grok flushes pending user message on a later assistant chunk", async () => {
+  const session = createGrokBackgroundTaskSession();
+  const items = collectTimelineItems(session);
+  asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: hiddenUserChunk("<system-reminder>wake</system-reminder>", "msg-hidden"),
+  });
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "user_message_chunk",
+      content: { type: "text", text: "ask something" },
+      messageId: "msg-user",
+    },
+  });
+  expect(items).toEqual([]);
+  await session.sessionUpdate({
+    sessionId: "session-1",
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      messageId: "msg-assistant",
+      content: { type: "text", text: "reply" },
+    },
+  });
+
+  expect(items).toEqual([
+    { type: "user_message", text: "ask something", messageId: "msg-user" },
+    { type: "assistant_message", text: "reply", messageId: "msg-assistant" },
   ]);
 });
 

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,0 +1,199 @@
+import type { Logger } from "pino";
+
+import type { AgentMode, AgentSessionConfig } from "../agent-sdk-types.js";
+import {
+  type ACPProviderModeWriteResult,
+  type ACPProviderModeWriterContext,
+  type SessionStateResponse,
+} from "./acp-agent.js";
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+/** Ask before tool executions — Grok's interactive default (`permission_mode = "ask"`). */
+export const GROK_ASK_MODE_ID = "ask";
+
+/**
+ * Grok's native unattended permission mode.
+ * Matches CLI `--always-approve` / `--yolo` and config `permission_mode = "always-approve"`.
+ * Grok does not advertise this as an ACP session mode; Paseo maps it onto the native
+ * launch flag and the `/always-approve on|off` available command.
+ */
+export const GROK_ALWAYS_APPROVE_MODE_ID = "always-approve";
+
+const GROK_ALWAYS_APPROVE_LAUNCH_FLAGS = new Set(["--always-approve", "--yolo"]);
+
+export const GROK_MODES: AgentMode[] = [
+  {
+    id: GROK_ASK_MODE_ID,
+    label: "Ask",
+    description: "Prompt before shell and tool executions",
+  },
+  {
+    id: GROK_ALWAYS_APPROVE_MODE_ID,
+    label: "Always Approve",
+    description:
+      "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
+    isUnattended: true,
+  },
+];
+
+interface GrokACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+/**
+ * Grok is installed from the ACP catalog as `grok agent stdio`. Grok's permission
+ * modes are not ACP session modes — they are process/session settings controlled by:
+ *   - `grok agent --always-approve stdio` (session launch)
+ *   - `/always-approve on|off` (in-session available command)
+ *   - `~/.grok/config.toml` `[ui] permission_mode` (user global; not used here)
+ *
+ * Paseo surfaces Ask / Always Approve in the mode picker, drives Grok through those
+ * native paths, and keeps a client-side auto-approve fallback if Grok still emits
+ * `session/request_permission` while Always Approve is selected.
+ */
+export class GrokACPAgentClient extends GenericACPAgentClient {
+  constructor(options: GrokACPAgentClientOptions) {
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId ?? "grok",
+      label: options.label ?? "Grok",
+      providerParams: options.providerParams,
+      defaultModes: GROK_MODES,
+      sessionResponseTransformer: transformGrokSessionResponse,
+      resolveSessionCommand: resolveGrokSessionCommand,
+      providerModeWriter: writeGrokProviderMode,
+      // Fallback only: when Grok is correctly in always-approve it does not call
+      // session/request_permission. This covers races / older Grok builds.
+      autoApproveModeIds: [GROK_ALWAYS_APPROVE_MODE_ID],
+    });
+  }
+}
+
+/**
+ * Inject or strip Grok's native `--always-approve` launch flag.
+ * Catalog command is `["grok", "agent", "stdio"]` → `["grok", "agent", "--always-approve", "stdio"]`.
+ */
+export function withGrokAlwaysApproveLaunchFlag(
+  command: [string, ...string[]],
+  enabled: boolean,
+): [string, ...string[]] {
+  const [binary, ...args] = command;
+  const withoutFlags = args.filter((arg) => !GROK_ALWAYS_APPROVE_LAUNCH_FLAGS.has(arg));
+  if (!enabled) {
+    return withoutFlags.length > 0
+      ? ([binary, ...withoutFlags] as [string, ...string[]])
+      : [binary];
+  }
+
+  const agentIndex = withoutFlags.indexOf("agent");
+  if (agentIndex >= 0) {
+    const next = [...withoutFlags];
+    next.splice(agentIndex + 1, 0, "--always-approve");
+    return [binary, ...next] as [string, ...string[]];
+  }
+
+  const stdioIndex = withoutFlags.lastIndexOf("stdio");
+  if (stdioIndex >= 0) {
+    const next = [...withoutFlags];
+    next.splice(stdioIndex, 0, "--always-approve");
+    return [binary, ...next] as [string, ...string[]];
+  }
+
+  return [binary, "--always-approve", ...withoutFlags] as [string, ...string[]];
+}
+
+export function resolveGrokSessionCommand(
+  command: [string, ...string[]],
+  config: AgentSessionConfig,
+): [string, ...string[]] {
+  return withGrokAlwaysApproveLaunchFlag(command, config.modeId === GROK_ALWAYS_APPROVE_MODE_ID);
+}
+
+function isGrokPermissionModeId(modeId: string | null | undefined): modeId is string {
+  return modeId === GROK_ASK_MODE_ID || modeId === GROK_ALWAYS_APPROVE_MODE_ID;
+}
+
+export function transformGrokSessionResponse(
+  response: SessionStateResponse,
+  sessionConfig?: AgentSessionConfig,
+): SessionStateResponse {
+  const upstreamModes = response.modes?.availableModes ?? [];
+  const upstreamIds = new Set(upstreamModes.map((mode) => mode.id));
+  const syntheticModes = GROK_MODES.filter((mode) => !upstreamIds.has(mode.id)).map((mode) => ({
+    id: mode.id,
+    name: mode.label,
+    description: mode.description ?? null,
+  }));
+  const preferredModeId = isGrokPermissionModeId(sessionConfig?.modeId)
+    ? sessionConfig.modeId
+    : GROK_ASK_MODE_ID;
+
+  if (upstreamModes.length === 0) {
+    return {
+      ...response,
+      modes: {
+        availableModes: GROK_MODES.map((mode) => ({
+          id: mode.id,
+          name: mode.label,
+          description: mode.description ?? null,
+        })),
+        // Prefer the session's configured Paseo mode so Always Approve at create
+        // time is not rewritten to Ask before applyConfiguredOverrides.
+        currentModeId: response.modes?.currentModeId ?? preferredModeId,
+      },
+    };
+  }
+
+  return {
+    ...response,
+    modes: {
+      ...response.modes,
+      availableModes: [...upstreamModes, ...syntheticModes],
+      // SessionModeState.currentModeId is a required string in the ACP schema.
+      currentModeId: response.modes?.currentModeId ?? upstreamModes[0]?.id ?? preferredModeId,
+    },
+  };
+}
+
+/**
+ * Drive Grok's native in-session permission toggle via the documented
+ * `/always-approve on|off` available command (not ACP setSessionMode).
+ */
+export async function writeGrokProviderMode(
+  context: ACPProviderModeWriterContext,
+): Promise<ACPProviderModeWriteResult> {
+  if (context.requestedModeId === GROK_ALWAYS_APPROVE_MODE_ID) {
+    if (context.currentModeId !== GROK_ALWAYS_APPROVE_MODE_ID) {
+      await context.connection.prompt({
+        sessionId: context.sessionId,
+        prompt: [{ type: "text", text: "/always-approve on" }],
+      });
+    }
+    return {
+      handled: true,
+      currentModeId: GROK_ALWAYS_APPROVE_MODE_ID,
+    };
+  }
+
+  if (context.requestedModeId === GROK_ASK_MODE_ID) {
+    if (context.currentModeId === GROK_ALWAYS_APPROVE_MODE_ID) {
+      await context.connection.prompt({
+        sessionId: context.sessionId,
+        prompt: [{ type: "text", text: "/always-approve off" }],
+      });
+    }
+    return {
+      handled: true,
+      currentModeId: GROK_ASK_MODE_ID,
+    };
+  }
+
+  return { handled: false };
+}

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -21,17 +21,26 @@ export const GROK_ALWAYS_APPROVE_MODE_ID = "always-approve";
 
 const GROK_ALWAYS_APPROVE_LAUNCH_FLAGS = new Set(["--always-approve", "--yolo"]);
 
+/**
+ * Single source of truth for Grok session + provider-definition modes.
+ * Keep icon/colorTier/isUnattended here so registry definition and runtime
+ * availableModes stay aligned after ACP mode derivation.
+ */
 export const GROK_MODES: AgentMode[] = [
   {
     id: GROK_ASK_MODE_ID,
     label: "Ask",
     description: "Prompt before shell and tool executions",
+    icon: "ShieldCheck",
+    colorTier: "safe",
   },
   {
     id: GROK_ALWAYS_APPROVE_MODE_ID,
     label: "Always Approve",
     description:
       "Auto-approve all tool executions for this session via Grok's native always-approve mode. Allows potentially destructive shell commands and file operations.",
+    icon: "ShieldOff",
+    colorTier: "dangerous",
     isUnattended: true,
   },
 ];

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -208,11 +208,20 @@ export async function writeGrokProviderMode(
         sessionId: context.sessionId,
         prompt: [{ type: "text", text: "/always-approve off" }],
       });
+      return {
+        handled: true,
+        currentModeId: GROK_ASK_MODE_ID,
+      };
     }
-    return {
-      handled: true,
-      currentModeId: GROK_ASK_MODE_ID,
-    };
+    if (context.currentModeId === GROK_ASK_MODE_ID) {
+      return {
+        handled: true,
+        currentModeId: GROK_ASK_MODE_ID,
+      };
+    }
+    // Leaving an upstream ACP mode (e.g. plan): do not claim handled so the
+    // generic setSessionMode path can switch Grok out of that mode.
+    return { handled: false };
   }
 
   return { handled: false };

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -8,6 +8,10 @@ import {
   type SessionStateResponse,
 } from "./acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
+import {
+  isGrokHiddenFromScrollbackUserChunk,
+  mapGrokExtensionNotificationToTimelineItems,
+} from "./grok-background-tasks.js";
 
 /** Ask before tool executions — Grok's interactive default (`permission_mode = "ask"`). */
 export const GROK_ASK_MODE_ID = "ask";
@@ -65,6 +69,10 @@ interface GrokACPAgentClientOptions {
  * Paseo surfaces Ask / Always Approve in the mode picker, drives Grok through those
  * native paths, and keeps a client-side auto-approve fallback if Grok still emits
  * `session/request_permission` while Always Approve is selected.
+ *
+ * Background-task UX (issue #2182): suppress model-only wake-up chunks marked
+ * `_meta.hideFromScrollback === true`, and map `_x.ai/session/update` task events
+ * to synthetic `tool_call` timeline items keyed by `task_id`.
  */
 export class GrokACPAgentClient extends GenericACPAgentClient {
   constructor(options: GrokACPAgentClientOptions) {
@@ -82,6 +90,8 @@ export class GrokACPAgentClient extends GenericACPAgentClient {
       // Fallback only: when Grok is correctly in always-approve it does not call
       // session/request_permission. This covers races / older Grok builds.
       autoApproveModeIds: [GROK_ALWAYS_APPROVE_MODE_ID],
+      shouldSuppressUserMessageChunk: isGrokHiddenFromScrollbackUserChunk,
+      extensionNotificationHandler: mapGrokExtensionNotificationToTimelineItems,
     });
   }
 }

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,6 +1,7 @@
 import type { Logger } from "pino";
+import type { AgentProviderModeDefinition } from "@getpaseo/protocol/provider-manifest";
 
-import type { AgentMode, AgentSessionConfig } from "../agent-sdk-types.js";
+import type { AgentSessionConfig } from "../agent-sdk-types.js";
 import {
   type ACPProviderModeWriteResult,
   type ACPProviderModeWriterContext,
@@ -23,10 +24,10 @@ const GROK_ALWAYS_APPROVE_LAUNCH_FLAGS = new Set(["--always-approve", "--yolo"])
 
 /**
  * Single source of truth for Grok session + provider-definition modes.
- * Keep icon/colorTier/isUnattended here so registry definition and runtime
- * availableModes stay aligned after ACP mode derivation.
+ * Typed as AgentProviderModeDefinition so registry.modes (required icon/colorTier)
+ * and session defaultModes stay one list.
  */
-export const GROK_MODES: AgentMode[] = [
+export const GROK_MODES: AgentProviderModeDefinition[] = [
   {
     id: GROK_ASK_MODE_ID,
     label: "Ask",

--- a/packages/server/src/server/agent/providers/grok-background-tasks.test.ts
+++ b/packages/server/src/server/agent/providers/grok-background-tasks.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from "vitest";
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+
+import {
+  GROK_SESSION_UPDATE_METHOD,
+  buildGrokBackgroundTaskCallId,
+  isGrokHiddenFromScrollbackUserChunk,
+  mapGrokExtensionNotificationToTimelineItems,
+} from "./grok-background-tasks.js";
+
+function userChunk(
+  text: string,
+  options: { messageId?: string | null; hideFromScrollback?: boolean } = {},
+): Extract<SessionUpdate, { sessionUpdate: "user_message_chunk" }> {
+  let meta: { hideFromScrollback: boolean; modelId?: string } | undefined;
+  if (options.hideFromScrollback === true) {
+    meta = { hideFromScrollback: true, modelId: "grok-4.5" };
+  } else if (options.hideFromScrollback === false) {
+    meta = { hideFromScrollback: false };
+  }
+
+  return {
+    sessionUpdate: "user_message_chunk",
+    content: { type: "text", text },
+    ...(options.messageId !== undefined ? { messageId: options.messageId } : {}),
+    ...(meta ? { _meta: meta } : {}),
+  };
+}
+
+function taskParams(input: {
+  sessionId?: string;
+  sessionUpdate: "task_backgrounded" | "task_completed";
+  taskId?: string;
+  command?: string;
+  cwd?: string;
+  output?: string | null;
+  truncated?: boolean;
+  exitCode?: number | null;
+  signal?: string | null;
+  kind?: string;
+}): Record<string, unknown> {
+  return {
+    ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+    update: {
+      sessionUpdate: input.sessionUpdate,
+      task_snapshot: {
+        task_id: input.taskId ?? "task-1",
+        command: input.command ?? "sleep 1",
+        cwd: input.cwd ?? "/tmp",
+        output: input.output === undefined ? "done" : input.output,
+        truncated: input.truncated ?? false,
+        exit_code: input.exitCode === undefined ? 0 : input.exitCode,
+        signal: input.signal === undefined ? null : input.signal,
+        completed: input.sessionUpdate === "task_completed",
+        kind: input.kind ?? "bash",
+      },
+      will_wake: true,
+    },
+  };
+}
+
+describe("isGrokHiddenFromScrollbackUserChunk", () => {
+  test("suppresses only when hideFromScrollback is strictly true", () => {
+    expect(
+      isGrokHiddenFromScrollbackUserChunk(
+        userChunk("<system-reminder>Background task completed</system-reminder>", {
+          hideFromScrollback: true,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isGrokHiddenFromScrollbackUserChunk(
+        userChunk("hello", { hideFromScrollback: false, messageId: "msg-1" }),
+      ),
+    ).toBe(false);
+    expect(isGrokHiddenFromScrollbackUserChunk(userChunk("hello", { messageId: "msg-1" }))).toBe(
+      false,
+    );
+  });
+
+  test("does not use system-reminder text as a global filter signal", () => {
+    expect(
+      isGrokHiddenFromScrollbackUserChunk(
+        userChunk("<system-reminder>not a real hidden chunk</system-reminder>"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("mapGrokExtensionNotificationToTimelineItems", () => {
+  test("returns null for unrelated extension methods", () => {
+    expect(
+      mapGrokExtensionNotificationToTimelineItems(
+        "_other.vendor/update",
+        taskParams({ sessionUpdate: "task_completed" }),
+        { sessionId: "session-1" },
+      ),
+    ).toBeNull();
+  });
+
+  test("ignores wrong-session notifications without throwing", () => {
+    expect(
+      mapGrokExtensionNotificationToTimelineItems(
+        GROK_SESSION_UPDATE_METHOD,
+        taskParams({ sessionId: "other", sessionUpdate: "task_completed" }),
+        { sessionId: "session-1" },
+      ),
+    ).toEqual([]);
+  });
+
+  test("ignores malformed payloads without throwing", () => {
+    expect(
+      mapGrokExtensionNotificationToTimelineItems(
+        GROK_SESSION_UPDATE_METHOD,
+        { sessionId: "session-1", update: { sessionUpdate: "task_completed" } },
+        { sessionId: "session-1" },
+      ),
+    ).toEqual([]);
+    expect(
+      mapGrokExtensionNotificationToTimelineItems(
+        GROK_SESSION_UPDATE_METHOD,
+        { sessionId: "session-1", update: "not-an-object" },
+        { sessionId: "session-1" },
+      ),
+    ).toEqual([]);
+  });
+
+  test("maps task_backgrounded to a running synthetic tool_call", () => {
+    const items = mapGrokExtensionNotificationToTimelineItems(
+      GROK_SESSION_UPDATE_METHOD,
+      taskParams({
+        sessionId: "session-1",
+        sessionUpdate: "task_backgrounded",
+        taskId: "abc-123",
+        command: "npm test",
+      }),
+      { sessionId: "session-1" },
+    );
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        type: "tool_call",
+        callId: buildGrokBackgroundTaskCallId("abc-123"),
+        name: "background_task",
+        status: "running",
+        error: null,
+        detail: expect.objectContaining({
+          type: "plain_text",
+          icon: "wrench",
+          label: "Background: npm test",
+        }),
+        metadata: expect.objectContaining({
+          synthetic: true,
+          source: "grok_background_task",
+          taskId: "abc-123",
+          sessionUpdate: "task_backgrounded",
+        }),
+      }),
+    ]);
+  });
+
+  test("maps successful task_completed to completed status", () => {
+    const items = mapGrokExtensionNotificationToTimelineItems(
+      GROK_SESSION_UPDATE_METHOD,
+      taskParams({
+        sessionId: "session-1",
+        sessionUpdate: "task_completed",
+        taskId: "abc-123",
+        exitCode: 0,
+        output: "ok",
+      }),
+      { sessionId: "session-1" },
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items?.[0]).toMatchObject({
+      type: "tool_call",
+      callId: buildGrokBackgroundTaskCallId("abc-123"),
+      status: "completed",
+      error: null,
+    });
+  });
+
+  test("maps non-zero exit to failed", () => {
+    const items = mapGrokExtensionNotificationToTimelineItems(
+      GROK_SESSION_UPDATE_METHOD,
+      taskParams({
+        sessionId: "session-1",
+        sessionUpdate: "task_completed",
+        taskId: "fail-1",
+        exitCode: 2,
+        output: "boom",
+      }),
+      { sessionId: "session-1" },
+    );
+
+    expect(items?.[0]).toMatchObject({
+      status: "failed",
+      error: { message: "Background task exited with code 2" },
+    });
+  });
+
+  test("maps signal/cancellation to canceled", () => {
+    const items = mapGrokExtensionNotificationToTimelineItems(
+      GROK_SESSION_UPDATE_METHOD,
+      taskParams({
+        sessionId: "session-1",
+        sessionUpdate: "task_completed",
+        taskId: "sig-1",
+        exitCode: null,
+        signal: "SIGTERM",
+        output: null,
+      }),
+      { sessionId: "session-1" },
+    );
+
+    expect(items?.[0]).toMatchObject({
+      status: "canceled",
+      error: null,
+      detail: expect.objectContaining({
+        text: expect.stringContaining("Signal: SIGTERM"),
+      }),
+    });
+  });
+
+  test("handles missing output and truncated output", () => {
+    const missing = mapGrokExtensionNotificationToTimelineItems(
+      GROK_SESSION_UPDATE_METHOD,
+      taskParams({
+        sessionId: "session-1",
+        sessionUpdate: "task_completed",
+        taskId: "out-1",
+        output: null,
+      }),
+      { sessionId: "session-1" },
+    );
+    expect(missing?.[0]).toMatchObject({
+      status: "completed",
+      detail: expect.objectContaining({
+        text: expect.stringContaining("(no output)"),
+      }),
+    });
+
+    const truncated = mapGrokExtensionNotificationToTimelineItems(
+      GROK_SESSION_UPDATE_METHOD,
+      taskParams({
+        sessionId: "session-1",
+        sessionUpdate: "task_completed",
+        taskId: "out-2",
+        output: "partial",
+        truncated: true,
+      }),
+      { sessionId: "session-1" },
+    );
+    expect(truncated?.[0]).toMatchObject({
+      detail: expect.objectContaining({
+        text: expect.stringContaining("Output truncated"),
+      }),
+      metadata: expect.objectContaining({ truncated: true }),
+    });
+  });
+
+  test("uses a stable callId from task_id for lifecycle projection", () => {
+    const backgrounded = mapGrokExtensionNotificationToTimelineItems(
+      GROK_SESSION_UPDATE_METHOD,
+      taskParams({
+        sessionId: "session-1",
+        sessionUpdate: "task_backgrounded",
+        taskId: "stable-id",
+      }),
+      { sessionId: "session-1" },
+    );
+    const completed = mapGrokExtensionNotificationToTimelineItems(
+      GROK_SESSION_UPDATE_METHOD,
+      taskParams({
+        sessionId: "session-1",
+        sessionUpdate: "task_completed",
+        taskId: "stable-id",
+      }),
+      { sessionId: "session-1" },
+    );
+
+    expect(backgrounded?.[0]).toMatchObject({
+      callId: buildGrokBackgroundTaskCallId("stable-id"),
+      status: "running",
+    });
+    expect(completed?.[0]).toMatchObject({
+      callId: buildGrokBackgroundTaskCallId("stable-id"),
+      status: "completed",
+    });
+  });
+});

--- a/packages/server/src/server/agent/providers/grok-background-tasks.test.ts
+++ b/packages/server/src/server/agent/providers/grok-background-tasks.test.ts
@@ -289,4 +289,11 @@ describe("mapGrokExtensionNotificationToTimelineItems", () => {
       status: "completed",
     });
   });
+
+  test("callIds for task IDs that only differ by normalized characters do not collide", () => {
+    expect(buildGrokBackgroundTaskCallId("task/1")).not.toBe(
+      buildGrokBackgroundTaskCallId("task_1"),
+    );
+    expect(buildGrokBackgroundTaskCallId("task/1")).toBe(buildGrokBackgroundTaskCallId("task/1"));
+  });
 });

--- a/packages/server/src/server/agent/providers/grok-background-tasks.ts
+++ b/packages/server/src/server/agent/providers/grok-background-tasks.ts
@@ -1,7 +1,9 @@
+import { createHash } from "node:crypto";
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import { z } from "zod";
 
 import type { AgentTimelineItem, ToolCallTimelineItem } from "../agent-sdk-types.js";
-import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import type { ACPExtensionNotificationContext } from "./acp-agent.js";
 
 /** Grok vendor extension method for structured session/task updates. */
 export const GROK_SESSION_UPDATE_METHOD = "_x.ai/session/update";
@@ -46,10 +48,6 @@ const GrokExtensionNotificationParamsSchema = z
 export type GrokTaskSnapshot = z.infer<typeof GrokTaskSnapshotSchema>;
 export type GrokSessionUpdate = z.infer<typeof GrokSessionUpdateSchema>;
 
-export interface GrokExtensionNotificationContext {
-  sessionId: string | null;
-}
-
 /**
  * True when a Grok user_message_chunk is model-only and must not enter scrollback.
  * Check happens before message assembly so a hidden chunk without messageId cannot
@@ -75,7 +73,7 @@ export function isGrokHiddenFromScrollbackUserChunk(
 export function mapGrokExtensionNotificationToTimelineItems(
   method: string,
   params: Record<string, unknown>,
-  context: GrokExtensionNotificationContext,
+  context: ACPExtensionNotificationContext,
 ): AgentTimelineItem[] | null {
   if (method !== GROK_SESSION_UPDATE_METHOD) {
     return null;
@@ -97,9 +95,13 @@ export function mapGrokExtensionNotificationToTimelineItems(
   return [toGrokBackgroundTaskToolCall(parsed.data.update)];
 }
 
+/**
+ * Stable call ID from the raw task_id. Hash the original string so IDs that only
+ * differ by normalized characters (e.g. `task/1` vs `task_1`) never collide.
+ */
 export function buildGrokBackgroundTaskCallId(taskId: string): string {
-  const normalized = taskId.trim().replace(/[^a-zA-Z0-9._:-]+/g, "_");
-  return `grok_task_${normalized.length > 0 ? normalized : "unknown"}`;
+  const digest = createHash("sha1").update(taskId.trim()).digest("hex").slice(0, 16);
+  return `grok_task_${digest}`;
 }
 
 function toGrokBackgroundTaskToolCall(update: GrokSessionUpdate): ToolCallTimelineItem {
@@ -107,30 +109,26 @@ function toGrokBackgroundTaskToolCall(update: GrokSessionUpdate): ToolCallTimeli
   const callId = buildGrokBackgroundTaskCallId(snapshot.task_id);
   const detailText = buildGrokTaskDetailText(snapshot);
   const label = buildGrokTaskLabel(update.sessionUpdate, snapshot);
+  const detail =
+    detailText === undefined
+      ? {
+          type: "plain_text" as const,
+          label,
+          icon: "wrench" as const,
+        }
+      : {
+          type: "plain_text" as const,
+          label,
+          icon: "wrench" as const,
+          text: detailText,
+        };
+  const metadata = buildGrokTaskMetadata(snapshot, update.sessionUpdate);
   const base = {
     type: "tool_call" as const,
     callId,
     name: "background_task",
-    detail: {
-      type: "plain_text" as const,
-      label,
-      icon: "wrench" as const,
-      ...(detailText ? { text: detailText } : {}),
-    },
-    metadata: {
-      synthetic: true,
-      source: "grok_background_task",
-      taskId: snapshot.task_id,
-      sessionUpdate: update.sessionUpdate,
-      ...(snapshot.kind ? { kind: snapshot.kind } : {}),
-      ...(snapshot.command ? { command: snapshot.command } : {}),
-      ...(snapshot.cwd ? { cwd: snapshot.cwd } : {}),
-      ...(snapshot.exit_code !== undefined && snapshot.exit_code !== null
-        ? { exitCode: snapshot.exit_code }
-        : {}),
-      ...(snapshot.signal ? { signal: snapshot.signal } : {}),
-      ...(snapshot.truncated ? { truncated: true } : {}),
-    },
+    detail,
+    metadata,
   };
 
   if (update.sessionUpdate === "task_backgrounded") {
@@ -161,6 +159,37 @@ function toGrokBackgroundTaskToolCall(update: GrokSessionUpdate): ToolCallTimeli
     status: "completed",
     error: null,
   };
+}
+
+function buildGrokTaskMetadata(
+  snapshot: GrokTaskSnapshot,
+  sessionUpdate: GrokSessionUpdate["sessionUpdate"],
+): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {
+    synthetic: true,
+    source: "grok_background_task",
+    taskId: snapshot.task_id,
+    sessionUpdate,
+  };
+  if (snapshot.kind) {
+    metadata.kind = snapshot.kind;
+  }
+  if (snapshot.command) {
+    metadata.command = snapshot.command;
+  }
+  if (snapshot.cwd) {
+    metadata.cwd = snapshot.cwd;
+  }
+  if (snapshot.exit_code !== undefined && snapshot.exit_code !== null) {
+    metadata.exitCode = snapshot.exit_code;
+  }
+  if (snapshot.signal) {
+    metadata.signal = snapshot.signal;
+  }
+  if (snapshot.truncated) {
+    metadata.truncated = true;
+  }
+  return metadata;
 }
 
 function resolveGrokTaskCompletionLifecycle(

--- a/packages/server/src/server/agent/providers/grok-background-tasks.ts
+++ b/packages/server/src/server/agent/providers/grok-background-tasks.ts
@@ -1,0 +1,239 @@
+import { z } from "zod";
+
+import type { AgentTimelineItem, ToolCallTimelineItem } from "../agent-sdk-types.js";
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+
+/** Grok vendor extension method for structured session/task updates. */
+export const GROK_SESSION_UPDATE_METHOD = "_x.ai/session/update";
+
+const OptionalTrimmedStringSchema = z.preprocess((value) => {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}, z.string().min(1).optional());
+
+const GrokTaskSnapshotSchema = z
+  .object({
+    task_id: z.string().min(1),
+    command: OptionalTrimmedStringSchema,
+    cwd: OptionalTrimmedStringSchema,
+    output: z.string().optional().nullable(),
+    truncated: z.boolean().optional().nullable(),
+    exit_code: z.number().nullable().optional(),
+    signal: OptionalTrimmedStringSchema.nullable(),
+    completed: z.boolean().optional().nullable(),
+    kind: OptionalTrimmedStringSchema,
+  })
+  .passthrough();
+
+const GrokSessionUpdateSchema = z
+  .object({
+    sessionUpdate: z.enum(["task_backgrounded", "task_completed"]),
+    task_snapshot: GrokTaskSnapshotSchema,
+    will_wake: z.boolean().optional().nullable(),
+  })
+  .passthrough();
+
+const GrokExtensionNotificationParamsSchema = z
+  .object({
+    sessionId: z.string().optional(),
+    update: GrokSessionUpdateSchema,
+  })
+  .passthrough();
+
+export type GrokTaskSnapshot = z.infer<typeof GrokTaskSnapshotSchema>;
+export type GrokSessionUpdate = z.infer<typeof GrokSessionUpdateSchema>;
+
+export interface GrokExtensionNotificationContext {
+  sessionId: string | null;
+}
+
+/**
+ * True when a Grok user_message_chunk is model-only and must not enter scrollback.
+ * Check happens before message assembly so a hidden chunk without messageId cannot
+ * contaminate a later visible user message.
+ */
+export function isGrokHiddenFromScrollbackUserChunk(
+  update: Extract<SessionUpdate, { sessionUpdate: "user_message_chunk" }>,
+): boolean {
+  const meta = update._meta;
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
+    return false;
+  }
+  return meta.hideFromScrollback === true;
+}
+
+/**
+ * Map a Grok `_x.ai/session/update` notification into synthetic tool_call timeline
+ * items. Returns:
+ * - `null` when the method is not owned by this handler
+ * - `[]` when owned but ignored (wrong session, malformed payload)
+ * - one tool_call item for valid task_backgrounded / task_completed updates
+ */
+export function mapGrokExtensionNotificationToTimelineItems(
+  method: string,
+  params: Record<string, unknown>,
+  context: GrokExtensionNotificationContext,
+): AgentTimelineItem[] | null {
+  if (method !== GROK_SESSION_UPDATE_METHOD) {
+    return null;
+  }
+
+  const parsed = GrokExtensionNotificationParamsSchema.safeParse(params);
+  if (!parsed.success) {
+    return [];
+  }
+
+  if (
+    context.sessionId !== null &&
+    parsed.data.sessionId !== undefined &&
+    parsed.data.sessionId !== context.sessionId
+  ) {
+    return [];
+  }
+
+  return [toGrokBackgroundTaskToolCall(parsed.data.update)];
+}
+
+export function buildGrokBackgroundTaskCallId(taskId: string): string {
+  const normalized = taskId.trim().replace(/[^a-zA-Z0-9._:-]+/g, "_");
+  return `grok_task_${normalized.length > 0 ? normalized : "unknown"}`;
+}
+
+function toGrokBackgroundTaskToolCall(update: GrokSessionUpdate): ToolCallTimelineItem {
+  const snapshot = update.task_snapshot;
+  const callId = buildGrokBackgroundTaskCallId(snapshot.task_id);
+  const detailText = buildGrokTaskDetailText(snapshot);
+  const label = buildGrokTaskLabel(update.sessionUpdate, snapshot);
+  const base = {
+    type: "tool_call" as const,
+    callId,
+    name: "background_task",
+    detail: {
+      type: "plain_text" as const,
+      label,
+      icon: "wrench" as const,
+      ...(detailText ? { text: detailText } : {}),
+    },
+    metadata: {
+      synthetic: true,
+      source: "grok_background_task",
+      taskId: snapshot.task_id,
+      sessionUpdate: update.sessionUpdate,
+      ...(snapshot.kind ? { kind: snapshot.kind } : {}),
+      ...(snapshot.command ? { command: snapshot.command } : {}),
+      ...(snapshot.cwd ? { cwd: snapshot.cwd } : {}),
+      ...(snapshot.exit_code !== undefined && snapshot.exit_code !== null
+        ? { exitCode: snapshot.exit_code }
+        : {}),
+      ...(snapshot.signal ? { signal: snapshot.signal } : {}),
+      ...(snapshot.truncated ? { truncated: true } : {}),
+    },
+  };
+
+  if (update.sessionUpdate === "task_backgrounded") {
+    return {
+      ...base,
+      status: "running",
+      error: null,
+    };
+  }
+
+  const lifecycle = resolveGrokTaskCompletionLifecycle(snapshot);
+  if (lifecycle.status === "failed") {
+    return {
+      ...base,
+      status: "failed",
+      error: lifecycle.error,
+    };
+  }
+  if (lifecycle.status === "canceled") {
+    return {
+      ...base,
+      status: "canceled",
+      error: null,
+    };
+  }
+  return {
+    ...base,
+    status: "completed",
+    error: null,
+  };
+}
+
+function resolveGrokTaskCompletionLifecycle(
+  snapshot: GrokTaskSnapshot,
+):
+  | { status: "completed" }
+  | { status: "failed"; error: { message: string } }
+  | { status: "canceled" } {
+  if (snapshot.signal) {
+    return { status: "canceled" };
+  }
+  if (typeof snapshot.exit_code === "number" && snapshot.exit_code !== 0) {
+    return {
+      status: "failed",
+      error: {
+        message: `Background task exited with code ${snapshot.exit_code}`,
+      },
+    };
+  }
+  return { status: "completed" };
+}
+
+function buildGrokTaskLabel(
+  sessionUpdate: GrokSessionUpdate["sessionUpdate"],
+  snapshot: GrokTaskSnapshot,
+): string {
+  if (sessionUpdate === "task_backgrounded") {
+    return snapshot.command ? `Background: ${truncateLabel(snapshot.command)}` : "Background task";
+  }
+  if (snapshot.signal) {
+    return snapshot.command
+      ? `Cancelled: ${truncateLabel(snapshot.command)}`
+      : "Background task cancelled";
+  }
+  if (typeof snapshot.exit_code === "number" && snapshot.exit_code !== 0) {
+    return snapshot.command
+      ? `Failed: ${truncateLabel(snapshot.command)}`
+      : "Background task failed";
+  }
+  return snapshot.command
+    ? `Completed: ${truncateLabel(snapshot.command)}`
+    : "Background task completed";
+}
+
+function buildGrokTaskDetailText(snapshot: GrokTaskSnapshot): string | undefined {
+  const lines: string[] = [];
+  if (snapshot.command) {
+    lines.push(`Command: ${snapshot.command}`);
+  }
+  if (snapshot.cwd) {
+    lines.push(`Cwd: ${snapshot.cwd}`);
+  }
+  if (typeof snapshot.exit_code === "number") {
+    lines.push(`Exit code: ${snapshot.exit_code}`);
+  }
+  if (snapshot.signal) {
+    lines.push(`Signal: ${snapshot.signal}`);
+  }
+  if (snapshot.truncated) {
+    lines.push("Output truncated");
+  }
+  if (typeof snapshot.output === "string" && snapshot.output.length > 0) {
+    lines.push(snapshot.output);
+  } else if (snapshot.output === null || snapshot.output === "") {
+    lines.push("(no output)");
+  }
+  return lines.length > 0 ? lines.join("\n") : undefined;
+}
+
+function truncateLabel(value: string, maxLength = 80): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, maxLength - 1)}…`;
+}


### PR DESCRIPTION
## Summary

- Suppress Grok ACP `user_message_chunk` updates when `_meta.hideFromScrollback === true` (live stream and history replay), before message assembly so hidden chunks without `messageId` cannot contaminate later visible user messages.
- Add narrow shared ACP hooks (`shouldSuppressUserMessageChunk`, `extensionNotificationHandler`) and route extension-driven timeline items through the same live-vs-history delivery path.
- Parse Grok `_x.ai/session/update` `task_backgrounded` / `task_completed` at the adapter boundary and map them to synthetic `tool_call` items with a stable `callId` derived from `task_id` (completed / failed / canceled / missing output / truncated).
- Keep Grok-specific logic in `GrokACPAgentClient` + `grok-background-tasks.ts`; do not introduce a global `<system-reminder>` text filter.
- Update `docs/providers.md` for the Grok adapter and hook architecture.

Fixes #2182

## Dependency

**Depends on #2177** (Grok ACP adapter / Always Approve). This branch is stacked on the latest `#2177` head (`feat/2053-grok-always-approve-mode`). Merge #2177 first, then rebase this PR onto `main` if needed.

## Test plan

- [x] `npx vitest run packages/server/src/server/agent/providers/grok-background-tasks.test.ts packages/server/src/server/agent/providers/grok-acp-agent.test.ts --bail=1` (34 passed)
- [x] `npm run typecheck --workspace=@getpaseo/server`
- [x] lint/format on touched files
- [ ] Manual: Grok session with background shell task → no raw `<system-reminder>` user bubble; compact task/tool item for backgrounded → completed
- [ ] Manual: non-zero exit / cancelled task / truncated output render distinct tool states
- [ ] Manual: non-Grok ACP providers still show normal user chunks (including any `_meta` they may send)