### PR TITLE
feat(opencode): switch the effective model when selecting a model-bound agent

### DIFF
--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -67,6 +67,7 @@ export interface AgentMode {
   description?: string;
   icon?: string;
   colorTier?: string;
+  model?: string;
 }
 
 export type ProviderStatus = "ready" | "loading" | "error" | "unavailable";

--- a/packages/protocol/src/messages.agent-mode-model.test.ts
+++ b/packages/protocol/src/messages.agent-mode-model.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { ProviderSnapshotEntrySchema } from "./messages";
+
+// AgentMode.model is an additive, optional field. These tests pin both-direction
+// back-compat: a new daemon may send a mode carrying `model`, and an old-shaped
+// mode (no `model`) must still parse. AgentModeSchema is exercised through the
+// exported ProviderSnapshotEntrySchema.modes array.
+describe("AgentMode model back-compat", () => {
+  it("parses a mode without a model (old client / old daemon)", () => {
+    const parsed = ProviderSnapshotEntrySchema.parse({
+      provider: "example",
+      status: "ready",
+      label: "Example",
+      modes: [{ id: "build", label: "Build" }],
+    });
+
+    expect(parsed.modes?.[0]).toEqual({ id: "build", label: "Build" });
+    expect(parsed.modes?.[0]?.model).toBeUndefined();
+  });
+
+  it("parses a mode carrying a model (new daemon → any client)", () => {
+    const parsed = ProviderSnapshotEntrySchema.parse({
+      provider: "example",
+      status: "ready",
+      label: "Example",
+      modes: [{ id: "build", label: "Build", model: "anthropic/claude-sonnet-4" }],
+    });
+
+    expect(parsed.modes?.[0]?.model).toBe("anthropic/claude-sonnet-4");
+  });
+});

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -199,6 +199,7 @@ const AgentModeSchema: z.ZodType<AgentMode> = z.object({
   description: z.string().optional(),
   icon: z.string().optional(),
   colorTier: z.string().optional(),
+  model: z.string().optional(),
 });
 
 const ProviderStatusSchema: z.ZodType<ProviderStatus> = z.enum([

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -3103,6 +3103,220 @@ test("persists live mode, model, and thinking changes without an external snapsh
   expect(persisted?.runtimeInfo?.model).toBe("gpt-5.4");
 });
 
+test("setAgentMode surfaces the agent-bound model into runtimeInfo on a mode switch", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-mode-bound-model-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  // A session whose bound model follows the selected mode/agent, for a provider
+  // that binds a model to an agent/mode. Selecting the mode must switch the
+  // effective model, which setAgentMode reads via getRuntimeInfo().
+  const MODEL_BY_MODE: Record<string, string> = {
+    atlas: "moonshot/kimi",
+    sisyphus: "anthropic/claude",
+  };
+
+  class BoundModelSession implements AgentSession {
+    readonly provider = "codex" as const;
+    readonly capabilities = TEST_CAPABILITIES;
+    readonly id = randomUUID();
+    private currentMode: string | null;
+    private effectiveModel: string | null;
+
+    constructor(private readonly config: AgentSessionConfig) {
+      this.currentMode = config.modeId ?? null;
+      this.effectiveModel = config.model ?? null;
+    }
+
+    async run(): Promise<AgentRunResult> {
+      return { sessionId: this.id, finalText: "", timeline: [] };
+    }
+
+    async startTurn(): Promise<{ turnId: string }> {
+      return { turnId: "turn-1" };
+    }
+
+    subscribe(): () => void {
+      return () => {};
+    }
+
+    async *streamHistory(): AsyncGenerator<AgentStreamEvent> {}
+
+    async getRuntimeInfo() {
+      return {
+        provider: this.provider,
+        sessionId: this.id,
+        model: this.effectiveModel,
+        modeId: this.currentMode,
+      };
+    }
+
+    async getAvailableModes() {
+      return [];
+    }
+
+    async getCurrentMode() {
+      return this.currentMode;
+    }
+
+    async setMode(modeId: string): Promise<void> {
+      this.currentMode = modeId;
+      const bound = MODEL_BY_MODE[modeId];
+      if (bound) {
+        this.effectiveModel = bound;
+      }
+    }
+
+    getPendingPermissions() {
+      return [];
+    }
+
+    async respondToPermission(): Promise<void> {}
+
+    describePersistence() {
+      return { provider: this.provider, sessionId: this.id };
+    }
+
+    async interrupt(): Promise<void> {}
+    async close(): Promise<void> {}
+  }
+
+  class BoundModelClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new BoundModelSession(config);
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: {
+      codex: new BoundModelClient(),
+    },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000401",
+  });
+
+  const snapshot = await manager.createAgent(
+    {
+      provider: "codex",
+      cwd: workdir,
+      modeId: "sisyphus",
+    },
+    undefined,
+    { workspaceId: undefined },
+  );
+
+  await manager.setAgentMode(snapshot.id, "atlas");
+
+  const agent = manager.getAgent(snapshot.id);
+  expect(agent?.currentModeId).toBe("atlas");
+  expect(agent?.runtimeInfo?.model).toBe("moonshot/kimi");
+  expect(agent?.config.model).toBe("moonshot/kimi");
+});
+
+test("setAgentModel surfaces the session's resolved model when clearing an override reverts to a bound model", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-clear-override-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  const BOUND_MODEL = "moonshot/kimi";
+
+  // A provider that binds a model to its agent: an explicit setModel wins, but
+  // clearing it (setModel(null)) reverts to the bound model rather than clearing,
+  // as OpenCodeAgentSession does. The manager must read the session's resolved
+  // effective model back instead of assuming the requested value.
+  class RevertingModelSession implements AgentSession {
+    readonly provider = "codex" as const;
+    readonly capabilities = TEST_CAPABILITIES;
+    readonly id = randomUUID();
+    private effectiveModel: string | null = BOUND_MODEL;
+
+    async run(): Promise<AgentRunResult> {
+      return { sessionId: this.id, finalText: "", timeline: [] };
+    }
+
+    async startTurn(): Promise<{ turnId: string }> {
+      return { turnId: "turn-1" };
+    }
+
+    subscribe(): () => void {
+      return () => {};
+    }
+
+    async *streamHistory(): AsyncGenerator<AgentStreamEvent> {}
+
+    async getRuntimeInfo() {
+      return {
+        provider: this.provider,
+        sessionId: this.id,
+        model: this.effectiveModel,
+        modeId: null,
+      };
+    }
+
+    async getAvailableModes() {
+      return [];
+    }
+
+    async getCurrentMode() {
+      return null;
+    }
+
+    async setMode(): Promise<void> {}
+
+    async setModel(modelId: string | null): Promise<void> {
+      this.effectiveModel = modelId ?? BOUND_MODEL;
+    }
+
+    getPendingPermissions() {
+      return [];
+    }
+
+    async respondToPermission(): Promise<void> {}
+
+    describePersistence() {
+      return { provider: this.provider, sessionId: this.id };
+    }
+
+    async interrupt(): Promise<void> {}
+    async close(): Promise<void> {}
+  }
+
+  class RevertingModelClient extends TestAgentClient {
+    override async createSession(): Promise<AgentSession> {
+      return new RevertingModelSession();
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: {
+      codex: new RevertingModelClient(),
+    },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000402",
+  });
+
+  const snapshot = await manager.createAgent(
+    {
+      provider: "codex",
+      cwd: workdir,
+    },
+    undefined,
+    { workspaceId: undefined },
+  );
+
+  await manager.setAgentModel(snapshot.id, "openai/gpt-5");
+  const overridden = manager.getAgent(snapshot.id);
+  expect(overridden?.config.model).toBe("openai/gpt-5");
+  expect(overridden?.runtimeInfo?.model).toBe("openai/gpt-5");
+
+  await manager.setAgentModel(snapshot.id, null);
+  const cleared = manager.getAgent(snapshot.id);
+  expect(cleared?.config.model).toBe(BOUND_MODEL);
+  expect(cleared?.runtimeInfo?.model).toBe(BOUND_MODEL);
+});
+
 test("session config drift events update state through the stream channel", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-session-config-events-"));
   let capturedSession: TestAgentSession | null = null;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1582,9 +1582,14 @@ export class AgentManager {
     const currentMode = (await agent.session.getCurrentMode()) ?? modeId;
     agent.config.modeId = currentMode ?? undefined;
     agent.currentModeId = currentMode;
-    // Update runtimeInfo to reflect the new mode
+    // A mode switch may re-bind the effective model when a provider binds a
+    // model to an agent/mode. Read the session's resulting effective model and
+    // surface it so the client model picker updates.
+    const effectiveModel = (await agent.session.getRuntimeInfo()).model ?? null;
+    agent.config.model = effectiveModel ?? undefined;
+    // Update runtimeInfo to reflect the new mode and effective model
     if (agent.runtimeInfo) {
-      agent.runtimeInfo = { ...agent.runtimeInfo, modeId: currentMode };
+      agent.runtimeInfo = { ...agent.runtimeInfo, modeId: currentMode, model: effectiveModel };
     }
     this.touchUpdatedAt(agent);
     this.emitState(agent);
@@ -1596,13 +1601,18 @@ export class AgentManager {
     const normalizedModelId =
       typeof modelId === "string" && modelId.trim().length > 0 ? modelId : null;
 
+    // A provider may resolve the request to a different effective model (e.g.
+    // clearing an override reverts to the agent's bound model), so read the
+    // resolved model back from the session instead of assuming the requested one.
+    let effectiveModel = normalizedModelId;
     if (agent.session.setModel) {
       await agent.session.setModel(normalizedModelId);
+      effectiveModel = (await agent.session.getRuntimeInfo()).model ?? null;
     }
 
-    agent.config.model = normalizedModelId ?? undefined;
+    agent.config.model = effectiveModel ?? undefined;
     if (agent.runtimeInfo) {
-      agent.runtimeInfo = { ...agent.runtimeInfo, model: normalizedModelId };
+      agent.runtimeInfo = { ...agent.runtimeInfo, model: effectiveModel };
     }
     this.touchUpdatedAt(agent);
     this.emitState(agent);

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -67,6 +67,11 @@ export interface AgentMode {
   description?: string;
   icon?: string;
   colorTier?: string;
+  /**
+   * Model bound to this mode/agent as `"providerID/modelID"`, if the provider
+   * binds one. Selecting the mode switches the effective model to this.
+   */
+  model?: string;
   isUnattended?: boolean;
 }
 

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -753,6 +753,128 @@ describe("OpenCodeAgentClient adapter smoke tests", () => {
   }, 180_000);
 });
 
+describe("OpenCode adapter agent→model binding", () => {
+  const logger = createTestLogger();
+  const buildConfig = (cwd: string): AgentSessionConfig => ({
+    provider: "opencode",
+    cwd,
+    model: TEST_MODEL,
+  });
+
+  async function createBoundModelSession() {
+    const cwd = tmpCwd();
+    const runtime = new TestOpenCodeHarness();
+    const openCodeClient = new TestOpenCodeClient();
+    // Plugins like oh-my-openagent bind agents to specific models.
+    openCodeClient.appAgentsResponse = {
+      data: [
+        { name: "atlas", mode: "primary", model: { providerID: "moonshot", modelID: "kimi-k2" } },
+        {
+          name: "sisyphus",
+          mode: "primary",
+          model: { providerID: "anthropic", modelID: "claude-opus" },
+        },
+        { name: "plan", mode: "primary" },
+      ],
+    };
+    runtime.enqueueClient(openCodeClient);
+    const client = new OpenCodeAgentClient(logger, undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const session = await client.createSession(buildConfig(cwd));
+    return { cwd, openCodeClient, session };
+  }
+
+  async function runTurnModel(
+    session: Awaited<ReturnType<typeof createBoundModelSession>>["session"],
+    openCodeClient: TestOpenCodeClient,
+  ): Promise<unknown> {
+    const before = openCodeClient.calls.sessionPromptAsync.length;
+    const turn = await collectTurnEvents(streamSession(session, "Hello"));
+    expect(turn.turnCompleted).toBe(true);
+    const lastCall = openCodeClient.calls.sessionPromptAsync[
+      openCodeClient.calls.sessionPromptAsync.length - 1
+    ] as { model?: unknown };
+    expect(openCodeClient.calls.sessionPromptAsync.length).toBe(before + 1);
+    return lastCall.model;
+  }
+
+  test("applies the selected agent's bound model as the effective prompt model (B2/B3)", async () => {
+    const { cwd, openCodeClient, session } = await createBoundModelSession();
+
+    await session.setMode("atlas");
+    expect(await runTurnModel(session, openCodeClient)).toEqual({
+      providerID: "moonshot",
+      modelID: "kimi-k2",
+    });
+
+    const runtimeInfo = await session.getRuntimeInfo();
+    expect(runtimeInfo.model).toBe("moonshot/kimi-k2");
+
+    await session.close();
+    rmSync(cwd, { recursive: true, force: true });
+  }, 60_000);
+
+  test("an explicit setModel override wins over the agent-bound model (B3)", async () => {
+    const { cwd, openCodeClient, session } = await createBoundModelSession();
+
+    await session.setMode("atlas");
+    await session.setModel("openai/gpt-5");
+
+    expect(await runTurnModel(session, openCodeClient)).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
+    });
+
+    await session.close();
+    rmSync(cwd, { recursive: true, force: true });
+  }, 60_000);
+
+  test("switching agents re-applies the new agent's model and drops the override (B4)", async () => {
+    const { cwd, openCodeClient, session } = await createBoundModelSession();
+
+    // atlas → bound kimi
+    await session.setMode("atlas");
+    expect(await runTurnModel(session, openCodeClient)).toEqual({
+      providerID: "moonshot",
+      modelID: "kimi-k2",
+    });
+
+    // explicit override sticks only for this selection
+    await session.setModel("openai/gpt-5");
+    expect(await runTurnModel(session, openCodeClient)).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5",
+    });
+
+    // switching to sisyphus re-applies its bound model; the override does not persist
+    await session.setMode("sisyphus");
+    expect(await runTurnModel(session, openCodeClient)).toEqual({
+      providerID: "anthropic",
+      modelID: "claude-opus",
+    });
+
+    await session.close();
+    rmSync(cwd, { recursive: true, force: true });
+  }, 60_000);
+
+  test("selecting an agent with no bound model leaves the current model unchanged (B2)", async () => {
+    const { cwd, openCodeClient, session } = await createBoundModelSession();
+
+    await session.setMode("atlas");
+    await session.setMode("plan");
+
+    expect(await runTurnModel(session, openCodeClient)).toEqual({
+      providerID: "moonshot",
+      modelID: "kimi-k2",
+    });
+
+    await session.close();
+    rmSync(cwd, { recursive: true, force: true });
+  }, 60_000);
+});
+
 describe("OpenCode adapter context-window normalization", () => {
   test("builds OpenCode file parts for image prompt blocks", () => {
     expect(
@@ -1015,6 +1137,39 @@ describe("OpenCode adapter context-window normalization", () => {
         color: "#fff",
       }),
     ).not.toHaveProperty("colorTier");
+  });
+
+  test("carries an OpenCode agent's bound model as providerID/modelID (B1)", () => {
+    expect(
+      __openCodeInternals.mapOpenCodeAgentToMode({
+        name: "atlas",
+        model: { providerID: "moonshot", modelID: "kimi-k2" },
+      }),
+    ).toMatchObject({
+      id: "atlas",
+      label: "Atlas",
+      model: "moonshot/kimi-k2",
+    });
+  });
+
+  test("omits the model field for agents without a bound model (B1)", () => {
+    expect(__openCodeInternals.mapOpenCodeAgentToMode({ name: "plan" })).not.toHaveProperty(
+      "model",
+    );
+
+    expect(
+      __openCodeInternals.mapOpenCodeAgentToMode({
+        name: "broken",
+        model: { providerID: "", modelID: "kimi-k2" },
+      }),
+    ).not.toHaveProperty("model");
+
+    expect(
+      __openCodeInternals.mapOpenCodeAgentToMode({
+        name: "broken",
+        model: { providerID: "moonshot" },
+      }),
+    ).not.toHaveProperty("model");
   });
 });
 

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -597,12 +597,32 @@ function readOpenCodeAgentHexColor(agent: { color?: unknown }): string | undefin
     : undefined;
 }
 
