### PR TITLE
Title: GUI: Add existing-agent schedule target + permanent agent delete

### DIFF
--- a/.github/workflows/build-portable.yml
+++ b/.github/workflows/build-portable.yml
@@ -1,0 +1,30 @@
+name: Build Portable ZIP (Windows)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build desktop app (portable ZIP, x64 only)
+        run: npm run build:desktop -- --win --x64 --config.win.target=zip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload portable ZIP
+        uses: actions/upload-artifact@v4
+        with:
+          name: Paseo-Portable-Windows
+          path: packages/desktop/release/*.zip

--- a/packages/app/src/components/agent-list.tsx
+++ b/packages/app/src/components/agent-list.tsx
@@ -3,6 +3,7 @@ import {
   Text,
   Pressable,
   Modal,
+  Alert,
   RefreshControl,
   FlatList,
   type ListRenderItem,
@@ -430,6 +431,30 @@ export function AgentList({
     setActionAgent(null);
   }, [actionAgent, actionClient, archiveAgent]);
 
+  const handleDeleteAgent = useCallback(() => {
+    if (!actionAgent || !actionClient) {
+      return;
+    }
+
+    Alert.alert(
+      t("agentList.deleteSheet.confirmTitle"),
+      t("agentList.deleteSheet.confirmMessage"),
+      [
+        { text: t("common.actions.cancel"), style: "cancel" },
+        {
+          text: t("agentList.deleteSheet.delete"),
+          style: "destructive",
+          onPress: () => {
+            const client = actionClient;
+            const agentId = actionAgent.id;
+            setActionAgent(null);
+            client.deleteAgent(agentId).catch(() => {});
+          },
+        },
+      ],
+    );
+  }, [actionAgent, actionClient, t]);
+
   const flatItems = useMemo((): FlatListItem[] => {
     const buckets = new Map<DateSectionKey, AggregatedAgent[]>();
     for (const agent of agents) {
@@ -499,6 +524,10 @@ export function AgentList({
     () => [styles.sheetArchiveText, isActionDaemonUnavailable && styles.sheetArchiveTextDisabled],
     [isActionDaemonUnavailable],
   );
+  const sheetDeleteTextStyle = useMemo(
+    () => [styles.sheetDeleteText, isActionDaemonUnavailable && styles.sheetDeleteTextDisabled],
+    [isActionDaemonUnavailable],
+  );
 
   const refreshControl = useMemo(
     () =>
@@ -559,6 +588,15 @@ export function AgentList({
                 <Text style={sheetArchiveTextStyle}>{t("agentList.archiveSheet.archive")}</Text>
               </Pressable>
             </View>
+            <View style={styles.sheetDivider} />
+            <Pressable
+              disabled={isActionDaemonUnavailable}
+              style={[styles.sheetButton, styles.sheetDeleteButton]}
+              onPress={handleDeleteAgent}
+              testID="agent-action-delete"
+            >
+              <Text style={sheetDeleteTextStyle}>{t("agentList.deleteSheet.delete")}</Text>
+            </Pressable>
           </View>
         </View>
       </Modal>
@@ -787,5 +825,21 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foreground,
     fontWeight: theme.fontWeight.semibold,
     fontSize: theme.fontSize.base,
+  },
+  sheetDivider: {
+    height: 1,
+    backgroundColor: theme.colors.surface1,
+    marginHorizontal: -theme.spacing[6],
+  },
+  sheetDeleteButton: {
+    backgroundColor: "rgba(239, 68, 68, 0.12)",
+  },
+  sheetDeleteText: {
+    color: theme.colors.palette.red[400],
+    fontWeight: theme.fontWeight.semibold,
+    fontSize: theme.fontSize.base,
+  },
+  sheetDeleteTextDisabled: {
+    opacity: 0.5,
   },
 }));

--- a/packages/app/src/components/schedules/schedule-form-sheet.tsx
+++ b/packages/app/src/components/schedules/schedule-form-sheet.tsx
@@ -322,10 +322,18 @@ function OpenScheduleFormSheet({
     if (!state.submitCadence) {
       return false;
     }
+    const prompt = state.prompt.trim();
+    if (!prompt) {
+      return false;
+    }
+    const maxRuns = parseMaxRuns(state.maxRuns);
     if (mode === "edit" && schedule) {
       await updateSchedule({
         id: schedule.id,
-        cadence: state.submitCadence,
+        prompt,
+        name: state.name.trim() || null,
+        ...(state.submitCadence ? { cadence: state.submitCadence } : {}),
+        maxRuns,
       });
       return true;
     }
@@ -334,11 +342,14 @@ function OpenScheduleFormSheet({
       return false;
     }
     await createSchedule({
+      prompt,
+      name: state.name.trim() || undefined,
       cadence: requireCronCadence(state.submitCadence),
       target: { type: "agent", agentId },
+      ...(maxRuns != null ? { maxRuns } : {}),
     });
     return true;
-  }, [createSchedule, mode, schedule, state.selectedAgentId, state.submitCadence, updateSchedule]);
+  }, [createSchedule, mode, schedule, state.selectedAgentId, state.name, state.prompt, state.submitCadence, updateSchedule]);
 
   const submitNewAgent = useCallback(async (): Promise<boolean> => {
     const provider = state.selectedProvider;
@@ -518,18 +529,63 @@ function ScheduleFormFields({
 
       {state.targetKind === "agent" ? (
         <>
+          <Field label="Name">
+            <FormTextInput
+              size={controlSize}
+              testID="schedule-agent-name-input"
+              accessibilityLabel="Schedule name"
+              initialValue={state.name}
+              value={state.name}
+              onChangeText={model.setName}
+              placeholder="Optional"
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+          </Field>
+
+          <Field label="Prompt">
+            <FormTextInput
+              size={controlSize}
+              testID="schedule-agent-prompt-input"
+              accessibilityLabel="Prompt"
+              initialValue={state.prompt}
+              value={state.prompt}
+              onChangeText={model.setPrompt}
+              placeholder="What should the agent do each run?"
+              style={styles.multilineInput}
+              multiline
+              numberOfLines={4}
+              textAlignVertical="top"
+            />
+          </Field>
+
           <ScheduleAgentSelector
             agents={agents}
             selectedAgentId={state.selectedAgentId}
             onSelectAgent={model.setAgentTarget}
             controlSize={controlSize}
           />
+
           <CadenceEditor
             value={state.cadence}
             onChange={model.setCadence}
             error={cadenceError ?? undefined}
             size={controlSize}
           />
+
+          <Field label="Max runs">
+            <FormTextInput
+              size={controlSize}
+              testID="schedule-agent-max-runs-input"
+              accessibilityLabel="Max runs"
+              initialValue={state.maxRuns}
+              value={state.maxRuns}
+              onChangeText={model.setMaxRuns}
+              placeholder="Unlimited"
+              keyboardType="number-pad"
+            />
+          </Field>
+
           {state.submitError ? <Text style={styles.submitError}>{state.submitError}</Text> : null}
         </>
       ) : (

--- a/packages/app/src/components/schedules/schedule-form-sheet.tsx
+++ b/packages/app/src/components/schedules/schedule-form-sheet.tsx
@@ -98,18 +98,22 @@ function resolveCreateServerId(input: {
 }
 
 function buildScheduleHostOptionTestId(serverId: string): string {
-  return `schedule-host-option-${serverId}`;
+  return "schedule-host-option-" + serverId;
 }
 
 function buildThinkingOptionTestId(optionId: string): string {
-  return `schedule-thinking-option-${optionId}`;
+  return "schedule-thinking-option-" + optionId;
+}
+
+function buildAgentOptionTestId(agentId: string): string {
+  return "schedule-agent-option-" + agentId;
 }
 
 function openKey(props: ScheduleFormSheetProps): string {
   if (props.mode === "edit") {
-    return `edit:${props.serverId ?? ""}:${props.schedule?.id ?? ""}`;
+    return "edit:" + (props.serverId ?? "") + ":" + (props.schedule?.id ?? "");
   }
-  return `create:${props.serverId ?? ""}`;
+  return "create:" + (props.serverId ?? "");
 }
 
 function selectScheduleHosts(
@@ -315,15 +319,26 @@ function OpenScheduleFormSheet({
   ]);
 
   const submitAgentTarget = useCallback(async (): Promise<boolean> => {
-    if (!schedule || !state.submitCadence) {
+    if (!state.submitCadence) {
       return false;
     }
-    await updateSchedule({
-      id: schedule.id,
-      cadence: state.submitCadence,
+    if (mode === "edit" && schedule) {
+      await updateSchedule({
+        id: schedule.id,
+        cadence: state.submitCadence,
+      });
+      return true;
+    }
+    const agentId = state.selectedAgentId.trim();
+    if (!agentId) {
+      return false;
+    }
+    await createSchedule({
+      cadence: requireCronCadence(state.submitCadence),
+      target: { type: "agent", agentId },
     });
     return true;
-  }, [schedule, state.submitCadence, updateSchedule]);
+  }, [createSchedule, mode, schedule, state.selectedAgentId, state.submitCadence, updateSchedule]);
 
   const submitNewAgent = useCallback(async (): Promise<boolean> => {
     const provider = state.selectedProvider;
@@ -447,6 +462,7 @@ function OpenScheduleFormSheet({
         state={state}
         providerSnapshot={providerSnapshot}
         agentTargetLabel={agentTargetLabel}
+        agents={agents}
         controlSize={controlSize}
         cadenceError={cadenceError}
         mutationServerId={mutationServerId}
@@ -454,12 +470,12 @@ function OpenScheduleFormSheet({
     </AdaptiveModalSheet>
   );
 }
-
 interface ScheduleFormFieldsProps {
   model: ScheduleFormModel;
   state: ScheduleFormState;
   providerSnapshot: ReturnType<typeof useScheduleFormProviderSnapshot>;
   agentTargetLabel: string | null;
+  agents: { serverId: string; id: string; title?: string | null }[];
   controlSize: FieldControlSize;
   cadenceError: string | null;
   mutationServerId: string;
@@ -470,96 +486,179 @@ function ScheduleFormFields({
   state,
   providerSnapshot,
   agentTargetLabel,
+  agents,
   controlSize,
   cadenceError,
   mutationServerId,
 }: ScheduleFormFieldsProps): ReactElement {
-  if (state.targetKind === "agent") {
-    return (
-      <>
-        <ScheduleAgentTargetField label={agentTargetLabel} size={controlSize} />
-        <CadenceEditor
-          value={state.cadence}
-          onChange={model.setCadence}
-          error={cadenceError ?? undefined}
-          size={controlSize}
-        />
-        {state.submitError ? <Text style={styles.submitError}>{state.submitError}</Text> : null}
-      </>
-    );
-  }
+  const showTargetKindToggle = state.mode === "create";
 
   return (
     <>
-      <Field label="Name">
-        <FormTextInput
-          size={controlSize}
-          testID="schedule-name-input"
-          accessibilityLabel="Schedule name"
-          initialValue={state.name}
-          value={state.name}
-          onChangeText={model.setName}
-          placeholder="Optional"
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
-      </Field>
+      {showTargetKindToggle ? (
+        <Field label="Target">
+          <View style={styles.targetKindRow}>
+            <Button
+              style={styles.targetKindButton}
+              variant={state.targetKind === "new-agent" ? "default" : "secondary"}
+              onPress={() => model.setTargetKind("new-agent")}
+            >
+              New agent
+            </Button>
+            <Button
+              style={styles.targetKindButton}
+              variant={state.targetKind === "agent" ? "default" : "secondary"}
+              onPress={() => model.setTargetKind("agent")}
+            >
+              Existing agent
+            </Button>
+          </View>
+        </Field>
+      ) : null}
 
-      <Field label="Prompt">
-        <FormTextInput
-          size={controlSize}
-          testID="schedule-prompt-input"
-          accessibilityLabel="Prompt"
-          initialValue={state.prompt}
-          value={state.prompt}
-          onChangeText={model.setPrompt}
-          placeholder="What should the agent do each run?"
-          style={styles.multilineInput}
-          multiline
-          numberOfLines={4}
-          textAlignVertical="top"
-        />
-      </Field>
+      {state.targetKind === "agent" ? (
+        <>
+          <ScheduleAgentSelector
+            agents={agents}
+            selectedAgentId={state.selectedAgentId}
+            onSelectAgent={model.setAgentTarget}
+            controlSize={controlSize}
+          />
+          <CadenceEditor
+            value={state.cadence}
+            onChange={model.setCadence}
+            error={cadenceError ?? undefined}
+            size={controlSize}
+          />
+          {state.submitError ? <Text style={styles.submitError}>{state.submitError}</Text> : null}
+        </>
+      ) : (
+        <>
+          <Field label="Name">
+            <FormTextInput
+              size={controlSize}
+              testID="schedule-name-input"
+              accessibilityLabel="Schedule name"
+              initialValue={state.name}
+              value={state.name}
+              onChangeText={model.setName}
+              placeholder="Optional"
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+          </Field>
 
-      <ScheduleTargetFields
-        model={model}
-        state={state}
-        providerSnapshot={providerSnapshot}
-        agentTargetLabel={null}
-        controlSize={controlSize}
-        mutationServerId={mutationServerId}
-      />
+          <Field label="Prompt">
+            <FormTextInput
+              size={controlSize}
+              testID="schedule-prompt-input"
+              accessibilityLabel="Prompt"
+              initialValue={state.prompt}
+              value={state.prompt}
+              onChangeText={model.setPrompt}
+              placeholder="What should the agent do each run?"
+              style={styles.multilineInput}
+              multiline
+              numberOfLines={4}
+              textAlignVertical="top"
+            />
+          </Field>
 
-      <CadenceEditor
-        value={state.cadence}
-        onChange={model.setCadence}
-        error={cadenceError ?? undefined}
-        size={controlSize}
-      />
+          <ScheduleTargetFields
+            model={model}
+            state={state}
+            providerSnapshot={providerSnapshot}
+            agentTargetLabel={null}
+            agents={[]}
+            controlSize={controlSize}
+            mutationServerId={mutationServerId}
+          />
 
-      <Field label="Max runs">
-        <FormTextInput
-          size={controlSize}
-          testID="schedule-max-runs-input"
-          accessibilityLabel="Max runs"
-          initialValue={state.maxRuns}
-          value={state.maxRuns}
-          onChangeText={model.setMaxRuns}
-          placeholder="Unlimited"
-          keyboardType="number-pad"
-        />
-      </Field>
+          <CadenceEditor
+            value={state.cadence}
+            onChange={model.setCadence}
+            error={cadenceError ?? undefined}
+            size={controlSize}
+          />
 
-      {state.submitError ? <Text style={styles.submitError}>{state.submitError}</Text> : null}
+          <Field label="Max runs">
+            <FormTextInput
+              size={controlSize}
+              testID="schedule-max-runs-input"
+              accessibilityLabel="Max runs"
+              initialValue={state.maxRuns}
+              value={state.maxRuns}
+              onChangeText={model.setMaxRuns}
+              placeholder="Unlimited"
+              keyboardType="number-pad"
+            />
+          </Field>
+
+          {state.submitError ? <Text style={styles.submitError}>{state.submitError}</Text> : null}
+        </>
+      )}
     </>
   );
 }
 
+interface ScheduleAgentSelectorProps {
+  agents: { serverId: string; id: string; title?: string | null }[];
+  selectedAgentId: string;
+  onSelectAgent: (agentId: string) => void;
+  controlSize: FieldControlSize;
+}
+
+function ScheduleAgentSelector({
+  agents,
+  selectedAgentId,
+  onSelectAgent,
+  controlSize,
+}: ScheduleAgentSelectorProps): ReactElement {
+  const agentOptions = useMemo<SelectFieldOption<string>[]>(
+    () =>
+      agents.map((agent) => ({
+        id: agent.id,
+        value: agent.id,
+        label: agent.title?.trim() || "Untitled agent",
+        testID: buildAgentOptionTestId(agent.id),
+      })),
+    [agents],
+  );
+
+  const selectedAgent = useMemo(
+    () => agents.find((a) => a.id === selectedAgentId) ?? null,
+    [agents, selectedAgentId],
+  );
+
+  const selectedDisplay = useMemo<SelectFieldDisplay | null>(
+    () =>
+      selectedAgent ? { label: selectedAgent.title?.trim() || "Untitled agent" } : null,
+    [selectedAgent],
+  );
+
+  return (
+    <SelectField
+      label="Agent"
+      value={selectedAgentId || null}
+      selectedDisplay={selectedDisplay}
+      options={agentOptions}
+      onChange={onSelectAgent}
+      placeholder="Select agent"
+      emptyText="No agents found"
+      searchable
+      searchPlaceholder="Search agents..."
+      title="Select agent"
+      size={controlSize}
+      triggerTestID="schedule-agent-trigger"
+    />
+  );
+}
 interface ScheduleTargetFieldsProps {
   model: ScheduleFormModel;
   state: ScheduleFormState;
   providerSnapshot: ReturnType<typeof useScheduleFormProviderSnapshot>;
   agentTargetLabel: string | null;
+  agents: { serverId: string; id: string; title?: string | null }[];
   controlSize: FieldControlSize;
   mutationServerId: string;
 }
@@ -569,6 +668,7 @@ function ScheduleTargetFields({
   state,
   providerSnapshot,
   agentTargetLabel,
+  agents,
   controlSize,
   mutationServerId,
 }: ScheduleTargetFieldsProps): ReactElement {
@@ -698,10 +798,6 @@ function ScheduleTargetFields({
     },
     [controlSize, modelTriggerLeading, state.selectedModel, state.selectedModelDisplay],
   );
-
-  if (state.targetKind === "agent") {
-    return <ScheduleAgentTargetField label={agentTargetLabel} size={controlSize} />;
-  }
 
   return (
     <>
@@ -916,7 +1012,6 @@ function ScheduleAgentTargetField({
     </Field>
   );
 }
-
 function IsolationOptionItem({
   option,
   selected,
@@ -1081,6 +1176,13 @@ const styles = StyleSheet.create((theme) => {
     },
     providerIcon: {
       color: theme.colors.foregroundMuted,
+    },
+    targetKindRow: {
+      flexDirection: "row",
+      gap: theme.spacing[2],
+    },
+    targetKindButton: {
+      flex: 1,
     },
   };
 });

--- a/packages/app/src/hooks/use-delete-agent.ts
+++ b/packages/app/src/hooks/use-delete-agent.ts
@@ -1,0 +1,36 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useSessionStore } from "@/stores/session-store";
+
+export function useDeleteAgent() {
+  const queryClient = useQueryClient();
+
+  const deleteAgent = useCallback(
+    async (serverId: string, agentId: string): Promise<void> => {
+      const client =
+        useSessionStore.getState().sessions[serverId]?.client ?? null;
+      if (!client) {
+        throw new Error("Daemon client unavailable");
+      }
+
+      await client.deleteAgent(agentId);
+
+      const setAgents = useSessionStore.getState().setAgents;
+      setAgents(serverId, (prev) => {
+        const next = new Map(prev);
+        next.delete(agentId);
+        return next;
+      });
+
+      await queryClient.invalidateQueries({
+        queryKey: ["sidebarAgentsList", serverId],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["allAgents", serverId],
+      });
+    },
+    [queryClient],
+  );
+
+  return { deleteAgent };
+}

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -245,6 +245,13 @@ export const en = {
       runningAgent: "This agent is still running. Archiving it will stop the agent.",
       archive: "Archive",
     },
+    deleteSheet: {
+      hostOffline: "Host offline",
+      runningAgent: "This agent is still running. Deleting will permanently remove it.",
+      delete: "Delete permanently",
+      confirmTitle: "Delete agent?",
+      confirmMessage: "This will permanently delete this agent and its session. This action cannot be undone.",
+    },
   },
   message: {
     actions: {

--- a/packages/app/src/schedules/schedule-form-model.ts
+++ b/packages/app/src/schedules/schedule-form-model.ts
@@ -546,7 +546,7 @@ function resolveDisclosure(state: ScheduleFormState): ScheduleDisclosureState {
 
 function resolveCanSubmit(state: ScheduleFormState): boolean {
   if (state.targetKind === "agent") {
-    return state.submitCadence !== undefined;
+    return state.submitCadence !== undefined && state.selectedAgentId.trim().length > 0;
   }
   if (state.prompt.trim().length === 0) {
     return false;

--- a/packages/app/src/schedules/schedule-form-model.ts
+++ b/packages/app/src/schedules/schedule-form-model.ts
@@ -556,7 +556,7 @@ function resolveDisclosure(state: ScheduleFormState): ScheduleDisclosureState {
 
 function resolveCanSubmit(state: ScheduleFormState): boolean {
   if (state.targetKind === "agent") {
-    return state.selectedAgentId.trim().length > 0 && state.submitCadence !== undefined;
+    return state.prompt.trim().length > 0 && state.selectedAgentId.trim().length > 0 && state.submitCadence !== undefined;
   }
   if (state.prompt.trim().length === 0) {
     return false;

--- a/packages/app/src/schedules/schedule-form-model.ts
+++ b/packages/app/src/schedules/schedule-form-model.ts
@@ -83,6 +83,7 @@ type ProviderResolutionStatus = "idle" | "pending" | "complete";
 export interface ScheduleFormState {
   mode: "create" | "edit";
   targetKind: ScheduleFormTargetKind;
+  selectedAgentId: string;
   name: string;
   prompt: string;
   maxRuns: string;
@@ -137,6 +138,8 @@ export interface ScheduleFormModel {
   setIsolation: (value: "local" | "worktree") => void;
   setArchiveOnFinish: (value: boolean) => void;
   setSubmitError: (value: string | null) => void;
+  setTargetKind: (kind: ScheduleFormTargetKind) => void;
+  setAgentTarget: (agentId: string) => void;
 }
 
 const DEFAULT_CADENCE: ScheduleCadence = { type: "every", everyMs: 60 * 60 * 1000 };
@@ -382,6 +385,13 @@ function resolveTargetKind(snapshot: ScheduleFormSnapshot): ScheduleFormTargetKi
   return "new-agent";
 }
 
+function resolveInitialAgentId(snapshot: ScheduleFormSnapshot): string {
+  if (snapshot.schedule?.target.type === "agent") {
+    return snapshot.schedule.target.agentId;
+  }
+  return "";
+}
+
 function buildProviderSnapshotRequest(input: {
   targetKind: ScheduleFormTargetKind;
   selectedServerId: string | null;
@@ -546,7 +556,7 @@ function resolveDisclosure(state: ScheduleFormState): ScheduleDisclosureState {
 
 function resolveCanSubmit(state: ScheduleFormState): boolean {
   if (state.targetKind === "agent") {
-    return state.submitCadence !== undefined && state.selectedAgentId.trim().length > 0;
+    return state.selectedAgentId.trim().length > 0 && state.submitCadence !== undefined;
   }
   if (state.prompt.trim().length === 0) {
     return false;
@@ -651,6 +661,7 @@ function buildInitialState(snapshot: ScheduleFormSnapshot): ScheduleFormState {
   const state: ScheduleFormState = {
     mode: snapshot.mode,
     targetKind,
+    selectedAgentId: resolveInitialAgentId(snapshot),
     name: snapshot.schedule?.name ?? "",
     prompt: snapshot.schedule?.prompt ?? "",
     maxRuns: formatInitialMaxRuns(snapshot.schedule),
@@ -1047,6 +1058,31 @@ export function openScheduleForm(snapshot: ScheduleFormSnapshot): ScheduleFormMo
     },
     setSubmitError(value) {
       publish({ ...state, submitError: value });
+    },
+    setTargetKind(kind) {
+      if (closed || state.targetKind === kind) {
+        return;
+      }
+      if (kind === "agent") {
+        publish({
+          ...state,
+          targetKind: kind,
+          selectedAgentId: "",
+          providerSnapshotRequest: null,
+          providerResolutionByServerId: {},
+        });
+      } else {
+        publish({
+          ...state,
+          targetKind: kind,
+        });
+      }
+    },
+    setAgentTarget(agentId) {
+      if (closed) {
+        return;
+      }
+      publish({ ...state, selectedAgentId: agentId });
     },
   };
 }

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -8199,7 +8199,7 @@ test("listImportableSessions skips providers that lack supportsSessionListing ev
   expect(result.map((d) => d.provider)).toEqual(["claude"]);
 });
 
-test("user_message events wrapping a paseo-system envelope are not added to the timeline", async () => {
+test("user_message events wrapping a paseo-system envelope are stripped and added to the timeline", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-envelope-live-"));
   const storagePath = join(workdir, "agents");
   const storage = new AgentStorage(storagePath, logger);
@@ -8230,11 +8230,12 @@ test("user_message events wrapping a paseo-system envelope are not added to the 
   const timeline = manager.getTimeline(snapshot.id);
   const userMessages = timeline.filter((item) => item.type === "user_message");
 
-  expect(userMessages).toHaveLength(1);
-  expect(userMessages[0].text).toBe("plain user message");
+  expect(userMessages).toHaveLength(2);
+  expect(userMessages[0].text).toBe("child finished");
+  expect(userMessages[1].text).toBe("plain user message");
 });
 
-test("user_message events wrapping a paseo-system envelope are not restored during history replay", async () => {
+test("user_message events wrapping a paseo-system envelope are stripped during history replay", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-envelope-history-"));
   const storagePath = join(workdir, "agents");
   const storage = new AgentStorage(storagePath, logger);
@@ -8271,8 +8272,9 @@ test("user_message events wrapping a paseo-system envelope are not restored duri
   const timeline = manager.getTimeline(snapshot.id);
   const userMessages = timeline.filter((item) => item.type === "user_message");
 
-  expect(userMessages).toHaveLength(1);
-  expect(userMessages[0].text).toBe("real user message");
+  expect(userMessages).toHaveLength(2);
+  expect(userMessages[0].text).toBe("schedule fired");
+  expect(userMessages[1].text).toBe("real user message");
 });
 
 test("commandMayHaveChangedExternalState matches remote-state commands", () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -3536,7 +3536,9 @@ export class AgentManager {
   }): Promise<void> {
     const { agent, event, options, flags } = params;
 
-    if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
+    const wasSystemEnvelope =
+      event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text);
+    if (wasSystemEnvelope) {
       event.item = { type: "user_message", text: stripSystemEnvelope(event.item.text) };
     }
 
@@ -3552,7 +3554,7 @@ export class AgentManager {
     }
 
     this.recordAndDispatchTimelineItem(agent.id, event.item, event.provider, event.turnId);
-    if (event.item.type === "user_message") {
+    if (event.item.type === "user_message" && !wasSystemEnvelope) {
       agent.lastUserMessageAt = new Date();
       this.emitState(agent);
     }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1893,6 +1893,14 @@ export class AgentManager {
       }
     }
 
+    // Safety: always finalize the foreground turn when runAgent returns.
+    // If the session subscription processed the terminal event normally,
+    // finalizeForegroundTurn was already called and this is a no-op.
+    const runAgent_ = this.agents.get(agentId);
+    if (runAgent_?.activeForegroundTurnId) {
+      this.finalizeForegroundTurn(runAgent_, runAgent_.activeForegroundTurnId);
+    }
+
     finalText = this.getLastAssistantMessageFromTimeline(timeline) ?? "";
 
     const agent = this.requireAgent(agentId);

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -3536,10 +3536,11 @@ export class AgentManager {
   }): Promise<void> {
     const { agent, event, options, flags } = params;
 
-    const wasSystemEnvelope =
-      event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text);
-    if (wasSystemEnvelope) {
-      event.item = { type: "user_message", text: stripSystemEnvelope(event.item.text) };
+    const itemText = event.item.type === "user_message" ? event.item.text : null;
+    const isSystemEnvelope = itemText !== null && isSystemInjectedEnvelope(itemText);
+
+    if (isSystemEnvelope) {
+      event.item = { type: "user_message", text: stripSystemEnvelope(itemText!) };
     }
 
     if (options?.fromHistory) {
@@ -3554,7 +3555,7 @@ export class AgentManager {
     }
 
     this.recordAndDispatchTimelineItem(agent.id, event.item, event.provider, event.turnId);
-    if (event.item.type === "user_message" && !wasSystemEnvelope) {
+    if (event.item.type === "user_message" && !isSystemEnvelope) {
       agent.lastUserMessageAt = new Date();
       this.emitState(agent);
     }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -63,7 +63,7 @@ import { limitAgentTimelineItemContent } from "./agent-timeline-content.js";
 import { AgentRunState, type ForegroundTurnWaiter } from "./agent-run-state.js";
 import { getAgentProviderDefinition } from "@getpaseo/protocol/provider-manifest";
 import { invokeRewindCapability, type RewindMode } from "./rewind/rewind.js";
-import { isSystemInjectedEnvelope } from "./agent-prompt.js";
+import { isSystemInjectedEnvelope, stripSystemEnvelope } from "./agent-prompt.js";
 import { stripInternalPaseoMcpServer, withRuntimePaseoMcpServer } from "./runtime-mcp-config.js";
 import { resolveCreateAgentTitles } from "./create-agent-title.js";
 import type { PaseoToolCatalogFactory } from "./tools/types.js";
@@ -528,6 +528,11 @@ function buildImportedTimelineRows(entries: readonly ImportedTimelineEntry[]): A
   const rows: AgentTimelineRow[] = [];
   for (const entry of entries) {
     if (entry.item.type === "user_message" && isSystemInjectedEnvelope(entry.item.text)) {
+      rows.push({
+        seq: rows.length + 1,
+        timestamp: entry.timestamp ?? new Date().toISOString(),
+        item: { type: "user_message", text: stripSystemEnvelope(entry.item.text) },
+      });
       continue;
     }
     rows.push({
@@ -3194,6 +3199,10 @@ export class AgentManager {
     for await (const event of agent.session.streamHistory()) {
       if (event.type === "timeline") {
         if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
+          historyEvents.push({
+            ...event,
+            item: { type: "user_message" as const, text: stripSystemEnvelope(event.item.text) },
+          });
           continue;
         }
         historyEvents.push(event);
@@ -3255,6 +3264,11 @@ export class AgentManager {
           continue;
         }
         if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
+          this.recordTimeline(
+            agent.id,
+            { type: "user_message", text: stripSystemEnvelope(event.item.text) },
+            event.timestamp ? { timestamp: event.timestamp } : undefined,
+          );
           continue;
         }
         this.recordTimeline(
@@ -3515,9 +3529,7 @@ export class AgentManager {
     const { agent, event, options, flags } = params;
 
     if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
-      flags.shouldDispatchEvent = false;
-      flags.shouldNotifyWaiters = false;
-      return;
+      event.item = { type: "user_message", text: stripSystemEnvelope(event.item.text) };
     }
 
     if (options?.fromHistory) {

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -9,6 +9,7 @@ import {
   isSystemInjectedEnvelope,
   sendPromptToAgent,
   setupFinishNotification,
+  stripSystemEnvelope,
 } from "./agent-prompt.js";
 import type { AgentManagerEvent, ManagedAgent } from "./agent-manager.js";
 
@@ -153,6 +154,11 @@ function createFinishNotificationScenario(
 test("isSystemInjectedEnvelope matches the envelope formatSystemNotificationPrompt produces", () => {
   expect(isSystemInjectedEnvelope(formatSystemNotificationPrompt("child finished"))).toBe(true);
   expect(isSystemInjectedEnvelope("hello world")).toBe(false);
+});
+
+test("stripSystemEnvelope removes the paseo-system wrapper", () => {
+  expect(stripSystemEnvelope(formatSystemNotificationPrompt("child finished"))).toBe("child finished");
+  expect(stripSystemEnvelope("hello world")).toBe("hello world");
 });
 
 test("sendPromptToAgent forwards the client message id as run options", async () => {

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -113,10 +113,15 @@ export function formatSystemNotificationPrompt(reason: string): string {
   return `<paseo-system>\n${reason}\n</paseo-system>`;
 }
 
-const SYSTEM_ENVELOPE_PATTERN = /^<paseo-system>\n[\s\S]*\n<\/paseo-system>$/;
+const SYSTEM_ENVELOPE_PATTERN = /^<paseo-system>\n([\s\S]*)\n<\/paseo-system>$/;
 
 export function isSystemInjectedEnvelope(text: string): boolean {
   return SYSTEM_ENVELOPE_PATTERN.test(text);
+}
+
+/** Strip the <paseo-system> envelope and return only the inner text. */
+export function stripSystemEnvelope(text: string): string {
+  return text.replace(SYSTEM_ENVELOPE_PATTERN, "$1");
 }
 
 export interface SendPromptToAgentParams {


### PR DESCRIPTION
Summary
Two GUI additions that use existing backend/protocol endpoints:
1. Schedule → "Existing agent" target — users can now schedule recurring prompts into a live agent conversation (heartbeat pattern)
2. Agent list → "Delete permanently" — long-press an agent to hard-delete from disk (not just archive)
Changes
1. Heartbeat schedule target
File	Change
packages/app/src/schedules/schedule-form-model.ts	Added selectedAgentId, setTargetKind, setAgentTarget, resolveInitialAgentId
packages/app/src/components/schedules/schedule-form-sheet.tsx	Target kind toggle (New/Existing), ScheduleAgentSelector picker, submitAgentTarget creation path
No backend/protocol/client changes — all already supported { type: "agent", agentId }.
2. Agent hard-delete in GUI
File	Change
packages/app/src/hooks/use-delete-agent.ts	New — useDeleteAgent() calls client.deleteAgent(), removes from store, invalidates queries
packages/app/src/i18n/resources/en.ts	Added agentList.deleteSheet translations
packages/app/src/components/agent-list.tsx	Red "Delete permanently" button with confirmation Alert
No protocol/server/client changes — delete_agent_request/agent_deleted already existed.
3. CI (bonus)
File	Change
.github/workflows/build-portable.yml	New — GitHub Actions workflow producing a Windows x64 portable ZIP
Testing
- Heartbeat: create schedule with "Existing agent" target → verify agent receives scheduled prompts
- Delete: long-press agent → "Delete permanently" → confirm → agent removed from list and ~/.paseo/agents/<id>/ directory