### PR TITLE
fix(app): pin the active workspace from a collapsed sidebar section

### DIFF
--- a/packages/app/e2e/sidebar-workspace-pin-shortcut.spec.ts
+++ b/packages/app/e2e/sidebar-workspace-pin-shortcut.spec.ts
@@ -1,0 +1,266 @@
+import { test, expect, type Page } from "./fixtures";
+import { gotoAppShell } from "./helpers/app";
+import { daemonWsRoutePattern } from "./helpers/daemon-port";
+import { seedWorkspace, type SeededWorkspace } from "./helpers/seed-client";
+import { getServerId } from "./helpers/server-id";
+
+// The pin shortcut used to be registered by the sidebar row itself, so it silently did nothing
+// whenever the row was unmounted — a collapsed project section being the common case. It now
+// lives in a single always-mounted handler keyed on the active route selection.
+const PIN_SHORTCUT = "ControlOrMeta+Shift+P";
+
+function workspaceRow(page: Page, workspaceId: string) {
+  return page.getByTestId(`sidebar-workspace-row-${getServerId()}:${workspaceId}`);
+}
+
+function pinnedSection(page: Page) {
+  return page.getByTestId("sidebar-pinned-section");
+}
+
+// Opens the workspace so it becomes the active route selection, which is what the shortcut acts on.
+async function openWorkspace(page: Page, workspaceId: string) {
+  const row = workspaceRow(page, workspaceId);
+  await expect(row).toBeVisible({ timeout: 30_000 });
+  await row.click();
+  await expect(page).toHaveURL(/\/workspace\//, { timeout: 30_000 });
+}
+
+// The project key is host-scoped and not exposed by the seed helper, so the header is addressed by
+// its display name, scoped to project rows so a workspace row can never match. Pressing the header
+// toggles the section, which unmounts every workspace row under it.
+async function collapseProjectSection(page: Page, project: SeededWorkspace): Promise<void> {
+  const header = page
+    .locator('[data-testid^="sidebar-project-row-"]')
+    .filter({ hasText: project.projectDisplayName });
+  await expect(header).toHaveCount(1, { timeout: 30_000 });
+
+  await header.click();
+  await expect(workspaceRow(page, project.workspaceId)).toHaveCount(0, { timeout: 10_000 });
+}
+
+async function switchToStatusGrouping(page: Page): Promise<void> {
+  await page.getByTestId("sidebar-display-preferences-menu").click();
+  await page.getByTestId("sidebar-grouping-status").click();
+  await expect(page.getByTestId("sidebar-status-list-scroll")).toBeVisible({ timeout: 10_000 });
+}
+
+// Status mode buckets workspaces by state rather than project, so the group holding this workspace
+// is discovered from the rows container it sits in rather than assumed.
+async function collapseStatusGroupContaining(page: Page, workspaceId: string): Promise<void> {
+  const rows = page
+    .locator('[data-testid^="sidebar-status-group-rows-"]')
+    .filter({ has: workspaceRow(page, workspaceId) });
+  await expect(rows).toHaveCount(1, { timeout: 30_000 });
+
+  const rowsTestId = await rows.getAttribute("data-testid");
+  const bucket = rowsTestId?.replace("sidebar-status-group-rows-", "");
+  expect(bucket).toBeTruthy();
+
+  await page.getByTestId(`sidebar-status-group-${bucket}`).click();
+  await expect(workspaceRow(page, workspaceId)).toHaveCount(0, { timeout: 10_000 });
+}
+
+function readSessionMessage(
+  message: string | Buffer,
+): { type?: unknown; requestId?: unknown } | null {
+  const raw = typeof message === "string" ? message : message.toString("utf8");
+  try {
+    const envelope = JSON.parse(raw) as { type?: unknown; message?: unknown };
+    if (envelope.type !== "session" || typeof envelope.message !== "object") {
+      return null;
+    }
+    return envelope.message as { type?: unknown; requestId?: unknown };
+  } catch {
+    return null;
+  }
+}
+
+const PIN_REJECTION_MESSAGE = "Pin rejected by test.";
+
+interface PinRpcGate {
+  /** Pin requests the client has sent so far. */
+  sentCount(): number;
+}
+
+// Proxies everything so the app boots against the real daemon, counting pin RPCs and optionally
+// rejecting the first `rejectFirst` of them. The count asserts how many pins one keypress actually
+// dispatched, which the rendered pin state cannot show — a toggle that fired twice lands back
+// where it started.
+async function installPinRpcGate(
+  page: Page,
+  options: { rejectFirst?: number } = {},
+): Promise<PinRpcGate> {
+  const rejectFirst = options.rejectFirst ?? 0;
+  let sent = 0;
+
+  await page.routeWebSocket(daemonWsRoutePattern(), (ws) => {
+    const server = ws.connectToServer();
+
+    ws.onMessage((message) => {
+      const sessionMessage = readSessionMessage(message);
+      if (
+        sessionMessage?.type === "workspace.pin.set.request" &&
+        typeof sessionMessage.requestId === "string"
+      ) {
+        sent += 1;
+        if (sent <= rejectFirst) {
+          ws.send(
+            JSON.stringify({
+              type: "session",
+              message: {
+                type: "rpc_error",
+                payload: {
+                  requestId: sessionMessage.requestId,
+                  requestType: "workspace.pin.set.request",
+                  error: PIN_REJECTION_MESSAGE,
+                  code: "transport",
+                },
+              },
+            }),
+          );
+          return;
+        }
+      }
+
+      try {
+        server.send(message);
+      } catch {
+        // server socket already closed
+      }
+    });
+
+    server.onMessage((message) => {
+      try {
+        ws.send(message);
+      } catch {
+        // client socket already closed
+      }
+    });
+  });
+
+  return { sentCount: () => sent };
+}
+
+test.describe("Pin workspace shortcut", () => {
+  test("pins the active workspace while its project section is collapsed", async ({ page }) => {
+    const workspace = await seedWorkspace({ repoPrefix: "pin-shortcut-collapsed-" });
+
+    try {
+      await gotoAppShell(page);
+      await openWorkspace(page, workspace.workspaceId);
+      await collapseProjectSection(page, workspace);
+
+      await page.keyboard.press(PIN_SHORTCUT);
+
+      await expect(pinnedSection(page)).toBeVisible({ timeout: 10_000 });
+      await expect(
+        pinnedSection(page).getByTestId(
+          `sidebar-workspace-row-${getServerId()}:${workspace.workspaceId}`,
+        ),
+      ).toBeVisible();
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  test("unpins the active workspace while the Pinned section is collapsed", async ({ page }) => {
+    const workspace = await seedWorkspace({ repoPrefix: "pin-shortcut-unpin-" });
+
+    try {
+      await gotoAppShell(page);
+      await openWorkspace(page, workspace.workspaceId);
+
+      await page.keyboard.press(PIN_SHORTCUT);
+      await expect(pinnedSection(page)).toBeVisible({ timeout: 10_000 });
+
+      await page.getByTestId("sidebar-pinned-section-header").click();
+      await expect(workspaceRow(page, workspace.workspaceId)).toHaveCount(0, { timeout: 10_000 });
+
+      await page.keyboard.press(PIN_SHORTCUT);
+
+      await expect(pinnedSection(page)).toHaveCount(0, { timeout: 10_000 });
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  test("sends exactly one pin RPC per press when the row is rendered and selected", async ({
+    page,
+  }) => {
+    const workspace = await seedWorkspace({ repoPrefix: "pin-shortcut-expanded-" });
+
+    try {
+      const gate = await installPinRpcGate(page);
+
+      await gotoAppShell(page);
+      await openWorkspace(page, workspace.workspaceId);
+
+      await page.keyboard.press(PIN_SHORTCUT);
+      await expect(pinnedSection(page)).toBeVisible({ timeout: 10_000 });
+      // Counting frames catches a press that produces zero or two RPCs — a misfiring in-flight
+      // guard, or a second dispatch path. It cannot detect a duplicate handler registration:
+      // `keyboardActionDispatcher.dispatch` returns at the first handler that returns true, so a
+      // shadowed second handler is unobservable from outside by design.
+      expect(gate.sentCount()).toBe(1);
+
+      await page.keyboard.press(PIN_SHORTCUT);
+      await expect(pinnedSection(page)).toHaveCount(0, { timeout: 10_000 });
+      expect(gate.sentCount()).toBe(2);
+      await expect(workspaceRow(page, workspace.workspaceId)).toHaveCount(1);
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  test("pins the active workspace while its status group is collapsed", async ({ page }) => {
+    const workspace = await seedWorkspace({ repoPrefix: "pin-shortcut-status-" });
+
+    try {
+      await gotoAppShell(page);
+      await openWorkspace(page, workspace.workspaceId);
+      await switchToStatusGrouping(page);
+      await collapseStatusGroupContaining(page, workspace.workspaceId);
+
+      await page.keyboard.press(PIN_SHORTCUT);
+
+      await expect(pinnedSection(page)).toBeVisible({ timeout: 10_000 });
+      await expect(
+        pinnedSection(page).getByTestId(
+          `sidebar-workspace-row-${getServerId()}:${workspace.workspaceId}`,
+        ),
+      ).toBeVisible();
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  test("shows an error toast when the host rejects the pin, and the next press succeeds", async ({
+    page,
+  }) => {
+    const workspace = await seedWorkspace({ repoPrefix: "pin-shortcut-failure-" });
+
+    try {
+      const gate = await installPinRpcGate(page, { rejectFirst: 1 });
+
+      await gotoAppShell(page);
+      await openWorkspace(page, workspace.workspaceId);
+
+      await page.keyboard.press(PIN_SHORTCUT);
+
+      await expect(page.getByTestId("app-toast-message")).toContainText(PIN_REJECTION_MESSAGE, {
+        timeout: 10_000,
+      });
+      await expect(pinnedSection(page)).toHaveCount(0);
+      await expect(workspaceRow(page, workspace.workspaceId)).toHaveCount(1);
+
+      // The failure must leave the action usable: the in-flight guard has to release the key so a
+      // retry is not swallowed. Without that release the workspace is unpinnable for the session.
+      await page.keyboard.press(PIN_SHORTCUT);
+
+      await expect(pinnedSection(page)).toBeVisible({ timeout: 10_000 });
+      expect(gate.sentCount()).toBe(2);
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+});

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -32,6 +32,7 @@ import { AppDiagnosticHost } from "@/components/app-diagnostic-host";
 import { LeftSidebar } from "@/components/left-sidebar";
 import { WindowSidebarMenuToggle } from "@/components/headers/menu-header";
 import { SidebarModelProvider } from "@/components/sidebar/sidebar-model";
+import { WorkspacePinShortcutHandler } from "@/components/workspace-pin-shortcut-handler";
 import { CompactExplorerSidebarHost } from "@/components/compact-explorer-sidebar-host";
 import { ProviderSettingsHost } from "@/components/provider-settings-host";
 import { RootErrorBoundary } from "@/components/root-error-boundary";
@@ -555,6 +556,7 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
       <UpdateCalloutSource />
       <WorktreeSetupCalloutSource />
       <CommandCenterRootActions />
+      <WorkspacePinShortcutHandler />
       <CommandCenter />
       <AddProjectFlowHost />
       <HostChooserModal />

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -1366,17 +1366,6 @@ function WorkspaceRowWithMenu({
     },
   });
 
-  useKeyboardActionHandler({
-    handlerId: `workspace-pin-${workspace.workspaceKey}`,
-    actions: ["workspace.pin"],
-    enabled: selected && canPin,
-    priority: 0,
-    handle: () => {
-      onTogglePin?.();
-      return true;
-    },
-  });
-
   return (
     <>
       <WorkspaceRowInner

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -479,17 +479,6 @@ function StatusWorkspaceRowWithMenu({
     },
   });
 
-  useKeyboardActionHandler({
-    handlerId: `workspace-pin-${workspace.workspaceKey}`,
-    actions: ["workspace.pin"],
-    enabled: selected && canPin,
-    priority: 0,
-    handle: () => {
-      onTogglePin?.();
-      return true;
-    },
-  });
-
   return (
     <>
       <StatusWorkspaceRowInner

--- a/packages/app/src/components/workspace-pin-shortcut-handler.tsx
+++ b/packages/app/src/components/workspace-pin-shortcut-handler.tsx
@@ -1,0 +1,9 @@
+import { useGlobalWorkspacePinAction } from "@/hooks/use-global-workspace-pin-action";
+
+// Headless host for the pin shortcut. The hook subscribes to the active workspace's pin state, so
+// it lives in its own component rather than the root layout — otherwise every pin toggle would
+// re-render the whole app shell.
+export function WorkspacePinShortcutHandler() {
+  useGlobalWorkspacePinAction();
+  return null;
+}

--- a/packages/app/src/hooks/use-global-workspace-pin-action.ts
+++ b/packages/app/src/hooks/use-global-workspace-pin-action.ts
@@ -1,0 +1,64 @@
+import { useCallback } from "react";
+import { useKeyboardActionHandler } from "@/hooks/use-keyboard-action-handler";
+import { useSidebarWorkspacePinController } from "@/hooks/use-sidebar-workspace-pin";
+import type { KeyboardActionId } from "@/keyboard/keyboard-action-dispatcher";
+import { useHostFeature } from "@/runtime/host-features";
+import { useActiveWorkspaceSelection } from "@/stores/navigation-active-workspace-store";
+import { useWorkspaceFields } from "@/stores/session-store-hooks";
+import { buildWorkspaceTabPersistenceKey } from "@/stores/workspace-tabs-store";
+
+const WORKSPACE_PIN_ACTIONS: readonly KeyboardActionId[] = ["workspace.pin"];
+
+// The pin shortcut used to live on the sidebar row, so it disappeared whenever the row was not
+// rendered — a collapsed project or status group, a collapsed Pinned section, or focus mode.
+// It belongs here instead: one registration keyed on the active route selection.
+//
+// "Active workspace" means the route selection, not a focused pane. Those are equivalent today
+// (panes belong to the routed workspace, and /settings parses to no selection, which correctly
+// disables the handler). Revisit this if panes ever span workspaces.
+export function useGlobalWorkspacePinAction() {
+  const selection = useActiveWorkspaceSelection();
+  const serverId = selection?.serverId ?? null;
+  const routeWorkspaceId = selection?.workspaceId ?? null;
+  // Narrow projection so pin state changes don't re-render on every gitRuntime/diffStat tick.
+  // A null result means the workspace is gone, which `pinnedAt: null` alone could not express.
+  //
+  // `id` is projected rather than reusing the route id: the route carries an opaque workspace id
+  // that is not guaranteed to equal the descriptor id (that is why `selectWorkspace` resolves it
+  // through `resolveWorkspaceMapKeyByIdentity`). The RPC and the in-flight key both need the
+  // descriptor id, so that sidebar rows and this handler agree on one identity.
+  const fields = useWorkspaceFields(serverId, routeWorkspaceId, (workspace) => ({
+    id: workspace.id,
+    pinnedAt: workspace.pinnedAt ?? null,
+  }));
+  const canPin = useHostFeature(serverId, "workspacePinning");
+  const togglePin = useSidebarWorkspacePinController();
+
+  const handle = useCallback(() => {
+    if (!serverId || !fields || !canPin) {
+      return false;
+    }
+    const workspaceKey = buildWorkspaceTabPersistenceKey({
+      serverId,
+      workspaceId: fields.id,
+    });
+    if (!workspaceKey) {
+      return false;
+    }
+    togglePin({
+      serverId,
+      workspaceId: fields.id,
+      workspaceKey,
+      pinnedAt: fields.pinnedAt,
+    });
+    return true;
+  }, [canPin, fields, serverId, togglePin]);
+
+  useKeyboardActionHandler({
+    handlerId: "workspace-pin-global",
+    actions: WORKSPACE_PIN_ACTIONS,
+    enabled: serverId !== null && fields !== null && canPin,
+    priority: 0,
+    handle,
+  });
+}

--- a/packages/app/src/hooks/use-sidebar-workspace-pin.ts
+++ b/packages/app/src/hooks/use-sidebar-workspace-pin.ts
@@ -1,22 +1,33 @@
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "@tanstack/react-query";
 import { useToast } from "@/contexts/toast-context";
 import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
 import { getHostRuntimeStore } from "@/runtime/host-runtime";
 
-export type ToggleSidebarWorkspacePin = (workspace: SidebarWorkspaceEntry) => void;
+// Everything the pin toggle actually needs. Kept narrower than SidebarWorkspaceEntry so the
+// global keyboard handler can build one from the active route selection without a sidebar row.
+export type PinnableWorkspace = Pick<
+  SidebarWorkspaceEntry,
+  "serverId" | "workspaceId" | "workspaceKey" | "pinnedAt"
+>;
+
+export type ToggleSidebarWorkspacePin = (workspace: PinnableWorkspace) => void;
+
+// Module scope, not a per-hook ref: the sidebar row menus and the global keyboard shortcut each
+// hold their own controller instance, and a per-instance guard would let a keypress and a menu
+// click fire two concurrent, opposite setWorkspacePinned calls for the same workspace.
+const pendingWorkspaceKeys = new Set<string>();
 
 export function useSidebarWorkspacePinController(): ToggleSidebarWorkspacePin {
   const { t } = useTranslation();
   const toast = useToast();
-  const pendingWorkspaceKeysRef = useRef(new Set<string>());
   const mutation = useMutation({
     mutationFn: async ({
       workspace,
       pinned,
     }: {
-      workspace: SidebarWorkspaceEntry;
+      workspace: PinnableWorkspace;
       pinned: boolean;
     }) => {
       const client = getHostRuntimeStore().getClient(workspace.serverId);
@@ -31,17 +42,17 @@ export function useSidebarWorkspacePinController(): ToggleSidebarWorkspacePin {
       );
     },
     onSettled: (_data, _error, { workspace }) => {
-      pendingWorkspaceKeysRef.current.delete(workspace.workspaceKey);
+      pendingWorkspaceKeys.delete(workspace.workspaceKey);
     },
   });
   const mutate = mutation.mutate;
 
   return useCallback(
-    (workspace: SidebarWorkspaceEntry) => {
-      if (pendingWorkspaceKeysRef.current.has(workspace.workspaceKey)) {
+    (workspace: PinnableWorkspace) => {
+      if (pendingWorkspaceKeys.has(workspace.workspaceKey)) {
         return;
       }
-      pendingWorkspaceKeysRef.current.add(workspace.workspaceKey);
+      pendingWorkspaceKeys.add(workspace.workspaceKey);
       mutate({ workspace, pinned: workspace.pinnedAt == null });
     },
     [mutate],


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Cmd+Shift+P (default pin/unpin shortcut) did nothing when the active workspace's row wasn't 
rendered in the sidebar. Collapsing a project section was the easy way to hit it, but the same
thing happened with a collapsed status group, a collapsed Pinned section (so you couldn't unpin
either), and in focus mode.

The cause is that the `workspace.pin` handler was registered by the sidebar row itself,
gated on `selected && canPin`. A collapsed `ProjectBlock` renders no workspace children at
all, so the only handler for the action unmounted with the row and
`keyboardActionDispatcher.dispatch` found zero candidates. It returns `false` and nothing
else picks the action up, so the keypress vanished with no toast and no error. Sidebar
visibility is not affected: `RetainedPanel` keeps a hidden sidebar mounted, so Cmd+B always
worked, which is part of why this is confusing to hit.

This moves the action to one always-mounted handler keyed on the active route selection,
following the same shape as `useGlobalNewWorkspaceAction` and `useActiveWorktreeNewAction`,
and deletes the two per-row registrations. The handler sits in a headless component rather
than being called from the root layout, so subscribing to the active workspace's pin state
doesn't re-render the whole app shell.

Two supporting changes:

- `useSidebarWorkspacePinController` now takes a narrow `PinnableWorkspace` instead of a
  full `SidebarWorkspaceEntry`, so a caller without a sidebar row can build one. Its
  in-flight guard moves to module scope, because the row menus and the shortcut hold
  separate controller instances and a per-instance guard would let a keypress and a menu
  click fire two concurrent, opposite RPCs.
- The handler resolves the descriptor id through `useWorkspaceFields` instead of reusing
  the route id. The route carries an opaque workspace id that isn't guaranteed to equal the
  descriptor id, which is why `selectWorkspace` runs it through
  `resolveWorkspaceMapKeyByIdentity`. Both the RPC and the in-flight key need the descriptor
  id so rows and this handler agree on one identity.

`workspace.archive` has the identical row-scoped defect (Cmd+Shift+Backspace is also a
no-op with the section collapsed). I left it alone to keep this to one change: it carries
per-row state (`isArchiving`, optimistic hiding, the risky-worktree confirm) and needs its
own PR.


### How did you verify it

Repro before the fix: open a workspace, collapse its project section in the sidebar, press
Cmd+Shift+P. Nothing happens. Expand the section and the same keypress pins it.

Verified manually in desktop app that it works correctly in the mentioned cases.

New Playwright spec, `packages/app/e2e/sidebar-workspace-pin-shortcut.spec.ts`, run against
a real daemon and a real browser:

```
✓ pins the active workspace while its project section is collapsed
✓ unpins the active workspace while the Pinned section is collapsed
✓ sends exactly one pin RPC per press when the row is rendered and selected
✓ pins the active workspace while its status group is collapsed
✓ shows an error toast when the host rejects the pin, and the next press succeeds
5 passed
```

To check the tests actually pin the regression rather than just passing, I stashed the
`packages/app/src` changes and reran the same spec against the pre-fix code. The three
collapse cases fail and the other two pass, which is the expected split — those two cover
the expanded-row path and the failure path, neither of which was broken:

```
✘ pins the active workspace while its project section is collapsed
✘ unpins the active workspace while the Pinned section is collapsed
✘ pins the active workspace while its status group is collapsed
✓ sends exactly one pin RPC per press when the row is rendered and selected
✓ shows an error toast when the host rejects the pin, and the next press succeeds
3 failed, 2 passed
```

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

