### PR TITLE
fix(acp): use tool title for display name when kind is missing or other

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,6 +10,8 @@ Extend `ACPAgentClient` from `packages/server/src/server/agent/providers/acp-age
 
 The only built-in ACP provider today is `copilot` (`copilot-acp-agent.ts`). `GenericACPAgentClient` (`generic-acp-agent.ts`) is also ACP-based but is used for user-defined custom providers configured via `extends: "acp"` overrides — see [docs/custom-providers.md](custom-providers.md).
 
+Tool cards use `kind` as the display name when it is a concrete ACP kind; when `kind` is missing or `other`, the base class prefers the tool `title` so cards are not labeled "Other".
+
 Copilot custom agents are exposed through ACP session config, not the slash-command list. When custom agents are available, Copilot returns a select config option with `id: "agent"` and `category: "_agent"`; Paseo maps that to the `agent` provider feature. Copilot uses the agent display name as the option value, and the blank value means the default Copilot agent.
 
 ### Direct

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -27,6 +27,7 @@ import {
   mapACPUsage,
   resolveACPModeSelection,
   resolveACPModelSelection,
+  resolveAcpToolCallName,
   summarizeACPRequestError,
 } from "./acp-agent.js";
 import type { ProcessTerminator, TreeKillTarget } from "../../../utils/tree-kill.js";
@@ -2992,5 +2993,46 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
       cwd: "/tmp/paseo-acp-test",
       mcpServers: [],
     });
+  });
+});
+
+describe("resolveAcpToolCallName", () => {
+  test("uses title when kind is other", () => {
+    expect(
+      resolveAcpToolCallName({
+        toolCallId: "call-1",
+        title: "Web search",
+        kind: "other",
+      } as never),
+    ).toBe("Web search");
+  });
+
+  test("uses title when kind is missing", () => {
+    expect(
+      resolveAcpToolCallName({
+        toolCallId: "call-2",
+        title: "Custom tool",
+      } as never),
+    ).toBe("Custom tool");
+  });
+
+  test("falls back to toolCallId when title and kind are empty", () => {
+    expect(
+      resolveAcpToolCallName({
+        toolCallId: "call-3",
+        title: "   ",
+        kind: "",
+      } as never),
+    ).toBe("call-3");
+  });
+
+  test("uses kind for normal tool kinds", () => {
+    expect(
+      resolveAcpToolCallName({
+        toolCallId: "call-4",
+        title: "Read a file",
+        kind: "read",
+      } as never),
+    ).toBe("read");
   });
 });

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -3062,6 +3062,17 @@ function mapPlanToTimeline(plan: Plan): AgentTimelineItem {
   };
 }
 
+export function resolveAcpToolCallName(snapshot: ACPToolSnapshot): string {
+  const kind = typeof snapshot.kind === "string" ? snapshot.kind.trim() : "";
+  const title = snapshot.title.trim();
+  // Generic ACP "other" (and missing kind) should not become the display label
+  // "Other" — prefer the human title agents put on the tool.
+  if (!kind || kind === "other") {
+    return title || kind || snapshot.toolCallId;
+  }
+  return kind;
+}
+
 function mapToolSnapshotToTimeline(
   snapshot: ACPToolSnapshot,
   terminals: Map<string, TerminalEntry>,
@@ -3071,7 +3082,7 @@ function mapToolSnapshotToTimeline(
   const base = {
     type: "tool_call" as const,
     callId: snapshot.toolCallId,
-    name: snapshot.kind ?? snapshot.title,
+    name: resolveAcpToolCallName(snapshot),
     detail,
     metadata: {
       kind: snapshot.kind ?? undefined,


### PR DESCRIPTION
### Linked issue

None yet — this is a small, objective display fix. Happy to file one if you'd like it tracked.

### Type of change

- [x] Bug fix

### What does this PR do

ACP tool cards use `kind` as the display name (`name: snapshot.kind ?? snapshot.title`), so any tool the agent reports with `kind: "other"` — or no kind at all — renders as a card literally labeled "Other", even when the tool has a descriptive title.

This adds `resolveAcpToolCallName`: concrete kinds (`read`, `edit`, …) keep using `kind`; when kind is missing or `"other"`, the human `title` is used, falling back to `toolCallId` if both are empty.

This affects every ACP provider (Copilot, Cursor, Kiro, Trae, custom `extends: "acp"`). Extracted from #2289 so that PR stays Grok-only; this fix stands on its own.

### How did you verify it

- Added 4 unit cases in `acp-agent.test.ts` covering: kind `"other"` → title, missing kind → title, empty title+kind → toolCallId, concrete kind → kind.
- Ran locally: `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1` (81 tests pass), `npm run typecheck`, `npm run lint`, `npm run format`.
- CI is green on this branch.
- Not visually re-verified in a running app — the change is a pure display-name string; no layout changes.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)
