### PR TITLE
feat: Background task tracking and UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ At the start of non-trivial work, list `docs/` and skim anything relevant to the
 | [docs/android.md](docs/android.md)                                 | App variants, local/cloud builds, EAS workflows                                                                                |
 | [docs/docker.md](docs/docker.md)                                   | Running the daemon and bundled web UI in Docker, volumes, agent images, security                                               |
 | [docs/release.md](docs/release.md)                                 | Release playbook, draft releases, completion checklist                                                                         |
+| [docs/fork-maintenance.md](docs/fork-maintenance.md)               | Fork rebase workflow, version suffix convention, conflict resolution                                                           |
 | [docs/terminal-activity.md](docs/terminal-activity.md)             | Terminal activity indicators — source-agnostic tracker, agent hook reporting, adding a new hook provider                       |
 | [SECURITY.md](SECURITY.md)                                         | Relay threat model, E2E encryption, DNS rebinding, agent auth                                                                  |
 

--- a/docs/fork-maintenance.md
+++ b/docs/fork-maintenance.md
@@ -1,0 +1,213 @@
+# Fork Maintenance Guide
+
+This document covers maintaining the `hydra-paseo` fork, including rebasing on upstream and managing the version suffix.
+
+## Version Suffix Convention
+
+All workspace packages in this fork include a git commit hash suffix in their version string:
+
+```
+{upstream-version}-hydra-h-{commit-short-hash}
+```
+
+**Example:** `0.1.109-hydra-h-ae5fc2d23`
+
+### How It Works
+
+1. Root `package.json` has version: `0.1.109-hydra`
+2. `scripts/sync-workspace-versions.mjs` appends `-h-{commit-short-hash}`
+3. All workspace packages get the full version with hash suffix
+4. Internal `@getpaseo/*` dependencies are updated to match
+
+### Version Resolution
+
+Each component reads its version from its own `package.json`:
+
+| Component | File | Function |
+|-----------|------|----------|
+| CLI | `packages/cli/src/version.ts` | `resolveCliVersion()` |
+| Web App | `packages/app/src/utils/app-version.ts` | `resolveAppVersion()` |
+| Daemon | `packages/server/src/server/daemon-version.ts` | `resolveDaemonVersion()` |
+
+## Rebase Workflow
+
+When upstream releases a new version, follow these steps to rebase the fork.
+
+### Prerequisites
+
+- Git configured with access to both `origin` (fork) and `upstream` (getpaseo/paseo)
+- Clean working directory (commit or stash changes first)
+
+### Step-by-Step Rebase
+
+```bash
+# 1. Navigate to the paseo directory
+cd external/paseo
+
+# 2. Fetch upstream changes
+git fetch upstream
+
+# 3. Start interactive rebase on upstream/main
+git rebase upstream/main
+
+# 4. Resolve conflicts (if any)
+# When conflicts occur in package.json files:
+#   - Take upstream version as base
+#   - Add -hydra suffix to the version
+#   - Update internal dependencies to match
+
+# 5. After resolving conflicts, continue rebase
+git add <resolved-files>
+git rebase --continue
+
+# 6. Once rebase completes, sync versions with hash
+node scripts/sync-workspace-versions.mjs
+
+# 7. Commit the synced versions
+git add packages/*/package.json
+git commit -m "chore: sync workspace versions with git hash suffix"
+
+# 8. Verify the versions
+grep '"version"' package.json packages/cli/package.json packages/server/package.json
+```
+
+### Conflict Resolution Pattern
+
+When resolving version conflicts in `package.json` files:
+
+**Before (conflict):**
+```json
+{
+  "name": "@getpaseo/cli",
+<<<<<<< HEAD
+  "version": "0.1.109",
+=======
+  "version": "0.1.107-hydra",
+>>>>>>> b66dadb99 (chore: rebase on v0.1.107, keep hydra patches)
+```
+
+**After (resolved):**
+```json
+{
+  "name": "@getpaseo/cli",
+  "version": "0.1.109-hydra",
+```
+
+For internal dependencies, update them to match:
+```json
+"dependencies": {
+  "@getpaseo/client": "0.1.109-hydra",
+  "@getpaseo/protocol": "0.1.109-hydra",
+  "@getpaseo/server": "0.1.109-hydra",
+}
+```
+
+### Automated Sync
+
+After rebasing, run the sync script to automatically:
+
+1. Get the current git commit hash
+2. Append `-h-{hash}` to all workspace versions
+3. Update all internal `@getpaseo/*` dependencies
+
+```bash
+# Sync versions (appends -h-{hash})
+node scripts/sync-workspace-versions.mjs
+
+# Or use npm script
+npm run version:sync-internal
+```
+
+## Common Scenarios
+
+### Scenario 1: New upstream patch release
+
+```bash
+git fetch upstream
+git rebase upstream/main
+# Resolve conflicts (take upstream version + -hydra suffix)
+git rebase --continue
+node scripts/sync-workspace-versions.mjs
+git add packages/*/package.json
+git commit -m "chore: sync workspace versions with git hash suffix"
+```
+
+### Scenario 2: New upstream minor/major release
+
+Same as patch release, but review upstream changelog for breaking changes:
+
+```bash
+git fetch upstream
+git log upstream/main..upstream/main --oneline  # Review changes
+git rebase upstream/main
+# Resolve conflicts and review code changes
+git rebase --continue
+node scripts/sync-workspace-versions.mjs
+git add packages/*/package.json
+git commit -m "chore: sync workspace versions with git hash suffix"
+```
+
+### Scenario 3: Adding hydra-specific patches
+
+```bash
+# Make your changes
+git add <files>
+git commit -m "feat: add hydra-specific feature"
+
+# Sync versions
+node scripts/sync-workspace-versions.mjs
+git add packages/*/package.json
+git commit -m "chore: sync workspace versions with git hash suffix"
+```
+
+## Version String Format
+
+### Components
+
+| Part | Example | Description |
+|------|---------|-------------|
+| Base version | `0.1.109` | Upstream semver |
+| Fork suffix | `-hydra` | Fork identifier |
+| Hash suffix | `-h-ae5fc2d23` | Git commit short hash |
+
+### Full Format
+
+```
+{major}.{minor}.{patch}-hydra-h-{commit-short-hash}
+```
+
+**Examples:**
+- `0.1.109-hydra-h-ae5fc2d23`
+- `0.2.0-hydra-h-b66dadb99`
+
+## Troubleshooting
+
+### Version not updating
+
+If the sync script doesn't update versions:
+
+1. Check you're in the correct directory (`external/paseo`)
+2. Verify git is available: `git rev-parse --short HEAD`
+3. Check root `package.json` has a valid version
+
+### Merge conflicts not resolving
+
+If conflicts persist:
+
+1. Abort the rebase: `git rebase --abort`
+2. Fetch latest upstream: `git fetch upstream`
+3. Try again: `git rebase upstream/main`
+
+### Hash suffix not appearing
+
+If versions don't have the hash suffix:
+
+1. Run sync script manually: `node scripts/sync-workspace-versions.mjs`
+2. Check git is available in the environment
+3. Verify the script completed without errors
+
+## References
+
+- Upstream repository: https://github.com/getpaseo/paseo
+- Fork repository: https://github.com/ddvnguyen/paseo
+- Version sync script: `scripts/sync-workspace-versions.mjs`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paseo",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.1-hydra",
   "private": true,
   "description": "Paseo: voice-controlled development environment for local AI coding agents",
   "keywords": [

--- a/packages/app/src/background-tasks/index.ts
+++ b/packages/app/src/background-tasks/index.ts
@@ -1,0 +1,6 @@
+export {
+  useBackgroundTaskStore,
+  refreshBackgroundTasks,
+  selectBackgroundTasksForAgent,
+} from "./store";
+export { useBackgroundTasksForAgent, useBackgroundTaskCountForAgent } from "./select";

--- a/packages/app/src/background-tasks/select.ts
+++ b/packages/app/src/background-tasks/select.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { useStoreWithEqualityFn } from "zustand/traditional";
+import equal from "fast-deep-equal";
+import { useSessionStore } from "@/stores/session-store";
+import {
+  refreshBackgroundTasks,
+  selectBackgroundTasksForAgent,
+  useBackgroundTaskStore,
+} from "./store";
+import type { BackgroundTaskDescriptorPayload } from "@getpaseo/protocol/messages";
+
+export function useBackgroundTasksForAgent(
+  serverId: string,
+  agentId: string,
+): BackgroundTaskDescriptorPayload[] {
+  const client = useSessionStore((state) => state.sessions[serverId]?.client ?? null);
+  const supported = useSessionStore(
+    (state) => state.sessions[serverId]?.serverInfo?.features?.backgroundTasks === true,
+  );
+
+  const tasks = useStoreWithEqualityFn(
+    useBackgroundTaskStore,
+    (state) => selectBackgroundTasksForAgent(state, serverId, agentId),
+    equal,
+  );
+
+  useEffect(() => {
+    if (!client || !supported || !agentId) return;
+    void refreshBackgroundTasks(client, serverId, agentId).catch(() => undefined);
+  }, [client, serverId, agentId, supported]);
+
+  return tasks;
+}
+
+export function useBackgroundTaskCountForAgent(serverId: string, agentId: string): number {
+  const tasks = useBackgroundTasksForAgent(serverId, agentId);
+  return tasks.filter((t) => t.status === "running").length;
+}

--- a/packages/app/src/background-tasks/store.test.ts
+++ b/packages/app/src/background-tasks/store.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useBackgroundTaskStore,
+  selectBackgroundTasksForAgent,
+  refreshBackgroundTasks,
+} from "./store";
+import type { BackgroundTaskDescriptorPayload } from "@getpaseo/protocol/messages";
+
+const SERVER = "test-server";
+const AGENT = "agent-1";
+
+function makeTask(
+  overrides: Partial<BackgroundTaskDescriptorPayload> = {},
+): BackgroundTaskDescriptorPayload {
+  return {
+    id: "task-1",
+    agentId: AGENT,
+    toolName: "background_bash",
+    command: "sleep 100",
+    status: "running",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    finishedAt: null,
+    exitCode: null,
+    outputPreview: null,
+    ...overrides,
+  };
+}
+
+describe("useBackgroundTaskStore", () => {
+  beforeEach(() => {
+    useBackgroundTaskStore.setState({ tasks: new Map() });
+  });
+
+  it("replaceList stores tasks sorted by startedAt", () => {
+    const task2 = makeTask({ id: "task-2", startedAt: "2026-01-01T00:00:01.000Z" });
+    const task1 = makeTask({ id: "task-1", startedAt: "2026-01-01T00:00:00.000Z" });
+
+    useBackgroundTaskStore.getState().replaceList(SERVER, AGENT, [task2, task1]);
+
+    const result = selectBackgroundTasksForAgent(useBackgroundTaskStore.getState(), SERVER, AGENT);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("task-1");
+    expect(result[1].id).toBe("task-2");
+  });
+
+  it("applyUpdate upsert adds a new task", () => {
+    const task = makeTask();
+    useBackgroundTaskStore.getState().applyUpdate(SERVER, {
+      kind: "upsert",
+      task,
+    });
+
+    const result = selectBackgroundTasksForAgent(useBackgroundTaskStore.getState(), SERVER, AGENT);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("task-1");
+    expect(result[0].status).toBe("running");
+  });
+
+  it("applyUpdate upsert updates existing task", () => {
+    const task = makeTask();
+    useBackgroundTaskStore.getState().applyUpdate(SERVER, { kind: "upsert", task });
+
+    const updated = makeTask({
+      id: "task-1",
+      status: "completed",
+      exitCode: 0,
+      finishedAt: "2026-01-01T00:01:00.000Z",
+    });
+    useBackgroundTaskStore.getState().applyUpdate(SERVER, { kind: "upsert", task: updated });
+
+    const result = selectBackgroundTasksForAgent(useBackgroundTaskStore.getState(), SERVER, AGENT);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("completed");
+    expect(result[0].exitCode).toBe(0);
+  });
+
+  it("applyUpdate remove deletes a task", () => {
+    const task = makeTask();
+    useBackgroundTaskStore.getState().applyUpdate(SERVER, { kind: "upsert", task });
+    useBackgroundTaskStore
+      .getState()
+      .applyUpdate(SERVER, { kind: "remove", agentId: AGENT, taskId: "task-1" });
+
+    const result = selectBackgroundTasksForAgent(useBackgroundTaskStore.getState(), SERVER, AGENT);
+    expect(result).toHaveLength(0);
+  });
+
+  it("selectBackgroundTasksForAgent returns empty array for unknown agent", () => {
+    const result = selectBackgroundTasksForAgent(
+      useBackgroundTaskStore.getState(),
+      SERVER,
+      "unknown",
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("replaceList for different agents are independent", () => {
+    const taskA = makeTask({ id: "task-a", agentId: "agent-A" });
+    const taskB = makeTask({ id: "task-b", agentId: "agent-B" });
+
+    useBackgroundTaskStore.getState().replaceList(SERVER, "agent-A", [taskA]);
+    useBackgroundTaskStore.getState().replaceList(SERVER, "agent-B", [taskB]);
+
+    expect(
+      selectBackgroundTasksForAgent(useBackgroundTaskStore.getState(), SERVER, "agent-A"),
+    ).toHaveLength(1);
+    expect(
+      selectBackgroundTasksForAgent(useBackgroundTaskStore.getState(), SERVER, "agent-B"),
+    ).toHaveLength(1);
+  });
+
+  it("replaceList replaces previous tasks", () => {
+    const old = makeTask({ id: "old" });
+    useBackgroundTaskStore.getState().replaceList(SERVER, AGENT, [old]);
+    expect(
+      selectBackgroundTasksForAgent(useBackgroundTaskStore.getState(), SERVER, AGENT),
+    ).toHaveLength(1);
+
+    const fresh = makeTask({ id: "fresh" });
+    useBackgroundTaskStore.getState().replaceList(SERVER, AGENT, [fresh]);
+    const result = selectBackgroundTasksForAgent(useBackgroundTaskStore.getState(), SERVER, AGENT);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("fresh");
+  });
+});
+
+describe("refreshBackgroundTasks", () => {
+  beforeEach(() => {
+    useBackgroundTaskStore.setState({ tasks: new Map() });
+  });
+
+  it("calls listBackgroundTasks and populates store", async () => {
+    const task1 = makeTask({ id: "bg-1" });
+    const task2 = makeTask({ id: "bg-2", status: "completed" });
+
+    const client = {
+      listBackgroundTasks: async () => ({
+        requestId: "req-1",
+        agentId: AGENT,
+        tasks: [task1, task2],
+        error: null,
+      }),
+    };
+
+    await refreshBackgroundTasks(client as never, SERVER, AGENT);
+
+    const result = selectBackgroundTasksForAgent(useBackgroundTaskStore.getState(), SERVER, AGENT);
+    expect(result).toHaveLength(2);
+  });
+
+  it("deduplicates concurrent requests for the same agent", async () => {
+    let callCount = 0;
+    const client = {
+      listBackgroundTasks: async () => {
+        callCount++;
+        return { requestId: "req-1", agentId: AGENT, tasks: [], error: null };
+      },
+    };
+
+    await Promise.all([
+      refreshBackgroundTasks(client as never, SERVER, AGENT),
+      refreshBackgroundTasks(client as never, SERVER, AGENT),
+    ]);
+
+    expect(callCount).toBe(1);
+  });
+});

--- a/packages/app/src/background-tasks/store.ts
+++ b/packages/app/src/background-tasks/store.ts
@@ -1,0 +1,105 @@
+import type {
+  BackgroundTaskDescriptorPayload,
+  SessionOutboundMessage,
+} from "@getpaseo/protocol/messages";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import { create } from "zustand";
+
+type BackgroundTaskUpdatePayload = Extract<
+  SessionOutboundMessage,
+  { type: "agent.background_tasks.update" }
+>["payload"];
+
+interface BackgroundTaskState {
+  tasks: Map<string, BackgroundTaskDescriptorPayload[]>;
+  replaceList(serverId: string, agentId: string, tasks: BackgroundTaskDescriptorPayload[]): void;
+  applyUpdate(serverId: string, payload: BackgroundTaskUpdatePayload): void;
+}
+
+function taskListKey(serverId: string, agentId: string): string {
+  return `${serverId}\0${agentId}`;
+}
+
+export const useBackgroundTaskStore = create<BackgroundTaskState>((set) => ({
+  tasks: new Map(),
+  replaceList(serverId, agentId, tasks) {
+    set((state) => {
+      const key = taskListKey(serverId, agentId);
+      const tasksMap = new Map(state.tasks);
+      tasksMap.set(
+        key,
+        [...tasks].sort((a, b) => a.startedAt.localeCompare(b.startedAt)),
+      );
+      return { tasks: tasksMap };
+    });
+  },
+  applyUpdate(serverId, payload) {
+    set((state) => {
+      if (payload.kind === "upsert") {
+        const { task } = payload;
+        const key = taskListKey(serverId, task.agentId);
+        const existing = state.tasks.get(key) ?? [];
+        const idx = existing.findIndex((t) => t.id === task.id);
+        const next = [...existing];
+        if (idx >= 0) {
+          next[idx] = task;
+        } else {
+          next.push(task);
+        }
+        next.sort((a, b) => a.startedAt.localeCompare(b.startedAt));
+        const tasksMap = new Map(state.tasks);
+        tasksMap.set(key, next);
+        return { tasks: tasksMap };
+      }
+      // remove
+      const { agentId, taskId } = payload;
+      const key = taskListKey(serverId, agentId);
+      const existing = state.tasks.get(key);
+      if (!existing) return state;
+      const next = existing.filter((t) => t.id !== taskId);
+      const tasksMap = new Map(state.tasks);
+      tasksMap.set(key, next);
+      return { tasks: tasksMap };
+    });
+  },
+}));
+
+type BackgroundTaskListClient = Pick<DaemonClient, "listBackgroundTasks">;
+
+const pendingListRequests = new WeakMap<BackgroundTaskListClient, Map<string, Promise<void>>>();
+
+export function refreshBackgroundTasks(
+  client: BackgroundTaskListClient,
+  serverId: string,
+  agentId: string,
+): Promise<void> {
+  const requestKey = `${serverId}\0${agentId}`;
+  let clientRequests = pendingListRequests.get(client);
+  if (!clientRequests) {
+    clientRequests = new Map();
+    pendingListRequests.set(client, clientRequests);
+  }
+  const pending = clientRequests.get(requestKey);
+  if (pending) return pending;
+
+  const request = client
+    .listBackgroundTasks(agentId)
+    .then((payload) => {
+      useBackgroundTaskStore.getState().replaceList(serverId, agentId, payload.tasks);
+      return undefined;
+    })
+    .finally(() => {
+      clientRequests?.delete(requestKey);
+    });
+  clientRequests.set(requestKey, request);
+  return request;
+}
+
+export function selectBackgroundTasksForAgent(
+  state: ReturnType<typeof useBackgroundTaskStore.getState>,
+  serverId: string,
+  agentId: string,
+): BackgroundTaskDescriptorPayload[] {
+  const key = taskListKey(serverId, agentId);
+  return state.tasks.get(key) ?? [];
+}

--- a/packages/app/src/background-tasks/track.tsx
+++ b/packages/app/src/background-tasks/track.tsx
@@ -1,0 +1,227 @@
+import { useCallback, useMemo, useState, type ReactElement } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import { ChevronDown, ChevronRight, SquareTerminal } from "lucide-react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { MAX_CONTENT_WIDTH } from "@/constants/layout";
+import type { Theme } from "@/styles/theme";
+import type { BackgroundTaskDescriptorPayload } from "@getpaseo/protocol/messages";
+
+const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedChevronRight = withUnistyles(ChevronRight);
+const ThemedSquareTerminal = withUnistyles(SquareTerminal);
+
+const foregroundMutedColorMapping = (theme: Theme) => ({
+  color: theme.colors.foregroundMuted,
+});
+
+function truncateCommand(command: string | null, maxLen = 60): string {
+  if (!command) return "(no command)";
+  const trimmed = command.trim();
+  if (trimmed.length <= maxLen) return trimmed;
+  return `${trimmed.slice(0, maxLen)}…`;
+}
+
+function formatElapsed(startedAt: string): string {
+  const ms = Date.now() - Date.parse(startedAt);
+  if (ms < 1000) return "<1s";
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${s % 60}s`;
+}
+
+export interface BackgroundTasksTrackProps {
+  tasks: BackgroundTaskDescriptorPayload[];
+}
+
+const TASKS_LIST_MAX_HEIGHT = 200;
+
+export function BackgroundTasksTrack({ tasks }: BackgroundTasksTrackProps): ReactElement | null {
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleExpanded = useCallback(() => {
+    setExpanded((current) => !current);
+  }, []);
+
+  const headerLabel = useMemo(() => {
+    const running = tasks.filter((t) => t.status === "running").length;
+    const total = tasks.length;
+    const parts = [`${total} ${total === 1 ? "background task" : "background tasks"}`];
+    if (running > 0) {
+      parts.push(`${running} running`);
+    }
+    return parts.join(" · ");
+  }, [tasks]);
+
+  const surfaceStyle = useMemo(
+    () => [styles.surface, expanded && styles.surfaceExpanded],
+    [expanded],
+  );
+
+  const headerContainerStyle = useMemo(
+    () => [styles.header, expanded ? styles.headerDivider : styles.headerCollapsed],
+    [expanded],
+  );
+
+  if (tasks.length === 0) {
+    return null;
+  }
+
+  return (
+    <View style={styles.outer} testID="background-tasks-track">
+      <View style={styles.track}>
+        <View style={surfaceStyle}>
+          <View style={headerContainerStyle}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={headerLabel}
+              testID="background-tasks-track-header"
+              onPress={toggleExpanded}
+              style={styles.headerToggle}
+            >
+              {expanded ? (
+                <ThemedChevronDown size={12} uniProps={foregroundMutedColorMapping} />
+              ) : (
+                <ThemedChevronRight size={12} uniProps={foregroundMutedColorMapping} />
+              )}
+              <Text style={styles.headerLabel} numberOfLines={1}>
+                {headerLabel}
+              </Text>
+            </Pressable>
+          </View>
+          {expanded ? (
+            <ScrollView
+              style={styles.scroll}
+              contentContainerStyle={styles.scrollContent}
+              showsVerticalScrollIndicator={false}
+              nestedScrollEnabled
+            >
+              {tasks.map((task) => (
+                <BackgroundTaskRow key={task.id} task={task} />
+              ))}
+            </ScrollView>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function BackgroundTaskRow({ task }: { task: BackgroundTaskDescriptorPayload }): ReactElement {
+  return (
+    <View style={styles.row}>
+      <StatusDot status={task.status} />
+      <ThemedSquareTerminal size={14} uniProps={foregroundMutedColorMapping} />
+      <View style={styles.rowContent}>
+        <Text style={styles.rowCommand} numberOfLines={1}>
+          {truncateCommand(task.command)}
+        </Text>
+        <Text style={styles.rowMeta} numberOfLines={1}>
+          {formatElapsed(task.startedAt)}
+          {task.exitCode != null ? ` · exit ${task.exitCode}` : ""}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const STATUS_DOT_STYLES: Record<string, string> = {
+  running: "#3b82f6",
+  completed: "#22c55e",
+  failed: "#ef4444",
+  cancelled: "#6b7280",
+};
+
+function StatusDot({ status }: { status: string }): ReactElement {
+  const dotStyle = useMemo(
+    () => ({
+      width: 8,
+      height: 8,
+      borderRadius: 4,
+      backgroundColor: STATUS_DOT_STYLES[status] ?? STATUS_DOT_STYLES.cancelled,
+    }),
+    [status],
+  );
+  return <View style={dotStyle} />;
+}
+
+const styles = StyleSheet.create((theme) => ({
+  outer: {
+    width: "100%",
+    alignItems: "center",
+    paddingHorizontal: theme.spacing[4],
+  },
+  track: {
+    width: "100%",
+    maxWidth: MAX_CONTENT_WIDTH,
+  },
+  surface: {
+    alignSelf: "stretch",
+    backgroundColor: theme.colors.surface1,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.borderAccent,
+    borderRadius: theme.borderRadius["2xl"],
+    overflow: "hidden",
+  },
+  surfaceExpanded: {
+    paddingBottom: theme.spacing[4],
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  headerToggle: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    paddingLeft: theme.spacing[3],
+    paddingRight: theme.spacing[1],
+    paddingVertical: theme.spacing[2],
+  },
+  headerCollapsed: {
+    paddingBottom: theme.spacing[3],
+  },
+  headerDivider: {
+    borderBottomWidth: theme.borderWidth[1],
+    borderBottomColor: theme.colors.border,
+  },
+  headerLabel: {
+    flexShrink: 1,
+    minWidth: 0,
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+  },
+  scroll: {
+    maxHeight: TASKS_LIST_MAX_HEIGHT,
+  },
+  scrollContent: {
+    paddingVertical: theme.spacing[1],
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[1],
+  },
+  rowContent: {
+    flex: 1,
+    minWidth: 0,
+  },
+  rowCommand: {
+    fontSize: theme.fontSize.xs,
+    fontFamily: "monospace",
+    color: theme.colors.foreground,
+  },
+  rowMeta: {
+    fontSize: 10,
+    color: theme.colors.foregroundMuted,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+}));

--- a/packages/app/src/components/agent-status-dot.tsx
+++ b/packages/app/src/components/agent-status-dot.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { View } from "react-native";
+import { Text, View } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import {
   AGENT_LIFECYCLE_STATUSES,
@@ -14,12 +14,14 @@ export function AgentStatusDot({
   attentionReason,
   pendingPermissionCount,
   showInactive = false,
+  backgroundTaskCount = 0,
 }: {
   status: string | null | undefined;
   requiresAttention: boolean | null | undefined;
   attentionReason?: "finished" | "error" | "permission" | null;
   pendingPermissionCount?: number;
   showInactive?: boolean;
+  backgroundTaskCount?: number;
 }) {
   const { theme } = useUnistyles();
 
@@ -42,7 +44,18 @@ export function AgentStatusDot({
     return null;
   }
 
-  return <AgentStatusDotView color={color} />;
+  return (
+    <View style={styles.container}>
+      <AgentStatusDotView color={color} />
+      {backgroundTaskCount > 0 ? (
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>
+            {backgroundTaskCount > 9 ? "9+" : backgroundTaskCount}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
 }
 
 function AgentStatusDotView({ color }: { color: string }) {
@@ -55,9 +68,29 @@ function isAgentLifecycleStatus(value: string): value is AgentLifecycleStatus {
 }
 
 const styles = StyleSheet.create((theme) => ({
+  container: {
+    position: "relative",
+  },
   dot: {
     width: 8,
     height: 8,
     borderRadius: theme.borderRadius.full,
+  },
+  badge: {
+    position: "absolute",
+    top: -4,
+    right: -8,
+    minWidth: 14,
+    height: 14,
+    borderRadius: 7,
+    backgroundColor: theme.colors.foregroundMuted,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 2,
+  },
+  badgeText: {
+    fontSize: 8,
+    fontWeight: "700",
+    color: theme.colors.surface1,
   },
 }));

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -65,6 +65,7 @@ import {
 } from "@/utils/host-routes";
 import {
   shouldShowSidebarHostLabels,
+  sortWorkspacesByRecent,
   type SidebarProjectEntry,
   type SidebarWorkspaceEntry,
   type SidebarWorkspacePlacement,
@@ -1642,6 +1643,15 @@ function ProjectBlock({
     [collapsed, project, supportsMultiplicityByServerId],
   );
 
+  const sortMode = useSidebarViewStore((state) => state.sortMode);
+
+  const sortedWorkspaces = useMemo(() => {
+    if (sortMode === "recent") {
+      return sortWorkspacesByRecent(project.workspaces, workspaceEntriesByKey);
+    }
+    return project.workspaces;
+  }, [project.workspaces, workspaceEntriesByKey, sortMode]);
+
   const active = isProjectSelectedByRoute({
     selection: activeWorkspaceSelection,
     project,
@@ -1786,7 +1796,7 @@ function ProjectBlock({
       projectChildren = (
         <DraggableList
           testID={`sidebar-workspace-list-${project.projectKey}`}
-          data={project.workspaces}
+          data={sortedWorkspaces}
           keyExtractor={workspaceKeyExtractor}
           renderItem={renderWorkspace}
           onDragEnd={handleWorkspaceDragEnd}

--- a/packages/app/src/components/sidebar/sidebar-display-preferences-menu.tsx
+++ b/packages/app/src/components/sidebar/sidebar-display-preferences-menu.tsx
@@ -14,7 +14,11 @@ import { HostStatusDot } from "@/components/host-status-dot";
 import { isWeb as platformIsWeb } from "@/constants/platform";
 import { useAppSettings, type WorkspaceTitleSource } from "@/hooks/use-settings";
 import { useHosts } from "@/runtime/host-runtime";
-import { useSidebarViewStore, type SidebarGroupMode } from "@/stores/sidebar-view-store";
+import {
+  useSidebarViewStore,
+  type SidebarGroupMode,
+  type SidebarSortMode,
+} from "@/stores/sidebar-view-store";
 
 const ThemedSettings2 = withUnistyles(Settings2);
 const filterColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
@@ -22,6 +26,11 @@ const filterColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMu
 const GROUP_MODE_ITEMS: Array<{ value: SidebarGroupMode; label: string }> = [
   { value: "project", label: "Project" },
   { value: "status", label: "Status" },
+];
+
+const SORT_MODE_ITEMS: Array<{ value: SidebarSortMode; label: string }> = [
+  { value: "recent", label: "Recent" },
+  { value: "title", label: "Title" },
 ];
 
 const WORKSPACE_TITLE_SOURCE_ITEMS: Array<{ value: WorkspaceTitleSource; label: string }> = [
@@ -36,8 +45,10 @@ interface DisplayPreferenceOption<Value extends string> {
 
 export function SidebarDisplayPreferencesMenu() {
   const groupMode = useSidebarViewStore((state) => state.groupMode);
+  const sortMode = useSidebarViewStore((state) => state.sortMode);
   const hostFilters = useSidebarViewStore((state) => state.hostFilters);
   const setGroupMode = useSidebarViewStore((state) => state.setGroupMode);
+  const setSortMode = useSidebarViewStore((state) => state.setSortMode);
   const toggleHostFilter = useSidebarViewStore((state) => state.toggleHostFilter);
   const clearHostFilters = useSidebarViewStore((state) => state.clearHostFilters);
   const hosts = useHosts();
@@ -51,6 +62,13 @@ export function SidebarDisplayPreferencesMenu() {
       setGroupMode(mode);
     },
     [setGroupMode],
+  );
+
+  const handleSortModeSelect = useCallback(
+    (mode: SidebarSortMode) => {
+      setSortMode(mode);
+    },
+    [setSortMode],
   );
 
   const handleWorkspaceTitleSourceSelect = useCallback(
@@ -92,6 +110,19 @@ export function SidebarDisplayPreferencesMenu() {
             isSelected={groupMode === item.value}
             testIDPrefix="sidebar-grouping"
             onSelect={handleSelectMode}
+          />
+        ))}
+        <DropdownMenuSeparator />
+        <View style={styles.menuHeader}>
+          <Text style={styles.menuHeaderLabel}>Sort by</Text>
+        </View>
+        {SORT_MODE_ITEMS.map((item) => (
+          <DisplayPreferenceMenuItem
+            key={item.value}
+            item={item}
+            isSelected={sortMode === item.value}
+            testIDPrefix="sidebar-sorting"
+            onSelect={handleSortModeSelect}
           />
         ))}
         {showHostFilter ? (

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -55,6 +55,7 @@ import { toErrorMessage } from "@/utils/error-messages";
 import { showProviderNoticeToast } from "@/utils/provider-notice-toast";
 import { applyCheckoutStatusUpdateFromEvent } from "@/git/checkout-status-cache";
 import { useProviderSubagentStore } from "@/subagents/provider-store";
+import { useBackgroundTaskStore } from "@/background-tasks/store";
 import { revalidateSessionAfterResume } from "@/contexts/session-resume-revalidation";
 
 // Re-export types from session-store and draft-store for backward compatibility
@@ -825,6 +826,11 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
       useProviderSubagentStore.getState().applyUpdate(serverId, message.payload);
     });
 
+    const unsubBackgroundTaskUpdate = client.on("agent.background_tasks.update", (message) => {
+      if (message.type !== "agent.background_tasks.update") return;
+      useBackgroundTaskStore.getState().applyUpdate(serverId, message.payload);
+    });
+
     const unsubScriptStatusUpdate = client.on("script_status_update", (message) => {
       if (message.type !== "script_status_update") return;
       setWorkspaces(serverId, (prev) => patchWorkspaceScripts(prev, message.payload));
@@ -1111,6 +1117,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
       unsubAgentStream();
       unsubAgentTimeline();
       unsubProviderSubagentUpdate();
+      unsubBackgroundTaskUpdate();
       unsubAgentAttention();
       unsubScriptStatusUpdate();
       unsubCheckoutStatusUpdate();

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -47,6 +47,10 @@ export interface SidebarWorkspaceEntry extends SidebarStatusWorkspacePlacement {
   archiveUnpushedCommitCount: number | null;
   scripts: WorkspaceDescriptor["scripts"];
   hasRunningScripts: boolean;
+  // Last activity timestamp from the root agent (attentionTimestamp ?? updatedAt).
+  // Always populated when agent activity exists, unlike statusEnteredAt which is
+  // null for "done" workspaces. Used by the sidebar sort-by-recent feature.
+  lastActivityAt?: Date | null;
 }
 
 export interface SidebarProjectEntry {
@@ -146,6 +150,7 @@ export function createSidebarWorkspaceEntry(input: {
 }): SidebarWorkspaceEntry {
   const projectKey = input.workspace.project?.projectKey ?? input.workspace.projectId;
   const effectiveStatus = deriveEffectiveWorkspaceStatus(input);
+  const rootAgentActivity = input.workspaceAgentActivity?.get(input.workspace.id);
   return {
     workspaceKey: `${input.serverId}:${input.workspace.id}`,
     serverId: input.serverId,
@@ -172,6 +177,7 @@ export function createSidebarWorkspaceEntry(input: {
     archiveUnpushedCommitCount: input.workspace.gitRuntime?.aheadOfOrigin ?? null,
     scripts: input.workspace.scripts,
     hasRunningScripts: input.workspace.scripts.some((script) => script.lifecycle === "running"),
+    lastActivityAt: rootAgentActivity?.enteredAt ?? null,
   };
 }
 

--- a/packages/app/src/hooks/use-sidebar-workspaces-list.ts
+++ b/packages/app/src/hooks/use-sidebar-workspaces-list.ts
@@ -6,7 +6,7 @@ import { useHostProjects } from "@/projects/host-projects";
 import { fetchAllWorkspaceDescriptors } from "@/projects/workspace-fetching";
 import { getHostRuntimeStore, useHostRegistryLoaded, useHosts } from "@/runtime/host-runtime";
 import { useSidebarOrderStore } from "@/stores/sidebar-order-store";
-import { useSidebarViewStore } from "@/stores/sidebar-view-store";
+import { useSidebarViewStore, type SidebarSortMode } from "@/stores/sidebar-view-store";
 import { shouldSuppressWorkspaceForLocalArchive } from "@/contexts/session-workspace-upserts";
 import {
   buildSidebarWorkspacePlacementModel,
@@ -42,6 +42,54 @@ const EMPTY_PROJECTS: SidebarProjectEntry[] = [];
 const EMPTY_WORKSPACES: SidebarWorkspacePlacement[] = [];
 const EMPTY_PROJECT_NAMES = new Map<string, string>();
 
+function sortWorkspacesByTitle(
+  workspaces: SidebarWorkspacePlacement[],
+): SidebarWorkspacePlacement[] {
+  return [...workspaces].sort((a, b) => {
+    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  });
+}
+
+function sortProjectsByTitle(projects: SidebarProjectEntry[]): SidebarProjectEntry[] {
+  return [...projects].sort((a, b) => {
+    return a.projectName.localeCompare(b.projectName, undefined, { sensitivity: "base" });
+  });
+}
+
+function applySortMode(
+  projects: SidebarProjectEntry[],
+  sortMode: SidebarSortMode,
+): SidebarProjectEntry[] {
+  if (sortMode === "title") {
+    const sortedProjects = sortProjectsByTitle(projects);
+    return sortedProjects.map((project) => {
+      const sortedWorkspaces = sortWorkspacesByTitle(project.workspaces);
+      return {
+        projectKey: project.projectKey,
+        projectName: project.projectName,
+        projectKind: project.projectKind,
+        iconWorkingDir: project.iconWorkingDir,
+        hosts: project.hosts,
+        workspaces: sortedWorkspaces,
+      };
+    });
+  }
+  return projects;
+}
+
+export function sortWorkspacesByRecent(
+  workspaces: SidebarWorkspacePlacement[],
+  entryMap: ReadonlyMap<string, SidebarWorkspaceEntry>,
+): SidebarWorkspacePlacement[] {
+  return [...workspaces].sort((a, b) => {
+    const entryA = entryMap.get(a.workspaceKey);
+    const entryB = entryMap.get(b.workspaceKey);
+    const timeA = entryA?.lastActivityAt?.getTime() ?? 0;
+    const timeB = entryB?.lastActivityAt?.getTime() ?? 0;
+    return timeB - timeA;
+  });
+}
+
 export interface SidebarWorkspacesListResult {
   workspacePlacements: SidebarWorkspacePlacement[];
   projects: SidebarProjectEntry[];
@@ -64,6 +112,7 @@ export function useSidebarWorkspacesList(options?: {
   const storeHostFilters = useSidebarViewStore((state) => state.hostFilters);
   const hostFilters = options?.hostFilters ?? storeHostFilters;
   const reconcileHostFilters = useSidebarViewStore((state) => state.reconcileHostFilters);
+  const sortMode = useSidebarViewStore((state) => state.sortMode);
   const isActive = options?.enabled !== false;
 
   const serverIds = useMemo(() => {
@@ -105,7 +154,10 @@ export function useSidebarWorkspacesList(options?: {
     [hostProjects],
   );
 
-  const projects = sidebarModel.projects.length > 0 ? sidebarModel.projects : EMPTY_PROJECTS;
+  const projects =
+    sidebarModel.projects.length > 0
+      ? applySortMode(sidebarModel.projects, sortMode)
+      : EMPTY_PROJECTS;
   const workspacePlacements =
     sidebarModel.workspaces.length > 0 ? sidebarModel.workspaces : EMPTY_WORKSPACES;
   const projectNamesByKey =

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -73,6 +73,8 @@ import {
   useSubagentsForParent,
 } from "@/subagents";
 import { SubagentsTrack } from "@/subagents/track";
+import { BackgroundTasksTrack } from "@/background-tasks/track";
+import { useBackgroundTasksForAgent } from "@/background-tasks/select";
 import type { PendingPermission } from "@/types/shared";
 import type { StreamItem } from "@/types/stream";
 import { getInitDeferred, getInitKey } from "@/utils/agent-initialization";
@@ -1435,8 +1437,11 @@ function ActiveAgentComposer({
     [isCompactComposerLayout, serverId, agentId],
   );
 
+  const backgroundTasks = useBackgroundTasksForAgent(serverId, agentId);
+
   return (
     <ReanimatedAnimated.View style={inputAreaStyle} onLayout={onInputAreaLayout}>
+      <BackgroundTasksTrack tasks={backgroundTasks} />
       <SubagentsTrack
         rows={subagentRows}
         onOpenSubagent={handleOpenSubagent}

--- a/packages/app/src/stores/sidebar-view-store.ts
+++ b/packages/app/src/stores/sidebar-view-store.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
 
 export type SidebarGroupMode = "project" | "status";
+export type SidebarSortMode = "title" | "recent";
 
 const SIDEBAR_VIEW_STORAGE_KEY = "sidebar-view";
 const LEGACY_SIDEBAR_GROUP_MODE_STORAGE_KEY = "sidebar-group-mode";
@@ -10,9 +11,11 @@ const SIDEBAR_VIEW_STORE_VERSION = 2;
 
 interface SidebarViewStoreState {
   groupMode: SidebarGroupMode;
+  sortMode: SidebarSortMode;
   // Empty means "all hosts". A non-empty list pins the sidebar to those hosts.
   hostFilters: string[];
   setGroupMode: (mode: SidebarGroupMode) => void;
+  setSortMode: (mode: SidebarSortMode) => void;
   toggleHostFilter: (serverId: string) => void;
   clearHostFilters: () => void;
   reconcileHostFilters: (serverIds: readonly string[]) => void;
@@ -20,11 +23,16 @@ interface SidebarViewStoreState {
 
 interface SidebarViewPersistedState {
   groupMode: SidebarGroupMode;
+  sortMode?: SidebarSortMode;
   hostFilters: string[];
 }
 
 function isSidebarGroupMode(value: unknown): value is SidebarGroupMode {
   return value === "project" || value === "status";
+}
+
+function isSidebarSortMode(value: unknown): value is SidebarSortMode {
+  return value === "title" || value === "recent";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -57,16 +65,17 @@ function readHostFilters(persistedState: Record<string, unknown>): string[] {
 
 export function migrateSidebarViewState(persistedState: unknown): SidebarViewPersistedState {
   if (!isRecord(persistedState)) {
-    return { groupMode: "project", hostFilters: [] };
+    return { groupMode: "project", sortMode: "recent", hostFilters: [] };
   }
 
   const legacyGroupMode = readLegacyGroupMode(persistedState);
   if (legacyGroupMode) {
-    return { groupMode: legacyGroupMode, hostFilters: [] };
+    return { groupMode: legacyGroupMode, sortMode: "recent", hostFilters: [] };
   }
 
   return {
     groupMode: isSidebarGroupMode(persistedState.groupMode) ? persistedState.groupMode : "project",
+    sortMode: isSidebarSortMode(persistedState.sortMode) ? persistedState.sortMode : "recent",
     hostFilters: readHostFilters(persistedState),
   };
 }
@@ -91,8 +100,10 @@ export const useSidebarViewStore = create<SidebarViewStoreState>()(
   persist(
     (set) => ({
       groupMode: "project",
+      sortMode: "recent",
       hostFilters: [],
       setGroupMode: (mode) => set({ groupMode: mode }),
+      setSortMode: (mode) => set({ sortMode: mode }),
       toggleHostFilter: (serverId) =>
         set((state) => ({
           hostFilters: state.hostFilters.includes(serverId)
@@ -119,6 +130,7 @@ export const useSidebarViewStore = create<SidebarViewStoreState>()(
       storage: createJSONStorage(createSidebarViewStorage),
       partialize: (state) => ({
         groupMode: state.groupMode,
+        sortMode: state.sortMode,
         hostFilters: state.hostFilters,
       }),
       migrate: migrateSidebarViewState,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/cli",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.1-hydra",
   "description": "Paseo CLI - control your AI coding agents from the command line",
   "bin": {
     "paseo": "bin/paseo"
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.0.0",
-    "@getpaseo/client": "0.2.0-beta.1",
-    "@getpaseo/protocol": "0.2.0-beta.1",
-    "@getpaseo/server": "0.2.0-beta.1",
+    "@getpaseo/client": "0.2.0-beta.1-hydra",
+    "@getpaseo/protocol": "0.2.0-beta.1-hydra",
+    "@getpaseo/server": "0.2.0-beta.1-hydra",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "mime-types": "^2.1.35",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/client",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.1-hydra",
   "description": "Paseo client SDK package",
   "files": [
     "dist",
@@ -35,8 +35,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@getpaseo/protocol": "0.2.0-beta.1",
-    "@getpaseo/relay": "0.2.0-beta.1",
+    "@getpaseo/protocol": "0.2.0-beta.1-hydra",
+    "@getpaseo/relay": "0.2.0-beta.1-hydra",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -19,6 +19,7 @@ import { validateWSOutboundMessage } from "@getpaseo/protocol/validation/ws-outb
 import type {
   AgentStreamEventPayload,
   AgentSnapshotPayload,
+  BackgroundTaskDescriptorPayload,
   ProjectPlacementPayload,
   AgentPermissionResolvedMessage,
   CreateAgentRequestMessage,
@@ -2683,6 +2684,37 @@ export class DaemonClient {
       options: { skipQueue: true },
       select: (response) =>
         response.type === "agent.provider_subagents.list.response" &&
+        response.payload.requestId === requestId
+          ? response.payload
+          : null,
+    });
+    if (payload.error) {
+      throw new Error(payload.error);
+    }
+    return payload;
+  }
+
+  async listBackgroundTasks(
+    agentId: string,
+    options: { requestId?: string; timeout?: number } = {},
+  ): Promise<{
+    requestId: string;
+    agentId: string;
+    tasks: BackgroundTaskDescriptorPayload[];
+    error: string | null;
+  }> {
+    const requestId = this.createRequestId(options.requestId);
+    const message = SessionInboundMessageSchema.parse({
+      type: "agent.background_tasks.list.request",
+      payload: { agentId, requestId },
+    });
+    const payload = await this.sendRequest({
+      requestId,
+      message,
+      timeout: options.timeout,
+      options: { skipQueue: true },
+      select: (response) =>
+        response.type === "agent.background_tasks.list.response" &&
         response.payload.requestId === requestId
           ? response.payload
           : null,

--- a/packages/highlight/package.json
+++ b/packages/highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/highlight",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.1-hydra",
   "files": [
     "dist",
     "!dist/**/*.map"

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/protocol",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.1-hydra",
   "description": "Paseo shared protocol schemas and wire types",
   "files": [
     "dist",

--- a/packages/protocol/src/client-capabilities.ts
+++ b/packages/protocol/src/client-capabilities.ts
@@ -21,6 +21,9 @@ export const CLIENT_CAPS = {
   // COMPAT(projectUpdates): added in v0.1.109, remove gate after 2027-01-15.
   projectUpdates: "project_updates",
   browserHost: "browser_host",
+  // COMPAT(backgroundTasks): added in v0.1.110. The daemon tracks and emits
+  // background bash task state for agents. Drop the gate when floor >= v0.1.110.
+  backgroundTasks: "background_tasks",
 } as const;
 
 export type ClientCapability = (typeof CLIENT_CAPS)[keyof typeof CLIENT_CAPS];

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2347,7 +2347,59 @@ export const HubExecutionAgentCreateRequestSchema = z.object({
 
 export type HubExecutionAgentCreateRequest = z.infer<typeof HubExecutionAgentCreateRequestSchema>;
 
+// ---------------------------------------------------------------------------
+// Background Task descriptors (bg-bash MCP + Claude native run_in_background)
+// ---------------------------------------------------------------------------
+
+export const BackgroundTaskDescriptorPayloadSchema = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  toolName: z.string(),
+  command: z.string().nullable(),
+  status: z.enum(["running", "completed", "failed", "cancelled"]),
+  startedAt: z.string(),
+  finishedAt: z.string().nullable(),
+  exitCode: z.number().nullable(),
+  outputPreview: z.string().nullable(),
+});
+
+export type BackgroundTaskDescriptorPayload = z.infer<typeof BackgroundTaskDescriptorPayloadSchema>;
+
+export const BackgroundTaskListRequestMessageSchema = z.object({
+  type: z.literal("agent.background_tasks.list.request"),
+  payload: z.object({
+    agentId: z.string(),
+    requestId: z.string(),
+  }),
+});
+
+export const BackgroundTaskListResponseMessageSchema = z.object({
+  type: z.literal("agent.background_tasks.list.response"),
+  payload: z.object({
+    requestId: z.string(),
+    agentId: z.string(),
+    tasks: z.array(BackgroundTaskDescriptorPayloadSchema),
+    error: z.string().nullable(),
+  }),
+});
+
+export const BackgroundTaskUpdateMessageSchema = z.object({
+  type: z.literal("agent.background_tasks.update"),
+  payload: z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("upsert"),
+      task: BackgroundTaskDescriptorPayloadSchema,
+    }),
+    z.object({
+      kind: z.literal("remove"),
+      agentId: z.string(),
+      taskId: z.string(),
+    }),
+  ]),
+});
+
 export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
+  BackgroundTaskListRequestMessageSchema,
   HubExecutionAgentCreateRequestSchema,
   BrowserAutomationExecuteResponseSchema,
   VoiceAudioChunkMessageSchema,
@@ -2730,6 +2782,8 @@ export const ServerInfoStatusPayloadSchema = z
         selectiveAgentTimeline: z.boolean().optional(),
         // COMPAT(stableProjectIdentity): added in v0.1.109, remove gate after 2027-01-15.
         stableProjectIdentity: z.boolean().optional(),
+        // COMPAT(backgroundTasks): added in v0.1.110, remove gate after 2027-01-16.
+        backgroundTasks: z.boolean().optional(),
       })
       .optional(),
   })
@@ -3484,6 +3538,10 @@ export const ProviderSubagentUpdateMessageSchema = z.object({
     }),
   ]),
 });
+
+// ---------------------------------------------------------------------------
+// Background Task messages
+// ---------------------------------------------------------------------------
 
 export const SetAgentTimelineSubscriptionResponseMessageSchema = z.object({
   type: z.literal("agent.timeline.set_subscription.response"),
@@ -4977,6 +5035,8 @@ export function parseHubExecutionOutboundMessage(value: unknown): HubExecutionOu
 export type DaemonUpdateProgressMessage = z.infer<typeof DaemonUpdateProgressMessageSchema>;
 
 export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
+  BackgroundTaskListResponseMessageSchema,
+  BackgroundTaskUpdateMessageSchema,
   HubExecutionAgentCreateResponseSchema,
   HubExecutionAgentUpdateSchema,
   HubExecutionAgentStreamSchema,
@@ -5565,6 +5625,7 @@ export const WSHelloMessageSchema = z.object({
       [CLIENT_CAPS.providerSubagents]: z.boolean().optional(),
       [CLIENT_CAPS.projectUpdates]: z.boolean().optional(),
       [CLIENT_CAPS.browserHost]: BrowserAutomationHostCapabilitySchema.optional(),
+      [CLIENT_CAPS.backgroundTasks]: z.boolean().optional(),
     })
     .passthrough()
     .optional(),

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/relay",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.1-hydra",
   "description": "Paseo relay for bridging daemon and client connections",
   "files": [
     "dist",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getpaseo/server",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.1-hydra",
   "description": "Paseo backend server",
   "files": [
     "dist/server",
@@ -67,10 +67,10 @@
     "@agentclientprotocol/sdk": "^0.17.1",
     "@anthropic-ai/claude-agent-sdk": "^0.3.214",
     "@anthropic-ai/sdk": "^0.104.2",
-    "@getpaseo/client": "0.2.0-beta.1",
-    "@getpaseo/highlight": "0.2.0-beta.1",
-    "@getpaseo/protocol": "0.2.0-beta.1",
-    "@getpaseo/relay": "0.2.0-beta.1",
+    "@getpaseo/client": "0.2.0-beta.1-hydra",
+    "@getpaseo/highlight": "0.2.0-beta.1-hydra",
+    "@getpaseo/protocol": "0.2.0-beta.1-hydra",
+    "@getpaseo/relay": "0.2.0-beta.1-hydra",
     "@isaacs/ttlcache": "^2.1.4",
     "@modelcontextprotocol/sdk": "^1.20.1",
     "@opencode-ai/sdk": "1.14.46",

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -5,6 +5,7 @@ import {
   AGENT_LIFECYCLE_STATUSES,
   type AgentLifecycleStatus,
 } from "@getpaseo/protocol/agent-lifecycle";
+import type { BackgroundTaskDescriptorPayload } from "@getpaseo/protocol/messages";
 import {
   getParentAgentIdFromLabels,
   isDelegatedAgent,
@@ -341,6 +342,10 @@ interface ManagedAgentBase {
    * User-defined labels for categorizing agents (e.g., { surface: "workspace" }).
    */
   labels: Record<string, string>;
+  /**
+   * Tracked background bash tasks (bg-bash MCP + Claude native run_in_background).
+   */
+  backgroundTasks: Map<string, BackgroundTaskDescriptorPayload>;
 }
 
 type ManagedAgentWithSession = ManagedAgentBase & {
@@ -989,6 +994,194 @@ export class AgentManager {
     return this.providerSubagents.fetchTimeline(parentAgentId, subagentId, options);
   }
 
+  // ---------------------------------------------------------------------------
+  // Background task management
+  // ---------------------------------------------------------------------------
+
+  listBackgroundTasks(agentId: string): BackgroundTaskDescriptorPayload[] {
+    const agent = this.requireAgent(agentId);
+    return [...agent.backgroundTasks.values()].sort((a, b) =>
+      a.startedAt.localeCompare(b.startedAt),
+    );
+  }
+
+  upsertBackgroundTask(agentId: string, task: BackgroundTaskDescriptorPayload): void {
+    const agent = this.requireAgent(agentId);
+    agent.backgroundTasks.set(task.id, task);
+    this.dispatch({
+      type: "agent_state",
+      agent,
+    });
+  }
+
+  removeBackgroundTask(agentId: string, taskId: string): void {
+    const agent = this.requireAgent(agentId);
+    if (agent.backgroundTasks.delete(taskId)) {
+      this.dispatch({
+        type: "agent_state",
+        agent,
+      });
+    }
+  }
+
+  private interceptBackgroundTaskFromToolCall(
+    agent: ActiveManagedAgent,
+    item: Extract<AgentTimelineItem, { type: "tool_call" }>,
+  ): void {
+    const toolName = item.name;
+    const input = item.input as Record<string, unknown> | null | undefined;
+
+    // Detect bg-bash MCP tools (mcp__bg_bash__background_bash, etc.)
+    if (toolName.includes("bg_bash") || toolName.includes("background_bash")) {
+      this.handleBgBashToolCall(agent, item, input);
+      return;
+    }
+
+    // Detect Claude native Bash with run_in_background: true
+    if (toolName === "Bash" && input && typeof input === "object") {
+      const runInBackground = (input as Record<string, unknown>).run_in_background;
+      if (runInBackground === true || runInBackground === "true") {
+        const command = typeof input.command === "string" ? input.command : null;
+        const task: BackgroundTaskDescriptorPayload = {
+          id: item.callId ?? `bg-${Date.now()}`,
+          agentId: agent.id,
+          toolName: "Bash",
+          command,
+          status: "running",
+          startedAt: new Date().toISOString(),
+          finishedAt: null,
+          exitCode: null,
+          outputPreview: null,
+        };
+        this.upsertBackgroundTask(agent.id, task);
+      }
+    }
+  }
+
+  private handleBgBashToolCall(
+    agent: ActiveManagedAgent,
+    item: Extract<AgentTimelineItem, { type: "tool_call" }>,
+    input: Record<string, unknown> | null | undefined,
+  ): void {
+    if (!input || typeof input !== "object") {
+      return;
+    }
+
+    const toolName = item.name;
+
+    // background_bash tool - start mode (has command) or re-invoke mode (has job_id)
+    if (toolName.includes("background_bash")) {
+      const jobId = typeof input.job_id === "string" ? input.job_id : null;
+      const command = typeof input.command === "string" ? input.command : null;
+
+      if (command && !jobId) {
+        // Start mode - create a new background task
+        const task: BackgroundTaskDescriptorPayload = {
+          id: `bg-bash-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          agentId: agent.id,
+          toolName: "background_bash",
+          command,
+          status: "running",
+          startedAt: new Date().toISOString(),
+          finishedAt: null,
+          exitCode: null,
+          outputPreview: null,
+        };
+        this.upsertBackgroundTask(agent.id, task);
+      } else if (jobId) {
+        // Re-invoke mode - check result in tool output
+        const existingTask = this.findBackgroundTaskByCommand(agent.id, null, jobId);
+        if (existingTask && item.output) {
+          this.updateBackgroundTaskFromOutput(agent.id, existingTask.id, item.output);
+        }
+      }
+    }
+
+    // bash_status tool - update task status
+    if (toolName.includes("bash_status") && typeof input.job_id === "string") {
+      const existingTask = agent.backgroundTasks.get(input.job_id);
+      if (existingTask && item.output != null) {
+        this.updateBackgroundTaskFromOutput(agent.id, existingTask.id, item.output);
+      }
+    }
+
+    // bash_cancel tool - mark task as cancelled
+    if (toolName.includes("bash_cancel") && typeof input.job_id === "string") {
+      const existingTask = agent.backgroundTasks.get(input.job_id);
+      if (existingTask && existingTask.status === "running") {
+        const updated: BackgroundTaskDescriptorPayload = {
+          ...existingTask,
+          status: "cancelled",
+          finishedAt: new Date().toISOString(),
+        };
+        this.upsertBackgroundTask(agent.id, updated);
+      }
+    }
+  }
+
+  private findBackgroundTaskByCommand(
+    agentId: string,
+    command: string | null,
+    jobId?: string,
+  ): BackgroundTaskDescriptorPayload | undefined {
+    const agent = this.agents.get(agentId);
+    if (!agent) return undefined;
+
+    for (const task of agent.backgroundTasks.values()) {
+      if (task.status !== "running") continue;
+      if (jobId && task.id.includes(jobId)) return task;
+      if (command && task.command === command) return task;
+    }
+    return undefined;
+  }
+
+  private updateBackgroundTaskFromOutput(agentId: string, taskId: string, output: unknown): void {
+    const agent = this.agents.get(agentId);
+    if (!agent) return;
+
+    const task = agent.backgroundTasks.get(taskId);
+    if (!task || task.status !== "running") return;
+
+    const outputText = typeof output === "string" ? output : JSON.stringify(output);
+
+    // Parse output for status information
+    let status: BackgroundTaskDescriptorPayload["status"] = task.status;
+    let exitCode: number | null = null;
+    let finishedAt: string | null = null;
+
+    if (outputText.includes('"status":') || outputText.includes("'status':")) {
+      // JSON-like output from bg-bash
+      if (outputText.includes('"completed"') || outputText.includes("'completed'")) {
+        status = "completed";
+        finishedAt = new Date().toISOString();
+      } else if (outputText.includes('"failed"') || outputText.includes("'failed'")) {
+        status = "failed";
+        finishedAt = new Date().toISOString();
+      } else if (outputText.includes('"cancelled"') || outputText.includes("'cancelled'")) {
+        status = "cancelled";
+        finishedAt = new Date().toISOString();
+      }
+    }
+
+    // Try to extract exit code
+    const exitCodeMatch = outputText.match(/"exit_code"\s*:\s*(\d+)/);
+    if (exitCodeMatch) {
+      exitCode = parseInt(exitCodeMatch[1], 10);
+    }
+
+    // Extract output preview (first 200 chars)
+    const outputPreview = outputText.slice(0, 200);
+
+    const updated: BackgroundTaskDescriptorPayload = {
+      ...task,
+      status,
+      exitCode,
+      finishedAt,
+      outputPreview,
+    };
+    this.upsertBackgroundTask(agentId, updated);
+  }
+
   createAgent(
     config: AgentSessionConfig,
     agentId: string | undefined,
@@ -1326,6 +1519,7 @@ export class AgentManager {
     const closedAgent = this.prepareAgentForClosure(agent, "agent closed");
     await agent.session.close();
     this.timelineStore.delete(agentId);
+    agent.backgroundTasks.clear();
     for (const event of this.providerSubagents.deleteParent(agentId)) {
       this.dispatch({ type: "provider_subagent", event });
     }
@@ -1460,6 +1654,7 @@ export class AgentManager {
         attention: { requiresAttention: false },
         internal: record.internal,
         labels: record.labels,
+        backgroundTasks: new Map(),
       },
     });
   }
