### PR TITLE
fix(app): show project name in command center workspace search

### DIFF
--- a/packages/app/e2e/command-center-workspaces.spec.ts
+++ b/packages/app/e2e/command-center-workspaces.spec.ts
@@ -55,9 +55,15 @@ test.describe("Command center workspaces", () => {
       );
       await expect(row).toBeVisible({ timeout: 30_000 });
       await expect(row).toContainText(WORKSPACE_TITLE);
-      await expect(row).toContainText(PRIMARY_HOST_LABEL);
       await expect(row).toContainText(WORKSPACE_BRANCH);
 
+      // The subtitle disambiguates by project: host · project · branch (multi-host).
+      const subtitle = row.getByTestId("command-center-workspace-subtitle");
+      await expect(subtitle).toContainText(PRIMARY_HOST_LABEL);
+      await expect(subtitle).toContainText(seeded.projectDisplayName);
+      await expect(subtitle).toContainText(WORKSPACE_BRANCH);
+
+      // The agent subtitle is unchanged by the shared-helper refactor.
       const agentRow = panel.getByTestId(`command-center-agent-${getServerId()}:${agent.id}`);
       await expect(agentRow).toContainText(AGENT_TITLE);
       await expect(agentRow).toContainText(PRIMARY_HOST_LABEL);
@@ -89,6 +95,10 @@ test.describe("Command center workspaces", () => {
       await expect(agentRow).toBeVisible();
       await expect(row).not.toBeVisible();
 
+      // The project name is now part of the workspace searchText.
+      await input.fill(seeded.projectDisplayName);
+      await expect(row).toBeVisible();
+
       await input.fill(AGENT_TITLE);
       await expect(agentRow).toBeVisible();
       await expect(row).not.toBeVisible();
@@ -99,6 +109,40 @@ test.describe("Command center workspaces", () => {
       await expectAppRoute(page, buildHostWorkspaceRoute(getServerId(), seeded.workspaceId), {
         timeout: 30_000,
       });
+    } finally {
+      await seeded.cleanup();
+    }
+  });
+
+  test("single-host workspace subtitle omits the host and shows project · branch", async ({
+    page,
+  }) => {
+    const seeded = await seedWorkspace({
+      repoPrefix: "command-center-workspace-single-",
+      title: WORKSPACE_TITLE,
+    });
+
+    try {
+      execFileSync("git", ["checkout", "-b", WORKSPACE_BRANCH], {
+        cwd: seeded.repoPath,
+        stdio: "ignore",
+      });
+      const refreshed = await seeded.client.checkoutRefresh(seeded.repoPath);
+      if (!refreshed.success) {
+        throw new Error(`Failed to refresh checkout: ${JSON.stringify(refreshed.error)}`);
+      }
+
+      // No secondary host: with a single host, the host label is gated away.
+      await gotoAppShell(page);
+
+      const panel = await openCommandCenter(page);
+      const row = panel.getByTestId(
+        `command-center-workspace-${getServerId()}:${seeded.workspaceId}`,
+      );
+      await expect(row).toBeVisible({ timeout: 30_000 });
+
+      const subtitle = row.getByTestId("command-center-workspace-subtitle");
+      await expect(subtitle).toHaveText(`${seeded.projectDisplayName} · ${WORKSPACE_BRANCH}`);
     } finally {
       await seeded.cleanup();
     }

--- a/packages/app/src/command-center/command-center.tsx
+++ b/packages/app/src/command-center/command-center.tsx
@@ -52,6 +52,7 @@ import type { CommandCenterContribution, CommandCenterIconProps } from "./contri
 import { useCommandCenterActions, useCommandCenterContributions } from "./provider";
 import {
   buildContributionSections,
+  joinSubtitleParts,
   moveActiveResultId,
   preserveActiveResultId,
   projectCommandCenterRows,
@@ -203,7 +204,7 @@ function useBuiltInSections(open: boolean, query: string): CommandCenterResultSe
   const { t } = useTranslation();
   const { agents } = useAggregatedAgents();
   const { projects } = useProjects({ enabled: open });
-  const showAgentHost = useHosts().length > 1;
+  const showHost = useHosts().length > 1;
 
   return useMemo(() => {
     if (!open) return [];
@@ -213,9 +214,11 @@ function useBuiltInSections(open: boolean, query: string): CommandCenterResultSe
         for (const workspace of host.workspaces) {
           if (workspace.archivingAt) continue;
           const title = workspace.title ?? workspace.name;
-          const subtitle = workspace.currentBranch
-            ? `${host.serverName} · ${workspace.currentBranch}`
-            : host.serverName;
+          const subtitle = joinSubtitleParts([
+            showHost ? host.serverName : null,
+            project.projectName,
+            workspace.currentBranch,
+          ]);
           const searchText = `${title} ${subtitle}`.toLowerCase();
           allWorkspaces.push({
             kind: "workspace",
@@ -251,13 +254,11 @@ function useBuiltInSections(open: boolean, query: string): CommandCenterResultSe
           ? workspaceTitleByKey.get(`${agent.serverId}:${agent.workspaceId}`)
           : undefined;
         const location = workspaceTitle ?? shortenPath(agent.cwd);
-        const subtitle = [
-          showAgentHost ? agent.serverLabel : null,
+        const subtitle = joinSubtitleParts([
+          showHost ? agent.serverLabel : null,
           location,
           formatTimeAgo(agent.lastActivityAt),
-        ]
-          .filter((part): part is string => Boolean(part))
-          .join(" · ");
+        ]);
         return {
           kind: "agent",
           id: `agent:${agent.serverId}:${agent.id}`,
@@ -282,7 +283,7 @@ function useBuiltInSections(open: boolean, query: string): CommandCenterResultSe
       },
       { id: "agents", rank: 3, title: t("shell.commandCenter.agents"), results: agentResults },
     ];
-  }, [agents, open, projects, query, showAgentHost, t]);
+  }, [agents, open, projects, query, showHost, t]);
 }
 
 interface CommandCenterState {
@@ -461,7 +462,11 @@ function ResultContent({ result }: { result: CommandCenterResult }) {
             <Text style={styles.title} numberOfLines={1}>
               {result.title}
             </Text>
-            <Text style={styles.subtitle} numberOfLines={1}>
+            <Text
+              style={styles.subtitle}
+              numberOfLines={1}
+              testID="command-center-workspace-subtitle"
+            >
               {result.subtitle}
             </Text>
           </View>

--- a/packages/app/src/command-center/results.test.ts
+++ b/packages/app/src/command-center/results.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { CommandCenterContribution } from "./contributions";
 import {
   buildContributionSections,
+  joinSubtitleParts,
   moveActiveResultId,
   preserveActiveResultId,
   projectCommandCenterRows,
@@ -101,5 +102,37 @@ describe("Command Center result projection", () => {
     expect(activeId).toBe(targetId);
     expect(projection.rowIndexByResultId.get(targetId)).toBe(151);
     expect(projection.offsets[151]).toBe(32 + 150 * 56);
+  });
+});
+
+describe("joinSubtitleParts", () => {
+  it("joins all present parts with a middle dot", () => {
+    expect(joinSubtitleParts(["a", "b", "c"])).toBe("a · b · c");
+  });
+
+  it("drops null and undefined parts", () => {
+    expect(joinSubtitleParts(["host", null, "master"])).toBe("host · master");
+    expect(joinSubtitleParts(["host", undefined, "master"])).toBe("host · master");
+  });
+
+  it("drops empty strings (Boolean parity — agents subtitle refactor guard)", () => {
+    expect(joinSubtitleParts(["", "paseo", "master"])).toBe("paseo · master");
+  });
+
+  it("returns an empty string when every part is null or empty", () => {
+    expect(joinSubtitleParts([null, undefined, ""])).toBe("");
+  });
+
+  it("returns a single part unchanged, with no separator", () => {
+    expect(joinSubtitleParts([null, "paseo", null])).toBe("paseo");
+  });
+
+  it("builds the workspace subtitle in host · project · branch order", () => {
+    // Single-host: host gated away, project leads.
+    expect(joinSubtitleParts([null, "paseo", "master"])).toBe("paseo · master");
+    // Multi-host: host first, then project, then branch.
+    expect(joinSubtitleParts(["host", "paseo", "master"])).toBe("host · paseo · master");
+    // No branch: degrades to project (or host · project).
+    expect(joinSubtitleParts([null, "paseo", null])).toBe("paseo");
   });
 });

--- a/packages/app/src/command-center/results.ts
+++ b/packages/app/src/command-center/results.ts
@@ -63,6 +63,11 @@ function matchesQuery(searchText: string, query: string): boolean {
   return !normalized || searchText.includes(normalized);
 }
 
+/** Join non-empty subtitle parts with " · ", dropping null/undefined/empty. */
+export function joinSubtitleParts(parts: readonly (string | null | undefined)[]): string {
+  return parts.filter((part): part is string => Boolean(part)).join(" · ");
+}
+
 function contributionSearchText(contribution: CommandCenterContribution): string {
   const presentationText =
     contribution.presentation.kind === "action"


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Searching the command center (Cmd+K) for a branch name like `master` returned a
Workspaces list where nearly every row was identical — the title was the branch
(`master`) and the subtitle was `<hostname> · <branch>`. On a single-machine setup
the hostname is the same on every row, so there was no way to tell which project
each `master` workspace belonged to.

This adds the **project name** to the workspace subtitle and gates the hostname
behind multi-host (matching how the Agents section already handles the host label):

- Single-host: `getpaseo/paseo · master` (no redundant hostname)
- Multi-host: `Christophs-MacBook-Pro.local · getpaseo/paseo · master`

Because the row's `searchText` is derived from title + subtitle, typing a project
name now also matches its workspaces, which it didn't before.

The subtitle join was extracted into a small shared `joinSubtitleParts()` helper and
reused by both the workspace and agent subtitles, removing the duplicated
`.filter(Boolean).join(" · ")` the Agents section previously hand-rolled.

Files: `command-center.tsx`, `results.ts`, `results.test.ts`,
`command-center-workspaces.spec.ts` (+99 / −12).

### How did you verify it

**Tested live on web** against my real daemon (real workspaces):

Before:

<img width="633" height="546" alt="image" src="https://github.com/user-attachments/assets/262a0f38-85da-49f9-9bd4-6a36147862eb" />

After (multi-host):

<img width="633" height="487" alt="image" src="https://github.com/user-attachments/assets/f2d3a1f8-aaab-4f03-b4ea-0ccd42448847" />

After (single-host):

<img width="629" height="483" alt="image" src="https://github.com/user-attachments/assets/66de900b-6fec-473f-931b-2b9e353ee17e" />

**Automated:**

- `npx vitest run packages/app/src/command-center/results.test.ts` → 10 passed (new `joinSubtitleParts` block, incl. an empty-string case that guards the agent-subtitle refactor).
- `npm run typecheck` → clean (all packages).
- `npm run lint` → 0 warnings, 0 errors on the changed files.
- `npm run format` (Biome) ran on the changed files.
- Extended the existing e2e spec (`command-center-workspaces.spec.ts`) to assert project display, single-host host-gating, unchanged agent subtitle, and search-by-project.

**Platforms:** the command center is shared cross-platform code (`command-center.tsx`,
no platform split), so behavior is identical everywhere. I only visually verified on
**web** — I did not separately capture iOS, Android, or desktop.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform _(web only — attach before/after; see note above)_
- [x] Tests added or updated where it made sense