### PR TITLE
fix(app): send readline byte sequences to the shell for macOS modifier keys

### DIFF
--- a/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
+++ b/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
@@ -20,6 +20,7 @@ import {
   mergeTerminalModifiers,
   normalizeDomTerminalKey,
   normalizeTerminalTransportKey,
+  resolveMacTerminalShortcut,
   shouldInterceptDomTerminalKey,
 } from "@/utils/terminal-keys";
 import { renderTerminalSnapshotToAnsi } from "./terminal-snapshot";
@@ -438,6 +439,13 @@ export class TerminalEmulatorRuntime {
         return true;
       }
 
+      // macOS Option/Cmd + arrows: xterm emits CSI modifier forms (\x1b[1;3D etc.)
+      // that macOS default readline doesn't bind. Remap to the readline-default
+      // word/line motion bytes so these shortcuts behave like a native terminal.
+      if (this.handleMacShortcut(event, normalizedKey)) {
+        return false;
+      }
+
       if (
         !shouldInterceptDomTerminalKey({
           key: normalizedKey,
@@ -722,6 +730,28 @@ export class TerminalEmulatorRuntime {
 
   blur(): void {
     this.terminal?.blur();
+  }
+
+  // macOS Option/Cmd + arrows remap. Returns true when the event was consumed
+  // (shortcut matched and the readline-default bytes were sent to the PTY).
+  private handleMacShortcut(event: KeyboardEvent, normalizedKey: string): boolean {
+    if (!isMac) {
+      return false;
+    }
+    const sequence = resolveMacTerminalShortcut({
+      key: normalizedKey,
+      ctrl: event.ctrlKey,
+      shift: event.shiftKey,
+      alt: event.altKey,
+      meta: event.metaKey,
+    });
+    if (sequence === null) {
+      return false;
+    }
+    this.callbacks.onInput?.(sequence);
+    event.preventDefault();
+    event.stopPropagation();
+    return true;
   }
 
   private refreshVisibleRows(): void {

--- a/packages/app/src/utils/terminal-keys.test.ts
+++ b/packages/app/src/utils/terminal-keys.test.ts
@@ -7,6 +7,7 @@ import {
   mergeTerminalModifiers,
   normalizeDomTerminalKey,
   normalizeTerminalTransportKey,
+  resolveMacTerminalShortcut,
   resolvePendingModifierDataInput,
   shouldInterceptDomTerminalKey,
 } from "./terminal-keys";
@@ -349,5 +350,54 @@ describe("terminal key helpers", () => {
       mode: "raw",
       clearPendingModifiers: false,
     });
+  });
+});
+
+describe("resolveMacTerminalShortcut", () => {
+  const none = { ctrl: false, shift: false, alt: false, meta: false };
+
+  it("maps Option+Left/Right to readline word-jump sequences", () => {
+    expect(resolveMacTerminalShortcut({ ...none, key: "ArrowLeft", alt: true })).toBe("\x1bb");
+    expect(resolveMacTerminalShortcut({ ...none, key: "ArrowRight", alt: true })).toBe("\x1bf");
+  });
+
+  it("maps Cmd+Left/Right to readline line-edge sequences", () => {
+    expect(resolveMacTerminalShortcut({ ...none, key: "ArrowLeft", meta: true })).toBe("\x01");
+    expect(resolveMacTerminalShortcut({ ...none, key: "ArrowRight", meta: true })).toBe("\x05");
+  });
+
+  it("returns null for plain arrows without a mac modifier", () => {
+    expect(resolveMacTerminalShortcut({ ...none, key: "ArrowLeft" })).toBeNull();
+    expect(resolveMacTerminalShortcut({ ...none, key: "ArrowRight" })).toBeNull();
+  });
+
+  it("ignores Shift so selection and other shift combos stay with xterm", () => {
+    expect(
+      resolveMacTerminalShortcut({ ...none, key: "ArrowLeft", alt: true, shift: true }),
+    ).toBeNull();
+    expect(
+      resolveMacTerminalShortcut({ ...none, key: "ArrowLeft", meta: true, shift: true }),
+    ).toBeNull();
+  });
+
+  it("ignores Ctrl so Ctrl+arrow stays with xterm", () => {
+    expect(
+      resolveMacTerminalShortcut({ ...none, key: "ArrowLeft", alt: true, ctrl: true }),
+    ).toBeNull();
+    expect(
+      resolveMacTerminalShortcut({ ...none, key: "ArrowLeft", meta: true, ctrl: true }),
+    ).toBeNull();
+  });
+
+  it("ignores combined Cmd+Option arrows", () => {
+    expect(
+      resolveMacTerminalShortcut({ ...none, key: "ArrowLeft", alt: true, meta: true }),
+    ).toBeNull();
+  });
+
+  it("ignores non-arrow keys even with Option or Cmd", () => {
+    expect(resolveMacTerminalShortcut({ ...none, key: "b", alt: true })).toBeNull();
+    expect(resolveMacTerminalShortcut({ ...none, key: "c", meta: true })).toBeNull();
+    expect(resolveMacTerminalShortcut({ ...none, key: "Backspace", meta: true })).toBeNull();
   });
 });

--- a/packages/app/src/utils/terminal-keys.test.ts
+++ b/packages/app/src/utils/terminal-keys.test.ts
@@ -395,9 +395,23 @@ describe("resolveMacTerminalShortcut", () => {
     ).toBeNull();
   });
 