@@ -2763,6 +2958,7 @@ export class AgentManager {
       attention: resolveInitialAttention(options?.attention),
       internal: config.internal ?? false,
       labels: options?.labels ?? {},
+      backgroundTasks: new Map(),
     } as ActiveManagedAgent;
   }
 
@@ -3357,6 +3553,11 @@ export class AgentManager {
       flags.shouldDispatchEvent = false;
       flags.shouldNotifyWaiters = false;
       return;
+    }
+
+    // Intercept bg-bash MCP tool calls for background task tracking
+    if (event.item.type === "tool_call") {
+      this.interceptBackgroundTaskFromToolCall(agent, event.item);
     }
 
     if (options?.fromHistory) {

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -146,7 +146,9 @@ export interface StartCreatedAgentInitialPromptParams {
   logger: Logger;
 }
 
-const AGENT_RUN_START_TIMEOUT_MS = 15_000;
+// HYDRA PATCH: Increase from 15s to 40s for relay latency tolerance.
+// With relay transport, agent creation takes ~16-17s (server startup + relay overhead).
+const AGENT_RUN_START_TIMEOUT_MS = 40_000;
 
 export async function waitForAgentRunStartWithTimeout(
   agentManager: AgentManager,

--- a/packages/server/src/server/agent/mcp-server.ts
+++ b/packages/server/src/server/agent/mcp-server.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
@@ -9,6 +10,53 @@ import type {
 import { addModelVisibleStructuredContent } from "./tools/paseo-tool-serialization.js";
 import { createPaseoToolCatalog, type PaseoToolHostDependencies } from "./tools/paseo-tools.js";
 import type { PaseoToolResult } from "./tools/types.js";
+
+// HYDRA PATCH: Pre-parse stringified discriminated union args at the MCP layer.
+// LLMs sometimes send complex object args as JSON strings (e.g. target="{...}").
+// The MCP SDK validates args with Zod before they reach the tool handler,
+// so this preprocessing must happen here to prevent InvalidParams errors.
+function preprocessMcpToolArgs(input: unknown): unknown {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return input;
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (typeof value === "string" && value.length > 1) {
+      const trimmed = value.trim();
+      if (
+        (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+        (trimmed.startsWith("[") && trimmed.endsWith("]"))
+      ) {
+        try {
+          result[key] = JSON.parse(trimmed);
+          continue;
+        } catch {
+          // Not valid JSON, keep as-is
+        }
+      }
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+function wrapInputSchemaWithPreprocessing(inputSchema: unknown): z.ZodType {
+  if (!inputSchema) {
+    return z.object({});
+  }
+  if (
+    typeof inputSchema === "object" &&
+    inputSchema !== null &&
+    typeof (inputSchema as { safeParseAsync?: unknown }).safeParseAsync === "function"
+  ) {
+    return z.preprocess(preprocessMcpToolArgs, inputSchema as z.ZodType);
+  }
+  // Raw shape — wrap with preprocess then passthrough
+  return z.preprocess(
+    preprocessMcpToolArgs,
+    z.object(inputSchema as z.ZodRawShape).passthrough(),
+  );
+}
 
 export type AgentMcpServerOptions = PaseoToolHostDependencies;
 
@@ -41,7 +89,7 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
       {
         title: tool.title,
         description: tool.description,
-        inputSchema: tool.inputSchema,
+        inputSchema: wrapInputSchemaWithPreprocessing(tool.inputSchema),
       },
       async (args: unknown, context?: McpToolContext) =>
         toMcpToolResult(await catalog.executeTool(tool.name, args, { signal: context?.signal })),

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -437,18 +437,47 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
   const childLogger = logger.child({ module: "agent", component: "paseo-tool-catalog" });
   const callerContext = callerAgentId ? (resolveCallerContext?.(callerAgentId) ?? null) : null;
 
+  // HYDRA PATCH: LLMs sometimes send discriminated union args as JSON strings
+  // (e.g. target="{\"kind\":\"checkout-branch\"}" instead of target={kind:"checkout-branch"}).
+  // This pre-parses any string values that look like JSON objects/arrays.
+  const preprocessStringifiedArgs = (input: unknown): unknown => {
+    if (typeof input !== "object" || input === null) {
+      return input;
+    }
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+      if (typeof value === "string" && value.length > 1) {
+        const trimmed = value.trim();
+        if (
+          (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+          (trimmed.startsWith("[") && trimmed.endsWith("]"))
+        ) {
+          try {
+            result[key] = JSON.parse(trimmed);
+            continue;
+          } catch {
+            // Not valid JSON, keep as-is
+          }
+        }
+      }
+      result[key] = value;
+    }
+    return result;
+  };
+
   const parseToolInput = async (tool: PaseoToolDefinition, input: unknown): Promise<unknown> => {
     const inputSchema = tool.inputSchema;
     if (!inputSchema) {
       return input;
     }
+    const preprocessed = preprocessStringifiedArgs(input);
     const schema =
       typeof inputSchema === "object" &&
       inputSchema !== null &&
       typeof (inputSchema as { safeParseAsync?: unknown }).safeParseAsync === "function"
         ? (inputSchema as z.ZodType)
         : z.object(inputSchema as z.ZodRawShape).passthrough();
-    return schema.parseAsync(input);
+    return schema.parseAsync(preprocessed);
   };
 
   const tools = new Map<string, PaseoToolDefinition>();

--- a/packages/server/src/server/pid-lock.ts
+++ b/packages/server/src/server/pid-lock.ts
@@ -160,7 +160,10 @@ async function writeNewPidLock(pidPath: string, lockInfo: PidLockInfo): Promise<
         raceLock,
       );
     }
-    throw new PidLockError("Failed to acquire PID lock due to race condition");
+    // File exists but is empty or invalid (e.g., from a crashed process) — treat as stale and retry.
+    await unlink(pidPath).catch(() => {});
+    await writeNewPidLock(pidPath, lockInfo);
+    return;
   } finally {
     await fd?.close();
   }
@@ -181,13 +184,16 @@ export async function acquirePidLock(
   // Try to read existing lock
   const existingLock = await readPidLock(pidPath);
 
-  // Check if existing lock is stale
+  // Check if existing lock is stale or invalid (empty/corrupted file)
   const lockOwnerPid = resolveOwnerPid(options?.ownerPid);
   if (existingLock) {
     const result = await clearExistingPidLock(pidPath, existingLock, lockOwnerPid, options);
     if (result === "already_owned") {
       return;
     }
+  } else if (existsSync(pidPath)) {
+    // File exists but is invalid — remove stale lock file
+    await unlink(pidPath).catch(() => {});
   }
 
   // Create new lock with exclusive flag

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1708,6 +1708,8 @@ export class Session {
         return this.handleProviderSubagentListRequest(msg);
       case "agent.provider_subagents.timeline.get.request":
         return this.handleProviderSubagentTimelineRequest(msg);
+      case "agent.background_tasks.list.request":
+        return this.handleBackgroundTaskListRequest(msg);
       case "agent.timeline.set_subscription.request": {
         const agentIds = [...new Set(msg.agentIds)].sort();
         if (
@@ -5831,6 +5833,32 @@ export class Session {
           requestId: msg.requestId,
           parentAgentId: msg.parentAgentId,
           subagents: [],
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+
+  private async handleBackgroundTaskListRequest(
+    msg: Extract<SessionInboundMessage, { type: "agent.background_tasks.list.request" }>,
+  ): Promise<void> {
+    try {
+      this.emit({
+        type: "agent.background_tasks.list.response",
+        payload: {
+          requestId: msg.payload.requestId,
+          agentId: msg.payload.agentId,
+          tasks: this.agentManager.listBackgroundTasks(msg.payload.agentId),
+          error: null,
+        },
+      });
+    } catch (error) {
+      this.emit({
+        type: "agent.background_tasks.list.response",
+        payload: {
+          requestId: msg.payload.requestId,
+          agentId: msg.payload.agentId,
+          tasks: [],
           error: error instanceof Error ? error.message : String(error),
         },
       });

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1416,6 +1416,8 @@ export class VoiceAssistantWebSocketServer {
         selectiveAgentTimeline: true,
         // COMPAT(stableProjectIdentity): added in v0.1.109, remove gate after 2027-01-15.
         stableProjectIdentity: true,
+        // COMPAT(backgroundTasks): added in v0.1.110, remove gate after 2027-01-16.
+        backgroundTasks: true,
       },
     };
   }

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# deploy-production.sh — Build and deploy paseo to production systemd service.
+# Usage: ./scripts/deploy-production.sh
+#
+# What it does:
+# 1. Pull latest from origin/hydra-paseo
+# 2. npm install
+# 3. Build server + web app (skips desktop/mobile packaging)
+# 4. Copy web UI dist to server expected location
+# 5. Restart systemd service
+# 6. Verify health
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WEB_UI_SRC="$REPO_ROOT/packages/app/dist"
+WEB_UI_DEST="$REPO_ROOT/packages/server/dist/server/web-ui"
+
+echo "=== Paseo Production Deploy ==="
+echo "Repo: $REPO_ROOT"
+
+# 1. Pull latest
+echo ""
+echo "[1/6] Pulling latest from origin/hydra-paseo..."
+cd "$REPO_ROOT"
+git pull origin hydra-paseo
+
+# 2. Install deps
+echo ""
+echo "[2/6] Installing dependencies..."
+npm install --prefer-offline
+
+# 3. Build server and web app only (skip desktop/mobile)
+echo ""
+echo "[3/6] Building server and web app..."
+npm run build --workspace=@getpaseo/highlight
+npm run build --workspace=@getpaseo/relay
+npm run build --workspace=@getpaseo/protocol
+npm run build --workspace=@getpaseo/client
+npm run build --workspace=@getpaseo/server
+npm run build --workspace=@getpaseo/cli
+
+# Build the web app (expo export)
+echo ""
+echo "[4/6] Building web app..."
+cd "$REPO_ROOT/packages/app"
+npm run build:web
+cd "$REPO_ROOT"
+
+# 4. Copy web UI dist to server location
+echo ""
+echo "[5/6] Copying web UI dist to server..."
+mkdir -p "$WEB_UI_DEST"
+rm -rf "$WEB_UI_DEST"
+cp -r "$WEB_UI_SRC" "$WEB_UI_DEST"
+echo "  Copied: $WEB_UI_SRC -> $WEB_UI_DEST"
+ls "$WEB_UI_DEST" | head -5
+
+# 5. Restart service
+echo ""
+echo "[6/6] Restarting paseo systemd service..."
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+systemctl --user restart paseo
+
+# 6. Verify health
+sleep 3
+HEALTH=$(curl -sf http://127.0.0.1:6767/api/health 2>/dev/null || echo '{"status":"error"}')
+HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" http://127.0.0.1:6767/ 2>/dev/null || echo "000")
+
+echo ""
+echo "=== Deploy Complete ==="
+echo "Health: $HEALTH"
+echo "Web UI HTTP: $HTTP_CODE"
+
+if [ "$HTTP_CODE" = "200" ]; then
+  echo "Status: OK"
+else
+  echo "Status: WARNING — Web UI returned HTTP $HTTP_CODE"
+fi

--- a/scripts/sync-workspace-versions.mjs
+++ b/scripts/sync-workspace-versions.mjs
@@ -22,7 +22,7 @@ function getGitCommitShortHash() {
 const rootPackage = JSON.parse(readFileSync(rootPackagePath, "utf8"));
 const rootVersion = rootPackage.version;
 const gitHash = getGitCommitShortHash();
-const versionWithHash = gitHash ? `${rootVersion}-h-${gitHash}` : rootVersion;
+const versionWithHash = gitHash ? `${rootVersion}-${gitHash}` : rootVersion;
 const workspacePaths = Array.isArray(rootPackage.workspaces) ? rootPackage.workspaces : [];
 const sharedMetadata = {
   homepage: rootPackage.homepage,

--- a/scripts/sync-workspace-versions.mjs
+++ b/scripts/sync-workspace-versions.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,8 +7,22 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
 const rootPackagePath = path.join(rootDir, "package.json");
 
+function getGitCommitShortHash() {
+  try {
+    return execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: rootDir,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
 const rootPackage = JSON.parse(readFileSync(rootPackagePath, "utf8"));
 const rootVersion = rootPackage.version;
+const gitHash = getGitCommitShortHash();
+const versionWithHash = gitHash ? `${rootVersion}-h-${gitHash}` : rootVersion;
 const workspacePaths = Array.isArray(rootPackage.workspaces) ? rootPackage.workspaces : [];
 const sharedMetadata = {
   homepage: rootPackage.homepage,
@@ -38,8 +53,8 @@ for (const workspacePath of workspacePaths) {
   const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
   let changed = false;
 
-  if (pkg.version !== rootVersion) {
-    pkg.version = rootVersion;
+  if (pkg.version !== versionWithHash) {
+    pkg.version = versionWithHash;
     changed = true;
   }
 
@@ -56,8 +71,8 @@ for (const workspacePath of workspacePaths) {
 
   // Private workspaces (app, desktop) keep "*" for internal deps so npm always
   // resolves the local sibling, never a registry artifact. Publishable workspaces
-  // get the root version so their published tarballs reference real npm versions.
-  const internalDepRange = pkg.private === true ? "*" : rootVersion;
+  // get the version with hash so their published tarballs reference real npm versions.
+  const internalDepRange = pkg.private === true ? "*" : versionWithHash;
 
   for (const section of dependencySections) {
     const deps = pkg[section];
@@ -86,9 +101,9 @@ for (const workspacePath of workspacePaths) {
 }
 
 if (touched.length === 0) {
-  console.log(`Workspace versions and internal deps already synced to ${rootVersion}`);
+  console.log(`Workspace versions and internal deps already synced to ${versionWithHash}`);
 } else {
-  console.log(`Synced to ${rootVersion}:`);
+  console.log(`Synced to ${versionWithHash}:`);
   for (const file of touched) {
     console.log(`- ${file}`);
   }


### PR DESCRIPTION
## Summary

Adds background task visibility to Paseo's UI, covering both Claude Code's native `run_in_background` and `mcp-bg-bash` MCP server.

## What's included

### Protocol (backward-compatible)
- `BackgroundTaskDescriptorPayload` schema (id, toolName, command, status, timestamps, exitCode, outputPreview)
- `agent.background_tasks.update` push messages (upsert/remove)
- `agent.background_tasks.list.request/response` messages
- `backgroundTasks` capability flag in `server_info.features`

### Server
- **Agent-manager**: `backgroundTasks: Map<string, BackgroundTaskDescriptor>` per agent, `upsertBackgroundTask`/`removeBackgroundTask`/`listBackgroundTasks` methods
- **MCP interception**: Detects `mcp__bg_bash__background_bash`, `mcp__bg_bash__bash_status`, `mcp__bg_bash__bash_cancel`, and Claude native `Bash` with `run_in_background: true`
- **Session handler**: Handles `agent.background_tasks.list.request` messages
- **WebSocket server**: Advertises `backgroundTasks: true` feature flag

### Client
- **Zustand store** (`background-tasks/store.ts\): `replaceList`/`applyUpdate` with sorted task lists
- **Hook** (`useBackgroundTasksForAgent`): Push + poll hybrid, server capability detection
- **Push wiring** (`session-context.tsx`): Subscribes to `agent.background_tasks.update` messages
- **Daemon client**: `listBackgroundTasks()` RPC method

### UI
- **BackgroundTasksTrack**: Collapsible panel showing task count, running count, status dots, command preview, elapsed time
- **AgentStatusDot**: Badge overlay showing background task count when > 0
- **AgentPanel**: Integrates BackgroundTasksTrack above the composer/subagents track

### Bug fix
- **PID lock** (`pid-lock.ts`): Handles empty/invalid PID files gracefully instead of throwing "race condition" (was crash-looping systemd service)

## Testing
- 249 unit tests passing (protocol, agent-manager, projections, subagents store, background-tasks store, pid-lock, tool-name-normalization, stream-coalescing)
- Playwright E2E: Dev daemon loads, WebSocket stable, prod daemon unaffected
- Typecheck, lint, format: all clean

## Notes
- BackgroundTasksTrack renders only inside AgentPanel (requires a working agent provider)
- Feature is gated behind `backgroundTasks` capability flag — old clients ignore bg task messages
- All protocol changes are backward-compatible (new optional fields, new message types)