### PR TITLE
feat(grok): specialize ACP provider for subagents, tools, and thinking

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -111,7 +111,7 @@ The collapsible track above the composer in an agent's pane (`packages/app/src/s
 parentAgentId === thisAgent.id  AND  !archivedAt
 ```
 
-- **Provider subagents** are child executions owned by Claude, Codex, or OpenCode. They are not inserted into `AgentManager` as managed agents. Providers emit a separate descriptor and timeline stream through `agent.provider_subagents.*`; the client keeps that state outside the normal agent store and merges only the presentation rows into the track.
+- **Provider subagents** are child executions owned by Claude, Codex, OpenCode, Grok, or OMP's progress-mapped tasks. They are not inserted into `AgentManager` as managed agents. Providers emit a separate descriptor and timeline stream through `agent.provider_subagents.*`; the client keeps that state outside the normal agent store and merges only the presentation rows into the track. Some adapters fold model/effort into the display `title` (OMP, Grok) without new protocol fields.
 
 Clicking either kind opens a workspace tab. A Paseo subagent tab is a normal interactive agent pane. A provider subagent tab is a read-only timeline pane with no composer, archive, detach, rewind, or fork actions. Both panes use `AgentStreamView`, so message, reasoning, tool-call, and layout rendering stay identical.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -8,11 +8,17 @@ This guide walks through adding a new agent provider end-to-end. There are two i
 
 Extend `ACPAgentClient` from `packages/server/src/server/agent/providers/acp-agent.ts`. The base class handles process spawning, stdio transport, session lifecycle, streaming, permissions, and model discovery. You provide configuration (command, modes, capabilities) and optionally override `isAvailable()` for auth checks.
 
-The only built-in ACP provider today is `copilot` (`copilot-acp-agent.ts`). `GenericACPAgentClient` (`generic-acp-agent.ts`) is also ACP-based but is used for user-defined custom providers configured via `extends: "acp"` overrides — see [docs/custom-providers.md](custom-providers.md).
+Built-in and catalog ACP providers share `ACPAgentClient`. Providers that only need a command use `GenericACPAgentClient`; providers with vendor extensions use focused subclasses such as `CursorACPAgentClient`, `KiroACPAgentClient`, `TraeACPAgentClient`, and `GrokACPAgentClient`. The registry selects these subclasses by provider ID while retaining the common ACP process, lifecycle, permission, and streaming implementation. User-defined `extends: "acp"` providers remain generic — see [docs/custom-providers.md](custom-providers.md).
 
 Tool cards use `kind` as the display name when it is a concrete ACP kind; when `kind` is missing or `other`, the base class prefers the tool `title` so cards are not labeled "Other".
 
 Copilot custom agents are exposed through ACP session config, not the slash-command list. When custom agents are available, Copilot returns a select config option with `id: "agent"` and `category: "_agent"`; Paseo maps that to the `agent` provider feature. Copilot uses the agent display name as the option value, and the blank value means the default Copilot agent.
+
+Grok Build is standard ACP plus a documented `x.ai/*` extension surface. `GrokACPAgentClient` keeps standard ACP for initialize, session create/load, prompts, cancellation, permissions, models, and config writes. It specializes only the product-specific seams: initialize metadata and available commands (including Grok's plan command), `x.ai/sessionConfig` reasoning options mapped to Paseo thinking levels, live and replayed subagent lifecycle notifications, standard child-session updates routed into subagent timelines (Grok uses the child session ID as the subagent ID), richer `x.ai/session/list` import discovery, and auth-readiness diagnostics. Unknown extension fields remain ignored so Grok can expand its vendor metadata without breaking Paseo.
+
+Grok provider-subagent **display** of model/effort is adapter-local (no protocol fields): the mapper folds them into the existing `title` string, e.g. `Map the registry · grok-4.5 · low`, same idea as OMP. Model comes from the `subagent_spawned` wire field when present. Reasoning effort is not on that frame; the adapter best-effort reads the child session's local `summary.json` under `GROK_HOME/sessions` (shallow walk fallback) on spawn/progress/finished and silently omits effort when missing.
+
+Grok parent-timeline Task tools use the shared ACP `toolDetailMapper` hook (`mapGrokAcpToolDetail`): `variant: "Task"` / `spawn_subagent` → `sub_agent` detail; `TaskOutput` / `get_command_or_subagent_output` → short `plain_text` wait summary; `open_page`-style tools nested under `action.url` → `fetch` detail; web search under `action.query` → `web_search` detail.
 
 ### Direct
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,6 +10,8 @@ Extend `ACPAgentClient` from `packages/server/src/server/agent/providers/acp-age
 
 The only built-in ACP provider today is `copilot` (`copilot-acp-agent.ts`). `GenericACPAgentClient` (`generic-acp-agent.ts`) is also ACP-based but is used for user-defined custom providers configured via `extends: "acp"` overrides — see [docs/custom-providers.md](custom-providers.md).
 
+Tool cards use `kind` as the display name when it is a concrete ACP kind; when `kind` is missing or `other`, the base class prefers the tool `title` so cards are not labeled "Other".
+
 Copilot custom agents are exposed through ACP session config, not the slash-command list. When custom agents are available, Copilot returns a select config option with `id: "agent"` and `category: "_agent"`; Paseo maps that to the `agent` provider feature. Copilot uses the agent display name as the option value, and the blank value means the default Copilot agent.
 
 ### Direct

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -172,6 +172,7 @@ const ThemedTodoCheckIcon = withUnistyles(Check);
 const ThemedFileSymlinkIcon = withUnistyles(FileSymlink);
 const ThemedTriangleAlertIcon = withUnistyles(TriangleAlertIcon);
 const ThemedChevronRightIcon = withUnistyles(ChevronRight);
+const ThemedActivityIndicator = withUnistyles(ActivityIndicator);
 
 const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
 const foregroundMutedColorMapping = (theme: Theme) => ({
@@ -2241,12 +2242,23 @@ interface TodoListCardProps {
   disableOuterSpacing?: boolean;
 }
 
-interface TodoListItemRowProps {
-  text: string;
-  completed: boolean;
+type TodoItemStatus = NonNullable<TodoEntry["status"]>;
+
+function resolveTodoStatus(item: { completed: boolean; status?: TodoItemStatus }): TodoItemStatus {
+  if (item.status) {
+    return item.status;
+  }
+  return item.completed ? "completed" : "pending";
 }
 
-function TodoListItemRow({ text, completed }: TodoListItemRowProps) {
+interface TodoListItemRowProps {
+  text: string;
+  status: TodoItemStatus;
+}
+
+function TodoListItemRow({ text, status }: TodoListItemRowProps) {
+  const completed = status === "completed";
+  const inProgress = status === "in_progress";
   const badgeStyle = useMemo(
     () => [
       todoListCardStylesheet.radioBadge,
@@ -2260,13 +2272,21 @@ function TodoListItemRow({ text, completed }: TodoListItemRowProps) {
     () => [todoListCardStylesheet.itemText, completed && todoListCardStylesheet.itemTextCompleted],
     [completed],
   );
+  let statusIcon: ReactNode = null;
+  if (completed) {
+    statusIcon = <ThemedTodoCheckIcon size={12} uniProps={primaryForegroundColorMapping} />;
+  } else if (inProgress) {
+    statusIcon = (
+      <ThemedActivityIndicator
+        size="small"
+        style={todoListCardStylesheet.progressIndicator}
+        uniProps={primaryForegroundColorMapping}
+      />
+    );
+  }
   return (
     <View style={todoListCardStylesheet.itemRow}>
-      <View style={badgeStyle}>
-        {completed ? (
-          <ThemedTodoCheckIcon size={12} uniProps={primaryForegroundColorMapping} />
-        ) : null}
-      </View>
+      <View style={badgeStyle}>{statusIcon}</View>
       <Text style={textStyle}>{text}</Text>
     </View>
   );
@@ -2298,6 +2318,9 @@ const todoListCardStylesheet = StyleSheet.create((theme) => ({
   radioBadgeComplete: {
     opacity: 0.95,
   },
+  progressIndicator: {
+    transform: [{ scale: 0.7 }],
+  },
   itemText: {
     flex: 1,
     color: theme.colors.foreground,
@@ -2320,7 +2343,13 @@ export const TodoListCard = memo(function TodoListCard({
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const nextTask = useMemo(() => items.find((item) => !item.completed)?.text, [items]);
+  const nextTask = useMemo(() => {
+    const inProgress = items.find((item) => resolveTodoStatus(item) === "in_progress");
+    if (inProgress) {
+      return inProgress.text;
+    }
+    return items.find((item) => resolveTodoStatus(item) === "pending")?.text;
+  }, [items]);
 
   const handleToggle = useCallback(() => {
     setIsExpanded((prev) => !prev);
@@ -2334,7 +2363,7 @@ export const TodoListCard = memo(function TodoListCard({
             <Text style={todoListCardStylesheet.emptyText}>{t("message.todo.empty")}</Text>
           ) : (
             items.map((item) => (
-              <TodoListItemRow key={item.text} text={item.text} completed={item.completed} />
+              <TodoListItemRow key={item.text} text={item.text} status={resolveTodoStatus(item)} />
             ))
           )}
         </View>

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -1894,6 +1894,111 @@ describe("processTimelineResponse", () => {
       endSeq: 2,
     });
   });
+
+  it("coalesces same provider+turn todo cards after timeline reload with turnId preserved", () => {
+    const turnA = "turn-reload-a";
+    const turnB = "turn-reload-b";
+    const provider = "grok";
+
+    const firstTodoEntry = {
+      seqStart: 1,
+      seqEnd: 1,
+      provider,
+      turnId: turnA,
+      item: {
+        type: "todo",
+        items: [
+          { text: "Investigate", completed: false, status: "pending" },
+          { text: "Fix", completed: false, status: "pending" },
+        ],
+      },
+      timestamp: new Date("2025-01-01T14:00:00Z").toISOString(),
+    };
+    const reasoningEntry = {
+      ...makeTimelineEntry(2, "checking reload path", "reasoning"),
+      provider,
+      turnId: turnA,
+    };
+    const assistantEntry = {
+      ...makeTimelineEntry(3, "working on it"),
+      provider,
+      turnId: turnA,
+      item: {
+        type: "assistant_message",
+        text: "working on it",
+        messageId: "msg-reload-coalesce",
+      },
+    };
+    const updatedTodoEntry = {
+      seqStart: 4,
+      seqEnd: 4,
+      provider,
+      turnId: turnA,
+      item: {
+        type: "todo",
+        items: [
+          { text: "Investigate", completed: false, status: "in_progress" },
+          { text: "Fix", completed: false, status: "pending" },
+        ],
+      },
+      timestamp: new Date("2025-01-01T14:00:04Z").toISOString(),
+    };
+    const nextTurnTodoEntry = {
+      seqStart: 5,
+      seqEnd: 5,
+      provider,
+      turnId: turnB,
+      item: {
+        type: "todo",
+        items: [{ text: "Verify", completed: false, status: "pending" }],
+      },
+      timestamp: new Date("2025-01-01T14:00:05Z").toISOString(),
+    };
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      isInitializing: true,
+      hasActiveInitDeferred: true,
+      initRequestDirection: "tail",
+      payload: {
+        ...baseTimelineInput.payload,
+        direction: "tail",
+        epoch: "epoch-1",
+        startCursor: { seq: 1 },
+        endCursor: { seq: 5 },
+        entries: [
+          firstTodoEntry,
+          reasoningEntry,
+          assistantEntry,
+          updatedTodoEntry,
+          nextTurnTodoEntry,
+        ],
+      },
+    });
+
+    const stream = [...result.tail, ...result.head];
+    const todoCards = stream.filter(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+    const firstCardIndex = stream.findIndex((item) => item.kind === "todo_list");
+    const thoughtIndex = stream.findIndex((item) => item.kind === "thought");
+    const assistantIndex = stream.findIndex((item) => item.kind === "assistant_message");
+
+    expect(todoCards).toHaveLength(2);
+    expect(todoCards[0]?.turnId).toBe(turnA);
+    expect(todoCards[0]?.provider).toBe(provider);
+    expect(todoCards[0]?.items.map((item) => ({ text: item.text, status: item.status }))).toEqual([
+      { text: "Investigate", status: "in_progress" },
+      { text: "Fix", status: "pending" },
+    ]);
+    expect(firstCardIndex).toBeGreaterThanOrEqual(0);
+    expect(firstCardIndex).toBeLessThan(thoughtIndex);
+    expect(firstCardIndex).toBeLessThan(assistantIndex);
+    expect(todoCards[1]?.turnId).toBe(turnB);
+    expect(todoCards[1]?.items.map((item) => ({ text: item.text, status: item.status }))).toEqual([
+      { text: "Verify", status: "pending" },
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -65,6 +65,7 @@ interface TimelineResponseEntry {
   sourceSeqRanges?: TimelineSeqRange[];
   collapsed?: string[];
   provider: string;
+  turnId?: string;
   item: Record<string, unknown>;
   timestamp: string;
 }
@@ -1066,6 +1067,7 @@ export function processTimelineResponse(
     event: {
       type: "timeline",
       provider: entry.provider,
+      ...(entry.turnId !== undefined ? { turnId: entry.turnId } : {}),
       item: entry.item,
     } as AgentStreamEventPayload,
     timestamp: new Date(entry.timestamp),

--- a/packages/app/src/types/stream.test.ts
+++ b/packages/app/src/types/stream.test.ts
@@ -89,10 +89,18 @@ function canonicalToolTimeline(params: {
   };
 }
 
-function todoTimeline(items: { text: string; completed: boolean }[]): AgentStreamEventPayload {
+function todoTimeline(
+  items: {
+    text: string;
+    completed: boolean;
+    status?: "pending" | "in_progress" | "completed";
+  }[],
+  options?: { provider?: AgentProvider; turnId?: string },
+): AgentStreamEventPayload {
   return {
     type: "timeline",
-    provider: "codex",
+    provider: options?.provider ?? "codex",
+    ...(options?.turnId !== undefined ? { turnId: options.turnId } : {}),
     item: {
       type: "todo",
       items,
@@ -1539,6 +1547,181 @@ describe("turn lifecycle events", () => {
     assert.deepStrictEqual(
       userMessages.map((item) => item.id),
       ["native-1", "native-2"],
+    );
+  });
+});
+
+describe("stream reducer todo status", () => {
+  it("preserves explicit pending, in_progress, and completed todo statuses", () => {
+    const state = hydrateStreamState([
+      {
+        event: todoTimeline(
+          [
+            { text: "Pending task", completed: false, status: "pending" },
+            { text: "Active task", completed: false, status: "in_progress" },
+            { text: "Done task", completed: true, status: "completed" },
+          ],
+          { provider: "grok", turnId: "turn-status" },
+        ),
+        timestamp: new Date("2025-01-01T13:00:00Z"),
+      },
+    ]);
+
+    const todos = state.filter(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+
+    assert.strictEqual(todos.length, 1);
+    assert.deepStrictEqual(
+      todos[0]?.items.map((item) => ({
+        text: item.text,
+        completed: item.completed,
+        status: item.status,
+      })),
+      [
+        { text: "Pending task", completed: false, status: "pending" },
+        { text: "Active task", completed: false, status: "in_progress" },
+        { text: "Done task", completed: true, status: "completed" },
+      ],
+    );
+  });
+
+  it("derives status from completed for legacy todo entries without status", () => {
+    const state = hydrateStreamState([
+      {
+        event: todoTimeline([
+          { text: "Outline", completed: false },
+          { text: "Ship", completed: true },
+        ]),
+        timestamp: new Date("2025-01-01T13:01:00Z"),
+      },
+    ]);
+
+    const todos = state.find(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+
+    assert.ok(todos);
+    assert.deepStrictEqual(
+      todos.items.map((item) => ({
+        text: item.text,
+        completed: item.completed,
+        status: item.status,
+      })),
+      [
+        { text: "Outline", completed: false, status: "pending" },
+        { text: "Ship", completed: true, status: "completed" },
+      ],
+    );
+  });
+
+  it("replaces the same provider+turn todo card in place across interleaved stream events", () => {
+    const turnId = "turn-coalesce";
+    const provider: AgentProvider = "grok";
+    const firstTodo = todoTimeline(
+      [
+        { text: "Investigate", completed: false, status: "pending" },
+        { text: "Fix", completed: false, status: "pending" },
+      ],
+      { provider, turnId },
+    );
+    const updatedTodo = todoTimeline(
+      [
+        { text: "Investigate", completed: false, status: "in_progress" },
+        { text: "Fix", completed: false, status: "pending" },
+      ],
+      { provider, turnId },
+    );
+
+    let state = reduceStreamUpdate([], firstTodo, new Date("2025-01-01T13:02:00Z"));
+    const firstCard = state.find(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+    assert.ok(firstCard);
+    const cardId = firstCard.id;
+    const cardIndex = state.findIndex((item) => item.id === cardId);
+
+    state = reduceStreamUpdate(
+      state,
+      reasoningTimeline("checking the reducer", provider),
+      new Date("2025-01-01T13:02:01Z"),
+    );
+    state = reduceStreamUpdate(
+      state,
+      assistantTimeline("working on it", provider, "msg-coalesce"),
+      new Date("2025-01-01T13:02:02Z"),
+    );
+    state = reduceStreamUpdate(
+      state,
+      canonicalToolTimeline({
+        provider,
+        callId: "tool-coalesce",
+        name: "shell",
+        status: "running",
+        input: { command: "rg status" },
+      }),
+      new Date("2025-01-01T13:02:03Z"),
+    );
+    state = reduceStreamUpdate(state, updatedTodo, new Date("2025-01-01T13:02:04Z"));
+
+    const todoCards = state.filter(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+    const replacedIndex = state.findIndex((item) => item.id === cardId);
+
+    assert.strictEqual(todoCards.length, 1);
+    assert.strictEqual(todoCards[0]?.id, cardId);
+    assert.strictEqual(todoCards[0]?.turnId, turnId);
+    assert.strictEqual(replacedIndex, cardIndex);
+    assert.deepStrictEqual(
+      todoCards[0]?.items.map((item) => ({ text: item.text, status: item.status })),
+      [
+        { text: "Investigate", status: "in_progress" },
+        { text: "Fix", status: "pending" },
+      ],
+    );
+    assert.ok(replacedIndex < state.findIndex((item) => item.kind === "thought"));
+    assert.ok(replacedIndex < state.findIndex((item) => item.kind === "assistant_message"));
+  });
+
+  it("creates a separate todo card for a different turn", () => {
+    const provider: AgentProvider = "grok";
+    const state = hydrateStreamState([
+      {
+        event: todoTimeline([{ text: "Turn one task", completed: false, status: "in_progress" }], {
+          provider,
+          turnId: "turn-a",
+        }),
+        timestamp: new Date("2025-01-01T13:03:00Z"),
+      },
+      {
+        event: assistantTimeline("between turns", provider, "msg-between-turns"),
+        timestamp: new Date("2025-01-01T13:03:01Z"),
+      },
+      {
+        event: todoTimeline([{ text: "Turn two task", completed: false, status: "pending" }], {
+          provider,
+          turnId: "turn-b",
+        }),
+        timestamp: new Date("2025-01-01T13:03:02Z"),
+      },
+    ]);
+
+    const todoCards = state.filter(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+
+    assert.strictEqual(todoCards.length, 2);
+    assert.deepStrictEqual(
+      todoCards.map((card) => ({
+        turnId: card.turnId,
+        text: card.items[0]?.text,
+        status: card.items[0]?.status,
+      })),
+      [
+        { turnId: "turn-a", text: "Turn one task", status: "in_progress" },
+        { turnId: "turn-b", text: "Turn two task", status: "pending" },
+      ],
     );
   });
 });

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -1,4 +1,8 @@
-import type { AgentProvider, ToolCallDetail } from "@getpaseo/protocol/agent-types";
+import type {
+  AgentProvider,
+  AgentTodoStatus,
+  ToolCallDetail,
+} from "@getpaseo/protocol/agent-types";
 import type { AgentAttachment, AgentStreamEventPayload } from "@getpaseo/protocol/messages";
 import type { AttachmentMetadata } from "@/attachments/types";
 import { extractTaskEntriesFromToolCall } from "../utils/tool-call-parsers";
@@ -194,6 +198,7 @@ export interface CompactionItem {
 export interface TodoEntry {
   text: string;
   completed: boolean;
+  status?: AgentTodoStatus;
 }
 
 export interface TodoListItem {
@@ -202,6 +207,7 @@ export interface TodoListItem {
   timestamp: Date;
   provider: AgentProvider;
   items: TodoEntry[];
+  turnId?: string;
 }
 
 export type StreamUpdateSource = "live" | "canonical";
@@ -698,30 +704,71 @@ function appendActivityLog(state: StreamItem[], entry: ActivityLogItem): StreamI
   return [...state, entry];
 }
 
+function normalizeTodoEntry(entry: {
+  text: string;
+  completed: boolean;
+  status?: AgentTodoStatus | null;
+}): TodoEntry {
+  if (
+    entry.status === "pending" ||
+    entry.status === "in_progress" ||
+    entry.status === "completed"
+  ) {
+    return {
+      text: entry.text,
+      status: entry.status,
+      completed: entry.status === "completed",
+    };
+  }
+  // COMPAT(todoStatus): added in v0.2.0, remove after 2027-01-20 once all hosts send status.
+  return {
+    text: entry.text,
+    completed: entry.completed,
+    status: entry.completed ? "completed" : "pending",
+  };
+}
+
 function appendTodoList(
   state: StreamItem[],
   provider: AgentProvider,
   items: TodoEntry[],
   timestamp: Date,
+  turnId?: string,
 ): StreamItem[] {
-  const normalizedItems = items.map((item) => ({
-    text: item.text,
-    completed: item.completed,
-  }));
+  const normalizedItems = items.map((item) => normalizeTodoEntry(item));
 
-  const lastItem = state[state.length - 1];
-  if (lastItem && lastItem.kind === "todo_list" && lastItem.provider === provider) {
-    const next = [...state];
-    const updated: TodoListItem = {
-      ...lastItem,
-      items: normalizedItems,
-      timestamp,
-    };
-    next[next.length - 1] = updated;
-    return next;
+  if (turnId !== undefined) {
+    for (let index = state.length - 1; index >= 0; index -= 1) {
+      const candidate = state[index];
+      if (
+        candidate?.kind === "todo_list" &&
+        candidate.provider === provider &&
+        candidate.turnId === turnId
+      ) {
+        const next = [...state];
+        next[index] = {
+          ...candidate,
+          items: normalizedItems,
+          timestamp,
+          turnId,
+        };
+        return next;
+      }
+    }
+  } else {
+    const lastItem = state[state.length - 1];
+    if (lastItem && lastItem.kind === "todo_list" && lastItem.provider === provider) {
+      const next = [...state];
+      next[next.length - 1] = {
+        ...lastItem,
+        items: normalizedItems,
+        timestamp,
+      };
+      return next;
+    }
   }
 
-  const idSeed = `${provider}:${JSON.stringify(normalizedItems)}`;
+  const idSeed = `${provider}:${turnId ?? ""}:${JSON.stringify(normalizedItems)}`;
   const entryId = createUniqueTimelineId(state, "todo", idSeed, timestamp);
 
   const entry: TodoListItem = {
@@ -730,6 +777,7 @@ function appendTodoList(
     timestamp,
     provider,
     items: normalizedItems,
+    ...(turnId !== undefined ? { turnId } : {}),
   };
 
   return [...state, entry];
@@ -763,8 +811,13 @@ function reduceTimelineToolCall(
     return appendTodoList(
       state,
       event.provider,
-      tasks.map((entry) => ({ text: entry.text, completed: entry.completed })),
+      tasks.map((entry) => ({
+        text: entry.text,
+        completed: entry.completed,
+        status: entry.status,
+      })),
       timestamp,
+      event.turnId,
     );
   }
 
@@ -773,8 +826,13 @@ function reduceTimelineToolCall(
     return appendTodoList(
       state,
       event.provider,
-      tasks.map((entry) => ({ text: entry.text, completed: entry.completed })),
+      tasks.map((entry) => ({
+        text: entry.text,
+        completed: entry.completed,
+        status: entry.status,
+      })),
       timestamp,
+      event.turnId,
     );
   }
 
@@ -865,8 +923,11 @@ function reduceTimelineEvent(
       const items: TodoEntry[] = (item.items ?? []).map((todo) => ({
         text: todo.text,
         completed: todo.completed,
+        status: todo.status,
       }));
-      return finalizeActiveThoughts(appendTodoList(state, event.provider, items, timestamp));
+      return finalizeActiveThoughts(
+        appendTodoList(state, event.provider, items, timestamp, event.turnId),
+      );
     }
     case "error": {
       const activity: ActivityLogItem = {

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -337,12 +337,14 @@ export interface CompactionTimelineItem {
   preTokens?: number;
 }
 
+export type AgentTodoStatus = "pending" | "in_progress" | "completed";
+
 export type AgentTimelineItem =
   | { type: "user_message"; text: string; messageId?: string; clientMessageId?: string }
   | { type: "assistant_message"; text: string; messageId?: string }
   | { type: "reasoning"; text: string }
   | ToolCallTimelineItem
-  | { type: "todo"; items: { text: string; completed: boolean }[] }
+  | { type: "todo"; items: { text: string; completed: boolean; status?: AgentTodoStatus }[] }
   | { type: "error"; message: string }
   | CompactionTimelineItem;
 

--- a/packages/protocol/src/messages.stream-parsing.test.ts
+++ b/packages/protocol/src/messages.stream-parsing.test.ts
@@ -195,6 +195,74 @@ describe("shared messages stream parsing", () => {
     }
   });
 
+  it("parses legacy and explicit-status todo timeline payloads", () => {
+    const legacyParsed = AgentStreamMessageSchema.parse({
+      type: "agent_stream",
+      payload: {
+        agentId: "agent_live",
+        timestamp: "2026-02-08T20:10:00.000Z",
+        event: {
+          type: "timeline",
+          provider: "grok",
+          item: {
+            type: "todo",
+            items: [
+              { text: "Legacy done", completed: true },
+              { text: "Legacy open", completed: false },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(legacyParsed.payload.event.type).toBe("timeline");
+    if (legacyParsed.payload.event.type !== "timeline") {
+      throw new Error("Expected timeline event");
+    }
+    expect(legacyParsed.payload.event.item).toEqual({
+      type: "todo",
+      items: [
+        { text: "Legacy done", completed: true },
+        { text: "Legacy open", completed: false },
+      ],
+    });
+
+    const statusParsed = AgentStreamMessageSchema.parse({
+      type: "agent_stream",
+      payload: {
+        agentId: "agent_live",
+        timestamp: "2026-02-08T20:10:00.000Z",
+        event: {
+          type: "timeline",
+          provider: "grok",
+          turnId: "turn-todo-status",
+          item: {
+            type: "todo",
+            items: [
+              { text: "Pending", completed: false, status: "pending" },
+              { text: "Active", completed: false, status: "in_progress" },
+              { text: "Done", completed: true, status: "completed" },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(statusParsed.payload.event.type).toBe("timeline");
+    if (statusParsed.payload.event.type !== "timeline") {
+      throw new Error("Expected timeline event");
+    }
+    expect(statusParsed.payload.event.turnId).toBe("turn-todo-status");
+    expect(statusParsed.payload.event.item).toEqual({
+      type: "todo",
+      items: [
+        { text: "Pending", completed: false, status: "pending" },
+        { text: "Active", completed: false, status: "in_progress" },
+        { text: "Done", completed: true, status: "completed" },
+      ],
+    });
+  });
+
   it("parses optional permission actions and selectedActionId compatibly", () => {
     const requestParsed = AgentStreamMessageSchema.parse({
       type: "agent_stream",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -588,6 +588,7 @@ export const AgentTimelineItemPayloadSchema: z.ZodType<AgentTimelineItem, unknow
       z.object({
         text: z.string(),
         completed: z.boolean(),
+        status: z.enum(["pending", "in_progress", "completed"]).optional(),
       }),
     ),
   }),
@@ -633,6 +634,7 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("timeline"),
     provider: AgentProviderSchema,
+    turnId: z.string().optional(),
     item: AgentTimelineItemPayloadSchema,
   }),
   z.object({
@@ -3429,6 +3431,7 @@ export const AgentTimelineEntryPayloadSchema = z.object({
   provider: AgentProviderSchema,
   item: AgentTimelineItemPayloadSchema,
   timestamp: z.string(),
+  turnId: z.string().optional(),
   seqStart: z.number().int().nonnegative(),
   seqEnd: z.number().int().nonnegative(),
   sourceSeqRanges: z.array(AgentTimelineSeqRangeSchema),

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -534,6 +534,7 @@ function buildImportedTimelineRows(entries: readonly ImportedTimelineEntry[]): A
       seq: rows.length + 1,
       timestamp: entry.timestamp ?? new Date().toISOString(),
       item: limitAgentTimelineItemContent(entry.item),
+      ...(entry.turnId !== undefined ? { turnId: entry.turnId } : {}),
     });
   }
   return rows;
@@ -1922,7 +1923,11 @@ export class AgentManager {
       // for live subscribers. Other event types are broadcast only.
       if (event.type === "timeline") {
         this.touchUpdatedAt(agent);
-        const row = this.recordTimeline(agent.id, event.item);
+        const row = this.recordTimeline(
+          agent.id,
+          event.item,
+          event.turnId !== undefined ? { turnId: event.turnId } : undefined,
+        );
         this.dispatchStream(agent.id, event, {
           seq: row.seq,
           epoch: this.timelineStore.getEpoch(agent.id),
@@ -3220,11 +3225,10 @@ export class AgentManager {
       }
     }
     for (const event of historyEvents) {
-      const row = this.recordTimeline(
-        agent.id,
-        event.item,
-        event.timestamp ? { timestamp: event.timestamp } : undefined,
-      );
+      const row = this.recordTimeline(agent.id, event.item, {
+        ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+        ...(event.turnId !== undefined ? { turnId: event.turnId } : {}),
+      });
       if (broadcast) {
         this.dispatchStream(agent.id, event, {
           seq: row.seq,
@@ -3257,11 +3261,10 @@ export class AgentManager {
         if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
           continue;
         }
-        this.recordTimeline(
-          agent.id,
-          event.item,
-          event.timestamp ? { timestamp: event.timestamp } : undefined,
-        );
+        this.recordTimeline(agent.id, event.item, {
+          ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+          ...(event.turnId !== undefined ? { turnId: event.turnId } : {}),
+        });
       }
     } catch {
       // ignore history failures
@@ -3521,11 +3524,10 @@ export class AgentManager {
     }
 
     if (options?.fromHistory) {
-      this.recordTimeline(
-        agent.id,
-        event.item,
-        event.timestamp ? { timestamp: event.timestamp } : undefined,
-      );
+      this.recordTimeline(agent.id, event.item, {
+        ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+        ...(event.turnId !== undefined ? { turnId: event.turnId } : {}),
+      });
       flags.shouldDispatchEvent = false;
       flags.shouldNotifyWaiters = false;
       return;
@@ -3717,7 +3719,7 @@ export class AgentManager {
     provider: AgentProvider,
     turnId?: string,
   ): AgentStreamEvent {
-    const row = this.recordTimeline(agentId, item);
+    const row = this.recordTimeline(agentId, item, turnId !== undefined ? { turnId } : undefined);
     const event: AgentStreamEvent = {
       type: "timeline",
       item,
@@ -3802,7 +3804,7 @@ export class AgentManager {
   private recordTimeline(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string },
+    options?: { timestamp?: string; turnId?: string },
   ): AgentTimelineRow {
     item = limitAgentTimelineItemContent(item);
     const row = this.timelineStore.append(agentId, item, options);

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -540,6 +540,7 @@ export interface ImportProviderSessionContext {
 export interface ImportedTimelineEntry {
   item: AgentTimelineItem;
   timestamp?: string;
+  turnId?: string;
 }
 
 export interface ImportedProviderSession {

--- a/packages/server/src/server/agent/agent-timeline-store-types.ts
+++ b/packages/server/src/server/agent/agent-timeline-store-types.ts
@@ -4,6 +4,7 @@ export interface AgentTimelineRow {
   seq: number;
   timestamp: string;
   item: AgentTimelineItem;
+  turnId?: string;
 }
 
 export interface AgentTimelineCursor {
@@ -46,7 +47,7 @@ export interface AgentTimelineStore {
   appendCommitted(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string },
+    options?: { timestamp?: string; turnId?: string },
   ): Promise<AgentTimelineRow>;
   fetchCommitted(
     agentId: string,

--- a/packages/server/src/server/agent/agent-timeline-store.test.ts
+++ b/packages/server/src/server/agent/agent-timeline-store.test.ts
@@ -50,4 +50,42 @@ describe("InMemoryAgentTimelineStore", () => {
       ],
     });
   });
+
+  it("preserves optional turnId on append and fetch", () => {
+    const store = new InMemoryAgentTimelineStore();
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      nextSeq: 1,
+      rows: [],
+    });
+
+    const withTurn = store.append(
+      "agent-1",
+      { type: "todo", items: [{ text: "one", completed: false }] },
+      { timestamp: "2026-01-01T00:00:00.000Z", turnId: "turn-1" },
+    );
+    const withoutTurn = store.append(
+      "agent-1",
+      { type: "assistant_message", text: "done" },
+      { timestamp: "2026-01-01T00:00:01.000Z" },
+    );
+
+    expect(withTurn.turnId).toBe("turn-1");
+    expect(withoutTurn.turnId).toBeUndefined();
+
+    const fetched = store.fetch("agent-1", { direction: "tail", limit: 10 });
+    expect(fetched.rows).toEqual([
+      {
+        seq: 1,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        item: { type: "todo", items: [{ text: "one", completed: false }] },
+        turnId: "turn-1",
+      },
+      {
+        seq: 2,
+        timestamp: "2026-01-01T00:00:01.000Z",
+        item: { type: "assistant_message", text: "done" },
+      },
+    ]);
+  });
 });

--- a/packages/server/src/server/agent/agent-timeline-store.ts
+++ b/packages/server/src/server/agent/agent-timeline-store.ts
@@ -235,13 +235,14 @@ export class InMemoryAgentTimelineStore {
   append(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string },
+    options?: { timestamp?: string; turnId?: string },
   ): AgentTimelineRow {
     const state = this.requireState(agentId);
     const row: AgentTimelineRow = {
       seq: state.nextSeq,
       timestamp: options?.timestamp ?? new Date().toISOString(),
       item,
+      ...(options?.turnId !== undefined ? { turnId: options.turnId } : {}),
     };
     state.nextSeq += 1;
     state.rows.push(row);

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -34,6 +34,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import { GrokACPAgentClient } from "./providers/grok-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
 import { OmpAgentClient } from "./providers/omp/agent.js";
@@ -675,6 +676,9 @@ function addDerivedProviders(
           };
           if (providerId === "cursor") {
             return new CursorACPAgentClient(acpOptions);
+          }
+          if (providerId === "grok") {
+            return new GrokACPAgentClient(acpOptions);
           }
           if (providerId === "kiro") {
             return new KiroACPAgentClient(acpOptions);

--- a/packages/server/src/server/agent/provider-session-import.ts
+++ b/packages/server/src/server/agent/provider-session-import.ts
@@ -78,6 +78,7 @@ async function collectImportedHistory(events: AsyncGenerator<AgentStreamEvent>):
     timeline.push({
       item: event.item,
       ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+      ...(event.turnId !== undefined ? { turnId: event.turnId } : {}),
     });
   }
   return { timeline, providerSubagentEvents };

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   ACPAgentClient,
   ACPAgentSession,
+  type ACPExtensionNotificationParser,
   type SpawnedACPProcess,
   type SessionStateResponse,
   buildACPClientCapabilities,
@@ -125,7 +126,11 @@ interface ACPConfiguredOverrideInternals {
   applyConfiguredOverrides(): Promise<void>;
 }
 
-function createSession(terminateProcess?: ProcessTerminator): ACPAgentSession {
+function createSession(
+  terminateProcess?: ProcessTerminator,
+  forwardChildSessionUpdates = false,
+  extensionNotificationParser?: ACPExtensionNotificationParser,
+): ACPAgentSession {
   return new ACPAgentSession(
     {
       provider: "claude-acp",
@@ -144,6 +149,8 @@ function createSession(terminateProcess?: ProcessTerminator): ACPAgentSession {
         supportsReasoningStream: true,
         supportsToolInvocations: true,
       },
+      forwardChildSessionUpdates,
+      extensionNotificationParser,
       ...(terminateProcess ? { terminateProcess } : {}),
     },
   );
@@ -2164,6 +2171,152 @@ describe("ACPAgentSession", () => {
       { type: "reasoning", text: " more" },
       { type: "user_message", text: "hel", messageId: "user-1" },
       { type: "user_message", text: "hello", messageId: "user-1" },
+    ]);
+  });
+
+  test("routes opted-in child session updates into provider subagent timelines", async () => {
+    const extensionNotificationParser: ACPExtensionNotificationParser = () => [
+      {
+        type: "provider_subagent",
+        provider: "claude-acp",
+        event: {
+          type: "timeline",
+          id: "child-1",
+          item: { type: "assistant_message", text: "Done" },
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "claude-acp",
+        event: { type: "upsert", id: "child-1", status: "completed" },
+      },
+    ];
+    const session = createSession(undefined, true, extensionNotificationParser);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "parent-1";
+    session.subscribe((event) => events.push(event));
+
+    const childUpdates = [
+      {
+        sessionUpdate: "user_message_chunk",
+        messageId: "user-1",
+        content: { type: "text", text: "hel" },
+      },
+      {
+        sessionUpdate: "user_message_chunk",
+        messageId: "user-1",
+        content: { type: "text", text: "lo" },
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "First" },
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: " part" },
+      },
+      {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "Think" },
+      },
+      {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: " more" },
+      },
+      {
+        sessionUpdate: "plan",
+        entries: [
+          { content: "Inspect", status: "completed" },
+          { content: "Implement", status: "in_progress" },
+          { content: "Report", status: "pending" },
+        ],
+      },
+      {
+        sessionUpdate: "tool_call",
+        toolCallId: "child-tool",
+        title: "Read a file",
+        kind: "read",
+        status: "pending",
+        rawInput: { path: "/tmp/input.txt" },
+      },
+      {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "child-tool",
+        status: "completed",
+      },
+      {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "child-answer",
+        content: { type: "text", text: "Done" },
+      },
+      // Intervening non-assistant event before completion output.
+      {
+        sessionUpdate: "tool_call",
+        toolCallId: "child-final-tool",
+        title: "Verify the result",
+        kind: "read",
+        status: "completed",
+        rawInput: { path: "/tmp/output.txt" },
+      },
+    ] as SessionUpdate[];
+
+    for (const update of childUpdates) {
+      await session.sessionUpdate({ sessionId: "child-1", update });
+    }
+    await session.extNotification("_provider/subagent_finished", {});
+
+    const projected = events.flatMap((event) => {
+      if (event.type !== "provider_subagent") {
+        return [];
+      }
+      if (event.event.type === "upsert") {
+        return [{ type: "upsert" as const, id: event.event.id, status: event.event.status }];
+      }
+      if (event.event.type !== "timeline") {
+        return [];
+      }
+      const item = event.event.item;
+      switch (item.type) {
+        case "user_message":
+        case "assistant_message":
+          return [{ type: item.type, text: item.text, messageId: item.messageId }];
+        case "reasoning":
+          return [{ type: "reasoning" as const, text: item.text }];
+        case "todo":
+          return [{ type: "todo" as const, items: item.items }];
+        case "tool_call":
+          return [{ type: "tool_call" as const, callId: item.callId, status: item.status }];
+        default:
+          return [{ type: item.type }];
+      }
+    });
+
+    const fallbackId = projected.find(
+      (entry) => entry.type === "assistant_message" && entry.messageId !== "child-answer",
+    )?.messageId;
+
+    expect(fallbackId).toEqual(expect.any(String));
+    expect(projected).toEqual([
+      { type: "user_message", text: "hel", messageId: "user-1" },
+      { type: "user_message", text: "hello", messageId: "user-1" },
+      { type: "assistant_message", text: "First", messageId: fallbackId },
+      { type: "assistant_message", text: " part", messageId: fallbackId },
+      { type: "reasoning", text: "Think" },
+      { type: "reasoning", text: " more" },
+      {
+        type: "todo",
+        items: [
+          { text: "Inspect", completed: true, status: "completed" },
+          { text: "Implement", completed: false, status: "in_progress" },
+          { text: "Report", completed: false, status: "pending" },
+        ],
+      },
+      { type: "tool_call", callId: "child-tool", status: "running" },
+      { type: "tool_call", callId: "child-tool", status: "completed" },
+      { type: "assistant_message", text: "Done", messageId: "child-answer" },
+      { type: "tool_call", callId: "child-final-tool", status: "completed" },
+      // Completion assistant text matching streamed output is dropped after the tool.
+      { type: "upsert", id: "child-1", status: "completed" },
     ]);
   });
 

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -27,6 +27,7 @@ import {
   mapACPUsage,
   resolveACPModeSelection,
   resolveACPModelSelection,
+  resolveAcpToolCallName,
   summarizeACPRequestError,
 } from "./acp-agent.js";
 import type { ProcessTerminator, TreeKillTarget } from "../../../utils/tree-kill.js";
@@ -2992,5 +2993,46 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
       cwd: "/tmp/paseo-acp-test",
       mcpServers: [],
     });
+  });
+});
+
+describe("resolveAcpToolCallName", () => {
+  test("uses title when kind is other", () => {
+    expect(
+      resolveAcpToolCallName({
+        toolCallId: "call-1",
+        title: "Web search",
+        kind: "other",
+      } as never),
+    ).toBe("Web search");
+  });
+
+  test("uses title when kind is missing", () => {
+    expect(
+      resolveAcpToolCallName({
+        toolCallId: "call-2",
+        title: "Custom tool",
+      } as never),
+    ).toBe("Custom tool");
+  });
+
+  test("falls back to toolCallId when title and kind are empty", () => {
+    expect(
+      resolveAcpToolCallName({
+        toolCallId: "call-3",
+        title: "   ",
+        kind: "",
+      } as never),
+    ).toBe("call-3");
+  });
+
+  test("uses kind for normal tool kinds", () => {
+    expect(
+      resolveAcpToolCallName({
+        toolCallId: "call-4",
+        title: "Read a file",
+        kind: "read",
+      } as never),
+    ).toBe("read");
   });
 });

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -3063,6 +3063,17 @@ function mapPlanToTimeline(plan: Plan): AgentTimelineItem {
   };
 }
 
+export function resolveAcpToolCallName(snapshot: ACPToolSnapshot): string {
+  const kind = typeof snapshot.kind === "string" ? snapshot.kind.trim() : "";
+  const title = snapshot.title.trim();
+  // Generic ACP "other" (and missing kind) should not become the display label
+  // "Other" — prefer the human title agents put on the tool.
+  if (!kind || kind === "other") {
+    return title || kind || snapshot.toolCallId;
+  }
+  return kind;
+}
+
 function mapToolSnapshotToTimeline(
   snapshot: ACPToolSnapshot,
   terminals: Map<string, TerminalEntry>,
@@ -3072,7 +3083,7 @@ function mapToolSnapshotToTimeline(
   const base = {
     type: "tool_call" as const,
     callId: snapshot.toolCallId,
-    name: snapshot.kind ?? snapshot.title,
+    name: resolveAcpToolCallName(snapshot),
     detail,
     metadata: {
       kind: snapshot.kind ?? undefined,

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -3058,6 +3058,7 @@ function mapPlanToTimeline(plan: Plan): AgentTimelineItem {
     items: plan.entries.map((entry) => ({
       text: entry.content,
       completed: entry.status === "completed",
+      status: entry.status,
     })),
   };
 }

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -238,6 +238,7 @@ const BASE_ACP_CLIENT_CAPABILITIES: ACPClientCapabilities = {
 };
 
 export type ACPClientCapabilityMeta = Record<string, unknown>;
+export type ACPInitializeRequestMeta = Record<string, unknown>;
 
 export function buildACPClientCapabilities(
   meta?: ACPClientCapabilityMeta,
@@ -365,6 +366,34 @@ export type ACPExtensionCommandsParser = (
   method: string,
   params: Record<string, unknown>,
 ) => AgentSlashCommand[] | null;
+export type ACPInitialCommandsParser = (response: InitializeResponse) => AgentSlashCommand[] | null;
+
+export interface ACPExtensionNotificationParserContext {
+  provider: string;
+  sessionId: string | null;
+  turnId: string | null;
+}
+
+export type ACPExtensionNotificationParser = (
+  method: string,
+  params: Record<string, unknown>,
+  context: ACPExtensionNotificationParserContext,
+) => AgentStreamEvent[] | null;
+
+export interface ACPThinkingOptionWriterContext {
+  connection: ClientSideConnection;
+  sessionId: string;
+  modelId: string;
+  thinkingOptionId: string;
+}
+
+export type ACPThinkingOptionWriter = (context: ACPThinkingOptionWriterContext) => Promise<void>;
+
+/** Optional post-pass after the generic ACP tool detail mapper (vendor polish). */
+export type ACPToolDetailMapper = (
+  snapshot: ACPToolSnapshot,
+  defaultDetail: ToolCallDetail,
+) => ToolCallDetail;
 
 interface ACPAgentClientOptions {
   provider: string;
@@ -378,19 +407,20 @@ interface ACPAgentClientOptions {
   configFeatureOptions?: ACPConfigFeatureOption[];
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
+  initializeRequestMeta?: ACPInitializeRequestMeta;
   modeIdTransformer?: (modeId: string) => string | null;
   toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  toolDetailMapper?: ACPToolDetailMapper;
   providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
   beforeModeWriter?: (context: ACPProviderModeWriterContext) => Promise<ACPBeforeModeWriteResult>;
-  thinkingOptionWriter?: (
-    connection: ClientSideConnection,
-    sessionId: string,
-    thinkingOptionId: string,
-  ) => Promise<void>;
+  thinkingOptionWriter?: ACPThinkingOptionWriter;
   capabilities?: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  initialCommandsParser?: ACPInitialCommandsParser;
+  extensionNotificationParser?: ACPExtensionNotificationParser;
+  forwardChildSessionUpdates?: boolean;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
@@ -408,19 +438,20 @@ interface ACPAgentSessionOptions {
   configFeatureOptions?: ACPConfigFeatureOption[];
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
+  initializeRequestMeta?: ACPInitializeRequestMeta;
   modeIdTransformer?: (modeId: string) => string | null;
   toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  toolDetailMapper?: ACPToolDetailMapper;
   providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
   beforeModeWriter?: (context: ACPProviderModeWriterContext) => Promise<ACPBeforeModeWriteResult>;
-  thinkingOptionWriter?: (
-    connection: ClientSideConnection,
-    sessionId: string,
-    thinkingOptionId: string,
-  ) => Promise<void>;
+  thinkingOptionWriter?: ACPThinkingOptionWriter;
   capabilities: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  initialCommandsParser?: ACPInitialCommandsParser;
+  extensionNotificationParser?: ACPExtensionNotificationParser;
+  forwardChildSessionUpdates?: boolean;
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
@@ -469,6 +500,14 @@ interface PendingPermission {
 
 interface MessageAssemblyState {
   text: string;
+}
+
+/** Per-session content translation state shared by foreground and child paths. */
+interface SessionContentTranslationState {
+  messageAssemblies: Map<string, MessageAssemblyState>;
+  toolCalls: Map<string, ACPToolSnapshot>;
+  fallbackAssistantMessageId: string | null;
+  currentAssistantAssemblyKey: string | null;
 }
 
 interface SubmittedUserMessageEcho {
@@ -717,22 +756,23 @@ export class ACPAgentClient implements AgentClient {
   private readonly configFeatureOptions: ACPConfigFeatureOption[];
   private readonly clientCapabilities?: ACPClientCapabilities;
   private readonly clientCapabilityMeta?: ACPClientCapabilityMeta;
+  private readonly initializeRequestMeta?: ACPInitializeRequestMeta;
   private readonly modeIdTransformer?: (modeId: string) => string | null;
   private readonly toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  private readonly toolDetailMapper?: ACPToolDetailMapper;
   private readonly providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
   private readonly beforeModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPBeforeModeWriteResult>;
-  private readonly thinkingOptionWriter?: (
-    connection: ClientSideConnection,
-    sessionId: string,
-    thinkingOptionId: string,
-  ) => Promise<void>;
+  private readonly thinkingOptionWriter?: ACPThinkingOptionWriter;
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly initialCommandsParser?: ACPInitialCommandsParser;
+  private readonly extensionNotificationParser?: ACPExtensionNotificationParser;
+  private readonly forwardChildSessionUpdates: boolean;
   protected readonly terminateProcess: ProcessTerminator;
 
   constructor(options: ACPAgentClientOptions) {
@@ -752,14 +792,19 @@ export class ACPAgentClient implements AgentClient {
     this.configFeatureOptions = options.configFeatureOptions ?? [];
     this.clientCapabilities = options.clientCapabilities;
     this.clientCapabilityMeta = options.clientCapabilityMeta;
+    this.initializeRequestMeta = options.initializeRequestMeta;
     this.modeIdTransformer = options.modeIdTransformer;
     this.toolSnapshotTransformer = options.toolSnapshotTransformer;
+    this.toolDetailMapper = options.toolDetailMapper;
     this.providerModeWriter = options.providerModeWriter;
     this.beforeModeWriter = options.beforeModeWriter;
     this.thinkingOptionWriter = options.thinkingOptionWriter;
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.initialCommandsParser = options.initialCommandsParser;
+    this.extensionNotificationParser = options.extensionNotificationParser;
+    this.forwardChildSessionUpdates = options.forwardChildSessionUpdates ?? false;
   }
 
   async createSession(
@@ -781,8 +826,10 @@ export class ACPAgentClient implements AgentClient {
         configFeatureOptions: this.configFeatureOptions,
         clientCapabilities: this.clientCapabilities,
         clientCapabilityMeta: this.clientCapabilityMeta,
+        initializeRequestMeta: this.initializeRequestMeta,
         modeIdTransformer: this.modeIdTransformer,
         toolSnapshotTransformer: this.toolSnapshotTransformer,
+        toolDetailMapper: this.toolDetailMapper,
         providerModeWriter: this.providerModeWriter,
         beforeModeWriter: this.beforeModeWriter,
         thinkingOptionWriter: this.thinkingOptionWriter,
@@ -790,6 +837,9 @@ export class ACPAgentClient implements AgentClient {
         agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
         extensionCommandsParser: this.extensionCommandsParser,
+        initialCommandsParser: this.initialCommandsParser,
+        extensionNotificationParser: this.extensionNotificationParser,
+        forwardChildSessionUpdates: this.forwardChildSessionUpdates,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
       },
@@ -831,8 +881,10 @@ export class ACPAgentClient implements AgentClient {
       configFeatureOptions: this.configFeatureOptions,
       clientCapabilities: this.clientCapabilities,
       clientCapabilityMeta: this.clientCapabilityMeta,
+      initializeRequestMeta: this.initializeRequestMeta,
       modeIdTransformer: this.modeIdTransformer,
       toolSnapshotTransformer: this.toolSnapshotTransformer,
+      toolDetailMapper: this.toolDetailMapper,
       providerModeWriter: this.providerModeWriter,
       beforeModeWriter: this.beforeModeWriter,
       thinkingOptionWriter: this.thinkingOptionWriter,
@@ -841,6 +893,9 @@ export class ACPAgentClient implements AgentClient {
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
       extensionCommandsParser: this.extensionCommandsParser,
+      initialCommandsParser: this.initialCommandsParser,
+      extensionNotificationParser: this.extensionNotificationParser,
+      forwardChildSessionUpdates: this.forwardChildSessionUpdates,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
     });
@@ -1073,6 +1128,7 @@ export class ACPAgentClient implements AgentClient {
               this.clientCapabilities,
             ),
             clientInfo: { name: "Paseo", version: "dev" },
+            _meta: this.initializeRequestMeta,
           }),
           transport.spawnError,
           ...(initializeTimeoutPromise ? [initializeTimeoutPromise] : []),
@@ -1285,29 +1341,33 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly configFeatureOptions: ACPConfigFeatureOption[];
   private readonly clientCapabilities?: ACPClientCapabilities;
   private readonly clientCapabilityMeta?: ACPClientCapabilityMeta;
+  private readonly initializeRequestMeta?: ACPInitializeRequestMeta;
   private readonly modeIdTransformer?: (modeId: string) => string | null;
   private readonly toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  private readonly toolDetailMapper?: ACPToolDetailMapper;
   private readonly providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
   private readonly beforeModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPBeforeModeWriteResult>;
-  private readonly thinkingOptionWriter?: (
-    connection: ClientSideConnection,
-    sessionId: string,
-    thinkingOptionId: string,
-  ) => Promise<void>;
+  private readonly thinkingOptionWriter?: ACPThinkingOptionWriter;
   private readonly agentId?: string;
   private readonly launchEnv?: Record<string, string>;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private readonly pendingPermissions = new Map<string, PendingPermission>();
-  private readonly messageAssemblies = new Map<string, MessageAssemblyState>();
+  private readonly contentTranslationState: SessionContentTranslationState = {
+    messageAssemblies: new Map(),
+    toolCalls: new Map(),
+    fallbackAssistantMessageId: null,
+    currentAssistantAssemblyKey: null,
+  };
   private readonly submittedUserMessageIds = new Set<string>();
   private activeSubmittedUserMessage: SubmittedUserMessageEcho | null = null;
-  private readonly toolCalls = new Map<string, ACPToolSnapshot>();
   private readonly terminalEntries = new Map<string, TerminalEntry>();
-  private readonly persistedHistory: AgentTimelineItem[] = [];
+  private readonly persistedEvents: Array<
+    Extract<AgentStreamEvent, { type: "timeline" } | { type: "provider_subagent" }>
+  > = [];
   private readonly initialHandle?: AgentPersistenceHandle;
 
   private readonly config: AgentSessionConfig;
@@ -1329,9 +1389,15 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private waitForInitialCommands: boolean;
   private initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly initialCommandsParser?: ACPInitialCommandsParser;
+  private readonly extensionNotificationParser?: ACPExtensionNotificationParser;
+  private readonly forwardChildSessionUpdates: boolean;
+  private readonly providerSubagentSessionUpdateStates = new Map<
+    string,
+    SessionContentTranslationState
+  >();
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
-  private fallbackAssistantMessageId: string | null = null;
   private closed = false;
   private historyPending = false;
   private replayingHistory = false;
@@ -1352,8 +1418,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.configFeatureOptions = options.configFeatureOptions ?? [];
     this.clientCapabilities = options.clientCapabilities;
     this.clientCapabilityMeta = options.clientCapabilityMeta;
+    this.initializeRequestMeta = options.initializeRequestMeta;
     this.modeIdTransformer = options.modeIdTransformer;
     this.toolSnapshotTransformer = options.toolSnapshotTransformer;
+    this.toolDetailMapper = options.toolDetailMapper;
     this.providerModeWriter = options.providerModeWriter;
     this.beforeModeWriter = options.beforeModeWriter;
     this.thinkingOptionWriter = options.thinkingOptionWriter;
@@ -1369,6 +1437,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.initialCommandsParser = options.initialCommandsParser;
+    this.extensionNotificationParser = options.extensionNotificationParser;
+    this.forwardChildSessionUpdates = options.forwardChildSessionUpdates ?? false;
   }
 
   get id(): string | null {
@@ -1390,6 +1461,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.sessionId = response.sessionId;
     this.bootstrapThreadEventPending = true;
     this.applySessionState(response);
+    this.applyInitialCommands(spawned.initialize);
     await this.applyConfiguredOverrides();
   }
 
@@ -1424,7 +1496,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         }),
       );
       this.replayingHistory = false;
-      this.historyPending = this.persistedHistory.length > 0;
+      this.historyPending = this.persistedEvents.length > 0;
       this.applySessionState(response);
     } else if (sessionCapabilities?.resume) {
       const response = await this.runACPRequest(() =>
@@ -1438,6 +1510,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     } else {
       throw new Error(`${this.provider} does not support ACP session resume`);
     }
+    this.applyInitialCommands(spawned.initialize);
 
     await this.applyConfiguredOverrides();
   }
@@ -1476,7 +1549,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     const turnId = randomUUID();
     const messageId = options?.clientMessageId ?? randomUUID();
     this.activeForegroundTurnId = turnId;
-    this.fallbackAssistantMessageId = null;
+    this.resetAssistantMessageContinuity(this.contentTranslationState);
     this.activeSubmittedUserMessage = null;
     this.emitBootstrapThreadEvent();
     this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
@@ -1522,15 +1595,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
-    if (!this.historyPending || this.persistedHistory.length === 0) {
+    if (!this.historyPending || this.persistedEvents.length === 0) {
       return;
     }
-    const history = [...this.persistedHistory];
-    this.persistedHistory.length = 0;
+    const history = [...this.persistedEvents];
+    this.persistedEvents.length = 0;
     this.historyPending = false;
-    for (const item of history) {
-      yield { type: "timeline", provider: this.provider, item };
-    }
+    yield* history;
   }
 
   async getRuntimeInfo(): Promise<AgentRuntimeInfo> {
@@ -1588,6 +1659,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       if (timer) {
         clearTimeout(timer);
       }
+    }
+  }
+
+  private applyInitialCommands(response: InitializeResponse): void {
+    const commands = this.initialCommandsParser?.(response);
+    if (commands) {
+      this.applyResolvedCommands(commands);
     }
   }
 
@@ -1845,7 +1923,15 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
 
     if (this.thinkingOptionWriter) {
-      await this.thinkingOptionWriter(this.connection, this.sessionId, thinkingOptionId);
+      if (!this.currentModel) {
+        throw new Error(`${this.provider} cannot set a thinking option without a current model`);
+      }
+      await this.thinkingOptionWriter({
+        connection: this.connection,
+        sessionId: this.sessionId,
+        modelId: this.currentModel,
+        thinkingOptionId,
+      });
       this.thinkingOptionId = thinkingOptionId;
       this.pushEvent({
         type: "thinking_option_changed",
@@ -2069,7 +2155,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     // Match Zed acp.rs:3189-3220: generic ACP permission requests stay pure pass-through.
     const requestId = randomUUID();
     let toolSnapshot =
-      this.toolCalls.get(params.toolCall.toolCallId) ??
+      this.contentTranslationState.toolCalls.get(params.toolCall.toolCallId) ??
       mergeToolSnapshot(params.toolCall.toolCallId, params.toolCall);
     if (this.toolSnapshotTransformer) {
       toolSnapshot = this.toolSnapshotTransformer(toolSnapshot);
@@ -2106,6 +2192,17 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       "provider.acp.raw_event",
     );
     if (params.sessionId !== this.sessionId) {
+      if (!this.forwardChildSessionUpdates) {
+        return;
+      }
+      const events = this.translateProviderSubagentSessionUpdate(params.sessionId, params.update);
+      if (this.replayingHistory) {
+        this.persistedEvents.push(...events);
+        return;
+      }
+      for (const event of events) {
+        this.pushEvent(event);
+      }
       return;
     }
 
@@ -2124,7 +2221,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     if (this.replayingHistory) {
       for (const event of events) {
         if (event.type === "timeline") {
-          this.persistedHistory.push(event.item);
+          this.persistedEvents.push(event);
         }
       }
       return;
@@ -2153,6 +2250,29 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         sessionId: typeof params.sessionId === "string" ? params.sessionId : undefined,
       });
     }
+
+    const parsedEvents = this.extensionNotificationParser?.(method, params, {
+      provider: this.provider,
+      sessionId: this.sessionId,
+      turnId: this.activeForegroundTurnId,
+    });
+    if (!parsedEvents) {
+      return;
+    }
+    const events = this.normalizeProviderSubagentCompletionEvents(parsedEvents);
+    if (this.replayingHistory) {
+      for (const event of events) {
+        if (event.type === "timeline" || event.type === "provider_subagent") {
+          this.persistedEvents.push(event);
+        }
+      }
+      this.clearCompletedProviderSubagentSessionUpdateStates(events);
+      return;
+    }
+    for (const event of events) {
+      this.pushEvent(event);
+    }
+    this.clearCompletedProviderSubagentSessionUpdateStates(events);
   }
 
   // Cache an asynchronously-delivered slash-command batch and unblock any
@@ -2343,6 +2463,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
           this.clientCapabilities,
         ),
         clientInfo: { name: "Paseo", version: "dev" },
