### PR TITLE
feat(sidebar): surface command center as a top menu item

### DIFF
--- a/packages/app/e2e/support/helpers/command-center-scroll.ts
+++ b/packages/app/e2e/support/helpers/command-center-scroll.ts
@@ -58,7 +58,7 @@ export async function observeCommandCenterScroll(page: Page): Promise<void> {
 }
 
 export async function openCommandCenterWithKeyboard(page: Page): Promise<Locator> {
-  await expect(page.getByTestId("sidebar-command-center-search")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("sidebar-command-center")).toBeVisible({ timeout: 30_000 });
   await page.keyboard.press("Meta+K");
   const panel = page.getByTestId("command-center-panel");
   await expect(panel).toBeVisible({ timeout: 30_000 });

--- a/packages/app/e2e/support/helpers/command-center.ts
+++ b/packages/app/e2e/support/helpers/command-center.ts
@@ -2,7 +2,7 @@ import { expect, type Locator, type Page } from "@playwright/test";
 
 // Opens the command center / global search palette from the sidebar and returns its panel.
 export async function openCommandCenter(page: Page): Promise<Locator> {
-  await page.getByTestId("sidebar-command-center-search").click();
+  await page.getByTestId("sidebar-command-center").click();
   const panel = page.getByTestId("command-center-panel");
   await expect(panel).toBeVisible({ timeout: 30_000 });
   return panel;

--- a/packages/app/e2e/support/helpers/directory-bootstrap-scenario.ts
+++ b/packages/app/e2e/support/helpers/directory-bootstrap-scenario.ts
@@ -34,7 +34,7 @@ async function createRunningMockAgent(
 }
 
 async function openCommandCenter(page: Page): Promise<void> {
-  await page.getByRole("button", { name: "Open command center" }).click();
+  await page.getByTestId("sidebar-command-center").click();
 }
 
 export class DirectoryBootstrapScenario {

--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -4,8 +4,8 @@ import {
   FolderPlus,
   History,
   Home,
+  LayoutGrid,
   Plus,
-  Search,
   Server,
   Settings,
   X,
@@ -98,6 +98,7 @@ interface SidebarSharedProps {
 interface SidebarLabels {
   addProject: string;
   newWorkspace: string;
+  commandCenter: string;
   hosts: string;
   home: string;
   settings: string;
@@ -220,6 +221,7 @@ export const LeftSidebar = memo(function LeftSidebar({ active }: { active: boole
     (): SidebarLabels => ({
       addProject: t("sidebar.actions.addProject"),
       newWorkspace: t("sidebar.actions.newWorkspace"),
+      commandCenter: t("sidebar.actions.commandCenter"),
       hosts: t("sidebar.actions.hosts"),
       home: t("sidebar.actions.home"),
       settings: t("sidebar.actions.settings"),
@@ -522,6 +524,37 @@ const SidebarNewWorkspaceHeaderRow = memo(function SidebarNewWorkspaceHeaderRow(
   );
 });
 
+const SidebarCommandCenterHeaderRow = memo(function SidebarCommandCenterHeaderRow({
+  label,
+  testID,
+  variant,
+  onBeforeOpen,
+}: {
+  label: string;
+  testID: string;
+  variant: "header" | "compact";
+  onBeforeOpen?: () => void;
+}) {
+  const setCommandCenterOpen = useKeyboardShortcutsStore((state) => state.setCommandCenterOpen);
+  const commandCenterKeys = useShortcutKeys("toggle-command-center");
+
+  const handlePress = useCallback(() => {
+    onBeforeOpen?.();
+    setCommandCenterOpen(true);
+  }, [onBeforeOpen, setCommandCenterOpen]);
+
+  return (
+    <SidebarHeaderRow
+      icon={LayoutGrid}
+      label={label}
+      onPress={handlePress}
+      testID={testID}
+      variant={variant}
+      shortcutKeys={commandCenterKeys}
+    />
+  );
+});
+
 function SidebarFooter({
   theme,
   handleOpenProject,
@@ -672,6 +705,12 @@ function MobileSidebar({
             isActive={isSchedulesActive}
             testID="sidebar-schedules"
             variant="compact"
+          />
+          <SidebarCommandCenterHeaderRow
+            label={labels.commandCenter}
+            testID="sidebar-command-center"
+            variant="compact"
+            onBeforeOpen={closeSidebar}
           />
         </View>
         <WindowChromeSafeArea placement="inline" style={styles.mobileCloseButtonRow}>
@@ -857,6 +896,11 @@ function DesktopSidebar({
               testID="sidebar-schedules"
               variant="compact"
             />
+            <SidebarCommandCenterHeaderRow
+              label={labels.commandCenter}
+              testID="sidebar-command-center"
+              variant="compact"
+            />
           </View>
         </View>
 
@@ -902,45 +946,10 @@ function DesktopSidebar({
 }
 
 function WorkspacesSectionHeader() {
-  const { theme } = useUnistyles();
-  const setCommandCenterOpen = useKeyboardShortcutsStore((state) => state.setCommandCenterOpen);
-  const commandCenterKeys = useShortcutKeys("toggle-command-center");
-  const handleSearchPress = useCallback(() => setCommandCenterOpen(true), [setCommandCenterOpen]);
-  const searchButtonStyle = useCallback(
-    ({ hovered = false, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
-      styles.workspacesHeaderIconButton,
-      (hovered || pressed) && styles.workspacesHeaderIconButtonHovered,
-    ],
-    [],
-  );
-
   return (
     <View style={styles.workspacesSectionHeader}>
       <Text style={styles.workspacesSectionTitle}>Workspaces</Text>
       <View style={styles.workspacesSectionActions}>
-        <Tooltip delayDuration={300}>
-          <TooltipTrigger asChild>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Open command center"
-              testID="sidebar-command-center-search"
-              style={searchButtonStyle}
-              onPress={handleSearchPress}
-            >
-              {({ hovered, pressed }) => (
-                <Search
-                  size={14}
-                  color={
-                    hovered || pressed ? theme.colors.foreground : theme.colors.foregroundMuted
-                  }
-                />
-              )}
-            </Pressable>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" align="center" offset={8}>
-            <IconTooltipContent label="Search" shortcutKeys={commandCenterKeys} />
-          </TooltipContent>
-        </Tooltip>
         <Tooltip delayDuration={300}>
           <TooltipTrigger asChild>
             <View>
@@ -1005,16 +1014,6 @@ const styles = StyleSheet.create((theme) => ({
     flexDirection: "row",
     alignItems: "center",
     gap: theme.spacing[1],
-  },
-  workspacesHeaderIconButton: {
-    width: 28,
-    height: 28,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: theme.borderRadius.md,
-  },
-  workspacesHeaderIconButtonHovered: {
-    backgroundColor: theme.colors.surfaceSidebarHover,
   },
   sidebarContent: {
     flex: 1,

--- a/packages/app/src/i18n/resources.test.ts
+++ b/packages/app/src/i18n/resources.test.ts
@@ -398,6 +398,7 @@ describe("translation resources", () => {
     expect(en.sidebar.host.switchTitle).toBe("Switch host");
     expect(en.sidebar.host.searchPlaceholder).toBe("Search hosts...");
     expect(en.sidebar.actions.addProject).toBe("Add project");
+    expect(en.sidebar.actions.commandCenter).toBe("Command Center");
     expect(en.sidebar.actions.hosts).toBe("Hosts");
     expect(en.sidebar.actions.home).toBe("Home");
     expect(en.sidebar.actions.settings).toBe("Settings");

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -928,6 +928,7 @@ export const ar: TranslationResources = {
     actions: {
       addProject: "إضافة مشروع",
       newWorkspace: "مساحة عمل جديدة",
+      commandCenter: "مركز الأوامر",
       hosts: "المضيفون",
       home: "بيت",
       settings: "إعدادات",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -938,6 +938,7 @@ export const en = {
     actions: {
       addProject: "Add project",
       newWorkspace: "New workspace",
+      commandCenter: "Command Center",
       hosts: "Hosts",
       home: "Home",
       settings: "Settings",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -959,6 +959,7 @@ export const es: TranslationResources = {
     actions: {
       addProject: "Agregar proyecto",
       newWorkspace: "Nuevo espacio de trabajo",
+      commandCenter: "Centro de comandos",
       hosts: "Hosts",
       home: "Hogar",
       settings: "Ajustes",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -958,6 +958,7 @@ export const fr: TranslationResources = {
     actions: {
       addProject: "Ajouter un projet",
       newWorkspace: "Nouvel espace de travail",
+      commandCenter: "Centre de commandes",
       hosts: "Hôtes",
       home: "Maison",
       settings: "Paramètres",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -939,6 +939,7 @@ export const ja: TranslationResources = {
     actions: {
       addProject: "プロジェクトを追加",
       newWorkspace: "新しいワークスペース",
+      commandCenter: "コマンドセンター",
       hosts: "ホスト",
       home: "ホーム",
       settings: "設定",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -950,6 +950,7 @@ export const ptBR: TranslationResources = {
     actions: {
       addProject: "Adicionar projeto",
       newWorkspace: "Novo workspace",
+      commandCenter: "Central de comandos",
       hosts: "Hosts",
       home: "Início",
       settings: "Configurações",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -950,6 +950,7 @@ export const ru: TranslationResources = {
     actions: {
       addProject: "Добавить проект",
       newWorkspace: "Новое рабочее пространство",
+      commandCenter: "Командный центр",
       hosts: "Хосты",
       home: "Дом",
       settings: "Настройки",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -920,6 +920,7 @@ export const zhCN: TranslationResources = {
     actions: {
       addProject: "添加 project",
       newWorkspace: "新建工作区",
+      commandCenter: "命令中心",
       hosts: "Hosts",
       home: "首页",
       settings: "设置",


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [ ] Bug fix
- [x] New feature - Minor incremental improvement
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Moves the command center out of a magnifier icon on the "Workspaces" header and into
a labeled "Command Center" row in the sidebar's top menu group, next to New workspace,
History, and Schedules. The magnifier is removed, so there's one entry point instead
of two.

## Why

Two things why I would change the placement:

- **It's not just search.** The magnifier icon read as "search workspaces." The command
  center is a jump-to-anything palette (models, agents, projects, settings, actions, ...). A labeled row
  named the same as the shortcuts menu says what it actually is.
- **It's not workspace-scoped.** It acts app-wide, so sitting on the "Workspaces" header
  was the wrong scope. It belongs in the top menu group with the other global entries.

Icon is platform-neutral `LayoutGrid`.


### How did you verify it

<img width="277" height="284" alt="image" src="https://github.com/user-attachments/assets/9456e433-0877-4d5e-922f-b3766e02f420" />

### Checklist
- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI screenshots for every affected platform