### PR TITLE
Preserve wide characters in terminal captures and restores

### DIFF
--- a/packages/protocol/src/terminal-snapshot.test.ts
+++ b/packages/protocol/src/terminal-snapshot.test.ts
@@ -7,6 +7,20 @@ function cells(text: string): TerminalState["grid"][number] {
 }
 
 describe("renderTerminalSnapshotToAnsi", () => {
+  it("preserves adjacent wide characters", () => {
+    const state: TerminalState = {
+      rows: 1,
+      cols: 4,
+      scrollback: [],
+      grid: [[{ char: "\u4e2d" }, { char: "" }, { char: "\u6587" }, { char: "" }]],
+      cursor: { row: 0, col: 4 },
+    };
+
+    const ansi = renderTerminalSnapshotToAnsi(state);
+
+    expect(ansi).toContain("\u4e2d\u6587");
+  });
+
   it("renders soft-wrapped rows as one contiguous logical line when wrap flags are present", () => {
     // The server soft-wrapped one logical line "ABCDEFGHIJKLMNOP" at 10 cols into
     // two grid rows. gridWrapped[0] = true marks row 0 as continuing into row 1.

--- a/packages/protocol/src/terminal-snapshot.ts
+++ b/packages/protocol/src/terminal-snapshot.ts
@@ -87,12 +87,15 @@ function renderTerminalRow(row: TerminalCell[], padToCols?: number): string {
 
   for (let index = 0; index < length; index += 1) {
     const cell = row[index] ?? { char: " " };
+    if (cell.char === "") {
+      continue;
+    }
     const nextStyle = getTerminalStyle(cell);
     if (!terminalStylesEqual(previousStyle, nextStyle)) {
       output.push(styleToAnsi(nextStyle));
       previousStyle = nextStyle;
     }
-    output.push(cell.char || " ");
+    output.push(cell.char);
   }
 
   if (!terminalStylesEqual(previousStyle, DEFAULT_STYLE)) {

--- a/packages/server/src/server/daemon-e2e/terminal.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/terminal.e2e.test.ts
@@ -1626,6 +1626,29 @@ describe("capture", () => {
     expect(capture.totalLines).toBeGreaterThan(0);
   }, 15000);
 
+  test("preserves adjacent CJK characters in captured output", async () => {
+    const cwd = tmpCwd();
+    tempDirs.push(cwd);
+    const created = await createTerminalInWorkspace(ctx.client, { cwd });
+    const terminalId = created.terminal!.id;
+
+    await ctx.client.subscribeTerminal(terminalId);
+    ctx.client.sendTerminalInput(terminalId, {
+      type: "input",
+      data: `node -e "process.stdout.write('START\\u4e2d\\u6587END\\n')"\r`,
+    });
+    await waitForTerminalOutput(
+      ctx.client,
+      terminalId,
+      (text) => text.includes("START\u4e2d\u6587END"),
+      15000,
+    );
+
+    const capture = await ctx.client.captureTerminal(terminalId);
+
+    expect(capture.lines).toContain("START\u4e2d\u6587END");
+  }, 15000);
+
   test("captures with start/end line range", async () => {
     const cwd = tmpCwd();
     tempDirs.push(cwd);

--- a/packages/server/src/terminal/terminal.ts
+++ b/packages/server/src/terminal/terminal.ts
@@ -494,7 +494,7 @@ function extractCell(terminal: TerminalType, row: number, col: number): Terminal
   const bg = bgMode !== 0 ? cell.getBgColor() : undefined;
 
   return {
-    char: cell.getChars() || " ",
+    char: cell.getWidth() === 0 ? "" : cell.getChars() || " ",
     fg,
     bg,
     fgMode: fgMode !== 0 ? fgMode : undefined,
@@ -553,7 +553,7 @@ function extractScrollback(
           const fg = fgMode !== 0 ? cell.getFgColor() : undefined;
           const bg = bgMode !== 0 ? cell.getBgColor() : undefined;
           rowCells.push({
-            char: cell.getChars() || " ",
+            char: cell.getWidth() === 0 ? "" : cell.getChars() || " ",
             fg,
             bg,
             fgMode: fgMode !== 0 ? fgMode : undefined,


### PR DESCRIPTION
### Linked issue

Closes #2193

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Terminal captures and restored snapshots no longer insert spaces between adjacent CJK and other wide characters. The terminal snapshot keeps zero-width continuation cells distinct from ordinary blank cells, and restoration skips those continuations.

### How did you verify it

Reproduced the bug first through a real-daemon terminal capture test, which captured adjacent CJK characters with inserted spaces. Confirmed that test passes after the fix.

- `npx vitest run packages/server/src/server/daemon-e2e/terminal.e2e.test.ts --bail=1 -t "preserves adjacent CJK characters in captured output"`
- `npx vitest run packages/protocol/src/terminal-snapshot.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

The complete terminal E2E file also reached an existing slow-client backpressure timeout. That test fails identically with this fix disabled; the changed CJK test remains green.

### Risk surface

Snapshot cell encoding now retains an empty string for wide-character continuation cells. The existing protocol schema already accepts string values, ordinary blank cells remain spaces, and no wire field was added.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense