### PR TITLE
fix(codex): preserve built-in plan mode instructions

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -22,6 +22,8 @@ Existing direct providers: `claude` (in `providers/claude/agent.ts`), `codex` (`
 
 Claude first-party model metadata lives in `packages/server/src/server/agent/providers/claude/model-manifest.ts`. When adding or updating a Claude model, update that manifest only; the model picker thinking options and Claude-specific feature gates are derived from the manifest. Do not add model-specific Claude capability lists in feature code.
 
+Codex collaboration modes and Paseo's additional instructions use separate app-server surfaces. `collaborationMode/list` intentionally omits built-in developer instructions, so mode selection must send `settings.developer_instructions: null` and let Codex resolve the selected mode's built-in instructions. Pass the composed per-agent and daemon-wide instructions only through `thread/start.developerInstructions` or `thread/resume.developerInstructions`; do not copy them into collaboration-mode settings or `turn/start`.
+
 Paseo tools are not implemented as MCP tools internally. They live in a shared tool catalog under `packages/server/src/server/agent/tools/`; MCP is only the fallback adapter. A provider that can register runtime tools directly should set `supportsNativePaseoTools: true` and consume `launchContext.paseoTools` in `createSession`/`resumeSession`. When native tools are present, `AgentManager` strips the internal Paseo MCP server from the provider launch config so the provider does not receive the same tools twice. Providers that only know MCP should keep `supportsMcpServers: true` and let the daemon inject `/mcp/agents`.
 
 Pi is a process-backed provider. Paseo requires the user to have the `pi` binary installed and talks to it through `pi --mode rpc`; the server package does not embed Pi's SDK/runtime packages.

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.features.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.features.test.ts
@@ -16,21 +16,24 @@ interface CollaborationModeRecord {
   mode?: string | null;
   model?: string | null;
   reasoning_effort?: string | null;
-  developer_instructions?: string | null;
 }
 
 const TEST_COLLABORATION_MODES: CollaborationModeRecord[] = [
   {
     name: "Code",
     mode: "code",
-    developer_instructions: "Built-in code mode",
   },
   {
     name: "Plan",
     mode: "plan",
-    developer_instructions: "Built-in plan mode",
+    reasoning_effort: "medium",
   },
 ];
+
+interface CapturedRequest {
+  method: "thread/start" | "thread/resume" | "turn/start";
+  params: Record<string, unknown>;
+}
 
 type CodexFeaturesTestSession = AgentSession;
 
@@ -69,10 +72,19 @@ function createSessionHarness(
 ): {
   session: CodexFeaturesTestSession;
   appServer: FakeCodexAppServer;
+  capturedRequests: CapturedRequest[];
 } {
   const config = createConfig(configOverrides);
+  const capturedRequests: CapturedRequest[] = [];
+  const capture = (method: CapturedRequest["method"], result: unknown) => (params: unknown) => {
+    capturedRequests.push({ method, params: params as Record<string, unknown> });
+    return result;
+  };
   const appServer = createFakeCodexAppServer({
     "collaborationMode/list": () => ({ data: TEST_COLLABORATION_MODES }),
+    "thread/start": capture("thread/start", { thread: { id: "thread-1" } }),
+    "thread/resume": capture("thread/resume", {}),
+    "turn/start": capture("turn/start", {}),
   });
   const session = new CodexAppServerAgentSession(
     { ...config, provider: CODEX_PROVIDER },
@@ -80,7 +92,7 @@ function createSessionHarness(
     options.logger ?? createTestLogger(),
     async () => appServer.child,
   ) as CodexFeaturesTestSession;
-  return { session, appServer };
+  return { session, appServer, capturedRequests };
 }
 
 async function createConnectedSession(
@@ -89,6 +101,7 @@ async function createConnectedSession(
 ): Promise<{
   session: CodexFeaturesTestSession;
   appServer: FakeCodexAppServer;
+  capturedRequests: CapturedRequest[];
 }> {
   const harness = createSessionHarness(configOverrides, options);
   await harness.session.connect();
@@ -341,9 +354,68 @@ describe("Codex app-server provider features", () => {
     await session.startTurn("hello");
 
     await expect(appServer.waitForTurnStart()).resolves.toMatchObject({
-      collaborationMode: expect.objectContaining({
+      collaborationMode: {
         mode: "plan",
-      }),
+        settings: expect.objectContaining({
+          developer_instructions: null,
+        }),
+      },
     });
   });
+
+  test.each([
+    {
+      name: "without appended instructions",
+      config: {},
+      expectedThreadInstructions: undefined,
+    },
+    {
+      name: "with systemPrompt",
+      config: { systemPrompt: "Agent instructions." },
+      expectedThreadInstructions: "Agent instructions.",
+    },
+    {
+      name: "with daemonAppendSystemPrompt",
+      config: { daemonAppendSystemPrompt: "Daemon instructions." },
+      expectedThreadInstructions: "Daemon instructions.",
+    },
+    {
+      name: "with both appended instruction sources",
+      config: {
+        systemPrompt: "Agent instructions.",
+        daemonAppendSystemPrompt: "Daemon instructions.",
+      },
+      expectedThreadInstructions: "Agent instructions.\n\nDaemon instructions.",
+    },
+  ])(
+    "keeps built-in plan instructions and sends thread instructions once $name",
+    async ({ config, expectedThreadInstructions }) => {
+      const { session, capturedRequests } = await createConnectedSession(config);
+
+      await session.setFeature?.("plan_mode", true);
+      await session.startTurn("implement the requested change");
+
+      const threadStart = capturedRequests.find((request) => request.method === "thread/start");
+      const turnStart = capturedRequests.find((request) => request.method === "turn/start");
+      expect(threadStart).toBeDefined();
+      expect(turnStart).toBeDefined();
+
+      if (expectedThreadInstructions === undefined) {
+        expect(threadStart?.params).not.toHaveProperty("developerInstructions");
+      } else {
+        expect(threadStart?.params).toMatchObject({
+          developerInstructions: expectedThreadInstructions,
+        });
+      }
+      expect(turnStart?.params).not.toHaveProperty("developerInstructions");
+      expect(turnStart?.params).toMatchObject({
+        collaborationMode: {
+          mode: "plan",
+          settings: expect.objectContaining({
+            developer_instructions: null,
+          }),
+        },
+      });
+    },
+  );
 });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.local.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.local.e2e.test.ts
@@ -215,6 +215,60 @@ function waitForEvent<TEvent extends AgentStreamEvent>(params: {
 
 describe("Codex app-server provider (local e2e)", () => {
   test.runIf(isCodexInstalled())(
+    "keeps built-in plan instructions alongside appended thread instructions exactly once",
+    async () => {
+      const cwd = mkdtempSync(path.join(os.tmpdir(), "codex-app-server-plan-cwd-"));
+      const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-app-server-plan-home-"));
+      const mockServer = await startMockResponsesServer([assistantMessageSse("done")]);
+      const agentInstruction = "PASEO_AGENT_INSTRUCTION_SENTINEL";
+      const daemonInstruction = "PASEO_DAEMON_INSTRUCTION_SENTINEL";
+
+      try {
+        writeMockCodexConfig(codexHome, mockServer.url);
+
+        const client = new CodexAppServerAgentClient(createTestLogger());
+        const session = await client.createSession(
+          {
+            provider: "codex",
+            cwd,
+            modeId: "auto",
+            model: "mock-model",
+            thinkingOptionId: "medium",
+            systemPrompt: agentInstruction,
+            daemonAppendSystemPrompt: daemonInstruction,
+          },
+          {
+            env: {
+              CODEX_HOME: codexHome,
+            },
+          },
+        );
+
+        try {
+          await session.setFeature?.("plan_mode", true);
+          await session.run("Implement a file change requested by the user.");
+
+          expect(mockServer.requestBodies).toHaveLength(1);
+          const body = JSON.parse(mockServer.requestBodies[0]) as { input?: unknown };
+          const input = JSON.stringify(body.input);
+          expect(input.split("<collaboration_mode>")).toHaveLength(2);
+          expect(input.split("</collaboration_mode>")).toHaveLength(2);
+          expect(input).toContain("<proposed_plan>");
+          expect(input.split(agentInstruction)).toHaveLength(2);
+          expect(input.split(daemonInstruction)).toHaveLength(2);
+        } finally {
+          await session.close();
+        }
+      } finally {
+        await mockServer.close();
+        rmSync(cwd, { recursive: true, force: true });
+        rmSync(codexHome, { recursive: true, force: true });
+      }
+    },
+    30_000,
+  );
+
+  test.runIf(isCodexInstalled())(
     "surfaces request_user_input from the app-server as question permissions and timeline tool calls",
     async () => {
       const cwd = mkdtempSync(path.join(os.tmpdir(), "codex-app-server-question-cwd-"));

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -44,7 +44,6 @@ interface CollaborationModeRecord {
   mode?: string | null;
   model?: string | null;
   reasoning_effort?: string | null;
-  developer_instructions?: string | null;
 }
 
 interface CodexSessionTestAccess {
@@ -3727,6 +3726,73 @@ describe("Codex app-server provider", () => {
     ]);
   });
 
+  test.each([
+    {
+      name: "without appended instructions",
+      config: {},
+      expectedInstructions: undefined,
+    },
+    {
+      name: "with systemPrompt",
+      config: { systemPrompt: "Agent instructions." },
+      expectedInstructions: "Agent instructions.",
+    },
+    {
+      name: "with daemonAppendSystemPrompt",
+      config: { daemonAppendSystemPrompt: "Daemon instructions." },
+      expectedInstructions: "Daemon instructions.",
+    },
+    {
+      name: "with both appended instruction sources",
+      config: {
+        systemPrompt: "Agent instructions.",
+        daemonAppendSystemPrompt: "Daemon instructions.",
+      },
+      expectedInstructions: "Agent instructions.\n\nDaemon instructions.",
+    },
+  ])(
+    "passes thread instructions once on resume $name",
+    async ({ config, expectedInstructions }) => {
+      const session = createSession(config);
+      session.currentThreadId = "archived-thread-id";
+      session.activeForegroundTurnId = null;
+      let threadLoaded = false;
+      const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+      session.client = {
+        request: vi.fn(async (method: string, params: unknown) => {
+          requests.push({ method, params: params as Record<string, unknown> });
+          if (method === "thread/loaded/list") {
+            return { data: threadLoaded ? ["archived-thread-id"] : [] };
+          }
+          if (method === "thread/resume") {
+            threadLoaded = true;
+            return {};
+          }
+          if (method === "turn/start") {
+            return {};
+          }
+          throw new Error(`Unexpected request: ${method}`);
+        }),
+      };
+
+      await asInternals(session).ensureThreadLoaded();
+      await session.startTurn("continue the implementation");
+
+      const resumes = requests.filter((request) => request.method === "thread/resume");
+      const turnStarts = requests.filter((request) => request.method === "turn/start");
+      expect(resumes).toHaveLength(1);
+      expect(turnStarts).toHaveLength(1);
+      const resume = resumes[0];
+      const turnStart = turnStarts[0];
+      if (expectedInstructions === undefined) {
+        expect(resume.params).not.toHaveProperty("developerInstructions");
+      } else {
+        expect(resume.params).toMatchObject({ developerInstructions: expectedInstructions });
+      }
+      expect(turnStart.params).not.toHaveProperty("developerInstructions");
+    },
+  );
+
   test("appends blank-line spacing to /goal status messages", async () => {
     const requests: Array<{ method: string; params: unknown }> = [];
     const session = createSession({}, { goalsEnabled: true });
@@ -4831,12 +4897,11 @@ describe("Codex app-server provider", () => {
       {
         name: "Code",
         mode: "code",
-        developer_instructions: "Built-in code mode",
       },
       {
         name: "Plan",
         mode: "plan",
-        developer_instructions: "Built-in plan mode",
+        reasoning_effort: "medium",
       },
     ];
     asInternals(session).refreshResolvedCollaborationMode();

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3171,7 +3171,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     mode?: string | null;
     model?: string | null;
     reasoning_effort?: string | null;
-    developer_instructions?: string | null;
   }> = [];
   private resolvedCollaborationMode: {
     mode: string;
@@ -3349,10 +3348,6 @@ export class CodexAppServerAgentSession implements AgentSession {
           model: typeof record?.model === "string" ? record.model : null,
           reasoning_effort:
             typeof record?.reasoning_effort === "string" ? record.reasoning_effort : null,
-          developer_instructions:
-            typeof record?.developer_instructions === "string"
-              ? record.developer_instructions
-              : null,
         };
       });
     } catch (error) {
@@ -3418,7 +3413,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     mode?: string | null;
     model?: string | null;
     reasoning_effort?: string | null;
-    developer_instructions?: string | null;
   } | null {
     if (this.collaborationModes.length === 0) return null;
     const findByName = (predicate: (name: string) => boolean) =>
@@ -3451,15 +3445,9 @@ export class CodexAppServerAgentSession implements AgentSession {
     const match = this.findCollaborationMode(this.planModeEnabled ? "plan" : "code");
     if (!match) return null;
 
-    const settings: Record<string, unknown> = {};
+    const settings: Record<string, unknown> = { developer_instructions: null };
     if (match.model) settings.model = match.model;
     if (match.reasoning_effort) settings.reasoning_effort = match.reasoning_effort;
-    const developerInstructions = composeSystemPromptParts(
-      match.developer_instructions,
-      this.config.systemPrompt,
-      this.config.daemonAppendSystemPrompt,
-    );
-    if (developerInstructions) settings.developer_instructions = developerInstructions;
     if (this.config.model) settings.model = this.config.model;
     const thinkingOptionId = normalizeCodexThinkingOptionId(this.config.thinkingOptionId);
     if (thinkingOptionId) settings.reasoning_effort = thinkingOptionId;
@@ -3754,7 +3742,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     approvalPolicy: string;
     sandboxPolicyType: string;
     hasOutputSchema: boolean;
-    hasDeveloperInstructions: boolean;
     hasCodexConfig: boolean;
   }> {
     const input = await this.buildUserInput(prompt);
@@ -3797,13 +3784,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     if (options?.outputSchema) {
       params.outputSchema = normalizeCodexOutputSchema(options.outputSchema);
     }
-    const developerInstructions = composeSystemPromptParts(
-      this.config.systemPrompt,
-      this.config.daemonAppendSystemPrompt,
-    );
-    if (developerInstructions) {
-      params.developerInstructions = developerInstructions;
-    }
     const codexConfig = this.buildCodexInnerConfig();
     if (codexConfig) {
       params.config = codexConfig;
@@ -3815,7 +3795,6 @@ export class CodexAppServerAgentSession implements AgentSession {
       approvalPolicy,
       sandboxPolicyType,
       hasOutputSchema: Boolean(options?.outputSchema),
-      hasDeveloperInstructions: Boolean(developerInstructions),
       hasCodexConfig: Boolean(codexConfig),
     };
   }
@@ -3826,7 +3805,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     approvalPolicy,
     sandboxPolicyType,
     hasOutputSchema,
-    hasDeveloperInstructions,
     hasCodexConfig,
   }: {
     turnId: string;
@@ -3834,7 +3812,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     approvalPolicy: string;
     sandboxPolicyType: string;
     hasOutputSchema: boolean;
-    hasDeveloperInstructions: boolean;
     hasCodexConfig: boolean;
   }): void {
     this.logger.info(
@@ -3850,7 +3827,6 @@ export class CodexAppServerAgentSession implements AgentSession {
         sandboxPolicyType,
         hasCollaborationMode: Boolean(this.resolvedCollaborationMode),
         hasOutputSchema,
-        hasDeveloperInstructions,
         hasCodexConfig,
       },
       "Starting Codex app-server turn",
@@ -3950,7 +3926,6 @@ export class CodexAppServerAgentSession implements AgentSession {
         approvalPolicy: turnStart.approvalPolicy,
         sandboxPolicyType: turnStart.sandboxPolicyType,
         hasOutputSchema: turnStart.hasOutputSchema,
-        hasDeveloperInstructions: turnStart.hasDeveloperInstructions,
         hasCodexConfig: turnStart.hasCodexConfig,
       });
       await this.client.request("turn/start", turnStart.params, TURN_START_TIMEOUT_MS);

--- a/packages/server/src/server/agent/providers/codex-plan-mode.real.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/codex-plan-mode.real.e2e.test.ts
@@ -1,9 +1,11 @@
 import { beforeAll, beforeEach, describe, expect, test } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createTestLogger } from "../../../test-utils/test-logger.js";
+import type { AgentStreamEvent } from "../agent-sdk-types.js";
 import {
   canRunRealProvider,
   createRealProviderClient,
@@ -12,6 +14,28 @@ import {
 
 function tmpCwd(): string {
   return mkdtempSync(path.join(tmpdir(), "codex-plan-mode-real-"));
+}
+
+function waitForEvent<TEvent extends AgentStreamEvent>(params: {
+  session: { subscribe(callback: (event: AgentStreamEvent) => void): () => void };
+  predicate: (event: AgentStreamEvent) => event is TEvent;
+  label: string;
+  timeoutMs?: number;
+}): Promise<TEvent> {
+  return new Promise<TEvent>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(new Error(`Timed out waiting for ${params.label}`));
+    }, params.timeoutMs ?? 120_000);
+    const unsubscribe = params.session.subscribe((event) => {
+      if (!params.predicate(event)) {
+        return;
+      }
+      clearTimeout(timeout);
+      unsubscribe();
+      resolve(event);
+    });
+  });
 }
 
 describe("Codex app-server provider (real) plan mode", () => {
@@ -27,9 +51,27 @@ describe("Codex app-server provider (real) plan mode", () => {
     }
   });
 
-  test("maps gpt-5.4 markdown plans to a plan tool call instead of todo items", async () => {
+  test("keeps implementation requests read-only with appended host instructions", async () => {
     const cwd = tmpCwd();
     const client = createRealProviderClient("codex", createTestLogger());
+    const targetFileName = "implementation-sentinel.txt";
+    const targetPath = path.join(cwd, targetFileName);
+    execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+    writeFileSync(path.join(cwd, "AGENTS.md"), "# Test fixture\n\nNo additional instructions.\n");
+    execFileSync("git", ["add", "AGENTS.md"], { cwd, stdio: "ignore" });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Paseo Tests",
+        "-c",
+        "user.email=tests@paseo.invalid",
+        "commit",
+        "-m",
+        "Initialize fixture",
+      ],
+      { cwd, stdio: "ignore" },
+    );
 
     try {
       const session = await client.createSession({
@@ -37,33 +79,64 @@ describe("Codex app-server provider (real) plan mode", () => {
         cwd,
         modeId: "auto",
         thinkingOptionId: "medium",
+        daemonAppendSystemPrompt: "The host application is Paseo.",
       });
 
       try {
         await session.setFeature?.("plan_mode", true);
+        const events: AgentStreamEvent[] = [];
+        const unsubscribe = session.subscribe((event) => events.push(event));
 
-        const result = await session.run(
-          "You are in plan mode. Produce a markdown plan with a short heading and exactly 3 bullets for implementing a login screen. Do not ask questions.",
-        );
+        try {
+          const planApproval = waitForEvent({
+            session,
+            label: "Codex plan approval",
+            predicate: (
+              event,
+            ): event is Extract<AgentStreamEvent, { type: "permission_requested" }> =>
+              event.type === "permission_requested" && event.request.kind === "plan",
+          });
+          const turnFinished = waitForEvent({
+            session,
+            label: "Codex plan turn completion",
+            predicate: (
+              event,
+            ): event is Extract<
+              AgentStreamEvent,
+              { type: "turn_completed" | "turn_failed" | "turn_canceled" }
+            > =>
+              event.type === "turn_completed" ||
+              event.type === "turn_failed" ||
+              event.type === "turn_canceled",
+          });
 
-        expect(result.timeline).not.toContainEqual(
-          expect.objectContaining({
-            type: "todo",
-          }),
-        );
+          await session.startTurn(
+            `Create ${targetFileName} with a single line containing IMPLEMENTED. Do not inspect existing files or ask questions; complete the change now.`,
+          );
+          const [permission, terminal] = await Promise.all([planApproval, turnFinished]);
 
-        const planCall = result.timeline.find(
-          (item) => item.type === "tool_call" && item.detail.type === "plan",
-        );
-
-        expect(planCall).toBeDefined();
-        if (!planCall || planCall.type !== "tool_call" || planCall.detail.type !== "plan") {
-          throw new Error("Expected a plan tool call");
+          expect(existsSync(targetPath)).toBe(false);
+          expect(execFileSync("git", ["status", "--short"], { cwd, encoding: "utf8" }).trim()).toBe(
+            "",
+          );
+          expect(terminal.type).toBe("turn_completed");
+          expect(permission.request).toMatchObject({
+            provider: "codex",
+            name: "CodexPlanApproval",
+            kind: "plan",
+            input: {
+              plan: expect.stringContaining(targetFileName),
+            },
+          });
+          expect(events).not.toContainEqual(
+            expect.objectContaining({
+              type: "timeline",
+              item: expect.objectContaining({ type: "todo" }),
+            }),
+          );
+        } finally {
+          unsubscribe();
         }
-
-        expect(planCall.detail.text).toContain("Login");
-        expect(planCall.detail.text).toContain("- ");
-        expect(result.finalText).toBe(planCall.detail.text);
       } finally {
         await session.close();
       }


### PR DESCRIPTION
## Summary

- preserve Codex's built-in collaboration-mode instructions by leaving `developer_instructions` null
- send composed host instructions only when starting or resuming a thread
- remove the duplicate turn-level instruction payload and align collaboration-mode fixtures with the current app-server response
- add unit, local app-server, real-provider, and approval UI regression coverage

## Root cause

`collaborationMode/list` does not expose Codex's built-in mode instructions. Paseo treated the omitted value as content to compose with host-level prompts and sent the result through `collaborationMode.settings.developer_instructions`, which overrides the built-in Plan mode instructions. The same appended prompt was also sent again through `turn/start`.

This change keeps mode selection and host-provided instructions on their separate app-server surfaces: Codex resolves the built-in mode instructions, while Paseo supplies appended instructions once at the thread level.

## Validation

- provider unit tests: 125 passed
- local Codex app-server E2E: 2 passed
- real-provider Plan mode E2E: 1 passed
- Plan approval App E2E: 1 passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

Fixes #2231
