### PR TITLE
fix(server): preserve Codex policy and turns on resume

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -483,6 +483,48 @@ class McpCapableTestAgentClient extends TestAgentClient {
   }
 }
 
+class BufferedResumeSession extends TestAgentSession {
+  private bufferedEvents: AgentStreamEvent[];
+
+  constructor(config: AgentSessionConfig, events: AgentStreamEvent[]) {
+    super(config);
+    this.bufferedEvents = [...events];
+  }
+
+  override subscribe(callback: (event: AgentStreamEvent) => void): () => void {
+    const unsubscribe = super.subscribe(callback);
+    queueMicrotask(() => this.flushPreSubscriptionEvents());
+    return unsubscribe;
+  }
+
+  flushPreSubscriptionEvents(): void {
+    const events = this.bufferedEvents;
+    this.bufferedEvents = [];
+    for (const event of events) {
+      this.pushEvent(event);
+    }
+  }
+}
+
+class BufferedResumeClient extends TestAgentClient {
+  constructor(private readonly events: AgentStreamEvent[]) {
+    super();
+  }
+
+  override async resumeSession(
+    _handle: AgentPersistenceHandle,
+    config?: Partial<AgentSessionConfig>,
+  ): Promise<AgentSession> {
+    return new BufferedResumeSession(
+      {
+        provider: this.provider,
+        cwd: config?.cwd ?? process.cwd(),
+      },
+      this.events,
+    );
+  }
+}
+
 class ControlledInterruptSession extends TestAgentSession {
   interruptCalled = false;
 
@@ -2319,6 +2361,93 @@ test("resumeAgentFromPersistence drops stored internal paseo MCP when runtime in
 
   expect(client.resumeOverrides[0]?.mcpServers).toBeUndefined();
   expect(snapshot.config.mcpServers).toBeUndefined();
+});
+
+test("resumeAgentFromPersistence drains a buffered autonomous start before returning", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-resume-start-"));
+  const agentId = "00000000-0000-4000-8000-000000000107";
+  const client = new BufferedResumeClient([
+    { type: "turn_started", provider: "codex", turnId: "goal-turn" },
+  ]);
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    logger,
+    idFactory: () => agentId,
+  });
+  const streamedEventTypes: string[] = [];
+  const lifecycleStates: ManagedAgent["lifecycle"][] = [];
+  const unsubscribe = manager.subscribe((event) => {
+    if (event.type === "agent_stream" && event.agentId === agentId) {
+      streamedEventTypes.push(event.event.type);
+    }
+    if (event.type === "agent_state" && event.agent.id === agentId) {
+      lifecycleStates.push(event.agent.lifecycle);
+    }
+  });
+
+  try {
+    const snapshot = await manager.resumeAgentFromPersistence({
+      provider: "codex",
+      sessionId: "active-goal-session",
+      metadata: { cwd: workdir },
+    });
+
+    expect(snapshot.lifecycle).toBe("running");
+    expect(streamedEventTypes).toEqual(["turn_started"]);
+    expect(lifecycleStates).not.toContain("idle");
+    expect(lifecycleStates.at(-1)).toBe("running");
+    await expect(manager.runAgent(snapshot.id, "start another turn")).rejects.toThrow(
+      "already has an active run",
+    );
+  } finally {
+    unsubscribe();
+    if (manager.getAgent(agentId)) {
+      await manager.closeAgent(agentId);
+    }
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("resumeAgentFromPersistence replays a completed autonomous turn in order", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-resume-complete-"));
+  const agentId = "00000000-0000-4000-8000-000000000108";
+  const client = new BufferedResumeClient([
+    { type: "turn_started", provider: "codex", turnId: "goal-turn" },
+    { type: "turn_completed", provider: "codex", turnId: "goal-turn" },
+  ]);
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    logger,
+    idFactory: () => agentId,
+  });
+  const streamedEventTypes: string[] = [];
+  const unsubscribe = manager.subscribe((event) => {
+    if (event.type === "agent_stream" && event.agentId === agentId) {
+      streamedEventTypes.push(event.event.type);
+    }
+  });
+
+  try {
+    const snapshot = await manager.resumeAgentFromPersistence({
+      provider: "codex",
+      sessionId: "completed-goal-session",
+      metadata: { cwd: workdir },
+    });
+
+    expect(snapshot.lifecycle).toBe("idle");
+    expect(streamedEventTypes).toEqual(["turn_started", "turn_completed"]);
+    await expect(manager.runAgent(snapshot.id, "start the next turn")).resolves.toMatchObject({
+      sessionId: expect.any(String),
+    });
+  } finally {
+    unsubscribe();
+    if (manager.getAgent(agentId)) {
+      await manager.closeAgent(agentId);
+    }
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("createAgent preserves a user-provided paseo MCP config", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2968,11 +2968,12 @@ export class AgentManager {
       await this.refreshSessionState(managed, { emit: false });
       this.assertAgentRegistrationActive(managed);
       managed.lifecycle = "idle";
+      await this.subscribeToSession(managed);
+      this.assertAgentRegistrationActive(managed);
       this.touchUpdatedAt(managed);
       await this.persistSnapshot(managed);
       this.assertAgentRegistrationActive(managed);
       this.emitState(managed, { persist: false });
-      this.subscribeToSession(managed);
       return { ...managed };
     } catch (error) {
       if (!registered) {
@@ -3174,7 +3175,7 @@ export class AgentManager {
   private emitClosedAgent(agent: ManagedAgentClosed, options?: { persist?: boolean }): void {
     this.emitState(agent, options);
   }
-  private subscribeToSession(agent: ActiveManagedAgent): void {
+  private async subscribeToSession(agent: ActiveManagedAgent): Promise<void> {
     if (agent.unsubscribeSession) {
       return;
     }
@@ -3183,6 +3184,8 @@ export class AgentManager {
       this.enqueueSessionEvent(agentId, event);
     });
     agent.unsubscribeSession = unsubscribe;
+    agent.session.flushPreSubscriptionEvents?.();
+    await this.drainSessionEvents(agentId);
   }
 
   private enqueueSessionEvent(agentId: string, event: AgentStreamEvent): void {

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -630,6 +630,8 @@ export interface AgentSession {
   run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult>;
   startTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<{ turnId: string }>;
   subscribe(callback: (event: AgentStreamEvent) => void): () => void;
+  /** Synchronously deliver events captured before the first subscriber attached. */
+  flushPreSubscriptionEvents?(): void;
   streamHistory(): AsyncGenerator<AgentStreamEvent>;
   getRuntimeInfo(): Promise<AgentRuntimeInfo>;
   getAvailableModes(): Promise<AgentMode[]>;

--- a/packages/server/src/server/agent/provider-registry-wrap.test.ts
+++ b/packages/server/src/server/agent/provider-registry-wrap.test.ts
@@ -18,6 +18,7 @@ type OptionalAgentSessionMethodName = {
 }[keyof AgentSession];
 
 const OPTIONAL_AGENT_SESSION_METHOD_NAMES = [
+  "flushPreSubscriptionEvents",
   "listCommands",
   "setModel",
   "setThinkingOption",
@@ -74,6 +75,10 @@ class FakeSession implements AgentSession {
   subscribe(_callback: (event: AgentStreamEvent) => void) {
     this.recordedCalls.push("subscribe");
     return () => {};
+  }
+
+  flushPreSubscriptionEvents() {
+    this.recordedCalls.push("flushPreSubscriptionEvents");
   }
 
   async *streamHistory() {
@@ -172,6 +177,7 @@ describe("wrapSessionProvider", () => {
     const session = new FakeSession();
     const wrapped = wrapSessionProvider("custom-claude", session);
 
+    wrapped.flushPreSubscriptionEvents?.();
     await wrapped.listCommands?.();
     await wrapped.setModel?.("sonnet");
     await wrapped.setThinkingOption?.("high");
@@ -183,6 +189,7 @@ describe("wrapSessionProvider", () => {
     await handler?.run({ emit: () => {} });
 
     expect(session.recordedCalls).toEqual([
+      "flushPreSubscriptionEvents",
       "listCommands",
       "setModel",
       "setThinkingOption",

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -445,6 +445,7 @@ export function wrapSessionProvider(provider: AgentProvider, inner: AgentSession
     run: (prompt, options) => inner.run(prompt, options),
     startTurn: (prompt, options) => inner.startTurn(prompt, options),
     subscribe: (callback) => inner.subscribe((event) => callback(mapStreamEvent(provider, event))),
+    flushPreSubscriptionEvents: inner.flushPreSubscriptionEvents?.bind(inner),
     async *streamHistory() {
       for await (const event of inner.streamHistory()) {
         yield mapStreamEvent(provider, event);

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -1459,6 +1459,109 @@ describe("Codex app-server provider", () => {
     appServer.assertNoErrors();
   });
 
+  test("replays an autonomous turn that starts while a resumed session connects", async () => {
+    let interruptParams: unknown;
+    let appServer: FakeCodexAppServer;
+    appServer = createFakeCodexAppServer({
+      "thread/resume": () => {
+        appServer.startsTurn({ threadId: "resumed-thread", turnId: "goal-turn" });
+        return {};
+      },
+      "turn/interrupt": (params) => {
+        interruptParams = params;
+        return {};
+      },
+    });
+    const session = new CodexAppServerAgentSession(
+      createConfig({ modeId: "full-access" }),
+      { sessionId: "resumed-thread" },
+      createTestLogger(),
+      async () => appServer.child,
+    );
+
+    try {
+      await session.connect();
+
+      const events: AgentStreamEvent[] = [];
+      const turnStarted = new Promise<void>((resolve) => {
+        session.subscribe((event) => {
+          events.push(event);
+          if (event.type === "turn_started") {
+            resolve();
+          }
+        });
+      });
+      await turnStarted;
+
+      expect(events).toContainEqual({
+        type: "turn_started",
+        provider: "codex",
+        turnId: "goal-turn",
+      });
+      await session.startTurn("continue the active goal");
+      await session.interrupt();
+      expect(interruptParams).toEqual({
+        threadId: "resumed-thread",
+        turnId: "goal-turn",
+      });
+      appServer.assertNoErrors();
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("does not let a buffered autonomous completion settle the next direct run", async () => {
+    const session = createSession();
+    session.activeForegroundTurnId = null;
+    const internals = asInternals(session);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/loaded/list") {
+        return { data: ["test-thread"] };
+      }
+      if (method === "turn/start") {
+        internals.handleNotification("turn/started", {
+          threadId: "test-thread",
+          turn: { id: "next-native-turn" },
+        });
+        internals.handleNotification("item/completed", {
+          threadId: "test-thread",
+          item: {
+            id: "next-answer",
+            type: "agentMessage",
+            text: "Answer from the next turn",
+          },
+        });
+        internals.handleNotification("turn/completed", {
+          threadId: "test-thread",
+          turn: { status: "completed" },
+        });
+        return {};
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    session.client = { request };
+
+    internals.handleNotification("turn/started", {
+      threadId: "test-thread",
+      turn: { id: "completed-goal-turn" },
+    });
+    internals.handleNotification("turn/completed", {
+      threadId: "test-thread",
+      turn: { status: "completed" },
+    });
+
+    await expect(session.run("start a fresh turn")).resolves.toMatchObject({
+      finalText: "Answer from the next turn",
+      timeline: [
+        {
+          type: "assistant_message",
+          messageId: "next-answer",
+          text: "Answer from the next turn",
+        },
+      ],
+    });
+  });
+
   test("lists repo skills using WorkspaceGitService repo-root resolution", async () => {
     const tempDir = await mkdtemp(path.join(tmpdir(), "codex-skills-"));
     const cwd = path.join(tempDir, "repo", "packages", "app");
@@ -3170,6 +3273,27 @@ describe("Codex app-server provider", () => {
     });
   });
 
+  test("does not interrupt a completed native Codex turn", async () => {
+    const session = createSession();
+    const request = vi.fn(async () => ({}));
+    session.activeForegroundTurnId = null;
+    session.client = { request };
+
+    asInternals(session).handleNotification("turn/started", {
+      threadId: "test-thread",
+      turn: { id: "completed-turn" },
+    });
+    asInternals(session).handleNotification("turn/completed", {
+      threadId: "test-thread",
+      turn: { status: "completed" },
+    });
+
+    await expect(session.interrupt()).rejects.toThrow(
+      "Cannot interrupt Codex before turn/started identifies the active turn",
+    );
+    expect(request).not.toHaveBeenCalled();
+  });
+
   test("never replaces the root identity with an early child thread start", () => {
     const session = createSession();
 
@@ -4153,8 +4277,81 @@ describe("Codex app-server provider", () => {
     expect(session.currentThreadId).toBe("archived-thread-id");
     expect(requests).toEqual([
       { method: "thread/loaded/list", params: {} },
-      { method: "thread/resume", params: { threadId: "archived-thread-id" } },
+      {
+        method: "thread/resume",
+        params: {
+          threadId: "archived-thread-id",
+          approvalPolicy: "on-request",
+          sandbox: "workspace-write",
+          model: "gpt-5.4",
+          cwd: "/tmp/codex-question-test",
+        },
+      },
     ]);
+  });
+
+  test("applies the persisted access mode when resuming a Codex thread", async () => {
+    const session = createSession({ modeId: "full-access" });
+    session.currentThreadId = "full-access-thread";
+    const requests: Array<{ method: string; params: unknown }> = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        requests.push({ method, params });
+        if (method === "thread/loaded/list") {
+          return { data: [] };
+        }
+        return {};
+      }),
+    };
+
+    await asInternals(session).ensureThreadLoaded();
+
+    expect(requests).toContainEqual({
+      method: "thread/resume",
+      params: {
+        threadId: "full-access-thread",
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+        model: "gpt-5.4",
+        cwd: "/tmp/codex-question-test",
+      },
+    });
+  });
+
+  test("preserves auto-review and fast settings when resuming a Codex thread", async () => {
+    const session = createSession(
+      {
+        modeId: "auto-review",
+        featureValues: { fast_mode: true },
+      },
+      { autoReviewEnabled: true },
+    );
+    session.currentThreadId = "specialized-thread";
+    const requests: Array<{ method: string; params: unknown }> = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        requests.push({ method, params });
+        if (method === "thread/loaded/list") {
+          return { data: [] };
+        }
+        return {};
+      }),
+    };
+
+    await asInternals(session).ensureThreadLoaded();
+
+    expect(requests).toContainEqual({
+      method: "thread/resume",
+      params: {
+        threadId: "specialized-thread",
+        approvalPolicy: "on-request",
+        sandbox: "workspace-write",
+        approvalsReviewer: "auto_review",
+        model: "gpt-5.4",
+        cwd: "/tmp/codex-question-test",
+        serviceTier: "fast",
+      },
+    });
   });
 
   test("appends blank-line spacing to /goal status messages", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3179,6 +3179,18 @@ interface ConsumedRootCompaction {
   itemId?: string;
 }
 
+type CodexStreamSubscriber = (event: AgentStreamEvent) => void;
+
+interface BufferedCodexStreamEvent {
+  event: AgentStreamEvent;
+  recipients: Set<CodexStreamSubscriber> | null;
+}
+
+interface DeliverToSubscribersOptions {
+  event: AgentStreamEvent;
+  recipients?: Iterable<CodexStreamSubscriber>;
+}
+
 export class CodexAppServerAgentSession implements AgentSession {
   readonly provider = CODEX_PROVIDER;
   readonly capabilities = CODEX_APP_SERVER_CAPABILITIES;
@@ -3200,7 +3212,10 @@ export class CodexAppServerAgentSession implements AgentSession {
     resolve: (turnId: string | null) => void;
   } | null = null;
   private client: CodexAppServerClient | null = null;
-  private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
+  private readonly subscribers = new Set<CodexStreamSubscriber>();
+  // thread/resume can start an autonomous goal before AgentManager receives the session.
+  private preSubscriptionEvents: BufferedCodexStreamEvent[] | null = [];
+  private preSubscriptionReplayScheduled = false;
   private nextTurnOrdinal = 0;
   private activeForegroundTurnId: string | null = null;
   private activeClientMessageId: string | null = null;
@@ -3756,17 +3771,10 @@ export class CodexAppServerAgentSession implements AgentSession {
       if (ids.includes(this.currentThreadId)) {
         return;
       }
-      const params: Record<string, unknown> = { threadId: this.currentThreadId };
-      const developerInstructions = composeSystemPromptParts(
-        this.config.systemPrompt,
-        this.config.daemonAppendSystemPrompt,
-      );
-      if (developerInstructions) {
-        params.developerInstructions = developerInstructions;
-      }
-      const codexConfig = this.buildCodexInnerConfig();
-      if (codexConfig) {
-        params.config = codexConfig;
+      const { params } = this.buildThreadRequest(this.config.model);
+      params.threadId = this.currentThreadId;
+      if (this.serviceTier) {
+        params.serviceTier = this.serviceTier;
       }
       const response = await this.client.request("thread/resume", params);
       this.rememberResolvedSandboxPolicy(response);
@@ -4064,7 +4072,8 @@ export class CodexAppServerAgentSession implements AgentSession {
       const turnId = this.createTurnId();
       this.activeForegroundTurnId = turnId;
       this.activeClientMessageId = options?.clientMessageId ?? null;
-      this.currentTurnId = null;
+      // Codex may steer this input into an existing autonomous turn. Keep that
+      // native id interruptible unless turn/started replaces it or the turn ends.
       this.pendingForegroundTurnIdentification?.resolve(null);
       let resolveTurnIdentification!: (identifiedTurnId: string | null) => void;
       const turnIdentification = new Promise<string | null>((resolvePromise) => {
@@ -4133,9 +4142,24 @@ export class CodexAppServerAgentSession implements AgentSession {
 
   subscribe(callback: (event: AgentStreamEvent) => void): () => void {
     this.subscribers.add(callback);
+    if (this.preSubscriptionEvents?.length === 0) {
+      this.preSubscriptionEvents = null;
+    } else {
+      const recipients = new Set(this.subscribers);
+      for (const buffered of this.preSubscriptionEvents ?? []) {
+        if (buffered.recipients === null) {
+          buffered.recipients = recipients;
+        }
+      }
+      this.schedulePreSubscriptionReplay();
+    }
     return () => {
       this.subscribers.delete(callback);
     };
+  }
+
+  flushPreSubscriptionEvents(): void {
+    this.replayPreSubscriptionEvents();
   }
 
   async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
@@ -4512,6 +4536,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.clearPendingPermissions();
     this.pendingSubAgentNotificationsByThreadId.clear();
     this.subscribers.clear();
+    this.preSubscriptionEvents = null;
     this.activeForegroundTurnId = null;
     this.activeClientMessageId = null;
     this.pendingForegroundTurnIdentification?.resolve(null);
@@ -4759,7 +4784,10 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.config.model = model;
     this.config.thinkingOptionId = thinkingOptionId;
 
-    const { params, approvalPolicy, sandbox } = this.buildThreadStartRequest(model);
+    const { params, approvalPolicy, sandbox } = this.buildThreadRequest(model);
+    if (this.ephemeral) {
+      params.ephemeral = true;
+    }
     const rawResponse = await this.client.request("thread/start", params);
     this.rememberResolvedSandboxPolicy(rawResponse);
     const response = toObjectRecord(rawResponse);
@@ -4783,7 +4811,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.currentThreadId = threadId;
   }
 
-  private buildThreadStartRequest(model: string): {
+  private buildThreadRequest(model?: string): {
     params: Record<string, unknown>;
     approvalPolicy?: string;
     sandbox?: string;
@@ -4797,7 +4825,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       this.config.daemonAppendSystemPrompt,
     );
     const params: Record<string, unknown> = {
-      model,
+      ...(model ? { model } : {}),
       cwd: this.config.cwd ?? null,
       ...(approvalPolicy && this.providerOptions.approval_policy === undefined
         ? { approvalPolicy }
@@ -4805,7 +4833,6 @@ export class CodexAppServerAgentSession implements AgentSession {
       ...(sandbox && this.providerOptions.sandbox_mode === undefined ? { sandbox } : {}),
       ...(developerInstructions ? { developerInstructions } : {}),
       ...(innerConfig ? { config: innerConfig } : {}),
-      ...(this.ephemeral ? { ephemeral: true } : {}),
     };
     if (this.hasWorkflowModeOverride) {
       applyApprovalsReviewerParam(params, preset);
@@ -4846,7 +4873,7 @@ export class CodexAppServerAgentSession implements AgentSession {
   }
 
   private notifySubscribers(event: AgentStreamEvent): void {
-    const turnId = this.activeForegroundTurnId;
+    const turnId = this.activeForegroundTurnId ?? this.currentTurnId;
     const tagged = turnId ? { ...event, turnId } : event;
     this.logger.trace(
       {
@@ -4858,9 +4885,62 @@ export class CodexAppServerAgentSession implements AgentSession {
       },
       "provider.codex.event_emit",
     );
-    for (const callback of this.subscribers) {
+    if (this.preSubscriptionEvents) {
+      this.preSubscriptionEvents.push({
+        event: tagged,
+        recipients: this.subscribers.size > 0 ? new Set(this.subscribers) : null,
+      });
+      this.schedulePreSubscriptionReplay();
+      return;
+    }
+    this.deliverToSubscribers({ event: tagged });
+  }
+
+  private schedulePreSubscriptionReplay(): void {
+    if (
+      !this.preSubscriptionEvents ||
+      this.preSubscriptionReplayScheduled ||
+      this.subscribers.size === 0
+    ) {
+      return;
+    }
+    this.preSubscriptionReplayScheduled = true;
+    // Defer replay so callbacks may safely capture the unsubscribe function
+    // returned by subscribe(), while recipient snapshots preserve event order.
+    queueMicrotask(() => {
+      this.preSubscriptionReplayScheduled = false;
+      this.replayPreSubscriptionEvents();
+    });
+  }
+
+  private replayPreSubscriptionEvents(): void {
+    const buffered = this.preSubscriptionEvents;
+    if (!buffered || this.subscribers.size === 0) {
+      return;
+    }
+    let consumed = 0;
+    while (consumed < buffered.length && this.subscribers.size > 0) {
+      const next = buffered[consumed++];
+      if (next?.recipients) {
+        this.deliverToSubscribers({ event: next.event, recipients: next.recipients });
+      }
+    }
+    buffered.splice(0, consumed);
+    if (buffered.length === 0) {
+      this.preSubscriptionEvents = null;
+    }
+  }
+
+  private deliverToSubscribers({
+    event,
+    recipients = this.subscribers,
+  }: DeliverToSubscribersOptions): void {
+    for (const callback of recipients) {
+      if (!this.subscribers.has(callback)) {
+        continue;
+      }
       try {
-        callback(tagged);
+        callback(event);
       } catch (error) {
         this.logger.warn({ err: error }, "Subscriber callback threw");
       }
@@ -5625,9 +5705,9 @@ export class CodexAppServerAgentSession implements AgentSession {
         usage: this.latestUsage,
       });
     }
+    this.currentTurnId = null;
     this.activeForegroundTurnId = null;
     this.activeClientMessageId = null;
-    this.currentTurnId = null;
     this.pendingForegroundTurnIdentification?.resolve(null);
     this.pendingForegroundTurnIdentification = null;
     this.pendingSubAgentNotificationsByThreadId.clear();


### PR DESCRIPTION
### Linked issue

Closes #2332

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Resumed Codex agents now keep their configured access mode and active autonomous turn state. Previously, resuming a Full access session could silently fall back to approval prompts, briefly publish the agent as idle, and lose the native turn ID needed by Stop after a continuation prompt.

The resume request now restores the persisted execution policy, model, working directory, and feature settings. Events emitted while `thread/resume` is still connecting are buffered through provider wrappers and drained before the final agent state is published, while native turn identity remains available until completion. 

### How did you verify it

- Ran the [deterministic two-worktree reproduction script](https://github.com/getpaseo/paseo/pull/2333#issuecomment-5050262586), which overlays only this PR's regression tests onto the exact pre-fix merge base and compares it with the PR head:
  - Pre-fix `65633004b23d6eeeda9321e04f096ca647694b2b`: the persisted-policy and resumed-state checks both failed.
  - PR head `f1e11fa50789d9fbea2a34cd6108178ea38f354d`: both checks passed.
- `npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1` — 113 passed.
- `npx vitest run packages/server/src/server/agent/agent-manager.test.ts --bail=1` — 144 passed.
- `npx vitest run packages/server/src/server/agent/provider-registry-wrap.test.ts --bail=1` — 1 passed.
- `npm run build:server` — passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed with 0 warnings and 0 errors.
- Formatting checks passed with no additional diff.

The regression coverage includes resume-time autonomous starts and completions, immediate follow-up runs, interruption after continuation, wrapped/custom providers, Full access, auto-review, fast mode.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; server-only change)
- [x] Tests added or updated where it made sense
