### PR TITLE
Show usage limits approaching exhaustion

### DIFF
--- a/packages/app/src/provider-usage/balance-bar.tsx
+++ b/packages/app/src/provider-usage/balance-bar.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Text, View, type StyleProp, type ViewStyle } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { clampPct, formatAmount, formatResetLabel } from "./format";
+import { resolveTone } from "./tone";
 import type { ProviderUsageBalance, ProviderUsageTone } from "./types";
 
 interface ResolvedBalance {
@@ -41,7 +42,7 @@ function fillToneStyle(tone: ProviderUsageTone) {
 
 export function ProviderUsageBalanceBar({ balance }: { balance: ProviderUsageBalance }) {
   const { amountText, usedPct } = resolveBalance(balance);
-  const tone = balance.tone ?? "default";
+  const tone = resolveTone(balance.tone, usedPct);
   const resetLabel = formatResetLabel(balance.resetsAt);
 
   const fillStyle = useMemo<StyleProp<ViewStyle>>(

--- a/packages/app/src/provider-usage/tone.test.ts
+++ b/packages/app/src/provider-usage/tone.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { resolveTone } from "./tone";
+
+describe("provider usage tone", () => {
+  it("shows the strongest risk from provider status and utilization", () => {
+    expect([
+      resolveTone("ok", 5),
+      resolveTone("ok", 70),
+      resolveTone("ok", 99),
+      resolveTone("danger", 5),
+    ]).toEqual(["ok", "warning", "danger", "danger"]);
+  });
+});

--- a/packages/app/src/provider-usage/tone.ts
+++ b/packages/app/src/provider-usage/tone.ts
@@ -1,8 +1,26 @@
 import type { ProviderUsageTone } from "./types";
 
+const TONE_RISK: Record<ProviderUsageTone, number> = {
+  default: 0,
+  ok: 1,
+  warning: 2,
+  danger: 3,
+};
+
 export function deriveTone(usedPct: number | null | undefined): ProviderUsageTone {
   if (usedPct == null) return "default";
   if (usedPct > 90) return "danger";
   if (usedPct >= 70) return "warning";
   return "default";
+}
+
+export function resolveTone(
+  providerTone: ProviderUsageTone | undefined,
+  usedPct: number | null | undefined,
+): ProviderUsageTone {
+  const utilizationTone = deriveTone(usedPct);
+  if (!providerTone || TONE_RISK[utilizationTone] > TONE_RISK[providerTone]) {
+    return utilizationTone;
+  }
+  return providerTone;
 }

--- a/packages/app/src/provider-usage/window-bar.tsx
+++ b/packages/app/src/provider-usage/window-bar.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { Text, View, type StyleProp, type ViewStyle } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { clampPct, formatPct, formatResetLabel } from "./format";
-import { deriveTone } from "./tone";
+import { resolveTone } from "./tone";
 import type { ProviderUsageTone, ProviderUsageWindow } from "./types";
 
 function resolveUsedPct(window: ProviderUsageWindow): number | null {
@@ -26,7 +26,7 @@ function fillToneStyle(tone: ProviderUsageTone) {
 
 export function ProviderUsageWindowBar({ window }: { window: ProviderUsageWindow }) {
   const usedPct = resolveUsedPct(window);
-  const tone = window.tone ?? deriveTone(usedPct);
+  const tone = resolveTone(window.tone, usedPct);
 
   const fillWidth = clampPct(usedPct ?? 0);
   const fillStyle = useMemo<StyleProp<ViewStyle>>(


### PR DESCRIPTION
### Linked issue

Closes #2320

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Usage meters now change to amber and red as a limit approaches exhaustion. Provider-specific alerts remain visible when they indicate a higher risk.

### How did you verify it

- Added a focused regression for healthy, warning, danger, and provider-alert states.
- Confirmed the regression failed before the fix and passed afterward.
- Ran `npx vitest run packages/app/src/provider-usage/tone.test.ts --bail=1`.
- Ran `npm run typecheck`, `npm run lint`, and `npm run format`.
- A visual smoke check on the supported app platforms remains for review because this environment does not have live near-limit provider data.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense