### PR TITLE
Update ACP SDK to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,15 +54,6 @@
         }
       }
     },
-    "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.17.1.tgz",
-      "integrity": "sha512-yjyIn8POL18IOXioLySYiL0G44kZ/IZctAls7vS3AC3X+qLhFXbWmzABSZehwRnWFShMXT+ODa/HJG1+mGXZ1A==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
     "node_modules/@ai-sdk/gateway": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.1.tgz",
@@ -38233,7 +38224,7 @@
       "name": "@getpaseo/server",
       "version": "0.3.0-beta.1",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.17.1",
+        "@agentclientprotocol/sdk": "^1.2.1",
         "@anthropic-ai/claude-agent-sdk": "^0.3.220",
         "@anthropic-ai/sdk": "^0.104.2",
         "@getpaseo/client": "0.3.0-beta.1",
@@ -38282,6 +38273,15 @@
         "tsx": "^4.6.0",
         "typescript": "^5.2.2",
         "vitest": "^4.1.6"
+      }
+    },
+    "packages/server/node_modules/@agentclientprotocol/sdk": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.2.1.tgz",
+      "integrity": "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "packages/server/node_modules/@anthropic-ai/claude-agent-sdk": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -66,7 +66,7 @@
     "test:e2e:ui": "vitest --ui e2e.test.ts"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.17.1",
+    "@agentclientprotocol/sdk": "^1.2.1",
     "@anthropic-ai/claude-agent-sdk": "^0.3.220",
     "@anthropic-ai/sdk": "^0.104.2",
     "@getpaseo/client": "0.3.0-beta.1",

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -108,13 +108,13 @@ interface ACPModelSelectionInternals {
 interface ACPConfiguredOverrideInternals {
   sessionId: string | null;
   connection: {
+    request: (method: string, params: unknown) => Promise<unknown>;
     setSessionMode: (input: { sessionId: string; modeId: string }) => Promise<void>;
     setSessionConfigOption: (input: {
       sessionId: string;
       configId: string;
       value: string;
     }) => Promise<unknown>;
-    unstable_setSessionModel?: (input: { sessionId: string; modelId: string }) => Promise<void>;
   };
   configOptions: SessionConfigOption[];
   availableModes: Array<{ id: string; label: string; description?: string }>;
@@ -393,21 +393,21 @@ function prepareConfiguredOverrideSession(
   } = {},
 ): {
   internals: ACPConfiguredOverrideInternals;
+  request: ReturnType<typeof vi.fn>;
   setSessionMode: ReturnType<typeof vi.fn>;
-  unstableSetSessionModel: ReturnType<typeof vi.fn>;
   setSessionConfigOption: ReturnType<typeof vi.fn>;
 } {
+  const request = vi.fn(async () => ({}));
   const setSessionMode = vi.fn(async () => undefined);
-  const unstableSetSessionModel = vi.fn(async () => undefined);
   const setSessionConfigOption = vi.fn(async () => ({
     configOptions: options.configOptions ?? [],
   }));
   const internals = asInternals<ACPConfiguredOverrideInternals>(session);
   internals.sessionId = "session-1";
   internals.connection = {
+    request,
     setSessionMode,
     setSessionConfigOption,
-    unstable_setSessionModel: unstableSetSessionModel,
     ...options.connection,
   };
   internals.availableModes = options.availableModes ?? [];
@@ -416,7 +416,7 @@ function prepareConfiguredOverrideSession(
   internals.currentMode = options.currentMode ?? null;
   internals.currentModel = options.currentModel ?? null;
 
-  return { internals, setSessionMode, unstableSetSessionModel, setSessionConfigOption };
+  return { internals, request, setSessionMode, setSessionConfigOption };
 }
 
 test("ACP setModel only uses config-option fallback when the matching select choice contains the model", async () => {
@@ -853,10 +853,11 @@ describe("ACPAgentSession Zed parity", () => {
 
     await valid.internals.applyConfiguredOverrides();
     expect(valid.setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "plan" });
-    expect(valid.unstableSetSessionModel).toHaveBeenCalledWith({
+    expect(valid.request).toHaveBeenCalledWith("session/set_model", {
       sessionId: "session-1",
       modelId: "sonnet",
     });
+    expect(valid.setSessionConfigOption).not.toHaveBeenCalled();
 
     const modeEvents = asInternals<ACPSessionInternals>(validSession).translateSessionUpdate({
       sessionUpdate: "current_mode_update",
@@ -894,7 +895,8 @@ describe("ACPAgentSession Zed parity", () => {
 
     await expect(invalid.internals.applyConfiguredOverrides()).resolves.toBeUndefined();
     expect(invalid.setSessionMode).not.toHaveBeenCalled();
-    expect(invalid.unstableSetSessionModel).not.toHaveBeenCalled();
+    expect(invalid.request).not.toHaveBeenCalled();
+    expect(invalid.setSessionConfigOption).not.toHaveBeenCalled();
     expect(childLogger.warn).toHaveBeenCalledWith(
       { value: expect.stringContaining("acceptEdits") },
       expect.stringContaining("not valid"),
@@ -914,7 +916,6 @@ describe("ACPAgentSession Zed parity", () => {
         { id: "plan", label: "Plan" },
       ],
       configOptions: [selectConfigOption("mode", ["default", "acceptEdits"], "default")],
-      connection: { unstable_setSessionModel: undefined },
     });
 
     await expect(internals.applyConfiguredOverrides()).resolves.toBeUndefined();
@@ -929,16 +930,12 @@ describe("ACPAgentSession Zed parity", () => {
       { provider: "deepseek-tui", model: "deepseek/v4" },
       logger,
     );
-    const { internals, setSessionConfigOption, unstableSetSessionModel } =
-      prepareConfiguredOverrideSession(session, {
-        currentModel: null,
-        availableModels: null,
-        configOptions: [],
-        connection: { unstable_setSessionModel: undefined },
-      });
+    const { internals, setSessionConfigOption } = prepareConfiguredOverrideSession(session, {
+      currentModel: null,
+      configOptions: [],
+    });
 
     await expect(internals.applyConfiguredOverrides()).resolves.toBeUndefined();
-    expect(unstableSetSessionModel).not.toHaveBeenCalled();
     expect(setSessionConfigOption).not.toHaveBeenCalled();
     expect(childLogger.warn).toHaveBeenCalledWith(
       { value: "deepseek/v4" },
@@ -1641,31 +1638,55 @@ describe("ACPAgentSession Zed parity", () => {
 });
 
 describe("deriveModelDefinitionsFromACP", () => {
-  test("attaches shared thinking options to ACP model state", () => {
+  test("derives models from the legacy ACP models response", () => {
     const result = deriveModelDefinitionsFromACP(
-      "claude-acp",
+      "cursor-acp",
       {
-        availableModels: [
-          { modelId: "haiku", name: "Haiku", description: "Fast" },
-          { modelId: "sonnet", name: "Sonnet", description: "Balanced" },
-        ],
-        currentModelId: "haiku",
+        availableModels: [{ modelId: "default", name: "Default", description: "Cursor default" }],
+        currentModelId: "default",
       },
-      [
-        {
-          id: "reasoning",
-          name: "Reasoning",
-          category: "thought_level",
-          type: "select",
-          currentValue: "medium",
-          options: [
-            { value: "low", name: "Low" },
-            { value: "medium", name: "Medium" },
-            { value: "high", name: "High" },
-          ],
-        },
-      ],
+      [],
     );
+
+    expect(result).toEqual([
+      {
+        provider: "cursor-acp",
+        id: "default",
+        label: "Default",
+        description: "Cursor default",
+        isDefault: true,
+        thinkingOptions: undefined,
+        defaultThinkingOptionId: undefined,
+      },
+    ]);
+  });
+
+  test("attaches shared thinking options to ACP model config options", () => {
+    const result = deriveModelDefinitionsFromACP("claude-acp", null, [
+      {
+        id: "model",
+        name: "Model",
+        category: "model",
+        type: "select",
+        currentValue: "haiku",
+        options: [
+          { value: "haiku", name: "Haiku", description: "Fast" },
+          { value: "sonnet", name: "Sonnet", description: "Balanced" },
+        ],
+      },
+      {
+        id: "reasoning",
+        name: "Reasoning",
+        category: "thought_level",
+        type: "select",
+        currentValue: "medium",
+        options: [
+          { value: "low", name: "Low" },
+          { value: "medium", name: "Medium" },
+          { value: "high", name: "High" },
+        ],
+      },
+    ]);
 
     expect(result).toEqual([
       {
@@ -1698,6 +1719,7 @@ describe("deriveModelDefinitionsFromACP", () => {
           },
         ],
         defaultThinkingOptionId: "medium",
+        metadata: undefined,
       },
       {
         provider: "claude-acp",
@@ -1729,13 +1751,14 @@ describe("deriveModelDefinitionsFromACP", () => {
           },
         ],
         defaultThinkingOptionId: "medium",
+        metadata: undefined,
       },
     ]);
   });
 });
 
 describe("ACPAgentClient modelTransformer", () => {
-  test("applies modelTransformer after deriving ACP models", async () => {
+  test("applies modelTransformer after adapting a legacy ACP models response", async () => {
     class TestACPAgentClient extends ACPAgentClient {
       protected override async spawnProcess(): Promise<SpawnedACPProcess> {
         return {
@@ -1785,6 +1808,38 @@ describe("ACPAgentClient modelTransformer", () => {
       ],
       modes: [],
     });
+  });
+
+  test("rejects malformed legacy ACP models at the catalog boundary", async () => {
+    class TestACPAgentClient extends ACPAgentClient {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+          connection: {
+            newSession: vi.fn().mockResolvedValue({
+              models: {
+                availableModels: [{ modelId: "default" }],
+                currentModelId: "default",
+              },
+              configOptions: [],
+            }),
+          },
+          initialize: { agentCapabilities: {} },
+        } as SpawnedACPProcess;
+      }
+
+      protected override async closeProbe(): Promise<void> {}
+    }
+
+    const client = new TestACPAgentClient({
+      provider: "cursor-acp",
+      logger: createTestLogger(),
+      defaultCommand: ["cursor-acp"],
+    });
+
+    await expect(
+      client.fetchCatalog({ scope: "workspace", cwd: "/tmp/acp-models", force: false }),
+    ).rejects.toThrow("ACP legacy models response is invalid");
   });
 });
 
@@ -1954,7 +2009,6 @@ describe("ACPAgentClient sessionResponseTransformer", () => {
           availableModes: [{ id: "raw", name: "Raw", description: "Before transform" }],
           currentModeId: "raw",
         },
-        models: null,
         configOptions: [],
       };
 
@@ -2002,7 +2056,7 @@ describe("ACPAgentClient sessionResponseTransformer", () => {
 
 describe("ACPAgentClient fetchCatalog", () => {
   test("passes the requested cwd to the catalog probe", async () => {
-    const newSession = vi.fn().mockResolvedValue({ modes: null, models: null, configOptions: [] });
+    const newSession = vi.fn().mockResolvedValue({ modes: null, configOptions: [] });
 
     class TestACPAgentClient extends ACPAgentClient {
       protected override async spawnProcess(): Promise<SpawnedACPProcess> {
@@ -2737,7 +2791,6 @@ describe("ACPAgentSession", () => {
 
     expect(prompt).toHaveBeenCalledWith({
       sessionId: "session-1",
-      messageId: "msg-client-1",
       prompt: [{ type: "text", text: "hello" }],
     });
     expect(
@@ -3188,8 +3241,9 @@ describe("ACPAgentSession", () => {
 });
 
 interface ACPCloseInternals {
+  agentCapabilities: { sessionCapabilities?: { close?: Record<string, never> | null } } | null;
   child: ChildProcess | null;
-  connection: unknown;
+  connection: { closeSession: (params: { sessionId: string }) => Promise<unknown> } | null;
   sessionId: string | null;
 }
 
@@ -3255,6 +3309,19 @@ describe("ACPAgentSession close() tree-kill", () => {
 
     expect(terminator.terminated).toContain(child);
     expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  test("close() uses the stable ACP closeSession method when advertised", async () => {
+    const session = createSession();
+    const internals = asInternals<ACPCloseInternals>(session);
+    const closeSession = vi.fn(async () => undefined);
+    internals.agentCapabilities = { sessionCapabilities: { close: {} } };
+    internals.connection = { closeSession };
+    internals.sessionId = "session-1";
+
+    await session.close();
+
+    expect(closeSession).toHaveBeenCalledWith({ sessionId: "session-1" });
   });
 
   test("close() terminates running terminal child processes", async () => {
@@ -3409,7 +3476,6 @@ describe("ACPAgentClient probe cleanup", () => {
           connection: {
             newSession: vi.fn().mockResolvedValue({
               modes: null,
-              models: null,
               configOptions: [],
             }),
           },
@@ -3445,22 +3511,20 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
     capabilities?: AgentCapabilityFlags;
     handle: AgentPersistenceHandle;
     loadSession?: ReturnType<typeof vi.fn>;
-    unstableResumeSession?: ReturnType<typeof vi.fn>;
+    resumeSession?: ReturnType<typeof vi.fn>;
   }) {
     const loadSession =
       args.loadSession ??
       vi.fn().mockResolvedValue({
         sessionId: "session-1",
         modes: null,
-        models: null,
         configOptions: [],
       });
-    const unstableResumeSession =
-      args.unstableResumeSession ??
+    const resumeSession =
+      args.resumeSession ??
       vi.fn().mockResolvedValue({
         sessionId: "session-1",
         modes: null,
-        models: null,
         configOptions: [],
       });
 
@@ -3471,7 +3535,7 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
           connection: {
             prompt: vi.fn(),
             loadSession,
-            unstable_resumeSession: unstableResumeSession,
+            resumeSession,
           } as unknown as ClientSideConnection,
           initialize: { agentCapabilities: args.capabilities ?? {} },
         } as SpawnedACPProcess;
@@ -3499,7 +3563,7 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
       },
     );
 
-    return { session, loadSession, unstableResumeSession };
+    return { session, loadSession, resumeSession };
   }
 
   test("loadSession is always called with sessionId, cwd, and mcpServers even when mcpServers is empty", async () => {
@@ -3531,7 +3595,6 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
       return {
         sessionId: "session-1",
         modes: null,
-        models: null,
         configOptions: [],
       };
     };
@@ -3651,7 +3714,6 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
       return {
         sessionId: "session-1",
         modes: null,
-        models: null,
         configOptions: [],
       };
     };
@@ -3692,15 +3754,15 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
     });
   });
 
-  test("unstable_resumeSession is always called with sessionId, cwd, and mcpServers", async () => {
-    const { session, unstableResumeSession } = makeTestSession({
+  test("resumeSession is always called with sessionId, cwd, and mcpServers", async () => {
+    const { session, resumeSession } = makeTestSession({
       capabilities: { sessionCapabilities: { resume: {} } },
       handle: { sessionId: "session-1", provider: "claude-acp" },
     });
 
     await session.initializeResumedSession();
 
-    expect(unstableResumeSession).toHaveBeenCalledWith({
+    expect(resumeSession).toHaveBeenCalledWith({
       sessionId: "session-1",
       cwd: "/tmp/paseo-acp-test",
       mcpServers: [],

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -40,7 +40,6 @@ import {
   type SessionConfigOption,
   type SessionInfoUpdate,
   type SessionMode,
-  type SessionModelState,
   type SessionNotification,
   type SessionUpdate,
   type TerminalOutputRequest,
@@ -483,6 +482,66 @@ interface PendingUserMessage {
 
 export type SessionStateResponse = NewSessionResponse | LoadSessionResponse | ResumeSessionResponse;
 
+// COMPAT(acp-models): added v0.2.0-beta.1, remove after 2027-01-20.
+// cursor-acp@0.1.0 returns only the pre-config-options `models` shape and
+// `session/set_model`; claude-agent-acp@0.31.4 still returns the same shape
+// alongside config options. Keep that legacy wire contract at this shared ACP
+// connection boundary until the supported agent floor no longer needs it.
+interface LegacyACPModelInfo {
+  modelId: string;
+  name: string;
+  description?: string | null;
+}
+
+interface LegacyACPSessionModelState {
+  availableModels: LegacyACPModelInfo[];
+  currentModelId: string;
+}
+
+function adaptLegacyACPModelState(
+  response: SessionStateResponse,
+): LegacyACPSessionModelState | null {
+  const rawResponse: unknown = response;
+  const models = isRecord(rawResponse) ? rawResponse.models : undefined;
+  if (models == null) {
+    return null;
+  }
+  if (
+    !isRecord(models) ||
+    !Array.isArray(models.availableModels) ||
+    typeof models.currentModelId !== "string"
+  ) {
+    throw new Error("ACP legacy models response is invalid");
+  }
+
+  const availableModels = models.availableModels.map((model) => {
+    if (
+      !isRecord(model) ||
+      typeof model.modelId !== "string" ||
+      typeof model.name !== "string" ||
+      (model.description !== undefined &&
+        model.description !== null &&
+        typeof model.description !== "string")
+    ) {
+      throw new Error("ACP legacy models response is invalid");
+    }
+    return {
+      modelId: model.modelId,
+      name: model.name,
+      description: model.description,
+    };
+  });
+
+  return { availableModels, currentModelId: models.currentModelId };
+}
+
+async function requestLegacyACPModelChange(
+  connection: ClientSideConnection,
+  params: { sessionId: string; modelId: string },
+): Promise<void> {
+  await connection.request("session/set_model", params);
+}
+
 interface TerminalExit {
   exitCode?: number | null;
   signal?: string | null;
@@ -526,7 +585,7 @@ interface SelectConfigChoice {
   description?: string | null;
   group?: string;
 }
-type AvailableACPModel = NonNullable<SessionModelState["availableModels"]>[number];
+type AvailableACPModel = LegacyACPSessionModelState["availableModels"][number];
 
 interface ACPModeSelection {
   availableMode: AgentMode | null;
@@ -647,13 +706,13 @@ export function deriveModesFromACP(
 
 export function deriveModelDefinitionsFromACP(
   provider: string,
-  models: SessionModelState | null | undefined,
+  models: LegacyACPSessionModelState | null | undefined,
   configOptions?: SessionConfigOption[] | null,
 ): AgentModelDefinition[] {
   const thinkingOptions = deriveSelectorOptions(configOptions, "thought_level");
   const defaultThinkingOptionId = thinkingOptions.find((option) => option.isDefault)?.id ?? null;
 
-  if (models?.availableModels?.length) {
+  if (models?.availableModels.length) {
     return models.availableModels.map((model) => ({
       provider,
       id: model.modelId,
@@ -926,7 +985,7 @@ export class ACPAgentClient implements AgentClient {
         const transformed = this.transformSessionResponse(response);
         const models = deriveModelDefinitionsFromACP(
           this.provider,
-          transformed.models,
+          adaptLegacyACPModelState(transformed),
           transformed.configOptions,
         );
         const modeInfo = deriveModesFromACP(
@@ -1248,7 +1307,7 @@ export class ACPAgentClient implements AgentClient {
         const transformed = this.transformSessionResponse(response);
         const models = deriveModelDefinitionsFromACP(
           this.provider,
-          transformed.models,
+          adaptLegacyACPModelState(transformed),
           transformed.configOptions,
         );
         const modeInfo = deriveModesFromACP(
@@ -1459,7 +1518,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   /**
    * IMPORTANT: Some ACP providers (e.g., Devin CLI) require all three params
    * (sessionId, cwd, mcpServers) to be present in session/load or
-   * unstable_resumeSession — even when mcpServers is an empty array — and
+   * resumeSession — even when mcpServers is an empty array — and
    * return "Invalid params" if any are omitted. Never drop cwd or mcpServers
    * from these calls regardless of capabilities.
    */
@@ -1493,7 +1552,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         this.applySessionState(response);
       } else if (sessionCapabilities?.resume) {
         const response = await this.runACPRequest(() =>
-          this.connection!.unstable_resumeSession({
+          this.connection!.resumeSession({
             sessionId: handle.sessionId,
             cwd: this.config.cwd,
             mcpServers: this.acpMcpServers(),
@@ -1566,7 +1625,6 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     void this.connection
       .prompt({
         sessionId: this.sessionId,
-        messageId,
         prompt: toACPContentBlocks(prompt),
       })
       .then((response) => {
@@ -1863,12 +1921,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         return;
       }
 
-      if (typeof this.connection.unstable_setSessionModel !== "function") {
-        throw new Error(this.modelSelectionUnavailableMessage());
-      }
-
       try {
-        await this.connection.unstable_setSessionModel({
+        await requestLegacyACPModelChange(this.connection, {
           sessionId: this.sessionId,
           modelId,
         });
@@ -1880,7 +1934,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         });
         return;
       } catch {
-        // Fall through to config option path.
+        // Preserve the pre-1.2 SDK behavior for agents that expose both legacy
+        // models and stable config options but reject the legacy request.
       }
     }
 
@@ -2138,7 +2193,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
       try {
         if (this.agentCapabilities?.sessionCapabilities?.close) {
-          await this.connection.unstable_closeSession({ sessionId: this.sessionId });
+          await this.connection.closeSession({ sessionId: this.sessionId });
         }
       } catch (error) {
         this.logger.debug({ err: error }, "ACP closeSession failed during shutdown");
@@ -2494,9 +2549,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.availableModes = modeInfo.modes;
     this.currentMode = modeInfo.currentModeId ?? this.currentMode;
 
-    this.availableModels = transformed.models?.availableModels ?? null;
+    const legacyModels = adaptLegacyACPModelState(transformed);
+    this.availableModels = legacyModels?.availableModels ?? null;
     this.currentModel =
-      transformed.models?.currentModelId ?? deriveCurrentConfigValue(this.configOptions, "model");
+      legacyModels?.currentModelId ?? deriveCurrentConfigValue(this.configOptions, "model");
     this.thinkingOptionId =
       deriveCurrentConfigValue(this.configOptions, "thought_level") ?? this.thinkingOptionId;
   }

--- a/packages/server/src/server/agent/providers/acp-wrapper-smoke.test.ts
+++ b/packages/server/src/server/agent/providers/acp-wrapper-smoke.test.ts
@@ -267,20 +267,20 @@ function installWireCapture(trace: SmokeTrace): void {
     },
   );
 
-  const originalSetModel = ClientSideConnection.prototype.unstable_setSessionModel;
-  vi.spyOn(ClientSideConnection.prototype, "unstable_setSessionModel").mockImplementation(
-    async function (params) {
-      trace.rpc.push({ direction: "out", method: "session/setModel", payload: params });
+  const originalRequest = ClientSideConnection.prototype.request;
+  vi.spyOn(ClientSideConnection.prototype, "request").mockImplementation(
+    async function (method, params, options) {
+      if (method !== "session/set_model") {
+        return originalRequest.call(this, method, params, options);
+      }
+
+      trace.rpc.push({ direction: "out", method, payload: params });
       try {
-        const response = await originalSetModel.call(this, params);
-        trace.rpc.push({ direction: "in", method: "session/setModel", payload: response });
+        const response = await originalRequest.call(this, method, params, options);
+        trace.rpc.push({ direction: "in", method, payload: response });
         return response;
       } catch (error) {
-        trace.rpc.push({
-          direction: "error",
-          method: "session/setModel",
-          payload: formatError(error),
-        });
+        trace.rpc.push({ direction: "error", method, payload: formatError(error) });
         throw error;
       }
     },
@@ -462,7 +462,7 @@ for (const config of wrappers) {
   wrapperDescribe(`real ${config.id} ACP wrapper smoke`, () => {
     let toolPromptTraceForEvidence: SmokeTrace | null = null;
 
-    test("(a) session/new exposes modes/models and applySessionState derives runtime state", async () => {
+    test("(a) session/new exposes modes/models and derives runtime state", async () => {
       const trace = createTrace(config);
       installWireCapture(trace);
       let session: ACPAgentSession | null = null;
@@ -472,11 +472,10 @@ for (const config of wrappers) {
         const modes = await session.getAvailableModes();
         const modelIds = getModelIds(session);
         const modelOption = getSelectOption(session, "model");
+        const modelValues = modelOption ? flattenSelectValues(modelOption) : [];
 
         expect(modes.length).toBeGreaterThan(0);
-        expect(
-          modelIds.length + (modelOption ? flattenSelectValues(modelOption).length : 0),
-        ).toBeGreaterThan(0);
+        expect(modelIds.length + modelValues.length).toBeGreaterThan(0);
         expect((await session.getRuntimeInfo()).sessionId).toBeTruthy();
         expect(
           trace.rpc.some((entry) => entry.method === "session/new" && entry.direction === "in"),
@@ -555,7 +554,8 @@ for (const config of wrappers) {
           trace.rpc.some(
             (entry) =>
               entry.direction === "out" &&
-              (entry.method === "session/setModel" || entry.method === "session/setConfigOption") &&
+              (entry.method === "session/set_model" ||
+                entry.method === "session/setConfigOption") &&
               JSON.stringify(entry.payload).includes(modelId),
           ),
         ).toBe(true);

--- a/packages/server/src/server/agent/providers/cursor-acp-smoke.test.ts
+++ b/packages/server/src/server/agent/providers/cursor-acp-smoke.test.ts
@@ -41,7 +41,6 @@ interface Issue560Evidence {
   warnings: unknown[];
   setModeRpc: Array<{ modeId: string; direction: "out" | "in" | "error"; payload: unknown }>;
   setConfigRpc: Array<{ configId: string; value: string; direction: "out" | "in" | "error" }>;
-  setModelRpc: Array<{ modelId: string; direction: "out" | "in" | "error" }>;
   acceptEditsConfigRpcSent: boolean;
   bracketedModelConfigRpcSent: boolean;
   planCurrentMode: string | null;
@@ -97,9 +96,35 @@ afterEach(() => {
 });
 
 runCursorACPSmoke("real cursor-acp@0.1.0 smoke", () => {
+  test("valid advertised model round-trips over legacy session/set_model", async () => {
+    const requestSpy = vi.spyOn(ClientSideConnection.prototype, "request");
+    const logger = createSmokeLogger();
+    let session: ACPAgentSession | null = null;
+
+    try {
+      session = createCursorSessionWithPersistedClaudeValues({ logger, model: "default" });
+      await session.initializeNewSession();
+      const sessionId = session.id;
+      expect(sessionId).toBeTruthy();
+
+      await session.setModel(null);
+      expect((await session.getRuntimeInfo()).model).toBeNull();
+
+      await session.setModel("default");
+
+      expect(requestSpy).toHaveBeenCalledWith("session/set_model", {
+        sessionId,
+        modelId: "default",
+      });
+      expect((await session.getRuntimeInfo()).model).toBe("default");
+    } finally {
+      await session?.close();
+    }
+  }, 120_000);
+
   test("reconnect skips invalid persisted values again on a fresh session", async () => {
     const setModeSpy = vi.spyOn(ClientSideConnection.prototype, "setSessionMode");
-    const setModelSpy = vi.spyOn(ClientSideConnection.prototype, "unstable_setSessionModel");
+    const requestSpy = vi.spyOn(ClientSideConnection.prototype, "request");
     const requestPermissionSpy = vi.spyOn(ACPAgentSession.prototype, "requestPermission");
     const logger = createSmokeLogger();
     const reconnectLogger = createSmokeLogger();
@@ -147,16 +172,17 @@ runCursorACPSmoke("real cursor-acp@0.1.0 smoke", () => {
       expect(evidence.acceptEditsRpcSent).toBe(false);
       expect(evidence.initialCurrentMode).toBe("default");
       expect(logger.warn).toHaveBeenCalledWith(
-        "acceptEdits",
+        { value: "acceptEdits" },
         expect.stringContaining("is not valid cursor-acp mode"),
       );
       expect(reconnectLogger.warn).toHaveBeenCalledWith(
-        "acceptEdits",
+        { value: "acceptEdits" },
         expect.stringContaining("is not valid cursor-acp mode"),
       );
       expect(evidence.reconnectCurrentMode).toBe("default");
       expect(evidence.requestPermissionCalls).toBe(0);
-      expect(setModelSpy).not.toHaveBeenCalledWith(
+      expect(requestSpy).not.toHaveBeenCalledWith(
+        "session/set_model",
         expect.objectContaining({ modelId: cursorClaudeModel }),
       );
     } catch (error) {
@@ -171,13 +197,13 @@ runCursorACPSmoke("real cursor-acp@0.1.0 smoke", () => {
 
   test("issue #560 replay skips invalid Claude selections and allows valid Cursor modes after resume", async () => {
     const logger = createSmokeLogger();
+    const requestSpy = vi.spyOn(ClientSideConnection.prototype, "request");
     const evidence: Issue560Evidence = {
       sessionNewSucceeded: false,
       availableModes: null,
       warnings: [],
       setModeRpc: [],
       setConfigRpc: [],
-      setModelRpc: [],
       acceptEditsConfigRpcSent: false,
       bracketedModelConfigRpcSent: false,
       planCurrentMode: null,
@@ -234,21 +260,6 @@ runCursorACPSmoke("real cursor-acp@0.1.0 smoke", () => {
       },
     );
 
-    const originalSetModel = ClientSideConnection.prototype.unstable_setSessionModel;
-    vi.spyOn(ClientSideConnection.prototype, "unstable_setSessionModel").mockImplementation(
-      async function (params) {
-        evidence.setModelRpc.push({ modelId: params.modelId, direction: "out" });
-        try {
-          const response = await originalSetModel.call(this, params);
-          evidence.setModelRpc.push({ modelId: params.modelId, direction: "in" });
-          return response;
-        } catch (error) {
-          evidence.setModelRpc.push({ modelId: params.modelId, direction: "error" });
-          throw error;
-        }
-      },
-    );
-
     try {
       session = createCursorSessionWithPersistedClaudeValues({
         logger,
@@ -290,16 +301,17 @@ runCursorACPSmoke("real cursor-acp@0.1.0 smoke", () => {
       ]);
       expect(evidence.setModeRpc.some((entry) => entry.modeId === "acceptEdits")).toBe(false);
       expect(evidence.acceptEditsConfigRpcSent).toBe(false);
-      expect(evidence.setModelRpc.some((entry) => entry.modelId === issue560ClaudeModel)).toBe(
-        false,
-      );
       expect(evidence.bracketedModelConfigRpcSent).toBe(false);
+      expect(requestSpy).not.toHaveBeenCalledWith(
+        "session/set_model",
+        expect.objectContaining({ modelId: issue560ClaudeModel }),
+      );
       expect(logger.warn).toHaveBeenCalledWith(
-        "acceptEdits",
+        { value: "acceptEdits" },
         expect.stringContaining("is not valid cursor-acp mode"),
       );
       expect(logger.warn).toHaveBeenCalledWith(
-        issue560ClaudeModel,
+        { value: issue560ClaudeModel },
         expect.stringContaining("is not a valid cursor-acp model"),
       );
       expect(evidence.setModeRpc).toEqual(


### PR DESCRIPTION
## Summary

- upgrade the Paseo server from `@agentclientprotocol/sdk` `^0.17.1` to `^1.2.1`
- adopt the stable session resume/close APIs and updated prompt request types
- preserve legacy ACP `models` responses and `session/set_model` at the connection boundary for supported older agents, while keeping the stable `configOptions` path unchanged
- update ACP unit and smoke coverage for both legacy and stable model-selection paths

## Why

ACP SDK 1.2.1 removed the unstable model state types and helper method that Paseo previously used. Some supported ACP agents still emit the former top-level `models` response and implement only `session/set_model`, so removing that path would regress existing model discovery and selection.

This change keeps that legacy wire contract in a dated compatibility adapter while otherwise following the 1.2.1 types and APIs. It does not add elicitation handling or advertise elicitation capabilities.

## Validation

- `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts packages/server/src/server/agent/providers/acp-wrapper-smoke.test.ts packages/server/src/server/agent/providers/cursor-acp-smoke.test.ts --bail=1` — 80 passed, 15 skipped opt-in smoke tests
- `CURSOR_ACP_SMOKE=1 npx vitest run packages/server/src/server/agent/providers/cursor-acp-smoke.test.ts --bail=1` — 3 passed
- `npm run typecheck`
- targeted `npm run lint -- ...` — 0 warnings and 0 errors
- `npm run format:check`
- `npm ls @agentclientprotocol/sdk --all` — resolves to 1.2.1
