### PR TITLE
fix(omp): render compaction recap summaries

### DIFF
--- a/docs/timeline-sync.md
+++ b/docs/timeline-sync.md
@@ -87,6 +87,14 @@ Canonical submitted user rows carry the provider's `messageId` and Paseo's optio
 `clientMessageId`. Clients reconcile optimistic prompts by `clientMessageId`. Content matching is
 limited to the dated compatibility path for daemon timelines created before that field existed.
 
+## Compaction recap reconciliation
+
+Compaction timeline items may carry optional `summary` and `shortSummary` recap text. Live provider
+events and authoritative history hydration map both fields into the same completed compaction item;
+the stream reducer preserves an existing recap when a later completion update omits it. The app
+shows a trimmed short recap when present, falls back to the detailed summary, and keeps legacy
+recap-free compaction markers unchanged.
+
 ## Relevant code
 
 - Server live stream forwarding: `packages/server/src/server/session.ts`

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -839,6 +839,8 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
                 status={item.status}
                 trigger={item.trigger}
                 preTokens={item.preTokens}
+                summary={item.summary}
+                shortSummary={item.shortSummary}
               />
             );
 

--- a/packages/app/src/agent-stream/web-virtualization.ts
+++ b/packages/app/src/agent-stream/web-virtualization.ts
@@ -57,7 +57,7 @@ export function estimateStreamItemHeight(item: StreamItem): number {
     case "activity_log":
       return 88;
     case "compaction":
-      return 72;
+      return 112;
     default:
       return 120;
   }

