### PR TITLE
feat(omp): add write approval mode

### DIFF
--- a/packages/protocol/src/provider-manifest.ts
+++ b/packages/protocol/src/provider-manifest.ts
@@ -152,6 +152,13 @@ export const OMP_MODES: AgentProviderModeDefinition[] = [
     isUnattended: true,
   },
   {
+    id: "write",
+    label: "Write Approval",
+    description: "Launches OMP with write approval mode — reads are free, writes require approval.",
+    icon: "ShieldAlert",
+    colorTier: "moderate",
+  },
+  {
     id: "ask",
     label: "Always Ask",
     description: "Launches OMP with always-ask approval mode for write and exec tools.",

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -78,7 +78,9 @@ describe("OMP agent client and session", () => {
     const omp = new OmpHarness();
     await omp.start({ modeId: "write" });
 
-    expect(omp.launchConfiguration()).toMatchObject({
+    expect(omp.launchConfiguration()).toEqual({
+      cwd: "/tmp/paseo-omp-agent-test",
+      protocolMode: "rpc-ui",
       modeId: "write",
       argv: ["omp", "--mode", "rpc-ui", "--approval-mode", "write", "--thinking", "medium"],
     });

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -74,6 +74,16 @@ describe("OMP agent client and session", () => {
     expect(omp.launchConfiguration().argv).toEqual(expect.arrayContaining(["--thinking", "max"]));
   });
 
+  test("launches with write approval mode", async () => {
+    const omp = new OmpHarness();
+    await omp.start({ modeId: "write" });
+
+    expect(omp.launchConfiguration()).toMatchObject({
+      modeId: "write",
+      argv: ["omp", "--mode", "rpc-ui", "--approval-mode", "write", "--thinking", "medium"],
+    });
+  });
+
   test("streams a prompt through completion", async () => {
     const omp = new OmpHarness();
     await omp.start();
@@ -282,6 +292,7 @@ describe("OMP agent client and session", () => {
 
     await expect(omp.availableModes()).resolves.toEqual([
       expect.objectContaining({ id: "full" }),
+      expect.objectContaining({ id: "write" }),
       expect.objectContaining({ id: "ask" }),
     ]);
     await expect(omp.commands()).resolves.toEqual(

--- a/packages/server/src/server/agent/providers/omp/provider-config.ts
+++ b/packages/server/src/server/agent/providers/omp/provider-config.ts
@@ -39,6 +39,11 @@ export function resolveOmpLaunchMode(
   switch (modeId ?? DEFAULT_OMP_MODE_ID) {
     case "full":
       return { modeId: "full", extraArgs: ["--approval-mode", "yolo", ...modelRoleArgs] };
+    case "write":
+      return {
+        modeId: "write",
+        extraArgs: ["--approval-mode", "write", ...modelRoleArgs],
+      };
     case "ask":
       return {
         modeId: "ask",

--- a/packages/server/src/server/daemon-e2e/agent-configs.ts
+++ b/packages/server/src/server/daemon-e2e/agent-configs.ts
@@ -62,6 +62,7 @@ export const agentConfigs = {
     thinkingOptionId: "medium",
     modes: {
       full: "full", // launches omp with yolo approval mode
+      write: "write", // launches omp with write approval mode
       ask: "ask", // launches omp with always-ask approval mode
     },
   },


### PR DESCRIPTION
### Linked issue

N/A — internal improvement.

### Type of change

- [x] New feature (with prior issue + design alignment)

### What does this PR do

Adds a **"Write Approval"** OMP mode between Full Access (`yolo`) and Always Ask (`always-ask`). Maps directly to OMP's built-in `--approval-mode write` — reads run without prompts, writes require an approval gate.

Previously OMP only exposed two extremes in Paseo: auto-approve everything or prompt for every tool call. This gives users a middle ground where file edits are gated but reads stay frictionless.

**Changes:**
- `packages/protocol/src/provider-manifest.ts` — new `"write"` entry in `OMP_MODES` array with `ShieldAlert` icon / moderate color tier
- `packages/server/src/server/agent/providers/omp/provider-config.ts` — `"write"` case in `resolveOmpLaunchMode` switch → passes `--approval-mode write`
- `packages/server/src/server/daemon-e2e/agent-configs.ts` — e2e test config mapping added

### How did you verify it

- Ran `npx vitest run packages/server/src/server/agent/providers/omp/agent.test.ts --bail=1` — 16 tests pass, including new integration test that verifies the generated argv contains `--approval-mode write`
- Updated existing `availableModes()` test expectation to include the new mode (was failing before update)
- `npm run typecheck --workspace=@getpaseo/protocol --workspace=@getpaseo/server` — clean
- `npm run lint` on all changed files — clean
- `npm run format` ran — correct formatting confirmed by pre-commit hook

From omp itself:
$ omp --help |grep approval-mode
      --approval-mode=<value>         Override tools.approvalMode for this session (always-ask|write|yolo)
$ omp --version
omp/17.0.5

Note: Pre-existing typecheck failures in `@getpaseo/app` and `@getpaseo/cli` workspaces (`DaemonClient` missing methods