### PR TITLE
feat(app): up-arrow message history recall in the composer

### DIFF
--- a/packages/app/src/components/ui/autocomplete.tsx
+++ b/packages/app/src/components/ui/autocomplete.tsx
@@ -20,7 +20,7 @@ export interface AutocompleteOption {
   label: string;
   detail?: string;
   description?: string;
-  kind?: "command" | "file" | "directory";
+  kind?: "command" | "file" | "directory" | "history";
 }
 
 interface AutocompleteProps {
@@ -105,7 +105,12 @@ function AutocompleteRow({
         </>
       ) : (
         <View style={styles.itemMainRow}>
-          <Text style={styles.itemLabel}>{optionLabel}</Text>
+          <Text
+            style={!optionDescription ? styles.itemLabelFill : styles.itemLabel}
+            numberOfLines={1}
+          >
+            {optionLabel}
+          </Text>
           {optionDescription ? (
             <Text style={styles.itemDescriptionInline} numberOfLines={1}>
               {optionDescription}
@@ -245,19 +250,11 @@ export function Autocomplete({
 
   return (
     <View style={styles.outerWrapper}>
-      {selectedOption?.kind === "command" && selectedOption.description ? (
-        <View style={styles.detailCard}>
-          <Text style={styles.detailLabel}>
-            {removeBoltGlyphs(selectedOption.label) ?? selectedOption.label}
-          </Text>
-          <Text style={styles.detailDescription}>
-            {removeBoltGlyphs(selectedOption.description)}
-          </Text>
-          {selectedOption.detail ? (
-            <Text style={styles.detailHint}>{removeBoltGlyphs(selectedOption.detail)}</Text>
-          ) : null}
-        </View>
-      ) : null}
+      <AutocompleteDetail
+        option={selectedOption}
+        selectedIndex={selectedIndex}
+        total={options.length}
+      />
       <View style={containerStyle}>
         <ScrollView
           ref={scrollRef}
@@ -366,6 +363,14 @@ const styles = StyleSheet.create((theme: Theme) => ({
     fontSize: theme.fontSize.sm,
     fontWeight: theme.fontWeight.normal,
   },
+  // When a row has no description (e.g. message history), let the label fill the
+  // row so numberOfLines={1} truncates with an ellipsis instead of overflowing.
+  itemLabelFill: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.normal,
+    flex: 1,
+  },
   itemDetail: {
     color: theme.colors.foregroundMuted,
     fontSize: theme.fontSize.xs,
@@ -389,3 +394,47 @@ const styles = StyleSheet.create((theme: Theme) => ({
     fontSize: theme.fontSize.sm,
   },
 })) as unknown as Record<string, object>;
+
+/**
+ * Preview panel above the list for the selected option. Commands (skills) show
+ * their name and description; history messages show the selected position
+ * (e.g. "2 / 5") as the header and the full message text below, so a row that
+ * was truncated to one line can still be read in full.
+ */
+function AutocompleteDetail({
+  option,
+  selectedIndex,
+  total,
+}: {
+  option: AutocompleteOption | undefined;
+  selectedIndex: number;
+  total: number;
+}) {
+  if (!option) {
+    return null;
+  }
+  if (option.kind === "command" && option.description) {
+    return (
+      <View style={styles.detailCard}>
+        <Text style={styles.detailLabel}>{removeBoltGlyphs(option.label) ?? option.label}</Text>
+        <Text style={styles.detailDescription}>{removeBoltGlyphs(option.description)}</Text>
+        {option.detail ? (
+          <Text style={styles.detailHint}>{removeBoltGlyphs(option.detail)}</Text>
+        ) : null}
+      </View>
+    );
+  }
+  if (option.kind === "history") {
+    return (
+      <View style={styles.detailCard}>
+        <Text style={styles.detailLabel}>
+          {selectedIndex + 1} / {total}
+        </Text>
+        <Text style={styles.detailDescription}>
+          {removeBoltGlyphs(option.label) ?? option.label}
+        </Text>
+      </View>
+    );
+  }
+  return null;
+}

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -45,6 +45,7 @@ import { useFilePicker } from "@/hooks/use-file-picker";
 import { useFileDrop } from "@/components/file-drop/use-file-drop";
 import type { DroppedItem } from "@/components/file-drop/types";
 import { MessageInput, type MessageInputRef, type AttachmentMenuItem } from "./input/input";
+import { useMessageHistory } from "./input/use-message-history";
 import type { ImageAttachment, MessagePayload } from "./types";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import type { DraftCommandConfig } from "@/hooks/use-agent-commands-query";
@@ -1136,6 +1137,20 @@ export function Composer({
   const autocompleteOnKeyPressRef = useRef(autocomplete.onKeyPress);
   autocompleteOnKeyPressRef.current = autocomplete.onKeyPress;
 
+  const {
+    handleHistoryKey,
+    closePopover: closeMessageHistory,
+    popover: messageHistoryPopover,
+  } = useMessageHistory({
+    agentId,
+    serverId,
+    value: userInput,
+    setValue: setUserInput,
+    cursorIndex,
+  });
+  const historyOnKeyPressRef = useRef(handleHistoryKey);
+  historyOnKeyPressRef.current = handleHistoryKey;
+
   // Clear send error when user edits the input
   useEffect(() => {
     if (sendError && userInput) {
@@ -1616,10 +1631,13 @@ export function Composer({
 
   const hasSendableContent = userInput.trim().length > 0 || selectedAttachments.length > 0;
 
-  // Handle keyboard navigation for command autocomplete.
+  // Handle keyboard navigation for command autocomplete, then message history recall.
   const handleCommandKeyPress = useCallback(
-    (event: { key: string; preventDefault: () => void }) =>
-      autocompleteOnKeyPressRef.current(event),
+    (event: { key: string; preventDefault: () => void }) => {
+      if (autocompleteOnKeyPressRef.current(event)) return true;
+      if (historyOnKeyPressRef.current(event)) return true;
+      return false;
+    },
     [],
   );
 
@@ -1862,9 +1880,11 @@ export function Composer({
       setIsMessageInputFocused(focused);
       if (focused) {
         onAttentionInputFocus?.();
+      } else {
+        closeMessageHistory();
       }
     },
-    [onAttentionInputFocus],
+    [closeMessageHistory, onAttentionInputFocus],
   );
 
   const handleLightboxClose = useCallback(() => {
@@ -1988,6 +2008,13 @@ export function Composer({
                 errorMessage={autocomplete.errorMessage}
                 loadingText={autocomplete.loadingText}
                 emptyText={autocomplete.emptyText}
+              />
+              <AutocompletePopover
+                visible={messageHistoryPopover.visible}
+                anchorRef={messageInputContainerRef}
+                options={messageHistoryPopover.options}
+                selectedIndex={messageHistoryPopover.selectedIndex}
+                onSelect={messageHistoryPopover.onSelect}
               />
 
               {/* MessageInput handles everything: text, dictation, attachments, all buttons */}

--- a/packages/app/src/composer/input/use-message-history.test.ts
+++ b/packages/app/src/composer/input/use-message-history.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { StreamItem } from "@/types/stream";
+import { deriveMessageHistory } from "./use-message-history";
+
+const userMessage = (text: string, id = text): StreamItem =>
+  ({ kind: "user_message", id, text, timestamp: new Date(0) }) as StreamItem;
+const assistantMessage = (text: string): StreamItem =>
+  ({ kind: "assistant_message", id: text, text, timestamp: new Date(0) }) as StreamItem;
+const thought = (): StreamItem =>
+  ({ kind: "thought", text: "thinking", timestamp: new Date(0) }) as StreamItem;
+
+describe("deriveMessageHistory", () => {
+  it("keeps only user messages, in stream order (oldest-first)", () => {
+    const items: StreamItem[] = [
+      userMessage("first"),
+      assistantMessage("a1"),
+      userMessage("second"),
+    ];
+    expect(deriveMessageHistory(items)).toEqual(["first", "second"]);
+  });
+
+  it("ignores non-user items such as assistant messages and thoughts", () => {
+    const items: StreamItem[] = [thought(), userMessage("only"), assistantMessage("reply")];
+    expect(deriveMessageHistory(items)).toEqual(["only"]);
+  });
+
+  it("ignores empty and whitespace-only user messages", () => {
+    const items: StreamItem[] = [userMessage("   "), userMessage("real"), userMessage("")];
+    expect(deriveMessageHistory(items)).toEqual(["real"]);
+  });
+
+  it("trims surrounding whitespace before storing", () => {
+    expect(deriveMessageHistory([userMessage("  hi  ")])).toEqual(["hi"]);
+  });
+
+  it("caps to the most recent N entries", () => {
+    const items: StreamItem[] = ["1", "2", "3", "4"].map((t) => userMessage(t));
+    expect(deriveMessageHistory(items, 2)).toEqual(["3", "4"]);
+  });
+
+  it("returns an empty list when there are no user messages", () => {
+    expect(deriveMessageHistory([assistantMessage("a"), thought()])).toEqual([]);
+  });
+});

--- a/packages/app/src/composer/input/use-message-history.ts
+++ b/packages/app/src/composer/input/use-message-history.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { AutocompleteOption } from "@/components/ui/autocomplete";
+import { useSessionStore } from "@/stores/session-store";
+import type { StreamItem } from "@/types/stream";
+
+/**
+ * Up/down arrow recall of previously sent messages, sourced from the agent's
+ * daemon-backed message stream (the same user messages rendered above the
+ * composer), presented as a completion-style popover (the same
+ * AutocompletePopover used by file and skill pickers).
+ *
+ * Interaction mirrors @file / /skill completion: ArrowUp on an empty input
+ * opens the popover with the most recent message highlighted (closest to the
+ * input); ArrowUp/Down move the highlight (Up = older); Enter or a click fills
+ * the input and closes; Escape closes without filling.
+ */
+
+const MAX_HISTORY = 100;
+const EMPTY_STREAM_ITEMS: readonly StreamItem[] = [];
+
+/**
+ * Pure: extract recallable user-message texts (oldest-first) from an agent's
+ * stream tail, capped to the most recent MAX_HISTORY. Empty/whitespace-only
+ * messages are ignored.
+ */
+export function deriveMessageHistory(
+  items: readonly StreamItem[],
+  max: number = MAX_HISTORY,
+): string[] {
+  const texts: string[] = [];
+  for (const item of items) {
+    if (item.kind === "user_message") {
+      const text = item.text.trim();
+      if (text) {
+        texts.push(text);
+      }
+    }
+  }
+  return texts.length > max ? texts.slice(texts.length - max) : texts;
+}
+
+export interface UseMessageHistoryArgs {
+  agentId: string;
+  serverId: string;
+  value: string;
+  setValue: (text: string) => void;
+  cursorIndex: number;
+}
+
+export interface MessageHistoryPopover {
+  visible: boolean;
+  options: readonly AutocompleteOption[];
+  selectedIndex: number;
+  onSelect: (option: AutocompleteOption) => void;
+}
+
+export interface UseMessageHistoryResult {
+  /** Key handler; returns true when it consumed a key (arrow / enter / escape). */
+  handleHistoryKey: (event: { key: string; preventDefault: () => void }) => boolean;
+  /** Close the popover without selecting (e.g. on input blur). */
+  closePopover: () => void;
+  /** Reactive view driving the history AutocompletePopover. */
+  popover: MessageHistoryPopover;
+}
+
+export function useMessageHistory({
+  agentId,
+  serverId,
+  value,
+  setValue,
+  cursorIndex,
+}: UseMessageHistoryArgs): UseMessageHistoryResult {
+  // The authoritative source: the agent's chronological stream tail from the
+  // daemon. Empty for placeholder agentIds used by agent-creation composers.
+  const streamItems =
+    useSessionStore((state) =>
+      agentId && serverId ? state.sessions[serverId]?.agentStreamTail?.get(agentId) : undefined,
+    ) ?? EMPTY_STREAM_ITEMS;
+  const history = useMemo(() => deriveMessageHistory(streamItems), [streamItems]);
+
+  const [open, setOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Mirror live values into refs so the stable key handler reads fresh state
+  // without churn in callback identity (matches the autocomplete ref pattern).
+  const openRef = useRef(false);
+  openRef.current = open;
+  const selectedIndexRef = useRef(0);
+  selectedIndexRef.current = selectedIndex;
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const cursorIndexRef = useRef(cursorIndex);
+  cursorIndexRef.current = cursorIndex;
+  const setValueRef = useRef(setValue);
+  setValueRef.current = setValue;
+
+  // Close the popover and drop a stale selection when the scoped conversation
+  // changes or the stream shrinks below the current index.
+  useEffect(() => {
+    setOpen(false);
+  }, [agentId, serverId]);
+
+  useEffect(() => {
+    setSelectedIndex((index) => (history.length === 0 ? 0 : Math.min(index, history.length - 1)));
+  }, [history]);
+
+  const closePopover = useCallback(() => setOpen(false), []);
+
+  const handleHistoryKey = useCallback(
+    (event: { key: string; preventDefault: () => void }) => {
+      if (history.length === 0) {
+        return false;
+      }
+      if (!openRef.current) {
+        // Open with ArrowUp only when the input is empty and the cursor sits
+        // at the start, so multi-line line navigation still works otherwise.
+        if (event.key === "ArrowUp" && valueRef.current === "" && cursorIndexRef.current === 0) {
+          event.preventDefault();
+          setSelectedIndex(history.length - 1);
+          setOpen(true);
+          return true;
+        }
+        return false;
+      }
+
+      switch (event.key) {
+        case "ArrowUp":
+          event.preventDefault();
+          setSelectedIndex((index) => Math.max(0, index - 1));
+          return true;
+        case "ArrowDown":
+          event.preventDefault();
+          setSelectedIndex((index) => Math.min(history.length - 1, index + 1));
+          return true;
+        case "Enter":
+          event.preventDefault();
+          setOpen(false);
+          setValueRef.current(history[selectedIndexRef.current] ?? "");
+          return true;
+        case "Escape":
+          event.preventDefault();
+          setOpen(false);
+          return true;
+        default:
+          // Any other key (typing) closes the popover and falls through to the input.
+          setOpen(false);
+          return false;
+      }
+    },
+    [history],
+  );
+
+  const onSelect = useCallback((option: AutocompleteOption) => {
+    setOpen(false);
+    setValueRef.current(option.label);
+  }, []);
+
+  const options = useMemo<AutocompleteOption[]>(
+    () =>
+      history.map((text, index) => ({
+        id: `${agentId}:${index}`,
+        label: text,
+        kind: "history",
+      })),
+    [agentId, history],
+  );
+
+  const popover: MessageHistoryPopover = { visible: open, options, selectedIndex, onSelect };
+
+  return { handleHistoryKey, closePopover, popover };
+}

--- a/packages/app/src/composer/input/use-message-history.web-flow.test.tsx
+++ b/packages/app/src/composer/input/use-message-history.web-flow.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useState } from "react";
+import { useSessionStore, type SessionState } from "@/stores/session-store";
+import type { StreamItem } from "@/types/stream";
+import { useMessageHistory } from "./use-message-history";
+
+/**
+ * Drives the hook with the same wiring the Composer uses on web (setValue
+ * moves the cursor to the end of the new text) and seeds the daemon-backed
+ * stream the hook now reads from. Covers the picker interaction; the source
+ * being the agent's stream means the first message is recallable for free.
+ */
+
+const SERVER = "srv-test";
+
+const press = (
+  handle: (event: { key: string; preventDefault: () => void }) => boolean,
+  key: string,
+) => handle({ key, preventDefault: () => {} });
+
+function seedUserMessages(agentId: string, texts: string[]): void {
+  const items: StreamItem[] = texts.map((text, index) => ({
+    kind: "user_message",
+    id: `${agentId}:${index}`,
+    text,
+    timestamp: new Date(index),
+  })) as StreamItem[];
+  useSessionStore.setState((state) => {
+    const prev = state.sessions[SERVER] as SessionState | undefined;
+    const tail = new Map(prev?.agentStreamTail ?? []).set(agentId, items);
+    return {
+      ...state,
+      sessions: { ...state.sessions, [SERVER]: { ...prev, agentStreamTail: tail } as SessionState },
+    };
+  });
+}
+
+function renderHistory(agentId: string) {
+  let lastValue = "";
+  const { result } = renderHook(() => {
+    const [value, setValue] = useState("");
+    const [cursor, setCursor] = useState(0);
+    lastValue = value;
+    return useMessageHistory({
+      agentId,
+      serverId: SERVER,
+      value,
+      setValue: (next: string) => {
+        setValue(next);
+        setCursor(next.length);
+      },
+      cursorIndex: cursor,
+    });
+  });
+  return { result, getLastValue: () => lastValue };
+}
+
+describe("useMessageHistory (picker)", () => {
+  it("opens on ArrowUp, navigates with arrows, selects on Enter", () => {
+    seedUserMessages("open", ["first", "second"]);
+    const { result, getLastValue } = renderHistory("open");
+    expect(result.current.popover.visible).toBe(false);
+
+    // ArrowUp on an empty input opens at the newest entry; input is not filled.
+    act(() => expect(press(result.current.handleHistoryKey, "ArrowUp")).toBe(true));
+    expect(result.current.popover.visible).toBe(true);
+    expect(result.current.popover.selectedIndex).toBe(1);
+    expect(result.current.popover.options.map((o) => o.label)).toEqual(["first", "second"]);
+    expect(getLastValue()).toBe("");
+
+    // ArrowUp moves toward older; input stays empty in picker mode.
+    act(() => expect(press(result.current.handleHistoryKey, "ArrowUp")).toBe(true));
+    expect(result.current.popover.selectedIndex).toBe(0);
+    expect(getLastValue()).toBe("");
+
+    // Enter selects the highlighted message, fills the input, and closes.
+    act(() => expect(press(result.current.handleHistoryKey, "Enter")).toBe(true));
+    expect(getLastValue()).toBe("first");
+    expect(result.current.popover.visible).toBe(false);
+  });
+
+  it("Escape closes the popover without filling the input", () => {
+    seedUserMessages("escape", ["only"]);
+    const { result, getLastValue } = renderHistory("escape");
+    act(() => press(result.current.handleHistoryKey, "ArrowUp"));
+    expect(result.current.popover.visible).toBe(true);
+
+    act(() => expect(press(result.current.handleHistoryKey, "Escape")).toBe(true));
+    expect(result.current.popover.visible).toBe(false);
+    expect(getLastValue()).toBe("");
+  });
+
+  it("does not open when the input is not empty", () => {
+    seedUserMessages("guard", ["first"]);
+    const { result } = renderHistory("guard");
+    act(() => press(result.current.handleHistoryKey, "ArrowUp"));
+    act(() => press(result.current.handleHistoryKey, "Enter"));
+    // Now value === "first"; ArrowUp must not reopen (multi-line nav should work).
+    act(() => expect(press(result.current.handleHistoryKey, "ArrowUp")).toBe(false));
+    expect(result.current.popover.visible).toBe(false);
+  });
+
+  it("recalls the first (oldest) message, sourced from the agent stream", () => {
+    // The first message lives in the daemon stream; no special recording needed.
+    seedUserMessages("created", ["creation first message", "follow up"]);
+    const { result, getLastValue } = renderHistory("created");
+
+    act(() => press(result.current.handleHistoryKey, "ArrowUp")); // newest = "follow up"
+    act(() => press(result.current.handleHistoryKey, "ArrowUp")); // older = "creation first message"
+    expect(result.current.popover.selectedIndex).toBe(0);
+    act(() => press(result.current.handleHistoryKey, "Enter"));
+    expect(getLastValue()).toBe("creation first message");
+  });
+});


### PR DESCRIPTION
## What

Press **ArrowUp** on an empty composer to browse the agent's previously sent user messages as a completion popover (the same `AutocompletePopover` used by `@file` and `/skill` pickers). ArrowUp/Down navigate, Enter fills the input, Escape closes.

## Why this source

History is read from the agent's **daemon-backed message stream** (`useSessionStore` `agentStreamTail`), not a separate in-memory store:

- Includes **every** user message sent to the agent - including the first/creation message (which previously got orphaned under a placeholder agentId).
- Survives app restarts and syncs across devices.
- No `recordSent` / recording-on-send machinery to keep in sync.

## UX

- Rows render **single-line** with ellipsis truncation (so long messages don't blow up row height).
- The selected message shows in the **detail card** with its **position/count** (e.g. `2 / 5`) and the **full text** below - mirroring the skill description preview, so a truncated row can still be read in full.

## Changes

- `composer/input/use-message-history.ts` (new) - hook reading the daemon stream; pure `deriveMessageHistory` helper; picker open/navigate/select/escape logic.
- `composer/index.tsx` - wire the hook into the composer (key handler chained after autocomplete, popover above the input, blur-to-close).
- `components/ui/autocomplete.tsx` - new `"history"` option kind, single-line label truncation, and a `AutocompleteDetail` card that shows position/count + full text for history (skill/command behavior unchanged).

## Testing

- `deriveMessageHistory` unit tests (filtering, trim, cap).
- Web-flow picker tests via `renderHook` + seeded `useSessionStore` (open/navigate/select/escape; first-message recallable).
- i18n parity test still green.
- Browser-verified on web: single-line rows, `2 / 5`-style card, full-text preview for long messages, first (creation) message recallable.
- Lint / typecheck / Biome format clean.