--- a/packages/app/src/components/message-compaction-label.test.ts
+++ b/packages/app/src/components/message-compaction-label.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { i18n } from "@/i18n/i18next";
-import { getCompactionMarkerLabel } from "./message-compaction-label";
+import { getCompactionMarkerLabel, getCompactionRecapPreview } from "./message-compaction-label";
 
 describe("getCompactionMarkerLabel", () => {
   it("renders loading, automatic, manual, tokenized, and fallback labels", () => {
@@ -25,5 +25,35 @@ describe("getCompactionMarkerLabel", () => {
     } finally {
       await i18n.changeLanguage("en");
     }
+  });
+});
+
+describe("getCompactionRecapPreview", () => {
+  it("prefers a non-empty short recap", () => {
+    expect(
+      getCompactionRecapPreview({
+        summary: "Detailed recap",
+        shortSummary: "Short recap",
+      }),
+    ).toBe("Short recap");
+  });
+
+  it("falls back to a non-empty detailed recap", () => {
+    expect(
+      getCompactionRecapPreview({
+        summary: "Detailed recap",
+        shortSummary: "   ",
+      }),
+    ).toBe("Detailed recap");
+  });
+
+  it("returns null when no non-empty recap exists", () => {
+    expect(getCompactionRecapPreview({})).toBeNull();
+    expect(
+      getCompactionRecapPreview({
+        summary: "",
+        shortSummary: "   ",
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/app/src/components/message-compaction-label.ts
+++ b/packages/app/src/components/message-compaction-label.ts
@@ -21,3 +21,17 @@ export function getCompactionMarkerLabel({
   }
   return i18n.t("message.compaction.completed");
 }
+
+export function getCompactionRecapPreview({
+  summary,
+  shortSummary,
+}: {
+  summary?: string;
+  shortSummary?: string;
+}): string | null {
+  const shortPreview = shortSummary?.trim();
+  if (shortPreview) return shortPreview;
+
+  const summaryPreview = summary?.trim();
+  return summaryPreview || null;
+}

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -101,7 +101,7 @@ import {
   useAssistantFileLinkActions,
   useAssistantLinkPress,
 } from "@/assistant-file-links";
-import { getCompactionMarkerLabel } from "./message-compaction-label";
+import { getCompactionMarkerLabel, getCompactionRecapPreview } from "./message-compaction-label";
 import { useAttachmentPreviewUrl } from "@/attachments/use-attachment-preview-url";
 import { persistAttachmentFromBytes, persistAttachmentFromDataUrl } from "@/attachments/service";
 import {
@@ -2186,6 +2186,8 @@ interface CompactionMarkerProps {
   status: "loading" | "completed";
   trigger?: "auto" | "manual";
   preTokens?: number;
+  summary?: string;
+  shortSummary?: string;
 }
 
 const compactionStylesheet = StyleSheet.create((theme) => ({
@@ -2206,6 +2208,34 @@ const compactionStylesheet = StyleSheet.create((theme) => ({
     alignItems: "center",
     gap: theme.spacing[2],
   },
+  recapContent: {
+    alignItems: "center",
+    flexShrink: 1,
+    gap: theme.spacing[1],
+  },
+  recapPreview: {
+    color: theme.colors.foregroundMuted,
+    fontFamily: theme.fontFamily.ui,
+    fontSize: 13,
+    lineHeight: 18,
+    textAlign: "center",
+  },
+  recapDetails: {
+    marginHorizontal: theme.spacing[4],
+    marginBottom: theme.spacing[3],
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[2],
+    backgroundColor: theme.colors.surface1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.md,
+    borderWidth: theme.borderWidth[1],
+  },
+  recapDetailsText: {
+    color: theme.colors.foreground,
+    fontFamily: theme.fontFamily.ui,
+    fontSize: 13,
+    lineHeight: 20,
+  },
   text: {
     fontFamily: theme.fontFamily.ui,
     fontSize: 13,
@@ -2217,21 +2247,79 @@ export const CompactionMarker = memo(function CompactionMarker({
   status,
   trigger,
   preTokens,
+  summary,
+  shortSummary,
 }: CompactionMarkerProps) {
   const label = getCompactionMarkerLabel({ status, trigger, preTokens });
+  const recapPreview = getCompactionRecapPreview({ summary, shortSummary });
+  const detailedSummary = summary?.trim() || null;
+  const [isExpanded, setIsExpanded] = useState(false);
+  const accessibilityState = useMemo(() => ({ expanded: isExpanded }), [isExpanded]);
+  const handlePress = useCallback(() => {
+    setIsExpanded((expanded) => !expanded);
+  }, []);
 
-  return (
+  if (status === "loading" || !recapPreview) {
+    return (
+      <View style={compactionStylesheet.container}>
+        <View style={compactionStylesheet.line} />
+        <View style={compactionStylesheet.label}>
+          {status === "loading" ? (
+            <ActivityIndicator size="small" color="#a1a1aa" />
+          ) : (
+            <Scissors size={12} color="#a1a1aa" />
+          )}
+          <Text style={compactionStylesheet.text}>{label}</Text>
+        </View>
+        <View style={compactionStylesheet.line} />
+      </View>
+    );
+  }
+
+  let recapChevron: ReactNode = null;
+  if (detailedSummary) {
+    const RecapChevron = isExpanded ? ChevronDown : ChevronRight;
+    recapChevron = <RecapChevron size={12} color="#a1a1aa" />;
+  }
+
+  const recapHeader = (
     <View style={compactionStylesheet.container}>
       <View style={compactionStylesheet.line} />
-      <View style={compactionStylesheet.label}>
-        {status === "loading" ? (
-          <ActivityIndicator size="small" color="#a1a1aa" />
-        ) : (
+      <View style={compactionStylesheet.recapContent}>
+        <View style={compactionStylesheet.label}>
           <Scissors size={12} color="#a1a1aa" />
-        )}
-        <Text style={compactionStylesheet.text}>{label}</Text>
+          <Text style={compactionStylesheet.text}>{label}</Text>
+          {recapChevron}
+        </View>
+        <Text selectable numberOfLines={2} style={compactionStylesheet.recapPreview}>
+          {recapPreview}
+        </Text>
       </View>
       <View style={compactionStylesheet.line} />
+    </View>
+  );
+
+  return (
+    <View>
+      {detailedSummary ? (
+        <Pressable
+          accessibilityLabel={`${label}. ${recapPreview}`}
+          accessibilityRole="button"
+          accessibilityState={accessibilityState}
+          onPress={handlePress}
+        >
+          {recapHeader}
+        </Pressable>
+      ) : (
+        recapHeader
+      )}
+      {isExpanded && detailedSummary ? (
+        <View style={compactionStylesheet.recapDetails}>
+          <Text selectable style={compactionStylesheet.recapDetailsText}>
+            {detailedSummary}
+          </Text>
+        </View>
+      ) : null}
     </View>
   );
 });

--- a/packages/app/src/types/stream.test.ts
+++ b/packages/app/src/types/stream.test.ts
@@ -102,7 +102,17 @@ function todoTimeline(items: { text: string; completed: boolean }[]): AgentStrea
 
 function compactionTimeline(
   status: "loading" | "completed",
-  trigger?: "auto" | "manual",
+  {
+    trigger,
+    preTokens,
+    summary,
+    shortSummary,
+  }: {
+    trigger?: "auto" | "manual";
+    preTokens?: number;
+    summary?: string;
+    shortSummary?: string;
+  } = {},
 ): AgentStreamEventPayload {
   return {
     type: "timeline",
@@ -111,6 +121,9 @@ function compactionTimeline(
       type: "compaction",
       status,
       ...(trigger ? { trigger } : {}),
+      ...(preTokens !== undefined ? { preTokens } : {}),
+      ...(summary !== undefined ? { summary } : {}),
+      ...(shortSummary !== undefined ? { shortSummary } : {}),
     },
   };
 }
@@ -845,14 +858,43 @@ describe("stream reducer canonical tool calls", () => {
     assert.strictEqual(todos.items[1]?.completed, true);
   });
 
-  it("preserves compaction trigger when completed update replaces loading marker", () => {
+  it("carries completed compaction recap fields into the stream item", () => {
     const state = hydrateStreamState([
       {
-        event: compactionTimeline("loading", "auto"),
+        event: compactionTimeline("completed", {
+          summary: "Reviewed the authentication flow and identified the remaining work.",
+          shortSummary: "Authentication flow review",
+        }),
+        timestamp: new Date("2025-01-01T10:50:00Z"),
+      },
+    ]);
+
+    const compaction = state.find(
+      (item): item is Extract<StreamItem, { kind: "compaction" }> => item.kind === "compaction",
+    );
+
+    assert.ok(compaction);
+    assert.strictEqual(
+      compaction.summary,
+      "Reviewed the authentication flow and identified the remaining work.",
+    );
+    assert.strictEqual(compaction.shortSummary, "Authentication flow review");
+  });
+
+  it("merges completion recap fields with loading compaction fallback metadata", () => {
+    const state = hydrateStreamState([
+      {
+        event: compactionTimeline("loading", {
+          trigger: "auto",
+          preTokens: 12_345,
+        }),
         timestamp: new Date("2025-01-01T10:50:00Z"),
       },
       {
-        event: compactionTimeline("completed"),
+        event: compactionTimeline("completed", {
+          summary: "Consolidated the implementation context for the next step.",
+          shortSummary: "Implementation context",
+        }),
         timestamp: new Date("2025-01-01T10:50:01Z"),
       },
     ]);
@@ -864,6 +906,12 @@ describe("stream reducer canonical tool calls", () => {
     assert.strictEqual(compactions.length, 1);
     assert.strictEqual(compactions[0].status, "completed");
     assert.strictEqual(compactions[0].trigger, "auto");
+    assert.strictEqual(compactions[0].preTokens, 12_345);
+    assert.strictEqual(
+      compactions[0].summary,
+      "Consolidated the implementation context for the next step.",
+    );
+    assert.strictEqual(compactions[0].shortSummary, "Implementation context");
   });
 
   it("renders Claude TodoWrite as todo_list and suppresses tool call badge", () => {

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -189,6 +189,8 @@ export interface CompactionItem {
   status: "loading" | "completed";
   trigger?: "auto" | "manual";
   preTokens?: number;
+  summary?: string;
+  shortSummary?: string;
 }
 
 export interface TodoEntry {
@@ -810,6 +812,8 @@ function reduceTimelineCompaction(
         status: "completed",
         trigger: item.trigger ?? existing.trigger,
         preTokens: item.preTokens ?? existing.preTokens,
+        summary: item.summary ?? existing.summary,
+        shortSummary: item.shortSummary ?? existing.shortSummary,
       };
       return [...state.slice(0, loadingIdx), updated, ...state.slice(loadingIdx + 1)];
     }
@@ -824,6 +828,8 @@ function reduceTimelineCompaction(
     status: item.status,
     trigger: item.trigger,
     preTokens: item.preTokens,
+    summary: item.summary,
+    shortSummary: item.shortSummary,
   };
   return [...state, compaction];
 }

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -335,6 +335,8 @@ export interface CompactionTimelineItem {
   status: "loading" | "completed";
   trigger?: "auto" | "manual";
   preTokens?: number;
+  summary?: string;
+  shortSummary?: string;
 }
 
 export type AgentTimelineItem =

--- a/packages/protocol/src/messages.stream-parsing.test.ts
+++ b/packages/protocol/src/messages.stream-parsing.test.ts
@@ -160,6 +160,68 @@ describe("shared messages stream parsing", () => {
     }
   });
 
+  it("preserves optional compaction recap fields and parses legacy compaction items", () => {
+    const recapParsed = AgentStreamMessageSchema.parse({
+      type: "agent_stream",
+      payload: {
+        agentId: "agent_compaction_recap",
+        timestamp: "2026-07-08T13:00:00.000Z",
+        event: {
+          type: "timeline",
+          provider: "omp",
+          item: {
+            type: "compaction",
+            status: "completed",
+            trigger: "auto",
+            preTokens: 321,
+            summary: "Wire recap: preserved the database migration sequence and safety checks.",
+            shortSummary: "Migration safety preserved",
+          },
+        },
+      },
+    });
+    expect(recapParsed.payload.event).toEqual({
+      type: "timeline",
+      provider: "omp",
+      item: {
+        type: "compaction",
+        status: "completed",
+        trigger: "auto",
+        preTokens: 321,
+        summary: "Wire recap: preserved the database migration sequence and safety checks.",
+        shortSummary: "Migration safety preserved",
+      },
+    });
+
+    const legacyParsed = AgentStreamMessageSchema.parse({
+      type: "agent_stream",
+      payload: {
+        agentId: "agent_compaction_legacy",
+        timestamp: "2026-07-08T13:00:01.000Z",
+        event: {
+          type: "timeline",
+          provider: "omp",
+          item: {
+            type: "compaction",
+            status: "completed",
+            trigger: "auto",
+            preTokens: 144,
+          },
+        },
+      },
+    });
+    expect(legacyParsed.payload.event).toEqual({
+      type: "timeline",
+      provider: "omp",
+      item: {
+        type: "compaction",
+        status: "completed",
+        trigger: "auto",
+        preTokens: 144,
+      },
+    });
+  });
+
   it("parses representative sub_agent tool_call event", () => {
     const parsed = AgentStreamMessageSchema.parse({
       type: "agent_stream",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -600,6 +600,8 @@ export const AgentTimelineItemPayloadSchema: z.ZodType<AgentTimelineItem, unknow
     status: z.enum(["loading", "completed"]),
     trigger: z.enum(["auto", "manual"]).optional(),
     preTokens: z.number().optional(),
+    summary: z.string().optional(),
+    shortSummary: z.string().optional(),
   }),
 ]);
 

--- a/packages/server/src/server/agent/providers/omp/event-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/omp/event-mapper.test.ts
@@ -212,8 +212,8 @@ describe("OMP runtime event mapper", () => {
         type: "auto_compaction_end",
         action: "context-full",
         result: {
-          summary: "trimmed",
-          shortSummary: "trimmed",
+          summary: "Live recap: retained the deployment decision and rollback plan.",
+          shortSummary: "Deployment decision retained",
           firstKeptEntryId: "entry-1",
           tokensBefore: 123,
         },
@@ -227,6 +227,8 @@ describe("OMP runtime event mapper", () => {
         status: "completed",
         trigger: "auto",
         preTokens: 123,
+        summary: "Live recap: retained the deployment decision and rollback plan.",
+        shortSummary: "Deployment decision retained",
       },
     });
 

--- a/packages/server/src/server/agent/providers/omp/event-mapper.ts
+++ b/packages/server/src/server/agent/providers/omp/event-mapper.ts
@@ -244,7 +244,7 @@ function mapAutoCompactionEndEvent(event: unknown): OmpRuntimeEventMapping {
   if (!parsed.success) {
     return { handled: true, item: null, logReason: "malformed_omp_auto_compaction_end" };
   }
-  const preTokens = readCompactionPreTokens(parsed.data.result);
+  const details = parsed.data.aborted ? {} : readOmpCompactionDetails(parsed.data.result);
   // Wire compaction items only support loading/completed, so every end event clears loading.
   return {
     handled: true,
@@ -252,7 +252,7 @@ function mapAutoCompactionEndEvent(event: unknown): OmpRuntimeEventMapping {
       type: "compaction",
       status: "completed",
       trigger: "auto",
-      ...(preTokens !== undefined ? { preTokens } : {}),
+      ...details,
     },
   };
 }
@@ -305,11 +305,27 @@ function readEventType(value: unknown): string | null {
   return typeof value.type === "string" ? value.type : null;
 }
 
-function readCompactionPreTokens(value: unknown): number | undefined {
+export function readOmpCompactionDetails(value: unknown): {
+  preTokens?: number;
+  summary?: string;
+  shortSummary?: string;
+} {
   if (!isRecord(value)) {
-    return undefined;
+    return {};
   }
-  return typeof value.tokensBefore === "number" ? value.tokensBefore : undefined;
+  const summary =
+    typeof value.summary === "string" && value.summary.trim().length > 0
+      ? value.summary
+      : undefined;
+  const shortSummary =
+    typeof value.shortSummary === "string" && value.shortSummary.trim().length > 0
+      ? value.shortSummary
+      : undefined;
+  return {
+    ...(typeof value.tokensBefore === "number" ? { preTokens: value.tokensBefore } : {}),
+    ...(summary !== undefined ? { summary } : {}),
+    ...(shortSummary !== undefined ? { shortSummary } : {}),
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/server/src/server/agent/providers/omp/history-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/omp/history-mapper.test.ts
@@ -388,6 +388,59 @@ describe("OMP history mapper", () => {
     ]);
   });
 
+  test("restores compaction recap entries as completed timeline items", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "omp-compaction-history-"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          id: "compaction-root",
+          parentId: null,
+          timestamp: "2026-07-08T12:00:00Z",
+        },
+        {
+          type: "compaction",
+          id: "compaction-recap",
+          parentId: "compaction-root",
+          timestamp: "2026-07-08T12:00:01Z",
+          summary: "History recap: traced the failed cache invalidation and its correction.",
+          shortSummary: "Cache invalidation corrected",
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n"),
+    );
+
+    const events: AgentStreamEvent[] = [];
+    for await (const event of streamOmpHistory({ sessionFile, provider: "omp" })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      {
+        type: "timeline",
+        provider: "omp",
+        timestamp: "2026-07-08T12:00:01Z",
+        item: {
+          type: "compaction",
+          status: "completed",
+          summary: "History recap: traced the failed cache invalidation and its correction.",
+          shortSummary: "Cache invalidation corrected",
+        },
+      },
+    ]);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        item: {
+          type: "assistant_message",
+          text: "[compaction] Unsupported history record",
+        },
+      }),
+    );
+  });
+
   test("rehydrates structured batch and nested task transcripts with stable status and time", async () => {
     const dir = mkdtempSync(join(tmpdir(), "omp-subagent-history-"));
     const parentFile = join(dir, "parent.jsonl");

--- a/packages/server/src/server/agent/providers/omp/history.ts
+++ b/packages/server/src/server/agent/providers/omp/history.ts
@@ -7,6 +7,7 @@ import type { OmpAgentMessage } from "./rpc-types.js";
 import type { OmpRuntimeSession } from "./runtime.js";
 import { OMP_HISTORY_MAPPER_HOOKS } from "./history-hooks.js";
 import { formatOmpSubagentTitle } from "./subagent-title.js";
+import { readOmpCompactionDetails } from "./event-mapper.js";
 
 interface OmpSessionEntry {
   type?: string;
@@ -68,21 +69,41 @@ export async function* streamOmpHistory(input: {
     throw error;
   }
   const messages: OmpAgentMessage[] = [];
-  const messageEntries: OmpSessionEntry[] = [];
   const userEntries: OmpCapturedUserMessageEntry[] = [];
+  const replayEntries: Array<
+    | { kind: "message"; entry: OmpSessionEntry; message: OmpAgentMessage }
+    | { kind: "compaction"; entry: OmpSessionEntry }
+  > = [];
   for (const entry of entries) {
+    if (entry.type === "compaction") {
+      replayEntries.push({ kind: "compaction", entry });
+      continue;
+    }
     const mapped = mapEntryMessage(entry);
     if (!mapped) continue;
     messages.push(mapped);
-    messageEntries.push(entry);
+    replayEntries.push({ kind: "message", entry, message: mapped });
     if (mapped.role === "user" && entry.id) {
       userEntries.push({ id: entry.id, text: textOf(mapped.content) });
     }
   }
   const mapper = new OmpHistoryMapper(input.provider, userEntries, OMP_HISTORY_MAPPER_HOOKS);
-  for (let index = 0; index < messages.length; index += 1) {
-    const timestamp = normalizeProviderReplayTimestamp(messageEntries[index]?.timestamp);
-    for (const event of mapper.mapMessages([messages[index]!])) {
+  for (const replayEntry of replayEntries) {
+    const timestamp = normalizeProviderReplayTimestamp(replayEntry.entry.timestamp);
+    if (replayEntry.kind === "compaction") {
+      yield {
+        type: "timeline",
+        provider: input.provider,
+        item: {
+          type: "compaction",
+          status: "completed",
+          ...readOmpCompactionDetails(replayEntry.entry),
+        },
+        ...(timestamp ? { timestamp } : {}),
+      };
+      continue;
+    }
+    for (const event of mapper.mapMessages([replayEntry.message])) {
       yield timestamp && event.type === "timeline" ? { ...event, timestamp } : event;
     }
   }


### PR DESCRIPTION
## Summary

- preserve `summary` and `shortSummary` from OMP automatic compaction events
- restore dedicated OMP `type: "compaction"` history entries as canonical completed compaction items
- carry optional recap fields through the protocol and app stream reducer
- render a short recap beside the compaction marker with an expandable full summary
- keep existing Codex and Pi markers unchanged when recap fields are absent

This PR covers context-compaction summaries only. OMP Idle Recap is a separate TUI-only feature and is not included.

## Verification

- `npm exec --workspace=@getpaseo/server -- vitest run src/server/agent/providers/omp/event-mapper.test.ts src/server/agent/providers/omp/history-mapper.test.ts --bail=1` (14 tests)
- `npm exec --workspace=@getpaseo/protocol -- vitest run src/messages.stream-parsing.test.ts --bail=1` (14 tests)
- `npm exec --workspace=@getpaseo/app -- vitest run src/types/stream.test.ts src/components/message-compaction-label.test.ts --bail=1` (49 tests)
- `npm run build:server`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

## Manual QA

A real OMP `/compact` run produced a `type: "compaction"` JSONL record with `summary`, `shortSummary`, and `tokensBefore`. After authoritative history hydration, Paseo displayed `Context compacted (63K tokens)` with the short recap. Expanding and collapsing the marker showed and hid the full summary.

Closes #2266