### PR TITLE
feat(timeline): persist turnId on timeline entries; add todo item status

### DIFF
--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -172,6 +172,7 @@ const ThemedTodoCheckIcon = withUnistyles(Check);
 const ThemedFileSymlinkIcon = withUnistyles(FileSymlink);
 const ThemedTriangleAlertIcon = withUnistyles(TriangleAlertIcon);
 const ThemedChevronRightIcon = withUnistyles(ChevronRight);
+const ThemedActivityIndicator = withUnistyles(ActivityIndicator);
 
 const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
 const foregroundMutedColorMapping = (theme: Theme) => ({
@@ -2241,12 +2242,23 @@ interface TodoListCardProps {
   disableOuterSpacing?: boolean;
 }
 
-interface TodoListItemRowProps {
-  text: string;
-  completed: boolean;
+type TodoItemStatus = NonNullable<TodoEntry["status"]>;
+
+function resolveTodoStatus(item: { completed: boolean; status?: TodoItemStatus }): TodoItemStatus {
+  if (item.status) {
+    return item.status;
+  }
+  return item.completed ? "completed" : "pending";
 }
 
-function TodoListItemRow({ text, completed }: TodoListItemRowProps) {
+interface TodoListItemRowProps {
+  text: string;
+  status: TodoItemStatus;
+}
+
+function TodoListItemRow({ text, status }: TodoListItemRowProps) {
+  const completed = status === "completed";
+  const inProgress = status === "in_progress";
   const badgeStyle = useMemo(
     () => [
       todoListCardStylesheet.radioBadge,
@@ -2260,13 +2272,21 @@ function TodoListItemRow({ text, completed }: TodoListItemRowProps) {
     () => [todoListCardStylesheet.itemText, completed && todoListCardStylesheet.itemTextCompleted],
     [completed],
   );
+  let statusIcon: ReactNode = null;
+  if (completed) {
+    statusIcon = <ThemedTodoCheckIcon size={12} uniProps={primaryForegroundColorMapping} />;
+  } else if (inProgress) {
+    statusIcon = (
+      <ThemedActivityIndicator
+        size="small"
+        style={todoListCardStylesheet.progressIndicator}
+        uniProps={primaryForegroundColorMapping}
+      />
+    );
+  }
   return (
     <View style={todoListCardStylesheet.itemRow}>
-      <View style={badgeStyle}>
-        {completed ? (
-          <ThemedTodoCheckIcon size={12} uniProps={primaryForegroundColorMapping} />
-        ) : null}
-      </View>
+      <View style={badgeStyle}>{statusIcon}</View>
       <Text style={textStyle}>{text}</Text>
     </View>
   );
@@ -2298,6 +2318,9 @@ const todoListCardStylesheet = StyleSheet.create((theme) => ({
   radioBadgeComplete: {
     opacity: 0.95,
   },
+  progressIndicator: {
+    transform: [{ scale: 0.7 }],
+  },
   itemText: {
     flex: 1,
     color: theme.colors.foreground,
@@ -2320,7 +2343,13 @@ export const TodoListCard = memo(function TodoListCard({
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const nextTask = useMemo(() => items.find((item) => !item.completed)?.text, [items]);
+  const nextTask = useMemo(() => {
+    const inProgress = items.find((item) => resolveTodoStatus(item) === "in_progress");
+    if (inProgress) {
+      return inProgress.text;
+    }
+    return items.find((item) => resolveTodoStatus(item) === "pending")?.text;
+  }, [items]);
 
   const handleToggle = useCallback(() => {
     setIsExpanded((prev) => !prev);
@@ -2334,7 +2363,7 @@ export const TodoListCard = memo(function TodoListCard({
             <Text style={todoListCardStylesheet.emptyText}>{t("message.todo.empty")}</Text>
           ) : (
             items.map((item) => (
-              <TodoListItemRow key={item.text} text={item.text} completed={item.completed} />
+              <TodoListItemRow key={item.text} text={item.text} status={resolveTodoStatus(item)} />
             ))
           )}
         </View>

--- a/packages/app/src/timeline/session-stream-reducers.test.ts
+++ b/packages/app/src/timeline/session-stream-reducers.test.ts
@@ -1894,6 +1894,111 @@ describe("processTimelineResponse", () => {
       endSeq: 2,
     });
   });
+
+  it("coalesces same provider+turn todo cards after timeline reload with turnId preserved", () => {
+    const turnA = "turn-reload-a";
+    const turnB = "turn-reload-b";
+    const provider = "grok";
+
+    const firstTodoEntry = {
+      seqStart: 1,
+      seqEnd: 1,
+      provider,
+      turnId: turnA,
+      item: {
+        type: "todo",
+        items: [
+          { text: "Investigate", completed: false, status: "pending" },
+          { text: "Fix", completed: false, status: "pending" },
+        ],
+      },
+      timestamp: new Date("2025-01-01T14:00:00Z").toISOString(),
+    };
+    const reasoningEntry = {
+      ...makeTimelineEntry(2, "checking reload path", "reasoning"),
+      provider,
+      turnId: turnA,
+    };
+    const assistantEntry = {
+      ...makeTimelineEntry(3, "working on it"),
+      provider,
+      turnId: turnA,
+      item: {
+        type: "assistant_message",
+        text: "working on it",
+        messageId: "msg-reload-coalesce",
+      },
+    };
+    const updatedTodoEntry = {
+      seqStart: 4,
+      seqEnd: 4,
+      provider,
+      turnId: turnA,
+      item: {
+        type: "todo",
+        items: [
+          { text: "Investigate", completed: false, status: "in_progress" },
+          { text: "Fix", completed: false, status: "pending" },
+        ],
+      },
+      timestamp: new Date("2025-01-01T14:00:04Z").toISOString(),
+    };
+    const nextTurnTodoEntry = {
+      seqStart: 5,
+      seqEnd: 5,
+      provider,
+      turnId: turnB,
+      item: {
+        type: "todo",
+        items: [{ text: "Verify", completed: false, status: "pending" }],
+      },
+      timestamp: new Date("2025-01-01T14:00:05Z").toISOString(),
+    };
+
+    const result = processTimelineResponse({
+      ...baseTimelineInput,
+      isInitializing: true,
+      hasActiveInitDeferred: true,
+      initRequestDirection: "tail",
+      payload: {
+        ...baseTimelineInput.payload,
+        direction: "tail",
+        epoch: "epoch-1",
+        startCursor: { seq: 1 },
+        endCursor: { seq: 5 },
+        entries: [
+          firstTodoEntry,
+          reasoningEntry,
+          assistantEntry,
+          updatedTodoEntry,
+          nextTurnTodoEntry,
+        ],
+      },
+    });
+
+    const stream = [...result.tail, ...result.head];
+    const todoCards = stream.filter(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+    const firstCardIndex = stream.findIndex((item) => item.kind === "todo_list");
+    const thoughtIndex = stream.findIndex((item) => item.kind === "thought");
+    const assistantIndex = stream.findIndex((item) => item.kind === "assistant_message");
+
+    expect(todoCards).toHaveLength(2);
+    expect(todoCards[0]?.turnId).toBe(turnA);
+    expect(todoCards[0]?.provider).toBe(provider);
+    expect(todoCards[0]?.items.map((item) => ({ text: item.text, status: item.status }))).toEqual([
+      { text: "Investigate", status: "in_progress" },
+      { text: "Fix", status: "pending" },
+    ]);
+    expect(firstCardIndex).toBeGreaterThanOrEqual(0);
+    expect(firstCardIndex).toBeLessThan(thoughtIndex);
+    expect(firstCardIndex).toBeLessThan(assistantIndex);
+    expect(todoCards[1]?.turnId).toBe(turnB);
+    expect(todoCards[1]?.items.map((item) => ({ text: item.text, status: item.status }))).toEqual([
+      { text: "Verify", status: "pending" },
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/app/src/timeline/session-stream-reducers.ts
+++ b/packages/app/src/timeline/session-stream-reducers.ts
@@ -65,6 +65,7 @@ interface TimelineResponseEntry {
   sourceSeqRanges?: TimelineSeqRange[];
   collapsed?: string[];
   provider: string;
+  turnId?: string;
   item: Record<string, unknown>;
   timestamp: string;
 }
@@ -1066,6 +1067,7 @@ export function processTimelineResponse(
     event: {
       type: "timeline",
       provider: entry.provider,
+      ...(entry.turnId !== undefined ? { turnId: entry.turnId } : {}),
       item: entry.item,
     } as AgentStreamEventPayload,
     timestamp: new Date(entry.timestamp),

--- a/packages/app/src/types/stream.test.ts
+++ b/packages/app/src/types/stream.test.ts
@@ -89,10 +89,18 @@ function canonicalToolTimeline(params: {
   };
 }
 
-function todoTimeline(items: { text: string; completed: boolean }[]): AgentStreamEventPayload {
+function todoTimeline(
+  items: {
+    text: string;
+    completed: boolean;
+    status?: "pending" | "in_progress" | "completed";
+  }[],
+  options?: { provider?: AgentProvider; turnId?: string },
+): AgentStreamEventPayload {
   return {
     type: "timeline",
-    provider: "codex",
+    provider: options?.provider ?? "codex",
+    ...(options?.turnId !== undefined ? { turnId: options.turnId } : {}),
     item: {
       type: "todo",
       items,
@@ -1539,6 +1547,181 @@ describe("turn lifecycle events", () => {
     assert.deepStrictEqual(
       userMessages.map((item) => item.id),
       ["native-1", "native-2"],
+    );
+  });
+});
+
+describe("stream reducer todo status", () => {
+  it("preserves explicit pending, in_progress, and completed todo statuses", () => {
+    const state = hydrateStreamState([
+      {
+        event: todoTimeline(
+          [
+            { text: "Pending task", completed: false, status: "pending" },
+            { text: "Active task", completed: false, status: "in_progress" },
+            { text: "Done task", completed: true, status: "completed" },
+          ],
+          { provider: "grok", turnId: "turn-status" },
+        ),
+        timestamp: new Date("2025-01-01T13:00:00Z"),
+      },
+    ]);
+
+    const todos = state.filter(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+
+    assert.strictEqual(todos.length, 1);
+    assert.deepStrictEqual(
+      todos[0]?.items.map((item) => ({
+        text: item.text,
+        completed: item.completed,
+        status: item.status,
+      })),
+      [
+        { text: "Pending task", completed: false, status: "pending" },
+        { text: "Active task", completed: false, status: "in_progress" },
+        { text: "Done task", completed: true, status: "completed" },
+      ],
+    );
+  });
+
+  it("derives status from completed for legacy todo entries without status", () => {
+    const state = hydrateStreamState([
+      {
+        event: todoTimeline([
+          { text: "Outline", completed: false },
+          { text: "Ship", completed: true },
+        ]),
+        timestamp: new Date("2025-01-01T13:01:00Z"),
+      },
+    ]);
+
+    const todos = state.find(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+
+    assert.ok(todos);
+    assert.deepStrictEqual(
+      todos.items.map((item) => ({
+        text: item.text,
+        completed: item.completed,
+        status: item.status,
+      })),
+      [
+        { text: "Outline", completed: false, status: "pending" },
+        { text: "Ship", completed: true, status: "completed" },
+      ],
+    );
+  });
+
+  it("replaces the same provider+turn todo card in place across interleaved stream events", () => {
+    const turnId = "turn-coalesce";
+    const provider: AgentProvider = "grok";
+    const firstTodo = todoTimeline(
+      [
+        { text: "Investigate", completed: false, status: "pending" },
+        { text: "Fix", completed: false, status: "pending" },
+      ],
+      { provider, turnId },
+    );
+    const updatedTodo = todoTimeline(
+      [
+        { text: "Investigate", completed: false, status: "in_progress" },
+        { text: "Fix", completed: false, status: "pending" },
+      ],
+      { provider, turnId },
+    );
+
+    let state = reduceStreamUpdate([], firstTodo, new Date("2025-01-01T13:02:00Z"));
+    const firstCard = state.find(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+    assert.ok(firstCard);
+    const cardId = firstCard.id;
+    const cardIndex = state.findIndex((item) => item.id === cardId);
+
+    state = reduceStreamUpdate(
+      state,
+      reasoningTimeline("checking the reducer", provider),
+      new Date("2025-01-01T13:02:01Z"),
+    );
+    state = reduceStreamUpdate(
+      state,
+      assistantTimeline("working on it", provider, "msg-coalesce"),
+      new Date("2025-01-01T13:02:02Z"),
+    );
+    state = reduceStreamUpdate(
+      state,
+      canonicalToolTimeline({
+        provider,
+        callId: "tool-coalesce",
+        name: "shell",
+        status: "running",
+        input: { command: "rg status" },
+      }),
+      new Date("2025-01-01T13:02:03Z"),
+    );
+    state = reduceStreamUpdate(state, updatedTodo, new Date("2025-01-01T13:02:04Z"));
+
+    const todoCards = state.filter(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+    const replacedIndex = state.findIndex((item) => item.id === cardId);
+
+    assert.strictEqual(todoCards.length, 1);
+    assert.strictEqual(todoCards[0]?.id, cardId);
+    assert.strictEqual(todoCards[0]?.turnId, turnId);
+    assert.strictEqual(replacedIndex, cardIndex);
+    assert.deepStrictEqual(
+      todoCards[0]?.items.map((item) => ({ text: item.text, status: item.status })),
+      [
+        { text: "Investigate", status: "in_progress" },
+        { text: "Fix", status: "pending" },
+      ],
+    );
+    assert.ok(replacedIndex < state.findIndex((item) => item.kind === "thought"));
+    assert.ok(replacedIndex < state.findIndex((item) => item.kind === "assistant_message"));
+  });
+
+  it("creates a separate todo card for a different turn", () => {
+    const provider: AgentProvider = "grok";
+    const state = hydrateStreamState([
+      {
+        event: todoTimeline([{ text: "Turn one task", completed: false, status: "in_progress" }], {
+          provider,
+          turnId: "turn-a",
+        }),
+        timestamp: new Date("2025-01-01T13:03:00Z"),
+      },
+      {
+        event: assistantTimeline("between turns", provider, "msg-between-turns"),
+        timestamp: new Date("2025-01-01T13:03:01Z"),
+      },
+      {
+        event: todoTimeline([{ text: "Turn two task", completed: false, status: "pending" }], {
+          provider,
+          turnId: "turn-b",
+        }),
+        timestamp: new Date("2025-01-01T13:03:02Z"),
+      },
+    ]);
+
+    const todoCards = state.filter(
+      (item): item is Extract<StreamItem, { kind: "todo_list" }> => item.kind === "todo_list",
+    );
+
+    assert.strictEqual(todoCards.length, 2);
+    assert.deepStrictEqual(
+      todoCards.map((card) => ({
+        turnId: card.turnId,
+        text: card.items[0]?.text,
+        status: card.items[0]?.status,
+      })),
+      [
+        { turnId: "turn-a", text: "Turn one task", status: "in_progress" },
+        { turnId: "turn-b", text: "Turn two task", status: "pending" },
+      ],
     );
   });
 });

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -1,4 +1,8 @@
-import type { AgentProvider, ToolCallDetail } from "@getpaseo/protocol/agent-types";
+import type {
+  AgentProvider,
+  AgentTodoStatus,
+  ToolCallDetail,
+} from "@getpaseo/protocol/agent-types";
 import type { AgentAttachment, AgentStreamEventPayload } from "@getpaseo/protocol/messages";
 import type { AttachmentMetadata } from "@/attachments/types";
 import { extractTaskEntriesFromToolCall } from "../utils/tool-call-parsers";
@@ -194,6 +198,7 @@ export interface CompactionItem {
 export interface TodoEntry {
   text: string;
   completed: boolean;
+  status?: AgentTodoStatus;
 }
 
 export interface TodoListItem {
@@ -202,6 +207,7 @@ export interface TodoListItem {
   timestamp: Date;
   provider: AgentProvider;
   items: TodoEntry[];
+  turnId?: string;
 }
 
 export type StreamUpdateSource = "live" | "canonical";
@@ -698,30 +704,71 @@ function appendActivityLog(state: StreamItem[], entry: ActivityLogItem): StreamI
   return [...state, entry];
 }
 
+function normalizeTodoEntry(entry: {
+  text: string;
+  completed: boolean;
+  status?: AgentTodoStatus | null;
+}): TodoEntry {
+  if (
+    entry.status === "pending" ||
+    entry.status === "in_progress" ||
+    entry.status === "completed"
+  ) {
+    return {
+      text: entry.text,
+      status: entry.status,
+      completed: entry.status === "completed",
+    };
+  }
+  // COMPAT(todoStatus): added in v0.2.0, remove after 2027-01-20 once all hosts send status.
+  return {
+    text: entry.text,
+    completed: entry.completed,
+    status: entry.completed ? "completed" : "pending",
+  };
+}
+
 function appendTodoList(
   state: StreamItem[],
   provider: AgentProvider,
   items: TodoEntry[],
   timestamp: Date,
+  turnId?: string,
 ): StreamItem[] {
-  const normalizedItems = items.map((item) => ({
-    text: item.text,
-    completed: item.completed,
-  }));
+  const normalizedItems = items.map((item) => normalizeTodoEntry(item));
 
-  const lastItem = state[state.length - 1];
-  if (lastItem && lastItem.kind === "todo_list" && lastItem.provider === provider) {
-    const next = [...state];
-    const updated: TodoListItem = {
-      ...lastItem,
-      items: normalizedItems,
-      timestamp,
-    };
-    next[next.length - 1] = updated;
-    return next;
+  if (turnId !== undefined) {
+    for (let index = state.length - 1; index >= 0; index -= 1) {
+      const candidate = state[index];
+      if (
+        candidate?.kind === "todo_list" &&
+        candidate.provider === provider &&
+        candidate.turnId === turnId
+      ) {
+        const next = [...state];
+        next[index] = {
+          ...candidate,
+          items: normalizedItems,
+          timestamp,
+          turnId,
+        };
+        return next;
+      }
+    }
+  } else {
+    const lastItem = state[state.length - 1];
+    if (lastItem && lastItem.kind === "todo_list" && lastItem.provider === provider) {
+      const next = [...state];
+      next[next.length - 1] = {
+        ...lastItem,
+        items: normalizedItems,
+        timestamp,
+      };
+      return next;
+    }
   }
 
-  const idSeed = `${provider}:${JSON.stringify(normalizedItems)}`;
+  const idSeed = `${provider}:${turnId ?? ""}:${JSON.stringify(normalizedItems)}`;
   const entryId = createUniqueTimelineId(state, "todo", idSeed, timestamp);
 
   const entry: TodoListItem = {
@@ -730,6 +777,7 @@ function appendTodoList(
     timestamp,
     provider,
     items: normalizedItems,
+    ...(turnId !== undefined ? { turnId } : {}),
   };
 
   return [...state, entry];
@@ -763,8 +811,13 @@ function reduceTimelineToolCall(
     return appendTodoList(
       state,
       event.provider,
-      tasks.map((entry) => ({ text: entry.text, completed: entry.completed })),
+      tasks.map((entry) => ({
+        text: entry.text,
+        completed: entry.completed,
+        status: entry.status,
+      })),
       timestamp,
+      event.turnId,
     );
   }
 
@@ -773,8 +826,13 @@ function reduceTimelineToolCall(
     return appendTodoList(
       state,
       event.provider,
-      tasks.map((entry) => ({ text: entry.text, completed: entry.completed })),
+      tasks.map((entry) => ({
+        text: entry.text,
+        completed: entry.completed,
+        status: entry.status,
+      })),
       timestamp,
+      event.turnId,
     );
   }
 
@@ -865,8 +923,11 @@ function reduceTimelineEvent(
       const items: TodoEntry[] = (item.items ?? []).map((todo) => ({
         text: todo.text,
         completed: todo.completed,
+        status: todo.status,
       }));
-      return finalizeActiveThoughts(appendTodoList(state, event.provider, items, timestamp));
+      return finalizeActiveThoughts(
+        appendTodoList(state, event.provider, items, timestamp, event.turnId),
+      );
     }
     case "error": {
       const activity: ActivityLogItem = {

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -337,12 +337,14 @@ export interface CompactionTimelineItem {
   preTokens?: number;
 }
 
+export type AgentTodoStatus = "pending" | "in_progress" | "completed";
+
 export type AgentTimelineItem =
   | { type: "user_message"; text: string; messageId?: string; clientMessageId?: string }
   | { type: "assistant_message"; text: string; messageId?: string }
   | { type: "reasoning"; text: string }
   | ToolCallTimelineItem
-  | { type: "todo"; items: { text: string; completed: boolean }[] }
+  | { type: "todo"; items: { text: string; completed: boolean; status?: AgentTodoStatus }[] }
   | { type: "error"; message: string }
   | CompactionTimelineItem;
 

--- a/packages/protocol/src/messages.stream-parsing.test.ts
+++ b/packages/protocol/src/messages.stream-parsing.test.ts
@@ -195,6 +195,74 @@ describe("shared messages stream parsing", () => {
     }
   });
 
+  it("parses legacy and explicit-status todo timeline payloads", () => {
+    const legacyParsed = AgentStreamMessageSchema.parse({
+      type: "agent_stream",
+      payload: {
+        agentId: "agent_live",
+        timestamp: "2026-02-08T20:10:00.000Z",
+        event: {
+          type: "timeline",
+          provider: "grok",
+          item: {
+            type: "todo",
+            items: [
+              { text: "Legacy done", completed: true },
+              { text: "Legacy open", completed: false },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(legacyParsed.payload.event.type).toBe("timeline");
+    if (legacyParsed.payload.event.type !== "timeline") {
+      throw new Error("Expected timeline event");
+    }
+    expect(legacyParsed.payload.event.item).toEqual({
+      type: "todo",
+      items: [
+        { text: "Legacy done", completed: true },
+        { text: "Legacy open", completed: false },
+      ],
+    });
+
+    const statusParsed = AgentStreamMessageSchema.parse({
+      type: "agent_stream",
+      payload: {
+        agentId: "agent_live",
+        timestamp: "2026-02-08T20:10:00.000Z",
+        event: {
+          type: "timeline",
+          provider: "grok",
+          turnId: "turn-todo-status",
+          item: {
+            type: "todo",
+            items: [
+              { text: "Pending", completed: false, status: "pending" },
+              { text: "Active", completed: false, status: "in_progress" },
+              { text: "Done", completed: true, status: "completed" },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(statusParsed.payload.event.type).toBe("timeline");
+    if (statusParsed.payload.event.type !== "timeline") {
+      throw new Error("Expected timeline event");
+    }
+    expect(statusParsed.payload.event.turnId).toBe("turn-todo-status");
+    expect(statusParsed.payload.event.item).toEqual({
+      type: "todo",
+      items: [
+        { text: "Pending", completed: false, status: "pending" },
+        { text: "Active", completed: false, status: "in_progress" },
+        { text: "Done", completed: true, status: "completed" },
+      ],
+    });
+  });
+
   it("parses optional permission actions and selectedActionId compatibly", () => {
     const requestParsed = AgentStreamMessageSchema.parse({
       type: "agent_stream",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -588,6 +588,7 @@ export const AgentTimelineItemPayloadSchema: z.ZodType<AgentTimelineItem, unknow
       z.object({
         text: z.string(),
         completed: z.boolean(),
+        status: z.enum(["pending", "in_progress", "completed"]).optional(),
       }),
     ),
   }),
@@ -633,6 +634,7 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("timeline"),
     provider: AgentProviderSchema,
+    turnId: z.string().optional(),
     item: AgentTimelineItemPayloadSchema,
   }),
   z.object({
@@ -3429,6 +3431,7 @@ export const AgentTimelineEntryPayloadSchema = z.object({
   provider: AgentProviderSchema,
   item: AgentTimelineItemPayloadSchema,
   timestamp: z.string(),
+  turnId: z.string().optional(),
   seqStart: z.number().int().nonnegative(),
   seqEnd: z.number().int().nonnegative(),
   sourceSeqRanges: z.array(AgentTimelineSeqRangeSchema),

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -534,6 +534,7 @@ function buildImportedTimelineRows(entries: readonly ImportedTimelineEntry[]): A
       seq: rows.length + 1,
       timestamp: entry.timestamp ?? new Date().toISOString(),
       item: limitAgentTimelineItemContent(entry.item),
+      ...(entry.turnId !== undefined ? { turnId: entry.turnId } : {}),
     });
   }
   return rows;
@@ -1922,7 +1923,11 @@ export class AgentManager {
       // for live subscribers. Other event types are broadcast only.
       if (event.type === "timeline") {
         this.touchUpdatedAt(agent);
-        const row = this.recordTimeline(agent.id, event.item);
+        const row = this.recordTimeline(
+          agent.id,
+          event.item,
+          event.turnId !== undefined ? { turnId: event.turnId } : undefined,
+        );
         this.dispatchStream(agent.id, event, {
           seq: row.seq,
           epoch: this.timelineStore.getEpoch(agent.id),
@@ -3220,11 +3225,10 @@ export class AgentManager {
       }
     }
     for (const event of historyEvents) {
-      const row = this.recordTimeline(
-        agent.id,
-        event.item,
-        event.timestamp ? { timestamp: event.timestamp } : undefined,
-      );
+      const row = this.recordTimeline(agent.id, event.item, {
+        ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+        ...(event.turnId !== undefined ? { turnId: event.turnId } : {}),
+      });
       if (broadcast) {
         this.dispatchStream(agent.id, event, {
           seq: row.seq,
@@ -3257,11 +3261,10 @@ export class AgentManager {
         if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
           continue;
         }
-        this.recordTimeline(
-          agent.id,
-          event.item,
-          event.timestamp ? { timestamp: event.timestamp } : undefined,
-        );
+        this.recordTimeline(agent.id, event.item, {
+          ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+          ...(event.turnId !== undefined ? { turnId: event.turnId } : {}),
+        });
       }
     } catch {
       // ignore history failures
@@ -3521,11 +3524,10 @@ export class AgentManager {
     }
 
     if (options?.fromHistory) {
-      this.recordTimeline(
-        agent.id,
-        event.item,
-        event.timestamp ? { timestamp: event.timestamp } : undefined,
-      );
+      this.recordTimeline(agent.id, event.item, {
+        ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+        ...(event.turnId !== undefined ? { turnId: event.turnId } : {}),
+      });
       flags.shouldDispatchEvent = false;
       flags.shouldNotifyWaiters = false;
       return;
@@ -3717,7 +3719,7 @@ export class AgentManager {
     provider: AgentProvider,
     turnId?: string,
   ): AgentStreamEvent {
-    const row = this.recordTimeline(agentId, item);
+    const row = this.recordTimeline(agentId, item, turnId !== undefined ? { turnId } : undefined);
     const event: AgentStreamEvent = {
       type: "timeline",
       item,
@@ -3802,7 +3804,7 @@ export class AgentManager {
   private recordTimeline(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string },
+    options?: { timestamp?: string; turnId?: string },
   ): AgentTimelineRow {
     item = limitAgentTimelineItemContent(item);
     const row = this.timelineStore.append(agentId, item, options);

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -540,6 +540,7 @@ export interface ImportProviderSessionContext {
 export interface ImportedTimelineEntry {
   item: AgentTimelineItem;
   timestamp?: string;
+  turnId?: string;
 }
 
 export interface ImportedProviderSession {

--- a/packages/server/src/server/agent/agent-timeline-store-types.ts
+++ b/packages/server/src/server/agent/agent-timeline-store-types.ts
@@ -4,6 +4,7 @@ export interface AgentTimelineRow {
   seq: number;
   timestamp: string;
   item: AgentTimelineItem;
+  turnId?: string;
 }
 
 export interface AgentTimelineCursor {
@@ -46,7 +47,7 @@ export interface AgentTimelineStore {
   appendCommitted(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string },
+    options?: { timestamp?: string; turnId?: string },
   ): Promise<AgentTimelineRow>;
   fetchCommitted(
     agentId: string,

--- a/packages/server/src/server/agent/agent-timeline-store.test.ts
+++ b/packages/server/src/server/agent/agent-timeline-store.test.ts
@@ -50,4 +50,42 @@ describe("InMemoryAgentTimelineStore", () => {
       ],
     });
   });
+
+  it("preserves optional turnId on append and fetch", () => {
+    const store = new InMemoryAgentTimelineStore();
+    store.initialize("agent-1", {
+      epoch: "epoch-1",
+      nextSeq: 1,
+      rows: [],
+    });
+
+    const withTurn = store.append(
+      "agent-1",
+      { type: "todo", items: [{ text: "one", completed: false }] },
+      { timestamp: "2026-01-01T00:00:00.000Z", turnId: "turn-1" },
+    );
+    const withoutTurn = store.append(
+      "agent-1",
+      { type: "assistant_message", text: "done" },
+      { timestamp: "2026-01-01T00:00:01.000Z" },
+    );
+
+    expect(withTurn.turnId).toBe("turn-1");
+    expect(withoutTurn.turnId).toBeUndefined();
+
+    const fetched = store.fetch("agent-1", { direction: "tail", limit: 10 });
+    expect(fetched.rows).toEqual([
+      {
+        seq: 1,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        item: { type: "todo", items: [{ text: "one", completed: false }] },
+        turnId: "turn-1",
+      },
+      {
+        seq: 2,
+        timestamp: "2026-01-01T00:00:01.000Z",
+        item: { type: "assistant_message", text: "done" },
+      },
+    ]);
+  });
 });

--- a/packages/server/src/server/agent/agent-timeline-store.ts
+++ b/packages/server/src/server/agent/agent-timeline-store.ts
@@ -235,13 +235,14 @@ export class InMemoryAgentTimelineStore {
   append(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string },
+    options?: { timestamp?: string; turnId?: string },
   ): AgentTimelineRow {
     const state = this.requireState(agentId);
     const row: AgentTimelineRow = {
       seq: state.nextSeq,
       timestamp: options?.timestamp ?? new Date().toISOString(),
       item,
+      ...(options?.turnId !== undefined ? { turnId: options.turnId } : {}),
     };
     state.nextSeq += 1;
     state.rows.push(row);

--- a/packages/server/src/server/agent/provider-session-import.ts
+++ b/packages/server/src/server/agent/provider-session-import.ts
@@ -78,6 +78,7 @@ async function collectImportedHistory(events: AsyncGenerator<AgentStreamEvent>):
     timeline.push({
       item: event.item,
       ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+      ...(event.turnId !== undefined ? { turnId: event.turnId } : {}),
     });
   }
   return { timeline, providerSubagentEvents };

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -3058,6 +3058,7 @@ function mapPlanToTimeline(plan: Plan): AgentTimelineItem {
     items: plan.entries.map((entry) => ({
       text: entry.content,
       completed: entry.status === "completed",
+      status: entry.status,
     })),
   };
 }

--- a/packages/server/src/server/agent/timeline-projection.test.ts
+++ b/packages/server/src/server/agent/timeline-projection.test.ts
@@ -119,6 +119,46 @@ describe("projectTimelineRows", () => {
     expect(projected[0]?.collapsed).toContain("reasoning_merge");
   });
 
+  test("does not merge adjacent text chunks across turns", () => {
+    const rows: AgentTimelineRow[] = [
+      {
+        seq: 1,
+        timestamp: "2026-02-13T00:00:00.000Z",
+        turnId: "turn-1",
+        item: { type: "assistant_message", text: "First answer" },
+      },
+      {
+        seq: 2,
+        timestamp: "2026-02-13T00:00:00.100Z",
+        turnId: "turn-2",
+        item: { type: "assistant_message", text: "Second answer" },
+      },
+      {
+        seq: 3,
+        timestamp: "2026-02-13T00:00:00.200Z",
+        turnId: "turn-1",
+        item: { type: "reasoning", text: "First thought" },
+      },
+      {
+        seq: 4,
+        timestamp: "2026-02-13T00:00:00.300Z",
+        turnId: "turn-2",
+        item: { type: "reasoning", text: "Second thought" },
+      },
+    ];
+
+    const projected = projectTimelineRows({ rows, mode: "projected" });
+
+    expect(projected).toHaveLength(4);
+    expect(projected.map((entry) => entry.turnId)).toEqual([
+      "turn-1",
+      "turn-2",
+      "turn-1",
+      "turn-2",
+    ]);
+    expect(projected.map((entry) => entry.collapsed)).toEqual([[], [], [], []]);
+  });
+
   test("collapses tool lifecycle by callId and reports exact source seq ranges", () => {
     const rows: AgentTimelineRow[] = [
       {

--- a/packages/server/src/server/agent/timeline-projection.ts
+++ b/packages/server/src/server/agent/timeline-projection.ts
@@ -14,6 +14,7 @@ export type TimelineLimitDirection = "tail" | "before" | "after";
 export interface TimelineProjectionEntry {
   item: AgentTimelineItem;
   timestamp: string;
+  turnId?: string;
   seqStart: number;
   seqEnd: number;
   sourceSeqRanges: TimelineSeqRange[];
@@ -111,6 +112,7 @@ function makeCanonicalEntries(rows: readonly AgentTimelineRow[]): WorkingEntry[]
   return rows.map((row) => ({
     item: row.item,
     timestamp: row.timestamp,
+    ...(row.turnId !== undefined ? { turnId: row.turnId } : {}),
     seqStart: row.seq,
     seqEnd: row.seq,
     sourceSeqRanges: [{ startSeq: row.seq, endSeq: row.seq }],
@@ -169,6 +171,7 @@ function mergeReasoningChunks(entries: readonly WorkingEntry[]): WorkingEntry[] 
       previous &&
       previous.item.type === "reasoning" &&
       entry.item.type === "reasoning" &&
+      previous.turnId === entry.turnId &&
       previous.seqEnd + 1 === entry.seqStart;
 
     if (!shouldMerge || !previous) {
@@ -209,6 +212,7 @@ function mergeAssistantChunks(entries: readonly WorkingEntry[]): WorkingEntry[] 
       previous &&
       previous.item.type === "assistant_message" &&
       entry.item.type === "assistant_message" &&
+      previous.turnId === entry.turnId &&
       previous.seqEnd + 1 === entry.seqStart;
 
     if (!shouldMerge || !previous) {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -5854,6 +5854,7 @@ export class Session {
             provider: snapshot.provider,
             item: entry.item,
             timestamp: entry.timestamp,
+            turnId: entry.turnId,
             seqStart: entry.seqStart,
             seqEnd: entry.seqEnd,
             sourceSeqRanges: entry.sourceSeqRanges,

--- a/packages/server/src/server/wire-compat.test.ts
+++ b/packages/server/src/server/wire-compat.test.ts
@@ -224,16 +224,19 @@ function createSessionForWireCompatTest(options?: {
     {
       seq: 1,
       timestamp: "2026-05-02T00:00:00.000Z",
+      turnId: "turn-wire-1",
       item: { type: "reasoning", text: "Step " },
     },
     {
       seq: 2,
       timestamp: "2026-05-02T00:00:00.100Z",
+      turnId: "turn-wire-1",
       item: { type: "reasoning", text: "by step" },
     },
     {
       seq: 3,
       timestamp: "2026-05-02T00:00:00.200Z",
+      turnId: "turn-wire-1",
       item: { type: "assistant_message", text: "done" },
     },
   ];
@@ -464,6 +467,32 @@ describe("wire compatibility", () => {
 
     const currentParsed = FetchAgentTimelineResponseMessageSchema.parse(response);
     expect(currentParsed.payload.entries[0]?.collapsed).toContain("reasoning_merge");
+  });
+
+  test("projects optional entry turnId for current clients while legacy schema still parses", async () => {
+    // Default clients strip reasoning_merge from collapsed, matching the legacy enum set.
+    const response = await emitTimelineResponse();
+
+    // Session emits turnId on projected entries before any client schema strip.
+    expect(response.payload.entries.map((entry) => entry.turnId)).toEqual([
+      "turn-wire-1",
+      "turn-wire-1",
+    ]);
+    expect(response.payload.entries[0]?.item).toEqual({
+      type: "reasoning",
+      text: "Step by step",
+    });
+    expect(response.payload.entries[0]?.collapsed).toEqual([]);
+
+    // Current and legacy schemas both accept the payload (unknown optional fields strip).
+    expect(() => FetchAgentTimelineResponseMessageSchema.parse(response)).not.toThrow();
+    const legacyParsed = LegacyFetchAgentTimelineResponseMessageSchema.parse(response);
+    expect(legacyParsed.payload.entries).toHaveLength(2);
+    expect(
+      legacyParsed.payload.entries.every(
+        (entry) => !Object.prototype.hasOwnProperty.call(entry, "turnId"),
+      ),
+    ).toBe(true);
   });
 
   test("sub_agent tool-call payload still parses against the v0.1.65-beta.3 schema", () => {


### PR DESCRIPTION
### Linked issue

Related: #617 (todos as a first-class cross-provider entity) — this PR is a step in that direction (per-item status, stable per-turn identity), but does not close it. No dedicated issue exists yet; happy to open one describing the problem if you'd prefer discussion there first.

### Type of change

- [x] New feature (with prior issue + design alignment)

### What does this PR do

Two problems today:

1. Providers that update a todo list mid-turn (interleaved with reasoning/tool events) create a new todo card per update, because the client only coalesces when the todo is the *last* stream item.
2. Todo items only carry `completed: boolean`, so "in progress" state is lost.

Server-side timeline events already carry `turnId` (Claude and the ACP base both stamp it) — it just never reached persistence or the wire. This PR threads it through:

- **Protocol:** optional `turnId` on timeline stream events / timeline entry payloads; optional `status` (`pending` | `in_progress` | `completed`) on todo items.
- **Server:** timeline store, session import, history replay, and projection persist/propagate `turnId`; projection stops merging reasoning/assistant chunks across different turns.
- **Client:** todo cards coalesce in place per provider+turn; in-progress items show a spinner; the collapsed card's "next task" prefers the in-progress item.

This affects all providers that emit timeline events (Claude, Codex, OMP, Pi, all ACP), not just one. Extracted from #2289 so that PR stays Grok-only.

Protocol compat: new fields are `.optional()` only; no transforms in wire schemas; legacy-schema parse tests included both directions; the client's legacy-todo normalization carries a `COMPAT(todoStatus)` tag.

### How did you verify it

- Ran locally: `npm run build:client && npm run build:server`, `npm run typecheck`, `npm run lint`, `npm run format`.
- Targeted unit suites (174 tests): `messages.stream-parsing`, `agent-timeline-store`, `timeline-projection`, `wire-compat`, `stream`, `session-stream-reducers` — including new cases for legacy payloads without `status`/`turnId` parsing in both directions, per-turn coalescing across interleaved events, and no cross-turn chunk merging.
- CI is green on this branch.
- **Not yet done:** visual verification of the in-progress spinner across platforms. Screenshots for the affected platforms will be added before this leaves draft; keeping it draft until then.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform (pending — reason PR is draft)
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)
