### PR TITLE
List paseo-skins as a community project

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -154,6 +154,7 @@ npm run typecheck
 ## 関連プロジェクト
 
 - [getpaseo/paseo-relay](https://github.com/getpaseo/paseo-relay) — Elixir 製の公式分散リレー
+- [paseo-skins](https://github.com/huangguang1999/paseo-skins) — Paseo デスクトップ向けコミュニティテーマと、Agent Skill 対応のゼロパッチテーマローダー
 - [paseo-vscode](https://marketplace.visualstudio.com/items?itemName=hinnes.paseo-vscode) — VS Code 拡張機能
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ npm run typecheck
 ## Related projects
 
 - [getpaseo/paseo-relay](https://github.com/getpaseo/paseo-relay) — official distributed relay, written in Elixir
+- [paseo-skins](https://github.com/huangguang1999/paseo-skins) — community themes and a zero-patch desktop theme loader with an Agent Skill
 - [paseo-vscode](https://marketplace.visualstudio.com/items?itemName=hinnes.paseo-vscode) — VS Code extension
 
 ## License

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,6 +154,7 @@ npm run typecheck
 ## 相关项目
 
 - [getpaseo/paseo-relay](https://github.com/getpaseo/paseo-relay) — 官方分布式 relay，使用 Elixir 编写
+- [paseo-skins](https://github.com/huangguang1999/paseo-skins) — Paseo 桌面端社区主题与零 patch 换肤工具，支持 Agent Skill
 - [paseo-vscode](https://marketplace.visualstudio.com/items?itemName=hinnes.paseo-vscode) — VS Code 扩展
 
 ### 自托管 relay TLS


### PR DESCRIPTION
### Linked issue

Docs-only change; no matching open issue.

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Adds [paseo-skins](https://github.com/huangguang1999/paseo-skins) to the Related projects section in the English, Simplified Chinese, and Japanese READMEs.

The description identifies it as a community theme project with an Agent Skill and a zero-patch desktop theme loader, so it does not imply that theming is an official built-in Paseo feature.

### How did you verify it

- Ran `npm run build:server` to refresh workspace declarations after rebasing.
- Ran `npm run typecheck` successfully.
- Ran `npm run lint` successfully with 0 warnings and 0 errors.
- Ran `npm run format` successfully.
- Confirmed the final diff contains exactly one new Related projects bullet in each of the three READMEs.
- Did not run the full test suite because this is a documentation-only change and the repository guidance advises against local full-suite runs.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [x] UI changes include screenshots or video for every affected platform (not applicable: docs-only)
- [x] Tests added or updated where it made sense (not applicable: docs-only)
