### PR TITLE
fix: keep archived Codex agents readable from History

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -62,6 +62,12 @@ Archive is distinct from runtime collection. Archive sets `archivedAt`, invokes 
 archive hook, and cascades to managed children. Runtime collection does none of those things; it only
 releases the live runtime and writes `lastStatus: closed` on the still-active record.
 
+History navigation may load an archived agent's provider timeline with a runtime-only history resume
+intent. That read-only load must leave both Paseo's `archivedAt` and the provider's native archived
+state unchanged: it never unarchives, re-archives, or creates a replacement provider session. Explicit
+**Unarchive** remains the only transition out of archive. It first unarchives the native provider
+session, then clears Paseo's `archivedAt`; the next interactive load uses the normal interactive resume.
+
 `create_agent_request` can opt an agent into `autoArchive`. In that mode the daemon archives the agent after the first terminal turn event (`turn_completed`, `turn_failed`, or `turn_canceled`). When the agent owns an isolated workspace, auto-archive archives that workspace too; the managed worktree is removed when its final workspace reference is gone.
 
 Archiving runs through `AgentManager.archiveAgent` (`packages/server/src/server/agent/agent-manager.ts`):

--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -99,6 +99,12 @@ Closing a tab on a **root agent** still archives — the tab is the agent's home
 
 Closing a tab on a **subagent** (any agent with `parentAgentId`) is **layout-only**. The agent stays unarchived and stays in its parent's track. The user can re-open the tab from the track at any time. This is implemented in `handleCloseAgentTab` (`packages/app/src/screens/workspace/workspace-screen.tsx`).
 
+When an agent is archived, reconciliation closes any ordinary workspace tab for that agent on every
+client. A user may explicitly reopen the archived agent from **History** as a read-only tab. That
+History-open intent is transient client state: reconciliation preserves the tab without auto-opening
+other archived agents, and clears the intent when the tab closes or the agent becomes active again.
+Opening the tab must not change either Paseo's or the provider's archive state.
+
 The asymmetry is intentional: a subagent's persistent relationship lives in the parent's track. Same-workspace subagents are not auto-opened as tabs; the user opens one from that track when needed. A cross-workspace subagent is also auto-opened as a tab in its own workspace so opening that workspace does not appear empty. It remains in the parent's track until it is actually detached.
 
 ## Workspace activity

