### PR TITLE
feat(agents): fork a session into a new tab

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -50,6 +50,10 @@ Draft metadata lookups should avoid creating provider sessions when the upstream
 
 Provider session import has its own contract. The picker calls `listImportableSessions` and receives rows only: provider handle, cwd, title, prompt previews, and last activity. Import calls `importSession({ providerHandleId, cwd })` for the selected row and must not call listing again. The provider returns the resumed session, storage config, persistence handle, and hydrated timeline for that one native session; `AgentManager.importProviderSession` seeds the daemon timeline and publishes the Paseo agent only after it is ready.
 
+Session forking builds on that import contract. `AgentClient.forkSession({ providerHandleId, cwd, config })` asks the provider to branch a durable session into a brand new one holding a full copy of the transcript, and returns only the new provider handle id. `AgentManager.forkAgentSession` then runs the ordinary import path against that new handle, so the fork becomes a separate Paseo agent with its own hydrated timeline. Forking must be non-destructive: the source session stays on disk and the source agent keeps running against it. Advertise support with the `supportsForkSession` capability flag — the client hides the "Fork session" tab action for providers that do not set it. Claude implements this with the Agent SDK's `forkSession()` (no `upToMessageId`, so the whole transcript is copied); Codex has the equivalent `thread/fork`. Providers without a native branch primitive should simply omit the method rather than emulating one by replaying history.
+
+Do not implement forking by passing a fork flag through `buildOptions()`-style session option builders. Those builders re-run on every query recreation (model switch, mode switch, interrupt, rewind), so a fork flag there re-forks on every restart. Forking is a one-shot operation that happens before the new session is registered.
+
 ## Provider Helper Processes
 
 Provider-owned helper processes that can outlive an individual agent session must be recorded in the daemon's managed-process registry. Store provider/kind metadata, the PID, launch command/args, and process identity captured from the platform process table. Remove the record on normal exit or shutdown.
@@ -360,6 +364,7 @@ interface AgentClient {
     input: ImportProviderSessionInput,
     context: ImportProviderSessionContext,
   ): Promise<ImportedProviderSession>;
+  forkSession(input: ForkProviderSessionInput): Promise<ForkedProviderSession>;
   getDiagnostic?(): Promise<{ diagnostic: string }>;
 }
 ```

--- a/packages/app/e2e/fork-session.claude.real.spec.ts
+++ b/packages/app/e2e/fork-session.claude.real.spec.ts
@@ -1,0 +1,276 @@
+import { mkdirSync, mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, type Locator, type Page } from "@playwright/test";
+import { test } from "./fixtures";
+import {
+  assertChatTranscript,
+  assertComposerIdle,
+  cleanupRewindFlow,
+  launchAgent,
+  sendMessage,
+  type AgentHandle,
+  type TranscriptMessage,
+} from "./helpers/rewind-flow";
+import type { SeedDaemonClient } from "./helpers/seed-client";
+
+/**
+ * Verifies the "Fork session" tab action end-to-end against a real Claude
+ * session: the SDK's full-copy forkSession() actually runs, the new agent lands
+ * in a tab immediately to the right of its source, the fork starts with the
+ * whole transcript, and the two sessions then diverge without bleeding into
+ * each other.
+ */
+
+const SHOT_DIR = process.env.FORK_SHOT_DIR ?? "/tmp/paseo-fork-verification";
+
+const CODEWORD = "ZEPHYRLOOM";
+const SECOND_WORD = "MARBLEFINCH";
+const MEMORY_PROMPT = `Remember this codeword: ${CODEWORD}. Reply with just the word "stored".`;
+const SECOND_PROMPT = `Remember a second codeword: ${SECOND_WORD}. Reply with just the word "stored".`;
+const RECALL_PROMPT =
+  "List both codewords I asked you to remember, in order, separated by a space. Reply with only those two words.";
+const SOURCE_MARKER = "TANGERINEHOLLOW";
+const SOURCE_PROMPT = `Reply with only this word: ${SOURCE_MARKER}`;
+
+/** The two exchanges the fork is expected to inherit verbatim. */
+const BASE_TRANSCRIPT: TranscriptMessage[] = [
+  { role: "user", text: MEMORY_PROMPT },
+  { role: "assistant", text: /.+/ },
+  { role: "user", text: SECOND_PROMPT },
+  { role: "assistant", text: /.+/ },
+];
+
+/** How long to hold the open menu on screen, so the recording is watchable. */
+const MENU_HOLD_MS = 2_000;
+
+/**
+ * Wait until an element is fully opaque. The tab context menu fades in, so
+ * screenshotting as soon as it is "visible" catches it mid-animation and the
+ * chat behind it bleeds through. Opacity is inherited multiplicatively, so this
+ * walks the ancestor chain rather than reading the element alone.
+ */
+async function waitForOpaque(target: Locator): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        target.evaluate((element) => {
+          let opacity = 1;
+          let node: HTMLElement | null = element as HTMLElement;
+          while (node) {
+            opacity *= Number(globalThis.getComputedStyle(node).opacity || "1");
+            node = node.parentElement;
+          }
+          return Number(opacity.toFixed(3));
+        }),
+      { timeout: 10_000 },
+    )
+    .toBe(1);
+}
+
+let shotIndex = 0;
+
+async function shot(page: Page, name: string): Promise<void> {
+  shotIndex += 1;
+  const file = path.join(SHOT_DIR, `${String(shotIndex).padStart(2, "0")}-${name}.png`);
+  await page.screenshot({ path: file, fullPage: false });
+  console.log(`[fork-verify] screenshot: ${file}`);
+}
+
+/**
+ * Whether an agent's own timeline contains a piece of text, straight from the
+ * daemon. Rendered chat text cannot answer "which session ran this turn": the
+ * source and the fork share a transcript prefix, so they answer identically.
+ * Only the per-agent timeline distinguishes them.
+ */
+async function timelineContains(
+  handle: AgentHandle,
+  agentId: string,
+  needle: string,
+): Promise<boolean> {
+  const client = handle.client as SeedDaemonClient & {
+    fetchAgentTimeline: (
+      agentId: string,
+      options?: { direction?: "tail"; projection?: "projected"; limit?: number },
+    ) => Promise<{ entries: unknown[] }>;
+  };
+  const timeline = await client.fetchAgentTimeline(agentId, {
+    direction: "tail",
+    projection: "projected",
+    limit: 200,
+  });
+  return JSON.stringify(timeline.entries).includes(needle);
+}
+
+/** The model and mode the daemon reports for an agent. */
+async function agentRuntimeConfig(
+  handle: AgentHandle,
+  agentId: string,
+): Promise<{ model: string | null; currentModeId: string | null }> {
+  const agents = await handle.client.fetchAgents({ scope: "active" });
+  const entry = agents.entries.find((candidate) => candidate.agent.id === agentId);
+  if (!entry) {
+    throw new Error(`Agent ${agentId} not found in the daemon's active agents`);
+  }
+  return { model: entry.agent.model, currentModeId: entry.agent.currentModeId };
+}
+
+/** Agent tab ids in left-to-right DOM order. */
+async function agentTabOrder(page: Page): Promise<string[]> {
+  return page
+    .locator('[data-testid^="workspace-tab-agent_"]')
+    .evaluateAll((elements) =>
+      elements.map((element) =>
+        (element.getAttribute("data-testid") ?? "").replace("workspace-tab-agent_", ""),
+      ),
+    );
+}
+
+test.describe("fork session - claude", () => {
+  test.setTimeout(900_000);
+
+  test("forks a real Claude session into a new tab to the right", async ({ page }) => {
+    mkdirSync(SHOT_DIR, { recursive: true });
+    const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "paseo-fork-session-claude-")));
+    let handle: AgentHandle | undefined;
+
+    try {
+      handle = await launchAgent({ page, provider: "claude", cwd, mode: "full-access" });
+
+      // 1. Give the source session a multi-turn transcript worth copying. Two
+      //    exchanges, so "full copy" is distinguishable from rewind's slice.
+      await sendMessage(handle, MEMORY_PROMPT);
+      await sendMessage(handle, SECOND_PROMPT);
+      await assertChatTranscript(handle, BASE_TRANSCRIPT);
+      await shot(page, "source-session-with-transcript");
+
+      // 2. The Fork session entry is present on the source tab's context menu.
+      const sourceTab = page.getByTestId(`workspace-tab-agent_${handle.agentId}`).first();
+      await sourceTab.click({ button: "right" });
+      const menu = page.getByTestId(`workspace-tab-context-agent_${handle.agentId}`);
+      await expect(menu).toBeVisible({ timeout: 10_000 });
+      const forkItem = page.getByTestId(
+        `workspace-tab-context-agent_${handle.agentId}-fork-session`,
+      );
+      // Let the fade-in finish before capturing, otherwise the menu is caught
+      // half-transparent with the chat showing through it.
+      await waitForOpaque(menu);
+      await page.waitForTimeout(MENU_HOLD_MS);
+      // Screenshot the open menu before asserting, so a missing entry is
+      // captured as evidence instead of only showing up as a bare timeout.
+      await shot(page, "fork-session-menu-entry");
+      await expect(forkItem).toBeVisible({ timeout: 10_000 });
+      // Hold the fully drawn menu on screen so the recording reads clearly
+      // before the click lands.
+      await page.waitForTimeout(MENU_HOLD_MS);
+
+      // 3. Fork. The daemon calls the Claude SDK's forkSession() for real here.
+      const tabsBefore = await agentTabOrder(page);
+      await forkItem.click();
+
+      await expect
+        .poll(async () => (await agentTabOrder(page)).length, { timeout: 180_000 })
+        .toBeGreaterThan(tabsBefore.length);
+
+      const tabsAfter = await agentTabOrder(page);
+      const sourceIndex = tabsAfter.indexOf(handle.agentId);
+      expect(sourceIndex, "source tab still present after fork").toBeGreaterThanOrEqual(0);
+      const forkedAgentId = tabsAfter[sourceIndex + 1];
+      if (!forkedAgentId) {
+        throw new Error(
+          `Expected a forked tab directly right of the source. Order: ${JSON.stringify(tabsAfter)}`,
+        );
+      }
+      expect(forkedAgentId).not.toBe(handle.agentId);
+      expect(tabsBefore).not.toContain(forkedAgentId);
+      console.log(`[fork-verify] source=${handle.agentId} forked=${forkedAgentId}`);
+
+      const forkHandle: AgentHandle = { ...handle, agentId: forkedAgentId };
+
+      // 3b. The forked tab must be ACTIVE, not merely present. Under the
+      //     original bug the tab was pruned as stale and re-added appended and
+      //     unfocused, so a presence check passes on broken code. Hold the
+      //     assertion across a few reconcile cycles: the failure signature is
+      //     appear → vanish → reappear in the wrong slot.
+      const activeForkTab = page.locator(
+        `[data-testid="workspace-tab-agent_${forkedAgentId}"][aria-selected="true"]`,
+      );
+      await expect(activeForkTab).toHaveCount(1, { timeout: 30_000 });
+      for (let cycle = 0; cycle < 3; cycle += 1) {
+        await page.waitForTimeout(1_000);
+        await expect(activeForkTab, `fork tab lost focus on reconcile cycle ${cycle}`).toHaveCount(
+          1,
+        );
+      }
+
+      // 3c. The fork continues the source conversation, so it must keep running
+      //     it the same way. Falling back to provider defaults would silently
+      //     move the user onto a different model and permission mode — a cost
+      //     and safety change they never asked for.
+      const sourceConfig = await agentRuntimeConfig(handle, handle.agentId);
+      await expect
+        .poll(() => agentRuntimeConfig(handle!, forkedAgentId), { timeout: 30_000 })
+        .toEqual(sourceConfig);
+
+      // 4. The forked tab is focused and holds a full copy of both exchanges.
+      await assertComposerIdle({ page });
+      await assertChatTranscript(forkHandle, BASE_TRANSCRIPT);
+      await shot(page, "forked-tab-holds-transcript-copy");
+
+      // 5. Send a turn from the forked tab. NOTE: a passing assertion here does
+      //    not by itself prove the fork is live — if the pane is still bound to
+      //    the source agent the turn runs on the source session, which has the
+      //    same context and answers identically. Step 6 is what disambiguates:
+      //    if this turn landed on the source, it shows up in the source's
+      //    transcript there.
+      await sendMessage(forkHandle, RECALL_PROMPT);
+      await assertChatTranscript(forkHandle, [
+        ...BASE_TRANSCRIPT,
+        { role: "user", text: RECALL_PROMPT },
+        { role: "assistant", text: new RegExp(`${CODEWORD}[\\s\\S]*${SECOND_WORD}`, "i") },
+      ]);
+      await shot(page, "fork-recalls-inherited-context");
+
+      // 5b. Daemon truth — the assertion that actually pins the routing. The
+      //     turn must have executed on the FORKED agent and must NOT appear in
+      //     the source's timeline. Without this, a fork that silently drives the
+      //     source session passes every UI assertion above, because the source
+      //     holds the same context and answers identically.
+      await expect
+        .poll(() => timelineContains(handle!, forkedAgentId, RECALL_PROMPT), { timeout: 30_000 })
+        .toBe(true);
+      expect(
+        await timelineContains(handle, handle.agentId, RECALL_PROMPT),
+        "source session must not absorb a turn sent from the forked tab",
+      ).toBe(false);
+
+      // 6. The source session is untouched by the fork's turn. Close the forked
+      //    tab first: with both agent tabs open only one chat scroll is
+      //    rendered, so the source pane has to be the only one left to read.
+      await page.getByTestId(`workspace-agent-close-${forkedAgentId}`).first().click();
+      await expect
+        .poll(async () => (await agentTabOrder(page)).includes(forkedAgentId), { timeout: 30_000 })
+        .toBe(false);
+      await assertComposerIdle({ page });
+      await assertChatTranscript(handle, BASE_TRANSCRIPT);
+      await shot(page, "source-unchanged-by-fork");
+
+      // 7. The source keeps running on its own session and diverges from the
+      //    fork point. The fork's recall turn never appears here.
+      await sendMessage(handle, SOURCE_PROMPT);
+      await assertChatTranscript(handle, [
+        ...BASE_TRANSCRIPT,
+        { role: "user", text: SOURCE_PROMPT },
+        { role: "assistant", text: new RegExp(SOURCE_MARKER, "i") },
+      ]);
+      const sourceTranscript = await page
+        .locator('[data-testid="agent-chat-scroll"]:visible')
+        .first()
+        .innerText();
+      expect(sourceTranscript).not.toContain(RECALL_PROMPT);
+      await shot(page, "source-diverges-independently");
+    } finally {
+      await cleanupRewindFlow({ handle, cwd });
+    }
+  });
+});

