### PR TITLE
feat(pi): add 'max' thinking level support

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -174,6 +174,7 @@ const PI_THINKING_OPTIONS: ReadonlyArray<{
   { id: "medium", label: "Medium", description: "Balanced reasoning", isDefault: true },
   { id: "high", label: "High", description: "Deeper reasoning" },
   { id: "xhigh", label: "XHigh", description: "Maximum reasoning" },
+  { id: "max", label: "Max", description: "Extreme reasoning" },
 ] as const;
 
 export interface PiRpcAgentClientOptions {
@@ -329,7 +330,8 @@ function isPiThinkingLevel(value: string | null | undefined): value is PiThinkin
     value === "low" ||
     value === "medium" ||
     value === "high" ||
-    value === "xhigh"
+    value === "xhigh" ||
+    value === "max"
   );
 }
 

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -173,7 +173,7 @@ const PI_THINKING_OPTIONS: ReadonlyArray<{
   { id: "low", label: "Low", description: "Faster reasoning" },
   { id: "medium", label: "Medium", description: "Balanced reasoning", isDefault: true },
   { id: "high", label: "High", description: "Deeper reasoning" },
-  { id: "xhigh", label: "XHigh", description: "Maximum reasoning" },
+  { id: "xhigh", label: "XHigh", description: "Very deep reasoning" },
   { id: "max", label: "Max", description: "Extreme reasoning" },
 ] as const;
 

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -1,4 +1,4 @@
-export type PiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+export type PiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
 export interface PiImageContent {
   type: "image";


### PR DESCRIPTION
## Problem

Pi recently added a `max` thinking level (beyond the existing `xhigh`), but Paseo's Pi adapter hard-codes the thinking level enum, options array, and type guard up to `xhigh` only — so `max` is silently dropped when users try to select it.

## Fix

Three surgical additions:

- **`rpc-types.ts`**: add `"max"` to the `PiThinkingLevel` union type
- **`agent.ts`**: append `{ id: "max", label: "Max", description: "Extreme reasoning" }` to `PI_THINKING_OPTIONS`
- **`agent.ts`**: add `value === "max"` to the `isPiThinkingLevel` type guard

No other files reference the Pi thinking level enum, so this is the complete fix.

## Verification

- `npx vitest run packages/server/src/server/agent/providers/pi/` — 33 tests passed
- Pre-commit lint (oxlint): 0 warnings, 0 errors
- Pre-commit format (oxfmt): all files correct