### PR TITLE
fix: prevent file mention autocomplete from triggering on emails

### DIFF
--- a/packages/app/src/utils/file-mention-autocomplete.test.ts
+++ b/packages/app/src/utils/file-mention-autocomplete.test.ts
@@ -48,6 +48,74 @@ describe("findActiveFileMention", () => {
     });
     expect(mention).toBeNull();
   });
+
+  it("returns null for the issue #1364 angle-bracket email example", () => {
+    const text = "user <12345+user@noreply.example.com>";
+    const mention = findActiveFileMention({
+      text,
+      cursorIndex: text.length,
+    });
+    expect(mention).toBeNull();
+  });
+
+  it("returns null for email addresses (word char before @)", () => {
+    const text = "send to alice@example.com please";
+    const mention = findActiveFileMention({
+      text,
+      cursorIndex: text.length,
+    });
+    expect(mention).toBeNull();
+  });
+
+  it("returns null for email addresses (+ immediately before @)", () => {
+    // Local part ends with + so the character at index-1 is '+', not a word char.
+    const text = "send to noreply+@example.com please";
+    const mention = findActiveFileMention({
+      text,
+      cursorIndex: text.length,
+    });
+    expect(mention).toBeNull();
+  });
+
+  it("returns null for plus-tagged email local parts", () => {
+    const text = "noreply+tag@example.com";
+    const mention = findActiveFileMention({
+      text,
+      cursorIndex: text.length,
+    });
+    expect(mention).toBeNull();
+  });
+
+  it("returns null when query contains angle brackets", () => {
+    const text = "check @foo<bar> end";
+    const mention = findActiveFileMention({
+      text,
+      cursorIndex: text.indexOf(" end"),
+    });
+    expect(mention).toBeNull();
+  });
+
+  it("returns null when query ends with a closing angle bracket", () => {
+    const text = "check @foo>";
+    const mention = findActiveFileMention({
+      text,
+      cursorIndex: text.length,
+    });
+    expect(mention).toBeNull();
+  });
+
+  it("still detects a file mention after an email in the same input", () => {
+    const text = "user <12345+user@noreply.example.com> and also @file";
+    const mention = findActiveFileMention({
+      text,
+      cursorIndex: text.length,
+    });
+    expect(mention).toEqual({
+      start: text.lastIndexOf("@"),
+      end: text.length,
+      query: "file",
+    });
+  });
 });
 
 describe("formatQuotedFileMentionPath", () => {

--- a/packages/app/src/utils/file-mention-autocomplete.ts
+++ b/packages/app/src/utils/file-mention-autocomplete.ts
@@ -15,7 +15,7 @@ interface ApplyFileMentionReplacementInput {
   relativePath: string;
 }
 
-const INVALID_MENTION_QUERY_CHARS = /[\s\n\r\t"']/;
+const INVALID_MENTION_QUERY_CHARS = /[\s\n\r\t"'<>]/;
 
 export function findActiveFileMention(input: FindActiveFileMentionInput): FileMentionRange | null {
   const clampedCursor = Math.max(0, Math.min(input.cursorIndex, input.text.length));
@@ -26,6 +26,11 @@ export function findActiveFileMention(input: FindActiveFileMentionInput): FileMe
     atIndex >= 0;
     atIndex = atIndex === 0 ? -1 : beforeCursor.lastIndexOf("@", atIndex - 1)
   ) {
+    // Skip @ that looks like part of an email address (local-part char immediately before @).
+    if (atIndex > 0 && /[\w+]/.test(beforeCursor[atIndex - 1]!)) {
+      continue;
+    }
+
     const query = beforeCursor.slice(atIndex + 1);
     if (INVALID_MENTION_QUERY_CHARS.test(query)) {
       continue;


### PR DESCRIPTION
## Summary

- File mention autocomplete no longer treats email `@` as a workspace path trigger.
- Skip `@` when the previous character is a word character or `+` (email local-part).
- Reject `<` / `>` in mention queries so angle-bracket emails cannot produce a valid query.
- Regression tests cover the #1364 example, plain/`+` emails, angle brackets, and email-then-`@file` in the same input.

Closes #1364

Supersedes the unmerged approach in #1365 (same guards, tighter tests including a real `+`-before-`@` case).

## Problem

Typing text like `user <12345+user@noreply.example.com>` activated file autocomplete. Enter selected a path and rewrote the input to:

`user <12345+user"some_file_in_workspace"`

## Solution

In `findActiveFileMention` (`packages/app/src/utils/file-mention-autocomplete.ts`):

1. Continue past `@` when preceded by `[\w+]`.
2. Extend `INVALID_MENTION_QUERY_CHARS` with `<>`.

Legitimate `@relative/path` mentions are unchanged.

## Test plan

- [x] `npx vitest run packages/app/src/utils/file-mention-autocomplete.test.ts --bail=1` (13 tests)
- [x] Pre-commit lint / format / typecheck
- [ ] Manual smoke (optional): type the issue email example → no file popover; Enter sends; `@src/` still suggests files