### PR TITLE
Stop archived workspaces from running background Git checks

### DIFF
--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -178,6 +178,7 @@ import type {
 } from "./agent/provider-launch-config.js";
 import type { PersistedConfig } from "./persisted-config.js";
 import { createServiceProxySubsystem, type ServiceProxySubsystem } from "./service-proxy.js";
+import { releaseWorkspaceServicePortPlan } from "./workspace-service-port-registry.js";
 import { ScriptHealthMonitor } from "./script-health-monitor.js";
 import { createScriptStatusEmitter } from "./script-status-projection.js";
 import { WorkspaceScriptRuntimeStore } from "./workspace-script-runtime-store.js";
@@ -867,18 +868,13 @@ export async function createPaseoDaemon(
     workspaceGitService,
   });
   const archiveWorkspaceRecordExternal = async (workspaceId: string) => {
-    const sessions = wsServer?.listTrustedSessions() ?? [];
-    if (sessions.length > 0) {
-      await Promise.all(
-        sessions.map((session) => session.archiveWorkspaceRecordForExternalMutation(workspaceId)),
-      );
-      return;
-    }
-
-    await archivePersistedWorkspaceRecord({
+    const existingWorkspace = await archivePersistedWorkspaceRecord({
       workspaceId,
       workspaceRegistry,
     });
+    if (!existingWorkspace || existingWorkspace.archivedAt) return;
+    scriptRuntimeStore.removeForWorkspace(workspaceId);
+    releaseWorkspaceServicePortPlan(workspaceId);
   };
   // external path→workspace adapter, not ownership: archive-by-path requests that
   // arrive with a worktree path and no workspaceId (old clients / CLI).

--- a/packages/server/src/server/paseo-worktree-service.ts
+++ b/packages/server/src/server/paseo-worktree-service.ts
@@ -91,6 +91,7 @@ export async function createPaseoWorktree(
       branch: createdWorktree.worktree.branchName || null,
       baseBranch: resolveIntentBaseBranch(createdWorktree.intent),
       title: input.title?.trim() || resolveFirstAgentPromptTitle(input.firstAgentContext),
+      expectsInitialAgent: Boolean(input.firstAgentContext),
     });
 
     deps.github.invalidate({ cwd: createdWorktree.worktree.worktreePath });

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -128,6 +128,7 @@ import {
   resolveWorkspaceName,
   type PersistedProjectRecord,
   type PersistedWorkspaceRecord,
+  type ProjectMutation,
   type ProjectRegistry,
   type WorkspaceMutation,
   type WorkspaceRegistry,
@@ -365,6 +366,7 @@ interface WorkspaceUpdatesSubscriptionState {
   isBootstrapping: boolean;
   pendingUpdatesByWorkspaceId: Map<string, WorkspaceUpdatePayload>;
   lastEmittedByWorkspaceId: Map<string, WorkspaceUpdatePayload>;
+  visibleEmptyProjectIds?: Set<string>;
 }
 
 class SessionRequestError extends Error {
@@ -586,8 +588,9 @@ export class Session {
   private readonly daemonConfigStore: DaemonConfigStore;
   private readonly pushTokenStore: PushTokenStore;
   private unsubscribeAgentEvents: (() => void) | null = null;
+  private unsubscribeProjectMutations: (() => void) | null = null;
   private unsubscribeWorkspaceMutations: (() => void) | null = null;
-  private workspaceMutationQueue: Promise<void> = Promise.resolve();
+  private registryMutationQueue: Promise<void> = Promise.resolve();
   private isCleanedUp = false;
   private viewedTimelineAgentIds = new Set<string>();
   private readonly viewedTimelineAgentIdsBySource = new Map<object, Set<string>>();
@@ -985,7 +988,7 @@ export class Session {
     });
 
     this.subscribeToAgentEvents();
-    this.subscribeToWorkspaceMutations();
+    this.subscribeToRegistryMutations();
 
     this.sessionLogger.trace({}, "agent.session.lifecycle.created");
   }
@@ -1349,17 +1352,22 @@ export class Session {
     this.providerCatalogSession.start();
   }
 
-  private subscribeToWorkspaceMutations(): void {
+  private subscribeToRegistryMutations(): void {
+    this.unsubscribeProjectMutations?.();
+    this.unsubscribeProjectMutations =
+      this.projectRegistry.subscribeToMutations?.((mutation) =>
+        this.enqueueRegistryMutation(() => this.handleProjectMutation(mutation)),
+      ) ?? null;
     this.unsubscribeWorkspaceMutations?.();
     this.unsubscribeWorkspaceMutations =
       this.workspaceRegistry.subscribeToMutations?.((mutation) =>
-        this.enqueueWorkspaceMutation(mutation),
+        this.enqueueRegistryMutation(() => this.handleWorkspaceMutation(mutation)),
       ) ?? null;
   }
 
-  private enqueueWorkspaceMutation(mutation: WorkspaceMutation): Promise<void> {
-    const next = this.workspaceMutationQueue.then(() => this.handleWorkspaceMutation(mutation));
-    this.workspaceMutationQueue = next.catch(() => {});
+  private enqueueRegistryMutation(handleMutation: () => Promise<void>): Promise<void> {
+    const next = this.registryMutationQueue.then(handleMutation);
+    this.registryMutationQueue = next.catch(() => {});
     return next;
   }
 
@@ -1374,17 +1382,8 @@ export class Session {
         mutation.workspace?.archivedAt
       ) {
         this.workspaceGitObserver.removeForWorkspaceId(mutation.workspaceId);
-      } else if (mutation.workspace && this.workspaceUpdatesSubscription) {
-        const currentWorkspace = await this.workspaceRegistry.get(mutation.workspaceId);
-        if (!currentWorkspace || currentWorkspace.archivedAt) {
-          this.workspaceGitObserver.removeForWorkspaceId(mutation.workspaceId);
-        } else {
-          await this.workspaceGitObserver.syncObserverForWorkspace(currentWorkspace);
-          if (this.isCleanedUp) {
-            this.workspaceGitObserver.removeForWorkspaceId(mutation.workspaceId);
-            return;
-          }
-        }
+      } else {
+        await this.syncWorkspaceMutationObserver(mutation);
       }
       if (this.isCleanedUp) {
         return;
@@ -1396,6 +1395,89 @@ export class Session {
       this.sessionLogger.warn(
         { err: error, workspaceId: mutation.workspaceId, mutationKind: mutation.kind },
         "Failed to apply workspace mutation to session",
+      );
+    }
+  }
+
+  private async syncWorkspaceMutationObserver(mutation: WorkspaceMutation): Promise<void> {
+    const subscription = this.workspaceUpdatesSubscription;
+    if (!mutation.workspace || !subscription) {
+      return;
+    }
+    const descriptorsByWorkspaceId = await this.buildWorkspaceDescriptorMap({
+      workspaceIds: [mutation.workspaceId],
+      includeGitData: false,
+    });
+    const descriptor = descriptorsByWorkspaceId.get(mutation.workspaceId);
+    if (
+      !descriptor ||
+      !this.matchesWorkspaceFilter({ workspace: descriptor, filter: subscription.filter })
+    ) {
+      this.workspaceGitObserver.removeForWorkspaceId(mutation.workspaceId);
+      return;
+    }
+    const currentWorkspace = await this.workspaceRegistry.get(mutation.workspaceId);
+    if (!currentWorkspace || currentWorkspace.archivedAt) {
+      this.workspaceGitObserver.removeForWorkspaceId(mutation.workspaceId);
+      return;
+    }
+    await this.workspaceGitObserver.syncObserverForWorkspace(currentWorkspace);
+    if (this.isCleanedUp) {
+      this.workspaceGitObserver.removeForWorkspaceId(mutation.workspaceId);
+    }
+  }
+
+  private async handleProjectMutation(mutation: ProjectMutation): Promise<void> {
+    try {
+      const subscription = this.workspaceUpdatesSubscription;
+      if (this.isCleanedUp || !subscription) {
+        return;
+      }
+      const projectWorkspaceIds = (await this.workspaceRegistry.list())
+        .filter((workspace) => workspace.projectId === mutation.projectId)
+        .map((workspace) => workspace.workspaceId);
+
+      if (mutation.kind === "remove") {
+        const visibleWorkspaceIds = projectWorkspaceIds.filter((workspaceId) => {
+          const lastEmitted = subscription.lastEmittedByWorkspaceId.get(workspaceId);
+          return (
+            lastEmitted?.kind === "upsert" ||
+            (lastEmitted?.kind === "remove" &&
+              lastEmitted.emptyProject?.projectId === mutation.projectId)
+          );
+        });
+        let updateIds = visibleWorkspaceIds;
+        if (
+          updateIds.length === 0 &&
+          subscription.visibleEmptyProjectIds?.has(mutation.projectId)
+        ) {
+          updateIds = [mutation.projectId];
+        }
+        if (updateIds.length === 0) {
+          return;
+        }
+        for (const workspaceId of projectWorkspaceIds) {
+          this.workspaceGitObserver.removeForWorkspaceId(workspaceId);
+        }
+        await this.emitWorkspaceUpdatesForWorkspaceIds(updateIds, {
+          skipReconcile: true,
+          removedProjectId: mutation.projectId,
+        });
+        return;
+      }
+
+      if (mutation.kind === "archive" || mutation.project?.archivedAt) {
+        for (const workspaceId of projectWorkspaceIds) {
+          this.workspaceGitObserver.removeForWorkspaceId(workspaceId);
+        }
+      }
+      await this.emitWorkspaceUpdatesForWorkspaceIds(projectWorkspaceIds, {
+        skipReconcile: true,
+      });
+    } catch (error) {
+      this.sessionLogger.warn(
+        { err: error, projectId: mutation.projectId, mutationKind: mutation.kind },
+        "Failed to apply project mutation to session",
       );
     }
   }
@@ -4274,6 +4356,16 @@ export class Session {
     subscription: WorkspaceUpdatesSubscriptionState,
     payload: WorkspaceUpdatePayload,
   ): void {
+    if (payload.kind === "upsert") {
+      subscription.visibleEmptyProjectIds?.delete(payload.workspace.projectId);
+    } else {
+      if (payload.emptyProject) {
+        subscription.visibleEmptyProjectIds?.add(payload.emptyProject.projectId);
+      }
+      if (payload.removedProjectId) {
+        subscription.visibleEmptyProjectIds?.delete(payload.removedProjectId);
+      }
+    }
     if (subscription.isBootstrapping) {
       const workspaceId = payload.kind === "upsert" ? payload.workspace.id : payload.id;
       subscription.pendingUpdatesByWorkspaceId.set(workspaceId, payload);
@@ -4553,7 +4645,7 @@ export class Session {
       this.workspaceGitObserver.recordDescriptorState(workspaceId, nextWorkspace);
 
       if (!nextWorkspace) {
-        if (this.shouldSkipWorkspaceRemoval(workspace, lastEmitted, options?.removedProjectId)) {
+        if (this.shouldSkipWorkspaceRemoval(lastEmitted, options?.removedProjectId)) {
           continue;
         }
         subscription.lastEmittedByWorkspaceId.delete(workspaceId);
@@ -4586,14 +4678,13 @@ export class Session {
   }
 
   private shouldSkipWorkspaceRemoval(
-    workspace: WorkspaceDescriptorPayload | undefined,
     lastEmitted: WorkspaceUpdatePayload | undefined,
     removedProjectId: string | undefined,
   ): boolean {
     if (lastEmitted?.kind === "remove") {
-      return !removedProjectId;
+      return !removedProjectId || lastEmitted.removedProjectId === removedProjectId;
     }
-    return Boolean(workspace && !lastEmitted);
+    return !lastEmitted && !removedProjectId;
   }
 
   private async buildWorkspaceRemoveUpdatePayload(
@@ -4807,6 +4898,7 @@ export class Session {
           isBootstrapping: true,
           pendingUpdatesByWorkspaceId: new Map(),
           lastEmittedByWorkspaceId: new Map(),
+          visibleEmptyProjectIds: new Set(),
         };
       }
 
@@ -4822,7 +4914,12 @@ export class Session {
         "fetch_workspaces_response_ready",
       );
       const snapshot = this.buildBootstrapSnapshot(payload.entries);
-      this.seedWorkspaceSubscriptionSnapshot(subscriptionId, request.filter, payload.entries);
+      this.seedWorkspaceSubscriptionSnapshot(
+        subscriptionId,
+        request.filter,
+        payload.entries,
+        payload.emptyProjects,
+      );
 
       this.emit({
         type: "fetch_workspaces_response",
@@ -4887,6 +4984,7 @@ export class Session {
     subscriptionId: string | null,
     filter: FetchWorkspacesRequestFilter | undefined,
     entries: FetchWorkspacesResponseEntry[],
+    emptyProjects: WorkspaceProjectDescriptorPayload[],
   ): void {
     const subscription = this.workspaceUpdatesSubscription;
     if (!subscription) return;
@@ -4897,6 +4995,9 @@ export class Session {
         kind: "upsert",
         workspace: entry,
       });
+    }
+    for (const project of emptyProjects) {
+      subscription.visibleEmptyProjectIds?.add(project.projectId);
     }
   }
 
@@ -6379,6 +6480,8 @@ export class Session {
       this.unsubscribeAgentEvents();
       this.unsubscribeAgentEvents = null;
     }
+    this.unsubscribeProjectMutations?.();
+    this.unsubscribeProjectMutations = null;
     this.unsubscribeWorkspaceMutations?.();
     this.unsubscribeWorkspaceMutations = null;
     this.agentUpdates.dispose();

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -588,6 +588,7 @@ export class Session {
   private unsubscribeAgentEvents: (() => void) | null = null;
   private unsubscribeWorkspaceMutations: (() => void) | null = null;
   private workspaceMutationQueue: Promise<void> = Promise.resolve();
+  private isCleanedUp = false;
   private viewedTimelineAgentIds = new Set<string>();
   private readonly viewedTimelineAgentIdsBySource = new Map<object, Set<string>>();
   private readonly clientCapabilitiesBySource = new Map<object, ReadonlySet<ClientCapability>>();
@@ -1364,6 +1365,9 @@ export class Session {
 
   private async handleWorkspaceMutation(mutation: WorkspaceMutation): Promise<void> {
     try {
+      if (this.isCleanedUp) {
+        return;
+      }
       if (
         mutation.kind === "archive" ||
         mutation.kind === "remove" ||
@@ -1371,7 +1375,19 @@ export class Session {
       ) {
         this.workspaceGitObserver.removeForWorkspaceId(mutation.workspaceId);
       } else if (mutation.workspace && this.workspaceUpdatesSubscription) {
-        await this.workspaceGitObserver.syncObserverForWorkspace(mutation.workspace);
+        const currentWorkspace = await this.workspaceRegistry.get(mutation.workspaceId);
+        if (!currentWorkspace || currentWorkspace.archivedAt) {
+          this.workspaceGitObserver.removeForWorkspaceId(mutation.workspaceId);
+        } else {
+          await this.workspaceGitObserver.syncObserverForWorkspace(currentWorkspace);
+          if (this.isCleanedUp) {
+            this.workspaceGitObserver.removeForWorkspaceId(mutation.workspaceId);
+            return;
+          }
+        }
+      }
+      if (this.isCleanedUp) {
+        return;
       }
       await this.emitWorkspaceUpdatesForWorkspaceIds([mutation.workspaceId], {
         skipReconcile: true,
@@ -4537,7 +4553,7 @@ export class Session {
       this.workspaceGitObserver.recordDescriptorState(workspaceId, nextWorkspace);
 
       if (!nextWorkspace) {
-        if (lastEmitted?.kind === "remove" || (workspace && !lastEmitted)) {
+        if (this.shouldSkipWorkspaceRemoval(workspace, lastEmitted, options?.removedProjectId)) {
           continue;
         }
         subscription.lastEmittedByWorkspaceId.delete(workspaceId);
@@ -4567,6 +4583,17 @@ export class Session {
     if (!options?.skipReconcile) {
       void this.reconcileAndEmitWorkspaceUpdates();
     }
+  }
+
+  private shouldSkipWorkspaceRemoval(
+    workspace: WorkspaceDescriptorPayload | undefined,
+    lastEmitted: WorkspaceUpdatePayload | undefined,
+    removedProjectId: string | undefined,
+  ): boolean {
+    if (lastEmitted?.kind === "remove") {
+      return !removedProjectId;
+    }
+    return Boolean(workspace && !lastEmitted);
   }
 
   private async buildWorkspaceRemoveUpdatePayload(
@@ -6346,6 +6373,7 @@ export class Session {
    */
   public async cleanup(): Promise<void> {
     this.sessionLogger.trace({}, "agent.session.lifecycle.cleanup");
+    this.isCleanedUp = true;
 
     if (this.unsubscribeAgentEvents) {
       this.unsubscribeAgentEvents();

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1135,14 +1135,26 @@ export class Session {
     await this.emitWorkspaceUpdatesForWorkspaceIds([workspaceId], { skipReconcile: true });
   }
 
-  private async emitCreatedWorkspaceUpdate(workspace: WorkspaceDescriptorPayload): Promise<void> {
+  private async emitCreatedWorkspaceUpdate(
+    workspace: WorkspaceDescriptorPayload,
+    optimisticStatus?: WorkspaceDescriptorPayload["status"],
+  ): Promise<void> {
     if (this.workspaceUpdatesSubscription) {
-      await this.emitWorkspaceUpdateForWorkspaceId(workspace.id);
+      await this.emitWorkspaceUpdatesForWorkspaceIds([workspace.id], {
+        skipReconcile: true,
+        ...(optimisticStatus ? { optimisticStatus } : {}),
+      });
       return;
     }
     // COMPAT(workspaceCreateCausalUpdate): added in v0.1.106, remove after 2027-01-12.
     // Older clients create before subscribing and require the causal update beside the response.
-    this.emit({ type: "workspace_update", payload: { kind: "upsert", workspace } });
+    this.emit({
+      type: "workspace_update",
+      payload: {
+        kind: "upsert",
+        workspace: optimisticStatus ? { ...workspace, status: optimisticStatus } : workspace,
+      },
+    });
   }
 
   markWorkspaceArchivingForExternalMutation(
@@ -1390,6 +1402,7 @@ export class Session {
       }
       await this.emitWorkspaceUpdatesForWorkspaceIds([mutation.workspaceId], {
         skipReconcile: true,
+        ...(mutation.expectsInitialAgent ? { optimisticStatus: "running" } : {}),
       });
     } catch (error) {
       this.sessionLogger.warn(
@@ -4612,7 +4625,12 @@ export class Session {
 
   private async emitWorkspaceUpdatesForWorkspaceIds(
     workspaceIds: Iterable<string>,
-    options?: { skipReconcile?: boolean; dedupeGitState?: boolean; removedProjectId?: string },
+    options?: {
+      skipReconcile?: boolean;
+      dedupeGitState?: boolean;
+      removedProjectId?: string;
+      optimisticStatus?: WorkspaceDescriptorPayload["status"];
+    },
   ): Promise<void> {
     const subscription = this.workspaceUpdatesSubscription;
     if (!subscription) {
@@ -4631,10 +4649,14 @@ export class Session {
 
     for (const workspaceId of uniqueWorkspaceIds) {
       const workspace = descriptorsByWorkspaceId.get(workspaceId);
-      const nextWorkspace =
+      const filteredWorkspace =
         workspace && this.matchesWorkspaceFilter({ workspace, filter: subscription.filter })
           ? workspace
           : null;
+      const nextWorkspace = this.applyOptimisticWorkspaceStatus(
+        filteredWorkspace,
+        options?.optimisticStatus,
+      );
       const lastEmitted = subscription.lastEmittedByWorkspaceId.get(workspaceId);
       if (
         options?.dedupeGitState &&
@@ -4675,6 +4697,16 @@ export class Session {
     if (!options?.skipReconcile) {
       void this.reconcileAndEmitWorkspaceUpdates();
     }
+  }
+
+  private applyOptimisticWorkspaceStatus(
+    workspace: WorkspaceDescriptorPayload | null,
+    optimisticStatus: WorkspaceDescriptorPayload["status"] | undefined,
+  ): WorkspaceDescriptorPayload | null {
+    if (!workspace || !optimisticStatus) {
+      return workspace;
+    }
+    return { ...workspace, status: optimisticStatus };
   }
 
   private shouldSkipWorkspaceRemoval(
@@ -5074,6 +5106,7 @@ export class Session {
       cwd,
       explicitTitle ?? promptTitle,
       request.source.projectId,
+      { expectsInitialAgent: Boolean(request.firstAgentContext) },
     );
     await this.syncWorkspaceGitObserverForWorkspace(workspace);
     const descriptor = await this.describeWorkspaceRecord(workspace);
@@ -5086,7 +5119,10 @@ export class Session {
         error: null,
       },
     });
-    await this.emitCreatedWorkspaceUpdate(descriptor);
+    await this.emitCreatedWorkspaceUpdate(
+      descriptor,
+      request.firstAgentContext ? "running" : undefined,
+    );
     void this.workspaceGitService
       .getSnapshot(workspace.cwd, { force: true, includeForge: true, reason: "open_project" })
       .catch((error) => {
@@ -5161,7 +5197,10 @@ export class Session {
         error: null,
       },
     });
-    await this.emitCreatedWorkspaceUpdate(descriptor);
+    await this.emitCreatedWorkspaceUpdate(
+      descriptor,
+      request.firstAgentContext ? "running" : undefined,
+    );
   }
 
   private async handleOpenProjectRequest(

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -587,6 +587,7 @@ export class Session {
   private readonly pushTokenStore: PushTokenStore;
   private unsubscribeAgentEvents: (() => void) | null = null;
   private unsubscribeWorkspaceMutations: (() => void) | null = null;
+  private workspaceMutationQueue: Promise<void> = Promise.resolve();
   private viewedTimelineAgentIds = new Set<string>();
   private readonly viewedTimelineAgentIdsBySource = new Map<object, Set<string>>();
   private readonly clientCapabilitiesBySource = new Map<object, ReadonlySet<ClientCapability>>();
@@ -1351,8 +1352,14 @@ export class Session {
     this.unsubscribeWorkspaceMutations?.();
     this.unsubscribeWorkspaceMutations =
       this.workspaceRegistry.subscribeToMutations?.((mutation) =>
-        this.handleWorkspaceMutation(mutation),
+        this.enqueueWorkspaceMutation(mutation),
       ) ?? null;
+  }
+
+  private enqueueWorkspaceMutation(mutation: WorkspaceMutation): Promise<void> {
+    const next = this.workspaceMutationQueue.then(() => this.handleWorkspaceMutation(mutation));
+    this.workspaceMutationQueue = next.catch(() => {});
+    return next;
   }
 
   private async handleWorkspaceMutation(mutation: WorkspaceMutation): Promise<void> {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -129,6 +129,7 @@ import {
   type PersistedProjectRecord,
   type PersistedWorkspaceRecord,
   type ProjectRegistry,
+  type WorkspaceMutation,
   type WorkspaceRegistry,
 } from "./workspace-registry.js";
 import { wrapSpokenInput } from "./voice-config.js";
@@ -585,6 +586,7 @@ export class Session {
   private readonly daemonConfigStore: DaemonConfigStore;
   private readonly pushTokenStore: PushTokenStore;
   private unsubscribeAgentEvents: (() => void) | null = null;
+  private unsubscribeWorkspaceMutations: (() => void) | null = null;
   private viewedTimelineAgentIds = new Set<string>();
   private readonly viewedTimelineAgentIdsBySource = new Map<object, Set<string>>();
   private readonly clientCapabilitiesBySource = new Map<object, ReadonlySet<ClientCapability>>();
@@ -981,6 +983,7 @@ export class Session {
     });
 
     this.subscribeToAgentEvents();
+    this.subscribeToWorkspaceMutations();
 
     this.sessionLogger.trace({}, "agent.session.lifecycle.created");
   }
@@ -1135,10 +1138,6 @@ export class Session {
     // COMPAT(workspaceCreateCausalUpdate): added in v0.1.106, remove after 2027-01-12.
     // Older clients create before subscribing and require the causal update beside the response.
     this.emit({ type: "workspace_update", payload: { kind: "upsert", workspace } });
-  }
-
-  async archiveWorkspaceRecordForExternalMutation(workspaceId: string): Promise<void> {
-    await this.archiveWorkspaceRecord(workspaceId);
   }
 
   markWorkspaceArchivingForExternalMutation(
@@ -1346,6 +1345,36 @@ export class Session {
         });
     }
     this.providerCatalogSession.start();
+  }
+
+  private subscribeToWorkspaceMutations(): void {
+    this.unsubscribeWorkspaceMutations?.();
+    this.unsubscribeWorkspaceMutations =
+      this.workspaceRegistry.subscribeToMutations?.((mutation) =>
+        this.handleWorkspaceMutation(mutation),
+      ) ?? null;
+  }
+
+  private async handleWorkspaceMutation(mutation: WorkspaceMutation): Promise<void> {
+    try {
+      if (
+        mutation.kind === "archive" ||
+        mutation.kind === "remove" ||
+        mutation.workspace?.archivedAt
+      ) {
+        this.workspaceGitObserver.removeForWorkspaceId(mutation.workspaceId);
+      } else if (mutation.workspace && this.workspaceUpdatesSubscription) {
+        await this.workspaceGitObserver.syncObserverForWorkspace(mutation.workspace);
+      }
+      await this.emitWorkspaceUpdatesForWorkspaceIds([mutation.workspaceId], {
+        skipReconcile: true,
+      });
+    } catch (error) {
+      this.sessionLogger.warn(
+        { err: error, workspaceId: mutation.workspaceId, mutationKind: mutation.kind },
+        "Failed to apply workspace mutation to session",
+      );
+    }
   }
 
   private subscribeToAgentEvents(): void {
@@ -4491,6 +4520,7 @@ export class Session {
         workspace && this.matchesWorkspaceFilter({ workspace, filter: subscription.filter })
           ? workspace
           : null;
+      const lastEmitted = subscription.lastEmittedByWorkspaceId.get(workspaceId);
       if (
         options?.dedupeGitState &&
         this.workspaceGitObserver.shouldSkipUpdate(workspaceId, nextWorkspace)
@@ -4500,7 +4530,7 @@ export class Session {
       this.workspaceGitObserver.recordDescriptorState(workspaceId, nextWorkspace);
 
       if (!nextWorkspace) {
-        if (workspace && !subscription.lastEmittedByWorkspaceId.has(workspaceId)) {
+        if (lastEmitted?.kind === "remove" || (workspace && !lastEmitted)) {
           continue;
         }
         subscription.lastEmittedByWorkspaceId.delete(workspaceId);
@@ -4516,7 +4546,6 @@ export class Session {
         workspace: nextWorkspace,
       };
 
-      const lastEmitted = subscription.lastEmittedByWorkspaceId.get(workspaceId);
       if (
         lastEmitted &&
         lastEmitted.kind === "upsert" &&
@@ -6315,6 +6344,8 @@ export class Session {
       this.unsubscribeAgentEvents();
       this.unsubscribeAgentEvents = null;
     }
+    this.unsubscribeWorkspaceMutations?.();
+    this.unsubscribeWorkspaceMutations = null;
     this.agentUpdates.dispose();
     await this.hubExecutionController?.cleanup();
     if (this.unsubscribeTerminalWorkspaceContributionEvents) {

--- a/packages/server/src/server/session.workspace-git-watch.test.ts
+++ b/packages/server/src/server/session.workspace-git-watch.test.ts
@@ -198,6 +198,7 @@ function createSessionForWorkspaceGitWatchTests(options?: {
       get: async () => null,
     }),
     projectRegistry: createStub<SessionOptions["projectRegistry"]>({
+      subscribeToMutations: () => () => {},
       initialize: async () => {},
       existsOnDisk: async () => true,
       list: async () => Array.from(projects.values()),
@@ -215,6 +216,7 @@ function createSessionForWorkspaceGitWatchTests(options?: {
       },
     }),
     workspaceRegistry: createStub<SessionOptions["workspaceRegistry"]>({
+      subscribeToMutations: () => () => {},
       initialize: async () => {},
       existsOnDisk: async () => true,
       list: async () => Array.from(workspaces.values()),

--- a/packages/server/src/server/session.workspace-resolution-invariants.test.ts
+++ b/packages/server/src/server/session.workspace-resolution-invariants.test.ts
@@ -109,6 +109,7 @@ function createHarness(input: {
       get: async () => null,
     }),
     projectRegistry: createStub<SessionOptions["projectRegistry"]>({
+      subscribeToMutations: () => () => {},
       initialize: async () => {},
       existsOnDisk: async () => true,
       list: async () => Array.from(projects.values()),
@@ -141,6 +142,7 @@ function createHarness(input: {
       },
     }),
     workspaceRegistry: createStub<SessionOptions["workspaceRegistry"]>({
+      subscribeToMutations: () => () => {},
       initialize: async () => {},
       existsOnDisk: async () => true,
       list: async () => Array.from(workspaces.values()),

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -3579,7 +3579,9 @@ test("project.remove.request removes an already-empty project", async () => {
     filter: undefined,
     isBootstrapping: false,
     pendingUpdatesByWorkspaceId: new Map(),
-    lastEmittedByWorkspaceId: new Map(),
+    lastEmittedByWorkspaceId: new Map([
+      [archivedWorkspace.workspaceId, { kind: "remove", id: archivedWorkspace.workspaceId }],
+    ]),
   };
   session.reconcileActiveWorkspaceRecords = async () => new Set();
   session.listAgentPayloads = async () => [];
@@ -7044,6 +7046,138 @@ test("workspace mutation handling does not let a delayed upsert recreate an arch
   resumeDescribe();
   await upsertPromise;
   await archivePromise;
+
+  expect(registerCalls).toEqual([REPO_CWD]);
+  expect(unsubscribeCalls).toEqual([REPO_CWD]);
+});
+
+test("workspace mutation handling drops queued observer sync after session cleanup", async () => {
+  let mutationListener: ((mutation: WorkspaceMutation) => void | Promise<void>) | null = null;
+  const registerCalls: string[] = [];
+  const unsubscribeCalls: string[] = [];
+  const project = createPersistedProjectRecord({
+    projectId: "proj-cleanup-race",
+    rootPath: REPO_CWD,
+    kind: "git",
+    displayName: "repo",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const firstWorkspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-cleanup-first",
+    projectId: project.projectId,
+    cwd: REPO_CWD,
+    kind: "local_checkout",
+    displayName: "main",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const queuedWorkspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-cleanup-queued",
+    projectId: project.projectId,
+    cwd: "/tmp/repo/queued",
+    kind: "local_checkout",
+    displayName: "queued",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const workspaces = new Map([
+    [firstWorkspace.workspaceId, firstWorkspace],
+    [queuedWorkspace.workspaceId, queuedWorkspace],
+  ]);
+  const workspaceRegistry: SessionOptions["workspaceRegistry"] = {
+    initialize: async () => {},
+    existsOnDisk: async () => true,
+    list: async () => [],
+    get: async (workspaceId: string) => workspaces.get(workspaceId) ?? null,
+    update: async () => null,
+    upsert: async () => {},
+    archive: async () => {},
+    remove: async () => {},
+    subscribeToMutations: (listener) => {
+      mutationListener = listener;
+      return () => {
+        mutationListener = null;
+      };
+    },
+  };
+  const session = createSessionForWorkspaceTests({
+    projectRegistry: {
+      initialize: async () => {},
+      existsOnDisk: async () => true,
+      list: async () => [project],
+      get: async (projectId: string) => (projectId === project.projectId ? project : null),
+      getOrCreateActiveByRoot: async () => project,
+      upsert: async () => {},
+      archive: async () => {},
+      remove: async () => {},
+    },
+    workspaceRegistry,
+    workspaceGitService: createNoopWorkspaceGitService({
+      registerWorkspace: ({ cwd }) => {
+        registerCalls.push(path.resolve(cwd));
+        return {
+          unsubscribe: () => {
+            unsubscribeCalls.push(path.resolve(cwd));
+          },
+        };
+      },
+    }),
+  });
+
+  await session.handleMessage({
+    type: "fetch_workspaces_request",
+    requestId: "req-fetch-workspaces-cleanup-subscribe",
+    subscribe: {},
+  });
+
+  session.describeWorkspaceRecordWithGitData = async (workspace) =>
+    ({
+      id: workspace.workspaceId,
+      projectId: workspace.projectId,
+      projectDisplayName: project.displayName,
+      projectRootPath: project.rootPath,
+      workspaceDirectory: workspace.cwd,
+      projectKind: project.kind,
+      workspaceKind: workspace.kind,
+      name: workspace.displayName,
+      status: "done",
+      activityAt: null,
+      diffStat: null,
+    }) as WorkspaceDescriptorPayload;
+
+  let resumeFirstEmit!: () => void;
+  const firstEmitStarted = new Promise<void>((resolveStarted) => {
+    session.emitWorkspaceUpdatesForWorkspaceIds = async () => {
+      resolveStarted();
+      await new Promise<void>((resolveResume) => {
+        resumeFirstEmit = resolveResume;
+      });
+    };
+  });
+
+  const firstMutationPromise = Promise.resolve(
+    mutationListener?.({
+      kind: "upsert",
+      workspaceId: firstWorkspace.workspaceId,
+      workspace: firstWorkspace,
+    }),
+  );
+  expect(firstMutationPromise).toBeDefined();
+  await firstEmitStarted;
+
+  const queuedMutationPromise = Promise.resolve(
+    mutationListener?.({
+      kind: "upsert",
+      workspaceId: queuedWorkspace.workspaceId,
+      workspace: queuedWorkspace,
+    }),
+  );
+
+  await session.cleanup();
+  resumeFirstEmit();
+  await firstMutationPromise;
+  await queuedMutationPromise;
 
   expect(registerCalls).toEqual([REPO_CWD]);
   expect(unsubscribeCalls).toEqual([REPO_CWD]);

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -70,6 +70,7 @@ import {
   createPersistedWorkspaceRecord,
   type PersistedProjectRecord,
   type PersistedWorkspaceRecord,
+  type WorkspaceMutation,
 } from "./workspace-registry.js";
 
 const REPO_CWD = path.resolve("/tmp/repo");
@@ -6925,6 +6926,127 @@ test("subscribed fetch_workspaces includes git enrichment in the initial snapsho
     gitWorkspace,
     gitProject,
   );
+});
+
+test("workspace mutation handling does not let a delayed upsert recreate an archived observer", async () => {
+  let mutationListener: ((mutation: WorkspaceMutation) => void | Promise<void>) | null = null;
+  const registerCalls: string[] = [];
+  const unsubscribeCalls: string[] = [];
+  const project = createPersistedProjectRecord({
+    projectId: "proj-race",
+    rootPath: REPO_CWD,
+    kind: "git",
+    displayName: "repo",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-race",
+    projectId: project.projectId,
+    cwd: REPO_CWD,
+    kind: "local_checkout",
+    displayName: "main",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const descriptor = {
+    id: workspace.workspaceId,
+    projectId: project.projectId,
+    projectDisplayName: project.displayName,
+    projectRootPath: project.rootPath,
+    workspaceDirectory: workspace.cwd,
+    projectKind: project.kind,
+    workspaceKind: workspace.kind,
+    name: workspace.displayName,
+    status: "done",
+    activityAt: null,
+    diffStat: null,
+  } as WorkspaceDescriptorPayload;
+  const workspaceRegistry: SessionOptions["workspaceRegistry"] = {
+    initialize: async () => {},
+    existsOnDisk: async () => true,
+    list: async () => [],
+    get: async (workspaceId: string) => (workspaceId === workspace.workspaceId ? workspace : null),
+    update: async () => null,
+    upsert: async () => {},
+    archive: async () => {},
+    remove: async () => {},
+    subscribeToMutations: (listener) => {
+      mutationListener = listener;
+      return () => {
+        mutationListener = null;
+      };
+    },
+  };
+  const session = createSessionForWorkspaceTests({
+    projectRegistry: {
+      initialize: async () => {},
+      existsOnDisk: async () => true,
+      list: async () => [project],
+      get: async (projectId: string) => (projectId === project.projectId ? project : null),
+      getOrCreateActiveByRoot: async () => project,
+      upsert: async () => {},
+      archive: async () => {},
+      remove: async () => {},
+    },
+    workspaceRegistry,
+    workspaceGitService: createNoopWorkspaceGitService({
+      registerWorkspace: ({ cwd }) => {
+        registerCalls.push(path.resolve(cwd));
+        return {
+          unsubscribe: () => {
+            unsubscribeCalls.push(path.resolve(cwd));
+          },
+        };
+      },
+    }),
+  });
+  session.emitWorkspaceUpdatesForWorkspaceIds = async () => {};
+
+  await session.handleMessage({
+    type: "fetch_workspaces_request",
+    requestId: "req-fetch-workspaces-subscribe",
+    subscribe: {},
+  });
+
+  let resumeDescribe!: () => void;
+  const describeStarted = new Promise<void>((resolveStarted) => {
+    session.describeWorkspaceRecordWithGitData = async () => {
+      resolveStarted();
+      await new Promise<void>((resolveResume) => {
+        resumeDescribe = resolveResume;
+      });
+      return descriptor;
+    };
+  });
+
+  const upsertMutation = mutationListener?.({
+    kind: "upsert",
+    workspaceId: workspace.workspaceId,
+    workspace,
+  });
+  expect(upsertMutation).toBeDefined();
+  const upsertPromise = Promise.resolve(upsertMutation);
+  await describeStarted;
+
+  const archivedWorkspace = { ...workspace, archivedAt: "2026-03-02T12:00:00.000Z" };
+  const archivePromise = Promise.resolve(
+    mutationListener?.({
+      kind: "archive",
+      workspaceId: workspace.workspaceId,
+      workspace: archivedWorkspace,
+    }),
+  );
+
+  await Promise.resolve();
+  expect(unsubscribeCalls).toEqual([]);
+
+  resumeDescribe();
+  await upsertPromise;
+  await archivePromise;
+
+  expect(registerCalls).toEqual([REPO_CWD]);
+  expect(unsubscribeCalls).toEqual([REPO_CWD]);
 });
 
 test("a workspace leaving a filtered subscription after bootstrap emits a removal", async () => {

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -3410,7 +3410,27 @@ test("archiving the last workspace emits a remove carrying the now-empty project
     filter: undefined,
     isBootstrapping: false,
     pendingUpdatesByWorkspaceId: new Map(),
-    lastEmittedByWorkspaceId: new Map(),
+    lastEmittedByWorkspaceId: new Map([
+      [
+        archivedWorkspace.workspaceId,
+        {
+          kind: "upsert",
+          workspace: {
+            id: archivedWorkspace.workspaceId,
+            projectId: project.projectId,
+            projectDisplayName: project.displayName,
+            projectRootPath: project.rootPath,
+            workspaceDirectory: archivedWorkspace.cwd,
+            projectKind: project.kind,
+            workspaceKind: archivedWorkspace.kind,
+            name: archivedWorkspace.displayName,
+            status: "done",
+            activityAt: null,
+            diffStat: null,
+          },
+        },
+      ],
+    ]),
   };
   session.reconcileActiveWorkspaceRecords = async () => new Set();
   // The archived workspace no longer resolves to an active descriptor.
@@ -6964,10 +6984,11 @@ test("workspace mutation handling does not let a delayed upsert recreate an arch
     activityAt: null,
     diffStat: null,
   } as WorkspaceDescriptorPayload;
+  let listedWorkspaces: PersistedWorkspaceRecord[] = [];
   const workspaceRegistry: SessionOptions["workspaceRegistry"] = {
     initialize: async () => {},
     existsOnDisk: async () => true,
-    list: async () => [],
+    list: async () => listedWorkspaces,
     get: async (workspaceId: string) => (workspaceId === workspace.workspaceId ? workspace : null),
     update: async () => null,
     upsert: async () => {},
@@ -7010,6 +7031,7 @@ test("workspace mutation handling does not let a delayed upsert recreate an arch
     requestId: "req-fetch-workspaces-subscribe",
     subscribe: {},
   });
+  listedWorkspaces = [workspace];
 
   let resumeDescribe!: () => void;
   const describeStarted = new Promise<void>((resolveStarted) => {
@@ -7051,6 +7073,199 @@ test("workspace mutation handling does not let a delayed upsert recreate an arch
   expect(unsubscribeCalls).toEqual([REPO_CWD]);
 });
 
+test("workspace mutations outside a filtered subscription neither watch nor emit", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  let mutationListener: ((mutation: WorkspaceMutation) => void | Promise<void>) | null = null;
+  const registerCalls: string[] = [];
+  const project = createPersistedProjectRecord({
+    projectId: "proj-filtered-mutation",
+    rootPath: REPO_CWD,
+    kind: "git",
+    displayName: "repo",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-filtered-mutation",
+    projectId: project.projectId,
+    cwd: REPO_CWD,
+    kind: "local_checkout",
+    displayName: "main",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const descriptor = {
+    id: workspace.workspaceId,
+    projectId: project.projectId,
+    projectDisplayName: project.displayName,
+    projectRootPath: project.rootPath,
+    workspaceDirectory: workspace.cwd,
+    projectKind: project.kind,
+    workspaceKind: workspace.kind,
+    name: workspace.displayName,
+    status: "done",
+    activityAt: null,
+    diffStat: null,
+  } as WorkspaceDescriptorPayload;
+  const workspaceRegistry: SessionOptions["workspaceRegistry"] = {
+    initialize: async () => {},
+    existsOnDisk: async () => true,
+    list: async () => [workspace],
+    get: async (workspaceId: string) => (workspaceId === workspace.workspaceId ? workspace : null),
+    update: async () => null,
+    upsert: async () => {},
+    archive: async () => {},
+    remove: async () => {},
+    subscribeToMutations: (listener) => {
+      mutationListener = listener;
+      return () => {
+        mutationListener = null;
+      };
+    },
+  };
+  const session = createSessionForWorkspaceTests({
+    onMessage: (message) => emitted.push(message),
+    projectRegistry: {
+      initialize: async () => {},
+      existsOnDisk: async () => true,
+      list: async () => [project],
+      get: async (projectId: string) => (projectId === project.projectId ? project : null),
+      getOrCreateActiveByRoot: async () => project,
+      upsert: async () => {},
+      archive: async () => {},
+      remove: async () => {},
+    },
+    workspaceRegistry,
+    workspaceGitService: createNoopWorkspaceGitService({
+      registerWorkspace: ({ cwd }) => {
+        registerCalls.push(path.resolve(cwd));
+        return { unsubscribe: () => {} };
+      },
+    }),
+  });
+  session.listFetchWorkspacesEntries = async () => ({
+    entries: [],
+    emptyProjects: [],
+    pageInfo: { nextCursor: null, prevCursor: null, hasMore: false },
+  });
+  session.buildWorkspaceDescriptorMap = async () => new Map([[descriptor.id, descriptor]]);
+
+  await session.handleMessage({
+    type: "fetch_workspaces_request",
+    requestId: "req-filtered-mutation",
+    filter: { projectId: "some-other-project" },
+    subscribe: {},
+  });
+  emitted.length = 0;
+
+  await mutationListener?.({
+    kind: "upsert",
+    workspaceId: workspace.workspaceId,
+    workspace,
+  });
+  session.buildWorkspaceDescriptorMap = async () => new Map();
+  await mutationListener?.({
+    kind: "archive",
+    workspaceId: workspace.workspaceId,
+    workspace: { ...workspace, archivedAt: "2026-03-02T12:00:00.000Z" },
+  });
+
+  expect(registerCalls).toEqual([]);
+  expect(filterByType(emitted, "workspace_update")).toEqual([]);
+});
+
+test("project removal mutation broadcasts the final delta to another subscribed session", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const project = createPersistedProjectRecord({
+    projectId: "proj-global-remove",
+    rootPath: REPO_CWD,
+    kind: "git",
+    displayName: "repo",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-global-remove",
+    projectId: project.projectId,
+    cwd: REPO_CWD,
+    kind: "local_checkout",
+    displayName: "main",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-02T12:00:00.000Z",
+    archivedAt: "2026-03-02T12:00:00.000Z",
+  });
+  let projectMutationListener:
+    | Parameters<NonNullable<SessionOptions["projectRegistry"]["subscribeToMutations"]>>[0]
+    | null = null;
+  const projectRegistry: SessionOptions["projectRegistry"] = {
+    initialize: async () => {},
+    existsOnDisk: async () => true,
+    list: async () => [],
+    get: async () => null,
+    getOrCreateActiveByRoot: async () => project,
+    upsert: async () => {},
+    archive: async () => {},
+    remove: async (projectId) => {
+      await projectMutationListener?.({ kind: "remove", projectId, project: null });
+    },
+    subscribeToMutations: (listener) => {
+      projectMutationListener = listener;
+      return () => {
+        projectMutationListener = null;
+      };
+    },
+  };
+  const session = createSessionForWorkspaceTests({
+    onMessage: (message) => emitted.push(message),
+    projectRegistry,
+    workspaceRegistry: {
+      initialize: async () => {},
+      existsOnDisk: async () => true,
+      list: async () => [workspace],
+      get: async (workspaceId) => (workspaceId === workspace.workspaceId ? workspace : null),
+      update: async () => null,
+      upsert: async () => {},
+      archive: async () => {},
+      remove: async () => {},
+    },
+  });
+  session.workspaceUpdatesSubscription = {
+    subscriptionId: "sub-global-remove",
+    filter: undefined,
+    isBootstrapping: false,
+    pendingUpdatesByWorkspaceId: new Map(),
+    lastEmittedByWorkspaceId: new Map([
+      [
+        workspace.workspaceId,
+        {
+          kind: "remove",
+          id: workspace.workspaceId,
+          emptyProject: {
+            projectId: project.projectId,
+            projectDisplayName: project.displayName,
+            projectCustomName: null,
+            projectRootPath: project.rootPath,
+            projectKind: project.kind,
+          },
+        },
+      ],
+    ]),
+  };
+
+  await projectRegistry.remove(project.projectId);
+
+  expect(filterByType(emitted, "workspace_update")).toEqual([
+    {
+      type: "workspace_update",
+      payload: {
+        kind: "remove",
+        id: workspace.workspaceId,
+        removedProjectId: project.projectId,
+      },
+    },
+  ]);
+});
+
 test("workspace mutation handling drops queued observer sync after session cleanup", async () => {
   let mutationListener: ((mutation: WorkspaceMutation) => void | Promise<void>) | null = null;
   const registerCalls: string[] = [];
@@ -7085,10 +7300,11 @@ test("workspace mutation handling drops queued observer sync after session clean
     [firstWorkspace.workspaceId, firstWorkspace],
     [queuedWorkspace.workspaceId, queuedWorkspace],
   ]);
+  let listedWorkspaces: PersistedWorkspaceRecord[] = [];
   const workspaceRegistry: SessionOptions["workspaceRegistry"] = {
     initialize: async () => {},
     existsOnDisk: async () => true,
-    list: async () => [],
+    list: async () => listedWorkspaces,
     get: async (workspaceId: string) => workspaces.get(workspaceId) ?? null,
     update: async () => null,
     upsert: async () => {},
@@ -7130,6 +7346,7 @@ test("workspace mutation handling drops queued observer sync after session clean
     requestId: "req-fetch-workspaces-cleanup-subscribe",
     subscribe: {},
   });
+  listedWorkspaces = Array.from(workspaces.values());
 
   session.describeWorkspaceRecordWithGitData = async (workspace) =>
     ({

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -8775,6 +8775,7 @@ test("workspace.create.response persists the first prompt as the initial title",
 test("workspace create emits through a matching workspace subscription", async () => {
   const emitted: SessionOutboundMessage[] = [];
   const workspaces = new Map<string, ReturnType<typeof createPersistedWorkspaceRecord>>();
+  let mutationListener: ((mutation: WorkspaceMutation) => void | Promise<void>) | null = null;
   const session = createSessionForWorkspaceTests({
     onMessage: (message) => emitted.push(message),
     workspaceRegistry: {
@@ -8782,11 +8783,23 @@ test("workspace create emits through a matching workspace subscription", async (
       existsOnDisk: async () => true,
       list: async () => Array.from(workspaces.values()),
       get: async (workspaceId) => workspaces.get(workspaceId) ?? null,
-      upsert: async (workspace) => {
+      upsert: async (workspace, context) => {
         workspaces.set(workspace.workspaceId, workspace);
+        await mutationListener?.({
+          kind: "upsert",
+          workspaceId: workspace.workspaceId,
+          workspace,
+          expectsInitialAgent: context?.expectsInitialAgent,
+        });
       },
       archive: async () => {},
       remove: async () => {},
+      subscribeToMutations: (listener) => {
+        mutationListener = listener;
+        return () => {
+          mutationListener = null;
+        };
+      },
     },
   });
   session.listAgentPayloads = async () => [];
@@ -8794,7 +8807,7 @@ test("workspace create emits through a matching workspace subscription", async (
   await session.handleMessage({
     type: "fetch_workspaces_request",
     requestId: "req-subscribe-create-match",
-    filter: { query: "repo" },
+    filter: { query: "Implement" },
     subscribe: { subscriptionId: "sub-create-match" },
   });
   emitted.length = 0;
@@ -8802,9 +8815,14 @@ test("workspace create emits through a matching workspace subscription", async (
     type: "workspace.create.request",
     requestId: "req-create-match",
     source: { kind: "directory", path: REPO_CWD },
+    firstAgentContext: { prompt: "Implement the requested change" },
   });
 
-  expect(filterByType(emitted, "workspace_update")).toHaveLength(1);
+  const statuses = filterByType(emitted, "workspace_update").flatMap((message) =>
+    message.payload.kind === "upsert" ? [message.payload.workspace.status] : [],
+  );
+  expect(statuses).toContain("running");
+  expect(statuses).not.toContain("done");
 });
 
 test("workspace create stays out of a non-matching workspace subscription", async () => {

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
@@ -42,6 +42,7 @@ export interface CreateWorktreeWorkspaceInput {
   branch: string | null;
   baseBranch: string | null;
   title: string | null;
+  expectsInitialAgent?: boolean;
 }
 
 export interface WorkspaceProvisioningService {
@@ -55,6 +56,7 @@ export interface WorkspaceProvisioningService {
     cwd: string,
     title?: string | null,
     projectId?: string,
+    context?: { expectsInitialAgent?: boolean },
   ): Promise<PersistedWorkspaceRecord>;
   createWorkspaceForWorktree(
     input: CreateWorktreeWorkspaceInput,
@@ -175,6 +177,7 @@ export function createWorkspaceProvisioningService(deps: {
     cwd: string,
     title?: string | null,
     projectId?: string,
+    context?: { expectsInitialAgent?: boolean },
   ): Promise<PersistedWorkspaceRecord> {
     const normalizedCwd = resolve(cwd);
     const checkout = await workspaceGitService.getCheckout(normalizedCwd);
@@ -191,7 +194,7 @@ export function createWorkspaceProvisioningService(deps: {
       createdAt: timestamp,
       updatedAt: timestamp,
     });
-    await workspaceRegistry.upsert(workspace);
+    await workspaceRegistry.upsert(workspace, context);
     return workspace;
   }
 
@@ -223,7 +226,9 @@ export function createWorkspaceProvisioningService(deps: {
       createdAt: timestamp,
       updatedAt: timestamp,
     });
-    await workspaceRegistry.upsert(workspace);
+    await workspaceRegistry.upsert(workspace, {
+      expectsInitialAgent: input.expectsInitialAgent,
+    });
     return workspace;
   }
 
@@ -294,7 +299,11 @@ export function createWorkspaceProvisioningService(deps: {
   ): Promise<string> {
     if (input.createdWorktree) return input.createdWorktree.workspace.workspaceId;
     if (input.requestedWorkspaceId) return input.requestedWorkspaceId;
-    return (await createWorkspaceForDirectory(input.cwd, input.initialTitle)).workspaceId;
+    return (
+      await createWorkspaceForDirectory(input.cwd, input.initialTitle, undefined, {
+        expectsInitialAgent: true,
+      })
+    ).workspaceId;
   }
 
   async function ensureWorkspaceRecordUnarchived(

--- a/packages/server/src/server/snapshot-mutation-ownership.test.ts
+++ b/packages/server/src/server/snapshot-mutation-ownership.test.ts
@@ -119,6 +119,7 @@ describe("snapshot mutation ownership boundary", () => {
           upsert: directStorageWrite,
         }),
         projectRegistry: createStub<SessionOptions["projectRegistry"]>({
+          subscribeToMutations: () => () => {},
           initialize: async () => {},
           existsOnDisk: async () => true,
           list: async () => [],
@@ -128,6 +129,7 @@ describe("snapshot mutation ownership boundary", () => {
           remove: async () => {},
         }),
         workspaceRegistry: createStub<SessionOptions["workspaceRegistry"]>({
+          subscribeToMutations: () => () => {},
           initialize: async () => {},
           existsOnDisk: async () => true,
           list: async () => [],

--- a/packages/server/src/server/workspace-archive-record-scoped.e2e.test.ts
+++ b/packages/server/src/server/workspace-archive-record-scoped.e2e.test.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { afterEach, beforeEach, expect, test } from "vitest";
 
 import { getFullAccessConfig } from "./daemon-e2e/agent-configs.js";
-import { createDaemonTestContext, type DaemonTestContext } from "./test-utils/index.js";
+import {
+  createDaemonTestContext,
+  DaemonClient,
+  type DaemonTestContext,
+} from "./test-utils/index.js";
 
 // Model B archive is scoped to a single workspace RECORD (by workspaceId), not
 // to a directory on disk. A directory can back multiple workspaces, so archiving
@@ -85,6 +89,33 @@ async function terminalIdsForWorkspace(cwd: string, workspaceId: string): Promis
   return new Set(listed.terminals.map((terminal) => terminal.id));
 }
 
+function collectWorkspaceRemovals(client: DaemonClient): {
+  workspaceIds: string[];
+  stop: () => void;
+} {
+  const workspaceIds: string[] = [];
+  const stop = client.on("workspace_update", (message) => {
+    if (message.payload.kind === "remove") {
+      workspaceIds.push(message.payload.id);
+    }
+  });
+  return { workspaceIds, stop };
+}
+
+function collectWorkspaceTitles(client: DaemonClient): {
+  workspaces: Array<{ id: string; name: string; title: string | null }>;
+  stop: () => void;
+} {
+  const workspaces: Array<{ id: string; name: string; title: string | null }> = [];
+  const stop = client.on("workspace_update", (message) => {
+    if (message.payload.kind === "upsert") {
+      const { id, name, title } = message.payload.workspace;
+      workspaces.push({ id, name, title });
+    }
+  });
+  return { workspaces, stop };
+}
+
 test("archiving one of two workspaces sharing a cwd spares the sibling and the directory", async () => {
   const cwd = makeTempDir("workspace-archive-shared-cwd-");
 
@@ -160,6 +191,62 @@ test("archiving one of two workspaces sharing a cwd spares the sibling and the d
 
   await ctx.client.killTerminal(terminalBId);
 }, 60000);
+
+test("archiving a workspace removes it from every subscribed client", async () => {
+  const cwd = makeTempDir("workspace-archive-global-");
+  const workspaceId = await createLocalWorkspace(cwd, "shared workspace");
+  const observer = new DaemonClient({
+    url: `ws://127.0.0.1:${ctx.daemon.port}/ws`,
+    reconnect: { enabled: false },
+  });
+
+  await observer.connect();
+  const initiatingClientRemovals = collectWorkspaceRemovals(ctx.client);
+  const removals = collectWorkspaceRemovals(observer);
+
+  try {
+    await ctx.client.fetchWorkspaces({ subscribe: { subscriptionId: "workspace-initiator" } });
+    await observer.fetchWorkspaces({ subscribe: { subscriptionId: "workspace-observer" } });
+
+    const archive = await ctx.client.archiveWorkspace(workspaceId);
+    await observer.ping({ requestId: "archive-observer-barrier" });
+
+    expect(archive.error).toBe(null);
+    expect(initiatingClientRemovals.workspaceIds).toEqual([workspaceId]);
+    expect(removals.workspaceIds).toEqual([workspaceId]);
+  } finally {
+    initiatingClientRemovals.stop();
+    removals.stop();
+    await observer.close();
+  }
+});
+
+test("renaming a workspace updates every subscribed client", async () => {
+  const cwd = makeTempDir("workspace-rename-global-");
+  const workspaceId = await createLocalWorkspace(cwd, "shared workspace");
+  const observer = new DaemonClient({
+    url: `ws://127.0.0.1:${ctx.daemon.port}/ws`,
+    reconnect: { enabled: false },
+  });
+
+  await observer.connect();
+  const titles = collectWorkspaceTitles(observer);
+
+  try {
+    await observer.fetchWorkspaces({ subscribe: { subscriptionId: "workspace-observer" } });
+
+    const renamed = await ctx.client.setWorkspaceTitle(workspaceId, "Renamed workspace");
+    await observer.ping({ requestId: "rename-observer-barrier" });
+
+    expect(renamed).toEqual({ title: "Renamed workspace" });
+    expect(titles.workspaces).toEqual([
+      { id: workspaceId, name: "Renamed workspace", title: "Renamed workspace" },
+    ]);
+  } finally {
+    titles.stop();
+    await observer.close();
+  }
+});
 
 test("archiving the last reference to a worktree removes it from disk regardless of the disk flag", async () => {
   const repoDir = createGitRepo();

--- a/packages/server/src/server/workspace-registry.ts
+++ b/packages/server/src/server/workspace-registry.ts
@@ -84,6 +84,12 @@ export interface WorkspaceMutation {
   workspace: PersistedWorkspaceRecord | null;
 }
 
+export interface ProjectMutation {
+  kind: "upsert" | "archive" | "remove";
+  projectId: string;
+  project: PersistedProjectRecord | null;
+}
+
 export interface ProjectRegistry {
   initialize(): Promise<void>;
   existsOnDisk(): Promise<boolean>;
@@ -99,13 +105,7 @@ export interface ProjectRegistry {
   archive(projectId: string, archivedAt: string): Promise<void>;
   remove(projectId: string): Promise<void>;
   /** Central lifecycle seam for daemon-global project observers. */
-  subscribeToMutations?(
-    listener: (mutation: {
-      kind: "upsert" | "archive" | "remove";
-      projectId: string;
-      project: PersistedProjectRecord | null;
-    }) => void | Promise<void>,
-  ): () => void;
+  subscribeToMutations?(listener: (mutation: ProjectMutation) => void | Promise<void>): () => void;
 }
 
 export interface WorkspaceRegistry {

--- a/packages/server/src/server/workspace-registry.ts
+++ b/packages/server/src/server/workspace-registry.ts
@@ -78,6 +78,12 @@ const PersistedWorkspaceRecordSchema = z.object({
 export type PersistedProjectRecord = z.infer<typeof PersistedProjectRecordSchema>;
 export type PersistedWorkspaceRecord = z.infer<typeof PersistedWorkspaceRecordSchema>;
 
+export interface WorkspaceMutation {
+  kind: "upsert" | "archive" | "remove";
+  workspaceId: string;
+  workspace: PersistedWorkspaceRecord | null;
+}
+
 export interface ProjectRegistry {
   initialize(): Promise<void>;
   existsOnDisk(): Promise<boolean>;
@@ -114,6 +120,10 @@ export interface WorkspaceRegistry {
   upsert(record: PersistedWorkspaceRecord): Promise<void>;
   archive(workspaceId: string, archivedAt: string): Promise<void>;
   remove(workspaceId: string): Promise<void>;
+  /** Central lifecycle seam for daemon-global workspace observers. */
+  subscribeToMutations?(
+    listener: (mutation: WorkspaceMutation) => void | Promise<void>,
+  ): () => void;
 }
 
 type RegistryRecord = PersistedProjectRecord | PersistedWorkspaceRecord;
@@ -186,10 +196,14 @@ class FileBackedRegistry<TRecord extends RegistryRecord> {
   }
 
   async archive(id: string, archivedAt: string): Promise<void> {
+    await this.archiveIfPresent(id, archivedAt);
+  }
+
+  protected async archiveIfPresent(id: string, archivedAt: string): Promise<TRecord | null> {
     await this.load();
     const existing = this.cache.get(id);
-    if (!existing) return;
-    await this.persistArchive(existing, archivedAt);
+    if (!existing) return null;
+    return this.persistArchive(existing, archivedAt);
   }
 
   protected async archiveIfActive(id: string, archivedAt: string): Promise<TRecord | null> {
@@ -372,6 +386,10 @@ export class FileBackedWorkspaceRegistry
   extends FileBackedRegistry<PersistedWorkspaceRecord>
   implements WorkspaceRegistry
 {
+  private readonly mutationListeners = new Set<
+    (mutation: WorkspaceMutation) => void | Promise<void>
+  >();
+
   constructor(filePath: string, logger: Logger) {
     super({
       filePath,
@@ -380,6 +398,49 @@ export class FileBackedWorkspaceRegistry
       getId: (record) => record.workspaceId,
       component: "workspaces",
     });
+  }
+
+  subscribeToMutations(
+    listener: (mutation: WorkspaceMutation) => void | Promise<void>,
+  ): () => void {
+    this.mutationListeners.add(listener);
+    return () => this.mutationListeners.delete(listener);
+  }
+
+  override async update(
+    workspaceId: string,
+    updater: (record: PersistedWorkspaceRecord) => PersistedWorkspaceRecord,
+  ): Promise<PersistedWorkspaceRecord | null> {
+    const workspace = await super.update(workspaceId, updater);
+    if (workspace) {
+      await this.notifyMutation({ kind: "upsert", workspaceId, workspace });
+    }
+    return workspace;
+  }
+
+  override async upsert(record: PersistedWorkspaceRecord): Promise<void> {
+    await super.upsert(record);
+    await this.notifyMutation({
+      kind: "upsert",
+      workspaceId: record.workspaceId,
+      workspace: record,
+    });
+  }
+
+  override async archive(workspaceId: string, archivedAt: string): Promise<void> {
+    const workspace = await this.archiveIfPresent(workspaceId, archivedAt);
+    if (!workspace) return;
+    await this.notifyMutation({ kind: "archive", workspaceId, workspace });
+  }
+
+  override async remove(workspaceId: string): Promise<void> {
+    const workspace = await this.removeIfPresent(workspaceId);
+    if (!workspace) return;
+    await this.notifyMutation({ kind: "remove", workspaceId, workspace: null });
+  }
+
+  private async notifyMutation(mutation: WorkspaceMutation): Promise<void> {
+    await Promise.all([...this.mutationListeners].map((listener) => listener(mutation)));
   }
 }
 

--- a/packages/server/src/server/workspace-registry.ts
+++ b/packages/server/src/server/workspace-registry.ts
@@ -82,6 +82,11 @@ export interface WorkspaceMutation {
   kind: "upsert" | "archive" | "remove";
   workspaceId: string;
   workspace: PersistedWorkspaceRecord | null;
+  expectsInitialAgent?: boolean;
+}
+
+export interface WorkspaceMutationContext {
+  expectsInitialAgent?: boolean;
 }
 
 export interface ProjectMutation {
@@ -117,7 +122,7 @@ export interface WorkspaceRegistry {
     workspaceId: string,
     updater: (record: PersistedWorkspaceRecord) => PersistedWorkspaceRecord,
   ): Promise<PersistedWorkspaceRecord | null>;
-  upsert(record: PersistedWorkspaceRecord): Promise<void>;
+  upsert(record: PersistedWorkspaceRecord, context?: WorkspaceMutationContext): Promise<void>;
   archive(workspaceId: string, archivedAt: string): Promise<void>;
   remove(workspaceId: string): Promise<void>;
   /** Central lifecycle seam for daemon-global workspace observers. */
@@ -418,12 +423,16 @@ export class FileBackedWorkspaceRegistry
     return workspace;
   }
 
-  override async upsert(record: PersistedWorkspaceRecord): Promise<void> {
+  override async upsert(
+    record: PersistedWorkspaceRecord,
+    context?: WorkspaceMutationContext,
+  ): Promise<void> {
     await super.upsert(record);
     await this.notifyMutation({
       kind: "upsert",
       workspaceId: record.workspaceId,
       workspace: record,
+      ...(context?.expectsInitialAgent ? { expectsInitialAgent: true } : {}),
     });
   }
 


### PR DESCRIPTION
### Linked issue

Refs #227

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Archiving a workspace now reaches every connected client session, so each session releases its workspace Git observer instead of continuing background Git checks against a deleted worktree.

Workspace mutations are published from the shared registry rather than only through the session that initiated them. External archive paths now persist and clean up once, independent of the number of active sessions, and clients receive each removal exactly once.

### How did you verify it

Reproduced the bug with a real daemon and two clients: one client archived a workspace while the other remained subscribed. Before the fix, the second client received no removal. After the fix, both clients receive exactly one removal.

Also verified that a workspace rename reaches another subscribed client, then ran:

- `npx vitest run packages/server/src/server/workspace-archive-record-scoped.e2e.test.ts --bail=1` — 6 passed
- `npx vitest run packages/server/src/server/workspace-registry.test.ts --bail=1` — 17 passed
- Focused session tests for archive, reconciliation, project removal, and filtered subscription removal — 4 passed
- `npm run typecheck`
- `npm run lint -- packages/server/src/server/bootstrap.ts packages/server/src/server/session.ts packages/server/src/server/workspace-registry.ts packages/server/src/server/workspace-archive-record-scoped.e2e.test.ts`
- `npm run format`

Risk is limited to workspace mutation ordering across concurrent sessions. Persisted data and wire schemas are unchanged; the multi-client E2E test covers the changed publication boundary.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense