### PR TITLE
fix(opencode): recover turns after event stream EOF

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -86,6 +86,12 @@ async function* waitForEventStreamEnd(signal: Promise<void>): AsyncGenerator<Ope
   yield* [];
 }
 
+async function flushMicrotasks(rounds = 20): Promise<void> {
+  for (let i = 0; i < rounds; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 function hasCompletedTurn(events: AgentStreamEvent[]): boolean {
   return events.some((event) => event.type === "turn_completed");
 }
@@ -1453,7 +1459,10 @@ describe("OpenCode adapter startTurn error handling", () => {
     expect(turn.turnFailed).toBe(false);
     expect(turn.assistantMessages.map((message) => message.text).join("")).toBe("Hello world");
     expect(globalEvent).toHaveBeenCalledTimes(2);
-    expect(status).toHaveBeenCalledWith({ directory: "/tmp/test" });
+    expect(status).toHaveBeenCalledWith(
+      { directory: "/tmp/test" },
+      { signal: expect.any(AbortSignal) },
+    );
     await session.close();
   });
 
@@ -1863,6 +1872,505 @@ describe("OpenCode adapter startTurn error handling", () => {
       }),
     ]);
     await session.close();
+  });
+
+  test("does not re-emit a live-delivered permission re-listed during stream recovery", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const permission = {
+      id: "perm_dup",
+      sessionID: "ses_unit_test",
+      permission: "bash",
+      patterns: ["npm test"],
+      metadata: { command: "npm test", cwd: "/tmp/test" },
+    };
+    const globalEvent = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          await eventsGate.promise;
+          yield { type: "permission.asked", properties: permission };
+        })(),
+      })
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          yield {
+            type: "session.status",
+            properties: { sessionID: "ses_unit_test", status: { type: "idle" } },
+          };
+        })(),
+      });
+    const fakeClient = {
+      global: { event: globalEvent },
+      permission: { list: vi.fn().mockResolvedValue({ data: [permission], error: undefined }) },
+      question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages: vi.fn().mockResolvedValue({ data: [], error: undefined }),
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status: vi.fn().mockResolvedValue({
+          data: { ses_unit_test: { type: "busy" } },
+          error: undefined,
+        }),
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+    expect(turn.turnCompleted).toBe(true);
+    expect(turn.events.filter((event) => event.type === "permission_requested")).toEqual([
+      expect.objectContaining({ request: expect.objectContaining({ id: "perm_dup" }) }),
+    ]);
+    await session.close();
+  });
+
+  test("fails the turn when the recovered assistant message carries a provider error", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const globalEvent = vi.fn().mockResolvedValue({
+      stream: (async function* () {
+        await eventsGate.promise;
+        yield {
+          type: "message.updated",
+          properties: {
+            info: { id: "msg_err", sessionID: "ses_unit_test", role: "assistant" },
+          },
+        };
+      })(),
+    });
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({
+        data: [
+          {
+            info: {
+              id: "msg_err",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              time: { created: Date.now(), completed: Date.now() + 1 },
+              error: { name: "ProviderError", data: { message: "boom" } },
+            },
+            parts: [],
+          },
+        ],
+        error: undefined,
+      });
+    const fakeClient = {
+      global: { event: globalEvent },
+      permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages,
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status: vi.fn().mockResolvedValue({ data: {}, error: undefined }),
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+    expect(turn.turnFailed).toBe(true);
+    expect(turn.error).toContain("boom");
+    await session.close();
+  });
+
+  test("recovers reasoning and tool parts missing from the streamed timeline", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const globalEvent = vi.fn().mockResolvedValue({
+      stream: (async function* () {
+        await eventsGate.promise;
+        yield {
+          type: "message.updated",
+          properties: {
+            info: { id: "msg_rich", sessionID: "ses_unit_test", role: "assistant" },
+          },
+        };
+      })(),
+    });
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({
+        data: [
+          {
+            info: {
+              id: "msg_rich",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              time: { created: Date.now(), completed: Date.now() + 1 },
+            },
+            parts: [
+              {
+                id: "prt_reason",
+                sessionID: "ses_unit_test",
+                messageID: "msg_rich",
+                type: "reasoning",
+                text: "Thinking harder",
+              },
+              {
+                id: "prt_tool",
+                sessionID: "ses_unit_test",
+                messageID: "msg_rich",
+                type: "tool",
+                tool: "bash",
+                callID: "call_bash",
+                state: { status: "completed", input: { command: "ls" }, output: "ok" },
+              },
+              {
+                id: "prt_done",
+                sessionID: "ses_unit_test",
+                messageID: "msg_rich",
+                type: "text",
+                text: "Done.",
+              },
+            ],
+          },
+        ],
+        error: undefined,
+      });
+    const fakeClient = {
+      global: { event: globalEvent },
+      permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages,
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status: vi.fn().mockResolvedValue({ data: {}, error: undefined }),
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+    expect(turn.turnCompleted).toBe(true);
+    expect(
+      turn.allTimelineItems.filter((item) => item.type === "reasoning").map((item) => item.text),
+    ).toEqual(["Thinking harder"]);
+    expect(turn.toolCalls).toEqual([expect.objectContaining({ callId: "call_bash" })]);
+    expect(turn.assistantMessages.map((item) => item.text)).toEqual(["Done."]);
+    await session.close();
+  });
+
+  test("suppresses buffered stream deltas that replay recovered assistant text", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const globalEvent = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          await eventsGate.promise;
+          yield {
+            type: "message.updated",
+            properties: {
+              info: { id: "msg_assistant", sessionID: "ses_unit_test", role: "assistant" },
+            },
+          };
+          yield {
+            type: "message.part.delta",
+            properties: {
+              sessionID: "ses_unit_test",
+              messageID: "msg_assistant",
+              partID: "prt_text",
+              field: "text",
+              delta: "Hello ",
+            },
+          };
+        })(),
+      })
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          // Buffered replay of text the recovery pass already bridged.
+          yield {
+            type: "message.part.delta",
+            properties: {
+              sessionID: "ses_unit_test",
+              messageID: "msg_assistant",
+              partID: "prt_text",
+              field: "text",
+              delta: "world",
+            },
+          };
+          yield {
+            type: "session.status",
+            properties: { sessionID: "ses_unit_test", status: { type: "idle" } },
+          };
+        })(),
+      });
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({
+        data: [
+          {
+            info: {
+              id: "msg_assistant",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              time: { created: Date.now() },
+            },
+            parts: [
+              {
+                id: "prt_text",
+                sessionID: "ses_unit_test",
+                messageID: "msg_assistant",
+                type: "text",
+                text: "Hello world",
+              },
+            ],
+          },
+        ],
+        error: undefined,
+      });
+    const fakeClient = {
+      global: { event: globalEvent },
+      permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages,
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status: vi.fn().mockResolvedValue({
+          data: { ses_unit_test: { type: "busy" } },
+          error: undefined,
+        }),
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+    expect(turn.turnCompleted).toBe(true);
+    expect(turn.assistantMessages.map((item) => item.text).join("")).toBe("Hello world");
+    await session.close();
+  });
+
+  test("bridges every assistant message when a recovered turn spans several", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const globalEvent = vi.fn().mockResolvedValue({
+      stream: (async function* () {
+        await eventsGate.promise;
+        yield {
+          type: "message.updated",
+          properties: {
+            info: { id: "msg_first", sessionID: "ses_unit_test", role: "assistant" },
+          },
+        };
+        yield {
+          type: "message.part.delta",
+          properties: {
+            sessionID: "ses_unit_test",
+            messageID: "msg_first",
+            partID: "prt_first",
+            field: "text",
+            delta: "First. ",
+          },
+        };
+      })(),
+    });
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({
+        data: [
+          {
+            info: {
+              id: "msg_first",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              time: { created: Date.now() },
+            },
+            parts: [
+              {
+                id: "prt_first",
+                sessionID: "ses_unit_test",
+                messageID: "msg_first",
+                type: "text",
+                text: "First. ",
+              },
+            ],
+          },
+          {
+            info: {
+              id: "msg_second",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              time: { created: Date.now(), completed: Date.now() + 1 },
+            },
+            parts: [
+              {
+                id: "prt_second",
+                sessionID: "ses_unit_test",
+                messageID: "msg_second",
+                type: "text",
+                text: "Second.",
+              },
+            ],
+          },
+        ],
+        error: undefined,
+      });
+    const fakeClient = {
+      global: { event: globalEvent },
+      permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages,
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status: vi.fn().mockResolvedValue({ data: {}, error: undefined }),
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+    expect(turn.turnCompleted).toBe(true);
+    expect(turn.assistantMessages.map((item) => item.text)).toEqual(["First. ", "Second."]);
+    await session.close();
+  });
+
+  test("close resolves promptly while the reconnect loop is sleeping between attempts", async () => {
+    vi.useFakeTimers();
+    try {
+      const streamGate = createTestDeferred<void>();
+      const promptStarted = createTestDeferred<void>();
+      const globalEvent = vi
+        .fn()
+        .mockResolvedValueOnce({ stream: waitForEventStreamEnd(streamGate.promise) })
+        .mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:1"));
+      const fakeClient = {
+        global: { event: globalEvent },
+        permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+        question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+        session: {
+          abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+          messages: vi.fn().mockResolvedValue({ data: [], error: undefined }),
+          promptAsync: vi.fn().mockImplementation(() => {
+            promptStarted.resolve();
+            return new Promise(() => {});
+          }),
+          status: vi.fn().mockResolvedValue({ data: {}, error: undefined }),
+        },
+      } as never;
+      const session = new __openCodeInternals.OpenCodeAgentSession(
+        { provider: "opencode", cwd: "/tmp/test" },
+        fakeClient,
+        "ses_unit_test",
+        createTestLogger(),
+      );
+
+      void collectTurnEvents(streamSession(session, "hello")).catch(() => null);
+      await promptStarted.promise;
+      streamGate.resolve();
+      await flushMicrotasks();
+      expect(globalEvent).toHaveBeenCalledTimes(1);
+
+      let closeSettled = false;
+      const closePromise = session.close().then(() => {
+        closeSettled = true;
+        return undefined;
+      });
+      // No timer advance: the abort signal alone must wake the backoff sleep.
+      await flushMicrotasks();
+      expect(closeSettled).toBe(true);
+      await closePromise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("reconnect delays double after zero-event cycles", async () => {
+    vi.useFakeTimers();
+    try {
+      const streamGate = createTestDeferred<void>();
+      const promptStarted = createTestDeferred<void>();
+      const globalEvent = vi
+        .fn()
+        .mockResolvedValueOnce({ stream: waitForEventStreamEnd(streamGate.promise) })
+        .mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:1"));
+      const fakeClient = {
+        global: { event: globalEvent },
+        permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+        question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+        session: {
+          abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+          messages: vi.fn().mockResolvedValue({ data: [], error: undefined }),
+          promptAsync: vi.fn().mockImplementation(() => {
+            promptStarted.resolve();
+            return new Promise(() => {});
+          }),
+          status: vi.fn().mockResolvedValue({ data: {}, error: undefined }),
+        },
+      } as never;
+      const session = new __openCodeInternals.OpenCodeAgentSession(
+        { provider: "opencode", cwd: "/tmp/test" },
+        fakeClient,
+        "ses_unit_test",
+        createTestLogger(),
+      );
+
+      void collectTurnEvents(streamSession(session, "hello")).catch(() => null);
+      await promptStarted.promise;
+      streamGate.resolve();
+      // Cycle 1 ends with zero events -> delay 200ms before the next connect.
+      await flushMicrotasks();
+      expect(globalEvent).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(199);
+      expect(globalEvent).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await flushMicrotasks();
+      // Cycle 2 failed instantly -> delay 400ms.
+      expect(globalEvent).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(399);
+      expect(globalEvent).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(1);
+      await flushMicrotasks();
+      expect(globalEvent).toHaveBeenCalledTimes(3);
+      await session.close();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("does not recover a compaction summary as assistant output", async () => {

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -81,6 +81,15 @@ async function collectTurnEvents(iterator: AsyncGenerator<AgentStreamEvent>): Pr
   return result;
 }
 
+async function* waitForEventStreamEnd(signal: Promise<void>): AsyncGenerator<OpenCodeEvent> {
+  await signal;
+  yield* [];
+}
+
+function hasCompletedTurn(events: AgentStreamEvent[]): boolean {
+  return events.some((event) => event.type === "turn_completed");
+}
+
 function providerAssistantMessages(events: AgentStreamEvent[], text: string): AgentStreamEvent[] {
   return events.filter(
     (event) =>
@@ -1341,6 +1350,630 @@ describe("OpenCode adapter startTurn error handling", () => {
     expect(turn.assistantMessages.map((message) => message.text).join("")).toBe(
       "Hello from global",
     );
+  });
+
+  test("reconnects the global event stream when it ends while OpenCode is still busy", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const globalEvent = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          await eventsGate.promise;
+          yield {
+            type: "message.updated",
+            properties: {
+              info: {
+                id: "msg_assistant",
+                sessionID: "ses_unit_test",
+                role: "assistant",
+              },
+            },
+          };
+          yield {
+            type: "message.part.delta",
+            properties: {
+              sessionID: "ses_unit_test",
+              messageID: "msg_assistant",
+              partID: "prt_text",
+              field: "text",
+              delta: "Hello ",
+            },
+          };
+        })(),
+      })
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          yield {
+            type: "message.part.delta",
+            properties: {
+              sessionID: "ses_unit_test",
+              messageID: "msg_assistant",
+              partID: "prt_text",
+              field: "text",
+              delta: "world",
+            },
+          };
+          yield {
+            type: "session.status",
+            properties: { sessionID: "ses_unit_test", status: { type: "idle" } },
+          };
+        })(),
+      });
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({
+        data: [
+          {
+            info: {
+              id: "msg_assistant",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              time: { created: Date.now() },
+            },
+            parts: [
+              {
+                id: "prt_text",
+                sessionID: "ses_unit_test",
+                messageID: "msg_assistant",
+                type: "text",
+                text: "Hello ",
+              },
+            ],
+          },
+        ],
+        error: undefined,
+      });
+    const status = vi.fn().mockResolvedValue({
+      data: { ses_unit_test: { type: "busy" } },
+      error: undefined,
+    });
+    const fakeClient = {
+      global: { event: globalEvent },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages,
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status,
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+    expect(turn.turnCompleted).toBe(true);
+    expect(turn.turnFailed).toBe(false);
+    expect(turn.assistantMessages.map((message) => message.text).join("")).toBe("Hello world");
+    expect(globalEvent).toHaveBeenCalledTimes(2);
+    expect(status).toHaveBeenCalledWith({ directory: "/tmp/test" });
+    await session.close();
+  });
+
+  test("recovers the missing assistant suffix when stream EOF finds OpenCode idle", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const globalEvent = vi.fn().mockResolvedValue({
+      stream: (async function* () {
+        await eventsGate.promise;
+        yield {
+          type: "message.updated",
+          properties: {
+            info: {
+              id: "msg_assistant",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+            },
+          },
+        };
+        yield {
+          type: "message.part.delta",
+          properties: {
+            sessionID: "ses_unit_test",
+            messageID: "msg_assistant",
+            partID: "prt_text",
+            field: "text",
+            delta: "Hello ",
+          },
+        };
+      })(),
+    });
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({
+        data: [
+          {
+            info: {
+              id: "msg_assistant",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              time: { created: Date.now(), completed: Date.now() + 1 },
+            },
+            parts: [
+              {
+                id: "prt_text",
+                sessionID: "ses_unit_test",
+                messageID: "msg_assistant",
+                type: "text",
+                text: "Hello world",
+                time: { start: Date.now(), end: Date.now() + 1 },
+              },
+            ],
+          },
+        ],
+        error: undefined,
+      });
+    const fakeClient = {
+      global: { event: globalEvent },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages,
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status: vi.fn().mockResolvedValue({
+          data: { ses_unit_test: { type: "idle" } },
+          error: undefined,
+        }),
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+    expect(turn.turnCompleted).toBe(true);
+    expect(turn.turnFailed).toBe(false);
+    expect(turn.assistantMessages.map((message) => message.text)).toEqual(["Hello ", "world"]);
+    expect(globalEvent).toHaveBeenCalledTimes(1);
+    expect(messages).toHaveBeenCalledTimes(2);
+    await session.close();
+  });
+
+  test("does not complete after stream EOF before the native command is dispatched", async () => {
+    const endFirstStream = createTestDeferred<void>();
+    const commandListStarted = createTestDeferred<void>();
+    const commandListResponse = createTestDeferred<{
+      data: Array<{ name: string; description: string; source: "command" }>;
+      error: undefined;
+    }>();
+    const commandDispatched = createTestDeferred<void>();
+    const globalEvent = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stream: waitForEventStreamEnd(endFirstStream.promise),
+      })
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          await commandDispatched.promise;
+          yield {
+            type: "session.status",
+            properties: { sessionID: "ses_unit_test", status: { type: "idle" } },
+          };
+        })(),
+      });
+    const status = vi.fn().mockResolvedValue({ data: {}, error: undefined });
+    const events: AgentStreamEvent[] = [];
+    const fakeClient = {
+      command: {
+        list: vi.fn().mockImplementation(async () => {
+          commandListStarted.resolve();
+          return await commandListResponse.promise;
+        }),
+      },
+      global: { event: globalEvent },
+      permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        command: vi.fn().mockImplementation(async () => {
+          commandDispatched.resolve();
+          return { data: {}, error: undefined };
+        }),
+        messages: vi.fn().mockResolvedValue({ data: [], error: undefined }),
+        status,
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+    session.subscribe((event) => events.push(event));
+    const startTurn = session.startTurn("/custom");
+
+    try {
+      await commandListStarted.promise;
+      endFirstStream.resolve();
+      await vi.waitFor(() => expect(status).toHaveBeenCalled());
+
+      expect(hasCompletedTurn(events)).toBe(false);
+      await vi.waitFor(() => expect(globalEvent).toHaveBeenCalledTimes(2));
+
+      commandListResponse.resolve({
+        data: [{ name: "custom", description: "Custom command", source: "command" }],
+        error: undefined,
+      });
+      await startTurn;
+      await vi.waitFor(() => expect(hasCompletedTurn(events)).toBe(true));
+    } finally {
+      commandListResponse.resolve({ data: [], error: undefined });
+      commandDispatched.resolve();
+      await session.close();
+    }
+  });
+
+  test("reconciles completion immediately after reconnecting the global stream", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const releaseSecondStream = createTestDeferred<void>();
+    const globalEvent = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stream: waitForEventStreamEnd(eventsGate.promise),
+      })
+      .mockResolvedValueOnce({
+        stream: waitForEventStreamEnd(releaseSecondStream.promise),
+      });
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({
+        data: [
+          {
+            info: {
+              id: "msg_assistant",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              time: { created: Date.now(), completed: Date.now() + 1 },
+            },
+            parts: [
+              {
+                id: "prt_text",
+                sessionID: "ses_unit_test",
+                messageID: "msg_assistant",
+                type: "text",
+                text: "Completed during reconnect",
+              },
+            ],
+          },
+        ],
+        error: undefined,
+      });
+    const status = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: { ses_unit_test: { type: "busy" } },
+        error: undefined,
+      })
+      .mockResolvedValue({ data: {}, error: undefined });
+    const fakeClient = {
+      global: { event: globalEvent },
+      permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages,
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status,
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    try {
+      const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+      expect(turn.turnCompleted).toBe(true);
+      expect(turn.assistantMessages.map((message) => message.text)).toEqual([
+        "Completed during reconnect",
+      ]);
+      expect(globalEvent).toHaveBeenCalledTimes(2);
+    } finally {
+      releaseSecondStream.resolve();
+      await session.close();
+    }
+  });
+
+  test("recovers a pending question that appears while the global stream reconnects", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const question = {
+      id: "question-during-reconnect",
+      sessionID: "ses_unit_test",
+      questions: [
+        {
+          question: "Which option should OpenCode use?",
+          header: "Option",
+          options: [{ label: "Safe", description: "Use the safe option" }],
+        },
+      ],
+    };
+    const globalEvent = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stream: waitForEventStreamEnd(eventsGate.promise),
+      })
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          yield {
+            type: "session.status",
+            properties: { sessionID: "ses_unit_test", status: { type: "idle" } },
+          };
+        })(),
+      });
+    const questionList = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({ data: [question], error: undefined });
+    const fakeClient = {
+      global: { event: globalEvent },
+      permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      question: { list: questionList },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages: vi.fn().mockResolvedValue({ data: [], error: undefined }),
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status: vi.fn().mockResolvedValue({
+          data: { ses_unit_test: { type: "busy" } },
+          error: undefined,
+        }),
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+    expect(turn.events.filter((event) => event.type === "permission_requested")).toEqual([
+      expect.objectContaining({
+        request: expect.objectContaining({ id: "question-during-reconnect", kind: "question" }),
+      }),
+    ]);
+    await session.close();
+  });
+
+  test("does not recover a compaction summary as assistant output", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({
+        data: [
+          {
+            info: {
+              id: "msg_compaction",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              summary: true,
+              time: { created: Date.now(), completed: Date.now() + 1 },
+            },
+            parts: [
+              {
+                id: "prt_summary",
+                sessionID: "ses_unit_test",
+                messageID: "msg_compaction",
+                type: "text",
+                text: "Internal compaction summary",
+              },
+            ],
+          },
+        ],
+        error: undefined,
+      });
+    const fakeClient = {
+      global: {
+        event: vi.fn().mockResolvedValue({
+          stream: waitForEventStreamEnd(eventsGate.promise),
+        }),
+      },
+      permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages,
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status: vi.fn().mockResolvedValue({ data: {}, error: undefined }),
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+    expect(turn.turnCompleted).toBe(true);
+    expect(turn.assistantMessages).toEqual([]);
+    await session.close();
+  });
+
+  test("does not recover todowrite tool parts that have their own timeline event", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({
+        data: [
+          {
+            info: {
+              id: "msg_assistant",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              time: { created: Date.now(), completed: Date.now() + 1 },
+            },
+            parts: [
+              {
+                id: "prt_todowrite",
+                sessionID: "ses_unit_test",
+                messageID: "msg_assistant",
+                type: "tool",
+                tool: "todowrite",
+                callID: "call_todowrite",
+                state: { status: "completed", input: { todos: [] }, output: "Updated todos" },
+              },
+            ],
+          },
+        ],
+        error: undefined,
+      });
+    const fakeClient = {
+      global: {
+        event: vi.fn().mockResolvedValue({
+          stream: waitForEventStreamEnd(eventsGate.promise),
+        }),
+      },
+      permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages,
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status: vi.fn().mockResolvedValue({ data: {}, error: undefined }),
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+    expect(turn.turnCompleted).toBe(true);
+    expect(turn.toolCalls).toEqual([]);
+    await session.close();
+  });
+
+  test("corrects partially streamed usage from the persisted assistant message", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({
+        data: [
+          {
+            info: {
+              id: "msg_assistant",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              time: { created: Date.now(), completed: Date.now() + 1 },
+              cost: 0.25,
+              tokens: {
+                input: 30_000,
+                output: 12_000,
+                reasoning: 3_000,
+                cache: { read: 5_000, write: 0 },
+              },
+            },
+            parts: [],
+          },
+        ],
+        error: undefined,
+      });
+    const fakeClient = {
+      global: {
+        event: vi.fn().mockResolvedValue({
+          stream: (async function* () {
+            await eventsGate.promise;
+            yield {
+              type: "message.updated",
+              properties: {
+                info: {
+                  id: "msg_assistant",
+                  sessionID: "ses_unit_test",
+                  role: "assistant",
+                },
+              },
+            };
+            yield {
+              type: "message.part.updated",
+              properties: {
+                part: {
+                  id: "prt_step",
+                  sessionID: "ses_unit_test",
+                  messageID: "msg_assistant",
+                  type: "step-finish",
+                  cost: 0.1,
+                  tokens: {
+                    input: 10_000,
+                    output: 4_000,
+                    reasoning: 1_000,
+                    cache: { read: 2_000, write: 0 },
+                  },
+                },
+              },
+            };
+          })(),
+        }),
+      },
+      permission: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      question: { list: vi.fn().mockResolvedValue({ data: [], error: undefined }) },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages,
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status: vi.fn().mockResolvedValue({ data: {}, error: undefined }),
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+    const completion = turn.events.find((event) => event.type === "turn_completed");
+
+    expect(completion).toMatchObject({
+      usage: {
+        inputTokens: 30_000,
+        cachedInputTokens: 5_000,
+        outputTokens: 12_000,
+        contextWindowUsedTokens: 50_000,
+        totalCostUsd: 0.25,
+      },
+    });
+    await session.close();
   });
 
   test("keeps a turn active while OpenCode is retrying", async () => {

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -1457,6 +1457,112 @@ describe("OpenCode adapter startTurn error handling", () => {
     await session.close();
   });
 
+  test("keeps reconnecting through consecutive failed event stream connects while OpenCode is busy", async () => {
+    const eventsGate = createTestDeferred<void>();
+    const globalEvent = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          await eventsGate.promise;
+          yield {
+            type: "message.updated",
+            properties: {
+              info: {
+                id: "msg_assistant",
+                sessionID: "ses_unit_test",
+                role: "assistant",
+              },
+            },
+          };
+          yield {
+            type: "message.part.delta",
+            properties: {
+              sessionID: "ses_unit_test",
+              messageID: "msg_assistant",
+              partID: "prt_text",
+              field: "text",
+              delta: "Hello ",
+            },
+          };
+        })(),
+      })
+      .mockRejectedValueOnce(new Error("connect ECONNREFUSED 127.0.0.1:1"))
+      .mockRejectedValueOnce(new Error("connect ECONNREFUSED 127.0.0.1:1"))
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          yield {
+            type: "message.part.delta",
+            properties: {
+              sessionID: "ses_unit_test",
+              messageID: "msg_assistant",
+              partID: "prt_text",
+              field: "text",
+              delta: "world",
+            },
+          };
+          yield {
+            type: "session.status",
+            properties: { sessionID: "ses_unit_test", status: { type: "idle" } },
+          };
+        })(),
+      });
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [], error: undefined })
+      .mockResolvedValue({
+        data: [
+          {
+            info: {
+              id: "msg_assistant",
+              sessionID: "ses_unit_test",
+              role: "assistant",
+              time: { created: Date.now() },
+            },
+            parts: [
+              {
+                id: "prt_text",
+                sessionID: "ses_unit_test",
+                messageID: "msg_assistant",
+                type: "text",
+                text: "Hello ",
+              },
+            ],
+          },
+        ],
+        error: undefined,
+      });
+    const status = vi.fn().mockResolvedValue({
+      data: { ses_unit_test: { type: "busy" } },
+      error: undefined,
+    });
+    const fakeClient = {
+      global: { event: globalEvent },
+      session: {
+        abort: vi.fn().mockResolvedValue({ data: true, error: undefined }),
+        messages,
+        promptAsync: vi.fn().mockImplementation(async () => {
+          eventsGate.resolve();
+          return { data: {}, error: undefined };
+        }),
+        status,
+      },
+    } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "hello"));
+
+    expect(turn.turnCompleted).toBe(true);
+    expect(turn.turnFailed).toBe(false);
+    expect(turn.assistantMessages.map((message) => message.text).join("")).toBe("Hello world");
+    expect(globalEvent).toHaveBeenCalledTimes(4);
+    await session.close();
+  });
+
   test("recovers the missing assistant suffix when stream EOF finds OpenCode idle", async () => {
     const eventsGate = createTestDeferred<void>();
     const globalEvent = vi.fn().mockResolvedValue({

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -2,6 +2,8 @@ import {
   createOpencodeClient,
   type AssistantMessage as OpenCodeAssistantMessage,
   type Event as OpenCodeEvent,
+  type EventPermissionAsked as OpenCodePermissionAskedEvent,
+  type EventQuestionAsked as OpenCodeQuestionAskedEvent,
   type FilePartInput as OpenCodeFilePartInput,
   type GlobalSession as OpenCodeGlobalSession,
   type Message as OpenCodeMessage,
@@ -103,6 +105,7 @@ const OPENCODE_LEGACY_FULL_ACCESS_MODE_ID = "full-access";
 const OPENCODE_AUTO_ACCEPT_FEATURE_ID = "auto_accept";
 const OPENCODE_PERSISTED_SESSION_LIMIT = 200;
 const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
+const OPENCODE_EVENT_STREAM_RECONNECT_DELAY_MS = 100;
 const OPENCODE_CHILD_SESSION_HYDRATION_LIMIT = 100;
 const OPENCODE_CHILD_SESSION_SERVER_REGISTRY_LIMIT = 500;
 const OPENCODE_PERMISSION_ACTION_ALLOW_ONCE = "allow_once";
@@ -265,6 +268,18 @@ type OpenCodePersistedSession = OpenCodeSession | OpenCodeGlobalSession;
 interface OpenCodeSessionMessage {
   info: OpenCodeMessage;
   parts: OpenCodePart[];
+}
+
+interface OpenCodeAssistantSessionMessage extends OpenCodeSessionMessage {
+  info: OpenCodeAssistantMessage;
+}
+
+type OpenCodePendingRequestEvent = OpenCodePermissionAskedEvent | OpenCodeQuestionAskedEvent;
+
+function isOpenCodeAssistantSessionMessage(
+  message: OpenCodeSessionMessage,
+): message is OpenCodeAssistantSessionMessage {
+  return message.info.role === "assistant";
 }
 
 type OpenCodeMcpConfig =
@@ -2927,6 +2942,16 @@ class OpenCodeAgentSession implements AgentSession {
   private eventStreamAbortController: AbortController | null = null;
   private eventStreamReady: Deferred<void> | null = null;
   private eventStreamTask: Promise<void> | null = null;
+  private foregroundTurnStartedAt: number | null = null;
+  private foregroundKnownMessageIds: ReadonlySet<string> | null = null;
+  private foregroundAssistantMessageIds = new Set<string>();
+  private foregroundAssistantText = "";
+  private foregroundEmittedReasoningByPartId = new Map<string, string>();
+  private foregroundEmittedToolCallSignatureByCallId = new Map<string, string>();
+  private foregroundNativeRequestDispatched = false;
+  private foregroundNativeActivityObserved = false;
+  private foregroundSessionTotalCostUsdAtStart: number | undefined;
+  private seenPermissionRequestIds = new Set<string>();
   private closed = false;
   private readonly persistSession: boolean;
   private deletedFromProvider = false;
@@ -3120,6 +3145,10 @@ class OpenCodeAgentSession implements AgentSession {
       throw new Error("OpenCode is still stopping the previous turn");
     }
 
+    const foregroundTurnStartedAt = Date.now();
+    const foregroundKnownMessageIds = await this.readForegroundSessionMessageIds();
+    this.resetForegroundRecoveryState(foregroundTurnStartedAt, foregroundKnownMessageIds);
+
     this.runningToolCalls.clear();
     this.subAgentsByCallId.clear();
     this.subAgentCallIdByChildSessionId.clear();
@@ -3155,6 +3184,7 @@ class OpenCodeAgentSession implements AgentSession {
     if (slashCommand) {
       if (slashCommand.commandName === "compact" || slashCommand.commandName === "summarize") {
         this.suppressAssistantMessagesUntilIdle.active = true;
+        this.foregroundNativeRequestDispatched = true;
         void this.client.session
           .summarize({
             sessionID: this.sessionId,
@@ -3191,6 +3221,7 @@ class OpenCodeAgentSession implements AgentSession {
 
       // command() is only dispatch acknowledgement. OpenCode session events are
       // the source of truth for when the command turn becomes idle or fails.
+      this.foregroundNativeRequestDispatched = true;
       void this.client.session
         .command({
           sessionID: this.sessionId,
@@ -3257,6 +3288,7 @@ class OpenCodeAgentSession implements AgentSession {
             this.config.systemPrompt,
             this.config.daemonAppendSystemPrompt,
           );
+          this.foregroundNativeRequestDispatched = true;
           const promptResponse = await this.client.session.promptAsync({
             sessionID: this.sessionId,
             directory: this.config.cwd,
@@ -3490,70 +3522,440 @@ class OpenCodeAgentSession implements AgentSession {
       cwd: this.config.cwd,
     });
     let eventStreamReadyResolved = false;
-    try {
-      const result = await this.client.global.event({
-        signal: eventStreamAbortController.signal,
-        sseMaxRetryAttempts: 0,
-      });
-      eventStreamReadyResolved = true;
-      this.traceOpenCode("provider.opencode.subscribe.ready", {
-        sessionId: this.sessionId,
-      });
-      eventStreamReady.resolve();
-
+    while (!eventStreamAbortController.signal.aborted) {
       let eventCount = 0;
-      for await (const rawEvent of result.stream) {
-        eventCount += 1;
-        await this.consumeOpenCodeStreamEvent({ rawEvent, eventCount });
+      let streamError: unknown;
+      try {
+        const isReplacementStream = eventStreamReadyResolved;
+        const result = await this.client.global.event({
+          signal: eventStreamAbortController.signal,
+          sseMaxRetryAttempts: 0,
+        });
+        if (!eventStreamReadyResolved) {
+          eventStreamReadyResolved = true;
+          this.traceOpenCode("provider.opencode.subscribe.ready", {
+            sessionId: this.sessionId,
+          });
+          eventStreamReady.resolve();
+        }
+
+        const activeTurnId = this.activeForegroundTurnId;
+        if (isReplacementStream && activeTurnId) {
+          await this.reconcileForegroundTurnAfterStreamEnd(activeTurnId);
+        }
+
+        for await (const rawEvent of result.stream) {
+          eventCount += 1;
+          await this.consumeOpenCodeStreamEvent({ rawEvent, eventCount });
+        }
+      } catch (error) {
+        streamError = error;
+        this.traceOpenCode("provider.opencode.subscribe.error", {
+          turnId: this.activeForegroundTurnId ?? undefined,
+          error:
+            error instanceof Error ? { name: error.name, message: error.message } : String(error),
+        });
+      }
+
+      if (eventStreamAbortController.signal.aborted) {
+        return;
+      }
+      if (!eventStreamReadyResolved) {
+        eventStreamReady.reject(
+          streamError ?? new Error("OpenCode event stream ended before it became ready"),
+        );
+        return;
       }
 
       this.traceOpenCode("provider.opencode.stream.eof", {
         eventCount,
-        aborted: eventStreamAbortController.signal.aborted,
         activeTurnId: this.activeForegroundTurnId,
+        streamError,
       });
-
-      if (!eventStreamAbortController.signal.aborted) {
-        if (!eventStreamReadyResolved) {
-          eventStreamReady.reject(new Error("OpenCode event stream ended before it became ready"));
-        }
-        const activeTurnId = this.activeForegroundTurnId;
-        if (activeTurnId) {
-          this.traceOpenCode("provider.opencode.turn.fail_eof", {
-            turnId: activeTurnId,
-            eventCount,
-          });
-          this.finishForegroundTurn(
-            {
-              type: "turn_failed",
-              provider: "opencode",
-              error: "OpenCode event stream ended before the turn reached a terminal state",
-            },
-            activeTurnId,
-          );
-        }
-      }
-    } catch (error) {
-      this.traceOpenCode("provider.opencode.subscribe.error", {
-        turnId: this.activeForegroundTurnId ?? undefined,
-        error:
-          error instanceof Error ? { name: error.name, message: error.message } : String(error),
-      });
-      if (!eventStreamReadyResolved) {
-        eventStreamReady.reject(error);
-      }
       const activeTurnId = this.activeForegroundTurnId;
-      if (!eventStreamAbortController.signal.aborted && activeTurnId) {
+      if (!activeTurnId) {
+        return;
+      }
+
+      const recovery = await this.reconcileForegroundTurnAfterStreamEnd(activeTurnId);
+      if (recovery === "handled") {
+        return;
+      }
+      if (recovery === "reconnect") {
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, OPENCODE_EVENT_STREAM_RECONNECT_DELAY_MS),
+        );
+        continue;
+      }
+
+      this.traceOpenCode("provider.opencode.turn.fail_eof", {
+        turnId: activeTurnId,
+        eventCount,
+        streamError,
+      });
+      this.finishForegroundTurn(
+        {
+          type: "turn_failed",
+          provider: "opencode",
+          error: streamError
+            ? toDiagnosticErrorMessage(streamError)
+            : "OpenCode event stream ended before the turn reached a terminal state",
+        },
+        activeTurnId,
+      );
+      return;
+    }
+  }
+
+  private async reconcileForegroundTurnAfterStreamEnd(
+    turnId: string,
+  ): Promise<"handled" | "reconnect" | "unresolved"> {
+    const [status, messages] = await Promise.all([
+      this.readForegroundSessionStatus(),
+      this.readForegroundSessionMessages(),
+    ]);
+    if (this.activeForegroundTurnId !== turnId) {
+      return "handled";
+    }
+
+    if (!this.foregroundNativeRequestDispatched) {
+      return "reconnect";
+    }
+
+    const nativeTurnIsActive = status === "busy" || status === "retry";
+    this.observeForegroundNativeActivity(nativeTurnIsActive, messages);
+
+    const hasPendingRequest = await this.recoverForegroundPendingRequests(turnId);
+    if (this.activeForegroundTurnId !== turnId) {
+      return "handled";
+    }
+    if (hasPendingRequest) {
+      this.foregroundNativeActivityObserved = true;
+      return "reconnect";
+    }
+
+    const assistantMessage = messages ? this.findForegroundAssistantMessage(messages) : null;
+    if (assistantMessage) {
+      this.foregroundNativeActivityObserved = true;
+      this.foregroundAssistantMessageIds.add(assistantMessage.info.id);
+      if (assistantMessage.info.error) {
         this.finishForegroundTurn(
           {
             type: "turn_failed",
             provider: "opencode",
-            error: toDiagnosticErrorMessage(error),
+            error: toDiagnosticErrorMessage(assistantMessage.info.error),
           },
-          activeTurnId,
+          turnId,
         );
+        return "handled";
+      }
+      if (!this.emitRecoveredAssistantParts(assistantMessage, turnId)) {
+        return "unresolved";
       }
     }
+
+    if (nativeTurnIsActive) {
+      this.logger.warn(
+        { sessionId: this.sessionId, turnId, status },
+        "OpenCode event stream ended during an active native turn; reconnecting",
+      );
+      return "reconnect";
+    }
+    if (!this.foregroundNativeActivityObserved) {
+      return "reconnect";
+    }
+    if (status !== "idle" && assistantMessage?.info.time?.completed === undefined) {
+      return "unresolved";
+    }
+
+    if (assistantMessage) {
+      this.applyRecoveredAssistantUsage(assistantMessage.info, turnId);
+    }
+    this.logger.warn(
+      { sessionId: this.sessionId, turnId },
+      "Recovered OpenCode turn completion after the event stream ended",
+    );
+    this.finishForegroundTurn(
+      {
+        type: "turn_completed",
+        provider: "opencode",
+        usage: hasNormalizedOpenCodeUsage(this.accumulatedUsage)
+          ? { ...this.accumulatedUsage }
+          : undefined,
+      },
+      turnId,
+    );
+    return "handled";
+  }
+
+  private observeForegroundNativeActivity(
+    nativeTurnIsActive: boolean,
+    messages: OpenCodeSessionMessage[] | null,
+  ): void {
+    const hasNewMessage =
+      this.foregroundKnownMessageIds !== null &&
+      messages?.some((message) => !this.foregroundKnownMessageIds?.has(message.info.id)) === true;
+    if (nativeTurnIsActive || hasNewMessage) {
+      this.foregroundNativeActivityObserved = true;
+    }
+  }
+
+  private async readForegroundSessionStatus(): Promise<"busy" | "retry" | "idle" | null> {
+    try {
+      const response = await this.client.session.status({ directory: this.config.cwd });
+      if (response.error || !response.data) {
+        return null;
+      }
+      const status = readOpenCodeRecord(response.data[this.sessionId]);
+      if (!status) {
+        // OpenCode removes idle sessions from the status map.
+        return "idle";
+      }
+      const type = readNonEmptyString(status.type);
+      return type === "busy" || type === "retry" || type === "idle" ? type : null;
+    } catch (error) {
+      this.logger.debug(
+        { err: error, sessionId: this.sessionId },
+        "Failed to read OpenCode session status after event stream termination",
+      );
+      return null;
+    }
+  }
+
+  private async readForegroundSessionMessages(): Promise<OpenCodeSessionMessage[] | null> {
+    try {
+      const response = await this.client.session.messages({
+        sessionID: this.sessionId,
+        directory: this.config.cwd,
+      });
+      return response.error || !response.data ? null : response.data;
+    } catch (error) {
+      this.logger.debug(
+        { err: error, sessionId: this.sessionId },
+        "Failed to read OpenCode messages after event stream termination",
+      );
+      return null;
+    }
+  }
+
+  private async readForegroundPendingRequestEvents(): Promise<OpenCodePendingRequestEvent[]> {
+    const readQuestions = async (): Promise<OpenCodeQuestionAskedEvent[]> => {
+      try {
+        const response = await this.client.question.list({ directory: this.config.cwd });
+        if (response.error || !response.data) {
+          return [];
+        }
+        return response.data
+          .filter(
+            (request) =>
+              request.sessionID === this.sessionId ||
+              this.knownChildSessionIds.has(request.sessionID),
+          )
+          .map((properties) => ({ id: properties.id, type: "question.asked", properties }));
+      } catch (error) {
+        this.logger.debug(
+          { err: error, sessionId: this.sessionId },
+          "Failed to read pending OpenCode questions during stream recovery",
+        );
+        return [];
+      }
+    };
+    const readPermissions = async (): Promise<OpenCodePermissionAskedEvent[]> => {
+      try {
+        const response = await this.client.permission.list({ directory: this.config.cwd });
+        if (response.error || !response.data) {
+          return [];
+        }
+        return response.data
+          .filter(
+            (request) =>
+              request.sessionID === this.sessionId ||
+              this.knownChildSessionIds.has(request.sessionID),
+          )
+          .map((properties) => ({ id: properties.id, type: "permission.asked", properties }));
+      } catch (error) {
+        this.logger.debug(
+          { err: error, sessionId: this.sessionId },
+          "Failed to read pending OpenCode permissions during stream recovery",
+        );
+        return [];
+      }
+    };
+
+    const [questionEvents, permissionEvents] = await Promise.all([
+      readQuestions(),
+      readPermissions(),
+    ]);
+    return [...questionEvents, ...permissionEvents];
+  }
+
+  private async recoverForegroundPendingRequests(turnId: string): Promise<boolean> {
+    const requestEvents = await this.readForegroundPendingRequestEvents();
+    let hasPendingRequest = false;
+    for (const event of requestEvents) {
+      const translated = await this.translateEvent(event);
+      for (const translatedEvent of translated) {
+        if (isOpenCodeProviderInternalEvent(translatedEvent)) {
+          this.notifySubscribers(translatedEvent, null);
+          continue;
+        }
+        this.notifySubscribers(translatedEvent, turnId);
+      }
+      hasPendingRequest ||= this.pendingPermissions.has(event.properties.id);
+    }
+    return hasPendingRequest;
+  }
+
+  private async readForegroundSessionMessageIds(): Promise<ReadonlySet<string> | null> {
+    const messages = await this.readForegroundSessionMessages();
+    return messages ? new Set(messages.map((message) => message.info.id)) : null;
+  }
+
+  private findForegroundAssistantMessage(
+    messages: readonly OpenCodeSessionMessage[],
+  ): OpenCodeAssistantSessionMessage | null {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (!message || !isOpenCodeAssistantSessionMessage(message)) {
+        continue;
+      }
+      if (this.foregroundKnownMessageIds?.has(message.info.id)) {
+        continue;
+      }
+      if (this.foregroundKnownMessageIds === null) {
+        const observedDuringTurn = this.foregroundAssistantMessageIds.has(message.info.id);
+        const createdDuringTurn =
+          this.foregroundTurnStartedAt !== null &&
+          typeof message.info.time?.created === "number" &&
+          message.info.time.created >= this.foregroundTurnStartedAt;
+        if (!observedDuringTurn && !createdDuringTurn) {
+          continue;
+        }
+      }
+      return message;
+    }
+    return null;
+  }
+
+  private emitRecoveredAssistantParts(
+    message: OpenCodeAssistantSessionMessage,
+    turnId: string,
+  ): boolean {
+    if (
+      this.suppressAssistantMessagesUntilIdle.active ||
+      isOpenCodeCompactionSummaryMessage(message.info)
+    ) {
+      return true;
+    }
+    for (const part of message.parts) {
+      if (part.type === "reasoning" && part.text) {
+        const emittedText = this.foregroundEmittedReasoningByPartId.get(part.id) ?? "";
+        if (!part.text.startsWith(emittedText)) {
+          return false;
+        }
+        const missingText = part.text.slice(emittedText.length);
+        if (missingText) {
+          this.foregroundEmittedReasoningByPartId.set(part.id, part.text);
+          this.notifySubscribers(
+            {
+              type: "timeline",
+              provider: "opencode",
+              item: { type: "reasoning", text: missingText },
+            },
+            turnId,
+          );
+        }
+        continue;
+      }
+      if (part.type !== "tool") {
+        continue;
+      }
+      if (isOpenCodeTodoWriteToolPart(part)) {
+        continue;
+      }
+      const parsedToolPart = OpencodeToolPartToTimelineItemSchema.safeParse(part);
+      if (!parsedToolPart.success || !parsedToolPart.data) {
+        continue;
+      }
+      const signature = JSON.stringify(parsedToolPart.data);
+      if (
+        this.foregroundEmittedToolCallSignatureByCallId.get(parsedToolPart.data.callId) ===
+        signature
+      ) {
+        continue;
+      }
+      this.foregroundEmittedToolCallSignatureByCallId.set(parsedToolPart.data.callId, signature);
+      this.trackToolCall(parsedToolPart.data);
+      this.notifySubscribers(
+        { type: "timeline", provider: "opencode", item: parsedToolPart.data },
+        turnId,
+      );
+    }
+
+    let completedText = message.parts
+      .filter((part): part is Extract<OpenCodePart, { type: "text" }> => part.type === "text")
+      .map((part) => part.text ?? "")
+      .join("");
+    if (!completedText) {
+      completedText = stringifyStructuredAssistantMessage(message.info.structured) ?? "";
+    }
+    if (!completedText.startsWith(this.foregroundAssistantText)) {
+      return false;
+    }
+    const missingText = completedText.slice(this.foregroundAssistantText.length);
+    if (missingText) {
+      this.notifySubscribers(
+        {
+          type: "timeline",
+          provider: "opencode",
+          item: { type: "assistant_message", text: missingText },
+        },
+        turnId,
+      );
+    }
+    return true;
+  }
+
+  private applyRecoveredAssistantUsage(info: OpenCodeAssistantMessage, turnId: string): void {
+    const usage: AgentUsage = {};
+    const cost = readPositiveFiniteNumber(info.cost);
+    if (cost !== undefined) {
+      const recoveredSessionTotalCostUsd = (this.foregroundSessionTotalCostUsdAtStart ?? 0) + cost;
+      this.sessionTotalCostUsd = maxFiniteNumber(
+        this.sessionTotalCostUsd,
+        recoveredSessionTotalCostUsd,
+      );
+    }
+    mergeOpenCodeStepFinishUsage(
+      usage,
+      { cost: info.cost, tokens: info.tokens },
+      {
+        totalCostUsd: this.sessionTotalCostUsd,
+      },
+    );
+    if (!hasNormalizedOpenCodeUsage(usage)) {
+      return;
+    }
+    this.accumulatedUsage = { ...this.accumulatedUsage, ...usage };
+    this.notifySubscribers(
+      { type: "usage_updated", provider: "opencode", usage: { ...this.accumulatedUsage } },
+      turnId,
+    );
+  }
+
+  private resetForegroundRecoveryState(
+    startedAt: number,
+    knownMessageIds: ReadonlySet<string> | null,
+  ): void {
+    this.foregroundTurnStartedAt = startedAt;
+    this.foregroundKnownMessageIds = knownMessageIds;
+    this.foregroundAssistantMessageIds.clear();
+    this.foregroundAssistantText = "";
+    this.foregroundEmittedReasoningByPartId.clear();
+    this.foregroundEmittedToolCallSignatureByCallId.clear();
+    this.foregroundNativeRequestDispatched = false;
+    this.foregroundNativeActivityObserved = false;
+    this.foregroundSessionTotalCostUsdAtStart = this.sessionTotalCostUsd;
   }
 
   private async consumeOpenCodeStreamEvent(params: {
@@ -3610,6 +4012,7 @@ class OpenCodeAgentSession implements AgentSession {
       });
       return;
     }
+    this.recordForegroundOpenCodeEvent(event);
     this.traceOpenCode("provider.opencode.parsed_event", {
       turnId,
       n: eventCount,
@@ -3636,7 +4039,44 @@ class OpenCodeAgentSession implements AgentSession {
         return;
       }
       this.notifySubscribers(e, turnId);
+      this.recordForegroundReasoningEmission(event, e);
     }
+  }
+
+  private recordForegroundOpenCodeEvent(event: OpenCodeEvent): void {
+    const eventSessionId = getOpenCodeEventSessionId(event);
+    if (eventSessionId !== this.sessionId) {
+      return;
+    }
+    if (!isOpenCodeTerminalEvent(event, this.sessionId)) {
+      this.foregroundNativeActivityObserved = true;
+    }
+    if (event.type === "message.updated" && event.properties.info.role === "assistant") {
+      this.foregroundAssistantMessageIds.add(event.properties.info.id);
+      return;
+    }
+    const properties = readOpenCodeRecord(event.properties);
+    const messageId = readNonEmptyString(properties?.messageID);
+    if (messageId && this.messageRoles.get(messageId) === "assistant") {
+      this.foregroundAssistantMessageIds.add(messageId);
+    }
+  }
+
+  private recordForegroundReasoningEmission(
+    event: OpenCodeEvent,
+    emittedEvent: AgentStreamEvent,
+  ): void {
+    if (emittedEvent.type !== "timeline" || emittedEvent.item.type !== "reasoning") {
+      return;
+    }
+    const properties = readOpenCodeRecord(event.properties);
+    const part = readOpenCodeRecord(properties?.part);
+    const partId = readNonEmptyString(properties?.partID) ?? readNonEmptyString(part?.id);
+    if (!partId) {
+      return;
+    }
+    const emittedText = this.foregroundEmittedReasoningByPartId.get(partId) ?? "";
+    this.foregroundEmittedReasoningByPartId.set(partId, emittedText + emittedEvent.item.text);
   }
 
   private emitBackgroundPermissionRequests(events: readonly AgentStreamEvent[]): void {
@@ -3679,6 +4119,9 @@ class OpenCodeAgentSession implements AgentSession {
 
   private startAutonomousTurn(): string {
     const turnId = this.createTurnId();
+    this.resetForegroundRecoveryState(Date.now(), null);
+    this.foregroundNativeRequestDispatched = true;
+    this.foregroundNativeActivityObserved = true;
     this.turnState = { status: "running", turnId };
     this.runningToolCalls.clear();
     this.subAgentsByCallId.clear();
@@ -3711,6 +4154,11 @@ class OpenCodeAgentSession implements AgentSession {
     }
     this.pendingUserMessageText = null;
     this.pendingClientMessageId = null;
+    this.foregroundTurnStartedAt = null;
+    this.foregroundKnownMessageIds = null;
+    this.foregroundNativeRequestDispatched = false;
+    this.foregroundNativeActivityObserved = false;
+    this.foregroundSessionTotalCostUsdAtStart = undefined;
     this.turnState = { status: "idle" };
     this.abortController = null;
     this.notifySubscribers(event, turnId);
@@ -3782,6 +4230,17 @@ class OpenCodeAgentSession implements AgentSession {
       return;
     }
     const turnId = turnIdOverride === null ? null : (turnIdOverride ?? this.activeForegroundTurnId);
+    if (turnId && turnId === this.activeForegroundTurnId) {
+      if (event.type === "timeline" && event.item.type === "assistant_message") {
+        this.foregroundAssistantText += event.item.text;
+      }
+      if (event.type === "timeline" && event.item.type === "tool_call") {
+        this.foregroundEmittedToolCallSignatureByCallId.set(
+          event.item.callId,
+          JSON.stringify(event.item),
+        );
+      }
+    }
     const tagged = turnId ? { ...event, turnId } : event;
     this.traceOpenCode("provider.opencode.event_emit", {
       turnId: getAgentStreamEventTurnId(tagged),
@@ -4289,6 +4748,10 @@ class OpenCodeAgentSession implements AgentSession {
     for (const translatedEvent of translated) {
       this.recordProviderInternalEvent(translatedEvent);
       if (translatedEvent.type === "permission_requested") {
+        if (this.seenPermissionRequestIds.has(translatedEvent.request.id)) {
+          continue;
+        }
+        this.seenPermissionRequestIds.add(translatedEvent.request.id);
         const directory =
           (eventSessionId ? this.childSessionCwds.get(eventSessionId) : undefined) ??
           this.config.cwd;

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -107,6 +107,42 @@ const OPENCODE_PERSISTED_SESSION_LIMIT = 200;
 const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
 const OPENCODE_EVENT_STREAM_RECONNECT_DELAY_MS = 100;
 const OPENCODE_EVENT_STREAM_RECONNECT_MAX_DELAY_MS = 5000;
+
+function foregroundStructuredTextKey(messageId: string): string {
+  return `structured:${messageId}`;
+}
+
+function toOpenCodeTraceError(
+  error: unknown,
+): { name: string; message: string } | string | undefined {
+  if (error === undefined) {
+    return undefined;
+  }
+  return error instanceof Error ? { name: error.name, message: error.message } : String(error);
+}
+
+function sleepUnlessAborted(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+  let timer: NodeJS.Timeout | undefined;
+  let onAbort: (() => void) | undefined;
+  return Promise.race([
+    new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, delayMs);
+    }),
+    new Promise<void>((resolve) => {
+      const listener = () => resolve();
+      onAbort = listener;
+      signal.addEventListener("abort", listener, { once: true });
+    }),
+  ]).finally(() => {
+    clearTimeout(timer);
+    if (onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  });
+}
 const OPENCODE_CHILD_SESSION_HYDRATION_LIMIT = 100;
 const OPENCODE_CHILD_SESSION_SERVER_REGISTRY_LIMIT = 500;
 const OPENCODE_PERMISSION_ACTION_ALLOW_ONCE = "allow_once";
@@ -1756,6 +1792,7 @@ type OpenCodeTraceMessage =
   | "provider.opencode.subscribe.ready"
   | "provider.opencode.stream.eof"
   | "provider.opencode.turn.fail_eof"
+  | "provider.opencode.turn.reconcile_unresolved"
   | "provider.opencode.subscribe.error"
   | "provider.opencode.raw_event"
   | "provider.opencode.event.skip"
@@ -2946,12 +2983,16 @@ class OpenCodeAgentSession implements AgentSession {
   private foregroundTurnStartedAt: number | null = null;
   private foregroundKnownMessageIds: ReadonlySet<string> | null = null;
   private foregroundAssistantMessageIds = new Set<string>();
-  private foregroundAssistantText = "";
+  private foregroundStreamedTextByPartId = new Map<string, string>();
+  private foregroundEmittedTextByPartId = new Map<string, string>();
   private foregroundEmittedReasoningByPartId = new Map<string, string>();
   private foregroundEmittedToolCallSignatureByCallId = new Map<string, string>();
   private foregroundNativeRequestDispatched = false;
   private foregroundNativeActivityObserved = false;
   private foregroundSessionTotalCostUsdAtStart: number | undefined;
+  // Session-lifetime by design: stream recovery re-lists pending requests
+  // across turn boundaries, so a per-turn reset would re-emit a request first
+  // surfaced in an earlier turn. Growth is one short id per request.
   private seenPermissionRequestIds = new Set<string>();
   private closed = false;
   private readonly persistSession: boolean;
@@ -3147,8 +3188,7 @@ class OpenCodeAgentSession implements AgentSession {
     }
 
     const foregroundTurnStartedAt = Date.now();
-    const foregroundKnownMessageIds = await this.readForegroundSessionMessageIds();
-    this.resetForegroundRecoveryState(foregroundTurnStartedAt, foregroundKnownMessageIds);
+    this.resetForegroundRecoveryState(foregroundTurnStartedAt, null);
 
     this.runningToolCalls.clear();
     this.subAgentsByCallId.clear();
@@ -3180,6 +3220,15 @@ class OpenCodeAgentSession implements AgentSession {
     const turnId = this.createTurnId();
     this.turnState = { status: "running", turnId };
     this.notifySubscribers({ type: "turn_started", provider: "opencode" }, turnId);
+
+    // Snapshot the pre-turn message ids after the turn is already active —
+    // delaying activation here would drop terminal events consumed meanwhile —
+    // but strictly before dispatch, so this turn's own messages never count as
+    // previously known.
+    const foregroundKnownMessageIds = await this.readForegroundSessionMessageIds();
+    if (this.activeForegroundTurnId === turnId) {
+      this.foregroundKnownMessageIds = foregroundKnownMessageIds;
+    }
 
     const slashCommand = await this.resolveSlashCommandInvocation(prompt);
     if (slashCommand) {
@@ -3546,7 +3595,21 @@ class OpenCodeAgentSession implements AgentSession {
 
         const activeTurnId = this.activeForegroundTurnId;
         if (isReplacementStream && activeTurnId) {
-          await this.reconcileForegroundTurnAfterStreamEnd(activeTurnId);
+          const recovery = await this.reconcileForegroundTurnAfterStreamEnd(
+            activeTurnId,
+            eventStreamAbortController.signal,
+          );
+          if (recovery === "unresolved") {
+            // Not fatal here — live events on the new stream may still resolve
+            // the turn — but the ambiguity must leave a forensic trail.
+            this.traceOpenCode("provider.opencode.turn.reconcile_unresolved", {
+              turnId: activeTurnId,
+            });
+            this.logger.warn(
+              { sessionId: this.sessionId, turnId: activeTurnId },
+              "OpenCode turn state was unresolved after reconnecting the event stream; waiting for live events",
+            );
+          }
         }
 
         for await (const rawEvent of result.stream) {
@@ -3557,12 +3620,16 @@ class OpenCodeAgentSession implements AgentSession {
         streamError = error;
         this.traceOpenCode("provider.opencode.subscribe.error", {
           turnId: this.activeForegroundTurnId ?? undefined,
-          error:
-            error instanceof Error ? { name: error.name, message: error.message } : String(error),
+          error: toOpenCodeTraceError(error),
         });
       }
 
       if (eventStreamAbortController.signal.aborted) {
+        if (!eventStreamReadyResolved) {
+          eventStreamReady.reject(
+            streamError ?? new Error("OpenCode event stream closed before it became ready"),
+          );
+        }
         return;
       }
       if (!eventStreamReadyResolved) {
@@ -3575,7 +3642,7 @@ class OpenCodeAgentSession implements AgentSession {
       this.traceOpenCode("provider.opencode.stream.eof", {
         eventCount,
         activeTurnId: this.activeForegroundTurnId,
-        streamError,
+        streamError: toOpenCodeTraceError(streamError),
       });
       consecutiveZeroEventCycles = eventCount === 0 ? consecutiveZeroEventCycles + 1 : 0;
       const activeTurnId = this.activeForegroundTurnId;
@@ -3583,7 +3650,10 @@ class OpenCodeAgentSession implements AgentSession {
         return;
       }
 
-      const recovery = await this.reconcileForegroundTurnAfterStreamEnd(activeTurnId);
+      const recovery = await this.reconcileForegroundTurnAfterStreamEnd(
+        activeTurnId,
+        eventStreamAbortController.signal,
+      );
       if (recovery === "handled") {
         return;
       }
@@ -3592,14 +3662,14 @@ class OpenCodeAgentSession implements AgentSession {
           OPENCODE_EVENT_STREAM_RECONNECT_DELAY_MS * 2 ** consecutiveZeroEventCycles,
           OPENCODE_EVENT_STREAM_RECONNECT_MAX_DELAY_MS,
         );
-        await new Promise<void>((resolve) => setTimeout(resolve, reconnectDelayMs));
+        await sleepUnlessAborted(reconnectDelayMs, eventStreamAbortController.signal);
         continue;
       }
 
       this.traceOpenCode("provider.opencode.turn.fail_eof", {
         turnId: activeTurnId,
         eventCount,
-        streamError,
+        streamError: toOpenCodeTraceError(streamError),
       });
       this.finishForegroundTurn(
         {
@@ -3617,12 +3687,13 @@ class OpenCodeAgentSession implements AgentSession {
 
   private async reconcileForegroundTurnAfterStreamEnd(
     turnId: string,
+    signal: AbortSignal,
   ): Promise<"handled" | "reconnect" | "unresolved"> {
     const [status, messages] = await Promise.all([
-      this.readForegroundSessionStatus(),
-      this.readForegroundSessionMessages(),
+      this.readForegroundSessionStatus(signal),
+      this.readForegroundSessionMessages(signal),
     ]);
-    if (this.activeForegroundTurnId !== turnId) {
+    if (signal.aborted || this.activeForegroundTurnId !== turnId) {
       return "handled";
     }
 
@@ -3633,8 +3704,8 @@ class OpenCodeAgentSession implements AgentSession {
     const nativeTurnIsActive = status === "busy" || status === "retry";
     this.observeForegroundNativeActivity(nativeTurnIsActive, messages);
 
-    const hasPendingRequest = await this.recoverForegroundPendingRequests(turnId);
-    if (this.activeForegroundTurnId !== turnId) {
+    const hasPendingRequest = await this.recoverForegroundPendingRequests(turnId, signal);
+    if (signal.aborted || this.activeForegroundTurnId !== turnId) {
       return "handled";
     }
     if (hasPendingRequest) {
@@ -3642,24 +3713,11 @@ class OpenCodeAgentSession implements AgentSession {
       return "reconnect";
     }
 
-    const assistantMessage = messages ? this.findForegroundAssistantMessage(messages) : null;
-    if (assistantMessage) {
-      this.foregroundNativeActivityObserved = true;
-      this.foregroundAssistantMessageIds.add(assistantMessage.info.id);
-      if (assistantMessage.info.error) {
-        this.finishForegroundTurn(
-          {
-            type: "turn_failed",
-            provider: "opencode",
-            error: toDiagnosticErrorMessage(assistantMessage.info.error),
-          },
-          turnId,
-        );
-        return "handled";
-      }
-      if (!this.emitRecoveredAssistantParts(assistantMessage, turnId)) {
-        return "unresolved";
-      }
+    const assistantMessages = messages ? this.findForegroundAssistantMessages(messages) : [];
+    const assistantMessage = assistantMessages.at(-1) ?? null;
+    const assistantRecovery = this.recoverForegroundAssistantMessages(assistantMessages, turnId);
+    if (assistantRecovery) {
+      return assistantRecovery;
     }
 
     if (nativeTurnIsActive) {
@@ -3693,7 +3751,40 @@ class OpenCodeAgentSession implements AgentSession {
       },
       turnId,
     );
+    const contextWindowMaxTokens = this.resolveSelectedModelContextWindowMaxTokens();
+    this.accumulatedUsage = contextWindowMaxTokens !== undefined ? { contextWindowMaxTokens } : {};
     return "handled";
+  }
+
+  private recoverForegroundAssistantMessages(
+    assistantMessages: readonly OpenCodeAssistantSessionMessage[],
+    turnId: string,
+  ): "handled" | "unresolved" | null {
+    const assistantMessage = assistantMessages.at(-1) ?? null;
+    if (!assistantMessage) {
+      return null;
+    }
+    this.foregroundNativeActivityObserved = true;
+    for (const message of assistantMessages) {
+      this.foregroundAssistantMessageIds.add(message.info.id);
+    }
+    if (assistantMessage.info.error) {
+      this.finishForegroundTurn(
+        {
+          type: "turn_failed",
+          provider: "opencode",
+          error: toDiagnosticErrorMessage(assistantMessage.info.error),
+        },
+        turnId,
+      );
+      return "handled";
+    }
+    for (const message of assistantMessages) {
+      if (!this.emitRecoveredAssistantParts(message, turnId)) {
+        return "unresolved";
+      }
+    }
+    return null;
   }
 
   private observeForegroundNativeActivity(
@@ -3708,9 +3799,14 @@ class OpenCodeAgentSession implements AgentSession {
     }
   }
 
-  private async readForegroundSessionStatus(): Promise<"busy" | "retry" | "idle" | null> {
+  private async readForegroundSessionStatus(
+    signal?: AbortSignal,
+  ): Promise<"busy" | "retry" | "idle" | null> {
     try {
-      const response = await this.client.session.status({ directory: this.config.cwd });
+      const response = await this.client.session.status(
+        { directory: this.config.cwd },
+        signal ? { signal } : undefined,
+      );
       if (response.error || !response.data) {
         return null;
       }
@@ -3730,12 +3826,17 @@ class OpenCodeAgentSession implements AgentSession {
     }
   }
 
-  private async readForegroundSessionMessages(): Promise<OpenCodeSessionMessage[] | null> {
+  private async readForegroundSessionMessages(
+    signal?: AbortSignal,
+  ): Promise<OpenCodeSessionMessage[] | null> {
     try {
-      const response = await this.client.session.messages({
-        sessionID: this.sessionId,
-        directory: this.config.cwd,
-      });
+      const response = await this.client.session.messages(
+        {
+          sessionID: this.sessionId,
+          directory: this.config.cwd,
+        },
+        signal ? { signal } : undefined,
+      );
       return response.error || !response.data ? null : response.data;
     } catch (error) {
       this.logger.debug(
@@ -3746,10 +3847,16 @@ class OpenCodeAgentSession implements AgentSession {
     }
   }
 
-  private async readForegroundPendingRequestEvents(): Promise<OpenCodePendingRequestEvent[]> {
+  private async readForegroundPendingRequestEvents(
+    signal?: AbortSignal,
+  ): Promise<OpenCodePendingRequestEvent[]> {
+    const requestOptions = signal ? { signal } : undefined;
     const readQuestions = async (): Promise<OpenCodeQuestionAskedEvent[]> => {
       try {
-        const response = await this.client.question.list({ directory: this.config.cwd });
+        const response = await this.client.question.list(
+          { directory: this.config.cwd },
+          requestOptions,
+        );
         if (response.error || !response.data) {
           return [];
         }
@@ -3770,7 +3877,10 @@ class OpenCodeAgentSession implements AgentSession {
     };
     const readPermissions = async (): Promise<OpenCodePermissionAskedEvent[]> => {
       try {
-        const response = await this.client.permission.list({ directory: this.config.cwd });
+        const response = await this.client.permission.list(
+          { directory: this.config.cwd },
+          requestOptions,
+        );
         if (response.error || !response.data) {
           return [];
         }
@@ -3797,8 +3907,11 @@ class OpenCodeAgentSession implements AgentSession {
     return [...questionEvents, ...permissionEvents];
   }
 
-  private async recoverForegroundPendingRequests(turnId: string): Promise<boolean> {
-    const requestEvents = await this.readForegroundPendingRequestEvents();
+  private async recoverForegroundPendingRequests(
+    turnId: string,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    const requestEvents = await this.readForegroundPendingRequestEvents(signal);
     let hasPendingRequest = false;
     for (const event of requestEvents) {
       const translated = await this.translateEvent(event);
@@ -3819,12 +3932,18 @@ class OpenCodeAgentSession implements AgentSession {
     return messages ? new Set(messages.map((message) => message.info.id)) : null;
   }
 
-  private findForegroundAssistantMessage(
+  private findForegroundAssistantMessages(
     messages: readonly OpenCodeSessionMessage[],
-  ): OpenCodeAssistantSessionMessage | null {
-    for (let index = messages.length - 1; index >= 0; index -= 1) {
-      const message = messages[index];
-      if (!message || !isOpenCodeAssistantSessionMessage(message)) {
+  ): OpenCodeAssistantSessionMessage[] {
+    // A turn can span multiple assistant messages (e.g. around tool calls);
+    // recovery must bridge every one of them, oldest first. Compaction
+    // summaries are skipped so completion checks read the last real message.
+    const found: OpenCodeAssistantSessionMessage[] = [];
+    for (const message of messages) {
+      if (!isOpenCodeAssistantSessionMessage(message)) {
+        continue;
+      }
+      if (isOpenCodeCompactionSummaryMessage(message.info)) {
         continue;
       }
       if (this.foregroundKnownMessageIds?.has(message.info.id)) {
@@ -3840,9 +3959,9 @@ class OpenCodeAgentSession implements AgentSession {
           continue;
         }
       }
-      return message;
+      found.push(message);
     }
-    return null;
+    return found;
   }
 
   private emitRecoveredAssistantParts(
@@ -3885,33 +4004,56 @@ class OpenCodeAgentSession implements AgentSession {
       if (!parsedToolPart.success || !parsedToolPart.data) {
         continue;
       }
-      const signature = JSON.stringify(parsedToolPart.data);
-      if (
-        this.foregroundEmittedToolCallSignatureByCallId.get(parsedToolPart.data.callId) ===
-        signature
-      ) {
+      // Route through the same subagent registration the live path uses so
+      // recovered task calls carry childSessionId and signatures compare
+      // like-for-like with live emissions.
+      const timelineItem = registerOpenCodeSubAgentToolCall(
+        parsedToolPart.data,
+        this.createTranslationState(),
+      );
+      const signature = JSON.stringify(timelineItem);
+      if (this.foregroundEmittedToolCallSignatureByCallId.get(timelineItem.callId) === signature) {
         continue;
       }
-      this.foregroundEmittedToolCallSignatureByCallId.set(parsedToolPart.data.callId, signature);
-      this.trackToolCall(parsedToolPart.data);
+      this.foregroundEmittedToolCallSignatureByCallId.set(timelineItem.callId, signature);
+      this.trackToolCall(timelineItem);
       this.notifySubscribers(
-        { type: "timeline", provider: "opencode", item: parsedToolPart.data },
+        { type: "timeline", provider: "opencode", item: timelineItem },
         turnId,
       );
     }
 
-    let completedText = message.parts
-      .filter((part): part is Extract<OpenCodePart, { type: "text" }> => part.type === "text")
-      .map((part) => part.text ?? "")
-      .join("");
-    if (!completedText) {
-      completedText = stringifyStructuredAssistantMessage(message.info.structured) ?? "";
+    const textParts = message.parts.filter(
+      (part): part is Extract<OpenCodePart, { type: "text" }> => part.type === "text",
+    );
+    if (textParts.length > 0) {
+      for (const part of textParts) {
+        if (!this.emitRecoveredAssistantText(part.id, part.text ?? "", turnId)) {
+          return false;
+        }
+      }
+      return true;
     }
-    if (!completedText.startsWith(this.foregroundAssistantText)) {
+    const structuredText = stringifyStructuredAssistantMessage(message.info.structured) ?? "";
+    return this.emitRecoveredAssistantText(
+      foregroundStructuredTextKey(message.info.id),
+      structuredText,
+      turnId,
+    );
+  }
+
+  private emitRecoveredAssistantText(
+    partKey: string,
+    completedText: string,
+    turnId: string,
+  ): boolean {
+    const emittedText = this.foregroundEmittedTextByPartId.get(partKey) ?? "";
+    if (!completedText.startsWith(emittedText)) {
       return false;
     }
-    const missingText = completedText.slice(this.foregroundAssistantText.length);
+    const missingText = completedText.slice(emittedText.length);
     if (missingText) {
+      this.foregroundEmittedTextByPartId.set(partKey, completedText);
       this.notifySubscribers(
         {
           type: "timeline",
@@ -3958,7 +4100,8 @@ class OpenCodeAgentSession implements AgentSession {
     this.foregroundTurnStartedAt = startedAt;
     this.foregroundKnownMessageIds = knownMessageIds;
     this.foregroundAssistantMessageIds.clear();
-    this.foregroundAssistantText = "";
+    this.foregroundStreamedTextByPartId.clear();
+    this.foregroundEmittedTextByPartId.clear();
     this.foregroundEmittedReasoningByPartId.clear();
     this.foregroundEmittedToolCallSignatureByCallId.clear();
     this.foregroundNativeRequestDispatched = false;
@@ -4046,9 +4189,73 @@ class OpenCodeAgentSession implements AgentSession {
         this.finishForegroundTurn(terminalEvent, turnId);
         return;
       }
-      this.notifySubscribers(e, turnId);
-      this.recordForegroundReasoningEmission(event, e);
+      this.emitForegroundStreamEvent(event, e, turnId);
     }
+  }
+
+  private emitForegroundStreamEvent(
+    event: OpenCodeEvent,
+    emittedEvent: AgentStreamEvent,
+    turnId: string,
+  ): void {
+    const adjusted = this.applyForegroundAssistantTextDedup(event, emittedEvent);
+    if (!adjusted) {
+      return;
+    }
+    this.notifySubscribers(adjusted, turnId);
+    this.recordForegroundReasoningEmission(event, adjusted);
+  }
+
+  // After a reconnect, events published between the SSE connect and the REST
+  // messages read sit buffered on the new stream and replay text the recovery
+  // path already emitted. Track streamed vs emitted text per part and forward
+  // only the portion not yet delivered.
+  private applyForegroundAssistantTextDedup(
+    event: OpenCodeEvent,
+    emittedEvent: AgentStreamEvent,
+  ): AgentStreamEvent | null {
+    if (emittedEvent.type !== "timeline" || emittedEvent.item.type !== "assistant_message") {
+      return emittedEvent;
+    }
+    const partKey = this.resolveForegroundTextPartKey(event);
+    if (!partKey) {
+      return emittedEvent;
+    }
+    const streamedText =
+      (this.foregroundStreamedTextByPartId.get(partKey) ?? "") + emittedEvent.item.text;
+    this.foregroundStreamedTextByPartId.set(partKey, streamedText);
+    const emittedText = this.foregroundEmittedTextByPartId.get(partKey) ?? "";
+    if (streamedText.startsWith(emittedText)) {
+      const missingText = streamedText.slice(emittedText.length);
+      if (!missingText) {
+        return null;
+      }
+      this.foregroundEmittedTextByPartId.set(partKey, streamedText);
+      return missingText === emittedEvent.item.text
+        ? emittedEvent
+        : { ...emittedEvent, item: { ...emittedEvent.item, text: missingText } };
+    }
+    if (emittedText.startsWith(streamedText)) {
+      // Replaying a prefix of text the recovery path already delivered.
+      return null;
+    }
+    // Divergent stream (e.g. the part was rewritten); fail open to the live
+    // delta and realign the emitted record with the stream.
+    this.foregroundEmittedTextByPartId.set(partKey, streamedText);
+    return emittedEvent;
+  }
+
+  private resolveForegroundTextPartKey(event: OpenCodeEvent): string | null {
+    const properties = readOpenCodeRecord(event.properties);
+    const part = readOpenCodeRecord(properties?.part);
+    const partId = readNonEmptyString(properties?.partID) ?? readNonEmptyString(part?.id);
+    if (partId) {
+      return partId;
+    }
+    const messageId =
+      readNonEmptyString(properties?.messageID) ??
+      readNonEmptyString(readOpenCodeRecord(properties?.info)?.id);
+    return messageId ? foregroundStructuredTextKey(messageId) : null;
   }
 
   private recordForegroundOpenCodeEvent(event: OpenCodeEvent): void {
@@ -4239,9 +4446,6 @@ class OpenCodeAgentSession implements AgentSession {
     }
     const turnId = turnIdOverride === null ? null : (turnIdOverride ?? this.activeForegroundTurnId);
     if (turnId && turnId === this.activeForegroundTurnId) {
-      if (event.type === "timeline" && event.item.type === "assistant_message") {
-        this.foregroundAssistantText += event.item.text;
-      }
       if (event.type === "timeline" && event.item.type === "tool_call") {
         this.foregroundEmittedToolCallSignatureByCallId.set(
           event.item.callId,

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -106,6 +106,7 @@ const OPENCODE_AUTO_ACCEPT_FEATURE_ID = "auto_accept";
 const OPENCODE_PERSISTED_SESSION_LIMIT = 200;
 const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
 const OPENCODE_EVENT_STREAM_RECONNECT_DELAY_MS = 100;
+const OPENCODE_EVENT_STREAM_RECONNECT_MAX_DELAY_MS = 5000;
 const OPENCODE_CHILD_SESSION_HYDRATION_LIMIT = 100;
 const OPENCODE_CHILD_SESSION_SERVER_REGISTRY_LIMIT = 500;
 const OPENCODE_PERMISSION_ACTION_ALLOW_ONCE = "allow_once";
@@ -3522,6 +3523,10 @@ class OpenCodeAgentSession implements AgentSession {
       cwd: this.config.cwd,
     });
     let eventStreamReadyResolved = false;
+    // Cycles that end without delivering a single event indicate the server is
+    // refusing or instantly dropping connections; back off exponentially so a
+    // dead server cannot turn the reconnect loop into a tight spin.
+    let consecutiveZeroEventCycles = 0;
     while (!eventStreamAbortController.signal.aborted) {
       let eventCount = 0;
       let streamError: unknown;
@@ -3572,6 +3577,7 @@ class OpenCodeAgentSession implements AgentSession {
         activeTurnId: this.activeForegroundTurnId,
         streamError,
       });
+      consecutiveZeroEventCycles = eventCount === 0 ? consecutiveZeroEventCycles + 1 : 0;
       const activeTurnId = this.activeForegroundTurnId;
       if (!activeTurnId) {
         return;
@@ -3582,9 +3588,11 @@ class OpenCodeAgentSession implements AgentSession {
         return;
       }
       if (recovery === "reconnect") {
-        await new Promise<void>((resolve) =>
-          setTimeout(resolve, OPENCODE_EVENT_STREAM_RECONNECT_DELAY_MS),
+        const reconnectDelayMs = Math.min(
+          OPENCODE_EVENT_STREAM_RECONNECT_DELAY_MS * 2 ** consecutiveZeroEventCycles,
+          OPENCODE_EVENT_STREAM_RECONNECT_MAX_DELAY_MS,
         );
+        await new Promise<void>((resolve) => setTimeout(resolve, reconnectDelayMs));
         continue;
       }
 


### PR DESCRIPTION
### Linked issue

Closes #2271

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Since #916, the OpenCode adapter fails the active foreground turn the moment the global event stream (`client.global.event`, `sseMaxRetryAttempts: 0`) ends or errors — one dropped SSE connection kills an otherwise healthy turn, even though the OpenCode session keeps running and usually completes. Details and evidence in #2271.

This PR makes stream EOF recoverable instead of fatal:

- On EOF with an active turn, reconcile against `session.status`, `session.messages`, and pending question/permission requests before deciding anything.
- If OpenCode is still busy (or has pending permission/question requests), reconnect the stream and keep going. Reconnects back off exponentially (100 ms → 5 s cap) when consecutive connects yield zero events, so a dead server can't turn the loop into a tight spin.
- Assistant parts that streamed while disconnected are bridged exactly once from the messages API (text suffix, reasoning suffix, tool-call state), deduplicated against what was already emitted.
- If the session completed while disconnected, the turn is recovered as completed, including usage/cost accounting.
- If state is genuinely unresolvable (e.g. server gone and no completed assistant message), the turn still fails with the original error — no silent hangs.

The stream remains the source of truth. The messages API is consulted once per disconnect to bridge the gap — this is not a return to the pre-#916 polling path.

### How did you verify it

**Reproducing the bug:** on my daemon (Paseo 0.1.110, OpenCode 1.18.3, macOS arm64), host load reliably triggers it: 9 concurrent OpenCode agents on one `opencode serve` produced 9 turn failures in ~5 minutes, all `provider.opencode.stream.eof` traces, while `session.status` still reported the sessions busy (log excerpts in #2271).

**Unit tests:**

```
npx vitest run packages/server/src/server/agent/providers/opencode-agent.test.ts --bail=1
# Test Files  1 passed (1)
# Tests  76 passed (76)
```

New coverage includes: reconnect while busy (stream EOF mid-turn → turn completes with full text), recovery of the missing assistant suffix when EOF finds the session idle, pending-permission recovery across EOF, failure when reconciliation is impossible, usage recovery, and reconnecting through consecutive failed connects (backoff path).

**Production soak:** this change (cherry-picked onto `v0.1.110`) has been running my real daemon workload — ~19 OpenCode agents, same load pattern that triggered the failures — since 2026-07-20. No EOF turn failures since deployment.

Also ran: server-package `npm run typecheck` (clean), `npm run lint` on changed files (clean), `npm run format:check` (clean). I did not run the `*.real.e2e` suites (they need live model access).

**Disclosure:** this patch was developed with AI assistance (Claude Code), then verified as described above — the test suite, the load repro, and the production deployment are real runs on my machine, not generated claims.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform (n/a — daemon only)
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)