+        _meta: this.initializeRequestMeta,
       }),
     );
 
@@ -2445,8 +2566,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[] {
     switch (update.sessionUpdate) {
       case "user_message_chunk": {
-        this.fallbackAssistantMessageId = null;
-        const item = this.createMessageTimelineItem("user_message", update);
+        const item = this.translateContentUpdate(update, this.contentTranslationState, {
+          userAssemblyFallbackId: this.activeForegroundTurnId,
+          freshToolCall: true,
+        });
         if (!item) {
           return [];
         }
@@ -2458,27 +2581,17 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         }
         return [this.wrapTimeline(item)];
       }
-      case "agent_message_chunk": {
-        const item = this.createMessageTimelineItem("assistant_message", update);
-        return item ? [this.wrapTimeline(item)] : [];
-      }
-      case "agent_thought_chunk": {
-        this.fallbackAssistantMessageId = null;
-        const item = this.createMessageTimelineItem("reasoning", update);
-        return item ? [this.wrapTimeline(item)] : [];
-      }
+      case "agent_message_chunk":
+      case "agent_thought_chunk":
       case "tool_call":
-        this.fallbackAssistantMessageId = null;
-        return this.handleToolCallUpdate(update.toolCallId, update, undefined);
       case "tool_call_update":
-        return this.handleToolCallUpdate(
-          update.toolCallId,
-          update,
-          this.toolCalls.get(update.toolCallId),
-        );
-      case "plan":
-        this.fallbackAssistantMessageId = null;
-        return [this.wrapTimeline(mapPlanToTimeline(update))];
+      case "plan": {
+        const item = this.translateContentUpdate(update, this.contentTranslationState, {
+          userAssemblyFallbackId: this.activeForegroundTurnId,
+          freshToolCall: true,
+        });
+        return item ? [this.wrapTimeline(item)] : [];
+      }
       case "current_mode_update":
         this.handleCurrentModeUpdate(update);
         return [
@@ -2511,68 +2624,218 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
-  private handleToolCallUpdate(
-    toolCallId: string,
-    update: ToolCall | ToolCallUpdate,
-    previous: ACPToolSnapshot | undefined,
-  ): AgentStreamEvent[] {
-    let snapshot = mergeToolSnapshot(toolCallId, update, previous);
-    if (this.toolSnapshotTransformer) {
-      snapshot = this.toolSnapshotTransformer(snapshot);
+  private translateProviderSubagentSessionUpdate(
+    sessionId: string,
+    update: SessionUpdate,
+  ): Array<Extract<AgentStreamEvent, { type: "provider_subagent" }>> {
+    const state = this.getProviderSubagentSessionUpdateState(sessionId);
+    const item = this.translateContentUpdate(update, state);
+    if (!item) {
+      return [];
     }
-    this.toolCalls.set(toolCallId, snapshot);
-    return [this.wrapTimeline(mapToolSnapshotToTimeline(snapshot, this.terminalEntries))];
+    return [
+      {
+        type: "provider_subagent",
+        provider: this.provider,
+        event: { type: "timeline", id: sessionId, item },
+      },
+    ];
   }
 
-  private createMessageTimelineItem(
+  /**
+   * Shared content translation for foreground and child sessions.
+   * Handles message chunks, tool calls/updates, and plans against injected state.
+   */
+  private translateContentUpdate(
+    update: SessionUpdate,
+    state: SessionContentTranslationState,
+    options?: { userAssemblyFallbackId?: string | null; freshToolCall?: boolean },
+  ): AgentTimelineItem | null {
+    switch (update.sessionUpdate) {
+      case "user_message_chunk":
+        this.resetAssistantMessageContinuity(state);
+        return this.appendContentMessage(
+          "user_message",
+          update,
+          state,
+          options?.userAssemblyFallbackId,
+        );
+      case "agent_message_chunk":
+        return this.appendContentMessage(
+          "assistant_message",
+          update,
+          state,
+          options?.userAssemblyFallbackId,
+        );
+      case "agent_thought_chunk":
+        this.resetAssistantMessageContinuity(state);
+        return this.appendContentMessage(
+          "reasoning",
+          update,
+          state,
+          options?.userAssemblyFallbackId,
+        );
+      case "tool_call":
+      case "tool_call_update": {
+        const previous = state.toolCalls.get(update.toolCallId);
+        const isToolCall = update.sessionUpdate === "tool_call";
+        // Foreground resets only on tool_call and replaces prior snapshot.
+        // Child also resets when there is no prior snapshot, and always merges.
+        if (isToolCall || (!options?.freshToolCall && !previous)) {
+          this.resetAssistantMessageContinuity(state);
+        }
+        let snapshot = mergeToolSnapshot(
+          update.toolCallId,
+          update,
+          isToolCall && options?.freshToolCall ? undefined : previous,
+        );
+        if (this.toolSnapshotTransformer) {
+          snapshot = this.toolSnapshotTransformer(snapshot);
+        }
+        state.toolCalls.set(update.toolCallId, snapshot);
+        return mapToolSnapshotToTimeline(snapshot, this.terminalEntries, {
+          detailMapper: this.toolDetailMapper,
+        });
+      }
+      case "plan":
+        this.resetAssistantMessageContinuity(state);
+        return mapPlanToTimeline(update);
+      default:
+        return null;
+    }
+  }
+
+  private appendContentMessage(
     type: "user_message" | "assistant_message" | "reasoning",
     update: Extract<
       SessionUpdate,
       { sessionUpdate: "user_message_chunk" | "agent_message_chunk" | "agent_thought_chunk" }
     >,
-  ):
-    | { type: "user_message"; text: string; messageId?: string }
-    | { type: "assistant_message"; text: string; messageId: string }
-    | { type: "reasoning"; text: string }
-    | null {
+    state: SessionContentTranslationState,
+    userAssemblyFallbackId?: string | null,
+  ): AgentTimelineItem | null {
     const chunkText = contentBlockToText(update.content);
     if (!chunkText) {
       return null;
     }
-    const key = this.messageAssemblyKey(type, update.messageId);
-    const state = this.messageAssemblies.get(key) ?? { text: "" };
-    state.text += chunkText;
-    this.messageAssemblies.set(key, state);
 
-    if (type === "user_message") {
-      return { type: "user_message", text: state.text, messageId: update.messageId ?? undefined };
-    }
     if (type === "assistant_message") {
+      const messageId = update.messageId ?? state.fallbackAssistantMessageId ?? randomUUID();
+      state.fallbackAssistantMessageId = update.messageId ? null : messageId;
+      const key = `assistant_message:${messageId}`;
+      const assembly = state.messageAssemblies.get(key) ?? { text: "" };
+      assembly.text += chunkText;
+      state.messageAssemblies.set(key, assembly);
+      state.currentAssistantAssemblyKey = key;
       return {
         type: "assistant_message",
         text: chunkText,
-        messageId: this.resolveAssistantMessageId(update.messageId),
+        messageId,
+      };
+    }
+
+    const fallbackId = type === "user_message" ? (userAssemblyFallbackId ?? "default") : "default";
+    const key = `${type}:${update.messageId ?? fallbackId}`;
+    const assembly = state.messageAssemblies.get(key) ?? { text: "" };
+    assembly.text += chunkText;
+    state.messageAssemblies.set(key, assembly);
+
+    if (type === "user_message") {
+      return {
+        type: "user_message",
+        text: assembly.text,
+        messageId: update.messageId ?? undefined,
       };
     }
     return { type: "reasoning", text: chunkText };
   }
 
-  private resolveAssistantMessageId(messageId: string | null | undefined): string {
-    if (messageId) {
-      this.fallbackAssistantMessageId = null;
-      return messageId;
-    }
-    this.fallbackAssistantMessageId ??= randomUUID();
-    return this.fallbackAssistantMessageId;
+  private resetAssistantMessageContinuity(state: SessionContentTranslationState): void {
+    state.fallbackAssistantMessageId = null;
+    state.currentAssistantAssemblyKey = null;
   }
 
-  private messageAssemblyKey(
-    type: "user_message" | "assistant_message" | "reasoning",
-    messageId: string | null | undefined,
-  ): string {
-    const fallbackId =
-      type === "user_message" ? (this.activeForegroundTurnId ?? "default") : "default";
-    return `${type}:${messageId ?? fallbackId}`;
+  private getProviderSubagentSessionUpdateState(sessionId: string): SessionContentTranslationState {
+    const existing = this.providerSubagentSessionUpdateStates.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+    const created: SessionContentTranslationState = {
+      messageAssemblies: new Map(),
+      toolCalls: new Map(),
+      fallbackAssistantMessageId: null,
+      currentAssistantAssemblyKey: null,
+    };
+    this.providerSubagentSessionUpdateStates.set(sessionId, created);
+    return created;
+  }
+
+  private normalizeProviderSubagentCompletionEvents(
+    events: AgentStreamEvent[],
+  ): AgentStreamEvent[] {
+    if (!this.forwardChildSessionUpdates) {
+      return events;
+    }
+    const completedIds = new Set(
+      events.flatMap((event) =>
+        event.type === "provider_subagent" &&
+        event.event.type === "upsert" &&
+        event.event.status !== undefined &&
+        event.event.status !== "running"
+          ? [event.event.id]
+          : [],
+      ),
+    );
+    if (completedIds.size === 0) {
+      return events;
+    }
+    return events.flatMap((event) => {
+      if (
+        event.type !== "provider_subagent" ||
+        event.event.type !== "timeline" ||
+        event.event.item.type !== "assistant_message" ||
+        !completedIds.has(event.event.id)
+      ) {
+        return [event];
+      }
+      const state = this.providerSubagentSessionUpdateStates.get(event.event.id);
+      if (!state) {
+        return [event];
+      }
+      const completionText = event.event.item.text;
+      for (const [key, assembly] of state.messageAssemblies) {
+        if (key.startsWith("assistant_message:") && assembly.text === completionText) {
+          return [];
+        }
+      }
+      const streamedText =
+        (state.currentAssistantAssemblyKey &&
+          state.messageAssemblies.get(state.currentAssistantAssemblyKey)?.text) ||
+        "";
+      if (!streamedText || !completionText.startsWith(streamedText)) {
+        return [event];
+      }
+      const suffix = completionText.slice(streamedText.length);
+      return suffix
+        ? [{ ...event, event: { ...event.event, item: { ...event.event.item, text: suffix } } }]
+        : [];
+    });
+  }
+
+  private clearCompletedProviderSubagentSessionUpdateStates(events: AgentStreamEvent[]): void {
+    if (!this.forwardChildSessionUpdates) {
+      return;
+    }
+    for (const event of events) {
+      if (
+        event.type === "provider_subagent" &&
+        event.event.type === "upsert" &&
+        event.event.status !== undefined &&
+        event.event.status !== "running"
+      ) {
+        this.providerSubagentSessionUpdateStates.delete(event.event.id);
+      }
+    }
   }
 
   private handleCurrentModeUpdate(update: CurrentModeUpdate): void {
@@ -2726,11 +2989,12 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     event: Extract<AgentStreamEvent, { type: "turn_completed" | "turn_failed" | "turn_canceled" }>,
   ): void {
     this.activeForegroundTurnId = null;
-    this.fallbackAssistantMessageId = null;
+    this.resetAssistantMessageContinuity(this.contentTranslationState);
     if (this.activeSubmittedUserMessage?.turnId === event.turnId) {
       this.activeSubmittedUserMessage = null;
     }
     this.pushEvent(event);
+    this.providerSubagentSessionUpdateStates.clear();
   }
 
   private isSubmittedUserMessageEcho(
@@ -2761,8 +3025,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private synthesizeCanceledToolCalls(): void {
-    for (const snapshot of this.toolCalls.values()) {
-      const mapped = mapToolSnapshotToTimeline(snapshot, this.terminalEntries);
+    for (const snapshot of this.contentTranslationState.toolCalls.values()) {
+      const mapped = mapToolSnapshotToTimeline(snapshot, this.terminalEntries, {
+        detailMapper: this.toolDetailMapper,
+      });
       if (mapped.status === "running") {
         this.pushEvent(
           this.wrapTimeline({
@@ -3067,7 +3333,7 @@ export function resolveAcpToolCallName(snapshot: ACPToolSnapshot): string {
   const kind = typeof snapshot.kind === "string" ? snapshot.kind.trim() : "";
   const title = snapshot.title.trim();
   // Generic ACP "other" (and missing kind) should not become the display label
-  // "Other" — prefer the human title agents put on the tool.
+  // "Other" — prefer the human title Grok and other agents put on the tool.
   if (!kind || kind === "other") {
     return title || kind || snapshot.toolCallId;
   }
@@ -3077,9 +3343,13 @@ export function resolveAcpToolCallName(snapshot: ACPToolSnapshot): string {
 function mapToolSnapshotToTimeline(
   snapshot: ACPToolSnapshot,
   terminals: Map<string, TerminalEntry>,
+  options?: { detailMapper?: ACPToolDetailMapper },
 ): ToolCallTimelineItem {
   const status = mapToolStatus(snapshot.status);
-  const detail = mapToolDetail(snapshot, terminals);
+  const defaultDetail = mapToolDetail(snapshot, terminals);
+  const detail = options?.detailMapper
+    ? options.detailMapper(snapshot, defaultDetail)
+    : defaultDetail;
   const base = {
     type: "tool_call" as const,
     callId: snapshot.toolCallId,

--- a/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
@@ -9,11 +9,13 @@ import { buildVersionProbeCommand, GenericACPAgentClient } from "./generic-acp-a
 
 const TEST_ACP_TIMEOUT_MS = 1_000;
 
-function parseInitializeTrace(content: string): Array<{ clientCapabilities: unknown }> {
+function parseInitializeTrace(
+  content: string,
+): Array<{ clientCapabilities: unknown; _meta: unknown }> {
   return content
     .trim()
     .split("\n")
-    .map((line) => JSON.parse(line) as { clientCapabilities: unknown });
+    .map((line) => JSON.parse(line) as { clientCapabilities: unknown; _meta: unknown });
 }
 
 describe("GenericACPAgentClient diagnostics", () => {
@@ -114,6 +116,9 @@ describe("GenericACPAgentClient diagnostics", () => {
             terminal: true,
           },
         },
+        initializeRequestMeta: {
+          clientIdentifier: "paseo-test",
+        },
       });
 
       await client.fetchCatalog({ cwd: testDir, force: true, timeoutMs: TEST_ACP_TIMEOUT_MS });
@@ -132,6 +137,9 @@ describe("GenericACPAgentClient diagnostics", () => {
             },
             terminal: true,
           },
+          _meta: {
+            clientIdentifier: "paseo-test",
+          },
         },
         {
           clientCapabilities: {
@@ -140,6 +148,9 @@ describe("GenericACPAgentClient diagnostics", () => {
               writeTextFile: true,
             },
             terminal: true,
+          },
+          _meta: {
+            clientIdentifier: "paseo-test",
           },
         },
       ]);
@@ -237,7 +248,10 @@ rl.on("line", (line) => {
     if (initializeTracePath) {
       fs.appendFileSync(
         initializeTracePath,
-        JSON.stringify({ clientCapabilities: message.params?.clientCapabilities }) + "\\n",
+        JSON.stringify({
+          clientCapabilities: message.params?.clientCapabilities,
+          _meta: message.params?._meta,
+        }) + "\\n",
       );
     }
     send(message.id, {

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -9,6 +9,13 @@ import {
   type ACPConfigFeatureOption,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
+  type ACPExtensionNotificationParser,
+  type ACPInitialCommandsParser,
+  type ACPInitializeRequestMeta,
+  type ACPThinkingOptionWriter,
+  type ACPToolDetailMapper,
+  type ACPToolSnapshot,
+  type SessionStateResponse,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -47,8 +54,16 @@ interface GenericACPAgentClientOptions {
   initialCommandsWaitTimeoutMs?: number;
   diagnosticPhaseTimeoutMs?: number;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
+  initializeRequestMeta?: ACPInitializeRequestMeta;
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  initialCommandsParser?: ACPInitialCommandsParser;
+  extensionNotificationParser?: ACPExtensionNotificationParser;
+  forwardChildSessionUpdates?: boolean;
+  sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
+  thinkingOptionWriter?: ACPThinkingOptionWriter;
+  toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
+  toolDetailMapper?: ACPToolDetailMapper;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -71,8 +86,16 @@ export class GenericACPAgentClient extends ACPAgentClient {
       initialCommandsWaitTimeoutMs: options.initialCommandsWaitTimeoutMs,
       clientCapabilities: providerParams.clientCapabilities,
       clientCapabilityMeta: options.clientCapabilityMeta,
+      initializeRequestMeta: options.initializeRequestMeta,
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
+      initialCommandsParser: options.initialCommandsParser,
+      extensionNotificationParser: options.extensionNotificationParser,
+      forwardChildSessionUpdates: options.forwardChildSessionUpdates,
+      sessionResponseTransformer: options.sessionResponseTransformer,
+      thinkingOptionWriter: options.thinkingOptionWriter,
+      toolSnapshotTransformer: options.toolSnapshotTransformer,
+      toolDetailMapper: options.toolDetailMapper,
     });
 
     this.command = options.command;

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,0 +1,511 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { ClientSideConnection, InitializeResponse } from "@agentclientprotocol/sdk";
+import { describe, expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import { buildProviderRegistry } from "../provider-registry.js";
+import type { SessionStateResponse, SpawnedACPProcess } from "./acp-agent.js";
+import {
+  applyDiskMeta,
+  createGrokExtensionNotificationParser,
+  formatGrokSubagentTitle,
+  GrokACPAgentClient,
+  parseGrokExtensionNotification,
+  parseGrokInitialCommands,
+  parseGrokSessionListPage,
+  transformGrokSessionResponse,
+  writeGrokThinkingOption,
+} from "./grok-acp-agent.js";
+
+class ProbeGrokClient extends GrokACPAgentClient {
+  constructor(private readonly probe: SpawnedACPProcess) {
+    super({
+      logger: createTestLogger(),
+      command: ["grok", "agent", "stdio"],
+      providerId: "grok",
+      label: "Grok",
+    });
+  }
+
+  protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+    return this.probe;
+  }
+
+  protected override async closeProbe(): Promise<void> {}
+}
+
+describe("GrokACPAgentClient", () => {
+  test("exposes Grok initialize commands with command and skill metadata", () => {
+    const response = {
+      _meta: {
+        grokShell: true,
+        availableCommands: [
+          {
+            name: "/plan",
+            description: "Enter plan mode",
+            input: { hint: "goal" },
+          },
+          {
+            name: "review",
+            description: "Review a change",
+            input: { unstructured: { hint: "path" } },
+            _meta: { scope: "workspace", path: "/tmp/skills/review" },
+          },
+        ],
+      },
+    } as unknown as InitializeResponse;
+
+    expect(parseGrokInitialCommands(response)).toEqual([
+      {
+        name: "plan",
+        description: "Enter plan mode",
+        argumentHint: "goal",
+        kind: "command",
+      },
+      {
+        name: "review",
+        description: "Review a change",
+        argumentHint: "path",
+        kind: "skill",
+      },
+    ]);
+  });
+
+  test("maps Grok reasoning modes into the standard ACP thinking selector", () => {
+    const response = {
+      sessionId: "session-1",
+      models: {
+        currentModelId: "grok-build",
+        availableModels: [
+          {
+            modelId: "grok-build",
+            name: "Grok Build",
+            _meta: {
+              reasoningEffort: "xhigh",
+              reasoningEfforts: [
+                {
+                  id: "minimal",
+                  value: "minimal",
+                  label: "Minimal",
+                  description: "Fastest response",
+                  default: false,
+                },
+                {
+                  id: "deep",
+                  value: "xhigh",
+                  label: "Deep",
+                  description: "More reasoning",
+                  default: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      _meta: {
+        "x.ai/sessionConfig": {
+          options: [
+            {
+              id: "grok-build",
+              category: "model",
+              label: "Grok Build",
+              selected: true,
+            },
+            {
+              id: "minimal",
+              category: "mode",
+              label: "Minimal",
+              description: "Fastest response",
+              selected: false,
+            },
+            {
+              id: "deep",
+              category: "mode",
+              label: "Deep",
+              description: "More reasoning",
+              selected: true,
+            },
+          ],
+        },
+      },
+    } as unknown as SessionStateResponse;
+
+    expect(transformGrokSessionResponse(response)).toMatchObject({
+      sessionId: "session-1",
+      configOptions: [
+        {
+          type: "select",
+          id: "_paseo.grok.reasoning_effort",
+          name: "Reasoning effort",
+          category: "thought_level",
+          currentValue: "xhigh",
+          options: [
+            { value: "minimal", name: "Minimal", description: "Fastest response" },
+            { value: "xhigh", name: "Deep", description: "More reasoning" },
+          ],
+        },
+      ],
+    });
+  });
+
+  test("writes Grok reasoning effort through session/set_model metadata", async () => {
+    const setSessionModel = vi.fn().mockResolvedValue({});
+
+    await writeGrokThinkingOption({
+      connection: {
+        unstable_setSessionModel: setSessionModel,
+      } as unknown as ClientSideConnection,
+      sessionId: "session-1",
+      modelId: "grok-build",
+      thinkingOptionId: "xhigh",
+    });
+
+    expect(setSessionModel).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modelId: "grok-build",
+      _meta: { reasoningEffort: "xhigh" },
+    });
+  });
+
+  test("formatGrokSubagentTitle folds model and effort into the title", () => {
+    expect(formatGrokSubagentTitle({ baseTitle: "Explore" })).toBe("Explore");
+    expect(formatGrokSubagentTitle({ baseTitle: "Explore", model: "grok-4.5" })).toBe(
+      "Explore · grok-4.5",
+    );
+    expect(
+      formatGrokSubagentTitle({
+        baseTitle: "Explore",
+        model: "grok-4.5",
+        thinkingOptionId: "low",
+      }),
+    ).toBe("Explore · grok-4.5 · low");
+  });
+
+  test("maps Grok subagent lifecycle updates", () => {
+    const context = { provider: "grok", sessionId: "parent-1", turnId: null };
+
+    expect(
+      parseGrokExtensionNotification(
+        "_x.ai/session_notification",
+        {
+          sessionId: "parent-1",
+          update: {
+            sessionUpdate: "subagent_spawned",
+            subagent_id: "child-1",
+            child_session_id: "child-1",
+            subagent_type: "explore",
+            description: "Map the provider registry",
+            model: "grok-4.5",
+          },
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "grok",
+        event: {
+          type: "upsert",
+          id: "child-1",
+          title: "Map the provider registry · grok-4.5",
+          description: "explore",
+          status: "running",
+        },
+      },
+    ]);
+
+    expect(
+      parseGrokExtensionNotification(
+        "_x.ai/session_notification",
+        {
+          sessionId: "parent-1",
+          update: {
+            sessionUpdate: "subagent_finished",
+            subagent_id: "child-1",
+            child_session_id: "child-1",
+            status: "completed",
+            output: "Found the registry branch.",
+          },
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "grok",
+        event: {
+          type: "timeline",
+          id: "child-1",
+          item: { type: "assistant_message", text: "Found the registry branch." },
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "grok",
+        event: {
+          type: "upsert",
+          id: "child-1",
+          title: "Map the provider registry · grok-4.5",
+          description: "explore",
+          status: "completed",
+        },
+      },
+    ]);
+  });
+
+  test("unwraps leader notifications and rejects another parent session", () => {
+    const context = { provider: "grok", sessionId: "parent-1", turnId: null };
+    const nestedParams = {
+      method: "x.ai/session_notification",
+      params: {
+        sessionId: "parent-1",
+        update: {
+          sessionUpdate: "subagent_progress",
+          subagent_id: "child-1",
+          child_session_id: "child-session-1",
+        },
+      },
+    };
+
+    expect(
+      parseGrokExtensionNotification("_x.ai/session_notification", nestedParams, context),
+    ).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "grok",
+        event: { type: "upsert", id: "child-session-1", status: "running" },
+      },
+    ]);
+    expect(
+      parseGrokExtensionNotification(
+        "x.ai/session_notification",
+        {
+          ...nestedParams.params,
+          sessionId: "parent-2",
+        },
+        context,
+      ),
+    ).toBeNull();
+  });
+
+  test("subagent display state is isolated across parser instances", () => {
+    const parserA = createGrokExtensionNotificationParser();
+    const parserB = createGrokExtensionNotificationParser();
+    const context = { provider: "grok", sessionId: "parent-1", turnId: null };
+    const spawnParams = {
+      sessionId: "parent-1",
+      update: {
+        sessionUpdate: "subagent_spawned",
+        subagent_id: "shared-child",
+        child_session_id: "shared-child",
+        subagent_type: "explore",
+        description: "Owned by A",
+        model: "grok-from-a",
+      },
+    };
+
+    parserA("_x.ai/session_notification", spawnParams, context);
+
+    // Parser B never saw the spawn — progress falls back to bare upsert (no title from A).
+    expect(
+      parserB(
+        "_x.ai/session_notification",
+        {
+          sessionId: "parent-1",
+          update: {
+            sessionUpdate: "subagent_progress",
+            subagent_id: "shared-child",
+            child_session_id: "shared-child",
+          },
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "grok",
+        event: { type: "upsert", id: "shared-child", status: "running" },
+      },
+    ]);
+
+    // Parser A still has the spawn state for finish title folding.
+    const finished = parserA(
+      "_x.ai/session_notification",
+      {
+        sessionId: "parent-1",
+        update: {
+          sessionUpdate: "subagent_finished",
+          subagent_id: "shared-child",
+          child_session_id: "shared-child",
+          status: "completed",
+        },
+      },
+      context,
+    );
+    expect(finished).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "grok",
+        event: {
+          type: "upsert",
+          id: "shared-child",
+          title: "Owned by A · grok-from-a",
+          description: "explore",
+          status: "completed",
+        },
+      },
+    ]);
+  });
+
+  test("applyDiskMeta does not touch the filesystem once model and effort are set", () => {
+    const readDisk = vi.fn(() => ({ model: "should-not-run", thinkingOptionId: "x" }));
+    const state = {
+      baseTitle: "Explore",
+      description: "explore",
+      model: "grok-4.5",
+      thinkingOptionId: "low",
+    };
+
+    expect(applyDiskMeta(state, "child-already-resolved", readDisk)).toBe(false);
+    expect(readDisk).not.toHaveBeenCalled();
+    expect(state.model).toBe("grok-4.5");
+    expect(state.thinkingOptionId).toBe("low");
+  });
+
+  test("maps Grok's richer session list envelope for import", () => {
+    expect(
+      parseGrokSessionListPage({
+        result: {
+          sessions: [
+            {
+              sessionId: "session-1",
+              cwd: "/work/project",
+              title: null,
+              summary: "Fix the registry",
+              firstPrompt: "Please fix the registry",
+              createdAt: "2026-07-19T10:00:00.000Z",
+              updatedAt: "2026-07-19T11:00:00.000Z",
+              lastActiveAt: "2026-07-19T12:00:00.000Z",
+              source: "local",
+            },
+          ],
+          nextCursor: "cursor-2",
+          _meta: { "x.ai/partial": { conversations: false } },
+        },
+        error: null,
+      }),
+    ).toEqual({
+      sessions: [
+        {
+          providerHandleId: "session-1",
+          cwd: "/work/project",
+          title: "Fix the registry",
+          firstPromptPreview: "Please fix the registry",
+          lastPromptPreview: null,
+          lastActivityAt: new Date("2026-07-19T12:00:00.000Z"),
+        },
+      ],
+      nextCursor: "cursor-2",
+    });
+  });
+
+  test("uses Grok session discovery with pagination and cwd filtering", async () => {
+    const extMethod = vi
+      .fn()
+      .mockResolvedValueOnce({
+        result: {
+          sessions: [
+            {
+              sessionId: "session-1",
+              cwd: "/work/project",
+              summary: "First session",
+              lastActiveAt: "2026-07-19T12:00:00.000Z",
+            },
+          ],
+          nextCursor: "cursor-2",
+        },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        result: {
+          sessions: [
+            {
+              sessionId: "session-2",
+              cwd: "/work/project",
+              summary: "Second session",
+              lastActiveAt: "2026-07-19T13:00:00.000Z",
+            },
+          ],
+        },
+        error: null,
+      });
+    const client = new ProbeGrokClient({
+      initialize: { _meta: { grokShell: true } },
+      connection: { extMethod },
+    } as unknown as SpawnedACPProcess);
+
+    const sessions = await client.listImportableSessions({
+      cwd: "/work/project",
+      limit: 2,
+    });
+
+    expect(sessions.map((session) => session.providerHandleId)).toEqual(["session-1", "session-2"]);
+    expect(extMethod).toHaveBeenNthCalledWith(1, "_x.ai/session/list", {
+      cwd: "/work/project",
+      limit: 2,
+    });
+    expect(extMethod).toHaveBeenNthCalledWith(2, "_x.ai/session/list", {
+      cwd: "/work/project",
+      cursor: "cursor-2",
+      limit: 2,
+    });
+  });
+  test("routes catalog Grok through auth-aware diagnostics without reading credentials", async () => {
+    const grokHome = await mkdtemp(path.join(tmpdir(), "paseo-grok-auth-"));
+    try {
+      await writeFile(path.join(grokHome, "auth.json"), '{"access_token":"do-not-log"}');
+      const logger = createTestLogger();
+      const registry = buildProviderRegistry(logger, {
+        providerOverrides: {
+          grok: {
+            extends: "acp",
+            label: "Grok",
+            command: [path.join(grokHome, "missing-grok"), "agent", "stdio"],
+            env: { GROK_HOME: grokHome },
+          },
+        },
+      });
+      const client = registry.grok.createClient(logger);
+
+      const { diagnostic } = await client.getDiagnostic!();
+
+      expect(diagnostic).toContain(
+        `Authentication: credentials found at ${path.join(grokHome, "auth.json")}`,
+      );
+      expect(diagnostic).not.toContain("do-not-log");
+    } finally {
+      await rm(grokHome, { recursive: true, force: true });
+    }
+  });
+
+  test.each(["GROK_AUTH_PROVIDER_COMMAND", "GROK_DEPLOYMENT_KEY"] as const)(
+    "recognizes %s without logging its credential value",
+    async (envKey) => {
+      const credential = "do-not-log-auth-value";
+      const client = new GrokACPAgentClient({
+        logger: createTestLogger(),
+        command: ["/paseo-missing-grok", "agent", "stdio"],
+        providerId: "grok",
+        label: "Grok",
+        env: { [envKey]: credential },
+      });
+
+      const { diagnostic } = await client.getDiagnostic();
+
+      expect(diagnostic).toContain(`Authentication: configured via ${envKey}`);
+      expect(diagnostic).not.toContain(credential);
+    },
+  );
+});

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,0 +1,606 @@
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { InitializeResponse } from "@agentclientprotocol/sdk";
+import type { Logger } from "pino";
+import { z } from "zod";
+
+import type {
+  AgentSlashCommand,
+  AgentSlashCommandKind,
+  AgentStreamEvent,
+  ImportableProviderSession,
+  ListImportableSessionsOptions,
+} from "../agent-sdk-types.js";
+import type {
+  ACPExtensionNotificationParser,
+  ACPInitialCommandsParser,
+  ACPThinkingOptionWriter,
+  SessionStateResponse,
+} from "./acp-agent.js";
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+import { readGrokSubagentDiskMeta } from "./grok-subagent-meta.js";
+import { mapGrokAcpToolDetail, transformGrokAcpToolSnapshot } from "./grok-tool-mapper.js";
+
+interface GrokACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+const GROK_INITIALIZE_META = {
+  clientType: "generic",
+  clientIdentifier: "paseo",
+};
+const GROK_AUTH_ENV_KEYS = [
+  "XAI_API_KEY",
+  "GROK_CODE_XAI_API_KEY",
+  "GROK_AUTH",
+  "GROK_AUTH_PROVIDER_COMMAND",
+  "GROK_DEPLOYMENT_KEY",
+] as const;
+
+const GROK_REASONING_CONFIG_ID = "_paseo.grok.reasoning_effort";
+const GROK_CANONICAL_REASONING_EFFORT: Record<string, string> = {
+  none: "none",
+  minimal: "minimal",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "xhigh",
+  max: "xhigh",
+};
+
+const GROK_SESSION_NOTIFICATION_METHODS: Record<string, true> = {
+  "x.ai/session_notification": true,
+  "_x.ai/session_notification": true,
+  "x.ai/session/update": true,
+  "_x.ai/session/update": true,
+};
+
+const GrokSessionConfigOptionSchema = z
+  .object({
+    id: z.string(),
+    category: z.string(),
+    label: z.string(),
+    description: z.string().nullish(),
+    selected: z.boolean(),
+  })
+  .passthrough();
+
+const GrokSessionConfigSchema = z
+  .object({
+    options: z.array(GrokSessionConfigOptionSchema),
+  })
+  .passthrough();
+
+type GrokSessionConfigOption = z.infer<typeof GrokSessionConfigOptionSchema>;
+
+interface GrokReasoningOption {
+  sourceId: string;
+  value: string;
+  name: string;
+  description: string | null;
+  isDefault: boolean;
+}
+
+const GrokSessionListRowSchema = z
+  .object({
+    sessionId: z.string(),
+    cwd: z.string(),
+    title: z.string().nullish(),
+    summary: z.string().nullish(),
+    firstPrompt: z.string().nullish(),
+    updatedAt: z.string().nullish(),
+    lastActiveAt: z.string().nullish(),
+    createdAt: z.string().nullish(),
+  })
+  .passthrough();
+
+const GrokSessionListEnvelopeSchema = z
+  .object({
+    result: z
+      .object({
+        sessions: z.array(GrokSessionListRowSchema),
+        nextCursor: z.string().nullish(),
+      })
+      .passthrough()
+      .nullish(),
+    error: z.unknown().nullish(),
+  })
+  .passthrough();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readCommandArgumentHint(command: Record<string, unknown>): string {
+  const input = isRecord(command.input) ? command.input : null;
+  if (!input) return "";
+  const directHint = readString(input, "hint");
+  if (directHint) return directHint;
+  const unstructured = isRecord(input.unstructured) ? input.unstructured : null;
+  return unstructured ? (readString(unstructured, "hint") ?? "") : "";
+}
+
+function mapGrokCommands(value: unknown): AgentSlashCommand[] {
+  if (!Array.isArray(value)) return [];
+  const commands: AgentSlashCommand[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (!isRecord(item)) continue;
+    const name = (readString(item, "name") ?? "").replace(/^\/+/, "");
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    const meta = isRecord(item._meta) ? item._meta : null;
+    const kind: AgentSlashCommandKind = meta?.path || meta?.scope ? "skill" : "command";
+    commands.push({
+      name,
+      description: readString(item, "description") ?? "",
+      argumentHint: readCommandArgumentHint(item),
+      kind,
+    });
+  }
+  return commands;
+}
+
+export const parseGrokInitialCommands: ACPInitialCommandsParser = (response) => {
+  const meta = response._meta;
+  if (!isRecord(meta) || !Array.isArray(meta.availableCommands)) return null;
+  return mapGrokCommands(meta.availableCommands);
+};
+
+function normalizeModelReasoningOptions(
+  rawEfforts: unknown[],
+  sessionOptions: GrokSessionConfigOption[],
+): GrokReasoningOption[] {
+  const options: GrokReasoningOption[] = [];
+  const seenValues = new Set<string>();
+  for (const rawEffort of rawEfforts) {
+    const record = isRecord(rawEffort) ? rawEffort : null;
+    let rawValue: string | null = null;
+    if (typeof rawEffort === "string") {
+      rawValue = rawEffort;
+    } else if (record) {
+      rawValue = readString(record, "value");
+    }
+    if (!rawValue) continue;
+    const value = GROK_CANONICAL_REASONING_EFFORT[rawValue.toLowerCase()];
+    if (!value || seenValues.has(value)) continue;
+    seenValues.add(value);
+    const sourceId = (record ? readString(record, "id") : null) ?? rawValue;
+    const sessionOption = sessionOptions.find((option) => option.id === sourceId);
+    options.push({
+      sourceId,
+      value,
+      name: (record ? readString(record, "label") : null) ?? sessionOption?.label ?? sourceId,
+      description:
+        (record ? readString(record, "description") : null) ?? sessionOption?.description ?? null,
+      isDefault: record?.default === true,
+    });
+  }
+  return options;
+}
+
+function normalizeSessionReasoningOptions(
+  sessionOptions: GrokSessionConfigOption[],
+): GrokReasoningOption[] {
+  const options: GrokReasoningOption[] = [];
+  const seenValues = new Set<string>();
+  for (const sessionOption of sessionOptions) {
+    const value = GROK_CANONICAL_REASONING_EFFORT[sessionOption.id.toLowerCase()];
+    if (!value || seenValues.has(value)) continue;
+    seenValues.add(value);
+    options.push({
+      sourceId: sessionOption.id,
+      value,
+      name: sessionOption.label,
+      description: sessionOption.description ?? null,
+      isDefault: false,
+    });
+  }
+  return options;
+}
+
+function resolveGrokReasoningCurrentValue(
+  modelMeta: Record<string, unknown> | null,
+  sessionOptions: GrokSessionConfigOption[],
+  options: GrokReasoningOption[],
+): string {
+  const selectedSessionId = sessionOptions.find((option) => option.selected)?.id;
+  const modelEffort = modelMeta ? readString(modelMeta, "reasoningEffort") : null;
+  return (
+    (modelEffort ? GROK_CANONICAL_REASONING_EFFORT[modelEffort.toLowerCase()] : undefined) ??
+    options.find((option) => option.sourceId === selectedSessionId)?.value ??
+    options.find((option) => option.isDefault)?.value ??
+    options[0].value
+  );
+}
+
+export function transformGrokSessionResponse(response: SessionStateResponse): SessionStateResponse {
+  const meta = response._meta;
+  if (!isRecord(meta)) return response;
+  const parsed = GrokSessionConfigSchema.safeParse(meta["x.ai/sessionConfig"]);
+  if (!parsed.success) return response;
+
+  const sessionOptions = parsed.data.options.filter((option) => option.category === "mode");
+  const selectedModelId = parsed.data.options.find(
+    (option) => option.category === "model" && option.selected,
+  )?.id;
+  const currentModel = response.models?.availableModels?.find(
+    (model) =>
+      model.modelId === response.models?.currentModelId || model.modelId === selectedModelId,
+  );
+  const modelMeta = currentModel && isRecord(currentModel._meta) ? currentModel._meta : null;
+  const rawEfforts =
+    modelMeta && Array.isArray(modelMeta.reasoningEfforts) ? modelMeta.reasoningEfforts : [];
+  const modelOptions = normalizeModelReasoningOptions(rawEfforts, sessionOptions);
+  const options =
+    modelOptions.length > 0 ? modelOptions : normalizeSessionReasoningOptions(sessionOptions);
+  if (options.length === 0) return response;
+
+  const currentValue = resolveGrokReasoningCurrentValue(modelMeta, sessionOptions, options);
+
+  return {
+    ...response,
+    configOptions: [
+      ...(response.configOptions ?? []).filter((option) => option.id !== GROK_REASONING_CONFIG_ID),
+      {
+        type: "select",
+        id: GROK_REASONING_CONFIG_ID,
+        name: "Reasoning effort",
+        category: "thought_level",
+        currentValue,
+        options: options.map((option) => ({
+          value: option.value,
+          name: option.name,
+          description: option.description,
+        })),
+      },
+    ],
+  };
+}
+
+export const writeGrokThinkingOption: ACPThinkingOptionWriter = async ({
+  connection,
+  sessionId,
+  modelId,
+  thinkingOptionId,
+}) => {
+  await connection.unstable_setSessionModel({
+    sessionId,
+    modelId,
+    _meta: { reasoningEffort: thinkingOptionId },
+  });
+};
+
+function subagentStatus(value: unknown): "completed" | "failed" | "canceled" {
+  if (value === "completed") return "completed";
+  if (value === "cancelled" || value === "canceled") return "canceled";
+  return "failed";
+}
+
+/**
+ * Grok-only presentation: fold model/effort into the existing title field
+ * (same idea as OMP). No protocol/store/UI schema changes required — track
+ * rows and tab labels already show `title`.
+ */
+export function formatGrokSubagentTitle(input: {
+  baseTitle: string;
+  model?: string | null;
+  thinkingOptionId?: string | null;
+}): string {
+  const parts = [input.baseTitle.trim() || "Grok subagent"];
+  const model = input.model?.trim();
+  if (model) parts.push(model);
+  const thinking = input.thinkingOptionId?.trim();
+  if (thinking) parts.push(thinking);
+  return parts.join(" · ");
+}
+
+interface GrokSubagentDisplayState {
+  baseTitle: string;
+  description: string | null;
+  model: string | null;
+  thinkingOptionId: string | null;
+}
+
+function diskMetaForChild(subagentId: string): {
+  model: string | null;
+  thinkingOptionId: string | null;
+} | null {
+  return readGrokSubagentDiskMeta({
+    childSessionId: subagentId,
+    env: process.env,
+    canonicalReasoningEffort: GROK_CANONICAL_REASONING_EFFORT,
+  });
+}
+
+type GrokDiskMetaReader = (subagentId: string) => {
+  model: string | null;
+  thinkingOptionId: string | null;
+} | null;
+
+/**
+ * Apply disk summary.json model/effort onto display state.
+ * Early-out once both values are known so ~2s progress ticks skip readdirSync.
+ */
+export function applyDiskMeta(
+  state: GrokSubagentDisplayState,
+  subagentId: string,
+  readDisk: GrokDiskMetaReader = diskMetaForChild,
+): boolean {
+  // Once both are populated, further disk walks cannot improve the title.
+  if (state.model && state.thinkingOptionId) {
+    return false;
+  }
+  const disk = readDisk(subagentId);
+  if (!disk) return false;
+  let changed = false;
+  if (disk.model && disk.model !== state.model) {
+    state.model = disk.model;
+    changed = true;
+  }
+  if (disk.thinkingOptionId && disk.thinkingOptionId !== state.thinkingOptionId) {
+    state.thinkingOptionId = disk.thinkingOptionId;
+    changed = true;
+  }
+  return changed;
+}
+
+function upsertWithDisplay(
+  provider: string,
+  id: string,
+  status: "running" | "completed" | "failed" | "canceled",
+  state: GrokSubagentDisplayState,
+): AgentStreamEvent {
+  return {
+    type: "provider_subagent",
+    provider,
+    event: {
+      type: "upsert",
+      id,
+      status,
+      title: formatGrokSubagentTitle(state),
+      description: state.description,
+    },
+  };
+}
+
+/**
+ * Per-client factory for Grok extension notifications. Owns the subagent
+ * display map so two Grok sessions in one daemon never share (or leak) state.
+ */
+export function createGrokExtensionNotificationParser(): ACPExtensionNotificationParser {
+  const grokSubagentDisplay = new Map<string, GrokSubagentDisplayState>();
+
+  function mapSpawnedSubagent(
+    update: Record<string, unknown>,
+    subagentId: string,
+    provider: string,
+  ): AgentStreamEvent[] {
+    const baseTitle = readString(update, "description") ?? "Grok subagent";
+    const description = readString(update, "subagent_type");
+    const wireModel = readString(update, "model");
+    const state: GrokSubagentDisplayState = {
+      baseTitle,
+      description,
+      model: wireModel,
+      thinkingOptionId: null,
+    };
+    // Best-effort: reasoning is not on the spawn wire; summary may already exist.
+    applyDiskMeta(state, subagentId);
+    if (!state.model && wireModel) state.model = wireModel;
+    grokSubagentDisplay.set(subagentId, state);
+    return [upsertWithDisplay(provider, subagentId, "running", state)];
+  }
+
+  function mapProgressSubagent(subagentId: string, provider: string): AgentStreamEvent[] {
+    const state = grokSubagentDisplay.get(subagentId);
+    if (!state) {
+      return [
+        {
+          type: "provider_subagent",
+          provider,
+          event: { type: "upsert", id: subagentId, status: "running" },
+        },
+      ];
+    }
+    // Progress ticks (~2s): retry disk for reasoning once summary is written.
+    applyDiskMeta(state, subagentId);
+    return [upsertWithDisplay(provider, subagentId, "running", state)];
+  }
+
+  function mapFinishedSubagent(
+    update: Record<string, unknown>,
+    subagentId: string,
+    provider: string,
+  ): AgentStreamEvent[] {
+    const events: AgentStreamEvent[] = [];
+    const output = readString(update, "output");
+    if (output) {
+      events.push({
+        type: "provider_subagent",
+        provider,
+        event: {
+          type: "timeline",
+          id: subagentId,
+          item: { type: "assistant_message", text: output },
+        },
+      });
+    }
+    const error = readString(update, "error");
+    if (error) {
+      events.push({
+        type: "provider_subagent",
+        provider,
+        event: {
+          type: "timeline",
+          id: subagentId,
+          item: { type: "error", message: error },
+        },
+      });
+    }
+    const state = grokSubagentDisplay.get(subagentId) ?? {
+      baseTitle: "Grok subagent",
+      description: null,
+      model: null,
+      thinkingOptionId: null,
+    };
+    applyDiskMeta(state, subagentId);
+    events.push(upsertWithDisplay(provider, subagentId, subagentStatus(update.status), state));
+    grokSubagentDisplay.delete(subagentId);
+    return events;
+  }
+
+  function parseGrokSubagentUpdate(
+    update: Record<string, unknown>,
+    provider: string,
+  ): AgentStreamEvent[] | null {
+    const type = readString(update, "sessionUpdate");
+    const subagentId = readString(update, "child_session_id") ?? readString(update, "subagent_id");
+    if (!subagentId) return null;
+    if (type === "subagent_spawned") return mapSpawnedSubagent(update, subagentId, provider);
+    if (type === "subagent_progress") return mapProgressSubagent(subagentId, provider);
+    if (type === "subagent_finished") return mapFinishedSubagent(update, subagentId, provider);
+    return null;
+  }
+
+  return (method, params, context) => {
+    let notificationMethod = method;
+    let notificationParams = params;
+    if (method === "_x.ai/session_notification") {
+      notificationMethod = readString(params, "method") ?? method;
+      notificationParams = isRecord(params.params) ? params.params : params;
+    }
+    if (!GROK_SESSION_NOTIFICATION_METHODS[notificationMethod]) return null;
+    const targetSessionId = readString(notificationParams, "sessionId");
+    if (targetSessionId && context.sessionId && targetSessionId !== context.sessionId) return null;
+    const update = isRecord(notificationParams.update) ? notificationParams.update : null;
+    return update ? parseGrokSubagentUpdate(update, context.provider) : null;
+  };
+}
+
+/** Shared parser instance for tests and one-off callers; production clients use a per-client factory. */
+export const parseGrokExtensionNotification: ACPExtensionNotificationParser =
+  createGrokExtensionNotificationParser();
+
+function isGrokInitialize(response: InitializeResponse): boolean {
+  return isRecord(response._meta) && response._meta.grokShell === true;
+}
+
+function toActivityDate(row: z.infer<typeof GrokSessionListRowSchema>): Date {
+  for (const value of [row.lastActiveAt, row.updatedAt, row.createdAt]) {
+    if (!value) continue;
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+  return new Date(0);
+}
+export function parseGrokSessionListPage(response: unknown): {
+  sessions: ImportableProviderSession[];
+  nextCursor: string | null;
+} {
+  const parsed = GrokSessionListEnvelopeSchema.parse(response);
+  if (parsed.error != null || !parsed.result) {
+    throw new Error("Grok session listing failed");
+  }
+  return {
+    sessions: parsed.result.sessions.map((row) => ({
+      providerHandleId: row.sessionId,
+      cwd: row.cwd,
+      title: row.title ?? row.summary ?? null,
+      firstPromptPreview: row.firstPrompt ?? null,
+      lastPromptPreview: null,
+      lastActivityAt: toActivityDate(row),
+    })),
+    nextCursor: parsed.result.nextCursor ?? null,
+  };
+}
+
+function authPath(env: Record<string, string | undefined>): string {
+  if (env.GROK_AUTH_PATH) return env.GROK_AUTH_PATH;
+  return join(env.GROK_HOME ?? join(homedir(), ".grok"), "auth.json");
+}
+
+export class GrokACPAgentClient extends GenericACPAgentClient {
+  private readonly configuredEnv: Record<string, string>;
+
+  constructor(options: GrokACPAgentClientOptions) {
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId,
+      label: options.label,
+      providerParams: options.providerParams,
+      initializeRequestMeta: GROK_INITIALIZE_META,
+      initialCommandsParser: parseGrokInitialCommands,
+      forwardChildSessionUpdates: true,
+      extensionNotificationParser: createGrokExtensionNotificationParser(),
+      sessionResponseTransformer: transformGrokSessionResponse,
+      thinkingOptionWriter: writeGrokThinkingOption,
+      toolSnapshotTransformer: transformGrokAcpToolSnapshot,
+      toolDetailMapper: mapGrokAcpToolDetail,
+    });
+    this.configuredEnv = options.env ?? {};
+  }
+
+  override async listImportableSessions(
+    options?: ListImportableSessionsOptions,
+  ): Promise<ImportableProviderSession[]> {
+    const probe = await this.spawnProcess({ NO_BROWSER: "true" });
+    if (!isGrokInitialize(probe.initialize)) {
+      await this.closeProbe(probe);
+      return await super.listImportableSessions(options);
+    }
+    try {
+      const sessions: ImportableProviderSession[] = [];
+      let cursor: string | null = null;
+      for (;;) {
+        const response = await this.runACPRequest(() =>
+          probe.connection.extMethod("_x.ai/session/list", {
+            ...(options?.cwd ? { cwd: options.cwd } : {}),
+            ...(cursor ? { cursor } : {}),
+            limit: options?.limit ?? 30,
+          }),
+        );
+        const page = parseGrokSessionListPage(response);
+        sessions.push(...page.sessions);
+        cursor = page.nextCursor;
+        if (!cursor || (options?.limit != null && sessions.length >= options.limit)) break;
+      }
+      return options?.limit == null ? sessions : sessions.slice(0, options.limit);
+    } finally {
+      await this.closeProbe(probe);
+    }
+  }
+
+  override async getDiagnostic(): Promise<{ diagnostic: string }> {
+    const result = await super.getDiagnostic();
+    const env = { ...process.env, ...this.configuredEnv };
+    const authEnvKey = GROK_AUTH_ENV_KEYS.find((key) => Boolean(env[key])) ?? null;
+    if (authEnvKey) {
+      return { diagnostic: `${result.diagnostic}\n  Authentication: configured via ${authEnvKey}` };
+    }
+
+    const path = authPath(env);
+    try {
+      await access(path);
+      return { diagnostic: `${result.diagnostic}\n  Authentication: credentials found at ${path}` };
+    } catch {
+      return {
+        diagnostic: `${result.diagnostic}\n  Authentication: no environment credential or auth.json found (config.toml and interactive login not inspected); run grok login or set XAI_API_KEY if launch fails`,
+      };
+    }
+  }
+}

--- a/packages/server/src/server/agent/providers/grok-subagent-meta.test.ts
+++ b/packages/server/src/server/agent/providers/grok-subagent-meta.test.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  encodeGrokSessionsCwdDirname,
+  readGrokSubagentDiskMeta,
+  resolveGrokHome,
+} from "./grok-subagent-meta.js";
+
+const CANONICAL = {
+  low: "low",
+  high: "high",
+  max: "xhigh",
+};
+
+describe("grok-subagent-meta", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("resolveGrokHome prefers GROK_HOME", () => {
+    expect(resolveGrokHome({ GROK_HOME: "/tmp/custom-grok" })).toBe("/tmp/custom-grok");
+  });
+
+  test("reads model and reasoning from child summary.json via cwd path", () => {
+    const grokHome = mkdtempSync(join(tmpdir(), "paseo-grok-meta-"));
+    tempDirs.push(grokHome);
+    const cwd = "/workspace/project";
+    const childId = "child-session-1";
+    const summaryDir = join(grokHome, "sessions", encodeGrokSessionsCwdDirname(cwd), childId);
+    mkdirSync(summaryDir, { recursive: true });
+    writeFileSync(
+      join(summaryDir, "summary.json"),
+      JSON.stringify({
+        current_model_id: "grok-4.5",
+        reasoning_effort: "max",
+      }),
+    );
+
+    expect(
+      readGrokSubagentDiskMeta({
+        childSessionId: childId,
+        cwd,
+        env: { GROK_HOME: grokHome },
+        canonicalReasoningEffort: CANONICAL,
+      }),
+    ).toEqual({
+      model: "grok-4.5",
+      thinkingOptionId: "xhigh",
+    });
+  });
+
+  test("falls back to shallow sessions walk when cwd encoding differs", () => {
+    const grokHome = mkdtempSync(join(tmpdir(), "paseo-grok-meta-walk-"));
+    tempDirs.push(grokHome);
+    const childId = "child-session-2";
+    const summaryDir = join(grokHome, "sessions", "hashed-cwd-epoch", childId);
+    mkdirSync(summaryDir, { recursive: true });
+    writeFileSync(
+      join(summaryDir, "summary.json"),
+      JSON.stringify({
+        current_model_id: "grok-code",
+        reasoning_effort: "low",
+      }),
+    );
+
+    expect(
+      readGrokSubagentDiskMeta({
+        childSessionId: childId,
+        cwd: "/some/other/cwd",
+        env: { GROK_HOME: grokHome },
+        canonicalReasoningEffort: CANONICAL,
+      }),
+    ).toEqual({
+      model: "grok-code",
+      thinkingOptionId: "low",
+    });
+  });
+
+  test("returns null when summary is missing or unreadable", () => {
+    const grokHome = mkdtempSync(join(tmpdir(), "paseo-grok-meta-miss-"));
+    tempDirs.push(grokHome);
+    expect(
+      readGrokSubagentDiskMeta({
+        childSessionId: "missing",
+        cwd: "/workspace",
+        env: { GROK_HOME: grokHome },
+        canonicalReasoningEffort: CANONICAL,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/server/src/server/agent/providers/grok-subagent-meta.ts
+++ b/packages/server/src/server/agent/providers/grok-subagent-meta.ts
@@ -1,0 +1,106 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+/**
+ * Best-effort reads of Grok Build child-session metadata from the local
+ * Grok home. All paths are private Grok layout; failures must be silent.
+ */
+
+const GrokChildSessionSummarySchema = z
+  .object({
+    current_model_id: z.string().optional(),
+    reasoning_effort: z.string().optional(),
+  })
+  .passthrough();
+
+export interface GrokSubagentDiskMeta {
+  model: string | null;
+  thinkingOptionId: string | null;
+}
+
+export function resolveGrokHome(env: Record<string, string | undefined> = process.env): string {
+  return env.GROK_HOME?.trim() || join(homedir(), ".grok");
+}
+
+/** Match Grok's short-path `encode_cwd_dirname` (urlencoding of the cwd). */
+export function encodeGrokSessionsCwdDirname(cwd: string): string {
+  return encodeURIComponent(cwd);
+}
+
+function normalizeReasoningEffort(
+  value: string | null | undefined,
+  canonical: Record<string, string>,
+): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return canonical[trimmed.toLowerCase()] ?? trimmed;
+}
+
+function readSummaryAt(
+  path: string,
+  canonical: Record<string, string>,
+): GrokSubagentDiskMeta | null {
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = GrokChildSessionSummarySchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) return null;
+    const model =
+      typeof parsed.data.current_model_id === "string" && parsed.data.current_model_id.trim()
+        ? parsed.data.current_model_id.trim()
+        : null;
+    const thinkingOptionId = normalizeReasoningEffort(parsed.data.reasoning_effort, canonical);
+    if (!model && !thinkingOptionId) return null;
+    return { model, thinkingOptionId };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Locate `summary.json` for a Grok child session under `~/.grok/sessions`.
+ * Prefer the direct cwd-encoded path; fall back to a shallow walk so long-cwd
+ * hash encodings and layout drift still work when possible.
+ */
+export function readGrokSubagentDiskMeta(input: {
+  childSessionId: string;
+  cwd?: string | null;
+  env?: Record<string, string | undefined>;
+  canonicalReasoningEffort?: Record<string, string>;
+}): GrokSubagentDiskMeta | null {
+  const childSessionId = input.childSessionId.trim();
+  if (!childSessionId) return null;
+
+  const env = input.env ?? process.env;
+  const grokHome = resolveGrokHome(env);
+  const sessionsRoot = join(grokHome, "sessions");
+  const canonical = input.canonicalReasoningEffort ?? {};
+
+  const cwd = typeof input.cwd === "string" ? input.cwd.trim() : "";
+  if (cwd) {
+    const direct = join(
+      sessionsRoot,
+      encodeGrokSessionsCwdDirname(cwd),
+      childSessionId,
+      "summary.json",
+    );
+    const fromDirect = readSummaryAt(direct, canonical);
+    if (fromDirect) return fromDirect;
+  }
+
+  // Shallow walk: sessions/<cwd-epoch>/<session-id>/summary.json
+  try {
+    for (const epoch of readdirSync(sessionsRoot, { withFileTypes: true })) {
+      if (!epoch.isDirectory()) continue;
+      const candidate = join(sessionsRoot, epoch.name, childSessionId, "summary.json");
+      const found = readSummaryAt(candidate, canonical);
+      if (found) return found;
+    }
+  } catch {
+    // missing sessions root or unreadable — graceful fail
+  }
+  return null;
+}

--- a/packages/server/src/server/agent/providers/grok-tool-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/grok-tool-mapper.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, test } from "vitest";
+
+import type { ACPToolSnapshot } from "./acp-agent.js";
+import { mapGrokAcpToolDetail, transformGrokAcpToolSnapshot } from "./grok-tool-mapper.js";
+
+const unknownDetail = {
+  type: "unknown" as const,
+  input: null,
+  output: null,
+};
+
+function snapshot(
+  partial: Partial<ACPToolSnapshot> & Pick<ACPToolSnapshot, "toolCallId" | "title">,
+): ACPToolSnapshot {
+  return {
+    kind: null,
+    status: "completed",
+    content: null,
+    locations: null,
+    ...partial,
+  };
+}
+
+describe("mapGrokAcpToolDetail", () => {
+  test("maps Task / spawn_subagent tools to sub_agent detail", () => {
+    const detail = mapGrokAcpToolDetail(
+      snapshot({
+        toolCallId: "call-1",
+        title: "Wait 10s random phrase",
+        kind: "other",
+        rawInput: {
+          variant: "Task",
+          description: "Wait 10s random phrase",
+          subagent_type: "general-purpose",
+          prompt: "Wait 10 seconds",
+          run_in_background: true,
+        },
+        rawOutput: {
+          type: "Text",
+          text: [
+            "Subagent started in background.",
+            "subagent_id: 019f8338-b3dd-7812-9035-175ed021d531",
+            "type: general-purpose",
+            "description: Wait 10s random phrase",
+            "",
+            'Use get_command_or_subagent_output with task_ids=["019f8338-b3dd-7812-9035-175ed021d531"] and timeout_ms to wait for results.',
+          ].join("\n"),
+        },
+      }),
+      unknownDetail,
+    );
+
+    expect(detail).toEqual({
+      type: "sub_agent",
+      subAgentType: "general-purpose",
+      description: "Wait 10s random phrase",
+      childSessionId: "019f8338-b3dd-7812-9035-175ed021d531",
+      // Identity lines already in the header are stripped from the log body.
+      log: "Subagent started in background.",
+    });
+  });
+
+  test("maps spawn_subagent title before kind update", () => {
+    const detail = mapGrokAcpToolDetail(
+      snapshot({
+        toolCallId: "call-2",
+        title: "spawn_subagent",
+        rawInput: {
+          description: "Explore registry",
+          prompt: "Map the provider registry",
+          subagent_type: "explore",
+          background: true,
+        },
+      }),
+      unknownDetail,
+    );
+
+    expect(detail).toMatchObject({
+      type: "sub_agent",
+      subAgentType: "explore",
+      description: "Explore registry",
+      log: "",
+    });
+  });
+
+  test("maps TaskOutput wait tools to plain_text summary", () => {
+    const detail = mapGrokAcpToolDetail(
+      snapshot({
+        toolCallId: "call-3",
+        title: "Get task output: 2 tasks",
+        kind: "other",
+        rawInput: {
+          variant: "TaskOutput",
+          task_ids: ["id-a", "id-b"],
+          timeout_ms: 60_000,
+        },
+        rawOutput: {
+          type: "TaskOutput",
+          MultiResult: {
+            mode: "wait_all",
+            results: [
+              {
+                task_id: "id-a",
+                command: "[subagent:general-purpose] Wait 10s random phrase",
+                status: "completed",
+                output: "Quiet rain on empty streets.\n\n<subagent_meta>id=id-a",
+              },
+              {
+                task_id: "id-b",
+                command: "[subagent:general-purpose] Wait 20s random phrase",
+                status: "completed",
+                output: "Velvet moons juggle quietly.",
+              },
+            ],
+          },
+        },
+      }),
+      unknownDetail,
+    );
+
+    expect(detail.type).toBe("plain_text");
+    if (detail.type !== "plain_text") return;
+    // Summary line is the row label; per-result lines are body only (no double header).
+    expect(detail.label).toBe("2/2 completed (wait_all)");
+    expect(detail.icon).toBe("bot");
+    expect(detail.text).not.toContain("2/2 completed (wait_all)");
+    expect(detail.text).toContain("Quiet rain on empty streets.");
+    expect(detail.text).toContain("Velvet moons juggle quietly.");
+    expect(detail.text).not.toContain("<subagent_meta");
+  });
+
+  test("normalizes TaskOutput tool title so the row is not double-labeled", () => {
+    const transformed = transformGrokAcpToolSnapshot(
+      snapshot({
+        toolCallId: "call-wait",
+        title: "multi-wait (wait_all)",
+        kind: "other",
+        rawInput: { variant: "TaskOutput", task_ids: ["a", "b"] },
+      }),
+    );
+    expect(transformed.title).toBe("Wait");
+  });
+
+  test("leaves unrelated tools unchanged", () => {
+    const detail = mapGrokAcpToolDetail(
+      snapshot({
+        toolCallId: "call-4",
+        title: "grep",
+        kind: "search",
+        rawInput: { pattern: "foo" },
+      }),
+      {
+        type: "search",
+        query: "foo",
+        toolName: "search",
+      },
+    );
+    expect(detail).toEqual({
+      type: "search",
+      query: "foo",
+      toolName: "search",
+    });
+  });
+
+  test("maps nested action.query web_search off placeholder title", () => {
+    const detail = mapGrokAcpToolDetail(
+      snapshot({
+        toolCallId: "call-ws",
+        title: "Web search:",
+        kind: "search",
+        rawInput: {
+          action: {
+            type: "search",
+            query: "Azure Container Apps serverless GPU pricing",
+            sources: [
+              {
+                type: "url",
+                url: "https://learn.microsoft.com/en-us/azure/container-apps/billing",
+                title: "Billing in Azure Container Apps",
+              },
+              {
+                type: "url",
+                url: "https://azure.microsoft.com/en-us/pricing/details/container-apps/",
+              },
+            ],
+          },
+        },
+      }),
+      {
+        // What the generic ACP mapper produces without action.query support.
+        type: "search",
+        query: "Web search:",
+        toolName: "search",
+      },
+    );
+
+    expect(detail).toEqual({
+      type: "search",
+      query: "Azure Container Apps serverless GPU pricing",
+      toolName: "web_search",
+      webResults: [
+        {
+          title: "Billing in Azure Container Apps",
+          url: "https://learn.microsoft.com/en-us/azure/container-apps/billing",
+        },
+        {
+          title: "https://azure.microsoft.com/en-us/pricing/details/container-apps/",
+          url: "https://azure.microsoft.com/en-us/pricing/details/container-apps/",
+        },
+      ],
+    });
+  });
+
+  test("maps Web search title with inline query when action is empty", () => {
+    const detail = mapGrokAcpToolDetail(
+      snapshot({
+        toolCallId: "call-ws-title",
+        title: "Web search: Gemma 4 pan-and-scan",
+        kind: "search",
+        rawInput: {},
+      }),
+      {
+        type: "search",
+        query: "Web search: Gemma 4 pan-and-scan",
+        toolName: "search",
+      },
+    );
+
+    expect(detail).toMatchObject({
+      type: "search",
+      query: "Gemma 4 pan-and-scan",
+      toolName: "web_search",
+    });
+  });
+
+  test("maps nested action.url open_page fetch", () => {
+    const detail = mapGrokAcpToolDetail(
+      snapshot({
+        toolCallId: "call-fetch",
+        title: "open_page",
+        kind: "other",
+        rawInput: {
+          action: {
+            type: "open_page",
+            url: "https://example.com/docs",
+            prompt: "summarize pricing",
+          },
+        },
+      }),
+      {
+        // Generic ACP mapper without action.url support falls back to title.
+        type: "other",
+        content: null,
+      } as never,
+    );
+
+    expect(detail).toMatchObject({
+      type: "fetch",
+      url: "https://example.com/docs",
+      prompt: "summarize pricing",
+    });
+  });
+
+  test("maps fetch with uri/href aliases under action", () => {
+    const detail = mapGrokAcpToolDetail(
+      snapshot({
+        toolCallId: "call-fetch-uri",
+        title: "Browse",
+        kind: "fetch",
+        rawInput: {
+          action: {
+            uri: "https://example.com/via-uri",
+          },
+        },
+      }),
+      {
+        type: "fetch",
+        url: "Browse",
+      },
+    );
+
+    expect(detail).toMatchObject({
+      type: "fetch",
+      url: "https://example.com/via-uri",
+    });
+  });
+
+  test("does not treat placeholder Web search title as the query when defaultDetail is placeholder", () => {
+    const detail = mapGrokAcpToolDetail(
+      snapshot({
+        toolCallId: "call-ws-ph",
+        title: "Web search:",
+        kind: "search",
+        rawInput: {
+          action: {
+            type: "search",
+            query: "real query from action",
+          },
+        },
+      }),
+      {
+        // After generic mapper reverts to main: query falls back to snapshot.title.
+        type: "search",
+        query: "Web search:",
+        toolName: "search",
+      },
+    );
+
+    expect(detail).toMatchObject({
+      type: "search",
+      query: "real query from action",
+      toolName: "web_search",
+    });
+  });
+});

--- a/packages/server/src/server/agent/providers/grok-tool-mapper.ts
+++ b/packages/server/src/server/agent/providers/grok-tool-mapper.ts
@@ -1,0 +1,481 @@
+import type { ToolCallDetail } from "../agent-sdk-types.js";
+import type { ACPToolSnapshot } from "./acp-agent.js";
+
+/**
+ * Grok ACP tool polish: map Task / TaskOutput tools onto existing Paseo detail
+ * types so the timeline matches Claude/OMP/OpenCode norms.
+ */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    const text = readString(value);
+    if (text) return text;
+  }
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null;
+}
+
+function extractTextFromContent(content: ACPToolSnapshot["content"]): string | null {
+  if (!content?.length) return null;
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!isRecord(block) || block.type !== "content") continue;
+    const inner = asRecord(block.content);
+    const text = readString(inner?.text);
+    if (text) parts.push(text);
+  }
+  return parts.length > 0 ? parts.join("\n") : null;
+}
+
+function asUnknownArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function readRecordArray(value: unknown): Record<string, unknown>[] {
+  return asUnknownArray(value).filter(isRecord);
+}
+
+function waitLabelForTaskIds(taskIds: unknown[]): string {
+  if (taskIds.length === 0) return "Wait for subagents";
+  return `Wait for ${taskIds.length} subagent${taskIds.length === 1 ? "" : "s"}`;
+}
+
+function extractTextFromRawOutput(rawOutput: unknown): string | null {
+  if (typeof rawOutput === "string") return rawOutput.trim() || null;
+  const record = asRecord(rawOutput);
+  if (!record) return null;
+  if (record.type === "Text") {
+    return firstString(record.text, record.content);
+  }
+  return firstString(record.text, record.output, record.content);
+}
+
+function parseSubagentIdFromText(text: string | null): string | null {
+  if (!text) return null;
+  const match = text.match(/subagent_id:\s*([^\s\n]+)/i);
+  return match?.[1]?.trim() || null;
+}
+
+function normalizeComparable(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+/**
+ * Drop instruction boilerplate and identity lines already shown in the
+ * sub_agent header (type, description, session id).
+ */
+function stripSpawnLogNoise(
+  text: string | null,
+  fields: {
+    childSessionId?: string | null;
+    subAgentType?: string | null;
+    description?: string | null;
+  },
+): string {
+  if (!text) return "";
+  const id = normalizeComparable(fields.childSessionId);
+  const type = normalizeComparable(fields.subAgentType);
+  const description = normalizeComparable(fields.description);
+  const lines = text
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return false;
+      const lower = trimmed.toLowerCase();
+      if (lower.startsWith("use get_command_or_subagent_output")) return false;
+      if (lower.startsWith("use get_task_output")) return false;
+      const idMatch = trimmed.match(/^subagent_id:\s*(.+)$/i);
+      if (idMatch && (!id || normalizeComparable(idMatch[1]) === id)) return false;
+      const typeMatch = trimmed.match(/^type:\s*(.+)$/i);
+      // Only strip when we know the field value and it matches (avoid dropping unknown labels).
+      if (typeMatch && type && normalizeComparable(typeMatch[1]) === type) return false;
+      const descMatch = trimmed.match(/^description:\s*(.+)$/i);
+      if (descMatch && description && normalizeComparable(descMatch[1]) === description) {
+        return false;
+      }
+      return true;
+    });
+  return lines.join("\n").trim();
+}
+
+function isGrokTaskSpawn(
+  snapshot: ACPToolSnapshot,
+  input: Record<string, unknown> | null,
+): boolean {
+  const variant = firstString(input?.variant);
+  if (variant === "Task") return true;
+  const title = snapshot.title.trim().toLowerCase();
+  if (title === "spawn_subagent" || title === "task") return true;
+  if (
+    input &&
+    firstString(input.subagent_type, input.subagentType) &&
+    firstString(input.prompt, input.description)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function isGrokTaskOutput(
+  snapshot: ACPToolSnapshot,
+  input: Record<string, unknown> | null,
+  rawOutput: Record<string, unknown> | null,
+): boolean {
+  const variant = firstString(input?.variant);
+  if (variant === "TaskOutput") return true;
+  const title = snapshot.title.trim().toLowerCase();
+  if (title === "get_command_or_subagent_output" || title.startsWith("get task output"))
+    return true;
+  if (title.startsWith("multi-wait")) return true;
+  if (rawOutput?.type === "TaskOutput") return true;
+  if (Array.isArray(input?.task_ids) || Array.isArray(input?.taskIds)) return true;
+  return false;
+}
+
+function mapTaskSpawnDetail(
+  snapshot: ACPToolSnapshot,
+  input: Record<string, unknown> | null,
+): ToolCallDetail {
+  const text =
+    extractTextFromContent(snapshot.content) ?? extractTextFromRawOutput(snapshot.rawOutput);
+  const childSessionId =
+    parseSubagentIdFromText(text) ??
+    firstString(input?.task_id, input?.taskId, input?.subagent_id, input?.subagentId);
+  const subAgentType =
+    firstString(input?.subagent_type, input?.subagentType, input?.agent, input?.type) ?? undefined;
+  const description =
+    firstString(input?.description, snapshot.title !== "spawn_subagent" ? snapshot.title : null) ??
+    undefined;
+  const log = stripSpawnLogNoise(text, { childSessionId, subAgentType, description });
+  return {
+    type: "sub_agent",
+    subAgentType,
+    description,
+    ...(childSessionId ? { childSessionId } : {}),
+    log,
+  };
+}
+
+function formatTaskResultLine(result: Record<string, unknown>): string {
+  const id = firstString(result.task_id, result.taskId) ?? "task";
+  const status = firstString(result.status) ?? "unknown";
+  const command = firstString(result.command);
+  const output = firstString(result.output);
+  const shortOutput = output
+    ? output
+        .split("\n")
+        .map((line) => line.trim())
+        .find((line) => line.length > 0 && !line.startsWith("<subagent_meta"))
+    : null;
+  const label = command?.replace(/^\[subagent:[^\]]+\]\s*/i, "") ?? id.slice(0, 8);
+  if (shortOutput) return `${status} · ${label} · ${shortOutput}`;
+  return `${status} · ${label}`;
+}
+
+function collectTaskOutputResults(
+  rawOutput: Record<string, unknown> | null,
+): Record<string, unknown>[] {
+  const multi = asRecord(rawOutput?.MultiResult) ?? asRecord(rawOutput?.multiResult);
+  const fromMulti = readRecordArray(multi?.results);
+  if (fromMulti.length > 0) return fromMulti;
+  return readRecordArray(rawOutput?.results);
+}
+
+function taskOutputLines(
+  results: Record<string, unknown>[],
+  ids: unknown[],
+  mode: string | null,
+  snapshot: ACPToolSnapshot,
+): string[] {
+  if (results.length > 0) {
+    const completed = results.filter((row) => firstString(row.status) === "completed").length;
+    const header = mode
+      ? `${completed}/${results.length} completed (${mode})`
+      : `${completed}/${results.length} completed`;
+    const lines = [header, ...results.slice(0, 8).map(formatTaskResultLine)];
+    if (results.length > 8) {
+      lines.push(`…and ${results.length - 8} more`);
+    }
+    return lines;
+  }
+  if (ids.length > 0) {
+    return [`Waiting for ${ids.length} subagent${ids.length === 1 ? "" : "s"}`];
+  }
+  const text =
+    extractTextFromContent(snapshot.content) ?? extractTextFromRawOutput(snapshot.rawOutput);
+  return text ? [text] : [];
+}
+
+function mapTaskOutputDetail(
+  snapshot: ACPToolSnapshot,
+  input: Record<string, unknown> | null,
+): ToolCallDetail {
+  const rawOutput = asRecord(snapshot.rawOutput);
+  const multi = asRecord(rawOutput?.MultiResult) ?? asRecord(rawOutput?.multiResult);
+  const results = collectTaskOutputResults(rawOutput);
+  const idsRaw = asUnknownArray(input?.task_ids);
+  const ids = idsRaw.length > 0 ? idsRaw : asUnknownArray(input?.taskIds);
+  const mode = firstString(multi?.mode, multi?.Mode);
+  const lines = taskOutputLines(results, ids, mode, snapshot);
+  // plain_text: label → row summary; text → expanded body.
+  // Keep them distinct so the header is not "Multi Wait … multi-wait …".
+  const summaryLine = lines[0] ?? waitLabelForTaskIds(ids);
+  const bodyLines = lines.length > 1 ? lines.slice(1) : [];
+
+  return {
+    type: "plain_text",
+    label: summaryLine,
+    text: bodyLines.join("\n"),
+    icon: "bot",
+  };
+}
+
+/**
+ * Grok backend web_search ACP rawInput nests fields under `action`:
+ * `{ action: { type: "search", query, sources } }` — not top-level `query`.
+ * Title is often the placeholder `Web search:` with the real query only in action.
+ */
+function isGrokWebSearch(
+  snapshot: ACPToolSnapshot,
+  input: Record<string, unknown> | null,
+): boolean {
+  const title = snapshot.title.trim().toLowerCase();
+  if (title === "web search" || title.startsWith("web search:")) return true;
+  if (snapshot.kind === "search" && asRecord(input?.action)?.query != null) return true;
+  const actionType = firstString(asRecord(input?.action)?.type);
+  return actionType === "search" && firstString(asRecord(input?.action)?.query) != null;
+}
+
+function queryFromWebSearchTitle(title: string): string | null {
+  const match = title.match(/^web\s*search\s*:\s*(.+)$/i);
+  const fromTitle = match?.[1]?.trim();
+  return fromTitle && fromTitle.length > 0 ? fromTitle : null;
+}
+
+function isPlaceholderSearchQuery(query: string | null | undefined): boolean {
+  if (!query) return true;
+  const trimmed = query.trim();
+  if (!trimmed) return true;
+  // Bare ACP title fallback — not a real search string.
+  return /^web\s*search\s*:?\s*$/i.test(trimmed) || /^search\s*:?\s*$/i.test(trimmed);
+}
+
+function extractGrokWebSearchQuery(
+  snapshot: ACPToolSnapshot,
+  input: Record<string, unknown> | null,
+): string | null {
+  const action = asRecord(input?.action);
+  const fromAction = firstString(action?.query, action?.pattern, action?.q);
+  if (fromAction) return fromAction;
+  const fromTop = firstString(input?.query, input?.pattern, input?.q, input?.search);
+  if (fromTop && !isPlaceholderSearchQuery(fromTop)) return fromTop;
+  const fromTitle = queryFromWebSearchTitle(snapshot.title);
+  if (fromTitle) return fromTitle;
+  return null;
+}
+
+function extractGrokWebResults(
+  input: Record<string, unknown> | null,
+  rawOutput: Record<string, unknown> | null,
+): Array<{ title: string; url: string }> {
+  const action = asRecord(input?.action);
+  const sourceLists = [
+    asUnknownArray(action?.sources),
+    asUnknownArray(input?.sources),
+    asUnknownArray(rawOutput?.sources),
+    asUnknownArray(asRecord(rawOutput?.action)?.sources),
+  ];
+  const results: Array<{ title: string; url: string }> = [];
+  const seen = new Set<string>();
+  for (const list of sourceLists) {
+    for (const entry of list) {
+      const row = asRecord(entry);
+      if (!row) continue;
+      const url = firstString(row.url, row.uri, row.href);
+      if (!url || seen.has(url)) continue;
+      seen.add(url);
+      const title = firstString(row.title, row.name, row.site_name) ?? url;
+      results.push({ title, url });
+    }
+  }
+  return results;
+}
+
+function mapWebSearchDetail(
+  snapshot: ACPToolSnapshot,
+  input: Record<string, unknown> | null,
+  defaultDetail: ToolCallDetail,
+): ToolCallDetail {
+  const rawOutput = asRecord(snapshot.rawOutput);
+  const query = extractGrokWebSearchQuery(snapshot, input);
+  const webResults = extractGrokWebResults(input, rawOutput);
+  const content =
+    extractTextFromContent(snapshot.content) ?? extractTextFromRawOutput(snapshot.rawOutput);
+
+  // Prefer Grok-shaped search even when the generic mapper already returned
+  // type "search" with a placeholder title as the query.
+  if (!query && webResults.length === 0 && content == null) {
+    return defaultDetail;
+  }
+
+  const resolvedQuery =
+    query ??
+    (defaultDetail.type === "search" && !isPlaceholderSearchQuery(defaultDetail.query)
+      ? defaultDetail.query
+      : null) ??
+    (webResults.length > 0
+      ? `${webResults.length} result${webResults.length === 1 ? "" : "s"}`
+      : null) ??
+    "Web search";
+
+  return {
+    type: "search",
+    query: resolvedQuery,
+    toolName: "web_search",
+    ...(content ? { content } : {}),
+    ...(webResults.length > 0 ? { webResults } : {}),
+    ...(snapshot.locations?.length
+      ? { filePaths: snapshot.locations.map((location) => location.path) }
+      : {}),
+  };
+}
+
+/**
+ * Normalize titles so ACP display name is not a second copy of the wait summary.
+ * Applied before detail mapping via toolSnapshotTransformer.
+ */
+export function transformGrokAcpToolSnapshot(snapshot: ACPToolSnapshot): ACPToolSnapshot {
+  const input = asRecord(snapshot.rawInput);
+  const rawOutput = asRecord(snapshot.rawOutput);
+  if (!isGrokTaskOutput(snapshot, input, rawOutput)) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    title: "Wait",
+  };
+}
+
+function isGrokFetch(snapshot: ACPToolSnapshot, input: Record<string, unknown> | null): boolean {
+  if (snapshot.kind === "fetch") return true;
+  const title = snapshot.title.trim().toLowerCase();
+  if (title === "open_page" || title.startsWith("open page") || title.startsWith("open_page")) {
+    return true;
+  }
+  const action = asRecord(input?.action);
+  if (!action) return false;
+  const actionType = firstString(action.type);
+  if (actionType === "open_page" || actionType === "fetch" || actionType === "browse") return true;
+  // Nested target URL without a concrete search action — open_page shape.
+  return (
+    firstString(action.url, action.uri, action.href) != null &&
+    firstString(action.query, action.pattern) == null
+  );
+}
+
+function asFetchDefault(
+  defaultDetail: ToolCallDetail,
+): Extract<ToolCallDetail, { type: "fetch" }> | null {
+  return defaultDetail.type === "fetch" ? defaultDetail : null;
+}
+
+function resolveFetchUrl(
+  snapshot: ACPToolSnapshot,
+  input: Record<string, unknown> | null,
+  action: Record<string, unknown> | null,
+  fromDefault: Extract<ToolCallDetail, { type: "fetch" }> | null,
+): string {
+  return (
+    firstString(
+      input?.url,
+      input?.uri,
+      input?.href,
+      action?.url,
+      action?.uri,
+      action?.href,
+      fromDefault?.url,
+    ) ?? snapshot.title
+  );
+}
+
+function resolveFetchResult(
+  snapshot: ACPToolSnapshot,
+  rawOutput: Record<string, unknown> | null,
+  fromDefault: Extract<ToolCallDetail, { type: "fetch" }> | null,
+): string | null {
+  return (
+    extractTextFromContent(snapshot.content) ??
+    extractTextFromRawOutput(snapshot.rawOutput) ??
+    firstString(rawOutput?.result, rawOutput?.text, rawOutput?.content) ??
+    fromDefault?.result ??
+    null
+  );
+}
+
+function resolveFetchCode(
+  rawOutput: Record<string, unknown> | null,
+  fromDefault: Extract<ToolCallDetail, { type: "fetch" }> | null,
+): number | undefined {
+  const codeValue = rawOutput?.status ?? rawOutput?.code ?? fromDefault?.code;
+  return typeof codeValue === "number" ? codeValue : undefined;
+}
+
+function mapFetchDetail(
+  snapshot: ACPToolSnapshot,
+  input: Record<string, unknown> | null,
+  defaultDetail: ToolCallDetail,
+): ToolCallDetail {
+  const action = asRecord(input?.action);
+  const rawOutput = asRecord(snapshot.rawOutput);
+  const fromDefault = asFetchDefault(defaultDetail);
+  const url = resolveFetchUrl(snapshot, input, action, fromDefault);
+  const prompt = firstString(input?.prompt, action?.prompt, fromDefault?.prompt);
+  const result = resolveFetchResult(snapshot, rawOutput, fromDefault);
+  const code = resolveFetchCode(rawOutput, fromDefault);
+  const detail: Extract<ToolCallDetail, { type: "fetch" }> = { type: "fetch", url };
+  if (prompt) detail.prompt = prompt;
+  if (result) detail.result = result;
+  if (code !== undefined) detail.code = code;
+  return detail;
+}
+
+/**
+ * Map Grok-specific ACP tool snapshots onto Paseo tool details.
+ * Returns `defaultDetail` unchanged for tools we don't special-case.
+ */
+export function mapGrokAcpToolDetail(
+  snapshot: ACPToolSnapshot,
+  defaultDetail: ToolCallDetail,
+): ToolCallDetail {
+  const input = asRecord(snapshot.rawInput);
+  const rawOutput = asRecord(snapshot.rawOutput);
+
+  if (isGrokTaskSpawn(snapshot, input)) {
+    return mapTaskSpawnDetail(snapshot, input);
+  }
+  if (isGrokTaskOutput(snapshot, input, rawOutput)) {
+    return mapTaskOutputDetail(snapshot, input);
+  }
+  // Grok nests web_search under action.query; generic ACP only reads top-level
+  // query/pattern and falls back to the placeholder title "Web search:".
+  if (isGrokWebSearch(snapshot, input)) {
+    return mapWebSearchDetail(snapshot, input, defaultDetail);
+  }
+  // Grok open_page nests the target under action.url (also uri/href, action.prompt).
+  if (isGrokFetch(snapshot, input)) {
+    return mapFetchDetail(snapshot, input, defaultDetail);
+  }
+  return defaultDetail;
+}

--- a/packages/server/src/server/agent/timeline-projection.test.ts
+++ b/packages/server/src/server/agent/timeline-projection.test.ts
@@ -119,6 +119,46 @@ describe("projectTimelineRows", () => {
     expect(projected[0]?.collapsed).toContain("reasoning_merge");
   });
 
+  test("does not merge adjacent text chunks across turns", () => {
+    const rows: AgentTimelineRow[] = [
+      {
+        seq: 1,
+        timestamp: "2026-02-13T00:00:00.000Z",
+        turnId: "turn-1",
+        item: { type: "assistant_message", text: "First answer" },
+      },
+      {
+        seq: 2,
+        timestamp: "2026-02-13T00:00:00.100Z",
+        turnId: "turn-2",
+        item: { type: "assistant_message", text: "Second answer" },
+      },
+      {
+        seq: 3,
+        timestamp: "2026-02-13T00:00:00.200Z",
+        turnId: "turn-1",
+        item: { type: "reasoning", text: "First thought" },
+      },
+      {
+        seq: 4,
+        timestamp: "2026-02-13T00:00:00.300Z",
+        turnId: "turn-2",
+        item: { type: "reasoning", text: "Second thought" },
+      },
+    ];
+
+    const projected = projectTimelineRows({ rows, mode: "projected" });
+
+    expect(projected).toHaveLength(4);
+    expect(projected.map((entry) => entry.turnId)).toEqual([
+      "turn-1",
+      "turn-2",
+      "turn-1",
+      "turn-2",
+    ]);
+    expect(projected.map((entry) => entry.collapsed)).toEqual([[], [], [], []]);
+  });
+
   test("collapses tool lifecycle by callId and reports exact source seq ranges", () => {
     const rows: AgentTimelineRow[] = [
       {

--- a/packages/server/src/server/agent/timeline-projection.ts
+++ b/packages/server/src/server/agent/timeline-projection.ts
@@ -14,6 +14,7 @@ export type TimelineLimitDirection = "tail" | "before" | "after";
 export interface TimelineProjectionEntry {
   item: AgentTimelineItem;
   timestamp: string;
+  turnId?: string;
   seqStart: number;
   seqEnd: number;
   sourceSeqRanges: TimelineSeqRange[];
@@ -111,6 +112,7 @@ function makeCanonicalEntries(rows: readonly AgentTimelineRow[]): WorkingEntry[]
   return rows.map((row) => ({
     item: row.item,
     timestamp: row.timestamp,
+    ...(row.turnId !== undefined ? { turnId: row.turnId } : {}),
     seqStart: row.seq,
     seqEnd: row.seq,
     sourceSeqRanges: [{ startSeq: row.seq, endSeq: row.seq }],
@@ -169,6 +171,7 @@ function mergeReasoningChunks(entries: readonly WorkingEntry[]): WorkingEntry[] 
       previous &&
       previous.item.type === "reasoning" &&
       entry.item.type === "reasoning" &&
+      previous.turnId === entry.turnId &&
       previous.seqEnd + 1 === entry.seqStart;
 
     if (!shouldMerge || !previous) {
@@ -209,6 +212,7 @@ function mergeAssistantChunks(entries: readonly WorkingEntry[]): WorkingEntry[] 
       previous &&
       previous.item.type === "assistant_message" &&
       entry.item.type === "assistant_message" &&
+      previous.turnId === entry.turnId &&
       previous.seqEnd + 1 === entry.seqStart;
 
     if (!shouldMerge || !previous) {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -5854,6 +5854,7 @@ export class Session {
             provider: snapshot.provider,
             item: entry.item,
             timestamp: entry.timestamp,
+            turnId: entry.turnId,
             seqStart: entry.seqStart,
             seqEnd: entry.seqEnd,
             sourceSeqRanges: entry.sourceSeqRanges,

--- a/packages/server/src/server/wire-compat.test.ts
+++ b/packages/server/src/server/wire-compat.test.ts
@@ -224,16 +224,19 @@ function createSessionForWireCompatTest(options?: {
     {
       seq: 1,
       timestamp: "2026-05-02T00:00:00.000Z",
+      turnId: "turn-wire-1",
       item: { type: "reasoning", text: "Step " },
     },
     {
       seq: 2,
       timestamp: "2026-05-02T00:00:00.100Z",
+      turnId: "turn-wire-1",
       item: { type: "reasoning", text: "by step" },
     },
     {
       seq: 3,
       timestamp: "2026-05-02T00:00:00.200Z",
+      turnId: "turn-wire-1",
       item: { type: "assistant_message", text: "done" },
     },
   ];
@@ -464,6 +467,32 @@ describe("wire compatibility", () => {
 
     const currentParsed = FetchAgentTimelineResponseMessageSchema.parse(response);
     expect(currentParsed.payload.entries[0]?.collapsed).toContain("reasoning_merge");
+  });
+
+  test("projects optional entry turnId for current clients while legacy schema still parses", async () => {
+    // Default clients strip reasoning_merge from collapsed, matching the legacy enum set.
+    const response = await emitTimelineResponse();
+
+    // Session emits turnId on projected entries before any client schema strip.
+    expect(response.payload.entries.map((entry) => entry.turnId)).toEqual([
+      "turn-wire-1",
+      "turn-wire-1",
+    ]);
+    expect(response.payload.entries[0]?.item).toEqual({
+      type: "reasoning",
+      text: "Step by step",
+    });
+    expect(response.payload.entries[0]?.collapsed).toEqual([]);
+
+    // Current and legacy schemas both accept the payload (unknown optional fields strip).
+    expect(() => FetchAgentTimelineResponseMessageSchema.parse(response)).not.toThrow();
+    const legacyParsed = LegacyFetchAgentTimelineResponseMessageSchema.parse(response);
+    expect(legacyParsed.payload.entries).toHaveLength(2);
+    expect(
+      legacyParsed.payload.entries.every(
+        (entry) => !Object.prototype.hasOwnProperty.call(entry, "turnId"),
+      ),
+    ).toBe(true);
   });
 
   test("sub_agent tool-call payload still parses against the v0.1.65-beta.3 schema", () => {


### PR DESCRIPTION
### Linked issue

No dedicated feature issue yet — I'll open one describing the Grok gaps this addresses (or take it to Discord) before marking ready, per CONTRIBUTING. Related existing Grok issues for context: #2199, #2041, #2053, #2182 (not closed by this PR).

### Type of change

- [x] New feature (with prior issue + design alignment)

### What does this PR do

Grok Build currently runs through the generic ACP client, which ignores its `x.ai/*` extension surface. This specializes it as `GrokACPAgentClient` (subclass of the generic ACP client), keeping standard ACP for initialize/session/prompt/permissions/models and adding only the vendor seams:

- **Subagents:** live + replayed `subagent_spawned/progress/finished` notifications and standard child-session updates route into provider-subagent timelines (child session ID = subagent ID). Model/effort fold into the display title (same approach as OMP — no protocol fields).
- **Thinking levels:** `x.ai/sessionConfig` reasoning options map to Paseo thinking levels; writes go through `unstable_setSessionModel` with `reasoningEffort` meta.
- **Tool cards:** Task/`spawn_subagent` → `sub_agent` detail; TaskOutput/multi-wait → compact wait summary; `web_search`/`open_page` read Grok's `action.*`-nested input. All Grok-only, via the new `toolDetailMapper` post-pass — the generic ACP mappers are untouched.
- **Import:** richer `_x.ai/session/list` discovery with pagination.
- **Diagnostics:** auth readiness (env keys / `auth.json`) appended to provider diagnostics.

Shared ACP base changes are limited to opt-in hooks the subclass needs (`initializeRequestMeta`, `initialCommandsParser`, `extensionNotificationParser`, `forwardChildSessionUpdates`, `toolDetailMapper`, `thinkingOptionWriter` context signature) plus a refactor that lets foreground and child sessions share the same content-translation code path. Default behavior for other ACP providers is unchanged.

**Stacked PR:** the first two commits are #2293 and #2294; please review only the last commit (`feat(grok): …`) here. I'll rebase onto main as those land so the diff shrinks to the Grok-only delta.

### How did you verify it

- Unit suites run locally (115 tests): `grok-acp-agent`, `grok-tool-mapper`, `grok-subagent-meta`, `acp-agent` (incl. a full child-session routing scenario), `generic-acp-agent.diagnostic`. Plus `npm run typecheck`, `npm run lint`, `npm run format`. CI green.
- **Not yet verified against a live Grok binary** — the reason this is still draft. Before marking ready I will run and attach evidence for:
  - thinking levels mapping via real `sessionConfig`
  - live subagent spawn → parent Task card + subagents track, model/effort in title
  - session import (in particular the `{ result: { sessions } }` envelope assumption for `extMethod("_x.ai/session/list")`)
  - auth diagnostics against a real `GROK_HOME`
  - screenshots of the subagent track / tool cards for affected platforms

### Checklist

- [x] One focused change. Unrelated cleanups split out (#2293, #2294).
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform (pending live verification)
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)