+function readOpenCodeAgentBoundModel(agent: { model?: unknown }): string | undefined {
+  const model = agent.model;
+  if (!model || typeof model !== "object") {
+    return undefined;
+  }
+  const providerID = (model as { providerID?: unknown }).providerID;
+  const modelID = (model as { modelID?: unknown }).modelID;
+  if (
+    typeof providerID !== "string" ||
+    providerID.trim().length === 0 ||
+    typeof modelID !== "string" ||
+    modelID.trim().length === 0
+  ) {
+    return undefined;
+  }
+  return buildOpenCodeModelLookupKey(providerID.trim(), modelID.trim());
+}
+
 function mapOpenCodeAgentToMode(agent: {
   name: string;
   description?: unknown;
   color?: unknown;
+  model?: unknown;
 }): AgentMode {
   const colorTier = readOpenCodeAgentHexColor(agent);
+  const model = readOpenCodeAgentBoundModel(agent);
   return {
     id: agent.name,
     label: agent.name.charAt(0).toUpperCase() + agent.name.slice(1),
@@ -612,6 +632,7 @@ function mapOpenCodeAgentToMode(agent: {
         ? agent.description.trim()
         : DEFAULT_MODES.find((mode) => mode.id === agent.name)?.description,
     ...(colorTier ? { colorTier } : {}),
+    ...(model ? { model } : {}),
   };
 }
 
@@ -2884,6 +2905,13 @@ class OpenCodeAgentSession implements AgentSession {
   private readonly logger: Logger;
   private readonly modelContextWindowsByModelKey: ReadonlyMap<string, number>;
   private currentMode: string | null = null;
+  /**
+   * The model bound to the currently selected OpenCode agent/mode (as
+   * `providerID/modelID`), if any. OpenCode plugins can bind an agent to a
+   * specific model (e.g. `atlas`→`kimi`); selecting that agent must switch the
+   * effective model like the OpenCode TUI does.
+   */
+  private agentBoundModel: string | undefined;
   private autoAcceptEnabled = false;
   private pendingPermissions = new Map<string, AgentPermissionRequest>();
   private abortController: AbortController | null = null;
@@ -2976,7 +3004,10 @@ class OpenCodeAgentSession implements AgentSession {
   async setModel(modelId: string | null): Promise<void> {
     const normalizedModelId =
       typeof modelId === "string" && modelId.trim().length > 0 ? modelId : null;
-    this.config.model = normalizedModelId ?? undefined;
+    // Explicit user choice wins over the current agent's bound model until the
+    // next setMode() starts a fresh selection. Clearing it reverts to the
+    // agent-bound model (if any).
+    this.config.model = normalizedModelId ?? this.agentBoundModel ?? undefined;
     this.selectedModelContextWindowMaxTokens = this.resolveConfiguredModelContextWindowMaxTokens(
       this.config.model,
     );
@@ -3802,13 +3833,42 @@ class OpenCodeAgentSession implements AgentSession {
   async setMode(modeId: string): Promise<void> {
     const normalizedModeId = normalizeOpenCodeModeId(modeId);
     if (normalizedModeId === OPENCODE_LEGACY_FULL_ACCESS_MODE_ID) {
+      await this.applyAgentBoundModelForModeSelection(OPENCODE_BUILD_MODE_ID);
       this.currentMode = OPENCODE_BUILD_MODE_ID;
       await this.setFeature(OPENCODE_AUTO_ACCEPT_FEATURE_ID, true);
       return;
     }
 
+    await this.applyAgentBoundModelForModeSelection(normalizedModeId);
     this.currentMode = normalizedModeId;
     this.config.modeId = normalizedModeId ?? undefined;
+  }
+
+  /**
+   * Resolves and applies the target agent's bound model as the effective
+   * prompt model. A mode selection is a fresh start: any prior explicit
+   * `setModel()` override does not persist across a mode switch (B4). If the
+   * newly selected agent has no bound model, the current model is left as-is.
+   */
+  private async applyAgentBoundModelForModeSelection(modeId: string | null): Promise<void> {
+    const boundModel = await this.resolveAgentBoundModel(modeId);
+    this.agentBoundModel = boundModel;
+    if (!boundModel) {
+      return;
+    }
+    this.config.model = boundModel;
+    this.selectedModelContextWindowMaxTokens =
+      this.resolveConfiguredModelContextWindowMaxTokens(boundModel);
+  }
+
+  private async resolveAgentBoundModel(modeId: string | null): Promise<string | undefined> {
+    if (modeId === null) {
+      return undefined;
+    }
+    const runtimeAgentId = resolveOpenCodeRuntimeAgentId(modeId);
+    const modes = await this.getAvailableModes();
+    const match = modes.find((mode) => mode.id === modeId || mode.id === runtimeAgentId);
+    return match?.model;
   }
 
   async setFeature(featureId: string, value: unknown): Promise<void> {


### PR DESCRIPTION
## What

When an OpenCode agent binds a specific model (e.g. a plugin binds `atlas`→Kimi, `sisyphus`→Opus), selecting that agent now switches the effective model the same way the OpenCode TUI does. Previously the composer's model picker kept the old model after a mode switch.

## Why it's scoped this way

This is split out of #2188 into a single, self-contained feature so it can be reviewed and merged on its own. It deliberately avoids the two things flagged in review:

- **No provider-specific branches.** There is no `if (provider === "opencode")` anywhere. `AgentManager.setAgentMode()` reads the generic `AgentSession.getRuntimeInfo().model` and surfaces it — the same path every provider already implements. An agent-manager unit test proves this with a **non-opencode (codex) fake**.
- **No opencode details in the protocol.** The only protocol change is an additive, optional, provider-agnostic `AgentMode.model?: string` (`"providerID/modelID"`). `packages/protocol` contains zero opencode references. Providers that don't bind a model leave it unset and are unaffected.

Every OpenCode-specific line lives inside `opencode-agent.ts`.

## Commits (3, dependency-ordered)

1. `feat(protocol)` — additive optional `AgentMode.model` + a both-direction wire-compat test.
2. `feat(opencode)` — the provider reads each agent's bound model, applies it on `setMode`, and lets an explicit `setModel` override win until the next switch (all inside the provider).
3. `feat(agent-manager)` — on a mode switch, read the session's resulting `runtimeInfo.model` and surface it into `config.model` / `runtimeInfo.model` so the client model picker updates.

## Testing

- **Unit** — protocol wire-compat (old/new both parse), provider binding (apply on switch, explicit-override precedence, no-op when the agent has no bound model), and provider-agnostic agent-manager surfacing (codex fake).
- **End-to-end against a real local OpenCode** — selecting `Sisyphus`↔`Atlas` flips the effective model between their bound models and back.

No client change is required — the app already renders `runtimeInfo.model` / `config.model`.
