### PR TITLE
fix(quota): restore Grok Settings usage for current CLI auth/billing

### DIFF
--- a/packages/server/src/services/quota-fetcher/providers/grok.ts
+++ b/packages/server/src/services/quota-fetcher/providers/grok.ts
@@ -38,6 +38,8 @@ const GrokUsageResponseSchema = z.object({
 interface GrokQuotaProviderOptions {
   logger: Logger;
   fetch?: ProviderApiFetch;
+  /** Override home directory (tests). Production uses os.homedir(). */
+  homeDir?: string;
 }
 
 /** Resolve a Grok CLI token from ~/.grok/auth.json (legacy or current nested shape). */
@@ -71,10 +73,12 @@ export class GrokQuotaProvider implements ProviderUsageFetcher {
 
   private readonly logger: Logger;
   private readonly fetchApi: ProviderApiFetch;
+  private readonly homeDir: string | undefined;
 
   constructor(options: GrokQuotaProviderOptions) {
     this.logger = options.logger;
     this.fetchApi = options.fetch ?? fetch;
+    this.homeDir = options.homeDir;
   }
 
   async fetchUsage(): Promise<ProviderUsage> {
@@ -134,7 +138,8 @@ export class GrokQuotaProvider implements ProviderUsageFetcher {
   }
 
   private async readGrokToken(): Promise<string | null> {
-    const path = join(homedir(), ".grok", "auth.json");
+    // homeDir override is for tests: Windows os.homedir() ignores $HOME (uses USERPROFILE).
+    const path = join(this.homeDir ?? homedir(), ".grok", "auth.json");
     if (!existsSync(path)) return null;
     try {
       return extractGrokTokenFromAuth(JSON.parse(await fs.readFile(path, "utf8")));

--- a/packages/server/src/services/quota-fetcher/providers/grok.ts
+++ b/packages/server/src/services/quota-fetcher/providers/grok.ts
@@ -21,6 +21,11 @@ const GrokUsageResponseSchema = z.object({
           val: ApiNumberSchema.optional(),
         })
         .nullish(),
+      used: z
+        .object({
+          val: ApiNumberSchema.optional(),
+        })
+        .nullish(),
     })
     .nullish(),
   usage: z
@@ -30,13 +35,34 @@ const GrokUsageResponseSchema = z.object({
     .nullish(),
 });
 
-const GrokAuthSchema = z.object({
-  access_token: z.string().optional(),
-});
-
 interface GrokQuotaProviderOptions {
   logger: Logger;
   fetch?: ProviderApiFetch;
+}
+
+/** Resolve a Grok CLI token from ~/.grok/auth.json (legacy or current nested shape). */
+export function extractGrokTokenFromAuth(auth: unknown): string | null {
+  if (auth == null || typeof auth !== "object" || Array.isArray(auth)) return null;
+  const record = auth as Record<string, unknown>;
+
+  const topLevel = record["access_token"];
+  if (typeof topLevel === "string" && topLevel.length > 0) {
+    return topLevel;
+  }
+
+  const entries = Object.entries(record);
+  const preferred = entries.filter(([key]) => key.startsWith("https://auth.x.ai::"));
+  const candidates = preferred.length > 0 ? preferred : entries;
+
+  for (const [, value] of candidates) {
+    if (value == null || typeof value !== "object" || Array.isArray(value)) continue;
+    const nestedKey = (value as Record<string, unknown>)["key"];
+    if (typeof nestedKey === "string" && nestedKey.length > 0) {
+      return nestedKey;
+    }
+  }
+
+  return null;
 }
 
 export class GrokQuotaProvider implements ProviderUsageFetcher {
@@ -76,7 +102,8 @@ export class GrokQuotaProvider implements ProviderUsageFetcher {
 
     const resp = GrokUsageResponseSchema.parse(await res.json());
     const monthlyLimit = resp.config?.monthlyLimit?.val ?? null;
-    const creditUsage = resp.usage?.creditUsage ?? null;
+    // Live CLI billing uses config.used.val; older mocks used usage.creditUsage.
+    const creditUsage = resp.config?.used?.val ?? resp.usage?.creditUsage ?? null;
     const balances: ProviderUsageBalance[] = [];
     if (monthlyLimit !== null || creditUsage !== null) {
       const remaining =
@@ -110,8 +137,7 @@ export class GrokQuotaProvider implements ProviderUsageFetcher {
     const path = join(homedir(), ".grok", "auth.json");
     if (!existsSync(path)) return null;
     try {
-      const auth = GrokAuthSchema.parse(JSON.parse(await fs.readFile(path, "utf8")));
-      return auth.access_token ?? null;
+      return extractGrokTokenFromAuth(JSON.parse(await fs.readFile(path, "utf8")));
     } catch {
       return null;
     }

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -387,7 +387,13 @@ describe("real provider usage fetchers", () => {
         new CopilotQuotaProvider({ logger, fetch: fetchThroughTestDouble }),
         new CursorQuotaProvider({ logger, fetch: fetchThroughTestDouble }),
         new ZaiQuotaProvider({ logger, fetch: fetchThroughTestDouble }),
-        new GrokQuotaProvider({ logger, fetch: fetchThroughTestDouble }),
+        new GrokQuotaProvider({
+          logger,
+          fetch: fetchThroughTestDouble,
+          // Match Kimi: inject temp HOME so nested auth-file tests work on Windows
+          // (os.homedir() uses USERPROFILE there and ignores process.env.HOME).
+          homeDir,
+        }),
         new KimiQuotaProvider({
           logger,
           fetch: fetchThroughTestDouble,

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -51,6 +51,11 @@ function writeKimiCredentials(dir: string, accessToken: string): void {
   );
 }
 
+function writeGrokAuth(home: string, auth: Record<string, unknown>): void {
+  mkdirSync(join(home, ".grok"), { recursive: true });
+  writeFileSync(join(home, ".grok", "auth.json"), JSON.stringify(auth));
+}
+
 function writeMiniMaxConfig(dir: string, payload: Record<string, unknown>): void {
   mkdirSync(join(dir, ".mmx"), { recursive: true });
   writeFileSync(join(dir, ".mmx", "config.json"), JSON.stringify(payload));
@@ -720,8 +725,7 @@ describe("real provider usage fetchers", () => {
           "https://cli-chat-proxy.grok.com/v1/billing",
           () =>
             jsonResponse({
-              config: { monthlyLimit: { val: 0 } },
-              usage: { creditUsage: 0 },
+              config: { monthlyLimit: { val: 0 }, used: { val: 0 } },
             }),
         ],
       ]),
@@ -737,6 +741,109 @@ describe("real provider usage fetchers", () => {
           used: 0,
           remaining: 0,
           limit: 0,
+        }),
+      ],
+    });
+  });
+
+  it("fetches Grok usage from live billing shape (config.used.val)", async () => {
+    process.env["GROK_API_KEY"] = "grok_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://cli-chat-proxy.grok.com/v1/billing",
+          () =>
+            jsonResponse({
+              config: {
+                monthlyLimit: { val: 150000 },
+                used: { val: 37886 },
+                billingPeriodStart: "2026-07-01T00:00:00+00:00",
+                billingPeriodEnd: "2026-08-01T00:00:00+00:00",
+              },
+            }),
+        ],
+      ]),
+    );
+
+    const grok = findProvider(await service().listUsage(), "grok");
+
+    expect(grok).toMatchObject({
+      status: "available",
+      balances: [
+        expect.objectContaining({
+          id: "monthly_credits",
+          used: 37886,
+          remaining: 112114,
+          limit: 150000,
+          unit: "credits",
+        }),
+      ],
+    });
+  });
+
+  it("fetches Grok usage with nested ~/.grok/auth.json key token", async () => {
+    writeGrokAuth(homeDir, {
+      "https://auth.x.ai::test-user-id": {
+        key: "nested_jwt_token",
+        refresh_token: "rt_nested",
+        expires_at: "2026-08-01T00:00:00Z",
+        user_id: "test-user-id",
+        email: "user@example.com",
+      },
+    });
+
+    let authorization: string | null = null;
+    fetchApi = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      authorization = (init?.headers as Record<string, string> | undefined)?.Authorization ?? null;
+      return jsonResponse({
+        config: {
+          monthlyLimit: { val: 100 },
+          used: { val: 25 },
+        },
+      });
+    }) as typeof fetch;
+
+    const grok = findProvider(await service().listUsage(), "grok");
+
+    expect(authorization).toBe("Bearer nested_jwt_token");
+    expect(grok).toMatchObject({
+      status: "available",
+      balances: [
+        expect.objectContaining({
+          id: "monthly_credits",
+          used: 25,
+          remaining: 75,
+          limit: 100,
+        }),
+      ],
+    });
+  });
+
+  it("still accepts legacy Grok usage.creditUsage when config.used is absent", async () => {
+    process.env["GROK_API_KEY"] = "grok_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://cli-chat-proxy.grok.com/v1/billing",
+          () =>
+            jsonResponse({
+              config: { monthlyLimit: { val: 50 } },
+              usage: { creditUsage: 10 },
+            }),
+        ],
+      ]),
+    );
+
+    const grok = findProvider(await service().listUsage(), "grok");
+
+    expect(grok).toMatchObject({
+      status: "available",
+      balances: [
+        expect.objectContaining({
+          id: "monthly_credits",
+          used: 10,
+          remaining: 40,
+          limit: 50,
         }),
       ],
     });


