### PR TITLE
fix(server): tone usage bars by how full they are

### DIFF
--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -14,6 +14,7 @@ import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
 import {
   ApiNumberSchema,
   fetchProviderApi,
+  toneFromUsedPct,
   unavailableUsage,
   windowFromUsedPct,
 } from "../usage.js";
@@ -156,7 +157,7 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
           label: "Session",
           utilizationPct: resp.five_hour.utilization,
           resetsAt: resp.five_hour.resets_at ?? null,
-          tone: "ok",
+          tone: toneFromUsedPct(resp.five_hour.utilization),
         }),
       );
     }
@@ -167,7 +168,7 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
           label: "Weekly",
           utilizationPct: resp.seven_day.utilization,
           resetsAt: resp.seven_day.resets_at ?? null,
-          tone: "ok",
+          tone: toneFromUsedPct(resp.seven_day.utilization),
         }),
       );
     }
@@ -178,7 +179,7 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
           label: "Weekly · Opus",
           utilizationPct: resp.seven_day_opus.utilization,
           resetsAt: resp.seven_day_opus.resets_at ?? null,
-          tone: "ok",
+          tone: toneFromUsedPct(resp.seven_day_opus.utilization),
         }),
       );
     }
@@ -189,7 +190,7 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
           label: "Weekly · Omelette",
           utilizationPct: resp.seven_day_omelette.utilization,
           resetsAt: resp.seven_day_omelette.resets_at ?? null,
-          tone: "ok",
+          tone: toneFromUsedPct(resp.seven_day_omelette.utilization),
         }),
       );
     }

--- a/packages/server/src/services/quota-fetcher/providers/codex.ts
+++ b/packages/server/src/services/quota-fetcher/providers/codex.ts
@@ -12,6 +12,7 @@ import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
 import {
   ApiNumberSchema,
   balanceToneFromRemaining,
+  toneFromUsedPct,
   fetchProviderApi,
   unavailableUsage,
   windowFromUsedPct,
@@ -143,7 +144,7 @@ export class CodexQuotaProvider implements ProviderUsageFetcher {
           label: "Session",
           utilizationPct: session.usedPct,
           resetsAt: session.resetsAt,
-          tone: "ok",
+          tone: toneFromUsedPct(session.usedPct),
         }),
       );
     }
@@ -154,7 +155,7 @@ export class CodexQuotaProvider implements ProviderUsageFetcher {
           label: "Weekly",
           utilizationPct: weekly.usedPct,
           resetsAt: weekly.resetsAt,
-          tone: weekly.usedPct >= 70 ? "warning" : "ok",
+          tone: toneFromUsedPct(weekly.usedPct),
         }),
       );
     }
@@ -165,7 +166,7 @@ export class CodexQuotaProvider implements ProviderUsageFetcher {
           label: "Code review",
           utilizationPct: codeReview.usedPct,
           resetsAt: codeReview.resetsAt,
-          tone: codeReview.usedPct >= 70 ? "warning" : "ok",
+          tone: toneFromUsedPct(codeReview.usedPct),
         }),
       );
     }

--- a/packages/server/src/services/quota-fetcher/providers/cursor.ts
+++ b/packages/server/src/services/quota-fetcher/providers/cursor.ts
@@ -9,7 +9,8 @@ import type { ProviderUsage, ProviderUsageBalance } from "../../../server/messag
 import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
 import {
   ApiNullableNumberSchema,
-  balanceToneFromRemaining,
+  toneFromUsedPct,
+  usedPctOf,
   fetchProviderApi,
   toIsoStringOrNull,
   unavailableUsage,
@@ -160,7 +161,7 @@ export class CursorQuotaProvider implements ProviderUsageFetcher {
         limit,
         unit: "usd",
         resetsAt: billingCycleEnd,
-        tone: balanceToneFromRemaining(remaining),
+        tone: toneFromUsedPct(usedPctOf(totalSpend, limit)),
       });
     }
 

--- a/packages/server/src/services/quota-fetcher/providers/grok.ts
+++ b/packages/server/src/services/quota-fetcher/providers/grok.ts
@@ -7,7 +7,8 @@ import type { ProviderUsage, ProviderUsageBalance } from "../../../server/messag
 import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
 import {
   ApiNumberSchema,
-  balanceToneFromRemaining,
+  toneFromUsedPct,
+  usedPctOf,
   fetchProviderApi,
   unavailableUsage,
 } from "../usage.js";
@@ -89,7 +90,7 @@ export class GrokQuotaProvider implements ProviderUsageFetcher {
         remaining,
         limit: monthlyLimit,
         unit: "credits",
-        tone: balanceToneFromRemaining(remaining),
+        tone: toneFromUsedPct(usedPctOf(creditUsage, monthlyLimit)),
       });
     }
 

--- a/packages/server/src/services/quota-fetcher/providers/kimi.ts
+++ b/packages/server/src/services/quota-fetcher/providers/kimi.ts
@@ -5,7 +5,12 @@ import type { Logger } from "pino";
 import { z } from "zod";
 import type { ProviderUsage } from "../../../server/messages.js";
 import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
-import { ApiOptionalStringSchema, fetchProviderApi, unavailableUsage } from "../usage.js";
+import {
+  ApiOptionalStringSchema,
+  fetchProviderApi,
+  toneFromUsedPct,
+  unavailableUsage,
+} from "../usage.js";
 
 const KimiUsageResponseSchema = z.object({
   usage: z
@@ -81,7 +86,7 @@ export class KimiQuotaProvider implements ProviderUsageFetcher {
           usedPct,
           remainingPct: usedPct === null ? null : Math.max(0, 100 - usedPct),
           resetsAt: resp.usage?.resetTime ?? null,
-          tone: "ok",
+          tone: toneFromUsedPct(usedPct),
         },
       ],
       balances: [],

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -947,3 +947,81 @@ describe("real provider usage fetchers", () => {
     });
   });
 });
+
+// Regression for #2320: providers hardcoded `tone: "ok"`, which suppressed the client's
+// own thresholds (window-bar.tsx reads `window.tone ?? deriveTone(usedPct)`), so a bar
+// stayed green at 99%. Codex escalated to "warning" but could never reach "danger".
+describe("usage bars escalate as they fill", () => {
+  let claudeHome: string;
+  let codexHome: string;
+
+  beforeEach(() => {
+    claudeHome = mkdtempSync(join(tmpdir(), "paseo-tone-claude-"));
+    codexHome = mkdtempSync(join(tmpdir(), "paseo-tone-codex-"));
+  });
+
+  afterEach(() => {
+    rmSync(claudeHome, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  });
+
+  function claudeAt(utilization: number) {
+    writeClaudeCredentials(claudeHome, "at_valid");
+    return new ClaudeQuotaProvider({
+      logger: createLogger(),
+      claudeHome,
+      claudeKeychainReader: async () => null,
+      fetch: mockFetch(
+        new Map([
+          [
+            "https://api.anthropic.com/api/oauth/usage",
+            () =>
+              jsonResponse({
+                seven_day: { utilization, resets_at: "2026-06-04T00:00:00Z" },
+              }),
+          ],
+        ]),
+      ),
+    }).fetchUsage();
+  }
+
+  it.each([
+    [10, "ok"],
+    [75, "warning"],
+    [99, "danger"],
+  ])("a Claude window at %s%% is %s", async (utilization, tone) => {
+    const usage = await claudeAt(utilization);
+    expect(usage.windows).toEqual([expect.objectContaining({ id: "weekly", tone })]);
+  });
+
+  it("a Codex window can reach danger, not just warning", async () => {
+    writeCodexAuth(codexHome, "at_codex");
+    const usage = await new CodexQuotaProvider({
+      logger: createLogger(),
+      codexHome,
+      fetch: mockFetch(
+        new Map([
+          [
+            "https://chatgpt.com/backend-api/wham/usage",
+            () =>
+              jsonResponse(
+                makeCodexResponse({
+                  rate_limit: {
+                    primary_window: { used_percent: 12, reset_at: 1_748_812_800 },
+                    secondary_window: { used_percent: 96, reset_at: 1_749_072_000 },
+                  },
+                }),
+              ),
+          ],
+        ]),
+      ),
+    }).fetchUsage();
+
+    expect(usage.windows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "session", tone: "ok" }),
+        expect.objectContaining({ id: "weekly", tone: "danger" }),
+      ]),
+    );
+  });
+});

--- a/packages/server/src/services/quota-fetcher/usage.test.ts
+++ b/packages/server/src/services/quota-fetcher/usage.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { balanceToneFromRemaining, toneFromUsedPct, usedPctOf } from "./usage.js";
+
+describe("toneFromUsedPct", () => {
+  // Thresholds must match deriveTone in the app's provider-usage/tone.ts, which is what
+  // the client applies when a window arrives without a tone.
+  it.each([
+    [0, "ok"],
+    [69.9, "ok"],
+    [70, "warning"],
+    [90, "warning"],
+    [90.1, "danger"],
+    [100, "danger"],
+    [150, "danger"],
+  ])("%s%% used is %s", (usedPct, expected) => {
+    expect(toneFromUsedPct(usedPct)).toBe(expected);
+  });
+
+  it("is neutral when the percentage is unknown", () => {
+    expect(toneFromUsedPct(null)).toBe("default");
+    expect(toneFromUsedPct(undefined)).toBe("default");
+  });
+});
+
+describe("usedPctOf", () => {
+  it("computes a percentage of the limit", () => {
+    expect(usedPctOf(15.79, 42.5)).toBeCloseTo(37.15, 2);
+  });
+
+  it("is unknown when either side is missing", () => {
+    expect(usedPctOf(null, 100)).toBeNull();
+    expect(usedPctOf(50, null)).toBeNull();
+  });
+
+  // A zero limit would divide to Infinity and render as a full red bar.
+  it("is unknown when the limit is zero or negative", () => {
+    expect(usedPctOf(50, 0)).toBeNull();
+    expect(usedPctOf(50, -1)).toBeNull();
+  });
+});
+
+describe("balanceToneFromRemaining", () => {
+  // Kept for balances with no limit, where no percentage can be computed. It only
+  // escalates at exhaustion, which is why anything with a limit should use
+  // toneFromUsedPct instead.
+  it("stays ok until nothing is left", () => {
+    expect(balanceToneFromRemaining(0.01)).toBe("ok");
+    expect(balanceToneFromRemaining(0)).toBe("danger");
+    expect(balanceToneFromRemaining(null)).toBe("default");
+  });
+});

--- a/packages/server/src/services/quota-fetcher/usage.ts
+++ b/packages/server/src/services/quota-fetcher/usage.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type {
   ProviderUsage,
   ProviderUsageBalance,
+  ProviderUsageTone,
   ProviderUsageWindow,
 } from "../../server/messages.js";
 import type { ProviderApiFetch } from "./provider.js";
@@ -67,12 +68,41 @@ export function windowFromUsedPct(input: {
   return window;
 }
 
+/**
+ * The tone scale for anything measured against a known limit, windows and balances alike.
+ *
+ * Thresholds match `deriveTone` in the app's provider-usage/tone.ts, which is what the
+ * client falls back to when a window arrives without a tone. Healthy is "ok" rather than
+ * "default" because that is what every provider setting a tone has always sent, and it is
+ * what the bars render today below their thresholds.
+ */
+export function toneFromUsedPct(usedPct: number | null | undefined): ProviderUsageTone {
+  if (typeof usedPct !== "number") return "default";
+  if (usedPct > 90) return "danger";
+  if (usedPct >= 70) return "warning";
+  return "ok";
+}
+
+/**
+ * Tone for a balance with no known limit, where a percentage cannot be computed and the
+ * only signal is whether anything is left. Prefer `toneFromUsedPct` when a limit exists:
+ * this one stays "ok" until the balance is completely spent.
+ */
 export function balanceToneFromRemaining(
   remaining: number | null | undefined,
 ): ProviderUsageBalance["tone"] {
   if (typeof remaining !== "number") return "default";
   if (remaining <= 0) return "danger";
   return "ok";
+}
+
+/** Percentage of a limit consumed, or null when either side is unknown. */
+export function usedPctOf(
+  used: number | null | undefined,
+  limit: number | null | undefined,
+): number | null {
+  if (typeof used !== "number" || typeof limit !== "number" || limit <= 0) return null;
+  return (used / limit) * 100;
 }
 
 export function toIsoStringOrNull(timestampMs: number): string | null {


### PR DESCRIPTION
### Linked issue

Closes #2320

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

A usage bar in Settings → Usage stayed green all the way to 100%, so the one moment the
meter matters was the moment it said nothing.

The client already computes this. `window-bar.tsx:29` reads
`window.tone ?? deriveTone(usedPct)`, and `deriveTone` escalates past 70% and 90%. But
`usage.ts:64` only assigns `window.tone` when a provider supplies one — so any provider
that sends a tone opts out of the thresholds entirely. Claude and Kimi hardcoded
`tone: "ok"`; Codex escalated to `warning` past 70% but could never reach `danger`.

Providers now derive tone from the percentage they already have, through one shared
`toneFromUsedPct` whose thresholds match the client's:

| Provider | Before | After |
|---|---|---|
| Claude — 4 windows | `"ok"` at every level | ok / warning / danger |
| Kimi — 1 window | `"ok"` at every level | ok / warning / danger |
| Codex — 3 windows | ok, or warning past 70 | ok / warning / danger |

Balances had the same gap by a different route: `balance-bar.tsx:44` has no `deriveTone`
fallback, and `balanceToneFromRemaining` only escalates once a balance is completely
spent, so a credits bar at 99% spent was green. Cursor and Grok know their limit and now
tone by used percentage.

Two providers are deliberately unchanged:

- **Codex credits** report a remaining balance with no limit, so no percentage exists.
  They keep `balanceToneFromRemaining`, which is now documented as the no-limit case.
- **MiniMax** maps a status its own API supplies rather than hardcoding a tone.

Healthy resolves to `"ok"` (green) rather than `deriveTone`'s `"default"` (grey), because
green is what every provider setting a tone has always sent and what the bars render
today below their thresholds. Deleting the hardcoded tones instead would have turned
healthy bars grey.

### How did you verify it

**Against the live Anthropic API**, with my own Max 20x account. Caught the session window
mid-band:

```
five_hour   Session   83%   tone=warning     ← previously "ok"
weekly      Weekly    55%   tone=ok
```

83% sits between the two thresholds, so this exercises the escalation on real data rather
than a fixture.

**Tests** — 40 pass across the two files:

```
npx vitest run packages/server/src/services/quota-fetcher
  Test Files  2 passed (2)
       Tests  40 passed (40)
```

12 new unit tests on the helpers, including the exact boundaries (69.9 / 70 / 90 / 90.1),
null handling, and a zero-limit guard that would otherwise divide to `Infinity` and paint
a full red bar. Plus provider-level regressions: a Claude window across all three bands,
and a Codex window reaching `danger` — the case that was previously unreachable.

**Screenshots** — before and after on the same window, desktop (Electron), macOS:

Before:

<img width="224" height="249" alt="image" src="https://github.com/user-attachments/assets/76bebe46-99f8-4dbb-8ca6-7254a2619587" />


After:

<img width="227" height="254" alt="image" src="https://github.com/user-attachments/assets/2c616c0f-584f-4adc-9725-b03d9e02da8d" />




**Checks** — `npm run typecheck`, `npm run lint`, `npm run format` clean.

**Platform and provider coverage, stated plainly:**

- Verified live on **Claude only**. I don't have Codex, Kimi, Cursor or Grok credentials,
  so those are fixture-tested only.
- Verified on **desktop (Electron), macOS**. Not run on iOS, Android or browser web. The
  change is server-side and the client renders `windows[]` and `balances[]` generically,
  so no per-platform client code is involved.

Touches `claude.ts` alongside #2303, which is also open. Independent changes — whichever
merges second I'll rebase.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense