### PR TITLE
fix(omp): complete turns when agent_end omits messages

### DIFF
--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -140,12 +140,10 @@ describe("OMP agent client and session", () => {
       "hello OMP",
       "empty terminal payload recovered",
     );
-    await new Promise<void>((resolve) => setImmediate(resolve));
-
-    expect(omp.completedTurnCount()).toBe(1);
     await expect(completion).resolves.toMatchObject({
       finalText: "empty terminal payload recovered",
     });
+    expect(omp.completedTurnCount()).toBe(1);
   });
 
   test("does not accept a follow-up until OMP reports stable idle", async () => {

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -132,6 +132,22 @@ describe("OMP agent client and session", () => {
     ]);
   });
 
+  test("completes a streamed assistant turn when agent_end omits messages", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    const { completion } = await omp.startPromptWithEmptyAgentEnd(
+      "hello OMP",
+      "empty terminal payload recovered",
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(omp.completedTurnCount()).toBe(1);
+    await expect(completion).resolves.toMatchObject({
+      finalText: "empty terminal payload recovered",
+    });
+  });
+
   test("does not accept a follow-up until OMP reports stable idle", async () => {
     const omp = new OmpHarness();
     await omp.start();

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -899,6 +899,7 @@ export class OmpAgentSession implements AgentSession {
   private activeTurnId: string | null = null;
   private activeClientMessageId: string | null = null;
   private activeAssistantMessageId: string | null = null;
+  private activeTurnTerminalAssistantMessage: OmpAgentMessage | null = null;
   private activeTurnStarted = false;
   private activeTurnHasUserMessage = false;
   private activeNoTurnPromptText: string | null = null;
@@ -987,6 +988,7 @@ export class OmpAgentSession implements AgentSession {
     this.activeTurnId = turnId;
     this.activeClientMessageId = options?.clientMessageId ?? null;
     this.activeAssistantMessageId = null;
+    this.activeTurnTerminalAssistantMessage = null;
     this.activeTurnStarted = false;
     this.activeTurnHasUserMessage = false;
     this.activePromptRequestId = null;
@@ -1017,6 +1019,7 @@ export class OmpAgentSession implements AgentSession {
         this.activeTurnStarted = false;
         this.activeTurnHasUserMessage = false;
         this.activeAssistantMessageId = null;
+        this.activeTurnTerminalAssistantMessage = null;
         this.clearNoTurnBuffers();
         if (isOmpRequestAbortError(error)) {
           this.emit({
@@ -1151,6 +1154,7 @@ export class OmpAgentSession implements AgentSession {
       this.activeTurnStarted = false;
       this.activeTurnHasUserMessage = false;
       this.activeAssistantMessageId = null;
+      this.activeTurnTerminalAssistantMessage = null;
       this.clearNoTurnBuffers();
       this.emit({
         type: "turn_canceled",
@@ -1773,6 +1777,7 @@ export class OmpAgentSession implements AgentSession {
     this.activeClientMessageId = null;
     this.activeTurnStarted = false;
     this.activeTurnHasUserMessage = false;
+    this.activeTurnTerminalAssistantMessage = null;
     this.clearNoTurnBuffers();
     this.emit({
       type: "turn_failed",
@@ -1857,17 +1862,25 @@ export class OmpAgentSession implements AgentSession {
           },
         });
         return;
-      case "agent_end":
+      case "agent_end": {
+        const messages = event.messages ?? [];
+        let terminalMessages: OmpAgentMessage[] | null = null;
+        if (messages.some((message) => message.role === "assistant")) {
+          terminalMessages = messages;
+        } else if (this.activeTurnTerminalAssistantMessage) {
+          terminalMessages = [this.activeTurnTerminalAssistantMessage];
+        }
         // OMP can end an internal extension-notice cycle before it starts the
-        // model turn for the same prompt. That cycle has no assistant message
-        // and is not the foreground turn's terminal event.
-        if (!(event.messages ?? []).some((message) => message.role === "assistant")) {
+        // model turn for the same prompt. Ignore only cycles where neither the
+        // terminal payload nor the live stream contained an assistant message.
+        if (!terminalMessages) {
           return;
         }
         // A state request is processed after OMP's RPC loop becomes promptable,
         // so do not advertise Paseo idle until it reports that transition.
-        void this.completeTurnAfterProviderIdle(turnId, event.messages ?? []);
+        void this.completeTurnAfterProviderIdle(turnId, terminalMessages);
         return;
+      }
       default:
         return;
     }
@@ -1983,6 +1996,9 @@ export class OmpAgentSession implements AgentSession {
   ): void {
     if (event.message.role === "assistant") {
       this.activeAssistantMessageId = null;
+      if (turnId) {
+        this.activeTurnTerminalAssistantMessage = event.message;
+      }
       return;
     }
     if (event.message.role === "custom") {
@@ -2097,6 +2113,7 @@ export class OmpAgentSession implements AgentSession {
     this.activeTurnId = null;
     this.activeClientMessageId = null;
     this.activeAssistantMessageId = null;
+    this.activeTurnTerminalAssistantMessage = null;
     this.activeTurnStarted = false;
     this.activeTurnHasUserMessage = false;
     this.clearNoTurnBuffers();

--- a/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
@@ -413,6 +413,12 @@ export class FakeOmpSession implements OmpRuntimeSession {
     this.emit({ type: "agent_end", messages: this.messages });
   }
 
+  finishTurnWithEmptyAgentEnd(message: OmpAgentMessage = { role: "assistant", content: [] }): void {
+    this.messages = [...this.messages, message];
+    this.emit({ type: "message_end", message });
+    this.emit({ type: "agent_end", messages: [] });
+  }
+
   beginTurn(): void {
     this.emit({ type: "turn_start" });
   }

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -173,6 +173,22 @@ export class OmpHarness {
     return await run;
   }
 
+  async startPromptWithEmptyAgentEnd(
+    input: string,
+    output: string,
+  ): Promise<{ completion: Promise<unknown> }> {
+    const session = this.requireSession();
+    const promptStarted = this.omp.latestSession().nextPrompt();
+    const completion = session.run(input);
+    await promptStarted;
+    const runtime = this.omp.latestSession();
+    runtime.beginTurn();
+    runtime.acceptPrompt(input, "user-1");
+    runtime.streamAssistantText(output);
+    runtime.finishTurnWithEmptyAgentEnd();
+    return { completion };
+  }
+
   async runPromptAfterExtensionNotice(input: string, output: string): Promise<unknown> {
     const session = this.requireSession();
     const promptStarted = this.omp.latestSession().nextPrompt();


### PR DESCRIPTION
### Linked issue

Closes #2260

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Retains the current foreground turn's terminal assistant `message_end` until the turn reaches a terminal or reset path. When OMP sends `agent_end`, the provider still prefers assistant messages from that payload, but falls back to the retained live assistant message if the payload omits it.

This preserves the existing assistant-less extension-notice guard: an `agent_end` is still ignored when neither the terminal payload nor the live turn contains an assistant message. Eligible turns continue through the existing `get_state` provider-idle gate; the change does not synthesize idle or add a timeout.

The regression harness now supports the exact sequence where the assistant is streamed normally and the terminal `agent_end` contains `messages: []`.

### How did you verify it

- Reproduced the bug with the new focused regression before the implementation: expected one completed turn, received zero.
- Ran `npx vitest run packages/server/src/server/agent/providers/omp/agent.test.ts --bail=1`: 16 tests passed.
- Ran `npm run build:server`: passed.
- Ran `npm run typecheck`: passed.
- Ran `npm run lint`: passed.
- Ran `npm run format`: completed with a clean working tree.
- Exercised the compiled server artifacts with the empty-`agent_end` harness: one `turn_completed`, final text preserved.
- Exercised a real OMP `17.0.5` process through a transparent JSONL fault-injection proxy. The original terminal frame contained two messages (`user`, `assistant`); the proxy rewrote only `agent_end.messages` to `[]`. The built provider returned `OMP_REAL_EMPTY_AGENT_END_OK` and emitted exactly one `turn_completed`.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI change)
- [x] Tests added or updated where it made sense