-  it("ignores non-arrow keys even with Option or Cmd", () => {
+  it("maps Option+Backspace/Delete to readline word-kill sequences", () => {
+    expect(resolveMacTerminalShortcut({ ...none, key: "Backspace", alt: true })).toBe("\x1b\x7f");
+    expect(resolveMacTerminalShortcut({ ...none, key: "Delete", alt: true })).toBe("\x1bd");
+  });
+
+  it("maps Cmd+Backspace to unix-line-discard", () => {
+    expect(resolveMacTerminalShortcut({ ...none, key: "Backspace", meta: true })).toBe("\x15");
+  });
+
+  it("leaves plain Backspace/Delete to the terminal", () => {
+    expect(resolveMacTerminalShortcut({ ...none, key: "Backspace" })).toBeNull();
+    expect(resolveMacTerminalShortcut({ ...none, key: "Delete" })).toBeNull();
+  });
+
+  it("ignores non-remapped keys even with Option or Cmd", () => {
     expect(resolveMacTerminalShortcut({ ...none, key: "b", alt: true })).toBeNull();
     expect(resolveMacTerminalShortcut({ ...none, key: "c", meta: true })).toBeNull();
-    expect(resolveMacTerminalShortcut({ ...none, key: "Backspace", meta: true })).toBeNull();
+    expect(resolveMacTerminalShortcut({ ...none, key: "Tab", meta: true })).toBeNull();
   });
 });

--- a/packages/app/src/utils/terminal-keys.ts
+++ b/packages/app/src/utils/terminal-keys.ts
@@ -226,19 +226,22 @@ export interface TerminalShortcutInput {
   meta: boolean;
 }
 
-// macOS-standard terminal shortcuts that xterm.js's built-in translation does not
-// emit in a form readline understands. For modifier + arrow keys, xterm always
-// produces the CSI modifier-encoded form (Alt+Left -> `\x1b[1;3D`, Meta+Left ->
-// `\x1b[1;9D`), but the default bash/zsh readline on macOS binds word/line motion
-// to the legacy Esc-prefix and control forms instead:
-//   backward-word  = `\eb`   forward-word = `\ef`
-//   beginning-of-line = `\C-a` (\x01)   end-of-line = `\C-e` (\x05)
-// We intercept the modifier+arrow combos and return the readline-default bytes so
-// Option / Cmd + arrows jump by word / line out of the box.
+// macOS-standard terminal shortcuts that xterm.js does not emit in a form
+// readline understands. Mirrors iTerm2's "Natural Text Editing" preset: for
+// modifier + arrow keys xterm produces the CSI modifier-encoded form
+// (Alt+Left -> `\x1b[1;3D`, Meta+Left -> `\x1b[1;9D`), but the default bash/zsh
+// readline binds word/line motion and word/line deletion to the legacy
+// Esc-prefix and control forms instead:
+//   backward-word      = `\eb`     forward-word      = `\ef`
+//   backward-kill-word = `\e\x7f`  kill-word         = `\ed`
+//   beginning-of-line  = `\x01`    end-of-line       = `\x05`
+//   unix-line-discard  = `\x15` (delete to line start; whole line when at end)
+// We intercept the modifier + arrow/backspace/delete combos and return the
+// readline-default bytes so these shortcuts behave like a native terminal.
 //
