### PR TITLE
fix(codex): materialize toolSurface screenshots out of timeline entries

### DIFF
--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { mapCodexToolCallEnvelope, mapCodexToolCallFromThreadItem } from "./tool-call-mapper.js";
+import {
+  mapCodexToolCallEnvelope,
+  mapCodexToolCallFromThreadItem,
+  splitCodexMcpToolResultImages,
+} from "./tool-call-mapper.js";
 
 function expectMapped<T>(item: T | null): T {
   expect(item).not.toBeNull();
@@ -839,6 +843,119 @@ describe("codex tool-call mapper", () => {
       },
     });
     expect(JSON.stringify(item)).not.toContain("iVBORw0KGgo=");
+  });
+
+  it("drops codex toolSurface screenshot data urls from mcp tool output", () => {
+    const item = expectMapped(
+      mapCodexToolCallFromThreadItem({
+        type: "mcpToolCall",
+        id: "codex-tool-surface",
+        status: "completed",
+        server: "node_repl",
+        tool: "js",
+        arguments: { code: "await page.screenshot()" },
+        result: {
+          content: [{ type: "text", text: "navigated" }],
+          structuredContent: { ok: true },
+          _meta: {
+            "codex/toolSurface": {
+              kind: "browser",
+              screenshot: {
+                url: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ==",
+                width: 1280,
+                height: 720,
+              },
+            },
+            "codex/requestId": "req-42",
+          },
+        },
+      }),
+    );
+
+    expect(item).toEqual({
+      type: "tool_call",
+      callId: "codex-tool-surface",
+      name: "node_repl.js",
+      status: "completed",
+      error: null,
+      detail: {
+        type: "unknown",
+        input: { code: "await page.screenshot()" },
+        output: {
+          content: [{ type: "text", text: "navigated" }],
+          structuredContent: { ok: true },
+          _meta: {
+            "codex/toolSurface": {
+              kind: "browser",
+              screenshot: { width: 1280, height: 720 },
+            },
+            "codex/requestId": "req-42",
+          },
+        },
+      },
+    });
+    expect(JSON.stringify(item)).not.toContain("/9j/4AAQSkZJRgABAQ==");
+  });
+
+  it("hands codex toolSurface screenshots to the image materialization path", () => {
+    const { images } = splitCodexMcpToolResultImages({
+      content: [{ type: "text", text: "navigated" }],
+      _meta: {
+        "codex/toolSurface": {
+          screenshot: { url: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ==" },
+        },
+      },
+    });
+
+    expect(images).toEqual([{ data: "/9j/4AAQSkZJRgABAQ==", mimeType: "image/jpeg" }]);
+  });
+
+  it("extracts both toolSurface screenshots and mcp image content blocks", () => {
+    const { images, output } = splitCodexMcpToolResultImages({
+      content: [
+        { type: "text", text: "navigated" },
+        { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+      ],
+      _meta: {
+        "codex/toolSurface": {
+          screenshot: { url: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ==" },
+        },
+      },
+    });
+
+    expect(images).toEqual([
+      { data: "/9j/4AAQSkZJRgABAQ==", mimeType: "image/jpeg" },
+      { data: "iVBORw0KGgo=", mimeType: "image/png" },
+    ]);
+    expect(output).toEqual({
+      content: [
+        { type: "text", text: "navigated" },
+        { type: "text", text: "[image]" },
+      ],
+      _meta: { "codex/toolSurface": { screenshot: {} } },
+    });
+  });
+
+  it("leaves remote toolSurface screenshot urls untouched", () => {
+    const result = {
+      content: [{ type: "text", text: "navigated" }],
+      _meta: {
+        "codex/toolSurface": {
+          screenshot: { url: "https://example.com/shot.jpg", width: 800 },
+        },
+      },
+    };
+
+    expect(splitCodexMcpToolResultImages(result)).toEqual({ images: [], output: result });
+  });
+
+  it("leaves mcp tool results without a toolSurface screenshot unchanged", () => {
+    const result = {
+      content: [{ type: "text", text: "navigated" }],
+      _meta: { "codex/requestId": "req-42" },
+    };
+
+    expect(splitCodexMcpToolResultImages(result)).toEqual({ images: [], output: result });
   });
 
   it("normalizes codex paseo_voice.speak mcp calls and extracts spoken text", () => {

--- a/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
+++ b/packages/server/src/server/agent/providers/codex/tool-call-mapper.ts
@@ -635,13 +635,65 @@ function readMcpImageContent(block: unknown): CodexMcpToolResultImage | null {
   };
 }
 
-export function splitCodexMcpToolResultImages(result: unknown): CodexMcpToolResultImagesSplit {
-  if (!isRecord(result) || !Array.isArray(result.content)) {
+const CODEX_TOOL_SURFACE_META_KEY = "codex/toolSurface";
+const DATA_URL_IMAGE_PATTERN = /^data:(image\/[^;]+);base64,(.*)$/;
+
+function readDataUrlImage(value: unknown): CodexMcpToolResultImage | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const match = value.match(DATA_URL_IMAGE_PATTERN);
+  if (!match) {
+    return null;
+  }
+  return {
+    data: match[2],
+    mimeType: match[1],
+  };
+}
+
+// Codex browser tools return their screenshot as a base64 data URL under
+// `_meta["codex/toolSurface"]` rather than as an MCP `image` content block. Left inline it lands
+// verbatim in the timeline entry, where a single screenshot can exceed 0.6 MB and a tail page can
+// outgrow the relay message cap.
+function splitCodexToolSurfaceScreenshot(result: unknown): CodexMcpToolResultImagesSplit {
+  if (!isRecord(result) || !isRecord(result._meta)) {
     return { images: [], output: result };
   }
 
-  const images: CodexMcpToolResultImage[] = [];
-  const content = result.content.map((block) => {
+  const surface = result._meta[CODEX_TOOL_SURFACE_META_KEY];
+  if (!isRecord(surface) || !isRecord(surface.screenshot)) {
+    return { images: [], output: result };
+  }
+
+  const image = readDataUrlImage(surface.screenshot.url);
+  if (!image) {
+    return { images: [], output: result };
+  }
+
+  const { url: _url, ...screenshot } = surface.screenshot;
+  return {
+    images: [image],
+    output: {
+      ...result,
+      _meta: {
+        ...result._meta,
+        [CODEX_TOOL_SURFACE_META_KEY]: { ...surface, screenshot },
+      },
+    },
+  };
+}
+
+export function splitCodexMcpToolResultImages(result: unknown): CodexMcpToolResultImagesSplit {
+  const surfaceSplit = splitCodexToolSurfaceScreenshot(result);
+  const base = surfaceSplit.output;
+
+  if (!isRecord(base) || !Array.isArray(base.content)) {
+    return surfaceSplit;
+  }
+
+  const images: CodexMcpToolResultImage[] = [...surfaceSplit.images];
+  const content = base.content.map((block) => {
     const image = readMcpImageContent(block);
     if (!image) {
       return block;
@@ -650,14 +702,14 @@ export function splitCodexMcpToolResultImages(result: unknown): CodexMcpToolResu
     return { type: "text", text: "[image]" };
   });
 
-  if (images.length === 0) {
-    return { images, output: result };
+  if (images.length === surfaceSplit.images.length) {
+    return { images, output: base };
   }
 
   return {
     images,
     output: {
-      ...result,
+      ...base,
       content,
     },
   };


### PR DESCRIPTION
Fixes #2220.

## Problem

Codex browser tools return their screenshot as a base64 data URL under
`_meta["codex/toolSurface"].screenshot.url`, not as an MCP `image` content block.
`splitCodexMcpToolResultImages` only inspects `content[]`, so the data URL lands
verbatim in the timeline entry. A single screenshot can exceed 0.6 MB; on an
image-heavy session the tail page reached 12.2 MiB, which after base64/E2EE
wrapping (×4/3) exceeds a 10 MB relay message cap — the relay closes the daemon
socket with 1009 and the client with 1012, and the client cannot open any session
on that daemon until it is force-quit.

## Change

Chain a toolSurface split ahead of the existing `content[]` split so both sources
feed one result. Extracted images flow into the existing `materializeProviderImage`
path via `mcpToolResultImagesToTimeline`, exactly as MCP `content[]` images already
do, and render as a markdown reference to a content-hashed file.

No new mechanism — this only widens *where* images are looked for. Only the `url`
key is dropped; the rest of `_meta` and the screenshot's own metadata
(`width`/`height`) are preserved.

This also helps direct/local connections, where the same inline base64 is currently
paid as memory and render cost rather than as a disconnect.

## QA / testing evidence

Tested on **macOS arm64 only** (daemon 0.1.110, desktop 0.1.110, mobile 0.1.109).
The patch was built as 0.1.110 npm tarballs, installed on the machine holding the
affected session, and run as the daemon against that machine's real `~/.paseo`.

Measured against the same affected agent, via `fetch_agent_timeline_request`
(`direction: "tail"`, `projection: "projected"`) on the live daemon:

| | before | after |
|---|---|---|
| tail page | 12,810,194 B (200 entries) | **590,705 B** (200 entries) |
| reduction | — | **95.4%** |
| inline `data:image` | present throughout | **0** |
| materialized image refs | 0 | **64** |
| `toolSurface` metadata | present | **preserved** (71, minus `url`) |
| largest single entry | ~618 KB | **42 KB** |

An unbounded fetch (`limit: 0`) of the whole session is 756,490 B / 264 entries,
comfortably under the cap. The session that previously could not be opened at all
now opens, and the extracted screenshots render as images in remote clients.

Automated checks: 5 new unit tests in `tool-call-mapper.test.ts` (47/47 in that
file); full `@getpaseo/server` unit suite 3984 passed. One unrelated pre-existing
failure, `bootstrap-provider-availability.test.ts`, reproduces identically on an
unpatched `main` in this environment (it asserts Codex is unavailable, but a
`codex` binary is on PATH here). `typecheck`, `lint` and `format` all clean.

## Notes

Written with AI assistance; the diagnosis, deployment and the measurements above
are my own, run against a real affected session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)