### PR TITLE
Render live omp system-notices as synthetic tool calls

### DIFF
--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -294,11 +294,16 @@ describe("OMP agent client and session", () => {
           "</system-notice>",
         ].join("\n"),
       );
+    omp.runtime().acceptCustomMessage("plain custom status text");
 
     expect(omp.timeline().filter((item) => item.type === "tool_call")).toMatchObject([
       { callId: "omp-notice:DocsSmokeTwo", name: "task_notification", status: "completed" },
     ]);
-    expect(omp.timeline().filter((item) => item.type === "assistant_message")).toHaveLength(1);
+    // Non-notice custom messages still fall through as assistant messages.
+    expect(omp.timeline().filter((item) => item.type === "assistant_message")).toMatchObject([
+      { text: "done" },
+      { text: "plain custom status text" },
+    ]);
   });
 
   test("does not complete a queued model turn from OMP's local-only hint", async () => {

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -277,6 +277,30 @@ describe("OMP agent client and session", () => {
     ]);
   });
 
+  test("renders a live system-notice custom message as a synthetic tool call", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    await omp.runPrompt("hello OMP", "done");
+    omp
+      .runtime()
+      .acceptCustomMessage(
+        [
+          "<system-notice>",
+          "Background job DocsSmokeTwo has completed.",
+          '<task-result id="DocsSmokeTwo" agent="explore" status="completed" duration="21.6s">',
+          "<output>done</output>",
+          "</task-result>",
+          "</system-notice>",
+        ].join("\n"),
+      );
+
+    expect(omp.timeline().filter((item) => item.type === "tool_call")).toMatchObject([
+      { callId: "omp-notice:DocsSmokeTwo", name: "task_notification", status: "completed" },
+    ]);
+    expect(omp.timeline().filter((item) => item.type === "assistant_message")).toHaveLength(1);
+  });
+
   test("does not complete a queued model turn from OMP's local-only hint", async () => {
     const omp = new OmpHarness();
     await omp.start();

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -68,6 +68,7 @@ export { formatOmpVersionSupport, resolveOmpDiagnosticPaths } from "./provider-c
 import { OmpSubagentCardTracker, type OmpSubagentCardScheduler } from "./subagent-card-tracker.js";
 import { shouldDisplayOmpCustomMessage } from "./custom-message.js";
 import { getUserMessageText } from "./message-history.js";
+import { mapOmpSystemNoticeToToolCall } from "./system-notice.js";
 import { materializeProviderImage } from "../provider-image-output.js";
 import { OmpCliRuntime } from "./cli-runtime.js";
 import { listOmpImportableSessions, readOmpImportSessionConfig } from "./session-descriptor.js";
@@ -2068,12 +2069,14 @@ export class OmpAgentSession implements AgentSession {
       if (shouldDisplayOmpCustomMessage(event.message)) {
         const text = getUserMessageText(event.message.content);
         if (text) {
-          const advisorItem = mapOmpAdvisorMessageToToolCall(event.message, text);
+          const item =
+            mapOmpAdvisorMessageToToolCall(event.message, text) ??
+            mapOmpSystemNoticeToToolCall(text);
           this.emit({
             type: "timeline",
             provider: this.provider,
             turnId,
-            item: advisorItem ?? { type: "assistant_message", text },
+            item: item ?? { type: "assistant_message", text },
           });
         }
       }


### PR DESCRIPTION
## Problem

omp `<system-notice>` messages (background job completions, xd:// device inventory changes) were showing up as raw text in agent timelines.

The replay path (`OMP_HISTORY_MAPPER_HOOKS` → `mapOmpSystemNoticeToToolCall`) already absorbs these custom messages into synthetic `task_notification` tool calls, but the live `message_end` path in `agent.ts` emitted every custom message verbatim as an `assistant_message` — so notices arriving mid-session rendered as raw `<system-notice>` text.

## Fix

Route live custom messages through the same `mapOmpSystemNoticeToToolCall` mapper used on replay; non-notice custom messages still render as assistant messages.

Note: omp 17.x upstream fixed xd:// mount notices triggering unsolicited turns and device tools leaking into the tool inventory, but notices are still delivered as `role: "custom"` messages — this change fixes how they render regardless of delivery timing, and covers task-result notices which upstream doesn't defer.

## Testing

- `npx vitest run packages/server/src/server/agent/providers/omp/agent.test.ts --bail=1` (26 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

## Risk surface

Live custom-message routing also handles advisor messages, hidden messages, and ordinary text. The rebased implementation preserves those paths and the focused agent tests cover each behavior.
