### PR TITLE
[codex] Fix archive diff stat scope

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -496,6 +496,11 @@ history surfaces tolerate transient orphaned workspaces by omitting those rows s
 blank the whole History screen, but mutation paths should repair or remove the orphaned state rather
 than treating it as valid.
 
+Workspace descriptor `diffStat` is runtime Git metadata, not a persisted workspace field. It is
+scoped to uncommitted working-tree state, including staged and untracked text additions, because the
+sidebar/archive UI uses it to describe local work that archive may discard. Branch/PR diff against
+the base branch is separate checkout UI state and must not be reused for archive-risk copy.
+
 ---
 
 ## 8. Push Token Store

--- a/packages/server/src/server/workspace-git-service.primitive.test.ts
+++ b/packages/server/src/server/workspace-git-service.primitive.test.ts
@@ -315,7 +315,7 @@ function createGitHubServiceStub(): ForgeService {
 interface CreateServiceOptions {
   getCheckoutSnapshotFacts?: ReturnType<typeof vi.fn>;
   getCheckoutStatus?: ReturnType<typeof vi.fn>;
-  getCheckoutShortstat?: ReturnType<typeof vi.fn>;
+  getCheckoutUncommittedShortstat?: ReturnType<typeof vi.fn>;
   getPullRequestStatus?: ReturnType<typeof vi.fn>;
   getCheckoutDiff?: ReturnType<typeof vi.fn>;
   resolveBranchCheckout?: ReturnType<typeof vi.fn>;
@@ -338,7 +338,7 @@ function buildDefaultServiceDeps() {
     readdir: vi.fn(async () => []),
     getCheckoutSnapshotFacts: vi.fn(async (cwd: string) => createCheckoutFacts(cwd)),
     getCheckoutStatus: vi.fn(async (cwd: string) => createCheckoutStatus(cwd)),
-    getCheckoutShortstat: vi.fn(async () => ({
+    getCheckoutUncommittedShortstat: vi.fn(async () => ({
       additions: 1,
       deletions: 0,
     })),
@@ -421,18 +421,18 @@ describe("WorkspaceGitServiceImpl primitive refresh entrypoint", () => {
 
   test("getSnapshot cold-loads when no snapshot exists yet with one shell burst", async () => {
     const getCheckoutStatus = vi.fn(async (cwd: string) => createCheckoutStatus(cwd));
-    const getCheckoutShortstat = vi.fn(async () => ({ additions: 1, deletions: 0 }));
+    const getCheckoutUncommittedShortstat = vi.fn(async () => ({ additions: 1, deletions: 0 }));
     const getPullRequestStatus = vi.fn(async () => createPullRequestStatusResult());
     const service = createService({
       getCheckoutStatus,
-      getCheckoutShortstat,
+      getCheckoutUncommittedShortstat,
       getPullRequestStatus,
     });
 
     await expect(service.getSnapshot(REPO_CWD)).resolves.toEqual(createSnapshot(REPO_CWD));
 
     expect(getCheckoutStatus).toHaveBeenCalledTimes(1);
-    expect(getCheckoutShortstat).toHaveBeenCalledTimes(1);
+    expect(getCheckoutUncommittedShortstat).toHaveBeenCalledTimes(1);
     expect(getPullRequestStatus).toHaveBeenCalledTimes(1);
 
     service.dispose();
@@ -597,10 +597,10 @@ describe("WorkspaceGitServiceImpl primitive refresh entrypoint", () => {
         const status = await refreshStatus.promise;
         return { ...status, currentBranch: "feature" };
       });
-    const getCheckoutShortstat = vi.fn(async () => ({ additions: 4, deletions: 2 }));
+    const getCheckoutUncommittedShortstat = vi.fn(async () => ({ additions: 4, deletions: 2 }));
     const service = createService({
       getCheckoutStatus,
-      getCheckoutShortstat,
+      getCheckoutUncommittedShortstat,
       now: () => new Date(nowMs),
     });
 
@@ -620,7 +620,7 @@ describe("WorkspaceGitServiceImpl primitive refresh entrypoint", () => {
     const directRead = service.getSnapshot(REPO_CWD);
 
     expect(getCheckoutStatus).toHaveBeenCalledTimes(2);
-    expect(getCheckoutShortstat).toHaveBeenCalledTimes(1);
+    expect(getCheckoutUncommittedShortstat).toHaveBeenCalledTimes(1);
     await expect(directRead).resolves.toEqual(initialSnapshot);
 
     refreshStatus.resolve(createCheckoutStatus(REPO_CWD, { currentBranch: "feature" }));
@@ -639,7 +639,7 @@ describe("WorkspaceGitServiceImpl primitive refresh entrypoint", () => {
       }),
     );
     expect(getCheckoutStatus).toHaveBeenCalledTimes(2);
-    expect(getCheckoutShortstat).toHaveBeenCalledTimes(2);
+    expect(getCheckoutUncommittedShortstat).toHaveBeenCalledTimes(2);
 
     service.dispose();
   });

--- a/packages/server/src/server/workspace-git-service.test.ts
+++ b/packages/server/src/server/workspace-git-service.test.ts
@@ -257,7 +257,7 @@ function createGitHubServiceStub(): ForgeService {
 interface CreateServiceTestOptions {
   getCheckoutStatus?: ReturnType<typeof vi.fn>;
   getCheckoutSnapshotFacts?: ReturnType<typeof vi.fn>;
-  getCheckoutShortstat?: ReturnType<typeof vi.fn>;
+  getCheckoutUncommittedShortstat?: ReturnType<typeof vi.fn>;
   getPullRequestStatus?: ReturnType<typeof vi.fn>;
   github?: ForgeService;
   resolveAbsoluteGitDir?: ReturnType<typeof vi.fn>;
@@ -275,7 +275,7 @@ function buildDefaultTestServiceDeps() {
     readdir: vi.fn(async () => []),
     getCheckoutSnapshotFacts: vi.fn(async (cwd: string) => createCheckoutSnapshotFacts(cwd)),
     getCheckoutStatus: vi.fn(async (cwd: string) => createCheckoutStatus(cwd)),
-    getCheckoutShortstat: vi.fn(async () => ({
+    getCheckoutUncommittedShortstat: vi.fn(async () => ({
       additions: 1,
       deletions: 0,
     })),
@@ -414,8 +414,8 @@ describe("WorkspaceGitServiceImpl", () => {
     service.dispose();
   });
 
-  test("getSnapshot keeps plain git classification when shortstat lookup fails", async () => {
-    const getCheckoutShortstat = vi.fn(async () => {
+  test("getSnapshot keeps plain git classification when uncommitted shortstat lookup fails", async () => {
+    const getCheckoutUncommittedShortstat = vi.fn(async () => {
       throw new Error(
         "Missing Paseo worktree base metadata: /tmp/repo/.git/worktrees/feature/paseo/worktree.json",
       );
@@ -429,7 +429,7 @@ describe("WorkspaceGitServiceImpl", () => {
           mainRepoRoot: "/tmp/main-repo",
         }),
       ),
-      getCheckoutShortstat,
+      getCheckoutUncommittedShortstat,
     });
 
     await expect(service.getSnapshot(REPO_CWD)).resolves.toEqual(
@@ -941,11 +941,11 @@ describe("WorkspaceGitServiceImpl", () => {
         return createWatcher();
       },
     );
-    const getCheckoutShortstat = vi
+    const getCheckoutUncommittedShortstat = vi
       .fn()
       .mockResolvedValueOnce({ additions: 1, deletions: 0 })
       .mockResolvedValueOnce({ additions: 8, deletions: 3 });
-    const service = createService({ getCheckoutShortstat, watch });
+    const service = createService({ getCheckoutUncommittedShortstat, watch });
     const workspaceListener = vi.fn();
 
     const initialSnapshot = await service.getSnapshot(REPO_CWD);
@@ -960,7 +960,7 @@ describe("WorkspaceGitServiceImpl", () => {
     await vi.advanceTimersByTimeAsync(1_000);
     await flushPromises();
 
-    expect(getCheckoutShortstat).toHaveBeenLastCalledWith(
+    expect(getCheckoutUncommittedShortstat).toHaveBeenLastCalledWith(
       REPO_CWD,
       expect.objectContaining({ paseoHome: "/tmp/paseo-test" }),
       { force: true },

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -15,7 +15,7 @@ import {
   type CheckoutDiffResult,
   getCheckoutDiff,
   getCheckoutSnapshotFacts,
-  getCheckoutShortstat,
+  getCheckoutUncommittedShortstat,
   getCheckoutStatus,
   getPullRequestStatus,
   forgeAuthStateFromError,
@@ -255,7 +255,7 @@ interface WorkspaceGitServiceDependencies {
   readdir: typeof readdir;
   getCheckoutSnapshotFacts: typeof getCheckoutSnapshotFacts;
   getCheckoutStatus: typeof getCheckoutStatus;
-  getCheckoutShortstat: typeof getCheckoutShortstat;
+  getCheckoutUncommittedShortstat: typeof getCheckoutUncommittedShortstat;
   getCheckoutDiff: typeof getCheckoutDiff;
   getPullRequestStatus: typeof getPullRequestStatus;
   resolveBranchCheckout: typeof resolveBranchCheckout;
@@ -348,7 +348,7 @@ function buildDefaultWorkspaceGitServiceDeps(): WorkspaceGitServiceDependencies 
     readdir,
     getCheckoutSnapshotFacts,
     getCheckoutStatus,
-    getCheckoutShortstat,
+    getCheckoutUncommittedShortstat,
     getCheckoutDiff,
     getPullRequestStatus,
     resolveBranchCheckout,
@@ -1761,7 +1761,7 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
     }
 
     const diffStat = await this.deps
-      .getCheckoutShortstat(cwd, context, { force: request.force })
+      .getCheckoutUncommittedShortstat(cwd, context, { force: request.force })
       .catch(() => null);
 
     target.latestGit = {

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -25,6 +25,7 @@ import {
   getCurrentBranch,
   getCheckoutDiff,
   getCheckoutShortstat,
+  getCheckoutUncommittedShortstat,
   getPullRequestStatus,
   getCheckoutStatus,
   checkoutResolvedBranch,
@@ -930,6 +931,19 @@ const x = 1;
     const shortstat = await getCheckoutShortstat(repoDir);
 
     expect(shortstat).toEqual({ additions: 1, deletions: 0 });
+  });
+
+  it("keeps uncommitted shortstat scoped to working tree changes on a feature branch", async () => {
+    setupRemoteTrackingMain(repoDir, tempDir);
+    execFileSync("git", ["checkout", "-b", "feature"], { cwd: repoDir });
+    commitFile(repoDir, "feature.txt", "feature\n", "feature update");
+    writeFileSync(join(repoDir, "file.txt"), "local one\nlocal two\n");
+
+    const branchShortstat = await getCheckoutShortstat(repoDir);
+    const uncommittedShortstat = await getCheckoutUncommittedShortstat(repoDir);
+
+    expect(branchShortstat).toEqual({ additions: 3, deletions: 1 });
+    expect(uncommittedShortstat).toEqual({ additions: 2, deletions: 1 });
   });
 
   it("includes untracked file lines in shortstat additions", async () => {

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -63,6 +63,8 @@ const lastSuccessfulPullRequestStatus = new Map<string, PullRequestStatusResult>
 let shortstatCacheTtlMs = DEFAULT_SHORTSTAT_CACHE_TTL_MS;
 let shortstatCache = createShortstatCache(shortstatCacheTtlMs);
 const shortstatInFlight = new Map<string, Promise<CheckoutShortstat | null>>();
+let uncommittedShortstatCache = createShortstatCache(shortstatCacheTtlMs);
+const uncommittedShortstatInFlight = new Map<string, Promise<CheckoutShortstat | null>>();
 
 interface CheckoutReadCacheOptions {
   force?: boolean;
@@ -164,6 +166,10 @@ export function __resetCheckoutShortstatCacheForTests(): void {
   shortstatCacheTtlMs = DEFAULT_SHORTSTAT_CACHE_TTL_MS;
   shortstatCache = createShortstatCache(shortstatCacheTtlMs);
   shortstatInFlight.clear();
+  uncommittedShortstatCache.clear();
+  uncommittedShortstatCache.cancelTimer();
+  uncommittedShortstatCache = createShortstatCache(shortstatCacheTtlMs);
+  uncommittedShortstatInFlight.clear();
 }
 
 export function __setCheckoutShortstatCacheTtlForTests(ttlMs: number): void {
@@ -172,6 +178,10 @@ export function __setCheckoutShortstatCacheTtlForTests(ttlMs: number): void {
   shortstatCacheTtlMs = ttlMs;
   shortstatCache = createShortstatCache(ttlMs);
   shortstatInFlight.clear();
+  uncommittedShortstatCache.clear();
+  uncommittedShortstatCache.cancelTimer();
+  uncommittedShortstatCache = createShortstatCache(ttlMs);
+  uncommittedShortstatInFlight.clear();
 }
 
 interface CheckoutFileChange {
@@ -2501,6 +2511,82 @@ export async function getCheckoutShortstat(
   options?: CheckoutReadCacheOptions,
 ): Promise<CheckoutShortstat | null> {
   return getOrLoadCheckoutShortstat(cwd, context, options);
+}
+
+async function getCheckoutUncommittedShortstatUncached(
+  cwd: string,
+  context?: CheckoutContext,
+): Promise<CheckoutShortstat | null> {
+  if (context?.facts?.isGit === false) {
+    return null;
+  }
+  if (!context?.facts?.isGit) {
+    try {
+      await requireGitRepo(cwd);
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    const [{ stdout }, untrackedAdditions] = await Promise.all([
+      runGitCommand(["diff", "--shortstat", "HEAD", "--"], {
+        cwd,
+        envOverlay: READ_ONLY_GIT_ENV,
+      }),
+      countUntrackedAdditions(cwd),
+    ]);
+
+    const tracked = parseCheckoutShortstat(stdout);
+    if (tracked) {
+      return { additions: tracked.additions + untrackedAdditions, deletions: tracked.deletions };
+    }
+    if (untrackedAdditions > 0) {
+      return { additions: untrackedAdditions, deletions: 0 };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function getOrLoadCheckoutUncommittedShortstat(
+  cwd: string,
+  context?: CheckoutContext,
+  options?: CheckoutReadCacheOptions,
+): Promise<CheckoutShortstat | null> {
+  const cacheKey = getShortstatCacheKey(cwd);
+  if (!options?.force) {
+    const cached = uncommittedShortstatCache.get(cacheKey);
+    if (cached !== undefined) {
+      return Promise.resolve(cached);
+    }
+
+    const existing = uncommittedShortstatInFlight.get(cacheKey);
+    if (existing) {
+      return existing;
+    }
+  }
+
+  const load = getCheckoutUncommittedShortstatUncached(cwd, context)
+    .then((shortstat) => {
+      uncommittedShortstatCache.set(cacheKey, shortstat);
+      return shortstat;
+    })
+    .finally(() => {
+      uncommittedShortstatInFlight.delete(cacheKey);
+    });
+
+  uncommittedShortstatInFlight.set(cacheKey, load);
+  return load;
+}
+
+export async function getCheckoutUncommittedShortstat(
+  cwd: string,
+  context?: CheckoutContext,
+  options?: CheckoutReadCacheOptions,
+): Promise<CheckoutShortstat | null> {
+  return getOrLoadCheckoutUncommittedShortstat(cwd, context, options);
 }
 
 export function getCachedCheckoutShortstat(cwd: string): CheckoutShortstat | null | undefined {


### PR DESCRIPTION
## Summary

Fixes #2225.

This changes workspace `diffStat` to represent only uncommitted working-tree changes instead of reusing the branch/base shortstat. The archive warning now reports the local changes that archive may discard, while branch/PR diff behavior remains separate.

## Root Cause

`WorkspaceGitService` was feeding workspace descriptors from `getCheckoutShortstat`, whose semantics are branch/base comparison plus untracked additions. On feature branches whose PR content was already merged by content but not by ancestry, that made the archive dialog label committed branch diff as uncommitted work.

## Changes

- Added `getCheckoutUncommittedShortstat` for staged, unstaged, and untracked local changes.
- Updated workspace Git snapshots to use the uncommitted shortstat for descriptor `diffStat`.
- Kept existing branch/base shortstat behavior for checkout diff UI.
- Documented the descriptor `diffStat` contract in `docs/data-model.md`.

## Validation

- `npx vitest run packages/server/src/utils/checkout-git.test.ts packages/server/src/server/workspace-git-service.test.ts packages/server/src/server/workspace-git-service.primitive.test.ts --bail=1`
- `npm run lint`
- `npm run build:server`

`npm run typecheck` passes through protocol/client/server/app/relay/website/desktop, then fails in unrelated `@getpaseo/cli` implicit-any errors in `agent/ls`, `permit/*`, and `provider/ls`.
