### PR TITLE
Start new workspaces from pasted pull requests

### DIFF
--- a/packages/app/e2e/global-setup.ts
+++ b/packages/app/e2e/global-setup.ts
@@ -328,6 +328,12 @@ interface PairingDaemonClient {
 
 async function createFakeEditorBin(): Promise<string> {
   const binDir = await mkdtemp(path.join(tmpdir(), "paseo-e2e-editor-bin-"));
+  let realGhPath = "";
+  try {
+    realGhPath = execSync("which gh").toString().trim();
+  } catch {
+    // The local PR fixture below remains usable without a system gh binary.
+  }
 
   const fakeEditorSource = `#!/usr/bin/env node
 const fs = require("fs");
@@ -348,6 +354,70 @@ if (recordPath) {
     await writeFile(editorPath, fakeEditorSource);
     await chmod(editorPath, 0o755);
   }
+
+  const fakeGhPath = path.join(binDir, "gh");
+  const fakeGhSource = `#!/usr/bin/env node
+const { spawnSync } = require("child_process");
+const args = process.argv.slice(2);
+const fixtureRemote = "https://github.com/paseo-e2e/local-fixture.git";
+const origin = spawnSync("git", ["config", "--get", "remote.origin.url"], {
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "ignore"]
+}).stdout?.trim();
+
+if (origin === fixtureRemote) {
+  const command = args.slice(0, 2).join(" ");
+  if (command === "auth status") process.exit(0);
+  if (command === "repo view") {
+    process.stdout.write(JSON.stringify({ owner: { login: "paseo-e2e" }, name: "local-fixture", parent: null }));
+    process.exit(0);
+  }
+  if (command === "issue list") {
+    process.stdout.write("[]");
+    process.exit(0);
+  }
+  if (command === "pr list" || command === "pr view") {
+    const pr = {
+      number: 1,
+      title: "Use pasted PR as start ref",
+      url: "https://github.com/paseo-e2e/local-fixture/pull/1",
+      state: "OPEN",
+      body: null,
+      labels: [],
+      baseRefName: "main",
+      headRefName: "pr-branch-1",
+      updatedAt: "2026-01-01T00:00:00Z"
+    };
+    process.stdout.write(JSON.stringify(command === "pr list" ? [pr] : pr));
+    process.exit(0);
+  }
+  if (command === "api graphql" && args.some((arg) => arg.includes("PullRequestCheckoutTarget"))) {
+    process.stdout.write(JSON.stringify({
+      data: { repository: { pullRequest: {
+        number: 1,
+        baseRefName: "main",
+        headRefName: "pr-branch-1",
+        isCrossRepository: false,
+        headRepositoryOwner: { login: "paseo-e2e" },
+        headRepository: {
+          sshUrl: "git@github.com:paseo-e2e/local-fixture.git",
+          url: fixtureRemote
+        }
+      } } }
+    }));
+    process.exit(0);
+  }
+  process.stderr.write("Unsupported local GitHub fixture command: " + args.join(" ") + "\\n");
+  process.exit(1);
+}
+
+const realGhPath = ${JSON.stringify(realGhPath)};
+if (!realGhPath) process.exit(127);
+const result = spawnSync(realGhPath, args, { stdio: "inherit" });
+process.exit(result.status ?? 1);
+`;
+  await writeFile(fakeGhPath, fakeGhSource);
+  await chmod(fakeGhPath, 0o755);
 
   return binDir;
 }

--- a/packages/app/e2e/helpers/github-fixtures.ts
+++ b/packages/app/e2e/helpers/github-fixtures.ts
@@ -1,5 +1,5 @@
 import { execFileSync, execSync } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 export function hasGithubAuth(): boolean {
@@ -56,6 +56,12 @@ export interface GhRepoFixture {
 
 export interface GhDefaultBranchClone {
   path: string;
+  cleanup(): Promise<void>;
+}
+
+export interface LocalGhPrFixture {
+  pr: GhPrFixture;
+  mainCheckout: GhDefaultBranchClone;
   cleanup(): Promise<void>;
 }
 
@@ -278,6 +284,60 @@ export async function cloneGithubRepoDefaultBranchOnly(
     path: clonePath,
     cleanup: async () => {
       await rm(clonePath, { recursive: true, force: true });
+    },
+  };
+}
+
+export async function createLocalGithubPrFixture(): Promise<LocalGhPrFixture> {
+  const fixtureRoot = await mkdtemp(path.join("/tmp", "paseo-e2e-local-github-pr-"));
+  const basePath = path.join(fixtureRoot, "base");
+  const remotePath = path.join(fixtureRoot, "remote.git");
+  const checkoutPath = path.join(fixtureRoot, "main-only");
+  const githubUrl = "https://github.com/paseo-e2e/local-fixture.git";
+  await mkdir(basePath);
+
+  git(["init", "-b", "main"], basePath);
+  git(["config", "user.email", "e2e@paseo.test"], basePath);
+  git(["config", "user.name", "Paseo E2E"], basePath);
+  git(["config", "commit.gpgsign", "false"], basePath);
+  await writeFile(path.join(basePath, "README.md"), "# Local GitHub fixture\n");
+  git(["add", "README.md"], basePath);
+  git(["commit", "-m", "Initial commit"], basePath);
+  git(["checkout", "-b", "pr-branch-1"], basePath);
+  await writeFile(path.join(basePath, "pr-1.txt"), "PR 1\n");
+  git(["add", "pr-1.txt"], basePath);
+  git(["commit", "-m", "Add PR 1"], basePath);
+  git(["checkout", "main"], basePath);
+
+  execFileSync("git", ["clone", "--quiet", "--bare", basePath, remotePath], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  git(["update-ref", "refs/pull/1/head", "refs/heads/pr-branch-1"], remotePath);
+  execFileSync(
+    "git",
+    ["clone", "--quiet", "--single-branch", "--branch", "main", remotePath, checkoutPath],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  git(["remote", "set-url", "origin", githubUrl], checkoutPath);
+  git(["config", `url.${remotePath}.insteadOf`, githubUrl], checkoutPath);
+  git(["config", "user.email", "e2e@paseo.test"], checkoutPath);
+  git(["config", "user.name", "Paseo E2E"], checkoutPath);
+  git(["config", "commit.gpgsign", "false"], checkoutPath);
+
+  return {
+    pr: {
+      number: 1,
+      title: "Use pasted PR as start ref",
+      url: "https://github.com/paseo-e2e/local-fixture/pull/1",
+      branch: "pr-branch-1",
+      localPath: basePath,
+    },
+    mainCheckout: {
+      path: checkoutPath,
+      cleanup: async () => {},
+    },
+    cleanup: async () => {
+      await rm(fixtureRoot, { recursive: true, force: true });
     },
   };
 }

--- a/packages/app/e2e/helpers/new-workspace.ts
+++ b/packages/app/e2e/helpers/new-workspace.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type BrowserContext, type Page } from "@playwright/test";
 import type { DaemonClient as InternalDaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { decodeWorkspaceIdFromPathSegment } from "@/utils/host-routes";
 import { connectDaemonClient } from "./daemon-client-loader";
@@ -290,6 +290,13 @@ export async function selectBranchInPicker(page: Page, name: string): Promise<vo
   await branchRow.click();
 }
 
+export async function searchAndSelectBranchInPicker(page: Page, name: string): Promise<void> {
+  const searchInput = page.getByPlaceholder("Search branches and PRs");
+  await expect(searchInput).toBeVisible({ timeout: 30_000 });
+  await searchInput.fill(name);
+  await selectBranchInPicker(page, name);
+}
+
 export async function selectGitHubPrInPicker(page: Page, number: number): Promise<void> {
   const prRow = page.getByTestId(`new-workspace-ref-picker-pr-${number}`);
   await expect(prRow).toBeVisible({ timeout: 30_000 });
@@ -349,6 +356,18 @@ export async function expectComposerGithubAttachmentPill(
   await expect(pills).toHaveCount(1);
   await expect(pills.first()).toContainText(`#${input.number}`);
   await expect(pills.first()).toContainText(input.title);
+}
+
+export async function pasteGithubPrUrl(
+  page: Page,
+  context: BrowserContext,
+  url: string,
+): Promise<void> {
+  const composer = page.getByRole("textbox", { name: "Message agent..." });
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.evaluate((value) => navigator.clipboard.writeText(value), url);
+  await composer.focus();
+  await page.keyboard.press("Control+V");
 }
 
 export async function assertNewWorkspaceSidebarAndHeader(

--- a/packages/app/e2e/new-workspace.spec.ts
+++ b/packages/app/e2e/new-workspace.spec.ts
@@ -838,6 +838,7 @@ test.describe("New workspace flow", () => {
       await composer.focus();
       await page.keyboard.press("Control+V");
 
+      await expect(page.getByTestId("workspace-create-submit")).toBeDisabled();
       await expectComposerGithubAttachmentPill(page, {
         number: pr.number,
         title: pr.title,

--- a/packages/app/e2e/new-workspace.spec.ts
+++ b/packages/app/e2e/new-workspace.spec.ts
@@ -17,11 +17,14 @@ import {
   expectPickerOpen,
   expectPickerSelected,
   expectStartingRefPickerTriggerPr,
+  fillNewWorkspaceDraft,
   openGlobalNewWorkspaceComposer,
   openBranchPicker,
   openNewWorkspaceComposer,
   openProjectViaDaemon,
   openStartingRefPicker,
+  pasteGithubPrUrl,
+  searchAndSelectBranchInPicker,
   selectBranchInPicker,
   selectGitHubPrInPicker,
   selectPickerOptionByKeyboard,
@@ -34,6 +37,7 @@ import {
   cloneGithubRepoDefaultBranchOnly,
   createTempGithubRepo,
   hasGithubAuth,
+  type LocalGhPrFixture,
 } from "./helpers/github-fixtures";
 import { getServerId } from "./helpers/server-id";
 import { getE2EDaemonPort } from "./helpers/daemon-port";
@@ -192,6 +196,7 @@ test.describe("New workspace flow", () => {
   let client: Awaited<ReturnType<typeof connectNewWorkspaceDaemonClient>>;
   const localWorkspaceIds = new Set<string>();
   const createdWorktreeDirectories = new Set<string>();
+  const localGithubFixtures = new Set<LocalGhPrFixture>();
 
   test.describe.configure({ timeout: 240_000 });
 
@@ -211,6 +216,13 @@ test.describe("New workspace flow", () => {
     createdWorktreeDirectories.clear();
     localWorkspaceIds.clear();
     await client?.close().catch(() => undefined);
+  });
+
+  test.afterAll(async () => {
+    for (const fixture of localGithubFixtures) {
+      await fixture.cleanup();
+    }
+    localGithubFixtures.clear();
   });
 
   test("adds a project from the selected empty host", async ({ page }) => {
@@ -808,60 +820,98 @@ test.describe("New workspace flow", () => {
     }
   });
 
-  test("pasted GitHub PR becomes the starting ref and creates its worktree", async ({
+  test("pasted GitHub PR replaces a selected branch and creates its worktree", async ({
     page,
     context,
   }) => {
     const fixture = await createLocalGithubPrFixture();
+    localGithubFixtures.add(fixture);
     const { pr, mainCheckout } = fixture;
 
-    try {
-      const openedProject = await openProjectViaDaemon(client, mainCheckout.path);
-      localWorkspaceIds.add(openedProject.workspaceId);
+    const openedProject = await openProjectViaDaemon(client, mainCheckout.path);
+    localWorkspaceIds.add(openedProject.workspaceId);
 
-      await gotoAppShell(page);
-      await waitForSidebarHydration(page);
-      await openNewWorkspaceComposer(page, {
-        projectKey: openedProject.projectKey,
-        projectDisplayName: openedProject.projectDisplayName,
-      });
-      await selectWorkspaceIsolation(page, "worktree");
+    await gotoAppShell(page);
+    await waitForSidebarHydration(page);
+    await openNewWorkspaceComposer(page, {
+      projectKey: openedProject.projectKey,
+      projectDisplayName: openedProject.projectDisplayName,
+    });
+    await selectWorkspaceIsolation(page, "worktree");
+    await openStartingRefPicker(page);
+    await selectBranchInPicker(page, "main");
 
-      const composer = page.getByRole("textbox", { name: "Message agent..." });
-      await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-      await page.evaluate((url) => navigator.clipboard.writeText(url), pr.url);
-      await composer.focus();
-      await page.keyboard.press("Control+V");
+    await pasteGithubPrUrl(page, context, pr.url);
 
-      await expect(page.getByTestId("workspace-create-submit")).toBeDisabled();
-      await expectComposerGithubAttachmentPill(page, {
-        number: pr.number,
-        title: pr.title,
-      });
-      await expectStartingRefPickerTriggerPr(page, {
-        number: pr.number,
-        title: pr.title,
-        headRef: pr.branch,
-      });
+    await expect(page.getByTestId("workspace-create-submit")).toBeDisabled();
+    await expectComposerGithubAttachmentPill(page, {
+      number: pr.number,
+      title: pr.title,
+    });
+    await expectStartingRefPickerTriggerPr(page, {
+      number: pr.number,
+      title: pr.title,
+      headRef: pr.branch,
+    });
 
-      await submitNewWorkspaceWithoutPrompt(page);
+    await submitNewWorkspaceWithoutPrompt(page);
 
-      const worktree = await assertNewWorkspaceSidebarAndHeader(page, {
-        serverId: getServerId(),
-        client,
-        previousWorkspaceId: openedProject.workspaceId,
-        projectDisplayName: openedProject.projectDisplayName,
-      });
-      createdWorktreeDirectories.add(worktree.workspaceDirectory);
+    const worktree = await assertNewWorkspaceSidebarAndHeader(page, {
+      serverId: getServerId(),
+      client,
+      previousWorkspaceId: openedProject.workspaceId,
+      projectDisplayName: openedProject.projectDisplayName,
+    });
+    createdWorktreeDirectories.add(worktree.workspaceDirectory);
 
-      const branchInfo = await readWorktreeBranchInfo({
-        worktreePath: worktree.workspaceDirectory,
-      });
-      expect(branchInfo.currentBranch).toBe(pr.branch);
-      expect(existsSync(path.join(worktree.workspaceDirectory, "pr-1.txt"))).toBe(true);
-    } finally {
-      await fixture.cleanup();
-    }
+    const branchInfo = await readWorktreeBranchInfo({
+      worktreePath: worktree.workspaceDirectory,
+    });
+    expect(branchInfo.currentBranch).toBe(pr.branch);
+    expect(existsSync(path.join(worktree.workspaceDirectory, "pr-1.txt"))).toBe(true);
+  });
+
+  test("branches remain searchable after a pasted PR and determine the created worktree", async ({
+    page,
+    context,
+  }) => {
+    const fixture = await createLocalGithubPrFixture();
+    localGithubFixtures.add(fixture);
+    const { pr, mainCheckout } = fixture;
+
+    const openedProject = await openProjectViaDaemon(client, mainCheckout.path);
+    localWorkspaceIds.add(openedProject.workspaceId);
+
+    await gotoAppShell(page);
+    await waitForSidebarHydration(page);
+    await openNewWorkspaceComposer(page, {
+      projectKey: openedProject.projectKey,
+      projectDisplayName: openedProject.projectDisplayName,
+    });
+    await selectWorkspaceIsolation(page, "worktree");
+    await pasteGithubPrUrl(page, context, pr.url);
+    await expectStartingRefPickerTriggerPr(page, {
+      number: pr.number,
+      title: pr.title,
+      headRef: pr.branch,
+    });
+
+    await openStartingRefPicker(page);
+    await searchAndSelectBranchInPicker(page, "main");
+    await expectPickerSelected(page, "main");
+    await fillNewWorkspaceDraft(page, `${pr.url}\nKeep this checkout on main`);
+    await expectPickerSelected(page, "main");
+    await submitNewWorkspaceWithoutPrompt(page);
+
+    const worktree = await assertNewWorkspaceSidebarAndHeader(page, {
+      serverId: getServerId(),
+      client,
+      previousWorkspaceId: openedProject.workspaceId,
+      projectDisplayName: openedProject.projectDisplayName,
+    });
+    createdWorktreeDirectories.add(worktree.workspaceDirectory);
+
+    expect(existsSync(path.join(worktree.workspaceDirectory, "pr-1.txt"))).toBe(false);
   });
 
   test("selected GitHub PR creates the worktree from the PR head even when the head branch is not fetched", async ({

--- a/packages/app/e2e/new-workspace.spec.ts
+++ b/packages/app/e2e/new-workspace.spec.ts
@@ -30,6 +30,7 @@ import {
 } from "./helpers/new-workspace";
 import { createTempGitRepo, readWorktreeBranchInfo } from "./helpers/workspace";
 import {
+  createLocalGithubPrFixture,
   cloneGithubRepoDefaultBranchOnly,
   createTempGithubRepo,
   hasGithubAuth,
@@ -811,14 +812,8 @@ test.describe("New workspace flow", () => {
     page,
     context,
   }) => {
-    test.skip(!hasGithubAuth(), "Requires GitHub authentication (gh auth login)");
-
-    const ghRepo = await createTempGithubRepo({
-      category: "new-workspace-pasted-pr-ref",
-      prs: [{ title: "Use pasted PR as start ref", state: "open" }],
-    });
-    const pr = ghRepo.prs[0]!;
-    const mainCheckout = await cloneGithubRepoDefaultBranchOnly(ghRepo);
+    const fixture = await createLocalGithubPrFixture();
+    const { pr, mainCheckout } = fixture;
 
     try {
       const openedProject = await openProjectViaDaemon(client, mainCheckout.path);
@@ -865,8 +860,7 @@ test.describe("New workspace flow", () => {
       expect(branchInfo.currentBranch).toBe(pr.branch);
       expect(existsSync(path.join(worktree.workspaceDirectory, "pr-1.txt"))).toBe(true);
     } finally {
-      await mainCheckout.cleanup();
-      await ghRepo.cleanup();
+      await fixture.cleanup();
     }
   });
 

--- a/packages/app/e2e/new-workspace.spec.ts
+++ b/packages/app/e2e/new-workspace.spec.ts
@@ -807,6 +807,68 @@ test.describe("New workspace flow", () => {
     }
   });
 
+  test("pasted GitHub PR becomes the starting ref and creates its worktree", async ({
+    page,
+    context,
+  }) => {
+    test.skip(!hasGithubAuth(), "Requires GitHub authentication (gh auth login)");
+
+    const ghRepo = await createTempGithubRepo({
+      category: "new-workspace-pasted-pr-ref",
+      prs: [{ title: "Use pasted PR as start ref", state: "open" }],
+    });
+    const pr = ghRepo.prs[0]!;
+    const mainCheckout = await cloneGithubRepoDefaultBranchOnly(ghRepo);
+
+    try {
+      const openedProject = await openProjectViaDaemon(client, mainCheckout.path);
+      localWorkspaceIds.add(openedProject.workspaceId);
+
+      await gotoAppShell(page);
+      await waitForSidebarHydration(page);
+      await openNewWorkspaceComposer(page, {
+        projectKey: openedProject.projectKey,
+        projectDisplayName: openedProject.projectDisplayName,
+      });
+      await selectWorkspaceIsolation(page, "worktree");
+
+      const composer = page.getByRole("textbox", { name: "Message agent..." });
+      await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+      await page.evaluate((url) => navigator.clipboard.writeText(url), pr.url);
+      await composer.focus();
+      await page.keyboard.press("Control+V");
+
+      await expectComposerGithubAttachmentPill(page, {
+        number: pr.number,
+        title: pr.title,
+      });
+      await expectStartingRefPickerTriggerPr(page, {
+        number: pr.number,
+        title: pr.title,
+        headRef: pr.branch,
+      });
+
+      await submitNewWorkspaceWithoutPrompt(page);
+
+      const worktree = await assertNewWorkspaceSidebarAndHeader(page, {
+        serverId: getServerId(),
+        client,
+        previousWorkspaceId: openedProject.workspaceId,
+        projectDisplayName: openedProject.projectDisplayName,
+      });
+      createdWorktreeDirectories.add(worktree.workspaceDirectory);
+
+      const branchInfo = await readWorktreeBranchInfo({
+        worktreePath: worktree.workspaceDirectory,
+      });
+      expect(branchInfo.currentBranch).toBe(pr.branch);
+      expect(existsSync(path.join(worktree.workspaceDirectory, "pr-1.txt"))).toBe(true);
+    } finally {
+      await mainCheckout.cleanup();
+      await ghRepo.cleanup();
+    }
+  });
+
   test("selected GitHub PR creates the worktree from the PR head even when the head branch is not fetched", async ({
     page,
   }) => {

--- a/packages/app/src/composer/github/auto-attach.test.tsx
+++ b/packages/app/src/composer/github/auto-attach.test.tsx
@@ -72,6 +72,14 @@ function createSearchClient(items: ForgeSearchItem[]): ForgeSearchClient & { cal
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -209,6 +217,44 @@ describe("useComposerGithubAutoAttach", () => {
       { cwd, query: "101", limit: 20 },
       { cwd, query: "202", limit: 20 },
     ]);
+    vi.useRealTimers();
+  });
+
+  it("stays resolving while overlapping lookups share a ref", async () => {
+    vi.useFakeTimers();
+    const firstLookup = deferred<ForgeSearchPayload>();
+    const secondLookup = deferred<ForgeSearchPayload>();
+    const client: ForgeSearchClient = {
+      searchForge: vi
+        .fn()
+        .mockReturnValueOnce(firstLookup.promise)
+        .mockReturnValueOnce(secondLookup.promise),
+    };
+    const { result } = renderHook(() => useHarness(client), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.setText(
+        "Refs https://github.com/acme/paseo/pull/101 and https://github.com/acme/paseo/pull/202",
+      );
+    });
+    await flushDebounce();
+
+    act(() => {
+      result.current.setText("Still https://github.com/acme/paseo/pull/202");
+    });
+    await flushDebounce();
+
+    await act(async () => {
+      firstLookup.resolve(githubPayload([], "search-101"));
+      await Promise.resolve();
+    });
+    expect(result.current.isResolving).toBe(true);
+
+    await act(async () => {
+      secondLookup.resolve(githubPayload([], "search-202"));
+      await Promise.resolve();
+    });
+    expect(result.current.isResolving).toBe(false);
     vi.useRealTimers();
   });
 });

--- a/packages/app/src/composer/github/auto-attach.test.tsx
+++ b/packages/app/src/composer/github/auto-attach.test.tsx
@@ -97,6 +97,7 @@ function createWrapper() {
 
 function useHarness(client: ForgeSearchClient, input: HarnessInput = {}) {
   const [text, setText] = useState(input.initialText ?? "");
+  const [searchClient, setSearchClient] = useState(client);
   const [workingDirectory, setWorkingDirectory] = useState(input.initialCwd ?? cwd);
   const [attachments, setAttachments] = useState<UserComposerAttachment[]>(
     input.initialAttachments ?? [],
@@ -105,7 +106,7 @@ function useHarness(client: ForgeSearchClient, input: HarnessInput = {}) {
     text,
     remoteUrl: input.remote ?? remoteUrl,
     attachments,
-    client,
+    client: searchClient,
     isConnected: true,
     serverId: "server-1",
     cwd: workingDirectory,
@@ -116,6 +117,7 @@ function useHarness(client: ForgeSearchClient, input: HarnessInput = {}) {
   return {
     text,
     setText,
+    setSearchClient,
     setWorkingDirectory,
     attachments,
     setAttachments,
@@ -291,6 +293,32 @@ describe("useComposerGithubAutoAttach", () => {
 
     expect(result.current.attachments).toEqual([]);
     expect(client.searchForge).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("accepts a lookup after the transport client is replaced for the same target", async () => {
+    vi.useFakeTimers();
+    const lookup = deferred<ForgeSearchPayload>();
+    const firstClient: ForgeSearchClient = {
+      searchForge: vi.fn().mockReturnValue(lookup.promise),
+    };
+    const replacementClient = createSearchClient([pr101]);
+    const { result } = renderHook(() => useHarness(firstClient), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.setText("Review https://github.com/acme/paseo/pull/101");
+    });
+    await flushDebounce();
+    act(() => {
+      result.current.setSearchClient(replacementClient);
+    });
+    await act(async () => {
+      lookup.resolve(githubPayload([pr101], "search-101"));
+      await Promise.resolve();
+    });
+
+    expect(result.current.attachments).toEqual([{ kind: "forge_change_request", item: pr101 }]);
+    expect(replacementClient.calls).toEqual([]);
     vi.useRealTimers();
   });
 });

--- a/packages/app/src/composer/github/auto-attach.test.tsx
+++ b/packages/app/src/composer/github/auto-attach.test.tsx
@@ -106,6 +106,7 @@ function useHarness(client: ForgeSearchClient, input: HarnessInput = {}) {
     setText,
     attachments,
     setAttachments,
+    isResolving: autoAttach.isResolving,
     markGithubAttachmentRemoved: autoAttach.markGithubAttachmentRemoved,
   };
 }
@@ -126,9 +127,11 @@ describe("useComposerGithubAutoAttach", () => {
     act(() => {
       result.current.setText("Please review https://github.com/acme/paseo/pull/101");
     });
+    expect(result.current.isResolving).toBe(true);
     await flushDebounce();
 
     expect(result.current.attachments).toEqual([{ kind: "forge_change_request", item: pr101 }]);
+    expect(result.current.isResolving).toBe(false);
     expect(client.calls).toEqual([{ cwd, query: "101", limit: 20 }]);
     vi.useRealTimers();
   });

--- a/packages/app/src/composer/github/auto-attach.test.tsx
+++ b/packages/app/src/composer/github/auto-attach.test.tsx
@@ -269,6 +269,26 @@ describe("useComposerGithubAutoAttach", () => {
     vi.useRealTimers();
   });
 
+  it("stops resolving when an in-flight PR URL is removed", async () => {
+    vi.useFakeTimers();
+    const lookup = deferred<ForgeSearchPayload>();
+    const client: ForgeSearchClient = {
+      searchForge: vi.fn().mockReturnValue(lookup.promise),
+    };
+    const { result } = renderHook(() => useHarness(client), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.setText("Review https://github.com/acme/paseo/pull/101");
+    });
+    await flushDebounce();
+    act(() => {
+      result.current.setText("");
+    });
+
+    expect(result.current.isResolving).toBe(false);
+    vi.useRealTimers();
+  });
+
   it("ignores a lookup that finishes after the target changes", async () => {
     vi.useFakeTimers();
     const lookup = deferred<ForgeSearchPayload>();

--- a/packages/app/src/composer/github/auto-attach.test.tsx
+++ b/packages/app/src/composer/github/auto-attach.test.tsx
@@ -48,6 +48,7 @@ interface SearchCall {
 
 interface HarnessInput {
   initialAttachments?: UserComposerAttachment[];
+  initialCwd?: string;
   initialText?: string;
   remote?: string | null;
 }
@@ -95,6 +96,7 @@ function createWrapper() {
 
 function useHarness(client: ForgeSearchClient, input: HarnessInput = {}) {
   const [text, setText] = useState(input.initialText ?? "");
+  const [workingDirectory, setWorkingDirectory] = useState(input.initialCwd ?? cwd);
   const [attachments, setAttachments] = useState<UserComposerAttachment[]>(
     input.initialAttachments ?? [],
   );
@@ -105,13 +107,14 @@ function useHarness(client: ForgeSearchClient, input: HarnessInput = {}) {
     client,
     isConnected: true,
     serverId: "server-1",
-    cwd,
+    cwd: workingDirectory,
     setAttachments,
   });
 
   return {
     text,
     setText,
+    setWorkingDirectory,
     attachments,
     setAttachments,
     isResolving: autoAttach.isResolving,
@@ -255,6 +258,31 @@ describe("useComposerGithubAutoAttach", () => {
       await Promise.resolve();
     });
     expect(result.current.isResolving).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("ignores a lookup that finishes after the target changes", async () => {
+    vi.useFakeTimers();
+    const lookup = deferred<ForgeSearchPayload>();
+    const client: ForgeSearchClient = {
+      searchForge: vi.fn().mockReturnValue(lookup.promise),
+    };
+    const { result } = renderHook(() => useHarness(client), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.setText("Review https://github.com/acme/paseo/pull/101");
+    });
+    await flushDebounce();
+
+    act(() => {
+      result.current.setWorkingDirectory("/other-repo");
+    });
+    await act(async () => {
+      lookup.resolve(githubPayload([pr101], "search-101"));
+      await Promise.resolve();
+    });
+
+    expect(result.current.attachments).toEqual([]);
     vi.useRealTimers();
   });
 });

--- a/packages/app/src/composer/github/auto-attach.test.tsx
+++ b/packages/app/src/composer/github/auto-attach.test.tsx
@@ -50,6 +50,7 @@ interface HarnessInput {
   initialAttachments?: UserComposerAttachment[];
   initialCwd?: string;
   initialText?: string;
+  onPullRequestDetected?: () => void;
   remote?: string | null;
 }
 
@@ -109,6 +110,7 @@ function useHarness(client: ForgeSearchClient, input: HarnessInput = {}) {
     serverId: "server-1",
     cwd: workingDirectory,
     setAttachments,
+    onPullRequestDetected: input.onPullRequestDetected,
   });
 
   return {
@@ -133,12 +135,16 @@ describe("useComposerGithubAutoAttach", () => {
   it("adds a matching pasted GitHub PR URL as a composer attachment", async () => {
     vi.useFakeTimers();
     const client = createSearchClient([pr101]);
-    const { result } = renderHook(() => useHarness(client), { wrapper: createWrapper() });
+    const onPullRequestDetected = vi.fn();
+    const { result } = renderHook(() => useHarness(client, { onPullRequestDetected }), {
+      wrapper: createWrapper(),
+    });
 
     act(() => {
       result.current.setText("Please review https://github.com/acme/paseo/pull/101");
     });
     expect(result.current.isResolving).toBe(true);
+    expect(onPullRequestDetected).toHaveBeenCalledTimes(1);
     await flushDebounce();
 
     expect(result.current.attachments).toEqual([{ kind: "forge_change_request", item: pr101 }]);
@@ -277,12 +283,14 @@ describe("useComposerGithubAutoAttach", () => {
     act(() => {
       result.current.setWorkingDirectory("/other-repo");
     });
+    await flushDebounce();
     await act(async () => {
       lookup.resolve(githubPayload([pr101], "search-101"));
       await Promise.resolve();
     });
 
     expect(result.current.attachments).toEqual([]);
+    expect(client.searchForge).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
   });
 });

--- a/packages/app/src/composer/github/auto-attach.ts
+++ b/packages/app/src/composer/github/auto-attach.ts
@@ -27,6 +27,7 @@ interface ComposerGithubAutoAttachInput {
   cwd: string;
   supportsForgeSearch?: boolean;
   setAttachments: Dispatch<SetStateAction<UserComposerAttachment[]>>;
+  onPullRequestAdded?: (item: ForgeSearchItem) => void;
 }
 
 interface ComposerGithubAutoAttachResult {
@@ -191,12 +192,19 @@ async function attachRef({
     return;
   }
 
-  latestRef.current.setAttachments((current) => {
+  const latest = latestRef.current;
+  if (isAttachmentSelectedForGithubItem(latest.attachments, item)) {
+    return;
+  }
+  latest.setAttachments((current) => {
     if (removedRefKeys.has(key) || isAttachmentSelectedForGithubItem(current, item)) {
       return current;
     }
     return toggleGithubAttachment(current, item);
   });
+  if (item.kind === "change_request") {
+    latest.onPullRequestAdded?.(item);
+  }
 }
 
 function refsReadyForLookup({

--- a/packages/app/src/composer/github/auto-attach.ts
+++ b/packages/app/src/composer/github/auto-attach.ts
@@ -41,7 +41,9 @@ export function useComposerGithubAutoAttach(
   const latestRef = useRef(params);
   const removedRefKeysRef = useRef(new Set<string>());
   const pendingRefKeysRef = useRef(new Set<string>());
-  const [resolvingRefKeys, setResolvingRefKeys] = useState<ReadonlySet<string>>(() => new Set());
+  const [resolvingRefCounts, setResolvingRefCounts] = useState<ReadonlyMap<string, number>>(
+    () => new Map(),
+  );
 
   latestRef.current = params;
 
@@ -56,7 +58,7 @@ export function useComposerGithubAutoAttach(
     }
 
     const refKeys = refs.map(githubRefKey);
-    setResolvingRefKeys((current) => addKeys(current, refKeys));
+    setResolvingRefCounts((current) => addKeys(current, refKeys));
     let lookupStarted = false;
 
     const timerId = setTimeout(() => {
@@ -68,14 +70,14 @@ export function useComposerGithubAutoAttach(
         removedRefKeys: removedRefKeysRef.current,
         pendingRefKeys: pendingRefKeysRef.current,
       }).finally(() => {
-        clearResolvingKeys(setResolvingRefKeys, refKeys);
+        clearResolvingKeys(setResolvingRefCounts, refKeys);
       });
     }, AUTO_ATTACH_DEBOUNCE_MS);
 
     return () => {
       clearTimeout(timerId);
       if (!lookupStarted) {
-        clearResolvingKeys(setResolvingRefKeys, refKeys);
+        clearResolvingKeys(setResolvingRefCounts, refKeys);
       }
     };
   }, [
@@ -99,32 +101,40 @@ export function useComposerGithubAutoAttach(
 
   return useMemo(
     () => ({
-      isResolving: resolvingRefKeys.size > 0,
+      isResolving: resolvingRefCounts.size > 0,
       markGithubAttachmentRemoved,
     }),
-    [markGithubAttachmentRemoved, resolvingRefKeys.size],
+    [markGithubAttachmentRemoved, resolvingRefCounts.size],
   );
 }
 
-function addKeys(current: ReadonlySet<string>, keys: readonly string[]): ReadonlySet<string> {
-  if (keys.every((key) => current.has(key))) return current;
-  const next = new Set(current);
-  for (const key of keys) next.add(key);
-  return next;
+function addKeys(
+  current: ReadonlyMap<string, number>,
+  keys: readonly string[],
+): ReadonlyMap<string, number> {
+  const nextCounts = new Map(current);
+  for (const key of keys) nextCounts.set(key, (nextCounts.get(key) ?? 0) + 1);
+  return nextCounts;
 }
 
-function removeKeys(current: ReadonlySet<string>, keys: readonly string[]): ReadonlySet<string> {
-  if (keys.every((key) => !current.has(key))) return current;
-  const next = new Set(current);
-  for (const key of keys) next.delete(key);
+function removeKeys(
+  current: ReadonlyMap<string, number>,
+  keys: readonly string[],
+): ReadonlyMap<string, number> {
+  const next = new Map(current);
+  for (const key of keys) {
+    const count = next.get(key) ?? 0;
+    if (count <= 1) next.delete(key);
+    else next.set(key, count - 1);
+  }
   return next;
 }
 
 function clearResolvingKeys(
-  setResolvingRefKeys: Dispatch<SetStateAction<ReadonlySet<string>>>,
+  setResolvingRefCounts: Dispatch<SetStateAction<ReadonlyMap<string, number>>>,
   keys: readonly string[],
 ): void {
-  setResolvingRefKeys((current) => removeKeys(current, keys));
+  setResolvingRefCounts((current) => removeKeys(current, keys));
 }
 
 async function attachRefs({

--- a/packages/app/src/composer/github/auto-attach.ts
+++ b/packages/app/src/composer/github/auto-attach.ts
@@ -72,26 +72,26 @@ export function useComposerGithubAutoAttach(
 
     const refKeys = refs.map(githubRefKey);
     setResolvingRefCounts((current) => addKeys(current, refKeys));
-    let lookupStarted = false;
+    let resolvingReleased = false;
+    const releaseResolving = () => {
+      if (resolvingReleased) return;
+      resolvingReleased = true;
+      clearResolvingKeys(setResolvingRefCounts, refKeys);
+    };
 
     const timerId = setTimeout(() => {
-      lookupStarted = true;
       void attachRefs({
         refs,
         queryClient,
         latestRef,
         removedRefKeys: removedRefKeysRef.current,
         pendingRefKeys: pendingRefKeysRef.current,
-      }).finally(() => {
-        clearResolvingKeys(setResolvingRefCounts, refKeys);
-      });
+      }).finally(releaseResolving);
     }, AUTO_ATTACH_DEBOUNCE_MS);
 
     return () => {
       clearTimeout(timerId);
-      if (!lookupStarted) {
-        clearResolvingKeys(setResolvingRefCounts, refKeys);
-      }
+      releaseResolving();
     };
   }, [
     params.text,

--- a/packages/app/src/composer/github/auto-attach.ts
+++ b/packages/app/src/composer/github/auto-attach.ts
@@ -188,22 +188,27 @@ async function attachRef({
     return;
   }
   const item = search.items.find((candidate) => githubItemMatchesRef(candidate, ref));
-  if (!item || removedRefKeys.has(key) || !isRefStillPresent(ref, latestRef.current)) {
+  const current = latestRef.current;
+  if (
+    !item ||
+    removedRefKeys.has(key) ||
+    !isSameLookupTarget(snapshot, current) ||
+    !isRefStillPresent(ref, current)
+  ) {
     return;
   }
 
-  const latest = latestRef.current;
-  if (isAttachmentSelectedForGithubItem(latest.attachments, item)) {
+  if (isAttachmentSelectedForGithubItem(current.attachments, item)) {
     return;
   }
-  latest.setAttachments((current) => {
-    if (removedRefKeys.has(key) || isAttachmentSelectedForGithubItem(current, item)) {
-      return current;
+  current.setAttachments((attachments) => {
+    if (removedRefKeys.has(key) || isAttachmentSelectedForGithubItem(attachments, item)) {
+      return attachments;
     }
-    return toggleGithubAttachment(current, item);
+    return toggleGithubAttachment(attachments, item);
   });
   if (item.kind === "change_request") {
-    latest.onPullRequestAdded?.(item);
+    current.onPullRequestAdded?.(item);
   }
 }
 
@@ -262,6 +267,18 @@ async function fetchGithubRefSearch({
 function isRefStillPresent(ref: GithubRef, params: ComposerGithubAutoAttachInput): boolean {
   return extractGithubRefs(params.text, params.remoteUrl).some(
     (candidate) => githubRefKey(candidate) === githubRefKey(ref),
+  );
+}
+
+function isSameLookupTarget(
+  initial: ComposerGithubAutoAttachInput,
+  current: ComposerGithubAutoAttachInput,
+): boolean {
+  return (
+    initial.client === current.client &&
+    initial.serverId === current.serverId &&
+    initial.cwd === current.cwd &&
+    initial.remoteUrl === current.remoteUrl
   );
 }
 

--- a/packages/app/src/composer/github/auto-attach.ts
+++ b/packages/app/src/composer/github/auto-attach.ts
@@ -27,6 +27,7 @@ interface ComposerGithubAutoAttachInput {
   cwd: string;
   supportsForgeSearch?: boolean;
   setAttachments: Dispatch<SetStateAction<UserComposerAttachment[]>>;
+  onPullRequestDetected?: () => void;
   onPullRequestAdded?: (item: ForgeSearchItem) => void;
 }
 
@@ -42,6 +43,8 @@ export function useComposerGithubAutoAttach(
   const latestRef = useRef(params);
   const removedRefKeysRef = useRef(new Set<string>());
   const pendingRefKeysRef = useRef(new Set<string>());
+  const presentPullRequestKeysRef = useRef(new Set<string>());
+  const previousTargetRef = useRef({ serverId: params.serverId, cwd: params.cwd });
   const [resolvingRefCounts, setResolvingRefCounts] = useState<ReadonlyMap<string, number>>(
     () => new Map(),
   );
@@ -49,6 +52,15 @@ export function useComposerGithubAutoAttach(
   latestRef.current = params;
 
   useEffect(() => {
+    suppressRefsCarriedAcrossTargets({
+      params: latestRef.current,
+      previousTargetRef,
+      removedRefKeys: removedRefKeysRef.current,
+    });
+    notifyNewPullRequestRefs({
+      params: latestRef.current,
+      presentPullRequestKeysRef,
+    });
     const refs = refsReadyForLookup({
       params: latestRef.current,
       removedRefKeys: removedRefKeysRef.current,
@@ -107,6 +119,48 @@ export function useComposerGithubAutoAttach(
     }),
     [markGithubAttachmentRemoved, resolvingRefCounts.size],
   );
+}
+
+function suppressRefsCarriedAcrossTargets({
+  params,
+  previousTargetRef,
+  removedRefKeys,
+}: {
+  params: ComposerGithubAutoAttachInput;
+  previousTargetRef: RefObject<{ serverId: string; cwd: string }>;
+  removedRefKeys: Set<string>;
+}): void {
+  const previous = previousTargetRef.current;
+  const targetChanged =
+    previous.cwd.trim().length > 0 &&
+    params.cwd.trim().length > 0 &&
+    (previous.serverId !== params.serverId || previous.cwd !== params.cwd);
+  previousTargetRef.current = { serverId: params.serverId, cwd: params.cwd };
+  if (!targetChanged) return;
+
+  for (const ref of extractGithubRefs(params.text, params.remoteUrl)) {
+    removedRefKeys.add(githubRefKey(ref));
+  }
+}
+
+function notifyNewPullRequestRefs({
+  params,
+  presentPullRequestKeysRef,
+}: {
+  params: ComposerGithubAutoAttachInput;
+  presentPullRequestKeysRef: RefObject<Set<string>>;
+}): void {
+  const currentKeys = new Set(
+    extractGithubRefs(params.text, params.remoteUrl)
+      .filter((ref) => ref.kind === "pull")
+      .map(githubRefKey),
+  );
+  for (const key of currentKeys) {
+    if (!presentPullRequestKeysRef.current.has(key)) {
+      params.onPullRequestDetected?.();
+    }
+  }
+  presentPullRequestKeysRef.current = currentKeys;
 }
 
 function addKeys(

--- a/packages/app/src/composer/github/auto-attach.ts
+++ b/packages/app/src/composer/github/auto-attach.ts
@@ -4,6 +4,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
   type Dispatch,
   type RefObject,
   type SetStateAction,
@@ -29,6 +30,7 @@ interface ComposerGithubAutoAttachInput {
 }
 
 interface ComposerGithubAutoAttachResult {
+  isResolving: boolean;
   markGithubAttachmentRemoved: (attachment: ComposerAttachment | undefined) => void;
 }
 
@@ -39,6 +41,7 @@ export function useComposerGithubAutoAttach(
   const latestRef = useRef(params);
   const removedRefKeysRef = useRef(new Set<string>());
   const pendingRefKeysRef = useRef(new Set<string>());
+  const [resolvingRefKeys, setResolvingRefKeys] = useState<ReadonlySet<string>>(() => new Set());
 
   latestRef.current = params;
 
@@ -52,18 +55,28 @@ export function useComposerGithubAutoAttach(
       return;
     }
 
+    const refKeys = refs.map(githubRefKey);
+    setResolvingRefKeys((current) => addKeys(current, refKeys));
+    let lookupStarted = false;
+
     const timerId = setTimeout(() => {
+      lookupStarted = true;
       void attachRefs({
         refs,
         queryClient,
         latestRef,
         removedRefKeys: removedRefKeysRef.current,
         pendingRefKeys: pendingRefKeysRef.current,
+      }).finally(() => {
+        clearResolvingKeys(setResolvingRefKeys, refKeys);
       });
     }, AUTO_ATTACH_DEBOUNCE_MS);
 
     return () => {
       clearTimeout(timerId);
+      if (!lookupStarted) {
+        clearResolvingKeys(setResolvingRefKeys, refKeys);
+      }
     };
   }, [
     params.text,
@@ -86,10 +99,32 @@ export function useComposerGithubAutoAttach(
 
   return useMemo(
     () => ({
+      isResolving: resolvingRefKeys.size > 0,
       markGithubAttachmentRemoved,
     }),
-    [markGithubAttachmentRemoved],
+    [markGithubAttachmentRemoved, resolvingRefKeys.size],
   );
+}
+
+function addKeys(current: ReadonlySet<string>, keys: readonly string[]): ReadonlySet<string> {
+  if (keys.every((key) => current.has(key))) return current;
+  const next = new Set(current);
+  for (const key of keys) next.add(key);
+  return next;
+}
+
+function removeKeys(current: ReadonlySet<string>, keys: readonly string[]): ReadonlySet<string> {
+  if (keys.every((key) => !current.has(key))) return current;
+  const next = new Set(current);
+  for (const key of keys) next.delete(key);
+  return next;
+}
+
+function clearResolvingKeys(
+  setResolvingRefKeys: Dispatch<SetStateAction<ReadonlySet<string>>>,
+  keys: readonly string[],
+): void {
+  setResolvingRefKeys((current) => removeKeys(current, keys));
 }
 
 async function attachRefs({

--- a/packages/app/src/composer/github/auto-attach.ts
+++ b/packages/app/src/composer/github/auto-attach.ts
@@ -329,7 +329,6 @@ function isSameLookupTarget(
   current: ComposerGithubAutoAttachInput,
 ): boolean {
   return (
-    initial.client === current.client &&
     initial.serverId === current.serverId &&
     initial.cwd === current.cwd &&
     initial.remoteUrl === current.remoteUrl

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -768,6 +768,8 @@ interface ComposerProps {
   submitIcon?: "arrow" | "return";
   /** Externally controlled loading state. When true, disables the submit button. */
   isSubmitLoading?: boolean;
+  /** When true, waits for pasted GitHub links to resolve before enabling submit. */
+  waitForGithubAutoAttachOnSubmit?: boolean;
   submitBehavior?: "clear" | "preserve-and-lock";
   /** When true, blurs the input immediately when submitting. */
   blurOnSubmit?: boolean;
@@ -981,6 +983,7 @@ export function Composer({
   submitButtonTestID,
   submitIcon = "arrow",
   isSubmitLoading = false,
+  waitForGithubAutoAttachOnSubmit = false,
   submitBehavior = "clear",
   blurOnSubmit = false,
   value,
@@ -1949,7 +1952,11 @@ export function Composer({
 
   const messageInputContainerRef = useRef<View>(null);
 
-  const isSubmitBusy = isProcessing || isSubmitLoading || isUploadingFile;
+  const isSubmitBusy =
+    isProcessing ||
+    isSubmitLoading ||
+    isUploadingFile ||
+    (waitForGithubAutoAttachOnSubmit && githubAutoAttach.isResolving);
 
   // Disable drops while submitting/uploading: the submit path clears and restores attachments,
   // so a drop in that window would be lost or land on a locked draft. `disabled` hides the

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -779,6 +779,7 @@ interface ComposerProps {
   attachmentScopeKeys?: readonly string[];
   onOpenWorkspaceAttachment?: (attachment: WorkspaceComposerAttachment) => void;
   onChangeAttachments: (updater: AttachmentListUpdater) => void;
+  onGithubPrAutoAttach?: (item: ForgeSearchItem) => void;
   cwd: string;
   clearDraft: (lifecycle: "sent" | "abandoned") => void;
   /** When true, auto-focuses the text input on web. */
@@ -992,6 +993,7 @@ export function Composer({
   attachmentScopeKeys = EMPTY_ATTACHMENT_SCOPE_KEYS,
   onOpenWorkspaceAttachment,
   onChangeAttachments,
+  onGithubPrAutoAttach,
   cwd,
   clearDraft,
   autoFocus = false,
@@ -1073,6 +1075,7 @@ export function Composer({
     cwd,
     supportsForgeSearch,
     setAttachments: setSelectedAttachments,
+    onPullRequestAdded: onGithubPrAutoAttach,
   });
   const [cursorIndex, setCursorIndex] = useState(0);
   const [isProcessing, setIsProcessing] = useState(false);

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -779,6 +779,7 @@ interface ComposerProps {
   attachmentScopeKeys?: readonly string[];
   onOpenWorkspaceAttachment?: (attachment: WorkspaceComposerAttachment) => void;
   onChangeAttachments: (updater: AttachmentListUpdater) => void;
+  onGithubPrDetected?: () => void;
   onGithubPrAutoAttach?: (item: ForgeSearchItem) => void;
   cwd: string;
   clearDraft: (lifecycle: "sent" | "abandoned") => void;
@@ -993,6 +994,7 @@ export function Composer({
   attachmentScopeKeys = EMPTY_ATTACHMENT_SCOPE_KEYS,
   onOpenWorkspaceAttachment,
   onChangeAttachments,
+  onGithubPrDetected,
   onGithubPrAutoAttach,
   cwd,
   clearDraft,
@@ -1075,6 +1077,7 @@ export function Composer({
     cwd,
     supportsForgeSearch,
     setAttachments: setSelectedAttachments,
+    onPullRequestDetected: onGithubPrDetected,
     onPullRequestAdded: onGithubPrAutoAttach,
   });
   const [cursorIndex, setCursorIndex] = useState(0);

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -970,9 +970,6 @@ export const ar: TranslationResources = {
     refPicker: {
       startingRef: "بدء المرجع",
       chooseStart: "اختر من أين تبدأ",
-      checkoutHint: "تحقق من {{noun}} {{numberPrefix}}{{number}}؟",
-      checkoutPr: "تحقق من {{noun}} {{numberPrefix}}{{number}}",
-      dismissCheckoutHint: "تجاهل تلميح الخروج {{noun}} {{numberPrefix}}{{number}}",
       intoBase: "إلى {{baseRef}}",
       searching: "جارٍ البحث...",
       noMatchingRefs: "لا توجد مراجع مطابقة.",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -980,9 +980,6 @@ export const en = {
     refPicker: {
       startingRef: "Starting ref",
       chooseStart: "Choose where to start from",
-      checkoutHint: "Check out {{noun}} {{numberPrefix}}{{number}}?",
-      checkoutPr: "Check out {{noun}} {{numberPrefix}}{{number}}",
-      dismissCheckoutHint: "Dismiss {{noun}} {{numberPrefix}}{{number}} checkout hint",
       intoBase: "into {{baseRef}}",
       searching: "Searching...",
       noMatchingRefs: "No matching refs.",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1001,9 +1001,6 @@ export const es: TranslationResources = {
     refPicker: {
       startingRef: "Árbitro inicial",
       chooseStart: "Elige por dónde empezar",
-      checkoutHint: "¿Mira {{noun}} {{numberPrefix}}{{number}}?",
-      checkoutPr: "Echa un vistazo a {{noun}} {{numberPrefix}}{{number}}",
-      dismissCheckoutHint: "Descartar la sugerencia de pago de {{noun}} {{numberPrefix}}{{number}}",
       intoBase: "en {{baseRef}}",
       searching: "Búsqueda...",
       noMatchingRefs: "No hay árbitros coincidentes.",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1000,9 +1000,6 @@ export const fr: TranslationResources = {
     refPicker: {
       startingRef: "Réf de départ",
       chooseStart: "Choisissez par où commencer",
-      checkoutHint: "Découvrez {{noun}} {{numberPrefix}}{{number}} ?",
-      checkoutPr: "Découvrez {{noun}} {{numberPrefix}}{{number}}",
-      dismissCheckoutHint: "Ignorer l'indice de paiement {{noun}} {{numberPrefix}}{{number}}",
       intoBase: "dans {{baseRef}}",
       searching: "Recherche...",
       noMatchingRefs: "Aucune référence correspondante.",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -981,9 +981,6 @@ export const ja: TranslationResources = {
     refPicker: {
       startingRef: "開始Ref",
       chooseStart: "開始点を選択",
-      checkoutHint: "{{noun}} {{numberPrefix}}{{number}}をチェックアウトしますか？",
-      checkoutPr: "{{noun}} {{numberPrefix}}{{number}}をチェックアウト",
-      dismissCheckoutHint: "{{noun}} {{numberPrefix}}{{number}}のチェックアウトヒントを閉じる",
       intoBase: "{{baseRef}}に",
       searching: "検索中...",
       noMatchingRefs: "一致するRefがありません。",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -992,9 +992,6 @@ export const ptBR: TranslationResources = {
     refPicker: {
       startingRef: "Ref inicial",
       chooseStart: "Escolha de onde começar",
-      checkoutHint: "Fazer checkout da {{noun}} {{numberPrefix}}{{number}}?",
-      checkoutPr: "Fazer checkout da {{noun}} {{numberPrefix}}{{number}}",
-      dismissCheckoutHint: "Dispensar dica de checkout da {{noun}} {{numberPrefix}}{{number}}",
       intoBase: "em {{baseRef}}",
       searching: "Buscando...",
       noMatchingRefs: "Nenhuma ref correspondente.",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -992,10 +992,6 @@ export const ru: TranslationResources = {
     refPicker: {
       startingRef: "Начальная ссылка",
       chooseStart: "Выберите, с чего начать",
-      checkoutHint: "Проверьте {{noun}} {{numberPrefix}}{{number}}?",
-      checkoutPr: "Проверьте {{noun}} {{numberPrefix}}{{number}}",
-      dismissCheckoutHint:
-        "Отклонить подсказку по оформлению заказа {{noun}} {{numberPrefix}}{{number}}",
       intoBase: "в {{baseRef}}",
       searching: "Идет поиск...",
       noMatchingRefs: "Нет подходящих ссылок.",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -959,9 +959,6 @@ export const zhCN: TranslationResources = {
     refPicker: {
       startingRef: "起始 ref",
       chooseStart: "选择起始位置",
-      checkoutHint: "Checkout {{noun}} {{numberPrefix}}{{number}}？",
-      checkoutPr: "Checkout {{noun}} {{numberPrefix}}{{number}}",
-      dismissCheckoutHint: "忽略 {{noun}} {{numberPrefix}}{{number}} checkout 提示",
       intoBase: "进入 {{baseRef}}",
       searching: "正在搜索...",
       noMatchingRefs: "没有匹配的 refs。",

--- a/packages/app/src/screens/new-workspace-picker-state.test.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { UserComposerAttachment } from "@/attachments/types";
 import {
   clearPickerPrAttachmentForTargetChange,
-  findCheckoutHintPrAttachment,
+  pickerItemFromAttachments,
   syncPickerPrAttachment,
 } from "./new-workspace-picker-state";
 import type { ForgeSearchItem } from "@getpaseo/protocol/messages";
@@ -133,53 +133,26 @@ describe("clearPickerPrAttachmentForTargetChange", () => {
   });
 });
 
-describe("findCheckoutHintPrAttachment", () => {
-  it("returns the first attached PR that is not selected or dismissed", () => {
-    const first = prAttachment(makePrItem(101, "A"));
-    const second = prAttachment(makePrItem(202, "B"));
+describe("pickerItemFromAttachments", () => {
+  it("uses a forge change request attachment as the starting ref", () => {
+    const item = makePrItem(101, "A");
 
-    expect(
-      findCheckoutHintPrAttachment({
-        attachments: [issueAttachment(44), first, second],
-        selectedItem: null,
-        dismissedPrNumbers: new Set(),
-      }),
-    ).toBe(first);
+    expect(pickerItemFromAttachments([{ kind: "forge_change_request", item }])).toEqual({
+      kind: "github-pr",
+      item,
+    });
   });
 
-  it("skips the selected PR and offers the next attached PR", () => {
-    const selected = prAttachment(makePrItem(101, "A"));
-    const next = prAttachment(makePrItem(202, "B"));
+  it("keeps legacy GitHub PR attachments working", () => {
+    const item = makePrItem(101, "A");
 
-    expect(
-      findCheckoutHintPrAttachment({
-        attachments: [selected, next],
-        selectedItem: { kind: "github-pr", item: selected.item },
-        dismissedPrNumbers: new Set(),
-      }),
-    ).toBe(next);
+    expect(pickerItemFromAttachments([prAttachment(item)])).toEqual({
+      kind: "github-pr",
+      item,
+    });
   });
 
-  it("skips dismissed PRs and ignores issues", () => {
-    const dismissed = prAttachment(makePrItem(101, "A"));
-    const next = prAttachment(makePrItem(202, "B"));
-
-    expect(
-      findCheckoutHintPrAttachment({
-        attachments: [issueAttachment(44), dismissed, next],
-        selectedItem: null,
-        dismissedPrNumbers: new Set([101]),
-      }),
-    ).toBe(next);
-  });
-
-  it("returns null when only issues qualify", () => {
-    expect(
-      findCheckoutHintPrAttachment({
-        attachments: [issueAttachment(44)],
-        selectedItem: null,
-        dismissedPrNumbers: new Set(),
-      }),
-    ).toBeNull();
+  it("ignores issue attachments", () => {
+    expect(pickerItemFromAttachments([issueAttachment(44)])).toBeNull();
   });
 });

--- a/packages/app/src/screens/new-workspace-picker-state.test.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.test.ts
@@ -28,6 +28,12 @@ function prAttachment(
   return { kind: "github_pr", item, ...(owner ? { owner } : {}) };
 }
 
+function forgePrAttachment(
+  item: ForgeSearchItem,
+): Extract<UserComposerAttachment, { kind: "forge_change_request" }> {
+  return { kind: "forge_change_request", item };
+}
+
 function issueAttachment(number: number): UserComposerAttachment {
   return {
     kind: "github_issue",
@@ -91,6 +97,15 @@ describe("syncPickerPrAttachment", () => {
     expect(result).toEqual([prAttachment(pr)]);
   });
 
+  it("does not duplicate a generalized PR attachment", () => {
+    const pr = makePrItem(202, "Refactor picker");
+    const result = syncPickerPrAttachment({
+      attachments: [forgePrAttachment(pr)],
+      item: { kind: "github-pr", item: pr },
+    });
+    expect(result).toEqual([forgePrAttachment(pr)]);
+  });
+
   it("clears a persisted picker selection without removing user-added attachments", () => {
     const pickerPr = prAttachment(makePrItem(202, "Picker PR"), "new-workspace-picker");
     const manuallyAttachedPr = prAttachment(makePrItem(303, "Manual PR"));
@@ -119,17 +134,19 @@ describe("clearPickerPrAttachmentForTargetChange", () => {
     ).toBe(attachments);
   });
 
-  it("clears only the picker-owned PR when the target changes", () => {
+  it("clears all PR attachments when the target changes", () => {
     const pickerPr = prAttachment(makePrItem(202, "Picker PR"), "new-workspace-picker");
     const manualPr = prAttachment(makePrItem(303, "Manual PR"));
+    const forgePr = forgePrAttachment(makePrItem(404, "Forge PR"));
+    const issue = issueAttachment(44);
 
     expect(
       clearPickerPrAttachmentForTargetChange({
-        attachments: [pickerPr, manualPr],
+        attachments: [issue, pickerPr, manualPr, forgePr],
         currentTargetId: "server-a",
         nextTargetId: "server-b",
       }),
-    ).toEqual([manualPr]);
+    ).toEqual([issue]);
   });
 });
 
@@ -137,7 +154,7 @@ describe("pickerItemFromAttachments", () => {
   it("uses a forge change request attachment as the starting ref", () => {
     const item = makePrItem(101, "A");
 
-    expect(pickerItemFromAttachments([{ kind: "forge_change_request", item }])).toEqual({
+    expect(pickerItemFromAttachments([forgePrAttachment(item)])).toEqual({
       kind: "github-pr",
       item,
     });

--- a/packages/app/src/screens/new-workspace-picker-state.test.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { UserComposerAttachment } from "@/attachments/types";
 import {
   clearPickerPrAttachmentForTargetChange,
-  pickerItemFromAttachments,
+  pickerItemFromLatestPrAttachment,
   syncPickerPrAttachment,
 } from "./new-workspace-picker-state";
 import type { ForgeSearchItem } from "@getpaseo/protocol/messages";
@@ -34,19 +34,20 @@ function forgePrAttachment(
   return { kind: "forge_change_request", item };
 }
 
-function issueAttachment(number: number): UserComposerAttachment {
+function makeIssueItem(number: number): ForgeSearchItem {
   return {
-    kind: "github_issue",
-    item: {
-      kind: "issue",
-      number,
-      title: `Issue ${number}`,
-      url: `https://example.com/issues/${number}`,
-      state: "open",
-      body: null,
-      labels: [],
-    },
+    kind: "issue",
+    number,
+    title: `Issue ${number}`,
+    url: `https://example.com/issues/${number}`,
+    state: "open",
+    body: null,
+    labels: [],
   };
+}
+
+function issueAttachment(number: number): UserComposerAttachment {
+  return { kind: "github_issue", item: makeIssueItem(number) };
 }
 
 describe("syncPickerPrAttachment", () => {
@@ -150,26 +151,36 @@ describe("clearPickerPrAttachmentForTargetChange", () => {
   });
 });
 
-describe("pickerItemFromAttachments", () => {
-  it("uses a forge change request attachment as the starting ref", () => {
+describe("pickerItemFromLatestPrAttachment", () => {
+  it("restores a forge change request attachment as the starting ref", () => {
     const item = makePrItem(101, "A");
 
-    expect(pickerItemFromAttachments([forgePrAttachment(item)])).toEqual({
+    expect(pickerItemFromLatestPrAttachment([forgePrAttachment(item)])).toEqual({
       kind: "github-pr",
       item,
     });
   });
 
-  it("keeps legacy GitHub PR attachments working", () => {
+  it("restores a legacy GitHub PR attachment as the starting ref", () => {
     const item = makePrItem(101, "A");
 
-    expect(pickerItemFromAttachments([prAttachment(item)])).toEqual({
+    expect(pickerItemFromLatestPrAttachment([prAttachment(item)])).toEqual({
       kind: "github-pr",
       item,
     });
   });
 
   it("ignores issue attachments", () => {
-    expect(pickerItemFromAttachments([issueAttachment(44)])).toBeNull();
+    expect(pickerItemFromLatestPrAttachment([issueAttachment(44)])).toBeNull();
+  });
+
+  it("restores the most recently attached PR", () => {
+    const first = forgePrAttachment(makePrItem(101, "A"));
+    const second = forgePrAttachment(makePrItem(202, "B"));
+
+    expect(pickerItemFromLatestPrAttachment([first, second])).toEqual({
+      kind: "github-pr",
+      item: second.item,
+    });
   });
 });

--- a/packages/app/src/screens/new-workspace-picker-state.test.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.test.ts
@@ -159,8 +159,23 @@ describe("reducePickerSelection", () => {
 
     expect(reducePickerSelection(detected, { type: "pr-added", item })).toEqual({
       selectedItem: item,
-      allowAutoPrSelection: true,
+      allowAutoPrSelection: false,
     });
+  });
+
+  it("keeps the first PR selected when one edit adds multiple PRs", () => {
+    const detected = reducePickerSelection(initialPickerSelectionState, { type: "pr-detected" });
+    const first = reducePickerSelection(detected, {
+      type: "pr-added",
+      item: { kind: "github-pr", item: makePrItem(101, "A") },
+    });
+
+    expect(
+      reducePickerSelection(first, {
+        type: "pr-added",
+        item: { kind: "github-pr", item: makePrItem(202, "B") },
+      }),
+    ).toEqual(first);
   });
 
   it("keeps a branch selected after a pending PR is added", () => {

--- a/packages/app/src/screens/new-workspace-picker-state.test.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { UserComposerAttachment } from "@/attachments/types";
 import {
   clearPickerPrAttachmentForTargetChange,
-  pickerItemFromLatestPrAttachment,
+  initialPickerSelectionState,
+  reducePickerSelection,
   syncPickerPrAttachment,
 } from "./new-workspace-picker-state";
 import type { ForgeSearchItem } from "@getpaseo/protocol/messages";
@@ -151,36 +152,51 @@ describe("clearPickerPrAttachmentForTargetChange", () => {
   });
 });
 
-describe("pickerItemFromLatestPrAttachment", () => {
-  it("restores a forge change request attachment as the starting ref", () => {
-    const item = makePrItem(101, "A");
+describe("reducePickerSelection", () => {
+  it("selects a PR that was newly detected and added", () => {
+    const item = { kind: "github-pr" as const, item: makePrItem(101, "A") };
+    const detected = reducePickerSelection(initialPickerSelectionState, { type: "pr-detected" });
 
-    expect(pickerItemFromLatestPrAttachment([forgePrAttachment(item)])).toEqual({
-      kind: "github-pr",
-      item,
+    expect(reducePickerSelection(detected, { type: "pr-added", item })).toEqual({
+      selectedItem: item,
+      allowAutoPrSelection: true,
     });
   });
 
-  it("restores a legacy GitHub PR attachment as the starting ref", () => {
-    const item = makePrItem(101, "A");
-
-    expect(pickerItemFromLatestPrAttachment([prAttachment(item)])).toEqual({
-      kind: "github-pr",
-      item,
+  it("keeps a branch selected after a pending PR is added", () => {
+    const detected = reducePickerSelection(initialPickerSelectionState, { type: "pr-detected" });
+    const branchSelected = reducePickerSelection(detected, {
+      type: "picker-selected",
+      item: { kind: "branch", name: "main" },
     });
+
+    expect(
+      reducePickerSelection(branchSelected, {
+        type: "pr-added",
+        item: { kind: "github-pr", item: makePrItem(101, "A") },
+      }),
+    ).toEqual(branchSelected);
   });
 
-  it("ignores issue attachments", () => {
-    expect(pickerItemFromLatestPrAttachment([issueAttachment(44)])).toBeNull();
+  it("does not derive checkout selection from an existing attachment", () => {
+    expect(
+      reducePickerSelection(initialPickerSelectionState, {
+        type: "pr-added",
+        item: { kind: "github-pr", item: makePrItem(101, "A") },
+      }),
+    ).toEqual(initialPickerSelectionState);
   });
 
-  it("restores the most recently attached PR", () => {
-    const first = forgePrAttachment(makePrItem(101, "A"));
-    const second = forgePrAttachment(makePrItem(202, "B"));
-
-    expect(pickerItemFromLatestPrAttachment([first, second])).toEqual({
-      kind: "github-pr",
-      item: second.item,
+  it("lets a newly detected PR replace an earlier explicit branch", () => {
+    const branchSelected = reducePickerSelection(initialPickerSelectionState, {
+      type: "picker-selected",
+      item: { kind: "branch", name: "main" },
     });
+    const detected = reducePickerSelection(branchSelected, { type: "pr-detected" });
+    const pr = { kind: "github-pr" as const, item: makePrItem(101, "A") };
+
+    expect(reducePickerSelection(detected, { type: "pr-added", item: pr }).selectedItem).toEqual(
+      pr,
+    );
   });
 });

--- a/packages/app/src/screens/new-workspace-picker-state.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.ts
@@ -4,6 +4,12 @@ import {
 } from "@/attachments/types";
 import type { PickerItem } from "./new-workspace-picker-item";
 
+function isPrAttachment(
+  attachment: UserComposerAttachment,
+): attachment is Extract<UserComposerAttachment, { kind: "forge_change_request" | "github_pr" }> {
+  return attachment.kind === "forge_change_request" || attachment.kind === "github_pr";
+}
+
 function isPickerOwnedPrAttachment(attachment: UserComposerAttachment): attachment is Extract<
   UserComposerAttachment,
   { kind: "github_pr" }
@@ -28,8 +34,7 @@ export function syncPickerPrAttachment(input: {
   if (input.item?.kind === "github-pr") {
     const selectedPr = input.item.item;
     const hasExistingPrAttachment = nextAttachments.some(
-      (attachment) =>
-        attachment.kind === "github_pr" && attachment.item.number === selectedPr.number,
+      (attachment) => isPrAttachment(attachment) && attachment.item.number === selectedPr.number,
     );
     if (!hasExistingPrAttachment) {
       return [
@@ -54,14 +59,14 @@ export function clearPickerPrAttachmentForTargetChange(input: {
   if (input.currentTargetId === input.nextTargetId) {
     return input.attachments;
   }
-  return syncPickerPrAttachment({ attachments: input.attachments, item: null });
+  return input.attachments.filter((attachment) => !isPrAttachment(attachment));
 }
 
 export function pickerItemFromAttachments(
   attachments: ReadonlyArray<UserComposerAttachment>,
 ): PickerItem | null {
   for (const attachment of attachments) {
-    if (attachment.kind !== "forge_change_request" && attachment.kind !== "github_pr") continue;
+    if (!isPrAttachment(attachment)) continue;
     return { kind: "github-pr", item: attachment.item };
   }
 

--- a/packages/app/src/screens/new-workspace-picker-state.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.ts
@@ -62,10 +62,11 @@ export function clearPickerPrAttachmentForTargetChange(input: {
   return input.attachments.filter((attachment) => !isPrAttachment(attachment));
 }
 
-export function pickerItemFromAttachments(
+export function pickerItemFromLatestPrAttachment(
   attachments: ReadonlyArray<UserComposerAttachment>,
 ): PickerItem | null {
-  for (const attachment of attachments) {
+  for (let index = attachments.length - 1; index >= 0; index -= 1) {
+    const attachment = attachments[index];
     if (!isPrAttachment(attachment)) continue;
     return { kind: "github-pr", item: attachment.item };
   }

--- a/packages/app/src/screens/new-workspace-picker-state.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.ts
@@ -28,7 +28,9 @@ export function reducePickerSelection(
     case "pr-detected":
       return { ...state, allowAutoPrSelection: true };
     case "pr-added":
-      return state.allowAutoPrSelection ? { ...state, selectedItem: event.item } : state;
+      return state.allowAutoPrSelection
+        ? { selectedItem: event.item, allowAutoPrSelection: false }
+        : state;
     case "picker-selected":
       return { selectedItem: event.item, allowAutoPrSelection: false };
     case "target-changed":

--- a/packages/app/src/screens/new-workspace-picker-state.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.ts
@@ -4,6 +4,38 @@ import {
 } from "@/attachments/types";
 import type { PickerItem } from "./new-workspace-picker-item";
 
+export interface PickerSelectionState {
+  selectedItem: PickerItem | null;
+  allowAutoPrSelection: boolean;
+}
+
+export type PickerSelectionEvent =
+  | { type: "pr-detected" }
+  | { type: "pr-added"; item: Extract<PickerItem, { kind: "github-pr" }> }
+  | { type: "picker-selected"; item: PickerItem }
+  | { type: "target-changed" };
+
+export const initialPickerSelectionState: PickerSelectionState = {
+  selectedItem: null,
+  allowAutoPrSelection: false,
+};
+
+export function reducePickerSelection(
+  state: PickerSelectionState,
+  event: PickerSelectionEvent,
+): PickerSelectionState {
+  switch (event.type) {
+    case "pr-detected":
+      return { ...state, allowAutoPrSelection: true };
+    case "pr-added":
+      return state.allowAutoPrSelection ? { ...state, selectedItem: event.item } : state;
+    case "picker-selected":
+      return { selectedItem: event.item, allowAutoPrSelection: false };
+    case "target-changed":
+      return initialPickerSelectionState;
+  }
+}
+
 function isPrAttachment(
   attachment: UserComposerAttachment,
 ): attachment is Extract<UserComposerAttachment, { kind: "forge_change_request" | "github_pr" }> {
@@ -60,16 +92,4 @@ export function clearPickerPrAttachmentForTargetChange(input: {
     return input.attachments;
   }
   return input.attachments.filter((attachment) => !isPrAttachment(attachment));
-}
-
-export function pickerItemFromLatestPrAttachment(
-  attachments: ReadonlyArray<UserComposerAttachment>,
-): PickerItem | null {
-  for (let index = attachments.length - 1; index >= 0; index -= 1) {
-    const attachment = attachments[index];
-    if (!isPrAttachment(attachment)) continue;
-    return { kind: "github-pr", item: attachment.item };
-  }
-
-  return null;
 }

--- a/packages/app/src/screens/new-workspace-picker-state.ts
+++ b/packages/app/src/screens/new-workspace-picker-state.ts
@@ -57,20 +57,12 @@ export function clearPickerPrAttachmentForTargetChange(input: {
   return syncPickerPrAttachment({ attachments: input.attachments, item: null });
 }
 
-export function findCheckoutHintPrAttachment(input: {
-  attachments: ReadonlyArray<UserComposerAttachment>;
-  selectedItem: PickerItem | null;
-  dismissedPrNumbers: ReadonlySet<number>;
-}): Extract<UserComposerAttachment, { kind: "github_pr" }> | null {
-  const selectedPrNumber =
-    input.selectedItem?.kind === "github-pr" ? input.selectedItem.item.number : null;
-
-  for (const attachment of input.attachments) {
-    if (attachment.kind !== "github_pr") continue;
-    const prNumber = attachment.item.number;
-    if (prNumber === selectedPrNumber) continue;
-    if (input.dismissedPrNumbers.has(prNumber)) continue;
-    return attachment;
+export function pickerItemFromAttachments(
+  attachments: ReadonlyArray<UserComposerAttachment>,
+): PickerItem | null {
+  for (const attachment of attachments) {
+    if (attachment.kind !== "forge_change_request" && attachment.kind !== "github_pr") continue;
+    return { kind: "github-pr", item: attachment.item };
   }
 
   return null;

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -9,15 +9,7 @@ import { StyleSheet, useUnistyles, withUnistyles } from "react-native-unistyles"
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { createNameId } from "mnemonic-id";
 import { useQuery } from "@tanstack/react-query";
-import {
-  Check,
-  ChevronDown,
-  Folder,
-  FolderPlus,
-  GitBranch,
-  GitPullRequest,
-  X,
-} from "lucide-react-native";
+import { ChevronDown, Folder, FolderPlus, GitBranch, GitPullRequest } from "lucide-react-native";
 import { Composer } from "@/composer";
 import { FileDropZone } from "@/components/file-drop/file-drop-zone";
 import { DraftAgentModeControl } from "@/composer/agent-controls/mode-control";
@@ -80,7 +72,7 @@ import {
 } from "@/projects/host-projects";
 import { useProjectIconDataByProjectKey } from "@/projects/project-icons";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
-import type { ComposerAttachment, UserComposerAttachment } from "@/attachments/types";
+import type { ComposerAttachment } from "@/attachments/types";
 import { useDraftWorkspaceAttachmentScopeKey } from "@/attachments/workspace-attachments-store";
 import type { MessagePayload } from "@/composer/types";
 import type { AgentAttachment, ForgeSearchItem } from "@getpaseo/protocol/messages";
@@ -99,7 +91,7 @@ import {
 } from "./new-workspace-picker-item";
 import {
   clearPickerPrAttachmentForTargetChange,
-  findCheckoutHintPrAttachment,
+  pickerItemFromAttachments,
   syncPickerPrAttachment,
 } from "./new-workspace-picker-state";
 import {
@@ -332,50 +324,6 @@ function ProjectPickerTrigger({
         <Text style={styles.tooltipText}>Choose project</Text>
       </TooltipContent>
     </Tooltip>
-  );
-}
-
-function CheckoutHintBadge({
-  label,
-  acceptLabel,
-  dismissLabel,
-  onAccept,
-  onDismiss,
-  iconColor,
-  iconSize,
-}: {
-  label: string;
-  acceptLabel: string;
-  dismissLabel: string;
-  onAccept: () => void;
-  onDismiss: () => void;
-  iconColor: string;
-  iconSize: number;
-}) {
-  return (
-    <View style={styles.checkoutHintBadge}>
-      <Text style={styles.badgeText} numberOfLines={1}>
-        {label}
-      </Text>
-      <Pressable
-        testID="new-workspace-checkout-hint-accept"
-        onPress={onAccept}
-        style={styles.checkoutHintAction}
-        accessibilityRole="button"
-        accessibilityLabel={acceptLabel}
-      >
-        <Check size={iconSize} color={iconColor} />
-      </Pressable>
-      <Pressable
-        testID="new-workspace-checkout-hint-dismiss"
-        onPress={onDismiss}
-        style={styles.checkoutHintAction}
-        accessibilityRole="button"
-        accessibilityLabel={dismissLabel}
-      >
-        <X size={iconSize} color={iconColor} />
-      </Pressable>
-    </View>
   );
 }
 
@@ -644,14 +592,6 @@ function AddProjectPickerAction({ onPress }: { onPress: () => void }) {
 function formatPrLabel(item: Pick<ForgeSearchItem, "forge" | "number" | "title">): string {
   const presentation = getForgePresentation(item.forge ?? "github");
   return `${presentation.numberPrefix}${item.number} ${item.title}`;
-}
-
-function getCheckoutHintPresentation(item: ForgeSearchItem) {
-  const presentation = getForgePresentation(item.forge ?? "github");
-  return {
-    noun: presentation.changeRequestAbbrev,
-    numberPrefix: presentation.numberPrefix,
-  };
 }
 
 function pickerItemLabel(item: PickerItem): string {
@@ -1058,47 +998,6 @@ function buildComposerConfig(input: {
     onlineServerIds: isConnected && serverId ? [serverId] : [],
     lockedWorkingDir: workingDir,
   };
-}
-
-function collectAttachedPrNumbers(attachments: ReadonlyArray<UserComposerAttachment>): Set<number> {
-  const numbers = new Set<number>();
-  for (const attachment of attachments) {
-    if (attachment.kind === "github_pr") {
-      numbers.add(attachment.item.number);
-    }
-  }
-  return numbers;
-}
-
-function pruneDismissedCheckoutHintPrNumbers(
-  dismissed: ReadonlySet<number>,
-  attached: ReadonlySet<number>,
-): ReadonlySet<number> {
-  let changed = false;
-  const next = new Set<number>();
-  for (const prNumber of dismissed) {
-    if (attached.has(prNumber)) {
-      next.add(prNumber);
-    } else {
-      changed = true;
-    }
-  }
-  return changed ? next : dismissed;
-}
-
-function useCheckoutHintDismissals(attachments: ReadonlyArray<UserComposerAttachment>) {
-  const [dismissedPrNumbers, setDismissedPrNumbers] = useState<ReadonlySet<number>>(
-    () => new Set(),
-  );
-  const attachedPrNumbers = useMemo(() => collectAttachedPrNumbers(attachments), [attachments]);
-
-  useEffect(() => {
-    setDismissedPrNumbers((current) =>
-      pruneDismissedCheckoutHintPrNumbers(current, attachedPrNumbers),
-    );
-  }, [attachedPrNumbers]);
-
-  return [dismissedPrNumbers, setDismissedPrNumbers] as const;
 }
 
 function usePendingWorkspaceDraftSetup(
@@ -1718,10 +1617,9 @@ export function NewWorkspaceScreen({
     }),
   });
   const composerState = chatDraft.composerState;
-  const [dismissedCheckoutHintPrNumbers, setDismissedCheckoutHintPrNumbers] =
-    useCheckoutHintDismissals(chatDraft.attachments);
-
-  const selectedItem = getSelectedPickerItem(manualPickerSelection);
+  const selectedItem =
+    getSelectedPickerItem(manualPickerSelection) ??
+    pickerItemFromAttachments(chatDraft.attachments);
 
   const withConnectedClient = useCallback(() => {
     if (!client || !isConnected) {
@@ -1876,32 +1774,6 @@ export function NewWorkspaceScreen({
     setProjectPickerOpen(false);
     openAddProjectPicker(selectedServerId);
   }, [openAddProjectPicker, selectedServerId]);
-
-  const checkoutHintPrAttachment = useMemo(
-    () =>
-      findCheckoutHintPrAttachment({
-        attachments: chatDraft.attachments,
-        selectedItem,
-        dismissedPrNumbers: dismissedCheckoutHintPrNumbers,
-      }),
-    [chatDraft.attachments, dismissedCheckoutHintPrNumbers, selectedItem],
-  );
-
-  const acceptCheckoutHint = useCallback(() => {
-    if (!checkoutHintPrAttachment) return;
-    selectPickerItem({ kind: "github-pr", item: checkoutHintPrAttachment.item });
-  }, [checkoutHintPrAttachment, selectPickerItem]);
-
-  const dismissCheckoutHint = useCallback(() => {
-    if (!checkoutHintPrAttachment) return;
-    const prNumber = checkoutHintPrAttachment.item.number;
-    setDismissedCheckoutHintPrNumbers((current) => {
-      if (current.has(prNumber)) return current;
-      const next = new Set(current);
-      next.add(prNumber);
-      return next;
-    });
-  }, [checkoutHintPrAttachment, setDismissedCheckoutHintPrNumbers]);
 
   const openPicker = useCallback(() => {
     setPickerOpen(true);
@@ -2234,42 +2106,11 @@ export function NewWorkspaceScreen({
   });
 
   const composerFooter = useMemo(
-    () => (
-      <>
-        {agentControlsWithDisabled ? (
-          <DraftAgentModeControl placement="footer" {...agentControlsWithDisabled} />
-        ) : null}
-        {checkoutHintPrAttachment ? (
-          <CheckoutHintBadge
-            label={t("newWorkspace.refPicker.checkoutHint", {
-              number: checkoutHintPrAttachment.item.number,
-              ...getCheckoutHintPresentation(checkoutHintPrAttachment.item),
-            })}
-            acceptLabel={t("newWorkspace.refPicker.checkoutPr", {
-              number: checkoutHintPrAttachment.item.number,
-              ...getCheckoutHintPresentation(checkoutHintPrAttachment.item),
-            })}
-            dismissLabel={t("newWorkspace.refPicker.dismissCheckoutHint", {
-              number: checkoutHintPrAttachment.item.number,
-              ...getCheckoutHintPresentation(checkoutHintPrAttachment.item),
-            })}
-            onAccept={acceptCheckoutHint}
-            onDismiss={dismissCheckoutHint}
-            iconColor={theme.colors.foregroundMuted}
-            iconSize={theme.iconSize.sm}
-          />
-        ) : null}
-      </>
-    ),
-    [
-      acceptCheckoutHint,
-      agentControlsWithDisabled,
-      checkoutHintPrAttachment,
-      dismissCheckoutHint,
-      t,
-      theme.colors.foregroundMuted,
-      theme.iconSize.sm,
-    ],
+    () =>
+      agentControlsWithDisabled ? (
+        <DraftAgentModeControl placement="footer" {...agentControlsWithDisabled} />
+      ) : null,
+    [agentControlsWithDisabled],
   );
   const screenHeaderLeft = useMemo(() => <SidebarMenuToggle />, []);
 
@@ -2386,23 +2227,6 @@ const styles = StyleSheet.create((theme) => ({
     paddingHorizontal: theme.spacing[2],
     borderRadius: theme.borderRadius["2xl"],
     gap: theme.spacing[1],
-  },
-  checkoutHintBadge: {
-    flexDirection: "row",
-    alignItems: "center",
-    height: BADGE_HEIGHT,
-    maxWidth: 240,
-    paddingHorizontal: theme.spacing[2],
-    borderRadius: theme.borderRadius["2xl"],
-    gap: theme.spacing[1],
-    backgroundColor: theme.colors.surface1,
-  },
-  checkoutHintAction: {
-    width: theme.iconSize.md,
-    height: theme.iconSize.md,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: theme.borderRadius.full,
   },
   badgeHovered: {
     backgroundColor: theme.colors.surface2,

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import type { ReactElement, RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
@@ -91,7 +91,8 @@ import {
 } from "./new-workspace-picker-item";
 import {
   clearPickerPrAttachmentForTargetChange,
-  pickerItemFromLatestPrAttachment,
+  initialPickerSelectionState,
+  reducePickerSelection,
   syncPickerPrAttachment,
 } from "./new-workspace-picker-state";
 import {
@@ -176,31 +177,6 @@ interface NewWorkspaceScreenProps {
 interface PickerOptionData {
   options: ComboboxOptionType[];
   itemById: Map<string, PickerItem>;
-}
-
-interface PickerSelection {
-  item: PickerItem;
-}
-
-function useNewWorkspacePickerSelection(input: {
-  attachments: Parameters<typeof pickerItemFromLatestPrAttachment>[0];
-  isDraftHydrated: boolean;
-}) {
-  const [pickerSelection, setPickerSelection] = useState<PickerSelection | null>(null);
-  const didRestorePickerSelectionRef = useRef(false);
-
-  useEffect(() => {
-    if (!input.isDraftHydrated || didRestorePickerSelectionRef.current) return;
-    didRestorePickerSelectionRef.current = true;
-    const restoredItem = pickerItemFromLatestPrAttachment(input.attachments);
-    if (!restoredItem) return;
-    setPickerSelection((current) => current ?? { item: restoredItem });
-  }, [input.attachments, input.isDraftHydrated]);
-
-  return {
-    selectedItem: pickerSelection ? pickerSelection.item : null,
-    setPickerSelection,
-  };
 }
 
 const BRANCH_OPTION_PREFIX = "branch:";
@@ -1632,17 +1608,22 @@ export function NewWorkspaceScreen({
     }),
   });
   const composerState = chatDraft.composerState;
-  const { selectedItem, setPickerSelection } = useNewWorkspacePickerSelection({
-    attachments: chatDraft.attachments,
-    isDraftHydrated: chatDraft.isHydrated,
-  });
-
-  const handleGithubPrAutoAttach = useCallback(
-    (item: ForgeSearchItem) => {
-      setPickerSelection({ item: { kind: "github-pr", item } });
-    },
-    [setPickerSelection],
+  const [pickerSelection, dispatchPickerSelection] = useReducer(
+    reducePickerSelection,
+    initialPickerSelectionState,
   );
+  const selectedItem = pickerSelection.selectedItem;
+
+  const handleGithubPrDetected = useCallback(() => {
+    dispatchPickerSelection({ type: "pr-detected" });
+  }, []);
+
+  const handleGithubPrAutoAttach = useCallback((item: ForgeSearchItem) => {
+    dispatchPickerSelection({
+      type: "pr-added",
+      item: { kind: "github-pr", item },
+    });
+  }, []);
 
   const withConnectedClient = useCallback(() => {
     if (!client || !isConnected) {
@@ -1743,11 +1724,11 @@ export function NewWorkspaceScreen({
         item,
       });
 
-      setPickerSelection({ item });
+      dispatchPickerSelection({ type: "picker-selected", item });
       chatDraft.setAttachments(nextAttachments);
       setPickerOpen(false);
     },
-    [chatDraft, setPickerSelection],
+    [chatDraft],
   );
 
   const handleSelectOption = useCallback(
@@ -1768,9 +1749,9 @@ export function NewWorkspaceScreen({
       });
       if (nextAttachments === chatDraft.attachments) return;
       chatDraft.setAttachments(nextAttachments);
-      setPickerSelection(null);
+      dispatchPickerSelection({ type: "target-changed" });
     },
-    [chatDraft, setPickerSelection],
+    [chatDraft],
   );
 
   const handleSelectProjectOption = useCallback(
@@ -2166,6 +2147,7 @@ export function NewWorkspaceScreen({
             attachments={chatDraft.attachments}
             attachmentScopeKeys={visibleDraftContextScopeKeys}
             onChangeAttachments={chatDraft.setAttachments}
+            onGithubPrDetected={handleGithubPrDetected}
             onGithubPrAutoAttach={handleGithubPrAutoAttach}
             cwd={selectedSourceDirectory ?? ""}
             clearDraft={handleClearDraft}

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -2135,6 +2135,7 @@ export function NewWorkspaceScreen({
             submitButtonTestID="workspace-create-submit"
             submitIcon="return"
             isSubmitLoading={isPending}
+            waitForGithubAutoAttachOnSubmit
             submitBehavior="preserve-and-lock"
             blurOnSubmit={true}
             value={chatDraft.text}

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -91,7 +91,7 @@ import {
 } from "./new-workspace-picker-item";
 import {
   clearPickerPrAttachmentForTargetChange,
-  pickerItemFromAttachments,
+  pickerItemFromLatestPrAttachment,
   syncPickerPrAttachment,
 } from "./new-workspace-picker-state";
 import {
@@ -180,6 +180,27 @@ interface PickerOptionData {
 
 interface PickerSelection {
   item: PickerItem;
+}
+
+function useNewWorkspacePickerSelection(input: {
+  attachments: Parameters<typeof pickerItemFromLatestPrAttachment>[0];
+  isDraftHydrated: boolean;
+}) {
+  const [pickerSelection, setPickerSelection] = useState<PickerSelection | null>(null);
+  const didRestorePickerSelectionRef = useRef(false);
+
+  useEffect(() => {
+    if (!input.isDraftHydrated || didRestorePickerSelectionRef.current) return;
+    didRestorePickerSelectionRef.current = true;
+    const restoredItem = pickerItemFromLatestPrAttachment(input.attachments);
+    if (!restoredItem) return;
+    setPickerSelection((current) => current ?? { item: restoredItem });
+  }, [input.attachments, input.isDraftHydrated]);
+
+  return {
+    selectedItem: pickerSelection ? pickerSelection.item : null,
+    setPickerSelection,
+  };
 }
 
 const BRANCH_OPTION_PREFIX = "branch:";
@@ -741,11 +762,6 @@ function getContentStyle(input: { isCompact: boolean; insetBottom: number }) {
     return [styles.content, styles.contentCompact, { paddingBottom: input.insetBottom }];
   }
   return [styles.content, styles.contentCentered];
-}
-
-function getSelectedPickerItem(selection: PickerSelection | null): PickerItem | null {
-  if (!selection) return null;
-  return selection.item;
 }
 
 function normalizeBranchDetails(
@@ -1546,7 +1562,6 @@ export function NewWorkspaceScreen({
     typeof normalizeWorkspaceDescriptor
   > | null>(null);
   const [pendingAction, setPendingAction] = useState<"chat" | "empty" | null>(null);
-  const [manualPickerSelection, setManualPickerSelection] = useState<PickerSelection | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
   const openAddProjectPicker = useOpenAddProject();
@@ -1617,9 +1632,17 @@ export function NewWorkspaceScreen({
     }),
   });
   const composerState = chatDraft.composerState;
-  const selectedItem =
-    getSelectedPickerItem(manualPickerSelection) ??
-    pickerItemFromAttachments(chatDraft.attachments);
+  const { selectedItem, setPickerSelection } = useNewWorkspacePickerSelection({
+    attachments: chatDraft.attachments,
+    isDraftHydrated: chatDraft.isHydrated,
+  });
+
+  const handleGithubPrAutoAttach = useCallback(
+    (item: ForgeSearchItem) => {
+      setPickerSelection({ item: { kind: "github-pr", item } });
+    },
+    [setPickerSelection],
+  );
 
   const withConnectedClient = useCallback(() => {
     if (!client || !isConnected) {
@@ -1720,11 +1743,11 @@ export function NewWorkspaceScreen({
         item,
       });
 
-      setManualPickerSelection({ item });
+      setPickerSelection({ item });
       chatDraft.setAttachments(nextAttachments);
       setPickerOpen(false);
     },
-    [chatDraft],
+    [chatDraft, setPickerSelection],
   );
 
   const handleSelectOption = useCallback(
@@ -1736,7 +1759,7 @@ export function NewWorkspaceScreen({
     [itemById, selectPickerItem],
   );
 
-  const clearManualPickerSelectionForTargetChange = useCallback(
+  const clearPickerSelectionForTargetChange = useCallback(
     (currentTargetId: string, nextTargetId: string) => {
       const nextAttachments = clearPickerPrAttachmentForTargetChange({
         attachments: chatDraft.attachments,
@@ -1745,9 +1768,9 @@ export function NewWorkspaceScreen({
       });
       if (nextAttachments === chatDraft.attachments) return;
       chatDraft.setAttachments(nextAttachments);
-      setManualPickerSelection(null);
+      setPickerSelection(null);
     },
-    [chatDraft],
+    [chatDraft, setPickerSelection],
   );
 
   const handleSelectProjectOption = useCallback(
@@ -1757,17 +1780,17 @@ export function NewWorkspaceScreen({
       // canCreateWorktree or non-git projects become unselectable.
       selectProjectOption(id);
       setProjectPickerOpen(false);
-      clearManualPickerSelectionForTargetChange(selectedProjectOptionId, id);
+      clearPickerSelectionForTargetChange(selectedProjectOptionId, id);
     },
-    [clearManualPickerSelectionForTargetChange, selectProjectOption, selectedProjectOptionId],
+    [clearPickerSelectionForTargetChange, selectProjectOption, selectedProjectOptionId],
   );
 
   const handleSelectWorkspaceHost = useCallback(
     (id: string) => {
       handleSelectHost(id);
-      clearManualPickerSelectionForTargetChange(selectedServerId, id);
+      clearPickerSelectionForTargetChange(selectedServerId, id);
     },
-    [clearManualPickerSelectionForTargetChange, handleSelectHost, selectedServerId],
+    [clearPickerSelectionForTargetChange, handleSelectHost, selectedServerId],
   );
 
   const handleAddProject = useCallback(() => {
@@ -2143,6 +2166,7 @@ export function NewWorkspaceScreen({
             attachments={chatDraft.attachments}
             attachmentScopeKeys={visibleDraftContextScopeKeys}
             onChangeAttachments={chatDraft.setAttachments}
+            onGithubPrAutoAttach={handleGithubPrAutoAttach}
             cwd={selectedSourceDirectory ?? ""}
             clearDraft={handleClearDraft}
             autoFocus

--- a/packages/server/src/server/worktree-core.posix.test.ts
+++ b/packages/server/src/server/worktree-core.posix.test.ts
@@ -621,6 +621,52 @@ describe.skipIf(isPlatform("win32"))("worktree-core POSIX-only", () => {
       expect(result.worktree.branchName).toBe("pr-123");
     });
 
+    test("tracks a same-repo PR branch from a single-branch clone", async () => {
+      const { tempDir, repoDir, remoteDir, paseoHome } = createSameRepoGitHubPrRemoteRepo();
+      cleanupPaths.push(tempDir);
+      execFileSync("git", ["config", "--unset-all", "remote.origin.fetch"], {
+        cwd: repoDir,
+        stdio: "pipe",
+      });
+      execFileSync(
+        "git",
+        ["config", "--add", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main"],
+        { cwd: repoDir, stdio: "pipe" },
+      );
+      execFileSync("git", ["update-ref", "-d", "refs/remotes/origin/daemon-shutdown-diagnostics"], {
+        cwd: repoDir,
+        stdio: "pipe",
+      });
+      const github = {
+        ...createGitHubServiceStub(),
+        getPullRequestCheckoutTarget: async () => ({
+          number: 1790,
+          baseRefName: "main",
+          headRefName: "daemon-shutdown-diagnostics",
+          headOwnerLogin: "getpaseo",
+          headRepositorySshUrl: remoteDir,
+          headRepositoryUrl: remoteDir,
+          isCrossRepository: false,
+        }),
+      };
+
+      const result = await createCoreWorktree(
+        {
+          cwd: repoDir,
+          action: "checkout",
+          githubPrNumber: 1790,
+          paseoHome,
+          runSetup: false,
+        },
+        createCoreDeps({ github }),
+      );
+
+      expect(result.worktree.branchName).toBe("daemon-shutdown-diagnostics");
+      expect(getBranchUpstream(result.worktree.worktreePath)).toBe(
+        "origin/daemon-shutdown-diagnostics",
+      );
+    });
+
     test("checks out a GitLab MR source branch through the resolved forge service", async () => {
       const { tempDir, repoDir, paseoHome } = createGitRepoWithOriginFeatureBranch();
       cleanupPaths.push(tempDir);

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1511,7 +1511,33 @@ async function tryFetchWorktreeTrackingRemote(options: {
       acceptExitCodes: [0, 1, 128],
     },
   );
-  return result.exitCode === 0 ? { name: options.remoteName, headRef: options.headRef } : undefined;
+  if (result.exitCode !== 0) {
+    return undefined;
+  }
+  await ensureRemoteFetchesBranch(options);
+  return { name: options.remoteName, headRef: options.headRef };
+}
+
+async function ensureRemoteFetchesBranch(options: {
+  cwd: string;
+  remoteName: string;
+  headRef: string;
+}): Promise<void> {
+  const configKey = `remote.${options.remoteName}.fetch`;
+  const exactRefspec = `refs/heads/${options.headRef}:refs/remotes/${options.remoteName}/${options.headRef}`;
+  const wildcardRefspec = `refs/heads/*:refs/remotes/${options.remoteName}/*`;
+  const { stdout } = await runGitCommand(["config", "--get-all", configKey], {
+    cwd: options.cwd,
+    acceptExitCodes: [0, 1],
+  });
+  const alreadyTracked = stdout
+    .split("\n")
+    .map((refspec) => refspec.trim().replace(/^\+/, ""))
+    .some((refspec) => refspec === exactRefspec || refspec === wildcardRefspec);
+  if (alreadyTracked) {
+    return;
+  }
+  await runGitCommand(["config", "--add", configKey, `+${exactRefspec}`], { cwd: options.cwd });
 }
 
 async function getWorktreeRemotePushUrl(


### PR DESCRIPTION
### Linked issue

No matching open issue found.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Pasting a recognized pull request into the new-workspace composer now adds its attachment and selects that pull request as the starting ref immediately. Create waits for every pasted-link lookup to finish, including overlapping resolutions, so submitting quickly cannot silently create from the current branch instead.

The starting-ref selector continues to show and search branches. Choosing a branch such as `main` explicitly overrides the automatic pull-request selection, including when the PR lookup is still pending. Later composer edits and draft restoration do not infer checkout state from the retained PR attachment. Users can also remove the attachment. Changing the project or host clears repository-specific pull request attachments and invalidates in-flight lookup results so an old target cannot leak into the new workspace.

The previous confirmation path only recognized the legacy attachment shape, so generalized forge attachments were displayed but never offered for checkout. Pull-request detection now arms a one-time selection event; any later explicit picker choice cancels it, and existing attachments never derive or override checkout state. When one edit contains multiple PR links, the first resolved PR becomes the checkout and later PRs remain attachments. Replacing the transport client does not invalidate a result for the same host and checkout.

This also ensures pull request branches fetched from single-branch clones are registered in the remote fetch configuration and can be tracked by the created worktree.

### How did you verify it

- Added deterministic Playwright coverage using local Git and a local forge seam, requiring no GitHub credentials.
- Verified pasting a pull request replaces the current automatic/default branch selection and creates the worktree from the pull-request branch.
- Verified branches remain searchable after attaching a pull request, selecting `main` survives later composer edits, and submission creates the worktree from `main`.
- Added a real-Git server regression for tracking a same-repository pull request branch from a single-branch clone.
- Focused app unit tests passed: 23 tests across the auto-attach and picker-state suites, including delayed lookup, URL removal, target switching, transport replacement, multiple PRs, draft restoration, and explicit-choice ordering.
- Focused Playwright tests passed: 2 tests covering both pull-request checkout and explicit branch override through workspace creation.
- Ran `npm run typecheck`, targeted lint, and `npm run format` successfully.

The web flow and Git checkout are covered end to end. Before merge, smoke attachment removal, target switching, and starting-ref override on a native build because those interactions share cross-platform UI code but the end-to-end coverage runs in Chromium.

### Risk surface

The starting-ref event and lookup invalidation behavior are shared by web and native clients. The remote configuration change only adds an exact branch refspec when neither an exact nor wildcard mapping already covers the fetched branch.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