-// `macOptionIsMeta: true` already covers Option + letter (Option+B -> `\x1bb`), so
-// this only fills the arrow-key gap. Returns null when the combo is not one we
-// remap, so the caller can let xterm handle it normally.
+// `macOptionIsMeta: true` already covers Option + letter (Option+B -> `\x1bb`),
+// so this only fills the motion/deletion gap. Returns null when the combo is
+// not one we remap, so the caller can let xterm handle it normally.
 export function resolveMacTerminalShortcut(input: TerminalShortcutInput): string | null {
   // Require exactly one of alt/meta and no shift/ctrl, so we don't clobber
   // selection (shift) or other modifier combos.
@@ -252,6 +255,8 @@ export function resolveMacTerminalShortcut(input: TerminalShortcutInput): string
         return "\x01"; // Ctrl-A: beginning-of-line
       case "ArrowRight":
         return "\x05"; // Ctrl-E: end-of-line
+      case "Backspace":
+        return "\x15"; // Ctrl-U: unix-line-discard (delete to line start)
     }
   } else {
     switch (input.key) {
@@ -259,6 +264,10 @@ export function resolveMacTerminalShortcut(input: TerminalShortcutInput): string
         return "\x1bb"; // Esc+b: backward-word
       case "ArrowRight":
         return "\x1bf"; // Esc+f: forward-word
+      case "Backspace":
+        return "\x1b\x7f"; // Esc+DEL: backward-kill-word
+      case "Delete":
+        return "\x1bd"; // Esc+d: kill-word (forward)
     }
   }
 

--- a/packages/app/src/utils/terminal-keys.ts
+++ b/packages/app/src/utils/terminal-keys.ts
@@ -217,3 +217,50 @@ export function resolvePendingModifierDataInput(args: {
     clearPendingModifiers: true,
   };
 }
