### PR TITLE
Keep sidebar pins visible while reopening

### DIFF
--- a/packages/app/e2e/helpers/sidebar.ts
+++ b/packages/app/e2e/helpers/sidebar.ts
@@ -39,6 +39,13 @@ export async function clickArchiveWorkspaceMenuItem(
   await archiveItem.click();
 }
 
+export async function pinWorkspaceFromSidebar(page: Page, workspaceId: string): Promise<void> {
+  const serverId = await openWorkspaceSidebarKebab(page, workspaceId);
+  const pinItem = page.getByTestId(`sidebar-workspace-menu-pin-${serverId}:${workspaceId}`);
+  await expect(pinItem).toBeVisible({ timeout: 10_000 });
+  await pinItem.click();
+}
+
 export async function archiveWorkspaceFromSidebar(page: Page, workspaceId: string): Promise<void> {
   // A clean workspace archives with no prompt. Managed worktree backing may raise
   // a browser confirm for unsynced work, so accept it when present.

--- a/packages/app/e2e/sidebar-workspace.spec.ts
+++ b/packages/app/e2e/sidebar-workspace.spec.ts
@@ -168,6 +168,33 @@ test.describe("Mobile sidebar panelState transition", () => {
     await closeMobileAgentSidebar(page);
     await expectMobileAgentSidebarHidden(page);
   });
+
+  test("keeps a pinned workspace rendered while the retained sidebar is closed", async ({
+    page,
+  }) => {
+    const workspace = await seedWorkspace({ repoPrefix: "sidebar-retained-pin-" });
+
+    try {
+      await gotoAppShell(page);
+      await openMobileAgentSidebar(page);
+      await expectMobileAgentSidebarVisible(page);
+
+      const workspaceKey = `${getServerId()}:${workspace.workspaceId}`;
+      const row = page.getByTestId(`sidebar-workspace-row-${workspaceKey}`);
+      await expect(row).toBeVisible({ timeout: 30_000 });
+      await row.hover();
+      await page.getByTestId(`sidebar-workspace-kebab-${workspaceKey}`).click();
+      await page.getByTestId(`sidebar-workspace-menu-pin-${workspaceKey}`).click();
+      await expect(page.getByTestId("sidebar-pinned-section")).toBeVisible();
+
+      await closeMobileAgentSidebar(page);
+      await expectMobileAgentSidebarHidden(page);
+
+      await expect(row).toHaveCount(1);
+    } finally {
+      await workspace.cleanup();
+    }
+  });
 });
 
 test.describe("Half-screen desktop layout", () => {

--- a/packages/app/e2e/sidebar-workspace.spec.ts
+++ b/packages/app/e2e/sidebar-workspace.spec.ts
@@ -6,6 +6,7 @@ import {
   expectMobileAgentSidebarHidden,
   expectMobileAgentSidebarVisible,
   openMobileAgentSidebar,
+  pinWorkspaceFromSidebar,
 } from "./helpers/sidebar";
 import { seedWorkspace } from "./helpers/seed-client";
 import { expectWorkspaceHeader } from "./helpers/workspace-ui";
@@ -179,12 +180,9 @@ test.describe("Mobile sidebar panelState transition", () => {
       await openMobileAgentSidebar(page);
       await expectMobileAgentSidebarVisible(page);
 
-      const workspaceKey = `${getServerId()}:${workspace.workspaceId}`;
-      const row = page.getByTestId(`sidebar-workspace-row-${workspaceKey}`);
+      const row = page.getByTestId(getWorkspaceRowTestId(workspace.workspaceId));
       await expect(row).toBeVisible({ timeout: 30_000 });
-      await row.hover();
-      await page.getByTestId(`sidebar-workspace-kebab-${workspaceKey}`).click();
-      await page.getByTestId(`sidebar-workspace-menu-pin-${workspaceKey}`).click();
+      await pinWorkspaceFromSidebar(page, workspace.workspaceId);
       await expect(page.getByTestId("sidebar-pinned-section")).toBeVisible();
 
       await closeMobileAgentSidebar(page);

--- a/packages/app/src/hooks/use-sidebar-workspace-entries.ts
+++ b/packages/app/src/hooks/use-sidebar-workspace-entries.ts
@@ -38,7 +38,10 @@ export function useSidebarWorkspaceEntries(
   // subscription to structurally shared indexes, never one session-store
   // subscription per mounted row.
   return useMemo(() => {
-    if (!enabled || placements.length === 0 || sessions.length === 0) {
+    if (!enabled) {
+      return previousEntriesRef.current;
+    }
+    if (placements.length === 0 || sessions.length === 0) {
       previousEntriesRef.current = EMPTY_ENTRIES;
       return EMPTY_ENTRIES;
     }


### PR DESCRIPTION
### Linked issue

No matching open issue.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Keeps the compact sidebar's last rendered workspace entries while the sidebar is closed, so pinned rows remain present throughout the opening animation instead of flashing empty.

The hidden sidebar still stops rebuilding entries from live session and activity updates. When reopened, it reconciles the retained rows with current store data.

### How did you verify it

- Added a compact-layout Playwright regression that pins a workspace, closes the retained sidebar, and verifies the pinned row remains mounted.
- Confirmed the regression failed before the fix with 0 rows instead of 1, then passed after the fix:
  `npm run test:e2e --workspace=@getpaseo/app -- sidebar-workspace.spec.ts --grep "keeps a pinned workspace rendered while the retained sidebar is closed"`
- `npm run typecheck`
- `npm run lint -- packages/app/src/hooks/use-sidebar-workspace-entries.ts packages/app/e2e/sidebar-workspace.spec.ts`
- `npm run format`

Compact web is covered by the focused real-browser test. Native iOS and Android were not manually exercised from this Linux checkout; both use the same retained sidebar entry hook.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense