### PR TITLE
fix(omp): complete delayed model turns after local-only results

### DIFF
--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -1,7 +1,8 @@
+import { setImmediate as waitForImmediate } from "node:timers/promises";
 import { describe, expect, test } from "vitest";
 
 import type { PaseoToolCatalog } from "../../tools/types.js";
-import type { OmpProviderIdleScheduler } from "./agent.js";
+import type { OmpNoTurnScheduler, OmpProviderIdleScheduler } from "./agent.js";
 import { OmpHarness } from "./test-utils/omp-harness.js";
 
 class ManualIdleScheduler implements OmpProviderIdleScheduler {
@@ -27,6 +28,41 @@ class ManualIdleScheduler implements OmpProviderIdleScheduler {
     const resolve = this.retries.shift();
     if (!resolve) throw new Error("OMP has not requested an idle-state retry");
     resolve();
+  }
+}
+
+class ManualNoTurnScheduler implements OmpNoTurnScheduler {
+  private settleResolve: (() => void) | null = null;
+  private aborted = false;
+
+  waitForSettle(signal: AbortSignal): Promise<void> {
+    if (signal.aborted) {
+      this.aborted = true;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.settleResolve = resolve;
+      signal.addEventListener(
+        "abort",
+        () => {
+          this.aborted = true;
+          this.settleResolve = null;
+          resolve();
+        },
+        { once: true },
+      );
+    });
+  }
+
+  settle(): void {
+    const resolve = this.settleResolve;
+    if (!resolve) throw new Error("OMP has not requested a no-turn settle wait");
+    this.settleResolve = null;
+    resolve();
+  }
+
+  wasAborted(): boolean {
+    return this.aborted;
   }
 }
 
@@ -233,6 +269,104 @@ describe("OMP agent client and session", () => {
       omp.runPromptAfterFalseLocalOnlyHint("hello OMP", "queued model turn completed"),
     ).resolves.toMatchObject({ finalText: "queued model turn completed" });
     expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("completes a local-only prompt when no OMP turn begins", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    await expect(omp.runPromptWithoutTurn("/model")).resolves.toMatchObject({ finalText: "" });
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("waits for a delayed queued model turn after OMP's local-only result", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    const completion = await omp.runPromptAfterDelayedFalseLocalOnlyResult(
+      "hello OMP",
+      "delayed queued model turn completed",
+    );
+
+    expect(completion.completedBeforeTurn).toBe(false);
+    expect(completion.result).toMatchObject({ finalText: "delayed queued model turn completed" });
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("completes an async local-only result after the settle window", async () => {
+    const scheduler = new ManualNoTurnScheduler();
+    const omp = new OmpHarness({ noTurnScheduler: scheduler });
+    await omp.start();
+    const { completion } = await omp.startPromptWithFalseLocalOnlyResult("local-only");
+    let completed = false;
+    void completion.then(
+      () => {
+        completed = true;
+        return undefined;
+      },
+      () => {
+        completed = true;
+        return undefined;
+      },
+    );
+
+    expect(completed).toBe(false);
+    scheduler.settle();
+    await expect(completion).resolves.toMatchObject({ finalText: "" });
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("cancels an async local-only settle when the OMP session closes", async () => {
+    const scheduler = new ManualNoTurnScheduler();
+    const omp = new OmpHarness({ noTurnScheduler: scheduler });
+    await omp.start();
+    const { completion } = await omp.startPromptWithFalseLocalOnlyResult("local-only");
+    let completed = false;
+    void completion.then(
+      () => {
+        completed = true;
+        return undefined;
+      },
+      () => {
+        completed = true;
+        return undefined;
+      },
+    );
+
+    await omp.close();
+    await waitForImmediate();
+
+    expect(scheduler.wasAborted()).toBe(true);
+    expect(completed).toBe(false);
+    expect(omp.completedTurnCount()).toBe(0);
+  });
+
+  test("preserves a correlated invoked result over a local-only prompt ack", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    const completion = await omp.runPromptAfterCorrelatedTrueResult(
+      "hello OMP",
+      "correlated model turn completed",
+    );
+
+    expect(completion.completedBeforeTurn).toBe(false);
+    expect(completion.result).toMatchObject({ finalText: "correlated model turn completed" });
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("completes an autonomous OMP turn without a foreground turn ID", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    await omp.runAutonomousTurn("autonomous turn completed");
+
+    expect(omp.completedTurnCount()).toBe(1);
+    expect(omp.timeline()).toContainEqual({
+      type: "assistant_message",
+      text: "autonomous turn completed",
+      messageId: "omp-assistant-1",
+    });
   });
 
   test("resumes an OMP session and replays its history", async () => {

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -1,4 +1,3 @@
-import { setImmediate as waitForImmediate } from "node:timers/promises";
 import { describe, expect, test } from "vitest";
 
 import type { PaseoToolCatalog } from "../../tools/types.js";
@@ -297,22 +296,11 @@ describe("OMP agent client and session", () => {
     const scheduler = new ManualNoTurnScheduler();
     const omp = new OmpHarness({ noTurnScheduler: scheduler });
     await omp.start();
-    const { completion } = await omp.startPromptWithFalseLocalOnlyResult("local-only");
-    let completed = false;
-    void completion.then(
-      () => {
-        completed = true;
-        return undefined;
-      },
-      () => {
-        completed = true;
-        return undefined;
-      },
-    );
+    const prompt = await omp.startPromptWithFalseLocalOnlyResult("local-only");
 
-    expect(completed).toBe(false);
+    expect(prompt.completed()).toBe(false);
     scheduler.settle();
-    await expect(completion).resolves.toMatchObject({ finalText: "" });
+    await expect(prompt.completion).resolves.toMatchObject({ finalText: "" });
     expect(omp.completedTurnCount()).toBe(1);
   });
 
@@ -320,24 +308,12 @@ describe("OMP agent client and session", () => {
     const scheduler = new ManualNoTurnScheduler();
     const omp = new OmpHarness({ noTurnScheduler: scheduler });
     await omp.start();
-    const { completion } = await omp.startPromptWithFalseLocalOnlyResult("local-only");
-    let completed = false;
-    void completion.then(
-      () => {
-        completed = true;
-        return undefined;
-      },
-      () => {
-        completed = true;
-        return undefined;
-      },
-    );
+    const prompt = await omp.startPromptWithFalseLocalOnlyResult("local-only");
 
     await omp.close();
-    await waitForImmediate();
 
     expect(scheduler.wasAborted()).toBe(true);
-    expect(completed).toBe(false);
+    expect(prompt.completed()).toBe(false);
     expect(omp.completedTurnCount()).toBe(0);
   });
 

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
+import { setImmediate as waitForImmediate, setTimeout as delay } from "node:timers/promises";
 import type { Logger } from "pino";
 import stripAnsi from "strip-ansi";
 
@@ -148,11 +149,22 @@ export interface OmpAgentClientOptions {
   runtime?: OmpRuntime;
   subagentCardScheduler?: OmpSubagentCardScheduler;
   providerIdleScheduler?: OmpProviderIdleScheduler;
+  noTurnScheduler?: OmpNoTurnScheduler;
 }
 
 export interface OmpProviderIdleScheduler {
   waitForRetry(): Promise<void>;
 }
+
+export interface OmpNoTurnScheduler {
+  waitForSettle(signal: AbortSignal): Promise<void>;
+}
+
+// COMPAT(ompDelayedLocalOnlyResult): OMP 17.0.5 can report a regular prompt as
+// local-only shortly before an extension-queued model turn starts. Added in
+// v0.2.0-beta.1; remove after January 20, 2027 once the minimum OMP version
+// guarantees prompt_result waits for queued extension work.
+const OMP_NO_TURN_SETTLE_MS = 5_000;
 
 interface OmpPromptPayload {
   text: string;
@@ -184,6 +196,7 @@ interface OmpAgentSessionOptions {
   logger: Logger;
   subagentCardScheduler?: OmpSubagentCardScheduler;
   providerIdleScheduler?: OmpProviderIdleScheduler;
+  noTurnScheduler?: OmpNoTurnScheduler;
   paseoTools?: PaseoToolCatalog;
   /**
    * When false (resumed sessions), replayed session events are dropped until
@@ -197,6 +210,14 @@ function createOmpProviderIdleScheduler(): OmpProviderIdleScheduler {
   return {
     waitForRetry: async () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
+    },
+  };
+}
+
+function createOmpNoTurnScheduler(): OmpNoTurnScheduler {
+  return {
+    waitForSettle: async (signal) => {
+      await delay(OMP_NO_TURN_SETTLE_MS, undefined, { signal });
     },
   };
 }
@@ -905,7 +926,9 @@ export class OmpAgentSession implements AgentSession {
   private activeNoTurnPromptText: string | null = null;
   private readonly pendingNoTurnOutputs: Array<{ turnId: string; message: string }> = [];
   private activePromptRequestId: string | null = null;
+  private activePromptAgentInvoked: boolean | null = null;
   private readonly pendingPromptResults = new Map<string, boolean>();
+  private pendingNoTurnCompletionAbort: AbortController | null = null;
   private lastKnownThinkingOptionId: string | null;
   private outOfBandCompactionEmit: ((event: AgentStreamEvent) => void) | null = null;
   private outOfBandCompactionStarted = false;
@@ -917,6 +940,7 @@ export class OmpAgentSession implements AgentSession {
   private state: OmpSessionState;
   private readonly currentModeId: string | null;
   private readonly providerIdleScheduler: OmpProviderIdleScheduler;
+  private readonly noTurnScheduler: OmpNoTurnScheduler;
   private closed = false;
   private live: boolean;
   private readonly emittedUserMessageIds = new Set<string>();
@@ -930,6 +954,7 @@ export class OmpAgentSession implements AgentSession {
     this.paseoTools = options.paseoTools;
     this.live = options.live ?? true;
     this.providerIdleScheduler = options.providerIdleScheduler ?? createOmpProviderIdleScheduler();
+    this.noTurnScheduler = options.noTurnScheduler ?? createOmpNoTurnScheduler();
     this.subagentCardTracker = new OmpSubagentCardTracker({
       scheduler: options.subagentCardScheduler,
     });
@@ -1005,8 +1030,12 @@ export class OmpAgentSession implements AgentSession {
         if (ack.requestId) {
           this.pendingPromptResults.delete(ack.requestId);
         }
-        const agentInvoked = correlatedResult ?? ack.agentInvoked;
-        if (agentInvoked === false) {
+        this.activePromptAgentInvoked = correlatedResult ?? ack.agentInvoked ?? null;
+        if (correlatedResult === false) {
+          this.scheduleNoTurnPromptCompletion(turnId);
+          return;
+        }
+        if (correlatedResult !== true && ack.agentInvoked === false) {
           await this.completeNoTurnPrompt(turnId);
           return;
         }
@@ -1183,6 +1212,7 @@ export class OmpAgentSession implements AgentSession {
       return;
     }
     this.closed = true;
+    this.cancelNoTurnPromptCompletion();
     try {
       await this.runtimeSession.close();
     } finally {
@@ -1309,11 +1339,40 @@ export class OmpAgentSession implements AgentSession {
     return this.activeTurnId ?? undefined;
   }
 
+  private scheduleNoTurnPromptCompletion(turnId: string): void {
+    this.cancelNoTurnPromptCompletion();
+    const abort = new AbortController();
+    this.pendingNoTurnCompletionAbort = abort;
+    void this.noTurnScheduler
+      .waitForSettle(abort.signal)
+      .then(async () => {
+        if (this.pendingNoTurnCompletionAbort !== abort) {
+          return undefined;
+        }
+        this.pendingNoTurnCompletionAbort = null;
+        return await this.completeNoTurnPrompt(turnId);
+      })
+      .catch((error: unknown) => {
+        if (!abort.signal.aborted) {
+          this.logger.debug({ err: error }, "OMP local-only settle wait failed");
+        }
+      });
+  }
+
+  private cancelNoTurnPromptCompletion(): void {
+    this.pendingNoTurnCompletionAbort?.abort();
+    this.pendingNoTurnCompletionAbort = null;
+  }
+
   private async completeNoTurnPrompt(turnId: string): Promise<void> {
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-    if (this.activeTurnId !== turnId || this.activeTurnStarted || this.activeTurnHasUserMessage) {
+    await waitForImmediate();
+    if (
+      this.closed ||
+      this.activeTurnId !== turnId ||
+      this.activeTurnStarted ||
+      this.activePromptAgentInvoked === true ||
+      this.activeTurnHasUserMessage
+    ) {
       return;
     }
     this.emitBufferedNoTurnOutputs(turnId);
@@ -1321,8 +1380,10 @@ export class OmpAgentSession implements AgentSession {
   }
 
   private clearNoTurnBuffers(): void {
+    this.cancelNoTurnPromptCompletion();
     this.activeNoTurnPromptText = null;
     this.activePromptRequestId = null;
+    this.activePromptAgentInvoked = null;
     this.pendingNoTurnOutputs.splice(0, this.pendingNoTurnOutputs.length);
   }
 
@@ -1736,12 +1797,13 @@ export class OmpAgentSession implements AgentSession {
           ? event.agentInvoked
           : undefined;
       if (requestId && agentInvoked !== undefined) {
-        if (
-          requestId === this.activePromptRequestId &&
-          agentInvoked === false &&
-          this.activeTurnId
-        ) {
-          void this.completeNoTurnPrompt(this.activeTurnId);
+        if (requestId === this.activePromptRequestId && this.activeTurnId) {
+          this.activePromptAgentInvoked = agentInvoked;
+          if (agentInvoked === false) {
+            this.scheduleNoTurnPromptCompletion(this.activeTurnId);
+          } else {
+            this.cancelNoTurnPromptCompletion();
+          }
         } else if (this.activePromptRequestId === null) {
           this.pendingPromptResults.set(requestId, agentInvoked);
         }
@@ -2139,7 +2201,7 @@ export class OmpAgentSession implements AgentSession {
     turnId: string | undefined,
     messages: OmpAgentMessage[],
   ): Promise<void> {
-    while (!this.closed && this.activeTurnId === turnId) {
+    while (!this.closed && this.activeTurnStarted && this.currentTurnIdForEvent() === turnId) {
       try {
         const state = await this.runtimeSession.getState();
         this.state = state;
@@ -2188,6 +2250,7 @@ export class OmpAgentClient implements AgentClient {
   private readonly modelRoleParams: OmpModelRoleParams;
   private readonly subagentCardScheduler?: OmpSubagentCardScheduler;
   private readonly providerIdleScheduler?: OmpProviderIdleScheduler;
+  private readonly noTurnScheduler?: OmpNoTurnScheduler;
   private readonly runtime: OmpRuntime;
 
   constructor(options: OmpAgentClientOptions) {
@@ -2209,6 +2272,7 @@ export class OmpAgentClient implements AgentClient {
     this.modelRoleParams = modelRoleParams;
     this.subagentCardScheduler = options.subagentCardScheduler;
     this.providerIdleScheduler = options.providerIdleScheduler;
+    this.noTurnScheduler = options.noTurnScheduler;
     this.runtime = options.runtime ?? createRuntime(options.logger, runtimeSettings);
   }
 
@@ -2249,6 +2313,7 @@ export class OmpAgentClient implements AgentClient {
         logger: this.logger,
         subagentCardScheduler: this.subagentCardScheduler,
         providerIdleScheduler: this.providerIdleScheduler,
+        noTurnScheduler: this.noTurnScheduler,
         paseoTools: launchContext?.paseoTools,
       });
     } catch (error) {
@@ -2289,6 +2354,7 @@ export class OmpAgentClient implements AgentClient {
         logger: this.logger,
         subagentCardScheduler: this.subagentCardScheduler,
         providerIdleScheduler: this.providerIdleScheduler,
+        noTurnScheduler: this.noTurnScheduler,
         paseoTools: launchContext?.paseoTools,
         live: false,
       });

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setImmediate as waitForImmediate } from "node:timers/promises";
 import pino from "pino";
 
 import type {
@@ -11,7 +12,12 @@ import type {
   AgentTimelineItem,
 } from "../../../agent-sdk-types.js";
 import type { PaseoToolCatalog } from "../../../tools/types.js";
-import { OmpAgentClient, OmpAgentSession, type OmpProviderIdleScheduler } from "../agent.js";
+import {
+  OmpAgentClient,
+  OmpAgentSession,
+  type OmpNoTurnScheduler,
+  type OmpProviderIdleScheduler,
+} from "../agent.js";
 import type { OmpAgentMessage, OmpRpcSlashCommand } from "../rpc-types.js";
 import { FakeOmp } from "./fake-omp.js";
 
@@ -59,11 +65,17 @@ export class OmpHarness {
   private readonly events: AgentStreamEvent[] = [];
   private session: OmpAgentSession | null = null;
 
-  constructor(options: { providerIdleScheduler?: OmpProviderIdleScheduler } = {}) {
+  constructor(
+    options: {
+      providerIdleScheduler?: OmpProviderIdleScheduler;
+      noTurnScheduler?: OmpNoTurnScheduler;
+    } = {},
+  ) {
     this.client = new OmpAgentClient({
       logger: pino({ level: "silent" }),
       runtime: this.omp,
       providerIdleScheduler: options.providerIdleScheduler,
+      noTurnScheduler: options.noTurnScheduler,
     });
   }
 
@@ -249,6 +261,110 @@ export class OmpHarness {
     runtime.streamAssistantText(output);
     runtime.finishTurn();
     return await run;
+  }
+
+  async runPromptWithoutTurn(input: string): Promise<unknown> {
+    const session = this.requireSession();
+    this.omp.latestSession().promptAck = { agentInvoked: false };
+    return await session.run(input);
+  }
+
+  async startPromptWithFalseLocalOnlyResult(
+    input: string,
+  ): Promise<{ completion: Promise<unknown> }> {
+    const session = this.requireSession();
+    const runtime = this.omp.latestSession();
+    runtime.promptAck = { requestId: "prompt-local-only" };
+    const promptStarted = runtime.nextPrompt();
+    const completion = session.run(input);
+    await promptStarted;
+    await waitForImmediate();
+    runtime.emit({
+      type: "prompt_result",
+      id: "prompt-local-only",
+      agentInvoked: false,
+    });
+    return { completion };
+  }
+
+  async runPromptAfterCorrelatedTrueResult(
+    input: string,
+    output: string,
+  ): Promise<{ completedBeforeTurn: boolean; result: unknown }> {
+    const session = this.requireSession();
+    const runtime = this.omp.latestSession();
+    runtime.promptAck = { requestId: "prompt-invoked", agentInvoked: false };
+    const promptStarted = runtime.nextPrompt();
+    const run = session.run(input);
+    let completed = false;
+    void run.then(
+      () => {
+        completed = true;
+        return undefined;
+      },
+      () => {
+        completed = true;
+        return undefined;
+      },
+    );
+    await promptStarted;
+    runtime.emit({
+      type: "prompt_result",
+      id: "prompt-invoked",
+      agentInvoked: true,
+    });
+    await waitForImmediate();
+    await waitForImmediate();
+    const completedBeforeTurn = completed;
+    runtime.acceptPrompt(input, "user-1");
+    runtime.beginTurn();
+    runtime.streamAssistantText(output);
+    runtime.finishTurn();
+    return { completedBeforeTurn, result: await run };
+  }
+
+  async runPromptAfterDelayedFalseLocalOnlyResult(
+    input: string,
+    output: string,
+  ): Promise<{ completedBeforeTurn: boolean; result: unknown }> {
+    const session = this.requireSession();
+    const runtime = this.omp.latestSession();
+    runtime.promptAck = { requestId: "prompt-1" };
+    const promptStarted = runtime.nextPrompt();
+    const run = session.run(input);
+    let completed = false;
+    void run.then(
+      () => {
+        completed = true;
+        return undefined;
+      },
+      () => {
+        completed = true;
+        return undefined;
+      },
+    );
+    await promptStarted;
+    await waitForImmediate();
+    runtime.emit({
+      type: "prompt_result",
+      id: "prompt-1",
+      agentInvoked: false,
+    });
+    await waitForImmediate();
+    const completedBeforeTurn = completed;
+    runtime.acceptPrompt(input, "user-1");
+    runtime.beginTurn();
+    runtime.streamAssistantText(output);
+    runtime.finishTurn();
+    return { completedBeforeTurn, result: await run };
+  }
+
+  async runAutonomousTurn(output: string): Promise<void> {
+    const runtime = this.omp.latestSession();
+    runtime.beginTurn();
+    runtime.streamAssistantText(output);
+    runtime.finishTurn();
+    await waitForImmediate();
   }
 
   timeline(): AgentTimelineItem[] {

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -271,12 +271,23 @@ export class OmpHarness {
 
   async startPromptWithFalseLocalOnlyResult(
     input: string,
-  ): Promise<{ completion: Promise<unknown> }> {
+  ): Promise<{ completed: () => boolean; completion: Promise<unknown> }> {
     const session = this.requireSession();
     const runtime = this.omp.latestSession();
     runtime.promptAck = { requestId: "prompt-local-only" };
     const promptStarted = runtime.nextPrompt();
     const completion = session.run(input);
+    let isCompleted = false;
+    void completion.then(
+      () => {
+        isCompleted = true;
+        return undefined;
+      },
+      () => {
+        isCompleted = true;
+        return undefined;
+      },
+    );
     await promptStarted;
     await waitForImmediate();
     runtime.emit({
@@ -284,7 +295,7 @@ export class OmpHarness {
       id: "prompt-local-only",
       agentInvoked: false,
     });
-    return { completion };
+    return { completed: () => isCompleted, completion };
   }
 
   async runPromptAfterCorrelatedTrueResult(
@@ -473,6 +484,7 @@ export class OmpHarness {
 
   async close(): Promise<void> {
     await this.requireSession().close();
+    await waitForImmediate();
   }
 
   isClosed(): boolean {


### PR DESCRIPTION
### Linked issue

Closes #2281

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Handles an OMP 17.0.5 ordering case where a correlated `prompt_result` reports `agentInvoked: false` shortly before extension-queued model work begins. Paseo now keeps that local-only result provisional for a bounded five-second settle window, cancels the pending no-turn completion when real turn activity begins, and preserves a correlated `agentInvoked: true` result over a conflicting prompt RPC hint.

Terminal completion now also accepts an OMP turn that started without a foreground Paseo turn ID, while retaining the existing `get_state` provider-idle gate. This allows the delayed model turn to emit one `turn_completed` and return the agent to `idle` instead of remaining active indefinitely.

The settle wait is injectable for deterministic tests and is canceled when the session closes. A compatibility comment records the OMP 17.0.5 behavior and its January 20, 2027 cleanup target.

This is independent of #2260 and #2261. Those cover terminal `agent_end` payloads that omit assistant messages, while this change covers prompt-result timing, correlation, and autonomous terminal completion. The delayed-turn commit applies cleanly to `main` without the #2261 changes.

### How did you verify it

- Added deterministic regressions for a delayed queued model turn after a local-only result, settle-window expiry, close-time cancellation, correlated `agentInvoked: true` precedence, and autonomous terminal completion.
- Applied the delayed-turn commit directly to `main` without conflicts and re-ran verification on that clean branch.
- Ran `npx vitest run packages/server/src/server/agent/providers/omp/agent.test.ts --bail=1`: 21 tests passed.
- Ran `npm run build:server`: passed.
- Ran `npm run typecheck`: passed.
- Ran `npm run lint`: passed.
- Ran `npm run format:check`: passed.
- Ran a built, isolated Paseo daemon with the real `/home/bhyoo/.local/bin/omp` and model `openai-codex/gpt-5.6-sol`. The agent returned `OMP_MAIN_SMOKE_PASS`, and `paseo wait` reported `idle`.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI change)
- [x] Tests added or updated where it made sense
