### PR TITLE
fix(server): recover agent logs when cwd is gone

### DIFF
--- a/packages/server/src/server/agent/agent-cwd.test.ts
+++ b/packages/server/src/server/agent/agent-cwd.test.ts
@@ -5,10 +5,13 @@ import { afterEach, describe, expect, test } from "vitest";
 
 import {
   assertAgentCwdExists,
+  assertAgentCwdExistsSync,
   isMissingAgentCwdError,
   MISSING_AGENT_CWD_ERROR_CODE,
   MissingAgentCwdError,
   pathIsExistingDirectory,
+  pathIsExistingDirectorySync,
+  resolveSafeReadRecoveryCwd,
 } from "./agent-cwd.js";
 
 const tempDirs: string[] = [];
@@ -81,6 +84,13 @@ describe("agent-cwd", () => {
         expect(missingError.message).not.toMatch(/\bENOTDIR\b|\bENOENT\b/);
         return true;
       });
+      expect(() => assertAgentCwdExistsSync(agentId, path)).toThrow(MissingAgentCwdError);
+      expect(pathIsExistingDirectorySync(path)).toBe(false);
     }
+  });
+
+  test("resolveSafeReadRecoveryCwd returns an existing directory", () => {
+    const safe = resolveSafeReadRecoveryCwd();
+    expect(pathIsExistingDirectorySync(safe)).toBe(true);
   });
 });

--- a/packages/server/src/server/agent/agent-cwd.test.ts
+++ b/packages/server/src/server/agent/agent-cwd.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -12,6 +12,15 @@ import {
 } from "./agent-cwd.js";
 
 const tempDirs: string[] = [];
+
+/** Build a cwd path whose ancestor is a file so stat() raises ENOTDIR. */
+function enotdirCwd(): string {
+  const dir = mkdtempSync(join(tmpdir(), "paseo-agent-cwd-enotdir-"));
+  tempDirs.push(dir);
+  const fileAncestor = join(dir, "not-a-dir");
+  writeFileSync(fileAncestor, "x");
+  return join(fileAncestor, "worktree", "agent-cwd");
+}
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
@@ -49,13 +58,29 @@ describe("agent-cwd", () => {
     await expect(assertAgentCwdExists("agent-ok", dir)).resolves.toBeUndefined();
   });
 
-  test("pathIsExistingDirectory treats ENOTDIR path components as missing", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "paseo-agent-cwd-file-"));
-    tempDirs.push(dir);
-    const filePath = join(dir, "not-a-dir");
-    const { writeFileSync } = await import("node:fs");
-    writeFileSync(filePath, "x");
-    // Path under a file component raises ENOTDIR on stat in most platforms.
-    expect(await pathIsExistingDirectory(join(filePath, "child"))).toBe(false);
+  test("ENOENT and ENOTDIR are both treated as missing cwd", async () => {
+    const enotdirPath = enotdirCwd();
+    const enoentPath = join(tmpdir(), `paseo-enoent-cwd-${Date.now()}`);
+
+    // pathIsExistingDirectory: both shapes are false (not raw FS throws).
+    expect(await pathIsExistingDirectory(enoentPath)).toBe(false);
+    expect(await pathIsExistingDirectory(enotdirPath)).toBe(false);
+
+    // assertAgentCwdExists: both become structured MissingAgentCwdError.
+    for (const [label, agentId, path] of [
+      ["ENOENT", "agent-missing-path", enoentPath],
+      ["ENOTDIR", "agent-file-ancestor", enotdirPath],
+    ] as const) {
+      await expect(assertAgentCwdExists(agentId, path)).rejects.toSatisfy((error: unknown) => {
+        expect(isMissingAgentCwdError(error), `${label} must be MissingAgentCwdError`).toBe(true);
+        const missingError = error as MissingAgentCwdError;
+        expect(missingError.message).toContain("working directory is missing");
+        expect(missingError.message).toMatch(/Recreate the worktree|rebind the agent cwd/i);
+        expect(missingError.message).not.toMatch(/\bAgent not found\b/i);
+        // Must not leak raw filesystem errno strings into operator-facing text.
+        expect(missingError.message).not.toMatch(/\bENOTDIR\b|\bENOENT\b/);
+        return true;
+      });
+    }
   });
 });

--- a/packages/server/src/server/agent/agent-cwd.test.ts
+++ b/packages/server/src/server/agent/agent-cwd.test.ts
@@ -1,0 +1,51 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  assertAgentCwdExists,
+  isMissingAgentCwdError,
+  MISSING_AGENT_CWD_ERROR_CODE,
+  MissingAgentCwdError,
+  pathIsExistingDirectory,
+} from "./agent-cwd.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("agent-cwd", () => {
+  test("pathIsExistingDirectory is true for real directories and false for missing paths", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "paseo-agent-cwd-"));
+    tempDirs.push(dir);
+    expect(await pathIsExistingDirectory(dir)).toBe(true);
+    expect(await pathIsExistingDirectory(join(dir, "does-not-exist"))).toBe(false);
+  });
+
+  test("assertAgentCwdExists throws a structured MissingAgentCwdError", async () => {
+    const missing = join(tmpdir(), `paseo-missing-cwd-${Date.now()}`);
+    await expect(assertAgentCwdExists("agent-123", missing)).rejects.toSatisfy((error: unknown) => {
+      expect(isMissingAgentCwdError(error)).toBe(true);
+      expect(error).toBeInstanceOf(MissingAgentCwdError);
+      const missingError = error as MissingAgentCwdError;
+      expect(missingError.code).toBe(MISSING_AGENT_CWD_ERROR_CODE);
+      expect(missingError.agentId).toBe("agent-123");
+      expect(missingError.message).toContain("agent-123");
+      expect(missingError.message).toContain("working directory is missing");
+      expect(missingError.message).toContain("Recreate the worktree");
+      expect(missingError.message).not.toMatch(/Agent not found/i);
+      return true;
+    });
+  });
+
+  test("assertAgentCwdExists accepts an existing directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "paseo-agent-cwd-ok-"));
+    tempDirs.push(dir);
+    await expect(assertAgentCwdExists("agent-ok", dir)).resolves.toBeUndefined();
+  });
+});

--- a/packages/server/src/server/agent/agent-cwd.test.ts
+++ b/packages/server/src/server/agent/agent-cwd.test.ts
@@ -48,4 +48,14 @@ describe("agent-cwd", () => {
     tempDirs.push(dir);
     await expect(assertAgentCwdExists("agent-ok", dir)).resolves.toBeUndefined();
   });
+
+  test("pathIsExistingDirectory treats ENOTDIR path components as missing", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "paseo-agent-cwd-file-"));
+    tempDirs.push(dir);
+    const filePath = join(dir, "not-a-dir");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(filePath, "x");
+    // Path under a file component raises ENOTDIR on stat in most platforms.
+    expect(await pathIsExistingDirectory(join(filePath, "child"))).toBe(false);
+  });
 });

--- a/packages/server/src/server/agent/agent-cwd.ts
+++ b/packages/server/src/server/agent/agent-cwd.ts
@@ -37,16 +37,22 @@ export function isMissingAgentCwdError(error: unknown): error is MissingAgentCwd
   );
 }
 
+function isMissingPathFsError(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) {
+    return false;
+  }
+  const code = (error as NodeJS.ErrnoException).code;
+  // ENOENT: path missing. ENOTDIR: a path component is not a directory (also
+  // unusable as a worktree cwd).
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
 export async function pathIsExistingDirectory(path: string): Promise<boolean> {
   try {
     const stats = await stat(path);
     return stats.isDirectory();
   } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      (error as NodeJS.ErrnoException).code === "ENOENT"
-    ) {
+    if (isMissingPathFsError(error)) {
       return false;
     }
     throw error;
@@ -65,11 +71,7 @@ export async function assertAgentCwdExists(agentId: string, cwd: string): Promis
     if (isMissingAgentCwdError(error)) {
       throw error;
     }
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      (error as NodeJS.ErrnoException).code === "ENOENT"
-    ) {
+    if (isMissingPathFsError(error)) {
       throw new MissingAgentCwdError(agentId, absoluteCwd);
     }
     throw error;

--- a/packages/server/src/server/agent/agent-cwd.ts
+++ b/packages/server/src/server/agent/agent-cwd.ts
@@ -1,4 +1,6 @@
+import { existsSync, statSync } from "node:fs";
 import { stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
 export const MISSING_AGENT_CWD_ERROR_CODE = "AGENT_CWD_MISSING" as const;
@@ -76,4 +78,41 @@ export async function assertAgentCwdExists(agentId: string, cwd: string): Promis
     }
     throw error;
   }
+}
+
+/**
+ * Sync twin of pathIsExistingDirectory for run-path guards that must not start
+ * provider work when the recorded worktree is gone.
+ */
+export function pathIsExistingDirectorySync(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch (error) {
+    if (isMissingPathFsError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/** Sync twin of assertAgentCwdExists for AgentManager run entrypoints. */
+export function assertAgentCwdExistsSync(agentId: string, cwd: string): void {
+  const absoluteCwd = resolve(cwd);
+  if (!pathIsExistingDirectorySync(absoluteCwd)) {
+    throw new MissingAgentCwdError(agentId, absoluteCwd);
+  }
+}
+
+/**
+ * Existing directory used only as the provider launch cwd when recovering
+ * timeline/logs for an agent whose recorded worktree is gone. Must never be
+ * written back as the managed/stored agent cwd.
+ */
+export function resolveSafeReadRecoveryCwd(): string {
+  const candidate = resolve(tmpdir());
+  if (existsSync(candidate) && statSync(candidate).isDirectory()) {
+    return candidate;
+  }
+  // Extremely defensive: process.cwd() is expected to exist for the daemon.
+  return resolve(process.cwd());
 }

--- a/packages/server/src/server/agent/agent-cwd.ts
+++ b/packages/server/src/server/agent/agent-cwd.ts
@@ -1,0 +1,77 @@
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+
+export const MISSING_AGENT_CWD_ERROR_CODE = "AGENT_CWD_MISSING" as const;
+
+/**
+ * Structured, actionable error when an existing agent still has a record but
+ * its recorded working directory/worktree has been deleted. Callers must not
+ * collapse this into generic "Agent not found".
+ */
+export class MissingAgentCwdError extends Error {
+  readonly code = MISSING_AGENT_CWD_ERROR_CODE;
+  readonly agentId: string;
+  readonly cwd: string;
+
+  constructor(agentId: string, cwd: string) {
+    const absoluteCwd = resolve(cwd);
+    super(
+      [
+        `Agent ${agentId} exists but its working directory is missing: ${absoluteCwd}.`,
+        "Recreate the worktree or rebind the agent cwd, then retry send/continue.",
+        "Timeline/logs can still be read when durable or in-memory history is available.",
+      ].join(" "),
+    );
+    this.name = "MissingAgentCwdError";
+    this.agentId = agentId;
+    this.cwd = absoluteCwd;
+  }
+}
+
+export function isMissingAgentCwdError(error: unknown): error is MissingAgentCwdError {
+  return (
+    error instanceof MissingAgentCwdError ||
+    (error instanceof Error &&
+      "code" in error &&
+      (error as { code?: unknown }).code === MISSING_AGENT_CWD_ERROR_CODE)
+  );
+}
+
+export async function pathIsExistingDirectory(path: string): Promise<boolean> {
+  try {
+    const stats = await stat(path);
+    return stats.isDirectory();
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/** Throws MissingAgentCwdError when the agent cwd is gone; preserves other fs errors. */
+export async function assertAgentCwdExists(agentId: string, cwd: string): Promise<void> {
+  const absoluteCwd = resolve(cwd);
+  try {
+    const stats = await stat(absoluteCwd);
+    if (!stats.isDirectory()) {
+      throw new MissingAgentCwdError(agentId, absoluteCwd);
+    }
+  } catch (error) {
+    if (isMissingAgentCwdError(error)) {
+      throw error;
+    }
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      throw new MissingAgentCwdError(agentId, absoluteCwd);
+    }
+    throw error;
+  }
+}

--- a/packages/server/src/server/agent/agent-loading.test.ts
+++ b/packages/server/src/server/agent/agent-loading.test.ts
@@ -1,0 +1,159 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import { ensureAgentLoaded } from "./agent-loading.js";
+import { MissingAgentCwdError } from "./agent-cwd.js";
+import type { AgentManager, ManagedAgent } from "./agent-manager.js";
+import type { AgentStorage } from "./agent-storage.js";
+
+describe("ensureAgentLoaded missing cwd", () => {
+  test("resumes with allowMissingCwd and hydrates timeline for log recovery", async () => {
+    const missingCwd = join(tmpdir(), `paseo-loading-missing-${Date.now()}`);
+    const agent: ManagedAgent = Object.create(null);
+    Reflect.set(agent, "id", "agent-1");
+    Reflect.set(agent, "provider", "codex");
+    Reflect.set(agent, "cwd", missingCwd);
+    Reflect.set(agent, "lifecycle", "idle");
+
+    const resumeSpy = vi.fn(async () => agent);
+    const hydrateSpy = vi.fn(async () => undefined);
+    let live: ManagedAgent | null = null;
+    const agentManager = {
+      getAgent: vi.fn(() => live),
+      getRegisteredProviderIds: () => ["codex"],
+      resumeAgentFromPersistence: vi.fn(async (...args: unknown[]) => {
+        const result = await resumeSpy(...args);
+        live = result;
+        return result;
+      }),
+      createAgent: vi.fn(),
+      hydrateTimelineFromProvider: hydrateSpy,
+      touchAgentActivity: vi.fn(() => live),
+      waitForAgentClose: vi.fn(async () => undefined),
+    } as unknown as AgentManager;
+
+    const agentStorage = {
+      get: vi.fn(async () => ({
+        id: "agent-1",
+        provider: "codex",
+        cwd: missingCwd,
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+        lastActivityAt: "2026-07-01T00:00:00.000Z",
+        lastUserMessageAt: null,
+        persistence: {
+          provider: "codex",
+          sessionId: "thread-1",
+          metadata: { provider: "codex", cwd: missingCwd },
+        },
+        labels: {},
+      })),
+    } as unknown as AgentStorage;
+
+    const loaded = await ensureAgentLoaded("agent-1", {
+      agentManager,
+      agentStorage,
+      logger: createTestLogger(),
+      allowMissingCwd: true,
+    });
+
+    expect(loaded.id).toBe("agent-1");
+    expect(resumeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "thread-1" }),
+      expect.objectContaining({ cwd: missingCwd }),
+      "agent-1",
+      expect.objectContaining({ allowMissingCwd: true }),
+    );
+    expect(hydrateSpy).toHaveBeenCalledWith("agent-1");
+    expect(agentManager.createAgent).not.toHaveBeenCalled();
+  });
+
+  test("without allowMissingCwd, resume keeps require-cwd behavior", async () => {
+    const missingCwd = join(tmpdir(), `paseo-loading-strict-${Date.now()}`);
+    const resumeSpy = vi.fn(async () => {
+      throw new Error(`Working directory does not exist: ${missingCwd}`);
+    });
+    const agentManager = {
+      getAgent: vi.fn(() => null),
+      getRegisteredProviderIds: () => ["codex"],
+      resumeAgentFromPersistence: resumeSpy,
+      createAgent: vi.fn(),
+      hydrateTimelineFromProvider: vi.fn(),
+      touchAgentActivity: vi.fn(() => null),
+      waitForAgentClose: vi.fn(async () => undefined),
+    } as unknown as AgentManager;
+
+    const agentStorage = {
+      get: vi.fn(async () => ({
+        id: "agent-2",
+        provider: "codex",
+        cwd: missingCwd,
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+        lastActivityAt: "2026-07-01T00:00:00.000Z",
+        lastUserMessageAt: null,
+        persistence: {
+          provider: "codex",
+          sessionId: "thread-2",
+          metadata: { provider: "codex", cwd: missingCwd },
+        },
+        labels: {},
+      })),
+    } as unknown as AgentStorage;
+
+    await expect(
+      ensureAgentLoaded("agent-2", {
+        agentManager,
+        agentStorage,
+        logger: createTestLogger(),
+      }),
+    ).rejects.toThrow("Working directory does not exist");
+
+    expect(resumeSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "agent-2",
+      expect.objectContaining({ allowMissingCwd: false }),
+    );
+  });
+
+  test("create-from-storage path throws MissingAgentCwdError when cwd is gone", async () => {
+    const missingCwd = join(tmpdir(), `paseo-loading-create-${Date.now()}`);
+    const agentManager = {
+      getAgent: vi.fn(() => null),
+      getRegisteredProviderIds: () => ["codex"],
+      resumeAgentFromPersistence: vi.fn(),
+      createAgent: vi.fn(),
+      hydrateTimelineFromProvider: vi.fn(),
+      touchAgentActivity: vi.fn(() => null),
+      waitForAgentClose: vi.fn(async () => undefined),
+    } as unknown as AgentManager;
+
+    const agentStorage = {
+      get: vi.fn(async () => ({
+        id: "agent-3",
+        provider: "codex",
+        cwd: missingCwd,
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+        lastActivityAt: "2026-07-01T00:00:00.000Z",
+        lastUserMessageAt: null,
+        persistence: null,
+        labels: {},
+      })),
+    } as unknown as AgentStorage;
+
+    await expect(
+      ensureAgentLoaded("agent-3", {
+        agentManager,
+        agentStorage,
+        logger: createTestLogger(),
+        allowMissingCwd: true,
+      }),
+    ).rejects.toBeInstanceOf(MissingAgentCwdError);
+
+    expect(agentManager.createAgent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/server/agent/agent-loading.test.ts
+++ b/packages/server/src/server/agent/agent-loading.test.ts
@@ -1,12 +1,29 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { createTestLogger } from "../../test-utils/test-logger.js";
 import { ensureAgentLoaded } from "./agent-loading.js";
-import { MissingAgentCwdError } from "./agent-cwd.js";
+import { MissingAgentCwdError, pathIsExistingDirectory } from "./agent-cwd.js";
 import type { AgentManager, ManagedAgent } from "./agent-manager.js";
 import type { AgentStorage } from "./agent-storage.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function enotdirCwd(): string {
+  const dir = mkdtempSync(join(tmpdir(), "paseo-loading-enotdir-"));
+  tempDirs.push(dir);
+  const fileAncestor = join(dir, "not-a-dir");
+  writeFileSync(fileAncestor, "x");
+  return join(fileAncestor, "worktree");
+}
 
 describe("ensureAgentLoaded missing cwd", () => {
   test("resumes with allowMissingCwd and hydrates timeline for log recovery", async () => {
@@ -67,6 +84,70 @@ describe("ensureAgentLoaded missing cwd", () => {
       expect.objectContaining({ allowMissingCwd: true }),
     );
     expect(hydrateSpy).toHaveBeenCalledWith("agent-1");
+    expect(agentManager.createAgent).not.toHaveBeenCalled();
+  });
+
+  test("ENOTDIR cwd still allows timeline recovery with allowMissingCwd", async () => {
+    const missingCwd = enotdirCwd();
+    expect(await pathIsExistingDirectory(missingCwd)).toBe(false);
+
+    const agent: ManagedAgent = Object.create(null);
+    Reflect.set(agent, "id", "agent-enotdir");
+    Reflect.set(agent, "provider", "codex");
+    Reflect.set(agent, "cwd", missingCwd);
+    Reflect.set(agent, "lifecycle", "idle");
+
+    const resumeSpy = vi.fn(async () => agent);
+    const hydrateSpy = vi.fn(async () => undefined);
+    let live: ManagedAgent | null = null;
+    const agentManager = {
+      getAgent: vi.fn(() => live),
+      getRegisteredProviderIds: () => ["codex"],
+      resumeAgentFromPersistence: vi.fn(async (...args: unknown[]) => {
+        const result = await resumeSpy(...args);
+        live = result;
+        return result;
+      }),
+      createAgent: vi.fn(),
+      hydrateTimelineFromProvider: hydrateSpy,
+      touchAgentActivity: vi.fn(() => live),
+      waitForAgentClose: vi.fn(async () => undefined),
+    } as unknown as AgentManager;
+
+    const agentStorage = {
+      get: vi.fn(async () => ({
+        id: "agent-enotdir",
+        provider: "codex",
+        cwd: missingCwd,
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+        lastActivityAt: "2026-07-01T00:00:00.000Z",
+        lastUserMessageAt: null,
+        persistence: {
+          provider: "codex",
+          sessionId: "thread-enotdir",
+          metadata: { provider: "codex", cwd: missingCwd },
+        },
+        labels: {},
+      })),
+    } as unknown as AgentStorage;
+
+    // Timeline/log path: allowMissingCwd must resume + hydrate rather than throw ENOTDIR.
+    const loaded = await ensureAgentLoaded("agent-enotdir", {
+      agentManager,
+      agentStorage,
+      logger: createTestLogger(),
+      allowMissingCwd: true,
+    });
+
+    expect(loaded.id).toBe("agent-enotdir");
+    expect(resumeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "thread-enotdir" }),
+      expect.objectContaining({ cwd: missingCwd }),
+      "agent-enotdir",
+      expect.objectContaining({ allowMissingCwd: true }),
+    );
+    expect(hydrateSpy).toHaveBeenCalledWith("agent-enotdir");
     expect(agentManager.createAgent).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/server/agent/agent-loading.ts
+++ b/packages/server/src/server/agent/agent-loading.ts
@@ -3,6 +3,7 @@ import type { Logger } from "pino";
 import type { AgentProvider } from "./agent-sdk-types.js";
 import type { AgentManager, ManagedAgent } from "./agent-manager.js";
 import type { AgentStorage } from "./agent-storage.js";
+import { MissingAgentCwdError, pathIsExistingDirectory } from "./agent-cwd.js";
 import {
   buildConfigOverrides,
   buildSessionConfig,
@@ -28,6 +29,11 @@ export interface EnsureAgentLoadedDeps {
   agentStorage: AgentStorage;
   validProviders?: Iterable<AgentProvider>;
   logger: Logger;
+  /**
+   * When true, resume an existing agent even if its recorded cwd is gone so
+   * timeline/logs can be recovered. Never use for send/continue or new work.
+   */
+  allowMissingCwd?: boolean;
 }
 
 export async function ensureUnarchivedAgentLoaded(
@@ -86,6 +92,7 @@ export async function ensureAgentLoaded(
     }
 
     const handle = toAgentPersistenceHandle(validProviders, record.persistence);
+    const cwdMissing = Boolean(record.cwd) && !(await pathIsExistingDirectory(record.cwd));
 
     let snapshot: ManagedAgent;
     if (handle) {
@@ -93,10 +100,17 @@ export async function ensureAgentLoaded(
         handle,
         buildConfigOverrides(record),
         agentId,
-        extractTimestamps(record),
+        {
+          ...extractTimestamps(record),
+          allowMissingCwd: deps.allowMissingCwd === true,
+        },
       );
       deps.logger.info({ agentId, provider: record.provider }, "Agent resumed from persistence");
     } else {
+      // createAgent is new work: always require a live cwd.
+      if (cwdMissing) {
+        throw new MissingAgentCwdError(agentId, record.cwd);
+      }
       const config = buildSessionConfig(record, {
         validProviders,
       });
@@ -111,7 +125,18 @@ export async function ensureAgentLoaded(
       deps.logger.info({ agentId, provider: record.provider }, "Agent created from stored config");
     }
 
-    await deps.agentManager.hydrateTimelineFromProvider(agentId);
+    try {
+      await deps.agentManager.hydrateTimelineFromProvider(agentId);
+    } catch (error) {
+      if (deps.allowMissingCwd && cwdMissing) {
+        deps.logger.warn(
+          { err: error, agentId, cwd: record.cwd },
+          "Timeline hydrate failed after missing-cwd resume; serving recovered session state",
+        );
+      } else {
+        throw error;
+      }
+    }
     return deps.agentManager.getAgent(agentId) ?? snapshot;
   })();
 

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -2129,6 +2129,47 @@ test("createAgent fails when cwd does not exist", async () => {
   ).rejects.toThrow("Working directory does not exist");
 });
 
+test("resumeAgentFromPersistence rejects missing cwd unless allowMissingCwd is set", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const client = new TestAgentClient();
+  const manager = new AgentManager({
+    clients: {
+      codex: client,
+    },
+    registry: storage,
+    logger,
+  });
+  const missingCwd = join(workdir, "deleted-worktree");
+  const agentId = "11111111-1111-4111-8111-111111111111";
+  const handle = {
+    provider: "codex" as const,
+    sessionId: "thread-missing-cwd",
+    metadata: {
+      provider: "codex",
+      cwd: missingCwd,
+    },
+  };
+
+  await expect(
+    manager.resumeAgentFromPersistence(handle, { cwd: missingCwd }, agentId),
+  ).rejects.toThrow("Working directory does not exist");
+  expect(client.resumeOverrides).toHaveLength(0);
+
+  const resumed = await manager.resumeAgentFromPersistence(handle, { cwd: missingCwd }, agentId, {
+    allowMissingCwd: true,
+  });
+  expect(resumed.id).toBe(agentId);
+  expect(resumed.cwd).toBe(missingCwd);
+  expect(client.resumeOverrides).toHaveLength(1);
+
+  // Timeline fetch must work after missing-cwd resume (logs path).
+  const timeline = manager.fetchTimeline(agentId, { direction: "tail", limit: 0 });
+  expect(timeline.rows).toEqual([]);
+  expect(timeline.window.nextSeq).toBeGreaterThanOrEqual(1);
+});
+
 test("createAgent reports configured providers when provider is unknown", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from "vitest";
 import { spawn } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -2161,13 +2161,92 @@ test("resumeAgentFromPersistence rejects missing cwd unless allowMissingCwd is s
     allowMissingCwd: true,
   });
   expect(resumed.id).toBe(agentId);
+  // Managed/recorded path stays the original missing worktree.
   expect(resumed.cwd).toBe(missingCwd);
+  expect(resumed.config.cwd).toBe(missingCwd);
   expect(client.resumeOverrides).toHaveLength(1);
+  // Provider resume must receive a real launch cwd (not the deleted worktree).
+  const launchCwd = client.resumeOverrides[0]?.cwd;
+  expect(launchCwd).toBeTruthy();
+  expect(launchCwd).not.toBe(missingCwd);
+  expect(existsSync(launchCwd!)).toBe(true);
 
   // Timeline fetch must work after missing-cwd resume (logs path).
   const timeline = manager.fetchTimeline(agentId, { direction: "tail", limit: 0 });
   expect(timeline.rows).toEqual([]);
   expect(timeline.window.nextSeq).toBeGreaterThanOrEqual(1);
+});
+
+test("read-recovered missing-cwd agent cannot start provider runs until path returns", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const missingCwd = join(workdir, "deleted-worktree");
+  const agentId = "22222222-2222-4222-8222-222222222222";
+
+  let startTurnCalls = 0;
+  class TrackingClient extends TestAgentClient {
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+      _launchContext?: AgentLaunchContext,
+    ): Promise<AgentSession> {
+      this.resumeOverrides.push(config);
+      const session = new TestAgentSession({
+        provider: this.provider,
+        cwd: config?.cwd ?? process.cwd(),
+      });
+      const originalStart = session.startTurn.bind(session);
+      session.startTurn = async () => {
+        startTurnCalls += 1;
+        return originalStart();
+      };
+      return session;
+    }
+  }
+
+  const client = new TrackingClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+  });
+  const handle = {
+    provider: "codex" as const,
+    sessionId: "thread-read-recovery",
+    metadata: { provider: "codex", cwd: missingCwd },
+  };
+
+  const resumed = await manager.resumeAgentFromPersistence(handle, { cwd: missingCwd }, agentId, {
+    allowMissingCwd: true,
+  });
+  expect(resumed.cwd).toBe(missingCwd);
+  expect(client.resumeOverrides[0]?.cwd).not.toBe(missingCwd);
+
+  // Direct/schedule run path: blocked before startTurn with structured error.
+  expect(() => manager.streamAgent(agentId, "schedule tick")).toThrow(
+    /working directory is missing/i,
+  );
+  expect(() => manager.tryRunOutOfBand(agentId, "/goal pause")).toThrow(
+    /working directory is missing/i,
+  );
+  await expect(manager.runAgent(agentId, "schedule tick")).rejects.toThrow(
+    /working directory is missing/i,
+  );
+  await expect(manager.replaceAgentRun(agentId, "replace")).rejects.toThrow(
+    /working directory is missing/i,
+  );
+  expect(startTurnCalls).toBe(0);
+
+  // Recreate original worktree path: run guard clears without sticky flags.
+  mkdirSync(missingCwd, { recursive: true });
+  const stream = manager.streamAgent(agentId, "hello after rebind");
+  // Drain until startTurn is observed (generator advances on first next).
+  const first = await stream.next();
+  void first;
+  // Give startTurn a chance if the generator yields after the turn starts.
+  await Promise.resolve();
+  expect(startTurnCalls).toBeGreaterThanOrEqual(1);
 });
 
 test("createAgent reports configured providers when provider is unknown", async () => {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -116,6 +116,9 @@ class TestAgentClient implements AgentClient {
   readonly capabilities = TEST_CAPABILITIES;
   readonly createdConfigs: AgentSessionConfig[] = [];
   readonly resumeOverrides: Array<Partial<AgentSessionConfig> | undefined> = [];
+  readonly resumeLaunchContexts: Array<AgentLaunchContext | undefined> = [];
+  /** Process spawn cwd observed by the provider (processCwd ?? config.cwd). */
+  readonly resumeProcessSpawnCwds: string[] = [];
 
   constructor(provider: AgentProvider = "codex") {
     this.provider = provider;
@@ -157,9 +160,13 @@ class TestAgentClient implements AgentClient {
   async resumeSession(
     _handle: AgentPersistenceHandle,
     config?: Partial<AgentSessionConfig>,
-    _launchContext?: AgentLaunchContext,
+    launchContext?: AgentLaunchContext,
   ): Promise<AgentSession> {
     this.resumeOverrides.push(config);
+    this.resumeLaunchContexts.push(launchContext);
+    const processSpawnCwd = launchContext?.processCwd ?? config?.cwd ?? process.cwd();
+    this.resumeProcessSpawnCwds.push(processSpawnCwd);
+    // Session config keeps the provider-facing cwd (original recorded path).
     return new TestAgentSession({
       provider: this.provider,
       cwd: config?.cwd ?? process.cwd(),
@@ -2165,11 +2172,14 @@ test("resumeAgentFromPersistence rejects missing cwd unless allowMissingCwd is s
   expect(resumed.cwd).toBe(missingCwd);
   expect(resumed.config.cwd).toBe(missingCwd);
   expect(client.resumeOverrides).toHaveLength(1);
-  // Provider resume must receive a real launch cwd (not the deleted worktree).
-  const launchCwd = client.resumeOverrides[0]?.cwd;
-  expect(launchCwd).toBeTruthy();
-  expect(launchCwd).not.toBe(missingCwd);
-  expect(existsSync(launchCwd!)).toBe(true);
+  // Session/config cwd must remain the original recorded path (not rewritten).
+  expect(client.resumeOverrides[0]?.cwd).toBe(missingCwd);
+  // Process spawn uses launchContext.processCwd only.
+  const processCwd = client.resumeLaunchContexts[0]?.processCwd;
+  expect(processCwd).toBeTruthy();
+  expect(processCwd).not.toBe(missingCwd);
+  expect(existsSync(processCwd!)).toBe(true);
+  expect(client.resumeProcessSpawnCwds[0]).toBe(processCwd);
 
   // Timeline fetch must work after missing-cwd resume (logs path).
   const timeline = manager.fetchTimeline(agentId, { direction: "tail", limit: 0 });
@@ -2185,20 +2195,22 @@ test("read-recovered missing-cwd agent cannot start provider runs until path ret
   const agentId = "22222222-2222-4222-8222-222222222222";
 
   let startTurnCalls = 0;
+  let lastStartTurnSessionCwd: string | undefined;
   class TrackingClient extends TestAgentClient {
     override async resumeSession(
-      _handle: AgentPersistenceHandle,
+      handle: AgentPersistenceHandle,
       config?: Partial<AgentSessionConfig>,
-      _launchContext?: AgentLaunchContext,
+      launchContext?: AgentLaunchContext,
     ): Promise<AgentSession> {
-      this.resumeOverrides.push(config);
-      const session = new TestAgentSession({
-        provider: this.provider,
-        cwd: config?.cwd ?? process.cwd(),
-      });
+      const session = (await super.resumeSession(
+        handle,
+        config,
+        launchContext,
+      )) as TestAgentSession;
       const originalStart = session.startTurn.bind(session);
       session.startTurn = async () => {
         startTurnCalls += 1;
+        lastStartTurnSessionCwd = session["config"]?.cwd ?? config?.cwd;
         return originalStart();
       };
       return session;
@@ -2221,7 +2233,12 @@ test("read-recovered missing-cwd agent cannot start provider runs until path ret
     allowMissingCwd: true,
   });
   expect(resumed.cwd).toBe(missingCwd);
-  expect(client.resumeOverrides[0]?.cwd).not.toBe(missingCwd);
+  // Config cwd stays original; process spawn uses safe processCwd.
+  expect(client.resumeOverrides[0]?.cwd).toBe(missingCwd);
+  expect(client.resumeLaunchContexts[0]?.processCwd).toBeTruthy();
+  expect(client.resumeLaunchContexts[0]?.processCwd).not.toBe(missingCwd);
+  expect(existsSync(client.resumeLaunchContexts[0]!.processCwd!)).toBe(true);
+  expect(client.resumeProcessSpawnCwds[0]).toBe(client.resumeLaunchContexts[0]?.processCwd);
 
   // Direct/schedule run path: blocked before startTurn with structured error.
   expect(() => manager.streamAgent(agentId, "schedule tick")).toThrow(
@@ -2241,12 +2258,11 @@ test("read-recovered missing-cwd agent cannot start provider runs until path ret
   // Recreate original worktree path: run guard clears without sticky flags.
   mkdirSync(missingCwd, { recursive: true });
   const stream = manager.streamAgent(agentId, "hello after rebind");
-  // Drain until startTurn is observed (generator advances on first next).
-  const first = await stream.next();
-  void first;
-  // Give startTurn a chance if the generator yields after the turn starts.
+  await stream.next();
   await Promise.resolve();
   expect(startTurnCalls).toBeGreaterThanOrEqual(1);
+  // startTurn still sees the original/rebound recorded cwd (not processCwd).
+  expect(lastStartTurnSessionCwd).toBe(missingCwd);
 });
 
 test("createAgent reports configured providers when provider is unknown", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -43,6 +43,11 @@ import {
   type ListImportableSessionsOptions,
 } from "./agent-sdk-types.js";
 import { buildArchivedAgentRecord, type ArchivedStoredAgentRecord } from "./agent-archive.js";
+import {
+  assertAgentCwdExistsSync,
+  pathIsExistingDirectory,
+  resolveSafeReadRecoveryCwd,
+} from "./agent-cwd.js";
 import type { StoredAgentRecord, AgentStorage } from "./agent-storage.js";
 import type { AgentOwner } from "./agent-owner.js";
 import {
@@ -1119,6 +1124,26 @@ export class AgentManager {
       { requireExistingCwd: !options?.allowMissingCwd },
     );
 
+    // Read recovery: provider spawn needs an existing launch cwd, but the managed
+    // agent must retain the original (possibly missing) recorded worktree path so
+    // run preflight and rebind recovery stay accurate.
+    let effectiveLaunchConfig = launchConfig;
+    if (options?.allowMissingCwd && launchConfig.cwd) {
+      const launchCwdExists = await pathIsExistingDirectory(launchConfig.cwd);
+      if (!launchCwdExists) {
+        const safeLaunchCwd = resolveSafeReadRecoveryCwd();
+        effectiveLaunchConfig = { ...launchConfig, cwd: safeLaunchCwd };
+        this.logger.warn(
+          {
+            agentId: resolvedAgentId,
+            recordedCwd: storedConfig.cwd,
+            launchCwd: safeLaunchCwd,
+          },
+          "Resuming agent for timeline recovery with temporary launch cwd; recorded cwd preserved",
+        );
+      }
+    }
+
     const client = this.requireClient(handle.provider);
     const available = await client.isAvailable();
     if (!available) {
@@ -1127,7 +1152,10 @@ export class AgentManager {
       );
     }
     const launchContext = await this.buildLaunchContext(resolvedAgentId, client);
-    const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
+    const providerLaunchConfig = this.resolveProviderLaunchConfig(
+      effectiveLaunchConfig,
+      launchContext,
+    );
     const session = await client.resumeSession(handle, providerLaunchConfig, launchContext);
     return this.registerSession(session, storedConfig, resolvedAgentId, {
       ...options,
@@ -1919,6 +1947,7 @@ export class AgentManager {
    */
   tryRunOutOfBand(agentId: string, prompt: AgentPromptInput): boolean {
     const agent = this.requireSessionAgent(agentId);
+    this.assertAgentCwdRunnable(agent);
     const handler = agent.session.tryHandleOutOfBand?.(prompt);
     if (!handler) {
       return false;
@@ -1990,6 +2019,10 @@ export class AgentManager {
     options?: AgentRunOptions,
   ): AsyncGenerator<AgentStreamEvent> {
     const existingAgent = this.requireSessionAgent(agentId);
+    // Central run guard: timeline-recovered agents keep a missing recorded cwd
+    // until the worktree is recreated or rebound. Re-checks the filesystem so
+    // recovery is automatic when the original path exists again (no sticky flag).
+    this.assertAgentCwdRunnable(existingAgent);
     this.logger.trace(
       {
         agentId,
@@ -2135,6 +2168,7 @@ export class AgentManager {
     options?: AgentRunOptions,
   ): Promise<AsyncGenerator<AgentStreamEvent>> {
     const snapshot = this.requireAgent(agentId);
+    this.assertAgentCwdRunnable(snapshot);
     if (
       snapshot.lifecycle !== "running" &&
       !snapshot.activeForegroundTurnId &&
@@ -4309,6 +4343,16 @@ export class AgentManager {
       throw new Error(`Agent '${agent.id}' has no managed session`);
     }
     return agent;
+  }
+
+  /**
+   * Non-bypassable run guard: provider turns require the agent's recorded cwd
+   * to exist on disk. Timeline recovery may leave agents live with a missing
+   * recorded path; schedule/direct run/out-of-band must fail closed until the
+   * worktree is recreated at that path or the agent is rebound.
+   */
+  private assertAgentCwdRunnable(agent: { id: string; cwd: string }): void {
+    assertAgentCwdExistsSync(agent.id, agent.cwd);
   }
 
   private requirePublicAgent(id: string): LiveManagedAgent {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1124,22 +1124,21 @@ export class AgentManager {
       { requireExistingCwd: !options?.allowMissingCwd },
     );
 
-    // Read recovery: provider spawn needs an existing launch cwd, but the managed
-    // agent must retain the original (possibly missing) recorded worktree path so
-    // run preflight and rebind recovery stay accurate.
-    let effectiveLaunchConfig = launchConfig;
-    if (options?.allowMissingCwd && launchConfig.cwd) {
-      const launchCwdExists = await pathIsExistingDirectory(launchConfig.cwd);
-      if (!launchCwdExists) {
-        const safeLaunchCwd = resolveSafeReadRecoveryCwd();
-        effectiveLaunchConfig = { ...launchConfig, cwd: safeLaunchCwd };
+    // Read recovery: keep AgentSessionConfig.cwd as the original recorded path.
+    // Provider child process spawn uses launchContext.processCwd only when the
+    // recorded worktree is gone — never rewrite session/config cwd.
+    let processCwd: string | undefined;
+    if (options?.allowMissingCwd && storedConfig.cwd) {
+      const recordedExists = await pathIsExistingDirectory(storedConfig.cwd);
+      if (!recordedExists) {
+        processCwd = resolveSafeReadRecoveryCwd();
         this.logger.warn(
           {
             agentId: resolvedAgentId,
             recordedCwd: storedConfig.cwd,
-            launchCwd: safeLaunchCwd,
+            processCwd,
           },
-          "Resuming agent for timeline recovery with temporary launch cwd; recorded cwd preserved",
+          "Resuming agent for timeline recovery with process-launch-only cwd; session config cwd preserved",
         );
       }
     }
@@ -1151,11 +1150,10 @@ export class AgentManager {
         `Provider '${handle.provider}' is not available. Please ensure the CLI is installed.`,
       );
     }
-    const launchContext = await this.buildLaunchContext(resolvedAgentId, client);
-    const providerLaunchConfig = this.resolveProviderLaunchConfig(
-      effectiveLaunchConfig,
-      launchContext,
-    );
+    const launchContext = await this.buildLaunchContext(resolvedAgentId, client, undefined, {
+      processCwd,
+    });
+    const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
     const session = await client.resumeSession(handle, providerLaunchConfig, launchContext);
     return this.registerSession(session, storedConfig, resolvedAgentId, {
       ...options,
@@ -4227,6 +4225,7 @@ export class AgentManager {
     agentId: string,
     client: AgentClient,
     env?: Record<string, string>,
+    options?: { processCwd?: string },
   ): Promise<AgentLaunchContext> {
     const context: AgentLaunchContext = {
       agentId,
@@ -4234,6 +4233,7 @@ export class AgentManager {
         ...env,
         PASEO_AGENT_ID: agentId,
       },
+      ...(options?.processCwd ? { processCwd: options.processCwd } : {}),
     };
     if (
       this.paseoToolsEnabled &&

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -118,6 +118,24 @@ interface PreparedSessionConfig {
 interface NormalizeConfigOptions {
   resolveDefaultModel?: boolean;
   env?: Record<string, string>;
+  /**
+   * When true (default), missing/non-directory cwd values throw.
+   * Set false only for resume/load-for-read paths that must recover
+   * timeline history after a worktree has been deleted.
+   * Never disable for createAgent / new work.
+   */
+  requireExistingCwd?: boolean;
+}
+
+export interface ResumeAgentFromPersistenceOptions {
+  createdAt?: Date;
+  updatedAt?: Date;
+  lastUserMessageAt?: Date | null;
+  labels?: Record<string, string>;
+  workspaceId?: string;
+  owner?: AgentOwner;
+  /** Allow resume when recorded cwd is gone (timeline/log recovery only). */
+  allowMissingCwd?: boolean;
 }
 
 interface TimeoutOptions {
@@ -1070,14 +1088,7 @@ export class AgentManager {
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,
     agentId?: string,
-    options?: {
-      createdAt?: Date;
-      updatedAt?: Date;
-      lastUserMessageAt?: Date | null;
-      labels?: Record<string, string>;
-      workspaceId?: string;
-      owner?: AgentOwner;
-    },
+    options?: ResumeAgentFromPersistenceOptions,
   ): Promise<ManagedAgent> {
     return this.trackAgentRegistrationOperation(
       this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options),
@@ -1088,14 +1099,7 @@ export class AgentManager {
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,
     agentId?: string,
-    options?: {
-      createdAt?: Date;
-      updatedAt?: Date;
-      lastUserMessageAt?: Date | null;
-      labels?: Record<string, string>;
-      workspaceId?: string;
-      owner?: AgentOwner;
-    },
+    options?: ResumeAgentFromPersistenceOptions,
   ): Promise<ManagedAgent> {
     this.assertAcceptingAgentRegistrations();
     const resolvedAgentId = validateAgentId(
@@ -1111,6 +1115,8 @@ export class AgentManager {
     const { storedConfig, launchConfig } = await this.prepareSessionConfig(
       mergedConfig,
       resolvedAgentId,
+      undefined,
+      { requireExistingCwd: !options?.allowMissingCwd },
     );
 
     const client = this.requireClient(handle.provider);
@@ -4065,27 +4071,34 @@ export class AgentManager {
     options: NormalizeConfigOptions = {},
   ): Promise<AgentSessionConfig> {
     const normalized: AgentSessionConfig = { ...config };
+    const requireExistingCwd = options.requireExistingCwd ?? true;
 
     // Always resolve cwd to absolute path for consistent history file lookup
     if (normalized.cwd) {
       normalized.cwd = resolve(normalized.cwd);
-      try {
-        const cwdStats = await stat(normalized.cwd);
-        if (!cwdStats.isDirectory()) {
-          throw new Error(`Working directory is not a directory: ${normalized.cwd}`);
+      if (requireExistingCwd) {
+        try {
+          const cwdStats = await stat(normalized.cwd);
+          if (!cwdStats.isDirectory()) {
+            throw new Error(`Working directory is not a directory: ${normalized.cwd}`);
+          }
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            "code" in error &&
+            (error as NodeJS.ErrnoException).code === "ENOENT"
+          ) {
+            throw new Error(`Working directory does not exist: ${normalized.cwd}`, {
+              cause: error,
+            });
+          }
+          if (error instanceof Error) {
+            throw error;
+          }
+          throw new Error(`Failed to access working directory: ${normalized.cwd}`, {
+            cause: error,
+          });
         }
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          "code" in error &&
-          (error as NodeJS.ErrnoException).code === "ENOENT"
-        ) {
-          throw new Error(`Working directory does not exist: ${normalized.cwd}`, { cause: error });
-        }
-        if (error instanceof Error) {
-          throw error;
-        }
-        throw new Error(`Failed to access working directory: ${normalized.cwd}`, { cause: error });
       }
     }
 
@@ -4146,8 +4159,12 @@ export class AgentManager {
     config: AgentSessionConfig,
     agentId: string,
     env?: Record<string, string>,
+    options?: Pick<NormalizeConfigOptions, "requireExistingCwd">,
   ): Promise<PreparedSessionConfig> {
-    const storedConfig = await this.normalizeConfig(stripInternalPaseoMcpServer(config), { env });
+    const storedConfig = await this.normalizeConfig(stripInternalPaseoMcpServer(config), {
+      env,
+      requireExistingCwd: options?.requireExistingCwd,
+    });
     const launchConfig = this.applyDaemonAppendSystemPrompt(
       withRuntimePaseoMcpServer({
         config: storedConfig,

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -277,6 +277,7 @@ test("sendPromptToAgent prefers live agent cwd over a stale stored cwd", async (
     })),
   );
 
+  // Live resident cwd is valid; stored path is gone. Send must succeed using live cwd.
   await sendPromptToAgent({
     agentManager,
     agentStorage,
@@ -285,7 +286,90 @@ test("sendPromptToAgent prefers live agent cwd over a stale stored cwd", async (
     logger: createTestLogger(),
   });
 
+  expect(streamAgentSpy).toHaveBeenCalledTimes(1);
   expect(streamAgentSpy).toHaveBeenCalledWith("agent-rebound", "hello", undefined);
+
+  // Control: if only the stale stored path were used, send would reject.
+  Reflect.set(
+    agentManager,
+    "getAgent",
+    vi.fn(() => null),
+  );
+  await expect(
+    sendPromptToAgent({
+      agentManager,
+      agentStorage,
+      agentId: "agent-rebound",
+      prompt: "hello-stale-only",
+      logger: createTestLogger(),
+    }),
+  ).rejects.toSatisfy((error: unknown) => {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/working directory is missing/i);
+    return true;
+  });
+  expect(streamAgentSpy).toHaveBeenCalledTimes(1);
+});
+
+test("sendPromptToAgent returns structured error when cwd ancestor is a file (ENOTDIR)", async () => {
+  const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const dir = mkdtempSync(join(tmpdir(), "paseo-send-enotdir-"));
+  const fileAncestor = join(dir, "not-a-dir");
+  writeFileSync(fileAncestor, "x");
+  const enotdirCwd = join(fileAncestor, "worktree");
+
+  try {
+    const agent: ManagedAgent = Object.create(null);
+    Reflect.set(agent, "id", "agent-file-ancestor");
+    Reflect.set(agent, "provider", "codex");
+    Reflect.set(agent, "cwd", enotdirCwd);
+
+    const streamAgentSpy = vi.fn(() => (async function* noop() {})());
+    const agentManager: AgentManager = Object.create(AgentManager.prototype);
+    Reflect.set(
+      agentManager,
+      "getAgent",
+      vi.fn(() => agent),
+    );
+    Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
+    Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(false));
+    Reflect.set(agentManager, "streamAgent", streamAgentSpy);
+
+    const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
+    Reflect.set(
+      agentStorage,
+      "get",
+      vi.fn(async () => ({
+        id: "agent-file-ancestor",
+        cwd: enotdirCwd,
+        provider: "codex",
+        archivedAt: null,
+      })),
+    );
+
+    await expect(
+      sendPromptToAgent({
+        agentManager,
+        agentStorage,
+        agentId: "agent-file-ancestor",
+        prompt: "hello",
+        logger: createTestLogger(),
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).toMatch(/working directory is missing/i);
+      expect(message).toMatch(/Recreate the worktree|rebind the agent cwd/i);
+      expect(message).not.toMatch(/\bAgent not found\b/i);
+      expect(message).not.toMatch(/\bENOTDIR\b|\bENOENT\b/);
+      return true;
+    });
+    expect(streamAgentSpy).not.toHaveBeenCalled();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("finish notifications tell the parent the child's last assistant message", async () => {

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -159,6 +159,7 @@ test("sendPromptToAgent forwards the client message id as run options", async ()
   const agent: ManagedAgent = Object.create(null);
   Reflect.set(agent, "id", "agent-1");
   Reflect.set(agent, "provider", "codex");
+  Reflect.set(agent, "cwd", process.cwd());
 
   const streamAgentSpy = vi.fn(() => (async function* noop() {})());
   const agentManager: AgentManager = Object.create(AgentManager.prototype);
@@ -192,6 +193,57 @@ test("sendPromptToAgent forwards the client message id as run options", async ()
     outputSchema: { type: "object" },
     clientMessageId: "msg-client-1",
   });
+});
+
+test("sendPromptToAgent returns structured missing-cwd error for present agents", async () => {
+  const missingCwd = `/tmp/paseo-missing-agent-cwd-${Date.now()}`;
+  const agent: ManagedAgent = Object.create(null);
+  Reflect.set(agent, "id", "agent-missing-cwd");
+  Reflect.set(agent, "provider", "codex");
+  Reflect.set(agent, "cwd", missingCwd);
+
+  const streamAgentSpy = vi.fn(() => (async function* noop() {})());
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(
+    agentManager,
+    "getAgent",
+    vi.fn(() => agent),
+  );
+  Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "streamAgent", streamAgentSpy);
+
+  const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
+  Reflect.set(
+    agentStorage,
+    "get",
+    vi.fn(async () => ({
+      id: "agent-missing-cwd",
+      cwd: missingCwd,
+      provider: "codex",
+      archivedAt: null,
+    })),
+  );
+
+  let caught: unknown;
+  try {
+    await sendPromptToAgent({
+      agentManager,
+      agentStorage,
+      agentId: "agent-missing-cwd",
+      prompt: "hello",
+      logger: createTestLogger(),
+    });
+  } catch (error) {
+    caught = error;
+  }
+
+  expect(caught).toBeInstanceOf(Error);
+  const message = (caught as Error).message;
+  expect(message).toMatch(/working directory is missing/i);
+  expect(message).toMatch(/Recreate the worktree|rebind the agent cwd/i);
+  expect(message).not.toMatch(/Agent not found/i);
+  expect(streamAgentSpy).not.toHaveBeenCalled();
 });
 
 test("finish notifications tell the parent the child's last assistant message", async () => {

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -246,6 +246,48 @@ test("sendPromptToAgent returns structured missing-cwd error for present agents"
   expect(streamAgentSpy).not.toHaveBeenCalled();
 });
 
+test("sendPromptToAgent prefers live agent cwd over a stale stored cwd", async () => {
+  const liveCwd = process.cwd();
+  const staleCwd = `/tmp/paseo-stale-agent-cwd-${Date.now()}`;
+  const agent: ManagedAgent = Object.create(null);
+  Reflect.set(agent, "id", "agent-rebound");
+  Reflect.set(agent, "provider", "codex");
+  Reflect.set(agent, "cwd", liveCwd);
+
+  const streamAgentSpy = vi.fn(() => (async function* noop() {})());
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(
+    agentManager,
+    "getAgent",
+    vi.fn(() => agent),
+  );
+  Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "streamAgent", streamAgentSpy);
+
+  const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
+  Reflect.set(
+    agentStorage,
+    "get",
+    vi.fn(async () => ({
+      id: "agent-rebound",
+      cwd: staleCwd,
+      provider: "codex",
+      archivedAt: null,
+    })),
+  );
+
+  await sendPromptToAgent({
+    agentManager,
+    agentStorage,
+    agentId: "agent-rebound",
+    prompt: "hello",
+    logger: createTestLogger(),
+  });
+
+  expect(streamAgentSpy).toHaveBeenCalledWith("agent-rebound", "hello", undefined);
+});
+
 test("finish notifications tell the parent the child's last assistant message", async () => {
   const scenario = createFinishNotificationScenario({
     childLastAssistantMessage: "Implemented the cleanup and all checks pass.",

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -311,6 +311,122 @@ test("sendPromptToAgent prefers live agent cwd over a stale stored cwd", async (
   expect(streamAgentSpy).toHaveBeenCalledTimes(1);
 });
 
+test("sendPromptToAgent rejects missing archived cwd before unarchive mutation", async () => {
+  const missingCwd = `/tmp/paseo-archived-missing-cwd-${Date.now()}`;
+  const unarchiveSnapshotSpy = vi.fn(async () => true);
+  const notifyAgentStateSpy = vi.fn();
+  const streamAgentSpy = vi.fn(() => (async function* noop() {})());
+  const setAgentModeSpy = vi.fn();
+  const tryRunOutOfBandSpy = vi.fn().mockReturnValue(false);
+  const hasInFlightRunSpy = vi.fn().mockReturnValue(false);
+  const getAgentSpy = vi.fn(() => null);
+
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(agentManager, "getAgent", getAgentSpy);
+  Reflect.set(agentManager, "unarchiveSnapshot", unarchiveSnapshotSpy);
+  Reflect.set(agentManager, "notifyAgentState", notifyAgentStateSpy);
+  Reflect.set(agentManager, "tryRunOutOfBand", tryRunOutOfBandSpy);
+  Reflect.set(agentManager, "hasInFlightRun", hasInFlightRunSpy);
+  Reflect.set(agentManager, "streamAgent", streamAgentSpy);
+  Reflect.set(agentManager, "setAgentMode", setAgentModeSpy);
+  Reflect.set(
+    agentManager,
+    "touchAgentActivity",
+    vi.fn(() => null),
+  );
+  Reflect.set(
+    agentManager,
+    "waitForAgentClose",
+    vi.fn(async () => undefined),
+  );
+  Reflect.set(agentManager, "getRegisteredProviderIds", () => ["codex"]);
+  Reflect.set(agentManager, "resumeAgentFromPersistence", vi.fn());
+  Reflect.set(agentManager, "createAgent", vi.fn());
+  Reflect.set(agentManager, "hydrateTimelineFromProvider", vi.fn());
+
+  const storageGetSpy = vi.fn(async () => ({
+    id: "agent-archived-missing",
+    cwd: missingCwd,
+    provider: "codex",
+    archivedAt: "2026-07-01T00:00:00.000Z",
+  }));
+  const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
+  Reflect.set(agentStorage, "get", storageGetSpy);
+
+  await expect(
+    sendPromptToAgent({
+      agentManager,
+      agentStorage,
+      agentId: "agent-archived-missing",
+      prompt: "hello",
+      unarchive: true,
+      logger: createTestLogger(),
+    }),
+  ).rejects.toSatisfy((error: unknown) => {
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toMatch(/working directory is missing/i);
+    expect(message).toMatch(/Recreate the worktree|rebind the agent cwd/i);
+    expect(message).not.toMatch(/\bAgent not found\b/i);
+    return true;
+  });
+
+  // Preflight must fail before any archive/provider/load mutation.
+  expect(storageGetSpy).toHaveBeenCalled();
+  expect(unarchiveSnapshotSpy).not.toHaveBeenCalled();
+  expect(notifyAgentStateSpy).not.toHaveBeenCalled();
+  expect(streamAgentSpy).not.toHaveBeenCalled();
+  expect(setAgentModeSpy).not.toHaveBeenCalled();
+  expect(tryRunOutOfBandSpy).not.toHaveBeenCalled();
+  expect(agentManager.resumeAgentFromPersistence).not.toHaveBeenCalled();
+  expect(agentManager.createAgent).not.toHaveBeenCalled();
+  expect(agentManager.hydrateTimelineFromProvider).not.toHaveBeenCalled();
+});
+
+test("sendPromptToAgent keeps archived silent no-op when unarchive=false", async () => {
+  const missingCwd = `/tmp/paseo-archived-noop-${Date.now()}`;
+  const unarchiveSnapshotSpy = vi.fn(async () => true);
+  const streamAgentSpy = vi.fn(() => (async function* noop() {})());
+
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(
+    agentManager,
+    "getAgent",
+    vi.fn(() => null),
+  );
+  Reflect.set(agentManager, "unarchiveSnapshot", unarchiveSnapshotSpy);
+  Reflect.set(agentManager, "notifyAgentState", vi.fn());
+  Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "streamAgent", streamAgentSpy);
+
+  const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
+  Reflect.set(
+    agentStorage,
+    "get",
+    vi.fn(async () => ({
+      id: "agent-archived-noop",
+      cwd: missingCwd,
+      provider: "codex",
+      archivedAt: "2026-07-01T00:00:00.000Z",
+    })),
+  );
+
+  await expect(
+    sendPromptToAgent({
+      agentManager,
+      agentStorage,
+      agentId: "agent-archived-noop",
+      prompt: "hello",
+      unarchive: false,
+      logger: createTestLogger(),
+    }),
+  ).resolves.toEqual({ outOfBand: false });
+
+  expect(unarchiveSnapshotSpy).not.toHaveBeenCalled();
+  expect(streamAgentSpy).not.toHaveBeenCalled();
+});
+
 test("sendPromptToAgent returns structured error when cwd ancestor is a file (ENOTDIR)", async () => {
   const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
   const { tmpdir } = await import("node:os");

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -181,23 +181,25 @@ export async function sendPromptToAgent(
   const unarchive = params.unarchive ?? true;
 
   const record = await params.agentStorage.get(params.agentId);
-  if (record?.archivedAt) {
-    if (!unarchive) {
-      return { outOfBand: false };
-    }
-    await unarchiveAgentState(params.agentStorage, params.agentManager, params.agentId);
+  // Archived + unarchive=false remains a silent no-op before any preflight.
+  if (record?.archivedAt && !unarchive) {
+    return { outOfBand: false };
   }
 
-  // Continue/send requires a live cwd. Check before load so missing-cwd agents
-  // get a structured recovery error instead of a generic not-found/load failure.
-  // Prefer the resident agent's cwd over storage so a rebound/live cwd wins over
-  // a stale stored path after worktree recovery.
+  // Continue/send requires a live cwd. Run preflight before unarchive/load so a
+  // missing worktree never mutates archive/provider state. Prefer the resident
+  // agent's cwd over storage so a rebound/live cwd wins over a stale stored path.
   const liveBeforeLoad = params.agentManager.getAgent(params.agentId);
   const cwd = liveBeforeLoad?.cwd ?? record?.cwd;
   if (cwd) {
     await assertAgentCwdExists(params.agentId, cwd);
   } else if (!record && !liveBeforeLoad) {
     throw new Error(`Agent not found: ${params.agentId}`);
+  }
+
+  // Unarchive only after cwd is known to be usable.
+  if (record?.archivedAt && unarchive) {
+    await unarchiveAgentState(params.agentStorage, params.agentManager, params.agentId);
   }
 
   await ensureAgentLoaded(params.agentId, {

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -190,8 +190,10 @@ export async function sendPromptToAgent(
 
   // Continue/send requires a live cwd. Check before load so missing-cwd agents
   // get a structured recovery error instead of a generic not-found/load failure.
+  // Prefer the resident agent's cwd over storage so a rebound/live cwd wins over
+  // a stale stored path after worktree recovery.
   const liveBeforeLoad = params.agentManager.getAgent(params.agentId);
-  const cwd = record?.cwd ?? liveBeforeLoad?.cwd;
+  const cwd = liveBeforeLoad?.cwd ?? record?.cwd;
   if (cwd) {
     await assertAgentCwdExists(params.agentId, cwd);
   } else if (!record && !liveBeforeLoad) {

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -3,6 +3,7 @@ import type { Logger } from "pino";
 import type { AgentPromptInput, AgentRunOptions } from "./agent-sdk-types.js";
 import type { AgentManager, ManagedAgent } from "./agent-manager.js";
 import type { AgentStorage } from "./agent-storage.js";
+import { assertAgentCwdExists } from "./agent-cwd.js";
 import { ensureAgentLoaded } from "./agent-loading.js";
 import { getParentAgentIdFromLabels } from "@getpaseo/protocol/agent-labels";
 
@@ -187,10 +188,22 @@ export async function sendPromptToAgent(
     await unarchiveAgentState(params.agentStorage, params.agentManager, params.agentId);
   }
 
+  // Continue/send requires a live cwd. Check before load so missing-cwd agents
+  // get a structured recovery error instead of a generic not-found/load failure.
+  const liveBeforeLoad = params.agentManager.getAgent(params.agentId);
+  const cwd = record?.cwd ?? liveBeforeLoad?.cwd;
+  if (cwd) {
+    await assertAgentCwdExists(params.agentId, cwd);
+  } else if (!record && !liveBeforeLoad) {
+    throw new Error(`Agent not found: ${params.agentId}`);
+  }
+
   await ensureAgentLoaded(params.agentId, {
     agentManager: params.agentManager,
     agentStorage: params.agentStorage,
     logger: params.logger,
+    // Never allow missing cwd on the send path.
+    allowMissingCwd: false,
   });
 
   if (params.sessionMode) {

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -588,6 +588,12 @@ export interface AgentLaunchContext {
   agentId?: string;
   env?: Record<string, string>;
   /**
+   * Process-launch-only working directory for spawning the provider child.
+   * Must never be written into AgentSessionConfig.cwd or persisted agent state.
+   * Used when resuming for timeline recovery while the recorded worktree is gone.
+   */
+  processCwd?: string;
+  /**
    * Runtime-only internal Paseo tools. This must never be persisted into
    * AgentSessionConfig; providers may adapt it to their native tool surface.
    */

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { PassThrough, Readable, Writable } from "node:stream";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   AgentSideConnection,
@@ -46,6 +47,7 @@ import { parseKiroExtensionCommands } from "./kiro-acp-agent.js";
 import { transformPiModels } from "./pi/agent.js";
 import type { AgentStreamEvent } from "../agent-sdk-types.js";
 import type { AgentCapabilityFlags, AgentPersistenceHandle } from "../agent-sdk-types.js";
+import * as providerLaunchConfig from "../provider-launch-config.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { buildStringCommandShellInvocation } from "../../../utils/string-command-shell.js";
 import { asInternals } from "../../test-utils/class-mocks.js";
@@ -2793,6 +2795,8 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
   function makeTestSession(args: {
     capabilities?: AgentCapabilityFlags;
     handle: AgentPersistenceHandle;
+    cwd?: string;
+    processCwd?: string;
     loadSession?: ReturnType<typeof vi.fn>;
     unstableResumeSession?: ReturnType<typeof vi.fn>;
   }) {
@@ -2829,7 +2833,7 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
 
     // Pass handle through the typed constructor option (no private-field casts).
     const session = new TestSession(
-      { provider: "claude-acp", cwd: "/tmp/paseo-acp-test" },
+      { provider: "claude-acp", cwd: args.cwd ?? "/tmp/paseo-acp-test" },
       {
         provider: "claude-acp",
         logger: createTestLogger(),
@@ -2845,6 +2849,7 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
           ...args.capabilities,
         },
         handle: args.handle,
+        processCwd: args.processCwd,
       },
     );
 
@@ -2992,5 +2997,209 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
       cwd: "/tmp/paseo-acp-test",
       mcpServers: [],
     });
+  });
+
+  test("loadSession keeps original config.cwd even when processCwd is set for recovery", async () => {
+    const originalCwd = "/missing/worktree-path";
+    const processCwd = "/tmp/safe-recovery-cwd";
+    const { session, loadSession } = makeTestSession({
+      capabilities: { loadSession: true },
+      handle: { sessionId: "session-1", provider: "claude-acp" },
+      cwd: originalCwd,
+      processCwd,
+    });
+
+    await session.initializeResumedSession();
+
+    expect(loadSession).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      cwd: originalCwd,
+      mcpServers: [],
+    });
+    expect(session.describePersistence()?.metadata).toMatchObject({ cwd: originalCwd });
+  });
+});
+
+describe("ACPAgentSession processCwd is process-launch-only", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  interface ProtocolCall {
+    method: "newSession" | "loadSession";
+    cwd: string;
+  }
+
+  function createHandshakeChild(protocolCalls: ProtocolCall[]): ChildProcessWithoutNullStreams {
+    // Separate duplexes so parent and agent can each take a web stream end.
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = Object.assign(new EventEmitter(), {
+      stdin,
+      stdout,
+      stderr,
+      exitCode: null,
+      signalCode: null,
+      killed: false,
+      pid: 42_001,
+    }) as ChildProcessWithoutNullStreams;
+    child.kill = vi.fn(() => {
+      child.killed = true;
+      queueMicrotask(() => child.emit("exit", 0, null));
+      return true;
+    }) as ChildProcessWithoutNullStreams["kill"];
+
+    const agent: Agent = {
+      async initialize() {
+        return {
+          protocolVersion: PROTOCOL_VERSION,
+          agentCapabilities: { loadSession: true },
+          authMethods: [],
+        };
+      },
+      async newSession(params) {
+        protocolCalls.push({ method: "newSession", cwd: params.cwd });
+        return {
+          sessionId: "session-new-1",
+          modes: null,
+          models: null,
+          configOptions: [],
+        };
+      },
+      async loadSession(params) {
+        protocolCalls.push({ method: "loadSession", cwd: params.cwd });
+        return {
+          sessionId: params.sessionId,
+          modes: null,
+          models: null,
+          configOptions: [],
+        };
+      },
+      async prompt() {
+        return { stopReason: "end_turn" };
+      },
+      async authenticate() {},
+      async cancel() {},
+    };
+
+    // Agent writes responses on stdout and reads requests from stdin.
+    // Retain on the child so the connection stays alive for the session.
+    const agentConnection = new AgentSideConnection(
+      () => agent,
+      ndJsonStream(Writable.toWeb(stdout), Readable.toWeb(stdin)),
+    );
+    Object.assign(child, { agentConnection });
+
+    return child;
+  }
+
+  function createSessionWithProcessCwd(args: {
+    cwd: string;
+    processCwd?: string;
+    handle?: AgentPersistenceHandle;
+  }): ACPAgentSession {
+    return new ACPAgentSession(
+      {
+        provider: "claude-acp",
+        cwd: args.cwd,
+      },
+      {
+        provider: "claude-acp",
+        logger: createTestLogger(),
+        defaultCommand: ["claude", "--acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        processCwd: args.processCwd,
+        handle: args.handle,
+        // Stub process: skip real tree-kill grace/force waits on close.
+        terminateProcess: async () => "terminated",
+      },
+    );
+  }
+
+  function mockProviderAvailable(): void {
+    vi.spyOn(providerLaunchConfig, "checkProviderLaunchAvailable").mockResolvedValue({
+      available: true,
+      resolvedPath: "/fake/claude",
+    });
+  }
+
+  test("spawns the child with processCwd while newSession keeps the original config.cwd", async () => {
+    const originalCwd = "/missing/worktree-path";
+    const processCwd = "/tmp/safe-recovery-cwd";
+    const protocolCalls: ProtocolCall[] = [];
+    const spawn = vi
+      .spyOn(spawnUtils, "spawnProcess")
+      .mockImplementation(() => createHandshakeChild(protocolCalls));
+    mockProviderAvailable();
+
+    const session = createSessionWithProcessCwd({ cwd: originalCwd, processCwd });
+    await session.initializeNewSession();
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ cwd: processCwd }),
+    );
+    expect(protocolCalls).toEqual([{ method: "newSession", cwd: originalCwd }]);
+    expect(session.describePersistence()?.metadata).toMatchObject({ cwd: originalCwd });
+
+    await session.close();
+  });
+
+  test("falls back to config.cwd for child spawn when processCwd is absent", async () => {
+    const originalCwd = "/workspace/project";
+    const protocolCalls: ProtocolCall[] = [];
+    const spawn = vi
+      .spyOn(spawnUtils, "spawnProcess")
+      .mockImplementation(() => createHandshakeChild(protocolCalls));
+    mockProviderAvailable();
+
+    const session = createSessionWithProcessCwd({ cwd: originalCwd });
+    await session.initializeNewSession();
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ cwd: originalCwd }),
+    );
+    expect(protocolCalls).toEqual([{ method: "newSession", cwd: originalCwd }]);
+
+    await session.close();
+  });
+
+  test("resumed loadSession keeps original cwd while spawn uses processCwd", async () => {
+    const originalCwd = "/missing/worktree-path";
+    const processCwd = "/tmp/safe-recovery-cwd";
+    const protocolCalls: ProtocolCall[] = [];
+    const spawn = vi
+      .spyOn(spawnUtils, "spawnProcess")
+      .mockImplementation(() => createHandshakeChild(protocolCalls));
+    mockProviderAvailable();
+
+    const session = createSessionWithProcessCwd({
+      cwd: originalCwd,
+      processCwd,
+      handle: { sessionId: "session-resume-1", provider: "claude-acp" },
+    });
+    await session.initializeResumedSession();
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ cwd: processCwd }),
+    );
+    expect(protocolCalls).toEqual([{ method: "loadSession", cwd: originalCwd }]);
+    expect(session.describePersistence()?.metadata).toMatchObject({ cwd: originalCwd });
+
+    await session.close();
   });
 });

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -424,6 +424,10 @@ interface ACPAgentSessionOptions {
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
+  /**
+   * Process-launch-only spawn cwd. Session protocol calls still use config.cwd.
+   */
+  processCwd?: string;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
@@ -789,6 +793,7 @@ export class ACPAgentClient implements AgentClient {
         capabilities: this.capabilities,
         agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
+        processCwd: launchContext?.processCwd,
         extensionCommandsParser: this.extensionCommandsParser,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
@@ -840,6 +845,7 @@ export class ACPAgentClient implements AgentClient {
       handle,
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
+      processCwd: launchContext?.processCwd,
       extensionCommandsParser: this.extensionCommandsParser,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
@@ -1300,6 +1306,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   ) => Promise<void>;
   private readonly agentId?: string;
   private readonly launchEnv?: Record<string, string>;
+  private readonly processCwd?: string;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private readonly pendingPermissions = new Map<string, PendingPermission>();
   private readonly messageAssemblies = new Map<string, MessageAssemblyState>();
@@ -1360,6 +1367,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.availableModes = options.defaultModes;
     this.agentId = options.agentId;
     this.launchEnv = options.launchEnv;
+    this.processCwd = options.processCwd;
     this.initialHandle = options.handle;
     this.config = { ...config, provider: options.provider };
     this.currentMode = config.modeId ?? null;
@@ -2299,8 +2307,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
     const command = prefix.command;
     const args = [...prefix.args, ...this.defaultCommand.slice(1)];
+    // processCwd is launch-only (timeline recovery when recorded cwd is gone).
+    // Protocol session calls continue to use this.config.cwd.
     const child = spawnProcess(command, args, {
-      cwd: this.config.cwd,
+      cwd: this.processCwd ?? this.config.cwd,
       ...createProviderEnvSpec({
         runtimeSettings: this.runtimeSettings,
         overlays: [this.launchEnv],

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -86,6 +86,35 @@ test("forwards launch-context env to the Pi process launch", async () => {
   await session.close();
 });
 
+test("uses processCwd for child spawn while session config.cwd stays original", async () => {
+  const pi = new FakePi();
+  const client = createClient(pi);
+  const originalCwd = "/missing/worktree-path";
+  const processCwd = "/tmp/safe-recovery-cwd";
+
+  const session = await client.createSession(createConfig({ cwd: originalCwd }), {
+    processCwd,
+  });
+
+  expect(pi.recordedLaunches[0]?.cwd).toBe(processCwd);
+  expect(session.describePersistence()?.metadata).toMatchObject({ cwd: originalCwd });
+
+  await session.close();
+});
+
+test("falls back to config.cwd for Pi spawn when processCwd is absent", async () => {
+  const pi = new FakePi();
+  const client = createClient(pi);
+  const originalCwd = "/workspace/project";
+
+  const session = await client.createSession(createConfig({ cwd: originalCwd }));
+
+  expect(pi.recordedLaunches[0]?.cwd).toBe(originalCwd);
+  expect(session.describePersistence()?.metadata).toMatchObject({ cwd: originalCwd });
+
+  await session.close();
+});
+
 test("starts internal Pi agents without persisting a native session", async () => {
   const pi = new FakePi();
   const client = createClient(pi);
@@ -711,6 +740,32 @@ describe("PiRpcAgentSession", () => {
       "--extension",
       actualLaunch.extensionPaths[0],
     ]);
+  });
+
+  test("resume uses processCwd for spawn while persistence metadata keeps original cwd", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+    const originalCwd = "/missing/worktree-path";
+    const processCwd = "/tmp/safe-recovery-cwd";
+
+    const session = await client.resumeSession(
+      {
+        provider: "pi",
+        sessionId: "pi-session-1",
+        nativeHandle: "/tmp/native-pi-session",
+        metadata: {
+          cwd: originalCwd,
+          model: "openrouter/model-a",
+        },
+      },
+      {},
+      { processCwd },
+    );
+
+    expect(pi.recordedLaunches[0]?.cwd).toBe(processCwd);
+    expect(session.describePersistence()?.metadata).toMatchObject({ cwd: originalCwd });
+
+    await session.close();
   });
 
   test("creates Pi sessions with agent and daemon system prompts appended", async () => {

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -531,6 +531,7 @@ function buildResumeStartInput(input: {
 }): PiStartSessionInput {
   return {
     cwd: input.resumeConfig.cwd,
+    ...(input.launchContext?.processCwd ? { processCwd: input.launchContext.processCwd } : {}),
     env: input.launchContext?.env,
     session: input.sessionFile,
     model: input.resumeConfig.model,
@@ -2312,6 +2313,7 @@ export class PiRpcAgentClient implements AgentClient {
     try {
       runtimeSession = await this.runtime.startSession({
         cwd: config.cwd,
+        ...(launchContext?.processCwd ? { processCwd: launchContext.processCwd } : {}),
         model: config.model,
         thinkingOptionId:
           normalizePiThinkingOption(config.thinkingOptionId) ?? DEFAULT_PI_THINKING_LEVEL,

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
@@ -150,6 +150,40 @@ describe("PiCliRuntime", () => {
     ]);
   });
 
+  test("uses processCwd for process launch while session identity cwd stays original", async () => {
+    const child = createPiChild();
+    replyToCommands(child, () => ({}));
+    const launches: PiRuntimeLaunch[] = [];
+    const runtime = createRuntime(child, launches);
+    const originalCwd = "/missing/worktree-path";
+    const processCwd = "/tmp/safe-recovery-cwd";
+
+    await runtime.startSession({ cwd: originalCwd, processCwd });
+
+    expect(launches).toEqual([
+      expect.objectContaining({
+        cwd: processCwd,
+        argv: ["pi", "--mode", "rpc"],
+      }),
+    ]);
+  });
+
+  test("falls back to session cwd for process launch when processCwd is absent", async () => {
+    const child = createPiChild();
+    replyToCommands(child, () => ({}));
+    const launches: PiRuntimeLaunch[] = [];
+    const runtime = createRuntime(child, launches);
+
+    await runtime.startSession({ cwd: "/workspace/project" });
+
+    expect(launches).toEqual([
+      expect.objectContaining({
+        cwd: "/workspace/project",
+        argv: ["pi", "--mode", "rpc"],
+      }),
+    ]);
+  });
+
   test("passes an MCP config path to Pi", async () => {
     const child = createPiChild();
     replyToCommands(child, () => ({}));

--- a/packages/server/src/server/agent/providers/pi/runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/runtime.ts
@@ -27,6 +27,12 @@ export interface PiRuntimeLaunch {
 
 export interface PiStartSessionInput {
   cwd: string;
+  /**
+   * Process-launch-only spawn cwd. When set, the child process starts here
+   * while `cwd` remains the session/workspace identity (may be missing on disk
+   * during timeline recovery).
+   */
+  processCwd?: string;
   env?: Record<string, string>;
   protocolMode?: "rpc" | "rpc-ui";
   model?: string;
@@ -89,7 +95,7 @@ export function buildPiLaunch(input: {
   appendPiLaunchArgs(argv, input.session, protocolMode, systemPrompt);
 
   return {
-    cwd: input.session.cwd,
+    cwd: input.session.processCwd ?? input.session.cwd,
     argv,
     env:
       input.runtimeSettings?.env || input.session.env

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -5804,10 +5804,14 @@ export class Session {
       : undefined;
 
     try {
+      // Timeline/logs must still work when the agent's recorded worktree is gone.
+      // allowMissingCwd lets resume recover provider history without requiring
+      // the cwd for new work (send still rejects missing cwd).
       const snapshot = await ensureAgentLoaded(msg.agentId, {
         agentManager: this.agentManager,
         agentStorage: this.agentStorage,
         logger: this.sessionLogger,
+        allowMissingCwd: true,
       });
       const agentPayload = await this.buildAgentPayload(snapshot);
 


### PR DESCRIPTION
## Summary

Fixes the Paseo-side root cause behind RF0 ASL tracker **reachfar-ai/reachfar-zero#2115** (visible-agent continuation / reattach):

- **Logs/timeline:** existing agents can be resumed for read/history when their recorded worktree/cwd no longer exists (`allowMissingCwd`), so `paseo logs` / timeline fetch no longer hard-fails solely on missing cwd.
- **Send/continue:** if the agent still exists but cwd is gone, return a structured `MissingAgentCwdError` with recovery guidance (recreate worktree / rebind cwd). Not generic `Agent not found`.
- **New work unchanged:** `createAgent` and normal `normalizeConfig` still require a live cwd.

## Changes

- `agent-cwd.ts`: `MissingAgentCwdError`, path checks, `assertAgentCwdExists`
- `agent-manager`: `requireExistingCwd` / `allowMissingCwd` on resume path
- `agent-loading`: pass `allowMissingCwd` for timeline recovery; never create-from-storage without cwd
- `agent-prompt` `sendPromptToAgent`: preflight missing-cwd check
- `session` timeline fetch: load with `allowMissingCwd: true`
- Unit tests for cwd helpers, send error, load/resume paths

## Test plan

- [x] `vitest` focused suite: `agent-cwd`, `agent-loading`, `agent-prompt`, full `agent-manager` (156 passed)
- [x] `oxfmt` / `oxlint` on touched files
- [x] `@getpaseo/server` typecheck passes after package builds
- [ ] CI on this PR
- [ ] Manual: agent with deleted worktree → `paseo logs <id>` recovers history when provider/durable data exists
- [ ] Manual: same agent → `paseo send <id> "..."` returns structured missing-cwd recovery error