--- a/packages/app/e2e/helpers/composer.ts
+++ b/packages/app/e2e/helpers/composer.ts
@@ -8,8 +8,11 @@ import { selectWorkspaceInSidebar } from "./sidebar";
 import { getServerId } from "./server-id";
 import { waitForTabBar } from "./launcher";
 
+// Inactive agent tabs stay mounted behind `display: none`, so with more than one
+// agent tab open the first composer in DOM order belongs to a hidden pane. Only
+// the visible one is the composer the user is actually typing into.
 function composerInput(page: Page) {
-  return page.getByRole("textbox", { name: "Message agent..." }).first();
+  return page.getByRole("textbox", { name: "Message agent..." }).filter({ visible: true }).first();
 }
 
 export function composerLocator(page: Page) {

--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -93,6 +93,8 @@ interface SplitContainerProps {
   closingTabIds: Set<string>;
   onNavigateTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
+  onForkSession: (agentId: string) => Promise<void> | void;
+  canForkSession: (agentId: string) => boolean;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
@@ -371,6 +373,8 @@ export function SplitContainer({
   closingTabIds,
   onNavigateTab,
   onCloseTab,
+  onForkSession,
+  canForkSession,
   onCopyResumeCommand,
   onCopyAgentId,
   onCopyFilePath,
@@ -590,6 +594,8 @@ export function SplitContainer({
           closingTabIds={closingTabIds}
           onNavigateTab={onNavigateTab}
           onCloseTab={onCloseTab}
+          onForkSession={onForkSession}
+          canForkSession={canForkSession}
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
           onCopyFilePath={onCopyFilePath}
@@ -736,6 +742,8 @@ function SplitNodeView({
   closingTabIds,
   onNavigateTab,
   onCloseTab,
+  onForkSession,
+  canForkSession,
   onCopyResumeCommand,
   onCopyAgentId,
   onCopyFilePath,
@@ -793,6 +801,8 @@ function SplitNodeView({
           closingTabIds={closingTabIds}
           onNavigateTab={onNavigateTab}
           onCloseTab={onCloseTab}
+          onForkSession={onForkSession}
+          canForkSession={canForkSession}
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
           onCopyFilePath={onCopyFilePath}
@@ -842,6 +852,8 @@ function SplitNodeView({
               closingTabIds={closingTabIds}
               onNavigateTab={onNavigateTab}
               onCloseTab={onCloseTab}
+              onForkSession={onForkSession}
+              canForkSession={canForkSession}
               onCopyResumeCommand={onCopyResumeCommand}
               onCopyAgentId={onCopyAgentId}
               onCopyFilePath={onCopyFilePath}
@@ -897,6 +909,8 @@ function SplitPaneView({
   closingTabIds,
   onNavigateTab,
   onCloseTab,
+  onForkSession,
+  canForkSession,
   onCopyResumeCommand,
   onCopyAgentId,
   onCopyFilePath,
@@ -1042,6 +1056,8 @@ function SplitPaneView({
             setHoveredCloseTabKey={setHoveredCloseTabKey}
             onNavigateTab={onNavigateTab}
             onCloseTab={onCloseTab}
+            onForkSession={onForkSession}
+            canForkSession={canForkSession}
             onCopyResumeCommand={onCopyResumeCommand}
             onCopyAgentId={onCopyAgentId}
             onCopyFilePath={onCopyFilePath}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -485,6 +485,8 @@ export const ar: TranslationResources = {
       },
       menu: {
         openFor: "فتح القائمة لـ{{label}}",
+        forkSession: "تفريع الجلسة",
+        forkSessionTooltip: "فرّع هذه الجلسة إلى علامة تبويب جديدة. تستمر الجلسة الأصلية في العمل.",
         copyResumeCommand: "نسخ أمر السيرة الذاتية",
         copyAgentId: "نسخ معرف الوكيل",
         copyFilePath: "Copy file path",
@@ -528,6 +530,9 @@ export const ar: TranslationResources = {
         filePathCopiedLabel: "File path",
         resumeIdUnavailable: "السيرة الذاتية ID غير متوفرة",
         resumeCommandUnavailable: "أمر الاستئناف غير متوفر",
+        forkingSession: "جارٍ تفريع الجلسة…",
+        forkedSession: "تم تفريع الجلسة",
+        failedToForkSession: "فشل تفريع الجلسة",
         reloadingAgent: "وكيل إعادة التحميل...",
         reloadedAgent: "وكيل إعادة تحميل",
         failedToReloadAgent: "فشل في إعادة تحميل الوكيل",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -484,6 +484,8 @@ export const en = {
       },
       menu: {
         openFor: "Open menu for {{label}}",
+        forkSession: "Fork session",
+        forkSessionTooltip: "Branch this session into a new tab. The original keeps running.",
         copyResumeCommand: "Copy resume command",
         copyAgentId: "Copy agent id",
         copyFilePath: "Copy file path",
@@ -527,6 +529,9 @@ export const en = {
         filePathCopiedLabel: "File path",
         resumeIdUnavailable: "Resume ID not available",
         resumeCommandUnavailable: "Resume command not available",
+        forkingSession: "Forking session…",
+        forkedSession: "Session forked",
+        failedToForkSession: "Failed to fork session",
         reloadingAgent: "Reloading agent...",
         reloadedAgent: "Reloaded agent",
         failedToReloadAgent: "Failed to reload agent",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -489,6 +489,9 @@ export const es: TranslationResources = {
       },
       menu: {
         openFor: "Menú abierto para{{label}}",
+        forkSession: "Bifurcar sesión",
+        forkSessionTooltip:
+          "Bifurca esta sesión en una pestaña nueva. La original sigue en ejecución.",
         copyResumeCommand: "Copiar comando de reanudación",
         copyAgentId: "Copiar ID del agente",
         copyFilePath: "Copy file path",
@@ -533,6 +536,9 @@ export const es: TranslationResources = {
         filePathCopiedLabel: "File path",
         resumeIdUnavailable: "ReanudarIDno disponible",
         resumeCommandUnavailable: "Comando de reanudación no disponible",
+        forkingSession: "Bifurcando sesión…",
+        forkedSession: "Sesión bifurcada",
+        failedToForkSession: "No se pudo bifurcar la sesión",
         reloadingAgent: "Agente de recarga...",
         reloadedAgent: "Agente recargado",
         failedToReloadAgent: "No se pudo recargar el agente",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -489,6 +489,9 @@ export const fr: TranslationResources = {
       },
       menu: {
         openFor: "Ouvrir le menu pour{{label}}",
+        forkSession: "Dupliquer la session",
+        forkSessionTooltip:
+          "Créez une branche de cette session dans un nouvel onglet. L'originale continue de s'exécuter.",
         copyResumeCommand: "Copier la commande de reprise",
         copyAgentId: "Copier l'identifiant de l'agent",
         copyFilePath: "Copy file path",
@@ -533,6 +536,9 @@ export const fr: TranslationResources = {
         filePathCopiedLabel: "File path",
         resumeIdUnavailable: "ReprendreIDnon disponible",
         resumeCommandUnavailable: "Commande de reprise non disponible",
+        forkingSession: "Duplication de la session…",
+        forkedSession: "Session dupliquée",
+        failedToForkSession: "Échec de la duplication de la session",
         reloadingAgent: "Agent de rechargement...",
         reloadedAgent: "Agent rechargé",
         failedToReloadAgent: "Échec du rechargement de l'agent",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -489,6 +489,9 @@ export const ja: TranslationResources = {
       },
       menu: {
         openFor: "{{label}}のメニューを開く",
+        forkSession: "セッションをフォーク",
+        forkSessionTooltip:
+          "このセッションを新しいタブに分岐します。元のセッションは実行を続けます。",
         copyResumeCommand: "再開コマンドをコピー",
         copyAgentId: "エージェントIDをコピー",
         copyFilePath: "ファイルパスをコピー",
@@ -533,6 +536,9 @@ export const ja: TranslationResources = {
         filePathCopiedLabel: "ファイルパス",
         resumeIdUnavailable: "再開IDが利用できません",
         resumeCommandUnavailable: "再開コマンドが利用できません",
+        forkingSession: "セッションをフォーク中…",
+        forkedSession: "セッションをフォークしました",
+        failedToForkSession: "セッションのフォークに失敗しました",
         reloadingAgent: "エージェントを再読み込み中...",
         reloadedAgent: "エージェントを再読み込みしました",
         failedToReloadAgent: "エージェントの再読み込みに失敗しました",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -489,6 +489,9 @@ export const ptBR: TranslationResources = {
       },
       menu: {
         openFor: "Abrir menu de {{label}}",
+        forkSession: "Bifurcar sessão",
+        forkSessionTooltip:
+          "Ramifique esta sessão em uma nova aba. A original continua em execução.",
         copyResumeCommand: "Copiar comando de retomada",
         copyAgentId: "Copiar ID do agente",
         copyFilePath: "Copiar caminho do arquivo",
@@ -532,6 +535,9 @@ export const ptBR: TranslationResources = {
         filePathCopiedLabel: "Caminho do arquivo",
         resumeIdUnavailable: "ID de retomada indisponível",
         resumeCommandUnavailable: "Comando de retomada indisponível",
+        forkingSession: "Bifurcando sessão…",
+        forkedSession: "Sessão bifurcada",
+        failedToForkSession: "Falha ao bifurcar a sessão",
         reloadingAgent: "Recarregando agente...",
         reloadedAgent: "Agente recarregado",
         failedToReloadAgent: "Falha ao recarregar agente",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -489,6 +489,8 @@ export const ru: TranslationResources = {
       },
       menu: {
         openFor: "Открыть меню для{{label}}",
+        forkSession: "Ответвить сессию",
+        forkSessionTooltip: "Ответвите эту сессию в новую вкладку. Исходная продолжит работу.",
         copyResumeCommand: "Копировать команду возобновления",
         copyAgentId: "Скопировать идентификатор агента",
         copyFilePath: "Copy file path",
@@ -532,6 +534,9 @@ export const ru: TranslationResources = {
         filePathCopiedLabel: "File path",
         resumeIdUnavailable: "Резюме ID недоступно",
         resumeCommandUnavailable: "Команда возобновления недоступна",
+        forkingSession: "Ответвление сессии…",
+        forkedSession: "Сессия ответвлена",
+        failedToForkSession: "Не удалось ответвить сессию",
         reloadingAgent: "Перезагрузка агента...",
         reloadedAgent: "Перезагруженный агент",
         failedToReloadAgent: "Не удалось перезагрузить агент",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -485,6 +485,8 @@ export const zhCN: TranslationResources = {
       },
       menu: {
         openFor: "打开 {{label}} 的菜单",
+        forkSession: "复刻会话",
+        forkSessionTooltip: "将此会话分支到新标签页。原会话继续运行。",
         copyResumeCommand: "复制恢复命令",
         copyAgentId: "复制 Agent ID",
         copyFilePath: "Copy file path",
@@ -528,6 +530,9 @@ export const zhCN: TranslationResources = {
         filePathCopiedLabel: "File path",
         resumeIdUnavailable: "恢复 ID 不可用",
         resumeCommandUnavailable: "恢复命令不可用",
+        forkingSession: "正在复刻会话…",
+        forkedSession: "会话已复刻",
+        failedToForkSession: "复刻会话失败",
         reloadingAgent: "正在重新加载 Agent...",
         reloadedAgent: "已重新加载 Agent",
         failedToReloadAgent: "重新加载 Agent 失败",

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -18,6 +18,7 @@ import {
 } from "react-native";
 import {
   CopyX,
+  GitBranch,
   ArrowLeftToLine,
   ArrowRightToLine,
   ChevronDown,
@@ -101,6 +102,7 @@ const ThemedRotateCw = withUnistyles(RotateCw);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
 const ThemedArrowRightToLine = withUnistyles(ArrowRightToLine);
 const ThemedCopyX = withUnistyles(CopyX);
+const ThemedGitBranch = withUnistyles(GitBranch);
 const ThemedPencil = withUnistyles(Pencil);
 const ThemedSquarePen = withUnistyles(SquarePen);
 const ThemedSquareTerminal = withUnistyles(SquareTerminal);
@@ -336,6 +338,8 @@ function TabContextMenuItem({
         return <ThemedArrowRightToLine size={16} uniProps={mutedColorMapping} />;
       case "copy-x":
         return <ThemedCopyX size={16} uniProps={mutedColorMapping} />;
+      case "git-branch":
+        return <ThemedGitBranch size={16} uniProps={mutedColorMapping} />;
       case "pencil":
         return <ThemedPencil size={16} uniProps={mutedColorMapping} />;
       case "x":
@@ -417,6 +421,8 @@ interface WorkspaceDesktopTabsRowProps {
   setHoveredCloseTabKey: Dispatch<SetStateAction<string | null>>;
   onNavigateTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
+  onForkSession: (agentId: string) => Promise<void> | void;
+  canForkSession: (agentId: string) => boolean;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
@@ -759,6 +765,8 @@ export function WorkspaceDesktopTabsRow({
   setHoveredCloseTabKey,
   onNavigateTab,
   onCloseTab,
+  onForkSession,
+  canForkSession,
   onCopyResumeCommand,
   onCopyAgentId,
   onCopyFilePath,
@@ -841,6 +849,8 @@ export function WorkspaceDesktopTabsRow({
   );
   const tabMenuLabels = useMemo<WorkspaceTabMenuLabels>(
     () => ({
+      forkSession: t("workspace.tabs.menu.forkSession"),
+      forkSessionTooltip: t("workspace.tabs.menu.forkSessionTooltip"),
       copyResumeCommand: t("workspace.tabs.menu.copyResumeCommand"),
       copyAgentId: t("workspace.tabs.menu.copyAgentId"),
       copyFilePath: t("workspace.tabs.menu.copyFilePath"),
@@ -939,6 +949,8 @@ export function WorkspaceDesktopTabsRow({
           tabCount={tabs.length}
           normalizedServerId={normalizedServerId}
           normalizedWorkspaceId={normalizedWorkspaceId}
+          onForkSession={onForkSession}
+          canForkSession={canForkSession}
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
           onCopyFilePath={onCopyFilePath}
@@ -973,6 +985,8 @@ export function WorkspaceDesktopTabsRow({
       onCloseTabsToRight,
       onCopyAgentId,
       onCopyFilePath,
+      onForkSession,
+      canForkSession,
       onCopyResumeCommand,
       onNavigateTab,
       onReloadAgent,
@@ -1091,6 +1105,8 @@ function ResolvedDesktopTabChip({
   tabCount,
   normalizedServerId,
   normalizedWorkspaceId,
+  onForkSession,
+  canForkSession,
   onCopyResumeCommand,
   onCopyAgentId,
   onCopyFilePath,
@@ -1117,6 +1133,8 @@ function ResolvedDesktopTabChip({
   tabCount: number;
   normalizedServerId: string;
   normalizedWorkspaceId: string;
+  onForkSession: (agentId: string) => Promise<void> | void;
+  canForkSession: (agentId: string) => boolean;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
@@ -1143,6 +1161,8 @@ function ResolvedDesktopTabChip({
         tab: item.tab,
         index,
         tabCount,
+        onForkSession,
+        canForkSession,
         onCopyResumeCommand,
         onCopyAgentId,
         onCopyFilePath,
@@ -1163,6 +1183,8 @@ function ResolvedDesktopTabChip({
       onCloseTabsToRight,
       onCopyAgentId,
       onCopyFilePath,
+      onForkSession,
+      canForkSession,
       onCopyResumeCommand,
       labels,
       onReloadAgent,

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from "react-i18next";
 import { DiffStat } from "@/components/diff-stat";
 import {
   CopyX,
+  GitBranch,
   ArrowLeftToLine,
   ArrowRightToLine,
   ChevronDown,
@@ -247,6 +248,7 @@ const ThemedRotateCw = withUnistyles(RotateCw);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
 const ThemedArrowRightToLine = withUnistyles(ArrowRightToLine);
 const ThemedCopyX = withUnistyles(CopyX);
+const ThemedGitBranch = withUnistyles(GitBranch);
 const ThemedPencil = withUnistyles(Pencil);
 const ThemedX = withUnistyles(X);
 const ThemedSquarePen = withUnistyles(SquarePen);
@@ -409,6 +411,8 @@ interface MobileWorkspaceTabSwitcherProps {
   normalizedServerId: string;
   normalizedWorkspaceId: string;
   onSelectSwitcherTab: (key: string) => void;
+  onForkSession: (agentId: string) => Promise<void> | void;
+  canForkSession: (agentId: string) => boolean;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
@@ -561,6 +565,8 @@ function MobileTabDropdownMenuItem({
         return <ThemedArrowRightToLine size={16} uniProps={mutedColorMapping} />;
       case "copy-x":
         return <ThemedCopyX size={16} uniProps={mutedColorMapping} />;
+      case "git-branch":
+        return <ThemedGitBranch size={16} uniProps={mutedColorMapping} />;
       case "pencil":
         return <ThemedPencil size={16} uniProps={mutedColorMapping} />;
       case "x":
@@ -597,6 +603,8 @@ function MobileWorkspaceTabOption({
   selected,
   active,
   onPress,
+  onForkSession,
+  canForkSession,
   onCopyResumeCommand,
   onCopyAgentId,
   onCopyFilePath,
@@ -615,6 +623,8 @@ function MobileWorkspaceTabOption({
   selected: boolean;
   active: boolean;
   onPress: () => void;
+  onForkSession: (agentId: string) => Promise<void> | void;
+  canForkSession: (agentId: string) => boolean;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
@@ -628,6 +638,8 @@ function MobileWorkspaceTabOption({
   const { t } = useTranslation();
   const tabMenuLabels = useMemo<WorkspaceTabMenuLabels>(
     () => ({
+      forkSession: t("workspace.tabs.menu.forkSession"),
+      forkSessionTooltip: t("workspace.tabs.menu.forkSessionTooltip"),
       copyResumeCommand: t("workspace.tabs.menu.copyResumeCommand"),
       copyAgentId: t("workspace.tabs.menu.copyAgentId"),
       copyFilePath: t("workspace.tabs.menu.copyFilePath"),
@@ -650,6 +662,8 @@ function MobileWorkspaceTabOption({
     index: tabIndex,
     tabCount,
     menuTestIDBase,
+    onForkSession,
+    canForkSession,
     onCopyResumeCommand,
     onCopyAgentId,
     onCopyFilePath,
@@ -717,6 +731,8 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
   normalizedServerId,
   normalizedWorkspaceId,
   onSelectSwitcherTab,
+  onForkSession,
+  canForkSession,
   onCopyResumeCommand,
   onCopyAgentId,
   onCopyFilePath,
@@ -773,6 +789,8 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
           selected={selected}
           active={active}
           onPress={onPress}
+          onForkSession={onForkSession}
+          canForkSession={canForkSession}
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
           onCopyFilePath={onCopyFilePath}
@@ -791,6 +809,8 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
       tabs.length,
       normalizedServerId,
       normalizedWorkspaceId,
+      onForkSession,
+      canForkSession,
       onCopyResumeCommand,
       onCopyAgentId,
       onCopyFilePath,
@@ -2044,6 +2064,10 @@ function WorkspaceScreenContent({
     }
     return () => viewedTimelineSync.replaceVisibleAgentIds(persistenceKey, []);
   }, [persistenceKey, viewedTimelineSync]);
+  // COMPAT(agentSessionFork): added in v0.1.109, drop the gate when floor >= v0.1.109.
+  const hostSupportsAgentSessionFork = useSessionStore(
+    (state) => state.sessions[normalizedServerId]?.serverInfo?.features?.agentSessionFork === true,
+  );
   const setFocusedAgentId = useSessionStore((state) => state.setFocusedAgentId);
   const setFocusedTerminalId = useSessionStore((state) => state.setFocusedTerminalId);
   const focusedPaneAgentId = useMemo(() => {
@@ -2781,6 +2805,51 @@ function WorkspaceScreenContent({
       }
     },
     [normalizedServerId, toast, t],
+  );
+
+  const canForkAgentSession = useCallback(
+    (agentId: string) => {
+      if (!hostSupportsAgentSessionFork) {
+        return false;
+      }
+      const agent =
+        useSessionStore.getState().sessions[normalizedServerId]?.agents?.get(agentId) ?? null;
+      if (agent?.capabilities?.supportsForkSession !== true) {
+        return false;
+      }
+      return Boolean(agent.runtimeInfo?.sessionId ?? agent.persistence?.sessionId);
+    },
+    [hostSupportsAgentSessionFork, normalizedServerId],
+  );
+
+  const handleForkSession = useCallback(
+    async (agentId: string) => {
+      if (!client || !isConnected) {
+        toast.error(t("workspace.terminal.hostDisconnected"));
+        return;
+      }
+
+      toast.show(t("workspace.tabs.toasts.forkingSession"), { durationMs: null });
+      try {
+        const forkedAgentId = await client.forkAgentSession({ agentId });
+        const tabId = persistenceKey
+          ? openWorkspaceTabFocused(
+              persistenceKey,
+              { kind: "agent", agentId: forkedAgentId },
+              { insertAfterTabId: buildDeterministicWorkspaceTabId({ kind: "agent", agentId }) },
+            )
+          : null;
+        if (tabId) {
+          navigateToTabId(tabId);
+        }
+        toast.show(t("workspace.tabs.toasts.forkedSession"), { variant: "success" });
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : t("workspace.tabs.toasts.failedToForkSession"),
+        );
+      }
+    },
+    [client, isConnected, navigateToTabId, openWorkspaceTabFocused, persistenceKey, toast, t],
   );
 
   const handleReloadAgent = useCallback(
@@ -3607,6 +3676,8 @@ function WorkspaceScreenContent({
         closingTabIds={closingTabIds}
         onNavigateTab={navigateToTabId}
         onCloseTab={handleCloseTabById}
+        onForkSession={handleForkSession}
+        canForkSession={canForkAgentSession}
         onCopyResumeCommand={handleCopyResumeCommand}
         onCopyAgentId={handleCopyAgentId}
         onCopyFilePath={handleCopyFilePath}
@@ -3644,6 +3715,8 @@ function WorkspaceScreenContent({
     navigateToTabId,
     handleCloseTabById,
     handleCopyResumeCommand,
+    handleForkSession,
+    canForkAgentSession,
     handleCopyAgentId,
     handleCopyFilePath,
     handleReloadAgent,
@@ -3724,6 +3797,8 @@ function WorkspaceScreenContent({
           normalizedServerId={normalizedServerId}
           normalizedWorkspaceId={normalizedWorkspaceId}
           onSelectSwitcherTab={handleSelectSwitcherTab}
+          onForkSession={handleForkSession}
+          canForkSession={canForkAgentSession}
           onCopyResumeCommand={handleCopyResumeCommand}
           onCopyAgentId={handleCopyAgentId}
           onCopyFilePath={handleCopyFilePath}
@@ -3746,6 +3821,8 @@ function WorkspaceScreenContent({
           setHoveredCloseTabKey={setHoveredCloseTabKey}
           onNavigateTab={navigateToTabId}
           onCloseTab={handleCloseTabById}
+          onForkSession={handleForkSession}
+          canForkSession={canForkAgentSession}
           onCopyResumeCommand={handleCopyResumeCommand}
           onCopyAgentId={handleCopyAgentId}
           onCopyFilePath={handleCopyFilePath}

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -10,6 +10,7 @@ import {
   type ComponentProps,
   type ReactNode,
 } from "react";
+import { useShallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import { useIsFocused } from "@react-navigation/native";
 import { ActivityIndicator, BackHandler, Keyboard, Pressable, Text, View } from "react-native";
@@ -206,6 +207,7 @@ const WORKSPACE_FLOATING_PANEL_PORTAL_HOST_PREFIX = "workspace-floating-panels";
 const EMPTY_UI_TABS: WorkspaceTab[] = [];
 const EMPTY_WORKSPACE_SCRIPTS: WorkspaceDescriptor["scripts"] = [];
 const EMPTY_PINNED_AGENT_IDS = new Set<string>();
+const EMPTY_FORKABLE_AGENT_IDS: string[] = [];
 const EMPTY_SET = new Set<string>();
 
 function getWorkspaceScripts(
@@ -2064,10 +2066,6 @@ function WorkspaceScreenContent({
     }
     return () => viewedTimelineSync.replaceVisibleAgentIds(persistenceKey, []);
   }, [persistenceKey, viewedTimelineSync]);
-  // COMPAT(agentSessionFork): added in v0.1.109, drop the gate when floor >= v0.1.109.
-  const hostSupportsAgentSessionFork = useSessionStore(
-    (state) => state.sessions[normalizedServerId]?.serverInfo?.features?.agentSessionFork === true,
-  );
   const setFocusedAgentId = useSessionStore((state) => state.setFocusedAgentId);
   const setFocusedTerminalId = useSessionStore((state) => state.setFocusedTerminalId);
   const focusedPaneAgentId = useMemo(() => {
@@ -2807,19 +2805,34 @@ function WorkspaceScreenContent({
     [normalizedServerId, toast, t],
   );
 
+  // A provider session id only lands once the agent has actually started, which
+  // is after the tab chip first builds its context menu. Reading the store with
+  // getState() inside the callback would leave that menu memoized against a
+  // null session id forever, so the entry has to be driven by a reactive
+  // selector that re-renders the chip when an agent becomes forkable.
+  const forkableAgentIds = useSessionStore(
+    useShallow((state) => {
+      const session = state.sessions[normalizedServerId];
+      // COMPAT(agentSessionFork): added in v0.1.109, drop the gate when floor >= v0.1.109.
+      if (session?.serverInfo?.features?.agentSessionFork !== true) {
+        return EMPTY_FORKABLE_AGENT_IDS;
+      }
+      const forkable: string[] = [];
+      for (const [agentId, agent] of session.agents ?? []) {
+        if (agent.capabilities?.supportsForkSession !== true) {
+          continue;
+        }
+        if (agent.runtimeInfo?.sessionId ?? agent.persistence?.sessionId) {
+          forkable.push(agentId);
+        }
+      }
+      return forkable;
+    }),
+  );
+
   const canForkAgentSession = useCallback(
-    (agentId: string) => {
-      if (!hostSupportsAgentSessionFork) {
-        return false;
-      }
-      const agent =
-        useSessionStore.getState().sessions[normalizedServerId]?.agents?.get(agentId) ?? null;
-      if (agent?.capabilities?.supportsForkSession !== true) {
-        return false;
-      }
-      return Boolean(agent.runtimeInfo?.sessionId ?? agent.persistence?.sessionId);
-    },
-    [hostSupportsAgentSessionFork, normalizedServerId],
+    (agentId: string) => forkableAgentIds.includes(agentId),
+    [forkableAgentIds],
   );
 
   const handleForkSession = useCallback(

--- a/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
@@ -29,6 +29,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       index: 1,
       tabCount: 3,
       menuTestIDBase: "workspace-tab-context-agent_123",
+      onForkSession: vi.fn(),
+      canForkSession: () => false,
       onCopyResumeCommand,
       onCopyAgentId,
       onCopyFilePath,
@@ -59,6 +61,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       index: 1,
       tabCount: 3,
       menuTestIDBase: "workspace-tab-menu-agent_123",
+      onForkSession: vi.fn(),
+      canForkSession: () => false,
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
       onCopyFilePath: vi.fn(),
@@ -94,6 +98,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       index: 0,
       tabCount: 1,
       menuTestIDBase: "workspace-tab-menu-draft_123",
+      onForkSession: vi.fn(),
+      canForkSession: () => false,
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
       onCopyFilePath: vi.fn(),
@@ -122,6 +128,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       index: 0,
       tabCount: 1,
       menuTestIDBase: "workspace-tab-context-agent_123",
+      onForkSession: vi.fn(),
+      canForkSession: () => false,
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
       onCopyFilePath: vi.fn(),
@@ -151,6 +159,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       index: 0,
       tabCount: 1,
       menuTestIDBase: "workspace-tab-context-agent_123",
+      onForkSession: vi.fn(),
+      canForkSession: () => false,
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
       onCopyFilePath: vi.fn(),
@@ -185,6 +195,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       index: 0,
       tabCount: 1,
       menuTestIDBase: "workspace-tab-context-terminal_abc",
+      onForkSession: vi.fn(),
+      canForkSession: () => false,
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
       onCopyFilePath: vi.fn(),
@@ -225,6 +237,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       index: 0,
       tabCount: 1,
       menuTestIDBase: "workspace-tab-context-file_abc",
+      onForkSession: vi.fn(),
+      canForkSession: () => false,
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
       onCopyFilePath,
@@ -266,6 +280,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       index: 0,
       tabCount: 1,
       menuTestIDBase,
+      onForkSession: vi.fn(),
+      canForkSession: () => false,
       onCopyResumeCommand: vi.fn(),
       onCopyAgentId: vi.fn(),
       onCopyFilePath: vi.fn(),
@@ -310,5 +326,63 @@ describe("buildWorkspaceTabMenuEntries", () => {
       .find((entry) => entry.kind === "separator");
     expect(agentSeparator?.key).toBe("rename-separator");
     expect(terminalSeparator?.key).toBe("rename-separator");
+  });
+  it("offers fork session as the first agent action when the agent can be forked", () => {
+    const onForkSession = vi.fn();
+
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab: createAgentTab(),
+      index: 1,
+      tabCount: 3,
+      menuTestIDBase: "workspace-tab-context-agent_123",
+      onForkSession,
+      canForkSession: (agentId) => agentId === "agent-123",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    const forkEntry = entries[0];
+    if (forkEntry?.kind !== "item") {
+      throw new Error("Fork session entry missing");
+    }
+    expect(forkEntry.key).toBe("fork-session");
+    expect(forkEntry.label).toBe("Fork session");
+    expect(forkEntry.testID).toBe("workspace-tab-context-agent_123-fork-session");
+    expect(entries[1]).toEqual({ kind: "separator", key: "fork-session-separator" });
+
+    forkEntry.onSelect();
+    expect(onForkSession).toHaveBeenCalledWith("agent-123");
+  });
+
+  it("omits fork session when the agent cannot be forked", () => {
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab: createAgentTab(),
+      index: 1,
+      tabCount: 3,
+      menuTestIDBase: "workspace-tab-context-agent_123",
+      onForkSession: vi.fn(),
+      canForkSession: () => false,
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    expect(entries.some((entry) => entry.key === "fork-session")).toBe(false);
+    expect(entries.some((entry) => entry.key === "fork-session-separator")).toBe(false);
   });
 });

--- a/packages/app/src/screens/workspace/workspace-tab-menu.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.ts
@@ -6,6 +6,8 @@ import { buildDeterministicWorkspaceTabId } from "@/workspace-tabs/identity";
 export type WorkspaceTabMenuSurface = "desktop" | "mobile";
 
 export interface WorkspaceTabMenuLabels {
+  forkSession: string;
+  forkSessionTooltip: string;
   copyResumeCommand: string;
   copyAgentId: string;
   copyFilePath: string;
@@ -21,6 +23,8 @@ export interface WorkspaceTabMenuLabels {
 }
 
 export const DEFAULT_WORKSPACE_TAB_MENU_LABELS: WorkspaceTabMenuLabels = {
+  forkSession: i18n.t("workspace.tabs.menu.forkSession"),
+  forkSessionTooltip: i18n.t("workspace.tabs.menu.forkSessionTooltip"),
   copyResumeCommand: i18n.t("workspace.tabs.menu.copyResumeCommand"),
   copyAgentId: i18n.t("workspace.tabs.menu.copyAgentId"),
   copyFilePath: i18n.t("workspace.tabs.menu.copyFilePath"),
@@ -42,6 +46,7 @@ export type WorkspaceTabMenuEntry =
       label: string;
       icon?:
         | "copy"
+        | "git-branch"
         | "rotate-cw"
         | "arrow-left-to-line"
         | "arrow-right-to-line"
@@ -66,6 +71,8 @@ interface BuildWorkspaceTabMenuEntriesInput {
   index: number;
   tabCount: number;
   menuTestIDBase: string;
+  onForkSession: (agentId: string) => Promise<void> | void;
+  canForkSession: (agentId: string) => boolean;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
@@ -82,6 +89,8 @@ interface BuildWorkspaceDesktopTabActionsInput {
   tab: WorkspaceTabDescriptor;
   index: number;
   tabCount: number;
+  onForkSession: (agentId: string) => Promise<void> | void;
+  canForkSession: (agentId: string) => boolean;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
@@ -156,6 +165,8 @@ export function buildWorkspaceTabMenuEntries(
     index,
     tabCount,
     menuTestIDBase,
+    onForkSession,
+    canForkSession,
     onCopyResumeCommand,
     onCopyAgentId,
     onCopyFilePath,
@@ -174,6 +185,23 @@ export function buildWorkspaceTabMenuEntries(
 
   if (tab.target.kind === "agent") {
     const { agentId } = tab.target;
+    if (canForkSession(agentId)) {
+      entries.push({
+        kind: "item",
+        key: "fork-session",
+        label: labels.forkSession,
+        icon: "git-branch",
+        tooltip: labels.forkSessionTooltip,
+        testID: `${menuTestIDBase}-fork-session`,
+        onSelect: () => {
+          void onForkSession(agentId);
+        },
+      });
+      entries.push({
+        kind: "separator",
+        key: "fork-session-separator",
+      });
+    }
     entries.push({
       kind: "item",
       key: "copy-resume-command",
@@ -301,6 +329,8 @@ export function buildWorkspaceDesktopTabActions(
       index: input.index,
       tabCount: input.tabCount,
       menuTestIDBase: contextMenuTestId,
+      onForkSession: input.onForkSession,
+      canForkSession: input.canForkSession,
       onCopyResumeCommand: input.onCopyResumeCommand,
       onCopyAgentId: input.onCopyAgentId,
       onCopyFilePath: input.onCopyFilePath,

--- a/packages/app/src/stores/navigation-active-workspace-store/index.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/index.ts
@@ -36,8 +36,8 @@ function navigateDeps(): NavigateToWorkspaceDeps {
     getSessionWorkspaces: (serverId) => useSessionStore.getState().sessions[serverId]?.workspaces,
     getSessionAgents: (serverId) =>
       useSessionStore.getState().sessions[serverId]?.agents.values() ?? [],
-    openTabFocused: (workspaceKey, target) =>
-      useWorkspaceLayoutStore.getState().openTabFocused(workspaceKey, target),
+    openTabFocused: (workspaceKey, target, options) =>
+      useWorkspaceLayoutStore.getState().openTabFocused(workspaceKey, target, options),
     pinAgent: (workspaceKey, agentId) =>
       useWorkspaceLayoutStore.getState().pinAgent(workspaceKey, agentId),
     rememberLastWorkspace: (selection) => lastWorkspaceSelectionStore.remember(selection),

--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -83,6 +83,11 @@ interface InsertTabIntoPaneInput {
   paneId: string;
   tab: WorkspaceTab;
   focusTabId?: string | null;
+  /**
+   * Place the new tab directly after this tab instead of at the end of the
+   * pane. Ignored when the anchor is not in this pane.
+   */
+  insertAfterTabId?: string;
 }
 
 interface InsertSplitInternalInput {
@@ -102,6 +107,8 @@ interface OpenTabInLayoutInput {
   layout: WorkspaceLayout;
   target: WorkspaceTabTarget;
   now: number;
+  /** Place the new tab directly after this tab instead of at the end of the pane. */
+  insertAfterTabId?: string;
 }
 
 interface OpenTabInLayoutResult {
@@ -716,6 +723,20 @@ function detachTabFromTree(
   };
 }
 
+function insertTabAtAnchor(
+  tabs: readonly WorkspaceTab[],
+  tab: WorkspaceTab,
+  insertAfterTabId: string | undefined,
+): WorkspaceTab[] {
+  const anchorIndex = insertAfterTabId
+    ? tabs.findIndex((existing) => existing.tabId === insertAfterTabId)
+    : -1;
+  if (anchorIndex < 0) {
+    return [...tabs, tab];
+  }
+  return [...tabs.slice(0, anchorIndex + 1), tab, ...tabs.slice(anchorIndex + 1)];
+}
+
 function insertTabIntoPane(
   root: SplitNodeInternal,
   input: InsertTabIntoPaneInput,
@@ -728,7 +749,7 @@ function insertTabIntoPane(
     const nextTabs =
       existingIndex >= 0
         ? node.pane.tabs.map((tab, index) => (index === existingIndex ? input.tab : tab))
-        : [...node.pane.tabs, input.tab];
+        : insertTabAtAnchor(node.pane.tabs, input.tab, input.insertAfterTabId);
     return {
       kind: "pane",
       pane: normalizePaneAfterTabChange({
@@ -1074,6 +1095,7 @@ function insertNewTabIntoFocusedPane(input: {
   target: WorkspaceTabTarget;
   now: number;
   focus: boolean;
+  insertAfterTabId?: string;
 }): OpenTabInLayoutResult {
   const layout = asInternalLayout(input.layout);
   const focusedPane =
@@ -1098,6 +1120,7 @@ function insertNewTabIntoFocusedPane(input: {
         paneId: focusedPane.id,
         tab: nextTab,
         focusTabId: input.focus ? tabId : preservedFocusTabId,
+        ...(input.insertAfterTabId ? { insertAfterTabId: input.insertAfterTabId } : {}),
       }),
       focusedPaneId: input.focus ? focusedPane.id : layout.focusedPaneId,
       parentTabIdByTabId: input.layout.parentTabIdByTabId,

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -375,6 +375,40 @@ describe("workspace-layout-store actions", () => {
       "agent_agent-c",
     ]);
     expect(forkedTabId).toBe("agent_agent-a-fork");
+    // Inserting mid-pane must still hand focus to the new tab, not leave it on
+    // the anchor — the pane renders whichever tab the pane says is focused.
+    expect(findPaneById(layout.root, layout.focusedPaneId)?.focusedTabId).toBe(
+      "agent_agent-a-fork",
+    );
+  });
+
+  it("drops an agent tab whose agent the directory does not know yet", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-a" });
+    store.openTabFocused(
+      workspaceKey,
+      { kind: "agent", agentId: "agent-a-fork" },
+      { insertAfterTabId: "agent_agent-a" },
+    );
+
+    // Reconciling against a snapshot that predates the new agent prunes its tab
+    // and drops focus back to the surviving tab. Callers that open a tab for a
+    // freshly created agent must therefore publish the agent first.
+    store.reconcileTabs(workspaceKey, {
+      agentsHydrated: true,
+      terminalsHydrated: true,
+      activeAgentIds: ["agent-a"],
+      autoOpenAgentIds: ["agent-a"],
+      knownAgentIds: ["agent-a"],
+      standaloneTerminalIds: [],
+      hasActivePendingDraftCreate: false,
+    });
+
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+    expect(collectAllTabs(layout.root).map((tab) => tab.tabId)).toEqual(["agent_agent-a"]);
+    expect(findPaneById(layout.root, layout.focusedPaneId)?.focusedTabId).toBe("agent_agent-a");
   });
 
   it("places the tab at the end when the anchor is the last tab", () => {

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -353,6 +353,95 @@ describe("workspace-layout-store actions", () => {
     ]);
   });
 
+  it("inserts a tab directly to the right of the anchor tab", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-a" });
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-b" });
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-c" });
+
+    const forkedTabId = store.openTabFocused(
+      workspaceKey,
+      { kind: "agent", agentId: "agent-a-fork" },
+      { insertAfterTabId: "agent_agent-a" },
+    );
+
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+    expect(collectAllTabs(layout.root).map((tab) => tab.tabId)).toEqual([
+      "agent_agent-a",
+      "agent_agent-a-fork",
+      "agent_agent-b",
+      "agent_agent-c",
+    ]);
+    expect(forkedTabId).toBe("agent_agent-a-fork");
+  });
+
+  it("places the tab at the end when the anchor is the last tab", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-a" });
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-b" });
+
+    store.openTabFocused(
+      workspaceKey,
+      { kind: "agent", agentId: "agent-b-fork" },
+      { insertAfterTabId: "agent_agent-b" },
+    );
+
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+    expect(collectAllTabs(layout.root).map((tab) => tab.tabId)).toEqual([
+      "agent_agent-a",
+      "agent_agent-b",
+      "agent_agent-b-fork",
+    ]);
+  });
+
+  it("focuses the existing tab instead of re-inserting when the fork tab is already open", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-a" });
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-a-fork" });
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-b" });
+
+    const reopened = store.openTabFocused(
+      workspaceKey,
+      { kind: "agent", agentId: "agent-a-fork" },
+      { insertAfterTabId: "agent_agent-a" },
+    );
+
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+    expect(reopened).toBe("agent_agent-a-fork");
+    expect(collectAllTabs(layout.root).map((tab) => tab.tabId)).toEqual([
+      "agent_agent-a",
+      "agent_agent-a-fork",
+      "agent_agent-b",
+    ]);
+  });
+
+  it("appends when the anchor tab is not in the pane", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-a" });
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-b" });
+
+    store.openTabFocused(
+      workspaceKey,
+      { kind: "agent", agentId: "agent-c" },
+      { insertAfterTabId: "agent_does-not-exist" },
+    );
+
+    const layout = workspaceLayoutStore.getState().layoutByWorkspace[workspaceKey];
+    expect(collectAllTabs(layout.root).map((tab) => tab.tabId)).toEqual([
+      "agent_agent-a",
+      "agent_agent-b",
+      "agent_agent-c",
+    ]);
+  });
+
   it("updates an existing file tab when opening the same path at a new line range", () => {
     const workspaceKey = createWorkspaceKey();
     const store = workspaceLayoutStore.getState();

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -71,13 +71,25 @@ export type {
   WorkspaceTabSnapshot,
 };
 
+export interface OpenTabPlacementOptions {
+  /**
+   * Place the new tab directly to the right of this tab instead of at the end
+   * of the pane. Ignored when the anchor tab is not in the target pane.
+   */
+  insertAfterTabId?: string;
+}
+
 interface WorkspaceLayoutStore {
   layoutByWorkspace: Record<string, WorkspaceLayout>;
   splitSizesByWorkspace: Record<string, Record<string, number[]>>;
   pinnedAgentIdsByWorkspace: Record<string, Set<string>>;
   hiddenAgentIdsByWorkspace: Record<string, Set<string>>;
   focusRestorationByWorkspace: Record<string, WorkspaceFocusRestorationState>;
-  openTabFocused: (workspaceKey: string, target: WorkspaceTabTarget) => string | null;
+  openTabFocused: (
+    workspaceKey: string,
+    target: WorkspaceTabTarget,
+    options?: OpenTabPlacementOptions,
+  ) => string | null;
   openChildTabFocused: (
     workspaceKey: string,
     target: WorkspaceTabTarget,
@@ -231,17 +243,19 @@ export function createWorkspaceLayoutStore(
         pinnedAgentIdsByWorkspace: {},
         hiddenAgentIdsByWorkspace: {},
         focusRestorationByWorkspace: {},
-        openTabFocused: (workspaceKey, target) => {
+        openTabFocused: (workspaceKey, target, options) => {
           const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
           const normalizedTarget = normalizeWorkspaceTabTarget(target);
           if (!normalizedWorkspaceKey || !normalizedTarget) {
             return null;
           }
 
+          const insertAfterTabId = trimNonEmpty(options?.insertAfterTabId ?? "");
           const result = openTabInLayoutFocused({
             layout: getWorkspaceLayout(get().layoutByWorkspace, normalizedWorkspaceKey),
             target: normalizedTarget,
             now: Date.now(),
+            ...(insertAfterTabId ? { insertAfterTabId } : {}),
           });
 
           set((state) => ({

--- a/packages/app/src/utils/prepare-workspace-tab.ts
+++ b/packages/app/src/utils/prepare-workspace-tab.ts
@@ -1,3 +1,4 @@
+import type { OpenTabPlacementOptions } from "@/stores/workspace-layout-store";
 import { generateDraftId } from "@/stores/draft-keys";
 import {
   buildWorkspaceTabPersistenceKey,
@@ -9,10 +10,16 @@ export interface PrepareWorkspaceTabInput {
   workspaceId: string;
   target: WorkspaceTabTarget;
   pin?: boolean;
+  /** Open the tab directly to the right of this tab instead of at the end. */
+  insertAfterTabId?: string;
 }
 
 export interface PrepareWorkspaceTabDeps {
-  openTabFocused: (workspaceKey: string, target: WorkspaceTabTarget) => string | null;
+  openTabFocused: (
+    workspaceKey: string,
+    target: WorkspaceTabTarget,
+    options?: OpenTabPlacementOptions,
+  ) => string | null;
   pinAgent: (workspaceKey: string, agentId: string) => void;
 }
 
@@ -34,7 +41,11 @@ export function prepareWorkspaceTab(
       workspaceId: input.workspaceId,
     }) ?? "";
 
-  deps.openTabFocused(key, target);
+  deps.openTabFocused(
+    key,
+    target,
+    input.insertAfterTabId ? { insertAfterTabId: input.insertAfterTabId } : undefined,
+  );
 
   if (input.pin && target.kind === "agent") {
     deps.pinAgent(key, target.agentId);

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -2341,6 +2341,97 @@ test("sends structured first-agent context attachments with create_paseo_worktre
   });
 });
 
+test("forkAgentSession resolves with the forked agent id", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const forkPromise = client.forkAgentSession({ agentId: "agent-source" });
+
+  expect(mock.sent).toHaveLength(1);
+  const sent = parseSentFrame(mock.sent[0]) as {
+    type: string;
+    requestId: string;
+    agentId: string;
+    workspaceId?: string;
+  };
+  expect(sent.type).toBe("agent.session.fork.request");
+  expect(sent.agentId).toBe("agent-source");
+  // workspaceId is omitted rather than sent as undefined so the daemon falls
+  // back to the source agent's workspace.
+  expect("workspaceId" in sent).toBe(false);
+
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "agent.session.fork.response",
+      payload: {
+        requestId: sent.requestId,
+        agentId: "agent-source",
+        forkedAgentId: "agent-fork",
+        ok: true,
+        error: null,
+      },
+    }),
+  );
+
+  await expect(forkPromise).resolves.toBe("agent-fork");
+});
+
+test("forkAgentSession rejects with the daemon's failure reason", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const forkPromise = client.forkAgentSession({
+    agentId: "agent-source",
+    workspaceId: "ws-1",
+  });
+
+  const sent = parseSentFrame(mock.sent[0]) as { requestId: string; workspaceId?: string };
+  expect(sent.workspaceId).toBe("ws-1");
+
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "agent.session.fork.response",
+      payload: {
+        requestId: sent.requestId,
+        agentId: "agent-source",
+        forkedAgentId: null,
+        ok: false,
+        error: "Provider 'opencode' does not support forking sessions",
+      },
+    }),
+  );
+
+  await expect(forkPromise).rejects.toThrow(
+    "Provider 'opencode' does not support forking sessions",
+  );
+});
+
 test("sends project.add.request without creating a workspace", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -2886,6 +2886,38 @@ export class DaemonClient {
     return payload;
   }
 
+  /**
+   * Branch an agent's provider session into a new agent seeded with a full copy
+   * of the transcript. Returns the id of the newly created agent.
+   */
+  async forkAgentSession(input: { agentId: string; workspaceId?: string }): Promise<string> {
+    const requestId = this.createRequestId();
+    const message = SessionInboundMessageSchema.parse({
+      type: "agent.session.fork.request",
+      requestId,
+      agentId: input.agentId,
+      ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+    });
+    const payload = await this.sendRequest({
+      requestId,
+      message,
+      options: { skipQueue: true },
+      select: (msg) => {
+        if (msg.type !== "agent.session.fork.response") {
+          return null;
+        }
+        if (msg.payload.requestId !== requestId) {
+          return null;
+        }
+        return msg.payload;
+      },
+    });
+    if (!payload.ok || !payload.forkedAgentId) {
+      throw new Error(payload.error ?? "Agent session fork failed");
+    }
+    return payload.forkedAgentId;
+  }
+
   async cancelAgent(agentId: string): Promise<void> {
     const requestId = this.createRequestId();
     const message = SessionInboundMessageSchema.parse({

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1491,6 +1491,24 @@ export const AgentRewindResponseMessageSchema = z.object({
   }),
 });
 
+export const AgentSessionForkRequestMessageSchema = z.object({
+  type: z.literal("agent.session.fork.request"),
+  agentId: z.string(),
+  workspaceId: z.string().optional(),
+  requestId: z.string(),
+});
+
+export const AgentSessionForkResponseMessageSchema = z.object({
+  type: z.literal("agent.session.fork.response"),
+  payload: z.object({
+    requestId: z.string(),
+    agentId: z.string(),
+    forkedAgentId: z.string().nullable(),
+    ok: z.boolean(),
+    error: z.string().nullable(),
+  }),
+});
+
 export const UpdateAgentResponseMessageSchema = z.object({
   type: z.literal("update_agent_response"),
   payload: AgentActionResponsePayloadSchema,
@@ -2465,6 +2483,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   SetAgentFeatureRequestMessageSchema,
   AgentDetachRequestMessageSchema,
   AgentRewindRequestMessageSchema,
+  AgentSessionForkRequestMessageSchema,
   AgentPermissionResponseMessageSchema,
   CheckoutStatusRequestSchema,
   SubscribeCheckoutDiffRequestSchema,
@@ -2762,6 +2781,8 @@ export const ServerInfoStatusPayloadSchema = z
         agentForkContext: z.boolean().optional(),
         // COMPAT(agentForkContextCursor): added in v0.1.108, remove gate after 2027-01-14.
         agentForkContextCursor: z.boolean().optional(),
+        // COMPAT(agentSessionFork): added in v0.1.109, remove gate after 2027-01-21.
+        agentSessionFork: z.boolean().optional(),
         // COMPAT(providerSubagents): added in v0.1.107, remove gate after 2027-01-12.
         providerSubagents: z.boolean().optional(),
         // COMPAT(workspacePinning): added in v0.1.107, remove gate after 2027-01-12.
@@ -5148,6 +5169,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   SetAgentFeatureResponseMessageSchema,
   AgentDetachResponseMessageSchema,
   AgentRewindResponseMessageSchema,
+  AgentSessionForkResponseMessageSchema,
   UpdateAgentResponseMessageSchema,
   ProjectRenameResponseSchema,
   ProjectRemoveResponseSchema,
@@ -5319,6 +5341,8 @@ export type SetAgentThinkingResponseMessage = z.infer<typeof SetAgentThinkingRes
 export type SetAgentFeatureResponseMessage = z.infer<typeof SetAgentFeatureResponseMessageSchema>;
 export type AgentDetachResponseMessage = z.infer<typeof AgentDetachResponseMessageSchema>;
 export type AgentRewindResponseMessage = z.infer<typeof AgentRewindResponseMessageSchema>;
+export type AgentSessionForkRequestMessage = z.infer<typeof AgentSessionForkRequestMessageSchema>;
+export type AgentSessionForkResponseMessage = z.infer<typeof AgentSessionForkResponseMessageSchema>;
 export type UpdateAgentResponseMessage = z.infer<typeof UpdateAgentResponseMessageSchema>;
 export type ProjectRenameResponse = z.infer<typeof ProjectRenameResponseSchema>;
 export type ProjectRemoveResponse = z.infer<typeof ProjectRemoveResponseSchema>;

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -2721,6 +2721,63 @@ test("forkAgentSession branches the source session into a new agent with the cop
   expect(manager.getAgent(source.id)?.lifecycle).toBe("idle");
 });
 
+test("forkAgentSession carries the source model, thinking level, and mode onto the fork", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-fork-config-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const forkedSession = new TestAgentSession({ provider: "codex", cwd: workdir });
+
+  class ForkConfigClient extends TestAgentClient {
+    async forkSession(input: ForkProviderSessionInput) {
+      return { providerHandleId: `${input.providerHandleId}-fork` };
+    }
+
+    // Echo the config the manager hands in, exactly as the real shared import
+    // helper does (`importSessionFromPersistence` returns `storedConfig`). A
+    // fake that returns a hardcoded config would hide this bug entirely.
+    async importSession(input: ImportProviderSessionInput, context: ImportProviderSessionContext) {
+      return {
+        session: forkedSession,
+        config: { ...context.storedConfig, provider: "codex" as const, cwd: input.cwd },
+        persistence: {
+          provider: "codex" as const,
+          sessionId: input.providerHandleId,
+          nativeHandle: input.providerHandleId,
+          metadata: { provider: "codex", cwd: input.cwd },
+        },
+        timeline: [],
+        providerSubagentEvents: [],
+      };
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new ForkConfigClient() },
+    registry: storage,
+    logger,
+  });
+
+  const source = await manager.createAgent(
+    {
+      provider: "codex",
+      cwd: workdir,
+      model: "gpt-5.4-mini",
+      thinkingOptionId: "low",
+      modeId: "full-access",
+    },
+    undefined,
+    { workspaceId: "ws-fork-config" },
+  );
+
+  const forked = await manager.forkAgentSession({ agentId: source.id });
+
+  // Forking must not silently move the user onto a different model, thinking
+  // level, or permission mode — that changes both cost and safety posture.
+  expect(forked.config.model).toBe("gpt-5.4-mini");
+  expect(forked.config.thinkingOptionId).toBe("low");
+  expect(forked.config.modeId).toBe("full-access");
+});
+
 test("forkAgentSession rejects providers that cannot fork", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-fork-unsupported-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -34,6 +34,7 @@ import type {
   AgentSlashCommand,
   AgentStreamEvent,
   AgentTimelineItem,
+  ForkProviderSessionInput,
   ImportProviderSessionInput,
   ResolveAgentDefaultModeInput,
 } from "./agent-sdk-types.js";
@@ -2637,6 +2638,128 @@ test("importProviderSession imports the selected session without listing and pub
     },
   });
   expect((await storage.get(imported.id))?.title).toBe("Trace provider imports");
+});
+
+test("forkAgentSession branches the source session into a new agent with the copied transcript", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-fork-session-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const sourceSession = new TestAgentSession({ provider: "codex", cwd: workdir });
+  const forkedSession = new TestAgentSession({ provider: "codex", cwd: workdir });
+
+  class ForkClient extends TestAgentClient {
+    forkInput: ForkProviderSessionInput | null = null;
+    importInput: ImportProviderSessionInput | null = null;
+
+    async forkSession(input: ForkProviderSessionInput) {
+      this.forkInput = input;
+      return { providerHandleId: `${input.providerHandleId}-fork` };
+    }
+
+    async importSession(input: ImportProviderSessionInput) {
+      this.importInput = input;
+      return {
+        // The fork is a genuinely separate provider session, so it gets its own
+        // AgentSession rather than sharing the source agent's.
+        session: input.providerHandleId.endsWith("-fork") ? forkedSession : sourceSession,
+        config: { provider: "codex" as const, cwd: workdir },
+        persistence: {
+          provider: "codex" as const,
+          sessionId: input.providerHandleId,
+          nativeHandle: input.providerHandleId,
+          metadata: { provider: "codex", cwd: workdir },
+        },
+        timeline: [
+          {
+            item: { type: "user_message" as const, text: "Original prompt" },
+            timestamp: "2026-01-02T00:00:00.000Z",
+          },
+          {
+            item: { type: "assistant_message" as const, text: "Original answer" },
+            timestamp: "2026-01-02T00:00:01.000Z",
+          },
+        ],
+        providerSubagentEvents: [],
+      };
+    }
+  }
+
+  const client = new ForkClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+  });
+
+  const source = await manager.importProviderSession({
+    provider: "codex",
+    providerHandleId: "thread-source",
+    cwd: workdir,
+    workspaceId: "ws-fork",
+    labels: { surface: "workspace" },
+  });
+
+  const forked = await manager.forkAgentSession({ agentId: source.id });
+
+  // The provider is asked to branch the source session id, and the resulting
+  // brand-new handle is what gets imported as a separate agent.
+  expect(client.forkInput?.providerHandleId).toBe("thread-source");
+  expect(client.importInput?.providerHandleId).toBe("thread-source-fork");
+
+  expect(forked.id).not.toBe(source.id);
+  expect(forked.persistence?.sessionId).toBe("thread-source-fork");
+  expect(forked.workspaceId).toBe("ws-fork");
+  expect(forked.labels).toEqual({ surface: "workspace" });
+  expect(forked.historyPrimed).toBe(true);
+  expect(manager.getTimeline(forked.id)).toEqual([
+    { type: "user_message", text: "Original prompt" },
+    { type: "assistant_message", text: "Original answer" },
+  ]);
+
+  // The source agent is left untouched — fork is non-destructive.
+  expect(manager.getAgent(source.id)?.persistence?.sessionId).toBe("thread-source");
+  expect(manager.getAgent(source.id)?.lifecycle).toBe("idle");
+});
+
+test("forkAgentSession rejects providers that cannot fork", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-fork-unsupported-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const session = new TestAgentSession({ provider: "codex", cwd: workdir });
+
+  class NoForkClient extends TestAgentClient {
+    async importSession(input: ImportProviderSessionInput) {
+      return {
+        session,
+        config: { provider: "codex" as const, cwd: workdir },
+        persistence: {
+          provider: "codex" as const,
+          sessionId: input.providerHandleId,
+          nativeHandle: input.providerHandleId,
+          metadata: { provider: "codex", cwd: workdir },
+        },
+        timeline: [],
+        providerSubagentEvents: [],
+      };
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new NoForkClient() },
+    registry: storage,
+    logger,
+  });
+
+  const source = await manager.importProviderSession({
+    provider: "codex",
+    providerHandleId: "thread-source",
+    cwd: workdir,
+    workspaceId: "ws-fork",
+  });
+
+  await expect(manager.forkAgentSession({ agentId: source.id })).rejects.toThrow(
+    "does not support forking sessions",
+  );
 });
 
 test("reloadAgentSession passes daemon launch env through the provider launch context", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -130,6 +130,25 @@ function formatProviderList(providers: readonly string[]): string {
   return providers.length > 0 ? providers.join(", ") : "none";
 }
 
+/**
+ * Config a forked agent should start from: everything the source agent was
+ * running with, minus the fields that identify a specific agent rather than
+ * describe how it runs.
+ *
+ * `title` is dropped so the fork derives its own from the copied transcript
+ * instead of impersonating the source tab, and `daemonAppendSystemPrompt` is
+ * dropped because it is reapplied from current daemon settings on launch and is
+ * deliberately never persisted into agent config.
+ */
+function buildForkedSessionConfig(sourceConfig: AgentSessionConfig): AgentSessionConfig {
+  const {
+    title: _title,
+    daemonAppendSystemPrompt: _daemonAppendSystemPrompt,
+    ...rest
+  } = sourceConfig;
+  return rest;
+}
+
 function buildStoredAgentConfig(record: StoredAgentRecord): AgentSessionConfig {
   const config: AgentSessionConfig = {
     provider: record.provider,
@@ -1188,6 +1207,11 @@ export class AgentManager {
       cwd: source.cwd,
       workspaceId,
       labels: input.labels ?? source.labels,
+      // A fork continues the source conversation, so it has to keep the source's
+      // model, thinking level, permission mode, and the rest of its runtime
+      // settings. Dropping them silently moves the user onto a different model
+      // and permission posture mid-conversation.
+      config: buildForkedSessionConfig(source.config),
     });
     this.logger.info(
       {
@@ -1207,6 +1231,13 @@ export class AgentManager {
     cwd: string;
     workspaceId: string;
     labels?: Record<string, string>;
+    /**
+     * Config to start the imported agent with. Plain imports have no prior
+     * agent to copy from and so fall back to provider defaults, but a fork
+     * continues an existing conversation and must keep running it the way the
+     * source did.
+     */
+    config?: AgentSessionConfig;
   }): Promise<ManagedAgent> {
     this.assertAcceptingAgentRegistrations();
     const resolvedAgentId = validateAgentId(this.idFactory(), "importProviderSession");
@@ -1219,6 +1250,7 @@ export class AgentManager {
 
     const { storedConfig, launchConfig } = await this.prepareSessionConfig(
       {
+        ...input.config,
         provider: input.provider,
         cwd: input.cwd,
       },

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1139,6 +1139,68 @@ export class AgentManager {
     return this.trackAgentRegistrationOperation(this.importProviderSessionInternal(input));
   }
 
+  /**
+   * Branch an existing agent's provider session into a brand new agent that
+   * starts with a full copy of the transcript. The source agent keeps running
+   * against its own session; the two diverge from here.
+   */
+  forkAgentSession(input: {
+    agentId: string;
+    workspaceId?: string;
+    labels?: Record<string, string>;
+  }): Promise<ManagedAgent> {
+    return this.trackAgentRegistrationOperation(this.forkAgentSessionInternal(input));
+  }
+
+  private async forkAgentSessionInternal(input: {
+    agentId: string;
+    workspaceId?: string;
+    labels?: Record<string, string>;
+  }): Promise<ManagedAgent> {
+    const source = this.requireAgent(input.agentId);
+    const sourceSessionId = source.persistence?.sessionId;
+    if (!sourceSessionId) {
+      throw new Error(`Agent '${source.id}' has no provider session to fork`);
+    }
+    const workspaceId = input.workspaceId ?? source.workspaceId;
+    if (!workspaceId) {
+      throw new Error(`Agent '${source.id}' has no workspace to fork into`);
+    }
+
+    const client = await this.requireAvailableClient({ provider: source.provider });
+    if (!client.forkSession) {
+      throw new Error(`Provider '${source.provider}' does not support forking sessions`);
+    }
+
+    this.logger.info(
+      { agentId: source.id, provider: source.provider, sessionId: sourceSessionId },
+      "agent.fork.start",
+    );
+    const forked = await client.forkSession({
+      providerHandleId: sourceSessionId,
+      cwd: source.cwd,
+      config: source.config,
+    });
+
+    const agent = await this.importProviderSessionInternal({
+      provider: source.provider,
+      providerHandleId: forked.providerHandleId,
+      cwd: source.cwd,
+      workspaceId,
+      labels: input.labels ?? source.labels,
+    });
+    this.logger.info(
+      {
+        agentId: source.id,
+        forkedAgentId: agent.id,
+        provider: source.provider,
+        sessionId: forked.providerHandleId,
+      },
+      "agent.fork.complete",
+    );
+    return agent;
+  }
+
   private async importProviderSessionInternal(input: {
     provider: AgentProvider;
     providerHandleId: string;

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -178,6 +178,7 @@ export interface AgentCapabilityFlags {
   supportsRewindConversation?: boolean;
   supportsRewindFiles?: boolean;
   supportsRewindBoth?: boolean;
+  supportsForkSession?: boolean;
 }
 
 export interface AgentPersistenceHandle {
@@ -531,6 +532,19 @@ export interface ImportProviderSessionInput {
   cwd: string;
 }
 
+export interface ForkProviderSessionInput {
+  /** Provider handle id of the session being branched. */
+  providerHandleId: string;
+  cwd: string;
+  /** Config of the source agent, used by providers that require it to fork. */
+  config?: AgentSessionConfig;
+}
+
+export interface ForkedProviderSession {
+  /** Provider handle id of the newly created session. */
+  providerHandleId: string;
+}
+
 export interface ImportProviderSessionContext {
   config: AgentSessionConfig;
   storedConfig: AgentSessionConfig;
@@ -708,6 +722,13 @@ export interface AgentClient {
     input: ImportProviderSessionInput,
     context: ImportProviderSessionContext,
   ): Promise<ImportedProviderSession>;
+  /**
+   * Branch a durable native session into a brand new one that starts with a full
+   * copy of the source transcript. Non-destructive: the source session is left
+   * untouched and both sides diverge independently from the fork point.
+   * Returns the provider handle id of the new session.
+   */
+  forkSession?(input: ForkProviderSessionInput): Promise<ForkedProviderSession>;
   /**
    * Check if this provider is available (CLI binary is installed).
    * Returns true if available, false otherwise.

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -52,6 +52,7 @@ import { appendOrReplaceGrowingAssistantMessage, runProviderTurn } from "../prov
 import { renderPromptAttachmentAsText } from "../../prompt-attachments.js";
 import { claudeQuery, type ClaudeOptions, type ClaudeQueryFactory } from "./query.js";
 import { realClaudeRewindSdk, revertClaudeConversation, revertClaudeFiles } from "./rewind.js";
+import { forkClaudeSession, realClaudeSessionForkSdk } from "./session-fork.js";
 import { normalizeProviderReplayTimestamp } from "../../provider-history-timestamps.js";
 import { claudeProjectDirSync } from "./project-dir.js";
 import { THINKING_APPLIES_NEXT_TURN_NOTICE } from "../../provider-notices.js";
@@ -89,6 +90,8 @@ import {
   type AgentUsage,
   type AgentRuntimeInfo,
   type FetchCatalogOptions,
+  type ForkedProviderSession,
+  type ForkProviderSessionInput,
   type ImportableProviderSession,
   type ImportProviderSessionContext,
   type ImportProviderSessionInput,
@@ -282,6 +285,7 @@ const CLAUDE_CAPABILITIES: AgentCapabilityFlags = {
   supportsRewindConversation: true,
   supportsRewindFiles: true,
   supportsRewindBoth: true,
+  supportsForkSession: true,
 };
 
 const DEFAULT_MODES: AgentMode[] = [
@@ -1560,6 +1564,14 @@ export class ClaudeAgentClient implements AgentClient {
       context,
       resumeSession: this.resumeSession.bind(this),
     });
+  }
+
+  async forkSession(input: ForkProviderSessionInput): Promise<ForkedProviderSession> {
+    const fork = await forkClaudeSession({
+      sdk: realClaudeSessionForkSdk,
+      sessionId: input.providerHandleId,
+    });
+    return { providerHandleId: fork.sessionId };
   }
 
   async isAvailable(): Promise<boolean> {

--- a/packages/server/src/server/agent/providers/claude/session-fork.test.ts
+++ b/packages/server/src/server/agent/providers/claude/session-fork.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { forkClaudeSession, type ClaudeSessionForkSdk } from "./session-fork.js";
+
+describe("forkClaudeSession", () => {
+  test("copies the whole transcript rather than slicing it like rewind does", async () => {
+    const forkSession = vi.fn().mockResolvedValue({ sessionId: "session-fork" });
+    const sdk: ClaudeSessionForkSdk = { forkSession };
+
+    const result = await forkClaudeSession({ sdk, sessionId: "session-source" });
+
+    expect(result).toEqual({ sessionId: "session-fork" });
+    expect(forkSession).toHaveBeenCalledTimes(1);
+    // Rewind passes upToMessageId to branch mid-conversation. A tab fork must
+    // not, or the new agent silently loses the tail of the transcript.
+    expect(forkSession).toHaveBeenCalledWith("session-source");
+  });
+
+  test("throws instead of forking when the source session is not ready", async () => {
+    const forkSession = vi.fn();
+    const sdk: ClaudeSessionForkSdk = { forkSession };
+
+    await expect(forkClaudeSession({ sdk, sessionId: null })).rejects.toThrow(
+      "Claude session is not ready to fork",
+    );
+    expect(forkSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/server/agent/providers/claude/session-fork.ts
+++ b/packages/server/src/server/agent/providers/claude/session-fork.ts
@@ -1,0 +1,26 @@
+import { forkSession as claudeForkSession } from "@anthropic-ai/claude-agent-sdk";
+
+export interface ClaudeSessionForkSdk {
+  forkSession(sessionId: string, options?: { title?: string }): Promise<{ sessionId: string }>;
+}
+
+export const realClaudeSessionForkSdk: ClaudeSessionForkSdk = {
+  forkSession: claudeForkSession,
+};
+
+/**
+ * Branch a Claude session into a new one holding a full copy of the transcript.
+ *
+ * Deliberately omits `upToMessageId` (rewind's fork slices the transcript; this
+ * one copies all of it) and `dir`, so the SDK searches every project directory
+ * for the session file — the same resolution rewind relies on.
+ */
+export async function forkClaudeSession(input: {
+  sdk: ClaudeSessionForkSdk;
+  sessionId: string | null;
+}): Promise<{ sessionId: string }> {
+  if (!input.sessionId) {
+    throw new Error("Claude session is not ready to fork");
+  }
+  return input.sdk.forkSession(input.sessionId);
+}

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -421,6 +421,44 @@ function createSessionForTest(options: SessionForTestOptions = {}): Session {
 }
 
 describe("agent session fork", () => {
+  test("publishes the forked agent to the client before answering the request", async () => {
+    const messages: SessionOutboundMessage[] = [];
+    const forkAgentSession = vi.fn().mockResolvedValue({ id: "agent-fork" });
+
+    const session = createSessionForTest({
+      messages,
+      agentManager: { forkAgentSession },
+    });
+
+    const forwardedAgentIds: string[] = [];
+    let releaseForward: () => void = () => {};
+    asSessionInternalsHelper<{
+      agentUpdates: { forwardLiveAgent: (agent: { id: string }) => Promise<void> };
+    }>(session).agentUpdates.forwardLiveAgent = async (agent) => {
+      forwardedAgentIds.push(agent.id);
+      await new Promise<void>((resolve) => {
+        releaseForward = resolve;
+      });
+    };
+
+    const handled = session.handleMessage({
+      type: "agent.session.fork.request",
+      agentId: "agent-source",
+      requestId: "fork-ordering",
+    });
+
+    await vi.waitFor(() => expect(forwardedAgentIds).toEqual(["agent-fork"]));
+    // The client opens and focuses a tab for the forked agent the instant this
+    // response lands, and its tab reconcile prunes agent tabs for agents the
+    // directory does not know yet. Answering first drops that tab and leaves
+    // the source agent focused, so the next turn runs on the source session.
+    expect(messages).toEqual([]);
+
+    releaseForward();
+    await handled;
+    expect(messages.map((message) => message.type)).toEqual(["agent.session.fork.response"]);
+  });
+
   test("forks the agent and returns the new agent id", async () => {
     const messages: SessionOutboundMessage[] = [];
     const forkAgentSession = vi.fn().mockResolvedValue({ id: "agent-fork" });

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -420,6 +420,73 @@ function createSessionForTest(options: SessionForTestOptions = {}): Session {
   return new Session(sessionOptions);
 }
 
+describe("agent session fork", () => {
+  test("forks the agent and returns the new agent id", async () => {
+    const messages: SessionOutboundMessage[] = [];
+    const forkAgentSession = vi.fn().mockResolvedValue({ id: "agent-fork" });
+
+    const session = createSessionForTest({
+      messages,
+      agentManager: { forkAgentSession },
+    });
+
+    await session.handleMessage({
+      type: "agent.session.fork.request",
+      agentId: "agent-source",
+      workspaceId: "ws-1",
+      requestId: "fork-1",
+    });
+
+    expect(forkAgentSession).toHaveBeenCalledWith({
+      agentId: "agent-source",
+      workspaceId: "ws-1",
+    });
+    expect(messages).toEqual([
+      {
+        type: "agent.session.fork.response",
+        payload: {
+          requestId: "fork-1",
+          agentId: "agent-source",
+          forkedAgentId: "agent-fork",
+          ok: true,
+          error: null,
+        },
+      },
+    ]);
+  });
+
+  test("reports the provider failure reason instead of throwing", async () => {
+    const messages: SessionOutboundMessage[] = [];
+    const forkAgentSession = vi
+      .fn()
+      .mockRejectedValue(new Error("Provider 'opencode' does not support forking sessions"));
+
+    const session = createSessionForTest({
+      messages,
+      agentManager: { forkAgentSession },
+    });
+
+    await session.handleMessage({
+      type: "agent.session.fork.request",
+      agentId: "agent-source",
+      requestId: "fork-2",
+    });
+
+    expect(messages).toEqual([
+      {
+        type: "agent.session.fork.response",
+        payload: {
+          requestId: "fork-2",
+          agentId: "agent-source",
+          forkedAgentId: null,
+          ok: false,
+          error: "Provider 'opencode' does not support forking sessions",
+        },
+      },
+    ]);
+  });
+});
+
 describe("session authorization scopes", () => {
   test("rejects an RPC outside an exact grant with the generic RPC error", async () => {
     const messages: SessionOutboundMessage[] = [];

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1789,6 +1789,8 @@ export class Session {
         return this.handleResumeAgentRequest(msg);
       case "import_agent_request":
         return this.handleImportAgentRequest(msg);
+      case "agent.session.fork.request":
+        return this.handleAgentSessionForkRequest(msg);
       case "refresh_agent_request":
         return this.handleRefreshAgentRequest(msg);
       case "cancel_agent_request":
@@ -3275,6 +3277,43 @@ export class Session {
       } else {
         this.handleAgentRunError(agentId, error, "Failed to cancel running agent on request");
       }
+    }
+  }
+
+  private async handleAgentSessionForkRequest(
+    msg: Extract<SessionInboundMessage, { type: "agent.session.fork.request" }>,
+  ): Promise<void> {
+    try {
+      const forked = await this.agentManager.forkAgentSession({
+        agentId: msg.agentId,
+        workspaceId: msg.workspaceId,
+      });
+      this.emit({
+        type: "agent.session.fork.response",
+        payload: {
+          requestId: msg.requestId,
+          agentId: msg.agentId,
+          forkedAgentId: forked.id,
+          ok: true,
+          error: null,
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to fork agent session";
+      this.sessionLogger.error(
+        { err: error, agentId: msg.agentId },
+        "Failed to fork agent session",
+      );
+      this.emit({
+        type: "agent.session.fork.response",
+        payload: {
+          requestId: msg.requestId,
+          agentId: msg.agentId,
+          forkedAgentId: null,
+          ok: false,
+          error: message,
+        },
+      });
     }
   }
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -3288,6 +3288,12 @@ export class Session {
         agentId: msg.agentId,
         workspaceId: msg.workspaceId,
       });
+      // The forked agent has to reach the client's agent directory *before* the
+      // response does. The client opens and focuses a tab for the returned id
+      // as soon as this resolves, and its tab reconcile prunes agent tabs whose
+      // agent it does not know yet — which silently drops the fresh tab and
+      // leaves focus on the source agent.
+      await this.agentUpdates.forwardLiveAgent(forked);
       this.emit({
         type: "agent.session.fork.response",
         payload: {

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1394,6 +1394,8 @@ export class VoiceAssistantWebSocketServer {
         agentForkContext: true,
         // COMPAT(agentForkContextCursor): added in v0.1.108, remove gate after 2027-01-14.
         agentForkContextCursor: true,
+        // COMPAT(agentSessionFork): added in v0.1.109, remove gate after 2027-01-21.
+        agentSessionFork: true,
         // COMPAT(providerSubagents): added in v0.1.107, remove gate after 2027-01-12.
         providerSubagents: true,
         // COMPAT(workspacePinning): added in v0.1.107, remove gate after 2027-01-12.

--- a/packages/server/src/server/wire-compat.test.ts
+++ b/packages/server/src/server/wire-compat.test.ts
@@ -560,6 +560,129 @@ describe("wire compatibility", () => {
     expect(parsed.capabilities.supportsRewindBoth).toBe(false);
   });
 
+  test("old clients drop the fork-session capability instead of rejecting the snapshot", () => {
+    // supportsForkSession rides the capabilities catchall, so a daemon that
+    // advertises it must still parse against a client built before it existed.
+    const parsed = LegacyAgentSnapshotPayloadSchema.parse({
+      id: "agent-1",
+      provider: "claude",
+      cwd: "/tmp/project",
+      model: null,
+      thinkingOptionId: null,
+      effectiveThinkingOptionId: null,
+      createdAt: "2026-05-23T00:00:00.000Z",
+      updatedAt: "2026-05-23T00:00:00.000Z",
+      lastUserMessageAt: null,
+      status: "idle",
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+        supportsForkSession: true,
+      },
+      currentModeId: null,
+      availableModes: [],
+      pendingPermissions: [],
+      persistence: null,
+      title: null,
+      labels: {},
+    });
+
+    expect(parsed.capabilities).toEqual({
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    });
+  });
+
+  test("new clients parse agent snapshots without the fork-session capability", () => {
+    const parsed = AgentSnapshotPayloadSchema.parse({
+      id: "agent-1",
+      provider: "claude",
+      cwd: "/tmp/project",
+      model: null,
+      thinkingOptionId: null,
+      effectiveThinkingOptionId: null,
+      createdAt: "2026-05-23T00:00:00.000Z",
+      updatedAt: "2026-05-23T00:00:00.000Z",
+      lastUserMessageAt: null,
+      status: "idle",
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      currentModeId: null,
+      availableModes: [],
+      pendingPermissions: [],
+      persistence: null,
+      title: null,
+      labels: {},
+    });
+
+    // Absent means "cannot fork", which is what gates the tab action off.
+    expect(parsed.capabilities.supportsForkSession).toBeUndefined();
+  });
+
+  test("agent.session.fork messages round-trip in both directions", () => {
+    const request = SessionInboundMessageSchema.parse({
+      type: "agent.session.fork.request",
+      agentId: "agent-source",
+      workspaceId: "ws-1",
+      requestId: "fork-1",
+    });
+    expect(request).toEqual({
+      type: "agent.session.fork.request",
+      agentId: "agent-source",
+      workspaceId: "ws-1",
+      requestId: "fork-1",
+    });
+
+    // workspaceId is optional: an older client omits it and the daemon falls
+    // back to the source agent's workspace.
+    expect(
+      SessionInboundMessageSchema.parse({
+        type: "agent.session.fork.request",
+        agentId: "agent-source",
+        requestId: "fork-2",
+      }),
+    ).toEqual({
+      type: "agent.session.fork.request",
+      agentId: "agent-source",
+      requestId: "fork-2",
+    });
+
+    const response: SessionOutboundMessage = SessionOutboundMessageSchema.parse({
+      type: "agent.session.fork.response",
+      payload: {
+        requestId: "fork-1",
+        agentId: "agent-source",
+        forkedAgentId: "agent-fork",
+        ok: true,
+        error: null,
+      },
+    });
+    expect(response).toEqual({
+      type: "agent.session.fork.response",
+      payload: {
+        requestId: "fork-1",
+        agentId: "agent-source",
+        forkedAgentId: "agent-fork",
+        ok: true,
+        error: null,
+      },
+    });
+  });
+
   test("legacy worktree request shape normalizes to the same internal input as the new shape", async () => {
     const workflow = new InMemoryWorktreeWorkflow();
 


### PR DESCRIPTION
Adds a **Fork session** action to the agent tab menu. It branches the agent's provider session into a brand new one holding a full copy of the transcript, then opens it as a separate agent in a tab directly to the right of the source tab. The source agent keeps running against its own session — the two diverge from the fork point.

## Why this is small

The daemon already forks sessions. Rewind uses the Claude SDK's `forkSession()` to branch mid-conversation (`providers/claude/rewind.ts`), and Codex has the equivalent `thread/fork`. The primitive was just locked inside provider-private rewind code and unreachable from `AgentManager`. This lifts it into the provider interface so it can back a user action.

Notably this does **not** shell out to `claude --resume --fork-session`. The Claude provider runs the Agent SDK in-process, so `resume`/`sessionId` are SDK options rather than argv. The `claude --resume {sessionId}` string in `provider-command-templates.ts` is display-only, for the clipboard action.

## What changed

**Provider layer**
- New optional `AgentClient.forkSession()` and a `supportsForkSession` capability flag. The capability map is open-ended and `AgentCapabilityFlagsSchema` has `.catchall(z.boolean())`, so the flag reaches clients with no schema change.
- Claude implements it via the SDK's `forkSession()` with `upToMessageId` omitted — full transcript copy, not rewind's slice.
- Providers with no native branch primitive (OpenCode, Pi, OMP, ACP) simply omit the method and the menu entry hides.

**Daemon**
- `AgentManager.forkAgentSession()` branches the session, then runs the *existing* import path against the new handle — so the fork gets its own hydrated timeline and inherits the source's workspace and labels.
- New `agent.session.fork` RPC following the dotted-namespace convention, gated on `server_info.features.agentSessionFork`.

**App**
- Tab insertion was append-only. `openTabFocused` now takes an optional `insertAfterTabId` that threads down through `prepareWorkspaceTab` → `openTabInLayoutFocused` → `insertTabIntoPane`, falling back to appending when the anchor isn't in the pane.
- The menu entry requires all three of: host advertises the feature, the agent's provider reports `supportsForkSession`, and the agent has a session id.

## Two traps avoided

Both are now written up in `docs/providers.md`:

1. **Don't pass a fork flag through `buildOptions()`.** `extra.claude.forkSession` would reach the SDK, but `buildOptions()` re-runs on every query recreation — model switch, mode switch, interrupt, rewind — so the agent would re-fork on every restart. Forking is one-shot, before the new session is registered.
2. **Don't route through `importAgent`.** Its de-dup filters already-imported sessions and two agents bound to one session id would fight over the same JSONL.

## Tests

17 fork-specific tests; 482 passing across the touched files.

- `agent-manager` — fork branches the source id and imports the *new* handle; source left untouched; unsupported providers rejected
- `session` — RPC returns the new agent id; provider failure surfaces as `ok: false` rather than throwing
- `wire-compat` — old clients drop `supportsForkSession` instead of rejecting the snapshot; message round-trips both directions; `workspaceId` genuinely optional
- `session-fork` — full copy (no `upToMessageId`); throws when the session isn't ready
- `daemon-client` — resolves with the forked id, omits `workspaceId` when absent, rejects with the daemon's reason
- `workspace-layout-store` — insert after anchor, anchor is last tab, anchor missing, tab already open
- `workspace-tab-menu` — entry is first and fires with the right agent id; hidden when the agent can't fork

Mutation-tested rather than assumed: making `insertTabAtAnchor` always append, making `forkClaudeSession` pass options, and making the handler drop `forkedAgentId` each produce exactly one failure.

---

## Verified end-to-end against a real Claude session

Ran this branch against a live Claude session (Haiku 4.5, bypass mode) with a new Playwright `real-provider` spec. Verification found **three bugs that all 17 original unit tests passed straight through** — each is fixed in a commit on this branch, and the run below is green as of `e9e5eb645`.

### Before → after: the feature was unreachable

The `Fork session` entry never rendered on a fresh agent:

![Tab context menu with no Fork session entry](https://raw.githubusercontent.com/kaspesi/paseo/fork-session-evidence/fork-session/01-menu-before-no-fork-entry.png)

After the fix:

![Tab context menu with Fork session as the first entry](https://raw.githubusercontent.com/kaspesi/paseo/fork-session-evidence/fork-session/02-menu-after-fork-entry.png)

`canForkAgentSession` read the agent's session id through a non-reactive `getState()` inside the memoized menu build. Instrumentation showed the gate ran 3× at tab-chip mount with the session id still `null`, while `agentSessionFork: true` and `supportsForkSession: true` were already on the wire. The id lands milliseconds later and nothing rebuilt the menu.

### The flow

Source session, two exchanges (two codewords, so a *full* transcript copy is distinguishable from rewind's single-turn slice):

![Source session with two completed exchanges](https://raw.githubusercontent.com/kaspesi/paseo/fork-session-evidence/fork-session/03-source-session.png)

Fork executes — new tab lands directly right of the source **and stays focused**:

![Forked tab active to the right of the source tab, holding the copied transcript](https://raw.githubusercontent.com/kaspesi/paseo/fork-session-evidence/fork-session/04-fork-tab-active.png)

The fork answers from the inherited context:

![Fork replying ZEPHYRLOOM MARBLEFINCH from the copied transcript](https://raw.githubusercontent.com/kaspesi/paseo/fork-session-evidence/fork-session/05-fork-recall.png)

Source is untouched by the fork's turn:

![Source tab still showing only its original two exchanges](https://raw.githubusercontent.com/kaspesi/paseo/fork-session-evidence/fork-session/06-source-unchanged.png)

Source diverges on its own branch:

![Source replying TANGERINEHOLLOW on its own session](https://raw.githubusercontent.com/kaspesi/paseo/fork-session-evidence/fork-session/07-source-diverges.png)

### Ground truth — the two session files

The decisive check, straight off disk after the run:

| session | shared prefix | own turn |
| --- | --- | --- |
| source | 2 exchanges | `TANGERINEHOLLOW` |
| fork | same 2 exchanges (full copy) | `ZEPHYRLOOM MARBLEFINCH` |

Neither contains the other's turn. Before the fix, the fork's file was frozen at 4 messages while the source held all 6.

### Walkthrough

Key steps, each held so they're readable — source conversation, the Fork session menu, the new fork tab, the fork's own reply (`ZEPHYRLOOM MARBLEFINCH`), then back on the untouched source as it diverges (`TANGERINEHOLLOW`):

![Fork session walkthrough](https://raw.githubusercontent.com/kaspesi/paseo/fork-session-evidence/fork-session/fork-walkthrough-v4.gif)

[Full continuous screen recording (MP4, 31s)](https://raw.githubusercontent.com/kaspesi/paseo/fork-session-evidence/fork-session/fork-run-full-v4.mp4)

---

## Known bug, not fixed here

**The composer shows the provider's default model until the agent's first turn completes.**

Visible above: immediately after forking, the composer reads **Opus 4.8 / Low** (4th image), then corrects to **Haiku 4.5** once the fork's first turn lands (5th image).

**Execution is not affected.** Every assistant turn in the forked session ran on `claude-haiku-4-5`, confirmed in the session JSONL:

```
forked session …jsonl
  model= claude-haiku-4-5-20251001   → "stored"
  model= claude-haiku-4-5-20251001   → "stored"
  model= claude-haiku-4-5-20251001   → "ZEPHYRLOOM MARBLEFINCH"
```

Cause: the agent's configured model can be an alias (`"haiku"`), while the model catalog keys on full ids (`"claude-haiku-4-5"`). `resolveAgentModelSelection` does an exact `findModelById` match, misses, and falls back to `getFallbackModel` — the `isDefault` entry, which is Opus 4.8. Once the first turn populates `runtimeInfo.model` with the full id, the exact match succeeds and the label corrects itself.

This looks **pre-existing and not fork-specific** — `resolveAgentModelSelection` has no fork-related logic, so any agent configured with a model alias should show the default until its first turn. Forking just makes it obvious, because a fork is born in exactly that state. Not reproduced on a non-forked fresh agent, so treat the "pre-existing" part as unconfirmed.

## Test coverage added

- `session.test.ts` — the fork RPC must publish the new agent before answering. Stubs `forwardLiveAgent` with a deferred and asserts no response is emitted while it is pending.
- `agent-manager.test.ts` — a fork keeps the source's model, thinking level, and mode. Its fake `importSession` echoes `context.storedConfig` the way the real shared import helper does; the pre-existing fork test returns a hardcoded config and so structurally cannot observe this.
- `workspace-layout-store.test.ts` — anchor-inserted tabs actually take focus, plus the prune-on-unknown-agent rule that was load-bearing in bug 2 and untested.
- `fork-session.claude.real.spec.ts` — the end-to-end run above.

Each of the three unit tests fails on the exact one-line revert of its fix.

<sub>Media hosted on the <a href="https://github.com/kaspesi/paseo/tree/fork-session-evidence">fork-session-evidence</a> branch.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)



