### PR TITLE
Keep dictation shortcuts working after recording

### DIFF
--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -70,6 +70,7 @@ import {
   resolveComposerSurfacePresentation,
   runAlternateSendAction,
   runDefaultSendAction,
+  runMessageInputKeyboardAction,
   stopRealtimeVoice,
 } from "./state";
 
@@ -496,65 +497,6 @@ function handleDesktopKeyPressImpl(
   ctx.handleDefaultSendAction();
 }
 
-interface KeyboardActionHandlers {
-  textInputRef: React.MutableRefObject<
-    TextInput | (TextInput & { getNativeRef?: () => unknown }) | null
-  >;
-  isDictatingRef: React.MutableRefObject<boolean>;
-  sendAfterTranscriptRef: React.MutableRefObject<boolean>;
-  confirmDictation: () => void | Promise<void>;
-  cancelDictation: () => void | Promise<void>;
-  startDictationIfAvailable: () => Promise<void>;
-  handleToggleRealtimeVoiceShortcut: () => void;
-  isRealtimeVoiceForCurrentAgent: boolean;
-  voice: { toggleMute: () => void } | null | undefined;
-}
-
-function runKeyboardActionImpl(
-  action: MessageInputKeyboardActionKind,
-  h: KeyboardActionHandlers,
-): boolean {
-  if (action === "focus") {
-    h.textInputRef.current?.focus();
-    return true;
-  }
-  if (action === "send" || action === "dictation-confirm") {
-    if (h.isDictatingRef.current) {
-      h.sendAfterTranscriptRef.current = true;
-      void h.confirmDictation();
-      return true;
-    }
-    return false;
-  }
-  if (action === "voice-toggle") {
-    h.handleToggleRealtimeVoiceShortcut();
-    return true;
-  }
-  if (action === "voice-mute-toggle") {
-    if (h.isRealtimeVoiceForCurrentAgent) {
-      h.voice?.toggleMute();
-    }
-    return true;
-  }
-  if (action === "dictation-cancel") {
-    if (h.isDictatingRef.current) {
-      void h.cancelDictation();
-      return true;
-    }
-    return false;
-  }
-  if (action === "dictation-toggle") {
-    if (h.isDictatingRef.current) {
-      h.sendAfterTranscriptRef.current = true;
-      void h.confirmDictation();
-    } else {
-      void h.startDictationIfAvailable();
-    }
-    return true;
-  }
-  return false;
-}
-
 function getTextInputNativeElement(
   current: TextInput | (TextInput & { getNativeRef?: () => unknown }) | null,
 ): HTMLElement | null {
@@ -916,22 +858,18 @@ function toggleRealtimeVoiceImpl(ctx: ToggleRealtimeVoiceContext): void {
 interface StartDictationContext {
   dictationUnavailableMessage: string | null | undefined;
   canStartDictation: () => boolean;
-  isDictatingRef: React.MutableRefObject<boolean>;
   toast: { error: (msg: string) => void };
   startDictation: () => Promise<void>;
 }
 
 async function startDictationIfAvailableImpl(ctx: StartDictationContext): Promise<void> {
   if (ctx.dictationUnavailableMessage) {
-    ctx.isDictatingRef.current = false;
     ctx.toast.error(ctx.dictationUnavailableMessage);
     return;
   }
   if (!ctx.canStartDictation()) {
-    ctx.isDictatingRef.current = false;
     return;
   }
-  ctx.isDictatingRef.current = true;
   await ctx.startDictation();
 }
 
@@ -1276,16 +1214,18 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
         textInputRef.current?.blur?.();
       },
       runKeyboardAction: (action) =>
-        runKeyboardActionImpl(action, {
-          textInputRef,
-          isDictatingRef,
-          sendAfterTranscriptRef,
+        runMessageInputKeyboardAction(action, {
+          focusInput: () => textInputRef.current?.focus(),
+          isDictationRecording: isDictationActive,
+          markTranscriptForSend: () => {
+            sendAfterTranscriptRef.current = true;
+          },
           confirmDictation,
           cancelDictation,
-          startDictationIfAvailable,
-          handleToggleRealtimeVoiceShortcut,
-          isRealtimeVoiceForCurrentAgent,
-          voice,
+          startDictation: startDictationIfAvailable,
+          toggleRealtimeVoice: handleToggleRealtimeVoiceShortcut,
+          isRealtimeVoiceActive: isRealtimeVoiceForCurrentAgent,
+          toggleRealtimeVoiceMute: () => voice?.toggleMute(),
         }),
       getNativeElement: () => (isWeb ? getTextInputNativeElement(textInputRef.current) : null),
     }));
@@ -1369,6 +1309,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
 
     const {
       isRecording: isDictating,
+      isRecordingActive: isDictationActive,
       isProcessing: isDictationProcessing,
       partialTranscript: _dictationPartialTranscript,
       volume: dictationVolume,
@@ -1388,11 +1329,6 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       canConfirm: canConfirmDictation,
       enableDuration: true,
     });
-
-    const isDictatingRef = useRef(isDictating);
-    useEffect(() => {
-      isDictatingRef.current = isDictating;
-    }, [isDictating]);
 
     const isRealtimeVoiceForCurrentAgent = computeIsRealtimeVoiceForAgent(
       voice,
@@ -1420,7 +1356,6 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
         startDictationIfAvailableImpl({
           dictationUnavailableMessage,
           canStartDictation,
-          isDictatingRef,
           toast,
           startDictation,
         }),

--- a/packages/app/src/composer/input/state.test.ts
+++ b/packages/app/src/composer/input/state.test.ts
@@ -4,11 +4,39 @@ import {
   resolveComposerSurfacePresentation,
   runAlternateSendAction,
   runDefaultSendAction,
+  runMessageInputKeyboardAction,
   stopRealtimeVoice,
 } from "./state";
 
 const connected = { isConnected: true } as never;
 const disconnected = { isConnected: false } as never;
+
+function createDictationKeyboard({ startsRecording }: { startsRecording: boolean }) {
+  let isRecording = false;
+  const actions: string[] = [];
+
+  return {
+    actions,
+    pressDictationShortcut: () =>
+      runMessageInputKeyboardAction("dictation-toggle", {
+        focusInput: () => undefined,
+        isDictationRecording: () => isRecording,
+        markTranscriptForSend: () => actions.push("send transcript"),
+        startDictation: () => {
+          actions.push("start");
+          isRecording = startsRecording;
+        },
+        confirmDictation: () => {
+          actions.push("confirm");
+          isRecording = false;
+        },
+        cancelDictation: () => undefined,
+        toggleRealtimeVoice: () => undefined,
+        isRealtimeVoiceActive: false,
+        toggleRealtimeVoiceMute: () => undefined,
+      }),
+  };
+}
 
 describe("composer surface presentation", () => {
   it("shows only the input when no voice overlay is active", () => {
@@ -111,6 +139,27 @@ describe("computeCanStartDictation", () => {
         dictationUnavailableMessage: null,
       }),
     ).toBe(false);
+  });
+});
+
+describe("dictation keyboard behavior", () => {
+  it("starts dictation again after the previous dictation finishes", () => {
+    const keyboard = createDictationKeyboard({ startsRecording: true });
+
+    keyboard.pressDictationShortcut();
+    keyboard.pressDictationShortcut();
+    keyboard.pressDictationShortcut();
+
+    expect(keyboard.actions).toEqual(["start", "send transcript", "confirm", "start"]);
+  });
+
+  it("can retry when starting dictation does not enter the recording state", () => {
+    const keyboard = createDictationKeyboard({ startsRecording: false });
+
+    keyboard.pressDictationShortcut();
+    keyboard.pressDictationShortcut();
+
+    expect(keyboard.actions).toEqual(["start", "start"]);
   });
 });
 

--- a/packages/app/src/composer/input/state.ts
+++ b/packages/app/src/composer/input/state.ts
@@ -1,5 +1,6 @@
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import type { MessagePayload } from "@/composer/types";
+import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
 
 export type SendBehavior = "interrupt" | "queue";
 
@@ -45,6 +46,18 @@ interface SendActionContext {
   handleQueueMessage: () => void;
 }
 
+interface MessageInputKeyboardActions {
+  focusInput: () => void;
+  isDictationRecording: () => boolean;
+  markTranscriptForSend: () => void;
+  confirmDictation: () => void | Promise<void>;
+  cancelDictation: () => void | Promise<void>;
+  startDictation: () => void | Promise<void>;
+  toggleRealtimeVoice: () => void;
+  isRealtimeVoiceActive: boolean;
+  toggleRealtimeVoiceMute: () => void;
+}
+
 export function computeCanStartDictation(input: {
   client: DaemonClient | null;
   isReadyForDictation: boolean | undefined;
@@ -74,6 +87,51 @@ export function runAlternateSendAction(ctx: SendActionContext): void {
   if (ctx.isAgentRunning && ctx.onQueue) {
     ctx.handleQueueMessage();
   }
+}
+
+export function runMessageInputKeyboardAction(
+  action: MessageInputKeyboardActionKind,
+  actions: MessageInputKeyboardActions,
+): boolean {
+  if (action === "focus") {
+    actions.focusInput();
+    return true;
+  }
+  if (action === "send" || action === "dictation-confirm") {
+    if (actions.isDictationRecording()) {
+      actions.markTranscriptForSend();
+      void actions.confirmDictation();
+      return true;
+    }
+    return false;
+  }
+  if (action === "voice-toggle") {
+    actions.toggleRealtimeVoice();
+    return true;
+  }
+  if (action === "voice-mute-toggle") {
+    if (actions.isRealtimeVoiceActive) {
+      actions.toggleRealtimeVoiceMute();
+    }
+    return true;
+  }
+  if (action === "dictation-cancel") {
+    if (actions.isDictationRecording()) {
+      void actions.cancelDictation();
+      return true;
+    }
+    return false;
+  }
+  if (action === "dictation-toggle") {
+    if (actions.isDictationRecording()) {
+      actions.markTranscriptForSend();
+      void actions.confirmDictation();
+    } else {
+      void actions.startDictation();
+    }
+    return true;
+  }
+  return false;
 }
 
 export async function stopRealtimeVoice(ctx: StopRealtimeVoiceContext): Promise<void> {

--- a/packages/app/src/hooks/use-dictation.shared.ts
+++ b/packages/app/src/hooks/use-dictation.shared.ts
@@ -15,6 +15,7 @@ export interface UseDictationOptions {
 
 export interface UseDictationResult {
   isRecording: boolean;
+  isRecordingActive: () => boolean;
   isProcessing: boolean;
   partialTranscript: string;
   volume: number;

--- a/packages/app/src/hooks/use-dictation.ts
+++ b/packages/app/src/hooks/use-dictation.ts
@@ -59,6 +59,7 @@ export function useDictation(options: UseDictationOptions): UseDictationResult {
   useEffect(() => {
     isRecordingRef.current = isRecording;
   }, [isRecording]);
+  const isRecordingActive = useCallback(() => isRecordingRef.current, []);
 
   const isProcessingRef = useRef(isProcessing);
   useEffect(() => {
@@ -453,6 +454,7 @@ export function useDictation(options: UseDictationOptions): UseDictationResult {
 
   return {
     isRecording,
+    isRecordingActive,
     isProcessing,
     partialTranscript,
     volume: audio.volume,


### PR DESCRIPTION
### Linked issue

Direct report; no matching open issue.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

Keeps Command-D responsive after finishing dictation and toggling the sidebar. The composer previously kept a second recording-state latch that could remain stale after the dictation surface changed, causing the shortcut to confirm an already-finished recording instead of starting a new one.

Shortcut decisions now query the dictation lifecycle's synchronous recording state. Keyboard-action routing also lives in the existing composer state module so the finish-and-restart behavior can be tested directly.

### How did you verify it

- Reproduced the failure in an isolated accessory Electron instance without touching the normal desktop app.
- Ran 20 consecutive cycles of: finish dictation, blur the composer, toggle the sidebar twice with Command-B, then press Command-D. All 20 restarted dictation.
- `npx vitest run packages/app/src/composer/input/state.test.ts --bail=1` — 15 tests passed.
- `npm run typecheck` passed.
- Targeted `npm run lint` passed for all five changed files.
- `npm run format` completed; the pre-commit format check passed.

### Risk surface

No visual, protocol, or persistence changes. The change centralizes existing focus, voice, send, and dictation keyboard routing; the focused tests exercise the dictation lifecycle, while the isolated Electron run covers the reported desktop shortcut sequence.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A: no visual change)
- [x] Tests added or updated where it made sense
