### PR TITLE
Copy complete assistant turns on iOS

### DIFF
--- a/packages/app/src/agent-stream/layout.test.ts
+++ b/packages/app/src/agent-stream/layout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { TurnTiming } from "@/timeline/turn-time";
 import type { StreamItem } from "@/types/stream";
 import {
+  collectAssistantTurnContentForStreamRenderStrategy,
   orderHeadForStreamRenderStrategy,
   orderTailForStreamRenderStrategy,
   type StreamStrategy,
@@ -309,6 +310,34 @@ describe("layoutStream", () => {
     expect(findLayoutItem(layout, assistant.id).completedFooter).toBeNull();
     expect(footerOwners(layout)).toEqual([assistant.id]);
   });
+
+  it.each(["web", "android"] as const)(
+    "copies every assistant block when a completed turn spans history and live head on %s",
+    (platform) => {
+      const strategy = strategyFor(platform);
+      const layout = layoutFor({
+        platform,
+        tail: [
+          userMessage("u1", 1),
+          assistantMessage("first block", 2, { groupId: "turn-1", index: 0 }),
+          assistantMessage("second block", 3, { groupId: "turn-1", index: 1 }),
+        ],
+        head: [assistantMessage("final block", 4, { groupId: "turn-1", index: 2 })],
+      });
+      const footer = layout.auxiliaryTurnFooter;
+
+      expect(footer).not.toBeNull();
+      expect(
+        collectAssistantTurnContentForStreamRenderStrategy({
+          strategy,
+          items: footer!.items,
+          startIndex: footer!.startIndex,
+          precedingItems: footer!.precedingItems,
+          precedingStartIndex: footer!.precedingStartIndex,
+        }),
+      ).toBe("first block\n\nsecond block\n\nfinal block");
+    },
+  );
 
   it.each(["web", "android"] as const)(
     "places inline footer after trailing visible tool rows before the next user on %s",

--- a/packages/app/src/agent-stream/layout.ts
+++ b/packages/app/src/agent-stream/layout.ts
@@ -10,6 +10,8 @@ export interface TurnFooterHost {
   items: StreamItem[];
   timing?: TurnTiming;
   startIndex: number;
+  precedingItems: StreamItem[] | null;
+  precedingStartIndex: number | null;
 }
 
 export interface StreamLayoutItem {
@@ -66,12 +68,16 @@ function createTurnFooterHost(input: {
   items: StreamItem[];
   index: number;
   timingByAssistantId: Map<string, TurnTiming>;
+  precedingItems?: StreamItem[] | null;
+  precedingStartIndex?: number | null;
 }): TurnFooterHost {
   return {
     itemId: input.item.id,
     items: input.items,
     timing: input.timingByAssistantId.get(input.item.id),
     startIndex: input.index,
+    precedingItems: input.precedingItems ?? null,
+    precedingStartIndex: input.precedingStartIndex ?? null,
   };
 }
 
@@ -141,6 +147,11 @@ function resolveAuxiliaryTurnFooter(input: StreamLayoutInput): TurnFooterHost | 
     items: assistant.items,
     index: assistant.index,
     timingByAssistantId: input.timingByAssistantId,
+    precedingItems: footerItems === input.liveHead ? input.history : null,
+    precedingStartIndex:
+      footerItems === input.liveHead
+        ? input.strategy.getHistoryLiveBoundaryIndex(input.history)
+        : null,
   });
 }
 
@@ -174,6 +185,8 @@ function resolveCompletedFooter(input: {
     items: assistant.items,
     index: assistant.index,
     timingByAssistantId: input.timingByAssistantId,
+    precedingItems: input.boundaryAboveItems,
+    precedingStartIndex: input.boundaryAboveIndex,
   });
 }
 

--- a/packages/app/src/agent-stream/strategy.ts
+++ b/packages/app/src/agent-stream/strategy.ts
@@ -272,8 +272,25 @@ export function collectAssistantTurnContentForStreamRenderStrategy(params: {
   strategy: StreamStrategy;
   items: StreamItem[];
   startIndex: number;
+  precedingItems?: StreamItem[] | null;
+  precedingStartIndex?: number | null;
 }): string {
-  return params.strategy.collectAssistantTurnContent(params.items, params.startIndex);
+  const content = params.strategy.collectAssistantTurnContent(params.items, params.startIndex);
+  if (!params.precedingItems || params.precedingStartIndex == null) {
+    return content;
+  }
+
+  const precedingContent = params.strategy.collectAssistantTurnContent(
+    params.precedingItems,
+    params.precedingStartIndex,
+  );
+  if (!precedingContent) {
+    return content;
+  }
+  if (!content) {
+    return precedingContent;
+  }
+  return `${precedingContent}\n\n${content}`;
 }
 
 export function isNearBottomForStreamRenderStrategy(

--- a/packages/app/src/agent-stream/turn-footer.tsx
+++ b/packages/app/src/agent-stream/turn-footer.tsx
@@ -3,8 +3,6 @@ import { View } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { MAX_CONTENT_WIDTH } from "@/constants/layout";
 import type { Theme } from "@/styles/theme";
-import type { TurnTiming } from "@/timeline/turn-time";
-import type { StreamItem } from "@/types/stream";
 import {
   collectAssistantTurnContentForStreamRenderStrategy,
   type StreamStrategy,
@@ -62,9 +60,7 @@ export const TurnFooter = memo(function TurnFooter({
   return (
     <CompletedTurnFooterRow
       strategy={strategy}
-      items={host.items}
-      timing={host.timing}
-      startIndex={host.startIndex}
+      host={host}
       supportsTimelineCursor={supportsTimelineCursor}
       onForkAssistantTurn={onForkAssistantTurn}
     />
@@ -73,16 +69,12 @@ export const TurnFooter = memo(function TurnFooter({
 
 export const CompletedTurnFooterRow = memo(function CompletedTurnFooterRow({
   strategy,
-  items,
-  timing,
-  startIndex,
+  host,
   supportsTimelineCursor,
   onForkAssistantTurn,
 }: {
   strategy: TurnContentStrategy;
-  items: StreamItem[];
-  timing?: TurnTiming;
-  startIndex: number;
+  host: TurnFooterHost;
   supportsTimelineCursor: boolean;
   onForkAssistantTurn?: AssistantTurnForkHandler;
 }) {
@@ -90,9 +82,7 @@ export const CompletedTurnFooterRow = memo(function CompletedTurnFooterRow({
     <TurnFooterRow>
       <CompletedTurnFooter
         strategy={strategy}
-        items={items}
-        timing={timing}
-        startIndex={startIndex}
+        host={host}
         supportsTimelineCursor={supportsTimelineCursor}
         onForkAssistantTurn={onForkAssistantTurn}
       />
@@ -133,16 +123,12 @@ function RunningTurnFooter({ inFlightTurnStartedAt }: { inFlightTurnStartedAt: D
 
 function CompletedTurnFooter({
   strategy,
-  items,
-  timing,
-  startIndex,
+  host,
   supportsTimelineCursor,
   onForkAssistantTurn,
 }: {
   strategy: TurnContentStrategy;
-  items: StreamItem[];
-  timing?: TurnTiming;
-  startIndex: number;
+  host: TurnFooterHost;
   supportsTimelineCursor: boolean;
   onForkAssistantTurn?: AssistantTurnForkHandler;
 }) {
@@ -150,14 +136,16 @@ function CompletedTurnFooter({
     () =>
       collectAssistantTurnContentForStreamRenderStrategy({
         strategy,
-        items,
-        startIndex,
+        items: host.items,
+        startIndex: host.startIndex,
+        precedingItems: host.precedingItems,
+        precedingStartIndex: host.precedingStartIndex,
       }),
-    [strategy, items, startIndex],
+    [strategy, host],
   );
   const boundary = resolveAssistantTurnForkBoundary({
-    items,
-    startIndex,
+    items: host.items,
+    startIndex: host.startIndex,
     supportsTimelineCursor,
   });
   const handleFork = useCallback(
@@ -173,8 +161,8 @@ function CompletedTurnFooter({
     <View style={stylesheet.turnFooterSlot}>
       <AssistantTurnFooter
         getContent={getContent}
-        completedAt={timing?.completedAt}
-        durationMs={timing?.durationMs}
+        completedAt={host.timing?.completedAt}
+        durationMs={host.timing?.durationMs}
         onFork={boundary && onForkAssistantTurn ? handleFork : undefined}
       />
     </View>

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -153,9 +153,7 @@ function renderStreamItemWithTurnFooter(input: {
   const footer = footerHost ? (
     <CompletedTurnFooterRow
       strategy={input.strategy}
-      items={footerHost.items}
-      timing={footerHost.timing}
-      startIndex={footerHost.startIndex}
+      host={footerHost}
       supportsTimelineCursor={input.supportsTimelineCursor}
       onForkAssistantTurn={input.onForkAssistantTurn}
     />


### PR DESCRIPTION
### Linked issue

Closes #2223

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Copy turn now includes every visible assistant block when a completed response spans the history and live portions of chat. This keeps the existing footer behavior while giving it the complete turn content.

### How did you verify it

Added a regression case for the exact split-turn shape. Before the fix it copied only the final block; after the fix it copies all three blocks in order for both forward and native-inverted stream strategies.

- npx vitest run packages/app/src/agent-stream/layout.test.ts packages/app/src/agent-stream/render-strategy.test.ts --bail=1 (41 tests passed)
- npm run typecheck
- npm run lint -- packages/app/src/agent-stream/layout.ts packages/app/src/agent-stream/layout.test.ts packages/app/src/agent-stream/strategy.ts packages/app/src/agent-stream/turn-footer.tsx packages/app/src/agent-stream/view.tsx
- npm run format

The clipboard result still needs a smoke check on a physical iOS build before merge.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense