### PR TITLE
Show OpenCode follow-ups after background work

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -91,6 +91,12 @@ function providerAssistantMessages(events: AgentStreamEvent[], text: string): Ag
   );
 }
 
+type TurnEventSignature = [type: AgentStreamEvent["type"], turnId: string | undefined];
+
+function turnEventSignatures(events: AgentStreamEvent[]): TurnEventSignature[] {
+  return events.map((event) => [event.type, "turnId" in event ? event.turnId : undefined]);
+}
+
 function assistantTurnEvents({
   sessionId = "session-1",
   text = "Hello from OpenCode",
@@ -2464,7 +2470,7 @@ describe("OpenCode provider subagent contract", () => {
     ]);
   });
 
-  test("synthesizes a turn for externally driven adopted child timeline events", async () => {
+  test("synthesizes an autonomous turn for adopted child timeline events", async () => {
     const { child, childClient, parent } = await createAdoptedChildSession();
     const completed = createTestDeferred<void>();
     const events: AgentStreamEvent[] = [];
@@ -2515,7 +2521,185 @@ describe("OpenCode provider subagent contract", () => {
     );
   });
 
-  test("synthesizes a turn for externally driven adopted child permissions", async () => {
+  test("surfaces an autonomous OpenCode wake as a new parent turn", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const openCode = new TestOpenCodeClient();
+    openCode.sessionCreateResponse = { data: { id: "ses_parent_plugin_wake" } };
+    runtime.enqueueClient(openCode);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const parent = await client.createSession({
+      provider: "opencode",
+      cwd: "/workspace/repo",
+    });
+    const events: AgentStreamEvent[] = [];
+    parent.subscribe((event) => events.push(event));
+
+    try {
+      openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_parent_plugin_wake", status: { type: "busy" } },
+      });
+      openCode.emitEvent({
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_plugin_wake",
+            sessionID: "ses_parent_plugin_wake",
+            role: "user",
+          },
+        },
+      });
+      openCode.emitEvent({
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "prt_plugin_wake",
+            sessionID: "ses_parent_plugin_wake",
+            messageID: "msg_plugin_wake",
+            type: "text",
+            text: "<system-reminder>All background tasks are complete.</system-reminder>",
+            time: { start: 1, end: 2 },
+          },
+        },
+      });
+      for (const event of assistantTurnEvents({
+        sessionId: "ses_parent_plugin_wake",
+        text: "Parent consumed the background result.",
+      })) {
+        openCode.emitEvent(event);
+      }
+
+      await vi.waitFor(() => {
+        expect(events).toEqual([
+          { type: "turn_started", provider: "opencode", turnId: "opencode-turn-0" },
+          {
+            type: "timeline",
+            provider: "opencode",
+            turnId: "opencode-turn-0",
+            item: {
+              type: "user_message",
+              text: "<system-reminder>All background tasks are complete.</system-reminder>",
+              messageId: "msg_plugin_wake",
+            },
+          },
+          {
+            type: "timeline",
+            provider: "opencode",
+            turnId: "opencode-turn-0",
+            item: {
+              type: "assistant_message",
+              text: "Parent consumed the background result.",
+              messageId: "msg_assistant",
+            },
+          },
+          {
+            type: "turn_completed",
+            provider: "opencode",
+            usage: undefined,
+            turnId: "opencode-turn-0",
+          },
+        ]);
+      });
+    } finally {
+      await parent.close();
+    }
+  });
+
+  test("does not mistake OpenCode session metadata for an autonomous turn", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const openCode = new TestOpenCodeClient();
+    openCode.sessionCreateResponse = { data: { id: "ses_parent_metadata" } };
+    runtime.enqueueClient(openCode);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const parent = await client.createSession({
+      provider: "opencode",
+      cwd: "/workspace/repo",
+    });
+    const events: AgentStreamEvent[] = [];
+    parent.subscribe((event) => events.push(event));
+
+    try {
+      openCode.emitEvent({
+        type: "session.created",
+        properties: { info: { id: "ses_parent_metadata" } },
+      });
+      openCode.emitEvent({
+        type: "session.idle",
+        properties: { sessionID: "ses_parent_metadata" },
+      });
+      for (const event of assistantTurnEvents({
+        sessionId: "ses_parent_metadata",
+        text: "Autonomous response.",
+      })) {
+        openCode.emitEvent(event);
+      }
+
+      await vi.waitFor(() => {
+        expect(turnEventSignatures(events)).toEqual([
+          ["turn_started", "opencode-turn-0"],
+          ["timeline", "opencode-turn-0"],
+          ["turn_completed", "opencode-turn-0"],
+        ]);
+      });
+    } finally {
+      await parent.close();
+    }
+  });
+
+  test("hands an autonomous OpenCode turn off to a direct Paseo prompt", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const openCode = new TestOpenCodeClient();
+    openCode.sessionCreateResponse = { data: { id: "ses_parent_handoff" } };
+    openCode.sessionPromptAsyncEvents = assistantTurnEvents({
+      sessionId: "ses_parent_handoff",
+      text: "Paseo response.",
+    });
+    runtime.enqueueClient(openCode);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const parent = await client.createSession({
+      provider: "opencode",
+      cwd: "/workspace/repo",
+    });
+    const events: AgentStreamEvent[] = [];
+    parent.subscribe((event) => events.push(event));
+
+    try {
+      openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_parent_handoff", status: { type: "busy" } },
+      });
+      await vi.waitFor(() => {
+        expect(events).toEqual([
+          { type: "turn_started", provider: "opencode", turnId: "opencode-turn-0" },
+        ]);
+      });
+
+      await parent.startTurn("Continue from Paseo");
+
+      await vi.waitFor(() => {
+        expect(turnEventSignatures(events)).toEqual([
+          ["turn_started", "opencode-turn-0"],
+          ["turn_completed", "opencode-turn-0"],
+          ["turn_started", "opencode-turn-1"],
+          ["timeline", "opencode-turn-1"],
+          ["turn_completed", "opencode-turn-1"],
+        ]);
+      });
+    } finally {
+      await parent.close();
+    }
+  });
+
+  test("synthesizes an autonomous turn for adopted child permissions", async () => {
     const { child, childClient, parent } = await createAdoptedChildSession();
     const completed = createTestDeferred<void>();
     const events: AgentStreamEvent[] = [];
@@ -2617,6 +2801,13 @@ describe("OpenCode provider subagent contract", () => {
         }),
       );
     });
+    expect(events.some((event) => event.type === "turn_started")).toBe(false);
+    expect(
+      events.find(
+        (event) =>
+          event.type === "permission_requested" && event.request.id === "perm_provider_child",
+      ),
+    ).not.toHaveProperty("turnId");
     expect(
       events.filter(
         (event) =>

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -97,6 +97,34 @@ function turnEventSignatures(events: AgentStreamEvent[]): TurnEventSignature[] {
   return events.map((event) => [event.type, "turnId" in event ? event.turnId : undefined]);
 }
 
+function userMessageEvents(params: {
+  sessionId: string;
+  messageId: string;
+  text: string;
+}): unknown[] {
+  return [
+    {
+      type: "message.updated",
+      properties: {
+        info: { id: params.messageId, sessionID: params.sessionId, role: "user" },
+      },
+    },
+    {
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: `part_${params.messageId}`,
+          sessionID: params.sessionId,
+          messageID: params.messageId,
+          type: "text",
+          text: params.text,
+          time: { start: 1, end: 2 },
+        },
+      },
+    },
+  ];
+}
+
 function assistantTurnEvents({
   sessionId = "session-1",
   text = "Hello from OpenCode",
@@ -127,6 +155,25 @@ function assistantTurnEvents({
     },
     { type: "session.idle", properties: { sessionID: sessionId } },
   ];
+}
+
+async function createParentSession(sessionId: string): Promise<{
+  readonly parent: Awaited<ReturnType<OpenCodeAgentClient["createSession"]>>;
+  readonly openCode: TestOpenCodeClient;
+}> {
+  const runtime = new TestOpenCodeHarness();
+  const openCode = new TestOpenCodeClient();
+  openCode.sessionCreateResponse = { data: { id: sessionId } };
+  runtime.enqueueClient(openCode);
+  const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+    serverManager: runtime,
+    createClient: runtime.createClient,
+  });
+  const parent = await client.createSession({
+    provider: "opencode",
+    cwd: "/workspace/repo",
+  });
+  return { parent, openCode };
 }
 
 function manualCompactEvents({
@@ -1850,92 +1897,51 @@ describe("OpenCode adapter startTurn error handling", () => {
     }
   });
 
-  test("delays the next prompt until a slow interrupt abort settles", async () => {
-    vi.useFakeTimers();
-    const abortDeferred = createTestDeferred<{ data: boolean; error: undefined }>();
-    const promptAsync = vi.fn().mockResolvedValue({ data: {}, error: undefined });
-    const abort = vi
-      .fn()
-      .mockReturnValueOnce(abortDeferred.promise)
-      .mockResolvedValue({ data: true, error: undefined });
-    const fakeClient = {
-      global: {
-        event: vi.fn().mockImplementation(
-          async (options: {
-            signal: AbortSignal;
-          }): Promise<{ stream: AsyncIterable<OpenCodeEvent> }> => ({
-            stream: abortableOpenCodeStream(options.signal),
-          }),
-        ),
-      },
-      session: {
-        promptAsync,
-        abort,
-      },
-    } as never;
+  test("retries abort and waits for provider idle before starting the next prompt", async () => {
+    const { parent: session, openCode } = await createParentSession("ses_unit_test");
+    openCode.sessionPromptAsyncEvents = [];
+    openCode.sessionAbortImplementation = async () => {
+      if (openCode.calls.sessionAbort.length === 1) {
+        throw new Error("abort transport failed");
+      }
+      openCode.emitEvent({
+        type: "session.idle",
+        properties: { sessionID: "ses_unit_test" },
+      });
+      return { data: true };
+    };
+    try {
+      await session.startTurn("first");
+      await session.interrupt();
+      expect(openCode.calls.sessionPromptAsync).toHaveLength(1);
 
-    const session = new __openCodeInternals.OpenCodeAgentSession(
-      { provider: "opencode", cwd: "/tmp/test" },
-      fakeClient,
-      "ses_unit_test",
-      createTestLogger(),
-    );
-
-    await session.startTurn("first");
-    expect(promptAsync).toHaveBeenCalledTimes(1);
-
-    const interruptPromise = session.interrupt();
-    await vi.advanceTimersByTimeAsync(2_000);
-    await interruptPromise;
-    expect(abort).toHaveBeenCalledTimes(1);
-
-    const secondTurnPromise = session.startTurn("second");
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(promptAsync).toHaveBeenCalledTimes(1);
-
-    abortDeferred.resolve({ data: true, error: undefined });
-    await secondTurnPromise;
-    expect(promptAsync).toHaveBeenCalledTimes(2);
-
-    await session.interrupt();
-    vi.useRealTimers();
+      await session.startTurn("second");
+      expect(openCode.calls.sessionAbort).toHaveLength(2);
+      expect(openCode.calls.sessionPromptAsync).toHaveLength(2);
+    } finally {
+      await session.close();
+    }
   });
 
-  test("starts the next prompt when an interrupt abort rejects", async () => {
-    const promptAsync = vi.fn().mockResolvedValue({ data: {}, error: undefined });
-    const abort = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("abort transport failed"))
-      .mockResolvedValue({ data: true, error: undefined });
-    const fakeClient = {
-      global: {
-        event: vi.fn().mockImplementation(
-          async (options: {
-            signal: AbortSignal;
-          }): Promise<{ stream: AsyncIterable<OpenCodeEvent> }> => ({
-            stream: abortableOpenCodeStream(options.signal),
-          }),
-        ),
-      },
-      session: {
-        promptAsync,
-        abort,
-      },
-    } as never;
+  test("does not send a prompt while the previous provider turn is still stopping", async () => {
+    vi.useFakeTimers();
+    const { parent: session, openCode } = await createParentSession("ses_unit_test");
+    openCode.sessionPromptAsyncEvents = [];
 
-    const session = new __openCodeInternals.OpenCodeAgentSession(
-      { provider: "opencode", cwd: "/tmp/test" },
-      fakeClient,
-      "ses_unit_test",
-      createTestLogger(),
-    );
+    try {
+      await session.startTurn("first");
+      await session.interrupt();
 
-    await session.startTurn("first");
-    await session.interrupt();
-    await expect(session.startTurn("second")).resolves.toEqual({ turnId: "opencode-turn-1" });
-    expect(promptAsync).toHaveBeenCalledTimes(2);
-
-    await session.interrupt();
+      const secondTurn = expect(session.startTurn("second")).rejects.toThrow(
+        "OpenCode previous turn to stop",
+      );
+      await vi.advanceTimersByTimeAsync(10_000);
+      await secondTurn;
+      expect(openCode.calls.sessionPromptAsync).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+      await session.close();
+    }
   });
 });
 
@@ -2559,48 +2565,21 @@ describe("OpenCode provider subagent contract", () => {
   });
 
   test("surfaces an autonomous OpenCode wake as a new parent turn", async () => {
-    const runtime = new TestOpenCodeHarness();
-    const openCode = new TestOpenCodeClient();
-    openCode.sessionCreateResponse = { data: { id: "ses_parent_plugin_wake" } };
-    runtime.enqueueClient(openCode);
-    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
-      serverManager: runtime,
-      createClient: runtime.createClient,
-    });
-    const parent = await client.createSession({
-      provider: "opencode",
-      cwd: "/workspace/repo",
-    });
+    const { parent, openCode } = await createParentSession("ses_parent_plugin_wake");
     const events: AgentStreamEvent[] = [];
     parent.subscribe((event) => events.push(event));
 
     try {
+      for (const event of userMessageEvents({
+        sessionId: "ses_parent_plugin_wake",
+        messageId: "msg_plugin_wake",
+        text: "<system-reminder>All background tasks are complete.</system-reminder>",
+      })) {
+        openCode.emitEvent(event);
+      }
       openCode.emitEvent({
         type: "session.status",
         properties: { sessionID: "ses_parent_plugin_wake", status: { type: "busy" } },
-      });
-      openCode.emitEvent({
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "msg_plugin_wake",
-            sessionID: "ses_parent_plugin_wake",
-            role: "user",
-          },
-        },
-      });
-      openCode.emitEvent({
-        type: "message.part.updated",
-        properties: {
-          part: {
-            id: "prt_plugin_wake",
-            sessionID: "ses_parent_plugin_wake",
-            messageID: "msg_plugin_wake",
-            type: "text",
-            text: "<system-reminder>All background tasks are complete.</system-reminder>",
-            time: { start: 1, end: 2 },
-          },
-        },
       });
       for (const event of assistantTurnEvents({
         sessionId: "ses_parent_plugin_wake",
@@ -2610,56 +2589,37 @@ describe("OpenCode provider subagent contract", () => {
       }
 
       await vi.waitFor(() => {
-        expect(events).toEqual([
-          { type: "turn_started", provider: "opencode", turnId: "opencode-turn-0" },
-          {
-            type: "timeline",
-            provider: "opencode",
-            turnId: "opencode-turn-0",
-            item: {
-              type: "user_message",
-              text: "<system-reminder>All background tasks are complete.</system-reminder>",
-              messageId: "msg_plugin_wake",
-            },
-          },
-          {
-            type: "timeline",
-            provider: "opencode",
-            turnId: "opencode-turn-0",
-            item: {
-              type: "assistant_message",
-              text: "Parent consumed the background result.",
-              messageId: "msg_assistant",
-            },
-          },
-          {
-            type: "turn_completed",
-            provider: "opencode",
-            usage: undefined,
-            turnId: "opencode-turn-0",
-          },
+        expect(turnEventSignatures(events)).toEqual([
+          ["turn_started", "opencode-turn-0"],
+          ["timeline", "opencode-turn-0"],
+          ["timeline", "opencode-turn-0"],
+          ["turn_completed", "opencode-turn-0"],
         ]);
       });
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "timeline",
+          item: expect.objectContaining({
+            type: "assistant_message",
+            text: "Parent consumed the background result.",
+          }),
+        }),
+      );
     } finally {
       await parent.close();
     }
   });
 
   test("does not mistake OpenCode session metadata for an autonomous turn", async () => {
-    const runtime = new TestOpenCodeHarness();
-    const openCode = new TestOpenCodeClient();
-    openCode.sessionCreateResponse = { data: { id: "ses_parent_metadata" } };
-    runtime.enqueueClient(openCode);
-    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
-      serverManager: runtime,
-      createClient: runtime.createClient,
-    });
-    const parent = await client.createSession({
-      provider: "opencode",
-      cwd: "/workspace/repo",
-    });
+    const { parent, openCode } = await createParentSession("ses_parent_metadata");
     const events: AgentStreamEvent[] = [];
-    parent.subscribe((event) => events.push(event));
+    const streamDrained = createTestDeferred<void>();
+    parent.subscribe((event) => {
+      events.push(event);
+      if (event.type === "provider_subagent") {
+        streamDrained.resolve();
+      }
+    });
 
     try {
       openCode.emitEvent({
@@ -2676,291 +2636,58 @@ describe("OpenCode provider subagent contract", () => {
       })) {
         openCode.emitEvent(event);
       }
-
-      await vi.waitFor(() => {
-        expect(turnEventSignatures(events)).toEqual([
-          ["turn_started", "opencode-turn-0"],
-          ["timeline", "opencode-turn-0"],
-          ["turn_completed", "opencode-turn-0"],
-        ]);
-      });
-    } finally {
-      await parent.close();
-    }
-  });
-
-  test("aborts an autonomous OpenCode turn before starting a direct Paseo prompt", async () => {
-    const runtime = new TestOpenCodeHarness();
-    const openCode = new TestOpenCodeClient();
-    const abortDeferred = createTestDeferred<{ data: boolean }>();
-    openCode.sessionCreateResponse = { data: { id: "ses_parent_handoff" } };
-    openCode.sessionAbortImplementation = async () => abortDeferred.promise;
-    openCode.sessionPromptAsyncEvents = [
-      {
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "msg_paseo_user",
-            sessionID: "ses_parent_handoff",
-            role: "user",
-          },
-        },
-      },
-      ...assistantTurnEvents({
-        sessionId: "ses_parent_handoff",
-        text: "Paseo response.",
-      }),
-    ];
-    runtime.enqueueClient(openCode);
-    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
-      serverManager: runtime,
-      createClient: runtime.createClient,
-    });
-    const parent = await client.createSession({
-      provider: "opencode",
-      cwd: "/workspace/repo",
-    });
-    const events: AgentStreamEvent[] = [];
-    parent.subscribe((event) => events.push(event));
-
-    try {
-      openCode.emitEvent({
-        type: "session.status",
-        properties: { sessionID: "ses_parent_handoff", status: { type: "busy" } },
-      });
-      await vi.waitFor(() => {
-        expect(events).toEqual([
-          { type: "turn_started", provider: "opencode", turnId: "opencode-turn-0" },
-        ]);
-      });
-
-      const directTurnPromise = parent.startTurn("Continue from Paseo");
-      await vi.waitFor(() => {
-        expect(openCode.calls.sessionAbort).toEqual([
-          { sessionID: "ses_parent_handoff", directory: "/workspace/repo" },
-        ]);
-      });
-      expect(openCode.calls.sessionPromptAsync).toEqual([]);
-
-      for (const event of assistantTurnEvents({
-        sessionId: "ses_parent_handoff",
-        text: "Late autonomous response.",
-      }).slice(0, -1)) {
-        openCode.emitEvent(event);
-      }
-      await vi.waitFor(() => {
-        expect(turnEventSignatures(events)).toEqual([["turn_started", "opencode-turn-0"]]);
-      });
-      expect(openCode.calls.sessionPromptAsync).toEqual([]);
-
-      abortDeferred.resolve({ data: true });
-      await directTurnPromise;
-
-      await vi.waitFor(() => {
-        expect(turnEventSignatures(events)).toEqual([
-          ["turn_started", "opencode-turn-0"],
-          ["turn_canceled", "opencode-turn-0"],
-          ["turn_started", "opencode-turn-1"],
-          ["timeline", "opencode-turn-1"],
-          ["timeline", "opencode-turn-1"],
-          ["turn_completed", "opencode-turn-1"],
-        ]);
-      });
-    } finally {
-      await parent.close();
-    }
-  });
-
-  test("cancels an autonomous turn and starts the direct prompt when abort rejects", async () => {
-    const runtime = new TestOpenCodeHarness();
-    const openCode = new TestOpenCodeClient();
-    openCode.sessionCreateResponse = { data: { id: "ses_parent_failed_handoff" } };
-    openCode.sessionAbortImplementation = async () => {
-      throw new Error("abort transport failed");
-    };
-    openCode.sessionPromptAsyncEvents = [
-      {
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "msg_paseo_user",
-            sessionID: "ses_parent_failed_handoff",
-            role: "user",
-          },
-        },
-      },
-      ...assistantTurnEvents({
-        sessionId: "ses_parent_failed_handoff",
-        text: "Paseo response.",
-      }),
-    ];
-    runtime.enqueueClient(openCode);
-    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
-      serverManager: runtime,
-      createClient: runtime.createClient,
-    });
-    const parent = await client.createSession({
-      provider: "opencode",
-      cwd: "/workspace/repo",
-    });
-    const events: AgentStreamEvent[] = [];
-    parent.subscribe((event) => events.push(event));
-
-    try {
-      openCode.emitEvent({
-        type: "session.status",
-        properties: { sessionID: "ses_parent_failed_handoff", status: { type: "busy" } },
-      });
-      await vi.waitFor(() => {
-        expect(events).toEqual([
-          { type: "turn_started", provider: "opencode", turnId: "opencode-turn-0" },
-        ]);
-      });
-
-      await parent.startTurn("Continue from Paseo");
-
-      await vi.waitFor(() => {
-        expect(turnEventSignatures(events)).toEqual([
-          ["turn_started", "opencode-turn-0"],
-          ["turn_canceled", "opencode-turn-0"],
-          ["turn_started", "opencode-turn-1"],
-          ["timeline", "opencode-turn-1"],
-          ["timeline", "opencode-turn-1"],
-          ["turn_completed", "opencode-turn-1"],
-        ]);
-      });
-    } finally {
-      await parent.close();
-    }
-  });
-
-  test("keeps interrupted output fenced when the abort wait times out", async () => {
-    const runtime = new TestOpenCodeHarness();
-    const openCode = new TestOpenCodeClient();
-    const abortDeferred = createTestDeferred<{ data: boolean }>();
-    openCode.sessionCreateResponse = { data: { id: "ses_parent_timed_out_handoff" } };
-    openCode.sessionAbortImplementation = async () => abortDeferred.promise;
-    openCode.sessionPromptAsyncEvents = [];
-    runtime.enqueueClient(openCode);
-    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
-      serverManager: runtime,
-      createClient: runtime.createClient,
-    });
-    const parent = await client.createSession({
-      provider: "opencode",
-      cwd: "/workspace/repo",
-    });
-    const events: AgentStreamEvent[] = [];
-    const autonomousStarted = createTestDeferred<void>();
-    const staleStreamDrained = createTestDeferred<void>();
-    const directTurnCompleted = createTestDeferred<void>();
-    parent.subscribe((event) => {
-      events.push(event);
-      if (event.type === "turn_started" && event.turnId === "opencode-turn-0") {
-        autonomousStarted.resolve();
-      }
-      if (event.type === "provider_subagent") {
-        staleStreamDrained.resolve();
-      }
-      if (event.type === "turn_completed" && event.turnId === "opencode-turn-1") {
-        directTurnCompleted.resolve();
-      }
-    });
-
-    try {
-      openCode.emitEvent({
-        type: "session.status",
-        properties: { sessionID: "ses_parent_timed_out_handoff", status: { type: "busy" } },
-      });
-      await autonomousStarted.promise;
-
-      vi.useFakeTimers();
-      const directTurnPromise = parent.startTurn("Continue from Paseo");
-      await vi.advanceTimersByTimeAsync(9_999);
-      expect(openCode.calls.sessionPromptAsync).toEqual([]);
-
-      await vi.advanceTimersByTimeAsync(1);
-      await directTurnPromise;
-      expect(turnEventSignatures(events)).toEqual([
-        ["turn_started", "opencode-turn-0"],
-        ["turn_canceled", "opencode-turn-0"],
-        ["turn_started", "opencode-turn-1"],
-      ]);
-
-      for (const event of assistantTurnEvents({
-        sessionId: "ses_parent_timed_out_handoff",
-        text: "Late interrupted response.",
-      })) {
-        openCode.emitEvent(event);
-      }
       openCode.emitEvent({
         type: "session.created",
         properties: {
           info: {
-            id: "ses_child_after_timed_out_handoff",
-            parentID: "ses_parent_timed_out_handoff",
+            id: "ses_child_after_parent_metadata",
+            parentID: "ses_parent_metadata",
             title: "Stream drain marker",
             directory: "/workspace/repo",
           },
         },
       });
-      await staleStreamDrained.promise;
-      expect(
-        turnEventSignatures(events.filter((event) => event.type !== "provider_subagent")),
-      ).toEqual([
-        ["turn_started", "opencode-turn-0"],
-        ["turn_canceled", "opencode-turn-0"],
-        ["turn_started", "opencode-turn-1"],
-      ]);
 
-      openCode.emitEvent({
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "msg_paseo_after_timed_out_handoff",
-            sessionID: "ses_parent_timed_out_handoff",
-            role: "user",
-          },
-        },
-      });
-      for (const event of assistantTurnEvents({
-        sessionId: "ses_parent_timed_out_handoff",
-        text: "Paseo response.",
-      })) {
-        openCode.emitEvent(event);
-      }
-      await directTurnCompleted.promise;
+      await streamDrained.promise;
       expect(
         turnEventSignatures(events.filter((event) => event.type !== "provider_subagent")),
-      ).toEqual([
-        ["turn_started", "opencode-turn-0"],
-        ["turn_canceled", "opencode-turn-0"],
-        ["turn_started", "opencode-turn-1"],
-        ["timeline", "opencode-turn-1"],
-        ["timeline", "opencode-turn-1"],
-        ["turn_completed", "opencode-turn-1"],
-      ]);
+      ).toEqual([]);
     } finally {
-      vi.useRealTimers();
-      abortDeferred.resolve({ data: true });
       await parent.close();
     }
   });
 
