### PR TITLE
Use safer automatic approval modes by default

### DIFF
--- a/packages/app/src/provider-selection/resolve-agent-form.test.ts
+++ b/packages/app/src/provider-selection/resolve-agent-form.test.ts
@@ -575,6 +575,25 @@ describe("resolveFormState", () => {
     expect(resolved.modeId).toBe("workspace-write");
   });
 
+  it("falls back when the provider cannot advertise its preferred default mode", () => {
+    const providerMap = makeProviderMap({
+      ...TEST_CODEX_DEFINITION,
+      defaultModeId: "auto-review",
+      modes: TEST_CODEX_DEFINITION.modes,
+    });
+
+    const resolved = resolveFormState(
+      undefined,
+      { provider: "codex" },
+      CODEX_MODELS,
+      INITIAL_USER_MODIFIED,
+      makeState({ provider: "codex" }).form,
+      providerMap,
+    );
+
+    expect(resolved.modeId).toBe("auto");
+  });
+
   it("ignores disabled ready providers when resolving selectable defaults", () => {
     const entries: ProviderSnapshotEntry[] = [
       {

--- a/packages/app/src/provider-selection/resolve-agent-form.ts
+++ b/packages/app/src/provider-selection/resolve-agent-form.ts
@@ -171,7 +171,12 @@ function resolvePreferredModeId(input: {
   const preferredModeId = normalizeSelectedModeId(input.preferredModeId);
   if (preferredModeId) return preferredModeId;
 
-  return input.providerDef?.defaultModeId ?? input.providerDef?.modes[0]?.id ?? "";
+  const defaultModeId = input.providerDef?.defaultModeId;
+  const modes = input.providerDef?.modes ?? [];
+  if (defaultModeId && (modes.length === 0 || modes.some((mode) => mode.id === defaultModeId))) {
+    return defaultModeId;
+  }
+  return modes[0]?.id ?? "";
 }
 
 export function mergeSelectedComposerPreferences(args: {

--- a/packages/protocol/src/provider-manifest.ts
+++ b/packages/protocol/src/provider-manifest.ts
@@ -185,7 +185,7 @@ export const AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [
     id: "claude",
     label: "Claude",
     description: "Anthropic's multi-tool assistant with MCP support, streaming, and deep reasoning",
-    defaultModeId: "default",
+    defaultModeId: "auto",
     modes: CLAUDE_MODES,
     voice: {
       enabled: true,
@@ -197,7 +197,7 @@ export const AGENT_PROVIDER_DEFINITIONS: AgentProviderDefinition[] = [
     id: "codex",
     label: "Codex",
     description: "OpenAI's Codex workspace agent with sandbox controls and optional network access",
-    defaultModeId: "auto",
+    defaultModeId: "auto-review",
     modes: CODEX_MODES,
     voice: {
       enabled: true,

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -111,10 +111,14 @@ function expectArchivedAgentRecord(
 }
 
 class TestAgentClient implements AgentClient {
-  readonly provider = "codex" as const;
+  readonly provider: AgentProvider;
   readonly capabilities = TEST_CAPABILITIES;
   readonly createdConfigs: AgentSessionConfig[] = [];
   readonly resumeOverrides: Array<Partial<AgentSessionConfig> | undefined> = [];
+
+  constructor(provider: AgentProvider = "codex") {
+    this.provider = provider;
+  }
 
   async isAvailable(): Promise<boolean> {
     return true;
@@ -129,18 +133,18 @@ class TestAgentClient implements AgentClient {
     return {
       models: [
         {
-          provider: "codex",
+          provider: this.provider,
           id: "gpt-5.4",
           label: "GPT-5.4",
           isDefault: true,
         },
         {
-          provider: "codex",
+          provider: this.provider,
           id: "gpt-5.4-mini",
           label: "GPT-5.4 Mini",
         },
         {
-          provider: "codex",
+          provider: this.provider,
           id: "gpt-5.2-codex",
           label: "GPT-5.2 Codex",
         },
@@ -156,7 +160,7 @@ class TestAgentClient implements AgentClient {
   ): Promise<AgentSession> {
     this.resumeOverrides.push(config);
     return new TestAgentSession({
-      provider: "codex",
+      provider: this.provider,
       cwd: config?.cwd ?? process.cwd(),
       daemonAppendSystemPrompt: config?.daemonAppendSystemPrompt,
     });
@@ -936,6 +940,20 @@ test("normalizeConfig injects the provider default model when omitted", async ()
 
   expect(snapshot.config.model).toBe("gpt-5.4");
   expect(snapshot.config.modeId).toBe("auto-review");
+});
+
+test("normalizeConfig injects Claude's automatic approval default when omitted", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-claude-default-test-"));
+  const manager = new AgentManager({
+    clients: { claude: new TestAgentClient("claude") },
+    logger,
+  });
+
+  const snapshot = await manager.createAgent({ provider: "claude", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+
+  expect(snapshot.config.modeId).toBe("auto");
 });
 
 test("normalizeConfig uses a capability-aware provider mode default", async () => {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -959,7 +959,7 @@ test("normalizeConfig injects Claude's automatic approval default when omitted",
 test("normalizeConfig uses a capability-aware provider mode default", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-mode-default-test-"));
   class CapabilityAwareClient extends TestAgentClient {
-    override async resolveDefaultModeId(): Promise<string> {
+    override async resolveDefaultModeId(_config: AgentSessionConfig): Promise<string> {
       return "auto";
     }
   }

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -938,6 +938,25 @@ test("normalizeConfig injects the provider default model when omitted", async ()
   expect(snapshot.config.modeId).toBe("auto-review");
 });
 
+test("normalizeConfig uses a capability-aware provider mode default", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-mode-default-test-"));
+  class CapabilityAwareClient extends TestAgentClient {
+    override async resolveDefaultModeId(): Promise<string> {
+      return "auto";
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new CapabilityAwareClient() },
+    logger,
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+
+  expect(snapshot.config.modeId).toBe("auto");
+});
+
 test("createAgent forwards request env into the spawned provider process", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-env-test-"));
   const client = new EnvProbeAgentClient();

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -35,6 +35,7 @@ import type {
   AgentStreamEvent,
   AgentTimelineItem,
   ImportProviderSessionInput,
+  ResolveAgentDefaultModeInput,
 } from "./agent-sdk-types.js";
 import type { PaseoToolCatalog } from "./tools/types.js";
 import type { ProviderDefinition } from "./provider-registry.js";
@@ -959,8 +960,8 @@ test("normalizeConfig injects Claude's automatic approval default when omitted",
 test("normalizeConfig uses a capability-aware provider mode default", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-mode-default-test-"));
   class CapabilityAwareClient extends TestAgentClient {
-    override async resolveDefaultModeId(_config: AgentSessionConfig): Promise<string> {
-      return "auto";
+    override async resolveDefaultModeId(input: ResolveAgentDefaultModeInput): Promise<string> {
+      return input.env?.CLAUDE_CODE_USE_BEDROCK === "1" ? "default" : "auto";
     }
   }
   const manager = new AgentManager({
@@ -970,9 +971,10 @@ test("normalizeConfig uses a capability-aware provider mode default", async () =
 
   const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
     workspaceId: undefined,
+    env: { CLAUDE_CODE_USE_BEDROCK: "1" },
   });
 
-  expect(snapshot.config.modeId).toBe("auto");
+  expect(snapshot.config.modeId).toBe("default");
 });
 
 test("createAgent forwards request env into the spawned provider process", async () => {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -935,7 +935,7 @@ test("normalizeConfig injects the provider default model when omitted", async ()
   );
 
   expect(snapshot.config.model).toBe("gpt-5.4");
-  expect(snapshot.config.modeId).toBe("auto");
+  expect(snapshot.config.modeId).toBe("auto-review");
 });
 
 test("createAgent forwards request env into the spawned provider process", async () => {
@@ -997,7 +997,7 @@ test("normalizeConfig strips legacy 'default' model id", async () => {
   );
 
   expect(snapshot.config.model).toBe("gpt-5.4");
-  expect(snapshot.config.modeId).toBe("auto");
+  expect(snapshot.config.modeId).toBe("auto-review");
 });
 
 test("listDraftCommands returns no commands without guessing a missing model", async () => {
@@ -1094,7 +1094,7 @@ test("listDraftCommands uses explicit model config without default model fetchin
       provider: "codex",
       cwd: workdir,
       model: "gpt-5.4",
-      modeId: "auto",
+      modeId: "auto-review",
     },
   ]);
 });
@@ -1194,7 +1194,7 @@ test("listDraftFeatures uses explicit model config without default model fetchin
       provider: "codex",
       cwd: workdir,
       model: "gpt-5.4",
-      modeId: "auto",
+      modeId: "auto-review",
     },
   ]);
 });
@@ -1651,7 +1651,7 @@ test("createAgent passes daemon launch env through the provider launch context",
     provider: "codex",
     cwd: workdir,
     model: "gpt-5.4",
-    modeId: "auto",
+    modeId: "auto-review",
   });
   expect(client.lastLaunchContext).toEqual({
     agentId: snapshot.id,
@@ -2448,7 +2448,7 @@ test("resumeAgentFromPersistence keeps metadata config, applies overrides, and p
   });
   expect(client.lastResumeOverrides).toMatchObject({
     model: "gpt-5.4",
-    modeId: "auto",
+    modeId: "auto-review",
     systemPrompt: "new prompt",
     mcpServers: {
       paseo: {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -4075,15 +4075,20 @@ export class AgentManager {
     }
 
     if (!normalized.modeId) {
-      try {
-        normalized.modeId =
-          getAgentProviderDefinition(normalized.provider).defaultModeId ?? undefined;
-      } catch {
-        // Unknown provider
-      }
+      normalized.modeId = await this.resolveDefaultModeId(normalized.provider);
     }
 
     return normalized;
+  }
+
+  private async resolveDefaultModeId(provider: AgentProvider): Promise<string | undefined> {
+    const providerDefault = await this.clients.get(provider)?.resolveDefaultModeId?.();
+    if (providerDefault) return providerDefault;
+    try {
+      return getAgentProviderDefinition(provider).defaultModeId ?? undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   private async resolveDefaultModelId(config: AgentSessionConfig): Promise<string | undefined> {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -4075,17 +4075,17 @@ export class AgentManager {
     }
 
     if (!normalized.modeId) {
-      normalized.modeId = await this.resolveDefaultModeId(normalized.provider);
+      normalized.modeId = await this.resolveDefaultModeId(normalized);
     }
 
     return normalized;
   }
 
-  private async resolveDefaultModeId(provider: AgentProvider): Promise<string | undefined> {
-    const providerDefault = await this.clients.get(provider)?.resolveDefaultModeId?.();
+  private async resolveDefaultModeId(config: AgentSessionConfig): Promise<string | undefined> {
+    const providerDefault = await this.clients.get(config.provider)?.resolveDefaultModeId?.(config);
     if (providerDefault) return providerDefault;
     try {
-      return getAgentProviderDefinition(provider).defaultModeId ?? undefined;
+      return getAgentProviderDefinition(config.provider).defaultModeId ?? undefined;
     } catch {
       return undefined;
     }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -117,6 +117,7 @@ interface PreparedSessionConfig {
 
 interface NormalizeConfigOptions {
   resolveDefaultModel?: boolean;
+  env?: Record<string, string>;
 }
 
 interface TimeoutOptions {
@@ -1034,7 +1035,11 @@ export class AgentManager {
     this.assertAcceptingAgentRegistrations();
     const resolvedAgentId = validateAgentId(agentId ?? this.idFactory(), "createAgent");
     await this.deleteAgentState(resolvedAgentId);
-    const { storedConfig, launchConfig } = await this.prepareSessionConfig(config, resolvedAgentId);
+    const { storedConfig, launchConfig } = await this.prepareSessionConfig(
+      config,
+      resolvedAgentId,
+      options?.env,
+    );
     this.requireEnabledProvider(storedConfig.provider);
     const client = await this.requireAvailableClient({
       provider: storedConfig.provider,
@@ -4075,14 +4080,19 @@ export class AgentManager {
     }
 
     if (!normalized.modeId) {
-      normalized.modeId = await this.resolveDefaultModeId(normalized);
+      normalized.modeId = await this.resolveDefaultModeId(normalized, options.env);
     }
 
     return normalized;
   }
 
-  private async resolveDefaultModeId(config: AgentSessionConfig): Promise<string | undefined> {
-    const providerDefault = await this.clients.get(config.provider)?.resolveDefaultModeId?.(config);
+  private async resolveDefaultModeId(
+    config: AgentSessionConfig,
+    env?: Record<string, string>,
+  ): Promise<string | undefined> {
+    const providerDefault = await this.clients
+      .get(config.provider)
+      ?.resolveDefaultModeId?.({ config, env });
     if (providerDefault) return providerDefault;
     try {
       return getAgentProviderDefinition(config.provider).defaultModeId ?? undefined;
@@ -4112,8 +4122,9 @@ export class AgentManager {
   private async prepareSessionConfig(
     config: AgentSessionConfig,
     agentId: string,
+    env?: Record<string, string>,
   ): Promise<PreparedSessionConfig> {
-    const storedConfig = await this.normalizeConfig(stripInternalPaseoMcpServer(config));
+    const storedConfig = await this.normalizeConfig(stripInternalPaseoMcpServer(config), { env });
     const launchConfig = this.applyDaemonAppendSystemPrompt(
       withRuntimePaseoMcpServer({
         config: storedConfig,

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -690,6 +690,7 @@ export interface AgentClient {
    * The registry is responsible for merging configured model overrides.
    */
   fetchCatalog(options: FetchCatalogOptions): Promise<ProviderCatalog>;
+  resolveDefaultModeId?(): Promise<string | undefined>;
   resolveCreateConfig?(input: ResolveAgentCreateConfigInput): ResolveAgentCreateConfigResult;
   isCreateConfigUnattended?(input: AgentCreateConfigUnattendedInput): boolean;
   listCommands?(config: AgentSessionConfig): Promise<AgentSlashCommand[]>;

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -690,7 +690,7 @@ export interface AgentClient {
    * The registry is responsible for merging configured model overrides.
    */
   fetchCatalog(options: FetchCatalogOptions): Promise<ProviderCatalog>;
-  resolveDefaultModeId?(): Promise<string | undefined>;
+  resolveDefaultModeId?(config: AgentSessionConfig): Promise<string | undefined>;
   resolveCreateConfig?(input: ResolveAgentCreateConfigInput): ResolveAgentCreateConfigResult;
   isCreateConfigUnattended?(input: AgentCreateConfigUnattendedInput): boolean;
   listCommands?(config: AgentSessionConfig): Promise<AgentSlashCommand[]>;

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -668,6 +668,12 @@ export type FetchCatalogOptions =
 export interface ProviderCatalog {
   models: AgentModelDefinition[];
   modes: AgentMode[];
+  defaultModeId?: string | null;
+}
+
+export interface ResolveAgentDefaultModeInput {
+  config: AgentSessionConfig;
+  env?: Record<string, string>;
 }
 
 export interface AgentClient {
@@ -690,7 +696,7 @@ export interface AgentClient {
    * The registry is responsible for merging configured model overrides.
    */
   fetchCatalog(options: FetchCatalogOptions): Promise<ProviderCatalog>;
-  resolveDefaultModeId?(config: AgentSessionConfig): Promise<string | undefined>;
+  resolveDefaultModeId?(input: ResolveAgentDefaultModeInput): Promise<string | undefined>;
   resolveCreateConfig?(input: ResolveAgentCreateConfigInput): ResolveAgentCreateConfigResult;
   isCreateConfigUnattended?(input: AgentCreateConfigUnattendedInput): boolean;
   listCommands?(config: AgentSessionConfig): Promise<AgentSlashCommand[]>;

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -1487,6 +1487,31 @@ describe("fetchCatalog", () => {
     expect(catalog.models.map((model) => model.id)).toEqual(["profile-model", "extra-model"]);
   });
 
+  test("replacement models still resolve the provider's capability-aware default mode", async () => {
+    const resolveDefaultModeId = vi.fn(async () => "default");
+    const injectedClient = {
+      provider: "codex",
+      capabilities: {},
+      resolveDefaultModeId,
+      isAvailable: vi.fn(async () => true),
+    } satisfies Partial<AgentClient> as AgentClient;
+    const registry = buildProviderRegistry(logger, {
+      providerOverrides: {
+        codex: { models: [{ id: "profile-model", label: "Profile Model" }] },
+      },
+    });
+
+    const catalog = await registry.codex.fetchCatalog(
+      { scope: "workspace", cwd: "/tmp/catalog", force: false },
+      injectedClient,
+    );
+
+    expect(catalog.defaultModeId).toBe("default");
+    expect(resolveDefaultModeId).toHaveBeenCalledWith({
+      config: { provider: "codex", cwd: "/tmp/catalog" },
+    });
+  });
+
   test("additionalModels can override replacement model fields", async () => {
     const registry = buildProviderRegistry(logger, {
       providerOverrides: {

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -814,7 +814,7 @@ test("enabled: false keeps provider metadata in registry", () => {
     id: "claude",
     label: "Claude",
     description: "Anthropic's multi-tool assistant with MCP support, streaming, and deep reasoning",
-    defaultModeId: "default",
+    defaultModeId: "auto",
     enabled: false,
   });
   expect(registry.claude.modes).toEqual(

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -433,6 +433,7 @@ function wrapClientProvider(
         modes: catalog.modes,
       };
     },
+    resolveDefaultModeId: inner.resolveDefaultModeId?.bind(inner),
     resolveCreateConfig: inner.resolveCreateConfig?.bind(inner),
     isCreateConfigUnattended: inner.isCreateConfigUnattended?.bind(inner),
     listFeatures: listFeatures

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -14,6 +14,7 @@ import type {
   ProviderCatalog,
   ResolveAgentCreateConfigInput,
   ResolveAgentCreateConfigResult,
+  ResolveAgentDefaultModeInput,
 } from "./agent-sdk-types.js";
 import {
   isDefaultAgentCreateConfigUnattended,
@@ -427,13 +428,20 @@ function wrapClientProvider(
     fetchCatalog: async (options) => {
       const catalog = await inner.fetchCatalog(options);
       return {
+        ...catalog,
         models: mergeModels(provider, profileModels, additionalModels, catalog.models, {
           profileModelsAreAdditive,
         }),
         modes: catalog.modes,
       };
     },
-    resolveDefaultModeId: inner.resolveDefaultModeId?.bind(inner),
+    resolveDefaultModeId: inner.resolveDefaultModeId
+      ? async ({ config, env }: ResolveAgentDefaultModeInput) =>
+          await inner.resolveDefaultModeId?.({
+            config: { ...config, provider: inner.provider },
+            env,
+          })
+      : undefined,
     resolveCreateConfig: inner.resolveCreateConfig?.bind(inner),
     isCreateConfigUnattended: inner.isCreateConfigUnattended?.bind(inner),
     listFeatures: listFeatures
@@ -517,17 +525,25 @@ function createRegistryEntry(
         // the single catalog API; otherwise use static/empty modes with no runtime.
         const models = mergeModelAdditions(provider, replacementModels, resolved.additionalModels);
         if (hasStaticModes) {
+          const defaultModeId = await catalogClient.resolveDefaultModeId?.({
+            config: {
+              provider,
+              cwd: options.scope === "workspace" ? options.cwd : process.cwd(),
+            },
+          });
           return {
             models,
             modes: decorateModes(resolved.definition.modes),
+            defaultModeId,
           };
         }
         const catalog = await catalogClient.fetchCatalog(options);
-        return { models, modes: decorateModes(catalog.modes) };
+        return { ...catalog, models, modes: decorateModes(catalog.modes) };
       }
 
       const catalog = await catalogClient.fetchCatalog(options);
       return {
+        ...catalog,
         models: mergeModels(
           provider,
           resolved.profileModels,

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -117,9 +117,11 @@ describe("ProviderSnapshotManager public surface", () => {
     try {
       const snapshot = manager.getSnapshot("/tmp/project");
       const claude = snapshot.find((entry) => entry.provider === "claude");
+      const codex = snapshot.find((entry) => entry.provider === "codex");
       expect(claude?.status).toBe("loading");
       expect(claude?.label).toBe("Claude");
-      expect(claude?.defaultModeId).toBe("default");
+      expect(claude?.defaultModeId).toBe("auto");
+      expect(codex?.defaultModeId).toBe("auto-review");
     } finally {
       manager.destroy();
     }

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -222,6 +222,34 @@ describe("ProviderSnapshotManager public surface", () => {
     }
   });
 
+  test("ready snapshots publish the catalog's capability-aware default mode", async () => {
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      extraClients: {
+        codex: createExtraClient("codex", {
+          isAvailable: async () => true,
+          fetchCatalog: async () => ({
+            models: [],
+            modes: [{ id: "default", label: "Default", description: "Ask before running tools" }],
+            defaultModeId: "default",
+          }),
+        }),
+      },
+    });
+
+    try {
+      const entry = await manager.getProvider({
+        cwd: "/tmp/project",
+        provider: "codex",
+        wait: true,
+      });
+
+      expect(entry).toMatchObject({ status: "ready", defaultModeId: "default" });
+    } finally {
+      manager.destroy();
+    }
+  });
+
   test("explicit refresh re-probes only the requested warm provider", async () => {
     const cwd = "/tmp/project";
     const isAvailableCodex = vi.fn(async () => true);

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -799,6 +799,8 @@ export class ProviderSnapshotManager {
 
       setEntry({
         ...base,
+        defaultModeId:
+          catalog.defaultModeId === undefined ? definition.defaultModeId : catalog.defaultModeId,
         status: "ready",
         enabled: true,
         models: catalog.models,

--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -229,8 +229,24 @@ test.each([
   });
 
   await expect(
-    client.resolveDefaultModeId({ provider: "claude", cwd: process.cwd() }),
+    client.resolveDefaultModeId({
+      config: { provider: "claude", cwd: process.cwd() },
+    }),
   ).resolves.toBe(expected);
+});
+
+test("launch environment participates in the Claude default mode", async () => {
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    runtimeSettings: { env: {} },
+  });
+
+  await expect(
+    client.resolveDefaultModeId({
+      config: { provider: "claude", cwd: process.cwd() },
+      env: { CLAUDE_CODE_USE_BEDROCK: "1" },
+    }),
+  ).resolves.toBe("default");
 });
 
 test("allows launch env to disable inherited Bedrock transport for auto mode", async () => {

--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -218,6 +218,21 @@ test("rejects auto mode when Claude Code uses Bedrock", async () => {
   }
 });
 
+test.each([
+  { env: {}, expected: "auto" },
+  { env: { CLAUDE_CODE_USE_BEDROCK: "1" }, expected: "default" },
+  { env: { CLAUDE_CODE_USE_VERTEX: "true" }, expected: "default" },
+])("defaults to $expected for transport environment $env", async ({ env, expected }) => {
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    runtimeSettings: { env },
+  });
+
+  await expect(
+    client.resolveDefaultModeId({ provider: "claude", cwd: process.cwd() }),
+  ).resolves.toBe(expected);
+});
+
 test("allows launch env to disable inherited Bedrock transport for auto mode", async () => {
   const previousBedrock = process.env.CLAUDE_CODE_USE_BEDROCK;
   process.env.CLAUDE_CODE_USE_BEDROCK = "1";

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -1472,7 +1472,21 @@ export class ClaudeAgentClient implements AgentClient {
   async fetchCatalog(_options: FetchCatalogOptions): Promise<ProviderCatalog> {
     // Claude exposes a global catalog here; cwd/force are intentionally irrelevant.
     const models = await getClaudeModelsWithSettings(this.logger, this.configDir);
-    return { models, modes: DEFAULT_MODES };
+    const modes = detectIneligibleAutoModeTransport(
+      createProviderEnv({ baseEnv: process.env, runtimeSettings: this.runtimeSettings }),
+    )
+      ? DEFAULT_MODES.filter((mode) => mode.id !== "auto")
+      : DEFAULT_MODES;
+    return { models, modes };
+  }
+
+  async resolveDefaultModeId(config: AgentSessionConfig): Promise<string> {
+    const env = createProviderEnv({
+      baseEnv: process.env,
+      runtimeSettings: this.runtimeSettings,
+      overlays: [config.extra?.claude?.env],
+    });
+    return detectIneligibleAutoModeTransport(env) ? "default" : "auto";
   }
 
   async listFeatures(config: AgentSessionConfig): Promise<AgentFeature[]> {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -91,6 +91,7 @@ import {
   type ListImportableSessionsOptions,
   type McpServerConfig,
   type ProviderCatalog,
+  type ResolveAgentDefaultModeInput,
 } from "../../agent-sdk-types.js";
 import { importSessionFromPersistence } from "../../provider-session-import.js";
 import {
@@ -1477,14 +1478,21 @@ export class ClaudeAgentClient implements AgentClient {
     )
       ? DEFAULT_MODES.filter((mode) => mode.id !== "auto")
       : DEFAULT_MODES;
-    return { models, modes };
+    return {
+      models,
+      modes,
+      defaultModeId: modes.some((mode) => mode.id === "auto") ? "auto" : "default",
+    };
   }
 
-  async resolveDefaultModeId(config: AgentSessionConfig): Promise<string> {
+  async resolveDefaultModeId({
+    config,
+    env: launchEnv,
+  }: ResolveAgentDefaultModeInput): Promise<string> {
     const env = createProviderEnv({
       baseEnv: process.env,
       runtimeSettings: this.runtimeSettings,
-      overlays: [config.extra?.claude?.env],
+      overlays: [config.extra?.claude?.env, launchEnv],
     });
     return detectIneligibleAutoModeTransport(env) ? "default" : "auto";
   }

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -6385,6 +6385,7 @@ export class CodexAppServerAgentClient implements AgentClient {
     ]);
     return {
       models,
+      defaultModeId: autoReviewEnabled ? "auto-review" : DEFAULT_CODEX_MODE_ID,
       modes: autoReviewEnabled
         ? CODEX_MODES
         : CODEX_MODES.filter((mode) => mode.id !== "auto-review"),

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -6379,8 +6379,20 @@ export class CodexAppServerAgentClient implements AgentClient {
   }
 
   async fetchCatalog(_options: FetchCatalogOptions): Promise<ProviderCatalog> {
-    const models = await this.fetchModelsFromAppServer();
-    return { models, modes: CODEX_MODES };
+    const [models, autoReviewEnabled] = await Promise.all([
+      this.fetchModelsFromAppServer(),
+      this.resolveAutoReviewEnabled(),
+    ]);
+    return {
+      models,
+      modes: autoReviewEnabled
+        ? CODEX_MODES
+        : CODEX_MODES.filter((mode) => mode.id !== "auto-review"),
+    };
+  }
+
+  async resolveDefaultModeId(): Promise<string> {
+    return (await this.resolveAutoReviewEnabled()) ? "auto-review" : DEFAULT_CODEX_MODE_ID;
   }
 
   private async fetchModelsFromAppServer(): Promise<AgentModelDefinition[]> {


### PR DESCRIPTION
New agents now start with automatic permission review as the middle ground between repeated manual approvals and unrestricted access. Claude defaults to Auto mode when its transport supports it, retaining Always Ask for Bedrock and Vertex. Codex defaults to Auto-review when the installed binary supports it and retains Default Permissions on older versions; explicit and saved mode choices continue to win, and voice defaults are unchanged.

This gives new users a practical starting point without silently granting full access or breaking provider runtimes that do not support automatic review.

## Verification

- Focused provider selection, registry, snapshot, agent-manager, Claude adapter, and Codex adapter tests
- `npm run typecheck`
- `npm run lint`
- `npm run format`

A real-provider smoke check can additionally confirm both automatic-review runtimes accept their default launch configuration.

## Risk surface

Configurations without an explicit mode now resolve to the new defaults, including old persisted records that omitted the field. Existing explicit and saved modes are preserved. Provider mode discovery and omitted-mode resolution apply the existing runtime capability constraints so unsupported hosts keep their prior defaults.