### PR TITLE
Show recent commit history in the explorer

### DIFF
--- a/packages/app/src/git/checkout-status-cache.test.ts
+++ b/packages/app/src/git/checkout-status-cache.test.ts
@@ -2,7 +2,11 @@
 import { QueryClient } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CheckoutStatusUpdate } from "@getpaseo/protocol/messages";
-import { checkoutPrStatusQueryKey, checkoutStatusQueryKey } from "@/git/query-keys";
+import {
+  checkoutCommitsQueryKey,
+  checkoutPrStatusQueryKey,
+  checkoutStatusQueryKey,
+} from "@/git/query-keys";
 import {
   prPanePipelineQueryKey,
   prPaneTimelineQueryKey,
@@ -130,6 +134,25 @@ describe("applyCheckoutStatusUpdateFromEvent", () => {
     });
 
     expect(queryClient.getQueryData(checkoutStatusQueryKey(serverId, cwd))).toEqual(pushed);
+  });
+
+  it("invalidates recent commits when checkout status is pushed", () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(checkoutCommitsQueryKey(serverId, cwd), { commits: [] });
+    queryClient.setQueryData(checkoutCommitsQueryKey(serverId, "/repo2"), { commits: [] });
+
+    applyCheckoutStatusUpdateFromEvent({
+      queryClient,
+      serverId,
+      message: checkoutStatusUpdate(checkoutStatus()),
+    });
+
+    expect(queryClient.getQueryState(checkoutCommitsQueryKey(serverId, cwd))?.isInvalidated).toBe(
+      true,
+    );
+    expect(
+      queryClient.getQueryState(checkoutCommitsQueryKey(serverId, "/repo2"))?.isInvalidated,
+    ).toBe(false);
   });
 
   it("writes the PR status cache when prStatus is present, and skips it otherwise", () => {

--- a/packages/app/src/git/checkout-status-cache.ts
+++ b/packages/app/src/git/checkout-status-cache.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import type { CheckoutStatusResponse, CheckoutStatusUpdate } from "@getpaseo/protocol/messages";
 import equal from "fast-deep-equal/es6";
 import {
+  checkoutCommitsQueryKey,
   checkoutPrStatusQueryKey,
   checkoutStatusQueryKey,
   invalidatePrPaneTimelineForCheckout,
@@ -49,6 +50,9 @@ export function applyCheckoutStatusUpdateFromEvent({
     : undefined;
   const cachePayload = prStatus ? { ...payload, prStatus } : payload;
   queryClient.setQueryData(checkoutStatusQueryKey(serverId, payload.cwd), cachePayload);
+  void queryClient.invalidateQueries({
+    queryKey: checkoutCommitsQueryKey(serverId, payload.cwd),
+  });
   expireStaleDiffModeOverrides({
     serverId,
     cwd: payload.cwd,

--- a/packages/app/src/git/query-keys.test.ts
+++ b/packages/app/src/git/query-keys.test.ts
@@ -2,6 +2,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
 import {
   checkoutDiffQueryKey,
+  checkoutCommitsQueryKey,
   checkoutPrStatusQueryKey,
   checkoutStatusQueryKey,
   invalidateCheckoutGitQueriesForClient,
@@ -24,6 +25,8 @@ describe("checkout query keys", () => {
       files: [],
     });
     queryClient.setQueryData(checkoutPrStatusQueryKey(serverId, cwd), { status: { number: 12 } });
+    queryClient.setQueryData(checkoutCommitsQueryKey(serverId, cwd), { commits: [] });
+    queryClient.setQueryData(checkoutCommitsQueryKey(serverId, "/tmp/other"), { commits: [] });
     queryClient.setQueryData(prPaneTimelineQueryKey({ serverId, cwd, prNumber: 12 }), {
       items: [],
     });
@@ -62,6 +65,12 @@ describe("checkout query keys", () => {
     expect(queryClient.getQueryState(checkoutPrStatusQueryKey(serverId, cwd))?.isInvalidated).toBe(
       true,
     );
+    expect(queryClient.getQueryState(checkoutCommitsQueryKey(serverId, cwd))?.isInvalidated).toBe(
+      true,
+    );
+    expect(
+      queryClient.getQueryState(checkoutCommitsQueryKey(serverId, "/tmp/other"))?.isInvalidated,
+    ).toBe(false);
     expect(
       queryClient.getQueryState(prPaneTimelineQueryKey({ serverId, cwd, prNumber: 12 }))
         ?.isInvalidated,
@@ -102,6 +111,8 @@ describe("checkout query keys", () => {
     queryClient.setQueryData(checkoutStatusQueryKey(serverId, cwd), { isGit: true });
     queryClient.setQueryData(checkoutStatusQueryKey(serverId, otherCwd), { isGit: true });
     queryClient.setQueryData(checkoutPrStatusQueryKey(serverId, cwd), { status: { number: 12 } });
+    queryClient.setQueryData(checkoutCommitsQueryKey(serverId, cwd), { commits: [] });
+    queryClient.setQueryData(checkoutCommitsQueryKey(otherServerId, cwd), { commits: [] });
     queryClient.setQueryData(prPaneTimelineQueryKey({ serverId, cwd, prNumber: 12 }), {
       items: [],
     });
@@ -128,6 +139,12 @@ describe("checkout query keys", () => {
     expect(queryClient.getQueryState(checkoutPrStatusQueryKey(serverId, cwd))?.isInvalidated).toBe(
       true,
     );
+    expect(queryClient.getQueryState(checkoutCommitsQueryKey(serverId, cwd))?.isInvalidated).toBe(
+      true,
+    );
+    expect(
+      queryClient.getQueryState(checkoutCommitsQueryKey(otherServerId, cwd))?.isInvalidated,
+    ).toBe(false);
     expect(
       queryClient.getQueryState(prPaneTimelineQueryKey({ serverId, cwd, prNumber: 12 }))
         ?.isInvalidated,

--- a/packages/app/src/git/query-keys.ts
+++ b/packages/app/src/git/query-keys.ts
@@ -63,6 +63,9 @@ export async function invalidateCheckoutGitQueriesForClient(
       predicate: checkoutQueryPredicate("checkoutPrStatus", identity),
     }),
     queryClient.invalidateQueries({
+      queryKey: checkoutCommitsQueryKey(identity.serverId, identity.cwd),
+    }),
+    queryClient.invalidateQueries({
       predicate: checkoutQueryPredicate(prPaneTimelineQueryKind, identity),
     }),
     queryClient.invalidateQueries({
@@ -81,6 +84,7 @@ export async function invalidateCheckoutGitQueriesForServer(
   const kinds = [
     "checkoutStatus",
     "checkoutPrStatus",
+    "checkoutCommits",
     prPaneTimelineQueryKind,
     prPanePipelineQueryKind,
   ];

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -788,12 +788,12 @@ export const ar: TranslationResources = {
         deletedFile: "تم الحذف",
         commits: {
           title: "الإيداعات",
-          countLabel: "{{count}} إيداعات قبل الأساس",
+          countLabel: "{{count}} من الإيداعات الأخيرة",
           fileDiffEmpty: "لا توجد تغييرات لعرضها",
           fileDiffError: "تعذّر تحميل فروق الملف",
           loading: "جارٍ تحميل الإيداعات…",
           loadError: "تعذّر تحميل الإيداعات",
-          empty: "لا توجد إيداعات قبل الأساس",
+          empty: "لا توجد إيداعات بعد",
         },
       },
       openInEditor: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -798,12 +798,12 @@ export const en = {
         deletedFile: "Deleted",
         commits: {
           title: "Commits",
-          countLabel: "{{count}} commits ahead of base",
+          countLabel: "{{count}} recent commits",
           fileDiffEmpty: "No changes to display",
           fileDiffError: "Failed to load file diff",
           loading: "Loading commits…",
           loadError: "Failed to load commits",
-          empty: "No commits ahead of base",
+          empty: "No commits yet",
         },
       },
       openInEditor: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -819,12 +819,12 @@ export const es: TranslationResources = {
         deletedFile: "Eliminado",
         commits: {
           title: "Commits",
-          countLabel: "{{count}} commits por delante de la base",
+          countLabel: "{{count}} commits recientes",
           fileDiffEmpty: "No hay cambios para mostrar",
           fileDiffError: "Error al cargar el diff del archivo",
           loading: "Cargando commits…",
           loadError: "Error al cargar los commits",
-          empty: "No hay commits por delante de la base",
+          empty: "Aún no hay commits",
         },
       },
       openInEditor: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -818,12 +818,12 @@ export const fr: TranslationResources = {
         deletedFile: "Supprimé",
         commits: {
           title: "Commits",
-          countLabel: "{{count}} commits en avance sur la base",
+          countLabel: "{{count}} commits récents",
           fileDiffEmpty: "Aucune modification à afficher",
           fileDiffError: "Échec du chargement du diff du fichier",
           loading: "Chargement des commits…",
           loadError: "Échec du chargement des commits",
-          empty: "Aucun commit en avance sur la base",
+          empty: "Aucun commit pour le moment",
         },
       },
       openInEditor: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -799,12 +799,12 @@ export const ja: TranslationResources = {
         deletedFile: "削除済み",
         commits: {
           title: "コミット",
-          countLabel: "ベースより先のコミット数: {{count}}",
+          countLabel: "最近のコミット数: {{count}}",
           fileDiffEmpty: "表示する変更はありません",
           fileDiffError: "ファイル差分の読み込みに失敗しました",
           loading: "コミットを読み込み中…",
           loadError: "コミットの読み込みに失敗しました",
-          empty: "ベースより先のコミットはありません",
+          empty: "コミットはまだありません",
         },
       },
       openInEditor: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -810,12 +810,12 @@ export const ptBR: TranslationResources = {
         deletedFile: "Excluído",
         commits: {
           title: "Commits",
-          countLabel: "{{count}} commits à frente da base",
+          countLabel: "{{count}} commits recentes",
           fileDiffEmpty: "Nenhuma alteração para exibir",
           fileDiffError: "Falha ao carregar diff do arquivo",
           loading: "Carregando commits…",
           loadError: "Falha ao carregar commits",
-          empty: "Nenhum commit à frente da base",
+          empty: "Ainda não há commits",
         },
       },
       openInEditor: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -810,12 +810,12 @@ export const ru: TranslationResources = {
         deletedFile: "Удалено",
         commits: {
           title: "Коммиты",
-          countLabel: "{{count}} коммитов впереди базы",
+          countLabel: "{{count}} последних коммитов",
           fileDiffEmpty: "Нет изменений для отображения",
           fileDiffError: "Не удалось загрузить различия файла",
           loading: "Загрузка коммитов…",
           loadError: "Не удалось загрузить коммиты",
-          empty: "Нет коммитов впереди базы",
+          empty: "Коммитов пока нет",
         },
       },
       openInEditor: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -780,12 +780,12 @@ export const zhCN: TranslationResources = {
         deletedFile: "已删除",
         commits: {
           title: "提交",
-          countLabel: "领先基线 {{count}} 个提交",
+          countLabel: "最近 {{count}} 个提交",
           fileDiffEmpty: "没有可显示的更改",
           fileDiffError: "加载文件差异失败",
           loading: "正在加载提交…",
           loadError: "加载提交失败",
-          empty: "没有领先基线的提交",
+          empty: "暂无提交",
         },
       },
       openInEditor: {

--- a/packages/server/src/utils/checkout-git.commit-file-diff.test.ts
+++ b/packages/server/src/utils/checkout-git.commit-file-diff.test.ts
@@ -88,4 +88,22 @@ describe("getCommitFileDiff", () => {
 
     expect(file).toBeNull();
   });
+
+  it("returns a merge commit diff against its first parent", async () => {
+    const repoDir = initRepo();
+    commitFile(repoDir, "README.md", "base\n", "initial");
+    git(["checkout", "-b", "feature"], repoDir);
+    commitFile(repoDir, "feature.txt", "feature\n", "add feature");
+    git(["checkout", "main"], repoDir);
+    commitFile(repoDir, "main.txt", "main\n", "advance main");
+    git(["merge", "--no-ff", "feature", "-m", "merge feature"], repoDir);
+    const sha = headSha(repoDir);
+
+    const file = await getCommitFileDiff({ cwd: repoDir, sha, path: "feature.txt" });
+
+    expect(file?.path).toBe("feature.txt");
+    expect(file?.isNew).toBe(true);
+    expect(file?.additions).toBe(1);
+    expect(file?.deletions).toBe(0);
+  });
 });

--- a/packages/server/src/utils/checkout-git.commits.test.ts
+++ b/packages/server/src/utils/checkout-git.commits.test.ts
@@ -107,6 +107,21 @@ describe("listCheckoutCommits", () => {
     expect(commits.every((c) => c.isOnRemote === false)).toBe(true);
   });
 
+  it("recognizes base history on a remote before the feature branch is pushed", async () => {
+    const { repoDir, tempDir } = initRepoOnMain();
+    addBareRemote(repoDir, tempDir);
+    git(["push", "-u", "origin", "main"], repoDir);
+    git(["checkout", "-b", "feature"], repoDir);
+    commitFile(repoDir, "feature.txt", "local\n", "Local feature");
+
+    const { commits } = await listCheckoutCommits({ cwd: repoDir });
+
+    expect(commits.map(({ subject, isOnRemote }) => ({ subject, isOnRemote }))).toEqual([
+      { subject: "Local feature", isOnRemote: false },
+      { subject: "initial", isOnRemote: true },
+    ]);
+  });
+
   it("limits history to the 20 most recent commits", async () => {
     const { repoDir } = initRepoOnMain();
     for (let index = 1; index <= 24; index += 1) {
@@ -119,6 +134,26 @@ describe("listCheckoutCommits", () => {
     expect(commits.map((entry) => entry.subject)).toEqual(
       Array.from({ length: 20 }, (_, index) => `Commit ${24 - index}`),
     );
+  });
+
+  it("shows merge commits with changes against their first parent", async () => {
+    const { repoDir } = initRepoOnMain();
+    git(["checkout", "-b", "feature"], repoDir);
+    commitFile(repoDir, "feature.txt", "feature\n", "Add feature");
+    git(["checkout", "main"], repoDir);
+    commitFile(repoDir, "main.txt", "main\n", "Advance main");
+    git(["merge", "--no-ff", "feature", "-m", "Merge feature"], repoDir);
+
+    const { commits } = await listCheckoutCommits({ cwd: repoDir });
+
+    expect(commits.map((entry) => entry.subject)).toEqual([
+      "Merge feature",
+      "Advance main",
+      "initial",
+    ]);
+    expect(commits[0]?.files).toEqual([
+      { path: "feature.txt", additions: 1, deletions: 0, status: "added" },
+    ]);
   });
 
   it("classifies renamed files with status renamed and correct destination path", async () => {

--- a/packages/server/src/utils/checkout-git.commits.test.ts
+++ b/packages/server/src/utils/checkout-git.commits.test.ts
@@ -52,7 +52,7 @@ function addBareRemote(repoDir: string, tempDir: string): string {
 }
 
 describe("listCheckoutCommits", () => {
-  it("lists commits ahead of base newest-first with on-remote flags and file stats", async () => {
+  it("lists recent commits newest-first with on-remote flags and file stats", async () => {
     const { repoDir, tempDir } = initRepoOnMain();
     git(["checkout", "-b", "feature"], repoDir);
     commitFile(repoDir, "foo.txt", "a\nb\nc\n", "Add foo");
@@ -65,12 +65,14 @@ describe("listCheckoutCommits", () => {
     const { baseRef, commits } = await listCheckoutCommits({ cwd: repoDir });
 
     expect(baseRef).toBe("main");
-    expect(commits).toHaveLength(2);
+    expect(commits).toHaveLength(3);
     expect(commits[0]?.subject).toBe("Add bar");
     expect(commits[1]?.subject).toBe("Add foo");
+    expect(commits[2]?.subject).toBe("initial");
 
     expect(commits[0]?.isOnRemote).toBe(false);
     expect(commits[1]?.isOnRemote).toBe(true);
+    expect(commits[2]?.isOnRemote).toBe(true);
 
     expect(commits[0]?.files).toEqual([
       { path: "bar.txt", additions: 1, deletions: 0, status: "added" },
@@ -85,11 +87,11 @@ describe("listCheckoutCommits", () => {
     expect(Number.isNaN(new Date(commits[0]?.authorDate ?? "").getTime())).toBe(false);
   });
 
-  it("returns [] when there are no commits ahead of base", async () => {
+  it("shows recent history on the base branch", async () => {
     const { repoDir } = initRepoOnMain();
     const { baseRef, commits } = await listCheckoutCommits({ cwd: repoDir });
     expect(baseRef).toBeNull();
-    expect(commits).toEqual([]);
+    expect(commits.map((entry) => entry.subject)).toEqual(["initial"]);
   });
 
   it("marks all commits local-only when there is no remote", async () => {
@@ -101,8 +103,22 @@ describe("listCheckoutCommits", () => {
     const { baseRef, commits } = await listCheckoutCommits({ cwd: repoDir });
 
     expect(baseRef).toBe("main");
-    expect(commits).toHaveLength(2);
+    expect(commits).toHaveLength(3);
     expect(commits.every((c) => c.isOnRemote === false)).toBe(true);
+  });
+
+  it("limits history to the 20 most recent commits", async () => {
+    const { repoDir } = initRepoOnMain();
+    for (let index = 1; index <= 24; index += 1) {
+      commitFile(repoDir, "history.txt", `${index}\n`, `Commit ${index}`);
+    }
+
+    const { commits } = await listCheckoutCommits({ cwd: repoDir });
+
+    expect(commits).toHaveLength(20);
+    expect(commits.map((entry) => entry.subject)).toEqual(
+      Array.from({ length: 20 }, (_, index) => `Commit ${24 - index}`),
+    );
   });
 
   it("classifies renamed files with status renamed and correct destination path", async () => {

--- a/packages/server/src/utils/checkout-git.commits.test.ts
+++ b/packages/server/src/utils/checkout-git.commits.test.ts
@@ -122,7 +122,7 @@ describe("listCheckoutCommits", () => {
     ]);
   });
 
-  it("limits history to the 20 most recent commits", async () => {
+  it("limits history and unpushed classification to the 20 most recent commits", async () => {
     const { repoDir } = initRepoOnMain();
     for (let index = 1; index <= 24; index += 1) {
       commitFile(repoDir, "history.txt", `${index}\n`, `Commit ${index}`);
@@ -131,6 +131,7 @@ describe("listCheckoutCommits", () => {
     const { commits } = await listCheckoutCommits({ cwd: repoDir });
 
     expect(commits).toHaveLength(20);
+    expect(commits.every((entry) => entry.isOnRemote === false)).toBe(true);
     expect(commits.map((entry) => entry.subject)).toEqual(
       Array.from({ length: 20 }, (_, index) => `Commit ${24 - index}`),
     );

--- a/packages/server/src/utils/checkout-git.commits.test.ts
+++ b/packages/server/src/utils/checkout-git.commits.test.ts
@@ -136,7 +136,7 @@ describe("listCheckoutCommits", () => {
     );
   });
 
-  it("shows merge commits with changes against their first parent", async () => {
+  it("shows merged branch commits and compares the merge against its first parent", async () => {
     const { repoDir } = initRepoOnMain();
     git(["checkout", "-b", "feature"], repoDir);
     commitFile(repoDir, "feature.txt", "feature\n", "Add feature");
@@ -149,6 +149,7 @@ describe("listCheckoutCommits", () => {
     expect(commits.map((entry) => entry.subject)).toEqual([
       "Merge feature",
       "Advance main",
+      "Add feature",
       "initial",
     ]);
     expect(commits[0]?.files).toEqual([

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -2001,9 +2001,8 @@ export async function getCheckoutStatus(
   };
 }
 
-// Cap on how many ahead-of-base commits we enumerate. Branches with more than
-// this many unmerged commits are truncated to the newest MAX_CHECKOUT_COMMITS.
-const MAX_CHECKOUT_COMMITS = 200;
+// The explorer is a recent-history view, not a full repository log.
+const MAX_CHECKOUT_COMMITS = 20;
 // Bytes git emits between fields/records. We split parsed output on these.
 const COMMIT_FIELD_SEPARATOR = "\x00";
 const COMMIT_RECORD_SEPARATOR = "\x1e";
@@ -2189,13 +2188,8 @@ async function getLocalOnlyCommitShas(
 }
 
 /**
- * Lists the current branch's commits that are ahead of its base branch, newest
- * first, each flagged local-only vs on-remote with per-commit file +/- stats.
- *
- * Base ref is resolved exactly like {@link getCheckoutStatus}: the stored/default
- * base branch, mapped to the best comparison ref (origin/<base> when present,
- * else local <base>). Returns `[]` when the base cannot be resolved, the current
- * ref is the base itself, or there are no commits ahead.
+ * Lists the current branch's 20 most recent commits, newest first, each flagged
+ * local-only vs on-remote with per-commit file +/- stats.
  */
 export interface CheckoutCommitsResult {
   baseRef: string | null;
@@ -2213,21 +2207,14 @@ export async function listCheckoutCommits({
   }
 
   const { resolvedBaseRef } = await resolveBaseRefForCwd(cwd);
-  if (!resolvedBaseRef) {
-    return { baseRef: null, commits: [] };
-  }
-
-  const normalizedBaseRef = normalizeLocalBranchRefName(resolvedBaseRef);
-  if (!normalizedBaseRef || normalizedBaseRef === currentBranch) {
-    return { baseRef: null, commits: [] };
-  }
-
-  let comparisonBaseRef: string;
-  try {
-    comparisonBaseRef = await resolveBestComparisonBaseRef(cwd, resolvedBaseRef);
-  } catch {
-    // Base branch is not present locally or on origin — nothing to compare against.
-    return { baseRef: null, commits: [] };
+  const normalizedBaseRef = resolvedBaseRef ? normalizeLocalBranchRefName(resolvedBaseRef) : null;
+  let comparisonBaseRef: string | null = null;
+  if (resolvedBaseRef && normalizedBaseRef && normalizedBaseRef !== currentBranch) {
+    try {
+      comparisonBaseRef = await resolveBestComparisonBaseRef(cwd, resolvedBaseRef);
+    } catch {
+      // History does not depend on the configured base being available.
+    }
   }
 
   // Single pass: `--raw` carries the status letter, `--numstat` the +/- counts.
@@ -2235,8 +2222,7 @@ export async function listCheckoutCommits({
   const logResult = await runGitCommand(
     [
       "log",
-      `${comparisonBaseRef}..HEAD`,
-      "--no-merges",
+      "HEAD",
       `--max-count=${MAX_CHECKOUT_COMMITS}`,
       `--format=${COMMIT_LOG_FORMAT}`,
       "--raw",

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -2146,11 +2146,14 @@ function parseCheckoutCommitRecords(stdout: string): ParsedCheckoutCommit[] {
 
 // Returns commits reachable from HEAD that are not reachable from any remote ref.
 async function getUnpushedCommitShas(cwd: string, context?: CheckoutContext): Promise<Set<string>> {
-  const { stdout } = await runGitCommand(["rev-list", "HEAD", "--not", "--remotes"], {
-    cwd,
-    envOverlay: READ_ONLY_GIT_ENV,
-    logger: context?.logger,
-  });
+  const { stdout } = await runGitCommand(
+    ["rev-list", `--max-count=${MAX_CHECKOUT_COMMITS}`, "HEAD", "--not", "--remotes"],
+    {
+      cwd,
+      envOverlay: READ_ONLY_GIT_ENV,
+      logger: context?.logger,
+    },
+  );
   return new Set(
     stdout
       .split("\n")

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -2144,37 +2144,9 @@ function parseCheckoutCommitRecords(stdout: string): ParsedCheckoutCommit[] {
   return commits;
 }
 
-async function resolveCheckoutCommitUpstreamRef(
-  cwd: string,
-  currentBranch: string,
-  context?: CheckoutContext,
-): Promise<string | null> {
-  // Prefer the branch's configured `@{u}`. If it's configured but the
-  // remote-tracking ref isn't present locally (e.g. configured upstream that was
-  // never fetched), fall back to `origin/<branch>` when that ref does exist, so a
-  // standard `origin` push is still recognized. Both missing => no remote.
-  const configured = await getConfiguredUpstreamRef(cwd, currentBranch, context);
-  if (configured && (await doesGitRefExist(cwd, `refs/remotes/${configured}`, context))) {
-    return configured;
-  }
-  if (await doesGitRefExist(cwd, `refs/remotes/origin/${currentBranch}`, context)) {
-    return `origin/${currentBranch}`;
-  }
-  return null;
-}
-
-// Returns the set of SHAs on the current branch that are NOT on the upstream
-// (local-only/unpushed), or `null` when no upstream exists (no remote at all).
-async function getLocalOnlyCommitShas(
-  cwd: string,
-  currentBranch: string,
-  context?: CheckoutContext,
-): Promise<Set<string> | null> {
-  const upstreamRef = await resolveCheckoutCommitUpstreamRef(cwd, currentBranch, context);
-  if (!upstreamRef) {
-    return null;
-  }
-  const { stdout } = await runGitCommand(["rev-list", `${upstreamRef}..HEAD`], {
+// Returns commits reachable from HEAD that are not reachable from any remote ref.
+async function getUnpushedCommitShas(cwd: string, context?: CheckoutContext): Promise<Set<string>> {
+  const { stdout } = await runGitCommand(["rev-list", "HEAD", "--not", "--remotes"], {
     cwd,
     envOverlay: READ_ONLY_GIT_ENV,
     logger: context?.logger,
@@ -2223,6 +2195,8 @@ export async function listCheckoutCommits({
     [
       "log",
       "HEAD",
+      "--first-parent",
+      "--diff-merges=first-parent",
       `--max-count=${MAX_CHECKOUT_COMMITS}`,
       `--format=${COMMIT_LOG_FORMAT}`,
       "--raw",
@@ -2237,7 +2211,7 @@ export async function listCheckoutCommits({
     return { baseRef: comparisonBaseRef, commits: [] };
   }
 
-  const localOnlyShas = await getLocalOnlyCommitShas(cwd, currentBranch);
+  const unpushedShas = await getUnpushedCommitShas(cwd);
 
   const commits = records.map((record) => ({
     sha: record.sha,
@@ -2245,7 +2219,7 @@ export async function listCheckoutCommits({
     subject: record.subject,
     authorName: record.authorName,
     authorDate: record.authorDate,
-    isOnRemote: localOnlyShas === null ? false : !localOnlyShas.has(record.sha),
+    isOnRemote: !unpushedShas.has(record.sha),
     files: record.files,
   }));
 
@@ -2257,13 +2231,12 @@ export async function listCheckoutCommits({
  * parses it into the same {@link ParsedDiffFile} shape the diff subscription
  * emits (so the client can reuse its existing renderer).
  *
- * Runs `git show <sha> --format= -- <path>` with the sha and path passed as
- * separate process args (never interpolated into a shell string), and `--format=`
- * suppresses the commit header so the output is a pure unified diff. The text is
- * parsed and highlighted by {@link parseAndHighlightDiff} — the exact parser the
- * diff subscription uses. Returns `null` when the file is absent from the commit
- * or the change is binary-only (no textual hunks). Throws on git failure (e.g. an
- * unknown sha), which the caller maps to a typed checkout error.
+ * Compares merge commits to their first parent, matching the linear history shown
+ * in the explorer. The text is parsed and highlighted by
+ * {@link parseAndHighlightDiff} — the exact parser the diff subscription uses.
+ * Returns `null` when the file is absent from the commit or the change is
+ * binary-only (no textual hunks). Throws on git failure (e.g. an unknown sha),
+ * which the caller maps to a typed checkout error.
  */
 export async function getCommitFileDiff({
   cwd,
@@ -2274,10 +2247,13 @@ export async function getCommitFileDiff({
   sha: string;
   path: string;
 }): Promise<ParsedDiffFile | null> {
-  const { stdout } = await runGitCommand(["show", sha, "--format=", "--", path], {
-    cwd,
-    envOverlay: READ_ONLY_GIT_ENV,
-  });
+  const { stdout } = await runGitCommand(
+    ["show", sha, "--format=", "--diff-merges=first-parent", "--", path],
+    {
+      cwd,
+      envOverlay: READ_ONLY_GIT_ENV,
+    },
+  );
 
   if (stdout.trim().length === 0) {
     return null;

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -2195,7 +2195,6 @@ export async function listCheckoutCommits({
     [
       "log",
       "HEAD",
-      "--first-parent",
       "--diff-merges=first-parent",
       `--max-count=${MAX_CHECKOUT_COMMITS}`,
       `--format=${COMMIT_LOG_FORMAT}`,


### PR DESCRIPTION
### Linked issue

No matching open issue found.

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The explorer now shows the current branch's 20 most recent commits reachable from HEAD, newest first, instead of only commits ahead of the base branch. Pushed and unpushed commits remain visually distinguishable based on whether each commit is reachable from any remote, so the list works as a quick view of recent repository activity even on the base branch or before a new branch is pushed.

Merge commits and their file diffs compare against the first parent, matching the linear history shown in the explorer. The existing commits-list response shape remains unchanged, so clients need no parallel path or protocol migration.

### How did you verify it

- `npx vitest run packages/server/src/utils/checkout-git.commits.test.ts packages/server/src/utils/checkout-git.commit-file-diff.test.ts --bail=1` — 12 tests passed against real temporary Git repositories, covering mixed pushed/unpushed history, unpublished branches with remote base history, base-branch history, first-parent merges and file diffs, newest-first ordering, the 20-commit cap, and file stats.
- `npm run typecheck` — passed across all workspaces.
- `npm run lint` — passed across the repository with no warnings or errors.
- `npm run format` — completed successfully.

No additional manual verification is needed before merge; the behavior is daemon-side Git selection feeding the existing explorer UI and is covered at the real Git boundary.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI layout or rendering changed)
- [x] Tests added or updated where it made sense