+  test("keeps an autonomous turn active until OpenCode reaches its terminal event", async () => {
+    const { parent, openCode } = await createParentSession("ses_parent_active_wake");
+    const events: AgentStreamEvent[] = [];
+    parent.subscribe((event) => events.push(event));
+
+    try {
+      openCode.emitEvent(
+        userMessageEvents({
+          sessionId: "ses_parent_active_wake",
+          messageId: "msg_autonomous_wake",
+          text: "Autonomous wake",
+        })[0],
+      );
+      await vi.waitFor(() => {
+        expect(events).toEqual([
+          { type: "turn_started", provider: "opencode", turnId: "opencode-turn-0" },
+        ]);
+      });
+
+      await expect(parent.startTurn("Continue from Paseo")).rejects.toThrow(
+        "A foreground turn is already active",
+      );
+      expect(openCode.calls.sessionAbort).toEqual([]);
+      expect(openCode.calls.sessionPromptAsync).toEqual([]);
+    } finally {
+      await parent.close();
+    }
+  });
   test("does not adopt late output from an interrupted Paseo turn", async () => {
-    const runtime = new TestOpenCodeHarness();
-    const openCode = new TestOpenCodeClient();
-    openCode.sessionCreateResponse = { data: { id: "ses_parent_interrupted" } };
+    const { parent, openCode } = await createParentSession("ses_parent_interrupted");
     openCode.sessionPromptAsyncEvents = [];
-    runtime.enqueueClient(openCode);
-    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
-      serverManager: runtime,
-      createClient: runtime.createClient,
-    });
-    const parent = await client.createSession({
-      provider: "opencode",
-      cwd: "/workspace/repo",
-    });
     const events: AgentStreamEvent[] = [];
     const streamDrained = createTestDeferred<void>();
     parent.subscribe((event) => {
@@ -2974,16 +2701,13 @@ describe("OpenCode provider subagent contract", () => {
       await parent.startTurn("Start from Paseo");
       await parent.interrupt();
 
-      openCode.emitEvent({
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "msg_delayed_interrupted_user",
-            sessionID: "ses_parent_interrupted",
-            role: "user",
-          },
-        },
-      });
+      for (const event of userMessageEvents({
+        sessionId: "ses_parent_interrupted",
+        messageId: "msg_delayed_interrupted_user",
+        text: "Delayed interrupted prompt",
+      })) {
+        openCode.emitEvent(event);
+      }
       for (const event of assistantTurnEvents({
         sessionId: "ses_parent_interrupted",
         text: "Late interrupted response.",
@@ -3954,32 +3678,4 @@ function waitForAbort(signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
     signal.addEventListener("abort", () => resolve(), { once: true });
   });
-}
-
-function abortableOpenCodeStream(signal: AbortSignal): AsyncIterable<OpenCodeEvent> {
-  return {
-    [Symbol.asyncIterator]: () => {
-      let emittedConnected = false;
-      return {
-        next: () => {
-          if (!emittedConnected) {
-            emittedConnected = true;
-            return Promise.resolve({
-              done: false,
-              value: { type: "server.connected", properties: {} } as OpenCodeEvent,
-            });
-          }
-          return new Promise<IteratorResult<OpenCodeEvent>>((resolve) => {
-            if (signal.aborted) {
-              resolve({ done: true, value: undefined });
-              return;
-            }
-            signal.addEventListener("abort", () => resolve({ done: true, value: undefined }), {
-              once: true,
-            });
-          });
-        },
-      };
-    },
-  };
 }

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -157,13 +157,17 @@ function assistantTurnEvents({
   ];
 }
 
-async function createParentSession(sessionId: string): Promise<{
+async function createParentSession(
+  sessionId: string,
+  configure?: (openCode: TestOpenCodeClient) => void,
+): Promise<{
   readonly parent: Awaited<ReturnType<OpenCodeAgentClient["createSession"]>>;
   readonly openCode: TestOpenCodeClient;
 }> {
   const runtime = new TestOpenCodeHarness();
   const openCode = new TestOpenCodeClient();
   openCode.sessionCreateResponse = { data: { id: sessionId } };
+  configure?.(openCode);
   runtime.enqueueClient(openCode);
   const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
     serverManager: runtime,
@@ -1943,6 +1947,45 @@ describe("OpenCode adapter startTurn error handling", () => {
       await session.close();
     }
   });
+
+  test("reconnects and confirms provider idle when the event stream ends while stopping", async () => {
+    const firstStreamEnd = createTestDeferred<void>();
+    let subscriptionCount = 0;
+    const { parent: session, openCode } = await createParentSession(
+      "ses_stream_reconnect",
+      (client) => {
+        client.globalEventImplementation = async (options) => {
+          subscriptionCount += 1;
+          const signal = (options as { signal: AbortSignal }).signal;
+          const end = subscriptionCount === 1 ? firstStreamEnd.promise : waitForAbort(signal);
+          return {
+            stream: {
+              async *[Symbol.asyncIterator]() {
+                yield { type: "server.connected", properties: {} };
+                await end;
+              },
+            },
+          };
+        };
+      },
+    );
+    openCode.sessionPromptAsyncEvents = [];
+
+    try {
+      await session.startTurn("first");
+      await session.interrupt();
+
+      const secondTurn = session.startTurn("second");
+      firstStreamEnd.resolve();
+
+      await expect(secondTurn).resolves.toEqual({ turnId: "opencode-turn-1" });
+      expect(openCode.calls.globalEvent).toHaveLength(2);
+      expect(openCode.calls.sessionStatus).toEqual([{ directory: "/workspace/repo" }]);
+      expect(openCode.calls.sessionPromptAsync).toHaveLength(2);
+    } finally {
+      await session.close();
+    }
+  }, 15_000);
 });
 
 describe("OpenCodeAgentClient env", () => {

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -1937,58 +1937,6 @@ describe("OpenCode adapter startTurn error handling", () => {
 
     await session.interrupt();
   });
-
-  test("caps how long a pending interrupt abort can block the next prompt", async () => {
-    vi.useFakeTimers();
-    const abortDeferred = createTestDeferred<{ data: boolean; error: undefined }>();
-    const promptAsync = vi.fn().mockResolvedValue({ data: {}, error: undefined });
-    const abort = vi
-      .fn()
-      .mockReturnValueOnce(abortDeferred.promise)
-      .mockResolvedValue({ data: true, error: undefined });
-    const fakeClient = {
-      global: {
-        event: vi.fn().mockImplementation(
-          async (options: {
-            signal: AbortSignal;
-          }): Promise<{ stream: AsyncIterable<OpenCodeEvent> }> => ({
-            stream: abortableOpenCodeStream(options.signal),
-          }),
-        ),
-      },
-      session: {
-        promptAsync,
-        abort,
-      },
-    } as never;
-
-    const session = new __openCodeInternals.OpenCodeAgentSession(
-      { provider: "opencode", cwd: "/tmp/test" },
-      fakeClient,
-      "ses_unit_test",
-      createTestLogger(),
-    );
-
-    try {
-      await session.startTurn("first");
-      const interruptPromise = session.interrupt();
-      await vi.advanceTimersByTimeAsync(2_000);
-      await interruptPromise;
-
-      const secondTurnPromise = session.startTurn("second");
-      await vi.advanceTimersByTimeAsync(9_999);
-      expect(promptAsync).toHaveBeenCalledTimes(1);
-
-      await vi.advanceTimersByTimeAsync(1);
-      await secondTurnPromise;
-      expect(promptAsync).toHaveBeenCalledTimes(2);
-
-      abortDeferred.resolve({ data: true, error: undefined });
-      await session.interrupt();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
 });
 
 describe("OpenCodeAgentClient env", () => {
@@ -2801,10 +2749,7 @@ describe("OpenCode provider subagent contract", () => {
         openCode.emitEvent(event);
       }
       await vi.waitFor(() => {
-        expect(turnEventSignatures(events)).toEqual([
-          ["turn_started", "opencode-turn-0"],
-          ["timeline", "opencode-turn-0"],
-        ]);
+        expect(turnEventSignatures(events)).toEqual([["turn_started", "opencode-turn-0"]]);
       });
       expect(openCode.calls.sessionPromptAsync).toEqual([]);
 
@@ -2814,7 +2759,6 @@ describe("OpenCode provider subagent contract", () => {
       await vi.waitFor(() => {
         expect(turnEventSignatures(events)).toEqual([
           ["turn_started", "opencode-turn-0"],
-          ["timeline", "opencode-turn-0"],
           ["turn_canceled", "opencode-turn-0"],
           ["turn_started", "opencode-turn-1"],
           ["timeline", "opencode-turn-1"],
@@ -2886,6 +2830,119 @@ describe("OpenCode provider subagent contract", () => {
         ]);
       });
     } finally {
+      await parent.close();
+    }
+  });
+
+  test("keeps interrupted output fenced when the abort wait times out", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const openCode = new TestOpenCodeClient();
+    const abortDeferred = createTestDeferred<{ data: boolean }>();
+    openCode.sessionCreateResponse = { data: { id: "ses_parent_timed_out_handoff" } };
+    openCode.sessionAbortImplementation = async () => abortDeferred.promise;
+    openCode.sessionPromptAsyncEvents = [];
+    runtime.enqueueClient(openCode);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const parent = await client.createSession({
+      provider: "opencode",
+      cwd: "/workspace/repo",
+    });
+    const events: AgentStreamEvent[] = [];
+    const autonomousStarted = createTestDeferred<void>();
+    const staleStreamDrained = createTestDeferred<void>();
+    const directTurnCompleted = createTestDeferred<void>();
+    parent.subscribe((event) => {
+      events.push(event);
+      if (event.type === "turn_started" && event.turnId === "opencode-turn-0") {
+        autonomousStarted.resolve();
+      }
+      if (event.type === "provider_subagent") {
+        staleStreamDrained.resolve();
+      }
+      if (event.type === "turn_completed" && event.turnId === "opencode-turn-1") {
+        directTurnCompleted.resolve();
+      }
+    });
+
+    try {
+      openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_parent_timed_out_handoff", status: { type: "busy" } },
+      });
+      await autonomousStarted.promise;
+
+      vi.useFakeTimers();
+      const directTurnPromise = parent.startTurn("Continue from Paseo");
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(openCode.calls.sessionPromptAsync).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await directTurnPromise;
+      expect(turnEventSignatures(events)).toEqual([
+        ["turn_started", "opencode-turn-0"],
+        ["turn_canceled", "opencode-turn-0"],
+        ["turn_started", "opencode-turn-1"],
+      ]);
+
+      for (const event of assistantTurnEvents({
+        sessionId: "ses_parent_timed_out_handoff",
+        text: "Late interrupted response.",
+      })) {
+        openCode.emitEvent(event);
+      }
+      openCode.emitEvent({
+        type: "session.created",
+        properties: {
+          info: {
+            id: "ses_child_after_timed_out_handoff",
+            parentID: "ses_parent_timed_out_handoff",
+            title: "Stream drain marker",
+            directory: "/workspace/repo",
+          },
+        },
+      });
+      await staleStreamDrained.promise;
+      expect(
+        turnEventSignatures(events.filter((event) => event.type !== "provider_subagent")),
+      ).toEqual([
+        ["turn_started", "opencode-turn-0"],
+        ["turn_canceled", "opencode-turn-0"],
+        ["turn_started", "opencode-turn-1"],
+      ]);
+
+      openCode.emitEvent({
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_paseo_after_timed_out_handoff",
+            sessionID: "ses_parent_timed_out_handoff",
+            role: "user",
+          },
+        },
+      });
+      for (const event of assistantTurnEvents({
+        sessionId: "ses_parent_timed_out_handoff",
+        text: "Paseo response.",
+      })) {
+        openCode.emitEvent(event);
+      }
+      await directTurnCompleted.promise;
+      expect(
+        turnEventSignatures(events.filter((event) => event.type !== "provider_subagent")),
+      ).toEqual([
+        ["turn_started", "opencode-turn-0"],
+        ["turn_canceled", "opencode-turn-0"],
+        ["turn_started", "opencode-turn-1"],
+        ["timeline", "opencode-turn-1"],
+        ["timeline", "opencode-turn-1"],
+        ["turn_completed", "opencode-turn-1"],
+      ]);
+    } finally {
+      vi.useRealTimers();
+      abortDeferred.resolve({ data: true });
       await parent.close();
     }
   });

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -1900,6 +1900,95 @@ describe("OpenCode adapter startTurn error handling", () => {
     await session.interrupt();
     vi.useRealTimers();
   });
+
+  test("starts the next prompt when an interrupt abort rejects", async () => {
+    const promptAsync = vi.fn().mockResolvedValue({ data: {}, error: undefined });
+    const abort = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("abort transport failed"))
+      .mockResolvedValue({ data: true, error: undefined });
+    const fakeClient = {
+      global: {
+        event: vi.fn().mockImplementation(
+          async (options: {
+            signal: AbortSignal;
+          }): Promise<{ stream: AsyncIterable<OpenCodeEvent> }> => ({
+            stream: abortableOpenCodeStream(options.signal),
+          }),
+        ),
+      },
+      session: {
+        promptAsync,
+        abort,
+      },
+    } as never;
+
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    await session.startTurn("first");
+    await session.interrupt();
+    await expect(session.startTurn("second")).resolves.toEqual({ turnId: "opencode-turn-1" });
+    expect(promptAsync).toHaveBeenCalledTimes(2);
+
+    await session.interrupt();
+  });
+
+  test("caps how long a pending interrupt abort can block the next prompt", async () => {
+    vi.useFakeTimers();
+    const abortDeferred = createTestDeferred<{ data: boolean; error: undefined }>();
+    const promptAsync = vi.fn().mockResolvedValue({ data: {}, error: undefined });
+    const abort = vi
+      .fn()
+      .mockReturnValueOnce(abortDeferred.promise)
+      .mockResolvedValue({ data: true, error: undefined });
+    const fakeClient = {
+      global: {
+        event: vi.fn().mockImplementation(
+          async (options: {
+            signal: AbortSignal;
+          }): Promise<{ stream: AsyncIterable<OpenCodeEvent> }> => ({
+            stream: abortableOpenCodeStream(options.signal),
+          }),
+        ),
+      },
+      session: {
+        promptAsync,
+        abort,
+      },
+    } as never;
+
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    try {
+      await session.startTurn("first");
+      const interruptPromise = session.interrupt();
+      await vi.advanceTimersByTimeAsync(2_000);
+      await interruptPromise;
+
+      const secondTurnPromise = session.startTurn("second");
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(promptAsync).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await secondTurnPromise;
+      expect(promptAsync).toHaveBeenCalledTimes(2);
+
+      abortDeferred.resolve({ data: true, error: undefined });
+      await session.interrupt();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("OpenCodeAgentClient env", () => {
@@ -2726,6 +2815,69 @@ describe("OpenCode provider subagent contract", () => {
         expect(turnEventSignatures(events)).toEqual([
           ["turn_started", "opencode-turn-0"],
           ["timeline", "opencode-turn-0"],
+          ["turn_canceled", "opencode-turn-0"],
+          ["turn_started", "opencode-turn-1"],
+          ["timeline", "opencode-turn-1"],
+          ["timeline", "opencode-turn-1"],
+          ["turn_completed", "opencode-turn-1"],
+        ]);
+      });
+    } finally {
+      await parent.close();
+    }
+  });
+
+  test("cancels an autonomous turn and starts the direct prompt when abort rejects", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const openCode = new TestOpenCodeClient();
+    openCode.sessionCreateResponse = { data: { id: "ses_parent_failed_handoff" } };
+    openCode.sessionAbortImplementation = async () => {
+      throw new Error("abort transport failed");
+    };
+    openCode.sessionPromptAsyncEvents = [
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_paseo_user",
+            sessionID: "ses_parent_failed_handoff",
+            role: "user",
+          },
+        },
+      },
+      ...assistantTurnEvents({
+        sessionId: "ses_parent_failed_handoff",
+        text: "Paseo response.",
+      }),
+    ];
+    runtime.enqueueClient(openCode);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const parent = await client.createSession({
+      provider: "opencode",
+      cwd: "/workspace/repo",
+    });
+    const events: AgentStreamEvent[] = [];
+    parent.subscribe((event) => events.push(event));
+
+    try {
+      openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_parent_failed_handoff", status: { type: "busy" } },
+      });
+      await vi.waitFor(() => {
+        expect(events).toEqual([
+          { type: "turn_started", provider: "opencode", turnId: "opencode-turn-0" },
+        ]);
+      });
+
+      await parent.startTurn("Continue from Paseo");
+
+      await vi.waitFor(() => {
+        expect(turnEventSignatures(events)).toEqual([
+          ["turn_started", "opencode-turn-0"],
           ["turn_canceled", "opencode-turn-0"],
           ["turn_started", "opencode-turn-1"],
           ["timeline", "opencode-turn-1"],

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -2738,6 +2738,65 @@ describe("OpenCode provider subagent contract", () => {
     }
   });
 
+  test("does not adopt late output from an interrupted Paseo turn", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const openCode = new TestOpenCodeClient();
+    openCode.sessionCreateResponse = { data: { id: "ses_parent_interrupted" } };
+    openCode.sessionPromptAsyncEvents = [];
+    runtime.enqueueClient(openCode);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const parent = await client.createSession({
+      provider: "opencode",
+      cwd: "/workspace/repo",
+    });
+    const events: AgentStreamEvent[] = [];
+    const permissionRequested = createTestDeferred<void>();
+    parent.subscribe((event) => {
+      events.push(event);
+      if (event.type === "permission_requested") {
+        permissionRequested.resolve();
+      }
+    });
+
+    try {
+      await parent.startTurn("Start from Paseo");
+      await parent.interrupt();
+
+      for (const event of assistantTurnEvents({
+        sessionId: "ses_parent_interrupted",
+        text: "Late interrupted response.",
+      })) {
+        openCode.emitEvent(event);
+      }
+      openCode.emitEvent({
+        type: "permission.asked",
+        properties: {
+          id: "perm_after_interrupted_output",
+          sessionID: "ses_parent_interrupted",
+          permission: "bash",
+          patterns: ["npm test"],
+          metadata: { command: "npm test", cwd: "/workspace/repo" },
+        },
+      });
+
+      await permissionRequested.promise;
+      expect(events.filter((event) => event.type !== "permission_requested")).toEqual([
+        { type: "turn_started", provider: "opencode", turnId: "opencode-turn-0" },
+        {
+          type: "turn_canceled",
+          provider: "opencode",
+          reason: "interrupted",
+          turnId: "opencode-turn-0",
+        },
+      ]);
+    } finally {
+      await parent.close();
+    }
+  });
+
   test("synthesizes an autonomous turn for adopted child permissions", async () => {
     const { child, childClient, parent } = await createAdoptedChildSession();
     const completed = createTestDeferred<void>();

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -2753,11 +2753,11 @@ describe("OpenCode provider subagent contract", () => {
       cwd: "/workspace/repo",
     });
     const events: AgentStreamEvent[] = [];
-    const permissionRequested = createTestDeferred<void>();
+    const streamDrained = createTestDeferred<void>();
     parent.subscribe((event) => {
       events.push(event);
-      if (event.type === "permission_requested") {
-        permissionRequested.resolve();
+      if (event.type === "provider_subagent") {
+        streamDrained.resolve();
       }
     });
 
@@ -2765,6 +2765,16 @@ describe("OpenCode provider subagent contract", () => {
       await parent.startTurn("Start from Paseo");
       await parent.interrupt();
 
+      openCode.emitEvent({
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_delayed_interrupted_user",
+            sessionID: "ses_parent_interrupted",
+            role: "user",
+          },
+        },
+      });
       for (const event of assistantTurnEvents({
         sessionId: "ses_parent_interrupted",
         text: "Late interrupted response.",
@@ -2772,18 +2782,19 @@ describe("OpenCode provider subagent contract", () => {
         openCode.emitEvent(event);
       }
       openCode.emitEvent({
-        type: "permission.asked",
+        type: "session.created",
         properties: {
-          id: "perm_after_interrupted_output",
-          sessionID: "ses_parent_interrupted",
-          permission: "bash",
-          patterns: ["npm test"],
-          metadata: { command: "npm test", cwd: "/workspace/repo" },
+          info: {
+            id: "ses_child_after_interrupted_output",
+            parentID: "ses_parent_interrupted",
+            title: "Stream drain marker",
+            directory: "/workspace/repo",
+          },
         },
       });
 
-      await permissionRequested.promise;
-      expect(events.filter((event) => event.type !== "permission_requested")).toEqual([
+      await streamDrained.promise;
+      expect(events.filter((event) => event.type !== "provider_subagent")).toEqual([
         { type: "turn_started", provider: "opencode", turnId: "opencode-turn-0" },
         {
           type: "turn_canceled",

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -2652,14 +2652,28 @@ describe("OpenCode provider subagent contract", () => {
     }
   });
 
-  test("hands an autonomous OpenCode turn off to a direct Paseo prompt", async () => {
+  test("aborts an autonomous OpenCode turn before starting a direct Paseo prompt", async () => {
     const runtime = new TestOpenCodeHarness();
     const openCode = new TestOpenCodeClient();
+    const abortDeferred = createTestDeferred<{ data: boolean }>();
     openCode.sessionCreateResponse = { data: { id: "ses_parent_handoff" } };
-    openCode.sessionPromptAsyncEvents = assistantTurnEvents({
-      sessionId: "ses_parent_handoff",
-      text: "Paseo response.",
-    });
+    openCode.sessionAbortImplementation = async () => abortDeferred.promise;
+    openCode.sessionPromptAsyncEvents = [
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_paseo_user",
+            sessionID: "ses_parent_handoff",
+            role: "user",
+          },
+        },
+      },
+      ...assistantTurnEvents({
+        sessionId: "ses_parent_handoff",
+        text: "Paseo response.",
+      }),
+    ];
     runtime.enqueueClient(openCode);
     const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
       serverManager: runtime,
@@ -2683,13 +2697,38 @@ describe("OpenCode provider subagent contract", () => {
         ]);
       });
 
-      await parent.startTurn("Continue from Paseo");
+      const directTurnPromise = parent.startTurn("Continue from Paseo");
+      await vi.waitFor(() => {
+        expect(openCode.calls.sessionAbort).toEqual([
+          { sessionID: "ses_parent_handoff", directory: "/workspace/repo" },
+        ]);
+      });
+      expect(openCode.calls.sessionPromptAsync).toEqual([]);
+
+      for (const event of assistantTurnEvents({
+        sessionId: "ses_parent_handoff",
+        text: "Late autonomous response.",
+      }).slice(0, -1)) {
+        openCode.emitEvent(event);
+      }
+      await vi.waitFor(() => {
+        expect(turnEventSignatures(events)).toEqual([
+          ["turn_started", "opencode-turn-0"],
+          ["timeline", "opencode-turn-0"],
+        ]);
+      });
+      expect(openCode.calls.sessionPromptAsync).toEqual([]);
+
+      abortDeferred.resolve({ data: true });
+      await directTurnPromise;
 
       await vi.waitFor(() => {
         expect(turnEventSignatures(events)).toEqual([
           ["turn_started", "opencode-turn-0"],
-          ["turn_completed", "opencode-turn-0"],
+          ["timeline", "opencode-turn-0"],
+          ["turn_canceled", "opencode-turn-0"],
           ["turn_started", "opencode-turn-1"],
+          ["timeline", "opencode-turn-1"],
           ["timeline", "opencode-turn-1"],
           ["turn_completed", "opencode-turn-1"],
         ]);

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -3052,6 +3052,7 @@ class OpenCodeAgentSession implements AgentSession {
           { err: error, sessionId: this.sessionId, turnId, reason },
           "OpenCode session.abort rejected",
         );
+        throw error;
       });
     const trackedAbortPromise = abortPromise.finally(() => {
       if (this.pendingAbortPromise === trackedAbortPromise) {
@@ -3086,11 +3087,15 @@ class OpenCodeAgentSession implements AgentSession {
   ): Promise<{ turnId: string }> {
     if (this.activeForegroundTurnId) {
       if (this.activeForegroundTurnSource === "autonomous") {
-        // A direct Paseo prompt owns the foreground; close the autonomous run first.
-        this.finishForegroundTurn(
-          { type: "turn_completed", provider: "opencode", usage: undefined },
-          this.activeForegroundTurnId,
-        );
+        const autonomousTurnId = this.activeForegroundTurnId;
+        await this.beginSessionAbort(autonomousTurnId, "direct_prompt_handoff");
+        if (this.activeForegroundTurnId === autonomousTurnId) {
+          this.suppressTerminalUntilNextUserMessage = true;
+          this.finishForegroundTurn(
+            { type: "turn_canceled", provider: "opencode", reason: "interrupted" },
+            autonomousTurnId,
+          );
+        }
       } else {
         throw new Error("A foreground turn is already active");
       }

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -3567,6 +3567,9 @@ class OpenCodeAgentSession implements AgentSession {
         foregroundEvents.push(translatedEvent);
       }
     }
+    if (this.shouldSuppressStaleInterruptedEvent(event, eventCount)) {
+      return;
+    }
     if (!turnId && this.shouldStartAutonomousTurn(event, foregroundEvents)) {
       turnId = this.startAutonomousTurn();
     }
@@ -3578,18 +3581,6 @@ class OpenCodeAgentSession implements AgentSession {
         type: event.type,
       });
       return;
-    }
-    if (this.suppressTerminalUntilNextUserMessage) {
-      if (isOpenCodeUserMessageEvent(event, this.sessionId)) {
-        this.suppressTerminalUntilNextUserMessage = false;
-      } else if (isOpenCodeTerminalEvent(event, this.sessionId)) {
-        this.traceOpenCode("provider.opencode.event.skip", {
-          n: eventCount,
-          reason: "stale_interrupt_terminal",
-          type: event.type,
-        });
-        return;
-      }
     }
     this.traceOpenCode("provider.opencode.parsed_event", {
       turnId,
@@ -3620,6 +3611,25 @@ class OpenCodeAgentSession implements AgentSession {
     }
   }
 
+  private shouldSuppressStaleInterruptedEvent(event: OpenCodeEvent, eventCount: number): boolean {
+    if (!this.suppressTerminalUntilNextUserMessage) {
+      return false;
+    }
+    if (isOpenCodeUserMessageEvent(event, this.sessionId)) {
+      this.suppressTerminalUntilNextUserMessage = false;
+      return false;
+    }
+    if (!isOpenCodeTerminalEvent(event, this.sessionId)) {
+      return false;
+    }
+    this.traceOpenCode("provider.opencode.event.skip", {
+      n: eventCount,
+      reason: "stale_interrupt_terminal",
+      type: event.type,
+    });
+    return true;
+  }
+
   private emitBackgroundPermissionRequests(events: readonly AgentStreamEvent[]): void {
     for (const event of events) {
       if (event.type === "permission_requested") {
@@ -3632,7 +3642,7 @@ class OpenCodeAgentSession implements AgentSession {
     event: OpenCodeEvent,
     foregroundEvents: readonly AgentStreamEvent[],
   ): boolean {
-    if (this.activeForegroundTurnId) {
+    if (this.activeForegroundTurnId || this.suppressTerminalUntilNextUserMessage) {
       return false;
     }
     if (getOpenCodeEventSessionId(event) !== this.sessionId) {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -106,6 +106,7 @@ const OPENCODE_CHILD_SESSION_HYDRATION_LIMIT = 100;
 const OPENCODE_CHILD_SESSION_SERVER_REGISTRY_LIMIT = 500;
 const OPENCODE_PERMISSION_ACTION_ALLOW_ONCE = "allow_once";
 const OPENCODE_PERMISSION_ACTION_ALLOW_ALWAYS = "allow_always";
+const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
 
 // OpenCode child sessions run on the server process that spawned them. Adoption
 // resumes must attach to that same helper server to receive live global events.
@@ -3060,7 +3061,16 @@ class OpenCodeAgentSession implements AgentSession {
     }
 
     try {
-      await pendingAbortPromise;
+      await withTimeout(
+        pendingAbortPromise,
+        OPENCODE_PENDING_ABORT_START_TIMEOUT_MS,
+        "OpenCode pending session.abort",
+      ).catch((error) => {
+        this.logger.warn(
+          { err: error, sessionId: this.sessionId },
+          "OpenCode session.abort did not settle before starting the next turn",
+        );
+      });
     } finally {
       if (this.pendingAbortPromise === pendingAbortPromise) {
         this.pendingAbortPromise = null;
@@ -3075,12 +3085,16 @@ class OpenCodeAgentSession implements AgentSession {
     if (this.activeForegroundTurnId) {
       if (this.activeForegroundTurnSource === "autonomous") {
         const autonomousTurnId = this.activeForegroundTurnId;
-        await this.beginSessionAbort(autonomousTurnId, "direct_prompt_handoff");
-        if (this.activeForegroundTurnId === autonomousTurnId) {
-          this.finishForegroundTurn(
-            { type: "turn_canceled", provider: "opencode", reason: "interrupted" },
-            autonomousTurnId,
-          );
+        this.beginSessionAbort(autonomousTurnId, "direct_prompt_handoff");
+        try {
+          await this.awaitPendingAbortBeforeStartingTurn();
+        } finally {
+          if (this.activeForegroundTurnId === autonomousTurnId) {
+            this.finishForegroundTurn(
+              { type: "turn_canceled", provider: "opencode", reason: "interrupted" },
+              autonomousTurnId,
+            );
+          }
         }
       } else {
         throw new Error("A foreground turn is already active");

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -102,7 +102,6 @@ const OPENCODE_BUILD_MODE_ID = "build";
 const OPENCODE_LEGACY_FULL_ACCESS_MODE_ID = "full-access";
 const OPENCODE_AUTO_ACCEPT_FEATURE_ID = "auto_accept";
 const OPENCODE_PERSISTED_SESSION_LIMIT = 200;
-const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
 const OPENCODE_CHILD_SESSION_HYDRATION_LIMIT = 100;
 const OPENCODE_CHILD_SESSION_SERVER_REGISTRY_LIMIT = 500;
 const OPENCODE_PERMISSION_ACTION_ALLOW_ONCE = "allow_once";
@@ -2790,14 +2789,6 @@ function getOpenCodeEventSessionId(event: OpenCodeEvent): string | null {
   );
 }
 
-function isOpenCodeUserMessageEvent(event: OpenCodeEvent, sessionId: string): boolean {
-  return (
-    event.type === "message.updated" &&
-    event.properties.info.sessionID === sessionId &&
-    event.properties.info.role === "user"
-  );
-}
-
 function isOpenCodeTerminalEvent(event: OpenCodeEvent, sessionId: string): boolean {
   if (event.type === "session.idle" || event.type === "session.error") {
     return event.properties.sessionID === sessionId;
@@ -2931,7 +2922,7 @@ class OpenCodeAgentSession implements AgentSession {
   private eventStreamAbortController: AbortController | null = null;
   private eventStreamReady: Deferred<void> | null = null;
   private eventStreamTask: Promise<void> | null = null;
-  private suppressTerminalUntilNextUserMessage = false;
+  private awaitingInterruptedTurnBoundary = false;
   private closed = false;
   private readonly persistSession: boolean;
   private deletedFromProvider = false;
@@ -3023,7 +3014,7 @@ class OpenCodeAgentSession implements AgentSession {
       );
     });
     if (turnId) {
-      this.suppressTerminalUntilNextUserMessage = true;
+      this.awaitingInterruptedTurnBoundary = true;
       this.finishForegroundTurn(
         { type: "turn_canceled", provider: "opencode", reason: "interrupted" },
         turnId,
@@ -3054,31 +3045,27 @@ class OpenCodeAgentSession implements AgentSession {
         );
         throw error;
       });
-    const trackedAbortPromise = abortPromise.finally(() => {
-      if (this.pendingAbortPromise === trackedAbortPromise) {
-        this.pendingAbortPromise = null;
-      }
-    });
-    this.pendingAbortPromise = trackedAbortPromise;
-    return trackedAbortPromise;
+    this.pendingAbortPromise = abortPromise;
+    return abortPromise;
   }
 
   private async awaitPendingAbortBeforeStartingTurn(): Promise<void> {
-    const pendingAbortPromise = this.pendingAbortPromise;
+    const pendingAbortPromise =
+      this.pendingAbortPromise ??
+      (this.awaitingInterruptedTurnBoundary
+        ? this.beginSessionAbort(null, "turn_start_boundary")
+        : null);
     if (!pendingAbortPromise) {
       return;
     }
 
-    await withTimeout(
-      pendingAbortPromise,
-      OPENCODE_PENDING_ABORT_START_TIMEOUT_MS,
-      "OpenCode pending session.abort",
-    ).catch((error) => {
-      this.logger.warn(
-        { err: error, sessionId: this.sessionId },
-        "OpenCode session.abort was still pending before starting the next turn",
-      );
-    });
+    try {
+      await pendingAbortPromise;
+    } finally {
+      if (this.pendingAbortPromise === pendingAbortPromise) {
+        this.pendingAbortPromise = null;
+      }
+    }
   }
 
   async startTurn(
@@ -3090,7 +3077,6 @@ class OpenCodeAgentSession implements AgentSession {
         const autonomousTurnId = this.activeForegroundTurnId;
         await this.beginSessionAbort(autonomousTurnId, "direct_prompt_handoff");
         if (this.activeForegroundTurnId === autonomousTurnId) {
-          this.suppressTerminalUntilNextUserMessage = true;
           this.finishForegroundTurn(
             { type: "turn_canceled", provider: "opencode", reason: "interrupted" },
             autonomousTurnId,
@@ -3101,6 +3087,7 @@ class OpenCodeAgentSession implements AgentSession {
       }
     }
     await this.awaitPendingAbortBeforeStartingTurn();
+    this.awaitingInterruptedTurnBoundary = false;
 
     this.runningToolCalls.clear();
     this.subAgentsByCallId.clear();
@@ -3567,7 +3554,7 @@ class OpenCodeAgentSession implements AgentSession {
         foregroundEvents.push(translatedEvent);
       }
     }
-    if (this.shouldSuppressStaleInterruptedEvent(event, eventCount)) {
+    if (this.consumeInterruptedTurnBoundary(event, eventCount)) {
       return;
     }
     if (!turnId && this.shouldStartAutonomousTurn(event, foregroundEvents)) {
@@ -3611,17 +3598,14 @@ class OpenCodeAgentSession implements AgentSession {
     }
   }
 
-  private shouldSuppressStaleInterruptedEvent(event: OpenCodeEvent, eventCount: number): boolean {
-    if (!this.suppressTerminalUntilNextUserMessage) {
-      return false;
-    }
-    if (isOpenCodeUserMessageEvent(event, this.sessionId)) {
-      this.suppressTerminalUntilNextUserMessage = false;
+  private consumeInterruptedTurnBoundary(event: OpenCodeEvent, eventCount: number): boolean {
+    if (!this.awaitingInterruptedTurnBoundary) {
       return false;
     }
     if (!isOpenCodeTerminalEvent(event, this.sessionId)) {
       return false;
     }
+    this.awaitingInterruptedTurnBoundary = false;
     this.traceOpenCode("provider.opencode.event.skip", {
       n: eventCount,
       reason: "stale_interrupt_terminal",
@@ -3642,7 +3626,7 @@ class OpenCodeAgentSession implements AgentSession {
     event: OpenCodeEvent,
     foregroundEvents: readonly AgentStreamEvent[],
   ): boolean {
-    if (this.activeForegroundTurnId || this.suppressTerminalUntilNextUserMessage) {
+    if (this.activeForegroundTurnId || this.awaitingInterruptedTurnBoundary) {
       return false;
     }
     if (getOpenCodeEventSessionId(event) !== this.sessionId) {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -3641,11 +3641,7 @@ class OpenCodeAgentSession implements AgentSession {
     ) {
       return true;
     }
-    return (
-      event.type === "session.status" &&
-      event.properties.sessionID === this.sessionId &&
-      event.properties.status.type === "busy"
-    );
+    return event.type === "session.status" && event.properties.status.type === "busy";
   }
 
   private startAutonomousTurn(): string {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -3058,13 +3058,54 @@ class OpenCodeAgentSession implements AgentSession {
     const stopping = this.turnState;
     // OpenCode creates prompts before joining its single session runner. Sending
     // while that runner is stopping can strand the new prompt behind the old
-    // run, so only the provider's idle event makes the session reusable.
-    void this.abortSession(null, "turn_start_boundary");
+    // run, so only provider-confirmed idle makes the session reusable.
     await withTimeout(
-      stopping.idle.promise,
+      this.observeProviderStopBoundary(stopping),
       OPENCODE_PENDING_ABORT_START_TIMEOUT_MS,
       "OpenCode previous turn to stop",
     );
+  }
+
+  private async observeProviderStopBoundary(
+    stopping: Extract<OpenCodeTurnState, { status: "stopping" }>,
+  ): Promise<void> {
+    while (this.turnState === stopping) {
+      void this.abortSession(null, "turn_start_boundary");
+      const eventStreamTask = this.eventStreamTask;
+      const boundary = await (eventStreamTask
+        ? Promise.race([
+            stopping.idle.promise.then(() => "idle" as const),
+            eventStreamTask.then(
+              () => "stream_ended" as const,
+              () => "stream_ended" as const,
+            ),
+          ])
+        : Promise.resolve("stream_ended" as const));
+      if (boundary === "idle") {
+        return;
+      }
+
+      await this.ensureEventStreamReady();
+      const response = await this.client.session.status({ directory: this.config.cwd });
+      if (response.error) {
+        throw new Error(
+          `Failed to confirm OpenCode session status: ${toDiagnosticErrorMessage(response.error)}`,
+        );
+      }
+      const statuses = readOpenCodeRecord(response.data);
+      if (!statuses) {
+        throw new Error("OpenCode returned an invalid session status response");
+      }
+      const status = readOpenCodeRecord(statuses[this.sessionId]);
+      const statusType = readNonEmptyString(status?.type);
+      if (!status || statusType === "idle") {
+        this.finishStoppingTurn();
+        return;
+      }
+      if (statusType !== "busy" && statusType !== "retry") {
+        throw new Error(`OpenCode returned an unknown session status '${statusType ?? "missing"}'`);
+      }
+    }
   }
 
   async startTurn(

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -1378,7 +1378,6 @@ export class OpenCodeAgentClient implements AgentClient {
         undefined,
         launchContext?.agentId,
         url,
-        registeredAcquisition !== null,
       );
     } catch (error) {
       await acquisition.release();
@@ -2916,7 +2915,7 @@ class OpenCodeAgentSession implements AgentSession {
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private nextTurnOrdinal = 0;
   private activeForegroundTurnId: string | null = null;
-  private activeForegroundTurnSource: "paseo" | "external" | null = null;
+  private activeForegroundTurnSource: "paseo" | "autonomous" | null = null;
   private readonly runningToolCalls = new Map<string, ToolCallTimelineItem>();
   private subAgentsByCallId = new Map<string, OpenCodeSubAgentActivityState>();
   private subAgentCallIdByChildSessionId = new Map<string, string>();
@@ -2946,7 +2945,6 @@ class OpenCodeAgentSession implements AgentSession {
     persistSession = true,
     private readonly agentId?: string,
     private readonly serverUrl?: string,
-    private readonly externallyDriven = false,
   ) {
     this.config = config;
     this.client = client;
@@ -3087,8 +3085,8 @@ class OpenCodeAgentSession implements AgentSession {
     options?: AgentRunOptions,
   ): Promise<{ turnId: string }> {
     if (this.activeForegroundTurnId) {
-      if (this.activeForegroundTurnSource === "external") {
-        // A direct Paseo prompt owns the foreground; close the adopted child run first.
+      if (this.activeForegroundTurnSource === "autonomous") {
+        // A direct Paseo prompt owns the foreground; close the autonomous run first.
         this.finishForegroundTurn(
           { type: "turn_completed", provider: "opencode", usage: undefined },
           this.activeForegroundTurnId,
@@ -3564,8 +3562,8 @@ class OpenCodeAgentSession implements AgentSession {
         foregroundEvents.push(translatedEvent);
       }
     }
-    if (!turnId && this.shouldStartExternalDrivenTurn(event, foregroundEvents)) {
-      turnId = this.startExternalDrivenTurn();
+    if (!turnId && this.shouldStartAutonomousTurn(event, foregroundEvents)) {
+      turnId = this.startAutonomousTurn();
     }
     if (!turnId) {
       this.emitBackgroundPermissionRequests(foregroundEvents);
@@ -3625,17 +3623,22 @@ class OpenCodeAgentSession implements AgentSession {
     }
   }
 
-  private shouldStartExternalDrivenTurn(
+  private shouldStartAutonomousTurn(
     event: OpenCodeEvent,
     foregroundEvents: readonly AgentStreamEvent[],
   ): boolean {
-    if (!this.externallyDriven) {
-      return false;
-    }
     if (this.activeForegroundTurnId) {
       return false;
     }
-    if (foregroundEvents.some((foregroundEvent) => !toTerminalTurnEvent(foregroundEvent))) {
+    if (getOpenCodeEventSessionId(event) !== this.sessionId) {
+      return false;
+    }
+    if (
+      foregroundEvents.some(
+        (foregroundEvent) =>
+          foregroundEvent.type !== "thread_started" && !toTerminalTurnEvent(foregroundEvent),
+      )
+    ) {
       return true;
     }
     return (
@@ -3645,10 +3648,10 @@ class OpenCodeAgentSession implements AgentSession {
     );
   }
 
-  private startExternalDrivenTurn(): string {
+  private startAutonomousTurn(): string {
     const turnId = this.createTurnId();
     this.activeForegroundTurnId = turnId;
-    this.activeForegroundTurnSource = "external";
+    this.activeForegroundTurnSource = "autonomous";
     this.runningToolCalls.clear();
     this.subAgentsByCallId.clear();
     this.subAgentCallIdByChildSessionId.clear();

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -108,6 +108,9 @@ const OPENCODE_PERMISSION_ACTION_ALLOW_ONCE = "allow_once";
 const OPENCODE_PERMISSION_ACTION_ALLOW_ALWAYS = "allow_always";
 const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
 
+type OpenCodeAbortResult = "confirmed" | "rejected";
+type OpenCodeAbortWaitResult = OpenCodeAbortResult | "not_needed" | "timed_out";
+
 // OpenCode child sessions run on the server process that spawned them. Adoption
 // resumes must attach to that same helper server to receive live global events.
 const openCodeChildSessionServerUrls = new Map<string, string>();
@@ -2884,7 +2887,7 @@ class OpenCodeAgentSession implements AgentSession {
   private autoAcceptEnabled = false;
   private pendingPermissions = new Map<string, AgentPermissionRequest>();
   private abortController: AbortController | null = null;
-  private pendingAbortPromise: Promise<void> | null = null;
+  private pendingAbortPromise: Promise<OpenCodeAbortResult> | null = null;
   private accumulatedUsage: AgentUsage = {};
   private sessionTotalCostUsd: number | undefined;
   private mcpConfigured = false;
@@ -3032,36 +3035,36 @@ class OpenCodeAgentSession implements AgentSession {
     });
   }
 
-  private beginSessionAbort(turnId: string | null, reason: string): Promise<void> {
+  private beginSessionAbort(turnId: string | null, reason: string): Promise<OpenCodeAbortResult> {
     const abortPromise = this.client.session
       .abort({
         sessionID: this.sessionId,
         directory: this.config.cwd,
       })
-      .then(() => undefined)
+      .then(() => "confirmed" as const)
       .catch((error) => {
         this.logger.warn(
           { err: error, sessionId: this.sessionId, turnId, reason },
           "OpenCode session.abort rejected",
         );
-        throw error;
+        return "rejected" as const;
       });
     this.pendingAbortPromise = abortPromise;
     return abortPromise;
   }
 
-  private async awaitPendingAbortBeforeStartingTurn(): Promise<void> {
+  private async awaitPendingAbortBeforeStartingTurn(): Promise<OpenCodeAbortWaitResult> {
     const pendingAbortPromise =
       this.pendingAbortPromise ??
       (this.awaitingInterruptedTurnBoundary
         ? this.beginSessionAbort(null, "turn_start_boundary")
         : null);
     if (!pendingAbortPromise) {
-      return;
+      return "not_needed";
     }
 
     try {
-      await withTimeout(
+      return await withTimeout(
         pendingAbortPromise,
         OPENCODE_PENDING_ABORT_START_TIMEOUT_MS,
         "OpenCode pending session.abort",
@@ -3070,6 +3073,7 @@ class OpenCodeAgentSession implements AgentSession {
           { err: error, sessionId: this.sessionId },
           "OpenCode session.abort did not settle before starting the next turn",
         );
+        return "timed_out" as const;
       });
     } finally {
       if (this.pendingAbortPromise === pendingAbortPromise) {
@@ -3082,12 +3086,14 @@ class OpenCodeAgentSession implements AgentSession {
     prompt: AgentPromptInput,
     options?: AgentRunOptions,
   ): Promise<{ turnId: string }> {
+    let abortWaitResult: OpenCodeAbortWaitResult | null = null;
     if (this.activeForegroundTurnId) {
       if (this.activeForegroundTurnSource === "autonomous") {
         const autonomousTurnId = this.activeForegroundTurnId;
+        this.awaitingInterruptedTurnBoundary = true;
         this.beginSessionAbort(autonomousTurnId, "direct_prompt_handoff");
         try {
-          await this.awaitPendingAbortBeforeStartingTurn();
+          abortWaitResult = await this.awaitPendingAbortBeforeStartingTurn();
         } finally {
           if (this.activeForegroundTurnId === autonomousTurnId) {
             this.finishForegroundTurn(
@@ -3100,8 +3106,10 @@ class OpenCodeAgentSession implements AgentSession {
         throw new Error("A foreground turn is already active");
       }
     }
-    await this.awaitPendingAbortBeforeStartingTurn();
-    this.awaitingInterruptedTurnBoundary = false;
+    abortWaitResult ??= await this.awaitPendingAbortBeforeStartingTurn();
+    if (abortWaitResult !== "timed_out") {
+      this.awaitingInterruptedTurnBoundary = false;
+    }
 
     this.runningToolCalls.clear();
     this.subAgentsByCallId.clear();
@@ -3616,13 +3624,16 @@ class OpenCodeAgentSession implements AgentSession {
     if (!this.awaitingInterruptedTurnBoundary) {
       return false;
     }
-    if (!isOpenCodeTerminalEvent(event, this.sessionId)) {
+    if (getOpenCodeEventSessionId(event) !== this.sessionId) {
       return false;
     }
-    this.awaitingInterruptedTurnBoundary = false;
+    const isTerminal = isOpenCodeTerminalEvent(event, this.sessionId);
+    if (isTerminal) {
+      this.awaitingInterruptedTurnBoundary = false;
+    }
     this.traceOpenCode("provider.opencode.event.skip", {
       n: eventCount,
-      reason: "stale_interrupt_terminal",
+      reason: isTerminal ? "stale_interrupt_terminal" : "stale_interrupt_event",
       type: event.type,
     });
     return true;

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -102,14 +102,11 @@ const OPENCODE_BUILD_MODE_ID = "build";
 const OPENCODE_LEGACY_FULL_ACCESS_MODE_ID = "full-access";
 const OPENCODE_AUTO_ACCEPT_FEATURE_ID = "auto_accept";
 const OPENCODE_PERSISTED_SESSION_LIMIT = 200;
+const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
 const OPENCODE_CHILD_SESSION_HYDRATION_LIMIT = 100;
 const OPENCODE_CHILD_SESSION_SERVER_REGISTRY_LIMIT = 500;
 const OPENCODE_PERMISSION_ACTION_ALLOW_ONCE = "allow_once";
 const OPENCODE_PERMISSION_ACTION_ALLOW_ALWAYS = "allow_always";
-const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
-
-type OpenCodeAbortResult = "confirmed" | "rejected";
-type OpenCodeAbortWaitResult = OpenCodeAbortResult | "not_needed" | "timed_out";
 
 // OpenCode child sessions run on the server process that spawned them. Adoption
 // resumes must attach to that same helper server to receive live global events.
@@ -1381,6 +1378,7 @@ export class OpenCodeAgentClient implements AgentClient {
         undefined,
         launchContext?.agentId,
         url,
+        registeredAcquisition !== null,
       );
     } catch (error) {
       await acquisition.release();
@@ -2758,6 +2756,11 @@ function createDeferred<T>(): Deferred<T> {
   return { promise, resolve, reject };
 }
 
+type OpenCodeTurnState =
+  | { status: "idle" }
+  | { status: "running"; turnId: string }
+  | { status: "stopping"; idle: Deferred<void> };
+
 function unwrapOpenCodeGlobalEvent(event: unknown): OpenCodeEvent | null {
   const record = readOpenCodeRecord(event);
   if (!record) {
@@ -2887,7 +2890,6 @@ class OpenCodeAgentSession implements AgentSession {
   private autoAcceptEnabled = false;
   private pendingPermissions = new Map<string, AgentPermissionRequest>();
   private abortController: AbortController | null = null;
-  private pendingAbortPromise: Promise<OpenCodeAbortResult> | null = null;
   private accumulatedUsage: AgentUsage = {};
   private sessionTotalCostUsd: number | undefined;
   private mcpConfigured = false;
@@ -2909,8 +2911,7 @@ class OpenCodeAgentSession implements AgentSession {
   private availableModesCache: AgentMode[] | null = null;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private nextTurnOrdinal = 0;
-  private activeForegroundTurnId: string | null = null;
-  private activeForegroundTurnSource: "paseo" | "autonomous" | null = null;
+  private turnState: OpenCodeTurnState = { status: "idle" };
   private readonly runningToolCalls = new Map<string, ToolCallTimelineItem>();
   private subAgentsByCallId = new Map<string, OpenCodeSubAgentActivityState>();
   private subAgentCallIdByChildSessionId = new Map<string, string>();
@@ -2926,7 +2927,6 @@ class OpenCodeAgentSession implements AgentSession {
   private eventStreamAbortController: AbortController | null = null;
   private eventStreamReady: Deferred<void> | null = null;
   private eventStreamTask: Promise<void> | null = null;
-  private awaitingInterruptedTurnBoundary = false;
   private closed = false;
   private readonly persistSession: boolean;
   private deletedFromProvider = false;
@@ -2940,6 +2940,7 @@ class OpenCodeAgentSession implements AgentSession {
     persistSession = true,
     private readonly agentId?: string,
     private readonly serverUrl?: string,
+    private readonly externallyDriven = false,
   ) {
     this.config = config;
     this.client = client;
@@ -2958,6 +2959,10 @@ class OpenCodeAgentSession implements AgentSession {
 
   get id(): string | null {
     return this.sessionId;
+  }
+
+  private get activeForegroundTurnId(): string | null {
+    return this.turnState.status === "running" ? this.turnState.turnId : null;
   }
 
   get features(): AgentFeature[] {
@@ -3001,29 +3006,24 @@ class OpenCodeAgentSession implements AgentSession {
   }
 
   async interrupt(): Promise<void> {
-    let turnId = this.activeForegroundTurnId;
-    const turnAbortController = this.abortController;
-    turnAbortController?.abort();
+    const turnId = this.activeForegroundTurnId;
+    this.abortController?.abort();
+    if (turnId) {
+      this.beginStoppingTurn(turnId);
+    }
     // COMPAT(opencodeSlowAbort): OpenCode 1.14.42+ blocks session.abort until
     // the running tool actually stops, which can be tens of seconds for
     // long-running tools. Cap the wait so the user-visible cancel lands
     // quickly while still giving OpenCode a chance to confirm the abort
     // cleanly. Drop the timeout once upstream returns abort acknowledgement
     // before tool teardown.
-    const abortPromise = this.beginSessionAbort(turnId, "interrupt");
+    const abortPromise = this.abortSession(turnId, "interrupt");
     await withTimeout(abortPromise, 2_000, "OpenCode session.abort").catch((error) => {
       this.logger.warn(
         { err: error, sessionId: this.sessionId, turnId },
         "OpenCode session.abort exceeded the cancel cap; proceeding with local cancel",
       );
     });
-    if (turnId) {
-      this.awaitingInterruptedTurnBoundary = true;
-      this.finishForegroundTurn(
-        { type: "turn_canceled", provider: "opencode", reason: "interrupted" },
-        turnId,
-      );
-    }
   }
 
   async revertBoth(input: { messageId: string }): Promise<void> {
@@ -3035,80 +3035,48 @@ class OpenCodeAgentSession implements AgentSession {
     });
   }
 
-  private beginSessionAbort(turnId: string | null, reason: string): Promise<OpenCodeAbortResult> {
-    const abortPromise = this.client.session
+  private abortSession(turnId: string | null, reason: string): Promise<void> {
+    return this.client.session
       .abort({
         sessionID: this.sessionId,
         directory: this.config.cwd,
       })
-      .then(() => "confirmed" as const)
+      .then(() => undefined)
       .catch((error) => {
         this.logger.warn(
           { err: error, sessionId: this.sessionId, turnId, reason },
           "OpenCode session.abort rejected",
         );
-        return "rejected" as const;
       });
-    this.pendingAbortPromise = abortPromise;
-    return abortPromise;
   }
 
-  private async awaitPendingAbortBeforeStartingTurn(): Promise<OpenCodeAbortWaitResult> {
-    const pendingAbortPromise =
-      this.pendingAbortPromise ??
-      (this.awaitingInterruptedTurnBoundary
-        ? this.beginSessionAbort(null, "turn_start_boundary")
-        : null);
-    if (!pendingAbortPromise) {
-      return "not_needed";
+  private async waitUntilProviderIdle(): Promise<void> {
+    if (this.turnState.status !== "stopping") {
+      return;
     }
 
-    try {
-      return await withTimeout(
-        pendingAbortPromise,
-        OPENCODE_PENDING_ABORT_START_TIMEOUT_MS,
-        "OpenCode pending session.abort",
-      ).catch((error) => {
-        this.logger.warn(
-          { err: error, sessionId: this.sessionId },
-          "OpenCode session.abort did not settle before starting the next turn",
-        );
-        return "timed_out" as const;
-      });
-    } finally {
-      if (this.pendingAbortPromise === pendingAbortPromise) {
-        this.pendingAbortPromise = null;
-      }
-    }
+    const stopping = this.turnState;
+    // OpenCode creates prompts before joining its single session runner. Sending
+    // while that runner is stopping can strand the new prompt behind the old
+    // run, so only the provider's idle event makes the session reusable.
+    void this.abortSession(null, "turn_start_boundary");
+    await withTimeout(
+      stopping.idle.promise,
+      OPENCODE_PENDING_ABORT_START_TIMEOUT_MS,
+      "OpenCode previous turn to stop",
+    );
   }
 
   async startTurn(
     prompt: AgentPromptInput,
     options?: AgentRunOptions,
   ): Promise<{ turnId: string }> {
-    let abortWaitResult: OpenCodeAbortWaitResult | null = null;
-    if (this.activeForegroundTurnId) {
-      if (this.activeForegroundTurnSource === "autonomous") {
-        const autonomousTurnId = this.activeForegroundTurnId;
-        this.awaitingInterruptedTurnBoundary = true;
-        this.beginSessionAbort(autonomousTurnId, "direct_prompt_handoff");
-        try {
-          abortWaitResult = await this.awaitPendingAbortBeforeStartingTurn();
-        } finally {
-          if (this.activeForegroundTurnId === autonomousTurnId) {
-            this.finishForegroundTurn(
-              { type: "turn_canceled", provider: "opencode", reason: "interrupted" },
-              autonomousTurnId,
-            );
-          }
-        }
-      } else {
-        throw new Error("A foreground turn is already active");
-      }
+    if (this.turnState.status === "running") {
+      throw new Error("A foreground turn is already active");
     }
-    abortWaitResult ??= await this.awaitPendingAbortBeforeStartingTurn();
-    if (abortWaitResult !== "timed_out") {
-      this.awaitingInterruptedTurnBoundary = false;
+    await this.waitUntilProviderIdle();
+    if (this.turnState.status !== "idle") {
+      throw new Error("OpenCode is still stopping the previous turn");
     }
 
     this.runningToolCalls.clear();
@@ -3139,8 +3107,7 @@ class OpenCodeAgentSession implements AgentSession {
     }
 
     const turnId = this.createTurnId();
-    this.activeForegroundTurnId = turnId;
-    this.activeForegroundTurnSource = "paseo";
+    this.turnState = { status: "running", turnId };
     this.notifySubscribers({ type: "turn_started", provider: "opencode" }, turnId);
 
     const slashCommand = await this.resolveSlashCommandInvocation(prompt);
@@ -3567,6 +3534,20 @@ class OpenCodeAgentSession implements AgentSession {
     if (!event) {
       return;
     }
+    if (
+      this.turnState.status === "stopping" &&
+      getOpenCodeEventSessionId(event) === this.sessionId
+    ) {
+      if (isOpenCodeTerminalEvent(event, this.sessionId)) {
+        this.finishStoppingTurn();
+      }
+      this.traceOpenCode("provider.opencode.event.skip", {
+        n: eventCount,
+        reason: "turn_stopping",
+        type: event.type,
+      });
+      return;
+    }
     const translated = await this.translateEvent(event);
     const foregroundEvents: AgentStreamEvent[] = [];
     for (const translatedEvent of translated) {
@@ -3575,9 +3556,6 @@ class OpenCodeAgentSession implements AgentSession {
       } else {
         foregroundEvents.push(translatedEvent);
       }
-    }
-    if (this.consumeInterruptedTurnBoundary(event, eventCount)) {
-      return;
     }
     if (!turnId && this.shouldStartAutonomousTurn(event, foregroundEvents)) {
       turnId = this.startAutonomousTurn();
@@ -3620,25 +3598,6 @@ class OpenCodeAgentSession implements AgentSession {
     }
   }
 
-  private consumeInterruptedTurnBoundary(event: OpenCodeEvent, eventCount: number): boolean {
-    if (!this.awaitingInterruptedTurnBoundary) {
-      return false;
-    }
-    if (getOpenCodeEventSessionId(event) !== this.sessionId) {
-      return false;
-    }
-    const isTerminal = isOpenCodeTerminalEvent(event, this.sessionId);
-    if (isTerminal) {
-      this.awaitingInterruptedTurnBoundary = false;
-    }
-    this.traceOpenCode("provider.opencode.event.skip", {
-      n: eventCount,
-      reason: isTerminal ? "stale_interrupt_terminal" : "stale_interrupt_event",
-      type: event.type,
-    });
-    return true;
-  }
-
   private emitBackgroundPermissionRequests(events: readonly AgentStreamEvent[]): void {
     for (const event of events) {
       if (event.type === "permission_requested") {
@@ -3651,10 +3610,19 @@ class OpenCodeAgentSession implements AgentSession {
     event: OpenCodeEvent,
     foregroundEvents: readonly AgentStreamEvent[],
   ): boolean {
-    if (this.activeForegroundTurnId || this.awaitingInterruptedTurnBoundary) {
+    if (this.turnState.status !== "idle") {
       return false;
     }
     if (getOpenCodeEventSessionId(event) !== this.sessionId) {
+      return false;
+    }
+    // OpenCode publishes the persisted user message before it marks the runner
+    // busy. That message is the earliest unambiguous boundary for a plugin-
+    // initiated parent turn; session metadata and assistant echoes are not.
+    if (event.type === "message.updated" && event.properties.info.role === "user") {
+      return true;
+    }
+    if (!this.externallyDriven) {
       return false;
     }
     if (
@@ -3670,8 +3638,7 @@ class OpenCodeAgentSession implements AgentSession {
 
   private startAutonomousTurn(): string {
     const turnId = this.createTurnId();
-    this.activeForegroundTurnId = turnId;
-    this.activeForegroundTurnSource = "autonomous";
+    this.turnState = { status: "running", turnId };
     this.runningToolCalls.clear();
     this.subAgentsByCallId.clear();
     this.subAgentCallIdByChildSessionId.clear();
@@ -3703,10 +3670,34 @@ class OpenCodeAgentSession implements AgentSession {
     }
     this.pendingUserMessageText = null;
     this.pendingClientMessageId = null;
-    this.activeForegroundTurnId = null;
-    this.activeForegroundTurnSource = null;
+    this.turnState = { status: "idle" };
     this.abortController = null;
     this.notifySubscribers(event, turnId);
+  }
+
+  private beginStoppingTurn(turnId: string): void {
+    if (this.turnState.status !== "running" || this.turnState.turnId !== turnId) {
+      return;
+    }
+    this.synthesizeInterruptedToolCalls(turnId);
+    this.pendingUserMessageText = null;
+    this.pendingClientMessageId = null;
+    this.abortController = null;
+    this.turnState = { status: "stopping", idle: createDeferred<void>() };
+    this.notifySubscribers(
+      { type: "turn_canceled", provider: "opencode", reason: "interrupted" },
+      turnId,
+    );
+  }
+
+  private finishStoppingTurn(): void {
+    if (this.turnState.status !== "stopping") {
+      return;
+    }
+    const stopping = this.turnState;
+    resetOpenCodeTurnTrackingState(this.createTranslationState());
+    this.turnState = { status: "idle" };
+    stopping.idle.resolve();
   }
 
   private trackToolCall(item: ToolCallTimelineItem): void {
@@ -3955,7 +3946,10 @@ class OpenCodeAgentSession implements AgentSession {
         logger: this.logger,
       });
       await this.deleteProviderSessionIfEphemeral();
-      this.activeForegroundTurnId = null;
+      if (this.turnState.status === "stopping") {
+        this.turnState.idle.resolve();
+      }
+      this.turnState = { status: "idle" };
     } finally {
       await this.releaseServer?.();
       this.releaseServer = null;

--- a/packages/server/src/server/agent/providers/opencode/test-utils/test-opencode-harness.ts
+++ b/packages/server/src/server/agent/providers/opencode/test-utils/test-opencode-harness.ts
@@ -89,6 +89,7 @@ export class TestOpenCodeClient {
     sessionGet: [] as unknown[],
     sessionMessages: [] as unknown[],
     sessionPromptAsync: [] as unknown[],
+    sessionStatus: [] as unknown[],
     sessionSummarize: [] as unknown[],
     sessionUpdate: [] as unknown[],
   };
@@ -102,6 +103,9 @@ export class TestOpenCodeClient {
   permissionReplyResponse: OpenCodeResponse = {};
   providerListResponse: OpenCodeResponse = { data: { connected: [], all: [] } };
   providerListImplementation: (() => Promise<OpenCodeResponse>) | null = null;
+  globalEventImplementation:
+    | ((options: unknown) => Promise<{ stream: AsyncIterable<unknown> }>)
+    | null = null;
   questionRejectResponse: OpenCodeResponse = {};
   questionReplyResponse: OpenCodeResponse = {};
   sessionAbortResponse: OpenCodeResponse = {};
@@ -119,6 +123,7 @@ export class TestOpenCodeClient {
   sessionMessagesResponse: OpenCodeResponse = { data: [] };
   sessionPromptAsyncEvents: unknown[] = [idleEvent()];
   sessionPromptAsyncResponse: OpenCodeResponse = {};
+  sessionStatusResponse: OpenCodeResponse = { data: {} };
   sessionSummarizeEvents: unknown[] = [idleEvent()];
   sessionSummarizeResponse: OpenCodeResponse = { data: {} };
   sessionUpdateResponse: OpenCodeResponse = {};
@@ -163,6 +168,9 @@ export class TestOpenCodeClient {
       global: {
         event: async (options: unknown) => {
           this.calls.globalEvent.push(options);
+          if (this.globalEventImplementation) {
+            return await this.globalEventImplementation(options);
+          }
           const signal = (options as { signal?: AbortSignal }).signal;
           return {
             stream: signal ? stopEventStreamOnAbort(this.eventStream, signal) : this.eventStream,
@@ -249,6 +257,10 @@ export class TestOpenCodeClient {
             this.emitEvent(event);
           }
           return this.sessionPromptAsyncResponse;
+        },
+        status: async (parameters: unknown) => {
+          this.calls.sessionStatus.push(parameters);
+          return this.sessionStatusResponse;
         },
         summarize: async (parameters: unknown) => {
           this.calls.sessionSummarize.push(parameters);

--- a/packages/server/src/server/agent/providers/opencode/test-utils/test-opencode-harness.ts
+++ b/packages/server/src/server/agent/providers/opencode/test-utils/test-opencode-harness.ts
@@ -105,6 +105,7 @@ export class TestOpenCodeClient {
   questionRejectResponse: OpenCodeResponse = {};
   questionReplyResponse: OpenCodeResponse = {};
   sessionAbortResponse: OpenCodeResponse = {};
+  sessionAbortImplementation: ((parameters: unknown) => Promise<OpenCodeResponse>) | null = null;
   sessionCommandError: unknown = null;
   sessionCommandEvents: unknown[] = [idleEvent()];
   sessionCommandResponse: OpenCodeResponse = {};
@@ -205,7 +206,9 @@ export class TestOpenCodeClient {
       session: {
         abort: async (parameters: unknown) => {
           this.calls.sessionAbort.push(parameters);
-          return this.sessionAbortResponse;
+          return this.sessionAbortImplementation
+            ? await this.sessionAbortImplementation(parameters)
+            : this.sessionAbortResponse;
         },
         command: async (parameters: unknown) => {
           this.calls.sessionCommand.push(parameters);


### PR DESCRIPTION
### Linked issue

No matching open issue.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

OpenCode sessions can start a follow-up after their original Paseo turn has gone idle, such as when background work finishes. Paseo now adopts that provider-originated activity as an autonomous turn, so the parent reminder, tool output, response, and final status remain visible.

The OpenCode provider now owns this through one lifecycle: `idle → running → stopping → idle`. A persisted user message on the exact parent session starts a normal autonomous turn. Adopted child sessions can still attach to visible in-progress activity. Metadata and assistant echoes cannot create phantom turns.

Interrupts enter `stopping` immediately and publish the local cancellation, but the session is not reusable until OpenCode confirms it is idle. A new prompt is never sent while OpenCode’s single session runner is tearing down. If the event stream dies during that boundary, Paseo reconnects and verifies the authoritative session-status map before releasing the fence.

### How did you verify it

- `npx vitest run packages/server/src/server/agent/providers/opencode-agent.test.ts --bail=1` — 67/67 passed.
- `npm run typecheck` — passed after rebuilding current protocol/client declarations.
- `npm run lint` — zero warnings and errors.
- `npm run format` — clean.
- Ran a real plugin-driven background child through an isolated Paseo daemon on an ephemeral port, pinned to OpenAI with OpenRouter cleared. The parent lifecycle was `initializing → idle → running → idle → running → idle`; the autonomous wake appended the expected parent response and grew the canonical timeline from 7 to 11 entries.

### Risk surface

This changes lifecycle ownership and event ordering only inside the OpenCode provider. Focused coverage includes normal parent autonomous wakes, adopted child activity, metadata and assistant phantom-turn rejection, child permission routing, interrupted late-event rejection, abort retry, refusal to send a prompt before provider idle, and recovery when the event stream ends during stop teardown. There are no protocol, persisted-data, or platform-specific UI changes.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI changes)
- [x] Tests added or updated where it made sense