+
+export interface TerminalShortcutInput {
+  key: string;
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+  meta: boolean;
+}
+
+// macOS-standard terminal shortcuts that xterm.js's built-in translation does not
+// emit in a form readline understands. For modifier + arrow keys, xterm always
+// produces the CSI modifier-encoded form (Alt+Left -> `\x1b[1;3D`, Meta+Left ->
+// `\x1b[1;9D`), but the default bash/zsh readline on macOS binds word/line motion
+// to the legacy Esc-prefix and control forms instead:
+//   backward-word  = `\eb`   forward-word = `\ef`
+//   beginning-of-line = `\C-a` (\x01)   end-of-line = `\C-e` (\x05)
+// We intercept the modifier+arrow combos and return the readline-default bytes so
+// Option / Cmd + arrows jump by word / line out of the box.
+//
+// `macOptionIsMeta: true` already covers Option + letter (Option+B -> `\x1bb`), so
+// this only fills the arrow-key gap. Returns null when the combo is not one we
+// remap, so the caller can let xterm handle it normally.
+export function resolveMacTerminalShortcut(input: TerminalShortcutInput): string | null {
+  // Require exactly one of alt/meta and no shift/ctrl, so we don't clobber
+  // selection (shift) or other modifier combos.
+  if (input.shift || input.ctrl || (input.alt && input.meta) || (!input.alt && !input.meta)) {
+    return null;
+  }
+
+  if (input.meta) {
+    switch (input.key) {
+      case "ArrowLeft":
+        return "\x01"; // Ctrl-A: beginning-of-line
+      case "ArrowRight":
+        return "\x05"; // Ctrl-E: end-of-line
+    }
+  } else {
+    switch (input.key) {
+      case "ArrowLeft":
+        return "\x1bb"; // Esc+b: backward-word
+      case "ArrowRight":
+        return "\x1bf"; // Esc+f: forward-word
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Core problem

When translating macOS modifier keys (Cmd/Option + arrow/Backspace/Delete) into the bytes written to the PTY, the terminal sends the **wrong form** — it emits the xterm CSI modifier-encoded sequence instead of the byte the shell's readline is actually bound to. As a result these shortcuts do nothing in the default bash/zsh on macOS.

The fix is, at its core, a **translation layer between macOS-conventional keys and shell readline standards**. The app translates macOS modifier combos into the byte sequences the shell's readline recognizes and writes them to the PTY, so the shortcuts work out of the box — with zero shell-side configuration.

## Root cause (transport is fine; the source bytes are wrong)

The app → PTY transport itself is fine (`onInput` writes raw bytes straight to the PTY). The problem is that xterm.js always produces the **CSI modifier-encoded form** for modifier + arrow keys:

- Option+Left → `\x1b[1;3D`, Cmd+Left → `\x1b[1;9D`

But the default bash/zsh readline on macOS **does not bind CSI sequences** — it binds the readline-standard forms (see `man readline`):

- word motion = `\eb` / `\ef`, line edges = `\x01` / `\x05`
- backward-kill-word = `\e\x7f` (M-Rubout), kill-word = `\ed`, unix-line-discard = `\x15`

`macOptionIsMeta: true` only covers Option + letter (Option+B → `\x1bb`); it has **no effect on arrow keys or Backspace** (those go through the CSI modifier-encoding path). So the bytes reaching the shell for these combos are sequences the shell doesn't understand.

## Fix

In `attachCustomKeyEventHandler`, before handing the event to xterm, intercept the macOS modifier combos and send the readline-standard bytes to the PTY instead (via `onInput`). This mirrors iTerm2's "Natural Text Editing" and Ghostty (the native-macOS-editing camp — the terminal does the translation, rather than offloading it to shell-side `bindkey` the way Kitty/Alacritty do).

| macOS shortcut | readline bytes sent to shell | readline action |
|---|---|---|
| Option+← / → | `\eb` / `\ef` | backward-word / forward-word |
| Cmd+← / → | `\x01` / `\x05` | beginning-of-line / end-of-line |
| Option+⌫ | `\e\x7f` | backward-kill-word |
| Option+⌦ | `\ed` | kill-word (forward) |
| Cmd+⌫ | `\x15` | unix-line-discard (delete to line start) |

## Design

- Gated on `isMac` only (Cmd/Option are macOS conventions); Shift/Ctrl combos (selection, Ctrl+arrow) are untouched and keep xterm's behavior.
- The runtime is shared by **web/Electron desktop** and the **native webview (iOS/iPad hardware keyboard)**, so one change covers both.
- Interception runs before `shouldInterceptDomTerminalKey` (the mobile modifier-bar path), so the two input paths don't interfere.
- On a hit it `return false` (xterm's "handled" contract for `attachCustomKeyEventHandler`), so xterm won't also emit its own CSI sequence into the PTY.

## Changes

- `packages/app/src/utils/terminal-keys.ts` — new pure function `resolveMacTerminalShortcut` (macOS combo → readline bytes)
- `packages/app/src/terminal/runtime/terminal-emulator-runtime.ts` — `handleMacShortcut` helper (intercepts before xterm and writes to the PTY)
- `packages/app/src/utils/terminal-keys.test.ts` — unit tests covering every combo plus boundaries

## Verification

- Unit tests 34/34 green (pure function across all combos, plus negatives: Shift / Ctrl / plain keys are not intercepted; Backspace/Delete with no modifier fall through to the normal path)
- typecheck / lint / format all clean; pre-commit hook passes
- Manual verification: dev desktop app against the local daemon, pressing Option/Cmd + arrows/Backspace confirms word-jump, line-edge, word-delete, and line-delete all reach the shell and trigger the expected readline action
