### PR TITLE
Make next-turn setting changes harder to miss

### DIFF
--- a/packages/app/src/components/toast-host.tsx
+++ b/packages/app/src/components/toast-host.tsx
@@ -6,7 +6,7 @@ import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { useTranslation } from "react-i18next";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { isWeb } from "@/constants/platform";
-import { AlertTriangle, CheckCircle2 } from "lucide-react-native";
+import { AlertTriangle, CheckCircle2, Info } from "lucide-react-native";
 import { getOverlayRoot, OVERLAY_Z } from "@/lib/overlay-root";
 import {
   HEADER_INNER_HEIGHT,
@@ -14,7 +14,7 @@ import {
   HEADER_TOP_PADDING_MOBILE,
 } from "@/constants/layout";
 
-export type ToastVariant = "default" | "success" | "error";
+export type ToastVariant = "default" | "info" | "success" | "warning" | "error";
 
 export interface ToastShowOptions {
   icon?: ReactNode;
@@ -230,7 +230,9 @@ export function ToastViewport({
   const toastAnimatedStyle = useMemo(
     () => [
       styles.toast,
+      toastVariant === "info" ? styles.toastInfo : null,
       toastVariant === "success" ? styles.toastSuccess : null,
+      toastVariant === "warning" ? styles.toastWarning : null,
       toastVariant === "error" ? styles.toastError : null,
       {
         marginTop: topOffset,
@@ -250,8 +252,12 @@ export function ToastViewport({
   }
 
   let defaultIcon: ReactNode = null;
-  if (toast.variant === "success") {
+  if (toast.variant === "info") {
+    defaultIcon = <Info size={18} color={theme.colors.palette.blue[300]} />;
+  } else if (toast.variant === "success") {
     defaultIcon = <CheckCircle2 size={18} color={theme.colors.primary} />;
+  } else if (toast.variant === "warning") {
+    defaultIcon = <AlertTriangle size={18} color={theme.colors.palette.amber[500]} />;
   } else if (toast.variant === "error") {
     defaultIcon = <AlertTriangle size={18} color={theme.colors.destructive} />;
   }
@@ -312,6 +318,12 @@ const styles = StyleSheet.create((theme) => ({
   },
   toastSuccess: {
     borderColor: theme.colors.border,
+  },
+  toastInfo: {
+    borderColor: theme.colors.palette.blue[300],
+  },
+  toastWarning: {
+    borderColor: theme.colors.palette.amber[500],
   },
   toastError: {
     borderColor: theme.colors.destructive,

--- a/packages/app/src/utils/provider-notice-toast.ts
+++ b/packages/app/src/utils/provider-notice-toast.ts
@@ -13,7 +13,7 @@ export function showProviderNoticeToast(
     return;
   }
   toast.show(notice.message, {
-    variant: "default",
-    durationMs: notice.type === "warning" ? 3200 : undefined,
+    variant: notice.type,
+    durationMs: notice.type === "warning" ? 5000 : undefined,
   });
 }

--- a/packages/server/src/server/agent/provider-notices.ts
+++ b/packages/server/src/server/agent/provider-notices.ts
@@ -1,6 +1,11 @@
 import type { AgentProviderNotice } from "./agent-sdk-types.js";
 
-export const SETTING_APPLIES_NEXT_TURN_NOTICE: AgentProviderNotice = {
-  type: "info",
-  message: "This change applies next turn.",
+export const MODE_APPLIES_NEXT_TURN_NOTICE: AgentProviderNotice = {
+  type: "warning",
+  message: "Permission mode applies next turn",
+};
+
+export const THINKING_APPLIES_NEXT_TURN_NOTICE: AgentProviderNotice = {
+  type: "warning",
+  message: "Thinking level applies next turn",
 };

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -704,8 +704,8 @@ describe("ClaudeAgentSession features", () => {
     });
 
     await expect(session.setThinkingOption?.("ultracode")).resolves.toEqual({
-      type: "info",
-      message: "This change applies next turn.",
+      type: "warning",
+      message: "Thinking level applies next turn",
     });
 
     await session.close();

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -50,7 +50,7 @@ import { claudeQuery, type ClaudeOptions, type ClaudeQueryFactory } from "./quer
 import { realClaudeRewindSdk, revertClaudeConversation, revertClaudeFiles } from "./rewind.js";
 import { normalizeProviderReplayTimestamp } from "../../provider-history-timestamps.js";
 import { claudeProjectDirSync } from "./project-dir.js";
-import { SETTING_APPLIES_NEXT_TURN_NOTICE } from "../../provider-notices.js";
+import { THINKING_APPLIES_NEXT_TURN_NOTICE } from "../../provider-notices.js";
 import {
   isProviderImageMarkdown,
   materializeProviderImage,
@@ -2209,7 +2209,7 @@ class ClaudeAgentSession implements AgentSession {
     }
     this.queryRestartNeeded = true;
     if (this.activeForegroundTurnId || this.autonomousTurn) {
-      return SETTING_APPLIES_NEXT_TURN_NOTICE;
+      return THINKING_APPLIES_NEXT_TURN_NOTICE;
     }
   }
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -347,12 +347,12 @@ describe("Codex app-server provider", () => {
     const session = createSession({ modeId: "auto", thinkingOptionId: "medium" });
 
     await expect(session.setMode("full-access")).resolves.toEqual({
-      type: "info",
-      message: "This change applies next turn.",
+      type: "warning",
+      message: "Permission mode applies next turn",
     });
     await expect(session.setThinkingOption?.("high")).resolves.toEqual({
-      type: "info",
-      message: "This change applies next turn.",
+      type: "warning",
+      message: "Thinking level applies next turn",
     });
 
     session.activeForegroundTurnId = null;

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -92,7 +92,10 @@ import {
   resolveBinaryVersion,
 } from "./diagnostic-utils.js";
 import { appendOrReplaceGrowingAssistantMessage, runProviderTurn } from "./provider-runner.js";
-import { SETTING_APPLIES_NEXT_TURN_NOTICE } from "../provider-notices.js";
+import {
+  MODE_APPLIES_NEXT_TURN_NOTICE,
+  THINKING_APPLIES_NEXT_TURN_NOTICE,
+} from "../provider-notices.js";
 import type { WorkspaceGitService } from "../../workspace-git-service.js";
 
 function assertChildWithPipes(
@@ -3943,7 +3946,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.currentMode = modeId;
     this.cachedRuntimeInfo = null;
     if (this.activeForegroundTurnId) {
-      return SETTING_APPLIES_NEXT_TURN_NOTICE;
+      return MODE_APPLIES_NEXT_TURN_NOTICE;
     }
   }
 
@@ -3961,7 +3964,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.refreshResolvedCollaborationMode();
     this.cachedRuntimeInfo = null;
     if (this.activeForegroundTurnId) {
-      return SETTING_APPLIES_NEXT_TURN_NOTICE;
+      return THINKING_APPLIES_NEXT_TURN_NOTICE;
     }
   }
 

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -232,7 +232,10 @@ describe("OMP agent client and session", () => {
         expect.objectContaining({ name: "review", kind: "skill" }),
       ]),
     );
-    await expect(omp.setMode("ask")).resolves.toEqual(expect.objectContaining({ type: "info" }));
+    await expect(omp.setMode("ask")).resolves.toEqual({
+      type: "warning",
+      message: "Start a new OMP session to change approval mode",
+    });
   });
 
   test("rewinds natively, interrupts, and shuts down", async () => {

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -1084,9 +1084,8 @@ export class OmpAgentSession implements AgentSession {
       throw new Error(`Invalid OMP mode '${modeId}'`);
     }
     return {
-      type: "info",
-      message:
-        "OMP approval mode is set when the agent launches. Start a new OMP session to use a different mode.",
+      type: "warning",
+      message: "Start a new OMP session to change approval mode",
     };
   }
 


### PR DESCRIPTION
### Linked issue

None

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Permission and thinking changes made during an active turn now say exactly which setting will apply next turn. These notices use a warning icon and amber outline, remain visible for five seconds, and omit trailing punctuation; ordinary informational notices now use blue info styling.

OMP's launch-only approval notice is also shorter and uses the same warning treatment.

### How did you verify it

- `npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts packages/server/src/server/agent/providers/claude/agent.test.ts packages/server/src/server/agent/providers/omp/agent.test.ts --bail=1` — 167 tests passed
- `npm run typecheck` — passed
- Targeted `npm run lint -- ...` for all changed files — passed
- Ran this worktree's Expo web build at 1440×1000 and confirmed the permission notice renders with the warning icon, amber outline, and `Permission mode applies next turn` copy

The toast is cross-platform React Native UI. Web was visually exercised; native platforms were not smoke-tested in this session.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense