### PR TITLE
Keep completed OpenCode turns idle

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -97,15 +97,6 @@ function turnEventSignatures(events: AgentStreamEvent[]): TurnEventSignature[] {
   return events.map((event) => [event.type, "turnId" in event ? event.turnId : undefined]);
 }
 
-function hasTurnCompleted(events: AgentStreamEvent[]): boolean {
-  for (const event of events) {
-    if (event.type === "turn_completed") {
-      return true;
-    }
-  }
-  return false;
-}
-
 function userMessageEvents(params: {
   sessionId: string;
   messageId: string;
@@ -2764,7 +2755,7 @@ describe("OpenCode provider subagent contract", () => {
       await parent.startTurn("Hello OpenCode");
 
       await vi.waitFor(() => {
-        expect(hasTurnCompleted(events)).toBe(true);
+        expect(events.some((e) => e.type === "turn_completed")).toBe(true);
       });
 
       // Post-turn message update for the same user message ID that already completed

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -2755,7 +2755,7 @@ describe("OpenCode provider subagent contract", () => {
       await parent.startTurn("Hello OpenCode");
 
       await vi.waitFor(() => {
-        expect(events.some((e) => e.type === "turn_completed")).toBe(true);
+        expect(events).toContainEqual(expect.objectContaining({ type: "turn_completed" }));
       });
 
       // Post-turn message update for the same user message ID that already completed

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -97,6 +97,15 @@ function turnEventSignatures(events: AgentStreamEvent[]): TurnEventSignature[] {
   return events.map((event) => [event.type, "turnId" in event ? event.turnId : undefined]);
 }
 
+function hasTurnCompleted(events: AgentStreamEvent[]): boolean {
+  for (const event of events) {
+    if (event.type === "turn_completed") {
+      return true;
+    }
+  }
+  return false;
+}
+
 function userMessageEvents(params: {
   sessionId: string;
   messageId: string;
@@ -2724,6 +2733,65 @@ describe("OpenCode provider subagent contract", () => {
       );
       expect(openCode.calls.sessionAbort).toEqual([]);
       expect(openCode.calls.sessionPromptAsync).toEqual([]);
+    } finally {
+      await parent.close();
+    }
+  });
+
+  test("does not start a new autonomous turn when post-turn user message updates arrive for an already emitted message", async () => {
+    const { parent, openCode } = await createParentSession("ses_parent_post_turn");
+    openCode.sessionPromptAsyncEvents = [
+      ...userMessageEvents({
+        sessionId: "ses_parent_post_turn",
+        messageId: "msg_user_1",
+        text: "Hello OpenCode",
+      }),
+      ...assistantTurnEvents({
+        sessionId: "ses_parent_post_turn",
+        text: "Response from OpenCode",
+      }),
+    ];
+    const events: AgentStreamEvent[] = [];
+    const streamDrained = createTestDeferred<void>();
+    parent.subscribe((event) => {
+      events.push(event);
+      if (event.type === "provider_subagent") {
+        streamDrained.resolve();
+      }
+    });
+
+    try {
+      await parent.startTurn("Hello OpenCode");
+
+      await vi.waitFor(() => {
+        expect(hasTurnCompleted(events)).toBe(true);
+      });
+
+      // Post-turn message update for the same user message ID that already completed
+      openCode.emitEvent({
+        type: "message.updated",
+        properties: {
+          info: { id: "msg_user_1", sessionID: "ses_parent_post_turn", role: "user" },
+        },
+      });
+
+      openCode.emitEvent({
+        type: "session.created",
+        properties: {
+          info: {
+            id: "ses_child_drain_marker",
+            parentID: "ses_parent_post_turn",
+            title: "Stream drain marker",
+            directory: "/workspace/repo",
+          },
+        },
+      });
+
+      await streamDrained.promise;
+
+      // Verify that no new turn_started was emitted after turn_completed
+      const turnStartedCount = events.filter((e) => e.type === "turn_started").length;
+      expect(turnStartedCount).toBe(1);
     } finally {
       await parent.close();
     }

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -3662,6 +3662,9 @@ class OpenCodeAgentSession implements AgentSession {
     // busy. That message is the earliest unambiguous boundary for a plugin-
     // initiated parent turn; session metadata and assistant echoes are not.
     if (event.type === "message.updated" && event.properties.info.role === "user") {
+      if (this.emittedUserMessageIds.has(event.properties.info.id)) {
+        return false;
+      }
       return true;
     }
     if (!this.externallyDriven) {


### PR DESCRIPTION
### Linked issue

Closes #2330

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

OpenCode can update the original user message metadata after a turn has already become idle. Paseo now ignores those updates when the message ID was already emitted, instead of mistaking them for a plugin-triggered follow-up and leaving the agent stuck running.

Fresh user message IDs still start autonomous turns, preserving background plugin wakeups.

### How did you verify it

- Reproduced the regression on main with the targeted test: one foreground turn emitted two turn_started events.
- Ran the complete OpenCode provider unit file on this branch: 68 tests passed.
- Ran npm run build:client followed by npm run typecheck.
- Ran npm run lint.
- Ran npm run format.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format ran
- [x] UI screenshots or video are not applicable; this is a server-only event classification fix.
- [x] Tests added or updated where it made sense