### PR DESCRIPTION
Closes #2352

## What is broken

Settings → **Usage** never shows Grok plan credits for a normal Grok CLI login, even when:

- the host is logged into Grok CLI (`~/.grok/auth.json` present), and
- `GET https://cli-chat-proxy.grok.com/v1/billing` returns a healthy monthly budget.

**Expected:** a `Monthly credits` balance (used / remaining / limit), same surface as Claude/Codex plan usage.  
**Actual:** Grok is missing, unavailable, or shows empty balances — no error that points at the real cause.

This is the **Settings plan-credits** path only (`GrokQuotaProvider` in the daemon quota-fetcher).  
It is **not** the composer context-window meter (that is a separate path: #1390 / ACP `usage_update`).

Issue: #2352

---

## Why it broke (two independent schema drifts)

Either drift alone is enough to drop the card; both are present on current Grok CLI installs. Verified against live host shapes (2026-07-23) and the code on `main`.

### Drift 1 — auth token (`readGrokToken`)

**Old code** only accepted a top-level field:

```ts
const GrokAuthSchema = z.object({ access_token: z.string().optional() });
// ...
return auth.access_token ?? null;
```

**Live `~/.grok/auth.json` shape** (structure only; no secrets):

```json
{
  "https://auth.x.ai::<uuid>": {
    "key": "<JWT>",
    "refresh_token": "...",
    "expires_at": "...",
    "user_id": "...",
    "email": "..."
  }
}
```

There is **no** top-level `access_token`. The token lives at the nested entry’s **`key`**.

So without `GROK_API_KEY` / `GROK_TOKEN` in the daemon env, `readGrokToken()` returned `null`, the billing request never ran, and Usage showed Grok as unavailable.

Env order was already correct and is **unchanged**:

1. `GROK_API_KEY`
2. `GROK_TOKEN`
3. file token from `~/.grok/auth.json`

### Drift 2 — billing response (`fetchUsage`)

**Old code:**

```ts
const monthlyLimit = resp.config?.monthlyLimit?.val ?? null;
const creditUsage = resp.usage?.creditUsage ?? null;
```

**Live `GET /v1/billing` body** (Bearer = nested `key`; headers already correct: `Authorization` + `X-XAI-Token-Auth: xai-grok-cli`):

```json
{
  "config": {
    "monthlyLimit": { "val": 150000 },
    "used": { "val": 37886 },
    "onDemandCap": { "val": 0 },
    "billingPeriodStart": "2026-07-01T00:00:00+00:00",
    "billingPeriodEnd": "2026-08-01T00:00:00+00:00",
    "history": [ ... ]
  }
}
```

There is **no** top-level `usage` / `creditUsage`. Used credits are `config.used.val`.

Even if auth were fixed first, `creditUsage` stayed `null` → used/remaining stayed null (limit alone could partially parse, but the card was still wrong / empty in practice for normal logins).

The unit test previously mocked the **obsolete** shape (`usage: { creditUsage: 0 }`), so CI did not catch the live response.

---

## What this PR changes

**Scope: daemon `GrokQuotaProvider` only** — no wire/protocol schema change, no Settings UI change (UI already renders balances when the daemon returns them).

### Files

| File | Role |
|------|------|
| `packages/server/src/services/quota-fetcher/providers/grok.ts` | primary fix |
| `packages/server/src/services/quota-fetcher/service.test.ts` | coverage for live + legacy shapes |
| `packages/server/src/services/quota-fetcher/manifest.ts` | **not** changed (already registered) |

### 1) Token resolution

Added `extractGrokTokenFromAuth()` used by `readGrokToken()`:

1. env (already outer in `fetchUsage`)
2. top-level `access_token` if non-empty (legacy)
3. nested object with non-empty string `key`, **preferring** keys that start with `https://auth.x.ai::` when multiple exist

Tokens are never logged.

### 2) Billing parse + schema

- Zod schema accepts `config.used.val`
- used = `config.used.val ?? usage.creditUsage` (live first, legacy fallback)
- limit = `config.monthlyLimit.val` (unchanged)
- remaining = `max(0, limit - used)` when both numbers are present
- balance id still `monthly_credits` / label `Monthly credits`

Billing period fields are **not** surfaced in `details` (kept the PR minimal).

---

## What this PR deliberately does **not** touch

| Item | Why |
|------|-----|
| #1390 ACP `handleUsageUpdate` / composer meter | different path; all ACP providers |
| #2182 Grok background-task reminders | unrelated UI |
| #2302 / #2303 Claude Fable / `limits[]` | leave alone |
| App Settings / Usage UI components | already render daemon balances |
| Protocol / wire schemas | no change needed |
| Other quota providers | unchanged |

---

## How it was verified

### Done (automated)

```bash
npx vitest run packages/server/src/services/quota-fetcher/service.test.ts --bail=1
# 27 passed
```

New / updated coverage:

1. **Live billing shape** — `config: { monthlyLimit: { val }, used: { val } }` → correct used / remaining / limit, `status: "available"`, balance `monthly_credits`
2. **Nested auth file** — write `~/.grok/auth.json` under test `HOME` with `https://auth.x.ai::… .key`, **no** env token → request uses `Authorization: Bearer <nested key>` and returns balances
3. **Zero values** preserved on live shape (`used: 0`, `limit: 0`)
4. **Legacy fallback** — `usage.creditUsage` still works when `config.used` is absent
5. **Env path** — `GROK_API_KEY` still works

Also: `oxlint` + format on touched files, and full monorepo `typecheck` (after building protocol/client/highlight dist for the worktree).

Test harness note: suite already sets `process.env.HOME = tempDir`; `os.homedir()` respects `HOME` on this platform, so nested auth is exercised by writing `join(homeDir, ".grok", "auth.json")` without injecting a homeDir option into `GrokQuotaProvider`.

### Not done (manual / live)

- Did **not** call the real billing API from this PR branch against a live host
- Did **not** restart a daemon or click Settings → Usage in the app
- Live shape knowledge comes from the issue investigation on a host with real Grok CLI auth (2026-07-23); this PR encodes that shape in unit tests

Optional smoke for reviewers (do not print secrets):

```bash
# auth shape only
python3 -c "import json;from pathlib import Path;d=json.loads((Path.home()/'.grok'/'auth.json').read_text());print(list(d)[0], list(d[list(d)[0]].keys()))"
# then GET /v1/billing with Bearer <key> and X-XAI-Token-Auth: xai-grok-cli
# restart *dev* daemon if needed; open Settings → Usage
```

---

## Acceptance criteria

- [x] Nested-only `~/.grok/auth.json` (no env token) can yield a token in code
- [x] Billing with only `config.used.val` + `config.monthlyLimit.val` yields `status: "available"` and correct `monthly_credits` used/remaining/limit
- [x] Legacy env token + legacy `usage.creditUsage` still work
- [x] No unrelated file churn
- [x] PR references #2352
- [ ] Live Settings → Usage confirmation on a Grok-CLI-only host (reviewer / follow-up)

Closes #2352