--- a/packages/app/e2e/archive-tab.spec.ts
+++ b/packages/app/e2e/archive-tab.spec.ts
@@ -10,6 +10,7 @@ import {
   archiveAgentFromSessions,
   clickSessionRow,
   createIdleAgent,
+  expectArchivedAgentFocused,
   expectSessionRowArchived,
   expectSessionRowVisible,
   expectWorkspaceArchiveOutcome,
@@ -144,6 +145,7 @@ test.describe("Archive tab reconciliation", () => {
 
     await clickSessionRow(page, archived.title);
 
+    await expectArchivedAgentFocused(page, archived.id);
     expect(await fetchAgentArchivedAt(client, archived.id)).toBe(archivedAt);
 
     await expect(page).toHaveURL(buildHostWorkspaceRoute(getServerId(), archived.workspaceId), {

--- a/packages/app/src/components/agent-list.tsx
+++ b/packages/app/src/components/agent-list.tsx
@@ -19,7 +19,7 @@ import { type AggregatedAgent } from "@/hooks/use-aggregated-agents";
 import { useSessionStore } from "@/stores/session-store";
 import { Archive, ChevronRight } from "lucide-react-native";
 import { getProviderIcon } from "@/components/provider-icons";
-import { navigateToAgent } from "@/utils/navigate-to-agent";
+import { navigateToAgent, type AgentNavigationPurpose } from "@/utils/navigate-to-agent";
 import { useArchiveAgent } from "@/hooks/use-archive-agent";
 
 interface AgentListProps {
@@ -32,6 +32,7 @@ interface AgentListProps {
   listFooterComponent?: ReactElement | null;
   showAttentionIndicator?: boolean;
   showHostColumn?: boolean;
+  navigationPurpose?: AgentNavigationPurpose;
 }
 
 type DateSectionKey = "today" | "yesterday" | "thisWeek" | "thisMonth" | "older";
@@ -365,6 +366,7 @@ export function AgentList({
   listFooterComponent,
   showAttentionIndicator = true,
   showHostColumn = false,
+  navigationPurpose = "interactive",
 }: AgentListProps) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
@@ -394,9 +396,10 @@ export function AgentList({
         serverId,
         agentId,
         workspaceId: agent.workspaceId,
+        purpose: navigationPurpose,
       });
     },
-    [isActionSheetVisible, onAgentSelect],
+    [isActionSheetVisible, navigationPurpose, onAgentSelect],
   );
 
   const handleAgentLongPress = useCallback(

--- a/packages/app/src/screens/sessions-screen.tsx
+++ b/packages/app/src/screens/sessions-screen.tsx
@@ -120,6 +120,7 @@ function SessionsScreenContent() {
           listFooterComponent={listFooterComponent}
           showAttentionIndicator={false}
           showHostColumn
+          navigationPurpose="history"
         />
       ) : null}
     </View>

--- a/packages/app/src/stores/navigation-active-workspace-store/index.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/index.ts
@@ -16,6 +16,7 @@ import {
 } from "./navigation";
 import { useSessionStore } from "@/stores/session-store";
 import { useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
+import { usePanelStore } from "@/stores/panel-store";
 import { stripHostWorkspaceRouteEchoSearchFromBrowserUrlAfterCommit } from "@/utils/host-route-browser";
 import { navigateToHostWorkspaceRoute } from "@/navigation/workspace-route-navigation";
 
@@ -40,6 +41,9 @@ function navigateDeps(): NavigateToWorkspaceDeps {
       useWorkspaceLayoutStore.getState().openTabFocused(workspaceKey, target),
     pinAgent: (workspaceKey, agentId) =>
       useWorkspaceLayoutStore.getState().pinAgent(workspaceKey, agentId),
+    retainAgentHistory: (workspaceKey, agentId) =>
+      useWorkspaceLayoutStore.getState().retainAgentHistory(workspaceKey, agentId),
+    showWorkspaceContent: () => usePanelStore.getState().showMobileAgent(),
     rememberLastWorkspace: (selection) => lastWorkspaceSelectionStore.remember(selection),
     navigateToRoute: (route) => {
       navigateToHostWorkspaceRoute(route);

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.test.ts
@@ -19,6 +19,8 @@ function createFakeDeps(overrides: Partial<NavigateToWorkspaceDeps> = {}) {
   const navigations: string[] = [];
   const remembered: ActiveWorkspaceSelection[] = [];
   const openedTabs: RecordedTab[] = [];
+  const retainedAgentHistory: RecordedTab[] = [];
+  const workspaceContentCommands: string[] = [];
   const deps: NavigateToWorkspaceDeps = {
     getSessionWorkspaces: () => null,
     getSessionAgents: () => [] as Agent[],
@@ -27,11 +29,24 @@ function createFakeDeps(overrides: Partial<NavigateToWorkspaceDeps> = {}) {
       return target.kind === "agent" ? target.agentId : null;
     },
     pinAgent: () => undefined,
+    retainAgentHistory: (workspaceKey, agentId) =>
+      retainedAgentHistory.push({
+        workspaceKey,
+        target: { kind: "agent", agentId },
+      }),
+    showWorkspaceContent: () => workspaceContentCommands.push("show"),
     rememberLastWorkspace: (selection) => remembered.push(selection),
     navigateToRoute: (route) => navigations.push(route),
     ...overrides,
   };
-  return { deps, navigations, remembered, openedTabs };
+  return {
+    deps,
+    navigations,
+    remembered,
+    openedTabs,
+    retainedAgentHistory,
+    workspaceContentCommands,
+  };
 }
 
 function createLastSelectionDeps(
@@ -112,7 +127,7 @@ describe("workspace navigation", () => {
       requiresAttention: true,
       attentionReason: "permission",
     } as unknown as Agent;
-    const { deps, openedTabs } = createFakeDeps({
+    const { deps, openedTabs, workspaceContentCommands } = createFakeDeps({
       getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
       getSessionAgents: () => [agent],
     });
@@ -132,6 +147,68 @@ describe("workspace navigation", () => {
         target: { kind: "draft", draftId: "draft-1" },
       },
     ]);
+    expect(workspaceContentCommands).toEqual([]);
+  });
+
+  it.each([
+    ["agent", { kind: "agent", agentId: "agent-1" }],
+    ["terminal", { kind: "terminal", terminalId: "terminal-1" }],
+  ] satisfies Array<[string, WorkspaceTabTarget]>)(
+    "does not switch workspace content for ordinary %s navigation",
+    (_label, target) => {
+      const workspace = {
+        id: "workspace-a",
+        workspaceDirectory: "/repo/workspace-a",
+      } as WorkspaceDescriptor;
+      const { deps, workspaceContentCommands } = createFakeDeps({
+        getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
+      });
+
+      navigateToWorkspace(
+        {
+          serverId: "server-1",
+          workspaceId: "workspace-a",
+          target,
+        },
+        deps,
+      );
+
+      expect(workspaceContentCommands).toEqual([]);
+    },
+  );
+
+  it("retains a History agent before opening its workspace tab", () => {
+    const workspace = {
+      id: "workspace-a",
+      workspaceDirectory: "/repo/workspace-a",
+    } as WorkspaceDescriptor;
+    const { deps, openedTabs, retainedAgentHistory, workspaceContentCommands } = createFakeDeps({
+      getSessionWorkspaces: () => new Map([[workspace.id, workspace]]),
+    });
+
+    navigateToWorkspace(
+      {
+        serverId: "server-1",
+        workspaceId: "workspace-a",
+        target: { kind: "agent", agentId: "archived-agent" },
+        retainAgentHistory: true,
+      },
+      deps,
+    );
+
+    expect(retainedAgentHistory).toEqual([
+      {
+        workspaceKey: "server-1:workspace-a",
+        target: { kind: "agent", agentId: "archived-agent" },
+      },
+    ]);
+    expect(openedTabs).toEqual([
+      {
+        workspaceKey: "server-1:workspace-a",
+        target: { kind: "agent", agentId: "archived-agent" },
+      },
+    ]);
+    expect(workspaceContentCommands).toEqual(["show"]);
   });
 
   it("defers an agent tab until a missing workspace is recovered", () => {

--- a/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
+++ b/packages/app/src/stores/navigation-active-workspace-store/navigation.ts
@@ -11,7 +11,10 @@ import {
   resolveWorkspaceMapKeyByIdentity,
 } from "@/utils/workspace-identity";
 import type { ActiveWorkspaceSelection } from "@/stores/last-workspace-selection";
-import type { WorkspaceTabTarget } from "@/stores/workspace-tabs-store";
+import {
+  buildWorkspaceTabPersistenceKey,
+  type WorkspaceTabTarget,
+} from "@/stores/workspace-tabs-store";
 import { prepareWorkspaceTab, type PrepareWorkspaceTabDeps } from "@/utils/prepare-workspace-tab";
 
 export interface RouteSelectionInput {
@@ -27,6 +30,8 @@ export interface NavigateToWorkspaceInput {
   workspaceId: string;
   target?: WorkspaceTabTarget;
   pin?: boolean;
+  // Keeps an explicitly opened archived Agent tab without treating it as active or pinned.
+  retainAgentHistory?: boolean;
 }
 
 export interface NavigateToWorkspaceDeps extends PrepareWorkspaceTabDeps {
@@ -34,6 +39,8 @@ export interface NavigateToWorkspaceDeps extends PrepareWorkspaceTabDeps {
   getSessionAgents: (serverId: string) => Iterable<Agent>;
   rememberLastWorkspace: (selection: ActiveWorkspaceSelection) => void;
   navigateToRoute: (route: string) => void;
+  retainAgentHistory: (workspaceKey: string, agentId: string) => void;
+  showWorkspaceContent: () => void;
 }
 
 export interface NavigateToLastWorkspaceDeps extends NavigateToWorkspaceDeps {
@@ -89,6 +96,16 @@ export function navigateToWorkspace(
     workspaceId: input.workspaceId,
   });
   if (input.target) {
+    if (input.target.kind === "agent" && input.retainAgentHistory) {
+      deps.showWorkspaceContent();
+      const workspaceKey = buildWorkspaceTabPersistenceKey({
+        serverId: input.serverId,
+        workspaceId: input.workspaceId,
+      });
+      if (workspaceKey) {
+        deps.retainAgentHistory(workspaceKey, input.target.agentId);
+      }
+    }
     if (resolvedWorkspaceId || input.target.kind !== "agent") {
       prepareWorkspaceTab({ ...input, target: input.target }, deps);
     }

--- a/packages/app/src/stores/workspace-layout-actions.ts
+++ b/packages/app/src/stores/workspace-layout-actions.ts
@@ -195,6 +195,7 @@ export interface WorkspaceTabReconcileState {
   layout: WorkspaceLayout;
   pinnedAgentIds?: ReadonlySet<string> | null;
   hiddenAgentIds?: ReadonlySet<string> | null;
+  historyAgentIds?: ReadonlySet<string> | null;
 }
 
 export interface WorkspaceTabSnapshot {
@@ -1655,13 +1656,17 @@ function applyPinnedAndHidden(input: {
   pinnedAgentIds: Set<string>;
   hiddenAgentIds: Set<string>;
   knownAgentIds: Set<string>;
+  retainedAgentIds?: Set<string>;
 }): Set<string> {
-  const { baseAgentIds, pinnedAgentIds, hiddenAgentIds, knownAgentIds } = input;
+  const { baseAgentIds, pinnedAgentIds, hiddenAgentIds, knownAgentIds, retainedAgentIds } = input;
   const result = new Set(baseAgentIds);
   for (const agentId of pinnedAgentIds) {
     if (knownAgentIds.has(agentId)) {
       result.add(agentId);
     }
+  }
+  for (const agentId of retainedAgentIds ?? []) {
+    result.add(agentId);
   }
   for (const agentId of hiddenAgentIds) {
     result.delete(agentId);
@@ -1785,6 +1790,7 @@ export function reconcileWorkspaceTabs(
   let reconciledFocusedTabId = originalFocusedTabId;
   const pinnedAgentIds = new Set(state.pinnedAgentIds ?? []);
   const hiddenAgentIds = new Set(state.hiddenAgentIds ?? []);
+  const historyAgentIds = new Set(state.historyAgentIds ?? []);
   const activeAgentIds = normalizeStringSet(snapshot.activeAgentIds);
   const autoOpenAgentIds = normalizeStringSet(snapshot.autoOpenAgentIds);
   const knownAgentIds = normalizeStringSet(snapshot.knownAgentIds);
@@ -1797,6 +1803,7 @@ export function reconcileWorkspaceTabs(
     pinnedAgentIds,
     hiddenAgentIds,
     knownAgentIds,
+    retainedAgentIds: historyAgentIds,
   });
   const autoOpenSet = applyPinnedAndHidden({
     baseAgentIds: autoOpenAgentIds,

--- a/packages/app/src/stores/workspace-layout-store.test.ts
+++ b/packages/app/src/stores/workspace-layout-store.test.ts
@@ -311,6 +311,7 @@ describe("workspace-layout-store actions", () => {
       splitSizesByWorkspace: {},
       pinnedAgentIdsByWorkspace: {},
       hiddenAgentIdsByWorkspace: {},
+      historyAgentIdsByWorkspace: {},
       focusRestorationByWorkspace: {},
     });
   });
@@ -1254,6 +1255,24 @@ describe("workspace-layout-store actions", () => {
     });
   });
 
+  it("keeps History agent retention in memory without persisting it", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    store.retainAgentHistory(workspaceKey, "archived-agent");
+
+    const state = workspaceLayoutStore.getState();
+    expect(Array.from(state.historyAgentIdsByWorkspace[workspaceKey] ?? [])).toEqual([
+      "archived-agent",
+    ]);
+    const partialize = workspaceLayoutStore.persist.getOptions().partialize;
+    expect(partialize).toBeTypeOf("function");
+    expect(partialize?.(state)).toEqual({
+      layoutByWorkspace: {},
+      splitSizesByWorkspace: {},
+    });
+  });
+
   it("convertDraftToAgent removes the draft and focuses the existing canonical agent tab", () => {
     useWorkspaceLayoutIds("67676767-6767-6767-6767-676767676767");
     const workspaceKey = createWorkspaceKey();
@@ -1494,6 +1513,88 @@ describe("workspace-layout-store actions", () => {
         .getWorkspaceTabs(workspaceKey)
         .map((tab) => tab.tabId),
     ).toEqual(["agent_parent-agent"]);
+  });
+
+  it("reconcileTabs keeps an archived agent explicitly opened from History", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    store.retainAgentHistory(workspaceKey, "archived-agent");
+    const tabId = store.openTabFocused(workspaceKey, {
+      kind: "agent",
+      agentId: "archived-agent",
+    });
+
+    store.reconcileTabs(workspaceKey, {
+      agentsHydrated: true,
+      terminalsHydrated: true,
+      activeAgentIds: [],
+      autoOpenAgentIds: [],
+      knownAgentIds: ["archived-agent"],
+      standaloneTerminalIds: [],
+      hasActivePendingDraftCreate: false,
+    });
+
+    const state = workspaceLayoutStore.getState();
+    const layout = state.layoutByWorkspace[workspaceKey];
+    expect(state.getWorkspaceTabs(workspaceKey).map((tab) => tab.tabId)).toEqual([
+      "agent_archived-agent",
+    ]);
+    expect(findPaneById(layout.root, layout.focusedPaneId)?.focusedTabId).toBe(tabId);
+    expect(Array.from(state.historyAgentIdsByWorkspace[workspaceKey] ?? [])).toEqual([
+      "archived-agent",
+    ]);
+  });
+
+  it("clears History retention when the agent becomes active so a later archive prunes it", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    store.retainAgentHistory(workspaceKey, "agent-1");
+    store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-1" });
+    store.reconcileTabs(workspaceKey, {
+      agentsHydrated: true,
+      terminalsHydrated: true,
+      activeAgentIds: ["agent-1"],
+      autoOpenAgentIds: ["agent-1"],
+      knownAgentIds: ["agent-1"],
+      standaloneTerminalIds: [],
+      hasActivePendingDraftCreate: false,
+    });
+
+    expect(
+      workspaceLayoutStore.getState().historyAgentIdsByWorkspace[workspaceKey],
+    ).toBeUndefined();
+
+    store.reconcileTabs(workspaceKey, {
+      agentsHydrated: true,
+      terminalsHydrated: true,
+      activeAgentIds: [],
+      autoOpenAgentIds: [],
+      knownAgentIds: ["agent-1"],
+      standaloneTerminalIds: [],
+      hasActivePendingDraftCreate: false,
+    });
+
+    expect(workspaceLayoutStore.getState().getWorkspaceTabs(workspaceKey)).toEqual([]);
+  });
+
+  it("clears History retention when its agent tab is closed or hidden", () => {
+    const workspaceKey = createWorkspaceKey();
+    const store = workspaceLayoutStore.getState();
+
+    store.retainAgentHistory(workspaceKey, "agent-1");
+    const tabId = store.openTabFocused(workspaceKey, { kind: "agent", agentId: "agent-1" });
+    store.closeTab(workspaceKey, tabId!);
+    expect(
+      workspaceLayoutStore.getState().historyAgentIdsByWorkspace[workspaceKey],
+    ).toBeUndefined();
+
+    store.retainAgentHistory(workspaceKey, "agent-1");
+    store.hideAgent(workspaceKey, "agent-1");
+    expect(
+      workspaceLayoutStore.getState().historyAgentIdsByWorkspace[workspaceKey],
+    ).toBeUndefined();
   });
 
   it("openTabFocused reopens hidden subagent tabs and clears hidden intent", () => {

--- a/packages/app/src/stores/workspace-layout-store.ts
+++ b/packages/app/src/stores/workspace-layout-store.ts
@@ -76,6 +76,8 @@ interface WorkspaceLayoutStore {
   splitSizesByWorkspace: Record<string, Record<string, number[]>>;
   pinnedAgentIdsByWorkspace: Record<string, Set<string>>;
   hiddenAgentIdsByWorkspace: Record<string, Set<string>>;
+  // Transient intent for archived agents explicitly opened from the History screen.
+  historyAgentIdsByWorkspace: Record<string, Set<string>>;
   focusRestorationByWorkspace: Record<string, WorkspaceFocusRestorationState>;
   openTabFocused: (workspaceKey: string, target: WorkspaceTabTarget) => string | null;
   openChildTabFocused: (
@@ -116,6 +118,7 @@ interface WorkspaceLayoutStore {
   unpinAgent: (workspaceKey: string, agentId: string) => void;
   hideAgent: (workspaceKey: string, agentId: string) => void;
   unhideAgent: (workspaceKey: string, agentId: string) => void;
+  retainAgentHistory: (workspaceKey: string, agentId: string) => void;
   purgeWorkspace: (workspaceKey: string) => void;
 }
 
@@ -230,6 +233,7 @@ export function createWorkspaceLayoutStore(
         splitSizesByWorkspace: {},
         pinnedAgentIdsByWorkspace: {},
         hiddenAgentIdsByWorkspace: {},
+        historyAgentIdsByWorkspace: {},
         focusRestorationByWorkspace: {},
         openTabFocused: (workspaceKey, target) => {
           const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
@@ -339,8 +343,15 @@ export function createWorkspaceLayoutStore(
           }
 
           set((state) => {
+            const currentLayout = getWorkspaceLayout(
+              state.layoutByWorkspace,
+              normalizedWorkspaceKey,
+            );
+            const closedTab = collectAllTabs(currentLayout.root).find(
+              (tab) => tab.tabId === normalizedTabId,
+            );
             const nextLayout = closeTabInLayout({
-              layout: getWorkspaceLayout(state.layoutByWorkspace, normalizedWorkspaceKey),
+              layout: currentLayout,
               tabId: normalizedTabId,
             });
             if (!nextLayout) {
@@ -349,6 +360,14 @@ export function createWorkspaceLayoutStore(
 
             return {
               ...withoutFocusRestoration(state, normalizedWorkspaceKey),
+              historyAgentIdsByWorkspace:
+                closedTab?.target.kind !== "agent"
+                  ? state.historyAgentIdsByWorkspace
+                  : removeAgentIdFromWorkspaceSet(
+                      state.historyAgentIdsByWorkspace,
+                      normalizedWorkspaceKey,
+                      closedTab.target.agentId,
+                    ),
               layoutByWorkspace: {
                 ...state.layoutByWorkspace,
                 [normalizedWorkspaceKey]: nextLayout,
@@ -459,6 +478,17 @@ export function createWorkspaceLayoutStore(
           }
 
           set((state) => {
+            const activeAgentIds = new Set(snapshot.activeAgentIds);
+            let historyAgentIdsByWorkspace = state.historyAgentIdsByWorkspace;
+            for (const agentId of state.historyAgentIdsByWorkspace[normalizedWorkspaceKey] ?? []) {
+              if (activeAgentIds.has(agentId)) {
+                historyAgentIdsByWorkspace = removeAgentIdFromWorkspaceSet(
+                  historyAgentIdsByWorkspace,
+                  normalizedWorkspaceKey,
+                  agentId,
+                );
+              }
+            }
             const currentLayout = getWorkspaceLayout(
               state.layoutByWorkspace,
               normalizedWorkspaceKey,
@@ -468,14 +498,19 @@ export function createWorkspaceLayoutStore(
                 layout: currentLayout,
                 pinnedAgentIds: state.pinnedAgentIdsByWorkspace[normalizedWorkspaceKey] ?? null,
                 hiddenAgentIds: state.hiddenAgentIdsByWorkspace[normalizedWorkspaceKey] ?? null,
+                historyAgentIds: historyAgentIdsByWorkspace[normalizedWorkspaceKey] ?? null,
               },
-              snapshot,
+              { ...snapshot, activeAgentIds },
             );
-            if (nextState.layout === currentLayout) {
+            if (
+              nextState.layout === currentLayout &&
+              historyAgentIdsByWorkspace === state.historyAgentIdsByWorkspace
+            ) {
               return state;
             }
 
             return {
+              historyAgentIdsByWorkspace,
               layoutByWorkspace: {
                 ...state.layoutByWorkspace,
                 [normalizedWorkspaceKey]: nextState.layout,
@@ -830,12 +865,21 @@ export function createWorkspaceLayoutStore(
               normalizedWorkspaceKey,
               normalizedAgentId,
             );
-            if (nextHiddenAgentIdsByWorkspace === state.hiddenAgentIdsByWorkspace) {
+            const nextHistoryAgentIdsByWorkspace = removeAgentIdFromWorkspaceSet(
+              state.historyAgentIdsByWorkspace,
+              normalizedWorkspaceKey,
+              normalizedAgentId,
+            );
+            if (
+              nextHiddenAgentIdsByWorkspace === state.hiddenAgentIdsByWorkspace &&
+              nextHistoryAgentIdsByWorkspace === state.historyAgentIdsByWorkspace
+            ) {
               return state;
             }
 
             return {
               hiddenAgentIdsByWorkspace: nextHiddenAgentIdsByWorkspace,
+              historyAgentIdsByWorkspace: nextHistoryAgentIdsByWorkspace,
             };
           });
         },
@@ -861,6 +905,26 @@ export function createWorkspaceLayoutStore(
             };
           });
         },
+        retainAgentHistory: (workspaceKey, agentId) => {
+          const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
+          const normalizedAgentId = trimNonEmpty(agentId);
+          if (!normalizedWorkspaceKey || !normalizedAgentId) {
+            return;
+          }
+
+          set((state) => ({
+            hiddenAgentIdsByWorkspace: removeAgentIdFromWorkspaceSet(
+              state.hiddenAgentIdsByWorkspace,
+              normalizedWorkspaceKey,
+              normalizedAgentId,
+            ),
+            historyAgentIdsByWorkspace: addAgentIdToWorkspaceSet(
+              state.historyAgentIdsByWorkspace,
+              normalizedWorkspaceKey,
+              normalizedAgentId,
+            ),
+          }));
+        },
         purgeWorkspace: (workspaceKey) => {
           const normalizedWorkspaceKey = trimNonEmpty(workspaceKey);
           if (!normalizedWorkspaceKey) {
@@ -873,6 +937,7 @@ export function createWorkspaceLayoutStore(
               normalizedWorkspaceKey in state.splitSizesByWorkspace ||
               normalizedWorkspaceKey in state.pinnedAgentIdsByWorkspace ||
               normalizedWorkspaceKey in state.hiddenAgentIdsByWorkspace ||
+              normalizedWorkspaceKey in state.historyAgentIdsByWorkspace ||
               normalizedWorkspaceKey in state.focusRestorationByWorkspace;
             if (!hasAny) {
               return state;
@@ -885,6 +950,8 @@ export function createWorkspaceLayoutStore(
               state.pinnedAgentIdsByWorkspace;
             const { [normalizedWorkspaceKey]: _hidden, ...hiddenAgentIdsByWorkspace } =
               state.hiddenAgentIdsByWorkspace;
+            const { [normalizedWorkspaceKey]: _history, ...historyAgentIdsByWorkspace } =
+              state.historyAgentIdsByWorkspace;
             const { [normalizedWorkspaceKey]: _restoration, ...focusRestorationByWorkspace } =
               state.focusRestorationByWorkspace;
             return {
@@ -892,6 +959,7 @@ export function createWorkspaceLayoutStore(
               splitSizesByWorkspace,
               pinnedAgentIdsByWorkspace,
               hiddenAgentIdsByWorkspace,
+              historyAgentIdsByWorkspace,
               focusRestorationByWorkspace,
             };
           });

--- a/packages/app/src/utils/navigate-to-agent/index.ts
+++ b/packages/app/src/utils/navigate-to-agent/index.ts
@@ -3,7 +3,7 @@ import { navigateToWorkspace } from "@/stores/navigation-active-workspace-store"
 import { useSessionStore } from "@/stores/session-store";
 import { resolveNavigateToAgent, type NavigateToAgentInput } from "./resolve";
 
-export type { NavigateToAgentInput } from "./resolve";
+export type { AgentNavigationPurpose, NavigateToAgentInput } from "./resolve";
 
 export function navigateToAgent(input: NavigateToAgentInput): string {
   return resolveNavigateToAgent(input, {

--- a/packages/app/src/utils/navigate-to-agent/resolve.test.ts
+++ b/packages/app/src/utils/navigate-to-agent/resolve.test.ts
@@ -86,6 +86,31 @@ describe("resolveNavigateToAgent", () => {
     ]);
   });
 
+  it("marks History navigation so archived workspace reconciliation retains the tab", () => {
+    const { deps, tabNavigations } = createFakeNavigators({
+      agentWorkspaceId: WORKSPACE_ID,
+    });
+
+    resolveNavigateToAgent(
+      {
+        serverId: SERVER_ID,
+        agentId: AGENT_ID,
+        purpose: "history",
+      },
+      deps,
+    );
+
+    expect(tabNavigations).toEqual([
+      {
+        serverId: SERVER_ID,
+        workspaceId: WORKSPACE_ID,
+        target: { kind: "agent", agentId: AGENT_ID },
+        pin: undefined,
+        retainAgentHistory: true,
+      },
+    ]);
+  });
+
   it("falls back to the host agent route when the agent has no workspaceId", () => {
     const { deps, hostNavigations, tabNavigations } = createFakeNavigators({
       agentWorkspaceId: null,

--- a/packages/app/src/utils/navigate-to-agent/resolve.ts
+++ b/packages/app/src/utils/navigate-to-agent/resolve.ts
@@ -9,7 +9,10 @@ export interface NavigateToAgentInput {
   // (cold deep-links). Otherwise the workspace is read from the store.
   workspaceId?: string | null;
   pin?: boolean;
+  purpose?: AgentNavigationPurpose;
 }
+
+export type AgentNavigationPurpose = "interactive" | "history";
 
 export interface AgentNavTarget {
   agentWorkspaceId: string | null | undefined;
@@ -41,5 +44,6 @@ export function resolveNavigateToAgent(
     workspaceId,
     target: { kind: "agent", agentId: input.agentId },
     pin: input.pin,
+    ...(input.purpose === "history" ? { retainAgentHistory: true } : {}),
   });
 }

--- a/packages/server/src/server/agent/agent-loading.test.ts
+++ b/packages/server/src/server/agent/agent-loading.test.ts
@@ -1,0 +1,82 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "vitest";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import { AgentManager } from "./agent-manager.js";
+import { ensureAgentLoaded } from "./agent-loading.js";
+import { AgentStorage } from "./agent-storage.js";
+import type {
+  AgentClient,
+  AgentLaunchContext,
+  AgentPersistenceHandle,
+  AgentResumeSessionOptions,
+  AgentSession,
+  AgentSessionConfig,
+} from "./agent-sdk-types.js";
+import { createTestAgentClients } from "../test-utils/fake-agent-client.js";
+
+test("loads archived records for history and active records with the interactive default", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "agent-loading-purpose-"));
+  const logger = createTestLogger();
+  const storage = new AgentStorage(path.join(root, "agents"), logger);
+  const baseClient = createTestAgentClients().codex;
+  if (!baseClient) {
+    throw new Error("expected Codex test client");
+  }
+
+  const resumeOptions: Array<AgentResumeSessionOptions | undefined> = [];
+  const client: AgentClient = {
+    provider: baseClient.provider,
+    capabilities: baseClient.capabilities,
+    createSession: async (
+      config: AgentSessionConfig,
+      launchContext?: AgentLaunchContext,
+    ): Promise<AgentSession> => await baseClient.createSession(config, launchContext),
+    resumeSession: async (
+      handle: AgentPersistenceHandle,
+      overrides?: Partial<AgentSessionConfig>,
+      launchContext?: AgentLaunchContext,
+      options?: AgentResumeSessionOptions,
+    ): Promise<AgentSession> => {
+      resumeOptions.push(options);
+      return await baseClient.resumeSession(handle, overrides, launchContext);
+    },
+    fetchCatalog: async (options) => await baseClient.fetchCatalog(options),
+    isAvailable: async () => await baseClient.isAvailable(),
+  };
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+  });
+
+  const archivedId = "00000000-0000-4000-8000-000000000301";
+  const activeId = "00000000-0000-4000-8000-000000000302";
+
+  try {
+    const archived = await manager.createAgent({ provider: "codex", cwd: root }, archivedId, {
+      workspaceId: "workspace-archived",
+    });
+    await manager.archiveAgent(archived.id);
+
+    const active = await manager.createAgent({ provider: "codex", cwd: root }, activeId, {
+      workspaceId: "workspace-active",
+    });
+    await manager.closeAgent(active.id);
+
+    await ensureAgentLoaded(archived.id, { agentManager: manager, agentStorage: storage, logger });
+    await ensureAgentLoaded(active.id, { agentManager: manager, agentStorage: storage, logger });
+
+    expect(resumeOptions).toEqual([{ purpose: "history" }, undefined]);
+  } finally {
+    await Promise.all([
+      manager.closeAgent(archivedId).catch(() => undefined),
+      manager.closeAgent(activeId).catch(() => undefined),
+    ]);
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/server/src/server/agent/agent-loading.ts
+++ b/packages/server/src/server/agent/agent-loading.ts
@@ -94,6 +94,7 @@ export async function ensureAgentLoaded(
         buildConfigOverrides(record),
         agentId,
         extractTimestamps(record),
+        record.archivedAt ? { purpose: "history" } : undefined,
       );
       deps.logger.info({ agentId, provider: record.provider }, "Agent resumed from persistence");
     } else {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -19,6 +19,7 @@ import {
   type AgentCapabilityFlags,
   type AgentClient,
   type AgentCreateSessionOptions,
+  type AgentResumeSessionOptions,
   type AgentFeature,
   type AgentLaunchContext,
   type AgentSlashCommand,
@@ -1078,9 +1079,10 @@ export class AgentManager {
       workspaceId?: string;
       owner?: AgentOwner;
     },
+    resumeOptions?: AgentResumeSessionOptions,
   ): Promise<ManagedAgent> {
     return this.trackAgentRegistrationOperation(
-      this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options),
+      this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options, resumeOptions),
     );
   }
 
@@ -1096,6 +1098,7 @@ export class AgentManager {
       workspaceId?: string;
       owner?: AgentOwner;
     },
+    resumeOptions?: AgentResumeSessionOptions,
   ): Promise<ManagedAgent> {
     this.assertAcceptingAgentRegistrations();
     const resolvedAgentId = validateAgentId(
@@ -1122,7 +1125,12 @@ export class AgentManager {
     }
     const launchContext = await this.buildLaunchContext(resolvedAgentId, client);
     const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
-    const session = await client.resumeSession(handle, providerLaunchConfig, launchContext);
+    const session = await client.resumeSession(
+      handle,
+      providerLaunchConfig,
+      launchContext,
+      resumeOptions,
+    );
     return this.registerSession(session, storedConfig, resolvedAgentId, {
       ...options,
       persistence: handle,

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -602,6 +602,12 @@ export interface AgentCreateSessionOptions {
   persistSession?: boolean;
 }
 
+/** Runtime-only intent for a persisted-session resume. Never persist this option. */
+export interface AgentResumeSessionOptions {
+  /** Defaults to interactive. History loading may be read-only for archived native sessions. */
+  purpose?: "interactive" | "history";
+}
+
 /**
  * Returned by respondToPermission when the permission resolution requires
  * a follow-up turn (e.g. Codex plan approval → implementation).
@@ -688,6 +694,7 @@ export interface AgentClient {
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
+    options?: AgentResumeSessionOptions,
   ): Promise<AgentSession>;
   /**
    * Discover models and modes together. Implementations may use one upstream

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -408,7 +408,7 @@ function wrapClientProvider(
           launchContext,
         ),
       ),
-    resumeSession: async (handle, overrides, launchContext) =>
+    resumeSession: async (handle, overrides, launchContext, options) =>
       wrapSessionProvider(
         provider,
         await inner.resumeSession(
@@ -423,6 +423,7 @@ function wrapClientProvider(
               }
             : undefined,
           launchContext,
+          options,
         ),
       ),
     fetchCatalog: async (options) => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -106,6 +106,37 @@ function createSession(
   return session;
 }
 
+function createProviderWithFakeAppServer(appServer: FakeCodexAppServer): CodexAppServerAgentClient {
+  const provider = new CodexAppServerAgentClient(createTestLogger());
+  const internals = castInternals<{
+    goalsEnabledPromise: Promise<boolean> | null;
+    autoReviewEnabledPromise: Promise<boolean> | null;
+    spawnAppServer: () => Promise<ChildProcessWithoutNullStreams>;
+  }>(provider);
+  internals.goalsEnabledPromise = Promise.resolve(false);
+  internals.autoReviewEnabledPromise = Promise.resolve(false);
+  internals.spawnAppServer = async () => appServer.child;
+  return provider;
+}
+
+function archivedThreadHandle() {
+  return {
+    sessionId: "archived-thread-id",
+    metadata: {
+      cwd: "/tmp/codex-question-test",
+      modeId: "auto",
+      model: "gpt-5.4",
+    },
+  };
+}
+
+function archivedThreadErrorMessage(threadId: string): string {
+  return (
+    `session ${threadId} is archived. ` +
+    `Run \`codex unarchive ${threadId}\` to unarchive it first.`
+  );
+}
+
 function asInternals(session: CodexTestSession): CodexSessionTestAccess {
   return castInternals<CodexSessionTestAccess>(session);
 }
@@ -1113,12 +1144,7 @@ describe("Codex app-server provider", () => {
         };
       },
     });
-    const provider = new CodexAppServerAgentClient(createTestLogger());
-    castInternals<{ goalsEnabledPromise: Promise<boolean> | null }>(provider).goalsEnabledPromise =
-      Promise.resolve(false);
-    castInternals<{ spawnAppServer: () => Promise<ChildProcessWithoutNullStreams> }>(
-      provider,
-    ).spawnAppServer = async () => appServer.child;
+    const provider = createProviderWithFakeAppServer(appServer);
 
     const outcome = await Promise.race([
       provider
@@ -1150,6 +1176,225 @@ describe("Codex app-server provider", () => {
 
     expect(threadRequests).toEqual(["thread/loaded/list", "thread/resume"]);
     expect(outcome).toBe("rejected");
+    appServer.assertNoErrors();
+  });
+
+  test("loads an archived Codex thread for history without changing its native archive state", async () => {
+    const threadRequests: Array<{ method: string; params: unknown }> = [];
+    const appServer = createFakeCodexAppServer({
+      "thread/loaded/list": (params) => {
+        threadRequests.push({ method: "thread/loaded/list", params });
+        return { data: [] };
+      },
+      "thread/resume": (params) => {
+        threadRequests.push({ method: "thread/resume", params });
+        return Promise.reject(new Error(archivedThreadErrorMessage("archived-thread-id")));
+      },
+      "thread/read": (params) => {
+        threadRequests.push({ method: "thread/read", params });
+        return {
+          thread: {
+            id: "archived-thread-id",
+            turns: [
+              {
+                items: [
+                  {
+                    type: "agentMessage",
+                    id: "archived-history-message",
+                    text: "Archived history loaded.",
+                    timestamp: "2026-07-21T08:00:00.000Z",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      },
+      "thread/start": (params) => {
+        threadRequests.push({ method: "thread/start", params });
+        return { thread: { id: "replacement-thread-id" } };
+      },
+    });
+    const provider = createProviderWithFakeAppServer(appServer);
+
+    const session = await provider.resumeSession(archivedThreadHandle(), undefined, undefined, {
+      purpose: "history",
+    });
+    const history: AgentStreamEvent[] = [];
+    for await (const event of session.streamHistory()) {
+      history.push(event);
+    }
+
+    expect(session.id).toBe("archived-thread-id");
+    expect(history).toEqual([
+      {
+        type: "timeline",
+        provider: "codex",
+        timestamp: "2026-07-21T08:00:00.000Z",
+        item: {
+          type: "assistant_message",
+          text: "Archived history loaded.",
+          messageId: "archived-history-message",
+        },
+      },
+    ]);
+    expect(threadRequests).toEqual([
+      { method: "thread/loaded/list", params: {} },
+      { method: "thread/resume", params: { threadId: "archived-thread-id" } },
+      {
+        method: "thread/read",
+        params: { threadId: "archived-thread-id", includeTurns: true },
+      },
+    ]);
+    await session.close();
+    appServer.assertNoErrors();
+  });
+
+  test("rejects a turn after history loading when the archived thread still cannot resume", async () => {
+    const threadRequests: string[] = [];
+    const appServer = createFakeCodexAppServer({
+      "thread/loaded/list": () => {
+        threadRequests.push("thread/loaded/list");
+        return { data: [] };
+      },
+      "thread/resume": () => {
+        threadRequests.push("thread/resume");
+        return Promise.reject(new Error(archivedThreadErrorMessage("archived-thread-id")));
+      },
+      "thread/read": () => {
+        threadRequests.push("thread/read");
+        return { thread: { id: "archived-thread-id", turns: [] } };
+      },
+      "thread/start": () => {
+        threadRequests.push("thread/start");
+        return { thread: { id: "replacement-thread-id" } };
+      },
+      "turn/start": () => {
+        threadRequests.push("turn/start");
+        return {};
+      },
+    });
+    const provider = createProviderWithFakeAppServer(appServer);
+    const session = await provider.resumeSession(archivedThreadHandle(), undefined, undefined, {
+      purpose: "history",
+    });
+
+    await expect(session.startTurn("Try to continue this archived thread.")).rejects.toThrow(
+      archivedThreadErrorMessage("archived-thread-id"),
+    );
+
+    expect(threadRequests).toEqual([
+      "thread/loaded/list",
+      "thread/resume",
+      "thread/read",
+      "thread/loaded/list",
+      "thread/resume",
+    ]);
+    await session.close();
+    appServer.assertNoErrors();
+  });
+
+  test("rejects an archived Codex thread during an interactive resume", async () => {
+    const threadRequests: string[] = [];
+    const appServer = createFakeCodexAppServer({
+      "thread/loaded/list": () => {
+        threadRequests.push("thread/loaded/list");
+        return { data: [] };
+      },
+      "thread/resume": () => {
+        threadRequests.push("thread/resume");
+        return Promise.reject(new Error(archivedThreadErrorMessage("archived-thread-id")));
+      },
+      "thread/read": () => {
+        threadRequests.push("thread/read");
+        return { thread: { turns: [] } };
+      },
+    });
+    const provider = createProviderWithFakeAppServer(appServer);
+
+    await expect(provider.resumeSession(archivedThreadHandle())).rejects.toThrow(
+      archivedThreadErrorMessage("archived-thread-id"),
+    );
+
+    expect(threadRequests).toEqual(["thread/loaded/list", "thread/resume"]);
+    appServer.assertNoErrors();
+  });
+
+  test("rejects an archive error for a different Codex thread while loading history", async () => {
+    const threadRequests: string[] = [];
+    const appServer = createFakeCodexAppServer({
+      "thread/loaded/list": () => {
+        threadRequests.push("thread/loaded/list");
+        return { data: [] };
+      },
+      "thread/resume": () => {
+        threadRequests.push("thread/resume");
+        return Promise.reject(new Error(archivedThreadErrorMessage("another-thread-id")));
+      },
+      "thread/read": () => {
+        threadRequests.push("thread/read");
+        return { thread: { turns: [] } };
+      },
+    });
+    const provider = createProviderWithFakeAppServer(appServer);
+
+    await expect(
+      provider.resumeSession(archivedThreadHandle(), undefined, undefined, { purpose: "history" }),
+    ).rejects.toThrow(archivedThreadErrorMessage("another-thread-id"));
+
+    expect(threadRequests).toEqual(["thread/loaded/list", "thread/resume"]);
+    appServer.assertNoErrors();
+  });
+
+  test("rejects other resume errors while loading Codex history", async () => {
+    const threadRequests: string[] = [];
+    const appServer = createFakeCodexAppServer({
+      "thread/loaded/list": () => {
+        threadRequests.push("thread/loaded/list");
+        return { data: [] };
+      },
+      "thread/resume": () => {
+        threadRequests.push("thread/resume");
+        return Promise.reject(new Error("Codex app-server resume failed"));
+      },
+      "thread/read": () => {
+        threadRequests.push("thread/read");
+        return { thread: { turns: [] } };
+      },
+    });
+    const provider = createProviderWithFakeAppServer(appServer);
+
+    await expect(
+      provider.resumeSession(archivedThreadHandle(), undefined, undefined, { purpose: "history" }),
+    ).rejects.toThrow("Codex app-server resume failed");
+
+    expect(threadRequests).toEqual(["thread/loaded/list", "thread/resume"]);
+    appServer.assertNoErrors();
+  });
+
+  test("rejects when an archived Codex thread history cannot be read", async () => {
+    const threadRequests: string[] = [];
+    const appServer = createFakeCodexAppServer({
+      "thread/loaded/list": () => {
+        threadRequests.push("thread/loaded/list");
+        return { data: [] };
+      },
+      "thread/resume": () => {
+        threadRequests.push("thread/resume");
+        return Promise.reject(new Error(archivedThreadErrorMessage("archived-thread-id")));
+      },
+      "thread/read": () => {
+        threadRequests.push("thread/read");
+        return Promise.reject(new Error("thread history is unavailable"));
+      },
+    });
+    const provider = createProviderWithFakeAppServer(appServer);
+
+    await expect(
+      provider.resumeSession(archivedThreadHandle(), undefined, undefined, { purpose: "history" }),
+    ).rejects.toThrow("thread history is unavailable");
+
+    expect(threadRequests).toEqual(["thread/loaded/list", "thread/resume", "thread/read"]);
     appServer.assertNoErrors();
   });
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -6,6 +6,7 @@ import {
   type AgentCreateSessionOptions,
   type AgentFeature,
   type AgentLaunchContext,
+  type AgentResumeSessionOptions,
   type AgentMode,
   type AgentModelDefinition,
   type McpServerConfig,
@@ -108,6 +109,14 @@ function assertChildWithPipes(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isArchivedCodexThreadResumeError(error: unknown, threadId: string): boolean {
+  if (!(error instanceof Error)) return false;
+  const expectedMessage =
+    `session ${threadId} is archived. ` +
+    `Run \`codex unarchive ${threadId}\` to unarchive it first.`;
+  return error.message === expectedMessage;
 }
 
 function isCodexAlreadyUnarchivedError(error: unknown, threadId: string): boolean {
@@ -3174,6 +3183,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     private readonly goalsEnabled: boolean = false,
     private readonly autoReviewEnabled: boolean = false,
     private readonly agentId?: string,
+    private readonly initialResumePurpose: "interactive" | "history" = "interactive",
   ) {
     this.logger = logger.child({
       module: "agent",
@@ -3227,7 +3237,9 @@ export class CodexAppServerAgentSession implements AgentSession {
     await this.loadSkills();
 
     if (this.currentThreadId) {
-      await this.ensureThreadLoaded();
+      await this.ensureThreadLoaded({
+        allowArchivedHistory: this.initialResumePurpose === "history",
+      });
       await this.loadPersistedHistory();
     }
 
@@ -3537,7 +3549,9 @@ export class CodexAppServerAgentSession implements AgentSession {
     }
   }
 
-  private async ensureThreadLoaded(): Promise<void> {
+  private async ensureThreadLoaded(
+    options: { allowArchivedHistory?: boolean } = {},
+  ): Promise<void> {
     if (!this.client || !this.currentThreadId) return;
     try {
       const loaded = toObjectRecord(await this.client.request("thread/loaded/list", {}));
@@ -3561,6 +3575,16 @@ export class CodexAppServerAgentSession implements AgentSession {
     } catch (error) {
       const threadId = this.currentThreadId;
       const message = error instanceof Error ? error.message : String(error);
+      if (
+        options.allowArchivedHistory === true &&
+        isArchivedCodexThreadResumeError(error, threadId)
+      ) {
+        this.logger.info(
+          { threadId },
+          "Loading archived Codex thread history without resuming the native session",
+        );
+        return;
+      }
       this.logger.warn({ error, threadId }, "Failed to resume persisted Codex thread");
       throw new Error(`Failed to resume Codex thread ${threadId}: ${message}`, { cause: error });
     }
@@ -6303,6 +6327,7 @@ export class CodexAppServerAgentClient implements AgentClient {
     handle: { sessionId: string; metadata?: Record<string, unknown> },
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
+    options?: AgentResumeSessionOptions,
   ): Promise<AgentSession> {
     const storedConfig = (handle.metadata ?? {}) as Partial<AgentSessionConfig>;
     const merged: AgentSessionConfig = {
@@ -6324,6 +6349,7 @@ export class CodexAppServerAgentClient implements AgentClient {
       goalsEnabled,
       autoReviewEnabled,
       launchContext?.agentId,
+      options?.purpose ?? "interactive",
     );
     await session.connect();
     return session;


### PR DESCRIPTION
### Linked issue

Closes #2307

Related context: #1435, #2002, #2123.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Opening an archived Codex agent from History now loads its existing conversation without changing archive state.

The daemon passes a runtime-only History resume intent for archived records. Codex still attempts `thread/resume`, but only the exact archived-session rejection for the current thread is allowed to continue to the existing `thread/read(includeTurns: true)` history path. Other resume errors, interactive resumes, later turns, and read failures remain strict.

The app records an explicit, transient History-open intent before creating the workspace tab. Reconciliation keeps that read-only archived tab without auto-opening other archived agents, while ordinary tabs still close on archive. The intent is cleared on close, hide, unarchive, or workspace purge and is not persisted. Compact clients switch to the content panel only for this History Agent navigation.

This does not unarchive/rearchive the native thread, create a replacement thread, change the WebSocket protocol, or change persisted data formats. Explicit **Unarchive** remains the only transition back to an interactive agent.

### How did you verify it

Reproduction before the fix:

1. Create a Codex agent and complete a turn.
2. Archive it.
3. Open History and select the archived row.
4. The conversation fails to stay open. The daemon reports `session <thread-id> is archived`, or, after isolating the server read path, the client immediately reconciles the tab away.

Verification after the fix:

- A packaged build now opens the archived agent, renders its existing timeline, keeps the archived callout visible, and leaves `archivedAt` unchanged.
- Codex provider test: 111 passed.
- Agent loading test: 1 passed.
- Relevant app navigation/layout tests: 69 passed; the final scoped navigation run was 12/12.
- `npm run format`: passed.
- `npm run typecheck`: passed.
- `npm run lint`: 0 warnings, 0 errors.
- `git diff --check`: passed.

The single archive Playwright scenario was attempted twice locally, but the isolated relay repeatedly replaced its daemon control connection before any browser session or test assertion ran (`Replaced by new connection`). The process was stopped without touching the production daemon; the pushed CI Playwright shard will provide the E2E result.

Android and Windows before/after screenshots or video are pending attachment while this PR is Draft. iOS and web have not received separate manual verification.

### Risk surface

- The History intent is internal runtime state only; there is no protocol or storage migration.
- The Codex archived-error match intentionally includes the current thread ID and full upstream message. If Codex changes that text, History loading fails safely instead of bypassing an unrelated resume failure.
- Normal archive reconciliation and all interactive resume paths retain their previous strict behavior.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
